### PR TITLE
fix(system): read version from package.json, not npm env var

### DIFF
--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -34,6 +34,17 @@ import { PlaybackService } from '../streaming/playback.service';
 import { MediaFile } from '../media/entities/media-file.entity';
 import { Episode } from '../media/entities/episode.entity';
 
+const APP_VERSION: string = (() => {
+  try {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'),
+    ) as { version?: string };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+})();
+
 export interface ActiveStreamDto {
   sessionId: string;
   userId: number | null;
@@ -140,7 +151,7 @@ export class SystemController {
     ]);
 
     return {
-      version: process.env.npm_package_version ?? '0.1.0',
+      version: APP_VERSION,
       uptimeSeconds: Math.floor(process.uptime()),
       database: dbStatus,
       indexers,


### PR DESCRIPTION
## Summary
- `/api/system/health` returned `process.env.npm_package_version ?? '0.1.0'`. That env var is only populated when Node is started through `npm run …`; the Docker image runs `CMD ["node", "dist/main"]`, so the fallback was always served and Admin → System displayed `v0.1.0` regardless of the actual release tag.
- Read the version from `package.json` at boot instead. Works in dev (`cwd = backend/`) and in the Docker runtime (`cwd = /app`, `package.json` is copied there by the Dockerfile).

## Test plan
- [ ] Run backend locally (`npm run start:dev`) → `/api/system/health` returns `version: "1.3.1"`.
- [ ] Build & run the Docker image → Admin → System shows the current version (no longer `v0.1.0`).