### PR TITLE
fix(transcode): move -output_ts_offset after -i to kill 2 s repeat at rotation seam

### DIFF
--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -163,14 +163,19 @@ export function buildFfmpegArgs(
     //     the decoded domain. Re-encoded audio is trimmed sample-accurately
     //     (not packet-snapped) so its first sample lines up with the first
     //     video frame at internal t = postSeek = source time T.
-    //  3. `-output_ts_offset preSeek` shifts the muxer-side PTS so the
-    //     first emitted PTS = postSeek + preSeek = T, matching the
-    //     playlist's expected tfdt for seg-K.
+    //  3. `-output_ts_offset preSeek` (placed AFTER `-i` — it's an
+    //     OPT_OUTPUT option per FFmpeg, see fftools/ffmpeg_opt.c) shifts
+    //     the muxer-side PTS so the first emitted PTS = postSeek +
+    //     preSeek = T, matching the playlist's expected tfdt for seg-K.
+    //     Placed before `-i` it lives in the input option group and can
+    //     get silently dropped or re-shifted by the muxer's
+    //     `avoid_negative_ts auto`, causing a PRE_SEEK_MARGIN_SECONDS
+    //     overlap with the previous segment (= a 2 s video repeat at
+    //     every rotation seam on Chromecast).
     //
     // Cost: PRE_SEEK_MARGIN_SECONDS of extra HW/CPU decode every
     // SEGMENT_ROTATION_INTERVAL_SECONDS — negligible.
     args.push('-ss', String(preSeek));
-    args.push('-output_ts_offset', String(preSeek));
   }
 
   // parseBitrateToBps handles both "8M" and "200k" correctly. Using parseInt()*1e6
@@ -260,10 +265,13 @@ export function buildFfmpegArgs(
 
   args.push('-i', inputPath);
 
-  if (startSegment > 0 && postSeek > 0) {
+  if (startSegment > 0) {
     // Output-seek companion to the input-seek above; trims the decoded
     // PRE_SEEK_MARGIN_SECONDS prelude sample-accurately on both tracks.
-    args.push('-ss', String(postSeek));
+    // `-output_ts_offset` is also placed here (after `-i`) because it's
+    // an OPT_OUTPUT option in FFmpeg — see the comment block above.
+    if (postSeek > 0) args.push('-ss', String(postSeek));
+    args.push('-output_ts_offset', String(preSeek));
   }
 
   // Video encoding
@@ -543,13 +551,15 @@ export function buildAudioOnlyFfmpegArgs(
 
   if (startSegment > 0) {
     args.push('-ss', String(preSeek));
-    args.push('-output_ts_offset', String(preSeek));
   }
 
   args.push('-i', inputPath);
 
-  if (startSegment > 0 && postSeek > 0) {
-    args.push('-ss', String(postSeek));
+  if (startSegment > 0) {
+    // `-ss postSeek` + `-output_ts_offset preSeek` placed after `-i` —
+    // both are OPT_OUTPUT options. Same rationale as buildFfmpegArgs.
+    if (postSeek > 0) args.push('-ss', String(postSeek));
+    args.push('-output_ts_offset', String(preSeek));
   }
 
   args.push('-map', `0:a:${audioStreamIndex}`);


### PR DESCRIPTION
## Summary
- `-output_ts_offset` is `OPT_OUTPUT` in FFmpeg. Placed before `-i` it landed in the input option group, where it was either dropped or re-shifted by the muxer's `avoid_negative_ts auto`, emitting `tfdt = preSeek` instead of `tfdt = preSeek + postSeek` on the first segment of each respawned encoder.
- The mismatch is exactly `PRE_SEEK_MARGIN_SECONDS` (= 2 s) → on Chromecast it surfaced as a 2 s video repeat + A/V drift every time the rotation worker respawned ffmpeg (every 10 min of content, per `SEGMENT_ROTATION_INTERVAL_SECONDS`).
- Fix: emit `-output_ts_offset` next to `-ss postSeek` after `-i` in both `buildFfmpegArgs` and `buildAudioOnlyFfmpegArgs`. The fast demuxer `-ss preSeek` stays before `-i` — no extra decoding on long files.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Cast a 2 h+ file, confirm no video repeat / A/V drift at the 10 min, 20 min, 30 min rotation seams