### PR TITLE
fix(transcode): replace zscale tonemap with format+colorspace

### DIFF
--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -288,8 +288,11 @@ export function buildFfmpegArgs(
     useVaapiTonemap && !burnIn?.filter
       ? ',tonemap_vaapi=format=nv12:t=bt709:p=bt709:m=bt709'
       : '';
+  // CPU tonemap chain: HDR (PQ/HLG BT.2020) → SDR (BT.709).
+  // Uses format + colorspace + tonemap (no zscale dependency — zimg/libzimg
+  // is not available in stock Homebrew FFmpeg on macOS).
   const tonemapCpu = tonemap
-    ? `zscale=t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=mobius:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p,`
+    ? `format=gbrpf32le,tonemap=mobius:desat=0,colorspace=all=bt709:iall=bt2020:trc=bt709:itrc=smpte2084:format=yuv420p,`
     : '';
 
   // For HW paths with crop: hwdownload to CPU, crop, then hwupload back.


### PR DESCRIPTION
zscale requires libzimg (not in Homebrew FFmpeg). Use built-in format + tonemap + colorspace filters for HDR→SDR.