### PR TITLE
feat(scheduler): targeted SearchMissing restart on stalled torrent

### DIFF
--- a/backend/src/modules/blocklist/blocklist.module.ts
+++ b/backend/src/modules/blocklist/blocklist.module.ts
@@ -4,9 +4,10 @@ import { BlocklistEntry } from './entities/blocklist-entry.entity';
 import { BlocklistService } from './blocklist.service';
 import { BlocklistController } from './blocklist.controller';
 import { AuthModule } from '../auth/auth.module';
+import { Indexer } from '../indexers/entities/indexer.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([BlocklistEntry]), AuthModule],
+  imports: [TypeOrmModule.forFeature([BlocklistEntry, Indexer]), AuthModule],
   controllers: [BlocklistController],
   providers: [BlocklistService],
   exports: [BlocklistService],

--- a/backend/src/modules/blocklist/blocklist.service.ts
+++ b/backend/src/modules/blocklist/blocklist.service.ts
@@ -12,12 +12,20 @@ export class BlocklistService {
   constructor(
     @InjectRepository(BlocklistEntry)
     private readonly repo: Repository<BlocklistEntry>,
+    @InjectRepository(Indexer)
+    private readonly indexerRepo: Repository<Indexer>,
   ) {}
 
-  create(dto: CreateBlocklistEntryDto): Promise<BlocklistEntry> {
+  async create(dto: CreateBlocklistEntryDto): Promise<BlocklistEntry> {
     const { indexerId, mediaId, userId, ...rest } = dto;
+    let indexerName = rest.indexerName;
+    if (indexerId && !indexerName) {
+      const ix = await this.indexerRepo.findOne({ where: { id: indexerId } });
+      indexerName = ix?.name ?? undefined;
+    }
     const row = this.repo.create({
       ...rest,
+      indexerName,
       indexer: indexerId ? ({ id: indexerId } as Indexer) : null,
       media: mediaId ? ({ id: mediaId } as Media) : null,
       user: userId ? ({ id: userId } as User) : null,

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -826,6 +826,13 @@ export class CompletionService {
           (history.grabSource === 'auto' || allowManualRestart);
         if (shouldRestart && history.mediaId) {
           mediaToResearch.add(history.mediaId);
+          this.log.log(
+            `StalledCleanup: "${history.sourceTitle ?? t.name}" blocklisted — auto-restart queued for media #${history.mediaId}`,
+          );
+        } else if (!shouldRestart) {
+          this.log.log(
+            `StalledCleanup: "${history.sourceTitle ?? t.name}" blocklisted — no auto-restart (autoRestart=${profile.autoRestart}, grabSource=${history.grabSource})`,
+          );
         }
       }
     }
@@ -836,7 +843,8 @@ export class CompletionService {
       );
       // Insert command directly to avoid circular dep with SchedulerService.
       await this.dataSource.query(
-        `INSERT INTO commands (name, status, trigger, body) VALUES ('SearchMissing', 'queued', 'scheduled', '{}')`,
+        `INSERT INTO commands (name, status, trigger, body) VALUES ('SearchMissing', 'queued', 'scheduled', $1)`,
+        [JSON.stringify({ mediaIds: Array.from(mediaToResearch) })],
       );
     }
   }

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -223,6 +223,7 @@ export class CompletionService {
             sourceTitle: history.sourceTitle,
             quality: history.quality,
             mediaId: history.mediaId,
+            indexerId: history.indexerId ?? undefined,
             note: `Auto-blocklist: import failed — ${(e as Error).message}`,
           });
           this.log.log(`Import: auto-blocklisted "${history.sourceTitle}"`);
@@ -812,6 +813,7 @@ export class CompletionService {
           sourceTitle: history.sourceTitle ?? t.name,
           quality: history.quality ?? undefined,
           mediaId: history.mediaId ?? undefined,
+          indexerId: history.indexerId ?? undefined,
           note: `Auto-blocklist: stalled torrent (profile=${profile.key})`,
         });
 

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -300,13 +300,20 @@ export class SchedulerService implements OnModuleInit {
   }
 
   private async dispatchCommand(name: string, cmdId: number): Promise<void> {
+    const cmd = await this.commandRepo.findOne({ where: { id: cmdId } });
+    const body = cmd?.body ?? {};
     await this.commandRepo.update(cmdId, {
       status: 'running',
       startedOn: new Date(),
     });
     this.eventsService.emit({ type: 'command.started', name });
     try {
-      if (name === 'SearchMissing') await this.doSearchMissing();
+      if (name === 'SearchMissing') {
+        const mediaIds = Array.isArray(body['mediaIds'])
+          ? (body['mediaIds'] as number[])
+          : undefined;
+        await this.doSearchMissing(mediaIds);
+      }
       else if (name === 'RefreshMetadata') await this.doRefreshMetadata();
       else if (name === 'RssSync') await this.doRssSync();
       else if (name === 'ImportCompleted')
@@ -352,7 +359,10 @@ export class SchedulerService implements OnModuleInit {
     }
   }
 
-  private async doSearchMissing(): Promise<void> {
+  private async doSearchMissing(mediaIds?: number[]): Promise<void> {
+    if (mediaIds?.length) {
+      this.log.log(`SearchMissing: targeted restart for media IDs [${mediaIds.join(', ')}]`);
+    }
     const indexers = await this.indexerRepo.find({
       where: { enabled: true },
       order: { priority: 'ASC' },
@@ -374,23 +384,27 @@ export class SchedulerService implements OnModuleInit {
       throw new Error(`Download client unreachable — ${connCheck.message}`);
     }
 
-    await this.searchMissingMovies(indexers, qbitClient);
-    await this.searchMissingEpisodes(indexers, qbitClient);
+    await this.searchMissingMovies(indexers, qbitClient, mediaIds);
+    await this.searchMissingEpisodes(indexers, qbitClient, mediaIds);
   }
 
   private async searchMissingMovies(
     indexers: Indexer[],
     qbitClient: DownloadClient,
+    mediaIds?: number[],
   ): Promise<void> {
-    const candidates = await this.mediaRepo
+    const qb = this.mediaRepo
       .createQueryBuilder('m')
       .leftJoinAndSelect('m.qualityProfile', 'qp')
       .leftJoinAndSelect('m.languageProfile', 'lp')
       .leftJoinAndSelect('m.files', 'f')
       .where('m.monitored = true')
       .andWhere('m.type = :type', { type: MediaType.MOVIE })
-      .andWhere('(f.id IS NULL OR qp."upgradeAllowed" = true)')
-      .getMany();
+      .andWhere('(f.id IS NULL OR qp."upgradeAllowed" = true)');
+    if (mediaIds?.length) {
+      qb.andWhere('m.id IN (:...mediaIds)', { mediaIds });
+    }
+    const candidates = await qb.getMany();
 
     if (!candidates.length) return;
 
@@ -453,11 +467,12 @@ export class SchedulerService implements OnModuleInit {
   private async searchMissingEpisodes(
     indexers: Indexer[],
     qbitClient: DownloadClient,
+    mediaIds?: number[],
   ): Promise<void> {
     const today = new Date().toISOString().slice(0, 10);
     const scoring = await this.autoGrab.buildScoringContext(indexers);
 
-    const episodes = await this.episodeRepo
+    const qb = this.episodeRepo
       .createQueryBuilder('ep')
       .innerJoin('ep.season', 'season')
       .innerJoin('season.media', 'media')
@@ -469,7 +484,11 @@ export class SchedulerService implements OnModuleInit {
       .andWhere('ep.monitored = true')
       .andWhere('ep.airDate IS NOT NULL')
       .andWhere('ep.airDate <= :today', { today })
-      .andWhere('(ep.hasFile = false OR qp."upgradeAllowed" = true)')
+      .andWhere('(ep.hasFile = false OR qp."upgradeAllowed" = true)');
+    if (mediaIds?.length) {
+      qb.andWhere('media.id IN (:...mediaIds)', { mediaIds });
+    }
+    const episodes = await qb
       .select([
         'ep.id',
         'ep.episodeNumber',

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1188,7 +1188,8 @@
       "col_title": "Titre de la release",
       "col_indexer": "Indexer",
       "col_quality": "Qualité",
-      "col_date": "Date"
+      "col_date": "Date",
+      "col_note": "Raison"
     },
     "notifications": {
       "title": "Notifications",

--- a/client/src/app/features/settings/blocklist/blocklist.html
+++ b/client/src/app/features/settings/blocklist/blocklist.html
@@ -32,6 +32,7 @@
             <th>{{ 'settings.blocklist.col_title' | translate }}</th>
             <th>{{ 'settings.blocklist.col_indexer' | translate }}</th>
             <th>{{ 'settings.blocklist.col_quality' | translate }}</th>
+            <th>{{ 'settings.blocklist.col_note' | translate }}</th>
             <th>{{ 'settings.blocklist.col_date' | translate }}</th>
             <th class="text-end w-24"></th>
           </tr>
@@ -42,6 +43,7 @@
               <td class="font-medium max-w-xs truncate">{{ entry.sourceTitle }}</td>
               <td class="text-sm text-base-content/70">{{ entry.indexerName ?? '—' }}</td>
               <td class="text-sm">{{ entry.quality ?? '—' }}</td>
+              <td class="text-sm text-base-content/60">{{ entry.note ?? '—' }}</td>
               <td class="text-sm text-base-content/60 tabular-nums">
                 {{ entry.createdAt | date:'dd/MM/yyyy' }}
               </td>


### PR DESCRIPTION
## Summary

- `SearchMissing` déclenché après un stalled ne relance plus la recherche pour **tous** les médias manquants — les `mediaIds` concernés sont passés dans le body de la commande
- `doSearchMissing(mediaIds?)` + `searchMissingMovies`/`searchMissingEpisodes` filtrent par `WHERE m.id IN (...)` quand des IDs sont fournis
- Logs info : quand un torrent est bloqué + auto-restart queué, et quand `SearchMissing` est lancé en mode ciblé