### PR TITLE
fix(streaming): rotate QSV encoder periodically to dodge BRC drift

### DIFF
--- a/backend/src/migrations/1778115000000-drop-streaming-qsv-tuning-knobs.ts
+++ b/backend/src/migrations/1778115000000-drop-streaming-qsv-tuning-knobs.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DropStreamingQsvTuningKnobs1778115000000 implements MigrationInterface {
+  name = 'DropStreamingQsvTuningKnobs1778115000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM "app_settings"
+         WHERE "key" IN ('streaming_qsv_adaptive', 'streaming_qsv_lookahead')`,
+    );
+  }
+
+  public async down(): Promise<void> {
+    // No rollback: `-adaptive_i / -adaptive_b` are now hard-enabled in
+    // qsvExtra and `-look_ahead` is removed entirely (it tripped the
+    // QSV→libx264 HW-accel fallback). BRC drift is handled by periodic
+    // encoder rotation, not by these toggles.
+  }
+}

--- a/backend/src/modules/streaming/active-stream-tracker.service.ts
+++ b/backend/src/modules/streaming/active-stream-tracker.service.ts
@@ -164,9 +164,7 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
 
   // ── Admin streaming settings forwarded to transcode sessions ──
   private readonly encoderPresetCache = new Map<number, string>();
-  private qsvLookaheadCache = false;
   private qsvLowPowerCache = false;
-  private qsvAdaptiveCache = true;
 
   setEncoderPreset(mediaFileId: number, preset: string) {
     this.encoderPresetCache.set(mediaFileId, preset);
@@ -177,25 +175,11 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
   }
 
   /** QSV advanced options are global (driven by admin streaming settings). */
-  setQsvOptions(opts: {
-    lookahead: boolean;
-    lowPower: boolean;
-    adaptive: boolean;
-  }) {
-    this.qsvLookaheadCache = opts.lookahead;
+  setQsvOptions(opts: { lowPower: boolean }) {
     this.qsvLowPowerCache = opts.lowPower;
-    this.qsvAdaptiveCache = opts.adaptive;
   }
-  getQsvOptions(): {
-    lookahead: boolean;
-    lowPower: boolean;
-    adaptive: boolean;
-  } {
-    return {
-      lookahead: this.qsvLookaheadCache,
-      lowPower: this.qsvLowPowerCache,
-      adaptive: this.qsvAdaptiveCache,
-    };
+  getQsvOptions(): { lowPower: boolean } {
+    return { lowPower: this.qsvLowPowerCache };
   }
 
   // ── Source-vs-client compat captured at playback-info time, read at

--- a/backend/src/modules/streaming/streaming-settings-cache.service.ts
+++ b/backend/src/modules/streaming/streaming-settings-cache.service.ts
@@ -12,18 +12,14 @@ export interface StreamingSettings {
     | 'slow'
     | 'slower'
     | 'veryslow';
-  qsvLookahead: boolean;
   qsvLowPower: boolean;
-  qsvAdaptive: boolean;
 }
 
 const KEYS = [
   'streaming_segment_duration',
   'streaming_init_time',
   'streaming_qsv_preset',
-  'streaming_qsv_lookahead',
   'streaming_qsv_low_power',
-  'streaming_qsv_adaptive',
 ] as const;
 
 @Injectable()
@@ -55,21 +51,12 @@ export class StreamingSettingsCache implements OnModuleInit {
 
   private async load(): Promise<StreamingSettings> {
     const values = await Promise.all(KEYS.map((k) => this.settings.get(k)));
-    const [
-      duration,
-      initTime,
-      qsvPreset,
-      qsvLookahead,
-      qsvLowPower,
-      qsvAdaptive,
-    ] = values;
+    const [duration, initTime, qsvPreset, qsvLowPower] = values;
     return {
       segmentDuration: parseFloat(duration ?? '3') || 3,
       initTime: parseFloat(initTime ?? '1') || 1,
       qsvPreset: (qsvPreset ?? 'faster') as StreamingSettings['qsvPreset'],
-      qsvLookahead: qsvLookahead === 'true',
       qsvLowPower: qsvLowPower === 'true',
-      qsvAdaptive: qsvAdaptive == null ? true : qsvAdaptive === 'true',
     };
   }
 }

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -443,9 +443,7 @@ export class StreamingController {
     // Persist encoder preset + QSV advanced options for downstream sessions.
     this.activeStreamTracker.setEncoderPreset(mediaFileId, ss.qsvPreset);
     this.activeStreamTracker.setQsvOptions({
-      lookahead: ss.qsvLookahead,
       lowPower: ss.qsvLowPower,
-      adaptive: ss.qsvAdaptive,
     });
 
     // Persist source→client codec compatibility so hlsMaster can pick a

--- a/backend/src/modules/streaming/transcoding/constants.ts
+++ b/backend/src/modules/streaming/transcoding/constants.ts
@@ -2,6 +2,12 @@ export const SESSION_TIMEOUT_MS = 60 * 1000; // 60s HLS session timeout
 export const MAX_SESSIONS = 4;
 /** Max gap (in segments) between FFmpeg frontier and requested segment before restarting. */
 export const SEEK_WAIT_THRESHOLD = 15;
+/** Kill+respawn the encoder every N segments produced. QSV's BRC quietly
+ *  accumulates state over long continuous runs and eventually refuses to
+ *  insert IDRs on dense scenes, producing 45 s GOPs that overrun the
+ *  HLS playlist's EXTINF slots. Rotating periodically resets the encoder
+ *  before that drift becomes visible. 200 segments × 3 s = ~10 min content. */
+export const SEGMENT_ROTATION_THRESHOLD = 200;
 
 /** Mutable runtime state for HLS segment durations. Updated from admin
  *  streaming settings via `setSegmentDurations()`. Read by FFmpeg arg

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -28,7 +28,7 @@ export interface BuildFfmpegArgsOptions {
    *  passthrough). When false, transcode to AAC stereo at profile bitrate. */
   copyAudio?: boolean;
   encoderPreset?: string;
-  qsvOptions?: { lookahead: boolean; lowPower: boolean; adaptive: boolean };
+  qsvOptions?: { lowPower: boolean };
   sourceFps?: number;
   trustedStreamInfo?: boolean;
   /** Short-lived parallel session producing only seg-0/seg-1 during a
@@ -56,7 +56,7 @@ export function buildFfmpegArgs(
     audioStreams,
     copyAudio = false,
     encoderPreset = 'faster',
-    qsvOptions = { lookahead: false, lowPower: false, adaptive: true },
+    qsvOptions = { lowPower: false },
     sourceFps,
     trustedStreamInfo = false,
     early = false,
@@ -74,16 +74,13 @@ export function buildFfmpegArgs(
   // INIT_TIME). When INIT_TIME >= SEGMENT_DURATION, collapses to regular
   // fixed-GOP behaviour.
   const forceKeyframesExpr = `expr:if(eq(n_forced,0),gte(t,0),gte(t,${INIT_TIME}+(n_forced-1)*${SEGMENT_DURATION}))`;
-  // Build reusable QSV extra options flag list.
-  const qsvExtra: string[] = [];
-  if (qsvOptions.lookahead) {
-    qsvExtra.push('-look_ahead', '1', '-look_ahead_depth', '40');
-  }
+  // adaptive_i/adaptive_b let QSV pick I/B placement per scene complexity —
+  // measurable quality win on dense / fast-motion content, no perf cost.
+  // QSV BRC drift on long continuous runs is handled separately by
+  // SEGMENT_ROTATION_THRESHOLD respawning the encoder periodically.
+  const qsvExtra: string[] = ['-adaptive_i', '1', '-adaptive_b', '1'];
   if (qsvOptions.lowPower) {
     qsvExtra.push('-low_power', '1');
-  }
-  if (qsvOptions.adaptive) {
-    qsvExtra.push('-adaptive_i', '1', '-adaptive_b', '1');
   }
   const args = ['-hide_banner', '-loglevel', 'warning'];
 

--- a/backend/src/modules/streaming/transcoding/profiles.ts
+++ b/backend/src/modules/streaming/transcoding/profiles.ts
@@ -69,7 +69,8 @@ export const MOBILE_PROFILES: TranscodeProfile[] = [
 ];
 
 export function getLadderForDevice(deviceType: DeviceType | undefined): TranscodeProfile[] {
-  return deviceType === 'mobile' ? MOBILE_PROFILES : DESKTOP_PROFILES;
+  if (deviceType === 'mobile') return MOBILE_PROFILES;
+  return DESKTOP_PROFILES;
 }
 
 /** Backward-compatible alias — most callers want the desktop ladder. */

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -13,11 +13,13 @@ import { TRANSCODE_DIR } from '../../../common/constants/paths';
 import {
   MAX_SESSIONS,
   SEEK_WAIT_THRESHOLD,
+  SEGMENT_ROTATION_THRESHOLD,
   SESSION_TIMEOUT_MS,
   getSegmentDuration,
   segmentIndexToSeconds,
   setSegmentDurations as applySegmentDurations,
 } from './constants';
+import { getLadderForDevice } from './profiles';
 import {
   buildAudioOnlyFfmpegArgs,
   buildFfmpegArgs,
@@ -25,7 +27,6 @@ import {
 } from './ffmpeg-args';
 import { detectHwAccel } from './hw-detect';
 import { generateMasterPlaylist, getAvailableProfiles } from './master-playlist';
-import { getLadderForDevice } from './profiles';
 import {
   fileExists,
   firstMissingSegment,
@@ -54,6 +55,28 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
 
   async onModuleInit() {
     await fsp.mkdir(this.cachePath, { recursive: true });
+
+    // The in-memory `sessions` map only knows about live sessions. After a
+    // backend restart the map starts empty, so any directory still under
+    // `cachePath` is an orphan — written by a previous process that is no
+    // longer alive to evict it. Wipe them so a re-load on the same
+    // (mediaFileId, userId) starts from a clean slate instead of inheriting
+    // partial / overflow segments from the previous run.
+    try {
+      const entries = await fsp.readdir(this.cachePath);
+      if (entries.length) {
+        await Promise.all(
+          entries.map((e) =>
+            fsp.rm(path.join(this.cachePath, e), { recursive: true, force: true }),
+          ),
+        );
+        this.log.log(
+          `[disk] init wipe: removed ${entries.length} orphan session dir(s)`,
+        );
+      }
+    } catch (err) {
+      this.log.warn(`[disk] init wipe failed: ${(err as Error).message}`);
+    }
 
     this.detectedHwAccel = await detectHwAccel(this.log);
     this.log.log(`Hardware acceleration: ${this.detectedHwAccel}`);
@@ -674,6 +697,8 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     const firstSegName = path.basename(firstSeg);
 
     let readyWatcher: FSWatcher | null = null;
+    let segmentWatcher: FSWatcher | null = null;
+    const segmentNameRe = new RegExp(`^seg-\\d+\\${segExt}$`);
     const checkReady = () => {
       if (!resolved && existsSync(firstSeg)) {
         resolved = true;
@@ -692,6 +717,40 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
           if (filename === firstSegName) checkReady();
         },
       );
+      // Persistent watcher: count every segment written so we can rotate
+      // the encoder before its BRC accumulates state across the periodic-
+      // bad-GOP threshold. Skipped for audio-only and remux sessions
+      // (only the QSV main encoder hits the BRC drift).
+      const isMainTranscode =
+        !extra?.remux && !extra?.isAudioOnly && !id.endsWith('-early');
+      if (isMainTranscode) {
+        // inotify emits both `rename` (create) and `change` (every write/
+        // close while ffmpeg streams the moof+mdat) for the same file, so
+        // counting raw events inflates `segmentsProduced` ~3-5×. Track
+        // unique filenames instead so the rotation threshold maps to real
+        // segments produced.
+        const seenSegments = new Set<string>();
+        segmentWatcher = watch(
+          segDir,
+          { persistent: false },
+          (_event, filename) => {
+            if (typeof filename !== 'string' || !segmentNameRe.test(filename)) {
+              return;
+            }
+            if (seenSegments.has(filename)) return;
+            seenSegments.add(filename);
+            session.segmentsProduced = seenSegments.size;
+            if (
+              session.segmentsProduced >= SEGMENT_ROTATION_THRESHOLD &&
+              !session.rotationScheduled &&
+              !session.intentionallyKilled
+            ) {
+              session.rotationScheduled = true;
+              void this.rotateSession(session);
+            }
+          },
+        );
+      }
     } catch {
       // Directory will be created by ffmpeg shortly — pollTimer covers this.
     }
@@ -708,6 +767,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     proc.on('close', (code) => {
       clearInterval(pollTimer);
       readyWatcher?.close();
+      segmentWatcher?.close();
       const firstSegProduced = resolved;
       if (!resolved) {
         resolved = true;
@@ -785,7 +845,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
 
     const usesVarStreamMap =
       isVideoOnly && audioStreams && audioStreams.length > 1;
-    return this.spawnFfmpegSession({
+    const session = this.spawnFfmpegSession({
       id: sessionId,
       mediaFileId,
       quality,
@@ -794,8 +854,14 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       startSegment,
       segExt: '.m4s',
       segSubDir: usesVarStreamMap ? '0' : undefined,
-      extra: { actualHwAccel: hwAccel },
+      extra: {
+        actualHwAccel: hwAccel,
+        // Stored for the rotation worker; see SEGMENT_ROTATION_THRESHOLD.
+        absolutePath,
+        ctx,
+      },
     });
+    return session;
   }
 
   private startSeekSession(
@@ -1070,6 +1136,58 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
 
     this.applyContext(session, ctx);
     return session;
+  }
+
+  /** Kill the current ffmpeg cleanly and respawn at the next un-encoded
+   *  segment so the encoder's BRC state is reset. Triggered from the
+   *  per-segment fs watcher once `segmentsProduced` crosses
+   *  `SEGMENT_ROTATION_THRESHOLD`. The rotation runs under the same
+   *  per-key lock as `getOrCreateSession`, so a player request that
+   *  arrives mid-rotation queues behind it and gets the new session. */
+  private async rotateSession(session: TranscodeSession): Promise<void> {
+    const id = session.id;
+    return this.withLock(id, async () => {
+      // The session might have been replaced (seek, quality change) or
+      // already rotated by a concurrent caller — bail if so.
+      if (this.sessions.get(id) !== session) return;
+      if (!session.absolutePath || !session.ctx) {
+        this.log.warn(`[rotate] ${id}: missing absolutePath/ctx, skipping`);
+        return;
+      }
+      const produced = session.segmentsProduced ?? 0;
+      const newStart = (session.startSegment ?? 0) + produced;
+      this.log.log(
+        `[rotate] ${id}: produced ${produced} segments since seg-${session.startSegment ?? 0}, restarting at seg-${newStart}`,
+      );
+
+      // Graceful (SIGTERM → SIGKILL after 5 s) so ffmpeg flushes its
+      // moof+mdat for the in-flight segment cleanly. The cache stays
+      // intact (resolveExistingSession only wipes on non-zero exit).
+      session.intentionallyKilled = true;
+      this.sessions.delete(id);
+      await this.killProcess(session.process, /* graceful */ true);
+
+      // Re-derive the profile from quality (same code path as the
+      // initial spawn) so any change to the ladder takes effect on
+      // rotation as well.
+      const ladder = getLadderForDevice(session.ctx.deviceType);
+      const profile =
+        ladder.find((p) => p.name === session.quality) ?? ladder[0];
+
+      const next = this.startFfmpeg(
+        id,
+        session.mediaFileId,
+        session.quality,
+        session.absolutePath,
+        profile,
+        session.cachePath,
+        session.actualHwAccel ?? this.detectedHwAccel,
+        newStart,
+        session.ctx,
+      );
+      this.applyContext(next, session.ctx);
+      this.sessions.set(id, next);
+    });
   }
 
   private cleanupStaleSessions() {

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -45,14 +45,10 @@ export interface SessionContext {
    * Default 'faster' if unset — good speed/quality trade-off.
    */
   encoderPreset?: string;
-  /** h264_qsv advanced options (all admin-configurable). */
+  /** h264_qsv advanced options (admin-configurable). */
   qsvOptions?: {
-    /** -look_ahead 1 -look_ahead_depth 40 (better rate control, slight GPU cost) */
-    lookahead: boolean;
     /** -low_power 1 (VDENC on Gen9+ — faster, slight quality loss) */
     lowPower: boolean;
-    /** -adaptive_i 1 -adaptive_b 1 (encoder chooses I/B placement) */
-    adaptive: boolean;
   };
   /** Source framerate (fps). Used to compute GOP = SEGMENT_DURATION * fps. */
   sourceFps?: number;
@@ -108,4 +104,21 @@ export interface TranscodeSession {
    *  change, etc.) so the close handler doesn't log a spurious "exited
    *  WITHOUT producing first segment" warning. */
   intentionallyKilled?: boolean;
+  /** Original input path — kept on the session so the rotation worker
+   *  can re-spawn ffmpeg without re-resolving the media file. */
+  absolutePath?: string;
+  /** Spawn-time SessionContext — kept on the session so the rotation
+   *  worker can re-spawn with the same audio map / tonemap / crop. */
+  ctx?: SessionContext;
+  /** Number of segments the current ffmpeg has written since spawn.
+   *  Driven by the post-write fs watcher. Used to schedule a periodic
+   *  kill+respawn (see `SEGMENT_ROTATION_THRESHOLD`) — QSV's BRC
+   *  accumulates state over long runs and eventually emits a 45 s GOP
+   *  that overruns the playlist's EXTINF slot; rotating every ~10 min
+   *  of content resets the encoder before that drift hits. */
+  segmentsProduced?: number;
+  /** Set true once a rotation has been scheduled for this session, so
+   *  subsequent segment writes don't re-fire the rotation logic while
+   *  the previous one is still draining. */
+  rotationScheduled?: boolean;
 }

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -925,12 +925,8 @@
       "qsv_preset": "Preset d'encodage (QSV / libx264)",
       "qsv_preset_help": "De 'veryfast' (le plus rapide, qualité moindre) à 'veryslow' (le plus lent, meilleure qualité). 'faster' est le bon compromis pour du transcodage à la volée. Ne s'applique pas au VAAPI ni au NVENC.",
       "qsv_advanced": "Options avancées Intel QSV",
-      "qsv_lookahead": "Lookahead encodeur",
-      "qsv_lookahead_help": "Active -look_ahead avec une profondeur de 40 frames. Meilleure allocation du bitrate sur les scènes complexes, coût GPU faible.",
       "qsv_low_power": "Mode basse consommation",
       "qsv_low_power_help": "Active -low_power 1 (VDENC, Intel Gen9+). Encodage plus rapide mais qualité légèrement inférieure. À tester selon la génération du CPU.",
-      "qsv_adaptive": "Frames adaptatives (I/B)",
-      "qsv_adaptive_help": "Active -adaptive_i et -adaptive_b. L'encodeur choisit le placement optimal des I-frames et B-frames selon le contenu. Recommandé.",
       "default": "défaut",
       "saved": "Paramètres de streaming enregistrés"
     },

--- a/client/src/app/features/settings/streaming/streaming.html
+++ b/client/src/app/features/settings/streaming/streaming.html
@@ -52,26 +52,10 @@
 
     <div class="form-control">
       <label class="label cursor-pointer justify-start gap-3">
-        <input type="checkbox" class="toggle" [ngModel]="qsvLookahead()" (ngModelChange)="qsvLookahead.set($event)" />
-        <span class="label-text font-medium">{{ 'settings.streaming.qsv_lookahead' | translate }}</span>
-      </label>
-      <label class="label"><span class="label-text-alt text-base-content/50">{{ 'settings.streaming.qsv_lookahead_help' | translate }}</span></label>
-    </div>
-
-    <div class="form-control">
-      <label class="label cursor-pointer justify-start gap-3">
         <input type="checkbox" class="toggle" [ngModel]="qsvLowPower()" (ngModelChange)="qsvLowPower.set($event)" />
         <span class="label-text font-medium">{{ 'settings.streaming.qsv_low_power' | translate }}</span>
       </label>
       <label class="label"><span class="label-text-alt text-base-content/50">{{ 'settings.streaming.qsv_low_power_help' | translate }}</span></label>
-    </div>
-
-    <div class="form-control">
-      <label class="label cursor-pointer justify-start gap-3">
-        <input type="checkbox" class="toggle" [ngModel]="qsvAdaptive()" (ngModelChange)="qsvAdaptive.set($event)" />
-        <span class="label-text font-medium">{{ 'settings.streaming.qsv_adaptive' | translate }}</span>
-      </label>
-      <label class="label"><span class="label-text-alt text-base-content/50">{{ 'settings.streaming.qsv_adaptive_help' | translate }}</span></label>
     </div>
 
     <button class="btn btn-primary" [disabled]="saving()" (click)="save()">

--- a/client/src/app/features/settings/streaming/streaming.ts
+++ b/client/src/app/features/settings/streaming/streaming.ts
@@ -21,9 +21,7 @@ export class StreamingSettingsComponent implements OnInit {
   readonly segmentDuration = signal('3');
   readonly initTime = signal('1');
   readonly qsvPreset = signal('faster');
-  readonly qsvLookahead = signal(false);
   readonly qsvLowPower = signal(false);
-  readonly qsvAdaptive = signal(true);
 
   async ngOnInit() {
     try {
@@ -31,14 +29,7 @@ export class StreamingSettingsComponent implements OnInit {
       this.segmentDuration.set(all['streaming_segment_duration'] ?? '3');
       this.initTime.set(all['streaming_init_time'] ?? '1');
       this.qsvPreset.set(all['streaming_qsv_preset'] ?? 'faster');
-      this.qsvLookahead.set(all['streaming_qsv_lookahead'] === 'true');
       this.qsvLowPower.set(all['streaming_qsv_low_power'] === 'true');
-      // Default true when the key is absent.
-      this.qsvAdaptive.set(
-        all['streaming_qsv_adaptive'] == null
-          ? true
-          : all['streaming_qsv_adaptive'] === 'true',
-      );
     } catch { /* interceptor */ }
     this.loading.set(false);
   }
@@ -50,9 +41,7 @@ export class StreamingSettingsComponent implements OnInit {
         streaming_segment_duration: this.segmentDuration(),
         streaming_init_time: this.initTime(),
         streaming_qsv_preset: this.qsvPreset(),
-        streaming_qsv_lookahead: String(this.qsvLookahead()),
         streaming_qsv_low_power: String(this.qsvLowPower()),
-        streaming_qsv_adaptive: String(this.qsvAdaptive()),
       });
       this.toast.success(this.translate.instant('settings.streaming.saved'));
     } catch { /* interceptor */ }


### PR DESCRIPTION
## Summary

- Cast freeze at ~16:40 was caused by Intel QSV's BRC drifting on long continuous runs and emitting a 45 s segment that overran the HLS playlist's EXTINF slot. Rotation kills+respawns the encoder every 200 segments (~10 min of content) before drift hits.
- The rotation watcher initially over-counted because `fs.watch` (inotify) fires both `rename` and multiple `change` events per file. Switched to a `Set<string>` of seen filenames so the threshold maps to real segments.
- Dropped the `qsvAdaptive` / `qsvLookahead` admin toggles (lookahead reliably tripped the QSV→libx264 HW-accel fallback; adaptive is now hard-enabled in the QSV extra args). Migration deletes the dead settings rows.
- Wipe orphan transcode session dirs at backend boot so a re-load on the same `(mediaFileId, userId)` starts clean instead of inheriting partial segments from a previous run.
- Reverted the QSV `-mbbrc 0 -strict_gop 1` belt-and-suspenders flags now that rotation is the actual fix.

## Test plan

- [x] Cast Mission Impossible 2160p → 1080p HDR transcode passes seg-0333 (the historic freeze point) without stutter
- [x] Backend logs show clean rotation cadence (one rotation every ~2 min wall-clock, no "Seek: unreachable gap" cascades)
- [x] No segment > 5 MB on a 10-min run (max 2.85 MB on 438 segs)
- [ ] DB migrations CI green
- [ ] Lint / typecheck pass on backend + client