### PR TITLE
feat(search): refocus input + reopen keyboard on same-route nav click

### DIFF
--- a/client/src/app/core/services/search-state.service.ts
+++ b/client/src/app/core/services/search-state.service.ts
@@ -18,6 +18,15 @@ export class SearchStateService {
   readonly externalResults = signal<MetadataSearchResult[]>([]);
   readonly externalLoading = signal(false);
   readonly hasQuery = computed(() => this.query().trim().length > 0);
+  /** Counter incremented whenever a caller (e.g. the bottom-dock
+   *  search button) asks the search page to refocus its input.
+   *  Search page watches this in an effect — using a counter (not a
+   *  boolean) so back-to-back requests both fire. */
+  readonly focusRequestId = signal(0);
+
+  requestFocus(): void {
+    this.focusRequestId.update((n) => n + 1);
+  }
 
   /** External results filtered to exclude items already in local results */
   readonly filteredExternalResults = computed(() => {

--- a/client/src/app/features/search/search.ts
+++ b/client/src/app/features/search/search.ts
@@ -2,6 +2,7 @@ import {
   Component,
   ChangeDetectionStrategy,
   signal,
+  effect,
   inject,
   Injector,
   OnDestroy,
@@ -47,6 +48,23 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
   readonly state = inject(SearchStateService);
 
   readonly searchInput = viewChild<ElementRef<HTMLInputElement>>('searchInput');
+
+  /** Refocus the input whenever something external (e.g. the bottom-
+   *  dock search button on mobile re-tapping the same route) requests
+   *  it. Selecting the current text lets the user immediately
+   *  overwrite the existing query. */
+  private readonly externalFocusEffect = effect(() => {
+    const id = this.state.focusRequestId();
+    if (id === 0) return;
+    // Defer to the next tick so the effect runs even when the view
+    // hasn't fully reconciled yet (e.g. just navigated to /search).
+    setTimeout(() => {
+      const el = this.searchInput()?.nativeElement;
+      if (!el) return;
+      el.focus();
+      el.select();
+    }, 0);
+  });
 
   readonly requestedTmdbIds = signal<Map<number, FliksRequestStatus>>(new Map());
 

--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -174,7 +174,7 @@
       <a routerLink="/search"
          [routerLinkActive]="['dock-active', '!bg-primary', '!text-primary-content']"
          [routerLinkActiveOptions]="{ exact: false }"
-         (click)="resetNavHistory()"
+         (click)="onSearchNavClick()"
          class="fixed left-1/2 -translate-x-1/2 z-50 bg-white text-primary !rounded-full !p-0 shadow-lg flex items-center justify-center [&.dock-active]:before:hidden [&.dock-active]:after:hidden"
          style="bottom: calc(env(safe-area-inset-bottom, 0px) + 1rem); width: 56px; height: 56px;"
          [attr.aria-label]="'search.title' | translate">

--- a/client/src/app/shared/layout/layout.ts
+++ b/client/src/app/shared/layout/layout.ts
@@ -37,6 +37,7 @@ import { LucideIconComponent } from '../components/lucide-icon';
 import { TvRowDirective } from '../directives/tv-row.directive';
 import { BackgroundComponent } from '../components/background/background';
 import { BackgroundService } from '../../core/services/background.service';
+import { SearchStateService } from '../../core/services/search-state.service';
 import {
   LucideMenu,
   LucideChevronLeft,
@@ -85,6 +86,7 @@ export class LayoutComponent implements OnInit, OnDestroy {
   readonly castService = inject(CastService);
   readonly navbar = inject(NavbarService);
   readonly background = inject(BackgroundService);
+  private readonly searchState = inject(SearchStateService);
   readonly tv = inject(TvService);
   readonly device = inject(DeviceService);
   readonly castPlayer = inject(CastPlayerService);
@@ -273,6 +275,17 @@ export class LayoutComponent implements OnInit, OnDestroy {
 
   resetNavHistory() {
     this.navbar.resetNavHistory();
+  }
+
+  /** Bottom-dock search button: same-route click should re-focus the
+   *  input and re-open the soft keyboard. The default Router behaviour
+   *  no-ops on a same-URL navigation, so the click handler signals the
+   *  search page via {@link SearchStateService.requestFocus}. */
+  onSearchNavClick(): void {
+    this.resetNavHistory();
+    if (this.router.url.split('?')[0] === '/search') {
+      this.searchState.requestFocus();
+    }
   }
 
   toggleBottomMenu() {


### PR DESCRIPTION
## Summary

Tapping the bottom-dock search button on mobile while already on \`/search\` used to be a no-op (Angular skips same-URL navigations), leaving the soft keyboard closed. Now the same-route tap refocuses the input and reopens the keyboard.

- New \`requestFocus()\` + \`focusRequestId\` counter on \`SearchStateService\`.
- Layout's search FAB handler checks \`router.url\`; when it matches \`/search\`, it signals the search page instead of just calling \`resetNavHistory\`.
- \`SearchComponent\` watches the counter in an \`effect\` and refocuses + \`select()\`s the input on the next tick — selecting lets a follow-up keystroke overwrite the existing query.

Triggered inside the click user gesture so iOS / Android WebViews reopen the soft keyboard. Desktop unaffected (no FAB).

## Test plan

- [ ] Android phone: open Search, type something, navigate away (e.g. home), tap the search FAB → keyboard reopens, query is pre-selected
- [ ] iOS phone: same as above
- [ ] Already on Search with focus elsewhere → FAB tap re-focuses the input
- [ ] Desktop: drawer "search" entry behaviour unchanged