### PR TITLE
feat(blocklist): show note and indexer in blocklist view

### DIFF
--- a/backend/src/modules/blocklist/blocklist.module.ts
+++ b/backend/src/modules/blocklist/blocklist.module.ts
@@ -4,9 +4,10 @@ import { BlocklistEntry } from './entities/blocklist-entry.entity';
 import { BlocklistService } from './blocklist.service';
 import { BlocklistController } from './blocklist.controller';
 import { AuthModule } from '../auth/auth.module';
+import { Indexer } from '../indexers/entities/indexer.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([BlocklistEntry]), AuthModule],
+  imports: [TypeOrmModule.forFeature([BlocklistEntry, Indexer]), AuthModule],
   controllers: [BlocklistController],
   providers: [BlocklistService],
   exports: [BlocklistService],

--- a/backend/src/modules/blocklist/blocklist.service.ts
+++ b/backend/src/modules/blocklist/blocklist.service.ts
@@ -12,12 +12,20 @@ export class BlocklistService {
   constructor(
     @InjectRepository(BlocklistEntry)
     private readonly repo: Repository<BlocklistEntry>,
+    @InjectRepository(Indexer)
+    private readonly indexerRepo: Repository<Indexer>,
   ) {}
 
-  create(dto: CreateBlocklistEntryDto): Promise<BlocklistEntry> {
+  async create(dto: CreateBlocklistEntryDto): Promise<BlocklistEntry> {
     const { indexerId, mediaId, userId, ...rest } = dto;
+    let indexerName = rest.indexerName;
+    if (indexerId && !indexerName) {
+      const ix = await this.indexerRepo.findOne({ where: { id: indexerId } });
+      indexerName = ix?.name ?? undefined;
+    }
     const row = this.repo.create({
       ...rest,
+      indexerName,
       indexer: indexerId ? ({ id: indexerId } as Indexer) : null,
       media: mediaId ? ({ id: mediaId } as Media) : null,
       user: userId ? ({ id: userId } as User) : null,

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -223,6 +223,7 @@ export class CompletionService {
             sourceTitle: history.sourceTitle,
             quality: history.quality,
             mediaId: history.mediaId,
+            indexerId: history.indexerId ?? undefined,
             note: `Auto-blocklist: import failed — ${(e as Error).message}`,
           });
           this.log.log(`Import: auto-blocklisted "${history.sourceTitle}"`);
@@ -812,6 +813,7 @@ export class CompletionService {
           sourceTitle: history.sourceTitle ?? t.name,
           quality: history.quality ?? undefined,
           mediaId: history.mediaId ?? undefined,
+          indexerId: history.indexerId ?? undefined,
           note: `Auto-blocklist: stalled torrent (profile=${profile.key})`,
         });
 

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1188,7 +1188,8 @@
       "col_title": "Titre de la release",
       "col_indexer": "Indexer",
       "col_quality": "Qualité",
-      "col_date": "Date"
+      "col_date": "Date",
+      "col_note": "Raison"
     },
     "notifications": {
       "title": "Notifications",

--- a/client/src/app/features/settings/blocklist/blocklist.html
+++ b/client/src/app/features/settings/blocklist/blocklist.html
@@ -32,6 +32,7 @@
             <th>{{ 'settings.blocklist.col_title' | translate }}</th>
             <th>{{ 'settings.blocklist.col_indexer' | translate }}</th>
             <th>{{ 'settings.blocklist.col_quality' | translate }}</th>
+            <th>{{ 'settings.blocklist.col_note' | translate }}</th>
             <th>{{ 'settings.blocklist.col_date' | translate }}</th>
             <th class="text-end w-24"></th>
           </tr>
@@ -42,6 +43,7 @@
               <td class="font-medium max-w-xs truncate">{{ entry.sourceTitle }}</td>
               <td class="text-sm text-base-content/70">{{ entry.indexerName ?? '—' }}</td>
               <td class="text-sm">{{ entry.quality ?? '—' }}</td>
+              <td class="text-sm text-base-content/60">{{ entry.note ?? '—' }}</td>
               <td class="text-sm text-base-content/60 tabular-nums">
                 {{ entry.createdAt | date:'dd/MM/yyyy' }}
               </td>


### PR DESCRIPTION
## Summary

- Colonne "Raison" ajoutée dans la liste de blocage (champ `note` déjà existant)
- `BlocklistService.create()` résout `indexerName` depuis la DB quand seul `indexerId` est fourni
- `completion.service` passe `indexerId` lors des auto-blocklist (torrent stallé, import échoué) — la colonne Indexer est maintenant remplie