### PR TITLE
feat(subtitles): defer upgrades on files that still have missing langs

### DIFF
--- a/backend/src/modules/scheduler/subtitle-scheduler.service.ts
+++ b/backend/src/modules/scheduler/subtitle-scheduler.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { Media } from '../media/entities/media.entity';
 import { MediaFile } from '../media/entities/media-file.entity';
 import { SubtitleFile } from '../subtitles/entities/subtitle-file.entity';
@@ -169,10 +169,32 @@ export class SubtitleSchedulerService {
       .andWhere('sf.status != :failed', { failed: SubtitleStatus.FAILED })
       .andWhere('sf.locked = false')
       .leftJoinAndSelect('sf.media', 'media')
+      .leftJoinAndSelect('media.languageProfile', 'lp')
       .leftJoinAndSelect('sf.mediaFile', 'mf')
       .getMany();
 
+    // Build "languages still missing on file F" map upfront so we don't pay
+    // an N+1 inside the upgrade loop. A file with even one required language
+    // and zero (non-failed) subs for it counts as "still missing" — upgrade
+    // defers to the next missing-search pass on those files so we don't
+    // spend provider quota on score bumps while gaps remain.
+    const fileIds = [
+      ...new Set(
+        lowScoreSubs.map((s) => s.mediaFile?.id).filter((id): id is number => id != null),
+      ),
+    ];
+    const missingByFileId = await this.buildMissingLangsByFile(
+      fileIds,
+      lowScoreSubs,
+    );
+
     for (const sub of lowScoreSubs) {
+      if (sub.mediaFile?.id != null && missingByFileId.get(sub.mediaFile.id)) {
+        this.log.debug?.(
+          `SubtitleUpgrade: skipping sub #${sub.id} ("${sub.media?.title}", ${sub.language}) — file still has missing required languages, deferring to next missing-search pass`,
+        );
+        continue;
+      }
       try {
         const results = await this.subtitlesService.searchSubtitles({
           imdbId: sub.media?.imdbId ?? undefined,
@@ -206,6 +228,58 @@ export class SubtitleSchedulerService {
         this.log.warn(`SubtitleUpgrade: failed for sub #${sub.id}: ${err}`);
       }
     }
+  }
+
+  /**
+   * For each media file id, decides whether it still has at least one
+   * required-by-profile subtitle language with no usable file. The map
+   * value is `true` when the upgrade pass should skip the file and leave
+   * the work to the next missing-search pass.
+   */
+  private async buildMissingLangsByFile(
+    fileIds: number[],
+    candidatesWithMedia: SubtitleFile[],
+  ): Promise<Map<number, boolean>> {
+    const result = new Map<number, boolean>();
+    if (!fileIds.length) return result;
+
+    const subsByFile = new Map<number, SubtitleFile[]>();
+    const allFileSubs = await this.subtitleFileRepo.find({
+      where: { mediaFile: { id: In(fileIds) } },
+      relations: ['mediaFile'],
+    });
+    for (const s of allFileSubs) {
+      const fid = s.mediaFile?.id;
+      if (fid == null) continue;
+      const list = subsByFile.get(fid) ?? [];
+      list.push(s);
+      subsByFile.set(fid, list);
+    }
+
+    const profileByFile = new Map<number, SubtitleLanguageItem[]>();
+    for (const cand of candidatesWithMedia) {
+      const fid = cand.mediaFile?.id;
+      if (fid == null || profileByFile.has(fid)) continue;
+      profileByFile.set(
+        fid,
+        cand.media?.languageProfile?.subtitleLanguages ?? [],
+      );
+    }
+
+    for (const fid of fileIds) {
+      const required = profileByFile.get(fid) ?? [];
+      if (!required.length) {
+        result.set(fid, false);
+        continue;
+      }
+      const present = new Set(
+        (subsByFile.get(fid) ?? [])
+          .filter((s) => s.status !== SubtitleStatus.FAILED)
+          .map((s) => s.language),
+      );
+      result.set(fid, required.some((l) => !present.has(l.isoCode)));
+    }
+    return result;
   }
 
   /** Called after a media file import to trigger subtitle search */


### PR DESCRIPTION
## Summary
- \`SubtitleSchedulerService.upgradeSubtitles\` picked every low-score subtitle from the DB and searched for a better one regardless of whether the same media file still had a required-by-profile language with no subtitle at all.
- With finite provider quotas (OpenSubtitles in particular caps daily downloads), that burned API calls on score improvements while gaps stayed open. The user explicitly asked to prioritise missing-search over cutoff-unmet upgrades.
- New private helper \`buildMissingLangsByFile\` pre-computes, for the upgrade candidates, whether each file still has at least one required language without a non-failed subtitle. Candidates whose file is still incomplete are skipped — the next missing-search pass fills the gap first, and the next upgrade pass after that can improve scores on a fully-covered file. The pre-computation is batched (\`In(fileIds)\`), no per-iteration extra query.

## Test plan
- [ ] Series with one missing required language (no sub at all) + one low-score language: upgrade pass skips the low-score one with a debug log. Next missing-search downloads the missing language. Following upgrade pass then improves the low-score one.
- [ ] Series with all required languages present (some low-score): upgrade pass behaves as before.
- [ ] Series with no language profile: upgrade pass behaves as before (no \`required\` set → not blocked).