### PR TITLE
fix(cast): broadcast media-info update so senders see audio tracks

### DIFF
--- a/cast-receiver/receiver.js
+++ b/cast-receiver/receiver.js
@@ -92,7 +92,11 @@ function publishAudioTracks() {
     (t) => t.type !== cast.framework.messages.TrackType.AUDIO,
   );
   info.tracks = [...otherTracks, ...cafAudioTracks];
-  playerManager.setMediaInformation(info, /* opt_broadcast */ true);
+  playerManager.setMediaInformation(info);
+  // Push the updated media info to senders via MEDIA_STATUS so they see the
+  // audio tracks in MediaInformation.tracks and can switch them via
+  // EditTracksInfoRequest.
+  playerManager.broadcastStatus(true);
   console.log(
     `[fliks-cast] published ${cafAudioTracks.length} audio tracks to media info`,
     cafAudioTracks.map((t) => ({ trackId: t.trackId, language: t.language, name: t.name })),


### PR DESCRIPTION
## Summary
- The published audio tracks weren't reaching the sender's \`media.media.tracks\` because \`setMediaInformation(info, true)\` interprets the second arg as \`opt_includeMedia\` (replaces current media), not \`opt_broadcast\`. Result: silent local update, no MEDIA_STATUS push to senders, sender's audio switch fell back to a full reload.
- Drop the second arg and call \`playerManager.broadcastStatus(true)\` explicitly, which is the documented way to push the updated MediaInformation to all senders.

## Test plan
- [ ] Power-cycle Chromecast; cast multi-audio file
- [ ] Sender console shows N AUDIO tracks visible at audio-switch time
- [ ] EDIT_TRACKS_INFO sent, no new LOAD intercepted