### PR TITLE
fix(nav): suppress back-arrow flash on first dock click

### DIFF
--- a/client/src/app/core/services/navbar.service.ts
+++ b/client/src/app/core/services/navbar.service.ts
@@ -87,10 +87,18 @@ export class NavbarService {
     });
   }
 
-  /** Reset history tracking — called when a top-level nav entry (home, library, …) is chosen. */
+  /**
+   * Reset history tracking — called from top-level nav entries (home,
+   * downloads, search, …). Click handlers fire *before* the resulting
+   * `NavigationEnd`, so we also flip `isPoppingBack` to suppress the
+   * push that would otherwise re-add the page we're leaving onto the
+   * freshly-cleared stack — which is why the back arrow used to flash
+   * on the first dock click and only disappear on the second.
+   */
   resetNavHistory() {
     this.navCount = 0;
     this.history.length = 0;
+    this.isPoppingBack = true;
     this.canGoBack.set(false);
   }
 


### PR DESCRIPTION
## Summary
- The mobile dock nav links call \`resetNavHistory()\` on click. The handler fires *before* the resulting \`NavigationEnd\`, which then re-pushes the page the user was leaving onto the freshly-cleared stack — bringing \`canGoBack\` back to true for one render. The arrow flashed in then disappeared on the second tap.
- Flip \`isPoppingBack = true\` inside \`resetNavHistory()\` so the next \`NavigationEnd\` skips its push, mirroring how browser-back already suppresses the push for popstate navigations.

## Test plan
- [ ] On phone, fresh load → navigate Home → Downloads via dock → back arrow stays hidden.
- [ ] Navigate Home → media-detail → Downloads via dock → arrow still hidden after the dock tap.
- [ ] Tap a media card from Home → arrow appears on the detail page. Browser back → home, arrow gone (regression check).