### PR TITLE
fix(streaming): force-transcode MP3 audio when remuxing to fMP4 (v1.6.1)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "0.0.1",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "0.0.1",
+      "version": "1.6.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@capacitor/app": "^8.1.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "",
   "author": "",
   "private": true,

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -253,12 +253,22 @@ export class StreamBuilderService {
       !needsBurnIn &&
       !needsCrop;
     if (canCopyVideo) {
-      const canCopyAudio = directPlayResult.audioSupported;
+      // Some audio codecs the device profile claims to support are
+      // only playable in their NATIVE container (e.g. MP3 via
+      // `audio/mpeg`), not when wrapped inside fMP4 segments via MSE
+      // — Chrome refuses `audio/mp4; codecs="mp4a.6B"` on append.
+      // For DirectStream we always emit fMP4 / HLS, so audio codecs
+      // outside the fMP4-MSE-safe set get force-transcoded to AAC
+      // regardless of the profile match.
+      const fmp4CompatibleAudio = new Set(['aac', 'ac3', 'eac3', 'opus', 'flac']);
+      const canCopyAudio =
+        directPlayResult.audioSupported &&
+        fmp4CompatibleAudio.has(sourceAudioCodec.toLowerCase());
       const outputAudioCodec = canCopyAudio ? sourceAudioCodec : 'aac';
       if (!canCopyAudio && !reasons.some((r) => r.flag.startsWith('Audio'))) {
         reasons.push({
           flag: 'AudioCodecNotSupported',
-          message: `Codec "${sourceAudioCodec}" incompatible`,
+          message: `Audio codec "${sourceAudioCodec}" is not playable inside fMP4 segments`,
         });
       }
       if (
@@ -267,7 +277,7 @@ export class StreamBuilderService {
       ) {
         reasons.push({
           flag: 'ContainerNotSupported',
-          message: `Conteneur "${sourceContainer}" incompatible`,
+          message: `Container "${sourceContainer}" not supported`,
         });
       }
 
@@ -617,7 +627,7 @@ export class StreamBuilderService {
           videoConditionsMet = false;
           reasons.push({
             flag: 'VideoProfileNotSupported',
-            message: `Profil "${source.videoProfile}" incompatible`,
+            message: `Video profile "${source.videoProfile}" not supported`,
           });
         }
         if (
@@ -678,19 +688,19 @@ export class StreamBuilderService {
     if (!videoSupported) {
       reasons.push({
         flag: 'VideoCodecNotSupported',
-        message: `Codec "${source.videoCodec}" incompatible`,
+        message: `Codec "${source.videoCodec}" not supported`,
       });
     }
     if (!audioSupported) {
       reasons.push({
         flag: 'AudioCodecNotSupported',
-        message: `Codec "${source.audioCodec}" incompatible`,
+        message: `Codec "${source.audioCodec}" not supported`,
       });
     }
     if (!containerSupported) {
       reasons.push({
         flag: 'ContainerNotSupported',
-        message: `Conteneur "${source.container}" incompatible`,
+        message: `Conteneur "${source.container}" not supported`,
       });
     }
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "1.5.1",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "1.5.1",
+      "version": "1.6.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@angular/cdk": "^21.2.4",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "scripts": {


### PR DESCRIPTION
## Summary

\`MediaSource.appendBuffer\` rejects MP3 inside fMP4 (\`audio/mp4; codecs="mp4a.6B"\`); Shaka surfaces it as error 3014. The DirectStream path copied the source audio whenever the device profile listed \`mp3\`, but the profile probes \`audio/mpeg\` (raw MP3), which doesn't imply MP3-in-fMP4 works on MSE.

- New \`fmp4CompatibleAudio\` set (\`aac\` / \`ac3\` / \`eac3\` / \`opus\` / \`flac\`). Anything outside gets transcoded to AAC during remux.
- Backend rejection reason strings translated from French to English (client i18n owns user-facing copy).
- Version bump \`1.6.0\` → \`1.6.1\`.

## Test plan

- [ ] Play a file with MP3 audio (e.g. Big Buck Bunny \`bbb_sunflower\`) → no 3014, audio plays.
- [ ] Files with AAC / AC3 / EAC3 / Opus / FLAC audio still take the remux-only path (no needless transcoding).