### PR TITLE
fix(android): use '=' assignment in build.gradle for version + signing props

### DIFF
--- a/client/android/app/build.gradle
+++ b/client/android/app/build.gradle
@@ -13,7 +13,7 @@ android {
         // main produces a strictly-increasing value Play Store will
         // accept. The committed default of 1 keeps local debug builds
         // working without any env setup.
-        versionCode (project.findProperty('FLIKS_VERSION_CODE') ?: 1) as int
+        versionCode = ((project.findProperty('FLIKS_VERSION_CODE') ?: 1) as int)
         versionName "1.1.1" // x-release-please-version
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
@@ -31,9 +31,9 @@ android {
             def keystoreFile = file('fliks-upload.jks')
             if (keystoreFile.exists()) {
                 storeFile keystoreFile
-                storePassword project.findProperty('FLIKS_KEYSTORE_PASSWORD') ?: ''
-                keyAlias project.findProperty('FLIKS_KEY_ALIAS') ?: ''
-                keyPassword project.findProperty('FLIKS_KEY_PASSWORD') ?: ''
+                storePassword = (project.findProperty('FLIKS_KEYSTORE_PASSWORD') ?: '')
+                keyAlias = (project.findProperty('FLIKS_KEY_ALIAS') ?: '')
+                keyPassword = (project.findProperty('FLIKS_KEY_PASSWORD') ?: '')
             }
         }
     }


### PR DESCRIPTION
Gradle DSL parsing trap. `versionCode (expr) as int` is interpreted as `versionCode(expr) as int` — method call (returns void) first, then cast to int → 'Value is null' at evaluation. Same trap on the signing properties. Adding `=` makes the RHS evaluate fully before assignment.

Caught by the manual workflow_dispatch run of #13 against `main`.