### PR TITLE
feat(pwa): auto-reload when the service worker has a new version ready

### DIFF
--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -16,6 +16,7 @@ import { ConfirmationModalComponent } from './shared/components/confirmation-mod
 import { SelectPickerComponent } from './shared/components/select-picker';
 import { DismissableStackService } from './core/services/dismissable-stack.service';
 import { NavbarService } from './core/services/navbar.service';
+import { PwaAutoUpdateService } from './core/services/pwa-auto-update.service';
 
 @Component({
   selector: 'app-root',
@@ -37,6 +38,7 @@ export class App implements OnInit, OnDestroy {
   private readonly router = inject(Router);
   private readonly dismissStack = inject(DismissableStackService);
   private readonly navbar = inject(NavbarService);
+  private readonly pwaAutoUpdate = inject(PwaAutoUpdateService);
   private backButtonListener?: { remove: () => Promise<void> };
   private resumeListener?: { remove: () => Promise<void> };
   private tizenKeyListener?: (e: KeyboardEvent) => void;
@@ -46,6 +48,9 @@ export class App implements OnInit, OnDestroy {
     this.auth.hydrateFromServer();
     // Pre-warm device profile cache (codec probing) so it's instant when the player needs it
     this.deviceProfile.getProfile();
+    // Watch for a fresher PWA build emitted by the Angular service worker
+    // — when one lands, full-reload the tab so the new asset map is live.
+    this.pwaAutoUpdate.init();
 
     if (Capacitor.isNativePlatform()) {
       document.body.classList.add('native');

--- a/client/src/app/core/services/pwa-auto-update.service.ts
+++ b/client/src/app/core/services/pwa-auto-update.service.ts
@@ -1,0 +1,42 @@
+import { Injectable, inject, DestroyRef } from '@angular/core';
+import { SwUpdate, VersionReadyEvent } from '@angular/service-worker';
+import { filter } from 'rxjs';
+
+/**
+ * Auto-reload the PWA when the Angular service worker has fetched a new
+ * version and marked it ready to activate.
+ *
+ * We don't prompt the user — the reload is unconditional. A version
+ * mismatch between the loaded app shell and a lazy chunk (their hashed
+ * filenames change between builds) crashes the route loader with
+ * `ChunkLoadError`, so the reload-on-VERSION_READY trade is "one extra
+ * reload at deploy time" against "broken navigation until the user
+ * happens to refresh manually". Worth it.
+ *
+ * Why `document.location.reload()` and not `swUpdate.activateUpdate()`:
+ * activateUpdate atomically swaps the SW to the new version inside the
+ * same tab, but the loaded JS still has the old chunk hashes — the next
+ * lazy import 404s. A full reload re-pulls index.html from the new SW,
+ * which then serves the new asset map. See the Angular SW comms doc:
+ * https://angular.dev/ecosystem/service-workers/communications
+ *
+ * Gated to web builds only — Capacitor native apps update via the store
+ * (Play Store / App Store) and have no Angular service worker.
+ */
+@Injectable({ providedIn: 'root' })
+export class PwaAutoUpdateService {
+  private readonly swUpdate = inject(SwUpdate);
+  private readonly destroyRef = inject(DestroyRef);
+
+  init(): void {
+    if (!this.swUpdate.isEnabled) return;
+
+    const sub = this.swUpdate.versionUpdates
+      .pipe(filter((evt): evt is VersionReadyEvent => evt.type === 'VERSION_READY'))
+      .subscribe(() => {
+        document.location.reload();
+      });
+
+    this.destroyRef.onDestroy(() => sub.unsubscribe());
+  }
+}


### PR DESCRIPTION
## Summary

Production web users were stuck on whatever build they first loaded — once cached, the service worker never volunteered to upgrade unless the tab was closed and reopened, so deploy-day fixes took hours / days to reach the audience.

- New \`PwaAutoUpdateService\`: subscribes to \`SwUpdate.versionUpdates\`, filters on \`VERSION_READY\`, and full-reloads the tab. No prompt.
- Wired from \`App.ngOnInit\` so the subscription opens at boot.
- Gated by \`SwUpdate.isEnabled\` (already false in dev / Capacitor native, per \`provideServiceWorker\` config), so dev + native are no-ops.

\`document.location.reload()\` over \`swUpdate.activateUpdate()\`: activate-in-place keeps the loaded JS pointing at the old chunk hashes, so the next lazy import 404s. A full reload re-pulls \`index.html\` from the new SW which then serves the matching asset map. The Angular SW comms doc calls this out: https://angular.dev/ecosystem/service-workers/communications

## Test plan
- [ ] Web prod build deployed twice in a row → an open tab reloads within \`registerWhenStable:30000\` + SW check interval.
- [ ] Dev (\`ng serve\`) → no reload (SW disabled).
- [ ] Capacitor Android / iOS → no reload (SW disabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)