### PR TITLE
feat(library): Genres tab, history-aware tab navigation, layout polish

### DIFF
--- a/backend/src/modules/media/media.controller.ts
+++ b/backend/src/modules/media/media.controller.ts
@@ -119,6 +119,25 @@ export class MediaController {
     return APP_QUALITIES;
   }
 
+  /** Distinct genres present in a library, each with item count + the
+   *  poster URLs of up to 4 sample items (rendered as a mosaic on the
+   *  library Genres tab). When `libraryId` is omitted the user's whole
+   *  accessible scope is aggregated. */
+  @Get('genres')
+  @CheckPolicies((ability) => ability.can(Action.Read, Media))
+  async genres(
+    @CurrentUser() user: User,
+    @Query('libraryId') libraryIdRaw?: string,
+  ) {
+    const accessible = await this.libraries.getAccessibleLibraryIds(user);
+    let libraryIds = accessible;
+    const libraryId = libraryIdRaw ? parseInt(libraryIdRaw, 10) : null;
+    if (libraryId && Number.isFinite(libraryId)) {
+      libraryIds = accessible.includes(libraryId) ? [libraryId] : [];
+    }
+    return this.mediaService.getGenres(libraryIds);
+  }
+
   @Get('calendar')
   @CheckPolicies((ability) => ability.can(Action.Read, Media))
   async calendar(@Query() query: CalendarQueryDto, @CurrentUser() user: User) {

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -418,6 +418,44 @@ export class MediaService {
     return Object.fromEntries(rows.map((r) => [r.libraryId, r.count]));
   }
 
+  /**
+   * Aggregate distinct genres across the accessible libraries, with the
+   * total item count + up to 4 sample posters per genre (used by the
+   * library Genres tab to render a mosaic when posters are available).
+   * Skips media with null / empty `posterUrl` for the sample collection
+   * — they wouldn't render anything useful in the mosaic.
+   */
+  async getGenres(
+    accessibleLibraryIds: number[],
+  ): Promise<{ genre: string; count: number; posters: string[] }[]> {
+    if (accessibleLibraryIds.length === 0) return [];
+    // jsonb_array_elements_text unrolls the `media.genres` array so we
+    // can GROUP BY genre. The lateral join lets us aggregate poster
+    // URLs in the same pass; LIMIT 4 inside the array_agg keeps payload
+    // small without a per-group subquery.
+    const rows: { genre: string; count: number; posters: string[] }[] =
+      await this.mediaRepo.query(
+        `
+        SELECT g.genre,
+               COUNT(*)::int AS count,
+               COALESCE(
+                 (ARRAY_AGG(m."posterUrl" ORDER BY m.id)
+                  FILTER (WHERE m."posterUrl" IS NOT NULL))[1:4],
+                 ARRAY[]::text[]
+               ) AS posters
+        FROM media m
+        CROSS JOIN LATERAL jsonb_array_elements_text(m.genres) AS g(genre)
+        WHERE m."libraryId" = ANY($1)
+          AND m.genres IS NOT NULL
+          AND m.genres::text != '[]'
+        GROUP BY g.genre
+        ORDER BY g.genre ASC
+        `,
+        [accessibleLibraryIds],
+      );
+    return rows;
+  }
+
   async findAll(
     query: SearchMediaDto,
     userId?: number,

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -484,7 +484,9 @@
     "filter_status_label": "Statut",
     "coming_soon": "Bientôt disponible",
     "suggestions_empty": "Pas encore de suggestions",
-    "suggestions_empty_hint": "Regardez quelques films / séries pour alimenter les recommandations basées sur votre historique."
+    "suggestions_empty_hint": "Regardez quelques films / séries pour alimenter les recommandations basées sur votre historique.",
+    "genres_empty": "Aucun genre dans cette bibliothèque",
+    "clear_genre": "Effacer le filtre genre"
   },
   "movies": {
     "title": "Films"

--- a/client/src/app/core/services/api/media.service.ts
+++ b/client/src/app/core/services/api/media.service.ts
@@ -148,6 +148,15 @@ export interface MediaPage {
   total: number;
 }
 
+/** One row of the library Genres tab: a genre, how many media carry it,
+ *  and the URLs of the first up-to-4 posters (rendered as a mosaic
+ *  when populated, fallback folder icon when empty). */
+export interface GenreSummary {
+  genre: string;
+  count: number;
+  posters: string[];
+}
+
 export interface SearchParams {
   q?: string;
   type?: MediaType;
@@ -230,6 +239,15 @@ export class MediaService {
   getCountsByLibrary() {
     return firstValueFrom(
       this.http.get<Record<number, number>>('/api/media/counts-by-library'),
+    );
+  }
+
+  getGenres(libraryId?: number) {
+    const params = libraryId
+      ? { params: { libraryId: String(libraryId) } }
+      : {};
+    return firstValueFrom(
+      this.http.get<GenreSummary[]>('/api/media/genres', params),
     );
   }
 

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -1,9 +1,12 @@
 <div class="flex flex-col gap-4 h-full">
-  <!-- Library title -->
-  <h1 class="text-2xl font-bold">{{ libraryName() }}</h1>
+  <!-- Library title — hidden when the mobile topbar already shows it
+       (avoids the duplicated heading on small screens). -->
+  @if (!navbar.mobileNavbarVisible()) {
+    <h1 class="text-2xl font-bold">{{ libraryName() }}</h1>
+  }
 
   <!-- View tabs (own row, centered like the reference) -->
-  <nav class="flex items-center gap-1">
+  <nav class="flex items-center gap-1 mt-2">
     <button
       type="button"
       class="px-4 py-1.5 rounded-full text-sm font-medium transition-colors whitespace-nowrap"
@@ -49,6 +52,20 @@
       <span class="text-sm text-base-content/70 mr-1">
         {{ 'library.element_count' | translate:{ count: list.total() } }}
       </span>
+
+      @if (selectedGenre()) {
+        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-primary/15 text-primary text-sm">
+          <span class="font-medium">{{ selectedGenre() }}</span>
+          <button
+            type="button"
+            class="hover:bg-primary/20 rounded-full p-0.5"
+            [attr.aria-label]="'library.clear_genre' | translate"
+            (click)="clearSelectedGenre()"
+          >
+            <svg lucideX class="h-3 w-3"></svg>
+          </button>
+        </span>
+      }
 
       <div class="flex items-center gap-1">
         <select
@@ -204,8 +221,8 @@
           <button class="btn btn-xs btn-ghost" (click)="deselectAll()">{{ 'library.bulk_deselect' | translate }}</button>
         </div>
       }
-      <div class="flex gap-2 h-full">
-        <div class="flex-1 min-w-0 pr-2 lg:pr-4 grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-6 gap-1.5 sm:gap-4">
+      <div class="flex gap-1">
+        <div class="flex-1 min-w-0 pr-1 lg:pr-2 grid content-start grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-6 gap-1.5 sm:gap-4">
           @for (item of list.visible(); track item.id) {
             @if (bulkMode()) {
               <div
@@ -233,14 +250,14 @@
         <!-- Alphabet sidebar — only meaningful when items are actually
              ordered alphabetically (sort=title ASC). Any other sort
              would make the letter jumps random, so we hide it.
-             Sticky at viewport mid: now that <main> uses `overflow-x:
-             clip` (instead of `hidden`), it's no longer a vertical scroll
-             container, so sticky's nearest scroll ancestor is the actual
-             page scroll. `self-start` keeps the nav at its content size
-             inside the flex parent so sticky has room to pin within the
-             column. -->
+             `position: fixed` rather than sticky: sticky would un-stick
+             whenever the cards grid is shorter than the viewport (no
+             containing block to anchor against), leaving the alphabet
+             floating against the cards instead of the viewport mid.
+             Fixed keeps it nailed to the right side at vertical center
+             regardless of how many items the grid holds. -->
         @if (sortBy() === 'title' && sortOrder() === 'ASC') {
-          <nav class="sticky top-[50vh] -translate-y-1/2 self-start z-20 flex flex-col items-center gap-0 select-none tv:pt-20">
+          <nav class="fixed top-1/2 right-1 lg:right-2 -translate-y-1/2 z-20 flex flex-col items-center gap-0 select-none tv:pt-20">
             @for (letter of alphabet; track letter) {
               <button
                 type="button"
@@ -369,8 +386,56 @@
         </div>
       }
     }
+  } @else if (viewMode() === 'genres') {
+    <div class="flex items-center gap-3">
+      <span class="text-sm text-base-content/70">
+        {{ 'library.element_count' | translate:{ count: genresList().length } }}
+      </span>
+    </div>
+    @if (genresLoading() && !genresList().length) {
+      <div class="flex justify-center py-12">
+        <span class="loading loading-spinner loading-lg"></span>
+      </div>
+    } @else if (!genresList().length) {
+      <div class="text-center py-24 text-base-content/50">
+        <p class="text-lg">{{ 'library.genres_empty' | translate }}</p>
+      </div>
+    } @else {
+      <!-- Genre grid — Emby-style: each card is a 4-poster mosaic
+           (when posters are available) or a folder icon, with the
+           genre name below. Click → pivot to `all` with the genre
+           filter applied. -->
+      <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 gap-3 sm:gap-4">
+        @for (g of genresList(); track g.genre) {
+          <button
+            type="button"
+            class="group flex flex-col items-stretch gap-2 text-left focus:outline-none"
+            (click)="pickGenre(g.genre)"
+          >
+            <div class="aspect-square rounded-xl overflow-hidden bg-base-300 ring-1 ring-base-300 group-hover:ring-primary group-focus-visible:ring-primary group-focus-visible:ring-2 transition-colors">
+              @if (g.posters.length >= 4) {
+                <div class="grid grid-cols-2 grid-rows-2 w-full h-full">
+                  @for (p of g.posters.slice(0, 4); track p) {
+                    <img appImgFadeIn [src]="p | resolveUrl:'thumb'" alt="" loading="lazy" class="w-full h-full object-cover" />
+                  }
+                </div>
+              } @else if (g.posters.length > 0) {
+                <img appImgFadeIn [src]="g.posters[0] | resolveUrl:'medium'" alt="" loading="lazy" class="w-full h-full object-cover" />
+              } @else {
+                <div class="w-full h-full flex items-center justify-center text-base-content/30">
+                  <svg lucideFolder class="w-12 h-12" [strokeWidth]="1.5"></svg>
+                </div>
+              }
+            </div>
+            <div class="text-sm">
+              <div class="font-medium truncate group-hover:text-primary transition-colors">{{ g.genre }}</div>
+              <div class="text-xs text-base-content/50">{{ g.count }}</div>
+            </div>
+          </button>
+        }
+      </div>
+    }
   } @else {
-    <!-- Genres placeholder (next iteration). -->
     <div class="text-center py-24 text-base-content/50">
       <p class="text-lg">{{ 'library.coming_soon' | translate }}</p>
     </div>

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -16,7 +16,7 @@ import { ActivatedRoute, NavigationStart, Router } from '@angular/router';
 import { Subscription, filter } from 'rxjs';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { MediaService, Media } from '../../core/services/api/media.service';
+import { MediaService, Media, GenreSummary } from '../../core/services/api/media.service';
 import { StreamingApiService } from '../../core/services/api/streaming-api.service';
 import { ProfilesService, QualityProfile } from '../../core/services/api/profiles.service';
 import { LibrariesApiService, LibrarySummary } from '../../core/services/api/libraries-api.service';
@@ -33,7 +33,9 @@ import { NavbarService } from '../../core/services/navbar.service';
 import { TvService } from '../../core/services/tv.service';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
 import { InfiniteScrollList } from '../../shared/utils/infinite-scroll-list';
-import { LucideSearch, LucideSlidersHorizontal, LucideArrowUp, LucideArrowDown } from '@lucide/angular';
+import { LucideSearch, LucideSlidersHorizontal, LucideArrowUp, LucideArrowDown, LucideFolder, LucideX } from '@lucide/angular';
+import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
+import { ImgFadeInDirective } from '../../shared/directives/img-fade-in.directive';
 
 const ALPHABET = '#ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
@@ -66,6 +68,10 @@ const NATURAL_ORDER_BY_SORT: Record<string, SortOrder> = {
     LucideSlidersHorizontal,
     LucideArrowUp,
     LucideArrowDown,
+    LucideFolder,
+    LucideX,
+    ResolveUrlPipe,
+    ImgFadeInDirective,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './library.html',
@@ -79,7 +85,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   private readonly router = inject(Router);
   private readonly scrollMemory = inject(ScrollMemoryService);
   private readonly focusMemory = inject(FocusMemoryService);
-  private readonly navbar = inject(NavbarService);
+  readonly navbar = inject(NavbarService);
   private readonly tv = inject(TvService);
   private readonly injector = inject(Injector);
   private readonly translate = inject(TranslateService);
@@ -88,6 +94,11 @@ export class LibraryComponent implements OnInit, OnDestroy {
   private navStartSub?: Subscription;
   private attachedSub?: Subscription;
   private detachedSub?: Subscription;
+  private queryParamSub?: Subscription;
+  /** Set while a state-driven `syncQueryParams` is being applied to the
+   *  URL, so the `queryParamMap` subscription that fires right after
+   *  can ignore the round-trip instead of re-applying our own write. */
+  private skipQueryParamSync = false;
 
   /** Resolved library (null while loading or if not found). */
   readonly library = signal<LibrarySummary | null>(null);
@@ -109,6 +120,14 @@ export class LibraryComponent implements OnInit, OnDestroy {
   /** History-based recommendations, scoped to the active library. */
   readonly suggestionsRecommendations = signal<RecommendationItem[]>([]);
   readonly suggestionsLoading = signal(false);
+
+  // ── Genres view ─────────────────────────────────────────────────────
+  /** Distinct genres in the library + sample posters for the mosaic. */
+  readonly genresList = signal<GenreSummary[]>([]);
+  readonly genresLoading = signal(false);
+  /** When set, the `all` grid is filtered to this genre via the API's
+   *  `genre=` param. Cleared with the chip's × button. */
+  readonly selectedGenre = signal<string>('');
 
   readonly monitoredCount = computed(() => this.list.all().filter((m) => m.monitored).length);
   readonly movieFileCount = computed(() =>
@@ -214,6 +233,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
       this.viewMode.set(
         (qp.get('view') ?? stored['view'] ?? 'all') as LibraryViewMode,
       );
+      this.selectedGenre.set(qp.get('genre') ?? stored['genre'] ?? '');
 
       this.scrollMemory.activate(scrollKey);
       this.list.trackScroll('media');
@@ -224,6 +244,8 @@ export class LibraryComponent implements OnInit, OnDestroy {
         // back-nav with the persisted mode. Fetch the suggestions data
         // alongside the regular grid so the panel isn't empty.
         void this.loadSuggestions();
+      } else if (this.viewMode() === 'genres') {
+        void this.loadGenres();
       }
       this.scrollMemory.restore(scrollKey, this.injector);
       if (this.tv.isTv()) {
@@ -243,10 +265,12 @@ export class LibraryComponent implements OnInit, OnDestroy {
       this.scrollMemory.activate(scrollKey);
       this.navbar.setPageTitle(lib.name);
       void this.load(lib.id, true);
-      // Re-fire suggestions when we're on that tab so the SWR cache
-      // has a chance to bring in fresh data on a back-navigation.
+      // Re-fire suggestions / genres when we're on that tab so the SWR
+      // cache has a chance to bring in fresh data on a back-navigation.
       if (this.viewMode() === 'suggestions') {
         void this.loadSuggestions();
+      } else if (this.viewMode() === 'genres') {
+        void this.loadGenres();
       }
       this.scrollMemory.restoreSticky(scrollKey);
       if (this.tv.isTv()) {
@@ -259,6 +283,30 @@ export class LibraryComponent implements OnInit, OnDestroy {
       const lib = this.library();
       if (lib) this.scrollMemory.deactivateIf(`library-${lib.id}`);
     });
+
+    // Re-apply state on browser back/forward (same route, queryParams
+    // change). Initial load + state-driven `syncQueryParams` writes are
+    // skipped via the `skipQueryParamSync` flag so we don't recurse.
+    this.queryParamSub = this.route.queryParamMap.subscribe((qp) => {
+      if (this.skipQueryParamSync) {
+        this.skipQueryParamSync = false;
+        return;
+      }
+      if (!this.library()) return;
+      this.searchQuery.set(qp.get('q') ?? '');
+      this.filterMonitored.set((qp.get('monitored') ?? '') as FilterMonitored);
+      this.filterStatus.set(qp.get('status') ?? '');
+      this.sortBy.set(qp.get('sortBy') ?? 'title');
+      this.sortOrder.set((qp.get('sortOrder') ?? 'ASC') as SortOrder);
+      this.viewMode.set((qp.get('view') ?? 'all') as LibraryViewMode);
+      this.selectedGenre.set(qp.get('genre') ?? '');
+      const lib = this.library();
+      if (lib) {
+        void this.load(lib.id, true);
+        if (this.viewMode() === 'genres') void this.loadGenres();
+        else if (this.viewMode() === 'suggestions') void this.loadSuggestions();
+      }
+    });
   }
 
   ngOnDestroy() {
@@ -268,6 +316,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
     this.navStartSub?.unsubscribe();
     this.attachedSub?.unsubscribe();
     this.detachedSub?.unsubscribe();
+    this.queryParamSub?.unsubscribe();
   }
 
   private applyDefaultFocus(libraryId: number) {
@@ -324,10 +373,47 @@ export class LibraryComponent implements OnInit, OnDestroy {
   }
 
   setViewMode(mode: LibraryViewMode) {
+    if (this.viewMode() === mode) return;
     this.viewMode.set(mode);
-    this.syncQueryParams();
+    // Push a history entry on tab switch so browser back walks through
+    // the previously-active tabs (Films / Suggestions / Genres). Same
+    // pattern as Plex / Jellyseerr web.
+    this.syncQueryParams(true);
     if (mode === 'suggestions') {
       void this.loadSuggestions();
+    } else if (mode === 'genres') {
+      void this.loadGenres();
+    }
+  }
+
+  /** Click handler on a genre card — set the genre filter and pivot
+   *  back to the main `all` grid where it's actually applied. */
+  pickGenre(genre: string) {
+    this.selectedGenre.set(genre);
+    this.viewMode.set('all');
+    // Push a real history entry so the browser back button returns
+    // to the Genres list instead of the page-before-library.
+    this.syncQueryParams(true);
+    void this.load(this.library()?.id);
+  }
+
+  clearSelectedGenre() {
+    this.selectedGenre.set('');
+    this.syncQueryParams();
+    void this.load(this.library()?.id);
+  }
+
+  /** Fetches the genres aggregate (count + sample posters) for the
+   *  current library. Same SWR pattern as `loadSuggestions`. */
+  private async loadGenres(): Promise<void> {
+    const lib = this.library();
+    if (!lib) return;
+    this.genresLoading.set(true);
+    try {
+      const rows = await this.mediaService.getGenres(lib.id).catch(() => null);
+      if (rows) this.genresList.set(rows);
+    } finally {
+      this.genresLoading.set(false);
     }
   }
 
@@ -410,7 +496,10 @@ export class LibraryComponent implements OnInit, OnDestroy {
     }
   }
 
-  private syncQueryParams() {
+  /** Reflect the current state in the URL. `push` adds a real history
+   *  entry instead of replacing — used for the genres-list → genre-filter
+   *  transition so the browser back button returns to the Genres list. */
+  private syncQueryParams(push = false) {
     const params: Record<string, string> = {};
     if (this.searchQuery()) params['q'] = this.searchQuery();
     if (this.filterMonitored()) params['monitored'] = this.filterMonitored();
@@ -418,7 +507,9 @@ export class LibraryComponent implements OnInit, OnDestroy {
     if (this.sortBy() !== 'title') params['sortBy'] = this.sortBy();
     if (this.sortOrder() !== 'ASC') params['sortOrder'] = this.sortOrder();
     if (this.viewMode() !== 'all') params['view'] = this.viewMode();
-    void this.router.navigate([], { queryParams: params, replaceUrl: true });
+    if (this.selectedGenre()) params['genre'] = this.selectedGenre();
+    this.skipQueryParamSync = true;
+    void this.router.navigate([], { queryParams: params, replaceUrl: !push });
     this.saveFilters();
   }
 
@@ -434,6 +525,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
     if (this.sortBy() !== 'title') data['sortBy'] = this.sortBy();
     if (this.sortOrder() !== 'ASC') data['sortOrder'] = this.sortOrder();
     if (this.viewMode() !== 'all') data['view'] = this.viewMode();
+    if (this.selectedGenre()) data['genre'] = this.selectedGenre();
     localStorage.setItem(this.storageKey, JSON.stringify(data));
   }
 
@@ -457,6 +549,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
           q: this.searchQuery() || undefined,
           sortBy: this.sortBy(),
           sortOrder: this.sortOrder(),
+          genre: this.selectedGenre() || undefined,
           monitored: monitored ? monitored === 'true' : undefined,
           missing: fs === 'missing' ? true : fs === 'downloaded' ? false : undefined,
           cutoffUnmet: fs === 'cutoffUnmet' ? true : undefined,


### PR DESCRIPTION
## Summary
- Genres tab renders an Emby-style grid of square genre cards. Each card shows a 2×2 poster mosaic when ≥ 4 posters exist for the genre, a single poster when 1–3 are available, or an empty folder icon. Click → pivot to the \`all\` tab with the genre filter applied; a primary chip in the toolbar shows the active filter with a × to clear.
- New \`GET /api/media/genres?libraryId=<id>\` endpoint returns \`{ genre, count, posters[] }[]\`. Single SQL query unrolling \`media.genres jsonb\` via \`jsonb_array_elements_text\` + \`ARRAY_AGG(...) FILTER(...)[1:4]\` — no extra table to maintain, no per-row N+1.
- Tab clicks (Films / Suggestions / Genres) and \`pickGenre\` now push real history entries; other filter tweaks (sort, search, monitored…) stay on \`replaceUrl: true\`. \`route.queryParamMap\` subscription replays URL → state on browser back/forward, with a re-entry guard to ignore round-trips from our own writes. Sequence: Films → click Genres → click \"Comédie\" → ⬅ goes to Genres list, ⬅ again goes back to Films.
- Library \`<h1>\` hidden when the mobile topbar already displays the page title (no duplicated heading on small screens). Tab nav gets \`mt-2\`.
- Grid \`pr\` and the wrapper \`gap\` shrunk to free a few px for cards.
- **Alphabet sidebar rewritten**: \`position: fixed top-1/2 right-1 lg:right-2 -translate-y-1/2\`. Sticky was a poor fit — it un-stuck whenever the grid was shorter than the viewport (alphabet floated against the cards instead of viewport mid), and \`min-h-full\` to fake a tall containing block bled empty space below the content. Fixed keeps it pinned at viewport center regardless of grid height with zero empty space below.
- Grid wrapper drops \`h-full\`; \`content-start\` packs card rows at the top so they don't stretch into empty space when there are only a few items.

## Test plan
- [x] \`npx tsc --noEmit\` clean (backend) + \`ng build\` clean (client)
- [ ] Library → Genres tab: grid of cards renders, mosaic appears for genres with ≥ 4 posters
- [ ] Click a genre → returns to \`all\` tab, grid filtered, primary chip in toolbar
- [ ] Click × on chip → filter cleared, full grid returns
- [ ] Browser ⬅ from a filtered grid → back to Genres list (when arrived via genre card); ⬅ from any tab → back to previous tab
- [ ] Library page on mobile: no duplicated title (h1 hidden when mobile topbar visible)
- [ ] Alphabet sidebar stays at viewport center regardless of scroll position and item count (no empty space below short grids)