### PR TITLE
ci: automated Play Store publish on release tags

### DIFF
--- a/.github/workflows/play-store-publish.yml
+++ b/.github/workflows/play-store-publish.yml
@@ -1,0 +1,117 @@
+# Builds a signed AAB of the Fliks Android client and uploads it to
+# the Play Store internal track on every release tag (`v*` produced by
+# release-please) plus on manual `workflow_dispatch` for ad-hoc
+# re-uploads to other tracks.
+#
+# Promotion from `internal` → `alpha`/`beta`/`production` stays a
+# manual click in Play Console; this workflow never touches anything
+# beyond what the dispatch input asks for.
+#
+# Required repo secrets (one-shot setup, see
+# `plans/play-store-automation.plan.md`):
+#   - ANDROID_UPLOAD_KEYSTORE_BASE64
+#   - ANDROID_UPLOAD_KEYSTORE_PASSWORD
+#   - ANDROID_UPLOAD_KEY_ALIAS
+#   - ANDROID_UPLOAD_KEY_PASSWORD
+#   - PLAY_STORE_SERVICE_ACCOUNT_JSON
+name: Publish Android to Play Store
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      track:
+        description: 'Play Store track'
+        type: choice
+        options: [internal, alpha, beta, production]
+        default: internal
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: client
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history needed so `git rev-list --count HEAD` produces
+          # a meaningful commit count for the versionCode.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: android-actions/setup-android@v3
+
+      - name: Install client dependencies
+        run: npm ci
+
+      - name: Build Angular client
+        run: npm run build
+
+      - name: Capacitor sync to Android shell
+        run: npx cap sync android
+
+      - name: Compute versionCode from commit count
+        id: vcode
+        run: echo "value=$(git rev-list --count HEAD)" >> "$GITHUB_OUTPUT"
+        working-directory: ${{ github.workspace }}
+
+      - name: Decode upload keystore
+        run: |
+          echo "${{ secrets.ANDROID_UPLOAD_KEYSTORE_BASE64 }}" \
+            | base64 -d > android/app/fliks-upload.jks
+
+      - name: Assemble signed release AAB
+        env:
+          ORG_GRADLE_PROJECT_FLIKS_VERSION_CODE: ${{ steps.vcode.outputs.value }}
+          ORG_GRADLE_PROJECT_FLIKS_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_PASSWORD }}
+          ORG_GRADLE_PROJECT_FLIKS_KEY_ALIAS: ${{ secrets.ANDROID_UPLOAD_KEY_ALIAS }}
+          ORG_GRADLE_PROJECT_FLIKS_KEY_PASSWORD: ${{ secrets.ANDROID_UPLOAD_KEY_PASSWORD }}
+        run: |
+          cd android
+          ./gradlew bundleRelease
+
+      - name: Extract latest release notes from CHANGELOG.md
+        # release-please writes one section per release in the format
+        # `## [X.Y.Z]` (followed by the date). Awk grabs everything
+        # between the first such header and the next one — that is
+        # the body of the most recent release. The result is dropped
+        # into the path the upload action reads (en-US default).
+        run: |
+          mkdir -p android/app/src/main/play/release-notes/en-US
+          awk '
+            /^## \[/ { count++; if (count > 1) exit }
+            count == 1 { print }
+          ' ../CHANGELOG.md \
+            | tail -n +2 \
+            > android/app/src/main/play/release-notes/en-US/default.txt
+          # Play Store rejects empty release notes — fail loudly rather
+          # than upload a blank section.
+          if [ ! -s android/app/src/main/play/release-notes/en-US/default.txt ]; then
+            echo "::error::Could not extract release notes from CHANGELOG.md"
+            exit 1
+          fi
+
+      - name: Upload to Play Store
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+          packageName: media.fliks.app
+          releaseFiles: client/android/app/build/outputs/bundle/release/app-release.aab
+          track: ${{ github.event.inputs.track || 'internal' }}
+          status: completed
+          whatsNewDirectory: client/android/app/src/main/play/release-notes

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ coverage/
 Thumbs.db
 
 # Project-specific
+# Android signing keystore — never commit. Local copy lives outside
+# the repo (1Password / etc.); CI receives it as a base64-encoded
+# secret decoded at build time.
+client/android/app/fliks-upload.jks
 volumes/*
 /backend/images/
 scripts/

--- a/client/android/app/build.gradle
+++ b/client/android/app/build.gradle
@@ -7,12 +7,13 @@ android {
         applicationId "media.fliks.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        // versionCode is monotonic and managed by the build workflow
-        // (derived from `git rev-list --count HEAD` so each merge to
+        // versionCode is monotonic. CI overrides it via the Gradle
+        // property `FLIKS_VERSION_CODE` (set from `git rev-list --count
+        // HEAD` in the play-store-publish workflow) so each merge to
         // main produces a strictly-increasing value Play Store will
-        // accept). The committed value here is just a sane local
-        // default; CI overrides it before assembling release builds.
-        versionCode 1
+        // accept. The committed default of 1 keeps local debug builds
+        // working without any env setup.
+        versionCode (project.findProperty('FLIKS_VERSION_CODE') ?: 1) as int
         versionName "1.1.1" // x-release-please-version
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
@@ -21,10 +22,31 @@ android {
             ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
     }
+    // Signing config sourced from Gradle properties so the workflow
+    // never writes secrets to disk. Only resolved when the keystore
+    // file actually exists — local debug builds (no fliks-upload.jks
+    // checked out) skip the release signing block entirely.
+    signingConfigs {
+        release {
+            def keystoreFile = file('fliks-upload.jks')
+            if (keystoreFile.exists()) {
+                storeFile keystoreFile
+                storePassword project.findProperty('FLIKS_KEYSTORE_PASSWORD') ?: ''
+                keyAlias project.findProperty('FLIKS_KEY_ALIAS') ?: ''
+                keyPassword project.findProperty('FLIKS_KEY_PASSWORD') ?: ''
+            }
+        }
+    }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            // Apply release signing only when the keystore file is
+            // present — keeps `./gradlew assembleDebug` and any local
+            // contributor build working out of the box.
+            if (file('fliks-upload.jks').exists()) {
+                signingConfig signingConfigs.release
+            }
         }
     }
 }


### PR DESCRIPTION
Implements `plans/play-store-automation.plan.md`. After the one-shot Play Console + keystore + service-account setup, every `v*` tag built by release-please uploads a signed AAB to the Play Store **internal track** automatically.

## What

- `.github/workflows/play-store-publish.yml` — workflow that builds Angular, syncs to Capacitor, assembles a signed AAB with versionCode = `git rev-list --count HEAD`, extracts release notes from `CHANGELOG.md`, and uploads via `r0adkll/upload-google-play`.
- `client/android/app/build.gradle` — versionCode + signingConfigs.release pulled from Gradle properties so the workflow injects everything via env vars, no on-disk secrets. The signing block is conditional on the keystore file existing → local debug builds keep working with zero env setup.
- `.gitignore` — `fliks-upload.jks` ignored as an anti-leak guard.

## Required repo secrets (manual one-shot)

Listed at the top of the workflow file:

- `ANDROID_UPLOAD_KEYSTORE_BASE64`
- `ANDROID_UPLOAD_KEYSTORE_PASSWORD`
- `ANDROID_UPLOAD_KEY_ALIAS`
- `ANDROID_UPLOAD_KEY_PASSWORD`
- `PLAY_STORE_SERVICE_ACCOUNT_JSON`

Steps to produce them are in the plan doc.

## Track strategy

- **Auto on tag**: `internal`. Instant rollout to internal testers, no Google review.
- **Promotion** to `alpha`/`beta`/`production`: manual click in Play Console, OR `workflow_dispatch` with the `track` input (e.g. for re-uploading a hotfix).

## Out of scope

- Apple / TestFlight automation (separate plan when the Apple Dev account is in place).
- Screenshot / store listing automation.
- Auto-promotion from `internal` to `production` — keeping a human gate there.