### PR TITLE
fix(player): no HDR brightness when tonemapping to SDR

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -656,7 +656,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         // Await playback-info (kicked off in parallel with media load above)
         this.playbackInfo = await playbackInfoPromise!;
         const pi = this.playbackInfo;
-        this.isHdrContent.set(!!pi.source?.hdrFormat);
+        this.isHdrContent.set(!!pi.source?.hdrFormat && !pi.tonemapping);
         this.introMarker.set(pi.markers?.intro ?? null);
         this.outroMarker.set(pi.markers?.outro ?? null);
         this.chapters.set(pi.chapters ?? []);


### PR DESCRIPTION
## Summary
- Player kept HDR max brightness + dim overlay on non-HDR tablets when backend tone-mapped the stream to SDR.
- `isHdrContent` now also requires `!pi.tonemapping`, so the SDR output state is respected.

## Test plan
- [ ] Play HDR file on non-HDR Android tablet → backend tone-maps → no max-brightness, no dim controls.
- [ ] Play HDR file on HDR-capable device (no tonemapping) → brightness boost still active.
- [ ] Play SDR file → unchanged.