### PR TITLE
fix(i18n): point empty-state CTA at libraries, not root folders

### DIFF
--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -279,8 +279,8 @@
     "path_wizard": {
       "title": "Mappage des dossiers racines",
       "description": "Associez chaque dossier racine de Radarr/Sonarr à un dossier racine Fliks existant, ou ignorez-le. Les chemins des conteneurs Radarr/Sonarr peuvent différer de ceux montés dans Fliks ; le mappage rétablit la correspondance.",
-      "no_root_folders": "Aucun dossier racine Fliks compatible n'est configuré. Créez-en un dans Réglages → Bibliothèques avant de relancer l'import.",
-      "go_to_root_folders": "Configurer les dossiers racines",
+      "no_root_folders": "Aucun dossier racine Fliks compatible n'est configuré. Les dossiers racines se définissent via les bibliothèques — créez ou éditez une bibliothèque avant de relancer l'import.",
+      "go_to_root_folders": "Configurer les bibliothèques",
       "option_ignore": "Ignorer",
       "confirm": "Confirmer l'import",
       "cancel": "Annuler",

--- a/client/src/app/features/settings/data-imports/data-imports.html
+++ b/client/src/app/features/settings/data-imports/data-imports.html
@@ -499,9 +499,9 @@
             <div role="alert" class="alert alert-warning mt-4 text-sm">
               <div>
                 <p>{{ 'import.path_wizard.no_root_folders' | translate }}</p>
-                <a routerLink="/settings/libraries" class="btn btn-sm btn-primary mt-3" (click)="cancelWizard('radarr')">
+                <button type="button" class="btn btn-sm btn-primary mt-3" (click)="goToLibraries('radarr')">
                   {{ 'import.path_wizard.go_to_root_folders' | translate }}
-                </a>
+                </button>
               </div>
             </div>
           } @else {
@@ -560,9 +560,9 @@
             <div role="alert" class="alert alert-warning mt-4 text-sm">
               <div>
                 <p>{{ 'import.path_wizard.no_root_folders' | translate }}</p>
-                <a routerLink="/settings/libraries" class="btn btn-sm btn-primary mt-3" (click)="cancelWizard('sonarr')">
+                <button type="button" class="btn btn-sm btn-primary mt-3" (click)="goToLibraries('sonarr')">
                   {{ 'import.path_wizard.go_to_root_folders' | translate }}
-                </a>
+                </button>
               </div>
             </div>
           } @else {

--- a/client/src/app/features/settings/data-imports/data-imports.ts
+++ b/client/src/app/features/settings/data-imports/data-imports.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
-import { RouterLink } from '@angular/router';
+import { Router } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { LucideDownload } from '@lucide/angular';
 import { firstValueFrom } from 'rxjs';
@@ -81,18 +81,13 @@ type LibrarySelection = number | 'new' | null;
 
 @Component({
   selector: 'app-data-imports-settings',
-  imports: [
-    FormsModule,
-    RouterLink,
-    TranslateModule,
-    LucideDownload,
-    ImportDiskComponent,
-  ],
+  imports: [FormsModule, TranslateModule, LucideDownload, ImportDiskComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './data-imports.html',
 })
 export class DataImportsSettingsComponent implements OnInit {
   private readonly http = inject(HttpClient);
+  private readonly router = inject(Router);
   private readonly settingsApi = inject(SettingsApiService);
   private readonly seerrApi = inject(SeerrApiService);
   private readonly librariesApi = inject(LibrariesApiService);
@@ -549,6 +544,17 @@ export class DataImportsSettingsComponent implements OnInit {
     this.showWizardSig(provider).set(false);
     this.previewSig(provider).set(null);
     this.mappingsSig(provider).set([]);
+  }
+
+  /**
+   * Empty-state CTA when the user has no compatible Fliks RootFolders. We
+   * navigate programmatically because mixing `routerLink` with the `(click)`
+   * handler that closes the wizard removed the anchor before Angular Router
+   * had a chance to navigate, and the click was a no-op.
+   */
+  goToLibraries(provider: Provider) {
+    this.cancelWizard(provider);
+    void this.router.navigateByUrl('/settings/libraries');
   }
 
   setMapping(provider: Provider, remotePath: string, value: MappingSelectValue) {


### PR DESCRIPTION
## Summary

The path-mapping wizard's empty-state alert ("Aucun dossier racine Fliks compatible n'est configuré.") came with a button labelled "Configurer les dossiers racines". That label is misleading — there is no standalone root-folders page. Root folders are attached to a library, edited from `Settings → Libraries`. The button already routes to `/settings/libraries`; only the labels were inconsistent.

Reworded both the alert body and the button label so the user is told to manage libraries — which is the actual place to add/remove root folders.