### PR TITLE
chore(streaming): bump stale-session cleanup timeout to 30min

### DIFF
--- a/backend/src/modules/streaming/transcoding/constants.ts
+++ b/backend/src/modules/streaming/transcoding/constants.ts
@@ -1,4 +1,4 @@
-export const SESSION_TIMEOUT_MS = 60 * 1000; // 60s HLS session timeout
+export const SESSION_TIMEOUT_MS = 30 * 60 * 1000; // 30min HLS session timeout
 export const MAX_SESSIONS = 4;
 /** Max gap (in segments) between FFmpeg frontier and requested segment before restarting. */
 export const SEEK_WAIT_THRESHOLD = 15;


### PR DESCRIPTION
## Summary

\`SESSION_TIMEOUT_MS\` was 60s — long enough to be sniped by buffering, idle pauses, or quality-switch handshakes that briefly stop touching the session. Bumped to 30min, which matches how long users actually leave a stream paused before stepping away.

## Test plan
- [ ] Pause a stream for several minutes — session keeps its cache, resume picks up at the right segment without a re-spawn.
- [ ] Hard-close the player tab — session still gets evicted on next sweep (just after 30min instead of 60s).