### PR TITLE
fix(player): audio label matches media-detail; stack header rows

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -978,9 +978,16 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // fallback (si-*), even at equal length — their IDs enable client-side
     // PID switching instead of a full backend reload.
     engine.on('audioTracksChanged', (e) => {
-      const tracks = e.tracks.map((t: any) => ({
+      // Cross-reference engine tracks with streamInfo.audio so the dropdown
+      // label matches what the media-detail header shows (e.g.
+      // "Français (EAC3 - 5.1)" instead of Shaka's raw "fre" / "English (eng)").
+      // Engine emits tracks in streamInfo order — see comment at the
+      // streamInfo-fallback branch below.
+      const file = this.media?.files?.find((f: any) => f.id === this.mediaFileId);
+      const audioList = (file?.streamInfo as any)?.audio ?? [];
+      const tracks = e.tracks.map((t: any, i: number) => ({
         id: t.id,
-        label: t.label,
+        label: audioList[i] ? formatAudioLabel(audioList[i], this.translate) : t.label,
         language: normalizeLang(t.language),
         selected: !!t.selected,
       }));

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -30,45 +30,49 @@
 
     <!-- Stream info: video (or file select) / audio / subtitles (hidden on series overview) -->
     @if (selectedFileId() && (mediaType() !== 'series' || episodeId())) {
-      <div class="flex flex-wrap items-center gap-x-4 gap-y-2 mt-3">
-        <span class="text-base-content/50">{{ 'media_info.video' | translate }}</span>
-        @if (multipleFiles()) {
-          <select class="select select-bordered select-sm w-fit" [ngModel]="selectedFileId()" (ngModelChange)="selectedFileIdChange.emit($event)">
-            @for (f of files(); track f.id) {
-              <option [ngValue]="f.id">{{ fileLabel(f) }}</option>
-            }
-          </select>
-        } @else if (videoLabel()) {
-          <span>{{ videoLabel() }}</span>
-        }
-        @if (audioTracks().length) {
-          <span class="text-base-content/50">{{ 'media_info.audio' | translate }}</span>
-          @if (audioTracks().length === 1) {
-            <span>{{ audioTracks()[0].label }}</span>
-          } @else {
-            <select class="select select-bordered select-sm w-fit" [ngModel]="selectedAudioIndex()" (ngModelChange)="onAudioChange($event)">
-              @for (t of audioTracks(); track t.index) {
-                <option [ngValue]="t.index">{{ t.label }}</option>
+      <div class="flex flex-col gap-y-1 mt-3">
+        <div class="flex items-center gap-x-4">
+          <span class="text-base-content/50">{{ 'media_info.video' | translate }}</span>
+          @if (multipleFiles()) {
+            <select class="select select-bordered select-sm w-fit" [ngModel]="selectedFileId()" (ngModelChange)="selectedFileIdChange.emit($event)">
+              @for (f of files(); track f.id) {
+                <option [ngValue]="f.id">{{ fileLabel(f) }}</option>
               }
             </select>
-          }
-        }
-      </div>
-      @if (subtitles().length) {
-        <div class="flex items-center gap-x-4 mt-2">
-          <span class="text-base-content/50">{{ 'media_info.subtitles' | translate }}</span>
-          @if (subtitles().length === 1) {
-            <span>{{ subtitles()[0].label }}</span>
-          } @else {
-            <select class="select select-bordered select-sm w-fit" [ngModel]="selectedSubtitleId()" (ngModelChange)="onSubtitleChange($event)">
-              <option [ngValue]="null">{{ 'player.off' | translate }}</option>
-              @for (s of subtitles(); track s.id) {
-                <option [ngValue]="s.id">{{ s.label }}</option>
-              }
-            </select>
+          } @else if (videoLabel()) {
+            <span>{{ videoLabel() }}</span>
           }
         </div>
-      }
+        @if (audioTracks().length) {
+          <div class="flex items-center gap-x-4">
+            <span class="text-base-content/50">{{ 'media_info.audio' | translate }}</span>
+            @if (audioTracks().length === 1) {
+              <span>{{ audioTracks()[0].label }}</span>
+            } @else {
+              <select class="select select-bordered select-sm w-fit" [ngModel]="selectedAudioIndex()" (ngModelChange)="onAudioChange($event)">
+                @for (t of audioTracks(); track t.index) {
+                  <option [ngValue]="t.index">{{ t.label }}</option>
+                }
+              </select>
+            }
+          </div>
+        }
+        @if (subtitles().length) {
+          <div class="flex items-center gap-x-4">
+            <span class="text-base-content/50">{{ 'media_info.subtitles' | translate }}</span>
+            @if (subtitles().length === 1) {
+              <span>{{ subtitles()[0].label }}</span>
+            } @else {
+              <select class="select select-bordered select-sm w-fit" [ngModel]="selectedSubtitleId()" (ngModelChange)="onSubtitleChange($event)">
+                <option [ngValue]="null">{{ 'player.off' | translate }}</option>
+                @for (s of subtitles(); track s.id) {
+                  <option [ngValue]="s.id">{{ s.label }}</option>
+                }
+              </select>
+            }
+          </div>
+        }
+      </div>
     }
 
     <!-- Library info + genres -->
@@ -258,7 +262,7 @@
 
       <!-- Stream info: Video (or file select) / Audio / Subtitles (hidden on series overview) -->
       @if (selectedFileId() && (mediaType() !== 'series' || episodeId())) {
-        <div class="flex flex-wrap items-center gap-x-5 gap-y-1.5 mt-3">
+        <div class="flex flex-col gap-y-1.5 mt-3">
           <div class="flex items-center gap-2">
             <span class="text-base-content/50 font-medium">{{ 'media_info.video' | translate }}</span>
             @if (multipleFiles()) {


### PR DESCRIPTION
## Summary

- Player audio dropdown drifted from the media-detail audio menu after the engine fired \`audioTracksChanged\`: the handler in \`player.ts\` was overwriting the formatted label with the raw engine string (Shaka's \`English (eng)\` / \`fre\`). Cross-reference \`e.tracks[i]\` with \`streamInfo.audio[i]\` (our HLS backend emits them in the same order) and run through \`formatAudioLabel\`, mirroring the streamInfo-fallback branch.
- Media-detail header: stack the three rows (Video / Audio / Subtitles) vertically so each label+select pair stays on its own line on both mobile and desktop — no more flex-wrap mixing Video and Audio onto the same row at intermediate widths.
- Tighten the mobile vertical gap (\`gap-y-2\` → \`gap-y-1\`) so the three rows feel like a single block, not three separated lines.

## Test plan

- [ ] Play a multi-audio file: the dropdown in the player and the audio menu in the media-detail header show the **exact same** string for each track (e.g. \`Français (EAC3 - 5.1)\`).
- [ ] Confirm both Shaka (web/Chromecast) and ExoPlayer (Android native) paths.
- [ ] Open the media-detail header on a phone: Video, Audio and Subtitles each occupy their own row, label on the left, select on the right.
- [ ] Desktop: same — never two pairs on one row.