### PR TITLE
fix(cast): drop custom Shaka tuning, use CAF defaults

### DIFF
--- a/cast-receiver/receiver.js
+++ b/cast-receiver/receiver.js
@@ -148,74 +148,18 @@ playerManager.setMessageInterceptor(
 // (default 10) — snappier resume after a seek or transient stall.
 // `supportedCommands` is set explicitly so the sender's transport
 // controls (play/pause/seek/skip-ad) are all advertised.
-
-// Tuned for VOD with a long-running transcoder behind it: deeper buffer
-// goal, larger gap tolerance for the PTS jitter at segment boundaries
-// (`-copyts`), and longer network retry timeout to ride out a transcode
-// cold-start. Mirrors the web player's `engine.configure(...)` budget so
-// the three engines stall under the same conditions.
-const SHAKA_CONFIG = {
-  streaming: {
-    bufferingGoal: 30,
-    rebufferingGoal: 4,
-    bufferBehind: 30,
-    retryParameters: {
-      timeout: 60000,
-      maxAttempts: 6,
-      baseDelay: 1000,
-      backoffFactor: 2,
-      fuzzFactor: 0.5,
-    },
-    stallEnabled: true,
-    stallThreshold: 1,
-    stallSkip: 0.1,
-    gapDetectionThreshold: 0.5,
-    smallGapLimit: 1.5,
-    jumpLargeGaps: true,
-  },
-  manifest: {
-    retryParameters: {
-      timeout: 30000,
-      maxAttempts: 5,
-      baseDelay: 1000,
-      backoffFactor: 2,
-      fuzzFactor: 0.5,
-    },
-    hls: {
-      mediaPlaylistFullMimeType:
-        'video/mp4; codecs="avc1.640028,mp4a.40.2"',
-    },
-  },
-};
-
-// CAF wraps Shaka when `useShakaForHls: true`. The wrapped instance is
-// reachable via `playerManager.getPlayer()`; calling `.configure(...)` on
-// PLAYER_LOADING is the supported hook to override Shaka defaults before
-// the manifest is parsed.
-playerManager.addEventListener(
-  cast.framework.events.EventType.PLAYER_LOADING,
-  () => {
-    try {
-      const shaka = playerManager.getPlayer && playerManager.getPlayer();
-      if (shaka && typeof shaka.configure === 'function') {
-        shaka.configure(SHAKA_CONFIG);
-        console.log('[fliks-cast] Shaka configured');
-      }
-    } catch (err) {
-      console.warn('[fliks-cast] Shaka configure failed', err);
-    }
-  },
-);
+//
+// Shaka's own buffering / retry knobs are left at their CAF defaults:
+// Google's official guidance for `useShakaForHls` is "the default values
+// set by the Web Receiver SDK are the recommended values", and the
+// defaults are calibrated against the per-device MediaSource quotas that
+// no override can lift.
 
 const options = new cast.framework.CastReceiverOptions();
 options.disableIdleTimeout = true;
 options.useShakaForHls = true;
 options.playbackConfig = new cast.framework.PlaybackConfig();
 options.playbackConfig.autoResumeDuration = 5;
-// Some CAF builds also accept the Shaka config declaratively on
-// `playbackConfig.shakaConfig`; setting both keeps the receiver robust
-// across SDK versions without relying on a single code path.
-options.playbackConfig.shakaConfig = SHAKA_CONFIG;
 options.supportedCommands = cast.framework.messages.Command.ALL_BASIC_MEDIA;
 context.start(options);
 console.log('[fliks-cast] context.start called');


### PR DESCRIPTION
## Summary
Removes the entire \`SHAKA_CONFIG\` override (bufferingGoal/bufferBehind/retryParameters/stall/gap settings) plus its \`PLAYER_LOADING\` hook and the duplicate \`playbackConfig.shakaConfig\`. The receiver now relies on the CAF defaults, as Google explicitly recommends for \`useShakaForHls\`:

> "The default values set by the Web Receiver SDK are the recommended values."
> — [CAF Shaka Migration Guide](https://developers.google.com/cast/docs/web_receiver/shaka_migration)

The override was pushing the player closer to the per-device MediaSource quotas (30 MB video / 2 MB audio on Chromecast 2nd gen — see [Chrome for Developers — QuotaExceededError](https://developer.chrome.com/blog/quotaexceedederror)), and a larger \`bufferingGoal: 30\` left less headroom on bitrate-spike scenes. Falling back to defaults lets Shaka's built-in recovery (\"disable the problematic stream for 30 s\") operate within its design envelope.

Side-effects:
- Removes the two \`Invalid config, unrecognized key .streaming.smallGapLimit\` / \`.jumpLargeGaps\` warnings (those keys were removed in Shaka 4.9.2-caf2).
- Removes the \`Supplying custom Shaka configurations is not recommended\` notice.
- Keeps the rest untouched: \`useShakaForHls\`, \`disableIdleTimeout\`, \`autoResumeDuration: 5\`, the LOAD interceptor's FMP4 hint + subtitle styling, \`supportedCommands\`, debug logging.

Single-rendition lockout (master playlist filtered to one quality → no fallback when 3017 fires) is a separate backend issue, tracked for a follow-up PR.

## Test plan
- [ ] Cast a 1080p multi-audio episode end-to-end — no 3017 mid-playback at the bitrate-spike scenes that previously triggered it.
- [ ] Resume from mid-file — initial fetch + steady-state playback both work.
- [ ] No \`Invalid config\` / \`Supplying custom Shaka configurations\` lines in chrome://inspect logs.
- [ ] Web Shaka playback unaffected (no shared code touched).