### PR TITLE
fix(navigation): library tabs out of history + player back always exits

### DIFF
--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -385,10 +385,10 @@ export class LibraryComponent implements OnInit, OnDestroy {
   setViewMode(mode: LibraryViewMode) {
     if (this.viewMode() === mode) return;
     this.viewMode.set(mode);
-    // Push a history entry on tab switch so browser back walks through
-    // the previously-active tabs (Films / Suggestions / Genres). Same
-    // pattern as Plex / Jellyseerr web.
-    this.syncQueryParams(true);
+    // Tab switches stay on the same history entry — back from the
+    // library should return to the previous page, not walk through
+    // every tab the user clicked.
+    this.syncQueryParams(false);
     if (mode === 'suggestions') {
       void this.loadSuggestions();
     } else if (mode === 'genres') {
@@ -403,9 +403,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   pickGenre(genre: string) {
     this.selectedGenre.set(genre);
     this.viewMode.set('all');
-    // Push a real history entry so the browser back button returns
-    // to the Genres list instead of the page-before-library.
-    this.syncQueryParams(true);
+    this.syncQueryParams(false);
     void this.load(this.library()?.id);
   }
 
@@ -418,7 +416,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   pickCollection(id: number) {
     this.selectedCollectionId.set(id);
     this.viewMode.set('all');
-    this.syncQueryParams(true);
+    this.syncQueryParams(false);
     void this.load(this.library()?.id);
   }
 

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -2057,13 +2057,9 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   };
 
   private onPlayerBackEvent = () => {
-    // Back/Escape progression while watching: dropdowns close first (via
-    // DismissableStack in player-controls), then the controls bar itself,
-    // and only when the screen is truly clean does back actually leave.
-    if (this.controlsVisible()) {
-      this.hideControls();
-      return;
-    }
+    // Hardware back / gesture back always leaves the player, regardless
+    // of whether the controls bar is visible. Dropdowns inside the bar
+    // still close first through DismissableStack in app.ts.
     this.onBack();
   };
 


### PR DESCRIPTION
## Library
Tab switches (Films / Suggestions / Genres / Collections) and the genre/collection drill-ins used to push real history entries (`syncQueryParams(true)`). Browser-back walked the user through every tab they had visited before actually leaving the library. They now `replaceUrl` so back jumps straight to the page that brought the user in.

## Player
`onPlayerBackEvent` checked `controlsVisible()` and only called `onBack()` on the second press — first one hid the controls bar. Drop the branch: hardware back / gesture back always exits the player. Dropdowns inside the controls still close first via `DismissableStack` upstream in `app.ts`.