### PR TITLE
fix(streaming): preserve source aspect in QSV scale output

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -236,6 +236,8 @@ export class StreamingController {
         this.activeStreamTracker.getAudioPlan(mediaFileId) ?? undefined,
       sourceVideoCodec:
         (si?.video?.[0]?.codec ?? '').toLowerCase() || undefined,
+      sourceWidth: si?.video?.[0]?.width,
+      sourceHeight: si?.video?.[0]?.height,
       isSourceHdr: !!si?.video?.[0]?.hdrFormat,
       // Variant chosen by stream-builder's codec selector at
       // playback-info time, threaded through every session spawn so

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@nestjs/common';
 import * as path from 'path';
 import { getSegmentDuration, segmentIndexToSeconds } from './constants';
-import { isHdrProfile, parseBitrateToBps } from './profiles';
+import { isHdrProfile, parseBitrateToBps, profileResolution } from './profiles';
 import { requestedHwAccelFor } from './hw-detect';
 import type {
   BurnInSubtitle,
@@ -52,6 +52,14 @@ export interface BuildFfmpegArgsOptions {
   /** Source bit depth (8 or 10). 10-bit HDR sources need a decoder
    *  that can handle p010le surfaces. Defaults to 8 when omitted. */
   sourceBitDepth?: BitDepth;
+  /** Source frame dimensions (post container crop / SAR). Drive the
+   *  aspect-preserving output sizing in `buildFfmpegArgs` — required
+   *  for non-16:9 sources (cinemascope, vertical, …) so the encoder's
+   *  explicit `h=…` filter argument matches the actual frame instead
+   *  of stretching to `profile.maxHeight`. When omitted, the output
+   *  defaults to the profile's raw `maxWidth × maxHeight`. */
+  sourceWidth?: number;
+  sourceHeight?: number;
   /** Audio output decision — see {@link SessionContext.audioPlan}. When
    *  omitted, ffmpeg-args falls back to AAC stereo at the profile bitrate
    *  (safe default that plays everywhere). */
@@ -109,6 +117,8 @@ export function buildFfmpegArgs(
     videoVariant,
     sourceVideoCodec,
     sourceBitDepth = 8,
+    sourceWidth = 0,
+    sourceHeight = 0,
     tonemapAlgo = 'auto',
   } = opts;
 
@@ -423,8 +433,20 @@ export function buildFfmpegArgs(
     args.push('-ss', String(seekSeconds));
   }
 
-  // Video encoding
-  const w = profile.maxWidth;
+  // Output dimensions cap the source aspect to the profile's
+  // `maxWidth`. `vpp_qsv` / `scale_qsv` don't honour the `-2`
+  // auto-height token, so a 2.39:1 cinemascope title (1920×804) needs
+  // its height computed up front to land at 1920×804 instead of being
+  // stretched to 1920×1080 by an explicit `h=maxHeight`. The result
+  // matches the RESOLUTION attribute the master playlist already
+  // advertises for this rung — display aspect stays stable across the
+  // session even if the player re-parses the manifest.
+  const outDims =
+    sourceWidth > 0 && sourceHeight > 0
+      ? profileResolution(profile, sourceWidth, sourceHeight)
+      : { width: profile.maxWidth, height: profile.maxHeight };
+  const w = outDims.width;
+  const h = outDims.height;
   const cropStr = crop
     ? `crop=${crop.width}:${crop.height}:${crop.x}:${crop.y}`
     : '';
@@ -466,7 +488,7 @@ export function buildFfmpegArgs(
     variant,
     target: {
       width: w,
-      height: profile.maxHeight,
+      height: h,
       videoBitrateBps: bitrateNum,
       gopSize,
       frameRate: fps,

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -665,6 +665,8 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
           videoVariant: ctx?.videoVariant,
           sourceVideoCodec: ctx?.sourceVideoCodec,
           sourceBitDepth: ctx?.isSourceHdr ? 10 : 8,
+          sourceWidth: ctx?.sourceWidth,
+          sourceHeight: ctx?.sourceHeight,
         },
         this.log,
       );
@@ -965,6 +967,8 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         videoVariant: ctx?.videoVariant,
         sourceVideoCodec: ctx?.sourceVideoCodec,
         sourceBitDepth: ctx?.isSourceHdr ? 10 : 8,
+        sourceWidth: ctx?.sourceWidth,
+        sourceHeight: ctx?.sourceHeight,
       },
       this.log,
     );

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -136,6 +136,15 @@ export interface SessionContext {
    */
   sourceVideoCodec?: string;
   /**
+   * Source frame dimensions (post container crop / SAR). Drive the
+   * aspect-preserving output sizing in `buildFfmpegArgs` — required
+   * for non-16:9 sources so the encoder's explicit `h=…` argument
+   * matches the source aspect instead of stretching to the profile's
+   * raw `maxHeight`.
+   */
+  sourceWidth?: number;
+  sourceHeight?: number;
+  /**
    * Source has HDR transfer characteristics (HDR10 / HLG / DV). The
    * session-wide `tonemap` flag follows the pass-through decision —
    * false when canPassThroughHdr is true (HDR client + HEVC source) —


### PR DESCRIPTION
## Summary
Cinemascope sources (1920×804 masters) were transcoded into 1920×1080 on the QSV path — `vpp_qsv` / `scale_qsv` don't honour the `-2` auto-height token the way `scale_vaapi` does, so feeding them `target.height = profile.maxHeight` raw stretched the picture vertically.

`buildFfmpegArgs` now derives the output dimensions via `profileResolution(profile, sourceWidth, sourceHeight)` — the same function the master playlist uses for its `RESOLUTION` attribute, so the bitstream and the manifest land on the same pixel grid. Source dims are threaded through `SessionContext` from `streamInfo.video[0]` and into both the early-warm and main spawn paths.

CPU + VAAPI encoders are unaffected — they already compute height from source via `scale=W:scaleMod16Height(W)` / `scale_vaapi=h=-16`.

## Test plan
- [x] 1920×804 cinemascope source → 1080p QSV transcode renders 1920×800 (mod-16 of 804) without vertical stretch.
- [x] Standard 16:9 source → identical output to before (`profileResolution` returns the unchanged maxWidth×maxHeight).
- [x] Crop pipeline → unaffected (`qsv-filters.ts` already used the crop aspect for `targetH`).
- [x] CPU / VAAPI / NVENC paths → no behaviour change, height stays driven by their own auto-height expressions.
