### PR TITLE
fix(player): pin master to picked rung + keep audio index on engine switch

### DIFF
--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -13,6 +13,7 @@ import {
   TranscodeProfile,
   TranscodingService,
   encoderRegistry,
+  getHdrLadderForDevice,
   getLadderForDevice,
   parseBitrateToBps,
   profileFitsSource,
@@ -208,6 +209,15 @@ export class StreamBuilderService {
 
     const deviceType: DeviceType = profile.deviceType ?? 'desktop';
     const ladder = getLadderForDevice(deviceType);
+    // Quality ladder shown to the UI matches what the backend will
+    // actually serve: HDR sessions emit the HDR ladder (2160p/1080p/
+    // 720p/480p-hdr — no 360p/240p/144p rungs). Exposing the SDR
+    // ladder in HDR mode let users pick rungs that don't exist; the
+    // pin then failed to match, fell back to the full ladder, and the
+    // master ABR-ran across every HDR rung.
+    const qualityLadder = useHdrLadder
+      ? getHdrLadderForDevice(deviceType)
+      : ladder;
 
     if (directPlayResult.canDirectPlay) {
       this.log.log(
@@ -228,7 +238,7 @@ export class StreamBuilderService {
         outputContainer: sourceContainer,
         hwAccel: 'none',
         tonemapping: false,
-        qualities: this.buildQualityList(source, 'DirectPlay', true, ladder),
+        qualities: this.buildQualityList(source, 'DirectPlay', true, qualityLadder),
         source,
       };
     }
@@ -312,7 +322,7 @@ export class StreamBuilderService {
         tonemapping: false,
         remuxMasterBandwidthBps: remuxBw > 0 ? remuxBw : undefined,
         transcodeBitrateByQuality,
-        qualities: this.buildQualityList(source, 'DirectStream', true, ladder),
+        qualities: this.buildQualityList(source, 'DirectStream', true, qualityLadder),
         source,
       };
     }
@@ -443,7 +453,7 @@ export class StreamBuilderService {
       hwAccel: effectiveHwAccel,
       tonemapping: needsTonemapping,
       transcodeBitrateByQuality,
-      qualities: this.buildQualityList(source, 'Transcode', false, ladder),
+      qualities: this.buildQualityList(source, 'Transcode', false, qualityLadder),
       source,
     };
   }

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -491,7 +491,10 @@ export class StreamBuilderService {
     if (!available.length) available.push(ladder[ladder.length - 1]);
     // Ladder is ordered top→bottom, so available[0] is the source-resolution rung.
     const topProfile = available[0];
-    const displayLabel = (name: string) => (name === '2160p' ? '4K' : name);
+    const displayLabel = (name: string) => {
+      const stripped = name.replace(/-hdr$/, '');
+      return stripped === '2160p' ? '4K' : stripped;
+    };
     const resolutionLabel = displayLabel(topProfile.name);
     const originalHeight = sourceH || topProfile.maxHeight;
 

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -192,18 +192,16 @@ export function generateMasterPlaylist(
       const baseHdrLadder = getHdrLadderForDevice(deviceType).filter((p) =>
         profileFitsSource(p, sourceWidth, sourceHeight),
       );
-      // Same rationale as the SDR branch below: the quality pin only
-      // applies when audio is muxed inline. With multi-audio /
-      // EXT-X-MEDIA renditions, exposing a single variant breaks
-      // Tizen AVPlay's rendition probing (issue #148).
-      const hdrLadder = multiAudio
-        ? baseHdrLadder
-        : applyQualityPin(
-            baseHdrLadder,
-            onlyQuality,
-            sourceWidth,
-            /* hdrSuffix */ true,
-          );
+      // Pin to the user-picked rung when `onlyQuality` is set so the
+      // master exposes a single variant — AVPlayer / ExoPlayer have
+      // no other rung to ABR-switch to and playback stays locked at
+      // the chosen quality.
+      const hdrLadder = applyQualityPin(
+        baseHdrLadder,
+        onlyQuality,
+        sourceWidth,
+        /* hdrSuffix */ true,
+      );
       for (const p of hdrLadder) {
         const avg =
           parseBitrateToBps(p.videoBitrate) + parseBitrateToBps(p.audioBitrate);
@@ -276,21 +274,11 @@ export function generateMasterPlaylist(
   const ladder = getLadderForDevice(deviceType);
   let profiles = getAvailableProfiles(sourceWidth, sourceHeight, deviceType);
   if (!profiles.length) profiles.push(ladder[ladder.length - 1]); // at least 480p
-  // The quality pin collapses the master to a single variant so
-  // ExoPlayer (Android) doesn't pre-load other rungs and trigger a
-  // FFmpeg respawn on every probe. That cost only exists when audio
-  // is muxed into the variant segments — when audio sits in its own
-  // EXT-X-MEDIA rendition the audio bytes are shared across all
-  // variants so an ABR probe is cheap. Crucially, Tizen AVPlay also
-  // refuses to fetch the audio rendition when the master only
-  // exposes a single variant (issue #148 bisection — single-audio
-  // fmp4 plays go variant + init then stall), so we MUST keep the
-  // full ladder when `multiAudio` is true. ExoPlayer still gets the
-  // pin via the var_stream_map path producing inline audio when
-  // `multiAudio` is false (legacy mp2-ts callers / single-audio TS).
-  if (!multiAudio) {
-    profiles = applyQualityPin(profiles, onlyQuality, sourceWidth);
-  }
+  // Pin to the user-picked rung when `onlyQuality` is set so the
+  // master exposes a single variant — AVPlayer / ExoPlayer have no
+  // other rung to ABR-switch to and playback stays locked at the
+  // chosen quality.
+  profiles = applyQualityPin(profiles, onlyQuality, sourceWidth);
 
   for (const p of profiles) {
     const avg =

--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -54,13 +54,6 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
     private var firstFrameObserver: NSKeyValueObservation?
     private var firstFrameEmitted = false
     private var savedBrightness: CGFloat?
-    /// Seek-and-play target captured at load() time, applied once the
-    /// item flips to .readyToPlay. Seeking on a .unknown item races
-    /// AVPlayer's own status-flip seek and the completion handler can
-    /// fire with `finished=false`, leaving play() never called —
-    /// playback gets stuck on the play overlay until the user taps
-    /// pause/play to re-evaluate.
-    private var pendingStartTime: Double = 0
 
     /// Exposed for PipPlugin to access the player layer.
     public var activePlayerLayer: AVPlayerLayer? { playerLayer }
@@ -269,21 +262,28 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
                 self.playerLayer?.player = player
             }
 
-            // Capture the resume position before setting up observers so
-            // the status-flip handler can apply seek + play once the
-            // item is .readyToPlay. Issuing the seek now would race
-            // AVPlayer's own status-flip seek.
-            self.pendingStartTime = startTime
-
             // Observe playback state
             self.setupObservers()
 
-            // Start position 0 (or no resume) — start playback immediately;
-            // AVPlayer waits internally for .readyToPlay before producing
-            // frames, no seek required.
-            if startTime <= 0 {
-                player.play()
+            // Seek BEFORE play so AVPlayer's initial prebuffer probe
+            // (gated by automaticallyWaitsToMinimizeStalling=true on
+            // an .unknown item) fires at the resume target, not at
+            // content time 0. On transcoded HLS the backend pre-spawns
+            // ffmpeg at startSegment and only warms segments forward —
+            // a probe at seg-0 / seg-1 cold-spawns a second session.
+            // AVPlayer queues seek and play on .unknown items and
+            // applies both once the asset is loaded. play() runs
+            // unconditionally rather than inside the seek completion
+            // handler — Apple's docs say the completion may fire with
+            // finished=false when AVPlayer pre-empts our seek with
+            // its own status-flip seek, and we would then never start
+            // playback (the symptom that bit us originally: load()
+            // resolved but playback stayed paused).
+            if startTime > 0 {
+                let cmTime = CMTime(seconds: startTime, preferredTimescale: 1000)
+                player.seek(to: cmTime)
             }
+            player.play()
 
             call.resolve()
         }
@@ -604,19 +604,6 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         statusObserver = player.currentItem?.observe(\.status) { [weak self] item, _ in
             switch item.status {
             case .readyToPlay:
-                if let pending = self?.pendingStartTime, pending > 0 {
-                    self?.pendingStartTime = 0
-                    let cmTime = CMTime(seconds: pending, preferredTimescale: 1000)
-                    // Default tolerance — AVPlayer snaps to the nearest IDR.
-                    // Frame-accurate seek (.zero/.zero) forces backward
-                    // IDR alignment, which on transcoded HLS reaches a
-                    // segment that hasn't been warmed by the ffmpeg
-                    // session at startAt and triggers a cold spawn —
-                    // user sees a black screen for ~30 s.
-                    player.seek(to: cmTime) { _ in
-                        player.play()
-                    }
-                }
                 self?.emitStateChanged("playing")
                 self?.emitTracksChanged()
             case .failed:

--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -54,6 +54,13 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
     private var firstFrameObserver: NSKeyValueObservation?
     private var firstFrameEmitted = false
     private var savedBrightness: CGFloat?
+    /// Seek-and-play target captured at load() time, applied once the
+    /// item flips to .readyToPlay. Seeking on a .unknown item races
+    /// AVPlayer's own status-flip seek and the completion handler can
+    /// fire with `finished=false`, leaving play() never called —
+    /// playback gets stuck on the play overlay until the user taps
+    /// pause/play to re-evaluate.
+    private var pendingStartTime: Double = 0
 
     /// Exposed for PipPlugin to access the player layer.
     public var activePlayerLayer: AVPlayerLayer? { playerLayer }
@@ -262,16 +269,19 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
                 self.playerLayer?.player = player
             }
 
+            // Capture the resume position before setting up observers so
+            // the status-flip handler can apply seek + play once the
+            // item is .readyToPlay. Issuing the seek now would race
+            // AVPlayer's own status-flip seek.
+            self.pendingStartTime = startTime
+
             // Observe playback state
             self.setupObservers()
 
-            // Seek to start position
-            if startTime > 0 {
-                let cmTime = CMTime(seconds: startTime, preferredTimescale: 1000)
-                player.seek(to: cmTime) { _ in
-                    player.play()
-                }
-            } else {
+            // Start position 0 (or no resume) — start playback immediately;
+            // AVPlayer waits internally for .readyToPlay before producing
+            // frames, no seek required.
+            if startTime <= 0 {
                 player.play()
             }
 
@@ -594,6 +604,13 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         statusObserver = player.currentItem?.observe(\.status) { [weak self] item, _ in
             switch item.status {
             case .readyToPlay:
+                if let pending = self?.pendingStartTime, pending > 0 {
+                    self?.pendingStartTime = 0
+                    let cmTime = CMTime(seconds: pending, preferredTimescale: 1000)
+                    player.seek(to: cmTime, toleranceBefore: .zero, toleranceAfter: .zero) { _ in
+                        player.play()
+                    }
+                }
                 self?.emitStateChanged("playing")
                 self?.emitTracksChanged()
             case .failed:

--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -607,7 +607,13 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
                 if let pending = self?.pendingStartTime, pending > 0 {
                     self?.pendingStartTime = 0
                     let cmTime = CMTime(seconds: pending, preferredTimescale: 1000)
-                    player.seek(to: cmTime, toleranceBefore: .zero, toleranceAfter: .zero) { _ in
+                    // Default tolerance — AVPlayer snaps to the nearest IDR.
+                    // Frame-accurate seek (.zero/.zero) forces backward
+                    // IDR alignment, which on transcoded HLS reaches a
+                    // segment that hasn't been warmed by the ffmpeg
+                    // session at startAt and triggers a cold spawn —
+                    // user sees a black screen for ~30 s.
+                    player.seek(to: cmTime) { _ in
                         player.play()
                     }
                 }

--- a/client/src/app/features/player/player.html
+++ b/client/src/app/features/player/player.html
@@ -56,7 +56,7 @@
     [episodeTitle]="episodeTitle()"
     [hasNextEpisode]="nextEpisodeContext() !== null"
     [hasPrevEpisode]="false"
-    [activeQualityLabel]="activeQualityId() === 'auto' ? (activeResolution() ? 'Auto (' + activeResolution() + ')' : 'Auto') : activeQualityId()"
+    [activeQualityLabel]="activeQualityLabel()"
     [isNative]="isNative"
     (togglePlay)="onTogglePlay()"
     (tapOverlay)="toggleControls()"

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1818,9 +1818,15 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
   async onSelectAudioTrack(trackId: string) {
     this.activeAudioTrackId.set(trackId);
-    // Only update activeAudioStreamIndex for si-* tracks (backend stream index).
-    // Shaka/engine tracks switch client-side — no backend reload needed.
-    if (trackId.startsWith('si-')) {
+    // 'si-*' and 'audio-*' suffixes are streamInfo audio indices: the
+    // backend emits EXT-X-MEDIA renditions in streamInfo.audio order
+    // and the native plugins enumerate them in that same order. Keep
+    // activeAudioStreamIndex in sync so a later reloadStream() hands
+    // the right index to /playback-info — otherwise the new master
+    // marks the wrong rendition DEFAULT=YES and the player reverts
+    // to the original language on the item swap. 'shaka-*' is
+    // Shaka's internal audioId, not a streamInfo index.
+    if (trackId.startsWith('si-') || trackId.startsWith('audio-')) {
       this.activeAudioStreamIndex = parseAudioIndex(trackId);
     }
     this.resetHideTimer();

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -204,6 +204,18 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   readonly activeQualityId = this.qualityManager.activeQualityId;
   readonly availableQualities = this.qualityManager.availableQualities;
   readonly activeResolution = this.qualityManager.activeResolution;
+  /** Label for the currently picked quality, mirroring the per-rung
+   *  label in the dropdown (`q.label`) — so the header row stays in
+   *  sync with the list and never surfaces internal ids like
+   *  `1080p-hdr`. Falls back to the id for legacy callers. */
+  readonly activeQualityLabel = computed(() => {
+    const id = this.activeQualityId();
+    if (id === 'auto') {
+      const res = this.activeResolution();
+      return res ? `Auto (${res})` : 'Auto';
+    }
+    return this.availableQualities().find((q) => q.id === id)?.label ?? id;
+  });
 
   // Component-owned signals (not delegated)
   readonly playbackRate = signal(1);


### PR DESCRIPTION
## Summary
Two iOS native bugs surface together on multi-audio HLS sources after an explicit quality pick:

1. **ABR keeps switching even after the user picked a quality.** AVPlayer has no client-side ABR off-switch — `preferredMaximumResolution` only caps height, `preferredPeakBitRate` only caps bitrate. The only deterministic lock is a single-variant master. The master generator used to skip `applyQualityPin` whenever the source was multi-audio, so iOS got the full 4-rung HDR ladder and AVPlayer ABR-switched at will. Apply the pin unconditionally on both the SDR and HDR branches (`backend/src/modules/streaming/transcoding/master-playlist.ts`).
2. **Audio language resets to default after a quality change.** Picking audio on iOS native goes through `engine.selectAudioTrack('audio-N')`, but `onSelectAudioTrack` only updated `activeAudioStreamIndex` for `si-*` ids. The stale index then rode through the next `reloadStream()` → the new master marked the wrong rendition `DEFAULT=YES` and AVPlayer reverted on the item swap. Update the index for `audio-*` too (iOS AVPlayer + Android ExoPlayer enumerate audio in the same EXT-X-MEDIA / streamInfo order, so the 1:1 mapping holds).

Tizen multi-audio risk (the old skip was originally there for issue #148) is tracked in #156 — if it regresses, the fix belongs in Tizen-side audio handling, not in master shaping.

## Test plan
- [ ] Multi-audio HDR title on iPhone: pick a non-default audio language, then change quality → audio language stays, no ABR jitter on the picked rung.
- [ ] Same on Android: audio language stays after quality change.
- [ ] Tizen multi-audio Auto: still plays (no `startQuality` → ladder unchanged).
- [ ] Tizen multi-audio explicit pick: monitor for issue-#148 regression (tracked in #156).
- [ ] Single-audio source on iOS: quality change works (unchanged path).