### PR TITLE
fix(ci): use 'draft' Play Store status while the app is in draft

### DIFF
--- a/.github/workflows/play-store-publish.yml
+++ b/.github/workflows/play-store-publish.yml
@@ -113,5 +113,10 @@ jobs:
           packageName: media.fliks.app
           releaseFiles: client/android/app/build/outputs/bundle/release/app-release.aab
           track: ${{ github.event.inputs.track || 'internal' }}
-          status: completed
+          # `draft` is required while the app itself is in draft status
+          # in Play Console (no production release ever submitted).
+          # Once the app is approved + published live, this can flip to
+          # `completed` so each upload rolls out automatically to the
+          # selected track.
+          status: draft
           whatsNewDirectory: client/android/app/src/main/play/release-notes


### PR DESCRIPTION
Workflow run failed at the final commit step:

```
Error: Only releases with status draft may be created on draft app.
```

Apps that never had a production release approved sit in `Brouillon` status, and the Play API only accepts `status: draft` releases for them. The AAB upload itself worked — the failure is purely on the commit step.

Once the app is live in production (post first Google review), this can flip back to `status: completed` so every tag automatically rolls out to its track.