### PR TITLE
fix(media-detail): hide Grab + Search-releases when not actionable

### DIFF
--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -435,7 +435,14 @@
       <span class="flex-1">{{ (watched() ? 'media_detail.mark_series_unwatched' : 'media_detail.mark_series_watched') | translate }}</span>
     </button>
   }
-  @if (canGrab()) {
+  <!-- Grab + Search releases are per-unit (movie or single episode). Hide
+       on the series-level header — the user picks a specific episode
+       from the seasons grid first, which renders its own header with
+       `mediaType` defaulting to 'movie'. Also gated on `qualityProfileName`
+       because the back-end refuses both actions without a quality profile;
+       surfacing greyed-out buttons that only ever throw an error toast is
+       worse than hiding them entirely until a profile is assigned. -->
+  @if (canGrab() && mediaType() !== 'series' && qualityProfileName()) {
     <button type="button" [disabled]="grabBusy() !== null" class="dropdown-item text-white" (click)="grabBest.emit()">
       @if (grabBusy() === 'best') { <span class="loading loading-spinner loading-sm"></span> }
       @else { <svg lucideDownload class="h-5 w-5 shrink-0 opacity-80"></svg> }


### PR DESCRIPTION
## Summary
- The series-level \`media-info-header\` dropdown shows \`Grab best\` and \`Search releases\`, but both back-end paths early-return on series (\`m.type !== 'movie'\`) so the modal never opens. Hide the buttons on the series header.
- Also hide them when \`qualityProfileName\` is null — the back-end now throws \`Assign a quality profile…\` in that case, and a greyed button that only fires an error toast is worse UX than no button.
- Episode header (picked from the seasons grid) defaults \`mediaType\` to \`'movie'\` so its buttons stay visible.

## Test plan
- [ ] Open a series detail page → dropdown no longer shows \"Grab best\" / \"Search releases\".
- [ ] Pick an episode → its header still has them.
- [ ] Movie detail with no quality profile assigned → buttons hidden.
- [ ] Movie detail with a quality profile → both buttons present and modal opens on click.