### PR TITLE
fix(cast): route every play button through PlayableMediaService

### DIFF
--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -8,8 +8,7 @@ import { MediaService, Media, CalendarEntry } from '../../core/services/api/medi
 import { StreamingApiService, ContinueWatchingItem, RecommendationItem } from '../../core/services/api/streaming-api.service';
 import { LibrariesApiService, LibrarySummary } from '../../core/services/api/libraries-api.service';
 import { ConfirmationService } from '../../core/services/confirmation.service';
-import { CastService } from '../../core/services/cast.service';
-import { CastPlayerService } from '../../core/services/cast-player.service';
+import { PlayableMediaService } from '../../core/services/playable-media.service';
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
 import { FocusMemoryService } from '../../core/services/focus-memory.service';
 import { NavbarService } from '../../core/services/navbar.service';
@@ -68,8 +67,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly streamingApi = inject(StreamingApiService);
   private readonly confirmation = inject(ConfirmationService);
   private readonly router = inject(Router);
-  private readonly castService = inject(CastService);
-  private readonly castPlayer = inject(CastPlayerService);
+  private readonly playableMedia = inject(PlayableMediaService);
   private readonly librariesApi = inject(LibrariesApiService);
   private readonly scrollMemory = inject(ScrollMemoryService);
   private readonly focusMemory = inject(FocusMemoryService);
@@ -280,30 +278,28 @@ export class HomeComponent implements OnInit, OnDestroy {
         void this.router.navigate(['/' + segment, media.id]);
         return;
       }
-      const qp: Record<string, number> = { mediaId: media.id };
-      if (file.episodeId) qp['episodeId'] = file.episodeId;
-      void this.router.navigate(['/watch', file.id], { queryParams: qp });
+      await this.playableMedia.play({
+        fileId: file.id,
+        mediaId: media.id,
+        episodeId: file.episodeId ?? undefined,
+        title: media.title,
+        fanartUrl: media.fanartUrl ?? media.posterUrl ?? null,
+        streamInfo: (file as any).streamInfo,
+      }, false);
     } catch {
       /* error handled by global interceptor */
     }
   }
 
   async playContinueWatching(item: ContinueWatchingItem) {
-    if (this.castService.isConnected()) {
-      await this.castPlayer.quickStart({
-        mediaFileId: item.mediaFileId,
-        mediaId: item.mediaId,
-        episodeId: item.episodeId ?? undefined,
-        title: item.mediaTitle,
-        episodeTitle: item.episodeLabel ?? undefined,
-        fanartUrl: item.fanartUrl ?? item.posterUrl,
-      });
-      this.castPlayer.expanded.set(true);
-    } else {
-      const qp: Record<string, number> = { mediaId: item.mediaId };
-      if (item.episodeId) qp['episodeId'] = item.episodeId;
-      this.router.navigate(['/watch', item.mediaFileId], { queryParams: qp });
-    }
+    await this.playableMedia.play({
+      fileId: item.mediaFileId,
+      mediaId: item.mediaId,
+      episodeId: item.episodeId ?? undefined,
+      title: item.mediaTitle,
+      episodeTitle: item.episodeLabel ?? undefined,
+      fanartUrl: item.fanartUrl ?? item.posterUrl ?? null,
+    }, false);
   }
 
   async removeContinueWatching(item: ContinueWatchingItem) {

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -6,7 +6,6 @@ import {
   input,
   output,
 } from '@angular/core';
-import { Router } from '@angular/router';
 import { UpperCasePipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
@@ -29,6 +28,7 @@ import {
   seasonsVisibleWithDiskFilter,
 } from '../../media-detail.utils';
 import { METADATA_PROVIDER_OPTIONS_OVERRIDE } from '../../../../core/constants/metadata-providers';
+import { PlayableMediaService } from '../../../../core/services/playable-media.service';
 
 
 @Component({
@@ -38,7 +38,7 @@ import { METADATA_PROVIDER_OPTIONS_OVERRIDE } from '../../../../core/constants/m
   templateUrl: './media-detail-seasons.component.html',
 })
 export class MediaDetailSeasonsComponent {
-  private readonly router = inject(Router);
+  private readonly playableMedia = inject(PlayableMediaService);
   readonly media = input.required<Media>();
   readonly selectedSeason = input<Season | null>(null);
   readonly activeSeasonId = input.required<number | null>();
@@ -118,17 +118,16 @@ export class MediaDetailSeasonsComponent {
 
   playEpisode(ep: Episode) {
     const files = this.trackedFilesForEpisode(ep.id);
-    if (files.length) {
-      const m = this.media();
-      // Detour via '/' forces Angular to remount the player component
-      // (same-route navigation reuses the component without re-reading params).
-      void this.router
-        .navigateByUrl('/', { skipLocationChange: true })
-        .then(() =>
-          this.router.navigate(['/watch', files[0].id], {
-            queryParams: { mediaId: m.id, episodeId: ep.id },
-          }),
-        );
-    }
+    if (!files.length) return;
+    const m = this.media();
+    void this.playableMedia.play({
+      fileId: files[0].id,
+      mediaId: m.id,
+      episodeId: ep.id,
+      title: m.title,
+      episodeTitle: ep.title ?? undefined,
+      fanartUrl: m.fanartUrl ?? null,
+      streamInfo: (files[0] as any).streamInfo,
+    }, false);
   }
 }

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -11,6 +11,7 @@ import { CardActionsDirective } from '../../directives/card-actions.directive';
 import { CardAction, CardActionsService } from '../../../core/services/card-actions.service';
 import { TvService } from '../../../core/services/tv.service';
 import { DeviceService } from '../../../core/services/device.service';
+import { PlayableMediaService } from '../../../core/services/playable-media.service';
 
 export type MediaCardAspect = 'portrait' | 'landscape';
 
@@ -38,6 +39,7 @@ export class MediaCardComponent {
   private readonly router = inject(Router);
   private readonly tv = inject(TvService);
   private readonly cardActionsService = inject(CardActionsService);
+  private readonly playableMedia = inject(PlayableMediaService);
   protected readonly device = inject(DeviceService);
   protected readonly isNative = Capacitor.isNativePlatform();
   /** Hover overlay (play button) only makes sense on a real pointer device. */
@@ -272,16 +274,16 @@ export class MediaCardComponent {
     this.played.emit();
     this.clicked.emit();
     const m = this.media();
-    if (m?.files?.length) {
-      const file = m.files[0];
-      const qp: Record<string, number> = { mediaId: m.id };
-      if (file.episodeId) qp['episodeId'] = file.episodeId;
-      const fanartUrl = (m as any).fanartUrl ?? this._img() ?? null;
-      void this.router.navigate(['/watch', file.id], {
-        queryParams: qp,
-        state: { fanartUrl },
-      });
-    }
+    if (!m?.files?.length) return;
+    const file = m.files[0];
+    void this.playableMedia.play({
+      fileId: file.id,
+      mediaId: m.id,
+      episodeId: file.episodeId ?? undefined,
+      title: m.title,
+      fanartUrl: (m as any).fanartUrl ?? this._img() ?? null,
+      streamInfo: (file as any).streamInfo,
+    }, false);
   }
 
   /**


### PR DESCRIPTION
## Summary
The play buttons on media cards, recommendation rows, and the episode list each had their own \`router.navigate(['/watch', …])\` instead of going through \`PlayableMediaService.play\` — so when Cast was connected, clicking play landed on a blank \`/watch\` page (the player tries to start while the receiver gets nothing).

\`PlayableMediaService.play\` already encapsulates the cast-vs-watch routing. Centralize on it: media-card.onPlayClick, home.playRecommendation, home.playContinueWatching, media-detail-seasons.playEpisode.

Drops the now-unused \`CastService\` / \`CastPlayerService\` injections from \`home.ts\` and the \`Router\` injection from the seasons component.

## Test plan
- [ ] Cast connected → click play on a library media-card → casts (no blank page)
- [ ] Same on a recommendation card and on a Continue Watching card
- [ ] Same on an episode in the seasons list of a series detail page
- [ ] Cast disconnected → all four paths still navigate to /watch as before