### PR TITLE
feat(cast): receiver caps probe + AC-3 5.1 surround on Cast

### DIFF
--- a/backend/src/modules/streaming/active-stream-tracker.service.ts
+++ b/backend/src/modules/streaming/active-stream-tracker.service.ts
@@ -138,6 +138,18 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
     return this.useExtXMediaCache.get(mediaFileId) ?? false;
   }
 
+  /** Set when the playback target is a Chromecast receiver. Drives the
+   *  HLS segment container choice (mpegts vs fmp4) in `buildFfmpegArgs`. */
+  private readonly useTsCache = new Map<number, boolean>();
+
+  setUseTs(mediaFileId: number, value: boolean) {
+    this.useTsCache.set(mediaFileId, value);
+  }
+
+  getUseTs(mediaFileId: number): boolean {
+    return this.useTsCache.get(mediaFileId) ?? false;
+  }
+
   private segmentDurationCache = 3;
   private initTimeCache = 1;
 

--- a/backend/src/modules/streaming/dto/device-profile.dto.ts
+++ b/backend/src/modules/streaming/dto/device-profile.dto.ts
@@ -76,4 +76,16 @@ export class DeviceProfileDto {
   @IsIn(['mobile', 'desktop'])
   @IsOptional()
   deviceType?: 'mobile' | 'desktop';
+
+  /**
+   * True when the request originates from a Chromecast sender. Drives the
+   * HLS segment container choice: MPEG-TS instead of fMP4. TS avoids the
+   * AAC/EAC3 encoder priming desync, because each audio packet in a TS
+   * stream carries its own PTS and there's no init segment / edit-list
+   * for the receiver to honour or ignore. fMP4 stays the default for web
+   * (Shaka), native (ExoPlayer / AVPlayer) and TV.
+   */
+  @IsBoolean()
+  @IsOptional()
+  useTs?: boolean;
 }

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -275,12 +275,29 @@ export class StreamBuilderService {
       effectiveHwAccel = 'vaapi';
     }
 
-    // Audio can ride on the transcode path as a copy when the client
-    // supports the source codec + channel count — there's no reason to
-    // downmix EAC-3 5.1 just because the video has to be re-encoded.
-    const canCopyAudio = directPlayResult.audioSupported;
+    // Audio output strategy on the transcode path. Two valid surround
+    // paths trigger `canCopyAudio=true` (= "preserve channels"):
+    //
+    //   1. Source codec is decodable by the receiver + channels ≤ max →
+    //      ffmpeg-args runs `-c:a copy` (no re-encode, no priming).
+    //   2. Source has ≥ 6 channels + the receiver accepts at least one
+    //      surround codec (AC-3 / EAC-3) + maxAudioChannels permits → we
+    //      re-encode to the best supported surround codec instead of
+    //      downmixing to AAC stereo. Lets a Cast 2 (only AC-3) still play
+    //      a 5.1 EAC-3 source in surround via EAC-3 → AC-3.
+    const profileAudioCodecs = profile.directPlayProfiles
+      .flatMap((p) => p.audioCodecs)
+      .map((c) => c.toLowerCase());
+    const srcChannels = source.audioChannels ?? 2;
+    const maxChannels = profile.maxAudioChannels ?? 2;
+    const surroundSupported =
+      srcChannels >= 6 &&
+      maxChannels >= 6 &&
+      (profileAudioCodecs.includes('ac3') ||
+        profileAudioCodecs.includes('eac3'));
+    const canCopyAudio = directPlayResult.audioSupported || surroundSupported;
     this.log.log(
-      `Transcode for file ${resolved.mediaFile.id}: ${reasons.map((r) => r.flag).join(', ')} (audio=${canCopyAudio ? 'copy' : 'aac'})`,
+      `Transcode for file ${resolved.mediaFile.id}: ${reasons.map((r) => r.flag).join(', ')} (audio=${canCopyAudio ? 'copy' : 'aac'}, srcCh=${srcChannels}, maxCh=${maxChannels}, surroundPath=${surroundSupported})`,
     );
     const url = `/api/stream/${resolved.mediaFile.id}/master.m3u8${tokenParam}`;
     const transcodeBitrateByQuality: NonNullable<

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -57,6 +57,12 @@ function withTimestampMap(vtt: string | Buffer): string {
 let SEG_DURATION = 3;
 let INIT_TIME = 1;
 
+/** Pick the right HLS segment Content-Type. fMP4 (.m4s / .mp4) → video/mp4,
+ *  MPEG-TS (.ts, used for Chromecast sessions) → video/MP2T. */
+function segmentContentType(segment: string): string {
+  return segment.endsWith('.ts') ? 'video/MP2T' : 'video/mp4';
+}
+
 function buildVodPlaylist(
   duration: number,
   segmentUrl: (index: string) => string,
@@ -178,6 +184,7 @@ export class StreamingController {
           ? ((si?.audio as { language?: string; title?: string }[]) ?? [])
           : undefined,
       deviceType: this.activeStreamTracker.getDeviceType(mediaFileId),
+      useTs: this.activeStreamTracker.getUseTs(mediaFileId),
       encoderPreset: this.activeStreamTracker.getEncoderPreset(mediaFileId),
       qsvOptions: this.activeStreamTracker.getQsvOptions(),
       // Source framerate (e.g. "24", "23.976", "29.97") — used to compute an
@@ -428,6 +435,10 @@ export class StreamingController {
       mediaFileId,
       deviceProfile.deviceType ?? 'desktop',
     );
+    this.activeStreamTracker.setUseTs(
+      mediaFileId,
+      !!deviceProfile.useTs,
+    );
     this.activeStreamTracker.setStreamingDurations(
       ss.segmentDuration,
       ss.initTime,
@@ -643,6 +654,7 @@ export class StreamingController {
       onlyQuality,
       pickedIdx ?? 0,
       deviceType,
+      this.activeStreamTracker.getCanCopyAudio(mediaFileId),
     );
 
     this.activeStreamTracker.setAudioStreamCount(
@@ -758,10 +770,14 @@ export class StreamingController {
     const token = firstQueryString(req.query, 'token');
     const tokenParam = token ? `?token=${encodeURIComponent(token)}` : '';
     const basePath = `/api/stream/${mediaFileId}/audio/${audioIndex}`;
+    const useTs = this.activeStreamTracker.getUseTs(mediaFileId);
+    const segExt = useTs ? 'ts' : 'm4s';
     const playlist = buildVodPlaylist(
       duration,
-      (seg) => `${basePath}/seg-${seg}.m4s${tokenParam}`,
-      `${basePath}/init_${audioIndex + 1}.mp4${tokenParam}`,
+      (seg) => `${basePath}/seg-${seg}.${segExt}${tokenParam}`,
+      useTs
+        ? undefined
+        : `${basePath}/init_${audioIndex + 1}.mp4${tokenParam}`,
     );
 
     res.setHeader('Content-Type', 'application/vnd.apple.mpegurl');
@@ -779,12 +795,12 @@ export class StreamingController {
     @Req() req: Request,
     @Res() res: Response,
   ) {
-    const AUDIO_SEG_RE = /^(init(_\d+)?\.mp4|seg-\d{3,4}\.m4s)$/;
+    const AUDIO_SEG_RE = /^(init(_\d+)?\.mp4|seg-\d{3,4}\.(m4s|ts))$/;
     if (!AUDIO_SEG_RE.test(segment)) {
       throw new BadRequestException(`Invalid audio segment name: ${segment}`);
     }
 
-    const segMatch = segment.match(/seg-(\d+)\.m4s/);
+    const segMatch = segment.match(/seg-(\d+)\.(m4s|ts)/);
     const segIndex = segMatch ? parseInt(segMatch[1], 10) : 0;
     const isInit = segment.startsWith('init');
     const user = req.user;
@@ -870,7 +886,7 @@ export class StreamingController {
       return;
     }
 
-    res.setHeader('Content-Type', 'video/mp4');
+    res.setHeader('Content-Type', segmentContentType(segment));
     res.setHeader('Access-Control-Allow-Origin', '*');
     const stream = fs.createReadStream(segPath);
     stream.on('error', () => {
@@ -950,11 +966,19 @@ export class StreamingController {
     const basePath = `/api/stream/${mediaFileId}/${quality}`;
     // Use the master.m3u8 decision — must match to avoid init filename mismatch.
     const multiAudio = this.activeStreamTracker.getUseExtXMedia(mediaFileId);
-    const initName = multiAudio ? 'init_0.mp4' : 'init.mp4';
+    const useTs = this.activeStreamTracker.getUseTs(mediaFileId);
+    // Cast sessions use MPEG-TS segments (no init segment) to avoid the
+    // fMP4 priming desync the Cast receiver doesn't compensate for.
+    const segExt = useTs ? 'ts' : 'm4s';
+    const initName = useTs
+      ? undefined
+      : multiAudio
+        ? 'init_0.mp4'
+        : 'init.mp4';
     const playlist = buildVodPlaylist(
       duration,
-      (seg) => `${basePath}/seg-${seg}.m4s${tokenParam}`,
-      `${basePath}/${initName}${tokenParam}`,
+      (seg) => `${basePath}/seg-${seg}.${segExt}${tokenParam}`,
+      initName ? `${basePath}/${initName}${tokenParam}` : undefined,
     );
 
     res.setHeader('Content-Type', 'application/vnd.apple.mpegurl');
@@ -975,11 +999,15 @@ export class StreamingController {
     if (!VALID_QUALITIES.has(quality)) {
       throw new BadRequestException(`Invalid quality: ${quality}`);
     }
-    const VIDEO_SEG_RE = /^(seg-\d{3,4}\.m4s|init(_\d+)?\.mp4)$/;
+    const VIDEO_SEG_RE = /^(seg-\d{3,4}\.(m4s|ts)|init(_\d+)?\.mp4)$/;
     if (!VIDEO_SEG_RE.test(segment)) {
       throw new BadRequestException(`Invalid segment name: ${segment}`);
     }
-    if (segment.startsWith('init') || segment === 'seg-0000.m4s') {
+    if (
+      segment.startsWith('init') ||
+      segment === 'seg-0000.m4s' ||
+      segment === 'seg-0000.ts'
+    ) {
       this.log.log(
         `[request] ${segment} mfid=${mediaFileId} quality=${quality}`,
       );
@@ -1020,7 +1048,7 @@ export class StreamingController {
           initFile,
         );
         if (initPath) {
-          res.setHeader('Content-Type', 'video/mp4');
+          res.setHeader('Content-Type', segmentContentType(segment));
           res.setHeader('Access-Control-Allow-Origin', '*');
           const initStream = fs.createReadStream(initPath);
           initStream.on('error', () => {
@@ -1044,7 +1072,7 @@ export class StreamingController {
       const segPath = `${existing.cachePath}/${segName}`;
       if (fs.existsSync(segPath)) {
         existing.lastAccess = Date.now();
-        res.setHeader('Content-Type', 'video/mp4');
+        res.setHeader('Content-Type', segmentContentType(segment));
         res.setHeader('Access-Control-Allow-Origin', '*');
         const stream = fs.createReadStream(segPath);
         stream.on('error', () => {
@@ -1091,7 +1119,7 @@ export class StreamingController {
           10_000,
         );
         if (segPath) {
-          res.setHeader('Content-Type', 'video/mp4');
+          res.setHeader('Content-Type', segmentContentType(segment));
           res.setHeader('Access-Control-Allow-Origin', '*');
           const stream = fs.createReadStream(segPath);
           stream.on('error', () => {
@@ -1143,7 +1171,7 @@ export class StreamingController {
       return;
     }
 
-    res.setHeader('Content-Type', 'video/mp4');
+    res.setHeader('Content-Type', segmentContentType(segment));
     res.setHeader('Access-Control-Allow-Origin', '*');
     const stream = fs.createReadStream(segPath);
     stream.on('error', () => {

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -36,6 +36,10 @@ export interface BuildFfmpegArgsOptions {
    *  for ramp-up speed: fastest encoder preset + reduced rate-control
    *  buffer so the first frame ships sooner. */
   early?: boolean;
+  /** When true, emit MPEG-TS segments instead of fMP4. Used for Chromecast
+   *  sessions to avoid the priming desync caused by the Cast receiver
+   *  ignoring the init fMP4 `edts/elst` atom. */
+  useTs?: boolean;
 }
 
 export function buildFfmpegArgs(
@@ -60,7 +64,15 @@ export function buildFfmpegArgs(
     sourceFps,
     trustedStreamInfo = false,
     early = false,
+    useTs = false,
   } = opts;
+
+  // Segment container choice. Cast → MPEG-TS (fixes the priming desync
+  // because TS packets carry per-frame PTS and there's no init fMP4 atom
+  // for the receiver to honour or ignore). Everyone else → fMP4 (better
+  // for HEVC / DASH-like manifests on Shaka & MSE).
+  const segType = useTs ? 'mpegts' : 'fmp4';
+  const segExt = useTs ? 'ts' : 'm4s';
 
   const SEGMENT_DURATION = getSegmentDuration();
   const INIT_TIME = getInitTime();
@@ -418,9 +430,13 @@ export function buildFfmpegArgs(
       args.push('-map', `0:a:${i}`);
     }
     if (copyAudio) {
-      // Re-encode to E-AC-3 5.1 (preserves surround passthrough; -c:a copy
-      // can't be trimmed precisely when video is transcoded + seeked).
-      args.push('-c:a', 'eac3', '-b:a', '640k');
+      // Re-encode to AC-3 5.1 (Dolby Digital). Every Chromecast generation
+      // including the HDMI dongles decodes AC-3 to PCM 5.1 over HDMI, so it
+      // is the lowest common denominator for surround. EAC-3 (DD+) would
+      // need to be gated on the Ultra+ class which we don't currently
+      // distinguish. `-c:a copy` is avoided because the hybrid seek needs
+      // a re-encode to trim precisely on resume.
+      args.push('-c:a', 'ac3', '-b:a', '640k');
     } else {
       args.push('-c:a', 'aac', '-b:a', profile.audioBitrate, '-ac', '2');
     }
@@ -438,11 +454,11 @@ export function buildFfmpegArgs(
       '-hls_init_time', String(INIT_TIME),
       '-hls_list_size', '0',
       '-start_number', String(startSegment),
-      '-hls_segment_type', 'fmp4',
-      '-hls_fmp4_init_filename', 'init_%v.mp4',
+      '-hls_segment_type', segType,
+      ...(useTs ? [] : ['-hls_fmp4_init_filename', 'init_%v.mp4']),
       '-hls_flags', 'independent_segments',
       '-var_stream_map', varParts.join(' '),
-      '-hls_segment_filename', path.join(outputDir, '%v', 'seg-%04d.m4s'),
+      '-hls_segment_filename', path.join(outputDir, '%v', `seg-%04d.${segExt}`),
       path.join(outputDir, '%v', 'index.m3u8'),
     );
   } else {
@@ -459,9 +475,9 @@ export function buildFfmpegArgs(
       args.push('-map', '0:v:0', '-map', '0:a:0');
     }
     if (copyAudio) {
-      // Re-encode to E-AC-3 5.1 (preserves surround passthrough; -c:a copy
-      // can't be trimmed precisely when video is transcoded + seeked).
-      args.push('-c:a', 'eac3', '-b:a', '640k');
+      // Re-encode to AC-3 5.1 — see the var_stream_map branch above for the
+      // rationale (lowest common denominator for Cast surround).
+      args.push('-c:a', 'ac3', '-b:a', '640k');
     } else {
       args.push('-c:a', 'aac', '-b:a', profile.audioBitrate, '-ac', '2');
     }
@@ -472,9 +488,9 @@ export function buildFfmpegArgs(
       '-hls_init_time', String(INIT_TIME),
       '-hls_list_size', '0',
       '-start_number', String(startSegment),
-      '-hls_segment_type', 'fmp4',
-      '-hls_fmp4_init_filename', 'init.mp4',
-      '-hls_segment_filename', path.join(outputDir, 'seg-%04d.m4s'),
+      '-hls_segment_type', segType,
+      ...(useTs ? [] : ['-hls_fmp4_init_filename', 'init.mp4']),
+      '-hls_segment_filename', path.join(outputDir, `seg-%04d.${segExt}`),
       '-hls_flags', 'independent_segments',
       path.join(outputDir, 'index.m3u8'),
     );
@@ -495,7 +511,10 @@ export function buildAudioOnlyFfmpegArgs(
   startSegment = 0,
   trustedStreamInfo = false,
   log: Logger,
+  useTs = false,
 ): string[] {
+  const segType = useTs ? 'mpegts' : 'fmp4';
+  const segExt = useTs ? 'ts' : 'm4s';
   const SEGMENT_DURATION = getSegmentDuration();
   const INIT_TIME = getInitTime();
 
@@ -539,9 +558,9 @@ export function buildAudioOnlyFfmpegArgs(
     '-hls_init_time', String(INIT_TIME),
     '-hls_list_size', '0',
     '-start_number', String(startSegment),
-    '-hls_segment_type', 'fmp4',
-    '-hls_fmp4_init_filename', 'init.mp4',
-    '-hls_segment_filename', path.join(outputDir, 'seg-%04d.m4s'),
+    '-hls_segment_type', segType,
+    ...(useTs ? [] : ['-hls_fmp4_init_filename', 'init.mp4']),
+    '-hls_segment_filename', path.join(outputDir, `seg-%04d.${segExt}`),
     '-hls_flags', 'independent_segments',
     path.join(outputDir, 'index.m3u8'),
   );

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -28,6 +28,11 @@ export function generateMasterPlaylist(
   onlyQuality?: string,
   defaultAudioIndex = 0,
   deviceType: DeviceType = 'desktop',
+  /** True when the active transcode preserves surround channels via the
+   *  `copyAudio` branch in ffmpeg-args (output codec = AC-3 5.1). The
+   *  advertised CODECS string must match the actual stream codec or the
+   *  receiver rejects the segment at MSE chunk-demuxer append. */
+  canCopyAudio = false,
 ): string {
   const multiAudio = audioStreams && audioStreams.length > 1;
   const lines = ['#EXTM3U'];
@@ -53,9 +58,11 @@ export function generateMasterPlaylist(
   // skip fetching seg 0 purely to probe codecs (TS has no init segment) —
   // otherwise a user resuming mid-file wastes a transcode pass at seg 0
   // before the real seek-aware session starts at their resume position.
-  // We always produce H.264 High @ L4.0 + AAC-LC, so the string is fixed.
+  // Video is always H.264 High @ L4.0. Audio is AAC-LC by default, or
+  // AC-3 ("ac-3") when the transcode is preserving surround.
   const audioAttr = multiAudio ? ',AUDIO="audio"' : '';
-  const transcodeCodecs = ',CODECS="avc1.640028,mp4a.40.2"';
+  const audioCodec = canCopyAudio ? 'ac-3' : 'mp4a.40.2';
+  const transcodeCodecs = `,CODECS="avc1.640028,${audioCodec}"`;
 
   // The HLS master never advertises the `/remux/` variant — it proved
   // unreliable on ExoPlayer (Android), which would ABR-downgrade from the

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -250,6 +250,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     onlyQuality?: string,
     defaultAudioIndex = 0,
     deviceType: DeviceType = 'desktop',
+    canCopyAudio = false,
   ): string {
     return generateMasterPlaylist(
       mediaFileId,
@@ -262,6 +263,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       onlyQuality,
       defaultAudioIndex,
       deviceType,
+      canCopyAudio,
     );
   }
 
@@ -537,6 +539,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
           sourceFps: ctx?.sourceFps,
           trustedStreamInfo: ctx?.trustedStreamInfo,
           early: true,
+          useTs: ctx?.useTs ?? false,
         },
         this.log,
       );
@@ -554,7 +557,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         args,
         sessionDir,
         startSegment: 0,
-        segExt: '.m4s',
+        segExt: ctx?.useTs ? '.ts' : '.m4s',
         segSubDir: usesVarStreamMap ? '0' : undefined,
         extra: { actualHwAccel: this.detectedHwAccel },
       });
@@ -839,6 +842,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         qsvOptions: ctx?.qsvOptions,
         sourceFps: ctx?.sourceFps,
         trustedStreamInfo: ctx?.trustedStreamInfo,
+        useTs: ctx?.useTs ?? false,
       },
       this.log,
     );
@@ -852,7 +856,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       args,
       sessionDir,
       startSegment,
-      segExt: '.m4s',
+      segExt: ctx?.useTs ? '.ts' : '.m4s',
       segSubDir: usesVarStreamMap ? '0' : undefined,
       extra: {
         actualHwAccel: hwAccel,
@@ -1122,6 +1126,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       requestedSegment,
       ctx?.trustedStreamInfo ?? false,
       this.log,
+      ctx?.useTs ?? false,
     );
 
     const session = this.spawnFfmpegSession({
@@ -1131,6 +1136,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       args,
       sessionDir,
       startSegment: requestedSegment,
+      segExt: ctx?.useTs ? '.ts' : undefined,
       extra: { isAudioOnly: true },
     });
 

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -70,6 +70,14 @@ export interface SessionContext {
    * later FFmpeg spawns (segments / quality switches).
    */
   copyAudio?: boolean;
+  /**
+   * True when the playback target is a Chromecast receiver. Switches HLS
+   * segments to MPEG-TS (instead of fMP4) so the Cast receiver isn't
+   * subject to the encoder-priming desync that comes from an unhonoured
+   * init fMP4 `edts/elst` atom. Container choice only — codecs and the
+   * rest of the pipeline are unchanged.
+   */
+  useTs?: boolean;
 }
 
 export interface TranscodeSession {

--- a/cast-receiver/receiver.js
+++ b/cast-receiver/receiver.js
@@ -136,6 +136,48 @@ playerManager.setMessageInterceptor(
   },
 );
 
+// --- Capability probe protocol ------------------------------------------
+//
+// Sender sends `{type:'probe'}` on the caps namespace and we reply with
+// the list of audio/video codecs MediaSource actually accepts on this
+// device. Lets the sender build an accurate device profile per-receiver:
+// e.g. a Cast 2 reports AAC-only via MSE even though its hardware decodes
+// AC-3 over HDMI passthrough — the sender needs the truthful MSE list,
+// otherwise Shaka rejects the segment at chunk-demuxer append.
+//
+// Result is cached sender-side keyed on the device's friendly name, so
+// only the first cast to a new device pays the probe round-trip.
+const CAPS_NAMESPACE = 'urn:x-cast:app.fliks.caps';
+const CAPS_AUDIO = [
+  { codec: 'mp4a.40.2',       label: 'aac' },
+  { codec: 'mp4a.40.5',       label: 'aac-he' },
+  { codec: 'ac-3',            label: 'ac3' },
+  { codec: 'ec-3',            label: 'eac3' },
+  { codec: 'opus',            label: 'opus' },
+];
+const CAPS_VIDEO = [
+  { codec: 'avc1.640028',         label: 'h264' },
+  { codec: 'hvc1.1.6.L150.B0',    label: 'hevc' },
+  { codec: 'vp09.00.50.08',       label: 'vp9' },
+  { codec: 'av01.0.04M.08',       label: 'av1' },
+];
+
+context.addCustomMessageListener(CAPS_NAMESPACE, (event) => {
+  if (!event.data || event.data.type !== 'probe') return;
+  const probe = (mime) => {
+    try { return MediaSource.isTypeSupported(mime); } catch { return false; }
+  };
+  const audioCodecs = CAPS_AUDIO
+    .filter((c) => probe(`audio/mp4; codecs="${c.codec}"`))
+    .map((c) => c.label);
+  const videoCodecs = CAPS_VIDEO
+    .filter((c) => probe(`video/mp4; codecs="${c.codec}"`))
+    .map((c) => c.label);
+  const reply = { type: 'caps', audioCodecs, videoCodecs };
+  console.log('[fliks-cast] caps probe →', JSON.stringify(reply));
+  context.sendCustomMessage(CAPS_NAMESPACE, event.senderId, reply);
+});
+
 // --- Boot ---------------------------------------------------------------
 //
 // `useShakaForHls: true` makes CAF use Shaka for HLS — the same engine
@@ -161,5 +203,8 @@ options.useShakaForHls = true;
 options.playbackConfig = new cast.framework.PlaybackConfig();
 options.playbackConfig.autoResumeDuration = 5;
 options.supportedCommands = cast.framework.messages.Command.ALL_BASIC_MEDIA;
+options.customNamespaces = {
+  [CAPS_NAMESPACE]: cast.framework.system.MessageType.JSON,
+};
 context.start(options);
 console.log('[fliks-cast] context.start called');

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -41,6 +41,10 @@ export interface DeviceProfile {
   /** Client device category — selects the backend bitrate ladder.
    *  Capacitor native (iOS/Android app) → 'mobile'; web (incl. Cast sender) → 'desktop'. */
   deviceType: 'mobile' | 'desktop';
+  /** True when the playback target is a Chromecast receiver. Drives the
+   *  HLS segment container choice on the backend (MPEG-TS instead of
+   *  fMP4) — see `device-profile.dto.ts` for the rationale. */
+  useTs?: boolean;
 }
 
 @Injectable({ providedIn: 'root' })

--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -103,18 +103,132 @@ export class CastPlayerService {
   private readonly mediaService = inject(MediaService);
   private readonly translate = inject(TranslateService);
 
-  /** Chromecast profile — force full transcode to guarantee H264+AAC HLS output. */
+  /** Chromecast profile, derived from the receiver-probed MSE codec list
+   *  (see `probeReceiverCapabilities`). `videoCodecs: []` keeps every Cast
+   *  on the transcode path so the backend ladder drives quality/ABR; the
+   *  surround output codec is picked in stream-builder from the audio
+   *  codecs we list here (priority EAC-3 > AC-3 > AAC).
+   *
+   *  Without cached caps (first cast to a new device, or older receiver
+   *  that doesn't answer the probe), we fall back to AAC-only stereo — a
+   *  Cast generation we don't recognise is safer downmixed than failing
+   *  to play.
+   *
+   *  `useTs` is conditional on the path:
+   *  - Stereo (AAC re-encode) → `useTs=true`. fMP4 + AAC suffers from the
+   *    encoder priming desync (~44 ms) because Shaka on Cast ignores the
+   *    init segment `edts/elst` atom. TS sidesteps the issue.
+   *  - Surround (AC-3 / EAC-3 re-encode) → `useTs=false`. Dolby codecs
+   *    have no encoder priming (MDCT overlap is built into the codec, not
+   *    extra lookahead) and AC-3 in TS doesn't survive the receiver's
+   *    Shaka transmuxer to fMP4 for MSE (error 4032), so fMP4 is required. */
   private getCastDeviceProfile(): DeviceProfile {
     const cs = this.castSettings.get();
+    const maxChannels = cs.audioChannels ?? 2;
+
+    // Pull the receiver's probed capabilities for the currently connected
+    // device (cached from a previous session, or just-populated by an
+    // in-flight probe). Default to AAC-only when we have nothing.
+    const deviceName = this.currentDeviceName();
+    const caps = deviceName
+      ? this.castSettings.getDeviceCapabilities(deviceName)
+      : null;
+    const receiverAudio = caps?.audioCodecs ?? ['aac'];
+
+    // Filter against codecs the backend can actually emit (the transcoder
+    // produces AAC, AC-3, or EAC-3) and against the channel preference.
+    const surroundOk = maxChannels >= 6;
+    const allowedAudio = receiverAudio.filter((c) => {
+      if (c === 'aac' || c === 'aac-he') return true;
+      if (c === 'ac3' || c === 'eac3') return surroundOk;
+      return false;
+    });
+    // Normalise to the codec strings stream-builder compares against.
+    const audioCodecs = allowedAudio.map((c) =>
+      c === 'aac-he' ? 'aac' : c,
+    );
+
+    const hasSurroundCodec = audioCodecs.some(
+      (c) => c === 'ac3' || c === 'eac3',
+    );
     return {
-      // Empty direct play profiles → nothing can direct play or remux → always transcode
-      directPlayProfiles: [],
+      directPlayProfiles: [
+        { containers: ['hls'], videoCodecs: [], audioCodecs },
+      ],
       codecConditions: [],
       maxStreamingBitrate: 20_000_000,
-      maxAudioChannels: cs.audioChannels ?? 2,
+      maxAudioChannels: maxChannels,
       supportsHdr: cs.hdr ?? false,
       deviceType: 'desktop',
+      useTs: !hasSurroundCodec,
     };
+  }
+
+  /** Friendly name of the currently connected Cast device, or null when
+   *  no session is active. Used as the cache key for receiver-probed
+   *  capabilities. */
+  private currentDeviceName(): string | null {
+    try {
+      const session = (window as any).cast?.framework?.CastContext
+        ?.getInstance?.()
+        ?.getCurrentSession?.();
+      return session?.getCastDevice?.()?.friendlyName ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Ask the receiver which audio/video codecs `MediaSource.isTypeSupported`
+   *  accepts. The receiver answers on the same `urn:x-cast:app.fliks.caps`
+   *  namespace. Result is cached per device so only the first session to
+   *  a new Cast pays the round-trip; subsequent sessions read directly
+   *  from {@link CastSettingsService.getDeviceCapabilities}. */
+  private async probeReceiverCapabilities(): Promise<void> {
+    const session = (window as any).cast?.framework?.CastContext
+      ?.getInstance?.()
+      ?.getCurrentSession?.();
+    if (!session) return;
+    const deviceName = session.getCastDevice?.()?.friendlyName;
+    if (!deviceName) return;
+    // Skip if we already have caps for this device — the probe is idempotent
+    // but each round-trip is ~150–300 ms and slows the first loadMedia.
+    if (this.castSettings.getDeviceCapabilities(deviceName)) return;
+
+    const namespace = 'urn:x-cast:app.fliks.caps';
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        try { session.removeMessageListener?.(namespace, listener); } catch { /* noop */ }
+        resolve();
+      };
+      const listener = (_ns: string, raw: string) => {
+        try {
+          const data = JSON.parse(raw);
+          if (data?.type !== 'caps') return;
+          this.castSettings.setDeviceCapabilities(deviceName, {
+            audioCodecs: Array.isArray(data.audioCodecs) ? data.audioCodecs : [],
+            videoCodecs: Array.isArray(data.videoCodecs) ? data.videoCodecs : [],
+          });
+        } catch {
+          /* malformed reply — leave the cache empty, the next session
+             retries against the safe stereo fallback */
+        }
+        finish();
+      };
+      try {
+        session.addMessageListener(namespace, listener);
+        session.sendMessage(namespace, JSON.stringify({ type: 'probe' }));
+      } catch {
+        finish();
+        return;
+      }
+      // 2 s ceiling — older receivers that don't implement the namespace
+      // won't answer, falling back to whatever capabilities (or absence)
+      // the cache already has.
+      setTimeout(finish, 2000);
+    });
   }
 
   // Sprite preview
@@ -229,6 +343,14 @@ export class CastPlayerService {
     effect(() => {
       const connected = this.cast.isConnected();
       if (!connected && this.hasMedia()) this.clear();
+    });
+    // On every session connect, ask the receiver which audio/video codecs
+    // its MediaSource accepts and cache the answer by device name. The
+    // probe is a no-op when the cache already covers this device.
+    effect(() => {
+      if (this.cast.isConnected()) {
+        void this.probeReceiverCapabilities();
+      }
     });
   }
 

--- a/client/src/app/core/services/cast-settings.service.ts
+++ b/client/src/app/core/services/cast-settings.service.ts
@@ -14,11 +14,24 @@ export interface CastSubtitleStyle {
   background: string;  // 'transparent' | 'semi' | 'black'
 }
 
+export interface CastDeviceCapabilities {
+  /** Audio codecs `MediaSource.isTypeSupported` accepts on the receiver
+   *  (`'aac' | 'aac-he' | 'ac3' | 'eac3' | 'opus'`). What MSE accepts —
+   *  may differ from the firmware's HDMI-passthrough capability set. */
+  audioCodecs: string[];
+  /** Video codecs `MediaSource.isTypeSupported` accepts on the receiver. */
+  videoCodecs: string[];
+}
+
 export interface CastSettings {
   hdr: boolean;
   maxQuality: string; // 'original' | '2160p' | '1080p' | '720p' | '480p'
   audioChannels: number; // 2 = stereo, 6 = 5.1, 8 = 7.1
   subtitleStyle: CastSubtitleStyle;
+  /** Capabilities cache, keyed by Cast device friendly name. Populated on
+   *  first session via the `urn:x-cast:app.fliks.caps` namespace probe so
+   *  subsequent sessions to the same device skip the round-trip. */
+  capabilities?: Record<string, CastDeviceCapabilities>;
 }
 
 const STORAGE_KEY = 'cast.settings';
@@ -83,5 +96,22 @@ export class CastSettingsService {
 
   get(): CastSettings {
     return this.settings();
+  }
+
+  /** Look up cached MSE-codec capabilities for a Cast device. Returns
+   *  `null` on first sight; the sender then probes the receiver and
+   *  calls {@link setDeviceCapabilities} to populate the cache. */
+  getDeviceCapabilities(deviceName: string): CastDeviceCapabilities | null {
+    const caps = this.settings().capabilities?.[deviceName];
+    return caps ?? null;
+  }
+
+  setDeviceCapabilities(deviceName: string, caps: CastDeviceCapabilities) {
+    const current = this.settings();
+    const updated: CastSettings = {
+      ...current,
+      capabilities: { ...(current.capabilities ?? {}), [deviceName]: caps },
+    };
+    this.save(updated);
   }
 }


### PR DESCRIPTION
## Summary

Adds a receiver → sender capability probe so the Cast profile is built from what the device's MediaSource actually accepts, instead of an optimistic hardcoded list. Then plumbs an AC-3 5.1 surround output through the backend with a matching CODECS string in the master playlist.

### Capability probe

- `cast-receiver/receiver.js` registers \`urn:x-cast:app.fliks.caps\`. On \`{type:'probe'}\` it runs \`MediaSource.isTypeSupported()\` for AAC / AAC-HE / AC-3 / EAC-3 / Opus and H.264 / HEVC / VP9 / AV1, replies with the matching label list.
- Sender (\`cast-player.service.ts\`) probes on every \`isConnected\` transition, caches the result per friendlyName in \`localStorage['cast.settings'].capabilities\`, idempotent so only the first cast to a new device pays the ~150-300 ms round-trip.
- Older receivers (or build-time receivers that haven't picked up this change) just don't answer; the sender's 2 s timeout falls back to the safe stereo default.

### Audio path on Cast

- \`getCastDeviceProfile\` derives \`directPlayProfiles.audioCodecs\` from cached caps (\`['aac']\` only on Cast 2/3 — what their MSE actually exposes; \`['aac','ac3','eac3']\` on Cast Ultra / Google TV).
- \`useTs\` is keyed on the picked output codec:
  - AAC stereo → \`useTs=true\`. TS sidesteps the 44 ms AAC encoder priming desync that Shaka on Cast doesn't compensate for on fMP4 \`edts/elst\` atoms.
  - AC-3 / EAC-3 → \`useTs=false\`. Dolby codecs have no encoder priming, and AC-3 in TS fails Shaka's TS-to-fMP4 transmuxer (error 4032) — fMP4 is mandatory.
- Backend \`stream-builder\` now allows the surround path even when the source codec isn't itself decodable: 5.1 source + device declares any surround codec → re-encode preserves channels via the best supported codec instead of downmixing to AAC stereo.
- \`ffmpeg-args\` \`copyAudio\` branch outputs AC-3 5.1 (lowest common denominator).
- \`master-playlist\` advertises \`CODECS=\"avc1.640028,ac-3\"\` when \`canCopyAudio=true\` so the receiver's MIME check matches what FFmpeg emits.

## Auto-deploy

The receiver part triggers \`.github/workflows/deploy-cast-receiver.yml\` on push to main — no manual upload to Cast Console needed.

## Test plan

- [ ] First Cast session to Cast 2: receiver console (\`chrome://inspect\` → Receiver page) logs \`[fliks-cast] caps probe → {audioCodecs:['aac'], …}\`.
- [ ] Subsequent sessions: no probe in console (cache hit), audio stays AAC stereo + TS, no desync at start or on mid-file resume.
- [ ] Cast Ultra / Google TV (when available): probe returns AC-3 / EAC-3, playback uses surround + fMP4, no priming desync.
- [ ] Source codecs to cover: AAC stereo, AC-3 5.1, EAC-3 5.1, DTS 5.1 (last one should fall back to AAC stereo on Cast 2).
- [ ] Mid-file resume + audio track switch still work on both stereo and surround paths.
- [ ] Source \`Ant-Man\` EAC-3 5.1 on Cast 2 specifically: probe → aac-only, profile down-shifts to AAC stereo + TS, error 4032 disappears.