### PR TITLE
fix(player): keep mobile play/seek buttons above the bottom bar

### DIFF
--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -63,25 +63,30 @@
   </div>
 </div>
 
-<!-- ===== CENTER OVERLAY (tap zone) ===== -->
+<!-- ===== CENTER OVERLAY (tap zone) =====
+     z-30 so the bottom bar (z-40) stays clickable. Tall titles + seekbar
+     can grow the bottom bar up into the centered area on phones, so the
+     mobile big buttons live in a separate z-50 layer below to keep them
+     tappable. -->
 <div
   class="absolute inset-0 z-30 flex items-center justify-center"
   (click)="isMobileTouch() ? tapOverlay.emit() : hasOpenDropdown() ? closeDropdown($event) : togglePlay.emit()"
   (dblclick)="isMobileTouch() ? null : toggleFullscreen.emit()"
->
-  <!-- Mobile: big center controls (rewind / play / forward) -->
-  @if (isMobileTouch() && !loading() && !buffering()) {
-    <div
-      class="flex items-center gap-6 transition-opacity duration-200"
-      [class.opacity-0]="!visible()"
-      [class.pointer-events-none]="!visible()"
-    >
+></div>
+
+<!-- Mobile: big center controls (rewind / play / forward) -->
+@if (isMobileTouch() && !loading() && !buffering()) {
+  <div
+    class="absolute inset-0 z-50 flex items-center justify-center pointer-events-none transition-opacity duration-200"
+    [class.opacity-0]="!visible()"
+  >
+    <div class="flex items-center gap-6">
       <!-- lucide:rotate-ccw -->
-      <button type="button" class="p-6 -m-3 text-white/90 active:scale-90 transition-transform" (click)="seek.emit(currentTime() - 10); $event.stopPropagation()">
+      <button type="button" class="p-6 -m-3 text-white/90 active:scale-90 transition-transform pointer-events-auto" [class.pointer-events-none]="!visible()" (click)="seek.emit(currentTime() - 10); $event.stopPropagation()">
         <svg lucideRotateCcw class="h-7 w-7" [strokeWidth]="1.5"></svg>
       </button>
       <!-- lucide:play / lucide:pause -->
-      <button type="button" class="p-6 -m-2 text-white active:scale-90 transition-transform" (click)="togglePlay.emit(); $event.stopPropagation()">
+      <button type="button" class="p-6 -m-2 text-white active:scale-90 transition-transform pointer-events-auto" [class.pointer-events-none]="!visible()" (click)="togglePlay.emit(); $event.stopPropagation()">
         @if (paused()) {
           <svg xmlns="http://www.w3.org/2000/svg" class="h-14 w-14 drop-shadow-lg" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M5 5a2 2 0 0 1 3.008-1.728l11.997 6.998a2 2 0 0 1 .003 3.458l-12 7A2 2 0 0 1 5 19z"/></svg>
         } @else {
@@ -89,12 +94,12 @@
         }
       </button>
       <!-- lucide:rotate-cw -->
-      <button type="button" class="p-6 -m-3 text-white/90 active:scale-90 transition-transform" (click)="seek.emit(currentTime() + 10); $event.stopPropagation()">
+      <button type="button" class="p-6 -m-3 text-white/90 active:scale-90 transition-transform pointer-events-auto" [class.pointer-events-none]="!visible()" (click)="seek.emit(currentTime() + 10); $event.stopPropagation()">
         <svg lucideRotateCw class="h-7 w-7" [strokeWidth]="1.5"></svg>
       </button>
     </div>
-  }
-</div>
+  </div>
+}
 
 <!-- ===== BOTTOM SECTION =====
      Padding scales with screen width via Tailwind breakpoints (no JS-side


### PR DESCRIPTION
## Summary

On phones the big rewind / play / forward buttons sit roughly center-of-screen, but the z-40 bottom bar grows tall (oversized title text + seekbar + duration row) and overlaps the lower half of those buttons. They were nested inside the z-30 tap overlay, so the bottom bar was painted on top and ate the taps — the buttons looked clickable but produced no response.

Move the mobile button block into a sibling \`absolute inset-0 z-50\` layer with \`pointer-events-none\` on the wrapper and \`pointer-events-auto\` on each button. Result:

- Buttons render above the bottom bar everywhere they're visible.
- Empty space inside the z-50 layer doesn't intercept taps — the bottom bar stays interactive when you tap the seekbar / title.
- When controls fade out, each button switches to \`pointer-events-none\` so the underlying tap-to-show-controls overlay still works.

## Test plan
- [ ] Mobile / Android: tap rewind, play/pause, forward — each registers regardless of overlap.
- [ ] Mobile: tap on the bottom bar (seekbar, settings, etc.) still works as before.
- [ ] Mobile: tap on empty area still toggles controls visibility.
- [ ] Desktop: layout unchanged (block is gated by \`isMobileTouch()\`).