### PR TITLE
feat(imports): path-mapping wizard for Radarr/Sonarr

### DIFF
--- a/backend/src/modules/imports/dto/import-api.dto.ts
+++ b/backend/src/modules/imports/dto/import-api.dto.ts
@@ -1,13 +1,29 @@
 import {
+  IsArray,
+  IsBoolean,
+  IsIn,
+  IsInt,
+  IsOptional,
   IsString,
   IsUrl,
-  IsOptional,
-  IsIn,
-  IsBoolean,
-  IsInt,
   Min,
+  ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+
+export class PathMappingDto {
+  @IsString()
+  remotePath: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  localRootFolderId: number | null;
+
+  @IsOptional()
+  @IsBoolean()
+  ignore?: boolean;
+}
 
 export class ImportApiDto {
   @IsUrl({ require_tld: false, require_protocol: true })
@@ -37,4 +53,14 @@ export class ImportApiDto {
   @IsOptional()
   @IsString()
   newLibraryName?: string;
+
+  /**
+   * Maps each *arr remote root folder onto an existing Fliks RootFolder, or
+   * marks it ignored. Required (can be empty when *arr exposes no roots).
+   * The wizard step in the UI is the only place these are produced.
+   */
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PathMappingDto)
+  pathMappings: PathMappingDto[];
 }

--- a/backend/src/modules/imports/dto/preview-import.dto.ts
+++ b/backend/src/modules/imports/dto/preview-import.dto.ts
@@ -1,0 +1,19 @@
+import { IsString, IsUrl } from 'class-validator';
+
+export class PreviewImportDto {
+  @IsUrl({ require_tld: false, require_protocol: true })
+  url: string;
+
+  @IsString()
+  apiKey: string;
+}
+
+export interface PreviewRow {
+  remotePath: string;
+  suggestedLocalRootFolderId: number | null;
+}
+
+export interface PreviewImportResult {
+  remoteRootFolders: PreviewRow[];
+  localRootFolders: { id: number; path: string; libraryId: number | null }[];
+}

--- a/backend/src/modules/imports/imports.controller.ts
+++ b/backend/src/modules/imports/imports.controller.ts
@@ -14,6 +14,7 @@ import { ImportApiDto } from './dto/import-api.dto';
 import { TestConnectionDto } from './dto/test-connection.dto';
 import { ScanFolderDto } from './dto/scan-folder.dto';
 import { ConfirmDiskImportDto } from './dto/confirm-disk-import.dto';
+import { PreviewImportDto } from './dto/preview-import.dto';
 
 @Controller('imports')
 @UseGuards(JwtOrApiKeyGuard, PoliciesGuard)
@@ -39,6 +40,12 @@ export class ImportsController {
     return this.importRadarrService.testConnection(dto.url, dto.apiKey);
   }
 
+  @Post('radarr/preview')
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
+  previewRadarr(@Body() dto: PreviewImportDto) {
+    return this.importRadarrService.previewRootFolders(dto.url, dto.apiKey);
+  }
+
   @Post('radarr')
   @CheckPolicies((ability) => ability.can(Action.Create, 'Settings'))
   importRadarrApi(@Body() dto: ImportApiDto): Promise<ApiImportResult> {
@@ -47,6 +54,7 @@ export class ImportsController {
       dto.apiKey,
       dto.mode ?? 'skip',
       dto.importSubtitles ?? false,
+      dto.pathMappings,
       {
         targetLibraryId: dto.targetLibraryId,
         newLibraryName: dto.newLibraryName,
@@ -64,6 +72,12 @@ export class ImportsController {
     return this.importSonarrService.testConnection(dto.url, dto.apiKey);
   }
 
+  @Post('sonarr/preview')
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
+  previewSonarr(@Body() dto: PreviewImportDto) {
+    return this.importSonarrService.previewRootFolders(dto.url, dto.apiKey);
+  }
+
   @Post('sonarr')
   @CheckPolicies((ability) => ability.can(Action.Create, 'Settings'))
   importSonarrApi(@Body() dto: ImportApiDto): Promise<ApiImportResult> {
@@ -72,6 +86,7 @@ export class ImportsController {
       dto.apiKey,
       dto.mode ?? 'skip',
       dto.importSubtitles ?? false,
+      dto.pathMappings,
       {
         targetLibraryId: dto.targetLibraryId,
         newLibraryName: dto.newLibraryName,

--- a/backend/src/modules/imports/radarr.service.ts
+++ b/backend/src/modules/imports/radarr.service.ts
@@ -10,13 +10,15 @@ import {
 import { APP_QUALITIES } from '../../common/constants/app-qualities';
 import { MediaType, MediaStatus } from '../../common/enums';
 import {
-  ensureRootFolderPathsExist,
+  applyPathMapping,
   parseLanguageFromPath,
   parseSubtitleTags,
-  resolveRootFolderFromArrPaths,
+  type PathMapping,
+  suggestLocalRootFolderId,
   SUBTITLE_FILE_EXTENSIONS,
   upsertImportedSubtitleFile,
 } from '../scheduler/utils/arr-import.util';
+import { PreviewImportResult } from './dto/preview-import.dto';
 import { SubtitleFile } from '../subtitles/entities/subtitle-file.entity';
 import { MediaFile } from '../media/entities/media-file.entity';
 import { SubtitleProviderType } from '../../common/enums';
@@ -134,11 +136,58 @@ export class ImportRadarrService {
     }
   }
 
+  /**
+   * Wizard step before the import: returns the *arr's root folders alongside
+   * a server-side suggestion for which Fliks RootFolder to map each one to.
+   * Pure read — no DB writes.
+   */
+  async previewRootFolders(
+    url: string,
+    apiKey: string,
+  ): Promise<PreviewImportResult> {
+    const baseUrl = url.replace(/\/+$/, '');
+    let remoteFolders: { path: string }[];
+    try {
+      const res = await fetch(`${baseUrl}/api/v3/rootfolder`, {
+        headers: { 'X-Api-Key': apiKey },
+      });
+      if (!res.ok) {
+        throw new BadRequestException(
+          `Radarr API returned ${res.status}: ${res.statusText}`,
+        );
+      }
+      remoteFolders = (await res.json()) as { path: string }[];
+    } catch (e) {
+      if (e instanceof BadRequestException) throw e;
+      throw new BadRequestException(
+        `Cannot connect to Radarr: ${(e as Error).message}`,
+      );
+    }
+    const localRootFolders = await this.rootFolderRepo.find();
+    return {
+      remoteRootFolders: remoteFolders
+        .filter((r) => r.path?.trim())
+        .map((r) => ({
+          remotePath: r.path,
+          suggestedLocalRootFolderId: suggestLocalRootFolderId(
+            r.path,
+            localRootFolders,
+          ),
+        })),
+      localRootFolders: localRootFolders.map((rf) => ({
+        id: rf.id,
+        path: rf.path,
+        libraryId: rf.libraryId ?? null,
+      })),
+    };
+  }
+
   async importFromApi(
     url: string,
     apiKey: string,
     mode: 'skip' | 'update' = 'skip',
     importSubtitles = false,
+    pathMappings: PathMapping[] = [],
     target: ImportTargetSpec = {},
   ): Promise<ApiImportResult> {
     const baseUrl = url.replace(/\/+$/, '');
@@ -153,6 +202,8 @@ export class ImportRadarrService {
       mediaType: MediaType.MOVIE,
       autoLabel: this.autoLibraryName(),
     });
+
+    await this.assertMappingsBelongToLibrary(pathMappings, targetLibrary.id);
 
     let movies: RadarrMovie[];
     try {
@@ -181,20 +232,11 @@ export class ImportRadarrService {
       };
     }
 
-    await this.reconcileRootFolders(
-      baseUrl,
-      apiKey,
-      rootFoldersCreated,
-      targetLibrary.id,
-      errors,
-    );
     const profileMap = await this.importQualityProfiles(
       baseUrl,
       apiKey,
       qualityProfilesCreated,
     );
-
-    const rootFolders = await this.rootFolderRepo.find();
 
     for (const movie of movies) {
       const title = movie.title ?? '';
@@ -212,16 +254,15 @@ export class ImportRadarrService {
             ? profileMap.get(movie.qualityProfileId)
             : undefined;
 
-        const resolved = resolveRootFolderFromArrPaths(
-          movie.path,
-          movie.rootFolderPath,
-          rootFolders,
-        );
-        const folderName =
-          resolved?.folderName ??
-          (movie.path
-            ? path.basename(movie.path.replace(/\/+$/, ''))
-            : undefined);
+        const resolved = applyPathMapping(movie.path, pathMappings);
+        if (resolved === null) {
+          errors.push(
+            `${title || '(no title)'}: no path mapping for "${movie.path ?? ''}"`,
+          );
+          continue;
+        }
+        if ('ignore' in resolved) continue;
+        const { rootFolderId, folderName } = resolved;
 
         if (exists) {
           if (mode === 'skip') continue;
@@ -230,7 +271,8 @@ export class ImportRadarrService {
             title,
             year: movie.year ?? exists.year,
             monitored: movie.monitored ?? exists.monitored,
-            folderName: folderName || exists.folderName,
+            rootFolder: { id: rootFolderId } as RootFolder,
+            folderName,
             imdbId: movie.imdbId || exists.imdbId,
             overview: movie.overview || exists.overview,
             qualityProfileId: localProfileId ?? exists.qualityProfileId,
@@ -245,11 +287,9 @@ export class ImportRadarrService {
               type: MediaType.MOVIE,
               status: MediaStatus.RELEASED,
               monitored: movie.monitored ?? true,
-              rootFolder: resolved?.rootFolderId
-                ? ({ id: resolved.rootFolderId } as RootFolder)
-                : null,
+              rootFolder: { id: rootFolderId } as RootFolder,
               library: targetLibrary,
-              folderName: folderName || undefined,
+              folderName,
               imdbId: movie.imdbId || undefined,
               overview: movie.overview || undefined,
               qualityProfileId: localProfileId ?? undefined,
@@ -491,36 +531,40 @@ export class ImportRadarrService {
     return 16; // fallback WEBDL-1080p
   }
 
-  private async reconcileRootFolders(
-    baseUrl: string,
-    apiKey: string,
-    rootFoldersCreated: string[],
-    libraryId: number,
-    warnings: string[],
+  /**
+   * Up-front guard: every mapping that targets a Fliks RootFolder must point
+   * to one whose library is unassigned or matches the import target. We
+   * refuse to silently re-home a RootFolder belonging to another library.
+   */
+  private async assertMappingsBelongToLibrary(
+    pathMappings: PathMapping[],
+    targetLibraryId: number,
   ): Promise<void> {
-    try {
-      const rfRes = await fetch(`${baseUrl}/api/v3/rootfolder`, {
-        headers: { 'X-Api-Key': apiKey },
-      });
-      if (rfRes.ok) {
-        const remoteFolders = (await rfRes.json()) as { path: string }[];
-        const before = rootFoldersCreated.length;
-        await ensureRootFolderPathsExist(
-          this.rootFolderRepo,
-          remoteFolders.map((r) => r.path),
-          rootFoldersCreated,
-          libraryId,
-          warnings,
-        );
-        for (let i = before; i < rootFoldersCreated.length; i++) {
-          this.log.log(
-            `Created root folder from Radarr: ${rootFoldersCreated[i]}`,
-          );
-        }
+    const ids = Array.from(
+      new Set(
+        pathMappings
+          .filter((m) => !m.ignore && m.localRootFolderId != null)
+          .map((m) => m.localRootFolderId as number),
+      ),
+    );
+    if (!ids.length) return;
+    const folders = await this.rootFolderRepo.findByIds(ids);
+    const offending: string[] = [];
+    for (const id of ids) {
+      const rf = folders.find((f) => f.id === id);
+      if (!rf) {
+        offending.push(`RootFolder #${id}: not found`);
+        continue;
       }
-    } catch (e) {
-      this.log.warn(
-        `Could not fetch Radarr root folders: ${(e as Error).message}`,
+      if (rf.libraryId != null && rf.libraryId !== targetLibraryId) {
+        offending.push(
+          `"${rf.path}" belongs to library #${rf.libraryId} (target is #${targetLibraryId})`,
+        );
+      }
+    }
+    if (offending.length) {
+      throw new BadRequestException(
+        `Path mappings reference root folders from another library: ${offending.join('; ')}`,
       );
     }
   }

--- a/backend/src/modules/imports/sonarr.service.ts
+++ b/backend/src/modules/imports/sonarr.service.ts
@@ -10,13 +10,15 @@ import {
 import { APP_QUALITIES } from '../../common/constants/app-qualities';
 import { MediaType, MediaStatus } from '../../common/enums';
 import {
-  ensureRootFolderPathsExist,
+  applyPathMapping,
   parseLanguageFromPath,
   parseSubtitleTags,
-  resolveRootFolderFromArrPaths,
+  type PathMapping,
   subtitlePathsBesideEpisode,
+  suggestLocalRootFolderId,
   upsertImportedSubtitleFile,
 } from '../scheduler/utils/arr-import.util';
+import { PreviewImportResult } from './dto/preview-import.dto';
 import { SubtitleFile } from '../subtitles/entities/subtitle-file.entity';
 import { MediaFile } from '../media/entities/media-file.entity';
 import { MediaService } from '../media/media.service';
@@ -119,11 +121,58 @@ export class ImportSonarrService {
     }
   }
 
+  /**
+   * Wizard step before the import: returns the *arr's root folders alongside
+   * a server-side suggestion for which Fliks RootFolder to map each one to.
+   * Pure read — no DB writes.
+   */
+  async previewRootFolders(
+    url: string,
+    apiKey: string,
+  ): Promise<PreviewImportResult> {
+    const baseUrl = url.replace(/\/+$/, '');
+    let remoteFolders: { path: string }[];
+    try {
+      const res = await fetch(`${baseUrl}/api/v3/rootfolder`, {
+        headers: { 'X-Api-Key': apiKey },
+      });
+      if (!res.ok) {
+        throw new BadRequestException(
+          `Sonarr API returned ${res.status}: ${res.statusText}`,
+        );
+      }
+      remoteFolders = (await res.json()) as { path: string }[];
+    } catch (e) {
+      if (e instanceof BadRequestException) throw e;
+      throw new BadRequestException(
+        `Cannot connect to Sonarr: ${(e as Error).message}`,
+      );
+    }
+    const localRootFolders = await this.rootFolderRepo.find();
+    return {
+      remoteRootFolders: remoteFolders
+        .filter((r) => r.path?.trim())
+        .map((r) => ({
+          remotePath: r.path,
+          suggestedLocalRootFolderId: suggestLocalRootFolderId(
+            r.path,
+            localRootFolders,
+          ),
+        })),
+      localRootFolders: localRootFolders.map((rf) => ({
+        id: rf.id,
+        path: rf.path,
+        libraryId: rf.libraryId ?? null,
+      })),
+    };
+  }
+
   async importFromApi(
     url: string,
     apiKey: string,
     mode: 'skip' | 'update' = 'skip',
     importSubtitles = false,
+    pathMappings: PathMapping[] = [],
     target: ImportTargetSpec = {},
   ): Promise<ApiImportResult> {
     const baseUrl = url.replace(/\/+$/, '');
@@ -138,6 +187,8 @@ export class ImportSonarrService {
       mediaType: MediaType.SERIES,
       autoLabel: this.autoLibraryName(),
     });
+
+    await this.assertMappingsBelongToLibrary(pathMappings, targetLibrary.id);
 
     let series: SonarrSeries[];
     try {
@@ -166,20 +217,11 @@ export class ImportSonarrService {
       };
     }
 
-    await this.reconcileRootFolders(
-      baseUrl,
-      apiKey,
-      rootFoldersCreated,
-      targetLibrary.id,
-      errors,
-    );
     const profileMap = await this.importQualityProfiles(
       baseUrl,
       apiKey,
       qualityProfilesCreated,
     );
-
-    const rootFolders = await this.rootFolderRepo.find();
 
     const newSeriesIds: number[] = [];
 
@@ -199,14 +241,15 @@ export class ImportSonarrService {
             ? profileMap.get(s.qualityProfileId)
             : undefined;
 
-        const resolved = resolveRootFolderFromArrPaths(
-          s.path,
-          s.rootFolderPath,
-          rootFolders,
-        );
-        const folderName =
-          resolved?.folderName ??
-          (s.path ? path.basename(s.path.replace(/\/+$/, '')) : undefined);
+        const resolved = applyPathMapping(s.path, pathMappings);
+        if (resolved === null) {
+          errors.push(
+            `${title || '(no title)'}: no path mapping for "${s.path ?? ''}"`,
+          );
+          continue;
+        }
+        if ('ignore' in resolved) continue;
+        const { rootFolderId, folderName } = resolved;
 
         if (exists) {
           if (mode === 'skip') continue;
@@ -214,7 +257,8 @@ export class ImportSonarrService {
             title,
             year: s.year ?? exists.year,
             monitored: s.monitored ?? exists.monitored,
-            folderName: folderName || exists.folderName,
+            rootFolder: { id: rootFolderId } as RootFolder,
+            folderName,
             imdbId: s.imdbId || exists.imdbId,
             overview: s.overview || exists.overview,
             qualityProfileId: localProfileId ?? exists.qualityProfileId,
@@ -229,11 +273,9 @@ export class ImportSonarrService {
               type: MediaType.SERIES,
               status: MediaStatus.CONTINUING,
               monitored: s.monitored ?? true,
-              rootFolder: resolved?.rootFolderId
-                ? ({ id: resolved.rootFolderId } as RootFolder)
-                : null,
+              rootFolder: { id: rootFolderId } as RootFolder,
               library: targetLibrary,
-              folderName: folderName || undefined,
+              folderName,
               imdbId: s.imdbId || undefined,
               overview: s.overview || undefined,
               qualityProfileId: localProfileId ?? undefined,
@@ -482,36 +524,40 @@ export class ImportSonarrService {
     return 16;
   }
 
-  private async reconcileRootFolders(
-    baseUrl: string,
-    apiKey: string,
-    rootFoldersCreated: string[],
-    libraryId: number,
-    warnings: string[],
+  /**
+   * Up-front guard: every mapping that targets a Fliks RootFolder must point
+   * to one whose library is unassigned or matches the import target. We
+   * refuse to silently re-home a RootFolder belonging to another library.
+   */
+  private async assertMappingsBelongToLibrary(
+    pathMappings: PathMapping[],
+    targetLibraryId: number,
   ): Promise<void> {
-    try {
-      const rfRes = await fetch(`${baseUrl}/api/v3/rootfolder`, {
-        headers: { 'X-Api-Key': apiKey },
-      });
-      if (rfRes.ok) {
-        const remoteFolders = (await rfRes.json()) as { path: string }[];
-        const before = rootFoldersCreated.length;
-        await ensureRootFolderPathsExist(
-          this.rootFolderRepo,
-          remoteFolders.map((r) => r.path),
-          rootFoldersCreated,
-          libraryId,
-          warnings,
-        );
-        for (let i = before; i < rootFoldersCreated.length; i++) {
-          this.log.log(
-            `Created root folder from Sonarr: ${rootFoldersCreated[i]}`,
-          );
-        }
+    const ids = Array.from(
+      new Set(
+        pathMappings
+          .filter((m) => !m.ignore && m.localRootFolderId != null)
+          .map((m) => m.localRootFolderId as number),
+      ),
+    );
+    if (!ids.length) return;
+    const folders = await this.rootFolderRepo.findByIds(ids);
+    const offending: string[] = [];
+    for (const id of ids) {
+      const rf = folders.find((f) => f.id === id);
+      if (!rf) {
+        offending.push(`RootFolder #${id}: not found`);
+        continue;
       }
-    } catch (e) {
-      this.log.warn(
-        `Could not fetch Sonarr root folders: ${(e as Error).message}`,
+      if (rf.libraryId != null && rf.libraryId !== targetLibraryId) {
+        offending.push(
+          `"${rf.path}" belongs to library #${rf.libraryId} (target is #${targetLibraryId})`,
+        );
+      }
+    }
+    if (offending.length) {
+      throw new BadRequestException(
+        `Path mappings reference root folders from another library: ${offending.join('; ')}`,
       );
     }
   }

--- a/backend/src/modules/scheduler/utils/arr-import.util.ts
+++ b/backend/src/modules/scheduler/utils/arr-import.util.ts
@@ -4,116 +4,83 @@ import { readdir } from 'fs/promises';
 import { RootFolder } from '../../root-folders/entities/root-folder.entity';
 import { SubtitleFile } from '../../subtitles/entities/subtitle-file.entity';
 import { Episode } from '../../media/entities/episode.entity';
-import { Library } from '../../libraries/entities/library.entity';
 import { Media } from '../../media/entities/media.entity';
 import { MediaFile } from '../../media/entities/media-file.entity';
 import { SubtitleProviderType, SubtitleStatus } from '../../../common/enums';
 
 // ---------------------------------------------------------------------------
-// Root folders (Radarr / Sonarr API reconcile)
+// User-provided remote→local path mapping (path mapping wizard)
 // ---------------------------------------------------------------------------
 
-/**
- * Insert missing root folders by path and link them to the given library.
- * If a path already exists but belongs to a different library, the path is
- * skipped and a warning string is pushed to `warningsOut` — it is never
- * silently re-homed.
- */
-export async function ensureRootFolderPathsExist(
-  repo: Repository<RootFolder>,
-  paths: string[],
-  createdOut: string[],
-  libraryId: number,
-  warningsOut: string[] = [],
-): Promise<void> {
-  const existing = await repo.find();
-  const byNormalizedPath = new Map(
-    existing.map((f) => [f.path.replace(/\/+$/, ''), f]),
-  );
-  for (const raw of paths) {
-    if (!raw?.trim()) continue;
-    const normalized = raw.replace(/\/+$/, '');
-    const present = byNormalizedPath.get(normalized);
-    if (present) {
-      if (present.libraryId != null && present.libraryId !== libraryId) {
-        warningsOut.push(
-          `Path "${raw}" already belongs to library #${present.libraryId}; skipped (would silently re-home it).`,
-        );
-      }
-      continue;
-    }
-    try {
-      const saved = await repo.save(
-        repo.create({
-          path: raw.trim(),
-          library: { id: libraryId } as Library,
-        }),
-      );
-      createdOut.push(raw.trim());
-      byNormalizedPath.set(normalized, saved);
-    } catch {
-      /* duplicate or DB error */
-    }
-  }
+export interface PathMapping {
+  remotePath: string;
+  localRootFolderId: number | null;
+  ignore?: boolean;
+}
+
+function normalizePath(p: string): string {
+  return path
+    .normalize(p.trim())
+    .replace(/[/\\]+$/, '')
+    .replace(/\\/g, '/');
 }
 
 /**
- * Map Radarr/Sonarr full library path + optional API rootFolderPath to our
- * rootFolderId + folderName (Media.path is computed from these).
+ * Longest-prefix match of `fullArrPath` against the user-provided mappings.
+ *   { rootFolderId, folderName }  → use this RootFolder + first-segment folder name
+ *   { ignore: true }              → matched mapping is ignored (caller skips silently)
+ *   null                          → no mapping matched (caller pushes error and skips)
+ *
+ * folderName is the first segment of the *arr path under the matched remote
+ * root, so that on-disk folder naming follows what Radarr/Sonarr already laid
+ * out — independent of how the local Fliks RootFolder is named.
  */
-export function resolveRootFolderFromArrPaths(
-  fullPath: string | undefined | null,
-  rootFolderPathFromApi: string | undefined | null,
-  rootFolders: RootFolder[],
-): { rootFolderId: number; folderName: string } | null {
-  if (!rootFolders.length) return null;
-
-  const norm = (p: string) =>
-    path
-      .normalize(p.trim())
-      .replace(/[/\\]+$/, '')
-      .replace(/\\/g, '/');
-
-  const sorted = [...rootFolders].sort(
-    (a, b) => norm(b.path).length - norm(a.path).length,
+export function applyPathMapping(
+  fullArrPath: string | null | undefined,
+  mappings: PathMapping[],
+): { rootFolderId: number; folderName: string } | { ignore: true } | null {
+  if (!fullArrPath?.trim() || !mappings.length) return null;
+  const full = normalizePath(fullArrPath);
+  const sorted = [...mappings].sort(
+    (a, b) => normalizePath(b.remotePath).length - normalizePath(a.remotePath).length,
   );
-
-  const full = fullPath?.trim() ? norm(fullPath) : '';
-  const apiRoot = rootFolderPathFromApi?.trim()
-    ? norm(rootFolderPathFromApi)
-    : '';
-
-  if (full) {
-    for (const rf of sorted) {
-      const root = norm(rf.path);
-      if (full === root) {
-        return { rootFolderId: rf.id, folderName: path.basename(full) };
-      }
-      const prefix = root + '/';
-      if (full.startsWith(prefix)) {
-        const rel = full.slice(prefix.length);
-        const folderName = rel.split('/')[0] || path.basename(full);
-        if (folderName) {
-          return { rootFolderId: rf.id, folderName };
-        }
-      }
-    }
+  for (const m of sorted) {
+    const remote = normalizePath(m.remotePath);
+    if (!remote) continue;
+    const prefix = remote + '/';
+    const isUnderRoot = full === remote || full.startsWith(prefix);
+    if (!isUnderRoot) continue;
+    if (m.ignore) return { ignore: true };
+    if (m.localRootFolderId == null) return null;
+    const rest = full === remote ? '' : full.slice(prefix.length);
+    const folderName = rest.split('/')[0] || path.basename(full);
+    if (!folderName) return null;
+    return { rootFolderId: m.localRootFolderId, folderName };
   }
+  return null;
+}
 
-  if (apiRoot && full) {
-    const rf = sorted.find((f) => norm(f.path) === apiRoot);
-    if (rf) {
-      const prefix = apiRoot + '/';
-      if (full.startsWith(prefix)) {
-        const rel = full.slice(prefix.length);
-        const folderName = rel.split('/')[0] || path.basename(full);
-        if (folderName) {
-          return { rootFolderId: rf.id, folderName };
-        }
-      }
-    }
-  }
-
+/**
+ * Server-side suggestion for the wizard pre-select:
+ *   1. unique RootFolder whose path ends with `/<basename(remotePath)>`
+ *   2. fallback: unique RootFolder whose basename equals basename(remotePath)
+ *   3. ambiguous or none → null (the row stays unselected, blocking Confirm)
+ */
+export function suggestLocalRootFolderId(
+  remotePath: string,
+  candidates: RootFolder[],
+): number | null {
+  if (!remotePath?.trim() || !candidates.length) return null;
+  const remoteBase = path.basename(normalizePath(remotePath));
+  if (!remoteBase) return null;
+  const tailMatches = candidates.filter((rf) =>
+    normalizePath(rf.path).endsWith('/' + remoteBase),
+  );
+  if (tailMatches.length === 1) return tailMatches[0].id;
+  const baseMatches = candidates.filter(
+    (rf) => path.basename(normalizePath(rf.path)) === remoteBase,
+  );
+  if (baseMatches.length === 1) return baseMatches[0].id;
   return null;
 }
 

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -253,7 +253,7 @@
   },
   "import": {
     "title": "Importer depuis Radarr / Sonarr",
-    "subtitle": "Connectez-vous à l'API de Radarr ou Sonarr pour importer toute leur bibliothèque. Les root folders seront automatiquement créés si nécessaire.",
+    "subtitle": "Connectez-vous à l'API de Radarr ou Sonarr pour importer toute leur bibliothèque.",
     "radarr_title": "Radarr",
     "radarr_desc": "Importez tous vos films depuis Radarr via son API.",
     "sonarr_title": "Sonarr",
@@ -264,6 +264,7 @@
     "sonarr_url_placeholder": "http://localhost:8989",
     "api_key_placeholder": "Clé API (Settings > General)",
     "import_btn": "Importer",
+    "continue_btn": "Continuer",
     "error": "Erreur lors de l'import.",
     "result_imported": "{{count}} importé(s)",
     "result_skipped": "{{count}} ignoré(s)",
@@ -274,7 +275,17 @@
     "mode_skip": "Completer (ignorer les existants)",
     "mode_update": "Mettre a jour (maj les existants)",
     "import_subtitles": "Importer les sous-titres externes",
-    "result_subtitles": "{{count}} sous-titre(s) importe(s)"
+    "result_subtitles": "{{count}} sous-titre(s) importe(s)",
+    "path_wizard": {
+      "title": "Mappage des dossiers racines",
+      "description": "Associez chaque dossier racine de Radarr/Sonarr à un dossier racine Fliks existant, ou ignorez-le. Les chemins des conteneurs Radarr/Sonarr peuvent différer de ceux montés dans Fliks ; le mappage rétablit la correspondance.",
+      "no_root_folders": "Aucun dossier racine Fliks compatible n'est configuré. Créez-en un dans Réglages → Bibliothèques avant de relancer l'import.",
+      "go_to_root_folders": "Configurer les dossiers racines",
+      "option_ignore": "Ignorer",
+      "confirm": "Confirmer l'import",
+      "cancel": "Annuler",
+      "preview_error": "Impossible de récupérer les dossiers racines distants."
+    }
   },
   "dashboard": {
     "title": "Tableau de bord",

--- a/client/src/app/features/settings/data-imports/data-imports.html
+++ b/client/src/app/features/settings/data-imports/data-imports.html
@@ -272,15 +272,15 @@
             <button
               type="button"
               class="btn btn-primary btn-sm"
-              [disabled]="radarrLoading() || !canSubmitRadarr"
-              (click)="importRadarr()"
+              [disabled]="radarrLoading() || radarrPreviewing() || !canSubmitRadarr"
+              (click)="openRadarrWizard()"
             >
-              @if (radarrLoading()) {
+              @if (radarrLoading() || radarrPreviewing()) {
                 <span class="loading loading-spinner loading-xs"></span>
               } @else {
                 <svg lucideDownload class="h-4 w-4"></svg>
               }
-              {{ 'import.import_btn' | translate }}
+              {{ 'import.continue_btn' | translate }}
             </button>
           </div>
 
@@ -430,15 +430,15 @@
             <button
               type="button"
               class="btn btn-primary btn-sm"
-              [disabled]="sonarrLoading() || !canSubmitSonarr"
-              (click)="importSonarr()"
+              [disabled]="sonarrLoading() || sonarrPreviewing() || !canSubmitSonarr"
+              (click)="openSonarrWizard()"
             >
-              @if (sonarrLoading()) {
+              @if (sonarrLoading() || sonarrPreviewing()) {
                 <span class="loading loading-spinner loading-xs"></span>
               } @else {
                 <svg lucideDownload class="h-4 w-4"></svg>
               }
-              {{ 'import.import_btn' | translate }}
+              {{ 'import.continue_btn' | translate }}
             </button>
           </div>
 
@@ -483,6 +483,130 @@
           }
         </div>
       </section>
+    </div>
+  }
+
+  <!-- Path mapping wizards (one per provider). Rendered outside the cards so
+       the modal backdrop covers the whole page. -->
+  @if (radarrShowWizard()) {
+    <div class="modal modal-open">
+      <div class="modal-box max-w-2xl">
+        <h3 class="font-bold text-lg">{{ 'import.path_wizard.title' | translate }}</h3>
+        <p class="text-sm text-base-content/60 mt-1">{{ 'import.path_wizard.description' | translate }}</p>
+
+        @if (radarrPreview(); as preview) {
+          @if (eligibleLocalRootFolders('radarr').length === 0) {
+            <div role="alert" class="alert alert-warning mt-4 text-sm">
+              <div>
+                <p>{{ 'import.path_wizard.no_root_folders' | translate }}</p>
+                <a routerLink="/settings/libraries" class="btn btn-sm btn-primary mt-3" (click)="cancelWizard('radarr')">
+                  {{ 'import.path_wizard.go_to_root_folders' | translate }}
+                </a>
+              </div>
+            </div>
+          } @else {
+            <div class="flex flex-col gap-3 mt-4">
+              @for (m of radarrMappings(); track m.remotePath) {
+                <div class="flex flex-col sm:flex-row sm:items-center gap-2">
+                  <code class="text-sm bg-base-300 px-2 py-1 rounded sm:flex-1 truncate">{{ m.remotePath }}</code>
+                  <span class="text-base-content/40 hidden sm:inline">→</span>
+                  <select
+                    class="select select-bordered select-sm sm:flex-1"
+                    [ngModel]="m.ignore ? IGNORE_VALUE : m.localRootFolderId"
+                    (ngModelChange)="setMapping('radarr', m.remotePath, $event)"
+                  >
+                    <option [ngValue]="null">—</option>
+                    @for (rf of eligibleLocalRootFolders('radarr'); track rf.id) {
+                      <option [ngValue]="rf.id">{{ rf.path }}</option>
+                    }
+                    <option [ngValue]="IGNORE_VALUE">{{ 'import.path_wizard.option_ignore' | translate }}</option>
+                  </select>
+                </div>
+              }
+            </div>
+          }
+        }
+
+        <div class="modal-action">
+          <button type="button" class="btn btn-ghost btn-sm" (click)="cancelWizard('radarr')">
+            {{ 'import.path_wizard.cancel' | translate }}
+          </button>
+          @if (eligibleLocalRootFolders('radarr').length > 0) {
+            <button
+              type="button"
+              class="btn btn-primary btn-sm"
+              [disabled]="!radarrCanConfirm() || radarrLoading()"
+              (click)="confirmRadarrImport()"
+            >
+              @if (radarrLoading()) {
+                <span class="loading loading-spinner loading-xs"></span>
+              }
+              {{ 'import.path_wizard.confirm' | translate }}
+            </button>
+          }
+        </div>
+      </div>
+    </div>
+  }
+
+  @if (sonarrShowWizard()) {
+    <div class="modal modal-open">
+      <div class="modal-box max-w-2xl">
+        <h3 class="font-bold text-lg">{{ 'import.path_wizard.title' | translate }}</h3>
+        <p class="text-sm text-base-content/60 mt-1">{{ 'import.path_wizard.description' | translate }}</p>
+
+        @if (sonarrPreview(); as preview) {
+          @if (eligibleLocalRootFolders('sonarr').length === 0) {
+            <div role="alert" class="alert alert-warning mt-4 text-sm">
+              <div>
+                <p>{{ 'import.path_wizard.no_root_folders' | translate }}</p>
+                <a routerLink="/settings/libraries" class="btn btn-sm btn-primary mt-3" (click)="cancelWizard('sonarr')">
+                  {{ 'import.path_wizard.go_to_root_folders' | translate }}
+                </a>
+              </div>
+            </div>
+          } @else {
+            <div class="flex flex-col gap-3 mt-4">
+              @for (m of sonarrMappings(); track m.remotePath) {
+                <div class="flex flex-col sm:flex-row sm:items-center gap-2">
+                  <code class="text-sm bg-base-300 px-2 py-1 rounded sm:flex-1 truncate">{{ m.remotePath }}</code>
+                  <span class="text-base-content/40 hidden sm:inline">→</span>
+                  <select
+                    class="select select-bordered select-sm sm:flex-1"
+                    [ngModel]="m.ignore ? IGNORE_VALUE : m.localRootFolderId"
+                    (ngModelChange)="setMapping('sonarr', m.remotePath, $event)"
+                  >
+                    <option [ngValue]="null">—</option>
+                    @for (rf of eligibleLocalRootFolders('sonarr'); track rf.id) {
+                      <option [ngValue]="rf.id">{{ rf.path }}</option>
+                    }
+                    <option [ngValue]="IGNORE_VALUE">{{ 'import.path_wizard.option_ignore' | translate }}</option>
+                  </select>
+                </div>
+              }
+            </div>
+          }
+        }
+
+        <div class="modal-action">
+          <button type="button" class="btn btn-ghost btn-sm" (click)="cancelWizard('sonarr')">
+            {{ 'import.path_wizard.cancel' | translate }}
+          </button>
+          @if (eligibleLocalRootFolders('sonarr').length > 0) {
+            <button
+              type="button"
+              class="btn btn-primary btn-sm"
+              [disabled]="!sonarrCanConfirm() || sonarrLoading()"
+              (click)="confirmSonarrImport()"
+            >
+              @if (sonarrLoading()) {
+                <span class="loading loading-spinner loading-xs"></span>
+              }
+              {{ 'import.path_wizard.confirm' | translate }}
+            </button>
+          }
+        </div>
+      </div>
     </div>
   }
 </div>

--- a/client/src/app/features/settings/data-imports/data-imports.ts
+++ b/client/src/app/features/settings/data-imports/data-imports.ts
@@ -9,6 +9,7 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
+import { RouterLink } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { LucideDownload } from '@lucide/angular';
 import { firstValueFrom } from 'rxjs';
@@ -49,6 +50,28 @@ interface ArrImportResult {
   subtitlesImported?: number;
 }
 
+interface PathMapping {
+  remotePath: string;
+  localRootFolderId: number | null;
+  ignore?: boolean;
+}
+
+interface PreviewRow {
+  remotePath: string;
+  suggestedLocalRootFolderId: number | null;
+}
+
+interface PreviewImportResult {
+  remoteRootFolders: PreviewRow[];
+  localRootFolders: { id: number; path: string; libraryId: number | null }[];
+}
+
+type Provider = 'radarr' | 'sonarr';
+
+/** Sentinel passed through the mapping select in place of a numeric RootFolder id. */
+const IGNORE_VALUE = '__ignore__' as const;
+type MappingSelectValue = number | typeof IGNORE_VALUE | null;
+
 /**
  * "new" sentinel for the library select -> tells the import to create a new
  * library (optionally with `newLibraryName`). null/undefined means "auto-create
@@ -58,7 +81,13 @@ type LibrarySelection = number | 'new' | null;
 
 @Component({
   selector: 'app-data-imports-settings',
-  imports: [FormsModule, TranslateModule, LucideDownload, ImportDiskComponent],
+  imports: [
+    FormsModule,
+    RouterLink,
+    TranslateModule,
+    LucideDownload,
+    ImportDiskComponent,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './data-imports.html',
 })
@@ -131,6 +160,29 @@ export class DataImportsSettingsComponent implements OnInit {
   } | null>(null);
   readonly sonarrResult = signal<ArrImportResult | null>(null);
   readonly sonarrError = signal('');
+
+  // ---- Path mapping wizard ----
+  readonly radarrPreview = signal<PreviewImportResult | null>(null);
+  readonly radarrMappings = signal<PathMapping[]>([]);
+  readonly radarrPreviewing = signal(false);
+  readonly radarrShowWizard = signal(false);
+  readonly radarrCanConfirm = computed(() =>
+    this.radarrMappings().every(
+      (m) => m.ignore || m.localRootFolderId != null,
+    ),
+  );
+
+  readonly sonarrPreview = signal<PreviewImportResult | null>(null);
+  readonly sonarrMappings = signal<PathMapping[]>([]);
+  readonly sonarrPreviewing = signal(false);
+  readonly sonarrShowWizard = signal(false);
+  readonly sonarrCanConfirm = computed(() =>
+    this.sonarrMappings().every(
+      (m) => m.ignore || m.localRootFolderId != null,
+    ),
+  );
+
+  readonly IGNORE_VALUE = IGNORE_VALUE;
 
   private lastHandledEvent: unknown = null;
 
@@ -437,73 +489,175 @@ export class DataImportsSettingsComponent implements OnInit {
     return {};
   }
 
-  async importRadarr() {
-    const url = this.radarrUrl().trim();
-    const apiKey = this.radarrApiKey().trim();
+  /**
+   * Step 1 of the import: ask the backend for *arr root folders + suggestions.
+   * Three branches:
+   *   - *arr exposes 0 root folders → skip the wizard and import with empty mappings
+   *   - Fliks has 0 root folders     → open wizard in "no roots configured" state
+   *   - otherwise                    → open wizard with one row per remote root
+   */
+  async openRadarrWizard() {
+    await this.openWizard('radarr');
+  }
+
+  async openSonarrWizard() {
+    await this.openWizard('sonarr');
+  }
+
+  private async openWizard(provider: Provider) {
+    const url = this.urlSig(provider)().trim();
+    const apiKey = this.apiKeySig(provider)().trim();
     if (!url || !apiKey) return;
 
-    // Persist before launching so the next reload of the page pre-fills.
-    await this.saveRadarrCredentials();
+    if (provider === 'radarr') await this.saveRadarrCredentials();
+    else await this.saveSonarrCredentials();
 
-    this.radarrLoading.set(true);
-    this.radarrResult.set(null);
-    this.radarrError.set('');
+    this.previewingSig(provider).set(true);
+    this.errorSig(provider).set('');
+    this.resultSig(provider).set(null);
     try {
-      const result = await firstValueFrom(
-        this.http.post<ArrImportResult>('/api/imports/radarr', {
-          url,
-          apiKey,
-          mode: this.radarrMode(),
-          importSubtitles: this.radarrImportSubs(),
-          ...this.libraryBody(
-            this.radarrLibrary(),
-            this.radarrNewLibraryName(),
-          ),
-        }),
+      const preview = await firstValueFrom(
+        this.http.post<PreviewImportResult>(
+          `/api/imports/${provider}/preview`,
+          { url, apiKey },
+        ),
       );
-      this.radarrResult.set(result);
+      this.previewSig(provider).set(preview);
+      if (preview.remoteRootFolders.length === 0) {
+        await this.confirmImport(provider, []);
+        return;
+      }
+      this.mappingsSig(provider).set(
+        preview.remoteRootFolders.map((row) => ({
+          remotePath: row.remotePath,
+          localRootFolderId: row.suggestedLocalRootFolderId,
+        })),
+      );
+      this.showWizardSig(provider).set(true);
     } catch (err: unknown) {
       const httpErr = err as { error?: { message?: string } };
-      this.radarrError.set(
-        httpErr.error?.message ?? this.translate.instant('import.error'),
+      this.errorSig(provider).set(
+        httpErr.error?.message ??
+          this.translate.instant('import.path_wizard.preview_error'),
       );
     } finally {
-      this.radarrLoading.set(false);
+      this.previewingSig(provider).set(false);
     }
   }
 
-  async importSonarr() {
-    const url = this.sonarrUrl().trim();
-    const apiKey = this.sonarrApiKey().trim();
+  cancelWizard(provider: Provider) {
+    this.showWizardSig(provider).set(false);
+    this.previewSig(provider).set(null);
+    this.mappingsSig(provider).set([]);
+  }
+
+  setMapping(provider: Provider, remotePath: string, value: MappingSelectValue) {
+    this.mappingsSig(provider).update((list) =>
+      list.map((m) =>
+        m.remotePath === remotePath
+          ? value === IGNORE_VALUE
+            ? { remotePath, localRootFolderId: null, ignore: true }
+            : { remotePath, localRootFolderId: value }
+          : m,
+      ),
+    );
+  }
+
+  /**
+   * Filter local root folders for the picker: a row is eligible when its
+   * library matches the import target or is unassigned. The backend enforces
+   * the same rule; this is just to hide the unselectable options.
+   */
+  eligibleLocalRootFolders(provider: Provider) {
+    const preview = this.previewSig(provider)();
+    if (!preview) return [];
+    const target =
+      provider === 'radarr' ? this.radarrLibrary() : this.sonarrLibrary();
+    return preview.localRootFolders.filter((rf) => {
+      if (rf.libraryId == null) return true;
+      return typeof target === 'number' && rf.libraryId === target;
+    });
+  }
+
+  async confirmRadarrImport() {
+    await this.confirmImport('radarr', this.radarrMappings());
+  }
+
+  async confirmSonarrImport() {
+    await this.confirmImport('sonarr', this.sonarrMappings());
+  }
+
+  private async confirmImport(provider: Provider, mappings: PathMapping[]) {
+    const url = this.urlSig(provider)().trim();
+    const apiKey = this.apiKeySig(provider)().trim();
     if (!url || !apiKey) return;
 
-    // Persist before launching so the next reload of the page pre-fills.
-    await this.saveSonarrCredentials();
+    this.showWizardSig(provider).set(false);
+    this.loadingSig(provider).set(true);
+    this.resultSig(provider).set(null);
+    this.errorSig(provider).set('');
 
-    this.sonarrLoading.set(true);
-    this.sonarrResult.set(null);
-    this.sonarrError.set('');
+    const lib =
+      provider === 'radarr' ? this.radarrLibrary() : this.sonarrLibrary();
+    const newLibName =
+      provider === 'radarr'
+        ? this.radarrNewLibraryName()
+        : this.sonarrNewLibraryName();
+    const mode = provider === 'radarr' ? this.radarrMode() : this.sonarrMode();
+    const importSubs =
+      provider === 'radarr'
+        ? this.radarrImportSubs()
+        : this.sonarrImportSubs();
+
     try {
       const result = await firstValueFrom(
-        this.http.post<ArrImportResult>('/api/imports/sonarr', {
+        this.http.post<ArrImportResult>(`/api/imports/${provider}`, {
           url,
           apiKey,
-          mode: this.sonarrMode(),
-          importSubtitles: this.sonarrImportSubs(),
-          ...this.libraryBody(
-            this.sonarrLibrary(),
-            this.sonarrNewLibraryName(),
-          ),
+          mode,
+          importSubtitles: importSubs,
+          pathMappings: mappings,
+          ...this.libraryBody(lib, newLibName),
         }),
       );
-      this.sonarrResult.set(result);
+      this.resultSig(provider).set(result);
     } catch (err: unknown) {
       const httpErr = err as { error?: { message?: string } };
-      this.sonarrError.set(
+      this.errorSig(provider).set(
         httpErr.error?.message ?? this.translate.instant('import.error'),
       );
     } finally {
-      this.sonarrLoading.set(false);
+      this.loadingSig(provider).set(false);
     }
+  }
+
+  // ---- Provider signal accessors (avoids duplicating the wizard pipeline) ----
+
+  private urlSig(p: Provider) {
+    return p === 'radarr' ? this.radarrUrl : this.sonarrUrl;
+  }
+  private apiKeySig(p: Provider) {
+    return p === 'radarr' ? this.radarrApiKey : this.sonarrApiKey;
+  }
+  private previewSig(p: Provider) {
+    return p === 'radarr' ? this.radarrPreview : this.sonarrPreview;
+  }
+  private mappingsSig(p: Provider) {
+    return p === 'radarr' ? this.radarrMappings : this.sonarrMappings;
+  }
+  private previewingSig(p: Provider) {
+    return p === 'radarr' ? this.radarrPreviewing : this.sonarrPreviewing;
+  }
+  private showWizardSig(p: Provider) {
+    return p === 'radarr' ? this.radarrShowWizard : this.sonarrShowWizard;
+  }
+  private loadingSig(p: Provider) {
+    return p === 'radarr' ? this.radarrLoading : this.sonarrLoading;
+  }
+  private resultSig(p: Provider) {
+    return p === 'radarr' ? this.radarrResult : this.sonarrResult;
+  }
+  private errorSig(p: Provider) {
+    return p === 'radarr' ? this.radarrError : this.sonarrError;
   }
 }


### PR DESCRIPTION
## Summary

Fix the long-standing bug where Fliks blindly reused Radarr/Sonarr's container view of paths (e.g. `/movies`) when those paths almost never match Fliks's own mounts (`/medias/movies`). Every imported `Media.path` ended up pointing at a non-existent directory.

A two-step wizard now sits in front of the *arr import:

1. New endpoint `POST /imports/{radarr,sonarr}/preview` lists the *arr root folders + a server-side suggestion of the Fliks RootFolder each one should map to (basename match, unique only).
2. The user confirms or overrides each mapping in a DaisyUI modal (or marks remote roots as ignored) and `POST /imports/{radarr,sonarr}` receives the explicit `pathMappings` array.

`applyPathMapping()` (longest-prefix match on `remotePath`) decides per item:
- mapping match → `{ rootFolderId, folderName }`, used as before
- explicit ignore → silent skip
- no mapping → error in `errors[]`, item skipped, others still import

The backend additionally rejects (400) any mapping pointing at a RootFolder that belongs to a *different* library than the import target.

## Out of scope (deferred)

- **Persistence** of mappings — re-import re-runs the wizard. No `arr_path_mappings` table, no `ArrConnection` entity.
- **Retroactive repair** of pre-existing buggy `Media.path` rows. Users on the old import path can delete and re-import; a dedicated repair tool can come later if demand surfaces.
- **Auto-creating RootFolders from inside the wizard.** The wizard directs the user to `Settings → Libraries` for that.

## Test plan

- [ ] Happy path — Radarr exposes `/movies`, Fliks has `/medias/movies` → wizard pre-selects via the basename suggestion, confirm imports correctly with `Media.path` resolving on disk.
- [ ] Set a remote root to `Ignorer` → items under it are silently skipped (no `errors[]` row).
- [ ] No-match — *arr returns a path under a remote root the user didn't map → `errors[]` lists `"<title>: no path mapping for ..."`, other items still import.
- [ ] Ambiguous suggestion (two Fliks RootFolders ending in `/movies`) → wizard pre-select stays empty, Confirm disabled.
- [ ] No Fliks RootFolders → wizard shows the guidance alert + link to `/settings/libraries`, no Confirm button.
- [ ] *arr returns 0 root folders → wizard skipped, import runs with empty mappings; loud failure per item.
- [ ] Cross-library mapping → backend returns 400 with offending paths.
- [ ] Re-import → wizard reappears (no persistence) and reproduces the same suggestions.
- [ ] `npm run build` (client) and `npx tsc --noEmit` (backend) both clean.