### PR TITLE
feat(home): lift setup checklist out of the TV section wrapper

### DIFF
--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -1,8 +1,9 @@
-<div appTvSection class="flex flex-col gap-8">
+@if (auth.canAccessSettings()) {
+  <app-setup-checklist [padding]="true" />
+}
 
-    @if (auth.canAccessSettings()) {
-      <app-setup-checklist class="mt-4" />
-    }
+
+<div appTvSection class="flex flex-col gap-8">
 
     <!-- Libraries -->
     @if (libraries().length) {

--- a/client/src/app/shared/components/setup-checklist/setup-checklist.html
+++ b/client/src/app/shared/components/setup-checklist/setup-checklist.html
@@ -1,5 +1,6 @@
 @if (visibleItems().length > 0 || (showAll() && items().length > 0)) {
-  <section class="card bg-base-200/60 backdrop-blur-sm shadow-sm">
+  <div [class.py-4]="padding()">
+  <section class="card bg-base-200/60 backdrop-blur-sm shadow-sm" >
     <div class="card-body p-4 sm:p-5 gap-3">
       <header class="flex items-center justify-between gap-3 flex-wrap">
         <h2 class="card-title text-base">
@@ -76,6 +77,7 @@
           </li>
         }
       </ul>
-    </div>
-  </section>
+      </div>
+    </section>
+  </div>
 }

--- a/client/src/app/shared/components/setup-checklist/setup-checklist.ts
+++ b/client/src/app/shared/components/setup-checklist/setup-checklist.ts
@@ -68,6 +68,8 @@ export class SetupChecklistComponent implements OnInit {
       ).length,
   );
 
+  padding = input(false);
+
   ngOnInit() {
     // Reuse already-cached items on second mount; otherwise fetch.
     if (this.items().length === 0) void this.api.refresh();


### PR DESCRIPTION
Pulls `<app-setup-checklist>` above the home's `appTvSection` container so it renders as a regular full-width card instead of inheriting the horizontal-scroller styling. New `padding` input on the checklist component wraps it in a `py-4` shell when set from the home page.