### PR TITLE
fix(player): Android cold-prepare stall + BT.709 SDR tagging + codec level

### DIFF
--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -418,16 +418,30 @@ export function buildFfmpegArgs(
   };
   args.push(...encoder.buildArgs(encoderInput));
 
-  // When tone-mapping HDR → SDR on the H.264 path, force the SPS VUI to
-  // BT.709 limited range. The pixel data is genuinely SDR after the
-  // tonemap filter, but some encoder paths (notably h264_qsv) carry the
-  // source's BT.2020/PQ color tags through from input AVFrame metadata
-  // into the SPS, producing a bitstream that signals HDR with SDR
-  // pixels. iOS AVPlayer rejects this combination with -12927; other
-  // players tolerate it but render with wrong color. These flags are
-  // a no-op when tone-mapping isn't active (the AVFrame already has
-  // BT.709 tags on SDR sources).
-  if (tonemap && !isHdrOutput) {
+  // Force BT.709 limited-range SPS VUI on every SDR output.
+  //
+  // Two failure modes this prevents:
+  //
+  // 1. HDR → SDR tonemap: h264_qsv (and a few other paths) carry the
+  //    source's BT.2020/PQ tags through from AVFrame metadata into the
+  //    output SPS, producing a bitstream that signals HDR with SDR
+  //    pixels. iOS AVPlayer rejects that combination with -12927; other
+  //    players tolerate it but render with the wrong gamut / TRC.
+  //
+  // 2. Source with unsignalled colorimetry (e.g. older WEBDL H.264
+  //    masters like Arcane S2): the source SPS leaves
+  //    color_primaries/_trc/_space/_range all `unknown`. FFmpeg
+  //    propagates the unknown tags into the output SPS. Android
+  //    Media3 + the HDR-preserving SurfaceView path can refuse to
+  //    initialise MediaCodec on cold prepare when the VUI is fully
+  //    unsigned — playback stalls in BUFFERING with no decoder
+  //    allocated. A manual seek bypasses the strict initial
+  //    validation, which is why the seek "unsticks" the player.
+  //
+  // No-op when the source already carries BT.709 tags (ffmpeg accepts
+  // the redundant overrides). HDR output paths skip this so the
+  // encoder keeps the BT.2020/PQ signalling.
+  if (!isHdrOutput) {
     args.push(
       '-color_primaries',
       'bt709',

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -479,7 +479,7 @@ export function buildFfmpegArgs(
       segType,
       ...(useTs ? [] : ['-hls_fmp4_init_filename', 'init_%v.mp4']),
       '-hls_flags',
-      'independent_segments',
+      'independent_segments+temp_file',
       '-var_stream_map',
       varParts.join(' '),
       '-hls_segment_filename',
@@ -516,7 +516,7 @@ export function buildFfmpegArgs(
       '-hls_segment_filename',
       path.join(outputDir, `seg-%04d.${segExt}`),
       '-hls_flags',
-      'independent_segments',
+      'independent_segments+temp_file',
       path.join(outputDir, 'index.m3u8'),
     );
   }
@@ -592,7 +592,7 @@ export function buildAudioOnlyFfmpegArgs(
     '-hls_segment_filename',
     path.join(outputDir, `seg-%04d.${segExt}`),
     '-hls_flags',
-    'independent_segments',
+    'independent_segments+temp_file',
     path.join(outputDir, 'index.m3u8'),
   );
 
@@ -722,7 +722,7 @@ export function buildRemuxArgs(
     '-hls_segment_filename',
     path.join(outputDir, 'seg-%04d.m4s'),
     '-hls_flags',
-    'independent_segments',
+    'independent_segments+temp_file',
     path.join(outputDir, 'index.m3u8'),
   );
 

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -9,6 +9,43 @@ import type { DeviceType, TranscodeProfile } from './types';
 import type { CodecVariant } from './codec/types';
 import { h264CodecString, hevcMainCodecString } from './codec/codec-strings';
 
+/** Apply the `onlyQuality` URL pin to a ladder. Used identically by
+ *  the SDR and HDR branches: when the player has a saved quality
+ *  preference (or an explicit dropdown pick), the master playlist
+ *  emits a single-variant ladder so ExoPlayer's HLS source can't
+ *  pre-load other variants — each unfocused variant playlist or
+ *  init.mp4 fetch triggers a ffmpeg kill+respawn on the backend
+ *  when the requested quality doesn't match the active session.
+ *
+ *  - `remux` / `original` collapse to the top SDR profile that fits
+ *    the source resolution (no upscale). HDR ladder ignores these
+ *    pseudo-labels because the source-resolution HDR rung is emitted
+ *    via the separate `hdrPassThrough` block.
+ *  - When `hdrSuffix` is true, an input `1080p` is matched against
+ *    `1080p-hdr` (HDR ladder rungs carry the suffix); already
+ *    `*-hdr` inputs pass through unchanged.
+ *  - Falls back to the full ladder when the pin doesn't match any
+ *    rung (legacy URLs / typos). */
+function applyQualityPin(
+  ladder: TranscodeProfile[],
+  onlyQuality: string | undefined,
+  sourceWidth: number,
+  hdrSuffix = false,
+): TranscodeProfile[] {
+  if (!onlyQuality) return ladder;
+  if (onlyQuality === 'remux' || onlyQuality === 'original') {
+    if (hdrSuffix) return ladder;
+    const top = ladder.find((p) => p.maxWidth <= sourceWidth) ?? ladder[0];
+    return [top];
+  }
+  const wanted =
+    hdrSuffix && !onlyQuality.endsWith('-hdr')
+      ? `${onlyQuality}-hdr`
+      : onlyQuality;
+  const picked = ladder.find((p) => p.name === wanted);
+  return picked ? [picked] : ladder;
+}
+
 /**
  * Get available quality profiles for a given source resolution + device class.
  */
@@ -116,8 +153,13 @@ export function generateMasterPlaylist(
     // Includes the source-resolution rung if there's an HDR profile
     // at or below source height.
     if (canEncodeHevcHdr) {
-      const hdrLadder = getHdrLadderForDevice(deviceType).filter((p) =>
-        profileFitsSource(p, sourceWidth, sourceHeight),
+      const hdrLadder = applyQualityPin(
+        getHdrLadderForDevice(deviceType).filter((p) =>
+          profileFitsSource(p, sourceWidth, sourceHeight),
+        ),
+        onlyQuality,
+        sourceWidth,
+        /* hdrSuffix */ true,
       );
       for (const p of hdrLadder) {
         const avg =
@@ -128,7 +170,9 @@ export function generateMasterPlaylist(
           sourceWidth,
           sourceHeight,
         );
-        const videoCodec = hevcMain10CodecStringForHeight(p.maxHeight);
+        // Use actual emitted height for the codec level — see SDR
+        // branch below for the rationale (Arcane / cropped sources).
+        const videoCodec = hevcMain10CodecStringForHeight(h);
         lines.push(
           `#EXT-X-STREAM-INF:BANDWIDTH=${bw},AVERAGE-BANDWIDTH=${avg},RESOLUTION=${w}x${h},VIDEO-RANGE=${range},NAME="${p.name}",CODECS="${videoCodec},${audioCodec}"${hdrAudioAttr}`,
           `/api/stream/${mediaFileId}/${p.name}/index.m3u8${tokenParam}`,
@@ -174,19 +218,7 @@ export function generateMasterPlaylist(
   const ladder = getLadderForDevice(deviceType);
   let profiles = getAvailableProfiles(sourceWidth, sourceHeight, deviceType);
   if (!profiles.length) profiles.push(ladder[ladder.length - 1]); // at least 480p
-
-  if (onlyQuality) {
-    if (onlyQuality === 'remux' || onlyQuality === 'original') {
-      // Pick the top profile whose maxWidth is ≤ source (matches source
-      // resolution as closely as possible without upscaling).
-      const top =
-        profiles.find((p) => p.maxWidth <= sourceWidth) ?? profiles[0];
-      profiles = [top];
-    } else {
-      const picked = profiles.find((p) => p.name === onlyQuality);
-      if (picked) profiles = [picked];
-    }
-  }
+  profiles = applyQualityPin(profiles, onlyQuality, sourceWidth);
 
   for (const p of profiles) {
     const avg =
@@ -202,9 +234,18 @@ export function generateMasterPlaylist(
       sourceWidth,
       sourceHeight,
     );
+    // Codec string MUST be derived from the actual emitted height (`h`),
+    // not `p.maxHeight`. Cropped content (e.g. 2.39:1 cinemascope on a
+    // 1920×1080 source → 1920×816) advertises a height below the
+    // profile nominal, so `h264CodecString({height: 720})` would
+    // declare avc1 L3.2 in the master while the bitstream SPS carries
+    // L3.1 for the actual 1280×544 frames. The mismatch (declared > SPS)
+    // can leave ExoPlayer's track selector stuck on cold prepare —
+    // visible as the Arcane "buffering forever, no decoder allocated"
+    // pattern on Android.
     const target = {
       width: w,
-      height: p.maxHeight,
+      height: h,
       videoBitrateBps: 0,
       gopSize: 0,
       frameRate: 24,

--- a/backend/src/modules/streaming/transcoding/segment-utils.ts
+++ b/backend/src/modules/streaming/transcoding/segment-utils.ts
@@ -58,19 +58,3 @@ export function firstMissingSegment(
   return null;
 }
 
-/**
- * 50ms size-stability check. Returns true when the file exists, is non-empty,
- * and its size hasn't changed in 50ms (= ffmpeg finished writing this segment).
- */
-export async function isSegmentStable(segPath: string): Promise<boolean> {
-  try {
-    const s1 = (await fsp.stat(segPath)).size;
-    if (s1 === 0) return false;
-    await new Promise((r) => setTimeout(r, 50));
-    const s2 = (await fsp.stat(segPath)).size;
-    return s1 === s2;
-  } catch {
-    return false;
-  }
-}
-

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -40,7 +40,6 @@ import {
 import {
   fileExists,
   firstMissingSegment,
-  isSegmentStable,
   segmentNearby,
 } from './segment-utils';
 import { audioSessionKey, earlySessionKey, sessionKey } from './session-key';
@@ -669,13 +668,10 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
    * Get a segment file path, waiting if it's being generated.
    *
    * Uses fs.watch (inotify on Linux) so we react within milliseconds of
-   * ffmpeg writing the segment. ffmpeg writes segments incrementally so
-   * we verify size-stability (50ms re-stat) before serving — without
-   * this the player can fetch a half-written .m4s and reject it. A
-   * previous attempt to swap this for `-hls_flags +temp_file` regressed
-   * the seek-resume path (the early session's init.mp4 rename happened
-   * late enough that the player stalled in loading), so the
-   * isSegmentStable poll is the supported readiness signal.
+   * ffmpeg's atomic rename. `-hls_flags +temp_file` (set by
+   * `ffmpeg-args.ts`) makes ffmpeg write each segment to `*.tmp` and
+   * rename to the final name once flushed, so seeing the final name on
+   * disk is sufficient — no size-stability poll needed.
    */
   async getSegmentPath(
     session: TranscodeSession,
@@ -684,17 +680,11 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
   ): Promise<string | null> {
     const segPath = path.join(session.cachePath, segmentName);
 
-    if (existsSync(segPath)) {
-      const stable = await isSegmentStable(segPath);
-      if (stable) return segPath;
-    }
+    if (existsSync(segPath)) return segPath;
 
     if (segmentName.includes('init')) {
       await session.ready;
-      if (existsSync(segPath)) {
-        const stable = await isSegmentStable(segPath);
-        if (stable) return segPath;
-      }
+      if (existsSync(segPath)) return segPath;
     }
 
     const dir = path.dirname(segPath);
@@ -715,26 +705,26 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         resolve(val);
       };
 
-      const tryServe = async () => {
-        if (settled || !existsSync(segPath)) return;
-        if (await isSegmentStable(segPath)) finish(segPath);
+      const tryServe = () => {
+        if (settled) return;
+        if (existsSync(segPath)) finish(segPath);
       };
 
       try {
         watcher = watch(dir, { persistent: false }, (_event, filename) => {
-          if (filename === name) void tryServe();
+          if (filename === name) tryServe();
         });
       } catch {
         // Directory doesn't exist yet — exitTimer covers it.
       }
 
-      void tryServe();
+      tryServe();
 
       exitTimer = setInterval(() => {
         if (session.process.exitCode !== null && !existsSync(segPath)) {
           finish(null);
         } else {
-          void tryServe();
+          tryServe();
         }
       }, 500);
 

--- a/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
@@ -372,9 +372,9 @@ public class NativePlayerPlugin extends Plugin {
             });
 
             // Diagnostic AnalyticsListener: captures every HLS segment + manifest
-            // load so when the player gets stuck buffering we can pin down WHICH
-            // request stalled / errored. Track last requested URI on the player
-            // instance so PlayerError can include it.
+            // load AND the video/audio renderer lifecycle so when the player
+            // gets stuck buffering we can pin down whether the decoder was
+            // even instantiated and which format ExoPlayer picked.
             player.addAnalyticsListener(new AnalyticsListener() {
                 @Override
                 public void onLoadStarted(@NonNull EventTime eventTime,
@@ -382,6 +382,7 @@ public class NativePlayerPlugin extends Plugin {
                                           @NonNull MediaLoadData mediaLoadData) {
                     lastRequestedUri = loadEventInfo.uri.toString();
                     Log.d(DIAG_TAG, "[load>>] dataType=" + mediaLoadData.dataType
+                            + " trackType=" + mediaLoadData.trackType
                             + " uri=" + lastRequestedUri);
                 }
 
@@ -390,6 +391,7 @@ public class NativePlayerPlugin extends Plugin {
                                             @NonNull LoadEventInfo loadEventInfo,
                                             @NonNull MediaLoadData mediaLoadData) {
                     Log.d(DIAG_TAG, "[load<<] dataType=" + mediaLoadData.dataType
+                            + " trackType=" + mediaLoadData.trackType
                             + " bytes=" + loadEventInfo.bytesLoaded
                             + " elapsed=" + loadEventInfo.loadDurationMs + "ms"
                             + " uri=" + loadEventInfo.uri);
@@ -405,6 +407,97 @@ public class NativePlayerPlugin extends Plugin {
                             + " wasCanceled=" + wasCanceled
                             + " uri=" + loadEventInfo.uri
                             + " err=" + error.getMessage());
+                }
+
+                @Override
+                public void onVideoEnabled(@NonNull EventTime eventTime,
+                                           @NonNull androidx.media3.exoplayer.DecoderCounters counters) {
+                    Log.d(DIAG_TAG, "[videoEnabled] renderer started");
+                }
+
+                @Override
+                public void onVideoDisabled(@NonNull EventTime eventTime,
+                                            @NonNull androidx.media3.exoplayer.DecoderCounters counters) {
+                    Log.d(DIAG_TAG, "[videoDisabled] dropped=" + counters.droppedBufferCount
+                            + " skipped=" + counters.skippedOutputBufferCount);
+                }
+
+                @Override
+                public void onVideoInputFormatChanged(@NonNull EventTime eventTime,
+                                                      @NonNull androidx.media3.common.Format format,
+                                                      @androidx.annotation.Nullable
+                                                      androidx.media3.exoplayer.DecoderReuseEvaluation eval) {
+                    Log.d(DIAG_TAG, "[videoFormat] codecs=" + format.codecs
+                            + " w=" + format.width + " h=" + format.height
+                            + " peakBitrate=" + format.peakBitrate
+                            + " colorInfo=" + (format.colorInfo != null ? format.colorInfo.toString() : "null")
+                            + " sampleMime=" + format.sampleMimeType);
+                }
+
+                @Override
+                public void onVideoDecoderInitialized(@NonNull EventTime eventTime,
+                                                      @NonNull String decoderName,
+                                                      long initializedTimestampMs,
+                                                      long initializationDurationMs) {
+                    Log.d(DIAG_TAG, "[videoDecoder] " + decoderName
+                            + " initMs=" + initializationDurationMs);
+                }
+
+                @Override
+                public void onVideoCodecError(@NonNull EventTime eventTime,
+                                              @NonNull Exception videoCodecError) {
+                    Log.e(DIAG_TAG, "[videoCodecError] " + videoCodecError.getClass().getSimpleName()
+                            + ": " + videoCodecError.getMessage(), videoCodecError);
+                }
+
+                @Override
+                public void onAudioEnabled(@NonNull EventTime eventTime,
+                                           @NonNull androidx.media3.exoplayer.DecoderCounters counters) {
+                    Log.d(DIAG_TAG, "[audioEnabled] renderer started");
+                }
+
+                @Override
+                public void onAudioInputFormatChanged(@NonNull EventTime eventTime,
+                                                      @NonNull androidx.media3.common.Format format,
+                                                      @androidx.annotation.Nullable
+                                                      androidx.media3.exoplayer.DecoderReuseEvaluation eval) {
+                    Log.d(DIAG_TAG, "[audioFormat] codecs=" + format.codecs
+                            + " channels=" + format.channelCount
+                            + " sampleRate=" + format.sampleRate
+                            + " sampleMime=" + format.sampleMimeType);
+                }
+
+                @Override
+                public void onAudioDecoderInitialized(@NonNull EventTime eventTime,
+                                                      @NonNull String decoderName,
+                                                      long initializedTimestampMs,
+                                                      long initializationDurationMs) {
+                    Log.d(DIAG_TAG, "[audioDecoder] " + decoderName
+                            + " initMs=" + initializationDurationMs);
+                }
+
+                @Override
+                public void onAudioCodecError(@NonNull EventTime eventTime,
+                                              @NonNull Exception audioCodecError) {
+                    Log.e(DIAG_TAG, "[audioCodecError] " + audioCodecError.getClass().getSimpleName()
+                            + ": " + audioCodecError.getMessage(), audioCodecError);
+                }
+
+                @Override
+                public void onDownstreamFormatChanged(@NonNull EventTime eventTime,
+                                                      @NonNull MediaLoadData mediaLoadData) {
+                    androidx.media3.common.Format f = mediaLoadData.trackFormat;
+                    if (f == null) return;
+                    Log.d(DIAG_TAG, "[abrPick] trackType=" + mediaLoadData.trackType
+                            + " codecs=" + f.codecs
+                            + " w=" + f.width + " h=" + f.height
+                            + " bitrate=" + f.bitrate);
+                }
+
+                @Override
+                public void onPlayWhenReadyChanged(@NonNull EventTime eventTime,
+                                                   boolean playWhenReady, int reason) {
+                    Log.d(DIAG_TAG, "[pwr] " + playWhenReady + " reason=" + reason);
                 }
             });
 

--- a/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
@@ -4,6 +4,7 @@ import android.graphics.Color;
 import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 import android.view.Gravity;
 import android.view.SurfaceView;
 import android.view.View;
@@ -31,8 +32,12 @@ import androidx.media3.exoplayer.DefaultLoadControl;
 import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.exoplayer.LoadControl;
+import androidx.media3.exoplayer.analytics.AnalyticsListener;
 import androidx.media3.exoplayer.hls.HlsMediaSource;
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
+import androidx.media3.exoplayer.source.LoadEventInfo;
+import androidx.media3.exoplayer.source.MediaLoadData;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import androidx.media3.ui.AspectRatioFrameLayout;
@@ -56,6 +61,8 @@ import java.util.Map;
  */
 @CapacitorPlugin(name = "NativePlayer")
 public class NativePlayerPlugin extends Plugin {
+    private static final String DIAG_TAG = "FlksPlayerDiag";
+
     private ExoPlayer player;
     private FrameLayout wrapper;
     private AspectRatioFrameLayout aspectFrame;
@@ -72,6 +79,11 @@ public class NativePlayerPlugin extends Plugin {
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
     private Handler positionHandler;
     private Runnable positionRunnable;
+
+    /** Diagnostic state — tracks last STATE_BUFFERING entry so we can
+     *  report how long we were stuck. Reset on state transitions. */
+    private long bufferingEnteredAt = 0;
+    private String lastRequestedUri = "";
 
     // ── Lifecycle ──
 
@@ -281,6 +293,18 @@ public class NativePlayerPlugin extends Plugin {
             player.addListener(new Player.Listener() {
                 @Override
                 public void onPlaybackStateChanged(int state) {
+                    Log.d(DIAG_TAG, "[state] " + stateName(state)
+                            + " pos=" + player.getCurrentPosition()
+                            + " buf=" + player.getBufferedPosition()
+                            + " playWhenReady=" + player.getPlayWhenReady()
+                            + " isPlaying=" + player.isPlaying());
+                    if (state == Player.STATE_BUFFERING) {
+                        bufferingEnteredAt = System.currentTimeMillis();
+                    } else if (bufferingEnteredAt > 0) {
+                        long delta = System.currentTimeMillis() - bufferingEnteredAt;
+                        Log.d(DIAG_TAG, "[state] BUFFERING exited after " + delta + "ms");
+                        bufferingEnteredAt = 0;
+                    }
                     switch (state) {
                         case Player.STATE_BUFFERING: emitStateChanged("buffering"); break;
                         case Player.STATE_READY: emitStateChanged(player.getPlayWhenReady() ? "playing" : "paused"); break;
@@ -290,6 +314,9 @@ public class NativePlayerPlugin extends Plugin {
                 }
 
                 @Override public void onIsPlayingChanged(boolean isPlaying) {
+                    Log.d(DIAG_TAG, "[playing] " + isPlaying
+                            + " state=" + stateName(player.getPlaybackState())
+                            + " pos=" + player.getCurrentPosition());
                     if (isPlaying) {
                         emitStateChanged("playing");
                     } else if (player.getPlaybackState() == Player.STATE_BUFFERING) {
@@ -301,10 +328,15 @@ public class NativePlayerPlugin extends Plugin {
 
 
                 @Override public void onPlayerError(@NonNull PlaybackException error) {
+                    Log.e(DIAG_TAG, "[error] code=" + error.errorCode
+                            + " name=" + error.getErrorCodeName()
+                            + " msg=" + error.getMessage()
+                            + " lastUri=" + lastRequestedUri, error);
                     emitError(error.errorCode, error.getMessage());
                 }
 
                 @Override public void onTracksChanged(@NonNull Tracks tracks) {
+                    Log.d(DIAG_TAG, "[tracks] groups=" + tracks.getGroups().size());
                     emitTracksChanged();
                     // Apply pending subtitle selection now that tracks are ready
                     if (pendingSubtitleTrackId != null) {
@@ -328,6 +360,7 @@ public class NativePlayerPlugin extends Plugin {
                 }
 
                 @Override public void onRenderedFirstFrame() {
+                    Log.d(DIAG_TAG, "[firstFrame] pos=" + player.getCurrentPosition());
                     emitFirstFrame();
                 }
 
@@ -335,6 +368,43 @@ public class NativePlayerPlugin extends Plugin {
                     if (subtitleView != null) {
                         subtitleView.setCues(cueGroup.cues);
                     }
+                }
+            });
+
+            // Diagnostic AnalyticsListener: captures every HLS segment + manifest
+            // load so when the player gets stuck buffering we can pin down WHICH
+            // request stalled / errored. Track last requested URI on the player
+            // instance so PlayerError can include it.
+            player.addAnalyticsListener(new AnalyticsListener() {
+                @Override
+                public void onLoadStarted(@NonNull EventTime eventTime,
+                                          @NonNull LoadEventInfo loadEventInfo,
+                                          @NonNull MediaLoadData mediaLoadData) {
+                    lastRequestedUri = loadEventInfo.uri.toString();
+                    Log.d(DIAG_TAG, "[load>>] dataType=" + mediaLoadData.dataType
+                            + " uri=" + lastRequestedUri);
+                }
+
+                @Override
+                public void onLoadCompleted(@NonNull EventTime eventTime,
+                                            @NonNull LoadEventInfo loadEventInfo,
+                                            @NonNull MediaLoadData mediaLoadData) {
+                    Log.d(DIAG_TAG, "[load<<] dataType=" + mediaLoadData.dataType
+                            + " bytes=" + loadEventInfo.bytesLoaded
+                            + " elapsed=" + loadEventInfo.loadDurationMs + "ms"
+                            + " uri=" + loadEventInfo.uri);
+                }
+
+                @Override
+                public void onLoadError(@NonNull EventTime eventTime,
+                                        @NonNull LoadEventInfo loadEventInfo,
+                                        @NonNull MediaLoadData mediaLoadData,
+                                        @NonNull IOException error,
+                                        boolean wasCanceled) {
+                    Log.w(DIAG_TAG, "[load!!] dataType=" + mediaLoadData.dataType
+                            + " wasCanceled=" + wasCanceled
+                            + " uri=" + loadEventInfo.uri
+                            + " err=" + error.getMessage());
                 }
             });
 
@@ -778,6 +848,16 @@ public class NativePlayerPlugin extends Plugin {
     private String lastEmittedState = "";
     private long lastNonBufferingAt = 0;
     private static final long BUFFERING_GUARD_MS = 300;
+
+    private static String stateName(int state) {
+        switch (state) {
+            case Player.STATE_IDLE: return "IDLE";
+            case Player.STATE_BUFFERING: return "BUFFERING";
+            case Player.STATE_READY: return "READY";
+            case Player.STATE_ENDED: return "ENDED";
+            default: return "UNKNOWN(" + state + ")";
+        }
+    }
 
     private void emitStateChanged(String state) {
         // Hysteresis on BUFFERING: ExoPlayer can briefly dip below the

--- a/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
@@ -4,7 +4,6 @@ import android.graphics.Color;
 import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
-import android.util.Log;
 import android.view.Gravity;
 import android.view.SurfaceView;
 import android.view.View;
@@ -32,12 +31,7 @@ import androidx.media3.exoplayer.DefaultLoadControl;
 import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.exoplayer.LoadControl;
-import androidx.media3.exoplayer.analytics.AnalyticsListener;
-import androidx.media3.exoplayer.hls.HlsMediaSource;
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
-import androidx.media3.exoplayer.source.LoadEventInfo;
-import androidx.media3.exoplayer.source.MediaLoadData;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import androidx.media3.ui.AspectRatioFrameLayout;
@@ -61,8 +55,6 @@ import java.util.Map;
  */
 @CapacitorPlugin(name = "NativePlayer")
 public class NativePlayerPlugin extends Plugin {
-    private static final String DIAG_TAG = "FlksPlayerDiag";
-
     private ExoPlayer player;
     private FrameLayout wrapper;
     private AspectRatioFrameLayout aspectFrame;
@@ -75,15 +67,22 @@ public class NativePlayerPlugin extends Plugin {
     private DefaultHttpDataSource.Factory httpFactory;
     private String currentHlsUrl;
     private int lastAudioTrackCount = -1;
+    // Cold-prepare bug bootstrap state. Media3 1.10.1's HLS source has
+    // a race on initial track surfacing when the variant carries EAC3
+    // (and especially EAC3-JOC Atmos) audio next to an fMP4 video
+    // track: the audio renderer enables first, the video format hasn't
+    // propagated yet when `selectTracks()` runs, so the video group
+    // is dropped from the selection and the renderer never allocates
+    // a decoder — playback stalls in BUFFERING with audio-only tracks.
+    // A user-issued seek unsticks it by forcing `selectTracks()` to
+    // re-run with the format now available; this flag arms a one-shot
+    // programmatic micro-seek in `onTracksChanged` that mimics that
+    // path when we detect the failure signature.
+    private boolean videoBootstrapDone = false;
     private final List<MediaItem.SubtitleConfiguration> subtitleConfigs = new ArrayList<>();
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
     private Handler positionHandler;
     private Runnable positionRunnable;
-
-    /** Diagnostic state — tracks last STATE_BUFFERING entry so we can
-     *  report how long we were stuck. Reset on state transitions. */
-    private long bufferingEnteredAt = 0;
-    private String lastRequestedUri = "";
 
     // ── Lifecycle ──
 
@@ -253,10 +252,9 @@ public class NativePlayerPlugin extends Plugin {
             // Offline: CacheDataSource (cached HLS) wrapped in DefaultDataSource
             // (adds file:// support for local subtitle VTTs).
             // Online: DefaultDataSource with HTTP factory.
-            DataSource.Factory dataSourceFactory = offline
+            final DataSource.Factory dataSourceFactory = offline
                     ? new DefaultDataSource.Factory(getContext(), FlixDownloadUtil.getCacheDataSourceFactory(getContext()))
                     : new DefaultDataSource.Factory(getContext(), httpFactory);
-            DefaultMediaSourceFactory mediaSourceFactory = new DefaultMediaSourceFactory(dataSourceFactory);
             // 500ms instead of ExoPlayer's default 2500ms — short-segment LAN HLS.
             LoadControl loadControl = new DefaultLoadControl.Builder()
                     .setBufferDurationsMs(3000, 8000, 500, 3000)
@@ -273,6 +271,17 @@ public class NativePlayerPlugin extends Plugin {
                     new DefaultRenderersFactory(getContext())
                             .setEnableAudioFloatOutput(false)
                             .setEnableDecoderFallback(true);
+            // DefaultMediaSourceFactory handles both URL autodetection
+            // (HLS for `.m3u8`, ProgressiveMediaSource for DirectPlay
+            // MP4) and the modern subtitle pipeline (parses external
+            // WebVTT to `application/x-media3-cues` via
+            // SubtitleExtractor before the TextRenderer sees them).
+            // Replicating that machinery with HlsMediaSource.Factory
+            // explicit means re-implementing internal Media3 APIs
+            // (`enableLazyLoadingWithSingleTrack` is package-private)
+            // — not worth the semantic-cleanliness trade-off.
+            DefaultMediaSourceFactory mediaSourceFactory =
+                    new DefaultMediaSourceFactory(dataSourceFactory);
             player = new ExoPlayer.Builder(getContext())
                     .setRenderersFactory(renderersFactory)
                     .setMediaSourceFactory(mediaSourceFactory)
@@ -293,18 +302,6 @@ public class NativePlayerPlugin extends Plugin {
             player.addListener(new Player.Listener() {
                 @Override
                 public void onPlaybackStateChanged(int state) {
-                    Log.d(DIAG_TAG, "[state] " + stateName(state)
-                            + " pos=" + player.getCurrentPosition()
-                            + " buf=" + player.getBufferedPosition()
-                            + " playWhenReady=" + player.getPlayWhenReady()
-                            + " isPlaying=" + player.isPlaying());
-                    if (state == Player.STATE_BUFFERING) {
-                        bufferingEnteredAt = System.currentTimeMillis();
-                    } else if (bufferingEnteredAt > 0) {
-                        long delta = System.currentTimeMillis() - bufferingEnteredAt;
-                        Log.d(DIAG_TAG, "[state] BUFFERING exited after " + delta + "ms");
-                        bufferingEnteredAt = 0;
-                    }
                     switch (state) {
                         case Player.STATE_BUFFERING: emitStateChanged("buffering"); break;
                         case Player.STATE_READY: emitStateChanged(player.getPlayWhenReady() ? "playing" : "paused"); break;
@@ -314,9 +311,6 @@ public class NativePlayerPlugin extends Plugin {
                 }
 
                 @Override public void onIsPlayingChanged(boolean isPlaying) {
-                    Log.d(DIAG_TAG, "[playing] " + isPlaying
-                            + " state=" + stateName(player.getPlaybackState())
-                            + " pos=" + player.getCurrentPosition());
                     if (isPlaying) {
                         emitStateChanged("playing");
                     } else if (player.getPlaybackState() == Player.STATE_BUFFERING) {
@@ -326,17 +320,11 @@ public class NativePlayerPlugin extends Plugin {
                     }
                 }
 
-
                 @Override public void onPlayerError(@NonNull PlaybackException error) {
-                    Log.e(DIAG_TAG, "[error] code=" + error.errorCode
-                            + " name=" + error.getErrorCodeName()
-                            + " msg=" + error.getMessage()
-                            + " lastUri=" + lastRequestedUri, error);
                     emitError(error.errorCode, error.getMessage());
                 }
 
                 @Override public void onTracksChanged(@NonNull Tracks tracks) {
-                    Log.d(DIAG_TAG, "[tracks] groups=" + tracks.getGroups().size());
                     emitTracksChanged();
                     // Apply pending subtitle selection now that tracks are ready
                     if (pendingSubtitleTrackId != null) {
@@ -350,6 +338,58 @@ public class NativePlayerPlugin extends Plugin {
                             pendingVideoHeight = -1;
                         }
                     }
+                    // Cold-prepare bootstrap. Fires at most once per load() to
+                    // recover from a Media3 1.10.1 race where every ExoPlayer
+                    // instance built after the first one in the same JVM gets
+                    // stuck: track selection completes, the audio renderer
+                    // prepares, but the video renderer silently never enables
+                    // and never allocates a decoder — state pins at BUFFERING
+                    // for the rest of the session. The bug reproduces reliably
+                    // on EAC3 5.1 sources (Atmos in particular) and is the same
+                    // hang a user-issued seek unsticks: `seekTo()` cancels the
+                    // in-flight loads and forces the source to re-run
+                    // `selectTracks()`, which wakes the renderer pipeline.
+                    if (!videoBootstrapDone) {
+                        boolean videoSelected = false;
+                        boolean videoSupported = false;
+                        for (Tracks.Group g : tracks.getGroups()) {
+                            if (g.getType() != C.TRACK_TYPE_VIDEO) continue;
+                            if (g.isSelected()) videoSelected = true;
+                            for (int i = 0; i < g.length; i++) {
+                                if (g.isTrackSupported(i)) {
+                                    videoSupported = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if (videoSelected) {
+                            // Common case: video track picked. Watchdog reads
+                            // playback state 1.5 s later; if the renderer
+                            // actually started (state != BUFFERING) the seek is
+                            // skipped, so healthy playback is untouched. When
+                            // the bug strikes, state is still BUFFERING and we
+                            // issue a 1 ms forward seek — imperceptible drift
+                            // (well below one frame at 24 fps).
+                            videoBootstrapDone = true;
+                            mainHandler.postDelayed(() -> {
+                                if (player == null) return;
+                                if (player.getPlaybackState() == Player.STATE_BUFFERING) {
+                                    player.seekTo(player.getCurrentPosition() + 1);
+                                }
+                            }, 1500);
+                        } else if (videoSupported) {
+                            // Less common signature: the selector dropped the
+                            // video group entirely (audio surfaced first, the
+                            // video format hadn't propagated). 200 ms is enough
+                            // for the format to arrive before the recovery seek
+                            // re-runs the selection.
+                            videoBootstrapDone = true;
+                            mainHandler.postDelayed(() -> {
+                                if (player == null) return;
+                                player.seekTo(player.getCurrentPosition() + 1);
+                            }, 200);
+                        }
+                    }
                 }
 
                 @Override public void onVideoSizeChanged(@NonNull VideoSize videoSize) {
@@ -360,7 +400,6 @@ public class NativePlayerPlugin extends Plugin {
                 }
 
                 @Override public void onRenderedFirstFrame() {
-                    Log.d(DIAG_TAG, "[firstFrame] pos=" + player.getCurrentPosition());
                     emitFirstFrame();
                 }
 
@@ -369,136 +408,7 @@ public class NativePlayerPlugin extends Plugin {
                         subtitleView.setCues(cueGroup.cues);
                     }
                 }
-            });
 
-            // Diagnostic AnalyticsListener: captures every HLS segment + manifest
-            // load AND the video/audio renderer lifecycle so when the player
-            // gets stuck buffering we can pin down whether the decoder was
-            // even instantiated and which format ExoPlayer picked.
-            player.addAnalyticsListener(new AnalyticsListener() {
-                @Override
-                public void onLoadStarted(@NonNull EventTime eventTime,
-                                          @NonNull LoadEventInfo loadEventInfo,
-                                          @NonNull MediaLoadData mediaLoadData) {
-                    lastRequestedUri = loadEventInfo.uri.toString();
-                    Log.d(DIAG_TAG, "[load>>] dataType=" + mediaLoadData.dataType
-                            + " trackType=" + mediaLoadData.trackType
-                            + " uri=" + lastRequestedUri);
-                }
-
-                @Override
-                public void onLoadCompleted(@NonNull EventTime eventTime,
-                                            @NonNull LoadEventInfo loadEventInfo,
-                                            @NonNull MediaLoadData mediaLoadData) {
-                    Log.d(DIAG_TAG, "[load<<] dataType=" + mediaLoadData.dataType
-                            + " trackType=" + mediaLoadData.trackType
-                            + " bytes=" + loadEventInfo.bytesLoaded
-                            + " elapsed=" + loadEventInfo.loadDurationMs + "ms"
-                            + " uri=" + loadEventInfo.uri);
-                }
-
-                @Override
-                public void onLoadError(@NonNull EventTime eventTime,
-                                        @NonNull LoadEventInfo loadEventInfo,
-                                        @NonNull MediaLoadData mediaLoadData,
-                                        @NonNull IOException error,
-                                        boolean wasCanceled) {
-                    Log.w(DIAG_TAG, "[load!!] dataType=" + mediaLoadData.dataType
-                            + " wasCanceled=" + wasCanceled
-                            + " uri=" + loadEventInfo.uri
-                            + " err=" + error.getMessage());
-                }
-
-                @Override
-                public void onVideoEnabled(@NonNull EventTime eventTime,
-                                           @NonNull androidx.media3.exoplayer.DecoderCounters counters) {
-                    Log.d(DIAG_TAG, "[videoEnabled] renderer started");
-                }
-
-                @Override
-                public void onVideoDisabled(@NonNull EventTime eventTime,
-                                            @NonNull androidx.media3.exoplayer.DecoderCounters counters) {
-                    Log.d(DIAG_TAG, "[videoDisabled] dropped=" + counters.droppedBufferCount
-                            + " skipped=" + counters.skippedOutputBufferCount);
-                }
-
-                @Override
-                public void onVideoInputFormatChanged(@NonNull EventTime eventTime,
-                                                      @NonNull androidx.media3.common.Format format,
-                                                      @androidx.annotation.Nullable
-                                                      androidx.media3.exoplayer.DecoderReuseEvaluation eval) {
-                    Log.d(DIAG_TAG, "[videoFormat] codecs=" + format.codecs
-                            + " w=" + format.width + " h=" + format.height
-                            + " peakBitrate=" + format.peakBitrate
-                            + " colorInfo=" + (format.colorInfo != null ? format.colorInfo.toString() : "null")
-                            + " sampleMime=" + format.sampleMimeType);
-                }
-
-                @Override
-                public void onVideoDecoderInitialized(@NonNull EventTime eventTime,
-                                                      @NonNull String decoderName,
-                                                      long initializedTimestampMs,
-                                                      long initializationDurationMs) {
-                    Log.d(DIAG_TAG, "[videoDecoder] " + decoderName
-                            + " initMs=" + initializationDurationMs);
-                }
-
-                @Override
-                public void onVideoCodecError(@NonNull EventTime eventTime,
-                                              @NonNull Exception videoCodecError) {
-                    Log.e(DIAG_TAG, "[videoCodecError] " + videoCodecError.getClass().getSimpleName()
-                            + ": " + videoCodecError.getMessage(), videoCodecError);
-                }
-
-                @Override
-                public void onAudioEnabled(@NonNull EventTime eventTime,
-                                           @NonNull androidx.media3.exoplayer.DecoderCounters counters) {
-                    Log.d(DIAG_TAG, "[audioEnabled] renderer started");
-                }
-
-                @Override
-                public void onAudioInputFormatChanged(@NonNull EventTime eventTime,
-                                                      @NonNull androidx.media3.common.Format format,
-                                                      @androidx.annotation.Nullable
-                                                      androidx.media3.exoplayer.DecoderReuseEvaluation eval) {
-                    Log.d(DIAG_TAG, "[audioFormat] codecs=" + format.codecs
-                            + " channels=" + format.channelCount
-                            + " sampleRate=" + format.sampleRate
-                            + " sampleMime=" + format.sampleMimeType);
-                }
-
-                @Override
-                public void onAudioDecoderInitialized(@NonNull EventTime eventTime,
-                                                      @NonNull String decoderName,
-                                                      long initializedTimestampMs,
-                                                      long initializationDurationMs) {
-                    Log.d(DIAG_TAG, "[audioDecoder] " + decoderName
-                            + " initMs=" + initializationDurationMs);
-                }
-
-                @Override
-                public void onAudioCodecError(@NonNull EventTime eventTime,
-                                              @NonNull Exception audioCodecError) {
-                    Log.e(DIAG_TAG, "[audioCodecError] " + audioCodecError.getClass().getSimpleName()
-                            + ": " + audioCodecError.getMessage(), audioCodecError);
-                }
-
-                @Override
-                public void onDownstreamFormatChanged(@NonNull EventTime eventTime,
-                                                      @NonNull MediaLoadData mediaLoadData) {
-                    androidx.media3.common.Format f = mediaLoadData.trackFormat;
-                    if (f == null) return;
-                    Log.d(DIAG_TAG, "[abrPick] trackType=" + mediaLoadData.trackType
-                            + " codecs=" + f.codecs
-                            + " w=" + f.width + " h=" + f.height
-                            + " bitrate=" + f.bitrate);
-                }
-
-                @Override
-                public void onPlayWhenReadyChanged(@NonNull EventTime eventTime,
-                                                   boolean playWhenReady, int reason) {
-                    Log.d(DIAG_TAG, "[pwr] " + playWhenReady + " reason=" + reason);
-                }
             });
 
             MediaItem.Builder itemBuilder = new MediaItem.Builder()
@@ -508,6 +418,7 @@ public class NativePlayerPlugin extends Plugin {
             }
             player.setMediaItem(itemBuilder.build());
             lastAudioTrackCount = -1; // Reset so emitTracksChanged fires for new media
+            videoBootstrapDone = false; // Arm cold-prepare bug bootstrap
 
             // Disable text tracks by default — user selects via UI
             player.setTrackSelectionParameters(
@@ -942,16 +853,6 @@ public class NativePlayerPlugin extends Plugin {
     private long lastNonBufferingAt = 0;
     private static final long BUFFERING_GUARD_MS = 300;
 
-    private static String stateName(int state) {
-        switch (state) {
-            case Player.STATE_IDLE: return "IDLE";
-            case Player.STATE_BUFFERING: return "BUFFERING";
-            case Player.STATE_READY: return "READY";
-            case Player.STATE_ENDED: return "ENDED";
-            default: return "UNKNOWN(" + state + ")";
-        }
-    }
-
     private void emitStateChanged(String state) {
         // Hysteresis on BUFFERING: ExoPlayer can briefly dip below the
         // rebuffer threshold after a seek and oscillate ready ↔ buffering
@@ -995,7 +896,18 @@ public class NativePlayerPlugin extends Plugin {
         positionHandler = new Handler(Looper.getMainLooper());
         positionRunnable = new Runnable() {
             @Override public void run() {
-                if (player != null && player.isPlaying()) {
+                // Emit while the player exists, not only while
+                // isPlaying() is true. NativeEngine's firstFrame
+                // fallback (in native-engine.ts) needs a second
+                // event with a growing position to clear the loading
+                // veil — gating on isPlaying() locked the UI on the
+                // spinner whenever Media3 spent its prepare time in
+                // STATE_BUFFERING (isPlaying() is false in that
+                // state). Was harmless when NativeEngine also polled
+                // getPosition() every second; that JS polling was
+                // dropped in commit 9e2269dc as redundant, which made
+                // this push the sole signal.
+                if (player != null) {
                     double pos = player.getCurrentPosition() / 1000.0;
                     double dur = player.getDuration() != C.TIME_UNSET ? player.getDuration() / 1000.0 : 0;
                     double buf = player.getBufferedPosition() / 1000.0;

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -998,47 +998,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // separate stateChanged 'playing' hook needed — that fires on
     // STATE_READY which can precede the first frame on cold starts.
     engine.on('firstFrame', () => {
-      console.log('[Player.diag] firstFrame received pos=', engine.currentTime);
       this.state.videoStarted.set(true);
-    });
-
-    // Buffering watchdog: log a full state dump if the player is stuck
-    // buffering for more than 30 s. Tied to the engine's stateChanged
-    // event so it cancels naturally on any transition away from
-    // buffering. The dump is enough to root-cause the intermittent
-    // Android stall (last requested segment URI shows up in adb logcat
-    // under tag `FlksPlayerDiag` on the native side).
-    let bufferingWatchdog: ReturnType<typeof setTimeout> | null = null;
-    let bufferingEnteredAt = 0;
-    engine.on('stateChanged', (e) => {
-      console.log('[Player.diag] stateChanged →', e.state, 'pos=', engine.currentTime, 'paused=', engine.paused, 'buffered=', engine.buffered);
-      if (e.state === 'buffering') {
-        bufferingEnteredAt = Date.now();
-        if (bufferingWatchdog) clearTimeout(bufferingWatchdog);
-        bufferingWatchdog = setTimeout(() => {
-          console.error('[Player.watchdog] stalled — buffering 30s+', {
-            engineState: e.state,
-            currentTime: engine.currentTime,
-            duration: engine.duration,
-            buffered: engine.buffered,
-            paused: engine.paused,
-            playbackMode: this.playbackMode(),
-            hwAccel: this.state.hwAccel(),
-            quality: this.activeQualityId(),
-            isNative: this.isNativeEngine(),
-            mediaFileId: this.mediaFileId,
-          });
-        }, 30_000);
-      } else {
-        if (bufferingWatchdog) {
-          const elapsed = Date.now() - bufferingEnteredAt;
-          if (elapsed > 1000) {
-            console.log('[Player.diag] buffering cleared after', elapsed, 'ms');
-          }
-          clearTimeout(bufferingWatchdog);
-          bufferingWatchdog = null;
-        }
-      }
     });
 
     // Listen for audio tracks from native engine.

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -998,7 +998,47 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // separate stateChanged 'playing' hook needed — that fires on
     // STATE_READY which can precede the first frame on cold starts.
     engine.on('firstFrame', () => {
+      console.log('[Player.diag] firstFrame received pos=', engine.currentTime);
       this.state.videoStarted.set(true);
+    });
+
+    // Buffering watchdog: log a full state dump if the player is stuck
+    // buffering for more than 30 s. Tied to the engine's stateChanged
+    // event so it cancels naturally on any transition away from
+    // buffering. The dump is enough to root-cause the intermittent
+    // Android stall (last requested segment URI shows up in adb logcat
+    // under tag `FlksPlayerDiag` on the native side).
+    let bufferingWatchdog: ReturnType<typeof setTimeout> | null = null;
+    let bufferingEnteredAt = 0;
+    engine.on('stateChanged', (e) => {
+      console.log('[Player.diag] stateChanged →', e.state, 'pos=', engine.currentTime, 'paused=', engine.paused, 'buffered=', engine.buffered);
+      if (e.state === 'buffering') {
+        bufferingEnteredAt = Date.now();
+        if (bufferingWatchdog) clearTimeout(bufferingWatchdog);
+        bufferingWatchdog = setTimeout(() => {
+          console.error('[Player.watchdog] stalled — buffering 30s+', {
+            engineState: e.state,
+            currentTime: engine.currentTime,
+            duration: engine.duration,
+            buffered: engine.buffered,
+            paused: engine.paused,
+            playbackMode: this.playbackMode(),
+            hwAccel: this.state.hwAccel(),
+            quality: this.activeQualityId(),
+            isNative: this.isNativeEngine(),
+            mediaFileId: this.mediaFileId,
+          });
+        }, 30_000);
+      } else {
+        if (bufferingWatchdog) {
+          const elapsed = Date.now() - bufferingEnteredAt;
+          if (elapsed > 1000) {
+            console.log('[Player.diag] buffering cleared after', elapsed, 'ms');
+          }
+          clearTimeout(bufferingWatchdog);
+          bufferingWatchdog = null;
+        }
+      }
     });
 
     // Listen for audio tracks from native engine.


### PR DESCRIPTION
## Summary

Three independent fixes landed together, all surfaced while chasing the *"player stuck in BUFFERING after second open"* report on Android.

### 1. Android cold-prepare bug (`NativePlayerPlugin.java`)

Media3 1.10.1 has a race where every ExoPlayer instance built after the first one in the same JVM can get stuck: track selection completes, audio renderer prepares, but the video renderer silently never enables — state pins at BUFFERING for the rest of the session. Reproduces reliably on EAC3 5.1 sources (Atmos in particular). It's the same hang a user-issued seek unsticks.

- `onTracksChanged` arms a 1.5 s watchdog on first track surface. If playback state is still BUFFERING when it fires, we issue a 1 ms forward seek (well under one frame at 24 fps). Healthy startups are untouched — state has already moved to READY by then.
- Time-update emission no longer gates on `player.isPlaying()`. The previous gate locked the spinner on every BUFFERING window — the #142 `firstFrame` fallback (`NativeEngine`, position-grew-between-two-updates) needed two events to fire, and those events were suppressed exactly when the fallback was supposed to recover. Was harmless when `NativeEngine` also polled `getPosition()` every second; that JS polling was dropped in #140 as redundant, which made this push the sole signal.

### 2. BT.709 SDR tagging on every SDR output (`ffmpeg-args.ts`)

Previously gated on `tonemap && !isHdrOutput`. Sources with unsignalled colorimetry (older WEBDL H.264 masters: all four of `color_primaries`/`_trc`/`_space`/`_range` = `unknown` on ffprobe) propagated the `unknown` tags into the encoded SPS VUI. Android Media3 with the HDR-preserving `SurfaceView` path can refuse to initialise MediaCodec on cold prepare when the VUI is fully unsigned. Always tagging BT.709 limited on non-HDR output is a no-op when the source already carries valid tags.

### 3. Codec-string level derived from emitted height (`master-playlist.ts`)

`h264CodecString` / `hevcMain10CodecStringForHeight` were called with `p.maxHeight` (1080, 720, …). For cropped content (Arcane: source 1920×1080 → crop 1920×816 → 1080p rung emits 1920×816 at L3.2, not L4.2) the master advertised a level above what the bitstream SPS actually signals. The declared > SPS mismatch can leave Media3's track selector stuck on cold prepare. Derive the level from the actual emitted resolution (`h` from `profileResolution`) so master and bitstream agree.

## Test plan

- [x] Android: first open of any media plays normally (no spinner delay on the healthy path)
- [x] Android: reopen same media within the same JVM — was reliably stuck before, now unsticks within ~1.5 s
- [x] Android: Arcane (cropped H.264 + EAC3 5.1) plays after the watchdog seek
- [x] Android: subtitles still work
- [x] iOS / web (Shaka): unchanged, no regression
- [ ] Validate one more cold start cycle on a fresh device profile