### PR TITLE
ci(play-store): skip automatic review submission

### DIFF
--- a/.github/workflows/play-store-publish.yml
+++ b/.github/workflows/play-store-publish.yml
@@ -119,4 +119,11 @@ jobs:
           # `completed` so each upload rolls out automatically to the
           # selected track.
           status: draft
+          # While the app has never had a production release approved,
+          # the Edit API refuses to submit changes for automatic review
+          # ("Changes cannot be sent for review automatically…"). Skip
+          # the auto-submission; the changes still land as a draft and
+          # can be promoted from the Play Console UI. Remove (or flip
+          # to false) once the first production rollout is live.
+          changesNotSentForReview: true
           whatsNewDirectory: client/android/app/src/main/play/release-notes


### PR DESCRIPTION
## Summary

Play Store upload failed with \`Changes cannot be sent for review automatically\` because the Edit API refuses auto-submission while the app is still in draft. \`changesNotSentForReview: true\` on the upload action sets the query param; drafts land in the Play Console and get promoted manually until the first production rollout.

## Test plan

- [ ] Re-trigger the workflow → upload succeeds, draft appears in Play Console internal track.