### PR TITLE
fix(rescan): skip non-episode files in series folders, drop orphan rows

### DIFF
--- a/backend/src/migrations/1777887905078-delete-orphan-series-media-files.ts
+++ b/backend/src/migrations/1777887905078-delete-orphan-series-media-files.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DeleteOrphanSeriesMediaFiles1777887905078
+  implements MigrationInterface
+{
+  name = 'DeleteOrphanSeriesMediaFiles1777887905078';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM "media_files"
+       WHERE "episodeId" IS NULL
+         AND "mediaId" IN (SELECT "id" FROM "media" WHERE "type" = 'series')`,
+    );
+  }
+
+  public async down(): Promise<void> {
+    // No rollback: the deleted rows pointed at non-episode files that
+    // were polluting series detail pages; restoring them would re-create
+    // the bug.
+  }
+}

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -2489,8 +2489,9 @@ export class MediaService {
           }
         } else {
           this.log.warn(
-            `Rescan[media #${mediaId}]: series file name has no SxxEyy pattern — "${filename}" (file will not link to an episode)`,
+            `Rescan[media #${mediaId}]: series file name has no SxxEyy pattern — "${filename}" (skipped, alien file in series folder)`,
           );
+          continue;
         }
       }
 

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -162,7 +162,10 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     const m = this.media();
     if (!m) return [];
     const list = m.files ?? [];
-    return m.type === 'series' ? list.filter((f) => !f.episodeId) : list;
+    // Series files always belong to an episode; the root page never has
+    // a "main file" to display, so don't surface orphans here even if
+    // legacy data leaked them through.
+    return m.type === 'series' ? [] : list;
   });
 
   /**


### PR DESCRIPTION
## Summary
A user imported a Radarr/Sonarr library that included a misplaced movie file (`Blue Mountain State The Rise Of Thadland (2016)…mkv`) sitting inside the *series* folder `/medias/series/Blue Mountain State/`. After rescan + refresh, the series detail page showed the movie file as the "main file" in the "Informations du fichier" panel, making the series look like a movie.

**Root cause** — `media.service.ts` rescan: when `parseEpisodeNumbers()` failed for a series file, the code logged a warning *and still* created a `MediaFile` with `episodeId = NULL`. The frontend `mediaFiles` computed for series specifically returned those orphans, then auto-selected the first one as the active file.

## Fix
- **Backend rescan** (`media.service.ts`): when a series file has no `SxxEyy` pattern, log the warning **and `continue`**. Alien files in series folders are no longer imported as orphan rows.
- **Migration `DeleteOrphanSeriesMediaFiles`**: cleans up pre-existing orphan `media_files` rows where `mediaId` is a series and `episodeId IS NULL`. `subtitle_files` and `playback_states` cascade-delete via existing FKs.
- **Frontend** (`media-detail.ts`): the series root `mediaFiles` computed now returns `[]` instead of orphan files. A series root page never has a "main file" — files belong to episodes. Defense in depth in case any orphan leaks through later.

## Out of scope
- The movie itself isn't linked to a `MediaFile` because its file is physically in the wrong root folder. The user has to move the `.mkv` to the movies root and re-scan; Fliks can't link a file the movie-library scan never sees.
- `completion.service.ts` (the post-download import flow) has a separate, similar fallback that names unparseable series files `S01E01` and saves them as orphans. Different code path, different bug, not touched here.

## Test plan
- [ ] On a DB containing the bug, boot the backend on this branch → migration runs at boot, orphan rows for series are removed.
- [ ] Reload the affected series detail page → the "Informations du fichier" panel is gone from the root view; episode pages still show their per-episode file info correctly.
- [ ] Re-run the `RescanAll` command on the series library → backend logs show `series file name has no SxxEyy pattern — "…" (skipped, alien file in series folder)` for the offending file, and no new orphan row appears in `media_files`.
- [ ] Sanity: a series with normally-named episode files still rescans correctly (episodes get linked, files appear under their respective episode pages).