### PR TITLE
refactor(downloads): centralise torrent ↔ history matching + type status

### DIFF
--- a/backend/src/modules/download-clients/download-clients.module.ts
+++ b/backend/src/modules/download-clients/download-clients.module.ts
@@ -6,6 +6,7 @@ import { QbittorrentService } from './qbittorrent.service';
 import { DownloadClientsService } from './download-clients.service';
 import { DownloadClientsController } from './download-clients.controller';
 import { AuthModule } from '../auth/auth.module';
+import { TorrentHistoryMatcher } from '../media/torrent-history-matcher.service';
 
 @Module({
   imports: [
@@ -13,7 +14,7 @@ import { AuthModule } from '../auth/auth.module';
     AuthModule,
   ],
   controllers: [DownloadClientsController],
-  providers: [QbittorrentService, DownloadClientsService],
-  exports: [TypeOrmModule, QbittorrentService],
+  providers: [QbittorrentService, DownloadClientsService, TorrentHistoryMatcher],
+  exports: [TypeOrmModule, QbittorrentService, TorrentHistoryMatcher],
 })
 export class DownloadClientsModule {}

--- a/backend/src/modules/download-clients/download-clients.service.ts
+++ b/backend/src/modules/download-clients/download-clients.service.ts
@@ -8,6 +8,7 @@ import { QbittorrentService, QbittorrentTorrent } from './qbittorrent.service';
 import { CreateDownloadClientDto } from './dto/create-download-client.dto';
 import { UpdateDownloadClientDto } from './dto/update-download-client.dto';
 import { TestDownloadClientDto } from './dto/test-download-client.dto';
+import { TorrentHistoryMatcher } from '../media/torrent-history-matcher.service';
 
 export interface QueueEntry extends QbittorrentTorrent {
   clientId: number;
@@ -55,6 +56,7 @@ export class DownloadClientsService {
     @InjectRepository(DownloadHistory)
     private readonly historyRepo: Repository<DownloadHistory>,
     private readonly qbittorrent: QbittorrentService,
+    private readonly historyMatcher: TorrentHistoryMatcher,
   ) {}
 
   async testConnection(
@@ -246,16 +248,10 @@ export class DownloadClientsService {
     });
 
     for (const entry of results) {
-      const hash = entry.hash?.toLowerCase();
-      const name = entry.name.toLowerCase();
-
-      const match =
-        historyEntries.find((h) => h.torrentHash && h.torrentHash === hash) ??
-        historyEntries.find(
-          (h) =>
-            h.sourceTitle.toLowerCase() === name ||
-            name.startsWith(h.sourceTitle.toLowerCase()),
-        );
+      const match = await this.historyMatcher.matchAndHeal(
+        entry,
+        historyEntries,
+      );
       if (match?.media) {
         entry.mediaId = match.mediaId;
         entry.mediaTitle = match.media.title;

--- a/backend/src/modules/media/entities/download-history.entity.ts
+++ b/backend/src/modules/media/entities/download-history.entity.ts
@@ -4,6 +4,19 @@ import { Media } from './media.entity';
 import { Indexer } from '../../indexers/entities/indexer.entity';
 import { DownloadClient } from '../../download-clients/entities/download-client.entity';
 
+/** Canonical lifecycle of a {@link DownloadHistory} row. */
+export const DOWNLOAD_HISTORY_STATUSES = [
+  'grabbed',
+  'importing',
+  'completed',
+  'failed',
+  'warning',
+] as const;
+export type DownloadHistoryStatus = (typeof DOWNLOAD_HISTORY_STATUSES)[number];
+
+/** Whether the grab was triggered by a user (manual) or by the scheduler (auto). */
+export type GrabSource = 'auto' | 'manual';
+
 @Entity('download_history')
 export class DownloadHistory extends BaseEntity {
   @ManyToOne(() => Media, { onDelete: 'CASCADE' })
@@ -40,7 +53,7 @@ export class DownloadHistory extends BaseEntity {
   torrentHash: string;
 
   @Column({ default: 'grabbed' })
-  status: string;
+  status: DownloadHistoryStatus;
 
   @Column({ type: 'text', nullable: true })
   statusMessage: string;
@@ -51,5 +64,5 @@ export class DownloadHistory extends BaseEntity {
    * Used by the stalled-cleanup job to decide whether re-grab after removal.
    */
   @Column({ type: 'varchar', length: 8, default: 'auto' })
-  grabSource: 'auto' | 'manual';
+  grabSource: GrabSource;
 }

--- a/backend/src/modules/media/torrent-history-matcher.service.ts
+++ b/backend/src/modules/media/torrent-history-matcher.service.ts
@@ -1,0 +1,120 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DownloadHistory } from './entities/download-history.entity';
+
+/** A subset of `QbittorrentTorrent` — all the matcher actually needs. */
+export interface MatchableTorrent {
+  hash?: string | null;
+  name: string;
+}
+
+export type MatchedBy = 'hash' | 'exact-name' | 'unique-prefix';
+
+export interface HistoryMatch {
+  history: DownloadHistory;
+  matchedBy: MatchedBy;
+}
+
+/**
+ * Single source of truth for the "which DownloadHistory does this qBittorrent
+ * torrent belong to" lookup. Three call sites used to inline three slightly
+ * different versions: `CompletionService.processCompleted`, the orphan-purge
+ * preamble inside it, and `DownloadClientsService.getQueue`. Each had its
+ * own bugs around `startsWith` cross-matching and none persisted the
+ * recovered `torrentHash` back onto the history row — so legacy auto-grabs
+ * (pre-PR-#82) without a hash stayed unmatched at every tick, surfacing in
+ * the Activities view as "downloads not linked to a media".
+ *
+ * Rules, in order:
+ *  1. `history.torrentHash === torrent.hash` — definitive.
+ *  2. Exactly one history with `sourceTitle === torrent.name`.
+ *  3. Exactly one history whose `sourceTitle` is a prefix of `torrent.name`
+ *     (or vice-versa). Multiple candidates abort instead of cross-matching.
+ *
+ * On (2) and (3) the matched history's `torrentHash` is filled in if it
+ * was null — self-healing legacy data without requiring a migration.
+ */
+@Injectable()
+export class TorrentHistoryMatcher {
+  private readonly log = new Logger(TorrentHistoryMatcher.name);
+
+  constructor(
+    @InjectRepository(DownloadHistory)
+    private readonly historyRepo: Repository<DownloadHistory>,
+  ) {}
+
+  findMatch(
+    torrent: MatchableTorrent,
+    histories: DownloadHistory[],
+  ): HistoryMatch | null {
+    const hash = torrent.hash?.toLowerCase() ?? null;
+    const name = torrent.name.toLowerCase();
+
+    if (hash) {
+      const byHash = histories.find(
+        (h) => h.torrentHash && h.torrentHash.toLowerCase() === hash,
+      );
+      if (byHash) return { history: byHash, matchedBy: 'hash' };
+    }
+
+    const exact = histories.filter(
+      (h) => h.sourceTitle?.toLowerCase() === name,
+    );
+    if (exact.length === 1) {
+      return { history: exact[0], matchedBy: 'exact-name' };
+    }
+    if (exact.length > 1) {
+      // Ambiguous exact match — refuse rather than guess.
+      this.log.warn(
+        `TorrentHistoryMatcher: ${exact.length} histories share sourceTitle="${torrent.name}" — refusing to cross-match`,
+      );
+      return null;
+    }
+
+    const prefix = histories.filter((h) => {
+      if (!h.sourceTitle) return false;
+      const s = h.sourceTitle.toLowerCase();
+      return name.startsWith(s) || s.startsWith(name);
+    });
+    if (prefix.length === 1) {
+      return { history: prefix[0], matchedBy: 'unique-prefix' };
+    }
+    if (prefix.length > 1) {
+      this.log.warn(
+        `TorrentHistoryMatcher: ${prefix.length} histories with prefix overlap on "${torrent.name}" — skipped`,
+      );
+    }
+    return null;
+  }
+
+  /**
+   * Persist the torrent hash on a history row when the matcher resolved it
+   * by name. Cheap idempotent UPDATE — safe to call on every match.
+   */
+  async healHash(history: DownloadHistory, hash: string): Promise<void> {
+    if (!hash || history.torrentHash) return;
+    await this.historyRepo.update(history.id, { torrentHash: hash });
+    history.torrentHash = hash;
+    this.log.log(
+      `TorrentHistoryMatcher: healed torrentHash=${hash} on history #${history.id} ("${history.sourceTitle}")`,
+    );
+  }
+
+  /**
+   * Convenience: match + self-heal in one call. Returns the history row or
+   * null. Use when the caller can't easily distinguish "hash" vs "name"
+   * matches itself.
+   */
+  async matchAndHeal(
+    torrent: MatchableTorrent,
+    histories: DownloadHistory[],
+  ): Promise<DownloadHistory | null> {
+    const match = this.findMatch(torrent, histories);
+    if (!match) return null;
+    if (match.matchedBy !== 'hash' && torrent.hash) {
+      await this.healHash(match.history, torrent.hash.toLowerCase());
+    }
+    return match.history;
+  }
+}

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -34,6 +34,7 @@ import { relativePathUnderMediaRoot } from '../../common/utils/media-path.util';
 import { StalledCheck } from './entities/stalled-check.entity';
 import { CleanupProfile } from '../cleanup-profiles/entities/cleanup-profile.entity';
 import { Library } from '../libraries/entities/library.entity';
+import { TorrentHistoryMatcher } from '../media/torrent-history-matcher.service';
 
 @Injectable()
 export class CompletionService {
@@ -73,6 +74,7 @@ export class CompletionService {
     private readonly events: EventsService,
     private readonly ffprobe: FfprobeService,
     private readonly thumbnailService: ThumbnailService,
+    private readonly historyMatcher: TorrentHistoryMatcher,
   ) {}
 
   @Cron(CronExpression.EVERY_MINUTE)
@@ -110,21 +112,16 @@ export class CompletionService {
         t.state === 'stoppedUP',
     );
 
-    // Purge grabbed/failed entries that have no matching torrent in any client
-    const allTorrentHashes = new Set(
-      allTorrents.map((t) => t.hash?.toLowerCase()),
-    );
-    const allTorrentNames = new Set(
-      allTorrents.map((t) => t.name.toLowerCase()),
-    );
-    const orphaned = grabbed.filter(
-      (h) =>
-        !(h.torrentHash && allTorrentHashes.has(h.torrentHash)) &&
-        !allTorrentNames.has(h.sourceTitle.toLowerCase()) &&
-        !allTorrents.some((t) =>
-          t.name.toLowerCase().startsWith(h.sourceTitle.toLowerCase()),
-        ),
-    );
+    // Purge grabbed/failed entries that have no matching torrent in any
+    // client. Build the reverse view: for each history, ask the matcher
+    // whether at least one current torrent maps to it — exactly the same
+    // rule processCompleted uses below to find the import target.
+    const matchedHistoryIds = new Set<number>();
+    for (const t of allTorrents) {
+      const m = this.historyMatcher.findMatch(t, grabbed);
+      if (m) matchedHistoryIds.add(m.history.id);
+    }
+    const orphaned = grabbed.filter((h) => !matchedHistoryIds.has(h.id));
     if (orphaned.length) {
       await this.historyRepo.remove(orphaned);
       this.log.log(
@@ -168,18 +165,19 @@ export class CompletionService {
       order: { path: 'ASC' },
     });
 
+    // Reverse-lookup: build `historyId → torrent` from the matcher (which
+    // also self-heals missing torrentHash on each history row).
+    const torrentByHistoryId = new Map<
+      number,
+      (typeof completedTorrents)[number]
+    >();
+    for (const t of completedTorrents) {
+      const matchedHistory = await this.historyMatcher.matchAndHeal(t, grabbed);
+      if (matchedHistory) torrentByHistoryId.set(matchedHistory.id, t);
+    }
+
     for (const history of grabbed) {
-      const torrent =
-        completedTorrents.find(
-          (t) =>
-            history.torrentHash &&
-            t.hash?.toLowerCase() === history.torrentHash,
-        ) ??
-        completedTorrents.find(
-          (t) =>
-            t.name.toLowerCase() === history.sourceTitle.toLowerCase() ||
-            t.name.toLowerCase().startsWith(history.sourceTitle.toLowerCase()),
-        );
+      const torrent = torrentByHistoryId.get(history.id);
       if (!torrent) {
         this.log.debug(
           `Import: no completed torrent matching "${history.sourceTitle}" (mediaId=${history.mediaId})`,


### PR DESCRIPTION
## Summary
- New \`TorrentHistoryMatcher\` service owns the lookup previously inlined (with slightly different rules) in three places:
  - The orphan purge in \`CompletionService.processCompleted\`
  - The completion match in the same method
  - The queue entry resolution in \`DownloadClientsService.getQueue\`
- Priority is hash → exact name → unique prefix. Ambiguous multi-candidate matches are refused instead of silently picking the first, fixing the \`Dune.2021\` / \`Dune.2021.Part.Two\` cross-match class.
- \`matchAndHeal\` variant persists the discovered hash back onto the history row, so legacy auto-grabs (pre-PR-#82) that lacked a \`torrentHash\` self-heal on first sighting. This is what fixes the prod report of \"many downloads not linked to a media\" in the Activities view without needing a one-off backfill.
- Type \`DownloadHistory.status\` as the \`DownloadHistoryStatus\` literal union (\`grabbed | importing | completed | failed | warning\`) and export \`DOWNLOAD_HISTORY_STATUSES\` for callers iterating the values. Catches typos at compile time without renaming any DB rows.

## Test plan
- [ ] After deploy, hit \`/api/download-clients/queue\` in a tab that previously had unlinked torrents → unlinked entries gain \`mediaId\`/\`mediaTitle\`. Subsequent \`SELECT torrentHash FROM download_history\` shows hashes filled in for the matched rows.
- [ ] Two histories with overlapping sourceTitle prefixes (e.g. \`Dune.2021\` and \`Dune.2021.Part.Two\`) → no cross-match, log shows the refusal.
- [ ] \`processCompleted\` cron still imports correctly for both hash-tracked and name-only matches.