### PR TITLE
feat(app-settings): display page with home background toggle

### DIFF
--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -108,8 +108,14 @@
       "player": "Lecture",
       "subtitles": "Sous-titres",
       "cast": "Chromecast",
+      "display": "Affichage",
       "storage": "Stockage"
     }
+  },
+  "display_settings": {
+    "title": "Affichage",
+    "home_background": "Image de fond sur l'accueil",
+    "home_background_hint": "Affiche une affiche en plein écran derrière les sections de l'accueil."
   },
   "storage_settings": {
     "clear_cache": "Vider le cache",

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -274,6 +274,13 @@ export const routes: Routes = [
             (m) => m.StorageSettingsPageComponent,
           ),
       },
+      {
+        path: 'display',
+        loadComponent: () =>
+          import('./features/app-settings/display-settings/display-settings').then(
+            (m) => m.DisplaySettingsPageComponent,
+          ),
+      },
     ],
   },
   // Admin area — own layout with dedicated sidebar

--- a/client/src/app/core/services/display-settings.service.ts
+++ b/client/src/app/core/services/display-settings.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, signal } from '@angular/core';
+
+export interface DisplaySettings {
+  /** Show the page-wide fanart background on the home page. */
+  homeBackground: boolean;
+}
+
+const STORAGE_KEY = 'display.settings';
+
+const DEFAULTS: DisplaySettings = {
+  homeBackground: true,
+};
+
+@Injectable({ providedIn: 'root' })
+export class DisplaySettingsService {
+  readonly settings = signal<DisplaySettings>(this.load());
+
+  private load(): DisplaySettings {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as Partial<DisplaySettings>;
+        return { ...DEFAULTS, ...parsed };
+      }
+    } catch { /* ignore */ }
+    return { ...DEFAULTS };
+  }
+
+  save(settings: DisplaySettings): void {
+    this.settings.set(settings);
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+    } catch { /* private mode / SSR */ }
+  }
+
+  get(): DisplaySettings {
+    return this.settings();
+  }
+}

--- a/client/src/app/features/app-settings/app-settings-shell.html
+++ b/client/src/app/features/app-settings/app-settings-shell.html
@@ -6,6 +6,7 @@
   <svg drawerIcon lucideSettings class="h-5 w-5"></svg>
 
   <ng-container drawerMenu>
+    <li><a routerLink="/app-settings/display" routerLinkActive="active"><svg lucideMonitor class="h-4 w-4"></svg>{{ 'app_settings.nav.display' | translate }}</a></li>
     <li><a routerLink="/app-settings/player" routerLinkActive="active"><svg lucidePlay class="h-4 w-4"></svg>{{ 'app_settings.nav.player' | translate }}</a></li>
     <li><a routerLink="/app-settings/subtitles" routerLinkActive="active"><svg lucideCaptions class="h-4 w-4"></svg>{{ 'app_settings.nav.subtitles' | translate }}</a></li>
     <li><a routerLink="/app-settings/cast" routerLinkActive="active"><svg lucideCast class="h-4 w-4"></svg>{{ 'app_settings.nav.cast' | translate }}</a></li>

--- a/client/src/app/features/app-settings/app-settings-shell.ts
+++ b/client/src/app/features/app-settings/app-settings-shell.ts
@@ -2,7 +2,7 @@ import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { SettingsDrawerComponent } from '../../shared/components/settings-drawer/settings-drawer';
-import { LucideSettings, LucidePlay, LucideCaptions, LucideCast, LucideHardDrive } from '@lucide/angular';
+import { LucideSettings, LucidePlay, LucideCaptions, LucideCast, LucideHardDrive, LucideMonitor } from '@lucide/angular';
 import { TvService } from '../../core/services/tv.service';
 
 @Component({
@@ -10,7 +10,7 @@ import { TvService } from '../../core/services/tv.service';
   imports: [
     RouterLink, RouterLinkActive, TranslateModule,
     SettingsDrawerComponent,
-    LucideSettings, LucidePlay, LucideCaptions, LucideCast, LucideHardDrive,
+    LucideSettings, LucidePlay, LucideCaptions, LucideCast, LucideHardDrive, LucideMonitor,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './app-settings-shell.html',

--- a/client/src/app/features/app-settings/display-settings/display-settings.html
+++ b/client/src/app/features/app-settings/display-settings/display-settings.html
@@ -1,0 +1,11 @@
+<h1 class="text-2xl font-bold mb-4">{{ 'display_settings.title' | translate }}</h1>
+<div class="card bg-base-100 border border-base-200">
+  <div class="card-body gap-5">
+    <app-toggle-field
+      [value]="homeBackground()"
+      (valueChange)="onHomeBackgroundChange($event)"
+      [label]="'display_settings.home_background' | translate"
+      [hint]="'display_settings.home_background_hint' | translate"
+    />
+  </div>
+</div>

--- a/client/src/app/features/app-settings/display-settings/display-settings.ts
+++ b/client/src/app/features/app-settings/display-settings/display-settings.ts
@@ -1,0 +1,26 @@
+import { Component, ChangeDetectionStrategy, inject, signal, OnInit } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { DisplaySettingsService } from '../../../core/services/display-settings.service';
+import { ToggleFieldComponent } from '../../../shared/components/forms/toggle-field/toggle-field';
+
+@Component({
+  selector: 'app-display-settings',
+  imports: [TranslateModule, ToggleFieldComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './display-settings.html',
+})
+export class DisplaySettingsPageComponent implements OnInit {
+  private readonly displaySettings = inject(DisplaySettingsService);
+
+  readonly homeBackground = signal(true);
+
+  ngOnInit() {
+    const s = this.displaySettings.get();
+    this.homeBackground.set(s.homeBackground);
+  }
+
+  onHomeBackgroundChange(value: boolean) {
+    this.homeBackground.set(value);
+    this.displaySettings.save({ homeBackground: value });
+  }
+}

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -13,6 +13,7 @@ import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
 import { FocusMemoryService } from '../../core/services/focus-memory.service';
 import { NavbarService } from '../../core/services/navbar.service';
 import { BackgroundService } from '../../core/services/background.service';
+import { DisplaySettingsService } from '../../core/services/display-settings.service';
 import { TvService } from '../../core/services/tv.service';
 import { MediaCardComponent } from '../../shared/components/media-card/media-card';
 import { HorizontalScrollerComponent } from '../../shared/components/horizontal-scroller';
@@ -77,6 +78,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly focusMemory = inject(FocusMemoryService);
   private readonly navbar = inject(NavbarService);
   private readonly backgroundService = inject(BackgroundService);
+  private readonly displaySettings = inject(DisplaySettingsService);
   readonly auth = inject(AuthService);
   private readonly tv = inject(TvService);
   private readonly injector = inject(Injector);
@@ -104,6 +106,10 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly recommendationsBackgroundEffect = effect(() => {
     const recs = this.recommendations();
     if (recs.length === 0) return;
+    if (!this.displaySettings.settings().homeBackground) {
+      this.backgroundService.clear();
+      return;
+    }
     const pool: string[] = [];
     for (const r of recs) {
       if (r.media.fanartUrl) pool.push(r.media.fanartUrl);

--- a/client/src/app/shared/components/background/background.html
+++ b/client/src/app/shared/components/background/background.html
@@ -1,14 +1,14 @@
-<!-- Hidden below the `lg` breakpoint so phones / tablet-portrait keep
-     the existing inline `mobile-fanart-hero` and don't show a second
-     image of the same fanart. -->
-<div class="fixed inset-0 -z-10 overflow-hidden pointer-events-none hidden lg:block">
+<!-- Hidden below the `md` breakpoint so phones keep the existing inline
+     `mobile-fanart-hero` and don't show a second image of the same
+     fanart. Tablets (md+) get the global background. -->
+<div class="fixed inset-0 -z-10 overflow-hidden pointer-events-none hidden md:block">
   @if (layerA()) {
     <img
       [src]="layerA()! | resolveUrl:'medium'"
       alt=""
       loading="eager"
       decoding="async"
-      class="absolute inset-0 w-full h-full object-cover object-[50%_25%] transition-opacity duration-500"
+      class="absolute inset-0 w-full h-full object-cover object-[50%_25%] transition-opacity duration-1500"
       [class.opacity-100]="activeLayer() === 'A' && imageVisible()"
       [class.opacity-0]="activeLayer() !== 'A' || !imageVisible()"
     />
@@ -19,7 +19,7 @@
       alt=""
       loading="eager"
       decoding="async"
-      class="absolute inset-0 w-full h-full object-cover object-[50%_25%] transition-opacity duration-500"
+      class="absolute inset-0 w-full h-full object-cover object-[50%_25%] transition-opacity duration-1500"
       [class.opacity-100]="activeLayer() === 'B' && imageVisible()"
       [class.opacity-0]="activeLayer() !== 'B' || !imageVisible()"
     />

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -1,5 +1,5 @@
 <!-- ===== MOBILE layout ===== -->
-<div class="lg:hidden tv:hidden">
+<div class="md:hidden tv:hidden">
   <app-mobile-fanart-hero [fanartUrl]="fanartUrl()" />
 
   <div class="-mt-16 relative z-20">
@@ -127,7 +127,7 @@
 </div>
 
 <!-- ===== DESKTOP layout ===== -->
-<div class="hidden lg:block tv:block relative">
+<div class="hidden md:block tv:block relative">
   @if (fanartUrl()) {
     @if (!navbar.mobileNavbarVisible()) {
       <button type="button" (click)="goBack()" class="relative z-10 btn btn-ghost btn gap-1 mb-4 text-base-content/80 hover:text-base-content">


### PR DESCRIPTION
## Summary

- New **Affichage** page in `/app-settings` with a single toggle controlling whether the global fanart background renders on the home (default on, persists in `localStorage`, saves immediately on change).
- `BackgroundComponent` now renders from `md` (≥ 768 px) instead of `lg` so tablet-portrait gets the fanart, not just desktop.
- Crossfade between two background images bumped from 500 ms to 1500 ms.
- `media-info-header` mobile/desktop split lifted to `md` to avoid showing the inline `mobile-fanart-hero` AND the global background simultaneously on tablet-portrait in `media-detail`.

## Test plan

- [ ] Tablet portrait (≥ 768 px): home shows fanart background; toggling the new setting off clears it on next visit / on re-render.
- [ ] Phone (< 768 px): no global background, no regression on home.
- [ ] Media-detail on tablet-portrait: poster-left/text-right layout (was bandeau fanart), single image visible.
- [ ] Desktop: unchanged behaviour, longer crossfade visible.
- [ ] Setting persists across reloads; default `true` on fresh install.