### PR TITLE
fix(transcode): preserve source PTS on every spawn, drop hls_init_time

### DIFF
--- a/backend/src/modules/streaming/active-stream-tracker.service.ts
+++ b/backend/src/modules/streaming/active-stream-tracker.service.ts
@@ -151,18 +151,13 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
   }
 
   private segmentDurationCache = 3;
-  private initTimeCache = 1;
 
-  setStreamingDurations(segDuration: number, initTime: number) {
+  setStreamingDuration(segDuration: number) {
     this.segmentDurationCache = segDuration;
-    this.initTimeCache = initTime;
   }
 
   getSegmentDuration(): number {
     return this.segmentDurationCache;
-  }
-  getInitTime(): number {
-    return this.initTimeCache;
   }
 
   setAudioStreamIndex(mediaFileId: number, index: number | undefined) {

--- a/backend/src/modules/streaming/streaming-settings-cache.service.ts
+++ b/backend/src/modules/streaming/streaming-settings-cache.service.ts
@@ -3,7 +3,6 @@ import { SettingsService } from '../settings/settings.service';
 
 export interface StreamingSettings {
   segmentDuration: number;
-  initTime: number;
   qsvPreset:
     | 'veryfast'
     | 'faster'
@@ -17,7 +16,6 @@ export interface StreamingSettings {
 
 const KEYS = [
   'streaming_segment_duration',
-  'streaming_init_time',
   'streaming_qsv_preset',
   'streaming_qsv_low_power',
 ] as const;
@@ -51,10 +49,9 @@ export class StreamingSettingsCache implements OnModuleInit {
 
   private async load(): Promise<StreamingSettings> {
     const values = await Promise.all(KEYS.map((k) => this.settings.get(k)));
-    const [duration, initTime, qsvPreset, qsvLowPower] = values;
+    const [duration, qsvPreset, qsvLowPower] = values;
     return {
       segmentDuration: parseFloat(duration ?? '3') || 3,
-      initTime: parseFloat(initTime ?? '1') || 1,
       qsvPreset: (qsvPreset ?? 'faster') as StreamingSettings['qsvPreset'],
       qsvLowPower: qsvLowPower === 'true',
     };

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -52,10 +52,8 @@ function withTimestampMap(vtt: string | Buffer): string {
   return text.replace(/^(WEBVTT[^\n]*)\n/, `$1\n${VTT_TIMESTAMP_MAP}\n`);
 }
 
-/** Generate a VOD HLS playlist for a given duration and segment URL pattern. */
-/** Default segment + init durations — overridden by admin streaming settings. */
+/** Default segment duration — overridden by admin streaming settings. */
 let SEG_DURATION = 3;
-let INIT_TIME = 1;
 
 /** Pick the right HLS segment Content-Type. fMP4 (.m4s / .mp4) → video/mp4,
  *  MPEG-TS (.ts, used for Chromecast sessions) → video/MP2T. */
@@ -63,23 +61,24 @@ function segmentContentType(segment: string): string {
   return segment.endsWith('.ts') ? 'video/MP2T' : 'video/mp4';
 }
 
+/** Generate a VOD HLS playlist for a given duration and segment URL pattern.
+ *  Uniform segment grid: each segment is SEG_DURATION seconds, seg-N covers
+ *  `[N*SEG, (N+1)*SEG)`. The EXTINF values mirror what FFmpeg actually emits
+ *  so Shaka's presentation timeline stays aligned with the moof PTS the
+ *  segments carry. */
 function buildVodPlaylist(
   duration: number,
   segmentUrl: (index: string) => string,
   initUrl?: string,
 ): string {
-  // FFmpeg `-hls_init_time` shortens segment 0 to ~INIT_TIME so the first
-  // frame ships sooner; remaining segments are SEG_DURATION. The EXTINF
-  // values below mirror that layout so Shaka's presentation timeline stays
-  // aligned with the moof PTS the segments actually carry.
-  const useShortInit = INIT_TIME > 0 && INIT_TIME < SEG_DURATION;
   // Subtract small epsilon before ceil to avoid phantom last segment when
   // ffprobe duration has floating-point imprecision (e.g. 120.001 → ceil
   // produces 41 segments but FFmpeg only writes 40).
   const epsilon = 0.05;
-  const tail = Math.max(0, duration - (useShortInit ? INIT_TIME : 0) - epsilon);
-  const tailCount = Math.ceil(tail / SEG_DURATION);
-  const segCount = Math.max(1, (useShortInit ? 1 : 0) + tailCount);
+  const segCount = Math.max(
+    1,
+    Math.ceil(Math.max(0, duration - epsilon) / SEG_DURATION),
+  );
   const lines = [
     '#EXTM3U',
     '#EXT-X-VERSION:7',
@@ -92,20 +91,8 @@ function buildVodPlaylist(
     lines.push(`#EXT-X-MAP:URI="${initUrl}"`);
   }
   for (let i = 0; i < segCount; i++) {
-    let segStart: number;
-    let segLen: number;
-    if (useShortInit) {
-      if (i === 0) {
-        segStart = 0;
-        segLen = Math.min(INIT_TIME, duration);
-      } else {
-        segStart = INIT_TIME + (i - 1) * SEG_DURATION;
-        segLen = Math.min(SEG_DURATION, duration - segStart);
-      }
-    } else {
-      segStart = i * SEG_DURATION;
-      segLen = Math.min(SEG_DURATION, duration - segStart);
-    }
+    const segStart = i * SEG_DURATION;
+    const segLen = Math.min(SEG_DURATION, duration - segStart);
     if (segLen <= 0) break;
     lines.push(`#EXTINF:${segLen.toFixed(3)},`);
     lines.push(segmentUrl(String(i).padStart(4, '0')));
@@ -439,17 +426,10 @@ export class StreamingController {
       mediaFileId,
       !!deviceProfile.useTs,
     );
-    this.activeStreamTracker.setStreamingDurations(
-      ss.segmentDuration,
-      ss.initTime,
-    );
+    this.activeStreamTracker.setStreamingDuration(ss.segmentDuration);
     // Update module-level constants used by buildVodPlaylist and transcoding
     SEG_DURATION = ss.segmentDuration;
-    INIT_TIME = ss.initTime;
-    this.transcodingService.setSegmentDurations(
-      ss.segmentDuration,
-      ss.initTime,
-    );
+    this.transcodingService.setSegmentDuration(ss.segmentDuration);
 
     // Persist encoder preset + QSV advanced options for downstream sessions.
     this.activeStreamTracker.setEncoderPreset(mediaFileId, ss.qsvPreset);

--- a/backend/src/modules/streaming/transcoding/constants.ts
+++ b/backend/src/modules/streaming/transcoding/constants.ts
@@ -3,49 +3,29 @@ export const MAX_SESSIONS = 4;
 /** Max gap (in segments) between FFmpeg frontier and requested segment before restarting. */
 export const SEEK_WAIT_THRESHOLD = 15;
 
-/** Mutable runtime state for HLS segment durations. Updated from admin
- *  streaming settings via `setSegmentDurations()`. Read by FFmpeg arg
+/** Mutable runtime state for HLS segment duration. Updated from admin
+ *  streaming settings via `setSegmentDuration()`. Read by FFmpeg arg
  *  builders and the session manager. */
 let segmentDuration = 3;
-let initTime = 1;
 
 export function getSegmentDuration(): number {
   return segmentDuration;
 }
 
-export function getInitTime(): number {
-  return initTime;
-}
-
-export function setSegmentDurations(seg: number, init: number): void {
+export function setSegmentDuration(seg: number): void {
   segmentDuration = seg;
-  initTime = init;
 }
 
-/** True when `-hls_init_time` actually shortens segment 0 (FFmpeg ignores it
- *  when init >= segment duration). */
-export function useShortInitSegment(
-  init = initTime,
-  seg = segmentDuration,
-): boolean {
-  return init > 0 && init < seg;
-}
-
-/** Convert a presentation time (seconds) to the FFmpeg segment number that
- *  contains it. Mirrors `-hls_init_time`: seg-0 holds [0, INIT_TIME],
- *  seg-N>=1 holds [INIT_TIME + (N-1)*SEG, INIT_TIME + N*SEG]. */
+/** Convert a presentation time (seconds) to the FFmpeg segment number
+ *  that contains it. Uniform grid: every segment is `segmentDuration`
+ *  long, seg-N covers `[N*SEG, (N+1)*SEG)`. */
 export function secondsToSegmentIndex(seconds: number): number {
   if (seconds <= 0) return 0;
-  if (!useShortInitSegment()) {
-    return Math.floor(seconds / segmentDuration);
-  }
-  if (seconds < initTime) return 0;
-  return 1 + Math.floor((seconds - initTime) / segmentDuration);
+  return Math.floor(seconds / segmentDuration);
 }
 
 /** Inverse of `secondsToSegmentIndex` — start time of an FFmpeg segment. */
 export function segmentIndexToSeconds(segment: number): number {
   if (segment <= 0) return 0;
-  if (!useShortInitSegment()) return segment * segmentDuration;
-  return initTime + (segment - 1) * segmentDuration;
+  return segment * segmentDuration;
 }

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -1,7 +1,6 @@
 import { Logger } from '@nestjs/common';
 import * as path from 'path';
 import {
-  getInitTime,
   getSegmentDuration,
   segmentIndexToSeconds,
 } from './constants';
@@ -82,7 +81,6 @@ export function buildFfmpegArgs(
   const segExt = useTs ? 'ts' : 'm4s';
 
   const SEGMENT_DURATION = getSegmentDuration();
-  const INIT_TIME = getInitTime();
 
   // Audio output args derived from the stream-builder decision. No
   // re-derivation here — we just emit what we were told. Safe fallback to
@@ -107,16 +105,11 @@ export function buildFfmpegArgs(
   // to the muxer so the first segment lands at tfdt = T × timescale.
   const seekSeconds = startSegment > 0 ? segmentIndexToSeconds(startSegment) : 0;
 
-  // Keyframes at: 0, INIT_TIME, INIT_TIME+SEG, INIT_TIME+2*SEG, …
-  // Lets `-hls_init_time` actually cut segment 0 short (needs a keyframe
-  // at INIT_TIME); collapses to a regular fixed-GOP cadence when
-  // INIT_TIME ≥ SEGMENT_DURATION. On a seek-resume we use `-copyts` so
-  // the encoder's `t` is in source time — the expression anchors at
-  // `seekSeconds` and IDRs land on the same grid the HLS muxer expects.
-  const forceKeyframesExpr =
-    startSegment > 0
-      ? `expr:gte(t,${seekSeconds}+n_forced*${SEGMENT_DURATION})`
-      : `expr:if(eq(n_forced,0),gte(t,0),gte(t,${INIT_TIME}+(n_forced-1)*${SEGMENT_DURATION}))`;
+  // Force an IDR every `SEGMENT_DURATION` seconds so the HLS muxer can
+  // cut segments on a uniform grid. On a seek-resume we use `-copyts`
+  // so the encoder's `t` is in source time — the expression anchors at
+  // `seekSeconds` and IDRs land on the same grid as before the seek.
+  const forceKeyframesExpr = `expr:gte(t,${seekSeconds}+n_forced*${SEGMENT_DURATION})`;
   // Closed-GOP, deterministic IDR placement on h264_qsv:
   //  - `-forced_idr 1` : every `force_key_frames` tick lands as a real
   //    IDR (without it, qsvenc emits some as plain I, breaking HLS
@@ -249,16 +242,24 @@ export function buildFfmpegArgs(
 
   args.push('-i', inputPath);
 
+  // Preserve source PTS end-to-end on every spawn (see
+  // docs/streaming/encoder-stability.md). Required so subtitle cues —
+  // timed in source PTS by external sidecar / extraction — line up
+  // with the muxed segments; without it the fmp4 muxer's default
+  // `avoid_negative_ts auto` shifts the timeline whenever the source
+  // has an audio `start_time` offset (common on MKV to compensate
+  // for codec priming), breaking subtitle alignment and creating
+  // hard-to-track A/V skew on some receivers.
+  args.push('-copyts', '-muxdelay', '0', '-muxpreload', '0');
+
   if (startSegment > 0) {
-    // Seek-resume timestamp wiring (see docs/streaming/encoder-stability.md):
-    //  - `-copyts` keeps source PTS end-to-end → tfdt = seekSeconds.
-    //  - `-muxdelay/-muxpreload 0` stops the fmp4 muxer from inserting
-    //    a priming edit list when CTS offsets show up on the IDR.
-    //  - `-ss seekSeconds` after `-i` drops decoded video frames before
-    //    seekSeconds, so the encoder's mandatory first IDR lands at T
-    //    instead of on the source keyframe ≤ T. Audio keeps its
-    //    ±21–40 ms packet-snap drift (intrinsic to demuxer seek).
-    args.push('-copyts', '-muxdelay', '0', '-muxpreload', '0');
+    // Output-seek after `-i`: with `-copyts` it operates in source-time
+    // and drops decoded video frames before `seekSeconds`, so the
+    // encoder's mandatory first IDR lands at T instead of on the
+    // source keyframe ≤ T (the HW-decode path's `accurate_seek`
+    // discard pass doesn't always trim frames on VAAPI surfaces).
+    // Audio keeps its ±21–40 ms packet-snap drift (intrinsic to
+    // demuxer seek on a packetised stream).
     args.push('-ss', String(seekSeconds));
   }
 
@@ -457,7 +458,6 @@ export function buildFfmpegArgs(
     args.push(
       '-f', 'hls',
       '-hls_time', String(SEGMENT_DURATION),
-      '-hls_init_time', String(INIT_TIME),
       '-hls_list_size', '0',
       '-start_number', String(startSegment),
       '-hls_segment_type', segType,
@@ -485,7 +485,6 @@ export function buildFfmpegArgs(
     args.push(
       '-f', 'hls',
       '-hls_time', String(SEGMENT_DURATION),
-      '-hls_init_time', String(INIT_TIME),
       '-hls_list_size', '0',
       '-start_number', String(startSegment),
       '-hls_segment_type', segType,
@@ -516,7 +515,6 @@ export function buildAudioOnlyFfmpegArgs(
   const segType = useTs ? 'mpegts' : 'fmp4';
   const segExt = useTs ? 'ts' : 'm4s';
   const SEGMENT_DURATION = getSegmentDuration();
-  const INIT_TIME = getInitTime();
 
   const args = ['-hide_banner', '-loglevel', 'warning'];
   if (trustedStreamInfo) {
@@ -529,11 +527,6 @@ export function buildAudioOnlyFfmpegArgs(
     args.push('-analyzeduration', '1000000', '-probesize', '1000000');
   }
 
-  // Single input-seek to T + `-copyts` to propagate source PTS straight
-  // through to the muxer (tfdt = T × timescale). See `buildFfmpegArgs`
-  // for the long explanation of why the previous
-  // `-avoid_negative_ts make_zero` + `-output_ts_offset` pair zeroed
-  // tfdt instead of lifting it.
   const seekSeconds = startSegment > 0 ? segmentIndexToSeconds(startSegment) : 0;
 
   if (startSegment > 0) {
@@ -542,8 +535,12 @@ export function buildAudioOnlyFfmpegArgs(
 
   args.push('-i', inputPath);
 
+  // Preserve source PTS end-to-end on every spawn (see
+  // `buildFfmpegArgs` for the full rationale) so audio renditions stay
+  // anchored to the same timeline as the main video output.
+  args.push('-copyts', '-muxdelay', '0', '-muxpreload', '0');
+
   if (startSegment > 0) {
-    args.push('-copyts', '-muxdelay', '0', '-muxpreload', '0');
     args.push('-ss', String(seekSeconds));
   }
 
@@ -554,7 +551,6 @@ export function buildAudioOnlyFfmpegArgs(
   args.push(
     '-f', 'hls',
     '-hls_time', String(SEGMENT_DURATION),
-    '-hls_init_time', String(INIT_TIME),
     '-hls_list_size', '0',
     '-start_number', String(startSegment),
     '-hls_segment_type', segType,
@@ -583,7 +579,6 @@ export function buildRemuxArgs(
   log?: Logger,
 ): string[] {
   const SEGMENT_DURATION = getSegmentDuration();
-  const INIT_TIME = getInitTime();
 
   const args = ['-hide_banner', '-loglevel', 'warning'];
   if (trustedStreamInfo) {
@@ -602,14 +597,13 @@ export function buildRemuxArgs(
 
   args.push('-i', inputPath);
 
+  // Preserve source PTS end-to-end on every spawn (see
+  // `buildFfmpegArgs` for the full rationale).
+  args.push('-copyts', '-muxdelay', '0', '-muxpreload', '0');
+
   if (startSegment > 0) {
-    // Same `-copyts` pattern as the transcode path: propagate source
-    // PTS through to the muxer so seg-N's tfdt = seekSeconds, instead
-    // of the previous `output_ts_offset + avoid_negative_ts make_zero`
-    // pair that cancelled to tfdt = 0. The output-seek `-ss` after
-    // `-i` drops decoded frames < seekSeconds (HW-decode + copy paths
-    // need it).
-    args.push('-copyts', '-muxdelay', '0', '-muxpreload', '0');
+    // Output-seek after `-i`: drops decoded frames < seekSeconds with
+    // `-copyts` operating in source-time.
     args.push('-ss', String(remuxSeekSeconds));
   }
 
@@ -636,7 +630,6 @@ export function buildRemuxArgs(
   args.push(
     '-f', 'hls',
     '-hls_time', String(SEGMENT_DURATION),
-    '-hls_init_time', String(INIT_TIME),
     '-hls_list_size', '0',
     '-start_number', String(startSegment),
     '-hls_segment_type', 'fmp4',

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -16,7 +16,7 @@ import {
   SESSION_TIMEOUT_MS,
   getSegmentDuration,
   segmentIndexToSeconds,
-  setSegmentDurations as applySegmentDurations,
+  setSegmentDuration as applySegmentDuration,
 } from './constants';
 import { getLadderForDevice } from './profiles';
 import {
@@ -113,9 +113,9 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     return this.detectedHwAccel;
   }
 
-  /** Update segment durations from admin streaming settings. */
-  setSegmentDurations(segDuration: number, initTime: number) {
-    applySegmentDurations(segDuration, initTime);
+  /** Update segment duration from admin streaming settings. */
+  setSegmentDuration(segDuration: number) {
+    applySegmentDuration(segDuration);
   }
 
   getSegmentDuration(): number {

--- a/client/src/app/features/settings/streaming/streaming.html
+++ b/client/src/app/features/settings/streaming/streaming.html
@@ -17,21 +17,6 @@
       <label class="label"><span class="label-text-alt text-base-content/50">{{ 'settings.streaming.segment_duration_help' | translate }}</span></label>
     </div>
 
-    <!-- Init time -->
-    <div class="form-control">
-      <label class="label"><span class="label-text font-medium">{{ 'settings.streaming.init_time' | translate }}</span></label>
-      <select class="select select-bordered w-full" [ngModel]="initTime()" (ngModelChange)="initTime.set($event)">
-        <option value="0.5">0.5s</option>
-        <option value="1">1s</option>
-        <option value="2">2s</option>
-        <option value="3">3s</option>
-        <option value="4">4s</option>
-        <option value="5">5s</option>
-        <option value="6">6s</option>
-      </select>
-      <label class="label"><span class="label-text-alt text-base-content/50">{{ 'settings.streaming.init_time_help' | translate }}</span></label>
-    </div>
-
     <!-- QSV / libx264 encoder preset -->
     <div class="form-control">
       <label class="label"><span class="label-text font-medium">{{ 'settings.streaming.qsv_preset' | translate }}</span></label>

--- a/client/src/app/features/settings/streaming/streaming.ts
+++ b/client/src/app/features/settings/streaming/streaming.ts
@@ -19,7 +19,6 @@ export class StreamingSettingsComponent implements OnInit {
   readonly saving = signal(false);
 
   readonly segmentDuration = signal('3');
-  readonly initTime = signal('1');
   readonly qsvPreset = signal('faster');
   readonly qsvLowPower = signal(false);
 
@@ -27,7 +26,6 @@ export class StreamingSettingsComponent implements OnInit {
     try {
       const all = await this.api.getAll();
       this.segmentDuration.set(all['streaming_segment_duration'] ?? '3');
-      this.initTime.set(all['streaming_init_time'] ?? '1');
       this.qsvPreset.set(all['streaming_qsv_preset'] ?? 'faster');
       this.qsvLowPower.set(all['streaming_qsv_low_power'] === 'true');
     } catch { /* interceptor */ }
@@ -39,7 +37,6 @@ export class StreamingSettingsComponent implements OnInit {
     try {
       await this.api.setBulk({
         streaming_segment_duration: this.segmentDuration(),
-        streaming_init_time: this.initTime(),
         streaming_qsv_preset: this.qsvPreset(),
         streaming_qsv_low_power: String(this.qsvLowPower()),
       });


### PR DESCRIPTION
## Summary
Two related fixes for subtitle / A/V alignment when the player plays back from segments emitted by the initial encoder spawn (no seek).

### Source PTS preservation
\`-copyts -muxdelay 0 -muxpreload 0\` now runs on every FFmpeg invocation (initial spawn AND seek-resume), in all three builders. Without it the fmp4 muxer's default \`avoid_negative_ts auto\` shifted the timeline whenever the source had an audio \`start_time\` ≠ 0, leaving tfdt slightly offset from source-PTS. Subtitles — anchored to source-PTS via sidecar extraction — drifted from the muxed segments, and the Chromecast receiver amplified the same shift into a visible A/V skew.

### Drop hls_init_time + uniform segment grid
The "1 s short first segment" optimisation needed an IDR at \`t=1\`, which \`-keyint_min 72\` (= 3 s @ 24 fps) prevented the QSV encoder from emitting. The first cut slid to the next IDR at \`t=3\`, segments desynchronised from the playlist's EXTINF positions, and the tfdt of later segments ended up +3 s off from where the player expected — so subtitles, anchored to source-PTS, drifted by exactly 3 s (validated by mp4 box dump of a real session: video timescale 13978, audio 48000, both tracks 3 s late on every initial-spawn segment).

Removing the short init removes the fight: every segment is now \`segmentDuration\` seconds, \`force_key_frames\` collapses to a single \`expr:gte(t, seekSeconds + n_forced*SEG)\` branch, and tfdt lines up with source-PTS by construction.

### Trade-off
Cold-start is ~1-2 s slower on the first frame of a fresh session (segment 0 is now 3 s instead of 1 s). Imperceptible on LAN, mild on mobile — accepted in exchange for correct subtitle / A/V alignment without needing a seek-resume to "fix" the timeline.

## Files touched
- \`backend/.../transcoding/constants.ts\`: \`getInitTime\`, \`useShortInitSegment\`, \`initTime\` mutable state and \`setSegmentDurations(seg, init)\` all gone; \`setSegmentDuration(seg)\` is the new shape, segment grid uniform.
- \`backend/.../transcoding/ffmpeg-args.ts\`: \`-hls_init_time\` arg removed from the four builders, \`force_key_frames\` simplified, \`INIT_TIME\` references gone.
- \`backend/.../transcoding/transcoding.service.ts\`: \`setSegmentDurations\` → \`setSegmentDuration\`.
- \`backend/.../streaming.controller.ts\`: \`buildVodPlaylist\` rewritten as uniform grid (\`ceil(duration / SEG)\` segments, each \`EXTINF = SEG\`); module-level \`INIT_TIME\` removed.
- \`backend/.../streaming-settings-cache.service.ts\` + \`active-stream-tracker.service.ts\`: \`initTime\` field / \`streaming_init_time\` setting key removed.
- \`client/src/app/features/settings/streaming/streaming.{ts,html}\`: "Init time" field removed from the admin UI.

## Test plan
- [x] \`npx tsc --noEmit\` clean (backend) + \`ng build\` clean (client)
- [x] Pre-transcode a movie end-to-end, then play from start on Android — subtitles aligned throughout
- [ ] Same scenario on Chromecast — A/V aligned throughout
- [ ] Seek-resume still works (validated already by the user before this PR)
- [ ] Admin Streaming settings page no longer shows the "Init time" field