### PR TITLE
chore(auto-match): verbose diagnostics every tick

### DIFF
--- a/backend/src/modules/media/torrent-auto-matcher.service.ts
+++ b/backend/src/modules/media/torrent-auto-matcher.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, ILike } from 'typeorm';
+import { Repository } from 'typeorm';
 import { Media } from './entities/media.entity';
 import { Season } from './entities/season.entity';
 import { Episode } from './entities/episode.entity';
@@ -134,27 +134,50 @@ export class TorrentAutoMatcher {
   }
 
   /**
-   * Title-based media lookup. Loads candidates by case-insensitive
-   * substring on `title`, then narrows in-memory using the alphanumeric
-   * `searchKey` and (optional) year. Ambiguity → null.
+   * Title-based media lookup. SQL pre-filter compares the alphanumeric-
+   * stripped form of every known title source (\`title\`, \`originalTitle\`,
+   * \`alternativeTitles\`) against the candidate's \`searchKey\`. We can't
+   * \`ILIKE '%title%'\` directly because:
+   *  - A French-localised media (\`title = "Margo a des problèmes d'argent"\`)
+   *    with the English original (\`originalTitle = "Margo's Got Money
+   *    Troubles"\`) wouldn't match a release named after the English title.
+   *  - Punctuation in either the torrent name or the stored title (an
+   *    apostrophe, a colon, dot separators) used to block the substring
+   *    match. Stripping non-alphanumerics on both sides removes the drift.
+   *
+   * Result set is then narrowed in JS using the same normalisation. Year
+   * is a tiebreaker when multiple candidates remain.
    */
   private async lookupMedia(
     parsed: ExtractedRelease,
     type: MediaType,
   ): Promise<Media | null> {
-    // Loose SQL filter to keep the candidate set small. We refine in JS
-    // using `searchKey` which is normalisation-tolerant.
-    const titleLike = parsed.title || parsed.searchKey;
-    if (!titleLike) return null;
-    const candidates = await this.mediaRepo.find({
-      where: { type, title: ILike(`%${titleLike}%`) },
-      take: 50,
-    });
+    if (!parsed.searchKey) return null;
+    const candidates = await this.mediaRepo
+      .createQueryBuilder('m')
+      .where('m.type = :type', { type })
+      .andWhere(
+        `(
+          regexp_replace(LOWER(m.title), '[^a-z0-9]+', '', 'g') LIKE :key
+          OR regexp_replace(LOWER(COALESCE(m."originalTitle", '')), '[^a-z0-9]+', '', 'g') LIKE :key
+          OR EXISTS (
+            SELECT 1 FROM jsonb_array_elements_text(m."alternativeTitles") alt
+            WHERE regexp_replace(LOWER(alt), '[^a-z0-9]+', '', 'g') LIKE :key
+          )
+        )`,
+        { key: `%${parsed.searchKey}%`, type },
+      )
+      .take(50)
+      .getMany();
 
+    const norm = (s: string | undefined | null): string =>
+      (s ?? '').toLowerCase().replace(/[^a-z0-9]+/g, '');
     const matching = candidates.filter((m) => {
-      const norm = (s: string | undefined | null): string =>
-        (s ?? '').toLowerCase().replace(/[^a-z0-9]+/g, '');
-      const candidateKeys = [norm(m.title), ...(m.alternativeTitles ?? []).map(norm)];
+      const candidateKeys = [
+        norm(m.title),
+        norm(m.originalTitle),
+        ...(m.alternativeTitles ?? []).map(norm),
+      ].filter(Boolean);
       return candidateKeys.includes(parsed.searchKey);
     });
 

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -248,6 +248,19 @@ export class CompletionService {
 
   @Cron(CronExpression.EVERY_MINUTE)
   async processCompleted(): Promise<void> {
+    // Load qBit + history in this order: we want the auto-match step
+    // to run even when `grabbed` is empty — that's PRECISELY the case
+    // an orphan-recovery flow is for (torrents in qBit with no history
+    // row at all). The previous early-return on empty `grabbed` is the
+    // reason the user reported "auto-match never logs anything"
+    // immediately after a fresh deploy.
+    const clients = await this.clientRepo.find({ where: { enabled: true } });
+    const qbitClients = clients.filter((c) => this.qbittorrent.supports(c));
+    if (!qbitClients.length) {
+      this.log.warn('Import: no enabled qBittorrent client found');
+      return;
+    }
+
     const grabbed = await this.historyRepo.find({
       where: [
         { status: 'grabbed' },
@@ -255,14 +268,6 @@ export class CompletionService {
         { status: 'warning' },
       ],
     });
-    if (!grabbed.length) return;
-
-    const clients = await this.clientRepo.find({ where: { enabled: true } });
-    const qbitClients = clients.filter((c) => this.qbittorrent.supports(c));
-    if (!qbitClients.length) {
-      this.log.warn('Import: no enabled qBittorrent client found');
-      return;
-    }
 
     const allTorrents = (
       await Promise.all(

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -139,14 +139,28 @@ export class CompletionService {
     const candidates = allTorrents.filter(
       (t) => t.hash && !knownHashes.has(t.hash.toLowerCase()),
     );
-    if (!candidates.length) return;
+    if (!candidates.length) {
+      this.log.debug?.(
+        `Auto-match: ${allTorrents.length} qBit torrents, all hashes already in history — nothing to do`,
+      );
+      return;
+    }
+    this.log.log(
+      `Auto-match: scanning ${candidates.length}/${allTorrents.length} torrent(s) without history`,
+    );
 
+    let matched = 0;
+    let skippedByNameFallback = 0;
+    let unidentified = 0;
     for (const torrent of candidates) {
       // Cheap belt-and-braces check: a stale name fallback could
       // legitimately point at one of the existing grabbed rows even
       // when the hash isn't recorded. Skip the auto-match in that case
       // and let `matchAndHeal` write the hash on the next pass.
-      if (this.historyMatcher.findMatch(torrent, grabbed)) continue;
+      if (this.historyMatcher.findMatch(torrent, grabbed)) {
+        skippedByNameFallback++;
+        continue;
+      }
 
       let match;
       try {
@@ -157,7 +171,13 @@ export class CompletionService {
         );
         continue;
       }
-      if (!match) continue;
+      if (!match) {
+        unidentified++;
+        this.log.log(
+          `Auto-match: "${torrent.name}" — no media in library matches the parsed title (ambiguous or unknown)`,
+        );
+        continue;
+      }
 
       const quality = parseReleaseQuality(torrent.name).quality.name;
       const row = await this.historyRepo.save(
@@ -179,6 +199,7 @@ export class CompletionService {
         ),
       );
       grabbed.push(row);
+      matched++;
 
       const epLabel = match.episode
         ? ` ${match.season ? `S${String(match.season.seasonNumber).padStart(2, '0')}` : ''}E${String(match.episode.episodeNumber).padStart(2, '0')}`
@@ -189,6 +210,9 @@ export class CompletionService {
         `Auto-match: bound torrent "${torrent.name}" → ${match.media.title}${epLabel} (history #${row.id})`,
       );
     }
+    this.log.log(
+      `Auto-match: done — ${matched} bound, ${skippedByNameFallback} matched by name (will heal hash), ${unidentified} unidentified`,
+    );
   }
 
   @Cron(CronExpression.EVERY_MINUTE)

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -126,38 +126,50 @@ export class CompletionService {
   ): Promise<void> {
     if (!allTorrents.length) return;
 
-    // Single SQL trip to collect every hash we've ever seen — avoids
-    // matching the same torrent again on every tick. Filter `null`
-    // hashes (legacy rows pre-PR-#82).
-    const allHashRows: { hash: string }[] = await this.historyRepo
-      .createQueryBuilder('h')
-      .select('LOWER(h.torrentHash)', 'hash')
-      .where('h.torrentHash IS NOT NULL')
-      .getRawMany();
-    const knownHashes = new Set(allHashRows.map((r) => r.hash));
+    // Index every history row by its hash so we can tell apart:
+    //  - "no row at all"            → create one.
+    //  - "row exists, media linked" → already handled by the main matcher.
+    //  - "row exists, media NULL"   → rebind the existing row (anomalous
+    //    state from past bugs; we cannot SQL-diagnose so we heal at
+    //    runtime). Updating instead of inserting keeps the row's
+    //    original \`createdAt\` / status history.
+    const allHistory = await this.historyRepo.find({
+      relations: ['media'],
+    });
+    const rowByHash = new Map<string, DownloadHistory>();
+    for (const h of allHistory) {
+      if (h.torrentHash) rowByHash.set(h.torrentHash.toLowerCase(), h);
+    }
 
-    const candidates = allTorrents.filter(
-      (t) => t.hash && !knownHashes.has(t.hash.toLowerCase()),
-    );
+    const candidates = allTorrents.filter((t) => {
+      if (!t.hash) return false;
+      const existing = rowByHash.get(t.hash.toLowerCase());
+      if (!existing) return true; // No row → candidate (create).
+      if (!existing.mediaId) return true; // Row but unlinked → candidate (rebind).
+      return false; // Row already linked → skip.
+    });
     if (!candidates.length) {
       this.log.debug?.(
-        `Auto-match: ${allTorrents.length} qBit torrents, all hashes already in history — nothing to do`,
+        `Auto-match: ${allTorrents.length} qBit torrents, all already linked — nothing to do`,
       );
       return;
     }
     this.log.log(
-      `Auto-match: scanning ${candidates.length}/${allTorrents.length} torrent(s) without history`,
+      `Auto-match: scanning ${candidates.length}/${allTorrents.length} torrent(s) without a media link`,
     );
 
-    let matched = 0;
+    let bound = 0;
+    let rebound = 0;
     let skippedByNameFallback = 0;
     let unidentified = 0;
     for (const torrent of candidates) {
-      // Cheap belt-and-braces check: a stale name fallback could
-      // legitimately point at one of the existing grabbed rows even
-      // when the hash isn't recorded. Skip the auto-match in that case
-      // and let `matchAndHeal` write the hash on the next pass.
-      if (this.historyMatcher.findMatch(torrent, grabbed)) {
+      const existingRow = rowByHash.get(torrent.hash!.toLowerCase());
+
+      // Belt-and-braces: name-fallback against currently-grabbed rows.
+      // Only skip if that match actually has a media reference — a
+      // \`mediaId IS NULL\` ghost row would otherwise prevent the heal.
+      const fallback = this.historyMatcher.findMatch(torrent, grabbed);
+      if (fallback?.history.mediaId) {
         skippedByNameFallback++;
         continue;
       }
@@ -180,38 +192,57 @@ export class CompletionService {
       }
 
       const quality = parseReleaseQuality(torrent.name).quality.name;
-      const row = await this.historyRepo.save(
-        this.historyRepo.create(
-          buildGrabHistoryRow({
-            media: match.media,
-            downloadClient: torrent._client,
-            sourceTitle: torrent.name,
-            torrentHash: torrent.hash,
-            quality,
-            // Auto-matched orphans look closer to a manual add (the
-            // user put the torrent in qBit, we just figured out which
-            // media it belongs to) than to a scheduler auto-grab.
-            grabSource: 'manual',
-            episodeId: match.episode?.id ?? null,
-            seasonId:
-              match.season?.id ?? match.episode?.season?.id ?? null,
-          }),
-        ),
-      );
-      grabbed.push(row);
-      matched++;
+      const seasonId =
+        match.season?.id ?? match.episode?.season?.id ?? null;
+      const episodeId = match.episode?.id ?? null;
+
+      let row: DownloadHistory;
+      if (existingRow) {
+        // Heal the existing orphan: assign the media + episode/season,
+        // bump quality + sourceTitle (decoded) so the next tick's
+        // matcher sees a clean row. Status / createdAt / grabSource
+        // are left intact — this is restoration, not a new grab.
+        existingRow.media = match.media;
+        existingRow.episode = match.episode ?? null;
+        existingRow.season =
+          match.season ?? match.episode?.season ?? null;
+        existingRow.quality = quality;
+        row = await this.historyRepo.save(existingRow);
+        rebound++;
+      } else {
+        row = await this.historyRepo.save(
+          this.historyRepo.create(
+            buildGrabHistoryRow({
+              media: match.media,
+              downloadClient: torrent._client,
+              sourceTitle: torrent.name,
+              torrentHash: torrent.hash,
+              quality,
+              // Auto-matched orphans look closer to a manual add (the
+              // user put the torrent in qBit, we just figured out which
+              // media it belongs to) than to a scheduler auto-grab.
+              grabSource: 'manual',
+              episodeId,
+              seasonId,
+            }),
+          ),
+        );
+        grabbed.push(row);
+        bound++;
+      }
 
       const epLabel = match.episode
         ? ` ${match.season ? `S${String(match.season.seasonNumber).padStart(2, '0')}` : ''}E${String(match.episode.episodeNumber).padStart(2, '0')}`
         : match.season
           ? ` Season ${match.season.seasonNumber}`
           : '';
+      const verb = existingRow ? 'rebound' : 'bound';
       this.log.log(
-        `Auto-match: bound torrent "${torrent.name}" → ${match.media.title}${epLabel} (history #${row.id})`,
+        `Auto-match: ${verb} torrent "${torrent.name}" → ${match.media.title}${epLabel} (history #${row.id})`,
       );
     }
     this.log.log(
-      `Auto-match: done — ${matched} bound, ${skippedByNameFallback} matched by name (will heal hash), ${unidentified} unidentified`,
+      `Auto-match: done — ${bound} created, ${rebound} healed, ${skippedByNameFallback} matched by name (will heal hash), ${unidentified} unidentified`,
     );
   }
 


### PR DESCRIPTION
## Summary
Previously only successful auto-matches were logged. When nothing matched (all hashes already known, or every name was ambiguous) the user couldn't tell whether the pass had even run.

Adds:
- Startup log when there's something to scan: \`Auto-match: scanning X/Y torrent(s) without history\`.
- Per-torrent info line when the parser handled it but the library couldn't disambiguate: \`Auto-match: "torrent.name" — no media in library matches the parsed title\`.
- Summary log at the end: \`Auto-match: done — N bound, M matched by name (will heal hash), K unidentified\`.

## Test plan
- [ ] Restart backend → within 1 min, one of these lines appears in the logs.