### PR TITLE
fix(player): iOS spinner, ABR freezes, HDR -12927

### DIFF
--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -489,6 +489,21 @@ export function buildFfmpegArgs(
       break;
   }
 
+  // Force SDR color signaling in the H.264 VUI when the pipeline tone-maps
+  // an HDR source. Without these flags, h264_videotoolbox (and to a lesser
+  // extent libx264 / h264_nvenc) inherits the source's BT.2020/PQ metadata
+  // and emits a bitstream whose VUI claims HDR even though the pixel data
+  // is now BT.709 SDR. iOS AVPlayer fails the variant with error -12927
+  // because the declared color volume doesn't match the HLS SDR rung.
+  if (tonemap) {
+    args.push(
+      '-color_primaries', 'bt709',
+      '-color_trc', 'bt709',
+      '-colorspace', 'bt709',
+      '-color_range', 'tv',
+    );
+  }
+
   // ── Audio mapping + HLS output ──
   // Always use var_stream_map for multi-audio, even when the user has
   // picked a specific track — otherwise switching audio would require a

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -58,12 +58,13 @@ export function generateMasterPlaylist(
   // skip fetching seg 0 purely to probe codecs (TS has no init segment) —
   // otherwise a user resuming mid-file wastes a transcode pass at seg 0
   // before the real seek-aware session starts at their resume position.
-  // Video is always H.264 High @ L4.0. Audio codec depends on the path
-  // chosen in stream-builder.
+  // Video codec string is per-rung: H.264 High profile with a level high
+  // enough for the rung's resolution at 60 fps. A single `avc1.640028`
+  // (L4.0) for every rung makes iOS AVPlayer reject 4K segments whose
+  // bitstream signals L5.x — visible as decoder reinit / frame freeze.
   const audioAttr = multiAudio ? ',AUDIO="audio"' : '';
   const audioCodecMap = { aac: 'mp4a.40.2', ac3: 'ac-3', eac3: 'ec-3' };
   const audioCodec = audioCodecMap[outputAudioCodec] ?? 'mp4a.40.2';
-  const transcodeCodecs = `,CODECS="avc1.640028,${audioCodec}"`;
 
   // The HLS master never advertises the `/remux/` variant — it proved
   // unreliable on ExoPlayer (Android), which would ABR-downgrade from the
@@ -89,15 +90,37 @@ export function generateMasterPlaylist(
   }
 
   for (const p of profiles) {
-    const bw =
+    const avg =
       parseBitrateToBps(p.videoBitrate) + parseBitrateToBps(p.audioBitrate);
+    // BANDWIDTH must reflect the peak segment bitrate (HLS spec). With
+    // `-maxrate == -b:v` the encoder is near-CBR but VBV bursts still
+    // push individual segments ~30% above nominal. Declaring BANDWIDTH
+    // ~1.5× nominal gives AVPlayer ABR a stable hysteresis margin and
+    // stops it from down-/up-shifting on every VBV spike.
+    const bw = Math.round(avg * 1.5);
     const w = Math.min(p.maxWidth, sourceWidth);
     const rawH = (w * sourceHeight) / sourceWidth;
     const h = Math.floor(rawH / 16) * 16 || 16;
+    const videoCodec = h264CodecStringForHeight(p.maxHeight);
+    const codecsAttr = `,CODECS="${videoCodec},${audioCodec}"`;
     lines.push(
-      `#EXT-X-STREAM-INF:BANDWIDTH=${bw},RESOLUTION=${w}x${h},NAME="${p.name}"${transcodeCodecs}${audioAttr}`,
+      `#EXT-X-STREAM-INF:BANDWIDTH=${bw},AVERAGE-BANDWIDTH=${avg},RESOLUTION=${w}x${h},NAME="${p.name}"${codecsAttr}${audioAttr}`,
       `/api/stream/${mediaFileId}/${p.name}/index.m3u8${tokenParam}`,
     );
   }
   return lines.join('\n');
+}
+
+/** H.264 codec string per rung. Levels picked to cover 60 fps at the rung
+ *  resolution, so the actual encoder output never signals a higher level
+ *  than the master playlist advertises (which would force iOS AVPlayer to
+ *  reinitialise the decoder mid-stream → frame freeze). */
+function h264CodecStringForHeight(height: number): string {
+  if (height >= 2160) return 'avc1.640034'; // High @ L5.2 — 4K60
+  if (height >= 1080) return 'avc1.64002a'; // High @ L4.2 — 1080p60 + headroom
+  if (height >= 720)  return 'avc1.640020'; // High @ L3.2 — 720p60
+  if (height >= 480)  return 'avc1.64001f'; // High @ L3.1 — 480p60
+  if (height >= 360)  return 'avc1.64001e'; // High @ L3.0 — 360p30
+  if (height >= 240)  return 'avc1.640015'; // High @ L2.1 — 240p60
+  return 'avc1.64000d';                      // High @ L1.3 — 144p
 }

--- a/client/ios/App/App.xcodeproj/project.pbxproj
+++ b/client/ios/App/App.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		F1000001AAAA000000000004 /* ImmersivePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1000001AAAA000000000014 /* ImmersivePlugin.swift */; };
 		F1000001AAAA000000000005 /* PipPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1000001AAAA000000000015 /* PipPlugin.swift */; };
 		F1000001AAAA000000000006 /* CastPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1000001AAAA000000000016 /* CastPlugin.swift */; };
+		F1000001AAAA000000000007 /* AudioCapabilitiesPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1000001AAAA000000000017 /* AudioCapabilitiesPlugin.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -41,6 +42,7 @@
 		F1000001AAAA000000000014 /* ImmersivePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImmersivePlugin.swift; sourceTree = "<group>"; };
 		F1000001AAAA000000000015 /* PipPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipPlugin.swift; sourceTree = "<group>"; };
 		F1000001AAAA000000000016 /* CastPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CastPlugin.swift; sourceTree = "<group>"; };
+		F1000001AAAA000000000017 /* AudioCapabilitiesPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCapabilitiesPlugin.swift; sourceTree = "<group>"; };
 		FC68EB0AF532CFC21C3344DD /* Pods-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-App/Pods-App.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -93,6 +95,7 @@
 				F1000001AAAA000000000014 /* ImmersivePlugin.swift */,
 				F1000001AAAA000000000015 /* PipPlugin.swift */,
 				F1000001AAAA000000000016 /* CastPlugin.swift */,
+				F1000001AAAA000000000017 /* AudioCapabilitiesPlugin.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -248,6 +251,7 @@
 				F1000001AAAA000000000004 /* ImmersivePlugin.swift in Sources */,
 				F1000001AAAA000000000005 /* PipPlugin.swift in Sources */,
 				F1000001AAAA000000000006 /* CastPlugin.swift in Sources */,
+				F1000001AAAA000000000007 /* AudioCapabilitiesPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -51,6 +51,8 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
     private var timeObserver: Any?
     private var statusObserver: NSKeyValueObservation?
     private var rateObserver: NSKeyValueObservation?
+    private var firstFrameObserver: NSKeyValueObservation?
+    private var firstFrameEmitted = false
     private var savedBrightness: CGFloat?
 
     /// Exposed for PipPlugin to access the player layer.
@@ -176,6 +178,7 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
 
             // Clean up previous player
             self.removeObservers()
+            self.firstFrameEmitted = false
             self.player?.pause()
 
             // Create AVURLAsset with custom headers
@@ -190,10 +193,30 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
                 "AVURLAssetHTTPHeaderFieldsKey": assetHeaders,
             ])
 
-            let playerItem = AVPlayerItem(asset: asset)
-            // Start with high bitrate preference so AVPlayer picks the best rendition immediately
-            playerItem.preferredPeakBitRate = 100_000_000  // 100 Mbps — effectively no limit
+            // Preload `playable`/`tracks`/`duration` so `.readyToPlay` fires
+            // without a second round-trip after the asset header arrives.
+            let playerItem = AVPlayerItem(
+                asset: asset,
+                automaticallyLoadedAssetKeys: ["playable", "tracks", "duration"]
+            )
+            // Cap ABR to the device's native resolution. The backend transcodes
+            // a fresh FFmpeg session per rung — each ABR switch warms a new
+            // pipeline and starves segments (visible as multi-second freezes
+            // with audio continuing). Locking to one rung at load avoids the
+            // thrash; `setMaxResolution` from the engine overrides this later
+            // when the user picks a quality.
+            let screen = UIScreen.main
+            playerItem.preferredMaximumResolution = CGSize(
+                width: screen.bounds.width * screen.scale,
+                height: screen.bounds.height * screen.scale
+            )
+            playerItem.preferredPeakBitRate = Self.peakBitRateForHeight(
+                Int(screen.bounds.height * screen.scale)
+            )
             let player = AVPlayer(playerItem: playerItem)
+            // Don't second-guess AVPlayer's prebuffer — let it wait until it
+            // has enough video to play without immediate stall.
+            player.automaticallyWaitsToMinimizeStalling = true
             self.player = player
 
             // Setup player layer
@@ -558,6 +581,21 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             }
         }
 
+        // First-frame painted — flip the Angular fanart/spinner off.
+        // `AVPlayerLayer.isReadyForDisplay` is the canonical signal that
+        // the layer has decoded + composited a frame to the surface;
+        // mirrors ExoPlayer's `onRenderedFirstFrame` on Android.
+        // `initial: .new` fires once synchronously, so we gate on
+        // `firstFrameEmitted` to skip the pre-load `false` value and emit
+        // only on the actual flip to `true`.
+        if let layer = playerLayer {
+            firstFrameObserver = layer.observe(\.isReadyForDisplay, options: [.new]) { [weak self] layer, _ in
+                guard let self = self, layer.isReadyForDisplay, !self.firstFrameEmitted else { return }
+                self.firstFrameEmitted = true
+                self.emitFirstFrame()
+            }
+        }
+
         // Buffering detection
         NotificationCenter.default.addObserver(
             self,
@@ -590,6 +628,8 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         }
         statusObserver?.invalidate()
         statusObserver = nil
+        firstFrameObserver?.invalidate()
+        firstFrameObserver = nil
         rateObserver?.invalidate()
         rateObserver = nil
         NotificationCenter.default.removeObserver(self)
@@ -661,6 +701,13 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private func emitStateChanged(_ state: String) {
         let js = "window.dispatchEvent(new CustomEvent('nativePlayerStateChanged', { detail: { state: '\(state)' } }));"
+        DispatchQueue.main.async { [weak self] in
+            self?.bridge?.webView?.evaluateJavaScript(js)
+        }
+    }
+
+    private func emitFirstFrame() {
+        let js = "window.dispatchEvent(new CustomEvent('nativePlayerFirstFrame'));"
         DispatchQueue.main.async { [weak self] in
             self?.bridge?.webView?.evaluateJavaScript(js)
         }

--- a/client/ios/App/Podfile.lock
+++ b/client/ios/App/Podfile.lock
@@ -11,6 +11,8 @@ PODS:
     - Capacitor
   - CapacitorPreferences (8.0.1):
     - Capacitor
+  - CapacitorSplashScreen (8.0.1):
+    - Capacitor
   - google-cast-sdk (4.8.4)
   - IONFilesystemLib (1.1.2)
 
@@ -21,6 +23,7 @@ DEPENDENCIES:
   - "CapacitorFilesystem (from `../../node_modules/@capacitor/filesystem`)"
   - "CapacitorKeyboard (from `../../node_modules/@capacitor/keyboard`)"
   - "CapacitorPreferences (from `../../node_modules/@capacitor/preferences`)"
+  - "CapacitorSplashScreen (from `../../node_modules/@capacitor/splash-screen`)"
   - google-cast-sdk (~> 4.8)
 
 SPEC REPOS:
@@ -41,6 +44,8 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/keyboard"
   CapacitorPreferences:
     :path: "../../node_modules/@capacitor/preferences"
+  CapacitorSplashScreen:
+    :path: "../../node_modules/@capacitor/splash-screen"
 
 SPEC CHECKSUMS:
   Capacitor: 22e541237135648c9aa736232bb4d2eec35fddcb
@@ -49,9 +54,10 @@ SPEC CHECKSUMS:
   CapacitorFilesystem: 2db285a1ac6e475cc27cae2e1bea999000f9e2be
   CapacitorKeyboard: 8aa4f4ae80b2c92f92c07bf0181c464c2e7f5ff0
   CapacitorPreferences: cca2021f386efb75947c850334447d9ff22b14f1
+  CapacitorSplashScreen: 4b46c72298db552b3c57ce021ef028b6dc7f1fa7
   google-cast-sdk: 32f65af50d164e3c475e79ad123db3cc26fbcd37
   IONFilesystemLib: 21a63377696b2d8fab5632ecfb7d2ac67bddb68a
 
-PODFILE CHECKSUM: 7156eb4384d1e6a6a4eca43f3c1b2c6f09093720
+PODFILE CHECKSUM: fe9a521ab0077bf2a93b8373a56743fcbe2f5fc8
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
## Summary

- **Spinner stuck on iOS**: emit `nativePlayerFirstFrame` via KVO on `AVPlayerLayer.isReadyForDisplay` so Angular's `videoStarted` flips and the fanart/spinner overlay clears once the video actually paints.
- **ABR freezes (audio plays, video stalls)**: drop the 100 Mbps peak-bitrate hack on iOS, cap at device-native resolution at load. Emit per-rung H.264 `CODECS` and add `AVERAGE-BANDWIDTH` in the master playlist so AVPlayer doesn't reinit the decoder when VT segments signal L5.x.
- **HDR error -12927**: force `bt709 / tv` color signaling on the H.264 VUI when tonemap=true. `h264_videotoolbox` was leaking BT.2020/PQ from the source.
- **Build fix**: register `AudioCapabilitiesPlugin.swift` in the Xcode App target.

## Test plan

- [ ] iOS: launch playback on a 1080p SDR title → spinner disappears at first frame, no ABR freeze
- [ ] iOS: launch playback on a 4K HDR title → no -12927 error, tonemapped SDR plays
- [ ] Android: spinner + ABR unchanged (no regression on the Android plugin path)
- [ ] macOS Shaka: master playlist still parses, ABR behaviour unchanged