### PR TITLE
refactor(streaming): drop MPEG-TS HLS, fMP4-only output

### DIFF
--- a/backend/src/migrations/1778011000000-drop-streaming-segment-format.ts
+++ b/backend/src/migrations/1778011000000-drop-streaming-segment-format.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DropStreamingSegmentFormat1778011000000 implements MigrationInterface {
+  name = 'DropStreamingSegmentFormat1778011000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM "app_settings" WHERE "key" = 'streaming_segment_format'`,
+    );
+  }
+
+  public async down(): Promise<void> {
+    // No rollback: HLS output is fMP4-only now; the setting is no longer read.
+  }
+}

--- a/backend/src/modules/streaming/active-stream-tracker.service.ts
+++ b/backend/src/modules/streaming/active-stream-tracker.service.ts
@@ -115,27 +115,6 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
     return this.audioStreamCountCache.get(mediaFileId) ?? 0;
   }
 
-  /** Whether the client handles multi-audio from muxed TS (ExoPlayer/AVPlayer) */
-  private readonly multiAudioMuxedCache = new Map<number, boolean>();
-
-  setMultiAudioMuxed(mediaFileId: number, value: boolean) {
-    this.multiAudioMuxedCache.set(mediaFileId, value);
-  }
-
-  getMultiAudioMuxed(mediaFileId: number): boolean {
-    return this.multiAudioMuxedCache.get(mediaFileId) ?? false;
-  }
-
-  private readonly fmp4SupportedCache = new Map<number, boolean>();
-
-  setFmp4Supported(mediaFileId: number, value: boolean) {
-    this.fmp4SupportedCache.set(mediaFileId, value);
-  }
-
-  getFmp4Supported(mediaFileId: number): boolean {
-    return this.fmp4SupportedCache.get(mediaFileId) ?? true;
-  }
-
   /** Client device category ('mobile' | 'desktop') captured at playback-info.
    *  Used by hlsMaster and HLS segment endpoints to pick the right bitrate ladder. */
   private readonly deviceTypeCache = new Map<number, 'mobile' | 'desktop'>();

--- a/backend/src/modules/streaming/dto/device-profile.dto.ts
+++ b/backend/src/modules/streaming/dto/device-profile.dto.ts
@@ -71,23 +71,7 @@ export class DeviceProfileDto {
 
   @IsBoolean()
   @IsOptional()
-  supportsHlsFmp4?: boolean;
-
-  @IsBoolean()
-  @IsOptional()
-  supportsHlsTs?: boolean;
-
-  @IsBoolean()
-  @IsOptional()
   supportsHdr?: boolean;
-
-  @IsBoolean()
-  @IsOptional()
-  hdrRequiresFmp4?: boolean;
-
-  @IsBoolean()
-  @IsOptional()
-  supportsMultiAudioMuxed?: boolean;
 
   @IsIn(['mobile', 'desktop'])
   @IsOptional()

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -39,8 +39,6 @@ export class StreamBuilderService {
     profile: DeviceProfileDto,
     tokenParam: string,
     burnInSubtitleId?: number,
-    /** Whether the output will use fMP4 segments (false = TS). */
-    useFmp4 = true,
   ): PlaybackInfoResponse {
     const si = resolved.mediaFile.streamInfo;
     const v = si?.video?.[0];
@@ -100,16 +98,7 @@ export class StreamBuilderService {
     // HDR detection
     const isSourceHdr = !!source.hdrFormat;
     const clientSupportsHdr = profile.supportsHdr === true;
-    // HDR passthrough requires HEVC which some containers can't carry:
-    // iOS AVPlayer crashes on HEVC in TS. When the client declares
-    // hdrRequiresFmp4 and the output is TS, force tonemapping to H264 SDR.
-    const hdrBlockedByFormat =
-      isSourceHdr &&
-      clientSupportsHdr &&
-      profile.hdrRequiresFmp4 === true &&
-      !useFmp4;
-    const needsTonemapping =
-      (isSourceHdr && !clientSupportsHdr) || hdrBlockedByFormat;
+    const needsTonemapping = isSourceHdr && !clientSupportsHdr;
     const needsBurnIn = !!burnInSubtitleId;
     const needsCrop = !!v?.crop;
 
@@ -129,14 +118,14 @@ export class StreamBuilderService {
       `audioDecision[file=${resolved.mediaFile.id}] tryDirectPlay → audioSupported=${directPlayResult.audioSupported}, containerSupported=${directPlayResult.containerSupported}, videoSupported=${directPlayResult.videoSupported}, reasons=${reasons.map((r) => r.flag).join('|') || '-'}`,
     );
 
-    // HDR on SDR client or incompatible format forces transcode
+    // HDR on SDR client forces transcode
     if (needsTonemapping) {
       if (directPlayResult.canDirectPlay)
         directPlayResult.canDirectPlay = false;
-      const reason = hdrBlockedByFormat
-        ? `HDR → SDR (HEVC incompatible with TS, ${source.hdrFormat})`
-        : `HDR → SDR (tone mapping ${source.hdrFormat})`;
-      reasons.push({ flag: 'VideoHdrNotSupported', message: reason });
+      reasons.push({
+        flag: 'VideoHdrNotSupported',
+        message: `HDR → SDR (tone mapping ${source.hdrFormat})`,
+      });
     }
 
     // Subtitle burn-in forces transcode

--- a/backend/src/modules/streaming/streaming-settings-cache.service.ts
+++ b/backend/src/modules/streaming/streaming-settings-cache.service.ts
@@ -2,7 +2,6 @@ import { Injectable, OnModuleInit } from '@nestjs/common';
 import { SettingsService } from '../settings/settings.service';
 
 export interface StreamingSettings {
-  segmentFormat: 'auto' | 'ts' | 'fmp4';
   segmentDuration: number;
   initTime: number;
   qsvPreset:
@@ -19,7 +18,6 @@ export interface StreamingSettings {
 }
 
 const KEYS = [
-  'streaming_segment_format',
   'streaming_segment_duration',
   'streaming_init_time',
   'streaming_qsv_preset',
@@ -58,7 +56,6 @@ export class StreamingSettingsCache implements OnModuleInit {
   private async load(): Promise<StreamingSettings> {
     const values = await Promise.all(KEYS.map((k) => this.settings.get(k)));
     const [
-      format,
       duration,
       initTime,
       qsvPreset,
@@ -67,7 +64,6 @@ export class StreamingSettingsCache implements OnModuleInit {
       qsvAdaptive,
     ] = values;
     return {
-      segmentFormat: (format ?? 'auto') as StreamingSettings['segmentFormat'],
       segmentDuration: parseFloat(duration ?? '3') || 3,
       initTime: parseFloat(initTime ?? '1') || 1,
       qsvPreset: (qsvPreset ?? 'faster') as StreamingSettings['qsvPreset'],

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -143,26 +143,15 @@ export class StreamingController {
       audioStreamIndex:
         this.activeStreamTracker.getAudioStreamIndex(mediaFileId),
       crop: si?.video?.[0]?.crop ?? undefined,
-      // videoOnly only makes sense with fMP4 (var_stream_map produces separate audio).
-      // For TS, audio must stay muxed in the video stream.
-      // Multi-audio handling depends on segment format:
-      //   - fMP4: videoOnly + var_stream_map (separate audio renditions in
-      //     subdirs) → Shaka can switch via EXT-X-MEDIA.
-      //   - TS:   mapAllAudio muxes every audio track as distinct PIDs in a
-      //     single TS stream → ExoPlayer/AVPlayer switch by PID natively.
+      // Multi-audio: produce video-only segments and let ffmpeg's var_stream_map
+      // emit one audio rendition per track (subdirs 1..N) so Shaka can switch
+      // client-side via EXT-X-MEDIA.
       videoOnly:
-        this.activeStreamTracker.getAudioStreamCount(mediaFileId) > 1 &&
-        this.activeStreamTracker.getFmp4Supported(mediaFileId),
-      mapAllAudio:
-        this.activeStreamTracker.getAudioStreamCount(mediaFileId) > 1 &&
-        !this.activeStreamTracker.getFmp4Supported(mediaFileId),
-      // Pass audio stream info for both var_stream_map (fMP4) and
-      // mapAllAudio (TS) — both paths need language metadata.
+        this.activeStreamTracker.getAudioStreamCount(mediaFileId) > 1,
       audioStreams:
         this.activeStreamTracker.getAudioStreamCount(mediaFileId) > 1
           ? ((si?.audio as { language?: string; title?: string }[]) ?? [])
           : undefined,
-      useFmp4: this.activeStreamTracker.getFmp4Supported(mediaFileId),
       deviceType: this.activeStreamTracker.getDeviceType(mediaFileId),
       encoderPreset: this.activeStreamTracker.getEncoderPreset(mediaFileId),
       qsvOptions: this.activeStreamTracker.getQsvOptions(),
@@ -380,22 +369,13 @@ export class StreamingController {
     const audioStreamIndex =
       audioStreamRaw != null ? parseInt(audioStreamRaw, 10) : undefined;
 
-    // Compute segment format early — the stream builder needs it to decide
-    // whether HDR passthrough is possible (HEVC requires fMP4 on iOS).
     const ss = await this.getStreamingSettings();
-    const audioCount = resolved.mediaFile.streamInfo?.audio?.length ?? 1;
-    const clientFmp4 = deviceProfile.supportsHlsFmp4 ?? true;
-    let useFmp4: boolean;
-    if (ss.segmentFormat === 'ts') useFmp4 = false;
-    else if (ss.segmentFormat === 'fmp4') useFmp4 = clientFmp4;
-    else useFmp4 = audioCount > 1 && clientFmp4; // auto: fMP4 for multi-audio only
 
     const result = this.streamBuilder.evaluate(
       resolved,
       deviceProfile,
       tokenParam,
       burnInSubtitleId,
-      useFmp4,
     );
     // Cache transcode reasons for the admin dashboard
     if (result.transcodeReasons.length) {
@@ -422,15 +402,10 @@ export class StreamingController {
       this.activeStreamTracker.setBurnIn(mediaFileId, undefined);
     }
     this.activeStreamTracker.setAudioStreamIndex(mediaFileId, audioStreamIndex);
-    this.activeStreamTracker.setMultiAudioMuxed(
-      mediaFileId,
-      deviceProfile.supportsMultiAudioMuxed ?? false,
-    );
     this.activeStreamTracker.setDeviceType(
       mediaFileId,
       deviceProfile.deviceType ?? 'desktop',
     );
-    this.activeStreamTracker.setFmp4Supported(mediaFileId, useFmp4);
     this.activeStreamTracker.setStreamingDurations(
       ss.segmentDuration,
       ss.initTime,
@@ -550,7 +525,6 @@ export class StreamingController {
       durationSeconds: duration,
       markers,
       chapters,
-      segmentFormat: useFmp4 ? 'fmp4' : 'ts',
     };
   }
 
@@ -621,19 +595,12 @@ export class StreamingController {
     const sourceBitrate = (v?.bitRate ?? 0) + (si?.audio?.[0]?.bitRate ?? 0);
     const audioStreams: { language?: string; title?: string }[] =
       si?.audio ?? [];
-    // Use EXT-X-MEDIA only when the client needs it (Shaka on web) AND supports fMP4.
-    // Native players (ExoPlayer/AVPlayer) handle multi-audio from muxed TS.
-    // Cast (TS) can't handle separate fMP4 audio renditions.
-    // Always expose every rendition even when the user has picked a specific
-    // track — the picked track is marked DEFAULT=YES in the playlist so Shaka
-    // preselects it, and subsequent switches happen client-side (no reload).
-    const clientMuxesAudio =
-      this.activeStreamTracker.getMultiAudioMuxed(mediaFileId);
-    const fmp4Supported =
-      this.activeStreamTracker.getFmp4Supported(mediaFileId);
+    // Multi-audio is exposed via separate EXT-X-MEDIA renditions so the
+    // player can switch audio client-side without a reload. Every rendition
+    // is listed even when the user has picked a specific track — the picked
+    // track is marked DEFAULT=YES so the player preselects it.
     const pickedIdx = this.activeStreamTracker.getAudioStreamIndex(mediaFileId);
-    const useExtXMedia =
-      audioStreams.length > 1 && !clientMuxesAudio && fmp4Supported;
+    const useExtXMedia = audioStreams.length > 1;
     const onlyQuality = firstQueryString(req.query, 'startQuality');
     // Device type: URL param wins (stream URL is built by the frontend with
     // the cached client profile); fall back to whatever playback-info stored.
@@ -941,25 +908,14 @@ export class StreamingController {
     const token = firstQueryString(req.query, 'token');
     const tokenParam = token ? `?token=${encodeURIComponent(token)}` : '';
     const basePath = `/api/stream/${mediaFileId}/${quality}`;
-    const useFmp4 = this.activeStreamTracker.getFmp4Supported(mediaFileId);
     // Use the master.m3u8 decision — must match to avoid init filename mismatch.
     const multiAudio = this.activeStreamTracker.getUseExtXMedia(mediaFileId);
-
-    let playlist: string;
-    if (useFmp4) {
-      const initName = multiAudio ? 'init_0.mp4' : 'init.mp4';
-      playlist = buildVodPlaylist(
-        duration,
-        (seg) => `${basePath}/seg-${seg}.m4s${tokenParam}`,
-        `${basePath}/${initName}${tokenParam}`,
-      );
-    } else {
-      // MPEG-TS for Cast (no init segment needed)
-      playlist = buildVodPlaylist(
-        duration,
-        (seg) => `${basePath}/seg-${seg}.ts${tokenParam}`,
-      );
-    }
+    const initName = multiAudio ? 'init_0.mp4' : 'init.mp4';
+    const playlist = buildVodPlaylist(
+      duration,
+      (seg) => `${basePath}/seg-${seg}.m4s${tokenParam}`,
+      `${basePath}/${initName}${tokenParam}`,
+    );
 
     res.setHeader('Content-Type', 'application/vnd.apple.mpegurl');
     res.setHeader('Access-Control-Allow-Origin', '*');
@@ -967,7 +923,7 @@ export class StreamingController {
     res.send(playlist);
   }
 
-  /** HLS segment — serves a transcoded .ts/.m4s segment or fMP4 init. */
+  /** HLS segment — serves a transcoded .m4s segment or fMP4 init. */
   @Get(':mediaFileId/:quality/:segment')
   async hlsSegment(
     @Param('mediaFileId', ParseIntPipe) mediaFileId: number,
@@ -979,11 +935,11 @@ export class StreamingController {
     if (!VALID_QUALITIES.has(quality)) {
       throw new BadRequestException(`Invalid quality: ${quality}`);
     }
-    const VIDEO_SEG_RE = /^(seg-\d{3,4}\.(ts|m4s)|init(_\d+)?\.mp4)$/;
+    const VIDEO_SEG_RE = /^(seg-\d{3,4}\.m4s|init(_\d+)?\.mp4)$/;
     if (!VIDEO_SEG_RE.test(segment)) {
       throw new BadRequestException(`Invalid segment name: ${segment}`);
     }
-    if (segment.startsWith('init') || segment === 'seg-0000.m4s' || segment === 'seg-0000.ts') {
+    if (segment.startsWith('init') || segment === 'seg-0000.m4s') {
       this.log.log(
         `[request] ${segment} mfid=${mediaFileId} quality=${quality}`,
       );

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -19,9 +19,7 @@ export interface BuildFfmpegArgsOptions {
   audioStreamIndex?: number;
   crop?: { width: number; height: number; x: number; y: number };
   videoOnly?: boolean;
-  mapAllAudio?: boolean;
   audioStreams?: { language?: string; title?: string }[];
-  useFmp4?: boolean;
   /** When true, keep the source audio with `-c:a copy` (bitstream
    *  passthrough). When false, transcode to AAC stereo at profile bitrate. */
   copyAudio?: boolean;
@@ -51,9 +49,7 @@ export function buildFfmpegArgs(
     audioStreamIndex,
     crop,
     videoOnly = false,
-    mapAllAudio = false,
     audioStreams,
-    useFmp4 = true,
     copyAudio = false,
     encoderPreset = 'faster',
     qsvOptions = { lookahead: false, lowPower: false, adaptive: true },
@@ -359,14 +355,14 @@ export function buildFfmpegArgs(
   }
 
   // ── Audio mapping + HLS output ──
-  // Always use var_stream_map for fMP4 multi-audio, even when the user has
+  // Always use var_stream_map for multi-audio, even when the user has
   // picked a specific track — otherwise switching audio would require a
   // full backend reload. With all audio renditions exposed, Shaka switches
   // client-side via EXT-X-MEDIA. The picked track is signalled via
   // DEFAULT=YES in the master.m3u8 (see streaming.controller.ts).
   const userPickedAudio = audioStreamIndex != null && audioStreamIndex > 0;
   const useVarStreamMap =
-    useFmp4 && videoOnly && audioStreams && audioStreams.length > 1;
+    videoOnly && audioStreams && audioStreams.length > 1;
 
   if (useVarStreamMap) {
     // Single FFmpeg process for video + all audio renditions (perfect sync).
@@ -405,29 +401,16 @@ export function buildFfmpegArgs(
       path.join(outputDir, '%v', 'index.m3u8'),
     );
   } else {
-    // Standard single-stream output.
-    // `userPickedAudio` (audioStreamIndex set) wins over `mapAllAudio`:
-    // when the user explicitly chose a track from the UI, honour it with a
-    // single -map so the next reload actually plays that audio. Otherwise
-    // mapAllAudio mux every PID for native client-side switching.
+    // Standard single-stream output: video + one audio track muxed.
+    // When the user picked a track from the UI honour it; otherwise default
+    // to the first audio. Explicit -map skips ffmpeg's auto-pick of a
+    // subtitle stream — mandatory on sources with many subtitle tracks
+    // (some HEVC MKVs have 28+) where the parallel subrip→webvtt pipeline
+    // starves the VAAPI HEVC decoder buffer pool, making the early session
+    // loop on "thread_get_buffer() failed".
     if (userPickedAudio) {
       args.push('-map', '0:v:0', '-map', `0:a:${audioStreamIndex}`);
-    } else if (mapAllAudio && audioStreams && audioStreams.length > 1) {
-      // TS + multi-audio: mux ALL audio tracks so native players (ExoPlayer/AVPlayer) can switch
-      args.push('-map', '0:v:0');
-      for (let i = 0; i < audioStreams.length; i++) {
-        args.push('-map', `0:a:${i}`);
-        const lang = audioStreams[i].language;
-        if (lang) {
-          args.push(`-metadata:s:a:${i}`, `language=${lang}`);
-        }
-      }
     } else {
-      // Default: explicitly map only video + first audio. Skips ffmpeg's
-      // auto-pick of a subtitle stream — mandatory on sources with many
-      // subtitle tracks (some HEVC MKVs have 28+) where the parallel
-      // subrip→webvtt pipeline starves the VAAPI HEVC decoder buffer
-      // pool, making the early session loop on "thread_get_buffer() failed".
       args.push('-map', '0:v:0', '-map', '0:a:0');
     }
     if (copyAudio) {
@@ -444,17 +427,9 @@ export function buildFfmpegArgs(
       '-hls_init_time', String(INIT_TIME),
       '-hls_list_size', '0',
       '-start_number', String(startSegment),
-    );
-    if (useFmp4) {
-      args.push(
-        '-hls_segment_type', 'fmp4',
-        '-hls_fmp4_init_filename', 'init.mp4',
-        '-hls_segment_filename', path.join(outputDir, 'seg-%04d.m4s'),
-      );
-    } else {
-      args.push('-hls_segment_filename', path.join(outputDir, 'seg-%04d.ts'));
-    }
-    args.push(
+      '-hls_segment_type', 'fmp4',
+      '-hls_fmp4_init_filename', 'init.mp4',
+      '-hls_segment_filename', path.join(outputDir, 'seg-%04d.m4s'),
       '-hls_flags', 'independent_segments',
       path.join(outputDir, 'index.m3u8'),
     );
@@ -527,9 +502,6 @@ export function buildRemuxArgs(
   audioBitrate = '192k',
   startSegment = 0,
   videoOnly = false,
-  mapAllAudio = false,
-  audioStreams?: { language?: string; title?: string }[],
-  useFmp4 = true,
   trustedStreamInfo = false,
   audioStreamIndex?: number,
   log?: Logger,
@@ -555,22 +527,10 @@ export function buildRemuxArgs(
 
   const userPickedAudio = audioStreamIndex != null && audioStreamIndex > 0;
   if (videoOnly && !userPickedAudio) {
-    // Video-only remux for fMP4 var_stream_map (audio served separately).
+    // Video-only remux for var_stream_map (audio served separately).
     args.push('-map', '0:v:0', '-c:v', 'copy', '-an');
   } else if (userPickedAudio) {
     args.push('-map', '0:v:0', '-map', `0:a:${audioStreamIndex}`, '-c:v', 'copy');
-    if (copyAudio) {
-      args.push('-c:a', 'copy');
-    } else {
-      args.push('-c:a', 'aac', '-b:a', audioBitrate, '-ac', '2');
-    }
-  } else if (mapAllAudio && audioStreams && audioStreams.length > 1) {
-    args.push('-map', '0:v:0', '-c:v', 'copy');
-    for (let i = 0; i < audioStreams.length; i++) {
-      args.push('-map', `0:a:${i}`);
-      const lang = audioStreams[i].language;
-      if (lang) args.push(`-metadata:s:a:${i}`, `language=${lang}`);
-    }
     if (copyAudio) {
       args.push('-c:a', 'copy');
     } else {
@@ -585,24 +545,15 @@ export function buildRemuxArgs(
     }
   }
 
-  // HLS output — fMP4 or TS based on useFmp4
   args.push(
     '-f', 'hls',
     '-hls_time', String(SEGMENT_DURATION),
     '-hls_init_time', String(INIT_TIME),
     '-hls_list_size', '0',
     '-start_number', String(startSegment),
-  );
-  if (useFmp4) {
-    args.push(
-      '-hls_segment_type', 'fmp4',
-      '-hls_fmp4_init_filename', 'init.mp4',
-      '-hls_segment_filename', path.join(outputDir, 'seg-%04d.m4s'),
-    );
-  } else {
-    args.push('-hls_segment_filename', path.join(outputDir, 'seg-%04d.ts'));
-  }
-  args.push(
+    '-hls_segment_type', 'fmp4',
+    '-hls_fmp4_init_filename', 'init.mp4',
+    '-hls_segment_filename', path.join(outputDir, 'seg-%04d.m4s'),
     '-hls_flags', 'independent_segments',
     path.join(outputDir, 'index.m3u8'),
   );

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -498,9 +498,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
           audioStreamIndex: ctx?.audioStreamIndex,
           crop: ctx?.crop,
           videoOnly: isVideoOnly,
-          mapAllAudio: ctx?.mapAllAudio ?? false,
           audioStreams: ctxAudioStreams,
-          useFmp4: ctx?.useFmp4 ?? true,
           copyAudio: ctx?.copyAudio ?? false,
           encoderPreset: ctx?.encoderPreset,
           qsvOptions: ctx?.qsvOptions,
@@ -517,7 +515,6 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
 
       const usesVarStreamMap =
         isVideoOnly && ctxAudioStreams && ctxAudioStreams.length > 1;
-      const useFmp4 = ctx?.useFmp4 ?? true;
       const session = this.spawnFfmpegSession({
         id,
         mediaFileId,
@@ -525,7 +522,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         args,
         sessionDir,
         startSegment: 0,
-        segExt: useFmp4 ? '.m4s' : '.ts',
+        segExt: '.m4s',
         segSubDir: usesVarStreamMap ? '0' : undefined,
         extra: { actualHwAccel: this.detectedHwAccel },
       });
@@ -542,7 +539,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     for (let i = 0; i < 120; i++) {
       if (await fileExists(playlistPath)) {
         const content = await fsp.readFile(playlistPath, 'utf-8');
-        if (content.includes('.ts') || content.includes('.m4s')) return content;
+        if (content.includes('.m4s')) return content;
       }
       await new Promise((r) => setTimeout(r, 500));
     }
@@ -754,7 +751,6 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
   ): TranscodeSession {
     const isVideoOnly = ctx?.videoOnly ?? false;
     const audioStreams = ctx?.audioStreams;
-    const useFmp4 = ctx?.useFmp4 ?? true;
 
     const args = buildFfmpegArgs(
       {
@@ -768,9 +764,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         audioStreamIndex: ctx?.audioStreamIndex,
         crop: ctx?.crop,
         videoOnly: isVideoOnly,
-        mapAllAudio: ctx?.mapAllAudio ?? false,
         audioStreams,
-        useFmp4,
         copyAudio: ctx?.copyAudio ?? false,
         encoderPreset: ctx?.encoderPreset,
         qsvOptions: ctx?.qsvOptions,
@@ -782,7 +776,6 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
 
     const usesVarStreamMap =
       isVideoOnly && audioStreams && audioStreams.length > 1;
-    const segExt = useFmp4 ? '.m4s' : '.ts';
     return this.spawnFfmpegSession({
       id: sessionId,
       mediaFileId,
@@ -790,7 +783,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       args,
       sessionDir,
       startSegment,
-      segExt,
+      segExt: '.m4s',
       segSubDir: usesVarStreamMap ? '0' : undefined,
       extra: { actualHwAccel: hwAccel },
     });
@@ -960,9 +953,6 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       '192k',
       requestedSegment,
       isVideoOnly,
-      ctx?.mapAllAudio ?? false,
-      ctx?.audioStreams,
-      ctx?.useFmp4 ?? true,
       ctx?.trustedStreamInfo,
       ctx?.audioStreamIndex,
       this.log,

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -35,12 +35,8 @@ export interface SessionContext {
   crop?: { width: number; height: number; x: number; y: number };
   /** When true, produce video-only segments (audio served separately via EXT-X-MEDIA) */
   videoOnly?: boolean;
-  /** When true, mux ALL audio tracks into the output (for native players like ExoPlayer) */
-  mapAllAudio?: boolean;
   /** Audio stream info for multi-audio var_stream_map (single FFmpeg process) */
   audioStreams?: { language?: string; title?: string }[];
-  /** Whether to use fMP4 segments (true) or MPEG-TS (false, for Cast) */
-  useFmp4?: boolean;
   /** Client device category — selects the per-device bitrate ladder. */
   deviceType?: DeviceType;
   /**

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -918,9 +918,6 @@
     "streaming": {
       "title": "Streaming",
       "description": "Configuration du format et de la taille des segments HLS. Affecte la vitesse de démarrage et le changement de qualité.",
-      "segment_format": "Format de segment",
-      "format_auto": "Auto (TS single-audio, fMP4 multi-audio)",
-      "segment_format_help": "TS est plus rapide au démarrage (pas d'init.mp4). fMP4 est nécessaire pour le multi-audio séparé (EXT-X-MEDIA).",
       "segment_duration": "Durée des segments",
       "segment_duration_help": "Segments plus courts = démarrage plus rapide mais plus de requêtes HTTP. 3s est un bon compromis.",
       "init_time": "Durée du premier segment",

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -76,10 +76,6 @@ export interface PlaybackInfoResponse {
   };
   /** Embedded chapters from the container (MKV/MP4). */
   chapters?: { startSeconds: number; endSeconds: number; title?: string }[];
-  /** HLS segment format decided by admin setting + client capability.
-   *  fmp4 supports EXT-X-MEDIA multi-audio (client-side switch); TS doesn't
-   *  (switching audio requires a backend reload). */
-  segmentFormat?: 'fmp4' | 'ts';
 }
 
 export interface MediaResumeInfo {

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -37,14 +37,7 @@ export interface DeviceProfile {
   codecConditions: CodecCondition[];
   maxStreamingBitrate: number;
   maxAudioChannels: number;
-  supportsHlsFmp4: boolean;
-  supportsHlsTs: boolean;
   supportsHdr: boolean;
-  /** True when HDR playback requires fMP4 segments (HEVC can't be carried in TS).
-   *  iOS AVPlayer needs this; Android ExoPlayer handles HEVC in TS fine. */
-  hdrRequiresFmp4: boolean;
-  /** True when the player handles multi-audio from muxed TS (ExoPlayer). False = use EXT-X-MEDIA. */
-  supportsMultiAudioMuxed: boolean;
   /** Client device category — selects the backend bitrate ladder.
    *  Capacitor native (iOS/Android app) → 'mobile'; web (incl. Cast sender) → 'desktop'. */
   deviceType: 'mobile' | 'desktop';
@@ -195,15 +188,6 @@ export class BrowserDeviceProfileService {
       maxAudioChannels = Math.max(maxAudioChannels, this.nativeAudio.maxChannels);
     }
 
-    // --- HLS support ---
-    const supportsHlsTs = this.testType(video, false, 'application/x-mpegURL') ||
-                           this.testType(video, false, 'application/vnd.apple.mpegurl');
-    // On web, fMP4 requires MSE (Shaka/hls.js). On native platforms
-    // (Capacitor), AVPlayer/ExoPlayer handle fMP4 HLS natively — no MSE
-    // needed. Without this, iOS gets HLS-TS which can't carry HEVC (HDR
-    // content is typically HEVC 10-bit → AVPlayer crash).
-    const supportsHlsFmp4 = hasMSE || Capacitor.isNativePlatform();
-
     // --- HDR support ---
     let supportsHdr: boolean;
     if (Capacitor.isNativePlatform()) {
@@ -224,16 +208,7 @@ export class BrowserDeviceProfileService {
       codecConditions,
       maxStreamingBitrate: 0, // 0 = no limit
       maxAudioChannels,
-      supportsHlsFmp4,
-      supportsHlsTs,
       supportsHdr,
-      // iOS AVPlayer can't decode HEVC in TS containers — HDR content
-      // (HEVC 10-bit) must be delivered via fMP4 or tonemapped to H264 SDR.
-      // Android ExoPlayer handles HEVC in TS fine.
-      hdrRequiresFmp4: Capacitor.getPlatform() === 'ios',
-      // Multi-audio in muxed TS doesn't work reliably (ExoPlayer can't switch PIDs).
-      // Audio switching always goes through server-side reload.
-      supportsMultiAudioMuxed: false,
       deviceType: Capacitor.isNativePlatform() ? 'mobile' : 'desktop',
     };
   }

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1542,18 +1542,15 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       return;
     }
 
-    // si-* tracks are the streamInfo fallback. For fMP4 HLS, the manifest
-    // always exposes every audio rendition via EXT-X-MEDIA so Shaka switches
+    // si-* tracks are the streamInfo fallback. For HLS, the manifest always
+    // exposes every audio rendition via EXT-X-MEDIA so Shaka switches
     // client-side — any transient si-* list upgrades to shaka-* as soon as
     // Shaka fires trackschanged, and the user picks the real track then.
-    // For TS HLS and direct MP4 play, switching audio requires a backend
-    // reload with a new audioStreamIndex. Offline: no backend.
+    // For direct MP4 play, switching audio requires a backend reload with a
+    // new audioStreamIndex. Offline: no backend.
     if (this.isOfflinePlayback) return;
     if (!trackId.startsWith('si-')) return;
-    const isFmp4Hls =
-      this.playbackMode() !== 'direct' &&
-      this.playbackInfo?.segmentFormat === 'fmp4';
-    if (!isFmp4Hls) {
+    if (this.playbackMode() === 'direct') {
       await this.reloadStream();
     }
   }

--- a/client/src/app/features/settings/streaming/streaming.html
+++ b/client/src/app/features/settings/streaming/streaming.html
@@ -5,17 +5,6 @@
     <h2 class="text-xl font-semibold">{{ 'settings.streaming.title' | translate }}</h2>
     <p class="text-base-content/60">{{ 'settings.streaming.description' | translate }}</p>
 
-    <!-- Segment format -->
-    <div class="form-control">
-      <label class="label"><span class="label-text font-medium">{{ 'settings.streaming.segment_format' | translate }}</span></label>
-      <select class="select select-bordered w-full" [ngModel]="segmentFormat()" (ngModelChange)="segmentFormat.set($event)">
-        <option value="auto">{{ 'settings.streaming.format_auto' | translate }}</option>
-        <option value="ts">MPEG-TS</option>
-        <option value="fmp4">fMP4</option>
-      </select>
-      <label class="label"><span class="label-text-alt text-base-content/50">{{ 'settings.streaming.segment_format_help' | translate }}</span></label>
-    </div>
-
     <!-- Segment duration -->
     <div class="form-control">
       <label class="label"><span class="label-text font-medium">{{ 'settings.streaming.segment_duration' | translate }}</span></label>

--- a/client/src/app/features/settings/streaming/streaming.ts
+++ b/client/src/app/features/settings/streaming/streaming.ts
@@ -18,7 +18,6 @@ export class StreamingSettingsComponent implements OnInit {
   readonly loading = signal(true);
   readonly saving = signal(false);
 
-  readonly segmentFormat = signal('auto');
   readonly segmentDuration = signal('3');
   readonly initTime = signal('1');
   readonly qsvPreset = signal('faster');
@@ -29,7 +28,6 @@ export class StreamingSettingsComponent implements OnInit {
   async ngOnInit() {
     try {
       const all = await this.api.getAll();
-      this.segmentFormat.set(all['streaming_segment_format'] ?? 'auto');
       this.segmentDuration.set(all['streaming_segment_duration'] ?? '3');
       this.initTime.set(all['streaming_init_time'] ?? '1');
       this.qsvPreset.set(all['streaming_qsv_preset'] ?? 'faster');
@@ -49,7 +47,6 @@ export class StreamingSettingsComponent implements OnInit {
     this.saving.set(true);
     try {
       await this.api.setBulk({
-        streaming_segment_format: this.segmentFormat(),
         streaming_segment_duration: this.segmentDuration(),
         streaming_init_time: this.initTime(),
         streaming_qsv_preset: this.qsvPreset(),


### PR DESCRIPTION
## Summary
All current clients speak fMP4 HLS (web Shaka, iOS AVPlayer, Android ExoPlayer, Cast receiver via \`useShakaForHls\`). TS was a legacy fallback for the old MPL Cast receiver that's no longer in our path.

This unifies the transcoding pipeline on fMP4: every \`useFmp4\` branch, every TS-specific flag (\`supportsHlsFmp4\`, \`supportsHlsTs\`, \`hdrRequiresFmp4\`, \`supportsMultiAudioMuxed\`), the \`segmentFormat\` admin setting, the HDR-via-TS-blocked fallback, and the segment-name regex tolerance for \`.ts\` are gone.

Net: 15 files, +63 / -256.

## Test plan
- [ ] Apply migration \`DropStreamingSegmentFormat1778011000000\`
- [ ] Web playback (Shaka): variant playlist serves \`.m4s\` segments + \`init.mp4\`, master.m3u8 advertises EXT-X-MEDIA on multi-audio files, ABR + audio switching still work
- [ ] Cast: master.m3u8 → \`.m4s\` segments through receiver Shaka, multi-audio renditions visible
- [ ] iOS / Android native: AVPlayer / ExoPlayer load fMP4 HLS without regression
- [ ] Settings → Streaming: segment-format selector is gone, other knobs still work