### PR TITLE
fix(playback): use relation-form criteria in hideFromContinueWatching

### DIFF
--- a/backend/src/modules/streaming/playback.service.ts
+++ b/backend/src/modules/streaming/playback.service.ts
@@ -767,7 +767,7 @@ export class PlaybackService implements OnModuleInit {
     mediaId: number,
   ): Promise<void> {
     await this.repo.update(
-      { userId, mediaId },
+      { user: { id: userId }, media: { id: mediaId } },
       { hiddenFromContinueWatching: true },
     );
   }


### PR DESCRIPTION
## Summary
Clicking "Retirer de cette liste" on a Continue Watching item threw:
\`\`\`
EntityPropertyNotFoundError: Property "userId" was not found in "PlaybackState".
\`\`\`
The endpoint called \`repo.update({ userId, mediaId }, ...)\` but \`userId\` / \`mediaId\` on the \`PlaybackState\` entity are \`@RelationId\` virtuals (not real top-level columns from the FindOptionsWhere DSL's perspective). TypeORM accepts the nested-relation form for criteria — every other update/delete in this service already uses it.

## Test plan
- [ ] Click "Retirer de cette liste" on a Continue Watching tile → no error, item disappears.
- [ ] Re-watch the same media a bit → item re-appears in Continue Watching (the unhide on resume path at `playback.service.ts:264` already exists).