### PR TITLE
fix(macos): HDR tonemap on VideoToolbox — full Metal pipeline + build script overwrite fix

### DIFF
--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-videotoolbox.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-videotoolbox.ts
@@ -15,16 +15,10 @@ export const h264Videotoolbox: EncoderDescriptor = {
   supportsHdrMetadata: () => false,
   codecString: (target: EncoderTarget) => h264CodecString(target),
   buildArgs(input: EncoderInput): string[] {
-    const { target, early, filters } = input;
+    const { target, early, filters, inputSurface } = input;
     const w = target.width;
     const bitrate = `${target.videoBitrateBps}`;
-    // CPU tonemap path — see the matching comment in
-    // `hevc-videotoolbox.ts`. The `scale_vt` Metal branch is removed
-    // because the decoder descriptor outputs CPU buffers (not VT
-    // IOSurfaces), and the filter graph can't bridge CPU → vt without
-    // `-hwaccel_output_format videotoolbox_vld` upstream. The CPU
-    // tonemap chain works on every macOS host.
-    return [
+    const common = [
       '-c:v',
       'h264_videotoolbox',
       '-profile:v',
@@ -34,14 +28,31 @@ export const h264Videotoolbox: EncoderDescriptor = {
       bitrate,
       '-maxrate',
       bitrate,
-      '-vf',
-      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+    ];
+    const trailing = [
       '-g',
       String(target.gopSize),
       '-keyint_min',
       String(target.gopSize),
       '-force_key_frames',
       input.forceKeyframesExpr,
+    ];
+    // Full-Metal HDR pipeline — see the matching comment in
+    // `hevc-videotoolbox.ts`. Active when the orchestrator already
+    // configured the decoder to emit videotoolbox_vld IOSurfaces.
+    if (inputSurface === 'videotoolbox') {
+      return [
+        ...common,
+        '-vf',
+        `scale_vt=w=${w}:h=-2:color_matrix=bt709:color_primaries=bt709:color_transfer=bt709`,
+        ...trailing,
+      ];
+    }
+    return [
+      ...common,
+      '-vf',
+      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+      ...trailing,
     ];
   },
 };

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-videotoolbox.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-videotoolbox.ts
@@ -15,10 +15,16 @@ export const h264Videotoolbox: EncoderDescriptor = {
   supportsHdrMetadata: () => false,
   codecString: (target: EncoderTarget) => h264CodecString(target),
   buildArgs(input: EncoderInput): string[] {
-    const { target, early, filters, tonemap, hasBurnIn, hasCrop } = input;
+    const { target, early, filters } = input;
     const w = target.width;
     const bitrate = `${target.videoBitrateBps}`;
-    const common = [
+    // CPU tonemap path — see the matching comment in
+    // `hevc-videotoolbox.ts`. The `scale_vt` Metal branch is removed
+    // because the decoder descriptor outputs CPU buffers (not VT
+    // IOSurfaces), and the filter graph can't bridge CPU → vt without
+    // `-hwaccel_output_format videotoolbox_vld` upstream. The CPU
+    // tonemap chain works on every macOS host.
+    return [
       '-c:v',
       'h264_videotoolbox',
       '-profile:v',
@@ -28,32 +34,14 @@ export const h264Videotoolbox: EncoderDescriptor = {
       bitrate,
       '-maxrate',
       bitrate,
-    ];
-    const trailing = [
+      '-vf',
+      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
       '-g',
       String(target.gopSize),
       '-keyint_min',
       String(target.gopSize),
       '-force_key_frames',
       input.forceKeyframesExpr,
-    ];
-
-    if (tonemap && !hasBurnIn && !hasCrop) {
-      // Full Metal pipeline: scale_vt does HDR→SDR tonemap via the
-      // Apple Media Engine. Everything stays on IOSurface — no CPU
-      // round-trip.
-      return [
-        ...common,
-        '-vf',
-        `scale_vt=w=${w}:h=-2:color_matrix=bt709:color_primaries=bt709:color_transfer=bt709`,
-        ...trailing,
-      ];
-    }
-    return [
-      ...common,
-      '-vf',
-      `${filters.cpuCropPrefix}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
-      ...trailing,
     ];
   },
 };

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-videotoolbox.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-videotoolbox.ts
@@ -15,10 +15,18 @@ export const hevcVideotoolbox: EncoderDescriptor = {
   supportsHdrMetadata: () => false,
   codecString: (target: EncoderTarget) => hevcMainCodecString(target),
   buildArgs(input: EncoderInput): string[] {
-    const { target, early, filters, tonemap, hasBurnIn, hasCrop } = input;
+    const { target, early, filters } = input;
     const w = target.width;
     const bitrate = `${target.videoBitrateBps}`;
-    const common = [
+    // CPU tonemap path. The previous `scale_vt` Metal branch required
+    // the decoder to be set up with `-hwaccel_output_format
+    // videotoolbox_vld`, but our VT decoder descriptor declares its
+    // output as CPU (filters / encoders downstream assume that). With
+    // CPU buffers feeding a `scale_vt`-anchored graph, FFmpeg fails
+    // pixel-format negotiation with `dst: videotoolbox_vld` → error
+    // -78 (ENOSYS). The CPU chain (tonemap filter + libsw scale) is
+    // a hair slower but works reliably on every macOS host.
+    return [
       '-c:v',
       'hevc_videotoolbox',
       '-profile:v',
@@ -28,8 +36,8 @@ export const hevcVideotoolbox: EncoderDescriptor = {
       bitrate,
       '-maxrate',
       bitrate,
-    ];
-    const trailing = [
+      '-vf',
+      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
       '-g',
       String(target.gopSize),
       '-keyint_min',
@@ -38,24 +46,6 @@ export const hevcVideotoolbox: EncoderDescriptor = {
       input.forceKeyframesExpr,
       '-tag:v',
       'hvc1',
-    ];
-
-    if (tonemap && !hasBurnIn && !hasCrop) {
-      // Full Metal pipeline: scale_vt does HDR→SDR tonemap on the
-      // Apple Media Engine. Avoids CPU round-trip when burn-in /
-      // crop aren't requested.
-      return [
-        ...common,
-        '-vf',
-        `scale_vt=w=${w}:h=-2:color_matrix=bt709:color_primaries=bt709:color_transfer=bt709`,
-        ...trailing,
-      ];
-    }
-    return [
-      ...common,
-      '-vf',
-      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
-      ...trailing,
     ];
   },
 };

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-videotoolbox.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-videotoolbox.ts
@@ -15,18 +15,10 @@ export const hevcVideotoolbox: EncoderDescriptor = {
   supportsHdrMetadata: () => false,
   codecString: (target: EncoderTarget) => hevcMainCodecString(target),
   buildArgs(input: EncoderInput): string[] {
-    const { target, early, filters } = input;
+    const { target, early, filters, inputSurface } = input;
     const w = target.width;
     const bitrate = `${target.videoBitrateBps}`;
-    // CPU tonemap path. The previous `scale_vt` Metal branch required
-    // the decoder to be set up with `-hwaccel_output_format
-    // videotoolbox_vld`, but our VT decoder descriptor declares its
-    // output as CPU (filters / encoders downstream assume that). With
-    // CPU buffers feeding a `scale_vt`-anchored graph, FFmpeg fails
-    // pixel-format negotiation with `dst: videotoolbox_vld` → error
-    // -78 (ENOSYS). The CPU chain (tonemap filter + libsw scale) is
-    // a hair slower but works reliably on every macOS host.
-    return [
+    const common = [
       '-c:v',
       'hevc_videotoolbox',
       '-profile:v',
@@ -36,8 +28,8 @@ export const hevcVideotoolbox: EncoderDescriptor = {
       bitrate,
       '-maxrate',
       bitrate,
-      '-vf',
-      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+    ];
+    const trailing = [
       '-g',
       String(target.gopSize),
       '-keyint_min',
@@ -46,6 +38,29 @@ export const hevcVideotoolbox: EncoderDescriptor = {
       input.forceKeyframesExpr,
       '-tag:v',
       'hvc1',
+    ];
+    // Full-Metal HDR pipeline: the orchestrator has set the decoder to
+    // emit videotoolbox_vld surfaces (`-hwaccel_output_format`), so
+    // `scale_vt` accepts the input directly and the entire chain runs
+    // on the Apple Media Engine — no CPU bounce. Only viable when no
+    // CPU-only filter (burn-in, crop) is required; the orchestrator
+    // checks those before flipping `inputSurface` to `'videotoolbox'`.
+    if (inputSurface === 'videotoolbox') {
+      return [
+        ...common,
+        '-vf',
+        `scale_vt=w=${w}:h=-2:color_matrix=bt709:color_primaries=bt709:color_transfer=bt709`,
+        ...trailing,
+      ];
+    }
+    // CPU tonemap fallback — works on every macOS host even when the
+    // Metal fast path is inapplicable (burn-in, crop, or a future
+    // decoder that hands off CPU buffers).
+    return [
+      ...common,
+      '-vf',
+      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+      ...trailing,
     ];
   },
 };

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -359,6 +359,25 @@ export function buildFfmpegArgs(
         );
   args.push(...decoder.buildInputArgs());
 
+  // Full-Metal HDR opt-in. The h264/hevc_videotoolbox encoders can keep
+  // the pipeline on IOSurface end-to-end when the only filter step is
+  // an HDR→SDR tonemap (no burn-in, no crop): `scale_vt` accepts
+  // videotoolbox_vld buffers and emits the same surface format the
+  // encoder ingests. The default VT decoder descriptor outputs CPU
+  // buffers (every other consumer expects them), so we override its
+  // input args here when the Metal fast path is eligible. The encoder
+  // branches on `inputSurface === 'videotoolbox'` to pick the scale_vt
+  // filter; falls back to the CPU tonemap chain otherwise.
+  const useVtMetalPath =
+    decoder.hwAccel === 'videotoolbox' &&
+    (encoder.id === 'h264_videotoolbox' || encoder.id === 'hevc_videotoolbox') &&
+    tonemap &&
+    !burnIn?.filter &&
+    !crop;
+  if (useVtMetalPath) {
+    args.push('-hwaccel_output_format', 'videotoolbox_vld');
+  }
+
   // OpenCL device init for the tonemap_opencl filter chain. Only needed
   // when (a) we're tonemapping HDR→SDR AND (b) the VAAPI in-place
   // tonemap fallback isn't active AND (c) the decoder's output sits on
@@ -476,7 +495,13 @@ export function buildFfmpegArgs(
     tonemapPath,
     hasBurnIn: !!burnIn?.filter,
     hasCrop: !!crop,
-    inputSurface: decoder.outputSurface,
+    // Override to 'videotoolbox' when the Metal fast path is active —
+    // the descriptor's static `outputSurface` is `'cpu'` because every
+    // OTHER VT consumer expects CPU buffers, but we just told the
+    // decoder (via `-hwaccel_output_format videotoolbox_vld`) to emit
+    // IOSurfaces in this particular session. The encoder branches on
+    // this to pick scale_vt vs the CPU tonemap chain.
+    inputSurface: useVtMetalPath ? 'videotoolbox' : decoder.outputSurface,
   };
   args.push(...encoder.buildArgs(encoderInput));
 
@@ -503,7 +528,15 @@ export function buildFfmpegArgs(
   // No-op when the source already carries BT.709 tags (ffmpeg accepts
   // the redundant overrides). HDR output paths skip this so the
   // encoder keeps the BT.2020/PQ signalling.
-  if (!isHdrOutput) {
+  //
+  // Also skipped on the VT Metal fast path. `scale_vt=color_matrix=
+  // bt709:color_primaries=bt709:color_transfer=bt709` already converts
+  // the IOSurface metadata, and adding the output-level `-color_*`
+  // flags re-triggers FFmpeg's negotiation to insert a CPU
+  // `auto_scale` between the decoder and scale_vt, which then fails
+  // with "Failed to find pixel format" (-78 ENOSYS) because no filter
+  // bridges CPU pixels back into a videotoolbox_vld IOSurface.
+  if (!isHdrOutput && !useVtMetalPath) {
     args.push(
       '-color_primaries',
       'bt709',

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -835,6 +835,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     this.log.log(
       `FFmpeg start [${id}] ${quality} dec=${decoder} enc=${encoder} ss=${ss} start_number=${startNumber}`,
     );
+    this.log.debug(`FFmpeg argv [${id}]: ffmpeg ${args.join(' ')}`);
 
     const proc = spawn('ffmpeg', args, {
       stdio: ['ignore', 'ignore', 'pipe'],

--- a/macos/Fliks.xcodeproj/project.pbxproj
+++ b/macos/Fliks.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		20E73B390732CBE1AFBB97B2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7F7DEBE793CEBCD07C904545 /* Assets.xcassets */; };
 		3685F8FE18738266C476C9C6 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7422312B1F5D7671E9744038 /* MenuBarView.swift */; };
 		3BA40AEEC5D78AF15B1FEF18 /* PostgresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EFDD9703C108943A23BE27 /* PostgresManager.swift */; };
+		48E3AE79299C0E5EB6D5B8F5 /* BuildConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6375114CD1C658A30D4CA5F /* BuildConfig.swift */; };
 		98A9A12AB18BD5FC9B012A00 /* ServerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D571CEB9FF05926A3DD18E2 /* ServerState.swift */; };
 		A60EC33352704F96FE6929C7 /* ProcessRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567B1538157A619F556157A7 /* ProcessRunner.swift */; };
 		B81065FF67224F21CE062F02 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B64ACCDF1778C8B2C04AEE /* AppState.swift */; };
@@ -31,6 +32,7 @@
 		9636D1AEAE72470DD3F15BCD /* AppIcon.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = AppIcon.icns; sourceTree = "<group>"; };
 		A40C10B954E0EB9D66C53747 /* ConfigStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigStore.swift; sourceTree = "<group>"; };
 		B6EFDD9703C108943A23BE27 /* PostgresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostgresManager.swift; sourceTree = "<group>"; };
+		C6375114CD1C658A30D4CA5F /* BuildConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildConfig.swift; sourceTree = "<group>"; };
 		E3B64ACCDF1778C8B2C04AEE /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		EE372A3138A37BDCE39B1584 /* Fliks.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Fliks.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -74,6 +76,7 @@
 		5EDB86BA3D552CB161DD5E2E /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				C6375114CD1C658A30D4CA5F /* BuildConfig.swift */,
 				46CF836D217191625BFC2462 /* Paths.swift */,
 				567B1538157A619F556157A7 /* ProcessRunner.swift */,
 			);
@@ -190,6 +193,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B81065FF67224F21CE062F02 /* AppState.swift in Sources */,
+				48E3AE79299C0E5EB6D5B8F5 /* BuildConfig.swift in Sources */,
 				104F45E5738E3150737FBAAF /* ConfigStore.swift in Sources */,
 				E02781C772245807E83D4217 /* FliksApp.swift in Sources */,
 				3685F8FE18738266C476C9C6 /* MenuBarView.swift in Sources */,

--- a/macos/Fliks/Fliks.entitlements
+++ b/macos/Fliks/Fliks.entitlements
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.security.app-sandbox</key>
-	<false/>
-	<key>com.apple.security.network.server</key>
-	<true/>
-	<key>com.apple.security.network.client</key>
-	<true/>
-</dict>
+<dict/>
 </plist>

--- a/macos/Scripts/build-app.sh
+++ b/macos/Scripts/build-app.sh
@@ -92,6 +92,14 @@ fi
 RESOURCES="$APP_BUNDLE/Contents/Resources"
 echo "==> Populating $APP_BUNDLE"
 
+# Wipe previously-populated trees before re-copying. macOS `cp` refuses
+# to overwrite codesigned binaries from a prior build with "Permission
+# denied" even when the user owns the file — the signature triggers a
+# protected-write check. Without this, an incremental xcodebuild leaves
+# the old Resources in place and the script aborts on the first cp,
+# silently shipping a DMG with a stale backend / Postgres / FFmpeg.
+rm -rf "$RESOURCES/node" "$RESOURCES/postgres" "$RESOURCES/ffmpeg" "$RESOURCES/backend" "$RESOURCES/client"
+
 # ── Node.js (statically linked, no dylib fixup needed) ──
 echo "    [node] Copying Node.js 24..."
 mkdir -p "$RESOURCES/node/bin"


### PR DESCRIPTION
## Summary

Three connected fixes for HDR sources on the macOS native app:

1. **build-app.sh wipes `Resources/{node,postgres,ffmpeg,backend,client}` before re-populating.** `cp -R` was failing on the second run with "Permission denied" — macOS refuses to overwrite previously codesigned binaries. `set -euo pipefail` then aborted the script silently, so every rebuild shipped a stale backend bundle. The first symptom was FFmpeg crashing on `zscale` (filter not in Homebrew FFmpeg) because the bundle was still on pre-`format+colorspace` code from before #128.

2. **VideoToolbox decoder now opts into IOSurface output (`-hwaccel_output_format videotoolbox_vld`) on the HDR fast path.** When the resolved encoder is `h264_videotoolbox` / `hevc_videotoolbox` AND the session is HDR→SDR tonemap with no burn-in or crop, the orchestrator threads VT surfaces end-to-end and the encoder's `scale_vt` branch becomes valid. Default decoder output stays CPU for every other path.

3. **Output-level `-color_*` flags are skipped on the Metal fast path.** `scale_vt`'s own `color_matrix=bt709:color_primaries=bt709:color_transfer=bt709` already rewrites the IOSurface color metadata. The redundant `-color_primaries / -trc / -space / -range` flags re-triggered FFmpeg's pixel-format negotiation, which inserted a CPU `auto_scale` between the decoder and `scale_vt` and bailed with `-78 (ENOSYS)`. Visible as "FFmpeg crashed (code 178)" → fallback to libx265 on every HDR play.

## Test plan

- [ ] Play a 4K HDR HEVC source on the macOS app at original quality — pipeline runs `dec=videotoolbox enc=hevc_videotoolbox`, no `libx265` fallback in logs.
- [ ] Switch to a lower quality (e.g. 1080p) mid-play — also stays on VT.
- [ ] Play an SDR source — no regression, `scale_vt` not used.
- [ ] Re-run `./Scripts/build-app.sh --skip-web --skip-xcode` twice in a row — second run completes (was failing with `cp ... Permission denied`).