### PR TITLE
fix(admin): show real playback position in active streams panel

### DIFF
--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -353,11 +353,11 @@ export class SystemController {
       let positionSeconds = 0;
       let durationSeconds = si?.durationSeconds ?? 0;
       let episodeId: number | null = null;
-      if (s.userId) {
+      if (s.userId && mf?.mediaId) {
         try {
           const ps = await this.playbackService.getState(
             s.userId,
-            s.mediaFileId,
+            mf.mediaId,
           );
           if (ps) {
             positionSeconds = ps.positionSeconds;


### PR DESCRIPTION
## Summary

\`playbackService.getState\` looks up rows by \`media.id\`, but the admin streams handler was passing \`session.mediaFileId\` for the second argument — so the lookup never matched and \`positionSeconds\` always returned 0. UI consequence: the green progress bar and \`0:00 / duration\` indicator stayed stuck at zero while the red transcode buffer (read directly from the FS) advanced normally.

## Test plan
- [ ] Start a stream → admin streams panel shows the green bar and current time advancing.
- [ ] Multi-episode shows still resolve the right episode label (uses the same \`getState\` result).