### PR TITLE
feat(subtitles): persist OSDb hash on MediaFile + hash-match invariant

### DIFF
--- a/backend/src/migrations/1779300000000-add-media-file-osdb-hash.ts
+++ b/backend/src/migrations/1779300000000-add-media-file-osdb-hash.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMediaFileOsdbHash1779300000000 implements MigrationInterface {
+  name = 'AddMediaFileOsdbHash1779300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "media_files"
+        ADD COLUMN IF NOT EXISTS "osdbHash" varchar(16),
+        ADD COLUMN IF NOT EXISTS "osdbBytesize" bigint
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "media_files"
+        DROP COLUMN IF EXISTS "osdbHash",
+        DROP COLUMN IF EXISTS "osdbBytesize"
+    `);
+  }
+}

--- a/backend/src/migrations/1779310000000-add-subtitle-file-hash-matched.ts
+++ b/backend/src/migrations/1779310000000-add-subtitle-file-hash-matched.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSubtitleFileHashMatched1779310000000
+  implements MigrationInterface
+{
+  name = 'AddSubtitleFileHashMatched1779310000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "subtitle_files"
+        ADD COLUMN IF NOT EXISTS "hashMatched" boolean NOT NULL DEFAULT false
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "subtitle_files"
+        DROP COLUMN IF EXISTS "hashMatched"
+    `);
+  }
+}

--- a/backend/src/modules/media/entities/media-file.entity.ts
+++ b/backend/src/modules/media/entities/media-file.entity.ts
@@ -45,4 +45,24 @@ export class MediaFile extends BaseEntity {
 
   @Column({ type: 'jsonb', nullable: true, default: null })
   streamInfo: MediaFileInfo | null;
+
+  /**
+   * OpenSubtitles movie hash (first + last 64 KiB summed as uint64 + size).
+   * Computed once on import / rescan and forwarded to provider lookups so
+   * subs returned by an OS hash search can be flagged `hashMatched` by the
+   * orchestrator — the scorer treats that as a near-perfect identification.
+   * Nullable when the file is smaller than 128 KiB or unreadable.
+   */
+  @Column({ type: 'varchar', length: 16, nullable: true })
+  osdbHash: string | null;
+
+  @Column({
+    type: 'bigint',
+    nullable: true,
+    transformer: {
+      to: (v: number | null) => v,
+      from: (v: string | null) => (v == null ? null : Number(v)),
+    },
+  })
+  osdbBytesize: number | null;
 }

--- a/backend/src/modules/media/media-service/media-rescan.service.ts
+++ b/backend/src/modules/media/media-service/media-rescan.service.ts
@@ -15,6 +15,7 @@ import { Episode } from '../entities/episode.entity';
 import { MediaType } from '../../../common/enums';
 import { APP_QUALITIES } from '../../../common/constants/app-qualities';
 import { AnalyzeMediaDto } from '../dto/analyze-media.dto';
+import { computeMovieHash } from '../../subtitles/moviehash';
 import { NamingService } from '../../scheduler/naming.service';
 import { FfprobeService } from '../../subtitles/ffprobe.service';
 import { SubtitlesService } from '../../subtitles/subtitles.service';
@@ -139,7 +140,31 @@ export class MediaRescanService {
     media: Media,
   ): Promise<void> {
     await this.detectAndStoreCrop(file, absPath);
+    await this.computeAndStoreOsdbHash(file, absPath);
     this.rebuildSubtitleCacheForFile(file, absPath, media);
+  }
+
+  /**
+   * Compute the OpenSubtitles movie hash for the file and persist it on
+   * the row so subsequent subtitle searches can do a hash-based lookup —
+   * the central scorer awards near-max credit when the provider confirms
+   * a hash match. Best-effort: small or unreadable files store nulls.
+   */
+  private async computeAndStoreOsdbHash(
+    file: MediaFile,
+    absPath: string,
+  ): Promise<void> {
+    try {
+      const result = computeMovieHash(absPath);
+      file.osdbHash = result?.hash ?? null;
+      file.osdbBytesize = result?.bytesize ?? null;
+      await this.mediaFileRepo.save(file);
+    } catch (err) {
+      this.log.warn(
+        `computeAndStoreOsdbHash: failed for "${absPath}"`,
+        err instanceof Error ? err.stack : err,
+      );
+    }
   }
 
   /**

--- a/backend/src/modules/media/media.controller.ts
+++ b/backend/src/modules/media/media.controller.ts
@@ -516,6 +516,8 @@ export class MediaController {
       season,
       episode,
       videoReleaseName,
+      moviehash: matchingFile?.osdbHash ?? undefined,
+      moviebytesize: matchingFile?.osdbBytesize ?? undefined,
     });
   }
 

--- a/backend/src/modules/scheduler/subtitle-scheduler.service.ts
+++ b/backend/src/modules/scheduler/subtitle-scheduler.service.ts
@@ -127,6 +127,8 @@ export class SubtitleSchedulerService {
               season: fileSeason,
               episode: fileEpisode,
               videoReleaseName,
+              moviehash: file.osdbHash ?? undefined,
+              moviebytesize: file.osdbBytesize ?? undefined,
             });
 
             const best = results.find((r) => r.score >= minScore);
@@ -232,9 +234,18 @@ export class SubtitleSchedulerService {
           season: sub.mediaFile?.episode?.season?.seasonNumber ?? undefined,
           episode: sub.mediaFile?.episode?.episodeNumber ?? undefined,
           videoReleaseName,
+          moviehash: sub.mediaFile?.osdbHash ?? undefined,
+          moviebytesize: sub.mediaFile?.osdbBytesize ?? undefined,
         });
 
-        const better = results.find((r) => r.score > sub.score);
+        // Invariant: a hash-matched sub is the perfect time sync — refuse
+        // to replace it with a non-hash candidate, no matter what the
+        // score says. A non-hash sub from a slightly-better release
+        // doesn't beat a verified hash match.
+        const candidates = sub.hashMatched
+          ? results.filter((r) => r.hashMatched)
+          : results;
+        const better = candidates.find((r) => r.score > sub.score);
         if (!better) continue;
 
         await this.subtitlesService.upgradeSubtitle(sub.id, better);
@@ -382,6 +393,8 @@ export class SubtitleSchedulerService {
           season: fileSeason,
           episode: fileEpisode,
           videoReleaseName,
+          moviehash: mediaFile.osdbHash ?? undefined,
+          moviebytesize: mediaFile.osdbBytesize ?? undefined,
         });
 
         const best = results.find((r) => r.score >= minScore);

--- a/backend/src/modules/subtitles/entities/subtitle-file.entity.ts
+++ b/backend/src/modules/subtitles/entities/subtitle-file.entity.ts
@@ -63,6 +63,15 @@ export class SubtitleFile extends BaseEntity {
   @Column({ type: 'int', default: 0 })
   score: number;
 
+  /**
+   * True when the candidate this row was downloaded from came out of a
+   * hash-based provider lookup (e.g. OpenSubtitles moviehash). Used by
+   * the upgrade pass as a guard: a hash-matched sub is the perfect time
+   * sync, so non-hash candidates can't replace it on score alone.
+   */
+  @Column({ default: false })
+  hashMatched: boolean;
+
   @Column({ default: false })
   synced: boolean;
 

--- a/backend/src/modules/subtitles/subtitles.service.ts
+++ b/backend/src/modules/subtitles/subtitles.service.ts
@@ -313,6 +313,7 @@ export class SubtitlesService {
       relativePath,
       status: SubtitleStatus.DOWNLOADED,
       score: searchResult.score,
+      hashMatched: !!searchResult.hashMatched,
       synced: false,
     } as any);
   }


### PR DESCRIPTION
## Summary
- Subtitle scoring already credits hash-matched candidates at near-max (PR #234) but the hash was only computed when a caller passed \`filePath\`, which the schedulers never did. The perfect-time-sync signal was lost in automated searches.
- Two new columns on \`media_files\`: \`osdbHash\` (varchar 16) and \`osdbBytesize\` (bigint). Populated in \`finalizeImportedFile\` so every import path (grab→import, disk import, rescan, manual analyse) stores them.
- Every \`SubtitlesService.searchSubtitles\` caller (scheduler missing pass, upgrade pass, post-import hook, manual search controller) now forwards \`moviehash\` + \`moviebytesize\`. OpenSubtitles runs a hash query and returns \`moviehash_match=true\`, mapped to \`hashMatched\` by the central scorer.
- New \`subtitle_files.hashMatched\` boolean column, set on download. The upgrade pass refuses to replace a hash-matched sub with a non-hash candidate (filter at the candidate-pick step, before the score comparison).

## Test plan
- [ ] Import a new file → \`SELECT osdbHash, osdbBytesize FROM media_files WHERE id=…\` returns the hex hash + size.
- [ ] Trigger \`SubtitleSearch\` for a movie known on OpenSubtitles by hash → the downloaded row has \`hashMatched=true\`.
- [ ] Run \`SubtitleUpgrade\` against that movie → it stays put even if a higher-percent non-hash candidate exists.
- [ ] Run \`SubtitleUpgrade\` against a non-hash sub with a hash candidate available → it upgrades.
- [ ] Migrations 1779300/1779310 apply cleanly.