### PR TITLE
fix(streaming): align A/V tfdt on resume with -output_ts_offset

### DIFF
--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -101,11 +101,23 @@ export function buildFfmpegArgs(
   }
 
   if (startSegment > 0) {
-    // -hls_init_time skews the segment-N → seconds map (seg-0 = INIT_TIME,
-    // seg-N>=1 = INIT_TIME + (N-1)*SEG_DURATION); seek to that exact start
-    // so the resumed encode picks up at the cached segment grid.
-    args.push('-ss', String(segmentIndexToSeconds(startSegment)));
-    args.push('-copyts', '-avoid_negative_ts', 'make_zero');
+    // Two-step timestamp handling so the moof tfdt of seg-K matches the
+    // playlist's presentation time for seg-K (= INIT_TIME + (K-1)*SEG):
+    //
+    //  1. `-ss <T>` before `-i` does an *input* seek that snaps to the
+    //     nearest source IDR at or before T. force_key_frames re-injects
+    //     a clean keyframe at exactly T on the encoder output, so the
+    //     first encoded video frame has output PTS 0 (after FFmpeg's
+    //     natural re-zeroing) — but audio packets sit at the nearest
+    //     audio-frame boundary, ~10–40 ms early.
+    //  2. `-output_ts_offset <T>` shifts every output stream by T. Both
+    //     video and audio inherit the same anchor, so their tfdts agree
+    //     in seg-K and Shaka doesn't end up with one track ~tens of ms
+    //     ahead of the other on resume.
+    const seekSeconds = segmentIndexToSeconds(startSegment);
+    args.push('-ss', String(seekSeconds));
+    args.push('-output_ts_offset', String(seekSeconds));
+    args.push('-avoid_negative_ts', 'make_zero');
   }
 
   // parseBitrateToBps handles both "8M" and "200k" correctly. Using parseInt()*1e6
@@ -472,8 +484,10 @@ export function buildAudioOnlyFfmpegArgs(
   }
 
   if (startSegment > 0) {
-    args.push('-ss', String(segmentIndexToSeconds(startSegment)));
-    args.push('-copyts', '-avoid_negative_ts', 'make_zero');
+    const seekSeconds = segmentIndexToSeconds(startSegment);
+    args.push('-ss', String(seekSeconds));
+    args.push('-output_ts_offset', String(seekSeconds));
+    args.push('-avoid_negative_ts', 'make_zero');
   }
 
   args.push('-i', inputPath);
@@ -525,8 +539,10 @@ export function buildRemuxArgs(
   }
 
   if (startSegment > 0) {
-    args.push('-ss', String(segmentIndexToSeconds(startSegment)));
-    args.push('-copyts', '-avoid_negative_ts', 'make_zero');
+    const seekSeconds = segmentIndexToSeconds(startSegment);
+    args.push('-ss', String(seekSeconds));
+    args.push('-output_ts_offset', String(seekSeconds));
+    args.push('-avoid_negative_ts', 'make_zero');
   }
 
   args.push('-i', inputPath);


### PR DESCRIPTION
## Summary
Resume sessions used \`-ss <T> -copyts -avoid_negative_ts make_zero\`. The input-side \`-ss\` snaps to the nearest source IDR (typically slightly before T), and \`-copyts\` preserves those imprecise source timestamps end-to-end:
- Video gets a fresh keyframe at exactly T thanks to \`-force_key_frames\` → first frame at PTS T.
- Audio packets sit at the nearest audio-frame boundary, ~10–40 ms before T → first audio sample at PTS T - δ.

The two moofs of seg-K therefore carry different tfdts, and Shaka aligns each track on its own tfdt. On Cast — where buffer + HDMI latency stack on top — it surfaces as audible lipsync drift on resume only (fresh play has no \`-ss\` so the bias never appears).

The fix replaces \`-copyts -avoid_negative_ts make_zero\` with \`-output_ts_offset <seekSeconds>\`. Without \`-copyts\`, FFmpeg re-zeroes output PTS to 0 + small per-stream decoder offset; \`-output_ts_offset\` then shifts everything by the same anchor. Both tracks land at the same tfdt for seg-K, matching the playlist's presentation time (\`INIT_TIME + (K-1)*SEG\`) computed in \`buildVodPlaylist\` since #57.

Applied at all three resume call sites in \`ffmpeg-args.ts\`: transcode (\`buildFfmpegArgs\`), audio-only (\`buildAudioOnlyFfmpegArgs\`), remux (\`buildRemuxArgs\`).

## Test plan
- [ ] Resume a multi-audio movie on Android Cast at >1 minute in: A/V stays in sync.
- [ ] Resume on web Shaka: no regression on lipsync.
- [ ] Fresh play (startSegment === 0) is unchanged.
- [ ] Seek backwards/forwards a few times during playback: A/V stays aligned.