### PR TITLE
chore: scrub specific media titles from source comments

### DIFF
--- a/backend/src/modules/streaming/transcoding/codec/tonemap-opencl-probe.ts
+++ b/backend/src/modules/streaming/transcoding/codec/tonemap-opencl-probe.ts
@@ -21,9 +21,9 @@ const execFileAsync = promisify(execFile);
  *  variant: the extra `hwdownload → crop → hwupload=vaapi → …`
  *  prefix changes the surface format that reaches the final
  *  `hwmap=qsv:reverse=1` step and trips the bridge. Splitting the
- *  capability lets a cropped HDR session (Arcane) fall back to
- *  tonemap_vaapi while an uncropped HDR session (Mission Impossible
- *  2160p) keeps using opencl for better mid-tone restoration. */
+ *  capability lets a cropped HDR session fall back to tonemap_vaapi
+ *  while an uncropped HDR session keeps using opencl for better
+ *  mid-tone restoration. */
 let probedOnce = false;
 let noCropEnabled = false;
 let withCropEnabled = false;
@@ -88,8 +88,8 @@ export async function runTonemapOpenclProbe(log: Logger): Promise<void> {
     );
 
     // Probe 1: tonemap_opencl without the crop prefix — the path
-    // session-time uses for uncropped HDR sources. Mirrors what we'd
-    // run for Mission Impossible 2160p HDR no-crop / similar.
+    // session-time uses for uncropped HDR sources (typical 2160p
+    // HDR10 movie at full source aspect).
     //
     // `-filter_hw_device va` (not `ocl`): without this the hwupload
     // back to vaapi after the CPU crop fails with `Function not

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -477,8 +477,8 @@ export function buildFfmpegArgs(
   // crop runs in the same colour space as the decoded surface: for a
   // 10-bit HDR source, `format=nv12` would silently downconvert to
   // 8-bit BT.709-clamped pixels before the tonemap filter ever runs,
-  // which is what produced the dark image on cropped HDR sources
-  // (Mission Impossible 2160p HDR10 + crop).
+  // which is what produced the dark image on cropped 2160p HDR10
+  // sources.
   const cropPxFmt = sourceBitDepth === 10 ? 'p010le' : 'nv12';
   const hwCropPrefix = cropStr
     ? `hwdownload,format=${cropPxFmt},${cropStr},hwupload=derive_device=vaapi,`
@@ -537,8 +537,8 @@ export function buildFfmpegArgs(
   //    pixels. iOS AVPlayer rejects that combination with -12927; other
   //    players tolerate it but render with the wrong gamut / TRC.
   //
-  // 2. Source with unsignalled colorimetry (e.g. older WEBDL H.264
-  //    masters like Arcane S2): the source SPS leaves
+  // 2. Source with unsignalled colorimetry (older WEBDL H.264
+  //    masters): the source SPS leaves
   //    color_primaries/_trc/_space/_range all `unknown`. FFmpeg
   //    propagates the unknown tags into the output SPS. Android
   //    Media3 + the HDR-preserving SurfaceView path can refuse to

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -301,8 +301,8 @@ export function generateMasterPlaylist(
     // declare avc1 L3.2 in the master while the bitstream SPS carries
     // L3.1 for the actual 1280×544 frames. The mismatch (declared > SPS)
     // can leave ExoPlayer's track selector stuck on cold prepare —
-    // visible as the Arcane "buffering forever, no decoder allocated"
-    // pattern on Android.
+    // visible as the "buffering forever, no decoder allocated"
+    // pattern on Android with cropped masters.
     const target = {
       width: w,
       height: h,

--- a/backend/src/modules/subtitles/ffprobe.service.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.ts
@@ -366,10 +366,10 @@ export class FfprobeService {
     );
     try {
       // Sample 6 timestamps spread across the file (5–80%) — animated 4K
-      // Blurays like Arcane mix full-frame action with cinema-aspect
-      // dialogue scenes, and a tight 3-sample run repeatedly hit only
-      // full-frame moments and reported 'no crop needed' on a clearly
-      // letterboxed source. Six samples in parallel finish faster than
+      // Blurays often mix full-frame action with cinema-aspect dialogue
+      // scenes, and a tight 3-sample run repeatedly hit only full-frame
+      // moments and reported 'no crop needed' on a clearly letterboxed
+      // source. Six samples in parallel finish faster than
       // three sequential, so the wider coverage is free.
       const dur = durationSeconds ?? 600;
       const fractions = [0.05, 0.15, 0.3, 0.45, 0.6, 0.8];


### PR DESCRIPTION
Replaces named-title references in source comments with generic descriptions of the bug class. Same rationale as the existing rule about competitor names — title names age out, code comments don't, and the technical context (cinemascope crop, cropped HDR, unsignalled WEBDL colorimetry) is what stays useful to a future reader.

Touched files:
- \`backend/src/modules/streaming/transcoding/codec/tonemap-opencl-probe.ts\`
- \`backend/src/modules/streaming/transcoding/ffmpeg-args.ts\`
- \`backend/src/modules/streaming/transcoding/master-playlist.ts\`
- \`backend/src/modules/subtitles/ffprobe.service.ts\`

PR descriptions of #146 and #159 were also edited to remove the same references.