### PR TITLE
fix(streaming): rotate ffmpeg by content seconds, not segment count

### DIFF
--- a/backend/src/modules/streaming/transcoding/constants.ts
+++ b/backend/src/modules/streaming/transcoding/constants.ts
@@ -2,12 +2,19 @@ export const SESSION_TIMEOUT_MS = 30 * 60 * 1000; // 30min HLS session timeout
 export const MAX_SESSIONS = 4;
 /** Max gap (in segments) between FFmpeg frontier and requested segment before restarting. */
 export const SEEK_WAIT_THRESHOLD = 15;
-/** Kill+respawn the encoder every N segments produced. QSV's BRC quietly
- *  accumulates state over long continuous runs and eventually refuses to
- *  insert IDRs on dense scenes, producing 45 s GOPs that overrun the
- *  HLS playlist's EXTINF slots. Rotating periodically resets the encoder
- *  before that drift becomes visible. 200 segments × 3 s = ~10 min content. */
-export const SEGMENT_ROTATION_THRESHOLD = 200;
+/** Kill+respawn the encoder every ~N seconds of content. QSV's BRC
+ *  quietly accumulates state over long continuous runs and eventually
+ *  refuses to insert IDRs on dense scenes, producing 45 s GOPs that
+ *  overrun the HLS playlist's EXTINF slots. The bad-GOP regime hits
+ *  around ~17 min, so we rotate well before that. Expressed in seconds
+ *  of content (not segments) so the cadence holds whatever the admin
+ *  picks for `streaming_segment_duration`. */
+export const SEGMENT_ROTATION_INTERVAL_SECONDS = 600;
+/** Translate the seconds budget into a segment count for the current
+ *  segment duration setting. */
+export function getRotationSegmentThreshold(): number {
+  return Math.max(1, Math.ceil(SEGMENT_ROTATION_INTERVAL_SECONDS / segmentDuration));
+}
 
 /** Mutable runtime state for HLS segment durations. Updated from admin
  *  streaming settings via `setSegmentDurations()`. Read by FFmpeg arg

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -77,7 +77,7 @@ export function buildFfmpegArgs(
   // adaptive_i/adaptive_b let QSV pick I/B placement per scene complexity —
   // measurable quality win on dense / fast-motion content, no perf cost.
   // QSV BRC drift on long continuous runs is handled separately by
-  // SEGMENT_ROTATION_THRESHOLD respawning the encoder periodically.
+  // SEGMENT_ROTATION_INTERVAL_SECONDS respawning the encoder periodically.
   const qsvExtra: string[] = ['-adaptive_i', '1', '-adaptive_b', '1'];
   if (qsvOptions.lowPower) {
     qsvExtra.push('-low_power', '1');

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -13,8 +13,8 @@ import { TRANSCODE_DIR } from '../../../common/constants/paths';
 import {
   MAX_SESSIONS,
   SEEK_WAIT_THRESHOLD,
-  SEGMENT_ROTATION_THRESHOLD,
   SESSION_TIMEOUT_MS,
+  getRotationSegmentThreshold,
   getSegmentDuration,
   segmentIndexToSeconds,
   setSegmentDurations as applySegmentDurations,
@@ -741,7 +741,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
             seenSegments.add(filename);
             session.segmentsProduced = seenSegments.size;
             if (
-              session.segmentsProduced >= SEGMENT_ROTATION_THRESHOLD &&
+              session.segmentsProduced >= getRotationSegmentThreshold() &&
               !session.rotationScheduled &&
               !session.intentionallyKilled
             ) {
@@ -856,7 +856,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       segSubDir: usesVarStreamMap ? '0' : undefined,
       extra: {
         actualHwAccel: hwAccel,
-        // Stored for the rotation worker; see SEGMENT_ROTATION_THRESHOLD.
+        // Stored for the rotation worker; see SEGMENT_ROTATION_INTERVAL_SECONDS.
         absolutePath,
         ctx,
       },
@@ -1141,7 +1141,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
   /** Kill the current ffmpeg cleanly and respawn at the next un-encoded
    *  segment so the encoder's BRC state is reset. Triggered from the
    *  per-segment fs watcher once `segmentsProduced` crosses
-   *  `SEGMENT_ROTATION_THRESHOLD`. The rotation runs under the same
+   *  the rotation segment threshold. The rotation runs under the same
    *  per-key lock as `getOrCreateSession`, so a player request that
    *  arrives mid-rotation queues behind it and gets the new session. */
   private async rotateSession(session: TranscodeSession): Promise<void> {

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -112,7 +112,7 @@ export interface TranscodeSession {
   ctx?: SessionContext;
   /** Number of segments the current ffmpeg has written since spawn.
    *  Driven by the post-write fs watcher. Used to schedule a periodic
-   *  kill+respawn (see `SEGMENT_ROTATION_THRESHOLD`) — QSV's BRC
+   *  kill+respawn (see `SEGMENT_ROTATION_INTERVAL_SECONDS`) — QSV's BRC
    *  accumulates state over long runs and eventually emits a 45 s GOP
    *  that overruns the playlist's EXTINF slot; rotating every ~10 min
    *  of content resets the encoder before that drift hits. */


### PR DESCRIPTION
## Summary

The QSV-rotation threshold was \`SEGMENT_ROTATION_THRESHOLD = 200\` (segments). At the default 3 s segment duration that's ~10 min — comfortably below the ~17 min mark where QSV's BRC drift starts producing 45 s segments.

Bumping the admin \`streaming_segment_duration\` to 6 s pushes that to 20 min, past the danger zone, so the original 16:40 freeze comes back.

Replace the segment-count constant with a seconds-of-content budget (\`SEGMENT_ROTATION_INTERVAL_SECONDS = 600\`) and convert it to a segment count on the fly via \`getRotationSegmentThreshold()\`. The budget now holds whatever segment duration the admin picks.

## Test plan
- [ ] \`streaming_segment_duration = 3\` → rotation fires around segment 200 (unchanged).
- [ ] \`streaming_segment_duration = 6\` → rotation fires around segment 100 (≈10 min content) — well before the 17 min QSV bad-GOP regime.
- [ ] No rotation cascade or phantom seek loops on either setting.