### PR TITLE
fix(cast): stop backend session when the cast session drops

### DIFF
--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, inject, signal } from '@angular/core';
+import { Injectable, effect, inject, signal } from '@angular/core';
 import { CastService } from './cast.service';
 import { CastSettingsService } from './cast-settings.service';
 import { StreamingApiService } from './api/streaming-api.service';
@@ -201,15 +201,32 @@ export class CastPlayerService {
     this.loadSpriteMetadata(opts.mediaFileId);
   }
 
-  /** Clear Cast media state (on disconnect/stop). Saves position first. */
+  /** Clear Cast media state (on disconnect/stop). Saves position first
+   *  and kills the backend transcode session so its ffmpeg stops; without
+   *  this the session lingers until SESSION_TIMEOUT_MS, holding HW
+   *  encoder slots and disk cache. */
   clear() {
+    const mfId = this.mediaFileId();
     this.saveCastPosition(); // Save final position before clearing
     this.stopPositionSaving();
+    if (mfId) {
+      this.streamingApi.stopSessions(mfId).catch(() => {});
+    }
     this.hasMedia.set(false);
     this.expanded.set(false);
     this.mediaFileId.set(0);
     this.spriteUrl.set(null);
     this.spriteMetadata.set(null);
+  }
+
+  constructor() {
+    // Auto-clear when the cast session drops (TV remote stop, network drop,
+    // sender app closed) — without this hook the backend ffmpeg keeps
+    // running until the next stale-session sweep.
+    effect(() => {
+      const connected = this.cast.isConnected();
+      if (!connected && this.hasMedia()) this.clear();
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary

\`CastPlayerService.clear()\` only reset client-side signals; the backend transcode session kept running until the stale-session sweep (currently 30min), pinning HW encoder slots and disk cache. Closing the cast from the TV remote or losing the network bypassed \`onDisconnectCast\` entirely — that was the default path, so backend sessions reliably leaked.

- \`clear()\` now also fires \`DELETE /api/streaming/:mediaFileId/sessions\` so ffmpeg dies immediately.
- A new \`effect()\` in the constructor watches \`cast.isConnected\`; the moment it goes false while we still have media loaded, \`clear()\` runs automatically. This covers TV-side stops, sender-app closes, and network drops.

## Test plan
- [ ] Cast a stream, then stop on the TV remote → backend ffmpeg exits within ~1 s (\`pgrep -af h264_qsv\` empty).
- [ ] Cast a stream, hit the in-app disconnect → backend ffmpeg exits.
- [ ] Cast a stream, kill the receiver (network blip) → backend ffmpeg exits.
- [ ] Quality / audio change still works (\`reloadCastStream\` still calls \`stopSessions\` before re-spawning).