### PR TITLE
fix(media-info-header): round the title anchor's focus ring

### DIFF
--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -6,7 +6,7 @@
     <!-- Title -->
     <h1 class="text-3xl font-semibold tracking-tight leading-tight">
       @if (episodeLabel()) {
-        <a [routerLink]="backRoute()" class="hover:underline">{{ title() }}</a>
+        <a [routerLink]="backRoute()" class="hover:underline rounded">{{ title() }}</a>
       } @else {
         {{ title() }}
       }
@@ -181,7 +181,7 @@
       <!-- Title -->
       <h1 class="text-4xl font-bold tracking-tight">
         @if (episodeLabel()) {
-          <a [routerLink]="backRoute()" class="hover:underline">{{ title() }}</a>
+          <a [routerLink]="backRoute()" class="hover:underline rounded">{{ title() }}</a>
         } @else {
           {{ title() }}
         }


### PR DESCRIPTION
Episode-mode title is an anchor with no `border-radius`, so the global `:focus-visible` box-shadow rendered as a sharp rectangle. Add `rounded` on both mobile and desktop title anchors so the ring matches the rest of the chrome.