### PR TITLE
fix(imports): write Seerr addedBy via the relation, not the @RelationId

### DIFF
--- a/backend/src/modules/imports/seerr-request-import.service.ts
+++ b/backend/src/modules/imports/seerr-request-import.service.ts
@@ -218,9 +218,12 @@ export class SeerrRequestImportService {
     // When the Seerr request maps to a Media already in Fliks that nobody
     // owns yet (`addedById` null — typical for *arr-migrated or disk-rescanned
     // rows), claim it for the Seerr requester so the "Mine" filter surfaces
-    // it without waiting on a manual re-approval.
+    // it without waiting on a manual re-approval. `addedById` is a
+    // `@RelationId` virtual column (read-only); we write through the
+    // `addedBy` relation so TypeORM resolves it to the underlying FK
+    // column instead of failing with "Property addedById was not found".
     if (media && media.addedById == null) {
-      await this.mediaRepo.update(media.id, { addedById: user.id });
+      await this.mediaRepo.update(media.id, { addedBy: { id: user.id } as User });
     }
 
     if (existing) {


### PR DESCRIPTION
## Summary

Importing Seerr requests skipped almost every request after the first run with the same misleading message in the backend log:

\`\`\`
WARN [SeerrRequestImportService] Seerr import: request #232 skipped —
  Property "addedById" was not found in "Media". Make sure your query is correct.
\`\`\`

\`Media.addedById\` is declared as \`@RelationId(...)\` — a virtual, read-only field derived from the \`addedBy\` relation. \`mediaRepo.update(id, { addedById })\` looks for a writable column with that name and doesn't find one, so it throws and the request is bucketed as an error.

Write through the relation instead (\`{ addedBy: { id: user.id } as User }\`); TypeORM resolves it to the underlying FK column. Behaviour unchanged on already-claimed media (\`addedById == null\` guard still skips).

## Test plan
- [ ] Re-run a Seerr import on a fresh Fliks install + a Seerr instance with many existing requests — imported count should match Seerr's total (minus the genuinely-skipped \`requestedBy.username\` / \`tmdbId\` ones).
- [ ] Re-run on the same data — second pass should report `updated` for everything, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)