### PR TITLE
fix(streaming): revert hls +temp_file — broke seek-resume init.mp4

### DIFF
--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -479,7 +479,7 @@ export function buildFfmpegArgs(
       segType,
       ...(useTs ? [] : ['-hls_fmp4_init_filename', 'init_%v.mp4']),
       '-hls_flags',
-      'independent_segments+temp_file',
+      'independent_segments',
       '-var_stream_map',
       varParts.join(' '),
       '-hls_segment_filename',
@@ -516,7 +516,7 @@ export function buildFfmpegArgs(
       '-hls_segment_filename',
       path.join(outputDir, `seg-%04d.${segExt}`),
       '-hls_flags',
-      'independent_segments+temp_file',
+      'independent_segments',
       path.join(outputDir, 'index.m3u8'),
     );
   }
@@ -592,7 +592,7 @@ export function buildAudioOnlyFfmpegArgs(
     '-hls_segment_filename',
     path.join(outputDir, `seg-%04d.${segExt}`),
     '-hls_flags',
-    'independent_segments+temp_file',
+    'independent_segments',
     path.join(outputDir, 'index.m3u8'),
   );
 
@@ -722,7 +722,7 @@ export function buildRemuxArgs(
     '-hls_segment_filename',
     path.join(outputDir, 'seg-%04d.m4s'),
     '-hls_flags',
-    'independent_segments+temp_file',
+    'independent_segments',
     path.join(outputDir, 'index.m3u8'),
   );
 

--- a/backend/src/modules/streaming/transcoding/segment-utils.ts
+++ b/backend/src/modules/streaming/transcoding/segment-utils.ts
@@ -58,3 +58,19 @@ export function firstMissingSegment(
   return null;
 }
 
+/**
+ * 50ms size-stability check. Returns true when the file exists, is non-empty,
+ * and its size hasn't changed in 50ms (= ffmpeg finished writing this segment).
+ */
+export async function isSegmentStable(segPath: string): Promise<boolean> {
+  try {
+    const s1 = (await fsp.stat(segPath)).size;
+    if (s1 === 0) return false;
+    await new Promise((r) => setTimeout(r, 50));
+    const s2 = (await fsp.stat(segPath)).size;
+    return s1 === s2;
+  } catch {
+    return false;
+  }
+}
+

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -40,6 +40,7 @@ import {
 import {
   fileExists,
   firstMissingSegment,
+  isSegmentStable,
   segmentNearby,
 } from './segment-utils';
 import { audioSessionKey, earlySessionKey, sessionKey } from './session-key';
@@ -668,10 +669,13 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
    * Get a segment file path, waiting if it's being generated.
    *
    * Uses fs.watch (inotify on Linux) so we react within milliseconds of
-   * ffmpeg's atomic rename. `-hls_flags +temp_file` (set by
-   * `ffmpeg-args.ts`) makes ffmpeg write each segment to `*.tmp` and
-   * rename to the final name once flushed, so seeing the final name on
-   * disk is sufficient — no size-stability poll needed.
+   * ffmpeg writing the segment. ffmpeg writes segments incrementally so
+   * we verify size-stability (50ms re-stat) before serving — without
+   * this the player can fetch a half-written .m4s and reject it. A
+   * previous attempt to swap this for `-hls_flags +temp_file` regressed
+   * the seek-resume path (the early session's init.mp4 rename happened
+   * late enough that the player stalled in loading), so the
+   * isSegmentStable poll is the supported readiness signal.
    */
   async getSegmentPath(
     session: TranscodeSession,
@@ -680,11 +684,17 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
   ): Promise<string | null> {
     const segPath = path.join(session.cachePath, segmentName);
 
-    if (existsSync(segPath)) return segPath;
+    if (existsSync(segPath)) {
+      const stable = await isSegmentStable(segPath);
+      if (stable) return segPath;
+    }
 
     if (segmentName.includes('init')) {
       await session.ready;
-      if (existsSync(segPath)) return segPath;
+      if (existsSync(segPath)) {
+        const stable = await isSegmentStable(segPath);
+        if (stable) return segPath;
+      }
     }
 
     const dir = path.dirname(segPath);
@@ -705,26 +715,26 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         resolve(val);
       };
 
-      const tryServe = () => {
-        if (settled) return;
-        if (existsSync(segPath)) finish(segPath);
+      const tryServe = async () => {
+        if (settled || !existsSync(segPath)) return;
+        if (await isSegmentStable(segPath)) finish(segPath);
       };
 
       try {
         watcher = watch(dir, { persistent: false }, (_event, filename) => {
-          if (filename === name) tryServe();
+          if (filename === name) void tryServe();
         });
       } catch {
         // Directory doesn't exist yet — exitTimer covers it.
       }
 
-      tryServe();
+      void tryServe();
 
       exitTimer = setInterval(() => {
         if (session.process.exitCode !== null && !existsSync(segPath)) {
           finish(null);
         } else {
-          tryServe();
+          void tryServe();
         }
       }, 500);
 


### PR DESCRIPTION
## Summary

Reverts the W1 part of #139. With \`+temp_file\` on hls_flags, ffmpeg writes init.mp4 to init.mp4.tmp and renames on completion, but the seek-resume path stalled — clicking **Reprendre** kept the player in the loading veil even though segments were produced on disk.

The 50 ms size-stability check was the supported readiness signal for both segments and init.mp4. Restoring it.

## Changes

- \`hls_flags\` back to \`independent_segments\` (no \`+temp_file\`) on all four output sites
- \`isSegmentStable\` helper restored in \`segment-utils.ts\` (50 ms size-stability re-stat)
- \`getSegmentPath\` re-runs \`isSegmentStable\` on the initial \`existsSync\`, the init retry after \`session.ready\`, and inside the fs.watch \`tryServe\`

W2 from #139 (drop the 5 s poll in \`verifyHwAccelOrFallback\` — race \`session.ready\` against the close event instead) is kept; that change is independent and not implicated.

## Trade-off

50 ms re-stat per served segment (~120 s cumulative on a 2 h playback) is back. Marginal perf cost — functional correctness ranks higher.

## Test plan

- [ ] Click **Reprendre** on a mid-played media → player exits the loading veil within 1-2 s and starts playback at the resume position
- [ ] Fresh play (no resume) → no regression
- [ ] HEVC HDR transcode + seek → no regression