### PR TITLE
Cast subtitle style — shared presets with the local player

### DIFF
--- a/cast-receiver/receiver.css
+++ b/cast-receiver/receiver.css
@@ -67,3 +67,18 @@ body.playing .splash {
   background: transparent;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.95), 0 0 4px rgba(0, 0, 0, 0.7);
 }
+
+/* Shaka UITextDisplayer (enabled in receiver.js) renders cue text as
+   HTML inside `.shaka-text-container > span[translate="no"]`. CAF
+   applies the sender's TextTrackStyle (color / background) inline on
+   that span; we add padding + radius here so the 'Black' / 'Semi'
+   background presets show up as a tidy rounded box rather than a flush
+   block. The values mirror the in-app player styling
+   (frontend/src/styles.css). */
+.shaka-text-container span[translate="no"] {
+  padding: 0.15em 0.4em !important;
+  border-radius: 0.25em !important;
+}
+.shaka-text-container .shaka-text-wrapper {
+  line-height: 1.1 !important;
+}

--- a/cast-receiver/receiver.js
+++ b/cast-receiver/receiver.js
@@ -64,6 +64,23 @@ playerManager.setMessageInterceptor(
   },
 );
 
+// --- Shaka UI text displayer --------------------------------------------
+//
+// CAF's default text track rendering goes through native ::cue, whose
+// allowed CSS is restricted (no padding, no border-radius). Switching
+// to Shaka's UITextDisplayer renders cues as HTML inside `.shaka-text-
+// container > span[translate="no"]`, where receiver.css can apply the
+// same boxed look the in-app Shaka player uses.
+playerManager.setMediaPlaybackInfoHandler((_req, cfg) => {
+  if (typeof shaka !== 'undefined' && shaka.text && shaka.text.UITextDisplayer) {
+    cfg.shakaConfig = {
+      ...(cfg.shakaConfig || {}),
+      textDisplayFactory: shaka.text.UITextDisplayer,
+    };
+  }
+  return cfg;
+});
+
 // --- Boot ---------------------------------------------------------------
 //
 // `disableIdleTimeout: true` keeps the receiver alive between clips so

--- a/frontend/android/app/src/main/java/media/fliks/app/CastPlugin.java
+++ b/frontend/android/app/src/main/java/media/fliks/app/CastPlugin.java
@@ -307,21 +307,14 @@ public class CastPlugin extends Plugin {
                 Log.w(TAG, "Error parsing subtitles", e);
             }
         }
+        JSObject styleSpec = call.getObject("textTrackStyle");
         if (!tracks.isEmpty()) {
             mediaInfoBuilder.setMediaTracks(tracks);
-
-            TextTrackStyle trackStyle = new TextTrackStyle();
-            trackStyle.setFontScale(0.85f);
-            trackStyle.setFontGenericFamily(TextTrackStyle.FONT_FAMILY_SANS_SERIF);
-            trackStyle.setForegroundColor(0xFFFFFFFF);
-            trackStyle.setBackgroundColor(0x00000000);
-            trackStyle.setWindowColor(0x00000000);
-
-            trackStyle.setWindowType(TextTrackStyle.WINDOW_TYPE_NONE);
-            trackStyle.setEdgeType(TextTrackStyle.EDGE_TYPE_DROP_SHADOW);
-            trackStyle.setEdgeColor(0xFF000000);
-            mediaInfoBuilder.setTextTrackStyle(trackStyle);
         }
+        // Always set the style — receiver fills its defaults when
+        // textTrackStyle is missing, masking the user's prefs whenever
+        // the LOAD has no preselected subtitle tracks.
+        mediaInfoBuilder.setTextTrackStyle(buildTextTrackStyle(styleSpec));
 
         MediaInfo mediaInfo = mediaInfoBuilder.build();
 
@@ -344,30 +337,92 @@ public class CastPlugin extends Plugin {
         client.load(requestBuilder.build());
 
         // Apply text track style after load (Default Media Receiver ignores it in MediaInfo)
-        if (!tracks.isEmpty()) {
-            pollHandler = mainHandler;
-            pollHandler.postDelayed(() -> {
-                try {
-                    TextTrackStyle style = new TextTrackStyle();
-                    style.setFontScale(0.85f);
-                    style.setFontGenericFamily(TextTrackStyle.FONT_FAMILY_SANS_SERIF);
-                    style.setForegroundColor(0xFFFFFFFF);
-                    style.setBackgroundColor(0x00000000);
-                    style.setWindowColor(0x00000000);
-                    style.setWindowType(TextTrackStyle.WINDOW_TYPE_NONE);
-                    style.setEdgeType(TextTrackStyle.EDGE_TYPE_DROP_SHADOW);
-                    style.setEdgeColor(0xFF000000);
-                    client.setTextTrackStyle(style);
-                } catch (Exception e) {
-                    Log.w(TAG, "Failed to set track style", e);
-                }
-            }, 2000);
-        }
+        pollHandler = mainHandler;
+        pollHandler.postDelayed(() -> {
+            try {
+                client.setTextTrackStyle(buildTextTrackStyle(styleSpec));
+            } catch (Exception e) {
+                Log.w(TAG, "Failed to set track style", e);
+            }
+        }, 2000);
 
         // Start position/state polling
         startMediaPolling(client);
 
         call.resolve();
+    }
+
+    /**
+     * Map the sender's subtitle presets ({@code size} / {@code color} /
+     * {@code shadow} / {@code background}) onto Cast SDK's
+     * {@link TextTrackStyle}. Same preset vocabulary as the local
+     * player settings — keeps a single shared UI between both. When
+     * {@code spec} is null, returns the receiver-matching defaults.
+     */
+    private TextTrackStyle buildTextTrackStyle(JSObject spec) {
+        TextTrackStyle style = new TextTrackStyle();
+        style.setFontGenericFamily(TextTrackStyle.FONT_FAMILY_SANS_SERIF);
+        style.setWindowType(TextTrackStyle.WINDOW_TYPE_NONE);
+        style.setWindowColor(0x00000000);
+        String size = spec != null ? spec.optString("size", "normal") : "normal";
+        String color = spec != null ? spec.optString("color", "white") : "white";
+        String shadow = spec != null ? spec.optString("shadow", "drop") : "drop";
+        String bg = spec != null ? spec.optString("background", "transparent") : "transparent";
+        style.setFontScale(mapSize(size));
+        style.setForegroundColor(mapFgColor(color));
+        style.setBackgroundColor(mapBgColor(bg));
+        int[] edge = mapShadow(shadow);
+        style.setEdgeType(edge[0]);
+        style.setEdgeColor(edge[1]);
+        return style;
+    }
+
+    private static float mapSize(String name) {
+        switch (name) {
+            case "small": return 0.7f;
+            case "large": return 1.1f;
+            case "xlarge": return 1.4f;
+            default: return 0.85f;
+        }
+    }
+
+    private static int mapFgColor(String name) {
+        switch (name) {
+            case "yellow": return 0xFFFFFF00;
+            case "green": return 0xFF00FF00;
+            case "cyan": return 0xFF00FFFF;
+            default: return 0xFFFFFFFF;
+        }
+    }
+
+    private static int mapBgColor(String name) {
+        switch (name) {
+            case "semi": return 0x80000000;
+            case "black": return 0xFF000000;
+            // Cast SDK on Android strips integer-color fields equal to
+            // 0 from the wire payload (treats them as "unset"), so the
+            // receiver falls through to CAF's built-in default — which
+            // happens to render an opaque black box. Use a non-zero
+            // value with alpha 0: still fully transparent visually,
+            // but serialised on the wire as #01000000 so the receiver
+            // sees an explicit transparent backgroundColor.
+            default: return 0x00010000;
+        }
+    }
+
+    /** Returns {edgeType, edgeColor}. */
+    private static int[] mapShadow(String name) {
+        switch (name) {
+            // Same wire-omission concern as transparent backgrounds —
+            // a 0 colour is stripped, the receiver picks its default.
+            // Edge isn't rendered when type=NONE so the visible result
+            // is the same; we keep the wire frame complete for
+            // determinism / debuggability.
+            case "none": return new int[] { TextTrackStyle.EDGE_TYPE_NONE, 0x00010000 };
+            case "outline": return new int[] { TextTrackStyle.EDGE_TYPE_OUTLINE, 0xFF000000 };
+            case "raised": return new int[] { TextTrackStyle.EDGE_TYPE_RAISED, 0xFF000000 };
+            default: return new int[] { TextTrackStyle.EDGE_TYPE_DROP_SHADOW, 0xFF000000 };
+        }
     }
 
     @PluginMethod()

--- a/frontend/ios/App/App/CastPlugin.swift
+++ b/frontend/ios/App/App/CastPlugin.swift
@@ -161,16 +161,12 @@ public class CastPlugin: CAPPlugin, CAPBridgedPlugin, GCKSessionManagerListener,
 
             if !tracks.isEmpty {
                 builder.mediaTracks = tracks
-
-                let textStyle = GCKMediaTextTrackStyle.createDefault()
-                textStyle.fontScale = 0.85
-                textStyle.fontGenericFamily = .sansSerif
-                textStyle.foregroundColor = GCKColor(uiColor: .white)
-                textStyle.backgroundColor = GCKColor(uiColor: .clear)
-                textStyle.edgeType = .dropShadow
-                textStyle.edgeColor = GCKColor(uiColor: .black)
-                builder.textTrackStyle = textStyle
             }
+            // Always set the style — receiver fills its defaults when
+            // textTrackStyle is missing, masking the user's prefs
+            // whenever the LOAD has no preselected subtitle tracks.
+            let spec = call.getObject("textTrackStyle")
+            builder.textTrackStyle = self?.buildTextTrackStyle(spec)
 
             let mediaInfo = builder.build()
 
@@ -331,6 +327,61 @@ public class CastPlugin: CAPPlugin, CAPBridgedPlugin, GCKSessionManagerListener,
         let js = "window.dispatchEvent(new CustomEvent('castMediaUpdate', { detail: { currentTime: \(time), duration: \(duration), isPaused: \(paused) } }));"
         DispatchQueue.main.async { [weak self] in
             self?.bridge?.webView?.evaluateJavaScript(js)
+        }
+    }
+
+    /// Map the sender's subtitle presets (`size` / `color` / `shadow` /
+    /// `background`) onto Cast SDK's `GCKMediaTextTrackStyle`. Same
+    /// preset vocabulary as the local player settings — keeps a single
+    /// shared UI between both. nil spec → receiver-matching defaults.
+    private func buildTextTrackStyle(_ spec: [String: Any]?) -> GCKMediaTextTrackStyle {
+        let style = GCKMediaTextTrackStyle.createDefault()
+        style.fontGenericFamily = .sansSerif
+        let size = spec?["size"] as? String ?? "normal"
+        let color = spec?["color"] as? String ?? "white"
+        let shadow = spec?["shadow"] as? String ?? "drop"
+        let bg = spec?["background"] as? String ?? "transparent"
+        style.fontScale = mapSize(size)
+        style.foregroundColor = mapFgColor(color)
+        style.backgroundColor = mapBgColor(bg)
+        let edge = mapShadow(shadow)
+        style.edgeType = edge.type
+        style.edgeColor = edge.color
+        return style
+    }
+
+    private func mapSize(_ name: String) -> CGFloat {
+        switch name {
+        case "small": return 0.7
+        case "large": return 1.1
+        case "xlarge": return 1.4
+        default: return 0.85
+        }
+    }
+
+    private func mapFgColor(_ name: String) -> GCKColor {
+        switch name {
+        case "yellow": return GCKColor(uiColor: UIColor(red: 1, green: 1, blue: 0, alpha: 1))
+        case "green": return GCKColor(uiColor: UIColor(red: 0, green: 1, blue: 0, alpha: 1))
+        case "cyan": return GCKColor(uiColor: UIColor(red: 0, green: 1, blue: 1, alpha: 1))
+        default: return GCKColor(uiColor: .white)
+        }
+    }
+
+    private func mapBgColor(_ name: String) -> GCKColor {
+        switch name {
+        case "semi": return GCKColor(uiColor: UIColor(red: 0, green: 0, blue: 0, alpha: 0.5))
+        case "black": return GCKColor(uiColor: .black)
+        default: return GCKColor(uiColor: .clear)
+        }
+    }
+
+    private func mapShadow(_ name: String) -> (type: GCKMediaTextTrackStyleEdgeType, color: GCKColor) {
+        switch name {
+        case "none": return (.none, GCKColor(uiColor: .clear))
+        case "outline": return (.outline, GCKColor(uiColor: .black))
+        case "raised": return (.raised, GCKColor(uiColor: .black))
+        default: return (.dropShadow, GCKColor(uiColor: .black))
         }
     }
 }

--- a/frontend/src/app/core/services/cast-settings.service.ts
+++ b/frontend/src/app/core/services/cast-settings.service.ts
@@ -1,29 +1,79 @@
 import { Injectable, signal } from '@angular/core';
 
+/** Subtitle appearance presets — same vocabulary as the local player
+ *  settings (`SubtitleAppearanceComponent`). Each consumer translates
+ *  the presets to its native rendering: Shaka CSS for local playback,
+ *  Cast SDK `TextTrackStyle` enums + `#AARRGGBB` colours for the
+ *  receiver. Storing presets (rather than RGB / numeric scale) keeps
+ *  one shared UI between local and Cast and matches user expectations
+ *  ("Normal / Grand", "Blanc / Jaune") rather than raw values. */
+export interface CastSubtitleStyle {
+  size: string;        // 'small' | 'normal' | 'large' | 'xlarge'
+  color: string;       // 'white' | 'yellow' | 'green' | 'cyan'
+  shadow: string;      // 'none' | 'drop' | 'outline' | 'raised'
+  background: string;  // 'transparent' | 'semi' | 'black'
+}
+
 export interface CastSettings {
   hdr: boolean;
   maxQuality: string; // 'original' | '2160p' | '1080p' | '720p' | '480p'
   audioChannels: number; // 2 = stereo, 6 = 5.1, 8 = 7.1
+  subtitleStyle: CastSubtitleStyle;
 }
 
 const STORAGE_KEY = 'cast.settings';
+
+/** Defaults match the receiver's bake-in (`cast-receiver/receiver.js`)
+ *  so the user-never-opened-settings path is visually identical
+ *  whether the receiver applies its fallback or the sender forwards
+ *  these presets. */
+export const DEFAULT_CAST_SUBTITLE_STYLE: CastSubtitleStyle = {
+  size: 'normal',
+  color: 'white',
+  shadow: 'drop',
+  background: 'transparent',
+};
 
 const DEFAULTS: CastSettings = {
   hdr: false,
   maxQuality: '1080p',
   audioChannels: 2,
+  subtitleStyle: { ...DEFAULT_CAST_SUBTITLE_STYLE },
 };
 
 @Injectable({ providedIn: 'root' })
 export class CastSettingsService {
   readonly settings = signal<CastSettings>(this.load());
 
+  constructor() {
+    // First-run: persist the defaults so the cast-settings form, the
+    // localStorage payload, and what the sender actually transmits to
+    // the receiver all stay in lockstep. Without this seed, an empty
+    // storage would still work in-memory (the signal is hydrated from
+    // DEFAULTS), but a hard reload, a second tab, or any future code
+    // path that re-reads storage would diverge silently.
+    try {
+      if (!localStorage.getItem(STORAGE_KEY)) {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(this.settings()));
+      }
+    } catch { /* private mode / SSR */ }
+  }
+
   private load(): CastSettings {
     try {
       const raw = localStorage.getItem(STORAGE_KEY);
-      if (raw) return { ...DEFAULTS, ...JSON.parse(raw) };
+      if (raw) {
+        const parsed = JSON.parse(raw) as Partial<CastSettings>;
+        return {
+          ...DEFAULTS,
+          ...parsed,
+          // Nested object — spread so older payloads without subtitleStyle
+          // get the defaults instead of `undefined`.
+          subtitleStyle: { ...DEFAULTS.subtitleStyle, ...(parsed.subtitleStyle ?? {}) },
+        };
+      }
     } catch { /* ignore */ }
-    return { ...DEFAULTS };
+    return { ...DEFAULTS, subtitleStyle: { ...DEFAULTS.subtitleStyle } };
   }
 
   save(settings: CastSettings) {

--- a/frontend/src/app/core/services/cast.service.ts
+++ b/frontend/src/app/core/services/cast.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, signal, OnDestroy } from '@angular/core';
+import { Injectable, inject, signal, OnDestroy } from '@angular/core';
 import { Capacitor, registerPlugin } from '@capacitor/core';
 import { environment } from '../../../environments/environment';
+import { CastSettingsService, CastSubtitleStyle } from './cast-settings.service';
 
 declare const cast: any;
 declare const chrome: any;
@@ -35,6 +36,10 @@ interface NativeCastLoadOpts {
   subtitles: { url: string; language: string; label: string }[];
   activeSubtitleTrackId: number;
   customData?: Record<string, unknown>;
+  /** Optional — when present, native plugin builds the platform's
+   *  text-track-style equivalent (TextTrackStyle on Android, GCKMedia-
+   *  TextTrackStyle on iOS) and attaches to MediaInformation. */
+  textTrackStyle?: CastSubtitleStyle;
 }
 
 interface NativeCastPlugin {
@@ -67,6 +72,7 @@ export class CastService implements OnDestroy {
   readonly castStreamBaseUrl = signal('');
 
   private readonly isNative = Capacitor.isNativePlatform();
+  private readonly castSettings = inject(CastSettingsService);
 
   // Web-only
   private session: any = null;
@@ -209,6 +215,8 @@ export class CastService implements OnDestroy {
       episodeId: info.episodeId,
     };
 
+    const subtitleStyle = this.castSettings.get().subtitleStyle;
+
     if (this.isNative) {
       try {
         await NativeCast.loadMedia({
@@ -221,6 +229,7 @@ export class CastService implements OnDestroy {
           subtitles: info.subtitles ?? [],
           activeSubtitleTrackId: info.activeSubtitleTrackId ?? 0,
           customData,
+          textTrackStyle: subtitleStyle,
         });
       } catch (err) {
         console.error('NativeCast.loadMedia failed:', err);
@@ -254,14 +263,12 @@ export class CastService implements OnDestroy {
         track.language = sub.language;
         return track;
       });
-      mediaInfo.textTrackStyle = new chrome.cast.media.TextTrackStyle();
-      mediaInfo.textTrackStyle.fontScale = 0.85;
-      mediaInfo.textTrackStyle.fontGenericFamily = chrome.cast.media.TextTrackFontGenericFamily.SANS_SERIF;
-      mediaInfo.textTrackStyle.foregroundColor = '#FFFFFFFF';
-      mediaInfo.textTrackStyle.backgroundColor = '#00000000';
-      mediaInfo.textTrackStyle.edgeType = chrome.cast.media.TextTrackEdgeType.DROP_SHADOW;
-      mediaInfo.textTrackStyle.edgeColor = '#000000FF';
     }
+    // Always send the style: receiver bakes in its defaults when
+    // textTrackStyle is missing, so skipping it here would mask the
+    // user's prefs for any LOAD that happened to omit tracks (e.g.
+    // movie cast with no preselected sub).
+    mediaInfo.textTrackStyle = this.buildWebTextTrackStyle(subtitleStyle);
 
     const request = new chrome.cast.media.LoadRequest(mediaInfo);
     request.currentTime = info.currentTime ?? 0;
@@ -338,4 +345,50 @@ export class CastService implements OnDestroy {
     const request = new chrome.cast.media.EditTracksInfoRequest(activeIds);
     media.editTracksInfo(request, () => {}, () => {});
   }
+
+  /** Map subtitle presets (size / colour / shadow / background — the same
+   *  vocabulary the local player uses) onto the web Cast SDK's
+   *  `TextTrackStyle`. Native plugins replicate this mapping for parity
+   *  so the receiver sees identical Cast values regardless of sender. */
+  private buildWebTextTrackStyle(s: CastSubtitleStyle) {
+    const style = new chrome.cast.media.TextTrackStyle();
+    style.fontGenericFamily = chrome.cast.media.TextTrackFontGenericFamily.SANS_SERIF;
+    style.fontScale = SUB_SIZE_SCALE[s.size] ?? SUB_SIZE_SCALE['normal'];
+    style.foregroundColor = SUB_FG_COLOR[s.color] ?? SUB_FG_COLOR['white'];
+    style.backgroundColor = SUB_BG_COLOR[s.background] ?? SUB_BG_COLOR['transparent'];
+    const shadow = SUB_SHADOW[s.shadow] ?? SUB_SHADOW['drop'];
+    style.edgeType = chrome.cast.media.TextTrackEdgeType[shadow.edge];
+    style.edgeColor = shadow.color;
+    return style;
+  }
 }
+
+// Preset → Cast value tables. Colours follow Cast Web SDK's wire
+// format `#RRGGBBAA` (alpha last). Native plugins receive the same
+// presets and translate to their platform's int / UIColor form.
+const SUB_SIZE_SCALE: Record<string, number> = {
+  small: 0.7,
+  normal: 0.85,
+  large: 1.1,
+  xlarge: 1.4,
+};
+
+const SUB_FG_COLOR: Record<string, string> = {
+  white: '#FFFFFFFF',
+  yellow: '#FFFF00FF',
+  green: '#00FF00FF',
+  cyan: '#00FFFFFF',
+};
+
+const SUB_BG_COLOR: Record<string, string> = {
+  transparent: '#00000000',
+  semi: '#00000080',
+  black: '#000000FF',
+};
+
+const SUB_SHADOW: Record<string, { edge: string; color: string }> = {
+  none: { edge: 'NONE', color: '#00000000' },
+  drop: { edge: 'DROP_SHADOW', color: '#000000FF' },
+  outline: { edge: 'OUTLINE', color: '#000000FF' },
+  raised: { edge: 'RAISED', color: '#000000FF' },
+};

--- a/frontend/src/app/features/playback-settings/cast-settings/cast-settings.html
+++ b/frontend/src/app/features/playback-settings/cast-settings/cast-settings.html
@@ -1,13 +1,11 @@
 <h1 class="text-2xl font-bold mb-4">Chromecast</h1>
 <div class="card bg-base-100 border border-base-200">
   <div class="card-body gap-5">
-    <div class="form-control">
-      <label class="label cursor-pointer justify-start gap-4">
-        <input type="checkbox" class="toggle toggle-primary" [ngModel]="hdr()" (ngModelChange)="hdr.set($event)" />
-        <span class="label-text font-medium">{{ 'playback_settings.cast_hdr' | translate }}</span>
-      </label>
-      <div class="label"><span class="label-text-alt text-base-content/50">{{ 'playback_settings.cast_hdr_hint' | translate }}</span></div>
-    </div>
+    <app-toggle-field
+      [(value)]="hdr"
+      [label]="'playback_settings.cast_hdr' | translate"
+      [hint]="'playback_settings.cast_hdr_hint' | translate"
+    />
 
     <div class="divider my-0"></div>
 
@@ -28,6 +26,19 @@
       </select>
       <div class="label"><span class="label-text-alt text-base-content/50">{{ 'playback_settings.cast_audio_hint' | translate }}</span></div>
     </label>
+
+    <div class="divider my-0"></div>
+
+    <app-subtitle-appearance
+      [size]="subSize()"
+      [color]="subColor()"
+      [shadow]="subShadow()"
+      [background]="subBackground()"
+      (sizeChange)="subSize.set($event)"
+      (colorChange)="subColor.set($event)"
+      (shadowChange)="subShadow.set($event)"
+      (backgroundChange)="subBackground.set($event)"
+    />
 
     <div class="card-actions justify-end pt-2">
       <button class="btn btn-primary" (click)="save()">{{ 'common.save' | translate }}</button>

--- a/frontend/src/app/features/playback-settings/cast-settings/cast-settings.ts
+++ b/frontend/src/app/features/playback-settings/cast-settings/cast-settings.ts
@@ -1,13 +1,15 @@
 import { Component, ChangeDetectionStrategy, inject, signal, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { CastSettingsService, CastSettings } from '../../../core/services/cast-settings.service';
+import { CastSettingsService, CastSettings, DEFAULT_CAST_SUBTITLE_STYLE } from '../../../core/services/cast-settings.service';
 import { ToastService } from '../../../core/services/toast.service';
+import { SubtitleAppearanceComponent } from '../../../shared/components/subtitle-appearance/subtitle-appearance';
+import { ToggleFieldComponent } from '../../../shared/components/forms/toggle-field/toggle-field';
 import { QUALITY_OPTIONS, AUDIO_CHANNEL_OPTIONS } from '../playback-options';
 
 @Component({
   selector: 'app-cast-settings',
-  imports: [FormsModule, TranslateModule],
+  imports: [FormsModule, TranslateModule, SubtitleAppearanceComponent, ToggleFieldComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './cast-settings.html',
 })
@@ -23,11 +25,20 @@ export class CastSettingsPageComponent implements OnInit {
   readonly maxQuality = signal('1080p');
   readonly audioChannels = signal(2);
 
+  readonly subSize = signal(DEFAULT_CAST_SUBTITLE_STYLE.size);
+  readonly subColor = signal(DEFAULT_CAST_SUBTITLE_STYLE.color);
+  readonly subShadow = signal(DEFAULT_CAST_SUBTITLE_STYLE.shadow);
+  readonly subBackground = signal(DEFAULT_CAST_SUBTITLE_STYLE.background);
+
   ngOnInit() {
     const c = this.castSettings.get();
     this.hdr.set(c.hdr);
     this.maxQuality.set(c.maxQuality);
     this.audioChannels.set(c.audioChannels);
+    this.subSize.set(c.subtitleStyle.size);
+    this.subColor.set(c.subtitleStyle.color);
+    this.subShadow.set(c.subtitleStyle.shadow);
+    this.subBackground.set(c.subtitleStyle.background);
   }
 
   save() {
@@ -35,6 +46,12 @@ export class CastSettingsPageComponent implements OnInit {
       hdr: this.hdr(),
       maxQuality: this.maxQuality(),
       audioChannels: this.audioChannels(),
+      subtitleStyle: {
+        size: this.subSize(),
+        color: this.subColor(),
+        shadow: this.subShadow(),
+        background: this.subBackground(),
+      },
     };
     this.castSettings.save(settings);
     this.toast.success(this.translate.instant('common.settings_saved'));

--- a/frontend/src/app/features/playback-settings/subtitle-settings/subtitle-settings.html
+++ b/frontend/src/app/features/playback-settings/subtitle-settings/subtitle-settings.html
@@ -35,36 +35,17 @@
 
     <div class="divider my-0"></div>
 
-    <h2 class="text-lg font-bold">{{ 'playback_settings.sub_appearance_title' | translate }}</h2>
-    <p class="text-sm text-base-content/60 -mt-4">{{ 'playback_settings.sub_appearance_hint' | translate }}</p>
+    <app-subtitle-appearance
+      [size]="subtitleSize()"
+      [color]="subtitleColor()"
+      [shadow]="subtitleShadow()"
+      [background]="subtitleBackground()"
+      (sizeChange)="subtitleSize.set($event)"
+      (colorChange)="subtitleColor.set($event)"
+      (shadowChange)="subtitleShadow.set($event)"
+      (backgroundChange)="subtitleBackground.set($event)"
+    />
 
-    <label class="form-control w-full max-w-xs">
-      <div class="label"><span class="label-text font-medium">{{ 'playback_settings.sub_size' | translate }}</span></div>
-      <select class="select select-bordered w-full" [ngModel]="subtitleSize()" (ngModelChange)="subtitleSize.set($event)">
-        @for (s of sizeOptions; track s.value) { <option [value]="s.value">{{ s.label }}</option> }
-      </select>
-    </label>
-
-    <label class="form-control w-full max-w-xs">
-      <div class="label"><span class="label-text font-medium">{{ 'playback_settings.sub_color' | translate }}</span></div>
-      <select class="select select-bordered w-full" [ngModel]="subtitleColor()" (ngModelChange)="subtitleColor.set($event)">
-        @for (c of colorOptions; track c.value) { <option [value]="c.value">{{ c.label }}</option> }
-      </select>
-    </label>
-
-    <label class="form-control w-full max-w-xs">
-      <div class="label"><span class="label-text font-medium">{{ 'playback_settings.sub_shadow' | translate }}</span></div>
-      <select class="select select-bordered w-full" [ngModel]="subtitleShadow()" (ngModelChange)="subtitleShadow.set($event)">
-        @for (s of shadowOptions; track s.value) { <option [value]="s.value">{{ s.label }}</option> }
-      </select>
-    </label>
-
-    <label class="form-control w-full max-w-xs">
-      <div class="label"><span class="label-text font-medium">{{ 'playback_settings.sub_bg' | translate }}</span></div>
-      <select class="select select-bordered w-full" [ngModel]="subtitleBackground()" (ngModelChange)="subtitleBackground.set($event)">
-        @for (b of bgOptions; track b.value) { <option [value]="b.value">{{ b.label }}</option> }
-      </select>
-    </label>
 
     <div class="divider my-0"></div>
 

--- a/frontend/src/app/features/playback-settings/subtitle-settings/subtitle-settings.ts
+++ b/frontend/src/app/features/playback-settings/subtitle-settings/subtitle-settings.ts
@@ -4,15 +4,15 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { PlayerSettingsService } from '../../../core/services/player-settings.service';
 import { ToastService } from '../../../core/services/toast.service';
 import { LucideTrash2 } from '@lucide/angular';
+import { SubtitleAppearanceComponent } from '../../../shared/components/subtitle-appearance/subtitle-appearance';
 import {
   LANGUAGE_OPTIONS, SUBTITLE_MODE_OPTIONS,
-  SIZE_OPTIONS, COLOR_OPTIONS, SHADOW_OPTIONS, BG_OPTIONS,
   BOTTOM_MARGIN_OPTIONS, TOP_MARGIN_OPTIONS,
 } from '../playback-options';
 
 @Component({
   selector: 'app-subtitle-settings',
-  imports: [FormsModule, TranslateModule, LucideTrash2],
+  imports: [FormsModule, TranslateModule, LucideTrash2, SubtitleAppearanceComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './subtitle-settings.html',
 })
@@ -23,10 +23,6 @@ export class SubtitleSettingsPageComponent implements OnInit {
 
   readonly languageOptions = LANGUAGE_OPTIONS;
   readonly subtitleModeOptions = SUBTITLE_MODE_OPTIONS;
-  readonly sizeOptions = SIZE_OPTIONS;
-  readonly colorOptions = COLOR_OPTIONS;
-  readonly shadowOptions = SHADOW_OPTIONS;
-  readonly bgOptions = BG_OPTIONS;
   readonly bottomMarginOptions = BOTTOM_MARGIN_OPTIONS;
   readonly topMarginOptions = TOP_MARGIN_OPTIONS;
 

--- a/frontend/src/app/shared/components/subtitle-appearance/subtitle-appearance.ts
+++ b/frontend/src/app/shared/components/subtitle-appearance/subtitle-appearance.ts
@@ -1,0 +1,82 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  output,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+import {
+  SIZE_OPTIONS,
+  COLOR_OPTIONS,
+  SHADOW_OPTIONS,
+  BG_OPTIONS,
+} from '../../../features/playback-settings/playback-options';
+
+/**
+ * Subtitle appearance preset selectors (size / colour / shadow /
+ * background), shared between the local player settings and the Cast
+ * settings page so users see one familiar form everywhere.
+ *
+ * The values stay raw preset strings (`small`, `white`, `drop`,
+ * `transparent`, …); each consumer is free to interpret them — Shaka CSS
+ * for local playback, Cast `TextTrackStyle` mapping for the receiver.
+ */
+@Component({
+  selector: 'app-subtitle-appearance',
+  standalone: true,
+  imports: [FormsModule, TranslateModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="flex flex-col gap-5">
+      <div class="flex flex-col gap-1">
+        <h2 class="text-lg font-bold">{{ 'playback_settings.sub_appearance_title' | translate }}</h2>
+        <p class="text-sm text-base-content/60">{{ 'playback_settings.sub_appearance_hint' | translate }}</p>
+      </div>
+
+      <label class="form-control w-full max-w-xs">
+        <div class="label"><span class="label-text font-medium">{{ 'playback_settings.sub_size' | translate }}</span></div>
+        <select class="select select-bordered w-full" [ngModel]="size()" (ngModelChange)="sizeChange.emit($event)">
+          @for (s of sizeOptions; track s.value) { <option [value]="s.value">{{ s.label }}</option> }
+        </select>
+      </label>
+
+      <label class="form-control w-full max-w-xs">
+        <div class="label"><span class="label-text font-medium">{{ 'playback_settings.sub_color' | translate }}</span></div>
+        <select class="select select-bordered w-full" [ngModel]="color()" (ngModelChange)="colorChange.emit($event)">
+          @for (c of colorOptions; track c.value) { <option [value]="c.value">{{ c.label }}</option> }
+        </select>
+      </label>
+
+      <label class="form-control w-full max-w-xs">
+        <div class="label"><span class="label-text font-medium">{{ 'playback_settings.sub_shadow' | translate }}</span></div>
+        <select class="select select-bordered w-full" [ngModel]="shadow()" (ngModelChange)="shadowChange.emit($event)">
+          @for (s of shadowOptions; track s.value) { <option [value]="s.value">{{ s.label }}</option> }
+        </select>
+      </label>
+
+      <label class="form-control w-full max-w-xs">
+        <div class="label"><span class="label-text font-medium">{{ 'playback_settings.sub_bg' | translate }}</span></div>
+        <select class="select select-bordered w-full" [ngModel]="background()" (ngModelChange)="backgroundChange.emit($event)">
+          @for (b of bgOptions; track b.value) { <option [value]="b.value">{{ b.label }}</option> }
+        </select>
+      </label>
+    </div>
+  `,
+})
+export class SubtitleAppearanceComponent {
+  readonly size = input.required<string>();
+  readonly color = input.required<string>();
+  readonly shadow = input.required<string>();
+  readonly background = input.required<string>();
+
+  readonly sizeChange = output<string>();
+  readonly colorChange = output<string>();
+  readonly shadowChange = output<string>();
+  readonly backgroundChange = output<string>();
+
+  protected readonly sizeOptions = SIZE_OPTIONS;
+  protected readonly colorOptions = COLOR_OPTIONS;
+  protected readonly shadowOptions = SHADOW_OPTIONS;
+  protected readonly bgOptions = BG_OPTIONS;
+}


### PR DESCRIPTION
## Summary

The subtitle appearance presets (size / colour / shadow / background) the local player has always had now also apply on Cast. One shared `SubtitleAppearanceComponent` drives both settings pages — same vocabulary, same UX, same defaults.

## Sender
- `CastSettingsService` stores presets and seeds them to `localStorage` on first run so the form / storage / Cast wire frame stay aligned.
- `cast.service.ts` converts presets to Cast `TextTrackStyle` on every LOAD (web SDK + Capacitor plugins). Always sends the style — the receiver bake-in only fired when the field was missing, masking the user's prefs whenever LOAD had no preselected subtitle tracks.
- Web wire format is `#RRGGBBAA` per Cast SDK docs (alpha last, not `AARRGGBB`).
- Android: the SDK strips integer-color fields equal to `0` from the wire frame, falling through to CAF's opaque-black default. `transparent` now serialises as `0x00010000` (alpha 0, visually invisible, non-zero bit survives serialisation).

## Receiver
- Switched cue rendering from native `::cue` to Shaka's `UITextDisplayer` via `setMediaPlaybackInfoHandler`. `::cue` forbids `padding` / `border-radius`; Shaka renders cues as HTML so `receiver.css` can apply the rounded-box look the in-app player already uses for `Black` / `Semi` backgrounds.
- Bundled: `PopoverMenu` ng-template + `ngTemplateOutlet` projection fix (same pattern as the dropdown PR) since `SelectPicker` still uses `PopoverMenu`.

## Test plan
- [ ] Cast a video on web Chrome with subs on → preset changes (size, colour, shadow) take effect after restart-cast
- [ ] Same on Android native (`npx cap sync android` + rebuild)
- [ ] Pick `Black` / `Semi` background → rendered as rounded box with padding
- [ ] Pick `Transparent` background → no visible box
- [ ] Local player subtitle appearance still works (regression check)
- [ ] Fresh install: `localStorage.cast.settings` is seeded on first app launch