### PR TITLE
chore(roles): strip the default User role to viewer + requester only

### DIFF
--- a/backend/src/common/constants/permissions.ts
+++ b/backend/src/common/constants/permissions.ts
@@ -20,13 +20,10 @@ export type Permission = (typeof PERMISSIONS)[number];
 /** Default permission sets for seeded roles. */
 export const DEFAULT_ROLES = {
   Admin: [...PERMISSIONS] as string[],
-  User: [
-    'media.read',
-    'media.create',
-    'media.edit',
-    'media.grab',
-    'requests.create',
-    'subtitles.manage',
-  ],
+  // Minimal viewer role: browse the library and submit requests for
+  // missing titles. Admin-side actions (create/edit/grab/delete,
+  // manage subs/requests, settings access, user admin) are intentionally
+  // off — an admin promotes per-user as needed.
+  User: ['media.read', 'requests.create'],
   Readonly: ['media.read'],
 };


### PR DESCRIPTION
First-boot User role used to include media.create, media.edit, media.grab and subtitles.manage. Trims to media.read + requests.create. Only affects fresh installs.