### PR TITLE
fix(settings): correct /medias/movies placeholder in library path input

### DIFF
--- a/client/src/app/features/settings/libraries/libraries.html
+++ b/client/src/app/features/settings/libraries/libraries.html
@@ -135,7 +135,7 @@
         <span class="label-text">{{ 'settings.libraries.path' | translate }}</span>
         <input type="text" class="input input-bordered input-sm w-full font-mono"
           [ngModel]="formPath()" (ngModelChange)="formPath.set($event)"
-          placeholder="/media/movies" />
+          placeholder="/medias/movies" />
         <span class="label-text-alt text-base-content/50 mt-1">{{ 'settings.libraries.path_hint' | translate }}</span>
       </label>
 


### PR DESCRIPTION
Single-character typo in the library path `<input>` placeholder: `/media/movies` → `/medias/movies` (matches the rest of the app's example paths).