### PR TITLE
ci: enforce conventional commit messages

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,19 @@
+# Validates commit messages on push + PR. Mirrors the local husky hook
+# (`.husky/commit-msg`) so a contributor who skipped local hooks can't
+# land non-conventional commits on `main`.
+name: Lint commit messages
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v6


### PR DESCRIPTION
Adds a CI workflow that validates commit messages on every push to main and on every pull request. Uses `wagoid/commitlint-github-action` with the default `@commitlint/config-conventional` ruleset (no config file needed).

Pairs with the branch protection on `main` (PR-only merges, no force push, linear history) so non-conventional commits can't slip in.