### PR TITLE
feat(player): episode still as backdrop + progressive load + CW thumbnails

### DIFF
--- a/backend/src/modules/streaming/playback.service.ts
+++ b/backend/src/modules/streaming/playback.service.ts
@@ -42,6 +42,8 @@ export interface ContinueWatchingItem {
   mediaType: string;
   posterUrl: string | null;
   fanartUrl: string | null;
+  /** Episode still — null for movie rows or when TMDB had no still. */
+  stillUrl: string | null;
   episodeLabel: string | null;
 }
 
@@ -343,6 +345,7 @@ export class PlaybackService implements OnModuleInit {
               ps.id, ps."mediaId", ps."mediaFileId", ps."episodeId",
               ps."positionSeconds", ps."durationSeconds", ps."lastPlayedAt",
               m.title AS "mediaTitle", m."posterUrl", m."fanartUrl",
+              NULL::text AS "stillUrl",
               CASE WHEN ps."durationSeconds" > 0
                    THEN ROUND((ps."positionSeconds" / ps."durationSeconds") * 100)
                    ELSE 0 END AS "progressPercent"
@@ -429,6 +432,7 @@ export class PlaybackService implements OnModuleInit {
         us."lastPlayedAt",
         m.title AS "mediaTitle",
         m."posterUrl", m."fanartUrl",
+        e."stillUrl",
         'S' || LPAD(s."seasonNumber"::text, 2, '0') || 'E' || LPAD(e."episodeNumber"::text, 2, '0')
           || COALESCE(' - ' || e.title, '') AS "episodeLabel",
         CASE WHEN COALESCE(ps_next."durationSeconds", c."durationSeconds", 0) > 0

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -155,6 +155,7 @@ export interface ContinueWatchingItem {
   mediaType: string;
   posterUrl: string | null;
   fanartUrl: string | null;
+  stillUrl: string | null;
   episodeLabel: string | null;
 }
 

--- a/client/src/app/core/services/playable-media.service.ts
+++ b/client/src/app/core/services/playable-media.service.ts
@@ -11,6 +11,9 @@ export interface PlayContext {
   title: string;
   episodeTitle?: string;
   fanartUrl?: string | null;
+  /** Episode thumbnail to use as the eager backdrop instead of the
+   *  series fanart when playing an episode. Optional. */
+  stillUrl?: string | null;
   streamInfo?: any;
 }
 
@@ -43,13 +46,18 @@ export class PlayableMediaService {
       const qp: any = { mediaId: ctx.mediaId };
       if (ctx.episodeId) qp.episodeId = ctx.episodeId;
       if (fromStart) qp.t = 0;
-      // Pass fanartUrl via router state so the player can paint the
-      // backdrop on its first tick — without it the fanart only appears
-      // after the media API call returns AND the image finishes
-      // downloading (~1s+ on cold network), leaving a long black phase.
+      // Pass fanartUrl + stillUrl via router state so the player can
+      // paint the backdrop on its first tick — without it the image
+      // only appears after the media API call returns AND the image
+      // finishes downloading (~1s+ on cold network), leaving a long
+      // black phase. Player prefers `stillUrl` over `fanartUrl` when
+      // both are present (episode-accurate backdrop on series).
       this.router.navigate(['/watch', ctx.fileId], {
         queryParams: qp,
-        state: { fanartUrl: ctx.fanartUrl ?? null },
+        state: {
+          fanartUrl: ctx.fanartUrl ?? null,
+          stillUrl: ctx.stillUrl ?? null,
+        },
       });
     }
   }

--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -28,7 +28,7 @@
         @for (item of continueWatching(); track item.id) {
           <app-media-card [aspect]="'landscape'"
             [attr.data-home-focus]="'cw:' + item.id"
-            [imageUrl]="item.fanartUrl ?? item.posterUrl"
+            [imageUrl]="item.stillUrl ?? item.fanartUrl ?? item.posterUrl"
             [title]="item.mediaTitle"
             [subtitle]="item.episodeLabel ?? undefined"
             [progressPercent]="item.progressPercent"

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -326,6 +326,7 @@ export class HomeComponent implements OnInit, OnDestroy {
       title: item.mediaTitle,
       episodeTitle: item.episodeLabel ?? undefined,
       fanartUrl: item.fanartUrl ?? item.posterUrl ?? null,
+      stillUrl: item.stillUrl ?? null,
     }, false);
   }
 

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -128,6 +128,7 @@ export class MediaDetailSeasonsComponent {
       title: m.title,
       episodeTitle: ep.title ?? undefined,
       fanartUrl: m.fanartUrl ?? null,
+      stillUrl: ep.stillUrl ?? null,
       streamInfo: (files[0] as any).streamInfo,
     }, false);
   }

--- a/client/src/app/features/player/player.html
+++ b/client/src/app/features/player/player.html
@@ -7,12 +7,38 @@
   [class.hidden]="castService.isConnected()"
   (mousemove)="device.isTouch() || isNative ? null : showControls()"
 >
-  <!-- Fanart backdrop until video renders its first frame. Rendered for
-       both web (Shaka) and native (ExoPlayer) — on native the WebView is
-       transparent so the fanart in HTML covers the ExoPlayer surface
-       behind it during the loading phase. -->
+  <!-- Backdrop until video renders its first frame. Rendered for both
+       web (Shaka) and native (ExoPlayer) — on native the WebView is
+       transparent so the HTML backdrop covers the ExoPlayer surface
+       behind it during the loading phase.
+
+       Progressive load: thumb variant (e.g. `?size=thumb`, ~10 KB)
+       paints first thanks to its smaller payload, then the full-res
+       version stacked on top fades in once it has decoded. Falls
+       back to the same image at both layers for remote / non-`/api/
+       images/...` URLs. -->
   @if (!videoStarted()) {
-    <div class="absolute inset-0 z-1" [style.background-image]="fanartUrl() ? 'url(' + fanartUrl() + ')' : 'none'" style="background-size: cover; background-position: center; background-color: #000"></div>
+    <div class="absolute inset-0 z-1 bg-black">
+      @if (fanartThumbUrl()) {
+        <img
+          [src]="fanartThumbUrl()!"
+          alt=""
+          fetchpriority="high"
+          decoding="async"
+          class="absolute inset-0 w-full h-full object-cover"
+        />
+      }
+      @if (fanartUrl()) {
+        <img
+          [src]="fanartUrl()!"
+          alt=""
+          fetchpriority="high"
+          decoding="async"
+          class="absolute inset-0 w-full h-full object-cover opacity-0 transition-opacity duration-300"
+          (load)="$any($event.target).classList.remove('opacity-0')"
+        />
+      }
+    </div>
   }
 
   <video

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -9,6 +9,7 @@ import {
   effect,
   inject,
   signal,
+  untracked,
   viewChild,
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -166,6 +167,13 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   private readonly qualityManager = inject(QualityManagerService);
   readonly device = inject(DeviceService);
 
+  /** Reset the singleton PlayerStateService synchronously at field-init
+   *  time so that effects declared further down (e.g. `autoHideOnPlay`)
+   *  don't see lingering `videoStarted=true` / `paused=false` from the
+   *  previous session. `state.reset()` is also called in
+   *  `ngAfterViewInit` but that happens after the first effect pass. */
+  private readonly _stateReset = (this.state.reset(), null);
+
   private readonly videoEl = viewChild<ElementRef<HTMLVideoElement>>('videoElement');
   private readonly containerEl = viewChild<ElementRef<HTMLDivElement>>('playerContainer');
 
@@ -224,12 +232,12 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
   // Component-owned signals (not delegated)
   readonly playbackRate = signal(1);
-  /** Controls start visible on browser (pointer present, the user
-   *  expects to see the affordances immediately) and hidden on native
-   *  (touch / TV — the user taps / moves the remote to reveal them).
-   *  The auto-hide timer that runs during playback toggles this back
-   *  to false after inactivity regardless of the initial state. */
-  readonly controlsVisible = signal(!Capacitor.isNativePlatform());
+  /** Controls start visible everywhere — the user is staring at a
+   *  paused / loading frame and expects to see the affordances. A
+   *  dedicated effect (see `playbackVisibilityEffect`) flips them
+   *  off the moment playback actually starts, and the auto-hide
+   *  timer takes over from there during the rest of the session. */
+  readonly controlsVisible = signal(true);
   readonly inPipMode = signal(false);
   readonly pipAvailable = signal(true);
   private readonly isLandscape = signal(screen.orientation?.type?.startsWith('landscape') ?? false);
@@ -332,6 +340,26 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     Pip.updatePlaybackState({ playing: !this.paused() }).catch(() => {});
   });
 
+  /** Hide the controls bar the moment the first frame of the new
+   *  session is painted. Uses `videoStarted` (per-session, set after
+   *  the engine actually surfaces a frame) rather than `paused` —
+   *  the `paused` signal is on a singleton service, so opening a
+   *  second video would inherit `paused = false` from the previous
+   *  session and the effect would fire before this video has even
+   *  loaded.
+   *  `controlsVisible` is read through `untracked` so the effect
+   *  only reacts to videoStarted transitions — without it, the
+   *  user moving the mouse (which calls `showControls()`) would
+   *  re-fire this effect and re-hide them immediately, making the
+   *  cursor / bar impossible to keep visible. Subsequent pause /
+   *  resume cycles fall through to the existing auto-hide timer +
+   *  user-interaction reveal. */
+  private readonly autoHideOnPlayEffect = effect(() => {
+    if (this.videoStarted() && untracked(() => this.controlsVisible())) {
+      this.controlsVisible.set(false);
+    }
+  });
+
   /** Re-apply native subtitle style on controls show/hide so the bottom-margin
       bump kicks in. Browser playback uses CSS instead — see styles below. */
   private readonly subtitleControlsMarginEffect = effect(() => {
@@ -355,6 +383,18 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   readonly mediaTitle = signal('');
   readonly episodeTitle = signal('');
   readonly fanartUrl = signal<string | null>(null);
+
+  /** Low-quality variant of `fanartUrl` for the loading backdrop's
+   *  LQIP layer. Only kicks in for our own `/api/images/...` URLs
+   *  (which support `?size=thumb`); remote / data URLs fall through
+   *  as-is so the layer paints the same image as the full-res one. */
+  readonly fanartThumbUrl = computed(() => {
+    const url = this.fanartUrl();
+    if (!url) return null;
+    if (!url.includes('/api/images/')) return url;
+    const sep = url.includes('?') ? '&' : '?';
+    return `${url}${sep}size=thumb`;
+  });
   private playbackInfo: PlaybackInfoResponse | null = null;
 
   readonly playerStats = computed<PlayerStats | null>(() => {
@@ -575,13 +615,17 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       screen.orientation?.addEventListener('change', this.onOrientationChange);
     }
 
-    // Eager fanart from router state — set BEFORE any await so the backdrop
-    // renders on the first tick of the loading phase instead of popping in
-    // only after the media API + image download (~1s+ later). The image is
-    // already in the browser cache from the source tile/header.
-    const navState = (this.router.getCurrentNavigation()?.extras?.state ?? history.state) as { fanartUrl?: string | null } | null;
-    if (navState?.fanartUrl) {
-      this.fanartUrl.set(this.serverConfig.resolveUrl(navState.fanartUrl));
+    // Eager backdrop from router state — set BEFORE any await so the
+    // loading screen renders on the first tick instead of popping in
+    // only after the media API + image download (~1s+ later). The
+    // image is already in the browser cache from the source tile/header.
+    // `stillUrl` (episode thumbnail) wins over `fanartUrl` when both
+    // are passed: a series viewer recognises the episode they just
+    // selected, not the show's hero.
+    const navState = (this.router.getCurrentNavigation()?.extras?.state ?? history.state) as { fanartUrl?: string | null; stillUrl?: string | null } | null;
+    const eagerBackdrop = navState?.stillUrl ?? navState?.fanartUrl;
+    if (eagerBackdrop) {
+      this.fanartUrl.set(this.serverConfig.resolveUrl(eagerBackdrop));
     }
 
     const qp = this.route.snapshot.queryParams;
@@ -652,6 +696,13 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
             if (ep) {
               const label = `S${season.seasonNumber}:E${ep.episodeNumber}`;
               this.episodeTitle.set(ep.title ? `${label} - ${ep.title}` : label);
+              // Prefer the episode still (full quality stored locally
+              // by ImageService.downloadAndStore('episode', ...)) over
+              // the series fanart so the loading backdrop matches
+              // exactly what's about to play.
+              if (ep.stillUrl) {
+                this.fanartUrl.set(this.serverConfig.resolveUrl(ep.stillUrl));
+              }
               break;
             }
           }


### PR DESCRIPTION
## Player backdrop
- Prefer the episode still over the series fanart for the loading backdrop when an episode is selected. `/api/images/episode/<id>` is already stored locally at full resolution by `ImageService.downloadAndStore('episode', …)`.
- Progressive load: two stacked `<img>` — `?size=thumb` paints first (already in browser cache from the source tile), full-res fades in on `load`. New `fanartThumbUrl` computed derives the thumb URL from `fanartUrl` when it's a `/api/images/...` path. The legacy `<div [style.background-image]>` is replaced by the stack.

## Plumbing
- `PlayContext.stillUrl?: string | null`. `PlayableMediaService.play` forwards it via router state alongside `fanartUrl`.
- `ContinueWatchingItem.stillUrl` exposed on the API: backend query joins `episodes.stillUrl` for series rows (`NULL::text` for movie rows). Frontend home card consumes `item.stillUrl ?? item.fanartUrl ?? item.posterUrl`.
- `media-detail-seasons` and `home.playContinueWatching` pass `ep.stillUrl` / `item.stillUrl` to `play()`.

## Controls visibility on launch
- `controlsVisible` initial = `true` everywhere — the user expects to see the affordances on the still while the engine loads.
- New `autoHideOnPlayEffect` watches `videoStarted` (per-session, set after first frame) and hides controls once. `controlsVisible` is read via `untracked` so mouse-move / tap reveals don't re-trigger the effect (otherwise the cursor disappeared the moment the user moved it on the player).
- `_stateReset` field initializer flushes the singleton `PlayerStateService` synchronously, so opening a second video doesn't inherit `videoStarted=true` from the previous session and hide controls before the new playback has even loaded.