### PR TITLE
feat(releases): polish search results + UI

### DIFF
--- a/backend/src/modules/indexers/torznab.service.ts
+++ b/backend/src/modules/indexers/torznab.service.ts
@@ -19,13 +19,44 @@ export interface TorznabRelease {
   downloadVolumeFactor: number; // 0=free, 0.5=half, 1=normal
 }
 
+/** HTML4 Latin-1 named entities we expect from misbehaving Torznab
+ *  back-ends (notably The Pirate Bay's Cardigann wrapper) that emit
+ *  HTML-escaped titles instead of pure XML. Restricted to the
+ *  Western-European subset that actually surfaces in release titles. */
+const HTML_NAMED_ENTITIES: Record<string, string> = {
+  amp: '&', lt: '<', gt: '>', apos: "'", quot: '"', nbsp: ' ',
+  iexcl: '¡', cent: '¢', pound: '£', yen: '¥', sect: '§',
+  copy: '©', reg: '®', deg: '°', plusmn: '±', sup2: '²', sup3: '³',
+  micro: 'µ', para: '¶', middot: '·', sup1: '¹', frac14: '¼', frac12: '½',
+  frac34: '¾', iquest: '¿', Agrave: 'À', Aacute: 'Á', Acirc: 'Â',
+  Atilde: 'Ã', Auml: 'Ä', Aring: 'Å', AElig: 'Æ', Ccedil: 'Ç',
+  Egrave: 'È', Eacute: 'É', Ecirc: 'Ê', Euml: 'Ë', Igrave: 'Ì',
+  Iacute: 'Í', Icirc: 'Î', Iuml: 'Ï', ETH: 'Ð', Ntilde: 'Ñ',
+  Ograve: 'Ò', Oacute: 'Ó', Ocirc: 'Ô', Otilde: 'Õ', Ouml: 'Ö',
+  Oslash: 'Ø', Ugrave: 'Ù', Uacute: 'Ú', Ucirc: 'Û', Uuml: 'Ü',
+  Yacute: 'Ý', THORN: 'Þ', szlig: 'ß', agrave: 'à', aacute: 'á',
+  acirc: 'â', atilde: 'ã', auml: 'ä', aring: 'å', aelig: 'æ',
+  ccedil: 'ç', egrave: 'è', eacute: 'é', ecirc: 'ê', euml: 'ë',
+  igrave: 'ì', iacute: 'í', icirc: 'î', iuml: 'ï', eth: 'ð',
+  ntilde: 'ñ', ograve: 'ò', oacute: 'ó', ocirc: 'ô', otilde: 'õ',
+  ouml: 'ö', oslash: 'ø', ugrave: 'ù', uacute: 'ú', ucirc: 'û',
+  uuml: 'ü', yacute: 'ý', thorn: 'þ', yuml: 'ÿ', OElig: 'Œ',
+  oelig: 'œ', Scaron: 'Š', scaron: 'š', Yuml: 'Ÿ', ldquo: '“',
+  rdquo: '”', lsquo: '‘', rsquo: '’', bdquo: '„', hellip: '…',
+  ndash: '–', mdash: '—', trade: '™', euro: '€',
+};
+
 function decodeXmlEntities(s: string): string {
-  return s
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&apos;/g, "'")
-    .replace(/&quot;/g, '"');
+  return s.replace(/&(?:#(x?)([0-9a-fA-F]+)|([a-zA-Z]+));/g, (raw, hex, num, name) => {
+    if (num) {
+      const code = parseInt(num, hex === 'x' ? 16 : 10);
+      if (isFinite(code) && code > 0) {
+        try { return String.fromCodePoint(code); } catch { /* invalid code point */ }
+      }
+      return raw;
+    }
+    return HTML_NAMED_ENTITIES[name as string] ?? raw;
+  });
 }
 
 /**

--- a/backend/src/modules/media/episode-download.service.ts
+++ b/backend/src/modules/media/episode-download.service.ts
@@ -19,6 +19,8 @@ import {
   parseReleaseLanguage,
   resolveUnknownLanguage,
 } from './release-language.parser';
+import { parseSeasonEpisode } from './release-episode.parser';
+import { getAppQualityById } from '../../common/constants/app-qualities';
 import { CustomFormatsService } from '../profiles/custom-formats.service';
 import { ProfilesService } from '../profiles/profiles.service';
 import { QualityDefinitionsService } from '../profiles/quality-definitions.service';
@@ -34,6 +36,8 @@ import {
   buildIndexerMinSeeders,
   buildAllowedQualityIds,
   computeRejections,
+  computeSizeDeviation,
+  detectVideoCodec,
   sortReleasesByRelevance,
   SizeLimits,
 } from './release-rejection.helper';
@@ -58,6 +62,19 @@ export interface EpisodeReleaseRow {
   rejections: ReleaseRejection[];
   freeleech: boolean;
   downloadVolumeFactor: number;
+  /** True when the release title parses as a full-season pack
+   *  (`S01`, `Season 1`, etc. without an episode number). */
+  isFullSeason: boolean;
+  /** Absolute distance of this release's MB/h from the codec-adjusted
+   *  preferred size for its quality, divided by the preferred. 0 when
+   *  on target, 0.5 = 50% off. `null` when the quality has no
+   *  preferred or the runtime is unknown. Used by the sort to nudge
+   *  on-target releases above oversized/undersized ones at equal
+   *  quality + custom-format score. */
+  sizeDeviation: number | null;
+  /** Video codec parsed from the release title. `null` when no
+   *  recognised codec token appears. */
+  videoCodec: 'AV1' | 'HEVC' | 'VP9' | 'x264' | null;
 }
 
 @Injectable()
@@ -106,7 +123,7 @@ export class EpisodeDownloadService {
 
     const episode = await this.episodeRepo.findOne({
       where: { id: episodeId },
-      relations: ['season'],
+      relations: ['season', 'season.episodes'],
     });
     if (!episode)
       throw new NotFoundException(`Episode #${episodeId} not found`);
@@ -169,24 +186,69 @@ export class EpisodeDownloadService {
         ),
       ),
     );
-    const flat = batches.flat();
+    // Filter out releases that clearly belong to a different episode.
+    // Some indexers (notably The Pirate Bay via Cardigann) ignore the
+    // `season=` / `ep=` Torznab parameters and run a plain text search,
+    // returning every episode of the show whose title matches. Keep
+    // releases when:
+    //   - the parser couldn't extract season/episode (could be a movie
+    //     or oddly-named release — let scoring decide), OR
+    //   - the season matches AND (episode matches OR it's a season pack
+    //     that contains the target episode).
+    const flat = batches.flat().filter((r) => {
+      const p = parseSeasonEpisode(r.title);
+      if (p.season === null) return true;
+      if (p.season !== season.seasonNumber) return false;
+      if (p.isFullSeason) return true;
+      if (p.episode === null) return true;
+      return p.episode === episode.episodeNumber;
+    });
 
-    const rows = await Promise.all(
-      flat.map((r) =>
-        this.buildReleaseRow(
+    // Season packs need their size scored against the WHOLE season's
+    // runtime (sum of episode runtimes), not a single episode — else
+    // a legit 25 GB 10-ep 2160p pack gets rejected as "oversize"
+    // because the limit was computed for a 45-min slot.
+    const defaultEpRuntime = media.runtime ?? 45;
+    const episodeRuntime = episode.runtime ?? defaultEpRuntime;
+    const seasonRuntime =
+      (episode.season.episodes ?? []).reduce(
+        (sum, ep) => sum + (ep.runtime ?? defaultEpRuntime),
+        0,
+      ) || episodeRuntime;
+
+    const rowsWithKind = await Promise.all(
+      flat.map(async (r) => {
+        const isPack = parseSeasonEpisode(r.title).isFullSeason;
+        const row = await this.buildReleaseRow(
           r,
           allowed,
           allowedLangs,
           sizeByQuality,
           indexerMinSeeders,
-          media.runtime ?? 45,
+          isPack ? seasonRuntime : episodeRuntime,
           indexerUnknownLang,
           expectedTitle,
-        ),
-      ),
+        );
+        return { row, isPack };
+      }),
     );
 
-    return sortReleasesByRelevance(rows);
+    // Drop everything above the profile's cutoff — see equivalent
+    // comment in MovieDownloadService.searchMovieReleases.
+    const cutoffRank = getAppQualityById(media.qualityProfile?.cutoff ?? 0)?.rank ?? 999;
+    const withinCutoff = rowsWithKind.filter((x) => x.row.rank <= cutoffRank);
+
+    // User is asking for ONE episode. Season packs still match, but
+    // they download a whole season for a single episode — they should
+    // rank below any equally-good single-episode release. Sort the two
+    // groups independently then concatenate.
+    const singles = sortReleasesByRelevance(
+      withinCutoff.filter((x) => !x.isPack).map((x) => x.row),
+    );
+    const packs = sortReleasesByRelevance(
+      withinCutoff.filter((x) => x.isPack).map((x) => x.row),
+    );
+    return [...singles, ...packs];
   }
 
   async grabEpisode(
@@ -327,6 +389,13 @@ export class EpisodeDownloadService {
       releaseTitle: r.title,
       expectedTitle,
     });
+    const isFullSeason = parseSeasonEpisode(r.title).isFullSeason;
+    const sizeDeviation = computeSizeDeviation(
+      r.title,
+      r.size,
+      runtimeMinutes,
+      sizeByQuality.get(parsed.quality.id),
+    );
     return {
       title: r.title,
       downloadUrl: r.downloadUrl,
@@ -347,6 +416,9 @@ export class EpisodeDownloadService {
       rejections,
       freeleech: r.freeleech,
       downloadVolumeFactor: r.downloadVolumeFactor,
+      isFullSeason,
+      sizeDeviation,
+      videoCodec: detectVideoCodec(r.title),
     };
   }
 
@@ -416,24 +488,48 @@ export class EpisodeDownloadService {
       ),
     );
 
-    const rows = await Promise.all(
-      batches
-        .flat()
-        .map((r) =>
-          this.buildReleaseRow(
-            r,
-            allowed,
-            allowedLangs,
-            sizeByQuality,
-            indexerMinSeeders,
-            seasonRuntime,
-            indexerUnknownLang,
-            expectedTitle,
-          ),
-        ),
+    // Same fan-out drift as the per-episode path: some indexers
+    // ignore `season=` and return any release whose title contains
+    // the show name. Keep only releases that parse to the requested
+    // season (single episodes or full packs alike).
+    const flat = batches.flat().filter((r) => {
+      const p = parseSeasonEpisode(r.title);
+      if (p.season === null) return true;
+      return p.season === season.seasonNumber;
+    });
+
+    const defaultEpisodeRuntime = media.runtime ?? 45;
+    const rowsWithKind = await Promise.all(
+      flat.map(async (r) => {
+        const isPack = parseSeasonEpisode(r.title).isFullSeason;
+        const row = await this.buildReleaseRow(
+          r,
+          allowed,
+          allowedLangs,
+          sizeByQuality,
+          indexerMinSeeders,
+          isPack ? seasonRuntime : defaultEpisodeRuntime,
+          indexerUnknownLang,
+          expectedTitle,
+        );
+        return { row, isPack };
+      }),
     );
 
-    return sortReleasesByRelevance(rows);
+    // Drop everything above the profile's cutoff.
+    const cutoffRank = getAppQualityById(media.qualityProfile?.cutoff ?? 0)?.rank ?? 999;
+    const withinCutoff = rowsWithKind.filter((x) => x.row.rank <= cutoffRank);
+
+    // User is asking for the whole season — surface packs first.
+    // Single episodes still appear (useful as a fallback when no
+    // pack matches the quality profile), just below all packs.
+    const packs = sortReleasesByRelevance(
+      withinCutoff.filter((x) => x.isPack).map((x) => x.row),
+    );
+    const singles = sortReleasesByRelevance(
+      withinCutoff.filter((x) => !x.isPack).map((x) => x.row),
+    );
+    return [...packs, ...singles];
   }
 
   async grabSeason(
@@ -628,21 +724,29 @@ export class EpisodeDownloadService {
             ),
           ),
         );
+        const epFlat = epBatches.flat().filter((r) => {
+          const p = parseSeasonEpisode(r.title);
+          if (p.season === null) return true;
+          if (p.season !== season.seasonNumber) return false;
+          if (p.isFullSeason) return true;
+          if (p.episode === null) return true;
+          return p.episode === ep.episodeNumber;
+        });
+        const epRuntime = ep.runtime ?? media.runtime ?? 45;
         const epRows = await Promise.all(
-          epBatches
-            .flat()
-            .map((r) =>
-              this.buildReleaseRow(
-                r,
-                allowed,
-                allowedLangs,
-                sizeByQuality,
-                indexerMinSeeders,
-                media.runtime ?? 45,
-                indexerUnknownLang,
-                expectedTitles,
-              ),
-            ),
+          epFlat.map((r) => {
+            const isPack = parseSeasonEpisode(r.title).isFullSeason;
+            return this.buildReleaseRow(
+              r,
+              allowed,
+              allowedLangs,
+              sizeByQuality,
+              indexerMinSeeders,
+              isPack ? seasonRuntime : epRuntime,
+              indexerUnknownLang,
+              expectedTitles,
+            );
+          }),
         );
         sortReleasesByRelevance(epRows);
 

--- a/backend/src/modules/media/movie-download.service.ts
+++ b/backend/src/modules/media/movie-download.service.ts
@@ -65,6 +65,9 @@ export interface MovieReleaseRow {
   rejections: ReleaseRejection[];
   freeleech: boolean;
   downloadVolumeFactor: number;
+  isFullSeason: boolean;
+  sizeDeviation: number | null;
+  videoCodec: 'AV1' | 'HEVC' | 'VP9' | 'x264' | null;
 }
 
 @Injectable()
@@ -210,12 +213,19 @@ export class MovieDownloadService {
       allowedLangs,
       customTitle || this.expectedTitlesForMedia(media),
     );
-    const accepted = rows.filter((r) => r.rejections.length === 0).length;
+    // Drop everything above the profile's cutoff. Above-cutoff qualities
+    // surfaced in manual results even when they couldn't be auto-grabbed,
+    // bloating the list with irrelevant 2160p hits when the user targets
+    // 1080p. The cutoff already gates the upgrade pipeline; mirror that
+    // contract here.
+    const cutoffRank = getAppQualityById(media.qualityProfile?.cutoff ?? 0)?.rank ?? 999;
+    const withinCutoff = rows.filter((r) => r.rank <= cutoffRank);
+    const accepted = withinCutoff.filter((r) => r.rejections.length === 0).length;
     this.log.log(
-      `[searchMovieReleases] "${media.title}" — ${rows.length} scored, ${accepted} accepted, ${rows.length - accepted} rejected`,
+      `[searchMovieReleases] "${media.title}" — ${withinCutoff.length} within cutoff (rank ≤ ${cutoffRank}), ${accepted} accepted, ${withinCutoff.length - accepted} rejected`,
     );
-    if (accepted === 0 && rows.length > 0) {
-      const sample = rows
+    if (accepted === 0 && withinCutoff.length > 0) {
+      const sample = withinCutoff
         .slice(0, 5)
         .map((r) => `"${r.title}" [${r.rejections.join(', ')}]`);
       this.log.warn(
@@ -223,7 +233,7 @@ export class MovieDownloadService {
       );
     }
 
-    return sortReleasesByRelevance(rows);
+    return sortReleasesByRelevance(withinCutoff);
   }
 
   async grabMovie(

--- a/backend/src/modules/media/release-rejection.helper.ts
+++ b/backend/src/modules/media/release-rejection.helper.ts
@@ -8,6 +8,7 @@ import {
   parseReleaseLanguage,
   resolveUnknownLanguage,
 } from './release-language.parser';
+import { parseSeasonEpisode } from './release-episode.parser';
 
 /**
  * Resolve a stored media-file quality string (e.g. `"WEBDL-1080p"`,
@@ -58,14 +59,52 @@ export interface ReleaseRejection {
  *   VP9          → 0.60 (~40% smaller than x264)
  *   Unknown      → 1.0  (conservative — assume x264)
  */
-function detectCodecSizeFactor(title?: string): number {
-  if (!title) return 1;
+/**
+ * Returns the codec-adjusted absolute deviation of a release's MB/h
+ * rate from the quality's preferred MB/h, normalised by preferred.
+ * 0 = on target; 0.5 = 50% off either way; `null` when preferred /
+ * runtime is unknown. Used by the sort comparator as a tiebreaker —
+ * lower deviation ranks above larger deviations at equal quality
+ * + custom-format score.
+ */
+export function computeSizeDeviation(
+  releaseTitle: string,
+  sizeBytes: number,
+  runtimeMinutes: number,
+  rawLimits: { min: number; preferred: number; max: number } | undefined,
+): number | null {
+  if (!rawLimits || rawLimits.preferred <= 0) return null;
+  if (runtimeMinutes <= 0 || sizeBytes <= 0) return null;
+  const sizeMb = sizeBytes / (1024 * 1024);
+  const sizeMbPerHour = sizeMb / (runtimeMinutes / 60);
+  const preferred = rawLimits.preferred * detectCodecSizeFactor(releaseTitle);
+  if (preferred <= 0) return null;
+  return Math.abs(sizeMbPerHour - preferred) / preferred;
+}
+
+export function detectCodecSizeFactor(title?: string): number {
+  switch (detectVideoCodec(title)) {
+    case 'AV1': return 0.45;
+    case 'HEVC': return 0.55;
+    case 'VP9': return 0.6;
+    default: return 1; // x264/h264 or unknown → baseline
+  }
+}
+
+/** Surface-friendly codec name parsed from the release title. Returns
+ *  null when no codec token is recognised so the UI can omit the
+ *  badge instead of guessing. */
+export function detectVideoCodec(title?: string): 'AV1' | 'HEVC' | 'VP9' | 'x264' | null {
+  if (!title) return null;
   const t = title.toLowerCase();
-  if (/\bav1\b/.test(t)) return 0.45;
-  if (/\b(x265|h\.?265|hevc)\b/.test(t)) return 0.55;
-  if (/\bvp9\b/.test(t)) return 0.6;
-  // x264/h264 or unknown → baseline
-  return 1;
+  if (/\bav1\b/.test(t)) return 'AV1';
+  // `h[.\s-]?` lets us catch "H.264", "H264", "h 264", "H-264" — some
+  // indexers tokenise dots to spaces, which would otherwise hide the
+  // codec marker behind a word boundary.
+  if (/\b(x265|h[.\s-]?265|hevc)\b/.test(t)) return 'HEVC';
+  if (/\bvp9\b/.test(t)) return 'VP9';
+  if (/\b(x264|h[.\s-]?264|avc)\b/.test(t)) return 'x264';
+  return null;
 }
 
 export interface SizeLimits {
@@ -291,22 +330,11 @@ export function computeRejections(opts: {
         },
       });
     }
-    if (
-      limits.preferred > 0 &&
-      out.every((r) => r.code !== 'SIZE_TOO_LOW' && r.code !== 'SIZE_TOO_HIGH')
-    ) {
-      const deviation =
-        Math.abs(sizeMbPerHour - limits.preferred) / limits.preferred;
-      if (deviation > 0.3) {
-        out.push({
-          code: 'SIZE_NOT_PREFERRED',
-          params: {
-            actual: Math.round(sizeMbPerHour),
-            preferred: Math.round(limits.preferred),
-          },
-        });
-      }
-    }
+    // Preferred is a sort-time signal only — anything within min/max
+    // is a valid release. Treating "deviation from preferred" as a
+    // rejection bumped legit season packs and oversize-but-still-good
+    // single episodes out of the auto-grab pool. min/max alone keep
+    // truly bad sizes out.
   }
 
   const minSeed = opts.indexerMinSeeders.get(opts.indexerId) ?? 0;
@@ -343,6 +371,7 @@ export function sortReleasesByRelevance<
     customFormatScore: number;
     seeders: number;
     freeleech: boolean;
+    sizeDeviation?: number | null;
   },
 >(rows: T[]): T[] {
   return rows.sort((a, b) => {
@@ -368,7 +397,15 @@ export function sortReleasesByRelevance<
     if (a.customFormatScore !== b.customFormatScore)
       return b.customFormatScore - a.customFormatScore;
 
-    // 7. Seeders desc (log scale)
+    // 7. Closer to preferred size wins (only when both rows expose it
+    //    and the gap is big enough to matter — within 5% of each other
+    //    counts as tied, otherwise tiny noise would flip the order).
+    if (a.sizeDeviation != null && b.sizeDeviation != null) {
+      const diff = Math.abs(a.sizeDeviation - b.sizeDeviation);
+      if (diff > 0.05) return a.sizeDeviation - b.sizeDeviation;
+    }
+
+    // 8. Seeders desc (log scale)
     const aSeed = Math.log2(a.seeders + 1);
     const bSeed = Math.log2(b.seeders + 1);
     if (Math.abs(aSeed - bSeed) > 0.5) return bSeed - aSeed;
@@ -393,6 +430,9 @@ export interface ScoredRelease extends TorznabRelease {
   languageName: string;
   languageAllowed: boolean;
   rejections: ReleaseRejection[];
+  isFullSeason: boolean;
+  sizeDeviation: number | null;
+  videoCodec: 'AV1' | 'HEVC' | 'VP9' | 'x264' | null;
 }
 
 /** Async callbacks injected by the caller (avoids coupling to NestJS services). */
@@ -470,6 +510,14 @@ export async function scoreAndSortReleases(
         languageAllowed:
           opts.allowedLangs.size === 0 || opts.allowedLangs.has(lang.id),
         rejections,
+        isFullSeason: parseSeasonEpisode(r.title).isFullSeason,
+        sizeDeviation: computeSizeDeviation(
+          r.title,
+          r.size,
+          opts.runtimeMinutes,
+          opts.sizeByQuality.get(parsed.quality.id),
+        ),
+        videoCodec: detectVideoCodec(r.title),
       };
     }),
   );

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -583,6 +583,7 @@
     "col_size": "Taille",
     "col_peers": "Seeds/Leech",
     "col_indexer": "Indexer",
+    "season_pack": "Pack de saison",
     "blocklisted": "Bloqué",
     "releases_empty": "Aucune release trouvée. Vérifiez vos indexers Torznab.",
     "releases_error": "Impossible de charger les releases.",

--- a/client/src/app/core/services/api/media.service.ts
+++ b/client/src/app/core/services/api/media.service.ts
@@ -43,6 +43,9 @@ export interface MovieRelease {
   rejections: { code: string; params?: Record<string, number | string> }[];
   freeleech: boolean;
   downloadVolumeFactor: number;
+  isFullSeason: boolean;
+  sizeDeviation: number | null;
+  videoCodec: 'AV1' | 'HEVC' | 'VP9' | 'x264' | null;
 }
 
 export interface Episode {

--- a/client/src/app/features/media-detail/components/releases-table/releases-table.component.html
+++ b/client/src/app/features/media-detail/components/releases-table/releases-table.component.html
@@ -3,13 +3,13 @@
     <thead>
       <tr>
         <th>{{ 'media_detail.col_release' | translate }}</th>
-        <th class="hidden sm:table-cell">{{ 'media_detail.col_quality' | translate }}</th>
+        <th class="hidden sm:table-cell w-72">{{ 'media_detail.col_quality' | translate }}</th>
         @if (showCfScore()) {
           <th class="hidden sm:table-cell text-center w-16">{{ 'media_detail.col_cf_score' | translate }}</th>
         }
         <th class="hidden sm:table-cell text-right w-20">{{ 'media_detail.col_size' | translate }}</th>
-        <th class="hidden sm:table-cell w-20">{{ 'media_detail.col_peers' | translate }}</th>
-        <th class="hidden sm:table-cell">{{ 'media_detail.col_indexer' | translate }}</th>
+        <th class="hidden sm:table-cell w-32">{{ 'media_detail.col_peers' | translate }}</th>
+        <th class="hidden sm:table-cell w-32">{{ 'media_detail.col_indexer' | translate }}</th>
         <th class="hidden sm:table-cell w-10"></th>
       </tr>
     </thead>
@@ -19,13 +19,21 @@
           <td class="text-sm min-w-0">
             <!-- Title scrolls horizontally on its own -->
             <div class="overflow-x-auto">
-              <p class="whitespace-nowrap">{{ r.title }}</p>
+              <p class="whitespace-nowrap inline-flex items-center gap-1.5">
+                @if (r.isFullSeason) {
+                  <svg lucidePackage class="h-4 w-4 shrink-0 text-info" [attr.title]="'media_detail.season_pack' | translate"></svg>
+                }
+                <span>{{ r.title }}</span>
+              </p>
             </div>
             <!-- Mobile-only info rows -->
             <div class="flex items-center justify-between gap-2 mt-1 sm:hidden">
               <div class="flex flex-col gap-1 min-w-0">
                 <div class="flex flex-wrap gap-1 items-center">
                   <span class="badge badge-sm badge-ghost">{{ r.qualityName }}</span>
+                  @if (r.videoCodec) {
+                    <span class="badge badge-sm badge-secondary">{{ r.videoCodec }}</span>
+                  }
                   <span class="badge badge-sm" [class]="r.languageAllowed ? 'badge-info' : 'badge-warning'">{{ r.languageName }}</span>
                   @if (r.freeleech) {
                     <span class="badge badge-sm badge-success">FL</span>
@@ -76,6 +84,9 @@
           <td class="hidden sm:table-cell whitespace-nowrap">
             <div class="flex flex-wrap gap-1 items-center">
               <span class="badge badge-sm badge-ghost">{{ r.qualityName }}</span>
+              @if (r.videoCodec) {
+                <span class="badge badge-sm badge-secondary">{{ r.videoCodec }}</span>
+              }
               <span class="badge badge-sm" [class]="r.languageAllowed ? 'badge-info' : 'badge-warning'">{{ r.languageName }}</span>
               @if (r.freeleech) {
                 <span class="badge badge-sm badge-success">FL</span>

--- a/client/src/app/features/media-detail/components/releases-table/releases-table.component.ts
+++ b/client/src/app/features/media-detail/components/releases-table/releases-table.component.ts
@@ -12,6 +12,7 @@ import {
   LucideCheck,
   LucideCircleAlert,
   LucideDownload,
+  LucidePackage,
 } from '@lucide/angular';
 import { MovieRelease } from '../../../../core/services/api/media.service';
 import { formatMediaDetailBytes } from '../../media-detail.utils';
@@ -19,7 +20,7 @@ import { formatReleaseRejection } from '../../media-detail-release.utils';
 
 @Component({
   selector: 'app-releases-table',
-  imports: [TranslateModule, LucideTriangleAlert, LucideCheck, LucideCircleAlert, LucideDownload],
+  imports: [TranslateModule, LucideTriangleAlert, LucideCheck, LucideCircleAlert, LucideDownload, LucidePackage],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './releases-table.component.html',
 })

--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -116,7 +116,7 @@
         @if (_link()) {
           <a [routerLink]="_link()" [state]="_navState()" class="absolute inset-0 z-0" [attr.aria-label]="_title()" (pointerdown)="flagPosterForTransition()" (keydown.enter)="flagPosterForTransition()" (click)="$event.stopPropagation()"></a>
         }
-        @if (_playable() || aspect() === 'landscape') {
+        @if (_playable()) {
           <button type="button" class="relative z-10 w-12 h-12 rounded-full bg-black/50 flex items-center justify-center text-white cursor-pointer" (click)="onPlayClick($event)">
             <svg lucidePlay class="h-6 w-6" [strokeWidth]="2"></svg>
           </button>

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -2,7 +2,7 @@
 <div class="lg:hidden tv:hidden">
   <app-mobile-fanart-hero [fanartUrl]="fanartUrl()" />
 
-  <div class="-mt-16 relative z-10">
+  <div class="-mt-16 relative z-20">
     <!-- Title -->
     <h1 class="text-3xl font-semibold tracking-tight leading-tight">
       @if (episodeLabel()) {
@@ -143,7 +143,7 @@
   }
 
   <div
-    class="flex gap-10 relative z-10 tv:pt-24!"
+    class="flex gap-10 relative z-20 tv:pt-24!"
     [style.padding-top]="!navbar.isHeroPage() || navbar.effectiveSidebarPinned() ? null : navbar.mobileNavbarVisible() ? 'calc(env(safe-area-inset-top, 0px) + 2rem)' : null"
   >
     <!-- Poster / Still (desktop only). Smaller poster on the lg-to-xl range


### PR DESCRIPTION
## Summary

Manual release-search modal: filtering, ranking, UI polish.

**Backend**
- Torznab XML decoder handles Latin-1 named entities + numeric refs (fixes garbled Pirate Bay titles)
- Episode/season searches: drop releases parsed to a different ep/season, cap at profile cutoff rank
- Episode search ranks single-episode > packs; season search ranks packs > singles
- Pack size scored against full season runtime
- `SIZE_NOT_PREFERRED` removed from rejections; replaced by `sizeDeviation` sort tiebreaker
- New `videoCodec` field (HEVC/AV1/VP9/x264) matching `H 264` / `H.264` / `H-264`
- New `isFullSeason` flag

**Frontend**
- Pack icon (lucide:package) before pack titles
- Codec badge (badge-secondary) next to quality
- Wider Seeds/Leech column, Release column claims remaining width
- Episode header dropdown shows Grab/Search release buttons (was hidden because `qualityProfileName` wasn't passed)
- Media-card play button hidden on landscape cards that aren't playable
- `media-info-header z-20` lifts dropdown above media-card badges

## Test plan

- [ ] Search a single episode → single-episode releases on top, packs below; nothing above profile cutoff
- [ ] Search a season → packs on top, singles below
- [ ] Pirate Bay results with HTML entities render correctly
- [ ] Codec badge visible on HEVC / x264 releases (including `H 264` form)
- [ ] Pack icon visible on full-season rows