### PR TITLE
fix(player): hide controls by default on native + tighter mobile bottom bar

### DIFF
--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -109,15 +109,18 @@
 <div
   class="absolute bottom-0 left-0 right-0 z-40 bg-gradient-to-t from-black/80 via-black/40 to-transparent transition-opacity duration-300 pt-12
          [--ctrl-px:1rem] [--ctrl-pb:0.5rem]
-         sm:[--ctrl-px:2rem] sm:[--ctrl-pb:2.5rem]
+         sm:[--ctrl-px:2rem] sm:[--ctrl-pb:1rem]
          lg:[--ctrl-px:2.5rem] lg:[--ctrl-pb:1rem]"
   style="padding-left: max(var(--ctrl-px), env(safe-area-inset-left)); padding-right: max(var(--ctrl-px), env(safe-area-inset-right)); padding-bottom: max(var(--ctrl-pb), env(safe-area-inset-bottom));"
   [class.opacity-0]="!visible()"
   [class.pointer-events-none]="!visible()"
 >
-  <!-- Episode + Title + Mobile action buttons row -->
-  <div class="flex items-end justify-between mb-1.5 gap-2">
-    <div class="min-w-0 flex-1">
+  <!-- Episode + Title + Mobile action buttons row. The row itself emits
+       tapOverlay so the empty gap between the title and the right-aligned
+       action buttons doubles as a "close controls" hit zone; the buttons
+       stop propagation so their own taps don't also dismiss. -->
+  <div class="flex items-end justify-between mb-1.5 gap-2" (click)="tapOverlay.emit()">
+    <div class="min-w-0 shrink">
       @if (episodeTitle()) {
         <div class="text-white/60 font-semibold truncate text-base sm:text-lg">{{ episodeTitle() }}</div>
       }
@@ -126,7 +129,7 @@
 
     <!-- Mobile: action buttons aligned right -->
     @if (isMobileTouch()) {
-      <div class="flex items-center gap-0.5 shrink-0">
+      <div class="flex items-center gap-0.5 shrink-0" (click)="$event.stopPropagation()">
         @if (hasNextEpisode()) {
           <button type="button" class="btn btn-ghost btn-sm btn-circle text-white/80" (click)="nextEpisode.emit()">
             <svg lucideSkipForward class="h-5 w-5"></svg>

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -187,7 +187,12 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
   // Component-owned signals (not delegated)
   readonly playbackRate = signal(1);
-  readonly controlsVisible = signal(true);
+  /** Controls start visible on browser (pointer present, the user
+   *  expects to see the affordances immediately) and hidden on native
+   *  (touch / TV — the user taps / moves the remote to reveal them).
+   *  The auto-hide timer that runs during playback toggles this back
+   *  to false after inactivity regardless of the initial state. */
+  readonly controlsVisible = signal(!Capacitor.isNativePlatform());
   readonly inPipMode = signal(false);
   private readonly isLandscape = signal(screen.orientation?.type?.startsWith('landscape') ?? false);
   readonly statsVisible = signal(false);


### PR DESCRIPTION
## Summary
- Controls now start hidden on Capacitor native (touch/TV reveal on interaction) and visible on browser, where a pointer makes the affordances expected upfront.
- Bottom bar sits closer to the screen edge on phone landscape — \`sm:[--ctrl-pb]\` dropped from 2.5rem to 1rem.
- Title row sizes to its content (\`shrink\` + \`min-w-0\` + \`truncate\`) instead of stretching with \`flex-1\`, freeing the gap next to the action buttons.
- That empty gap (and the rest of the title row's whitespace) now emits \`tapOverlay\` so a tap there dismisses the controls; the mobile button cluster \`stopPropagation\`s so its taps still fire their actions.

## Test plan
- [ ] Browser: open player → controls visible immediately, auto-hide after 3s
- [ ] Android: open player → controls hidden by default; tap to reveal
- [ ] Android landscape: bottom bar (title, seekbar, buttons) sits flush near the edge
- [ ] Mobile: tap in the gap right of the episode/movie title → controls close
- [ ] Mobile: tap a button in that row (next episode, captions, audio, speed, settings, fullscreen) → action fires, controls stay open
- [ ] Long titles still truncate cleanly with the action buttons anchored right