### PR TITLE
docs(readme): name Plex/Jellyfin/Emby as alternatives in the tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Fliks
 
-Self-hosted media server: organise your media folders into libraries
-and stream them on every screen in the house — adaptive streaming,
-multi-audio and multi-subtitle support, fast Cast-to-TV.
+Self-hosted media server — an alternative to Plex, Jellyfin and Emby.
+Organise your media folders into libraries and stream them on every
+screen in the house, with adaptive streaming, multi-audio and
+multi-subtitle support and fast Cast-to-TV.
 
 NestJS backend, Angular client (web + iOS + Android + Android TV via
 Capacitor; Samsung Tizen and LG webOS targets in progress), custom


### PR DESCRIPTION
## Summary
Restores the comparison line in the README tagline. Naming the established alternatives helps prospective users immediately place what category Fliks fits in, which is what the README's positioning paragraph is for.

## Test plan
- [ ] Confirm the tagline reads cleanly on GitHub.