### PR TITLE
fix(tv): fanart visible through veils on Chromium-85 builds

### DIFF
--- a/client/src/app/shared/components/background/background.html
+++ b/client/src/app/shared/components/background/background.html
@@ -24,9 +24,14 @@
       [class.opacity-0]="activeLayer() !== 'B' || !imageVisible()"
     />
   }
-  <!-- Veil is permanent: when no background is set, the 90 % base-100
-       tint over the body's solid base-100 is a no-op (same colour);
-       when an image is fading in/out beneath it, the tint stays
-       constant so we never flash an un-tinted frame. -->
-  <div class="absolute inset-0 bg-base-100/95"></div>
+  <!-- Veil is permanent: when no background is set, the tint over
+       the body's solid base-100 is a no-op (same colour); when an
+       image is fading in/out beneath it, the tint stays constant
+       so we never flash an un-tinted frame.
+       Custom class (instead of Tailwind's `bg-base-100/N`) because
+       Tailwind v4 emits `color-mix(in oklab, …)` for that helper,
+       which Chromium 85 (Tizen TV) doesn't support — the preset-env
+       fallback drops the alpha and the veil ends up 100% opaque,
+       killing the fanart. Plain `rgba()` is universally supported. -->
+  <div class="absolute inset-0 app-bg-veil"></div>
 </div>

--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -13,8 +13,10 @@
       [class.lg:hidden]="device.isDesktop() || (device.isTv() && navbar.effectiveSidebarPinned())"
       [class.md:hidden]="device.isTablet() && navbar.effectiveSidebarPinned()"
       [class.-translate-y-full]="navbarHidden()"
-      [class.bg-base-100]="!navbarTransparent()"
-      [class.shadow-sm]="!navbarTransparent()"
+      [class.bg-base-100]="!navbarTransparent() && !background.url()"
+      [class.app-navbar-veil]="!navbarTransparent() && !!background.url()"
+      [class.backdrop-blur-sm]="!navbarTransparent() && !!background.url()"
+      [class.shadow-sm]="!navbarTransparent() && !background.url()"
       [class.bg-transparent]="navbarTransparent()"
       [class.text-white]="navbarTransparent()"
       [class.nav-hero-icons]="navbarTransparent()"
@@ -250,7 +252,7 @@
     <label for="sidebar" [attr.aria-label]="'nav.close_menu' | translate" class="drawer-overlay"></label>
     <aside class="w-64 min-h-full flex flex-col"
            [class.bg-base-100]="!background.url()"
-           [class.bg-base-100/40]="!!background.url()"
+           [class.app-sidebar-veil]="!!background.url()"
            [class.backdrop-blur-sm]="!!background.url()"
            style="padding-top: calc(env(safe-area-inset-top, 0px) / 2 )">
       <div class="p-4 border-b border-base-200 flex items-center gap-2">

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -35,6 +35,38 @@
   white-space: normal;
 }
 
+/* Global background veil — sits over the fanart image inside
+   `<app-background>`. Hard-coded rgba so the rule survives the
+   Tizen / webOS downlevel pass (Chromium 85 doesn't grok
+   `color-mix`, and the preset-env fallback for Tailwind's
+   `bg-base-100/N` drops the alpha and yields a 100%-opaque veil).
+   `#1d232a` matches daisyUI's dark theme `--color-base-100`. */
+.app-bg-veil {
+  background-color: rgba(29, 35, 42, 0.95);
+}
+
+/* Sidebar veil when a fanart background is showing — frosted
+   look without depending on Tailwind's color-mix-based
+   `bg-base-100/40`. Phones/tablets/desktop: 40 % alpha. TV: a
+   little stronger so the menu text doesn't bleed into the fanart. */
+.app-sidebar-veil {
+  background-color: rgba(29, 35, 42, 0.4);
+}
+body.tv .app-sidebar-veil {
+  background-color: rgba(29, 35, 42, 0.55);
+}
+
+/* Topbar veil when a fanart background is showing. Non-TV gets a
+   light frosted-glass tint; TV stays fully transparent so the
+   fanart reads cleanly across the top of the screen at 10-foot
+   viewing distance. */
+.app-navbar-veil {
+  background-color: rgba(29, 35, 42, 0.4);
+}
+body.tv .app-navbar-veil {
+  background-color: transparent;
+}
+
 /* Native app (Capacitor): offset content from system bars */
 body.native {
   padding-left: env(safe-area-inset-left);


### PR DESCRIPTION
Tailwind v4's `bg-base-100/N` helper emits `color-mix(in oklab, …)`. Chromium 85 (Tizen 6.5 / webOS 6) doesn't support `color-mix`, and the postcss-preset-env fallback in our TV downlevel pass drops the alpha — the veils that should let the fanart show through end up 100 % opaque, so on TV:
- the global `<app-background>` veil hid the image entirely,
- the sidebar panel was solid when a background was active,
- the top navbar's `bg-base-100` painted over the image at the top of the screen.

Each veil is now a small custom rule using literal `rgba(29, 35, 42, α)` (same `#1d232a` as daisyUI's dark `--color-base-100`) so the downlevel pass leaves it intact:
- `.app-bg-veil` (95 %) — global background tint, uniform across form factors.
- `.app-sidebar-veil` (40 % / 55 % on TV) — frosted drawer panel.
- `.app-navbar-veil` (40 % on phone/tablet/desktop, fully transparent on TV) — top navbar reads cleanly across the screen at 10-foot distance.

`backdrop-blur-sm` stays on the sidebar / navbar for non-TV form factors.