### PR TITLE
feat(macos): bake TMDB/TVDB API keys at build time

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -59,8 +59,13 @@ jobs:
         run: xcodegen generate
 
       # ── Build .app + bundle resources + dylibs ──
+      # API keys are baked into Info.plist via Xcode build settings,
+      # then read at runtime by BuildConfig.swift.
       - name: Build Fliks.app
         working-directory: macos
+        env:
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+          TVDB_API_KEY: ${{ secrets.TVDB_API_KEY }}
         run: ./Scripts/build-app.sh --skip-web
 
       # ── Create DMG ──

--- a/macos/Fliks/Info.plist
+++ b/macos/Fliks/Info.plist
@@ -24,6 +24,10 @@
 	<string>13.0</string>
 	<key>CFBundleIconFile</key>
 	<string>AppIcon</string>
+	<key>TMDB_API_KEY</key>
+	<string>$(TMDB_API_KEY)</string>
+	<key>TVDB_API_KEY</key>
+	<string>$(TVDB_API_KEY)</string>
 	<key>LSUIElement</key>
 	<true/>
 </dict>

--- a/macos/Fliks/Services/NodeManager.swift
+++ b/macos/Fliks/Services/NodeManager.swift
@@ -15,6 +15,7 @@ actor NodeManager {
     private var process: Process?
     private var stdoutPipe: Pipe?
     private var stderrPipe: Pipe?
+    private var logFileHandle: FileHandle?
     private var isIntentionallyStopping = false
     private var restartDelay: TimeInterval = 1
 
@@ -46,12 +47,24 @@ actor NodeManager {
         self.stdoutPipe = stdout
         self.stderrPipe = stderr
 
-        // Stream stderr to os_log for diagnostics.
-        stderr.fileHandleForReading.readabilityHandler = { [logger] handle in
-            let data = handle.availableData
-            guard !data.isEmpty, let line = String(data: data, encoding: .utf8) else { return }
-            logger.info("node: \(line)")
+        // Write backend logs to file + os_log.
+        let logFile = Paths.logsDir.appendingPathComponent("backend.log")
+        try? Paths.ensureDirectory(Paths.logsDir)
+        let logHandle = Self.openLogFile(logFile)
+        self.logFileHandle = logHandle
+
+        let handleOutput = { [logger] (pipe: Pipe) in
+            pipe.fileHandleForReading.readabilityHandler = { handle in
+                let data = handle.availableData
+                guard !data.isEmpty else { return }
+                logHandle?.write(data)
+                if let line = String(data: data, encoding: .utf8) {
+                    logger.info("node: \(line)")
+                }
+            }
         }
+        handleOutput(stdout)
+        handleOutput(stderr)
 
         // Crash recovery handler.
         let intentionalCheck = { @Sendable [weak self] in
@@ -99,6 +112,8 @@ actor NodeManager {
         self.process = nil
         self.stdoutPipe = nil
         self.stderrPipe = nil
+        self.logFileHandle?.closeFile()
+        self.logFileHandle = nil
     }
 
     var isRunning: Bool {
@@ -106,6 +121,20 @@ actor NodeManager {
     }
 
     // MARK: - Private
+
+    /// Open (or create) the backend log file for appending.
+    private static func openLogFile(_ url: URL) -> FileHandle? {
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: url.path) {
+            fm.createFile(atPath: url.path, contents: nil)
+        }
+        let handle = try? FileHandle(forWritingTo: url)
+        handle?.seekToEndOfFile()
+        // Write a separator on each launch.
+        let header = "\n--- Fliks backend started at \(ISO8601DateFormatter().string(from: Date())) ---\n"
+        handle?.write(header.data(using: .utf8) ?? Data())
+        return handle
+    }
 
     /// Create symlinks in the data directory so the backend finds its code
     /// while using a writable cwd for images/backups/thumbnails.

--- a/macos/Fliks/Services/NodeManager.swift
+++ b/macos/Fliks/Services/NodeManager.swift
@@ -197,7 +197,7 @@ struct BackendEnvironment {
         let nodeBin = Paths.nodeBinary.deletingLastPathComponent().path
         let systemPath = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
-        return [
+        var env: [String: String] = [
             "NODE_ENV": "production",
             "PORT": String(port),
             "DB_HOST": "localhost",
@@ -210,6 +210,10 @@ struct BackendEnvironment {
             "PATH": "\(ffmpegBin):\(nodeBin):\(systemPath)",
             "UV_THREADPOOL_SIZE": "16",
         ]
+        // API keys baked at build time via SWIFT_ACTIVE_COMPILATION_CONDITIONS.
+        env["TMDB_API_KEY"] = BuildConfig.tmdbApiKey
+        env["TVDB_API_KEY"] = BuildConfig.tvdbApiKey
+        return env
     }
 }
 

--- a/macos/Fliks/Services/NodeManager.swift
+++ b/macos/Fliks/Services/NodeManager.swift
@@ -47,10 +47,9 @@ actor NodeManager {
         self.stdoutPipe = stdout
         self.stderrPipe = stderr
 
-        // Write backend logs to file + os_log.
-        let logFile = Paths.logsDir.appendingPathComponent("backend.log")
+        // Write backend logs to daily file + os_log.
         try? Paths.ensureDirectory(Paths.logsDir)
-        let logHandle = Self.openLogFile(logFile)
+        let logHandle = Self.openLogFile(Paths.logsDir)
         self.logFileHandle = logHandle
 
         let handleOutput = { [logger] (pipe: Pipe) in
@@ -122,19 +121,27 @@ actor NodeManager {
 
     // MARK: - Private
 
-    /// Open (or create) the backend log file for appending.
-    private static func openLogFile(_ url: URL) -> FileHandle? {
+    /// Open (or create) the daily backend log file for appending.
+    /// File name: `backend-2026-05-15.log`
+    private static func openLogFile(_ baseDir: URL) -> FileHandle? {
         let fm = FileManager.default
+        let dateStr = Self.dayFormatter.string(from: Date())
+        let url = baseDir.appendingPathComponent("backend-\(dateStr).log")
         if !fm.fileExists(atPath: url.path) {
             fm.createFile(atPath: url.path, contents: nil)
         }
         let handle = try? FileHandle(forWritingTo: url)
         handle?.seekToEndOfFile()
-        // Write a separator on each launch.
         let header = "\n--- Fliks backend started at \(ISO8601DateFormatter().string(from: Date())) ---\n"
         handle?.write(header.data(using: .utf8) ?? Data())
         return handle
     }
+
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
 
     /// Create symlinks in the data directory so the backend finds its code
     /// while using a writable cwd for images/backups/thumbnails.

--- a/macos/Fliks/Services/PostgresManager.swift
+++ b/macos/Fliks/Services/PostgresManager.swift
@@ -92,7 +92,7 @@ actor PostgresManager {
             arguments: [
                 "-D", dataDir.path,
                 "-l", logFile.path,
-                "-o", "-p \(port)",
+                "-o", "-p \(port) -c dynamic_library_path=\(libDir.appendingPathComponent("postgresql").path)",
                 "start",
             ],
             environment: pgEnv,

--- a/macos/Fliks/Utilities/BuildConfig.swift
+++ b/macos/Fliks/Utilities/BuildConfig.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Build-time configuration injected via Xcode build settings.
+///
+/// Values are set in project.yml as `GCC_PREPROCESSOR_DEFINITIONS` and
+/// read from Info.plist at runtime. The CI passes them as xcodebuild
+/// arguments: `TMDB_API_KEY=xxx TVDB_API_KEY=yyy`.
+enum BuildConfig {
+    static let tmdbApiKey: String = {
+        Bundle.main.infoDictionary?["TMDB_API_KEY"] as? String ?? ""
+    }()
+
+    static let tvdbApiKey: String = {
+        Bundle.main.infoDictionary?["TVDB_API_KEY"] as? String ?? ""
+    }()
+}

--- a/macos/Scripts/build-app.sh
+++ b/macos/Scripts/build-app.sh
@@ -78,6 +78,8 @@ if [ "$SKIP_XCODE" = false ]; then
         -configuration Release \
         -derivedDataPath "$BUILD_DIR" \
         ONLY_ACTIVE_ARCH=YES \
+        TMDB_API_KEY="${TMDB_API_KEY:-}" \
+        TVDB_API_KEY="${TVDB_API_KEY:-}" \
         build 2>&1 | tail -3
 fi
 

--- a/macos/Scripts/build-app.sh
+++ b/macos/Scripts/build-app.sh
@@ -117,8 +117,20 @@ for pgbin in "$RESOURCES/postgres/bin/"*; do
 done
 
 # Copy share directory (timezone data, SQL scripts needed by initdb).
-cp -R "$PG_PREFIX/share/postgresql@18/"* "$RESOURCES/postgres/share/" 2>/dev/null || \
-    cp -R "$PG_PREFIX/share/"* "$RESOURCES/postgres/share/" 2>/dev/null || true
+# Preserve the postgresql/ subdirectory so initdb -L finds it.
+mkdir -p "$RESOURCES/postgres/share/postgresql"
+cp -R "$PG_PREFIX/share/postgresql@18/"* "$RESOURCES/postgres/share/postgresql/" 2>/dev/null || \
+    cp -R "$PG_PREFIX/share/postgresql/"* "$RESOURCES/postgres/share/postgresql/" 2>/dev/null || true
+
+# Copy extension libraries (pg_trgm, plpgsql, etc.) so $libdir resolves
+# to our bundled versions — not the host's Homebrew (which may be a
+# different PG minor version with ABI-incompatible symbols).
+PG_EXTLIB="$PG_PREFIX/lib/postgresql"
+if [ -d "$PG_EXTLIB" ]; then
+    mkdir -p "$RESOURCES/postgres/lib/postgresql"
+    cp "$PG_EXTLIB"/*.dylib "$RESOURCES/postgres/lib/postgresql/" 2>/dev/null || true
+    echo "    [copy] $(ls "$RESOURCES/postgres/lib/postgresql/"*.dylib 2>/dev/null | wc -l | tr -d ' ') extension libraries"
+fi
 
 # Bundle Homebrew dylib dependencies for postgres binaries.
 bash "$SCRIPTS_DIR/bundle-dylibs.sh" "$RESOURCES/postgres/bin" "$RESOURCES/postgres/lib"


### PR DESCRIPTION
## Summary
- API keys injected via xcodebuild build settings → Info.plist `$(TMDB_API_KEY)` → `BuildConfig.swift` → `BackendEnvironment`
- CI reads from `secrets.TMDB_API_KEY` / `secrets.TVDB_API_KEY` (same secrets as Docker workflow)
- Empty string fallback when not set (local dev builds)