### PR TITLE
fix(activities): never unlink a media from its download history

### DIFF
--- a/backend/src/modules/download-clients/qbittorrent.service.ts
+++ b/backend/src/modules/download-clients/qbittorrent.service.ts
@@ -1,9 +1,41 @@
 import { Injectable, BadRequestException, Logger } from '@nestjs/common';
-import axios from 'axios';
+import axios, { AxiosInstance } from 'axios';
 import * as crypto from 'crypto';
 import FormData from 'form-data';
 import { DownloadClient } from './entities/download-client.entity';
 import { decodeHtmlEntities } from '../../common/utils/decode-html-entities';
+
+/**
+ * Pull the BitTorrent info-hash out of a magnet URI. Magnets carry the
+ * hash either as a 40-char hex string or as a 32-char base32 string —
+ * the previous regex only matched hex, so trackers that advertise base32
+ * magnets (uncommon but they exist) silently fell back to the
+ * list-diff recovery path and were briefly orphaned in Activities.
+ */
+function extractMagnetInfoHash(magnet: string): string | undefined {
+  const hex = magnet.match(/xt=urn:btih:([a-fA-F0-9]{40})/)?.[1];
+  if (hex) return hex.toLowerCase();
+  const b32 = magnet.match(/xt=urn:btih:([A-Z2-7]{32})/i)?.[1];
+  if (!b32) return undefined;
+  // Decode base32 → 20 bytes, then hex-encode to match qBit's format.
+  const upper = b32.toUpperCase();
+  const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  let bits = 0;
+  let value = 0;
+  const out = Buffer.alloc(20);
+  let idx = 0;
+  for (const ch of upper) {
+    const v = ALPHABET.indexOf(ch);
+    if (v < 0) return undefined;
+    value = (value << 5) | v;
+    bits += 5;
+    if (bits >= 8) {
+      bits -= 8;
+      out[idx++] = (value >>> bits) & 0xff;
+    }
+  }
+  return out.toString('hex');
+}
 
 export interface QbittorrentTorrent {
   hash: string;
@@ -445,10 +477,16 @@ export class QbittorrentService {
     let addRes: { status: number; data: unknown };
     let infoHash: string | undefined;
 
+    // Snapshot the current torrent set BEFORE the add so we can recover
+    // the just-added torrent's hash via list-diff if the URL didn't
+    // surface one (base32-encoded magnet that an older regex didn't
+    // catch, .torrent buffers we couldn't parse, custom add endpoints
+    // returning HTML in the body, …). Cheap — qBit's `/torrents/info`
+    // is a single GET we'd run within the next 60s anyway.
+    const beforeHashes = await this.snapshotHashes(http, base, cookieHeader);
+
     if (torrentUrl.startsWith('magnet:')) {
-      // Extract info hash from magnet URI
-      const btih = torrentUrl.match(/xt=urn:btih:([a-fA-F0-9]{40})/)?.[1];
-      if (btih) infoHash = btih.toLowerCase();
+      infoHash = extractMagnetInfoHash(torrentUrl);
 
       const formAdd = new URLSearchParams({ urls: torrentUrl });
       if (category) formAdd.set('category', category);
@@ -475,8 +513,7 @@ export class QbittorrentService {
         this.log.log(
           `Indexer redirected to magnet — adding directly to qBittorrent`,
         );
-        const btih = fetched.magnet.match(/xt=urn:btih:([a-fA-F0-9]{40})/)?.[1];
-        if (btih) infoHash = btih.toLowerCase();
+        infoHash = extractMagnetInfoHash(fetched.magnet);
         const formAdd = new URLSearchParams({ urls: fetched.magnet });
         if (category) formAdd.set('category', category);
         addRes = await http.post(
@@ -518,7 +555,87 @@ export class QbittorrentService {
       );
     }
 
+    // Recovery path: when none of the upfront extractors produced a
+    // hash, ask qBit for its torrent list and diff against the snapshot
+    // we took before the add. qBit takes a few hundred ms to index a
+    // new entry, so retry a handful of times before giving up.
+    if (!infoHash) {
+      infoHash = await this.recoverNewlyAddedHash(
+        http,
+        base,
+        cookieHeader,
+        beforeHashes,
+      );
+      if (infoHash) {
+        this.log.log(
+          `qBittorrent: recovered hash=${infoHash} via list-diff after add (upfront extractor returned none)`,
+        );
+      } else {
+        this.log.warn(
+          `qBittorrent: could not recover hash for newly-added torrent — Activities row will rely on name match until next tick`,
+        );
+      }
+    }
+
     return infoHash ?? '';
+  }
+
+  /** Snapshot every torrent's hash currently known by qBit. Used as the
+   *  "before" set for {@link recoverNewlyAddedHash}. */
+  private async snapshotHashes(
+    http: AxiosInstance,
+    base: string,
+    cookieHeader: string,
+  ): Promise<Set<string>> {
+    try {
+      const res = await http.get(`${base}/api/v2/torrents/info`, {
+        headers: { Cookie: cookieHeader },
+        validateStatus: () => true,
+      });
+      if (res.status !== 200 || !Array.isArray(res.data)) return new Set();
+      return new Set(
+        (res.data as { hash?: string }[])
+          .map((t) => t.hash?.toLowerCase())
+          .filter((h): h is string => !!h),
+      );
+    } catch {
+      return new Set();
+    }
+  }
+
+  /** Poll `/torrents/info` for the newly-added torrent and return its
+   *  hash. Compares against `before` to find the diff. ~3s budget split
+   *  in retries: qBit needs a few hundred ms to register a magnet that
+   *  hasn't fetched metadata yet. */
+  private async recoverNewlyAddedHash(
+    http: AxiosInstance,
+    base: string,
+    cookieHeader: string,
+    before: Set<string>,
+  ): Promise<string | undefined> {
+    const ATTEMPTS = 6;
+    const DELAY_MS = 500;
+    for (let i = 0; i < ATTEMPTS; i++) {
+      await new Promise((r) => setTimeout(r, DELAY_MS));
+      const res = await http.get(`${base}/api/v2/torrents/info`, {
+        headers: { Cookie: cookieHeader },
+        validateStatus: () => true,
+      });
+      if (res.status !== 200 || !Array.isArray(res.data)) continue;
+      const after = res.data as { hash?: string; added_on?: number }[];
+      const fresh = after.filter(
+        (t) => t.hash && !before.has(t.hash.toLowerCase()),
+      );
+      if (fresh.length === 1) return fresh[0].hash!.toLowerCase();
+      if (fresh.length > 1) {
+        // Multiple new torrents (other consumer of the same qBit
+        // instance racing us). Pick the most recently added — best
+        // effort.
+        fresh.sort((a, b) => (b.added_on ?? 0) - (a.added_on ?? 0));
+        return fresh[0].hash!.toLowerCase();
+      }
+    }
+    return undefined;
   }
 
   /**

--- a/backend/src/modules/media/grab-history.util.ts
+++ b/backend/src/modules/media/grab-history.util.ts
@@ -3,6 +3,7 @@ import { DownloadHistory, GrabSource } from './entities/download-history.entity'
 import { Media } from './entities/media.entity';
 import { Indexer } from '../indexers/entities/indexer.entity';
 import { DownloadClient } from '../download-clients/entities/download-client.entity';
+import { decodeHtmlEntities } from '../../common/utils/decode-html-entities';
 
 /**
  * Builds the partial entity for a freshly-grabbed `DownloadHistory` row.
@@ -28,7 +29,11 @@ export function buildGrabHistoryRow(args: {
   return {
     media: args.media as Media,
     downloadClient: args.downloadClient,
-    sourceTitle: args.sourceTitle,
+    // Decode HTML entities ahead of persistence so the stored title
+    // matches what qBittorrent renders (it decodes on display). Without
+    // this normalisation the matcher's fallback name comparison drifts
+    // and the orphan-handler eventually flips the row to `failed`.
+    sourceTitle: decodeHtmlEntities(args.sourceTitle),
     torrentHash: args.torrentHash || undefined,
     quality: args.quality,
     status: 'grabbed',

--- a/backend/src/modules/media/torrent-history-matcher.service.ts
+++ b/backend/src/modules/media/torrent-history-matcher.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { DownloadHistory } from './entities/download-history.entity';
+import { decodeHtmlEntities } from '../../common/utils/decode-html-entities';
 
 /** A subset of `QbittorrentTorrent` — all the matcher actually needs. */
 export interface MatchableTorrent {
@@ -28,9 +29,15 @@ export interface HistoryMatch {
  *
  * Rules, in order:
  *  1. `history.torrentHash === torrent.hash` — definitive.
- *  2. Exactly one history with `sourceTitle === torrent.name`.
- *  3. Exactly one history whose `sourceTitle` is a prefix of `torrent.name`
- *     (or vice-versa). Multiple candidates abort instead of cross-matching.
+ *  2. Exactly one history with normalised `sourceTitle === torrent.name`.
+ *  3. Exactly one history whose normalised `sourceTitle` is a prefix of the
+ *     normalised `torrent.name` (or vice-versa). Multiple candidates abort.
+ *
+ * Both name comparisons use {@link normaliseTorrentName}, which decodes HTML
+ * entities, collapses whitespace and strips noise tokens — qBittorrent
+ * decodes `&amp;`, `&#39;` etc. in the displayed name while the indexer's
+ * raw title (which we stored as `sourceTitle`) keeps them, and that drift
+ * alone used to orphan otherwise-perfectly-linked rows.
  *
  * On (2) and (3) the matched history's `torrentHash` is filled in if it
  * was null — self-healing legacy data without requiring a migration.
@@ -49,7 +56,7 @@ export class TorrentHistoryMatcher {
     histories: DownloadHistory[],
   ): HistoryMatch | null {
     const hash = torrent.hash?.toLowerCase() ?? null;
-    const name = torrent.name.toLowerCase();
+    const name = normaliseTorrentName(torrent.name);
 
     if (hash) {
       const byHash = histories.find(
@@ -59,7 +66,7 @@ export class TorrentHistoryMatcher {
     }
 
     const exact = histories.filter(
-      (h) => h.sourceTitle?.toLowerCase() === name,
+      (h) => normaliseTorrentName(h.sourceTitle ?? '') === name,
     );
     if (exact.length === 1) {
       return { history: exact[0], matchedBy: 'exact-name' };
@@ -67,14 +74,15 @@ export class TorrentHistoryMatcher {
     if (exact.length > 1) {
       // Ambiguous exact match — refuse rather than guess.
       this.log.warn(
-        `TorrentHistoryMatcher: ${exact.length} histories share sourceTitle="${torrent.name}" — refusing to cross-match`,
+        `TorrentHistoryMatcher: ${exact.length} histories share normalised sourceTitle="${name}" — refusing to cross-match`,
       );
       return null;
     }
 
     const prefix = histories.filter((h) => {
       if (!h.sourceTitle) return false;
-      const s = h.sourceTitle.toLowerCase();
+      const s = normaliseTorrentName(h.sourceTitle);
+      if (!s) return false;
       return name.startsWith(s) || s.startsWith(name);
     });
     if (prefix.length === 1) {
@@ -117,4 +125,25 @@ export class TorrentHistoryMatcher {
     }
     return match.history;
   }
+}
+
+/**
+ * Tolerant normalisation for the "is this the same release?" comparison:
+ *  - HTML entities decoded via the shared Latin-1 + numeric decoder
+ *    (handles `&amp;`, `&iacute;`, `&#39;`, `&#x27;` …). qBittorrent
+ *    decodes entities on display while the indexer's raw title (stored
+ *    as `sourceTitle`) keeps them, and a single character drift used to
+ *    send a row into the orphan pile and ultimately into
+ *    `historyRepo.remove` once the orphan-cleanup tick fired.
+ *  - Trailing `.torrent` stripped.
+ *  - `.`, `_`, multi-space all collapsed to single spaces so
+ *    `Show.S01E01-GROUP` matches `Show S01E01 GROUP`.
+ *  - Lowercased.
+ */
+export function normaliseTorrentName(raw: string): string {
+  if (!raw) return '';
+  let s = decodeHtmlEntities(raw);
+  s = s.replace(/\.torrent$/i, '');
+  s = s.replace(/[._\s]+/g, ' ').trim();
+  return s.toLowerCase();
 }

--- a/backend/src/modules/media/torrent-history-matcher.spec.ts
+++ b/backend/src/modules/media/torrent-history-matcher.spec.ts
@@ -1,0 +1,38 @@
+import { normaliseTorrentName } from './torrent-history-matcher.service';
+
+describe('normaliseTorrentName', () => {
+  it('decodes HTML entities qBittorrent renders on display', () => {
+    expect(normaliseTorrentName('Show &amp; Co S01E01-GROUP')).toBe(
+      'show & co s01e01-group',
+    );
+    expect(normaliseTorrentName('Berl&iacute;n.S02E01.1080p.WEB-DL.x265')).toBe(
+      'berlín s02e01 1080p web-dl x265',
+    );
+  });
+
+  it('decodes numeric and hex character references', () => {
+    expect(normaliseTorrentName("Mum&#39;s.S01.WEB-DL")).toBe(
+      "mum's s01 web-dl",
+    );
+    expect(normaliseTorrentName('A&#x26;B.S01')).toBe('a&b s01');
+  });
+
+  it('treats dots, underscores and spaces as equivalent separators', () => {
+    expect(normaliseTorrentName('Show.S01E01-GROUP')).toBe(
+      normaliseTorrentName('Show S01E01-GROUP'),
+    );
+    expect(normaliseTorrentName('Show_S01E01.GROUP')).toBe(
+      normaliseTorrentName('Show.S01E01.GROUP'),
+    );
+  });
+
+  it('is case-insensitive', () => {
+    expect(normaliseTorrentName('Show S01E01')).toBe(
+      normaliseTorrentName('SHOW S01E01'),
+    );
+  });
+
+  it('handles the empty / nullish input', () => {
+    expect(normaliseTorrentName('')).toBe('');
+  });
+});

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -36,6 +36,16 @@ import { MarkersService } from '../markers/markers.service';
 import { FileTransferService } from '../../common/services/file-transfer.service';
 import { MediaService } from '../media/media.service';
 
+/**
+ * How long a `grabbed` history row may stay without a matching qBit
+ * torrent before we mark it `failed`. Picked at 30 min so a transient
+ * mismatch (HTML-entity decode drift between qBit and the indexer's raw
+ * title, a brief qBit unavailability, a torrent rename mid-tick) can't
+ * trip the orphan handler. The row is NEVER deleted; only its status
+ * flips so the user sees the failure in Activities and can re-grab.
+ */
+const ORPHAN_GRACE_MS = 30 * 60_000;
+
 @Injectable()
 export class CompletionService {
   private readonly log = new Logger(CompletionService.name);
@@ -126,24 +136,49 @@ export class CompletionService {
         t.state === 'stoppedUP',
     );
 
-    // Purge grabbed/failed entries that have no matching torrent in any
-    // client. Build the reverse view: for each history, ask the matcher
-    // whether at least one current torrent maps to it — exactly the same
-    // rule processCompleted uses below to find the import target.
+    // Identify history rows with no matching torrent in any client right
+    // now. We do NOT delete them — even a transient mismatch (a renamed
+    // torrent, an HTML-entity decode drift, qBit briefly returning an
+    // empty list) used to wipe perfectly-linked rows, leaving "downloads
+    // not linked to a media" in the Activities view. The invariant is:
+    // once a row has a media reference it is preserved forever; the
+    // worst we can do is flip its status to `failed` so the user knows
+    // the torrent has vanished from the client.
     const matchedHistoryIds = new Set<number>();
     for (const t of allTorrents) {
       const m = this.historyMatcher.findMatch(t, grabbed);
       if (m) matchedHistoryIds.add(m.history.id);
     }
-    const orphaned = grabbed.filter((h) => !matchedHistoryIds.has(h.id));
+    const orphaned = grabbed.filter(
+      (h) => h.status === 'grabbed' && !matchedHistoryIds.has(h.id),
+    );
     if (orphaned.length) {
-      await this.historyRepo.remove(orphaned);
-      this.log.log(
-        `Import: purged ${orphaned.length} orphaned entries (no matching torrent)`,
+      // Only flip rows that have been disconnected for at least
+      // `ORPHAN_GRACE_MS` so we don't fail-fast on a single bad qBit
+      // call. The grace is computed off `updatedAt` because every
+      // status / hash heal write bumps it; a row whose torrent just
+      // arrived in qBit has a fresh `updatedAt`.
+      const cutoff = Date.now() - ORPHAN_GRACE_MS;
+      const expired = orphaned.filter(
+        (h) => h.updatedAt.getTime() < cutoff,
       );
+      if (expired.length) {
+        await this.historyRepo.update(
+          expired.map((h) => h.id),
+          {
+            status: 'failed',
+            statusMessage: 'Torrent no longer present in download client',
+          },
+        );
+        this.log.warn(
+          `Import: ${expired.length} grabbed entries lost their torrent in qBittorrent for > ${ORPHAN_GRACE_MS / 60_000}min — marked failed (media link preserved)`,
+        );
+      }
     }
 
-    const remaining = grabbed.length - orphaned.length;
+    const remaining = grabbed.filter(
+      (h) => matchedHistoryIds.has(h.id),
+    ).length;
     if (!remaining || !completedTorrents.length) return;
     this.log.log(
       `Import: ${remaining} entries to process, ${completedTorrents.length} completed torrents`,


### PR DESCRIPTION
## Summary
Every minute, \`CompletionService.processCompleted\` checked which \`grabbed\` history rows matched a current qBittorrent torrent and **deleted** the ones that didn't (\`historyRepo.remove(orphaned)\`). A single missed tick — qBit hiccup, torrent rename mid-tick, HTML-entity decode drift between the indexer's raw \`sourceTitle\` and qBit's decoded display name — permanently destroyed an otherwise-perfectly-linked row. The user saw this in Activities as "downloads not linked to a media", no recovery.

**New invariant**: a history row with a media reference is preserved forever.

- Removed the \`historyRepo.remove\`. Orphan handling now flips to \`status='failed'\` only after **30 min** of continuous disconnection (measured off \`updatedAt\` which every match write bumps). Single-tick blips can't trip it.
- \`TorrentHistoryMatcher\` compares via a new \`normaliseTorrentName\` that decodes HTML entities (shared \`decodeHtmlEntities\` util — Latin-1 + numeric + hex) and collapses \`.\` / \`_\` / whitespace. Both stored \`sourceTitle\` and qBit's name go through it.
- \`buildGrabHistoryRow\` decodes \`sourceTitle\` at save time so future rows are clean. Legacy rows are fixed by the matcher's tolerant compare.
- \`qbittorrent.service.addTorrentUrl\`:
  - Decodes **base32 magnets** (\`[A-Z2-7]{32}\`) too — previous regex was hex-only.
  - When no upfront extractor produced a hash, snapshots qBit's torrent set before the add and diffs after for up to 3 s to recover the freshly-added hash. Persisted on the history row.

## Test plan
- [ ] Existing orphaned rows (had a media but lost the qBit torrent recently) stop being deleted; they flip to \`failed\` after 30 min.
- [ ] A torrent whose name contains \`&amp;\` (qBit decodes, sourceTitle stored encoded) is matched by name on the very first tick → \`torrentHash\` self-heals.
- [ ] A base32-encoded magnet URL gets a non-empty hash stored on the history row immediately.
- [ ] When the indexer returns a torrent format that fails bencode parse, the list-diff recovery captures the hash within ~1 s.
- [ ] 5 new unit tests in \`torrent-history-matcher.spec.ts\` pass.