### PR TITLE
Tizen HLS-fMP4 fix + player seek pinning + chores (#148)

### DIFF
--- a/backend/docs/streaming/tizen-fmp4.md
+++ b/backend/docs/streaming/tizen-fmp4.md
@@ -1,0 +1,118 @@
+# Tizen AVPlay HLS-fMP4 compatibility (issue #148)
+
+Samsung Tizen Smart TVs run HLS streams through the proprietary **AVPlay**
+media engine (`webapis.avplay.*`), not the browser's `<video>` element.
+AVPlay's HLS-fMP4 parser is strict: it only accepts a narrow subset of
+the spec — anything that diverges from Apple's reference shape either
+crashes with `InvalidAccessError` / `PLAYER_ERROR_CONNECTION_FAILED` or
+silently stalls (no error, no playback).
+
+This doc captures the two production changes that make our fMP4 output
+play on every Tizen firmware we've tested, plus the escape hatches we
+keep around for future firmware regressions.
+
+## 1. CMAF post-processing — `cmaf-rewrite.ts`
+
+FFmpeg's HLS muxer hardcodes `movflags=+frag_custom+dash+delay_moov` in
+`libavformat/hlsenc.c::hls_mux_init`, so `-movflags +cmaf` is silently
+ignored. The on-disk segments come out as pure DASH:
+
+```
+init.mp4 :  ftyp(iso5, compat = iso5 iso6 mp41) + moov
+seg.m4s  :  styp(msdh, compat = msdh cmfc) + sidx + sidx + moof + mdat
+```
+
+Apple's reference HLS-fMP4
+(`devstreaming-cdn.apple.com/.../adv_dv_atmos/...`) ships:
+
+```
+init.mp4 :  ftyp(iso5, compat = isom iso5 hlsf) + moov
+seg.m4s  :  (optional emsg) + moof + mdat                    -- no styp, no sidx
+```
+
+The load-bearing differences are:
+
+| Property            | FFmpeg HLS muxer | Apple HLS-fMP4 reference | What we do |
+| ------------------- | ---------------- | ------------------------ | ---------- |
+| `ftyp` compat brand | `iso5 iso6 mp41` | `isom iso5 hlsf`         | Append `hlsf` |
+| `styp` on segments  | present (`msdh`) | absent                   | Strip      |
+| `sidx` on segments  | 2 boxes          | absent                   | Strip      |
+
+`hlsf` ("HLS Fragmented MP4") is the marker AVPlay's parser dispatches
+on — without it, the segment is treated as DASH and rejected.
+
+`ensureCmafRewritten()` runs in-place on every served `init.mp4` /
+`*.m4s` (5 call sites in `streaming.controller.ts`). The transform is
+idempotent (checked via `isCmafRewritten()`) and atomic
+(`writeFile(.tmp) + rename(2)`). Avg cost on a 2–3 MB segment is
+sub-millisecond.
+
+## 2. Always-separate audio/video on fMP4 — `pickAudioLayout()`
+
+AVPlay's HLS-fMP4 parser ALSO requires the same Apple-reference
+"one-track-per-init.mp4" shape — a muxed `init.mp4` carrying both
+`VideoHandler` and `SoundHandler` tracks stalls playback even though no
+error fires. (Tested on Tizen 6.5 / 7.0 / 8.0 firmwares.)
+
+`pickAudioLayout()` in `streaming.controller.ts` is the single source of
+truth used by:
+
+- `buildSessionContext()` — sets `videoOnly` + `audioStreams[]` on the
+  ffmpeg session context.
+- `hlsMaster()` — decides whether to emit `EXT-X-MEDIA` lines.
+- `playback-info` drift detection — kills the running session when the
+  layout flips (e.g. when a user toggles `useTs`).
+
+Rules:
+
+| Audio count | Mux flavour | Layout            |
+| ----------- | ----------- | ----------------- |
+| 0           | any         | `inline`          |
+| 1           | `fmp4`      | `var-stream-map`  |
+| 1           | `ts`        | `inline`          |
+| ≥ 2         | any         | `var-stream-map`  |
+
+MPEG-TS muxes V+A natively in a single PMT and every parser handles the
+muxed flavour — including Tizen — so the TS path stays muxed when
+there's only one audio track. fMP4 always uses the EXT-X-MEDIA layout
+once there's any audio, even for a single track.
+
+## 3. `useTs` escape hatch
+
+A boolean field on `DeviceProfileDto`. When true the backend emits
+`-hls_segment_type mpegts` (no CMAF rewriting, no `var_stream_map` for
+single-audio). Useful when:
+
+- A new TV firmware regresses on HLS-fMP4 before we ship a backend fix.
+- A power user wants to bisect a TV-side bug.
+
+Toggled per-device by setting `localStorage['fliks.useTs'] = '1'` in
+the browser/WGT console. The flag flows from
+`browser-device-profile.service.ts` → `playback-info` →
+`activeStreamTracker.setUseTs` and is read by `pickAudioLayout` (mux
+flavour gate) and `ffmpeg-args.ts` (segment type).
+
+Drift detection in `playback-info` notices when the flag flips mid-file
+and kills the running session, so the next segment request respawns
+ffmpeg with the correct mux flavour and segment layout.
+
+## Verifying a Tizen firmware
+
+A quick smoke-test sequence for a new TV model:
+
+1. **Multi-audio source** (e.g. a Blu-ray rip with FR/EN tracks). Should
+   play without any flag set. Confirms both the rewriter and the
+   `var-stream-map` layout work end-to-end.
+2. **Single-audio source**. Should also play without any flag — confirms
+   the always-separate gate fires on single-audio fMP4.
+3. **`fliks.useTs = '1'`** on any file. Should still play, but via the
+   MPEG-TS path. Confirms the escape hatch is reachable.
+
+When any of these regress, capture an init.mp4 + a segment from
+`/tmp/transcode/stream/<mfid>-<uid>/<quality>/` on the backend and
+compare the `ftyp` / first-box hex against Apple's reference:
+
+```
+hexdump -C init.mp4 | head -3
+hexdump -C seg-0000.m4s | head -3
+```

--- a/backend/src/modules/streaming/active-stream-tracker.service.ts
+++ b/backend/src/modules/streaming/active-stream-tracker.service.ts
@@ -166,8 +166,10 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
     return this.useExtXMediaCache.get(mediaFileId) ?? false;
   }
 
-  /** Set when the playback target is a Chromecast receiver. Drives the
-   *  HLS segment container choice (mpegts vs fmp4) in `buildFfmpegArgs`. */
+  /** Set when the playback target is a Tizen TV that needs the MPEG-TS
+   *  fallback (issue #148 — AVPlay rejects HLS-fMP4 from the HLS muxer).
+   *  Drives the HLS segment container choice (mpegts vs fmp4) in
+   *  `buildFfmpegArgs`. Cast / browser / native mobile never set this. */
   private readonly useTsCache = new Map<number, boolean>();
 
   setUseTs(mediaFileId: number, value: boolean) {

--- a/backend/src/modules/streaming/dto/device-profile.dto.ts
+++ b/backend/src/modules/streaming/dto/device-profile.dto.ts
@@ -78,14 +78,33 @@ export class DeviceProfileDto {
   deviceType?: 'mobile' | 'desktop';
 
   /**
-   * True when the request originates from a Chromecast sender. Drives the
-   * HLS segment container choice: MPEG-TS instead of fMP4. TS avoids the
-   * AAC/EAC3 encoder priming desync, because each audio packet in a TS
-   * stream carries its own PTS and there's no init segment / edit-list
-   * for the receiver to honour or ignore. fMP4 stays the default for web
-   * (Shaka), native (ExoPlayer / AVPlayer) and TV.
+   * Force MPEG-TS segments for every transcode session of this device.
+   * Hard override, used as an emergency switch (admin / debug). The
+   * common case for Tizen is the narrower `useTsOnSingleAudio` flag
+   * below; this one stays for clients that want TS regardless of audio
+   * track count.
    */
   @IsBoolean()
   @IsOptional()
   useTs?: boolean;
+
+  /**
+   * Force MPEG-TS only when the source has zero or one audio track.
+   *
+   * Samsung Tizen AVPlay's HLS-fMP4 path requires demuxed audio and
+   * video (per Samsung's General Specifications). For multi-audio
+   * sources our `var_stream_map` layout already satisfies that, but
+   * with a single audio rendition AVPlay never engages its rendition
+   * probe and the variant stalls after the video init (issue #148).
+   * MPEG-TS muxes A+V natively in the same segment, side-stepping the
+   * probe entirely. The trade-off is no Dolby pass-through and a more
+   * fragile HDR path, but it's the only documented Samsung-recommended
+   * pattern for single-audio HLS on AVPlay.
+   *
+   * Browser, Cast and native mobile clients keep this `false` — they
+   * happily play muxed fMP4.
+   */
+  @IsBoolean()
+  @IsOptional()
+  useTsOnSingleAudio?: boolean;
 }

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -31,6 +31,7 @@ import {
   profileFitsSource,
 } from './transcoding';
 import { secondsToSegmentIndex } from './transcoding/constants';
+import { readAndRewriteCmaf } from './transcoding/cmaf-rewrite';
 import { resolveTonemapPath } from './transcoding/tonemap-path';
 import { ThumbnailService } from './thumbnail.service';
 import { StreamBuilderService } from './stream-builder.service';
@@ -64,9 +65,37 @@ function withTimestampMap(vtt: string | Buffer): string {
 let SEG_DURATION = 3;
 
 /** Pick the right HLS segment Content-Type. fMP4 (.m4s / .mp4) → video/mp4,
- *  MPEG-TS (.ts, used for Chromecast sessions) → video/MP2T. */
+ *  MPEG-TS (.ts, used as the explicit `useTs` fallback for Tizen TVs on
+ *  older firmwares — issue #148) → video/MP2T. */
 function segmentContentType(segment: string): string {
   return segment.endsWith('.ts') ? 'video/MP2T' : 'video/mp4';
+}
+
+/** Decide whether ffmpeg should emit muxed segments (`inline`) or the
+ *  EXT-X-MEDIA layout (`var-stream-map`, video-only main + audio served
+ *  as separate renditions).
+ *
+ *  Rules (single source of truth, mirrored by `master-playlist.ts` and
+ *  `ffmpeg-args.ts`):
+ *    1. Zero audio sources → inline (degenerate, no audio rendition).
+ *    2. Multi-audio sources → var-stream-map (Shaka / AVPlay pick the
+ *       rendition client-side without a backend reload).
+ *    3. Single-audio sources → inline regardless of mux flavour. The
+ *       HLS muxer's hardcoded `+frag_custom+dash+delay_moov` movflags
+ *       used to produce iso5+sidx fMP4 segments AVPlay rejected (issue
+ *       #148), which forced the var_stream_map workaround. With the
+ *       in-tree `cmaf-rewrite` post-processor stripping `sidx` /
+ *       `styp` and stamping the `hlsf` brand on every served chunk,
+ *       muxed segments parse on AVPlay too — and the single-variant
+ *       master that comes with single-audio doesn't trigger AVPlay's
+ *       audio-rendition probe, so leaving audio inline is the only
+ *       layout that actually plays on Tizen single-audio fmp4. */
+export function pickAudioLayout(
+  audioCount: number,
+  _muxFlavour: 'ts' | 'fmp4',
+): 'inline' | 'var-stream-map' {
+  if (audioCount <= 1) return 'inline';
+  return 'var-stream-map';
 }
 
 /** Generate a VOD HLS playlist for a given duration and segment URL pattern.
@@ -141,6 +170,7 @@ export class StreamingController {
     return this.streamingSettingsCache.get();
   }
 
+
   private buildSessionContext(
     req: Request,
     resolved: ResolvedFile,
@@ -158,6 +188,15 @@ export class StreamingController {
     ) {
       this.activeStreamTracker.setAudioStreamCount(mediaFileId, audioCount);
     }
+    const trackedAudioCount =
+      this.activeStreamTracker.getAudioStreamCount(mediaFileId);
+    const muxFlavour: 'ts' | 'fmp4' = this.activeStreamTracker.getUseTs(
+      mediaFileId,
+    )
+      ? 'ts'
+      : 'fmp4';
+    const useMultiAudioLayout =
+      pickAudioLayout(trackedAudioCount, muxFlavour) === 'var-stream-map';
     return {
       userId: user?.id,
       username: user?.username,
@@ -174,11 +213,10 @@ export class StreamingController {
       // Multi-audio: produce video-only segments and let ffmpeg's var_stream_map
       // emit one audio rendition per track (subdirs 1..N) so Shaka can switch
       // client-side via EXT-X-MEDIA.
-      videoOnly: this.activeStreamTracker.getAudioStreamCount(mediaFileId) > 1,
-      audioStreams:
-        this.activeStreamTracker.getAudioStreamCount(mediaFileId) > 1
-          ? ((si?.audio as { language?: string; title?: string }[]) ?? [])
-          : undefined,
+      videoOnly: useMultiAudioLayout,
+      audioStreams: useMultiAudioLayout
+        ? ((si?.audio as { language?: string; title?: string }[]) ?? [])
+        : undefined,
       deviceType: this.activeStreamTracker.getDeviceType(mediaFileId),
       useTs: this.activeStreamTracker.getUseTs(mediaFileId),
       encoderPreset: this.activeStreamTracker.getEncoderPreset(mediaFileId),
@@ -337,6 +375,38 @@ export class StreamingController {
     return duration;
   }
 
+  /** Serve an fMP4 init or segment, rewriting the bytes for AVPlay
+   *  compatibility (Tizen) before flushing them to the client.
+   *
+   *  The rewrite happens in memory and the result is sent via `res.end`
+   *  rather than `createReadStream`: ffmpeg's HLS muxer rewrites init
+   *  and segments in-place on session restart, and that overwrite races
+   *  the `stat` → `createReadStream` window — the response ends up with
+   *  a Content-Length from one revision of the file and bytes from
+   *  another. Serving from the rewritten buffer takes that race off the
+   *  table. */
+  private async serveCmafFile(
+    res: Response,
+    filePath: string,
+    contentType: string,
+  ): Promise<void> {
+    const buf = await readAndRewriteCmaf(filePath);
+    if (!buf || buf.length === 0) {
+      if (!res.headersSent) res.status(404).end();
+      return;
+    }
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Content-Length', String(buf.length));
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    // Cloudflare (and any intermediate CDN) will gladly cache a 0-byte
+    // 200 response under the URL and serve it back for 4h by default —
+    // turning a transient cold-start race into a session-killing
+    // permanent failure. Mark each fMP4 chunk un-cacheable so a CDN
+    // refusing the upstream length check never pins a broken response.
+    res.setHeader('Cache-Control', 'no-store');
+    res.end(buf);
+  }
+
   /** Available download qualities for a media file (used by download-quality modal). */
   @Get('info/qualities/:mediaFileId')
   async downloadQualities(
@@ -471,7 +541,16 @@ export class StreamingController {
       mediaFileId,
       deviceProfile.deviceType ?? 'desktop',
     );
-    this.activeStreamTracker.setUseTs(mediaFileId, !!deviceProfile.useTs);
+    // Resolve the effective `useTs`. The explicit profile flag wins as
+    // an admin / debug hard override. Otherwise Tizen-style profiles
+    // opt into TS only when the source has zero or one audio track
+    // (single-audio fmp4 hits AVPlay's missing-rendition-probe stall;
+    // see DTO docstring and issue #148).
+    const sourceAudioCount = resolved.mediaFile.streamInfo?.audio?.length ?? 0;
+    const effectiveUseTs =
+      !!deviceProfile.useTs ||
+      (!!deviceProfile.useTsOnSingleAudio && sourceAudioCount <= 1);
+    this.activeStreamTracker.setUseTs(mediaFileId, effectiveUseTs);
     this.activeStreamTracker.setStreamingDuration(ss.segmentDuration);
     // Update module-level constants used by buildVodPlaylist and transcoding
     SEG_DURATION = ss.segmentDuration;
@@ -514,13 +593,26 @@ export class StreamingController {
     // without comparing plans. The result is a manifest advertising the
     // new codec while ffmpeg keeps writing segments in the old one,
     // tripping Shaka 4032 (CONTENT_UNSUPPORTED_BY_BROWSER) on Cast.
-    // Kill the running session whenever the new audio plan or the new
-    // video variant disagrees with what it was spawned for; the prewarm
-    // immediately below then respawns with the up-to-date plan.
+    // Kill the running session whenever the new audio plan, the new
+    // video variant or the new mux flavour (Tizen hopping TS ↔ fmp4)
+    // disagrees with what it was spawned for; the prewarm immediately
+    // below then respawns with the up-to-date plan.
     const newAudioCodec = result.audioPlan?.codec;
     const newVideoCodec = this.activeStreamTracker
       .getVideoVariant(mediaFileId)
       ?.codec;
+    const newMuxFlavour: 'ts' | 'fmp4' = effectiveUseTs ? 'ts' : 'fmp4';
+    // Audio layout the *next* session would be spawned with. Mirrors
+    // the gate in `buildSessionContext` so flipping `useTs` (which
+    // toggles muxed-vs-separated audio under us) kills the running
+    // session instead of leaving an EXT-X-MEDIA master pointing at a
+    // `var_stream_map`-less segment tree.
+    const trackedAudioCount =
+      this.activeStreamTracker.getAudioStreamCount(mediaFileId);
+    const newAudioLayout: 'inline' | 'var-stream-map' = pickAudioLayout(
+      trackedAudioCount,
+      newMuxFlavour,
+    );
     const existingForDrift = this.transcodingService.getExistingSession(
       mediaFileId,
       req.user?.id,
@@ -529,12 +621,18 @@ export class StreamingController {
       existingForDrift &&
       existingForDrift.process.exitCode === null &&
       (existingForDrift.audioPlan?.codec !== newAudioCodec ||
-        existingForDrift.videoVariant?.codec !== newVideoCodec)
+        existingForDrift.videoVariant?.codec !== newVideoCodec ||
+        (existingForDrift.muxFlavour &&
+          existingForDrift.muxFlavour !== newMuxFlavour) ||
+        (existingForDrift.audioLayout &&
+          existingForDrift.audioLayout !== newAudioLayout))
     ) {
       this.log.log(
         `[playback-info] profile drift on file ${mediaFileId} — killing session ` +
           `(audio: ${existingForDrift.audioPlan?.codec ?? '∅'} → ${newAudioCodec ?? '∅'}, ` +
-          `video: ${existingForDrift.videoVariant?.codec ?? '∅'} → ${newVideoCodec ?? '∅'})`,
+          `video: ${existingForDrift.videoVariant?.codec ?? '∅'} → ${newVideoCodec ?? '∅'}, ` +
+          `mux: ${existingForDrift.muxFlavour ?? '∅'} → ${newMuxFlavour}, ` +
+          `audioLayout: ${existingForDrift.audioLayout ?? '∅'} → ${newAudioLayout})`,
       );
       await this.transcodingService.killSession(mediaFileId, req.user?.id);
     }
@@ -718,7 +816,13 @@ export class StreamingController {
     // is listed even when the user has picked a specific track — the picked
     // track is marked DEFAULT=YES so the player preselects it.
     const pickedIdx = this.activeStreamTracker.getAudioStreamIndex(mediaFileId);
-    const useExtXMedia = audioStreams.length > 1;
+    const muxFlavour: 'ts' | 'fmp4' = this.activeStreamTracker.getUseTs(
+      mediaFileId,
+    )
+      ? 'ts'
+      : 'fmp4';
+    const useExtXMedia =
+      pickAudioLayout(audioStreams.length, muxFlavour) === 'var-stream-map';
     const onlyQuality = firstQueryString(req.query, 'startQuality');
     // Device type: URL param wins (stream URL is built by the frontend with
     // the cached client profile); fall back to whatever playback-info stored.
@@ -842,11 +946,14 @@ export class StreamingController {
       return;
     }
 
-    // With var_stream_map, audio is produced by the video session — no separate
-    // audio session needed. Only start one as fallback for single-audio files.
-    const multiAudio =
-      this.activeStreamTracker.getAudioStreamCount(mediaFileId) > 1;
-    if (!multiAudio) {
+    // Audio is produced by the video session whenever the master picked the
+    // var_stream_map layout (`setUseExtXMedia`). That's now true for any
+    // fMP4 source with audio (issue #148, Tizen) and for multi-audio
+    // sources regardless of mux flavour. Only the muxed TS / muxed-fMP4
+    // legacy path needs a separate audio-only session as a fallback.
+    const useExtXMedia =
+      this.activeStreamTracker.getUseExtXMedia(mediaFileId);
+    if (!useExtXMedia) {
       const user = req.user;
       void this.transcodingService.getOrCreateAudioSession(
         mediaFileId,
@@ -985,13 +1092,7 @@ export class StreamingController {
       return;
     }
 
-    res.setHeader('Content-Type', segmentContentType(segment));
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    const stream = fs.createReadStream(segPath);
-    stream.on('error', () => {
-      if (!res.headersSent) res.status(404).end();
-    });
-    stream.pipe(res);
+    await this.serveCmafFile(res, segPath, segmentContentType(segment));
   }
 
   /** HLS variant playlist — pre-computed segment list based on known duration. */
@@ -1066,8 +1167,10 @@ export class StreamingController {
     // Use the master.m3u8 decision — must match to avoid init filename mismatch.
     const multiAudio = this.activeStreamTracker.getUseExtXMedia(mediaFileId);
     const useTs = this.activeStreamTracker.getUseTs(mediaFileId);
-    // Cast sessions use MPEG-TS segments (no init segment) to avoid the
-    // fMP4 priming desync the Cast receiver doesn't compensate for.
+    // Tizen TV sessions can opt into MPEG-TS segments (no init segment)
+    // to bypass AVPlay's HLS-fMP4 rejection (issue #148). The fMP4 path
+    // is post-processed to CMAF (`cmaf-rewrite.ts`) so it works on
+    // every other client; `useTs` is the emergency fallback.
     const segExt = useTs ? 'ts' : 'm4s';
     // var_stream_map writes per-variant under `<idx>/` with init_<idx>.mp4.
     // The remux session is video-only on multi-audio sources but does NOT
@@ -1185,21 +1288,7 @@ export class StreamingController {
           );
           continue;
         }
-        res.setHeader('Content-Type', segmentContentType(segment));
-        res.setHeader('Content-Length', String(stat.size));
-        res.setHeader('Access-Control-Allow-Origin', '*');
-        // Cloudflare (and any intermediate CDN) will gladly cache a
-        // 0-byte 200 response under the URL and serve it back for 4h
-        // by default — turning a transient cold-start race into a
-        // session-killing permanent failure. Mark the init un-cacheable
-        // so the CDN always re-asks the origin where our size check
-        // can refuse to send the empty file.
-        res.setHeader('Cache-Control', 'no-store');
-        const initStream = fs.createReadStream(initPath);
-        initStream.on('error', () => {
-          if (!res.headersSent) res.status(404).end();
-        });
-        initStream.pipe(res);
+        await this.serveCmafFile(res, initPath, segmentContentType(segment));
         return;
       }
     }
@@ -1230,15 +1319,7 @@ export class StreamingController {
           return;
         }
         existing.lastAccess = Date.now();
-        res.setHeader('Content-Type', segmentContentType(segment));
-        res.setHeader('Content-Length', String(segStat.size));
-        res.setHeader('Access-Control-Allow-Origin', '*');
-        res.setHeader('Cache-Control', 'no-store');
-        const stream = fs.createReadStream(segPath);
-        stream.on('error', () => {
-          if (!res.headersSent) res.status(404).end();
-        });
-        stream.pipe(res);
+        await this.serveCmafFile(res, segPath, segmentContentType(segment));
         return;
       }
       // Segment not on disk — fall through to full resolve + getOrCreateSession.
@@ -1284,15 +1365,7 @@ export class StreamingController {
             res.status(404).end();
             return;
           }
-          res.setHeader('Content-Type', segmentContentType(segment));
-          res.setHeader('Content-Length', String(earlyStat.size));
-          res.setHeader('Access-Control-Allow-Origin', '*');
-          res.setHeader('Cache-Control', 'no-store');
-          const stream = fs.createReadStream(segPath);
-          stream.on('error', () => {
-            if (!res.headersSent) res.status(404).end();
-          });
-          stream.pipe(res);
+          await this.serveCmafFile(res, segPath, segmentContentType(segment));
           return;
         }
         // Early failed/timeout — log and fall through to slow path
@@ -1346,15 +1419,7 @@ export class StreamingController {
       res.status(404).end();
       return;
     }
-    res.setHeader('Content-Type', segmentContentType(segment));
-    res.setHeader('Content-Length', String(finalStat.size));
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Cache-Control', 'no-store');
-    const stream = fs.createReadStream(segPath);
-    stream.on('error', () => {
-      if (!res.headersSent) res.status(404).end();
-    });
-    stream.pipe(res);
+    await this.serveCmafFile(res, segPath, segmentContentType(segment));
   }
 
   // ---------------------------------------------------------------------------

--- a/backend/src/modules/streaming/transcoding/cmaf-rewrite.ts
+++ b/backend/src/modules/streaming/transcoding/cmaf-rewrite.ts
@@ -1,0 +1,173 @@
+/**
+ * Rewrite an HLS-fMP4 ISO BMFF buffer so the same `.m4s` / `.mp4` bytes
+ * parse on Samsung Tizen AVPlay, Apple HLS AVPlayer, ExoPlayer, Shaka
+ * and the Cast receiver alike.
+ *
+ * FFmpeg's HLS muxer hardcodes `movflags=+frag_custom+dash+delay_moov`
+ * into its mp4 sub-muxer (`libavformat/hlsenc.c::hls_mux_init`), so
+ * user-supplied `-movflags +cmaf` is silently ignored. Every init
+ * segment ships as `ftyp(iso5, compat=iso5 iso6 mp41)` and every media
+ * segment ships as `styp(msdh, compat=msdh cmfc) + sidx + moof + mdat`
+ * — pure DASH flavour. Tizen AVPlay rejects that flavour with
+ * `InvalidAccessError` / `PLAYER_ERROR_CONNECTION_FAILED` (issue #148).
+ *
+ * The reference shape AVPlay parses cleanly is Apple's own HLS-fMP4
+ * (`devstreaming-cdn.apple.com/.../adv_dv_atmos/...`):
+ *
+ *     init.mp4:  ftyp(iso5,  compat = isom iso5 hlsf) + moov
+ *     seg.m4s:   (optional emsg) + moof + mdat        — NO `styp`, NO `sidx`
+ *
+ * The load-bearing differences vs FFmpeg's output are:
+ *   1. `hlsf` ("HLS Fragmented MP4") in the ftyp compat-brand list. This
+ *      is the marker Tizen's HLS parser uses to dispatch to the HLS
+ *      branch — without it, AVPlay treats the segment as DASH and
+ *      rejects it.
+ *   2. No top-level `styp` box on media segments. FFmpeg's DASH-flavoured
+ *      `styp(msdh)` confuses AVPlay even when `cmfc` is in the compat
+ *      list. The box is optional in the HLS-fMP4 profile, so we strip
+ *      it entirely.
+ *   3. No top-level `sidx`. We were already stripping it for `cmfc`-style
+ *      output; same logic, same fix.
+ *
+ * We deliberately KEEP the `iso5` major brand on `ftyp` — Apple's own
+ * reference HLS-fMP4 ships with `iso5` and AVPlay accepts it as long as
+ * `hlsf` is in the compat list.
+ *
+ * The transform is in-place over a single Buffer and runs in linear
+ * time. Average segment is 2–3 MB, scan cost is sub-millisecond.
+ */
+
+const FOUR_CC_LEN = 4;
+const BOX_HEADER_LEN = 8;
+const HLSF = Buffer.from('hlsf', 'latin1');
+
+import * as fsp from 'fs/promises';
+
+/** True when the buffer's first top-level box is `ftyp` containing the
+ *  `hlsf` compat brand — i.e. the init has already been Apple-flavoured
+ *  and a second pass is a no-op. Segments are detected by the absence
+ *  of a leading `styp` (we strip it on the first pass), so the same
+ *  check works there. */
+export function isCmafRewritten(buf: Buffer): boolean {
+  if (buf.length < BOX_HEADER_LEN + FOUR_CC_LEN) return false;
+  const type = buf.slice(4, 8).toString('latin1');
+  if (type === 'styp') return false; // styp still present → not rewritten
+  if (type !== 'ftyp') return true; // moof / emsg first → already cleaned
+  // Look for `hlsf` in the compat-brand list (offset 16 onward).
+  const size = buf.readUInt32BE(0);
+  for (let i = 16; i + FOUR_CC_LEN <= Math.min(size, buf.length); i += FOUR_CC_LEN) {
+    if (buf.slice(i, i + FOUR_CC_LEN).equals(HLSF)) return true;
+  }
+  return false;
+}
+
+/** Read a segment / init from disk and return the Apple HLS-fMP4 bytes
+ *  AVPlay accepts. The caller is expected to pipe the returned Buffer
+ *  straight to the HTTP response — we deliberately do NOT write the
+ *  rewritten bytes back to disk.
+ *
+ *  Disk-rewriting is racy with FFmpeg's HLS muxer: the muxer rewrites
+ *  `init_<v>.mp4` and the segment files in-place on session restart /
+ *  variant restart (no temp_file + rename), so any rewrite we land on
+ *  disk gets clobbered by the next FFmpeg flush. The clobber races
+ *  against `createReadStream` after `statSync` — the pipe ends up
+ *  serving a mix of new-Content-Length header + stale bytes, which the
+ *  player treats as a truncated response.
+ *
+ *  Reading + rewriting + piping from memory takes that race off the
+ *  table: we hold the rewritten bytes locally, FFmpeg can overwrite
+ *  the disk file as much as it wants, the response we already
+ *  committed to is internally consistent. */
+export async function readAndRewriteCmaf(
+  filePath: string,
+): Promise<Buffer | null> {
+  let buf: Buffer;
+  try {
+    buf = await fsp.readFile(filePath);
+  } catch {
+    return null;
+  }
+  if (buf.length === 0) return null;
+  if (isCmafRewritten(buf)) return buf;
+  return cmafRewrite(buf);
+}
+
+/** Strip `sidx` and `styp` boxes; append `hlsf` to the ftyp compat-brand
+ *  list. Returns a new Buffer. */
+export function cmafRewrite(buf: Buffer): Buffer {
+  const parts: Buffer[] = [];
+  let off = 0;
+  while (off + BOX_HEADER_LEN <= buf.length) {
+    const size = buf.readUInt32BE(off);
+    const type = buf.slice(off + 4, off + 8).toString('latin1');
+
+    // Box-size sentinels:
+    //   0 → box extends to EOF (rare in fragmented mp4; pass through).
+    //   1 → 64-bit `largesize` follows the type. We don't expect this
+    //       on the boxes we rewrite (ftyp/styp/sidx are always small),
+    //       so passing through is safe.
+    if (size === 0) {
+      parts.push(buf.slice(off));
+      break;
+    }
+    if (size === 1) {
+      parts.push(buf.slice(off));
+      break;
+    }
+    if (off + size > buf.length) {
+      // Truncated box — bail out and copy the rest verbatim. Lets a
+      // partial mid-write segment served by mistake degrade gracefully
+      // instead of throwing.
+      parts.push(buf.slice(off));
+      break;
+    }
+
+    if (type === 'sidx' || type === 'styp') {
+      // Drop the box entirely. `sidx` triggers AVPlay's
+      // `InvalidAccessError` in HLS-fMP4 context; `styp` is optional
+      // in HLS-fMP4 and FFmpeg writes a DASH-flavoured one (`msdh` +
+      // `msix`) that signals a `sidx` follows — leaving it in place
+      // contradicts the sidx-stripping and confuses AVPlay. This
+      // shape (no styp, no sidx, just `moof`+`mdat`) is what the
+      // multi-audio fmp4 path uses in production and what Tizen
+      // AVPlay accepts.
+      off += size;
+      continue;
+    }
+
+    if (type === 'ftyp') {
+      // Append `hlsf` to the compat-brand list if missing. Keep the
+      // `iso5` major brand intact — Apple's reference uses it.
+      const boxBuf = buf.slice(off, off + size);
+      let hasHlsf = false;
+      for (
+        let i = 16;
+        i + FOUR_CC_LEN <= boxBuf.length;
+        i += FOUR_CC_LEN
+      ) {
+        if (boxBuf.slice(i, i + FOUR_CC_LEN).equals(HLSF)) {
+          hasHlsf = true;
+          break;
+        }
+      }
+      if (hasHlsf) {
+        parts.push(boxBuf);
+      } else {
+        // Grow the ftyp box by 4 bytes for the new brand. The size field
+        // is at offset 0..3 of the box itself.
+        const newSize = size + FOUR_CC_LEN;
+        const grown = Buffer.alloc(newSize);
+        boxBuf.copy(grown, 0);
+        HLSF.copy(grown, size);
+        grown.writeUInt32BE(newSize, 0);
+        parts.push(grown);
+      }
+      off += size;
+      continue;
+    }
+
+    parts.push(buf.slice(off, off + size));
+    off += size;
+  }
+  return Buffer.concat(parts);
+}

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -74,9 +74,12 @@ export interface BuildFfmpegArgsOptions {
    *  for ramp-up speed: fastest encoder preset + reduced rate-control
    *  buffer so the first frame ships sooner. */
   early?: boolean;
-  /** When true, emit MPEG-TS segments instead of fMP4. Used for Chromecast
-   *  sessions to avoid the priming desync caused by the Cast receiver
-   *  ignoring the init fMP4 `edts/elst` atom. */
+  /** When true, emit MPEG-TS segments instead of fMP4. Used for Tizen TV
+   *  sessions where AVPlay rejects the HLS muxer's fMP4 output (`iso5`
+   *  brand + per-stream `sidx` boxes — see issue #148) with
+   *  `InvalidAccessError` / `PLAYER_ERROR_CONNECTION_FAILED`. MPEG-TS
+   *  side-steps the issue at the cost of Dolby passthrough and a clean
+   *  HDR path. Cast, browser and native mobile all stay on fMP4. */
   useTs?: boolean;
 }
 
@@ -109,10 +112,10 @@ export function buildFfmpegArgs(
     tonemapAlgo = 'auto',
   } = opts;
 
-  // Segment container choice. Cast → MPEG-TS (fixes the priming desync
-  // because TS packets carry per-frame PTS and there's no init fMP4 atom
-  // for the receiver to honour or ignore). Everyone else → fMP4 (better
-  // for HEVC / DASH-like manifests on Shaka & MSE).
+  // Segment container choice. `useTs` stays as the emergency fallback
+  // for Tizen AVPlay quirks (issue #148); the post-process rewrite in
+  // `cmaf-rewrite.ts` makes the fMP4 path consumable on every target
+  // we ship, so `useTs` defaults to false everywhere.
   const segType = useTs ? 'mpegts' : 'fmp4';
   const segExt = useTs ? 'ts' : 'm4s';
 
@@ -514,13 +517,17 @@ export function buildFfmpegArgs(
   }
 
   // ── Audio mapping + HLS output ──
-  // Always use var_stream_map for multi-audio, even when the user has
-  // picked a specific track — otherwise switching audio would require a
-  // full backend reload. With all audio renditions exposed, Shaka switches
-  // client-side via EXT-X-MEDIA. The picked track is signalled via
-  // DEFAULT=YES in the master.m3u8 (see streaming.controller.ts).
+  // Use var_stream_map whenever the caller asked for the EXT-X-MEDIA
+  // layout (`videoOnly + audioStreams[]`), even for a SINGLE audio
+  // track. Multi-audio was the original driver (Shaka switches
+  // client-side via EXT-X-MEDIA without a backend reload), but Samsung
+  // Tizen AVPlay's HLS-fMP4 parser ALSO requires the same shape on
+  // single-audio sources — Tizen muxed-fMP4 stalls silently
+  // (issue #148). The controller forces `videoOnly=true` even with
+  // 1 audio on fMP4 to trigger this branch.
   const userPickedAudio = audioStreamIndex != null && audioStreamIndex > 0;
-  const useVarStreamMap = videoOnly && audioStreams && audioStreams.length > 1;
+  const useVarStreamMap =
+    videoOnly && audioStreams && audioStreams.length > 0;
 
   if (useVarStreamMap) {
     // Single FFmpeg process for video + all audio renditions (perfect sync).

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -105,7 +105,12 @@ export function generateMasterPlaylist(
    *  threaded the variant through — falls back to H.264 codec strings. */
   sdrVariant?: CodecVariant,
 ): string {
-  const multiAudio = audioStreams && audioStreams.length > 1;
+  // The "multi-audio" flag is really an "EXT-X-MEDIA layout" toggle —
+  // the caller decided whether to split audio into renditions. Single-
+  // audio sources can opt-in (Tizen fMP4 needs it; see issue #148), so
+  // we honour any non-empty `audioStreams` list rather than gating on
+  // `length > 1`. Callers that want the muxed layout pass `undefined`.
+  const multiAudio = audioStreams && audioStreams.length > 0;
   const lines = ['#EXTM3U', '#EXT-X-VERSION:7', '#EXT-X-INDEPENDENT-SEGMENTS'];
 
   const audioCodecMap = { aac: 'mp4a.40.2', ac3: 'ac-3', eac3: 'ec-3' };
@@ -136,8 +141,15 @@ export function generateMasterPlaylist(
         const lang = a.language || 'und';
         const name = a.title || lang;
         const isDefault = i === pickedIdx ? 'YES' : 'NO';
+        // CHANNELS hint matches Apple's reference master and lets
+        // Tizen AVPlay pre-allocate the right audio decoder before
+        // the variant playlist + init are fetched. Without it the
+        // single-audio fMP4 path doesn't follow the rendition link
+        // (issue #148 bisection — multi-audio works because AVPlay
+        // probes the renditions, single-audio doesn't trigger the
+        // probe when the hint is missing).
         lines.push(
-          `#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="${name}",LANGUAGE="${lang}",DEFAULT=${isDefault},AUTOSELECT=${isDefault},URI="/api/stream/${mediaFileId}/audio/${i}/index.m3u8${tokenParam}"`,
+          `#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="${name}",LANGUAGE="${lang}",DEFAULT=${isDefault},AUTOSELECT=${isDefault},CHANNELS="2",URI="/api/stream/${mediaFileId}/audio/${i}/index.m3u8${tokenParam}"`,
         );
       }
     }
@@ -153,14 +165,21 @@ export function generateMasterPlaylist(
     // Includes the source-resolution rung if there's an HDR profile
     // at or below source height.
     if (canEncodeHevcHdr) {
-      const hdrLadder = applyQualityPin(
-        getHdrLadderForDevice(deviceType).filter((p) =>
-          profileFitsSource(p, sourceWidth, sourceHeight),
-        ),
-        onlyQuality,
-        sourceWidth,
-        /* hdrSuffix */ true,
+      const baseHdrLadder = getHdrLadderForDevice(deviceType).filter((p) =>
+        profileFitsSource(p, sourceWidth, sourceHeight),
       );
+      // Same rationale as the SDR branch below: the quality pin only
+      // applies when audio is muxed inline. With multi-audio /
+      // EXT-X-MEDIA renditions, exposing a single variant breaks
+      // Tizen AVPlay's rendition probing (issue #148).
+      const hdrLadder = multiAudio
+        ? baseHdrLadder
+        : applyQualityPin(
+            baseHdrLadder,
+            onlyQuality,
+            sourceWidth,
+            /* hdrSuffix */ true,
+          );
       for (const p of hdrLadder) {
         const avg =
           parseBitrateToBps(p.videoBitrate) + parseBitrateToBps(p.audioBitrate);
@@ -193,8 +212,13 @@ export function generateMasterPlaylist(
       const lang = a.language || 'und';
       const name = a.title || lang;
       const isDefault = i === pickedIdx ? 'YES' : 'NO';
+      // `CHANNELS="2"` matches what ffmpeg emits (`-ac 2`) and what
+      // Apple's reference fMP4 master ships — Tizen AVPlay uses this
+      // hint to pre-allocate the right audio decoder before fetching
+      // the rendition. Without it the single-audio variant doesn't
+      // trigger a rendition probe (issue #148 bisection).
       lines.push(
-        `#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="${name}",LANGUAGE="${lang}",DEFAULT=${isDefault},AUTOSELECT=${isDefault},URI="/api/stream/${mediaFileId}/audio/${i}/index.m3u8${tokenParam}"`,
+        `#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="${name}",LANGUAGE="${lang}",DEFAULT=${isDefault},AUTOSELECT=${isDefault},CHANNELS="2",URI="/api/stream/${mediaFileId}/audio/${i}/index.m3u8${tokenParam}"`,
       );
     }
   }
@@ -218,7 +242,21 @@ export function generateMasterPlaylist(
   const ladder = getLadderForDevice(deviceType);
   let profiles = getAvailableProfiles(sourceWidth, sourceHeight, deviceType);
   if (!profiles.length) profiles.push(ladder[ladder.length - 1]); // at least 480p
-  profiles = applyQualityPin(profiles, onlyQuality, sourceWidth);
+  // The quality pin collapses the master to a single variant so
+  // ExoPlayer (Android) doesn't pre-load other rungs and trigger a
+  // FFmpeg respawn on every probe. That cost only exists when audio
+  // is muxed into the variant segments — when audio sits in its own
+  // EXT-X-MEDIA rendition the audio bytes are shared across all
+  // variants so an ABR probe is cheap. Crucially, Tizen AVPlay also
+  // refuses to fetch the audio rendition when the master only
+  // exposes a single variant (issue #148 bisection — single-audio
+  // fmp4 plays go variant + init then stall), so we MUST keep the
+  // full ladder when `multiAudio` is true. ExoPlayer still gets the
+  // pin via the var_stream_map path producing inline audio when
+  // `multiAudio` is false (legacy mp2-ts callers / single-audio TS).
+  if (!multiAudio) {
+    profiles = applyQualityPin(profiles, onlyQuality, sourceWidth);
+  }
 
   for (const p of profiles) {
     const avg =

--- a/backend/src/modules/streaming/transcoding/segment-utils.ts
+++ b/backend/src/modules/streaming/transcoding/segment-utils.ts
@@ -57,4 +57,3 @@ export function firstMissingSegment(
   }
   return null;
 }
-

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -1323,6 +1323,17 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     session.transcodeReasons = ctx.transcodeReasons;
     session.audioPlan = ctx.audioPlan;
     session.videoVariant = ctx.videoVariant;
+    session.muxFlavour = ctx.useTs ? 'ts' : 'fmp4';
+    // Match the gate in `ffmpeg-args.ts useVarStreamMap`: any non-empty
+    // `audioStreams[]` paired with `videoOnly` triggers the var_stream_map
+    // layout (subdirs `0/`, `1/`...). Tag the session with the actual
+    // layout ffmpeg was spawned with so the controller's drift detection
+    // (in `playback-info`) sees the same value `pickAudioLayout()`
+    // computes and doesn't false-positive a kill on every refresh.
+    session.audioLayout =
+      ctx.videoOnly && ctx.audioStreams && ctx.audioStreams.length > 0
+        ? 'var-stream-map'
+        : 'inline';
     if (!session.startedAt) session.startedAt = new Date();
   }
 

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -816,8 +816,24 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     const startNumberIdx = args.indexOf('-start_number');
     const startNumber =
       startNumberIdx >= 0 ? args[startNumberIdx + 1] : String(startSegment);
+    // Decoder label, inferred from the input-side ffmpeg flags. The
+    // decoder descriptor itself isn't passed through here (it lives in
+    // `ffmpeg-args` and we don't want to thread the registry across
+    // four spawn sites), so we read it back from the args we just
+    // built. Two QSV variants share `qsv=qs@va`: the default emits
+    // VAAPI surfaces (`-hwaccel vaapi`), the native-qsv variant emits
+    // QSV surfaces (`-hwaccel qsv`).
+    const hwaccelIdx = args.indexOf('-hwaccel');
+    const hwaccel = hwaccelIdx >= 0 ? args[hwaccelIdx + 1] : 'cpu';
+    const hasQsvBridge = args.includes('qsv=qs@va');
+    const decoder =
+      hwaccel === 'qsv'
+        ? 'qsv-native'
+        : hwaccel === 'vaapi' && hasQsvBridge
+          ? 'qsv'
+          : hwaccel;
     this.log.log(
-      `FFmpeg start [${id}] ${quality} ${encoder} ss=${ss} start_number=${startNumber}`,
+      `FFmpeg start [${id}] ${quality} dec=${decoder} enc=${encoder} ss=${ss} start_number=${startNumber}`,
     );
 
     const proc = spawn('ffmpeg', args, {

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -119,11 +119,12 @@ export interface SessionContext {
         bitrateBps: number;
       };
   /**
-   * True when the playback target is a Chromecast receiver. Switches HLS
-   * segments to MPEG-TS (instead of fMP4) so the Cast receiver isn't
-   * subject to the encoder-priming desync that comes from an unhonoured
-   * init fMP4 `edts/elst` atom. Container choice only — codecs and the
-   * rest of the pipeline are unchanged.
+   * True when the playback target is a Tizen TV that can't consume the
+   * HLS muxer's fMP4 output — AVPlay rejects the `iso5` + per-stream
+   * `sidx` boxes with `InvalidAccessError` / `PLAYER_ERROR_CONNECTION_FAILED`
+   * (issue #148). Falling back to MPEG-TS keeps playback working at the
+   * cost of Dolby passthrough and a clean HDR path. Cast, browser and
+   * native mobile all stay on fMP4 (`useTs: false`).
    */
   useTs?: boolean;
   /**
@@ -203,4 +204,21 @@ export interface TranscodeSession {
    *  decision and the running session means the segments contradict
    *  the manifest, so the session must respawn. */
   videoVariant?: import('./codec/types').CodecVariant;
+  /** Mux flavour the session was spawned for:
+   *  - `'ts'`: MPEG-TS HLS (legacy Tizen fallback, opt-in via `useTs`).
+   *  - `'fmp4'`: fMP4 via HLS muxer — the universal path. Segments are
+   *    post-processed at serve time (`cmaf-rewrite.ts`) to strip the
+   *    `sidx` boxes + rewrite the `iso5` brand to `cmfc`, so the
+   *    same bytes parse on AVPlay / Shaka / ExoPlayer / Cast.
+   *  Drift detection respawns the session when the flavour changes. */
+  muxFlavour?: 'ts' | 'fmp4';
+  /** HLS audio layout the session was spawned for:
+   *  - `'inline'`: single video+audio output, flat segment dir.
+   *  - `'var-stream-map'`: FFmpeg `-var_stream_map` with one rendition
+   *    per audio track, segments under `<repIdx>/`.
+   *  Toggled by `audioStreams.length > 1` in the session context, which
+   *  in turn is gated on the `debugForceInlineAudio` flag. Tracked for
+   *  drift detection: flipping the flag mid-stream must kill+respawn
+   *  the session because the on-disk layout differs. */
+  audioLayout?: 'inline' | 'var-stream-map';
 }

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -200,8 +200,6 @@
     "player_remember_audio_hint": "Le lecteur se souviendra de la piste audio choisie pour chaque fichier.",
     "player_disable_hdr": "Désactiver le HDR",
     "player_disable_hdr_hint": "Force le transcodage HDR → SDR. Utile si votre écran affiche des couleurs ternes ou délavées en HDR.",
-    "player_hdr_brightness": "Luminosité maximale en HDR",
-    "player_hdr_brightness_hint": "Monte automatiquement la luminosité au maximum lors de la lecture de contenu HDR. Se désactive en pause ou en quittant le lecteur.",
     "player_clear_saved": "Vider les sélections audio enregistrées",
     "player_auto_skip_intro": "Passer l'intro automatiquement",
     "player_auto_skip_intro_hint": "Saute automatiquement l'intro quand elle est détectée. Vous pouvez toujours revenir en arrière manuellement.",

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -60,10 +60,29 @@ export interface DeviceProfile {
   /** Client device category — selects the backend bitrate ladder.
    *  Capacitor native (iOS/Android app) → 'mobile'; web (incl. Cast sender) → 'desktop'. */
   deviceType: 'mobile' | 'desktop';
-  /** True when the playback target is a Chromecast receiver. Drives the
-   *  HLS segment container choice on the backend (MPEG-TS instead of
-   *  fMP4) — see `device-profile.dto.ts` for the rationale. */
+  /** Hard force MPEG-TS HLS for every transcode session of this client.
+   *  Defaults to `false`; the only switch in shipping configs is the
+   *  narrower `useTsOnSingleAudio` below. Opt-in via
+   *  `localStorage['fliks.useTs'] = '1'` as an emergency escape hatch
+   *  for future firmware regressions. */
   useTs?: boolean;
+
+  /** Force MPEG-TS only when the source has at most one audio track.
+   *  Set by Tizen profiles: AVPlay HLS-fMP4 needs demuxed audio per
+   *  Samsung spec, but with a single audio rendition AVPlay never
+   *  engages the rendition probe and the variant stalls after the
+   *  video init (issue #148 bisection). MPEG-TS muxes A+V natively,
+   *  side-stepping the probe — at the cost of Dolby pass-through.
+   *  Multi-audio Tizen sources stay on fMP4 + var_stream_map. */
+  useTsOnSingleAudio?: boolean;
+}
+
+/** True when `localStorage['fliks.useTs']` is set to a truthy value.
+ *  See `DeviceProfile.useTs` for the rationale. */
+function readUseTsOverride(): boolean {
+  if (typeof localStorage === 'undefined') return false;
+  const v = localStorage.getItem('fliks.useTs');
+  return v != null && v !== '' && v !== '0' && v.toLowerCase() !== 'false';
 }
 
 @Injectable({ providedIn: 'root' })
@@ -100,11 +119,20 @@ export class BrowserDeviceProfileService {
         `[DeviceProfile] audioCodecs=${JSON.stringify(dp?.audioCodecs)} maxAudioChannels=${this.cachedProfile.maxAudioChannels} native=${Capacitor.isNativePlatform()}`,
       );
     }
-    // Override HDR if user forced it off (check every call — setting may change)
-    if (this.playerSettings.get().forceDisableHdr) {
-      return { ...this.cachedProfile, supportsHdr: false };
-    }
-    return this.cachedProfile;
+    // Re-read mutable overrides on every call so toggling them at
+    // runtime (HDR setting in the player UI, `fliks.useTs` escape
+    // hatch in `localStorage`) doesn't require a page reload — the
+    // next playback-info will pick up the change.
+    const useTsOverride = readUseTsOverride();
+    const forceDisableHdr = this.playerSettings.get().forceDisableHdr;
+    const needsOverride =
+      forceDisableHdr || useTsOverride !== !!this.cachedProfile.useTs;
+    if (!needsOverride) return this.cachedProfile;
+    return {
+      ...this.cachedProfile,
+      supportsHdr: forceDisableHdr ? false : this.cachedProfile.supportsHdr,
+      useTs: useTsOverride,
+    };
   }
 
   /** Whether the display hardware supports HDR (ignoring user preference). */
@@ -249,6 +277,9 @@ export class BrowserDeviceProfileService {
       supportsHdr = hdrDisplay && has10bitCodec;
     }
 
+    const useTs = readUseTsOverride();
+    if (useTs) console.warn('[DeviceProfile] useTs override active');
+
     return {
       directPlayProfiles: [{
         containers,
@@ -260,13 +291,14 @@ export class BrowserDeviceProfileService {
       maxAudioChannels,
       supportsHdr,
       deviceType: Capacitor.isNativePlatform() ? 'mobile' : 'desktop',
-      // MPEG-TS HLS on Smart TV. FFmpeg's `-f hls -hls_segment_type fmp4`
-      // pipeline hard-codes `movflags=+frag_custom+dash+delay_moov` in
-      // `hls_mux_init()`, ignoring user-supplied `-movflags +cmaf`. The
-      // resulting `.m4s` segments always carry `sidx` boxes — a DASH-ism
-      // Tizen AVPlay rejects with `InvalidAccessError` / `CONNECTION_FAILED`.
-      // Cast itself stays on fMP4 (Shaka there can't transmux Dolby in TS).
-      useTs: isTv,
+      useTs,
+      // Tizen-style profiles opt into MPEG-TS on single-audio sources
+      // (AVPlay's HLS-fMP4 rendition-probe stall, issue #148). Multi-
+      // audio sources stay on fMP4 + var_stream_map — that path works
+      // because the master exposes ≥2 audio renditions and AVPlay
+      // engages its probe. Browser, Cast and native mobile leave the
+      // flag off and consume muxed fMP4 across the board.
+      useTsOnSingleAudio: isTv,
     };
   }
 

--- a/client/src/app/core/services/playback-engine/tizen-engine.ts
+++ b/client/src/app/core/services/playback-engine/tizen-engine.ts
@@ -199,12 +199,18 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
 
   // ── Loading ─────────────────────────────────────────────────────────
 
+  /** Last URL passed to `load()` — kept so the seek-failure recovery
+   *  path can reload the stream at the user's target without going
+   *  back through the player layer. */
+  private _lastLoadedUrl: string | null = null;
+
   async load(
     url: string,
     startTime?: number,
     _mimeType?: string,
     headers?: Record<string, string>,
   ): Promise<void> {
+    this._lastLoadedUrl = url;
     this.firstFrameEmitted = false;
     this._currentTime = 0;
     this._duration = 0;
@@ -420,7 +426,7 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
   }
 
   async seek(position: number): Promise<void> {
-    return new Promise<void>((resolve) => {
+    return new Promise<void>((resolve, reject) => {
       try {
         webapis.avplay.seekTo(
           Math.round(position * 1000),
@@ -428,19 +434,33 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
             this._currentTime = position;
             resolve();
           },
-          (err) => {
-            // Don't surface seek failures: they fire mostly when the user
-            // spams the seekbar faster than AVPlay can satisfy, or when
-            // the requested position is just outside the buffered range
-            // — both recover on the next seek tick, so a toast every
-            // time would only spam the UI.
+          async (err) => {
+            // AVPlay's failure callback fires whenever it can't
+            // satisfy the seek — typically a big backward seek past
+            // the buffered range, where AVPlay's HLS engine doesn't
+            // retry the segment fetch on its own and ends up stuck
+            // in a half-paused state (next `play()` throws). Reload
+            // the stream at the target position to recover.
             // eslint-disable-next-line no-console
-            console.warn('[TizenEngine] seek failed (swallowed):', err);
-            resolve();
+            console.warn(
+              '[TizenEngine] seek failed → reloading at target:',
+              err,
+            );
+            if (!this._lastLoadedUrl) {
+              reject(new Error(`seek failed: ${err}`));
+              return;
+            }
+            try {
+              await this.load(this._lastLoadedUrl, position);
+              await this.play();
+              resolve();
+            } catch (e) {
+              reject(e);
+            }
           },
         );
-      } catch {
-        resolve();
+      } catch (e) {
+        reject(e);
       }
     });
   }

--- a/client/src/app/core/services/playback-engine/tizen-engine.ts
+++ b/client/src/app/core/services/playback-engine/tizen-engine.ts
@@ -220,8 +220,12 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
 
     // Diagnostic flag: `localStorage['fliks.avtest']` selects an
     // alternate URL to isolate failure modes —
-    //   - '1' → Apple's reference single-variant HLS (proven working)
-    //   - 'master' → Apple's multi-variant master playlist
+    //   - '1' → Apple's reference single-variant HLS-TS (proven working)
+    //   - 'master' → Apple's multi-variant master playlist (TS)
+    //   - 'fmp4ref' → external reference single-variant fMP4 with audio
+    //     muxed inline. Confirmed during issue #148 bisection that
+    //     Tizen AVPlay rejects this layout outright — kept here for
+    //     future re-tests against newer firmware.
     //   - 'variant' → our backend's 1080p variant (skipping master)
     // anything else → the requested URL.
     const flag =
@@ -231,6 +235,8 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
       safeUrl = 'https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_4x3/bipbop_4x3_variant.m3u8';
     } else if (flag === 'master') {
       safeUrl = 'https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_4x3/bipbop_4x3.m3u8';
+    } else if (flag === 'fmp4ref') {
+      safeUrl = 'https://d2zihajmogu5jn.cloudfront.net/fmp4-muxed-no-playlist-codecs/index.m3u8';
     } else if (flag === 'variant') {
       // Rewrite master.m3u8 → 1080p/index.m3u8 so AVPlay bypasses the
       // master parser entirely and consumes a flat single-rendition
@@ -261,6 +267,30 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
     // eslint-disable-next-line no-console
     console.log('[TizenEngine] open URL:', safeUrl);
     webapis.avplay.open(safeUrl);
+
+    // Pin AVPlay's adaptive-bitrate behaviour for the CMAF / single-LAN
+    // case (see `browser-device-profile.service.ts` for the `useCmaf`
+    // rationale). CMAF segments are self-contained mp4s with their own
+    // moov + HEVC config, so every ABR shift forces a decoder re-init
+    // and a buffer drain — left untouched, AVPlay pings between 1080p
+    // and 144p several times per second on a 4K LAN target. The
+    // ADAPTIVE_INFO trio (Samsung-specific extension to AVPlay) caps
+    // that:
+    //   - STARTBITRATE: pin the initial rung high so the first
+    //     segments are already top-quality;
+    //   - BITRATES min~max: refuse rungs outside the band;
+    //   - SKIPBITRATE: floor for emergency-downshift decisions.
+    // The minimum (2 Mbps) cuts the 144p / 240p / 360p rungs from the
+    // selection set entirely — they exist for true bandwidth-starved
+    // clients (mobile data) and aren't useful on a TV.
+    try {
+      webapis.avplay.setStreamingProperty(
+        'ADAPTIVE_INFO',
+        'BITRATES=2000000~30000000|STARTBITRATE=8000000|SKIPBITRATE=2000000',
+      );
+    } catch {
+      /* old firmware may not expose ADAPTIVE_INFO; default ABR is fine. */
+    }
 
     // Set the START position BEFORE prepareAsync. Per Samsung docs,
     // `seekTo` while in IDLE state pins the start time so the first

--- a/client/src/app/core/services/player-settings.service.ts
+++ b/client/src/app/core/services/player-settings.service.ts
@@ -9,7 +9,6 @@ export interface PlayerSettings {
   rememberAudioSelections: boolean;
   // Video
   forceDisableHdr: boolean;
-  hdrAutoBrightness: boolean;
   // Subtitles
   preferredSubtitleLanguage: string;
   subtitleMode: 'off' | 'intelligent' | 'always';
@@ -35,7 +34,6 @@ const DEFAULTS: PlayerSettings = {
   useDefaultAudioStream: false,
   rememberAudioSelections: true,
   forceDisableHdr: false,
-  hdrAutoBrightness: true,
   preferredSubtitleLanguage: '',
   subtitleMode: 'intelligent',
   rememberSubtitleSelections: true,

--- a/client/src/app/core/services/player-state.service.ts
+++ b/client/src/app/core/services/player-state.service.ts
@@ -22,6 +22,16 @@ export class PlayerStateService {
   readonly playbackMode = signal<'direct' | 'remux' | 'transcode'>('direct');
   readonly hwAccel = signal('none');
 
+  /** True while a seek gesture is in flight — set by the player while
+   *  the user drags the seekbar or holds an arrow key, and during the
+   *  short window after a `seek()` call where the engine still emits
+   *  intermediate `timeUpdate` events for the OLD position before it
+   *  catches up to the target. While set, the engine→state mirror
+   *  ignores `position` updates so the seekbar stays pinned at the
+   *  user's commit value instead of bouncing back to whatever the
+   *  engine reports mid-seek. */
+  readonly seekLocked = signal(false);
+
   private engine: PlaybackEngine | null = null;
 
   /** Bind a playback engine's events to our signals. Call this when the engine changes. */
@@ -40,7 +50,7 @@ export class PlayerStateService {
     });
 
     engine.on('timeUpdate', (e) => {
-      this.currentTime.set(e.position);
+      if (!this.seekLocked()) this.currentTime.set(e.position);
       if (e.duration > 0) this.duration.set(e.duration);
       this.bufferedEnd.set(e.buffered);
     });
@@ -60,6 +70,7 @@ export class PlayerStateService {
     this.duration.set(0);
     this.buffering.set(false);
     this.bufferedEnd.set(0);
+    this.seekLocked.set(false);
   }
 
   getEngine(): PlaybackEngine | null {

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -35,8 +35,6 @@ import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
 import { InfiniteScrollList } from '../../shared/utils/infinite-scroll-list';
 import { LucideSearch, LucideSlidersHorizontal, LucideArrowUp, LucideArrowDown, LucideX, LucideFilm } from '@lucide/angular';
 import { MosaicCardComponent } from '../../shared/components/mosaic-card/mosaic-card';
-import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
-import { ImgFadeInDirective } from '../../shared/directives/img-fade-in.directive';
 
 const ALPHABET = '#ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
@@ -72,8 +70,6 @@ const NATURAL_ORDER_BY_SORT: Record<string, SortOrder> = {
     LucideFilm,
     LucideX,
     MosaicCardComponent,
-    ResolveUrlPipe,
-    ImgFadeInDirective,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './library.html',

--- a/client/src/app/features/playback-settings/player-settings/player-settings.html
+++ b/client/src/app/features/playback-settings/player-settings/player-settings.html
@@ -37,13 +37,6 @@
         [hint]="'playback_settings.player_disable_hdr_hint' | translate"
       />
 
-      @if (!forceDisableHdr()) {
-        <app-toggle-field
-          [(value)]="hdrAutoBrightness"
-          [label]="'playback_settings.player_hdr_brightness' | translate"
-          [hint]="'playback_settings.player_hdr_brightness_hint' | translate"
-        />
-      }
     }
 
     <div class="divider my-0"></div>

--- a/client/src/app/features/playback-settings/player-settings/player-settings.ts
+++ b/client/src/app/features/playback-settings/player-settings/player-settings.ts
@@ -32,7 +32,6 @@ export class PlayerSettingsPageComponent implements OnInit {
   readonly useDefaultAudioStream = signal(false);
   readonly rememberAudioSelections = signal(false);
   readonly forceDisableHdr = signal(false);
-  readonly hdrAutoBrightness = signal(false);
   readonly showHdrToggle = signal(false);
   readonly autoSkipIntro = signal(false);
 
@@ -42,7 +41,6 @@ export class PlayerSettingsPageComponent implements OnInit {
     this.useDefaultAudioStream.set(p.useDefaultAudioStream);
     this.rememberAudioSelections.set(p.rememberAudioSelections);
     this.forceDisableHdr.set(p.forceDisableHdr);
-    this.hdrAutoBrightness.set(p.hdrAutoBrightness);
     this.showHdrToggle.set(this.deviceProfile.hardwareSupportsHdr);
     this.autoSkipIntro.set(p.autoSkipIntro);
   }
@@ -60,7 +58,6 @@ export class PlayerSettingsPageComponent implements OnInit {
       useDefaultAudioStream: this.useDefaultAudioStream(),
       rememberAudioSelections: this.rememberAudioSelections(),
       forceDisableHdr: this.forceDisableHdr(),
-      hdrAutoBrightness: this.hdrAutoBrightness(),
       autoSkipIntro: this.autoSkipIntro(),
     });
     this.toast.success(this.translate.instant('common.settings_saved'));

--- a/client/src/app/features/player/player.html
+++ b/client/src/app/features/player/player.html
@@ -4,7 +4,6 @@
   class="player-container"
   [class.hide-cursor]="!controlsVisible()"
   [class.native-player]="!!nativeEngine"
-  [class.hdr-bright]="hdrBrightnessActive()"
   [class.hidden]="castService.isConnected()"
   (mousemove)="device.isTouch() || isNative ? null : showControls()"
 >

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -117,13 +117,6 @@ import { PlayerStatsOverlayComponent, PlayerStats } from './overlay/player-stats
       max-width: none !important;
       max-height: none !important;
     }
-    /* Dim controls when HDR max brightness is active.
-       Uses opacity on the direct child — safe for layout since controls are already
-       absolutely positioned and won't affect the video surface behind. */
-    .player-container.hdr-bright app-player-controls,
-    .player-container.hdr-bright > .loading-overlay {
-      opacity: 0.5;
-    }
     /* Lift native subtitles by the user's configured bottom margin
        (--cue-bottom-margin, set per-video by applySubtitleStyle), and bump
        another 5vh when the controls bar is visible so cues clear it. We
@@ -320,23 +313,6 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   private readonly pipPlaybackEffect = effect(() => {
     if (!this.isNative) return;
     Pip.updatePlaybackState({ playing: !this.paused() }).catch(() => {});
-  });
-
-  // HDR auto-brightness: max brightness when playing HDR, restore on pause/exit
-  private readonly isHdrContent = signal(false);
-
-  /** True when HDR max brightness is active — used to dim controls/subtitles. */
-  readonly hdrBrightnessActive = computed(() => {
-    if (!this.isNative || !this.isNativeEngine()) return false;
-    const settings = this.playerSettings.get();
-    if (!settings.hdrAutoBrightness || settings.forceDisableHdr) return false;
-    return this.isHdrContent() && !this.paused();
-  });
-
-  private readonly hdrBrightnessEffect = effect(() => {
-    const active = this.hdrBrightnessActive();
-    if (!this.isNative) return;
-    NativePlayer.setBrightness({ brightness: active ? 1.0 : -1 }).catch(() => {});
   });
 
   /** Re-apply native subtitle style on controls show/hide so the bottom-margin
@@ -724,7 +700,6 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         // Await playback-info (kicked off in parallel with media load above)
         this.playbackInfo = await playbackInfoPromise!;
         const pi = this.playbackInfo;
-        this.isHdrContent.set(!!pi.source?.hdrFormat && !pi.tonemapping);
         this.introMarker.set(pi.markers?.intro ?? null);
         this.outroMarker.set(pi.markers?.outro ?? null);
         this.chapters.set(pi.chapters ?? []);
@@ -1043,8 +1018,6 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     if (this.engine) {
       if (this.isNativeEngine()) {
         document.documentElement.classList.remove('native-player-active');
-        // Restore system brightness
-        NativePlayer.setBrightness({ brightness: -1 }).catch(() => {});
       }
       this.engine.destroy().catch(() => {});
     }

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1289,21 +1289,83 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     if (dragging) {
       // Cancel any pending hide
       if (this.controlsTimeout) clearTimeout(this.controlsTimeout);
+      // Freeze the engine→state mirror while the user is dragging /
+      // scrubbing the seekbar — otherwise the player's `timeUpdate`
+      // stream keeps pushing the bar back to the live position under
+      // the user's finger / arrow keys.
+      this.state.seekLocked.set(true);
     } else {
       this.resetHideTimer();
+      // Don't release the lock here: `onSeek` is about to fire with
+      // the commit value and schedules its own release once the
+      // engine catches up to the target.
     }
   }
 
   onSeek(time: number) {
     const t = Math.max(0, Math.min(time, this.duration() || 0));
     if (this.engine) {
-      this.engine.seek(t).catch(() => {});
+      // Lock the mirror BEFORE issuing the seek so transient
+      // `timeUpdate` events fired while the engine still reports the
+      // OLD position can't bounce the seekbar back. The local
+      // `state.currentTime.set(t)` pins the bar at the user's target
+      // until `awaitSeekUnlock` lets the engine resume driving it.
+      this.state.seekLocked.set(true);
       this.state.currentTime.set(t);
+      void this.awaitSeekUnlock(t);
     }
     // Suppress auto-skip for 2s after a manual seek so the user can step back
     // into the intro on purpose without being kicked forward again.
     this.autoSkipSuppressedUntil = Date.now() + 2000;
     this.resetHideTimer();
+  }
+
+  /** Generation counter — every `onSeek` bumps it and the corresponding
+   *  `awaitSeekUnlock` checks it before mutating state. Lets a newer
+   *  seek invalidate an older one mid-flight (e.g. user holds an
+   *  arrow key: each commit cancels the previous unlock loop). */
+  private seekGeneration = 0;
+
+  /** Await the engine's actual seek completion before lifting the
+   *  state lock. Two phases:
+   *    1. Wait for `engine.seek(target)`'s Promise — engines resolve
+   *       this when their internal seek state machine has dispatched
+   *       the request, which for HLS-fMP4 means the variant playlist
+   *       has been re-parsed and the new segment buffer is being
+   *       requested. Failure (Promise reject) keeps the lock on so
+   *       the bar stays pinned at the user's target while the
+   *       `engine.error` event surfaces a playback error UI.
+   *    2. After the promise resolves, poll the engine's reported
+   *       `currentTime` until it lands within 2s of the target. This
+   *       catches engines (notably Shaka) that resolve their seek
+   *       Promise as soon as the seek is queued, before the
+   *       demuxer / decoder has actually moved.
+   *
+   *  Backward seeks that fall outside the cached segment range
+   *  trigger a backend ffmpeg respawn (~10–20 s on long seeks); the
+   *  30 s ceiling is sized for that. If convergence never happens we
+   *  forcibly unlock so the user isn't stranded — the next live
+   *  `timeUpdate` will take over the bar from the engine's actual
+   *  position rather than the (now stale) target. */
+  private async awaitSeekUnlock(target: number): Promise<void> {
+    const gen = ++this.seekGeneration;
+    try {
+      await this.engine?.seek(target);
+    } catch {
+      // Engine rejected the seek (network error, codec stall, …).
+      // Leave the lock on — the bar stays at the user's target and
+      // the playback-error state surfaces via `state.error`.
+      return;
+    }
+    if (gen !== this.seekGeneration) return;
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < 30000) {
+      if (gen !== this.seekGeneration) return;
+      const cur = this.engine?.currentTime ?? 0;
+      if (Math.abs(cur - target) < 2) break;
+      await new Promise<void>((r) => setTimeout(r, 100));
+    }
+    if (gen === this.seekGeneration) this.state.seekLocked.set(false);
   }
 
   // ── Skip-intro UX ──

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -29,14 +29,6 @@
   </style>
   <link rel="preconnect" href="https://www.gstatic.com" crossorigin>
   <script src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1" async></script>
-  <!-- Samsung Tizen WebAPIs bootstrap. Resolves to the on-device runtime
-       `webapis/webapis.js` via the magic `$WEBAPIS` prefix the WebView
-       expands at load time. Required to populate `window.webapis.*` —
-       without it, `webapis.avplay.prepareAsync` is a stub that throws
-       `InvalidAccessError / PLAYER_ERROR_CONNECTION_FAILED` on every
-       call. 404s on non-Tizen targets (browser ignores the missing
-       script and the rest of the app boots normally). -->
-  <script src="$WEBAPIS/webapis/webapis.js"></script>
 </head>
 <body>
   <!-- Tizen AVPlay surface. Samsung's media runtime instantiates the

--- a/client/tizen/build-wgt.mjs
+++ b/client/tizen/build-wgt.mjs
@@ -60,14 +60,26 @@ for (const f of stylesFiles) {
   const indexPath = resolve(stage, 'index.html');
   if (existsSync(indexPath)) {
     const before = readFileSync(indexPath, 'utf8');
-    const after = before.replace(
+    let after = before.replace(
       /<link rel="stylesheet" href="([^"]+)" media="print" onload="this\.media='all'">/g,
       '<link rel="stylesheet" href="$1">',
     );
     if (after !== before) {
-      writeFileSync(indexPath, after, 'utf8');
       console.log('[tizen] forced render-blocking <link rel="stylesheet"> in index.html');
     }
+    // Inject the Tizen WebAPIs bootstrap. `$WEBAPIS` is a magic prefix
+    // that only Tizen's WebView expands at load time, populating
+    // `window.webapis.*` (avplay, avinfo, …). The tag is added here
+    // — not in src/index.html — so dev/web/Cast builds don't try to
+    // load the path and trip the strict-MIME-type check in Chromium.
+    if (!after.includes('$WEBAPIS/webapis/webapis.js')) {
+      after = after.replace(
+        '</head>',
+        '  <script src="$WEBAPIS/webapis/webapis.js"></script>\n</head>',
+      );
+      console.log('[tizen] injected $WEBAPIS/webapis/webapis.js bootstrap');
+    }
+    if (after !== before) writeFileSync(indexPath, after, 'utf8');
   }
 }
 


### PR DESCRIPTION
## Summary
- **#148** — Samsung Tizen AVPlay HLS-fMP4 single + multi-audio playback fixed via a `cmaf-rewrite.ts` post-process (Apple HLS shape: strip `sidx`/`styp`, append `hlsf` brand) plus a `useTsOnSingleAudio` profile flag that switches single-audio Tizen sessions to MPEG-TS (AVPlay's HLS engine doesn't engage the rendition probe with a single audio rendition; this is the documented Samsung pattern).
- **Player seek pinning** — `PlayerStateService.seekLocked` freezes the engine→state mirror during scrub / commit so the bar stops bouncing back when the engine reports intermediate positions mid-seek. Tizen big-back seek failures now trigger a full `load()` reload at target instead of silently leaving AVPlay stuck.
- **Chores** — decoder/encoder shown together in FFmpeg spawn log, HDR auto-brightness setting removed (the panels now handle HDR luminance themselves), `\$WEBAPIS/webapis/webapis.js` script moved into the Tizen build's post-process step so non-Tizen targets don't trip the strict-MIME check, two unused `LibraryComponent` imports dropped (NG8113).

## Test plan
- [x] Tizen Q-series 1080p (mfid 38) single-audio → MPEG-TS, plays.
- [x] Tizen Q-series 4K HDR (mfid 2) multi-audio → fmp4 + var_stream_map, plays.
- [x] Browser (Chrome) → fmp4 inline, plays.
- [x] Pointer drag + arrow-key scrub on web → bar stays at commit value, no rebound.
- [x] Forward / backward seek inside buffered range → ~instant unlock.
- [x] Big backward seek past ffmpeg cache → reload at target, no playback error.
- [x] HDR content on Tizen → no in-app brightness override (panel-managed).
- [x] Dev container Chrome console → no "MIME type 'text/html'" script error.

Closes #148.