### PR TITLE
feat(media-detail): global page background + condensed season actions

### DIFF
--- a/client/src/app/core/services/background.service.ts
+++ b/client/src/app/core/services/background.service.ts
@@ -1,0 +1,26 @@
+import { Injectable, signal } from '@angular/core';
+
+/**
+ * Global page-background image. Pages opt in by calling
+ * `setBackground(url)`; the rendering layer (BackgroundComponent in
+ * the root layout) listens to {@link url} and crossfades whenever it
+ * changes. Pages that don't set a background see the default body
+ * colour — there is no implicit fallback.
+ *
+ * Use cases:
+ *  - media-detail: fanart of the current title
+ *  - home: rotating posters/fanart from the library
+ */
+@Injectable({ providedIn: 'root' })
+export class BackgroundService {
+  /** Current target URL. `null` means "fade out, no background". */
+  readonly url = signal<string | null>(null);
+
+  setBackground(url: string | null): void {
+    this.url.set(url);
+  }
+
+  clear(): void {
+    this.url.set(null);
+  }
+}

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -35,6 +35,57 @@
             <span class="flex-1">{{ 'media_detail.mark_season_watched' | translate }}</span>
           }
         </button>
+        @if (isSeasonTabVisible(selSeason) && !episodesHasFileOnly()) {
+          @if (canGrab() && m.qualityProfile) {
+            <button
+              type="button"
+              class="dropdown-item text-white"
+              [disabled]="seasonReleasesLoading() && seasonReleasesOpenId() === selSeason.id"
+              (click)="loadSeasonReleases.emit(selSeason)"
+            >
+              @if (seasonReleasesLoading() && seasonReleasesOpenId() === selSeason.id) {
+                <span class="loading loading-spinner loading-sm"></span>
+                <span class="flex-1"></span>
+              } @else {
+                <svg lucidePackage class="h-5 w-5 shrink-0 opacity-80"></svg>
+                <span class="flex-1">{{ 'media_detail.season_releases' | translate }}</span>
+              }
+            </button>
+            <button
+              type="button"
+              class="dropdown-item text-white"
+              [disabled]="seasonGrabBusy() !== null"
+              (click)="grabSeason.emit(selSeason)"
+            >
+              @if (seasonGrabBusy() !== null) {
+                <span class="loading loading-spinner loading-sm"></span>
+                <span class="flex-1"></span>
+              } @else {
+                <svg lucideDownload class="h-5 w-5 shrink-0 opacity-80"></svg>
+                <span class="flex-1">{{ 'media_detail.grab_season' | translate }}</span>
+              }
+            </button>
+          }
+          @if (isAdmin()) {
+            <button
+              type="button"
+              class="dropdown-item text-white"
+              [disabled]="seasonBusyId() === selSeason.id"
+              (click)="toggleSeasonMonitored.emit(selSeason)"
+            >
+              @if (seasonBusyId() === selSeason.id) {
+                <span class="loading loading-spinner loading-sm"></span>
+                <span class="flex-1"></span>
+              } @else if (selSeason.monitored) {
+                <svg lucideEyeOff class="h-5 w-5 shrink-0 opacity-80"></svg>
+                <span class="flex-1">{{ 'media_detail.unmonitor' | translate }}</span>
+              } @else {
+                <svg lucideEye class="h-5 w-5 shrink-0 opacity-80"></svg>
+                <span class="flex-1">{{ 'media_detail.monitor' | translate }}</span>
+              }
+            </button>
+          }
+        }
       }
     </app-dropdown-menu>
     <select
@@ -50,67 +101,11 @@
       }
     </select>
     @if (selSeason && isSeasonTabVisible(selSeason) && !episodesHasFileOnly()) {
-      <div class="w-4 shrink-0"></div>
       @if (!selSeason.monitored) {
         <span class="badge badge-ghost shrink-0">{{ 'media_detail.unmonitored' | translate }}</span>
       }
       @if (selSeason.preferredProvider) {
         <span class="badge badge-primary badge-sm shrink-0">{{ selSeason.preferredProvider | uppercase }}</span>
-      }
-      @if (canGrab()) {
-        <button
-          type="button"
-          class="btn btn-outline btn-primary shrink-0"
-          [disabled]="seasonReleasesLoading() && seasonReleasesOpenId() === selSeason.id"
-          (click)="loadSeasonReleases.emit(selSeason)"
-        >
-          @if (seasonReleasesLoading() && seasonReleasesOpenId() === selSeason.id) {
-            <span class="loading loading-spinner loading-xs"></span>
-          } @else {
-            {{ 'media_detail.season_releases' | translate }}
-          }
-        </button>
-        <button
-          type="button"
-          class="btn btn-primary shrink-0"
-          [disabled]="seasonGrabBusy() !== null"
-          (click)="grabSeason.emit(selSeason)"
-        >
-          @if (seasonGrabBusy() !== null) {
-            <span class="loading loading-spinner loading-xs"></span>
-          } @else {
-            {{ 'media_detail.grab_season' | translate }}
-          }
-        </button>
-      }
-      @if (isAdmin()) {
-        <button
-          type="button"
-          class="btn btn-ghost shrink-0"
-          [class.opacity-50]="seasonBusyId() === selSeason.id"
-          [disabled]="seasonBusyId() === selSeason.id"
-          (click)="toggleSeasonMonitored.emit(selSeason)"
-        >
-          @if (seasonBusyId() === selSeason.id) {
-            <span class="loading loading-spinner loading-xs"></span>
-          } @else if (selSeason.monitored) {
-            {{ 'media_detail.unmonitor' | translate }}
-          } @else {
-            {{ 'media_detail.monitor' | translate }}
-          }
-        </button>
-        <select
-          class="select select-bordered select-sm shrink-0"
-          [title]="'media_detail.provider_section_title' | translate"
-          [ngModel]="selSeason.preferredProvider ?? null"
-          (ngModelChange)="setSeasonProvider.emit({ season: selSeason, provider: $event })"
-        >
-          @for (opt of providerOptions; track opt.value) {
-            <option [ngValue]="opt.value">
-              {{ opt.labelKey ? (opt.labelKey | translate) : opt.label }}
-            </option>
-          }
-        </select>
       }
     }
   </div>

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -9,7 +9,15 @@ import {
 import { UpperCasePipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { LucideCheck, LucideEllipsisVertical, LucideX } from '@lucide/angular';
+import {
+  LucideCheck,
+  LucideDownload,
+  LucideEllipsisVertical,
+  LucideEye,
+  LucideEyeOff,
+  LucidePackage,
+  LucideX,
+} from '@lucide/angular';
 import { HorizontalScrollerComponent } from '../../../../shared/components/horizontal-scroller';
 import { MediaCardComponent } from '../../../../shared/components/media-card/media-card';
 import { DropdownMenuComponent } from '../../../../shared/components/dropdown-menu';
@@ -27,13 +35,12 @@ import {
   filterSeasonEpisodesOnDisk,
   seasonsVisibleWithDiskFilter,
 } from '../../media-detail.utils';
-import { METADATA_PROVIDER_OPTIONS_OVERRIDE } from '../../../../core/constants/metadata-providers';
 import { PlayableMediaService } from '../../../../core/services/playable-media.service';
 
 
 @Component({
   selector: 'app-media-detail-seasons',
-  imports: [TranslateModule, FormsModule, UpperCasePipe, HorizontalScrollerComponent, MediaCardComponent, DropdownMenuComponent, TvSelectDirective, TvRowDirective, LucideCheck, LucideEllipsisVertical, LucideX],
+  imports: [TranslateModule, FormsModule, UpperCasePipe, HorizontalScrollerComponent, MediaCardComponent, DropdownMenuComponent, TvSelectDirective, TvRowDirective, LucideCheck, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucidePackage, LucideX],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-seasons.component.html',
 })
@@ -71,13 +78,7 @@ export class MediaDetailSeasonsComponent {
   readonly toggleSeasonMonitored = output<Season>();
   readonly toggleSeasonWatched = output<{ season: Season; watched: boolean }>();
   readonly toggleEpisodeWatched = output<{ episode: Episode; watched: boolean }>();
-  readonly setSeasonProvider = output<{
-    season: Season;
-    provider: 'tmdb' | 'tvdb' | null;
-  }>();
   readonly seasonWatchedBusyId = input<number | null>(null);
-
-  readonly providerOptions = METADATA_PROVIDER_OPTIONS_OVERRIDE;
 
   /** Every episode with a file in the season is in the watched set. */
   seasonFullyWatched(season: Season | null): boolean {

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -204,7 +204,6 @@
             (toggleSeasonMonitored)="toggleSeasonMonitored($event)"
             (toggleSeasonWatched)="onToggleSeasonWatched(m.id, $event.season, $event.watched)"
             (toggleEpisodeWatched)="onToggleEpisodeWatched(m.id, $event.episode, $event.watched)"
-            (setSeasonProvider)="setSeasonProvider($event.season, $event.provider)"
           />
         }
 

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -29,6 +29,7 @@ import {
   Library,
 } from '../../core/services/api/libraries-api.service';
 import { NavbarService } from '../../core/services/navbar.service';
+import { BackgroundService } from '../../core/services/background.service';
 import { StreamingApiService, MediaResumeInfo } from '../../core/services/api/streaming-api.service';
 import { MarkersApiService } from '../../core/services/api/markers-api.service';
 import { MediaInfoHeaderComponent } from '../../shared/components/media-info-header/media-info-header';
@@ -100,6 +101,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   private readonly translate = inject(TranslateService);
   private readonly librariesApi = inject(LibrariesApiService);
   private readonly navbarService = inject(NavbarService);
+  private readonly backgroundService = inject(BackgroundService);
   private readonly confirmation = inject(ConfirmationService);
   private readonly toast = inject(ToastService);
   private readonly sse = inject(SseService);
@@ -129,6 +131,18 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     const paramId = idParam ? Number(idParam) : NaN;
     if (m.id !== paramId) return;
     this.applyEpisodeFocus(m, params.get('episodeId'));
+  });
+
+  /**
+   * Drive the global page background from the currently-focused media.
+   * In episode mode we prefer the episode still over the parent media's
+   * fanart — keeps the backdrop tied to what the viewer is looking at.
+   */
+  private readonly backgroundEffect = effect(() => {
+    const m = this.media();
+    const ep = this.focusedEpisode();
+    const url = ep?.stillUrl ?? m?.fanartUrl ?? null;
+    this.backgroundService.setBackground(url);
   });
 
   /** React to SSE rescan + metadata-refresh events for this media */
@@ -508,6 +522,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.navbarService.leaveHeroPage();
+    this.backgroundService.clear();
   }
 
   async ngOnInit() {
@@ -1072,35 +1087,6 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
         ),
       });
       this.syncActiveSeasonForSeriesFilter();
-    } finally {
-      this.seasonBusy.set(null);
-    }
-  }
-
-  async setSeasonProvider(
-    season: Season,
-    provider: 'tmdb' | 'tvdb' | null,
-  ): Promise<void> {
-    if (!this.isAdmin()) return;
-    if ((season.preferredProvider ?? null) === provider) return;
-    this.seasonBusy.set(season.id);
-    try {
-      const updated = await this.mediaService.updateSeason(season.id, {
-        preferredProvider: provider,
-      });
-      const m = this.media();
-      if (!m?.seasons) return;
-      this.media.set({
-        ...m,
-        seasons: m.seasons.map((s) =>
-          s.id === updated.id
-            ? { ...s, preferredProvider: updated.preferredProvider }
-            : s,
-        ),
-      });
-      this.toast.success(
-        this.translate.instant('media_detail.provider_saved'),
-      );
     } finally {
       this.seasonBusy.set(null);
     }

--- a/client/src/app/shared/components/background/background.html
+++ b/client/src/app/shared/components/background/background.html
@@ -1,0 +1,32 @@
+<!-- Hidden below the `lg` breakpoint so phones / tablet-portrait keep
+     the existing inline `mobile-fanart-hero` and don't show a second
+     image of the same fanart. -->
+<div class="fixed inset-0 -z-10 overflow-hidden pointer-events-none hidden lg:block">
+  @if (layerA()) {
+    <img
+      [src]="layerA()! | resolveUrl:'medium'"
+      alt=""
+      loading="eager"
+      decoding="async"
+      class="absolute inset-0 w-full h-full object-cover object-[50%_25%] transition-opacity duration-500"
+      [class.opacity-100]="activeLayer() === 'A' && imageVisible()"
+      [class.opacity-0]="activeLayer() !== 'A' || !imageVisible()"
+    />
+  }
+  @if (layerB()) {
+    <img
+      [src]="layerB()! | resolveUrl:'medium'"
+      alt=""
+      loading="eager"
+      decoding="async"
+      class="absolute inset-0 w-full h-full object-cover object-[50%_25%] transition-opacity duration-500"
+      [class.opacity-100]="activeLayer() === 'B' && imageVisible()"
+      [class.opacity-0]="activeLayer() !== 'B' || !imageVisible()"
+    />
+  }
+  <!-- Veil is permanent: when no background is set, the 90 % base-100
+       tint over the body's solid base-100 is a no-op (same colour);
+       when an image is fading in/out beneath it, the tint stays
+       constant so we never flash an un-tinted frame. -->
+  <div class="absolute inset-0 bg-base-100/90"></div>
+</div>

--- a/client/src/app/shared/components/background/background.ts
+++ b/client/src/app/shared/components/background/background.ts
@@ -1,0 +1,64 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  inject,
+  signal,
+} from '@angular/core';
+import { BackgroundService } from '../../../core/services/background.service';
+import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
+
+/**
+ * Page-wide background renderer. Mounted once at the layout root so
+ * the image covers everything — including under the sidebar — and
+ * survives route changes without remount.
+ *
+ * Crossfade strategy: two stacked layers ping-pong. Setting a new URL
+ * writes it into the currently-hidden layer, then flips which layer
+ * is "active". The CSS opacity transition does the visual swap, so
+ * neither image is destroyed mid-fade (which would flash).
+ */
+@Component({
+  selector: 'app-background',
+  imports: [ResolveUrlPipe],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './background.html',
+})
+export class BackgroundComponent {
+  private readonly bg = inject(BackgroundService);
+
+  readonly layerA = signal<string | null>(null);
+  readonly layerB = signal<string | null>(null);
+  readonly activeLayer = signal<'A' | 'B'>('A');
+  /** Tracks whether the active layer should currently be at full
+   *  opacity. The image is dimmed in CSS (filter: brightness),
+   *  so we no longer need a separate veil — fade-out can use the
+   *  image opacity directly without showing un-tinted colour. */
+  readonly imageVisible = signal(false);
+
+  constructor() {
+    let last: string | null = null;
+    effect(() => {
+      const next = this.bg.url();
+      if (next === last) return;
+      last = next;
+
+      if (next === null) {
+        this.imageVisible.set(false);
+        return;
+      }
+
+      this.imageVisible.set(true);
+      // Write into the currently-inactive layer, then flip active.
+      // Keeping the old layer's URL intact means it can fade out
+      // smoothly instead of vanishing the moment we swap.
+      if (this.activeLayer() === 'A') {
+        this.layerB.set(next);
+        this.activeLayer.set('B');
+      } else {
+        this.layerA.set(next);
+        this.activeLayer.set('A');
+      }
+    });
+  }
+}

--- a/client/src/app/shared/components/media-info-extra/media-info-extra.html
+++ b/client/src/app/shared/components/media-info-extra/media-info-extra.html
@@ -54,7 +54,7 @@
           <dt class="text-base-content/50 text-sm">{{ 'media_info.genres' | translate }}</dt>
           <dd class="font-medium text-base flex flex-wrap">
             @for (genre of genres(); track genre; let last = $last) {
-              <span class="whitespace-nowrap"><button type="button" class="hover:underline" (click)="navigateToGenre(genre)">{{ genre }}</button>@if (!last){<span>,&nbsp;</span>}</span>
+              <span><button type="button" class="hover:underline" (click)="navigateToGenre(genre)">{{ genre }}</button>@if (!last){<span>,&nbsp;</span>}</span>
             }
           </dd>
         </div>

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -129,11 +129,6 @@
 <!-- ===== DESKTOP layout ===== -->
 <div class="hidden lg:block tv:block relative">
   @if (fanartUrl()) {
-    <div class="absolute inset-0 -mx-6 -mt-6 overflow-hidden">
-      <img appImgFadeIn [src]="fanartUrl()! | resolveUrl:'medium'" alt="" loading="eager" fetchpriority="high" decoding="async" class="w-full h-full object-cover object-[50%_25%]" />
-      <div class="absolute inset-0 bg-base-100/80"></div>
-      <div class="absolute inset-0 bg-gradient-to-t from-base-100 via-base-100/30 to-base-100/50"></div>
-    </div>
     @if (!navbar.mobileNavbarVisible()) {
       <button type="button" (click)="goBack()" class="relative z-10 btn btn-ghost btn gap-1 mb-4 text-base-content/80 hover:text-base-content">
         <svg lucideChevronLeft class="h-4 w-4"></svg>

--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -1,3 +1,4 @@
+<app-background />
 <div class="drawer min-h-screen"
      [class.lg:drawer-open]="device.isDesktop() || (device.isTv() && navbar.effectiveSidebarPinned())"
      [class.md:drawer-open]="device.isTablet() && navbar.effectiveSidebarPinned()">
@@ -247,7 +248,11 @@
 
   <div class="drawer-side z-40" [class.hidden]="isNative && device.isPhone()">
     <label for="sidebar" [attr.aria-label]="'nav.close_menu' | translate" class="drawer-overlay"></label>
-    <aside class="bg-base-100 w-64 min-h-full flex flex-col" style="padding-top: calc(env(safe-area-inset-top, 0px) / 2 )">
+    <aside class="w-64 min-h-full flex flex-col"
+           [class.bg-base-100]="!background.url()"
+           [class.bg-base-100/40]="!!background.url()"
+           [class.backdrop-blur-sm]="!!background.url()"
+           style="padding-top: calc(env(safe-area-inset-top, 0px) / 2 )">
       <div class="p-4 border-b border-base-200 flex items-center gap-2">
         <a routerLink="/" class="flex items-center gap-2 pl-2 text-2xl font-bold flex-1 min-w-0">
           <img src="fliks-mark.png" alt="" class="h-8 w-8 shrink-0" />

--- a/client/src/app/shared/layout/layout.ts
+++ b/client/src/app/shared/layout/layout.ts
@@ -35,6 +35,8 @@ import { CardActionsPanelComponent } from '../components/card-actions-panel/card
 import { UserMenuComponent } from '../components/user-menu';
 import { LucideIconComponent } from '../components/lucide-icon';
 import { TvRowDirective } from '../directives/tv-row.directive';
+import { BackgroundComponent } from '../components/background/background';
+import { BackgroundService } from '../../core/services/background.service';
 import {
   LucideMenu,
   LucideChevronLeft,
@@ -63,6 +65,7 @@ import {
     UserMenuComponent,
     LucideIconComponent,
     TvRowDirective,
+    BackgroundComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './layout.html',
@@ -81,6 +84,7 @@ export class LayoutComponent implements OnInit, OnDestroy {
   readonly networkService = inject(NetworkService);
   readonly castService = inject(CastService);
   readonly navbar = inject(NavbarService);
+  readonly background = inject(BackgroundService);
   readonly tv = inject(TvService);
   readonly device = inject(DeviceService);
   readonly castPlayer = inject(CastPlayerService);


### PR DESCRIPTION
## Summary

- New \`BackgroundService\` + \`BackgroundComponent\` mounted at the layout root. Pages push a fanart URL via \`setBackground()\`; the component renders two ping-pong \`<img>\` layers with a 500 ms opacity crossfade and a permanent \`bg-base-100/90\` veil so the swap never flashes un-tinted. Hidden below \`lg\` — phones / portrait tablets keep the existing inline mobile fanart hero.
- Sidebar drops opaque \`bg-base-100\` when a background is active and uses \`bg-base-100/40\` + \`backdrop-blur-sm\` so the image shows through with a subtle frosted-glass tint.
- \`media-detail\` wires its fanart (or focused episode still) into the service and clears on destroy.
- Genre chips in \`media-info-extra\` lose \`whitespace-nowrap\` so long names don't overflow on narrow viewports.

## Season actions

- "Voir les packs", "Télécharger la saison" and monitor/unmonitor moved into the existing ellipsis dropdown to the left of the season selector. Release/grab entries additionally require a quality profile to be set on the media.
- Per-season TMDB/TVDB provider picker removed (UI + output + parent method). \`preferredProvider\` badge stays for display.

## Test plan

- [ ] Open a movie / series — fanart fades in once data is loaded; veil instantly in place during fade
- [ ] Switch between two media without intermediate route — image crossfades smoothly
- [ ] Resize below \`lg\` (or open on mobile) — global background hidden, inline mobile hero unchanged
- [ ] Sidebar shows blurred fanart behind it when a media is open; solid \`bg-base-100\` elsewhere
- [ ] Series page: ellipsis dropdown shows all season actions; provider picker is gone
- [ ] Series with no quality profile: pack/grab entries hidden, monitor entry still present for admins
- [ ] Genre list wraps on narrow viewport without horizontal scroll