### PR TITLE
fix(search): filter Torznab results by show title + use external IDs

### DIFF
--- a/backend/src/migrations/1778400000000-add-media-alternative-titles.ts
+++ b/backend/src/migrations/1778400000000-add-media-alternative-titles.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMediaAlternativeTitles1778400000000
+  implements MigrationInterface
+{
+  name = 'AddMediaAlternativeTitles1778400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "media"
+         ADD COLUMN IF NOT EXISTS "alternativeTitles" jsonb
+         NOT NULL DEFAULT '[]'::jsonb`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "media" DROP COLUMN IF EXISTS "alternativeTitles"`,
+    );
+  }
+}

--- a/backend/src/modules/indexers/torznab.service.ts
+++ b/backend/src/modules/indexers/torznab.service.ts
@@ -27,6 +27,38 @@ function decodeXmlEntities(s: string): string {
     .replace(/&quot;/g, '"');
 }
 
+/**
+ * Build a Torznab query string. Drops null/undefined params so optional
+ * external-id filters (tvdbid / imdbid / tmdbid) are only sent when known.
+ * IMDb IDs are stripped of the `tt` prefix — that's what every Newznab-spec
+ * indexer expects on the wire.
+ */
+function buildTorznabQuery(opts: {
+  t: string;
+  q?: string;
+  season?: number;
+  ep?: number;
+  cat: string;
+  apiKey: string;
+  tvdbId?: number | null;
+  imdbId?: string | null;
+  tmdbId?: number | null;
+}): string {
+  const parts: string[] = [`t=${opts.t}`];
+  if (opts.q) parts.push(`q=${encodeURIComponent(opts.q)}`);
+  if (opts.season != null) parts.push(`season=${opts.season}`);
+  if (opts.ep != null) parts.push(`ep=${opts.ep}`);
+  parts.push(`cat=${opts.cat}`);
+  parts.push(`apikey=${encodeURIComponent(opts.apiKey)}`);
+  if (opts.tvdbId) parts.push(`tvdbid=${opts.tvdbId}`);
+  if (opts.imdbId) {
+    const stripped = opts.imdbId.replace(/^tt/i, '');
+    if (stripped) parts.push(`imdbid=${stripped}`);
+  }
+  if (opts.tmdbId) parts.push(`tmdbid=${opts.tmdbId}`);
+  return parts.join('&');
+}
+
 function extractInnerXml(block: string, tag: string): string | null {
   const re = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, 'i');
   const m = block.match(re);
@@ -220,6 +252,7 @@ export class TorznabService {
     indexer: Indexer,
     showTitle: string,
     season: number,
+    externalIds?: { tvdbId?: number | null; imdbId?: string | null },
   ): Promise<TorznabRelease[]> {
     if (!indexer.enabled || !indexer.enableSearch) return [];
     const impl = (indexer.implementation || '').toLowerCase();
@@ -230,7 +263,15 @@ export class TorznabService {
     const apiKey = String(settings.apiKey || '');
     if (!baseUrl) return [];
 
-    const url = `${baseUrl}?t=tvsearch&q=${encodeURIComponent(showTitle)}&season=${season}&cat=5000&apikey=${encodeURIComponent(apiKey)}`;
+    const url = `${baseUrl}?${buildTorznabQuery({
+      t: 'tvsearch',
+      q: showTitle,
+      season,
+      cat: '5000',
+      apiKey,
+      tvdbId: externalIds?.tvdbId,
+      imdbId: externalIds?.imdbId,
+    })}`;
     const start = Date.now();
     try {
       const res = await axios.get<string>(url, {
@@ -273,6 +314,7 @@ export class TorznabService {
     showTitle: string,
     season: number,
     episode: number,
+    externalIds?: { tvdbId?: number | null; imdbId?: string | null },
   ): Promise<TorznabRelease[]> {
     if (!indexer.enabled || !indexer.enableSearch) return [];
     const impl = (indexer.implementation || '').toLowerCase();
@@ -283,7 +325,16 @@ export class TorznabService {
     const apiKey = String(settings.apiKey || '');
     if (!baseUrl) return [];
 
-    const url = `${baseUrl}?t=tvsearch&q=${encodeURIComponent(showTitle)}&season=${season}&ep=${episode}&cat=5000&apikey=${encodeURIComponent(apiKey)}`;
+    const url = `${baseUrl}?${buildTorznabQuery({
+      t: 'tvsearch',
+      q: showTitle,
+      season,
+      ep: episode,
+      cat: '5000',
+      apiKey,
+      tvdbId: externalIds?.tvdbId,
+      imdbId: externalIds?.imdbId,
+    })}`;
     const start = Date.now();
     try {
       const res = await axios.get<string>(url, {
@@ -324,6 +375,7 @@ export class TorznabService {
   async searchMovie(
     indexer: Indexer,
     query: string,
+    externalIds?: { imdbId?: string | null; tmdbId?: number | null },
   ): Promise<TorznabRelease[]> {
     if (!indexer.enabled || !indexer.enableSearch) return [];
     const impl = (indexer.implementation || '').toLowerCase();
@@ -337,7 +389,18 @@ export class TorznabService {
       return [];
     }
 
-    const url = `${baseUrl}?t=search&q=${encodeURIComponent(query)}&cat=2000&apikey=${encodeURIComponent(apiKey)}`;
+    // `t=movie` is the spec'd endpoint for imdbid/tmdbid filtering. Fall back
+    // to the generic `t=search&cat=2000` when no external IDs are available
+    // so q=-only trackers stay reachable.
+    const useMovieSearch = !!(externalIds?.imdbId || externalIds?.tmdbId);
+    const url = `${baseUrl}?${buildTorznabQuery({
+      t: useMovieSearch ? 'movie' : 'search',
+      q: query,
+      cat: '2000',
+      apiKey,
+      imdbId: externalIds?.imdbId,
+      tmdbId: externalIds?.tmdbId,
+    })}`;
     const start = Date.now();
     try {
       const res = await axios.get<string>(url, {

--- a/backend/src/modules/media/auto-grab-pipeline.service.ts
+++ b/backend/src/modules/media/auto-grab-pipeline.service.ts
@@ -143,6 +143,9 @@ export class AutoGrabPipelineService {
     mediaType: 'movie' | 'series';
     /** Free-form label for logs — e.g. `"Dune (2021)"` or `"Show S01E03"`. */
     label: string;
+    /** Expected media title(s) — pass canonical + TMDB/TVDB alternatives
+     *  so localised release names still match. */
+    expectedTitle?: string | string[];
     runtimeMinutes: number;
     /** Per-source pending check (e.g. episode-scoped lookup). */
     pendingCheck?: () => Promise<boolean>;
@@ -173,6 +176,7 @@ export class AutoGrabPipelineService {
         indexerMinSeeders: args.scoring.indexerMinSeeders,
         indexerUnknownLang: args.scoring.indexerUnknownLang,
         runtimeMinutes: args.runtimeMinutes,
+        expectedTitle: args.expectedTitle,
       },
       {
         scoreCustomFormats: (title, meta) =>

--- a/backend/src/modules/media/entities/media.entity.ts
+++ b/backend/src/modules/media/entities/media.entity.ts
@@ -36,6 +36,16 @@ export class Media extends BaseEntity {
   @Column({ nullable: true })
   originalTitle: string;
 
+  /**
+   * International release titles (TMDB `alternative_titles`, TVDB
+   * `aliases`). Used to validate Torznab results: a release labelled with
+   * a localised name — e.g. "A Very Secret Service" for "Au service de la
+   * France" — still matches if the localised form is in this list.
+   * Empty array when the provider returns no aliases.
+   */
+  @Column({ type: 'jsonb', default: () => "'[]'::jsonb" })
+  alternativeTitles: string[];
+
   @Column({ nullable: true })
   year: number;
 

--- a/backend/src/modules/media/episode-download.service.ts
+++ b/backend/src/modules/media/episode-download.service.ts
@@ -145,24 +145,21 @@ export class EpisodeDownloadService {
     );
 
     const searchQuery = customQuery?.trim();
+    const queryTitle = searchQuery || media.title;
+    const expectedTitle: string | string[] = searchQuery
+      ? searchQuery
+      : [media.title, ...(media.alternativeTitles ?? [])];
+    const externalIds = { tvdbId: media.tvdbId, imdbId: media.imdbId };
     const batches = await Promise.all(
-      searchQuery
-        ? indexers.map((ix) =>
-            this.torznab.searchSeries(
-              ix,
-              searchQuery,
-              season.seasonNumber,
-              episode.episodeNumber,
-            ),
-          )
-        : indexers.map((ix) =>
-            this.torznab.searchSeries(
-              ix,
-              media.title,
-              season.seasonNumber,
-              episode.episodeNumber,
-            ),
-          ),
+      indexers.map((ix) =>
+        this.torznab.searchSeries(
+          ix,
+          queryTitle,
+          season.seasonNumber,
+          episode.episodeNumber,
+          externalIds,
+        ),
+      ),
     );
     const flat = batches.flat();
 
@@ -176,6 +173,7 @@ export class EpisodeDownloadService {
           indexerMinSeeders,
           media.runtime ?? 45,
           indexerUnknownLang,
+          expectedTitle,
         ),
       ),
     );
@@ -292,6 +290,7 @@ export class EpisodeDownloadService {
     indexerMinSeeders: Map<number, number>,
     runtimeMinutes: number,
     indexerUnknownLang: Map<number, string | undefined>,
+    expectedTitle?: string | string[],
   ): Promise<EpisodeReleaseRow> {
     const parsed = parseReleaseQuality(r.title);
     const lang = resolveUnknownLanguage(
@@ -318,6 +317,7 @@ export class EpisodeDownloadService {
       indexerId: r.indexerId,
       indexerMinSeeders,
       releaseTitle: r.title,
+      expectedTitle,
     });
     return {
       title: r.title,
@@ -391,10 +391,20 @@ export class EpisodeDownloadService {
         0,
       ) || defaultEpRuntime;
 
-    const searchTitle = customQuery?.trim() || media.title;
+    const customTitle = customQuery?.trim();
+    const searchTitle = customTitle || media.title;
+    const expectedTitle: string | string[] = customTitle
+      ? customTitle
+      : [media.title, ...(media.alternativeTitles ?? [])];
+    const externalIds = { tvdbId: media.tvdbId, imdbId: media.imdbId };
     const batches = await Promise.all(
       indexers.map((ix) =>
-        this.torznab.searchSeasonPack(ix, searchTitle, season.seasonNumber),
+        this.torznab.searchSeasonPack(
+          ix,
+          searchTitle,
+          season.seasonNumber,
+          externalIds,
+        ),
       ),
     );
 
@@ -410,6 +420,7 @@ export class EpisodeDownloadService {
             indexerMinSeeders,
             seasonRuntime,
             indexerUnknownLang,
+            expectedTitle,
           ),
         ),
     );
@@ -514,9 +525,16 @@ export class EpisodeDownloadService {
       ]),
     );
 
+    const externalIds = { tvdbId: media.tvdbId, imdbId: media.imdbId };
+    const expectedTitles = [media.title, ...(media.alternativeTitles ?? [])];
     const packBatches = await Promise.all(
       indexers.map((ix) =>
-        this.torznab.searchSeasonPack(ix, media.title, season.seasonNumber),
+        this.torznab.searchSeasonPack(
+          ix,
+          media.title,
+          season.seasonNumber,
+          externalIds,
+        ),
       ),
     );
     // Season pack runtime = episode runtime × number of episodes
@@ -539,6 +557,7 @@ export class EpisodeDownloadService {
             indexerMinSeeders,
             seasonRuntime,
             indexerUnknownLang,
+            expectedTitles,
           ),
         ),
     );
@@ -597,6 +616,7 @@ export class EpisodeDownloadService {
               media.title,
               season.seasonNumber,
               ep.episodeNumber,
+              externalIds,
             ),
           ),
         );
@@ -612,6 +632,7 @@ export class EpisodeDownloadService {
                 indexerMinSeeders,
                 media.runtime ?? 45,
                 indexerUnknownLang,
+                expectedTitles,
               ),
             ),
         );

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -1721,6 +1721,7 @@ export class MediaService {
     return {
       title: details.title,
       originalTitle: details.originalTitle ?? details.title,
+      alternativeTitles: details.alternativeTitles ?? [],
       year,
       type,
       tmdbId: details.tmdbId || undefined,

--- a/backend/src/modules/media/movie-download.service.ts
+++ b/backend/src/modules/media/movie-download.service.ts
@@ -101,6 +101,7 @@ export class MovieDownloadService {
     indexers: Indexer[],
     allowed: Set<number>,
     allowedLangs: Set<number>,
+    expectedTitle?: string | string[],
   ): Promise<MovieReleaseRow[]> {
     const scored = await scoreAndSortReleases(
       releases,
@@ -116,6 +117,7 @@ export class MovieDownloadService {
           ]),
         ),
         runtimeMinutes: media.runtime ?? 0,
+        expectedTitle,
       },
       {
         scoreCustomFormats: (title, meta) =>
@@ -132,8 +134,12 @@ export class MovieDownloadService {
   private searchIndexer(
     indexer: Indexer,
     query: string,
+    media?: Media,
   ): Promise<TorznabRelease[]> {
-    return this.torznab.searchMovie(indexer, query);
+    return this.torznab.searchMovie(indexer, query, {
+      imdbId: media?.imdbId,
+      tmdbId: media?.tmdbId,
+    });
   }
 
   private searchQueryForMedia(media: Media): string {
@@ -164,9 +170,10 @@ export class MovieDownloadService {
       where: { enabled: true },
       order: { priority: 'ASC', id: 'ASC' },
     });
-    const query = customQuery?.trim() || this.searchQueryForMedia(media);
+    const customTitle = customQuery?.trim();
+    const query = customTitle || this.searchQueryForMedia(media);
     const batches = await Promise.all(
-      indexers.map((ix) => this.searchIndexer(ix, query)),
+      indexers.map((ix) => this.searchIndexer(ix, query, media)),
     );
     const flat = batches.flat();
 
@@ -176,6 +183,7 @@ export class MovieDownloadService {
       indexers,
       allowed,
       allowedLangs,
+      customTitle || [media.title, ...(media.alternativeTitles ?? [])],
     );
 
     return sortReleasesByRelevance(rows);
@@ -337,9 +345,10 @@ export class MovieDownloadService {
       where: { enabled: true },
       order: { priority: 'ASC', id: 'ASC' },
     });
-    const query = customQuery?.trim() || this.searchQueryForMedia(media);
+    const customTitle = customQuery?.trim();
+    const query = customTitle || this.searchQueryForMedia(media);
     const batches = await Promise.all(
-      indexers.map((ix) => this.searchIndexer(ix, query)),
+      indexers.map((ix) => this.searchIndexer(ix, query, media)),
     );
     const flat = batches.flat();
     const allowedLangs = allowedAudioLanguageIds(
@@ -352,6 +361,7 @@ export class MovieDownloadService {
       indexers,
       allowed,
       allowedLangs,
+      customTitle || [media.title, ...(media.alternativeTitles ?? [])],
     );
 
     // Only keep releases that are strictly better than current AND within cutoff

--- a/backend/src/modules/media/release-rejection.helper.ts
+++ b/backend/src/modules/media/release-rejection.helper.ts
@@ -120,6 +120,73 @@ export function buildIndexerMinSeeders(
  * Compute every reason a release does **not** perfectly match the user's criteria.
  * Returns an empty array when the release fully matches.
  */
+/**
+ * Stop-words dropped before comparing a release title against the expected
+ * show / movie title. Keeps the meaningful tokens (proper nouns, distinct
+ * words) and avoids false matches on connectors that are nearly universal.
+ */
+const TITLE_STOPWORDS = new Set([
+  // FR
+  'a', 'au', 'aux', 'de', 'des', 'du', 'la', 'le', 'les', 'l',
+  'un', 'une', 'et', 'ou', 'en', 'd', 's',
+  // EN
+  'the', 'an', 'of', 'and', 'or', 'in', 'on', 'at', 'to', 'for',
+]);
+
+/** Normalize a title for matching: lowercase, strip accents, replace any
+ *  non-alphanumeric with a space, collapse whitespace. */
+function normalizeForMatch(s: string): string {
+  return s
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+/** Significant tokens of a title — tokens that must appear in the release
+ *  title for it to be considered a match. Excludes stopwords and very short
+ *  tokens (1 char). Falls back to the full normalized title when filtering
+ *  leaves nothing (e.g. titles made entirely of stopwords). */
+function significantTokens(title: string): string[] {
+  const normalized = normalizeForMatch(title);
+  if (!normalized) return [];
+  const tokens = normalized
+    .split(' ')
+    .filter((t) => t.length > 1 && !TITLE_STOPWORDS.has(t));
+  return tokens.length ? tokens : normalized.split(' ').filter(Boolean);
+}
+
+/**
+ * Return true when a release title plausibly matches *any* of the expected
+ * titles. Every significant token of one expected variant must appear as
+ * a whole-word substring in the normalized release title.
+ *
+ * Multiple expected titles is the normal case: an "Au service de la France"
+ * release indexed under its international name "A Very Secret Service"
+ * still passes when both forms are in the candidate list (TMDB's
+ * `alternative_titles` / TVDB's `aliases`).
+ *
+ * Used as a backend safety net for indexers that ignore `q=` and return any
+ * S01 / category-2000 release regardless of what we asked for.
+ */
+export function titleMatchesExpectation(
+  releaseTitle: string,
+  expected: string | string[],
+): boolean {
+  const candidates = (Array.isArray(expected) ? expected : [expected]).filter(
+    (s): s is string => !!s && s.trim().length > 0,
+  );
+  if (!candidates.length) return true; // nothing meaningful to match
+  const releaseTokens = new Set(normalizeForMatch(releaseTitle).split(' '));
+  for (const cand of candidates) {
+    const tokens = significantTokens(cand);
+    if (!tokens.length) return true; // pathological — treat as match
+    if (tokens.every((t) => releaseTokens.has(t))) return true;
+  }
+  return false;
+}
+
 export function computeRejections(opts: {
   qualityId: number;
   allowed: Set<number>;
@@ -133,10 +200,20 @@ export function computeRejections(opts: {
   seeders: number;
   indexerId: number;
   indexerMinSeeders: Map<number, number>;
-  /** Release title — used to detect video codec for size-limit scaling. */
+  /** Release title — used to detect video codec for size-limit scaling AND
+   *  for the title-mismatch check below. */
   releaseTitle?: string;
+  /** Expected show / movie title(s). Pass the canonical title together
+   *  with TMDB / TVDB alternative titles so that releases indexed under a
+   *  localised name still pass; otherwise they get `TITLE_MISMATCH`. */
+  expectedTitle?: string | string[];
 }): ReleaseRejection[] {
   const out: ReleaseRejection[] = [];
+
+  if (opts.expectedTitle && opts.releaseTitle &&
+      !titleMatchesExpectation(opts.releaseTitle, opts.expectedTitle)) {
+    out.push({ code: 'TITLE_MISMATCH' });
+  }
 
   if (!opts.allowed.has(opts.qualityId)) {
     out.push({ code: 'QUALITY_NOT_ALLOWED' });
@@ -317,6 +394,10 @@ export async function scoreAndSortReleases(
     indexerMinSeeders: Map<number, number>;
     indexerUnknownLang: Map<number, string | undefined>;
     runtimeMinutes: number;
+    /** Title(s) we expect releases to refer to. Releases whose name
+     *  doesn't contain the significant tokens of *any* candidate are
+     *  flagged TITLE_MISMATCH. */
+    expectedTitle?: string | string[];
   },
   deps: ReleaseScorerDeps,
 ): Promise<ScoredRelease[]> {
@@ -347,6 +428,7 @@ export async function scoreAndSortReleases(
         indexerId: r.indexerId,
         indexerMinSeeders: opts.indexerMinSeeders,
         releaseTitle: r.title,
+        expectedTitle: opts.expectedTitle,
       });
       return {
         ...r,

--- a/backend/src/modules/metadata-providers/interfaces/metadata-provider.interface.ts
+++ b/backend/src/modules/metadata-providers/interfaces/metadata-provider.interface.ts
@@ -35,6 +35,11 @@ export interface MetadataDetails extends MetadataSearchResult {
   crew: MetadataCrewItem[];
   videos: MetadataVideo[];
   keywords: string[];
+  /** International release titles surfaced by the metadata provider (TMDB's
+   *  `alternative_titles`). Used to match Torznab results indexed under a
+   *  localised name (e.g. "A Very Secret Service" for "Au service de la
+   *  France") that the strict title-mismatch filter would otherwise drop. */
+  alternativeTitles: string[];
 }
 
 export interface MetadataCastItem {

--- a/backend/src/modules/metadata-providers/providers/tmdb-api.types.ts
+++ b/backend/src/modules/metadata-providers/providers/tmdb-api.types.ts
@@ -118,6 +118,7 @@ export interface TmdbMovieDetailsResponse {
   credits?: { cast?: TmdbCastMember[]; crew?: TmdbCrewMember[] };
   videos?: { results?: TmdbVideo[] };
   keywords?: { keywords?: TmdbKeyword[] };
+  alternative_titles?: { titles?: { iso_3166_1?: string; title: string; type?: string }[] };
 }
 
 export interface TmdbTvDetailsResponse {
@@ -143,6 +144,7 @@ export interface TmdbTvDetailsResponse {
   credits?: { cast?: TmdbCastMember[]; crew?: TmdbCrewMember[] };
   videos?: { results?: TmdbVideo[] };
   keywords?: { results?: TmdbKeyword[] };
+  alternative_titles?: { results?: { iso_3166_1?: string; title: string; type?: string }[] };
 }
 
 export interface TmdbTvSeasonStub {

--- a/backend/src/modules/metadata-providers/providers/tmdb.provider.ts
+++ b/backend/src/modules/metadata-providers/providers/tmdb.provider.ts
@@ -26,6 +26,46 @@ import type {
 
 const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p';
 
+/**
+ * Pull alternative_titles out of a TMDB movie / tv details response.
+ * The two endpoints differ on field name (`titles` vs `results`) and item
+ * key (`title` vs `name`). Output is deduplicated against `data.title /
+ * data.name` and `data.original_title / data.original_name` so callers
+ * don't have to filter again.
+ */
+function extractAlternativeTitles(
+  data: TmdbMovieDetailsResponse | TmdbTvDetailsResponse,
+  kind: 'movie' | 'series',
+): string[] {
+  const raw =
+    kind === 'movie'
+      ? ((data as TmdbMovieDetailsResponse).alternative_titles?.titles ?? [])
+      : ((data as TmdbTvDetailsResponse).alternative_titles?.results ?? []);
+  const primary =
+    kind === 'movie'
+      ? (data as TmdbMovieDetailsResponse).title
+      : (data as TmdbTvDetailsResponse).name;
+  const original =
+    kind === 'movie'
+      ? (data as TmdbMovieDetailsResponse).original_title
+      : (data as TmdbTvDetailsResponse).original_name;
+  const seen = new Set<string>(
+    [primary, original]
+      .filter((s): s is string => !!s)
+      .map((s) => s.toLowerCase()),
+  );
+  const out: string[] = [];
+  for (const entry of raw as { title?: string; name?: string }[]) {
+    const t = (entry.title ?? entry.name ?? '').trim();
+    if (!t) continue;
+    const k = t.toLowerCase();
+    if (seen.has(k)) continue;
+    seen.add(k);
+    out.push(t);
+  }
+  return out;
+}
+
 @Injectable()
 export class TmdbProvider implements IMetadataProvider {
   readonly name = 'tmdb';
@@ -77,7 +117,7 @@ export class TmdbProvider implements IMetadataProvider {
         params: {
           language: 'fr-FR',
           append_to_response:
-            'external_ids,images,release_dates,credits,videos,keywords',
+            'external_ids,images,release_dates,credits,videos,keywords,alternative_titles',
         },
       },
     );
@@ -141,6 +181,7 @@ export class TmdbProvider implements IMetadataProvider {
         name: v.name,
       })),
       keywords: (data.keywords?.keywords ?? []).map((k) => k.name),
+      alternativeTitles: extractAlternativeTitles(data, 'movie'),
     };
   }
 
@@ -151,7 +192,8 @@ export class TmdbProvider implements IMetadataProvider {
       {
         params: {
           language: 'fr-FR',
-          append_to_response: 'external_ids,images,credits,videos,keywords',
+          append_to_response:
+            'external_ids,images,credits,videos,keywords,alternative_titles',
         },
       },
     );
@@ -215,6 +257,7 @@ export class TmdbProvider implements IMetadataProvider {
         name: v.name,
       })),
       keywords: (data.keywords?.results ?? []).map((k) => k.name),
+      alternativeTitles: extractAlternativeTitles(data, 'series'),
     };
   }
 

--- a/backend/src/modules/metadata-providers/providers/tvdb.provider.ts
+++ b/backend/src/modules/metadata-providers/providers/tvdb.provider.ts
@@ -26,9 +26,33 @@ import type {
   TvdbRemoteId,
   TvdbTranslation,
   TvdbSeasonBase,
+  TvdbAlias,
 } from './tvdb-api.types';
 
 const TVDB_BASE = 'https://api4.thetvdb.com/v4';
+
+/**
+ * Collect TVDB aliases into the same flat string array shape that the TMDB
+ * provider produces. Deduplicates against the canonical name and lowercase
+ * variants so we don't pad the field with redundant entries.
+ */
+function dedupeAliases(
+  aliases: TvdbAlias[] | undefined,
+  canonical: string,
+): string[] {
+  if (!aliases?.length) return [];
+  const seen = new Set<string>([canonical.toLowerCase()]);
+  const out: string[] = [];
+  for (const a of aliases) {
+    const t = (a.name ?? '').trim();
+    if (!t) continue;
+    const k = t.toLowerCase();
+    if (seen.has(k)) continue;
+    seen.add(k);
+    out.push(t);
+  }
+  return out;
+}
 
 /** Artwork type IDs: 2=poster, 3=background/fanart, 7=banner, 12=clearart */
 const ART_POSTER = 2;
@@ -159,6 +183,7 @@ export class TvdbProvider implements IMetadataProvider {
         name: t.name,
       })),
       keywords: (m.tagOptions ?? []).map((t) => t.name),
+      alternativeTitles: dedupeAliases(m.aliases, m.name),
     };
   }
 
@@ -219,6 +244,7 @@ export class TvdbProvider implements IMetadataProvider {
         name: t.name,
       })),
       keywords: (s.tagOptions ?? []).map((t) => t.name),
+      alternativeTitles: dedupeAliases(s.aliases, s.name),
     };
   }
 

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -407,7 +407,12 @@ export class SchedulerService implements OnModuleInit {
 
       const query = [media.title, media.year].filter(Boolean).join(' ');
       const batches = await Promise.allSettled(
-        indexers.map((ix) => this.torznab.searchMovie(ix, query)),
+        indexers.map((ix) =>
+          this.torznab.searchMovie(ix, query, {
+            imdbId: media.imdbId,
+            tmdbId: media.tmdbId,
+          }),
+        ),
       );
       const releases = batches.flatMap((r) =>
         r.status === 'fulfilled' ? r.value : [],
@@ -421,6 +426,7 @@ export class SchedulerService implements OnModuleInit {
         scoring,
         mediaType: 'movie',
         label: media.title,
+        expectedTitle: [media.title, ...(media.alternativeTitles ?? [])],
         runtimeMinutes: media.runtime ?? 0,
         pendingCheck: async () => {
           const pending = await this.historyRepo.findOne({
@@ -522,6 +528,7 @@ export class SchedulerService implements OnModuleInit {
             media.title,
             season.seasonNumber,
             ep.episodeNumber,
+            { tvdbId: media.tvdbId, imdbId: media.imdbId },
           ),
         ),
       );
@@ -537,6 +544,7 @@ export class SchedulerService implements OnModuleInit {
         scoring,
         mediaType: 'series',
         label: `${media.title} ${epLabel}`,
+        expectedTitle: [media.title, ...(media.alternativeTitles ?? [])],
         // Episodes are typically 20-60 min; 30 min fallback for size check.
         runtimeMinutes: media.runtime ?? 30,
         pendingCheck: async () => {

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -685,7 +685,8 @@
       "SIZE_TOO_LOW": "Taille trop faible ({{actual}} MB < {{min}} MB)",
       "SIZE_TOO_HIGH": "Taille trop élevée ({{actual}} MB > {{max}} MB)",
       "SIZE_NOT_PREFERRED": "Taille éloignée du recommandé ({{actual}} MB ≠ {{preferred}} MB)",
-      "MIN_SEEDERS": "Seeders insuffisants ({{actual}} < {{min}})"
+      "MIN_SEEDERS": "Seeders insuffisants ({{actual}} < {{min}})",
+      "TITLE_MISMATCH": "Titre ne correspond pas au média"
     }
   },
   "requests": {


### PR DESCRIPTION
## Symptom

Searching the S01 pack of "Au service de la France" surfaced lots of "Hippocrate S01" / "Lupin S01" results — the indexer ignores \`q=\` for the \`tvsearch\` endpoint and returns every S01 in category 5000.

## Root cause

\`searchSeasonReleases\` (and friends) flattened indexer results straight into the UI. \`computeRejections\` / \`scoreAndSortReleases\` filtered on quality / language / size / seeders / blocklist, but **never** verified the release title corresponds to the requested show. Indexers that don't honour \`q=\` get a free pass.

## Two-layer fix

### 1. Send external IDs (\`torznab.service.ts\`)
- \`searchSeasonPack\` / \`searchSeries\`: append \`tvdbid=\` and \`imdbid=\` (stripped of \`tt\`) when known.
- \`searchMovie\`: append \`imdbid=\` / \`tmdbid=\` AND switch \`t=search\` → \`t=movie\` when any ID is provided. Matches Radarr / Sonarr behaviour. Indexers that index by ID now filter strictly.
- Helper \`buildTorznabQuery\` keeps URL construction DRY across the three methods.

### 2. Backend title-mismatch rejection (\`release-rejection.helper.ts\`)
- \`titleMatchesExpectation(release, expected: string | string[])\`: normalises both sides (NFD strip, lowercase, separators → space) and requires every significant token of one expected variant to appear as a whole word in the release title.
- FR + EN stop-words (\`au, de, la, le, the, a, an, of, and, …\`) dropped before tokenising so they don't dilute the match.
- New rejection code \`TITLE_MISMATCH\` (+ FR i18n).

### 3. Alternative titles (to keep international names working)
- Without this, "A Very Secret Service" (the EN title of "Au service de la France") would be rejected by the filter. The user explicitly wants those releases to grab.
- New column \`media.alternativeTitles jsonb DEFAULT '[]'\` (migration \`1778400000000\`).
- TMDB provider: \`append_to_response=alternative_titles\`, mapped via \`extractAlternativeTitles\` (dedup against title + originalTitle).
- TVDB provider: maps the \`aliases\` field via \`dedupeAliases\`.
- All search paths now pass \`[media.title, ...media.alternativeTitles]\` (or the customQuery alone if user provided one).

## Wiring

\`episode-download.service.ts\` (manual episode + manual season-pack + auto season-pack + per-episode fallback), \`movie-download.service.ts\` (manual + auto search), \`scheduler.service.ts\` (cron auto-grab movies + episodes), \`auto-grab-pipeline.service.ts\` (\`expectedTitle\` parameter on \`tryAutoGrab\`).

## Backfill

Existing \`media\` rows get \`alternativeTitles: []\`. They populate automatically on the next metadata refresh — no batch TMDB call in the migration (would hammer TMDB for inactive libraries).

## Test plan

- [ ] Refresh metadata for "Au service de la France": confirm \`alternativeTitles\` includes "A Very Secret Service" (DB or admin tool).
- [ ] Search S01 pack: Hippocrate / Lupin / etc. no longer appear; "A Very Secret Service" releases do.
- [ ] Search a movie with a heavily-localised title (e.g. a Studio Ghibli film) and confirm the international name still surfaces.
- [ ] Auto-grab cron on a missing season pack: no cross-show contamination in logs.
- [ ] Indexer that **does** honour \`q=\` (e.g. Jackett mainstream tracker): no regression — title filter is a soft no-op when q= already filtered server-side.
- [ ] Custom query in the UI ("search with this exact name"): only the custom string is used as expected title, alt-titles ignored.