### PR TITLE
Codec architecture refactor + HEVC HDR + cinema-aspect fixes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,17 @@
 #   - every push to main               → `main` tag for downstream tests
 #   - manual workflow_dispatch         → `manual-<sha>` tag, ad-hoc rebuilds
 #
+# Build topology:
+#   - Releases (`v*` tag) and `main` pushes: matrix on linux/amd64 +
+#     linux/arm64, each on its native runner (no QEMU emulation). Two
+#     parallel single-arch builds → merge job combines digests into one
+#     multi-arch manifest.
+#   - workflow_dispatch (test images): amd64 only — most ad-hoc test
+#     deployments are TrueNAS SCALE / generic x86 servers, and an arm64
+#     build under emulation used to add ~3 min per iteration. The matrix
+#     degenerates to one element; the merge job still runs and creates a
+#     single-platform manifest with the requested tag.
+#
 # First push leaves the package private — flip it to Public once via
 # https://github.com/orgs/fliks-app/packages → fliks → settings →
 # Change visibility. After that, TrueNAS users (and anyone else) can
@@ -29,10 +40,88 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-push:
+  setup:
     runs-on: ubuntu-latest
+    outputs:
+      platforms: ${{ steps.set.outputs.platforms }}
+    steps:
+      - id: set
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo 'platforms=[{"platform":"linux/amd64","runner":"ubuntu-latest"}]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'platforms=[{"platform":"linux/amd64","runner":"ubuntu-latest"},{"platform":"linux/arm64","runner":"ubuntu-24.04-arm"}]' >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.setup.outputs.platforms) }}
+    runs-on: ${{ matrix.target.runner }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Sanitize platform for cache key
+        id: sanitize
+        run: echo "tag=$(echo '${{ matrix.target.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ matrix.target.platform }}
+          # push-by-digest: each matrix job pushes its single-arch image
+          # under a content-addressable digest only (no human tag). The
+          # merge job stitches the digests into a multi-arch manifest and
+          # applies the actual tags.
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            TMDB_API_KEY=${{ secrets.TMDB_API_KEY }}
+            TVDB_API_KEY=${{ secrets.TVDB_API_KEY }}
+          # Per-platform cache scope: amd64 and arm64 caches never share
+          # layers (different base manifest + apt arch), so a single
+          # `gha` scope just causes cross-eviction.
+          cache-from: type=gha,scope=${{ steps.sanitize.outputs.tag }}
+          cache-to: type=gha,mode=max,scope=${{ steps.sanitize.outputs.tag }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ steps.sanitize.outputs.tag }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -50,39 +139,20 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            # Tag pushes (release-please's v1.2.3 produces all of these)
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            # Branch pushes (main → :main, useful for downstream smoke tests)
             type=ref,event=branch
-            # Manual / ad-hoc runs — always include the sha tag for
-            # traceability + a custom tag from the workflow input (defaults
-            # to "test"). The custom tag is what you pull from TrueNAS /
-            # staging to validate a branch before merging to main.
             type=raw,value=manual-{{sha}},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' }}
-            # `:latest` only on tag pushes — never on a main commit, so a
-            # broken main never overrides a stable tag for users tracking
-            # `:latest`.
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          push: true
-          # Multi-arch: amd64 covers TrueNAS SCALE / generic x86 servers,
-          # arm64 covers Apple Silicon Docker Desktop (M1+), ARM NAS, Pi 5.
-          # HW transcode accel (QSV/VAAPI/NVENC) is x86-Linux only — arm64
-          # users fall back to libx264 CPU encoding (no Metal/VideoToolbox
-          # passthrough from container to host on Docker Desktop).
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            TMDB_API_KEY=${{ secrets.TMDB_API_KEY }}
-            TVDB_API_KEY=${{ secrets.TVDB_API_KEY }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -2524,26 +2524,20 @@ export class MediaService {
       }
 
       // Always re-probe streamInfo (fast, ~1s) to pick up schema changes.
-      // Skip detectCrop (~5-10s) if file size is unchanged AND crop has
-      // already been recorded — both conditions guard against the same
-      // expensive scan, but skipping when crop is missing leaves files
-      // imported before detectCrop existed (or after a failed probe)
-      // stuck without crop metadata forever. Backfill in that case.
+      // Skip detectCrop (~5-10s parallel) when the file size hasn't
+      // changed — crop is a property of the file, so unchanged bytes
+      // mean unchanged crop. Backfilling files that lack crop metadata
+      // would otherwise force every legacy rescan to do the slow probe
+      // again. Operators can force re-detection by deleting the dbFile
+      // row or temporarily breaking the size match.
       const sizeUnchanged = dbFile.size === diskSize;
-      const cropAlreadyRecorded =
-        (dbFile.streamInfo as { video?: { crop?: unknown }[] } | undefined)
-          ?.video?.[0]?.crop != null;
-      const shouldRunCropDetect = !sizeUnchanged || !cropAlreadyRecorded;
       dbFile.size = diskSize;
       let streamInfo: Awaited<
         ReturnType<FfprobeService['detectMediaFileInfo']>
       >;
       try {
         streamInfo = await this.ffprobe.detectMediaFileInfo(absPath);
-        if (streamInfo?.video?.[0] && shouldRunCropDetect) {
-          this.log.log(
-            `Rescan: running detectCrop for "${normPath}" (sizeUnchanged=${sizeUnchanged}, cropAlreadyRecorded=${cropAlreadyRecorded})`,
-          );
+        if (streamInfo?.video?.[0] && !sizeUnchanged) {
           try {
             const v = streamInfo.video[0];
             const crop = await this.ffprobe.detectCrop(
@@ -2582,7 +2576,7 @@ export class MediaService {
         await this.mediaFileRepo.save(dbFile);
         updated++;
         this.log.log(
-          `Rescan: refreshed "${normPath}" for media #${mediaId} (size: ${diskSize}, quality: ${qualityName}${!shouldRunCropDetect ? ', skipped crop' : ''})`,
+          `Rescan: refreshed "${normPath}" for media #${mediaId} (size: ${diskSize}, quality: ${qualityName}${sizeUnchanged ? ', skipped crop' : ''})`,
         );
         if (!options?.skipWarmup) {
           void this.subtitleStream.warmupCache(

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -2232,6 +2232,7 @@ export class MediaService {
             streamInfo.durationSeconds,
             v.width,
             v.height,
+            !!v.hdrFormat,
           );
           if (crop) v.crop = crop;
         } catch (err) {
@@ -2550,6 +2551,7 @@ export class MediaService {
               streamInfo.durationSeconds,
               v.width,
               v.height,
+              !!v.hdrFormat,
             );
             if (crop) v.crop = crop;
           } catch (err) {
@@ -2697,6 +2699,7 @@ export class MediaService {
               streamInfo.durationSeconds,
               v.width,
               v.height,
+              !!v.hdrFormat,
             );
             if (crop) v.crop = crop;
           } catch (err) {

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -2532,16 +2532,17 @@ export class MediaService {
       const cropAlreadyRecorded =
         (dbFile.streamInfo as { video?: { crop?: unknown }[] } | undefined)
           ?.video?.[0]?.crop != null;
+      const shouldRunCropDetect = !sizeUnchanged || !cropAlreadyRecorded;
       dbFile.size = diskSize;
       let streamInfo: Awaited<
         ReturnType<FfprobeService['detectMediaFileInfo']>
       >;
       try {
         streamInfo = await this.ffprobe.detectMediaFileInfo(absPath);
-        if (
-          streamInfo?.video?.[0] &&
-          (!sizeUnchanged || !cropAlreadyRecorded)
-        ) {
+        if (streamInfo?.video?.[0] && shouldRunCropDetect) {
+          this.log.log(
+            `Rescan: running detectCrop for "${normPath}" (sizeUnchanged=${sizeUnchanged}, cropAlreadyRecorded=${cropAlreadyRecorded})`,
+          );
           try {
             const v = streamInfo.video[0];
             const crop = await this.ffprobe.detectCrop(
@@ -2579,7 +2580,7 @@ export class MediaService {
         await this.mediaFileRepo.save(dbFile);
         updated++;
         this.log.log(
-          `Rescan: refreshed "${normPath}" for media #${mediaId} (size: ${diskSize}, quality: ${qualityName}${sizeUnchanged ? ', skipped crop' : ''})`,
+          `Rescan: refreshed "${normPath}" for media #${mediaId} (size: ${diskSize}, quality: ${qualityName}${!shouldRunCropDetect ? ', skipped crop' : ''})`,
         );
         if (!options?.skipWarmup) {
           void this.subtitleStream.warmupCache(

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -2523,15 +2523,25 @@ export class MediaService {
       }
 
       // Always re-probe streamInfo (fast, ~1s) to pick up schema changes.
-      // Skip detectCrop (~5-10s) if file size is unchanged — crop doesn't change.
+      // Skip detectCrop (~5-10s) if file size is unchanged AND crop has
+      // already been recorded — both conditions guard against the same
+      // expensive scan, but skipping when crop is missing leaves files
+      // imported before detectCrop existed (or after a failed probe)
+      // stuck without crop metadata forever. Backfill in that case.
       const sizeUnchanged = dbFile.size === diskSize;
+      const cropAlreadyRecorded =
+        (dbFile.streamInfo as { video?: { crop?: unknown }[] } | undefined)
+          ?.video?.[0]?.crop != null;
       dbFile.size = diskSize;
       let streamInfo: Awaited<
         ReturnType<FfprobeService['detectMediaFileInfo']>
       >;
       try {
         streamInfo = await this.ffprobe.detectMediaFileInfo(absPath);
-        if (streamInfo?.video?.[0] && !sizeUnchanged) {
+        if (
+          streamInfo?.video?.[0] &&
+          (!sizeUnchanged || !cropAlreadyRecorded)
+        ) {
           try {
             const v = streamInfo.video[0];
             const crop = await this.ffprobe.detectCrop(

--- a/backend/src/modules/streaming/active-stream-tracker.service.ts
+++ b/backend/src/modules/streaming/active-stream-tracker.service.ts
@@ -217,17 +217,6 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
     return { lowPower: this.qsvLowPowerCache };
   }
 
-  /** Global HEVC HDR encoder toggle, driven by admin streaming settings.
-   *  When false, stream-builder tone-maps HDR sources to H.264 SDR
-   *  instead of routing them through the HEVC HDR ladder. */
-  private hevcHdrEnabledCache = true;
-  setHevcHdrEnabled(value: boolean) {
-    this.hevcHdrEnabledCache = value;
-  }
-  getHevcHdrEnabled(): boolean {
-    return this.hevcHdrEnabledCache;
-  }
-
   // ── Source-vs-client compat captured at playback-info time, read at
   //    master.m3u8 time to decide whether to emit a smart-remux variant ──
   private readonly canCopyVideoCache = new Map<number, boolean>();

--- a/backend/src/modules/streaming/active-stream-tracker.service.ts
+++ b/backend/src/modules/streaming/active-stream-tracker.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import type { BurnInSubtitle } from './transcoding';
+import type { CodecVariant } from './transcoding/codec/types';
 
 export interface DirectPlaySession {
   userId: number;
@@ -99,6 +100,19 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
   }
   getHdrLadder(mediaFileId: number): boolean {
     return this.hdrLadderCache.get(mediaFileId) ?? false;
+  }
+
+  /** Output codec variant chosen by stream-builder's selector. Read by
+   *  the controller when building the SessionContext so ffmpeg-args
+   *  resolves the right encoder descriptor. Single-codec-per-master
+   *  rule: only one variant per file at a time. */
+  private readonly videoVariantCache = new Map<number, CodecVariant>();
+  setVideoVariant(mediaFileId: number, variant: CodecVariant | null) {
+    if (variant) this.videoVariantCache.set(mediaFileId, variant);
+    else this.videoVariantCache.delete(mediaFileId);
+  }
+  getVideoVariant(mediaFileId: number): CodecVariant | undefined {
+    return this.videoVariantCache.get(mediaFileId);
   }
 
   setBurnIn(mediaFileId: number, info: BurnInSubtitle | undefined) {

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -15,6 +15,8 @@ import {
   getLadderForDevice,
   parseBitrateToBps,
 } from './transcoding';
+import { pickPrimaryVariant } from './transcoding/codec/selector';
+import type { CodecVariant } from './transcoding/codec/types';
 
 /**
  * Decides how a media file should be played: DirectPlay, DirectStream (remux), or Transcode.
@@ -125,6 +127,32 @@ export class StreamBuilderService {
     // filter or AVPlayer rejects with -12927 (mismatched VUI vs codec).
     const needsTonemapping = isSourceHdr && !useHdrLadder;
     this.activeStreamTracker.setHdrLadder(resolved.mediaFile.id, useHdrLadder);
+
+    // Codec selector: picks the variant the encoder pipeline will produce
+    // when the playback path lands on transcode. The result is stored in
+    // the tracker so the controller can thread it into every later
+    // session spawn via SessionContext.videoVariant. Today only the
+    // first-ranked variant is emitted (single codec per master); the
+    // remainder is kept in diagnostics. Source HDR + HEVC source still
+    // routes through `useHdrLadder` for backward compat — the selector's
+    // job here is to give the encoder layer an explicit variant target
+    // rather than rely on profile-name inference.
+    const detectedHwAccel = this.transcodingService.getDetectedHwAccel();
+    const userAgent = ''; // UA-driven quirks plumbed via a later patch
+    const selectedVariant = pickPrimaryVariant(
+      {
+        width: source.width ?? 0,
+        height: source.height ?? 0,
+        hdr: (source.hdrFormat as CodecVariant['hdr']) ?? null,
+      },
+      profile,
+      detectedHwAccel,
+      userAgent,
+    );
+    this.activeStreamTracker.setVideoVariant(
+      resolved.mediaFile.id,
+      selectedVariant,
+    );
     const needsBurnIn = !!burnInSubtitleId;
     const needsCrop = !!v?.crop;
 

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -18,6 +18,7 @@ import {
   profileFitsSource,
   requestedHwAccelFor,
 } from './transcoding';
+import { isDecoderEnabled } from './transcoding/codec/decoder-probe';
 import { pickPrimaryVariant } from './transcoding/codec/selector';
 import type { CodecVariant, VideoCodec } from './transcoding/codec/types';
 
@@ -336,13 +337,29 @@ export class StreamBuilderService {
       });
     }
     // Mirror the ffmpeg-args dispatch: same pipeline rule, same registry
-    // resolve. Picks up the registry's runtime fallback (e.g. h264_vaapi
-    // disabled → libx264) so the stats overlay reports the actual encoder
-    // that will run, not the host's nominal HW accel.
-    const requestedHwAccel = requestedHwAccelFor(
-      this.transcodingService.getDetectedHwAccel(),
-      { burnIn: needsBurnIn, crop: needsCrop },
-    );
+    // resolve, same qsvCanCrop hint. Picks up the registry's runtime
+    // fallback (e.g. h264_vaapi disabled → libx264) so the stats overlay
+    // reports the actual encoder that will run, not the host's nominal
+    // HW accel.
+    const detectedHw = this.transcodingService.getDetectedHwAccel();
+    const normalisedSourceCodecForDecode = normaliseCodec(sourceVideoCodec);
+    const qsvNativeAvailableForReport =
+      detectedHw === 'qsv' &&
+      needsCrop &&
+      !needsTonemapping &&
+      !needsBurnIn &&
+      normalisedSourceCodecForDecode != null &&
+      isDecoderEnabled(
+        `${normalisedSourceCodecForDecode}_qsv_native_decode`,
+      );
+    const qsvCanCropForReport =
+      qsvNativeAvailableForReport ||
+      (detectedHw === 'qsv' && needsCrop && needsTonemapping && !needsBurnIn);
+    const requestedHwAccel = requestedHwAccelFor(detectedHw, {
+      burnIn: needsBurnIn,
+      crop: needsCrop,
+      qsvCanCrop: qsvCanCropForReport,
+    });
     const effectiveHwAccel =
       encoderRegistry.resolve(selectedVariant, requestedHwAccel)?.hwAccel ??
       'none';

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -105,23 +105,19 @@ export class StreamBuilderService {
     const isSourceHdr = !!source.hdrFormat;
     const clientSupportsHdr = profile.supportsHdr === true;
     // HEVC HDR ladder eligibility. Triggers a separate master.m3u8 path
-    // (HEVC Main10 transcodes + remux at source resolution, all carrying
-    // BT.2020/PQ in their VUI) instead of the H.264 SDR ladder. Gated by:
-    //   - Source video codec is HEVC (only codec we can pass through /
-    //     re-encode while preserving HDR signaling in HLS).
+    // (HEVC Main10 transcodes carrying BT.2020/PQ in their VUI) instead
+    // of the H.264 SDR ladder. Gated by:
+    //   - Source video codec is HEVC (only codec we re-encode while
+    //     preserving HDR signaling in HLS).
     //   - Client claims HDR support (browser-device-profile sourced from
     //     `AVPlayer.eligibleForHDRPlayback` on iOS, MediaCapabilities on
     //     web/Android).
-    //   - HEVC encoding is enabled in admin streaming settings. The
-    //     toggle falls back to H.264 SDR tonemap on every rung for
-    //     deployments whose HW path can't sustain hevc_qsv Main10
-    //     (older Intel iGPUs, no Main10 encoder available).
-    const hevcEnabled = this.activeStreamTracker.getHevcHdrEnabled();
+    // Encoder availability is checked downstream by the codec selector
+    // via `encoderRegistry.resolve()` — deployments without a working
+    // hevc_qsv Main10 path automatically fall back to libx265 (or to
+    // H.264 SDR if the source isn't HEVC).
     const useHdrLadder =
-      isSourceHdr &&
-      clientSupportsHdr &&
-      sourceVideoCodec === 'hevc' &&
-      hevcEnabled;
+      isSourceHdr && clientSupportsHdr && sourceVideoCodec === 'hevc';
     // Tone-map iff the source is HDR and we're not routing through the
     // HDR ladder. Anything that re-encodes via H.264 needs the tonemap
     // filter or AVPlayer rejects with -12927 (mismatched VUI vs codec).

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -19,6 +19,7 @@ import {
   requestedHwAccelFor,
 } from './transcoding';
 import { isDecoderEnabled } from './transcoding/codec/decoder-probe';
+import { isVppQsvTonemapEnabled } from './transcoding/codec/vpp-qsv-probe';
 import { pickPrimaryVariant } from './transcoding/codec/selector';
 import type { CodecVariant, VideoCodec } from './transcoding/codec/types';
 
@@ -343,15 +344,17 @@ export class StreamBuilderService {
     // HW accel.
     const detectedHw = this.transcodingService.getDetectedHwAccel();
     const normalisedSourceCodecForDecode = normaliseCodec(sourceVideoCodec);
-    const qsvNativeAvailableForReport =
+    const hasUsableQsvNativeDecoderForReport =
       detectedHw === 'qsv' &&
-      needsCrop &&
-      !needsTonemapping &&
       !needsBurnIn &&
       normalisedSourceCodecForDecode != null &&
       isDecoderEnabled(
         `${normalisedSourceCodecForDecode}_qsv_native_decode`,
       );
+    const qsvNativeAvailableForReport =
+      hasUsableQsvNativeDecoderForReport &&
+      needsCrop &&
+      (!needsTonemapping || isVppQsvTonemapEnabled());
     const qsvCanCropForReport =
       qsvNativeAvailableForReport ||
       (detectedHw === 'qsv' && needsCrop && needsTonemapping && !needsBurnIn);

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -12,8 +12,11 @@ import {
   ORIGINAL_SEPARATE_RATIO,
   TranscodeProfile,
   TranscodingService,
+  encoderRegistry,
   getLadderForDevice,
   parseBitrateToBps,
+  profileFitsSource,
+  requestedHwAccelFor,
 } from './transcoding';
 import { pickPrimaryVariant } from './transcoding/codec/selector';
 import type { CodecVariant, VideoCodec } from './transcoding/codec/types';
@@ -332,17 +335,17 @@ export class StreamBuilderService {
         message: `HDR → SDR (tone mapping ${source.hdrFormat})`,
       });
     }
-    // Compute effective HW accel (same logic as transcoding/ffmpeg-args.ts buildFfmpegArgs):
-    // - Burn-in forces CPU for QSV/VAAPI/NVENC (filters need HW surfaces),
-    //   but NOT for VideoToolbox — VT decode outputs CPU buffers, so
-    //   subtitle filters work in-place.
-    // - QSV + crop falls back to VAAPI (fixed-size pool constraint)
-    let effectiveHwAccel = this.transcodingService.getDetectedHwAccel();
-    if (needsBurnIn && effectiveHwAccel !== 'videotoolbox') {
-      effectiveHwAccel = 'none';
-    } else if (effectiveHwAccel === 'qsv' && needsCrop) {
-      effectiveHwAccel = 'vaapi';
-    }
+    // Mirror the ffmpeg-args dispatch: same pipeline rule, same registry
+    // resolve. Picks up the registry's runtime fallback (e.g. h264_vaapi
+    // disabled → libx264) so the stats overlay reports the actual encoder
+    // that will run, not the host's nominal HW accel.
+    const requestedHwAccel = requestedHwAccelFor(
+      this.transcodingService.getDetectedHwAccel(),
+      { burnIn: needsBurnIn, crop: needsCrop },
+    );
+    const effectiveHwAccel =
+      encoderRegistry.resolve(selectedVariant, requestedHwAccel)?.hwAccel ??
+      'none';
 
     // Audio output decision — single source of truth for ffmpeg-args and
     // the master playlist. Three paths:
@@ -470,8 +473,8 @@ export class StreamBuilderService {
       source.formatBitRate ??
       (source.videoBitRate ?? 0) + (source.audioBitRate ?? 0);
 
-    const available = ladder.filter(
-      (p) => p.maxWidth <= sourceW || p.maxHeight <= sourceH,
+    const available = ladder.filter((p) =>
+      profileFitsSource(p, sourceW, sourceH),
     );
     if (!available.length) available.push(ladder[ladder.length - 1]);
     // Ladder is ordered top→bottom, so available[0] is the source-resolution rung.

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -336,12 +336,12 @@ export class StreamBuilderService {
     // - Burn-in forces CPU for QSV/VAAPI/NVENC (filters need HW surfaces),
     //   but NOT for VideoToolbox — VT decode outputs CPU buffers, so
     //   subtitle filters work in-place.
-    // QSV cropping is handled in-pipeline via hwdownload → CPU crop →
-    // hwupload, so it stays on QSV instead of falling back to VAAPI.
-    void needsCrop;
+    // - QSV + crop falls back to VAAPI (fixed-size pool constraint)
     let effectiveHwAccel = this.transcodingService.getDetectedHwAccel();
     if (needsBurnIn && effectiveHwAccel !== 'videotoolbox') {
       effectiveHwAccel = 'none';
+    } else if (effectiveHwAccel === 'qsv' && needsCrop) {
+      effectiveHwAccel = 'vaapi';
     }
 
     // Audio output decision — single source of truth for ffmpeg-args and

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -242,7 +242,9 @@ export class StreamBuilderService {
       const remuxBw =
         source.formatBitRate ??
         (source.videoBitRate ?? 0) + (source.audioBitRate ?? 0);
-      // Même échelle que le master.m3u8 (variantes transcodées après la ligne remux)
+      // Same scale as the master playlist's transcoded rungs — exposes
+      // a bitrate hint per quality so the stats overlay can plot the
+      // selected rung without re-deriving the bitrate ladder client-side.
       const transcodeBitrateByQuality: NonNullable<
         PlaybackInfoResponse['transcodeBitrateByQuality']
       > = {};

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -16,7 +16,7 @@ import {
   parseBitrateToBps,
 } from './transcoding';
 import { pickPrimaryVariant } from './transcoding/codec/selector';
-import type { CodecVariant } from './transcoding/codec/types';
+import type { CodecVariant, VideoCodec } from './transcoding/codec/types';
 
 /**
  * Decides how a media file should be played: DirectPlay, DirectStream (remux), or Transcode.
@@ -140,6 +140,7 @@ export class StreamBuilderService {
         width: source.width ?? 0,
         height: source.height ?? 0,
         hdr: (source.hdrFormat as CodecVariant['hdr']) ?? null,
+        codec: normaliseCodec(source.videoCodec),
       },
       profile,
       detectedHwAccel,
@@ -687,5 +688,30 @@ export class StreamBuilderService {
       audioSupported,
       videoConditionsMet,
     };
+  }
+}
+
+/** ffprobe-form codec name → `VideoCodec` union. Aliases (`h265`/`hvc1`/
+ *  `hev1` for HEVC, `avc1`/`avc` for H.264, `av01` for AV1) all collapse
+ *  to the canonical codec. Returns undefined when the source codec
+ *  isn't in our encoder universe (Theora, VP9, etc.) so the selector
+ *  falls through to the efficiency ranking. */
+function normaliseCodec(name: string | undefined): VideoCodec | undefined {
+  if (!name) return undefined;
+  switch (name.toLowerCase()) {
+    case 'h264':
+    case 'avc':
+    case 'avc1':
+      return 'h264';
+    case 'hevc':
+    case 'h265':
+    case 'hvc1':
+    case 'hev1':
+      return 'hevc';
+    case 'av1':
+    case 'av01':
+      return 'av1';
+    default:
+      return undefined;
   }
 }

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -336,12 +336,12 @@ export class StreamBuilderService {
     // - Burn-in forces CPU for QSV/VAAPI/NVENC (filters need HW surfaces),
     //   but NOT for VideoToolbox — VT decode outputs CPU buffers, so
     //   subtitle filters work in-place.
-    // - QSV + crop falls back to VAAPI (fixed-size pool constraint)
+    // QSV cropping is handled in-pipeline via hwdownload → CPU crop →
+    // hwupload, so it stays on QSV instead of falling back to VAAPI.
+    void needsCrop;
     let effectiveHwAccel = this.transcodingService.getDetectedHwAccel();
     if (needsBurnIn && effectiveHwAccel !== 'videotoolbox') {
       effectiveHwAccel = 'none';
-    } else if (effectiveHwAccel === 'qsv' && needsCrop) {
-      effectiveHwAccel = 'vaapi';
     }
 
     // Audio output decision — single source of truth for ffmpeg-args and

--- a/backend/src/modules/streaming/streaming-settings-cache.service.ts
+++ b/backend/src/modules/streaming/streaming-settings-cache.service.ts
@@ -12,17 +12,12 @@ export interface StreamingSettings {
     | 'slower'
     | 'veryslow';
   qsvLowPower: boolean;
-  /** Master switch for the HEVC HDR ladder. When false, HDR sources are
-   *  tone-mapped to H.264 SDR for every rung — useful when the HW
-   *  encoder can't sustain hevc_qsv Main10. */
-  hevcHdrEnabled: boolean;
 }
 
 const KEYS = [
   'streaming_segment_duration',
   'streaming_qsv_preset',
   'streaming_qsv_low_power',
-  'streaming_hevc_hdr_enabled',
 ] as const;
 
 @Injectable()
@@ -54,15 +49,11 @@ export class StreamingSettingsCache implements OnModuleInit {
 
   private async load(): Promise<StreamingSettings> {
     const values = await Promise.all(KEYS.map((k) => this.settings.get(k)));
-    const [duration, qsvPreset, qsvLowPower, hevcHdrEnabled] = values;
+    const [duration, qsvPreset, qsvLowPower] = values;
     return {
       segmentDuration: parseFloat(duration ?? '3') || 3,
       qsvPreset: (qsvPreset ?? 'faster') as StreamingSettings['qsvPreset'],
       qsvLowPower: qsvLowPower === 'true',
-      // Default true: HDR sources get the HEVC HDR ladder. Operators opt
-      // out via the streaming settings page when their HW path can't
-      // sustain hevc_qsv Main10.
-      hevcHdrEnabled: hevcHdrEnabled !== 'false',
     };
   }
 }

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -651,6 +651,7 @@ export class StreamingController {
         : this.activeStreamTracker.getDeviceType(mediaFileId);
     this.activeStreamTracker.setDeviceType(mediaFileId, deviceType);
 
+    const sdrVariant = this.activeStreamTracker.getVideoVariant(mediaFileId);
     const playlist = this.transcodingService.generateMasterPlaylist(
       mediaFileId,
       w,
@@ -665,6 +666,9 @@ export class StreamingController {
       (this.activeStreamTracker.getAudioPlan(mediaFileId)?.codec ?? 'aac') as
         | 'aac' | 'ac3' | 'eac3',
       hdrPassThrough,
+      // Only the SDR ladder branch consumes this — the HDR branch
+      // already drives its codec strings from `hdrPassThrough`.
+      sdrVariant && sdrVariant.hdr == null ? sdrVariant : undefined,
     );
 
     this.activeStreamTracker.setAudioStreamCount(

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -256,7 +256,16 @@ export class StreamingController {
       // avoids the spawn-then-kill dance; the player's first segment
       // fetch starts ffmpeg synchronously at the correct rung.
       if (startQuality === 'remux' || startQuality === 'original') return;
-      const targetQuality = startQuality;
+      // When the HDR ladder is in effect, the master only publishes
+      // `*-hdr` rungs. The frontend's saved quality is height-based
+      // (`1080p`), so translate to the HDR equivalent so prewarm
+      // doesn't spawn a doomed SDR session that the player will
+      // immediately kill and replace with the matching HDR rung.
+      const targetQuality =
+        this.activeStreamTracker.getHdrLadder(mediaFileId) &&
+        !startQuality.endsWith('-hdr')
+          ? `${startQuality}-hdr`
+          : startQuality;
       const startSegment = Math.max(0, secondsToSegmentIndex(effectiveStartAt));
 
       // Spawn early en PARALLÈLE de main (fire-and-forget). hlsSegment

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -192,6 +192,12 @@ export class StreamingController {
       audioPlan: this.activeStreamTracker.getAudioPlan(mediaFileId) ?? undefined,
       sourceVideoCodec: (si?.video?.[0]?.codec ?? '').toLowerCase() || undefined,
       isSourceHdr: !!si?.video?.[0]?.hdrFormat,
+      // Variant chosen by stream-builder's codec selector at
+      // playback-info time. Threads through every session spawn so
+      // ffmpeg-args resolves the matching encoder descriptor. Absent
+      // for callers that never reach playback-info (legacy direct
+      // URLs) — buildFfmpegArgs falls back to profile-name inference.
+      videoVariant: this.activeStreamTracker.getVideoVariant(mediaFileId),
     };
   }
 

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -26,6 +26,7 @@ import {
   PROFILES,
   DESKTOP_HDR_PROFILES,
   SessionContext,
+  getHdrLadderForDevice,
   getLadderForDevice,
 } from './transcoding';
 import { secondsToSegmentIndex } from './transcoding/constants';
@@ -246,12 +247,22 @@ export class StreamingController {
       const ctx = this.buildSessionContext(req, resolved, mediaFileId);
 
       // Prewarm only runs for transcode rungs. Plain `remux` / `original`
-      // pseudo-qualities map onto the top profile of the device ladder
-      // (HDR top rung is now a transcode, not a copy pass-through), so
-      // the same transcode prewarm applies.
+      // pseudo-qualities map onto the top profile of the device ladder.
+      // For HDR sources on HDR clients the master emits the HDR ladder
+      // (`<height>p-hdr` rung names), so the prewarm has to match —
+      // otherwise it spawns the top SDR rung (`2160p`), the player
+      // immediately asks for `1080p-hdr` (or whatever it picked from
+      // the master), and the orchestrator kills + respawns. The
+      // `useHdrLadder` decision was already cached by stream-builder
+      // at playback-info time.
+      const useHdrLadder =
+        this.activeStreamTracker.getHdrLadder(mediaFileId);
+      const ladderTop = useHdrLadder
+        ? getHdrLadderForDevice(deviceType)[0].name
+        : getLadderForDevice(deviceType)[0].name;
       const targetQuality =
         startQuality === 'remux' || startQuality === 'original'
-          ? getLadderForDevice(deviceType)[0].name
+          ? ladderTop
           : startQuality;
       const startSegment = Math.max(0, secondsToSegmentIndex(effectiveStartAt));
 

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -28,6 +28,7 @@ import {
   SessionContext,
   getHdrLadderForDevice,
   getLadderForDevice,
+  profileFitsSource,
 } from './transcoding';
 import { secondsToSegmentIndex } from './transcoding/constants';
 import { ThumbnailService } from './thumbnail.service';
@@ -336,7 +337,7 @@ export class StreamingController {
 
     const qualities: { key: string; label: string; estimatedSize: number }[] = [];
     for (const p of PROFILES) {
-      if (p.maxWidth > sourceWidth && p.maxHeight > sourceHeight) continue;
+      if (!profileFitsSource(p, sourceWidth, sourceHeight)) continue;
       const videoBps = this.parseBitrateString(p.videoBitrate);
       const audioBps = this.parseBitrateString(p.audioBitrate);
       const duration = (info as any)?.durationSeconds ?? 0;

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -246,24 +246,16 @@ export class StreamingController {
       if (existing && existing.process.exitCode === null) return;
       const ctx = this.buildSessionContext(req, resolved, mediaFileId);
 
-      // Prewarm only runs for transcode rungs. Plain `remux` / `original`
-      // pseudo-qualities map onto the top profile of the device ladder.
-      // For HDR sources on HDR clients the master emits the HDR ladder
-      // (`<height>p-hdr` rung names), so the prewarm has to match —
-      // otherwise it spawns the top SDR rung (`2160p`), the player
-      // immediately asks for `1080p-hdr` (or whatever it picked from
-      // the master), and the orchestrator kills + respawns. The
-      // `useHdrLadder` decision was already cached by stream-builder
-      // at playback-info time.
-      const useHdrLadder =
-        this.activeStreamTracker.getHdrLadder(mediaFileId);
-      const ladderTop = useHdrLadder
-        ? getHdrLadderForDevice(deviceType)[0].name
-        : getLadderForDevice(deviceType)[0].name;
-      const targetQuality =
-        startQuality === 'remux' || startQuality === 'original'
-          ? ladderTop
-          : startQuality;
+      // `remux` / `original` resolve to the player's actual rung only
+      // after the manifest loads — Shaka filters variants whose
+      // CODECS string the browser can't decode (HEVC Main10 L5.1 is
+      // commonly filtered on web), so the top rung we'd guess from
+      // the device ladder is often not what the player ends up
+      // requesting. Skipping the prewarm for these pseudo-labels
+      // avoids the spawn-then-kill dance; the player's first segment
+      // fetch starts ffmpeg synchronously at the correct rung.
+      if (startQuality === 'remux' || startQuality === 'original') return;
+      const targetQuality = startQuality;
       const startSegment = Math.max(0, secondsToSegmentIndex(effectiveStartAt));
 
       // Spawn early en PARALLÈLE de main (fire-and-forget). hlsSegment

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -862,7 +862,18 @@ export class StreamingController {
         sourceH,
         deviceType,
       );
-      const quality = (profiles[0] ?? PROFILES[PROFILES.length - 1]).name;
+      const baseQuality = (profiles[0] ?? PROFILES[PROFILES.length - 1]).name;
+      // Audio route can race ahead of the seek-restart's video session
+      // being registered: it sees no session, falls into this branch
+      // and spawns a brand-new one at the SDR top rung — which then
+      // kills the in-flight HDR session via `getOrCreateSession`'s
+      // quality-change path. Translate to the HDR rung when the master
+      // is publishing the HDR ladder so the spawned session matches.
+      const quality =
+        this.activeStreamTracker.getHdrLadder(mediaFileId) &&
+        !baseQuality.endsWith('-hdr')
+          ? `${baseQuality}-hdr`
+          : baseQuality;
       videoSession = await this.transcodingService.getOrCreateSession(
         mediaFileId,
         quality,

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -397,9 +397,6 @@ export class StreamingController {
       audioStreamRaw != null ? parseInt(audioStreamRaw, 10) : undefined;
 
     const ss = await this.getStreamingSettings();
-    // Push the global HEVC HDR toggle to the tracker before evaluate —
-    // stream-builder reads it synchronously to decide useHdrLadder.
-    this.activeStreamTracker.setHevcHdrEnabled(ss.hevcHdrEnabled);
 
     const result = this.streamBuilder.evaluate(
       resolved,

--- a/backend/src/modules/streaming/transcoding/codec/codec-strings.ts
+++ b/backend/src/modules/streaming/transcoding/codec/codec-strings.ts
@@ -1,0 +1,109 @@
+import type { EncoderTarget, HdrFormat } from './types';
+
+/** RFC 6381 CODECS attribute generators. Each function returns the
+ *  string that goes inside `CODECS="..."` on an `EXT-X-STREAM-INF`
+ *  master-playlist entry.
+ *
+ *  Why per-rung strings: iOS AVPlayer (and Shaka in strict mode) filter
+ *  variants whose declared profile doesn't match the bitstream SPS,
+ *  and reinitialise the decoder mid-stream when the declared level is
+ *  below what the SPS signals. Picking the level from `height × fps`
+ *  guarantees the manifest claim covers the actual encoder output.
+ */
+
+/** H.264 — `avc1.PPCCLL` (6 hex digits). High profile = `64`, constraint
+ *  set byte `00` (no flags), level encoded as hex. Levels are sized to
+ *  cover 60 fps at the rung resolution. */
+export function h264CodecString(target: EncoderTarget): string {
+  const { height } = target;
+  if (height >= 2160) return 'avc1.640034'; // High @ L5.2 — 4K60
+  if (height >= 1080) return 'avc1.64002a'; // High @ L4.2 — 1080p60 + headroom
+  if (height >= 720) return 'avc1.640020'; //  High @ L3.2 — 720p60
+  if (height >= 480) return 'avc1.64001f'; //  High @ L3.1 — 480p60
+  if (height >= 360) return 'avc1.64001e'; //  High @ L3.0 — 360p30
+  if (height >= 240) return 'avc1.640015'; //  High @ L2.1 — 240p60
+  return 'avc1.64000d'; //                     High @ L1.3 — 144p
+}
+
+/** HEVC SDR Main 8-bit — `hvc1.1.6.L<level*30>.B0`. Profile = Main,
+ *  profile-compat = `6`, tier = Main (`L`). */
+export function hevcMainCodecString(target: EncoderTarget): string {
+  return `hvc1.1.6.${hevcLevel(target.height)}.B0`;
+}
+
+/** HEVC HDR Main10 — `hvc1.2.4.L<level*30>.B0`. Profile space prefix
+ *  `2` = profile_space + profile_idc combined (Main10), compat `4`. */
+export function hevcMain10CodecString(target: EncoderTarget): string {
+  return `hvc1.2.4.${hevcLevel(target.height)}.B0`;
+}
+
+/** AV1 — `av01.<profile>.<level><tier>.<bit_depth>` (simplified form;
+ *  Apple/Android both accept this short form for HLS). Profile 0 = Main,
+ *  tier `M` = Main, level = `level_idc * 30`. */
+export function av1CodecString(target: EncoderTarget, bitDepth: 8 | 10): string {
+  return `av01.0.${av1Level(target)}M.${String(bitDepth).padStart(2, '0')}`;
+}
+
+/** Dolby Vision — `dvh1.PP.LL`. Apple HLS requires `dvh1` (parameter sets
+ *  in moov), never `dvhe`. Profile and level pulled from the source's DV
+ *  RPU sidedata when present. Listed for completeness — we don't transcode
+ *  to DV, only pass through on DirectPlay. */
+export function dolbyVisionCodecString(
+  profile: number,
+  level: number,
+): string {
+  return `dvh1.${pad2(profile)}.${pad2(level)}`;
+}
+
+/** Generates `SUPPLEMENTAL-CODECS` value for HDR10+/DV backward-compat
+ *  variants. Apple HLS 2024+. */
+export function supplementalCodecsBrand(hdr: HdrFormat): string | null {
+  switch (hdr) {
+    case 'HDR10':
+      return null; // No supplemental codec for vanilla HDR10
+    case 'HLG':
+      return null;
+    case 'DV5':
+      return null; // Profile 5 has no HDR10/HLG fallback
+    case 'DV81':
+      return 'db1p'; // DV 8.1 → HDR10 BL
+    case 'DV84':
+      return 'db4h'; // DV 8.4 → HLG BL
+  }
+}
+
+/** VIDEO-RANGE master-playlist attribute. iOS AVPlayer reads this to
+ *  filter variants by display transfer-function compatibility. */
+export function videoRange(hdr: HdrFormat | null): 'SDR' | 'PQ' | 'HLG' {
+  if (hdr == null) return 'SDR';
+  if (hdr === 'HLG') return 'HLG';
+  return 'PQ'; // HDR10, DV5, DV81, DV84 all carry PQ-tagged transfer
+}
+
+// ───────────────────────── helpers ─────────────────────────
+
+/** HEVC level encoded as `L<level_idc>` where `level_idc = level * 30`.
+ *  Sized to cover 60 fps at the rung resolution. */
+function hevcLevel(height: number): string {
+  if (height >= 2160) return 'L153'; // L5.1 — 4K60
+  if (height >= 1080) return 'L123'; // L4.1 — 1080p60
+  if (height >= 720) return 'L120'; //  L4.0 — 720p60
+  return 'L93'; //                      L3.1 — up to 720p30
+}
+
+/** AV1 level encoded as `<level_idc>` (decimal). Levels follow the AV1
+ *  spec table A.3 (max display luma sample count per second). */
+function av1Level(target: EncoderTarget): string {
+  const { width, height, frameRate } = target;
+  const lumaPerSec = width * height * frameRate;
+  if (lumaPerSec > 1_069_547_520) return '13'; // L5.1 — 4K60
+  if (lumaPerSec > 530_841_600) return '12'; //   L5.0 — 4K30
+  if (lumaPerSec > 311_951_360) return '09'; //   L4.1 — 1080p60
+  if (lumaPerSec > 155_975_680) return '08'; //   L4.0 — 1080p30
+  if (lumaPerSec > 83_558_400) return '06'; //    L3.1 — 720p60
+  return '04'; //                                 L3.0 — 720p30
+}
+
+function pad2(n: number): string {
+  return n.toString().padStart(2, '0');
+}

--- a/backend/src/modules/streaming/transcoding/codec/decoder-probe.ts
+++ b/backend/src/modules/streaming/transcoding/codec/decoder-probe.ts
@@ -1,0 +1,180 @@
+import { Logger } from '@nestjs/common';
+import { execFile } from 'child_process';
+import { unlink, writeFile } from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { promisify } from 'util';
+import type { DecoderDescriptor } from './decoders/types';
+import type { VideoCodec } from './types';
+
+const execFileAsync = promisify(execFile);
+
+/** Decoder probe results, populated once at boot by `runDecoderProbes()`.
+ *  Read by the registry's `isUsable` gate. Same shape and semantics as
+ *  the encoder probe. */
+const probeResult = new Map<string, boolean>();
+let probedOnce = false;
+
+/** Default-true before the first probe wave finishes (services that
+ *  resolve a decoder during the brief boot window pre-probe get the CPU
+ *  fallback if the HW choice ends up disabled). Once the probe has run,
+ *  the explicit map wins. */
+export function isDecoderEnabled(descriptorId: string): boolean {
+  if (!probedOnce) return true;
+  return probeResult.get(descriptorId) ?? false;
+}
+
+/** Walk every decoder descriptor: synthesize a 1-frame bitstream in the
+ *  matching codec via a CPU encoder, then decode it with the descriptor
+ *  under test. HW decoders run strictly serially because Intel iGPUs
+ *  reject concurrent VAAPI/QSV contexts at boot (same pattern that
+ *  produced the encoder-probe false negatives). CPU decoders run in
+ *  parallel — no shared state. */
+export async function runDecoderProbes(
+  descriptors: readonly DecoderDescriptor[],
+  log: Logger,
+): Promise<void> {
+  const t0 = Date.now();
+
+  // Pre-generate one tiny test bitstream per source codec we'll probe.
+  // Re-using the same file across all decoders of that codec keeps the
+  // probe cheap and deterministic.
+  const codecs = new Set<VideoCodec>();
+  for (const d of descriptors) {
+    if (d.sourceCodec !== 'any') codecs.add(d.sourceCodec);
+  }
+  const samples = await prepareSampleBitstreams([...codecs]);
+
+  const cpuDescriptors: DecoderDescriptor[] = [];
+  const hwDescriptors: DecoderDescriptor[] = [];
+  for (const d of descriptors) {
+    (d.hwAccel === 'none' ? cpuDescriptors : hwDescriptors).push(d);
+  }
+
+  const runOne = async (
+    d: DecoderDescriptor,
+  ): Promise<{ id: string; ok: boolean }> => {
+    if (!d.supports()) {
+      probeResult.set(d.id, false);
+      return { id: d.id, ok: false };
+    }
+    // `'any'` (CPU software path) just needs to verify ffmpeg can run.
+    // We pick any sample for that — h264 is the safest bet (every
+    // ffmpeg build has libavcodec h264).
+    const samplePath =
+      d.sourceCodec === 'any'
+        ? (samples.get('h264') ?? null)
+        : (samples.get(d.sourceCodec) ?? null);
+    if (!samplePath) {
+      probeResult.set(d.id, false);
+      return { id: d.id, ok: false };
+    }
+    const ok = await probeOne(d, samplePath);
+    probeResult.set(d.id, ok);
+    return { id: d.id, ok };
+  };
+
+  const cpuTask = Promise.all(cpuDescriptors.map(runOne));
+  const hwTask = (async () => {
+    const out: { id: string; ok: boolean }[] = [];
+    for (const d of hwDescriptors) out.push(await runOne(d));
+    return out;
+  })();
+
+  const settled = (await Promise.all([cpuTask, hwTask])).flat();
+
+  // Cleanup the temp samples — best-effort, never throws.
+  await Promise.all(
+    [...samples.values()].map((p) => unlink(p).catch(() => {})),
+  );
+
+  probedOnce = true;
+  const enabled: string[] = [];
+  const disabled: string[] = [];
+  for (const r of settled) (r.ok ? enabled : disabled).push(r.id);
+  log.log(
+    `[decoder-probe] ${enabled.length}/${descriptors.length} enabled (${Date.now() - t0}ms): ${enabled.join(',')}${disabled.length ? ` | disabled: ${disabled.join(',')}` : ''}`,
+  );
+}
+
+/** Encode a tiny single-frame bitstream for each codec we need to probe.
+ *  Returns a map from codec → tmpfile path. Missing entries mean the CPU
+ *  encoder for that codec is missing from this ffmpeg build, which
+ *  cascades to "no decoder probe for that codec ran" — fine, those
+ *  descriptors stay disabled and the runtime falls back to CPU decode. */
+async function prepareSampleBitstreams(
+  codecs: VideoCodec[],
+): Promise<Map<VideoCodec, string>> {
+  const samples = new Map<VideoCodec, string>();
+  const encoderFor: Record<VideoCodec, { codec: string; ext: string }> = {
+    h264: { codec: 'libx264', ext: 'h264' },
+    hevc: { codec: 'libx265', ext: 'hevc' },
+    av1: { codec: 'libsvtav1', ext: 'ivf' },
+  };
+  for (const codec of codecs) {
+    const cfg = encoderFor[codec];
+    if (!cfg) continue;
+    const out = path.join(
+      os.tmpdir(),
+      `fliks-decoder-probe-${codec}-${process.pid}.${cfg.ext}`,
+    );
+    try {
+      await execFileAsync(
+        'ffmpeg',
+        [
+          '-hide_banner',
+          '-loglevel',
+          'error',
+          '-y',
+          '-f',
+          'lavfi',
+          '-i',
+          'nullsrc=size=320x180:rate=30',
+          '-frames:v',
+          '1',
+          '-c:v',
+          cfg.codec,
+          '-pix_fmt',
+          'yuv420p',
+          out,
+        ],
+        { timeout: 10_000 },
+      );
+      samples.set(codec, out);
+    } catch {
+      // Encoder missing in this ffmpeg build — leave the codec out of
+      // the map. Decoders for it will fail-fast in runOne above.
+      await writeFile(out, Buffer.alloc(0)).catch(() => {});
+      await unlink(out).catch(() => {});
+    }
+  }
+  return samples;
+}
+
+/** Run the descriptor's input args against a real bitstream, drop the
+ *  decoded frame straight to a null muxer. Exit 0 ⇒ both the device
+ *  init (when applicable) and the codec decode worked. */
+async function probeOne(
+  d: DecoderDescriptor,
+  samplePath: string,
+): Promise<boolean> {
+  const args = [
+    '-hide_banner',
+    '-loglevel',
+    'error',
+    ...d.buildInputArgs(),
+    '-i',
+    samplePath,
+    '-frames:v',
+    '1',
+    '-f',
+    'null',
+    '-',
+  ];
+  try {
+    await execFileAsync('ffmpeg', args, { timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/backend/src/modules/streaming/transcoding/codec/decoders/bridge.ts
+++ b/backend/src/modules/streaming/transcoding/codec/decoders/bridge.ts
@@ -1,0 +1,71 @@
+import type { HwAccelType } from '../../types';
+import type { BitDepth } from '../types';
+import type { SurfaceFormat } from './types';
+
+/** Build the filter snippet that turns a decoder output surface into the
+ *  surface the encoder expects. Returned string is either empty or ends
+ *  with a comma so the encoder concatenates it as-is at the head of its
+ *  `-vf` chain.
+ *
+ *  The semantics rely on libavfilter's standard bridges:
+ *  - `hwdownload,format=<sw>` : pull a HW surface to main memory at the
+ *    given software pixel format. nv12 for 8-bit, p010le for 10-bit.
+ *  - `format=<sw>,hwupload`   : push a software frame onto the active
+ *    HW device's surface pool.
+ *  - `hwmap=derive_device=<target>,format=<target>` : zero-copy reroute
+ *    when the source and target share GPU memory (VAAPI ↔ QSV on
+ *    Intel Linux). */
+export function surfaceBridge(
+  from: SurfaceFormat,
+  toHwAccel: HwAccelType,
+  bitDepth: BitDepth,
+): string {
+  const swFmt = bitDepth === 10 ? 'p010le' : 'nv12';
+
+  if (from === surfaceFormatFor(toHwAccel)) return '';
+
+  // CPU encoder: pull HW surfaces down to software. VideoToolbox decode
+  // is treated as `'cpu'` already, so it never falls in here.
+  if (toHwAccel === 'none') {
+    if (from === 'cpu') return '';
+    return `hwdownload,format=${swFmt},`;
+  }
+
+  // CPU source going to a HW encoder: upload onto the encoder's device.
+  if (from === 'cpu') {
+    if (toHwAccel === 'nvenc') return `format=${swFmt},hwupload_cuda,`;
+    // qsv and vaapi: the active filter device is initialised in the
+    // orchestrator's input setup, so plain hwupload picks the right
+    // target.
+    return `format=${swFmt},hwupload,`;
+  }
+
+  // VAAPI ↔ QSV: shared Intel device, hwmap is zero-copy.
+  if (from === 'vaapi' && toHwAccel === 'qsv') {
+    return `hwmap=derive_device=qsv,format=qsv,`;
+  }
+  if (from === 'qsv' && toHwAccel === 'vaapi') {
+    return `hwmap=derive_device=vaapi,format=vaapi,`;
+  }
+
+  // Cross-family HW (e.g. vaapi → cuda): nothing zero-copy. Round-trip
+  // through CPU. Slow but correct; not a path we exercise on supported
+  // configurations.
+  return `hwdownload,format=${swFmt},hwupload,`;
+}
+
+/** Map an encoder's `hwAccel` to the surface format its `-c:v` consumes. */
+function surfaceFormatFor(hwAccel: HwAccelType): SurfaceFormat {
+  switch (hwAccel) {
+    case 'qsv':
+      return 'qsv';
+    case 'vaapi':
+      return 'vaapi';
+    case 'nvenc':
+      return 'cuda';
+    case 'videotoolbox':
+      return 'videotoolbox';
+    case 'none':
+      return 'cpu';
+  }
+}

--- a/backend/src/modules/streaming/transcoding/codec/decoders/cpu.ts
+++ b/backend/src/modules/streaming/transcoding/codec/decoders/cpu.ts
@@ -1,0 +1,17 @@
+import type { DecoderDescriptor } from './types';
+
+/** Software decode. ffmpeg picks the right `libavcodec` decoder from the
+ *  source codec automatically — we don't pass `-c:v` because that's the
+ *  decoder's job, and ffmpeg's default selection (e.g. h264 → libavcodec
+ *  h264, hevc → hevc, av1 → libdav1d when built in) is what we want.
+ *  No HW device init means no `-hwaccel` flag — frames land in main
+ *  memory as the codec's native output (yuv420p, yuv420p10le, etc.). */
+export const cpuDecoder: DecoderDescriptor = {
+  id: 'cpu',
+  hwAccel: 'none',
+  sourceCodec: 'any',
+  maxBitDepth: 10,
+  outputSurface: 'cpu',
+  supports: () => true,
+  buildInputArgs: () => [],
+};

--- a/backend/src/modules/streaming/transcoding/codec/decoders/index.ts
+++ b/backend/src/modules/streaming/transcoding/codec/decoders/index.ts
@@ -1,0 +1,139 @@
+import type { HwAccelType } from '../../types';
+import type { VideoCodec } from '../types';
+import { isDecoderEnabled } from '../decoder-probe';
+import { cpuDecoder } from './cpu';
+import {
+  h264QsvDecoder,
+  hevcQsvDecoder,
+  av1QsvDecoder,
+  h264QsvNativeDecoder,
+  hevcQsvNativeDecoder,
+  av1QsvNativeDecoder,
+} from './qsv';
+import { h264VaapiDecoder, hevcVaapiDecoder, av1VaapiDecoder } from './vaapi';
+import { h264CudaDecoder, hevcCudaDecoder, av1CudaDecoder } from './nvenc';
+import {
+  h264VideotoolboxDecoder,
+  hevcVideotoolboxDecoder,
+} from './videotoolbox';
+import type {
+  DecoderDescriptor,
+  DecoderRegistry,
+  DecoderSourceInfo,
+} from './types';
+
+/** Static registry of every decoder descriptor compiled in. Order
+ *  matters: the first match wins when iterating, so HW entries come
+ *  before CPU. Within HW, we keep platform-native first (QSV before
+ *  VAAPI on Intel Linux to bias `vpp_qsv` crop). */
+const DESCRIPTORS: readonly DecoderDescriptor[] = [
+  // Intel modern path. Default qsv decoder emits VAAPI surfaces (drop-
+  // in compatible with the scale_vaapi-based encoder chains). A
+  // qsv-native variant emits QSV surfaces directly — selected only by
+  // paths that opt in (vpp_qsv crop in Phase 5+).
+  h264QsvDecoder,
+  hevcQsvDecoder,
+  av1QsvDecoder,
+  // Universal Linux fallback (also serves AMD).
+  h264VaapiDecoder,
+  hevcVaapiDecoder,
+  av1VaapiDecoder,
+  // NVIDIA.
+  h264CudaDecoder,
+  hevcCudaDecoder,
+  av1CudaDecoder,
+  // Apple.
+  h264VideotoolboxDecoder,
+  hevcVideotoolboxDecoder,
+  // CPU last — always wins as fallback for any codec.
+  cpuDecoder,
+];
+
+function matchesCodec(d: DecoderDescriptor, codec: VideoCodec): boolean {
+  return d.sourceCodec === 'any' || d.sourceCodec === codec;
+}
+
+function isUsable(d: DecoderDescriptor, src: DecoderSourceInfo): boolean {
+  if (!d.supports()) return false;
+  if (!matchesCodec(d, src.codec)) return false;
+  if (src.bitDepth > d.maxBitDepth) return false;
+  if (!isDecoderEnabled(d.id)) return false;
+  return true;
+}
+
+class StaticDecoderRegistry implements DecoderRegistry {
+  resolve(
+    source: DecoderSourceInfo,
+    preferredHwAccel: HwAccelType,
+  ): DecoderDescriptor {
+    // Pass 1: exact family match (decoder + encoder share surface
+    // device → bridge filter empty).
+    for (const d of DESCRIPTORS) {
+      if (d.hwAccel !== preferredHwAccel) continue;
+      if (!isUsable(d, source)) continue;
+      return d;
+    }
+    // Pass 2: any other HW decoder that can handle the codec — the
+    // surface bridge picks up the inter-device hop.
+    if (preferredHwAccel !== 'none') {
+      for (const d of DESCRIPTORS) {
+        if (d.hwAccel === 'none') continue;
+        if (d.hwAccel === preferredHwAccel) continue;
+        if (!isUsable(d, source)) continue;
+        return d;
+      }
+    }
+    // Pass 3: CPU. Always returns true on `isUsable` for ffmpeg-known
+    // codecs, so this branch never falls through.
+    return cpuDecoder;
+  }
+
+  candidates(
+    source: DecoderSourceInfo,
+    preferredHwAccel: HwAccelType,
+  ): DecoderDescriptor[] {
+    const out: DecoderDescriptor[] = [];
+    for (const d of DESCRIPTORS) {
+      if (d.hwAccel !== preferredHwAccel) continue;
+      if (!isUsable(d, source)) continue;
+      out.push(d);
+    }
+    if (preferredHwAccel !== 'none') {
+      for (const d of DESCRIPTORS) {
+        if (d.hwAccel === 'none' || d.hwAccel === preferredHwAccel) continue;
+        if (!isUsable(d, source)) continue;
+        out.push(d);
+      }
+    }
+    if (isUsable(cpuDecoder, source)) out.push(cpuDecoder);
+    return out;
+  }
+}
+
+/** Full list of compiled-in decoder descriptors, plus the qsv-native
+ *  variants which aren't in `DESCRIPTORS` (the resolver skips them
+ *  unless an opt-in path requests them by id). Both lists are used by
+ *  the boot probe. */
+export const ALL_DECODERS: readonly DecoderDescriptor[] = [
+  ...DESCRIPTORS,
+  h264QsvNativeDecoder,
+  hevcQsvNativeDecoder,
+  av1QsvNativeDecoder,
+];
+
+/** Lookup a qsv-native decoder by source codec — exposed for the
+ *  Phase 5 vpp_qsv crop path that bypasses the registry resolver. */
+export function findQsvNativeDecoder(
+  codec: 'h264' | 'hevc' | 'av1',
+): DecoderDescriptor | null {
+  switch (codec) {
+    case 'h264':
+      return h264QsvNativeDecoder;
+    case 'hevc':
+      return hevcQsvNativeDecoder;
+    case 'av1':
+      return av1QsvNativeDecoder;
+  }
+}
+
+export const decoderRegistry: DecoderRegistry = new StaticDecoderRegistry();

--- a/backend/src/modules/streaming/transcoding/codec/decoders/nvenc.ts
+++ b/backend/src/modules/streaming/transcoding/codec/decoders/nvenc.ts
@@ -1,0 +1,33 @@
+import type { DecoderDescriptor } from './types';
+import type { VideoCodec } from '../types';
+
+/** NVIDIA CUDA decode (paired with NVENC encode on the same device).
+ *  `-hwaccel cuda` keeps frames in CUDA surfaces; without
+ *  `-hwaccel_output_format cuda` the frames land in CPU memory, which
+ *  is what the NVENC tonemap CPU path wants. We always set the output
+ *  format here — the tonemap path uses `hwdownload` explicitly when it
+ *  needs CPU buffers. */
+function cudaDecoder(
+  codec: VideoCodec,
+  maxBitDepth: 8 | 10,
+): DecoderDescriptor {
+  return {
+    id: `${codec}_cuda_decode`,
+    hwAccel: 'nvenc',
+    sourceCodec: codec,
+    maxBitDepth,
+    outputSurface: 'cuda',
+    supports: () => true,
+    buildInputArgs: () => [
+      '-hwaccel',
+      'cuda',
+      '-hwaccel_output_format',
+      'cuda',
+      '-noautorotate',
+    ],
+  };
+}
+
+export const h264CudaDecoder = cudaDecoder('h264', 8);
+export const hevcCudaDecoder = cudaDecoder('hevc', 10);
+export const av1CudaDecoder = cudaDecoder('av1', 10);

--- a/backend/src/modules/streaming/transcoding/codec/decoders/qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/decoders/qsv.ts
@@ -1,0 +1,83 @@
+import type { DecoderDescriptor } from './types';
+import type { VideoCodec } from '../types';
+
+/** Build a QSV decoder descriptor for `codec`. Decode actually happens
+ *  on the VAAPI driver (Linux Intel) — libavcodec wires the qsv encoder
+ *  on top via the `qsv=qs@va` device that derives a QSV context from
+ *  the VAAPI one. Frames hit the filter chain as VAAPI surfaces, which
+ *  is what the existing `scale_vaapi → hwmap=qsv` encoder chains
+ *  expect. The 'qsv'-encoder native vpp_qsv crop path takes a
+ *  different decoder variant (see qsvNative below) so this default
+ *  one stays drop-in compatible. */
+function qsvDecoder(codec: VideoCodec, maxBitDepth: 8 | 10): DecoderDescriptor {
+  return {
+    id: `${codec}_qsv_decode`,
+    hwAccel: 'qsv',
+    sourceCodec: codec,
+    maxBitDepth,
+    // 'vaapi' rather than 'qsv': the decoder produces VAAPI surfaces
+    // that the qsv encoder filter chain hwmap's into qsv format. A
+    // future encoder chain that consumes qsv surfaces directly (Phase
+    // 5: vpp_qsv crop) opts into the qsv-native decoder below.
+    outputSurface: 'vaapi',
+    supports: () => true,
+    buildInputArgs: () => [
+      '-init_hw_device',
+      'vaapi=va:/dev/dri/renderD128',
+      '-init_hw_device',
+      'qsv=qs@va',
+      '-hwaccel',
+      'vaapi',
+      '-hwaccel_output_format',
+      'vaapi',
+      '-hwaccel_device',
+      'va',
+      '-extra_hw_frames',
+      '32',
+      '-noautorotate',
+    ],
+  };
+}
+
+/** QSV-native decoder variant — same iGPU but emits QSV surfaces
+ *  directly. Used by `vpp_qsv` crop / scale paths in Phase 5; the
+ *  default qsv decoder above stays VAAPI-output for compatibility
+ *  with the existing scale_vaapi-based encoder chains. */
+function qsvNativeDecoder(
+  codec: VideoCodec,
+  maxBitDepth: 8 | 10,
+): DecoderDescriptor {
+  return {
+    id: `${codec}_qsv_native_decode`,
+    hwAccel: 'qsv',
+    sourceCodec: codec,
+    maxBitDepth,
+    outputSurface: 'qsv',
+    supports: () => true,
+    buildInputArgs: () => [
+      '-init_hw_device',
+      'vaapi=va:/dev/dri/renderD128',
+      '-init_hw_device',
+      'qsv=qs@va',
+      '-filter_hw_device',
+      'qs',
+      '-hwaccel',
+      'qsv',
+      '-hwaccel_output_format',
+      'qsv',
+      '-hwaccel_device',
+      'qs',
+      '-extra_hw_frames',
+      '32',
+      '-noautorotate',
+    ],
+  };
+}
+
+export const h264QsvDecoder = qsvDecoder('h264', 8);
+export const hevcQsvDecoder = qsvDecoder('hevc', 10);
+export const av1QsvDecoder = qsvDecoder('av1', 10);
+
+export const h264QsvNativeDecoder = qsvNativeDecoder('h264', 8);
+export const hevcQsvNativeDecoder = qsvNativeDecoder('hevc', 10);
+export const av1QsvNativeDecoder = qsvNativeDecoder('av1', 10);

--- a/backend/src/modules/streaming/transcoding/codec/decoders/types.ts
+++ b/backend/src/modules/streaming/transcoding/codec/decoders/types.ts
@@ -1,0 +1,74 @@
+import type { HwAccelType } from '../../types';
+import type { BitDepth, VideoCodec } from '../types';
+
+/** Where the decoder lands its output frames. The orchestrator uses
+ *  this to compute the bridge filter that turns a decoder surface into
+ *  the format the encoder expects (see `surfaceBridge`).
+ *
+ *  - `'cpu'`         : software frames (e.g. yuv420p in main memory)
+ *  - `'vaapi'`       : libva surface, lives in iGPU/dGPU memory
+ *  - `'qsv'`         : Intel Media SDK QSV surface (sibling of vaapi
+ *                      but a different libavutil hwcontext)
+ *  - `'cuda'`        : NVIDIA CUDA surface
+ *  - `'videotoolbox'`: macOS IOSurface produced by VT decode (we keep
+ *                      the descriptor's `outputSurface` at `'cpu'` for
+ *                      now because the rest of the pipeline expects
+ *                      software frames on VT; future work can lift
+ *                      that constraint). */
+export type SurfaceFormat = 'cpu' | 'vaapi' | 'qsv' | 'cuda' | 'videotoolbox';
+
+/** Just enough source-side metadata for the decoder selector. Populated
+ *  from ffprobe streamInfo at session-spawn time. */
+export interface DecoderSourceInfo {
+  codec: VideoCodec;
+  bitDepth: BitDepth;
+}
+
+/** A single decoder binding — one ffmpeg decoder × one platform × one
+ *  source codec. Mirror of `EncoderDescriptor`: the orchestrator owns
+ *  no codec-specific decode logic, every quirk lives in one descriptor
+ *  file under `./decoders/`. */
+export interface DecoderDescriptor {
+  /** Stable identifier surfaced in logs and the boot probe summary
+   *  (e.g. `'hevc_qsv_decode'`). */
+  readonly id: string;
+  readonly hwAccel: HwAccelType;
+  /** Source codec this descriptor decodes. `'any'` covers the CPU
+   *  software path which handles every codec ffmpeg knows. */
+  readonly sourceCodec: VideoCodec | 'any';
+  /** Maximum source bit-depth this decoder can ingest. 10 covers 8 too. */
+  readonly maxBitDepth: BitDepth;
+  /** Surface format on the output side of the decode. Drives the
+   *  bridge filter we splice in front of the encoder. */
+  readonly outputSurface: SurfaceFormat;
+  /** Soft host-level capability check (e.g. `process.platform === 'darwin'`
+   *  for VideoToolbox). Runs build-time / sync. The runtime probe in
+   *  `decoder-probe.ts` is the second gate that catches missing
+   *  drivers, kernel modules and similar. */
+  supports(): boolean;
+  /** ffmpeg input args slice — `-hwaccel`, `-hwaccel_output_format`,
+   *  `-init_hw_device`, `-filter_hw_device`. Inserted before `-i` in
+   *  the orchestrator's `buildFfmpegArgs`. Does NOT include `-i`
+   *  itself or any input-only `-ss`/`-t` — those stay with the
+   *  orchestrator. */
+  buildInputArgs(): string[];
+}
+
+/** Selector / lookup over the registered decoders. */
+export interface DecoderRegistry {
+  /** Pick the preferred decoder for `source`, biased toward staying
+   *  on `preferredHwAccel` so the decoder and encoder share a device
+   *  and the surface bridge is empty. Falls back to CPU decode when
+   *  no HW decoder matches. Never returns `null` — `cpu` always
+   *  qualifies for any codec ffmpeg understands. */
+  resolve(
+    source: DecoderSourceInfo,
+    preferredHwAccel: HwAccelType,
+  ): DecoderDescriptor;
+  /** All decoders that could decode `source` on this host, ordered by
+   *  preference (same-family first, then other HW, CPU last). */
+  candidates(
+    source: DecoderSourceInfo,
+    preferredHwAccel: HwAccelType,
+  ): DecoderDescriptor[];
+}

--- a/backend/src/modules/streaming/transcoding/codec/decoders/vaapi.ts
+++ b/backend/src/modules/streaming/transcoding/codec/decoders/vaapi.ts
@@ -1,0 +1,39 @@
+import type { DecoderDescriptor } from './types';
+import type { VideoCodec } from '../types';
+
+/** VAAPI decode — universal Linux path. Output surfaces stay in VAAPI
+ *  memory until either the encoder consumes them (h264_vaapi / hevc_vaapi
+ *  / av1_vaapi) or a bridge filter (`hwmap` or `hwdownload`) reroutes
+ *  them. */
+function vaapiDecoder(
+  codec: VideoCodec,
+  maxBitDepth: 8 | 10,
+): DecoderDescriptor {
+  return {
+    id: `${codec}_vaapi_decode`,
+    hwAccel: 'vaapi',
+    sourceCodec: codec,
+    maxBitDepth,
+    outputSurface: 'vaapi',
+    supports: () => true,
+    buildInputArgs: () => [
+      '-init_hw_device',
+      'vaapi=va:/dev/dri/renderD128',
+      '-filter_hw_device',
+      'va',
+      '-hwaccel',
+      'vaapi',
+      '-hwaccel_output_format',
+      'vaapi',
+      '-hwaccel_device',
+      'va',
+      '-extra_hw_frames',
+      '32',
+      '-noautorotate',
+    ],
+  };
+}
+
+export const h264VaapiDecoder = vaapiDecoder('h264', 8);
+export const hevcVaapiDecoder = vaapiDecoder('hevc', 10);
+export const av1VaapiDecoder = vaapiDecoder('av1', 10);

--- a/backend/src/modules/streaming/transcoding/codec/decoders/videotoolbox.ts
+++ b/backend/src/modules/streaming/transcoding/codec/decoders/videotoolbox.ts
@@ -1,0 +1,27 @@
+import type { DecoderDescriptor } from './types';
+import type { VideoCodec } from '../types';
+
+/** Apple VideoToolbox decode. Output surface is treated as `'cpu'`:
+ *  VT can emit IOSurfaces (videotoolbox_vld) for the full Metal
+ *  pipeline, but every consuming filter we ship today (subtitle burn-
+ *  in, software scale, libass) operates on CPU buffers. The encoder
+ *  side (`hevc_videotoolbox` etc.) is happy ingesting CPU input too,
+ *  so keeping the surface at `'cpu'` matches the existing behaviour
+ *  while removing the hwAccel branching from ffmpeg-args. */
+function videotoolboxDecoder(
+  codec: VideoCodec,
+  maxBitDepth: 8 | 10,
+): DecoderDescriptor {
+  return {
+    id: `${codec}_videotoolbox_decode`,
+    hwAccel: 'videotoolbox',
+    sourceCodec: codec,
+    maxBitDepth,
+    outputSurface: 'cpu',
+    supports: () => process.platform === 'darwin',
+    buildInputArgs: () => ['-hwaccel', 'videotoolbox', '-noautorotate'],
+  };
+}
+
+export const h264VideotoolboxDecoder = videotoolboxDecoder('h264', 8);
+export const hevcVideotoolboxDecoder = videotoolboxDecoder('hevc', 10);

--- a/backend/src/modules/streaming/transcoding/codec/encoder-probe.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoder-probe.ts
@@ -68,7 +68,7 @@ export async function runEncoderProbes(
 
 async function probeOne(
   d: EncoderDescriptor,
-  log: Logger,
+  _log: Logger,
 ): Promise<boolean> {
   // Synthetic minimal input: a 320×180 black frame at the descriptor's
   // expected pixel layout. The encoder is invoked with the same arg
@@ -111,9 +111,11 @@ async function probeOne(
   try {
     await execFileAsync('ffmpeg', args, { timeout: 10_000 });
     return true;
-  } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
-    log.warn(`[encoder-probe] ${d.id} failed: ${msg.split('\n')[0]}`);
+  } catch {
+    // The disabled list in the summary log already names every failed
+    // descriptor; suppressing the per-failure WARN here keeps boot
+    // logs quiet on hosts where most HW paths aren't present (e.g.
+    // a QSV-only deployment legitimately fails 18+ probes).
     return false;
   }
 }

--- a/backend/src/modules/streaming/transcoding/codec/encoder-probe.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoder-probe.ts
@@ -47,15 +47,9 @@ export async function runEncoderProbes(
   const t0 = Date.now();
 
   const cpuDescriptors: EncoderDescriptor[] = [];
-  const hwGroups = new Map<string, EncoderDescriptor[]>();
+  const hwDescriptors: EncoderDescriptor[] = [];
   for (const d of descriptors) {
-    if (d.hwAccel === 'none') {
-      cpuDescriptors.push(d);
-    } else {
-      const bucket = hwGroups.get(d.hwAccel) ?? [];
-      bucket.push(d);
-      hwGroups.set(d.hwAccel, bucket);
-    }
+    (d.hwAccel === 'none' ? cpuDescriptors : hwDescriptors).push(d);
   }
 
   const runOne = async (
@@ -70,17 +64,21 @@ export async function runEncoderProbes(
     return { id: d.id, ok };
   };
 
+  // CPU probes in parallel (no shared state). Every HW probe runs
+  // strictly serially after the previous one finishes — QSV and VAAPI
+  // are nominally different `hwAccel`s but on Linux Intel they share
+  // a single iGPU device, and running them in parallel families still
+  // produced the 'internal encoding error 24' false negatives we were
+  // chasing.
   const cpuTask = Promise.all(cpuDescriptors.map(runOne));
 
-  const hwTasks = Array.from(hwGroups.values()).map(async (group) => {
+  const hwTask = (async () => {
     const out: { id: string; ok: boolean }[] = [];
-    for (const d of group) out.push(await runOne(d));
+    for (const d of hwDescriptors) out.push(await runOne(d));
     return out;
-  });
+  })();
 
-  const settled = (
-    await Promise.all([cpuTask, ...hwTasks])
-  ).flat();
+  const settled = (await Promise.all([cpuTask, hwTask])).flat();
 
   probedOnce = true;
   const enabled: string[] = [];

--- a/backend/src/modules/streaming/transcoding/codec/encoder-probe.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoder-probe.ts
@@ -32,34 +32,61 @@ export function isEncoderEnabled(descriptorId: string): boolean {
   return probeResult.get(descriptorId) ?? false;
 }
 
-/** Spawn one tiny ffmpeg per descriptor in parallel. Probe args are
- *  derived from each descriptor's `buildArgs()` so we exercise the
- *  exact encoder + pixel format + filter the runtime path uses (modulo
- *  the lavfi source and the 1-frame `-frames:v 1 -f null -` sink). */
+/** Probe one tiny ffmpeg per descriptor. HW-accel descriptors run
+ *  serially within their family because driver state on the iGPU /
+ *  dGPU is shared — 20+ concurrent VAAPI contexts trip 'internal
+ *  encoding error 24' even when each context, taken alone, encodes
+ *  cleanly. CPU descriptors run in parallel (no shared state).
+ *  Probe args are derived from each descriptor's `buildArgs()` so we
+ *  exercise the exact encoder + pixel format + filter the runtime
+ *  path uses (modulo the lavfi source and the `-f null -` sink). */
 export async function runEncoderProbes(
   descriptors: readonly EncoderDescriptor[],
   log: Logger,
 ): Promise<void> {
   const t0 = Date.now();
-  const results = await Promise.allSettled(
-    descriptors.map(async (d) => {
-      // Static gate first — no point probing what hw-detect already
-      // says is absent.
-      if (!d.supports()) {
-        probeResult.set(d.id, false);
-        return { id: d.id, ok: false, reason: 'supports()=false' };
-      }
-      const ok = await probeOne(d, log);
-      probeResult.set(d.id, ok);
-      return { id: d.id, ok, reason: ok ? 'ok' : 'probe-failed' };
-    }),
-  );
+
+  const cpuDescriptors: EncoderDescriptor[] = [];
+  const hwGroups = new Map<string, EncoderDescriptor[]>();
+  for (const d of descriptors) {
+    if (d.hwAccel === 'none') {
+      cpuDescriptors.push(d);
+    } else {
+      const bucket = hwGroups.get(d.hwAccel) ?? [];
+      bucket.push(d);
+      hwGroups.set(d.hwAccel, bucket);
+    }
+  }
+
+  const runOne = async (
+    d: EncoderDescriptor,
+  ): Promise<{ id: string; ok: boolean }> => {
+    if (!d.supports()) {
+      probeResult.set(d.id, false);
+      return { id: d.id, ok: false };
+    }
+    const ok = await probeOne(d, log);
+    probeResult.set(d.id, ok);
+    return { id: d.id, ok };
+  };
+
+  const cpuTask = Promise.all(cpuDescriptors.map(runOne));
+
+  const hwTasks = Array.from(hwGroups.values()).map(async (group) => {
+    const out: { id: string; ok: boolean }[] = [];
+    for (const d of group) out.push(await runOne(d));
+    return out;
+  });
+
+  const settled = (
+    await Promise.all([cpuTask, ...hwTasks])
+  ).flat();
+
   probedOnce = true;
   const enabled: string[] = [];
   const disabled: string[] = [];
-  for (const r of results) {
-    if (r.status !== 'fulfilled') continue;
-    (r.value.ok ? enabled : disabled).push(r.value.id);
+  for (const r of settled) {
+    (r.ok ? enabled : disabled).push(r.id);
   }
   log.log(
     `[encoder-probe] ${enabled.length}/${descriptors.length} enabled (${Date.now() - t0}ms): ${enabled.join(',')}${disabled.length ? ` | disabled: ${disabled.join(',')}` : ''}`,

--- a/backend/src/modules/streaming/transcoding/codec/encoder-probe.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoder-probe.ts
@@ -85,22 +85,37 @@ async function probeOne(
         'bt2020nc',
       ]
     : [];
-  // We bypass the descriptor's buildArgs because it expects HW input
-  // surfaces; instead build a minimal CPU-source encode command that
-  // targets the same `-c:v` and pixel format. The probe verifies the
-  // encoder binary is present and accepts our flags — full HW pipeline
-  // validation happens at first session spawn (errors caught by the
-  // runtime fallback layer).
+  // VAAPI encoders only accept HW surfaces — feeding them lavfi CPU
+  // frames raises the exact `Function not implemented` filter error
+  // production hits. Set up the same `-init_hw_device vaapi` + `hwupload`
+  // bridge the runtime path uses so the probe exercises a representative
+  // pipeline. QSV's wrapper auto-converts CPU input on this ffmpeg
+  // build (verified locally), so it stays on the CPU-input fast path;
+  // we keep that variant minimal to avoid spuriously failing setups
+  // that lack a QSV device file but ship the encoder binary.
+  const isVaapi = d.hwAccel === 'vaapi';
+  const inputArgs = isVaapi
+    ? [
+        '-init_hw_device', 'vaapi=va:/dev/dri/renderD128',
+        '-filter_hw_device', 'va',
+        '-f', 'lavfi',
+        '-i', `nullsrc=size=320x180:rate=30,format=${pixFmt}`,
+      ]
+    : [
+        '-f', 'lavfi',
+        '-i', `nullsrc=size=320x180:rate=30,format=${pixFmt}`,
+      ];
+  const filterArgs = isVaapi
+    ? ['-vf', `format=${pixFmt},hwupload`]
+    : [];
   const args = [
     '-hide_banner',
     '-loglevel',
     'error',
-    '-f',
-    'lavfi',
-    '-i',
-    `nullsrc=size=320x180:rate=30,format=${pixFmt}`,
+    ...inputArgs,
     '-frames:v',
     '1',
+    ...filterArgs,
     '-c:v',
     encoderName(d),
     ...colorTags,

--- a/backend/src/modules/streaming/transcoding/codec/encoder-probe.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoder-probe.ts
@@ -1,0 +1,148 @@
+import { Logger } from '@nestjs/common';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import type { EncoderDescriptor } from './types';
+
+const execFileAsync = promisify(execFile);
+
+/** One-frame ffmpeg encode test. Each encoder descriptor gets probed at
+ *  startup: encode a 320×180 black frame from `lavfi nullsrc` and check
+ *  ffmpeg exits 0. Encoders that fail (missing in this ffmpeg build,
+ *  HW generation too old, driver bug) are blacklisted in the runtime
+ *  map so the registry resolver skips them, and the selector falls
+ *  back to the next candidate.
+ *
+ *  Static `descriptor.supports()` is the build-time gate (cheap, sync);
+ *  this probe layer is the runtime gate (one ffmpeg spawn per encoder,
+ *  ~50-200ms each, parallelised). Both must pass before an encoder is
+ *  usable.
+ *
+ *  The result map is a singleton — populated once at boot, mutated
+ *  by `runEncoderProbes()` and queried by `isEncoderEnabled()`. */
+const probeResult = new Map<string, boolean>();
+let probedOnce = false;
+
+/** Default: unprobed = usable. The runtime fallback in
+ *  `getOrCreateSession()` catches mis-probed cases (e.g. encoder that
+ *  passes the 1-frame test but breaks on the real content). After the
+ *  first probe wave finishes, only the explicitly-passing entries
+ *  stay true. */
+export function isEncoderEnabled(descriptorId: string): boolean {
+  if (!probedOnce) return true;
+  return probeResult.get(descriptorId) ?? false;
+}
+
+/** Spawn one tiny ffmpeg per descriptor in parallel. Probe args are
+ *  derived from each descriptor's `buildArgs()` so we exercise the
+ *  exact encoder + pixel format + filter the runtime path uses (modulo
+ *  the lavfi source and the 1-frame `-frames:v 1 -f null -` sink). */
+export async function runEncoderProbes(
+  descriptors: readonly EncoderDescriptor[],
+  log: Logger,
+): Promise<void> {
+  const t0 = Date.now();
+  const results = await Promise.allSettled(
+    descriptors.map(async (d) => {
+      // Static gate first — no point probing what hw-detect already
+      // says is absent.
+      if (!d.supports()) {
+        probeResult.set(d.id, false);
+        return { id: d.id, ok: false, reason: 'supports()=false' };
+      }
+      const ok = await probeOne(d, log);
+      probeResult.set(d.id, ok);
+      return { id: d.id, ok, reason: ok ? 'ok' : 'probe-failed' };
+    }),
+  );
+  probedOnce = true;
+  const enabled: string[] = [];
+  const disabled: string[] = [];
+  for (const r of results) {
+    if (r.status !== 'fulfilled') continue;
+    (r.value.ok ? enabled : disabled).push(r.value.id);
+  }
+  log.log(
+    `[encoder-probe] ${enabled.length}/${descriptors.length} enabled (${Date.now() - t0}ms): ${enabled.join(',')}${disabled.length ? ` | disabled: ${disabled.join(',')}` : ''}`,
+  );
+}
+
+async function probeOne(
+  d: EncoderDescriptor,
+  log: Logger,
+): Promise<boolean> {
+  // Synthetic minimal input: a 320×180 black frame at the descriptor's
+  // expected pixel layout. The encoder is invoked with the same arg
+  // slice it would emit in production, just shortened to 1 frame.
+  const isHdr = d.variant.hdr != null;
+  const pixFmt = d.variant.bitDepth === 10 ? 'yuv420p10le' : 'yuv420p';
+  const colorTags = isHdr
+    ? [
+        '-color_primaries',
+        'bt2020',
+        '-color_trc',
+        d.variant.hdr === 'HLG' ? 'arib-std-b67' : 'smpte2084',
+        '-colorspace',
+        'bt2020nc',
+      ]
+    : [];
+  // We bypass the descriptor's buildArgs because it expects HW input
+  // surfaces; instead build a minimal CPU-source encode command that
+  // targets the same `-c:v` and pixel format. The probe verifies the
+  // encoder binary is present and accepts our flags — full HW pipeline
+  // validation happens at first session spawn (errors caught by the
+  // runtime fallback layer).
+  const args = [
+    '-hide_banner',
+    '-loglevel',
+    'error',
+    '-f',
+    'lavfi',
+    '-i',
+    `nullsrc=size=320x180:rate=30,format=${pixFmt}`,
+    '-frames:v',
+    '1',
+    '-c:v',
+    encoderName(d),
+    ...colorTags,
+    '-f',
+    'null',
+    '-',
+  ];
+  try {
+    await execFileAsync('ffmpeg', args, { timeout: 10_000 });
+    return true;
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warn(`[encoder-probe] ${d.id} failed: ${msg.split('\n')[0]}`);
+    return false;
+  }
+}
+
+/** Map descriptor id back to the ffmpeg encoder binary name. Reads
+ *  the first `-c:v <name>` from a stub input that doesn't have HW
+ *  surfaces — so descriptors that only accept HW-derived AVFrame
+ *  inputs (HEVC HDR pipelines, etc.) get probed against the same
+ *  encoder binary but with a CPU source. */
+function encoderName(d: EncoderDescriptor): string {
+  switch (d.hwAccel) {
+    case 'qsv':
+      if (d.variant.codec === 'av1') return 'av1_qsv';
+      if (d.variant.codec === 'hevc') return 'hevc_qsv';
+      return 'h264_qsv';
+    case 'vaapi':
+      if (d.variant.codec === 'av1') return 'av1_vaapi';
+      if (d.variant.codec === 'hevc') return 'hevc_vaapi';
+      return 'h264_vaapi';
+    case 'nvenc':
+      if (d.variant.codec === 'av1') return 'av1_nvenc';
+      if (d.variant.codec === 'hevc') return 'hevc_nvenc';
+      return 'h264_nvenc';
+    case 'videotoolbox':
+      if (d.variant.codec === 'hevc') return 'hevc_videotoolbox';
+      return 'h264_videotoolbox';
+    case 'none':
+      if (d.variant.codec === 'av1') return 'libsvtav1';
+      if (d.variant.codec === 'hevc') return 'libx265';
+      return 'libx264';
+  }
+}

--- a/backend/src/modules/streaming/transcoding/codec/encoder-probe.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoder-probe.ts
@@ -118,7 +118,16 @@ async function probeOne(
   // build (verified locally), so it stays on the CPU-input fast path;
   // we keep that variant minimal to avoid spuriously failing setups
   // that lack a QSV device file but ship the encoder binary.
+  //
+  // VAAPI input format note: convert through nv12 / p010le (the native
+  // VAAPI surface formats) before hwupload. Going from yuv420p directly
+  // produces a VAAPI surface whose internal layout h264_vaapi rejects
+  // with 'internal encoding error 24' at 320x180 specifically, even
+  // when the same combo succeeds at 1920x1080 — a probe false negative
+  // we chased for an hour. nv12 / p010le sidestep the small-frame
+  // layout quirk entirely.
   const isVaapi = d.hwAccel === 'vaapi';
+  const vaapiSurfaceFmt = d.variant.bitDepth === 10 ? 'p010le' : 'nv12';
   const inputArgs = isVaapi
     ? [
         '-init_hw_device', 'vaapi=va:/dev/dri/renderD128',
@@ -131,7 +140,7 @@ async function probeOne(
         '-i', `nullsrc=size=320x180:rate=30,format=${pixFmt}`,
       ];
   const filterArgs = isVaapi
-    ? ['-vf', `format=${pixFmt},hwupload`]
+    ? ['-vf', `format=${vaapiSurfaceFmt},hwupload`]
     : [];
   const args = [
     '-hide_banner',

--- a/backend/src/modules/streaming/transcoding/codec/encoders/av1-cpu.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/av1-cpu.ts
@@ -1,6 +1,7 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { av1CodecString } from '../codec-strings';
 import { hdrColorArgs } from './helpers/hdr-variants';
+import { scaleMod16Height } from './helpers/scale-filter';
 
 /** Maps a named ffmpeg preset onto the SVT-AV1 integer preset namespace
  *  (`0` slowest / highest-quality, `13` fastest). Values picked to match
@@ -40,7 +41,7 @@ export const av1Cpu: EncoderDescriptor = {
       '-b:v', bitrate,
       '-maxrate', bitrate,
       '-vf',
-      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:-2:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
       '-g', String(target.gopSize),
       '-keyint_min', String(target.gopSize),
       '-force_key_frames', input.forceKeyframesExpr,
@@ -72,7 +73,7 @@ export const av1CpuHdr10: EncoderDescriptor = {
       '-svtav1-params',
       'enable-hdr=1:mastering-display=G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(10000000,1):content-light=1000,400',
       '-vf',
-      `${filters.cpuCropPrefix}scale=${w}:-2:flags=lanczos,format=yuv420p10le`,
+      `${filters.cpuCropPrefix}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p10le`,
       '-g', String(target.gopSize),
       '-keyint_min', String(target.gopSize),
       '-force_key_frames', input.forceKeyframesExpr,
@@ -106,7 +107,7 @@ export const av1CpuHlg: EncoderDescriptor = {
       '-svtav1-params',
       'color-primaries=9:transfer-characteristics=18:matrix-coefficients=9',
       '-vf',
-      `${filters.cpuCropPrefix}scale=${w}:-2:flags=lanczos,format=yuv420p10le`,
+      `${filters.cpuCropPrefix}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p10le`,
       '-g', String(target.gopSize),
       '-keyint_min', String(target.gopSize),
       '-force_key_frames', input.forceKeyframesExpr,

--- a/backend/src/modules/streaming/transcoding/codec/encoders/av1-cpu.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/av1-cpu.ts
@@ -1,5 +1,6 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { av1CodecString } from '../codec-strings';
+import { hdrColorArgs } from './helpers/hdr-variants';
 
 /** Maps a named ffmpeg preset onto the SVT-AV1 integer preset namespace
  *  (`0` slowest / highest-quality, `13` fastest). Values picked to match
@@ -75,9 +76,7 @@ export const av1CpuHdr10: EncoderDescriptor = {
       '-g', String(target.gopSize),
       '-keyint_min', String(target.gopSize),
       '-force_key_frames', input.forceKeyframesExpr,
-      '-color_primaries', 'bt2020',
-      '-color_trc', 'smpte2084',
-      '-colorspace', 'bt2020nc',
+      ...hdrColorArgs('HDR10'),
     ];
   },
 };
@@ -111,9 +110,7 @@ export const av1CpuHlg: EncoderDescriptor = {
       '-g', String(target.gopSize),
       '-keyint_min', String(target.gopSize),
       '-force_key_frames', input.forceKeyframesExpr,
-      '-color_primaries', 'bt2020',
-      '-color_trc', 'arib-std-b67',
-      '-colorspace', 'bt2020nc',
+      ...hdrColorArgs('HLG'),
     ];
   },
 };

--- a/backend/src/modules/streaming/transcoding/codec/encoders/av1-cpu.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/av1-cpu.ts
@@ -1,0 +1,119 @@
+import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
+import { av1CodecString } from '../codec-strings';
+
+/** Maps a named ffmpeg preset onto the SVT-AV1 integer preset namespace
+ *  (`0` slowest / highest-quality, `13` fastest). Values picked to match
+ *  perceived quality of the libx264 / libx265 namesakes at similar bitrate
+ *  targets: `veryfast` stays watchable on weak CPUs, `medium` is a sane
+ *  steady-state default, `slow` reserves CPU for VOD style packing. */
+function svtAv1Preset(preset: string): string {
+  switch (preset) {
+    case 'veryfast': return '10';
+    case 'faster': return '9';
+    case 'fast': return '7';
+    case 'slow': return '3';
+    case 'medium':
+    default: return '5';
+  }
+}
+
+/** Universal libsvtav1 fallback. Threads use SVT-AV1's auto-detect (no
+ *  explicit `-threads` cap — libsvtav1 is tile-parallel and its internal
+ *  scheduler is conservative enough that seg-0 latency isn't a problem at
+ *  the presets we ship). Reference quality for AV1 HDR is set by this
+ *  encoder. */
+export const av1Cpu: EncoderDescriptor = {
+  id: 'libsvtav1',
+  hwAccel: 'none',
+  variant: { codec: 'av1', bitDepth: 8, hdr: null },
+  supports: () => true,
+  supportsHdrMetadata: () => true,
+  codecString: (target: EncoderTarget) => av1CodecString(target, 8),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, preset, filters } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    return [
+      '-c:v', 'libsvtav1',
+      '-preset', svtAv1Preset(preset),
+      '-b:v', bitrate,
+      '-maxrate', bitrate,
+      '-vf',
+      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:-2:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+      '-g', String(target.gopSize),
+      '-keyint_min', String(target.gopSize),
+      '-force_key_frames', input.forceKeyframesExpr,
+    ];
+  },
+};
+
+/** libsvtav1 HDR10 — `enable-hdr=1` plus the same 1000-nit BT.2020
+ *  mastering-display geometry NVENC writes, threaded through SVT-AV1's
+ *  own `-svtav1-params` channel. ffmpeg-side `-color_*` flags are kept
+ *  in lockstep so the SPS VUI matches the OBU metadata. */
+export const av1CpuHdr10: EncoderDescriptor = {
+  id: 'libsvtav1_hdr10',
+  hwAccel: 'none',
+  variant: { codec: 'av1', bitDepth: 10, hdr: 'HDR10' },
+  supports: () => true,
+  supportsHdrMetadata: () => true,
+  codecString: (target: EncoderTarget) => av1CodecString(target, 10),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, preset, filters } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    return [
+      '-c:v', 'libsvtav1',
+      '-pix_fmt', 'yuv420p10le',
+      '-preset', svtAv1Preset(preset),
+      '-b:v', bitrate,
+      '-maxrate', bitrate,
+      '-svtav1-params',
+      'enable-hdr=1:mastering-display=G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(10000000,1):content-light=1000,400',
+      '-vf',
+      `${filters.cpuCropPrefix}scale=${w}:-2:flags=lanczos,format=yuv420p10le`,
+      '-g', String(target.gopSize),
+      '-keyint_min', String(target.gopSize),
+      '-force_key_frames', input.forceKeyframesExpr,
+      '-color_primaries', 'bt2020',
+      '-color_trc', 'smpte2084',
+      '-colorspace', 'bt2020nc',
+    ];
+  },
+};
+
+/** libsvtav1 HLG — color signaling lives entirely in `-svtav1-params`
+ *  (color-primaries=9 BT.2020, transfer-characteristics=18 ARIB STD-B67,
+ *  matrix-coefficients=9 BT.2020 NCL). Doubled in ffmpeg `-color_*` for
+ *  symmetry with the HDR10 path. No mastering-display — HLG is metadata-
+ *  free by design. */
+export const av1CpuHlg: EncoderDescriptor = {
+  id: 'libsvtav1_hlg',
+  hwAccel: 'none',
+  variant: { codec: 'av1', bitDepth: 10, hdr: 'HLG' },
+  supports: () => true,
+  supportsHdrMetadata: () => true,
+  codecString: (target: EncoderTarget) => av1CodecString(target, 10),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, preset, filters } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    return [
+      '-c:v', 'libsvtav1',
+      '-pix_fmt', 'yuv420p10le',
+      '-preset', svtAv1Preset(preset),
+      '-b:v', bitrate,
+      '-maxrate', bitrate,
+      '-svtav1-params',
+      'color-primaries=9:transfer-characteristics=18:matrix-coefficients=9',
+      '-vf',
+      `${filters.cpuCropPrefix}scale=${w}:-2:flags=lanczos,format=yuv420p10le`,
+      '-g', String(target.gopSize),
+      '-keyint_min', String(target.gopSize),
+      '-force_key_frames', input.forceKeyframesExpr,
+      '-color_primaries', 'bt2020',
+      '-color_trc', 'arib-std-b67',
+      '-colorspace', 'bt2020nc',
+    ];
+  },
+};

--- a/backend/src/modules/streaming/transcoding/codec/encoders/av1-nvenc.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/av1-nvenc.ts
@@ -1,0 +1,120 @@
+import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
+import { av1CodecString } from '../codec-strings';
+
+/** NVIDIA NVENC AV1 encoder — Ada Lovelace (RTX 4000 series) and later.
+ *  Pascal, Turing and Ampere don't ship the AV1 encode unit, so
+ *  `supports()` returning true relies on the runtime fallback path
+ *  catching the spawn error and downgrading to libsvtav1 there. Tonemap
+ *  path round-trips via CPU like h264_nvenc — no tonemap_cuda in
+ *  mainline FFmpeg. */
+export const av1Nvenc: EncoderDescriptor = {
+  id: 'av1_nvenc',
+  hwAccel: 'nvenc',
+  variant: { codec: 'av1', bitDepth: 8, hdr: null },
+  supports: () => true,
+  supportsHdrMetadata: () => false,
+  codecString: (target: EncoderTarget) => av1CodecString(target, 8),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, nvencPreset, filters, tonemap, hasCrop } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    const common = [
+      '-c:v', 'av1_nvenc',
+      '-preset', nvencPreset,
+      '-b:v', bitrate,
+      '-maxrate', bitrate,
+    ];
+    const trailing = [
+      '-g', String(target.gopSize),
+      '-keyint_min', String(target.gopSize),
+      '-force_key_frames', input.forceKeyframesExpr,
+    ];
+
+    if (tonemap) {
+      return [
+        ...common,
+        '-vf',
+        `hwdownload,format=p010le,${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:-2`,
+        ...trailing,
+      ];
+    }
+    const nvCropFilter = hasCrop
+      ? `hwdownload,format=nv12,${filters.cropStr},hwupload_cuda,`
+      : '';
+    return [
+      ...common,
+      '-vf',
+      `${nvCropFilter}scale_cuda=w=${w}:h=-2:format=nv12`,
+      ...trailing,
+    ];
+  },
+};
+
+/** NVENC AV1 HDR10 — Ada writes the HDR10 static metadata SEI when
+ *  `-master_display` and `-max_cll` are passed on the encoder. Static
+ *  values match a 1000-nit BT.2020 mastering display with 400-nit MaxFALL,
+ *  the common reference for UHD Blu-ray remasters and the dominant
+ *  source-side authoring target. */
+export const av1NvencHdr10: EncoderDescriptor = {
+  id: 'av1_nvenc_hdr10',
+  hwAccel: 'nvenc',
+  variant: { codec: 'av1', bitDepth: 10, hdr: 'HDR10' },
+  supports: () => true,
+  supportsHdrMetadata: () => true,
+  codecString: (target: EncoderTarget) => av1CodecString(target, 10),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, nvencPreset } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    return [
+      '-c:v', 'av1_nvenc',
+      '-pix_fmt', 'p010le',
+      '-preset', nvencPreset,
+      '-b:v', bitrate,
+      '-maxrate', bitrate,
+      '-vf',
+      `scale_cuda=w=${w}:h=-2:format=p010le`,
+      '-g', String(target.gopSize),
+      '-keyint_min', String(target.gopSize),
+      '-force_key_frames', input.forceKeyframesExpr,
+      '-color_primaries', 'bt2020',
+      '-color_trc', 'smpte2084',
+      '-colorspace', 'bt2020nc',
+      '-master_display',
+      'G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(10000000,1)',
+      '-max_cll', '1000,400',
+    ];
+  },
+};
+
+/** NVENC AV1 HLG — same encoder path, only the SPS VUI transfer flag
+ *  flips to ARIB STD-B67 and no mastering-display / max_cll is emitted
+ *  (HLG signaling is purely in the OETF, no static metadata). */
+export const av1NvencHlg: EncoderDescriptor = {
+  id: 'av1_nvenc_hlg',
+  hwAccel: 'nvenc',
+  variant: { codec: 'av1', bitDepth: 10, hdr: 'HLG' },
+  supports: () => true,
+  supportsHdrMetadata: () => true,
+  codecString: (target: EncoderTarget) => av1CodecString(target, 10),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, nvencPreset } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    return [
+      '-c:v', 'av1_nvenc',
+      '-pix_fmt', 'p010le',
+      '-preset', nvencPreset,
+      '-b:v', bitrate,
+      '-maxrate', bitrate,
+      '-vf',
+      `scale_cuda=w=${w}:h=-2:format=p010le`,
+      '-g', String(target.gopSize),
+      '-keyint_min', String(target.gopSize),
+      '-force_key_frames', input.forceKeyframesExpr,
+      '-color_primaries', 'bt2020',
+      '-color_trc', 'arib-std-b67',
+      '-colorspace', 'bt2020nc',
+    ];
+  },
+};

--- a/backend/src/modules/streaming/transcoding/codec/encoders/av1-nvenc.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/av1-nvenc.ts
@@ -1,5 +1,6 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { av1CodecString } from '../codec-strings';
+import { hdrColorArgs } from './helpers/hdr-variants';
 
 /** NVIDIA NVENC AV1 encoder — Ada Lovelace (RTX 4000 series) and later.
  *  Pascal, Turing and Ampere don't ship the AV1 encode unit, so
@@ -77,9 +78,7 @@ export const av1NvencHdr10: EncoderDescriptor = {
       '-g', String(target.gopSize),
       '-keyint_min', String(target.gopSize),
       '-force_key_frames', input.forceKeyframesExpr,
-      '-color_primaries', 'bt2020',
-      '-color_trc', 'smpte2084',
-      '-colorspace', 'bt2020nc',
+      ...hdrColorArgs('HDR10'),
       '-master_display',
       'G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(10000000,1)',
       '-max_cll', '1000,400',
@@ -112,9 +111,7 @@ export const av1NvencHlg: EncoderDescriptor = {
       '-g', String(target.gopSize),
       '-keyint_min', String(target.gopSize),
       '-force_key_frames', input.forceKeyframesExpr,
-      '-color_primaries', 'bt2020',
-      '-color_trc', 'arib-std-b67',
-      '-colorspace', 'bt2020nc',
+      ...hdrColorArgs('HLG'),
     ];
   },
 };

--- a/backend/src/modules/streaming/transcoding/codec/encoders/av1-nvenc.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/av1-nvenc.ts
@@ -1,6 +1,7 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { av1CodecString } from '../codec-strings';
 import { hdrColorArgs } from './helpers/hdr-variants';
+import { scaleMod16Height } from './helpers/scale-filter';
 
 /** NVIDIA NVENC AV1 encoder — Ada Lovelace (RTX 4000 series) and later.
  *  Pascal, Turing and Ampere don't ship the AV1 encode unit, so
@@ -35,7 +36,7 @@ export const av1Nvenc: EncoderDescriptor = {
       return [
         ...common,
         '-vf',
-        `hwdownload,format=p010le,${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:-2`,
+        `hwdownload,format=p010le,${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}`,
         ...trailing,
       ];
     }

--- a/backend/src/modules/streaming/transcoding/codec/encoders/av1-qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/av1-qsv.ts
@@ -1,5 +1,6 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { av1CodecString } from '../codec-strings';
+import { hdrColorArgs } from './helpers/hdr-variants';
 
 /** Intel QSV AV1 encoder — Arc (DG2) and Meteor Lake iGPU and above on
  *  Linux 6.2+. Same VAAPI-decode → scale_vaapi → hwmap-to-qsv chain as
@@ -87,9 +88,7 @@ export const av1QsvHdr10: EncoderDescriptor = {
       '-g', String(target.gopSize),
       '-keyint_min', String(target.gopSize),
       '-force_key_frames', input.forceKeyframesExpr,
-      '-color_primaries', 'bt2020',
-      '-color_trc', 'smpte2084',
-      '-colorspace', 'bt2020nc',
+      ...hdrColorArgs('HDR10'),
     ];
   },
 };

--- a/backend/src/modules/streaming/transcoding/codec/encoders/av1-qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/av1-qsv.ts
@@ -1,0 +1,95 @@
+import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
+import { av1CodecString } from '../codec-strings';
+
+/** Intel QSV AV1 encoder — Arc (DG2) and Meteor Lake iGPU and above on
+ *  Linux 6.2+. Same VAAPI-decode → scale_vaapi → hwmap-to-qsv chain as
+ *  h264_qsv; only the encoder name, pixel format and CODECS string
+ *  differ. SDR path uses nv12 throughout. */
+export const av1Qsv: EncoderDescriptor = {
+  id: 'av1_qsv',
+  hwAccel: 'qsv',
+  variant: { codec: 'av1', bitDepth: 8, hdr: null },
+  supports: () => true,
+  supportsHdrMetadata: () => false,
+  codecString: (target: EncoderTarget) => av1CodecString(target, 8),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, preset, qsv, filters, tonemap } = input;
+    const w = target.width;
+    const common = [
+      '-c:v', 'av1_qsv',
+      '-preset', preset,
+      ...qsv.extra,
+      '-mbbrc', '1',
+      '-b:v', String(target.videoBitrateBps),
+      '-maxrate', String(target.videoBitrateBps + 1),
+      '-rc_init_occupancy', String(qsv.rcInitOccupancy),
+      '-bufsize', String(qsv.bufsize),
+    ];
+    const trailing = [
+      '-g', String(target.gopSize),
+      '-keyint_min', String(target.gopSize),
+      '-force_key_frames', input.forceKeyframesExpr,
+    ];
+
+    if (filters.tonemapVaapi) {
+      return [
+        ...common,
+        '-vf',
+        `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`,
+        ...trailing,
+      ];
+    }
+    if (filters.tonemapOpencl) {
+      return [
+        ...common,
+        '-vf',
+        `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`,
+        ...trailing,
+      ];
+    }
+    void tonemap;
+    return [
+      ...common,
+      '-vf',
+      `scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
+      ...trailing,
+    ];
+  },
+};
+
+/** Intel QSV AV1 HDR10 — same pipeline in p010le. `supportsHdrMetadata`
+ *  is false: media-driver issue 1592 — `av1_qsv` has no mastering-display
+ *  API, so the mdcv/clli SEI never reaches the bitstream. Registry routes
+ *  HDR variants to the libsvtav1 fallback instead. Color tags are kept
+ *  here for completeness in case the encoder ever gains the API. */
+export const av1QsvHdr10: EncoderDescriptor = {
+  id: 'av1_qsv_hdr10',
+  hwAccel: 'qsv',
+  variant: { codec: 'av1', bitDepth: 10, hdr: 'HDR10' },
+  supports: () => true,
+  supportsHdrMetadata: () => false,
+  codecString: (target: EncoderTarget) => av1CodecString(target, 10),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, preset, qsv } = input;
+    const w = target.width;
+    return [
+      '-c:v', 'av1_qsv',
+      '-pix_fmt', 'p010le',
+      '-preset', preset,
+      ...qsv.extra,
+      '-mbbrc', '1',
+      '-b:v', String(target.videoBitrateBps),
+      '-maxrate', String(target.videoBitrateBps + 1),
+      '-rc_init_occupancy', String(qsv.rcInitOccupancy),
+      '-bufsize', String(qsv.bufsize),
+      '-vf',
+      `scale_vaapi=w=${w}:h=-16:format=p010le:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
+      '-g', String(target.gopSize),
+      '-keyint_min', String(target.gopSize),
+      '-force_key_frames', input.forceKeyframesExpr,
+      '-color_primaries', 'bt2020',
+      '-color_trc', 'smpte2084',
+      '-colorspace', 'bt2020nc',
+    ];
+  },
+};

--- a/backend/src/modules/streaming/transcoding/codec/encoders/av1-vaapi.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/av1-vaapi.ts
@@ -1,0 +1,85 @@
+import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
+import { av1CodecString } from '../codec-strings';
+
+/** AMD VAAPI AV1 encoder — RDNA3 (RX 7000) and Ryzen 7000/8000 APUs on
+ *  Mesa 23.3+. No `-preset` knob (the VAAPI driver picks rate control
+ *  internally; same story as h264_vaapi). Bitrate is passed as raw bps
+ *  so VAAPI's parser accepts it directly. */
+export const av1Vaapi: EncoderDescriptor = {
+  id: 'av1_vaapi',
+  hwAccel: 'vaapi',
+  variant: { codec: 'av1', bitDepth: 8, hdr: null },
+  supports: () => true,
+  supportsHdrMetadata: () => false,
+  codecString: (target: EncoderTarget) => av1CodecString(target, 8),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, filters } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    const common = [
+      '-c:v', 'av1_vaapi',
+      '-b:v', bitrate,
+      '-maxrate', bitrate,
+    ];
+    const trailing = [
+      '-g', String(target.gopSize),
+      '-keyint_min', String(target.gopSize),
+      '-force_key_frames', input.forceKeyframesExpr,
+    ];
+
+    if (filters.tonemapVaapi) {
+      return [
+        ...common,
+        '-vf',
+        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi}`,
+        ...trailing,
+      ];
+    }
+    if (filters.tonemapOpencl) {
+      return [
+        ...common,
+        '-vf',
+        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=vaapi:mode=write:reverse=1,format=vaapi`,
+        ...trailing,
+      ];
+    }
+    return [
+      ...common,
+      '-vf',
+      `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:format=nv12`,
+      ...trailing,
+    ];
+  },
+};
+
+/** AMD VAAPI AV1 HDR10 — `supportsHdrMetadata` is false because Mesa's
+ *  AV1 HDR static-metadata emission is still immature (mastering-display
+ *  packet writing landed but is not reliably propagated by every driver
+ *  version on the support matrix). Registry falls back to libsvtav1 for
+ *  the HDR rungs while keeping AV1 SDR on VAAPI. */
+export const av1VaapiHdr10: EncoderDescriptor = {
+  id: 'av1_vaapi_hdr10',
+  hwAccel: 'vaapi',
+  variant: { codec: 'av1', bitDepth: 10, hdr: 'HDR10' },
+  supports: () => true,
+  supportsHdrMetadata: () => false,
+  codecString: (target: EncoderTarget) => av1CodecString(target, 10),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, filters } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    return [
+      '-c:v', 'av1_vaapi',
+      '-b:v', bitrate,
+      '-maxrate', bitrate,
+      '-vf',
+      `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:format=p010le`,
+      '-g', String(target.gopSize),
+      '-keyint_min', String(target.gopSize),
+      '-force_key_frames', input.forceKeyframesExpr,
+      '-color_primaries', 'bt2020',
+      '-color_trc', 'smpte2084',
+      '-colorspace', 'bt2020nc',
+    ];
+  },
+};

--- a/backend/src/modules/streaming/transcoding/codec/encoders/av1-vaapi.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/av1-vaapi.ts
@@ -1,5 +1,6 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { av1CodecString } from '../codec-strings';
+import { hdrColorArgs } from './helpers/hdr-variants';
 
 /** AMD VAAPI AV1 encoder — RDNA3 (RX 7000) and Ryzen 7000/8000 APUs on
  *  Mesa 23.3+. No `-preset` knob (the VAAPI driver picks rate control
@@ -77,9 +78,7 @@ export const av1VaapiHdr10: EncoderDescriptor = {
       '-g', String(target.gopSize),
       '-keyint_min', String(target.gopSize),
       '-force_key_frames', input.forceKeyframesExpr,
-      '-color_primaries', 'bt2020',
-      '-color_trc', 'smpte2084',
-      '-colorspace', 'bt2020nc',
+      ...hdrColorArgs('HDR10'),
     ];
   },
 };

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-cpu.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-cpu.ts
@@ -1,5 +1,6 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { h264CodecString } from '../codec-strings';
+import { scaleMod16Height } from './helpers/scale-filter';
 
 /** Universal libx264 fallback. Threads capped at 4 so seg-0 ships
  *  before a long `(threads-1)` frame pre-buffer fills (CPU encoders
@@ -36,7 +37,7 @@ export const h264Cpu: EncoderDescriptor = {
       '-maxrate', bitrate,
       '-bufsize', libx264BufsizeMb,
       '-vf',
-      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:-2:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
       '-force_key_frames', input.forceKeyframesExpr,
       '-sc_threshold:v:0', '0',
     ];

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-cpu.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-cpu.ts
@@ -21,6 +21,13 @@ export const h264Cpu: EncoderDescriptor = {
       '-c:v', 'libx264',
       '-threads:v', '4',
       '-preset', preset,
+      // Force High profile so the SPS in the early session's init.mp4
+      // matches the steady-state session's segments. `-tune zerolatency`
+      // and any preset >= veryfast keep CABAC on, but pin the profile
+      // anyway — defensive against future preset tweaks. The master
+      // playlist advertises `avc1.6400xx` (High), so a bitstream that
+      // signalled Constrained Baseline would trip MSE on append.
+      '-profile:v', 'high',
       ...(early ? ['-tune', 'zerolatency'] : []),
       '-b:v', bitrate,
       '-maxrate', bitrate,

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-cpu.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-cpu.ts
@@ -1,0 +1,34 @@
+import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
+import { h264CodecString } from '../codec-strings';
+
+/** Universal libx264 fallback. Threads capped at 4 so seg-0 ships
+ *  before a long `(threads-1)` frame pre-buffer fills (CPU encoders
+ *  with the default thread count add ~half a second of startup
+ *  latency to first-frame). `-tune zerolatency` only on early
+ *  sessions because steady-state quality suffers. */
+export const h264Cpu: EncoderDescriptor = {
+  id: 'libx264',
+  hwAccel: 'none',
+  variant: { codec: 'h264', bitDepth: 8, hdr: null },
+  supports: () => true,
+  supportsHdrMetadata: () => false,
+  codecString: (target: EncoderTarget) => h264CodecString(target),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, preset, early, filters, libx264BufsizeMb } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    return [
+      '-c:v', 'libx264',
+      '-threads:v', '4',
+      '-preset', preset,
+      ...(early ? ['-tune', 'zerolatency'] : []),
+      '-b:v', bitrate,
+      '-maxrate', bitrate,
+      '-bufsize', libx264BufsizeMb,
+      '-vf',
+      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:-2:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+      '-force_key_frames', input.forceKeyframesExpr,
+      '-sc_threshold:v:0', '0',
+    ];
+  },
+};

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-cpu.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-cpu.ts
@@ -4,8 +4,18 @@ import { h264CodecString } from '../codec-strings';
 /** Universal libx264 fallback. Threads capped at 4 so seg-0 ships
  *  before a long `(threads-1)` frame pre-buffer fills (CPU encoders
  *  with the default thread count add ~half a second of startup
- *  latency to first-frame). `-tune zerolatency` only on early
- *  sessions because steady-state quality suffers. */
+ *  latency to first-frame).
+ *
+ *  Preset is pinned to `veryfast` and `-tune zerolatency` is *not*
+ *  used. The early-warm session writes init.mp4 at the same time as
+ *  the steady-state session; the controller serves init.mp4 from
+ *  one of them and segments from the other, so the two pipelines
+ *  must produce identical SPS. libx264 bakes preset-dependent
+ *  knobs (`ref`, `bframes`, `weightp`, …) into the SPS, and any
+ *  difference between sessions trips the decoder ("QP out of range"
+ *  / "decode_slice_header error"). The QSV path is immune — its
+ *  SPS only encodes profile/level — but on libx264 we have to hold
+ *  the encoder configuration identical across sessions. */
 export const h264Cpu: EncoderDescriptor = {
   id: 'libx264',
   hwAccel: 'none',
@@ -14,21 +24,14 @@ export const h264Cpu: EncoderDescriptor = {
   supportsHdrMetadata: () => false,
   codecString: (target: EncoderTarget) => h264CodecString(target),
   buildArgs(input: EncoderInput): string[] {
-    const { target, preset, early, filters, libx264BufsizeMb } = input;
+    const { target, filters, libx264BufsizeMb } = input;
     const w = target.width;
     const bitrate = `${target.videoBitrateBps}`;
     return [
       '-c:v', 'libx264',
       '-threads:v', '4',
-      '-preset', preset,
-      // Force High profile so the SPS in the early session's init.mp4
-      // matches the steady-state session's segments. `-tune zerolatency`
-      // and any preset >= veryfast keep CABAC on, but pin the profile
-      // anyway — defensive against future preset tweaks. The master
-      // playlist advertises `avc1.6400xx` (High), so a bitstream that
-      // signalled Constrained Baseline would trip MSE on append.
+      '-preset', 'veryfast',
       '-profile:v', 'high',
-      ...(early ? ['-tune', 'zerolatency'] : []),
       '-b:v', bitrate,
       '-maxrate', bitrate,
       '-bufsize', libx264BufsizeMb,

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-nvenc.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-nvenc.ts
@@ -1,0 +1,49 @@
+import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
+import { h264CodecString } from '../codec-strings';
+
+/** NVIDIA NVENC H.264 encoder — Kepler and later. Tonemap path round-trips
+ *  via CPU (hwdownload + scale + tonemap chain) because the CUDA filter
+ *  graph has no native tonemap_cuda equivalent in mainline FFmpeg yet. */
+export const h264Nvenc: EncoderDescriptor = {
+  id: 'h264_nvenc',
+  hwAccel: 'nvenc',
+  variant: { codec: 'h264', bitDepth: 8, hdr: null },
+  supports: () => true,
+  supportsHdrMetadata: () => false,
+  codecString: (target: EncoderTarget) => h264CodecString(target),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, nvencPreset, filters, tonemap, hasCrop } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    const common = [
+      '-c:v', 'h264_nvenc',
+      '-preset', nvencPreset,
+      '-b:v', bitrate,
+      '-maxrate', bitrate,
+    ];
+    const trailing = [
+      '-g', String(target.gopSize),
+      '-keyint_min', String(target.gopSize),
+      '-force_key_frames', input.forceKeyframesExpr,
+    ];
+
+    if (tonemap) {
+      // Download to CPU, tonemap on CPU, encode on NVENC.
+      return [
+        ...common,
+        '-vf',
+        `hwdownload,format=p010le,${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:-2`,
+        ...trailing,
+      ];
+    }
+    const nvCropFilter = hasCrop
+      ? `hwdownload,format=nv12,${filters.cropStr},hwupload_cuda,`
+      : '';
+    return [
+      ...common,
+      '-vf',
+      `${nvCropFilter}scale_cuda=w=${w}:h=-2:format=nv12`,
+      ...trailing,
+    ];
+  },
+};

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-nvenc.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-nvenc.ts
@@ -1,5 +1,6 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { h264CodecString } from '../codec-strings';
+import { scaleMod16Height } from './helpers/scale-filter';
 
 /** NVIDIA NVENC H.264 encoder — Kepler and later. Tonemap path round-trips
  *  via CPU (hwdownload + scale + tonemap chain) because the CUDA filter
@@ -32,7 +33,7 @@ export const h264Nvenc: EncoderDescriptor = {
       return [
         ...common,
         '-vf',
-        `hwdownload,format=p010le,${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:-2`,
+        `hwdownload,format=p010le,${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}`,
         ...trailing,
       ];
     }

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-qsv.ts
@@ -36,7 +36,7 @@ export const h264Qsv: EncoderDescriptor = {
       return [
         ...common,
         '-vf',
-        `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`,
+        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`,
         ...trailing,
       ];
     }
@@ -45,7 +45,7 @@ export const h264Qsv: EncoderDescriptor = {
       return [
         ...common,
         '-vf',
-        `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`,
+        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`,
         ...trailing,
       ];
     }
@@ -55,7 +55,7 @@ export const h264Qsv: EncoderDescriptor = {
     return [
       ...common,
       '-vf',
-      `scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
+      `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
       ...trailing,
     ];
   },

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-qsv.ts
@@ -36,7 +36,7 @@ export const h264Qsv: EncoderDescriptor = {
       return [
         ...common,
         '-vf',
-        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`,
+        `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`,
         ...trailing,
       ];
     }
@@ -45,7 +45,7 @@ export const h264Qsv: EncoderDescriptor = {
       return [
         ...common,
         '-vf',
-        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`,
+        `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`,
         ...trailing,
       ];
     }
@@ -55,7 +55,7 @@ export const h264Qsv: EncoderDescriptor = {
     return [
       ...common,
       '-vf',
-      `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
+      `scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
       ...trailing,
     ];
   },

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-qsv.ts
@@ -1,5 +1,6 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { h264CodecString } from '../codec-strings';
+import { qsvScaleFilter8bit } from './helpers/qsv-filters';
 
 /** Intel QSV H.264 encoder — Skylake gen6 and above. Three filter chains
  *  depending on tonemap availability: VAAPI-native tonemap (cheapest,
@@ -13,9 +14,8 @@ export const h264Qsv: EncoderDescriptor = {
   supportsHdrMetadata: () => false,
   codecString: (target: EncoderTarget) => h264CodecString(target),
   buildArgs(input: EncoderInput): string[] {
-    const { target, preset, qsv, filters, tonemap } = input;
-    const w = target.width;
-    const common = [
+    const { target, preset, qsv } = input;
+    return [
       '-c:v', 'h264_qsv',
       '-preset', preset,
       ...qsv.extra,
@@ -24,39 +24,10 @@ export const h264Qsv: EncoderDescriptor = {
       '-maxrate', String(target.videoBitrateBps + 1),
       '-rc_init_occupancy', String(qsv.rcInitOccupancy),
       '-bufsize', String(qsv.bufsize),
-    ];
-    const trailing = [
+      '-vf', qsvScaleFilter8bit(input),
       '-g', String(target.gopSize),
       '-keyint_min', String(target.gopSize),
       '-force_key_frames', input.forceKeyframesExpr,
-    ];
-
-    if (filters.tonemapVaapi) {
-      // VAAPI decode → VAAPI scale → VAAPI tonemap → QSV encode (1 device)
-      return [
-        ...common,
-        '-vf',
-        `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`,
-        ...trailing,
-      ];
-    }
-    if (filters.tonemapOpencl) {
-      // VAAPI decode → VAAPI scale → OpenCL tonemap → map to QSV → QSV encode
-      return [
-        ...common,
-        '-vf',
-        `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`,
-        ...trailing,
-      ];
-    }
-    // Suppress unused warning when tonemap was requested but no filter is
-    // active (shouldn't normally happen — orchestrator guards).
-    void tonemap;
-    return [
-      ...common,
-      '-vf',
-      `scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
-      ...trailing,
     ];
   },
 };

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-qsv.ts
@@ -1,0 +1,62 @@
+import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
+import { h264CodecString } from '../codec-strings';
+
+/** Intel QSV H.264 encoder — Skylake gen6 and above. Three filter chains
+ *  depending on tonemap availability: VAAPI-native tonemap (cheapest,
+ *  used on early sessions), OpenCL tonemap (better quality, steady-state
+ *  HDR→SDR), or plain (no tonemap). */
+export const h264Qsv: EncoderDescriptor = {
+  id: 'h264_qsv',
+  hwAccel: 'qsv',
+  variant: { codec: 'h264', bitDepth: 8, hdr: null },
+  supports: () => true,
+  supportsHdrMetadata: () => false,
+  codecString: (target: EncoderTarget) => h264CodecString(target),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, preset, qsv, filters, tonemap } = input;
+    const w = target.width;
+    const common = [
+      '-c:v', 'h264_qsv',
+      '-preset', preset,
+      ...qsv.extra,
+      '-mbbrc', '1',
+      '-b:v', String(target.videoBitrateBps),
+      '-maxrate', String(target.videoBitrateBps + 1),
+      '-rc_init_occupancy', String(qsv.rcInitOccupancy),
+      '-bufsize', String(qsv.bufsize),
+    ];
+    const trailing = [
+      '-g', String(target.gopSize),
+      '-keyint_min', String(target.gopSize),
+      '-force_key_frames', input.forceKeyframesExpr,
+    ];
+
+    if (filters.tonemapVaapi) {
+      // VAAPI decode → VAAPI scale → VAAPI tonemap → QSV encode (1 device)
+      return [
+        ...common,
+        '-vf',
+        `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`,
+        ...trailing,
+      ];
+    }
+    if (filters.tonemapOpencl) {
+      // VAAPI decode → VAAPI scale → OpenCL tonemap → map to QSV → QSV encode
+      return [
+        ...common,
+        '-vf',
+        `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`,
+        ...trailing,
+      ];
+    }
+    // Suppress unused warning when tonemap was requested but no filter is
+    // active (shouldn't normally happen — orchestrator guards).
+    void tonemap;
+    return [
+      ...common,
+      '-vf',
+      `scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
+      ...trailing,
+    ];
+  },
+};

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-vaapi.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-vaapi.ts
@@ -1,0 +1,54 @@
+import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
+import { h264CodecString } from '../codec-strings';
+
+/** AMD / Intel-on-Linux VAAPI H.264 encoder. Same code path is used for
+ *  both — AMD GPUs talk through Mesa's VAAPI driver, Intel on Linux
+ *  falls back to VAAPI when crop forces it (QSV can't crop). Bitrate
+ *  passed as the raw profile string (`8M`, `500k`) since VAAPI accepts
+ *  the ffmpeg shorthand directly. */
+export const h264Vaapi: EncoderDescriptor = {
+  id: 'h264_vaapi',
+  hwAccel: 'vaapi',
+  variant: { codec: 'h264', bitDepth: 8, hdr: null },
+  supports: () => true,
+  supportsHdrMetadata: () => false,
+  codecString: (target: EncoderTarget) => h264CodecString(target),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, filters } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    const common = [
+      '-c:v', 'h264_vaapi',
+      '-b:v', bitrate,
+      '-maxrate', bitrate,
+    ];
+    const trailing = [
+      '-g', String(target.gopSize),
+      '-keyint_min', String(target.gopSize),
+      '-force_key_frames', input.forceKeyframesExpr,
+    ];
+
+    if (filters.tonemapVaapi) {
+      return [
+        ...common,
+        '-vf',
+        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi}`,
+        ...trailing,
+      ];
+    }
+    if (filters.tonemapOpencl) {
+      return [
+        ...common,
+        '-vf',
+        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=vaapi:mode=write:reverse=1,format=vaapi`,
+        ...trailing,
+      ];
+    }
+    return [
+      ...common,
+      '-vf',
+      `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:format=nv12`,
+      ...trailing,
+    ];
+  },
+};

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-videotoolbox.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-videotoolbox.ts
@@ -1,5 +1,6 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { h264CodecString } from '../codec-strings';
+import { scaleMod16Height } from './helpers/scale-filter';
 
 /** Apple VideoToolbox H.264 encoder — Mac 2011+ and all Apple Silicon.
  *  Two paths: full Metal pipeline with `scale_vt` HDR tonemap (no CPU
@@ -51,7 +52,7 @@ export const h264Videotoolbox: EncoderDescriptor = {
     return [
       ...common,
       '-vf',
-      `${filters.cpuCropPrefix}scale=${w}:-2:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+      `${filters.cpuCropPrefix}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
       ...trailing,
     ];
   },

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-videotoolbox.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-videotoolbox.ts
@@ -1,0 +1,58 @@
+import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
+import { h264CodecString } from '../codec-strings';
+
+/** Apple VideoToolbox H.264 encoder — Mac 2011+ and all Apple Silicon.
+ *  Two paths: full Metal pipeline with `scale_vt` HDR tonemap (no CPU
+ *  round-trip) when only tonemap is requested, or CPU buffers + libsw
+ *  filters when crop or subtitle burn-in is required (VT decode emits
+ *  CPU buffers anyway, so software filters work in place). */
+export const h264Videotoolbox: EncoderDescriptor = {
+  id: 'h264_videotoolbox',
+  hwAccel: 'videotoolbox',
+  variant: { codec: 'h264', bitDepth: 8, hdr: null },
+  supports: () => true,
+  supportsHdrMetadata: () => false,
+  codecString: (target: EncoderTarget) => h264CodecString(target),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, early, filters, tonemap, hasBurnIn, hasCrop } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    const common = [
+      '-c:v',
+      'h264_videotoolbox',
+      '-profile:v',
+      'high',
+      ...(early ? ['-realtime', '1'] : []),
+      '-b:v',
+      bitrate,
+      '-maxrate',
+      bitrate,
+    ];
+    const trailing = [
+      '-g',
+      String(target.gopSize),
+      '-keyint_min',
+      String(target.gopSize),
+      '-force_key_frames',
+      input.forceKeyframesExpr,
+    ];
+
+    if (tonemap && !hasBurnIn && !hasCrop) {
+      // Full Metal pipeline: scale_vt does HDR→SDR tonemap via the
+      // Apple Media Engine. Everything stays on IOSurface — no CPU
+      // round-trip.
+      return [
+        ...common,
+        '-vf',
+        `scale_vt=w=${w}:h=-2:color_matrix=bt709:color_primaries=bt709:color_transfer=bt709`,
+        ...trailing,
+      ];
+    }
+    return [
+      ...common,
+      '-vf',
+      `${filters.cpuCropPrefix}scale=${w}:-2:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+      ...trailing,
+    ];
+  },
+};

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/hdr-variants.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/hdr-variants.ts
@@ -1,0 +1,42 @@
+import type { EncoderDescriptor, EncoderInput, HdrFormat } from '../../types';
+
+/** Standard ffmpeg `-color_*` flag triplet for an HDR bitstream. BT.2020
+ *  primaries and matrix; transfer characteristic switches PQ (HDR10) vs
+ *  HLG. Belt-and-suspenders: most encoders carry color tags through from
+ *  the input AVFrame, but several HW builds (notably hevc_qsv) drop them
+ *  silently. Hard-coding the SPS VUI here prevents that regression. */
+export function hdrColorArgs(format: HdrFormat | 'HDR10' | 'HLG'): string[] {
+  const trc = format === 'HLG' ? 'arib-std-b67' : 'smpte2084';
+  return [
+    '-color_primaries',
+    'bt2020',
+    '-color_trc',
+    trc,
+    '-colorspace',
+    'bt2020nc',
+  ];
+}
+
+/** Build an HLG-variant descriptor from an existing HDR10 descriptor by
+ *  swapping the `-color_trc` value from PQ (`smpte2084`) to HLG
+ *  (`arib-std-b67`) on the encoder args. Only valid when the encoder's
+ *  HDR signaling lives entirely in the standard `-color_*` flags (the
+ *  case for QSV / VAAPI / NVENC / VideoToolbox). CPU encoders that
+ *  carry HDR config through encoder-specific params (`-x265-params`,
+ *  `-svtav1-params`) build their HLG variant by hand. */
+export function hlgFromHdr10(
+  id: string,
+  hdr10: EncoderDescriptor,
+): EncoderDescriptor {
+  return {
+    ...hdr10,
+    id,
+    variant: { ...hdr10.variant, hdr: 'HLG' },
+    buildArgs(input: EncoderInput) {
+      const args = hdr10.buildArgs(input);
+      const tIdx = args.indexOf('-color_trc');
+      if (tIdx !== -1) args[tIdx + 1] = 'arib-std-b67';
+      return args;
+    },
+  };
+}

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
@@ -19,13 +19,19 @@ export function qsvScaleFilter8bit(input: EncoderInput): string {
   if (input.inputSurface === 'qsv') {
     // crop_qsv + scale_qsv in one filter. `vpp_qsv` is the libavfilter
     // wrapper over Intel VPP and accepts both crop region and output
-    // size in a single pass. When there's no crop, the c{w,h,x,y}
-    // options default to the full input and `vpp_qsv` is a pure scale.
-    const cropOpts = hasCrop && filters.cropStr
-      ? // filters.cropStr is `crop=W:H:X:Y` — destructure into vpp_qsv params.
-        cropStrToVppArgs(filters.cropStr)
+    // size in a single pass. Unlike software `scale=W:-2`, vpp_qsv
+    // requires explicit integer h — compute it from the crop's aspect
+    // (or the rung's profile maxHeight when there's no crop) snapped
+    // to mod-2 so the encoder doesn't reject odd luma height.
+    const cropArgs =
+      hasCrop && filters.cropStr ? parseCropStr(filters.cropStr) : null;
+    const targetH = cropArgs
+      ? snapEven(Math.round((w * cropArgs.h) / cropArgs.w))
+      : target.height;
+    const cropOpts = cropArgs
+      ? `cw=${cropArgs.w}:ch=${cropArgs.h}:cx=${cropArgs.x}:cy=${cropArgs.y}:`
       : '';
-    return `vpp_qsv=${cropOpts}w=${w}:h=-2:format=nv12`;
+    return `vpp_qsv=${cropOpts}w=${w}:h=${targetH}:format=nv12`;
   }
   if (filters.tonemapVaapi) {
     return `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`;
@@ -36,11 +42,19 @@ export function qsvScaleFilter8bit(input: EncoderInput): string {
   return `scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`;
 }
 
-/** Turn `'crop=W:H:X:Y'` into the `cw=W:ch=H:cx=X:cy=Y:` prefix that
- *  `vpp_qsv` accepts. */
-function cropStrToVppArgs(cropStr: string): string {
+function parseCropStr(
+  cropStr: string,
+): { w: number; h: number; x: number; y: number } | null {
   const m = cropStr.match(/^crop=(\d+):(\d+):(\d+):(\d+)$/);
-  if (!m) return '';
-  const [, cw, ch, cx, cy] = m;
-  return `cw=${cw}:ch=${ch}:cx=${cx}:cy=${cy}:`;
+  if (!m) return null;
+  return {
+    w: parseInt(m[1], 10),
+    h: parseInt(m[2], 10),
+    x: parseInt(m[3], 10),
+    y: parseInt(m[4], 10),
+  };
+}
+
+function snapEven(n: number): number {
+  return n - (n % 2);
 }

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
@@ -14,12 +14,13 @@ import type { EncoderInput } from '../../types';
  *  because libva exposes more scaling-quality knobs (`extra_hw_frames`,
  *  native nv12 output) on every gen we care about. */
 export function qsvScaleFilter8bit(input: EncoderInput): string {
-  const { target, filters, hasCrop } = input;
+  const { target, filters, hasCrop, tonemap } = input;
   const w = target.width;
   if (input.inputSurface === 'qsv') {
-    // crop_qsv + scale_qsv in one filter. `vpp_qsv` is the libavfilter
-    // wrapper over Intel VPP and accepts both crop region and output
-    // size in a single pass. Unlike software `scale=W:-2`, vpp_qsv
+    // Single-pass `vpp_qsv` on the QSV device — combines crop, scale,
+    // format conversion AND fixed-function HDR tone-mapping (when the
+    // host's iGPU has the VPP HDR LUT, gated by the boot probe in
+    // `vpp-qsv-probe.ts`). Unlike software `scale=W:-2`, vpp_qsv
     // requires explicit integer h — compute it from the crop's aspect
     // (or the rung's profile maxHeight when there's no crop) snapped
     // to mod-2 so the encoder doesn't reject odd luma height.
@@ -31,7 +32,8 @@ export function qsvScaleFilter8bit(input: EncoderInput): string {
     const cropOpts = cropArgs
       ? `cw=${cropArgs.w}:ch=${cropArgs.h}:cx=${cropArgs.x}:cy=${cropArgs.y}:`
       : '';
-    return `vpp_qsv=${cropOpts}w=${w}:h=${targetH}:format=nv12`;
+    const tonemapOpt = tonemap ? 'tonemap=1:' : '';
+    return `vpp_qsv=${tonemapOpt}${cropOpts}w=${w}:h=${targetH}:format=nv12`;
   }
   // hwCropPrefix = 'hwdownload,format=nv12,crop=…,hwupload=vaapi,' when
   // a crop is needed and we're on the vaapi-input path. Prepending it

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
@@ -33,13 +33,19 @@ export function qsvScaleFilter8bit(input: EncoderInput): string {
       : '';
     return `vpp_qsv=${cropOpts}w=${w}:h=${targetH}:format=nv12`;
   }
+  // hwCropPrefix = 'hwdownload,format=nv12,crop=…,hwupload=vaapi,' when
+  // a crop is needed and we're on the vaapi-input path. Prepending it
+  // lets scale_vaapi rebuild a fresh fixed-size pool from the cropped
+  // CPU frames — the QSV hwmap downstream then accepts the surfaces
+  // (the 'fixed-size pool' rejection only fires when the pool changes
+  // size mid-chain, which scale_vaapi avoids by reallocating).
   if (filters.tonemapVaapi) {
-    return `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`;
+    return `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`;
   }
   if (filters.tonemapOpencl) {
-    return `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`;
+    return `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`;
   }
-  return `scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`;
+  return `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`;
 }
 
 function parseCropStr(

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
@@ -1,20 +1,32 @@
 import type { EncoderInput } from '../../types';
 
 /** Build the `-vf` value for an 8-bit QSV encode (h264_qsv / hevc_qsv).
- *  Three branches depending on which tonemap the orchestrator wants:
+ *  Branches on what we received from the decoder:
  *
- *  - `tonemapVaapi`  : keep VAAPI surfaces, tonemap on the VPP (1 device).
- *  - `tonemapOpencl` : reinhard via OpenCL, then map to QSV.
- *  - default         : no HDR, plain scale_vaapi → hwmap to QSV.
+ *  - `inputSurface === 'qsv'` (qsv-native decoder, no tonemap): use
+ *    `vpp_qsv` for crop + scale + format on the QSV device. End-to-end
+ *    QSV pipeline, no hwmap, no fixed-pool quirk on crop.
+ *  - tonemapVaapi: keep on VAAPI surfaces, tonemap on the VPP (1 device).
+ *  - tonemapOpencl: reinhard via OpenCL, then hwmap to QSV.
+ *  - default (vaapi surfaces, no tonemap): scale_vaapi → hwmap to QSV.
  *
- *  scale_vaapi is preferred over scale_qsv because libva exposes more
- *  scaling-quality knobs (`extra_hw_frames`, native nv12 output) on
- *  every gen we care about. The hwmap at the tail moves the surfaces
- *  to the QSV device so the encoder consumes them without an implicit
- *  download/upload. */
+ *  scale_vaapi is preferred over scale_qsv for the vaapi-input paths
+ *  because libva exposes more scaling-quality knobs (`extra_hw_frames`,
+ *  native nv12 output) on every gen we care about. */
 export function qsvScaleFilter8bit(input: EncoderInput): string {
-  const { target, filters } = input;
+  const { target, filters, hasCrop } = input;
   const w = target.width;
+  if (input.inputSurface === 'qsv') {
+    // crop_qsv + scale_qsv in one filter. `vpp_qsv` is the libavfilter
+    // wrapper over Intel VPP and accepts both crop region and output
+    // size in a single pass. When there's no crop, the c{w,h,x,y}
+    // options default to the full input and `vpp_qsv` is a pure scale.
+    const cropOpts = hasCrop && filters.cropStr
+      ? // filters.cropStr is `crop=W:H:X:Y` — destructure into vpp_qsv params.
+        cropStrToVppArgs(filters.cropStr)
+      : '';
+    return `vpp_qsv=${cropOpts}w=${w}:h=-2:format=nv12`;
+  }
   if (filters.tonemapVaapi) {
     return `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`;
   }
@@ -22,4 +34,13 @@ export function qsvScaleFilter8bit(input: EncoderInput): string {
     return `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`;
   }
   return `scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`;
+}
+
+/** Turn `'crop=W:H:X:Y'` into the `cw=W:ch=H:cx=X:cy=Y:` prefix that
+ *  `vpp_qsv` accepts. */
+function cropStrToVppArgs(cropStr: string): string {
+  const m = cropStr.match(/^crop=(\d+):(\d+):(\d+):(\d+)$/);
+  if (!m) return '';
+  const [, cw, ch, cx, cy] = m;
+  return `cw=${cw}:ch=${ch}:cx=${cx}:cy=${cy}:`;
 }

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
@@ -1,0 +1,25 @@
+import type { EncoderInput } from '../../types';
+
+/** Build the `-vf` value for an 8-bit QSV encode (h264_qsv / hevc_qsv).
+ *  Three branches depending on which tonemap the orchestrator wants:
+ *
+ *  - `tonemapVaapi`  : keep VAAPI surfaces, tonemap on the VPP (1 device).
+ *  - `tonemapOpencl` : reinhard via OpenCL, then map to QSV.
+ *  - default         : no HDR, plain scale_vaapi → hwmap to QSV.
+ *
+ *  scale_vaapi is preferred over scale_qsv because libva exposes more
+ *  scaling-quality knobs (`extra_hw_frames`, native nv12 output) on
+ *  every gen we care about. The hwmap at the tail moves the surfaces
+ *  to the QSV device so the encoder consumes them without an implicit
+ *  download/upload. */
+export function qsvScaleFilter8bit(input: EncoderInput): string {
+  const { target, filters } = input;
+  const w = target.width;
+  if (filters.tonemapVaapi) {
+    return `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`;
+  }
+  if (filters.tonemapOpencl) {
+    return `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`;
+  }
+  return `scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`;
+}

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/scale-filter.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/scale-filter.ts
@@ -1,0 +1,16 @@
+/** Build the height argument for ffmpeg's software `scale` filter so the
+ *  CPU pipeline produces mod-16 output — matching what HW encoders emit
+ *  (`scale_vaapi=h=-16`) and what the master playlist advertises
+ *  (`profileResolution` snaps to mod-16). `scale=W:-2` alone produces
+ *  mod-2, which drifts on theatrical 4K masters (3840×2024 → 2024 mod-2
+ *  vs 2016 mod-16); a `-2`/`-16` mismatch between the bitstream and the
+ *  master `RESOLUTION` attribute can trip MSE on append and leaves the
+ *  player guessing about the pixel grid.
+ *
+ *  The expression preserves source aspect via `ih*W/iw` and rounds the
+ *  height down to the nearest multiple of 16. `max(16, …)` guards
+ *  against extremely small dummy inputs (the lavfi-based encoder probe
+ *  pushes 320×180 black frames). */
+export function scaleMod16Height(targetWidth: number): string {
+  return `max(16,trunc(ih*${targetWidth}/iw/16)*16)`;
+}

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/scale-filter.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/scale-filter.ts
@@ -7,10 +7,11 @@
  *  master `RESOLUTION` attribute can trip MSE on append and leaves the
  *  player guessing about the pixel grid.
  *
- *  The expression preserves source aspect via `ih*W/iw` and rounds the
- *  height down to the nearest multiple of 16. `max(16, …)` guards
- *  against extremely small dummy inputs (the lavfi-based encoder probe
- *  pushes 320×180 black frames). */
+ *  Inline expression preserves source aspect via `ih*W/iw` and rounds
+ *  the height down to the nearest multiple of 16. No `max(…)` guard:
+ *  any `,` inside a filter option ends the current filter, and even an
+ *  escaped one is fragile across ffmpeg builds — real video sources
+ *  are always large enough that mod-16 is non-zero. */
 export function scaleMod16Height(targetWidth: number): string {
-  return `max(16,trunc(ih*${targetWidth}/iw/16)*16)`;
+  return `trunc(ih*${targetWidth}/iw/16)*16`;
 }

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/scale-filter.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/scale-filter.ts
@@ -13,5 +13,5 @@
  *  escaped one is fragile across ffmpeg builds — real video sources
  *  are always large enough that mod-16 is non-zero. */
 export function scaleMod16Height(targetWidth: number): string {
-  return `trunc(ih*${targetWidth}/iw/16)*16`;
+  return `ceil(ih*${targetWidth}/iw/16)*16`;
 }

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-cpu.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-cpu.ts
@@ -1,0 +1,171 @@
+import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
+import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
+
+/** Universal libx265 HEVC SDR fallback. Same thread cap as libx264 (4):
+ *  first-segment latency stays bounded because the frame thread pool
+ *  pre-buffers ~`threads-1` frames before emitting output. Preset
+ *  namespace is shared with libx264 (`veryfast..slow`) so the
+ *  orchestrator's preset string maps 1:1. */
+export const hevcCpu: EncoderDescriptor = {
+  id: 'libx265',
+  hwAccel: 'none',
+  variant: { codec: 'hevc', bitDepth: 8, hdr: null },
+  supports: () => true,
+  supportsHdrMetadata: () => true,
+  codecString: (target: EncoderTarget) => hevcMainCodecString(target),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, preset, filters } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    return [
+      '-c:v',
+      'libx265',
+      '-threads:v',
+      '4',
+      '-preset',
+      preset,
+      '-b:v',
+      bitrate,
+      '-maxrate',
+      bitrate,
+      '-vf',
+      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:-2:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+      '-g',
+      String(target.gopSize),
+      '-keyint_min',
+      String(target.gopSize),
+      '-force_key_frames',
+      input.forceKeyframesExpr,
+      '-tag:v',
+      'hvc1',
+    ];
+  },
+};
+
+/** Reference HDR10 master-display string for `x265-params`. The values
+ *  describe a BT.2020 display mastered at 1000-nit peak / 0.0001-nit
+ *  black point — a sane default for a home-server that re-encodes from
+ *  consumer HDR sources without per-title color analysis. Units follow
+ *  x265's convention: chromaticities are `0.00002`-step integers and
+ *  luminance is `0.0001 cd/m2`. */
+const X265_MASTER_DISPLAY =
+  'G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(10000000,1)';
+
+/** Default MaxCLL / MaxFALL — 1000 / 400 nits. Reasonable HDR10 envelope
+ *  for streaming-grade content; conservative enough that downstream
+ *  displays don't see clipped highlights. */
+const X265_MAX_CLL = '1000,400';
+
+/** libx265 HEVC Main10 HDR10 — universal CPU fallback for HDR rungs
+ *  whenever the platform's HW path either can't emit Main10 or can't
+ *  write the `mdcv` / `clli` SEI reliably. `hdr-opt=1` enables PQ
+ *  optimisations, `repeat-headers=1` keeps each segment self-decodable
+ *  without dragging in the previous segment's parameter sets. */
+export const hevcCpuHdr10: EncoderDescriptor = {
+  id: 'libx265_main10',
+  hwAccel: 'none',
+  variant: { codec: 'hevc', bitDepth: 10, hdr: 'HDR10' },
+  supports: () => true,
+  supportsHdrMetadata: () => true,
+  codecString: (target: EncoderTarget) => hevcMain10CodecString(target),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, preset, filters } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    const x265Params = [
+      'hdr-opt=1',
+      'repeat-headers=1',
+      'colorprim=bt2020',
+      'transfer=smpte2084',
+      'colormatrix=bt2020nc',
+      `master-display=${X265_MASTER_DISPLAY}`,
+      `max-cll=${X265_MAX_CLL}`,
+    ].join(':');
+    return [
+      '-c:v',
+      'libx265',
+      '-threads:v',
+      '4',
+      '-preset',
+      preset,
+      '-pix_fmt',
+      'yuv420p10le',
+      '-b:v',
+      bitrate,
+      '-maxrate',
+      bitrate,
+      '-vf',
+      `${filters.cpuCropPrefix}scale=${w}:-2:flags=lanczos,format=yuv420p10le${filters.burnInFilter}`,
+      '-g',
+      String(target.gopSize),
+      '-keyint_min',
+      String(target.gopSize),
+      '-force_key_frames',
+      input.forceKeyframesExpr,
+      '-x265-params',
+      x265Params,
+      '-color_primaries',
+      'bt2020',
+      '-color_trc',
+      'smpte2084',
+      '-colorspace',
+      'bt2020nc',
+      '-tag:v',
+      'hvc1',
+    ];
+  },
+};
+
+/** libx265 HEVC Main10 HLG. HLG has no mastering-display SEI, so the
+ *  params shrink to just primaries + transfer + matrix. */
+export const hevcCpuHlg: EncoderDescriptor = {
+  id: 'libx265_hlg',
+  hwAccel: 'none',
+  variant: { codec: 'hevc', bitDepth: 10, hdr: 'HLG' },
+  supports: () => true,
+  supportsHdrMetadata: () => true,
+  codecString: (target: EncoderTarget) => hevcMain10CodecString(target),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, preset, filters } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    const x265Params = [
+      'repeat-headers=1',
+      'colorprim=bt2020',
+      'transfer=arib-std-b67',
+      'colormatrix=bt2020nc',
+    ].join(':');
+    return [
+      '-c:v',
+      'libx265',
+      '-threads:v',
+      '4',
+      '-preset',
+      preset,
+      '-pix_fmt',
+      'yuv420p10le',
+      '-b:v',
+      bitrate,
+      '-maxrate',
+      bitrate,
+      '-vf',
+      `${filters.cpuCropPrefix}scale=${w}:-2:flags=lanczos,format=yuv420p10le${filters.burnInFilter}`,
+      '-g',
+      String(target.gopSize),
+      '-keyint_min',
+      String(target.gopSize),
+      '-force_key_frames',
+      input.forceKeyframesExpr,
+      '-x265-params',
+      x265Params,
+      '-color_primaries',
+      'bt2020',
+      '-color_trc',
+      'arib-std-b67',
+      '-colorspace',
+      'bt2020nc',
+      '-tag:v',
+      'hvc1',
+    ];
+  },
+};

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-cpu.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-cpu.ts
@@ -1,5 +1,6 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
+import { hdrColorArgs } from './helpers/hdr-variants';
 
 /** Universal libx265 HEVC SDR fallback. Same thread cap as libx264 (4):
  *  first-segment latency stays bounded because the frame thread pool
@@ -104,12 +105,7 @@ export const hevcCpuHdr10: EncoderDescriptor = {
       input.forceKeyframesExpr,
       '-x265-params',
       x265Params,
-      '-color_primaries',
-      'bt2020',
-      '-color_trc',
-      'smpte2084',
-      '-colorspace',
-      'bt2020nc',
+      ...hdrColorArgs('HDR10'),
       '-tag:v',
       'hvc1',
     ];
@@ -158,12 +154,7 @@ export const hevcCpuHlg: EncoderDescriptor = {
       input.forceKeyframesExpr,
       '-x265-params',
       x265Params,
-      '-color_primaries',
-      'bt2020',
-      '-color_trc',
-      'arib-std-b67',
-      '-colorspace',
-      'bt2020nc',
+      ...hdrColorArgs('HLG'),
       '-tag:v',
       'hvc1',
     ];

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-cpu.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-cpu.ts
@@ -1,6 +1,7 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
 import { hdrColorArgs } from './helpers/hdr-variants';
+import { scaleMod16Height } from './helpers/scale-filter';
 
 /** Universal libx265 HEVC SDR fallback. Same thread cap as libx264 (4):
  *  first-segment latency stays bounded because the frame thread pool
@@ -30,7 +31,7 @@ export const hevcCpu: EncoderDescriptor = {
       '-maxrate',
       bitrate,
       '-vf',
-      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:-2:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
       '-g',
       String(target.gopSize),
       '-keyint_min',
@@ -96,7 +97,7 @@ export const hevcCpuHdr10: EncoderDescriptor = {
       '-maxrate',
       bitrate,
       '-vf',
-      `${filters.cpuCropPrefix}scale=${w}:-2:flags=lanczos,format=yuv420p10le${filters.burnInFilter}`,
+      `${filters.cpuCropPrefix}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p10le${filters.burnInFilter}`,
       '-g',
       String(target.gopSize),
       '-keyint_min',
@@ -145,7 +146,7 @@ export const hevcCpuHlg: EncoderDescriptor = {
       '-maxrate',
       bitrate,
       '-vf',
-      `${filters.cpuCropPrefix}scale=${w}:-2:flags=lanczos,format=yuv420p10le${filters.burnInFilter}`,
+      `${filters.cpuCropPrefix}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p10le${filters.burnInFilter}`,
       '-g',
       String(target.gopSize),
       '-keyint_min',

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-nvenc.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-nvenc.ts
@@ -1,5 +1,6 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
+import { hdrColorArgs, hlgFromHdr10 } from './helpers/hdr-variants';
 
 /** NVIDIA NVENC HEVC SDR encoder — Maxwell 2nd gen (GM20x) and later.
  *  Tonemap path round-trips via CPU because mainline FFmpeg still has no
@@ -98,12 +99,7 @@ export const hevcNvencHdr10: EncoderDescriptor = {
       String(target.gopSize),
       '-force_key_frames',
       input.forceKeyframesExpr,
-      '-color_primaries',
-      'bt2020',
-      '-color_trc',
-      'smpte2084',
-      '-colorspace',
-      'bt2020nc',
+      ...hdrColorArgs('HDR10'),
       '-tag:v',
       'hvc1',
     ];
@@ -112,17 +108,7 @@ export const hevcNvencHdr10: EncoderDescriptor = {
 
 /** NVENC HEVC Main10 HLG variant — identical to HDR10 with `arib-std-b67`
  *  for the transfer tag. */
-export const hevcNvencHlg: EncoderDescriptor = {
-  id: 'hevc_nvenc_hlg',
-  hwAccel: 'nvenc',
-  variant: { codec: 'hevc', bitDepth: 10, hdr: 'HLG' },
-  supports: () => true,
-  supportsHdrMetadata: () => true,
-  codecString: (target: EncoderTarget) => hevcMain10CodecString(target),
-  buildArgs(input: EncoderInput): string[] {
-    const args = hevcNvencHdr10.buildArgs(input);
-    const tIdx = args.indexOf('-color_trc');
-    if (tIdx !== -1) args[tIdx + 1] = 'arib-std-b67';
-    return args;
-  },
-};
+export const hevcNvencHlg: EncoderDescriptor = hlgFromHdr10(
+  'hevc_nvenc_hlg',
+  hevcNvencHdr10,
+);

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-nvenc.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-nvenc.ts
@@ -1,0 +1,128 @@
+import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
+import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
+
+/** NVIDIA NVENC HEVC SDR encoder — Maxwell 2nd gen (GM20x) and later.
+ *  Tonemap path round-trips via CPU because mainline FFmpeg still has no
+ *  tonemap_cuda equivalent; HDR variants below stay on GPU end-to-end. */
+export const hevcNvenc: EncoderDescriptor = {
+  id: 'hevc_nvenc',
+  hwAccel: 'nvenc',
+  variant: { codec: 'hevc', bitDepth: 8, hdr: null },
+  supports: () => true,
+  supportsHdrMetadata: () => false,
+  codecString: (target: EncoderTarget) => hevcMainCodecString(target),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, nvencPreset, filters, tonemap, hasCrop } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    const common = [
+      '-c:v',
+      'hevc_nvenc',
+      '-preset',
+      nvencPreset,
+      '-profile:v',
+      'main',
+      '-b:v',
+      bitrate,
+      '-maxrate',
+      bitrate,
+    ];
+    const trailing = [
+      '-g',
+      String(target.gopSize),
+      '-keyint_min',
+      String(target.gopSize),
+      '-force_key_frames',
+      input.forceKeyframesExpr,
+      '-tag:v',
+      'hvc1',
+    ];
+
+    if (tonemap) {
+      return [
+        ...common,
+        '-vf',
+        `hwdownload,format=p010le,${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:-2`,
+        ...trailing,
+      ];
+    }
+    const nvCropFilter = hasCrop
+      ? `hwdownload,format=nv12,${filters.cropStr},hwupload_cuda,`
+      : '';
+    return [
+      ...common,
+      '-vf',
+      `${nvCropFilter}scale_cuda=w=${w}:h=-2:format=nv12`,
+      ...trailing,
+    ];
+  },
+};
+
+/** NVENC HEVC Main10 HDR10 encoder — Pascal (GP10x) and later. NVENC has
+ *  emitted the full mastering-display / content-light-level SEI since
+ *  the 2019 FFmpeg patch landed, so `supportsHdrMetadata()` is true and
+ *  the orchestrator can drive it as the preferred HDR HW path on NV
+ *  hardware. */
+export const hevcNvencHdr10: EncoderDescriptor = {
+  id: 'hevc_nvenc_main10',
+  hwAccel: 'nvenc',
+  variant: { codec: 'hevc', bitDepth: 10, hdr: 'HDR10' },
+  supports: () => true,
+  supportsHdrMetadata: () => true,
+  codecString: (target: EncoderTarget) => hevcMain10CodecString(target),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, nvencPreset, filters, hasCrop } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    const nvCropFilter = hasCrop
+      ? `hwdownload,format=p010le,${filters.cropStr},hwupload_cuda,`
+      : '';
+    return [
+      '-c:v',
+      'hevc_nvenc',
+      '-preset',
+      nvencPreset,
+      '-profile:v',
+      'main10',
+      '-pix_fmt',
+      'p010le',
+      '-b:v',
+      bitrate,
+      '-maxrate',
+      bitrate,
+      '-vf',
+      `${nvCropFilter}scale_cuda=w=${w}:h=-2:format=p010le`,
+      '-g',
+      String(target.gopSize),
+      '-keyint_min',
+      String(target.gopSize),
+      '-force_key_frames',
+      input.forceKeyframesExpr,
+      '-color_primaries',
+      'bt2020',
+      '-color_trc',
+      'smpte2084',
+      '-colorspace',
+      'bt2020nc',
+      '-tag:v',
+      'hvc1',
+    ];
+  },
+};
+
+/** NVENC HEVC Main10 HLG variant — identical to HDR10 with `arib-std-b67`
+ *  for the transfer tag. */
+export const hevcNvencHlg: EncoderDescriptor = {
+  id: 'hevc_nvenc_hlg',
+  hwAccel: 'nvenc',
+  variant: { codec: 'hevc', bitDepth: 10, hdr: 'HLG' },
+  supports: () => true,
+  supportsHdrMetadata: () => true,
+  codecString: (target: EncoderTarget) => hevcMain10CodecString(target),
+  buildArgs(input: EncoderInput): string[] {
+    const args = hevcNvencHdr10.buildArgs(input);
+    const tIdx = args.indexOf('-color_trc');
+    if (tIdx !== -1) args[tIdx + 1] = 'arib-std-b67';
+    return args;
+  },
+};

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-nvenc.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-nvenc.ts
@@ -1,6 +1,7 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
 import { hdrColorArgs, hlgFromHdr10 } from './helpers/hdr-variants';
+import { scaleMod16Height } from './helpers/scale-filter';
 
 /** NVIDIA NVENC HEVC SDR encoder — Maxwell 2nd gen (GM20x) and later.
  *  Tonemap path round-trips via CPU because mainline FFmpeg still has no
@@ -43,7 +44,7 @@ export const hevcNvenc: EncoderDescriptor = {
       return [
         ...common,
         '-vf',
-        `hwdownload,format=p010le,${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:-2`,
+        `hwdownload,format=p010le,${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}`,
         ...trailing,
       ];
     }

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-qsv.ts
@@ -42,7 +42,7 @@ export const hevcQsv: EncoderDescriptor = {
       return [
         ...common,
         '-vf',
-        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`,
+        `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`,
         ...trailing,
       ];
     }
@@ -50,14 +50,14 @@ export const hevcQsv: EncoderDescriptor = {
       return [
         ...common,
         '-vf',
-        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`,
+        `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`,
         ...trailing,
       ];
     }
     return [
       ...common,
       '-vf',
-      `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
+      `scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
       ...trailing,
     ];
   },
@@ -76,7 +76,7 @@ export const hevcQsvHdr10: EncoderDescriptor = {
   supportsHdrMetadata: () => true,
   codecString: (target: EncoderTarget) => hevcMain10CodecString(target),
   buildArgs(input: EncoderInput): string[] {
-    const { target, preset, qsv, filters } = input;
+    const { target, preset, qsv } = input;
     const w = target.width;
     return [
       '-c:v', 'hevc_qsv',
@@ -89,7 +89,7 @@ export const hevcQsvHdr10: EncoderDescriptor = {
       '-rc_init_occupancy', String(qsv.rcInitOccupancy),
       '-bufsize', String(qsv.bufsize),
       '-vf',
-      `${filters.hwCropPrefix10}scale_vaapi=w=${w}:h=-16:format=p010le:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
+      `scale_vaapi=w=${w}:h=-16:format=p010le:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
       '-g', String(target.gopSize),
       '-keyint_min', String(target.gopSize),
       '-force_key_frames', input.forceKeyframesExpr,

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-qsv.ts
@@ -1,0 +1,56 @@
+import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
+import { hevcMain10CodecString } from '../codec-strings';
+
+/** Intel QSV HEVC Main10 encoder — Kaby Lake gen7 and above. The only
+ *  HW HEVC path with reliable HDR10 / HLG metadata propagation on
+ *  mainline FFmpeg. Color tags come from the input AVFrame; the
+ *  `-color_*` flags here are belt-and-suspenders for encoder builds
+ *  that ignore AVFrame metadata. */
+export const hevcQsvHdr10: EncoderDescriptor = {
+  id: 'hevc_qsv_main10',
+  hwAccel: 'qsv',
+  variant: { codec: 'hevc', bitDepth: 10, hdr: 'HDR10' },
+  supports: () => true,
+  supportsHdrMetadata: () => true,
+  codecString: (target: EncoderTarget) => hevcMain10CodecString(target),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, preset, qsv } = input;
+    const w = target.width;
+    return [
+      '-c:v', 'hevc_qsv',
+      '-profile:v', 'main10',
+      '-preset', preset,
+      ...qsv.extra,
+      '-mbbrc', '1',
+      '-b:v', String(target.videoBitrateBps),
+      '-maxrate', String(target.videoBitrateBps + 1),
+      '-rc_init_occupancy', String(qsv.rcInitOccupancy),
+      '-bufsize', String(qsv.bufsize),
+      '-vf',
+      `scale_vaapi=w=${w}:h=-16:format=p010le:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
+      '-g', String(target.gopSize),
+      '-keyint_min', String(target.gopSize),
+      '-force_key_frames', input.forceKeyframesExpr,
+      '-color_primaries', 'bt2020',
+      '-color_trc', 'smpte2084',
+      '-colorspace', 'bt2020nc',
+      '-tag:v', 'hvc1',
+    ];
+  },
+};
+
+/** Same encoder, HLG variant — only difference is the SPS VUI tag. */
+export const hevcQsvHlg: EncoderDescriptor = {
+  id: 'hevc_qsv_hlg',
+  hwAccel: 'qsv',
+  variant: { codec: 'hevc', bitDepth: 10, hdr: 'HLG' },
+  supports: () => true,
+  supportsHdrMetadata: () => true,
+  codecString: (target: EncoderTarget) => hevcMain10CodecString(target),
+  buildArgs(input: EncoderInput): string[] {
+    const args = hevcQsvHdr10.buildArgs(input);
+    const tIdx = args.indexOf('-color_trc');
+    if (tIdx !== -1) args[tIdx + 1] = 'arib-std-b67';
+    return args;
+  },
+};

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-qsv.ts
@@ -1,5 +1,7 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
+import { hdrColorArgs, hlgFromHdr10 } from './helpers/hdr-variants';
+import { qsvScaleFilter8bit } from './helpers/qsv-filters';
 
 /** Intel QSV HEVC Main 8-bit encoder — Skylake gen6 and above. Native
  *  HW path for HEVC SDR sources; avoids the libx265 CPU round-trip the
@@ -14,9 +16,14 @@ export const hevcQsv: EncoderDescriptor = {
   supportsHdrMetadata: () => false,
   codecString: (target: EncoderTarget) => hevcMainCodecString(target),
   buildArgs(input: EncoderInput): string[] {
-    const { target, preset, qsv, filters } = input;
-    const w = target.width;
-    const common = [
+    const { target, preset, qsv } = input;
+    // Tonemap dispatch is shared with h264_qsv — same VAAPI surfaces,
+    // same VAAPI/OpenCL tonemap kernels, same hwmap to QSV at the
+    // tail. Without it an HDR source decoded to this SDR descriptor
+    // would arrive at the encoder as nv12 pixels still carrying PQ
+    // luminance and the BT.709 SPS tags downstream would render
+    // washed-out greys.
+    return [
       '-c:v', 'hevc_qsv',
       '-preset', preset,
       ...qsv.extra,
@@ -25,40 +32,11 @@ export const hevcQsv: EncoderDescriptor = {
       '-maxrate', String(target.videoBitrateBps + 1),
       '-rc_init_occupancy', String(qsv.rcInitOccupancy),
       '-bufsize', String(qsv.bufsize),
-    ];
-    const trailing = [
+      '-vf', qsvScaleFilter8bit(input),
       '-g', String(target.gopSize),
       '-keyint_min', String(target.gopSize),
       '-force_key_frames', input.forceKeyframesExpr,
       '-tag:v', 'hvc1',
-    ];
-
-    // Match h264-qsv's tonemap dispatch: HDR source going to this SDR
-    // descriptor needs an explicit HDR→SDR filter in the VAAPI scale
-    // chain. Without it the encoder sees nv12 pixels that still carry
-    // PQ luminance, then the BT.709 SPS tags injected downstream by
-    // the orchestrator turn the output into washed-out greys.
-    if (filters.tonemapVaapi) {
-      return [
-        ...common,
-        '-vf',
-        `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`,
-        ...trailing,
-      ];
-    }
-    if (filters.tonemapOpencl) {
-      return [
-        ...common,
-        '-vf',
-        `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`,
-        ...trailing,
-      ];
-    }
-    return [
-      ...common,
-      '-vf',
-      `scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
-      ...trailing,
     ];
   },
 };
@@ -93,26 +71,14 @@ export const hevcQsvHdr10: EncoderDescriptor = {
       '-g', String(target.gopSize),
       '-keyint_min', String(target.gopSize),
       '-force_key_frames', input.forceKeyframesExpr,
-      '-color_primaries', 'bt2020',
-      '-color_trc', 'smpte2084',
-      '-colorspace', 'bt2020nc',
+      ...hdrColorArgs('HDR10'),
       '-tag:v', 'hvc1',
     ];
   },
 };
 
 /** Same encoder, HLG variant — only difference is the SPS VUI tag. */
-export const hevcQsvHlg: EncoderDescriptor = {
-  id: 'hevc_qsv_hlg',
-  hwAccel: 'qsv',
-  variant: { codec: 'hevc', bitDepth: 10, hdr: 'HLG' },
-  supports: () => true,
-  supportsHdrMetadata: () => true,
-  codecString: (target: EncoderTarget) => hevcMain10CodecString(target),
-  buildArgs(input: EncoderInput): string[] {
-    const args = hevcQsvHdr10.buildArgs(input);
-    const tIdx = args.indexOf('-color_trc');
-    if (tIdx !== -1) args[tIdx + 1] = 'arib-std-b67';
-    return args;
-  },
-};
+export const hevcQsvHlg: EncoderDescriptor = hlgFromHdr10(
+  'hevc_qsv_hlg',
+  hevcQsvHdr10,
+);

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-qsv.ts
@@ -14,9 +14,9 @@ export const hevcQsv: EncoderDescriptor = {
   supportsHdrMetadata: () => false,
   codecString: (target: EncoderTarget) => hevcMainCodecString(target),
   buildArgs(input: EncoderInput): string[] {
-    const { target, preset, qsv } = input;
+    const { target, preset, qsv, filters } = input;
     const w = target.width;
-    return [
+    const common = [
       '-c:v', 'hevc_qsv',
       '-preset', preset,
       ...qsv.extra,
@@ -25,12 +25,40 @@ export const hevcQsv: EncoderDescriptor = {
       '-maxrate', String(target.videoBitrateBps + 1),
       '-rc_init_occupancy', String(qsv.rcInitOccupancy),
       '-bufsize', String(qsv.bufsize),
-      '-vf',
-      `scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
+    ];
+    const trailing = [
       '-g', String(target.gopSize),
       '-keyint_min', String(target.gopSize),
       '-force_key_frames', input.forceKeyframesExpr,
       '-tag:v', 'hvc1',
+    ];
+
+    // Match h264-qsv's tonemap dispatch: HDR source going to this SDR
+    // descriptor needs an explicit HDR→SDR filter in the VAAPI scale
+    // chain. Without it the encoder sees nv12 pixels that still carry
+    // PQ luminance, then the BT.709 SPS tags injected downstream by
+    // the orchestrator turn the output into washed-out greys.
+    if (filters.tonemapVaapi) {
+      return [
+        ...common,
+        '-vf',
+        `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`,
+        ...trailing,
+      ];
+    }
+    if (filters.tonemapOpencl) {
+      return [
+        ...common,
+        '-vf',
+        `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`,
+        ...trailing,
+      ];
+    }
+    return [
+      ...common,
+      '-vf',
+      `scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
+      ...trailing,
     ];
   },
 };

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-qsv.ts
@@ -42,7 +42,7 @@ export const hevcQsv: EncoderDescriptor = {
       return [
         ...common,
         '-vf',
-        `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`,
+        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`,
         ...trailing,
       ];
     }
@@ -50,14 +50,14 @@ export const hevcQsv: EncoderDescriptor = {
       return [
         ...common,
         '-vf',
-        `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`,
+        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`,
         ...trailing,
       ];
     }
     return [
       ...common,
       '-vf',
-      `scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
+      `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
       ...trailing,
     ];
   },
@@ -76,7 +76,7 @@ export const hevcQsvHdr10: EncoderDescriptor = {
   supportsHdrMetadata: () => true,
   codecString: (target: EncoderTarget) => hevcMain10CodecString(target),
   buildArgs(input: EncoderInput): string[] {
-    const { target, preset, qsv } = input;
+    const { target, preset, qsv, filters } = input;
     const w = target.width;
     return [
       '-c:v', 'hevc_qsv',
@@ -89,7 +89,7 @@ export const hevcQsvHdr10: EncoderDescriptor = {
       '-rc_init_occupancy', String(qsv.rcInitOccupancy),
       '-bufsize', String(qsv.bufsize),
       '-vf',
-      `scale_vaapi=w=${w}:h=-16:format=p010le:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
+      `${filters.hwCropPrefix10}scale_vaapi=w=${w}:h=-16:format=p010le:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
       '-g', String(target.gopSize),
       '-keyint_min', String(target.gopSize),
       '-force_key_frames', input.forceKeyframesExpr,

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-qsv.ts
@@ -1,5 +1,39 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
-import { hevcMain10CodecString } from '../codec-strings';
+import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
+
+/** Intel QSV HEVC Main 8-bit encoder — Skylake gen6 and above. Native
+ *  HW path for HEVC SDR sources; avoids the libx265 CPU round-trip the
+ *  registry would otherwise pick as fallback when this descriptor is
+ *  absent. Same VAAPI-decode → scale_vaapi → hwmap → hevc_qsv chain
+ *  as h264_qsv, only the encoder and codec string differ. */
+export const hevcQsv: EncoderDescriptor = {
+  id: 'hevc_qsv',
+  hwAccel: 'qsv',
+  variant: { codec: 'hevc', bitDepth: 8, hdr: null },
+  supports: () => true,
+  supportsHdrMetadata: () => false,
+  codecString: (target: EncoderTarget) => hevcMainCodecString(target),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, preset, qsv } = input;
+    const w = target.width;
+    return [
+      '-c:v', 'hevc_qsv',
+      '-preset', preset,
+      ...qsv.extra,
+      '-mbbrc', '1',
+      '-b:v', String(target.videoBitrateBps),
+      '-maxrate', String(target.videoBitrateBps + 1),
+      '-rc_init_occupancy', String(qsv.rcInitOccupancy),
+      '-bufsize', String(qsv.bufsize),
+      '-vf',
+      `scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
+      '-g', String(target.gopSize),
+      '-keyint_min', String(target.gopSize),
+      '-force_key_frames', input.forceKeyframesExpr,
+      '-tag:v', 'hvc1',
+    ];
+  },
+};
 
 /** Intel QSV HEVC Main10 encoder — Kaby Lake gen7 and above. The only
  *  HW HEVC path with reliable HDR10 / HLG metadata propagation on

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-qsv.ts
@@ -54,7 +54,7 @@ export const hevcQsvHdr10: EncoderDescriptor = {
   supportsHdrMetadata: () => true,
   codecString: (target: EncoderTarget) => hevcMain10CodecString(target),
   buildArgs(input: EncoderInput): string[] {
-    const { target, preset, qsv } = input;
+    const { target, preset, qsv, filters, hasCrop, inputSurface } = input;
     const w = target.width;
     return [
       '-c:v', 'hevc_qsv',
@@ -67,7 +67,7 @@ export const hevcQsvHdr10: EncoderDescriptor = {
       '-rc_init_occupancy', String(qsv.rcInitOccupancy),
       '-bufsize', String(qsv.bufsize),
       '-vf',
-      `scale_vaapi=w=${w}:h=-16:format=p010le:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
+      hevcQsvHdr10FilterChain({ w, target, filters, hasCrop, inputSurface }),
       '-g', String(target.gopSize),
       '-keyint_min', String(target.gopSize),
       '-force_key_frames', input.forceKeyframesExpr,
@@ -76,6 +76,37 @@ export const hevcQsvHdr10: EncoderDescriptor = {
     ];
   },
 };
+
+/** Filter chain for the 10-bit HDR hevc_qsv encode. Two branches:
+ *  - `inputSurface='qsv'` (qsv-native decoder, e.g. for HDR + crop):
+ *    use `vpp_qsv` which handles crop + scale on the QSV device, p010le
+ *    output. Requires explicit integer height — derived from the crop
+ *    aspect.
+ *  - default (vaapi decoder output): scale_vaapi + hwmap to qsv as
+ *    before. */
+function hevcQsvHdr10FilterChain(args: {
+  w: number;
+  target: EncoderInput['target'];
+  filters: EncoderInput['filters'];
+  hasCrop: boolean;
+  inputSurface: EncoderInput['inputSurface'];
+}): string {
+  const { w, target, filters, hasCrop, inputSurface } = args;
+  if (inputSurface === 'qsv') {
+    const cropMatch =
+      hasCrop && filters.cropStr.match(/^crop=(\d+):(\d+):(\d+):(\d+)$/);
+    const cropOpts = cropMatch
+      ? `cw=${cropMatch[1]}:ch=${cropMatch[2]}:cx=${cropMatch[3]}:cy=${cropMatch[4]}:`
+      : '';
+    const targetH = cropMatch
+      ? Math.round((w * parseInt(cropMatch[2], 10)) / parseInt(cropMatch[1], 10)) -
+        (Math.round((w * parseInt(cropMatch[2], 10)) / parseInt(cropMatch[1], 10)) %
+          2)
+      : target.height;
+    return `vpp_qsv=${cropOpts}w=${w}:h=${targetH}:format=p010le`;
+  }
+  return `scale_vaapi=w=${w}:h=-16:format=p010le:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`;
+}
 
 /** Same encoder, HLG variant — only difference is the SPS VUI tag. */
 export const hevcQsvHlg: EncoderDescriptor = hlgFromHdr10(

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-vaapi.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-vaapi.ts
@@ -1,0 +1,126 @@
+import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
+import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
+
+/** AMD / Intel-on-Linux VAAPI HEVC SDR encoder (Main 8-bit). Same path as
+ *  `h264_vaapi` — used when crop forces VAAPI off the QSV fast lane, and
+ *  on AMD GPUs where VAAPI is the only HEVC HW exposure. */
+export const hevcVaapi: EncoderDescriptor = {
+  id: 'hevc_vaapi',
+  hwAccel: 'vaapi',
+  variant: { codec: 'hevc', bitDepth: 8, hdr: null },
+  supports: () => true,
+  supportsHdrMetadata: () => false,
+  codecString: (target: EncoderTarget) => hevcMainCodecString(target),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, filters } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    const common = [
+      '-c:v',
+      'hevc_vaapi',
+      '-profile:v',
+      '1',
+      '-b:v',
+      bitrate,
+      '-maxrate',
+      bitrate,
+    ];
+    const trailing = [
+      '-g',
+      String(target.gopSize),
+      '-keyint_min',
+      String(target.gopSize),
+      '-force_key_frames',
+      input.forceKeyframesExpr,
+      '-tag:v',
+      'hvc1',
+    ];
+
+    if (filters.tonemapVaapi) {
+      return [
+        ...common,
+        '-vf',
+        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi}`,
+        ...trailing,
+      ];
+    }
+    if (filters.tonemapOpencl) {
+      return [
+        ...common,
+        '-vf',
+        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=vaapi:mode=write:reverse=1,format=vaapi`,
+        ...trailing,
+      ];
+    }
+    return [
+      ...common,
+      '-vf',
+      `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:format=nv12`,
+      ...trailing,
+    ];
+  },
+};
+
+/** VAAPI HEVC Main10 HDR10 encoder. Profile 2 (Main10), p010 surfaces,
+ *  BT.2020 + PQ color tags. Mesa VAAPI does not reliably emit the
+ *  mastering-display (`mdcv`) / content-light-level (`clli`) SEI on most
+ *  drivers — `supportsHdrMetadata()` returns false so the registry falls
+ *  back to libx265 for HDR rungs. The builder remains here so a future
+ *  Mesa fix only requires flipping the capability bit. */
+export const hevcVaapiHdr10: EncoderDescriptor = {
+  id: 'hevc_vaapi_main10',
+  hwAccel: 'vaapi',
+  variant: { codec: 'hevc', bitDepth: 10, hdr: 'HDR10' },
+  supports: () => true,
+  supportsHdrMetadata: () => false,
+  codecString: (target: EncoderTarget) => hevcMain10CodecString(target),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, filters } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    return [
+      '-c:v',
+      'hevc_vaapi',
+      '-profile:v',
+      '2',
+      '-b:v',
+      bitrate,
+      '-maxrate',
+      bitrate,
+      '-vf',
+      `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:format=p010le`,
+      '-g',
+      String(target.gopSize),
+      '-keyint_min',
+      String(target.gopSize),
+      '-force_key_frames',
+      input.forceKeyframesExpr,
+      '-color_primaries',
+      'bt2020',
+      '-color_trc',
+      'smpte2084',
+      '-colorspace',
+      'bt2020nc',
+      '-tag:v',
+      'hvc1',
+    ];
+  },
+};
+
+/** VAAPI HEVC Main10 HLG variant — same encoder path as HDR10, only the
+ *  transfer characteristic differs. Same Mesa metadata limitation
+ *  applies; registry falls back to libx265. */
+export const hevcVaapiHlg: EncoderDescriptor = {
+  id: 'hevc_vaapi_hlg',
+  hwAccel: 'vaapi',
+  variant: { codec: 'hevc', bitDepth: 10, hdr: 'HLG' },
+  supports: () => true,
+  supportsHdrMetadata: () => false,
+  codecString: (target: EncoderTarget) => hevcMain10CodecString(target),
+  buildArgs(input: EncoderInput): string[] {
+    const args = hevcVaapiHdr10.buildArgs(input);
+    const tIdx = args.indexOf('-color_trc');
+    if (tIdx !== -1) args[tIdx + 1] = 'arib-std-b67';
+    return args;
+  },
+};

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-vaapi.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-vaapi.ts
@@ -1,5 +1,6 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
+import { hdrColorArgs, hlgFromHdr10 } from './helpers/hdr-variants';
 
 /** AMD / Intel-on-Linux VAAPI HEVC SDR encoder (Main 8-bit). Same path as
  *  `h264_vaapi` — used when crop forces VAAPI off the QSV fast lane, and
@@ -95,12 +96,7 @@ export const hevcVaapiHdr10: EncoderDescriptor = {
       String(target.gopSize),
       '-force_key_frames',
       input.forceKeyframesExpr,
-      '-color_primaries',
-      'bt2020',
-      '-color_trc',
-      'smpte2084',
-      '-colorspace',
-      'bt2020nc',
+      ...hdrColorArgs('HDR10'),
       '-tag:v',
       'hvc1',
     ];
@@ -110,17 +106,7 @@ export const hevcVaapiHdr10: EncoderDescriptor = {
 /** VAAPI HEVC Main10 HLG variant — same encoder path as HDR10, only the
  *  transfer characteristic differs. Same Mesa metadata limitation
  *  applies; registry falls back to libx265. */
-export const hevcVaapiHlg: EncoderDescriptor = {
-  id: 'hevc_vaapi_hlg',
-  hwAccel: 'vaapi',
-  variant: { codec: 'hevc', bitDepth: 10, hdr: 'HLG' },
-  supports: () => true,
-  supportsHdrMetadata: () => false,
-  codecString: (target: EncoderTarget) => hevcMain10CodecString(target),
-  buildArgs(input: EncoderInput): string[] {
-    const args = hevcVaapiHdr10.buildArgs(input);
-    const tIdx = args.indexOf('-color_trc');
-    if (tIdx !== -1) args[tIdx + 1] = 'arib-std-b67';
-    return args;
-  },
-};
+export const hevcVaapiHlg: EncoderDescriptor = hlgFromHdr10(
+  'hevc_vaapi_hlg',
+  hevcVaapiHdr10,
+);

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-videotoolbox.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-videotoolbox.ts
@@ -1,6 +1,7 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
 import { hdrColorArgs, hlgFromHdr10 } from './helpers/hdr-variants';
+import { scaleMod16Height } from './helpers/scale-filter';
 
 /** Apple VideoToolbox HEVC SDR encoder — Mac 2017+ (T2 / Apple Silicon).
  *  VT decode emits CPU-backed buffers, so the filter chain mirrors the
@@ -53,7 +54,7 @@ export const hevcVideotoolbox: EncoderDescriptor = {
     return [
       ...common,
       '-vf',
-      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:-2:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
       ...trailing,
     ];
   },
@@ -89,7 +90,7 @@ export const hevcVideotoolboxHdr10: EncoderDescriptor = {
       '-maxrate',
       bitrate,
       '-vf',
-      `${filters.cpuCropPrefix}scale=${w}:-2:flags=lanczos,format=p010le`,
+      `${filters.cpuCropPrefix}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=p010le`,
       '-g',
       String(target.gopSize),
       '-keyint_min',

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-videotoolbox.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-videotoolbox.ts
@@ -13,10 +13,10 @@ export const hevcVideotoolbox: EncoderDescriptor = {
   supportsHdrMetadata: () => false,
   codecString: (target: EncoderTarget) => hevcMainCodecString(target),
   buildArgs(input: EncoderInput): string[] {
-    const { target, early, filters } = input;
+    const { target, early, filters, tonemap, hasBurnIn, hasCrop } = input;
     const w = target.width;
     const bitrate = `${target.videoBitrateBps}`;
-    return [
+    const common = [
       '-c:v',
       'hevc_videotoolbox',
       '-profile:v',
@@ -26,8 +26,8 @@ export const hevcVideotoolbox: EncoderDescriptor = {
       bitrate,
       '-maxrate',
       bitrate,
-      '-vf',
-      `${filters.cpuCropPrefix}scale=${w}:-2:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+    ];
+    const trailing = [
       '-g',
       String(target.gopSize),
       '-keyint_min',
@@ -36,6 +36,24 @@ export const hevcVideotoolbox: EncoderDescriptor = {
       input.forceKeyframesExpr,
       '-tag:v',
       'hvc1',
+    ];
+
+    if (tonemap && !hasBurnIn && !hasCrop) {
+      // Full Metal pipeline: scale_vt does HDR→SDR tonemap on the
+      // Apple Media Engine. Avoids CPU round-trip when burn-in /
+      // crop aren't requested.
+      return [
+        ...common,
+        '-vf',
+        `scale_vt=w=${w}:h=-2:color_matrix=bt709:color_primaries=bt709:color_transfer=bt709`,
+        ...trailing,
+      ];
+    }
+    return [
+      ...common,
+      '-vf',
+      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:-2:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+      ...trailing,
     ];
   },
 };

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-videotoolbox.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-videotoolbox.ts
@@ -1,5 +1,6 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
+import { hdrColorArgs, hlgFromHdr10 } from './helpers/hdr-variants';
 
 /** Apple VideoToolbox HEVC SDR encoder — Mac 2017+ (T2 / Apple Silicon).
  *  VT decode emits CPU-backed buffers, so the filter chain mirrors the
@@ -95,12 +96,7 @@ export const hevcVideotoolboxHdr10: EncoderDescriptor = {
       String(target.gopSize),
       '-force_key_frames',
       input.forceKeyframesExpr,
-      '-color_primaries',
-      'bt2020',
-      '-color_trc',
-      'smpte2084',
-      '-colorspace',
-      'bt2020nc',
+      ...hdrColorArgs('HDR10'),
       '-tag:v',
       'hvc1',
     ];
@@ -108,17 +104,7 @@ export const hevcVideotoolboxHdr10: EncoderDescriptor = {
 };
 
 /** VT HEVC Main10 HLG variant — same silent-fallback caveat as HDR10. */
-export const hevcVideotoolboxHlg: EncoderDescriptor = {
-  id: 'hevc_videotoolbox_hlg',
-  hwAccel: 'videotoolbox',
-  variant: { codec: 'hevc', bitDepth: 10, hdr: 'HLG' },
-  supports: () => true,
-  supportsHdrMetadata: () => false,
-  codecString: (target: EncoderTarget) => hevcMain10CodecString(target),
-  buildArgs(input: EncoderInput): string[] {
-    const args = hevcVideotoolboxHdr10.buildArgs(input);
-    const tIdx = args.indexOf('-color_trc');
-    if (tIdx !== -1) args[tIdx + 1] = 'arib-std-b67';
-    return args;
-  },
-};
+export const hevcVideotoolboxHlg: EncoderDescriptor = hlgFromHdr10(
+  'hevc_videotoolbox_hlg',
+  hevcVideotoolboxHdr10,
+);

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-videotoolbox.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-videotoolbox.ts
@@ -1,0 +1,106 @@
+import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
+import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
+
+/** Apple VideoToolbox HEVC SDR encoder — Mac 2017+ (T2 / Apple Silicon).
+ *  VT decode emits CPU-backed buffers, so the filter chain mirrors the
+ *  H.264 VT path: software scale + lanczos + yuv420p, with optional
+ *  burn-in subtitles spliced after `format=yuv420p`. */
+export const hevcVideotoolbox: EncoderDescriptor = {
+  id: 'hevc_videotoolbox',
+  hwAccel: 'videotoolbox',
+  variant: { codec: 'hevc', bitDepth: 8, hdr: null },
+  supports: () => true,
+  supportsHdrMetadata: () => false,
+  codecString: (target: EncoderTarget) => hevcMainCodecString(target),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, early, filters } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    return [
+      '-c:v',
+      'hevc_videotoolbox',
+      '-profile:v',
+      'main',
+      ...(early ? ['-realtime', '1'] : []),
+      '-b:v',
+      bitrate,
+      '-maxrate',
+      bitrate,
+      '-vf',
+      `${filters.cpuCropPrefix}scale=${w}:-2:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+      '-g',
+      String(target.gopSize),
+      '-keyint_min',
+      String(target.gopSize),
+      '-force_key_frames',
+      input.forceKeyframesExpr,
+      '-tag:v',
+      'hvc1',
+    ];
+  },
+};
+
+/** VT HEVC Main10 HDR10. The builder is implemented end-to-end, but
+ *  `hevc_videotoolbox` has a documented history of silently degrading
+ *  Main10 inputs to 8-bit on some FFmpeg builds (lisamelton report
+ *  #106). Until the silent-fallback fix lands and ships in our pinned
+ *  FFmpeg, `supportsHdrMetadata()` returns false so the registry routes
+ *  HDR rungs to libx265 on Apple platforms. */
+export const hevcVideotoolboxHdr10: EncoderDescriptor = {
+  id: 'hevc_videotoolbox_main10',
+  hwAccel: 'videotoolbox',
+  variant: { codec: 'hevc', bitDepth: 10, hdr: 'HDR10' },
+  supports: () => true,
+  supportsHdrMetadata: () => false,
+  codecString: (target: EncoderTarget) => hevcMain10CodecString(target),
+  buildArgs(input: EncoderInput): string[] {
+    const { target, early, filters } = input;
+    const w = target.width;
+    const bitrate = `${target.videoBitrateBps}`;
+    return [
+      '-c:v',
+      'hevc_videotoolbox',
+      '-profile:v',
+      'main10',
+      ...(early ? ['-realtime', '1'] : []),
+      '-pix_fmt',
+      'p010le',
+      '-b:v',
+      bitrate,
+      '-maxrate',
+      bitrate,
+      '-vf',
+      `${filters.cpuCropPrefix}scale=${w}:-2:flags=lanczos,format=p010le`,
+      '-g',
+      String(target.gopSize),
+      '-keyint_min',
+      String(target.gopSize),
+      '-force_key_frames',
+      input.forceKeyframesExpr,
+      '-color_primaries',
+      'bt2020',
+      '-color_trc',
+      'smpte2084',
+      '-colorspace',
+      'bt2020nc',
+      '-tag:v',
+      'hvc1',
+    ];
+  },
+};
+
+/** VT HEVC Main10 HLG variant — same silent-fallback caveat as HDR10. */
+export const hevcVideotoolboxHlg: EncoderDescriptor = {
+  id: 'hevc_videotoolbox_hlg',
+  hwAccel: 'videotoolbox',
+  variant: { codec: 'hevc', bitDepth: 10, hdr: 'HLG' },
+  supports: () => true,
+  supportsHdrMetadata: () => false,
+  codecString: (target: EncoderTarget) => hevcMain10CodecString(target),
+  buildArgs(input: EncoderInput): string[] {
+    const args = hevcVideotoolboxHdr10.buildArgs(input);
+    const tIdx = args.indexOf('-color_trc');
+    if (tIdx !== -1) args[tIdx + 1] = 'arib-std-b67';
+    return args;
+  },
+};

--- a/backend/src/modules/streaming/transcoding/codec/encoders/index.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/index.ts
@@ -5,6 +5,7 @@ import type {
   HdrFormat,
 } from '../types';
 import type { HwAccelType } from '../../types';
+import { isEncoderEnabled } from '../encoder-probe';
 import { h264Qsv } from './h264-qsv';
 import { h264Vaapi } from './h264-vaapi';
 import { h264Nvenc } from './h264-nvenc';
@@ -64,6 +65,15 @@ const DESCRIPTORS: readonly EncoderDescriptor[] = [
   h264Cpu,
 ];
 
+/** Gate combining the build-time `supports()` check and the runtime
+ *  one-frame probe result. An encoder is only usable when both pass. */
+function isUsable(d: EncoderDescriptor, variant: CodecVariant): boolean {
+  if (!d.supports()) return false;
+  if (variant.hdr && !d.supportsHdrMetadata()) return false;
+  if (!isEncoderEnabled(d.id)) return false;
+  return true;
+}
+
 class StaticRegistry implements EncoderRegistry {
   resolve(
     variant: CodecVariant,
@@ -73,8 +83,7 @@ class StaticRegistry implements EncoderRegistry {
     for (const d of DESCRIPTORS) {
       if (d.hwAccel !== hwAccel) continue;
       if (!variantMatches(d.variant, variant)) continue;
-      if (!d.supports()) continue;
-      if (variant.hdr && !d.supportsHdrMetadata()) continue;
+      if (!isUsable(d, variant)) continue;
       return d;
     }
     // Pass 2: CPU fallback for the same variant.
@@ -82,7 +91,7 @@ class StaticRegistry implements EncoderRegistry {
       for (const d of DESCRIPTORS) {
         if (d.hwAccel !== 'none') continue;
         if (!variantMatches(d.variant, variant)) continue;
-        if (!d.supports()) continue;
+        if (!isUsable(d, variant)) continue;
         return d;
       }
     }
@@ -95,8 +104,7 @@ class StaticRegistry implements EncoderRegistry {
     for (const d of DESCRIPTORS) {
       if (d.hwAccel !== hwAccel) continue;
       if (!variantMatches(d.variant, variant)) continue;
-      if (!d.supports()) continue;
-      if (variant.hdr && !d.supportsHdrMetadata()) continue;
+      if (!isUsable(d, variant)) continue;
       out.push(d);
     }
     // Then CPU fallback (if it can produce this variant).
@@ -104,13 +112,18 @@ class StaticRegistry implements EncoderRegistry {
       for (const d of DESCRIPTORS) {
         if (d.hwAccel !== 'none') continue;
         if (!variantMatches(d.variant, variant)) continue;
-        if (!d.supports()) continue;
+        if (!isUsable(d, variant)) continue;
         out.push(d);
       }
     }
     return out;
   }
 }
+
+/** Full list of compiled-in encoder descriptors. Exposed so the
+ *  startup probe layer can iterate every encoder and run its
+ *  one-frame test. */
+export const ALL_DESCRIPTORS = DESCRIPTORS;
 
 /** Strict identity check on the variant tuple. `null` HDR matches only
  *  `null` HDR — SDR rungs never resolve to HDR descriptors and vice

--- a/backend/src/modules/streaming/transcoding/codec/encoders/index.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/index.ts
@@ -11,7 +11,7 @@ import { h264Vaapi } from './h264-vaapi';
 import { h264Nvenc } from './h264-nvenc';
 import { h264Videotoolbox } from './h264-videotoolbox';
 import { h264Cpu } from './h264-cpu';
-import { hevcQsvHdr10, hevcQsvHlg } from './hevc-qsv';
+import { hevcQsv, hevcQsvHdr10, hevcQsvHlg } from './hevc-qsv';
 import { hevcVaapi, hevcVaapiHdr10, hevcVaapiHlg } from './hevc-vaapi';
 import { hevcNvenc, hevcNvencHdr10, hevcNvencHlg } from './hevc-nvenc';
 import {
@@ -31,6 +31,7 @@ import { av1Cpu, av1CpuHdr10, av1CpuHlg } from './av1-cpu';
  *  entries come before CPU fallbacks. */
 const DESCRIPTORS: readonly EncoderDescriptor[] = [
   // HEVC HW
+  hevcQsv,
   hevcQsvHdr10,
   hevcQsvHlg,
   hevcVaapi,

--- a/backend/src/modules/streaming/transcoding/codec/encoders/index.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/index.ts
@@ -1,0 +1,91 @@
+import type {
+  CodecVariant,
+  EncoderDescriptor,
+  EncoderRegistry,
+  HdrFormat,
+} from '../types';
+import type { HwAccelType } from '../../types';
+import { h264Qsv } from './h264-qsv';
+import { h264Vaapi } from './h264-vaapi';
+import { h264Nvenc } from './h264-nvenc';
+import { h264Videotoolbox } from './h264-videotoolbox';
+import { h264Cpu } from './h264-cpu';
+import { hevcQsvHdr10, hevcQsvHlg } from './hevc-qsv';
+
+/** Static registry of every encoder descriptor compiled in. The order
+ *  matters: when multiple descriptors match a `(variant, hwAccel)` query
+ *  the registry returns the first one in iteration order, so HW-accelerated
+ *  entries come before CPU fallbacks. */
+const DESCRIPTORS: readonly EncoderDescriptor[] = [
+  h264Qsv,
+  h264Vaapi,
+  h264Nvenc,
+  h264Videotoolbox,
+  hevcQsvHdr10,
+  hevcQsvHlg,
+  // CPU fallback last — `candidates()` returns it as a last resort.
+  h264Cpu,
+];
+
+class StaticRegistry implements EncoderRegistry {
+  resolve(
+    variant: CodecVariant,
+    hwAccel: HwAccelType,
+  ): EncoderDescriptor | null {
+    // Pass 1: exact match on hwAccel.
+    for (const d of DESCRIPTORS) {
+      if (d.hwAccel !== hwAccel) continue;
+      if (!variantMatches(d.variant, variant)) continue;
+      if (!d.supports()) continue;
+      if (variant.hdr && !d.supportsHdrMetadata()) continue;
+      return d;
+    }
+    // Pass 2: CPU fallback for the same variant.
+    if (hwAccel !== 'none') {
+      for (const d of DESCRIPTORS) {
+        if (d.hwAccel !== 'none') continue;
+        if (!variantMatches(d.variant, variant)) continue;
+        if (!d.supports()) continue;
+        return d;
+      }
+    }
+    return null;
+  }
+
+  candidates(variant: CodecVariant, hwAccel: HwAccelType): EncoderDescriptor[] {
+    const out: EncoderDescriptor[] = [];
+    // HW first, in declared order.
+    for (const d of DESCRIPTORS) {
+      if (d.hwAccel !== hwAccel) continue;
+      if (!variantMatches(d.variant, variant)) continue;
+      if (!d.supports()) continue;
+      if (variant.hdr && !d.supportsHdrMetadata()) continue;
+      out.push(d);
+    }
+    // Then CPU fallback (if it can produce this variant).
+    if (hwAccel !== 'none') {
+      for (const d of DESCRIPTORS) {
+        if (d.hwAccel !== 'none') continue;
+        if (!variantMatches(d.variant, variant)) continue;
+        if (!d.supports()) continue;
+        out.push(d);
+      }
+    }
+    return out;
+  }
+}
+
+/** Strict identity check on the variant tuple. `null` HDR matches only
+ *  `null` HDR — SDR rungs never resolve to HDR descriptors and vice
+ *  versa. */
+function variantMatches(d: CodecVariant, q: CodecVariant): boolean {
+  return (
+    d.codec === q.codec && d.bitDepth === q.bitDepth && sameHdr(d.hdr, q.hdr)
+  );
+}
+
+function sameHdr(a: HdrFormat | null, b: HdrFormat | null): boolean {
+  return a === b;
+}
+
+export const encoderRegistry: EncoderRegistry = new StaticRegistry();

--- a/backend/src/modules/streaming/transcoding/codec/encoders/index.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/index.ts
@@ -11,19 +11,56 @@ import { h264Nvenc } from './h264-nvenc';
 import { h264Videotoolbox } from './h264-videotoolbox';
 import { h264Cpu } from './h264-cpu';
 import { hevcQsvHdr10, hevcQsvHlg } from './hevc-qsv';
+import { hevcVaapi, hevcVaapiHdr10, hevcVaapiHlg } from './hevc-vaapi';
+import { hevcNvenc, hevcNvencHdr10, hevcNvencHlg } from './hevc-nvenc';
+import {
+  hevcVideotoolbox,
+  hevcVideotoolboxHdr10,
+  hevcVideotoolboxHlg,
+} from './hevc-videotoolbox';
+import { hevcCpu, hevcCpuHdr10, hevcCpuHlg } from './hevc-cpu';
+import { av1Qsv, av1QsvHdr10 } from './av1-qsv';
+import { av1Vaapi, av1VaapiHdr10 } from './av1-vaapi';
+import { av1Nvenc, av1NvencHdr10, av1NvencHlg } from './av1-nvenc';
+import { av1Cpu, av1CpuHdr10, av1CpuHlg } from './av1-cpu';
 
 /** Static registry of every encoder descriptor compiled in. The order
  *  matters: when multiple descriptors match a `(variant, hwAccel)` query
  *  the registry returns the first one in iteration order, so HW-accelerated
  *  entries come before CPU fallbacks. */
 const DESCRIPTORS: readonly EncoderDescriptor[] = [
+  // HEVC HW
+  hevcQsvHdr10,
+  hevcQsvHlg,
+  hevcVaapi,
+  hevcVaapiHdr10,
+  hevcVaapiHlg,
+  hevcNvenc,
+  hevcNvencHdr10,
+  hevcNvencHlg,
+  hevcVideotoolbox,
+  hevcVideotoolboxHdr10,
+  hevcVideotoolboxHlg,
+  // AV1 HW
+  av1Qsv,
+  av1QsvHdr10,
+  av1Vaapi,
+  av1VaapiHdr10,
+  av1Nvenc,
+  av1NvencHdr10,
+  av1NvencHlg,
+  // H.264 HW
   h264Qsv,
   h264Vaapi,
   h264Nvenc,
   h264Videotoolbox,
-  hevcQsvHdr10,
-  hevcQsvHlg,
   // CPU fallback last — `candidates()` returns it as a last resort.
+  hevcCpu,
+  hevcCpuHdr10,
+  hevcCpuHlg,
+  av1Cpu,
+  av1CpuHdr10,
+  av1CpuHlg,
   h264Cpu,
 ];
 

--- a/backend/src/modules/streaming/transcoding/codec/fallback.ts
+++ b/backend/src/modules/streaming/transcoding/codec/fallback.ts
@@ -1,0 +1,114 @@
+import type { CodecVariant } from './types';
+import type { DeviceProfileDto } from '../../dto/device-profile.dto';
+
+/** A client-specific override that filters or rewrites the candidate
+ *  variant list. Used to drop codec/HDR/resolution combinations a client
+ *  claims to support but that fail in practice — typically Chromecast
+ *  receivers whose `canDisplayType` returns true for codecs the device
+ *  silently rejects at decode time. */
+export interface ClientQuirk {
+  /** Stable id for logging — visible in playback-info diagnostics. */
+  readonly id: string;
+  /** Predicate. Receives the device profile sent by the client (UA-derived
+   *  hints, codec list, channel count, etc.) and any extra HTTP context
+   *  passed to the resolver. Return `true` iff this quirk applies. */
+  matches(ctx: QuirkContext): boolean;
+  /** Filter / rewrite the variant list. Implementations should be
+   *  idempotent — apply twice = same result as apply once. */
+  filter(variants: CodecVariant[], ctx: QuirkContext): CodecVariant[];
+  /** Free-text reason — surfaced in playback-info `transcodeReasons` so
+   *  the admin dashboard can show *why* a client wasn't offered HEVC. */
+  readonly reason: string;
+}
+
+export interface QuirkContext {
+  profile: DeviceProfileDto;
+  /** Source video dimensions — required to filter "X codec but only
+   *  ≤ 1080p" quirks like CCwGTV HD silently failing HEVC Main10 @ 4K. */
+  sourceHeight: number;
+  /** Lowercased `User-Agent` header. Optional — quirks that key on
+   *  HTTP-only signals (e.g. specific Chromecast firmware versions)
+   *  read this. */
+  userAgent: string;
+}
+
+const CCWGTV_HD_NO_4K_HEVC_HDR: ClientQuirk = {
+  id: 'ccwgtv-hd-no-4k-hevc-hdr',
+  matches: (ctx) =>
+    /chromecast.+google.+tv/i.test(ctx.userAgent) &&
+    !/4k/i.test(ctx.userAgent) &&
+    ctx.sourceHeight > 1080,
+  filter: (variants) =>
+    variants.filter((v) => !(v.codec === 'hevc' && v.hdr !== null)),
+  reason:
+    'Chromecast with Google TV (HD) silently fails HEVC Main10 above 1080p',
+};
+
+const CCWGTV_HD_NO_4K: ClientQuirk = {
+  id: 'ccwgtv-hd-no-4k-rungs',
+  matches: (ctx) =>
+    /chromecast.+google.+tv/i.test(ctx.userAgent) && !/4k/i.test(ctx.userAgent),
+  filter: (variants) => variants,
+  reason: 'Chromecast with Google TV (HD) caps decode at 1080p',
+};
+
+const OLDER_CHROMECAST_NO_AV1: ClientQuirk = {
+  id: 'older-chromecast-no-av1',
+  matches: (ctx) => {
+    if (!/cast|chromecast/i.test(ctx.userAgent)) return false;
+    // Google TV Streamer (2024) is the first Cast receiver with HW AV1
+    // decode reliably available; everything older silently fails on AV1.
+    return !/streamer|google.+tv\b/i.test(ctx.userAgent);
+  },
+  filter: (variants) => variants.filter((v) => v.codec !== 'av1'),
+  reason: 'Pre-2024 Chromecast receivers lack reliable HW AV1 decode',
+};
+
+const APPLE_TV_PRE_A17_NO_AV1: ClientQuirk = {
+  id: 'apple-pre-a17-no-av1',
+  matches: (ctx) => {
+    // AV1 HW decode is iPhone 15 Pro / iPad M3 / Apple TV with A17+
+    // (none shipped yet on Apple TV at time of writing). Be conservative:
+    // any iOS UA without a clear A17+ signal drops AV1.
+    if (!/iphone|ipad|apple.?tv/i.test(ctx.userAgent)) return false;
+    return !/cpu (iphone )?os 17_4|version\/17\.4/i.test(ctx.userAgent);
+  },
+  filter: (variants) => variants.filter((v) => v.codec !== 'av1'),
+  reason: 'iOS / Apple TV without A17 HW AV1 decoder',
+};
+
+const DROP_DV_TRANSCODE: ClientQuirk = {
+  id: 'no-dv-transcode',
+  matches: () => true,
+  filter: (variants) =>
+    variants.filter(
+      (v) => v.hdr !== 'DV5' && v.hdr !== 'DV81' && v.hdr !== 'DV84',
+    ),
+  reason: 'Dolby Vision transcode is not implemented (DirectPlay only)',
+};
+
+const REGISTRY: readonly ClientQuirk[] = [
+  CCWGTV_HD_NO_4K_HEVC_HDR,
+  CCWGTV_HD_NO_4K,
+  OLDER_CHROMECAST_NO_AV1,
+  APPLE_TV_PRE_A17_NO_AV1,
+  DROP_DV_TRANSCODE,
+];
+
+/** Run every applicable quirk against the candidate variants. Returns
+ *  the filtered list plus the ids of the quirks that fired (for log /
+ *  diagnostic surfacing). */
+export function applyQuirks(
+  variants: CodecVariant[],
+  ctx: QuirkContext,
+): { variants: CodecVariant[]; applied: string[] } {
+  let current = variants;
+  const applied: string[] = [];
+  for (const quirk of REGISTRY) {
+    if (!quirk.matches(ctx)) continue;
+    const next = quirk.filter(current, ctx);
+    if (next.length !== current.length) applied.push(quirk.id);
+    current = next;
+  }
+  return { variants: current, applied };
+}

--- a/backend/src/modules/streaming/transcoding/codec/selector.ts
+++ b/backend/src/modules/streaming/transcoding/codec/selector.ts
@@ -1,0 +1,96 @@
+import type { CodecVariant, VideoCodec } from './types';
+import type { DeviceProfileDto } from '../../dto/device-profile.dto';
+import type { HwAccelType } from '../types';
+import { encoderRegistry } from './encoders';
+import { applyQuirks, type QuirkContext } from './fallback';
+
+/** Pick the codec variant(s) we'll expose to a given client. Ordered by
+ *  preference: HEVC HDR first when the source is HDR and the client can
+ *  decode it, then SDR ladders (AV1 > HEVC > H.264) restricted to what
+ *  the client claims to support. Run through the quirks DB to drop
+ *  known-bad combos.
+ *
+ *  Returns the full ranked list; the caller usually emits only the
+ *  top entry (one codec per master playlist — see the architecture
+ *  plan §5.6) and keeps the rest for diagnostics / fallback. */
+export function pickVariants(
+  source: SourceInfoForSelector,
+  profile: DeviceProfileDto,
+  hwAccel: HwAccelType,
+  userAgent: string,
+): { variants: CodecVariant[]; quirksApplied: string[] } {
+  const clientCodecs = new Set(
+    profile.directPlayProfiles.flatMap((p) =>
+      p.videoCodecs.map((c) => c.toLowerCase()),
+    ),
+  );
+
+  const candidates: CodecVariant[] = [];
+
+  // HDR path — only meaningful when source is HDR AND client supports
+  // an HDR display (browser caps + display gamut probe). Walk codecs
+  // in efficiency order; the first one the registry can produce
+  // (HW + HDR metadata, or CPU libx265/libsvtav1 fallback) wins
+  // the HDR slot.
+  if (source.hdr && profile.supportsHdr === true) {
+    for (const codec of ['hevc', 'av1'] as VideoCodec[]) {
+      if (!clientSupports(clientCodecs, codec)) continue;
+      const variant: CodecVariant = { codec, bitDepth: 10, hdr: source.hdr };
+      if (encoderRegistry.resolve(variant, hwAccel)) {
+        candidates.push(variant);
+        break;
+      }
+    }
+  }
+
+  // SDR ladder — always present, even on HDR clients (they can tone-map
+  // for the SDR fallback when the HDR encoder path is unavailable, and
+  // they need an SDR base anyway for legacy non-HDR sources).
+  for (const codec of ['av1', 'hevc', 'h264'] as VideoCodec[]) {
+    if (!clientSupports(clientCodecs, codec)) continue;
+    const variant: CodecVariant = { codec, bitDepth: 8, hdr: null };
+    if (encoderRegistry.resolve(variant, hwAccel)) {
+      candidates.push(variant);
+    }
+  }
+
+  const ctx: QuirkContext = {
+    profile,
+    sourceHeight: source.height,
+    userAgent: userAgent.toLowerCase(),
+  };
+  const { variants, applied } = applyQuirks(candidates, ctx);
+  return { variants, quirksApplied: applied };
+}
+
+/** Convenience: pick a single variant — the top-ranked one after quirks.
+ *  Falls back to H.264 SDR if nothing else survives (universal codec
+ *  every client claims to support). */
+export function pickPrimaryVariant(
+  source: SourceInfoForSelector,
+  profile: DeviceProfileDto,
+  hwAccel: HwAccelType,
+  userAgent: string,
+): CodecVariant {
+  const { variants } = pickVariants(source, profile, hwAccel, userAgent);
+  return variants[0] ?? { codec: 'h264', bitDepth: 8, hdr: null };
+}
+
+export interface SourceInfoForSelector {
+  width: number;
+  height: number;
+  hdr: CodecVariant['hdr'];
+}
+
+/** Codec name list comparison — clients send aliases (`hvc1`/`hev1` for
+ *  HEVC, `avc1` for H.264) so we normalise both sides. */
+function clientSupports(set: Set<string>, codec: VideoCodec): boolean {
+  switch (codec) {
+    case 'h264':
+      return set.has('h264') || set.has('avc1');
+    case 'hevc':
+      return set.has('hevc') || set.has('h265') || set.has('hvc1') || set.has('hev1');
+    case 'av1':
+      return set.has('av1') || set.has('av01');
+  }
+}

--- a/backend/src/modules/streaming/transcoding/codec/selector.ts
+++ b/backend/src/modules/streaming/transcoding/codec/selector.ts
@@ -4,15 +4,21 @@ import type { HwAccelType } from '../types';
 import { encoderRegistry } from './encoders';
 import { applyQuirks, type QuirkContext } from './fallback';
 
-/** Pick the codec variant(s) we'll expose to a given client. Ordered by
- *  preference: HEVC HDR first when the source is HDR and the client can
- *  decode it, then SDR ladders (AV1 > HEVC > H.264) restricted to what
- *  the client claims to support. Run through the quirks DB to drop
- *  known-bad combos.
+/** Pick the codec variant(s) we'll expose to a given client. Order of
+ *  preference (within each HDR/SDR group):
  *
- *  Returns the full ranked list; the caller usually emits only the
- *  top entry (one codec per master playlist — see the architecture
- *  plan §5.6) and keeps the rest for diagnostics / fallback. */
+ *  1. Source codec — when the client supports it, transcoding to the
+ *     same codec preserves visual fidelity (no cross-codec artifacts)
+ *     and reuses the most-tested HW path in this deployment.
+ *  2. Efficiency ranking — AV1 > HEVC > H.264 for the remaining codecs.
+ *
+ *  Each candidate is gated on encoder availability via
+ *  `encoderRegistry.resolve()`; combos with no working encoder are
+ *  dropped. The quirks DB filters known-bad client/codec pairings last.
+ *
+ *  Returns the full ranked list; the caller usually emits only the top
+ *  entry (one codec per master playlist — see the architecture plan
+ *  §5.6) and keeps the rest for diagnostics / fallback. */
 export function pickVariants(
   source: SourceInfoForSelector,
   profile: DeviceProfileDto,
@@ -27,13 +33,24 @@ export function pickVariants(
 
   const candidates: CodecVariant[] = [];
 
+  // Codec ranking: source codec first when client supports it, then
+  // efficiency fallback. H.264 last as the universal compatibility safety.
+  const efficiencyOrder: VideoCodec[] = ['av1', 'hevc', 'h264'];
+  const codecOrder: VideoCodec[] =
+    source.codec && clientSupports(clientCodecs, source.codec)
+      ? [
+          source.codec,
+          ...efficiencyOrder.filter((c) => c !== source.codec),
+        ]
+      : efficiencyOrder;
+
   // HDR path — only meaningful when source is HDR AND client supports
-  // an HDR display (browser caps + display gamut probe). Walk codecs
-  // in efficiency order; the first one the registry can produce
-  // (HW + HDR metadata, or CPU libx265/libsvtav1 fallback) wins
-  // the HDR slot.
+  // an HDR display (browser caps + display gamut probe). H.264 is
+  // skipped (8-bit only). First codec with a resolvable HDR encoder
+  // (HW + HDR metadata, or CPU libx265/libsvtav1 fallback) wins.
   if (source.hdr && profile.supportsHdr === true) {
-    for (const codec of ['hevc', 'av1'] as VideoCodec[]) {
+    for (const codec of codecOrder) {
+      if (codec === 'h264') continue;
       if (!clientSupports(clientCodecs, codec)) continue;
       const variant: CodecVariant = { codec, bitDepth: 10, hdr: source.hdr };
       if (encoderRegistry.resolve(variant, hwAccel)) {
@@ -46,7 +63,7 @@ export function pickVariants(
   // SDR ladder — always present, even on HDR clients (they can tone-map
   // for the SDR fallback when the HDR encoder path is unavailable, and
   // they need an SDR base anyway for legacy non-HDR sources).
-  for (const codec of ['av1', 'hevc', 'h264'] as VideoCodec[]) {
+  for (const codec of codecOrder) {
     if (!clientSupports(clientCodecs, codec)) continue;
     const variant: CodecVariant = { codec, bitDepth: 8, hdr: null };
     if (encoderRegistry.resolve(variant, hwAccel)) {
@@ -80,6 +97,10 @@ export interface SourceInfoForSelector {
   width: number;
   height: number;
   hdr: CodecVariant['hdr'];
+  /** Source video codec (lowercased ffprobe name, normalised to the
+   *  `VideoCodec` union). When set, the selector prefers transcoding to
+   *  the same codec for fidelity and HW path predictability. */
+  codec?: VideoCodec;
 }
 
 /** Codec name list comparison — clients send aliases (`hvc1`/`hev1` for

--- a/backend/src/modules/streaming/transcoding/codec/selector.ts
+++ b/backend/src/modules/streaming/transcoding/codec/selector.ts
@@ -89,7 +89,9 @@ function clientSupports(set: Set<string>, codec: VideoCodec): boolean {
     case 'h264':
       return set.has('h264') || set.has('avc1');
     case 'hevc':
-      return set.has('hevc') || set.has('h265') || set.has('hvc1') || set.has('hev1');
+      return (
+        set.has('hevc') || set.has('h265') || set.has('hvc1') || set.has('hev1')
+      );
     case 'av1':
       return set.has('av1') || set.has('av01');
   }

--- a/backend/src/modules/streaming/transcoding/codec/types.ts
+++ b/backend/src/modules/streaming/transcoding/codec/types.ts
@@ -1,0 +1,104 @@
+import type { HwAccelType } from '../types';
+
+/** Video codecs supported by the streaming pipeline. Extend this union and
+ *  add encoder implementations under `./encoders/` to introduce a new
+ *  codec (e.g. `'vvc'`); every other module reads codec capability through
+ *  the registry, so no switch statements need editing. */
+export type VideoCodec = 'h264' | 'hevc' | 'av1';
+
+export type BitDepth = 8 | 10;
+
+/** HDR transfer / signaling. `null` means SDR.
+ *  - HDR10: BT.2020 primaries + SMPTE-ST-2084 (PQ) transfer + static metadata
+ *  - HLG:   BT.2020 primaries + ARIB STD-B67 transfer
+ *  - DV*:   Dolby Vision profiles; transcode support is intentionally out of
+ *           scope (DirectPlay only). Listed for typing completeness. */
+export type HdrFormat = 'HDR10' | 'HLG' | 'DV5' | 'DV81' | 'DV84';
+
+/** The triple that uniquely identifies a video output format. Resolution
+ *  and bitrate are not part of identity — those live on `LadderRung`. */
+export interface CodecVariant {
+  codec: VideoCodec;
+  bitDepth: BitDepth;
+  hdr: HdrFormat | null;
+}
+
+/** Minimal source-side info the encoder needs to set up scale filters,
+ *  color tags and seek geometry. Populated from ffprobe streamInfo. */
+export interface EncoderSourceInfo {
+  width: number;
+  height: number;
+  frameRate?: number;
+  hdr: HdrFormat | null;
+  /** Source bit depth (driven by sourceVideoCodec + ffprobe `bits_per_raw_sample`). */
+  bitDepth: BitDepth;
+  /** ffprobe `codec_name` (lowercased). Drives bsf choice and decode path. */
+  codecName: string;
+}
+
+/** Output target for a single rung — resolution + bitrate + GOP cadence. */
+export interface EncoderTarget {
+  width: number;
+  height: number;
+  videoBitrateBps: number;
+  /** Number of frames between forced IDRs. Drives `-g`, `-keyint_min` and
+   *  `force_key_frames` expression. Computed from source fps × segment
+   *  duration so segments stay perfectly uniform. */
+  gopSize: number;
+  /** Source frame rate (rounded to int for ffmpeg). */
+  frameRate: number;
+}
+
+/** Per-spawn inputs to an encoder's args builder. Common across encoders. */
+export interface EncoderInput {
+  source: EncoderSourceInfo;
+  variant: CodecVariant;
+  target: EncoderTarget;
+  /** Encoder preset hint (`veryfast`, `faster`, `fast`, `medium`, `slow`).
+   *  Each encoder maps it onto its own preset namespace. */
+  preset: string;
+  /** Mid-file resume position (source seconds). Encoders may use it to
+   *  derive `force_key_frames` offsets. 0 = fresh play. */
+  seekSeconds: number;
+  /** True for the early-warm shadow session (small `-t 4` window, runs
+   *  parallel to the main session to serve seg-0 fast). */
+  early: boolean;
+}
+
+/** A single encoder binding — one ffmpeg encoder × one platform × one
+ *  CodecVariant. Each binding lives in its own file under `./encoders/`.
+ *  The registry holds an immutable list of every binding compiled in. */
+export interface EncoderDescriptor {
+  /** Short identifier for logs / stats overlay (e.g. `'hevc_qsv_main10'`). */
+  readonly id: string;
+  readonly hwAccel: HwAccelType;
+  readonly variant: CodecVariant;
+  /** Soft capability check at runtime. Reads `hw-detect.ts` to know if
+   *  this binding is usable on the current host (HW present, generation
+   *  sufficient, ffmpeg build has the encoder, etc.). */
+  supports(): boolean;
+  /** True iff this encoder reliably writes HDR static metadata (`mdcv`,
+   *  `clli` boxes; SEI messages). When false on an HDR variant, the
+   *  registry resolver picks a CPU-fallback descriptor instead. */
+  supportsHdrMetadata(): boolean;
+  /** Build the ffmpeg argument slice for video encoding only — the input
+   *  spec (`-ss`, `-i`, hwaccel init), audio mapping and HLS muxer
+   *  options are appended by the orchestrator. */
+  buildArgs(input: EncoderInput): string[];
+  /** RFC 6381 CODECS attribute for the master playlist's
+   *  `EXT-X-STREAM-INF` entry. Driven by `target` because `hvc1.*.LXXX`
+   *  encodes the level and the level depends on resolution + fps. */
+  codecString(target: EncoderTarget): string;
+}
+
+/** Selector / lookup over the registered encoders. */
+export interface EncoderRegistry {
+  /** Pick the highest-preference descriptor able to produce `variant`
+   *  on `hwAccel`. Returns `null` when no descriptor matches — caller
+   *  must drop the rung or fall back to a different variant. */
+  resolve(variant: CodecVariant, hwAccel: HwAccelType): EncoderDescriptor | null;
+  /** Every descriptor that can produce `variant`, ordered by preference
+   *  (HW first, CPU fallback last). Used by the runtime fallback path
+   *  when a HW encoder fails at session-spawn time. */
+  candidates(variant: CodecVariant, hwAccel: HwAccelType): EncoderDescriptor[];
+}

--- a/backend/src/modules/streaming/transcoding/codec/types.ts
+++ b/backend/src/modules/streaming/transcoding/codec/types.ts
@@ -89,7 +89,13 @@ export interface EncoderInput {
   filters: {
     cropStr: string;
     cpuCropPrefix: string;
+    /** HW crop bridge for 8-bit pipelines: `hwdownload,format=nv12,
+     *  crop=…,hwupload=derive_device=vaapi,`. */
     hwCropPrefix: string;
+    /** HW crop bridge for 10-bit pipelines (HDR variants): same shape
+     *  as `hwCropPrefix` but with `format=p010le` so precision survives
+     *  the round-trip. Empty when no crop is needed. */
+    hwCropPrefix10: string;
     burnInFilter: string;
     tonemapVaapi: string;
     tonemapOpencl: string;

--- a/backend/src/modules/streaming/transcoding/codec/types.ts
+++ b/backend/src/modules/streaming/transcoding/codec/types.ts
@@ -90,6 +90,15 @@ export interface EncoderInput {
     cropStr: string;
     cpuCropPrefix: string;
     hwCropPrefix: string;
+    /** Bridge filter between the decoder's output surface and the
+     *  encoder's input surface. Either `''` (decoder and encoder share
+     *  the same device → zero-copy) or a short ffmpeg snippet ending
+     *  with a comma — e.g. `'hwdownload,format=nv12,'` (HW→CPU),
+     *  `'format=nv12,hwupload,'` (CPU→HW), `'hwmap=derive_device=qsv,
+     *  format=qsv,'` (VAAPI↔QSV). Encoders splice it at the very start
+     *  of their `-vf` chain so every downstream filter sees the right
+     *  surface. */
+    surfaceBridge: string;
     burnInFilter: string;
     tonemapVaapi: string;
     tonemapOpencl: string;
@@ -101,6 +110,12 @@ export interface EncoderInput {
   tonemap: boolean;
   hasBurnIn: boolean;
   hasCrop: boolean;
+  /** Surface format on the decoder's output side. Encoders use it to
+   *  pick the right scale / crop filter: when a QSV encoder receives
+   *  QSV surfaces from a qsv-native decoder it can use `vpp_qsv` for
+   *  both crop and scale; when it receives VAAPI surfaces (default
+   *  Linux path) it stays on the `scale_vaapi → hwmap=qsv` chain. */
+  inputSurface: import('./decoders/types').SurfaceFormat;
 }
 
 /** A single encoder binding — one ffmpeg encoder × one platform × one

--- a/backend/src/modules/streaming/transcoding/codec/types.ts
+++ b/backend/src/modules/streaming/transcoding/codec/types.ts
@@ -55,14 +55,52 @@ export interface EncoderInput {
   variant: CodecVariant;
   target: EncoderTarget;
   /** Encoder preset hint (`veryfast`, `faster`, `fast`, `medium`, `slow`).
-   *  Each encoder maps it onto its own preset namespace. */
+   *  Each encoder maps it onto its own preset namespace (NVENC `p1..p7`,
+   *  VAAPI ignores presets entirely). The orchestrator passes the
+   *  early-session-adjusted preset already — encoders don't second-guess. */
   preset: string;
-  /** Mid-file resume position (source seconds). Encoders may use it to
-   *  derive `force_key_frames` offsets. 0 = fresh play. */
+  /** NVENC-specific preset (`p1..p7`). Orchestrator pre-resolves it
+   *  separately because libx264 / x265 / qsv / vt all share the named
+   *  preset namespace but NVENC uses numbers. */
+  nvencPreset: string;
+  /** Mid-file resume position (source seconds). 0 = fresh play. */
   seekSeconds: number;
   /** True for the early-warm shadow session (small `-t 4` window, runs
    *  parallel to the main session to serve seg-0 fast). */
   early: boolean;
+  /** `force_key_frames` expression — pre-formatted by the orchestrator
+   *  so every encoder anchors IDRs on the same uniform grid. */
+  forceKeyframesExpr: string;
+  /** QSV-specific rate-control knobs. Other encoders ignore. */
+  qsv: {
+    /** Encoder flags: `-forced_idr 1 -adaptive_i 0 -bf 0 -b_strategy 0`,
+     *  plus `-low_power 1` when enabled in admin settings. */
+    extra: string[];
+    /** `-rc_init_occupancy` in bits. */
+    rcInitOccupancy: number;
+    /** `-bufsize` in bits. */
+    bufsize: number;
+  };
+  /** libx264 `-bufsize` in megabits (formatted string, e.g. `"16M"`). */
+  libx264BufsizeMb: string;
+  /** Filter snippets the encoder may need to splice into its `-vf` chain.
+   *  Each is either empty `""` or starts with `,` to chain after a prior
+   *  filter (e.g. `cpuCropPrefix` is `"crop=W:H:X:Y,"`). */
+  filters: {
+    cropStr: string;
+    cpuCropPrefix: string;
+    hwCropPrefix: string;
+    burnInFilter: string;
+    tonemapVaapi: string;
+    tonemapOpencl: string;
+    tonemapCpu: string;
+  };
+  /** True when the orchestrator is applying an HDR→SDR tonemap pass.
+   *  Encoders use this to force BT.709 color tags on the SPS VUI so the
+   *  bitstream doesn't carry source HDR tags through with SDR pixels. */
+  tonemap: boolean;
+  hasBurnIn: boolean;
+  hasCrop: boolean;
 }
 
 /** A single encoder binding — one ffmpeg encoder × one platform × one

--- a/backend/src/modules/streaming/transcoding/codec/types.ts
+++ b/backend/src/modules/streaming/transcoding/codec/types.ts
@@ -89,13 +89,7 @@ export interface EncoderInput {
   filters: {
     cropStr: string;
     cpuCropPrefix: string;
-    /** HW crop bridge for 8-bit pipelines: `hwdownload,format=nv12,
-     *  crop=…,hwupload=derive_device=vaapi,`. */
     hwCropPrefix: string;
-    /** HW crop bridge for 10-bit pipelines (HDR variants): same shape
-     *  as `hwCropPrefix` but with `format=p010le` so precision survives
-     *  the round-trip. Empty when no crop is needed. */
-    hwCropPrefix10: string;
     burnInFilter: string;
     tonemapVaapi: string;
     tonemapOpencl: string;

--- a/backend/src/modules/streaming/transcoding/codec/vpp-qsv-probe.ts
+++ b/backend/src/modules/streaming/transcoding/codec/vpp-qsv-probe.ts
@@ -1,0 +1,122 @@
+import { Logger } from '@nestjs/common';
+import { execFile } from 'child_process';
+import { unlink } from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+/** Result of the vpp_qsv tonemap capability probe. The fixed-function
+ *  HDR tone-mapping unit only exists on Intel iGPUs/dGPUs from Tiger
+ *  Lake (gen11) onwards — Skylake / Kaby / Coffee / Comet / Ice Lake
+ *  ship VPP but no HDR LUT. We probe it once at boot rather than
+ *  whitelisting CPU generations: a real one-frame run is more reliable
+ *  than parsing /sys/devices output, and it also catches the few
+ *  driver releases where Init succeeds but the encoder later rejects
+ *  the surfaces.
+ *
+ *  The flag is queried by `qsvScaleFilter8bit` (and the HDR encoder
+ *  filter chains) to decide between the upstream `vpp_qsv=tonemap=1`
+ *  single-pass HDR→SDR path and the legacy `hwmap+tonemap_vaapi+hwmap`
+ *  fallback. */
+let probedOnce = false;
+let enabled = false;
+
+export function isVppQsvTonemapEnabled(): boolean {
+  return probedOnce && enabled;
+}
+
+export async function runVppQsvTonemapProbe(log: Logger): Promise<void> {
+  const t0 = Date.now();
+  const hdrSample = path.join(
+    os.tmpdir(),
+    `fliks-vpp-qsv-tonemap-probe-${process.pid}.hevc`,
+  );
+  try {
+    // Synthesise a tiny 8-frame HEVC Main10 HDR bitstream with PQ tags
+    // and a baseline mastering-display SEI — enough metadata for
+    // `vpp_qsv tonemap=1` to engage the HDR path. `nullsrc` produces
+    // black frames, which is what we want (we're testing the filter
+    // graph plumbing, not visual fidelity).
+    await execFileAsync(
+      'ffmpeg',
+      [
+        '-hide_banner',
+        '-loglevel',
+        'error',
+        '-y',
+        '-f',
+        'lavfi',
+        '-i',
+        'nullsrc=size=320x180:rate=30,format=yuv420p10le',
+        '-frames:v',
+        '8',
+        '-c:v',
+        'libx265',
+        '-color_primaries',
+        'bt2020',
+        '-color_trc',
+        'smpte2084',
+        '-colorspace',
+        'bt2020nc',
+        '-x265-params',
+        [
+          'hdr-opt=1',
+          'repeat-headers=1',
+          'colorprim=bt2020',
+          'transfer=smpte2084',
+          'colormatrix=bt2020nc',
+          'master-display=G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(10000000,1)',
+          'max-cll=1000,400',
+        ].join(':'),
+        hdrSample,
+      ],
+      { timeout: 15_000 },
+    );
+
+    // Decode the sample on QSV-native, run vpp_qsv tonemap, encode 1
+    // frame with h264_qsv. Exit 0 = the HW path is real and functional.
+    await execFileAsync(
+      'ffmpeg',
+      [
+        '-hide_banner',
+        '-loglevel',
+        'error',
+        '-init_hw_device',
+        'vaapi=va:/dev/dri/renderD128',
+        '-init_hw_device',
+        'qsv=qs@va',
+        '-filter_hw_device',
+        'qs',
+        '-hwaccel',
+        'qsv',
+        '-hwaccel_output_format',
+        'qsv',
+        '-i',
+        hdrSample,
+        '-vf',
+        'vpp_qsv=tonemap=1:w=320:h=176:format=nv12',
+        '-c:v',
+        'h264_qsv',
+        '-preset',
+        'veryfast',
+        '-frames:v',
+        '1',
+        '-f',
+        'null',
+        '-',
+      ],
+      { timeout: 15_000 },
+    );
+    enabled = true;
+  } catch {
+    enabled = false;
+  } finally {
+    await unlink(hdrSample).catch(() => {});
+    probedOnce = true;
+    log.log(
+      `[vpp-qsv-tonemap-probe] ${enabled ? 'enabled' : 'disabled'} (${Date.now() - t0}ms)`,
+    );
+  }
+}

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -195,13 +195,12 @@ export function buildFfmpegArgs(
 
   // Early sessions live ~1s before Shaka jumps to the main session — visual
   // quality on those warm-up frames is throwaway, so bias every knob towards
-  // ramp-up speed. Per-encoder mapping since 'ultrafast' is libx264-only,
-  // QSV stops at 'veryfast', NVENC uses p1..p7, VAAPI ignores -preset.
-  const earlyPreset = early
-    ? effectiveHwAccel === 'qsv'
-      ? 'veryfast'
-      : 'ultrafast'
-    : encoderPreset;
+  // ramp-up speed. `veryfast` everywhere keeps the H.264 profile consistent
+  // with the steady-state session (`faster` → High); the libx264 `ultrafast`
+  // preset implies `--no-cabac` which downgrades the bitstream to Constrained
+  // Baseline and produces an SPS that doesn't match the High SPS in the
+  // main session's init.mp4 — player concatenates the two and corrupts.
+  const earlyPreset = early ? 'veryfast' : encoderPreset;
   const earlyNvencPreset = early ? 'p1' : 'p4';
   // QSV rate-control: tight VBV (bufsize = bitrate × 1) so the BRC has a
   // short horizon and can't defer big I-frames. Early uses 0.5× / 1× so

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -170,11 +170,12 @@ export function buildFfmpegArgs(
   // - Subtitle burn-in forces CPU for QSV/VAAPI/NVENC (filters need CPU surfaces)
   //   but NOT for VideoToolbox — VT decode already outputs CPU buffers, so
   //   libswscale filters (including subtitle overlay) work in-place.
-  // QSV cropping is handled in-pipeline via hwdownload → CPU crop → hwupload,
-  // so it no longer needs to fall back to VAAPI just to apply a crop filter.
+  // - QSV can't crop (fixed-size pool constraint), fallback to VAAPI encode
   const requestedHwAccel: HwAccelType = burnIn?.filter && hwAccel !== 'videotoolbox'
     ? 'none'
-    : hwAccel;
+    : hwAccel === 'qsv' && crop
+      ? 'vaapi'
+      : hwAccel;
 
   // Resolve the actual encoder before setting up the input pipeline.
   // The registry can downgrade to CPU when a HW encoder failed its
@@ -340,11 +341,6 @@ export function buildFfmpegArgs(
   const hwCropPrefix = cropStr
     ? `hwdownload,format=nv12,${cropStr},hwupload=derive_device=vaapi,`
     : '';
-  // 10-bit variant for HDR pipelines — keeps p010le precision through the
-  // round-trip; nv12 would silently truncate to 8 bits.
-  const hwCropPrefix10 = cropStr
-    ? `hwdownload,format=p010le,${cropStr},hwupload=derive_device=vaapi,`
-    : '';
 
   const variant = variantForResolve;
   const encoder = resolvedEncoder;
@@ -380,7 +376,6 @@ export function buildFfmpegArgs(
       cropStr,
       cpuCropPrefix,
       hwCropPrefix,
-      hwCropPrefix10,
       burnInFilter,
       tonemapVaapi,
       tonemapOpencl,

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -12,7 +12,10 @@ import type {
   TranscodeProfile,
 } from './types';
 import { encoderRegistry } from './codec/encoders';
-import type { CodecVariant, EncoderInput } from './codec/types';
+import type { BitDepth, CodecVariant, EncoderInput, VideoCodec } from './codec/types';
+import { decoderRegistry, findQsvNativeDecoder } from './codec/decoders';
+import { isDecoderEnabled } from './codec/decoder-probe';
+import { surfaceBridge } from './codec/decoders/bridge';
 
 export interface BuildFfmpegArgsOptions {
   inputPath: string;
@@ -30,6 +33,14 @@ export interface BuildFfmpegArgsOptions {
    *  `encoderRegistry`. When omitted (legacy callers), the variant is
    *  inferred from `isHdrProfile(profile.name)` + `hwAccel === 'qsv'`. */
   videoVariant?: CodecVariant;
+  /** Source video codec from ffprobe (`'h264'`, `'hevc'`, `'av1'`, plus
+   *  aliases `'avc1'`, `'hev1'`, `'av01'`). Drives decoder selection
+   *  via `decoderRegistry`. Falls back to CPU decode when omitted or
+   *  unknown. */
+  sourceVideoCodec?: string;
+  /** Source bit depth (8 or 10). 10-bit HDR sources need a decoder
+   *  that can handle p010le surfaces. Defaults to 8 when omitted. */
+  sourceBitDepth?: BitDepth;
   /** Audio output decision — see {@link SessionContext.audioPlan}. When
    *  omitted, ffmpeg-args falls back to AAC stereo at the profile bitrate
    *  (safe default that plays everywhere). */
@@ -79,6 +90,8 @@ export function buildFfmpegArgs(
     early = false,
     useTs = false,
     videoVariant,
+    sourceVideoCodec,
+    sourceBitDepth = 8,
   } = opts;
 
   // Segment container choice. Cast → MPEG-TS (fixes the priming desync
@@ -167,9 +180,24 @@ export function buildFfmpegArgs(
   // would give 200 Mbps for "200k" (it drops the suffix and multiplies as if M).
   const bitrateNum = parseBitrateToBps(profile.videoBitrate);
 
+  // Pre-flight: is the qsv-native crop path actually available for this
+  // source? Drives `qsvCanCrop` below so we don't bounce off QSV onto
+  // VAAPI when we *can* stay on QSV with vpp_qsv.
+  const normalisedSourceCodecPreflight = normaliseSourceCodec(sourceVideoCodec);
+  const qsvNativeAvailable =
+    hwAccel === 'qsv' &&
+    !!crop &&
+    !tonemap &&
+    !burnIn?.filter &&
+    normalisedSourceCodecPreflight != null &&
+    isDecoderEnabled(
+      `${normalisedSourceCodecPreflight}_qsv_native_decode`,
+    );
+
   const requestedHwAccel = requestedHwAccelFor(hwAccel, {
     burnIn: !!burnIn?.filter,
     crop: !!crop,
+    qsvCanCrop: qsvNativeAvailable,
   });
 
   // Resolve the actual encoder before setting up the input pipeline.
@@ -238,63 +266,44 @@ export function buildFfmpegArgs(
     (effectiveHwAccel === 'vaapi' ||
       (early && effectiveHwAccel === 'qsv'));
 
-  // Hardware acceleration input decoding
-  if (effectiveHwAccel === 'qsv') {
-    // Linux approach: decode with VAAPI (native), scale with VAAPI,
-    // then map to QSV surfaces for encoding. More compatible than pure QSV pipeline.
-    args.push(
-      '-init_hw_device', 'vaapi=va:/dev/dri/renderD128',
-      '-init_hw_device', 'qsv=qs@va',
-    );
-    if (tonemap && !useVaapiTonemap) {
-      args.push('-init_hw_device', 'opencl=ocl:0.0', '-filter_hw_device', 'ocl');
-    }
-    args.push(
-      '-hwaccel', 'vaapi',
-      '-hwaccel_output_format', 'vaapi',
-      '-hwaccel_device', 'va',
-      '-extra_hw_frames', '32',
-      '-noautorotate',
-    );
-  } else if (effectiveHwAccel === 'vaapi') {
-    args.push('-init_hw_device', 'vaapi=va:/dev/dri/renderD128');
-    if (tonemap && !useVaapiTonemap) {
-      args.push('-init_hw_device', 'opencl=ocl:0.0', '-filter_hw_device', 'ocl');
-    }
-    args.push(
-      '-hwaccel', 'vaapi',
-      '-hwaccel_output_format', 'vaapi',
-      '-hwaccel_device', 'va',
-      '-extra_hw_frames', '32',
-      '-noautorotate',
-    );
-  } else if (effectiveHwAccel === 'nvenc') {
-    if (tonemap) {
-      // For tone mapping, don't force cuda output format — allows hwdownload to CPU
-      args.push('-hwaccel', 'cuda', '-noautorotate');
-    } else {
-      args.push(
-        '-hwaccel', 'cuda',
-        '-hwaccel_output_format', 'cuda',
-        '-noautorotate',
-      );
-    }
-  } else if (effectiveHwAccel === 'videotoolbox') {
-    // VideoToolbox = Apple Media Engine (h264/hevc encode+decode ASIC).
-    // Two modes:
-    //   1. Tonemap (no burn-in/crop): keep VT surfaces, use scale_vt for
-    //      hardware HDR→SDR tonemap via Metal — full GPU pipeline.
-    //   2. Everything else: download to CPU buffers for software filters
-    //      (crop, burn-in, scale), then re-upload via the encoder.
-    if (tonemap && !burnIn?.filter && !crop) {
-      args.push(
-        '-hwaccel', 'videotoolbox',
-        '-hwaccel_output_format', 'videotoolbox_vld',
-        '-noautorotate',
-      );
-    } else {
-      args.push('-hwaccel', 'videotoolbox', '-noautorotate');
-    }
+  // Resolve the decoder via the same registry pattern as the encoder.
+  // The decoder picks how the source is brought into memory (HW device
+  // init + `-hwaccel`); the encoder's hwAccel decides where the frame
+  // needs to land for encode. `surfaceBridge` computes the filter
+  // snippet that reshapes the decoder's output surface into the
+  // encoder's expected one — empty when both stay on the same device.
+  const normalisedSourceCodec = normalisedSourceCodecPreflight;
+  // Opt into the qsv-native decoder when the qsv crop path is in use
+  // (pre-flighted above so requestedHwAccelFor could keep us on QSV).
+  // The default qsv decoder emits VAAPI surfaces — kept as the safe
+  // baseline for every other QSV path.
+  const decoder: ReturnType<typeof decoderRegistry.resolve> =
+    qsvNativeAvailable &&
+    effectiveHwAccel === 'qsv' &&
+    normalisedSourceCodec
+      ? (findQsvNativeDecoder(normalisedSourceCodec) ??
+        decoderRegistry.resolve(
+          {
+            codec: normalisedSourceCodec,
+            bitDepth: sourceBitDepth,
+          },
+          effectiveHwAccel,
+        ))
+      : decoderRegistry.resolve(
+          {
+            codec: normalisedSourceCodec ?? 'h264',
+            bitDepth: sourceBitDepth,
+          },
+          effectiveHwAccel,
+        );
+  args.push(...decoder.buildInputArgs());
+
+  // OpenCL device init for the tonemap_opencl filter chain. Only needed
+  // when (a) we're tonemapping HDR→SDR AND (b) the VAAPI in-place
+  // tonemap fallback isn't active AND (c) the decoder's output sits on
+  // VAAPI surfaces — the only path that uses the opencl bridge today.
+  if (tonemap && !useVaapiTonemap && decoder.outputSurface === 'vaapi') {
+    args.push('-init_hw_device', 'opencl=ocl:0.0', '-filter_hw_device', 'ocl');
   }
 
   args.push('-i', inputPath);
@@ -348,6 +357,16 @@ export function buildFfmpegArgs(
     ? `hwdownload,format=nv12,${cropStr},hwupload=derive_device=vaapi,`
     : '';
 
+  // Decoder→encoder surface bridge. Empty when both stay on the same
+  // device (qsv→qsv, vaapi→vaapi, cuda→cuda). Otherwise emits the
+  // hwdownload / hwupload / hwmap snippet the encoder splices in front
+  // of its `-vf` chain.
+  const surfaceBridgeFilter = surfaceBridge(
+    decoder.outputSurface,
+    encoder.hwAccel,
+    variant.bitDepth,
+  );
+
   const encoderInput: EncoderInput = {
     source: {
       width: 0,
@@ -379,6 +398,7 @@ export function buildFfmpegArgs(
       cropStr,
       cpuCropPrefix,
       hwCropPrefix,
+      surfaceBridge: surfaceBridgeFilter,
       burnInFilter,
       tonemapVaapi,
       tonemapOpencl,
@@ -387,6 +407,7 @@ export function buildFfmpegArgs(
     tonemap,
     hasBurnIn: !!burnIn?.filter,
     hasCrop: !!crop,
+    inputSurface: decoder.outputSurface,
   };
   args.push(...encoder.buildArgs(encoderInput));
 
@@ -651,4 +672,28 @@ export function buildRemuxArgs(
   );
 
   return args;
+}
+
+/** ffprobe codec name → `VideoCodec` union. Aliases (`hvc1`/`hev1` for
+ *  HEVC, `avc1` for H.264, `av01` for AV1) collapse to the canonical
+ *  form. Returns null on unknown codecs so the decoder registry can
+ *  fall back to CPU decode. */
+function normaliseSourceCodec(name: string | undefined): VideoCodec | null {
+  if (!name) return null;
+  switch (name.toLowerCase()) {
+    case 'h264':
+    case 'avc':
+    case 'avc1':
+      return 'h264';
+    case 'hevc':
+    case 'h265':
+    case 'hvc1':
+    case 'hev1':
+      return 'hevc';
+    case 'av1':
+    case 'av01':
+      return 'av1';
+    default:
+      return null;
+  }
 }

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -16,6 +16,7 @@ import type { BitDepth, CodecVariant, EncoderInput, VideoCodec } from './codec/t
 import { decoderRegistry, findQsvNativeDecoder } from './codec/decoders';
 import { isDecoderEnabled } from './codec/decoder-probe';
 import { surfaceBridge } from './codec/decoders/bridge';
+import { isVppQsvTonemapEnabled } from './codec/vpp-qsv-probe';
 
 export interface BuildFfmpegArgsOptions {
   inputPath: string;
@@ -180,27 +181,32 @@ export function buildFfmpegArgs(
   // would give 200 Mbps for "200k" (it drops the suffix and multiplies as if M).
   const bitrateNum = parseBitrateToBps(profile.videoBitrate);
 
-  // Pre-flight: is the qsv-native crop path actually available for this
-  // source? Drives `qsvCanCrop` below so we don't bounce off QSV onto
-  // VAAPI when we *can* stay on QSV with vpp_qsv.
+  // Pre-flight: can we keep the whole pipeline on QSV (decode + filter
+  // + encode without bouncing through VAAPI)?
+  //
+  // Three sub-cases, all gated on `hwAccel === 'qsv'`, no burn-in
+  // (libass needs CPU buffers) and a known source codec:
+  //
+  //   a. crop + !tonemap → qsv-native decoder + vpp_qsv crop/scale.
+  //   b. tonemap + vpp_qsv tonemap probed enabled → qsv-native decoder
+  //      + vpp_qsv with `tonemap=1` (single-pass HDR→SDR on the iGPU
+  //      VPP, no hwmap, no opencl bridge). Available on Tiger Lake and
+  //      later; the boot probe in `vpp-qsv-probe.ts` is the gate.
+  //   c. crop + tonemap on older gens → still goes through the legacy
+  //      vaapi-decode chain (scale_vaapi+tonemap_vaapi+hwmap=qsv), so
+  //      we can stay on the QSV encoder via the hwCropPrefix splice.
   const normalisedSourceCodecPreflight = normaliseSourceCodec(sourceVideoCodec);
-  const qsvNativeAvailable =
+  const hasUsableQsvNativeDecoder =
     hwAccel === 'qsv' &&
-    !!crop &&
-    !tonemap &&
     !burnIn?.filter &&
     normalisedSourceCodecPreflight != null &&
     isDecoderEnabled(
       `${normalisedSourceCodecPreflight}_qsv_native_decode`,
     );
-
-  // QSV can also handle crop + tonemap via the legacy vaapi-decode
-  // path: hwCropPrefix downloads to CPU, hwupload back to vaapi, then
-  // scale_vaapi+tonemap_vaapi+hwmap to qsv produces a fixed-size pool
-  // that the qsv encoder accepts. The qsv encoder filter chain
-  // prepends hwCropPrefix when it's present, so we only need to keep
-  // the orchestrator on QSV (don't bounce to VAAPI). Burn-in still
-  // forces CPU because libass subtitles need software surfaces.
+  const qsvNativeAvailable =
+    hasUsableQsvNativeDecoder &&
+    !!crop &&
+    (!tonemap || isVppQsvTonemapEnabled());
   const qsvCanCrop =
     qsvNativeAvailable ||
     (hwAccel === 'qsv' && !!crop && !!tonemap && !burnIn?.filter);

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -265,17 +265,15 @@ export function buildFfmpegArgs(
   // slightly worse than tonemap_opencl/reinhard but the difference is
   // invisible at streaming bitrates.
   //
-  // We force it for any vaapi-encode path (not just early) because the
-  // OpenCL tonemap chain — `hwmap=derive_device=opencl,tonemap_opencl,
-  // hwmap=derive_device=vaapi:reverse=1` — depends on a working
-  // QSV↔OpenCL↔VAAPI bridge that several Intel hosts can't service
-  // (driver returns 'QSV to OpenCL mapping not usable' and the encoder
-  // crashes). QSV-encode keeps the opencl path on steady-state because
-  // it doesn't need the reverse-hwmap that tripped vaapi.
+  // Force it on every QSV/VAAPI tonemap path. The OpenCL chain
+  // (`hwmap=derive_device=opencl,tonemap_opencl,hwmap=...,format=qsv`)
+  // depends on a working QSV↔OpenCL bridge that several Intel hosts
+  // can't service — the driver returns 'QSV to OpenCL mapping not
+  // usable' and the encoder crashes with exit=218. tonemap_vaapi has
+  // no such dependency and runs end-to-end inside VAAPI / QSV.
   const useVaapiTonemap =
     tonemap &&
-    (effectiveHwAccel === 'vaapi' ||
-      (early && effectiveHwAccel === 'qsv'));
+    (effectiveHwAccel === 'vaapi' || effectiveHwAccel === 'qsv');
 
   // Resolve the decoder via the same registry pattern as the encoder.
   // The decoder picks how the source is brought into memory (HW device

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -170,12 +170,11 @@ export function buildFfmpegArgs(
   // - Subtitle burn-in forces CPU for QSV/VAAPI/NVENC (filters need CPU surfaces)
   //   but NOT for VideoToolbox — VT decode already outputs CPU buffers, so
   //   libswscale filters (including subtitle overlay) work in-place.
-  // - QSV can't crop (fixed-size pool constraint), fallback to VAAPI encode
+  // QSV cropping is handled in-pipeline via hwdownload → CPU crop → hwupload,
+  // so it no longer needs to fall back to VAAPI just to apply a crop filter.
   const requestedHwAccel: HwAccelType = burnIn?.filter && hwAccel !== 'videotoolbox'
     ? 'none'
-    : hwAccel === 'qsv' && crop
-      ? 'vaapi'
-      : hwAccel;
+    : hwAccel;
 
   // Resolve the actual encoder before setting up the input pipeline.
   // The registry can downgrade to CPU when a HW encoder failed its
@@ -341,6 +340,11 @@ export function buildFfmpegArgs(
   const hwCropPrefix = cropStr
     ? `hwdownload,format=nv12,${cropStr},hwupload=derive_device=vaapi,`
     : '';
+  // 10-bit variant for HDR pipelines — keeps p010le precision through the
+  // round-trip; nv12 would silently truncate to 8 bits.
+  const hwCropPrefix10 = cropStr
+    ? `hwdownload,format=p010le,${cropStr},hwupload=derive_device=vaapi,`
+    : '';
 
   const variant = variantForResolve;
   const encoder = resolvedEncoder;
@@ -376,6 +380,7 @@ export function buildFfmpegArgs(
       cropStr,
       cpuCropPrefix,
       hwCropPrefix,
+      hwCropPrefix10,
       burnInFilter,
       tonemapVaapi,
       tonemapOpencl,

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -185,21 +185,18 @@ export function buildFfmpegArgs(
   // with `Function not implemented` / `Impossible to convert between
   // the formats supported by the filter`.
   const isHdrOutput = isHdrProfile(profile.name);
-  const variantForResolve: CodecVariant =
+  const variant: CodecVariant =
     videoVariant ??
     (isHdrOutput && requestedHwAccel === 'qsv'
       ? { codec: 'hevc', bitDepth: 10, hdr: 'HDR10' }
       : { codec: 'h264', bitDepth: 8, hdr: null });
-  const resolvedEncoder = encoderRegistry.resolve(
-    variantForResolve,
-    requestedHwAccel,
-  );
-  if (!resolvedEncoder) {
+  const encoder = encoderRegistry.resolve(variant, requestedHwAccel);
+  if (!encoder) {
     throw new Error(
-      `No encoder for variant ${JSON.stringify(variantForResolve)} on ${requestedHwAccel}`,
+      `No encoder for variant ${JSON.stringify(variant)} on ${requestedHwAccel}`,
     );
   }
-  const effectiveHwAccel: HwAccelType = resolvedEncoder.hwAccel;
+  const effectiveHwAccel: HwAccelType = encoder.hwAccel;
 
   // Early sessions live ~1s before Shaka jumps to the main session — visual
   // quality on those warm-up frames is throwaway, so bias every knob towards
@@ -341,9 +338,6 @@ export function buildFfmpegArgs(
   const hwCropPrefix = cropStr
     ? `hwdownload,format=nv12,${cropStr},hwupload=derive_device=vaapi,`
     : '';
-
-  const variant = variantForResolve;
-  const encoder = resolvedEncoder;
 
   const encoderInput: EncoderInput = {
     source: {

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -143,9 +143,11 @@ export function buildFfmpegArgs(
   // headers and stops. Otherwise fall back to a balanced 1s/1MB budget.
   // Default FFmpeg is 5s/5MB which burns 3-5s on cold start of large 4K MKVs.
   if (trustedStreamInfo) {
-    log.log('Probe: using cached streamInfo (0s / 200KB scan)');
+    log.debug?.('Probe: using cached streamInfo (0s / 200KB scan)');
     args.push('-analyzeduration', '0', '-probesize', '200000');
   } else {
+    // Keep the no-cache fallback at LOG — cold-start scans are expected
+    // only on rescan / import races, so each one is worth surfacing.
     log.log('Probe: no cached streamInfo — running full FFmpeg scan (1s / 1MB)');
     args.push('-analyzeduration', '1000000', '-probesize', '1000000');
   }
@@ -484,7 +486,7 @@ export function buildAudioOnlyFfmpegArgs(
 
   const args = ['-hide_banner', '-loglevel', 'warning'];
   if (trustedStreamInfo) {
-    log.log('Probe [audio-only]: using cached streamInfo (0s / 200KB scan)');
+    log.debug?.('Probe [audio-only]: using cached streamInfo (0s / 200KB scan)');
     args.push('-analyzeduration', '0', '-probesize', '200000');
   } else {
     log.log(

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -213,7 +213,14 @@ export function buildFfmpegArgs(
   );
   const qsvBufsize = bitrateNum;
   // libx264 -bufsize is expressed in Mbits. Stock = 2x bitrate, early = 1x.
-  const libx264BufsizeMb = `${Math.max(1, parseInt(profile.videoBitrate) * (early ? 1 : 2))}M`;
+  // parseInt() drops ffmpeg's 'k'/'M' suffix silently — `parseInt('1500k')`
+  // gives 1500, then ×2 + 'M' yields "3000M" = 3 Gbits and ffmpeg rejects
+  // it as out-of-range. Derive Mbits from bitrateNum (already parsed via
+  // parseBitrateToBps) so the multiplier sees real units.
+  const libx264BufsizeMb = `${Math.max(
+    1,
+    Math.ceil((bitrateNum * (early ? 1 : 2)) / 1_000_000),
+  )}M`;
 
   // tonemap_vaapi keeps the pipeline inside VAAPI (1 device transition, no
   // OpenCL kernel compile) — saves ~300-500ms cold-start on HDR. Quality is

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -171,11 +171,35 @@ export function buildFfmpegArgs(
   //   but NOT for VideoToolbox — VT decode already outputs CPU buffers, so
   //   libswscale filters (including subtitle overlay) work in-place.
   // - QSV can't crop (fixed-size pool constraint), fallback to VAAPI encode
-  const effectiveHwAccel: HwAccelType = burnIn?.filter && hwAccel !== 'videotoolbox'
+  const requestedHwAccel: HwAccelType = burnIn?.filter && hwAccel !== 'videotoolbox'
     ? 'none'
     : hwAccel === 'qsv' && crop
       ? 'vaapi'
       : hwAccel;
+
+  // Resolve the actual encoder before setting up the input pipeline.
+  // The registry can downgrade to CPU when a HW encoder failed its
+  // boot-time probe (e.g. h264_vaapi on a renderD node that exposes
+  // only video-proc entrypoints). If we keep the HW input setup the
+  // CPU encoder receives HW surfaces and the filter chain blows up
+  // with `Function not implemented` / `Impossible to convert between
+  // the formats supported by the filter`.
+  const isHdrOutput = isHdrProfile(profile.name);
+  const variantForResolve: CodecVariant =
+    videoVariant ??
+    (isHdrOutput && requestedHwAccel === 'qsv'
+      ? { codec: 'hevc', bitDepth: 10, hdr: 'HDR10' }
+      : { codec: 'h264', bitDepth: 8, hdr: null });
+  const resolvedEncoder = encoderRegistry.resolve(
+    variantForResolve,
+    requestedHwAccel,
+  );
+  if (!resolvedEncoder) {
+    throw new Error(
+      `No encoder for variant ${JSON.stringify(variantForResolve)} on ${requestedHwAccel}`,
+    );
+  }
+  const effectiveHwAccel: HwAccelType = resolvedEncoder.hwAccel;
 
   // Early sessions live ~1s before Shaka jumps to the main session — visual
   // quality on those warm-up frames is throwaway, so bias every knob towards
@@ -318,23 +342,8 @@ export function buildFfmpegArgs(
     ? `hwdownload,format=nv12,${cropStr},hwupload=derive_device=vaapi,`
     : '';
 
-  const isHdrOutput = isHdrProfile(profile.name);
-
-  // Variant resolution. Callers that have already chosen via the codec
-  // selector pass it explicitly; legacy callers fall back to the
-  // pre-refactor inference (HEVC HDR10 only on QSV, H.264 SDR elsewhere).
-  const variant: CodecVariant =
-    videoVariant ??
-    (isHdrOutput && effectiveHwAccel === 'qsv'
-      ? { codec: 'hevc', bitDepth: 10, hdr: 'HDR10' }
-      : { codec: 'h264', bitDepth: 8, hdr: null });
-
-  const encoder = encoderRegistry.resolve(variant, effectiveHwAccel);
-  if (!encoder) {
-    throw new Error(
-      `No encoder for variant ${JSON.stringify(variant)} on ${effectiveHwAccel}`,
-    );
-  }
+  const variant = variantForResolve;
+  const encoder = resolvedEncoder;
 
   const encoderInput: EncoderInput = {
     source: {

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -194,10 +194,21 @@ export function buildFfmpegArgs(
       `${normalisedSourceCodecPreflight}_qsv_native_decode`,
     );
 
+  // QSV can also handle crop + tonemap via the legacy vaapi-decode
+  // path: hwCropPrefix downloads to CPU, hwupload back to vaapi, then
+  // scale_vaapi+tonemap_vaapi+hwmap to qsv produces a fixed-size pool
+  // that the qsv encoder accepts. The qsv encoder filter chain
+  // prepends hwCropPrefix when it's present, so we only need to keep
+  // the orchestrator on QSV (don't bounce to VAAPI). Burn-in still
+  // forces CPU because libass subtitles need software surfaces.
+  const qsvCanCrop =
+    qsvNativeAvailable ||
+    (hwAccel === 'qsv' && !!crop && !!tonemap && !burnIn?.filter);
+
   const requestedHwAccel = requestedHwAccelFor(hwAccel, {
     burnIn: !!burnIn?.filter,
     crop: !!crop,
-    qsvCanCrop: qsvNativeAvailable,
+    qsvCanCrop,
   });
 
   // Resolve the actual encoder before setting up the input pipeline.

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -5,6 +5,7 @@ import {
   segmentIndexToSeconds,
 } from './constants';
 import { isHdrProfile, parseBitrateToBps } from './profiles';
+import { requestedHwAccelFor } from './hw-detect';
 import type {
   BurnInSubtitle,
   HwAccelType,
@@ -166,16 +167,10 @@ export function buildFfmpegArgs(
   // would give 200 Mbps for "200k" (it drops the suffix and multiplies as if M).
   const bitrateNum = parseBitrateToBps(profile.videoBitrate);
 
-  // Force pipeline adjustments when HW accel can't handle required filters:
-  // - Subtitle burn-in forces CPU for QSV/VAAPI/NVENC (filters need CPU surfaces)
-  //   but NOT for VideoToolbox — VT decode already outputs CPU buffers, so
-  //   libswscale filters (including subtitle overlay) work in-place.
-  // - QSV can't crop (fixed-size pool constraint), fallback to VAAPI encode
-  const requestedHwAccel: HwAccelType = burnIn?.filter && hwAccel !== 'videotoolbox'
-    ? 'none'
-    : hwAccel === 'qsv' && crop
-      ? 'vaapi'
-      : hwAccel;
+  const requestedHwAccel = requestedHwAccelFor(hwAccel, {
+    burnIn: !!burnIn?.filter,
+    crop: !!crop,
+  });
 
   // Resolve the actual encoder before setting up the input pipeline.
   // The registry can downgrade to CPU when a HW encoder failed its

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -10,6 +10,8 @@ import type {
   HwAccelType,
   TranscodeProfile,
 } from './types';
+import { encoderRegistry } from './codec/encoders';
+import type { CodecVariant, EncoderInput } from './codec/types';
 
 export interface BuildFfmpegArgsOptions {
   inputPath: string;
@@ -311,212 +313,62 @@ export function buildFfmpegArgs(
 
   const isHdrOutput = isHdrProfile(profile.name);
 
-  switch (effectiveHwAccel) {
-    case 'qsv':
-      // Note: QSV + crop is forced to CPU via effectiveHwAccel (fixed-size pool constraint)
-      if (isHdrOutput) {
-        // HEVC HDR pass-through transcode: VAAPI decode → VAAPI scale
-        // keeping p010le (10-bit, HDR pixels preserved) → hwmap qsv →
-        // hevc_qsv Main10 encode. Color signaling propagates from the
-        // input AVFrame metadata; `-color_*` flags are belt-and-suspenders
-        // so encoders that ignore the AVFrame still emit a correct SPS
-        // VUI. Output is tagged `hvc1` later in the HLS muxer args.
-        args.push(
-          '-c:v', 'hevc_qsv',
-          '-profile:v', 'main10',
-          '-preset', earlyPreset,
-          ...qsvExtra,
-          '-mbbrc', '1',
-          '-b:v', String(bitrateNum),
-          '-maxrate', String(bitrateNum + 1),
-          '-rc_init_occupancy', String(qsvRcInitOccupancy),
-          '-bufsize', String(qsvBufsize),
-          '-vf',
-          `scale_vaapi=w=${w}:h=-16:format=p010le:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
-          '-g', String(gopSize),
-          '-keyint_min', String(gopSize),
-          '-force_key_frames', forceKeyframesExpr,
-          '-color_primaries', 'bt2020',
-          '-color_trc', 'smpte2084',
-          '-colorspace', 'bt2020nc',
-          '-tag:v', 'hvc1',
-        );
-      } else if (tonemapVaapi) {
-        // VAAPI decode → VAAPI scale → VAAPI tonemap → QSV encode (no OpenCL hop)
-        args.push(
-          '-c:v', 'h264_qsv',
-          '-preset', earlyPreset,
-          ...qsvExtra,
-          '-mbbrc', '1',
-          '-b:v', String(bitrateNum),
-          '-maxrate', String(bitrateNum + 1),
-          '-rc_init_occupancy', String(qsvRcInitOccupancy),
-          '-bufsize', String(qsvBufsize),
-          '-vf',
-          `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${tonemapVaapi},hwmap=derive_device=qsv,format=qsv`,
-          '-g', String(gopSize),
-          '-keyint_min', String(gopSize),
-          '-force_key_frames', forceKeyframesExpr,
-        );
-      } else if (tonemapOpencl) {
-        // VAAPI decode → VAAPI scale → OpenCL tonemap → map to QSV → QSV encode
-        args.push(
-          '-c:v', 'h264_qsv',
-          '-preset', earlyPreset,
-          ...qsvExtra,
-          '-mbbrc', '1',
-          '-b:v', String(bitrateNum),
-          '-maxrate', String(bitrateNum + 1),
-          '-rc_init_occupancy', String(qsvRcInitOccupancy),
-          '-bufsize', String(qsvBufsize),
-          '-vf',
-          `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`,
-          '-g', String(gopSize),
-          '-keyint_min', String(gopSize),
-          '-force_key_frames', forceKeyframesExpr,
-        );
-      } else {
-        args.push(
-          '-c:v', 'h264_qsv',
-          '-preset', earlyPreset,
-          ...qsvExtra,
-          '-mbbrc', '1',
-          '-b:v', String(bitrateNum),
-          '-maxrate', String(bitrateNum + 1),
-          '-rc_init_occupancy', String(qsvRcInitOccupancy),
-          '-bufsize', String(qsvBufsize),
-          '-vf',
-          `scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
-          '-g', String(gopSize),
-          '-keyint_min', String(gopSize),
-          '-force_key_frames', forceKeyframesExpr,
-        );
-      }
-      break;
-    case 'vaapi':
-      if (tonemapVaapi) {
-        // VAAPI decode → VAAPI scale → VAAPI tonemap → VAAPI encode (single device)
-        args.push(
-          '-c:v', 'h264_vaapi',
-          '-b:v', profile.videoBitrate,
-          '-maxrate', profile.videoBitrate,
-          '-vf',
-          `${hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${tonemapVaapi}`,
-          '-g', String(gopSize),
-          '-keyint_min', String(gopSize),
-          '-force_key_frames', forceKeyframesExpr,
-        );
-      } else if (tonemapOpencl) {
-        args.push(
-          '-c:v', 'h264_vaapi',
-          '-b:v', profile.videoBitrate,
-          '-maxrate', profile.videoBitrate,
-          '-vf',
-          `${hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${tonemapOpencl},hwmap=derive_device=vaapi:mode=write:reverse=1,format=vaapi`,
-          '-g', String(gopSize),
-          '-keyint_min', String(gopSize),
-          '-force_key_frames', forceKeyframesExpr,
-        );
-      } else {
-        args.push(
-          '-c:v', 'h264_vaapi',
-          '-b:v', profile.videoBitrate,
-          '-maxrate', profile.videoBitrate,
-          '-vf',
-          `${hwCropPrefix}scale_vaapi=w=${w}:h=-16:format=nv12`,
-          '-g', String(gopSize),
-          '-keyint_min', String(gopSize),
-          '-force_key_frames', forceKeyframesExpr,
-        );
-      }
-      break;
-    case 'nvenc':
-      if (tonemap) {
-        // No native GPU tone mapping — download from GPU, tonemap on CPU, encode with NVENC
-        args.push(
-          '-c:v', 'h264_nvenc',
-          '-preset', earlyNvencPreset,
-          '-b:v', profile.videoBitrate,
-          '-maxrate', profile.videoBitrate,
-          '-vf',
-          `hwdownload,format=p010le,${cpuCropPrefix}${tonemapCpu}scale=${w}:-2`,
-          '-g', String(gopSize),
-          '-keyint_min', String(gopSize),
-          '-force_key_frames', forceKeyframesExpr,
-        );
-      } else {
-        const nvCropFilter = cropStr
-          ? `hwdownload,format=nv12,${cropStr},hwupload_cuda,`
-          : '';
-        args.push(
-          '-c:v', 'h264_nvenc',
-          '-preset', earlyNvencPreset,
-          '-b:v', profile.videoBitrate,
-          '-maxrate', profile.videoBitrate,
-          '-vf',
-          `${nvCropFilter}scale_cuda=w=${w}:h=-2:format=nv12`,
-          '-g', String(gopSize),
-          '-keyint_min', String(gopSize),
-          '-force_key_frames', forceKeyframesExpr,
-        );
-      }
-      break;
-    case 'videotoolbox':
-      // h264_videotoolbox driven by Apple's Media Engine — H.264 High
-      // profile L4.0 on Apple Silicon transcodes 4K @ 60 fps comfortably.
-      // No `-preset` knob (VT doesn't expose presets); `-realtime 1`
-      // tells the encoder to favour latency over efficiency on early
-      // ramp-up frames.
-      if (tonemap && !burnIn?.filter && !crop) {
-        // Full GPU pipeline: VT decode → scale_vt (Metal tonemap + resize)
-        // → VT encode. HDR→SDR via color_transfer/primaries/matrix=bt709.
-        // No CPU round-trip — everything stays on Metal/IOSurface.
-        args.push(
-          '-c:v', 'h264_videotoolbox',
-          '-profile:v', 'high',
-          ...(early ? ['-realtime', '1'] : []),
-          '-b:v', profile.videoBitrate,
-          '-maxrate', profile.videoBitrate,
-          '-vf',
-          `scale_vt=w=${w}:h=-2:color_matrix=bt709:color_primaries=bt709:color_transfer=bt709`,
-          '-g', String(gopSize),
-          '-keyint_min', String(gopSize),
-          '-force_key_frames', forceKeyframesExpr,
-        );
-      } else {
-        // CPU path: VT decode → CPU buffers → software filters (crop,
-        // burn-in, scale) → VT encode (re-uploads internally).
-        args.push(
-          '-c:v', 'h264_videotoolbox',
-          '-profile:v', 'high',
-          ...(early ? ['-realtime', '1'] : []),
-          '-b:v', profile.videoBitrate,
-          '-maxrate', profile.videoBitrate,
-          '-vf',
-          `${cpuCropPrefix}scale=${w}:-2:flags=lanczos,format=yuv420p${burnInFilter}`,
-          '-g', String(gopSize),
-          '-keyint_min', String(gopSize),
-          '-force_key_frames', forceKeyframesExpr,
-        );
-      }
-      break;
-    default:
-      args.push(
-        '-c:v', 'libx264',
-        // Cap frame-threading so segment 0 emits before a long (threads-1)-frame prebuffer.
-        '-threads:v', '4',
-        '-preset', earlyPreset,
-        ...(early ? ['-tune', 'zerolatency'] : []),
-        '-b:v', profile.videoBitrate,
-        '-maxrate', profile.videoBitrate,
-        '-bufsize', libx264BufsizeMb,
-        '-vf',
-        `${cpuCropPrefix}${tonemapCpu}scale=${w}:-2:flags=lanczos,format=yuv420p${burnInFilter}`,
-        '-force_key_frames', forceKeyframesExpr,
-        '-sc_threshold:v:0', '0',
-      );
-      break;
+  // Pick the codec variant we're producing on this rung. Today only two
+  // variants are wired: HEVC Main10 HDR10 (for `-hdr` profiles on QSV)
+  // and H.264 8-bit SDR everywhere else. Phases 2+ extend this with
+  // HEVC SDR cross-platform and AV1.
+  const variant: CodecVariant = isHdrOutput && effectiveHwAccel === 'qsv'
+    ? { codec: 'hevc', bitDepth: 10, hdr: 'HDR10' }
+    : { codec: 'h264', bitDepth: 8, hdr: null };
+
+  const encoder = encoderRegistry.resolve(variant, effectiveHwAccel);
+  if (!encoder) {
+    throw new Error(
+      `No encoder for variant ${JSON.stringify(variant)} on ${effectiveHwAccel}`,
+    );
   }
+
+  const encoderInput: EncoderInput = {
+    source: {
+      width: 0,
+      height: 0,
+      hdr: null,
+      bitDepth: 8,
+      codecName: '',
+    },
+    variant,
+    target: {
+      width: w,
+      height: profile.maxHeight,
+      videoBitrateBps: bitrateNum,
+      gopSize,
+      frameRate: fps,
+    },
+    preset: earlyPreset,
+    nvencPreset: earlyNvencPreset,
+    seekSeconds,
+    early,
+    forceKeyframesExpr,
+    qsv: {
+      extra: qsvExtra,
+      rcInitOccupancy: qsvRcInitOccupancy,
+      bufsize: qsvBufsize,
+    },
+    libx264BufsizeMb,
+    filters: {
+      cropStr,
+      cpuCropPrefix,
+      hwCropPrefix,
+      burnInFilter,
+      tonemapVaapi,
+      tonemapOpencl,
+      tonemapCpu,
+    },
+    tonemap,
+    hasBurnIn: !!burnIn?.filter,
+    hasCrop: !!crop,
+  };
+  args.push(...encoder.buildArgs(encoderInput));
 
   // When tone-mapping HDR → SDR on the H.264 path, force the SPS VUI to
   // BT.709 limited range. The pixel data is genuinely SDR after the

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -25,6 +25,10 @@ export interface BuildFfmpegArgsOptions {
   crop?: { width: number; height: number; x: number; y: number };
   videoOnly?: boolean;
   audioStreams?: { language?: string; title?: string }[];
+  /** Output codec variant. When set, drives the encoder lookup via
+   *  `encoderRegistry`. When omitted (legacy callers), the variant is
+   *  inferred from `isHdrProfile(profile.name)` + `hwAccel === 'qsv'`. */
+  videoVariant?: CodecVariant;
   /** Audio output decision — see {@link SessionContext.audioPlan}. When
    *  omitted, ffmpeg-args falls back to AAC stereo at the profile bitrate
    *  (safe default that plays everywhere). */
@@ -73,6 +77,7 @@ export function buildFfmpegArgs(
     trustedStreamInfo = false,
     early = false,
     useTs = false,
+    videoVariant,
   } = opts;
 
   // Segment container choice. Cast → MPEG-TS (fixes the priming desync
@@ -313,13 +318,14 @@ export function buildFfmpegArgs(
 
   const isHdrOutput = isHdrProfile(profile.name);
 
-  // Pick the codec variant we're producing on this rung. Today only two
-  // variants are wired: HEVC Main10 HDR10 (for `-hdr` profiles on QSV)
-  // and H.264 8-bit SDR everywhere else. Phases 2+ extend this with
-  // HEVC SDR cross-platform and AV1.
-  const variant: CodecVariant = isHdrOutput && effectiveHwAccel === 'qsv'
-    ? { codec: 'hevc', bitDepth: 10, hdr: 'HDR10' }
-    : { codec: 'h264', bitDepth: 8, hdr: null };
+  // Variant resolution. Callers that have already chosen via the codec
+  // selector pass it explicitly; legacy callers fall back to the
+  // pre-refactor inference (HEVC HDR10 only on QSV, H.264 SDR elsewhere).
+  const variant: CodecVariant =
+    videoVariant ??
+    (isHdrOutput && effectiveHwAccel === 'qsv'
+      ? { codec: 'hevc', bitDepth: 10, hdr: 'HDR10' }
+      : { codec: 'h264', bitDepth: 8, hdr: null });
 
   const encoder = encoderRegistry.resolve(variant, effectiveHwAccel);
   if (!encoder) {

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -223,12 +223,20 @@ export function buildFfmpegArgs(
 
   // tonemap_vaapi keeps the pipeline inside VAAPI (1 device transition, no
   // OpenCL kernel compile) — saves ~300-500ms cold-start on HDR. Quality is
-  // slightly worse than tonemap_opencl/reinhard, but the early session's
-  // output is jumped past by Shaka after ~1s, so the user never sees those
-  // frames in steady-state. Restricted to early on HW paths that have a
-  // VAAPI decoder (qsv on Linux derives from vaapi, so it qualifies too).
+  // slightly worse than tonemap_opencl/reinhard but the difference is
+  // invisible at streaming bitrates.
+  //
+  // We force it for any vaapi-encode path (not just early) because the
+  // OpenCL tonemap chain — `hwmap=derive_device=opencl,tonemap_opencl,
+  // hwmap=derive_device=vaapi:reverse=1` — depends on a working
+  // QSV↔OpenCL↔VAAPI bridge that several Intel hosts can't service
+  // (driver returns 'QSV to OpenCL mapping not usable' and the encoder
+  // crashes). QSV-encode keeps the opencl path on steady-state because
+  // it doesn't need the reverse-hwmap that tripped vaapi.
   const useVaapiTonemap =
-    early && tonemap && (effectiveHwAccel === 'qsv' || effectiveHwAccel === 'vaapi');
+    tonemap &&
+    (effectiveHwAccel === 'vaapi' ||
+      (early && effectiveHwAccel === 'qsv'));
 
   // Hardware acceleration input decoding
   if (effectiveHwAccel === 'qsv') {

--- a/backend/src/modules/streaming/transcoding/hw-detect.ts
+++ b/backend/src/modules/streaming/transcoding/hw-detect.ts
@@ -83,17 +83,22 @@ export async function detectHwAccel(log: Logger): Promise<HwAccelType> {
  *  - Subtitle burn-in needs CPU surfaces for libass — force `'none'`
  *    on QSV / VAAPI / NVENC. VideoToolbox decode already lands in CPU
  *    buffers so libass works in-place.
- *  - QSV cannot crop (the fixed-size frame pool can't accept variable
- *    output from CPU `crop`) — fall back to VAAPI for the encode.
+ *  - QSV cannot crop on the legacy vaapi-decode-then-hwmap chain (the
+ *    fixed-size QSV frame pool rejects the variable output of CPU
+ *    `crop` after hwupload back to vaapi). When the caller indicates
+ *    `qsvCanCrop=true` we stay on QSV — that flag means the caller has
+ *    a qsv-native decoder + `vpp_qsv` filter path ready, which crops
+ *    on the QSV device without touching vaapi pools. Without it we
+ *    fall back to VAAPI like before.
  *
  *  Centralised here so `ffmpeg-args` and `stream-builder` (the stats
  *  overlay path) can't drift on the rule. The registry still has the
  *  final say at resolve time. */
 export function requestedHwAccelFor(
   detected: HwAccelType,
-  needs: { burnIn: boolean; crop: boolean },
+  needs: { burnIn: boolean; crop: boolean; qsvCanCrop?: boolean },
 ): HwAccelType {
   if (needs.burnIn && detected !== 'videotoolbox') return 'none';
-  if (detected === 'qsv' && needs.crop) return 'vaapi';
+  if (detected === 'qsv' && needs.crop && !needs.qsvCanCrop) return 'vaapi';
   return detected;
 }

--- a/backend/src/modules/streaming/transcoding/hw-detect.ts
+++ b/backend/src/modules/streaming/transcoding/hw-detect.ts
@@ -75,3 +75,25 @@ export async function detectHwAccel(log: Logger): Promise<HwAccelType> {
 
   return 'none';
 }
+
+/** Map the host-detected hwAccel onto the slice the orchestrator should
+ *  ask the encoder registry for, applying the two pipeline-level
+ *  filtering constraints:
+ *
+ *  - Subtitle burn-in needs CPU surfaces for libass — force `'none'`
+ *    on QSV / VAAPI / NVENC. VideoToolbox decode already lands in CPU
+ *    buffers so libass works in-place.
+ *  - QSV cannot crop (the fixed-size frame pool can't accept variable
+ *    output from CPU `crop`) — fall back to VAAPI for the encode.
+ *
+ *  Centralised here so `ffmpeg-args` and `stream-builder` (the stats
+ *  overlay path) can't drift on the rule. The registry still has the
+ *  final say at resolve time. */
+export function requestedHwAccelFor(
+  detected: HwAccelType,
+  needs: { burnIn: boolean; crop: boolean },
+): HwAccelType {
+  if (needs.burnIn && detected !== 'videotoolbox') return 'none';
+  if (detected === 'qsv' && needs.crop) return 'vaapi';
+  return detected;
+}

--- a/backend/src/modules/streaming/transcoding/index.ts
+++ b/backend/src/modules/streaming/transcoding/index.ts
@@ -10,7 +10,11 @@ export {
   getLadderForDevice,
   isHdrProfile,
   parseBitrateToBps,
+  profileFitsSource,
+  profileResolution,
 } from './profiles';
+export { requestedHwAccelFor } from './hw-detect';
+export { encoderRegistry } from './codec/encoders';
 export { audioSessionKey, earlySessionKey, sessionKey } from './session-key';
 export { generateMasterPlaylist, getAvailableProfiles } from './master-playlist';
 export { TranscodingService } from './transcoding.service';

--- a/backend/src/modules/streaming/transcoding/ladder/bitrates.ts
+++ b/backend/src/modules/streaming/transcoding/ladder/bitrates.ts
@@ -1,0 +1,85 @@
+import type { CodecVariant, BitDepth } from '../codec/types';
+import type { DeviceType } from '../types';
+
+/** Bitrate ladder anchored on H.264 SDR. Each rung lists `(maxHeight,
+ *  videoKbps, audioKbps)` for the standard H.264 target. Other codecs
+ *  scale this ladder by the ratios in {@link CODEC_BITRATE_RATIO} —
+ *  HEVC is ~30% more efficient than H.264 at equivalent visual quality,
+ *  AV1 ~50%. Mobile uses lower bitrates because cellular bandwidth and
+ *  battery decode budget are both tighter. */
+interface RungSpec {
+  maxHeight: number;
+  width: number;
+  videoKbps: number;
+  audioKbps: number;
+}
+
+const DESKTOP_BASE: readonly RungSpec[] = [
+  { maxHeight: 2160, width: 3840, videoKbps: 20000, audioKbps: 192 },
+  { maxHeight: 1080, width: 1920, videoKbps: 8000, audioKbps: 192 },
+  { maxHeight: 720, width: 1280, videoKbps: 4000, audioKbps: 128 },
+  { maxHeight: 480, width: 854, videoKbps: 2000, audioKbps: 96 },
+  { maxHeight: 360, width: 640, videoKbps: 1000, audioKbps: 64 },
+  { maxHeight: 240, width: 426, videoKbps: 500, audioKbps: 64 },
+  { maxHeight: 144, width: 256, videoKbps: 200, audioKbps: 48 },
+];
+
+const MOBILE_BASE: readonly RungSpec[] = [
+  { maxHeight: 2160, width: 3840, videoKbps: 8000, audioKbps: 192 },
+  { maxHeight: 1080, width: 1920, videoKbps: 3000, audioKbps: 192 },
+  { maxHeight: 720, width: 1280, videoKbps: 1500, audioKbps: 128 },
+  { maxHeight: 480, width: 854, videoKbps: 800, audioKbps: 96 },
+  { maxHeight: 360, width: 640, videoKbps: 500, audioKbps: 64 },
+  { maxHeight: 240, width: 426, videoKbps: 300, audioKbps: 64 },
+  { maxHeight: 144, width: 256, videoKbps: 150, audioKbps: 48 },
+];
+
+/** Codec efficiency ratio vs H.264. A 0.7 ratio means the codec needs
+ *  70% of the H.264 bitrate to reach equivalent visual quality. The
+ *  10-bit boost (+10%) compensates for the extra precision needed when
+ *  encoding HDR or 10-bit SDR sources. */
+const CODEC_BITRATE_RATIO: Record<CodecVariant['codec'], number> = {
+  h264: 1.0,
+  hevc: 0.7,
+  av1: 0.5,
+};
+
+const BIT_DEPTH_BOOST: Record<BitDepth, number> = {
+  8: 1.0,
+  10: 1.1,
+};
+
+/** Resolved rung bitrate for a `(deviceType, variant, height)` triple. */
+export function bitrateForRung(
+  deviceType: DeviceType,
+  variant: CodecVariant,
+  height: number,
+): { videoBps: number; audioBps: number; width: number } {
+  const base = (deviceType === 'mobile' ? MOBILE_BASE : DESKTOP_BASE).find(
+    (r) => r.maxHeight === height,
+  );
+  if (!base) {
+    throw new Error(`No bitrate spec for height ${height}`);
+  }
+  const ratio =
+    CODEC_BITRATE_RATIO[variant.codec] * BIT_DEPTH_BOOST[variant.bitDepth];
+  return {
+    videoBps: Math.round(base.videoKbps * 1000 * ratio),
+    audioBps: base.audioKbps * 1000,
+    width: base.width,
+  };
+}
+
+/** Every rung height available for a given device type. */
+export function rungHeights(deviceType: DeviceType): readonly number[] {
+  const base = deviceType === 'mobile' ? MOBILE_BASE : DESKTOP_BASE;
+  return base.map((r) => r.maxHeight);
+}
+
+/** Rungs that fit at or below `sourceHeight`. Used to avoid upscaling. */
+export function availableHeights(
+  deviceType: DeviceType,
+  sourceHeight: number,
+): number[] {
+  return rungHeights(deviceType).filter((h) => h <= sourceHeight);
+}

--- a/backend/src/modules/streaming/transcoding/ladder/build.ts
+++ b/backend/src/modules/streaming/transcoding/ladder/build.ts
@@ -1,0 +1,119 @@
+import type { CodecVariant } from '../codec/types';
+import type { DeviceType } from '../types';
+import { availableHeights, bitrateForRung } from './bitrates';
+import type { LadderRung, LadderSpec, AudioRendition } from './types';
+
+/** Build the ladder for one variant. Each rung is the same codec/HDR
+ *  combo at a different resolution; the player picks the rung that fits
+ *  its display + bandwidth. Heights cap at the source resolution to
+ *  avoid pointless upscaling. */
+export function buildLadderForVariant(
+  variant: CodecVariant,
+  source: { width: number; height: number },
+  deviceType: DeviceType,
+  audioRenditions: AudioRendition[],
+): LadderSpec {
+  const heights = availableHeights(deviceType, source.height);
+
+  const rungs: LadderRung[] = heights.map((height) => {
+    const { videoBps, audioBps, width: rungWidth } = bitrateForRung(
+      deviceType,
+      variant,
+      height,
+    );
+    const w = Math.min(rungWidth, source.width);
+    const h = Math.floor((w * source.height) / source.width / 16) * 16 || 16;
+    return {
+      id: rungIdFor(variant, height),
+      variant,
+      width: w,
+      height: h,
+      videoBitrateBps: videoBps,
+      audioBitrateBps: audioBps,
+      label: labelFor(variant, height),
+    };
+  });
+
+  return {
+    rungs,
+    audioRenditions,
+    splitAudio: audioRenditions.length > 0,
+  };
+}
+
+/** Stable URL fragment used by HLS segment routes — `:quality` is parsed
+ *  back to a variant via `parseRungId`. Format keeps the existing
+ *  scheme (`1080p`, `2160p-hdr`) compatible: H.264 SDR rungs stay
+ *  bare (`1080p`), other codecs get a suffix.
+ *
+ *  Examples:
+ *  - H.264 SDR 1080p → `1080p`
+ *  - H.264 SDR 2160p → `2160p`
+ *  - HEVC SDR 1080p → `1080p-hevc`
+ *  - HEVC HDR10 2160p → `2160p-hevc-hdr10`
+ *  - HEVC HLG 1080p → `1080p-hevc-hlg`
+ *  - AV1 HDR10 2160p → `2160p-av1-hdr10` */
+export function rungIdFor(variant: CodecVariant, height: number): string {
+  const tag = codecTag(variant);
+  const hdr = variant.hdr ? `-${variant.hdr.toLowerCase()}` : '';
+  return tag ? `${height}p-${tag}${hdr}` : `${height}p${hdr}`;
+}
+
+function codecTag(variant: CodecVariant): string {
+  switch (variant.codec) {
+    case 'h264':
+      // H.264 SDR rungs keep the legacy bare name (`1080p`). HDR-tagged
+      // H.264 doesn't exist (codec is 8-bit only) — defensive fallthrough.
+      return variant.hdr ? 'h264' : '';
+    case 'hevc':
+      return 'hevc';
+    case 'av1':
+      return 'av1';
+  }
+}
+
+function labelFor(variant: CodecVariant, height: number): string {
+  const res = height === 2160 ? '4K' : `${height}p`;
+  if (variant.hdr === 'HDR10') return `${res} HDR`;
+  if (variant.hdr === 'HLG') return `${res} HLG`;
+  if (variant.hdr) return `${res} ${variant.hdr}`;
+  return res;
+}
+
+/** Parse a rung id back to its variant + height — used by the segment
+ *  handler when the player asks for `/api/stream/N/2160p-hevc-hdr10/...`. */
+export function parseRungId(id: string): {
+  variant: CodecVariant;
+  height: number;
+} | null {
+  const m = id.match(/^(\d+)p(?:-([a-z0-9]+))?(?:-([a-z0-9]+))?$/i);
+  if (!m) return null;
+  const height = parseInt(m[1], 10);
+  const tagA = m[2]?.toLowerCase();
+  const tagB = m[3]?.toLowerCase();
+  // Order is [height]p-[codec?]-[hdr?]. When only one tag is present it
+  // could be either codec or HDR — disambiguate by checking the known
+  // codec tags first.
+  const knownCodecs = new Set(['hevc', 'av1', 'h264']);
+  const knownHdr = new Map<string, CodecVariant['hdr']>([
+    ['hdr10', 'HDR10'],
+    ['hlg', 'HLG'],
+    ['dv5', 'DV5'],
+    ['dv81', 'DV81'],
+    ['dv84', 'DV84'],
+  ]);
+
+  let codec: CodecVariant['codec'] = 'h264';
+  let hdr: CodecVariant['hdr'] = null;
+  if (tagA && knownCodecs.has(tagA)) {
+    codec = tagA as CodecVariant['codec'];
+    if (tagB && knownHdr.has(tagB)) hdr = knownHdr.get(tagB) ?? null;
+  } else if (tagA && knownHdr.has(tagA)) {
+    hdr = knownHdr.get(tagA) ?? null;
+  } else if (tagA) {
+    return null;
+  }
+
+  const bitDepth = hdr ? 10 : 8;
+  return { variant: { codec, bitDepth, hdr }, height };
+}

--- a/backend/src/modules/streaming/transcoding/ladder/types.ts
+++ b/backend/src/modules/streaming/transcoding/ladder/types.ts
@@ -1,0 +1,38 @@
+import type { CodecVariant } from '../codec/types';
+
+/** A single rung of the master playlist. `id` is the URL fragment served
+ *  on the wire (e.g. `2160p-hevc-hdr10`); the player passes it back as
+ *  `:quality` on segment requests. */
+export interface LadderRung {
+  id: string;
+  variant: CodecVariant;
+  width: number;
+  height: number;
+  videoBitrateBps: number;
+  audioBitrateBps: number;
+  /** UI label exposed by the quality picker (e.g. "4K HDR"). */
+  label: string;
+}
+
+/** Multi-audio renditions referenced by every video rung via
+ *  `AUDIO="audio"`. Empty when the source is single-audio (audio is
+ *  muxed into the video segments instead). */
+export interface AudioRendition {
+  /** Index of the audio track in the source file. */
+  sourceIndex: number;
+  language: string;
+  name: string;
+  isDefault: boolean;
+}
+
+/** Output of the ladder builder. Consumed by the master playlist
+ *  emitter and the HLS controller (to validate quality strings on
+ *  segment requests). */
+export interface LadderSpec {
+  rungs: LadderRung[];
+  audioRenditions: AudioRendition[];
+  /** True when audio is served via separate `EXT-X-MEDIA` renditions
+   *  (var_stream_map on the video session, or a dedicated audio
+   *  ffmpeg session). False = audio is muxed inside the video segments. */
+  splitAudio: boolean;
+}

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -4,6 +4,11 @@ import {
   parseBitrateToBps,
 } from './profiles';
 import type { DeviceType, TranscodeProfile } from './types';
+import type { CodecVariant } from './codec/types';
+import {
+  h264CodecString,
+  hevcMainCodecString,
+} from './codec/codec-strings';
 
 /**
  * Get available quality profiles for a given source resolution + device class.
@@ -56,6 +61,13 @@ export function generateMasterPlaylist(
    *  ExoPlayer. When false, only the remux pass-through rung is emitted
    *  — that path is `-c:v copy` and works regardless of hwAccel. */
   canEncodeHevcHdr = false,
+  /** SDR-ladder output codec, picked by the codec selector. When the
+   *  selector promoted HEVC (source codec match, or efficiency
+   *  ranking on HEVC-capable clients), every SDR rung emits a
+   *  `hvc1.*` CODECS string instead of `avc1.*` so MSE doesn't reject
+   *  the appended segments. Absent for legacy callers that haven't
+   *  threaded the variant through — falls back to H.264 codec strings. */
+  sdrVariant?: CodecVariant,
 ): string {
   const multiAudio = audioStreams && audioStreams.length > 1;
   const lines = ['#EXTM3U'];
@@ -187,7 +199,17 @@ export function generateMasterPlaylist(
     const w = Math.min(p.maxWidth, sourceWidth);
     const rawH = (w * sourceHeight) / sourceWidth;
     const h = Math.floor(rawH / 16) * 16 || 16;
-    const videoCodec = h264CodecStringForHeight(p.maxHeight);
+    const target = {
+      width: w,
+      height: p.maxHeight,
+      videoBitrateBps: 0,
+      gopSize: 0,
+      frameRate: 24,
+    };
+    const videoCodec =
+      sdrVariant?.codec === 'hevc'
+        ? hevcMainCodecString(target)
+        : h264CodecString(target);
     const codecsAttr = `,CODECS="${videoCodec},${audioCodec}"`;
     lines.push(
       `#EXT-X-STREAM-INF:BANDWIDTH=${bw},AVERAGE-BANDWIDTH=${avg},RESOLUTION=${w}x${h},NAME="${p.name}"${codecsAttr}${audioAttr}`,

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -2,6 +2,8 @@ import {
   getHdrLadderForDevice,
   getLadderForDevice,
   parseBitrateToBps,
+  profileFitsSource,
+  profileResolution,
 } from './profiles';
 import type { DeviceType, TranscodeProfile } from './types';
 import type { CodecVariant } from './codec/types';
@@ -18,8 +20,8 @@ export function getAvailableProfiles(
   sourceHeight: number,
   deviceType: DeviceType = 'desktop',
 ): TranscodeProfile[] {
-  return getLadderForDevice(deviceType).filter(
-    (p) => p.maxWidth <= sourceWidth || p.maxHeight <= sourceHeight,
+  return getLadderForDevice(deviceType).filter((p) =>
+    profileFitsSource(p, sourceWidth, sourceHeight),
   );
 }
 
@@ -117,20 +119,18 @@ export function generateMasterPlaylist(
     // Includes the source-resolution rung if there's an HDR profile
     // at or below source height.
     if (canEncodeHevcHdr) {
-      // Width OR height keeps cinema-aspect sources (e.g. 3840×2024 IMAX
-      // bluray) on the 2160p-hdr rung. A pure `maxHeight <= sourceHeight`
-      // check drops 2160p-hdr for any source whose vertical resolution
-      // falls below 2160 — which is most theatrical 4K masters.
-      const hdrLadder = getHdrLadderForDevice(deviceType).filter(
-        (p) => p.maxWidth <= sourceWidth || p.maxHeight <= sourceHeight,
+      const hdrLadder = getHdrLadderForDevice(deviceType).filter((p) =>
+        profileFitsSource(p, sourceWidth, sourceHeight),
       );
       for (const p of hdrLadder) {
         const avg =
           parseBitrateToBps(p.videoBitrate) + parseBitrateToBps(p.audioBitrate);
         const bw = Math.round(avg * 1.5);
-        const w = Math.min(p.maxWidth, sourceWidth);
-        const rawH = (w * sourceHeight) / sourceWidth;
-        const h = Math.floor(rawH / 16) * 16 || 16;
+        const { width: w, height: h } = profileResolution(
+          p,
+          sourceWidth,
+          sourceHeight,
+        );
         const videoCodec = hevcMain10CodecStringForHeight(p.maxHeight);
         lines.push(
           `#EXT-X-STREAM-INF:BANDWIDTH=${bw},AVERAGE-BANDWIDTH=${avg},RESOLUTION=${w}x${h},VIDEO-RANGE=${range},NAME="${p.name}",CODECS="${videoCodec},${audioCodec}"${hdrAudioAttr}`,
@@ -200,9 +200,11 @@ export function generateMasterPlaylist(
     // ~1.5× nominal gives AVPlayer ABR a stable hysteresis margin and
     // stops it from down-/up-shifting on every VBV spike.
     const bw = Math.round(avg * 1.5);
-    const w = Math.min(p.maxWidth, sourceWidth);
-    const rawH = (w * sourceHeight) / sourceWidth;
-    const h = Math.floor(rawH / 16) * 16 || 16;
+    const { width: w, height: h } = profileResolution(
+      p,
+      sourceWidth,
+      sourceHeight,
+    );
     const target = {
       width: w,
       height: p.maxHeight,

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -117,8 +117,12 @@ export function generateMasterPlaylist(
     // Includes the source-resolution rung if there's an HDR profile
     // at or below source height.
     if (canEncodeHevcHdr) {
+      // Width OR height keeps cinema-aspect sources (e.g. 3840×2024 IMAX
+      // bluray) on the 2160p-hdr rung. A pure `maxHeight <= sourceHeight`
+      // check drops 2160p-hdr for any source whose vertical resolution
+      // falls below 2160 — which is most theatrical 4K masters.
       const hdrLadder = getHdrLadderForDevice(deviceType).filter(
-        (p) => p.maxHeight <= sourceHeight,
+        (p) => p.maxWidth <= sourceWidth || p.maxHeight <= sourceHeight,
       );
       for (const p of hdrLadder) {
         const avg =

--- a/backend/src/modules/streaming/transcoding/profiles.ts
+++ b/backend/src/modules/streaming/transcoding/profiles.ts
@@ -131,8 +131,12 @@ export function profileFitsSource(
 
 /** Compute output dimensions for a profile against a source. Width is
  *  capped at the source (no upscale); height follows the source aspect
- *  ratio, snapped down to a multiple of 16 so HW encoders that require
- *  mod-16 luma dimensions don't reject the variant. */
+ *  ratio, snapped UP to a multiple of 16. The HW filters we ship
+ *  (`scale_vaapi=h=-16` etc.) round up too, so master, HW and CPU all
+ *  agree on the same target — without that, the master advertises one
+ *  height and the bitstream carries another (a 16-px drift on theatrical
+ *  4K masters like 3840×2024), and the player allocates a video surface
+ *  that no longer matches the decoded frame. */
 export function profileResolution(
   p: { maxWidth: number },
   sourceWidth: number,
@@ -140,7 +144,7 @@ export function profileResolution(
 ): { width: number; height: number } {
   const width = Math.min(p.maxWidth, sourceWidth);
   const rawH = (width * sourceHeight) / sourceWidth;
-  const height = Math.floor(rawH / 16) * 16 || 16;
+  const height = Math.ceil(rawH / 16) * 16 || 16;
   return { width, height };
 }
 

--- a/backend/src/modules/streaming/transcoding/profiles.ts
+++ b/backend/src/modules/streaming/transcoding/profiles.ts
@@ -115,6 +115,35 @@ export function isHdrProfile(name: string): boolean {
   return name.endsWith('-hdr');
 }
 
+/** True when a profile is small enough to encode on the source — either
+ *  axis fitting is enough so cinema-aspect 4K (e.g. 3840×2024 IMAX)
+ *  still gets the 2160p ladder rung. A strict `maxHeight <= sourceHeight`
+ *  check drops the top rung for any source whose vertical resolution
+ *  falls below the profile's category label, which is wrong for most
+ *  theatrical 4K masters. */
+export function profileFitsSource(
+  p: { maxWidth: number; maxHeight: number },
+  sourceWidth: number,
+  sourceHeight: number,
+): boolean {
+  return p.maxWidth <= sourceWidth || p.maxHeight <= sourceHeight;
+}
+
+/** Compute output dimensions for a profile against a source. Width is
+ *  capped at the source (no upscale); height follows the source aspect
+ *  ratio, snapped down to a multiple of 16 so HW encoders that require
+ *  mod-16 luma dimensions don't reject the variant. */
+export function profileResolution(
+  p: { maxWidth: number },
+  sourceWidth: number,
+  sourceHeight: number,
+): { width: number; height: number } {
+  const width = Math.min(p.maxWidth, sourceWidth);
+  const rawH = (width * sourceHeight) / sourceWidth;
+  const height = Math.floor(rawH / 16) * 16 || 16;
+  return { width, height };
+}
+
 /** Backward-compatible alias — most callers want the desktop ladder. */
 export const PROFILES = DESKTOP_PROFILES;
 

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -28,6 +28,7 @@ import { ALL_DESCRIPTORS } from './codec/encoders';
 import { runEncoderProbes } from './codec/encoder-probe';
 import { ALL_DECODERS } from './codec/decoders';
 import { runDecoderProbes } from './codec/decoder-probe';
+import { runVppQsvTonemapProbe } from './codec/vpp-qsv-probe';
 import { generateMasterPlaylist, getAvailableProfiles } from './master-playlist';
 import {
   fileExists,
@@ -96,6 +97,11 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     // probes fire fire-and-forget — by the time a transcode session
     // actually runs, both maps are populated.
     void runDecoderProbes(ALL_DECODERS, this.log);
+    // Probe whether the iGPU's fixed-function HDR tone-mapping unit
+    // is wired up. Only the upstream `vpp_qsv tonemap=1` path uses
+    // it; gates the single-pass HDR→SDR chain in the QSV encoder
+    // filter helpers.
+    void runVppQsvTonemapProbe(this.log);
 
     this.cleanupTimer = setInterval(() => this.cleanupStaleSessions(), 30_000);
   }

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -348,6 +348,15 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         this.log.log(
           `Quality change [${key}]: ${existing.quality} → ${quality}, killing old session`,
         );
+        // Inherit the killed session's seek position when the caller
+        // didn't pass one (init.mp4 requests arrive without a segment
+        // hint → requestedSegment=0). Without this, the new quality
+        // session spawns at ss=0 and gets killed seconds later by the
+        // first segment fetch which triggers a seek restart at the
+        // real position.
+        if (requestedSegment === 0 && existing.startSegment) {
+          requestedSegment = existing.startSegment;
+        }
         this.sessions.delete(key);
         existing.intentionallyKilled = true;
         await this.killProcess(existing.process);
@@ -708,7 +717,21 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     const { resolve: readyResolve, promise: readyPromise } =
       this.createDeferred();
 
-    this.log.log(`FFmpeg start [${id}]: ffmpeg ${args.join(' ')}`);
+    // Compact one-liner at LOG level — quality + encoder + seek + start_number
+    // is what the operator needs in normal operation. Full ffmpeg command at
+    // DEBUG for diagnostics; enable with LOG_LEVEL=debug to inspect filters
+    // and rate-control knobs.
+    const encoderIdx = args.indexOf('-c:v');
+    const encoder = encoderIdx >= 0 ? args[encoderIdx + 1] : '?';
+    const ssIdx = args.lastIndexOf('-ss');
+    const ss = ssIdx >= 0 ? args[ssIdx + 1] : '0';
+    const startNumberIdx = args.indexOf('-start_number');
+    const startNumber =
+      startNumberIdx >= 0 ? args[startNumberIdx + 1] : String(startSegment);
+    this.log.log(
+      `FFmpeg start [${id}] ${quality} ${encoder} ss=${ss} start_number=${startNumber}`,
+    );
+    this.log.debug?.(`FFmpeg full command [${id}]: ffmpeg ${args.join(' ')}`);
 
     const proc = spawn('ffmpeg', args, {
       stdio: ['ignore', 'ignore', 'pipe'],

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -264,6 +264,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       videoBitRateBps?: number;
       audioBitRateBps?: number;
     },
+    sdrVariant?: import('./codec/types').CodecVariant,
   ): string {
     // Only the QSV branch in ffmpeg-args has `hevc_qsv Main10` wired —
     // every other hwAccel hits libx264 for HEVC HDR profile names and
@@ -286,6 +287,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       outputAudioCodec,
       hdrPassThrough,
       canEncodeHevcHdr,
+      sdrVariant,
     );
   }
 

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -717,10 +717,12 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     const { resolve: readyResolve, promise: readyPromise } =
       this.createDeferred();
 
-    // Compact one-liner at LOG level — quality + encoder + seek + start_number
-    // is what the operator needs in normal operation. Full ffmpeg command at
-    // DEBUG for diagnostics; enable with LOG_LEVEL=debug to inspect filters
-    // and rate-control knobs.
+    // Compact one-liner — quality + encoder + seek + start_number is what
+    // the operator needs in normal operation. Full ffmpeg command was at
+    // DEBUG previously but Nest's dev logger emits debug by default,
+    // which defeated the noise reduction. If full command is needed,
+    // grep the ffmpeg process tree (`ps aux | grep ffmpeg`) or
+    // re-derive from the descriptor + ctx.
     const encoderIdx = args.indexOf('-c:v');
     const encoder = encoderIdx >= 0 ? args[encoderIdx + 1] : '?';
     const ssIdx = args.lastIndexOf('-ss');
@@ -731,7 +733,6 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     this.log.log(
       `FFmpeg start [${id}] ${quality} ${encoder} ss=${ss} start_number=${startNumber}`,
     );
-    this.log.debug?.(`FFmpeg full command [${id}]: ffmpeg ${args.join(' ')}`);
 
     const proc = spawn('ffmpeg', args, {
       stdio: ['ignore', 'ignore', 'pipe'],

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -26,6 +26,8 @@ import {
 import { detectHwAccel } from './hw-detect';
 import { ALL_DESCRIPTORS } from './codec/encoders';
 import { runEncoderProbes } from './codec/encoder-probe';
+import { ALL_DECODERS } from './codec/decoders';
+import { runDecoderProbes } from './codec/decoder-probe';
 import { generateMasterPlaylist, getAvailableProfiles } from './master-playlist';
 import {
   fileExists,
@@ -88,6 +90,12 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     // usable" until the probe completes (the runtime fallback layer
     // catches stragglers).
     void runEncoderProbes(ALL_DESCRIPTORS, this.log);
+    // Same one-frame validation pass on the decoder side: synthesise a
+    // tiny bitstream per codec, hand it to each descriptor under its
+    // real `-hwaccel ...` setup, drop the frame to /dev/null. Both
+    // probes fire fire-and-forget — by the time a transcode session
+    // actually runs, both maps are populated.
+    void runDecoderProbes(ALL_DECODERS, this.log);
 
     this.cleanupTimer = setInterval(() => this.cleanupStaleSessions(), 30_000);
   }
@@ -573,6 +581,8 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
           early: true,
           useTs: ctx?.useTs ?? false,
           videoVariant: ctx?.videoVariant,
+          sourceVideoCodec: ctx?.sourceVideoCodec,
+          sourceBitDepth: ctx?.isSourceHdr ? 10 : 8,
         },
         this.log,
       );

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -551,6 +551,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
           trustedStreamInfo: ctx?.trustedStreamInfo,
           early: true,
           useTs: ctx?.useTs ?? false,
+          videoVariant: ctx?.videoVariant,
         },
         this.log,
       );
@@ -817,6 +818,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         sourceFps: ctx?.sourceFps,
         trustedStreamInfo: ctx?.trustedStreamInfo,
         useTs: ctx?.useTs ?? false,
+        videoVariant: ctx?.videoVariant,
       },
       this.log,
     );

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -24,6 +24,8 @@ import {
   buildRemuxArgs,
 } from './ffmpeg-args';
 import { detectHwAccel } from './hw-detect';
+import { ALL_DESCRIPTORS } from './codec/encoders';
+import { runEncoderProbes } from './codec/encoder-probe';
 import { generateMasterPlaylist, getAvailableProfiles } from './master-playlist';
 import {
   fileExists,
@@ -78,6 +80,14 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
 
     this.detectedHwAccel = await detectHwAccel(this.log);
     this.log.log(`Hardware acceleration: ${this.detectedHwAccel}`);
+
+    // Probe every compiled-in encoder. Each runs a single black-frame
+    // ffmpeg encode; the descriptors that fail to open are blacklisted
+    // in the runtime registry gate. Runs async — module init doesn't
+    // wait for it, but the codec selector defaults to "every encoder
+    // usable" until the probe completes (the runtime fallback layer
+    // catches stragglers).
+    void runEncoderProbes(ALL_DESCRIPTORS, this.log);
 
     this.cleanupTimer = setInterval(() => this.cleanupStaleSessions(), 30_000);
   }

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -865,6 +865,8 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         trustedStreamInfo: ctx?.trustedStreamInfo,
         useTs: ctx?.useTs ?? false,
         videoVariant: ctx?.videoVariant,
+        sourceVideoCodec: ctx?.sourceVideoCodec,
+        sourceBitDepth: ctx?.isSourceHdr ? 10 : 8,
       },
       this.log,
     );

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -128,6 +128,15 @@ export interface SessionContext {
    * this with `tonemap` when picking a non-remux quality.
    */
   isSourceHdr?: boolean;
+  /**
+   * Output video format the player asked for, picked by stream-builder
+   * via the codec selector + quirks DB. When set, ffmpeg-args resolves
+   * the matching encoder descriptor from `encoderRegistry`; when null,
+   * it falls back to the legacy `profile.name`-driven inference (H.264
+   * SDR or HEVC HDR10 on QSV). Phases 0-4 left this optional so the
+   * orchestrator could be wired up progressively.
+   */
+  videoVariant?: import('./codec/types').CodecVariant;
 }
 
 export interface TranscodeSession {

--- a/backend/src/modules/subtitles/ffprobe.service.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.ts
@@ -437,7 +437,7 @@ export class FfprobeService {
       const totalHorizontalCrop = originalWidth ? originalWidth - w : x * 2;
       if (totalVerticalCrop < 40 && totalHorizontalCrop < 40) {
         this.logger.log(
-          `cropdetect "${label}": no crop needed (detected ${bestCrop}, total crop: ${totalVerticalCrop}v/${totalHorizontalCrop}h)`,
+          `cropdetect "${label}": no crop needed (detected ${w}:${h}:${x}:${y}, total crop: ${totalVerticalCrop}v/${totalHorizontalCrop}h)`,
         );
         return null;
       }

--- a/backend/src/modules/subtitles/ffprobe.service.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.ts
@@ -358,76 +358,91 @@ export class FfprobeService {
     durationSeconds?: number,
     originalWidth?: number,
     originalHeight?: number,
+    isHdr = false,
   ): Promise<CropInfo | null> {
     const label = path.basename(videoPath);
     this.logger.log(
-      `cropdetect started for "${label}" (${originalWidth}x${originalHeight})`,
+      `cropdetect started for "${label}" (${originalWidth}x${originalHeight}, hdr=${isHdr})`,
     );
     try {
-      // Sample 6 timestamps spread across the file (5–80%) and scan 8 s
-      // per sample with `cropdetect=skip=24` so each pass discards the
-      // first 24 frames before measuring — those are usually fades or
-      // partly-black transitions that mask the true frame edges.
-      // Three samples were too few: animated 4K Blurays like Arcane mix
-      // full-frame action with cinema-aspect dialogue scenes, and a
-      // 3-sample run regularly hit only full-frame moments and reported
-      // 'no crop needed' on a clearly letterboxed source.
+      // Sample 6 timestamps spread across the file (5–80%) — animated 4K
+      // Blurays like Arcane mix full-frame action with cinema-aspect
+      // dialogue scenes, and a tight 3-sample run repeatedly hit only
+      // full-frame moments and reported 'no crop needed' on a clearly
+      // letterboxed source. Six samples in parallel finish faster than
+      // three sequential, so the wider coverage is free.
       const dur = durationSeconds ?? 600;
       const fractions = [0.05, 0.15, 0.3, 0.45, 0.6, 0.8];
       const timestamps = fractions.map((f) => Math.floor(dur * f));
 
-      // Pick the LARGEST crop observed across samples (the tightest box
-      // that still fits content), not the most common one. A scene with
-      // a small overlay can falsely shrink the detected crop on one
-      // sample; the largest crop is the union of content regions, which
-      // is what we want to keep visible at playback.
+      // limit (cropdetect threshold for "this pixel is black"):
+      //   - SDR encodes black around luma 16 (BT.709 narrow range), so
+      //     limit=24 is the legacy default and works.
+      //   - HDR (PQ / HLG) encodes black around luma 50–70 — limit=24
+      //     misses every 4K HDR Bluray we touched. limit=64 catches the
+      //     letterbox but on SDR it pulls in low-luma scene content
+      //     ('most of a dim scene is below 64') and falsely shrinks the
+      //     crop. Pick per-source so neither side gets the wrong default.
+      const limit = isHdr ? 64 : 24;
+
+      // skip=24 drops the first 24 frames per pass so fades / transition
+      // black don't shift the detected edges. round=16 keeps the result
+      // mod-16 to match HW encoder constraints.
+      const cropFilter = `cropdetect=limit=${limit}:round=16:reset=0:skip=24`;
+
+      const sampleResults = await Promise.all(
+        timestamps.map(async (ss) => {
+          try {
+            const { stderr } = await execFileAsync(
+              'ffmpeg',
+              [
+                '-ss',
+                String(Math.floor(ss)),
+                '-i',
+                videoPath,
+                '-t',
+                '5',
+                '-vf',
+                cropFilter,
+                '-an',
+                '-f',
+                'null',
+                '-',
+              ],
+              { timeout: 30_000 },
+            );
+            const lines = stderr.split('\n');
+            for (let i = lines.length - 1; i >= 0; i--) {
+              const m = lines[i].match(/crop=(\d+):(\d+):(\d+):(\d+)/);
+              if (m) {
+                return {
+                  ss,
+                  w: parseInt(m[1], 10),
+                  h: parseInt(m[2], 10),
+                  x: parseInt(m[3], 10),
+                  y: parseInt(m[4], 10),
+                };
+              }
+            }
+            return null;
+          } catch {
+            return null;
+          }
+        }),
+      );
+
+      // Aggregate: pick the LARGEST crop observed (the loosest box that
+      // still fits content). A small overlay on one sample can falsely
+      // shrink the detected crop, but the largest area is the union of
+      // content regions across scenes — what we actually want visible.
       let bestCrop: { w: number; h: number; x: number; y: number } | null =
         null;
       const seenSamples: string[] = [];
-
-      for (const ss of timestamps) {
-        try {
-          const { stderr } = await execFileAsync(
-            'ffmpeg',
-            [
-              '-ss',
-              String(Math.floor(ss)),
-              '-i',
-              videoPath,
-              '-t',
-              '8',
-              '-vf',
-              // limit=64: HDR sources encode black around luma 50–70 in
-              // the PQ curve (vs ~16 in SDR BT.709), so the legacy
-              // limit=24 missed every 4K HDR Bluray we touched. 64
-              // catches HDR letterbox without crossing into dark-scene
-              // false positives that a 96+ threshold would trip.
-              'cropdetect=limit=64:round=16:reset=0:skip=24',
-              '-an',
-              '-f',
-              'null',
-              '-',
-            ],
-            { timeout: 30_000 },
-          );
-
-          const lines = stderr.split('\n');
-          for (let i = lines.length - 1; i >= 0; i--) {
-            const m = lines[i].match(/crop=(\d+):(\d+):(\d+):(\d+)/);
-            if (m) {
-              const w = parseInt(m[1], 10);
-              const h = parseInt(m[2], 10);
-              const x = parseInt(m[3], 10);
-              const y = parseInt(m[4], 10);
-              seenSamples.push(`@${ss}s=${w}:${h}:${x}:${y}`);
-              if (!bestCrop || w * h > bestCrop.w * bestCrop.h) {
-                bestCrop = { w, h, x, y };
-              }
-              break;
-            }
-          }
-        } catch {
-          // Individual sample failed, continue
+      for (const r of sampleResults) {
+        if (!r) continue;
+        seenSamples.push(`@${r.ss}s=${r.w}:${r.h}:${r.x}:${r.y}`);
+        if (!bestCrop || r.w * r.h > bestCrop.w * bestCrop.h) {
+          bestCrop = { w: r.w, h: r.h, x: r.x, y: r.y };
         }
       }
 

--- a/backend/src/modules/subtitles/ffprobe.service.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.ts
@@ -397,7 +397,12 @@ export class FfprobeService {
               '-t',
               '8',
               '-vf',
-              'cropdetect=limit=24:round=16:reset=0:skip=24',
+              // limit=64: HDR sources encode black around luma 50–70 in
+              // the PQ curve (vs ~16 in SDR BT.709), so the legacy
+              // limit=24 missed every 4K HDR Bluray we touched. 64
+              // catches HDR letterbox without crossing into dark-scene
+              // false positives that a 96+ threshold would trip.
+              'cropdetect=limit=64:round=16:reset=0:skip=24',
               '-an',
               '-f',
               'null',

--- a/backend/src/modules/subtitles/ffprobe.service.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.ts
@@ -328,7 +328,7 @@ export class FfprobeService {
     // HDR is defined by the transfer curve, not the bit depth. An 8-bit PQ
     // file is mis-encoded but still needs the HDR pipeline (or tone-mapping):
     // played as SDR, the PQ values render as gamma 2.2 and the picture goes
-    // dark/washed. Match Jellyfin/Plex: classify by transfer function alone.
+    // dark/washed. Classify by transfer function alone.
     if (!colorTransfer) return undefined;
     const isBt2020 = colorPrimaries === 'bt2020';
     if (colorTransfer === 'smpte2084' && isBt2020) return 'HDR10';

--- a/backend/src/modules/subtitles/ffprobe.service.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.ts
@@ -364,15 +364,26 @@ export class FfprobeService {
       `cropdetect started for "${label}" (${originalWidth}x${originalHeight})`,
     );
     try {
-      // Sample at 3 different timestamps to avoid false positives (dark scenes, credits)
+      // Sample 6 timestamps spread across the file (5–80%) and scan 8 s
+      // per sample with `cropdetect=skip=24` so each pass discards the
+      // first 24 frames before measuring — those are usually fades or
+      // partly-black transitions that mask the true frame edges.
+      // Three samples were too few: animated 4K Blurays like Arcane mix
+      // full-frame action with cinema-aspect dialogue scenes, and a
+      // 3-sample run regularly hit only full-frame moments and reported
+      // 'no crop needed' on a clearly letterboxed source.
       const dur = durationSeconds ?? 600;
-      const timestamps = [
-        Math.min(60, dur * 0.1), // 10% or 60s
-        Math.min(300, dur * 0.3), // 30% or 300s
-        Math.min(600, dur * 0.5), // 50% or 600s
-      ];
+      const fractions = [0.05, 0.15, 0.3, 0.45, 0.6, 0.8];
+      const timestamps = fractions.map((f) => Math.floor(dur * f));
 
-      const cropCounts = new Map<string, number>();
+      // Pick the LARGEST crop observed across samples (the tightest box
+      // that still fits content), not the most common one. A scene with
+      // a small overlay can falsely shrink the detected crop on one
+      // sample; the largest crop is the union of content regions, which
+      // is what we want to keep visible at playback.
+      let bestCrop: { w: number; h: number; x: number; y: number } | null =
+        null;
+      const seenSamples: string[] = [];
 
       for (const ss of timestamps) {
         try {
@@ -384,9 +395,9 @@ export class FfprobeService {
               '-i',
               videoPath,
               '-t',
-              '3',
+              '8',
               '-vf',
-              'cropdetect=24:16:0',
+              'cropdetect=limit=24:round=16:reset=0:skip=24',
               '-an',
               '-f',
               'null',
@@ -395,13 +406,18 @@ export class FfprobeService {
             { timeout: 30_000 },
           );
 
-          // Parse last crop= line
           const lines = stderr.split('\n');
           for (let i = lines.length - 1; i >= 0; i--) {
             const m = lines[i].match(/crop=(\d+):(\d+):(\d+):(\d+)/);
             if (m) {
-              const key = `${m[1]}:${m[2]}:${m[3]}:${m[4]}`;
-              cropCounts.set(key, (cropCounts.get(key) ?? 0) + 1);
+              const w = parseInt(m[1], 10);
+              const h = parseInt(m[2], 10);
+              const x = parseInt(m[3], 10);
+              const y = parseInt(m[4], 10);
+              seenSamples.push(`@${ss}s=${w}:${h}:${x}:${y}`);
+              if (!bestCrop || w * h > bestCrop.w * bestCrop.h) {
+                bestCrop = { w, h, x, y };
+              }
               break;
             }
           }
@@ -410,21 +426,11 @@ export class FfprobeService {
         }
       }
 
-      if (!cropCounts.size) return null;
-
-      // Pick the most common crop value
-      let bestCrop = '';
-      let bestCount = 0;
-      for (const [crop, count] of cropCounts) {
-        if (count > bestCount) {
-          bestCrop = crop;
-          bestCount = count;
-        }
-      }
-
-      const parts = bestCrop.split(':').map(Number);
-      if (parts.length !== 4) return null;
-      const [w, h, x, y] = parts;
+      if (!bestCrop) return null;
+      const { w, h, x, y } = bestCrop;
+      this.logger.debug(
+        `cropdetect "${label}" samples: ${seenSamples.join(', ')}`,
+      );
 
       // Only crop if bars are significant (> 40px total removed on at least one axis)
       const totalVerticalCrop = originalHeight ? originalHeight - h : y * 2;

--- a/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
@@ -592,18 +592,33 @@ public class NativePlayerPlugin extends Plugin {
             }
 
             if (width <= 0 || height <= 0) {
-                // Auto: clear manual override → ExoPlayer re-runs adaptive selection.
+                // Auto: clear manual override and the soft size cap → ExoPlayer
+                // re-runs adaptive selection across every advertised variant.
                 pendingVideoHeight = -1;
                 player.setTrackSelectionParameters(
                         player.getTrackSelectionParameters().buildUpon()
                                 .clearOverridesOfType(C.TRACK_TYPE_VIDEO)
+                                .clearVideoSizeConstraints()
                                 .build());
                 call.resolve();
                 return;
             }
 
-            // Manual override on the video group disables ABR for that track type.
-            // Store height for onTracksChanged if variants aren't available yet.
+            // Set a soft cap on max video size FIRST. This filters out
+            // higher-than-target variants from ExoPlayer's initial track
+            // selection — without it the player starts fetching the top
+            // rung from the master and only honours the override after
+            // onTracksChanged fires, costing a wasted ffmpeg session
+            // (visible in the backend log as 'Quality change [X]:
+            // 2160p-hdr → 1080p-hdr, killing old session').
+            player.setTrackSelectionParameters(
+                    player.getTrackSelectionParameters().buildUpon()
+                            .setMaxVideoSize(width, height)
+                            .build());
+            // Then pin to the exact variant once it's known (onTracksChanged).
+            // The override is a manual pick, not just a cap, so a 2160p
+            // variant with height 2016 (cinema 4K) doesn't sneak in when
+            // the user picked 1080p.
             if (!applyVideoOverrideByHeight(height)) {
                 pendingVideoHeight = height;
             } else {

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -957,9 +957,6 @@
       "qsv_advanced": "Options avancées Intel QSV",
       "qsv_low_power": "Mode basse consommation",
       "qsv_low_power_help": "Active -low_power 1 (VDENC, Intel Gen9+). Encodage plus rapide mais qualité légèrement inférieure. À tester selon la génération du CPU.",
-      "hdr_section": "Encodage HDR",
-      "hevc_hdr_enabled": "Encodage HEVC HDR",
-      "hevc_hdr_enabled_help": "Active l'échelle HEVC Main10 (BT.2020/PQ ou HLG) pour les sources HDR sur les clients compatibles. Désactivé, les sources HDR sont tone-mappées en H.264 SDR sur toutes les résolutions. À désactiver si le HW (iGPU Intel ancien) ne supporte pas hevc_qsv Main10.",
       "default": "défaut",
       "saved": "Paramètres de streaming enregistrés"
     },

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -101,9 +101,14 @@ export class BrowserDeviceProfileService {
     const containers: string[] = [];
     if (this.testType(video, hasMSE, 'video/mp4')) containers.push('mp4', 'm4v', 'mov');
     if (this.testType(video, hasMSE, 'video/webm')) containers.push('webm');
-    // MKV: browsers can NOT play MKV containers directly. Do NOT add 'mkv' here.
-    // MKV files with supported codecs will be handled via DirectStream (remux to HLS)
-    // by the StreamBuilder, which checks video/audio codec support independently.
+    // MKV: browsers can NOT play MKV containers directly via MSE, but
+    // Capacitor native paths use ExoPlayer (Android) / AVPlayer (iOS),
+    // both of which demux MKV in their own pipelines. Advertising MKV
+    // support unlocks the DirectPlay path on native — the backend
+    // streams the source file untouched instead of remuxing to HLS.
+    if (Capacitor.isNativePlatform()) {
+      containers.push('mkv', 'matroska');
+    }
 
     // --- Detect supported video codecs ---
     const videoCodecs: string[] = [];

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -101,14 +101,9 @@ export class BrowserDeviceProfileService {
     const containers: string[] = [];
     if (this.testType(video, hasMSE, 'video/mp4')) containers.push('mp4', 'm4v', 'mov');
     if (this.testType(video, hasMSE, 'video/webm')) containers.push('webm');
-    // MKV: browsers can NOT play MKV containers directly via MSE, but
-    // Capacitor native paths use ExoPlayer (Android) / AVPlayer (iOS),
-    // both of which demux MKV in their own pipelines. Advertising MKV
-    // support unlocks the DirectPlay path on native — the backend
-    // streams the source file untouched instead of remuxing to HLS.
-    if (Capacitor.isNativePlatform()) {
-      containers.push('mkv', 'matroska');
-    }
+    // MKV: browsers can NOT play MKV containers directly. Do NOT add 'mkv' here.
+    // MKV files with supported codecs will be handled via DirectStream (remux to HLS)
+    // by the StreamBuilder, which checks video/audio codec support independently.
 
     // --- Detect supported video codecs ---
     const videoCodecs: string[] = [];

--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -112,16 +112,7 @@ export class CastPlayerService {
    *  Without cached caps (first cast to a new device, or older receiver
    *  that doesn't answer the probe), we fall back to AAC-only stereo — a
    *  Cast generation we don't recognise is safer downmixed than failing
-   *  to play.
-   *
-   *  `useTs` is conditional on the path:
-   *  - Stereo (AAC re-encode) → `useTs=true`. fMP4 + AAC suffers from the
-   *    encoder priming desync (~44 ms) because Shaka on Cast ignores the
-   *    init segment `edts/elst` atom. TS sidesteps the issue.
-   *  - Surround (AC-3 / EAC-3 re-encode) → `useTs=false`. Dolby codecs
-   *    have no encoder priming (MDCT overlap is built into the codec, not
-   *    extra lookahead) and AC-3 in TS doesn't survive the receiver's
-   *    Shaka transmuxer to fMP4 for MSE (error 4032), so fMP4 is required. */
+   *  to play. */
   private getCastDeviceProfile(): DeviceProfile {
     const cs = this.castSettings.get();
     const maxChannels = cs.audioChannels ?? 2;

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -98,9 +98,20 @@ import { PlayerStatsOverlayComponent, PlayerStats } from './overlay/player-stats
       cursor: none;
     }
     .player-video {
+      position: absolute;
+      inset: 0;
       width: 100%;
       height: 100%;
       object-fit: contain;
+      /* Override Tailwind preflight's `max-width: 100%; height: auto`
+       * for <video>: it leaves the element at its intrinsic size when
+       * the container grows beyond the decoded frame's natural width,
+       * which surfaces as black bars on all four sides instead of
+       * letterboxing on the short axis only. The !important here only
+       * has to beat preflight (specificity 0,0,0 via :where) so it's
+       * cheap. */
+      max-width: none !important;
+      max-height: none !important;
     }
     /* Dim controls when HDR max brightness is active.
        Uses opacity on the direct child — safe for layout since controls are already

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -715,18 +715,27 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
           } else {
             // HLS transcode/remux — apply quality constraint before load to
             // stop ExoPlayer from picking 4K on a phone (slow transcode →
-            // A/V desync). Auto / original: no constraint, ExoPlayer
-            // picks the top rung the master advertises.
+            // A/V desync). `auto`: no constraint, ExoPlayer's ABR picks
+            // adaptively. `original`: pin to source dimensions so ABR
+            // can't downgrade (the user explicitly forced top quality).
+            // Specific rung: pin to that rung's width/height.
             const savedQualityId = this.activeQualityId();
-            if (savedQualityId !== 'auto' && savedQualityId !== 'original') {
-              const PROFILE_WIDTHS: Record<string, number> = {
-                '2160p': 3840, '1080p': 1920, '720p': 1280, '480p': 854,
-                '360p': 640, '240p': 426, '144p': 256,
-              };
-              const baseId = savedQualityId.replace(/-hdr$/, '');
-              const w = PROFILE_WIDTHS[baseId] ?? 1920;
-              const h = this.qualityManager.availableQualities()
-                .find(q => q.id === savedQualityId)?.height ?? 1080;
+            if (savedQualityId !== 'auto') {
+              let w: number;
+              let h: number;
+              if (savedQualityId === 'original') {
+                w = this.playbackInfo?.source?.width ?? 3840;
+                h = this.playbackInfo?.source?.height ?? 2160;
+              } else {
+                const PROFILE_WIDTHS: Record<string, number> = {
+                  '2160p': 3840, '1080p': 1920, '720p': 1280, '480p': 854,
+                  '360p': 640, '240p': 426, '144p': 256,
+                };
+                const baseId = savedQualityId.replace(/-hdr$/, '');
+                w = PROFILE_WIDTHS[baseId] ?? 1920;
+                h = this.qualityManager.availableQualities()
+                  .find(q => q.id === savedQualityId)?.height ?? 1080;
+              }
               (this.engine as NativeEngine).selectVariantTrack({ width: w, height: h });
             }
             const nativeStartQuality = savedQualityId !== 'auto' ? savedQualityId : undefined;

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -715,14 +715,16 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
           } else {
             // HLS transcode/remux — apply quality constraint before load to
             // stop ExoPlayer from picking 4K on a phone (slow transcode →
-            // A/V desync). Auto: no constraint, ExoPlayer picks adaptively.
+            // A/V desync). Auto / original: no constraint, ExoPlayer
+            // picks the top rung the master advertises.
             const savedQualityId = this.activeQualityId();
-            if (savedQualityId !== 'auto') {
+            if (savedQualityId !== 'auto' && savedQualityId !== 'original') {
               const PROFILE_WIDTHS: Record<string, number> = {
                 '2160p': 3840, '1080p': 1920, '720p': 1280, '480p': 854,
                 '360p': 640, '240p': 426, '144p': 256,
               };
-              const w = PROFILE_WIDTHS[savedQualityId] ?? 1920;
+              const baseId = savedQualityId.replace(/-hdr$/, '');
+              const w = PROFILE_WIDTHS[baseId] ?? 1920;
               const h = this.qualityManager.availableQualities()
                 .find(q => q.id === savedQualityId)?.height ?? 1080;
               (this.engine as NativeEngine).selectVariantTrack({ width: w, height: h });

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -103,9 +103,9 @@ import { PlayerStatsOverlayComponent, PlayerStats } from './overlay/player-stats
       width: 100%;
       height: 100%;
       object-fit: contain;
-      /* Override Tailwind preflight's `max-width: 100%; height: auto`
-       * for <video>: it leaves the element at its intrinsic size when
-       * the container grows beyond the decoded frame's natural width,
+      /* Override Tailwind preflight's max-width:100%/height:auto for
+       * video: it leaves the element at its intrinsic size when the
+       * container grows beyond the decoded frame's natural width,
        * which surfaces as black bars on all four sides instead of
        * letterboxing on the short axis only. The !important here only
        * has to beat preflight (specificity 0,0,0 via :where) so it's

--- a/client/src/app/features/settings/streaming/streaming.html
+++ b/client/src/app/features/settings/streaming/streaming.html
@@ -32,17 +32,6 @@
       <label class="label"><span class="label-text-alt text-base-content/50">{{ 'settings.streaming.qsv_preset_help' | translate }}</span></label>
     </div>
 
-    <!-- HDR encoding -->
-    <div class="divider">{{ 'settings.streaming.hdr_section' | translate }}</div>
-
-    <div class="form-control">
-      <label class="label cursor-pointer justify-start gap-3">
-        <input type="checkbox" class="toggle" [ngModel]="hevcHdrEnabled()" (ngModelChange)="hevcHdrEnabled.set($event)" />
-        <span class="label-text font-medium">{{ 'settings.streaming.hevc_hdr_enabled' | translate }}</span>
-      </label>
-      <label class="label"><span class="label-text-alt text-base-content/50">{{ 'settings.streaming.hevc_hdr_enabled_help' | translate }}</span></label>
-    </div>
-
     <!-- QSV advanced options (Intel Quick Sync only) -->
     <div class="divider">{{ 'settings.streaming.qsv_advanced' | translate }}</div>
 

--- a/client/src/app/features/settings/streaming/streaming.ts
+++ b/client/src/app/features/settings/streaming/streaming.ts
@@ -21,7 +21,6 @@ export class StreamingSettingsComponent implements OnInit {
   readonly segmentDuration = signal('3');
   readonly qsvPreset = signal('faster');
   readonly qsvLowPower = signal(false);
-  readonly hevcHdrEnabled = signal(true);
 
   async ngOnInit() {
     try {
@@ -29,7 +28,6 @@ export class StreamingSettingsComponent implements OnInit {
       this.segmentDuration.set(all['streaming_segment_duration'] ?? '3');
       this.qsvPreset.set(all['streaming_qsv_preset'] ?? 'faster');
       this.qsvLowPower.set(all['streaming_qsv_low_power'] === 'true');
-      this.hevcHdrEnabled.set(all['streaming_hevc_hdr_enabled'] !== 'false');
     } catch { /* interceptor */ }
     this.loading.set(false);
   }
@@ -41,7 +39,6 @@ export class StreamingSettingsComponent implements OnInit {
         streaming_segment_duration: this.segmentDuration(),
         streaming_qsv_preset: this.qsvPreset(),
         streaming_qsv_low_power: String(this.qsvLowPower()),
-        streaming_hevc_hdr_enabled: String(this.hevcHdrEnabled()),
       });
       this.toast.success(this.translate.instant('settings.streaming.saved'));
     } catch { /* interceptor */ }


### PR DESCRIPTION
## Summary

Reworks the transcoding pipeline around an explicit codec abstraction (encoder descriptors + registry + selector) so that codec choice, HDR variants, and bitrate ladders no longer live in tangled `if`/`switch` chains across the orchestrator. While that scaffolding is in place, fixes a number of streaming-path regressions surfaced along the way:

- **Codec abstraction** — `EncoderDescriptor` per `(codec, hwAccel, hdr)` triple, `EncoderRegistry` with HW-first / CPU-fallback resolve, `pickPrimaryVariant` selector with source-codec priority + efficiency ranking + quirks DB. The orchestrator now calls one `encoder.buildArgs(input)` instead of a 200-line dispatch switch.
- **Runtime encoder probe** — every descriptor gets a one-frame ffmpeg encode test at startup. VAAPI probes spin up a real `-init_hw_device vaapi + hwupload` so the test exercises the production pipeline. Blacklisted entries are skipped by `registry.resolve()`.
- **Encoder-first ffmpeg arg build** — resolves the encoder before the HW input setup runs and pins `effectiveHwAccel = encoder.hwAccel`. Without this, a CPU fallback (e.g. registry → libx264 because `h264_vaapi` failed its probe) ran on a VAAPI-decoded input and the filter chain blew up with `Function not implemented`.
- **Cinema-aspect HDR ladder** — the HDR ladder filter was `p.maxHeight <= sourceHeight`, which dropped the 2160p-hdr rung for IMAX masters (3840×2024). Aligned with the SDR helper that already used `maxWidth OR maxHeight`.
- **libx264 hardening** — `parseInt('1500k')` was dropping the `'k'` suffix and emitting `bufsize=3000M` (3 Gbits) on the 720p mobile rung; reuse `bitrateNum`. Early and main libx264 sessions now produce a byte-identical init.mp4: pinned `-preset veryfast -profile:v high`, no `-tune zerolatency`, so the SPS doesn't drift on `ref` / `bframes` / `weightp` between sessions and the player can mix init from one with segments from the other without corrupt frames.
- **HEVC HDR Android playback** — TextureView → SurfaceView in the native plugin (TextureView routes through GPU composition and clips HDR to SDR), media3 1.10.0 → 1.10.1 (fixes the `HlsChunkSource.createFallbackOptions` AIOBE crash on HEVC HDR).
- **Quality picker** — `'original'` pins to source dimensions instead of `99999×99999`; HDR rung names strip `-hdr` for `PROFILE_WIDTHS` lookup; prewarm skips `remux`/`original` (can't predict the actual rung).
- **Stats overlay correctness** — `stream-builder` now resolves through the registry too, so the reported \`hwAccel\` matches the encoder that actually runs (no more 'VAAPI' label while libx264 is on the wire).
- **Dedup pass** — extracted `profileFitsSource` / `profileResolution`, `requestedHwAccelFor`, `hdrColorArgs` / `hlgFromHdr10`, `qsvScaleFilter8bit` so the same rule isn't re-emitted in 4 places.

## Test plan

- [ ] HEVC HDR Android: image stays HDR (no TextureView SDR clipping), no `HlsChunkSource` crash on media3 1.10.1.
- [ ] Player 'original' on 4K HDR: native engine pins to 2160p variant.
- [ ] Quality switch: existing `selectVariantTrack` path still works, no unload/reload of Shaka.
- [ ] Encoder probe summary at boot lists the expected enabled / disabled descriptors for the host.
- [ ] Stats overlay shows the same encoder string that appears in the FFmpeg start log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)