### PR TITLE
fix(activity, media-detail): show indexer on queue rows + drop duplicate grab toast

### DIFF
--- a/backend/src/modules/download-clients/download-clients.service.ts
+++ b/backend/src/modules/download-clients/download-clients.service.ts
@@ -16,6 +16,8 @@ export interface QueueEntry extends QbittorrentTorrent {
   mediaId?: number;
   mediaTitle?: string;
   mediaType?: 'movie' | 'series';
+  /** Indexer the torrent was grabbed from (resolved through DownloadHistory). */
+  indexerName?: string;
   /** Download client status (Downloading, Seeding, Paused, Stalled…) */
   trackerStatus: string;
   /** App-level status (Awaiting import, Importing, Imported, Import failed…) */
@@ -244,7 +246,7 @@ export class DownloadClientsService {
         { status: 'completed' },
         { status: 'warning' },
       ],
-      relations: ['media'],
+      relations: ['media', 'indexer'],
     });
 
     for (const entry of results) {
@@ -256,6 +258,9 @@ export class DownloadClientsService {
         entry.mediaId = match.mediaId;
         entry.mediaTitle = match.media.title;
         entry.mediaType = match.media.type;
+      }
+      if (match?.indexer) {
+        entry.indexerName = match.indexer.name;
       }
 
       // App-level status from history

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -602,7 +602,6 @@
     "releases_error": "Impossible de charger les releases.",
     "grab_ok": "Envoyé au client de téléchargement.",
     "grab_success": "Téléchargement lancé avec succès.",
-    "grab_error": "Échec de l'ajout du téléchargement.",
     "profiles_section": "Profils",
     "language_profile_label": "Profil de langue",
     "profile_none": "Non défini",

--- a/client/src/app/core/services/api/download-clients-api.service.ts
+++ b/client/src/app/core/services/api/download-clients-api.service.ts
@@ -58,6 +58,7 @@ export interface QueueItem {
   mediaId?: number;
   mediaTitle?: string;
   mediaType?: MediaType;
+  indexerName?: string;
   statusMessage?: string;
 }
 

--- a/client/src/app/features/activity/queue/queue.html
+++ b/client/src/app/features/activity/queue/queue.html
@@ -111,8 +111,8 @@
             @if (item.num_seeds > 0 || item.num_leechs > 0) {
               <span>S:{{ item.num_seeds }} L:{{ item.num_leechs }}</span>
             }
-            @if (item.category) {
-              <span class="badge badge-ghost badge-xs">{{ item.category }}</span>
+            @if (item.indexerName) {
+              <span class="badge badge-ghost badge-xs">{{ item.indexerName }}</span>
             }
             @if (item.clientName) {
               <span class="badge badge-outline badge-xs">{{ item.clientName }}</span>

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -856,7 +856,6 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       this.toast.success(this.translate.instant('media_detail.grab_success'));
     } catch {
       this.grabState.update((s) => new Map(s).set('best', 'error'));
-      this.toast.error(this.translate.instant('media_detail.grab_error'));
     } finally {
       this.grabBusy.set(null);
     }
@@ -1192,7 +1191,6 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       this.toast.success(this.translate.instant('media_detail.grab_success'));
     } catch {
       this.epGrabState.update((s) => new Map(s).set('best', 'error'));
-      this.toast.error(this.translate.instant('media_detail.grab_error'));
     } finally {
       this.epGrabBusy.set(null);
     }
@@ -1207,7 +1205,6 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       this.toast.success(this.translate.instant('media_detail.grab_success'));
     } catch {
       this.epGrabState.update((s) => new Map(s).set(key, 'error'));
-      this.toast.error(this.translate.instant('media_detail.grab_error'));
     } finally {
       this.epGrabBusy.set(null);
     }
@@ -1239,7 +1236,6 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       await this.mediaService.grabSeason(mediaId, season.id, {});
       this.toast.success(this.translate.instant('media_detail.grab_success'));
     } catch {
-      this.toast.error(this.translate.instant('media_detail.grab_error'));
     } finally {
       this.seasonGrabBusy.set(null);
     }
@@ -1263,7 +1259,6 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       this.toast.success(this.translate.instant('media_detail.grab_success'));
     } catch {
       this.seasonReleaseGrabState.update((s) => new Map(s).set(key, 'error'));
-      this.toast.error(this.translate.instant('media_detail.grab_error'));
     } finally {
       this.seasonGrabBusy.set(null);
     }
@@ -1385,7 +1380,6 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       this.toast.success(this.translate.instant('media_detail.grab_success'));
     } catch {
       this.grabState.update((s) => new Map(s).set(key, 'error'));
-      this.toast.error(this.translate.instant('media_detail.grab_error'));
     } finally {
       this.grabBusy.set(null);
     }


### PR DESCRIPTION
## Activity queue
Each row's badge used to show the qBittorrent **category** (e.g. `fliks-movies`). Swap it for the **source indexer name**, resolved through the matching `DownloadHistory` row (`indexer` relation already in DB).

- Backend: `QueueEntry.indexerName` field populated when the history match has a non-null `indexer` relation. Queue fetch now loads `relations: ['media', 'indexer']`.
- Frontend: `QueueItem.indexerName` typed; the activity row swaps `{{ item.category }}` for `{{ item.indexerName }}`.

## Duplicate grab toast
Grabbing a release that failed (e.g. the magnet-redirect bug just fixed) surfaced **two** toasts on top of each other:
1. The backend message via the global HTTP error interceptor (the actually-useful one).
2. A generic `Échec de l'ajout du téléchargement` from the component's local catch.

Drop the local toast at the six call-sites in `media-detail.ts` — the interceptor message is more informative and matches the [no-error-banners convention](memory). `grabState` updates are preserved so the in-card icon still flips to error.

The now-orphan `media_detail.grab_error` i18n key is also removed.

## Test plan
- [ ] Trigger an indexer grab failure (e.g. via Lime before the magnet-redirect fix lands): exactly **one** toast appears, with the backend error message.
- [ ] Successful grab: still shows the success toast.
- [ ] Activity queue: rows display the source indexer name; if the history row has no indexer relation (manual import) the badge is hidden.
