### PR TITLE
ci: release-please uses a PAT so its tags trigger downstream workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,5 +29,11 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          # Personal access token instead of the default GITHUB_TOKEN
+          # so the tag + release commit it creates can trigger
+          # *other* workflows (notably docker-publish on the v* tag).
+          # GitHub blocks the default token from triggering further
+          # runs as an anti-loop measure.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Without this, the `v*` tag created by release-please does not fire `docker-publish` (GitHub blocks the default `GITHUB_TOKEN` from triggering further workflows). Each release needs a manual `workflow_dispatch` to publish the matching image.

## Setup

A repository secret `RELEASE_PLEASE_TOKEN` must exist on the repo before this lands. Either:
- Fine-grained PAT with `Contents: write` + `Pull requests: write` on `fliks-app/fliks`, OR
- Classic PAT with `public_repo` + `workflow` (sufficient as long as `fliks-app/fliks` stays public).

## Result

After merge, the next release flow is:
`feat:` lands → release-please opens release PR → merge → tag `v1.x.y` → docker-publish auto-triggers and pushes `ghcr.io/fliks-app/fliks:1.x.y` (+ `:1.x`, `:1`, `:latest`).