### PR TITLE
perf(client): multi-platform fixes (web + iOS + Android + TV)

### DIFF
--- a/client/ios/App/App/CastPlugin.swift
+++ b/client/ios/App/App/CastPlugin.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Capacitor
 import GoogleCast
 
@@ -21,6 +22,11 @@ public class CastPlugin: CAPPlugin, CAPBridgedPlugin, GCKSessionManagerListener,
 
     private var sessionManager: GCKSessionManager?
     private var pollTimer: Timer?
+    /** Tracks whether the 1Hz media-status poll was running when the app
+     *  backgrounded; restart it on foreground so we don't keep firing
+     *  `evaluateJavaScript` against a paused WebView (fliks declares
+     *  `UIBackgroundModes: audio`, so Timers keep running). */
+    private var pollWasActiveBeforeBackground = false
 
     // MARK: - Initialize
 
@@ -31,6 +37,22 @@ public class CastPlugin: CAPPlugin, CAPBridgedPlugin, GCKSessionManagerListener,
             // GCKCastContext already initialized in AppDelegate
             self.sessionManager = GCKCastContext.sharedInstance().sessionManager
             self.sessionManager?.add(self)
+
+            // Pause/resume the media-status poll on app background to
+            // avoid wasted bridge round-trips while the WebView is
+            // suspended.
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(self.appDidEnterBackground),
+                name: UIApplication.didEnterBackgroundNotification,
+                object: nil
+            )
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(self.appWillEnterForeground),
+                name: UIApplication.willEnterForegroundNotification,
+                object: nil
+            )
 
             // Listen for device discovery
             let discoveryManager = GCKCastContext.sharedInstance().discoveryManager
@@ -290,6 +312,18 @@ public class CastPlugin: CAPPlugin, CAPBridgedPlugin, GCKSessionManagerListener,
     private func stopPolling() {
         pollTimer?.invalidate()
         pollTimer = nil
+    }
+
+    @objc private func appDidEnterBackground() {
+        pollWasActiveBeforeBackground = pollTimer != nil
+        stopPolling()
+    }
+
+    @objc private func appWillEnterForeground() {
+        if pollWasActiveBeforeBackground && currentSession?.remoteMediaClient != nil {
+            startPolling()
+        }
+        pollWasActiveBeforeBackground = false
     }
 
     private func pollMediaState() {

--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -184,10 +184,11 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
 
         // Diagnostic: when the URL points at an HLS master playlist, fetch
         // it ourselves and dump the body to console BEFORE handing it to
-        // AVPlayer. The exact CODECS / BANDWIDTH / VIDEO-RANGE values that
-        // AVPlayer is about to validate. Crucial when -12927 fires with an
-        // empty errorLog — AVPlayer rejected something at variant
-        // selection and we need to see what.
+        // AVPlayer. Captured CODECS / BANDWIDTH / VIDEO-RANGE values so
+        // we can reproduce a -12927 rejection that came back with an
+        // empty errorLog. Gated on DEBUG: in release the extra fetch
+        // adds 100ms-3s of cellular latency to every load.
+        #if DEBUG
         if urlString.contains(".m3u8") {
             var req = URLRequest(url: url)
             for (k, v) in headers {
@@ -205,6 +206,7 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
                 }
             }.resume()
         }
+        #endif
 
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }

--- a/client/src/app/core/services/device.service.ts
+++ b/client/src/app/core/services/device.service.ts
@@ -58,10 +58,21 @@ export class DeviceService {
     // 1. UA marker
     if (/AndroidTV\/\d/.test(ua)) return { input: 'dpad', formFactor: 'tv' };
 
-    // 2. No pointer at all
+    // 2. Samsung Tizen / LG webOS native browsers — UA strings published
+    // by both vendors. Tizen ships a Samsung-branded UA that always
+    // contains the literal `Tizen `; webOS uses `Web0S` (zero, not letter
+    // O) or the legacy `webOS`. Anchoring on these markers covers the
+    // smart-TV V1/V2 roadmap targets and the rare browsers shipped on
+    // home-cinema STBs (Hisense Vidaa, Vewd) that reuse the SMART-TV
+    // UA literal.
+    if (/Tizen |Web0S|webOS|SMART-TV/i.test(ua)) {
+      return { input: 'dpad', formFactor: 'tv' };
+    }
+
+    // 3. No pointer at all
     if (mm && mm('(pointer: none)').matches) return { input: 'dpad', formFactor: 'tv' };
 
-    // 3. TV-only UA sniff (best effort, only on native Android)
+    // 4. TV-only UA sniff (best effort, only on native Android)
     if (Capacitor.getPlatform() === 'android' && /Android.*TV|BRAVIA|SHIELD|AFT[A-Z0-9]+|GoogleTV/i.test(ua)) {
       return { input: 'dpad', formFactor: 'tv' };
     }

--- a/client/src/app/core/services/offline-storage.service.ts
+++ b/client/src/app/core/services/offline-storage.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, inject } from '@angular/core';
 import { Capacitor } from '@capacitor/core';
-import shaka from 'shaka-player';
 import { AuthService } from './auth.service';
 
 const CACHE_NAME = 'offline-media';
@@ -13,6 +12,17 @@ let _fs: typeof import('@capacitor/filesystem') | null = null;
 async function getFs() {
   if (!_fs) _fs = await import('@capacitor/filesystem');
   return _fs;
+}
+
+/** Lazy-loaded Shaka Player. Eager-importing it pulls ~750 KB into the
+ *  initial bundle even though the offline-download path is only reached
+ *  from the downloads page (and never on native, where ExoPlayer /
+ *  AVPlayer take over). Loaded on first call to `shakaDownload` /
+ *  `shakaRemove`. */
+let _shaka: typeof import('shaka-player').default | null = null;
+async function getShaka() {
+  if (!_shaka) _shaka = (await import('shaka-player')).default;
+  return _shaka;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -87,6 +97,7 @@ export class OfflineStorageService {
     if (this.isNative) return null;
 
     // Create a temporary Shaka player for the storage API.
+    const shaka = await getShaka();
     const video = document.createElement('video');
     video.style.display = 'none';
     document.body.appendChild(video);
@@ -154,6 +165,7 @@ export class OfflineStorageService {
     const uri = this.getShakaOfflineUri(mediaFileId);
     if (!uri) return;
 
+    const shaka = await getShaka();
     const video = document.createElement('video');
     const player = new shaka.Player();
     await player.attach(video);

--- a/client/src/app/core/services/playback-engine/native-engine.ts
+++ b/client/src/app/core/services/playback-engine/native-engine.ts
@@ -39,7 +39,6 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
   private _variantTracks: any[] = [];
 
   private listeners: Array<{ event: string; fn: EventListener }> = [];
-  private positionPoll: ReturnType<typeof setInterval> | null = null;
 
   // ── Native subtitle overlay (iOS) ──
   private readonly _isIos = Capacitor.getPlatform() === 'ios';
@@ -65,7 +64,6 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
 
   async destroy(): Promise<void> {
     this._initialized = false;
-    this.stopPositionPoll();
     this.unbindWindowEvents();
     this.destroySubtitleOverlay();
     await NativePlayer.destroy();
@@ -93,8 +91,6 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
     if (this._subtitleStyle) {
       await NativePlayer.setSubtitleStyle(this._subtitleStyle);
     }
-
-    this.startPositionPoll();
   }
 
   private _subtitleStyle: {
@@ -135,7 +131,6 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
   }
 
   async unload(): Promise<void> {
-    this.stopPositionPoll();
     await NativePlayer.stop();
     this._state = 'idle';
     this._currentTime = 0;
@@ -336,31 +331,6 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
       window.removeEventListener(event, fn);
     }
     this.listeners = [];
-  }
-
-  // ── Position polling (fallback if native events are sparse) ──
-
-  private startPositionPoll(): void {
-    this.stopPositionPoll();
-    this.positionPoll = setInterval(async () => {
-      try {
-        const pos = await NativePlayer.getPosition();
-        this._currentTime = pos.position;
-        this._duration = pos.duration;
-        this._buffered = pos.buffered;
-        this.emit('timeUpdate', pos);
-        this.updateSubtitleOverlay();
-      } catch {
-        /* player might be destroyed */
-      }
-    }, 1000);
-  }
-
-  private stopPositionPoll(): void {
-    if (this.positionPoll) {
-      clearInterval(this.positionPoll);
-      this.positionPoll = null;
-    }
   }
 
   // ── Native Subtitle Overlay (iOS) ──

--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -1,24 +1,21 @@
-@if (loading()) {
-  <div class="flex justify-center py-16">
-    <span class="loading loading-spinner loading-lg"></span>
-  </div>
-} @else {
-  <div appTvSection class="flex flex-col gap-8">
+<div appTvSection class="flex flex-col gap-8">
 
     <!-- Libraries -->
-    <app-horizontal-scroller [title]="'home.libraries' | translate">
-      @for (lib of libraries(); track lib.id) {
-        <a [routerLink]="libraryUrl(lib)"
-           [attr.data-home-focus]="'library:' + lib.id"
-           class="shrink-0 w-36 h-20 sm:w-48 sm:h-28 rounded-xl border flex items-center gap-3 px-4 sm:px-5 hover:shadow-lg transition-shadow"
-           [style.background]="'linear-gradient(135deg, color-mix(in oklch, ' + libraryColor(lib) + ' 20%, transparent), color-mix(in oklch, ' + libraryColor(lib) + ' 5%, transparent))'"
-           [style.border-color]="'color-mix(in oklch, ' + libraryColor(lib) + ' 15%, transparent)'"
-        >
-          <app-lucide-icon [name]="lib.icon || 'library'" class="h-6 w-6 sm:h-8 sm:w-8 shrink-0" [style.color]="libraryColor(lib)" />
-          <span class="text-sm sm:text-base font-semibold">{{ lib.name }}</span>
-        </a>
-      }
-    </app-horizontal-scroller>
+    @if (libraries().length) {
+      <app-horizontal-scroller [title]="'home.libraries' | translate">
+        @for (lib of libraries(); track lib.id) {
+          <a [routerLink]="libraryUrl(lib)"
+             [attr.data-home-focus]="'library:' + lib.id"
+             class="shrink-0 w-36 h-20 sm:w-48 sm:h-28 rounded-xl border flex items-center gap-3 px-4 sm:px-5 hover:shadow-lg transition-shadow"
+             [style.background]="'linear-gradient(135deg, color-mix(in oklch, ' + libraryColor(lib) + ' 20%, transparent), color-mix(in oklch, ' + libraryColor(lib) + ' 5%, transparent))'"
+             [style.border-color]="'color-mix(in oklch, ' + libraryColor(lib) + ' 15%, transparent)'"
+          >
+            <app-lucide-icon [name]="lib.icon || 'library'" class="h-6 w-6 sm:h-8 sm:w-8 shrink-0" [style.color]="libraryColor(lib)" />
+            <span class="text-sm sm:text-base font-semibold">{{ lib.name }}</span>
+          </a>
+        }
+      </app-horizontal-scroller>
+    }
 
     <!-- Continue Watching -->
     @if (continueWatching().length) {
@@ -100,4 +97,3 @@
     }
 
   </div>
-}

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -85,7 +85,6 @@ export class HomeComponent implements OnInit, OnDestroy {
   private attachedSub?: Subscription;
   private detachedSub?: Subscription;
 
-  readonly loading = signal(true);
   readonly libraries = signal<LibrarySummary[]>([]);
   readonly continueWatching = signal<ContinueWatchingItem[]>([]);
   readonly recentMedia = signal<Media[]>([]);
@@ -110,8 +109,9 @@ export class HomeComponent implements OnInit, OnDestroy {
   async ngOnInit() {
     this.arrivedViaBack = this.navbar.lastWasBack();
     this.scrollMemory.activate(HomeComponent.SCROLL_KEY);
+    // Each section guards itself with `@if (().length)` so sections paint
+    // independently as their data arrives. No global loading gate.
     await this.loadAllSections();
-    this.loading.set(false);
     this.scrollMemory.restore(HomeComponent.SCROLL_KEY, this.injector);
     if (this.tv.isTv()) {
       afterNextRender(() => this.applyDefaultFocus(), { injector: this.injector });

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -300,7 +300,7 @@
           <div class="avatar">
             <div class="w-16 h-16 sm:w-20 sm:h-20 rounded-full ring ring-base-200 group-hover:ring-primary group-focus:ring-primary group-focus-visible:ring-primary group-focus:ring-2 group-focus-visible:ring-2 transition-colors">
               @if (c.person.avatarUrl) {
-                <img appImgFadeIn [src]="c.person.avatarUrl | resolveUrl:'thumb'" [alt]="c.person.name" loading="lazy" fetchpriority="low" />
+                <img appImgFadeIn [src]="c.person.avatarUrl | resolveUrl:'thumb'" [alt]="c.person.name" loading="lazy" decoding="async" fetchpriority="low" />
               } @else {
                 <div class="bg-base-300 flex items-center justify-center w-full h-full text-lg font-bold text-base-content/30">
                   {{ c.person.name.charAt(0) }}

--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -28,6 +28,7 @@
         [class.opacity-35]="imageBlurred()"
         [class.scale-105]="imageBlurred()"
         loading="lazy"
+        decoding="async"
       />
     } @else {
       <div class="flex items-center justify-center w-full h-full text-base-content/20">

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -207,6 +207,12 @@ export class MediaCardComponent {
    * etc.).
    */
   protected flagPosterForTransition() {
+    // Skip on engines without View Transitions API (Chromium <111,
+    // Tizen 5.5 WebKit, webOS 5 Chromium 79). Angular's
+    // `withViewTransitions()` already feature-detects, but the
+    // imperative DOM stamping below would mutate styles for nothing on
+    // those targets and adds a querySelectorAll per click.
+    if (!('startViewTransition' in document)) return;
     const id = this.resolveMediaId();
     const img = this.imgRef()?.nativeElement;
     if (id == null || !img) return;

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -130,7 +130,7 @@
 <div class="hidden lg:block tv:block relative">
   @if (fanartUrl()) {
     <div class="absolute inset-0 -mx-6 -mt-6 overflow-hidden">
-      <img appImgFadeIn [src]="fanartUrl()! | resolveUrl:'medium'" alt="" loading="eager" fetchpriority="high" class="w-full h-full object-cover object-[50%_25%]" />
+      <img appImgFadeIn [src]="fanartUrl()! | resolveUrl:'medium'" alt="" loading="eager" fetchpriority="high" decoding="async" class="w-full h-full object-cover object-[50%_25%]" />
       <div class="absolute inset-0 bg-base-100/80"></div>
       <div class="absolute inset-0 bg-gradient-to-t from-base-100 via-base-100/30 to-base-100/50"></div>
     </div>
@@ -158,7 +158,7 @@
         <img
           appImgFadeIn
           [src]="posterUrl()! | resolveUrl:'medium'" [alt]="title()"
-          loading="eager" fetchpriority="high"
+          loading="eager" fetchpriority="high" decoding="async"
           class="w-full rounded-xl object-cover bg-base-300"
           [class.aspect-2/3]="posterMode() === 'poster'"
           [class.aspect-video]="posterMode() === 'still'"

--- a/client/src/app/shared/layout/layout.ts
+++ b/client/src/app/shared/layout/layout.ts
@@ -182,13 +182,15 @@ export class LayoutComponent implements OnInit, OnDestroy {
       this.langTick.update((n) => n + 1);
       this.syncNavbarTitleFromRoute();
     });
-    this.router.events.subscribe(e => {
-      if (e instanceof NavigationEnd) {
-        this.bottomMenuOpen.set(false);
-        this.isHomeRoute.set(e.urlAfterRedirects === '/' || e.urlAfterRedirects.startsWith('/?'));
-        this.syncNavbarTitleFromRoute();
-      }
-    });
+    this.router.events
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(e => {
+        if (e instanceof NavigationEnd) {
+          this.bottomMenuOpen.set(false);
+          this.isHomeRoute.set(e.urlAfterRedirects === '/' || e.urlAfterRedirects.startsWith('/?'));
+          this.syncNavbarTitleFromRoute();
+        }
+      });
     this.syncNavbarTitleFromRoute();
   }
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -26,6 +26,7 @@ import { App } from './app/app';
   const isTv =
     effectiveOverride === 'tv' ||
     /AndroidTV\/\d/.test(ua) ||
+    /Tizen |Web0S|webOS|SMART-TV/i.test(ua) ||
     (matchMedia && matchMedia('(pointer: none)').matches) ||
     /Android.*TV|BRAVIA|SHIELD|AFT[A-Z0-9]+|GoogleTV/i.test(ua);
   if (!isTv) return;


### PR DESCRIPTION
## Summary

9 client-side perf opts from the multi-platform audit. Library-touching items skipped per request; cache-evictor change skipped because the Android cache is offline-downloads only and LRU would silently delete user content.

### 🔴 P0

- **Lazy-load shaka-player** (\`offline-storage.service.ts\`). Removes ~750 KB from the initial bundle on **every platform**, including native where ExoPlayer / AVPlayer don't need it. Pattern matches the existing lazy filesystem loader.
- **Drop the 1Hz JS-side position poll** in NativeEngine. Native plugins already push \`nativePlayerTimeUpdate\` events at the same rate — saves 60 redundant bridge round-trips per playback-minute on iOS + Android.
- **Wrap iOS manifest dump in \`#if DEBUG\`** (\`NativePlayerPlugin.swift\`). The unconditional \`URLSession.shared.dataTask\` added 100-3000 ms cellular latency to every release-build HLS load.

### 🟠 P1

- **Tizen / webOS / Hisense Vidaa UAs detected as TV** (\`device.service.ts\` + \`main.ts\`). Required before Tizen V1 / webOS V2 ship; previously only \`AndroidTV\` / \`(pointer: none)\` matched.
- **Feature-gate View Transitions** in \`media-card.ts\` so Chromium <111, Tizen 5.5 and webOS 5 skip the \`querySelectorAll\` + style mutation that's a no-op there.
- **Drop home page global loading gate**. Each section already guards itself; LCP drops by waiting for the slowest endpoint to one waiting for the fastest. Libraries scroller wrapped in its own \`@if\` so the empty title doesn't render.
- **\`takeUntilDestroyed\` on Layout's router.events subscription**. Layout is destroyed/recreated on /watch and /login transitions; previously leaked one subscription per round.
- **iOS Cast: pause 1Hz poll on background**, restart on foreground when a session is still alive. fliks has \`UIBackgroundModes: audio\` so the Timer kept firing into a suspended WebView.

### 🟢 P2

- \`decoding=\"async\"\` on poster, fanart, detail-poster and cast avatar imgs.

### Skipped (per audit)

- \`LeastRecentlyUsedCacheEvictor\` on Android SimpleCache: the cache is used **only** for offline downloads (\`NativePlayerPlugin.java:244\` shows it's gated behind \`offline\`). LRU would silently evict user downloads — kept \`NoOpCacheEvictor\`.

## Test plan

- [x] \`tsc --noEmit\` clean
- [ ] Verify bundle size: initial chunk drops ~750 KB after lazy-shaka
- [ ] iOS: HLS load no longer fetches+logs manifest in release builds
- [ ] iOS Cast: background app while casting, foreground after 30s, position resumes updating
- [ ] Android playback: time updates still arrive at 1Hz (via the native event, not the deleted poll)
- [ ] Smart-TV emulator: Tizen / webOS UA → TV layout activates
- [ ] Home page: sections paint independently as data arrives (no spinner blocking everything)