### PR TITLE
refactor(grab): extract a shared buildGrabHistoryRow helper

### DIFF
--- a/backend/src/modules/media/auto-grab-pipeline.service.ts
+++ b/backend/src/modules/media/auto-grab-pipeline.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { Media } from './entities/media.entity';
 import { RequestLifecycleService } from '../requests/request-lifecycle.service';
 import { DownloadHistory } from './entities/download-history.entity';
+import { buildGrabHistoryRow } from './grab-history.util';
 import { Indexer } from '../indexers/entities/indexer.entity';
 import { TorznabRelease } from '../indexers/torznab.service';
 import { DownloadClient } from '../download-clients/entities/download-client.entity';
@@ -157,19 +158,30 @@ export class AutoGrabPipelineService {
      *  requests. Whole-series and movie grabs pass undefined. */
     seasonNumber?: number;
   }): Promise<boolean> {
+    const logSkip = (reason: string): void =>
+      this.log.log(
+        `AutoGrab[${args.mediaType}]: "${args.label}" skipped — ${reason}`,
+      );
+
     const decision = this.classifyForSearch(args.media, args.files);
     if (decision.mode !== 'missing' && decision.mode !== 'upgrade') {
-      if (decision.mode === 'unprofiled') {
-        this.log.debug?.(
-          `AutoGrab[${args.mediaType}]: "${args.label}" has no quality/language profile — skipped`,
-        );
-      }
+      logSkip(
+        decision.mode === 'unprofiled'
+          ? 'no quality/language profile on media'
+          : `at/above cutoff (mode=${decision.mode})`,
+      );
       return false;
     }
 
-    if (!args.releases.length) return false;
+    if (!args.releases.length) {
+      logSkip('no releases returned by indexers');
+      return false;
+    }
 
-    if (args.pendingCheck && (await args.pendingCheck())) return false;
+    if (args.pendingCheck && (await args.pendingCheck())) {
+      logSkip('a grab is already pending');
+      return false;
+    }
 
     const { allowed, allowedLangs } = this.profiles.resolveAllowedForMedia(
       args.media,
@@ -198,8 +210,15 @@ export class AutoGrabPipelineService {
         r.rank <= decision.maxRankInclusive,
     );
     if (!pick) {
-      this.log.debug?.(
-        `AutoGrab[${args.mediaType}]: no eligible release for "${args.label}" (mode=${decision.mode}, ${sorted.length} checked)`,
+      const topRejections = sorted
+        .slice(0, 3)
+        .map(
+          (r) =>
+            `"${r.title}" → ${r.rejections.length ? r.rejections.join(', ') : `rank ${r.rank} out of [${decision.minRankExclusive + 1}..${decision.maxRankInclusive}]`}`,
+        )
+        .join(' | ');
+      logSkip(
+        `no eligible release (mode=${decision.mode}, ${sorted.length} checked)${topRejections ? ` — top: ${topRejections}` : ''}`,
       );
       return false;
     }
@@ -243,16 +262,17 @@ export class AutoGrabPipelineService {
         args.mediaType,
       );
       await this.historyRepo.save(
-        this.historyRepo.create({
-          media: args.media,
-          downloadClient: args.qbitClient,
-          indexer: { id: args.pick.indexerId } as Indexer,
-          sourceTitle: args.pick.title,
-          quality: this.naming.parseQuality(args.pick.title),
-          status: 'grabbed',
-          grabSource: 'auto',
-          torrentHash: torrentHash || undefined,
-        }),
+        this.historyRepo.create(
+          buildGrabHistoryRow({
+            media: args.media,
+            downloadClient: args.qbitClient,
+            sourceTitle: args.pick.title,
+            torrentHash,
+            quality: this.naming.parseQuality(args.pick.title),
+            grabSource: 'auto',
+            indexerId: args.pick.indexerId,
+          }),
+        ),
       );
       this.log.log(
         `AutoGrab[${args.mediaType}]: grabbed "${args.pick.title}" for "${args.label}"`,

--- a/backend/src/modules/media/episode-download.service.ts
+++ b/backend/src/modules/media/episode-download.service.ts
@@ -10,6 +10,7 @@ import { Media } from './entities/media.entity';
 import { Season } from './entities/season.entity';
 import { Episode } from './entities/episode.entity';
 import { DownloadHistory } from './entities/download-history.entity';
+import { buildGrabHistoryRow } from './grab-history.util';
 import { Indexer } from '../indexers/entities/indexer.entity';
 import { DownloadClient } from '../download-clients/entities/download-client.entity';
 import { TorznabService } from '../indexers/torznab.service';
@@ -320,17 +321,19 @@ export class EpisodeDownloadService {
     );
     this.log.log(`Grab successful for "${sourceTitle}" (hash=${torrentHash})`);
 
-    const row = this.historyRepo.create({
-      media,
-      downloadClient: qbit,
-      sourceTitle: sourceTitle,
-      torrentHash: torrentHash || undefined,
-      quality: parsed.quality.name,
-      status: 'grabbed',
-      grabSource,
-      indexer: indexerId != null ? ({ id: indexerId } as Indexer) : null,
-    });
-    const saved = await this.historyRepo.save(row);
+    const saved = await this.historyRepo.save(
+      this.historyRepo.create(
+        buildGrabHistoryRow({
+          media,
+          downloadClient: qbit,
+          sourceTitle,
+          torrentHash,
+          quality: parsed.quality.name,
+          grabSource,
+          indexerId,
+        }),
+      ),
+    );
 
     void this.notifications.dispatch('grab.started', {
       title: `${media.title} ${epLabel}`,
@@ -582,19 +585,17 @@ export class EpisodeDownloadService {
         `Grab successful for "${sourceTitle}" (hash=${torrentHash})`,
       );
       await this.historyRepo.save(
-        this.historyRepo.create({
-          media: { id: mediaId } as Media,
-          downloadClient: qbit,
-          sourceTitle,
-          torrentHash: torrentHash || undefined,
-          quality: parsed.quality.name,
-          status: 'grabbed',
-          grabSource: 'manual',
-          indexer:
-            dto?.indexerId != null
-              ? ({ id: dto.indexerId } as Indexer)
-              : null,
-        }),
+        this.historyRepo.create(
+          buildGrabHistoryRow({
+            media: { id: mediaId },
+            downloadClient: qbit,
+            sourceTitle,
+            torrentHash,
+            quality: parsed.quality.name,
+            grabSource: 'manual',
+            indexerId: dto?.indexerId,
+          }),
+        ),
       );
       void this.notifications.dispatch('grab.started', {
         title: `${media.title} S${String(season.seasonNumber).padStart(2, '0')}`,
@@ -679,16 +680,17 @@ export class EpisodeDownloadService {
         `Season pack grab successful for "${bestPack.title}" (hash=${packHash})`,
       );
       await this.historyRepo.save(
-        this.historyRepo.create({
-          media: { id: mediaId } as Media,
-          downloadClient: qbit,
-          sourceTitle: bestPack.title,
-          torrentHash: packHash || undefined,
-          quality: bestPack.qualityName,
-          status: 'grabbed',
-          grabSource: 'auto',
-          indexer: { id: bestPack.indexerId } as Indexer,
-        }),
+        this.historyRepo.create(
+          buildGrabHistoryRow({
+            media: { id: mediaId },
+            downloadClient: qbit,
+            sourceTitle: bestPack.title,
+            torrentHash: packHash,
+            quality: bestPack.qualityName,
+            grabSource: 'auto',
+            indexerId: bestPack.indexerId,
+          }),
+        ),
       );
       void this.notifications.dispatch('grab.started', {
         title: `${media.title} S${String(season.seasonNumber).padStart(2, '0')}`,
@@ -782,16 +784,17 @@ export class EpisodeDownloadService {
           `[${epLabel}] grab successful for "${pick.title}" (hash=${epHash})`,
         );
         await this.historyRepo.save(
-          this.historyRepo.create({
-            media: { id: mediaId } as Media,
-            downloadClient: qbit,
-            sourceTitle: pick.title,
-            torrentHash: epHash || undefined,
-            quality: pick.qualityName,
-            status: 'grabbed',
-            grabSource: 'auto',
-            indexer: { id: pick.indexerId } as Indexer,
-          }),
+          this.historyRepo.create(
+            buildGrabHistoryRow({
+              media: { id: mediaId },
+              downloadClient: qbit,
+              sourceTitle: pick.title,
+              torrentHash: epHash,
+              quality: pick.qualityName,
+              grabSource: 'auto',
+              indexerId: pick.indexerId,
+            }),
+          ),
         );
         grabbed++;
       } catch (e) {

--- a/backend/src/modules/media/grab-history.util.ts
+++ b/backend/src/modules/media/grab-history.util.ts
@@ -1,0 +1,39 @@
+import { DeepPartial } from 'typeorm';
+import { DownloadHistory, GrabSource } from './entities/download-history.entity';
+import { Media } from './entities/media.entity';
+import { Indexer } from '../indexers/entities/indexer.entity';
+import { DownloadClient } from '../download-clients/entities/download-client.entity';
+
+/**
+ * Builds the partial entity for a freshly-grabbed `DownloadHistory` row.
+ * Single source of truth for the column set and the relation casts so the
+ * seven grab paths (movie / movie upgrade / episode / season manual /
+ * season pack / per-episode fallback / scheduler auto-grab) stay in sync
+ * and a missing field can't drift between them.
+ *
+ * - `media` accepts either a hydrated entity or a bare `{ id }` shape
+ *   because some callers only have the id at hand.
+ * - `indexerId` is optional: raw-URL paste flows have no indexer context
+ *   and persist `indexer: null` so the Activity page renders no badge.
+ */
+export function buildGrabHistoryRow(args: {
+  media: Media | { id: number };
+  downloadClient: DownloadClient;
+  sourceTitle: string;
+  torrentHash: string | null | undefined;
+  quality: string;
+  grabSource: GrabSource;
+  indexerId?: number | null;
+}): DeepPartial<DownloadHistory> {
+  return {
+    media: args.media as Media,
+    downloadClient: args.downloadClient,
+    sourceTitle: args.sourceTitle,
+    torrentHash: args.torrentHash || undefined,
+    quality: args.quality,
+    status: 'grabbed',
+    grabSource: args.grabSource,
+    indexer:
+      args.indexerId != null ? ({ id: args.indexerId } as Indexer) : null,
+  };
+}

--- a/backend/src/modules/media/movie-download.service.ts
+++ b/backend/src/modules/media/movie-download.service.ts
@@ -8,6 +8,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Media } from './entities/media.entity';
 import { DownloadHistory } from './entities/download-history.entity';
+import { buildGrabHistoryRow } from './grab-history.util';
 import { Indexer } from '../indexers/entities/indexer.entity';
 import { DownloadClient } from '../download-clients/entities/download-client.entity';
 import { TorznabService, TorznabRelease } from '../indexers/torznab.service';
@@ -311,17 +312,19 @@ export class MovieDownloadService {
     );
     this.log.log(`Grab successful for "${sourceTitle}" (hash=${torrentHash})`);
 
-    const row = this.historyRepo.create({
-      media,
-      downloadClient: qbit,
-      sourceTitle,
-      torrentHash: torrentHash || undefined,
-      quality: parsed.quality.name,
-      status: 'grabbed',
-      grabSource,
-      indexer: indexerId != null ? ({ id: indexerId } as Indexer) : null,
-    });
-    const saved = await this.historyRepo.save(row);
+    const saved = await this.historyRepo.save(
+      this.historyRepo.create(
+        buildGrabHistoryRow({
+          media,
+          downloadClient: qbit,
+          sourceTitle,
+          torrentHash,
+          quality: parsed.quality.name,
+          grabSource,
+          indexerId,
+        }),
+      ),
+    );
 
     void this.notifications.dispatch('grab.started', {
       title: media.title,
@@ -528,17 +531,19 @@ export class MovieDownloadService {
       `Upgrade grab successful for "${sourceTitle}" (hash=${torrentHash})`,
     );
 
-    const row = this.historyRepo.create({
-      media,
-      downloadClient: qbit,
-      sourceTitle,
-      torrentHash: torrentHash || undefined,
-      quality: parsed.quality.name,
-      status: 'grabbed',
-      grabSource,
-      indexer: indexerId != null ? ({ id: indexerId } as Indexer) : null,
-    });
-    const saved = await this.historyRepo.save(row);
+    const saved = await this.historyRepo.save(
+      this.historyRepo.create(
+        buildGrabHistoryRow({
+          media,
+          downloadClient: qbit,
+          sourceTitle,
+          torrentHash,
+          quality: parsed.quality.name,
+          grabSource,
+          indexerId,
+        }),
+      ),
+    );
 
     void this.notifications.dispatch('grab.started', {
       title: media.title,


### PR DESCRIPTION
## Summary
- Seven \`DownloadHistory\` create sites built the same row shape with slightly-divergent boilerplate: \`auto-grab-pipeline.grabAndRecord\`, the four manual grab methods (\`grabMovie\`, \`grabUpgrade\`, \`grabEpisode\`, \`grabSeason\` manual URL), and the two auto fallbacks inside \`grabSeason\` (season pack + per-episode).
- The fragile bits — \`indexer: indexerId != null ? ({ id } as Indexer) : null\`, the \`status: 'grabbed'\` default, the \`torrentHash || undefined\` normalisation — were duplicated. The previous fix had to add the indexer field at 4 sites individually; a future column (e.g. \`releaseGroup\`) would face the same risk.
- New \`buildGrabHistoryRow\` helper in \`backend/src/modules/media/grab-history.util.ts\` returns a \`DeepPartial<DownloadHistory>\`. Accepts a hydrated \`Media\` entity or a bare \`{ id }\` shape so callers that only have the id work too. No behaviour change.

## Test plan
- [ ] Manually grab a movie release → row has indexer + status='grabbed'.
- [ ] Manually grab an episode → idem.
- [ ] grabSeason via manual URL → row carries dto.indexerId.
- [ ] grabSeason via season-pack auto → row carries bestPack.indexerId.
- [ ] grabSeason per-episode fallback → each row carries pick.indexerId.
- [ ] Auto-grab scheduler → unchanged.