### PR TITLE
fix(cast): use Shaka for HLS playback on the receiver

### DIFF
--- a/cast-receiver/receiver.js
+++ b/cast-receiver/receiver.js
@@ -66,12 +66,18 @@ playerManager.setMessageInterceptor(
 
 // --- Boot ---------------------------------------------------------------
 //
+// `useShakaForHls: true` makes CAF use Shaka for HLS — the same engine
+// the Fliks web/Android paths use, so all three clients share buffering
+// and ABR behaviour.
+//
 // `disableIdleTimeout: true` keeps the receiver alive between clips so
 // queue/skip-intro features work later without re-launching the app.
-// `playbackConfig` left at defaults — Shaka inside CAF handles HLS/DASH
-// for us. CORS on the user's NAS responses is the only blocker; document
-// in README.
+// `autoResumeDuration: 5` starts/resumes playback on 5s of buffered media
+// (default 10) — snappier resume after a seek or transient stall.
 
-context.start({
-  disableIdleTimeout: true,
-});
+const options = new cast.framework.CastReceiverOptions();
+options.disableIdleTimeout = true;
+options.useShakaForHls = true;
+options.playbackConfig = new cast.framework.PlaybackConfig();
+options.playbackConfig.autoResumeDuration = 5;
+context.start(options);


### PR DESCRIPTION
## Summary
- Receiver-side fix for the 1000s freeze on Chromecast (Android sender).
- CAF defaults to MPL (closed-source) for HLS, which freezes around 1000s on long VOD streams produced by on-the-fly transcoders. Backend goes silent (no more segment requests), receiver enters "loading" state and never recovers.
- Force Shaka via `options.useShakaForHls = true`. Same engine as the Fliks web/Android paths — MSE-based, with proper buffer eviction, well-trodden on long content.
- Bonus: `autoResumeDuration = 5` (default 10) for snappier resume after a seek/transient stall.

## Test plan
- [ ] Merge → `deploy-cast-receiver.yml` republishes `cast-receiver/` to GitHub Pages automatically.
- [ ] Power-cycle the Chromecast (or wait full idle) to force-fetch the new receiver shell.
- [ ] Cast a 30+ min media that previously froze at 1000s, let it run past 17 min, confirm no freeze.
- [ ] Sanity: subtitle styling defaults still apply, splash hides on play, ENDED restores splash.