### PR TITLE
fix(libraries): resolve library view outside the create/update tx

### DIFF
--- a/backend/src/modules/libraries/libraries.service.ts
+++ b/backend/src/modules/libraries/libraries.service.ts
@@ -217,7 +217,12 @@ export class LibrariesService implements OnModuleInit {
   }
 
   async create(dto: CreateLibraryDto): Promise<LibraryWithDetails> {
-    return this.dataSource.transaction(async (m) => {
+    // findOne() reads through this.repo (DataSource-level), which under
+    // READ COMMITTED can't see writes from an open transaction on another
+    // connection — calling it inside the transaction returned null and
+    // threw "Library #X not found". Run the writes in the tx, then resolve
+    // the enriched view from the committed state.
+    const id = await this.dataSource.transaction(async (m) => {
       // Enforce at-most-one default per type.
       if (dto.isDefaultForMovies)
         await this.clearDefaultFlag(m, 'isDefaultForMovies');
@@ -253,12 +258,13 @@ export class LibrariesService implements OnModuleInit {
         await this.replaceUserAccess(m, lib.id, dto.userIds);
       }
 
-      return this.findOne(lib.id);
+      return lib.id;
     });
+    return this.findOne(id);
   }
 
   async update(id: number, dto: UpdateLibraryDto): Promise<LibraryWithDetails> {
-    return this.dataSource.transaction(async (m) => {
+    await this.dataSource.transaction(async (m) => {
       const lib = await m.findOne(Library, { where: { id } });
       if (!lib) throw new NotFoundException(`Library #${id} not found`);
 
@@ -293,9 +299,8 @@ export class LibrariesService implements OnModuleInit {
       if (dto.isDefaultForSeries !== undefined)
         patch.isDefaultForSeries = dto.isDefaultForSeries;
       if (Object.keys(patch).length) await m.update(Library, id, patch);
-
-      return this.findOne(id);
     });
+    return this.findOne(id);
   }
 
   async remove(id: number): Promise<void> {


### PR DESCRIPTION
## Summary

`LibrariesService.create` and `LibrariesService.update` returned `this.findOne(id)` from inside the transaction callback. `findOne` reads via `this.repo` (the DataSource-level repository), which uses a different connection than the open transaction. Under Postgres's default `READ COMMITTED` isolation, that outside read can't see writes from an open tx until commit:

- `create()` → the just-inserted row is invisible → `findOne` returns null → throws `NotFoundException("Library #X not found")` → tx rolls back. End-user reproducer: open Settings → Libraries, hit "Create library", get `Library #4 not found`.
- `update()` → the row exists from before so `findOne` succeeds, but it returns the **pre-patch** state since the in-tx update isn't visible.

The fix is structural: do the writes in the tx, return the new id, and resolve the enriched view via `findOne` **after** the tx commits.

## Test plan

- [ ] Settings → Libraries → Create library: form succeeds and returns the new library row.
- [ ] Edit an existing library (rename, change defaults): UI reflects the patched state immediately, no stale fields.
- [ ] Backend type-check: `cd backend && npx tsc --noEmit` clean.