### PR TITLE
feat(search): unify missing + cutoff-unmet rules across manual, auto and library

### DIFF
--- a/backend/src/migrations/1778300000000-backfill-media-language-profile.ts
+++ b/backend/src/migrations/1778300000000-backfill-media-language-profile.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Until now `resolveLanguageProfileIdForImport` could return null, leaving
+ * `media.languageProfileId` unset. We now require a language profile on
+ * every media (mirror of the quality-profile rule). Seed the default
+ * profile if none exists, then attribute it to every orphan media row.
+ */
+export class BackfillMediaLanguageProfile1778300000000
+  implements MigrationInterface
+{
+  name = 'BackfillMediaLanguageProfile1778300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const [existing] = await queryRunner.query(
+      `SELECT COUNT(*)::int AS c FROM "language_profiles"`,
+    );
+    if ((existing?.c ?? 0) === 0) {
+      await queryRunner.query(
+        `INSERT INTO "language_profiles"
+           ("name", "audioLanguages", "subtitleLanguages", "createdAt", "updatedAt")
+           VALUES ($1, $2, $3, now(), now())`,
+        ['Toutes les langues (défaut)', '[]', '[]'],
+      );
+    }
+    await queryRunner.query(
+      `UPDATE "media"
+          SET "languageProfileId" = (
+            SELECT id FROM "language_profiles" ORDER BY id ASC LIMIT 1
+          )
+        WHERE "languageProfileId" IS NULL`,
+    );
+  }
+
+  public async down(): Promise<void> {
+    // No rollback: we don't know which medias originally had no profile.
+  }
+}

--- a/backend/src/modules/media/episode-download.service.ts
+++ b/backend/src/modules/media/episode-download.service.ts
@@ -20,6 +20,7 @@ import {
   resolveUnknownLanguage,
 } from './release-language.parser';
 import { CustomFormatsService } from '../profiles/custom-formats.service';
+import { ProfilesService } from '../profiles/profiles.service';
 import { QualityDefinitionsService } from '../profiles/quality-definitions.service';
 import { BlocklistService } from '../blocklist/blocklist.service';
 import { NotificationsService } from '../notifications/notifications.service';
@@ -82,6 +83,7 @@ export class EpisodeDownloadService {
     private readonly blocklist: BlocklistService,
     private readonly notifications: NotificationsService,
     private readonly qualityDefs: QualityDefinitionsService,
+    private readonly profiles: ProfilesService,
   ) {}
 
   private allowedQualityIds(
@@ -125,21 +127,14 @@ export class EpisodeDownloadService {
       episodeId,
     );
 
-    const allowed = this.allowedQualityIds(media.qualityProfile?.items);
-    if (!allowed.size) {
-      throw new BadRequestException(
-        'Assign a quality profile with at least one allowed quality to this series',
-      );
-    }
+    const { allowed, allowedLangs } =
+      this.profiles.resolveAllowedForMediaOrThrow(media, 'series');
 
     const indexers = await this.indexerRepo.find({
       where: { enabled: true },
       order: { priority: 'ASC', id: 'ASC' },
     });
 
-    const allowedLangs = allowedAudioLanguageIds(
-      media.languageProfile?.audioLanguages,
-    );
     const sizeByQuality = await this.qualityDefs.getSizeLimitsMap();
     const indexerMinSeeders = buildIndexerMinSeeders(indexers);
     const indexerUnknownLang = new Map(
@@ -203,12 +198,10 @@ export class EpisodeDownloadService {
       );
     }
 
-    const allowed = this.allowedQualityIds(media.qualityProfile?.items);
-    if (!allowed.size) {
-      throw new BadRequestException(
-        'Assign a quality profile with at least one allowed quality to this series',
-      );
-    }
+    const { allowed } = this.profiles.resolveAllowedForMediaOrThrow(
+      media,
+      'series',
+    );
 
     let downloadUrl = dto?.downloadUrl?.trim();
     let sourceTitle = dto?.sourceTitle?.trim();
@@ -375,21 +368,14 @@ export class EpisodeDownloadService {
       );
     }
 
-    const allowed = this.allowedQualityIds(media.qualityProfile?.items);
-    if (!allowed.size) {
-      throw new BadRequestException(
-        'Assign a quality profile with at least one allowed quality to this series',
-      );
-    }
+    const { allowed, allowedLangs } =
+      this.profiles.resolveAllowedForMediaOrThrow(media, 'series');
 
     const indexers = await this.indexerRepo.find({
       where: { enabled: true },
       order: { priority: 'ASC', id: 'ASC' },
     });
 
-    const allowedLangs = allowedAudioLanguageIds(
-      media.languageProfile?.audioLanguages,
-    );
     const sizeByQuality = await this.qualityDefs.getSizeLimitsMap();
     const indexerMinSeeders = buildIndexerMinSeeders(indexers);
     const indexerUnknownLang = new Map(
@@ -460,12 +446,8 @@ export class EpisodeDownloadService {
       );
     }
 
-    const allowed = this.allowedQualityIds(media.qualityProfile?.items);
-    if (!allowed.size) {
-      throw new BadRequestException(
-        'Assign a quality profile with at least one allowed quality to this series',
-      );
-    }
+    const { allowed, allowedLangs } =
+      this.profiles.resolveAllowedForMediaOrThrow(media, 'series');
 
     const clients = await this.clientRepo.find({
       order: { priority: 'ASC', id: 'ASC' },
@@ -523,9 +505,6 @@ export class EpisodeDownloadService {
       order: { priority: 'ASC', id: 'ASC' },
     });
 
-    const allowedLangs = allowedAudioLanguageIds(
-      media.languageProfile?.audioLanguages,
-    );
     const sizeByQuality = await this.qualityDefs.getSizeLimitsMap();
     const indexerMinSeeders = buildIndexerMinSeeders(indexers);
     const indexerUnknownLang = new Map(

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -45,6 +45,7 @@ import {
   getAppQualityById,
   APP_QUALITIES,
 } from '../../common/constants/app-qualities';
+import { rankFromQualityString } from './release-rejection.helper';
 
 import { ImageService } from '../images/image.service';
 import { SubtitleStreamService } from '../streaming/subtitle-stream.service';
@@ -529,15 +530,72 @@ export class MediaService {
     });
 
     if (query.cutoffUnmet === true) {
-      const qualityByName = new Map(APP_QUALITIES.map((q) => [q.name, q]));
+      // Cutoff comparison must reach below the cutoff *on the unit that gets
+      // downloaded* — the whole movie for movies, each individual episode
+      // for series. The previous implementation looked at all
+      // `media.files[]` collectively for series, so a single upgraded
+      // episode hid every other below-cutoff one. We also fold "totally
+      // missing" media (no file → rank 0) into this bucket and lean on
+      // `parseReleaseQuality` (via {@link rankFromQualityString}) so legacy
+      // stored quality strings are parsed instead of needing an exact
+      // `APP_QUALITIES.name` match.
+      const cutoffByMedia = new Map<number, number>();
+      for (const m of enriched) {
+        if (!m.qualityProfile) continue;
+        const cq = getAppQualityById(m.qualityProfile.cutoff);
+        if (cq) cutoffByMedia.set(m.id, cq.rank);
+      }
+      const seriesIds = enriched
+        .filter(
+          (m) => m.type === MediaType.SERIES && cutoffByMedia.has(m.id),
+        )
+        .map((m) => m.id);
+      const epBestByMedia = new Map<number, Map<number, number>>();
+      if (seriesIds.length) {
+        const epRows: {
+          mediaId: number;
+          epId: number;
+          quality: string | null;
+        }[] = await this.dataSource.query(
+          `SELECT s."mediaId" AS "mediaId",
+                  e.id      AS "epId",
+                  f."quality" AS "quality"
+             FROM seasons s
+             JOIN episodes e ON e."seasonId" = s.id
+             LEFT JOIN media_files f ON f."episodeId" = e.id
+            WHERE s."mediaId" = ANY($1)
+              AND s."seasonNumber" > 0
+              AND e.monitored = true`,
+          [seriesIds],
+        );
+        for (const row of epRows) {
+          let byEp = epBestByMedia.get(row.mediaId);
+          if (!byEp) {
+            byEp = new Map();
+            epBestByMedia.set(row.mediaId, byEp);
+          }
+          const rank = rankFromQualityString(row.quality);
+          const prev = byEp.get(row.epId);
+          if (prev == null || rank > prev) byEp.set(row.epId, rank);
+        }
+      }
       enriched = enriched.filter((m) => {
-        if (!m.files?.length || !m.qualityProfile) return false;
-        const cutoffQuality = getAppQualityById(m.qualityProfile.cutoff);
-        if (!cutoffQuality) return false;
-        return !m.files.some((f) => {
-          const fq = qualityByName.get(f.quality);
-          return fq && fq.rank >= cutoffQuality.rank;
-        });
+        const cutoffRank = cutoffByMedia.get(m.id);
+        if (cutoffRank == null) return false;
+        if (m.type === MediaType.MOVIE) {
+          let rank = 0;
+          for (const f of m.files ?? []) {
+            const r = rankFromQualityString(f.quality);
+            if (r > rank) rank = r;
+          }
+          return rank < cutoffRank;
+        }
+        const byEp = epBestByMedia.get(m.id);
+        if (!byEp || byEp.size === 0) return false;
+        for (const rank of byEp.values()) {
+          if (rank < cutoffRank) return true;
+        }
+        return false;
       });
     }
 

--- a/backend/src/modules/media/movie-download.service.ts
+++ b/backend/src/modules/media/movie-download.service.ts
@@ -13,6 +13,7 @@ import { DownloadClient } from '../download-clients/entities/download-client.ent
 import { TorznabService, TorznabRelease } from '../indexers/torznab.service';
 import { QbittorrentService } from '../download-clients/qbittorrent.service';
 import { CustomFormatsService } from '../profiles/custom-formats.service';
+import { ProfilesService } from '../profiles/profiles.service';
 import { QualityDefinitionsService } from '../profiles/quality-definitions.service';
 import { BlocklistService } from '../blocklist/blocklist.service';
 import { NotificationsService } from '../notifications/notifications.service';
@@ -85,6 +86,7 @@ export class MovieDownloadService {
     private readonly blocklist: BlocklistService,
     private readonly notifications: NotificationsService,
     private readonly qualityDefs: QualityDefinitionsService,
+    private readonly profiles: ProfilesService,
   ) {}
 
   private allowedQualityIds(
@@ -155,12 +157,8 @@ export class MovieDownloadService {
       );
     }
 
-    const allowed = this.allowedQualityIds(media.qualityProfile?.items);
-    if (!allowed.size) {
-      throw new BadRequestException(
-        'Assign a quality profile with at least one allowed quality to this movie',
-      );
-    }
+    const { allowed, allowedLangs } =
+      this.profiles.resolveAllowedForMediaOrThrow(media, 'movie');
 
     const indexers = await this.indexerRepo.find({
       where: { enabled: true },
@@ -171,9 +169,6 @@ export class MovieDownloadService {
       indexers.map((ix) => this.searchIndexer(ix, query)),
     );
     const flat = batches.flat();
-    const allowedLangs = allowedAudioLanguageIds(
-      media.languageProfile?.audioLanguages,
-    );
 
     const rows = await this.buildMovieReleaseRows(
       flat,
@@ -206,12 +201,10 @@ export class MovieDownloadService {
       );
     }
 
-    const allowed = this.allowedQualityIds(media.qualityProfile?.items);
-    if (!allowed.size) {
-      throw new BadRequestException(
-        'Assign a quality profile with at least one allowed quality to this movie',
-      );
-    }
+    const { allowed } = this.profiles.resolveAllowedForMediaOrThrow(
+      media,
+      'movie',
+    );
 
     let downloadUrl = dto.downloadUrl?.trim();
     let sourceTitle = dto.sourceTitle?.trim();

--- a/backend/src/modules/media/release-rejection.helper.ts
+++ b/backend/src/modules/media/release-rejection.helper.ts
@@ -10,6 +10,19 @@ import {
 } from './release-language.parser';
 
 /**
+ * Resolve a stored media-file quality string (e.g. `"WEBDL-1080p"`,
+ * `"HDTV-720p"`) into its rank via {@link parseReleaseQuality}. Returns
+ * 0 for null / empty / unparsable input so callers can treat
+ * "no usable file" as "below any cutoff".
+ */
+export function rankFromQualityString(
+  quality: string | null | undefined,
+): number {
+  if (!quality) return 0;
+  return parseReleaseQuality(quality).quality.rank;
+}
+
+/**
  * Convert a language profile's audio language items into a set of app-language IDs
  * for rejection checking. Empty set = no language restriction.
  */

--- a/backend/src/modules/profiles/default-language-profile.ts
+++ b/backend/src/modules/profiles/default-language-profile.ts
@@ -1,0 +1,17 @@
+import { CreateLanguageProfileDto } from './dto/create-language-profile.dto';
+
+export const DEFAULT_LANGUAGE_PROFILE_NAME = 'Toutes les langues (défaut)';
+
+/**
+ * Default profile: no audio restriction, no forced subtitles. Exists so
+ * every media has *some* language profile assigned (mirror of the
+ * default quality profile). Runtime resolution never falls back to this —
+ * it is purely a seed.
+ */
+export function buildDefaultLanguageProfileDto(): CreateLanguageProfileDto {
+  return {
+    name: DEFAULT_LANGUAGE_PROFILE_NAME,
+    audioLanguages: [],
+    subtitleLanguages: [],
+  };
+}

--- a/backend/src/modules/profiles/profiles.module.ts
+++ b/backend/src/modules/profiles/profiles.module.ts
@@ -42,6 +42,7 @@ export class ProfilesModule implements OnModuleInit {
 
   onModuleInit() {
     void this.profiles.ensureDefaultQualityProfiles();
+    void this.profiles.ensureDefaultLanguageProfiles();
     void this.qualityDefs.ensureDefaults();
   }
 }

--- a/backend/src/modules/profiles/profiles.service.ts
+++ b/backend/src/modules/profiles/profiles.service.ts
@@ -10,6 +10,11 @@ import { LanguageProfile } from './entities/language-profile.entity';
 import { CreateQualityProfileDto } from './dto/create-quality-profile.dto';
 import { CreateLanguageProfileDto } from './dto/create-language-profile.dto';
 import { buildDefaultMovieQualityProfileDto } from './default-movie-quality-profile';
+import { buildDefaultLanguageProfileDto } from './default-language-profile';
+import {
+  buildAllowedQualityIds,
+  allowedAudioLanguageIds,
+} from '../media/release-rejection.helper';
 
 @Injectable()
 export class ProfilesService {
@@ -23,6 +28,11 @@ export class ProfilesService {
   async ensureDefaultQualityProfiles(): Promise<void> {
     if ((await this.qpRepo.count()) > 0) return;
     await this.createQualityProfile(buildDefaultMovieQualityProfileDto());
+  }
+
+  async ensureDefaultLanguageProfiles(): Promise<void> {
+    if ((await this.lpRepo.count()) > 0) return;
+    await this.createLanguageProfile(buildDefaultLanguageProfileDto());
   }
 
   async resolveQualityProfileIdForImport(
@@ -45,9 +55,60 @@ export class ProfilesService {
     return first?.id ?? null;
   }
 
+  /**
+   * Effective allowed-quality + allowed-audio-language sets for a media.
+   * No runtime fallback to system-default profiles — defaults are seeded
+   * once (via `ensureDefault*Profiles`) and the import flow assigns them
+   * automatically. A media reaching this code without a profile yields an
+   * empty allowed set; the search/grab pipelines treat that as "skip /
+   * refuse to act". The same rule applies to both quality and language.
+   */
+  resolveAllowedForMedia(media: {
+    qualityProfile?: QualityProfile | null;
+    languageProfile?: LanguageProfile | null;
+  }): { allowed: Set<number>; allowedLangs: Set<number> } {
+    return {
+      allowed: buildAllowedQualityIds(media.qualityProfile?.items),
+      allowedLangs: allowedAudioLanguageIds(
+        media.languageProfile?.audioLanguages,
+      ),
+    };
+  }
+
+  /**
+   * Strict variant for the manual grab paths: throws `BadRequest` with a
+   * caller-aware noun when either profile is missing, or when the quality
+   * profile has zero allowed qualities. The auto SearchMissing path uses
+   * the non-throwing variant and skips silently via `classifyForSearch`.
+   */
+  resolveAllowedForMediaOrThrow(
+    media: {
+      qualityProfile?: QualityProfile | null;
+      languageProfile?: LanguageProfile | null;
+    },
+    noun: 'movie' | 'series',
+  ): { allowed: Set<number>; allowedLangs: Set<number> } {
+    if (!media.qualityProfile) {
+      throw new BadRequestException(
+        `Assign a quality profile with at least one allowed quality to this ${noun}`,
+      );
+    }
+    if (!media.languageProfile) {
+      throw new BadRequestException(`Assign a language profile to this ${noun}`);
+    }
+    const sets = this.resolveAllowedForMedia(media);
+    if (!sets.allowed.size) {
+      throw new BadRequestException(
+        `Assign a quality profile with at least one allowed quality to this ${noun}`,
+      );
+    }
+    return sets;
+  }
+
   async resolveLanguageProfileIdForImport(
     requested?: number,
   ): Promise<number | null> {
+    await this.ensureDefaultLanguageProfiles();
     if (requested != null) {
       const p = await this.lpRepo.findOne({ where: { id: requested } });
       if (!p) {
@@ -57,7 +118,11 @@ export class ProfilesService {
       }
       return p.id;
     }
-    return null;
+    const [first] = await this.lpRepo.find({
+      order: { id: 'ASC' },
+      take: 1,
+    });
+    return first?.id ?? null;
   }
 
   async createQualityProfile(

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -29,15 +29,16 @@ import {
   buildSpriteLabel,
 } from '../streaming/thumbnail.service';
 import { CustomFormatsService } from '../profiles/custom-formats.service';
+import { ProfilesService } from '../profiles/profiles.service';
 import { QualityDefinitionsService } from '../profiles/quality-definitions.service';
 import { BlocklistService } from '../blocklist/blocklist.service';
 import { MarkersService } from '../markers/markers.service';
 import {
-  buildAllowedQualityIds,
   buildIndexerMinSeeders,
-  allowedAudioLanguageIds,
+  rankFromQualityString,
   scoreAndSortReleases,
 } from '../media/release-rejection.helper';
+import { getAppQualityById } from '../../common/constants/app-qualities';
 
 /** Yield the event loop so HTTP requests aren't starved by bulk tasks. */
 const yieldLoop = () => new Promise<void>((r) => setTimeout(r, 50));
@@ -77,6 +78,7 @@ export class SchedulerService implements OnModuleInit {
     private readonly qualityDefs: QualityDefinitionsService,
     private readonly blocklist: BlocklistService,
     private readonly markers: MarkersService,
+    private readonly profiles: ProfilesService,
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -384,17 +386,22 @@ export class SchedulerService implements OnModuleInit {
     indexers: Indexer[],
     qbitClient: DownloadClient,
   ): Promise<void> {
-    const missing = await this.mediaRepo
+    // Candidates = monitored movies that are either missing on disk OR have
+    // files below the cutoff. SQL keeps the first cut narrow; the
+    // file-vs-cutoff comparison is finished in JS using `currentRankOf`.
+    const candidates = await this.mediaRepo
       .createQueryBuilder('m')
-      .leftJoin('m.files', 'f')
       .leftJoinAndSelect('m.qualityProfile', 'qp')
       .leftJoinAndSelect('m.languageProfile', 'lp')
+      .leftJoinAndSelect('m.files', 'f')
       .where('m.monitored = true')
       .andWhere('m.type = :type', { type: MediaType.MOVIE })
-      .andWhere('f.id IS NULL')
+      // Narrow to rows that *could* need action: nothing on disk OR a profile
+      // that allows upgrades. Cutoff comparison is finished in JS.
+      .andWhere('(f.id IS NULL OR qp."upgradeAllowed" = true)')
       .getMany();
 
-    if (!missing.length) return;
+    if (!candidates.length) return;
 
     const today = new Date().toISOString().slice(0, 10);
     const sizeByQuality = await this.qualityDefs.getSizeLimitsMap();
@@ -406,17 +413,27 @@ export class SchedulerService implements OnModuleInit {
       ]),
     );
 
-    for (let i = 0; i < missing.length; i++) {
-      const media = missing[i];
+    for (let i = 0; i < candidates.length; i++) {
+      const media = candidates[i];
       this.eventsService.emit({
         type: 'task.progress',
         command: 'SearchMissing',
         current: i,
-        total: missing.length,
+        total: candidates.length,
         message: media.title,
       });
 
       if (!this.isAvailable(media, today)) continue;
+
+      const decision = this.classifyForSearch(media, media.files ?? []);
+      if (decision.mode !== 'missing' && decision.mode !== 'upgrade') {
+        if (decision.mode === 'unprofiled') {
+          this.log.debug?.(
+            `SearchMissing[movie]: "${media.title}" has no quality profile — skipped (assign one to enable auto-grab/upgrade)`,
+          );
+        }
+        continue;
+      }
 
       const pending = await this.historyRepo.findOne({
         where: { media: { id: media.id }, status: 'grabbed' },
@@ -432,13 +449,13 @@ export class SchedulerService implements OnModuleInit {
       );
       if (!results.length) continue;
 
+      const { allowed, allowedLangs } =
+        this.profiles.resolveAllowedForMedia(media);
       const sorted = await scoreAndSortReleases(
         results,
         {
-          allowed: buildAllowedQualityIds(media.qualityProfile?.items),
-          allowedLangs: allowedAudioLanguageIds(
-            media.languageProfile?.audioLanguages,
-          ),
+          allowed,
+          allowedLangs,
           sizeByQuality,
           indexerMinSeeders,
           indexerUnknownLang,
@@ -446,10 +463,15 @@ export class SchedulerService implements OnModuleInit {
         },
         this.scorerDeps(),
       );
-      const pick = sorted.find((r) => r.rejections.length === 0);
+      const pick = sorted.find(
+        (r) =>
+          r.rejections.length === 0 &&
+          r.rank > decision.minRankExclusive &&
+          r.rank <= decision.maxRankInclusive,
+      );
       if (!pick) {
         this.log.debug?.(
-          `SearchMissing[movie]: no release without rejections for "${media.title}" (${sorted.length} checked)`,
+          `SearchMissing[movie]: no eligible release for "${media.title}" (mode=${decision.mode}, ${sorted.length} checked)`,
         );
         continue;
       }
@@ -486,10 +508,64 @@ export class SchedulerService implements OnModuleInit {
     this.eventsService.emit({
       type: 'task.progress',
       command: 'SearchMissing',
-      current: missing.length,
-      total: missing.length,
+      current: candidates.length,
+      total: candidates.length,
       message: 'SearchMissing',
     });
+  }
+
+  /**
+   * Decide what (if anything) SearchMissing should do for a given media.
+   *
+   * - `skip`        — has files at/above cutoff, OR has files but profile
+   *                   forbids upgrades, OR no monitored profile.
+   * - `unprofiled`  — no quality profile assigned: we refuse to act without
+   *                   one. The system-default profile is a seed only and is
+   *                   NOT applied at runtime.
+   * - `missing`     — no files on disk; grab the best release.
+   * - `upgrade`     — has files below cutoff and `upgradeAllowed` is true;
+   *                   only releases strictly better than current AND within
+   *                   cutoff are eligible.
+   */
+  private classifyForSearch(
+    media: Media,
+    files: { quality?: string | null }[],
+  ):
+    | { mode: 'skip' | 'unprofiled' }
+    | {
+        mode: 'missing' | 'upgrade';
+        minRankExclusive: number;
+        maxRankInclusive: number;
+      } {
+    // Same rule for both axes: a media without a profile gets no action.
+    // Defaults are seeded at install and assigned automatically by the import
+    // flow; there is no runtime fallback.
+    if (!media.qualityProfile || !media.languageProfile) {
+      return { mode: 'unprofiled' };
+    }
+    if (!files.length) {
+      return {
+        mode: 'missing',
+        minRankExclusive: 0,
+        maxRankInclusive: Number.POSITIVE_INFINITY,
+      };
+    }
+    // Files exist — upgrade only.
+    const profile = media.qualityProfile;
+    if (!profile.upgradeAllowed) return { mode: 'skip' };
+    let currentRank = 0;
+    for (const f of files) {
+      const r = rankFromQualityString(f.quality);
+      if (r > currentRank) currentRank = r;
+    }
+    const cutoffRank = getAppQualityById(profile.cutoff)?.rank;
+    if (cutoffRank == null) return { mode: 'skip' };
+    if (currentRank >= cutoffRank) return { mode: 'skip' };
+    return {
+      mode: 'upgrade',
+      minRankExclusive: currentRank,
+      maxRankInclusive: cutoffRank,
+    };
   }
 
   private async searchMissingEpisodes(
@@ -506,8 +582,9 @@ export class SchedulerService implements OnModuleInit {
       ]),
     );
 
-    // Find monitored series with monitored, un-downloaded, aired episodes.
-    // Include quality + language profiles for scoring.
+    // Candidate episodes: aired & monitored, on a monitored series — and
+    // either missing on disk OR potentially upgradeable. The cutoff
+    // comparison is finished in JS using the linked MediaFile's quality.
     const episodes = await this.episodeRepo
       .createQueryBuilder('ep')
       .innerJoin('ep.season', 'season')
@@ -518,15 +595,46 @@ export class SchedulerService implements OnModuleInit {
       .andWhere('media.type = :type', { type: MediaType.SERIES })
       .andWhere('season.monitored = true')
       .andWhere('ep.monitored = true')
-      .andWhere('ep.hasFile = false')
       .andWhere('ep.airDate IS NOT NULL')
       .andWhere('ep.airDate <= :today', { today })
-      .select(['ep.id', 'ep.episodeNumber', 'ep.title', 'ep.airDate'])
+      .andWhere('(ep.hasFile = false OR qp."upgradeAllowed" = true)')
+      .select([
+        'ep.id',
+        'ep.episodeNumber',
+        'ep.title',
+        'ep.airDate',
+        'ep.hasFile',
+      ])
       .addSelect(['season.id', 'season.seasonNumber', 'season.mediaId'])
       .addSelect(['media.id', 'media.title', 'media.year', 'media.runtime'])
       .getMany();
 
     if (!episodes.length) return;
+
+    // Batch-load the linked MediaFile quality for upgrade-candidate episodes
+    // so the cutoff comparison runs in JS without an N+1.
+    const upgradeEpIds = episodes
+      .filter((e) => e.hasFile)
+      .map((e) => e.id);
+    const fileQualityByEpId = new Map<number, string>();
+    if (upgradeEpIds.length) {
+      const fileRows = await this.mediaFileRepo
+        .createQueryBuilder('f')
+        .select(['f.episodeId AS "episodeId"', 'f.quality AS "quality"'])
+        .where('f.episodeId IN (:...ids)', { ids: upgradeEpIds })
+        .getRawMany<{ episodeId: number; quality: string }>();
+      for (const row of fileRows) {
+        // Multiple files per ep: keep the best quality seen.
+        const prev = fileQualityByEpId.get(row.episodeId);
+        if (!prev) {
+          fileQualityByEpId.set(row.episodeId, row.quality);
+          continue;
+        }
+        const prevRank = rankFromQualityString(prev);
+        const curRank = rankFromQualityString(row.quality);
+        if (curRank > prevRank) fileQualityByEpId.set(row.episodeId, row.quality);
+      }
+    }
 
     for (let i = 0; i < episodes.length; i++) {
       const ep = episodes[i];
@@ -541,6 +649,19 @@ export class SchedulerService implements OnModuleInit {
         total: episodes.length,
         message: `${media.title} ${epLabel}`,
       });
+
+      const fileLike = ep.hasFile
+        ? [{ quality: fileQualityByEpId.get(ep.id) ?? null }]
+        : [];
+      const decision = this.classifyForSearch(media, fileLike);
+      if (decision.mode !== 'missing' && decision.mode !== 'upgrade') {
+        if (decision.mode === 'unprofiled') {
+          this.log.debug?.(
+            `SearchMissing[series]: "${media.title}" ${epLabel} has no quality profile — skipped`,
+          );
+        }
+        continue;
+      }
 
       const pending = await this.historyRepo
         .createQueryBuilder('h')
@@ -567,13 +688,13 @@ export class SchedulerService implements OnModuleInit {
       );
       if (!results.length) continue;
 
+      const { allowed, allowedLangs } =
+        this.profiles.resolveAllowedForMedia(media);
       const sorted = await scoreAndSortReleases(
         results,
         {
-          allowed: buildAllowedQualityIds(media.qualityProfile?.items),
-          allowedLangs: allowedAudioLanguageIds(
-            media.languageProfile?.audioLanguages,
-          ),
+          allowed,
+          allowedLangs,
           sizeByQuality,
           indexerMinSeeders,
           indexerUnknownLang,
@@ -582,10 +703,15 @@ export class SchedulerService implements OnModuleInit {
         },
         this.scorerDeps(),
       );
-      const pick = sorted.find((r) => r.rejections.length === 0);
+      const pick = sorted.find(
+        (r) =>
+          r.rejections.length === 0 &&
+          r.rank > decision.minRankExclusive &&
+          r.rank <= decision.maxRankInclusive,
+      );
       if (!pick) {
         this.log.debug?.(
-          `SearchMissing[series]: no release without rejections for "${media.title}" ${epLabel} (${sorted.length} checked)`,
+          `SearchMissing[series]: no eligible release for "${media.title}" ${epLabel} (mode=${decision.mode}, ${sorted.length} checked)`,
         );
         continue;
       }


### PR DESCRIPTION
## Summary

- `ProfilesService.resolveAllowedForMedia[OrThrow]` centralises the
  quality+language profile resolution. Default quality/language profiles are
  seed-only (created on install via \`ensureDefault*Profiles\` and assigned on
  import via \`resolve*ProfileIdForImport\`); no runtime fallback. A media
  without an explicit profile gets no action, manual or auto. Same rule for
  both axes.
- New default language profile (\`Toutes les langues (défaut)\`, audio +
  subtitles vides) mirrors the default quality profile, and migration
  \`1778300000000\` backfills \`media.languageProfileId\` for orphans imported
  before this was wired.
- SearchMissing cron now retries "cutoff-unmet" media too, not only totally
  missing ones. \`classifyForSearch(media, files)\` returns
  \`missing\` / \`upgrade\` / \`skip\` / \`unprofiled\` plus an eligible-rank
  window \`(minRankExclusive, maxRankInclusive]\` applied to the release pick,
  so upgrades stay strictly above current AND within cutoff.
- Library \`cutoffUnmet\` filter rewritten:
  - Uses \`parseReleaseQuality\` (\`rankFromQualityString\` helper) instead of
    an exact \`APP_QUALITIES.name\` match — fixes silent mis-classification of
    legacy quality strings.
  - Per-episode logic for series: cutoff-unmet when any monitored episode's
    best file is below cutoff or absent (the old code looked at
    \`media.files[]\` collectively, hiding below-cutoff episodes as soon as
    one episode was upgraded).
  - Includes totally missing media (rank 0 < any cutoff).

## Test plan
- [ ] Run migrations → \`media.languageProfileId\` populated everywhere; a
  default language profile exists in \`language_profiles\`.
- [ ] Import a new movie → both \`qualityProfileId\` and \`languageProfileId\`
  set from defaults.
- [ ] Manually unset \`languageProfileId\` on a media → manual grab returns
  \`Assign a language profile to this …\`; auto SearchMissing logs and skips.
- [ ] On a profile with \`upgradeAllowed = true\` and an existing file below
  the cutoff, \`SearchMissing\` picks a release strictly better than current
  and at-or-below cutoff. With \`upgradeAllowed = false\`, no upgrade attempt.
- [ ] Library \`cutoffUnmet\` filter:
  - A series with all episodes downloaded at cutoff doesn't appear.
  - A series with one episode missing OR one below cutoff appears.
  - A movie with no files appears.
  - A movie with a 720p file under a 1080p cutoff appears.