### PR TITLE
feat(docker): build linux/arm64 image for Apple Silicon + ARM hosts

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -73,10 +73,12 @@ jobs:
           context: .
           file: Dockerfile
           push: true
-          # amd64 only for now — TrueNAS SCALE is x86, the ARM hosts
-          # (Pi 5, Apple Silicon containers, ARM NAS) come in a follow-up
-          # once the image is proven on amd64.
-          platforms: linux/amd64
+          # Multi-arch: amd64 covers TrueNAS SCALE / generic x86 servers,
+          # arm64 covers Apple Silicon Docker Desktop (M1+), ARM NAS, Pi 5.
+          # HW transcode accel (QSV/VAAPI/NVENC) is x86-Linux only — arm64
+          # users fall back to libx264 CPU encoding (no Metal/VideoToolbox
+          # passthrough from container to host on Docker Desktop).
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,10 @@ RUN npm run build
 # --- Stage 3: Production runtime ---
 FROM ubuntu:24.04
 
+# Populated by Docker buildx with the target platform's arch (amd64,
+# arm64, ...). Used below to skip x86-only packages on arm64 builds.
+ARG TARGETARCH
+
 # Install Node.js 24
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
   && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
@@ -28,7 +32,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
   && apt-get purge -y curl gnupg \
   && rm -rf /var/lib/apt/lists/*
 
-# Install runtime dependencies + Intel GPU drivers + FFmpeg
+# Install runtime dependencies + FFmpeg. Intel GPU stack and the alass
+# binary are amd64-only — on arm64 (Apple Silicon Docker, ARM NAS, Pi)
+# the image falls back to CPU transcoding (libx264) and subtitle sync
+# via ffsubsync alone. ffmpeg apt package is arch-aware on both.
 RUN apt-get update && apt-get install -y --no-install-recommends \
   bash \
   postgresql-client \
@@ -38,19 +45,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python3-venv \
   ffmpeg \
   libchromaprint-tools \
-  intel-media-va-driver-non-free \
-  intel-opencl-icd \
-  libmfx-gen1.2 \
-  libvpl2 \
-  vainfo \
   wget \
   ca-certificates \
   gcc \
   python3-dev \
   libc6-dev \
+  && if [ "$TARGETARCH" = "amd64" ]; then \
+       apt-get install -y --no-install-recommends \
+         intel-media-va-driver-non-free \
+         intel-opencl-icd \
+         libmfx-gen1.2 \
+         libvpl2 \
+         vainfo; \
+     fi \
   && python3 -m pip install --no-cache-dir --break-system-packages ffsubsync \
-  && wget -q -O /usr/local/bin/alass https://github.com/kaegi/alass/releases/download/v2.0.0/alass-linux64 \
-  && chmod +x /usr/local/bin/alass \
+  && if [ "$TARGETARCH" = "amd64" ]; then \
+       wget -q -O /usr/local/bin/alass https://github.com/kaegi/alass/releases/download/v2.0.0/alass-linux64 \
+       && chmod +x /usr/local/bin/alass; \
+     fi \
   && apt-get purge -y wget gcc python3-dev libc6-dev \
   && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/*

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -79,6 +79,12 @@ services:
   #   fliks:
   #     devices:
   #       - /dev/dri:/dev/dri
+  #
+  # ARM hosts (Apple Silicon Docker Desktop, Pi 5, ARM NAS): the image
+  # is published for linux/arm64 too — Docker pulls the right variant
+  # automatically. No HW transcode there (the Intel GPU stack ships only
+  # in the amd64 image, and Metal/VideoToolbox aren't reachable from a
+  # Linux container), so streams fall back to libx264 CPU encoding.
 
 volumes:
   fliks_pgdata:


### PR DESCRIPTION
## Summary
- Workflow builds and publishes both \`linux/amd64\` and \`linux/arm64\` variants — Docker pulls the right arch automatically.
- Mac M1+ users on Docker Desktop, Pi 5 owners and ARM NAS can now run the published image without local buildx.
- Intel GPU stack (\`intel-media-va-driver-non-free\`, \`intel-opencl-icd\`, \`libmfx-gen1.2\`, \`libvpl2\`, \`vainfo\`) and the \`alass\` binary (x86_64-only release) are gated on \`TARGETARCH=amd64\`.
- ARM hosts fall back to libx264 CPU encode (no Intel/QSV/VAAPI, no Metal passthrough from container to macOS host). Subtitle sync degrades to \`ffsubsync\` alone; the existing try/catch in \`subtitle-sync.service.ts\` keeps subs flowing when \`alass\` is missing.

## Test plan
- [x] CI build green for both \`linux/amd64\` and \`linux/arm64\` ([run #25869059380](https://github.com/fliks-app/fliks/actions/runs/25869059380), \`:test-arm64\` tag published).
- [ ] Pull \`ghcr.io/fliks-app/fliks:test-arm64\` on a Mac M1 via Docker Desktop, start the stack, verify CPU transcode plays.
- [ ] Existing amd64 hosts: no regression in HW transcode (\`docker run --device /dev/dri:/dev/dri ...\` still has Intel drivers).