### PR TITLE
fix(ios): suppress accidental focus / zoom / native-select pop-ups

### DIFF
--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -52,6 +52,8 @@ export class App implements OnInit, OnDestroy {
     // — when one lands, full-reload the tab so the new asset map is live.
     this.pwaAutoUpdate.init();
 
+    this.initInputModalityTracking();
+
     if (Capacitor.isNativePlatform()) {
       document.body.classList.add('native');
 
@@ -128,6 +130,42 @@ export class App implements OnInit, OnDestroy {
       this.tizenKeyListener = handler;
       window.addEventListener('keydown', handler);
     }
+  }
+
+  /** Track input modality (keyboard / D-pad vs pointer / touch) and
+   *  toggle `body.keyboard-modality`. CSS gates `:focus-visible`
+   *  visuals on it so an iOS long-press — which Safari WebKit
+   *  incorrectly classifies as a focus-visible trigger — doesn't
+   *  paint the high-contrast focus ring on the card the user was
+   *  trying to context-tap. The class flips on the first
+   *  navigation-key press and clears on the next pointer / touch
+   *  interaction. TV stays focused-visible regardless (`body.tv`
+   *  short-circuits the suppression rule in styles.css). */
+  private initInputModalityTracking(): void {
+    const NAV_KEYS = new Set([
+      'Tab',
+      'ArrowUp',
+      'ArrowDown',
+      'ArrowLeft',
+      'ArrowRight',
+      'Enter',
+      ' ',
+    ]);
+    let keyboardActive = false;
+    const setKeyboard = (on: boolean) => {
+      if (on === keyboardActive) return;
+      keyboardActive = on;
+      document.body.classList.toggle('keyboard-modality', on);
+    };
+    window.addEventListener('keydown', (e) => {
+      if (NAV_KEYS.has(e.key)) setKeyboard(true);
+    });
+    const clearOnPointer = () => setKeyboard(false);
+    window.addEventListener('pointerdown', clearOnPointer, { capture: true });
+    window.addEventListener('touchstart', clearOnPointer, {
+      capture: true,
+      passive: true,
+    });
   }
 
   /** Hardware-back common path — Capacitor (Android/iOS) and Tizen share

--- a/client/src/app/core/services/select-picker.service.ts
+++ b/client/src/app/core/services/select-picker.service.ts
@@ -51,7 +51,15 @@ export class SelectPickerService {
     this.currentSelect = null;
     // Restore focus to the trigger so a subsequent Enter / Space re-opens
     // the picker — without this the browser drops focus to <body> when the
-    // popover unmounts and the user has to Tab back to the select.
-    sel?.focus({ preventScroll: true });
+    // popover unmounts and the user has to Tab back to the select. Only
+    // worth doing in keyboard / D-pad modality though: on iOS touch,
+    // calling `focus()` on a `<select>` pops the native picker right
+    // after we just dismissed our custom one. The `keyboard-modality`
+    // body class (toggled by app.ts) plus `body.tv` cover every modality
+    // where focus restoration is actually wanted.
+    const wantsFocusRestore =
+      document.body.classList.contains('keyboard-modality') ||
+      document.body.classList.contains('tv');
+    if (wantsFocusRestore) sel?.focus({ preventScroll: true });
   }
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -227,6 +227,36 @@ html.tv-host {
 body.tv *:hover {
   background-color: revert;
 }
+/* Suppress every `:focus-visible` visual when the user isn't on a
+   keyboard / D-pad modality. Safari WebKit on iOS incorrectly fires
+   focus-visible on long-press, so a context-tap on a media card used
+   to paint the high-contrast ring. The `keyboard-modality` body
+   class is set by app.ts on the first navigation keydown and cleared
+   on the next pointer / touch interaction; TV always uses the ring
+   so it short-circuits the suppression. `transform: none` covers the
+   scale-up rule on media cards a few selectors down. */
+body:not(.keyboard-modality):not(.tv)
+  :focus-visible:not(input, textarea, select, [contenteditable]) {
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+/* iOS Safari auto-zooms the viewport when a focused input has
+   `font-size` below 16 px — Apple's anti-eyestrain default, but it
+   reads as "the page suddenly grows" when tapping the search bar.
+   Lock the in-app form fields at 16 px on the Capacitor build so
+   focus never triggers the zoom. Desktop / web is untouched. */
+body.native input,
+body.native textarea,
+body.native select {
+  font-size: 16px;
+}
+body:not(.keyboard-modality):not(.tv) app-media-card figure:focus-visible,
+body:not(.keyboard-modality):not(.tv) [data-home-focus]:focus-visible,
+body:not(.keyboard-modality):not(.tv) [data-tv-focusable]:focus-visible {
+  transform: none !important;
+}
+
 /* High-contrast primary focus ring — applies on every form factor so
    keyboard / D-pad navigation looks identical. `:focus-visible` only
    so mouse clicks on desktop don't paint a ring after activation.


### PR DESCRIPTION
## Summary

iOS Safari WebKit gets the input-modality heuristic wrong on Capacitor builds, and three separate symptoms came out of it. All three share the same fix: track input modality (keyboard / D-pad vs pointer / touch) and gate the affected behaviours on it.

### Symptoms

1. **Stray focus ring on long-press** — long-pressing a media card briefly fires `:focus-visible`, so the high-contrast ring lit up on a card the user just meant to context-tap.
2. **Auto-zoom on input focus** — viewport zoomed in when a user tapped an input field with font-size below 16 px (Apple's anti-eyestrain default).
3. **Native iOS picker pops over the custom one** — `SelectPickerService.close()` restored focus to the underlying `<select>` for keyboard re-entry; on touch that focus call popped the native picker right after the custom one had just been dismissed.

### Fix

- **`app.ts#initInputModalityTracking`** — toggles `body.keyboard-modality` on the first navigation keydown (Tab / arrows / Enter / Space) and clears it on the next pointer / touch interaction.
- **`styles.css`** — gates every `:focus-visible` visual (outline, box-shadow, transform scale on media cards) on `body.keyboard-modality` or `body.tv`. Form fields (`input`, `textarea`, `select`, `[contenteditable]`) keep their focus ring even on touch because the on-screen keyboard makes it useful.
- **`styles.css`** — pins `body.native input/textarea/select` to 16 px so Safari never triggers the zoom.
- **`SelectPickerService#close()`** — skips the post-close `focus()` call unless `body.keyboard-modality` or `body.tv` is set.

## Test plan

- [ ] iOS: long-press a media card → context-menu suppression still works, no focus ring flashes.
- [ ] iOS: tap the search bar → keyboard opens, no viewport zoom, focus ring visible.
- [ ] iOS: open and close the season selector → native `<select>` picker does NOT appear after.
- [ ] iPad with external keyboard: Tab through cards → ring + scale show, modality flips correctly.
- [ ] Web desktop: focus behaviour unchanged.
- [ ] TV: D-pad navigation still paints rings.