### PR TITLE
feat(admin): setup checklist widget (home + general settings)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -24,6 +24,7 @@ import { MarkersModule } from './modules/markers/markers.module';
 import { PersonsModule } from './modules/persons/persons.module';
 import { ImageModule } from './modules/images/image.module';
 import { ImportsModule } from './modules/imports/imports.module';
+import { SetupChecklistModule } from './modules/setup-checklist/setup-checklist.module';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
 
@@ -93,6 +94,7 @@ import { join } from 'path';
     ImageModule,
     MarkersModule,
     ImportsModule,
+    SetupChecklistModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/modules/setup-checklist/setup-checklist.controller.ts
+++ b/backend/src/modules/setup-checklist/setup-checklist.controller.ts
@@ -1,0 +1,62 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Param,
+  UseGuards,
+  BadRequestException,
+} from '@nestjs/common';
+import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
+import { PoliciesGuard } from '../auth/casl/policies.guard';
+import { CheckPolicies } from '../auth/casl/check-policies.decorator';
+import { Action } from '../auth/casl/actions.enum';
+import {
+  ChecklistItemKey,
+  SetupChecklistService,
+} from './setup-checklist.service';
+
+const KNOWN_KEYS: ChecklistItemKey[] = [
+  'library',
+  'quality-profile',
+  'language-profile',
+  'download-client',
+  'indexer',
+  'subtitle-provider',
+  'notification',
+  'non-admin-user',
+  'auto-approval-rule',
+];
+
+function parseKey(raw: string): ChecklistItemKey {
+  if (!(KNOWN_KEYS as string[]).includes(raw)) {
+    throw new BadRequestException(`Unknown checklist key: ${raw}`);
+  }
+  return raw as ChecklistItemKey;
+}
+
+@Controller('setup-checklist')
+@UseGuards(JwtOrApiKeyGuard, PoliciesGuard)
+export class SetupChecklistController {
+  constructor(private readonly service: SetupChecklistService) {}
+
+  @Get()
+  @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
+  list() {
+    return this.service.getStatus();
+  }
+
+  @Post(':key/dismiss')
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
+  async dismiss(@Param('key') key: string) {
+    await this.service.dismiss(parseKey(key));
+    return { ok: true };
+  }
+
+  @Delete(':key/dismiss')
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
+  async undismiss(@Param('key') key: string) {
+    await this.service.undismiss(parseKey(key));
+    return { ok: true };
+  }
+}

--- a/backend/src/modules/setup-checklist/setup-checklist.module.ts
+++ b/backend/src/modules/setup-checklist/setup-checklist.module.ts
@@ -1,0 +1,36 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Library } from '../libraries/entities/library.entity';
+import { QualityProfile } from '../profiles/entities/quality-profile.entity';
+import { LanguageProfile } from '../profiles/entities/language-profile.entity';
+import { DownloadClient } from '../download-clients/entities/download-client.entity';
+import { Indexer } from '../indexers/entities/indexer.entity';
+import { SubtitleProvider } from '../subtitles/entities/subtitle-provider.entity';
+import { NotificationConnection } from '../notifications/entities/notification-connection.entity';
+import { User } from '../users/entities/user.entity';
+import { AutoApprovalRule } from '../requests/entities/auto-approval-rule.entity';
+import { AuthModule } from '../auth/auth.module';
+import { SettingsModule } from '../settings/settings.module';
+import { SetupChecklistService } from './setup-checklist.service';
+import { SetupChecklistController } from './setup-checklist.controller';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      Library,
+      QualityProfile,
+      LanguageProfile,
+      DownloadClient,
+      Indexer,
+      SubtitleProvider,
+      NotificationConnection,
+      User,
+      AutoApprovalRule,
+    ]),
+    forwardRef(() => AuthModule),
+    SettingsModule,
+  ],
+  controllers: [SetupChecklistController],
+  providers: [SetupChecklistService],
+})
+export class SetupChecklistModule {}

--- a/backend/src/modules/setup-checklist/setup-checklist.service.ts
+++ b/backend/src/modules/setup-checklist/setup-checklist.service.ts
@@ -1,0 +1,210 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Not } from 'typeorm';
+import { Library } from '../libraries/entities/library.entity';
+import { QualityProfile } from '../profiles/entities/quality-profile.entity';
+import { LanguageProfile } from '../profiles/entities/language-profile.entity';
+import { DownloadClient } from '../download-clients/entities/download-client.entity';
+import { Indexer } from '../indexers/entities/indexer.entity';
+import { SubtitleProvider } from '../subtitles/entities/subtitle-provider.entity';
+import { NotificationConnection } from '../notifications/entities/notification-connection.entity';
+import { User } from '../users/entities/user.entity';
+import { AutoApprovalRule } from '../requests/entities/auto-approval-rule.entity';
+import { SettingsService } from '../settings/settings.service';
+
+/** Storage key in `app_settings` for the JSON array of dismissed
+ *  checklist item keys. Global (not per-user) — Fliks installs
+ *  typically have a single admin, so a dismiss-once UX is acceptable
+ *  and avoids a join table. */
+const DISMISSED_SETTING_KEY = 'setup_checklist_dismissed_keys';
+
+export type ChecklistItemSeverity = 'required' | 'recommended';
+
+export type ChecklistItemKey =
+  | 'library'
+  | 'quality-profile'
+  | 'language-profile'
+  | 'download-client'
+  | 'indexer'
+  | 'subtitle-provider'
+  | 'notification'
+  | 'non-admin-user'
+  | 'auto-approval-rule';
+
+interface ChecklistItemDef {
+  key: ChecklistItemKey;
+  severity: ChecklistItemSeverity;
+  /** Frontend route segments to navigate to when the user clicks
+   *  "Configurer". Kept on the backend so adding a new item only
+   *  touches one place. */
+  route: string[];
+  check: () => Promise<boolean>;
+}
+
+export interface ChecklistItemStatus {
+  key: ChecklistItemKey;
+  severity: ChecklistItemSeverity;
+  /** True when the underlying condition is satisfied. */
+  done: boolean;
+  /** True when an admin has explicitly dismissed this item. */
+  dismissed: boolean;
+  route: string[];
+}
+
+@Injectable()
+export class SetupChecklistService {
+  private readonly log = new Logger(SetupChecklistService.name);
+
+  constructor(
+    @InjectRepository(Library)
+    private readonly libraryRepo: Repository<Library>,
+    @InjectRepository(QualityProfile)
+    private readonly qualityProfileRepo: Repository<QualityProfile>,
+    @InjectRepository(LanguageProfile)
+    private readonly languageProfileRepo: Repository<LanguageProfile>,
+    @InjectRepository(DownloadClient)
+    private readonly downloadClientRepo: Repository<DownloadClient>,
+    @InjectRepository(Indexer)
+    private readonly indexerRepo: Repository<Indexer>,
+    @InjectRepository(SubtitleProvider)
+    private readonly subtitleProviderRepo: Repository<SubtitleProvider>,
+    @InjectRepository(NotificationConnection)
+    private readonly notificationConnectionRepo: Repository<NotificationConnection>,
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+    @InjectRepository(AutoApprovalRule)
+    private readonly autoApprovalRuleRepo: Repository<AutoApprovalRule>,
+    private readonly settings: SettingsService,
+  ) {}
+
+  /** Single source of truth for checklist items. Adding a new item:
+   *  push an entry here, add an i18n key on the frontend, done. */
+  private readonly items: ChecklistItemDef[] = [
+    {
+      key: 'library',
+      severity: 'required',
+      route: ['/admin', 'settings', 'libraries'],
+      check: async () => (await this.libraryRepo.count()) > 0,
+    },
+    {
+      key: 'quality-profile',
+      severity: 'required',
+      route: ['/admin', 'settings', 'quality-profiles'],
+      check: async () => (await this.qualityProfileRepo.count()) > 0,
+    },
+    {
+      key: 'language-profile',
+      severity: 'required',
+      route: ['/admin', 'settings', 'language-profiles'],
+      check: async () => (await this.languageProfileRepo.count()) > 0,
+    },
+    {
+      key: 'download-client',
+      severity: 'required',
+      route: ['/admin', 'settings', 'download-clients'],
+      check: async () =>
+        (await this.downloadClientRepo.count({ where: { enabled: true } })) > 0,
+    },
+    {
+      key: 'indexer',
+      severity: 'required',
+      route: ['/admin', 'settings', 'indexers'],
+      check: async () =>
+        (await this.indexerRepo.count({ where: { enabled: true } })) > 0,
+    },
+    {
+      key: 'subtitle-provider',
+      severity: 'recommended',
+      route: ['/admin', 'settings', 'subtitle-providers'],
+      check: async () =>
+        (await this.subtitleProviderRepo.count({ where: { enabled: true } })) >
+        0,
+    },
+    {
+      key: 'notification',
+      severity: 'recommended',
+      route: ['/admin', 'settings', 'notifications'],
+      check: async () => (await this.notificationConnectionRepo.count()) > 0,
+    },
+    {
+      key: 'non-admin-user',
+      severity: 'recommended',
+      route: ['/admin', 'settings', 'users'],
+      check: async () =>
+        (await this.userRepo.count({ where: { isAdmin: Not(true) } })) > 0,
+    },
+    {
+      key: 'auto-approval-rule',
+      severity: 'recommended',
+      route: ['/admin', 'settings', 'auto-approval'],
+      check: async () => (await this.autoApprovalRuleRepo.count()) > 0,
+    },
+  ];
+
+  async getStatus(): Promise<ChecklistItemStatus[]> {
+    const dismissed = await this.getDismissedKeys();
+    // Run every check in parallel — each one is a single `count()` so
+    // hitting them sequentially would needlessly add 9× the round-trip.
+    const dones = await Promise.all(
+      this.items.map(async (item) => {
+        try {
+          return await item.check();
+        } catch (err) {
+          this.log.warn(
+            `Checklist item "${item.key}" check failed: ${
+              err instanceof Error ? err.message : 'unknown error'
+            }`,
+          );
+          return false;
+        }
+      }),
+    );
+    return this.items.map((item, i) => ({
+      key: item.key,
+      severity: item.severity,
+      done: dones[i],
+      dismissed: dismissed.has(item.key),
+      route: item.route,
+    }));
+  }
+
+  async dismiss(key: ChecklistItemKey): Promise<void> {
+    if (!this.isKnownKey(key)) return;
+    const dismissed = await this.getDismissedKeys();
+    if (dismissed.has(key)) return;
+    dismissed.add(key);
+    await this.saveDismissedKeys(dismissed);
+  }
+
+  async undismiss(key: ChecklistItemKey): Promise<void> {
+    const dismissed = await this.getDismissedKeys();
+    if (!dismissed.delete(key)) return;
+    await this.saveDismissedKeys(dismissed);
+  }
+
+  private async getDismissedKeys(): Promise<Set<ChecklistItemKey>> {
+    const raw = await this.settings.get(DISMISSED_SETTING_KEY);
+    if (!raw) return new Set();
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (!Array.isArray(parsed)) return new Set();
+      return new Set(
+        parsed.filter((k): k is ChecklistItemKey =>
+          this.isKnownKey(k as string),
+        ),
+      );
+    } catch {
+      return new Set();
+    }
+  }
+
+  private async saveDismissedKeys(
+    dismissed: Set<ChecklistItemKey>,
+  ): Promise<void> {
+    await this.settings.set(DISMISSED_SETTING_KEY, JSON.stringify([...dismissed]));
+  }
+
+  private isKnownKey(key: string): key is ChecklistItemKey {
+    return this.items.some((i) => i.key === key);
+  }
+}

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -919,6 +919,53 @@
     "confirm_delete": "Supprimer ce téléchargement ? Le fichier sera supprimé de cet appareil.",
     "retry": "Réessayer"
   },
+  "setup_checklist": {
+    "title": "Configuration",
+    "configure": "Configurer",
+    "dismiss": "Masquer",
+    "undismiss": "Réactiver",
+    "status_done": "Configuré",
+    "status_required": "Requis",
+    "status_recommended": "Recommandé",
+    "items": {
+      "library": {
+        "label": "Ajouter au moins une bibliothèque",
+        "hint": "Indiquez le chemin d'au moins un dossier de films ou de séries pour qu'ils apparaissent dans Fliks."
+      },
+      "quality-profile": {
+        "label": "Créer un profil de qualité",
+        "hint": "Définit les qualités acceptées et préférées (1080p, 4K, ...) lors du téléchargement."
+      },
+      "language-profile": {
+        "label": "Créer un profil de langue",
+        "hint": "Détermine les langues audio et de sous-titres préférées pour les releases téléchargées."
+      },
+      "download-client": {
+        "label": "Connecter un client de téléchargement",
+        "hint": "qBittorrent, Transmission… au moins un client actif est nécessaire pour télécharger."
+      },
+      "indexer": {
+        "label": "Ajouter un indexeur",
+        "hint": "Au moins un indexeur Torznab actif est nécessaire pour chercher des releases."
+      },
+      "subtitle-provider": {
+        "label": "Activer un fournisseur de sous-titres",
+        "hint": "Active la recherche automatique de sous-titres (OpenSubtitles, Subdl…)."
+      },
+      "notification": {
+        "label": "Configurer les notifications",
+        "hint": "Recevez les évènements (téléchargements, erreurs…) sur Discord, Telegram ou autre."
+      },
+      "non-admin-user": {
+        "label": "Créer un utilisateur non-administrateur",
+        "hint": "Donnez accès à Fliks à vos proches sans leur accorder les droits admin."
+      },
+      "auto-approval-rule": {
+        "label": "Configurer une règle d'approbation automatique",
+        "hint": "Les demandes correspondant à la règle sont approuvées sans intervention manuelle."
+      }
+    }
+  },
   "settings": {
     "nav": {
       "general": "Général",

--- a/client/src/app/core/services/api/setup-checklist-api.service.ts
+++ b/client/src/app/core/services/api/setup-checklist-api.service.ts
@@ -1,0 +1,69 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject, signal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+
+export type ChecklistItemSeverity = 'required' | 'recommended';
+
+export type ChecklistItemKey =
+  | 'library'
+  | 'quality-profile'
+  | 'language-profile'
+  | 'download-client'
+  | 'indexer'
+  | 'subtitle-provider'
+  | 'notification'
+  | 'non-admin-user'
+  | 'auto-approval-rule';
+
+export interface ChecklistItem {
+  key: ChecklistItemKey;
+  severity: ChecklistItemSeverity;
+  done: boolean;
+  dismissed: boolean;
+  route: string[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class SetupChecklistApiService {
+  private readonly http = inject(HttpClient);
+
+  /** Cached list of items so multiple consumers (home widget + admin
+   *  page) share one network request. Cleared on dismiss/undismiss/refresh. */
+  readonly items = signal<ChecklistItem[]>([]);
+  readonly loading = signal(false);
+
+  async refresh(): Promise<void> {
+    this.loading.set(true);
+    try {
+      const data = await firstValueFrom(
+        this.http.get<ChecklistItem[]>('/api/setup-checklist'),
+      );
+      this.items.set(data);
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async dismiss(key: ChecklistItemKey): Promise<void> {
+    await firstValueFrom(
+      this.http.post<{ ok: boolean }>(
+        `/api/setup-checklist/${key}/dismiss`,
+        {},
+      ),
+    );
+    this.items.update((items) =>
+      items.map((i) => (i.key === key ? { ...i, dismissed: true } : i)),
+    );
+  }
+
+  async undismiss(key: ChecklistItemKey): Promise<void> {
+    await firstValueFrom(
+      this.http.delete<{ ok: boolean }>(
+        `/api/setup-checklist/${key}/dismiss`,
+      ),
+    );
+    this.items.update((items) =>
+      items.map((i) => (i.key === key ? { ...i, dismissed: false } : i)),
+    );
+  }
+}

--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -1,5 +1,9 @@
 <div appTvSection class="flex flex-col gap-8">
 
+    @if (auth.canAccessSettings()) {
+      <app-setup-checklist class="mt-4" />
+    }
+
     <!-- Libraries -->
     @if (libraries().length) {
       <app-horizontal-scroller [title]="'home.libraries' | translate">

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -17,7 +17,9 @@ import { TvService } from '../../core/services/tv.service';
 import { MediaCardComponent } from '../../shared/components/media-card/media-card';
 import { HorizontalScrollerComponent } from '../../shared/components/horizontal-scroller';
 import { LucideIconComponent } from '../../shared/components/lucide-icon';
+import { SetupChecklistComponent } from '../../shared/components/setup-checklist/setup-checklist';
 import { TvSectionDirective } from '../../shared/directives/tv-section.directive';
+import { AuthService } from '../../core/services/auth.service';
 
 /**
  * # Home page
@@ -58,6 +60,7 @@ import { TvSectionDirective } from '../../shared/directives/tv-section.directive
     MediaCardComponent,
     HorizontalScrollerComponent,
     LucideIconComponent,
+    SetupChecklistComponent,
     TvSectionDirective,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -74,6 +77,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly focusMemory = inject(FocusMemoryService);
   private readonly navbar = inject(NavbarService);
   private readonly backgroundService = inject(BackgroundService);
+  readonly auth = inject(AuthService);
   private readonly tv = inject(TvService);
   private readonly injector = inject(Injector);
   private readonly route = inject(ActivatedRoute);

--- a/client/src/app/features/settings/general/general.html
+++ b/client/src/app/features/settings/general/general.html
@@ -4,6 +4,8 @@
     <p class="text-sm text-base-content/60 mt-1">{{ 'settings.general.subtitle' | translate }}</p>
   </div>
 
+  <app-setup-checklist [showAll]="true" />
+
   @if (loading()) {
     <div class="flex justify-center py-16">
       <span class="loading loading-spinner loading-lg"></span>

--- a/client/src/app/features/settings/general/general.ts
+++ b/client/src/app/features/settings/general/general.ts
@@ -9,10 +9,11 @@ import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { SettingsApiService } from '../../../core/services/api/settings-api.service';
 import { ToastService } from '../../../core/services/toast.service';
+import { SetupChecklistComponent } from '../../../shared/components/setup-checklist/setup-checklist';
 
 @Component({
   selector: 'app-general-settings',
-  imports: [FormsModule, TranslateModule],
+  imports: [FormsModule, TranslateModule, SetupChecklistComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './general.html',
 })

--- a/client/src/app/shared/components/setup-checklist/setup-checklist.html
+++ b/client/src/app/shared/components/setup-checklist/setup-checklist.html
@@ -1,0 +1,81 @@
+@if (visibleItems().length > 0 || (showAll() && items().length > 0)) {
+  <section class="card bg-base-200/60 backdrop-blur-sm shadow-sm">
+    <div class="card-body p-4 sm:p-5 gap-3">
+      <header class="flex items-center justify-between gap-3 flex-wrap">
+        <h2 class="card-title text-base">
+          {{ 'setup_checklist.title' | translate }}
+          @if (pendingRequiredCount() > 0) {
+            <span class="badge badge-error badge-sm">
+              {{ pendingRequiredCount() }}
+            </span>
+          } @else if (pendingRecommendedCount() > 0) {
+            <span class="badge badge-warning badge-sm">
+              {{ pendingRecommendedCount() }}
+            </span>
+          }
+        </h2>
+        @if (loading() && items().length === 0) {
+          <span class="loading loading-spinner loading-sm"></span>
+        }
+      </header>
+
+      <ul class="flex flex-col divide-y divide-base-300/50">
+        @for (item of visibleItems(); track trackByKey($index, item)) {
+          <li class="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0">
+            <span class="shrink-0">
+              @if (item.done) {
+                <span class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-success/20 text-success" [attr.aria-label]="'setup_checklist.status_done' | translate">
+                  <svg lucideCheck class="h-3.5 w-3.5"></svg>
+                </span>
+              } @else if (item.severity === 'required') {
+                <span class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-error/20 text-error" [attr.aria-label]="'setup_checklist.status_required' | translate">
+                  <svg lucideCircleAlert class="h-3.5 w-3.5"></svg>
+                </span>
+              } @else {
+                <span class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-warning/20 text-warning" [attr.aria-label]="'setup_checklist.status_recommended' | translate">
+                  <svg lucideTriangleAlert class="h-3.5 w-3.5"></svg>
+                </span>
+              }
+            </span>
+
+            <div class="flex-1 min-w-0">
+              <p class="text-sm font-medium leading-tight"
+                 [class.line-through]="item.done || item.dismissed"
+                 [class.text-base-content/50]="item.done || item.dismissed">
+                {{ 'setup_checklist.items.' + item.key + '.label' | translate }}
+              </p>
+              <p class="text-xs text-base-content/60 mt-0.5 line-clamp-2">
+                {{ 'setup_checklist.items.' + item.key + '.hint' | translate }}
+              </p>
+            </div>
+
+            <div class="shrink-0 flex items-center gap-1">
+              @if (!item.done && !item.dismissed) {
+                <a [routerLink]="item.route"
+                   class="btn btn-ghost btn-sm gap-1"
+                   [attr.aria-label]="'setup_checklist.configure' | translate">
+                  <span class="hidden sm:inline">{{ 'setup_checklist.configure' | translate }}</span>
+                  <svg lucideChevronRight class="h-4 w-4"></svg>
+                </a>
+                <button type="button"
+                        class="btn btn-ghost btn-sm btn-square"
+                        (click)="onDismiss(item.key, $event)"
+                        [attr.aria-label]="'setup_checklist.dismiss' | translate"
+                        [attr.title]="'setup_checklist.dismiss' | translate">
+                  <svg lucideX class="h-4 w-4"></svg>
+                </button>
+              } @else if (item.dismissed) {
+                <button type="button"
+                        class="btn btn-ghost btn-sm"
+                        (click)="onUndismiss(item.key, $event)"
+                        [attr.title]="'setup_checklist.undismiss' | translate">
+                  {{ 'setup_checklist.undismiss' | translate }}
+                </button>
+              }
+            </div>
+          </li>
+        }
+      </ul>
+    </div>
+  </section>
+}

--- a/client/src/app/shared/components/setup-checklist/setup-checklist.ts
+++ b/client/src/app/shared/components/setup-checklist/setup-checklist.ts
@@ -1,0 +1,90 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  OnInit,
+} from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import {
+  LucideCheck,
+  LucideChevronRight,
+  LucideCircleAlert,
+  LucideTriangleAlert,
+  LucideX,
+} from '@lucide/angular';
+import {
+  ChecklistItem,
+  ChecklistItemKey,
+  SetupChecklistApiService,
+} from '../../../core/services/api/setup-checklist-api.service';
+
+@Component({
+  selector: 'app-setup-checklist',
+  imports: [
+    RouterLink,
+    TranslateModule,
+    LucideCheck,
+    LucideChevronRight,
+    LucideCircleAlert,
+    LucideTriangleAlert,
+    LucideX,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './setup-checklist.html',
+})
+export class SetupChecklistComponent implements OnInit {
+  private readonly api = inject(SetupChecklistApiService);
+
+  /** When `true`, also surface completed and dismissed items (with a
+   *  reactivate button on the latter). Off by default — the home
+   *  widget only wants pending things. */
+  readonly showAll = input(false);
+
+  readonly items = this.api.items;
+  readonly loading = this.api.loading;
+
+  /** Items shown in the list. Compact mode (default) keeps only the
+   *  pending, non-dismissed ones — those are the user's TODO. */
+  readonly visibleItems = computed(() => {
+    const all = this.items();
+    if (this.showAll()) return all;
+    return all.filter((i) => !i.done && !i.dismissed);
+  });
+
+  /** Severity counters used by the header badge. */
+  readonly pendingRequiredCount = computed(
+    () =>
+      this.items().filter(
+        (i) => i.severity === 'required' && !i.done && !i.dismissed,
+      ).length,
+  );
+  readonly pendingRecommendedCount = computed(
+    () =>
+      this.items().filter(
+        (i) => i.severity === 'recommended' && !i.done && !i.dismissed,
+      ).length,
+  );
+
+  ngOnInit() {
+    // Reuse already-cached items on second mount; otherwise fetch.
+    if (this.items().length === 0) void this.api.refresh();
+  }
+
+  onDismiss(key: ChecklistItemKey, event: Event) {
+    event.stopPropagation();
+    void this.api.dismiss(key);
+  }
+
+  onUndismiss(key: ChecklistItemKey, event: Event) {
+    event.stopPropagation();
+    void this.api.undismiss(key);
+  }
+
+  /** Used by *@for track* to keep DOM stable across refreshes. */
+  trackByKey(_: number, item: ChecklistItem) {
+    return item.key;
+  }
+}


### PR DESCRIPTION
## Summary

Onboarding-style checklist surfacing the most common configuration steps a fresh Fliks install needs. Visible to admins only.

### Items

**Required**
- Library
- Quality profile
- Language profile
- Download client (enabled)
- Indexer (enabled)

**Recommended**
- Subtitle provider (enabled)
- Notification connection
- Non-admin user
- Auto-approval rule

Each row links to its settings page and exposes a dismiss button.

### Architecture

- **Backend**: \`SetupChecklistModule\` — single config-driven array of items; each \`check()\` is a parallel \`count()\` against the relevant repo. Dismissals stored globally in \`app_settings\` under \`setup_checklist_dismissed_keys\` (Fliks installs are typically single-admin — a per-user join table would be more machinery than the UX gains).
- **Frontend**: \`<app-setup-checklist>\` reusable component, default compact mode (pending only, auto-hides when empty) + \`[showAll]\` mode with reactivation buttons.
  - Home (gated on \`canAccessSettings()\`, with \`mt-4\`)
  - Admin → Settings → Général (full mode under the page title)
- **i18n**: \`setup_checklist.*\` (label + hint per item).

## Test plan

- [ ] Open the home as admin → checklist shows only the items I haven't configured
- [ ] Dismiss an item → it disappears from the home + from the compact view; the General settings page lets me reactivate it
- [ ] Configure a missing item (e.g. add an indexer) → next refresh, the item turns done; compact mode hides it
- [ ] Open the home as a non-admin → no checklist visible
- [ ] Backend \`GET /api/setup-checklist\` returns 9 items with correct \`done\` flags