### PR TITLE
feat(completion): run cropdetect and subtitle warmup after grab import

### DIFF
--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -2327,24 +2327,6 @@ export class MediaService {
     let streamInfo: Awaited<ReturnType<FfprobeService['detectMediaFileInfo']>>;
     try {
       streamInfo = await this.ffprobe.detectMediaFileInfo(absPath);
-      if (streamInfo?.video?.[0]) {
-        try {
-          const v = streamInfo.video[0];
-          const crop = await this.ffprobe.detectCrop(
-            absPath,
-            streamInfo.durationSeconds,
-            v.width,
-            v.height,
-            !!v.hdrFormat,
-          );
-          if (crop) v.crop = crop;
-        } catch (err) {
-          this.log.warn(
-            `enrichMediaFileFromDisk: detectCrop failed for "${normPath}" (metadata otherwise kept)`,
-            err instanceof Error ? err.stack : err,
-          );
-        }
-      }
     } catch (err) {
       this.log.error(
         `enrichMediaFileFromDisk: ffprobe failed for "${absPath}"`,
@@ -2361,31 +2343,70 @@ export class MediaService {
     dbFile.size = diskSize;
     dbFile.streamInfo = streamInfo;
     dbFile.quality = qualityName;
-    await this.mediaFileRepo.save(dbFile);
+    const saved = await this.mediaFileRepo.save(dbFile);
     this.log.log(
       `enrichMediaFileFromDisk: enriched media file #${mediaFileId} "${normPath}"`,
     );
 
-    // Pre-extract embedded text subtitles to cache so the first playback
-    // doesn't pay the extraction cost (ExoPlayer on Android pre-fetches all
-    // SubtitleConfiguration URLs at player prepare, blocking playback).
-    // Clear this file's cache subdir first in case the stream layout changed.
-    void this.subtitleStream
-      .clearMediaFileSubtitleCache(dbFile.media?.path, mediaFileId)
-      .then(() =>
-        this.subtitleStream.warmupCache(
-          absPath,
-          dbFile.media?.path,
-          mediaFileId,
-          streamInfo.subtitles,
-          dbFile.media?.title,
-        ),
-      );
+    await this.finalizeImportedFile(saved, absPath, dbFile.media);
 
     void this.mediaServers.dispatch('library.rescan', {
       title: dbFile.media.title,
       path: dbFile.media.path,
     });
+  }
+
+  /**
+   * Post-probe enrichment shared by every import path (grab→import, disk
+   * import, rescan). Runs ffmpeg `cropdetect` and stashes the result into
+   * `streamInfo.video[0].crop`, then pre-extracts embedded text subtitles
+   * to the player cache (so the first playback doesn't pay the extraction
+   * cost — ExoPlayer on Android blocks prepare until every
+   * SubtitleConfiguration URL has been fetched).
+   *
+   * Caller must have already persisted `file.streamInfo` from a fresh
+   * ffprobe of `absPath`. Best-effort: failures are logged but don't throw.
+   */
+  async finalizeImportedFile(
+    file: MediaFile,
+    absPath: string,
+    media: Media,
+  ): Promise<void> {
+    const streamInfo = file.streamInfo;
+    const v = streamInfo?.video?.[0];
+    if (v) {
+      try {
+        const crop = await this.ffprobe.detectCrop(
+          absPath,
+          streamInfo.durationSeconds,
+          v.width,
+          v.height,
+          !!v.hdrFormat,
+        );
+        if (crop) {
+          v.crop = crop;
+          file.streamInfo = streamInfo;
+          await this.mediaFileRepo.save(file);
+        }
+      } catch (err) {
+        this.log.warn(
+          `finalizeImportedFile: detectCrop failed for "${absPath}"`,
+          err instanceof Error ? err.stack : err,
+        );
+      }
+    }
+
+    void this.subtitleStream
+      .clearMediaFileSubtitleCache(media?.path, file.id)
+      .then(() =>
+        this.subtitleStream.warmupCache(
+          absPath,
+          media?.path,
+          file.id,
+          streamInfo?.subtitles,
+          media?.title,
+        ),
+      );
   }
 
   // ---------------------------------------------------------------------------

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, In, LessThan, Repository } from 'typeorm';
@@ -34,6 +34,7 @@ import { Library } from '../libraries/entities/library.entity';
 import { TorrentHistoryMatcher } from '../media/torrent-history-matcher.service';
 import { MarkersService } from '../markers/markers.service';
 import { FileTransferService } from '../../common/services/file-transfer.service';
+import { MediaService } from '../media/media.service';
 
 @Injectable()
 export class CompletionService {
@@ -74,6 +75,8 @@ export class CompletionService {
     private readonly historyMatcher: TorrentHistoryMatcher,
     private readonly fileTransfer: FileTransferService,
     private readonly markers: MarkersService,
+    @Inject(forwardRef(() => MediaService))
+    private readonly mediaService: MediaService,
   ) {}
 
   /**
@@ -366,7 +369,11 @@ export class CompletionService {
       );
     }
 
-    const importedFiles: { savedFile: MediaFile; episodeId?: number }[] = [];
+    const importedFiles: {
+      savedFile: MediaFile;
+      episodeId?: number;
+      destPath: string;
+    }[] = [];
 
     for (let idx = 0; idx < filesToImport.length; idx++) {
       const videoFile = filesToImport[idx];
@@ -514,7 +521,7 @@ export class CompletionService {
         await this.episodeRepo.update(episodeId, { hasFile: true });
       }
 
-      importedFiles.push({ savedFile, episodeId });
+      importedFiles.push({ savedFile, episodeId, destPath });
     }
 
     await this.historyRepo.update(history.id, { status: 'completed' });
@@ -539,9 +546,21 @@ export class CompletionService {
       path: media.path,
     });
 
-    // Trigger subtitle search for each imported file (sequential to avoid rate limits)
+    // Per-file post-import work: cropdetect + embedded-subtitle cache warmup
+    // via finalizeImportedFile (shared with disk import / rescan), then the
+    // external-subtitle search. Sequential to avoid hammering ffmpeg and the
+    // subtitle provider rate limits.
     void (async () => {
-      for (const { savedFile, episodeId: epId } of importedFiles) {
+      for (const { savedFile, episodeId: epId, destPath } of importedFiles) {
+        try {
+          await this.mediaService.finalizeImportedFile(
+            savedFile,
+            destPath,
+            media,
+          );
+        } catch (e) {
+          this.log.warn(`Post-import enrichment failed: ${e}`);
+        }
         try {
           await this.subtitleScheduler.onMediaFileImported(
             media.id,


### PR DESCRIPTION
## Summary
- Grab→import previously stopped at ffprobe stream info: no cropdetect (letterbox info missing → player can't auto-crop) and no embedded-subtitle warmup (first playback paid the per-track extraction cost, especially painful on ExoPlayer/Android TV).
- Extracted the post-probe enrichment from \`enrichMediaFileFromDisk\` into a shared \`MediaService.finalizeImportedFile(file, absPath, media)\`. All three import paths (grab, disk import, rescan) now call the same helper.
- \`CompletionService\` invokes it per imported file in the same background loop as the external-subtitle search.

## Test plan
- [ ] Grab a movie via a download client → after import, check \`media_file.streamInfo.video[0].crop\` is populated and \`.cache/subtitles/<fileId>/*.vtt\` exists.
- [ ] Disk import still enriches files (no regression in the existing path).
- [ ] Library rescan still preserves crop when file size is unchanged.
- [ ] First playback after a grab on Android TV starts without the multi-second pre-fetch stall.