### PR TITLE
fix(cast): client-side audio switch on Android (no reload)

### DIFF
--- a/client/android/app/src/main/java/media/fliks/app/CastPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/CastPlugin.java
@@ -493,6 +493,88 @@ public class CastPlugin extends Plugin {
         });
     }
 
+    /**
+     * Switch the active audio rendition on the receiver via the standard
+     * media bus (setActiveMediaTracks → EDIT_TRACKS_INFO). The receiver
+     * mirrors Shaka's HLS audio renditions into MediaInformation as
+     * AUDIO tracks, so Cast SDK's track-selection API drives the swap
+     * client-side without an ffmpeg restart.
+     *
+     * Resolves with {@code success: false} when no matching track is
+     * found — caller falls back to a full reload in that case.
+     */
+    @PluginMethod()
+    public void setActiveAudioLanguage(PluginCall call) {
+        runOnMainThread(() -> {
+            String language = call.getString("language", "");
+            String name = call.getString("name", "");
+            RemoteMediaClient client = getClient();
+            if (client == null) {
+                call.resolve(new JSObject().put("success", false));
+                return;
+            }
+            // Prefer MediaStatus' MediaInfo: it reflects receiver-side
+            // setMediaInformation() updates (where the audio renditions are
+            // published). Fall back to client.getMediaInfo() for safety.
+            MediaInfo mediaInfo = client.getMediaStatus() != null
+                ? client.getMediaStatus().getMediaInfo()
+                : null;
+            if (mediaInfo == null) mediaInfo = client.getMediaInfo();
+            List<MediaTrack> tracks = mediaInfo != null ? mediaInfo.getMediaTracks() : null;
+            if (tracks == null || tracks.isEmpty()) {
+                call.resolve(new JSObject().put("success", false));
+                return;
+            }
+            // Match by NAME first: Shaka rewrites manifest LANGUAGE from
+            // ISO 639-2 (eng) to ISO 639-1 (en) before exposing renditions,
+            // so plain language equality fails on 3-letter sources. The
+            // NAME emitted in master.m3u8 (track title or language fallback)
+            // is preserved verbatim.
+            MediaTrack target = null;
+            for (MediaTrack t : tracks) {
+                if (t.getType() == MediaTrack.TYPE_AUDIO && name.equals(t.getName())) {
+                    target = t;
+                    break;
+                }
+            }
+            if (target == null) {
+                for (MediaTrack t : tracks) {
+                    if (t.getType() == MediaTrack.TYPE_AUDIO && language.equals(t.getLanguage())) {
+                        target = t;
+                        break;
+                    }
+                }
+            }
+            if (target == null) {
+                call.resolve(new JSObject().put("success", false));
+                return;
+            }
+            // Preserve any active text track — setActiveMediaTracks replaces
+            // the whole active set in one shot, mirroring the web's
+            // applyActiveTracks union semantics.
+            long textId = -1;
+            if (client.getMediaStatus() != null) {
+                long[] active = client.getMediaStatus().getActiveTrackIds();
+                if (active != null) {
+                    for (long id : active) {
+                        for (MediaTrack t : tracks) {
+                            if (t.getId() == id && t.getType() == MediaTrack.TYPE_TEXT) {
+                                textId = id;
+                                break;
+                            }
+                        }
+                        if (textId >= 0) break;
+                    }
+                }
+            }
+            long[] newActive = textId >= 0
+                ? new long[] { target.getId(), textId }
+                : new long[] { target.getId() };
+            client.setActiveMediaTracks(newActive);
+            call.resolve(new JSObject().put("success", true));
+        });
+    }
+
     private RemoteMediaClient getClient() {
         if (Looper.myLooper() != Looper.getMainLooper()) {
             Log.w(TAG, "getClient() must run on main thread");

--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -336,10 +336,11 @@ export class CastPlayerService {
     this.activeAudioTrackId.set(trackId);
 
     // Fast path: switch the active audio rendition via EditTracksInfoRequest
-    // on the standard media bus. Sub-100ms swap, no ffmpeg restart. Native
-    // Cast plugin falls through to a full reload.
+    // (web) or RemoteMediaClient.setActiveMediaTracks (native) on the
+    // standard media bus. Sub-100ms swap, no ffmpeg restart. Falls through
+    // to a full reload when the receiver hasn't published the rendition yet.
     const audio = this.availableAudioTracks()[audioIndex];
-    if (audio && this.cast.setActiveAudioLanguage(audio.language, audio.name)) {
+    if (audio && (await this.cast.setActiveAudioLanguage(audio.language, audio.name))) {
       return;
     }
 

--- a/client/src/app/core/services/cast.service.ts
+++ b/client/src/app/core/services/cast.service.ts
@@ -53,6 +53,7 @@ interface NativeCastPlugin {
   stop(): Promise<void>;
   disconnect(): Promise<void>;
   setActiveSubtitle(opts: { trackId: number }): Promise<void>;
+  setActiveAudioLanguage(opts: { language: string; name: string }): Promise<{ success: boolean }>;
 }
 
 const NativeCast = registerPlugin<NativeCastPlugin>('NativeCast');
@@ -345,10 +346,21 @@ export class CastService implements OnDestroy {
    * Switch the active audio rendition by language + name through the
    * standard CAF media bus. The receiver mirrors Shaka's HLS audio
    * renditions into MediaInformation with type=AUDIO so each becomes a
-   * regular CAF Track addressable via EditTracksInfoRequest.
+   * regular CAF Track addressable via EditTracksInfoRequest (web) or
+   * RemoteMediaClient.setActiveMediaTracks (native).
+   *
+   * Returns false when no matching track is found — caller falls back
+   * to a full ffmpeg-restart reload in that case.
    */
-  setActiveAudioLanguage(language: string, name: string): boolean {
-    if (this.isNative) return false;
+  async setActiveAudioLanguage(language: string, name: string): Promise<boolean> {
+    if (this.isNative) {
+      try {
+        const { success } = await NativeCast.setActiveAudioLanguage({ language, name });
+        return success;
+      } catch {
+        return false;
+      }
+    }
     const session = cast.framework.CastContext.getInstance().getCurrentSession?.();
     const media = session?.getMediaSession?.();
     if (!media?.media) return false;


### PR DESCRIPTION
## Summary

- Mirror the web's fast audio-switch path on Android: instead of reloading the stream (full ffmpeg restart), `changeAudio` now sends `setActiveMediaTracks` on the standard CAF media bus, the same mechanism the receiver already exposes via Shaka rendition mirroring.
- New `setActiveAudioLanguage` plugin method on `CastPlugin.java` matches by NAME first (Shaka rewrites manifest LANGUAGE 639-2 → 639-1), preserves the active TEXT track, and falls back to a full reload when no rendition matches.
- `CastService.setActiveAudioLanguage` is now `Promise<boolean>` so web and native share one call site in `CastPlayerService.changeAudio`.

## Test plan

- [ ] Cast a multi-audio movie from the Android app, switch language → audio swaps without buffering / black frame.
- [ ] Switch language while a subtitle track is active → subtitle stays on.
- [ ] Cast the same media from a browser → unchanged behaviour (regression check).
- [ ] Force a "no match" path (e.g. cast before the receiver publishes renditions) → falls back to reload, no crash.