### PR TITLE
fix(qbittorrent): decode HTML entities in torrent names

### DIFF
--- a/backend/src/common/utils/decode-html-entities.ts
+++ b/backend/src/common/utils/decode-html-entities.ts
@@ -1,0 +1,46 @@
+/**
+ * Decode the Latin-1 HTML4 named entities + numeric character refs
+ * that surface in release titles emitted by Cardigann-wrapped
+ * indexers (`Berl&iacute;n` → `Berlín`) and in `.torrent` `name`
+ * fields whose creator HTML-escaped diacritics before generating
+ * the metainfo. Restricted to the Western-European subset that
+ * actually shows up in real-world titles — adding hundreds of
+ * astral-plane entities would pull no extra coverage and bloat the
+ * lookup. Plain XML (`&amp;` etc.) is included so the helper is a
+ * drop-in replacement for the basic XML decoder.
+ */
+const HTML_NAMED_ENTITIES: Record<string, string> = {
+  amp: '&', lt: '<', gt: '>', apos: "'", quot: '"', nbsp: ' ',
+  iexcl: '¡', cent: '¢', pound: '£', yen: '¥', sect: '§',
+  copy: '©', reg: '®', deg: '°', plusmn: '±', sup2: '²', sup3: '³',
+  micro: 'µ', para: '¶', middot: '·', sup1: '¹', frac14: '¼', frac12: '½',
+  frac34: '¾', iquest: '¿', Agrave: 'À', Aacute: 'Á', Acirc: 'Â',
+  Atilde: 'Ã', Auml: 'Ä', Aring: 'Å', AElig: 'Æ', Ccedil: 'Ç',
+  Egrave: 'È', Eacute: 'É', Ecirc: 'Ê', Euml: 'Ë', Igrave: 'Ì',
+  Iacute: 'Í', Icirc: 'Î', Iuml: 'Ï', ETH: 'Ð', Ntilde: 'Ñ',
+  Ograve: 'Ò', Oacute: 'Ó', Ocirc: 'Ô', Otilde: 'Õ', Ouml: 'Ö',
+  Oslash: 'Ø', Ugrave: 'Ù', Uacute: 'Ú', Ucirc: 'Û', Uuml: 'Ü',
+  Yacute: 'Ý', THORN: 'Þ', szlig: 'ß', agrave: 'à', aacute: 'á',
+  acirc: 'â', atilde: 'ã', auml: 'ä', aring: 'å', aelig: 'æ',
+  ccedil: 'ç', egrave: 'è', eacute: 'é', ecirc: 'ê', euml: 'ë',
+  igrave: 'ì', iacute: 'í', icirc: 'î', iuml: 'ï', eth: 'ð',
+  ntilde: 'ñ', ograve: 'ò', oacute: 'ó', ocirc: 'ô', otilde: 'õ',
+  ouml: 'ö', oslash: 'ø', ugrave: 'ù', uacute: 'ú', ucirc: 'û',
+  uuml: 'ü', yacute: 'ý', thorn: 'þ', yuml: 'ÿ', OElig: 'Œ',
+  oelig: 'œ', Scaron: 'Š', scaron: 'š', Yuml: 'Ÿ', ldquo: '“',
+  rdquo: '”', lsquo: '‘', rsquo: '’', bdquo: '„', hellip: '…',
+  ndash: '–', mdash: '—', trade: '™', euro: '€',
+};
+
+export function decodeHtmlEntities(s: string): string {
+  return s.replace(/&(?:#(x?)([0-9a-fA-F]+)|([a-zA-Z]+));/g, (raw, hex, num, name) => {
+    if (num) {
+      const code = parseInt(num, hex === 'x' ? 16 : 10);
+      if (isFinite(code) && code > 0) {
+        try { return String.fromCodePoint(code); } catch { /* invalid code point */ }
+      }
+      return raw;
+    }
+    return HTML_NAMED_ENTITIES[name as string] ?? raw;
+  });
+}

--- a/backend/src/modules/download-clients/qbittorrent.service.ts
+++ b/backend/src/modules/download-clients/qbittorrent.service.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 import * as crypto from 'crypto';
 import FormData from 'form-data';
 import { DownloadClient } from './entities/download-client.entity';
+import { decodeHtmlEntities } from '../../common/utils/decode-html-entities';
 
 export interface QbittorrentTorrent {
   hash: string;
@@ -161,7 +162,13 @@ export class QbittorrentService {
         );
         return [];
       }
-      return res.data;
+      // Decode HTML entities baked into the `.torrent` `name` field by
+      // misbehaving indexers (`Berl&iacute;n` → `Berlín`). Anything
+      // downstream — history matching, activity UI, sourceTitle —
+      // gets the human-readable form.
+      return res.data.map((t) =>
+        t.name ? { ...t, name: decodeHtmlEntities(t.name) } : t,
+      );
     } catch (e) {
       this.log.warn(
         `getTorrents: error fetching torrents from "${client.name}": ${(e as Error).message}`,

--- a/backend/src/modules/indexers/torznab.service.ts
+++ b/backend/src/modules/indexers/torznab.service.ts
@@ -5,6 +5,7 @@ import axios, { AxiosError } from 'axios';
 import { Indexer } from './entities/indexer.entity';
 import { IndexerStat } from './entities/indexer-stat.entity';
 import { IndexerThrottle } from './indexer-throttle.service';
+import { decodeHtmlEntities } from '../../common/utils/decode-html-entities';
 
 export interface TorznabRelease {
   title: string;
@@ -19,45 +20,7 @@ export interface TorznabRelease {
   downloadVolumeFactor: number; // 0=free, 0.5=half, 1=normal
 }
 
-/** HTML4 Latin-1 named entities we expect from misbehaving Torznab
- *  back-ends (notably The Pirate Bay's Cardigann wrapper) that emit
- *  HTML-escaped titles instead of pure XML. Restricted to the
- *  Western-European subset that actually surfaces in release titles. */
-const HTML_NAMED_ENTITIES: Record<string, string> = {
-  amp: '&', lt: '<', gt: '>', apos: "'", quot: '"', nbsp: ' ',
-  iexcl: '¡', cent: '¢', pound: '£', yen: '¥', sect: '§',
-  copy: '©', reg: '®', deg: '°', plusmn: '±', sup2: '²', sup3: '³',
-  micro: 'µ', para: '¶', middot: '·', sup1: '¹', frac14: '¼', frac12: '½',
-  frac34: '¾', iquest: '¿', Agrave: 'À', Aacute: 'Á', Acirc: 'Â',
-  Atilde: 'Ã', Auml: 'Ä', Aring: 'Å', AElig: 'Æ', Ccedil: 'Ç',
-  Egrave: 'È', Eacute: 'É', Ecirc: 'Ê', Euml: 'Ë', Igrave: 'Ì',
-  Iacute: 'Í', Icirc: 'Î', Iuml: 'Ï', ETH: 'Ð', Ntilde: 'Ñ',
-  Ograve: 'Ò', Oacute: 'Ó', Ocirc: 'Ô', Otilde: 'Õ', Ouml: 'Ö',
-  Oslash: 'Ø', Ugrave: 'Ù', Uacute: 'Ú', Ucirc: 'Û', Uuml: 'Ü',
-  Yacute: 'Ý', THORN: 'Þ', szlig: 'ß', agrave: 'à', aacute: 'á',
-  acirc: 'â', atilde: 'ã', auml: 'ä', aring: 'å', aelig: 'æ',
-  ccedil: 'ç', egrave: 'è', eacute: 'é', ecirc: 'ê', euml: 'ë',
-  igrave: 'ì', iacute: 'í', icirc: 'î', iuml: 'ï', eth: 'ð',
-  ntilde: 'ñ', ograve: 'ò', oacute: 'ó', ocirc: 'ô', otilde: 'õ',
-  ouml: 'ö', oslash: 'ø', ugrave: 'ù', uacute: 'ú', ucirc: 'û',
-  uuml: 'ü', yacute: 'ý', thorn: 'þ', yuml: 'ÿ', OElig: 'Œ',
-  oelig: 'œ', Scaron: 'Š', scaron: 'š', Yuml: 'Ÿ', ldquo: '“',
-  rdquo: '”', lsquo: '‘', rsquo: '’', bdquo: '„', hellip: '…',
-  ndash: '–', mdash: '—', trade: '™', euro: '€',
-};
-
-function decodeXmlEntities(s: string): string {
-  return s.replace(/&(?:#(x?)([0-9a-fA-F]+)|([a-zA-Z]+));/g, (raw, hex, num, name) => {
-    if (num) {
-      const code = parseInt(num, hex === 'x' ? 16 : 10);
-      if (isFinite(code) && code > 0) {
-        try { return String.fromCodePoint(code); } catch { /* invalid code point */ }
-      }
-      return raw;
-    }
-    return HTML_NAMED_ENTITIES[name as string] ?? raw;
-  });
-}
+const decodeXmlEntities = decodeHtmlEntities;
 
 /**
  * Build a Torznab query string. Drops null/undefined params so optional


### PR DESCRIPTION
## Summary

Indexers sometimes ship `.torrent` files whose internal `name` field is HTML-escaped (`Berl&iacute;n` → `Berlín`); the activity page was rendering them verbatim. Extracts the Latin-1 + numeric-ref entity decoder into a shared util and applies it at the qBittorrent boundary, so queue activity, history matching, and `sourceTitle` linking all see the decoded form.

## Test plan

- [ ] Grab a release whose `.torrent` name contains HTML entities → activity row renders the diacritics correctly.
- [ ] Torznab path still decodes (no regression in release-search results).