### PR TITLE
feat(library): redesign toolbar — view tabs, sort+order, filter dropdown

### DIFF
--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -479,9 +479,21 @@ export class MediaService {
       this.applyFullTextSearch(qb, query.q);
     }
 
-    const sortBy = query.sortBy ?? 'media.title';
-    const sortOrder = query.sortOrder ?? 'ASC';
-    qb.orderBy(sortBy.includes('.') ? sortBy : `media.${sortBy}`, sortOrder);
+    // Whitelist + column mapping for ORDER BY. The raw `sortBy` value
+    // arrives from the client, so we must reject anything outside the
+    // allowed keys (otherwise the string ends up concatenated into the
+    // SQL — classic ORDER BY injection vector) and translate UI-side
+    // aliases like `added` to the actual physical column (`createdAt`,
+    // inherited from BaseEntity).
+    const SORT_BY_MAP: Record<string, string> = {
+      title: 'media.title',
+      year: 'media.year',
+      added: 'media.createdAt',
+      rating: 'media.rating',
+    };
+    const sortBy = SORT_BY_MAP[query.sortBy ?? 'title'] ?? 'media.title';
+    const sortOrder = query.sortOrder === 'DESC' ? 'DESC' : 'ASC';
+    qb.orderBy(sortBy, sortOrder);
 
     if (limit > 0) {
       qb.skip(offset).take(limit);

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -462,9 +462,9 @@
     "filter_missing": "Manquants",
     "filter_cutoff_unmet": "Cutoff non atteint",
     "sort_title": "Titre",
-    "sort_year": "Année",
-    "sort_added": "Ajouté",
-    "sort_rating": "Note",
+    "sort_year": "Date de sortie",
+    "sort_added": "Date d'ajout",
+    "sort_rating": "Note TMDB",
     "bulk_edit": "Édition groupée",
     "bulk_selected": "{{count}} sélectionné(s)",
     "bulk_apply": "Appliquer",
@@ -472,7 +472,17 @@
     "bulk_select_all": "Tout sélectionner",
     "bulk_deselect": "Tout désélectionner",
     "bulk_quality_profile": "Profil de qualité",
-    "bulk_monitored": "Surveillance"
+    "bulk_monitored": "Surveillance",
+    "view_suggestions": "Suggestions",
+    "view_genres": "Genres",
+    "element_count": "{{count}} éléments",
+    "order_asc": "Tri croissant",
+    "order_desc": "Tri décroissant",
+    "filter_button": "Filtres",
+    "filter_disabled": "Désactivé",
+    "filter_monitoring_label": "Surveillance",
+    "filter_status_label": "Statut",
+    "coming_soon": "Bientôt disponible"
   },
   "movies": {
     "title": "Films"

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -1,60 +1,60 @@
-<div class="flex flex-col gap-4">
-  <!-- Header -->
-  <div class="flex flex-col gap-3">
-    <h1 class="sr-only lg:not-sr-only text-2xl font-bold">{{ libraryName() }}</h1>
-    <!-- Search + filter toggle -->
-    <div class="flex gap-2 items-center">
-      <div class="relative flex-1">
-        <svg lucideSearch class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-base-content/40 pointer-events-none z-10"></svg>
-        <input
-          type="text"
-          [placeholder]="'common.search' | translate"
-          class="input input-bordered input-sm w-full pl-9"
-          [ngModel]="searchQuery()"
-          (ngModelChange)="onSearch($event)"
-        />
-      </div>
-      <button class="btn btn-sm btn-square btn-ghost relative" (click)="filtersOpen.set(!filtersOpen())">
-        <svg lucideSlidersHorizontal class="h-5 w-5"></svg>
-        @if (hasActiveFilters()) {
-          <span class="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-primary"></span>
-        }
-      </button>
-      <button
-        class="hidden lg:inline-flex btn btn-sm"
-        [class.btn-primary]="bulkMode()"
-        [class.btn-outline]="!bulkMode()"
-        (click)="toggleBulkMode()"
-      >
-        {{ 'library.bulk_edit' | translate }}
-      </button>
-    </div>
-    <!-- Collapsible filters -->
-    @if (filtersOpen()) {
-      <div class="flex flex-wrap gap-2">
+<div class="flex flex-col gap-4 h-full">
+  <!-- Library title -->
+  <h1 class="text-2xl font-bold">{{ libraryName() }}</h1>
+
+  <!-- View tabs (own row, centered like the reference) -->
+  <nav class="flex items-center gap-1">
+    <button
+      type="button"
+      class="px-4 py-1.5 rounded-full text-sm font-medium transition-colors whitespace-nowrap"
+      [class.bg-base-300]="viewMode() === 'all'"
+      [class.text-base-content/70]="viewMode() !== 'all'"
+      [class.hover:bg-base-200]="viewMode() !== 'all'"
+      (click)="setViewMode('all')"
+    >
+      {{ libraryName() }}
+    </button>
+    <button
+      type="button"
+      class="px-4 py-1.5 rounded-full text-sm font-medium transition-colors whitespace-nowrap"
+      [class.bg-base-300]="viewMode() === 'suggestions'"
+      [class.text-base-content/70]="viewMode() !== 'suggestions'"
+      [class.hover:bg-base-200]="viewMode() !== 'suggestions'"
+      (click)="setViewMode('suggestions')"
+    >
+      {{ 'library.view_suggestions' | translate }}
+    </button>
+    <button
+      type="button"
+      class="px-4 py-1.5 rounded-full text-sm font-medium transition-colors whitespace-nowrap"
+      [class.bg-base-300]="viewMode() === 'genres'"
+      [class.text-base-content/70]="viewMode() !== 'genres'"
+      [class.hover:bg-base-200]="viewMode() !== 'genres'"
+      (click)="setViewMode('genres')"
+    >
+      {{ 'library.view_genres' | translate }}
+    </button>
+  </nav>
+
+  @if (viewMode() === 'all') {
+    <!-- Toolbar: count + sort + order + filter + search.
+         When the alphabet sidebar is visible (title-ASC sort), add right
+         padding equal to its column width (≈ button + gap) so the search
+         input never extends into the sticky alphabet column when it
+         passes through it during scroll. -->
+    <div
+      class="flex flex-wrap items-center gap-2"
+      [class.pr-6]="sortBy() === 'title' && sortOrder() === 'ASC'"
+    >
+      <span class="text-sm text-base-content/70 mr-1">
+        {{ 'library.element_count' | translate:{ count: list.total() } }}
+      </span>
+
+      <div class="flex items-center gap-1">
         <select
-          class="select select-bordered select-sm flex-1 min-w-28"
-          [ngModel]="filterMonitored()"
-          (ngModelChange)="filterMonitored.set($event); onFilterChange()"
-        >
-          <option value="">{{ 'library.filter_all' | translate }}</option>
-          <option value="true">{{ 'library.filter_monitored' | translate }}</option>
-          <option value="false">{{ 'library.filter_unmonitored' | translate }}</option>
-        </select>
-        <select
-          class="select select-bordered select-sm flex-1 min-w-28"
-          [ngModel]="filterStatus()"
-          (ngModelChange)="filterStatus.set($event); onFilterChange()"
-        >
-          <option value="">{{ 'library.filter_all_status' | translate }}</option>
-          <option value="downloaded">{{ 'library.filter_downloaded' | translate }}</option>
-          <option value="missing">{{ 'library.filter_missing' | translate }}</option>
-          <option value="cutoffUnmet">{{ 'library.filter_cutoff_unmet' | translate }}</option>
-        </select>
-        <select
-          class="select select-bordered select-sm flex-1 min-w-28"
+          class="select select-bordered select-sm w-fit"
           [ngModel]="sortBy()"
-          (ngModelChange)="sortBy.set($event); onFilterChange()"
+          (ngModelChange)="onSortByChange($event)"
         >
           <option value="title">{{ 'library.sort_title' | translate }}</option>
           <option value="year">{{ 'library.sort_year' | translate }}</option>
@@ -62,145 +62,271 @@
           <option value="rating">{{ 'library.sort_rating' | translate }}</option>
         </select>
         <button
-          class="btn btn-sm lg:hidden"
-          [class.btn-primary]="bulkMode()"
-          [class.btn-outline]="!bulkMode()"
-          (click)="toggleBulkMode()"
+          type="button"
+          class="btn btn-sm btn-square btn-ghost"
+          [attr.aria-label]="(sortOrder() === 'ASC' ? 'library.order_asc' : 'library.order_desc') | translate"
+          (click)="toggleSortOrder()"
         >
-          {{ 'library.bulk_edit' | translate }}
+          @if (sortOrder() === 'ASC') {
+            <svg lucideArrowUp class="h-4 w-4"></svg>
+          } @else {
+            <svg lucideArrowDown class="h-4 w-4"></svg>
+          }
+        </button>
+      </div>
+
+      <!-- Filter button + search input share an inline flex wrapper so they
+           wrap together to a new line on narrow viewports (rather than the
+           filter staying with the sort group while the search jumps below). -->
+      <div class="flex items-center gap-2 ml-auto flex-1 min-w-40 max-w-md">
+        <div class="relative flex-1">
+          <svg lucideSearch class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-base-content/40 pointer-events-none z-10"></svg>
+          <input
+            type="text"
+            [placeholder]="'common.search' | translate"
+            class="input input-bordered input-sm w-full pl-9"
+            [ngModel]="searchQuery()"
+            (ngModelChange)="onSearch($event)"
+          />
+        </div>
+        <app-dropdown-menu placement="bottom-end">
+          <button
+            trigger
+            type="button"
+            class="btn btn-sm btn-square btn-ghost relative"
+            [attr.aria-label]="'library.filter_button' | translate"
+          >
+            <svg lucideSlidersHorizontal class="h-5 w-5"></svg>
+            @if (hasActiveFilters()) {
+              <span class="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-primary"></span>
+            }
+          </button>
+
+          <div class="p-3 space-y-4 min-w-56">
+          <!-- Section: Surveillance -->
+          <div>
+            <h4 class="text-xs font-semibold uppercase tracking-wide text-base-content/50 mb-2">
+              {{ 'library.filter_monitoring_label' | translate }}
+            </h4>
+            <div class="space-y-1">
+              <label class="flex items-center gap-2 cursor-pointer py-1">
+                <input
+                  type="radio" name="library-filter-monitored"
+                  class="radio radio-sm radio-primary"
+                  [checked]="filterMonitored() === ''"
+                  (change)="filterMonitored.set(''); onFilterChange()"
+                />
+                <span class="text-sm">{{ 'library.filter_disabled' | translate }}</span>
+              </label>
+              <label class="flex items-center gap-2 cursor-pointer py-1">
+                <input
+                  type="radio" name="library-filter-monitored"
+                  class="radio radio-sm radio-primary"
+                  [checked]="filterMonitored() === 'true'"
+                  (change)="filterMonitored.set('true'); onFilterChange()"
+                />
+                <span class="text-sm">{{ 'library.filter_monitored' | translate }}</span>
+              </label>
+              <label class="flex items-center gap-2 cursor-pointer py-1">
+                <input
+                  type="radio" name="library-filter-monitored"
+                  class="radio radio-sm radio-primary"
+                  [checked]="filterMonitored() === 'false'"
+                  (change)="filterMonitored.set('false'); onFilterChange()"
+                />
+                <span class="text-sm">{{ 'library.filter_unmonitored' | translate }}</span>
+              </label>
+            </div>
+          </div>
+
+          <!-- Section: Statut -->
+          <div>
+            <h4 class="text-xs font-semibold uppercase tracking-wide text-base-content/50 mb-2">
+              {{ 'library.filter_status_label' | translate }}
+            </h4>
+            <div class="space-y-1">
+              <label class="flex items-center gap-2 cursor-pointer py-1">
+                <input
+                  type="radio" name="library-filter-status"
+                  class="radio radio-sm radio-primary"
+                  [checked]="filterStatus() === ''"
+                  (change)="filterStatus.set(''); onFilterChange()"
+                />
+                <span class="text-sm">{{ 'library.filter_disabled' | translate }}</span>
+              </label>
+              <label class="flex items-center gap-2 cursor-pointer py-1">
+                <input
+                  type="radio" name="library-filter-status"
+                  class="radio radio-sm radio-primary"
+                  [checked]="filterStatus() === 'downloaded'"
+                  (change)="filterStatus.set('downloaded'); onFilterChange()"
+                />
+                <span class="text-sm">{{ 'library.filter_downloaded' | translate }}</span>
+              </label>
+              <label class="flex items-center gap-2 cursor-pointer py-1">
+                <input
+                  type="radio" name="library-filter-status"
+                  class="radio radio-sm radio-primary"
+                  [checked]="filterStatus() === 'missing'"
+                  (change)="filterStatus.set('missing'); onFilterChange()"
+                />
+                <span class="text-sm">{{ 'library.filter_missing' | translate }}</span>
+              </label>
+              <label class="flex items-center gap-2 cursor-pointer py-1">
+                <input
+                  type="radio" name="library-filter-status"
+                  class="radio radio-sm radio-primary"
+                  [checked]="filterStatus() === 'cutoffUnmet'"
+                  (change)="filterStatus.set('cutoffUnmet'); onFilterChange()"
+                />
+                <span class="text-sm">{{ 'library.filter_cutoff_unmet' | translate }}</span>
+              </label>
+            </div>
+          </div>
+        </div>
+        </app-dropdown-menu>
+      </div>
+    </div>
+
+    @if (loading()) {
+      <div class="flex justify-center py-12">
+        <span class="loading loading-spinner loading-lg"></span>
+      </div>
+    } @else if (list.visible().length === 0) {
+      <div class="text-center py-12 text-base-content/50">
+        <p class="text-lg">{{ 'library.empty' | translate }}</p>
+        <p class="text-sm mt-2">{{ 'library.empty_hint' | translate }}</p>
+      </div>
+    } @else {
+      @if (bulkMode()) {
+        <div class="flex items-center gap-2 text-sm">
+          <button class="btn btn-xs btn-ghost" (click)="selectAll()">{{ 'library.bulk_select_all' | translate }}</button>
+          <button class="btn btn-xs btn-ghost" (click)="deselectAll()">{{ 'library.bulk_deselect' | translate }}</button>
+        </div>
+      }
+      <div class="flex gap-2 h-full">
+        <div class="flex-1 min-w-0 pr-2 lg:pr-4 grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-6 gap-1.5 sm:gap-4">
+          @for (item of list.visible(); track item.id) {
+            @if (bulkMode()) {
+              <div
+                class="relative cursor-pointer cv-auto"
+                [id]="'media-' + item.id"
+                (click)="toggleSelect(item.id)"
+              >
+                <input
+                  type="checkbox"
+                  class="checkbox checkbox-primary checkbox-sm absolute top-2 left-2 z-10"
+                  [checked]="selectedIds().has(item.id)"
+                  (click)="$event.stopPropagation()"
+                  (change)="toggleSelect(item.id)"
+                />
+                <app-media-card [media]="item" [status]="watchedIds().has(item.id) ? 'watched' : null" />
+              </div>
+            } @else {
+              <div [id]="'media-' + item.id" [attr.data-library-focus]="'media:' + item.id">
+                <app-media-card [media]="item" [status]="watchedIds().has(item.id) ? 'watched' : null" />
+              </div>
+            }
+          }
+        </div>
+
+        <!-- Alphabet sidebar — only meaningful when items are actually
+             ordered alphabetically (sort=title ASC). Any other sort
+             would make the letter jumps random, so we hide it.
+             Sticky at viewport mid: now that <main> uses `overflow-x:
+             clip` (instead of `hidden`), it's no longer a vertical scroll
+             container, so sticky's nearest scroll ancestor is the actual
+             page scroll. `self-start` keeps the nav at its content size
+             inside the flex parent so sticky has room to pin within the
+             column. -->
+        @if (sortBy() === 'title' && sortOrder() === 'ASC') {
+          <nav class="sticky top-[50vh] -translate-y-1/2 self-start z-20 flex flex-col items-center gap-0 select-none tv:pt-20">
+            @for (letter of alphabet; track letter) {
+              <button
+                type="button"
+                class="text-[10px] font-medium w-4 h-4 tv:h-3.5 flex items-center justify-center rounded transition-colors"
+                [class.bg-primary]="list.activeLetter() === letter"
+                [class.text-primary-content]="list.activeLetter() === letter"
+                [class.text-base-content/60]="list.activeLetter() !== letter && list.availableLetters().has(letter)"
+                [class.text-base-content/15]="!list.availableLetters().has(letter)"
+                [class.hover:bg-primary/20]="list.activeLetter() !== letter && list.availableLetters().has(letter)"
+                [disabled]="!list.availableLetters().has(letter)"
+                (click)="scrollToLetter(letter)"
+              >
+                {{ letter }}
+              </button>
+            }
+          </nav>
+        }
+      </div>
+
+      @if (list.hasMore()) {
+        <div #sentinel class="flex justify-center py-4">
+          <span class="loading loading-spinner loading-sm"></span>
+        </div>
+      }
+    }
+
+    @if (bulkMode() && selectedIds().size > 0) {
+      <div class="sticky bottom-0 z-20 bg-base-200 border-t border-base-300 px-4 py-3 flex flex-wrap items-center gap-3 shadow-lg rounded-t-lg">
+        <span class="font-semibold text-sm">{{ 'library.bulk_selected' | translate:{ count: selectedIds().size } }}</span>
+        <select
+          class="select select-bordered select-sm"
+          [ngModel]="bulkQualityProfileId()"
+          (ngModelChange)="bulkQualityProfileId.set($event)"
+        >
+          <option [ngValue]="null">{{ 'library.bulk_quality_profile' | translate }}</option>
+          @for (profile of qualityProfiles(); track profile.id) {
+            <option [ngValue]="profile.id">{{ profile.name }}</option>
+          }
+        </select>
+        <select
+          class="select select-bordered select-sm"
+          [ngModel]="bulkMonitored()"
+          (ngModelChange)="bulkMonitored.set($event)"
+        >
+          <option value="">{{ 'library.bulk_monitored' | translate }}</option>
+          <option value="true">{{ 'library.filter_monitored' | translate }}</option>
+          <option value="false">{{ 'library.filter_unmonitored' | translate }}</option>
+        </select>
+        <button class="btn btn-sm btn-primary" (click)="applyBulk()" [disabled]="bulkSaving()">
+          @if (bulkSaving()) {
+            <span class="loading loading-spinner loading-xs"></span>
+          }
+          {{ 'library.bulk_apply' | translate }}
+        </button>
+        <button class="btn btn-sm btn-ghost" (click)="toggleBulkMode()">
+          {{ 'library.bulk_cancel' | translate }}
         </button>
       </div>
     }
-  </div>
 
-  @if (loading()) {
-    <div class="flex justify-center py-12">
-      <span class="loading loading-spinner loading-lg"></span>
-    </div>
-  } @else if (list.visible().length === 0) {
-    <div class="text-center py-12 text-base-content/50">
-      <p class="text-lg">{{ 'library.empty' | translate }}</p>
-      <p class="text-sm mt-2">{{ 'library.empty_hint' | translate }}</p>
-    </div>
-  } @else {
-    @if (bulkMode()) {
-      <div class="flex items-center gap-2 text-sm">
-        <button class="btn btn-xs btn-ghost" (click)="selectAll()">{{ 'library.bulk_select_all' | translate }}</button>
-        <button class="btn btn-xs btn-ghost" (click)="deselectAll()">{{ 'library.bulk_deselect' | translate }}</button>
-      </div>
-    }
-    <div class="flex gap-2">
-      <div class="flex-1 min-w-0 pr-2 lg:pr-4 grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-6 gap-1.5 sm:gap-4">
-        @for (item of list.visible(); track item.id) {
-          @if (bulkMode()) {
-            <div
-              class="relative cursor-pointer cv-auto"
-              [id]="'media-' + item.id"
-              (click)="toggleSelect(item.id)"
-            >
-              <input
-                type="checkbox"
-                class="checkbox checkbox-primary checkbox-sm absolute top-2 left-2 z-10"
-                [checked]="selectedIds().has(item.id)"
-                (click)="$event.stopPropagation()"
-                (change)="toggleSelect(item.id)"
-              />
-              <app-media-card [media]="item" [status]="watchedIds().has(item.id) ? 'watched' : null" />
-            </div>
-          } @else {
-            <div [id]="'media-' + item.id" [attr.data-library-focus]="'media:' + item.id">
-              <app-media-card [media]="item" [status]="watchedIds().has(item.id) ? 'watched' : null" />
-            </div>
+    @if (list.visible().length > 0) {
+      <div class="flex flex-wrap items-start justify-between gap-6 mt-6 px-2 py-3 border-t border-base-200 text-sm text-base-content/70">
+        <div class="flex flex-col gap-1">
+          <div class="flex items-center gap-2"><span class="w-3 h-3 rounded-sm bg-green-500"></span> {{ 'legend.downloaded_monitored' | translate }}</div>
+          <div class="flex items-center gap-2"><span class="w-3 h-3 rounded-sm bg-green-800"></span> {{ 'legend.downloaded_unmonitored' | translate }}</div>
+          <div class="flex items-center gap-2"><span class="w-3 h-3 rounded-sm bg-red-500"></span> {{ 'legend.missing_monitored' | translate }}</div>
+          <div class="flex items-center gap-2"><span class="w-3 h-3 rounded-sm bg-amber-500"></span> {{ 'legend.missing_unmonitored' | translate }}</div>
+          <div class="flex items-center gap-2"><span class="w-3 h-3 rounded-sm bg-blue-400"></span> {{ 'legend.unreleased' | translate }}</div>
+        </div>
+        <div class="flex flex-wrap gap-x-8 gap-y-1">
+          <div><span class="font-semibold">{{ 'legend.total' | translate }}</span> {{ list.total() }}</div>
+          @if (hasMovies()) {
+            <div><span class="font-semibold">{{ 'legend.movie_files' | translate }}</span> {{ movieFileCount() }}</div>
           }
-        }
-      </div>
-
-      <!-- Alphabet sidebar — sticky at viewport mid. Now that <main> uses
-           `overflow-x: clip` (instead of `hidden`), it's no longer a
-           vertical scroll container, so sticky's nearest scroll ancestor
-           is the actual page scroll. `self-start` keeps the nav at its
-           content size inside the flex parent so sticky has room to pin
-           within the column. -->
-      <nav class="sticky top-[50vh] -translate-y-1/2 self-start z-20 flex flex-col items-center gap-0 select-none tv:pt-20">
-        @for (letter of alphabet; track letter) {
-          <button
-            type="button"
-            class="text-[10px] font-medium w-4 h-4 tv:h-3.5 flex items-center justify-center rounded transition-colors"
-            [class.bg-primary]="list.activeLetter() === letter"
-            [class.text-primary-content]="list.activeLetter() === letter"
-            [class.text-base-content/60]="list.activeLetter() !== letter && list.availableLetters().has(letter)"
-            [class.text-base-content/15]="!list.availableLetters().has(letter)"
-            [class.hover:bg-primary/20]="list.activeLetter() !== letter && list.availableLetters().has(letter)"
-            [disabled]="!list.availableLetters().has(letter)"
-            (click)="scrollToLetter(letter)"
-          >
-            {{ letter }}
-          </button>
-        }
-      </nav>
-    </div>
-
-    @if (list.hasMore()) {
-      <div #sentinel class="flex justify-center py-4">
-        <span class="loading loading-spinner loading-sm"></span>
+          @if (hasSeries()) {
+            <div><span class="font-semibold">{{ 'legend.episodes' | translate }}</span> {{ downloadedEpisodes() }} / {{ totalEpisodes() }}</div>
+          }
+          <div><span class="font-semibold">{{ 'legend.monitored' | translate }}</span> {{ monitoredCount() }}</div>
+          <div><span class="font-semibold">{{ 'legend.unmonitored' | translate }}</span> {{ list.total() - monitoredCount() }}</div>
+        </div>
       </div>
     }
-  }
-
-  @if (bulkMode() && selectedIds().size > 0) {
-    <div class="sticky bottom-0 z-20 bg-base-200 border-t border-base-300 px-4 py-3 flex flex-wrap items-center gap-3 shadow-lg rounded-t-lg">
-      <span class="font-semibold text-sm">{{ 'library.bulk_selected' | translate:{ count: selectedIds().size } }}</span>
-      <select
-        class="select select-bordered select-sm"
-        [ngModel]="bulkQualityProfileId()"
-        (ngModelChange)="bulkQualityProfileId.set($event)"
-      >
-        <option [ngValue]="null">{{ 'library.bulk_quality_profile' | translate }}</option>
-        @for (profile of qualityProfiles(); track profile.id) {
-          <option [ngValue]="profile.id">{{ profile.name }}</option>
-        }
-      </select>
-      <select
-        class="select select-bordered select-sm"
-        [ngModel]="bulkMonitored()"
-        (ngModelChange)="bulkMonitored.set($event)"
-      >
-        <option value="">{{ 'library.bulk_monitored' | translate }}</option>
-        <option value="true">{{ 'library.filter_monitored' | translate }}</option>
-        <option value="false">{{ 'library.filter_unmonitored' | translate }}</option>
-      </select>
-      <button class="btn btn-sm btn-primary" (click)="applyBulk()" [disabled]="bulkSaving()">
-        @if (bulkSaving()) {
-          <span class="loading loading-spinner loading-xs"></span>
-        }
-        {{ 'library.bulk_apply' | translate }}
-      </button>
-      <button class="btn btn-sm btn-ghost" (click)="toggleBulkMode()">
-        {{ 'library.bulk_cancel' | translate }}
-      </button>
-    </div>
-  }
-
-  @if (list.visible().length > 0) {
-    <div class="flex flex-wrap items-start justify-between gap-6 mt-6 px-2 py-3 border-t border-base-200 text-sm text-base-content/70">
-      <div class="flex flex-col gap-1">
-        <div class="flex items-center gap-2"><span class="w-3 h-3 rounded-sm bg-green-500"></span> {{ 'legend.downloaded_monitored' | translate }}</div>
-        <div class="flex items-center gap-2"><span class="w-3 h-3 rounded-sm bg-green-800"></span> {{ 'legend.downloaded_unmonitored' | translate }}</div>
-        <div class="flex items-center gap-2"><span class="w-3 h-3 rounded-sm bg-red-500"></span> {{ 'legend.missing_monitored' | translate }}</div>
-        <div class="flex items-center gap-2"><span class="w-3 h-3 rounded-sm bg-amber-500"></span> {{ 'legend.missing_unmonitored' | translate }}</div>
-        <div class="flex items-center gap-2"><span class="w-3 h-3 rounded-sm bg-blue-400"></span> {{ 'legend.unreleased' | translate }}</div>
-      </div>
-      <div class="flex flex-wrap gap-x-8 gap-y-1">
-        <div><span class="font-semibold">{{ 'legend.total' | translate }}</span> {{ list.total() }}</div>
-        @if (hasMovies()) {
-          <div><span class="font-semibold">{{ 'legend.movie_files' | translate }}</span> {{ movieFileCount() }}</div>
-        }
-        @if (hasSeries()) {
-          <div><span class="font-semibold">{{ 'legend.episodes' | translate }}</span> {{ downloadedEpisodes() }} / {{ totalEpisodes() }}</div>
-        }
-        <div><span class="font-semibold">{{ 'legend.monitored' | translate }}</span> {{ monitoredCount() }}</div>
-        <div><span class="font-semibold">{{ 'legend.unmonitored' | translate }}</span> {{ list.total() - monitoredCount() }}</div>
-      </div>
+  } @else {
+    <!-- Placeholders for upcoming views -->
+    <div class="text-center py-24 text-base-content/50">
+      <p class="text-lg">{{ 'library.coming_soon' | translate }}</p>
     </div>
   }
 </div>

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -21,19 +21,46 @@ import { StreamingApiService } from '../../core/services/api/streaming-api.servi
 import { ProfilesService, QualityProfile } from '../../core/services/api/profiles.service';
 import { LibrariesApiService, LibrarySummary } from '../../core/services/api/libraries-api.service';
 import { MediaCardComponent } from '../../shared/components/media-card/media-card';
+import { DropdownMenuComponent } from '../../shared/components/dropdown-menu';
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
 import { FocusMemoryService } from '../../core/services/focus-memory.service';
 import { NavbarService } from '../../core/services/navbar.service';
 import { TvService } from '../../core/services/tv.service';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
 import { InfiniteScrollList } from '../../shared/utils/infinite-scroll-list';
-import { LucideSearch, LucideSlidersHorizontal } from '@lucide/angular';
+import { LucideSearch, LucideSlidersHorizontal, LucideArrowUp, LucideArrowDown } from '@lucide/angular';
 
 const ALPHABET = '#ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
+/** Top-bar tab — `all` is the existing library grid (label = library name),
+ *  `suggestions` / `genres` are placeholders for upcoming views. */
+export type LibraryViewMode = 'all' | 'suggestions' | 'genres';
+export type SortOrder = 'ASC' | 'DESC';
+type FilterMonitored = '' | 'true' | 'false';
+
+/** Natural default order per sort field. Title reads A→Z; the three
+ *  date / rating fields lead with the most recent / best value because
+ *  that's what users actually want to see first. Applied whenever the
+ *  user switches `sortBy` — they can still flip with the ↑/↓ button. */
+const NATURAL_ORDER_BY_SORT: Record<string, SortOrder> = {
+  title: 'ASC',
+  year: 'DESC',
+  added: 'DESC',
+  rating: 'DESC',
+};
+
 @Component({
   selector: 'app-library',
-  imports: [MediaCardComponent, FormsModule, TranslateModule, LucideSearch, LucideSlidersHorizontal],
+  imports: [
+    MediaCardComponent,
+    DropdownMenuComponent,
+    FormsModule,
+    TranslateModule,
+    LucideSearch,
+    LucideSlidersHorizontal,
+    LucideArrowUp,
+    LucideArrowDown,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './library.html',
 })
@@ -65,8 +92,10 @@ export class LibraryComponent implements OnInit, OnDestroy {
   readonly loading = signal(false);
   readonly searchQuery = signal('');
   readonly sortBy = signal('title');
-  readonly filterMonitored = signal<'' | 'true' | 'false'>('');
+  readonly sortOrder = signal<SortOrder>('ASC');
+  readonly filterMonitored = signal<FilterMonitored>('');
   readonly filterStatus = signal('');
+  readonly viewMode = signal<LibraryViewMode>('all');
 
   readonly monitoredCount = computed(() => this.list.all().filter((m) => m.monitored).length);
   readonly movieFileCount = computed(() =>
@@ -88,9 +117,8 @@ export class LibraryComponent implements OnInit, OnDestroy {
   readonly hasSeries = computed(() => this.totalSeries() > 0);
 
   readonly alphabet = ALPHABET;
-  readonly filtersOpen = signal(false);
   readonly hasActiveFilters = computed(() =>
-    this.filterMonitored() !== '' || this.filterStatus() !== '' || this.sortBy() !== 'title',
+    this.filterMonitored() !== '' || this.filterStatus() !== '',
   );
 
   @ViewChild('sentinel') set sentinelRef(ref: ElementRef<HTMLElement> | undefined) {
@@ -102,7 +130,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   readonly bulkMode = signal(false);
   readonly bulkSaving = signal(false);
   readonly bulkQualityProfileId = signal<number | null>(null);
-  readonly bulkMonitored = signal<'' | 'true' | 'false'>('');
+  readonly bulkMonitored = signal<FilterMonitored>('');
   readonly qualityProfiles = signal<QualityProfile[]>([]);
 
   private allLibraries: LibrarySummary[] = [];
@@ -163,10 +191,16 @@ export class LibraryComponent implements OnInit, OnDestroy {
       const stored = this.loadFilters(lib.name);
       this.searchQuery.set(qp.get('q') ?? stored['q'] ?? '');
       this.filterMonitored.set(
-        (qp.get('monitored') ?? stored['monitored'] ?? '') as '' | 'true' | 'false',
+        (qp.get('monitored') ?? stored['monitored'] ?? '') as FilterMonitored,
       );
       this.filterStatus.set(qp.get('status') ?? stored['status'] ?? '');
       this.sortBy.set(qp.get('sortBy') ?? stored['sortBy'] ?? 'title');
+      this.sortOrder.set(
+        (qp.get('sortOrder') ?? stored['sortOrder'] ?? 'ASC') as SortOrder,
+      );
+      this.viewMode.set(
+        (qp.get('view') ?? stored['view'] ?? 'all') as LibraryViewMode,
+      );
 
       this.scrollMemory.activate(scrollKey);
       this.list.trackScroll('media');
@@ -251,6 +285,25 @@ export class LibraryComponent implements OnInit, OnDestroy {
     this.load(this.library()?.id);
   }
 
+  toggleSortOrder() {
+    this.sortOrder.update((o) => (o === 'ASC' ? 'DESC' : 'ASC'));
+    this.onFilterChange();
+  }
+
+  onSortByChange(field: string) {
+    this.sortBy.set(field);
+    // Snap to the field's natural order so the leading items are the
+    // ones the user typically wants (newest / best first). The arrow
+    // button still lets them flip after the fact.
+    this.sortOrder.set(NATURAL_ORDER_BY_SORT[field] ?? 'ASC');
+    this.onFilterChange();
+  }
+
+  setViewMode(mode: LibraryViewMode) {
+    this.viewMode.set(mode);
+    this.syncQueryParams();
+  }
+
   toggleSelect(id: number) {
     this.selectedIds.update((set) => {
       const next = new Set(set);
@@ -312,6 +365,8 @@ export class LibraryComponent implements OnInit, OnDestroy {
     if (this.filterMonitored()) params['monitored'] = this.filterMonitored();
     if (this.filterStatus()) params['status'] = this.filterStatus();
     if (this.sortBy() !== 'title') params['sortBy'] = this.sortBy();
+    if (this.sortOrder() !== 'ASC') params['sortOrder'] = this.sortOrder();
+    if (this.viewMode() !== 'all') params['view'] = this.viewMode();
     void this.router.navigate([], { queryParams: params, replaceUrl: true });
     this.saveFilters();
   }
@@ -326,6 +381,8 @@ export class LibraryComponent implements OnInit, OnDestroy {
     if (this.filterMonitored()) data['monitored'] = this.filterMonitored();
     if (this.filterStatus()) data['status'] = this.filterStatus();
     if (this.sortBy() !== 'title') data['sortBy'] = this.sortBy();
+    if (this.sortOrder() !== 'ASC') data['sortOrder'] = this.sortOrder();
+    if (this.viewMode() !== 'all') data['view'] = this.viewMode();
     localStorage.setItem(this.storageKey, JSON.stringify(data));
   }
 
@@ -348,6 +405,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
           libraryId,
           q: this.searchQuery() || undefined,
           sortBy: this.sortBy(),
+          sortOrder: this.sortOrder(),
           monitored: monitored ? monitored === 'true' : undefined,
           missing: fs === 'missing' ? true : fs === 'downloaded' ? false : undefined,
           cutoffUnmet: fs === 'cutoffUnmet' ? true : undefined,


### PR DESCRIPTION
## Summary
- Library page opens with a title row + a tab row (active = library name, plus \`Suggestions\` / \`Genres\` placeholders for upcoming views — they show a \"Bientôt disponible\" message).
- New toolbar: element count, sort field dropdown (Titre / Date de sortie / Date d'ajout / Note TMDB), separate ↑/↓ button to flip the order, filters dropdown, and search input.
- Filters dropdown uses the shared \`app-dropdown-menu\` (form-factor-aware: DaisyUI dropdown on desktop, bottom-sheet on mobile / TV). Sections per filter — Surveillance + Statut, each with radios.
- Switching \`sortBy\` snaps \`sortOrder\` to the field's natural lead: title → ASC, year / added / rating → DESC. The arrow button still flips after.
- Alphabet sidebar only renders when sort is title + ASC; other sorts hide it (and the toolbar gets \`pr-6\` then, so the search input never extends into the sticky alphabet column when it passes through it on scroll).
- Filter button + search share an inner flex wrapper so they wrap together on narrow viewports (no more lonely search line below the toolbar).
- Backend \`MediaService.findAll\` now whitelists \`sortBy\` and maps UI aliases (\`added\` → \`media.createdAt\`). Closes the ORDER BY injection vector that previously concatenated the raw param into SQL, and fixes the \`column media.added does not exist\` crash that the new sort field hit.
- Bulk-edit button removed; the underlying logic (selection, sticky panel, profile dropdown) is intact and reachable when we re-introduce the entry point.

## Test plan
- [x] \`npx tsc --noEmit\` clean (backend) + \`ng build\` clean (client)
- [ ] Library page: title + tabs row visible; tab pill highlights with \`bg-base-300\` when active
- [ ] Switching to \`Suggestions\` / \`Genres\` shows the placeholder
- [ ] Sort dropdown changes apply immediately and snap to the natural order per field
- [ ] ↑/↓ button flips order; alphabet sidebar appears only on \`title + ASC\`
- [ ] Filter dropdown opens as a popover on desktop and a bottom-sheet on mobile
- [ ] Backend no longer crashes on \`sortBy=added\` (was \`column media.added does not exist\`)
- [ ] Search bar wraps on narrow screens with the filter button next to it (not separated)