### PR TITLE
feat(media): log library imports and targeted search-missing counts

### DIFF
--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -2184,11 +2184,24 @@ export class MediaService {
       ...(addedByUserId ? { addedBy: { id: addedByUserId } as User } : {}),
     });
     const saved = await this.mediaRepo.save(row);
+    this.logLibraryAdded('movie', saved);
     await this.downloadMediaImages(saved.id, details);
     await this.updateSearchVector(saved.id);
     await this.persistMediaMetadata(saved, details);
     await this.requestLifecycle.onMediaImported(saved, addedByUserId ?? null);
     return this.findOne(saved.id);
+  }
+
+  private logLibraryAdded(
+    kind: 'movie' | 'series',
+    media: Media,
+    extra?: string,
+  ): void {
+    const year = media.year ? ` (${media.year})` : '';
+    const tail = extra ? `, ${extra}` : '';
+    this.log.log(
+      `Library: added ${kind} "${media.title}"${year} — id=${media.id}, tmdbId=${media.tmdbId ?? '?'}${tail}`,
+    );
   }
 
   private async persistImportedSeries(
@@ -2215,6 +2228,7 @@ export class MediaService {
       ...(addedByUserId ? { addedBy: { id: addedByUserId } as User } : {}),
     });
     const saved = await this.mediaRepo.save(row);
+    this.logLibraryAdded('series', saved, `seasons=${seasons.length}`);
     await this.downloadMediaImages(saved.id, details);
 
     for (const sd of seasons) {

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -381,6 +381,30 @@ export class SchedulerService implements OnModuleInit {
     }
   }
 
+  // Only logs when a targeted (request-driven) SearchMissing kicks off,
+  // so scheduled bulk runs don't get noisy. The hint tells the user what
+  // the candidate query is filtering on when the count is zero.
+  private logTargetedCandidateCount(
+    scope: 'movies' | 'episodes',
+    mediaIds: number[] | undefined,
+    count: number,
+  ): void {
+    if (!mediaIds?.length) return;
+    if (count > 0) {
+      this.log.log(
+        `SearchMissing[${scope}]: ${count} candidate(s) for media IDs [${mediaIds.join(', ')}]`,
+      );
+      return;
+    }
+    const hint =
+      scope === 'movies'
+        ? "check monitored flag, type=movie, and that there's no file already at cutoff"
+        : 'check that the series/seasons/episodes are monitored and have an airDate ≤ today';
+    this.log.log(
+      `SearchMissing[${scope}]: 0 candidates for media IDs [${mediaIds.join(', ')}] — ${hint}`,
+    );
+  }
+
   private async doSearchMissing(mediaIds?: number[]): Promise<void> {
     if (mediaIds?.length) {
       this.log.log(
@@ -430,6 +454,7 @@ export class SchedulerService implements OnModuleInit {
     }
     const candidates = await qb.getMany();
 
+    this.logTargetedCandidateCount('movies', mediaIds, candidates.length);
     if (!candidates.length) return;
 
     const today = new Date().toISOString().slice(0, 10);
@@ -537,6 +562,7 @@ export class SchedulerService implements OnModuleInit {
       .addSelect('lp')
       .getMany();
 
+    this.logTargetedCandidateCount('episodes', mediaIds, episodes.length);
     if (!episodes.length) return;
 
     // Batch-load the linked MediaFile quality for upgrade-candidate episodes


### PR DESCRIPTION
## Summary

- `persistImportedMovie` / `persistImportedSeries` now emit one info-level `Library: added <kind> "Title" (year) — id=…, tmdbId=…` line at import time, so the audit trail starts at the moment a request approval (or manual /add) lands in the library.
- `searchMissingMovies` / `searchMissingEpisodes` now log the targeted candidate count via a shared `logTargetedCandidateCount(scope, mediaIds, count)` helper. Zero-candidate cases include a hint about the filter (monitored flag / cutoff for movies, monitored+airDate for episodes). Scheduled bulk passes stay quiet — the helper short-circuits when `mediaIds` is empty.

## Why

After a request approval fires `searchMissingForMedia(...)`, the `SearchMissing: targeted restart for media IDs […]` log was the last thing admins saw in every silent skip path: empty release list, pending grab, no eligible release after scoring, zero candidates from the episode/movie query. Half of those branches were `log.debug` (invisible under Nest's default info level) and the rest returned with no log at all, so "request approved but never downloaded" had no diagnostic signal. The auto-grab skip-reason logs were already promoted to info in the companion refactor merged via #229; this PR closes the remaining two gaps (import event + candidate query).

## Test plan

- [ ] Approve a series request for a title with all episodes already aired → expect `Library: added series …` followed by `SearchMissing[episodes]: N candidate(s) for media IDs […]` and the usual auto-grab flow.
- [ ] Approve a request for an unreleased/upcoming series → expect `SearchMissing[episodes]: 0 candidates for media IDs […] — check that the series/seasons/episodes are monitored and have an airDate ≤ today`.
- [ ] Trigger a scheduled `SearchMissing` (no `mediaIds`) → no candidate-count lines are emitted (helper short-circuits).