### PR TITLE
fix(admin-streams): pass episodeId when reading playback state

### DIFF
--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -368,7 +368,15 @@ export class SystemController {
       let episodeId: number | null = null;
       if (s.userId && mf?.mediaId) {
         try {
-          const ps = await this.playbackService.getState(s.userId, mf.mediaId);
+          // `playback_states` is keyed by (user, media, episode?). Series
+          // episodes carry an episodeId — the media-file row tells us
+          // which one — so we pass it through, otherwise the lookup
+          // hits the IS NULL branch (movies) and returns nothing.
+          const ps = await this.playbackService.getState(
+            s.userId,
+            mf.mediaId,
+            mf.episodeId ?? undefined,
+          );
           if (ps) {
             positionSeconds = ps.positionSeconds;
             if (ps.durationSeconds > 0) durationSeconds = ps.durationSeconds;


### PR DESCRIPTION
## Summary

\`playback_states\` is keyed by \`(userId, mediaId, episodeId?)\`. The admin streams dashboard called \`playbackService.getState(userId, mediaId)\` without an \`episodeId\` — TypeORM resolved that to a \`WHERE episode IS NULL\` clause, which only matches movie rows. For series episodes the lookup returned null and the dashboard displayed \`0:00 / duration\` even while the player was actively saving positions.

Pull \`episodeId\` from the active stream's media file (\`mf.episodeId\`) and pass it through. Movies still work — \`mf.episodeId\` is null there and we forward \`undefined\`, preserving the IS NULL branch.

## Test plan

- [ ] Watch a series episode → admin streams dashboard shows the live position (ticks every ~10 s as the player saves)
- [ ] Watch a movie → still works (position visible, no regression)