### PR TITLE
fix(indexers): query Torznab with original title

### DIFF
--- a/backend/src/modules/media/episode-download.service.ts
+++ b/backend/src/modules/media/episode-download.service.ts
@@ -145,10 +145,18 @@ export class EpisodeDownloadService {
     );
 
     const searchQuery = customQuery?.trim();
-    const queryTitle = searchQuery || media.title;
+    // Sonarr-style: prefer the original (typically English) title for
+    // the indexer query — scene release names rarely use localized
+    // titles. The localized title still goes into expectedTitle so the
+    // matcher accepts releases that use either spelling.
+    const queryTitle = searchQuery || media.originalTitle || media.title;
     const expectedTitle: string | string[] = searchQuery
       ? searchQuery
-      : [media.title, ...(media.alternativeTitles ?? [])];
+      : [
+          media.originalTitle,
+          media.title,
+          ...(media.alternativeTitles ?? []),
+        ].filter((t): t is string => !!t && t.length > 0);
     const externalIds = { tvdbId: media.tvdbId, imdbId: media.imdbId };
     const batches = await Promise.all(
       indexers.map((ix) =>

--- a/backend/src/modules/media/movie-download.service.ts
+++ b/backend/src/modules/media/movie-download.service.ts
@@ -143,9 +143,24 @@ export class MovieDownloadService {
   }
 
   private searchQueryForMedia(media: Media): string {
-    const parts = [media.title];
+    // Radarr-style: indexer release names overwhelmingly use the
+    // original title (typically English), so a TMDB import in a
+    // non-English locale would otherwise search "Le Seigneur des
+    // Anneaux" and miss "The Lord of the Rings" releases entirely.
+    const parts = [media.originalTitle || media.title];
     if (media.year) parts.push(String(media.year));
     return parts.join(' ');
+  }
+
+  /** Title list passed to the scorer for release-title matching. Order
+   *  doesn't matter — the matcher tries each. Filter out falsy values
+   *  in case the media has no original title or no localized title. */
+  private expectedTitlesForMedia(media: Media): string[] {
+    return [
+      media.originalTitle,
+      media.title,
+      ...(media.alternativeTitles ?? []),
+    ].filter((t): t is string => !!t && t.length > 0);
   }
 
   async searchMovieReleases(
@@ -193,7 +208,7 @@ export class MovieDownloadService {
       indexers,
       allowed,
       allowedLangs,
-      customTitle || [media.title, ...(media.alternativeTitles ?? [])],
+      customTitle || this.expectedTitlesForMedia(media),
     );
     const accepted = rows.filter((r) => r.rejections.length === 0).length;
     this.log.log(
@@ -383,7 +398,7 @@ export class MovieDownloadService {
       indexers,
       allowed,
       allowedLangs,
-      customTitle || [media.title, ...(media.alternativeTitles ?? [])],
+      customTitle || this.expectedTitlesForMedia(media),
     );
 
     // Only keep releases that are strictly better than current AND within cutoff


### PR DESCRIPTION
## Summary

- Indexer search now uses `media.originalTitle || media.title` as the primary query — scene release names rarely use localized titles, so a TMDB import in a non-English locale was missing releases entirely.
- Expected-title list (used by the scorer for release-title matching) widens to include both original and localized titles plus `alternativeTitles`, so a release using either spelling is still accepted.
- User-supplied custom queries remain authoritative when provided.

## Test plan

- [ ] Import a movie in a non-English locale, trigger release search → results include releases named with the original title.
- [ ] Same for a series episode search.
- [ ] Custom query override still wins.
