### PR TITLE
fix(auth): unblock login spinner stuck on IDB cache wipe after server switch

### DIFF
--- a/client/src/app/core/interceptors/cache.interceptor.ts
+++ b/client/src/app/core/interceptors/cache.interceptor.ts
@@ -61,6 +61,50 @@ function openDb(): Promise<IDBDatabase> {
   return dbPromise;
 }
 
+/**
+ * Wipe the cache's IDB store. Closes the module-level connection first
+ * so `indexedDB.deleteDatabase` doesn't get stuck in the `blocked` state
+ * (which then makes a subsequent delete hang forever waiting behind the
+ * previous never-completed delete). Resolves within a short ceiling so a
+ * stuck IDB doesn't gate a login spinner.
+ */
+export function clearRequestCache(): Promise<void> {
+  const closeExisting = dbPromise
+    ? dbPromise
+        .then((db) => {
+          try { db.close(); } catch { /* ignore */ }
+        })
+        .catch(() => {
+          /* the open itself failed — nothing to close */
+        })
+    : Promise.resolve();
+  dbPromise = null;
+  return closeExisting.then(() => {
+    return new Promise<void>((resolve) => {
+      let settled = false;
+      const done = () => {
+        if (settled) return;
+        settled = true;
+        resolve();
+      };
+      try {
+        const req = indexedDB.deleteDatabase(DB_NAME);
+        req.onsuccess = done;
+        req.onerror = done;
+        req.onblocked = done;
+      } catch {
+        done();
+        return;
+      }
+      // Safety net: some Capacitor WebViews never fire any of the events
+      // when another tab/process holds a connection. Don't gate the UI on
+      // it — the data is small (TTL-capped per-entry) and any stragglers
+      // are overwritten on the next put().
+      setTimeout(done, 500);
+    });
+  });
+}
+
 async function getCached(url: string): Promise<CacheEntry | null> {
   try {
     const db = await openDb();

--- a/client/src/app/core/services/auth.service.ts
+++ b/client/src/app/core/services/auth.service.ts
@@ -97,23 +97,27 @@ export class AuthService {
   }
 
   async login(username: string, password: string): Promise<LoginResponse> {
+    // Wipe any cached data from a previous session BEFORE the auth round-trip,
+    // so the new login starts on a clean slate and `_user` / `_accessToken`
+    // are then set in a single block without an async point between them
+    // where a stray effect could observe a mid-update inconsistency.
+    await this.serverCache.clearAll();
     const res = await firstValueFrom(
       this.http.post<LoginResponse>('/api/auth/login', { username, password }),
     );
-    // Discard any cached data from the previous session before publishing the
-    // new user — a "switch user" path otherwise inherits the previous user's
-    // home rows, library views, etc. from the IDB request cache.
-    await this.serverCache.clearAll();
-    this._user.set(res.user);
     if (this.serverConfig.isNative && res.accessToken) {
       this._accessToken = res.accessToken;
       await this.saveToken(res.accessToken);
     }
-    // Bump the active server in the known-servers list so it surfaces first
-    // in /setup next time. Keeps the last username for pre-fill on return.
+    this._user.set(res.user);
+    // Fire-and-forget — bumps the active server in the known-servers list
+    // so it surfaces first in /setup next time. Awaiting here could block
+    // the login spinner if Preferences write stalled.
     const activeUrl = this.serverConfig.serverUrl();
     if (activeUrl) {
-      await this.serverConfig.addOrTouchKnownServer(activeUrl, { username: res.user.username });
+      void this.serverConfig.addOrTouchKnownServer(activeUrl, {
+        username: res.user.username,
+      });
     }
     return res;
   }

--- a/client/src/app/core/services/server-cache.service.ts
+++ b/client/src/app/core/services/server-cache.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, inject } from '@angular/core';
-import { REQUEST_CACHE_DB } from '../interceptors/cache.interceptor';
+import { clearRequestCache } from '../interceptors/cache.interceptor';
 import { CachingReuseStrategy } from './route-reuse.strategy';
 
 /**
@@ -23,24 +23,10 @@ export class ServerCacheService {
 
   async clearAll(): Promise<void> {
     await Promise.all([
-      this.deleteRequestCacheDb(),
+      clearRequestCache(),
       this.clearCachedUser(),
       this.clearRouteReuse(),
     ]);
-  }
-
-  private deleteRequestCacheDb(): Promise<void> {
-    return new Promise<void>((resolve) => {
-      try {
-        const req = indexedDB.deleteDatabase(REQUEST_CACHE_DB);
-        req.onsuccess = () => resolve();
-        req.onerror = () => resolve();
-        // Another tab still has the DB open — it'll be deleted when that closes.
-        req.onblocked = () => resolve();
-      } catch {
-        resolve();
-      }
-    });
   }
 
   private async clearCachedUser(): Promise<void> {

--- a/client/src/app/features/login/login.ts
+++ b/client/src/app/features/login/login.ts
@@ -50,10 +50,6 @@ export class LoginComponent {
 
     const { username, password } = this.form.getRawValue();
     try {
-      // Trim only the username — a password can legitimately contain leading/
-      // trailing whitespace and we shouldn't quietly mutate it. Whitespace
-      // around usernames is almost always a copy-paste artefact that breaks
-      // auth.
       await this.auth.login(username.trim(), password);
       this.loading.set(false);
       void this.router.navigate(['/'], { replaceUrl: true });


### PR DESCRIPTION
## Symptom

"Se connecter" hung indefinitely in this scenario on the Capacitor WebView:

1. Change server.
2. Pick another known server.
3. Pick user.
4. Type password.
5. Submit.

Login POST fired, succeeded, but the spinner never cleared and the app had to be restarted. Console showed the flow reaching \`[auth.login] step 1: clearAll start\` and never moving past it.

## Root cause

\`serverCache.clearAll()\` calls \`indexedDB.deleteDatabase('fliks-api-cache')\`. The cache interceptor's module-level \`dbPromise\` holds an open connection that the WebView never closed on its own. \`deleteDatabase\` enters the \`blocked\` state; our \`onblocked\` handler resolves the local promise but the underlying delete stays pending. The **second** \`deleteDatabase\` call (second login in the same app session) queues behind the first and never fires any event — Capacitor's IDB layer silently swallows them.

## Fix

\`cache.interceptor.ts\` now exports \`clearRequestCache()\`:

- Closes the module-level \`dbPromise\` connection and resets it to \`null\` first, so \`deleteDatabase\` doesn't block on our own connection.
- Calls \`deleteDatabase\` and wires \`onsuccess\` / \`onerror\` / \`onblocked\` to a single \`done\`.
- 500 ms safety-net timeout — even if every event handler is silenced, the promise resolves and the UI never stalls. We don't need the DB to actually be gone (stragglers get overwritten on the next put); we just need to not block the UI on it.

\`server-cache.service.ts\` consumes the helper instead of duplicating the delete dance.

Also tightened the login flow:

- \`clearAll()\` runs before the auth POST (instead of between POST and user/token assignment), removing the brief inconsistent window.
- Token is saved before \`this._user.set(res.user)\`, so effects watching \`isAuthenticated()\` (download-manager auto-recover, etc.) see a complete auth state.
- \`addOrTouchKnownServer()\` is fire-and-forget so a slow Preferences write can't block the spinner.

## Test plan

- [ ] Capacitor app on Android: server switch flow described above resolves and lands on home with fresh data.
- [ ] Multiple consecutive server switches without restarting the app.
- [ ] Web build: same flow, no regression.
- [ ] Direct login (no server switch) still works on both platforms.
- [ ] After login, no stale request data leaks from the previous server.