### PR TITLE
feat(media): per-season posters + random fanart pool on detail/home

### DIFF
--- a/backend/src/migrations/1778800000000-add-season-poster-url.ts
+++ b/backend/src/migrations/1778800000000-add-season-poster-url.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSeasonPosterUrl1778800000000 implements MigrationInterface {
+  name = 'AddSeasonPosterUrl1778800000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "seasons"
+        ADD COLUMN IF NOT EXISTS "posterUrl" text
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "seasons"
+        DROP COLUMN IF EXISTS "posterUrl"
+    `);
+  }
+}

--- a/backend/src/migrations/1778900000000-add-media-additional-fanart-urls.ts
+++ b/backend/src/migrations/1778900000000-add-media-additional-fanart-urls.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMediaAdditionalFanartUrls1778900000000
+  implements MigrationInterface
+{
+  name = 'AddMediaAdditionalFanartUrls1778900000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "media"
+        ADD COLUMN IF NOT EXISTS "additionalFanartUrls" text[] NOT NULL DEFAULT '{}'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "media"
+        DROP COLUMN IF EXISTS "additionalFanartUrls"
+    `);
+  }
+}

--- a/backend/src/modules/images/image.controller.ts
+++ b/backend/src/modules/images/image.controller.ts
@@ -49,7 +49,7 @@ export class ImageController {
     sizeRaw: string | undefined,
     res: Response,
   ) {
-    const validTypes = ['media', 'person', 'episode'];
+    const validTypes = ['media', 'person', 'episode', 'season'];
     if (!validTypes.includes(type)) throw new NotFoundException();
 
     const size: ImageSize = (VALID_SIZES as string[]).includes(sizeRaw ?? '')

--- a/backend/src/modules/images/image.service.ts
+++ b/backend/src/modules/images/image.service.ts
@@ -3,8 +3,12 @@ import axios from 'axios';
 import * as fs from 'fs';
 import * as path from 'path';
 
-export type ImageType = 'media' | 'person' | 'episode';
-export type MediaImageVariant = 'poster' | 'fanart';
+export type ImageType = 'media' | 'person' | 'episode' | 'season';
+/** Variant of a media image. `fanart-${N}` (N≥1) addresses the extra
+ *  fanarts kept for randomised page backgrounds — they share `fanart`'s
+ *  size pipeline (thumb / medium / full) so frontends can request any
+ *  size without an extra round-trip to the source provider. */
+export type MediaImageVariant = 'poster' | 'fanart' | `fanart-${number}`;
 export type ImageSize = 'thumb' | 'medium' | 'full';
 
 /**
@@ -23,12 +27,18 @@ const TMDB_SIZE_MAP: Record<string, Partial<Record<ImageSize, string>>> = {
   'media/fanart': { thumb: 'w300', medium: 'w780', full: 'original' },
   person: { thumb: 'w45', full: 'original' },
   episode: { thumb: 'w300', full: 'original' },
+  season: { thumb: 'w185', medium: 'w500', full: 'original' },
 };
 
 const TMDB_HOST = /^https?:\/\/image\.tmdb\.org\//;
 
 function sizeMapKey(type: ImageType, variant?: MediaImageVariant): string {
-  if (type === 'media') return `media/${variant ?? 'poster'}`;
+  if (type === 'media') {
+    const v = variant ?? 'poster';
+    // Indexed fanarts share the parent `fanart` size pipeline.
+    const base = /^fanart-\d+$/.test(v) ? 'fanart' : v;
+    return `media/${base}`;
+  }
   return type;
 }
 
@@ -162,6 +172,8 @@ export class ImageService {
         return path.join(this.baseDir, 'persons', `${id}${suffix}.jpg`);
       case 'episode':
         return path.join(this.baseDir, 'episodes', `${id}${suffix}.jpg`);
+      case 'season':
+        return path.join(this.baseDir, 'seasons', `${id}${suffix}.jpg`);
     }
   }
 
@@ -177,6 +189,8 @@ export class ImageService {
         return `/api/images/person/${id}`;
       case 'episode':
         return `/api/images/episode/${id}`;
+      case 'season':
+        return `/api/images/season/${id}`;
     }
   }
 }

--- a/backend/src/modules/media/entities/media.entity.ts
+++ b/backend/src/modules/media/entities/media.entity.ts
@@ -123,6 +123,12 @@ export class Media extends BaseEntity {
   @Column({ nullable: true })
   fanartUrl: string;
 
+  /** Extra fanarts pulled from the provider (top N by score), stored
+   *  as local API paths (variants `fanart-1`, `fanart-2`, …). Mixed
+   *  with {@link fanartUrl} to randomise the page background. */
+  @Column({ type: 'text', array: true, default: () => "'{}'" })
+  additionalFanartUrls: string[];
+
   @Column({ type: 'float', nullable: true })
   rating: number;
 

--- a/backend/src/modules/media/entities/season.entity.ts
+++ b/backend/src/modules/media/entities/season.entity.ts
@@ -34,6 +34,12 @@ export class Season extends BaseEntity {
   @Column({ type: 'varchar', length: 16, nullable: true, default: null })
   preferredProvider: string | null;
 
+  /** Season-specific poster, populated from TMDB / TVDB during metadata
+   *  refresh. Falls back to {@link Media.posterUrl} on the UI when null
+   *  (e.g. provider returned no per-season artwork). */
+  @Column({ type: 'text', nullable: true })
+  posterUrl: string | null;
+
   @OneToMany(() => Episode, (episode) => episode.season, { cascade: true })
   episodes: Episode[];
 }

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -1232,7 +1232,7 @@ export class MediaService {
       });
       await this.downloadMediaImages(media.id, details);
       await this.persistMediaMetadata(media, details);
-      await this.refreshSeriesEpisodes(media);
+      await this.refreshSeriesEpisodes(media, { provider, externalId });
     }
 
     await this.updateSearchVector(media.id);
@@ -1292,9 +1292,17 @@ export class MediaService {
     return this.findOne(mediaId);
   }
 
-  private async refreshSeriesEpisodes(media: Media): Promise<void> {
+  private async refreshSeriesEpisodes(
+    media: Media,
+    preResolved?: { provider: IMetadataProvider; externalId: string },
+  ): Promise<void> {
     // 1. Media-level provider enumerates all seasons and provides defaults.
-    const mediaResolve = await this.resolveProviderForMedia(media);
+    //    `refreshMetadata` has already resolved the provider — accept it
+    //    so we don't re-emit the `resolveProvider:` log and skip the DB
+    //    lookup. Cron / non-refreshMetadata callers omit `preResolved`
+    //    and we resolve on their behalf.
+    const mediaResolve =
+      preResolved ?? (await this.resolveProviderForMedia(media));
     const mediaSeasons = await mediaResolve.provider.getTvShowSeasons(
       mediaResolve.externalId,
     );
@@ -1458,6 +1466,10 @@ export class MediaService {
         await this.downloadEpisodeStill(id, stillUrl);
       }
     });
+
+    if (sd.posterUrl) {
+      await this.downloadSeasonPoster(dbSeason.id, sd.posterUrl);
+    }
   }
 
   /**
@@ -1877,6 +1889,31 @@ export class MediaService {
       if (local) updates.fanartUrl = local;
     }
 
+    // Extra fanarts (variants fanart-1..N). Downloaded in parallel
+    // since each entry is an independent CDN GET. Slots are
+    // 1-indexed so the on-disk filename mirrors the variant string
+    // a frontend caller passes back (`/api/images/media/X/fanart-1`).
+    if (details.additionalFanartUrls?.length) {
+      const downloaded = await Promise.all(
+        details.additionalFanartUrls.map((url: string, i: number) =>
+          this.imageService.downloadAndStore(
+            url,
+            'media',
+            mediaId,
+            `fanart-${i + 1}`,
+          ),
+        ),
+      );
+      updates.additionalFanartUrls = downloaded.filter(
+        (p): p is string => !!p,
+      );
+    } else {
+      // Provider returned no extras → clear stale entries from a
+      // previous refresh that did. Keeps the column consistent
+      // with provider reality.
+      updates.additionalFanartUrls = [];
+    }
+
     if (Object.keys(updates).length > 0) {
       await this.mediaRepo.update(mediaId, updates);
     }
@@ -1914,6 +1951,26 @@ export class MediaService {
     );
     if (local) {
       await this.episodeRepo.update(episodeId, { stillUrl: local });
+    }
+  }
+
+  /**
+   * Download a season poster from TMDB / TVDB and persist the local
+   * API path on the Season row. Best-effort: a failed download leaves
+   * `posterUrl` null on the DB row and the UI falls back to the
+   * series poster.
+   */
+  private async downloadSeasonPoster(
+    seasonId: number,
+    posterUrl: string,
+  ): Promise<void> {
+    const local = await this.imageService.downloadAndStore(
+      posterUrl,
+      'season',
+      seasonId,
+    );
+    if (local) {
+      await this.seasonRepo.update(seasonId, { posterUrl: local });
     }
   }
 
@@ -2189,6 +2246,9 @@ export class MediaService {
             monitored: true,
           })),
         );
+      }
+      if (sd.posterUrl) {
+        await this.downloadSeasonPoster(sSaved.id, sd.posterUrl);
       }
     }
 

--- a/backend/src/modules/metadata-providers/interfaces/metadata-provider.interface.ts
+++ b/backend/src/modules/metadata-providers/interfaces/metadata-provider.interface.ts
@@ -17,6 +17,10 @@ export interface MetadataDetails extends MetadataSearchResult {
   imdbId: string | null;
   tvdbId: number | null;
   fanartUrl: string | null;
+  /** Extra fanarts (top-N) returned by the provider, used to
+   *  randomise the page background. Empty array when the provider
+   *  has no additional artwork. */
+  additionalFanartUrls: string[];
   runtime: number | null;
   releaseDate: string | null;
   inCinemas: string | null;
@@ -100,6 +104,9 @@ export interface SeasonDetails {
   episodeCount: number;
   overview: string | null;
   airDate: string | null;
+  /** Per-season poster URL (provider-hosted). May be null when the
+   *  provider has no artwork for this season. */
+  posterUrl: string | null;
   episodes: EpisodeDetails[];
 }
 

--- a/backend/src/modules/metadata-providers/providers/tmdb-api.types.ts
+++ b/backend/src/modules/metadata-providers/providers/tmdb-api.types.ts
@@ -87,6 +87,20 @@ export interface TmdbPaginated<T> {
   results: T[];
 }
 
+export interface TmdbImage {
+  file_path: string;
+  vote_average?: number;
+  iso_639_1?: string | null;
+  width?: number;
+  height?: number;
+}
+
+export interface TmdbImages {
+  backdrops?: TmdbImage[];
+  posters?: TmdbImage[];
+  logos?: TmdbImage[];
+}
+
 export interface TmdbReleaseDateCountry {
   iso_3166_1: string;
   release_dates: { type: number; release_date: string }[];
@@ -122,6 +136,7 @@ export interface TmdbMovieDetailsResponse {
   alternative_titles?: {
     titles?: { iso_3166_1?: string; title: string; type?: string }[];
   };
+  images?: TmdbImages;
 }
 
 export interface TmdbTvDetailsResponse {
@@ -150,6 +165,7 @@ export interface TmdbTvDetailsResponse {
   alternative_titles?: {
     results?: { iso_3166_1?: string; title: string; type?: string }[];
   };
+  images?: TmdbImages;
 }
 
 export interface TmdbTvSeasonStub {
@@ -174,5 +190,6 @@ export interface TmdbTvSeasonResponse {
   season_number: number;
   overview?: string | null;
   air_date?: string | null;
+  poster_path?: string | null;
   episodes?: TmdbTvEpisode[];
 }

--- a/backend/src/modules/metadata-providers/providers/tmdb.provider.ts
+++ b/backend/src/modules/metadata-providers/providers/tmdb.provider.ts
@@ -11,6 +11,7 @@ import {
   ExternalIdResult,
 } from '../interfaces/metadata-provider.interface';
 import type {
+  TmdbImages,
   TmdbMovieDetailsResponse,
   TmdbMovieListItem,
   TmdbPaginated,
@@ -25,6 +26,30 @@ import type {
 } from './tmdb-api.types';
 
 const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p';
+
+/** Cap on how many extra fanarts we keep per media. Each entry is
+ *  downloaded at thumb + medium + full → ~3× storage per item, so 5
+ *  stays under ~10 MB per series even with high-res sources. */
+const MAX_ADDITIONAL_FANARTS = 5;
+
+/**
+ * Pick the top `n` fanart URLs from a TMDB images response,
+ * skipping the one already used as the primary `fanartUrl` so the
+ * background rotation doesn't repeat it. Sorted by `vote_average`
+ * descending — TMDB's community-voted score is a decent proxy for
+ * "looks good as a backdrop".
+ */
+function pickAdditionalFanarts(
+  images: TmdbImages | undefined,
+  primaryPath: string | null | undefined,
+  n: number,
+): string[] {
+  const candidates = (images?.backdrops ?? [])
+    .filter((b) => b.file_path && b.file_path !== primaryPath)
+    .sort((a, b) => (b.vote_average ?? 0) - (a.vote_average ?? 0))
+    .slice(0, n);
+  return candidates.map((b) => `${TMDB_IMAGE_BASE}/original${b.file_path}`);
+}
 
 /**
  * Pull alternative_titles out of a TMDB movie / tv details response.
@@ -139,6 +164,11 @@ export class TmdbProvider implements IMetadataProvider {
       fanartUrl: data.backdrop_path
         ? `${TMDB_IMAGE_BASE}/original${data.backdrop_path}`
         : null,
+      additionalFanartUrls: pickAdditionalFanarts(
+        data.images,
+        data.backdrop_path,
+        MAX_ADDITIONAL_FANARTS,
+      ),
       rating: data.vote_average ?? 0,
       genres: data.genres?.map((g: TmdbNamed) => g.name) ?? [],
       mediaType: 'movie',
@@ -214,6 +244,11 @@ export class TmdbProvider implements IMetadataProvider {
       fanartUrl: data.backdrop_path
         ? `${TMDB_IMAGE_BASE}/original${data.backdrop_path}`
         : null,
+      additionalFanartUrls: pickAdditionalFanarts(
+        data.images,
+        data.backdrop_path,
+        MAX_ADDITIONAL_FANARTS,
+      ),
       rating: data.vote_average ?? 0,
       genres: data.genres?.map((g: TmdbNamed) => g.name) ?? [],
       mediaType: 'series',
@@ -300,6 +335,9 @@ export class TmdbProvider implements IMetadataProvider {
       episodeCount: season.episodes?.length ?? 0,
       overview: season.overview || null,
       airDate: season.air_date || null,
+      posterUrl: season.poster_path
+        ? `${TMDB_IMAGE_BASE}/w500${season.poster_path}`
+        : null,
       episodes: (season.episodes ?? []).map((e: TmdbTvEpisode) => ({
         episodeNumber: e.episode_number,
         title: e.name,
@@ -335,6 +373,9 @@ export class TmdbProvider implements IMetadataProvider {
           episodeCount: season.episodes?.length ?? 0,
           overview: season.overview || null,
           airDate: season.air_date || null,
+          posterUrl: season.poster_path
+            ? `${TMDB_IMAGE_BASE}/w500${season.poster_path}`
+            : null,
           episodes: (season.episodes ?? []).map((e: TmdbTvEpisode) => ({
             episodeNumber: e.episode_number,
             title: e.name,

--- a/backend/src/modules/metadata-providers/providers/tvdb.provider.ts
+++ b/backend/src/modules/metadata-providers/providers/tvdb.provider.ts
@@ -152,6 +152,12 @@ export class TvdbProvider implements IMetadataProvider {
       year: m.year ? parseInt(m.year) : null,
       posterUrl: this.pickArtwork(m.artworks, ART_POSTER) ?? m.image ?? null,
       fanartUrl: this.pickArtwork(m.artworks, ART_BACKGROUND) ?? null,
+      additionalFanartUrls: this.pickArtworks(
+        m.artworks,
+        ART_BACKGROUND,
+        5,
+        this.pickArtwork(m.artworks, ART_BACKGROUND),
+      ),
       rating: 0,
       genres: (m.genres ?? []).map((g) => g.name),
       mediaType: 'movie',
@@ -217,6 +223,12 @@ export class TvdbProvider implements IMetadataProvider {
       year: s.year ? parseInt(s.year) : null,
       posterUrl: this.pickArtwork(s.artworks, ART_POSTER) ?? s.image ?? null,
       fanartUrl: this.pickArtwork(s.artworks, ART_BACKGROUND) ?? null,
+      additionalFanartUrls: this.pickArtworks(
+        s.artworks,
+        ART_BACKGROUND,
+        5,
+        this.pickArtwork(s.artworks, ART_BACKGROUND),
+      ),
       rating: 0,
       genres: (s.genres ?? []).map((g) => g.name),
       mediaType: 'series',
@@ -324,6 +336,7 @@ export class TvdbProvider implements IMetadataProvider {
         episodeCount: eps.length,
         overview: null,
         airDate: seasonBase?.year ?? eps[0]?.aired ?? null,
+        posterUrl: seasonBase?.image || null,
         episodes: eps.map((ep) => {
           const tr = epTranslations.get(ep.id);
           return {
@@ -529,6 +542,23 @@ export class TvdbProvider implements IMetadataProvider {
         return (b.score ?? 0) - (a.score ?? 0);
       });
     return filtered[0]?.image ?? null;
+  }
+
+  /** Top-N artworks of a given type, skipping the one already
+   *  consumed as the primary (matched by URL). Sorted by score
+   *  descending — same ranking as {@link pickArtwork}. */
+  private pickArtworks(
+    artworks: TvdbArtwork[] | undefined,
+    type: number,
+    n: number,
+    skipUrl: string | null,
+  ): string[] {
+    if (!artworks) return [];
+    return artworks
+      .filter((a) => a.type === type && a.image && a.image !== skipUrl)
+      .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+      .slice(0, n)
+      .map((a) => a.image);
   }
 
   private extractRemoteId(

--- a/backend/src/modules/streaming/recommendation.service.ts
+++ b/backend/src/modules/streaming/recommendation.service.ts
@@ -63,6 +63,14 @@ export interface RecommendationItem {
     type: string;
     year: number;
     posterUrl: string | null;
+    /** Primary fanart for the recommended title. Exposed so the home
+     *  page can use the recommendations as a background image pool
+     *  without an extra round-trip per title. */
+    fanartUrl: string | null;
+    /** Extra fanarts (variants `fanart-1`..`fanart-N`). Same role as
+     *  on {@link Media}; concatenated with `fanartUrl` to build the
+     *  randomised background pool. */
+    additionalFanartUrls: string[];
     genres: string[];
     /** True when the title is actually playable: ≥1 downloaded file for
      *  movies, ≥1 downloaded episode for series. Drives the missing-
@@ -179,6 +187,8 @@ export class RecommendationService {
         'm.type',
         'm.year',
         'm.posterUrl',
+        'm.fanartUrl',
+        'm.additionalFanartUrls',
         'm.genres',
       ])
       .where('m.genres IS NOT NULL')
@@ -287,6 +297,8 @@ export class RecommendationService {
         type: s.media.type,
         year: s.media.year,
         posterUrl: s.media.posterUrl,
+        fanartUrl: s.media.fanartUrl ?? null,
+        additionalFanartUrls: s.media.additionalFanartUrls ?? [],
         genres: s.media.genres,
         available: availableIds.has(s.media.id),
       },

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -617,6 +617,7 @@
     "seasons_section": "Saisons & épisodes",
     "season": "Saison",
     "more_from_season": "Plus de saison {{season}}",
+    "other_seasons_of": "Autres saisons de {{title}}",
     "col_ep": "Ep.",
     "col_title": "Titre",
     "col_airdate": "Diffusion",

--- a/client/src/app/core/services/api/media.service.ts
+++ b/client/src/app/core/services/api/media.service.ts
@@ -67,6 +67,8 @@ export interface Season {
   seasonNumber: number;
   monitored: boolean;
   preferredProvider?: 'tmdb' | 'tvdb' | null;
+  /** Season-specific poster (TMDB/TVDB); null → fall back to series poster. */
+  posterUrl: string | null;
   episodes: Episode[];
 }
 
@@ -87,6 +89,9 @@ export interface Media {
   library?: { id: number; name: string } | null;
   posterUrl: string | null;
   fanartUrl: string | null;
+  /** Extra fanarts kept locally (variants `fanart-1`..`fanart-N`).
+   *  Mixed with {@link fanartUrl} for the randomised page background. */
+  additionalFanartUrls: string[];
   rating: number;
   genres?: string[];
   runtime: number;

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -127,6 +127,11 @@ export interface RecommendationItem {
     type: string;
     year: number;
     posterUrl: string | null;
+    /** Primary fanart, exposed so the home page can include
+     *  recommended titles in its background-image pool. */
+    fanartUrl: string | null;
+    /** Extra fanarts variants — same role as on {@link Media}. */
+    additionalFanartUrls: string[];
     genres: string[];
     /** False when the recommendation is requested-but-not-yet-downloaded
      *  (no files / no episodes on disk). Drives the missing-files cross

--- a/client/src/app/core/services/background.service.ts
+++ b/client/src/app/core/services/background.service.ts
@@ -2,25 +2,51 @@ import { Injectable, signal } from '@angular/core';
 
 /**
  * Global page-background image. Pages opt in by calling
- * `setBackground(url)`; the rendering layer (BackgroundComponent in
- * the root layout) listens to {@link url} and crossfades whenever it
- * changes. Pages that don't set a background see the default body
- * colour — there is no implicit fallback.
+ * `setBackground(url)` (single image) or `setBackgrounds(urls)`
+ * (one random pick from the list). The BackgroundComponent at the
+ * layout root listens to {@link url} and crossfades on change.
  *
- * Use cases:
- *  - media-detail: fanart of the current title
- *  - home: rotating posters/fanart from the library
+ * The pick from `setBackgrounds` is stable: as long as the same
+ * pool is passed back (e.g. when the media signal re-emits with
+ * equal data), the chosen URL stays put — no flashing on every
+ * change-detection cycle.
  */
 @Injectable({ providedIn: 'root' })
 export class BackgroundService {
   /** Current target URL. `null` means "fade out, no background". */
   readonly url = signal<string | null>(null);
 
+  /** Pool the current pick came from. Used to detect equivalent
+   *  calls so we don't re-randomise on every signal re-emit. */
+  private pool: string[] = [];
+
   setBackground(url: string | null): void {
+    this.pool = url ? [url] : [];
     this.url.set(url);
   }
 
+  /**
+   * Pick one image at random from `urls`. Re-calling with an
+   * identical pool is a no-op so the displayed image doesn't
+   * change while the user is on the page.
+   */
+  setBackgrounds(urls: string[]): void {
+    const next = urls.filter((u): u is string => !!u);
+    if (next.length === 0) {
+      this.clear();
+      return;
+    }
+    const samePool =
+      next.length === this.pool.length &&
+      next.every((u, i) => u === this.pool[i]);
+    if (samePool) return;
+
+    this.pool = next;
+    this.url.set(next[Math.floor(Math.random() * next.length)]);
+  }
+
   clear(): void {
+    this.pool = [];
     this.url.set(null);
   }
 }

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject, signal, OnInit, OnDestroy, Injector, afterNextRender } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, signal, effect, OnInit, OnDestroy, Injector, afterNextRender } from '@angular/core';
 import { ActivatedRoute, NavigationStart, Router, RouterLink } from '@angular/router';
 import { Subscription, filter } from 'rxjs';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
@@ -12,6 +12,7 @@ import { PlayableMediaService } from '../../core/services/playable-media.service
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
 import { FocusMemoryService } from '../../core/services/focus-memory.service';
 import { NavbarService } from '../../core/services/navbar.service';
+import { BackgroundService } from '../../core/services/background.service';
 import { TvService } from '../../core/services/tv.service';
 import { MediaCardComponent } from '../../shared/components/media-card/media-card';
 import { HorizontalScrollerComponent } from '../../shared/components/horizontal-scroller';
@@ -72,6 +73,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly scrollMemory = inject(ScrollMemoryService);
   private readonly focusMemory = inject(FocusMemoryService);
   private readonly navbar = inject(NavbarService);
+  private readonly backgroundService = inject(BackgroundService);
   private readonly tv = inject(TvService);
   private readonly injector = inject(Injector);
   private readonly route = inject(ActivatedRoute);
@@ -90,6 +92,21 @@ export class HomeComponent implements OnInit, OnDestroy {
   readonly recentMedia = signal<Media[]>([]);
   readonly comingSoon = signal<CalendarEntry[]>([]);
   readonly recommendations = signal<RecommendationItem[]>([]);
+
+  /** Once the recommendations land, randomise the page background
+   *  using their fanarts (primary + extras). One pick per visit;
+   *  the BackgroundService keeps it stable while the user stays on
+   *  the home — same contract as media-detail. */
+  private readonly recommendationsBackgroundEffect = effect(() => {
+    const recs = this.recommendations();
+    if (recs.length === 0) return;
+    const pool: string[] = [];
+    for (const r of recs) {
+      if (r.media.fanartUrl) pool.push(r.media.fanartUrl);
+      pool.push(...(r.media.additionalFanartUrls ?? []));
+    }
+    if (pool.length) this.backgroundService.setBackgrounds(pool);
+  });
   readonly onlyMyRequests = signal(
     localStorage.getItem('fliks.home.onlyMyRequests') === 'true',
   );
@@ -159,6 +176,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     this.navStartSub?.unsubscribe();
     this.attachedSub?.unsubscribe();
     this.detachedSub?.unsubscribe();
+    this.backgroundService.clear();
   }
 
   /**

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -135,6 +135,7 @@
             [status]="watchedEpisodeIds().has(ep.id) ? 'watched' : (!ep.hasFile ? 'missing' : null)"
             [progressPercent]="episodeProgress()[ep.id]"
             [link]="episodeRoute(ep)"
+            [replaceUrl]="hideControls()"
             [playable]="ep.hasFile"
             [interactiveWatched]="ep.hasFile"
             [dimmed]="!ep.monitored"

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -85,6 +85,23 @@
           />
         }
 
+        @if (otherSeasons().length) {
+          <div class="divider my-6"></div>
+          <app-horizontal-scroller [title]="'media_detail.other_seasons_of' | translate:{ title: m.title }">
+            @for (other of otherSeasons(); track other.id) {
+              <app-media-card
+                class="shrink-0 w-28 sm:w-36"
+                [aspect]="'portrait'"
+                [imageUrl]="other.posterUrl ?? m.posterUrl"
+                [title]="('media_detail.season' | translate) + ' ' + other.seasonNumber"
+                [subtitle]="other.episodes.length + ' ' + ('media_detail.episodes' | translate)"
+                [link]="seasonLink(m, other)"
+                [replaceUrl]="true"
+              />
+            }
+          </app-horizontal-scroller>
+        }
+
         @if (cast().length) {
           <div class="divider my-6"></div>
           <ng-container *ngTemplateOutlet="castCrewBlock" />

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -41,6 +41,7 @@ import { ReleasesModalComponent } from './components/releases-modal/releases-mod
 import { MediaDetailProfilesModalComponent } from './components/media-detail-profiles-modal/media-detail-profiles-modal.component';
 import { MediaDetailLibraryModalComponent } from './components/media-detail-library-modal/media-detail-library-modal.component';
 import { HorizontalScrollerComponent } from '../../shared/components/horizontal-scroller';
+import { MediaCardComponent } from '../../shared/components/media-card/media-card';
 import { DownloadQualityModalComponent } from '../../shared/components/download-quality-modal/download-quality-modal';
 import { DownloadManagerService } from '../../core/services/download-manager.service';
 import {
@@ -82,6 +83,7 @@ function readEpisodesHasFileOnlyFromStorage(): boolean {
     MediaDetailProfilesModalComponent,
     MediaDetailLibraryModalComponent,
     HorizontalScrollerComponent,
+    MediaCardComponent,
     DownloadQualityModalComponent,
     RouterLink,
     NgTemplateOutlet,
@@ -135,14 +137,27 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
 
   /**
    * Drive the global page background from the currently-focused media.
-   * In episode mode we prefer the episode still over the parent media's
-   * fanart — keeps the backdrop tied to what the viewer is looking at.
+   *
+   * We always pull from the *series / movie* fanart pool (never the
+   * episode still): TMDB stills cap at ~780×438 and look mushy when
+   * stretched fullscreen. The pool is `[fanartUrl,
+   * ...additionalFanartUrls]`; one entry is picked at random when the
+   * page loads and stays put — no auto-rotation.
    */
   private readonly backgroundEffect = effect(() => {
     const m = this.media();
-    const ep = this.focusedEpisode();
-    const url = ep?.stillUrl ?? m?.fanartUrl ?? null;
-    this.backgroundService.setBackground(url);
+    if (!m) {
+      this.backgroundService.clear();
+      return;
+    }
+    const pool = [m.fanartUrl, ...(m.additionalFanartUrls ?? [])].filter(
+      (u): u is string => !!u,
+    );
+    if (pool.length === 0) {
+      this.backgroundService.clear();
+      return;
+    }
+    this.backgroundService.setBackgrounds(pool);
   });
 
   /** React to SSE rescan + metadata-refresh events for this media */
@@ -314,6 +329,29 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     const s = this.focusedSeason();
     return hideShadowedEpisodes(s?.episodes ?? []);
   });
+
+  /**
+   * Sibling seasons rendered as cards under the "more from season N" row on
+   * the episode detail page. Hides the currently-focused season and any
+   * empty season (no episodes → no link target).
+   */
+  readonly otherSeasons = computed<Season[]>(() => {
+    const m = this.media();
+    const focused = this.focusedSeason();
+    if (!m?.seasons || !focused) return [];
+    return m.seasons
+      .filter((s) => s.id !== focused.id && (s.episodes?.length ?? 0) > 0)
+      .slice()
+      .sort((a, b) => a.seasonNumber - b.seasonNumber);
+  });
+
+  /** Route to the first episode of `season` so a click jumps the user
+   *  into that season's context without an intermediate landing page. */
+  seasonLink(m: Media, season: Season): string[] | null {
+    const first = season.episodes?.[0];
+    if (!first) return null;
+    return ['/series', String(m.id), 'episode', String(first.id)];
+  }
 
   /**
    * When the focused episode changes on the episode detail page, center the

--- a/client/src/app/shared/components/background/background.html
+++ b/client/src/app/shared/components/background/background.html
@@ -28,5 +28,5 @@
        tint over the body's solid base-100 is a no-op (same colour);
        when an image is fading in/out beneath it, the tint stays
        constant so we never flash an un-tinted frame. -->
-  <div class="absolute inset-0 bg-base-100/90"></div>
+  <div class="absolute inset-0 bg-base-100/95"></div>
 </div>

--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -114,7 +114,7 @@
     @if (showHoverOverlay()) {
       <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center pointer-events-none group-hover:pointer-events-auto">
         @if (_link()) {
-          <a [routerLink]="_link()" [state]="_navState()" class="absolute inset-0 z-0" [attr.aria-label]="_title()" (pointerdown)="flagPosterForTransition()" (keydown.enter)="flagPosterForTransition()" (click)="$event.stopPropagation()"></a>
+          <a [routerLink]="_link()" [state]="_navState()" [replaceUrl]="replaceUrl()" class="absolute inset-0 z-0" [attr.aria-label]="_title()" (pointerdown)="onAnchorPointerdown()" (keydown.enter)="onAnchorPointerdown()" (click)="$event.stopPropagation()"></a>
         }
         @if (_playable()) {
           <button type="button" class="relative z-10 w-12 h-12 rounded-full bg-black/50 flex items-center justify-center text-white cursor-pointer" (click)="onPlayClick($event)">
@@ -147,7 +147,7 @@
   <!-- Title below -->
   <div class="pt-1.5">
     @if (_link()) {
-      <a [routerLink]="_link()" [state]="_navState()" class="hover:underline" [attr.tabindex]="innerTabindex()" (pointerdown)="flagPosterForTransition()" (keydown.enter)="flagPosterForTransition()">
+      <a [routerLink]="_link()" [state]="_navState()" [replaceUrl]="replaceUrl()" class="hover:underline" [attr.tabindex]="innerTabindex()" (pointerdown)="onAnchorPointerdown()" (keydown.enter)="onAnchorPointerdown()">
         <h3 class="text-sm font-medium line-clamp-1 leading-snug">{{ _title() }}</h3>
       </a>
     } @else {

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -12,6 +12,7 @@ import { CardAction, CardActionsService } from '../../../core/services/card-acti
 import { TvService } from '../../../core/services/tv.service';
 import { DeviceService } from '../../../core/services/device.service';
 import { PlayableMediaService } from '../../../core/services/playable-media.service';
+import { NavbarService } from '../../../core/services/navbar.service';
 
 export type MediaCardAspect = 'portrait' | 'landscape';
 
@@ -40,6 +41,7 @@ export class MediaCardComponent {
   private readonly tv = inject(TvService);
   private readonly cardActionsService = inject(CardActionsService);
   private readonly playableMedia = inject(PlayableMediaService);
+  private readonly navbar = inject(NavbarService);
   protected readonly device = inject(DeviceService);
   protected readonly isNative = Capacitor.isNativePlatform();
   /** Hover overlay (play button) only makes sense on a real pointer device. */
@@ -75,6 +77,12 @@ export class MediaCardComponent {
   // Navigation (override media-derived link)
   readonly link = input<string[] | null>(null);
   readonly subtitleLink = input<string[] | null>(null);
+  /** When true, navigation triggered by the card replaces the
+   *  current history entry instead of pushing a new one. Useful for
+   *  "cards within the same media context" (sibling seasons, sibling
+   *  episodes…) so a single browser-back exits the media instead of
+   *  walking up the in-page chain. */
+  readonly replaceUrl = input(false);
   readonly playable = input(false);
 
   // Progress
@@ -206,6 +214,16 @@ export class MediaCardComponent {
    * same media appears in two cards (continue-watching + recently-added,
    * etc.).
    */
+  /** Pointerdown helper for the inline `[routerLink]` anchors: prepare
+   *  the view transition AND mark the next navigation as a back-pop
+   *  when `replaceUrl` is on, so NavbarService doesn't push the
+   *  replaced URL onto its history stack. Pointerdown fires before
+   *  click → before RouterLink kicks off `navigateByUrl`. */
+  protected onAnchorPointerdown() {
+    this.flagPosterForTransition();
+    if (this.replaceUrl()) this.navbar.markAsBackNavigation();
+  }
+
   protected flagPosterForTransition() {
     // Skip on engines without View Transitions API (Chromium <111,
     // Tizen 5.5 WebKit, webOS 5 Chromium 79). Angular's
@@ -253,7 +271,17 @@ export class MediaCardComponent {
     // parent's navigate kicked in.
     if (this.clickIntent() !== 'play') {
       const link = this._link();
-      if (link) void this.router.navigate(link, { state: this._navState() });
+      if (link) {
+        // Keep NavbarService's history stack in sync with the browser
+        // history: when we replace the URL, the page we're leaving
+        // must NOT be pushed onto the back stack — otherwise the
+        // in-app "Retour" walks the chain of replaced entries.
+        if (this.replaceUrl()) this.navbar.markAsBackNavigation();
+        void this.router.navigate(link, {
+          state: this._navState(),
+          replaceUrl: this.replaceUrl(),
+        });
+      }
     }
     this.clicked.emit();
   }
@@ -267,7 +295,11 @@ export class MediaCardComponent {
     const link = this._link();
     if (!link) return;
     this.flagPosterForTransition();
-    void this.router.navigate(link, { state: this._navState() });
+    if (this.replaceUrl()) this.navbar.markAsBackNavigation();
+    void this.router.navigate(link, {
+      state: this._navState(),
+      replaceUrl: this.replaceUrl(),
+    });
   }
 
   protected onWatchedClick(event: Event) {


### PR DESCRIPTION
## Summary

- **Per-season posters.** Seasons gain their own \`posterUrl\`, pulled from TMDB (\`season.poster_path\`) or TVDB (\`seasonBase.image\`) on metadata refresh. Stored locally under \`/api/images/season/<id>\`. Season cards fall back to the series poster when null.
- **Multiple fanarts per media.** \`Media.additionalFanartUrls\` keeps up to 5 extras (top by score / vote). Variant \`fanart-N\` shares fanart's size pipeline (thumb/medium/full).
- **Randomised page background.** \`BackgroundService.setBackgrounds(urls)\` picks one URL at random and keeps it stable while the user is on the page. \`media-detail\` pushes \`[fanartUrl, ...additionalFanartUrls]\`; \`home\` aggregates fanarts from recommendations. Episode mode no longer uses the low-res still as the fullscreen backdrop (kept inline on mobile via \`mobile-fanart-hero\`).
- **Replace-URL on sibling navigation.** New \`replaceUrl\` input on \`MediaCardComponent\` (propagated to every navigation path + \`NavbarService\`). Episode and sibling-season cards in episode-mode navigate with \`replaceUrl: true\`, so a single in-app "Retour" exits the media context instead of walking the chain of replaced entries.
- Veil over background tightened from \`bg-base-100/90\` → \`/95\` (image less visible behind content).
- Recommendation API was missing \`fanartUrl\` / \`additionalFanartUrls\` in its hand-picked queryBuilder \`select()\` — added.

## Migrations

- \`1778800000000-add-season-poster-url.ts\` — \`seasons.posterUrl text\`
- \`1778900000000-add-media-additional-fanart-urls.ts\` — \`media.additionalFanartUrls text[] DEFAULT '{}'\`

## Test plan

- [ ] Refresh metadata on a series with TVDB provider → all seasons get a poster (DB + \`/api/images/season/<id>\` reachable)
- [ ] Refresh metadata on a TMDB-backed series/movie → \`additionalFanartUrls\` populated with 5 entries (or fewer if TMDB has fewer)
- [ ] Open the same series twice → background reshuffles between visits, stays stable during the visit
- [ ] Open an episode → background uses the series fanart pool (no more soft 780p still)
- [ ] Episode A → click episode B in the sibling row → single "Retour" exits to the previous page (no walk through replaced entries)
- [ ] Sibling-seasons row → click any season → lands on its first episode, "Retour" still exits cleanly
- [ ] Home with recommendations populated → fanart visible behind the page on desktop, hidden on mobile
- [ ] Mobile views unchanged: inline \`mobile-fanart-hero\` still renders on media-detail