### PR TITLE
feat(activities): auto-match orphan torrents + episode/season FKs

### DIFF
--- a/backend/src/migrations/1779400000000-add-download-history-episode-season.ts
+++ b/backend/src/migrations/1779400000000-add-download-history-episode-season.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddDownloadHistoryEpisodeSeason1779400000000
+  implements MigrationInterface
+{
+  name = 'AddDownloadHistoryEpisodeSeason1779400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "download_history"
+        ADD COLUMN IF NOT EXISTS "episodeId" int,
+        ADD COLUMN IF NOT EXISTS "seasonId" int
+    `);
+    // SET NULL on delete so a removed episode/season doesn't erase the
+    // history row — the media link must be preserved at all costs
+    // (see the "never unlink" invariant in completion.service).
+    await queryRunner.query(`
+      ALTER TABLE "download_history"
+        ADD CONSTRAINT "FK_download_history_episode"
+        FOREIGN KEY ("episodeId") REFERENCES "episodes"("id")
+        ON DELETE SET NULL
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "download_history"
+        ADD CONSTRAINT "FK_download_history_season"
+        FOREIGN KEY ("seasonId") REFERENCES "seasons"("id")
+        ON DELETE SET NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "download_history"
+        DROP CONSTRAINT IF EXISTS "FK_download_history_season",
+        DROP CONSTRAINT IF EXISTS "FK_download_history_episode",
+        DROP COLUMN IF EXISTS "seasonId",
+        DROP COLUMN IF EXISTS "episodeId"
+    `);
+  }
+}

--- a/backend/src/modules/download-clients/download-clients.service.ts
+++ b/backend/src/modules/download-clients/download-clients.service.ts
@@ -16,6 +16,14 @@ export interface QueueEntry extends QbittorrentTorrent {
   mediaId?: number;
   mediaTitle?: string;
   mediaType?: 'movie' | 'series';
+  /** Resolved season (single-episode grabs include the parent season,
+   *  season packs include just this). */
+  seasonNumber?: number;
+  /** Resolved episode (single-episode grabs only — packs leave it
+   *  unset). */
+  episodeNumber?: number;
+  /** Episode title where known. */
+  episodeTitle?: string | null;
   /** Indexer the torrent was grabbed from (resolved through DownloadHistory). */
   indexerName?: string;
   /** Download client status (Downloading, Seeding, Paused, Stalled…) */
@@ -246,7 +254,7 @@ export class DownloadClientsService {
         { status: 'completed' },
         { status: 'warning' },
       ],
-      relations: ['media', 'indexer'],
+      relations: ['media', 'indexer', 'episode', 'season'],
     });
 
     for (const entry of results) {
@@ -261,6 +269,17 @@ export class DownloadClientsService {
       }
       if (match?.indexer) {
         entry.indexerName = match.indexer.name;
+      }
+      // Surface the resolved season / episode so the Activities row can
+      // render "Show — S01E03" or "Show — Saison 1" without joining
+      // back through the files. Single-episode grabs always include
+      // both fields; season packs include only `seasonNumber`.
+      if (match?.episode) {
+        entry.episodeNumber = match.episode.episodeNumber;
+        entry.episodeTitle = match.episode.title ?? null;
+      }
+      if (match?.season) {
+        entry.seasonNumber = match.season.seasonNumber;
       }
 
       // App-level status from history

--- a/backend/src/modules/media/auto-grab-pipeline.service.ts
+++ b/backend/src/modules/media/auto-grab-pipeline.service.ts
@@ -157,6 +157,12 @@ export class AutoGrabPipelineService {
      *  the lifecycle hook can flip only the matching per-season
      *  requests. Whole-series and movie grabs pass undefined. */
     seasonNumber?: number;
+    /** Season + episode primary keys — persisted on the
+     *  `DownloadHistory` row so Activities can show "Show — S01E03"
+     *  for a single-episode grab without joining back through the
+     *  files at import time. */
+    seasonId?: number;
+    episodeId?: number;
   }): Promise<boolean> {
     const logSkip = (reason: string): void =>
       this.log.log(
@@ -230,6 +236,8 @@ export class AutoGrabPipelineService {
       mediaType: args.mediaType,
       label: args.label,
       seasonNumber: args.seasonNumber,
+      seasonId: args.seasonId,
+      episodeId: args.episodeId,
     });
   }
 
@@ -251,6 +259,9 @@ export class AutoGrabPipelineService {
      *  `APPROVED → PROCESSING` transition. Omit for whole-series and
      *  movie grabs. */
     seasonNumber?: number;
+    /** Season + episode primary keys to persist on the history row. */
+    seasonId?: number;
+    episodeId?: number;
   }): Promise<boolean> {
     try {
       this.log.log(
@@ -271,6 +282,8 @@ export class AutoGrabPipelineService {
             quality: this.naming.parseQuality(args.pick.title),
             grabSource: 'auto',
             indexerId: args.pick.indexerId,
+            seasonId: args.seasonId,
+            episodeId: args.episodeId,
           }),
         ),
       );

--- a/backend/src/modules/media/entities/download-history.entity.ts
+++ b/backend/src/modules/media/entities/download-history.entity.ts
@@ -1,6 +1,8 @@
 import { Entity, Column, ManyToOne, JoinColumn, RelationId } from 'typeorm';
 import { BaseEntity } from '../../../common/entities/base.entity';
 import { Media } from './media.entity';
+import { Episode } from './episode.entity';
+import { Season } from './season.entity';
 import { Indexer } from '../../indexers/entities/indexer.entity';
 import { DownloadClient } from '../../download-clients/entities/download-client.entity';
 
@@ -25,6 +27,34 @@ export class DownloadHistory extends BaseEntity {
 
   @RelationId((dh: DownloadHistory) => dh.media)
   mediaId: number;
+
+  /**
+   * Optional episode link. Set when the grabbed/auto-matched torrent
+   * targets a single episode (\`Show.S01E03\`). Null for season packs,
+   * movies, and torrents whose name didn't surface a specific episode.
+   * SET NULL on delete so a removed episode doesn't take the history
+   * row with it (the media reference must survive — see the "never
+   * unlink" invariant).
+   */
+  @ManyToOne(() => Episode, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'episodeId' })
+  episode: Episode | null;
+
+  @RelationId((dh: DownloadHistory) => dh.episode)
+  episodeId: number | null;
+
+  /**
+   * Optional season link. Set when the grabbed/auto-matched torrent
+   * targets a whole season (\`Show.S01\`) or a single episode (in
+   * which case the season is the episode's parent — stored for direct
+   * lookup so the UI doesn't need a JOIN).
+   */
+  @ManyToOne(() => Season, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'seasonId' })
+  season: Season | null;
+
+  @RelationId((dh: DownloadHistory) => dh.season)
+  seasonId: number | null;
 
   @ManyToOne(() => Indexer, { nullable: true, onDelete: 'SET NULL' })
   @JoinColumn({ name: 'indexerId' })

--- a/backend/src/modules/media/episode-download.service.ts
+++ b/backend/src/modules/media/episode-download.service.ts
@@ -331,6 +331,8 @@ export class EpisodeDownloadService {
           quality: parsed.quality.name,
           grabSource,
           indexerId,
+          episodeId: episode.id,
+          seasonId: season.id,
         }),
       ),
     );
@@ -594,6 +596,7 @@ export class EpisodeDownloadService {
             quality: parsed.quality.name,
             grabSource: 'manual',
             indexerId: dto?.indexerId,
+            seasonId: season.id,
           }),
         ),
       );
@@ -689,6 +692,7 @@ export class EpisodeDownloadService {
             quality: bestPack.qualityName,
             grabSource: 'auto',
             indexerId: bestPack.indexerId,
+            seasonId: season.id,
           }),
         ),
       );
@@ -793,6 +797,8 @@ export class EpisodeDownloadService {
               quality: pick.qualityName,
               grabSource: 'auto',
               indexerId: pick.indexerId,
+              episodeId: ep.id,
+              seasonId: season.id,
             }),
           ),
         );

--- a/backend/src/modules/media/grab-history.util.ts
+++ b/backend/src/modules/media/grab-history.util.ts
@@ -1,6 +1,8 @@
 import { DeepPartial } from 'typeorm';
 import { DownloadHistory, GrabSource } from './entities/download-history.entity';
 import { Media } from './entities/media.entity';
+import { Episode } from './entities/episode.entity';
+import { Season } from './entities/season.entity';
 import { Indexer } from '../indexers/entities/indexer.entity';
 import { DownloadClient } from '../download-clients/entities/download-client.entity';
 import { decodeHtmlEntities } from '../../common/utils/decode-html-entities';
@@ -25,6 +27,14 @@ export function buildGrabHistoryRow(args: {
   quality: string;
   grabSource: GrabSource;
   indexerId?: number | null;
+  /** Optional episode link — set for single-episode grabs / matches.
+   *  Null for season packs, movies, or when the episode hasn't been
+   *  identified yet. */
+  episodeId?: number | null;
+  /** Optional season link — set for season packs and single-episode
+   *  grabs (the episode's parent season). Null for movies and
+   *  unidentified series torrents. */
+  seasonId?: number | null;
 }): DeepPartial<DownloadHistory> {
   return {
     media: args.media as Media,
@@ -40,5 +50,9 @@ export function buildGrabHistoryRow(args: {
     grabSource: args.grabSource,
     indexer:
       args.indexerId != null ? ({ id: args.indexerId } as Indexer) : null,
+    episode:
+      args.episodeId != null ? ({ id: args.episodeId } as Episode) : null,
+    season:
+      args.seasonId != null ? ({ id: args.seasonId } as Season) : null,
   };
 }

--- a/backend/src/modules/media/media.module.ts
+++ b/backend/src/modules/media/media.module.ts
@@ -24,6 +24,7 @@ import { MediaServersModule } from '../media-servers/media-servers.module';
 import { MovieDownloadService } from './movie-download.service';
 import { EpisodeDownloadService } from './episode-download.service';
 import { AutoGrabPipelineService } from './auto-grab-pipeline.service';
+import { TorrentAutoMatcher } from './torrent-auto-matcher.service';
 import { NamingService } from '../scheduler/naming.service';
 import { MediaImportService } from './media-service/media-import.service';
 import { MediaMetadataService } from './media-service/media-metadata.service';
@@ -76,8 +77,9 @@ import { StreamingModule } from '../streaming/streaming.module';
     MovieDownloadService,
     EpisodeDownloadService,
     AutoGrabPipelineService,
+    TorrentAutoMatcher,
     NamingService,
   ],
-  exports: [MediaService, AutoGrabPipelineService],
+  exports: [MediaService, AutoGrabPipelineService, TorrentAutoMatcher],
 })
 export class MediaModule {}

--- a/backend/src/modules/media/torrent-auto-matcher.service.ts
+++ b/backend/src/modules/media/torrent-auto-matcher.service.ts
@@ -1,0 +1,174 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, ILike } from 'typeorm';
+import { Media } from './entities/media.entity';
+import { Season } from './entities/season.entity';
+import { Episode } from './entities/episode.entity';
+import { MediaType } from '../../common/enums';
+import {
+  ExtractedRelease,
+  extractMediaTitle,
+} from '../../common/release-parsing';
+
+export interface AutoMatchResult {
+  media: Media;
+  season?: Season | null;
+  episode?: Episode | null;
+  /**
+   * Reason the match succeeded. `'series-episode'` for single episodes,
+   * `'series-season'` for season packs, `'movie'` for movies. Useful in
+   * logs and for the caller to decide which row shape to persist.
+   */
+  matchedKind: 'series-episode' | 'series-season' | 'movie';
+}
+
+/**
+ * Identifies a `Media` (and where possible a `Season` + `Episode`) from
+ * a raw torrent / file name, without going through `DownloadHistory`.
+ *
+ * Used by the orphan-torrent recovery flow in `CompletionService` so a
+ * torrent appearing in qBit with no history row (added manually, hand-
+ * imported from another tool, or surviving a database wipe) gets
+ * bound back to its media automatically — instead of staying invisible
+ * to the rest of the system forever.
+ *
+ * Algorithm:
+ *   1. {@link extractMediaTitle} extracts \`{ searchKey, year, season,
+ *      episode, kind }\` from the name.
+ *   2. \`searchKey\` is normalised alphanumerics-only — we query the
+ *      DB with the SAME normalisation on the candidate titles so dot /
+ *      space / punctuation drift doesn't kill the lookup.
+ *   3. Series path: load monitored series whose normalised title or
+ *      \`alternativeTitles\` entry matches. If multiple → ambiguous,
+ *      give up (the user can manually link). If one + the release
+ *      carries a season number, walk the seasons + episodes to bind.
+ *   4. Movie path: same name lookup scoped to \`type=movie\`. The year
+ *      acts as a tiebreaker when several candidates share a title.
+ *
+ * Returns null on any ambiguity — the orphan recovery flow then leaves
+ * the torrent unlinked and surfaces it for manual binding.
+ */
+@Injectable()
+export class TorrentAutoMatcher {
+  private readonly log = new Logger(TorrentAutoMatcher.name);
+
+  constructor(
+    @InjectRepository(Media)
+    private readonly mediaRepo: Repository<Media>,
+    @InjectRepository(Season)
+    private readonly seasonRepo: Repository<Season>,
+    @InjectRepository(Episode)
+    private readonly episodeRepo: Repository<Episode>,
+  ) {}
+
+  async tryMatch(torrentName: string): Promise<AutoMatchResult | null> {
+    if (!torrentName) return null;
+    const parsed = extractMediaTitle(torrentName);
+    if (!parsed.searchKey) return null;
+
+    if (parsed.kind === 'series' || parsed.season !== null) {
+      return this.matchSeries(parsed);
+    }
+    if (parsed.kind === 'movie' || parsed.year !== null) {
+      return this.matchMovie(parsed);
+    }
+    // Last-ditch: try series first then movie. Some malformed names
+    // ("Some Show Disc 1") have no S/E and no year — they're rare and
+    // not worth a separate codepath.
+    return (
+      (await this.matchSeries(parsed)) ?? (await this.matchMovie(parsed))
+    );
+  }
+
+  private async matchSeries(
+    parsed: ExtractedRelease,
+  ): Promise<AutoMatchResult | null> {
+    const series = await this.lookupMedia(parsed, MediaType.SERIES);
+    if (!series) return null;
+
+    // Bind season if the release carries one and the series has it.
+    if (parsed.season === null) {
+      return { media: series, matchedKind: 'series-season' };
+    }
+    const season = await this.seasonRepo.findOne({
+      where: { media: { id: series.id }, seasonNumber: parsed.season },
+    });
+    if (!season) {
+      // The series matches but the season number doesn't exist on it
+      // — likely a different series sharing the title. Bail rather
+      // than associate against the wrong one.
+      this.log.debug?.(
+        `TorrentAutoMatcher: series "${series.title}" matched but has no season ${parsed.season} — refusing`,
+      );
+      return null;
+    }
+
+    // Season pack vs single episode.
+    if (parsed.isFullSeason || parsed.episode === null) {
+      return { media: series, season, matchedKind: 'series-season' };
+    }
+    const episode = await this.episodeRepo.findOne({
+      where: {
+        season: { id: season.id },
+        episodeNumber: parsed.episode,
+      },
+    });
+    if (!episode) {
+      // Episode number out of range — same caution as above. Fall back
+      // to season-only binding so the row still carries useful info.
+      return { media: series, season, matchedKind: 'series-season' };
+    }
+    return {
+      media: series,
+      season,
+      episode,
+      matchedKind: 'series-episode',
+    };
+  }
+
+  private async matchMovie(
+    parsed: ExtractedRelease,
+  ): Promise<AutoMatchResult | null> {
+    const movie = await this.lookupMedia(parsed, MediaType.MOVIE);
+    return movie ? { media: movie, matchedKind: 'movie' } : null;
+  }
+
+  /**
+   * Title-based media lookup. Loads candidates by case-insensitive
+   * substring on `title`, then narrows in-memory using the alphanumeric
+   * `searchKey` and (optional) year. Ambiguity → null.
+   */
+  private async lookupMedia(
+    parsed: ExtractedRelease,
+    type: MediaType,
+  ): Promise<Media | null> {
+    // Loose SQL filter to keep the candidate set small. We refine in JS
+    // using `searchKey` which is normalisation-tolerant.
+    const titleLike = parsed.title || parsed.searchKey;
+    if (!titleLike) return null;
+    const candidates = await this.mediaRepo.find({
+      where: { type, title: ILike(`%${titleLike}%`) },
+      take: 50,
+    });
+
+    const matching = candidates.filter((m) => {
+      const norm = (s: string | undefined | null): string =>
+        (s ?? '').toLowerCase().replace(/[^a-z0-9]+/g, '');
+      const candidateKeys = [norm(m.title), ...(m.alternativeTitles ?? []).map(norm)];
+      return candidateKeys.includes(parsed.searchKey);
+    });
+
+    if (matching.length === 0) return null;
+    if (matching.length === 1) return matching[0];
+
+    // Multiple candidates — the year is our only tiebreaker.
+    if (parsed.year !== null) {
+      const byYear = matching.filter((m) => m.year === parsed.year);
+      if (byYear.length === 1) return byYear[0];
+    }
+    this.log.warn(
+      `TorrentAutoMatcher: ${matching.length} ${type} candidates for "${parsed.title}"${parsed.year ? ` (${parsed.year})` : ''} — refusing to guess`,
+    );
+    return null;
+  }
+}

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -32,6 +32,9 @@ import { StalledCheck } from './entities/stalled-check.entity';
 import { CleanupProfile } from '../cleanup-profiles/entities/cleanup-profile.entity';
 import { Library } from '../libraries/entities/library.entity';
 import { TorrentHistoryMatcher } from '../media/torrent-history-matcher.service';
+import { TorrentAutoMatcher } from '../media/torrent-auto-matcher.service';
+import { buildGrabHistoryRow } from '../media/grab-history.util';
+import { parseReleaseQuality } from '../../common/release-parsing';
 import { MarkersService } from '../markers/markers.service';
 import { FileTransferService } from '../../common/services/file-transfer.service';
 import { MediaService } from '../media/media.service';
@@ -83,6 +86,7 @@ export class CompletionService {
     private readonly ffprobe: FfprobeService,
     private readonly thumbnailService: ThumbnailService,
     private readonly historyMatcher: TorrentHistoryMatcher,
+    private readonly autoMatcher: TorrentAutoMatcher,
     private readonly fileTransfer: FileTransferService,
     private readonly markers: MarkersService,
     @Inject(forwardRef(() => MediaService))
@@ -99,6 +103,92 @@ export class CompletionService {
    */
   private autoDetectMarkersOnImport(): boolean {
     return true;
+  }
+
+  /**
+   * For every torrent currently in qBit that has no corresponding
+   * `DownloadHistory` row (matched neither by hash nor by sourceTitle
+   * fallback), attempt to identify its media via
+   * {@link TorrentAutoMatcher} and create a fresh history row.
+   *
+   * Mutates `grabbed` in place to include any newly-created rows so
+   * the caller's downstream loops treat them like normal grab rows.
+   *
+   * Skips torrents whose hash is already referenced by ANY history row
+   * (including `completed` / `imported`) to avoid duplicating rows for
+   * torrents we've already processed.
+   */
+  private async autoMatchOrphanTorrents(
+    allTorrents: ReadonlyArray<
+      QbittorrentTorrent & { _clientId: number; _client: DownloadClient }
+    >,
+    grabbed: DownloadHistory[],
+  ): Promise<void> {
+    if (!allTorrents.length) return;
+
+    // Single SQL trip to collect every hash we've ever seen — avoids
+    // matching the same torrent again on every tick. Filter `null`
+    // hashes (legacy rows pre-PR-#82).
+    const allHashRows: { hash: string }[] = await this.historyRepo
+      .createQueryBuilder('h')
+      .select('LOWER(h.torrentHash)', 'hash')
+      .where('h.torrentHash IS NOT NULL')
+      .getRawMany();
+    const knownHashes = new Set(allHashRows.map((r) => r.hash));
+
+    const candidates = allTorrents.filter(
+      (t) => t.hash && !knownHashes.has(t.hash.toLowerCase()),
+    );
+    if (!candidates.length) return;
+
+    for (const torrent of candidates) {
+      // Cheap belt-and-braces check: a stale name fallback could
+      // legitimately point at one of the existing grabbed rows even
+      // when the hash isn't recorded. Skip the auto-match in that case
+      // and let `matchAndHeal` write the hash on the next pass.
+      if (this.historyMatcher.findMatch(torrent, grabbed)) continue;
+
+      let match;
+      try {
+        match = await this.autoMatcher.tryMatch(torrent.name);
+      } catch (err) {
+        this.log.warn(
+          `Auto-match: tryMatch threw on "${torrent.name}": ${(err as Error).message}`,
+        );
+        continue;
+      }
+      if (!match) continue;
+
+      const quality = parseReleaseQuality(torrent.name).quality.name;
+      const row = await this.historyRepo.save(
+        this.historyRepo.create(
+          buildGrabHistoryRow({
+            media: match.media,
+            downloadClient: torrent._client,
+            sourceTitle: torrent.name,
+            torrentHash: torrent.hash,
+            quality,
+            // Auto-matched orphans look closer to a manual add (the
+            // user put the torrent in qBit, we just figured out which
+            // media it belongs to) than to a scheduler auto-grab.
+            grabSource: 'manual',
+            episodeId: match.episode?.id ?? null,
+            seasonId:
+              match.season?.id ?? match.episode?.season?.id ?? null,
+          }),
+        ),
+      );
+      grabbed.push(row);
+
+      const epLabel = match.episode
+        ? ` ${match.season ? `S${String(match.season.seasonNumber).padStart(2, '0')}` : ''}E${String(match.episode.episodeNumber).padStart(2, '0')}`
+        : match.season
+          ? ` Season ${match.season.seasonNumber}`
+          : '';
+      this.log.log(
+        `Auto-match: bound torrent "${torrent.name}" → ${match.media.title}${epLabel} (history #${row.id})`,
+      );
+    }
   }
 
   @Cron(CronExpression.EVERY_MINUTE)
@@ -135,6 +225,16 @@ export class CompletionService {
         t.state === 'stalledUP' ||
         t.state === 'stoppedUP',
     );
+
+    // Auto-match orphan torrents — anything in qBit with no existing
+    // history row (manually added by the user, surviving a DB wipe,
+    // imported from another tool …) gets identified by name via the
+    // shared release parsers + DB lookup, then bound to its media
+    // through a freshly-created history row. New rows are appended to
+    // `grabbed` so the orphan-status check below sees them as matched
+    // and the rest of the import flow handles them like any normal
+    // grab.
+    await this.autoMatchOrphanTorrents(allTorrents, grabbed);
 
     // Identify history rows with no matching torrent in any client right
     // now. We do NOT delete them — even a transient mismatch (a renamed

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -634,6 +634,8 @@ export class SchedulerService implements OnModuleInit {
         // Episodes are typically 20-60 min; 30 min fallback for size check.
         runtimeMinutes: media.runtime ?? 30,
         seasonNumber: season.seasonNumber,
+        seasonId: season.id,
+        episodeId: ep.id,
         pendingCheck: async () => {
           const pending = await this.historyRepo
             .createQueryBuilder('h')

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -802,6 +802,7 @@
     "confirm_delete_with_files": "Supprimer ce torrent et ses fichiers téléchargés ?",
     "link_media": "Associer à un média",
     "link_search_placeholder": "Rechercher un film ou une série…",
+    "season_pack": "Saison {{season}} (pack)",
     "link_no_results": "Aucun résultat dans la bibliothèque.",
     "link_confirm": "Associer",
     "queue_empty": "Aucun téléchargement actif.",

--- a/client/src/app/core/services/api/download-clients-api.service.ts
+++ b/client/src/app/core/services/api/download-clients-api.service.ts
@@ -58,6 +58,9 @@ export interface QueueItem {
   mediaId?: number;
   mediaTitle?: string;
   mediaType?: MediaType;
+  seasonNumber?: number;
+  episodeNumber?: number;
+  episodeTitle?: string | null;
   indexerName?: string;
   statusMessage?: string;
 }

--- a/client/src/app/features/activity/queue/queue.html
+++ b/client/src/app/features/activity/queue/queue.html
@@ -29,6 +29,15 @@
                   class="font-medium text-sm leading-tight truncate text-primary hover:underline"
                   [title]="item.name"
                 >{{ item.name }}</a>
+                @if (item.episodeNumber != null) {
+                  <p class="text-xs text-base-content/60 truncate">
+                    S{{ item.seasonNumber ?? 0 | number:'2.0-0' }}E{{ item.episodeNumber | number:'2.0-0' }}{{ item.episodeTitle ? ' — ' + item.episodeTitle : '' }}
+                  </p>
+                } @else if (item.seasonNumber != null) {
+                  <p class="text-xs text-base-content/60 truncate">
+                    {{ 'activity.season_pack' | translate:{ season: item.seasonNumber } }}
+                  </p>
+                }
               } @else {
                 <p class="font-medium text-sm leading-tight truncate" [title]="item.name">
                   {{ item.name }}


### PR DESCRIPTION
## Summary
Every torrent in qBit now ends up bound to a media (and to a specific episode when the name permits) — even torrents Fliks never grabbed.

- **\`TorrentAutoMatcher\`** (\`modules/media/\`): takes a raw torrent name, calls \`extractMediaTitle\` (PR #240), and looks up the Media + Season + Episode. Returns null on ambiguity to avoid mis-binding.
- **\`DownloadHistory.episodeId\` + \`seasonId\`** (nullable, SET NULL on delete — the media link is preserved). Migration \`1779400000000\`.
- **\`buildGrabHistoryRow\`** accepts the new IDs. Every existing grab path that knows the episode/season fills them: \`grabEpisode\`, \`grabSeason\` (manual URL + season-pack + per-episode fallback), and the scheduler auto-grab via \`searchMissingEpisodes\` which already has \`ep.id\` and \`season.id\`.
- **\`CompletionService.processCompleted\`** now calls the auto-matcher on every qBit torrent whose hash isn't already in the DB. A successful match creates a fresh history row (\`grabSource: 'manual'\`) and appends it to \`grabbed\` so the rest of the tick treats it normally.
- **\`getQueue\`** + frontend \`QueueItem\`: surface \`seasonNumber\` / \`episodeNumber\` / \`episodeTitle\`. Activities row renders "S01E03 — Title" for episodes, "Saison N (pack)" for season packs.

## Test plan
- Add a torrent manually in qBittorrent whose name parses as \`Show.S01E03.…\` for a series in the library → within a minute, an Activities row appears bound to the series + episode.
- Add a season pack → bound with \`seasonNumber\` only, displayed "Saison N (pack)".
- Add a movie torrent → bound to the movie.
- Add a torrent whose title matches two series in the library → stays unlinked; warning logged.
- Existing Fliks-grabbed episodes show "S01E03 — Title" in Activities (was: just the series title).
- Migration \`1779400000000\` applies cleanly.