### PR TITLE
fix(popover-menu): clipping / top-layer / focus polish for in-modal usage

### DIFF
--- a/client/src/app/features/select-user/select-user.html
+++ b/client/src/app/features/select-user/select-user.html
@@ -16,7 +16,7 @@
           @let init = initials(user.username);
           <button
             type="button"
-            class="flex flex-col items-center gap-2 p-2 rounded-lg hover:bg-base-100 focus:bg-base-100 transition-colors"
+            class="flex flex-col items-center gap-2 p-2 rounded-lg hover:bg-base-100 focus-visible:bg-base-100 transition-colors"
             (click)="selectUser(user); $event.stopPropagation()"
           >
             <div class="avatar avatar-placeholder">

--- a/client/src/app/shared/components/popover-menu.ts
+++ b/client/src/app/shared/components/popover-menu.ts
@@ -7,6 +7,7 @@ import {
   inject,
   input,
   output,
+  signal,
 } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
 import { BottomSheetComponent } from './bottom-sheet';
@@ -35,6 +36,12 @@ import { DismissableStackService } from '../../core/services/dismissable-stack.s
   standalone: true,
   imports: [BottomSheetComponent, NgTemplateOutlet],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  // `display: contents` keeps the host out of its parent's layout — the
+  // backdrop + content divs are `position: fixed` so they don't need a
+  // box of their own, and the host would otherwise act as a stray grid
+  // item inside a parent like daisyUI's `.modal` (display: grid;
+  // place-items: center) and shift the modal-box off-centre.
+  styles: [':host { display: contents; }'],
   template: `
     <!-- Capture projected content in a template ref so it can be rendered
          in either the dropdown or sheet branch without hitting the
@@ -78,18 +85,31 @@ export class PopoverMenuComponent {
   private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
   private readonly dismissStack = inject(DismissableStackService);
 
+  /** Ticked on every scroll / resize while the popover is open so the
+   *  `position()` computed re-reads the anchor's `getBoundingClientRect`
+   *  and the `position: fixed` box stays glued to the trigger. */
+  private readonly viewportTick = signal(0);
+
   constructor() {
-    // Move the host to <html> on every platform that renders the sheet
-    // variant. Two separate problems both need this:
+    // Move the host out of any clipping / transformed ancestor on the
+    // sheet variant (touch / TV). Two separate problems need this:
     //   • TV → body.tv has a scale transform that re-anchors fixed
     //     descendants to body's box instead of the viewport.
     //   • Mobile → the layout's drawer-content is `position: relative`,
     //     creating a stacking context that traps z-[101] below the
     //     bottom dock (z-40 at body level).
-    // Hosting under <html> escapes both.
+    //
+    // Target: the closest open <dialog> ancestor if there is one, so we
+    // stay inside its top-layer (showModal() puts the dialog above
+    // everything else regardless of z-index); otherwise <html>.
     if (typeof document !== 'undefined' && !this.useDropdown()) {
       queueMicrotask(() => {
-        document.documentElement.appendChild(this.host.nativeElement);
+        const openDialog = this.host.nativeElement.closest<HTMLDialogElement>(
+          'dialog[open]',
+        );
+        (openDialog ?? document.documentElement).appendChild(
+          this.host.nativeElement,
+        );
       });
     }
     // Focus the first focusable inside the menu on every open. autofocus
@@ -115,19 +135,33 @@ export class PopoverMenuComponent {
       const close = () => this.close();
       this.dismissStack.push(close);
       onCleanup(() => this.dismissStack.remove(close));
+
+      // Re-tick on scroll / resize so the `position()` computed
+      // re-reads `getBoundingClientRect` and the fixed-positioned box
+      // stays glued to its trigger. `capture: true` catches scrolls in
+      // any nested overflow container, not just window.
+      if (typeof window === 'undefined' || !this.useDropdown()) return;
+      const tick = () => this.viewportTick.update((v) => v + 1);
+      window.addEventListener('scroll', tick, { capture: true, passive: true });
+      window.addEventListener('resize', tick);
+      onCleanup(() => {
+        window.removeEventListener('scroll', tick, { capture: true } as never);
+        window.removeEventListener('resize', tick);
+      });
     });
   }
 
   /** Anchored dropdown only on desktop with a mouse. TV + touch get the sheet. */
   readonly useDropdown = computed(() => !this.tv.isTv() && !this.device.isTouch());
 
-  /** Recomputed every render. The parent passes anchor by ref so we can
-   *  read its bounding box at open time without an explicit signal.
-   *  `maxHeight` is capped to the available space between the popover's
-   *  edge and the viewport edge so a long list doesn't overflow off-screen
-   *  (the internal `overflow-y-auto` only scrolls content INSIDE the box,
-   *  it doesn't help when the box itself is taller than the viewport). */
+  /** Re-reads `getBoundingClientRect` on every anchor change AND on
+   *  every viewport tick (scroll / resize) so the fixed-positioned box
+   *  follows its trigger when the page moves under it. `maxHeight` is
+   *  capped to the available space between the popover's edge and the
+   *  viewport edge so a long list doesn't overflow off-screen (the
+   *  internal `overflow-y-auto` only scrolls content INSIDE the box). */
   readonly position = computed(() => {
+    this.viewportTick(); // dependency: forces recompute on scroll / resize
     const a = this.anchor();
     if (!a) return { top: 0, left: 0, width: 0, maxHeight: 0 };
     const r = a.getBoundingClientRect();

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -101,64 +101,16 @@
                     </td>
                     <td class="text-end">
                       @if (canGrab() && sub.providerType !== 'embedded') {
-                        <app-dropdown-menu placement="top-end">
-                          <div trigger tabindex="0" role="button" class="btn btn-ghost btn-xs" [class.btn-disabled]="subtitleActionBusy()">
-                            {{ 'media_detail.subtitle_actions' | translate }}
-                            <svg lucideChevronDown class="h-3 w-3"></svg>
-                          </div>
-                          <button type="button" class="dropdown-item text-white" (click)="openSyncModal(sub.id)">
-                            <svg lucidePlay class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                            {{ 'media_detail.action_sync' | translate }}
-                          </button>
-                          <button type="button" class="dropdown-item text-white" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'removeHiTags' })">
-                            <svg lucideVolume2 class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                            {{ 'media_detail.action_remove_hi' | translate }}
-                          </button>
-                          <button type="button" class="dropdown-item text-white" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'removeStyleTags' })">
-                            <svg lucideCode class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                            {{ 'media_detail.action_remove_style' | translate }}
-                          </button>
-                          <button type="button" class="dropdown-item text-white" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'removeEmoji' })">
-                            <svg lucideSmile class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                            {{ 'media_detail.action_remove_emoji' | translate }}
-                          </button>
-                          <button type="button" class="dropdown-item text-white" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'ocrFixes' })">
-                            <svg lucideImage class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                            {{ 'media_detail.action_ocr_fixes' | translate }}
-                          </button>
-                          <button type="button" class="dropdown-item text-white" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'commonFixes' })">
-                            <svg lucideThermometer class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                            {{ 'media_detail.action_common_fixes' | translate }}
-                          </button>
-                          <button type="button" class="dropdown-item text-white" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'fixUppercase' })">
-                            <svg lucideMaximize2 class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                            {{ 'media_detail.action_fix_uppercase' | translate }}
-                          </button>
-                          <button type="button" class="dropdown-item text-white" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'reverseRtl' })">
-                            <svg lucideArrowRightLeft class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                            {{ 'media_detail.action_reverse_rtl' | translate }}
-                          </button>
-                          <button type="button" class="dropdown-item text-white" (click)="postProcessSubtitle({ subtitleId: sub.id, action: 'convertToSrt' })">
-                            <svg lucideFileText class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                            {{ 'media_detail.action_convert_srt' | translate }}
-                          </button>
-                          <button type="button" class="dropdown-item text-white" (click)="openAdjustModal(sub.id)">
-                            <svg lucideClock class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                            {{ 'media_detail.action_adjust_times' | translate }}
-                          </button>
-                          <button type="button" class="dropdown-item text-white" (click)="openFpsModal(sub.id)">
-                            <svg lucideZap class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
-                            {{ 'media_detail.action_change_fps' | translate }}
-                          </button>
-                          <button type="button" class="dropdown-item text-warning" (click)="blacklistSubtitle(sub)">
-                            <svg lucideBan class="h-4 w-4 shrink-0 opacity-80" aria-hidden="true"></svg>
-                            {{ 'media_detail.action_blacklist' | translate }}
-                          </button>
-                          <button type="button" class="dropdown-item text-error" (click)="deleteSubtitle(sub.id)">
-                            <svg lucideTrash2 class="h-4 w-4 shrink-0" aria-hidden="true"></svg>
-                            {{ 'media_detail.action_delete' | translate }}
-                          </button>
-                        </app-dropdown-menu>
+                        <button
+                          #actionsTrigger
+                          type="button"
+                          class="btn btn-ghost btn-xs"
+                          [disabled]="subtitleActionBusy()"
+                          (click)="openSubActions(sub, actionsTrigger)"
+                        >
+                          {{ 'media_detail.subtitle_actions' | translate }}
+                          <svg lucideChevronDown class="h-3 w-3"></svg>
+                        </button>
                       }
                     </td>
                   </tr>
@@ -178,6 +130,74 @@
       }
     </section>
   </div>
+
+  <!-- Single shared Actions popover. Lives INSIDE the parent <dialog>
+       so it participates in the same top-layer once the dialog is open
+       via showModal() — otherwise the modal would paint over it
+       regardless of z-index. `position: fixed` on the popover-menu's
+       content escapes modal-box's overflow on its own. -->
+  @if (actionsSub()) {
+    <app-popover-menu
+      [open]="true"
+      [anchor]="actionsAnchor()"
+      placement="top-end"
+      (closed)="closeSubActions()"
+    >
+      <button type="button" class="dropdown-item text-white" (click)="runSubAction(s => openSyncModal(s.id))">
+        <svg lucidePlay class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+        {{ 'media_detail.action_sync' | translate }}
+      </button>
+      <button type="button" class="dropdown-item text-white" (click)="runSubAction(s => postProcessSubtitle({ subtitleId: s.id, action: 'removeHiTags' }))">
+        <svg lucideVolume2 class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+        {{ 'media_detail.action_remove_hi' | translate }}
+      </button>
+      <button type="button" class="dropdown-item text-white" (click)="runSubAction(s => postProcessSubtitle({ subtitleId: s.id, action: 'removeStyleTags' }))">
+        <svg lucideCode class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+        {{ 'media_detail.action_remove_style' | translate }}
+      </button>
+      <button type="button" class="dropdown-item text-white" (click)="runSubAction(s => postProcessSubtitle({ subtitleId: s.id, action: 'removeEmoji' }))">
+        <svg lucideSmile class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+        {{ 'media_detail.action_remove_emoji' | translate }}
+      </button>
+      <button type="button" class="dropdown-item text-white" (click)="runSubAction(s => postProcessSubtitle({ subtitleId: s.id, action: 'ocrFixes' }))">
+        <svg lucideImage class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+        {{ 'media_detail.action_ocr_fixes' | translate }}
+      </button>
+      <button type="button" class="dropdown-item text-white" (click)="runSubAction(s => postProcessSubtitle({ subtitleId: s.id, action: 'commonFixes' }))">
+        <svg lucideThermometer class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+        {{ 'media_detail.action_common_fixes' | translate }}
+      </button>
+      <button type="button" class="dropdown-item text-white" (click)="runSubAction(s => postProcessSubtitle({ subtitleId: s.id, action: 'fixUppercase' }))">
+        <svg lucideMaximize2 class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+        {{ 'media_detail.action_fix_uppercase' | translate }}
+      </button>
+      <button type="button" class="dropdown-item text-white" (click)="runSubAction(s => postProcessSubtitle({ subtitleId: s.id, action: 'reverseRtl' }))">
+        <svg lucideArrowRightLeft class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+        {{ 'media_detail.action_reverse_rtl' | translate }}
+      </button>
+      <button type="button" class="dropdown-item text-white" (click)="runSubAction(s => postProcessSubtitle({ subtitleId: s.id, action: 'convertToSrt' }))">
+        <svg lucideFileText class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+        {{ 'media_detail.action_convert_srt' | translate }}
+      </button>
+      <button type="button" class="dropdown-item text-white" (click)="runSubAction(s => openAdjustModal(s.id))">
+        <svg lucideClock class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+        {{ 'media_detail.action_adjust_times' | translate }}
+      </button>
+      <button type="button" class="dropdown-item text-white" (click)="runSubAction(s => openFpsModal(s.id))">
+        <svg lucideZap class="h-4 w-4 shrink-0 opacity-70" aria-hidden="true"></svg>
+        {{ 'media_detail.action_change_fps' | translate }}
+      </button>
+      <button type="button" class="dropdown-item text-warning" (click)="runSubAction(s => blacklistSubtitle(s))">
+        <svg lucideBan class="h-4 w-4 shrink-0 opacity-80" aria-hidden="true"></svg>
+        {{ 'media_detail.action_blacklist' | translate }}
+      </button>
+      <button type="button" class="dropdown-item text-error" (click)="runSubAction(s => deleteSubtitle(s.id))">
+        <svg lucideTrash2 class="h-4 w-4 shrink-0" aria-hidden="true"></svg>
+        {{ 'media_detail.action_delete' | translate }}
+      </button>
+    </app-popover-menu>
+  }
+
   <form method="dialog" class="modal-backdrop">
     <button>close</button>
   </form>

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -47,7 +47,7 @@ import { SseService } from '../../../core/services/sse.service';
 import { ToastService } from '../../../core/services/toast.service';
 import { PaginationComponent } from '../pagination/pagination';
 import { MediaDetailSubtitleSearchModalComponent } from '../../../features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component';
-import { DropdownMenuComponent } from '../dropdown-menu';
+import { PopoverMenuComponent } from '../popover-menu';
 import type { MediaInfoHeaderSubtitle } from '../media-info-header/media-info-header';
 
 interface SubtitleRow {
@@ -71,7 +71,7 @@ interface SubtitleRow {
     SubtitleFilenamePipe,
     PaginationComponent,
     MediaDetailSubtitleSearchModalComponent,
-    DropdownMenuComponent,
+    PopoverMenuComponent,
     LucideArrowRightLeft,
     LucideBan,
     LucideChevronDown,
@@ -115,6 +115,31 @@ export class SubtitlesModalComponent {
   readonly subtitles = signal<SubtitleFileRow[]>([]);
   readonly subtitlesLoading = signal(false);
   readonly subtitleActionBusy = signal(false);
+
+  /** Row whose Actions popover is currently open. `null` when closed.
+   *  A single popover instance is reused for every row; `actionsSub()`
+   *  resolves the active row's data inside the popover template. */
+  readonly actionsOpenForId = signal<number | null>(null);
+  readonly actionsAnchor = signal<HTMLElement | null>(null);
+  readonly actionsSub = computed(() => {
+    const id = this.actionsOpenForId();
+    return id == null ? null : this.subtitles().find((s) => s.id === id) ?? null;
+  });
+
+  protected openSubActions(sub: SubtitleFileRow, anchor: HTMLElement) {
+    this.actionsAnchor.set(anchor);
+    this.actionsOpenForId.set(sub.id);
+  }
+  protected closeSubActions() {
+    this.actionsOpenForId.set(null);
+    this.actionsAnchor.set(null);
+  }
+  protected runSubAction(action: (sub: SubtitleFileRow) => void): void {
+    const sub = this.actionsSub();
+    if (!sub) return;
+    this.closeSubActions();
+    action(sub);
+  }
   readonly subSearchLang = signal('en');
   readonly subSearchResults = signal<SubtitleSearchResult[]>([]);
   readonly subSearchLoading = signal(false);

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -410,14 +410,18 @@ body.tv .to-base-100\/50 {
 /* Shared item style for app-dropdown-menu (desktop dropdown + mobile/TV
    bottom sheet). Caller adds a colour utility (`text-white`, `text-error`,
    …) and an icon — everything else (padding, hover, focus, layout) lives
-   here so each menu item stays a one-liner. */
+   here so each menu item stays a one-liner.
+   `focus-visible` (not plain `focus`) so the highlight only shows on
+   keyboard / D-pad navigation. A touch tap auto-focuses the item which
+   would otherwise leave a lingering "selected" tint on phones and
+   tablets after the sheet closes. */
 .dropdown-item {
-  @apply w-full flex items-center gap-3 px-3 py-2 text-left text-base rounded-lg cursor-pointer hover:bg-white/5 focus:bg-white/10 focus:outline-none active:bg-white/10 disabled:opacity-40;
+  @apply w-full flex items-center gap-3 px-3 py-2 text-left text-base rounded-lg cursor-pointer hover:bg-white/5 focus-visible:bg-white/10 focus-visible:outline-none active:bg-white/10 disabled:opacity-40;
 }
 /* TV / keyboard focus: subtle hover tint isn't enough on a 10-foot UI —
    the user can't track which row is highlighted from the couch without
    a clear ring. */
-body.tv .dropdown-item:focus {
+body.tv .dropdown-item:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: -2px;
 }


### PR DESCRIPTION
## Summary

The per-row Actions dropdown in the subtitles modal was clipped, then once routed through \`app-popover-menu\` surfaced three more bugs in how the popover behaves inside a \`<dialog>\` opened via \`showModal()\`. Plus a tidy on the touch focus tint.

### \`popover-menu\` — three independent fixes

- **Position re-evaluates on scroll / resize**. A \`viewportTick\` signal is incremented on every \`scroll\` / \`resize\` while the popover is open; the \`position()\` computed reads it so the fixed box stays glued to the trigger when any ancestor scrolls.
- **\`:host { display: contents }\`**. The custom element was acting as a third grid item inside daisyUI's \`.modal\` (\`display: grid; place-items: center\`), shifting \`.modal-box\` off-centre. Removing the host from the box tree fixes it; the two \`position: fixed\` children reach the parent layout without anchoring it.
- **Reparent to the closest open \`<dialog>\`**. The sheet variant was reparented to \`<html>\` (to escape TV's body scale-transform + the mobile drawer-content stacking context). Inside a modal dialog, \`<html>\` sits below the top-layer, so the sheet rendered behind the modal. Reparent to \`closest('dialog[open]')\` first, fall back to \`<html>\` otherwise.

### \`subtitles-modal\` — Actions dropdown via popover-menu

- The per-row \`<app-dropdown-menu>\` (daisyUI \`.dropdown\` is position: absolute) was clipped by \`.modal-box\`'s overflow. Switched to a plain \`<button>\` trigger per row recording its ref, plus a single shared \`<app-popover-menu>\` mounted inside the parent \`<dialog>\` (so it inherits the top-layer).
- \`runSubAction(action: (sub) => void)\` keeps Angular's strict template checker happy — narrowing the \`@if\` alias through a closure doesn't flow, but typing the lambda parameter does.

### \`.dropdown-item\` / select-user button — focus-visible

- Touch taps were leaving a persistent tint after a sheet closed, because \`focus:bg-*\` triggers on touch focus too. Swap to \`focus-visible:bg-*\` so only keyboard / D-pad nav paints the highlight; \`active:\` still gives a brief tap feedback.
- Audited the rest of the codebase for plain \`focus:bg/ring/shadow/scale/border/text\` utilities — \`select-user.html\` was the only other place that needed the same swap. The global box-shadow ring was already \`:focus-visible\`.

## Test plan

- [ ] Open the subtitles modal on desktop. Click Actions on any row → dropdown opens above the trigger, fully visible regardless of which row was clicked. Scrolling the modal repositions the dropdown.
- [ ] Same on mobile / tablet (Capacitor or browser dev mode). Sheet variant opens above the modal-box, not behind it.
- [ ] Open the modal, then click Actions. The modal-box doesn't shift sideways when the popover opens.
- [ ] On phone, tap any sheet entry, watch it close. No leftover tint on the previously-tapped item.
- [ ] Keyboard arrow nav inside the sheet still paints the \`:focus-visible\` tint and the TV ring still works on \`body.tv\`.