### PR TITLE
fix(cast): align HLS playlist with hls_init_time + tune Shaka receiver

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -27,6 +27,7 @@ import {
   SessionContext,
   getLadderForDevice,
 } from './transcoding';
+import { secondsToSegmentIndex } from './transcoding/constants';
 import { ThumbnailService } from './thumbnail.service';
 import { StreamBuilderService } from './stream-builder.service';
 import { ActiveStreamTracker } from './active-stream-tracker.service';
@@ -52,30 +53,54 @@ function withTimestampMap(vtt: string | Buffer): string {
 }
 
 /** Generate a VOD HLS playlist for a given duration and segment URL pattern. */
-/** Default segment duration — overridden by admin streaming settings via tracker. */
+/** Default segment + init durations — overridden by admin streaming settings. */
 let SEG_DURATION = 3;
+let INIT_TIME = 1;
 
 function buildVodPlaylist(
   duration: number,
   segmentUrl: (index: string) => string,
   initUrl?: string,
 ): string {
+  // FFmpeg `-hls_init_time` shortens segment 0 to ~INIT_TIME so the first
+  // frame ships sooner; remaining segments are SEG_DURATION. The EXTINF
+  // values below mirror that layout so Shaka's presentation timeline stays
+  // aligned with the moof PTS the segments actually carry.
+  const useShortInit = INIT_TIME > 0 && INIT_TIME < SEG_DURATION;
   // Subtract small epsilon before ceil to avoid phantom last segment when
   // ffprobe duration has floating-point imprecision (e.g. 120.001 → ceil
   // produces 41 segments but FFmpeg only writes 40).
-  const segCount = Math.max(1, Math.ceil((duration - 0.05) / SEG_DURATION));
+  const epsilon = 0.05;
+  const tail = Math.max(0, duration - (useShortInit ? INIT_TIME : 0) - epsilon);
+  const tailCount = Math.ceil(tail / SEG_DURATION);
+  const segCount = Math.max(1, (useShortInit ? 1 : 0) + tailCount);
   const lines = [
     '#EXTM3U',
     '#EXT-X-VERSION:7',
-    `#EXT-X-TARGETDURATION:${SEG_DURATION}`,
+    `#EXT-X-TARGETDURATION:${Math.ceil(SEG_DURATION)}`,
     '#EXT-X-MEDIA-SEQUENCE:0',
     '#EXT-X-PLAYLIST-TYPE:VOD',
+    '#EXT-X-INDEPENDENT-SEGMENTS',
   ];
   if (initUrl) {
     lines.push(`#EXT-X-MAP:URI="${initUrl}"`);
   }
   for (let i = 0; i < segCount; i++) {
-    const segLen = Math.min(SEG_DURATION, duration - i * SEG_DURATION);
+    let segStart: number;
+    let segLen: number;
+    if (useShortInit) {
+      if (i === 0) {
+        segStart = 0;
+        segLen = Math.min(INIT_TIME, duration);
+      } else {
+        segStart = INIT_TIME + (i - 1) * SEG_DURATION;
+        segLen = Math.min(SEG_DURATION, duration - segStart);
+      }
+    } else {
+      segStart = i * SEG_DURATION;
+      segLen = Math.min(SEG_DURATION, duration - segStart);
+    }
+    if (segLen <= 0) break;
     lines.push(`#EXTINF:${segLen.toFixed(3)},`);
     lines.push(segmentUrl(String(i).padStart(4, '0')));
   }
@@ -223,10 +248,7 @@ export class StreamingController {
         const top = ladder.find((p) => p.maxWidth <= sourceW) ?? ladder[0];
         targetQuality = top.name;
       }
-      const startSegment = Math.max(
-        0,
-        Math.floor(effectiveStartAt / SEG_DURATION),
-      );
+      const startSegment = Math.max(0, secondsToSegmentIndex(effectiveStartAt));
 
       // Spawn early en PARALLÈLE de main (fire-and-forget). hlsSegment
       // routera vers cette session pour seg-0 via isEarlyProbe pendant
@@ -412,6 +434,7 @@ export class StreamingController {
     );
     // Update module-level constants used by buildVodPlaylist and transcoding
     SEG_DURATION = ss.segmentDuration;
+    INIT_TIME = ss.initTime;
     this.transcodingService.setSegmentDurations(
       ss.segmentDuration,
       ss.initTime,
@@ -828,9 +851,7 @@ export class StreamingController {
       return;
     }
 
-    const contentType =
-      segment === 'init.mp4' ? 'video/mp4' : 'video/iso.segment';
-    res.setHeader('Content-Type', contentType);
+    res.setHeader('Content-Type', 'video/mp4');
     res.setHeader('Access-Control-Allow-Origin', '*');
     const stream = fs.createReadStream(segPath);
     stream.on('error', () => {
@@ -881,7 +902,7 @@ export class StreamingController {
       );
       if (!existing || existing.process.exitCode !== null) {
         const startAtSec = parseInt(startAtRaw, 10);
-        const startSegment = startAtSec > 0 ? Math.floor(startAtSec / 6) : 0;
+        const startSegment = secondsToSegmentIndex(startAtSec);
         const ctx = this.buildSessionContext(req, resolved, mediaFileId);
         if (quality === 'remux') {
           const copyAudio =

--- a/backend/src/modules/streaming/transcoding/constants.ts
+++ b/backend/src/modules/streaming/transcoding/constants.ts
@@ -21,3 +21,31 @@ export function setSegmentDurations(seg: number, init: number): void {
   segmentDuration = seg;
   initTime = init;
 }
+
+/** True when `-hls_init_time` actually shortens segment 0 (FFmpeg ignores it
+ *  when init >= segment duration). */
+export function useShortInitSegment(
+  init = initTime,
+  seg = segmentDuration,
+): boolean {
+  return init > 0 && init < seg;
+}
+
+/** Convert a presentation time (seconds) to the FFmpeg segment number that
+ *  contains it. Mirrors `-hls_init_time`: seg-0 holds [0, INIT_TIME],
+ *  seg-N>=1 holds [INIT_TIME + (N-1)*SEG, INIT_TIME + N*SEG]. */
+export function secondsToSegmentIndex(seconds: number): number {
+  if (seconds <= 0) return 0;
+  if (!useShortInitSegment()) {
+    return Math.floor(seconds / segmentDuration);
+  }
+  if (seconds < initTime) return 0;
+  return 1 + Math.floor((seconds - initTime) / segmentDuration);
+}
+
+/** Inverse of `secondsToSegmentIndex` — start time of an FFmpeg segment. */
+export function segmentIndexToSeconds(segment: number): number {
+  if (segment <= 0) return 0;
+  if (!useShortInitSegment()) return segment * segmentDuration;
+  return initTime + (segment - 1) * segmentDuration;
+}

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -1,6 +1,10 @@
 import { Logger } from '@nestjs/common';
 import * as path from 'path';
-import { getInitTime, getSegmentDuration } from './constants';
+import {
+  getInitTime,
+  getSegmentDuration,
+  segmentIndexToSeconds,
+} from './constants';
 import { parseBitrateToBps } from './profiles';
 import type {
   BurnInSubtitle,
@@ -97,8 +101,10 @@ export function buildFfmpegArgs(
   }
 
   if (startSegment > 0) {
-    const seekSeconds = startSegment * SEGMENT_DURATION;
-    args.push('-ss', String(seekSeconds));
+    // -hls_init_time skews the segment-N → seconds map (seg-0 = INIT_TIME,
+    // seg-N>=1 = INIT_TIME + (N-1)*SEG_DURATION); seek to that exact start
+    // so the resumed encode picks up at the cached segment grid.
+    args.push('-ss', String(segmentIndexToSeconds(startSegment)));
     args.push('-copyts', '-avoid_negative_ts', 'make_zero');
   }
 
@@ -466,7 +472,7 @@ export function buildAudioOnlyFfmpegArgs(
   }
 
   if (startSegment > 0) {
-    args.push('-ss', String(startSegment * SEGMENT_DURATION));
+    args.push('-ss', String(segmentIndexToSeconds(startSegment)));
     args.push('-copyts', '-avoid_negative_ts', 'make_zero');
   }
 
@@ -519,7 +525,7 @@ export function buildRemuxArgs(
   }
 
   if (startSegment > 0) {
-    args.push('-ss', String(startSegment * SEGMENT_DURATION));
+    args.push('-ss', String(segmentIndexToSeconds(startSegment)));
     args.push('-copyts', '-avoid_negative_ts', 'make_zero');
   }
 

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -15,6 +15,7 @@ import {
   SEEK_WAIT_THRESHOLD,
   SESSION_TIMEOUT_MS,
   getSegmentDuration,
+  segmentIndexToSeconds,
   setSegmentDurations as applySegmentDurations,
 } from './constants';
 import {
@@ -180,17 +181,25 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
   ): Promise<number> {
     if (!durationSeconds || durationSeconds <= 0) return 0;
     try {
-      const files = await fsp.readdir(session.cachePath);
+      // var_stream_map sessions write video into a `0/` subdir; fall back to
+      // the session root for single-stream sessions and remux output.
+      const rootDir = session.cachePath;
+      const dirs = [path.join(rootDir, '0'), rootDir];
       let maxSeg = -1;
-      for (const f of files) {
-        const m = f.match(/^seg-(\d+)\.ts$/);
-        if (m) {
-          const n = parseInt(m[1], 10);
-          if (n > maxSeg) maxSeg = n;
+      for (const dir of dirs) {
+        let files: string[];
+        try { files = await fsp.readdir(dir); } catch { continue; }
+        for (const f of files) {
+          const m = f.match(/^seg-(\d+)\.m4s$/);
+          if (m) {
+            const n = parseInt(m[1], 10);
+            if (n > maxSeg) maxSeg = n;
+          }
         }
+        if (maxSeg >= 0) break;
       }
       if (maxSeg < 0) return 0;
-      const transcodedUpTo = (maxSeg + 1) * getSegmentDuration();
+      const transcodedUpTo = segmentIndexToSeconds(maxSeg + 1);
       return Math.min(100, (transcodedUpTo / durationSeconds) * 100);
     } catch {
       return 0;

--- a/cast-receiver/receiver.js
+++ b/cast-receiver/receiver.js
@@ -112,16 +112,25 @@ playerManager.setMessageInterceptor(
       loadRequest.media?.contentType,
     );
     const media = loadRequest.media;
-    if (media && !media.textTrackStyle) {
-      const style = new cast.framework.messages.TextTrackStyle();
-      style.fontGenericFamily =
-        cast.framework.messages.TextTrackFontGenericFamily.SANS_SERIF;
-      style.fontScale = 0.85;
-      style.foregroundColor = '#FFFFFFFF';
-      style.backgroundColor = '#00000000';
-      style.edgeType = cast.framework.messages.TextTrackEdgeType.DROP_SHADOW;
-      style.edgeColor = '#000000FF';
-      media.textTrackStyle = style;
+    if (media) {
+      // Tell CAF the segments are fMP4 so Shaka picks the right HLS
+      // demuxer up-front instead of probing seg-0 with the TS parser
+      // (which fails silently on init.mp4 + .m4s output).
+      media.hlsSegmentFormat =
+        cast.framework.messages.HlsSegmentFormat.FMP4;
+      media.hlsVideoSegmentFormat =
+        cast.framework.messages.HlsVideoSegmentFormat.FMP4;
+      if (!media.textTrackStyle) {
+        const style = new cast.framework.messages.TextTrackStyle();
+        style.fontGenericFamily =
+          cast.framework.messages.TextTrackFontGenericFamily.SANS_SERIF;
+        style.fontScale = 0.85;
+        style.foregroundColor = '#FFFFFFFF';
+        style.backgroundColor = '#00000000';
+        style.edgeType = cast.framework.messages.TextTrackEdgeType.DROP_SHADOW;
+        style.edgeColor = '#000000FF';
+        media.textTrackStyle = style;
+      }
     }
     return loadRequest;
   },
@@ -140,11 +149,73 @@ playerManager.setMessageInterceptor(
 // `supportedCommands` is set explicitly so the sender's transport
 // controls (play/pause/seek/skip-ad) are all advertised.
 
+// Tuned for VOD with a long-running transcoder behind it: deeper buffer
+// goal, larger gap tolerance for the PTS jitter at segment boundaries
+// (`-copyts`), and longer network retry timeout to ride out a transcode
+// cold-start. Mirrors the web player's `engine.configure(...)` budget so
+// the three engines stall under the same conditions.
+const SHAKA_CONFIG = {
+  streaming: {
+    bufferingGoal: 30,
+    rebufferingGoal: 4,
+    bufferBehind: 30,
+    retryParameters: {
+      timeout: 60000,
+      maxAttempts: 6,
+      baseDelay: 1000,
+      backoffFactor: 2,
+      fuzzFactor: 0.5,
+    },
+    stallEnabled: true,
+    stallThreshold: 1,
+    stallSkip: 0.1,
+    gapDetectionThreshold: 0.5,
+    smallGapLimit: 1.5,
+    jumpLargeGaps: true,
+  },
+  manifest: {
+    retryParameters: {
+      timeout: 30000,
+      maxAttempts: 5,
+      baseDelay: 1000,
+      backoffFactor: 2,
+      fuzzFactor: 0.5,
+    },
+    hls: {
+      mediaPlaylistFullMimeType:
+        'video/mp4; codecs="avc1.640028,mp4a.40.2"',
+    },
+  },
+};
+
+// CAF wraps Shaka when `useShakaForHls: true`. The wrapped instance is
+// reachable via `playerManager.getPlayer()`; calling `.configure(...)` on
+// PLAYER_LOADING is the supported hook to override Shaka defaults before
+// the manifest is parsed.
+playerManager.addEventListener(
+  cast.framework.events.EventType.PLAYER_LOADING,
+  () => {
+    try {
+      const shaka = playerManager.getPlayer && playerManager.getPlayer();
+      if (shaka && typeof shaka.configure === 'function') {
+        shaka.configure(SHAKA_CONFIG);
+        console.log('[fliks-cast] Shaka configured');
+      }
+    } catch (err) {
+      console.warn('[fliks-cast] Shaka configure failed', err);
+    }
+  },
+);
+
 const options = new cast.framework.CastReceiverOptions();
 options.disableIdleTimeout = true;
 options.useShakaForHls = true;
 options.playbackConfig = new cast.framework.PlaybackConfig();
 options.playbackConfig.autoResumeDuration = 5;
+// Some CAF builds also accept the Shaka config declaratively on
+// `playbackConfig.shakaConfig`; setting both keeps the receiver robust
+// across SDK versions without relying on a single code path.
+options.playbackConfig.shakaConfig = SHAKA_CONFIG;
 options.supportedCommands = cast.framework.messages.Command.ALL_BASIC_MEDIA;
 context.start(options);
 console.log('[fliks-cast] context.start called');


### PR DESCRIPTION
## Summary
- VOD playlist EXTINF now mirrors FFmpeg's \`-hls_init_time\` (seg-0 = INIT_TIME, seg-N≥1 = SEG_DURATION) so Shaka's presentation timeline stays aligned with the moof PTS the segments actually carry.
- Single helper (\`secondsToSegmentIndex\` / \`segmentIndexToSeconds\`) now drives every segment-index ↔ seconds conversion: VOD playlist, resume seek (\`-ss\`), prewarm, hlsPlaylist startAt, transcode percent. Replaces the previous mix of \`* SEG_DURATION\`, \`/ SEG_DURATION\` and the hardcoded \`/ 6\` in hlsPlaylist.
- Receiver: explicit Shaka config (bufferingGoal=30, rebufferingGoal=4, bufferBehind=30, retryParameters timeout=60s, stall + gap detection on) applied via \`PLAYER_LOADING\` and \`playbackConfig.shakaConfig\`. FMP4 segment-format hint set in the LOAD interceptor.
- \`getTranscodePercent\`: regex \`\\\\.ts$\` → \`\\\\.m4s$\` (was returning 0 since the fMP4 migration), now also reads the \`0/\` subdir of multi-audio var_stream_map sessions.
- Audio segment Content-Type \`video/iso.segment\` → \`video/mp4\`.

## Test plan
- [ ] Cast a 1080p HLS transcode end-to-end past the 16:40 mark — no freeze.
- [ ] Cast resume mid-file (startAt > 0) lands on the right segment, no double-load.
- [ ] Web player still plays without regression (same mapping is used everywhere).
- [ ] Multi-audio source: audio renditions still selectable from the sender; audio segments serve as \`video/mp4\`.
- [ ] Admin streaming dashboard shows non-zero transcode % for an active session.
- [ ] Try \`segmentDuration=6 / initTime=1\` and \`segmentDuration=6 / initTime=6\` — both should play cleanly on Cast.