### PR TITLE
fix(auto-grab): hydrate series quality/language profiles in SearchMissing

### DIFF
--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -521,7 +521,20 @@ export class SchedulerService implements OnModuleInit {
         'ep.hasFile',
       ])
       .addSelect(['season.id', 'season.seasonNumber', 'season.mediaId'])
-      .addSelect(['media.id', 'media.title', 'media.year', 'media.runtime'])
+      .addSelect([
+        'media.id',
+        'media.title',
+        'media.year',
+        'media.runtime',
+        'media.tvdbId',
+        'media.imdbId',
+        'media.alternativeTitles',
+      ])
+      // Profile rows are joined for the upgrade-cutoff WHERE clause AND
+      // hydrated on the media entity so AutoGrabPipeline.classifyForSearch
+      // doesn't read them as undefined and skip with "no profile".
+      .addSelect('qp')
+      .addSelect('lp')
       .getMany();
 
     if (!episodes.length) return;


### PR DESCRIPTION
## Summary
- After approving a series request the user saw \`AutoGrab[series]: \"Show SxxExx\" has no quality/language profile — skipped\` for every episode, even though the series did have both profiles assigned.
- Root cause: \`searchMissingEpisodes\` joined the profile tables to use the upgrade-cutoff flag in the WHERE clause but the explicit \`.select([…])\` block right after wiped the auto-selected join columns. \`media.qualityProfile\` and \`media.languageProfile\` arrived at \`AutoGrabPipeline.classifyForSearch\` as \`undefined\`, which short-circuits to \`unprofiled\`.
- Adds the two aliases to \`addSelect\` so the profiles are hydrated. Also surfaces \`tvdbId\`, \`imdbId\` and \`alternativeTitles\` which were used downstream (torznab id-based matching, expected-title aliases) but silently undefined because of the same select truncation.

## Test plan
- [ ] Approve a request on a series that has a quality + language profile → episodes are no longer logged as "no quality/language profile". An auto-grab attempt fires per episode.
- [ ] Series with NO quality profile still log the skip (correct behavior — unchanged).
- [ ] Movies are unaffected (they use a different path).
- [ ] Series upgrade flow still works: episodes with files below cutoff are picked up.