### PR TITLE
feat(nav): keyboard spatial navigation on desktop / laptop too

### DIFF
--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -40,6 +40,7 @@ export class App implements OnInit, OnDestroy {
   private backButtonListener?: { remove: () => Promise<void> };
   private resumeListener?: { remove: () => Promise<void> };
   private tizenKeyListener?: (e: KeyboardEvent) => void;
+  private escapeKeyListener?: (e: KeyboardEvent) => void;
 
   ngOnInit() {
     this.auth.hydrateFromServer();
@@ -76,6 +77,22 @@ export class App implements OnInit, OnDestroy {
         this.resumeListener = handle;
       });
     }
+
+    // Browser/desktop Escape mirrors the hardware back button: closes the
+    // topmost dismissable layer (open dropdown, bottom sheet, modal) if
+    // any, else falls through to route-level back. Skip when focus is
+    // inside a text input so Escape can still e.g. cancel an inline edit
+    // without navigating away.
+    this.escapeKeyListener = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
+      e.preventDefault();
+      e.stopPropagation();
+      this.handleBackButton();
+    };
+    window.addEventListener('keydown', this.escapeKeyListener, true);
 
     // Samsung Tizen "Return" remote key. Capacitor's `backButton` event
     // never fires here (we're not running through Capacitor on Tizen), so
@@ -153,6 +170,9 @@ export class App implements OnInit, OnDestroy {
     this.resumeListener?.remove();
     if (this.tizenKeyListener) {
       window.removeEventListener('keydown', this.tizenKeyListener);
+    }
+    if (this.escapeKeyListener) {
+      window.removeEventListener('keydown', this.escapeKeyListener, true);
     }
   }
 }

--- a/client/src/app/core/interceptors/cache.interceptor.ts
+++ b/client/src/app/core/interceptors/cache.interceptor.ts
@@ -24,6 +24,12 @@ const CACHEABLE_PREFIXES = [
   '/api/playback/history',
   '/api/playback/watched-ids',
   '/api/libraries/mine',
+  // Form-population endpoints — change rarely, dominate the media-detail
+  // page load when reopened (profiles modal + library picker). SWR keeps
+  // them fresh in the background without blocking render.
+  '/api/libraries',
+  '/api/profiles/quality',
+  '/api/profiles/language',
 ];
 
 const EXCLUDED_PREFIXES = [
@@ -41,7 +47,7 @@ const EXCLUDED_PATTERNS = [
 
 const DETAIL_PATTERN = /^\/api\/media\/\d+$/;
 const TTL_LIST = 5 * 60_000;
-const TTL_DETAIL = 60 * 60_000;
+const TTL_DETAIL = 4 * 60 * 60_000;
 
 interface CacheEntry {
   url: string;

--- a/client/src/app/core/services/playable-media.service.ts
+++ b/client/src/app/core/services/playable-media.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { CastService } from './cast.service';
 import { CastPlayerService } from './cast-player.service';
+import { MediaService } from './api/media.service';
 import { StreamingApiService } from './api/streaming-api.service';
 
 export interface PlayContext {
@@ -27,6 +28,7 @@ export class PlayableMediaService {
   readonly castService = inject(CastService);
   private readonly castPlayer = inject(CastPlayerService);
   private readonly streamingApi = inject(StreamingApiService);
+  private readonly mediaService = inject(MediaService);
 
   /** Play a media file — Cast if connected, otherwise navigate to player. */
   async play(ctx: PlayContext, fromStart: boolean) {
@@ -59,6 +61,15 @@ export class PlayableMediaService {
           stillUrl: ctx.stillUrl ?? null,
         },
       });
+      // Warm the stale-while-revalidate cache for the media-detail page
+      // the user will land on when they back out of the player. The
+      // detail's `getOne` / cast / crew responses get stored under
+      // `/api/media/<id>*` keys in `fliks-api-cache` (60 min TTL), so the
+      // back-navigation renders instantly instead of spinning on a cold
+      // network round-trip.
+      void this.mediaService.getOne(ctx.mediaId).catch(() => {});
+      void this.mediaService.getCast(ctx.mediaId).catch(() => {});
+      void this.mediaService.getCrew(ctx.mediaId).catch(() => {});
     }
   }
 

--- a/client/src/app/core/services/select-picker.service.ts
+++ b/client/src/app/core/services/select-picker.service.ts
@@ -46,7 +46,12 @@ export class SelectPickerService {
   }
 
   close() {
+    const sel = this.currentSelect;
     this.open.set(false);
     this.currentSelect = null;
+    // Restore focus to the trigger so a subsequent Enter / Space re-opens
+    // the picker — without this the browser drops focus to <body> when the
+    // popover unmounts and the user has to Tab back to the select.
+    sel?.focus({ preventScroll: true });
   }
 }

--- a/client/src/app/core/services/tv-spatial-nav.service.ts
+++ b/client/src/app/core/services/tv-spatial-nav.service.ts
@@ -166,20 +166,27 @@ export class TvSpatialNavService {
     const isMultiLineText = tag === 'TEXTAREA' || tag === 'OPTION' || !!active?.isContentEditable;
     if (isMultiLineText) return;
 
-    // Desktop / laptop users expect native arrow handling everywhere inside
-    // form fields (caret in text, value cycle in select / range / number /
-    // date, etc.). Get out of the way entirely for any input + select when
-    // we're not in TV mode — they fall through to the browser. On TV the
-    // narrower skip list below preserves the existing D-pad semantics.
-    if (!this.tv.isTv() && (tag === 'INPUT' || tag === 'SELECT')) return;
+    // Inputs without native arrow handling — checkbox/radio/button-style
+    // — must always fall through to the spatial-nav tree, regardless of
+    // platform, or the user gets focus-trapped on the field. Toggles
+    // (DaisyUI `.toggle` is a styled `<input type="checkbox">`) are the
+    // canonical example: no caret, no value cycle, arrows would just
+    // dead-end without this.
+    const NATIVE_INPUT_TYPES = new Set([
+      'text', 'email', 'password', 'search', 'tel', 'url',
+      'number', 'range', 'date', 'time', 'datetime-local', 'month', 'week',
+    ]);
+    const isInputWithNativeArrows = tag === 'INPUT' && NATIVE_INPUT_TYPES.has(inputType ?? 'text');
+
+    // Desktop / laptop: defer entirely to native for fields that actually
+    // use arrows (caret in text, value cycle in number / range / date /
+    // select). TV keeps the narrower skip list below for the same fields.
+    if (!this.tv.isTv() && (isInputWithNativeArrows || tag === 'SELECT')) return;
 
     // TV mode: text-style inputs own horizontal arrows (caret); other arrow
     // directions and other inputs escape to the spatial-nav tree so the
     // D-pad user isn't trapped on a field.
-    const isSingleLineTextInput =
-      tag === 'INPUT' &&
-      !['checkbox', 'radio', 'range', 'button', 'submit', 'reset'].includes(inputType ?? '');
-    if (isSingleLineTextInput && (dir === 'left' || dir === 'right')) return;
+    if (isInputWithNativeArrows && inputType !== 'range' && (dir === 'left' || dir === 'right')) return;
     // Native `<select>` cycles its options on arrow keys (changing the
     // value silently). Always block that on TV. We still try to move focus
     // — if a tree-aware neighbour exists, the user goes there; otherwise

--- a/client/src/app/core/services/tv-spatial-nav.service.ts
+++ b/client/src/app/core/services/tv-spatial-nav.service.ts
@@ -181,7 +181,11 @@ export class TvSpatialNavService {
     // Desktop / laptop: defer entirely to native for fields that actually
     // use arrows (caret in text, value cycle in number / range / date /
     // select). TV keeps the narrower skip list below for the same fields.
-    if (!this.tv.isTv() && (isInputWithNativeArrows || tag === 'SELECT')) return;
+    // `<select appTvSelect>` opts out — the directive routes opens through
+    // SelectPickerService, so arrow keys should escape to spatial nav
+    // instead of silently cycling the underlying native value.
+    const isPickerSelect = tag === 'SELECT' && active?.hasAttribute('appTvSelect');
+    if (!this.tv.isTv() && (isInputWithNativeArrows || (tag === 'SELECT' && !isPickerSelect))) return;
 
     // TV mode: text-style inputs own horizontal arrows (caret); other arrow
     // directions and other inputs escape to the spatial-nav tree so the
@@ -208,7 +212,14 @@ export class TvSpatialNavService {
     const next = this.findNeighbor(dir);
     e.preventDefault();
     if (next) {
-      next.focus({ preventScroll: false });
+      // `preventScroll: true` keeps the browser's instant auto-scroll from
+      // firing on every focus tick. We then call `scrollIntoView` smooth
+      // with `block: 'nearest'` so an off-screen card animates in, while
+      // horizontal-scroller's `focusin` handler owns vertical row-top
+      // alignment when focus crosses rows. Two coordinated smooth
+      // scrolls instead of a jarring instant→smooth one-two punch.
+      next.focus({ preventScroll: true });
+      next.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'smooth' });
       return;
     }
     // No focusable neighbour: scroll the page manually so the user can

--- a/client/src/app/core/services/tv-spatial-nav.service.ts
+++ b/client/src/app/core/services/tv-spatial-nav.service.ts
@@ -1,8 +1,12 @@
-import { Injectable, inject, DestroyRef, effect } from '@angular/core';
+import { Injectable, inject, DestroyRef } from '@angular/core';
 import { TvService } from './tv.service';
 
 /**
- * Spatial navigation for D-pad input on Android TV.
+ * Spatial navigation for D-pad input on Android TV — and keyboard
+ * arrow keys on desktop / laptop. Same algorithm, same container
+ * tree; the gating is removed so any pointer device benefits. The
+ * TV-only quirks (forced initial focus, `body.tv` 10-foot styling)
+ * stay scoped via the `tv.isTv()` checks they already had.
  *
  * Two cooperating layers:
  *
@@ -45,11 +49,11 @@ export class TvSpatialNavService {
   private readonly containers = new Map<HTMLElement, ContainerNode>();
 
   constructor() {
-    // Use an effect so we react to isTv flipping later (e.g. when TvService is
-    // instantiated after us, or if detection is updated post-bootstrap).
-    effect(() => {
-      if (this.tv.isTv() && !this.bound) this.bind();
-    });
+    // Bind unconditionally — desktop / laptop users press arrow keys
+    // expecting spatial focus moves, and the handler is a no-op for
+    // any non-arrow key. Touch-only phones never fire arrow keydowns
+    // so binding there has no observable effect.
+    this.bind();
   }
 
   private bind() {
@@ -71,7 +75,12 @@ export class TvSpatialNavService {
     // means D-pad events are consumed by the native View and never reach JS.
     // Pushing focus to the first interactive element guarantees subsequent
     // keydowns are dispatched into our handler.
-    queueMicrotask(() => this.focusFirstIfNoFocus());
+    // Desktop / laptop opt out — stealing focus on bootstrap from whatever
+    // the browser would otherwise restore (e.g. a form input on a refresh)
+    // is hostile, and arrow keys reach the body fine anyway.
+    if (this.tv.isTv()) {
+      queueMicrotask(() => this.focusFirstIfNoFocus());
+    }
   }
 
   /**
@@ -151,25 +160,29 @@ export class TvSpatialNavService {
     // still ship `keyCode` 37/38/39/40 — accept either form.
     const dir = ARROW_TO_DIR[e.key] ?? KEYCODE_TO_DIR[e.keyCode];
     if (!dir) return;
-    // Skip if focus is inside a text-style input, a <select>, or its
-    // open-picker option — they own arrow-key handling natively (caret
-    // movement / option cycling). Checkbox/radio/range have no caret, so
-    // spatial nav keeps handling them.
     const active = document.activeElement as HTMLElement | null;
     const tag = active?.tagName;
     const inputType = (active as HTMLInputElement | null)?.type;
+    const isMultiLineText = tag === 'TEXTAREA' || tag === 'OPTION' || !!active?.isContentEditable;
+    if (isMultiLineText) return;
+
+    // Desktop / laptop users expect native arrow handling everywhere inside
+    // form fields (caret in text, value cycle in select / range / number /
+    // date, etc.). Get out of the way entirely for any input + select when
+    // we're not in TV mode — they fall through to the browser. On TV the
+    // narrower skip list below preserves the existing D-pad semantics.
+    if (!this.tv.isTv() && (tag === 'INPUT' || tag === 'SELECT')) return;
+
+    // TV mode: text-style inputs own horizontal arrows (caret); other arrow
+    // directions and other inputs escape to the spatial-nav tree so the
+    // D-pad user isn't trapped on a field.
     const isSingleLineTextInput =
       tag === 'INPUT' &&
       !['checkbox', 'radio', 'range', 'button', 'submit', 'reset'].includes(inputType ?? '');
-    const isMultiLineText = tag === 'TEXTAREA' || tag === 'OPTION' || !!active?.isContentEditable;
-    // Single-line text inputs only have a horizontal caret — left/right belong
-    // to the field, but up/down should escape to the spatial-nav tree so D-pad
-    // users on TV aren't trapped on the input.
     if (isSingleLineTextInput && (dir === 'left' || dir === 'right')) return;
-    if (isMultiLineText) return;
     // Native `<select>` cycles its options on arrow keys (changing the
-    // value silently). Always block that. We still try to move focus —
-    // if a tree-aware neighbour exists, the user goes there; otherwise
+    // value silently). Always block that on TV. We still try to move focus
+    // — if a tree-aware neighbour exists, the user goes there; otherwise
     // we preventDefault below and the focus stays put. Either way, the
     // value of the select isn't mutated by a stray arrow press.
     if (tag === 'SELECT') {

--- a/client/src/app/features/activity/queue/queue.html
+++ b/client/src/app/features/activity/queue/queue.html
@@ -54,33 +54,25 @@
                   {{ item.status }}
                 </span>
               }
-              <div class="dropdown dropdown-end">
-                <label tabindex="0" class="btn btn-ghost btn-xs btn-circle">
+              <app-dropdown-menu placement="bottom-end">
+                <button trigger type="button" class="btn btn-ghost btn-xs btn-circle">
                   <svg lucideEllipsisVertical class="h-4 w-4"></svg>
-                </label>
-                <ul tabindex="0" class="dropdown-content menu menu-sm bg-base-200 rounded-box shadow-lg z-10 w-56 p-2">
-                  @if (item.status === 'Imported' || item.status === 'Quality not upgraded' || item.status === 'Import failed' || (!item.status && item.progress >= 1)) {
-                    <li>
-                      <button (click)="reimportAndTrigger(item)">
-                        <svg lucideRotateCcw class="h-4 w-4"></svg>
-                        {{ 'activity.reimport' | translate }}
-                      </button>
-                    </li>
-                  }
-                  <li>
-                    <button (click)="removeTorrent(item, false)">
-                      <svg lucideTrash2 class="h-4 w-4"></svg>
-                      {{ 'activity.remove_torrent' | translate }}
-                    </button>
-                  </li>
-                  <li>
-                    <button class="text-error" (click)="removeTorrent(item, true)">
-                      <svg lucideTrash2 class="h-4 w-4"></svg>
-                      {{ 'activity.remove_torrent_with_files' | translate }}
-                    </button>
-                  </li>
-                </ul>
-              </div>
+                </button>
+                @if (item.status === 'Imported' || item.status === 'Quality not upgraded' || item.status === 'Import failed' || (!item.status && item.progress >= 1)) {
+                  <button type="button" class="dropdown-item text-white" (click)="reimportAndTrigger(item)">
+                    <svg lucideRotateCcw class="h-4 w-4"></svg>
+                    {{ 'activity.reimport' | translate }}
+                  </button>
+                }
+                <button type="button" class="dropdown-item text-white" (click)="removeTorrent(item, false)">
+                  <svg lucideTrash2 class="h-4 w-4"></svg>
+                  {{ 'activity.remove_torrent' | translate }}
+                </button>
+                <button type="button" class="dropdown-item text-error" (click)="removeTorrent(item, true)">
+                  <svg lucideTrash2 class="h-4 w-4"></svg>
+                  {{ 'activity.remove_torrent_with_files' | translate }}
+                </button>
+              </app-dropdown-menu>
             </div>
           </div>
 

--- a/client/src/app/features/activity/queue/queue.ts
+++ b/client/src/app/features/activity/queue/queue.ts
@@ -32,10 +32,11 @@ import {
   LucideTrash2,
 } from '@lucide/angular';
 import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
+import { DropdownMenuComponent } from '../../../shared/components/dropdown-menu';
 
 @Component({
   selector: 'app-activity-queue',
-  imports: [TranslateModule, DecimalPipe, NgClass, RouterLink, FormsModule, ResolveUrlPipe, LucideRotateCcw, LucideLink2, LucideEllipsisVertical, LucideTriangleAlert, LucideDownload, LucideSearch, LucideTrash2],
+  imports: [TranslateModule, DecimalPipe, NgClass, RouterLink, FormsModule, ResolveUrlPipe, DropdownMenuComponent, LucideRotateCcw, LucideLink2, LucideEllipsisVertical, LucideTriangleAlert, LucideDownload, LucideSearch, LucideTrash2],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './queue.html',
 })

--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -49,7 +49,7 @@
       <app-horizontal-scroller [title]="'home.recommendations' | translate">
         @for (rec of recommendations(); track rec.media.id) {
           <app-media-card
-            class="shrink-0 w-28 sm:w-36"
+            class="shrink-0 w-32 sm:w-40"
             [attr.data-home-focus]="'rec:' + rec.media.id"
             [imageUrl]="rec.media.posterUrl"
             [title]="rec.media.title"
@@ -77,7 +77,7 @@
       <app-horizontal-scroller [title]="'home.recent_media' | translate">
         @for (m of recentMedia(); track m.id) {
           <app-media-card
-            class="shrink-0 w-28 sm:w-36"
+            class="shrink-0 w-32 sm:w-40"
             [attr.data-home-focus]="'recent:' + m.id"
             [media]="m"
             [subtitle]="'' + m.year"
@@ -92,7 +92,7 @@
       <app-horizontal-scroller [title]="'home.coming_soon' | translate">
         @for (entry of comingSoon(); track entry.id) {
           <app-media-card
-            class="shrink-0 w-28 sm:w-36"
+            class="shrink-0 w-32 sm:w-40"
             [attr.data-home-focus]="'soon:' + entry.id"
             [imageUrl]="entry.posterUrl"
             [title]="entry.title"

--- a/client/src/app/features/media-detail/components/media-detail-library-modal/media-detail-library-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-library-modal/media-detail-library-modal.component.html
@@ -10,6 +10,7 @@
         <select
           class="select select-bordered select-sm w-full"
           name="library"
+          appTvSelect
           [ngModel]="selectedLibraryId()"
           (ngModelChange)="selectedLibraryIdChange.emit($event)"
         >
@@ -24,6 +25,7 @@
         <select
           class="select select-bordered select-sm w-full"
           name="provider"
+          appTvSelect
           [ngModel]="selectedProvider()"
           (ngModelChange)="selectedProviderChange.emit($event)"
         >

--- a/client/src/app/features/media-detail/components/media-detail-library-modal/media-detail-library-modal.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-library-modal/media-detail-library-modal.component.ts
@@ -10,10 +10,11 @@ import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { Library } from '../../../../core/services/api/libraries-api.service';
 import { METADATA_PROVIDER_OPTIONS_OVERRIDE } from '../../../../core/constants/metadata-providers';
+import { TvSelectDirective } from '../../../../shared/directives/tv-select.directive';
 
 @Component({
   selector: 'app-media-detail-library-modal',
-  imports: [TranslateModule, FormsModule],
+  imports: [TranslateModule, FormsModule, TvSelectDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-library-modal.component.html',
 })

--- a/client/src/app/features/media-detail/components/media-detail-profiles-modal/media-detail-profiles-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-profiles-modal/media-detail-profiles-modal.component.html
@@ -15,6 +15,7 @@
           <select
             class="select select-bordered select-sm w-full"
             name="qualityProfile"
+            appTvSelect
             [ngModel]="draftQualityProfileId()"
             (ngModelChange)="draftQualityProfileIdChange.emit($event)"
           >
@@ -29,6 +30,7 @@
           <select
             class="select select-bordered select-sm w-full"
             name="languageProfile"
+            appTvSelect
             [ngModel]="draftLanguageProfileId()"
             (ngModelChange)="draftLanguageProfileIdChange.emit($event)"
           >

--- a/client/src/app/features/media-detail/components/media-detail-profiles-modal/media-detail-profiles-modal.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-profiles-modal/media-detail-profiles-modal.component.ts
@@ -8,10 +8,11 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
+import { TvSelectDirective } from '../../../../shared/directives/tv-select.directive';
 
 @Component({
   selector: 'app-media-detail-profiles-modal',
-  imports: [TranslateModule, FormsModule],
+  imports: [TranslateModule, FormsModule, TvSelectDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-profiles-modal.component.html',
 })

--- a/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.html
@@ -4,6 +4,7 @@
     <div class="flex gap-2 mb-4">
       <select
         class="select select-bordered select-sm"
+        appTvSelect
         [ngModel]="subSearchLang()"
         (ngModelChange)="subSearchLangChange.emit($event)"
       >

--- a/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.ts
@@ -10,10 +10,11 @@ import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { LocalizeLanguagePipe } from '../../../../core/pipes/localize-language.pipe';
 import { SubtitleSearchResult } from '../../../../core/services/api/subtitles-api.service';
+import { TvSelectDirective } from '../../../../shared/directives/tv-select.directive';
 
 @Component({
   selector: 'app-media-detail-subtitle-search-modal',
-  imports: [TranslateModule, FormsModule, LocalizeLanguagePipe],
+  imports: [TranslateModule, FormsModule, LocalizeLanguagePipe, TvSelectDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-subtitle-search-modal.component.html',
 })

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -90,7 +90,7 @@
           <app-horizontal-scroller [title]="'media_detail.other_seasons_of' | translate:{ title: m.title }">
             @for (other of otherSeasons(); track other.id) {
               <app-media-card
-                class="shrink-0 w-28 sm:w-36"
+                class="shrink-0 w-32 sm:w-40"
                 [aspect]="'portrait'"
                 [imageUrl]="other.posterUrl ?? m.posterUrl"
                 [title]="('media_detail.season' | translate) + ' ' + other.seasonNumber"

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -267,9 +267,10 @@ export class PlayerControlsComponent {
     if (next) {
       // Remember the trigger so Back/Escape can refocus it after closing.
       this.dropdownTrigger = (event?.currentTarget as HTMLElement) ?? null;
-      // On TV, push focus into the panel so the D-pad lands on the first item
-      // instead of having to traverse out of the trigger via spatial nav.
-      if (this.isTv()) this.focusFirstDropdownItem();
+      // Push focus into the panel so the first item is reachable without
+      // having to traverse out of the trigger via spatial nav (D-pad on TV,
+      // arrow keys on desktop keyboard). Harmless for mouse users.
+      this.focusFirstDropdownItem();
     }
   }
 

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -2036,6 +2036,20 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     switch (e.key) {
       case ' ':
       case 'k':
+        // Space is the universal activation key on buttons / links. When
+        // the controls bar is shown and focus sits on an interactive
+        // element inside it, let the native activation fire instead of
+        // hijacking the press for play/pause. 'k' has no such overload —
+        // it always toggles playback.
+        if (
+          e.key === ' ' &&
+          this.controlsVisible() &&
+          active &&
+          active !== document.body &&
+          active.closest('app-player-controls')
+        ) {
+          return; // fall through to native activation
+        }
         e.preventDefault();
         this.onTogglePlay();
         break;
@@ -2266,6 +2280,12 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     this.streamingApi.stopSessions(this.mediaFileId).catch(() => {});
   }
 
+  /** Last second-rounded position we PUT to /state. Used to dedup the
+   *  3 saves that fire on exit (onBack, ngOnDestroy, savePosition
+   *  interval): all three see the same `currentTime`, so only the first
+   *  hits the network. */
+  private lastSavedPosition: number | null = null;
+
   private async savePosition() {
     if (!this.mediaId) return;
 
@@ -2283,6 +2303,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     }
 
     if (!pos) return;
+
+    const rounded = Math.floor(pos);
+    if (this.lastSavedPosition === rounded) return;
+    this.lastSavedPosition = rounded;
 
     const payload = {
       positionSeconds: pos,

--- a/client/src/app/features/player/remote/cast-remote.html
+++ b/client/src/app/features/player/remote/cast-remote.html
@@ -28,71 +28,62 @@
     <div class="flex items-center justify-center gap-3 mb-3 landscape:mb-1">
       <!-- Subtitles -->
       @if (availableSubtitles().length) {
-        <div class="dropdown dropdown-top dropdown-end">
-          <button tabindex="0" class="btn btn-ghost btn-sm text-white/70 gap-2">
+        <app-dropdown-menu placement="top-end">
+          <button trigger type="button" class="btn btn-ghost btn-sm text-white/70 gap-2">
             <svg lucideCaptions class="h-4 w-4"></svg>
             Sous-titres
           </button>
-          <div tabindex="0" class="dropdown-content bg-neutral/95 backdrop-blur-sm rounded-2xl shadow-2xl py-3 px-2 min-w-60 max-h-[50vh] overflow-y-auto mb-2">
-            <div class="text-center text-white/70 text-xs font-medium mb-2">Sous-titres</div>
-            <button class="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-white hover:bg-white/10" (click)="selectSubtitle(null)">
+          <button class="dropdown-item text-white" (click)="selectSubtitle(null)">
+            <svg lucideCaptions class="h-4 w-4 text-white/50 shrink-0"></svg>
+            <span class="flex-1 text-left">Désactivé</span>
+            @if (!activeSubId()) { <svg lucideCheck class="h-4 w-4 text-white shrink-0"></svg> }
+          </button>
+          @for (sub of availableSubtitles(); track sub.id) {
+            <button class="dropdown-item text-white" (click)="selectSubtitle(sub)">
               <svg lucideCaptions class="h-4 w-4 text-white/50 shrink-0"></svg>
-              <span class="flex-1 text-left">Désactivé</span>
-              @if (!activeSubId()) { <svg lucideCheck class="h-4 w-4 text-white shrink-0"></svg> }
+              <span class="flex-1 text-left">{{ sub.label }}@if (sub.burnIn) { <span class="text-warning/70 text-[10px] ml-1">gravé</span> }</span>
+              @if (activeSubId() === sub.id) { <svg lucideCheck class="h-4 w-4 text-white shrink-0"></svg> }
             </button>
-            @for (sub of availableSubtitles(); track sub.id) {
-              <button class="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-white hover:bg-white/10" (click)="selectSubtitle(sub)">
-                <svg lucideCaptions class="h-4 w-4 text-white/50 shrink-0"></svg>
-                <span class="flex-1 text-left">{{ sub.label }}@if (sub.burnIn) { <span class="text-warning/70 text-[10px] ml-1">gravé</span> }</span>
-                @if (activeSubId() === sub.id) { <svg lucideCheck class="h-4 w-4 text-white shrink-0"></svg> }
-              </button>
-            }
-          </div>
-        </div>
+          }
+        </app-dropdown-menu>
       }
 
       <!-- Audio -->
       @if (availableAudioTracks().length > 1) {
-        <div class="dropdown dropdown-top dropdown-end">
-          <button tabindex="0" class="btn btn-ghost btn-sm text-white/70 gap-2">
+        <app-dropdown-menu placement="top-end">
+          <button trigger type="button" class="btn btn-ghost btn-sm text-white/70 gap-2">
             <svg lucideHeadphones class="h-4 w-4"></svg>
             Audio
           </button>
-          <div tabindex="0" class="dropdown-content bg-neutral/95 backdrop-blur-sm rounded-2xl shadow-2xl py-3 px-2 min-w-60 max-h-[50vh] overflow-y-auto mb-2">
-            <div class="text-center text-white/70 text-xs font-medium mb-2">Piste audio</div>
-            @for (track of availableAudioTracks(); track track.id) {
-              <button class="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-white hover:bg-white/10" (click)="selectAudio(track)">
-                <svg lucideHeadphones class="h-4 w-4 text-white/50 shrink-0"></svg>
-                <span class="flex-1 text-left">{{ track.label }}</span>
-                @if (activeAudioId() === track.id) { <svg lucideCheck class="h-4 w-4 text-white shrink-0"></svg> }
-              </button>
-            }
-          </div>
-        </div>
+          @for (track of availableAudioTracks(); track track.id) {
+            <button class="dropdown-item text-white" (click)="selectAudio(track)">
+              <svg lucideHeadphones class="h-4 w-4 text-white/50 shrink-0"></svg>
+              <span class="flex-1 text-left">{{ track.label }}</span>
+              @if (activeAudioId() === track.id) { <svg lucideCheck class="h-4 w-4 text-white shrink-0"></svg> }
+            </button>
+          }
+        </app-dropdown-menu>
       }
 
       <!-- Quality -->
       @if (availableQualities().length > 1) {
-        <div class="dropdown dropdown-top dropdown-end">
-          <button tabindex="0" class="btn btn-ghost btn-sm text-white/70 gap-2">
+        <app-dropdown-menu placement="top-end">
+          <button trigger type="button" class="btn btn-ghost btn-sm text-white/70 gap-2">
             <svg lucideSettings class="h-4 w-4"></svg>
             {{ activeQualityId() === 'auto' ? 'Auto' : activeQualityId() }}
           </button>
-          <div tabindex="0" class="dropdown-content bg-neutral/95 backdrop-blur-sm rounded-2xl shadow-2xl py-3 px-2 min-w-60 max-h-[50vh] overflow-y-auto mb-2">
-            <div class="text-center text-white/70 text-xs font-medium mb-2">Qualité</div>
-            @for (q of availableQualities(); track q.id) {
-              <button class="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-white hover:bg-white/10" (click)="selectQuality(q)">
-                <span class="flex-1 text-left">
-                  {{ q.label }}
-                  @if (q.lowBandwidth) {
-                    <span class="text-white/50 ml-1 text-xs">({{ 'player.low_bandwidth' | translate }})</span>
-                  }
-                </span>
-                @if (activeQualityId() === q.id) { <svg lucideCheck class="h-4 w-4 text-white shrink-0"></svg> }
-              </button>
-            }
-          </div>
-        </div>
+          @for (q of availableQualities(); track q.id) {
+            <button class="dropdown-item text-white" (click)="selectQuality(q)">
+              <span class="flex-1 text-left">
+                {{ q.label }}
+                @if (q.lowBandwidth) {
+                  <span class="text-white/50 ml-1 text-xs">({{ 'player.low_bandwidth' | translate }})</span>
+                }
+              </span>
+              @if (activeQualityId() === q.id) { <svg lucideCheck class="h-4 w-4 text-white shrink-0"></svg> }
+            </button>
+          }
+        </app-dropdown-menu>
       }
     </div>
 

--- a/client/src/app/features/player/remote/cast-remote.ts
+++ b/client/src/app/features/player/remote/cast-remote.ts
@@ -8,6 +8,7 @@ import {
   signal,
 } from '@angular/core';
 import { CastService } from '../../../core/services/cast.service';
+import { DropdownMenuComponent } from '../../../shared/components/dropdown-menu';
 import { TranslateModule } from '@ngx-translate/core';
 import {
   LucideCaptions,
@@ -50,6 +51,7 @@ export interface CastQualityOption {
     LucideHeadphones, LucidePause, LucidePlay, LucideRotateCcw, LucideRotateCw,
     LucideSettings, LucideSquare,
     TranslateModule,
+    DropdownMenuComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './cast-remote.html',

--- a/client/src/app/features/search/search.html
+++ b/client/src/app/features/search/search.html
@@ -17,19 +17,17 @@
         </button>
       }
     </div>
-    <div class="dropdown dropdown-end">
-      <div tabindex="0" role="button" class="btn btn-square btn-ghost">
+    <app-dropdown-menu placement="bottom-end">
+      <div trigger tabindex="0" role="button" class="btn btn-square btn-ghost">
         <svg lucideSettings class="h-5 w-5"></svg>
       </div>
-      <div tabindex="0" class="dropdown-content bg-base-100 rounded-box shadow-xl border border-base-200 p-4 w-64 z-50">
-        <label class="flex items-center justify-between gap-3 cursor-pointer">
-          <span class="text-sm">{{ 'search.external_search' | translate }}</span>
-          <input type="checkbox" class="toggle toggle-primary toggle-sm"
-                 [ngModel]="state.externalEnabled()"
-                 (ngModelChange)="toggleExternal()" />
-        </label>
-      </div>
-    </div>
+      <label class="flex items-center justify-between gap-3 cursor-pointer px-3 py-2">
+        <span class="text-sm">{{ 'search.external_search' | translate }}</span>
+        <input type="checkbox" class="toggle toggle-primary toggle-sm"
+               [ngModel]="state.externalEnabled()"
+               (ngModelChange)="toggleExternal()" />
+      </label>
+    </app-dropdown-menu>
   </div>
 
   <!-- Filter tabs -->

--- a/client/src/app/features/search/search.ts
+++ b/client/src/app/features/search/search.ts
@@ -27,11 +27,12 @@ import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
 import { MediaType } from '../../core/enums/media-type.enum';
 import { MediaCardComponent, CardBadge } from '../../shared/components/media-card/media-card';
+import { DropdownMenuComponent } from '../../shared/components/dropdown-menu';
 import { LucideSearch, LucideX, LucideSettings } from '@lucide/angular';
 
 @Component({
   selector: 'app-search',
-  imports: [FormsModule, TranslateModule, MediaCardComponent, LucideSearch, LucideX, LucideSettings],
+  imports: [FormsModule, TranslateModule, MediaCardComponent, DropdownMenuComponent, LucideSearch, LucideX, LucideSettings],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './search.html',
 })

--- a/client/src/app/features/system/status/status.html
+++ b/client/src/app/features/system/status/status.html
@@ -72,19 +72,15 @@
             {{ item.label | translate }}
           </button>
         } @else {
-          <div class="dropdown dropdown-bottom">
-            <div tabindex="0" role="button" class="btn btn-outline btn-sm">{{ item.label | translate }} ▾</div>
-            <ul tabindex="0" class="dropdown-content z-10 menu p-1 shadow-lg bg-base-200 rounded-lg min-w-48 mt-1">
-              @for (sub of item.items; track sub.name) {
-                <li>
-                  <button type="button" (click)="trigger(sub.name)" [disabled]="triggering() !== null" class="text-sm">
-                    @if (triggering() === sub.name) { <span class="loading loading-spinner loading-xs"></span> }
-                    {{ sub.label | translate }}
-                  </button>
-                </li>
-              }
-            </ul>
-          </div>
+          <app-dropdown-menu placement="bottom-start">
+            <div trigger tabindex="0" role="button" class="btn btn-outline btn-sm">{{ item.label | translate }} ▾</div>
+            @for (sub of item.items; track sub.name) {
+              <button type="button" class="dropdown-item text-white" (click)="trigger(sub.name)" [disabled]="triggering() !== null">
+                @if (triggering() === sub.name) { <span class="loading loading-spinner loading-xs"></span> }
+                {{ sub.label | translate }}
+              </button>
+            }
+          </app-dropdown-menu>
         }
       }
     </div>

--- a/client/src/app/features/system/status/status.ts
+++ b/client/src/app/features/system/status/status.ts
@@ -9,6 +9,7 @@ import { LucideTrash2 } from '@lucide/angular';
 import { SseService } from '../../../core/services/sse.service';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { PaginationComponent } from '../../../shared/components/pagination/pagination';
+import { DropdownMenuComponent } from '../../../shared/components/dropdown-menu';
 
 interface CommandEntry { id: number; name: string; status: string; trigger: string; startedOn: string; endedOn?: string; body?: Record<string, unknown>; }
 interface ServiceStatus { name: string; ok: boolean; message?: string; }
@@ -16,7 +17,7 @@ interface HealthReport { version: string; uptimeSeconds: number; database: Servi
 
 @Component({
   selector: 'app-system-status',
-  imports: [TranslateModule, DatePipe, DecimalPipe, NgClass, KeyValuePipe, LucideTrash2, PaginationComponent],
+  imports: [TranslateModule, DatePipe, DecimalPipe, NgClass, KeyValuePipe, LucideTrash2, PaginationComponent, DropdownMenuComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './status.html',
 })

--- a/client/src/app/features/watch-history/watch-history.html
+++ b/client/src/app/features/watch-history/watch-history.html
@@ -87,16 +87,16 @@
             </span>
           </div>
           <!-- Mobile: dropdown menu -->
-          <div class="sm:hidden shrink-0 self-center dropdown dropdown-end">
-            <div tabindex="0" role="button" class="btn btn-ghost btn-sm btn-circle">
-              <svg lucideEllipsisVertical class="h-4 w-4"></svg>
-            </div>
-            <ul tabindex="0" class="dropdown-content z-10 menu p-1 shadow-lg bg-base-200 rounded-lg min-w-36 mt-1">
+          <div class="sm:hidden shrink-0 self-center">
+            <app-dropdown-menu placement="bottom-end">
+              <div trigger tabindex="0" role="button" class="btn btn-ghost btn-sm btn-circle">
+                <svg lucideEllipsisVertical class="h-4 w-4"></svg>
+              </div>
               @if (!item.completed) {
-                <li><button type="button" (click)="markWatched(item)" class="text-sm"><svg lucideCheck class="h-4 w-4"></svg>{{ 'history.mark_watched' | translate }}</button></li>
+                <button type="button" class="dropdown-item text-white" (click)="markWatched(item)"><svg lucideCheck class="h-4 w-4"></svg>{{ 'history.mark_watched' | translate }}</button>
               }
-              <li><button type="button" (click)="removeItem(item)" class="text-sm text-error"><svg lucideTrash2 class="h-4 w-4"></svg>{{ 'history.remove' | translate }}</button></li>
-            </ul>
+              <button type="button" class="dropdown-item text-error" (click)="removeItem(item)"><svg lucideTrash2 class="h-4 w-4"></svg>{{ 'history.remove' | translate }}</button>
+            </app-dropdown-menu>
           </div>
         </div>
       }

--- a/client/src/app/features/watch-history/watch-history.ts
+++ b/client/src/app/features/watch-history/watch-history.ts
@@ -9,10 +9,11 @@ import { ConfirmationService } from '../../core/services/confirmation.service';
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
 import { PaginationComponent } from '../../shared/components/pagination/pagination';
+import { DropdownMenuComponent } from '../../shared/components/dropdown-menu';
 
 @Component({
   selector: 'app-watch-history',
-  imports: [TranslateModule, ResolveUrlPipe, PaginationComponent, LucideHistory, LucideTrash2, LucidePlay, LucideFilm, LucideTv, LucideCheck, LucideEllipsisVertical],
+  imports: [TranslateModule, ResolveUrlPipe, PaginationComponent, DropdownMenuComponent, LucideHistory, LucideTrash2, LucidePlay, LucideFilm, LucideTv, LucideCheck, LucideEllipsisVertical],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './watch-history.html',
 })

--- a/client/src/app/shared/cast-overlay/cast-overlay.html
+++ b/client/src/app/shared/cast-overlay/cast-overlay.html
@@ -76,56 +76,50 @@
           <!-- Pickers -->
           <div class="flex items-center justify-center gap-3 lg:gap-2 flex-wrap">
             @if (cp.availableSubtitles().length) {
-              <div class="dropdown dropdown-top dropdown-start">
-                <div tabindex="0" role="button" class="btn btn-ghost btn-sm gap-1">
+              <app-dropdown-menu placement="top-start">
+                <div trigger tabindex="0" role="button" class="btn btn-ghost btn-sm gap-1">
                   <svg lucideCaptions class="h-4 w-4"></svg>
                   <span class="text-xs">Sous-titres</span>
                 </div>
-                <div tabindex="0" class="dropdown-content z-50 bg-base-200 rounded-lg shadow-xl p-2 w-56 max-w-[calc(100vw-2rem)] max-h-40 overflow-y-auto mb-2">
-                  <button class="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm hover:bg-white/10" (click)="selectSubtitle(null)">
-                    <span class="flex-1 text-left">Désactivé</span>
-                    @if (!cp.activeSubtitleId()) { <svg lucideCheck class="h-4 w-4 shrink-0"></svg> }
+                <button class="dropdown-item text-white" (click)="selectSubtitle(null)">
+                  <span class="flex-1 text-left">Désactivé</span>
+                  @if (!cp.activeSubtitleId()) { <svg lucideCheck class="h-4 w-4 shrink-0"></svg> }
+                </button>
+                @for (sub of cp.availableSubtitles(); track sub.id) {
+                  <button class="dropdown-item text-white" (click)="selectSubtitle(sub)">
+                    <span class="flex-1 text-left">{{ sub.label }}</span>
+                    @if (cp.activeSubtitleId() === sub.id) { <svg lucideCheck class="h-4 w-4 shrink-0"></svg> }
                   </button>
-                  @for (sub of cp.availableSubtitles(); track sub.id) {
-                    <button class="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm hover:bg-white/10" (click)="selectSubtitle(sub)">
-                      <span class="flex-1 text-left">{{ sub.label }}</span>
-                      @if (cp.activeSubtitleId() === sub.id) { <svg lucideCheck class="h-4 w-4 shrink-0"></svg> }
-                    </button>
-                  }
-                </div>
-              </div>
+                }
+              </app-dropdown-menu>
             }
             @if (cp.availableAudioTracks().length > 1) {
-              <div class="dropdown dropdown-top dropdown-end">
-                <div tabindex="0" role="button" class="btn btn-ghost btn-sm gap-1">
+              <app-dropdown-menu placement="top-end">
+                <div trigger tabindex="0" role="button" class="btn btn-ghost btn-sm gap-1">
                   <svg lucideHeadphones class="h-4 w-4"></svg>
                   <span class="text-xs">Audio</span>
                 </div>
-                <div tabindex="0" class="dropdown-content z-50 bg-base-200 rounded-lg shadow-xl p-2 w-56 max-w-[calc(100vw-2rem)] max-h-40 overflow-y-auto mb-2">
-                  @for (track of cp.availableAudioTracks(); track track.id) {
-                    <button class="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm hover:bg-white/10" (click)="selectAudio(track)">
-                      <span class="flex-1 text-left">{{ track.label }}</span>
-                      @if (cp.activeAudioTrackId() === track.id) { <svg lucideCheck class="h-4 w-4 shrink-0"></svg> }
-                    </button>
-                  }
-                </div>
-              </div>
+                @for (track of cp.availableAudioTracks(); track track.id) {
+                  <button class="dropdown-item text-white" (click)="selectAudio(track)">
+                    <span class="flex-1 text-left">{{ track.label }}</span>
+                    @if (cp.activeAudioTrackId() === track.id) { <svg lucideCheck class="h-4 w-4 shrink-0"></svg> }
+                  </button>
+                }
+              </app-dropdown-menu>
             }
             @if (cp.availableQualities().length > 1) {
-              <div class="dropdown dropdown-top dropdown-end">
-                <div tabindex="0" role="button" class="btn btn-ghost btn-sm gap-1">
+              <app-dropdown-menu placement="top-end">
+                <div trigger tabindex="0" role="button" class="btn btn-ghost btn-sm gap-1">
                   <svg lucideSettings class="h-4 w-4"></svg>
                   <span class="text-xs">Qualité</span>
                 </div>
-                <div tabindex="0" class="dropdown-content z-50 bg-base-200 rounded-lg shadow-xl p-2 w-48 max-h-40 overflow-y-auto mb-2">
-                  @for (q of cp.availableQualities(); track q.id) {
-                    <button class="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm hover:bg-white/10" (click)="selectQuality(q)">
-                      <span class="flex-1 text-left">{{ q.label }}</span>
-                      @if (cp.activeQualityId() === q.id) { <svg lucideCheck class="h-4 w-4 shrink-0"></svg> }
-                    </button>
-                  }
-                </div>
-              </div>
+                @for (q of cp.availableQualities(); track q.id) {
+                  <button class="dropdown-item text-white" (click)="selectQuality(q)">
+                    <span class="flex-1 text-left">{{ q.label }}</span>
+                    @if (cp.activeQualityId() === q.id) { <svg lucideCheck class="h-4 w-4 shrink-0"></svg> }
+                  </button>
+                }
+              </app-dropdown-menu>
             }
           </div>
 

--- a/client/src/app/shared/cast-overlay/cast-overlay.ts
+++ b/client/src/app/shared/cast-overlay/cast-overlay.ts
@@ -3,6 +3,7 @@ import { formatTime, parseAudioIndex } from '../../core/utils/player.utils';
 import { CastService } from '../../core/services/cast.service';
 import { CastPlayerService } from '../../core/services/cast-player.service';
 import { SeekbarComponent } from '../components/seekbar/seekbar';
+import { DropdownMenuComponent } from '../components/dropdown-menu';
 import {
   LucideCaptions,
   LucideCast,
@@ -24,6 +25,7 @@ import {
     LucideHeadphones, LucidePause, LucidePlay, LucideRotateCcw, LucideRotateCw,
     LucideSettings, LucideSquare, LucideX,
     SeekbarComponent,
+    DropdownMenuComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './cast-overlay.html',

--- a/client/src/app/shared/components/dropdown-menu.ts
+++ b/client/src/app/shared/components/dropdown-menu.ts
@@ -92,6 +92,8 @@ export class DropdownMenuComponent {
    *  traps `z-[101]` below the bottom dock at `z-40`). The trigger stays
    *  inline so the layout's flex/grid placement keeps working. */
   private readonly sheet = viewChild('sheet', { read: ElementRef });
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private wasOpen = false;
 
   constructor() {
     if (typeof document === 'undefined') return;
@@ -100,6 +102,20 @@ export class DropdownMenuComponent {
       if (!ref || this.useDropdown()) return;
       queueMicrotask(() => {
         document.documentElement.appendChild(ref.nativeElement);
+      });
+    });
+    // Sheet branch (touch / TV) doesn't go through DropdownToggleDirective,
+    // so refocus the projected trigger ourselves on close — keeps Enter /
+    // tap parity with the dropdown branch (re-activating re-opens).
+    effect(() => {
+      const open = this.open();
+      const justClosed = this.wasOpen && !open;
+      this.wasOpen = open;
+      if (!justClosed || this.useDropdown()) return;
+      queueMicrotask(() => {
+        this.host.nativeElement
+          .querySelector<HTMLElement>('[trigger]')
+          ?.focus({ preventScroll: true });
       });
     });
   }

--- a/client/src/app/shared/components/horizontal-scroller.ts
+++ b/client/src/app/shared/components/horizontal-scroller.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   ChangeDetectionStrategy,
+  HostListener,
   inject,
   input,
   signal,
@@ -10,8 +11,8 @@ import {
   OnDestroy,
 } from '@angular/core';
 import { LucideChevronLeft, LucideChevronRight } from '@lucide/angular';
-import { TvService } from '../../core/services/tv.service';
 import { TvRowDirective } from '../directives/tv-row.directive';
+import { TvService } from '../../core/services/tv.service';
 
 @Component({
   selector: 'app-horizontal-scroller',
@@ -26,6 +27,8 @@ import { TvRowDirective } from '../directives/tv-row.directive';
       @if (!atStart() || !atEnd()) {
         <div class="flex gap-1 scroll-arrows">
           <button
+            type="button"
+            tabindex="-1"
             class="btn btn-ghost btn-sm btn-circle"
             [disabled]="atStart()"
             (click)="scrollLeft()"
@@ -33,6 +36,8 @@ import { TvRowDirective } from '../directives/tv-row.directive';
             <svg lucideChevronLeft class="h-5 w-5"></svg>
           </button>
           <button
+            type="button"
+            tabindex="-1"
             class="btn btn-ghost btn-sm btn-circle"
             [disabled]="atEnd()"
             (click)="scrollRight()"
@@ -42,19 +47,15 @@ import { TvRowDirective } from '../directives/tv-row.directive';
         </div>
       }
     </div>
-    <!-- Scrollable content (no visible scrollbar). On TV the scroller gets
-         vertical padding (and a matching negative margin so neighbours don't
-         shift) to make room for the focus ring + media-card scale-up — both
-         extend past the row and would otherwise be clipped by overflow-y. -->
+    <!-- Scrollable content (no visible scrollbar). Vertical / horizontal
+         padding (with matching negative margin so neighbours don't shift)
+         makes room for the focus ring + media-card scale-up — both extend
+         past the row and would otherwise be clipped by overflow-x:auto's
+         implicit overflow-y. -->
     <div
       #scroller
       appTvRow
-      class="flex gap-3 overflow-x-auto scrollbar-none tv:[scroll-behavior:smooth]"
-      [class.py-3]="tv.isTv()"
-      [class.-my-3]="tv.isTv()"
-      [class.px-3]="tv.isTv()"
-      [class.-mx-3]="tv.isTv()"
-      [class.scroll-px-3]="tv.isTv()"
+      class="flex gap-4 overflow-x-auto scrollbar-none [scroll-behavior:smooth] py-5 -my-5 px-5 -mx-5 scroll-px-5"
       (scroll)="updateArrows()"
     >
       <ng-content />
@@ -77,13 +78,52 @@ import { TvRowDirective } from '../directives/tv-row.directive';
   `],
 })
 export class HorizontalScrollerComponent implements AfterViewInit, OnDestroy {
-  protected readonly tv = inject(TvService);
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly tv = inject(TvService);
   readonly title = input('');
   readonly atStart = signal(true);
   readonly atEnd = signal(false);
 
   private readonly scrollerEl = viewChild<ElementRef<HTMLElement>>('scroller');
   private resizeObserver?: ResizeObserver;
+
+  /** Smooth-scroll the page so this row's top sits at the viewport top
+   *  when focus arrives from outside (e.g. the row above/below). The
+   *  spatial-nav default `focus()` triggers an `instant` scrollIntoView
+   *  that drops the user mid-row — this hostlistener replaces it with
+   *  a smooth, row-aligned animation. Skips when focus moves between
+   *  cards inside the same rail. */
+  @HostListener('focusin', ['$event'])
+  protected onFocusIn(event: FocusEvent): void {
+    const from = event.relatedTarget as Node | null;
+    if (from && this.host.nativeElement.contains(from)) return;
+    queueMicrotask(() => this.snapToRowTop());
+  }
+
+  private snapToRowTop(): void {
+    if (typeof window === 'undefined') return;
+    const scrollEl = document.scrollingElement ?? document.documentElement;
+    const rect = this.host.nativeElement.getBoundingClientRect();
+    const currentTop = scrollEl.scrollTop ?? 0;
+    // Leave a gap above the row title so the focused row doesn't sit
+    // flush against the viewport edge. On TV the cast/user dock floats
+    // top-right (~48 px tall at top:24); bump the offset so the focused
+    // row clears the dock with its own breathing room.
+    const TOP_OFFSET = this.tv.isTv() ? 96 : 24;
+    // Skip when the row is already fully visible in the viewport: the
+    // user is just walking between visible rows, no scroll is warranted.
+    // Only snap when the row is partially / fully off-screen, in which
+    // case we need to bring it back into view.
+    const viewportH = window.innerHeight;
+    if (rect.top >= TOP_OFFSET && rect.bottom <= viewportH) return;
+    const targetTop = Math.max(0, currentTop + rect.top - TOP_OFFSET);
+    if (Math.abs(targetTop - currentTop) < 4) return;
+    try {
+      window.scrollTo({ top: targetTop, left: 0, behavior: 'smooth' });
+    } catch {
+      window.scrollTo(0, targetTop);
+    }
+  }
 
   ngAfterViewInit() {
     this.updateArrows();

--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -147,7 +147,7 @@
   <!-- Title below -->
   <div class="pt-1.5">
     @if (_link()) {
-      <a [routerLink]="_link()" [state]="_navState()" [replaceUrl]="replaceUrl()" class="hover:underline" [attr.tabindex]="innerTabindex()" (pointerdown)="onAnchorPointerdown()" (keydown.enter)="onAnchorPointerdown()">
+      <a [routerLink]="_link()" [state]="_navState()" [replaceUrl]="replaceUrl()" class="hover:underline" [attr.tabindex]="innerTabindex" (pointerdown)="onAnchorPointerdown()" (keydown.enter)="onAnchorPointerdown()">
         <h3 class="text-sm font-medium line-clamp-1 leading-snug">{{ _title() }}</h3>
       </a>
     } @else {
@@ -155,7 +155,7 @@
     }
     @if (_subtitle()) {
       @if (subtitleLink()) {
-        <a [routerLink]="subtitleLink()" class="hover:underline" [attr.tabindex]="innerTabindex()">
+        <a [routerLink]="subtitleLink()" class="hover:underline" [attr.tabindex]="innerTabindex">
           <p class="text-xs text-base-content/50 line-clamp-1">{{ _subtitle() }}</p>
         </a>
       } @else {

--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -1,7 +1,7 @@
 <div
   class="relative"
   [class.opacity-55]="dimmed()"
-  [class]="aspect() === 'landscape' ? 'shrink-0 w-56 sm:w-64' : ''"
+  [class]="aspect() === 'landscape' ? 'shrink-0 w-60 sm:w-72' : ''"
 >
   <!-- Image -->
   <figure

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -47,12 +47,12 @@ export class MediaCardComponent {
   /** Hover overlay (play button) only makes sense on a real pointer device. */
   protected readonly showHoverOverlay = computed(() => this.device.input() === 'mouse');
   /**
-   * On TV the figure is the single focus target — child links (title, subtitle,
-   * hover overlay) are visually still navigable via the contextual actions
-   * panel but should not steal focus from D-pad navigation, so we mark them
-   * with tabindex=-1.
+   * The figure is the single focus target across every form factor —
+   * child links (title, subtitle, hover overlay) stay clickable but
+   * never steal the spatial nav focus from the card itself. Same
+   * semantics for D-pad on TV, arrow keys on desktop, and Tab order.
    */
-  protected readonly innerTabindex = computed(() => this.tv.isTv() ? -1 : null);
+  protected readonly innerTabindex = -1;
 
   // Data source (auto-derives imageUrl, title, rating, link, playable, barStatus, barPercent)
   readonly media = input<Media | null>(null);

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -315,7 +315,7 @@
       <div class="flex items-center gap-2">
         <span class="text-base-content/50">{{ 'media_info.video' | translate }}</span>
         @if (multipleFiles()) {
-          <select class="select select-bordered select-sm w-fit" [ngModel]="selectedFileId()" (ngModelChange)="selectedFileIdChange.emit($event)">
+          <select class="select select-bordered select-sm w-fit" appTvSelect [ngModel]="selectedFileId()" (ngModelChange)="selectedFileIdChange.emit($event)">
             @for (f of files(); track f.id) {
               <option [ngValue]="f.id">{{ fileLabel(f) }}</option>
             }
@@ -330,7 +330,7 @@
           @if (audioTracks().length === 1) {
             <span>{{ audioTracks()[0].label }}</span>
           } @else {
-            <select class="select select-bordered select-sm w-fit" [ngModel]="selectedAudioIndex()" (ngModelChange)="onAudioChange($event)">
+            <select class="select select-bordered select-sm w-fit" appTvSelect [ngModel]="selectedAudioIndex()" (ngModelChange)="onAudioChange($event)">
               @for (t of audioTracks(); track t.index) {
                 <option [ngValue]="t.index">{{ t.label }}</option>
               }
@@ -344,7 +344,7 @@
           @if (subtitles().length === 1) {
             <span>{{ subtitles()[0].label }}</span>
           } @else {
-            <select class="select select-bordered select-sm w-fit" [ngModel]="selectedSubtitleId()" (ngModelChange)="onSubtitleChange($event)">
+            <select class="select select-bordered select-sm w-fit" appTvSelect [ngModel]="selectedSubtitleId()" (ngModelChange)="onSubtitleChange($event)">
               <option [ngValue]="null">{{ 'player.off' | translate }}</option>
               @for (s of subtitles(); track s.id) {
                 <option [ngValue]="s.id">{{ s.label }}</option>

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -43,6 +43,7 @@ import { formatAudioLabel } from '../../../core/utils/player.utils';
 import { DropdownMenuComponent } from '../dropdown-menu';
 import { ImgFadeInDirective } from '../../directives/img-fade-in.directive';
 import { TvRowDirective } from '../../directives/tv-row.directive';
+import { TvSelectDirective } from '../../directives/tv-select.directive';
 import { NgTemplateOutlet } from '@angular/common';
 
 export interface MediaInfoHeaderFile {
@@ -74,6 +75,7 @@ interface AudioTrack {
     DropdownMenuComponent,
     ImgFadeInDirective,
     TvRowDirective,
+    TvSelectDirective,
     NgTemplateOutlet,
     DecimalPipe, FormsModule, RouterLink, TranslateModule,
     LucideCaptions, LucideChevronLeft, LucideCheck, LucideDownload,

--- a/client/src/app/shared/components/popover-menu.ts
+++ b/client/src/app/shared/components/popover-menu.ts
@@ -12,6 +12,7 @@ import { NgTemplateOutlet } from '@angular/common';
 import { BottomSheetComponent } from './bottom-sheet';
 import { TvService } from '../../core/services/tv.service';
 import { DeviceService } from '../../core/services/device.service';
+import { DismissableStackService } from '../../core/services/dismissable-stack.service';
 
 /**
  * Reusable menu chrome that picks its presentation per-platform:
@@ -45,6 +46,7 @@ import { DeviceService } from '../../core/services/device.service';
       <!-- Click-out backdrop (transparent) -->
       <div class="fixed inset-0 z-[100]" (click)="close()"></div>
       <div
+        data-tv-modal
         class="fixed z-[101] bg-base-200 rounded-box shadow-xl overflow-hidden"
         [style.top.px]="position().top"
         [style.left.px]="position().left"
@@ -73,6 +75,7 @@ export class PopoverMenuComponent {
   private readonly tv = inject(TvService);
   private readonly device = inject(DeviceService);
   private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly dismissStack = inject(DismissableStackService);
 
   constructor() {
     // Move the host to <html> on every platform that renders the sheet
@@ -91,13 +94,18 @@ export class PopoverMenuComponent {
     // Focus the first focusable inside the menu on every open. autofocus
     // is unreliable on Capacitor's Android WebView for dynamically added
     // content, so we do it programmatically.
-    effect(() => {
+    effect((onCleanup) => {
       if (!this.open()) return;
       queueMicrotask(() => {
         this.host.nativeElement
           .querySelector<HTMLElement>('a[href], button:not([disabled]), [tabindex="0"]')
           ?.focus({ preventScroll: false });
       });
+      // Register with the dismissable stack so Escape (browser) and the
+      // hardware back button (Capacitor / Tizen) close the popover.
+      const close = () => this.close();
+      this.dismissStack.push(close);
+      onCleanup(() => this.dismissStack.remove(close));
     });
   }
 

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -101,92 +101,64 @@
                     </td>
                     <td class="text-end">
                       @if (canGrab() && sub.providerType !== 'embedded') {
-                        <div class="dropdown dropdown-end dropdown-top">
-                          <div tabindex="0" role="button" class="btn btn-ghost btn-xs" [class.btn-disabled]="subtitleActionBusy()">
+                        <app-dropdown-menu placement="top-end">
+                          <div trigger tabindex="0" role="button" class="btn btn-ghost btn-xs" [class.btn-disabled]="subtitleActionBusy()">
                             {{ 'media_detail.subtitle_actions' | translate }}
                             <svg lucideChevronDown class="h-3 w-3"></svg>
                           </div>
-                          <ul tabindex="0" class="dropdown-content menu bg-base-200 rounded-box z-10 w-56 p-2 shadow-lg text-sm">
-                            <li>
-                              <a class="flex items-center gap-3" (click)="openSyncModal(sub.id)">
-                                <svg lucidePlay class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                                {{ 'media_detail.action_sync' | translate }}
-                              </a>
-                            </li>
-                            <li>
-                              <a class="flex items-center gap-3" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'removeHiTags' })">
-                                <svg lucideVolume2 class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                                {{ 'media_detail.action_remove_hi' | translate }}
-                              </a>
-                            </li>
-                            <li>
-                              <a class="flex items-center gap-3" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'removeStyleTags' })">
-                                <svg lucideCode class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                                {{ 'media_detail.action_remove_style' | translate }}
-                              </a>
-                            </li>
-                            <li>
-                              <a class="flex items-center gap-3" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'removeEmoji' })">
-                                <svg lucideSmile class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                                {{ 'media_detail.action_remove_emoji' | translate }}
-                              </a>
-                            </li>
-                            <li>
-                              <a class="flex items-center gap-3" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'ocrFixes' })">
-                                <svg lucideImage class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                                {{ 'media_detail.action_ocr_fixes' | translate }}
-                              </a>
-                            </li>
-                            <li>
-                              <a class="flex items-center gap-3" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'commonFixes' })">
-                                <svg lucideThermometer class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                                {{ 'media_detail.action_common_fixes' | translate }}
-                              </a>
-                            </li>
-                            <li>
-                              <a class="flex items-center gap-3" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'fixUppercase' })">
-                                <svg lucideMaximize2 class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                                {{ 'media_detail.action_fix_uppercase' | translate }}
-                              </a>
-                            </li>
-                            <li>
-                              <a class="flex items-center gap-3" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'reverseRtl' })">
-                                <svg lucideArrowRightLeft class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                                {{ 'media_detail.action_reverse_rtl' | translate }}
-                              </a>
-                            </li>
-                            <li>
-                              <a class="flex items-center gap-3" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'convertToSrt' })">
-                                <svg lucideFileText class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                                {{ 'media_detail.action_convert_srt' | translate }}
-                              </a>
-                            </li>
-                            <li>
-                              <a class="flex items-center gap-3" (click)="openAdjustModal(sub.id)">
-                                <svg lucideClock class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                                {{ 'media_detail.action_adjust_times' | translate }}
-                              </a>
-                            </li>
-                            <li>
-                              <a class="flex items-center gap-3" (click)="openFpsModal(sub.id)">
-                                <svg lucideZap class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                                {{ 'media_detail.action_change_fps' | translate }}
-                              </a>
-                            </li>
-                            <li class="border-t border-base-300 mt-1 pt-1">
-                              <a class="flex items-center gap-3 text-warning" (click)="blacklistSubtitle(sub)">
-                                <svg lucideBan class="h-4 w-4 shrink-0 opacity-80" aria-hidden="true"></svg>
-                                {{ 'media_detail.action_blacklist' | translate }}
-                              </a>
-                            </li>
-                            <li>
-                              <a class="flex items-center gap-3 text-error" (click)="deleteSubtitle(sub.id)">
-                                <svg lucideTrash2 class="h-4 w-4 shrink-0" aria-hidden="true"></svg>
-                                {{ 'media_detail.action_delete' | translate }}
-                              </a>
-                            </li>
-                          </ul>
-                        </div>
+                          <button type="button" class="dropdown-item text-white" (click)="openSyncModal(sub.id)">
+                            <svg lucidePlay class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+                            {{ 'media_detail.action_sync' | translate }}
+                          </button>
+                          <button type="button" class="dropdown-item text-white" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'removeHiTags' })">
+                            <svg lucideVolume2 class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+                            {{ 'media_detail.action_remove_hi' | translate }}
+                          </button>
+                          <button type="button" class="dropdown-item text-white" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'removeStyleTags' })">
+                            <svg lucideCode class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+                            {{ 'media_detail.action_remove_style' | translate }}
+                          </button>
+                          <button type="button" class="dropdown-item text-white" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'removeEmoji' })">
+                            <svg lucideSmile class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+                            {{ 'media_detail.action_remove_emoji' | translate }}
+                          </button>
+                          <button type="button" class="dropdown-item text-white" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'ocrFixes' })">
+                            <svg lucideImage class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+                            {{ 'media_detail.action_ocr_fixes' | translate }}
+                          </button>
+                          <button type="button" class="dropdown-item text-white" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'commonFixes' })">
+                            <svg lucideThermometer class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+                            {{ 'media_detail.action_common_fixes' | translate }}
+                          </button>
+                          <button type="button" class="dropdown-item text-white" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'fixUppercase' })">
+                            <svg lucideMaximize2 class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+                            {{ 'media_detail.action_fix_uppercase' | translate }}
+                          </button>
+                          <button type="button" class="dropdown-item text-white" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'reverseRtl' })">
+                            <svg lucideArrowRightLeft class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+                            {{ 'media_detail.action_reverse_rtl' | translate }}
+                          </button>
+                          <button type="button" class="dropdown-item text-white" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'convertToSrt' })">
+                            <svg lucideFileText class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+                            {{ 'media_detail.action_convert_srt' | translate }}
+                          </button>
+                          <button type="button" class="dropdown-item text-white" (click)="openAdjustModal(sub.id)">
+                            <svg lucideClock class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+                            {{ 'media_detail.action_adjust_times' | translate }}
+                          </button>
+                          <button type="button" class="dropdown-item text-white" (click)="openFpsModal(sub.id)">
+                            <svg lucideZap class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+                            {{ 'media_detail.action_change_fps' | translate }}
+                          </button>
+                          <button type="button" class="dropdown-item text-warning" (click)="blacklistSubtitle(sub)">
+                            <svg lucideBan class="h-4 w-4 shrink-0 opacity-80" aria-hidden="true"></svg>
+                            {{ 'media_detail.action_blacklist' | translate }}
+                          </button>
+                          <button type="button" class="dropdown-item text-error" (click)="deleteSubtitle(sub.id)">
+                            <svg lucideTrash2 class="h-4 w-4 shrink-0" aria-hidden="true"></svg>
+                            {{ 'media_detail.action_delete' | translate }}
+                          </button>
+                        </app-dropdown-menu>
                       }
                     </td>
                   </tr>

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -47,6 +47,7 @@ import { SseService } from '../../../core/services/sse.service';
 import { ToastService } from '../../../core/services/toast.service';
 import { PaginationComponent } from '../pagination/pagination';
 import { MediaDetailSubtitleSearchModalComponent } from '../../../features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component';
+import { DropdownMenuComponent } from '../dropdown-menu';
 import type { MediaInfoHeaderSubtitle } from '../media-info-header/media-info-header';
 
 interface SubtitleRow {
@@ -70,6 +71,7 @@ interface SubtitleRow {
     SubtitleFilenamePipe,
     PaginationComponent,
     MediaDetailSubtitleSearchModalComponent,
+    DropdownMenuComponent,
     LucideArrowRightLeft,
     LucideBan,
     LucideChevronDown,

--- a/client/src/app/shared/directives/dropdown-toggle.directive.ts
+++ b/client/src/app/shared/directives/dropdown-toggle.directive.ts
@@ -4,15 +4,11 @@ import { DismissableStackService } from '../../core/services/dismissable-stack.s
 /**
  * Click-driven `.dropdown-open` toggle for any DaisyUI dropdown trigger.
  *
- * DaisyUI's default open mechanism is `:focus-within`, which we explicitly
- * disable on TV to stop D-pad navigation from auto-opening dropdowns. With
- * focus-within out, dropdowns never open on TV — this directive provides
- * the missing click handler. On web/desktop the focus-within path still
- * works, so the directive is a non-disruptive add-on (clicking the trigger
- * just toggles a class that DaisyUI was already going to apply via focus).
- *
- * Outside clicks and the back button (via DismissableStackService) close
- * the dropdown.
+ * DaisyUI's default open mechanism is `:focus-within`, which we neutralise
+ * globally so Tab / D-pad focus alone never auto-opens a dropdown. With
+ * focus-within out, this directive provides the click / keyboard activation
+ * path. Outside clicks and the back button (via DismissableStackService)
+ * close the dropdown.
  *
  * Usage:
  *   <div class="dropdown">
@@ -24,6 +20,7 @@ import { DismissableStackService } from '../../core/services/dismissable-stack.s
   selector: '[appDropdownToggle]',
   host: {
     '(click)': 'onClick($event)',
+    '(keydown)': 'onKey($event)',
   },
 })
 export class DropdownToggleDirective implements OnDestroy {
@@ -31,6 +28,9 @@ export class DropdownToggleDirective implements OnDestroy {
   private readonly dismissStack = inject(DismissableStackService);
   private outsideClickHandler: ((e: MouseEvent) => void) | null = null;
   private currentClose: (() => void) | null = null;
+  /** The focusable element that opened the dropdown — refocused on close so
+   *  Enter / Space re-opens it without needing to Tab back. */
+  private triggerEl: HTMLElement | null = null;
 
   ngOnDestroy() {
     this.cleanup();
@@ -41,15 +41,29 @@ export class DropdownToggleDirective implements OnDestroy {
     const dropdown = this.host.nativeElement.closest<HTMLElement>('.dropdown');
     if (!dropdown) return;
     const isOpening = !dropdown.classList.contains('dropdown-open');
-    if (isOpening) this.open(dropdown);
-    else this.close();
+    if (isOpening) {
+      const target = (event.target as HTMLElement | null)
+        ?.closest<HTMLElement>('button, a, [tabindex], [role="button"]');
+      this.triggerEl = target ?? this.host.nativeElement;
+      this.open(dropdown);
+    } else {
+      this.close();
+    }
+  }
+
+  /** Enter / Space on a div-based trigger doesn't synthesise a click —
+   *  handle it so keyboard activation opens the dropdown. */
+  protected onKey(event: KeyboardEvent) {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    this.onClick(event);
   }
 
   private open(dropdown: HTMLElement) {
     dropdown.classList.add('dropdown-open');
     const close = () => {
       dropdown.classList.remove('dropdown-open');
-      (this.host.nativeElement as HTMLElement).blur();
+      this.triggerEl?.focus({ preventScroll: true });
       this.cleanup();
     };
     this.currentClose = close;

--- a/client/src/app/shared/directives/tv-row.directive.ts
+++ b/client/src/app/shared/directives/tv-row.directive.ts
@@ -1,9 +1,9 @@
-import { Directive, ElementRef, inject, OnDestroy, OnInit, input } from '@angular/core';
-import { TvService } from '../../core/services/tv.service';
+import { Directive, ElementRef, HostListener, inject, OnDestroy, OnInit, input } from '@angular/core';
 import { TvSpatialNavService } from '../../core/services/tv-spatial-nav.service';
+import { TvService } from '../../core/services/tv.service';
 
 /**
- * Horizontal-orientation container in the TV spatial-nav tree. `←/→` step
+ * Horizontal-orientation container in the spatial-nav tree. `←/→` step
  * between siblings, `↑/↓` exit the row and propagate to the parent
  * section. Last-active card is remembered, so re-entering the row from
  * above/below lands back on it instead of the first card.
@@ -12,8 +12,10 @@ import { TvSpatialNavService } from '../../core/services/tv-spatial-nav.service'
  *
  *   <div appTvRow class="flex overflow-x-auto"> ... </div>
  *
- * No-op outside TV. `[appTvRowWrap]="true"` enables → from the last card
- * looping back to the first (handy on circular content like cast lists).
+ * Registers on every form factor — desktop keyboard users get the same
+ * tree-aware nav as TV D-pad. `[appTvRowWrap]="true"` enables → from the
+ * last card looping back to the first (handy on circular content like
+ * cast lists).
  */
 @Directive({
   selector: '[appTvRow]',
@@ -21,13 +23,17 @@ import { TvSpatialNavService } from '../../core/services/tv-spatial-nav.service'
 })
 export class TvRowDirective implements OnInit, OnDestroy {
   private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
-  private readonly tv = inject(TvService);
   private readonly nav = inject(TvSpatialNavService);
+  private readonly tv = inject(TvService);
 
   readonly appTvRowWrap = input(false);
+  /** Smooth-scroll the page so the row sits 24 px below the viewport top
+   *  when focus enters from outside. Used on standalone rows (e.g. the
+   *  top-right cast/user dock) that aren't wrapped in
+   *  `<app-horizontal-scroller>`, which has the same behaviour built-in. */
+  readonly appTvRowSnap = input(false);
 
   ngOnInit(): void {
-    if (!this.tv.isTv()) return;
     this.nav.registerContainer(this.host.nativeElement, {
       orientation: 'horizontal',
       isWrapping: this.appTvRowWrap(),
@@ -35,7 +41,33 @@ export class TvRowDirective implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    if (!this.tv.isTv()) return;
     this.nav.unregisterContainer(this.host.nativeElement);
+  }
+
+  @HostListener('focusin', ['$event'])
+  protected onFocusIn(event: FocusEvent): void {
+    if (!this.appTvRowSnap()) return;
+    const from = event.relatedTarget as Node | null;
+    if (from && this.host.nativeElement.contains(from)) return;
+    queueMicrotask(() => this.snapToRowTop());
+  }
+
+  private snapToRowTop(): void {
+    if (typeof window === 'undefined') return;
+    const scrollEl = document.scrollingElement ?? document.documentElement;
+    const rect = this.host.nativeElement.getBoundingClientRect();
+    const currentTop = scrollEl.scrollTop ?? 0;
+    const TOP_OFFSET = this.tv.isTv() ? 96 : 24;
+    // Skip when the row is already fully visible: the user is just walking
+    // between visible rows, no scroll needed.
+    const viewportH = window.innerHeight;
+    if (rect.top >= TOP_OFFSET && rect.bottom <= viewportH) return;
+    const targetTop = Math.max(0, currentTop + rect.top - TOP_OFFSET);
+    if (Math.abs(targetTop - currentTop) < 4) return;
+    try {
+      window.scrollTo({ top: targetTop, left: 0, behavior: 'smooth' });
+    } catch {
+      window.scrollTo(0, targetTop);
+    }
   }
 }

--- a/client/src/app/shared/directives/tv-section.directive.ts
+++ b/client/src/app/shared/directives/tv-section.directive.ts
@@ -1,9 +1,8 @@
 import { Directive, ElementRef, inject, OnDestroy, OnInit, input } from '@angular/core';
-import { TvService } from '../../core/services/tv.service';
 import { TvSpatialNavService } from '../../core/services/tv-spatial-nav.service';
 
 /**
- * Marks a region as a vertical-orientation container in the TV spatial-nav
+ * Marks a region as a vertical-orientation container in the spatial-nav
  * tree. `↑/↓` step between this section's direct navigable children
  * (registered sub-containers + focusable leaves), `←/→` walk inside its
  * sub-containers as defined by their own orientation.
@@ -12,8 +11,9 @@ import { TvSpatialNavService } from '../../core/services/tv-spatial-nav.service'
  *
  *   <main appTvSection> ... </main>
  *
- * No-op outside TV (the directive registers nothing). Companion to
- * `[appTvRow]` for horizontal regions.
+ * Registers on every form factor — desktop keyboard users get the same
+ * tree-aware nav as TV D-pad. Companion to `[appTvRow]` for horizontal
+ * regions.
  *
  * Set `[appTvSectionWrap]="true"` to make ↑ from the first child wrap to
  * the last (rare; typically left off so the user doesn't loop the whole
@@ -25,13 +25,11 @@ import { TvSpatialNavService } from '../../core/services/tv-spatial-nav.service'
 })
 export class TvSectionDirective implements OnInit, OnDestroy {
   private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
-  private readonly tv = inject(TvService);
   private readonly nav = inject(TvSpatialNavService);
 
   readonly appTvSectionWrap = input(false);
 
   ngOnInit(): void {
-    if (!this.tv.isTv()) return;
     this.nav.registerContainer(this.host.nativeElement, {
       orientation: 'vertical',
       isWrapping: this.appTvSectionWrap(),
@@ -39,7 +37,6 @@ export class TvSectionDirective implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    if (!this.tv.isTv()) return;
     this.nav.unregisterContainer(this.host.nativeElement);
   }
 }

--- a/client/src/app/shared/directives/tv-select.directive.ts
+++ b/client/src/app/shared/directives/tv-select.directive.ts
@@ -1,18 +1,19 @@
 import { Directive, ElementRef, HostListener, inject, input } from '@angular/core';
-import { TvService } from '../../core/services/tv.service';
 import { SelectPickerService } from '../../core/services/select-picker.service';
 
 /**
- * Apposed on a native `<select>`. On TV, intercepts the open gesture
- * (Enter / Space / click) and routes through SelectPickerService for a
- * styled popover. The native element stays in DOM as the value source so
- * existing `[(ngModel)]` / `(change)` bindings are unaffected.
+ * Apposed on a native `<select>`. Intercepts the open gesture (mouse,
+ * Enter, Space) on every form factor and routes through
+ * SelectPickerService for a consistent styled popover. The native element
+ * stays in DOM as the value source so existing `[(ngModel)]` / `(change)`
+ * bindings are unaffected.
  *
  * Arrow keys are intentionally NOT captured here: the global
  * `TvSpatialNavService` already preventDefaults arrow events on a focused
- * `<select>` (blocking native option-cycling) and decides the next focus
- * target — tree-aware when the surrounding region is annotated, rect-based
- * fallback otherwise. Adding arrow handlers here would race with that.
+ * `<select appTvSelect>` (blocking native option-cycling) and decides the
+ * next focus target — tree-aware when the surrounding region is annotated,
+ * rect-based fallback otherwise. Adding arrow handlers here would race
+ * with that.
  *
  * Usage: `<select appTvSelect [(ngModel)]="x">…</select>`
  */
@@ -22,7 +23,6 @@ import { SelectPickerService } from '../../core/services/select-picker.service';
 })
 export class TvSelectDirective {
   private readonly host = inject<ElementRef<HTMLSelectElement>>(ElementRef);
-  private readonly tv = inject(TvService);
   private readonly picker = inject(SelectPickerService);
 
   /** Optional sheet title shown above the option list. */
@@ -32,7 +32,6 @@ export class TvSelectDirective {
   @HostListener('keydown.enter', ['$event'])
   @HostListener('keydown.space', ['$event'])
   protected onOpen(e: Event) {
-    if (!this.tv.isTv()) return;
     e.preventDefault();
     e.stopPropagation();
     this.picker.show(this.host.nativeElement, this.appTvSelect());

--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -93,8 +93,9 @@
     ></div>
     <!-- Desktop top-right: Cast + User -->
     <div appTvRow
+         [appTvRowSnap]="true"
          class="hidden items-center justify-end gap-1 absolute right-4 z-50 pointer-events-none [&>*]:pointer-events-auto"
-         style="top: calc(0.75rem + env(safe-area-inset-top, 0px))"
+         [style.top]="tv.isTv() ? 'calc(4rem + env(safe-area-inset-top, 0px))' : 'calc(1.5rem + env(safe-area-inset-top, 0px))'"
          [class.lg:flex]="device.isDesktop() || (device.isTv() && navbar.effectiveSidebarPinned())"
          [class.md:flex]="device.isTablet() && navbar.effectiveSidebarPinned()">
       @if (castPlayer.hasMedia()) {
@@ -256,7 +257,7 @@
            [class.backdrop-blur-sm]="!!background.url()"
            style="padding-top: calc(env(safe-area-inset-top, 0px) / 2 )">
       <div class="p-4 border-b border-base-200 flex items-center gap-2">
-        <a routerLink="/" class="flex items-center gap-2 pl-2 text-2xl font-bold flex-1 min-w-0">
+        <a routerLink="/" class="flex items-center gap-2 px-2 py-1 rounded-lg text-2xl font-bold flex-1 min-w-0">
           <img src="fliks-mark.png" alt="" class="h-8 w-8 shrink-0" />
           <span class="truncate">{{ 'app.name' | translate }}</span>
         </a>

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -235,10 +235,24 @@ body.tv app-media-card .opacity-0.group-hover\:opacity-100 {
    `z-index` keeps it above the cover image. The matching
    `outline: none` defeats the generic ring above that would draw a
    duplicate outer ring at offset:4. */
-app-media-card figure:focus-visible {
+/* Inset focus ring for card-shaped focusables — applied to
+   `app-media-card`'s inner figure and to any home card that opts in
+   via `[data-home-focus]` (libraries, continue-watching, etc.).
+   Draws the ring INSIDE the element via `::after { inset: 0;
+   border: 3px }` so it follows the card's own `border-radius` and
+   sits on top of stacking contexts that the cover image would
+   otherwise occlude (lingering `view-transition-name`). The matching
+   `outline: none` defeats the generic outline that would draw a
+   duplicate outer ring at offset:4.
+   `position: relative` is added on focus so the pseudo can anchor
+   to the element even when its layout didn't already position it. */
+app-media-card figure:focus-visible,
+[data-home-focus]:focus-visible {
   outline: none !important;
+  position: relative;
 }
-app-media-card figure:focus-visible::after {
+app-media-card figure:focus-visible::after,
+[data-home-focus]:focus-visible::after {
   content: '';
   position: absolute;
   inset: 0;

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -190,9 +190,10 @@ html.tv-host {
 body.tv *:hover {
   background-color: revert;
 }
-/* High-contrast focus ring for D-pad navigation */
-body.tv :is(a, button, [role="button"], [tabindex]):focus-visible,
-body.tv :is(a, button, [role="button"], [tabindex]):focus {
+/* High-contrast primary focus ring — applies on every form factor so
+   keyboard / D-pad navigation looks identical. `:focus-visible` only
+   so mouse clicks on desktop don't paint a ring after activation. */
+:is(a, button, [role="button"], [tabindex]):focus-visible {
   outline: 3px solid var(--color-primary, #7a3ff2);
   outline-offset: 4px;
   z-index: 1;
@@ -208,11 +209,11 @@ body.tv .btn-ghost:focus-visible {
   background-color: transparent !important;
   --btn-bg: rgba(0, 0, 0, 0) !important;
 }
-/* Cards/list items — scale up on focus to give a clear "selected" affordance */
+/* Cards/list items — scale up on focus to give a clear "selected"
+   affordance on TV. Desktop users get the focus ring + native hover
+   states; the extra scale would feel jumpy alongside the pointer. */
 body.tv .media-card:focus-within,
-body.tv .media-card:focus,
-body.tv [data-tv-focusable]:focus-visible,
-body.tv [data-tv-focusable]:focus {
+body.tv [data-tv-focusable]:focus-visible {
   transform: scale(1.06);
   transition: transform 0.15s ease-out;
 }
@@ -226,20 +227,18 @@ body.tv app-media-card figure > .absolute.inset-0,
 body.tv app-media-card .opacity-0.group-hover\:opacity-100 {
   display: none !important;
 }
-/* Card focus on TV — drawn as an absolutely-positioned pseudo-element so
-   the ring overlays the cover image AND repaints reliably even when the
-   img sits in its own stacking context (the lingering view-transition-name
-   on the clicked card creates one). `border-radius: inherit` follows the
-   figure's `rounded-lg`, `inset: 0` snaps to its border-box, `z-index`
-   keeps it above the cover image. The matching `outline: none` defeats
-   the generic body.tv :focus rule that would otherwise draw a duplicate
-   outer ring at offset:4. */
-body.tv app-media-card figure:focus,
-body.tv app-media-card figure:focus-visible {
+/* Card focus ring — drawn as an absolutely-positioned pseudo-element
+   so it overlays the cover image AND repaints reliably even when the
+   img sits in its own stacking context (lingering view-transition-name
+   on the clicked card creates one). `border-radius: inherit` follows
+   the figure's `rounded-lg`, `inset: 0` snaps to its border-box,
+   `z-index` keeps it above the cover image. The matching
+   `outline: none` defeats the generic ring above that would draw a
+   duplicate outer ring at offset:4. */
+app-media-card figure:focus-visible {
   outline: none !important;
 }
-body.tv app-media-card figure:focus::after,
-body.tv app-media-card figure:focus-visible::after {
+app-media-card figure:focus-visible::after {
   content: '';
   position: absolute;
   inset: 0;

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -192,10 +192,20 @@ body.tv *:hover {
 }
 /* High-contrast primary focus ring — applies on every form factor so
    keyboard / D-pad navigation looks identical. `:focus-visible` only
-   so mouse clicks on desktop don't paint a ring after activation. */
-:is(a, button, [role="button"], [tabindex]):focus-visible {
-  outline: 3px solid var(--color-primary, #7a3ff2);
-  outline-offset: 4px;
+   so mouse clicks on desktop don't paint a ring after activation.
+   Rendered as a two-layer box-shadow (page-bg gap + primary ring)
+   instead of `outline` because `outline` ignores `border-radius` on
+   Chromium <94 (Tizen 6.5 ships Chromium ~85), which would paint a
+   rectangle around a rounded button. box-shadow follows border-radius
+   everywhere. The inner layer uses `--color-base-100` (the surrounding
+   page bg in this dark theme) so the gap looks transparent over the
+   common backgrounds — a real `transparent` value can't be used here
+   because the second shadow shows through it. */
+:is(a, button, select, input, [role="button"], [tabindex]):focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--color-base-100, #1d232a),
+    0 0 0 4px var(--color-primary, #7a3ff2);
   z-index: 1;
   position: relative;
 }
@@ -209,13 +219,19 @@ body.tv .btn-ghost:focus-visible {
   background-color: transparent !important;
   --btn-bg: rgba(0, 0, 0, 0) !important;
 }
-/* Cards/list items — scale up on focus to give a clear "selected"
-   affordance on TV. Desktop users get the focus ring + native hover
-   states; the extra scale would feel jumpy alongside the pointer. */
+/* Cards / list items — gentle scale on keyboard / D-pad focus so the
+   selected card "lifts" off the grid. Smaller bump on desktop (mouse
+   users already get hover feedback), bigger on TV for the 10-foot UI. */
+app-media-card figure:focus-visible,
+[data-home-focus]:focus-visible {
+  transform: scale(1.04);
+  transition: transform 0.15s ease-out;
+}
 body.tv .media-card:focus-within,
+body.tv app-media-card figure:focus-visible,
+body.tv [data-home-focus]:focus-visible,
 body.tv [data-tv-focusable]:focus-visible {
   transform: scale(1.06);
-  transition: transform 0.15s ease-out;
 }
 
 /* Media-card simplification on TV: the card is a single focus target. The
@@ -227,39 +243,21 @@ body.tv app-media-card figure > .absolute.inset-0,
 body.tv app-media-card .opacity-0.group-hover\:opacity-100 {
   display: none !important;
 }
-/* Card focus ring — drawn as an absolutely-positioned pseudo-element
-   so it overlays the cover image AND repaints reliably even when the
-   img sits in its own stacking context (lingering view-transition-name
-   on the clicked card creates one). `border-radius: inherit` follows
-   the figure's `rounded-lg`, `inset: 0` snaps to its border-box,
-   `z-index` keeps it above the cover image. The matching
-   `outline: none` defeats the generic ring above that would draw a
-   duplicate outer ring at offset:4. */
-/* Inset focus ring for card-shaped focusables — applied to
-   `app-media-card`'s inner figure and to any home card that opts in
-   via `[data-home-focus]` (libraries, continue-watching, etc.).
-   Draws the ring INSIDE the element via `::after { inset: 0;
-   border: 3px }` so it follows the card's own `border-radius` and
-   sits on top of stacking contexts that the cover image would
-   otherwise occlude (lingering `view-transition-name`). The matching
-   `outline: none` defeats the generic outline that would draw a
-   duplicate outer ring at offset:4.
-   `position: relative` is added on focus so the pseudo can anchor
-   to the element even when its layout didn't already position it. */
+/* Card focus — Lumen "lit-from-within" ring inspired by
+   mediaplatform-hub/frontend-tv: 2 px spacer in the surface colour,
+   4 px primary ring outside that, plus a soft primary glow and a
+   drop shadow so the focused card lifts off the rail on any bg.
+   Spread sits at 0 offset (against the element edge) so it follows
+   the card's `border-radius` — needed because Tizen 6.5 Chromium 85
+   would otherwise paint a rectangle (outline-without-radius). */
 app-media-card figure:focus-visible,
 [data-home-focus]:focus-visible {
   outline: none !important;
-  position: relative;
-}
-app-media-card figure:focus-visible::after,
-[data-home-focus]:focus-visible::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border: 3px solid var(--color-primary, #7a3ff2);
-  border-radius: inherit;
-  pointer-events: none;
-  z-index: 10;
+  box-shadow:
+    0 0 0 2px var(--color-base-100, #1d232a),
+    0 0 0 6px var(--color-primary, #7a3ff2),
+    0 0 18px -4px var(--color-primary, #7a3ff2),
+    0 8px 22px rgb(0 0 0 / 35%) !important;
 }
 /* Touch-only UI elements should be hidden on TV */
 body.tv [data-touch-only] {
@@ -327,10 +325,11 @@ body.tv .to-base-100\/50 {
   --tw-gradient-to: transparent;
 }
 
-/* TV: dropdowns are signal-controlled (`.dropdown-open`). Neutralise any
-   `:focus-within` fallback that DaisyUI might re-introduce — D-pad focus alone
-   should never auto-open a dropdown. */
-body.tv .dropdown:not(.dropdown-open) > .dropdown-content {
+/* Dropdowns are click-driven (`.dropdown-open` toggled by
+   `appDropdownToggle`). Neutralise DaisyUI's `:focus-within` fallback so
+   tabbing onto a trigger never auto-opens the menu — Tab/D-pad focus alone
+   should be a focus move, not an open. */
+.dropdown:not(.dropdown-open) > .dropdown-content {
   display: none !important;
 }
 
@@ -374,6 +373,12 @@ html.tv-host .toggle {
      Uses a translucent base-content colour — works on both light & dark
      themes (darkens on light bg, lightens on dark bg). */
   background-color: rgba(128, 128, 128, 0.35);
+  /* DaisyUI v5's default `border-radius: var(--rounded-btn)` is stripped
+     by the downlevel CSS pipeline on Tizen 6.5 (Chromium 85) — explicit
+     pill radius so the toggle stays rounded AND the box-shadow focus
+     ring inherits it. Without this, focus paints a rectangle around the
+     pill. */
+  border-radius: 9999px;
 }
 html.tv-host .toggle:before {
   width: 1.125rem;


### PR DESCRIPTION
`TvSpatialNavService` already drove D-pad arrow handling on TV with a container tree (`appTvRow` / `appTvSection`) + rect-based fallback. Lifting the `tv.isTv()` gate so the same service binds on every form factor — desktop / laptop users get arrow-key spatial focus moves across the same logical tree without touching call-sites.

## TV-only quirks scoped behind `tv.isTv()`
- `focusFirstIfNoFocus` (Android TV WebView workaround that steals initial focus on bootstrap) — desktop keeps whatever focus the browser restores.
- The arrow-skip policy: on desktop any `<input>` or `<select>` defers entirely to native handling (caret, value cycle, number stepper, range adjust…). TV keeps the narrower rules unchanged (left/right caret on text inputs, spatial nav on every other field).

10-foot styles (font scale, focus rings, container scale) stay gated on `body.tv` so the desktop chrome is untouched. Browser `:focus-visible` provides the focus affordance via the default user-agent ring.

## Test plan
- [ ] Desktop browser: arrow keys move focus across the home, library, media-detail (same logical tree as TV).
- [ ] Desktop: typing in any `<input>` / `<textarea>` works (arrows don't escape).
- [ ] Desktop: `<select>` cycles its options on arrows (no spatial steal).
- [ ] Desktop: `<input type="range">` adjusts value on arrows.
- [ ] TV: no regression, D-pad still navigates as before.