### PR TITLE
fix(popover-menu): keep options above <dialog open> top-layer

### DIFF
--- a/client/src/app/shared/components/popover-menu.ts
+++ b/client/src/app/shared/components/popover-menu.ts
@@ -91,32 +91,35 @@ export class PopoverMenuComponent {
   private readonly viewportTick = signal(0);
 
   constructor() {
-    // Move the host out of any clipping / transformed ancestor on the
-    // sheet variant (touch / TV). Two separate problems need this:
-    //   • TV → body.tv has a scale transform that re-anchors fixed
-    //     descendants to body's box instead of the viewport.
-    //   • Mobile → the layout's drawer-content is `position: relative`,
-    //     creating a stacking context that traps z-[101] below the
-    //     bottom dock (z-40 at body level).
-    //
-    // Target: the closest open <dialog> ancestor if there is one, so we
-    // stay inside its top-layer (showModal() puts the dialog above
-    // everything else regardless of z-index); otherwise <html>.
-    if (typeof document !== 'undefined' && !this.useDropdown()) {
-      queueMicrotask(() => {
-        const openDialog = this.host.nativeElement.closest<HTMLDialogElement>(
-          'dialog[open]',
-        );
-        (openDialog ?? document.documentElement).appendChild(
-          this.host.nativeElement,
-        );
-      });
-    }
     // Focus the first focusable inside the menu on every open. autofocus
     // is unreliable on Capacitor's Android WebView for dynamically added
     // content, so we do it programmatically.
     effect((onCleanup) => {
       if (!this.open()) return;
+      // Move the host on every open so we land in the right stacking
+      // context for the *current* anchor. Three problems we sidestep:
+      //   • <dialog open> → showModal() renders in the browser top-layer,
+      //     which sits above every regular z-index. The popover host can
+      //     be mounted anywhere (e.g. the SelectPicker singleton lives
+      //     at the app root, not inside the dialog), so we walk up from
+      //     the anchor — not the host — to find the open dialog and
+      //     append into its top-layer.
+      //   • TV → body.tv has a scale transform that re-anchors fixed
+      //     descendants to body's box instead of the viewport.
+      //   • Mobile → drawer-content is `position: relative`, creating a
+      //     stacking context that traps z-[101] below the bottom dock.
+      // When no dialog is open we relocate to <html> unconditionally
+      // (dropdown variant included) so a previous dialog-scoped open
+      // doesn't leave the host orphaned inside a now-closed dialog.
+      if (typeof document !== 'undefined') {
+        const anchor = this.anchor();
+        const openDialog =
+          anchor?.closest<HTMLDialogElement>('dialog[open]') ?? null;
+        const target = openDialog ?? document.documentElement;
+        if (this.host.nativeElement.parentElement !== target) {
+          target.appendChild(this.host.nativeElement);
+        }
+      }
       queueMicrotask(() => {
         // Prefer the active item (caller marks it with `[autofocus]` or
         // `[aria-current]`) so the user lands on the current selection


### PR DESCRIPTION
## Summary

The custom select picker (used for the language dropdown in the subtitle-search modal, among others) rendered its options *behind* the modal overlay. The popover host is now relocated by walking up from the **anchor** instead of the host, so it correctly lands inside the open `<dialog>` and joins its top-layer.

## Why

A `<dialog>` opened with `showModal()` renders in the browser's top-layer, which sits above every regular z-index — even our `z-[101]` fixed positioning. To appear above the dialog content the popover has to be a descendant of the dialog (top-layer rendering carries down to children).

The previous relocation logic walked up from the host with `this.host.closest('dialog[open]')`, but the `SelectPicker` singleton is mounted at the app layout root, so the host never had a dialog ancestor — the lookup always returned `null` and the host stayed put.

## Changes

- Walk up from the *anchor* (the `<select>` / trigger element that opens the popover) — that one IS inside the modal — and append the host into its `dialog[open]` ancestor when present.
- Move on every `open` transition rather than once at construction, so each new anchor gets the correct stacking context.
- Unconditional fallback to `<html>` when no dialog is open, so a previous dialog-scoped open doesn't leave the host orphaned inside a now-closed dialog. Safe for both variants — dropdowns are `position: fixed` and don't depend on their DOM parent.

## Test plan

- [ ] Open the subtitle-search modal on a movie/episode → change the language → options render above the modal.
- [ ] Open any kebab-menu / sort dropdown on the main library page (no dialog open) → still anchored correctly to the trigger.
- [ ] Open a quality/library/profile picker modal that contains a `<select appTvSelect>` → dropdown lands above the modal.
- [ ] Touch / TV form factor: bottom sheets still open correctly when triggered from inside a dialog and from outside one.