### PR TITLE
fix(subtitles): always detect embedded subs on rescan and import

### DIFF
--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -2201,7 +2201,6 @@ export class MediaService {
 
     let added = 0;
     let removed = 0;
-    const changedFileIds = new Set<number>();
 
     // 3. Remove DB records whose files no longer exist on disk
     for (const dbFile of dbFiles) {
@@ -2391,7 +2390,6 @@ export class MediaService {
       try {
         await this.mediaFileRepo.save(dbFile);
         updated++;
-        if (!sizeUnchanged) changedFileIds.add(dbFile.id);
         this.log.log(
           `Rescan: refreshed "${normPath}" for media #${mediaId} (size: ${diskSize}, quality: ${qualityName}${sizeUnchanged ? ', skipped crop' : ''})`,
         );
@@ -2542,7 +2540,6 @@ export class MediaService {
           }),
         );
         added++;
-        changedFileIds.add(savedFile.id);
         this.log.log(
           `Rescan: added new file "${relativePath}" for media #${mediaId}`,
         );
@@ -2586,13 +2583,14 @@ export class MediaService {
           `Rescan: discovered ${discovered} external subtitle(s) on disk for media #${mediaId}`,
         );
       }
-      // Re-detect embedded subtitle streams only for files that changed
-      // (size differs) or were newly added — skip unchanged files.
+      // Always re-detect embedded subtitle streams on rescan: detectAndStore
+      // wipes the file's existing embedded rows and recreates them from
+      // ffprobe, so deleted tracks disappear and new ones get added even
+      // when the file size hasn't changed (e.g. a remux that preserves size).
       const allFiles = await this.mediaFileRepo.find({
         where: { media: { id: mediaId } },
       });
       for (const file of allFiles) {
-        if (!changedFileIds.has(file.id)) continue;
         try {
           await this.embeddedSubtitle.detectAndStore(
             mediaId,

--- a/backend/src/modules/scheduler/subtitle-scheduler.service.ts
+++ b/backend/src/modules/scheduler/subtitle-scheduler.service.ts
@@ -214,6 +214,18 @@ export class SubtitleSchedulerService {
     mediaFileId: number,
     episodeId?: number,
   ): Promise<void> {
+    // Always detect & store embedded subtitles first — independent of the
+    // auto-search setting and the language profile. Skipping this when
+    // auto_search is disabled (or no languages are configured) used to
+    // leave embedded tracks invisible in the subtitle_files table even
+    // though ffprobe sees them.
+    const embeddedSubs = await this.embeddedSubtitle.detectAndStore(
+      mediaId,
+      mediaFileId,
+      episodeId,
+    );
+    const embeddedLangs = new Set(embeddedSubs.map((s) => s.language));
+
     const autoSearch = await this.settings.get('subtitle_auto_search');
     if (autoSearch === 'false') return;
 
@@ -231,14 +243,6 @@ export class SubtitleSchedulerService {
       where: { id: mediaFileId },
     });
     if (!mediaFile) return;
-
-    // Detect embedded subtitles before searching providers
-    const embeddedSubs = await this.embeddedSubtitle.detectAndStore(
-      mediaId,
-      mediaFileId,
-      episodeId,
-    );
-    const embeddedLangs = new Set(embeddedSubs.map((s) => s.language));
 
     const minScore = Number(
       (await this.settings.get('subtitle_min_score')) ?? '70',


### PR DESCRIPTION
## Summary

Two import paths could leave embedded subtitle tracks invisible in the `subtitle_files` table even though ffprobe reported them on the file.

- **Rescan**: `detectAndStore` was only called for files whose on-disk size had changed since the last scan. A remux that preserved the size kept stale (or empty) embedded rows. The size gate is dropped and the now-unused `changedFileIds` set is removed; `detectAndStore` is already idempotent (delete-then-recreate).
- **Disk import / completion**: `onMediaFileImported` returned early when `subtitle_auto_search` was disabled or `languageProfile.subtitleLanguages` was empty, before ever calling `detectAndStore`. Disk imports under those settings ended up with embedded tracks playable through `streamInfo` but absent from the DB. Detection is now above the gate; the toggle only affects the provider auto-search loop.

Net effect: rescan, disk-import, and completion all converge on the same single source of truth for embedded detection.

## Test plan

- [ ] Disk-import a file with embedded subs while `subtitle_auto_search` is `false` — embedded rows appear in `subtitle_files` and show up in the player picker.
- [ ] Rescan an unchanged file after manually editing its `subtitle_files` rows — rows are reconciled back to ffprobe truth.
- [ ] Rescan a remux with same size but different embedded tracks — DB reflects the new track set.
- [ ] Disk-import with `subtitle_auto_search` enabled — provider search still skips languages already covered by embedded.