### PR TITLE
fix(grab): persist indexer on download-history rows from manual grabs

### DIFF
--- a/backend/src/modules/media/dto/grab-movie.dto.ts
+++ b/backend/src/modules/media/dto/grab-movie.dto.ts
@@ -1,4 +1,5 @@
-import { IsOptional, IsString } from 'class-validator';
+import { IsInt, IsOptional, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
 
 export class GrabMovieDto {
   @IsOptional()
@@ -8,4 +9,13 @@ export class GrabMovieDto {
   @IsOptional()
   @IsString()
   sourceTitle?: string;
+
+  /** Indexer the release came from. Passed by the frontend when grabbing a
+   *  specific release row so the Activity page can show which indexer
+   *  served the grab; left undefined for raw-URL paste flows where there
+   *  is no indexer context. */
+  @IsOptional()
+  @IsInt()
+  @Type(() => Number)
+  indexerId?: number;
 }

--- a/backend/src/modules/media/episode-download.service.ts
+++ b/backend/src/modules/media/episode-download.service.ts
@@ -263,6 +263,7 @@ export class EpisodeDownloadService {
 
     let downloadUrl = dto?.downloadUrl?.trim();
     let sourceTitle = dto?.sourceTitle?.trim();
+    let indexerId = dto?.indexerId;
     const grabSource: 'auto' | 'manual' = downloadUrl ? 'manual' : 'auto';
 
     const epLabel = `S${String(season.seasonNumber).padStart(2, '0')}E${String(episode.episodeNumber).padStart(2, '0')}`;
@@ -283,6 +284,7 @@ export class EpisodeDownloadService {
       }
       downloadUrl = pick.downloadUrl;
       sourceTitle = pick.title;
+      indexerId = pick.indexerId;
       this.log.log(`Auto-picked: "${sourceTitle}" — ${downloadUrl}`);
     } else {
       if (!sourceTitle) sourceTitle = downloadUrl.slice(0, 240);
@@ -326,6 +328,7 @@ export class EpisodeDownloadService {
       quality: parsed.quality.name,
       status: 'grabbed',
       grabSource,
+      indexer: indexerId != null ? ({ id: indexerId } as Indexer) : null,
     });
     const saved = await this.historyRepo.save(row);
 
@@ -587,6 +590,10 @@ export class EpisodeDownloadService {
           quality: parsed.quality.name,
           status: 'grabbed',
           grabSource: 'manual',
+          indexer:
+            dto?.indexerId != null
+              ? ({ id: dto.indexerId } as Indexer)
+              : null,
         }),
       );
       void this.notifications.dispatch('grab.started', {
@@ -680,6 +687,7 @@ export class EpisodeDownloadService {
           quality: bestPack.qualityName,
           status: 'grabbed',
           grabSource: 'auto',
+          indexer: { id: bestPack.indexerId } as Indexer,
         }),
       );
       void this.notifications.dispatch('grab.started', {
@@ -782,6 +790,7 @@ export class EpisodeDownloadService {
             quality: pick.qualityName,
             status: 'grabbed',
             grabSource: 'auto',
+            indexer: { id: pick.indexerId } as Indexer,
           }),
         );
         grabbed++;

--- a/backend/src/modules/media/movie-download.service.ts
+++ b/backend/src/modules/media/movie-download.service.ts
@@ -250,6 +250,7 @@ export class MovieDownloadService {
 
     let downloadUrl = dto.downloadUrl?.trim();
     let sourceTitle = dto.sourceTitle?.trim();
+    let indexerId = dto.indexerId;
     const grabSource: 'auto' | 'manual' = downloadUrl ? 'manual' : 'auto';
 
     this.log.log(
@@ -273,6 +274,7 @@ export class MovieDownloadService {
       }
       downloadUrl = pick.downloadUrl;
       sourceTitle = pick.title;
+      indexerId = pick.indexerId;
       this.log.log(`Auto-picked: "${sourceTitle}" — ${downloadUrl}`);
     } else {
       // Manual grab — still check blocklist
@@ -317,6 +319,7 @@ export class MovieDownloadService {
       quality: parsed.quality.name,
       status: 'grabbed',
       grabSource,
+      indexer: indexerId != null ? ({ id: indexerId } as Indexer) : null,
     });
     const saved = await this.historyRepo.save(row);
 
@@ -450,6 +453,7 @@ export class MovieDownloadService {
 
     let downloadUrl = dto.downloadUrl?.trim();
     let sourceTitle = dto.sourceTitle?.trim();
+    let indexerId = dto.indexerId;
     const grabSource: 'auto' | 'manual' = downloadUrl ? 'manual' : 'auto';
 
     this.log.log(
@@ -474,6 +478,7 @@ export class MovieDownloadService {
       }
       downloadUrl = pick.downloadUrl;
       sourceTitle = pick.title;
+      indexerId = pick.indexerId;
       this.log.log(`Upgrade auto-picked: "${sourceTitle}" — ${downloadUrl}`);
     } else {
       if (!sourceTitle) sourceTitle = inferTitleFromTorrentUrl(downloadUrl);
@@ -531,6 +536,7 @@ export class MovieDownloadService {
       quality: parsed.quality.name,
       status: 'grabbed',
       grabSource,
+      indexer: indexerId != null ? ({ id: indexerId } as Indexer) : null,
     });
     const saved = await this.historyRepo.save(row);
 

--- a/client/src/app/core/services/api/media.service.ts
+++ b/client/src/app/core/services/api/media.service.ts
@@ -321,7 +321,7 @@ export class MediaService {
     return firstValueFrom(this.http.get<MovieRelease[]>(`/api/media/${id}/releases`, { params }));
   }
 
-  grabMovie(id: number, body?: { downloadUrl?: string; sourceTitle?: string }) {
+  grabMovie(id: number, body?: { downloadUrl?: string; sourceTitle?: string; indexerId?: number }) {
     return firstValueFrom(
       this.http.post<{ id: number; status: string }>(
         `/api/media/${id}/grab`,
@@ -377,7 +377,7 @@ export class MediaService {
     );
   }
 
-  grabSeason(mediaId: number, seasonId: number, body?: { downloadUrl?: string; sourceTitle?: string }) {
+  grabSeason(mediaId: number, seasonId: number, body?: { downloadUrl?: string; sourceTitle?: string; indexerId?: number }) {
     return firstValueFrom(
       this.http.post<{ grabbed: number; errors: string[] }>(
         `/api/media/${mediaId}/seasons/${seasonId}/grab`,
@@ -394,7 +394,7 @@ export class MediaService {
     );
   }
 
-  grabEpisode(mediaId: number, episodeId: number, body?: { downloadUrl?: string; sourceTitle?: string }) {
+  grabEpisode(mediaId: number, episodeId: number, body?: { downloadUrl?: string; sourceTitle?: string; indexerId?: number }) {
     return firstValueFrom(
       this.http.post<{ id: number; status: string }>(
         `/api/media/${mediaId}/episodes/${episodeId}/grab`,
@@ -411,7 +411,7 @@ export class MediaService {
     );
   }
 
-  grabUpgrade(mediaId: number, body?: { downloadUrl?: string; sourceTitle?: string }) {
+  grabUpgrade(mediaId: number, body?: { downloadUrl?: string; sourceTitle?: string; indexerId?: number }) {
     return firstValueFrom(
       this.http.post<{ id: number; status: string }>(
         `/api/media/${mediaId}/upgrade`,

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -1315,7 +1315,11 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     const key = `ep-${index}`;
     this.epGrabBusy.set(key);
     try {
-      await this.mediaService.grabEpisode(mediaId, episodeId, { downloadUrl: r.downloadUrl, sourceTitle: r.title });
+      await this.mediaService.grabEpisode(mediaId, episodeId, {
+        downloadUrl: r.downloadUrl,
+        sourceTitle: r.title,
+        indexerId: r.indexerId,
+      });
       this.epGrabState.update((s) => new Map(s).set(key, 'ok'));
       this.toast.success(this.translate.instant('media_detail.grab_success'));
     } catch {
@@ -1369,6 +1373,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       await this.mediaService.grabSeason(mediaId, season.id, {
         downloadUrl: r.downloadUrl,
         sourceTitle: r.title,
+        indexerId: r.indexerId,
       });
       this.seasonReleaseGrabState.update((s) => new Map(s).set(key, 'ok'));
       this.toast.success(this.translate.instant('media_detail.grab_success'));
@@ -1490,7 +1495,11 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     const key = `r-${index}`;
     this.grabBusy.set(key);
     try {
-      await this.mediaService.grabMovie(m.id, { downloadUrl: r.downloadUrl, sourceTitle: r.title });
+      await this.mediaService.grabMovie(m.id, {
+        downloadUrl: r.downloadUrl,
+        sourceTitle: r.title,
+        indexerId: r.indexerId,
+      });
       this.grabState.update((s) => new Map(s).set(key, 'ok'));
       this.toast.success(this.translate.instant('media_detail.grab_success'));
     } catch {


### PR DESCRIPTION
## Summary
- Manual grabs (\`grabEpisode\`, \`grabMovie\`, \`grabSeason\`, \`grabUpgrade\`) were creating \`DownloadHistory\` rows without an \`indexer\` reference. The Activity page reads \`item.indexerName\` and only the scheduler's auto-grab pipeline (\`auto-grab-pipeline.service.ts:249\`) was setting it — so the badge appeared for auto-grabbed rows but never for manually-grabbed ones.
- Most noticeable on episodes because the user-driven "Search releases" flow is the dominant path there (auto-grab for series was also broken until #227).
- \`GrabMovieDto\` gets an optional \`indexerId\`; the four grab methods derive the indexer from either the DTO (user picked a specific release row) or the auto-picked release; the field is persisted on the history row. Frontend forwards \`r.indexerId\` from \`MovieRelease\` everywhere a release row is grabbed. Raw-URL paste keeps \`indexer\` null.

## Test plan
- [ ] Manually grab a movie release → Activity row shows the indexer badge.
- [ ] Manually grab an episode release (S01E01 etc.) → Activity row shows the indexer badge.
- [ ] Manually grab a season release → Activity row shows the indexer badge.
- [ ] Grab via the "best pick" buttons (no DTO indexerId) → still tagged with the auto-picked release's indexer.
- [ ] Paste a raw torrent URL → row has no indexer (no regression; no indexer context exists).
- [ ] Auto-grab from the scheduler still works (unchanged path).