### PR TITLE
feat(tmdb-preview): align UI with media-detail (back button, page-wide fanart, breakpoint)

### DIFF
--- a/client/src/app/features/tmdb-preview/tmdb-preview.html
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.html
@@ -7,7 +7,7 @@
 } @else if (media(); as m) {
 
   <!-- ===== MOBILE layout ===== -->
-  <div class="lg:hidden">
+  <div class="md:hidden">
     <app-mobile-fanart-hero [fanartUrl]="m.fanartUrl" />
 
     <div class="px-1 -mt-16 relative z-10">
@@ -91,18 +91,25 @@
     </div>
   </div>
 
-  <!-- ===== DESKTOP layout ===== -->
-  <div class="hidden lg:block relative">
+  <!-- ===== DESKTOP layout =====
+       Page-wide fanart is handled by BackgroundService (same as
+       media-detail) — no inline bleed div here. md+ matches the
+       breakpoint media-info-header uses for its own desktop split. -->
+  <div class="hidden md:block relative">
     @if (m.fanartUrl) {
-      <div class="absolute inset-0 -mx-6 -mt-6 overflow-hidden">
-        <img [src]="m.fanartUrl | resolveUrl:'medium'" alt="" class="w-full h-full object-cover object-[50%_25%]" />
-        <div class="absolute inset-0 bg-base-100/80"></div>
-        <div class="absolute inset-0 bg-gradient-to-t from-base-100 via-base-100/30 to-base-100/50"></div>
-      </div>
+      @if (!navbar.mobileNavbarVisible()) {
+        <button type="button" (click)="goBack()" class="relative z-10 btn btn-ghost btn gap-1 mb-4 text-base-content/80 hover:text-base-content">
+          <svg lucideChevronLeft class="h-4 w-4"></svg>
+          {{ 'media_detail.back' | translate }}
+        </button>
+      }
     }
 
-    <div class="flex gap-10 relative z-10">
-      <div class="shrink-0 w-[240px]">
+    <div
+      class="flex gap-10 relative z-20 tv:pt-24!"
+      [style.padding-top]="!navbar.isHeroPage() || navbar.effectiveSidebarPinned() ? null : navbar.mobileNavbarVisible() ? 'calc(env(safe-area-inset-top, 0px) + 2.5rem)' : null"
+    >
+      <div class="shrink-0 w-[200px] xl:w-[220px] 2xl:w-[280px]">
         @if (m.posterUrl) {
           <img [src]="m.posterUrl | resolveUrl:'medium'" [alt]="m.title" class="w-full rounded-xl aspect-2/3 object-cover bg-base-300" />
         } @else {
@@ -113,22 +120,23 @@
       </div>
 
       <div class="flex-1 min-w-0 pt-2">
-        <div class="flex flex-wrap items-center gap-2 mb-2">
-          @if (m.status) { <span class="badge badge-lg badge-neutral">{{ m.status }}</span> }
-          @if (m.year) { <span class="badge badge-lg badge-outline">{{ m.year }}</span> }
+        <h1 class="text-4xl font-bold tracking-tight">{{ m.title }}</h1>
+        @if (m.originalTitle && m.originalTitle !== m.title) {
+          <p class="text-base-content/70 mt-1 text-lg">{{ m.originalTitle }}</p>
+        }
+
+        <!-- Metadata row — same plain-text style as media-detail. -->
+        <div class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-3 text-base-content/60">
           @if (m.rating) {
-            <span class="badge badge-lg badge-warning gap-1">
+            <span class="flex items-center gap-1 text-warning font-semibold">
               <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
               {{ m.rating | number:'1.1-1' }}
             </span>
           }
-          @if (m.runtime) { <span class="badge badge-lg badge-outline">{{ m.runtime }} min</span> }
+          @if (m.year) { <span>{{ m.year }}</span> }
+          @if (m.runtime) { <span>{{ m.runtime }}min</span> }
+          @if (m.status) { <span>{{ m.status }}</span> }
         </div>
-
-        <h1 class="text-4xl font-bold tracking-tight">{{ m.title }}</h1>
-        @if (m.originalTitle && m.originalTitle !== m.title) {
-          <p class="text-base-content/60 mt-1 text-lg">{{ m.originalTitle }}</p>
-        }
 
         @if (m.genres.length) {
           <div class="flex flex-wrap gap-1.5 mt-4">
@@ -136,12 +144,28 @@
           </div>
         }
 
+        <!-- Action buttons — order + sizing matching media-detail's row. -->
+        <div class="flex flex-wrap items-center gap-2 mt-6">
+          @if (canImport()) {
+            <button type="button" class="btn btn-primary" (click)="openImportModal()">
+              {{ 'discover.add_to_library' | translate }}
+            </button>
+          }
+          @if (canRequest()) {
+            <button type="button" class="btn btn-secondary" (click)="openRequestModal()">
+              {{ 'discover.request' | translate }}
+            </button>
+          }
+        </div>
+
         @if (m.overview) {
           <p class="mt-4 text-base-content/90 leading-relaxed whitespace-pre-line">{{ m.overview }}</p>
         }
 
-        <!-- Metadata grid -->
-        <div class="grid grid-cols-2 gap-x-8 gap-y-3 text-sm mt-4">
+        <!-- Secondary metadata grid — kept inline because tmdb-preview's
+             `MetadataDetails` doesn't fit `app-media-info-extra`'s
+             `Media` input. Same visual cadence as that component. -->
+        <div class="grid grid-cols-2 gap-x-8 gap-y-3 text-sm mt-6">
           @if (m.originalLanguage) {
             <div>
               <span class="text-base-content/50 block">{{ 'discover.preview_original_language' | translate }}</span>
@@ -206,19 +230,6 @@
             <span class="text-base-content/50 block">TMDB</span>
             <span class="font-medium">{{ m.tmdbId }}</span>
           </div>
-        </div>
-
-        <div class="flex items-center gap-2 mt-5">
-          @if (canImport()) {
-            <button type="button" class="btn btn-primary btn-sm" (click)="openImportModal()">
-              {{ 'discover.add_to_library' | translate }}
-            </button>
-          }
-          @if (canRequest()) {
-            <button type="button" class="btn btn-secondary btn-sm" (click)="openRequestModal()">
-              {{ 'discover.request' | translate }}
-            </button>
-          }
         </div>
       </div>
     </div>

--- a/client/src/app/features/tmdb-preview/tmdb-preview.html
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.html
@@ -107,7 +107,7 @@
 
     <div
       class="flex gap-10 relative z-20 tv:pt-24!"
-      [style.padding-top]="!navbar.isHeroPage() || navbar.effectiveSidebarPinned() ? null : navbar.mobileNavbarVisible() ? 'calc(env(safe-area-inset-top, 0px) + 2.5rem)' : null"
+      [style.padding-top]="!navbar.isHeroPage() || navbar.effectiveSidebarPinned() ? null : navbar.mobileNavbarVisible() ? 'calc(env(safe-area-inset-top, 0px) + 3.5rem)' : null"
     >
       <div class="shrink-0 w-[200px] xl:w-[220px] 2xl:w-[280px]">
         @if (m.posterUrl) {

--- a/client/src/app/features/tmdb-preview/tmdb-preview.html
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.html
@@ -106,8 +106,8 @@
     }
 
     <div
-      class="flex gap-10 relative z-20 tv:pt-24!"
-      [style.padding-top]="!navbar.isHeroPage() || navbar.effectiveSidebarPinned() ? null : navbar.mobileNavbarVisible() ? 'calc(env(safe-area-inset-top, 0px) + 3.5rem)' : null"
+      class="flex gap-6 lg:gap-10 relative z-20 tv:pt-24!"
+      [style.padding-top]="!navbar.isHeroPage() || navbar.effectiveSidebarPinned() ? null : navbar.mobileNavbarVisible() ? 'calc(env(safe-area-inset-top, 0px) + 3rem)' : null"
     >
       <div class="shrink-0 w-[200px] xl:w-[220px] 2xl:w-[280px]">
         @if (m.posterUrl) {

--- a/client/src/app/features/tmdb-preview/tmdb-preview.ts
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.ts
@@ -4,6 +4,7 @@ import {
   signal,
   inject,
   computed,
+  effect,
   OnInit,
   OnDestroy,
   viewChild,
@@ -20,16 +21,17 @@ import {
 import { ProfilesService } from '../../core/services/api/profiles.service';
 import { LibrariesApiService, Library } from '../../core/services/api/libraries-api.service';
 import { NavbarService } from '../../core/services/navbar.service';
+import { BackgroundService } from '../../core/services/background.service';
 import { RequestModalComponent } from './components/request-modal/request-modal.component';
 import { ImportModalComponent } from './components/import-modal/import-modal.component';
 import { MediaType } from '../../core/enums/media-type.enum';
-import { LucideFilm } from '@lucide/angular';
+import { LucideFilm, LucideChevronLeft } from '@lucide/angular';
 import { MobileFanartHeroComponent } from '../../shared/components/mobile-fanart-hero';
 import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
 
 @Component({
   selector: 'app-tmdb-preview',
-  imports: [FormsModule, CurrencyPipe, DatePipe, DecimalPipe, TranslateModule, ResolveUrlPipe, RequestModalComponent, ImportModalComponent, MobileFanartHeroComponent, LucideFilm],
+  imports: [FormsModule, CurrencyPipe, DatePipe, DecimalPipe, TranslateModule, ResolveUrlPipe, RequestModalComponent, ImportModalComponent, MobileFanartHeroComponent, LucideFilm, LucideChevronLeft],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './tmdb-preview.html',
 })
@@ -40,8 +42,27 @@ export class TmdbPreviewComponent implements OnInit, OnDestroy {
   private readonly profilesApi = inject(ProfilesService);
   private readonly librariesApi = inject(LibrariesApiService);
   private readonly translate = inject(TranslateService);
-  private readonly navbar = inject(NavbarService);
+  protected readonly navbar = inject(NavbarService);
+  private readonly backgroundService = inject(BackgroundService);
   readonly auth = inject(AuthService);
+
+  /** Page-wide fanart background — same plumbing as media-detail. The
+   *  inline bleed div is gone; `app-background` (mounted in layout)
+   *  picks the URL up from the service and renders it under the page. */
+  private readonly backgroundEffect = effect(() => {
+    const m = this.media();
+    if (!m?.fanartUrl) {
+      this.backgroundService.clear();
+      return;
+    }
+    this.backgroundService.setBackgrounds([m.fanartUrl]);
+  });
+
+  /** Back to the previous in-app URL — falls back to `/` when no history.
+   *  Same contract as media-detail's back button on desktop. */
+  goBack() {
+    this.navbar.goBack(['/']);
+  }
 
   readonly media = signal<MetadataDetails | null>(null);
   readonly loading = signal(true);
@@ -76,6 +97,7 @@ export class TmdbPreviewComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.navbar.leaveHeroPage();
+    this.backgroundService.clear();
   }
 
   async ngOnInit() {

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -145,8 +145,8 @@
   }
 
   <div
-    class="flex gap-10 relative z-20 tv:pt-24!"
-    [style.padding-top]="!navbar.isHeroPage() || navbar.effectiveSidebarPinned() ? null : navbar.mobileNavbarVisible() ? 'calc(env(safe-area-inset-top, 0px) + 3.5rem)' : null"
+    class="flex gap-6 lg:gap-10 relative z-20 tv:pt-24!"
+    [style.padding-top]="!navbar.isHeroPage() || navbar.effectiveSidebarPinned() ? null : navbar.mobileNavbarVisible() ? 'calc(env(safe-area-inset-top, 0px) + 3rem)' : null"
   >
     <!-- Poster / Still (desktop only). Smaller poster on the lg-to-xl range
          (sidebar pinned + tablet/desktop window) so the content next to it

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -146,7 +146,7 @@
 
   <div
     class="flex gap-10 relative z-20 tv:pt-24!"
-    [style.padding-top]="!navbar.isHeroPage() || navbar.effectiveSidebarPinned() ? null : navbar.mobileNavbarVisible() ? 'calc(env(safe-area-inset-top, 0px) + 2rem)' : null"
+    [style.padding-top]="!navbar.isHeroPage() || navbar.effectiveSidebarPinned() ? null : navbar.mobileNavbarVisible() ? 'calc(env(safe-area-inset-top, 0px) + 3.5rem)' : null"
   >
     <!-- Poster / Still (desktop only). Smaller poster on the lg-to-xl range
          (sidebar pinned + tablet/desktop window) so the content next to it


### PR DESCRIPTION
## Summary

Bring the \`/add/movie/...\` & \`/add/tv/...\` pages in line with media-detail's chrome:

- **Desktop back button** gated on \`m.fanartUrl && !navbar.mobileNavbarVisible()\`, matching media-info-header's existing logic.
- **Breakpoint**: \`mobile→desktop\` flipped from \`lg:\` (≥1024 px) to \`md:\` (≥768 px) to match media-detail.
- **Page-wide fanart**: dropped the inline bleed div, wired \`BackgroundService\` via an \`effect\` so \`app-background\` (layout root) paints the fanart full-page — same plumbing as media-detail.
- **Content order**: title → metadata row (rating star, year, runtime, status as plain text) → genres → action buttons → overview → secondary metadata grid. Poster sizing tracks media-info-header's responsive widths (\`200/220/280\`).
- **Padding bump**: when the in-page back button is hidden (mobile-navbar layer takes over), bump the flex container's padding-top from \`safe-area + 2rem\` to \`safe-area + 3.5rem\` so the title isn't flush against the fixed navbar. Behaviour unchanged when the in-page back button is visible (sidebar pinned).

## Test plan

- [ ] At ≥1024 px (sidebar pinned): tmdb-preview shows the in-page back button, no extra top padding, fanart fills the page background.
- [ ] At 768–1023 px (mobile navbar visible): in-page back button hidden, top padding gives ~3.5rem breathing room from the navbar.
- [ ] At <768 px: mobile layout intact (fanart hero, stacked content).
- [ ] Compare side-by-side with \`/movies/<id>\` — same back-button placement, poster sizing, content order.