### PR TITLE
fix(home): show play button on Continue Watching cards

### DIFF
--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -27,6 +27,7 @@
             [title]="item.mediaTitle"
             [subtitle]="item.episodeLabel ?? undefined"
             [progressPercent]="item.progressPercent"
+            [playable]="true"
             [link]="['/' + (item.mediaType === 'series' ? 'series' : 'movies'), '' + item.mediaId]"
             [subtitleLink]="item.episodeId ? ['/series', '' + item.mediaId, 'episode', '' + item.episodeId] : null"
             [dismissable]="true"


### PR DESCRIPTION
## Summary

Continue Watching cards don't pass \`[media]\` to \`app-media-card\` — they hydrate from \`PlaybackState\` rows that only carry strings (\`mediaTitle\`, \`fanartUrl\`, \`progressPercent\`, …), so \`_playable()\` fell back to \`!!media.files?.length\` and returned false. A \`PlaybackState\` row only exists because the user actually played the item, so playability is implicit — pass \`[playable]="true"\` explicitly.

## Test plan

- [ ] Home → Continue Watching row → hover a card → arrow renders.