### PR TITLE
fix(hdr): detect HDR by transfer function, not bit depth

### DIFF
--- a/backend/src/modules/subtitles/ffprobe.service.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.ts
@@ -252,13 +252,7 @@ export class FfprobeService {
           colorSpace: s.color_space,
           colorTransfer: s.color_transfer,
           colorPrimaries: s.color_primaries,
-          hdrFormat: this.deriveHdrFormat(
-            s.color_transfer,
-            s.color_primaries,
-            s.bits_per_raw_sample ? Number(s.bits_per_raw_sample) : undefined,
-            s.pix_fmt,
-            s.profile,
-          ),
+          hdrFormat: this.deriveHdrFormat(s.color_transfer, s.color_primaries),
         }));
 
       const audio: AudioStreamInfo[] = streams
@@ -330,17 +324,12 @@ export class FfprobeService {
   private deriveHdrFormat(
     colorTransfer?: string,
     colorPrimaries?: string,
-    bitDepth?: number,
-    pixelFormat?: string,
-    profile?: string,
   ): HdrFormat | undefined {
+    // HDR is defined by the transfer curve, not the bit depth. An 8-bit PQ
+    // file is mis-encoded but still needs the HDR pipeline (or tone-mapping):
+    // played as SDR, the PQ values render as gamma 2.2 and the picture goes
+    // dark/washed. Match Jellyfin/Plex: classify by transfer function alone.
     if (!colorTransfer) return undefined;
-    // Determine if 10-bit from bitDepth, pixel format, or codec profile
-    const is10bit =
-      (bitDepth && bitDepth >= 10) ||
-      (pixelFormat && /10le|10be|p010/.test(pixelFormat)) ||
-      (profile && /main 10|main10/i.test(profile));
-    if (!is10bit) return undefined;
     const isBt2020 = colorPrimaries === 'bt2020';
     if (colorTransfer === 'smpte2084' && isBt2020) return 'HDR10';
     if (colorTransfer === 'arib-std-b67' && isBt2020) return 'HLG';


### PR DESCRIPTION
## Summary
- `deriveHdrFormat` no longer requires 10-bit. Industry practice (Jellyfin/Plex): HDR is defined by the transfer curve, bit depth is a quality concern.
- 8-bit PQ-tagged files (mis-encodes, botched transcodes) are effectively HDR — played as SDR the PQ curve renders as gamma 2.2 and the picture goes dark / washed.
- Downstream is already wired: `stream-builder` tone-maps for SDR clients, direct-plays for HDR-capable ones; `media-info-header` shows the HDR badge; `player.isHdrContent` triggers brightness boost.

## Migration note
Existing files have `hdrFormat = null` in DB (old gate). They need a rescan / metadata refresh to be re-evaluated.

## Test plan
- [ ] Rescan a known 10-bit HDR10 file → `hdrFormat = HDR10`, HDR pipeline kicks in on capable device.
- [ ] Rescan an 8-bit file tagged smpte2084 + bt2020 (the "Hurlevent" case) → now flagged HDR10, tone-mapped on SDR devices, direct-played + bright on HDR Android.
- [ ] SDR file (rec709 transfer) → still SDR, no behaviour change.