### PR TITLE
feat(cast): forward receiver errors to the sender's toast layer

### DIFF
--- a/cast-receiver/receiver.js
+++ b/cast-receiver/receiver.js
@@ -49,13 +49,41 @@ playerManager.addEventListener(
   );
 });
 
+// Custom message bus the Fliks senders subscribe to so they can surface
+// receiver-side errors in the phone / desktop UI (a stalled stream on the
+// TV would otherwise look like silence on the controlling device).
+const FLIKS_MESSAGE_NAMESPACE = 'urn:x-cast:media.fliks.app';
+const fliksBus = context.getCastMessageBus(
+  FLIKS_MESSAGE_NAMESPACE,
+  cast.framework.system.MessageType.JSON,
+);
+
 // Surface any player error on the device's DevTools console with the full
-// CAF event payload (detailedErrorCode, reason, shaka-side error data).
+// CAF event payload (detailedErrorCode, reason, shaka-side error data),
+// and forward a structured payload to senders so they can show a toast.
 playerManager.addEventListener(
   cast.framework.events.EventType.ERROR,
   (event) => {
     console.error('[fliks-cast] ERROR', JSON.stringify(event));
     document.body.classList.remove('playing');
+    try {
+      const info = playerManager.getMediaInformation();
+      fliksBus.broadcast({
+        kind: 'player_error',
+        at: Date.now(),
+        detailedErrorCode: event.detailedErrorCode,
+        severity: event.severity,
+        shakaErrorCode: event.error?.shakaErrorCode,
+        shakaErrorData: event.error?.shakaErrorData,
+        reason: event.reason,
+        mediaTitle: info?.metadata?.title,
+        mediaSubtitle: info?.metadata?.subtitle,
+        mediaId: info?.customData?.mediaId,
+        episodeId: info?.customData?.episodeId,
+      });
+    } catch (err) {
+      console.warn('[fliks-cast] failed to forward error to senders', err);
+    }
   },
 );
 

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1602,6 +1602,18 @@
     "remove_from_list": "Retirer de cette liste",
     "actions": "Actions"
   },
+  "cast": {
+    "error": {
+      "generic": "Erreur de lecture sur le Chromecast (code {{code}}).",
+      "shaka_1001": "Le Chromecast n'a pas pu joindre le serveur (code 1001).",
+      "shaka_1002": "Délai dépassé en récupérant un segment depuis le Chromecast (code 1002).",
+      "shaka_3015": "Le Chromecast a refusé un fragment (code 3015).",
+      "shaka_3016": "Le Chromecast a rencontré une erreur de décodage vidéo (code 3016).",
+      "shaka_3017": "Le Chromecast a saturé sa mémoire de lecture. Essayez une qualité plus basse (code 3017).",
+      "shaka_4001": "Manifeste HLS invalide reçu par le Chromecast (code 4001).",
+      "shaka_6001": "Le Chromecast ne supporte pas ce codec audio/vidéo (code 6001)."
+    }
+  },
   "legend": {
     "downloaded_monitored": "Téléchargé (suivi)",
     "downloaded_unmonitored": "Téléchargé (non suivi)",

--- a/client/src/app/core/services/cast.service.ts
+++ b/client/src/app/core/services/cast.service.ts
@@ -1,7 +1,32 @@
 import { Injectable, inject, signal, OnDestroy } from '@angular/core';
 import { Capacitor, registerPlugin } from '@capacitor/core';
+import { TranslateService } from '@ngx-translate/core';
 import { environment } from '../../../environments/environment';
 import { CastSettingsService, CastSubtitleStyle } from './cast-settings.service';
+import { ToastService } from './toast.service';
+
+/** Custom Cast message namespace shared between the Fliks receiver and
+ *  every sender. Used today for receiver → sender error forwarding;
+ *  reserved for any future bidirectional control message. Keep in sync
+ *  with `cast-receiver/receiver.js`. */
+const FLIKS_CAST_NAMESPACE = 'urn:x-cast:media.fliks.app';
+
+/** Receiver → sender error payload. Fields mirror what the receiver
+ *  pushes via `fliksBus.broadcast`; everything is optional because the
+ *  receiver is forward-compatible with older senders. */
+interface ReceiverPlayerError {
+  kind: 'player_error';
+  at?: number;
+  detailedErrorCode?: number;
+  severity?: number;
+  shakaErrorCode?: number;
+  shakaErrorData?: unknown;
+  reason?: string;
+  mediaTitle?: string;
+  mediaSubtitle?: string;
+  mediaId?: number;
+  episodeId?: number;
+}
 
 declare const cast: any;
 declare const chrome: any;
@@ -74,6 +99,11 @@ export class CastService implements OnDestroy {
 
   private readonly isNative = Capacitor.isNativePlatform();
   private readonly castSettings = inject(CastSettingsService);
+  private readonly toast = inject(ToastService);
+  private readonly translate = inject(TranslateService);
+  /** Tracks which session id we already attached the error listener to
+   *  so a reconnect to the same session doesn't double-listen. */
+  private errorListenerSessionId: string | null = null;
 
   // Web-only
   private session: any = null;
@@ -188,6 +218,56 @@ export class CastService implements OnDestroy {
     this.session = connected
       ? cast.framework.CastContext.getInstance().getCurrentSession()
       : null;
+    if (this.session) {
+      this.attachReceiverMessageListener(this.session);
+    } else {
+      this.errorListenerSessionId = null;
+    }
+  }
+
+  /** Wires the receiver-side custom message bus to the sender's toast.
+   *  CAF auto-removes the listener when the session is torn down, but we
+   *  guard against re-adding on the same session so a reconnect with the
+   *  same id doesn't stack listeners and double-toast the same error. */
+  private attachReceiverMessageListener(session: any) {
+    const sessionId = session?.getSessionId?.();
+    if (sessionId && sessionId === this.errorListenerSessionId) return;
+    try {
+      session.addMessageListener(FLIKS_CAST_NAMESPACE, (_ns: string, raw: string) => {
+        try {
+          const payload = JSON.parse(raw) as ReceiverPlayerError;
+          if (payload?.kind === 'player_error') this.handleReceiverError(payload);
+        } catch {
+          /* malformed messages are ignored — receiver is forward-compatible */
+        }
+      });
+      this.errorListenerSessionId = sessionId ?? null;
+    } catch (err) {
+      console.warn('Cast addMessageListener failed', err);
+    }
+  }
+
+  private handleReceiverError(payload: ReceiverPlayerError) {
+    // Map the Shaka error code to a translation key when we recognise it
+    // so the toast wording is actionable; fall back to a generic message
+    // with the raw code for everything else.
+    const knownKey = `cast.error.shaka_${payload.shakaErrorCode}`;
+    const fallbackKey = 'cast.error.generic';
+    const params = {
+      title: payload.mediaTitle ?? '',
+      code:
+        payload.shakaErrorCode != null
+          ? String(payload.shakaErrorCode)
+          : payload.detailedErrorCode != null
+            ? String(payload.detailedErrorCode)
+            : '?',
+    };
+    const translated = this.translate.instant(knownKey, params);
+    const message =
+      translated === knownKey
+        ? this.translate.instant(fallbackKey, params)
+        : translated;
+    this.toast.error(message);
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds a custom Cast message bus (\`urn:x-cast:media.fliks.app\`) so receiver-side player errors surface as a toast on the controlling device.

### Receiver
- New \`fliksBus\` registered via \`context.getCastMessageBus(...)\`.
- The existing ERROR listener now also broadcasts a structured \`player_error\` payload (code, severity, Shaka error code/data, currently-playing media title/id) on top of the existing \`console.error\` and \`body.classList.remove('playing')\`.

### Web sender
- \`CastService\` attaches \`session.addMessageListener(FLIKS_CAST_NAMESPACE, …)\` on every session connect, deduped by \`getSessionId()\` so a reconnect to the same session doesn't double-toast.
- Lookup tries \`cast.error.shaka_<code>\` first, falls back to \`cast.error.generic\` with the raw code interpolated.
- Routes the resulting message through the existing \`ToastService.error\`.

### i18n (fr)
- Added \`cast.error.generic\` plus actionable wording for the Shaka codes we've seen in production: 1001/1002 (network), 3015/3016/3017 (media, with the explicit memory-saturation hint for 3017), 4001 (manifest), 6001 (codec).

### Out of scope
- Native (Capacitor) sender doesn't surface these toasts yet because the local \`NativeCast\` plugin doesn't expose a generic \`addMessageListener\`. Tracked for a follow-up that adds the Java/Swift glue.

## Test plan
- [ ] Trigger a 3017 on a 1080p Cast → the phone/desktop shows a toast referencing 3017 + the saturation hint.
- [ ] Drop the receiver mid-playback (kill power on the Chromecast) → reconnecting the session doesn't stack listeners (toast appears once per error).
- [ ] Web Shaka playback still has no toast spam (no shared code touched).
- [ ] No regression on multi-audio rendition switch (which uses the standard EditTracksInfoRequest bus, separate from this custom namespace).