### PR TITLE
perf(streaming): atomic segments + drop redundant fallback poll

### DIFF
--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -479,7 +479,7 @@ export function buildFfmpegArgs(
       segType,
       ...(useTs ? [] : ['-hls_fmp4_init_filename', 'init_%v.mp4']),
       '-hls_flags',
-      'independent_segments',
+      'independent_segments+temp_file',
       '-var_stream_map',
       varParts.join(' '),
       '-hls_segment_filename',
@@ -516,7 +516,7 @@ export function buildFfmpegArgs(
       '-hls_segment_filename',
       path.join(outputDir, `seg-%04d.${segExt}`),
       '-hls_flags',
-      'independent_segments',
+      'independent_segments+temp_file',
       path.join(outputDir, 'index.m3u8'),
     );
   }
@@ -592,7 +592,7 @@ export function buildAudioOnlyFfmpegArgs(
     '-hls_segment_filename',
     path.join(outputDir, `seg-%04d.${segExt}`),
     '-hls_flags',
-    'independent_segments',
+    'independent_segments+temp_file',
     path.join(outputDir, 'index.m3u8'),
   );
 
@@ -722,7 +722,7 @@ export function buildRemuxArgs(
     '-hls_segment_filename',
     path.join(outputDir, 'seg-%04d.m4s'),
     '-hls_flags',
-    'independent_segments',
+    'independent_segments+temp_file',
     path.join(outputDir, 'index.m3u8'),
   );
 

--- a/backend/src/modules/streaming/transcoding/segment-utils.ts
+++ b/backend/src/modules/streaming/transcoding/segment-utils.ts
@@ -58,18 +58,3 @@ export function firstMissingSegment(
   return null;
 }
 
-/**
- * 50ms size-stability check. Returns true when the file exists, is non-empty,
- * and its size hasn't changed in 50ms (= ffmpeg finished writing this segment).
- */
-export async function isSegmentStable(segPath: string): Promise<boolean> {
-  try {
-    const s1 = (await fsp.stat(segPath)).size;
-    if (s1 === 0) return false;
-    await new Promise((r) => setTimeout(r, 50));
-    const s2 = (await fsp.stat(segPath)).size;
-    return s1 === s2;
-  } catch {
-    return false;
-  }
-}

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -40,7 +40,6 @@ import {
 import {
   fileExists,
   firstMissingSegment,
-  isSegmentStable,
   segmentNearby,
 } from './segment-utils';
 import { audioSessionKey, earlySessionKey, sessionKey } from './session-key';
@@ -460,10 +459,12 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
   /**
    * Verify HW accel didn't crash on spawn; fall back to CPU if it did.
    *
-   * Runs OUTSIDE the session-creation lock — awaits session.ready + up to 5s
-   * of polling which would otherwise block every concurrent segment request
-   * on this key (seen as 10s Shaka timeouts during pre-start of big 4K/HDR
-   * sources where the first segment takes 15-30s to appear).
+   * Runs OUTSIDE the session-creation lock — `session.ready` is the
+   * coordination point: `spawnFfmpegSession` resolves it either when
+   * seg-0 lands on disk (happy path) or when the ffmpeg process closes
+   * (crash safety net). After the await, a non-zero exitCode with no
+   * segment on disk means the HW path failed — kill it and respawn on
+   * CPU.
    */
   private async verifyHwAccelOrFallback(
     session: TranscodeSession,
@@ -497,11 +498,6 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       }
       return false;
     };
-    for (let i = 0; i < 10; i++) {
-      if (session.process.exitCode !== null) break;
-      if (await segExists()) break;
-      await new Promise((r) => setTimeout(r, 500));
-    }
     const crashed = session.process.exitCode !== null && !(await segExists());
     if (!crashed) return session;
 
@@ -672,8 +668,10 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
    * Get a segment file path, waiting if it's being generated.
    *
    * Uses fs.watch (inotify on Linux) so we react within milliseconds of
-   * ffmpeg writing the segment. Without `temp_file`, ffmpeg writes segments
-   * incrementally so we verify size-stability (50ms re-stat) before serving.
+   * ffmpeg's atomic rename. `-hls_flags +temp_file` (set by
+   * `ffmpeg-args.ts`) makes ffmpeg write each segment to `*.tmp` and
+   * rename to the final name once flushed, so seeing the final name on
+   * disk is sufficient — no size-stability poll needed.
    */
   async getSegmentPath(
     session: TranscodeSession,
@@ -682,17 +680,11 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
   ): Promise<string | null> {
     const segPath = path.join(session.cachePath, segmentName);
 
-    if (existsSync(segPath)) {
-      const stable = await isSegmentStable(segPath);
-      if (stable) return segPath;
-    }
+    if (existsSync(segPath)) return segPath;
 
     if (segmentName.includes('init')) {
       await session.ready;
-      if (existsSync(segPath)) {
-        const stable = await isSegmentStable(segPath);
-        if (stable) return segPath;
-      }
+      if (existsSync(segPath)) return segPath;
     }
 
     const dir = path.dirname(segPath);
@@ -713,26 +705,26 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         resolve(val);
       };
 
-      const tryServe = async () => {
-        if (settled || !existsSync(segPath)) return;
-        if (await isSegmentStable(segPath)) finish(segPath);
+      const tryServe = () => {
+        if (settled) return;
+        if (existsSync(segPath)) finish(segPath);
       };
 
       try {
         watcher = watch(dir, { persistent: false }, (_event, filename) => {
-          if (filename === name) void tryServe();
+          if (filename === name) tryServe();
         });
       } catch {
         // Directory doesn't exist yet — exitTimer covers it.
       }
 
-      void tryServe();
+      tryServe();
 
       exitTimer = setInterval(() => {
         if (session.process.exitCode !== null && !existsSync(segPath)) {
           finish(null);
         } else {
-          void tryServe();
+          tryServe();
         }
       }, 500);
 


### PR DESCRIPTION
## Summary

Two cold-start / steady-state wins from the perf audit.

### W1 — \`+temp_file\` in hls_flags

ffmpeg writes each segment to \`seg-NNNN.m4s.tmp\` then renames atomically. Replaces the 50ms \`isSegmentStable\` re-stat that ran on every served segment (~120s cumulative on a 2h playback) and eliminates a partial-segment race window on extremely fast clients.

Applied to all four hls output sites: var_stream_map, single-stream, audio-only, remux. \`isSegmentStable\` helper deleted with its only import.

### W2 — drop redundant 5s poll in \`verifyHwAccelOrFallback\`

\`session.ready\` already resolves on either seg-0 written OR process close (see \`spawnFfmpegSession.checkReady\` + the safety-net \`proc.on('close')\`). The 10×500ms loop after the await never iterated past first check on happy or crash paths — pure dead time when ffmpeg crashes mid-encode (~0-4s saved on the CPU-fallback path).

Collapsed to a single \`segExists()\` check after the await. Behaviour identical for healthy sessions; faster fallback when HW dies.

## Test plan

- [x] \`tsc --noEmit\` clean
- [ ] H.264 SDR transcode end-to-end (Shaka + Native)
- [ ] HEVC HDR10 transcode + seek (verify segments still served correctly with temp_file rename)
- [ ] Force HW crash (e.g. wrong renderD path) to confirm fallback to CPU still happens within seconds, not 5+s
- [ ] Multi-audio var_stream_map session (worst-case for temp_file file count)