### PR TITLE
feat(collections): TMDB collection grouping in library

### DIFF
--- a/backend/src/migrations/1778600000000-add-media-tmdb-collection.ts
+++ b/backend/src/migrations/1778600000000-add-media-tmdb-collection.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMediaTmdbCollection1778600000000 implements MigrationInterface {
+  name = 'AddMediaTmdbCollection1778600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "media"
+        ADD COLUMN IF NOT EXISTS "tmdbCollectionId"   integer,
+        ADD COLUMN IF NOT EXISTS "tmdbCollectionName" character varying
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "media"
+        DROP COLUMN IF EXISTS "tmdbCollectionId",
+        DROP COLUMN IF EXISTS "tmdbCollectionName"
+    `);
+  }
+}

--- a/backend/src/modules/blocklist/blocklist.module.ts
+++ b/backend/src/modules/blocklist/blocklist.module.ts
@@ -4,9 +4,10 @@ import { BlocklistEntry } from './entities/blocklist-entry.entity';
 import { BlocklistService } from './blocklist.service';
 import { BlocklistController } from './blocklist.controller';
 import { AuthModule } from '../auth/auth.module';
+import { Indexer } from '../indexers/entities/indexer.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([BlocklistEntry]), AuthModule],
+  imports: [TypeOrmModule.forFeature([BlocklistEntry, Indexer]), AuthModule],
   controllers: [BlocklistController],
   providers: [BlocklistService],
   exports: [BlocklistService],

--- a/backend/src/modules/blocklist/blocklist.service.ts
+++ b/backend/src/modules/blocklist/blocklist.service.ts
@@ -12,12 +12,20 @@ export class BlocklistService {
   constructor(
     @InjectRepository(BlocklistEntry)
     private readonly repo: Repository<BlocklistEntry>,
+    @InjectRepository(Indexer)
+    private readonly indexerRepo: Repository<Indexer>,
   ) {}
 
-  create(dto: CreateBlocklistEntryDto): Promise<BlocklistEntry> {
+  async create(dto: CreateBlocklistEntryDto): Promise<BlocklistEntry> {
     const { indexerId, mediaId, userId, ...rest } = dto;
+    let indexerName = rest.indexerName;
+    if (indexerId && !indexerName) {
+      const ix = await this.indexerRepo.findOne({ where: { id: indexerId } });
+      indexerName = ix?.name ?? undefined;
+    }
     const row = this.repo.create({
       ...rest,
+      indexerName,
       indexer: indexerId ? ({ id: indexerId } as Indexer) : null,
       media: mediaId ? ({ id: mediaId } as Media) : null,
       user: userId ? ({ id: userId } as User) : null,

--- a/backend/src/modules/media/dto/search-media.dto.ts
+++ b/backend/src/modules/media/dto/search-media.dto.ts
@@ -38,6 +38,11 @@ export class SearchMediaDto {
   @IsNumber()
   @IsOptional()
   @Type(() => Number)
+  collectionId?: number;
+
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
   qualityProfileId?: number;
 
   @IsNumber()

--- a/backend/src/modules/media/entities/media.entity.ts
+++ b/backend/src/modules/media/entities/media.entity.ts
@@ -130,6 +130,12 @@ export class Media extends BaseEntity {
   genres: string[];
 
   @Column({ nullable: true })
+  tmdbCollectionId: number | null;
+
+  @Column({ nullable: true })
+  tmdbCollectionName: string | null;
+
+  @Column({ nullable: true })
   runtime: number;
 
   @Column({ type: 'date', nullable: true })

--- a/backend/src/modules/media/media.controller.ts
+++ b/backend/src/modules/media/media.controller.ts
@@ -138,6 +138,21 @@ export class MediaController {
     return this.mediaService.getGenres(libraryIds);
   }
 
+  @Get('collections')
+  @CheckPolicies((ability) => ability.can(Action.Read, Media))
+  async collections(
+    @CurrentUser() user: User,
+    @Query('libraryId') libraryIdRaw?: string,
+  ) {
+    const accessible = await this.libraries.getAccessibleLibraryIds(user);
+    let libraryIds = accessible;
+    const libraryId = libraryIdRaw ? parseInt(libraryIdRaw, 10) : null;
+    if (libraryId && Number.isFinite(libraryId)) {
+      libraryIds = accessible.includes(libraryId) ? [libraryId] : [];
+    }
+    return this.mediaService.getCollections(libraryIds);
+  }
+
   @Get('calendar')
   @CheckPolicies((ability) => ability.can(Action.Read, Media))
   async calendar(@Query() query: CalendarQueryDto, @CurrentUser() user: User) {

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -456,6 +456,33 @@ export class MediaService {
     return rows;
   }
 
+  async getCollections(
+    accessibleLibraryIds: number[],
+  ): Promise<{ id: number; name: string; count: number; posters: string[] }[]> {
+    if (accessibleLibraryIds.length === 0) return [];
+    const rows: { id: number; name: string; count: number; posters: string[] }[] =
+      await this.mediaRepo.query(
+        `
+        SELECT m."tmdbCollectionId"   AS id,
+               m."tmdbCollectionName" AS name,
+               COUNT(*)::int          AS count,
+               COALESCE(
+                 (ARRAY_AGG(m."posterUrl" ORDER BY m.id)
+                  FILTER (WHERE m."posterUrl" IS NOT NULL))[1:4],
+                 ARRAY[]::text[]
+               ) AS posters
+        FROM media m
+        WHERE m."libraryId" = ANY($1)
+          AND m."tmdbCollectionId" IS NOT NULL
+          AND m."tmdbCollectionName" IS NOT NULL
+        GROUP BY m."tmdbCollectionId", m."tmdbCollectionName"
+        ORDER BY m."tmdbCollectionName" ASC
+        `,
+        [accessibleLibraryIds],
+      );
+    return rows;
+  }
+
   async findAll(
     query: SearchMediaDto,
     userId?: number,
@@ -1470,6 +1497,11 @@ export class MediaService {
         genre: JSON.stringify([query.genre]),
       });
     }
+    if (query.collectionId) {
+      qb.andWhere('media.tmdbCollectionId = :collectionId', {
+        collectionId: query.collectionId,
+      });
+    }
     if (query.qualityProfileId) {
       qb.andWhere('media.qualityProfileId = :qpId', {
         qpId: query.qualityProfileId,
@@ -1798,6 +1830,8 @@ export class MediaService {
       physicalRelease: details.physicalRelease
         ? details.physicalRelease.slice(0, 10)
         : undefined,
+      tmdbCollectionId: details.tmdbCollectionId ?? null,
+      tmdbCollectionName: details.tmdbCollectionName ?? null,
     };
   }
 

--- a/backend/src/modules/metadata-providers/interfaces/metadata-provider.interface.ts
+++ b/backend/src/modules/metadata-providers/interfaces/metadata-provider.interface.ts
@@ -40,6 +40,8 @@ export interface MetadataDetails extends MetadataSearchResult {
    *  localised name (e.g. "A Very Secret Service" for "Au service de la
    *  France") that the strict title-mismatch filter would otherwise drop. */
   alternativeTitles: string[];
+  tmdbCollectionId: number | null;
+  tmdbCollectionName: string | null;
 }
 
 export interface MetadataCastItem {

--- a/backend/src/modules/metadata-providers/providers/tmdb-api.types.ts
+++ b/backend/src/modules/metadata-providers/providers/tmdb-api.types.ts
@@ -97,6 +97,7 @@ export interface TmdbMovieDetailsResponse {
   title: string;
   original_title: string;
   overview: string;
+  belongs_to_collection?: { id: number; name: string } | null;
   release_date?: string;
   poster_path?: string | null;
   backdrop_path?: string | null;

--- a/backend/src/modules/metadata-providers/providers/tmdb.provider.ts
+++ b/backend/src/modules/metadata-providers/providers/tmdb.provider.ts
@@ -182,6 +182,8 @@ export class TmdbProvider implements IMetadataProvider {
       })),
       keywords: (data.keywords?.keywords ?? []).map((k) => k.name),
       alternativeTitles: extractAlternativeTitles(data, 'movie'),
+      tmdbCollectionId: data.belongs_to_collection?.id ?? null,
+      tmdbCollectionName: data.belongs_to_collection?.name ?? null,
     };
   }
 
@@ -258,6 +260,8 @@ export class TmdbProvider implements IMetadataProvider {
       })),
       keywords: (data.keywords?.results ?? []).map((k) => k.name),
       alternativeTitles: extractAlternativeTitles(data, 'series'),
+      tmdbCollectionId: null,
+      tmdbCollectionName: null,
     };
   }
 

--- a/backend/src/modules/metadata-providers/providers/tvdb.provider.ts
+++ b/backend/src/modules/metadata-providers/providers/tvdb.provider.ts
@@ -184,6 +184,8 @@ export class TvdbProvider implements IMetadataProvider {
       })),
       keywords: (m.tagOptions ?? []).map((t) => t.name),
       alternativeTitles: dedupeAliases(m.aliases, m.name),
+      tmdbCollectionId: null,
+      tmdbCollectionName: null,
     };
   }
 
@@ -245,6 +247,8 @@ export class TvdbProvider implements IMetadataProvider {
       })),
       keywords: (s.tagOptions ?? []).map((t) => t.name),
       alternativeTitles: dedupeAliases(s.aliases, s.name),
+      tmdbCollectionId: null,
+      tmdbCollectionName: null,
     };
   }
 

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -826,6 +826,13 @@ export class CompletionService {
           (history.grabSource === 'auto' || allowManualRestart);
         if (shouldRestart && history.mediaId) {
           mediaToResearch.add(history.mediaId);
+          this.log.log(
+            `StalledCleanup: "${history.sourceTitle ?? t.name}" blocklisted — auto-restart queued for media #${history.mediaId}`,
+          );
+        } else if (!shouldRestart) {
+          this.log.log(
+            `StalledCleanup: "${history.sourceTitle ?? t.name}" blocklisted — no auto-restart (autoRestart=${profile.autoRestart}, grabSource=${history.grabSource})`,
+          );
         }
       }
     }
@@ -836,7 +843,8 @@ export class CompletionService {
       );
       // Insert command directly to avoid circular dep with SchedulerService.
       await this.dataSource.query(
-        `INSERT INTO commands (name, status, trigger, body) VALUES ('SearchMissing', 'queued', 'scheduled', '{}')`,
+        `INSERT INTO commands (name, status, trigger, body) VALUES ('SearchMissing', 'queued', 'scheduled', $1)`,
+        [JSON.stringify({ mediaIds: Array.from(mediaToResearch) })],
       );
     }
   }

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -223,6 +223,7 @@ export class CompletionService {
             sourceTitle: history.sourceTitle,
             quality: history.quality,
             mediaId: history.mediaId,
+            indexerId: history.indexerId ?? undefined,
             note: `Auto-blocklist: import failed — ${(e as Error).message}`,
           });
           this.log.log(`Import: auto-blocklisted "${history.sourceTitle}"`);
@@ -812,6 +813,7 @@ export class CompletionService {
           sourceTitle: history.sourceTitle ?? t.name,
           quality: history.quality ?? undefined,
           mediaId: history.mediaId ?? undefined,
+          indexerId: history.indexerId ?? undefined,
           note: `Auto-blocklist: stalled torrent (profile=${profile.key})`,
         });
 

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -300,13 +300,20 @@ export class SchedulerService implements OnModuleInit {
   }
 
   private async dispatchCommand(name: string, cmdId: number): Promise<void> {
+    const cmd = await this.commandRepo.findOne({ where: { id: cmdId } });
+    const body = cmd?.body ?? {};
     await this.commandRepo.update(cmdId, {
       status: 'running',
       startedOn: new Date(),
     });
     this.eventsService.emit({ type: 'command.started', name });
     try {
-      if (name === 'SearchMissing') await this.doSearchMissing();
+      if (name === 'SearchMissing') {
+        const mediaIds = Array.isArray(body['mediaIds'])
+          ? (body['mediaIds'] as number[])
+          : undefined;
+        await this.doSearchMissing(mediaIds);
+      }
       else if (name === 'RefreshMetadata') await this.doRefreshMetadata();
       else if (name === 'RssSync') await this.doRssSync();
       else if (name === 'ImportCompleted')
@@ -352,7 +359,10 @@ export class SchedulerService implements OnModuleInit {
     }
   }
 
-  private async doSearchMissing(): Promise<void> {
+  private async doSearchMissing(mediaIds?: number[]): Promise<void> {
+    if (mediaIds?.length) {
+      this.log.log(`SearchMissing: targeted restart for media IDs [${mediaIds.join(', ')}]`);
+    }
     const indexers = await this.indexerRepo.find({
       where: { enabled: true },
       order: { priority: 'ASC' },
@@ -374,23 +384,27 @@ export class SchedulerService implements OnModuleInit {
       throw new Error(`Download client unreachable — ${connCheck.message}`);
     }
 
-    await this.searchMissingMovies(indexers, qbitClient);
-    await this.searchMissingEpisodes(indexers, qbitClient);
+    await this.searchMissingMovies(indexers, qbitClient, mediaIds);
+    await this.searchMissingEpisodes(indexers, qbitClient, mediaIds);
   }
 
   private async searchMissingMovies(
     indexers: Indexer[],
     qbitClient: DownloadClient,
+    mediaIds?: number[],
   ): Promise<void> {
-    const candidates = await this.mediaRepo
+    const qb = this.mediaRepo
       .createQueryBuilder('m')
       .leftJoinAndSelect('m.qualityProfile', 'qp')
       .leftJoinAndSelect('m.languageProfile', 'lp')
       .leftJoinAndSelect('m.files', 'f')
       .where('m.monitored = true')
       .andWhere('m.type = :type', { type: MediaType.MOVIE })
-      .andWhere('(f.id IS NULL OR qp."upgradeAllowed" = true)')
-      .getMany();
+      .andWhere('(f.id IS NULL OR qp."upgradeAllowed" = true)');
+    if (mediaIds?.length) {
+      qb.andWhere('m.id IN (:...mediaIds)', { mediaIds });
+    }
+    const candidates = await qb.getMany();
 
     if (!candidates.length) return;
 
@@ -453,11 +467,12 @@ export class SchedulerService implements OnModuleInit {
   private async searchMissingEpisodes(
     indexers: Indexer[],
     qbitClient: DownloadClient,
+    mediaIds?: number[],
   ): Promise<void> {
     const today = new Date().toISOString().slice(0, 10);
     const scoring = await this.autoGrab.buildScoringContext(indexers);
 
-    const episodes = await this.episodeRepo
+    const qb = this.episodeRepo
       .createQueryBuilder('ep')
       .innerJoin('ep.season', 'season')
       .innerJoin('season.media', 'media')
@@ -469,7 +484,11 @@ export class SchedulerService implements OnModuleInit {
       .andWhere('ep.monitored = true')
       .andWhere('ep.airDate IS NOT NULL')
       .andWhere('ep.airDate <= :today', { today })
-      .andWhere('(ep.hasFile = false OR qp."upgradeAllowed" = true)')
+      .andWhere('(ep.hasFile = false OR qp."upgradeAllowed" = true)');
+    if (mediaIds?.length) {
+      qb.andWhere('media.id IN (:...mediaIds)', { mediaIds });
+    }
+    const episodes = await qb
       .select([
         'ep.id',
         'ep.episodeNumber',

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1188,7 +1188,8 @@
       "col_title": "Titre de la release",
       "col_indexer": "Indexer",
       "col_quality": "Qualité",
-      "col_date": "Date"
+      "col_date": "Date",
+      "col_note": "Raison"
     },
     "notifications": {
       "title": "Notifications",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -486,7 +486,12 @@
     "suggestions_empty": "Pas encore de suggestions",
     "suggestions_empty_hint": "Regardez quelques films / séries pour alimenter les recommandations basées sur votre historique.",
     "genres_empty": "Aucun genre dans cette bibliothèque",
-    "clear_genre": "Effacer le filtre genre"
+    "clear_genre": "Effacer le filtre genre",
+    "view_collections": "Collections",
+    "collections_count": "{{count}} collection(s)",
+    "collections_empty": "Aucune collection TMDB trouvée dans cette bibliothèque",
+    "collection": "Collection",
+    "clear_collection": "Effacer le filtre collection"
   },
   "movies": {
     "title": "Films"

--- a/client/src/app/core/services/api/media.service.ts
+++ b/client/src/app/core/services/api/media.service.ts
@@ -157,6 +157,13 @@ export interface GenreSummary {
   posters: string[];
 }
 
+export interface CollectionSummary {
+  id: number;
+  name: string;
+  count: number;
+  posters: string[];
+}
+
 export interface SearchParams {
   q?: string;
   type?: MediaType;
@@ -248,6 +255,15 @@ export class MediaService {
       : {};
     return firstValueFrom(
       this.http.get<GenreSummary[]>('/api/media/genres', params),
+    );
+  }
+
+  getCollections(libraryId?: number) {
+    const params = libraryId
+      ? { params: { libraryId: String(libraryId) } }
+      : {};
+    return firstValueFrom(
+      this.http.get<CollectionSummary[]>('/api/media/collections', params),
     );
   }
 

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -37,6 +37,16 @@
     >
       {{ 'library.view_genres' | translate }}
     </button>
+    <button
+      type="button"
+      class="px-4 py-1.5 rounded-full text-sm font-medium transition-colors whitespace-nowrap"
+      [class.bg-base-300]="viewMode() === 'collections'"
+      [class.text-base-content/70]="viewMode() !== 'collections'"
+      [class.hover:bg-base-200]="viewMode() !== 'collections'"
+      (click)="setViewMode('collections')"
+    >
+      {{ 'library.view_collections' | translate }}
+    </button>
   </nav>
 
   @if (viewMode() === 'all') {
@@ -61,6 +71,19 @@
             class="hover:bg-primary/20 rounded-full p-0.5"
             [attr.aria-label]="'library.clear_genre' | translate"
             (click)="clearSelectedGenre()"
+          >
+            <svg lucideX class="h-3 w-3"></svg>
+          </button>
+        </span>
+      }
+      @if (selectedCollectionId()) {
+        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-primary/15 text-primary text-sm">
+          <span class="font-medium">{{ collectionsList().find(c => c.id === selectedCollectionId())?.name ?? ('library.collection' | translate) }}</span>
+          <button
+            type="button"
+            class="hover:bg-primary/20 rounded-full p-0.5"
+            [attr.aria-label]="'library.clear_collection' | translate"
+            (click)="clearSelectedCollection()"
           >
             <svg lucideX class="h-3 w-3"></svg>
           </button>
@@ -437,9 +460,47 @@
         }
       </div>
     }
-  } @else {
-    <div class="text-center py-24 text-base-content/50">
-      <p class="text-lg">{{ 'library.coming_soon' | translate }}</p>
-    </div>
+  } @else if (viewMode() === 'collections') {
+    <p class="text-sm text-base-content/50 mb-4">
+      {{ 'library.collections_count' | translate:{ count: collectionsList().length } }}
+    </p>
+    @if (collectionsLoading() && !collectionsList().length) {
+      <div class="flex justify-center py-16"><span class="loading loading-spinner loading-lg"></span></div>
+    } @else if (!collectionsList().length) {
+      <div class="flex flex-col items-center justify-center py-16 gap-3 text-base-content/40">
+        <svg lucideFilm class="w-12 h-12" [strokeWidth]="1.5"></svg>
+        <p class="text-lg">{{ 'library.collections_empty' | translate }}</p>
+      </div>
+    } @else {
+      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+        @for (c of collectionsList(); track c.id) {
+          <button
+            type="button"
+            class="group flex flex-col gap-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-xl"
+            (click)="pickCollection(c.id)"
+          >
+            <div class="aspect-square rounded-xl overflow-hidden bg-base-300 ring-1 ring-base-300 group-hover:ring-primary group-focus-visible:ring-primary group-focus-visible:ring-2 transition-colors">
+              @if (c.posters.length >= 4) {
+                <div class="grid grid-cols-2 grid-rows-2 w-full h-full">
+                  @for (p of c.posters.slice(0, 4); track p) {
+                    <img appImgFadeIn [src]="p | resolveUrl:'thumb'" alt="" loading="lazy" class="w-full h-full object-cover" />
+                  }
+                </div>
+              } @else if (c.posters.length > 0) {
+                <img appImgFadeIn [src]="c.posters[0] | resolveUrl:'medium'" alt="" loading="lazy" class="w-full h-full object-cover" />
+              } @else {
+                <div class="w-full h-full flex items-center justify-center text-base-content/30">
+                  <svg lucideFilm class="w-12 h-12" [strokeWidth]="1.5"></svg>
+                </div>
+              }
+            </div>
+            <div class="text-sm">
+              <div class="font-medium truncate group-hover:text-primary transition-colors">{{ c.name }}</div>
+              <div class="text-xs text-base-content/50">{{ c.count }}</div>
+            </div>
+          </button>
+        }
+      </div>
+    }
   }
 </div>

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -16,7 +16,7 @@ import { ActivatedRoute, NavigationStart, Router } from '@angular/router';
 import { Subscription, filter } from 'rxjs';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { MediaService, Media, GenreSummary } from '../../core/services/api/media.service';
+import { MediaService, Media, GenreSummary, CollectionSummary } from '../../core/services/api/media.service';
 import { StreamingApiService } from '../../core/services/api/streaming-api.service';
 import { ProfilesService, QualityProfile } from '../../core/services/api/profiles.service';
 import { LibrariesApiService, LibrarySummary } from '../../core/services/api/libraries-api.service';
@@ -33,7 +33,7 @@ import { NavbarService } from '../../core/services/navbar.service';
 import { TvService } from '../../core/services/tv.service';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
 import { InfiniteScrollList } from '../../shared/utils/infinite-scroll-list';
-import { LucideSearch, LucideSlidersHorizontal, LucideArrowUp, LucideArrowDown, LucideFolder, LucideX } from '@lucide/angular';
+import { LucideSearch, LucideSlidersHorizontal, LucideArrowUp, LucideArrowDown, LucideFolder, LucideX, LucideFilm } from '@lucide/angular';
 import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
 import { ImgFadeInDirective } from '../../shared/directives/img-fade-in.directive';
 
@@ -41,7 +41,7 @@ const ALPHABET = '#ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
 /** Top-bar tab — `all` is the existing library grid (label = library name),
  *  `suggestions` / `genres` are placeholders for upcoming views. */
-export type LibraryViewMode = 'all' | 'suggestions' | 'genres';
+export type LibraryViewMode = 'all' | 'suggestions' | 'genres' | 'collections';
 export type SortOrder = 'ASC' | 'DESC';
 type FilterMonitored = '' | 'true' | 'false';
 
@@ -69,6 +69,7 @@ const NATURAL_ORDER_BY_SORT: Record<string, SortOrder> = {
     LucideArrowUp,
     LucideArrowDown,
     LucideFolder,
+    LucideFilm,
     LucideX,
     ResolveUrlPipe,
     ImgFadeInDirective,
@@ -128,6 +129,11 @@ export class LibraryComponent implements OnInit, OnDestroy {
   /** When set, the `all` grid is filtered to this genre via the API's
    *  `genre=` param. Cleared with the chip's × button. */
   readonly selectedGenre = signal<string>('');
+
+  // ── Collections view ────────────────────────────────────────────────
+  readonly collectionsList = signal<CollectionSummary[]>([]);
+  readonly collectionsLoading = signal(false);
+  readonly selectedCollectionId = signal<number | null>(null);
 
   readonly monitoredCount = computed(() => this.list.all().filter((m) => m.monitored).length);
   readonly movieFileCount = computed(() =>
@@ -234,6 +240,8 @@ export class LibraryComponent implements OnInit, OnDestroy {
         (qp.get('view') ?? stored['view'] ?? 'all') as LibraryViewMode,
       );
       this.selectedGenre.set(qp.get('genre') ?? stored['genre'] ?? '');
+      const storedColl = qp.get('collectionId') ?? stored['collectionId'];
+      this.selectedCollectionId.set(storedColl ? Number(storedColl) : null);
 
       this.scrollMemory.activate(scrollKey);
       this.list.trackScroll('media');
@@ -246,6 +254,8 @@ export class LibraryComponent implements OnInit, OnDestroy {
         void this.loadSuggestions();
       } else if (this.viewMode() === 'genres') {
         void this.loadGenres();
+      } else if (this.viewMode() === 'collections') {
+        void this.loadCollections();
       }
       this.scrollMemory.restore(scrollKey, this.injector);
       if (this.tv.isTv()) {
@@ -300,10 +310,13 @@ export class LibraryComponent implements OnInit, OnDestroy {
       this.sortOrder.set((qp.get('sortOrder') ?? 'ASC') as SortOrder);
       this.viewMode.set((qp.get('view') ?? 'all') as LibraryViewMode);
       this.selectedGenre.set(qp.get('genre') ?? '');
+      const collId = qp.get('collectionId');
+      this.selectedCollectionId.set(collId ? Number(collId) : null);
       const lib = this.library();
       if (lib) {
         void this.load(lib.id, true);
         if (this.viewMode() === 'genres') void this.loadGenres();
+        else if (this.viewMode() === 'collections') void this.loadCollections();
         else if (this.viewMode() === 'suggestions') void this.loadSuggestions();
       }
     });
@@ -383,6 +396,8 @@ export class LibraryComponent implements OnInit, OnDestroy {
       void this.loadSuggestions();
     } else if (mode === 'genres') {
       void this.loadGenres();
+    } else if (mode === 'collections') {
+      void this.loadCollections();
     }
   }
 
@@ -401,6 +416,31 @@ export class LibraryComponent implements OnInit, OnDestroy {
     this.selectedGenre.set('');
     this.syncQueryParams();
     void this.load(this.library()?.id);
+  }
+
+  pickCollection(id: number) {
+    this.selectedCollectionId.set(id);
+    this.viewMode.set('all');
+    this.syncQueryParams(true);
+    void this.load(this.library()?.id);
+  }
+
+  clearSelectedCollection() {
+    this.selectedCollectionId.set(null);
+    this.syncQueryParams();
+    void this.load(this.library()?.id);
+  }
+
+  private async loadCollections(): Promise<void> {
+    const lib = this.library();
+    if (!lib) return;
+    this.collectionsLoading.set(true);
+    try {
+      const rows = await this.mediaService.getCollections(lib.id).catch(() => null);
+      if (rows) this.collectionsList.set(rows);
+    } finally {
+      this.collectionsLoading.set(false);
+    }
   }
 
   /** Fetches the genres aggregate (count + sample posters) for the
@@ -508,6 +548,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
     if (this.sortOrder() !== 'ASC') params['sortOrder'] = this.sortOrder();
     if (this.viewMode() !== 'all') params['view'] = this.viewMode();
     if (this.selectedGenre()) params['genre'] = this.selectedGenre();
+    if (this.selectedCollectionId()) params['collectionId'] = String(this.selectedCollectionId());
     this.skipQueryParamSync = true;
     void this.router.navigate([], { queryParams: params, replaceUrl: !push });
     this.saveFilters();
@@ -526,6 +567,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
     if (this.sortOrder() !== 'ASC') data['sortOrder'] = this.sortOrder();
     if (this.viewMode() !== 'all') data['view'] = this.viewMode();
     if (this.selectedGenre()) data['genre'] = this.selectedGenre();
+    if (this.selectedCollectionId()) data['collectionId'] = String(this.selectedCollectionId());
     localStorage.setItem(this.storageKey, JSON.stringify(data));
   }
 
@@ -550,6 +592,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
           sortBy: this.sortBy(),
           sortOrder: this.sortOrder(),
           genre: this.selectedGenre() || undefined,
+          collectionId: this.selectedCollectionId() ?? undefined,
           monitored: monitored ? monitored === 'true' : undefined,
           missing: fs === 'missing' ? true : fs === 'downloaded' ? false : undefined,
           cutoffUnmet: fs === 'cutoffUnmet' ? true : undefined,

--- a/client/src/app/features/settings/blocklist/blocklist.html
+++ b/client/src/app/features/settings/blocklist/blocklist.html
@@ -32,6 +32,7 @@
             <th>{{ 'settings.blocklist.col_title' | translate }}</th>
             <th>{{ 'settings.blocklist.col_indexer' | translate }}</th>
             <th>{{ 'settings.blocklist.col_quality' | translate }}</th>
+            <th>{{ 'settings.blocklist.col_note' | translate }}</th>
             <th>{{ 'settings.blocklist.col_date' | translate }}</th>
             <th class="text-end w-24"></th>
           </tr>
@@ -42,6 +43,7 @@
               <td class="font-medium max-w-xs truncate">{{ entry.sourceTitle }}</td>
               <td class="text-sm text-base-content/70">{{ entry.indexerName ?? '—' }}</td>
               <td class="text-sm">{{ entry.quality ?? '—' }}</td>
+              <td class="text-sm text-base-content/60">{{ entry.note ?? '—' }}</td>
               <td class="text-sm text-base-content/60 tabular-nums">
                 {{ entry.createdAt | date:'dd/MM/yyyy' }}
               </td>


### PR DESCRIPTION
## Summary

- `tmdbCollectionId` + `tmdbCollectionName` ajoutés à l'entité Media (migration incluse), peuplés depuis `belongs_to_collection` TMDB au refresh metadata
- `GET /api/media/collections?libraryId=X` — agrège les collections présentes dans la bibliothèque avec count + 4 posters mosaic
- `GET /api/media` — nouveau param `collectionId` pour filtrer la grille
- Library : onglet **Collections** avec grille mosaic identique aux genres ; clic → pivot vers la grille filtrée ; chip × pour effacer ; persisté dans l'URL et localStorage

## Test plan

- [ ] Refresh metadata sur un film appartenant à une collection TMDB → colonnes `tmdbCollectionId`/`tmdbCollectionName` remplies
- [ ] Onglet Collections visible dans la bibliothèque, affiche les collections avec mosaics
- [ ] Clic sur une collection → grille filtrée, chip affiché
- [ ] × du chip → retour à la liste complète
- [ ] Films sans collection TMDB n'apparaissent pas dans l'onglet Collections