### PR TITLE
feat(subtitles): per-language hearing-impaired enforcement

### DIFF
--- a/backend/src/modules/profiles/entities/language-profile.entity.ts
+++ b/backend/src/modules/profiles/entities/language-profile.entity.ts
@@ -18,9 +18,30 @@ export interface AudioLanguageItem {
   name: string;
 }
 
+export type HearingImpairedMode = 'prefer' | 'avoid' | 'require' | 'forbid';
+
 export interface SubtitleLanguageItem {
   isoCode: string;
   name: string;
   forced: boolean;
   hi: boolean;
+  /**
+   * Per-language hearing-impaired preference. Optional — when absent
+   * the legacy `hi` boolean is interpreted: `hi=true` → `prefer`,
+   * `hi=false` → `avoid`.
+   *
+   * - `prefer`:  HI subs score the 1-point bit; non-HI don't.
+   * - `avoid`:   non-HI subs score the bit; HI don't. (Default.)
+   * - `require`: HI candidates only; non-HI filtered out before scoring.
+   * - `forbid`:  non-HI only; HI candidates filtered out.
+   */
+  hearingImpaired?: HearingImpairedMode;
+}
+
+/** Resolves a language item's effective HI mode, defaulting from the
+ *  legacy `hi` boolean when no explicit mode is set. */
+export function resolveHearingImpairedMode(
+  item: SubtitleLanguageItem,
+): HearingImpairedMode {
+  return item.hearingImpaired ?? (item.hi ? 'prefer' : 'avoid');
 }

--- a/backend/src/modules/scheduler/subtitle-scheduler.service.ts
+++ b/backend/src/modules/scheduler/subtitle-scheduler.service.ts
@@ -11,7 +11,10 @@ import { SubtitleSyncService } from '../subtitles/subtitle-sync.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { SettingsService } from '../settings/settings.service';
 import { SubtitleProviderType, SubtitleStatus } from '../../common/enums';
-import { SubtitleLanguageItem } from '../profiles/entities/language-profile.entity';
+import {
+  SubtitleLanguageItem,
+  resolveHearingImpairedMode,
+} from '../profiles/entities/language-profile.entity';
 import { EmbeddedSubtitleService } from '../subtitles/embedded-subtitle.service';
 import { MediaServersService } from '../media-servers/media-servers.service';
 
@@ -129,6 +132,7 @@ export class SubtitleSchedulerService {
               videoReleaseName,
               moviehash: file.osdbHash ?? undefined,
               moviebytesize: file.osdbBytesize ?? undefined,
+              hearingImpairedMode: resolveHearingImpairedMode(langItem),
             });
 
             const best = results.find((r) => r.score >= minScore);
@@ -225,6 +229,9 @@ export class SubtitleSchedulerService {
         const videoReleaseName = fileRel
           ? path.basename(fileRel, path.extname(fileRel))
           : undefined;
+        const langItem = sub.media?.languageProfile?.subtitleLanguages?.find(
+          (l) => l.isoCode === sub.language,
+        );
         const results = await this.subtitlesService.searchSubtitles({
           imdbId: sub.media?.imdbId ?? undefined,
           tmdbId: sub.media?.tmdbId,
@@ -236,6 +243,9 @@ export class SubtitleSchedulerService {
           videoReleaseName,
           moviehash: sub.mediaFile?.osdbHash ?? undefined,
           moviebytesize: sub.mediaFile?.osdbBytesize ?? undefined,
+          hearingImpairedMode: langItem
+            ? resolveHearingImpairedMode(langItem)
+            : 'avoid',
         });
 
         // Invariant: a hash-matched sub is the perfect time sync — refuse
@@ -395,6 +405,7 @@ export class SubtitleSchedulerService {
           videoReleaseName,
           moviehash: mediaFile.osdbHash ?? undefined,
           moviebytesize: mediaFile.osdbBytesize ?? undefined,
+          hearingImpairedMode: resolveHearingImpairedMode(langItem),
         });
 
         const best = results.find((r) => r.score >= minScore);

--- a/backend/src/modules/subtitles/providers/subtitle-provider.interface.ts
+++ b/backend/src/modules/subtitles/providers/subtitle-provider.interface.ts
@@ -15,6 +15,10 @@ export interface SubtitleSearchParams {
    *  (release_group, source, resolution, codecs). Providers ignore
    *  this; it only matters in SubtitlesService. */
   videoReleaseName?: string;
+  /** Per-language hearing-impaired preference: `prefer` / `avoid` flip
+   *  the 1-point scorer bit; `require` / `forbid` filter candidates
+   *  in the orchestrator before scoring. Default `avoid`. */
+  hearingImpairedMode?: 'prefer' | 'avoid' | 'require' | 'forbid';
 }
 
 /**

--- a/backend/src/modules/subtitles/subtitle-scorer.spec.ts
+++ b/backend/src/modules/subtitles/subtitle-scorer.spec.ts
@@ -113,15 +113,31 @@ describe('subtitle-scorer', () => {
   });
 
   describe('hearing-impaired bit', () => {
-    it('awards non-HI by default', () => {
+    it('awards non-HI by default (avoid mode)', () => {
       const s = scoreSubtitle({ hearingImpaired: false }, EPISODE_CTX);
       expect(s.matches).toContain('hearingImpaired');
     });
 
-    it('awards HI when caller prefers it', () => {
+    it('does not award HI to non-HI candidate in `prefer` mode', () => {
+      const s = scoreSubtitle(
+        { hearingImpaired: false },
+        { ...EPISODE_CTX, hearingImpairedMode: 'prefer' },
+      );
+      expect(s.matches).not.toContain('hearingImpaired');
+    });
+
+    it('awards HI when mode is `prefer`', () => {
       const s = scoreSubtitle(
         { hearingImpaired: true },
-        { ...EPISODE_CTX, preferHearingImpaired: true },
+        { ...EPISODE_CTX, hearingImpairedMode: 'prefer' },
+      );
+      expect(s.matches).toContain('hearingImpaired');
+    });
+
+    it('treats `require` like `prefer` for the bit', () => {
+      const s = scoreSubtitle(
+        { hearingImpaired: true },
+        { ...EPISODE_CTX, hearingImpairedMode: 'require' },
       );
       expect(s.matches).toContain('hearingImpaired');
     });

--- a/backend/src/modules/subtitles/subtitle-scorer.ts
+++ b/backend/src/modules/subtitles/subtitle-scorer.ts
@@ -80,9 +80,11 @@ export interface SubtitleScoreVideoContext {
   episode?: number | null;
   /** IMDB id of the media — used by equivalence map. */
   imdbId?: string | null;
-  /** Caller preference for hearing-impaired subs (default: false → award
-   *  the bit when candidate is NOT hearing-impaired). */
-  preferHearingImpaired?: boolean;
+  /** Caller preference for hearing-impaired subs (default: `avoid` →
+   *  award the bit when candidate is NOT hearing-impaired). `require` /
+   *  `forbid` are enforced by the orchestrator before scoring; the
+   *  scorer treats them as a `prefer` / `avoid` for the bit weight. */
+  hearingImpairedMode?: 'prefer' | 'avoid' | 'require' | 'forbid';
 }
 
 export interface SubtitleScore {
@@ -240,11 +242,13 @@ export function scoreSubtitle(
     }
   }
 
-  // Hearing-impaired bit (always available — doesn't need release names).
-  // Default prefers NON-HI subs. The 1-point weight is intentionally
-  // small — it's a tie-breaker, not a filter. Real enforcement (require
-  // / forbid) belongs to the language-profile layer.
-  const prefersHI = context.preferHearingImpaired === true;
+  // Hearing-impaired bit. The 1-point weight is intentionally small —
+  // it's a tie-breaker among already-eligible candidates. Hard
+  // enforcement (`require` / `forbid`) belongs to the orchestrator
+  // which filters candidates BEFORE scoring; here we map all four
+  // modes to a binary "prefer HI?" flag for the bit award.
+  const mode = context.hearingImpairedMode ?? 'avoid';
+  const prefersHI = mode === 'prefer' || mode === 'require';
   if (prefersHI ? candidate.hearingImpaired : !candidate.hearingImpaired) {
     award('hearingImpaired', weights.hearingImpaired);
   }

--- a/backend/src/modules/subtitles/subtitles.service.ts
+++ b/backend/src/modules/subtitles/subtitles.service.ts
@@ -116,6 +116,16 @@ export class SubtitlesService {
       (r) => !blacklistSet.has(`${r.providerType}:${r.providerFileId}`),
     );
 
+    // Hearing-impaired hard filter. `require` keeps only HI candidates,
+    // `forbid` drops them; `prefer` / `avoid` leave the candidate set
+    // intact and only nudge the 1-point bit in the scorer below.
+    const hiMode = params.hearingImpairedMode ?? 'avoid';
+    const hiFiltered = filtered.filter((r) => {
+      if (hiMode === 'require') return r.hearingImpaired;
+      if (hiMode === 'forbid') return !r.hearingImpaired;
+      return true;
+    });
+
     // Cross-provider dedup: when the same release name + language + HI
     // flag appear from two providers, keep the first occurrence (encounter
     // order mirrors provider priority since `findEnabled` returns by
@@ -123,7 +133,7 @@ export class SubtitlesService {
     // to the `providerType:providerFileId` axis which is already unique.
     const seenReleaseKey = new Set<string>();
     const deduped: SubtitleSearchResult[] = [];
-    for (const r of filtered) {
+    for (const r of hiFiltered) {
       const releaseKey = r.releaseName
         ? `${r.releaseName.toLowerCase()}|${r.language}|${r.hearingImpaired ? 'hi' : 'normal'}|${r.forced ? 'forced' : 'full'}`
         : `${r.providerType}:${r.providerFileId}`;
@@ -148,6 +158,7 @@ export class SubtitlesService {
       season: params.season ?? null,
       episode: params.episode ?? null,
       imdbId: params.imdbId ?? null,
+      hearingImpairedMode: hiMode,
     };
     const scored: (SubtitleSearchResult & { _score: SubtitleScore })[] =
       deduped.map((r) => {


### PR DESCRIPTION
## Summary
The legacy \`SubtitleLanguageItem.hi\` boolean was a soft preference — the scorer added a 1-point bit either way. There was no way to forbid HI candidates outright (users who can't read fast), nor to require them (accessibility profiles).

- Extends \`SubtitleLanguageItem\` with an optional \`hearingImpaired: 'prefer' | 'avoid' | 'require' | 'forbid'\`. When absent the legacy \`hi\` is interpreted (\`true\` → prefer, \`false\` → avoid) so existing profiles behave unchanged.
- \`require\` / \`forbid\` are HARD filters in \`SubtitlesService.searchSubtitles\` before scoring. \`prefer\` / \`avoid\` remain soft and only nudge the scorer's 1-point bit.
- Plumbed through missing-search, upgrade, and post-import hooks (per-language). Upgrade resolves the mode from the media's language profile per subtitle row.

## Test plan
- [ ] Set a language to \`require\` HI → only HI subs are downloaded.
- [ ] Set to \`forbid\` → only non-HI subs are downloaded.
- [ ] Set to \`prefer\` → HI subs rank slightly above non-HI at equal scores.
- [ ] Leave language with legacy \`hi=true\` and no \`hearingImpaired\` field → behaves like \`prefer\` (back-compat).
- [ ] 4 new unit tests in \`subtitle-scorer.spec.ts\` pass.