### PR TITLE
feat(requests): drive PROCESSING / AVAILABLE transitions from auto-grab + completion

### DIFF
--- a/backend/src/modules/media/auto-grab-pipeline.service.ts
+++ b/backend/src/modules/media/auto-grab-pipeline.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Media } from './entities/media.entity';
+import { MediaService } from './media.service';
 import { DownloadHistory } from './entities/download-history.entity';
 import { Indexer } from '../indexers/entities/indexer.entity';
 import { TorznabRelease } from '../indexers/torznab.service';
@@ -67,6 +68,8 @@ export class AutoGrabPipelineService {
     private readonly qbittorrent: QbittorrentService,
     private readonly naming: NamingService,
     private readonly qualityDefs: QualityDefinitionsService,
+    @Inject(forwardRef(() => MediaService))
+    private readonly mediaService: MediaService,
   ) {}
 
   async buildScoringContext(
@@ -149,6 +152,10 @@ export class AutoGrabPipelineService {
     runtimeMinutes: number;
     /** Per-source pending check (e.g. episode-scoped lookup). */
     pendingCheck?: () => Promise<boolean>;
+    /** Season targeted by this grab — forwarded to `grabAndRecord` so
+     *  the lifecycle hook can flip only the matching per-season
+     *  requests. Whole-series and movie grabs pass undefined. */
+    seasonNumber?: number;
   }): Promise<boolean> {
     const decision = this.classifyForSearch(args.media, args.files);
     if (decision.mode !== 'missing' && decision.mode !== 'upgrade') {
@@ -203,6 +210,7 @@ export class AutoGrabPipelineService {
       qbitClient: args.qbitClient,
       mediaType: args.mediaType,
       label: args.label,
+      seasonNumber: args.seasonNumber,
     });
   }
 
@@ -219,6 +227,11 @@ export class AutoGrabPipelineService {
     qbitClient: DownloadClient;
     mediaType: 'movie' | 'series';
     label: string;
+    /** Season number when the grabbed release targets a specific
+     *  season/episode — drives per-season request scoping for the
+     *  `APPROVED → PROCESSING` transition. Omit for whole-series and
+     *  movie grabs. */
+    seasonNumber?: number;
   }): Promise<boolean> {
     try {
       this.log.log(
@@ -244,6 +257,15 @@ export class AutoGrabPipelineService {
       this.log.log(
         `AutoGrab[${args.mediaType}]: grabbed "${args.pick.title}" for "${args.label}"`,
       );
+      // Flip linked APPROVED requests to PROCESSING. Failures don't
+      // abort the grab — best effort.
+      void this.mediaService
+        .onReleaseGrabbedForMedia(args.media.id, args.seasonNumber)
+        .catch((err) =>
+          this.log.warn(
+            `request-lifecycle: failed to flip requests to PROCESSING for media#${args.media.id}: ${(err as Error).message}`,
+          ),
+        );
       return true;
     } catch (e) {
       this.log.warn(

--- a/backend/src/modules/media/auto-grab-pipeline.service.ts
+++ b/backend/src/modules/media/auto-grab-pipeline.service.ts
@@ -2,7 +2,7 @@ import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Media } from './entities/media.entity';
-import { MediaService } from './media.service';
+import { RequestLifecycleService } from '../requests/request-lifecycle.service';
 import { DownloadHistory } from './entities/download-history.entity';
 import { Indexer } from '../indexers/entities/indexer.entity';
 import { TorznabRelease } from '../indexers/torznab.service';
@@ -68,8 +68,8 @@ export class AutoGrabPipelineService {
     private readonly qbittorrent: QbittorrentService,
     private readonly naming: NamingService,
     private readonly qualityDefs: QualityDefinitionsService,
-    @Inject(forwardRef(() => MediaService))
-    private readonly mediaService: MediaService,
+    @Inject(forwardRef(() => RequestLifecycleService))
+    private readonly requestLifecycle: RequestLifecycleService,
   ) {}
 
   async buildScoringContext(
@@ -259,8 +259,8 @@ export class AutoGrabPipelineService {
       );
       // Flip linked APPROVED requests to PROCESSING. Failures don't
       // abort the grab — best effort.
-      void this.mediaService
-        .onReleaseGrabbedForMedia(args.media.id, args.seasonNumber)
+      void this.requestLifecycle
+        .onReleaseGrabbed(args.media.id, args.seasonNumber)
         .catch((err) =>
           this.log.warn(
             `request-lifecycle: failed to flip requests to PROCESSING for media#${args.media.id}: ${(err as Error).message}`,

--- a/backend/src/modules/media/media.module.ts
+++ b/backend/src/modules/media/media.module.ts
@@ -9,7 +9,7 @@ import { MediaMetadata } from './entities/media-metadata.entity';
 import { Person } from './entities/person.entity';
 import { MediaCast } from './entities/media-cast.entity';
 import { MediaCrew } from './entities/media-crew.entity';
-import { FliksRequest } from '../requests/entities/request.entity';
+import { RequestsModule } from '../requests/requests.module';
 import { MediaService } from './media.service';
 import { MediaController } from './media.controller';
 import { AuthModule } from '../auth/auth.module';
@@ -44,8 +44,6 @@ import { StreamingModule } from '../streaming/streaming.module';
       MediaCast,
       MediaCrew,
       Library,
-      // Linked from media.service when an import resolves an open request.
-      FliksRequest,
     ]),
     AuthModule,
     MetadataProvidersModule,
@@ -57,6 +55,7 @@ import { StreamingModule } from '../streaming/streaming.module';
     SubtitlesModule,
     MediaServersModule,
     forwardRef(() => FliksSchedulerModule),
+    forwardRef(() => RequestsModule),
     ImageModule,
     StreamingModule,
     LibrariesModule,

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -4,6 +4,8 @@ import {
   NotFoundException,
   ConflictException,
   BadRequestException,
+  OnModuleInit,
+  OnModuleDestroy,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -53,6 +55,9 @@ import { EmbeddedSubtitleService } from '../subtitles/embedded-subtitle.service'
 import { clearMediaCache } from '../../common/utils/media-cache.util';
 import { mapWithConcurrency } from '../../common/utils/concurrency';
 import { MediaServersService } from '../media-servers/media-servers.service';
+import { EventsService } from '../scheduler/events.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { Subscription } from 'rxjs';
 import { FfprobeService } from '../subtitles/ffprobe.service';
 import { SubtitlesService } from '../subtitles/subtitles.service';
 import * as fs from 'fs';
@@ -60,8 +65,9 @@ import * as path from 'path';
 import { relativePathUnderMediaRoot } from '../../common/utils/media-path.util';
 
 @Injectable()
-export class MediaService {
+export class MediaService implements OnModuleInit, OnModuleDestroy {
   private readonly log = new Logger(MediaService.name);
+  private importCompleteSub?: Subscription;
 
   constructor(
     @InjectRepository(Media)
@@ -99,7 +105,27 @@ export class MediaService {
     private readonly subtitles: SubtitlesService,
     private readonly imageService: ImageService,
     private readonly subtitleStream: SubtitleStreamService,
+    private readonly events: EventsService,
+    private readonly notifications: NotificationsService,
   ) {}
+
+  onModuleInit(): void {
+    // Listen for download completions so we can recompute the lifecycle
+    // status of every active request linked to the media. Cheap: only
+    // active requests get inspected, and most events have none.
+    this.importCompleteSub = this.events.subscribe((event) => {
+      if (event.type !== 'import.complete') return;
+      this.onMediaFilesChanged(event.mediaId).catch((err) => {
+        this.log.warn(
+          `request-lifecycle: failed to recompute on import.complete for media#${event.mediaId}: ${(err as Error).message}`,
+        );
+      });
+    });
+  }
+
+  onModuleDestroy(): void {
+    this.importCompleteSub?.unsubscribe();
+  }
 
   async importFromTmdb(
     dto: ImportTmdbDto,
@@ -2309,6 +2335,125 @@ export class MediaService {
     await this.persistMediaMetadata(saved, details);
     await this.linkOpenRequestsToImportedMedia(saved, addedByUserId ?? null);
     return this.findOne(saved.id);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Request lifecycle hooks — drive the `APPROVED → PROCESSING → AVAILABLE`
+  // progression based on auto-grab + file landing events. See issue #208 for
+  // the design rationale.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Called when a release is grabbed (sent to the download client) for
+   * `mediaId`. Flips every active `APPROVED` request linked to that
+   * media to `PROCESSING` so the user sees the download is on its way.
+   *
+   * `seasonNumber` is honoured for series: per-season requests only
+   * flip when their scope includes the grabbed season. Whole-series
+   * requests flip on any grab. Movies pass `undefined`.
+   */
+  async onReleaseGrabbedForMedia(
+    mediaId: number,
+    seasonNumber?: number,
+  ): Promise<void> {
+    const candidates = await this.requestRepo.find({
+      where: {
+        media: { id: mediaId },
+        status: RequestStatus.APPROVED,
+      },
+    });
+    if (candidates.length === 0) return;
+    const touched: FliksRequest[] = [];
+    for (const r of candidates) {
+      if (
+        seasonNumber !== undefined &&
+        r.seasons?.length &&
+        !r.seasons.includes(seasonNumber)
+      ) {
+        continue;
+      }
+      r.status = RequestStatus.PROCESSING;
+      touched.push(r);
+    }
+    if (touched.length) {
+      await this.requestRepo.save(touched);
+      for (const r of touched) {
+        void this.notifications.dispatch('request.processing', {
+          title: r.title,
+          mediaType: r.mediaType,
+        });
+      }
+    }
+  }
+
+  /**
+   * Called after one or more `MediaFile` rows are inserted for
+   * `mediaId`. Walks active `APPROVED` / `PROCESSING` requests and
+   * promotes the ones whose scope is now fully on disk to `AVAILABLE`.
+   *
+   *  - Movies: at least one file → covered.
+   *  - Series whole-request (`seasons` empty/null): every monitored
+   *    season with monitored episodes has all those episodes on disk.
+   *  - Series per-season request: every monitored episode of each
+   *    listed season has a file.
+   *
+   * Unmonitored items are ignored — the admin dropped them from the
+   * scope, they don't gate the promotion.
+   */
+  async onMediaFilesChanged(mediaId: number): Promise<void> {
+    const active = await this.requestRepo.find({
+      where: {
+        media: { id: mediaId },
+        status: In([RequestStatus.APPROVED, RequestStatus.PROCESSING]),
+      },
+    });
+    if (active.length === 0) return;
+
+    const ctx = await this.mediaRepo.findOne({
+      where: { id: mediaId },
+      relations: ['files', 'seasons', 'seasons.episodes'],
+    });
+    if (!ctx) return;
+
+    const touched: FliksRequest[] = [];
+    for (const r of active) {
+      if (!this.isRequestScopeCovered(r, ctx)) continue;
+      r.status = RequestStatus.AVAILABLE;
+      touched.push(r);
+    }
+    if (touched.length) {
+      await this.requestRepo.save(touched);
+      for (const r of touched) {
+        void this.notifications.dispatch('request.available', {
+          title: r.title,
+          mediaType: r.mediaType,
+        });
+      }
+    }
+  }
+
+  /** True when every file the request scope requires is on disk. */
+  private isRequestScopeCovered(request: FliksRequest, media: Media): boolean {
+    if (media.type === MediaType.MOVIE) {
+      return (media.files?.length ?? 0) > 0;
+    }
+    const scope = !request.seasons || request.seasons.length === 0
+      ? null
+      : new Set(request.seasons);
+    const seasons = media.seasons ?? [];
+    let anyChecked = false;
+    for (const s of seasons) {
+      if (scope && !scope.has(s.seasonNumber)) continue;
+      if (!s.monitored) continue;
+      const monitoredEps = (s.episodes ?? []).filter((e) => e.monitored);
+      if (monitoredEps.length === 0) continue;
+      anyChecked = true;
+      if (!monitoredEps.every((e) => e.hasFile)) return false;
+    }
+    // Nothing left to wait for (everything unmonitored, or scope
+    // covers seasons that don't exist) — treat as delivered rather
+    // than stranding the request in PROCESSING forever.
+    return anyChecked;
   }
 
   /**

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -4,12 +4,12 @@ import {
   NotFoundException,
   ConflictException,
   BadRequestException,
-  OnModuleInit,
-  OnModuleDestroy,
+  forwardRef,
+  Inject,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, DataSource, SelectQueryBuilder, Brackets, In } from 'typeorm';
+import { Repository, DataSource, SelectQueryBuilder, Brackets } from 'typeorm';
 import { Media } from './entities/media.entity';
 import { MediaFile } from './entities/media-file.entity';
 import { Season } from './entities/season.entity';
@@ -34,8 +34,8 @@ import {
   MetadataDetails,
   SeasonDetails,
 } from '../metadata-providers/interfaces/metadata-provider.interface';
-import { MediaType, MediaStatus, RequestStatus } from '../../common/enums';
-import { FliksRequest } from '../requests/entities/request.entity';
+import { MediaType, MediaStatus } from '../../common/enums';
+import { RequestLifecycleService } from '../requests/request-lifecycle.service';
 import { ProfilesService } from '../profiles/profiles.service';
 import { QualityProfile } from '../profiles/entities/quality-profile.entity';
 import { LanguageProfile } from '../profiles/entities/language-profile.entity';
@@ -55,9 +55,6 @@ import { EmbeddedSubtitleService } from '../subtitles/embedded-subtitle.service'
 import { clearMediaCache } from '../../common/utils/media-cache.util';
 import { mapWithConcurrency } from '../../common/utils/concurrency';
 import { MediaServersService } from '../media-servers/media-servers.service';
-import { EventsService } from '../scheduler/events.service';
-import { NotificationsService } from '../notifications/notifications.service';
-import { Subscription } from 'rxjs';
 import { FfprobeService } from '../subtitles/ffprobe.service';
 import { SubtitlesService } from '../subtitles/subtitles.service';
 import * as fs from 'fs';
@@ -65,9 +62,8 @@ import * as path from 'path';
 import { relativePathUnderMediaRoot } from '../../common/utils/media-path.util';
 
 @Injectable()
-export class MediaService implements OnModuleInit, OnModuleDestroy {
+export class MediaService {
   private readonly log = new Logger(MediaService.name);
-  private importCompleteSub?: Subscription;
 
   constructor(
     @InjectRepository(Media)
@@ -91,8 +87,6 @@ export class MediaService implements OnModuleInit, OnModuleDestroy {
     private readonly castRepo: Repository<MediaCast>,
     @InjectRepository(MediaCrew)
     private readonly crewRepo: Repository<MediaCrew>,
-    @InjectRepository(FliksRequest)
-    private readonly requestRepo: Repository<FliksRequest>,
     private readonly dataSource: DataSource,
     private readonly tmdb: TmdbProvider,
     private readonly providerRegistry: MetadataProviderRegistry,
@@ -105,27 +99,9 @@ export class MediaService implements OnModuleInit, OnModuleDestroy {
     private readonly subtitles: SubtitlesService,
     private readonly imageService: ImageService,
     private readonly subtitleStream: SubtitleStreamService,
-    private readonly events: EventsService,
-    private readonly notifications: NotificationsService,
+    @Inject(forwardRef(() => RequestLifecycleService))
+    private readonly requestLifecycle: RequestLifecycleService,
   ) {}
-
-  onModuleInit(): void {
-    // Listen for download completions so we can recompute the lifecycle
-    // status of every active request linked to the media. Cheap: only
-    // active requests get inspected, and most events have none.
-    this.importCompleteSub = this.events.subscribe((event) => {
-      if (event.type !== 'import.complete') return;
-      this.onMediaFilesChanged(event.mediaId).catch((err) => {
-        this.log.warn(
-          `request-lifecycle: failed to recompute on import.complete for media#${event.mediaId}: ${(err as Error).message}`,
-        );
-      });
-    });
-  }
-
-  onModuleDestroy(): void {
-    this.importCompleteSub?.unsubscribe();
-  }
 
   async importFromTmdb(
     dto: ImportTmdbDto,
@@ -830,15 +806,7 @@ export class MediaService implements OnModuleInit, OnModuleDestroy {
 
     const saved = await this.mediaRepo.save(media);
     await this.updateSearchVector(saved.id);
-    // Admin just disabled monitoring → any active request on this title
-    // can no longer be fulfilled; mark them declined so users see the
-    // status change. Same rule as the media-deletion path.
-    if (wasMonitored && saved.monitored === false) {
-      await this.declineLinkedActiveRequests(
-        saved,
-        'Media was unmonitored',
-      );
-    }
+    await this.requestLifecycle.onMediaMonitorChange(saved, wasMonitored);
     return this.findOne(saved.id);
   }
 
@@ -942,84 +910,12 @@ export class MediaService implements OnModuleInit, OnModuleDestroy {
     const media = await this.findOne(id);
     const title = media.title;
     const mediaPath = media.path;
-    await this.declineLinkedActiveRequests(media);
+    await this.requestLifecycle.onMediaRemoved(media);
     await this.mediaRepo.remove(media);
     void this.mediaServers.dispatch('media.deleted', {
       title,
       path: mediaPath,
     });
-  }
-
-  /**
-   * Decline every active (`PENDING` / `APPROVED` / `PROCESSING`) request
-   * linked to this media — used when the row is going away or when the
-   * admin disables monitoring on it. `AVAILABLE` requests stay as-is:
-   * the user already had the content at some point, the post-fulfilment
-   * removal is library hygiene, not a rejection of their original ask.
-   */
-  private async declineLinkedActiveRequests(
-    media: Media,
-    reason = 'Media removed from library',
-  ): Promise<void> {
-    const linked = await this.requestRepo.find({
-      where: {
-        media: { id: media.id },
-        status: In([
-          RequestStatus.PENDING,
-          RequestStatus.APPROVED,
-          RequestStatus.PROCESSING,
-        ]),
-      },
-    });
-    if (linked.length === 0) return;
-    for (const r of linked) {
-      r.status = RequestStatus.DECLINED;
-      r.declinedReason = reason;
-      r.media = null;
-    }
-    await this.requestRepo.save(linked);
-  }
-
-  /**
-   * When the admin disables monitoring on a single season, requests
-   * touching that season can't be fulfilled anymore:
-   *  - Per-season requests carrying ONLY this season → declined.
-   *  - Per-season requests carrying this season AND others → scope
-   *    trimmed (the season is removed from `seasons`), the rest of the
-   *    request lives on.
-   *  - Whole-series requests (`seasons` empty/null) → untouched. The
-   *    user wanted the whole show, partial unmonitoring is the admin's
-   *    discretion and doesn't void the ask.
-   */
-  private async declineLinkedActiveRequestsForSeason(
-    media: Media,
-    seasonNumber: number,
-  ): Promise<void> {
-    const candidates = await this.requestRepo.find({
-      where: {
-        media: { id: media.id },
-        status: In([
-          RequestStatus.PENDING,
-          RequestStatus.APPROVED,
-          RequestStatus.PROCESSING,
-        ]),
-      },
-    });
-    const touched: FliksRequest[] = [];
-    for (const r of candidates) {
-      if (!r.seasons || r.seasons.length === 0) continue;
-      if (!r.seasons.includes(seasonNumber)) continue;
-      const remaining = r.seasons.filter((n) => n !== seasonNumber);
-      if (remaining.length === 0) {
-        r.status = RequestStatus.DECLINED;
-        r.declinedReason = `Season ${seasonNumber} was unmonitored`;
-        r.media = null;
-      } else {
-        r.seasons = remaining;
-      }
-      touched.push(r);
-    }
-    if (touched.length) await this.requestRepo.save(touched);
   }
 
   // ---------------------------------------------------------------------------
@@ -1219,10 +1115,12 @@ export class MediaService implements OnModuleInit, OnModuleDestroy {
     if (patch.preferredProvider !== undefined)
       season.preferredProvider = patch.preferredProvider;
     const saved = await this.seasonRepo.save(season);
-    if (wasMonitored && saved.monitored === false && season.media) {
-      await this.declineLinkedActiveRequestsForSeason(
+    if (season.media) {
+      await this.requestLifecycle.onSeasonMonitorChange(
         season.media,
         saved.seasonNumber,
+        wasMonitored,
+        saved.monitored,
       );
     }
     return saved;
@@ -2276,7 +2174,7 @@ export class MediaService implements OnModuleInit, OnModuleDestroy {
     await this.downloadMediaImages(saved.id, details);
     await this.updateSearchVector(saved.id);
     await this.persistMediaMetadata(saved, details);
-    await this.linkOpenRequestsToImportedMedia(saved, addedByUserId ?? null);
+    await this.requestLifecycle.onMediaImported(saved, addedByUserId ?? null);
     return this.findOne(saved.id);
   }
 
@@ -2333,127 +2231,24 @@ export class MediaService implements OnModuleInit, OnModuleDestroy {
 
     await this.updateSearchVector(saved.id);
     await this.persistMediaMetadata(saved, details);
-    await this.linkOpenRequestsToImportedMedia(saved, addedByUserId ?? null);
+    await this.requestLifecycle.onMediaImported(saved, addedByUserId ?? null);
     return this.findOne(saved.id);
   }
 
   // ---------------------------------------------------------------------------
-  // Request lifecycle hooks — drive the `APPROVED → PROCESSING → AVAILABLE`
-  // progression based on auto-grab + file landing events. See issue #208 for
-  // the design rationale.
+  // Request-driven media operations — narrow public surface that
+  // `RequestLifecycleService` calls when it needs to mutate the media
+  // layer. The orchestration itself lives in the lifecycle service.
   // ---------------------------------------------------------------------------
 
-  /**
-   * Called when a release is grabbed (sent to the download client) for
-   * `mediaId`. Flips every active `APPROVED` request linked to that
-   * media to `PROCESSING` so the user sees the download is on its way.
-   *
-   * `seasonNumber` is honoured for series: per-season requests only
-   * flip when their scope includes the grabbed season. Whole-series
-   * requests flip on any grab. Movies pass `undefined`.
-   */
-  async onReleaseGrabbedForMedia(
-    mediaId: number,
-    seasonNumber?: number,
-  ): Promise<void> {
-    const candidates = await this.requestRepo.find({
-      where: {
-        media: { id: mediaId },
-        status: RequestStatus.APPROVED,
-      },
-    });
-    if (candidates.length === 0) return;
-    const touched: FliksRequest[] = [];
-    for (const r of candidates) {
-      if (
-        seasonNumber !== undefined &&
-        r.seasons?.length &&
-        !r.seasons.includes(seasonNumber)
-      ) {
-        continue;
-      }
-      r.status = RequestStatus.PROCESSING;
-      touched.push(r);
-    }
-    if (touched.length) {
-      await this.requestRepo.save(touched);
-      for (const r of touched) {
-        void this.notifications.dispatch('request.processing', {
-          title: r.title,
-          mediaType: r.mediaType,
-        });
-      }
-    }
-  }
-
-  /**
-   * Called after one or more `MediaFile` rows are inserted for
-   * `mediaId`. Walks active `APPROVED` / `PROCESSING` requests and
-   * promotes the ones whose scope is now fully on disk to `AVAILABLE`.
-   *
-   *  - Movies: at least one file → covered.
-   *  - Series whole-request (`seasons` empty/null): every monitored
-   *    season with monitored episodes has all those episodes on disk.
-   *  - Series per-season request: every monitored episode of each
-   *    listed season has a file.
-   *
-   * Unmonitored items are ignored — the admin dropped them from the
-   * scope, they don't gate the promotion.
-   */
-  async onMediaFilesChanged(mediaId: number): Promise<void> {
-    const active = await this.requestRepo.find({
-      where: {
-        media: { id: mediaId },
-        status: In([RequestStatus.APPROVED, RequestStatus.PROCESSING]),
-      },
-    });
-    if (active.length === 0) return;
-
-    const ctx = await this.mediaRepo.findOne({
+  /** Load a media row with the relations the lifecycle needs to compute
+   *  coverage (`files`, `seasons`, `seasons.episodes`). Centralised here
+   *  to keep `mediaRepo.findOne` calls in one place. */
+  findOneWithSeasonsAndFiles(mediaId: number): Promise<Media | null> {
+    return this.mediaRepo.findOne({
       where: { id: mediaId },
       relations: ['files', 'seasons', 'seasons.episodes'],
     });
-    if (!ctx) return;
-
-    const touched: FliksRequest[] = [];
-    for (const r of active) {
-      if (!this.isRequestScopeCovered(r, ctx)) continue;
-      r.status = RequestStatus.AVAILABLE;
-      touched.push(r);
-    }
-    if (touched.length) {
-      await this.requestRepo.save(touched);
-      for (const r of touched) {
-        void this.notifications.dispatch('request.available', {
-          title: r.title,
-          mediaType: r.mediaType,
-        });
-      }
-    }
-  }
-
-  /** True when every file the request scope requires is on disk. */
-  private isRequestScopeCovered(request: FliksRequest, media: Media): boolean {
-    if (media.type === MediaType.MOVIE) {
-      return (media.files?.length ?? 0) > 0;
-    }
-    const scope = !request.seasons || request.seasons.length === 0
-      ? null
-      : new Set(request.seasons);
-    const seasons = media.seasons ?? [];
-    let anyChecked = false;
-    for (const s of seasons) {
-      if (scope && !scope.has(s.seasonNumber)) continue;
-      if (!s.monitored) continue;
-      const monitoredEps = (s.episodes ?? []).filter((e) => e.monitored);
-      if (monitoredEps.length === 0) continue;
-      anyChecked = true;
-      if (!monitoredEps.every((e) => e.hasFile)) return false;
-    }
-    // Nothing left to wait for (everything unmonitored, or scope
-    // covers seasons that don't exist) — treat as delivered rather
-    // than stranding the request in PROCESSING forever.
-    return anyChecked;
   }
 
   /**
@@ -2490,72 +2285,6 @@ export class MediaService implements OnModuleInit, OnModuleDestroy {
       for (const s of targets) s.monitored = true;
       await this.seasonRepo.save(targets);
     }
-  }
-
-  /**
-   * After a manual import (admin clicks "Add to library" on /add), look
-   * at every open request on the same `tmdbId` and decide what to do
-   * with each:
-   *
-   *  - **Profile envelope covers the request** (e.g. media imported as
-   *    1080p FR-EN, request was 1080p FR): link to the media and, if
-   *    `PENDING`, flip to `APPROVED` with `approvedBy = importer`. The
-   *    new media will satisfy the request.
-   *  - **Profile envelope does NOT cover the request** (e.g. media
-   *    imported as FR, request was VO): leave the request untouched.
-   *    The user wanted something else; an admin will have to decline
-   *    or import a second profile manually. We don't silently swap
-   *    profiles on the user.
-   *
-   * `APPROVED` / `PROCESSING` requests are linked too (so they can
-   * transition to `AVAILABLE` later) but only when the envelope still
-   * covers them — same rule applies in both directions.
-   * `DECLINED` / `FAILED` / `AVAILABLE` are skipped: terminal or
-   * already resolved.
-   */
-  private async linkOpenRequestsToImportedMedia(
-    media: Media,
-    addedByUserId: number | null,
-  ): Promise<void> {
-    if (!media.tmdbId) return;
-    const open = await this.requestRepo.find({
-      where: {
-        tmdbId: media.tmdbId,
-        mediaType: media.type,
-        status: In([
-          RequestStatus.PENDING,
-          RequestStatus.APPROVED,
-          RequestStatus.PROCESSING,
-        ]),
-      },
-    });
-    if (open.length === 0) return;
-
-    const mediaEnvelope = {
-      qualityProfileId: media.qualityProfile?.id ?? null,
-      languageProfileId: media.languageProfile?.id ?? null,
-    };
-
-    const touched: FliksRequest[] = [];
-    for (const r of open) {
-      const covers = await this.profiles.envelopeCovers(mediaEnvelope, {
-        qualityProfileId: r.qualityProfileId,
-        languageProfileId: r.languageProfileId,
-      });
-      if (!covers) continue;
-      r.media = media;
-      if (r.status === RequestStatus.PENDING) {
-        r.status = RequestStatus.APPROVED;
-        if (addedByUserId) {
-          r.approvedBy = { id: addedByUserId } as User;
-        }
-      }
-      touched.push(r);
-      // Bring monitoring in line with what was promised by the request.
-      // Idempotent (no-op when already on), and per-season-aware.
-      await this.applyMonitoredForRequestScope(media, r.seasons ?? null);
-    }
-    if (touched.length) await this.requestRepo.save(touched);
   }
 
   /**

--- a/backend/src/modules/notifications/dto/create-notification-connection.dto.ts
+++ b/backend/src/modules/notifications/dto/create-notification-connection.dto.ts
@@ -12,6 +12,8 @@ const VALID_EVENTS = [
   'request.created',
   'request.approved',
   'request.declined',
+  'request.processing',
+  'request.available',
   'grab.started',
   'download.complete',
   'health.issue',

--- a/backend/src/modules/notifications/entities/notification-connection.entity.ts
+++ b/backend/src/modules/notifications/entities/notification-connection.entity.ts
@@ -12,6 +12,8 @@ export type NotificationEvent =
   | 'request.created'
   | 'request.approved'
   | 'request.declined'
+  | 'request.processing'
+  | 'request.available'
   | 'grab.started'
   | 'download.complete'
   | 'health.issue'

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -174,6 +174,10 @@ export class NotificationsService {
         return `Request approved: ${title}`;
       case 'request.declined':
         return `Request declined: ${title}`;
+      case 'request.processing':
+        return `Request downloading: ${title}`;
+      case 'request.available':
+        return `Request available: ${title}`;
       case 'grab.started':
         return `Grabbing: ${title}`;
       case 'download.complete':

--- a/backend/src/modules/requests/request-lifecycle.service.ts
+++ b/backend/src/modules/requests/request-lifecycle.service.ts
@@ -1,0 +1,325 @@
+import {
+  forwardRef,
+  Inject,
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { Subscription } from 'rxjs';
+import { FliksRequest } from './entities/request.entity';
+import { MediaType, RequestStatus } from '../../common/enums';
+import { Media } from '../media/entities/media.entity';
+import { MediaService } from '../media/media.service';
+import { ProfilesService } from '../profiles/profiles.service';
+import { EventsService } from '../scheduler/events.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { User } from '../users/entities/user.entity';
+import {
+  IN_FLIGHT_REQUEST_STATUSES,
+  seasonScopeOf,
+} from './request-status.constants';
+
+/**
+ * Cross-module orchestration for the request lifecycle. This is where
+ * "something happened on the media side" turns into "promote / decline
+ * / trim the linked request rows". Keeping it in one file makes the
+ * full state machine readable in a single sweep — and stops bloating
+ * `MediaService` with request-shaped methods.
+ *
+ * Triggers (one method each, named after the event that fires them):
+ *
+ *  - `onMediaImported`     — admin clicked Add or an approval imported
+ *                            the row. Link & auto-approve compatible
+ *                            open requests.
+ *  - `onReleaseGrabbed`    — auto-grab pipeline pushed a release to
+ *                            the download client. Flip APPROVED →
+ *                            PROCESSING.
+ *  - `onImportComplete`    — files landed on disk (via `EventsService`
+ *                            subscription). Promote PROCESSING /
+ *                            APPROVED → AVAILABLE for covered scopes.
+ *  - `onMediaMonitorChange`— admin toggled `media.monitored`. Decline
+ *                            active requests when monitoring is OFF.
+ *  - `onSeasonMonitorChange` — same at season granularity (decline
+ *                            scope-only requests, trim multi-season).
+ *  - `onMediaRemoved`      — admin deleted the media row. Decline
+ *                            active requests with a clear reason.
+ */
+@Injectable()
+export class RequestLifecycleService
+  implements OnModuleInit, OnModuleDestroy
+{
+  private readonly log = new Logger(RequestLifecycleService.name);
+  private readonly subscriptions = new Subscription();
+
+  constructor(
+    @InjectRepository(FliksRequest)
+    private readonly requestRepo: Repository<FliksRequest>,
+    @Inject(forwardRef(() => MediaService))
+    private readonly mediaService: MediaService,
+    private readonly profiles: ProfilesService,
+    private readonly events: EventsService,
+    private readonly notifications: NotificationsService,
+  ) {}
+
+  onModuleInit(): void {
+    // Files landing on disk is the canonical "request might be
+    // available now" trigger. Subscribing here keeps the recompute
+    // tied to actual download completions regardless of the path
+    // (auto-grab, manual grab, disk import all route through
+    // `import.complete`).
+    this.subscriptions.add(
+      this.events.subscribe((event) => {
+        if (event.type !== 'import.complete') return;
+        this.onImportComplete(event.mediaId).catch((err) => {
+          this.log.warn(
+            `onImportComplete failed for media#${event.mediaId}: ${(err as Error).message}`,
+          );
+        });
+      }),
+    );
+  }
+
+  onModuleDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Import / approval-side
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Called after a Media row is persisted from an import (admin manual
+   * /add, request approval, profile-match auto-approve). Walks open
+   * requests on the same tmdbId and decides per row:
+   *
+   * - Envelope covers the request → link, flip `PENDING` to `APPROVED`
+   *   with `approvedBy = importer`, apply monitoring on the request's
+   *   season scope.
+   * - Envelope does NOT cover the request → leave untouched. Silent
+   *   profile substitution would surprise the requester (VO ≠ FR).
+   */
+  async onMediaImported(
+    media: Media,
+    addedByUserId: number | null,
+  ): Promise<void> {
+    if (!media.tmdbId) return;
+    const open = await this.requestRepo.find({
+      where: {
+        tmdbId: media.tmdbId,
+        mediaType: media.type,
+        status: In([...IN_FLIGHT_REQUEST_STATUSES]),
+      },
+    });
+    if (open.length === 0) return;
+
+    const mediaEnvelope = {
+      qualityProfileId: media.qualityProfile?.id ?? null,
+      languageProfileId: media.languageProfile?.id ?? null,
+    };
+
+    const touched: FliksRequest[] = [];
+    for (const r of open) {
+      const covers = await this.profiles.envelopeCovers(mediaEnvelope, {
+        qualityProfileId: r.qualityProfileId,
+        languageProfileId: r.languageProfileId,
+      });
+      if (!covers) continue;
+      r.media = media;
+      if (r.status === RequestStatus.PENDING) {
+        r.status = RequestStatus.APPROVED;
+        if (addedByUserId) {
+          r.approvedBy = { id: addedByUserId } as User;
+        }
+      }
+      touched.push(r);
+      // Idempotently monitor the request's scope — admins' previously
+      // unmonitored seasons get re-monitored when a request lands on them.
+      await this.mediaService.applyMonitoredForRequestScope(
+        media,
+        r.seasons ?? null,
+      );
+    }
+    if (touched.length) await this.requestRepo.save(touched);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Grab / completion side
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Auto-grab pipeline sent a release to the download client. Flip
+   * matching `APPROVED` requests to `PROCESSING`. Per-season requests
+   * honour the season scope: only flip when the grabbed season is in
+   * the `seasons` array. Movies / whole-series flip on any grab.
+   */
+  async onReleaseGrabbed(
+    mediaId: number,
+    seasonNumber?: number,
+  ): Promise<void> {
+    const candidates = await this.requestRepo.find({
+      where: {
+        media: { id: mediaId },
+        status: RequestStatus.APPROVED,
+      },
+    });
+    if (candidates.length === 0) return;
+    const touched: FliksRequest[] = [];
+    for (const r of candidates) {
+      if (
+        seasonNumber !== undefined &&
+        r.seasons?.length &&
+        !r.seasons.includes(seasonNumber)
+      ) {
+        continue;
+      }
+      r.status = RequestStatus.PROCESSING;
+      touched.push(r);
+    }
+    if (touched.length) {
+      await this.requestRepo.save(touched);
+      for (const r of touched) {
+        void this.notifications.dispatch('request.processing', {
+          title: r.title,
+          mediaType: r.mediaType,
+        });
+      }
+    }
+  }
+
+  /**
+   * Files landed for `mediaId` — walk active requests and promote the
+   * ones whose scope is now fully on disk to `AVAILABLE`. Coverage
+   * rules (see `isRequestScopeCovered`):
+   *  - Movies: ≥ 1 file.
+   *  - Series whole: every monitored season's monitored episodes have files.
+   *  - Series per-season: every monitored episode of listed seasons has a file.
+   */
+  async onImportComplete(mediaId: number): Promise<void> {
+    const active = await this.requestRepo.find({
+      where: {
+        media: { id: mediaId },
+        status: In([RequestStatus.APPROVED, RequestStatus.PROCESSING]),
+      },
+    });
+    if (active.length === 0) return;
+
+    const ctx = await this.mediaService.findOneWithSeasonsAndFiles(mediaId);
+    if (!ctx) return;
+
+    const touched: FliksRequest[] = [];
+    for (const r of active) {
+      if (!this.isRequestScopeCovered(r, ctx)) continue;
+      r.status = RequestStatus.AVAILABLE;
+      touched.push(r);
+    }
+    if (touched.length) {
+      await this.requestRepo.save(touched);
+      for (const r of touched) {
+        void this.notifications.dispatch('request.available', {
+          title: r.title,
+          mediaType: r.mediaType,
+        });
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Admin-driven cleanup (unmonitor / remove)
+  // ---------------------------------------------------------------------------
+
+  /** Admin disabled `media.monitored`. Active requests can no longer
+   *  be fulfilled — decline them with a machine-readable reason. */
+  onMediaMonitorChange(media: Media, wasMonitored: boolean): Promise<void> {
+    if (!wasMonitored || media.monitored !== false) return Promise.resolve();
+    return this.declineActiveLinkedRequests(media, 'Media was unmonitored');
+  }
+
+  /** Admin disabled monitoring on a single season. Per-season requests
+   *  targeting only this season are declined; multi-season requests
+   *  have the season trimmed from their scope; whole-series requests
+   *  are left alone (partial unmonitoring is admin discretion). */
+  async onSeasonMonitorChange(
+    media: Media,
+    seasonNumber: number,
+    wasMonitored: boolean,
+    isMonitored: boolean,
+  ): Promise<void> {
+    if (!wasMonitored || isMonitored !== false) return;
+    const candidates = await this.requestRepo.find({
+      where: {
+        media: { id: media.id },
+        status: In([...IN_FLIGHT_REQUEST_STATUSES]),
+      },
+    });
+    const touched: FliksRequest[] = [];
+    for (const r of candidates) {
+      const scope = seasonScopeOf(r);
+      if (!scope || !scope.has(seasonNumber)) continue;
+      const remaining = [...r.seasons!].filter((n) => n !== seasonNumber);
+      if (remaining.length === 0) {
+        r.status = RequestStatus.DECLINED;
+        r.declinedReason = `Season ${seasonNumber} was unmonitored`;
+        r.media = null;
+      } else {
+        r.seasons = remaining;
+      }
+      touched.push(r);
+    }
+    if (touched.length) await this.requestRepo.save(touched);
+  }
+
+  /** Admin deleted the media row. Decline every active linked request
+   *  so users see a final status instead of a stale "in progress". */
+  onMediaRemoved(media: Media): Promise<void> {
+    return this.declineActiveLinkedRequests(media, 'Media removed from library');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internals
+  // ---------------------------------------------------------------------------
+
+  /** Decline every active linked request and unwire the media FK.
+   *  `AVAILABLE` requests are left intact — the user already had the
+   *  content, the cleanup is library hygiene, not a rejection. */
+  private async declineActiveLinkedRequests(
+    media: Media,
+    reason: string,
+  ): Promise<void> {
+    const linked = await this.requestRepo.find({
+      where: {
+        media: { id: media.id },
+        status: In([...IN_FLIGHT_REQUEST_STATUSES]),
+      },
+    });
+    if (linked.length === 0) return;
+    for (const r of linked) {
+      r.status = RequestStatus.DECLINED;
+      r.declinedReason = reason;
+      r.media = null;
+    }
+    await this.requestRepo.save(linked);
+  }
+
+  /** True when every file the request scope requires is on disk. */
+  private isRequestScopeCovered(request: FliksRequest, media: Media): boolean {
+    if (media.type === MediaType.MOVIE) {
+      return (media.files?.length ?? 0) > 0;
+    }
+    const scope = seasonScopeOf(request);
+    let anyChecked = false;
+    for (const s of media.seasons ?? []) {
+      if (scope && !scope.has(s.seasonNumber)) continue;
+      if (!s.monitored) continue;
+      const monitoredEps = (s.episodes ?? []).filter((e) => e.monitored);
+      if (monitoredEps.length === 0) continue;
+      anyChecked = true;
+      if (!monitoredEps.every((e) => e.hasFile)) return false;
+    }
+    // Nothing left to wait for (scope past the library, all unmonitored)
+    // — treat as delivered rather than stranding the request forever.
+    return anyChecked;
+  }
+}

--- a/backend/src/modules/requests/request-lifecycle.service.ts
+++ b/backend/src/modules/requests/request-lifecycle.service.ts
@@ -71,9 +71,10 @@ export class RequestLifecycleService
    * Whether an import driven by a request approval should kick off a
    * targeted search immediately, or wait for the next scheduled
    * SearchMissing tick. Default is "yes" — users expect the download
-   * to start right after the green check. A future settings toggle
-   * (e.g. `requests.autoGrabOnApproval`) will read here so the admin
-   * can opt out without changing the rest of the pipeline.
+   * to start right after the green check.
+   *
+   * TODO(#212): replace with an awaited `SettingsService.get(...)` read
+   * so the admin can opt out from the UI. Default stays `true`.
    */
   private autoGrabOnApproval(): boolean {
     return true;

--- a/backend/src/modules/requests/request-lifecycle.service.ts
+++ b/backend/src/modules/requests/request-lifecycle.service.ts
@@ -15,6 +15,7 @@ import { Media } from '../media/entities/media.entity';
 import { MediaService } from '../media/media.service';
 import { ProfilesService } from '../profiles/profiles.service';
 import { EventsService } from '../scheduler/events.service';
+import { SchedulerService } from '../scheduler/scheduler.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { User } from '../users/entities/user.entity';
 import {
@@ -61,8 +62,22 @@ export class RequestLifecycleService
     private readonly mediaService: MediaService,
     private readonly profiles: ProfilesService,
     private readonly events: EventsService,
+    @Inject(forwardRef(() => SchedulerService))
+    private readonly scheduler: SchedulerService,
     private readonly notifications: NotificationsService,
   ) {}
+
+  /**
+   * Whether an import driven by a request approval should kick off a
+   * targeted search immediately, or wait for the next scheduled
+   * SearchMissing tick. Default is "yes" — users expect the download
+   * to start right after the green check. A future settings toggle
+   * (e.g. `requests.autoGrabOnApproval`) will read here so the admin
+   * can opt out without changing the rest of the pipeline.
+   */
+  private autoGrabOnApproval(): boolean {
+    return true;
+  }
 
   onModuleInit(): void {
     // Files landing on disk is the canonical "request might be
@@ -143,6 +158,14 @@ export class RequestLifecycleService
       );
     }
     if (touched.length) await this.requestRepo.save(touched);
+
+    // If the import actually satisfied at least one request, kick off
+    // an immediate SearchMissing for that media so the user doesn't
+    // wait up to 6 h for the next scheduled tick. Fire-and-forget;
+    // failures (missing indexer, etc.) are logged inside the scheduler.
+    if (touched.length && this.autoGrabOnApproval()) {
+      void this.scheduler.searchMissingForMedia([media.id]);
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/backend/src/modules/requests/request-status.constants.ts
+++ b/backend/src/modules/requests/request-status.constants.ts
@@ -1,0 +1,37 @@
+import { RequestStatus } from '../../common/enums';
+import { FliksRequest } from './entities/request.entity';
+
+/** Statuses that count as "this user already wants this title".
+ *  Pending: awaiting decision. Approved/Processing: the system is on it.
+ *  Available: already delivered. All four block a same-user re-request. */
+export const ACTIVE_REQUEST_STATUSES: readonly RequestStatus[] = [
+  RequestStatus.PENDING,
+  RequestStatus.APPROVED,
+  RequestStatus.PROCESSING,
+  RequestStatus.AVAILABLE,
+] as const;
+
+/** Statuses on which another user's request can satisfy a new one — the
+ *  resulting media is (or will be) downloaded under those profiles. */
+export const SATISFIABLE_REQUEST_STATUSES: readonly RequestStatus[] = [
+  RequestStatus.APPROVED,
+  RequestStatus.PROCESSING,
+  RequestStatus.AVAILABLE,
+] as const;
+
+/** Statuses still in motion — the lifecycle can still mutate them. */
+export const IN_FLIGHT_REQUEST_STATUSES: readonly RequestStatus[] = [
+  RequestStatus.PENDING,
+  RequestStatus.APPROVED,
+  RequestStatus.PROCESSING,
+] as const;
+
+/** Resolve a request's season scope to a normalised representation:
+ *  - `null` → covers everything (movie or whole-series).
+ *  - `Set<number>` → covers exactly these season numbers. */
+export function seasonScopeOf(
+  request: Pick<FliksRequest, 'seasons'>,
+): Set<number> | null {
+  if (!request.seasons || request.seasons.length === 0) return null;
+  return new Set(request.seasons);
+}

--- a/backend/src/modules/requests/requests.module.ts
+++ b/backend/src/modules/requests/requests.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { FliksRequest } from './entities/request.entity';
 import { RequestComment } from './entities/request-comment.entity';
@@ -8,6 +8,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
 import { MediaModule } from '../media/media.module';
 import { ProfilesModule } from '../profiles/profiles.module';
 import { RequestsService } from './requests.service';
+import { RequestLifecycleService } from './request-lifecycle.service';
 import { RequestsController } from './requests.controller';
 import { AutoApprovalRulesController } from './auto-approval-rules.controller';
 
@@ -16,11 +17,14 @@ import { AutoApprovalRulesController } from './auto-approval-rules.controller';
     TypeOrmModule.forFeature([FliksRequest, RequestComment, AutoApprovalRule]),
     AuthModule,
     NotificationsModule,
-    MediaModule,
+    // forwardRef: MediaModule injects RequestLifecycleService for the
+    // import / remove / unmonitor hooks, and we inject MediaService here
+    // for the monitoring + 409 fallback lookups.
+    forwardRef(() => MediaModule),
     ProfilesModule,
   ],
   controllers: [RequestsController, AutoApprovalRulesController],
-  providers: [RequestsService],
-  exports: [RequestsService],
+  providers: [RequestsService, RequestLifecycleService],
+  exports: [RequestsService, RequestLifecycleService],
 })
 export class RequestsModule {}

--- a/backend/src/modules/requests/requests.module.ts
+++ b/backend/src/modules/requests/requests.module.ts
@@ -7,6 +7,7 @@ import { AuthModule } from '../auth/auth.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { MediaModule } from '../media/media.module';
 import { ProfilesModule } from '../profiles/profiles.module';
+import { FliksSchedulerModule } from '../scheduler/scheduler.module';
 import { RequestsService } from './requests.service';
 import { RequestLifecycleService } from './request-lifecycle.service';
 import { RequestsController } from './requests.controller';
@@ -22,6 +23,10 @@ import { AutoApprovalRulesController } from './auto-approval-rules.controller';
     // for the monitoring + 409 fallback lookups.
     forwardRef(() => MediaModule),
     ProfilesModule,
+    // forwardRef because FliksSchedulerModule itself imports MediaModule,
+    // which already imports RequestsModule via forwardRef — defensive to
+    // avoid the cycle resolver throwing on a clean cold boot.
+    forwardRef(() => FliksSchedulerModule),
   ],
   controllers: [RequestsController, AutoApprovalRulesController],
   providers: [RequestsService, RequestLifecycleService],

--- a/backend/src/modules/requests/requests.service.ts
+++ b/backend/src/modules/requests/requests.service.ts
@@ -27,24 +27,11 @@ import { Media } from '../media/entities/media.entity';
 import { ProfilesService } from '../profiles/profiles.service';
 import { CaslAbilityFactory } from '../auth/casl/casl-ability.factory';
 import { Action } from '../auth/casl/actions.enum';
-
-/** Request statuses that count as "this user already wants this title".
- *  Pending: awaiting decision. Approved/Processing: the system is on it.
- *  Available: already delivered. All four block a same-user re-request. */
-const ACTIVE_REQUEST_STATUSES: readonly RequestStatus[] = [
-  RequestStatus.PENDING,
-  RequestStatus.APPROVED,
-  RequestStatus.PROCESSING,
-  RequestStatus.AVAILABLE,
-] as const;
-
-/** Statuses on which another user's request can satisfy a new one — the
- *  resulting media is (or will be) downloaded under those profiles. */
-const SATISFIABLE_REQUEST_STATUSES: readonly RequestStatus[] = [
-  RequestStatus.APPROVED,
-  RequestStatus.PROCESSING,
-  RequestStatus.AVAILABLE,
-] as const;
+import {
+  ACTIVE_REQUEST_STATUSES,
+  SATISFIABLE_REQUEST_STATUSES,
+  seasonScopeOf,
+} from './request-status.constants';
 
 interface ProfileEnvelope {
   qualityProfileId: number | null;
@@ -313,29 +300,25 @@ export class RequestsService {
     };
 
     for (const existing of candidates) {
-      if (
-        !(await this.coversSeasons(existing, dto)) ||
-        !(await this.envelopeCovers(existing, requested))
-      ) {
-        continue;
-      }
+      if (!this.coversSeasons(existing, dto)) continue;
+      if (!(await this.envelopeCovers(existing, requested))) continue;
       return true;
     }
     return false;
   }
 
   /** For series only: true when `existing` already covers every season
-   *  the new request is asking for. `null`/empty seasons on `existing`
-   *  means whole series → always covers. Movies skip this check. */
-  private async coversSeasons(
+   *  the new request is asking for. `null` scope on `existing` means
+   *  whole series → always covers. Movies skip this check. */
+  private coversSeasons(
     existing: FliksRequest,
     dto: CreateRequestDto,
-  ): Promise<boolean> {
+  ): boolean {
     if (dto.mediaType !== MediaType.SERIES) return true;
-    if (!existing.seasons || existing.seasons.length === 0) return true;
+    const existingScope = seasonScopeOf(existing);
+    if (!existingScope) return true;
     if (!dto.seasons || dto.seasons.length === 0) return false;
-    const taken = new Set(existing.seasons);
-    return dto.seasons.every((s) => taken.has(s));
+    return dto.seasons.every((s) => existingScope.has(s));
   }
 
   /** Thin wrapper — the encompassment rule lives in ProfilesService so

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -32,6 +32,7 @@ import { StalledCheck } from './entities/stalled-check.entity';
 import { CleanupProfile } from '../cleanup-profiles/entities/cleanup-profile.entity';
 import { Library } from '../libraries/entities/library.entity';
 import { TorrentHistoryMatcher } from '../media/torrent-history-matcher.service';
+import { MarkersService } from '../markers/markers.service';
 import { FileTransferService } from '../../common/services/file-transfer.service';
 
 @Injectable()
@@ -72,7 +73,19 @@ export class CompletionService {
     private readonly thumbnailService: ThumbnailService,
     private readonly historyMatcher: TorrentHistoryMatcher,
     private readonly fileTransfer: FileTransferService,
+    private readonly markers: MarkersService,
   ) {}
+
+  /**
+   * Whether series imports trigger automatic intro / outro marker
+   * detection. Default on — most users want skip-intro working right
+   * after a series finishes downloading. A future settings toggle
+   * (e.g. `markers.autoDetectOnImport`) will read here so the admin
+   * can opt out without changing the rest of the pipeline.
+   */
+  private autoDetectMarkersOnImport(): boolean {
+    return true;
+  }
 
   @Cron(CronExpression.EVERY_MINUTE)
   async processCompleted(): Promise<void> {
@@ -539,6 +552,37 @@ export class CompletionService {
         }
       }
     })();
+
+    // Series only: kick off intro / outro marker detection for every
+    // season whose episodes just landed. Detection runs at season
+    // granularity (it compares audio fingerprints across episodes) so
+    // we dedupe per season. Fire-and-forget; the detection itself is
+    // queued via a Command row, and the in-flight guard skips seasons
+    // already being scanned.
+    if (media.type === 'series' && this.autoDetectMarkersOnImport()) {
+      void (async () => {
+        const seasonIds = new Set<number>();
+        for (const { episodeId: epId } of importedFiles) {
+          if (epId == null) continue;
+          const ep = await this.episodeRepo.findOne({
+            where: { id: epId },
+            relations: ['season'],
+          });
+          if (ep?.season?.id) seasonIds.add(ep.season.id);
+        }
+        for (const seasonId of seasonIds) {
+          try {
+            await this.markers.detectSeason(seasonId, 'auto');
+          } catch (e) {
+            // BadRequest (already in flight) and infra errors stay
+            // out of the import path — detection is best effort.
+            this.log.debug?.(
+              `Post-import marker detection skipped season #${seasonId}: ${(e as Error).message}`,
+            );
+          }
+        }
+      })();
+    }
 
     // Generate thumbnail sprites (seekbar preview) for each imported file.
     // Runs in background — generateForFile is idempotent and ThumbnailService

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -79,9 +79,10 @@ export class CompletionService {
   /**
    * Whether series imports trigger automatic intro / outro marker
    * detection. Default on — most users want skip-intro working right
-   * after a series finishes downloading. A future settings toggle
-   * (e.g. `markers.autoDetectOnImport`) will read here so the admin
-   * can opt out without changing the rest of the pipeline.
+   * after a series finishes downloading.
+   *
+   * TODO(#212): replace with an awaited `SettingsService.get(...)` read
+   * so the admin can opt out from the UI. Default stays `true`.
    */
   private autoDetectMarkersOnImport(): boolean {
     return true;

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -571,6 +571,7 @@ export class SchedulerService implements OnModuleInit {
         expectedTitle: [media.title, ...(media.alternativeTitles ?? [])],
         // Episodes are typically 20-60 min; 30 min fallback for size check.
         runtimeMinutes: media.runtime ?? 30,
+        seasonNumber: season.seasonNumber,
         pendingCheck: async () => {
           const pending = await this.historyRepo
             .createQueryBuilder('h')
@@ -855,6 +856,7 @@ export class SchedulerService implements OnModuleInit {
               mediaType: 'series',
               label: `${seriesMatch.title} S${String(parsed.season).padStart(2, '0')}`,
               runtimeMinutes: seriesMatch.runtime ?? 30,
+              seasonNumber: parsed.season,
               extraPendingCheck: () =>
                 this.hasRecentSeasonPackGrab(seriesMatch.id, parsed.season!),
             });
@@ -884,6 +886,7 @@ export class SchedulerService implements OnModuleInit {
             mediaType: 'series',
             label: `${seriesMatch.title} ${epLabel}`,
             runtimeMinutes: seriesMatch.runtime ?? 30,
+            seasonNumber: parsed.season,
             extraPendingCheck: async () => {
               // Cross-pull Phase 2: a pack was already grabbed for this
               // season in a previous pull — the episode is now redundant.
@@ -1169,6 +1172,10 @@ export class SchedulerService implements OnModuleInit {
     mediaType: 'movie' | 'series';
     label: string;
     runtimeMinutes: number;
+    /** Season targeted by the matched release — forwarded so the
+     *  request-lifecycle hook flips only the matching per-season
+     *  requests when the grab succeeds. */
+    seasonNumber?: number;
     /** Extra grab-dedup logic on top of the same-source-title check. */
     extraPendingCheck?: () => Promise<boolean>;
   }): Promise<boolean> {
@@ -1185,6 +1192,7 @@ export class SchedulerService implements OnModuleInit {
         ...(args.media.alternativeTitles ?? []),
       ],
       runtimeMinutes: args.runtimeMinutes,
+      seasonNumber: args.seasonNumber,
       pendingCheck: async () => {
         // Same release in history — happens because the same item
         // re-appears across feed polls.

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -206,6 +206,29 @@ export class SchedulerService implements OnModuleInit {
     });
   }
 
+  /**
+   * Targeted, fire-and-forget search for one or more media ids. Used
+   * by the request lifecycle right after an approval-driven import so
+   * the user doesn't wait for the next scheduled SearchMissing tick
+   * (up to 6 h). Bypasses the Command row on purpose — the audit
+   * trail for this trigger lives on the request itself, an extra
+   * Command per approval would just clutter the history.
+   *
+   * Throws on infra misconfiguration (no indexer, no download client)
+   * are swallowed and logged: a botched auto-trigger shouldn't take
+   * down the approval transaction.
+   */
+  async searchMissingForMedia(mediaIds: number[]): Promise<void> {
+    if (mediaIds.length === 0) return;
+    try {
+      await this.doSearchMissing(mediaIds);
+    } catch (e) {
+      this.log.warn(
+        `searchMissingForMedia([${mediaIds.join(', ')}]) failed: ${(e as Error).message}`,
+      );
+    }
+  }
+
   async triggerCommand(name: string): Promise<Command> {
     const known = [
       ...SchedulerService.SCHEDULERS.filter((s) => s.triggerable).map(


### PR DESCRIPTION
## Summary

Closes the scoped portion of #208 — the request lifecycle now progresses past \`APPROVED\` automatically:

- **\`APPROVED → PROCESSING\`** when the auto-grab pipeline sends a release to qBittorrent for the media. Per-season requests are scope-aware: only flip when the grabbed season is in the request's \`seasons\` array.
- **\`PROCESSING / APPROVED → AVAILABLE\`** when the matching files land on disk. Subscribes to the existing \`import.complete\` event emitted by \`scheduler/completion.service\`, so every download path (auto-grab, manual grab, disk import) feeds into the same recompute.

Coverage rules for the AVAILABLE check:
- Movies: at least one file → covered.
- Series whole-request (\`seasons\` empty/null): every monitored season's monitored episodes have files.
- Series per-season request: every monitored episode of each listed season has a file.

Unmonitored seasons / episodes don't gate the promotion (admin dropped them).

## Implementation

- New \`MediaService.onReleaseGrabbedForMedia(mediaId, seasonNumber?)\` and \`MediaService.onMediaFilesChanged(mediaId)\` on \`MediaService\` — the lifecycle helpers.
- \`AutoGrabPipelineService.grabAndRecord\` now calls \`onReleaseGrabbedForMedia\` right after the qBittorrent submit + DownloadHistory insert. Both \`grabAndRecord\` and \`tryAutoGrab\` accept an optional \`seasonNumber\`. Scheduler forwards it from the missing-episode scan and the RSS feed paths (full-season pack + single-episode).
- \`MediaService\` subscribes to the global \`EventsService\` stream in \`OnModuleInit\` and triggers \`onMediaFilesChanged\` on every \`import.complete\` event. \`OnModuleDestroy\` tears the subscription down cleanly.
- \`NotificationsService\` accepts and formats two new events: \`request.processing\` (\"Request downloading: …\") and \`request.available\` (\"Request available: …\"). The lifecycle hooks dispatch them per touched row.

## Out of scope (deferred)

- Manual one-shot grabs from \`MovieDownloadService\` / \`EpisodeDownloadService\` — they don't go through \`AutoGrabPipelineService\`, so the PROCESSING flip is missed for those triggers. AVAILABLE still works because they share the same import-complete path. Tracked separately.
- Reverse transitions (\`AVAILABLE → APPROVED\` if files are removed). Out of scope per #208.
- Per-episode requests (would require a schema change). Out of scope per #208.

## Test plan

- [ ] Create a movie request → admin approves → auto-grab sends a torrent → request flips to PROCESSING. Once the torrent completes and the import job runs → request flips to AVAILABLE, \`request.available\` notification fires.
- [ ] Series whole-request → all monitored episodes' files arrive → AVAILABLE.
- [ ] Series per-season request \`[3]\` → episodes of season 3 arrive (other seasons untouched) → AVAILABLE.
- [ ] Two users on the same title: User A's PROCESSING shouldn't promote User B's whole-series request unless B's scope is also fully covered.
- [ ] \`request.processing\` and \`request.available\` accepted by the notification connection editor.