### PR TITLE
fix(player): restore 'back hides controls first' only on TV

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -2057,9 +2057,15 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   };
 
   private onPlayerBackEvent = () => {
-    // Hardware back / gesture back always leaves the player, regardless
-    // of whether the controls bar is visible. Dropdowns inside the bar
-    // still close first through DismissableStack in app.ts.
+    // TV: D-pad navigation needs an explicit "dismiss controls" step
+    // before exiting the player, so back/Return on the remote first
+    // closes the controls bar, then leaves on the second press.
+    // Phones and tablets get the direct exit — touch users dismiss
+    // controls by tapping the video surface, not via hardware back.
+    if (this.device.isTv() && this.controlsVisible()) {
+      this.hideControls();
+      return;
+    }
     this.onBack();
   };
 


### PR DESCRIPTION
Hardware back was changed to always exit the player. TV users relied on the legacy progression (Return on the remote → hide controls; Return again → exit) because D-pad navigation has no equivalent of "tap the video surface to dismiss controls".

Re-add the dismiss-first guard, but only when `device.isTv()`. Phones / tablets / desktop keep the direct-exit behaviour from the previous fix.