### PR TITLE
fix(player): hide PiP button when permission is revoked

### DIFF
--- a/client/android/app/src/main/java/media/fliks/app/PipPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/PipPlugin.java
@@ -1,14 +1,17 @@
 package media.fliks.app;
 
+import android.app.AppOpsManager;
 import android.app.PendingIntent;
 import android.app.PictureInPictureParams;
 import android.app.RemoteAction;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.drawable.Icon;
 import android.os.Build;
 import android.util.Rational;
 
+import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
@@ -27,6 +30,24 @@ public class PipPlugin extends Plugin {
     static final String ACTION_TOGGLE_PLAYBACK = "media.fliks.app.PIP_TOGGLE_PLAYBACK";
     private boolean autoEnterEnabled = false;
     private boolean isPlaying = false;
+
+    @PluginMethod()
+    public void isAvailable(PluginCall call) {
+        JSObject result = new JSObject();
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O
+                || !getActivity().getPackageManager().hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)) {
+            result.put("available", false);
+            call.resolve(result);
+            return;
+        }
+        AppOpsManager appOps = (AppOpsManager) getContext().getSystemService(Context.APP_OPS_SERVICE);
+        int mode = appOps.checkOpNoThrow(
+                AppOpsManager.OPSTR_PICTURE_IN_PICTURE,
+                android.os.Process.myUid(),
+                getContext().getPackageName());
+        result.put("available", mode == AppOpsManager.MODE_ALLOWED);
+        call.resolve(result);
+    }
 
     @PluginMethod()
     public void enter(PluginCall call) {

--- a/client/ios/App/App/PipPlugin.swift
+++ b/client/ios/App/App/PipPlugin.swift
@@ -17,12 +17,17 @@ public class PipPlugin: CAPPlugin, CAPBridgedPlugin, AVPictureInPictureControlle
     public let identifier = "PipPlugin"
     public let jsName = "Pip"
     public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "isAvailable", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "enter", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setAutoEnter", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "updatePlaybackState", returnType: CAPPluginReturnPromise),
     ]
 
     private var pipController: AVPictureInPictureController?
+
+    @objc func isAvailable(_ call: CAPPluginCall) {
+        call.resolve(["available": AVPictureInPictureController.isPictureInPictureSupported()])
+    }
 
     @objc func enter(_ call: CAPPluginCall) {
         DispatchQueue.main.async { [weak self] in

--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -44,8 +44,8 @@
         }
       </button>
     }
-    <!-- lucide:picture-in-picture-2 — hidden on TV (no PiP on Android TV) -->
-    @if (!isTv()) {
+    <!-- lucide:picture-in-picture-2 — hidden on TV (no PiP on Android TV) and when permission is revoked -->
+    @if (!isTv() && pipAvailable()) {
       <button type="button" class="btn btn-ghost btn-circle text-white btn-sm lg:btn-md" (click)="togglePip.emit()">
         <svg lucidePictureInPicture2 [class]="isMobileTouch() ? 'h-5 w-5' : 'h-6 w-6'"></svg>
       </button>

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -149,6 +149,7 @@ export class PlayerControlsComponent {
   readonly activeQualityId = input('auto');
   readonly availableAudioTracks = input<{ id: string; label: string }[]>([]);
   readonly activeAudioTrackId = input<string | null>(null);
+  readonly pipAvailable = input(true);
   readonly castAvailable = input(false);
   readonly castConnected = input(false);
   readonly castConnecting = input(false);

--- a/client/src/app/features/player/player.html
+++ b/client/src/app/features/player/player.html
@@ -83,6 +83,7 @@
     [fillScreen]="fillScreen()"
     (speedChange)="onSpeedChange($event)"
     (back)="onBack()"
+    [pipAvailable]="pipAvailable()"
     [castAvailable]="castService.isAvailable()"
     [castConnected]="castService.isConnected()"
     [castConnecting]="castService.connecting()"

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -58,6 +58,7 @@ interface ImmersivePlugin {
 const Immersive = registerPlugin<ImmersivePlugin>('Immersive');
 
 interface PipPlugin {
+  isAvailable(): Promise<{ available: boolean }>;
   enter(): Promise<void>;
   setAutoEnter(options: { enabled: boolean }): Promise<void>;
   updatePlaybackState(options: { playing: boolean }): Promise<void>;
@@ -194,6 +195,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
    *  to false after inactivity regardless of the initial state. */
   readonly controlsVisible = signal(!Capacitor.isNativePlatform());
   readonly inPipMode = signal(false);
+  readonly pipAvailable = signal(true);
   private readonly isLandscape = signal(screen.orientation?.type?.startsWith('landscape') ?? false);
   readonly statsVisible = signal(false);
   readonly fillScreen = signal(false);
@@ -884,6 +886,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
     // PiP mode change listener (native Android)
     if (this.isNative) {
+      Pip.isAvailable().then(({ available }) => this.pipAvailable.set(available)).catch(() => this.pipAvailable.set(false));
       window.addEventListener('pipModeChanged', this.onPipModeChanged as EventListener);
       window.addEventListener('pipAction', this.onPipAction as EventListener);
       Pip.setAutoEnter({ enabled: true }).catch(() => {});


### PR DESCRIPTION
## Summary

- Adds `isAvailable()` to `PipPlugin` on Android (via `AppOpsManager.OPSTR_PICTURE_IN_PICTURE`) and iOS (`AVPictureInPictureController.isPictureInPictureSupported()`)
- Player checks availability at startup and stores the result in a `pipAvailable` signal (defaults `true` on web)
- PiP button in the controls is hidden when `pipAvailable` is `false`

## Test plan

- [ ] Android : révoquer la permission PiP dans Paramètres > Apps > Fliks > Image dans l'image → le bouton disparaît au prochain lancement du player
- [ ] Android : ré-activer la permission → le bouton réapparaît
- [ ] iOS : vérifier que le bouton s'affiche normalement sur un appareil supportant PiP
- [ ] Web : vérifier que le bouton s'affiche toujours (signal défaut `true`)
- [ ] AndroidTV : le bouton reste caché (`isTv()` guard inchangé)