### PR TITLE
feat(home): two-pass SWR refresh on app open

### DIFF
--- a/client/src/app/core/interceptors/cache.interceptor.ts
+++ b/client/src/app/core/interceptors/cache.interceptor.ts
@@ -171,6 +171,11 @@ function resourcePrefix(url: string): string {
   return m?.[1] ?? url;
 }
 
+/** Opt-in hint for callers that want the freshest data on this specific
+ *  request even when a fresh cache entry exists. Stripped before the
+ *  request leaves the interceptor — the backend has no use for it. */
+export const CACHE_BYPASS_HEADER = 'X-Cache-Bypass';
+
 export const cacheInterceptor: HttpInterceptorFn = (req, next) => {
   const url = req.urlWithParams;
 
@@ -181,6 +186,19 @@ export const cacheInterceptor: HttpInterceptorFn = (req, next) => {
   }
 
   if (!isCacheable(url)) return next(req);
+
+  // Force-refresh path: skip the cache READ but still PUT the network
+  // response so future cache-first callers get the refreshed value.
+  if (req.headers.has(CACHE_BYPASS_HEADER)) {
+    const cleanReq = req.clone({ headers: req.headers.delete(CACHE_BYPASS_HEADER) });
+    return next(cleanReq).pipe(
+      tap((event) => {
+        if (event instanceof HttpResponse && event.status === 200) {
+          void putCache(url, event.body);
+        }
+      }),
+    );
+  }
 
   return new Observable((subscriber) => {
     getCached(url).then((entry) => {

--- a/client/src/app/core/services/api/libraries-api.service.ts
+++ b/client/src/app/core/services/api/libraries-api.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
+import { CACHE_BYPASS_HEADER } from '../../interceptors/cache.interceptor';
 
 export type StalledCleanupProfileKey = 'fast' | 'medium' | 'slow';
 
@@ -65,9 +66,12 @@ export class LibrariesApiService {
   }
 
   /** User-accessible lightweight list (sidebar, route resolution). */
-  listMine() {
+  listMine(opts: { force?: boolean } = {}) {
     return firstValueFrom(
-      this.http.get<LibrarySummary[]>('/api/libraries/mine'),
+      this.http.get<LibrarySummary[]>(
+        '/api/libraries/mine',
+        opts.force ? { headers: { [CACHE_BYPASS_HEADER]: '1' } } : {},
+      ),
     );
   }
 

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -4,6 +4,7 @@ import { firstValueFrom } from 'rxjs';
 import { AuthService } from '../auth.service';
 import { ServerConfigService } from '../server-config.service';
 import { CastService } from '../cast.service';
+import { CACHE_BYPASS_HEADER } from '../../interceptors/cache.interceptor';
 import {
   BrowserDeviceProfileService,
   DeviceProfile,
@@ -364,26 +365,34 @@ export class StreamingApiService {
     );
   }
 
-  getContinueWatching(libraryId?: number) {
-    const params = libraryId
-      ? { params: { libraryId: String(libraryId) } }
-      : {};
+  getContinueWatching(libraryId?: number, opts: { force?: boolean } = {}) {
+    const reqOpts: { params?: { libraryId: string }; headers?: { [k: string]: string } } = {};
+    if (libraryId) reqOpts.params = { libraryId: String(libraryId) };
+    if (opts.force) reqOpts.headers = { [CACHE_BYPASS_HEADER]: '1' };
     return firstValueFrom(
       this.http.get<ContinueWatchingItem[]>(
         '/api/playback/continue-watching',
-        params,
+        reqOpts,
       ),
     );
   }
 
-  getRecommendations(opts: { libraryId?: number; limit?: number } = {}) {
+  getRecommendations(
+    opts: { libraryId?: number; limit?: number; force?: boolean } = {},
+  ) {
     const params: Record<string, string> = {};
     if (opts.libraryId) params['libraryId'] = String(opts.libraryId);
     if (opts.limit) params['limit'] = String(opts.limit);
+    const reqOpts: {
+      params?: Record<string, string>;
+      headers?: { [k: string]: string };
+    } = {};
+    if (Object.keys(params).length) reqOpts.params = params;
+    if (opts.force) reqOpts.headers = { [CACHE_BYPASS_HEADER]: '1' };
     return firstValueFrom(
       this.http.get<RecommendationItem[]>(
         '/api/playback/recommendations',
-        Object.keys(params).length ? { params } : {},
+        reqOpts,
       ),
     );
   }

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -139,6 +139,13 @@ export class HomeComponent implements OnInit, OnDestroy {
     // Each section guards itself with `@if (().length)` so sections paint
     // independently as their data arrives. No global loading gate.
     await this.loadAllSections();
+    // App-open SWR: the cache served Pass 1 above (instant render even on
+    // a cold network). Now force a network round-trip so the user sees
+    // the freshest data — additions, watched-status flips made on
+    // another device, new recommendations, etc. — without waiting on it.
+    // Signals already populated, so a slower fresh response just
+    // overwrites in place; no spinner, no flash.
+    queueMicrotask(() => void this.loadAllSections({ force: true }));
     this.scrollMemory.restore(HomeComponent.SCROLL_KEY, this.injector);
     if (this.tv.isTv()) {
       afterNextRender(() => this.applyDefaultFocus(), { injector: this.injector });
@@ -193,13 +200,24 @@ export class HomeComponent implements OnInit, OnDestroy {
    * Fetch every section in parallel. Signals are updated as responses land —
    * existing values stay visible until each new response arrives, so a
    * background revalidation never blanks the UI.
+   *
+   * The pattern is two-pass SWR-on-demand:
+   *   • Pass 1 (default): cache-first. The interceptor serves IndexedDB
+   *     if fresh, network otherwise. Renders the home in ≤1 frame on a
+   *     warm cache.
+   *   • Pass 2 (`{ force: true }`): always go to network. Fired right
+   *     after Pass 1 from `ngOnInit` to refresh the home's data even
+   *     when the cache was fresh — the user expects the page to reflect
+   *     current backend state every time they open the app, but doesn't
+   *     want to wait for the network for the first paint.
    */
-  private async loadAllSections(): Promise<void> {
+  private async loadAllSections(opts: { force?: boolean } = {}): Promise<void> {
+    const force = !!opts.force;
     try {
       const [libs, cw, recs] = await Promise.all([
-        this.librariesApi.listMine().catch(() => null),
-        this.streamingApi.getContinueWatching().catch(() => null),
-        this.streamingApi.getRecommendations().catch(() => null),
+        this.librariesApi.listMine({ force }).catch(() => null),
+        this.streamingApi.getContinueWatching(undefined, { force }).catch(() => null),
+        this.streamingApi.getRecommendations({ force }).catch(() => null),
       ]);
       if (libs) this.libraries.set(libs);
       if (cw) this.continueWatching.set(cw);


### PR DESCRIPTION
## Summary

When the app opens, the home was showing whatever the IndexedDB cache held — even when the user had made changes on another device since the last visit. The HTTP cache interceptor doesn't background-revalidate fresh entries, and the home's first-mount load resolved on the cached emission, so the screen never refreshed.

Pattern: cache-first for the first render, then a forced network refresh that overwrites the signals in place. No spinner — the cached values stay visible while the fresh response is in flight.

## Changes

- \`cache.interceptor.ts\` exports \`CACHE_BYPASS_HEADER\`. When present, the interceptor skips the cache READ but still PUTs the network response (so subsequent cache-first callers see the refreshed value). Header is stripped before the request leaves.
- \`streamingApi.getContinueWatching\` / \`getRecommendations\` / \`librariesApi.listMine\` accept \`{ force?: boolean }\` which flips the header on.
- \`HomeComponent.loadAllSections({ force })\` threads the flag through. \`ngOnInit\` runs Pass 1 (cache-first), then \`queueMicrotask\` Pass 2 (\`force: true\`).
- Scoped to the first-mount path (\`ngOnInit\`). The route-attach flow runs against a freshly-touched cache and doesn't need it.

## Test plan
- [ ] Cold IndexedDB: home loads from network (visible spinner ok). Pass 2 also runs but is identical.
- [ ] Warm IndexedDB, no backend changes: home renders instantly from cache, no visible flicker on Pass 2.
- [ ] Warm IndexedDB, change CW server-side: home renders instantly with old data, then updates with new CW within ~1 s.
- [ ] Navigate to /movies and back: NavigationEnd → route attach path. No Pass 2 fires (verify Network tab — only normal endpoints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)