### PR TITLE
fix(ios): wait for AVPlayer seek completion before resolving

### DIFF
--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -355,9 +355,29 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
     @objc func seek(_ call: CAPPluginCall) {
         let position = call.getDouble("position") ?? 0
         DispatchQueue.main.async { [weak self] in
+            guard let player = self?.player else {
+                call.resolve()
+                return
+            }
             let cmTime = CMTime(seconds: position, preferredTimescale: 1000)
-            self?.player?.seek(to: cmTime, toleranceBefore: .zero, toleranceAfter: .zero)
-            call.resolve()
+            // Resolve only AFTER AVPlayer finishes the seek. Resolving
+            // synchronously (the old behaviour) made the JS layer think
+            // the engine was at `position` immediately, the seek-lock
+            // released, and the next time-observer tick with a still-
+            // mid-seek `player.currentTime()` (often 0 because CMTime
+            // briefly becomes .indefinite during the transition)
+            // snapped the seekbar back to 0 before AVPlayer settled at
+            // the target — the visible "forward → back to 0 → forward"
+            // hop. Apple guarantees the completion fires even when our
+            // seek is pre-empted by a subsequent seek (finished=false),
+            // so this never hangs.
+            player.seek(
+                to: cmTime,
+                toleranceBefore: .zero,
+                toleranceAfter: .zero
+            ) { _ in
+                call.resolve()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the visible "forward → snap back to 0 → forward" hop the iOS seekbar made on every click-to-seek.

### Cause

Plugin's `seek()` resolved the JS promise immediately after dispatching the seek to AVPlayer. Chain:

1. JS engine awaits `NativePlayer.seek()` — resolves synchronously on iOS.
2. Engine sets `_currentTime = target` optimistically.
3. `player.ts#awaitSeekUnlock` poll sees `engine.currentTime === target` → break → release `seekLocked`.
4. AVPlayer is still mid-seek (100-500 ms). Next time-observer tick reads `player.currentTime().seconds` — either the old position or `0` (CMTime briefly becomes `.indefinite` during the transition).
5. `seekLocked` is now false → `state.currentTime.set(0)` → seekbar bar snaps to 0.
6. AVPlayer settles, next tick reads the target → bar jumps forward again.

### Fix

Gate `call.resolve()` on the AVPlayer seek **completion handler**. Apple guarantees the handler fires even on a pre-empted seek (`finished=false`), so this can't hang.

## Test plan

- [ ] Click seekbar to a forward position → bar moves once, no snapback.
- [ ] Click seekbar to a backward position → same.
- [ ] Drag-and-release the seekbar → same.
- [ ] Rapid seeks (multiple clicks in quick succession) — each one supersedes the previous, no hang.