### PR TITLE
fix(cast-receiver): drop customNamespaces option that may crash boot on some CAF versions

### DIFF
--- a/cast-receiver/receiver.js
+++ b/cast-receiver/receiver.js
@@ -203,8 +203,5 @@ options.useShakaForHls = true;
 options.playbackConfig = new cast.framework.PlaybackConfig();
 options.playbackConfig.autoResumeDuration = 5;
 options.supportedCommands = cast.framework.messages.Command.ALL_BASIC_MEDIA;
-options.customNamespaces = {
-  [CAPS_NAMESPACE]: cast.framework.system.MessageType.JSON,
-};
 context.start(options);
 console.log('[fliks-cast] context.start called');


### PR DESCRIPTION
## Symptom

Android sender can't connect to Cast since PR #94 landed.

## Hypothesis

The receiver's \`CastReceiverOptions.customNamespaces = { [ns]: cast.framework.system.MessageType.JSON }\` line may resolve to \`undefined\` on the CAF runtime present on some Cast device firmwares (notably the older Cast 2 / 3 HDMI dongles), raising at \`context.start()\` and taking the whole receiver down — every sender then fails to establish a session. CAF v3 docs are explicit: \`addCustomMessageListener(namespace, …)\` registers the namespace on demand, so the explicit options entry is redundant.

## Fix

Drop the option. The caps probe protocol introduced in #94 still works because \`addCustomMessageListener\` is unchanged and auto-registers.

## Test plan

- [ ] Wait for the deploy-cast-receiver workflow to ship.
- [ ] Android: open Fliks, tap Cast, pick Cast 2 → connects without error.
- [ ] Web: same flow → connects, console logs \`[fliks-cast] caps probe →\` on the receiver DevTools.