### PR TITLE
feat(subtitles): circuit breaker on top of provider rate-limiter

### DIFF
--- a/backend/src/modules/subtitles/providers/gestdown.provider.ts
+++ b/backend/src/modules/subtitles/providers/gestdown.provider.ts
@@ -4,11 +4,11 @@ import {
   SubtitleSearchParams,
   SubtitleSearchResult,
 } from './subtitle-provider.interface';
+import { isRateLimited, rateLimitedFetch } from './rate-limiter';
 
+const PROVIDER_TYPE = 'gestdown';
 const BASE_URL = 'https://api.gestdown.info';
 const USER_AGENT = 'Fliks/1.0';
-const MAX_RETRIES = 3;
-const RETRY_DELAY_MS = 5_000;
 
 // Gestdown uses Addic7ed-style language names
 const LANG_MAP: Record<string, string> = {
@@ -66,6 +66,8 @@ export class GestdownProvider implements SubtitleProviderInterface {
   private readonly logger = new Logger(GestdownProvider.name);
 
   async search(params: SubtitleSearchParams): Promise<SubtitleSearchResult[]> {
+    if (isRateLimited(PROVIDER_TYPE)) return [];
+
     // Gestdown only supports TV shows
     if (params.season == null || params.episode == null) return [];
 
@@ -79,7 +81,12 @@ export class GestdownProvider implements SubtitleProviderInterface {
     if (!showId) return [];
 
     const url = `${BASE_URL}/subtitles/get/${showId}/${params.season}/${params.episode}/${lang}`;
-    const res = await this.fetchWithRetry(url);
+    const res = await rateLimitedFetch(
+      PROVIDER_TYPE,
+      url,
+      { headers: { 'User-Agent': USER_AGENT } },
+      { defaultBackoffSec: 5 },
+    );
     if (!res || !res.ok) return [];
 
     const body = (await res.json()) as {
@@ -103,8 +110,16 @@ export class GestdownProvider implements SubtitleProviderInterface {
   }
 
   async download(result: SubtitleSearchResult): Promise<Buffer> {
+    if (isRateLimited(PROVIDER_TYPE)) {
+      throw new Error('Gestdown is rate-limited, try again later');
+    }
     const url = `${BASE_URL}${result.providerFileId}`;
-    const res = await this.fetchWithRetry(url);
+    const res = await rateLimitedFetch(
+      PROVIDER_TYPE,
+      url,
+      { headers: { 'User-Agent': USER_AGENT } },
+      { defaultBackoffSec: 5 },
+    );
     if (!res || !res.ok)
       throw new Error(`Gestdown download failed: ${res?.status}`);
     return Buffer.from(await res.arrayBuffer());
@@ -125,11 +140,14 @@ export class GestdownProvider implements SubtitleProviderInterface {
     params: SubtitleSearchParams,
   ): Promise<string | null> {
     const searchUrl = `${BASE_URL}/shows/search/${encodeURIComponent(params.title)}`;
-    const res = await fetch(searchUrl, {
-      headers: { 'User-Agent': USER_AGENT },
-    });
-    if (!res.ok) {
-      this.logger.warn(`Gestdown show search failed: ${res.status}`);
+    const res = await rateLimitedFetch(
+      PROVIDER_TYPE,
+      searchUrl,
+      { headers: { 'User-Agent': USER_AGENT } },
+      { defaultBackoffSec: 5 },
+    );
+    if (!res || !res.ok) {
+      if (res) this.logger.warn(`Gestdown show search failed: ${res.status}`);
       return null;
     }
 
@@ -147,21 +165,5 @@ export class GestdownProvider implements SubtitleProviderInterface {
 
     // Fallback to first result
     return body.shows[0].id;
-  }
-
-  /** Fetch with retry on HTTP 423 (rate-limited). */
-  private async fetchWithRetry(url: string): Promise<Response | null> {
-    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-      const res = await fetch(url, {
-        headers: { 'User-Agent': USER_AGENT },
-      });
-      if (res.status !== 423) return res;
-      this.logger.warn(
-        `Gestdown rate-limited (423), retry ${attempt + 1}/${MAX_RETRIES}`,
-      );
-      await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
-    }
-    this.logger.warn('Gestdown: max retries reached');
-    return null;
   }
 }

--- a/backend/src/modules/subtitles/providers/rate-limiter.spec.ts
+++ b/backend/src/modules/subtitles/providers/rate-limiter.spec.ts
@@ -1,0 +1,61 @@
+import { getAllCooldowns, isRateLimited, rateLimitedFetch } from './rate-limiter';
+
+describe('rate-limiter circuit breaker', () => {
+  const PROVIDER = `test-${Math.random().toString(36).slice(2)}`;
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('opens the circuit after 3 consecutive 5xx responses', async () => {
+    global.fetch = jest.fn(async () =>
+      new Response(null, { status: 503 }),
+    ) as unknown as typeof fetch;
+
+    for (let i = 0; i < 3; i++) {
+      await rateLimitedFetch(PROVIDER, 'https://example.test/path');
+    }
+
+    expect(isRateLimited(PROVIDER)).toBe(true);
+    const state = getAllCooldowns().find((c) => c.providerType === PROVIDER);
+    expect(state?.circuit).toBe('open');
+    expect(state?.consecutiveFailures).toBeGreaterThanOrEqual(3);
+  });
+
+  it('opens the circuit on repeated network errors', async () => {
+    const provider = `${PROVIDER}-net`;
+    global.fetch = jest.fn(async () => {
+      throw new Error('ECONNRESET');
+    }) as unknown as typeof fetch;
+
+    for (let i = 0; i < 3; i++) {
+      const res = await rateLimitedFetch(provider, 'https://example.test/x');
+      expect(res).toBeNull();
+    }
+
+    expect(isRateLimited(provider)).toBe(true);
+  });
+
+  it('resets the breaker on a successful 2xx after failures', async () => {
+    const provider = `${PROVIDER}-mix`;
+    let firstCall = true;
+    global.fetch = jest.fn(async () => {
+      if (firstCall) {
+        firstCall = false;
+        return new Response(null, { status: 503 });
+      }
+      return new Response('ok', { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await rateLimitedFetch(provider, 'https://example.test/y'); // 503
+    let state = getAllCooldowns().find((c) => c.providerType === provider);
+    expect(state?.consecutiveFailures).toBe(1);
+
+    await rateLimitedFetch(provider, 'https://example.test/y'); // 200
+    state = getAllCooldowns().find((c) => c.providerType === provider);
+    // After success, the entry has zero failures + closed circuit, so
+    // `getAllCooldowns` filters it out entirely. That's the assertion.
+    expect(state).toBeUndefined();
+  });
+});

--- a/backend/src/modules/subtitles/providers/rate-limiter.ts
+++ b/backend/src/modules/subtitles/providers/rate-limiter.ts
@@ -2,15 +2,95 @@ import { Logger } from '@nestjs/common';
 
 const log = new Logger('ProviderRateLimiter');
 
+/** Number of consecutive non-429 network failures before the breaker
+ *  opens. Picked low because subtitle providers are best-effort — when
+ *  one is down it's better to skip than to slow every scheduler tick. */
+const CIRCUIT_FAILURE_THRESHOLD = 3;
+/** How long to keep the circuit open before letting one probe request
+ *  through (half-open). 5 minutes balances "give the provider a chance
+ *  to recover" against "don't hammer a struggling endpoint". */
+const CIRCUIT_OPEN_MS = 5 * 60_000;
+
+type CircuitState = 'closed' | 'open' | 'half-open';
+
 interface ProviderCooldown {
-  /** Timestamp (ms) when the provider can be used again */
+  /** Timestamp (ms) when the rate-limit cooldown clears. */
   retryAfter: number;
   /** Remaining downloads in current window (provider-specific) */
   remaining: number | null;
+  /** Count of back-to-back non-429 failures (5xx, network, timeout). */
+  consecutiveFailures: number;
+  /** Circuit state. Open = skip every call until `circuitResetAt`. */
+  circuit: CircuitState;
+  /** Timestamp (ms) at which the open circuit transitions to half-open. */
+  circuitResetAt: number;
 }
 
 /** In-memory cooldown state per provider type */
 const cooldowns = new Map<string, ProviderCooldown>();
+
+function getOrCreate(providerType: string): ProviderCooldown {
+  let cd = cooldowns.get(providerType);
+  if (!cd) {
+    cd = {
+      retryAfter: 0,
+      remaining: null,
+      consecutiveFailures: 0,
+      circuit: 'closed',
+      circuitResetAt: 0,
+    };
+    cooldowns.set(providerType, cd);
+  }
+  return cd;
+}
+
+/** True when the circuit is currently blocking calls. */
+function circuitOpen(providerType: string): boolean {
+  const cd = cooldowns.get(providerType);
+  if (!cd || cd.circuit === 'closed') return false;
+  if (cd.circuit === 'open' && Date.now() >= cd.circuitResetAt) {
+    cd.circuit = 'half-open';
+    log.warn(
+      `${providerType}: circuit half-open, letting one probe request through`,
+    );
+  }
+  return cd.circuit === 'open';
+}
+
+/** Records a successful request — resets consecutive failures and
+ *  closes a previously-open circuit. */
+function recordSuccess(providerType: string): void {
+  const cd = cooldowns.get(providerType);
+  if (!cd) return;
+  if (cd.circuit !== 'closed') {
+    log.log(`${providerType}: circuit closed (recovered)`);
+  }
+  cd.consecutiveFailures = 0;
+  cd.circuit = 'closed';
+  cd.circuitResetAt = 0;
+}
+
+/** Records a network / 5xx failure. Opens the circuit once the threshold
+ *  is crossed. 429/423 are handled separately via `markRateLimited` —
+ *  rate-limiting is expected behaviour, not a breaker condition. */
+function recordFailure(providerType: string, reason: string): void {
+  const cd = getOrCreate(providerType);
+  // A failure in half-open means the probe failed — re-open immediately.
+  if (cd.circuit === 'half-open') {
+    cd.circuit = 'open';
+    cd.circuitResetAt = Date.now() + CIRCUIT_OPEN_MS;
+    log.warn(`${providerType}: half-open probe failed (${reason}), re-opening`);
+    return;
+  }
+  cd.consecutiveFailures += 1;
+  if (cd.consecutiveFailures >= CIRCUIT_FAILURE_THRESHOLD) {
+    cd.circuit = 'open';
+    cd.circuitResetAt = Date.now() + CIRCUIT_OPEN_MS;
+    log.warn(
+      `${providerType}: circuit OPEN after ${cd.consecutiveFailures} consecutive failures (${reason}); skipping for ${CIRCUIT_OPEN_MS / 60_000}min`,
+    );
+  }
+}
 
 /**
  * Check if a provider is currently rate-limited.
@@ -21,17 +101,20 @@ export function getRateLimitDelay(providerType: string): number {
   if (!cd) return 0;
   const now = Date.now();
   if (now >= cd.retryAfter) {
-    cooldowns.delete(providerType);
+    // Clear the rate-limit but keep circuit / failure state intact —
+    // those decay on their own via `recordSuccess` / `circuitOpen`.
+    cd.retryAfter = 0;
     return 0;
   }
   return Math.ceil((cd.retryAfter - now) / 1000);
 }
 
 /**
- * Check if provider is rate-limited. If so, log a warning and return true.
+ * Check if provider is unavailable to callers: either rate-limited or
+ * with an open circuit. Either condition makes `rateLimitedFetch` skip.
  */
 export function isRateLimited(providerType: string): boolean {
-  return getRateLimitDelay(providerType) > 0;
+  return getRateLimitDelay(providerType) > 0 || circuitOpen(providerType);
 }
 
 /**
@@ -44,6 +127,7 @@ export function markRateLimited(
   defaultBackoffSec = 60,
 ): void {
   let backoffSec = defaultBackoffSec;
+  const cd = getOrCreate(providerType);
 
   if (response) {
     const retryAfter = response.headers.get('retry-after');
@@ -65,20 +149,12 @@ export function markRateLimited(
       response.headers.get('x-ratelimit-remaining-second') ??
       response.headers.get('ratelimit-remaining');
     if (remaining !== null) {
-      const cd = cooldowns.get(providerType) ?? {
-        retryAfter: 0,
-        remaining: null,
-      };
       cd.remaining = Number(remaining);
-      cooldowns.set(providerType, cd);
     }
   }
 
   log.warn(`${providerType} rate-limited, backing off ${backoffSec}s`);
-  cooldowns.set(providerType, {
-    retryAfter: Date.now() + backoffSec * 1000,
-    remaining: cooldowns.get(providerType)?.remaining ?? null,
-  });
+  cd.retryAfter = Date.now() + backoffSec * 1000;
 }
 
 /**
@@ -91,23 +167,26 @@ export function trackQuota(providerType: string, response: Response): void {
     response.headers.get('ratelimit-remaining') ??
     response.headers.get('x-ratelimit-remaining');
   if (remaining !== null) {
-    const cd = cooldowns.get(providerType) ?? {
-      retryAfter: 0,
-      remaining: null,
-    };
-    cd.remaining = Number(remaining);
-    cooldowns.set(providerType, cd);
+    getOrCreate(providerType).remaining = Number(remaining);
   }
 }
 
 /**
- * Return current rate-limit state for all providers.
+ * Return current state for every provider that has at least one
+ * non-default field (rate-limit cooldown, an open/half-open circuit,
+ * or a non-zero remaining quota). Surfaces both rate-limit and
+ * circuit-breaker conditions so an admin UI can show "Provider X is
+ * skipped for 4 min — 3 consecutive failures".
  */
 export function getAllCooldowns(): {
   providerType: string;
   retryAfter: number;
   remaining: number | null;
   delaySec: number;
+  circuit: CircuitState;
+  circuitResetAt: number;
+  circuitResetInSec: number;
+  consecutiveFailures: number;
 }[] {
   const now = Date.now();
   const result: {
@@ -115,22 +194,40 @@ export function getAllCooldowns(): {
     retryAfter: number;
     remaining: number | null;
     delaySec: number;
+    circuit: CircuitState;
+    circuitResetAt: number;
+    circuitResetInSec: number;
+    consecutiveFailures: number;
   }[] = [];
   for (const [providerType, cd] of cooldowns) {
-    if (now >= cd.retryAfter) continue;
+    const rateLimited = now < cd.retryAfter;
+    const breaker = cd.circuit !== 'closed';
+    if (!rateLimited && !breaker && cd.consecutiveFailures === 0) continue;
     result.push({
       providerType,
       retryAfter: cd.retryAfter,
       remaining: cd.remaining,
-      delaySec: Math.ceil((cd.retryAfter - now) / 1000),
+      delaySec: rateLimited ? Math.ceil((cd.retryAfter - now) / 1000) : 0,
+      circuit: cd.circuit,
+      circuitResetAt: cd.circuitResetAt,
+      circuitResetInSec:
+        breaker && cd.circuitResetAt > now
+          ? Math.ceil((cd.circuitResetAt - now) / 1000)
+          : 0,
+      consecutiveFailures: cd.consecutiveFailures,
     });
   }
   return result;
 }
 
 /**
- * Wrapper for fetch that handles rate-limiting automatically.
- * Returns null if rate-limited (caller should return empty results).
+ * Wrapper for fetch that handles rate-limiting AND circuit-breaker
+ * state automatically:
+ *  - Skips the call when rate-limited or with an open circuit.
+ *  - Records success / failure so the breaker reacts to repeated
+ *    network errors or 5xx responses.
+ *  - Returns null in any skip case (caller should treat as empty
+ *    results — providers' contract is best-effort).
  */
 export async function rateLimitedFetch(
   providerType: string,
@@ -144,7 +241,16 @@ export async function rateLimitedFetch(
   const defaultBackoff = opts?.defaultBackoffSec ?? 60;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    const res = await fetch(url, init);
+    let res: Response;
+    try {
+      res = await fetch(url, init);
+    } catch (err) {
+      // Network error (DNS, TLS, ECONNRESET, timeout, …). Don't retry
+      // here — let the breaker decide if subsequent calls should be
+      // skipped wholesale.
+      recordFailure(providerType, `network: ${(err as Error).message}`);
+      return null;
+    }
 
     if (res.status === 429 || res.status === 423) {
       markRateLimited(providerType, res, defaultBackoff);
@@ -161,9 +267,39 @@ export async function rateLimitedFetch(
       return null;
     }
 
+    if (res.status >= 500) {
+      recordFailure(providerType, `http ${res.status}`);
+      return res;
+    }
+
+    // 2xx / 3xx / 4xx (other than 429/423): the request reached the
+    // provider, so the circuit is healthy. 4xx is the caller's problem,
+    // not the provider's.
+    recordSuccess(providerType);
     trackQuota(providerType, res);
     return res;
   }
 
   return null;
+}
+
+/**
+ * Wraps a non-fetch provider operation (auth call, manual `fetch` that
+ * predates `rateLimitedFetch`) so it participates in circuit-breaker
+ * state. Use when a provider has its own networking and we just want
+ * the failure-counting semantics.
+ */
+export async function withCircuitBreaker<T>(
+  providerType: string,
+  fn: () => Promise<T>,
+): Promise<T | null> {
+  if (isRateLimited(providerType)) return null;
+  try {
+    const result = await fn();
+    recordSuccess(providerType);
+    return result;
+  } catch (err) {
+    recordFailure(providerType, (err as Error).message);
+    throw err;
+  }
 }

--- a/backend/src/modules/subtitles/providers/subsynchro.provider.ts
+++ b/backend/src/modules/subtitles/providers/subsynchro.provider.ts
@@ -4,7 +4,9 @@ import {
   SubtitleSearchParams,
   SubtitleSearchResult,
 } from './subtitle-provider.interface';
+import { isRateLimited, rateLimitedFetch } from './rate-limiter';
 
+const PROVIDER_TYPE = 'subsynchro';
 const BASE_URL = 'https://www.subsynchro.com';
 const SEARCH_URL = `${BASE_URL}/include/ajax/subMarin.php`;
 const USER_AGENT = 'Fliks';
@@ -37,6 +39,8 @@ export class SubsynchroProvider implements SubtitleProviderInterface {
    * Based on Bazarr's implementation (subliminal_patch/providers/subsynchro.py).
    */
   async search(params: SubtitleSearchParams): Promise<SubtitleSearchResult[]> {
+    if (isRateLimited(PROVIDER_TYPE)) return [];
+
     // Subsynchro is movie-only — skip series
     if (params.season != null || params.episode != null) {
       return [];
@@ -46,16 +50,12 @@ export class SubsynchroProvider implements SubtitleProviderInterface {
     query.set('title', params.title);
     if (params.year) query.set('year', String(params.year));
 
-    let res: Response;
-    try {
-      res = await fetch(`${SEARCH_URL}?${query}`, {
-        headers: this.headers,
-      });
-    } catch (e) {
-      this.logger.warn(`Subsynchro search error: ${(e as Error).message}`);
-      return [];
-    }
-
+    const res = await rateLimitedFetch(
+      PROVIDER_TYPE,
+      `${SEARCH_URL}?${query}`,
+      { headers: this.headers },
+    );
+    if (!res) return [];
     if (!res.ok) {
       this.logger.warn(`Subsynchro search failed: ${res.status}`);
       return [];
@@ -99,9 +99,14 @@ export class SubsynchroProvider implements SubtitleProviderInterface {
       ? downloadUrl
       : `${BASE_URL}${downloadUrl.startsWith('/') ? '' : '/'}${downloadUrl}`;
 
-    const res = await fetch(url, { headers: this.headers });
-    if (!res.ok) {
-      throw new Error(`Subsynchro download failed: ${res.status}`);
+    if (isRateLimited(PROVIDER_TYPE)) {
+      throw new Error('Subsynchro is rate-limited, try again later');
+    }
+    const res = await rateLimitedFetch(PROVIDER_TYPE, url, {
+      headers: this.headers,
+    });
+    if (!res || !res.ok) {
+      throw new Error(`Subsynchro download failed: ${res?.status}`);
     }
 
     const buf = Buffer.from(await res.arrayBuffer());

--- a/backend/src/modules/subtitles/providers/supersubtitles.provider.ts
+++ b/backend/src/modules/subtitles/providers/supersubtitles.provider.ts
@@ -4,7 +4,9 @@ import {
   SubtitleSearchParams,
   SubtitleSearchResult,
 } from './subtitle-provider.interface';
+import { isRateLimited, rateLimitedFetch } from './rate-limiter';
 
+const PROVIDER_TYPE = 'supersubtitles';
 const BASE_URL = 'https://www.feliratok.eu';
 const REFERER = `${BASE_URL}/index.php`;
 
@@ -53,6 +55,8 @@ export class SupersubtitlesProvider implements SubtitleProviderInterface {
    * Based on Bazarr's implementation (subliminal_patch/providers/supersubtitles.py).
    */
   async search(params: SubtitleSearchParams): Promise<SubtitleSearchResult[]> {
+    if (isRateLimited(PROVIDER_TYPE)) return [];
+
     if (params.season != null && params.episode != null) {
       return this.searchEpisode(params);
     }
@@ -60,10 +64,15 @@ export class SupersubtitlesProvider implements SubtitleProviderInterface {
   }
 
   async download(result: SubtitleSearchResult): Promise<Buffer> {
+    if (isRateLimited(PROVIDER_TYPE)) {
+      throw new Error('Supersubtitles is rate-limited, try again later');
+    }
     const url = `${BASE_URL}/index.php?action=letolt&felirat=${result.providerFileId}`;
-    const res = await fetch(url, { headers: this.headers });
-    if (!res.ok) {
-      throw new Error(`Supersubtitles download failed: ${res.status}`);
+    const res = await rateLimitedFetch(PROVIDER_TYPE, url, {
+      headers: this.headers,
+    });
+    if (!res || !res.ok) {
+      throw new Error(`Supersubtitles download failed: ${res?.status}`);
     }
     return Buffer.from(await res.arrayBuffer());
   }
@@ -98,16 +107,10 @@ export class SupersubtitlesProvider implements SubtitleProviderInterface {
 
     // Step 2: Query subtitles for the specific episode
     const url = `${BASE_URL}/index.php?action=xbmc&sid=${seriesId}&ev=${params.season ?? 1}&rtol=${params.episode ?? 1}`;
-    let res: Response;
-    try {
-      res = await fetch(url, { headers: this.headers });
-    } catch (e) {
-      this.logger.warn(
-        `Supersubtitles episode search error: ${(e as Error).message}`,
-      );
-      return [];
-    }
-
+    const res = await rateLimitedFetch(PROVIDER_TYPE, url, {
+      headers: this.headers,
+    });
+    if (!res) return [];
     if (!res.ok) {
       this.logger.warn(`Supersubtitles episode search failed: ${res.status}`);
       return [];
@@ -151,18 +154,10 @@ export class SupersubtitlesProvider implements SubtitleProviderInterface {
    */
   private async lookupSeriesId(title: string): Promise<string | null> {
     const url = `${BASE_URL}/index.php?term=${encodeURIComponent(title)}&nyelv=0&action=autoname`;
-
-    let res: Response;
-    try {
-      res = await fetch(url, { headers: this.headers });
-    } catch (e) {
-      this.logger.warn(
-        `Supersubtitles series lookup error: ${(e as Error).message}`,
-      );
-      return null;
-    }
-
-    if (!res.ok) return null;
+    const res = await rateLimitedFetch(PROVIDER_TYPE, url, {
+      headers: this.headers,
+    });
+    if (!res || !res.ok) return null;
 
     const body = (await res.json()) as { name: string; ID: string }[];
     if (!Array.isArray(body) || !body.length) return null;
@@ -182,17 +177,10 @@ export class SupersubtitlesProvider implements SubtitleProviderInterface {
     params: SubtitleSearchParams,
   ): Promise<SubtitleSearchResult[]> {
     const url = `${BASE_URL}/index.php?search=${encodeURIComponent(params.title)}&soriSorszam=&nyelv=&tab=film`;
-
-    let res: Response;
-    try {
-      res = await fetch(url, { headers: this.headers });
-    } catch (e) {
-      this.logger.warn(
-        `Supersubtitles movie search error: ${(e as Error).message}`,
-      );
-      return [];
-    }
-
+    const res = await rateLimitedFetch(PROVIDER_TYPE, url, {
+      headers: this.headers,
+    });
+    if (!res) return [];
     if (!res.ok) {
       this.logger.warn(`Supersubtitles movie search failed: ${res.status}`);
       return [];

--- a/backend/src/modules/subtitles/providers/yify.provider.ts
+++ b/backend/src/modules/subtitles/providers/yify.provider.ts
@@ -5,7 +5,9 @@ import {
   SubtitleSearchResult,
 } from './subtitle-provider.interface';
 import { extractSubtitleFromZip } from './zip-utils';
+import { isRateLimited, rateLimitedFetch } from './rate-limiter';
 
+const PROVIDER_TYPE = 'yify';
 const BASE_URL = 'https://yifysubtitles.ch';
 const USER_AGENT =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36';
@@ -49,16 +51,18 @@ export class YifyProvider implements SubtitleProviderInterface {
   private readonly logger = new Logger(YifyProvider.name);
 
   async search(params: SubtitleSearchParams): Promise<SubtitleSearchResult[]> {
+    if (isRateLimited(PROVIDER_TYPE)) return [];
+
     // YIFY only supports movies, searched by IMDB ID
     if (!params.imdbId) return [];
     if (params.season != null) return [];
 
     const url = `${BASE_URL}/movie-imdb/${params.imdbId}`;
-    const res = await fetch(url, {
+    const res = await rateLimitedFetch(PROVIDER_TYPE, url, {
       headers: { 'User-Agent': USER_AGENT },
       redirect: 'manual',
     });
-
+    if (!res) return [];
     // 3xx or 404 = movie not found
     if (res.status >= 300) return [];
     if (!res.ok) {
@@ -73,13 +77,16 @@ export class YifyProvider implements SubtitleProviderInterface {
   }
 
   async download(result: SubtitleSearchResult): Promise<Buffer> {
+    if (isRateLimited(PROVIDER_TYPE)) {
+      throw new Error('YIFY is rate-limited, try again later');
+    }
     // providerFileId stores the subtitle page path (e.g. /subtitles/...)
     const pageUrl = `${BASE_URL}${result.providerFileId}`;
-    const pageRes = await fetch(pageUrl, {
+    const pageRes = await rateLimitedFetch(PROVIDER_TYPE, pageUrl, {
       headers: { 'User-Agent': USER_AGENT },
     });
-    if (!pageRes.ok)
-      throw new Error(`YIFY subtitle page failed: ${pageRes.status}`);
+    if (!pageRes || !pageRes.ok)
+      throw new Error(`YIFY subtitle page failed: ${pageRes?.status}`);
 
     const pageHtml = await pageRes.text();
     const dlMatch = pageHtml.match(
@@ -89,10 +96,11 @@ export class YifyProvider implements SubtitleProviderInterface {
       throw new Error('YIFY: download link not found on subtitle page');
 
     const dlUrl = `${BASE_URL}${dlMatch[1]}`;
-    const dlRes = await fetch(dlUrl, {
+    const dlRes = await rateLimitedFetch(PROVIDER_TYPE, dlUrl, {
       headers: { 'User-Agent': USER_AGENT },
     });
-    if (!dlRes.ok) throw new Error(`YIFY download failed: ${dlRes.status}`);
+    if (!dlRes || !dlRes.ok)
+      throw new Error(`YIFY download failed: ${dlRes?.status}`);
 
     const zipBuf = Buffer.from(await dlRes.arrayBuffer());
 


### PR DESCRIPTION
## Summary
The existing rate-limiter handled 429/423 cooldowns but treated every other failure (5xx, ECONNRESET, DNS error, timeout) as a normal miss. A subtitle provider that goes down — at least one usually is — still got hammered every 6h by the scheduler and slowed every pass.

- Adds a per-provider circuit breaker to the same module: \`consecutiveFailures\` counter, \`circuit\` state (\`closed\` / \`open\` / \`half-open\`), \`circuitResetAt\` timestamp.
- 3 consecutive non-429 failures → circuit OPENS for 5 minutes. \`rateLimitedFetch\` short-circuits to null while open. After cool-off the next call goes through as a probe (half-open); success closes the breaker, failure re-opens.
- Successful 2xx/3xx/4xx (non-429) resets the counter.
- \`getAllCooldowns\` now reports circuit state so an admin UI can show "Provider X skipped — 4min, 3 failures".
- Provider migration: gestdown, subsynchro, supersubtitles, yify now use \`rateLimitedFetch\` everywhere (search + download + auxiliary lookups). opensubtitles + subdl already did. Removed gestdown's custom 423 retry loop.

## Test plan
- [ ] Simulate a provider down (block via /etc/hosts) → after 3 search ticks the provider is skipped for 5 min.
- [ ] Provider comes back online → next half-open probe succeeds, circuit closes.
- [ ] OpenSubtitles 429 still backs off as before (rate-limit path unchanged).
- [ ] 3 new unit tests in \`rate-limiter.spec.ts\` pass.