### PR TITLE
chore: change default port from 3000 to 4848

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,6 @@ COPY --from=client-build /app/dist/client/browser ./client
 ENV NODE_ENV=production
 ENV SERVE_STATIC_PATH=/app/client
 
-EXPOSE 3000
+EXPOSE 4848
 
 CMD ["node", "dist/main"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -44,6 +44,6 @@ RUN npm ci
 
 COPY . .
 
-EXPOSE 3000
+EXPOSE 4848
 
 CMD ["npm", "run", "start:dev"]

--- a/backend/src/common/stream-public-base-url.util.ts
+++ b/backend/src/common/stream-public-base-url.util.ts
@@ -19,5 +19,5 @@ export function resolveStreamPublicBaseUrl(
     const proto = (req.headers['x-forwarded-proto'] as string) || 'http';
     return `${proto}://${host}`;
   }
-  return `http://localhost:${process.env.PORT || 3000}`;
+  return `http://localhost:${process.env.PORT || 4848}`;
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -53,7 +53,7 @@ async function bootstrap() {
     }),
   );
 
-  const port = Number(process.env.PORT) || 3000;
+  const port = Number(process.env.PORT) || 4848;
   await app.listen(port);
 }
 bootstrap();


### PR DESCRIPTION
Default port was 3000, which collides with too many dev defaults (Next.js, Grafana, plenty of dev servers). Switch to **4848** — palindrome, easy to remember, unassigned by IANA, unlikely to clash with anything else self-hosted.

`PORT` env var still wins, so any existing deployment keeps working with whatever it had hard-coded.

## Changed

- `Dockerfile` — `EXPOSE`
- `backend/Dockerfile` — `EXPOSE`
- `backend/src/main.ts` — `process.env.PORT || 4848`
- `backend/src/common/stream-public-base-url.util.ts` — same fallback