### PR TITLE
fix(media-detail): show Grab/Search releases on episode header

### DIFF
--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -54,6 +54,7 @@
           [subtitles]="subtitleSection()?.headerSubtitles() ?? []"
           [files]="episodeFiles()"
           [selectedFileId]="episodeActiveFileId()"
+          [qualityProfileName]="m.qualityProfile?.name ?? null"
           [canGrab]="canGrab()"
           [isAdmin]="isAdmin()"
           [releasesLoading]="epReleasesLoading()"


### PR DESCRIPTION
## Summary

The two release actions ("Grab best" + "Search releases") in the dropdown were silently hidden on the per-episode header. Root cause: the gate in `media-info-header` requires `qualityProfileName()` to be truthy (otherwise the backend would reject both calls), and the episode-mode header in `media-detail.html` didn't pass the prop.

## Test plan

- [ ] Open a series with a quality profile assigned → pick an episode → "..." dropdown shows both actions.
- [ ] Open a series with no quality profile → buttons stay hidden (unchanged behaviour).