### PR TITLE
feat(media): track adder on Media + surface missing files on cards

### DIFF
--- a/backend/src/migrations/1778200000000-add-media-added-by.ts
+++ b/backend/src/migrations/1778200000000-add-media-added-by.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMediaAddedBy1778200000000 implements MigrationInterface {
+  name = 'AddMediaAddedBy1778200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "media" ADD COLUMN IF NOT EXISTS "addedById" integer`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "media" ADD CONSTRAINT "FK_media_addedById_users"
+         FOREIGN KEY ("addedById") REFERENCES "users"("id")
+         ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_media_addedById" ON "media" ("addedById")`,
+    );
+
+    // Backfill: media created via the Requests flow before this column existed
+    // get their requester attributed retroactively. Picks the earliest known
+    // request when a media was requested multiple times.
+    await queryRunner.query(
+      `UPDATE "media" m
+         SET "addedById" = sub.user_id
+         FROM (
+           SELECT DISTINCT ON (r."mediaId") r."mediaId", r."userId" AS user_id
+           FROM "requests" r
+           WHERE r."mediaId" IS NOT NULL AND r."userId" IS NOT NULL
+           ORDER BY r."mediaId", r."createdAt" ASC
+         ) sub
+         WHERE m.id = sub."mediaId" AND m."addedById" IS NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_media_addedById"`);
+    await queryRunner.query(
+      `ALTER TABLE "media" DROP CONSTRAINT IF EXISTS "FK_media_addedById_users"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "media" DROP COLUMN IF EXISTS "addedById"`,
+    );
+  }
+}

--- a/backend/src/modules/imports/seerr-request-import.service.ts
+++ b/backend/src/modules/imports/seerr-request-import.service.ts
@@ -215,6 +215,14 @@ export class SeerrRequestImportService {
       },
     });
 
+    // When the Seerr request maps to a Media already in Fliks that nobody
+    // owns yet (`addedById` null — typical for *arr-migrated or disk-rescanned
+    // rows), claim it for the Seerr requester so the "Mine" filter surfaces
+    // it without waiting on a manual re-approval.
+    if (media && media.addedById == null) {
+      await this.mediaRepo.update(media.id, { addedById: user.id });
+    }
+
     if (existing) {
       existing.status = status;
       existing.seasons = seasons;

--- a/backend/src/modules/media/entities/media.entity.ts
+++ b/backend/src/modules/media/entities/media.entity.ts
@@ -19,6 +19,7 @@ import { QualityProfile } from '../../profiles/entities/quality-profile.entity';
 import { LanguageProfile } from '../../profiles/entities/language-profile.entity';
 import { RootFolder } from '../../root-folders/entities/root-folder.entity';
 import { Library } from '../../libraries/entities/library.entity';
+import { User } from '../../users/entities/user.entity';
 import { Season } from './season.entity';
 import { MediaFile } from './media-file.entity';
 import { MediaMetadata } from './media-metadata.entity';
@@ -182,6 +183,18 @@ export class Media extends BaseEntity {
 
   @OneToMany(() => MediaFile, (file) => file.media, { cascade: true })
   files: MediaFile[];
+
+  /**
+   * User who initiated the direct import (no Request involved). Null for media
+   * created via approved Requests, disk rescans, or arr migrations — those
+   * flows attribute ownership elsewhere (Request.user, etc.).
+   */
+  @ManyToOne(() => User, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'addedById' })
+  addedBy: User | null;
+
+  @RelationId((m: Media) => m.addedBy)
+  addedById: number | null;
 
   toJSON() {
     return { ...this, path: this.path };

--- a/backend/src/modules/media/media.controller.ts
+++ b/backend/src/modules/media/media.controller.ts
@@ -69,14 +69,14 @@ export class MediaController {
 
   @Post('import/tmdb')
   @CheckPolicies((ability) => ability.can(Action.Create, Media))
-  importFromTmdb(@Body() dto: ImportTmdbDto) {
-    return this.mediaService.importFromTmdb(dto);
+  importFromTmdb(@Body() dto: ImportTmdbDto, @CurrentUser() user: User) {
+    return this.mediaService.importFromTmdb(dto, user?.id ?? null);
   }
 
   @Post('import')
   @CheckPolicies((ability) => ability.can(Action.Create, Media))
-  importMedia(@Body() dto: ImportMediaDto) {
-    return this.mediaService.importMedia(dto);
+  importMedia(@Body() dto: ImportMediaDto, @CurrentUser() user: User) {
+    return this.mediaService.importMedia(dto, user?.id ?? null);
   }
 
   @Post()

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -34,6 +34,9 @@ import {
 } from '../metadata-providers/interfaces/metadata-provider.interface';
 import { MediaType, MediaStatus } from '../../common/enums';
 import { ProfilesService } from '../profiles/profiles.service';
+import { QualityProfile } from '../profiles/entities/quality-profile.entity';
+import { LanguageProfile } from '../profiles/entities/language-profile.entity';
+import { User } from '../users/entities/user.entity';
 import { RootFolder } from '../root-folders/entities/root-folder.entity';
 import { Library } from '../libraries/entities/library.entity';
 import { LibrariesService } from '../libraries/libraries.service';
@@ -97,7 +100,10 @@ export class MediaService {
     private readonly subtitleStream: SubtitleStreamService,
   ) {}
 
-  async importFromTmdb(dto: ImportTmdbDto): Promise<Media> {
+  async importFromTmdb(
+    dto: ImportTmdbDto,
+    addedByUserId: number | null = null,
+  ): Promise<Media> {
     const key = this.config.get<string>('TMDB_API_KEY', '');
     if (!key?.trim()) {
       throw new BadRequestException('TMDB API key is not configured');
@@ -155,6 +161,7 @@ export class MediaService {
         rootFolderId,
         folderName,
         libraryId,
+        addedByUserId,
       );
     }
 
@@ -176,6 +183,7 @@ export class MediaService {
       rootFolderId,
       folderName,
       libraryId,
+      addedByUserId,
     );
   }
 
@@ -183,7 +191,10 @@ export class MediaService {
    * Import media from any provider (TMDB, TVDB).
    * Cross-references IDs between providers when possible.
    */
-  async importMedia(dto: ImportMediaDto): Promise<Media> {
+  async importMedia(
+    dto: ImportMediaDto,
+    addedByUserId: number | null = null,
+  ): Promise<Media> {
     const provider = this.providerRegistry.resolve(dto.provider ?? null);
 
     // Check for existing media (by any known ID)
@@ -260,6 +271,7 @@ export class MediaService {
         rootFolderId,
         folderName,
         libraryId,
+        addedByUserId,
       );
     }
 
@@ -289,6 +301,7 @@ export class MediaService {
       rootFolderId,
       folderName,
       libraryId,
+      addedByUserId,
     );
   }
 
@@ -455,13 +468,10 @@ export class MediaService {
     }
 
     if (query.requestedByMe && userId) {
-      qb.andWhere(
-        `media.id IN (
-          SELECT r."mediaId" FROM requests r
-          WHERE r."userId" = :reqUserId AND r."mediaId" IS NOT NULL
-        )`,
-        { reqUserId: userId },
-      );
+      // Approved requests set `media.addedById` to the requester, and direct
+      // imports set it to the importer — so a single column lookup covers
+      // both flows.
+      qb.andWhere('media."addedById" = :reqUserId', { reqUserId: userId });
     }
 
     if (query.q) {
@@ -707,20 +717,24 @@ export class MediaService {
   ): Promise<Media> {
     await this.findOne(id);
     const patch: {
-      qualityProfileId?: number | null;
-      languageProfileId?: number | null;
+      qualityProfile?: QualityProfile | null;
+      languageProfile?: LanguageProfile | null;
     } = {};
     if (dto.qualityProfileId !== undefined) {
       if (dto.qualityProfileId !== null) {
         await this.profiles.findOneQualityProfile(dto.qualityProfileId);
+        patch.qualityProfile = { id: dto.qualityProfileId } as QualityProfile;
+      } else {
+        patch.qualityProfile = null;
       }
-      patch.qualityProfileId = dto.qualityProfileId;
     }
     if (dto.languageProfileId !== undefined) {
       if (dto.languageProfileId !== null) {
         await this.profiles.findOneLanguageProfile(dto.languageProfileId);
+        patch.languageProfile = { id: dto.languageProfileId } as LanguageProfile;
+      } else {
+        patch.languageProfile = null;
       }
-      patch.languageProfileId = dto.languageProfileId;
     }
     if (Object.keys(patch).length === 0) {
       throw new BadRequestException(
@@ -738,10 +752,16 @@ export class MediaService {
     const patch: Partial<Record<string, unknown>> = {};
 
     if (dto.qualityProfileId !== undefined) {
-      patch.qualityProfileId = dto.qualityProfileId;
+      patch.qualityProfile =
+        dto.qualityProfileId === null
+          ? null
+          : ({ id: dto.qualityProfileId } as QualityProfile);
     }
     if (dto.languageProfileId !== undefined) {
-      patch.languageProfileId = dto.languageProfileId;
+      patch.languageProfile =
+        dto.languageProfileId === null
+          ? null
+          : ({ id: dto.languageProfileId } as LanguageProfile);
     }
     if (dto.monitored !== undefined) {
       patch.monitored = dto.monitored;
@@ -857,10 +877,7 @@ export class MediaService {
         moviesQb.andWhere('m.monitored = true');
       }
       if (dto.requestedByMe && userId) {
-        moviesQb.andWhere(
-          `m.id IN (SELECT r."mediaId" FROM requests r WHERE r."userId" = :calUserId AND r."mediaId" IS NOT NULL)`,
-          { calUserId: userId },
-        );
+        moviesQb.andWhere('m."addedById" = :calUserId', { calUserId: userId });
       }
       if (accessibleLibraryIds !== undefined && accessibleLibraryIds !== null) {
         if (accessibleLibraryIds.length === 0) {
@@ -928,10 +945,7 @@ export class MediaService {
         epQb.andWhere('media.monitored = true').andWhere('ep.monitored = true');
       }
       if (dto.requestedByMe && userId) {
-        epQb.andWhere(
-          `media.id IN (SELECT r."mediaId" FROM requests r WHERE r."userId" = :calUserId AND r."mediaId" IS NOT NULL)`,
-          { calUserId: userId },
-        );
+        epQb.andWhere('media."addedById" = :calUserId', { calUserId: userId });
       }
       if (accessibleLibraryIds !== undefined && accessibleLibraryIds !== null) {
         if (accessibleLibraryIds.length === 0) {
@@ -1935,18 +1949,26 @@ export class MediaService {
     rootFolderId?: number,
     folderName?: string,
     libraryId?: number,
+    addedByUserId?: number | null,
   ): Promise<Media> {
     const row = this.mediaRepo.create({
       ...this.buildMediaFieldsFromTmdb(details, MediaType.MOVIE),
       monitored: true,
       metadataRefreshedAt: new Date(),
-      ...(qualityProfileId != null ? { qualityProfileId } : {}),
-      ...(languageProfileId != null ? { languageProfileId } : {}),
+      ...(qualityProfileId != null
+        ? { qualityProfile: { id: qualityProfileId } as QualityProfile }
+        : {}),
+      ...(languageProfileId != null
+        ? { languageProfile: { id: languageProfileId } as LanguageProfile }
+        : {}),
       ...(rootFolderId
         ? { rootFolder: { id: rootFolderId } as RootFolder }
         : {}),
       ...(libraryId ? { library: { id: libraryId } as Library } : {}),
       ...(folderName ? { folderName } : {}),
+      ...(addedByUserId
+        ? { addedBy: { id: addedByUserId } as User }
+        : {}),
     });
     const saved = await this.mediaRepo.save(row);
     await this.downloadMediaImages(saved.id, details);
@@ -1963,18 +1985,26 @@ export class MediaService {
     rootFolderId?: number,
     folderName?: string,
     libraryId?: number,
+    addedByUserId?: number | null,
   ): Promise<Media> {
     const row = this.mediaRepo.create({
       ...this.buildMediaFieldsFromTmdb(details, MediaType.SERIES),
       monitored: true,
       metadataRefreshedAt: new Date(),
-      ...(qualityProfileId != null ? { qualityProfileId } : {}),
-      ...(languageProfileId != null ? { languageProfileId } : {}),
+      ...(qualityProfileId != null
+        ? { qualityProfile: { id: qualityProfileId } as QualityProfile }
+        : {}),
+      ...(languageProfileId != null
+        ? { languageProfile: { id: languageProfileId } as LanguageProfile }
+        : {}),
       ...(rootFolderId
         ? { rootFolder: { id: rootFolderId } as RootFolder }
         : {}),
       ...(libraryId ? { library: { id: libraryId } as Library } : {}),
       ...(folderName ? { folderName } : {}),
+      ...(addedByUserId
+        ? { addedBy: { id: addedByUserId } as User }
+        : {}),
     });
     const saved = await this.mediaRepo.save(row);
     await this.downloadMediaImages(saved.id, details);

--- a/backend/src/modules/requests/requests.service.ts
+++ b/backend/src/modules/requests/requests.service.ts
@@ -314,15 +314,22 @@ export class RequestsService {
     row.approvedBy = admin;
     row.declinedReason = null;
 
-    // Import the media into the library
+    // Import the media into the library. Attribute the new Media row to the
+    // requester (not the approving admin) so the "Afficher uniquement les
+    // médias que j'ai demandé" filter — which matches `addedById = me OR
+    // requests.userId = me` — keeps surfacing it even if the Request row is
+    // later purged.
     try {
-      const media = await this.mediaService.importFromTmdb({
-        type: row.mediaType,
-        tmdbId: row.tmdbId,
-        qualityProfileId: row.qualityProfileId ?? undefined,
-        languageProfileId: row.languageProfileId ?? undefined,
-        rootFolderId: row.rootFolderId ?? undefined,
-      });
+      const media = await this.mediaService.importFromTmdb(
+        {
+          type: row.mediaType,
+          tmdbId: row.tmdbId,
+          qualityProfileId: row.qualityProfileId ?? undefined,
+          languageProfileId: row.languageProfileId ?? undefined,
+          rootFolderId: row.rootFolderId ?? undefined,
+        },
+        row.userId ?? null,
+      );
       row.media = media;
     } catch (err) {
       // If already in library, resolve the existing media ID

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1587,6 +1587,7 @@
     "unmonitored": "Non surveillé",
     "unreleased": "Non sorti",
     "queued": "En file",
+    "missing_files": "Fichiers manquants",
     "play": "Lire",
     "open_detail": "Voir la fiche",
     "mark_watched": "Marquer comme vu",

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -42,8 +42,8 @@ import { TvSectionDirective } from '../../shared/directives/tv-section.directive
  *
  * ## Récemment ajoutés
  * Last 20 media added to the library (movies + series mixed),
- * excluding already-watched and missing-file entries.
- * Data: `GET /api/media?sortBy=createdAt&sortOrder=DESC&limit=20&excludeWatched=true&missing=false`.
+ * excluding already-watched entries. Includes items still awaiting download.
+ * Data: `GET /api/media?sortBy=createdAt&sortOrder=DESC&limit=20&excludeWatched=true`.
  *
  * ## Recommandations
  * Genre-based suggestions derived from the user's watch history.
@@ -224,7 +224,6 @@ export class HomeComponent implements OnInit, OnDestroy {
           sortOrder: 'DESC',
           limit: 20,
           excludeWatched: true,
-          missing: false,
           requestedByMe: mine || undefined,
         }),
         this.mediaService.getCalendar(startStr, in30dStr, true, mine).catch(() => []),

--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -43,14 +43,22 @@
       </div>
     }
 
-    <!-- Top-left: status badge or episode number -->
-    @if (statusBadge()) {
-      <div class="absolute top-1.5 left-1.5 z-20">
-        <span class="badge badge-sm" [ngClass]="statusBadge()!.class">{{ statusBadge()!.text }}</span>
-      </div>
-    } @else if (topLeftBadge()) {
-      <div class="absolute top-1.5 left-1.5 z-20">
-        <span class="badge badge-sm badge-neutral font-mono">{{ topLeftBadge() }}</span>
+    <!-- Top-left: missing-files indicator (auto), status badge, episode number -->
+    @if (_resolvedStatus() === 'missing' || statusBadge() || topLeftBadge()) {
+      <div class="absolute top-2 left-2 z-30 flex items-center gap-1">
+        @if (_resolvedStatus() === 'missing') {
+          <svg
+            lucideCircleX
+            class="h-5 w-5 text-error drop-shadow"
+            [attr.aria-label]="'media_card.missing_files' | translate"
+            [attr.title]="'media_card.missing_files' | translate"
+          ></svg>
+        }
+        @if (statusBadge()) {
+          <span class="badge badge-sm" [ngClass]="statusBadge()!.class">{{ statusBadge()!.text }}</span>
+        } @else if (topLeftBadge()) {
+          <span class="badge badge-sm badge-neutral font-mono">{{ topLeftBadge() }}</span>
+        }
       </div>
     }
 
@@ -75,10 +83,6 @@
           }
         }
       </div>
-    } @else if (status() === 'missing') {
-      <div class="absolute top-1.5 right-1.5 z-20">
-        <svg lucideCircleX class="h-5 w-5 text-error/60 drop-shadow"></svg>
-      </div>
     } @else if (interactiveWatched()) {
       <button
         type="button"
@@ -97,7 +101,7 @@
           [class.text-white/80]="status() !== 'watched'"
         ></svg>
       </button>
-    } @else if (status() === 'watched') {
+    } @else if (_resolvedStatus() === 'watched') {
       <div class="absolute top-1.5 right-1.5 z-20">
         <div class="w-6 h-6 rounded-full bg-success flex items-center justify-center shadow">
           <svg lucideCheck class="h-3.5 w-3.5 text-success-content"></svg>

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -339,6 +339,23 @@ export class MediaCardComponent {
     return actions;
   });
 
+  /**
+   * Resolved top-right status. Falls back to an auto-detected `'missing'`
+   * marker when the media is in the library but has no playable files yet
+   * (movies: no files; series: zero downloaded episodes), so cards in
+   * Recently Added / Library make the missing-file state immediately visible
+   * without each parent having to wire `[status]` itself.
+   */
+  protected readonly _resolvedStatus = computed((): CardStatus => {
+    if (this.status()) return this.status();
+    if (this.badge()) return null;
+    const m = this.media();
+    if (!m) return null;
+    const s = computeMediaBarStatus(m);
+    if (s === 'missing-monitored' || s === 'missing-unmonitored') return 'missing';
+    return null;
+  });
+
   /** Status badge shown in the top-left corner of the poster. */
   protected readonly statusBadge = computed((): { text: string; class: string } | null => {
     const s = this._barStatus();


### PR DESCRIPTION
## Summary
- New `media.addedById` FK (nullable, ON DELETE SET NULL) with a migration that backfills from the earliest matching `requests.userId`. Direct imports attribute to the caller; request approvals attribute to the requester (not the approving admin); Seerr request import claims orphan media for the Seerr requester. Home "Mine" filter is simplified to a single column lookup in list + calendar queries.
- Profile FKs (`qualityProfileId`/`languageProfileId`) now persist on import and update — `@RelationId` virtuals can't be written via `repo.create`/`.update`, so we set the relation object instead.
- Home "Recently Added" no longer hides media without files yet.
- Media-card auto-shows a missing-files indicator (top-left, kept above the hover overlay) when the media has no playable files, displayed alongside the Surveillé/Non surveillé badge.

## Test plan
- [ ] Run `npm run typeorm migration:run` and confirm `media.addedById` exists with the FK + index.
- [ ] Approve a pending Request → new Media has `addedById = request.userId`.
- [ ] Import directly via `/add/movie|tv/tmdb/:id` → `addedById = current user`.
- [ ] Toggle "Afficher uniquement les médias que j'ai demandé" on Home → shows both requested and directly-imported media for the current user.
- [ ] Edit profiles on an existing media → DB columns `qualityProfileId`/`languageProfileId` actually update (no `EntityPropertyNotFoundError`).
- [ ] Add a media; before any file is downloaded it appears in Home → Recently Added with the red CircleX icon top-left.
- [ ] Hover the card on desktop — the missing indicator stays visible above the overlay.