### PR TITLE
fix(playback): FK race + propagate episode watched toggle

### DIFF
--- a/backend/src/modules/streaming/playback.service.ts
+++ b/backend/src/modules/streaming/playback.service.ts
@@ -56,6 +56,11 @@ export interface MediaResumeInfo {
  */
 const RESUME_FROM_START_UNDER_SECONDS = 10;
 
+/** Postgres foreign-key violation. Library refresh can drop the parent media
+ *  row mid-session; cascade clears existing playback_states, then a beacon
+ *  arrives for that mediaId and the fresh INSERT trips this FK. */
+const PG_FK_VIOLATION = '23503';
+
 @Injectable()
 export class PlaybackService implements OnModuleInit {
   private readonly log = new Logger(PlaybackService.name);
@@ -247,7 +252,7 @@ export class PlaybackService implements OnModuleInit {
       mediaFileId: number;
       episodeId?: number;
     },
-  ): Promise<PlaybackState> {
+  ): Promise<PlaybackState | null> {
     if (!mediaId || !body.mediaFileId) {
       throw new BadRequestException('mediaId and mediaFileId are required');
     }
@@ -278,7 +283,12 @@ export class PlaybackService implements OnModuleInit {
       });
     }
 
-    return this.repo.save(state);
+    try {
+      return await this.repo.save(state);
+    } catch (err) {
+      if ((err as { code?: string })?.code === PG_FK_VIOLATION) return null;
+      throw err;
+    }
   }
 
   /**

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -67,6 +67,7 @@
           (grabBest)="grabEpisodeBest(m.id, ep.id)"
           (rescanFiles)="rescanFiles()"
           (editSubtitles)="openSubtitles()"
+          (episodeWatchedToggled)="onEpisodeWatchedToggledFromHeader($event)"
         />
 
         @if (currentSeasonEpisodes().length > 1) {

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -1303,22 +1303,31 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     if (!fileId) return;
 
     const prev = this.watchedEpisodeIds();
-    const next = new Set(prev);
-    if (watched) next.add(episode.id);
-    else next.delete(episode.id);
-    this.watchedEpisodeIds.set(next);
-
-    if (watched) {
-      const nextProgress = { ...this.episodeProgress() };
-      delete nextProgress[episode.id];
-      this.episodeProgress.set(nextProgress);
-    }
+    this.applyEpisodeWatchedLocal(episode.id, watched);
 
     try {
       await this.streamingApi.toggleWatched(mediaId, fileId, episode.id);
     } catch {
       this.watchedEpisodeIds.set(prev);
     }
+  }
+
+  /** Mirror the header's single-episode toggle: it has already called the API,
+   *  we just need to refresh local watched/progress state so the surrounding
+   *  scroller cards ("Plus de saison X", season panel) reflect the change. */
+  onEpisodeWatchedToggledFromHeader(payload: { episodeId: number; watched: boolean }) {
+    this.applyEpisodeWatchedLocal(payload.episodeId, payload.watched);
+  }
+
+  private applyEpisodeWatchedLocal(episodeId: number, watched: boolean): void {
+    const next = new Set(this.watchedEpisodeIds());
+    if (watched) next.add(episodeId);
+    else next.delete(episodeId);
+    this.watchedEpisodeIds.set(next);
+
+    const nextProgress = { ...this.episodeProgress() };
+    delete nextProgress[episodeId];
+    this.episodeProgress.set(nextProgress);
   }
 
   onSeriesWatchedToggled(payload: { watched: boolean }) {

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -166,6 +166,9 @@ export class MediaInfoHeaderComponent {
   readonly editSubtitles = output<void>();
   /** Emitted after a series-level bulk watched toggle. Parent should refresh its episode watched list. */
   readonly seriesWatchedToggled = output<{ watched: boolean }>();
+  /** Emitted after a single-episode watched toggle so the parent can refresh
+   *  watched/progress state on the surrounding scroller cards. */
+  readonly episodeWatchedToggled = output<{ episodeId: number; watched: boolean }>();
 
   // ── Internal state ──
 
@@ -288,10 +291,11 @@ export class MediaInfoHeaderComponent {
     const fileId = this.selectedFileId();
     if (!fileId) return;
     try {
+      const episodeId = this.episodeId();
       const completed = await this.playable.toggleWatched(
         mediaId,
         fileId,
-        this.episodeId(),
+        episodeId,
       );
       this.watched.set(completed);
       // Backend resets positionSeconds to 0 when marking as watched — mirror
@@ -299,6 +303,9 @@ export class MediaInfoHeaderComponent {
       if (completed) {
         this.resumePositionSeconds.set(null);
         this.durationSeconds.set(null);
+      }
+      if (episodeId) {
+        this.episodeWatchedToggled.emit({ episodeId, watched: completed });
       }
     } catch { /* ignore */ }
   }


### PR DESCRIPTION
## Summary
- Backend `updateState` swallows Postgres FK violation (`23503`) so a deleted-mid-session media no longer 500s the progress beacon. Cause: library refresh cascades wipe `playback_states`, then next beacon insert trips the FK.
- `app-media-info-header` now emits `episodeWatchedToggled` on single-episode toggle so the parent can refresh watched/progress state on surrounding scrollers (e.g. "Plus de saison X"). Before, only the header's internal signal updated.
- Shared `applyEpisodeWatchedLocal` helper in media-detail; progress now cleared on both watch + un-watch, matching the backend `positionSeconds` reset.

## Test plan
- [ ] Long playback during a library refresh that deletes the media → backend logs no 500 for progress beacon.
- [ ] Episode page → toggle watched in the header → "Plus de saison X" card flips status + progress immediately.
- [ ] Episode page → toggle un-watched → progress bar gone in both header and scroller card.
- [ ] Series root toggle (existing path) and scroller toggle still work.