### PR TITLE
fix: 2 s audio echo at rotation seam + media-card badge z-index

### DIFF
--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -267,10 +267,28 @@ export function buildFfmpegArgs(
 
   if (startSegment > 0) {
     // Output-seek companion to the input-seek above; trims the decoded
-    // PRE_SEEK_MARGIN_SECONDS prelude sample-accurately on both tracks.
+    // PRE_SEEK_MARGIN_SECONDS prelude on the video side (the AAC encoder
+    // ignores this on the audio side — see the `-af atrim` below).
     // `-output_ts_offset` is also placed here (after `-i`) because it's
     // an OPT_OUTPUT option in FFmpeg — see the comment block above.
-    if (postSeek > 0) args.push('-ss', String(postSeek));
+    if (postSeek > 0) {
+      args.push('-ss', String(postSeek));
+      // Sample-accurate audio trim. `-ss` after `-i` does NOT reliably
+      // drop the pre-seek prelude for an AAC / AC-3 / EAC-3 re-encode:
+      // the encoder receives the full decoded stream starting at the
+      // input-seek point (internal_t = 0) and emits packets from
+      // PTS = 0, which after `output_ts_offset = preSeek` lands at
+      // tfdt = preSeek instead of preSeek + postSeek. On a Chromecast
+      // (which doesn't honour fMP4 `edts/elst` for priming) that
+      // surfaces as the new segment overlapping the previous one's
+      // last PRE_SEEK_MARGIN_SECONDS of audio — a 2 s "echo" at every
+      // rotation seam. `atrim` runs in the filter graph (before the
+      // encoder), so the prelude is dropped sample-accurately; we
+      // intentionally skip `asetpts` so the first kept sample keeps
+      // PTS = postSeek and `output_ts_offset` lifts it to the
+      // expected boundary.
+      args.push('-af', `atrim=start=${postSeek}`);
+    }
     args.push('-output_ts_offset', String(preSeek));
   }
 
@@ -557,8 +575,14 @@ export function buildAudioOnlyFfmpegArgs(
 
   if (startSegment > 0) {
     // `-ss postSeek` + `-output_ts_offset preSeek` placed after `-i` —
-    // both are OPT_OUTPUT options. Same rationale as buildFfmpegArgs.
-    if (postSeek > 0) args.push('-ss', String(postSeek));
+    // both are OPT_OUTPUT options. `atrim` runs in the audio filter
+    // graph and is what actually drops the pre-seek prelude before
+    // the AAC encoder sees it — `-ss` post-`-i` is unreliable here
+    // (see the comment block in `buildFfmpegArgs`).
+    if (postSeek > 0) {
+      args.push('-ss', String(postSeek));
+      args.push('-af', `atrim=start=${postSeek}`);
+    }
     args.push('-output_ts_offset', String(preSeek));
   }
 

--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -37,7 +37,7 @@
 
     <!-- Rating badge (bottom-left, portrait only) -->
     @if (_rating() > 0 && aspect() === 'portrait') {
-      <div class="absolute bottom-1.5 left-1.5 z-20 flex items-center gap-0.5 bg-black/60 rounded-md px-1.5 py-0.5">
+      <div class="absolute bottom-1.5 left-1.5 z-10 flex items-center gap-0.5 bg-black/60 rounded-md px-1.5 py-0.5">
         <svg lucideStar class="h-3 w-3 text-yellow-400 fill-yellow-400"></svg>
         <span class="text-[11px] text-white font-semibold tabular-nums">{{ _rating() | number:'1.1-1' }}</span>
       </div>
@@ -45,7 +45,7 @@
 
     <!-- Top-left: missing-files indicator (auto), status badge, episode number -->
     @if (_resolvedStatus() === 'missing' || statusBadge() || topLeftBadge()) {
-      <div class="absolute top-2 left-2 z-30 flex items-center gap-1">
+      <div class="absolute top-2 left-2 z-10 flex items-center gap-1">
         @if (_resolvedStatus() === 'missing') {
           <svg
             lucideCircleX
@@ -64,7 +64,7 @@
 
     <!-- Top-right: discover badge OR status icon -->
     @if (badge()) {
-      <div class="absolute top-1.5 right-1.5 z-20">
+      <div class="absolute top-1.5 right-1.5 z-10">
         @switch (badge()) {
           @case ('library') {
             <div class="w-6 h-6 rounded-full bg-success flex items-center justify-center shadow">
@@ -86,7 +86,7 @@
     } @else if (interactiveWatched()) {
       <button
         type="button"
-        class="absolute top-1.5 right-1.5 z-20 w-6 h-6 rounded-full flex items-center justify-center shadow transition-colors cursor-pointer"
+        class="absolute top-1.5 right-1.5 z-10 w-6 h-6 rounded-full flex items-center justify-center shadow transition-colors cursor-pointer"
         [class.bg-success]="status() === 'watched'"
         [class.hover:bg-success/90]="status() === 'watched'"
         [class.bg-black/50]="status() !== 'watched'"
@@ -102,7 +102,7 @@
         ></svg>
       </button>
     } @else if (_resolvedStatus() === 'watched') {
-      <div class="absolute top-1.5 right-1.5 z-20">
+      <div class="absolute top-1.5 right-1.5 z-10">
         <div class="w-6 h-6 rounded-full bg-success flex items-center justify-center shadow">
           <svg lucideCheck class="h-3.5 w-3.5 text-success-content"></svg>
         </div>
@@ -134,7 +134,7 @@
     @if (showHoverOverlay() && cardActions().length) {
       <button
         type="button"
-        class="absolute top-2 right-2 z-20 btn btn-circle btn-sm border-0 bg-black/50 text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-black/65"
+        class="absolute top-2 right-2 z-10 btn btn-circle btn-sm border-0 bg-black/50 text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-black/65"
         (click)="openActions($event)"
         [attr.aria-label]="'media_card.actions' | translate"
       >


### PR DESCRIPTION
## Summary
- **Audio echo at rotation seam (Chromecast)**: \`-ss postSeek\` placed after \`-i\` reliably trims video because \`force_key_frames\` anchors the first IDR at \`internal_t = postSeek\`. The audio re-encoder has no such anchor and emits from PTS 0 (= source \`preSeek\`), so after \`output_ts_offset = preSeek\` the new segment's audio tfdt lands at \`preSeek\` instead of \`preSeek + postSeek\` — overlapping the previous segment's last \`PRE_SEEK_MARGIN_SECONDS\` of audio. On a Chromecast (which doesn't honour fMP4 \`edts/elst\` priming) this surfaces as a 2 s audio echo at every 10-min rotation seam. Fix: \`-af atrim=start={postSeek}\` in the audio filter graph runs before the AAC / AC-3 / EAC-3 encoder, dropping the prelude sample-accurately; we intentionally omit \`asetpts\` so \`output_ts_offset\` can lift the first kept sample (PTS = postSeek) to the same boundary as the video's tfdt. Applied to both \`buildFfmpegArgs\` (main transcode + var_stream_map) and \`buildAudioOnlyFfmpegArgs\` (audio-only EXT-X-MEDIA renditions).
- **Media-card badges z-index**: badges previously used z-20 / z-30 — equal to / above the layout navbar (z-30) and dock (z-40), causing them to bleed through dropdowns, bottom-sheets and the Android system topbar in some stacking-context combos. Capped to z-10: still above the card's click-anchor (z-0) and play button (z-10), but well below every overlay band (z-30+).

## Test plan
- [x] Backend \`npx tsc --noEmit\` clean
- [ ] Chromecast a 2 h+ file, confirm no audio echo / desync at the 10 min, 20 min, 30 min rotation seams (video already verified by PR #100)
- [ ] Media cards no longer overlap dropdowns / the mobile topbar / the bottom-sheet