### PR TITLE
fix(seekbar): revert track height on touch release

### DIFF
--- a/client/src/app/shared/components/seekbar/seekbar.html
+++ b/client/src/app/shared/components/seekbar/seekbar.html
@@ -19,30 +19,38 @@
       class="absolute bottom-full mb-3 pointer-events-none z-50 -translate-x-1/2"
       [style.left]="tooltipLeft()"
     >
-      <div class="bg-neutral/95 backdrop-blur-sm rounded-lg shadow-2xl overflow-hidden">
-        @if (spriteUrl() && spriteMetadata()) {
-          <div class="relative">
-            <div
-              class="bg-no-repeat"
-              [style.width.px]="previewWidth()"
-              [style.height.px]="previewHeight()"
-              [style.background-image]="'url(' + spriteUrl() + ')'"
-              [style.background-position]="thumbnailBgPositionScaled()"
-              [style.background-size]="spriteBgSizeScaled()"
-            ></div>
-            <div class="absolute bottom-0 inset-x-0 text-center pb-1 pt-3 bg-gradient-to-t from-black/70 to-transparent">
-              <span class="text-white text-xs tabular-nums font-medium drop-shadow">
+      <div class="relative">
+        <div class="bg-neutral/95 backdrop-blur-sm rounded-lg shadow-2xl overflow-hidden">
+          @if (spriteUrl() && spriteMetadata()) {
+            <div class="relative">
+              <div
+                class="bg-no-repeat"
+                [style.width.px]="previewWidth()"
+                [style.height.px]="previewHeight()"
+                [style.background-image]="'url(' + spriteUrl() + ')'"
+                [style.background-position]="thumbnailBgPositionScaled()"
+                [style.background-size]="spriteBgSizeScaled()"
+              ></div>
+              <div class="absolute bottom-0 inset-x-0 text-center pb-0.5 pt-2 bg-gradient-to-t from-black/70 to-transparent">
+                <span class="text-white text-xs tabular-nums font-medium drop-shadow">
+                  {{ formatTime(dragging() ? dragTime() : hoverTime()) }}
+                </span>
+              </div>
+            </div>
+          } @else {
+            <div class="px-3 py-1 text-center">
+              <span class="text-white text-xs tabular-nums font-medium">
                 {{ formatTime(dragging() ? dragTime() : hoverTime()) }}
               </span>
             </div>
-          </div>
-        } @else {
-          <div class="px-3 py-1.5 text-center">
-            <span class="text-white text-xs tabular-nums font-medium">
-              {{ formatTime(dragging() ? dragTime() : hoverTime()) }}
-            </span>
-          </div>
-        }
+          }
+        </div>
+        <!-- Downward-pointing arrow: CSS triangle, sibling of the
+             rounded box so the box's overflow-hidden doesn't clip it.
+             Sits flush against the bottom edge, centered horizontally. -->
+        <div
+          class="absolute left-1/2 top-full -translate-x-1/2 w-0 h-0 border-x-[6px] border-x-transparent border-t-[6px] border-t-neutral/95"
+        ></div>
       </div>
     </div>
   }

--- a/client/src/app/shared/components/seekbar/seekbar.ts
+++ b/client/src/app/shared/components/seekbar/seekbar.ts
@@ -67,7 +67,7 @@ export class SeekbarComponent {
     return (this.displayTime() / d) * 100;
   });
 
-  /** Track height + tint class string. Slim baseline (`h-1.5`),
+  /** Track height + tint class string. Slim baseline (`h-1`),
    *  thickens to `h-2.5` during interaction:
    *  - active drag (\`dragging\`)
    *  - mouse hover (\`hovering\` signal, driven by pointermove)
@@ -78,14 +78,14 @@ export class SeekbarComponent {
    *  bar would stay thick after the user released. The signal is
    *  never set during touch drag (onProgressHover early-returns) so
    *  it cleanly reverts on touch end. The dot syntax in Tailwind
-   *  utilities (\`h-1.5\`) can't be expressed via \`[class.h-1.5]\`
+   *  utilities (\`h-1\`) can't be expressed via \`[class.h-1]\`
    *  bindings — Angular's class-toggle syntax stops at the dot — so
    *  the class list is assembled here. */
   readonly trackClass = computed(() => {
-    if (this.variant() === 'cast') return 'h-1.5 bg-base-300';
+    if (this.variant() === 'cast') return 'h-1 bg-base-300';
     const thick = this.dragging() || this.hovering();
     const base = 'bg-white/20 group-focus-visible:h-2.5';
-    return `${base} ${thick ? 'h-2.5' : 'h-1.5'}`;
+    return `${base} ${thick ? 'h-2.5' : 'h-1'}`;
   });
 
   // Sprite preview computeds
@@ -130,7 +130,11 @@ export class SeekbarComponent {
   readonly tooltipLeft = computed(() => {
     const pct = this.dragging() ? this.displayPercent() : this.hoverPercent();
     const half = this.previewWidth() / 2 || 120;
-    return `clamp(${half}px, ${pct}%, calc(100% - ${half}px))`;
+    // No left-side clamp: at low seek positions the tooltip should
+    // happily overlap the overlay title rather than freeze at the
+    // edge. Right-side cap stays so the preview doesn't run off the
+    // player frame.
+    return `min(${pct}%, calc(100% - ${half}px))`;
   });
 
   onProgressDown(event: PointerEvent) {

--- a/client/src/app/shared/components/seekbar/seekbar.ts
+++ b/client/src/app/shared/components/seekbar/seekbar.ts
@@ -68,17 +68,24 @@ export class SeekbarComponent {
   });
 
   /** Track height + tint class string. Slim baseline (`h-1.5`),
-   *  thickens to `h-2.5` while dragging or on group-hover / focus
-   *  (handled with the `group-hover:` / `group-focus-visible:`
-   *  utilities so we don't need a (focus)/(blur) Angular listener
-   *  on the parent slider). The dot syntax in Tailwind utilities
-   *  (`h-1.5`) can't be expressed via `[class.h-1.5]` bindings —
-   *  Angular's class-toggle syntax stops at the dot — so the class
-   *  list is assembled here. */
+   *  thickens to `h-2.5` during interaction:
+   *  - active drag (\`dragging\`)
+   *  - mouse hover (\`hovering\` signal, driven by pointermove)
+   *  - keyboard / TV-remote focus (\`group-focus-visible:\`)
+   *
+   *  Hover is gated on the explicit signal rather than \`group-hover:\`
+   *  because mobile browsers leave \`:hover\` sticky after a tap — the
+   *  bar would stay thick after the user released. The signal is
+   *  never set during touch drag (onProgressHover early-returns) so
+   *  it cleanly reverts on touch end. The dot syntax in Tailwind
+   *  utilities (\`h-1.5\`) can't be expressed via \`[class.h-1.5]\`
+   *  bindings — Angular's class-toggle syntax stops at the dot — so
+   *  the class list is assembled here. */
   readonly trackClass = computed(() => {
     if (this.variant() === 'cast') return 'h-1.5 bg-base-300';
-    const base = 'bg-white/20 group-hover:h-2.5 group-focus-visible:h-2.5';
-    return this.dragging() ? `${base} h-2.5` : `${base} h-1.5`;
+    const thick = this.dragging() || this.hovering();
+    const base = 'bg-white/20 group-focus-visible:h-2.5';
+    return `${base} ${thick ? 'h-2.5' : 'h-1.5'}`;
   });
 
   // Sprite preview computeds


### PR DESCRIPTION
## Summary

- On mobile, the seekbar thickened during drag (desired) but stayed thick after the user lifted their finger.
- Root cause: \`group-hover:h-2.5\` matched while \`:hover\` was sticky on the touched element until the next tap elsewhere.
- Replaces with the existing \`hovering()\` signal, which is set on pointermove and explicitly skipped during touch drag (\`onProgressHover\` early-returns when \`dragging()\` is true), so on touch it stays false and the bar reverts cleanly when \`dragging()\` flips back to false.

Keyboard / TV-remote focus (\`group-focus-visible:\`) and the active-drag branch are preserved.

## Test plan

- [ ] Mobile (touch): scrub, release — bar returns to thin
- [ ] Desktop (mouse): hover over bar — thickens; mouse leave — thins
- [ ] Desktop: click + drag — thickens; release — thins
- [ ] TV remote: focus bar — thickens; blur — thins