### PR TITLE
feat(indexers): per-indexer rate limit + 429/Retry-After + backoff

### DIFF
--- a/backend/src/migrations/1778700000000-add-indexer-request-delay.ts
+++ b/backend/src/migrations/1778700000000-add-indexer-request-delay.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddIndexerRequestDelay1778700000000 implements MigrationInterface {
+  name = 'AddIndexerRequestDelay1778700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "indexers"
+        ADD COLUMN IF NOT EXISTS "requestDelay" integer NOT NULL DEFAULT 2
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "indexers"
+        DROP COLUMN IF EXISTS "requestDelay"
+    `);
+  }
+}

--- a/backend/src/modules/indexers/dto/create-indexer.dto.ts
+++ b/backend/src/modules/indexers/dto/create-indexer.dto.ts
@@ -32,6 +32,11 @@ export class CreateIndexerDto {
   @IsOptional()
   priority?: number;
 
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  requestDelay?: number;
+
   @IsBoolean()
   @IsOptional()
   enabled?: boolean;

--- a/backend/src/modules/indexers/dto/update-indexer.dto.ts
+++ b/backend/src/modules/indexers/dto/update-indexer.dto.ts
@@ -34,6 +34,11 @@ export class UpdateIndexerDto {
   @IsOptional()
   priority?: number;
 
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  requestDelay?: number;
+
   @IsBoolean()
   @IsOptional()
   enabled?: boolean;

--- a/backend/src/modules/indexers/entities/indexer.entity.ts
+++ b/backend/src/modules/indexers/entities/indexer.entity.ts
@@ -21,6 +21,13 @@ export class Indexer extends BaseEntity {
   @Column({ default: 25 })
   priority: number;
 
+  /** Minimum seconds between two consecutive requests to this indexer.
+   *  Enforced by `IndexerThrottle` — protects against IP bans from
+   *  trackers behind anti-DDoS (Cloudflare etc.) when the search
+   *  runner fans out across many medias. */
+  @Column({ default: 2 })
+  requestDelay: number;
+
   @Column({ default: true })
   enabled: boolean;
 

--- a/backend/src/modules/indexers/indexer-throttle.service.ts
+++ b/backend/src/modules/indexers/indexer-throttle.service.ts
@@ -1,0 +1,138 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Indexer } from './entities/indexer.entity';
+
+/**
+ * Serialises requests to each indexer and enforces a minimum delay
+ * between them, mirroring Prowlarr's per-indexer throttle. Public
+ * tracker portals (especially behind Cloudflare anti-DDoS) IP-ban
+ * clients that exceed their tolerance; this layer is what keeps the
+ * scheduler — which fans out across hundreds of medias — within those
+ * limits.
+ *
+ * Three protection mechanisms layered together:
+ *   1. Per-indexer serial queue — only one in-flight request at a
+ *      time. Cross-indexer calls remain parallel.
+ *   2. Minimum `requestDelay` (seconds) between the START of two
+ *      consecutive requests for the same indexer.
+ *   3. `Retry-After` window — when a 429/503 surfaces the header,
+ *      subsequent calls block until the window elapses; this overrides
+ *      `requestDelay` upward, never downward.
+ *   4. Progressive cooldown on consecutive failures — 30s → 2min →
+ *      15min → 1h → 6h. Resets on success.
+ */
+@Injectable()
+export class IndexerThrottle {
+  private readonly log = new Logger(IndexerThrottle.name);
+  /** Tail of the per-indexer promise chain. Awaiting it serialises
+   *  the next operation behind all currently-queued ones. */
+  private chains = new Map<number, Promise<unknown>>();
+  /** Earliest wall-clock ms a new request to this indexer is allowed
+   *  to start. Updated post-request (current + delay) AND on
+   *  Retry-After (current + retry window). */
+  private nextAllowedAt = new Map<number, number>();
+  /** Consecutive failure count — drives progressive cooldown. */
+  private failureCount = new Map<number, number>();
+
+  /** Queue `fn` against `indexer`. Returns whatever `fn` resolves to.
+   *  Rejections propagate untouched (so callers can pattern-match on
+   *  axios errors), but failure metadata is recorded for backoff. */
+  async run<T>(indexer: Indexer, fn: () => Promise<T>): Promise<T> {
+    const prev = this.chains.get(indexer.id) ?? Promise.resolve();
+    const current = prev.then(() => this.runOne(indexer, fn));
+    // Swallow rejections at the chain level so a single failure
+    // doesn't poison every queued follower with an unhandled-rejection
+    // error. The caller still sees the rejection through its own
+    // `await current`.
+    this.chains.set(
+      indexer.id,
+      current.catch(() => undefined),
+    );
+    return current;
+  }
+
+  private async runOne<T>(indexer: Indexer, fn: () => Promise<T>): Promise<T> {
+    const delayMs = Math.max(0, indexer.requestDelay ?? 2) * 1000;
+    const earliest = this.nextAllowedAt.get(indexer.id) ?? 0;
+    const wait = earliest - Date.now();
+    if (wait > 0) await sleep(wait);
+    try {
+      const result = await fn();
+      this.notifySuccess(indexer.id);
+      this.nextAllowedAt.set(indexer.id, Date.now() + delayMs);
+      return result;
+    } catch (e) {
+      this.nextAllowedAt.set(indexer.id, Date.now() + delayMs);
+      throw e;
+    }
+  }
+
+  /** Honour a `Retry-After` value (in seconds OR an absolute date).
+   *  Caller passes whatever the response header carried. */
+  setRetryAfter(indexer: Indexer, headerValue: string | undefined): void {
+    const ms = parseRetryAfter(headerValue);
+    if (ms <= 0) return;
+    const until = Date.now() + ms;
+    const current = this.nextAllowedAt.get(indexer.id) ?? 0;
+    if (until > current) this.nextAllowedAt.set(indexer.id, until);
+    this.log.warn(
+      `[${indexer.name}] Retry-After honoured — next request in ${Math.round(ms / 1000)}s`,
+    );
+  }
+
+  /** Caller signals a transport-level failure (network error, 5xx,
+   *  429 even after Retry-After). Drives progressive cooldown. */
+  notifyFailure(indexer: Indexer): void {
+    const n = (this.failureCount.get(indexer.id) ?? 0) + 1;
+    this.failureCount.set(indexer.id, n);
+    const cooldownMs = backoffFor(n);
+    if (cooldownMs <= 0) return;
+    const until = Date.now() + cooldownMs;
+    const current = this.nextAllowedAt.get(indexer.id) ?? 0;
+    if (until > current) this.nextAllowedAt.set(indexer.id, until);
+    this.log.warn(
+      `[${indexer.name}] consecutive failure #${n} — cooldown ${Math.round(cooldownMs / 1000)}s`,
+    );
+  }
+
+  /** Reset the backoff state for an indexer on confirmed success. */
+  notifySuccess(indexerId: number): void {
+    this.failureCount.delete(indexerId);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * RFC 7231 §7.1.3: `Retry-After` is either a delta-seconds integer or
+ * an HTTP-date. Returns the wait in milliseconds; 0 if unparseable.
+ */
+function parseRetryAfter(value: string | undefined): number {
+  if (!value) return 0;
+  const trimmed = value.trim();
+  if (/^\d+$/.test(trimmed)) {
+    return parseInt(trimmed, 10) * 1000;
+  }
+  const ts = Date.parse(trimmed);
+  if (!isNaN(ts)) {
+    return Math.max(0, ts - Date.now());
+  }
+  return 0;
+}
+
+/**
+ * Progressive cooldown after consecutive failures. Caps at 6h so a
+ * permanently-broken indexer doesn't waste cycles but still
+ * occasionally probes for recovery.
+ */
+function backoffFor(failureCount: number): number {
+  const steps = [
+    30_000,        // 1st failure → 30s
+    2 * 60_000,    // 2nd        → 2 min
+    15 * 60_000,   // 3rd        → 15 min
+    60 * 60_000,   // 4th        → 1 h
+    6 * 60 * 60_000, // 5th+    → 6 h
+  ];
+  return steps[Math.min(failureCount, steps.length) - 1] ?? 0;
+}

--- a/backend/src/modules/indexers/indexers.module.ts
+++ b/backend/src/modules/indexers/indexers.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Indexer } from './entities/indexer.entity';
 import { IndexerStat } from './entities/indexer-stat.entity';
 import { TorznabService } from './torznab.service';
+import { IndexerThrottle } from './indexer-throttle.service';
 import { IndexersService } from './indexers.service';
 import { IndexersController } from './indexers.controller';
 import { AuthModule } from '../auth/auth.module';
@@ -10,7 +11,7 @@ import { AuthModule } from '../auth/auth.module';
 @Module({
   imports: [TypeOrmModule.forFeature([Indexer, IndexerStat]), AuthModule],
   controllers: [IndexersController],
-  providers: [TorznabService, IndexersService],
+  providers: [TorznabService, IndexerThrottle, IndexersService],
   exports: [TypeOrmModule, TorznabService],
 })
 export class IndexersModule {}

--- a/backend/src/modules/indexers/indexers.service.ts
+++ b/backend/src/modules/indexers/indexers.service.ts
@@ -44,6 +44,7 @@ export class IndexersService {
       enableRss: dto.enableRss ?? true,
       enableSearch: dto.enableSearch ?? true,
       priority: dto.priority ?? 25,
+      requestDelay: dto.requestDelay ?? 2,
       enabled: dto.enabled ?? true,
     });
 
@@ -73,6 +74,7 @@ export class IndexersService {
     if (dto.enableRss !== undefined) ix.enableRss = dto.enableRss;
     if (dto.enableSearch !== undefined) ix.enableSearch = dto.enableSearch;
     if (dto.priority !== undefined) ix.priority = dto.priority;
+    if (dto.requestDelay !== undefined) ix.requestDelay = dto.requestDelay;
     if (dto.enabled !== undefined) ix.enabled = dto.enabled;
     if (dto.settings !== undefined)
       ix.settings = this.sanitizeSettings(dto.settings);

--- a/backend/src/modules/indexers/torznab.service.ts
+++ b/backend/src/modules/indexers/torznab.service.ts
@@ -1,9 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { Indexer } from './entities/indexer.entity';
 import { IndexerStat } from './entities/indexer-stat.entity';
+import { IndexerThrottle } from './indexer-throttle.service';
 
 export interface TorznabRelease {
   title: string;
@@ -162,7 +163,27 @@ export class TorznabService {
     private readonly statRepo: Repository<IndexerStat>,
     @InjectRepository(Indexer)
     private readonly indexerRepo: Repository<Indexer>,
+    private readonly throttle: IndexerThrottle,
   ) {}
+
+  /** Detect Retry-After-bearing responses (429, 503) and feed the
+   *  header to the throttle so subsequent queued calls wait. Returns
+   *  true if the error was rate-limit-shaped — caller treats it as a
+   *  transient failure rather than a hard outage. */
+  private maybeHandleRateLimit(indexer: Indexer, e: unknown): boolean {
+    if (!axios.isAxiosError(e)) return false;
+    const ax = e as AxiosError;
+    const status = ax.response?.status;
+    if (status === 429 || status === 503) {
+      const header = ax.response?.headers?.['retry-after'];
+      this.throttle.setRetryAfter(
+        indexer,
+        typeof header === 'string' ? header : undefined,
+      );
+      return true;
+    }
+    return false;
+  }
 
   /**
    * Call t=caps and persist the results on the indexer row.
@@ -179,14 +200,16 @@ export class TorznabService {
     let capsTvSearch = false;
 
     try {
-      const res = await axios.get<string>(
-        `${baseUrl}?t=caps&apikey=${encodeURIComponent(apiKey)}`,
-        {
-          timeout: 10_000,
-          responseType: 'text',
-          headers: { 'User-Agent': 'Fliks/1.0' },
-          validateStatus: () => true,
-        },
+      const res = await this.throttle.run(indexer, () =>
+        axios.get<string>(
+          `${baseUrl}?t=caps&apikey=${encodeURIComponent(apiKey)}`,
+          {
+            timeout: 10_000,
+            responseType: 'text',
+            headers: { 'User-Agent': 'Fliks/1.0' },
+            validateStatus: () => true,
+          },
+        ),
       );
       const body = typeof res.data === 'string' ? res.data : String(res.data);
       capsMovieSearch = /<movie-search\s[^>]*available="yes"/i.test(body);
@@ -195,6 +218,8 @@ export class TorznabService {
         `[${indexer.name}] caps refreshed — movieSearch=${capsMovieSearch}, tvSearch=${capsTvSearch}`,
       );
     } catch (e) {
+      this.maybeHandleRateLimit(indexer, e);
+      this.throttle.notifyFailure(indexer);
       this.log.warn(
         `[${indexer.name}] caps fetch failed: ${(e as Error).message}`,
       );
@@ -218,12 +243,14 @@ export class TorznabService {
   ): Promise<{ results: TorznabRelease[]; torznabError: string | null }> {
     const start = Date.now();
     try {
-      const res = await axios.get<string>(url, {
-        timeout: 90_000,
-        responseType: 'text',
-        headers: { 'User-Agent': 'Fliks/1.0' },
-        validateStatus: (s) => s >= 200 && s < 400,
-      });
+      const res = await this.throttle.run(indexer, () =>
+        axios.get<string>(url, {
+          timeout: 90_000,
+          responseType: 'text',
+          headers: { 'User-Agent': 'Fliks/1.0' },
+          validateStatus: (s) => s >= 200 && s < 400,
+        }),
+      );
       const body = typeof res.data === 'string' ? res.data : String(res.data);
       if (/<error\s+code=/i.test(body)) {
         const m = body.match(/description="([^"]*)"/i);
@@ -251,6 +278,8 @@ export class TorznabService {
       );
       return { results, torznabError: null };
     } catch (e) {
+      this.maybeHandleRateLimit(indexer, e);
+      this.throttle.notifyFailure(indexer);
       const msg = (e as Error).message;
       void this.statRepo.save(
         this.statRepo.create({
@@ -299,6 +328,9 @@ export class TorznabService {
     }
     const url = `${base}?t=caps&apikey=${encodeURIComponent(apiKey || '')}`;
     try {
+      // Connection test is invoked from the UI before an indexer row
+      // exists — no throttle key to use. The user only fires this
+      // sporadically, so it can safely bypass the per-indexer queue.
       const res = await axios.get<string>(url, {
         timeout: 30_000,
         responseType: 'text',
@@ -336,12 +368,14 @@ export class TorznabService {
     const url = `${baseUrl}?t=search&q=&cat=2000&apikey=${encodeURIComponent(apiKey)}`;
     const start = Date.now();
     try {
-      const res = await axios.get<string>(url, {
-        timeout: 60_000,
-        responseType: 'text',
-        headers: { 'User-Agent': 'Fliks/1.0' },
-        validateStatus: (s) => s >= 200 && s < 400,
-      });
+      const res = await this.throttle.run(indexer, () =>
+        axios.get<string>(url, {
+          timeout: 60_000,
+          responseType: 'text',
+          headers: { 'User-Agent': 'Fliks/1.0' },
+          validateStatus: (s) => s >= 200 && s < 400,
+        }),
+      );
       const body = typeof res.data === 'string' ? res.data : String(res.data);
       const results = parseTorznabItems(body, indexer);
       void this.statRepo.save(
@@ -355,6 +389,8 @@ export class TorznabService {
       );
       return results;
     } catch (e) {
+      this.maybeHandleRateLimit(indexer, e);
+      this.throttle.notifyFailure(indexer);
       void this.statRepo.save(
         this.statRepo.create({
           indexer,

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1018,6 +1018,8 @@
       "field_min_seeders": "Seeders minimum",
       "field_seed_ratio": "Ratio de seed",
       "seed_ratio_hint": "Ratio minimum avant suppression (defaut : 1.0)",
+      "field_request_delay": "Délai entre requêtes (secondes)",
+      "request_delay_hint": "Temps minimum entre 2 requêtes vers cet indexer. 2s minimum recommandé pour les trackers publics derrière Cloudflare ; 3-5s pour les sites plus stricts (sinon risque de ban IP).",
       "field_max_retention": "Retention max (jours)",
       "max_retention_hint": "Supprimer apres N jours, sans attendre le ratio",
       "save": "Enregistrer",

--- a/client/src/app/core/services/api/indexers-api.service.ts
+++ b/client/src/app/core/services/api/indexers-api.service.ts
@@ -10,6 +10,7 @@ export interface IndexerRow {
   enableRss: boolean;
   enableSearch: boolean;
   priority: number;
+  requestDelay: number;
   enabled: boolean;
 }
 
@@ -20,6 +21,7 @@ export interface CreateIndexerBody {
   enableRss?: boolean;
   enableSearch?: boolean;
   priority?: number;
+  requestDelay?: number;
   enabled?: boolean;
 }
 

--- a/client/src/app/features/settings/indexers/indexers.html
+++ b/client/src/app/features/settings/indexers/indexers.html
@@ -163,6 +163,21 @@
             />
           </label>
         </div>
+        <div class="grid grid-cols-1 gap-3">
+          <label class="form-control w-full">
+            <span class="label-text">{{ 'settings.indexers.field_request_delay' | translate }}</span>
+            <input
+              type="number"
+              class="input input-bordered input-sm w-full"
+              [ngModel]="formRequestDelay()"
+              (ngModelChange)="formRequestDelay.set(+$event)"
+              min="0"
+            />
+            <div class="label">
+              <span class="label-text-alt text-base-content/50">{{ 'settings.indexers.request_delay_hint' | translate }}</span>
+            </div>
+          </label>
+        </div>
         <div class="grid grid-cols-2 gap-3">
           <label class="form-control w-full">
             <span class="label-text">{{ 'settings.indexers.field_seed_ratio' | translate }}</span>

--- a/client/src/app/features/settings/indexers/indexers.ts
+++ b/client/src/app/features/settings/indexers/indexers.ts
@@ -40,6 +40,7 @@ export class IndexersSettingsComponent implements OnInit {
 
   readonly formName = signal('');
   readonly formPriority = signal(25);
+  readonly formRequestDelay = signal(2);
   readonly formEnabled = signal(true);
   readonly formEnableSearch = signal(true);
   readonly formTorznabBase = signal('');
@@ -83,6 +84,7 @@ export class IndexersSettingsComponent implements OnInit {
     this.editingId.set(null);
     this.formName.set('');
     this.formPriority.set(25);
+    this.formRequestDelay.set(2);
     this.formEnabled.set(true);
     this.formEnableSearch.set(true);
     this.formTorznabBase.set('');
@@ -99,6 +101,7 @@ export class IndexersSettingsComponent implements OnInit {
     this.editingId.set(ix.id);
     this.formName.set(ix.name);
     this.formPriority.set(ix.priority);
+    this.formRequestDelay.set(ix.requestDelay ?? 2);
     this.formEnabled.set(ix.enabled);
     this.formEnableSearch.set(ix.enableSearch);
     const s = ix.settings ?? {};
@@ -156,6 +159,7 @@ export class IndexersSettingsComponent implements OnInit {
       name,
       implementation: 'torznab' as const,
       priority: this.formPriority(),
+      requestDelay: this.formRequestDelay(),
       enabled: this.formEnabled(),
       enableSearch: this.formEnableSearch(),
       settings: {


### PR DESCRIPTION
## Summary

Trackers behind Cloudflare-style anti-DDoS IP-ban clients that exceed their request tolerance. A `SearchMissing` cron over a few dozen medias was enough to get banned on 1337x. This adds per-indexer throttling:

- **Per-indexer serial queue** — only one in-flight request to a given indexer at a time. Cross-indexer calls remain parallel.
- **Per-indexer minimum delay** between requests, configurable via the indexer-edit form (`requestDelay`, default 2s).
- **`Retry-After` honoured** on 429 and 503 responses — subsequent queued calls block until the window elapses.
- **Progressive cooldown on consecutive failures** (30s → 2min → 15min → 1h → 6h), reset on success.

Wired through every axios call in `TorznabService` (caps refresh, search, RSS, fallback). Connection-test path intentionally bypasses since it runs before the indexer row exists.

## Test plan

- [ ] Existing indexers auto-migrate to `requestDelay = 2`.
- [ ] Indexer edit form shows the new field with hint.
- [ ] Setting `requestDelay: 5` on an indexer caps RSS sync calls to that indexer at one every 5s (visible in `IndexerStat`).
- [ ] When the indexer returns 429 with `Retry-After: 60`, subsequent calls wait ≥60s.
