### PR TITLE
fix(horizontal-scroller): hide arrows when content fits without scroll

### DIFF
--- a/client/src/app/shared/components/horizontal-scroller.ts
+++ b/client/src/app/shared/components/horizontal-scroller.ts
@@ -18,25 +18,29 @@ import { TvRowDirective } from '../directives/tv-row.directive';
   imports: [LucideChevronLeft, LucideChevronRight, TvRowDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <!-- Header: title + arrows (arrows are mouse-only — hidden on touch/TV) -->
+    <!-- Header: title + arrows (arrows are mouse-only — hidden on touch/TV,
+         and when content fits without scrolling so we don't show two grey
+         disabled chevrons doing nothing). -->
     <div class="flex items-center justify-between mb-3">
       <h2 class="text-lg font-bold">{{ title() }}</h2>
-      <div class="flex gap-1 scroll-arrows">
-        <button
-          class="btn btn-ghost btn-sm btn-circle"
-          [disabled]="atStart()"
-          (click)="scrollLeft()"
-        >
-          <svg lucideChevronLeft class="h-5 w-5"></svg>
-        </button>
-        <button
-          class="btn btn-ghost btn-sm btn-circle"
-          [disabled]="atEnd()"
-          (click)="scrollRight()"
-        >
-          <svg lucideChevronRight class="h-5 w-5"></svg>
-        </button>
-      </div>
+      @if (!atStart() || !atEnd()) {
+        <div class="flex gap-1 scroll-arrows">
+          <button
+            class="btn btn-ghost btn-sm btn-circle"
+            [disabled]="atStart()"
+            (click)="scrollLeft()"
+          >
+            <svg lucideChevronLeft class="h-5 w-5"></svg>
+          </button>
+          <button
+            class="btn btn-ghost btn-sm btn-circle"
+            [disabled]="atEnd()"
+            (click)="scrollRight()"
+          >
+            <svg lucideChevronRight class="h-5 w-5"></svg>
+          </button>
+        </div>
+      }
     </div>
     <!-- Scrollable content (no visible scrollbar). On TV the scroller gets
          vertical padding (and a matching negative margin so neighbours don't


### PR DESCRIPTION
## Summary

Two greyed-out disabled chevrons next to a row title was visual noise on rows that fit in the viewport (e.g. a "More from season" row with one episode left). Wrap the arrow group in \`@if (!atStart() || !atEnd())\`. Both true ⇒ nothing can scroll ⇒ drop the arrows entirely.

The existing \`ResizeObserver\` re-evaluates \`atStart\` / \`atEnd\` when the viewport or content size changes, so the arrows reappear if the row starts overflowing later (resize, lazy-loaded cards, etc.).

## Test plan

- [ ] Open a media-detail page with a short cast row that fits the viewport — no chevrons visible.
- [ ] Same row on a narrower viewport (resize browser) where it overflows — chevrons reappear.
- [ ] Scroll a long row to the end — only the left chevron stays (right one disabled-but-visible, current behaviour). At the start: only right one visible.