### PR TITLE
feat(auth): auto-generate JWT secret on first boot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,13 @@ COPY --from=client-build /app/dist/client/browser ./client
 ENV NODE_ENV=production
 ENV SERVE_STATIC_PATH=/app/client
 
+# Persistent conf dir for auto-generated server-side secrets (JWT
+# signing key, future encryption keys, etc.). Mount this as a Docker
+# volume so the secret survives container restarts and image
+# rebuilds. Permissions stay 0700; the secret files inside are 0600.
+RUN mkdir -p /app/conf && chmod 700 /app/conf
+VOLUME /app/conf
+
 EXPOSE 4848
 
 CMD ["node", "dist/main"]

--- a/backend/src/common/utils/jwt-secret.ts
+++ b/backend/src/common/utils/jwt-secret.ts
@@ -1,0 +1,53 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { randomBytes } from 'crypto';
+import { join } from 'path';
+
+/**
+ * Resolve the JWT signing secret without forcing the operator to set
+ * one. Strategy:
+ *
+ *   1. If `JWT_SECRET` is in the environment, use it (lets operators
+ *      rotate without touching the file, or pin a known value across
+ *      multiple replicas).
+ *   2. Otherwise, read it from `<conf-dir>/.jwt-secret` if the file
+ *      exists.
+ *   3. On first boot, generate a fresh 256-bit secret, write it to
+ *      that file with `0600` perms inside a `0700` directory, and
+ *      return it.
+ *
+ * The conf directory defaults to `/app/conf` (mountable as a Docker
+ * volume so the secret survives container restarts and image
+ * rebuilds). Override with `FLIKS_CONF_DIR` for local dev where
+ * `/app/conf` is not writable.
+ *
+ * Sync I/O is intentional: this runs once at module init, before the
+ * HTTP server starts accepting requests. Async would force the
+ * AuthModule to be async-everything and gain nothing.
+ *
+ * Result is cached for the process lifetime — every JWT sign /
+ * verify reads from memory, never the disk.
+ */
+const CONF_DIR = process.env.FLIKS_CONF_DIR || '/app/conf';
+const JWT_SECRET_FILE = join(CONF_DIR, '.jwt-secret');
+
+let cached: string | null = null;
+
+export function getJwtSecret(): string {
+  if (cached) return cached;
+
+  if (process.env.JWT_SECRET) {
+    cached = process.env.JWT_SECRET;
+    return cached;
+  }
+
+  if (existsSync(JWT_SECRET_FILE)) {
+    cached = readFileSync(JWT_SECRET_FILE, 'utf8').trim();
+    return cached;
+  }
+
+  mkdirSync(CONF_DIR, { recursive: true, mode: 0o700 });
+  const secret = randomBytes(32).toString('hex');
+  writeFileSync(JWT_SECRET_FILE, secret, { mode: 0o600 });
+  cached = secret;
+  return secret;
+}

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -15,6 +15,7 @@ import { EventsModule } from '../scheduler/events.module';
 import { PairingRequest } from './pairing/entities/pairing-request.entity';
 import { PairingService } from './pairing/pairing.service';
 import { PairingController } from './pairing/pairing.controller';
+import { getJwtSecret } from '../../common/utils/jwt-secret';
 
 @Module({
   imports: [
@@ -26,7 +27,10 @@ import { PairingController } from './pairing/pairing.controller';
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (config: ConfigService) => ({
-        secret: config.getOrThrow<string>('JWT_SECRET'),
+        // Resolved from JWT_SECRET env, then <conf-dir>/.jwt-secret,
+        // then auto-generated on first boot. See
+        // common/utils/jwt-secret.ts.
+        secret: getJwtSecret(),
         signOptions: {
           expiresIn: config.get('JWT_EXPIRATION', '7d'),
         },

--- a/backend/src/modules/auth/strategies/jwt.strategy.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.ts
@@ -1,7 +1,6 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Request } from 'express';
@@ -11,6 +10,7 @@ import {
   getRequestCookieHeader,
   parseCookieValue,
 } from '../request-cookie.util';
+import { getJwtSecret } from '../../../common/utils/jwt-secret';
 
 export interface JwtPayload {
   sub: number;
@@ -28,7 +28,6 @@ function jwtFromQueryParam(req: Request): string | null {
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor(
-    config: ConfigService,
     @InjectRepository(User)
     private readonly userRepo: Repository<User>,
   ) {
@@ -39,7 +38,9 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
         jwtFromQueryParam,
       ]),
       ignoreExpiration: false,
-      secretOrKey: config.getOrThrow<string>('JWT_SECRET'),
+      // Same resolution chain as the JwtModule signing key:
+      // JWT_SECRET env > <conf-dir>/.jwt-secret > auto-generated.
+      secretOrKey: getJwtSecret(),
     });
   }
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -58,6 +58,11 @@ services:
       - /path/to/your/media:/medias:ro
 
       # ---- App-managed storage -----------------------------------------
+      # Server-side secrets auto-generated on first boot (JWT signing
+      # key, future encryption keys). Must be persisted across container
+      # restarts — losing this file invalidates every JWT and forces all
+      # users to log back in. Permissions inside are 0700 / 0600.
+      - fliks_conf:/app/conf
       # Cached TMDB / fanart images, sprite sheets for player seek preview.
       - fliks_images:/app/images
       # Optional: persistent transcoding cache (HLS segments, etc.)
@@ -77,5 +82,6 @@ services:
 
 volumes:
   fliks_pgdata:
+  fliks_conf:
   fliks_images:
   fliks_transcode:


### PR DESCRIPTION
## What

Drops the requirement for the operator to set `JWT_SECRET` themselves. New resolution chain:

1. `JWT_SECRET` env var still wins (lets operators rotate explicitly or pin a known value across replicas).
2. `<conf-dir>/.jwt-secret` read from disk if present.
3. First boot: generate 256-bit random, write to that path with 0600 inside a 0700 dir, return.

Cached in memory after first read.

## Why

Two reasons `JWT_SECRET` in the compose env was bad:

- Friction: every Self-host user had to remember to set it. Some inevitably ship with the docker-compose default and end up with everyone using the same key.
- Wrong abstraction: it's a server-side cryptographic secret, not configuration. Belongs in a persisted file, not in a Compose YAML the user edits by hand.

## Operator-visible changes

- `JWT_SECRET` removed from the env block in `docker-compose.example.yml`.
- New `fliks_conf` named volume mounted at `/app/conf` — must survive container restarts. Losing the file invalidates every JWT and forces all users back through the login screen.
- `Dockerfile` creates `/app/conf` with 0700 perms and declares it as a `VOLUME`.

## Local dev

Set `FLIKS_CONF_DIR=./conf` in the backend's `.env` (gitignored already) so the secret lands somewhere writable. Or just keep `JWT_SECRET` in your dev `.env` and skip the file path entirely.