### PR TITLE
fix(client): update angular.json buildTarget refs after project rename

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -60,13 +60,13 @@
           },
           "configurations": {
             "production": {
-              "buildTarget": "frontend:build:production"
+              "buildTarget": "client:build:production"
             },
             "development": {
-              "buildTarget": "frontend:build:development"
+              "buildTarget": "client:build:development"
             },
             "docker": {
-              "buildTarget": "frontend:build:development",
+              "buildTarget": "client:build:development",
               "proxyConfig": "proxy.docker.conf.json"
             }
           },


### PR DESCRIPTION
Three `buildTarget: "frontend:build:*"` references inside `serve.configurations` were missed when the Angular project was renamed from `frontend` to `client`. `ng serve` fails with 'Project "frontend" does not exist' — caught when running `docker compose up` against the dev stack.