### PR TITLE
fix(ui): recover the 15 commits that never reached PR #203

### DIFF
--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -115,7 +115,9 @@
   "display_settings": {
     "title": "Affichage",
     "home_background": "Image de fond sur l'accueil",
-    "home_background_hint": "Affiche une affiche en plein écran derrière les sections de l'accueil."
+    "home_background_hint": "Affiche une affiche en plein écran derrière les sections de l'accueil.",
+    "only_my_requests": "Afficher uniquement les médias que j'ai demandé",
+    "only_my_requests_hint": "Filtre les sections « Récemment ajoutés » et « Bientôt disponible » de l'accueil pour ne garder que les médias que vous avez demandés."
   },
   "storage_settings": {
     "clear_cache": "Vider le cache",
@@ -185,8 +187,7 @@
     "continue_watching": "Reprendre la lecture",
     "coming_soon": "Bientôt disponible",
     "recent_media": "Récemment ajoutés",
-    "recommendations": "Recommandations",
-    "only_my_requests": "Afficher uniquement les médias que j'ai demandé"
+    "recommendations": "Recommandations"
   },
   "playback_settings": {
     "title": "Paramètres de lecture",

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -244,7 +244,7 @@ export const routes: Routes = [
       import('./features/app-settings/app-settings-shell').then((m) => m.AppSettingsShellComponent),
     canActivate: [serverConfigGuard, authGuard, passwordChangeGuard],
     children: [
-      { path: '', pathMatch: 'full', redirectTo: 'player' },
+      { path: '', pathMatch: 'full', redirectTo: 'display' },
       {
         path: 'player',
         loadComponent: () =>

--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -85,14 +85,26 @@ export class App implements OnInit, OnDestroy {
 
     // Browser/desktop Escape mirrors the hardware back button: closes the
     // topmost dismissable layer (open dropdown, bottom sheet, modal) if
-    // any, else falls through to route-level back. Skip when focus is
-    // inside a text input so Escape can still e.g. cancel an inline edit
-    // without navigating away.
+    // any, else falls through to route-level back. Skip when focus is on
+    // a form control whose native Escape behaviour is preferable:
+    //  - INPUT / TEXTAREA / contentEditable: cancel inline edits without
+    //    navigating away.
+    //  - SELECT: close the native option list while keeping focus on the
+    //    select (our preventDefault would otherwise blur it, dropping
+    //    focus to <body>).
     this.escapeKeyListener = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
+      // Defer to the browser's default Escape when focus is on a form
+      // control. `closest()` catches the open-select case where Chrome
+      // dispatches keydown on the focused <option> rather than the
+      // <select> itself — both resolve to the same <select> ancestor.
+      // `activeElement` is a second signal in case the browser routes
+      // the event to <document> while the dropdown is open.
       const target = e.target as HTMLElement | null;
-      const tag = target?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
+      const active = document.activeElement as HTMLElement | null;
+      const isFormControl = (el: HTMLElement | null) =>
+        !!el && (el.isContentEditable || !!el.closest('select, input, textarea'));
+      if (isFormControl(target) || isFormControl(active)) return;
       e.preventDefault();
       e.stopPropagation();
       this.handleBackButton();

--- a/client/src/app/core/services/display-settings.service.ts
+++ b/client/src/app/core/services/display-settings.service.ts
@@ -3,12 +3,16 @@ import { Injectable, signal } from '@angular/core';
 export interface DisplaySettings {
   /** Show the page-wide fanart background on the home page. */
   homeBackground: boolean;
+  /** Filter home's "Recently added" + "Coming soon" rows to media the user requested. */
+  onlyMyRequests: boolean;
 }
 
 const STORAGE_KEY = 'display.settings';
+const LEGACY_ONLY_MY_REQUESTS_KEY = 'fliks.home.onlyMyRequests';
 
 const DEFAULTS: DisplaySettings = {
   homeBackground: true,
+  onlyMyRequests: false,
 };
 
 @Injectable({ providedIn: 'root' })
@@ -22,14 +26,21 @@ export class DisplaySettingsService {
         const parsed = JSON.parse(raw) as Partial<DisplaySettings>;
         return { ...DEFAULTS, ...parsed };
       }
+      // First load after the toggle moved out of home — pick up the old key
+      // so the user's preference survives the migration.
+      const legacy = localStorage.getItem(LEGACY_ONLY_MY_REQUESTS_KEY);
+      if (legacy !== null) {
+        return { ...DEFAULTS, onlyMyRequests: legacy === 'true' };
+      }
     } catch { /* ignore */ }
     return { ...DEFAULTS };
   }
 
-  save(settings: DisplaySettings): void {
-    this.settings.set(settings);
+  save(patch: Partial<DisplaySettings>): void {
+    const next = { ...this.settings(), ...patch };
+    this.settings.set(next);
     try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
     } catch { /* private mode / SSR */ }
   }
 

--- a/client/src/app/core/services/tv-spatial-nav.service.ts
+++ b/client/src/app/core/services/tv-spatial-nav.service.ts
@@ -178,14 +178,6 @@ export class TvSpatialNavService {
     ]);
     const isInputWithNativeArrows = tag === 'INPUT' && NATIVE_INPUT_TYPES.has(inputType ?? 'text');
 
-    // `<select appTvSelect>` opts out of native arrow handling — the
-    // directive routes opens through SelectPickerService, so arrow keys
-    // should escape to spatial nav instead of silently cycling the
-    // underlying native value.
-    const isPickerSelect = tag === 'SELECT' && active?.hasAttribute('appTvSelect');
-    // Native <select> (without the picker directive): always defer to
-    // native; left/right cycles options, up/down opens the dropdown.
-    if (tag === 'SELECT' && !isPickerSelect) return;
     // Text-style inputs own horizontal arrows (caret movement) — defer
     // left/right to native UNTIL the caret hits the end of the value, at
     // which point the arrow should escape to spatial nav instead of
@@ -204,11 +196,12 @@ export class TvSpatialNavService {
       if (dir === 'right' && !atEnd) return;
       // Caret at boundary → fall through to spatial nav.
     }
-    // Native `<select>` cycles its options on arrow keys (changing the
-    // value silently). Always block that on TV. We still try to move focus
-    // — if a tree-aware neighbour exists, the user goes there; otherwise
-    // we preventDefault below and the focus stays put. Either way, the
-    // value of the select isn't mutated by a stray arrow press.
+    // Native `<select>` cycles its options on arrow keys (silently
+    // changing the value) and Alt+Down opens the dropdown. Block both:
+    // selects open via mouse / Enter / Space (see TvSelectDirective for
+    // the styled picker variant); arrows are reserved for spatial nav.
+    // If no neighbour exists, focus stays put — never a stray value
+    // mutation from an arrow press.
     if (tag === 'SELECT') {
       e.preventDefault();
     }
@@ -238,42 +231,46 @@ export class TvSpatialNavService {
     // No focusable neighbour: scroll the page manually so the user can
     // reach informational content (file infos, descriptions, etc.) that
     // sits below the last focusable card. Up/down only — left/right at a
-    // boundary should just block (intra-row). Skip when a modal trap is
-    // active (open popover / dropdown / bottom-sheet): the user hitting
-    // the boundary inside a menu shouldn't drift the page underneath.
-    const modalOpen =
-      !!document.querySelector('[data-tv-modal]') ||
-      !!document.querySelector('.dropdown-open .dropdown-content');
-    if (!modalOpen && (dir === 'down' || dir === 'up')) {
+    // boundary should just block (intra-row). Skip while a modal is open
+    // so the user hitting the boundary inside a menu doesn't drift the
+    // page underneath.
+    if (!this.openModals().length && (dir === 'down' || dir === 'up')) {
       window.scrollBy({ top: dir === 'down' ? 300 : -300, behavior: 'smooth' });
     }
   }
 
-  private findNeighbor(dir: 'left' | 'right' | 'up' | 'down'): HTMLElement | null {
-    const active = document.activeElement as HTMLElement | null;
-    // Tree-aware path runs first: if the active element sits inside a
-    // registered container, walk the logical tree (orientation-aware,
-    // last-active-child memorised). Returning the rect-based fallback only
-    // when the tree has nothing to say keeps unmigrated pages working
-    // exactly as before.
-    if (active && active !== document.body && this.containers.size > 0) {
-      const tree = this.findNeighborInTree(active, dir);
-      if (tree) return tree;
-    }
-    // Focus trap: transient overlays (open dropdown / popover / bottom
-    // sheet) opt in via `[data-tv-modal]` so arrow keys can't leak out.
-    // Only applies when focus is CURRENTLY inside the modal — otherwise
-    // an open dropdown elsewhere on the page would block normal nav.
-    // The `.dropdown-open .dropdown-content` form is kept for legacy
-    // player dropdowns that don't carry the attribute.
-    const modalCandidates: HTMLElement[] = [
+  /** Currently-open overlays that scope spatial navigation. Bottom sheets
+   *  / popovers carry `[data-tv-modal]`; daisyUI dropdowns are detected
+   *  via `.dropdown-open .dropdown-content` because their content stays
+   *  in the DOM with `display:none` when closed (a bare attribute would
+   *  falsely match). */
+  private openModals(): HTMLElement[] {
+    return [
       ...Array.from(document.querySelectorAll<HTMLElement>('[data-tv-modal]')),
       ...Array.from(
         document.querySelectorAll<HTMLElement>('.dropdown-open .dropdown-content'),
       ),
     ];
-    const openModal =
-      modalCandidates.find((m) => active && m.contains(active)) ?? null;
+  }
+
+  private findNeighbor(dir: 'left' | 'right' | 'up' | 'down'): HTMLElement | null {
+    const active = document.activeElement as HTMLElement | null;
+    // Modal trap takes precedence over tree-aware. The dropdown / sheet
+    // is a self-contained universe; walking up the container tree would
+    // bridge to whatever sits behind it on the page (a dropdown rendered
+    // inside the top-right cluster's [appTvRow] would otherwise let ↓
+    // from its first item escape down into the page section below).
+    // Prefer the modal that contains focus; fall back to the first open
+    // one so a freshly-opened dropdown still scopes arrows even before
+    // focus has settled inside it.
+    const modals = this.openModals();
+    const openModal = modals.length
+      ? modals.find((m) => active && m.contains(active)) ?? modals[0]
+      : null;
+    if (!openModal && active && active !== document.body && this.containers.size > 0) {
+      const tree = this.findNeighborInTree(active, dir);
+      if (tree) return tree;
+    }
     const all = openModal ? collectFocusables(openModal) : collectFocusables();
     if (!all.length) return null;
 

--- a/client/src/app/core/services/tv-spatial-nav.service.ts
+++ b/client/src/app/core/services/tv-spatial-nav.service.ts
@@ -260,14 +260,12 @@ export class TvSpatialNavService {
       const tree = this.findNeighborInTree(active, dir);
       if (tree) return tree;
     }
-    // Focus trap: any open dropdown / menu / bottom-sheet / always-visible
-    // pinned sidebar that opts in via `[data-tv-modal]` restricts
-    // navigation to its contents so arrow keys can't leak outside. Only
-    // applies when focus is CURRENTLY inside the modal — otherwise an
-    // always-on element (e.g. the pinned admin sidebar) would prevent
-    // ever reaching it from elsewhere on the page. The `.dropdown-open
-    // .dropdown-content` form is kept for the legacy player dropdowns
-    // that don't carry the attribute.
+    // Focus trap: transient overlays (open dropdown / popover / bottom
+    // sheet) opt in via `[data-tv-modal]` so arrow keys can't leak out.
+    // Only applies when focus is CURRENTLY inside the modal — otherwise
+    // an open dropdown elsewhere on the page would block normal nav.
+    // The `.dropdown-open .dropdown-content` form is kept for legacy
+    // player dropdowns that don't carry the attribute.
     const modalCandidates: HTMLElement[] = [
       ...Array.from(document.querySelectorAll<HTMLElement>('[data-tv-modal]')),
       ...Array.from(
@@ -288,11 +286,13 @@ export class TvSpatialNavService {
     const fromCy = fromRect.top + fromRect.height / 2;
     const horizontal = dir === 'left' || dir === 'right';
 
-    // Scope horizontal nav to the active horizontal scroller (if any). Without
-    // this, pressing Right on the last card of a row would fall through to
-    // the `anywhere` fallback and land on a card from another row or a button
-    // elsewhere. Inside a scroller, Left/Right should stay among siblings;
-    // boundaries (first/last card) just block.
+    // Scope horizontal nav to the active horizontal scroller (if any).
+    // Without this, pressing Right on the last card of a row would fall
+    // through to the `anywhere` fallback and land on a card from another
+    // row. The restriction is applied below only to off-line / anywhere
+    // candidates — in-line (same row) candidates are always considered
+    // so the user can step out of the row toward a same-band element
+    // outside it (typically: the layout sidebar on the left).
     const activeScroller = horizontal
       ? active.closest<HTMLElement>('.flex.overflow-x-auto, [data-scroller]')
       : null;
@@ -312,11 +312,6 @@ export class TvSpatialNavService {
 
     for (const el of all) {
       if (el === active) continue;
-      // Horizontal nav inside a scroller: candidates must be siblings in the
-      // same scroller. At the last/first card the loop yields no candidates
-      // and findNeighbor returns null — D-pad Right at end-of-row blocks
-      // (no jump to a button on another row), matching TV remote convention.
-      if (activeScroller && !activeScroller.contains(el)) continue;
       const r = el.getBoundingClientRect();
       if (r.width === 0 || r.height === 0) continue;
       if (getComputedStyle(el).pointerEvents === 'none') continue;
@@ -340,7 +335,14 @@ export class TvSpatialNavService {
       const cross   = horizontal ? Math.abs(dy) : Math.abs(dx);
 
       if (sameRowOrCol) {
+        // Same-band candidates are considered globally — this is what lets
+        // Left from the leftmost card in a row reach the sidebar without
+        // falling through to the cross-row `anywhere` fallback.
         inLine.push({ el, primary });
+      } else if (activeScroller && !activeScroller.contains(el)) {
+        // Off-line candidates outside the active row scroller would let
+        // Right on the last card jump to a card in a row below. Skip.
+        continue;
       } else if (cross <= primary) {
         offLine.push({ el, score: primary * primary + 16 * cross * cross });
       } else {

--- a/client/src/app/features/app-settings/display-settings/display-settings.html
+++ b/client/src/app/features/app-settings/display-settings/display-settings.html
@@ -7,5 +7,14 @@
       [label]="'display_settings.home_background' | translate"
       [hint]="'display_settings.home_background_hint' | translate"
     />
+
+    <div class="divider my-0"></div>
+
+    <app-toggle-field
+      [value]="onlyMyRequests()"
+      (valueChange)="onOnlyMyRequestsChange($event)"
+      [label]="'display_settings.only_my_requests' | translate"
+      [hint]="'display_settings.only_my_requests_hint' | translate"
+    />
   </div>
 </div>

--- a/client/src/app/features/app-settings/display-settings/display-settings.ts
+++ b/client/src/app/features/app-settings/display-settings/display-settings.ts
@@ -13,14 +13,21 @@ export class DisplaySettingsPageComponent implements OnInit {
   private readonly displaySettings = inject(DisplaySettingsService);
 
   readonly homeBackground = signal(true);
+  readonly onlyMyRequests = signal(false);
 
   ngOnInit() {
     const s = this.displaySettings.get();
     this.homeBackground.set(s.homeBackground);
+    this.onlyMyRequests.set(s.onlyMyRequests);
   }
 
   onHomeBackgroundChange(value: boolean) {
     this.homeBackground.set(value);
     this.displaySettings.save({ homeBackground: value });
+  }
+
+  onOnlyMyRequestsChange(value: boolean) {
+    this.onlyMyRequests.set(value);
+    this.displaySettings.save({ onlyMyRequests: value });
   }
 }

--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -65,13 +65,6 @@
       </app-horizontal-scroller>
     }
 
-    <!-- Filter toggle -->
-    <label class="flex items-center gap-2 cursor-pointer">
-      <input type="checkbox" class="toggle toggle-sm toggle-primary"
-        [ngModel]="onlyMyRequests()" (ngModelChange)="toggleOnlyMyRequests()" />
-      <span class="text-sm text-base-content/70">{{ 'home.only_my_requests' | translate }}</span>
-    </label>
-
     <!-- Recently Added -->
     @if (recentMedia().length) {
       <app-horizontal-scroller [title]="'home.recent_media' | translate">

--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -36,9 +36,11 @@
             [link]="['/' + (item.mediaType === 'series' ? 'series' : 'movies'), '' + item.mediaId]"
             [subtitleLink]="item.episodeId ? ['/series', '' + item.mediaId, 'episode', '' + item.episodeId] : null"
             [dismissable]="true"
+            [interactiveWatched]="true"
             [clickIntent]="'play'"
             (clicked)="playContinueWatching(item)"
             (dismissed)="removeContinueWatching(item)"
+            (watchedToggled)="toggleContinueWatchingWatched(item, $event)"
           />
         }
       </app-horizontal-scroller>
@@ -75,6 +77,8 @@
             [media]="m"
             [subtitle]="'' + m.year"
             [hideStatusBar]="true"
+            [interactiveWatched]="canMarkMediaWatched(m)"
+            (watchedToggled)="toggleRecentMediaWatched(m, $event)"
           />
         }
       </app-horizontal-scroller>

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -351,6 +351,46 @@ export class HomeComponent implements OnInit, OnDestroy {
     }, false);
   }
 
+  /** "Mark as watched" can only fire on a movie with at least one file
+   *  or a series (bulk-toggle endpoint). For lean rows that don't expose
+   *  a file (e.g. recommendations without a local copy) the action stays
+   *  hidden from the context menu. */
+  canMarkMediaWatched(m: Media): boolean {
+    return m.type === 'series' || !!m.files?.length;
+  }
+
+  async toggleContinueWatchingWatched(item: ContinueWatchingItem, watched: boolean) {
+    try {
+      await this.streamingApi.toggleWatched(item.mediaId, item.mediaFileId, item.episodeId ?? undefined);
+      // Mark-watched drops the current episode but may surface the next
+      // one in the series (the backend auto-advances continue-watching).
+      // Refetch the row instead of filtering locally so the user sees the
+      // next episode appear in place rather than the card vanishing.
+      if (watched) {
+        const list = await this.streamingApi.getContinueWatching(undefined, { force: true }).catch(() => null);
+        if (list) this.continueWatching.set(list);
+      }
+    } catch { /* global error toast */ }
+  }
+
+  async toggleRecentMediaWatched(m: Media, watched: boolean) {
+    try {
+      if (m.type === 'series') {
+        await this.streamingApi.toggleSeriesWatched(m.id, watched);
+      } else {
+        const fileId = m.files?.[0]?.id;
+        if (!fileId) return;
+        await this.streamingApi.toggleWatched(m.id, fileId);
+      }
+      if (watched) {
+        // Recently-added is loaded with excludeWatched=true, so a watched
+        // row would vanish on the next refresh anyway — remove it now to
+        // match the visible expectation.
+        this.recentMedia.update(list => list.filter(x => x.id !== m.id));
+      }
+    } catch { /* global error toast */ }
+  }
+
   async removeContinueWatching(item: ContinueWatchingItem) {
     const confirmed = await this.confirmation.confirm({
       title: 'Retirer',

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -2,7 +2,6 @@ import { Component, ChangeDetectionStrategy, inject, signal, effect, OnInit, OnD
 import { ActivatedRoute, NavigationStart, Router, RouterLink } from '@angular/router';
 import { Subscription, filter } from 'rxjs';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
-import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { MediaService, Media, CalendarEntry } from '../../core/services/api/media.service';
 import { StreamingApiService, ContinueWatchingItem, RecommendationItem } from '../../core/services/api/streaming-api.service';
@@ -57,7 +56,7 @@ import { AuthService } from '../../core/services/auth.service';
 @Component({
   selector: 'app-home',
   imports: [
-    RouterLink, TranslateModule, FormsModule,
+    RouterLink, TranslateModule,
     MediaCardComponent,
     HorizontalScrollerComponent,
     LucideIconComponent,
@@ -117,9 +116,19 @@ export class HomeComponent implements OnInit, OnDestroy {
     }
     if (pool.length) this.backgroundService.setBackgrounds(pool);
   });
-  readonly onlyMyRequests = signal(
-    localStorage.getItem('fliks.home.onlyMyRequests') === 'true',
-  );
+  /** Reactively re-filter the home rows whenever the user flips the
+   *  "only my requests" toggle in display settings. Skips the very first
+   *  invocation so we don't double-fetch on initial page load — ngOnInit
+   *  already calls loadAllSections(). */
+  private firstOnlyMyRequestsRun = true;
+  private readonly onlyMyRequestsEffect = effect(() => {
+    void this.displaySettings.settings().onlyMyRequests;
+    if (this.firstOnlyMyRequestsRun) {
+      this.firstOnlyMyRequestsRun = false;
+      return;
+    }
+    void this.loadFilteredSections();
+  });
 
   libraryUrl(lib: LibrarySummary): string {
     return `/libraries/${encodeURIComponent(lib.name)}`;
@@ -247,14 +256,8 @@ export class HomeComponent implements OnInit, OnDestroy {
     root.querySelector<HTMLElement>(FOCUSABLE)?.focus({ preventScroll: false });
   }
 
-  async toggleOnlyMyRequests() {
-    this.onlyMyRequests.update((v) => !v);
-    localStorage.setItem('fliks.home.onlyMyRequests', String(this.onlyMyRequests()));
-    await this.loadFilteredSections();
-  }
-
   private async loadFilteredSections() {
-    const mine = this.onlyMyRequests();
+    const mine = this.displaySettings.settings().onlyMyRequests;
     const today = new Date();
     const threeDaysAgo = new Date(today);
     threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -265,11 +265,21 @@
                   (click)="$event.stopPropagation()"
                   (change)="toggleSelect(item.id)"
                 />
-                <app-media-card [media]="item" [status]="watchedIds().has(item.id) ? 'watched' : null" />
+                <app-media-card
+                  [media]="item"
+                  [status]="watchedIds().has(item.id) ? 'watched' : null"
+                  [interactiveWatched]="canMarkMediaWatched(item)"
+                  (watchedToggled)="toggleMediaWatched(item, $event)"
+                />
               </div>
             } @else {
               <div [id]="'media-' + item.id" [attr.data-library-focus]="'media:' + item.id">
-                <app-media-card [media]="item" [status]="watchedIds().has(item.id) ? 'watched' : null" />
+                <app-media-card
+                  [media]="item"
+                  [status]="watchedIds().has(item.id) ? 'watched' : null"
+                  [interactiveWatched]="canMarkMediaWatched(item)"
+                  (watchedToggled)="toggleMediaWatched(item, $event)"
+                />
               </div>
             }
           }

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -603,4 +603,31 @@ export class LibraryComponent implements OnInit, OnDestroy {
       if (!silent) this.loading.set(false);
     }
   }
+
+  /** Series always toggleable (bulk endpoint, no file needed). Movies need
+   *  at least one local file — without it `toggleWatched` has nothing to
+   *  reference and the action would silently no-op. */
+  canMarkMediaWatched(m: Media): boolean {
+    return m.type === 'series' || !!m.files?.length;
+  }
+
+  async toggleMediaWatched(m: Media, watched: boolean) {
+    try {
+      if (m.type === 'series') {
+        await this.streamingApi.toggleSeriesWatched(m.id, watched);
+      } else {
+        const fileId = m.files?.[0]?.id;
+        if (!fileId) return;
+        await this.streamingApi.toggleWatched(m.id, fileId);
+      }
+      // Reflect new state on the visible card without a full refetch —
+      // the parent's `watchedIds` set drives the `'watched'` status badge.
+      this.watchedIds.update((set) => {
+        const next = new Set(set);
+        if (watched) next.add(m.id);
+        else next.delete(m.id);
+        return next;
+      });
+    } catch { /* global error toast */ }
+  }
 }

--- a/client/src/app/features/search/search.html
+++ b/client/src/app/features/search/search.html
@@ -11,6 +11,7 @@
         [placeholder]="'search.placeholder' | translate"
         [ngModel]="state.query()"
         (ngModelChange)="onQueryInput($event)"
+        [ngModelOptions]="{ standalone: true }"
         (focus)="onInputFocus()"
         (blur)="onInputBlur()"
       />

--- a/client/src/app/features/search/search.html
+++ b/client/src/app/features/search/search.html
@@ -1,22 +1,25 @@
 <div class="flex flex-col gap-4">
   <!-- Search input + settings -->
   <div class="flex gap-2 items-center">
-    <div class="relative flex-1">
+    <form class="relative flex-1" (ngSubmit)="dismissKeyboard()">
       <svg lucideSearch class="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-base-content/40 pointer-events-none z-10"></svg>
       <input
         #searchInput
         type="text"
+        enterkeyhint="search"
         class="input input-bordered w-full pl-10 pr-10"
         [placeholder]="'search.placeholder' | translate"
         [ngModel]="state.query()"
         (ngModelChange)="onQueryInput($event)"
+        (focus)="onInputFocus()"
+        (blur)="onInputBlur()"
       />
       @if (state.hasQuery()) {
-        <button class="btn btn-ghost btn-circle btn-sm absolute right-1 top-1/2 -translate-y-1/2" (click)="clearQuery()">
+        <button type="button" class="btn btn-ghost btn-circle btn-sm absolute right-1 top-1/2 -translate-y-1/2" (click)="clearQuery()">
           <svg lucideX class="h-4 w-4"></svg>
         </button>
       }
-    </div>
+    </form>
     <app-dropdown-menu placement="bottom-end">
       <div trigger tabindex="0" role="button" class="btn btn-square btn-ghost">
         <svg lucideSettings class="h-5 w-5"></svg>

--- a/client/src/app/features/search/search.ts
+++ b/client/src/app/features/search/search.ts
@@ -29,6 +29,8 @@ import { MediaType } from '../../core/enums/media-type.enum';
 import { MediaCardComponent, CardBadge } from '../../shared/components/media-card/media-card';
 import { DropdownMenuComponent } from '../../shared/components/dropdown-menu';
 import { LucideSearch, LucideX, LucideSettings } from '@lucide/angular';
+import { Capacitor } from '@capacitor/core';
+import { Keyboard } from '@capacitor/keyboard';
 
 @Component({
   selector: 'app-search',
@@ -104,6 +106,50 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
     this.scrollMemory.deactivate();
     this.attachedSub?.unsubscribe();
     this.detachedSub?.unsubscribe();
+    this.removeOutsidePointerListener();
+  }
+
+  /** Outside-tap → blur. Capacitor's iOS WebView doesn't reliably blur an
+   *  input when the user taps a non-interactive element (no cursor:pointer,
+   *  no click handler). We register a one-shot pointerdown listener while
+   *  the input has focus that blurs it on any tap outside its wrapper. */
+  private outsidePointerHandler: ((e: Event) => void) | null = null;
+
+  protected onInputFocus() {
+    if (this.outsidePointerHandler) return;
+    const inputEl = this.searchInput()?.nativeElement;
+    if (!inputEl) return;
+    this.outsidePointerHandler = (e: Event) => {
+      const target = e.target as Node | null;
+      if (!target) return;
+      // Tap inside the input or the surrounding <form> (clear button, icon)
+      // — keep focus.
+      if (inputEl.closest('form')?.contains(target)) return;
+      inputEl.blur();
+    };
+    document.addEventListener('pointerdown', this.outsidePointerHandler, { capture: true });
+  }
+
+  protected onInputBlur() {
+    this.removeOutsidePointerListener();
+    // Capacitor WebView sometimes keeps the soft keyboard up after a JS
+    // blur — force it down to match the visual state.
+    if (Capacitor.isNativePlatform()) {
+      Keyboard.hide().catch(() => {});
+    }
+  }
+
+  /** Called from the <form> ngSubmit (virtual-keyboard Enter on iOS and
+   *  Android both fire it through the native browser form contract). */
+  protected dismissKeyboard() {
+    this.searchInput()?.nativeElement.blur();
+  }
+
+  private removeOutsidePointerListener() {
+    if (this.outsidePointerHandler) {
+      document.removeEventListener('pointerdown', this.outsidePointerHandler, { capture: true });
+      this.outsidePointerHandler = null;
+    }
   }
 
   async loadRequestedIds() {

--- a/client/src/app/shared/components/media-info-extra/media-info-extra.html
+++ b/client/src/app/shared/components/media-info-extra/media-info-extra.html
@@ -54,7 +54,7 @@
           <dt class="text-base-content/50 text-sm">{{ 'media_info.genres' | translate }}</dt>
           <dd class="font-medium text-base flex flex-wrap gap-x-1">
             @for (genre of genres(); track genre; let last = $last) {
-              <span class="whitespace-nowrap"><button type="button" class="hover:underline rounded" (click)="navigateToGenre(genre)">{{ genre }}</button>@if (!last){,}</span>
+              <span><button type="button" class="hover:underline rounded text-left" (click)="navigateToGenre(genre)">{{ genre }}</button>@if (!last){,}</span>
             }
           </dd>
         </div>

--- a/client/src/app/shared/components/media-info-extra/media-info-extra.html
+++ b/client/src/app/shared/components/media-info-extra/media-info-extra.html
@@ -10,7 +10,7 @@
       @if (originalTitle()) {
         <div>
           <dt class="text-base-content/50 text-sm">{{ 'discover.preview_original_title' | translate }}</dt>
-          <dd class="font-medium text-base truncate">{{ originalTitle() }}</dd>
+          <dd class="font-medium text-base">{{ originalTitle() }}</dd>
         </div>
       }
       @if (media().status) {
@@ -34,27 +34,27 @@
       @if (productionCountries()) {
         <div>
           <dt class="text-base-content/50 text-sm">{{ 'discover.preview_countries' | translate }}</dt>
-          <dd class="font-medium text-base truncate">{{ productionCountries() }}</dd>
+          <dd class="font-medium text-base">{{ productionCountries() }}</dd>
         </div>
       }
       @if (productionCompanies()) {
         <div>
           <dt class="text-base-content/50 text-sm">{{ 'discover.preview_studios' | translate }}</dt>
-          <dd class="font-medium text-base truncate">{{ productionCompanies() }}</dd>
+          <dd class="font-medium text-base">{{ productionCompanies() }}</dd>
         </div>
       }
       @if (directorsLabel()) {
         <div>
           <dt class="text-base-content/50 text-sm">{{ 'media_info.directors' | translate }}</dt>
-          <dd class="font-medium text-base truncate">{{ directorsLabel() }}</dd>
+          <dd class="font-medium text-base">{{ directorsLabel() }}</dd>
         </div>
       }
       @if (genres().length) {
         <div>
           <dt class="text-base-content/50 text-sm">{{ 'media_info.genres' | translate }}</dt>
-          <dd class="font-medium text-base flex flex-wrap">
+          <dd class="font-medium text-base flex flex-wrap gap-x-1">
             @for (genre of genres(); track genre; let last = $last) {
-              <span><button type="button" class="hover:underline rounded px-1" (click)="navigateToGenre(genre)">{{ genre }}</button>@if (!last){<span>,&nbsp;</span>}</span>
+              <span class="whitespace-nowrap"><button type="button" class="hover:underline rounded" (click)="navigateToGenre(genre)">{{ genre }}</button>@if (!last){,}</span>
             }
           </dd>
         </div>

--- a/client/src/app/shared/components/settings-drawer/settings-drawer.html
+++ b/client/src/app/shared/components/settings-drawer/settings-drawer.html
@@ -44,9 +44,7 @@
 
   <div class="drawer-side z-40">
     <label [for]="drawerId" class="drawer-overlay"></label>
-    <aside
-      data-tv-modal
-      class="bg-base-100 w-64 min-h-full flex flex-col"
+    <aside class="bg-base-100 w-64 min-h-full flex flex-col"
       style="
         padding-top: calc(env(safe-area-inset-top, 0px) / 2 );
         padding-bottom: env(safe-area-inset-bottom, 0px);

--- a/client/src/app/shared/components/setup-checklist/setup-checklist.html
+++ b/client/src/app/shared/components/setup-checklist/setup-checklist.html
@@ -1,5 +1,5 @@
 @if (visibleItems().length > 0 || (showAll() && items().length > 0)) {
-  <div [class.py-4]="padding()">
+  <div [class.pb-4]="padding()">
   <section class="card bg-base-200/60 backdrop-blur-sm shadow-sm" >
     <div class="card-body p-4 sm:p-5 gap-3">
       <header class="flex items-center justify-between gap-3 flex-wrap">

--- a/client/src/app/shared/components/user-menu.ts
+++ b/client/src/app/shared/components/user-menu.ts
@@ -36,13 +36,18 @@ import {
         <svg lucideUser class="h-5 w-5"></svg>
       </button>
       @if (auth.user(); as user) {
-        <div class="flex items-center gap-3 px-3 py-3 border-b border-white/10">
-          <div class="w-10 h-10 rounded-full bg-white/10 flex items-center justify-center shrink-0">
-            <svg lucideUser class="h-5 w-5 text-white/60"></svg>
-          </div>
-          <a routerLink="/account" class="min-w-0 flex-1 cursor-pointer">
-            <p class="font-semibold truncate text-white">{{ user.username }}</p>
-            <p class="text-xs text-white/50">{{ user.role }}</p>
+        <div class="border-b border-white/10 pb-1 mb-1">
+          <a
+            routerLink="/account"
+            class="flex items-center gap-3 px-3 py-2 rounded-lg cursor-pointer hover:bg-white/5"
+          >
+            <div class="w-10 h-10 rounded-full bg-white/10 flex items-center justify-center shrink-0">
+              <svg lucideUser class="h-5 w-5 text-white/60"></svg>
+            </div>
+            <div class="min-w-0 flex-1">
+              <p class="font-semibold truncate text-white">{{ user.username }}</p>
+              <p class="text-xs text-white/50">{{ user.role }}</p>
+            </div>
           </a>
         </div>
       }

--- a/client/src/app/shared/directives/dropdown-toggle.directive.ts
+++ b/client/src/app/shared/directives/dropdown-toggle.directive.ts
@@ -16,6 +16,9 @@ import { DismissableStackService } from '../../core/services/dismissable-stack.s
  *     <div class="dropdown-content">…</div>
  *   </div>
  */
+const MENU_FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
 @Directive({
   selector: '[appDropdownToggle]',
   host: {
@@ -27,6 +30,7 @@ export class DropdownToggleDirective implements OnDestroy {
   private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
   private readonly dismissStack = inject(DismissableStackService);
   private outsideClickHandler: ((e: MouseEvent) => void) | null = null;
+  private tabKeyHandler: ((e: KeyboardEvent) => void) | null = null;
   private currentClose: (() => void) | null = null;
   /** The focusable element that opened the dropdown — refocused on close so
    *  Enter / Space re-opens it without needing to Tab back. */
@@ -61,6 +65,15 @@ export class DropdownToggleDirective implements OnDestroy {
 
   private open(dropdown: HTMLElement) {
     dropdown.classList.add('dropdown-open');
+    const content = dropdown.querySelector<HTMLElement>('.dropdown-content');
+    // Move focus into the menu so arrow keys step between items
+    // (spatial-nav scopes nav to `.dropdown-open .dropdown-content`)
+    // and keyboard users can act without an extra Tab. Standard ARIA
+    // menu pattern.
+    queueMicrotask(() => {
+      const first = content?.querySelector<HTMLElement>(MENU_FOCUSABLE_SELECTOR);
+      first?.focus({ preventScroll: true });
+    });
     const close = () => {
       dropdown.classList.remove('dropdown-open');
       this.triggerEl?.focus({ preventScroll: true });
@@ -76,6 +89,37 @@ export class DropdownToggleDirective implements OnDestroy {
       if (this.host.nativeElement.contains(e.target as Node)) return;
       close();
     };
+    // Tab trap: spatial-nav already scopes arrow keys when focus is
+    // inside `.dropdown-open .dropdown-content`, but Tab uses the
+    // browser's native focus order and walks straight out. Wrap Tab /
+    // Shift+Tab at the menu boundaries so keyboard users stay inside
+    // until they explicitly dismiss (Escape via DismissableStackService,
+    // click outside, or pick an item).
+    this.tabKeyHandler = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab' || !content) return;
+      const items = Array.from(
+        content.querySelectorAll<HTMLElement>(MENU_FOCUSABLE_SELECTOR),
+      );
+      if (!items.length) return;
+      const first = items[0];
+      const last = items[items.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      // Focus drifted outside (e.g. before the auto-focus settled) →
+      // pull it back to the natural end of the cycle.
+      if (!active || !content.contains(active)) {
+        e.preventDefault();
+        (e.shiftKey ? last : first).focus({ preventScroll: true });
+        return;
+      }
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus({ preventScroll: true });
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus({ preventScroll: true });
+      }
+    };
+    document.addEventListener('keydown', this.tabKeyHandler);
     setTimeout(() => {
       if (this.outsideClickHandler) {
         document.addEventListener('click', this.outsideClickHandler);
@@ -91,6 +135,10 @@ export class DropdownToggleDirective implements OnDestroy {
     if (this.outsideClickHandler) {
       document.removeEventListener('click', this.outsideClickHandler);
       this.outsideClickHandler = null;
+    }
+    if (this.tabKeyHandler) {
+      document.removeEventListener('keydown', this.tabKeyHandler);
+      this.tabKeyHandler = null;
     }
     if (this.currentClose) {
       this.dismissStack.remove(this.currentClose);

--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -123,7 +123,7 @@
     <main
       class="min-w-0 flex-1 p-4 lg:p-6"
       [class.overflow-x-clip]="!navbar.isHeroPage()"
-      [class.lg:pt-12]="!navbar.isHeroPage() && !isNative && !navbar.mobileNavbarVisible()"
+      [class.lg:pt-20]="!navbar.isHeroPage() && !isNative && !navbar.mobileNavbarVisible()"
       [style.padding-top]="!navbar.isHeroPage() && isNative && !navbar.mobileNavbarVisible() ? 'calc(env(safe-area-inset-top, 0px) + 1rem)' : null"
     >
       @if (!networkService.isOnline()) {

--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -251,8 +251,7 @@
 
   <div class="drawer-side z-40" [class.hidden]="isNative && device.isPhone()">
     <label for="sidebar" [attr.aria-label]="'nav.close_menu' | translate" class="drawer-overlay"></label>
-    <aside data-tv-modal
-           class="w-64 min-h-full flex flex-col"
+    <aside class="w-64 min-h-full flex flex-col"
            [class.bg-base-100]="!background.url()"
            [class.app-sidebar-veil]="!!background.url()"
            [class.backdrop-blur-sm]="!!background.url()"

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -23,6 +23,15 @@
   border-color: transparent;
 }
 
+/* daisyUI ships `.tab` flat by default, which makes the global focus ring
+   (a box-shadow that traces border-radius) render as a square notched
+   into the otherwise rounded UI. Give every tab the same radius as the
+   rest of the design tokens so the ring reads consistently — inside
+   `.tabs-boxed` they still nest cleanly under the larger container. */
+.tab {
+  border-radius: var(--radius-box, 0.5rem);
+}
+
 /* Flex children inherit `min-width: auto`, which prevents inner text from
    wrapping inside DaisyUI labels — the label expands to the longest line
    instead, causing horizontal overflow. Force the side div + alt text to


### PR DESCRIPTION
## Summary

PR #203 was squash-merged with only 3 of the 18 commits we wrote together — the upstream tracking on `fix/media-detail-ui-polish` was lost after the first push and every subsequent \`git push\` failed silently (\"no upstream branch\" exit, masked by the tooling output). The 15 missing commits stayed local; this PR replays them on top of \`main\`.

No conflicts on rebase, type-check clean. Each commit kept its original message.

## Commits restored

- \`fix(layout)\` — bump <main> top padding for the floating cluster
- \`chore(app-settings)\` — redirect /app-settings to /display
- \`chore(setup-checklist)\` — bottom-only padding on home
- \`feat(display-settings)\` — move 'only my requests' toggle from home to display settings
- \`refactor(spatial-nav)\` — relax scroller scope to unify sidebar traversal
- \`fix(spatial-nav)\` — trap focus inside open dropdowns and selects
- \`fix(user-menu)\` — focus ring wraps the whole user header row
- \`fix(app)\` — Escape on a focused <select> stays browser-default
- \`fix(tabs)\` — round .tab so the focus ring is rounded
- \`fix(search)\` — dismiss virtual keyboard on Enter + outside tap (iOS/Android)
- \`fix(media-info-extra)\` — glue genre commas, stop truncating sibling rows
- \`feat(home)\` — mark-watched action on continue-watching + recently-added cards
- \`feat(library)\` — mark-watched action in the library grid
- \`style(media-info-extra)\` — left-align genre buttons, drop forced no-wrap
- \`fix(search)\` — mark ngModel standalone inside the <form>

## Test plan

- [x] \`tsc --noEmit\` clean
- [ ] Smoke-test media-detail mobile synopsis, search keyboard dismissal, spatial-nav arrows in dropdowns / selects, mark-watched on home + library