### PR TITLE
fix(mobile): keep player controls while a panel is up; never minimise on back

### DIFF
--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -97,11 +97,13 @@ export class App implements OnInit, OnDestroy {
           this.navbar.goBack();
           return;
         }
-        // On TV the back button must never minimise the app — that drops the
-        // user back to the launcher and feels like a crash. With no history,
-        // stay put and let the dedicated Home button on the remote exit.
-        if (this.tv.isTv()) return;
-        CapApp.minimizeApp();
+        // Back at a top-level page with no in-app history left: stay put.
+        // Minimising would drop the user out of the app on a "just navigate"
+        // gesture, which on Android 14+ feels indistinguishable from a crash.
+        // Modern UX convention is to leave the app via the home gesture or
+        // the recent-apps switcher — never the back gesture. TV already
+        // followed this rule; mobile now does too.
+        return;
       }).then((handle) => {
         this.backButtonListener = handle;
       });

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -99,7 +99,16 @@ export class PlayerControlsComponent {
         this.playPauseBtn()?.nativeElement.focus({ preventScroll: true });
       }
     });
+    // Propagate any-panel-open state to the parent player so it can suspend
+    // its auto-hide timer while a dropdown or bottom sheet is up.
+    effect(() => {
+      const open = this.openDropdown() !== null || this.activeSheet() !== null;
+      if (open === this.lastPanelOpen) return;
+      this.lastPanelOpen = open;
+      this.panelOpenChange.emit(open);
+    });
   }
+  private lastPanelOpen = false;
   private lastVisible = true;
   /**
    * Player layout selection. Splits the three concerns the template branches on:
@@ -173,6 +182,13 @@ export class PlayerControlsComponent {
   readonly toggleFillScreen = output<void>();
   readonly openMedia = output<void>();
   readonly seekDragChange = output<boolean>();
+  /**
+   * Fires whenever any of the controls' own panels (desktop dropdown OR
+   * mobile bottom sheet) opens or closes. Lets the parent player pause its
+   * auto-hide timer while a panel is up — otherwise the subtitle/audio sheet
+   * on mobile gets orphaned when the 3 s timer hides the controls behind it.
+   */
+  readonly panelOpenChange = output<boolean>();
 
   readonly speedOptions = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
 

--- a/client/src/app/features/player/player.html
+++ b/client/src/app/features/player/player.html
@@ -95,6 +95,7 @@
     (skipIntro)="skipIntro()"
     (skipToNextEpisode)="goToNextEpisode()"
     (nextEpisode)="goToNextEpisode()"
+    (panelOpenChange)="onControlsPanelOpenChange($event)"
   />
   }
 

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -195,6 +195,9 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   private readonly statsRefreshTick = signal(0);
   readonly subtitlePickerOpen = signal(false);
   readonly qualityPickerOpen = signal(false);
+  /** True when any panel inside <app-player-controls> (desktop dropdown or
+   *  mobile bottom sheet) is open — suspends the auto-hide timer. */
+  private readonly controlsPanelOpen = signal(false);
 
   // ── Skip-intro state ──
   /** Episode-level intro marker received in playback-info (null for movies / no marker). */
@@ -1048,11 +1051,29 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   private isDropdownOpen(): boolean {
     // Check via signals (reliable on mobile)
     if (this.subtitlePickerOpen() || this.qualityPickerOpen()) return true;
+    // Click-driven dropdowns / bottom sheets owned by <app-player-controls>.
+    // Reported via (panelOpenChange) so we don't depend on DOM focus.
+    if (this.controlsPanelOpen()) return true;
     // Check via DOM (DaisyUI dropdowns use focus-within)
     const container = this.containerEl()?.nativeElement;
     if (container?.querySelector('.dropdown:focus-within')) return true;
     const active = document.activeElement;
     return !!active && !!active.closest('.dropdown');
+  }
+
+  /**
+   * Called by <app-player-controls> when its dropdown / bottom-sheet state
+   * changes. While open, we keep the controls visible. On close, re-arm
+   * the auto-hide so the bar fades back out in the normal delay.
+   */
+  onControlsPanelOpenChange(open: boolean): void {
+    this.controlsPanelOpen.set(open);
+    if (open) {
+      if (this.controlsTimeout) clearTimeout(this.controlsTimeout);
+      this.controlsVisible.set(true);
+    } else {
+      this.resetHideTimer();
+    }
   }
 
   // ── Player actions ──


### PR DESCRIPTION
## Summary

Two unrelated mobile UX papercuts bundled together — both are tiny.

### Player controls: don't hide while a sheet is open
- The 3 s auto-hide timer was firing even when the user had a subtitle / audio bottom-sheet open, leaving the panel orphaned on a black overlay.
- New \`panelOpenChange\` output on \`<app-player-controls>\` reports any-panel-open transitions (desktop dropdown OR mobile bottom-sheet).
- Player keeps a \`controlsPanelOpen\` signal, used in \`isDropdownOpen()\` so the timer callback doesn't hide, and re-arms the timer on \`open=false\` so the bar fades out normally after the panel closes.

### Back gesture: never close the app
- \`CapApp.minimizeApp()\` at the end of the back-button handler is gone. At a top-level page with no in-app history left, stay put.
- The Android home gesture / recent-apps switcher is the right way out — on Android 14+ a back gesture that minimises feels like a crash. TV already followed this rule; mobile now does too.
- Other branches of the handler (\`<select>\` blur → cast overlay → dismiss stack → \`/watch\` delegation → \`navbar.goBack()\`) are untouched.

## Test plan

Mobile, video playing:
- [ ] Tap the subtitle / audio button → bottom sheet appears, controls stay visible for as long as it's open.
- [ ] Dismiss the sheet → bar fades out 3 s later.
- [ ] Open one panel, then another without closing — the bar never hides between the two.

Mobile, navigation:
- [ ] On home, swipe back: app stays on home (no minimise).
- [ ] From media-detail → home: the back gesture pops to home; from home: stays put.
- [ ] On \`/watch\`: back gesture still routes through the player's own back handler.