### PR TITLE
feat(library): Suggestions tab — continue-watching + history-based recommendations

### DIFF
--- a/backend/src/modules/libraries/libraries.service.ts
+++ b/backend/src/modules/libraries/libraries.service.ts
@@ -145,13 +145,17 @@ export class LibrariesService implements OnModuleInit {
   // ---------------------------------------------------------------------------
 
   /**
-   * Returns the list of library IDs the user can read.
-   *  - `null` means "no filter" — admins or users with `manage:all`.
-   *  - `[]` means "user has no library access" — caller should return empty.
-   *  - non-empty array — apply `WHERE libraryId IN (…)`.
+   * Returns the list of library IDs the user can read. Always concrete —
+   * admins / `manage:all` get every existing library ID (resolved at call
+   * time, so libraries added after login show up immediately). `[]` means
+   * the user has no library access at all and the caller should return
+   * empty without further work.
    */
-  async getAccessibleLibraryIds(user: User): Promise<number[] | null> {
-    if (user.isAdmin || user.permissions.includes('manage:all')) return null;
+  async getAccessibleLibraryIds(user: User): Promise<number[]> {
+    if (user.isAdmin || user.permissions.includes('manage:all')) {
+      const rows = await this.repo.find({ select: ['id'] });
+      return rows.map((r) => r.id);
+    }
     // libraryId is @RelationId — TypeORM auto-populates it without loading the
     // related Library entity.
     const rows = await this.accessRepo.find({

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -388,7 +388,7 @@ export class MediaService {
   }
 
   async getCounts(
-    accessibleLibraryIds?: number[] | null,
+    accessibleLibraryIds: number[],
   ): Promise<{ movies: number; series: number }> {
     const buildQb = (type: MediaType) => {
       const qb = this.mediaRepo
@@ -405,7 +405,7 @@ export class MediaService {
   }
 
   async getCountsByLibrary(
-    accessibleLibraryIds: number[] | null,
+    accessibleLibraryIds: number[],
   ): Promise<Record<number, number>> {
     const qb = this.mediaRepo
       .createQueryBuilder('m')
@@ -421,7 +421,7 @@ export class MediaService {
   async findAll(
     query: SearchMediaDto,
     userId?: number,
-    accessibleLibraryIds?: number[] | null,
+    accessibleLibraryIds: number[] = [],
   ): Promise<{ data: Media[]; total: number }> {
     const page = query.page ?? 1;
     const limit = query.limit ?? 25;
@@ -614,14 +614,18 @@ export class MediaService {
     return { data: enriched, total };
   }
 
+  /** When `accessibleLibraryIds` is omitted the lookup is unscoped — used
+   *  by internal callers (admin approve path, schedulers) that have
+   *  already validated access. Controllers must pass the user's library
+   *  set so the result respects the ACL. */
   async findByTmdbId(
     tmdbId: number,
     type: MediaType,
-    accessibleLibraryIds?: number[] | null,
+    accessibleLibraryIds?: number[],
   ): Promise<Media | null> {
     const m = await this.mediaRepo.findOne({ where: { tmdbId, type } });
     if (!m) return null;
-    if (accessibleLibraryIds !== undefined && accessibleLibraryIds !== null) {
+    if (accessibleLibraryIds) {
       if (m.libraryId == null || !accessibleLibraryIds.includes(m.libraryId)) {
         return null;
       }
@@ -632,13 +636,11 @@ export class MediaService {
   /**
    * Throws NotFoundException when the media exists but is outside the user's
    * accessible libraries — same shape as "not found" so we don't leak existence.
-   * Pass `null` to skip the check (admins / internal callers).
    */
   async assertAccessible(
     mediaId: number,
-    accessibleLibraryIds: number[] | null,
+    accessibleLibraryIds: number[],
   ): Promise<void> {
-    if (accessibleLibraryIds === null) return;
     // `libraryId` is a @RelationId virtual — TypeORM's findOne + select
     // can't project it. Use a raw query on the join column instead.
     const row = await this.mediaRepo
@@ -672,15 +674,16 @@ export class MediaService {
     return e.season.mediaId;
   }
 
-  /** Adds `WHERE <alias>.libraryId IN (...)` when ACL is in effect. Uses the
-   *  query builder's own alias so it works whether the caller aliased the
-   *  media table as "media" (default) or "m" (findAll / counts queries). */
+  /** Adds `WHERE <alias>.libraryId IN (...)` to scope a query to the
+   *  caller's accessible libraries. Uses the query builder's own alias
+   *  so it works whether the caller aliased the media table as "media"
+   *  (default) or "m" (findAll / counts queries). An empty array short-
+   *  circuits to `1 = 0` so the caller still hits a real WHERE and
+   *  returns no rows. */
   private applyLibraryAcl(
     qb: SelectQueryBuilder<Media>,
-    accessibleLibraryIds: number[] | null | undefined,
+    accessibleLibraryIds: number[],
   ): void {
-    if (accessibleLibraryIds === undefined || accessibleLibraryIds === null)
-      return;
     if (accessibleLibraryIds.length === 0) {
       qb.andWhere('1 = 0');
       return;
@@ -879,7 +882,7 @@ export class MediaService {
 
   async getCalendar(
     dto: CalendarQueryDto,
-    accessibleLibraryIds?: number[] | null,
+    accessibleLibraryIds: number[],
     userId?: number,
   ) {
     // TypeORM may return PostgreSQL `date` columns as Date objects.
@@ -954,14 +957,12 @@ export class MediaService {
       if (dto.requestedByMe && userId) {
         moviesQb.andWhere('m."addedById" = :calUserId', { calUserId: userId });
       }
-      if (accessibleLibraryIds !== undefined && accessibleLibraryIds !== null) {
-        if (accessibleLibraryIds.length === 0) {
-          moviesQb.andWhere('1 = 0');
-        } else {
-          moviesQb.andWhere('m.libraryId IN (:...accessibleLibraryIds)', {
-            accessibleLibraryIds,
-          });
-        }
+      if (accessibleLibraryIds.length === 0) {
+        moviesQb.andWhere('1 = 0');
+      } else {
+        moviesQb.andWhere('m.libraryId IN (:...accessibleLibraryIds)', {
+          accessibleLibraryIds,
+        });
       }
       const movies = await moviesQb.getMany();
 
@@ -1022,14 +1023,12 @@ export class MediaService {
       if (dto.requestedByMe && userId) {
         epQb.andWhere('media."addedById" = :calUserId', { calUserId: userId });
       }
-      if (accessibleLibraryIds !== undefined && accessibleLibraryIds !== null) {
-        if (accessibleLibraryIds.length === 0) {
-          epQb.andWhere('1 = 0');
-        } else {
-          epQb.andWhere('media.libraryId IN (:...accessibleLibraryIds)', {
-            accessibleLibraryIds,
-          });
-        }
+      if (accessibleLibraryIds.length === 0) {
+        epQb.andWhere('1 = 0');
+      } else {
+        epQb.andWhere('media.libraryId IN (:...accessibleLibraryIds)', {
+          accessibleLibraryIds,
+        });
       }
       const episodes = await epQb.getMany();
 

--- a/backend/src/modules/streaming/playback.controller.ts
+++ b/backend/src/modules/streaming/playback.controller.ts
@@ -30,10 +30,27 @@ export class PlaybackController {
   ) {}
 
   @Get('recommendations')
-  async recommendations(@Req() req: Request) {
+  async recommendations(
+    @Req() req: Request,
+    @Query('libraryId') libraryIdRaw?: string,
+    @Query('limit') limitRaw?: string,
+  ) {
     const user = req.user as User;
-    const libraryIds = await this.libraries.getAccessibleLibraryIds(user);
-    return this.recommendationService.getRecommendations(user.id, libraryIds);
+    const accessible = await this.libraries.getAccessibleLibraryIds(user);
+    // Scope to a single library when requested, but only if it's in the
+    // user's accessible set — silent intersection (empty result) rather
+    // than a 403, to keep the page renderable.
+    let libraryIds = accessible;
+    const libraryId = libraryIdRaw ? parseInt(libraryIdRaw, 10) : null;
+    if (libraryId && Number.isFinite(libraryId)) {
+      libraryIds = accessible.includes(libraryId) ? [libraryId] : [];
+    }
+    const limit = limitRaw ? Math.min(50, Math.max(1, parseInt(limitRaw, 10) || 15)) : undefined;
+    return this.recommendationService.getRecommendations(
+      user.id,
+      libraryIds,
+      limit,
+    );
   }
 
   /** Persist a "remove from recommendations" gesture. Idempotent. */
@@ -67,9 +84,17 @@ export class PlaybackController {
   }
 
   @Get('continue-watching')
-  async continueWatching(@Req() req: Request) {
+  async continueWatching(
+    @Req() req: Request,
+    @Query('libraryId') libraryIdRaw?: string,
+  ) {
     const user = req.user as User;
-    const libraryIds = await this.libraries.getAccessibleLibraryIds(user);
+    const accessible = await this.libraries.getAccessibleLibraryIds(user);
+    let libraryIds = accessible;
+    const libraryId = libraryIdRaw ? parseInt(libraryIdRaw, 10) : null;
+    if (libraryId && Number.isFinite(libraryId)) {
+      libraryIds = accessible.includes(libraryId) ? [libraryId] : [];
+    }
     return this.playbackService.getContinueWatching(user.id, libraryIds);
   }
 

--- a/backend/src/modules/streaming/playback.service.ts
+++ b/backend/src/modules/streaming/playback.service.ts
@@ -317,23 +317,11 @@ export class PlaybackService implements OnModuleInit {
 
   async getContinueWatching(
     userId: number,
-    accessibleLibraryIds?: number[] | null,
+    accessibleLibraryIds: number[],
   ): Promise<ContinueWatchingItem[]> {
-    if (
-      accessibleLibraryIds !== undefined &&
-      accessibleLibraryIds !== null &&
-      accessibleLibraryIds.length === 0
-    ) {
-      return [];
-    }
-    const libFilter =
-      accessibleLibraryIds === undefined || accessibleLibraryIds === null
-        ? ''
-        : ` AND m."libraryId" = ANY($2)`;
-    const params: unknown[] =
-      accessibleLibraryIds === undefined || accessibleLibraryIds === null
-        ? [userId]
-        : [userId, accessibleLibraryIds];
+    if (accessibleLibraryIds.length === 0) return [];
+    const libFilter = ` AND m."libraryId" = ANY($2)`;
+    const params: unknown[] = [userId, accessibleLibraryIds];
     // 1. Movies: in-progress, one per media (guaranteed unique by new schema)
     const movies: ContinueWatchingItem[] = await this.repo.query(
       `SELECT
@@ -470,24 +458,17 @@ export class PlaybackService implements OnModuleInit {
     userId: number,
     page: number,
     limit: number,
-    accessibleLibraryIds?: number[] | null,
+    accessibleLibraryIds: number[],
   ): Promise<{ data: WatchHistoryItem[]; total: number }> {
-    if (
-      accessibleLibraryIds !== undefined &&
-      accessibleLibraryIds !== null &&
-      accessibleLibraryIds.length === 0
-    ) {
-      return { data: [], total: 0 };
-    }
-    const useAcl =
-      accessibleLibraryIds !== undefined && accessibleLibraryIds !== null;
+    if (accessibleLibraryIds.length === 0) return { data: [], total: 0 };
 
     // No dedup needed — one state per (mediaId, episodeId) by design
     const countResult = await this.repo.query(
       `SELECT COUNT(*) AS cnt
        FROM playback_states ps
-       WHERE ps."userId" = $1 AND ps."playedAt" IS NOT NULL${useAcl ? ` AND EXISTS (SELECT 1 FROM media mAcl WHERE mAcl.id = ps."mediaId" AND mAcl."libraryId" = ANY($2))` : ''}`,
-      useAcl ? [userId, accessibleLibraryIds] : [userId],
+       WHERE ps."userId" = $1 AND ps."playedAt" IS NOT NULL
+         AND EXISTS (SELECT 1 FROM media mAcl WHERE mAcl.id = ps."mediaId" AND mAcl."libraryId" = ANY($2))`,
+      [userId, accessibleLibraryIds],
     );
     const total = Number(countResult[0]?.cnt ?? 0);
 
@@ -509,12 +490,11 @@ export class PlaybackService implements OnModuleInit {
        JOIN media m ON m.id = ps."mediaId"
        LEFT JOIN episodes e ON e.id = ps."episodeId"
        LEFT JOIN seasons s ON s.id = e."seasonId"
-       WHERE ps."userId" = $1 AND ps."playedAt" IS NOT NULL${useAcl ? ` AND m."libraryId" = ANY($4)` : ''}
+       WHERE ps."userId" = $1 AND ps."playedAt" IS NOT NULL
+         AND m."libraryId" = ANY($4)
        ORDER BY ps."playedAt" DESC
        LIMIT $2 OFFSET $3`,
-      useAcl
-        ? [userId, limit, (page - 1) * limit, accessibleLibraryIds]
-        : [userId, limit, (page - 1) * limit],
+      [userId, limit, (page - 1) * limit, accessibleLibraryIds],
     );
 
     for (const item of data) {
@@ -535,31 +515,17 @@ export class PlaybackService implements OnModuleInit {
 
   async getWatchedMediaIds(
     userId: number,
-    accessibleLibraryIds?: number[] | null,
+    accessibleLibraryIds: number[],
   ): Promise<number[]> {
-    if (
-      accessibleLibraryIds !== undefined &&
-      accessibleLibraryIds !== null &&
-      accessibleLibraryIds.length === 0
-    ) {
-      return [];
-    }
-    const useAcl =
-      accessibleLibraryIds !== undefined && accessibleLibraryIds !== null;
-    const movieFilter = useAcl ? ` AND m."libraryId" = ANY($2)` : '';
-    const seriesFilter = useAcl
-      ? ` AND EXISTS (SELECT 1 FROM media m2 WHERE m2.id = s."mediaId" AND m2."libraryId" = ANY($2))`
-      : '';
-    const params: unknown[] = useAcl
-      ? [userId, accessibleLibraryIds]
-      : [userId];
+    if (accessibleLibraryIds.length === 0) return [];
 
     const rows: { id: number }[] = await this.repo.query(
       `
       SELECT DISTINCT ps."mediaId" AS id
       FROM playback_states ps
       JOIN media m ON m.id = ps."mediaId"
-      WHERE ps."userId" = $1 AND ps.completed = true AND m.type = 'movie'${movieFilter}
+      WHERE ps."userId" = $1 AND ps.completed = true AND m.type = 'movie'
+        AND m."libraryId" = ANY($2)
 
       UNION
 
@@ -568,11 +534,12 @@ export class PlaybackService implements OnModuleInit {
       JOIN episodes e ON e."seasonId" = s.id
       LEFT JOIN playback_states ps
         ON ps."userId" = $1 AND ps."episodeId" = e.id AND ps.completed = true
-      WHERE s."seasonNumber" > 0 AND e."hasFile" = true${seriesFilter}
+      WHERE s."seasonNumber" > 0 AND e."hasFile" = true
+        AND EXISTS (SELECT 1 FROM media m2 WHERE m2.id = s."mediaId" AND m2."libraryId" = ANY($2))
       GROUP BY s."mediaId"
       HAVING COUNT(*) > 0 AND COUNT(*) = COUNT(ps.id)
       `,
-      params,
+      [userId, accessibleLibraryIds],
     );
     return rows.map((r) => r.id);
   }

--- a/backend/src/modules/streaming/recommendation.service.ts
+++ b/backend/src/modules/streaming/recommendation.service.ts
@@ -49,7 +49,7 @@
  *   not full series completion.
  */
 
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Media } from '../media/entities/media.entity';
@@ -110,8 +110,13 @@ export class RecommendationService {
 
   async getRecommendations(
     userId: number,
-    accessibleLibraryIds?: number[] | null,
+    accessibleLibraryIds: number[],
+    /** Override the default 15-item cap. Capped server-side at 50 by
+     *  the controller, so this only widens — passing larger values has
+     *  no effect once the cap is hit. */
+    limit?: number,
   ): Promise<RecommendationItem[]> {
+    if (accessibleLibraryIds.length === 0) return [];
     // 1. Recently completed media
     const recentStates = await this.playbackRepo.find({
       where: { user: { id: userId }, completed: true },
@@ -180,12 +185,7 @@ export class RecommendationService {
       });
     }
 
-    if (accessibleLibraryIds !== undefined && accessibleLibraryIds !== null) {
-      if (accessibleLibraryIds.length === 0) return [];
-      qb.andWhere('m."libraryId" IN (:...libs)', {
-        libs: accessibleLibraryIds,
-      });
-    }
+    qb.andWhere('m."libraryId" IN (:...libs)', { libs: accessibleLibraryIds });
 
     const candidates = await qb.getMany();
 
@@ -227,8 +227,10 @@ export class RecommendationService {
     // type when both exist in the candidate pool. If only one type has
     // recommendations, the cap is lifted in the fill pass so we don't
     // return fewer than 15 items just to enforce diversity.
-    const PER_TYPE_CAP = 10;
-    const TOTAL = 15;
+    const TOTAL = limit ?? 15;
+    // Keep the per-type cap proportional so a wider window still
+    // guarantees a real mix between movies + series.
+    const PER_TYPE_CAP = Math.max(10, Math.ceil(TOTAL * 0.7));
     const top: typeof scored = [];
     const overflow: typeof scored = [];
     const perType: Record<string, number> = {};

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -482,7 +482,9 @@
     "filter_disabled": "Désactivé",
     "filter_monitoring_label": "Surveillance",
     "filter_status_label": "Statut",
-    "coming_soon": "Bientôt disponible"
+    "coming_soon": "Bientôt disponible",
+    "suggestions_empty": "Pas encore de suggestions",
+    "suggestions_empty_hint": "Regardez quelques films / séries pour alimenter les recommandations basées sur votre historique."
   },
   "movies": {
     "title": "Films"

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -349,15 +349,27 @@ export class StreamingApiService {
     );
   }
 
-  getContinueWatching() {
+  getContinueWatching(libraryId?: number) {
+    const params = libraryId
+      ? { params: { libraryId: String(libraryId) } }
+      : {};
     return firstValueFrom(
-      this.http.get<ContinueWatchingItem[]>('/api/playback/continue-watching'),
+      this.http.get<ContinueWatchingItem[]>(
+        '/api/playback/continue-watching',
+        params,
+      ),
     );
   }
 
-  getRecommendations() {
+  getRecommendations(opts: { libraryId?: number; limit?: number } = {}) {
+    const params: Record<string, string> = {};
+    if (opts.libraryId) params['libraryId'] = String(opts.libraryId);
+    if (opts.limit) params['limit'] = String(opts.limit);
     return firstValueFrom(
-      this.http.get<RecommendationItem[]>('/api/playback/recommendations'),
+      this.http.get<RecommendationItem[]>(
+        '/api/playback/recommendations',
+        Object.keys(params).length ? { params } : {},
+      ),
     );
   }
 

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -323,8 +323,54 @@
         </div>
       </div>
     }
+  } @else if (viewMode() === 'suggestions') {
+    @if (suggestionsLoading()) {
+      <div class="flex justify-center py-12">
+        <span class="loading loading-spinner loading-lg"></span>
+      </div>
+    } @else {
+      <!-- Continue watching (horizontal scroller). Hidden when nothing
+           in-progress in this library so we don't render an empty row. -->
+      @if (suggestionsContinue().length) {
+        <app-horizontal-scroller [title]="'home.continue_watching' | translate">
+          @for (item of suggestionsContinue(); track item.id) {
+            <app-media-card
+              [aspect]="'landscape'"
+              [imageUrl]="item.fanartUrl ?? item.posterUrl"
+              [title]="item.mediaTitle"
+              [subtitle]="item.episodeLabel ?? undefined"
+              [progressPercent]="item.progressPercent"
+              [link]="['/' + (item.mediaType === 'series' ? 'series' : 'movies'), '' + item.mediaId]"
+              [subtitleLink]="item.episodeId ? ['/series', '' + item.mediaId, 'episode', '' + item.episodeId] : null"
+            />
+          }
+        </app-horizontal-scroller>
+      }
+
+      <!-- Recommendations grid — same column rhythm as the main `all`
+           grid so the suggestions feel like a continuation of the same
+           page rather than a separate component. -->
+      @if (suggestionsRecommendations().length) {
+        <h2 class="text-lg font-semibold mt-2">{{ 'home.recommendations' | translate }}</h2>
+        <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-6 gap-1.5 sm:gap-4">
+          @for (rec of suggestionsRecommendations(); track rec.media.id) {
+            <app-media-card
+              [imageUrl]="rec.media.posterUrl"
+              [title]="rec.media.title"
+              [subtitle]="rec.media.year ? '' + rec.media.year : undefined"
+              [link]="['/' + (rec.media.type === 'series' ? 'series' : 'movies'), '' + rec.media.id]"
+            />
+          }
+        </div>
+      } @else if (!suggestionsContinue().length) {
+        <div class="text-center py-24 text-base-content/50">
+          <p class="text-lg">{{ 'library.suggestions_empty' | translate }}</p>
+          <p class="text-sm mt-2">{{ 'library.suggestions_empty_hint' | translate }}</p>
+        </div>
+      }
+    }
   } @else {
-    <!-- Placeholders for upcoming views -->
+    <!-- Genres placeholder (next iteration). -->
     <div class="text-center py-24 text-base-content/50">
       <p class="text-lg">{{ 'library.coming_soon' | translate }}</p>
     </div>

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -22,6 +22,11 @@ import { ProfilesService, QualityProfile } from '../../core/services/api/profile
 import { LibrariesApiService, LibrarySummary } from '../../core/services/api/libraries-api.service';
 import { MediaCardComponent } from '../../shared/components/media-card/media-card';
 import { DropdownMenuComponent } from '../../shared/components/dropdown-menu';
+import { HorizontalScrollerComponent } from '../../shared/components/horizontal-scroller';
+import type {
+  ContinueWatchingItem,
+  RecommendationItem,
+} from '../../core/services/api/streaming-api.service';
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
 import { FocusMemoryService } from '../../core/services/focus-memory.service';
 import { NavbarService } from '../../core/services/navbar.service';
@@ -54,6 +59,7 @@ const NATURAL_ORDER_BY_SORT: Record<string, SortOrder> = {
   imports: [
     MediaCardComponent,
     DropdownMenuComponent,
+    HorizontalScrollerComponent,
     FormsModule,
     TranslateModule,
     LucideSearch,
@@ -96,6 +102,13 @@ export class LibraryComponent implements OnInit, OnDestroy {
   readonly filterMonitored = signal<FilterMonitored>('');
   readonly filterStatus = signal('');
   readonly viewMode = signal<LibraryViewMode>('all');
+
+  // ── Suggestions view ────────────────────────────────────────────────
+  /** Continue-watching items, scoped to the active library. */
+  readonly suggestionsContinue = signal<ContinueWatchingItem[]>([]);
+  /** History-based recommendations, scoped to the active library. */
+  readonly suggestionsRecommendations = signal<RecommendationItem[]>([]);
+  readonly suggestionsLoading = signal(false);
 
   readonly monitoredCount = computed(() => this.list.all().filter((m) => m.monitored).length);
   readonly movieFileCount = computed(() =>
@@ -206,6 +219,12 @@ export class LibraryComponent implements OnInit, OnDestroy {
       this.list.trackScroll('media');
       this.syncQueryParams();
       await this.load(lib.id);
+      if (this.viewMode() === 'suggestions') {
+        // Either a deep-link with `?view=suggestions` or a return from
+        // back-nav with the persisted mode. Fetch the suggestions data
+        // alongside the regular grid so the panel isn't empty.
+        void this.loadSuggestions();
+      }
       this.scrollMemory.restore(scrollKey, this.injector);
       if (this.tv.isTv()) {
         afterNextRender(() => this.applyDefaultFocus(lib.id), { injector: this.injector });
@@ -224,6 +243,11 @@ export class LibraryComponent implements OnInit, OnDestroy {
       this.scrollMemory.activate(scrollKey);
       this.navbar.setPageTitle(lib.name);
       void this.load(lib.id, true);
+      // Re-fire suggestions when we're on that tab so the SWR cache
+      // has a chance to bring in fresh data on a back-navigation.
+      if (this.viewMode() === 'suggestions') {
+        void this.loadSuggestions();
+      }
       this.scrollMemory.restoreSticky(scrollKey);
       if (this.tv.isTv()) {
         this.arrivedViaBack = true;
@@ -302,6 +326,33 @@ export class LibraryComponent implements OnInit, OnDestroy {
   setViewMode(mode: LibraryViewMode) {
     this.viewMode.set(mode);
     this.syncQueryParams();
+    if (mode === 'suggestions') {
+      void this.loadSuggestions();
+    }
+  }
+
+  /** Fetches continue-watching + recommendations for the active library.
+   *  No in-memory dedup — the HTTP cache (stale-while-revalidate) handles
+   *  the no-op case when the entry is fresh, and we want every `attached$`
+   *  re-visit to give the SWR a chance to pull in updated data. Signals
+   *  keep their previous value until each response lands, so flipping
+   *  between tabs never blanks the panel. */
+  private async loadSuggestions(): Promise<void> {
+    const lib = this.library();
+    if (!lib) return;
+    this.suggestionsLoading.set(true);
+    try {
+      const [cw, recs] = await Promise.all([
+        this.streamingApi.getContinueWatching(lib.id).catch(() => null),
+        this.streamingApi
+          .getRecommendations({ libraryId: lib.id, limit: 30 })
+          .catch(() => null),
+      ]);
+      if (cw) this.suggestionsContinue.set(cw);
+      if (recs) this.suggestionsRecommendations.set(recs);
+    } finally {
+      this.suggestionsLoading.set(false);
+    }
   }
 
   toggleSelect(id: number) {


### PR DESCRIPTION
## Summary
- The library page's Suggestions tab is now wired: a horizontal scroller of in-progress items in the active library + a grid of history-based recommendations (capped at 30, same column rhythm as the main grid).
- \`GET /api/playback/continue-watching\` and \`/recommendations\` accept optional \`?libraryId=\` (intersects with the user's accessible libraries — silent → empty result if out of scope). \`/recommendations\` also accepts \`?limit=\` (default 15, capped 50); the per-type cap scales with the total so the movie/series mix stays proportional.
- \`LibrariesService.getAccessibleLibraryIds\` always returns a concrete \`number[]\` now — admins / \`manage:all\` get every library ID resolved at call time. Closes the silent-empty-result bug that hit admins on library-scoped queries, and removes the \`null === no filter\` sentinel.
- Follow-up dead-code purge of the \`accessibleLibraryIds === null\` branches in \`PlaybackService\` (\`getContinueWatching\`, \`getHistory\`, \`getWatchedMediaIds\`), \`RecommendationService.getRecommendations\`, and \`MediaService\` (\`findAll\`, \`getCounts\`, \`getCountsByLibrary\`, \`assertAccessible\`, \`getCalendar\`, \`applyLibraryAcl\`). \`findByTmdbId\` keeps its optional ACL — internal callers (admin approve path) deliberately bypass it.
- Client \`loadSuggestions()\` mirrors home's pattern: no in-memory dedup, relies on the HTTP cache interceptor (stale-while-revalidate); signals keep their previous value until each response lands. \`attached$\` (route-reuse re-attach) re-fires the load when the Suggestions tab is active, so the SWR cache can surface fresh data on a back-navigation — same self-healing path as home.

## Test plan
- [x] \`npx tsc --noEmit\` clean (backend) + \`ng build\` clean (client)
- [ ] Library → Suggestions tab: continue-watching scroller renders the active library's in-progress items
- [ ] Recommendations grid populated for users with ≥ 1 completed media with genres
- [ ] Admin user gets results (validates the \`getAccessibleLibraryIds\` fix)
- [ ] Empty state shown when both rows have nothing
- [ ] Navigating away from the library and coming back refreshes Suggestions (SWR cache re-validation)