### PR TITLE
fix(cast): codec drift respawn + H.264 level fix + cast profile pi from player

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -506,6 +506,39 @@ export class StreamingController {
       sv?.height ?? 0,
     );
 
+    // Device-profile drift detection. A single user can hop between a
+    // browser tab (which accepts EAC-3 copy on 2-ch) and the Chromecast
+    // (AAC transcode only) without unloading the file. The session map
+    // is keyed (mediaFileId, userId), so both hops share the same
+    // entry — and prewarm short-circuits on `existing.exitCode === null`
+    // without comparing plans. The result is a manifest advertising the
+    // new codec while ffmpeg keeps writing segments in the old one,
+    // tripping Shaka 4032 (CONTENT_UNSUPPORTED_BY_BROWSER) on Cast.
+    // Kill the running session whenever the new audio plan or the new
+    // video variant disagrees with what it was spawned for; the prewarm
+    // immediately below then respawns with the up-to-date plan.
+    const newAudioCodec = result.audioPlan?.codec;
+    const newVideoCodec = this.activeStreamTracker
+      .getVideoVariant(mediaFileId)
+      ?.codec;
+    const existingForDrift = this.transcodingService.getExistingSession(
+      mediaFileId,
+      req.user?.id,
+    );
+    if (
+      existingForDrift &&
+      existingForDrift.process.exitCode === null &&
+      (existingForDrift.audioPlan?.codec !== newAudioCodec ||
+        existingForDrift.videoVariant?.codec !== newVideoCodec)
+    ) {
+      this.log.log(
+        `[playback-info] profile drift on file ${mediaFileId} — killing session ` +
+          `(audio: ${existingForDrift.audioPlan?.codec ?? '∅'} → ${newAudioCodec ?? '∅'}, ` +
+          `video: ${existingForDrift.videoVariant?.codec ?? '∅'} → ${newVideoCodec ?? '∅'})`,
+      );
+      await this.transcodingService.killSession(mediaFileId, req.user?.id);
+    }
+
     // Pre-spawn ffmpeg as early as possible — the client will GET master.m3u8
     // next (~100–300ms later) and then seg-0. Starting ffmpeg here overlaps
     // that gap with encoder init so segment 0 is usually already on disk

--- a/backend/src/modules/streaming/transcoding/codec/codec-strings.ts
+++ b/backend/src/modules/streaming/transcoding/codec/codec-strings.ts
@@ -12,17 +12,53 @@ import type { EncoderTarget, HdrFormat } from './types';
  */
 
 /** H.264 — `avc1.PPCCLL` (6 hex digits). High profile = `64`, constraint
- *  set byte `00` (no flags), level encoded as hex. Levels are sized to
- *  cover 60 fps at the rung resolution. */
+ *  set byte `00` (no flags), level encoded as hex.
+ *
+ *  Level matches what the encoder actually emits: H.264 encoders
+ *  (h264_qsv, libx264, h264_vaapi, h264_nvenc, h264_videotoolbox) pick
+ *  the lowest level whose `MaxMBPerSec` covers the rung's macroblock
+ *  rate, and forcing a higher level via `-level:v` is fragile (qsv
+ *  refuses, others happily ignore). A 1080p24 transcode runs at
+ *  ~49 M luma samples/s — well within L4.0 (62 M) — so the encoder
+ *  picks L4.0. An overpromise like `64002a` (L4.2) makes Cast Shaka
+ *  reject the variant with 4032 CONTENT_UNSUPPORTED_BY_BROWSER because
+ *  the bitstream level_idc (40) doesn't match the manifest claim (42).
+ *  Drive the level off luma sample rate to keep manifest == bitstream. */
 export function h264CodecString(target: EncoderTarget): string {
-  const { height } = target;
-  if (height >= 2160) return 'avc1.640034'; // High @ L5.2 — 4K60
-  if (height >= 1080) return 'avc1.64002a'; // High @ L4.2 — 1080p60 + headroom
-  if (height >= 720) return 'avc1.640020'; //  High @ L3.2 — 720p60
-  if (height >= 480) return 'avc1.64001f'; //  High @ L3.1 — 480p60
-  if (height >= 360) return 'avc1.64001e'; //  High @ L3.0 — 360p30
-  if (height >= 240) return 'avc1.640015'; //  High @ L2.1 — 240p60
-  return 'avc1.64000d'; //                     High @ L1.3 — 144p
+  // Pick the lowest level whose MaxFS (frame size in macroblocks) AND
+  // MaxMBPerSec (macroblock rate) both cover this rung — mirrors what
+  // every H.264 encoder we drive does internally. A pure luma-sample-rate
+  // bucket would mis-classify 1080p24 (49 M samples/s, fits L3.2 by
+  // rate) as L3.2 even though MaxFS=5120 MB rejects the 8160-MB frame.
+  // The level_idc that ends up in the SPS would be L4.0; advertising
+  // L3.2 in the manifest then trips Cast Shaka with 4032
+  // CONTENT_UNSUPPORTED_BY_BROWSER.
+  const mbPerFrame = Math.ceil(target.width / 16) * Math.ceil(target.height / 16);
+  const mbPerSec = mbPerFrame * target.frameRate;
+  // [hex level_idc, MaxFS, MaxMBPerSec]
+  const levels: Array<[string, number, number]> = [
+    ['0a', 99, 1485], //       L1.0
+    ['0c', 396, 3000], //      L1.2
+    ['0d', 396, 11880], //     L1.3
+    ['15', 792, 19800], //     L2.1
+    ['16', 1620, 20250], //    L2.2
+    ['1e', 1620, 40500], //    L3.0
+    ['1f', 3600, 108000], //   L3.1
+    ['20', 5120, 216000], //   L3.2
+    ['28', 8192, 245760], //   L4.0
+    ['29', 8192, 245760], //   L4.1
+    ['2a', 8704, 522240], //   L4.2
+    ['32', 22080, 589824], //  L5.0
+    ['33', 36864, 983040], //  L5.1
+    ['34', 36864, 2073600], // L5.2
+  ];
+  for (const [lvl, maxFS, maxMBPS] of levels) {
+    if (mbPerFrame <= maxFS && mbPerSec <= maxMBPS) {
+      return `avc1.6400${lvl}`;
+    }
+  }
+  return 'avc1.640034'; // Above L5.2 falls back to its codec string; the
+  // encoder will refuse the stream anyway.
 }
 
 /** HEVC SDR Main 8-bit — `hvc1.1.6.L<level*30>.B0`. Profile = Main,

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -1321,6 +1321,8 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     session.mediaType = ctx.mediaType;
     session.posterUrl = ctx.posterUrl;
     session.transcodeReasons = ctx.transcodeReasons;
+    session.audioPlan = ctx.audioPlan;
+    session.videoVariant = ctx.videoVariant;
     if (!session.startedAt) session.startedAt = new Date();
   }
 

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -186,4 +186,21 @@ export interface TranscodeSession {
    *  change, etc.) so the close handler doesn't log a spurious "exited
    *  WITHOUT producing first segment" warning. */
   intentionallyKilled?: boolean;
+  /** Audio output the session was spawned for. Compared against the
+   *  fresh playback-info plan on every subsequent /playback-info call;
+   *  a codec drift (e.g. Chromecast picking AAC where browser was on
+   *  EAC-3 copy) forces a kill+respawn so the segments stay coherent
+   *  with the master.m3u8 CODECS string the player will see. */
+  audioPlan?:
+    | { mode: 'copy'; codec: string }
+    | {
+        mode: 'transcode';
+        codec: 'aac' | 'ac3' | 'eac3';
+        bitrateBps: number;
+      };
+  /** Video variant the session was spawned for. Same role as
+   *  `audioPlan` above: any divergence between a fresh playback-info
+   *  decision and the running session means the segments contradict
+   *  the manifest, so the session must respawn. */
+  videoVariant?: import('./codec/types').CodecVariant;
 }

--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -113,7 +113,7 @@ export class CastPlayerService {
    *  that doesn't answer the probe), we fall back to AAC-only stereo — a
    *  Cast generation we don't recognise is safer downmixed than failing
    *  to play. */
-  private getCastDeviceProfile(): DeviceProfile {
+  getCastDeviceProfile(): DeviceProfile {
     const cs = this.castSettings.get();
     const maxChannels = cs.audioChannels ?? 2;
 

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1368,12 +1368,26 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
   /** Push current player state to the CastPlayerService and start streaming. */
   private async startCastFromPlayer(position?: number) {
-    // Don't reuse the local player's quality list — that's the web ladder
-    // (Auto + every Shaka rung up to source). Cast forces transcode and is
-    // capped by the user's Cast-side maxQuality preference. Pass the
-    // backend-authoritative qualities through the cast filter.
+    // Re-derive the quality ladder from a fresh playback-info call made
+    // with the Cast device profile, not the local player's pi. The
+    // local pi was computed with the browser profile that accepts HEVC,
+    // so its top rung is `'original'` (remux) at the source bitrate;
+    // Cast can't direct-play HEVC and the cast ladder is a pure H.264
+    // transcode set with the source-resolution rung at the profile
+    // bitrate (e.g. 8 Mbps for 1080p). Reusing the browser pi here
+    // makes `buildCastQualityOptions` drop the `'original'` entry and
+    // present the wrong bitrates in the cast dropdown.
+    const castProfile = this.castPlayerService.getCastDeviceProfile();
+    const castPi = await this.streamingApi.getPlaybackInfo(
+      this.mediaFileId,
+      castProfile,
+      this.activeBurnInId ?? undefined,
+      this.activeAudioStreamIndex ?? undefined,
+      undefined,
+      position != null ? Math.floor(position) : undefined,
+    );
     const castQualities = buildCastQualityOptions(
-      this.playbackInfo?.qualities,
+      castPi.qualities,
       this.castSettings.get().maxQuality,
     );
     // Snap the active pick onto the cast list when the local quality (e.g.


### PR DESCRIPTION
## Summary

Three independent fixes for Chromecast playback regressions surfaced after the transcode engine refactor.

### 1. `4ecae065` — respawn ffmpeg on audio/video codec drift between playback-info calls

A single user hopping browser-tab ↔ Chromecast on the same file shares the same transcode session (key `(mediaFileId, userId)`). The two contexts declare different device profiles:
- Browser: accepts EAC-3 copy on 2-ch → `audioPlan = { mode: copy, codec: eac3 }`
- Cast: filters EAC-3 out → `audioPlan = { mode: transcode, codec: aac }`

The fresh `master.m3u8` advertised the new codec, but prewarm short-circuited on `existing.exitCode === null` and the original ffmpeg kept emitting in the old codec. Cast Shaka then asked MSE for `audio/mp4; codecs="mp4a.40.2"`, got the still-EAC-3 init segment, bailed with Shaka 4032 `CONTENT_UNSUPPORTED_BY_BROWSER`.

Record `audioPlan` + `videoVariant` on the `TranscodeSession` itself (already on `SessionContext`, just thread through `applyContext`). In `/playback-info`, compare against the running session's plan after the stream-builder decision lands — kill on drift, prewarm respawns fresh. Matching codecs are a no-op; quality-only switches with the same codec stay on the existing session.

### 2. `7d5aaf22` — drive H.264 codec level from MaxFS + MaxMBPerSec

`h264CodecString` returned `avc1.64002a` (L4.2) for any height ≥ 1080. But H.264 encoders (h264_qsv, libx264, h264_vaapi, h264_nvenc, h264_videotoolbox) pick the lowest level whose Annex A constraints (MaxFS frame-size cap + MaxMBPerSec macroblock-rate cap) are both satisfied. A 1080p24 transcode (8160 MB frame, 196k mb/s) lands at L4.0 — so the SPS carries `level_idc=40` while the manifest claimed `level_idc=42`.

Cast Shaka 4.15 cross-checks manifest level against bitstream SPS and rejects mismatched variants with the same 4032 error. Visible symptom: black-screen LOAD failure on receiver with no actionable log.

Replace the height-only ladder with the spec-table lookup against MaxFS + MaxMBPerSec — same pattern the HEVC helper already uses. Forcing `-level:v` on the encoder side is fragile (qsv refuses on iHD), so matching what the encoder auto-picks is the safer side of the contract.

### 3. `1f161ed6` — re-fetch playback-info with cast profile when casting from player

`startCastFromPlayer` was reusing `this.playbackInfo` (computed from the browser device profile) to build the cast quality dropdown. The browser profile accepts the source codec (typically HEVC), so the backend returns the source-resolution rung as `'original'` (remux at source bitrate ~1.4 Mbps for a typical 1080p HEVC episode).

`buildCastQualityOptions` then drops the `'original'` rung — cast forces transcode — so the dropdown loses the source-resolution row entirely. The bitrates shown elsewhere don't match what the cast session will actually stream (cast ladder is full H.264 transcode at the profile bitrate, e.g. 8 Mbps for 1080p).

Fetch a fresh playback-info with the cast device profile before building the dropdown — same path `quickStart` already takes for the outside-player cast flow. Expose `getCastDeviceProfile()` so the player can grab the cast cap list without re-deriving it.

## Test plan

- [x] Backend `tsc --noEmit` clean
- [x] Client `tsc --noEmit` clean
- [x] Live verify: master playlist now emits `avc1.640028` (L4.0) for 1080p24 sources; SPS in `seg-NNNN.m4s` confirmed `level=40`; codecs match
- [x] Live verify: `playback-info` with Cast profile vs Browser profile returns different ladders (cast = full transcode, browser = remux at 'original')
- [ ] Cast cold-start: open file in Chromecast from the home library — Shaka receiver no longer throws 4032 on LOAD
- [ ] Cast from player: open file in local player → click Cast → quality dropdown shows the same rungs/labels as the outside-player cast flow
- [ ] Cast → disconnect → resume local player: backend respawns ffmpeg with the browser audio plan, local playback resumes without manual reload
- [ ] Mid-playback quality switch (same codec): no spurious kill (fast-path preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)