### PR TITLE
fix(player): seekbar polish + suppress native long-press selection

### DIFF
--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -75,7 +75,7 @@
 ></div>
 
 <!-- Mobile: big center controls (rewind / play / forward) -->
-@if (isMobileTouch() && !loading() && !buffering()) {
+@if (isMobileTouch() && !loading() && !buffering() && videoStarted()) {
   <div
     class="absolute inset-0 z-50 flex items-center justify-center pointer-events-none transition-opacity duration-200"
     [class.opacity-0]="!visible()"
@@ -119,7 +119,7 @@
        tapOverlay so the empty gap between the title and the right-aligned
        action buttons doubles as a "close controls" hit zone; the buttons
        stop propagation so their own taps don't also dismiss. -->
-  <div class="flex items-end justify-between mb-1.5 gap-2" (click)="tapOverlay.emit()">
+  <div class="flex items-end justify-between mb-0.5 gap-2" (click)="tapOverlay.emit()">
     <div class="min-w-0 shrink">
       @if (episodeTitle()) {
         <div class="text-white/60 font-semibold truncate text-base sm:text-lg">{{ episodeTitle() }}</div>

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -130,6 +130,10 @@ export class PlayerControlsComponent {
   readonly paused = input(true);
   readonly loading = input(false);
   readonly buffering = input(false);
+  /** True once the first decoded frame is on the surface. Hides the big
+   *  mobile play/pause button on cold start so it doesn't overlay the
+   *  centered loading spinner before any frame has rendered. */
+  readonly videoStarted = input(true);
   readonly currentTime = input(0);
   readonly duration = input(0);
   readonly bufferedEnd = input(0);

--- a/client/src/app/features/player/player.html
+++ b/client/src/app/features/player/player.html
@@ -73,6 +73,7 @@
     [paused]="paused()"
     [loading]="loading()"
     [buffering]="buffering()"
+    [videoStarted]="videoStarted()"
     [currentTime]="currentTime()"
     [duration]="duration()"
     [bufferedEnd]="bufferedEnd()"

--- a/client/src/app/shared/cast-overlay/cast-overlay.html
+++ b/client/src/app/shared/cast-overlay/cast-overlay.html
@@ -46,7 +46,6 @@
               [spriteUrl]="cp.spriteUrl()"
               [spriteMetadata]="cp.spriteMetadata()"
               variant="cast"
-              [showThumb]="false"
               [showBuffered]="false"
               (seek)="cast.seek($event)"
             />

--- a/client/src/app/shared/components/seekbar/seekbar.html
+++ b/client/src/app/shared/components/seekbar/seekbar.html
@@ -47,21 +47,25 @@
     </div>
   }
 
-  <!-- Track -->
+  <!-- Track. Slim by default; thickens on hover (pointer), focus-visible
+       (keyboard / TV remote), or while the user is actively dragging. -->
   <div
     class="relative w-full rounded-full overflow-hidden transition-all"
-    [class]="variant() === 'player' ? 'h-2 group-hover:h-2.5 bg-white/20' : 'h-2 bg-base-300'"
+    [class]="trackClass()"
   >
-    <!-- Buffered -->
+    <!-- Buffered. Same `rounded-l-full` treatment as the progress so its
+         right edge is a crisp vertical line, not a curved bulge. -->
     @if (showBuffered() && bufferedEnd()) {
       <div
-        class="absolute inset-y-0 left-0 bg-white/30 rounded-full"
+        class="absolute inset-y-0 left-0 bg-white/30 rounded-l-full"
         [style.width.%]="duration() ? (bufferedEnd() / duration()) * 100 : 0"
       ></div>
     }
-    <!-- Progress -->
+    <!-- Progress. `rounded-l-full` matches the track's left cap;
+         right side stays square so the progress ends on a crisp
+         vertical edge instead of a curved bulge. -->
     <div
-      class="absolute inset-y-0 left-0 rounded-full"
+      class="absolute inset-y-0 left-0 rounded-l-full"
       [class]="variant() === 'player' ? 'bg-white' : 'bg-info'"
       [style.width.%]="displayPercent()"
     ></div>
@@ -74,13 +78,4 @@
       ></div>
     }
   </div>
-
-  <!-- Thumb -->
-  @if (showThumb()) {
-    <div
-      class="seekbar-thumb absolute h-3.5 w-3.5 rounded-full bg-white shadow -translate-x-1/2 pointer-events-none group-hover:scale-125 transition-all"
-      [class.scale-125]="dragging()"
-      [style.left.%]="displayPercent()"
-    ></div>
-  }
 </div>

--- a/client/src/app/shared/components/seekbar/seekbar.ts
+++ b/client/src/app/shared/components/seekbar/seekbar.ts
@@ -21,7 +21,6 @@ export class SeekbarComponent {
   readonly spriteMetadata = input<SpriteMetadata | null>(null);
   readonly variant = input<'player' | 'cast'>('player');
   readonly showTooltip = input(true);
-  readonly showThumb = input(true);
   readonly showBuffered = input(true);
   readonly chapters = input<{ startSeconds: number; endSeconds: number; title?: string }[]>([]);
 
@@ -66,6 +65,20 @@ export class SeekbarComponent {
   readonly displayPercent = computed(() => {
     const d = this.duration() || 1;
     return (this.displayTime() / d) * 100;
+  });
+
+  /** Track height + tint class string. Slim baseline (`h-1.5`),
+   *  thickens to `h-2.5` while dragging or on group-hover / focus
+   *  (handled with the `group-hover:` / `group-focus-visible:`
+   *  utilities so we don't need a (focus)/(blur) Angular listener
+   *  on the parent slider). The dot syntax in Tailwind utilities
+   *  (`h-1.5`) can't be expressed via `[class.h-1.5]` bindings —
+   *  Angular's class-toggle syntax stops at the dot — so the class
+   *  list is assembled here. */
+  readonly trackClass = computed(() => {
+    if (this.variant() === 'cast') return 'h-1.5 bg-base-300';
+    const base = 'bg-white/20 group-hover:h-2.5 group-focus-visible:h-2.5';
+    return this.dragging() ? `${base} h-2.5` : `${base} h-1.5`;
   });
 
   // Sprite preview computeds

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -88,6 +88,31 @@ body.native {
 body.native.immersive {
   padding: 0 !important;
 }
+/* Suppress browser-style text / image selection on Capacitor builds.
+   A long-press on iOS (and on some Android builds) otherwise opens the
+   system "Copy / Save Image" menu when the user just meant to focus or
+   hold a media card. Inputs, textareas and explicit `[contenteditable]`
+   regions are re-enabled below so forms and dialogs still work. The
+   `.select-text` opt-in lets specific surfaces (e.g. release notes,
+   stack traces in the debug panel) keep selection if we want it. */
+body.native,
+body.native * {
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-user-drag: none;
+}
+body.native input,
+body.native textarea,
+body.native [contenteditable="true"],
+body.native [contenteditable=""],
+body.native .select-text,
+body.native .select-text * {
+  -webkit-user-select: text;
+  user-select: text;
+  -webkit-touch-callout: default;
+}
+
 /* Native player (ExoPlayer/AVPlayer behind WebView) — force ALL layers transparent
    so the native video surface shows through the WebView. */
 html.native-player-active {

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -230,18 +230,6 @@ body.tv *:hover {
   box-shadow: none !important;
 }
 
-/* Seekbar thumb: when its parent slider has focus, paint a primary ring
-   around the white dot with a 2 px base-100 gap. Implemented as plain
-   box-shadow so the rule works on Tizen 6.5 / Chromium 85 where
-   Tailwind v4's `ring-*` utilities can lose their custom-property
-   wiring through the downlevel CSS pipeline. */
-[role="slider"]:focus .seekbar-thumb,
-[role="slider"]:focus-visible .seekbar-thumb {
-  box-shadow:
-    0 0 0 2px var(--color-base-100, #1d232a),
-    0 0 0 4px var(--color-primary, #7a3ff2);
-  transform: translateX(-50%) scale(1.25);
-}
 /* TV ghost buttons keep their transparent bg even when focused. The
    3px primary-color outline above is already a strong focus cue on a
    10-foot UI, so layering daisyUI's fill (which kicks in via the


### PR DESCRIPTION
## Summary

Two small UI fixes bundled on the same branch.

### Seekbar polish

- Drop the seekbar thumb dot entirely (`showThumb` input + the inner div + the focus-ring CSS rule). Cleaner read as a single line.
- Progress and buffered bars now use `rounded-l-full` instead of `rounded-full` — left cap matches the track, right edge is a crisp vertical line.
- Trim the player track from `h-2` to `h-1.5`; thickens to `h-2.5` on hover, focus-visible (keyboard / TV remote), or while the user is actively dragging. Class string moved into a `trackClass` computed so the Tailwind dotted utilities (`h-1.5`, `h-2.5`) work — Angular's `[class.h-1.5]` syntax can't express the dot.
- Shrink the gap between the title/buttons row and the seekbar (`mb-1.5` → `mb-0.5`).
- New `videoStarted` input on `app-player-controls`. The big mobile centre play/pause used to render as soon as `loading` / `buffering` flipped to false, but `videoStarted` (engine's first-frame event) could still be false at that point — the button then sat in front of the centred loading spinner. Now gated on `videoStarted` too.

### Suppress long-press selection on Capacitor builds

iOS (and occasionally Android) interprets a long-press on any text or image as a request to open the system selection menu — "Copy", "Save Image", "Look Up", … — which broke long-press affordances on media cards. Native apps don't expose browser-style selection at all, so it's suppressed globally under `body.native`, with inputs / textareas / `[contenteditable]` re-enabled. A `.select-text` opt-in class is available for surfaces that genuinely need selectable text.

## Test plan

- [ ] Seekbar bar is slim by default, thickens on hover / focus / drag.
- [ ] Buffered + progress bars end with a vertical edge (no curved bulge).
- [ ] Open the player on a cold start — only the spinner is visible at centre, no overlapping play button.
- [ ] On the iOS app, long-press a media card → no system "Copy / Save Image" menu.
- [ ] Login + search forms still accept input and let the user select text inside them.