### PR TITLE
fix(transcode): stable long-running QSV + sample-accurate seek-resume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ volumes/*
 scripts/
 logos/
 plans/
-docs/
+/docs/
 docker-compose.yml
 docker-compose.prod.yml
 

--- a/backend/docs/streaming/encoder-stability.md
+++ b/backend/docs/streaming/encoder-stability.md
@@ -1,0 +1,149 @@
+# Long-running QSV transcodes + seek-resume seam
+
+This note explains the encoder configuration and the seek-resume FFmpeg
+args used by `backend/src/modules/streaming/transcoding/ffmpeg-args.ts`,
+plus the two bugs they fix. Keep it next to the source — when you
+question why a flag is there, the answer is here.
+
+## Background
+
+The streaming backend transcodes media into HLS fmp4 segments via
+FFmpeg with VAAPI decode + h264_qsv encode on Intel iGPUs. A single
+FFmpeg process serves the whole session: cold-spawned on the first
+segment request, killed only on seek-resume (when the player requests a
+segment ahead of the encoder's frontier by more than
+`SEEK_WAIT_THRESHOLD`).
+
+Two distinct issues bite in this setup. The first concerns the encoder
+itself drifting over long runs; the second concerns the timestamp
+wiring at seek-resume. They each have their own root cause and fix.
+
+## Issue 1 — 45 s GOPs after ~17 min of continuous encoding
+
+**Symptom.** The HLS muxer pools samples until the next IDR, producing
+one giant segment that overruns its `EXTINF` slot. The player stalls or
+drops the stream.
+
+**Root cause.** Despite the "BRC drift" label this isn't a bitrate-
+controller issue. When `-adaptive_i 1` is on and a scene-cut IDR has
+been emitted "close enough" to a `force_key_frames` instant, Intel
+Media SDK refuses to promote the forced instant to a real IDR and emits
+a plain I-frame instead (Intel-Media-SDK#2776, jellyfin-ffmpeg#413).
+The HLS muxer waits for an IDR before cutting a new segment, so it
+keeps pooling samples until one finally shows up — that's where the
+45 s GOP comes from. The ~17 min cadence is just the phase between
+`-g`, the SDK's internal IDR cycle and the adaptive-I heuristic finally
+lining up against our `force_key_frames` ticks.
+
+**Fix — encoder configuration.**
+
+```
+-c:v h264_qsv
+-forced_idr 1        # every force_key_frames tick lands as a real IDR
+-adaptive_i 0        # scene-cut placement off (it fights forced IDRs)
+-bf 0                # no B-frames
+-b_strategy 0        # closed GOP, deterministic IDR placement
+-mbbrc 1
+-b:v X -maxrate X+1
+-bufsize X           # tight VBV (1× target); a larger buffer lets the
+                     # BRC defer big I-frames on dense scenes
+-g <fps×SEG> -keyint_min <fps×SEG>
+-force_key_frames expr:gte(t, seekSeconds + n_forced*SEG)
+```
+
+`-forced_idr 1` is the load-bearing flag. `-adaptive_i 0` is needed
+alongside it because the adaptive-I heuristic is exactly what races
+with forced keyframes. `-bf 0` removes B-frame reordering at segment
+edges so the HLS muxer cuts cleanly on each forced IDR. Tight VBV
+(`bufsize = bitrate`) shrinks the BRC's "save up bits" window, which
+is the secondary factor that lets the encoder defer big I-frames on
+dense scenes.
+
+## Issue 2 — A/V seam after a user seek
+
+**Symptom.** After seeking to `T`, video shows content from a few
+seconds before `T` while audio is correctly anchored at `T`.
+
+**Root cause.** `-ss T -i input` with VAAPI decode + `accurate_seek`
+(default) doesn't reliably drop frames before `T` on hardware-decoded
+surfaces. The decoder emits frames from the source keyframe `≤ T`
+(could be 5–10 s before `T`), and the encoder's mandatory first IDR
+lands on that earliest frame instead of on `T`. Video `tfdt` ends up
+several seconds behind audio `tfdt` (audio still snaps to the
+audio-frame boundary `≤ T`, drift bounded to ±21–40 ms).
+
+**Fix — seek-resume FFmpeg args.** For a resume at content time `T`
+(`startSegment > 0`):
+
+```
+-ss T                       # before -i — fast demuxer seek to keyframe ≤ T
+-i input.mkv
+-copyts                     # propagate source PTS end-to-end
+-muxdelay 0 -muxpreload 0   # no priming edit-list on the first IDR
+-ss T                       # after -i — drop decoded frames < T before encoder
+-force_key_frames "expr:gte(t, T + n_forced*SEG)"
+```
+
+The double `-ss` is intentional and not redundant:
+
+- The first `-ss T` is the demuxer-side seek (jumps quickly to the
+  keyframe `≤ T`).
+- `-copyts` keeps source PTS on every decoded frame all the way to the
+  muxer, so `tfdt` on the first written segment is `T × timescale`.
+- The second `-ss T` is the output-seek: with `-copyts` it operates in
+  source-time and drops decoded frames before they reach the encoder,
+  including the frames between the source keyframe and `T` that the
+  HW-decoder path doesn't trim on its own.
+- The encoder receives only frames with PTS ≥ T; its forced first IDR
+  lands at `T`. Video `tfdt = T`, audio `tfdt ≈ T` (audio is packet-
+  snapped at the demuxer; the drift is bounded to ±21 ms for AAC,
+  ±32 ms for AC-3, ±40 ms for DTS — imperceptible).
+- `-force_key_frames` anchors at `seekSeconds` instead of `0`: with
+  `-copyts` the encoder's `t` variable is in source time, so the
+  expression has to acknowledge that.
+
+This works for `-c:a copy` and re-encode audio alike — `-copyts` is
+codec-agnostic. `-af atrim` would have been a sample-accurate audio
+trim but is incompatible with `-c:a copy` ("Filtering and streamcopy
+cannot be used together"); the demuxer-snap drift on copy audio is
+small enough to not need active correction.
+
+## Things to NOT do
+
+- Pair `-avoid_negative_ts make_zero` with `-output_ts_offset T`. They
+  cancel each other on the fmp4 muxer (the offset is applied, then
+  `make_zero` zeroes every timestamp), and the HLS muxer pools samples
+  until the next encoder-natural keyframe.
+- Drop `-forced_idr 1`. HLS needs a guaranteed IDR at every segment
+  boundary; without `forced_idr` the SDK will skip some of them.
+- Turn `-adaptive_i` back on. The scene-cut placement races with the
+  forced-IDR cadence and brings the 45 s GOP back.
+- Add `-extbrc 1` or `-look_ahead 1`. Both have known long-run
+  bitrate-control regressions (Intel-Media-SDK#1511) and aren't needed
+  for this use case.
+
+## Fallback ladder if the encoder still drifts
+
+If a future media file / driver combination exhibits drift past the
+17-min mark despite the config above, try in order:
+
+1. **CBR**: set `-minrate = -b:v = -maxrate`, keep `-bufsize 2*bitrate`.
+   Removes the VBR envelope entirely.
+2. **Add `-max_frame_size <bytes>`**. Caps the worst-case I-frame so
+   the BRC has slack for the next forced IDR.
+3. **ICQ**: `-global_quality 23 -look_ahead 0`. No bitrate accumulator,
+   IDR placement becomes deterministic at the cost of variable bitrate.
+4. **CQP**: `-q 23`. No BRC state at all — diagnostic-only; if CQP also
+   drifts, the bug is in the driver, not the encoder logic.
+5. **Switch to `h264_vaapi`**. Same hardware path, different BRC
+   implementation; not known to exhibit this drift.
+
+## References
+
+- Intel-Media-SDK#2776 — `forced_idr` bug in `h264_qsv`
+- jellyfin-ffmpeg#413 — QSV produces unplayable HLS segments
+- intel/media-driver#1576 — QSV produces files with one I-frame
+- FFmpeg-devel "respect user's setting for keyframes" patch
+- intel/media-delivery `quality.rst` — HLS streaming recommendations
+- Jellyfin `MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs`
+  (one-long-FFmpeg pattern + GOP-based keyframe forcing)

--- a/backend/src/modules/streaming/transcoding/constants.ts
+++ b/backend/src/modules/streaming/transcoding/constants.ts
@@ -2,19 +2,6 @@ export const SESSION_TIMEOUT_MS = 30 * 60 * 1000; // 30min HLS session timeout
 export const MAX_SESSIONS = 4;
 /** Max gap (in segments) between FFmpeg frontier and requested segment before restarting. */
 export const SEEK_WAIT_THRESHOLD = 15;
-/** Kill+respawn the encoder every ~N seconds of content. QSV's BRC
- *  quietly accumulates state over long continuous runs and eventually
- *  refuses to insert IDRs on dense scenes, producing 45 s GOPs that
- *  overrun the HLS playlist's EXTINF slots. The bad-GOP regime hits
- *  around ~17 min, so we rotate well before that. Expressed in seconds
- *  of content (not segments) so the cadence holds whatever the admin
- *  picks for `streaming_segment_duration`. */
-export const SEGMENT_ROTATION_INTERVAL_SECONDS = 600;
-/** Translate the seconds budget into a segment count for the current
- *  segment duration setting. */
-export function getRotationSegmentThreshold(): number {
-  return Math.max(1, Math.ceil(SEGMENT_ROTATION_INTERVAL_SECONDS / segmentDuration));
-}
 
 /** Mutable runtime state for HLS segment durations. Updated from admin
  *  streaming settings via `setSegmentDurations()`. Read by FFmpeg arg

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -102,30 +102,36 @@ export function buildFfmpegArgs(
   const fps = sourceFps && sourceFps > 0 ? sourceFps : 24;
   const gopSize = Math.max(1, Math.round(SEGMENT_DURATION * fps));
 
-  // Hybrid seek for mid-file resumes (see big block below `-i`). Decompose
-  // the absolute resume time T into a fast IDR-snap input-seek (`preSeek`)
-  // followed by a sample-accurate output-seek (`postSeek`) of a few seconds.
-  const PRE_SEEK_MARGIN_SECONDS = 2;
+  // Resume point for mid-file seek (`startSegment > 0`). Seek to T,
+  // then `-copyts` (set after `-i` below) threads source PTS through
+  // to the muxer so the first segment lands at tfdt = T × timescale.
   const seekSeconds = startSegment > 0 ? segmentIndexToSeconds(startSegment) : 0;
-  const preSeek = Math.max(0, seekSeconds - PRE_SEEK_MARGIN_SECONDS);
-  const postSeek = seekSeconds - preSeek;
 
-  // Keyframes at: 0, INIT_TIME, INIT_TIME+SEG, INIT_TIME+2*SEG, ...
-  // Lets -hls_init_time actually cut segment 0 short (needs a keyframe at
-  // INIT_TIME). When INIT_TIME >= SEGMENT_DURATION, collapses to regular
-  // fixed-GOP behaviour.
-  // On resume (start>0) the encoder sees internal t starting at `postSeek`
-  // (not 0), so the IDR anchors are shifted by postSeek to keep HLS segment
-  // boundaries on multiples of SEGMENT_DURATION from the resume point.
+  // Keyframes at: 0, INIT_TIME, INIT_TIME+SEG, INIT_TIME+2*SEG, …
+  // Lets `-hls_init_time` actually cut segment 0 short (needs a keyframe
+  // at INIT_TIME); collapses to a regular fixed-GOP cadence when
+  // INIT_TIME ≥ SEGMENT_DURATION. On a seek-resume we use `-copyts` so
+  // the encoder's `t` is in source time — the expression anchors at
+  // `seekSeconds` and IDRs land on the same grid the HLS muxer expects.
   const forceKeyframesExpr =
     startSegment > 0
-      ? `expr:gte(t,${postSeek}+n_forced*${SEGMENT_DURATION})`
+      ? `expr:gte(t,${seekSeconds}+n_forced*${SEGMENT_DURATION})`
       : `expr:if(eq(n_forced,0),gte(t,0),gte(t,${INIT_TIME}+(n_forced-1)*${SEGMENT_DURATION}))`;
-  // adaptive_i/adaptive_b let QSV pick I/B placement per scene complexity —
-  // measurable quality win on dense / fast-motion content, no perf cost.
-  // QSV BRC drift on long continuous runs is handled separately by
-  // SEGMENT_ROTATION_INTERVAL_SECONDS respawning the encoder periodically.
-  const qsvExtra: string[] = ['-adaptive_i', '1', '-adaptive_b', '1'];
+  // Closed-GOP, deterministic IDR placement on h264_qsv:
+  //  - `-forced_idr 1` : every `force_key_frames` tick lands as a real
+  //    IDR (without it, qsvenc emits some as plain I, breaking HLS
+  //    segment cuts).
+  //  - `-adaptive_i 0` : scene-cut detection off — its placement fights
+  //    with the forced-IDR cadence we want.
+  //  - `-bf 0 -b_strategy 0` : no B-frames, no reordering across
+  //    segment edges → HLS muxer can cut cleanly on each forced IDR.
+  // See `docs/streaming/encoder-stability.md` for the full rationale.
+  const qsvExtra: string[] = [
+    '-forced_idr', '1',
+    '-adaptive_i', '0',
+    '-bf', '0',
+    '-b_strategy', '0',
+  ];
   if (qsvOptions.lowPower) {
     qsvExtra.push('-low_power', '1');
   }
@@ -145,37 +151,13 @@ export function buildFfmpegArgs(
   }
 
   if (startSegment > 0) {
-    // Hybrid seek to keep audio/video sample-aligned across encoder
-    // respawns (SEGMENT_ROTATION_INTERVAL_SECONDS).
-    //
-    // The naive `-ss T -i input` (input-seek only) drifts: FFmpeg snaps
-    // each stream independently to its own frame boundary (~21 ms for
-    // AAC, ~32 ms for AC-3, up to ~40 ms for DTS) and then
-    // `-avoid_negative_ts make_zero` shifts audio by the per-stream
-    // snap delta while leaving video at 0 — every respawn injects a
-    // fresh, randomly-signed delta of A/V skew.
-    //
-    //  1. `-ss preSeek` before `-i` does the cheap demuxer seek + the
-    //     decode-and-discard pass implied by accurate_seek (the default),
-    //     leaving internal PTS = 0 at exact source time preSeek for both
-    //     streams.
-    //  2. `-ss postSeek` after `-i` does an output seek that operates in
-    //     the decoded domain. Re-encoded audio is trimmed sample-accurately
-    //     (not packet-snapped) so its first sample lines up with the first
-    //     video frame at internal t = postSeek = source time T.
-    //  3. `-output_ts_offset preSeek` (placed AFTER `-i` — it's an
-    //     OPT_OUTPUT option per FFmpeg, see fftools/ffmpeg_opt.c) shifts
-    //     the muxer-side PTS so the first emitted PTS = postSeek +
-    //     preSeek = T, matching the playlist's expected tfdt for seg-K.
-    //     Placed before `-i` it lives in the input option group and can
-    //     get silently dropped or re-shifted by the muxer's
-    //     `avoid_negative_ts auto`, causing a PRE_SEEK_MARGIN_SECONDS
-    //     overlap with the previous segment (= a 2 s video repeat at
-    //     every rotation seam on Chromecast).
-    //
-    // Cost: PRE_SEEK_MARGIN_SECONDS of extra HW/CPU decode every
-    // SEGMENT_ROTATION_INTERVAL_SECONDS — negligible.
-    args.push('-ss', String(preSeek));
+    // Single input-seek to T. The demuxer snaps each stream to its own
+    // frame boundary ≤ T (≤ 21 ms for AAC, 32 ms for AC-3, 40 ms for
+    // DTS); `-copyts` (set after `-i` below) threads the source PTS
+    // straight through to the muxer so the first emitted segment's
+    // tfdt = seekSeconds × timescale and the player picks up the
+    // playlist boundary cleanly.
+    args.push('-ss', String(seekSeconds));
   }
 
   // parseBitrateToBps handles both "8M" and "200k" correctly. Using parseInt()*1e6
@@ -201,13 +183,15 @@ export function buildFfmpegArgs(
       : 'ultrafast'
     : encoderPreset;
   const earlyNvencPreset = early ? 'p1' : 'p4';
-  // QSV rate-control: stock = 2x init / 4x bufsize. Early = 0.5x / 1x so the
-  // encoder doesn't hold back frames waiting for the buffer to pre-fill.
+  // QSV rate-control: tight VBV (bufsize = bitrate × 1) so the BRC has a
+  // short horizon and can't defer big I-frames. Early uses 0.5× / 1× so
+  // the encoder doesn't hold back frames waiting for the buffer to fill.
+  // Recommended by Intel media-delivery quality.rst for HLS streaming.
   const qsvRcInitOccupancy = Math.max(
     1,
-    early ? Math.round(bitrateNum * 0.5) : bitrateNum * 2,
+    early ? Math.round(bitrateNum * 0.5) : bitrateNum,
   );
-  const qsvBufsize = early ? bitrateNum : bitrateNum * 4;
+  const qsvBufsize = bitrateNum;
   // libx264 -bufsize is expressed in Mbits. Stock = 2x bitrate, early = 1x.
   const libx264BufsizeMb = `${Math.max(1, parseInt(profile.videoBitrate) * (early ? 1 : 2))}M`;
 
@@ -266,30 +250,16 @@ export function buildFfmpegArgs(
   args.push('-i', inputPath);
 
   if (startSegment > 0) {
-    // Output-seek companion to the input-seek above; trims the decoded
-    // PRE_SEEK_MARGIN_SECONDS prelude on the video side (the AAC encoder
-    // ignores this on the audio side — see the `-af atrim` below).
-    // `-output_ts_offset` is also placed here (after `-i`) because it's
-    // an OPT_OUTPUT option in FFmpeg — see the comment block above.
-    if (postSeek > 0) {
-      args.push('-ss', String(postSeek));
-      // Sample-accurate audio trim. `-ss` after `-i` does NOT reliably
-      // drop the pre-seek prelude for an AAC / AC-3 / EAC-3 re-encode:
-      // the encoder receives the full decoded stream starting at the
-      // input-seek point (internal_t = 0) and emits packets from
-      // PTS = 0, which after `output_ts_offset = preSeek` lands at
-      // tfdt = preSeek instead of preSeek + postSeek. On a Chromecast
-      // (which doesn't honour fMP4 `edts/elst` for priming) that
-      // surfaces as the new segment overlapping the previous one's
-      // last PRE_SEEK_MARGIN_SECONDS of audio — a 2 s "echo" at every
-      // rotation seam. `atrim` runs in the filter graph (before the
-      // encoder), so the prelude is dropped sample-accurately; we
-      // intentionally skip `asetpts` so the first kept sample keeps
-      // PTS = postSeek and `output_ts_offset` lifts it to the
-      // expected boundary.
-      args.push('-af', `atrim=start=${postSeek}`);
-    }
-    args.push('-output_ts_offset', String(preSeek));
+    // Seek-resume timestamp wiring (see docs/streaming/encoder-stability.md):
+    //  - `-copyts` keeps source PTS end-to-end → tfdt = seekSeconds.
+    //  - `-muxdelay/-muxpreload 0` stops the fmp4 muxer from inserting
+    //    a priming edit list when CTS offsets show up on the IDR.
+    //  - `-ss seekSeconds` after `-i` drops decoded video frames before
+    //    seekSeconds, so the encoder's mandatory first IDR lands at T
+    //    instead of on the source keyframe ≤ T. Audio keeps its
+    //    ±21–40 ms packet-snap drift (intrinsic to demuxer seek).
+    args.push('-copyts', '-muxdelay', '0', '-muxpreload', '0');
+    args.push('-ss', String(seekSeconds));
   }
 
   // Video encoding
@@ -559,31 +529,22 @@ export function buildAudioOnlyFfmpegArgs(
     args.push('-analyzeduration', '1000000', '-probesize', '1000000');
   }
 
-  // Hybrid seek (same rationale as buildFfmpegArgs): input-seek for the
-  // fast IDR snap, output-seek for sample-accurate trim. Keeps this
-  // audio rendition aligned with the video output across encoder respawns.
-  const PRE_SEEK_MARGIN_SECONDS = 2;
+  // Single input-seek to T + `-copyts` to propagate source PTS straight
+  // through to the muxer (tfdt = T × timescale). See `buildFfmpegArgs`
+  // for the long explanation of why the previous
+  // `-avoid_negative_ts make_zero` + `-output_ts_offset` pair zeroed
+  // tfdt instead of lifting it.
   const seekSeconds = startSegment > 0 ? segmentIndexToSeconds(startSegment) : 0;
-  const preSeek = Math.max(0, seekSeconds - PRE_SEEK_MARGIN_SECONDS);
-  const postSeek = seekSeconds - preSeek;
 
   if (startSegment > 0) {
-    args.push('-ss', String(preSeek));
+    args.push('-ss', String(seekSeconds));
   }
 
   args.push('-i', inputPath);
 
   if (startSegment > 0) {
-    // `-ss postSeek` + `-output_ts_offset preSeek` placed after `-i` —
-    // both are OPT_OUTPUT options. `atrim` runs in the audio filter
-    // graph and is what actually drops the pre-seek prelude before
-    // the AAC encoder sees it — `-ss` post-`-i` is unreliable here
-    // (see the comment block in `buildFfmpegArgs`).
-    if (postSeek > 0) {
-      args.push('-ss', String(postSeek));
-      args.push('-af', `atrim=start=${postSeek}`);
-    }
-    args.push('-output_ts_offset', String(preSeek));
+    args.push('-copyts', '-muxdelay', '0', '-muxpreload', '0');
+    args.push('-ss', String(seekSeconds));
   }
 
   args.push('-map', `0:a:${audioStreamIndex}`);
@@ -633,14 +594,24 @@ export function buildRemuxArgs(
     args.push('-analyzeduration', '1000000', '-probesize', '1000000');
   }
 
+  const remuxSeekSeconds =
+    startSegment > 0 ? segmentIndexToSeconds(startSegment) : 0;
   if (startSegment > 0) {
-    const seekSeconds = segmentIndexToSeconds(startSegment);
-    args.push('-ss', String(seekSeconds));
-    args.push('-output_ts_offset', String(seekSeconds));
-    args.push('-avoid_negative_ts', 'make_zero');
+    args.push('-ss', String(remuxSeekSeconds));
   }
 
   args.push('-i', inputPath);
+
+  if (startSegment > 0) {
+    // Same `-copyts` pattern as the transcode path: propagate source
+    // PTS through to the muxer so seg-N's tfdt = seekSeconds, instead
+    // of the previous `output_ts_offset + avoid_negative_ts make_zero`
+    // pair that cancelled to tfdt = 0. The output-seek `-ss` after
+    // `-i` drops decoded frames < seekSeconds (HW-decode + copy paths
+    // need it).
+    args.push('-copyts', '-muxdelay', '0', '-muxpreload', '0');
+    args.push('-ss', String(remuxSeekSeconds));
+  }
 
   const userPickedAudio = audioStreamIndex != null && audioStreamIndex > 0;
   if (videoOnly && !userPickedAudio) {

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -14,7 +14,6 @@ import {
   MAX_SESSIONS,
   SEEK_WAIT_THRESHOLD,
   SESSION_TIMEOUT_MS,
-  getRotationSegmentThreshold,
   getSegmentDuration,
   segmentIndexToSeconds,
   setSegmentDurations as applySegmentDurations,
@@ -700,8 +699,6 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     const firstSegName = path.basename(firstSeg);
 
     let readyWatcher: FSWatcher | null = null;
-    let segmentWatcher: FSWatcher | null = null;
-    const segmentNameRe = new RegExp(`^seg-\\d+\\${segExt}$`);
     const checkReady = () => {
       if (!resolved && existsSync(firstSeg)) {
         resolved = true;
@@ -720,40 +717,6 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
           if (filename === firstSegName) checkReady();
         },
       );
-      // Persistent watcher: count every segment written so we can rotate
-      // the encoder before its BRC accumulates state across the periodic-
-      // bad-GOP threshold. Skipped for audio-only and remux sessions
-      // (only the QSV main encoder hits the BRC drift).
-      const isMainTranscode =
-        !extra?.remux && !extra?.isAudioOnly && !id.endsWith('-early');
-      if (isMainTranscode) {
-        // inotify emits both `rename` (create) and `change` (every write/
-        // close while ffmpeg streams the moof+mdat) for the same file, so
-        // counting raw events inflates `segmentsProduced` ~3-5×. Track
-        // unique filenames instead so the rotation threshold maps to real
-        // segments produced.
-        const seenSegments = new Set<string>();
-        segmentWatcher = watch(
-          segDir,
-          { persistent: false },
-          (_event, filename) => {
-            if (typeof filename !== 'string' || !segmentNameRe.test(filename)) {
-              return;
-            }
-            if (seenSegments.has(filename)) return;
-            seenSegments.add(filename);
-            session.segmentsProduced = seenSegments.size;
-            if (
-              session.segmentsProduced >= getRotationSegmentThreshold() &&
-              !session.rotationScheduled &&
-              !session.intentionallyKilled
-            ) {
-              session.rotationScheduled = true;
-              void this.rotateSession(session);
-            }
-          },
-        );
-      }
     } catch {
       // Directory will be created by ffmpeg shortly — pollTimer covers this.
     }
@@ -770,7 +733,6 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     proc.on('close', (code) => {
       clearInterval(pollTimer);
       readyWatcher?.close();
-      segmentWatcher?.close();
       const firstSegProduced = resolved;
       if (!resolved) {
         resolved = true;
@@ -860,9 +822,6 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       segSubDir: usesVarStreamMap ? '0' : undefined,
       extra: {
         actualHwAccel: hwAccel,
-        // Stored for the rotation worker; see SEGMENT_ROTATION_INTERVAL_SECONDS.
-        absolutePath,
-        ctx,
       },
     });
     return session;
@@ -1144,57 +1103,6 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     return session;
   }
 
-  /** Kill the current ffmpeg cleanly and respawn at the next un-encoded
-   *  segment so the encoder's BRC state is reset. Triggered from the
-   *  per-segment fs watcher once `segmentsProduced` crosses
-   *  the rotation segment threshold. The rotation runs under the same
-   *  per-key lock as `getOrCreateSession`, so a player request that
-   *  arrives mid-rotation queues behind it and gets the new session. */
-  private async rotateSession(session: TranscodeSession): Promise<void> {
-    const id = session.id;
-    return this.withLock(id, async () => {
-      // The session might have been replaced (seek, quality change) or
-      // already rotated by a concurrent caller — bail if so.
-      if (this.sessions.get(id) !== session) return;
-      if (!session.absolutePath || !session.ctx) {
-        this.log.warn(`[rotate] ${id}: missing absolutePath/ctx, skipping`);
-        return;
-      }
-      const produced = session.segmentsProduced ?? 0;
-      const newStart = (session.startSegment ?? 0) + produced;
-      this.log.log(
-        `[rotate] ${id}: produced ${produced} segments since seg-${session.startSegment ?? 0}, restarting at seg-${newStart}`,
-      );
-
-      // Graceful (SIGTERM → SIGKILL after 5 s) so ffmpeg flushes its
-      // moof+mdat for the in-flight segment cleanly. The cache stays
-      // intact (resolveExistingSession only wipes on non-zero exit).
-      session.intentionallyKilled = true;
-      this.sessions.delete(id);
-      await this.killProcess(session.process, /* graceful */ true);
-
-      // Re-derive the profile from quality (same code path as the
-      // initial spawn) so any change to the ladder takes effect on
-      // rotation as well.
-      const ladder = getLadderForDevice(session.ctx.deviceType);
-      const profile =
-        ladder.find((p) => p.name === session.quality) ?? ladder[0];
-
-      const next = this.startFfmpeg(
-        id,
-        session.mediaFileId,
-        session.quality,
-        session.absolutePath,
-        profile,
-        session.cachePath,
-        session.actualHwAccel ?? this.detectedHwAccel,
-        newStart,
-        session.ctx,
-      );
-      this.applyContext(next, session.ctx);
-      this.sessions.set(id, next);
-    });
-  }
 
   private cleanupStaleSessions() {
     const now = Date.now();

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -135,21 +135,4 @@ export interface TranscodeSession {
    *  change, etc.) so the close handler doesn't log a spurious "exited
    *  WITHOUT producing first segment" warning. */
   intentionallyKilled?: boolean;
-  /** Original input path — kept on the session so the rotation worker
-   *  can re-spawn ffmpeg without re-resolving the media file. */
-  absolutePath?: string;
-  /** Spawn-time SessionContext — kept on the session so the rotation
-   *  worker can re-spawn with the same audio map / tonemap / crop. */
-  ctx?: SessionContext;
-  /** Number of segments the current ffmpeg has written since spawn.
-   *  Driven by the post-write fs watcher. Used to schedule a periodic
-   *  kill+respawn (see `SEGMENT_ROTATION_INTERVAL_SECONDS`) — QSV's BRC
-   *  accumulates state over long runs and eventually emits a 45 s GOP
-   *  that overruns the playlist's EXTINF slot; rotating every ~10 min
-   *  of content resets the encoder before that drift hits. */
-  segmentsProduced?: number;
-  /** Set true once a rotation has been scheduled for this session, so
-   *  subsequent segment writes don't re-fire the rotation logic while
-   *  the previous one is still draining. */
-  rotationScheduled?: boolean;
 }


### PR DESCRIPTION
## Summary
Two distinct transcode bugs, both fixed with config-only changes, plus removal of the kill+respawn ("rotation") workaround that masked the first one at the cost of seam glitches at every rotation boundary.

### Issue 1 — h264_qsv emitting 45 s GOPs after ~17 min
Root cause: adaptive scene-cut placement was racing with our \`force_key_frames\` cadence and the SDK demoted some forced instants to plain I-frames; HLS muxer waited for an IDR and pooled samples until one finally showed up ([Intel-Media-SDK#2776](https://github.com/Intel-Media-SDK/MediaSDK/issues/2776), [jellyfin-ffmpeg#413](https://github.com/jellyfin/jellyfin-ffmpeg/issues/413)).

Fix: closed-GOP h264_qsv with deterministic IDR placement — \`-forced_idr 1 -adaptive_i 0 -bf 0 -b_strategy 0\` and tight VBV (\`bufsize = bitrate\`, was 4×). Validated past the 16-min mark on a 432-segment dump with no anomalous segment sizes.

### Issue 2 — A/V seam after a user seek to T
Root cause: VAAPI decode + \`accurate_seek\` doesn't reliably drop frames before T on hardware surfaces, so the encoder's mandatory first IDR landed on the source keyframe ≤ T instead of T, leaving video tfdt several seconds behind audio tfdt.

Fix: \`-ss T -i input -copyts -muxdelay 0 -muxpreload 0 -ss T\` plus \`force_key_frames\` anchored at T. The first \`-ss\` is the demuxer seek to the keyframe ≤ T; \`-copyts\` keeps source PTS end-to-end (tfdt = T); the second \`-ss\` operates in source-time and drops decoded frames before they reach the encoder. Audio keeps its bounded ±21–40 ms packet-snap drift (intrinsic to demuxer seek; sample-accurate trim via \`-af atrim\` is incompatible with \`-c:a copy\`). Same pattern applied in \`buildFfmpegArgs\`, \`buildAudioOnlyFfmpegArgs\` and \`buildRemuxArgs\`.

### Cleanup
- Removed \`rotateSession\`, the segment watcher that fed it, \`segmentsProduced\` / \`rotationScheduled\` / \`absolutePath\` / \`ctx\` on \`TranscodeSession\` (only used by the rotation worker), and \`SEGMENT_ROTATION_INTERVAL_SECONDS\` / \`getRotationSegmentThreshold\`.
- Stripped bug-history narratives from source comments. The remaining comments describe what the current code does, with a pointer to the new \`backend/docs/streaming/encoder-stability.md\` for the full rationale + a fallback ladder (CBR → max_frame_size → ICQ → CQP → h264_vaapi).
- \`.gitignore\`: scoped \`docs/\` to root so \`backend/docs/\` ships with the repo.

## Test plan
- [x] Backend \`npx tsc --noEmit\` clean
- [x] Encoder stable past the 16-min mark — sampled segments around the 16:40 boundary (\`seg-0330\` … \`seg-0345\`) all at ~1.2 MB, no anomaly
- [x] Seek-resume on Android: A/V aligned at the resume point (verified by the user)
- [ ] Long playback (1 h+) on Cast + Android to confirm no regression at any boundary