### PR TITLE
fix(data-imports): wizard option uses lib.id (typo from rename)

### DIFF
--- a/client/src/app/features/settings/data-imports/data-imports.html
+++ b/client/src/app/features/settings/data-imports/data-imports.html
@@ -499,7 +499,7 @@
                   >
                     <option [ngValue]="null">—</option>
                     @for (lib of eligibleLocalLibraries('radarr'); track lib.id) {
-                      <option [ngValue]="rf.id">{{ lib.name }} ({{ lib.path }})</option>
+                      <option [ngValue]="lib.id">{{ lib.name }} ({{ lib.path }})</option>
                     }
                     <option [ngValue]="IGNORE_VALUE">{{ 'import.path_wizard.option_ignore' | translate }}</option>
                   </select>
@@ -560,7 +560,7 @@
                   >
                     <option [ngValue]="null">—</option>
                     @for (lib of eligibleLocalLibraries('sonarr'); track lib.id) {
-                      <option [ngValue]="rf.id">{{ lib.name }} ({{ lib.path }})</option>
+                      <option [ngValue]="lib.id">{{ lib.name }} ({{ lib.path }})</option>
                     }
                     <option [ngValue]="IGNORE_VALUE">{{ 'import.path_wizard.option_ignore' | translate }}</option>
                   </select>


### PR DESCRIPTION
Build break after the RootFolder collapse: the wizard `<option>` inside the Radarr/Sonarr path-mapping list still referenced `rf.id` after the `@for` loop variable was renamed to `lib`. Two-line typo, replaces both occurrences with `lib.id`.