### PR TITLE
feat(pagination, subtitles): ellipsis pagination + disk-scan trusted scoring

### DIFF
--- a/backend/src/migrations/1779000000000-backfill-disk-subtitle-score.ts
+++ b/backend/src/migrations/1779000000000-backfill-disk-subtitle-score.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Disk-discovered subtitles were previously stored with score=0 and
+ * synced=false, putting them at the bottom of the selection order and
+ * scheduling them for a sync pass even though a user-provided file on
+ * disk is at least as trustworthy as an embedded track (score=100,
+ * synced=true). Align them on the same defaults so they win against
+ * same-language remote rows and aren't re-sync'd unnecessarily.
+ * Only touches rows that still sit at the default score=0 — already-
+ * rescored (e.g. via Whisper sync) entries are left untouched.
+ */
+export class BackfillDiskSubtitleScore1779000000000 implements MigrationInterface {
+  name = 'BackfillDiskSubtitleScore1779000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "subtitle_files"
+          SET "score" = 100,
+              "synced" = true
+        WHERE "providerType" = 'disk'
+          AND "score" = 0`,
+    );
+  }
+
+  public async down(): Promise<void> {
+    // No rollback: we'd flip back legitimately-rescored rows to zero.
+  }
+}

--- a/backend/src/modules/subtitles/subtitles.service.ts
+++ b/backend/src/modules/subtitles/subtitles.service.ts
@@ -589,8 +589,8 @@ export class SubtitlesService {
           providerType: SubtitleProviderType.DISK,
           relativePath: relPath,
           status: SubtitleStatus.DOWNLOADED,
-          score: 0,
-          synced: false,
+          score: 100,
+          synced: true,
         } as any);
 
         existingPaths.add(relPath);

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -907,6 +907,11 @@
     "retry": "Réessayer",
     "offline_banner": "Mode hors-ligne — les données affichées peuvent ne pas être à jour"
   },
+  "pagination": {
+    "label": "Pagination",
+    "previous": "Page précédente",
+    "next": "Page suivante"
+  },
   "downloads": {
     "title": "Téléchargements",
     "download": "Télécharger",

--- a/client/src/app/features/settings/blocklist/blocklist.html
+++ b/client/src/app/features/settings/blocklist/blocklist.html
@@ -63,21 +63,11 @@
     </div>
 
     @if (totalPages > 1) {
-      <div class="flex justify-center gap-2">
-        <button
-          class="btn btn-sm btn-ghost"
-          [disabled]="page() <= 1"
-          (click)="load(page() - 1)"
-        >«</button>
-        <span class="btn btn-sm btn-ghost pointer-events-none">
-          {{ page() }} / {{ totalPages }}
-        </span>
-        <button
-          class="btn btn-sm btn-ghost"
-          [disabled]="page() >= totalPages"
-          (click)="load(page() + 1)"
-        >»</button>
-      </div>
+      <app-pagination
+        [current]="page()"
+        [total]="totalPages"
+        (pageChange)="load($event)"
+      />
     }
   }
 </div>

--- a/client/src/app/features/settings/blocklist/blocklist.ts
+++ b/client/src/app/features/settings/blocklist/blocklist.ts
@@ -12,10 +12,11 @@ import {
   BlocklistApiService,
   BlocklistEntry,
 } from '../../../core/services/api/blocklist-api.service';
+import { PaginationComponent } from '../../../shared/components/pagination/pagination';
 
 @Component({
   selector: 'app-blocklist-settings',
-  imports: [TranslateModule, DatePipe],
+  imports: [TranslateModule, DatePipe, PaginationComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './blocklist.html',
 })

--- a/client/src/app/features/settings/subtitles/subtitles-stats.html
+++ b/client/src/app/features/settings/subtitles/subtitles-stats.html
@@ -101,25 +101,12 @@
         </div>
 
         @if (totalPages() > 1) {
-          <div class="flex justify-center items-center gap-1 mt-2">
-            <button type="button" class="btn btn-ghost btn-xs" [disabled]="page() === 0" (click)="goToPage(page() - 1)">
-              {{ 'common.prev' | translate }}
-            </button>
-            @for (p of [].constructor(totalPages()); track $index) {
-              <button
-                type="button"
-                class="btn btn-xs"
-                [class.btn-primary]="$index === page()"
-                [class.btn-ghost]="$index !== page()"
-                (click)="goToPage($index)"
-              >
-                {{ $index + 1 }}
-              </button>
-            }
-            <button type="button" class="btn btn-ghost btn-xs" [disabled]="page() === totalPages() - 1" (click)="goToPage(page() + 1)">
-              {{ 'common.next' | translate }}
-            </button>
-          </div>
+          <app-pagination
+            class="mt-2"
+            [current]="page() + 1"
+            [total]="totalPages()"
+            (pageChange)="goToPage($event - 1)"
+          />
         }
       }
     </div>

--- a/client/src/app/features/settings/subtitles/subtitles-stats.ts
+++ b/client/src/app/features/settings/subtitles/subtitles-stats.ts
@@ -16,10 +16,11 @@ import {
 } from '../../../core/services/api/subtitles-api.service';
 import { ToastService } from '../../../core/services/toast.service';
 import { TranslateService } from '@ngx-translate/core';
+import { PaginationComponent } from '../../../shared/components/pagination/pagination';
 
 @Component({
   selector: 'app-subtitles-stats',
-  imports: [LucideSearch, RouterLink, TranslateModule],
+  imports: [LucideSearch, RouterLink, TranslateModule, PaginationComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './subtitles-stats.html',
 })

--- a/client/src/app/features/system/status/status.html
+++ b/client/src/app/features/system/status/status.html
@@ -142,17 +142,12 @@
       </table>
     </div>
     @if (commandsTotalPages > 1) {
-      <div class="flex justify-center mt-3">
-        <div class="join">
-          @for (p of [].constructor(commandsTotalPages); track $index) {
-            <button
-              class="join-item btn btn-sm"
-              [class.btn-active]="commandsPage() === $index + 1"
-              (click)="loadCommands($index + 1)"
-            >{{ $index + 1 }}</button>
-          }
-        </div>
-      </div>
+      <app-pagination
+        class="mt-3"
+        [current]="commandsPage()"
+        [total]="commandsTotalPages"
+        (pageChange)="loadCommands($event)"
+      />
     }
   }
 </div>

--- a/client/src/app/features/system/status/status.ts
+++ b/client/src/app/features/system/status/status.ts
@@ -8,6 +8,7 @@ import { firstValueFrom } from 'rxjs';
 import { LucideTrash2 } from '@lucide/angular';
 import { SseService } from '../../../core/services/sse.service';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
+import { PaginationComponent } from '../../../shared/components/pagination/pagination';
 
 interface CommandEntry { id: number; name: string; status: string; trigger: string; startedOn: string; endedOn?: string; body?: Record<string, unknown>; }
 interface ServiceStatus { name: string; ok: boolean; message?: string; }
@@ -15,7 +16,7 @@ interface HealthReport { version: string; uptimeSeconds: number; database: Servi
 
 @Component({
   selector: 'app-system-status',
-  imports: [TranslateModule, DatePipe, DecimalPipe, NgClass, KeyValuePipe, LucideTrash2],
+  imports: [TranslateModule, DatePipe, DecimalPipe, NgClass, KeyValuePipe, LucideTrash2, PaginationComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './status.html',
 })

--- a/client/src/app/features/watch-history/watch-history.html
+++ b/client/src/app/features/watch-history/watch-history.html
@@ -104,31 +104,12 @@
 
     <!-- Pagination -->
     @if (totalPages() > 1) {
-      <div class="flex justify-center gap-1.5 pt-2">
-        <button
-          class="btn btn-sm"
-          [disabled]="currentPage() <= 1"
-          (click)="goToPage(currentPage() - 1)"
-        >
-          &laquo;
-        </button>
-        @for (p of visiblePages(); track p) {
-          <button
-            class="btn btn-sm"
-            [class.btn-primary]="currentPage() === p"
-            (click)="goToPage(p)"
-          >
-            {{ p }}
-          </button>
-        }
-        <button
-          class="btn btn-sm"
-          [disabled]="currentPage() >= totalPages()"
-          (click)="goToPage(currentPage() + 1)"
-        >
-          &raquo;
-        </button>
-      </div>
+      <app-pagination
+        class="pt-2"
+        [current]="currentPage()"
+        [total]="totalPages()"
+        (pageChange)="goToPage($event)"
+      />
     }
   }
 </div>

--- a/client/src/app/features/watch-history/watch-history.ts
+++ b/client/src/app/features/watch-history/watch-history.ts
@@ -8,10 +8,11 @@ import { PlaybackState, StreamingApiService, WatchHistoryItem } from '../../core
 import { ConfirmationService } from '../../core/services/confirmation.service';
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
+import { PaginationComponent } from '../../shared/components/pagination/pagination';
 
 @Component({
   selector: 'app-watch-history',
-  imports: [TranslateModule, ResolveUrlPipe, LucideHistory, LucideTrash2, LucidePlay, LucideFilm, LucideTv, LucideCheck, LucideEllipsisVertical],
+  imports: [TranslateModule, ResolveUrlPipe, PaginationComponent, LucideHistory, LucideTrash2, LucidePlay, LucideFilm, LucideTv, LucideCheck, LucideEllipsisVertical],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './watch-history.html',
 })
@@ -34,15 +35,6 @@ export class WatchHistoryComponent implements OnInit, OnDestroy {
   readonly pageSize = 25;
 
   readonly totalPages = computed(() => Math.ceil(this.total() / this.pageSize));
-
-  /** Visible page numbers (max 7, centered around current page) */
-  readonly visiblePages = computed(() => {
-    const total = this.totalPages();
-    const current = this.currentPage();
-    if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
-    const start = Math.max(1, Math.min(current - 3, total - 6));
-    return Array.from({ length: 7 }, (_, i) => start + i);
-  });
 
   async ngOnInit() {
     this.scrollMemory.activate(WatchHistoryComponent.SCROLL_KEY);

--- a/client/src/app/shared/components/pagination/pagination.html
+++ b/client/src/app/shared/components/pagination/pagination.html
@@ -1,0 +1,48 @@
+<nav class="flex justify-end items-center gap-1" [attr.aria-label]="'pagination.label' | translate">
+  <button
+    type="button"
+    class="btn btn-sm btn-ghost"
+    [class.btn-square]="compact()"
+    [disabled]="current() <= 1"
+    [attr.aria-label]="'pagination.previous' | translate"
+    (click)="goTo(current() - 1)"
+  >
+    @if (compact()) {
+      <svg lucideChevronLeft class="h-4 w-4"></svg>
+    } @else {
+      {{ 'common.prev' | translate }}
+    }
+  </button>
+
+  @for (slot of slots(); track $index) {
+    @if (slot === 'ellipsis') {
+      <span class="px-1.5 text-base-content/50 select-none" aria-hidden="true">…</span>
+    } @else {
+      <button
+        type="button"
+        class="btn btn-sm min-w-10"
+        [class.btn-primary]="slot === current()"
+        [class.btn-ghost]="slot !== current()"
+        [attr.aria-current]="slot === current() ? 'page' : null"
+        (click)="goTo(slot)"
+      >
+        {{ slot }}
+      </button>
+    }
+  }
+
+  <button
+    type="button"
+    class="btn btn-sm btn-ghost"
+    [class.btn-square]="compact()"
+    [disabled]="current() >= total()"
+    [attr.aria-label]="'pagination.next' | translate"
+    (click)="goTo(current() + 1)"
+  >
+    @if (compact()) {
+      <svg lucideChevronRight class="h-4 w-4"></svg>
+    } @else {
+      {{ 'common.next' | translate }}
+    }
+  </button>
+</nav>

--- a/client/src/app/shared/components/pagination/pagination.ts
+++ b/client/src/app/shared/components/pagination/pagination.ts
@@ -1,0 +1,67 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output,
+} from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { LucideChevronLeft, LucideChevronRight } from '@lucide/angular';
+
+type Slot = number | 'ellipsis';
+
+@Component({
+  selector: 'app-pagination',
+  standalone: true,
+  imports: [TranslateModule, LucideChevronLeft, LucideChevronRight],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './pagination.html',
+  host: { class: 'block' },
+})
+export class PaginationComponent {
+  /** 1-indexed current page. */
+  readonly current = input.required<number>();
+  /** Total number of pages (≥ 1). */
+  readonly total = input.required<number>();
+  /** Pages to show on each side of the current page. Default 1 → 7 slots max. */
+  readonly siblings = input<number>(1);
+  /** When true, prev/next render as icon-only chevrons (compact). */
+  readonly compact = input<boolean>(false);
+
+  readonly pageChange = output<number>();
+
+  readonly slots = computed<Slot[]>(() => {
+    const total = this.total();
+    const current = this.current();
+    const siblings = this.siblings();
+
+    const totalSlots = siblings * 2 + 5;
+    if (total <= totalSlots) {
+      return Array.from({ length: total }, (_, i) => i + 1);
+    }
+
+    const leftSibling = Math.max(current - siblings, 1);
+    const rightSibling = Math.min(current + siblings, total);
+    const showLeftDots = leftSibling > 2;
+    const showRightDots = rightSibling < total - 1;
+    const edgeRun = 3 + 2 * siblings;
+
+    if (!showLeftDots && showRightDots) {
+      return [...this.range(1, edgeRun), 'ellipsis', total];
+    }
+    if (showLeftDots && !showRightDots) {
+      return [1, 'ellipsis', ...this.range(total - edgeRun + 1, total)];
+    }
+    return [1, 'ellipsis', ...this.range(leftSibling, rightSibling), 'ellipsis', total];
+  });
+
+  goTo(page: number) {
+    const total = this.total();
+    if (page < 1 || page > total || page === this.current()) return;
+    this.pageChange.emit(page);
+  }
+
+  private range(start: number, end: number): number[] {
+    return Array.from({ length: end - start + 1 }, (_, i) => start + i);
+  }
+}

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -196,25 +196,12 @@
           </table>
         </div>
         @if (totalPages() > 1) {
-          <div class="flex justify-center items-center gap-1 mt-2">
-            <button type="button" class="btn btn-ghost btn-xs" [disabled]="page() === 0" (click)="goToPage(page() - 1)">
-              {{ 'common.prev' | translate }}
-            </button>
-            @for (p of [].constructor(totalPages()); track $index) {
-              <button
-                type="button"
-                class="btn btn-xs"
-                [class.btn-primary]="$index === page()"
-                [class.btn-ghost]="$index !== page()"
-                (click)="goToPage($index)"
-              >
-                {{ $index + 1 }}
-              </button>
-            }
-            <button type="button" class="btn btn-ghost btn-xs" [disabled]="page() === totalPages() - 1" (click)="goToPage(page() + 1)">
-              {{ 'common.next' | translate }}
-            </button>
-          </div>
+          <app-pagination
+            class="mt-2"
+            [current]="page() + 1"
+            [total]="totalPages()"
+            (pageChange)="goToPage($event - 1)"
+          />
         }
       }
     </section>

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -45,6 +45,7 @@ import {
 } from '../../../core/services/api/profiles.service';
 import { SseService } from '../../../core/services/sse.service';
 import { ToastService } from '../../../core/services/toast.service';
+import { PaginationComponent } from '../pagination/pagination';
 import { MediaDetailSubtitleSearchModalComponent } from '../../../features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component';
 import type { MediaInfoHeaderSubtitle } from '../media-info-header/media-info-header';
 
@@ -67,6 +68,7 @@ interface SubtitleRow {
     TranslateModule,
     LocalizeLanguagePipe,
     SubtitleFilenamePipe,
+    PaginationComponent,
     MediaDetailSubtitleSearchModalComponent,
     LucideArrowRightLeft,
     LucideBan,


### PR DESCRIPTION
## Summary

- **Pagination** — new `<app-pagination>` shared component with first/last anchors, current ± siblings, and \"…\" between gaps (≤ 7 slots by default). Right-aligned, `btn-sm`, host `display:block`. Replaces five call-sites that previously rendered every page button as a single button (the bug visible at large page counts):
  - `subtitles-modal`
  - `settings → subtitles → stats`
  - `admin → system → status` (recent commands history)
  - `watch-history` (sliding-window of 7 → real ellipsis)
  - `settings → blocklist` (was \"X / Y\" → numbered)
- **Disk-discovered subtitles** — file-scan now stores rows with `score=100` + `synced=true` (same defaults as embedded tracks) instead of `score=0` + `synced=false`. A user-provided file on disk is at least as trustworthy as an embedded one, and there is no reason to schedule an automated sync against itself. Backfill migration aligns existing disk rows that still sit at the default `score=0` (already-rescored entries are left untouched).

## Test plan

- [ ] Open `admin → system → status` with > 10 command history pages: pagination shows `« 1 … N-1 N N+1 … last »`, current page highlighted, clicks jump correctly.
- [ ] Same check on `subtitles-modal`, `watch-history`, `settings/blocklist`, `settings/subtitles → stats`.
- [ ] Prev/next disabled at boundaries, `aria-current=\"page\"` on the active button.
- [ ] Run the migration on a DB with disk-scanned subtitles: existing rows at score 0 become score 100 / synced true; rows with non-zero score untouched.
- [ ] New disk-scanned subtitles arrive directly with score 100, synced true.