### PR TITLE
fix(macos-dmg): patch Info.plist with the release version before building

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -20,6 +20,30 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # ── Resolve version + patch Info.plist BEFORE build ──
+      # The DMG name comes from Info.plist's CFBundleShortVersionString
+      # (make-dmg.sh reads it via PlistBuddy). Without this step every
+      # build shipped as Fliks-1.0.0-arm64.dmg regardless of the tag.
+      - name: Resolve version
+        id: version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=dev-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Patch Info.plist with version
+        run: |
+          RAW="${{ steps.version.outputs.version }}"
+          # CFBundleShortVersionString must be N[.N[.N]] per Apple — for
+          # dev builds drop the suffix so the plist stays valid.
+          SHORT="$(echo "$RAW" | grep -oE '^[0-9]+(\.[0-9]+){0,2}' || true)"
+          [ -z "$SHORT" ] && SHORT="0.0.0"
+          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $SHORT" macos/Fliks/Info.plist
+          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $SHORT" macos/Fliks/Info.plist
+          echo "Patched Info.plist: CFBundleShortVersionString=$SHORT (from $RAW)"
+
       # ── Node.js for building client + backend ──
       - uses: actions/setup-node@v4
         with:
@@ -72,16 +96,6 @@ jobs:
       - name: Create DMG
         working-directory: macos
         run: ./Scripts/make-dmg.sh
-
-      # ── Extract version for artifact naming ──
-      - name: Get version
-        id: version
-        run: |
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
-          else
-            echo "version=dev-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-          fi
 
       # ── Upload DMG as artifact (always) ──
       - name: Upload DMG artifact


### PR DESCRIPTION
## Summary

Every macOS DMG was shipping as \`Fliks-1.0.0-arm64.dmg\` regardless of the release tag. \`make-dmg.sh\` derives the file name from \`CFBundleShortVersionString\` (read via PlistBuddy from the built \`.app\`'s Info.plist), and the checked-in \`macos/Fliks/Info.plist\` ships hardcoded as \`1.0.0\`.

Add a step that runs right after \`checkout\` and before the Xcode build:

1. Resolves the version from \`refs/tags/v*\` (or \`dev-<sha>\` on \`workflow_dispatch\`).
2. Strips it to \`N[.N[.N]]\` so it's valid for Apple's plist format.
3. Writes both \`CFBundleShortVersionString\` and \`CFBundleVersion\` into \`Info.plist\` via PlistBuddy.

The pre-existing late \`Get version\` step folds into this one — single source of truth for the artifact name + plist value.

## Test plan

- [ ] Cut a release tag \`v1.2.3\` → DMG artifact is \`Fliks-1.2.3-arm64.dmg\` and the App's About dialog shows \`1.2.3\`.
- [ ] Trigger via \`workflow_dispatch\` → DMG artifact is \`Fliks-dev-<sha>-arm64.dmg\` and the plist shows \`0.0.0\`.