### PR TITLE
Cast app ID, naming defaults, DaisyUI dropdown migration

### DIFF
--- a/backend/src/modules/imports/disk-import.service.ts
+++ b/backend/src/modules/imports/disk-import.service.ts
@@ -159,10 +159,34 @@ export class DiskImportService {
         }
 
         if (!media.path) continue; // Skip if we can't compute a path
-        const relativePath = relativePathUnderMediaRoot(
+        let relativePath = relativePathUnderMediaRoot(
           media.path,
           entry.filePath,
         );
+        // The disk folder may not match media.folderName when titles are
+        // localised (e.g. "Mean Girls (2004)" on disk vs "Lolita malgré
+        // moi (2004)" stored from a French TMDB lookup). The user-confirmed
+        // import already vouches for the media association, so realign
+        // folderName to the actual disk folder under the same rootFolder.
+        if (!relativePath && media.rootFolder?.path) {
+          const dir = path.dirname(entry.filePath);
+          if (dir.startsWith(media.rootFolder.path)) {
+            const newFolderName = dir
+              .slice(media.rootFolder.path.length)
+              .replace(/^\/+/, '')
+              .split('/')[0];
+            if (newFolderName && newFolderName !== media.folderName) {
+              await this.mediaRepo.update(media.id, {
+                folderName: newFolderName,
+              });
+              media.folderName = newFolderName;
+              relativePath = relativePathUnderMediaRoot(
+                media.path,
+                entry.filePath,
+              );
+            }
+          }
+        }
         if (!relativePath) {
           this.logger.error(
             `Disk import: file outside media folder — mediaId=${media.id} mediaPath=${media.path} filePath=${entry.filePath}`,

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -141,7 +141,7 @@ export class MediaService {
       const details = await this.tmdb.getMovieDetails(String(dto.tmdbId));
       const movieFolderFormat =
         fmtMap['naming_movie_folder_format'] ??
-        '{Movie Title} ({Release Year})';
+        '{Original Title} ({Release Year})';
       const folderName = this.naming.applyMovieFolderFormat(movieFolderFormat, {
         title: details.title,
         originalTitle: details.originalTitle,
@@ -164,6 +164,7 @@ export class MediaService {
       fmtMap['naming_series_folder_format'] ?? '{Series Title}';
     const folderName = this.naming.applySeriesFolderFormat(seriesFolderFormat, {
       seriesTitle: details.title,
+      originalTitle: details.originalTitle,
       year: details.year,
       tmdbId: details.tmdbId,
     });
@@ -245,7 +246,7 @@ export class MediaService {
       }
       const movieFolderFormat =
         fmtMap['naming_movie_folder_format'] ??
-        '{Movie Title} ({Release Year})';
+        '{Original Title} ({Release Year})';
       const folderName = this.naming.applyMovieFolderFormat(movieFolderFormat, {
         title: details.title,
         originalTitle: details.originalTitle,
@@ -276,6 +277,7 @@ export class MediaService {
       fmtMap['naming_series_folder_format'] ?? '{Series Title}';
     const folderName = this.naming.applySeriesFolderFormat(seriesFolderFormat, {
       seriesTitle: details.title,
+      originalTitle: details.originalTitle,
       year: details.year,
       tmdbId: details.tmdbId,
     });

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -339,6 +339,7 @@ export class CompletionService {
           })
         : this.naming.applySeriesFolderFormat(seriesFolderFormat, {
             seriesTitle: media.title,
+            originalTitle: media.originalTitle,
             year: media.year,
             tmdbId: media.tmdbId,
           }));

--- a/backend/src/modules/scheduler/naming.service.ts
+++ b/backend/src/modules/scheduler/naming.service.ts
@@ -101,12 +101,17 @@ export class NamingService {
     format: string,
     data: {
       seriesTitle: string;
+      originalTitle?: string;
       year?: number | null;
       tmdbId?: number | null;
     },
   ): string {
     let name = format;
     name = name.replace(/\{Series Title\}/g, data.seriesTitle ?? '');
+    name = name.replace(
+      /\{Original Title\}/g,
+      data.originalTitle || data.seriesTitle || '',
+    );
     name = name.replace(
       /\{Release Year\}/g,
       data.year ? String(data.year) : '',

--- a/frontend/android/app/src/main/res/values/strings.xml
+++ b/frontend/android/app/src/main/res/values/strings.xml
@@ -11,5 +11,5 @@
       Fliks receiver shell is published. MUST match `castAppId` in
       frontend/src/environments/environment.ts.
     -->
-    <string name="cast_receiver_app_id">CC1AD845</string>
+    <string name="cast_receiver_app_id">66BF4DAE</string>
 </resources>

--- a/frontend/ios/App/App/AppDelegate.swift
+++ b/frontend/ios/App/App/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Initialize Google Cast SDK early (required for device discovery)
         let castOptions = GCKCastOptions(discoveryCriteria:
-            GCKDiscoveryCriteria(applicationID: "CC1AD845"))
+            GCKDiscoveryCriteria(applicationID: "66BF4DAE"))
         castOptions.disableDiscoveryAutostart = false
         GCKCastContext.setSharedInstanceWith(castOptions)
 

--- a/frontend/ios/App/App/Info.plist
+++ b/frontend/ios/App/App/Info.plist
@@ -55,7 +55,7 @@
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_googlecast._tcp</string>
-		<string>_CC1AD845._googlecast._tcp</string>
+		<string>_66BF4DAE._googlecast._tcp</string>
 	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>

--- a/frontend/ios/App/Podfile
+++ b/frontend/ios/App/Podfile
@@ -15,6 +15,7 @@ def capacitor_pods
   pod 'CapacitorFilesystem', :path => '../../node_modules/@capacitor/filesystem'
   pod 'CapacitorKeyboard', :path => '../../node_modules/@capacitor/keyboard'
   pod 'CapacitorPreferences', :path => '../../node_modules/@capacitor/preferences'
+  pod 'CapacitorSplashScreen', :path => '../../node_modules/@capacitor/splash-screen'
 end
 
 target 'App' do

--- a/frontend/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/frontend/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -4,21 +4,11 @@
 <section class="space-y-4">
   @if (!hideControls()) {
   <div appTvRow class="flex items-center gap-2 flex-wrap">
-    <button
-      #seasonTrigger
-      type="button"
-      class="btn btn-ghost btn-circle shrink-0"
-      (click)="seasonMenuOpen.set(!seasonMenuOpen())"
-    >
-      <svg lucideEllipsisVertical class="h-5 w-5"></svg>
-    </button>
-    <app-popover-menu
-      [open]="seasonMenuOpen()"
-      [anchor]="seasonTrigger"
-      placement="bottom-start"
-      (closed)="seasonMenuOpen.set(false)"
-    >
-      <label class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base text-white rounded-lg active:bg-white/10 hover:bg-white/5 cursor-pointer">
+    <app-dropdown-menu placement="bottom-start">
+      <button trigger type="button" class="btn btn-ghost btn-circle shrink-0">
+        <svg lucideEllipsisVertical class="h-5 w-5"></svg>
+      </button>
+      <label class="dropdown-item text-white">
         <input
           type="checkbox"
           class="toggle toggle-primary toggle-sm shrink-0"
@@ -31,8 +21,8 @@
         <button
           type="button"
           [disabled]="seasonWatchedBusyId() === selSeason.id"
-          class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base text-white rounded-lg active:bg-white/10 hover:bg-white/5 disabled:opacity-40"
-          (click)="toggleSeasonWatched.emit({ season: selSeason, watched: !seasonFullyWatched(selSeason) }); seasonMenuOpen.set(false)"
+          class="dropdown-item text-white"
+          (click)="toggleSeasonWatched.emit({ season: selSeason, watched: !seasonFullyWatched(selSeason) })"
         >
           @if (seasonWatchedBusyId() === selSeason.id) {
             <span class="loading loading-spinner loading-sm"></span>
@@ -46,7 +36,7 @@
           }
         </button>
       }
-    </app-popover-menu>
+    </app-dropdown-menu>
     <select
       appTvSelect
       class="select select-bordered w-fit shrink-0"

--- a/frontend/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/frontend/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -5,7 +5,6 @@ import {
   inject,
   input,
   output,
-  signal,
 } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { UpperCasePipe } from '@angular/common';
@@ -14,7 +13,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { LucideCheck, LucideEllipsisVertical, LucideX } from '@lucide/angular';
 import { HorizontalScrollerComponent } from '../../../../shared/components/horizontal-scroller';
 import { MediaCardComponent } from '../../../../shared/components/media-card/media-card';
-import { PopoverMenuComponent } from '../../../../shared/components/popover-menu';
+import { DropdownMenuComponent } from '../../../../shared/components/dropdown-menu';
 import { TvSelectDirective } from '../../../../shared/directives/tv-select.directive';
 import { TvRowDirective } from '../../../../shared/directives/tv-row.directive';
 import { ResolveUrlPipe } from '../../../../core/pipes/resolve-url.pipe';
@@ -35,13 +34,12 @@ import { METADATA_PROVIDER_OPTIONS_OVERRIDE } from '../../../../core/constants/m
 
 @Component({
   selector: 'app-media-detail-seasons',
-  imports: [TranslateModule, FormsModule, RouterLink, ResolveUrlPipe, UpperCasePipe, HorizontalScrollerComponent, MediaCardComponent, PopoverMenuComponent, TvSelectDirective, TvRowDirective, LucideCheck, LucideEllipsisVertical, LucideX],
+  imports: [TranslateModule, FormsModule, RouterLink, ResolveUrlPipe, UpperCasePipe, HorizontalScrollerComponent, MediaCardComponent, DropdownMenuComponent, TvSelectDirective, TvRowDirective, LucideCheck, LucideEllipsisVertical, LucideX],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-seasons.component.html',
 })
 export class MediaDetailSeasonsComponent {
   private readonly router = inject(Router);
-  protected readonly seasonMenuOpen = signal(false);
   readonly media = input.required<Media>();
   readonly selectedSeason = input<Season | null>(null);
   readonly activeSeasonId = input.required<number | null>();

--- a/frontend/src/app/features/settings/naming/naming.ts
+++ b/frontend/src/app/features/settings/naming/naming.ts
@@ -45,6 +45,7 @@ function applySeriesFormat(format: string): string {
 function applySeriesFolderFormat(format: string): string {
   return format
     .replace(/\{Series Title\}/g, 'Breaking Bad')
+    .replace(/\{Original Title\}/g, 'Breaking Bad')
     .replace(/\{Release Year\}/g, '2008')
     .replace(/\{TMDB Id\}/g, '1396')
     .replace(/\s{2,}/g, ' ')
@@ -97,7 +98,7 @@ export class NamingSettingsComponent implements OnInit {
   ];
 
   readonly seriesFolderTokens = [
-    '{Series Title}', '{Release Year}', '{TMDB Id}',
+    '{Series Title}', '{Original Title}', '{Release Year}', '{TMDB Id}',
   ];
 
   readonly seasonFolderTokens = [

--- a/frontend/src/app/shared/components/dropdown-menu.ts
+++ b/frontend/src/app/shared/components/dropdown-menu.ts
@@ -1,0 +1,126 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  computed,
+  effect,
+  inject,
+  input,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
+import { BottomSheetComponent } from './bottom-sheet';
+import { DropdownToggleDirective } from '../directives/dropdown-toggle.directive';
+import { DeviceService } from '../../core/services/device.service';
+import { TvService } from '../../core/services/tv.service';
+
+type Placement = 'bottom-end' | 'bottom-start' | 'top-end' | 'top-start';
+
+/**
+ * Form-factor-aware menu wrapper.
+ *
+ *   • Desktop (mouse + non-TV) → DaisyUI `.dropdown` / `.dropdown-content`
+ *     anchored sibling layout. Open/close handled by `appDropdownToggle`
+ *     (click + outside-click + back-button via DismissableStackService).
+ *   • Mobile / tablet / TV → BottomSheetComponent.
+ *
+ * Authoring:
+ *
+ *   <app-dropdown-menu placement="bottom-end">
+ *     <button trigger type="button" class="btn btn-ghost btn-circle">…</button>
+ *     <a routerLink="/account">…</a>
+ *     <button (click)="logout()">…</button>
+ *   </app-dropdown-menu>
+ *
+ * The element marked `trigger` is projected as the first child of
+ * `.dropdown` on desktop so DaisyUI's `:focus-within` open path keeps
+ * working alongside the click toggle. All other children are projected
+ * into `.dropdown-content` (desktop) or the bottom sheet body (TV/touch).
+ *
+ * Both <ng-content> slots live inside <ng-template> refs and are rendered
+ * via *ngTemplateOutlet — direct <ng-content> inside @if blocks does not
+ * project reliably (Angular 21 still hits this case under nested control
+ * flow).
+ */
+@Component({
+  selector: 'app-dropdown-menu',
+  standalone: true,
+  imports: [NgTemplateOutlet, BottomSheetComponent, DropdownToggleDirective],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <ng-template #triggerTpl><ng-content select="[trigger]"></ng-content></ng-template>
+    <ng-template #itemsTpl><ng-content></ng-content></ng-template>
+
+    @if (useDropdown()) {
+      <div class="dropdown" [class]="dropdownClasses()">
+        <div appDropdownToggle class="contents">
+          <ng-container *ngTemplateOutlet="triggerTpl"></ng-container>
+        </div>
+        <div
+          tabindex="0"
+          class="dropdown-content bg-base-200 rounded-box shadow-xl min-w-60 p-1 z-[101] overflow-hidden whitespace-nowrap"
+        >
+          <ng-container *ngTemplateOutlet="itemsTpl"></ng-container>
+        </div>
+      </div>
+    } @else {
+      <div class="contents" (click)="open.set(true)">
+        <ng-container *ngTemplateOutlet="triggerTpl"></ng-container>
+      </div>
+      <app-bottom-sheet #sheet [open]="open()" (closed)="open.set(false)">
+        <div data-tv-modal class="px-2 pb-2" (click)="onItemsClick($event)">
+          <ng-container *ngTemplateOutlet="itemsTpl"></ng-container>
+        </div>
+      </app-bottom-sheet>
+    }
+  `,
+})
+export class DropdownMenuComponent {
+  readonly placement = input<Placement>('bottom-end');
+
+  private readonly tv = inject(TvService);
+  private readonly device = inject(DeviceService);
+
+  readonly useDropdown = computed(() => !this.tv.isTv() && !this.device.isTouch());
+  protected readonly open = signal(false);
+
+  /** Reference to <app-bottom-sheet> on the touch/TV branch — used to
+   *  reparent the sheet under <html> so its `position: fixed` resolves
+   *  against the viewport instead of the layout's drawer-content (which
+   *  has `position: relative` on mobile, creating a stacking context that
+   *  traps `z-[101]` below the bottom dock at `z-40`). The trigger stays
+   *  inline so the layout's flex/grid placement keeps working. */
+  private readonly sheet = viewChild('sheet', { read: ElementRef });
+
+  constructor() {
+    if (typeof document === 'undefined') return;
+    effect(() => {
+      const ref = this.sheet();
+      if (!ref || this.useDropdown()) return;
+      queueMicrotask(() => {
+        document.documentElement.appendChild(ref.nativeElement);
+      });
+    });
+  }
+
+  protected readonly dropdownClasses = computed(() => {
+    const p = this.placement();
+    const cls: string[] = [];
+    if (p.endsWith('end')) cls.push('dropdown-end');
+    if (p.startsWith('top')) cls.push('dropdown-top');
+    return cls.join(' ');
+  });
+
+  /** Close on any click that lands on an `<a>` / `<button>` inside the
+   *  sheet — mirrors the desktop `DropdownToggleDirective` behaviour
+   *  (the directive's outside-click handler treats item clicks as
+   *  "outside the trigger" and closes). Padding / spacer clicks are
+   *  ignored so the sheet doesn't dismiss on stray taps. */
+  protected onItemsClick(event: Event) {
+    const target = event.target as HTMLElement | null;
+    if (target?.closest('a, button')) {
+      this.open.set(false);
+    }
+  }
+}

--- a/frontend/src/app/shared/components/media-info-header/media-info-header.html
+++ b/frontend/src/app/shared/components/media-info-header/media-info-header.html
@@ -144,15 +144,13 @@
           {{ 'media_detail.delete' | translate }}
         </button>
       }
-      <button
-        #moreTriggerMobile
-        type="button"
-        class="flex flex-col items-center gap-1 text-sm cursor-pointer"
-        (click)="openMore(moreTriggerMobile)"
-      >
-        <svg lucideEllipsisVertical class="h-5 w-5"></svg>
-        {{ 'common.more' | translate }}
-      </button>
+      <app-dropdown-menu placement="bottom-end">
+        <button trigger type="button" class="flex flex-col items-center gap-1 text-sm cursor-pointer">
+          <svg lucideEllipsisVertical class="h-5 w-5"></svg>
+          {{ 'common.more' | translate }}
+        </button>
+        <ng-container *ngTemplateOutlet="moreMenuItems"></ng-container>
+      </app-dropdown-menu>
     </div>
 
     <!-- Series episode progress -->
@@ -384,14 +382,12 @@
             </button>
           }
         }
-        <button
-          #moreTriggerDesktop
-          type="button"
-          class="btn btn-ghost btn btn-circle"
-          (click)="openMore(moreTriggerDesktop)"
-        >
-          <svg lucideEllipsisVertical class="h-5 w-5"></svg>
-        </button>
+        <app-dropdown-menu placement="bottom-end">
+          <button trigger type="button" class="btn btn-ghost btn btn-circle">
+            <svg lucideEllipsisVertical class="h-5 w-5"></svg>
+          </button>
+          <ng-container *ngTemplateOutlet="moreMenuItems"></ng-container>
+        </app-dropdown-menu>
       </div>
 
       <!-- Progress bar -->
@@ -431,73 +427,63 @@
   </div>
 </div>
 
-<!-- Shared "more actions" popover — anchored to whichever trigger the user clicked. -->
-<app-popover-menu
-  [open]="openMoreMenu()"
-  [anchor]="moreAnchor()"
-  placement="bottom-end"
-  (closed)="openMoreMenu.set(false)"
->
-  <ng-container *ngTemplateOutlet="moreMenuItems"></ng-container>
-</app-popover-menu>
-
-<!-- Items shared by the popover above. -->
+<!-- Items projected into both mobile + desktop dropdown-menus. -->
 <ng-template #moreMenuItems>
   @if (mediaType() === 'series' && !episodeId()) {
-    <button type="button" class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base text-white rounded-lg active:bg-white/10 hover:bg-white/5" (click)="onToggleWatched(); openMoreMenu.set(false)">
+    <button type="button" class="dropdown-item text-white" (click)="onToggleWatched()">
       <svg lucideCheck class="h-5 w-5 shrink-0 opacity-80" [class.text-success]="watched()"></svg>
       <span class="flex-1">{{ (watched() ? 'media_detail.mark_series_unwatched' : 'media_detail.mark_series_watched') | translate }}</span>
     </button>
   }
   @if (canGrab()) {
-    <button type="button" [disabled]="grabBusy() !== null" class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base text-white rounded-lg active:bg-white/10 hover:bg-white/5 disabled:opacity-40" (click)="grabBest.emit(); openMoreMenu.set(false)">
+    <button type="button" [disabled]="grabBusy() !== null" class="dropdown-item text-white" (click)="grabBest.emit()">
       @if (grabBusy() === 'best') { <span class="loading loading-spinner loading-sm"></span> }
       @else { <svg lucideDownload class="h-5 w-5 shrink-0 opacity-80"></svg> }
       <span class="flex-1">{{ 'media_detail.grab_best' | translate }}</span>
     </button>
-    <button type="button" [disabled]="releasesLoading()" class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base text-white rounded-lg active:bg-white/10 hover:bg-white/5 disabled:opacity-40" (click)="loadReleases.emit(); openMoreMenu.set(false)">
+    <button type="button" [disabled]="releasesLoading()" class="dropdown-item text-white" (click)="loadReleases.emit()">
       @if (releasesLoading()) { <span class="loading loading-spinner loading-sm"></span> }
       @else { <svg lucideSearch class="h-5 w-5 shrink-0 opacity-80"></svg> }
       <span class="flex-1">{{ 'media_detail.search_releases' | translate }}</span>
     </button>
   }
   @if (canEditProfiles()) {
-    <button type="button" class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base text-white rounded-lg active:bg-white/10 hover:bg-white/5" (click)="openProfiles.emit(); openMoreMenu.set(false)">
+    <button type="button" class="dropdown-item text-white" (click)="openProfiles.emit()">
       <svg lucideSettings class="h-5 w-5 shrink-0 opacity-80"></svg>
       <span class="flex-1">{{ 'media_detail.edit_profiles' | translate }}</span>
     </button>
-    <button type="button" class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base text-white rounded-lg active:bg-white/10 hover:bg-white/5" (click)="openLibrary.emit(); openMoreMenu.set(false)">
+    <button type="button" class="dropdown-item text-white" (click)="openLibrary.emit()">
       <svg lucideFolder class="h-5 w-5 shrink-0 opacity-80"></svg>
       <span class="flex-1">{{ 'media_detail.edit_library' | translate }}</span>
     </button>
   }
   @if (mediaType() === 'movie' || episodeId()) {
-    <button type="button" class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base text-white rounded-lg active:bg-white/10 hover:bg-white/5" (click)="editSubtitles.emit(); openMoreMenu.set(false)">
+    <button type="button" class="dropdown-item text-white" (click)="editSubtitles.emit()">
       <svg lucideCaptions class="h-5 w-5 shrink-0 opacity-80"></svg>
       <span class="flex-1">{{ 'media_detail.edit_subtitles' | translate }}</span>
     </button>
   }
   @if (isAdmin()) {
-    <button type="button" class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base text-white rounded-lg active:bg-white/10 hover:bg-white/5" (click)="refreshMetadata.emit(); openMoreMenu.set(false)">
+    <button type="button" class="dropdown-item text-white" (click)="refreshMetadata.emit()">
       <svg lucideRotateCcw class="h-5 w-5 shrink-0 opacity-80"></svg>
       <span class="flex-1">{{ 'media_detail.refresh_metadata' | translate }}</span>
     </button>
-    <button type="button" class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base text-white rounded-lg active:bg-white/10 hover:bg-white/5" (click)="rescanFiles.emit(); openMoreMenu.set(false)">
+    <button type="button" class="dropdown-item text-white" (click)="rescanFiles.emit()">
       <svg lucideFileText class="h-5 w-5 shrink-0 opacity-80"></svg>
       <span class="flex-1">{{ 'media_detail.rescan_files' | translate }}</span>
     </button>
     @if (mediaType() === 'series') {
-      <button type="button" class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base text-white rounded-lg active:bg-white/10 hover:bg-white/5" (click)="detectIntros.emit(); openMoreMenu.set(false)">
+      <button type="button" class="dropdown-item text-white" (click)="detectIntros.emit()">
         <svg lucideSkipForward class="h-5 w-5 shrink-0 opacity-80"></svg>
         <span class="flex-1">{{ 'markers.detect_intros' | translate }}</span>
       </button>
     }
-    <button type="button" [disabled]="monitoredLoading()" class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base text-white rounded-lg active:bg-white/10 hover:bg-white/5 disabled:opacity-40" (click)="toggleMonitored.emit(); openMoreMenu.set(false)">
+    <button type="button" [disabled]="monitoredLoading()" class="dropdown-item text-white" (click)="toggleMonitored.emit()">
       @if (monitored()) { <svg lucideEyeOff class="h-5 w-5 shrink-0 opacity-80"></svg> }
       @else { <svg lucideEye class="h-5 w-5 shrink-0 opacity-80"></svg> }
       <span class="flex-1">{{ (monitored() ? 'media_detail.unmonitor' : 'media_detail.monitor') | translate }}</span>
     </button>
-    <button type="button" [disabled]="deleteLoading()" class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base text-error rounded-lg active:bg-white/10 hover:bg-white/5 disabled:opacity-40" (click)="deleteMedia.emit(); openMoreMenu.set(false)">
+    <button type="button" [disabled]="deleteLoading()" class="dropdown-item text-error" (click)="deleteMedia.emit()">
       @if (deleteLoading()) { <span class="loading loading-spinner loading-sm"></span> }
       @else { <svg lucideTrash2 class="h-5 w-5 shrink-0"></svg> }
       <span class="flex-1">{{ 'media_detail.delete_from_library' | translate }}</span>

--- a/frontend/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/frontend/src/app/shared/components/media-info-header/media-info-header.ts
@@ -39,7 +39,7 @@ import { NavbarService } from '../../../core/services/navbar.service';
 import { TvService } from '../../../core/services/tv.service';
 import { MobileFanartHeroComponent } from '../mobile-fanart-hero';
 import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
-import { PopoverMenuComponent } from '../popover-menu';
+import { DropdownMenuComponent } from '../dropdown-menu';
 import { ImgFadeInDirective } from '../../directives/img-fade-in.directive';
 import { TvRowDirective } from '../../directives/tv-row.directive';
 import { NgTemplateOutlet } from '@angular/common';
@@ -70,7 +70,7 @@ interface AudioTrack {
   imports: [
     MobileFanartHeroComponent,
     ResolveUrlPipe,
-    PopoverMenuComponent,
+    DropdownMenuComponent,
     ImgFadeInDirective,
     TvRowDirective,
     NgTemplateOutlet,
@@ -157,16 +157,6 @@ export class MediaInfoHeaderComponent {
   readonly openDownload = output<void>();
   readonly openProfiles = output<void>();
   readonly openLibrary = output<void>();
-  /** "More actions" menu open-state — shared between mobile + desktop layouts. */
-  readonly openMoreMenu = signal(false);
-  /** Active trigger element so the dropdown variant anchors to whichever
-   *  layout (mobile or desktop) the user clicked. */
-  readonly moreAnchor = signal<HTMLElement | null>(null);
-
-  protected openMore(anchor: HTMLElement) {
-    this.moreAnchor.set(anchor);
-    this.openMoreMenu.set(true);
-  }
   readonly refreshMetadata = output<void>();
   readonly toggleMonitored = output<void>();
   readonly deleteMedia = output<void>();

--- a/frontend/src/app/shared/components/popover-menu.ts
+++ b/frontend/src/app/shared/components/popover-menu.ts
@@ -8,6 +8,7 @@ import {
   input,
   output,
 } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
 import { BottomSheetComponent } from './bottom-sheet';
 import { TvService } from '../../core/services/tv.service';
 import { DeviceService } from '../../core/services/device.service';
@@ -31,28 +32,32 @@ import { DeviceService } from '../../core/services/device.service';
 @Component({
   selector: 'app-popover-menu',
   standalone: true,
-  imports: [BottomSheetComponent],
+  imports: [BottomSheetComponent, NgTemplateOutlet],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    @if (open()) {
-      @if (useDropdown()) {
-        <!-- Click-out backdrop (transparent) -->
-        <div class="fixed inset-0 z-[100]" (click)="close()"></div>
-        <div
-          class="fixed z-[101] bg-base-200 rounded-box shadow-xl overflow-hidden"
-          [style.top.px]="position().top"
-          [style.left.px]="position().left"
-          [style.min-width.px]="position().width"
-        >
-          <ng-content></ng-content>
+    <!-- Capture projected content in a template ref so it can be rendered
+         in either the dropdown or sheet branch without hitting the
+         "ng-content inside @if doesn't project" issue. The <ng-template>
+         itself never renders; *ngTemplateOutlet does. -->
+    <ng-template #content><ng-content></ng-content></ng-template>
+
+    @if (open() && useDropdown()) {
+      <!-- Click-out backdrop (transparent) -->
+      <div class="fixed inset-0 z-[100]" (click)="close()"></div>
+      <div
+        class="fixed z-[101] bg-base-200 rounded-box shadow-xl overflow-hidden"
+        [style.top.px]="position().top"
+        [style.left.px]="position().left"
+        [style.min-width.px]="position().width"
+      >
+        <ng-container *ngTemplateOutlet="content"></ng-container>
+      </div>
+    } @else if (open() && !useDropdown()) {
+      <app-bottom-sheet [open]="true" (closed)="close()">
+        <div data-tv-modal class="px-2 pb-2">
+          <ng-container *ngTemplateOutlet="content"></ng-container>
         </div>
-      } @else {
-        <app-bottom-sheet [open]="true" (closed)="close()">
-          <div data-tv-modal class="px-2 pb-2">
-            <ng-content></ng-content>
-          </div>
-        </app-bottom-sheet>
-      }
+      </app-bottom-sheet>
     }
   `,
 })

--- a/frontend/src/app/shared/components/select-picker.ts
+++ b/frontend/src/app/shared/components/select-picker.ts
@@ -27,7 +27,7 @@ import { PopoverMenuComponent } from './popover-menu';
         <button
           type="button"
           [disabled]="opt.disabled"
-          class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base rounded-lg active:bg-white/10 hover:bg-white/5 disabled:opacity-40"
+          class="dropdown-item"
           [class.text-primary]="opt.selected"
           [class.text-white]="!opt.selected"
           (click)="picker.pick(opt.value)"

--- a/frontend/src/app/shared/components/user-menu.ts
+++ b/frontend/src/app/shared/components/user-menu.ts
@@ -1,9 +1,9 @@
-import { Component, ChangeDetectionStrategy, inject, signal } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { AuthService } from '../../core/services/auth.service';
 import { ServerConfigService } from '../../core/services/server-config.service';
-import { PopoverMenuComponent } from './popover-menu';
+import { DropdownMenuComponent } from './dropdown-menu';
 import { Capacitor } from '@capacitor/core';
 import {
   LucideUser,
@@ -19,71 +19,65 @@ import {
   selector: 'app-user-menu',
   imports: [
     RouterLink, TranslateModule,
-    PopoverMenuComponent,
+    DropdownMenuComponent,
     LucideUser, LucideSettings, LucideShield, LucideRepeat, LucideLogOut,
     LucideServer, LucideMonitorSmartphone,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <button
-      #trigger
-      type="button"
-      class="btn btn-ghost btn-circle"
-      [attr.aria-label]="'nav.user_menu' | translate"
-      (click)="open.set(!open())"
-    >
-      <svg lucideUser class="h-5 w-5"></svg>
-    </button>
-    <app-popover-menu
-      [open]="open()"
-      [anchor]="trigger"
-      placement="bottom-end"
-      (closed)="open.set(false)"
-    >
+    <app-dropdown-menu placement="bottom-end">
+      <button
+        trigger
+        type="button"
+        class="btn btn-ghost btn-circle"
+        [attr.aria-label]="'nav.user_menu' | translate"
+      >
+        <svg lucideUser class="h-5 w-5"></svg>
+      </button>
       @if (auth.user(); as user) {
-        <div class="flex items-center gap-3 px-4 py-3 border-b border-white/10">
+        <div class="flex items-center gap-3 px-3 py-3 border-b border-white/10">
           <div class="w-10 h-10 rounded-full bg-white/10 flex items-center justify-center shrink-0">
             <svg lucideUser class="h-5 w-5 text-white/60"></svg>
           </div>
-          <a routerLink="/account" class="min-w-0 flex-1 cursor-pointer" (click)="open.set(false)">
+          <a routerLink="/account" class="min-w-0 flex-1 cursor-pointer">
             <p class="font-semibold truncate text-white">{{ user.username }}</p>
             <p class="text-xs text-white/50">{{ user.role }}</p>
           </a>
         </div>
       }
-      <a routerLink="/account" (click)="open.set(false)" class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base text-white rounded-lg active:bg-white/10 hover:bg-white/5">
+      <a routerLink="/account" class="dropdown-item text-white">
         <svg lucideUser class="h-5 w-5 shrink-0 opacity-80"></svg>
         <span class="flex-1">{{ 'nav.account_settings' | translate }}</span>
       </a>
-      <a routerLink="/app-settings" (click)="open.set(false)" class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base text-white rounded-lg active:bg-white/10 hover:bg-white/5">
+      <a routerLink="/app-settings" class="dropdown-item text-white">
         <svg lucideSettings class="h-5 w-5 shrink-0 opacity-80"></svg>
         <span class="flex-1">{{ 'nav.app_settings' | translate }}</span>
       </a>
       @if (auth.canAccessSettings()) {
-        <a routerLink="/admin" (click)="open.set(false)" class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base text-white rounded-lg active:bg-white/10 hover:bg-white/5">
+        <a routerLink="/admin" class="dropdown-item text-white">
           <svg lucideShield class="h-5 w-5 shrink-0 opacity-80"></svg>
           <span class="flex-1">{{ 'nav.administration' | translate }}</span>
         </a>
       }
-      <a routerLink="/pending-requests" (click)="open.set(false)" class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base text-white rounded-lg active:bg-white/10 hover:bg-white/5">
+      <a routerLink="/pending-requests" class="dropdown-item text-white">
         <svg lucideMonitorSmartphone class="h-5 w-5 shrink-0 opacity-80"></svg>
         <span class="flex-1">{{ 'pending_requests.menu_entry' | translate }}</span>
       </a>
-      <button type="button" (click)="switchUser()" class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base text-white rounded-lg active:bg-white/10 hover:bg-white/5">
+      <button type="button" (click)="switchUser()" class="dropdown-item text-white">
         <svg lucideRepeat class="h-5 w-5 shrink-0 opacity-80"></svg>
         <span class="flex-1">{{ 'nav.switch_user' | translate }}</span>
       </button>
       @if (isNative) {
-        <button type="button" (click)="changeServer()" class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base text-white rounded-lg active:bg-white/10 hover:bg-white/5">
+        <button type="button" (click)="changeServer()" class="dropdown-item text-white">
           <svg lucideServer class="h-5 w-5 shrink-0 opacity-80"></svg>
           <span class="flex-1">{{ 'nav.change_server' | translate }}</span>
         </button>
       }
-      <button type="button" (click)="logout()" class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base text-error rounded-lg active:bg-white/10 hover:bg-white/5">
+      <button type="button" (click)="logout()" class="dropdown-item text-error">
         <svg lucideLogOut class="h-5 w-5 shrink-0"></svg>
         <span class="flex-1">{{ 'nav.logout' | translate }}</span>
       </button>
-    </app-popover-menu>
+    </app-dropdown-menu>
   `,
 })
 export class UserMenuComponent {
@@ -91,21 +85,17 @@ export class UserMenuComponent {
   private readonly router = inject(Router);
   private readonly serverConfig = inject(ServerConfigService);
   protected readonly isNative = Capacitor.isNativePlatform();
-  protected readonly open = signal(false);
 
   protected switchUser() {
-    this.open.set(false);
     this.router.navigate(['/login'], { queryParams: { switch: true } });
   }
 
   protected async changeServer() {
-    this.open.set(false);
     await this.serverConfig.clear();
     this.router.navigate(['/setup']);
   }
 
   protected logout() {
-    this.open.set(false);
     this.auth.logout();
   }
 }

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -12,5 +12,5 @@ export const environment = {
    * box with no console registration but no Fliks branding. Keep as
    * fallback so devs without console access can still cast.
    */
-  castAppId: 'CC1AD845',
+  castAppId: '66BF4DAE',
 };

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -215,6 +215,14 @@ body.tv .dropdown:not(.dropdown-open) > .dropdown-content {
   display: none !important;
 }
 
+/* Shared item style for app-dropdown-menu (desktop dropdown + mobile/TV
+   bottom sheet). Caller adds a colour utility (`text-white`, `text-error`,
+   …) and an icon — everything else (padding, hover, focus, layout) lives
+   here so each menu item stays a one-liner. */
+.dropdown-item {
+  @apply w-full flex items-center gap-3 px-3 py-2 text-left text-base rounded-lg cursor-pointer hover:bg-white/5 active:bg-white/10 disabled:opacity-40;
+}
+
 /* ============================================================================
    Tablet form-factor — body.tablet toggled by DeviceService
    ============================================================================ */


### PR DESCRIPTION
## Summary

Three independent threads bundled because they land together end-of-day.

- **Cast app ID `66BF4DAE`** — published receiver replaces the placeholder `CC1AD845` across web + Android + iOS (incl. Bonjour service). Cast SDK now launches the branded Fliks receiver.
- **Folder naming** — movie default switches to `{Original Title} ({Release Year})` so disk folders match release-group conventions (Mean Girls vs Lolita malgré moi). Series gains `{Original Title}` token for parity. Disk import auto-realigns `media.folderName` when the file lives under the same rootFolder but a different folder than the stored localised title — kills the spurious "file outside media folder" error.
- **DaisyUI dropdown** — new `DropdownMenuComponent` replaces `PopoverMenu` for the 3 main menus (UserMenu, MediaInfoHeader more-actions, MediaDetailSeasons). DaisyUI handles desktop anchoring in pure CSS; bottom-sheet stays for mobile / tablet / TV. Shared `.dropdown-item` utility class. SelectPicker keeps PopoverMenu (TV-only path, external-anchor model).

## Test plan
- [ ] Cast a media on a registered Chromecast → Fliks branded splash + playback (no stuck "pending")
- [ ] Add a new movie via library import → folder uses original English title
- [ ] Disk-import a file from a folder whose name differs from `media.folderName` → import succeeds, folderName updates
- [ ] Open user menu / media-detail more-actions / season menu on desktop → DaisyUI dropdown anchors correctly under the trigger
- [ ] Same on mobile + Android native → bottom sheet sits ABOVE the bottom dock
- [ ] Item click closes the menu (desktop and bottom-sheet)
- [ ] Outside-click + Escape + back button all dismiss