### PR TITLE
fix(cache): wipe server-data caches on logout / switch user / switch server

### DIFF
--- a/client/src/app/core/interceptors/cache.interceptor.ts
+++ b/client/src/app/core/interceptors/cache.interceptor.ts
@@ -12,7 +12,8 @@ import { Observable, of, tap } from 'rxjs';
  * Storage: IndexedDB ("fliks-api-cache" database).
  */
 
-const DB_NAME = 'fliks-api-cache';
+export const REQUEST_CACHE_DB = 'fliks-api-cache';
+const DB_NAME = REQUEST_CACHE_DB;
 const DB_VERSION = 1;
 const STORE_NAME = 'responses';
 

--- a/client/src/app/core/services/auth.service.ts
+++ b/client/src/app/core/services/auth.service.ts
@@ -3,7 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { Observable, catchError, firstValueFrom, map, of, tap } from 'rxjs';
 import { ServerConfigService } from './server-config.service';
-import { CachingReuseStrategy } from './route-reuse.strategy';
+import { ServerCacheService } from './server-cache.service';
 import { Preferences } from '@capacitor/preferences';
 
 export interface User {
@@ -51,7 +51,7 @@ export class AuthService {
   private readonly http = inject(HttpClient);
   private readonly router = inject(Router);
   private readonly serverConfig = inject(ServerConfigService);
-  private readonly reuseStrategy = inject(CachingReuseStrategy);
+  private readonly serverCache = inject(ServerCacheService);
 
   private static readonly TOKEN_KEY = 'fliks_access_token';
 
@@ -100,6 +100,10 @@ export class AuthService {
     const res = await firstValueFrom(
       this.http.post<LoginResponse>('/api/auth/login', { username, password }),
     );
+    // Discard any cached data from the previous session before publishing the
+    // new user — a "switch user" path otherwise inherits the previous user's
+    // home rows, library views, etc. from the IDB request cache.
+    await this.serverCache.clearAll();
     this._user.set(res.user);
     if (this.serverConfig.isNative && res.accessToken) {
       this._accessToken = res.accessToken;
@@ -169,6 +173,7 @@ export class AuthService {
       this._accessToken = accessToken;
       await this.saveToken(accessToken);
     }
+    await this.serverCache.clearAll();
     const user = await firstValueFrom(this.http.get<User>('/api/auth/me'));
     this._user.set(user);
     const activeUrl = this.serverConfig.serverUrl();
@@ -307,7 +312,7 @@ export class AuthService {
       this._user.set(null);
       this._accessToken = null;
       await this.removeToken();
-      this.reuseStrategy.clear();
+      await this.serverCache.clearAll();
       // Land on the user picker, same as a fresh visit. The password form
       // is one tap away via the picker → user → 'Mot de passe'.
       void this.router.navigate(['/select-user']);

--- a/client/src/app/core/services/server-cache.service.ts
+++ b/client/src/app/core/services/server-cache.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, inject } from '@angular/core';
+import { REQUEST_CACHE_DB } from '../interceptors/cache.interceptor';
+import { CachingReuseStrategy } from './route-reuse.strategy';
+
+/**
+ * Single-call wipe of every "server data" cache the app keeps locally so a
+ * fresh session never inherits the previous one's view. Called from:
+ *
+ * - `AuthService.logout()` / `login()` — different user implies different
+ *   permissions, different libraries, different home rows.
+ * - User-menu / select-user "Switch user" — same as above.
+ * - User-menu / select-user "Change server" — IDs are scoped to the server,
+ *   reusing them across servers would surface ghosts.
+ * - Storage settings → "Vider le cache" — user-initiated reset.
+ *
+ * Explicitly preserved: downloaded media (file IDs are server-scoped but
+ * the user opted into them), the auth token (until logout), UI prefs
+ * (sidebar pinned, player settings, etc.).
+ */
+@Injectable({ providedIn: 'root' })
+export class ServerCacheService {
+  private readonly reuseStrategy = inject(CachingReuseStrategy);
+
+  async clearAll(): Promise<void> {
+    await Promise.all([
+      this.deleteRequestCacheDb(),
+      this.clearCachedUser(),
+      this.clearRouteReuse(),
+    ]);
+  }
+
+  private deleteRequestCacheDb(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      try {
+        const req = indexedDB.deleteDatabase(REQUEST_CACHE_DB);
+        req.onsuccess = () => resolve();
+        req.onerror = () => resolve();
+        // Another tab still has the DB open — it'll be deleted when that closes.
+        req.onblocked = () => resolve();
+      } catch {
+        resolve();
+      }
+    });
+  }
+
+  private async clearCachedUser(): Promise<void> {
+    try { localStorage.removeItem('fliks.cachedUser'); } catch { /* ignore */ }
+  }
+
+  private async clearRouteReuse(): Promise<void> {
+    this.reuseStrategy.clear();
+  }
+}

--- a/client/src/app/features/playback-settings/storage-settings/storage-settings.ts
+++ b/client/src/app/features/playback-settings/storage-settings/storage-settings.ts
@@ -4,8 +4,7 @@ import { ToastService } from '../../../core/services/toast.service';
 import { DownloadManagerService } from '../../../core/services/download-manager.service';
 import { DownloadCacheService } from '../../../core/services/download-cache.service';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
-
-const API_CACHE_DB = 'fliks-api-cache';
+import { ServerCacheService } from '../../../core/services/server-cache.service';
 
 @Component({
   selector: 'app-storage-settings',
@@ -19,6 +18,7 @@ export class StorageSettingsPageComponent {
   private readonly dlManager = inject(DownloadManagerService);
   private readonly dlCache = inject(DownloadCacheService);
   private readonly confirmation = inject(ConfirmationService);
+  private readonly serverCache = inject(ServerCacheService);
 
   readonly clearing = signal(false);
   readonly deleting = signal(false);
@@ -26,13 +26,7 @@ export class StorageSettingsPageComponent {
   async clearCache() {
     this.clearing.set(true);
     try {
-      // Delete the IndexedDB API cache
-      await new Promise<void>((resolve, reject) => {
-        const req = indexedDB.deleteDatabase(API_CACHE_DB);
-        req.onsuccess = () => resolve();
-        req.onerror = () => reject(req.error);
-        req.onblocked = () => resolve(); // DB in use — will clear on next open
-      });
+      await this.serverCache.clearAll();
       this.toast.success(this.translate.instant('storage_settings.cache_cleared'));
     } catch {
       this.toast.error(this.translate.instant('common.error'));

--- a/client/src/app/features/select-user/select-user.ts
+++ b/client/src/app/features/select-user/select-user.ts
@@ -8,6 +8,7 @@ import { Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { Capacitor } from '@capacitor/core';
 import { AuthService, PublicUserSummary } from '../../core/services/auth.service';
+import { ServerCacheService } from '../../core/services/server-cache.service';
 import { ServerConfigService } from '../../core/services/server-config.service';
 import { initialsAvatar } from '../../core/utils/initials-avatar';
 import { LucideMonitorSmartphone, LucideKeyRound, LucideUserRoundPen } from '@lucide/angular';
@@ -27,6 +28,7 @@ export class SelectUserComponent {
   private readonly auth = inject(AuthService);
   private readonly router = inject(Router);
   private readonly serverConfig = inject(ServerConfigService);
+  private readonly serverCache = inject(ServerCacheService);
 
   readonly users = signal<PublicUserSummary[]>([]);
   readonly loading = signal(true);
@@ -73,6 +75,7 @@ export class SelectUserComponent {
   }
 
   async changeServer() {
+    await this.serverCache.clearAll();
     await this.serverConfig.clear();
     void this.router.navigate(['/setup']);
   }

--- a/client/src/app/shared/components/user-menu.ts
+++ b/client/src/app/shared/components/user-menu.ts
@@ -2,6 +2,7 @@ import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { AuthService } from '../../core/services/auth.service';
+import { ServerCacheService } from '../../core/services/server-cache.service';
 import { ServerConfigService } from '../../core/services/server-config.service';
 import { DropdownMenuComponent } from './dropdown-menu';
 import { Capacitor } from '@capacitor/core';
@@ -84,13 +85,16 @@ export class UserMenuComponent {
   readonly auth = inject(AuthService);
   private readonly router = inject(Router);
   private readonly serverConfig = inject(ServerConfigService);
+  private readonly serverCache = inject(ServerCacheService);
   protected readonly isNative = Capacitor.isNativePlatform();
 
-  protected switchUser() {
+  protected async switchUser() {
+    await this.serverCache.clearAll();
     this.router.navigate(['/login'], { queryParams: { switch: true } });
   }
 
   protected async changeServer() {
+    await this.serverCache.clearAll();
     await this.serverConfig.clear();
     this.router.navigate(['/setup']);
   }

--- a/client/src/app/shared/layout/layout.ts
+++ b/client/src/app/shared/layout/layout.ts
@@ -20,6 +20,7 @@ import { MediaService } from '../../core/services/api/media.service';
 import { LibrariesApiService, LibrarySummary } from '../../core/services/api/libraries-api.service';
 import { DownloadClientsApiService } from '../../core/services/api/download-clients-api.service';
 import { RequestsService } from '../../core/services/api/requests.service';
+import { ServerCacheService } from '../../core/services/server-cache.service';
 import { ServerConfigService } from '../../core/services/server-config.service';
 import { SseService } from '../../core/services/sse.service';
 import { CastService } from '../../core/services/cast.service';
@@ -74,6 +75,7 @@ export class LayoutComponent implements OnInit, OnDestroy {
   private readonly downloadApi = inject(DownloadClientsApiService);
   private readonly requestsService = inject(RequestsService);
   readonly serverConfig = inject(ServerConfigService);
+  private readonly serverCache = inject(ServerCacheService);
   private readonly sse = inject(SseService);
   private readonly downloadManager = inject(DownloadManagerService);
   readonly networkService = inject(NetworkService);
@@ -283,9 +285,11 @@ export class LayoutComponent implements OnInit, OnDestroy {
     this.castPlayer.expanded.update(v => !v);
   }
 
-  switchUser() {
-    // Navigate to login without clearing the current session
-    // (allows reconnection later without password)
+  async switchUser() {
+    // Wipe cached server data so the next login does not inherit the previous
+    // user's home rows / library views. Auth state survives — the user keeps
+    // the current session until they actually log in as someone else.
+    await this.serverCache.clearAll();
     this.router.navigate(['/login'], { queryParams: { switch: true } });
   }
 


### PR DESCRIPTION
## Summary

- The IDB request cache (\`fliks-api-cache\`), the cached \`/auth/me\` payload (\`localStorage['fliks.cachedUser']\`) and the route-reuse DOM cache all outlived sessions. Switching to another account or server, or tapping "Vider le cache" in app settings, kept showing the previous session's home rows / library views until each cache happened to expire on its own.
- Centralise the wipe in a new \`ServerCacheService.clearAll()\` and call it from every session-boundary path: \`login\`, \`loginWithToken\`, \`logout\`, user-menu / layout \`switchUser\`, user-menu / select-user \`changeServer\`, and the storage-settings clear-cache button.
- Downloads, auth token and UI preferences (sidebar pinned, player settings, search filters) are explicitly preserved.

## What gets wiped

| Store | Where | Cleared by |
|---|---|---|
| IDB \`fliks-api-cache\` | \`cache.interceptor.ts\` (stale-while-revalidate for home, libraries, playback) | \`ServerCacheService.clearAll()\` |
| \`localStorage['fliks.cachedUser']\` | \`auth.service.ts\` fast path | idem |
| Route-reuse DOM cache | \`CachingReuseStrategy\` (Home, Libraries, …) | idem |

## What is preserved

- Auth token (cleared by \`logout()\` itself, not by \`clearAll()\`)
- Downloads metadata + offline media files
- UI preferences (\`fliks.sidebarPinned\`, search filters, player settings)

## Test plan

- [ ] Logout → land on \`/select-user\`. Log back in: home page hits the network on first paint (verify via devtools network panel, no cached response).
- [ ] Switch user from the user menu → home rebuilds with the new user's data, no flash of the previous user's rows.
- [ ] Change server from the user menu or \`/select-user\` → \`/setup\`. Pick a different server, log in: no ghost entries from the previous server.
- [ ] Settings → Storage → "Vider le cache" → next nav to home refetches everything.
- [ ] Downloads survive all four actions (check the Downloads page is intact).
- [ ] Player settings (preferred audio/sub language, etc.) survive all four actions.