### PR TITLE
fix(ui): media-detail UI polish (synopsis toggle, scroll overflow, focus border)

### DIFF
--- a/client/src/app/shared/components/horizontal-scroller.ts
+++ b/client/src/app/shared/components/horizontal-scroller.ts
@@ -55,7 +55,7 @@ import { TvService } from '../../core/services/tv.service';
     <div
       #scroller
       appTvRow
-      class="flex gap-2 lg:gap-4 overflow-x-auto scrollbar-none [scroll-behavior:smooth] py-5 -my-5 px-5 -mx-5 scroll-px-5"
+      class="flex gap-2 lg:gap-4 overflow-x-auto scrollbar-none [scroll-behavior:smooth] py-5 -my-5 px-4 -mx-4 lg:px-5 lg:-mx-5 scroll-px-4 lg:scroll-px-5"
       (scroll)="updateArrows()"
     >
       <ng-content />

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -120,7 +120,14 @@
 
     <!-- Overview -->
     @if (overview()) {
-      <p class="mt-4 text-base-content/80 leading-relaxed line-clamp-4">{{ overview() }}</p>
+      <p #overviewText
+         class="mt-4 text-base-content/80 leading-relaxed"
+         [class.line-clamp-4]="!overviewExpanded()">{{ overview() }}</p>
+      @if (overviewClamped() || overviewExpanded()) {
+        <button type="button" class="link link-primary no-underline hover:underline text-sm mt-1" (click)="toggleOverview()">
+          {{ (overviewExpanded() ? 'common.show_less' : 'common.show_more') | translate }}
+        </button>
+      }
     }
 
   </div>

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -1,12 +1,14 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   computed,
   effect,
   inject,
   input,
   output,
   signal,
+  viewChild,
 } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
@@ -179,6 +181,26 @@ export class MediaInfoHeaderComponent {
   readonly durationSeconds = signal<number | null>(null);
   readonly selectedAudioIndex = signal<number | null>(null);
   readonly selectedSubtitleId = signal<string | null>(null);
+
+  // Mobile overview clamp / expand
+  private readonly overviewTextRef = viewChild<ElementRef<HTMLParagraphElement>>('overviewText');
+  readonly overviewClamped = signal(false);
+  readonly overviewExpanded = signal(false);
+
+  private readonly overviewClampEffect = effect(() => {
+    // Re-measure whenever the overview text changes.
+    this.overview();
+    this.overviewExpanded.set(false);
+    requestAnimationFrame(() => {
+      const el = this.overviewTextRef()?.nativeElement;
+      if (el) this.overviewClamped.set(el.scrollHeight > el.clientHeight + 1);
+      else this.overviewClamped.set(false);
+    });
+  });
+
+  toggleOverview() {
+    this.overviewExpanded.update(v => !v);
+  }
 
   // ── Load playback state + watched when media/episode changes ──
 

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -14,10 +14,13 @@
   --radius-box: 0.5rem;
 }
 
-/* Thinner focus outline on form fields */
+/* Thinner focus outline on form fields. Suppress daisyUI's border on focus —
+   the focus ring (outline) is the only visual cue we want, the extra white
+   border doubled up with the ring looks noisy. */
 .select:focus, .input:focus, .textarea:focus {
   outline-width: 1px;
   outline-offset: 0px;
+  border-color: transparent;
 }
 
 /* Flex children inherit `min-width: auto`, which prevents inner text from


### PR DESCRIPTION
## Summary

Three small UI/UX fixes batched on one branch — I'll keep adding fixes here as they get validated.

- **Mobile synopsis**: add a *Voir plus / Voir moins* link below the line-clamped overview, shown only when the text actually overflows.
- **Horizontal scroll overflow**: the `-mx-5 px-5` bleed on `app-horizontal-scroller` exceeded `<main>`'s mobile padding (`p-4` = 16 px) — and on hero pages `<main>` drops `overflow-x-clip` so the fanart can bleed, letting that 4 px reach the body. Bleed now matches `<main>`'s padding per breakpoint (`-mx-4 px-4` below `lg`, `-mx-5 px-5` from `lg` up).
- **Input focus**: suppress daisyUI's border on focused `.input` / `.select` / `.textarea` so only the focus ring shows (was doubled up with a white border).

## Test plan

- [ ] Media detail (mobile): long synopsis truncates at 4 lines with a *Voir plus* link; tapping expands; *Voir moins* collapses; short synopsis shows no link.
- [ ] Media detail (mobile): no horizontal scrollbar on `<body>`; scroller still scrolls smoothly.
- [ ] Media detail (lg+): cast / other-seasons scrollers unchanged (focus scale-up still bleeds into the row's gutter).
- [ ] Focus any input/select/textarea: only the thin ring is visible (no extra white border underneath).