### PR TITLE
fix(media): use upper-bound ceilings on both axes for resolution detection

### DIFF
--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -2710,12 +2710,18 @@ export class MediaService {
     actualHeight?: number,
     actualWidth?: number,
   ): string {
-    // Use width to determine resolution (stable across aspect ratios)
+    // Resolution bucket from frame dimensions: first ceiling that fits BOTH
+    // width AND height wins. Ceilings on both axes absorb anamorphic / scope
+    // crops (e.g. a 1080p source encoded as 1796x1076 or 1920x800) which a
+    // width-only threshold mis-buckets as 720p.
+    const w = actualWidth ?? 0;
+    const h = actualHeight ?? 0;
     let resolution: number;
-    if (actualWidth && actualWidth >= 3800) resolution = 2160;
-    else if (actualWidth && actualWidth >= 1900) resolution = 1080;
-    else if (actualWidth && actualWidth >= 1260) resolution = 720;
-    else resolution = 480;
+    if (!w && !h) resolution = 480;
+    else if (w <= 720 && h <= 576) resolution = 480;
+    else if (w <= 1280 && h <= 962) resolution = 720;
+    else if (w <= 1920 && h <= 1440) resolution = 1080;
+    else resolution = 2160;
 
     // Determine source from filename (bluray, web, remux, etc.)
     const t = filename.replace(/\./g, ' ').toLowerCase();


### PR DESCRIPTION
## Summary
- Width-only thresholds in `resolveQuality()` mis-classified scope/anamorphic crops of 1080p sources (e.g. `1796x1076`, `1920x800`) as 720p.
- Switch to an upper-bound switch: the first ceiling that fits BOTH width AND height wins. A 1080p frame cropped on either axis now buckets as 1080p, while a true `1280x720` stays 720p.

## Test plan
- [ ] Rescan a library containing a known scope-cropped 1080p file (e.g. `1796x1076`) → its `media_files.quality` flips from `HDTV-720p` to `HDTV-1080p`.
- [ ] Rescan a native `1280x720` HDTV → stays 720p.
- [ ] Rescan a `3840x2160` 4K file → stays 2160p.
- [ ] Rescan a `1920x800` scope 1080p → buckets as 1080p.