### PR TITLE
ci(docker): allow custom tag on workflow_dispatch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,6 +14,11 @@ on:
     branches: [main]
     tags: ['v*']
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Custom tag to publish (e.g. "test", "preview-foo"). Builds from the branch you trigger the workflow on.'
+        required: false
+        default: 'test'
 
 permissions:
   contents: read
@@ -51,8 +56,12 @@ jobs:
             type=semver,pattern={{major}}
             # Branch pushes (main → :main, useful for downstream smoke tests)
             type=ref,event=branch
-            # Manual / ad-hoc runs
+            # Manual / ad-hoc runs — always include the sha tag for
+            # traceability + a custom tag from the workflow input (defaults
+            # to "test"). The custom tag is what you pull from TrueNAS /
+            # staging to validate a branch before merging to main.
             type=raw,value=manual-{{sha}},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' }}
             # `:latest` only on tag pushes — never on a main commit, so a
             # broken main never overrides a stable tag for users tracking
             # `:latest`.


### PR DESCRIPTION
## Summary
- Adds a \`tag\` input (default \`test\`) to the docker-publish workflow_dispatch.
- Lets any branch publish an ad-hoc image via \`gh workflow run docker-publish.yml --ref <branch> -f tag=<name>\` or the Actions UI.
- The \`manual-<sha>\` tag stays for traceability; the custom tag is what staging / TrueNAS pulls to validate a branch before merge.

## Test plan
- [ ] \`gh workflow run docker-publish.yml --ref ci/docker-dev-tag-build -f tag=test\` produces \`ghcr.io/fliks-app/fliks:test\` + the \`manual-<sha>\` tag.
- [ ] Push to main still publishes \`:main\` as before.
- [ ] Release tag (\`v*\`) still publishes semver tags + \`:latest\`.