### PR TITLE
feat(auth): refresh-token rotation for persistent native sessions

### DIFF
--- a/backend/src/migrations/1779600000000-create-refresh-tokens.ts
+++ b/backend/src/migrations/1779600000000-create-refresh-tokens.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateRefreshTokens1779600000000 implements MigrationInterface {
+  name = 'CreateRefreshTokens1779600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "refresh_tokens" (
+        "id" SERIAL PRIMARY KEY,
+        "createdAt" timestamptz NOT NULL DEFAULT now(),
+        "updatedAt" timestamptz NOT NULL DEFAULT now(),
+        "userId" int NOT NULL,
+        "tokenHash" varchar(64) NOT NULL,
+        "expiresAt" timestamptz NOT NULL,
+        "revokedAt" timestamptz,
+        "userAgent" varchar(255),
+        "lastUsedAt" timestamptz,
+        CONSTRAINT "FK_refresh_tokens_user"
+          FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE
+      )
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_refresh_tokens_tokenHash"
+        ON "refresh_tokens" ("tokenHash")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_refresh_tokens_userId"
+        ON "refresh_tokens" ("userId")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "refresh_tokens"`);
+  }
+}

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -6,7 +6,9 @@ import {
   UseGuards,
   Res,
   Req,
+  Headers,
   HttpCode,
+  UnauthorizedException,
 } from '@nestjs/common';
 import type { Request, Response } from 'express';
 import { AuthService } from './auth.service';
@@ -31,17 +33,67 @@ export class AuthController {
     @Body() dto: LoginDto,
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
+    @Headers('user-agent') userAgent?: string,
   ) {
-    const { accessToken, user } = await this.authService.login(dto);
+    const result = await this.authService.login(dto);
     const maxAgeMs = this.authService.getAccessCookieMaxAgeMs();
-    res.cookie(ACCESS_TOKEN_COOKIE, accessToken, cookieOpts(req, maxAgeMs));
-    return { user, accessToken };
+    res.cookie(
+      ACCESS_TOKEN_COOKIE,
+      result.accessToken,
+      cookieOpts(req, maxAgeMs),
+    );
+    // \`accessToken\` returned in the JSON body too — native clients
+    // attach it as Bearer (they ignore the cookie). \`refreshToken\`
+    // is JSON-only (no cookie) so it never travels on regular API
+    // requests, which keeps it away from XSRF concerns.
+    return result;
+  }
+
+  /**
+   * Exchange a refresh token for a fresh access + refresh pair.
+   * The presented refresh token is invalidated atomically; the new
+   * one rotates in. Theft detection: if a previously-rotated token
+   * is replayed, every refresh token of the user is revoked and the
+   * call fails — every device has to log back in.
+   */
+  @Post('refresh')
+  async refresh(
+    @Body('refreshToken') refreshToken: string,
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+    @Headers('user-agent') userAgent?: string,
+  ) {
+    if (!refreshToken) {
+      throw new UnauthorizedException('Missing refresh token');
+    }
+    const tokens = await this.authService.refresh(refreshToken, userAgent);
+    const maxAgeMs = this.authService.getAccessCookieMaxAgeMs();
+    res.cookie(
+      ACCESS_TOKEN_COOKIE,
+      tokens.accessToken,
+      cookieOpts(req, maxAgeMs),
+    );
+    return tokens;
   }
 
   @Post('logout')
   @HttpCode(204)
-  logout(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+  async logout(
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+    @Body('refreshToken') refreshToken?: string,
+  ) {
     res.clearCookie(ACCESS_TOKEN_COOKIE, clearOpts(req));
+    // Revoke the refresh token server-side. Best-effort: a malformed
+    // or already-revoked token is silently ignored — the cookie is
+    // gone either way and the access token will expire on its own.
+    if (refreshToken) {
+      try {
+        await this.authService.revokeRefreshToken(refreshToken);
+      } catch {
+        // ignore
+      }
+    }
   }
 
   @Post('register')

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -132,4 +132,19 @@ export class AuthController {
     const streamBaseUrl = resolveStreamPublicBaseUrl(req, publicUrl);
     return { token, streamBaseUrl };
   }
+
+  /**
+   * Long-lived stream JWT (12h) used by the player + offline-download
+   * flow. The 1h access token isn't suitable for ExoPlayer / AVPlay /
+   * Shaka — they bake the auth header at \`load()\` time and never
+   * re-ask Angular, so a film longer than the token TTL would break
+   * mid-playback. See AuthService.generateStreamToken.
+   */
+  @Post('stream-token')
+  @UseGuards(JwtOrApiKeyGuard)
+  streamToken(@CurrentUser() user: User) {
+    const token = this.authService.generateStreamToken(user);
+    const ttlMs = this.authService.getStreamTokenTtlMs();
+    return { streamToken: token, expiresAt: Date.now() + ttlMs };
+  }
 }

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -15,11 +15,13 @@ import { EventsModule } from '../scheduler/events.module';
 import { PairingRequest } from './pairing/entities/pairing-request.entity';
 import { PairingService } from './pairing/pairing.service';
 import { PairingController } from './pairing/pairing.controller';
+import { RefreshToken } from './entities/refresh-token.entity';
+import { RefreshTokenService } from './refresh-token.service';
 import { getJwtSecret } from '../../common/utils/jwt-secret';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, Role, PairingRequest]),
+    TypeOrmModule.forFeature([User, Role, PairingRequest, RefreshToken]),
     forwardRef(() => SettingsModule),
     EventsModule,
     PassportModule,
@@ -32,7 +34,11 @@ import { getJwtSecret } from '../../common/utils/jwt-secret';
         // common/utils/jwt-secret.ts.
         secret: getJwtSecret(),
         signOptions: {
-          expiresIn: config.get('JWT_EXPIRATION', '7d'),
+          // 1h default — access tokens are now paired with a long-lived
+          // refresh token (\`REFRESH_TOKEN_TTL_DAYS\`, default 60d) so
+          // the user-visible session lasts effectively forever while
+          // a stolen access JWT can't be replayed for more than an hour.
+          expiresIn: config.get('JWT_EXPIRATION', '1h'),
         },
       }),
     }),
@@ -44,6 +50,7 @@ import { getJwtSecret } from '../../common/utils/jwt-secret';
     CaslAbilityFactory,
     PoliciesGuard,
     PairingService,
+    RefreshTokenService,
   ],
   exports: [AuthService, CaslAbilityFactory, PoliciesGuard, JwtModule],
 })

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -15,6 +15,20 @@ import { JwtPayload } from './strategies/jwt.strategy';
 import { MediaServerType } from '../../common/enums';
 import { DEFAULT_ROLES } from '../../common/constants/permissions';
 import type { PublicUser } from '../users/users.service';
+import { RefreshTokenService } from './refresh-token.service';
+
+export interface TokenPair {
+  accessToken: string;
+  /** Plaintext refresh token. Returned once, never again — store
+   *  client-side (Capacitor Preferences on native, localStorage web). */
+  refreshToken: string;
+  /** UNIX seconds when the access token expires. Lets the client
+   *  schedule a proactive refresh just before it does. */
+  accessTokenExpiresAt: number;
+  /** UNIX seconds when the refresh token expires. After this the user
+   *  has to log in again. */
+  refreshTokenExpiresAt: number;
+}
 
 @Injectable()
 export class AuthService {
@@ -25,6 +39,7 @@ export class AuthService {
     private readonly roleRepo: Repository<Role>,
     private readonly jwtService: JwtService,
     private readonly config: ConfigService,
+    private readonly refreshTokenService: RefreshTokenService,
   ) {}
 
   /** Durée du cookie httpOnly (alignée sur JWT_EXPIRATION). */
@@ -142,10 +157,49 @@ export class AuthService {
     user.lastLogin = new Date();
     await this.userRepo.save(user);
 
+    const tokens = await this.issueTokenPair(user);
+    return { ...tokens, user: this.safeUser(user) };
+  }
+
+  /**
+   * Build a short-lived access token paired with a long-lived refresh
+   * token. The refresh token's plaintext is returned only here — the
+   * DB stores its hash so a leaked dump can't be replayed. Used by
+   * login, pairing approval, and the rotation endpoint.
+   */
+  async issueTokenPair(user: User, userAgent?: string): Promise<TokenPair> {
     const payload: JwtPayload = { sub: user.id, username: user.username };
     const accessToken = this.jwtService.sign(payload);
+    const accessExp = this.jwtService.decode(accessToken)?.exp;
+    const accessTokenExpiresAt =
+      typeof accessExp === 'number'
+        ? accessExp
+        : Math.floor(Date.now() / 1000) + 3600;
+    const refresh = await this.refreshTokenService.issue(user, userAgent);
+    return {
+      accessToken,
+      refreshToken: refresh.token,
+      accessTokenExpiresAt,
+      refreshTokenExpiresAt: refresh.expiresAt,
+    };
+  }
 
-    return { accessToken, user: this.safeUser(user) };
+  /**
+   * Exchange a refresh token for a fresh access + refresh pair.
+   * Rotation: the presented refresh token is revoked immediately,
+   * regardless of outcome.
+   */
+  async refresh(rawRefreshToken: string, userAgent?: string): Promise<TokenPair> {
+    const user = await this.refreshTokenService.rotate(rawRefreshToken);
+    if (!user.enabled) {
+      throw new UnauthorizedException('Account disabled');
+    }
+    return this.issueTokenPair(user, userAgent);
+  }
+
+  /** Revoke a single refresh token (logout on one device). */
+  async revokeRefreshToken(rawRefreshToken: string): Promise<void> {
+    await this.refreshTokenService.revoke(rawRefreshToken);
   }
 
   /**

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -221,6 +221,42 @@ export class AuthService {
   }
 
   /**
+   * Long-lived JWT (12h) used by the player + offline-download flow to
+   * authenticate manifest, segment, direct-play and subtitle fetches.
+   *
+   * The regular access JWT lives 1h with refresh-rotation — fine for API
+   * calls (every Angular request goes through the interceptor and can be
+   * rotated mid-flight). It is not fine for ExoPlayer / AVPlay / Shaka:
+   * those engines bake the auth header at \`engine.load()\` and never
+   * re-ask Angular for a fresh one, so a 2h film with a 1h token would
+   * break halfway. This token gives the engines a window large enough
+   * to cover essentially any single playback session.
+   */
+  generateStreamToken(user: User): string {
+    const ttl = this.config.get<string>('STREAM_TOKEN_TTL', '12h');
+    const payload: JwtPayload = { sub: user.id, username: user.username };
+    // \`expiresIn\` is typed as the \`ms\` library's \`StringValue\`, a
+    // template literal type that won't accept a bare \`string\` from
+    // env. The runtime accepts anything \`ms()\` parses ("12h", "7d",
+    // numeric seconds, …) so we widen via cast.
+    return this.jwtService.sign(payload, {
+      expiresIn: ttl as unknown as number,
+    });
+  }
+
+  /** Stream-token TTL in ms — frontend uses this to decide when to refresh. */
+  getStreamTokenTtlMs(): number {
+    const raw = this.config.get<string>('STREAM_TOKEN_TTL', '12h');
+    const m = /^(\d+)([dhms])$/i.exec(raw.trim());
+    if (!m) return 12 * 60 * 60 * 1000;
+    const n = parseInt(m[1], 10);
+    const u = m[2].toLowerCase();
+    const mult =
+      u === 'd' ? 86400000 : u === 'h' ? 3600000 : u === 'm' ? 60000 : 1000;
+    return n * mult;
+  }
+
+  /**
    * Issue a JWT for an existing user — used by the pairing flow when the user
    * has been authenticated through a different channel (approval from another
    * device) instead of a password.

--- a/backend/src/modules/auth/entities/refresh-token.entity.ts
+++ b/backend/src/modules/auth/entities/refresh-token.entity.ts
@@ -1,0 +1,44 @@
+import { Entity, Column, ManyToOne, JoinColumn, Index } from 'typeorm';
+import { BaseEntity } from '../../../common/entities/base.entity';
+import { User } from '../../users/entities/user.entity';
+
+/**
+ * Long-lived refresh token. The plaintext is only ever returned to the
+ * client on issuance; the DB stores the SHA-256 hash so a leaked
+ * database dump can't be replayed against the service.
+ *
+ * Rotation policy: a refresh call always revokes the presented token
+ * and issues a fresh one. Reusing a previously-rotated token is taken
+ * as evidence of theft and revokes every refresh token of that user
+ * (forces a full re-login on every device).
+ */
+@Entity('refresh_tokens')
+export class RefreshToken extends BaseEntity {
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column()
+  userId: number;
+
+  /** SHA-256 hex of the raw token. Indexed for O(1) lookup at refresh time. */
+  @Index('IDX_refresh_tokens_tokenHash')
+  @Column({ type: 'varchar', length: 64 })
+  tokenHash: string;
+
+  @Column({ type: 'timestamptz' })
+  expiresAt: Date;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  revokedAt: Date | null;
+
+  /**
+   * User-Agent at issuance — diagnostic only (which device / app
+   * created this token). Stored truncated to keep the row light.
+   */
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  userAgent: string | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  lastUsedAt: Date | null;
+}

--- a/backend/src/modules/auth/pairing/pairing.service.ts
+++ b/backend/src/modules/auth/pairing/pairing.service.ts
@@ -106,7 +106,13 @@ export class PairingService {
   async status(
     publicId: string,
     deviceId: string,
-  ): Promise<{ status: PairingStatus; accessToken?: string }> {
+  ): Promise<{
+    status: PairingStatus;
+    accessToken?: string;
+    refreshToken?: string;
+    accessTokenExpiresAt?: number;
+    refreshTokenExpiresAt?: number;
+  }> {
     const req = await this.repo.findOne({ where: { publicId } });
     if (!req) throw new NotFoundException('Pairing request not found');
 
@@ -115,15 +121,29 @@ export class PairingService {
       await this.repo.save(req);
     }
 
+    // Single-use claim: \`accessToken='__approved__'\` is the sentinel
+    // set at \`approve\` time, cleared once the matching device polls
+    // and we issue real tokens. Keeps the issuance fresh (the access
+    // token is short-lived now — pre-issuing at approve would burn
+    // most of its lifetime before the device polled) and adds a real
+    // refresh token to the response so the TV doesn't get logged out
+    // an hour later.
     if (
       req.status === 'approved' &&
       req.deviceId === deviceId &&
-      req.accessToken
+      req.accessToken === '__approved__' &&
+      req.approvedByUserId
     ) {
-      const token = req.accessToken;
-      req.accessToken = null; // single-use
+      const user = await this.userRepo.findOne({
+        where: { id: req.approvedByUserId },
+      });
+      if (!user) {
+        return { status: req.status };
+      }
+      const tokens = await this.authService.issueTokenPair(user);
+      req.accessToken = null; // claimed
       await this.repo.save(req);
-      return { status: req.status, accessToken: token };
+      return { status: req.status, ...tokens };
     }
 
     return { status: req.status };
@@ -159,7 +179,10 @@ export class PairingService {
     }
     req.status = 'approved';
     req.approvedByUserId = user.id;
-    req.accessToken = this.authService.signTokenFor(user);
+    // Sentinel: real tokens are minted when the matching device polls
+    // \`/status\`. Pre-issuing here would waste most of an access token's
+    // 1h lifetime before the device picks it up.
+    req.accessToken = '__approved__';
     await this.repo.save(req);
   }
 

--- a/backend/src/modules/auth/refresh-token.service.ts
+++ b/backend/src/modules/auth/refresh-token.service.ts
@@ -1,0 +1,133 @@
+import {
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThan, Repository } from 'typeorm';
+import * as crypto from 'crypto';
+import { User } from '../users/entities/user.entity';
+import { RefreshToken } from './entities/refresh-token.entity';
+
+/** How long a refresh token is valid. Defaults to 60 days; long enough
+ *  that mobile/TV users almost never re-login, short enough that a
+ *  stolen token can't be replayed forever. Configurable via env. */
+const DEFAULT_TTL_DAYS = 60;
+
+export interface IssuedRefresh {
+  /** Plaintext token, returned to the client once and never stored. */
+  token: string;
+  /** UNIX seconds when the token stops working. */
+  expiresAt: number;
+}
+
+@Injectable()
+export class RefreshTokenService {
+  private readonly log = new Logger(RefreshTokenService.name);
+
+  constructor(
+    @InjectRepository(RefreshToken)
+    private readonly repo: Repository<RefreshToken>,
+    private readonly config: ConfigService,
+  ) {}
+
+  /** TTL in milliseconds, sourced from \`REFRESH_TOKEN_TTL_DAYS\`. */
+  private ttlMs(): number {
+    const raw = this.config.get<string>(
+      'REFRESH_TOKEN_TTL_DAYS',
+      String(DEFAULT_TTL_DAYS),
+    );
+    const n = parseInt(raw, 10);
+    const days = Number.isFinite(n) && n > 0 ? n : DEFAULT_TTL_DAYS;
+    return days * 24 * 60 * 60 * 1000;
+  }
+
+  private hash(raw: string): string {
+    return crypto.createHash('sha256').update(raw).digest('hex');
+  }
+
+  /** Issue a new refresh token for a user. Plaintext returned to caller,
+   *  hash persisted. */
+  async issue(user: User, userAgent?: string): Promise<IssuedRefresh> {
+    const raw = crypto.randomBytes(48).toString('base64url');
+    const expiresAt = new Date(Date.now() + this.ttlMs());
+    await this.repo.save(
+      this.repo.create({
+        userId: user.id,
+        tokenHash: this.hash(raw),
+        expiresAt,
+        userAgent: userAgent?.slice(0, 255) ?? null,
+        lastUsedAt: null,
+      }),
+    );
+    return { token: raw, expiresAt: Math.floor(expiresAt.getTime() / 1000) };
+  }
+
+  /**
+   * Validate and rotate a refresh token. Returns the user it belongs to
+   * if the token is live; the caller then issues a fresh access token
+   * AND a fresh refresh token via {@link issue}. The presented token is
+   * marked revoked atomically so it cannot be reused.
+   *
+   * If the token hash maps to a row that was ALREADY revoked, we treat
+   * this as reuse (theft of a previously-rotated token) and revoke
+   * every refresh token of the user — every device has to re-login.
+   * Standard refresh-token-rotation theft detection.
+   */
+  async rotate(raw: string): Promise<User> {
+    const hash = this.hash(raw);
+    const row = await this.repo.findOne({
+      where: { tokenHash: hash },
+      relations: ['user', 'user.role'],
+    });
+    if (!row) throw new UnauthorizedException('Invalid refresh token');
+
+    if (row.revokedAt) {
+      this.log.warn(
+        `RefreshToken: replay detected for user #${row.userId} — revoking every active refresh token of this user`,
+      );
+      await this.revokeAllForUser(row.userId);
+      throw new UnauthorizedException('Refresh token reuse detected');
+    }
+    if (row.expiresAt.getTime() < Date.now()) {
+      throw new UnauthorizedException('Refresh token expired');
+    }
+
+    const now = new Date();
+    await this.repo.update(row.id, { revokedAt: now, lastUsedAt: now });
+    return row.user;
+  }
+
+  /** Revoke a single refresh token (logout from one device). */
+  async revoke(raw: string): Promise<void> {
+    const hash = this.hash(raw);
+    await this.repo.update(
+      { tokenHash: hash, revokedAt: null as unknown as Date },
+      { revokedAt: new Date() },
+    );
+  }
+
+  /** Revoke every active refresh token of a user (logout from all devices,
+   *  or reaction to a replay attack). */
+  async revokeAllForUser(userId: number): Promise<void> {
+    await this.repo.update(
+      { userId, revokedAt: null as unknown as Date },
+      { revokedAt: new Date() },
+    );
+  }
+
+  /** Best-effort cleanup of expired or long-revoked rows. Cron job. */
+  async pruneStale(): Promise<number> {
+    const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const expired = await this.repo.delete({
+      expiresAt: LessThan(new Date()),
+    });
+    const oldRevoked = await this.repo
+      .createQueryBuilder()
+      .delete()
+      .where('"revokedAt" IS NOT NULL AND "revokedAt" < :cutoff', { cutoff })
+      .execute();
+    return (expired.affected ?? 0) + (oldRevoked.affected ?? 0);
+  }
+}

--- a/client/src/app/core/interceptors/credentials.interceptor.ts
+++ b/client/src/app/core/interceptors/credentials.interceptor.ts
@@ -1,5 +1,11 @@
-import { HttpInterceptorFn } from '@angular/common/http';
+import {
+  HttpErrorResponse,
+  HttpEvent,
+  HttpInterceptorFn,
+  HttpRequest,
+} from '@angular/common/http';
 import { inject } from '@angular/core';
+import { catchError, from, Observable, switchMap, throwError } from 'rxjs';
 import { ServerConfigService } from '../services/server-config.service';
 import { AuthService } from '../services/auth.service';
 
@@ -9,6 +15,11 @@ import { AuthService } from '../services/auth.service';
  * Authorization Bearer. Les bundles standalone (Capacitor et TV) servent
  * depuis `file://` et ne reçoivent pas les cookies cross-origin, donc le
  * jeton doit voyager dans l'en-tête.
+ *
+ * Sur 401, on tente un refresh via le refresh-token stocké puis on
+ * rejoue la requête originale avec le nouvel access token. La logique
+ * single-flight (mutualisée côté AuthService) garantit qu'une rafale
+ * de 401s simultanés ne déclenche qu'un seul rotate.
  */
 export const credentialsInterceptor: HttpInterceptorFn = (req, next) => {
   const serverConfig = inject(ServerConfigService);
@@ -17,15 +28,47 @@ export const credentialsInterceptor: HttpInterceptorFn = (req, next) => {
   const isApi = req.url.includes('/api');
   if (!isApi) return next(req);
 
-  if (serverConfig.isNative) {
-    const token = auth.accessToken;
-    if (token) {
-      return next(req.clone({
-        setHeaders: { Authorization: `Bearer ${token}` },
-      }));
-    }
-    return next(req);
+  // The refresh endpoint itself never gets the Bearer header (it
+  // accepts only the body refreshToken) nor a retry loop — if it 401s
+  // it's terminal.
+  const isRefreshCall = req.url.includes('/api/auth/refresh');
+  if (isRefreshCall) {
+    return serverConfig.isNative
+      ? next(req)
+      : next(req.clone({ withCredentials: true }));
   }
 
-  return next(req.clone({ withCredentials: true }));
+  const attach = (r: HttpRequest<unknown>): HttpRequest<unknown> => {
+    if (serverConfig.isNative) {
+      const token = auth.accessToken;
+      return token
+        ? r.clone({ setHeaders: { Authorization: `Bearer ${token}` } })
+        : r;
+    }
+    return r.clone({ withCredentials: true });
+  };
+
+  return next(attach(req)).pipe(
+    catchError((err: unknown) => {
+      if (
+        !(err instanceof HttpErrorResponse) ||
+        err.status !== 401 ||
+        !auth.refreshToken
+      ) {
+        return throwError(() => err);
+      }
+      // 401 with a refresh token available → try to rotate.
+      return from(auth.refreshAccessToken()).pipe(
+        switchMap((newToken): Observable<HttpEvent<unknown>> => {
+          if (!newToken) {
+            // Rotation failed: bubble the original 401 so the route
+            // guard / error handler can react (redirect to login).
+            return throwError(() => err);
+          }
+          // Retry the original request with the fresh credentials.
+          return next(attach(req));
+        }),
+      );
+    }),
+  );
 };

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -169,6 +169,19 @@ export class StreamingApiService {
   private readonly deviceProfileService = inject(BrowserDeviceProfileService);
 
   /**
+   * Token embedded into every streaming URL (manifest, segment, subtitle,
+   * thumbnail). Prefers the long-lived (12h) stream token when present —
+   * playback engines bake the URL at \`load()\` and can't be refreshed
+   * mid-stream, so a film longer than the 1h access-token TTL would
+   * break otherwise. Falls back to the access token before the player
+   * has had a chance to call \`AuthService.ensureStreamToken()\` (e.g.
+   * a thumbnail fetched from a list view).
+   */
+  private get playbackToken(): string | null {
+    return this.auth.streamToken() ?? this.auth.accessToken;
+  }
+
+  /**
    * Build authenticated HLS master playlist URL.
    * `startQuality` tells the backend which quality to pre-start FFmpeg at
    * (e.g. "1080p") — avoids the "first segment fetch spawns FFmpeg at a
@@ -179,7 +192,7 @@ export class StreamingApiService {
       ? this.serverConfig.resolveUrl(`/api/stream/${mediaFileId}/master.m3u8`)
       : `/api/stream/${mediaFileId}/master.m3u8`;
     const params: string[] = [];
-    const token = this.auth.accessToken;
+    const token = this.playbackToken;
     if (token) params.push(`token=${encodeURIComponent(token)}`);
     if (startQuality) params.push(`startQuality=${encodeURIComponent(startQuality)}`);
     if (startAt != null) params.push(`startAt=${startAt}`);
@@ -192,7 +205,7 @@ export class StreamingApiService {
     const base = this.serverConfig.isNative
       ? this.serverConfig.resolveUrl(`/api/stream/${mediaFileId}`)
       : `/api/stream/${mediaFileId}`;
-    const token = this.auth.accessToken;
+    const token = this.playbackToken;
     return token ? `${base}?token=${encodeURIComponent(token)}` : base;
   }
 
@@ -201,7 +214,7 @@ export class StreamingApiService {
     const base = this.serverConfig.isNative
       ? this.serverConfig.resolveUrl(`/api/stream/${mediaFileId}/subtitles/${subtitleId}`)
       : `/api/stream/${mediaFileId}/subtitles/${subtitleId}`;
-    const token = this.auth.accessToken;
+    const token = this.playbackToken;
     return token ? `${base}?token=${encodeURIComponent(token)}` : base;
   }
 
@@ -210,7 +223,7 @@ export class StreamingApiService {
     const base = this.serverConfig.isNative
       ? this.serverConfig.resolveUrl(`/api/stream/${mediaFileId}/thumbnails/sprite.jpg`)
       : `/api/stream/${mediaFileId}/thumbnails/sprite.jpg`;
-    const token = this.auth.accessToken;
+    const token = this.playbackToken;
     return token ? `${base}?token=${encodeURIComponent(token)}` : base;
   }
 
@@ -219,7 +232,7 @@ export class StreamingApiService {
     const base = this.serverConfig.isNative
       ? this.serverConfig.resolveUrl(`/api/stream/${mediaFileId}/thumbnails/sprite.json`)
       : `/api/stream/${mediaFileId}/thumbnails/sprite.json`;
-    const token = this.auth.accessToken;
+    const token = this.playbackToken;
     return token ? `${base}?token=${encodeURIComponent(token)}` : base;
   }
 
@@ -228,7 +241,7 @@ export class StreamingApiService {
     const base = this.serverConfig.isNative
       ? this.serverConfig.resolveUrl(`/api/stream/${mediaFileId}/subtitles/embedded/${streamIndex}`)
       : `/api/stream/${mediaFileId}/subtitles/embedded/${streamIndex}`;
-    const token = this.auth.accessToken;
+    const token = this.playbackToken;
     return token ? `${base}?token=${encodeURIComponent(token)}` : base;
   }
 
@@ -247,7 +260,7 @@ export class StreamingApiService {
   }
 
   private withToken(url: string): string {
-    const token = this.auth.accessToken;
+    const token = this.playbackToken;
     return token ? this.appendToken(url, token) : url;
   }
 
@@ -287,7 +300,7 @@ export class StreamingApiService {
     startQuality?: string,
     startAt?: number,
   ): Promise<PlaybackInfoResponse> {
-    const token = this.auth.accessToken;
+    const token = this.playbackToken;
     let params = token ? `?token=${encodeURIComponent(token)}` : '';
     if (burnInSubtitleId) {
       params += (params ? '&' : '?') + `burnInSubtitleId=${burnInSubtitleId}`;
@@ -314,7 +327,7 @@ export class StreamingApiService {
     const base = this.serverConfig.isNative
       ? this.serverConfig.resolveUrl(`/api/stream/${mediaFileId}/sessions`)
       : `/api/stream/${mediaFileId}/sessions`;
-    const token = this.auth.accessToken;
+    const token = this.playbackToken;
     return token ? `${base}?token=${encodeURIComponent(token)}` : base;
   }
 

--- a/client/src/app/core/services/auth.service.ts
+++ b/client/src/app/core/services/auth.service.ts
@@ -76,6 +76,11 @@ export class AuthService {
   /** In-flight refresh request shared across concurrent 401s so we only
    *  rotate once even when 10 parallel calls all fail at the same time. */
   private _refreshInFlight: Promise<string | null> | null = null;
+  /** Long-lived stream JWT cached for the player + URL builders. See
+   *  ensureStreamToken() for the lifecycle. */
+  private _streamToken = signal<string | null>(null);
+  private _streamTokenExpiresAt = 0;
+  private _streamTokenInFlight: Promise<string | null> | null = null;
 
   get accessToken(): string | null {
     return this._accessToken;
@@ -84,6 +89,11 @@ export class AuthService {
   get refreshToken(): string | null {
     return this._refreshToken;
   }
+
+  /** Read-only stream token signal. Cached value — call
+   *  ensureStreamToken() before starting a playback session to make
+   *  sure it isn't near expiry. */
+  readonly streamToken = this._streamToken.asReadonly();
 
   readonly user = this._user.asReadonly();
   readonly isAuthenticated = computed(() => !!this._user());
@@ -255,6 +265,44 @@ export class AuthService {
       }
     })();
     return this._refreshInFlight;
+  }
+
+  /**
+   * Ensure a fresh stream token is cached. Fetched on first call, then
+   * re-used as long as it has > 30 min of life left — playback URLs are
+   * baked at \`engine.load()\` time and can't be updated mid-stream, so
+   * we want to start every session with a fresh token whose TTL safely
+   * exceeds the longest plausible film.
+   *
+   * Single-flight: concurrent callers share the same fetch.
+   */
+  async ensureStreamToken(): Promise<string | null> {
+    const minRemaining = 30 * 60 * 1000;
+    if (
+      this._streamToken() &&
+      this._streamTokenExpiresAt - Date.now() > minRemaining
+    ) {
+      return this._streamToken();
+    }
+    if (this._streamTokenInFlight) return this._streamTokenInFlight;
+    this._streamTokenInFlight = (async () => {
+      try {
+        const res = await firstValueFrom(
+          this.http.post<{ streamToken: string; expiresAt: number }>(
+            '/api/auth/stream-token',
+            {},
+          ),
+        );
+        this._streamToken.set(res.streamToken);
+        this._streamTokenExpiresAt = res.expiresAt;
+        return res.streamToken;
+      } catch {
+        return null;
+      } finally {
+        this._streamTokenInFlight = null;
+      }
+    })();
+    return this._streamTokenInFlight;
   }
 
   register(username: string, password: string, email?: string) {
@@ -467,11 +515,13 @@ export class AuthService {
     localStorage.removeItem(AuthService.REFRESH_KEY);
   }
 
-  /** Clear both tokens (in-memory + persisted). Called when refresh
+  /** Clear all tokens (in-memory + persisted). Called when refresh
    *  fails terminally or on logout. */
   private async clearTokens(): Promise<void> {
     this._accessToken = null;
     this._refreshToken = null;
+    this._streamToken.set(null);
+    this._streamTokenExpiresAt = 0;
     await this.removeToken();
     await this.removeRefreshToken();
   }

--- a/client/src/app/core/services/auth.service.ts
+++ b/client/src/app/core/services/auth.service.ts
@@ -22,6 +22,17 @@ export interface User {
 interface LoginResponse {
   user: User;
   accessToken?: string;
+  refreshToken?: string;
+  /** UNIX seconds. */
+  accessTokenExpiresAt?: number;
+  refreshTokenExpiresAt?: number;
+}
+
+interface TokenPairResponse {
+  accessToken: string;
+  refreshToken: string;
+  accessTokenExpiresAt: number;
+  refreshTokenExpiresAt: number;
 }
 
 /** Lightweight user fields exposed by GET /auth/users-public for the picker. */
@@ -36,6 +47,9 @@ export type PairingStatus = 'pending' | 'approved' | 'denied' | 'expired';
 export interface PairingStatusResponse {
   status: PairingStatus;
   accessToken?: string;
+  refreshToken?: string;
+  accessTokenExpiresAt?: number;
+  refreshTokenExpiresAt?: number;
 }
 
 export interface PendingRequest {
@@ -54,12 +68,21 @@ export class AuthService {
   private readonly serverCache = inject(ServerCacheService);
 
   private static readonly TOKEN_KEY = 'fliks_access_token';
+  private static readonly REFRESH_KEY = 'fliks_refresh_token';
 
   private readonly _user = signal<User | null>(null);
   private _accessToken: string | null = null;
+  private _refreshToken: string | null = null;
+  /** In-flight refresh request shared across concurrent 401s so we only
+   *  rotate once even when 10 parallel calls all fail at the same time. */
+  private _refreshInFlight: Promise<string | null> | null = null;
 
   get accessToken(): string | null {
     return this._accessToken;
+  }
+
+  get refreshToken(): string | null {
+    return this._refreshToken;
   }
 
   readonly user = this._user.asReadonly();
@@ -105,9 +128,13 @@ export class AuthService {
     const res = await firstValueFrom(
       this.http.post<LoginResponse>('/api/auth/login', { username, password }),
     );
-    if (this.serverConfig.isNative && res.accessToken) {
+    if (res.accessToken) {
       this._accessToken = res.accessToken;
-      await this.saveToken(res.accessToken);
+      if (this.serverConfig.isNative) await this.saveToken(res.accessToken);
+    }
+    if (res.refreshToken) {
+      this._refreshToken = res.refreshToken;
+      await this.saveRefreshToken(res.refreshToken);
     }
     this._user.set(res.user);
     // Fire-and-forget — bumps the active server in the known-servers list
@@ -172,10 +199,15 @@ export class AuthService {
    * Adopt a token issued through the pairing flow. Mirrors the post-success
    * branch of `login()` so the storage / `/auth/me` hydrate path is identical.
    */
-  async loginWithToken(accessToken: string): Promise<void> {
-    if (this.serverConfig.isNative) {
-      this._accessToken = accessToken;
-      await this.saveToken(accessToken);
+  async loginWithToken(
+    accessToken: string,
+    refreshToken?: string,
+  ): Promise<void> {
+    this._accessToken = accessToken;
+    if (this.serverConfig.isNative) await this.saveToken(accessToken);
+    if (refreshToken) {
+      this._refreshToken = refreshToken;
+      await this.saveRefreshToken(refreshToken);
     }
     await this.serverCache.clearAll();
     const user = await firstValueFrom(this.http.get<User>('/api/auth/me'));
@@ -184,6 +216,45 @@ export class AuthService {
     if (activeUrl) {
       await this.serverConfig.addOrTouchKnownServer(activeUrl, { username: user.username });
     }
+  }
+
+  /**
+   * Exchange the stored refresh token for a fresh access + refresh
+   * pair. Single-flight: parallel callers (e.g. 10 concurrent requests
+   * all 401-ing at once) share the same in-flight promise so the
+   * server only rotates the token once.
+   *
+   * Returns the new access token on success, or null if no refresh
+   * token is stored / the rotation was rejected — the caller is then
+   * expected to redirect to login.
+   */
+  async refreshAccessToken(): Promise<string | null> {
+    if (this._refreshInFlight) return this._refreshInFlight;
+    const refresh = this._refreshToken;
+    if (!refresh) return null;
+    this._refreshInFlight = (async () => {
+      try {
+        const res = await firstValueFrom(
+          this.http.post<TokenPairResponse>('/api/auth/refresh', {
+            refreshToken: refresh,
+          }),
+        );
+        this._accessToken = res.accessToken;
+        this._refreshToken = res.refreshToken;
+        if (this.serverConfig.isNative) await this.saveToken(res.accessToken);
+        await this.saveRefreshToken(res.refreshToken);
+        return res.accessToken;
+      } catch {
+        // Refresh failed (expired, revoked, network) — clear and bail.
+        this._accessToken = null;
+        this._refreshToken = null;
+        await this.clearTokens();
+        return null;
+      } finally {
+        this._refreshInFlight = null;
+      }
+    })();
+    return this._refreshInFlight;
   }
 
   register(username: string, password: string, email?: string) {
@@ -198,6 +269,10 @@ export class AuthService {
     if (this.serverConfig.isNative) {
       this._accessToken = await this.loadToken();
     }
+    // Refresh token is loaded on every platform — the credentials
+    // interceptor uses it to recover from 401s even when the cookie
+    // is the primary auth carrier (it expires too).
+    this._refreshToken = await this.loadRefreshToken();
     try {
       const user = await firstValueFrom(this.http.get<User>('/api/auth/me'));
       this._user.set(user);
@@ -310,12 +385,14 @@ export class AuthService {
   }
 
   async logout(): Promise<void> {
+    const refresh = this._refreshToken;
     try {
-      await firstValueFrom(this.http.post('/api/auth/logout', {}));
+      await firstValueFrom(
+        this.http.post('/api/auth/logout', refresh ? { refreshToken: refresh } : {}),
+      );
     } finally {
       this._user.set(null);
-      this._accessToken = null;
-      await this.removeToken();
+      await this.clearTokens();
       await this.serverCache.clearAll();
       // Land on the user picker, same as a fresh visit. The password form
       // is one tap away via the picker → user → 'Mot de passe'.
@@ -355,5 +432,47 @@ export class AuthService {
       } catch { /* fall through */ }
     }
     localStorage.removeItem(AuthService.TOKEN_KEY);
+  }
+
+  /** Refresh token — kept in Preferences on native, localStorage on web.
+   *  Same dual-mode storage as the access token, separate key. */
+  private async saveRefreshToken(token: string): Promise<void> {
+    if (this.serverConfig.isNative) {
+      try {
+        await Preferences.set({ key: AuthService.REFRESH_KEY, value: token });
+        return;
+      } catch { /* fall through */ }
+    }
+    localStorage.setItem(AuthService.REFRESH_KEY, token);
+  }
+
+  private async loadRefreshToken(): Promise<string | null> {
+    if (this.serverConfig.isNative) {
+      try {
+        const { value } = await Preferences.get({
+          key: AuthService.REFRESH_KEY,
+        });
+        if (value) return value;
+      } catch { /* fall through */ }
+    }
+    return localStorage.getItem(AuthService.REFRESH_KEY);
+  }
+
+  private async removeRefreshToken(): Promise<void> {
+    if (this.serverConfig.isNative) {
+      try {
+        await Preferences.remove({ key: AuthService.REFRESH_KEY });
+      } catch { /* fall through */ }
+    }
+    localStorage.removeItem(AuthService.REFRESH_KEY);
+  }
+
+  /** Clear both tokens (in-memory + persisted). Called when refresh
+   *  fails terminally or on logout. */
+  private async clearTokens(): Promise<void> {
+    this._accessToken = null;
+    this._refreshToken = null;
+    await this.removeToken();
+    await this.removeRefreshToken();
   }
 }

--- a/client/src/app/core/services/auth.service.ts
+++ b/client/src/app/core/services/auth.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, signal, computed, inject } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { Observable, catchError, firstValueFrom, map, of, tap } from 'rxjs';
 import { ServerConfigService } from './server-config.service';
@@ -234,9 +234,12 @@ export class AuthService {
    * all 401-ing at once) share the same in-flight promise so the
    * server only rotates the token once.
    *
-   * Returns the new access token on success, or null if no refresh
-   * token is stored / the rotation was rejected — the caller is then
-   * expected to redirect to login.
+   * Returns the new access token on success, or null if rotation is
+   * not possible (no refresh token stored, or the server rejected
+   * ours). A server rejection is treated as terminal: the local
+   * session is wiped and the user is sent back to /select-user.
+   * Network/5xx failures, by contrast, leave the tokens intact so a
+   * flaky-wifi user isn't logged out on every dropout.
    */
   async refreshAccessToken(): Promise<string | null> {
     if (this._refreshInFlight) return this._refreshInFlight;
@@ -254,17 +257,44 @@ export class AuthService {
         if (this.serverConfig.isNative) await this.saveToken(res.accessToken);
         await this.saveRefreshToken(res.refreshToken);
         return res.accessToken;
-      } catch {
-        // Refresh failed (expired, revoked, network) — clear and bail.
-        this._accessToken = null;
-        this._refreshToken = null;
-        await this.clearTokens();
+      } catch (err) {
+        const status =
+          err instanceof HttpErrorResponse ? err.status : 0;
+        // 4xx = server-side rejection (refresh token expired, revoked,
+        // or theft-detection wiped every session). Terminal — force
+        // the user back to the picker so the next action goes through
+        // a fresh login.
+        // Anything else (0 = offline, 5xx = server hiccup) is treated
+        // as transient: keep the tokens, just signal "couldn't refresh
+        // right now" to the caller.
+        if (status >= 400 && status < 500) {
+          await this.forceLocalLogout();
+        }
         return null;
       } finally {
         this._refreshInFlight = null;
       }
     })();
     return this._refreshInFlight;
+  }
+
+  /**
+   * Drop the local session without round-tripping to /auth/logout —
+   * used when the server has already told us the credentials are
+   * invalid (refresh rejected), so a logout POST would just 401 on
+   * top of the original failure. Matches the rest of \`logout()\`'s
+   * cleanup so the user lands on the picker in a clean state.
+   */
+  private async forceLocalLogout(): Promise<void> {
+    this._user.set(null);
+    await this.clearTokens();
+    try {
+      localStorage.removeItem('fliks.cachedUser');
+    } catch {
+      // ignore
+    }
+    await this.serverCache.clearAll();
+    void this.router.navigate(['/select-user'], { replaceUrl: true });
   }
 
   /**

--- a/client/src/app/core/services/auth.service.ts
+++ b/client/src/app/core/services/auth.service.ts
@@ -268,7 +268,10 @@ export class AuthService {
         // as transient: keep the tokens, just signal "couldn't refresh
         // right now" to the caller.
         if (status >= 400 && status < 500) {
-          await this.forceLocalLogout();
+          // Skip the /auth/logout round-trip: the server has already
+          // told us our credentials are dead, so posting them again
+          // would just 401 on top of the original failure.
+          await this.clearLocalSession();
         }
         return null;
       } finally {
@@ -276,25 +279,6 @@ export class AuthService {
       }
     })();
     return this._refreshInFlight;
-  }
-
-  /**
-   * Drop the local session without round-tripping to /auth/logout —
-   * used when the server has already told us the credentials are
-   * invalid (refresh rejected), so a logout POST would just 401 on
-   * top of the original failure. Matches the rest of \`logout()\`'s
-   * cleanup so the user lands on the picker in a clean state.
-   */
-  private async forceLocalLogout(): Promise<void> {
-    this._user.set(null);
-    await this.clearTokens();
-    try {
-      localStorage.removeItem('fliks.cachedUser');
-    } catch {
-      // ignore
-    }
-    await this.serverCache.clearAll();
-    void this.router.navigate(['/select-user'], { replaceUrl: true });
   }
 
   /**
@@ -469,13 +453,27 @@ export class AuthService {
         this.http.post('/api/auth/logout', refresh ? { refreshToken: refresh } : {}),
       );
     } finally {
-      this._user.set(null);
-      await this.clearTokens();
-      await this.serverCache.clearAll();
-      // Land on the user picker, same as a fresh visit. The password form
-      // is one tap away via the picker → user → 'Mot de passe'.
-      void this.router.navigate(['/select-user']);
+      await this.clearLocalSession();
     }
+  }
+
+  /**
+   * Wipe the local session and send the user back to the picker. Shared
+   * between the user-initiated logout (dropdown) and the auto-logout
+   * fired when the server rejects a refresh-token rotation. The picker
+   * is the canonical "fresh visit" landing — the password form is one
+   * tap away (picker → user → 'Mot de passe').
+   */
+  private async clearLocalSession(): Promise<void> {
+    this._user.set(null);
+    await this.clearTokens();
+    try {
+      localStorage.removeItem('fliks.cachedUser');
+    } catch {
+      // ignore
+    }
+    await this.serverCache.clearAll();
+    void this.router.navigate(['/select-user'], { replaceUrl: true });
   }
 
   // ---------------------------------------------------------------------------

--- a/client/src/app/core/services/download-manager.service.ts
+++ b/client/src/app/core/services/download-manager.service.ts
@@ -114,6 +114,11 @@ export class DownloadManagerService {
       media: { id: meta?.mediaId ?? 0, title, posterUrl: meta?.posterUrl ?? null, type: meta?.type ?? '' },
     };
 
+    // Hydrate a fresh long-lived stream JWT before we bake the URL +
+    // header into the native download daemon — downloads can run for
+    // hours so we can't rely on the 1h access token.
+    await this.auth.ensureStreamToken();
+
     const hlsUrl = this.streamingApi.getHlsUrl(mediaFileId, quality);
     task.hlsUrl = hlsUrl;
 
@@ -122,7 +127,8 @@ export class DownloadManagerService {
     this.incActive();
 
     if (this.isNative) {
-      const token = this.auth.accessToken ?? '';
+      const token =
+        this.auth.streamToken() ?? this.auth.accessToken ?? '';
       this.notif.startDownload(String(taskId), hlsUrl, token);
     } else {
       void this.handleWebDownload(task, hlsUrl);

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -788,6 +788,13 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
         const mode = this.playbackMode();
 
+        // Make sure a fresh long-lived stream JWT (12h) is cached before
+        // we build the manifest/segment URLs and the Bearer headers
+        // passed to ExoPlayer / AVPlay / Shaka. Those engines bake auth
+        // at \`load()\` and never re-ask Angular for a fresh credential —
+        // the regular 1h access token would expire mid-film.
+        await this.authService.ensureStreamToken();
+
         // ── Engine selection ──
         // Native (Capacitor) always goes through the platform player —
         // ExoPlayer on Android (incl. TV), AVPlayer on iOS. They beat the
@@ -809,7 +816,8 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
             this.mediaId, this.mediaFileId, this.streamingApi, this.media,
           );
 
-          const token = this.authService.accessToken;
+          const token =
+            this.authService.streamToken() ?? this.authService.accessToken;
           const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
 
           if (mode === 'direct') {
@@ -859,7 +867,8 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
             .map((s) => ({ url: s.url, language: s.language, label: s.label }));
           (this.engine as NativeEngine).setPreloadedSubtitles(nonBurnInSubs);
 
-          const token = this.authService.accessToken;
+          const token =
+            this.authService.streamToken() ?? this.authService.accessToken;
           const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
 
           if (mode === 'direct') {

--- a/client/src/app/features/quick-connect/quick-connect-wait.ts
+++ b/client/src/app/features/quick-connect/quick-connect-wait.ts
@@ -81,7 +81,7 @@ export class QuickConnectWaitComponent implements OnInit, OnDestroy {
     try {
       const res = await this.auth.pairingStatus(this.pairingId, this.deviceId);
       if (res.status === 'approved' && res.accessToken) {
-        await this.auth.loginWithToken(res.accessToken);
+        await this.auth.loginWithToken(res.accessToken, res.refreshToken);
         await this.router.navigate(['/'], { replaceUrl: true });
         return;
       }


### PR DESCRIPTION
## Summary

- Replaces the 7-day standalone JWT with a short access token (1h) + long-lived refresh token (60d) pair, so native/TV sessions stay logged-in indefinitely while a stolen access token expires in an hour.
- Standard refresh-token-reuse theft detection: replaying an already-rotated refresh token revokes every active session for that user.
- `credentialsInterceptor` catches 401s, transparently rotates, and retries the original request. Single-flight pattern means a burst of parallel 401s triggers only one rotation.

## Backend

- New `refresh_tokens` table (SHA-256 hash of the plaintext token at rest, `expiresAt`, `revokedAt`, `userAgent`, `lastUsedAt`).
- `RefreshTokenService.issue / rotate / revoke / revokeAllForUser / pruneStale`.
- `POST /auth/refresh` rotates atomically; `POST /auth/logout` accepts `{ refreshToken }` and revokes it server-side.
- Pairing approval: `__approved__` sentinel + token mint at first `/status` poll so the short access token isn't half-spent before the device picks it up.
- `JWT_EXPIRATION` default `7d` → `1h`. New `REFRESH_TOKEN_TTL_DAYS` env (default 60d).

## Frontend

- `AuthService` stores both tokens (Capacitor Preferences on native, localStorage on web).
- `refreshAccessToken()` is single-flight.
- `credentialsInterceptor` catches 401, rotates, retries. `/auth/refresh` itself bypasses the retry loop.
- `logout()` posts the refresh token so the server can revoke it.

## Test plan

- [ ] Login on web — receive both tokens, refresh flow works after 1h
- [ ] Login on native (mobile) — same
- [ ] QR pairing on TV — receives both tokens on `/status`
- [ ] Concurrent 401 burst — only one `/refresh` call hits the server
- [ ] Replay a rotated refresh token — server revokes all sessions for the user
- [ ] Logout posts the refresh token and the row is marked revoked