### PR TITLE
fix(cast): handle audio-switch msg as STRING namespace

### DIFF
--- a/cast-receiver/receiver.js
+++ b/cast-receiver/receiver.js
@@ -72,7 +72,15 @@ playerManager.addEventListener(
 
 context.addCustomMessageListener(FLIKS_AUDIO_NAMESPACE, (event) => {
   console.log('[fliks-cast] audio msg received:', event.data);
-  const { language, name } = event.data ?? {};
+  // Sender posts a JSON string (see cast.service.ts comment for why).
+  let payload;
+  try {
+    payload = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+  } catch (err) {
+    console.warn('[fliks-cast] audio msg: JSON parse failed', err, event.data);
+    return;
+  }
+  const { language, name } = payload ?? {};
   if (!language) {
     console.warn('[fliks-cast] audio msg: no language → bail');
     return;
@@ -164,7 +172,7 @@ options.playbackConfig = new cast.framework.PlaybackConfig();
 options.playbackConfig.autoResumeDuration = 5;
 options.supportedCommands = cast.framework.messages.Command.ALL_BASIC_MEDIA;
 options.customNamespaces = {
-  [FLIKS_AUDIO_NAMESPACE]: cast.framework.system.MessageType.JSON,
+  [FLIKS_AUDIO_NAMESPACE]: cast.framework.system.MessageType.STRING,
 };
 context.start(options);
 console.log('[fliks-cast] context.start called');


### PR DESCRIPTION
## Summary
- Sender's send callback returned success but the receiver's `addCustomMessageListener` never fired — known finickiness with `MessageType.JSON` + JS-object payloads on certain CAF SDK builds.
- Now sender stringifies + receiver parses; namespace declared as `STRING`.

## Test plan
- [ ] Power-cycle Chromecast; cast a multi-audio file; switch language
- [ ] Receiver console (chrome://inspect): `[fliks-cast] audio msg received: ...` + `audio switch → trackId=...`
- [ ] No new LOAD intercepted, audio swaps in-place