### PR TITLE
fix(streaming): retryable transient errors for HLS live transcoding

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -44,6 +44,33 @@ async function bootstrap() {
   const expressApp = app.getHttpAdapter().getInstance();
   expressApp.set('trust proxy', true);
 
+  // CDNs (Cloudflare etc.) cache 4xx responses by default — disastrous
+  // for live transcoding where a transient 404 (segment requested
+  // before ffmpeg wrote it) gets pinned under the URL and every retry
+  // sees the same 404 even after the file exists. Intercept writeHead
+  // to force `Cache-Control: no-store` on every error response before
+  // it leaves the process. Successful responses keep whatever headers
+  // their controller set.
+  expressApp.use(
+    (
+      _req: import('express').Request,
+      res: import('express').Response,
+      next: import('express').NextFunction,
+    ) => {
+      const origWriteHead = res.writeHead.bind(res);
+      res.writeHead = function (statusCode: number, ...args: unknown[]) {
+        if (statusCode >= 400) {
+          res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
+        }
+        return (origWriteHead as (s: number, ...a: unknown[]) => typeof res)(
+          statusCode,
+          ...args,
+        );
+      } as typeof res.writeHead;
+      next();
+    },
+  );
+
   app.setGlobalPrefix('api');
   app.useGlobalPipes(
     new ValidationPipe({

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -98,6 +98,42 @@ export function pickAudioLayout(
   return 'var-stream-map';
 }
 
+/**
+ * Poll `filePath` until its size is non-zero or the timeout elapses.
+ * Returns `true` when the file became non-empty, `false` on timeout
+ * or missing path. Used to absorb the ~200-500 ms gap between
+ * ffmpeg's `creat()` (visible to the kernel) and its first
+ * moov-box write (visible to the player). Anything looking at the
+ * file in that window sees a 0-byte entry and would, without this
+ * helper, serve a corrupt 200 or a transient 404.
+ */
+async function awaitFileNonEmpty(
+  filePath: string,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const stat = fs.statSync(filePath);
+      if (stat.size > 0) return true;
+    } catch {
+      /* still creating */
+    }
+    await new Promise<void>((r) => setTimeout(r, 50));
+  }
+  return false;
+}
+
+/** Send a transient unavailability response. Players with sane HTTP
+ *  retry policies (Shaka, Media3's loader when given a backoff)
+ *  treat 503 as retryable, unlike 404 which Media3 marks as a
+ *  terminal failure. `Retry-After` is honoured by both stacks. */
+function sendTransientUnavailable(res: Response, retryAfterSec: number = 2): void {
+  res.setHeader('Retry-After', String(retryAfterSec));
+  res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
+  res.status(503).end();
+}
+
 /** Generate a VOD HLS playlist for a given duration and segment URL pattern.
  *  Uniform segment grid: each segment is SEG_DURATION seconds, seg-N covers
  *  `[N*SEG, (N+1)*SEG)`. The EXTINF values mirror what FFmpeg actually emits
@@ -1274,21 +1310,18 @@ export class StreamingController {
         );
         if (!initPath) continue;
         // 0-byte init.mp4: ffmpeg races between `creat()` and the first
-        // moov write (no temp_file rename for inits). Early sessions
-        // that get killed inside that window leave a present-but-empty
-        // file on disk — `getSegmentPath`'s `existsSync` returns true
-        // and we'd stream 0 bytes to the player. Skip empty inits and
-        // fall through to the next source (main session almost always
-        // has a complete one).
-        let stat;
-        try {
-          stat = fs.statSync(initPath);
-        } catch {
-          continue;
-        }
-        if (stat.size === 0) {
+        // moov write (no temp_file rename for inits). Poll the file
+        // until it has bytes — beats giving up immediately, which
+        // would surface as a terminal 404 on every player that
+        // doesn't retry HTTP errors (ExoPlayer's
+        // DefaultLoadErrorHandlingPolicy treats 404 as unrecoverable).
+        // 5s is well above ffmpeg's typical write-the-moov latency
+        // (~200-500 ms after spawn) and bounded so a permanently-
+        // broken session can't hang the request forever.
+        const ready = await awaitFileNonEmpty(initPath, 5000);
+        if (!ready) {
           this.log.warn(
-            `[init] 0-byte ${label} init.mp4 at ${initPath} — skipping`,
+            `[init] 0-byte ${label} init.mp4 at ${initPath} after 5s — skipping`,
           );
           continue;
         }
@@ -1319,7 +1352,7 @@ export class StreamingController {
         // session un-cacheable for the same reason.
         const segStat = fs.statSync(segPath);
         if (segStat.size === 0) {
-          res.status(404).end();
+          sendTransientUnavailable(res);
           return;
         }
         existing.lastAccess = Date.now();
@@ -1366,7 +1399,7 @@ export class StreamingController {
         if (segPath) {
           const earlyStat = fs.statSync(segPath);
           if (earlyStat.size === 0) {
-            res.status(404).end();
+            sendTransientUnavailable(res);
             return;
           }
           await this.serveCmafFile(res, segPath, segmentContentType(segment));
@@ -1411,6 +1444,16 @@ export class StreamingController {
       segName,
     );
     if (!segPath) {
+      // ffmpeg session is healthy (exitCode === null) → segment will
+      // arrive on the next tick; surface as transient so players retry.
+      // Hard 404 only when the session actually died.
+      if (session.process.exitCode === null) {
+        this.log.warn(
+          `Segment 503 (transient): ${segment} (quality=${quality}, mfid=${mediaFileId})`,
+        );
+        sendTransientUnavailable(res);
+        return;
+      }
       this.log.warn(
         `Segment 404: ${segment} (quality=${quality}, mfid=${mediaFileId}, exitCode=${session.process.exitCode})`,
       );
@@ -1420,7 +1463,7 @@ export class StreamingController {
 
     const finalStat = fs.statSync(segPath);
     if (finalStat.size === 0) {
-      res.status(404).end();
+      sendTransientUnavailable(res);
       return;
     }
     await this.serveCmafFile(res, segPath, segmentContentType(segment));

--- a/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
@@ -281,7 +281,8 @@ public class NativePlayerPlugin extends Plugin {
             // (`enableLazyLoadingWithSingleTrack` is package-private)
             // — not worth the semantic-cleanliness trade-off.
             DefaultMediaSourceFactory mediaSourceFactory =
-                    new DefaultMediaSourceFactory(dataSourceFactory);
+                    new DefaultMediaSourceFactory(dataSourceFactory)
+                            .setLoadErrorHandlingPolicy(new RetryHttp404LoadErrorPolicy());
             player = new ExoPlayer.Builder(getContext())
                     .setRenderersFactory(renderersFactory)
                     .setMediaSourceFactory(mediaSourceFactory)

--- a/client/android/app/src/main/java/media/fliks/app/RetryHttp404LoadErrorPolicy.java
+++ b/client/android/app/src/main/java/media/fliks/app/RetryHttp404LoadErrorPolicy.java
@@ -1,0 +1,61 @@
+package media.fliks.app;
+
+import androidx.annotation.OptIn;
+import androidx.media3.common.C;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.datasource.HttpDataSource;
+import androidx.media3.exoplayer.upstream.DefaultLoadErrorHandlingPolicy;
+import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy;
+
+/**
+ * Custom LoadErrorHandlingPolicy that retries transient HTTP error
+ * responses instead of treating them as terminal failures.
+ *
+ * Media3's default policy returns {@code C.TIME_UNSET} (= "give up")
+ * on 403 / 404 / 410 / 416 / 500 / 503 response codes — designed for
+ * static CDN-served content where these statuses are stable. Our
+ * streaming pipeline serves segments from a live ffmpeg transcode
+ * session, so a 404 in the first seconds after a quality switch is a
+ * transient race condition (segment file not yet written) — the very
+ * next request would succeed. The default policy fails the playback
+ * before ffmpeg gets a chance to catch up.
+ *
+ * Override the retry decision: for the response codes the default
+ * marks as terminal, return a backoff delay (1s, 2s, 4s, 8s, …)
+ * capped by {@link DefaultLoadErrorHandlingPolicy#DEFAULT_TRACK_BLACKLIST_MS}.
+ * Combined with a higher {@code minimumLoadableRetryCount}, the
+ * loader keeps probing for ~10s before surfacing the error — long
+ * enough to absorb the ffmpeg cold-start.
+ */
+@OptIn(markerClass = UnstableApi.class)
+public class RetryHttp404LoadErrorPolicy extends DefaultLoadErrorHandlingPolicy {
+
+    public RetryHttp404LoadErrorPolicy() {
+        // Lift the retry count from the default 3 — the policy below
+        // only matters if Media3 is willing to call us back this many
+        // times. 8 with exponential backoff gives roughly 15 s of
+        // tolerance before propagating the error.
+        super(/* minimumLoadableRetryCount= */ 8);
+    }
+
+    @Override
+    public long getRetryDelayMsFor(LoadErrorHandlingPolicy.LoadErrorInfo info) {
+        if (info.exception instanceof HttpDataSource.InvalidResponseCodeException) {
+            int code =
+                ((HttpDataSource.InvalidResponseCodeException) info.exception).responseCode;
+            if (code == 403
+                || code == 404
+                || code == 410
+                || code == 416
+                || code == 500
+                || code == 503) {
+                // Exponential backoff: 1s, 2s, 4s, 8s, …, capped at the
+                // policy's blacklist window so we don't keep retrying
+                // a permanently-dead URL forever.
+                long delay = 1000L * (1L << Math.min(info.errorCount - 1, 4));
+                return Math.min(delay, DEFAULT_TRACK_BLACKLIST_MS);
+            }
+        }
+        return super.getRetryDelayMsFor(info);
+    }
+}


### PR DESCRIPTION
## Summary

Live ffmpeg transcoding has narrow windows where a segment or init.mp4 is on disk but still being written. The previous behaviour treated these as terminal failures: the backend returned 404 (cached by Cloudflare, pinning the error), and Media3's default policy treats 404 as unrecoverable (no retry).

- **Backend**: 0-byte segments and segment-not-found-while-ffmpeg-alive now return **503 + Retry-After: 2** instead of 404. Init handler **polls a 0-byte init.mp4 for 5 s** rather than skipping it. All 4xx/5xx responses get **Cache-Control: no-store** so CDNs cannot cache a transient miss.
- **Android**: new \`RetryHttp404LoadErrorPolicy\` retries 403/404/410/416/500/503 with exponential backoff (1–16 s, 8 attempts ≈ 15 s tolerance). Wired into \`NativePlayerPlugin\`'s media-source factory.

## Test plan

- [ ] Movie play through Shaka — no regression on direct/remux/transcode
- [ ] Movie play on Android via ExoPlayer — quality switch mid-playback no longer kills the session
- [ ] Cold-start a 1080p quality, immediately seek — first-segment race absorbed
- [ ] Confirm Cloudflare no longer caches a transient 404 (curl response headers show \`no-store\`)