### PR TITLE
fix(streaming): audit follow-ups red + orange priority

### DIFF
--- a/backend/src/modules/metadata-providers/providers/tvdb.provider.ts
+++ b/backend/src/modules/metadata-providers/providers/tvdb.provider.ts
@@ -8,6 +8,7 @@ import {
   SeasonDetails,
   PersonDetails,
   PersonCombinedCredits,
+  PersonCreditItem,
   ExternalIdResult,
 } from '../interfaces/metadata-provider.interface';
 import type {
@@ -376,24 +377,24 @@ export class TvdbProvider implements IMetadataProvider {
     );
     const chars = data.data?.characters ?? [];
 
-    const cast = chars
+    const cast: PersonCreditItem[] = chars
       .filter((c) => c.peopleType === 'Actor' || c.peopleType === 'Guest Star')
       .map((c) => ({
         externalId: c.seriesId ?? c.movieId ?? 0,
         title: '',
-        mediaType: (c.movieId ? 'movie' : 'series') as 'movie' | 'series',
+        mediaType: c.movieId ? 'movie' : 'series',
         character: c.name,
         posterUrl: c.image ?? null,
         releaseDate: null,
         rating: 0,
       }));
 
-    const crew = chars
+    const crew: PersonCreditItem[] = chars
       .filter((c) => c.peopleType !== 'Actor' && c.peopleType !== 'Guest Star')
       .map((c) => ({
         externalId: c.seriesId ?? c.movieId ?? 0,
         title: '',
-        mediaType: (c.movieId ? 'movie' : 'series') as 'movie' | 'series',
+        mediaType: c.movieId ? 'movie' : 'series',
         job: c.peopleType,
         department: c.peopleType,
         posterUrl: c.image ?? null,

--- a/backend/src/modules/streaming/transcoding/codec/encoders/av1-qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/av1-qsv.ts
@@ -1,6 +1,7 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { av1CodecString } from '../codec-strings';
 import { hdrColorArgs } from './helpers/hdr-variants';
+import { qsvScaleFilter8bit, qsvScaleFilter10bit } from './helpers/qsv-filters';
 
 /** Intel QSV AV1 encoder — Arc (DG2) and Meteor Lake iGPU and above on
  *  Linux 6.2+. Same VAAPI-decode → scale_vaapi → hwmap-to-qsv chain as
@@ -14,46 +15,31 @@ export const av1Qsv: EncoderDescriptor = {
   supportsHdrMetadata: () => false,
   codecString: (target: EncoderTarget) => av1CodecString(target, 8),
   buildArgs(input: EncoderInput): string[] {
-    const { target, preset, qsv, filters, tonemap } = input;
-    const w = target.width;
-    const common = [
-      '-c:v', 'av1_qsv',
-      '-preset', preset,
-      ...qsv.extra,
-      '-mbbrc', '1',
-      '-b:v', String(target.videoBitrateBps),
-      '-maxrate', String(target.videoBitrateBps + 1),
-      '-rc_init_occupancy', String(qsv.rcInitOccupancy),
-      '-bufsize', String(qsv.bufsize),
-    ];
-    const trailing = [
-      '-g', String(target.gopSize),
-      '-keyint_min', String(target.gopSize),
-      '-force_key_frames', input.forceKeyframesExpr,
-    ];
-
-    if (filters.tonemapVaapi) {
-      return [
-        ...common,
-        '-vf',
-        `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`,
-        ...trailing,
-      ];
-    }
-    if (filters.tonemapOpencl) {
-      return [
-        ...common,
-        '-vf',
-        `scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`,
-        ...trailing,
-      ];
-    }
-    void tonemap;
+    const { target, preset, qsv } = input;
     return [
-      ...common,
+      '-c:v',
+      'av1_qsv',
+      '-preset',
+      preset,
+      ...qsv.extra,
+      '-mbbrc',
+      '1',
+      '-b:v',
+      String(target.videoBitrateBps),
+      '-maxrate',
+      String(target.videoBitrateBps + 1),
+      '-rc_init_occupancy',
+      String(qsv.rcInitOccupancy),
+      '-bufsize',
+      String(qsv.bufsize),
       '-vf',
-      `scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
-      ...trailing,
+      qsvScaleFilter8bit(input),
+      '-g',
+      String(target.gopSize),
+      '-keyint_min',
+      String(target.gopSize),
+      '-force_key_frames',
+      input.forceKeyframesExpr,
     ];
   },
 };
@@ -72,22 +58,32 @@ export const av1QsvHdr10: EncoderDescriptor = {
   codecString: (target: EncoderTarget) => av1CodecString(target, 10),
   buildArgs(input: EncoderInput): string[] {
     const { target, preset, qsv } = input;
-    const w = target.width;
     return [
-      '-c:v', 'av1_qsv',
-      '-pix_fmt', 'p010le',
-      '-preset', preset,
+      '-c:v',
+      'av1_qsv',
+      '-pix_fmt',
+      'p010le',
+      '-preset',
+      preset,
       ...qsv.extra,
-      '-mbbrc', '1',
-      '-b:v', String(target.videoBitrateBps),
-      '-maxrate', String(target.videoBitrateBps + 1),
-      '-rc_init_occupancy', String(qsv.rcInitOccupancy),
-      '-bufsize', String(qsv.bufsize),
+      '-mbbrc',
+      '1',
+      '-b:v',
+      String(target.videoBitrateBps),
+      '-maxrate',
+      String(target.videoBitrateBps + 1),
+      '-rc_init_occupancy',
+      String(qsv.rcInitOccupancy),
+      '-bufsize',
+      String(qsv.bufsize),
       '-vf',
-      `scale_vaapi=w=${w}:h=-16:format=p010le:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`,
-      '-g', String(target.gopSize),
-      '-keyint_min', String(target.gopSize),
-      '-force_key_frames', input.forceKeyframesExpr,
+      qsvScaleFilter10bit(input),
+      '-g',
+      String(target.gopSize),
+      '-keyint_min',
+      String(target.gopSize),
+      '-force_key_frames',
+      input.forceKeyframesExpr,
       ...hdrColorArgs('HDR10'),
     ];
   },

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
@@ -50,6 +50,30 @@ export function qsvScaleFilter8bit(input: EncoderInput): string {
   return `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`;
 }
 
+/** Build the `-vf` value for a 10-bit QSV encode (hevc_qsv main10,
+ *  av1_qsv hdr10). Same shape as {@link qsvScaleFilter8bit} but the
+ *  HW surfaces stay in `p010le` and there are no tonemap branches —
+ *  the encoder is producing HDR, so a tonemap would defeat the
+ *  bitstream's HDR signaling. Tonemap-to-SDR HDR sources never reach
+ *  a 10-bit HDR encoder; the registry routes them to an SDR rung
+ *  with the matching 8-bit descriptor. */
+export function qsvScaleFilter10bit(input: EncoderInput): string {
+  const { target, filters, hasCrop } = input;
+  const w = target.width;
+  if (input.inputSurface === 'qsv') {
+    const cropArgs =
+      hasCrop && filters.cropStr ? parseCropStr(filters.cropStr) : null;
+    const targetH = cropArgs
+      ? snapEven(Math.round((w * cropArgs.h) / cropArgs.w))
+      : target.height;
+    const cropOpts = cropArgs
+      ? `cw=${cropArgs.w}:ch=${cropArgs.h}:cx=${cropArgs.x}:cy=${cropArgs.y}:`
+      : '';
+    return `vpp_qsv=${cropOpts}w=${w}:h=${targetH}:format=p010le`;
+  }
+  return `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:format=p010le:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`;
+}
+
 function parseCropStr(
   cropStr: string,
 ): { w: number; h: number; x: number; y: number } | null {

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-qsv.ts
@@ -1,7 +1,7 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
 import { hdrColorArgs, hlgFromHdr10 } from './helpers/hdr-variants';
-import { qsvScaleFilter8bit } from './helpers/qsv-filters';
+import { qsvScaleFilter8bit, qsvScaleFilter10bit } from './helpers/qsv-filters';
 
 /** Intel QSV HEVC Main 8-bit encoder — Skylake gen6 and above. Native
  *  HW path for HEVC SDR sources; avoids the libx265 CPU round-trip the
@@ -24,19 +24,31 @@ export const hevcQsv: EncoderDescriptor = {
     // luminance and the BT.709 SPS tags downstream would render
     // washed-out greys.
     return [
-      '-c:v', 'hevc_qsv',
-      '-preset', preset,
+      '-c:v',
+      'hevc_qsv',
+      '-preset',
+      preset,
       ...qsv.extra,
-      '-mbbrc', '1',
-      '-b:v', String(target.videoBitrateBps),
-      '-maxrate', String(target.videoBitrateBps + 1),
-      '-rc_init_occupancy', String(qsv.rcInitOccupancy),
-      '-bufsize', String(qsv.bufsize),
-      '-vf', qsvScaleFilter8bit(input),
-      '-g', String(target.gopSize),
-      '-keyint_min', String(target.gopSize),
-      '-force_key_frames', input.forceKeyframesExpr,
-      '-tag:v', 'hvc1',
+      '-mbbrc',
+      '1',
+      '-b:v',
+      String(target.videoBitrateBps),
+      '-maxrate',
+      String(target.videoBitrateBps + 1),
+      '-rc_init_occupancy',
+      String(qsv.rcInitOccupancy),
+      '-bufsize',
+      String(qsv.bufsize),
+      '-vf',
+      qsvScaleFilter8bit(input),
+      '-g',
+      String(target.gopSize),
+      '-keyint_min',
+      String(target.gopSize),
+      '-force_key_frames',
+      input.forceKeyframesExpr,
+      '-tag:v',
+      'hvc1',
     ];
   },
 };
@@ -54,59 +66,39 @@ export const hevcQsvHdr10: EncoderDescriptor = {
   supportsHdrMetadata: () => true,
   codecString: (target: EncoderTarget) => hevcMain10CodecString(target),
   buildArgs(input: EncoderInput): string[] {
-    const { target, preset, qsv, filters, hasCrop, inputSurface } = input;
-    const w = target.width;
+    const { target, preset, qsv } = input;
     return [
-      '-c:v', 'hevc_qsv',
-      '-profile:v', 'main10',
-      '-preset', preset,
+      '-c:v',
+      'hevc_qsv',
+      '-profile:v',
+      'main10',
+      '-preset',
+      preset,
       ...qsv.extra,
-      '-mbbrc', '1',
-      '-b:v', String(target.videoBitrateBps),
-      '-maxrate', String(target.videoBitrateBps + 1),
-      '-rc_init_occupancy', String(qsv.rcInitOccupancy),
-      '-bufsize', String(qsv.bufsize),
+      '-mbbrc',
+      '1',
+      '-b:v',
+      String(target.videoBitrateBps),
+      '-maxrate',
+      String(target.videoBitrateBps + 1),
+      '-rc_init_occupancy',
+      String(qsv.rcInitOccupancy),
+      '-bufsize',
+      String(qsv.bufsize),
       '-vf',
-      hevcQsvHdr10FilterChain({ w, target, filters, hasCrop, inputSurface }),
-      '-g', String(target.gopSize),
-      '-keyint_min', String(target.gopSize),
-      '-force_key_frames', input.forceKeyframesExpr,
+      qsvScaleFilter10bit(input),
+      '-g',
+      String(target.gopSize),
+      '-keyint_min',
+      String(target.gopSize),
+      '-force_key_frames',
+      input.forceKeyframesExpr,
       ...hdrColorArgs('HDR10'),
-      '-tag:v', 'hvc1',
+      '-tag:v',
+      'hvc1',
     ];
   },
 };
-
-/** Filter chain for the 10-bit HDR hevc_qsv encode. Two branches:
- *  - `inputSurface='qsv'` (qsv-native decoder, e.g. for HDR + crop):
- *    use `vpp_qsv` which handles crop + scale on the QSV device, p010le
- *    output. Requires explicit integer height — derived from the crop
- *    aspect.
- *  - default (vaapi decoder output): scale_vaapi + hwmap to qsv as
- *    before. */
-function hevcQsvHdr10FilterChain(args: {
-  w: number;
-  target: EncoderInput['target'];
-  filters: EncoderInput['filters'];
-  hasCrop: boolean;
-  inputSurface: EncoderInput['inputSurface'];
-}): string {
-  const { w, target, filters, hasCrop, inputSurface } = args;
-  if (inputSurface === 'qsv') {
-    const cropMatch =
-      hasCrop && filters.cropStr.match(/^crop=(\d+):(\d+):(\d+):(\d+)$/);
-    const cropOpts = cropMatch
-      ? `cw=${cropMatch[1]}:ch=${cropMatch[2]}:cx=${cropMatch[3]}:cy=${cropMatch[4]}:`
-      : '';
-    const targetH = cropMatch
-      ? Math.round((w * parseInt(cropMatch[2], 10)) / parseInt(cropMatch[1], 10)) -
-        (Math.round((w * parseInt(cropMatch[2], 10)) / parseInt(cropMatch[1], 10)) %
-          2)
-      : target.height;
-    return `vpp_qsv=${cropOpts}w=${w}:h=${targetH}:format=p010le`;
-  }
-  return `scale_vaapi=w=${w}:h=-16:format=p010le:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`;
-}
 
 /** Same encoder, HLG variant — only difference is the SPS VUI tag. */
 export const hevcQsvHlg: EncoderDescriptor = hlgFromHdr10(

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -1,18 +1,16 @@
 import { Logger } from '@nestjs/common';
 import * as path from 'path';
-import {
-  getSegmentDuration,
-  segmentIndexToSeconds,
-} from './constants';
+import { getSegmentDuration, segmentIndexToSeconds } from './constants';
 import { isHdrProfile, parseBitrateToBps } from './profiles';
 import { requestedHwAccelFor } from './hw-detect';
-import type {
-  BurnInSubtitle,
-  HwAccelType,
-  TranscodeProfile,
-} from './types';
+import type { BurnInSubtitle, HwAccelType, TranscodeProfile } from './types';
 import { encoderRegistry } from './codec/encoders';
-import type { BitDepth, CodecVariant, EncoderInput, VideoCodec } from './codec/types';
+import type {
+  BitDepth,
+  CodecVariant,
+  EncoderInput,
+  VideoCodec,
+} from './codec/types';
 import { decoderRegistry, findQsvNativeDecoder } from './codec/decoders';
 import { isDecoderEnabled } from './codec/decoder-probe';
 import { isVppQsvTonemapEnabled } from './codec/vpp-qsv-probe';
@@ -30,9 +28,11 @@ export interface BuildFfmpegArgsOptions {
   crop?: { width: number; height: number; x: number; y: number };
   videoOnly?: boolean;
   audioStreams?: { language?: string; title?: string }[];
-  /** Output codec variant. When set, drives the encoder lookup via
-   *  `encoderRegistry`. When omitted (legacy callers), the variant is
-   *  inferred from `isHdrProfile(profile.name)` + `hwAccel === 'qsv'`. */
+  /** Output codec variant. Drives the encoder lookup via
+   *  `encoderRegistry`. Required: a missing variant means the caller
+   *  lost the master-playlist variant for this session, which would
+   *  silently emit segments that contradict the manifest's CODECS
+   *  string and trip MSE's chunk-demuxer. */
   videoVariant?: CodecVariant;
   /** Source video codec from ffprobe (`'h264'`, `'hevc'`, `'av1'`, plus
    *  aliases `'avc1'`, `'hev1'`, `'av01'`). Drives decoder selection
@@ -125,7 +125,8 @@ export function buildFfmpegArgs(
   // Resume point for mid-file seek (`startSegment > 0`). Seek to T,
   // then `-copyts` (set after `-i` below) threads source PTS through
   // to the muxer so the first segment lands at tfdt = T × timescale.
-  const seekSeconds = startSegment > 0 ? segmentIndexToSeconds(startSegment) : 0;
+  const seekSeconds =
+    startSegment > 0 ? segmentIndexToSeconds(startSegment) : 0;
 
   // Force an IDR every `SEGMENT_DURATION` seconds so the HLS muxer can
   // cut segments on a uniform grid. On a seek-resume we use `-copyts`
@@ -142,10 +143,14 @@ export function buildFfmpegArgs(
   //    segment edges → HLS muxer can cut cleanly on each forced IDR.
   // See `docs/streaming/encoder-stability.md` for the full rationale.
   const qsvExtra: string[] = [
-    '-forced_idr', '1',
-    '-adaptive_i', '0',
-    '-bf', '0',
-    '-b_strategy', '0',
+    '-forced_idr',
+    '1',
+    '-adaptive_i',
+    '0',
+    '-bf',
+    '0',
+    '-b_strategy',
+    '0',
   ];
   if (qsvOptions.lowPower) {
     qsvExtra.push('-low_power', '1');
@@ -163,7 +168,9 @@ export function buildFfmpegArgs(
   } else {
     // Keep the no-cache fallback at LOG — cold-start scans are expected
     // only on rescan / import races, so each one is worth surfacing.
-    log.log('Probe: no cached streamInfo — running full FFmpeg scan (1s / 1MB)');
+    log.log(
+      'Probe: no cached streamInfo — running full FFmpeg scan (1s / 1MB)',
+    );
     args.push('-analyzeduration', '1000000', '-probesize', '1000000');
   }
 
@@ -200,9 +207,7 @@ export function buildFfmpegArgs(
     hwAccel === 'qsv' &&
     !burnIn?.filter &&
     normalisedSourceCodecPreflight != null &&
-    isDecoderEnabled(
-      `${normalisedSourceCodecPreflight}_qsv_native_decode`,
-    );
+    isDecoderEnabled(`${normalisedSourceCodecPreflight}_qsv_native_decode`);
   const qsvNativeAvailable =
     hasUsableQsvNativeDecoder &&
     !!crop &&
@@ -224,12 +229,21 @@ export function buildFfmpegArgs(
   // CPU encoder receives HW surfaces and the filter chain blows up
   // with `Function not implemented` / `Impossible to convert between
   // the formats supported by the filter`.
-  const isHdrOutput = isHdrProfile(profile.name);
-  const variant: CodecVariant =
-    videoVariant ??
-    (isHdrOutput && requestedHwAccel === 'qsv'
-      ? { codec: 'hevc', bitDepth: 10, hdr: 'HDR10' }
-      : { codec: 'h264', bitDepth: 8, hdr: null });
+  //
+  // `videoVariant` is required: callers must thread it from the
+  // ActiveStreamTracker so the segment bitstream matches the master
+  // playlist's CODECS string. Heuristic inference (profile name +
+  // hwAccel) silently produced HEVC when the manifest claimed H.264
+  // (or vice-versa) on cache misses — MSE then rejected the segments.
+  // Fail fast so the player retries after the next playback-info call
+  // repopulates the variant tracker.
+  if (!videoVariant) {
+    throw new Error(
+      `buildFfmpegArgs: missing videoVariant for profile "${profile.name}" — caller must pass it from ActiveStreamTracker`,
+    );
+  }
+  const variant: CodecVariant = videoVariant;
+  const isHdrOutput = variant.hdr !== null;
   const encoder = encoderRegistry.resolve(variant, requestedHwAccel);
   if (!encoder) {
     throw new Error(
@@ -278,8 +292,7 @@ export function buildFfmpegArgs(
   // usable' and the encoder crashes with exit=218. tonemap_vaapi has
   // no such dependency and runs end-to-end inside VAAPI / QSV.
   const useVaapiTonemap =
-    tonemap &&
-    (effectiveHwAccel === 'vaapi' || effectiveHwAccel === 'qsv');
+    tonemap && (effectiveHwAccel === 'vaapi' || effectiveHwAccel === 'qsv');
 
   // Resolve the decoder via the same registry pattern as the encoder.
   // The decoder picks how the source is brought into memory (HW device
@@ -292,9 +305,7 @@ export function buildFfmpegArgs(
   // The default qsv decoder emits VAAPI surfaces — kept as the safe
   // baseline for every other QSV path.
   const decoder: ReturnType<typeof decoderRegistry.resolve> =
-    qsvNativeAvailable &&
-    effectiveHwAccel === 'qsv' &&
-    normalisedSourceCodec
+    qsvNativeAvailable && effectiveHwAccel === 'qsv' && normalisedSourceCodec
       ? (findQsvNativeDecoder(normalisedSourceCodec) ??
         decoderRegistry.resolve(
           {
@@ -425,10 +436,14 @@ export function buildFfmpegArgs(
   // BT.709 tags on SDR sources).
   if (tonemap && !isHdrOutput) {
     args.push(
-      '-color_primaries', 'bt709',
-      '-color_trc', 'bt709',
-      '-colorspace', 'bt709',
-      '-color_range', 'tv',
+      '-color_primaries',
+      'bt709',
+      '-color_trc',
+      'bt709',
+      '-colorspace',
+      'bt709',
+      '-color_range',
+      'tv',
     );
   }
 
@@ -439,8 +454,7 @@ export function buildFfmpegArgs(
   // client-side via EXT-X-MEDIA. The picked track is signalled via
   // DEFAULT=YES in the master.m3u8 (see streaming.controller.ts).
   const userPickedAudio = audioStreamIndex != null && audioStreamIndex > 0;
-  const useVarStreamMap =
-    videoOnly && audioStreams && audioStreams.length > 1;
+  const useVarStreamMap = videoOnly && audioStreams && audioStreams.length > 1;
 
   if (useVarStreamMap) {
     // Single FFmpeg process for video + all audio renditions (perfect sync).
@@ -460,15 +474,23 @@ export function buildFfmpegArgs(
     }
 
     args.push(
-      '-f', 'hls',
-      '-hls_time', String(SEGMENT_DURATION),
-      '-hls_list_size', '0',
-      '-start_number', String(startSegment),
-      '-hls_segment_type', segType,
+      '-f',
+      'hls',
+      '-hls_time',
+      String(SEGMENT_DURATION),
+      '-hls_list_size',
+      '0',
+      '-start_number',
+      String(startSegment),
+      '-hls_segment_type',
+      segType,
       ...(useTs ? [] : ['-hls_fmp4_init_filename', 'init_%v.mp4']),
-      '-hls_flags', 'independent_segments',
-      '-var_stream_map', varParts.join(' '),
-      '-hls_segment_filename', path.join(outputDir, '%v', `seg-%04d.${segExt}`),
+      '-hls_flags',
+      'independent_segments',
+      '-var_stream_map',
+      varParts.join(' '),
+      '-hls_segment_filename',
+      path.join(outputDir, '%v', `seg-%04d.${segExt}`),
       path.join(outputDir, '%v', 'index.m3u8'),
     );
   } else {
@@ -487,14 +509,21 @@ export function buildFfmpegArgs(
     args.push(...audioArgs);
 
     args.push(
-      '-f', 'hls',
-      '-hls_time', String(SEGMENT_DURATION),
-      '-hls_list_size', '0',
-      '-start_number', String(startSegment),
-      '-hls_segment_type', segType,
+      '-f',
+      'hls',
+      '-hls_time',
+      String(SEGMENT_DURATION),
+      '-hls_list_size',
+      '0',
+      '-start_number',
+      String(startSegment),
+      '-hls_segment_type',
+      segType,
       ...(useTs ? [] : ['-hls_fmp4_init_filename', 'init.mp4']),
-      '-hls_segment_filename', path.join(outputDir, `seg-%04d.${segExt}`),
-      '-hls_flags', 'independent_segments',
+      '-hls_segment_filename',
+      path.join(outputDir, `seg-%04d.${segExt}`),
+      '-hls_flags',
+      'independent_segments',
       path.join(outputDir, 'index.m3u8'),
     );
   }
@@ -522,7 +551,9 @@ export function buildAudioOnlyFfmpegArgs(
 
   const args = ['-hide_banner', '-loglevel', 'warning'];
   if (trustedStreamInfo) {
-    log.debug?.('Probe [audio-only]: using cached streamInfo (0s / 200KB scan)');
+    log.debug?.(
+      'Probe [audio-only]: using cached streamInfo (0s / 200KB scan)',
+    );
     args.push('-analyzeduration', '0', '-probesize', '200000');
   } else {
     log.log(
@@ -531,7 +562,8 @@ export function buildAudioOnlyFfmpegArgs(
     args.push('-analyzeduration', '1000000', '-probesize', '1000000');
   }
 
-  const seekSeconds = startSegment > 0 ? segmentIndexToSeconds(startSegment) : 0;
+  const seekSeconds =
+    startSegment > 0 ? segmentIndexToSeconds(startSegment) : 0;
 
   if (startSegment > 0) {
     args.push('-ss', String(seekSeconds));
@@ -553,14 +585,21 @@ export function buildAudioOnlyFfmpegArgs(
   args.push('-c:a', 'aac', '-b:a', audioBitrate, '-ac', '2');
 
   args.push(
-    '-f', 'hls',
-    '-hls_time', String(SEGMENT_DURATION),
-    '-hls_list_size', '0',
-    '-start_number', String(startSegment),
-    '-hls_segment_type', segType,
+    '-f',
+    'hls',
+    '-hls_time',
+    String(SEGMENT_DURATION),
+    '-hls_list_size',
+    '0',
+    '-start_number',
+    String(startSegment),
+    '-hls_segment_type',
+    segType,
     ...(useTs ? [] : ['-hls_fmp4_init_filename', 'init.mp4']),
-    '-hls_segment_filename', path.join(outputDir, `seg-%04d.${segExt}`),
-    '-hls_flags', 'independent_segments',
+    '-hls_segment_filename',
+    path.join(outputDir, `seg-%04d.${segExt}`),
+    '-hls_flags',
+    'independent_segments',
     path.join(outputDir, 'index.m3u8'),
   );
 
@@ -596,7 +635,9 @@ export function buildRemuxArgs(
     log?.log('Probe [remux]: using cached streamInfo (0s / 200KB scan)');
     args.push('-analyzeduration', '0', '-probesize', '200000');
   } else {
-    log?.log('Probe [remux]: no cached streamInfo — running full FFmpeg scan (1s / 1MB)');
+    log?.log(
+      'Probe [remux]: no cached streamInfo — running full FFmpeg scan (1s / 1MB)',
+    );
     args.push('-analyzeduration', '1000000', '-probesize', '1000000');
   }
 
@@ -627,7 +668,14 @@ export function buildRemuxArgs(
     // Video-only remux for var_stream_map (audio served separately).
     args.push('-map', '0:v:0', '-c:v', 'copy', '-an');
   } else if (userPickedAudio) {
-    args.push('-map', '0:v:0', '-map', `0:a:${audioStreamIndex}`, '-c:v', 'copy');
+    args.push(
+      '-map',
+      '0:v:0',
+      '-map',
+      `0:a:${audioStreamIndex}`,
+      '-c:v',
+      'copy',
+    );
     if (copyAudio) {
       args.push('-c:a', 'copy');
     } else {
@@ -656,24 +704,34 @@ export function buildRemuxArgs(
   //     with "Too many packets buffered for output stream".
   if (sourceVideoCodec === 'hevc') {
     args.push(
-      '-tag:v', 'hvc1',
-      '-bsf:v', 'hevc_mp4toannexb',
-      '-max_muxing_queue_size', '2048',
+      '-tag:v',
+      'hvc1',
+      '-bsf:v',
+      'hevc_mp4toannexb',
+      '-max_muxing_queue_size',
+      '2048',
     );
   }
 
   args.push(
-    '-f', 'hls',
-    '-hls_time', String(SEGMENT_DURATION),
-    '-hls_list_size', '0',
-    '-start_number', String(startSegment),
-    '-hls_segment_type', 'fmp4',
-    '-hls_fmp4_init_filename', 'init.mp4',
-    '-hls_segment_filename', path.join(outputDir, 'seg-%04d.m4s'),
-    '-hls_flags', 'independent_segments',
+    '-f',
+    'hls',
+    '-hls_time',
+    String(SEGMENT_DURATION),
+    '-hls_list_size',
+    '0',
+    '-start_number',
+    String(startSegment),
+    '-hls_segment_type',
+    'fmp4',
+    '-hls_fmp4_init_filename',
+    'init.mp4',
+    '-hls_segment_filename',
+    path.join(outputDir, 'seg-%04d.m4s'),
+    '-hls_flags',
+    'independent_segments',
     path.join(outputDir, 'index.m3u8'),
   );
 
   return args;
 }
-

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -17,19 +17,26 @@ import {
   segmentIndexToSeconds,
   setSegmentDuration as applySegmentDuration,
 } from './constants';
-import { getHdrLadderForDevice, getLadderForDevice, isHdrProfile } from './profiles';
+import {
+  getHdrLadderForDevice,
+  getLadderForDevice,
+  isHdrProfile,
+} from './profiles';
 import {
   buildAudioOnlyFfmpegArgs,
   buildFfmpegArgs,
   buildRemuxArgs,
 } from './ffmpeg-args';
 import { detectHwAccel } from './hw-detect';
-import { ALL_DESCRIPTORS } from './codec/encoders';
+import { ALL_DESCRIPTORS, encoderRegistry } from './codec/encoders';
 import { runEncoderProbes } from './codec/encoder-probe';
 import { ALL_DECODERS } from './codec/decoders';
 import { runDecoderProbes } from './codec/decoder-probe';
 import { runVppQsvTonemapProbe } from './codec/vpp-qsv-probe';
-import { generateMasterPlaylist, getAvailableProfiles } from './master-playlist';
+import {
+  generateMasterPlaylist,
+  getAvailableProfiles,
+} from './master-playlist';
 import {
   fileExists,
   firstMissingSegment,
@@ -70,7 +77,10 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       if (entries.length) {
         await Promise.all(
           entries.map((e) =>
-            fsp.rm(path.join(this.cachePath, e), { recursive: true, force: true }),
+            fsp.rm(path.join(this.cachePath, e), {
+              recursive: true,
+              force: true,
+            }),
           ),
         );
         this.log.log(
@@ -233,7 +243,11 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       let maxSeg = -1;
       for (const dir of dirs) {
         let files: string[];
-        try { files = await fsp.readdir(dir); } catch { continue; }
+        try {
+          files = await fsp.readdir(dir);
+        } catch {
+          continue;
+        }
         for (const f of files) {
           const m = f.match(/^seg-(\d+)\.m4s$/);
           if (m) {
@@ -280,13 +294,18 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     },
     sdrVariant?: import('./codec/types').CodecVariant,
   ): string {
-    // Only the QSV branch in ffmpeg-args has `hevc_qsv Main10` wired —
-    // every other hwAccel hits libx264 for HEVC HDR profile names and
-    // produces H.264 segments that contradict the master's `hvc1.*`
-    // CODECS string. Skip the lower-res transcode rungs on non-QSV
-    // backends so we don't hand the player a manifest claim we can't
-    // fulfil. The top remux rung stays — `-c:v copy` works everywhere.
-    const canEncodeHevcHdr = this.detectedHwAccel === 'qsv';
+    // Ask the encoder registry whether any HEVC Main10 HDR10 encoder is
+    // probed-OK on the detected hwAccel (or CPU fallback). When false,
+    // the manifest skips lower-res HEVC HDR rungs so we don't advertise
+    // `hvc1.*` segments we can't actually produce — the top remux rung
+    // stays because `-c:v copy` works regardless of the encoder probe
+    // matrix. Pre-registry this was hard-coded to `qsv` and ignored
+    // libx265 + hevc_vaapi_main10, leaving valid HDR rungs off the
+    // manifest on AMD/CPU-only hosts.
+    const canEncodeHevcHdr = !!encoderRegistry.resolve(
+      { codec: 'hevc', bitDepth: 10, hdr: 'HDR10' },
+      this.detectedHwAccel,
+    );
     return generateMasterPlaylist(
       mediaFileId,
       sourceWidth,
@@ -376,19 +395,28 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         await this.killProcess(existing.process);
       } else {
         const resolved = await this.resolveExistingSession(
-          key, existing, requestedSegment, qualityMatch,
+          key,
+          existing,
+          requestedSegment,
+          qualityMatch,
         );
         if (resolved) return resolved;
         const restartAt = existing.startSegment ?? requestedSegment;
         const dir = path.join(this.cachePath, key, quality);
         await fsp.mkdir(dir, { recursive: true });
         if (useVarStreamMap) {
-          for (let i = 0; i <= ctxAudioStreams!.length; i++) {
+          for (let i = 0; i <= ctxAudioStreams.length; i++) {
             await fsp.mkdir(path.join(dir, String(i)), { recursive: true });
           }
         }
         return this.startSeekSession(
-          key, mediaFileId, quality, absolutePath, dir, restartAt, ctx,
+          key,
+          mediaFileId,
+          quality,
+          absolutePath,
+          dir,
+          restartAt,
+          ctx,
         );
       }
     }
@@ -405,7 +433,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     );
 
     if (useVarStreamMap) {
-      for (let i = 0; i <= ctxAudioStreams!.length; i++) {
+      for (let i = 0; i <= ctxAudioStreams.length; i++) {
         await fsp.mkdir(path.join(sessionDir, String(i)), { recursive: true });
       }
     }
@@ -458,8 +486,10 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     const segExts = ['.m4s', '.ts'];
     const segExists = async () => {
       for (const ext of segExts) {
-        if (await fileExists(path.join(sessionDir, `seg-${segNum}${ext}`))) return true;
-        if (await fileExists(path.join(sessionDir, '0', `seg-${segNum}${ext}`))) return true;
+        if (await fileExists(path.join(sessionDir, `seg-${segNum}${ext}`)))
+          return true;
+        if (await fileExists(path.join(sessionDir, '0', `seg-${segNum}${ext}`)))
+          return true;
       }
       return false;
     };
@@ -468,8 +498,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       if (await segExists()) break;
       await new Promise((r) => setTimeout(r, 500));
     }
-    const crashed =
-      session.process.exitCode !== null && !(await segExists());
+    const crashed = session.process.exitCode !== null && !(await segExists());
     if (!crashed) return session;
 
     return this.withLock(key, async () => {
@@ -483,8 +512,10 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       await this.killAndClean(session.process, sessionDir);
       await fsp.mkdir(sessionDir, { recursive: true });
       if (useVarStreamMap) {
-        for (let i = 0; i <= ctxAudioStreams!.length; i++) {
-          await fsp.mkdir(path.join(sessionDir, String(i)), { recursive: true });
+        for (let i = 0; i <= ctxAudioStreams.length; i++) {
+          await fsp.mkdir(path.join(sessionDir, String(i)), {
+            recursive: true,
+          });
         }
       }
       const cpuSession = this.startFfmpeg(
@@ -562,7 +593,9 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         isVideoOnly && ctxAudioStreams && ctxAudioStreams.length > 1;
       if (useVarStreamMap) {
         for (let i = 0; i <= ctxAudioStreams.length; i++) {
-          await fsp.mkdir(path.join(sessionDir, String(i)), { recursive: true });
+          await fsp.mkdir(path.join(sessionDir, String(i)), {
+            recursive: true,
+          });
         }
       }
 
@@ -804,7 +837,9 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         readyResolve();
       }
       if (code && code !== 0 && code !== 255) {
-        this.log.error(`FFmpeg [${id}] exited ${code}:\n${stderr.slice(-2000)}`);
+        this.log.error(
+          `FFmpeg [${id}] exited ${code}:\n${stderr.slice(-2000)}`,
+        );
       } else if (!firstSegProduced && !session.intentionallyKilled) {
         this.log.warn(
           `FFmpeg [${id}] exited code=${code} WITHOUT producing first segment ${firstSegName}\nstderr:\n${stderr.slice(-2000)}`,
@@ -955,26 +990,31 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       }
     }
     await Promise.all(promises);
-    const parentDir = path.join(this.cachePath, key);
-    if (!this.sessions.has(key)) {
+    // Parent-dir rm is serialised under the same per-key lock as
+    // getOrCreate to close a race: without the lock, a new session
+    // could enter getOrCreate between the `has(key)` probe below and
+    // the (previously async, fire-and-forget) rm completing, and the
+    // recursive rm would then wipe the new session's fresh segments.
+    // The lock makes "either rm the parent OR start a new session"
+    // atomic per key.
+    await this.removeParentDirIfIdle(key);
+    await this.removeParentDirIfIdle(earlyKey);
+  }
+
+  private async removeParentDirIfIdle(key: string): Promise<void> {
+    await this.withLock(key, async () => {
+      if (this.sessions.has(key)) {
+        const parentDir = path.join(this.cachePath, key);
+        this.log.log(
+          `[disk] skip rm parent ${parentDir} — session ${key} replaced`,
+        );
+        return;
+      }
+      const parentDir = path.join(this.cachePath, key);
       const existed = existsSync(parentDir);
       this.log.log(`[disk] rm parent ${parentDir} (existed=${existed})`);
-      fsp.rm(parentDir, { recursive: true, force: true }).catch(() => {});
-    } else {
-      this.log.log(
-        `[disk] skip rm parent ${parentDir} — session ${key} replaced`,
-      );
-    }
-    const earlyParentDir = path.join(this.cachePath, earlyKey);
-    if (!this.sessions.has(earlyKey)) {
-      const existed = existsSync(earlyParentDir);
-      this.log.log(`[disk] rm parent ${earlyParentDir} (existed=${existed})`);
-      fsp.rm(earlyParentDir, { recursive: true, force: true }).catch(() => {});
-    } else {
-      this.log.log(
-        `[disk] skip rm parent ${earlyParentDir} — session ${earlyKey} replaced`,
-      );
-    }
+      await fsp.rm(parentDir, { recursive: true, force: true }).catch(() => {});
+    });
   }
 
   /** Kill a session by its map key (used by admin dashboard). */
@@ -1039,7 +1079,10 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         await this.killAndClean(existing.process, existing.cachePath);
       } else {
         const resolved = await this.resolveExistingSession(
-          key, existing, requestedSegment, qualityMatch,
+          key,
+          existing,
+          requestedSegment,
+          qualityMatch,
         );
         if (resolved) return resolved;
         requestedSegment = existing.startSegment ?? requestedSegment;
@@ -1170,7 +1213,6 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     return session;
   }
 
-
   private cleanupStaleSessions() {
     const now = Date.now();
     for (const [id, session] of this.sessions) {
@@ -1227,9 +1269,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
   ): Promise<void> {
     await this.killProcess(proc, false);
     if (sessionId && this.sessions.has(sessionId)) {
-      this.log.log(
-        `[disk] skip rm ${dirPath} — session ${sessionId} replaced`,
-      );
+      this.log.log(`[disk] skip rm ${dirPath} — session ${sessionId} replaced`);
       return;
     }
     await fsp.rm(dirPath, { recursive: true, force: true });

--- a/client/src/app/core/services/playback-engine/cast-engine.ts
+++ b/client/src/app/core/services/playback-engine/cast-engine.ts
@@ -1,9 +1,8 @@
-import type {
-  PlaybackEngine,
-  AudioTrack,
-  EngineStats,
-  EngineEvent,
-  EngineEventMap,
+import {
+  AbstractPlaybackEngine,
+  type PlaybackEngine,
+  type AudioTrack,
+  type EngineStats,
 } from './playback-engine';
 
 /**
@@ -15,18 +14,19 @@ import type {
  * Since Cast doesn't expose a rich event model like Shaka or ExoPlayer,
  * we poll the CastService signals every second to emit engine events.
  */
-export class CastEngine implements PlaybackEngine {
+export class CastEngine extends AbstractPlaybackEngine implements PlaybackEngine {
   private _volume = 1;
   private _muted = false;
   private _playbackRate = 1;
 
-  private handlers = new Map<string, Set<Function>>();
   private pollTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(
     private castService: any, // CastService
     private castPlayerService: any, // CastPlayerService
-  ) {}
+  ) {
+    super();
+  }
 
   // ── Lifecycle ──
 
@@ -150,30 +150,6 @@ export class CastEngine implements PlaybackEngine {
 
   getStats(): EngineStats {
     return { droppedFrames: 0 };
-  }
-
-  // ── Events ──
-
-  on<E extends EngineEvent>(
-    event: E,
-    handler: (data: EngineEventMap[E]) => void,
-  ): void {
-    if (!this.handlers.has(event)) this.handlers.set(event, new Set());
-    this.handlers.get(event)!.add(handler);
-  }
-
-  off<E extends EngineEvent>(
-    event: E,
-    handler: (data: EngineEventMap[E]) => void,
-  ): void {
-    this.handlers.get(event)?.delete(handler);
-  }
-
-  private emit<E extends EngineEvent>(
-    event: E,
-    data: EngineEventMap[E],
-  ): void {
-    this.handlers.get(event)?.forEach((fn) => fn(data));
   }
 
   // ── Polling ──

--- a/client/src/app/core/services/playback-engine/native-engine.ts
+++ b/client/src/app/core/services/playback-engine/native-engine.ts
@@ -1,12 +1,11 @@
 import { Capacitor } from '@capacitor/core';
 import { NativePlayer } from '../../plugins/native-player.plugin';
-import type {
-  PlaybackEngine,
-  AudioTrack,
-  EngineStats,
-  PlaybackState,
-  EngineEvent,
-  EngineEventMap,
+import {
+  AbstractPlaybackEngine,
+  type PlaybackEngine,
+  type AudioTrack,
+  type EngineStats,
+  type PlaybackState,
 } from './playback-engine';
 
 interface VttCue {
@@ -21,7 +20,7 @@ interface VttCue {
  *
  * The native player renders behind the WebView — the Angular UI sits on top.
  */
-export class NativeEngine implements PlaybackEngine {
+export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngine {
   private _currentTime = 0;
   private _duration = 0;
   private _buffered = 0;
@@ -33,7 +32,6 @@ export class NativeEngine implements PlaybackEngine {
   private _audioTracks: AudioTrack[] = [];
   private _variantTracks: any[] = [];
 
-  private handlers = new Map<string, Set<Function>>();
   private listeners: Array<{ event: string; fn: EventListener }> = [];
   private positionPoll: ReturnType<typeof setInterval> | null = null;
 
@@ -291,30 +289,6 @@ export class NativeEngine implements PlaybackEngine {
       // Auto mode: remove resolution constraints
       NativePlayer.setMaxResolution({ width: 0, height: 0 });
     }
-  }
-
-  // ── Events ──
-
-  on<E extends EngineEvent>(
-    event: E,
-    handler: (data: EngineEventMap[E]) => void,
-  ): void {
-    if (!this.handlers.has(event)) this.handlers.set(event, new Set());
-    this.handlers.get(event)!.add(handler);
-  }
-
-  off<E extends EngineEvent>(
-    event: E,
-    handler: (data: EngineEventMap[E]) => void,
-  ): void {
-    this.handlers.get(event)?.delete(handler);
-  }
-
-  private emit<E extends EngineEvent>(
-    event: E,
-    data: EngineEventMap[E],
-  ): void {
-    this.handlers.get(event)?.forEach((fn) => fn(data));
   }
 
   // ── Window event bridge ──

--- a/client/src/app/core/services/playback-engine/playback-engine.ts
+++ b/client/src/app/core/services/playback-engine/playback-engine.ts
@@ -56,6 +56,44 @@ export type EngineEventMap = {
 
 export type EngineEvent = keyof EngineEventMap;
 
+export type EngineEventHandler<E extends EngineEvent> = (
+  data: EngineEventMap[E],
+) => void;
+
+// ---------------------------------------------------------------------------
+// Base class — shared event bus
+// ---------------------------------------------------------------------------
+
+/** Common event-bus plumbing for every PlaybackEngine. Subclasses
+ *  inherit on/off and call `this.emit(event, data)` from their own
+ *  bridge code (video element listeners, Capacitor window events, Cast
+ *  polling). Keeps the typed handler map identical across engines so
+ *  divergence on event semantics can't sneak in by accident. */
+export abstract class AbstractPlaybackEngine {
+  private handlers = new Map<EngineEvent, Set<EngineEventHandler<any>>>();
+
+  on<E extends EngineEvent>(event: E, handler: EngineEventHandler<E>): void {
+    if (!this.handlers.has(event)) this.handlers.set(event, new Set());
+    this.handlers.get(event)!.add(handler);
+  }
+
+  off<E extends EngineEvent>(event: E, handler: EngineEventHandler<E>): void {
+    this.handlers.get(event)?.delete(handler);
+  }
+
+  protected emit<E extends EngineEvent>(
+    event: E,
+    data: EngineEventMap[E],
+  ): void {
+    const set = this.handlers.get(event);
+    if (set) for (const h of set) h(data);
+  }
+
+  protected clearHandlers(): void {
+    this.handlers.clear();
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Interface
 // ---------------------------------------------------------------------------

--- a/client/src/app/core/services/playback-engine/shaka-engine.ts
+++ b/client/src/app/core/services/playback-engine/shaka-engine.ts
@@ -1,14 +1,11 @@
 import shaka from 'shaka-player';
 import {
+  AbstractPlaybackEngine,
   AudioTrack,
-  EngineEvent,
-  EngineEventMap,
   EngineStats,
   PlaybackEngine,
   PlaybackState,
 } from './playback-engine';
-
-type Handler<E extends EngineEvent> = (data: EngineEventMap[E]) => void;
 
 /**
  * Shaka Player implementation of the PlaybackEngine interface.
@@ -18,13 +15,10 @@ type Handler<E extends EngineEvent> = (data: EngineEventMap[E]) => void;
  *
  * This is a plain TypeScript class with NO Angular dependencies.
  */
-export class ShakaEngine implements PlaybackEngine {
+export class ShakaEngine extends AbstractPlaybackEngine implements PlaybackEngine {
 
   private player: shaka.Player | null = null;
   private video: HTMLVideoElement | null = null;
-
-  /** Per-event listener maps for the unified event system. */
-  private listeners = new Map<EngineEvent, Set<Handler<any>>>();
 
   /** Refs kept so we can removeEventListener on destroy. */
   private videoListeners: Array<{ event: string; handler: EventListener }> = [];
@@ -102,7 +96,7 @@ export class ShakaEngine implements PlaybackEngine {
     }
 
     this.video = null;
-    this.listeners.clear();
+    this.clearHandlers();
   }
 
   async load(url: string, startTime?: number, mimeType?: string, _headers?: Record<string, string>): Promise<void> {
@@ -273,28 +267,6 @@ export class ShakaEngine implements PlaybackEngine {
           }
         : undefined,
     };
-  }
-
-  // ─── Events ────────────────────────────────────────────────────────
-
-  on<E extends EngineEvent>(event: E, handler: Handler<E>): void {
-    if (!this.listeners.has(event)) {
-      this.listeners.set(event, new Set());
-    }
-    this.listeners.get(event)!.add(handler);
-  }
-
-  off<E extends EngineEvent>(event: E, handler: Handler<E>): void {
-    this.listeners.get(event)?.delete(handler);
-  }
-
-  private emit<E extends EngineEvent>(event: E, data: EngineEventMap[E]): void {
-    const handlers = this.listeners.get(event);
-    if (handlers) {
-      for (const h of handlers) {
-        h(data);
-      }
-    }
   }
 
   // ─── Internal: bridge native events ────────────────────────────────

--- a/client/src/app/core/services/quality-manager.service.ts
+++ b/client/src/app/core/services/quality-manager.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, signal } from '@angular/core';
 import type { PlaybackEngine } from './playback-engine/playback-engine';
+import { widthForProfile } from '../utils/player.utils';
 
 export interface QualityOption {
   id: string;      // 'auto' | 'original' | '2160p' | '1080p' | '720p' | '480p' | ...
@@ -181,14 +182,14 @@ export class QualityManagerService {
     const allTracks = engine.getVariantTracks();
 
     if (!allTracks.length) {
-      // No variant tracks (native player) — use profile maxWidth to set resolution constraint.
-      // Must match backend PROFILES exactly to avoid off-by-one with ExoPlayer track selection.
-      const PROFILE_WIDTHS: Record<string, number> = {
-        '2160p': 3840, '1080p': 1920, '720p': 1280, '480p': 854,
-        '360p': 640, '240p': 426, '144p': 256, 'original': 99999,
-      };
-      const w = PROFILE_WIDTHS[option.id] ?? Math.round(option.height * 16 / 9);
-      const h = option.id === 'original' ? 99999 : option.height;
+      // No variant tracks (native player) — use profile maxWidth to set
+      // resolution constraint. Must match backend PROFILES exactly to
+      // avoid off-by-one with ExoPlayer track selection.
+      const isOriginal = option.id === 'original';
+      const w = isOriginal
+        ? 99999
+        : (widthForProfile(option.id) ?? Math.round(option.height * 16 / 9));
+      const h = isOriginal ? 99999 : option.height;
       engine.selectVariantTrack({ height: h, width: w }, true);
       return;
     }

--- a/client/src/app/core/utils/player.utils.ts
+++ b/client/src/app/core/utils/player.utils.ts
@@ -1,6 +1,34 @@
 import type { TranslateService } from '@ngx-translate/core';
 import { localizeLanguage } from './language.utils';
 
+/** Pixel widths backing each ladder rung id (must match the backend
+ *  `PROFILES` table). Used by NativeEngine + quality-manager to set
+ *  ExoPlayer's max-resolution constraint; ExoPlayer matches tracks by
+ *  exact width × height, so a 1px mismatch silently picks the wrong
+ *  rung.
+ *
+ *  `original` is intentionally absent — call sites that need it pass a
+ *  sentinel resolution directly (the source dimensions, or 99999 when
+ *  the source isn't known yet). */
+export const PROFILE_WIDTHS: Record<string, number> = {
+  '2160p': 3840,
+  '1080p': 1920,
+  '720p': 1280,
+  '480p': 854,
+  '360p': 640,
+  '240p': 426,
+  '144p': 256,
+};
+
+/** Resolve a quality id (`'1080p'`, `'1080p-hdr'`, `'original'`, …) to
+ *  the rung width. Strips an `-hdr` suffix because HDR rungs share the
+ *  resolution of their SDR sibling. Returns `undefined` for unknown ids
+ *  so the caller can apply its own fallback. */
+export function widthForProfile(id: string): number | undefined {
+  const base = id.replace(/-hdr$/, '');
+  return PROFILE_WIDTHS[base];
+}
+
 /** Format seconds to h:mm:ss or m:ss. */
 export function formatTime(seconds: number): string {
   if (!seconds || !isFinite(seconds)) return '0:00';

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -33,7 +33,7 @@ import { CastSettingsService } from '../../core/services/cast-settings.service';
 import { ServerConfigService } from '../../core/services/server-config.service';
 import { NavigationHistoryService } from '../../core/services/navigation-history.service';
 import { NavbarService } from '../../core/services/navbar.service';
-import { formatAudioLabel, parseAudioIndex, SpriteMetadata } from '../../core/utils/player.utils';
+import { formatAudioLabel, parseAudioIndex, SpriteMetadata, widthForProfile } from '../../core/utils/player.utils';
 import {
   PlayerSettingsService, normalizeLang,
   SUBTITLE_SIZE_MAP, SUBTITLE_COLOR_MAP, SUBTITLE_SHADOW_MAP, SUBTITLE_BG_MAP,
@@ -738,12 +738,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
                 w = this.playbackInfo?.source?.width ?? 3840;
                 h = this.playbackInfo?.source?.height ?? 2160;
               } else {
-                const PROFILE_WIDTHS: Record<string, number> = {
-                  '2160p': 3840, '1080p': 1920, '720p': 1280, '480p': 854,
-                  '360p': 640, '240p': 426, '144p': 256,
-                };
-                const baseId = savedQualityId.replace(/-hdr$/, '');
-                w = PROFILE_WIDTHS[baseId] ?? 1920;
+                w = widthForProfile(savedQualityId) ?? 1920;
                 h = this.qualityManager.availableQualities()
                   .find(q => q.id === savedQualityId)?.height ?? 1080;
               }


### PR DESCRIPTION
## Summary

Six fixes from the post-merge stream/player audit.

### 🔴 Critical
- **Variant cache miss → fail-fast** (`ffmpeg-args.ts`). The heuristic fallback (HDR+qsv → HEVC, else H.264) silently produced segments that contradicted master.m3u8's CODECS string when ActiveStreamTracker lost the variant, tripping MSE chunk-demuxer. Throw explicitly instead.
- **Race kill/rm parent dir** (`transcoding.service.ts`). Fire-and-forget recursive rm could wipe a fresh session's cache when a new getOrCreate raced into the same key between the `has()` probe and rm completion. Now serialised under the same `withLock(key)` as getOrCreate via `removeParentDirIfIdle()`.

### 🟠 Important
- **`canEncodeHevcHdr` via registry** (`transcoding.service.ts:289`). Was `detectedHwAccel === 'qsv'` — replaced with `encoderRegistry.resolve({hevc, 10, HDR10}, detectedHwAccel)` so CPU libx265 + hevc_vaapi_main10 contribute HDR rungs on non-Intel hosts.
- **AbstractPlaybackEngine** base class (`playback-engine.ts`). Shaka/Native/Cast now share the typed event bus (on/off/emit) instead of triplicating the `Map<string, Set<Function>>` plumbing.
- **PROFILE_WIDTHS hoist** (`player.utils.ts`). Single map + `widthForProfile(id)` helper, consumed by `player.ts` and `quality-manager.service.ts`. Strips `-hdr` once.
- **av1-qsv use shared helpers** (`av1-qsv.ts`, `hevc-qsv.ts`). Added `qsvScaleFilter10bit` and routed every QSV encoder through it; av1QsvHdr10 also picks up the `hwCropPrefix` branch it was missing.

### Plus
- Narrow `tvdb.provider.ts` PersonCreditItem mediaType so strict tsc passes on the watch loop.

## Test plan

- [ ] `npx tsc --noEmit` clean on backend + client
- [ ] Boot probes still run on a fresh container (encoder + decoder + vpp_qsv)
- [ ] H.264 SDR transcode plays end-to-end (Shaka, Native Android, Cast)
- [ ] HEVC Main10 HDR10 transcode plays with vpp_qsv tonemap path
- [ ] HDR + crop combo plays without filter graph errors
- [ ] Quality switch (1080p → 2160p-hdr) on Android selects correct width via `widthForProfile`
- [ ] Quick close+replay doesn't lose seg-0 (race rm fix)