### PR TITLE
fix(player): fallback firstFrame on Android when onRenderedFirstFrame stalls

### DIFF
--- a/client/src/app/core/services/playback-engine/native-engine.ts
+++ b/client/src/app/core/services/playback-engine/native-engine.ts
@@ -40,6 +40,20 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
 
   private listeners: Array<{ event: string; fn: EventListener }> = [];
 
+  /** Guards against double-emit of 'firstFrame' (engine listeners use
+   *  it to clear the loading veil — flipping it twice is harmless but
+   *  the position-advance fallback below would otherwise fire on every
+   *  later timeUpdate). Reset on each load(). */
+  private firstFrameEmitted = false;
+  /** Last `timeUpdate.position` seen, used to detect that playback is
+   *  actually advancing (Android's onRenderedFirstFrame is unreliable on
+   *  some devices: it fires late or never on transcode → ABR switches,
+   *  leaving the UI stuck on the loading spinner even though the stream
+   *  is playing). When position grows between two updates, we know
+   *  frames are decoding and can fire 'firstFrame' ourselves as a
+   *  belt-and-suspenders signal. */
+  private lastTimeUpdatePos = -1;
+
   // ── Native subtitle overlay (iOS) ──
   private readonly _isIos = Capacitor.getPlatform() === 'ios';
   private _parsedTracks = new Map<string, VttCue[]>();
@@ -82,6 +96,8 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
     _mimeType?: string,
     headers?: Record<string, string>,
   ): Promise<void> {
+    this.firstFrameEmitted = false;
+    this.lastTimeUpdatePos = -1;
     const subtitles = this._preloadedSubtitles.length > 0
       ? this._preloadedSubtitles
       : undefined;
@@ -307,6 +323,21 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
       this._buffered = d.buffered;
       this.emit('timeUpdate', d);
       this.updateSubtitleOverlay();
+      // Fallback for the missing onRenderedFirstFrame case: native only
+      // fires nativePlayerTimeUpdate when `player.isPlaying()`, so a
+      // position that grows between two updates is a strong signal that
+      // decoded frames are flowing. We use the second observation (not
+      // the first) because a seek-resume's initial update can land at
+      // position=T before any frame has rendered.
+      if (
+        !this.firstFrameEmitted &&
+        this.lastTimeUpdatePos >= 0 &&
+        d.position > this.lastTimeUpdatePos
+      ) {
+        this.firstFrameEmitted = true;
+        this.emit('firstFrame', undefined);
+      }
+      this.lastTimeUpdatePos = d.position;
     });
 
     bind('nativePlayerError', (e: Event) => {
@@ -322,6 +353,8 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
     });
 
     bind('nativePlayerFirstFrame', () => {
+      if (this.firstFrameEmitted) return;
+      this.firstFrameEmitted = true;
       this.emit('firstFrame', undefined);
     });
   }


### PR DESCRIPTION
## Summary

Fixes the intermittent Android \"stays in loading mode\" symptom on Reprendre, even when segments are produced on the backend.

### Diagnosis

The player's spinner+fanart overlay is gated by:

\`\`\`html
@if (loading() || buffering() || (!videoStarted() && !error())) { … }
\`\`\`

\`videoStarted\` only flips on the engine \`firstFrame\` event, which on native is forwarded from ExoPlayer's \`Player.Listener.onRenderedFirstFrame()\`. On some Android devices that callback is delivered late or not at all on transcode / ABR-switch playbacks, so the gate stays true and the UI is stuck even though frames are flowing on the SurfaceView.

### Fix

NativeEngine treats a growing \`nativePlayerTimeUpdate.position\` as a backstop \`firstFrame\` signal. The Android plugin only emits time updates while \`player.isPlaying()\` (\`NativePlayerPlugin.java:825\`), so a second update where position advanced proves the decoder is producing frames.

- New \`firstFrameEmitted\` flag, reset on each \`load()\`
- Both code paths (real callback + position-advance fallback) flip the flag and emit at most once per load
- Fallback uses the *second* observation, never the first — a seek-resume's initial update at \`position=T\` shouldn't trigger before any frame renders

### Trade-off

Spinner may take ~2 s longer to clear on the rare device where onRenderedFirstFrame is genuinely slow (vs ideal-case <1 s). Better than the previous indefinite stall.

## Test plan

- [ ] Reprendre on Android several times to reproduce the original stall; verify the spinner now clears within ~2 s of playback starting
- [ ] Fresh play on Android: no regression on the happy path (onRenderedFirstFrame still fires first, flag prevents double emit)
- [ ] Web (Shaka): unaffected (NativeEngine not used)