### PR TITLE
chore(release-please): bump macos, tizen and webos manifests on release

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -17,6 +17,20 @@
           "path": "client/package.json",
           "jsonpath": "$.version"
         },
+        {
+          "type": "json",
+          "path": "client/webos/appinfo.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "xml",
+          "path": "client/tizen/config.xml",
+          "xpath": "//*[local-name()='widget']/@version"
+        },
+        {
+          "type": "generic",
+          "path": "macos/Fliks/Info.plist"
+        },
         "client/android/app/build.gradle",
         "cast-receiver/index.html",
         "client/ios/App/App.xcodeproj/project.pbxproj"

--- a/client/tizen/config.xml
+++ b/client/tizen/config.xml
@@ -15,7 +15,7 @@
 <widget xmlns="http://www.w3.org/ns/widgets"
         xmlns:tizen="http://tizen.org/ns/widgets"
         id="https://fliks.media/tizen"
-        version="1.5.1"
+        version="1.7.1"
         viewmodes="maximized">
   <name>Fliks</name>
   <description>Fliks media app for Samsung Smart TV</description>

--- a/client/webos/appinfo.json
+++ b/client/webos/appinfo.json
@@ -1,6 +1,6 @@
 {
   "id": "media.fliks.app",
-  "version": "1.5.1",
+  "version": "1.7.1",
   "vendor": "Fliks",
   "type": "web",
   "main": "index.html",

--- a/macos/Fliks/Info.plist
+++ b/macos/Fliks/Info.plist
@@ -17,7 +17,8 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.7.1</string> <!-- x-release-please-version -->
+
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary
- \`macos/Fliks/Info.plist\` (CFBundleShortVersionString) was hard-coded at \`1.0.0\` and only patched at DMG build time by \`macos-dmg.yml\`.
- \`client/tizen/config.xml\` (widget \`version\` attribute) and \`client/webos/appinfo.json\` (\`\$.version\`) were stuck at \`1.5.1\` and shipped to the Samsung / LG app stores with the wrong version string since 1.6.0.
- Adds the three files to \`release-please-config.json\` (json / xml / generic updaters) so future release PRs bump them in lockstep with the rest. Manifests are also brought to \`1.7.1\` so the next release computes a clean diff.

## Test plan
- [ ] After this lands, push a tiny \`fix:\` commit to main and confirm the next release-please PR touches \`client/webos/appinfo.json\`, \`client/tizen/config.xml\` and \`macos/Fliks/Info.plist\` with the new version.
- [ ] Open \`macos/Fliks/Info.plist\` in Xcode to confirm it doesn't strip the \`x-release-please-version\` marker comment on save.
- [ ] \`macos-dmg.yml\` continues to produce a DMG with the correct \`CFBundleShortVersionString\` (it now runs against an already-bumped source — the PlistBuddy patch is a no-op on tag builds, still useful for dev builds).