### PR TITLE
feat(subtitles): centralised video-aware scoring (Bazarr-style)

### DIFF
--- a/backend/src/modules/media/media.controller.ts
+++ b/backend/src/modules/media/media.controller.ts
@@ -478,6 +478,7 @@ export class MediaController {
     // season_number + episode_number (ex. S02E05 → 2 et 5), pas la clé primaire.
     let season: number | undefined;
     let episode: number | undefined;
+    let epDbIdResolved: number | undefined;
     if (episodeId != null && episodeId !== '') {
       const epDbId = Number(episodeId);
       if (Number.isFinite(epDbId)) {
@@ -486,11 +487,25 @@ export class MediaController {
           if (ep) {
             season = s.seasonNumber;
             episode = ep.episodeNumber;
+            epDbIdResolved = epDbId;
             break;
           }
         }
       }
     }
+
+    // Try to pick the file that backs the user's view so the scorer can
+    // compare release attributes (group / source / resolution / codecs).
+    // For episodes we want the file linked to the picked episode; for
+    // movies the first file (movies have at most one in practice).
+    const files = media.files ?? [];
+    const matchingFile =
+      (epDbIdResolved != null
+        ? files.find((f) => f.episodeId === epDbIdResolved)
+        : files[0]) ?? files[0];
+    const videoReleaseName = matchingFile?.relativePath
+      ? matchingFile.relativePath.split('/').pop()?.replace(/\.[^.]+$/, '')
+      : undefined;
 
     return this.subtitlesService.searchSubtitles({
       imdbId: media.imdbId ?? undefined,
@@ -500,6 +515,7 @@ export class MediaController {
       language: language ?? 'en',
       season,
       episode,
+      videoReleaseName,
     });
   }
 

--- a/backend/src/modules/media/release-attributes.parser.ts
+++ b/backend/src/modules/media/release-attributes.parser.ts
@@ -1,0 +1,157 @@
+/**
+ * Generic release-name attribute extractor used by the subtitle scorer
+ * (Bazarr-style) to compare a candidate subtitle's release name with the
+ * local video file's release name and award per-attribute credit.
+ *
+ * Complements {@link parseReleaseQuality} (which already picks resolution
+ * + source) by also extracting release_group, video_codec, audio_codec
+ * and edition. Resolution + source are re-extracted here so downstream
+ * code can score against a single shape without coupling to AppQuality.
+ */
+
+export type ReleaseSource =
+  | 'remux'
+  | 'bluray'
+  | 'web-dl'
+  | 'webrip'
+  | 'hdtv'
+  | 'dvd'
+  | 'sdtv'
+  | 'cam'
+  | 'ts'
+  | 'tc'
+  | null;
+
+export type VideoCodec = 'h265' | 'h264' | 'av1' | 'vp9' | 'xvid' | 'mpeg2' | null;
+
+export type AudioCodec =
+  | 'truehd'
+  | 'dts-hd'
+  | 'dts'
+  | 'eac3'
+  | 'ac3'
+  | 'flac'
+  | 'aac'
+  | 'opus'
+  | 'mp3'
+  | null;
+
+export type ReleaseEdition =
+  | 'directors-cut'
+  | 'extended'
+  | 'theatrical'
+  | 'uncut'
+  | 'remastered'
+  | 'criterion'
+  | 'imax'
+  | null;
+
+export interface ReleaseAttributes {
+  /** 2160, 1080, 720, 480 … 0 when not detected. */
+  resolution: number;
+  source: ReleaseSource;
+  videoCodec: VideoCodec;
+  audioCodec: AudioCodec;
+  edition: ReleaseEdition;
+  /** Group suffix after the final dash, e.g. `-CtrlHD`. Lowercased. */
+  releaseGroup: string | null;
+  /** True when the release name carries an SDH / HI marker. */
+  hearingImpaired: boolean;
+}
+
+function norm(s: string): string {
+  return s.replace(/\./g, ' ').toLowerCase();
+}
+
+function detectResolution(t: string): number {
+  if (/\b(4320p?|8k)\b/.test(t)) return 4320;
+  if (/\b(2160p?|4k|uhd)\b/.test(t)) return 2160;
+  if (/\b1080[ip]?\b/.test(t)) return 1080;
+  if (/\b720[ip]?\b/.test(t)) return 720;
+  const m = t.match(/\b(576|480|360)p?\b/);
+  return m ? parseInt(m[1], 10) : 0;
+}
+
+function detectSource(t: string): ReleaseSource {
+  if (/\bremux\b/.test(t)) return 'remux';
+  if (/\b(bluray|blu-?ray|bdrip|brrip|bdr)\b/.test(t)) return 'bluray';
+  if (/\bweb-?dl\b/.test(t)) return 'web-dl';
+  if (/\bweb-?rip\b/.test(t)) return 'webrip';
+  if (/\bhdtv\b/.test(t)) return 'hdtv';
+  if (/\b(dvd|dvdrip|dvd-?r)\b/.test(t)) return 'dvd';
+  if (/\bsdtv\b/.test(t)) return 'sdtv';
+  if (/\bcam\b/.test(t)) return 'cam';
+  if (/\b(ts|telesync)\b/.test(t)) return 'ts';
+  if (/\btc\b|telecine/.test(t)) return 'tc';
+  return null;
+}
+
+function detectVideoCodec(t: string): VideoCodec {
+  if (/\b(h\.?265|x265|hevc)\b/.test(t)) return 'h265';
+  if (/\b(h\.?264|x264|avc)\b/.test(t)) return 'h264';
+  if (/\bav1\b/.test(t)) return 'av1';
+  if (/\bvp9\b/.test(t)) return 'vp9';
+  if (/\bxvid\b/.test(t)) return 'xvid';
+  if (/\b(mpeg-?2|mpg2)\b/.test(t)) return 'mpeg2';
+  return null;
+}
+
+function detectAudioCodec(t: string): AudioCodec {
+  if (/\btruehd\b/.test(t)) return 'truehd';
+  if (/\bdts-?hd\b/.test(t)) return 'dts-hd';
+  if (/\bdts\b/.test(t)) return 'dts';
+  if (/\be-?ac-?3\b|\bddp\b/.test(t)) return 'eac3';
+  if (/\bac-?3\b|\bdd5\b/.test(t)) return 'ac3';
+  if (/\bflac\b/.test(t)) return 'flac';
+  if (/\baac\b/.test(t)) return 'aac';
+  if (/\bopus\b/.test(t)) return 'opus';
+  if (/\bmp3\b/.test(t)) return 'mp3';
+  return null;
+}
+
+function detectEdition(t: string): ReleaseEdition {
+  if (/\b(director'?s?[\s\-_]?cut|dc)\b/.test(t)) return 'directors-cut';
+  if (/\bextended\b/.test(t)) return 'extended';
+  if (/\btheatrical\b/.test(t)) return 'theatrical';
+  if (/\buncut\b/.test(t)) return 'uncut';
+  if (/\bremastered\b/.test(t)) return 'remastered';
+  if (/\bcriterion\b/.test(t)) return 'criterion';
+  if (/\bimax\b/.test(t)) return 'imax';
+  return null;
+}
+
+function detectReleaseGroup(rawTitle: string): string | null {
+  // Group is typically the token after the LAST dash before the extension.
+  // Use the original title (not normalised) because group casing can carry
+  // meaning, but match case-insensitively.
+  const stem = rawTitle.replace(/\.[a-z0-9]{2,4}$/i, '');
+  const m = stem.match(/-([a-z0-9_]+)$/i);
+  if (!m) return null;
+  const group = m[1].toLowerCase();
+  // Reject obvious false positives (resolutions, sources, codecs).
+  if (/^(1080p|720p|2160p|480p|hevc|x264|x265|av1|h264|h265|dvd|web|bluray|remux)$/.test(group)) {
+    return null;
+  }
+  return group;
+}
+
+function detectHearingImpaired(t: string): boolean {
+  return /\b(sdh|hi|hearing[\s\-_]?impaired|cc|closed[\s\-_]?caption)\b/.test(t);
+}
+
+/**
+ * Parse a release name (torrent title, file name) into the attribute set
+ * the subtitle scorer compares against the video file.
+ */
+export function parseReleaseAttributes(title: string): ReleaseAttributes {
+  const t = norm(title);
+  return {
+    resolution: detectResolution(t),
+    source: detectSource(t),
+    videoCodec: detectVideoCodec(t),
+    audioCodec: detectAudioCodec(t),
+    edition: detectEdition(t),
+    releaseGroup: detectReleaseGroup(title),
+    hearingImpaired: detectHearingImpaired(t),
+  };
+}

--- a/backend/src/modules/scheduler/subtitle-scheduler.service.ts
+++ b/backend/src/modules/scheduler/subtitle-scheduler.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
+import * as path from 'path';
 import { Media } from '../media/entities/media.entity';
 import { MediaFile } from '../media/entities/media-file.entity';
 import { SubtitleFile } from '../subtitles/entities/subtitle-file.entity';
@@ -60,6 +61,11 @@ export class SubtitleSchedulerService {
     const autoSearch = await this.settings.get('subtitle_auto_search');
     if (autoSearch === 'false') return;
 
+    // `subtitle_min_score` / `subtitle_upgrade_threshold` are now read as
+    // PERCENT (0-100) of the centralised scorer's max — see
+    // `subtitle-scorer.ts`. Existing rows persisted under the previous
+    // per-provider 0-100 scale stay readable; the upgrade pass naturally
+    // re-scores them via the central scorer on the next run.
     const minScore = Number(
       (await this.settings.get('subtitle_min_score')) ?? '70',
     );
@@ -70,7 +76,12 @@ export class SubtitleSchedulerService {
 
     const mediaList = await this.mediaRepo.find({
       where: { monitored: true },
-      relations: ['languageProfile', 'files'],
+      relations: [
+        'languageProfile',
+        'files',
+        'files.episode',
+        'files.episode.season',
+      ],
     });
 
     for (const media of mediaList) {
@@ -91,6 +102,13 @@ export class SubtitleSchedulerService {
           where: { mediaFile: { id: file.id } },
         });
 
+        const videoReleaseName = path.basename(
+          file.relativePath,
+          path.extname(file.relativePath),
+        );
+        const fileSeason = file.episode?.season?.seasonNumber ?? undefined;
+        const fileEpisode = file.episode?.episodeNumber ?? undefined;
+
         for (const langItem of subtitleLangs) {
           const hasSub = existingSubs.some(
             (s) =>
@@ -106,6 +124,9 @@ export class SubtitleSchedulerService {
               title: media.title,
               year: media.year ?? undefined,
               language: langItem.isoCode,
+              season: fileSeason,
+              episode: fileEpisode,
+              videoReleaseName,
             });
 
             const best = results.find((r) => r.score >= minScore);
@@ -171,6 +192,8 @@ export class SubtitleSchedulerService {
       .leftJoinAndSelect('sf.media', 'media')
       .leftJoinAndSelect('media.languageProfile', 'lp')
       .leftJoinAndSelect('sf.mediaFile', 'mf')
+      .leftJoinAndSelect('mf.episode', 'mfEpisode')
+      .leftJoinAndSelect('mfEpisode.season', 'mfSeason')
       .getMany();
 
     // Build "languages still missing on file F" map upfront so we don't pay
@@ -196,11 +219,19 @@ export class SubtitleSchedulerService {
         continue;
       }
       try {
+        const fileRel = sub.mediaFile?.relativePath;
+        const videoReleaseName = fileRel
+          ? path.basename(fileRel, path.extname(fileRel))
+          : undefined;
         const results = await this.subtitlesService.searchSubtitles({
           imdbId: sub.media?.imdbId ?? undefined,
           tmdbId: sub.media?.tmdbId,
           title: sub.media?.title ?? '',
+          year: sub.media?.year ?? undefined,
           language: sub.language,
+          season: sub.mediaFile?.episode?.season?.seasonNumber ?? undefined,
+          episode: sub.mediaFile?.episode?.episodeNumber ?? undefined,
+          videoReleaseName,
         });
 
         const better = results.find((r) => r.score > sub.score);
@@ -315,6 +346,7 @@ export class SubtitleSchedulerService {
 
     const mediaFile = await this.mediaFileRepo.findOne({
       where: { id: mediaFileId },
+      relations: ['episode', 'episode.season'],
     });
     if (!mediaFile) return;
 
@@ -325,6 +357,13 @@ export class SubtitleSchedulerService {
       (await this.settings.get('subtitle_auto_sync')) === 'true';
     const encodeUtf8 =
       (await this.settings.get('subtitle_encode_utf8')) !== 'false';
+
+    const videoReleaseName = path.basename(
+      mediaFile.relativePath,
+      path.extname(mediaFile.relativePath),
+    );
+    const fileSeason = mediaFile.episode?.season?.seasonNumber ?? undefined;
+    const fileEpisode = mediaFile.episode?.episodeNumber ?? undefined;
 
     for (const langItem of subtitleLangs) {
       if (embeddedLangs.has(langItem.isoCode)) {
@@ -340,6 +379,9 @@ export class SubtitleSchedulerService {
           title: media.title,
           year: media.year ?? undefined,
           language: langItem.isoCode,
+          season: fileSeason,
+          episode: fileEpisode,
+          videoReleaseName,
         });
 
         const best = results.find((r) => r.score >= minScore);

--- a/backend/src/modules/subtitles/providers/gestdown.provider.ts
+++ b/backend/src/modules/subtitles/providers/gestdown.provider.ts
@@ -91,11 +91,12 @@ export class GestdownProvider implements SubtitleProviderInterface {
       .map((s) => ({
         providerFileId: s.downloadUri,
         title: [params.title, s.version, s.release].filter(Boolean).join(' - '),
+        releaseName: s.release ?? s.version ?? undefined,
         language: params.language,
         forced: false,
         hearingImpaired: s.hearingImpaired,
         downloadCount: s.downloadCount,
-        score: Math.min(100, Math.round(Math.log2(s.downloadCount + 1) * 10)),
+        score: 0,
         providerName: 'Gestdown',
         providerType: 'gestdown',
       }));

--- a/backend/src/modules/subtitles/providers/opensubtitles.provider.ts
+++ b/backend/src/modules/subtitles/providers/opensubtitles.provider.ts
@@ -82,22 +82,23 @@ export class OpenSubtitlesProvider implements SubtitleProviderInterface {
           ratings: number;
           moviehash_match: boolean;
           files: { file_id: number }[];
+          feature_details?: { imdb_id?: number };
         };
       }[];
     };
 
     return body.data.map((item) => {
-      const baseScore = Math.round(
-        item.attributes.ratings * 10 + item.attributes.download_count / 100,
-      );
-      const hashBonus = item.attributes.moviehash_match ? 20 : 0;
+      const imdbRaw = item.attributes.feature_details?.imdb_id;
       return {
         providerFileId: String(item.attributes.files[0]?.file_id ?? item.id),
         title: item.attributes.release,
+        releaseName: item.attributes.release,
+        imdbId: imdbRaw != null ? String(imdbRaw) : undefined,
+        hashMatched: item.attributes.moviehash_match,
         language: item.attributes.language,
         forced: item.attributes.foreign_parts_only,
         hearingImpaired: item.attributes.hearing_impaired,
-        score: Math.min(100, baseScore + hashBonus),
+        score: 0,
         downloadCount: item.attributes.download_count,
         providerName: 'OpenSubtitles',
         providerType: PROVIDER_TYPE,

--- a/backend/src/modules/subtitles/providers/subdl.provider.ts
+++ b/backend/src/modules/subtitles/providers/subdl.provider.ts
@@ -74,10 +74,11 @@ export class SubdlProvider implements SubtitleProviderInterface {
     return (body.subtitles ?? []).map((item) => ({
       providerFileId: item.url,
       title: item.release_name,
+      releaseName: item.release_name,
       language: item.language,
       forced: false,
       hearingImpaired: item.hi,
-      score: Math.min(100, Math.round((item.rating ?? 5) * 10)),
+      score: 0,
       providerName: 'Subdl',
       providerType: PROVIDER_TYPE,
     }));

--- a/backend/src/modules/subtitles/providers/subsynchro.provider.ts
+++ b/backend/src/modules/subtitles/providers/subsynchro.provider.ts
@@ -70,17 +70,18 @@ export class SubsynchroProvider implements SubtitleProviderInterface {
       return [];
     }
 
-    return body.data.map((item, index) => {
+    return body.data.map((item) => {
       const label =
         item.release || item.filename || item.titre_original || item.titre;
       return {
         // Store the download URL as the provider file ID
         providerFileId: item.telechargement,
         title: label,
+        releaseName: item.release || item.filename || undefined,
         language: 'fr',
         forced: false,
         hearingImpaired: false,
-        score: Math.max(0, 50 - index),
+        score: 0,
         providerName: 'Subsynchro',
         providerType: 'subsynchro',
       };

--- a/backend/src/modules/subtitles/providers/subtitle-provider.interface.ts
+++ b/backend/src/modules/subtitles/providers/subtitle-provider.interface.ts
@@ -9,14 +9,43 @@ export interface SubtitleSearchParams {
   filePath?: string;
   moviehash?: string;
   moviebytesize?: number;
+  /** Local video file's release name (typically the file basename
+   *  without extension). Forwarded by the orchestrator to the central
+   *  scorer so it can compute per-attribute match credit
+   *  (release_group, source, resolution, codecs). Providers ignore
+   *  this; it only matters in SubtitlesService. */
+  videoReleaseName?: string;
 }
 
+/**
+ * Provider-returned subtitle candidate. Providers expose RAW metadata —
+ * they no longer attempt to score the match themselves. `SubtitlesService`
+ * rescores every candidate against the video file via the central scorer
+ * so scores stay comparable across providers.
+ */
 export interface SubtitleSearchResult {
   providerFileId: string;
+  /** Title as returned by the provider's listing (movie/episode name).
+   *  Kept for compatibility; the scorer prefers `releaseName`. */
   title: string;
+  /** Release name of the subtitle's source (e.g. `Show.S01E01.1080p.WEB-DL.x265-NTb`).
+   *  Empty when the provider doesn't expose one — scoring falls back to
+   *  language + imdb-equivalence credit only. */
+  releaseName?: string;
+  /** IMDB id reported by the provider for this candidate (no `tt`
+   *  prefix required). Enables the equivalence map: title/year are
+   *  credited when imdb matches the media. */
+  imdbId?: string;
+  /** True when the candidate came from a hash-based provider lookup
+   *  (e.g. OpenSubtitles moviehash). Treated as a perfect match by the
+   *  central scorer — credit hash + series/title/year + season/episode. */
+  hashMatched?: boolean;
   language: string;
   forced: boolean;
   hearingImpaired: boolean;
+  /** Normalised 0-100 score assigned by the central
+   *  scorer in `SubtitlesService`. Providers must NOT set this — it is
+   *  overwritten before the result list is returned to callers. */
   score: number;
   downloadCount?: number;
   providerName: string;

--- a/backend/src/modules/subtitles/providers/supersubtitles.provider.ts
+++ b/backend/src/modules/subtitles/providers/supersubtitles.provider.ts
@@ -133,10 +133,11 @@ export class SupersubtitlesProvider implements SubtitleProviderInterface {
       results.push({
         providerFileId: String(item.felirat),
         title: label,
+        releaseName: item.fnev || item.nev || undefined,
         language: lang,
         forced,
         hearingImpaired: false,
-        score: 50,
+        score: 0,
         providerName: 'Supersubtitles',
         providerType: 'supersubtitles',
       });
@@ -246,13 +247,15 @@ export class SupersubtitlesProvider implements SubtitleProviderInterface {
       const forced =
         row.toLowerCase().includes('forced') || row.includes('szinkronoshoz');
 
+      const decodedLabel = this.decodeHtmlEntities(label);
       results.push({
         providerFileId: subtitleId,
-        title: this.decodeHtmlEntities(label),
+        title: decodedLabel,
+        releaseName: decodedLabel,
         language: lang,
         forced,
         hearingImpaired: false,
-        score: 50,
+        score: 0,
         providerName: 'Supersubtitles',
         providerType: 'supersubtitles',
       });

--- a/backend/src/modules/subtitles/providers/yify.provider.ts
+++ b/backend/src/modules/subtitles/providers/yify.provider.ts
@@ -175,16 +175,16 @@ export class YifyProvider implements SubtitleProviderInterface {
       results.push({
         providerFileId: pagePath,
         title: releaseName,
+        releaseName,
         language,
         forced: false,
         hearingImpaired,
-        score: Math.min(100, rating * 10),
+        score: 0,
         providerName: 'YIFY',
         providerType: 'yify',
       });
     }
 
-    results.sort((a, b) => b.score - a.score);
     return results;
   }
 

--- a/backend/src/modules/subtitles/subtitle-scorer.spec.ts
+++ b/backend/src/modules/subtitles/subtitle-scorer.spec.ts
@@ -1,0 +1,155 @@
+import {
+  EPISODE_WEIGHTS,
+  MAX_EPISODE_SCORE,
+  MAX_MOVIE_SCORE,
+  MOVIE_WEIGHTS,
+  scoreSubtitle,
+} from './subtitle-scorer';
+
+const EPISODE_CTX = {
+  kind: 'episode' as const,
+  videoReleaseName: 'Mr.Robot.S01E01.1080p.BluRay.x265.DTS-CtrlHD',
+  title: 'Mr. Robot',
+  year: 2015,
+  season: 1,
+  episode: 1,
+  imdbId: 'tt4158110',
+};
+
+const MOVIE_CTX = {
+  kind: 'movie' as const,
+  videoReleaseName: 'Dune.2021.2160p.UHD.BluRay.x265.DV.HDR.DTS-HD.MA.7.1-CtrlHD',
+  title: 'Dune',
+  year: 2021,
+  imdbId: 'tt1160419',
+};
+
+describe('subtitle-scorer', () => {
+  describe('hash match', () => {
+    it('awards near-max score for an episode hash match', () => {
+      // No releaseName / videoReleaseName here so only hash + id-style
+      // bonuses + the default-non-HI bit are credited.
+      const s = scoreSubtitle({ hashMatched: true }, {
+        ...EPISODE_CTX,
+        videoReleaseName: null,
+      });
+      expect(s.matches).toContain('hash');
+      expect(s.matches).toContain('series');
+      expect(s.matches).toContain('season');
+      expect(s.matches).toContain('episode');
+      expect(s.matches).toContain('year');
+      const expectedRaw =
+        EPISODE_WEIGHTS.hash +
+        EPISODE_WEIGHTS.series +
+        EPISODE_WEIGHTS.season +
+        EPISODE_WEIGHTS.episode +
+        EPISODE_WEIGHTS.year +
+        EPISODE_WEIGHTS.hearingImpaired;
+      expect(s.raw).toBe(expectedRaw);
+      expect(s.max).toBe(MAX_EPISODE_SCORE);
+    });
+
+    it('awards hash + title + year for a movie hash match', () => {
+      const s = scoreSubtitle({ hashMatched: true }, {
+        ...MOVIE_CTX,
+        videoReleaseName: null,
+      });
+      expect(s.matches).toEqual(
+        expect.arrayContaining(['hash', 'title', 'year']),
+      );
+      expect(s.raw).toBe(
+        MOVIE_WEIGHTS.hash +
+          MOVIE_WEIGHTS.title +
+          MOVIE_WEIGHTS.year +
+          MOVIE_WEIGHTS.hearingImpaired,
+      );
+    });
+  });
+
+  describe('release-name matching', () => {
+    it('matches release group, source, resolution, codecs on an exact episode release', () => {
+      const s = scoreSubtitle(
+        { releaseName: 'Mr.Robot.S01E01.1080p.BluRay.x265.DTS-CtrlHD' },
+        EPISODE_CTX,
+      );
+      expect(s.matches).toEqual(
+        expect.arrayContaining([
+          'series',
+          'season',
+          'episode',
+          'releaseGroup',
+          'source',
+          'resolution',
+          'videoCodec',
+          'audioCodec',
+        ]),
+      );
+    });
+
+    it('scores lower when the source/resolution differ', () => {
+      const good = scoreSubtitle(
+        { releaseName: 'Mr.Robot.S01E01.1080p.BluRay.x265-CtrlHD' },
+        EPISODE_CTX,
+      );
+      const bad = scoreSubtitle(
+        { releaseName: 'Mr.Robot.S01E01.720p.WEB-DL.x264-FGT' },
+        EPISODE_CTX,
+      );
+      expect(good.raw).toBeGreaterThan(bad.raw);
+    });
+  });
+
+  describe('imdb equivalence', () => {
+    it('credits series + year when imdb matches and release name is empty', () => {
+      const s = scoreSubtitle({ imdbId: 'tt4158110' }, EPISODE_CTX);
+      expect(s.matches).toContain('series');
+      expect(s.matches).toContain('year');
+    });
+
+    it('strips tt prefix for comparison', () => {
+      const s = scoreSubtitle({ imdbId: 'tt1160419' }, MOVIE_CTX);
+      expect(s.matches).toContain('title');
+    });
+  });
+
+  describe('hearing-impaired bit', () => {
+    it('awards non-HI by default', () => {
+      const s = scoreSubtitle({ hearingImpaired: false }, EPISODE_CTX);
+      expect(s.matches).toContain('hearingImpaired');
+    });
+
+    it('awards HI when caller prefers it', () => {
+      const s = scoreSubtitle(
+        { hearingImpaired: true },
+        { ...EPISODE_CTX, preferHearingImpaired: true },
+      );
+      expect(s.matches).toContain('hearingImpaired');
+    });
+  });
+
+  describe('percent normalisation', () => {
+    it('returns 100 when every applicable attribute matches an episode', () => {
+      const s = scoreSubtitle(
+        {
+          hashMatched: true,
+          releaseName: 'Mr.Robot.S01E01.1080p.BluRay.x265.DTS-CtrlHD',
+          imdbId: 'tt4158110',
+          hearingImpaired: false,
+        },
+        EPISODE_CTX,
+      );
+      expect(s.percent).toBe(100);
+    });
+
+    it('caps percent at 0..100', () => {
+      const s = scoreSubtitle({}, EPISODE_CTX);
+      expect(s.percent).toBeGreaterThanOrEqual(0);
+      expect(s.percent).toBeLessThanOrEqual(100);
+    });
+
+    it('uses different max for movie kind', () => {
+      const s = scoreSubtitle({ hashMatched: true }, MOVIE_CTX);
+      expect(s.max).toBe(MAX_MOVIE_SCORE);
+    });
+  });
+});

--- a/backend/src/modules/subtitles/subtitle-scorer.ts
+++ b/backend/src/modules/subtitles/subtitle-scorer.ts
@@ -1,0 +1,267 @@
+import {
+  ReleaseAttributes,
+  parseReleaseAttributes,
+} from '../media/release-attributes.parser';
+import { parseSeasonEpisode } from '../media/release-episode.parser';
+
+/**
+ * Bazarr-style scoring weights (mirrored from
+ * `subliminal_patch/score.py`). Each weight is the credit awarded when
+ * the attribute MATCHES between the candidate subtitle and the local
+ * video file. `MAX_*` is the sum of all weights for that kind, used to
+ * normalise the score to a 0-100 percentage so the user-facing thresholds
+ * stay portable across episode / movie regardless of which weights drift.
+ */
+export const EPISODE_WEIGHTS = {
+  hash: 359,
+  series: 180,
+  year: 90,
+  season: 30,
+  episode: 30,
+  releaseGroup: 14,
+  source: 7,
+  audioCodec: 3,
+  resolution: 2,
+  videoCodec: 2,
+  hearingImpaired: 1,
+} as const;
+
+export const MOVIE_WEIGHTS = {
+  hash: 119,
+  title: 60,
+  year: 30,
+  releaseGroup: 13,
+  source: 7,
+  audioCodec: 3,
+  resolution: 2,
+  videoCodec: 2,
+  edition: 1,
+  hearingImpaired: 1,
+} as const;
+
+export const MAX_EPISODE_SCORE = Object.values(EPISODE_WEIGHTS).reduce(
+  (a, b) => a + b,
+  0,
+);
+export const MAX_MOVIE_SCORE = Object.values(MOVIE_WEIGHTS).reduce(
+  (a, b) => a + b,
+  0,
+);
+
+export interface SubtitleScoreCandidate {
+  /** Release name the provider returned for this subtitle (preferred field
+   *  for attribute matching). May be missing on providers that don't
+   *  expose one — score falls back to language+equivalence credit. */
+  releaseName?: string | null;
+  /** True when the candidate came from a hash-based provider lookup
+   *  (e.g. OpenSubtitles moviehash search). Awards full hash weight,
+   *  which alone usually beats every other release-name match. */
+  hashMatched?: boolean;
+  /** IMDB id reported by the provider — used by the equivalence map. */
+  imdbId?: string | null;
+  /** True when the subtitle is flagged as hearing-impaired / SDH. */
+  hearingImpaired?: boolean;
+}
+
+export interface SubtitleScoreVideoContext {
+  /** 'episode' or 'movie'. Picks the weights set. */
+  kind: 'episode' | 'movie';
+  /** Local video file's release name (typically the file basename). When
+   *  null the attribute-match block gets zero credit and the scorer is
+   *  effectively language+equivalence only. */
+  videoReleaseName: string | null;
+  /** Canonical media title (TMDB-side). */
+  title: string;
+  /** Year, when known. */
+  year?: number | null;
+  /** Series-only: season number on the file. */
+  season?: number | null;
+  /** Series-only: episode number on the file. */
+  episode?: number | null;
+  /** IMDB id of the media — used by equivalence map. */
+  imdbId?: string | null;
+  /** Caller preference for hearing-impaired subs (default: false → award
+   *  the bit when candidate is NOT hearing-impaired). */
+  preferHearingImpaired?: boolean;
+}
+
+export interface SubtitleScore {
+  /** Sum of weights of every matched attribute. Range 0..MAX_*. */
+  raw: number;
+  /** Max possible for this kind — useful for serialising debug info. */
+  max: number;
+  /** Normalised 0..100 score. The scheduler thresholds compare against this. */
+  percent: number;
+  /** Names of attributes that matched. */
+  matches: string[];
+}
+
+/**
+ * Score a subtitle candidate against the video context using
+ * Bazarr-style attribute matching. Pure function — no I/O.
+ */
+export function scoreSubtitle(
+  candidate: SubtitleScoreCandidate,
+  context: SubtitleScoreVideoContext,
+): SubtitleScore {
+  const isEpisode = context.kind === 'episode';
+  const weights = isEpisode ? EPISODE_WEIGHTS : MOVIE_WEIGHTS;
+  const max = isEpisode ? MAX_EPISODE_SCORE : MAX_MOVIE_SCORE;
+  const matches: string[] = [];
+  let raw = 0;
+
+  const award = (name: string, value: number) => {
+    // Idempotent: an attribute credited once (e.g. `series` via hash)
+    // doesn't double-score when the same attribute also matches via
+    // imdb-equivalence or release-name. Keeps the running total ≤ max.
+    if (matches.includes(name)) return;
+    raw += value;
+    matches.push(name);
+  };
+
+  // Hash matching is treated as Bazarr-style perfect identification:
+  // every "id-style" attribute (series / title / year / season / episode)
+  // is credited because a movie/episode hash collision is effectively
+  // impossible. We DON'T short-circuit — release-name attributes still
+  // get credited below when present, so a hash + perfect-release combo
+  // can reach 100% while hash + missing-release tops out lower.
+  if (candidate.hashMatched) {
+    award('hash', weights.hash);
+    if (isEpisode) {
+      award('series', (weights as typeof EPISODE_WEIGHTS).series);
+      award('season', (weights as typeof EPISODE_WEIGHTS).season);
+      award('episode', (weights as typeof EPISODE_WEIGHTS).episode);
+    } else {
+      award('title', (weights as typeof MOVIE_WEIGHTS).title);
+    }
+    if (context.year) award('year', weights.year);
+  }
+
+  // IMDB equivalence: a confirmed imdb-id match means the provider
+  // located the right title/year (and the right series for episodes).
+  // Saves us from depending on release-name token matching for those.
+  const imdbMatched =
+    !!candidate.imdbId &&
+    !!context.imdbId &&
+    candidate.imdbId.replace(/^tt/, '') ===
+      context.imdbId.replace(/^tt/, '');
+  if (imdbMatched) {
+    if (isEpisode) {
+      award('series', (weights as typeof EPISODE_WEIGHTS).series);
+    } else {
+      award('title', (weights as typeof MOVIE_WEIGHTS).title);
+    }
+    if (context.year) award('year', weights.year);
+  }
+
+  // Release-name attribute matching. Without a release name from either
+  // side we skip the whole block — the candidate falls back to the bonuses
+  // already awarded above plus hearing_impaired below.
+  if (candidate.releaseName && context.videoReleaseName) {
+    const subAttrs = parseReleaseAttributes(candidate.releaseName);
+    const vidAttrs = parseReleaseAttributes(context.videoReleaseName);
+
+    if (
+      subAttrs.releaseGroup &&
+      vidAttrs.releaseGroup &&
+      subAttrs.releaseGroup === vidAttrs.releaseGroup
+    ) {
+      award('releaseGroup', weights.releaseGroup);
+    }
+    if (subAttrs.source && vidAttrs.source && subAttrs.source === vidAttrs.source) {
+      award('source', weights.source);
+    }
+    if (
+      subAttrs.resolution &&
+      vidAttrs.resolution &&
+      subAttrs.resolution === vidAttrs.resolution
+    ) {
+      award('resolution', weights.resolution);
+    }
+    if (
+      subAttrs.videoCodec &&
+      vidAttrs.videoCodec &&
+      subAttrs.videoCodec === vidAttrs.videoCodec
+    ) {
+      award('videoCodec', weights.videoCodec);
+    }
+    if (
+      subAttrs.audioCodec &&
+      vidAttrs.audioCodec &&
+      subAttrs.audioCodec === vidAttrs.audioCodec
+    ) {
+      award('audioCodec', weights.audioCodec);
+    }
+    if (
+      !isEpisode &&
+      subAttrs.edition &&
+      vidAttrs.edition &&
+      subAttrs.edition === vidAttrs.edition
+    ) {
+      award('edition', (weights as typeof MOVIE_WEIGHTS).edition);
+    }
+
+    // Series / title / year recovery from release names when imdb didn't
+    // match. Comparison strips every non-alphanumeric so dots / dashes /
+    // underscores / spaces between words don't break the match
+    // (`Mr.Robot.S01…` should match `Mr. Robot`).
+    if (!matches.includes('series') && !matches.includes('title')) {
+      if (looseTitleMatch(candidate.releaseName, context.title)) {
+        if (isEpisode) {
+          award('series', (weights as typeof EPISODE_WEIGHTS).series);
+        } else {
+          award('title', (weights as typeof MOVIE_WEIGHTS).title);
+        }
+      }
+    }
+    if (!matches.includes('year') && context.year) {
+      if (new RegExp(`\\b${context.year}\\b`).test(candidate.releaseName)) {
+        award('year', weights.year);
+      }
+    }
+
+    // Season / episode for series — extracted from the release name.
+    if (isEpisode) {
+      const parsed = parseSeasonEpisode(candidate.releaseName);
+      if (
+        parsed.season != null &&
+        context.season != null &&
+        parsed.season === context.season
+      ) {
+        award('season', (weights as typeof EPISODE_WEIGHTS).season);
+      }
+      if (
+        parsed.episode != null &&
+        context.episode != null &&
+        parsed.episode === context.episode
+      ) {
+        award('episode', (weights as typeof EPISODE_WEIGHTS).episode);
+      }
+    }
+  }
+
+  // Hearing-impaired bit (always available — doesn't need release names).
+  // Default prefers NON-HI subs. The 1-point weight is intentionally
+  // small — it's a tie-breaker, not a filter. Real enforcement (require
+  // / forbid) belongs to the language-profile layer.
+  const prefersHI = context.preferHearingImpaired === true;
+  if (prefersHI ? candidate.hearingImpaired : !candidate.hearingImpaired) {
+    award('hearingImpaired', weights.hearingImpaired);
+  }
+
+  return finalize(raw, max, matches);
+}
+
+function finalize(raw: number, max: number, matches: string[]): SubtitleScore {
+  const percent = Math.max(0, Math.min(100, Math.round((raw / max) * 100)));
+  return { raw, max, percent, matches };
+}
+
+/** Loose title-in-release-name check. Strips every non-alphanumeric on
+ *  both sides so token separators (`.`, `-`, `_`, space) don't matter. */
+function looseTitleMatch(haystack: string, needle: string): boolean {
+  const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '');
+  const n = norm(needle);
+  if (!n) return false;
+  return norm(haystack).includes(n);
+}

--- a/backend/src/modules/subtitles/subtitles.service.ts
+++ b/backend/src/modules/subtitles/subtitles.service.ts
@@ -31,6 +31,10 @@ import {
   APP_LANGUAGES,
   ISO_639_2_TO_1,
 } from '../../common/constants/app-languages';
+import {
+  SubtitleScore,
+  scoreSubtitle,
+} from './subtitle-scorer';
 
 @Injectable()
 export class SubtitlesService {
@@ -103,7 +107,7 @@ export class SubtitlesService {
       `Subtitle search for "${params.title}" [${params.language}]: ${allResults.length} result(s) from ${providers.length} provider(s)`,
     );
 
-    // Filter out blacklisted subtitles
+    // Filter out blacklisted subtitles (composite key includes provider).
     const blacklisted = await this.blacklistRepo.find();
     const blacklistSet = new Set(
       blacklisted.map((b) => `${b.providerType}:${b.providerFileId}`),
@@ -112,8 +116,56 @@ export class SubtitlesService {
       (r) => !blacklistSet.has(`${r.providerType}:${r.providerFileId}`),
     );
 
-    filtered.sort((a, b) => b.score - a.score);
-    return filtered;
+    // Cross-provider dedup: when the same release name + language + HI
+    // flag appear from two providers, keep the first occurrence (encounter
+    // order mirrors provider priority since `findEnabled` returns by
+    // priority ASC). Providers that don't expose a releaseName fall back
+    // to the `providerType:providerFileId` axis which is already unique.
+    const seenReleaseKey = new Set<string>();
+    const deduped: SubtitleSearchResult[] = [];
+    for (const r of filtered) {
+      const releaseKey = r.releaseName
+        ? `${r.releaseName.toLowerCase()}|${r.language}|${r.hearingImpaired ? 'hi' : 'normal'}|${r.forced ? 'forced' : 'full'}`
+        : `${r.providerType}:${r.providerFileId}`;
+      if (seenReleaseKey.has(releaseKey)) continue;
+      seenReleaseKey.add(releaseKey);
+      deduped.push(r);
+    }
+
+    // Central scoring: every candidate is rescored against the video
+    // context so the comparison stays fair across providers. The
+    // per-provider `score` field is ignored (providers no longer compute
+    // it). When the caller didn't supply video context (title only), the
+    // scorer still produces a useful ranking via hash + imdb-equivalence
+    // + hearing-impaired bit.
+    const scoringCtx = {
+      kind: (params.season != null && params.episode != null
+        ? 'episode'
+        : 'movie') as 'episode' | 'movie',
+      videoReleaseName: params.videoReleaseName ?? null,
+      title: params.title,
+      year: params.year ?? null,
+      season: params.season ?? null,
+      episode: params.episode ?? null,
+      imdbId: params.imdbId ?? null,
+    };
+    const scored: (SubtitleSearchResult & { _score: SubtitleScore })[] =
+      deduped.map((r) => {
+        const s = scoreSubtitle(r, scoringCtx);
+        r.score = s.percent;
+        return Object.assign(r, { _score: s });
+      });
+
+    scored.sort((a, b) => {
+      if (a._score.percent !== b._score.percent) {
+        return b._score.percent - a._score.percent;
+      }
+      // Tie-breaker: prefer higher download count when scores are equal —
+      // it's the only popularity-style signal left after centralisation.
+      return (b.downloadCount ?? 0) - (a.downloadCount ?? 0);
+    });
+
+    return scored;
   }
 
   async autoDownload(


### PR DESCRIPTION
## Summary
Each subtitle provider used to compute its own 0–100 score from incomparable signals (gestdown: log of download count, opensubtitles: ratings × 10 + downloads/100 + hash bonus, subdl: rating × 10, subsynchro: 50−index, supersubtitles: flat 50, yify: rating × 10). The orchestrator sorted across providers as if those numbers were comparable, which they weren't — and none of them looked at the local video file. A popular but wrong-release sub regularly beat a perfect-release but obscure one.

This PR mirrors Bazarr's \`subliminal_patch\` design:
- **Providers** stop scoring. They expose raw metadata: \`releaseName\`, \`imdbId\`, \`hashMatched\`, plus the existing \`hearingImpaired\` / \`forced\` / \`downloadCount\`.
- **New \`subtitle-scorer.ts\`** (pure, unit-tested) compares candidate vs video context with Bazarr's weight tables: hash 359/119, series/title 180/60, year 90/30, season/episode 30, release_group 14/13, source 7, audio_codec 3, resolution 2, video_codec 2, edition (movies only) 1, hearing_impaired 1. Normalises to 0–100 %.
- **New \`release-attributes.parser.ts\`** extracts release_group, source, resolution, video/audio codec, edition, HI flag from a release name.
- **\`SubtitlesService.searchSubtitles\`** now aggregates → blacklists → cross-provider dedupes by (releaseName, language, HI, forced) → rescores → sorts. Download count is a tie-breaker.
- **Callers** (\`subtitle-scheduler\` missing + upgrade, \`onMediaFileImported\`, manual search controller) now resolve the file basename + season/episode from the linked \`MediaFile.episode.season\` and forward both via a new \`videoReleaseName\` field on \`SubtitleSearchParams\`.
- **Equivalence map**: imdb match → series/title + year credited even when release name is missing.
- **Settings** \`subtitle_min_score\` (70) and \`subtitle_upgrade_threshold\` (90) now mean PERCENT of the scorer's max. Defaults stay meaningful; old rows re-score naturally on the next upgrade pass.

## Test plan
- [ ] Manual search for a movie/episode I know has subs in the library → top result is the release-matching one, not the most-downloaded one.
- [ ] OpenSubtitles hash-matched sub shows up at 90 %+.
- [ ] A series episode that has only mismatched-quality candidates ranks them below better matches.
- [ ] \`SubtitleSearch\` cron downloads when the percent score crosses \`subtitle_min_score\`.
- [ ] \`SubtitleUpgrade\` doesn't downgrade a sub when no candidate scores strictly higher.
- [ ] 11 unit tests in \`subtitle-scorer.spec.ts\` pass.