### PR TITLE
feat(ui): TV polish — focus lock, transient admin drawer, denser cards

### DIFF
--- a/client/android/app/src/main/AndroidManifest.xml
+++ b/client/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
     <application
         android:usesCleartextTraffic="true"
         android:allowBackup="true"
+        android:hardwareAccelerated="true"
+        android:largeHeap="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:banner="@drawable/tv_banner"

--- a/client/src/app/core/services/tv-spatial-nav.service.ts
+++ b/client/src/app/core/services/tv-spatial-nav.service.ts
@@ -260,13 +260,22 @@ export class TvSpatialNavService {
       const tree = this.findNeighborInTree(active, dir);
       if (tree) return tree;
     }
-    // Focus trap: any open dropdown/menu/bottom-sheet that opts in via
-    // `[data-tv-modal]` (or `.dropdown-open .dropdown-content` for the
-    // legacy player dropdowns) restricts navigation to its contents so
-    // D-pad keys can't escape the modal.
+    // Focus trap: any open dropdown / menu / bottom-sheet / always-visible
+    // pinned sidebar that opts in via `[data-tv-modal]` restricts
+    // navigation to its contents so arrow keys can't leak outside. Only
+    // applies when focus is CURRENTLY inside the modal — otherwise an
+    // always-on element (e.g. the pinned admin sidebar) would prevent
+    // ever reaching it from elsewhere on the page. The `.dropdown-open
+    // .dropdown-content` form is kept for the legacy player dropdowns
+    // that don't carry the attribute.
+    const modalCandidates: HTMLElement[] = [
+      ...Array.from(document.querySelectorAll<HTMLElement>('[data-tv-modal]')),
+      ...Array.from(
+        document.querySelectorAll<HTMLElement>('.dropdown-open .dropdown-content'),
+      ),
+    ];
     const openModal =
-      document.querySelector<HTMLElement>('[data-tv-modal]') ??
-      document.querySelector<HTMLElement>('.dropdown-open .dropdown-content');
+      modalCandidates.find((m) => active && m.contains(active)) ?? null;
     const all = openModal ? collectFocusables(openModal) : collectFocusables();
     if (!all.length) return null;
 

--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -49,7 +49,7 @@
       <app-horizontal-scroller [title]="'home.recommendations' | translate">
         @for (rec of recommendations(); track rec.media.id) {
           <app-media-card
-            class="shrink-0 w-32 sm:w-40"
+            class="shrink-0 w-28 sm:w-40"
             [attr.data-home-focus]="'rec:' + rec.media.id"
             [imageUrl]="rec.media.posterUrl"
             [title]="rec.media.title"
@@ -77,7 +77,7 @@
       <app-horizontal-scroller [title]="'home.recent_media' | translate">
         @for (m of recentMedia(); track m.id) {
           <app-media-card
-            class="shrink-0 w-32 sm:w-40"
+            class="shrink-0 w-28 sm:w-40"
             [attr.data-home-focus]="'recent:' + m.id"
             [media]="m"
             [subtitle]="'' + m.year"
@@ -92,7 +92,7 @@
       <app-horizontal-scroller [title]="'home.coming_soon' | translate">
         @for (entry of comingSoon(); track entry.id) {
           <app-media-card
-            class="shrink-0 w-32 sm:w-40"
+            class="shrink-0 w-28 sm:w-40"
             [attr.data-home-focus]="'soon:' + entry.id"
             [imageUrl]="entry.posterUrl"
             [title]="entry.title"

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -90,7 +90,7 @@
           <app-horizontal-scroller [title]="'media_detail.other_seasons_of' | translate:{ title: m.title }">
             @for (other of otherSeasons(); track other.id) {
               <app-media-card
-                class="shrink-0 w-32 sm:w-40"
+                class="shrink-0 w-28 sm:w-40"
                 [aspect]="'portrait'"
                 [imageUrl]="other.posterUrl ?? m.posterUrl"
                 [title]="('media_detail.season' | translate) + ' ' + other.seasonNumber"

--- a/client/src/app/shared/components/background/background.html
+++ b/client/src/app/shared/components/background/background.html
@@ -6,8 +6,9 @@
     <img
       [src]="layerA()! | resolveUrl:'medium'"
       alt=""
-      loading="eager"
+      loading="lazy"
       decoding="async"
+      fetchpriority="low"
       class="absolute inset-0 w-full h-full object-cover object-[50%_25%] transition-opacity duration-1500"
       [class.opacity-100]="activeLayer() === 'A' && imageVisible()"
       [class.opacity-0]="activeLayer() !== 'A' || !imageVisible()"
@@ -17,8 +18,9 @@
     <img
       [src]="layerB()! | resolveUrl:'medium'"
       alt=""
-      loading="eager"
+      loading="lazy"
       decoding="async"
+      fetchpriority="low"
       class="absolute inset-0 w-full h-full object-cover object-[50%_25%] transition-opacity duration-1500"
       [class.opacity-100]="activeLayer() === 'B' && imageVisible()"
       [class.opacity-0]="activeLayer() !== 'B' || !imageVisible()"

--- a/client/src/app/shared/components/horizontal-scroller.ts
+++ b/client/src/app/shared/components/horizontal-scroller.ts
@@ -55,7 +55,7 @@ import { TvService } from '../../core/services/tv.service';
     <div
       #scroller
       appTvRow
-      class="flex gap-4 overflow-x-auto scrollbar-none [scroll-behavior:smooth] py-5 -my-5 px-5 -mx-5 scroll-px-5"
+      class="flex gap-2 lg:gap-4 overflow-x-auto scrollbar-none [scroll-behavior:smooth] py-5 -my-5 px-5 -mx-5 scroll-px-5"
       (scroll)="updateArrows()"
     >
       <ng-content />

--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -1,7 +1,7 @@
 <div
   class="relative"
   [class.opacity-55]="dimmed()"
-  [class]="aspect() === 'landscape' ? 'shrink-0 w-60 sm:w-72' : ''"
+  [class]="aspect() === 'landscape' ? 'shrink-0 w-48 sm:w-72' : ''"
 >
   <!-- Image -->
   <figure

--- a/client/src/app/shared/components/settings-drawer/settings-drawer.html
+++ b/client/src/app/shared/components/settings-drawer/settings-drawer.html
@@ -1,17 +1,27 @@
-<div class="drawer lg:drawer-open min-h-screen">
-  <input [id]="drawerId" type="checkbox" class="drawer-toggle" />
+<!-- Drawer: `lg:drawer-open` is gated on NON-tv so desktop keeps the
+     pinned-sidebar look while TV behaves like mobile (checkbox-driven,
+     transient). `tv-drawer-closed` is NOT used — the checkbox alone
+     controls visibility, no class toggle, no `display:none` override,
+     no DaisyUI animation quirks to dance around. -->
+<div class="drawer min-h-screen" [class.lg:drawer-open]="!tv.isTv()">
+  <input [id]="drawerId" #drawerToggle type="checkbox" class="drawer-toggle" />
   <div class="drawer-content flex flex-col relative min-w-0">
-    <!-- Mobile top bar -->
+    <!-- Top bar — `lg:hidden` on desktop only. On TV the navbar is
+         permanent (drawer is transient there, the hamburger is the
+         entry point back). -->
     <nav
-      class="navbar bg-base-100 shadow-sm lg:hidden fixed top-0 left-0 right-0 z-30 transition-all duration-300"
+      appTvRow
+      class="navbar bg-base-100 shadow-sm fixed top-0 left-0 right-0 z-30 transition-all duration-300"
+      [class.lg:hidden]="!tv.isTv()"
       style="padding-top: calc(env(safe-area-inset-top, 0px) + 4px)"
+      [class.top-4]="tv.isAndroidTv()"
       [class.-translate-y-full]="navbarHidden()"
     >
       <div class="flex-none flex">
-        <button class="btn btn-square btn-ghost" (click)="goBack()">
+        <button type="button" class="btn btn-square btn-ghost" (click)="goBack()">
           <svg lucideChevronLeft class="h-5 w-5"></svg>
         </button>
-        <label [for]="drawerId" class="btn btn-square btn-ghost">
+        <label [for]="drawerId" tabindex="0" role="button" class="btn btn-square btn-ghost">
           <svg lucideMenu class="h-5 w-5"></svg>
         </label>
       </div>
@@ -19,10 +29,10 @@
         <span class="text-lg font-bold">{{ title }}</span>
       </div>
     </nav>
-    <!-- Spacer pushes content below the fixed mobile navbar; needs to match
-         the navbar's actual height (safe-area-inset-top + 64px nav body). -->
+    <!-- Spacer pushes content below the fixed navbar (visible on TV too
+         where the navbar is permanent). -->
     <div
-      class="lg:hidden"
+      [class.lg:hidden]="!tv.isTv()"
       style="height: calc(env(safe-area-inset-top, 0px) + 4rem)"
     ></div>
     <main
@@ -35,6 +45,7 @@
   <div class="drawer-side z-40">
     <label [for]="drawerId" class="drawer-overlay"></label>
     <aside
+      data-tv-modal
       class="bg-base-100 w-64 min-h-full flex flex-col"
       style="
         padding-top: calc(env(safe-area-inset-top, 0px) / 2 );
@@ -43,7 +54,7 @@
       "
     >
       <div class="p-4 border-b border-base-200">
-        <a routerLink="/" class="flex items-center gap-2 text-base-content/60 hover:text-base-content text-sm mb-2 mt-4">
+        <a routerLink="/" class="flex items-center gap-2 px-2 py-1 rounded-lg text-base-content/60 hover:text-base-content text-sm mb-2 mt-4">
           <svg lucideChevronLeft class="h-4 w-4"></svg>
           {{ backLabel }}
         </a>
@@ -53,7 +64,7 @@
         </h2>
       </div>
 
-      <ul class="menu p-4 flex-1 gap-0.5 min-w-64 overflow-y-auto">
+      <ul class="menu p-4 flex-1 gap-0.5 min-w-64 overflow-y-auto" (click)="onMenuClick($event)">
         <ng-content select="[drawerMenu]"></ng-content>
       </ul>
     </aside>

--- a/client/src/app/shared/components/settings-drawer/settings-drawer.ts
+++ b/client/src/app/shared/components/settings-drawer/settings-drawer.ts
@@ -1,8 +1,11 @@
-import { Component, ChangeDetectionStrategy, Input, signal, OnInit, OnDestroy } from '@angular/core';
+import {
+  Component, ChangeDetectionStrategy, Input, signal, OnInit, OnDestroy, ElementRef, viewChild,
+} from '@angular/core';
 import { RouterOutlet, RouterLink } from '@angular/router';
 import { Location } from '@angular/common';
 import { inject } from '@angular/core';
 import { LucideChevronLeft, LucideMenu } from '@lucide/angular';
+import { TvService } from '../../../core/services/tv.service';
 
 @Component({
   selector: 'app-settings-drawer',
@@ -18,6 +21,11 @@ export class SettingsDrawerComponent implements OnInit, OnDestroy {
   @Input() drawerId = 'settings-drawer';
 
   readonly navbarHidden = signal(false);
+  readonly tv = inject(TvService);
+
+  private readonly drawerToggleEl =
+    viewChild<ElementRef<HTMLInputElement>>('drawerToggle');
+
   private lastScrollY = 0;
   private readonly onScroll = () => {
     const y = window.scrollY;
@@ -27,6 +35,16 @@ export class SettingsDrawerComponent implements OnInit, OnDestroy {
   };
 
   ngOnInit() {
+    // On TV the drawer behaves like mobile (checkbox-driven, no
+    // `lg:drawer-open`). Start "open" so the user lands on /admin with
+    // the sidebar visible — they navigate to a section, drawer slides
+    // out, hamburger brings it back.
+    if (this.tv.isTv()) {
+      queueMicrotask(() => {
+        const cb = this.drawerToggleEl()?.nativeElement;
+        if (cb) cb.checked = true;
+      });
+    }
     window.addEventListener('scroll', this.onScroll, { passive: true });
   }
 
@@ -36,5 +54,16 @@ export class SettingsDrawerComponent implements OnInit, OnDestroy {
 
   goBack() {
     this.location.back();
+  }
+
+  /** Click inside the menu region (TV) — close the drawer if the click
+   *  hit a link so the main content takes over. No-op on desktop where
+   *  `lg:drawer-open` keeps the drawer permanent. */
+  onMenuClick(event: Event) {
+    if (!this.tv.isTv()) return;
+    const target = event.target as HTMLElement | null;
+    if (!target?.closest('a')) return;
+    const cb = this.drawerToggleEl()?.nativeElement;
+    if (cb) cb.checked = false;
   }
 }

--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -251,7 +251,8 @@
 
   <div class="drawer-side z-40" [class.hidden]="isNative && device.isPhone()">
     <label for="sidebar" [attr.aria-label]="'nav.close_menu' | translate" class="drawer-overlay"></label>
-    <aside class="w-64 min-h-full flex flex-col"
+    <aside data-tv-modal
+           class="w-64 min-h-full flex flex-col"
            [class.bg-base-100]="!background.url()"
            [class.app-sidebar-veil]="!!background.url()"
            [class.backdrop-blur-sm]="!!background.url()"

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -280,6 +280,34 @@ app-media-card figure:focus-visible,
     0 0 18px -4px var(--color-primary, #7a3ff2),
     0 8px 22px rgb(0 0 0 / 35%) !important;
 }
+/* Android TV ships on Capacitor + Chromium WebView, often with mid-range
+   SoCs where blurred box-shadows are the most expensive thing on the
+   compositor. D-pad nav rapidly moves focus card-to-card, so each move
+   re-paints the 18 px glow + 22 px drop shadow blur regions — visible
+   as jank. Drop the blurs on AndroidTV, keep the crisp 2-step ring
+   (cheap, no blur). Tizen / webOS / desktop keep the full Lumen look. */
+body.tv-androidtv app-media-card figure:focus-visible,
+body.tv-androidtv [data-home-focus]:focus-visible {
+  box-shadow:
+    0 0 0 2px var(--color-base-100, #1d232a),
+    0 0 0 6px var(--color-primary, #7a3ff2) !important;
+}
+/* Smaller media-card footprint on AndroidTV: visually the same layout but
+   ~10 % shorter cards, which both reduces image decode pressure (smaller
+   thumb pixels rendered → less GPU work per scroll) and fits a couple more
+   cards in a row for denser browsing. Targets the `sm:` Tailwind widths
+   only — TV viewports always cross the 640 px breakpoint, so this is the
+   width that actually paints. Other form factors are untouched. */
+@media (min-width: 640px) {
+  body.tv-androidtv app-media-card.sm\:w-40 { width: 7.5rem; }    /* 160px → 120px (portrait) */
+  body.tv-androidtv app-media-card > .sm\:w-72 { width: 13rem; }  /* 288px → 208px (landscape) */
+  /* Library cards on the home page (linear pill with icon + name). Same
+     ~17 % reduction so they line up visually with the media-card width
+     and the row keeps a consistent density. */
+  body.tv-androidtv [data-home-focus^="library:"].sm\:w-48 { width: 10rem; }   /* 192px → 160px */
+  body.tv-androidtv [data-home-focus^="library:"].sm\:h-28 { height: 6rem; }   /* 112px → 96px */
+}
+
 /* Touch-only UI elements should be hidden on TV */
 body.tv [data-touch-only] {
   display: none !important;


### PR DESCRIPTION
## Summary

Grab-bag of TV / mobile UI polish from a couple of sessions of in-app testing on AndroidTV + browser.

### Perf (AndroidTV)
- Drop the blurred glow + drop shadow from the media-card Lumen focus ring on `body.tv-androidtv` only — the blur was the most expensive op on mid-range TV WebView GPUs and re-painted on every D-pad move.
- AndroidManifest: explicit `hardwareAccelerated="true"` + `largeHeap="true"` (defensive — defaults already true on SDK 14+ but some TV builds flip).
- Background image layers: `loading="lazy"` + `fetchpriority="low"`. Eager-decode of a 1920×800 fanart was blocking the compositor.

### Card sizing
- AndroidTV media-card: ~25 % narrower via attribute selectors on `sm:w-40` / `sm:w-72`.
- AndroidTV library-card: similar reduction on `sm:w-48` / `sm:h-28`.
- Mobile media-card: portrait `w-32 → w-28`, landscape `w-60 → w-48`. `sm:` variants untouched.
- Mobile / tablet rail gap: `gap-4 → gap-2 lg:gap-4`.

### Focus rings
- Cast member uses `data-no-focus-ring` opt-out + a Lumen-matching ring (offset 2 + ring 4) on the inner round avatar — rectangular outer ring gone.
- Genres button: `rounded px-1` so its ring follows the pill.
- Library tabs: `py-2 -my-2 px-2 -mx-2` on the nav so first/last tab rings aren't clipped by `overflow-x:auto`.
- Settings-drawer back link: `rounded-lg`.

### Spatial nav
- Text-input boundary escape: `←/→` defer to native caret only inside the value; at `selectionStart=0` / `=length`, the arrow escapes to spatial nav. `↑/↓` always escape on single-line inputs.
- Modal trap scoped to `active ⊂ modal` — previously any `[data-tv-modal]` permanently activated the trap, locking focus inside an always-visible pinned sidebar.

### Sidebars
- `[data-tv-modal]` on main layout aside + admin settings-drawer aside → focus locks inside once entered.
- Settings-drawer on TV: gate `lg:drawer-open` to non-TV so the admin sidebar is transient (checkbox-driven, mobile pattern). Hamburger navbar shown on TV. Menu link click closes the drawer via viewChild on the checkbox. Initial state on TV = open via a one-shot microtask. Desktop unchanged.
- Hamburger label: `tabindex="0" role="button"`; `appTvRow` on the nav.

## Test plan
- [ ] AndroidTV: focus a media-card via D-pad. Ring is crisp (no glow / drop shadow). Move focus rapidly between cards — feels fluid.
- [ ] AndroidTV: home cards are visibly smaller; more visible in a row.
- [ ] Mobile: home cards tighter, more visible, gap smaller.
- [ ] Browser: Tab into a search input, press `→` repeatedly — caret moves through, then escape to next focusable at the end.
- [ ] TV: focus enters main sidebar from main content (arrow left), tries to exit via arrow right — stays inside.
- [ ] TV: open /admin. Sidebar visible. Click "Statistiques" — sidebar slides out, main reclaims width. Click hamburger — sidebar reappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)