### PR TITLE
fix(transcode): drop H.264 level 4.0 on VT (breaks 4K)

### DIFF
--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -444,7 +444,7 @@ export function buildFfmpegArgs(
         // No CPU round-trip — everything stays on Metal/IOSurface.
         args.push(
           '-c:v', 'h264_videotoolbox',
-          '-profile:v', 'high', '-level', '4.0',
+          '-profile:v', 'high',
           ...(early ? ['-realtime', '1'] : []),
           '-b:v', profile.videoBitrate,
           '-maxrate', profile.videoBitrate,
@@ -459,7 +459,7 @@ export function buildFfmpegArgs(
         // burn-in, scale) → VT encode (re-uploads internally).
         args.push(
           '-c:v', 'h264_videotoolbox',
-          '-profile:v', 'high', '-level', '4.0',
+          '-profile:v', 'high',
           ...(early ? ['-realtime', '1'] : []),
           '-b:v', profile.videoBitrate,
           '-maxrate', profile.videoBitrate,


### PR DESCRIPTION
Level 4.0 max is 2048x1024. 4K encode fails. Let VT auto-select.