### PR TITLE
fix(cast): drop receiver custom message bus that broke Android sessions

### DIFF
--- a/cast-receiver/receiver.js
+++ b/cast-receiver/receiver.js
@@ -49,41 +49,13 @@ playerManager.addEventListener(
   );
 });
 
-// Custom message bus the Fliks senders subscribe to so they can surface
-// receiver-side errors in the phone / desktop UI (a stalled stream on the
-// TV would otherwise look like silence on the controlling device).
-const FLIKS_MESSAGE_NAMESPACE = 'urn:x-cast:media.fliks.app';
-const fliksBus = context.getCastMessageBus(
-  FLIKS_MESSAGE_NAMESPACE,
-  cast.framework.system.MessageType.JSON,
-);
-
 // Surface any player error on the device's DevTools console with the full
-// CAF event payload (detailedErrorCode, reason, shaka-side error data),
-// and forward a structured payload to senders so they can show a toast.
+// CAF event payload (detailedErrorCode, reason, shaka-side error data).
 playerManager.addEventListener(
   cast.framework.events.EventType.ERROR,
   (event) => {
     console.error('[fliks-cast] ERROR', JSON.stringify(event));
     document.body.classList.remove('playing');
-    try {
-      const info = playerManager.getMediaInformation();
-      fliksBus.broadcast({
-        kind: 'player_error',
-        at: Date.now(),
-        detailedErrorCode: event.detailedErrorCode,
-        severity: event.severity,
-        shakaErrorCode: event.error?.shakaErrorCode,
-        shakaErrorData: event.error?.shakaErrorData,
-        reason: event.reason,
-        mediaTitle: info?.metadata?.title,
-        mediaSubtitle: info?.metadata?.subtitle,
-        mediaId: info?.customData?.mediaId,
-        episodeId: info?.customData?.episodeId,
-      });
-    } catch (err) {
-      console.warn('[fliks-cast] failed to forward error to senders', err);
-    }
   },
 );
 


### PR DESCRIPTION
## Summary

After #69 shipped, Android Cast sessions get stuck: the receiver shows the Fliks splash on TV, but the sender stays in \"pending\" then disconnects. The hypothesis is that \`context.getCastMessageBus(...)\` (or the new namespace registration) is throwing on the receiver before \`context.start()\` runs — splash is HTML/CSS so it shows fine, but the receiver never confirms LAUNCH on the Cast protocol level.

This drops only the receiver-side broadcast path. The sender's \`attachReceiverMessageListener\` in \`cast.service.ts\` stays in place — it's a no-op on Android (native Cast plugin path doesn't run it), and it'll just sit idle on web now that the receiver doesn't broadcast on that namespace.

## Test plan
- [ ] Android: tap Cast → select Chromecast → session connects, no \"pending\" hang.
- [ ] Web Chrome: Cast still works as before #69.