### PR TITLE
feat(nav): keyboard nav polish — focus opt-out, input boundary, popover sizing

### DIFF
--- a/client/src/app/core/services/tv-spatial-nav.service.ts
+++ b/client/src/app/core/services/tv-spatial-nav.service.ts
@@ -178,19 +178,32 @@ export class TvSpatialNavService {
     ]);
     const isInputWithNativeArrows = tag === 'INPUT' && NATIVE_INPUT_TYPES.has(inputType ?? 'text');
 
-    // Desktop / laptop: defer entirely to native for fields that actually
-    // use arrows (caret in text, value cycle in number / range / date /
-    // select). TV keeps the narrower skip list below for the same fields.
-    // `<select appTvSelect>` opts out — the directive routes opens through
-    // SelectPickerService, so arrow keys should escape to spatial nav
-    // instead of silently cycling the underlying native value.
+    // `<select appTvSelect>` opts out of native arrow handling — the
+    // directive routes opens through SelectPickerService, so arrow keys
+    // should escape to spatial nav instead of silently cycling the
+    // underlying native value.
     const isPickerSelect = tag === 'SELECT' && active?.hasAttribute('appTvSelect');
-    if (!this.tv.isTv() && (isInputWithNativeArrows || (tag === 'SELECT' && !isPickerSelect))) return;
-
-    // TV mode: text-style inputs own horizontal arrows (caret); other arrow
-    // directions and other inputs escape to the spatial-nav tree so the
-    // D-pad user isn't trapped on a field.
-    if (isInputWithNativeArrows && inputType !== 'range' && (dir === 'left' || dir === 'right')) return;
+    // Native <select> (without the picker directive): always defer to
+    // native; left/right cycles options, up/down opens the dropdown.
+    if (tag === 'SELECT' && !isPickerSelect) return;
+    // Text-style inputs own horizontal arrows (caret movement) — defer
+    // left/right to native UNTIL the caret hits the end of the value, at
+    // which point the arrow should escape to spatial nav instead of
+    // dead-ending on a no-op caret move. Up/down don't move the caret on
+    // single-line inputs, so they escape unconditionally. Range inputs
+    // are excluded (their arrows adjust the value on every axis).
+    if (isInputWithNativeArrows && inputType !== 'range' && (dir === 'left' || dir === 'right')) {
+      const input = active as HTMLInputElement;
+      const value = input.value ?? '';
+      const start = input.selectionStart ?? 0;
+      const end = input.selectionEnd ?? 0;
+      const hasSelection = start !== end;
+      const atStart = !hasSelection && start === 0;
+      const atEnd = !hasSelection && end === value.length;
+      if (dir === 'left' && !atStart) return;
+      if (dir === 'right' && !atEnd) return;
+      // Caret at boundary → fall through to spatial nav.
+    }
     // Native `<select>` cycles its options on arrow keys (changing the
     // value silently). Always block that on TV. We still try to move focus
     // — if a tree-aware neighbour exists, the user goes there; otherwise
@@ -225,8 +238,13 @@ export class TvSpatialNavService {
     // No focusable neighbour: scroll the page manually so the user can
     // reach informational content (file infos, descriptions, etc.) that
     // sits below the last focusable card. Up/down only — left/right at a
-    // boundary should just block (intra-row).
-    if (dir === 'down' || dir === 'up') {
+    // boundary should just block (intra-row). Skip when a modal trap is
+    // active (open popover / dropdown / bottom-sheet): the user hitting
+    // the boundary inside a menu shouldn't drift the page underneath.
+    const modalOpen =
+      !!document.querySelector('[data-tv-modal]') ||
+      !!document.querySelector('.dropdown-open .dropdown-content');
+    if (!modalOpen && (dir === 'down' || dir === 'up')) {
       window.scrollBy({ top: dir === 'down' ? 300 : -300, behavior: 'smooth' });
     }
   }

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -6,7 +6,7 @@
   }
 
   <!-- View tabs (own row, centered like the reference) -->
-  <nav class="flex items-center gap-1 mt-2 overflow-x-auto">
+  <nav class="flex items-center gap-1 mt-2 overflow-x-auto py-2 -my-2 px-2 -mx-2">
     <button
       type="button"
       class="px-4 py-1.5 rounded-full text-sm font-medium transition-colors whitespace-nowrap"
@@ -92,6 +92,7 @@
 
       <div class="flex items-center gap-1">
         <select
+          appTvSelect
           class="select select-bordered select-sm w-fit"
           [ngModel]="sortBy()"
           (ngModelChange)="onSortByChange($event)"
@@ -315,6 +316,7 @@
       <div class="sticky bottom-0 z-20 bg-base-200 border-t border-base-300 px-4 py-3 flex flex-wrap items-center gap-3 shadow-lg rounded-t-lg">
         <span class="font-semibold text-sm">{{ 'library.bulk_selected' | translate:{ count: selectedIds().size } }}</span>
         <select
+          appTvSelect
           class="select select-bordered select-sm"
           [ngModel]="bulkQualityProfileId()"
           (ngModelChange)="bulkQualityProfileId.set($event)"
@@ -325,6 +327,7 @@
           }
         </select>
         <select
+          appTvSelect
           class="select select-bordered select-sm"
           [ngModel]="bulkMonitored()"
           (ngModelChange)="bulkMonitored.set($event)"

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -22,6 +22,7 @@ import { ProfilesService, QualityProfile } from '../../core/services/api/profile
 import { LibrariesApiService, LibrarySummary } from '../../core/services/api/libraries-api.service';
 import { MediaCardComponent } from '../../shared/components/media-card/media-card';
 import { DropdownMenuComponent } from '../../shared/components/dropdown-menu';
+import { TvSelectDirective } from '../../shared/directives/tv-select.directive';
 import { HorizontalScrollerComponent } from '../../shared/components/horizontal-scroller';
 import type {
   ContinueWatchingItem,
@@ -60,6 +61,7 @@ const NATURAL_ORDER_BY_SORT: Record<string, SortOrder> = {
   imports: [
     MediaCardComponent,
     DropdownMenuComponent,
+    TvSelectDirective,
     HorizontalScrollerComponent,
     FormsModule,
     TranslateModule,

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -313,9 +313,9 @@
     <div class="cv-auto" style="contain-intrinsic-size: auto 12rem">
     <app-horizontal-scroller [title]="'media_detail.cast' | translate">
       @for (c of cast(); track c.id) {
-        <a [routerLink]="['/persons', c.person.id]" class="shrink-0 w-20 sm:w-24 flex flex-col items-center gap-1.5 group tv:focus:outline-none! tv:focus-visible:outline-none!">
+        <a [routerLink]="['/persons', c.person.id]" data-no-focus-ring class="shrink-0 w-20 sm:w-24 flex flex-col items-center gap-1.5 group">
           <div class="avatar">
-            <div class="w-16 h-16 sm:w-20 sm:h-20 rounded-full ring ring-base-200 group-hover:ring-primary group-focus:ring-primary group-focus-visible:ring-primary group-focus:ring-2 group-focus-visible:ring-2 transition-colors">
+            <div class="w-16 h-16 sm:w-20 sm:h-20 rounded-full ring ring-base-200 group-hover:ring-primary group-focus:ring-primary group-focus-visible:ring-primary group-focus:ring-4 group-focus-visible:ring-4 group-focus:ring-offset-2 group-focus-visible:ring-offset-2 group-focus:ring-offset-base-100 group-focus-visible:ring-offset-base-100 transition-colors">
               @if (c.person.avatarUrl) {
                 <img appImgFadeIn [src]="c.person.avatarUrl | resolveUrl:'thumb'" [alt]="c.person.name" loading="lazy" decoding="async" fetchpriority="low" />
               } @else {

--- a/client/src/app/shared/components/media-info-extra/media-info-extra.html
+++ b/client/src/app/shared/components/media-info-extra/media-info-extra.html
@@ -54,7 +54,7 @@
           <dt class="text-base-content/50 text-sm">{{ 'media_info.genres' | translate }}</dt>
           <dd class="font-medium text-base flex flex-wrap">
             @for (genre of genres(); track genre; let last = $last) {
-              <span><button type="button" class="hover:underline" (click)="navigateToGenre(genre)">{{ genre }}</button>@if (!last){<span>,&nbsp;</span>}</span>
+              <span><button type="button" class="hover:underline rounded px-1" (click)="navigateToGenre(genre)">{{ genre }}</button>@if (!last){<span>,&nbsp;</span>}</span>
             }
           </dd>
         </div>

--- a/client/src/app/shared/components/popover-menu.ts
+++ b/client/src/app/shared/components/popover-menu.ts
@@ -47,10 +47,11 @@ import { DismissableStackService } from '../../core/services/dismissable-stack.s
       <div class="fixed inset-0 z-[100]" (click)="close()"></div>
       <div
         data-tv-modal
-        class="fixed z-[101] bg-base-200 rounded-box shadow-xl overflow-hidden"
+        class="fixed z-[101] bg-base-200 rounded-box shadow-xl overflow-y-auto p-2 [scroll-padding:0.5rem] [scroll-behavior:smooth]"
         [style.top.px]="position().top"
         [style.left.px]="position().left"
         [style.min-width.px]="position().width"
+        [style.max-height.px]="position().maxHeight"
       >
         <ng-container *ngTemplateOutlet="content"></ng-container>
       </div>
@@ -97,9 +98,17 @@ export class PopoverMenuComponent {
     effect((onCleanup) => {
       if (!this.open()) return;
       queueMicrotask(() => {
-        this.host.nativeElement
-          .querySelector<HTMLElement>('a[href], button:not([disabled]), [tabindex="0"]')
-          ?.focus({ preventScroll: false });
+        // Prefer the active item (caller marks it with `[autofocus]` or
+        // `[aria-current]`) so the user lands on the current selection
+        // instead of having to scroll through the list. Falls back to the
+        // first focusable when nothing's marked active.
+        const root = this.host.nativeElement;
+        const target =
+          root.querySelector<HTMLElement>('[autofocus]:not([disabled])') ??
+          root.querySelector<HTMLElement>('[aria-current="true"]:not([disabled])') ??
+          root.querySelector<HTMLElement>('a[href], button:not([disabled]), [tabindex="0"]');
+        target?.focus({ preventScroll: false });
+        target?.scrollIntoView({ block: 'nearest', behavior: 'instant' as ScrollBehavior });
       });
       // Register with the dismissable stack so Escape (browser) and the
       // hardware back button (Capacitor / Tizen) close the popover.
@@ -113,18 +122,26 @@ export class PopoverMenuComponent {
   readonly useDropdown = computed(() => !this.tv.isTv() && !this.device.isTouch());
 
   /** Recomputed every render. The parent passes anchor by ref so we can
-   *  read its bounding box at open time without an explicit signal. */
+   *  read its bounding box at open time without an explicit signal.
+   *  `maxHeight` is capped to the available space between the popover's
+   *  edge and the viewport edge so a long list doesn't overflow off-screen
+   *  (the internal `overflow-y-auto` only scrolls content INSIDE the box,
+   *  it doesn't help when the box itself is taller than the viewport). */
   readonly position = computed(() => {
     const a = this.anchor();
-    if (!a) return { top: 0, left: 0, width: 0 };
+    if (!a) return { top: 0, left: 0, width: 0, maxHeight: 0 };
     const r = a.getBoundingClientRect();
     const placement = this.placement();
     const onTop = placement.startsWith('top');
     const onEnd = placement.endsWith('end');
+    const GUTTER = 8;
+    const viewportH = typeof window !== 'undefined' ? window.innerHeight : 800;
+    const maxHeight = onTop ? r.top - GUTTER * 2 : viewportH - r.bottom - GUTTER * 2;
     return {
-      top: onTop ? r.top - 8 : r.bottom + 8,
+      top: onTop ? r.top - GUTTER : r.bottom + GUTTER,
       left: onEnd ? r.right - 240 : r.left,
       width: 240,
+      maxHeight: Math.max(120, maxHeight),
     };
   });
 

--- a/client/src/app/shared/components/seekbar/seekbar.html
+++ b/client/src/app/shared/components/seekbar/seekbar.html
@@ -1,4 +1,5 @@
 <div
+  data-no-focus-ring
   class="group relative w-full flex items-center cursor-pointer touch-none focus:outline-none"
   [class]="variant() === 'player' ? 'h-6' : 'h-5'"
   tabindex="0"
@@ -77,7 +78,7 @@
   <!-- Thumb -->
   @if (showThumb()) {
     <div
-      class="absolute h-3.5 w-3.5 rounded-full bg-white shadow -translate-x-1/2 pointer-events-none group-hover:scale-125 transition-transform"
+      class="seekbar-thumb absolute h-3.5 w-3.5 rounded-full bg-white shadow -translate-x-1/2 pointer-events-none group-hover:scale-125 transition-all"
       [class.scale-125]="dragging()"
       [style.left.%]="displayPercent()"
     ></div>

--- a/client/src/app/shared/components/select-picker.ts
+++ b/client/src/app/shared/components/select-picker.ts
@@ -27,6 +27,7 @@ import { PopoverMenuComponent } from './popover-menu';
         <button
           type="button"
           [disabled]="opt.disabled"
+          [attr.aria-current]="opt.selected ? 'true' : null"
           class="dropdown-item"
           [class.text-primary]="opt.selected"
           [class.text-white]="!opt.selected"

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -209,6 +209,27 @@ body.tv *:hover {
   z-index: 1;
   position: relative;
 }
+/* Opt-out for focusables that paint their own focus affordance (e.g.
+   round avatar with a ring-primary on the inner div). The default
+   rectangle would draw a competing outer ring around the card. */
+[data-no-focus-ring]:focus-visible,
+[data-no-focus-ring]:focus {
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+/* Seekbar thumb: when its parent slider has focus, paint a primary ring
+   around the white dot with a 2 px base-100 gap. Implemented as plain
+   box-shadow so the rule works on Tizen 6.5 / Chromium 85 where
+   Tailwind v4's `ring-*` utilities can lose their custom-property
+   wiring through the downlevel CSS pipeline. */
+[role="slider"]:focus .seekbar-thumb,
+[role="slider"]:focus-visible .seekbar-thumb {
+  box-shadow:
+    0 0 0 2px var(--color-base-100, #1d232a),
+    0 0 0 4px var(--color-primary, #7a3ff2);
+  transform: translateX(-50%) scale(1.25);
+}
 /* TV ghost buttons keep their transparent bg even when focused. The
    3px primary-color outline above is already a strong focus cue on a
    10-foot UI, so layering daisyUI's fill (which kicks in via the


### PR DESCRIPTION
## Summary
- Focus ring opt-out via `[data-no-focus-ring]` (cast avatars, seekbar) so elements with their own focus affordance don't get a competing rectangle.
- Cast avatars + genres + library tabs: tweak markup so rings follow the element shape and aren't clipped by `overflow-x:auto`.
- Text inputs no longer trap focus — left/right defers to native only while the caret is mid-value; once at the boundary the arrow escapes to spatial nav.
- Popover-menu: dynamic `maxHeight` from anchor position so long lists never spill out of the viewport; `[autofocus]` / `aria-current` lands focus on the active value at open; smooth in-popover scroll; modal-trap blocks the boundary-scroll fallback so opening a long picker doesn't drift the page underneath.
- Seekbar thumb focus ring rewritten as flat box-shadow in `styles.css` (matches universal proportions: 2 px base-100 gap + 4 px primary) — Tailwind v4's ring utilities lose their custom-property wiring on Tizen 6.5 / Chromium 85.
- `appTvSelect` added to the 3 remaining native `<select>`s in library page (sort, bulk quality, bulk monitored).

## Test plan
- [ ] Browser: Tab through media-detail cast list — round avatar ring shows in primary, no rectangle.
- [ ] Browser: Tab through genres — pill-rounded focus ring.
- [ ] Browser + TV: library tabs first/last item — full ring, no clipping.
- [ ] Browser + TV: focus a search input, press right at end of value → focus exits to next element.
- [ ] Browser + TV: open a long subtitle picker, scroll inside without page scrolling underneath.
- [ ] Browser + TV: open a picker on a select that has a current value → that value is focused on open.
- [ ] TV: seekbar focus shows primary ring with 2 px gap around the white dot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)