### PR TITLE
fix(cast): serve fMP4 HLS to the Cast device profile

### DIFF
--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -60,7 +60,6 @@ export class CastPlayerService {
   private readonly trackManager = inject(TrackManagerService);
   private readonly mediaService = inject(MediaService);
 
-  /** Chromecast device profile — only H264 + AAC, forces transcode for incompatible codecs. */
   /** Chromecast profile — force full transcode to guarantee H264+AAC HLS output. */
   private getCastDeviceProfile(): DeviceProfile {
     const cs = this.castSettings.get();
@@ -70,10 +69,12 @@ export class CastPlayerService {
       codecConditions: [],
       maxStreamingBitrate: 20_000_000,
       maxAudioChannels: cs.audioChannels ?? 2,
-      supportsHlsFmp4: false,  // Default Cast receiver (MPL) doesn't support fMP4 HLS
+      // The receiver opts into Shaka for HLS, which prefers fMP4 (no TS
+      // demux step). TS is kept as a fallback for older receivers.
+      supportsHlsFmp4: true,
       supportsHlsTs: true,
       supportsHdr: cs.hdr ?? false,
-      hdrRequiresFmp4: false,  // Cast uses TS — HDR will be tonemapped if needed
+      hdrRequiresFmp4: true,
       supportsMultiAudioMuxed: false,
       deviceType: 'desktop',
     };


### PR DESCRIPTION
## Why
Receiver-side change in #35 switched HLS playback to Shaka. Shaka in CAF plays fMP4 HLS natively (no MPEG-TS demux step) and is the more reliable path on long VOD streams. We were still telling the backend the Cast device only supports HLS-TS — comment dated from when the receiver used the default closed-source HLS player.

## Change
`client/src/app/core/services/cast-player.service.ts:getCastDeviceProfile()`:
- `supportsHlsFmp4: false → true`
- `supportsHlsTs: true` kept as fallback
- `hdrRequiresFmp4: false → true` (matches the new primary path; HDR can now passthrough on fMP4 instead of being tonemapped on TS)

Backend flips the variant playlist to fMP4 (`.m4s` segments + init segment) automatically when the device profile says so — no backend change needed.

## Test plan
- [ ] Power-cycle the Chromecast.
- [ ] Cast a media. Player should start (was stuck on splash before).
- [ ] Seek mid-playback — should be cheap, no full session restart.
- [ ] Play past the 16:40 mark on a long file — confirms #35 + this together kill the original freeze.