### PR TITLE
fix(streaming): remove 4-session transcoding limit

### DIFF
--- a/backend/src/modules/streaming/transcoding/constants.ts
+++ b/backend/src/modules/streaming/transcoding/constants.ts
@@ -1,5 +1,4 @@
 export const SESSION_TIMEOUT_MS = 30 * 60 * 1000; // 30min HLS session timeout
-export const MAX_SESSIONS = 4;
 /** Max gap (in segments) between FFmpeg frontier and requested segment before restarting. */
 export const SEEK_WAIT_THRESHOLD = 15;
 

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -11,7 +11,6 @@ import * as path from 'path';
 import { TRANSCODE_DIR } from '../../../common/constants/paths';
 
 import {
-  MAX_SESSIONS,
   SEEK_WAIT_THRESHOLD,
   SESSION_TIMEOUT_MS,
   getSegmentDuration,
@@ -343,13 +342,6 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
           key, mediaFileId, quality, absolutePath, dir, restartAt, ctx,
         );
       }
-    }
-
-    const videoSessionCount = Array.from(this.sessions.values()).filter(
-      (s) => !s.isAudioOnly,
-    ).length;
-    if (videoSessionCount >= MAX_SESSIONS) {
-      this.evictOldestSession();
     }
 
     const ladder = getLadderForDevice(ctx?.deviceType);
@@ -976,10 +968,6 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       }
     }
 
-    if (this.sessions.size >= MAX_SESSIONS) {
-      this.evictOldestSession();
-    }
-
     const sessionDir = path.join(this.cachePath, key, 'remux');
     await fsp.mkdir(sessionDir, { recursive: true });
 
@@ -1113,21 +1101,6 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         this.sessions.delete(id);
         this.gracefulKill(session);
       }
-    }
-  }
-
-  private evictOldestSession() {
-    let oldest: TranscodeSession | null = null;
-    for (const session of this.sessions.values()) {
-      if (session.isAudioOnly) continue;
-      if (!oldest || session.lastAccess < oldest.lastAccess) {
-        oldest = session;
-      }
-    }
-    if (oldest) {
-      this.log.log(`Evicting session: ${oldest.id}`);
-      this.sessions.delete(oldest.id);
-      this.gracefulKill(oldest);
     }
   }
 

--- a/client/android/app/src/main/java/media/fliks/app/PipPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/PipPlugin.java
@@ -1,14 +1,17 @@
 package media.fliks.app;
 
+import android.app.AppOpsManager;
 import android.app.PendingIntent;
 import android.app.PictureInPictureParams;
 import android.app.RemoteAction;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.drawable.Icon;
 import android.os.Build;
 import android.util.Rational;
 
+import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
@@ -27,6 +30,24 @@ public class PipPlugin extends Plugin {
     static final String ACTION_TOGGLE_PLAYBACK = "media.fliks.app.PIP_TOGGLE_PLAYBACK";
     private boolean autoEnterEnabled = false;
     private boolean isPlaying = false;
+
+    @PluginMethod()
+    public void isAvailable(PluginCall call) {
+        JSObject result = new JSObject();
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O
+                || !getActivity().getPackageManager().hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)) {
+            result.put("available", false);
+            call.resolve(result);
+            return;
+        }
+        AppOpsManager appOps = (AppOpsManager) getContext().getSystemService(Context.APP_OPS_SERVICE);
+        int mode = appOps.checkOpNoThrow(
+                AppOpsManager.OPSTR_PICTURE_IN_PICTURE,
+                android.os.Process.myUid(),
+                getContext().getPackageName());
+        result.put("available", mode == AppOpsManager.MODE_ALLOWED);
+        call.resolve(result);
+    }
 
     @PluginMethod()
     public void enter(PluginCall call) {

--- a/client/ios/App/App/PipPlugin.swift
+++ b/client/ios/App/App/PipPlugin.swift
@@ -17,12 +17,17 @@ public class PipPlugin: CAPPlugin, CAPBridgedPlugin, AVPictureInPictureControlle
     public let identifier = "PipPlugin"
     public let jsName = "Pip"
     public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "isAvailable", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "enter", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setAutoEnter", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "updatePlaybackState", returnType: CAPPluginReturnPromise),
     ]
 
     private var pipController: AVPictureInPictureController?
+
+    @objc func isAvailable(_ call: CAPPluginCall) {
+        call.resolve(["available": AVPictureInPictureController.isPictureInPictureSupported()])
+    }
 
     @objc func enter(_ call: CAPPluginCall) {
         DispatchQueue.main.async { [weak self] in

--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -44,8 +44,8 @@
         }
       </button>
     }
-    <!-- lucide:picture-in-picture-2 — hidden on TV (no PiP on Android TV) -->
-    @if (!isTv()) {
+    <!-- lucide:picture-in-picture-2 — hidden on TV (no PiP on Android TV) and when permission is revoked -->
+    @if (!isTv() && pipAvailable()) {
       <button type="button" class="btn btn-ghost btn-circle text-white btn-sm lg:btn-md" (click)="togglePip.emit()">
         <svg lucidePictureInPicture2 [class]="isMobileTouch() ? 'h-5 w-5' : 'h-6 w-6'"></svg>
       </button>

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -149,6 +149,7 @@ export class PlayerControlsComponent {
   readonly activeQualityId = input('auto');
   readonly availableAudioTracks = input<{ id: string; label: string }[]>([]);
   readonly activeAudioTrackId = input<string | null>(null);
+  readonly pipAvailable = input(true);
   readonly castAvailable = input(false);
   readonly castConnected = input(false);
   readonly castConnecting = input(false);

--- a/client/src/app/features/player/player.html
+++ b/client/src/app/features/player/player.html
@@ -83,6 +83,7 @@
     [fillScreen]="fillScreen()"
     (speedChange)="onSpeedChange($event)"
     (back)="onBack()"
+    [pipAvailable]="pipAvailable()"
     [castAvailable]="castService.isAvailable()"
     [castConnected]="castService.isConnected()"
     [castConnecting]="castService.connecting()"

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -58,6 +58,7 @@ interface ImmersivePlugin {
 const Immersive = registerPlugin<ImmersivePlugin>('Immersive');
 
 interface PipPlugin {
+  isAvailable(): Promise<{ available: boolean }>;
   enter(): Promise<void>;
   setAutoEnter(options: { enabled: boolean }): Promise<void>;
   updatePlaybackState(options: { playing: boolean }): Promise<void>;
@@ -194,6 +195,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
    *  to false after inactivity regardless of the initial state. */
   readonly controlsVisible = signal(!Capacitor.isNativePlatform());
   readonly inPipMode = signal(false);
+  readonly pipAvailable = signal(true);
   private readonly isLandscape = signal(screen.orientation?.type?.startsWith('landscape') ?? false);
   readonly statsVisible = signal(false);
   readonly fillScreen = signal(false);
@@ -884,6 +886,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
     // PiP mode change listener (native Android)
     if (this.isNative) {
+      Pip.isAvailable().then(({ available }) => this.pipAvailable.set(available)).catch(() => this.pipAvailable.set(false));
       window.addEventListener('pipModeChanged', this.onPipModeChanged as EventListener);
       window.addEventListener('pipAction', this.onPipAction as EventListener);
       Pip.setAutoEnter({ enabled: true }).catch(() => {});


### PR DESCRIPTION
## Summary

- Supprime `MAX_SESSIONS = 4` dans `constants.ts`
- Retire les deux guards qui appelaient `evictOldestSession()` (transcode vidéo + remux)
- Supprime `evictOldestSession()` devenu dead code

Les sessions expirent toujours via le timeout idle de 30 minutes.

## Test plan

- [ ] Lancer 5+ streams simultanés → tous démarrent sans évincement
- [ ] Vérifier que les sessions expirent bien après 30 min d'inactivité