### PR TITLE
fix(media): surface 4K releases in manual search

### DIFF
--- a/backend/src/common/constants/app-qualities.ts
+++ b/backend/src/common/constants/app-qualities.ts
@@ -56,4 +56,20 @@ export function getAppQualityById(
   return byId.get(id);
 }
 
+/**
+ * Highest rank among a set of allowed quality IDs. Used to drop search
+ * results that overshoot the profile's reach — e.g. 2160p hits for a
+ * 1080p-only profile. Returns 0 when no IDs resolve to a known quality;
+ * callers should treat that as "nothing allowed" rather than "everything
+ * allowed".
+ */
+export function maxAllowedRank(allowed: Set<number>): number {
+  let max = 0;
+  for (const id of allowed) {
+    const rank = byId.get(id)?.rank ?? 0;
+    if (rank > max) max = rank;
+  }
+  return max;
+}
+
 export const DEFAULT_MOVIE_QUALITY_PROFILE_NAME = 'HD-1080p (défaut)';

--- a/backend/src/common/release-parsing/quality.parser.ts
+++ b/backend/src/common/release-parsing/quality.parser.ts
@@ -50,6 +50,12 @@ export function parseReleaseQuality(title: string): ParsedReleaseQuality {
     return { quality: q, label: q.name };
   }
 
+  // 'hdtv' is a reasonable fallback at 480p/720p/1080p (broadcast TV is
+  // common at those resolutions), but broadcast 2160p essentially doesn't
+  // circulate — modern 4K is almost always WEB-DL or BluRay. Defaulting
+  // sourceless 2160p+ to 'hdtv' parked legitimate `<title>.<year>.2160p
+  // .HDR.HEVC-<group>` hits into HDTV-2160p (id 20), which most Ultra HD
+  // profiles don't bother to tick → frontend silently hid them.
   let source:
     | 'remux'
     | 'bluray'
@@ -57,7 +63,7 @@ export function parseReleaseQuality(title: string): ParsedReleaseQuality {
     | 'hdtv'
     | 'dvd'
     | 'sdtv'
-    | 'workprint' = 'hdtv';
+    | 'workprint' = resolution >= 2160 ? 'web' : 'hdtv';
   if (isRemux) source = 'remux';
   else if (isBluray) source = 'bluray';
   else if (isWebDl || isWebRip) source = 'web';

--- a/backend/src/modules/indexers/torznab.service.ts
+++ b/backend/src/modules/indexers/torznab.service.ts
@@ -418,9 +418,15 @@ export class TorznabService {
     if (!baseUrl) return [];
 
     const useTvSearch = indexer.capsTvSearch && !indexer.capsSearchFallback;
+    // See comment in searchSeries: text-mode search needs the season tag
+    // baked into `q` so the indexer's result cap doesn't bury packs for
+    // popular shows below the cutoff.
+    const searchQ = useTvSearch
+      ? showTitle
+      : `${showTitle} S${String(season).padStart(2, '0')}`;
     const typedUrl = `${baseUrl}?${buildTorznabQuery({
       t: useTvSearch ? 'tvsearch' : 'search',
-      q: showTitle,
+      q: searchQ,
       season: useTvSearch ? season : undefined,
       cat: '5000',
       apiKey,
@@ -439,9 +445,10 @@ export class TorznabService {
       this.log.warn(
         `[${indexer.name}] tvsearch failed (${torznabError}), falling back to t=search`,
       );
+      const fallbackQ = `${showTitle} S${String(season).padStart(2, '0')}`;
       return this.retryWithSearchFallback(
         indexer,
-        `${baseUrl}?${buildTorznabQuery({ t: 'search', q: showTitle, cat: '5000', apiKey })}`,
+        `${baseUrl}?${buildTorznabQuery({ t: 'search', q: fallbackQ, cat: '5000', apiKey })}`,
         'season',
       );
     }
@@ -465,9 +472,20 @@ export class TorznabService {
     if (!baseUrl) return [];
 
     const useTvSearch = indexer.capsTvSearch && !indexer.capsSearchFallback;
+    // When using t=search (indexer can't tvsearch, or admin pinned the
+    // fallback), the indexer does a plain text match on the torrent
+    // title and applies its own result cap (often 100). With just the
+    // show title in `q`, popular series fill that cap with loud
+    // single-episode 1080p hits and season packs / 4K get crowded out.
+    // Appending the season tag narrows the result set the same way the
+    // movie search includes the year; substring-matching still catches
+    // both per-episode releases (`...S02E02...`) and packs (`...S02...`).
+    const searchQ = useTvSearch
+      ? showTitle
+      : `${showTitle} S${String(season).padStart(2, '0')}`;
     const typedUrl = `${baseUrl}?${buildTorznabQuery({
       t: useTvSearch ? 'tvsearch' : 'search',
-      q: showTitle,
+      q: searchQ,
       season: useTvSearch ? season : undefined,
       ep: useTvSearch ? episode : undefined,
       cat: '5000',
@@ -487,9 +505,10 @@ export class TorznabService {
       this.log.warn(
         `[${indexer.name}] tvsearch failed (${torznabError}), falling back to t=search`,
       );
+      const fallbackQ = `${showTitle} S${String(season).padStart(2, '0')}`;
       return this.retryWithSearchFallback(
         indexer,
-        `${baseUrl}?${buildTorznabQuery({ t: 'search', q: showTitle, cat: '5000', apiKey })}`,
+        `${baseUrl}?${buildTorznabQuery({ t: 'search', q: fallbackQ, cat: '5000', apiKey })}`,
         'tvsearch',
       );
     }

--- a/backend/src/modules/media/episode-download.service.ts
+++ b/backend/src/modules/media/episode-download.service.ts
@@ -21,7 +21,7 @@ import {
   parseSeasonEpisode,
   resolveUnknownLanguage,
 } from '../../common/release-parsing';
-import { getAppQualityById } from '../../common/constants/app-qualities';
+import { maxAllowedRank } from '../../common/constants/app-qualities';
 import { CustomFormatsService } from '../profiles/custom-formats.service';
 import { ProfilesService } from '../profiles/profiles.service';
 import { QualityDefinitionsService } from '../profiles/quality-definitions.service';
@@ -224,20 +224,20 @@ export class EpisodeDownloadService {
       }),
     );
 
-    // Drop everything above the profile's cutoff — see equivalent
+    // Drop releases that overshoot the profile — see equivalent
     // comment in MovieDownloadService.searchMovieReleases.
-    const cutoffRank = getAppQualityById(media.qualityProfile?.cutoff ?? 0)?.rank ?? 999;
-    const withinCutoff = rowsWithKind.filter((x) => x.row.rank <= cutoffRank);
+    const maxRank = maxAllowedRank(allowed);
+    const withinProfile = rowsWithKind.filter((x) => x.row.rank <= maxRank);
 
     // User is asking for ONE episode. Season packs still match, but
     // they download a whole season for a single episode — they should
     // rank below any equally-good single-episode release. Sort the two
     // groups independently then concatenate.
     const singles = sortReleasesByRelevance(
-      withinCutoff.filter((x) => !x.isPack).map((x) => x.row),
+      withinProfile.filter((x) => !x.isPack).map((x) => x.row),
     );
     const packs = sortReleasesByRelevance(
-      withinCutoff.filter((x) => x.isPack).map((x) => x.row),
+      withinProfile.filter((x) => x.isPack).map((x) => x.row),
     );
     return [...singles, ...packs];
   }
@@ -511,14 +511,14 @@ export class EpisodeDownloadService {
       }),
     );
 
-    // Drop everything above the profile's cutoff, and drop single
+    // Drop releases that overshoot the profile, and drop single
     // episodes — the user asked for a season pack, releases that
     // happen to match the show but aren't packs aren't relevant
     // here. The auto-grab path still falls back to per-episode
     // search if no pack works.
-    const cutoffRank = getAppQualityById(media.qualityProfile?.cutoff ?? 0)?.rank ?? 999;
+    const maxRank = maxAllowedRank(allowed);
     const packs = rowsWithKind
-      .filter((x) => x.isPack && x.row.rank <= cutoffRank)
+      .filter((x) => x.isPack && x.row.rank <= maxRank)
       .map((x) => x.row);
     return sortReleasesByRelevance(packs);
   }

--- a/backend/src/modules/media/movie-download.service.ts
+++ b/backend/src/modules/media/movie-download.service.ts
@@ -21,7 +21,10 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { MediaType } from '../../common/enums';
 import { GrabMovieDto } from './dto/grab-movie.dto';
 import { QualityProfileItem } from '../profiles/entities/quality-profile.entity';
-import { getAppQualityById } from '../../common/constants/app-qualities';
+import {
+  getAppQualityById,
+  maxAllowedRank,
+} from '../../common/constants/app-qualities';
 import { parseReleaseQuality } from '../../common/release-parsing';
 import {
   ReleaseRejection,
@@ -201,19 +204,23 @@ export class MovieDownloadService {
       allowedLangs,
       customTitle || resolveSearchTitles(media).expectedTitles,
     );
-    // Drop everything above the profile's cutoff. Above-cutoff qualities
-    // surfaced in manual results even when they couldn't be auto-grabbed,
-    // bloating the list with irrelevant 2160p hits when the user targets
-    // 1080p. The cutoff already gates the upgrade pipeline; mirror that
-    // contract here.
-    const cutoffRank = getAppQualityById(media.qualityProfile?.cutoff ?? 0)?.rank ?? 999;
-    const withinCutoff = rows.filter((r) => r.rank <= cutoffRank);
-    const accepted = withinCutoff.filter((r) => r.rejections.length === 0).length;
+    // Drop releases that overshoot the profile's reach. Profiles have two
+    // independent fields — `cutoff` (the auto-grab "good enough" target)
+    // and `items[].allowed` (the qualities the user is willing to accept).
+    // Filtering by cutoff strips legitimate above-cutoff hits when the
+    // user explicitly allows them (e.g. an Ultra HD profile with cutoff
+    // left at the WEBDL-1080p default still allows 2160p — those releases
+    // must surface). Use the highest allowed rank instead: it still hides
+    // 2160p noise from a 1080p-only profile because those IDs aren't in
+    // `allowed`.
+    const maxRank = maxAllowedRank(allowed);
+    const withinProfile = rows.filter((r) => r.rank <= maxRank);
+    const accepted = withinProfile.filter((r) => r.rejections.length === 0).length;
     this.log.log(
-      `[searchMovieReleases] "${media.title}" — ${withinCutoff.length} within cutoff (rank ≤ ${cutoffRank}), ${accepted} accepted, ${withinCutoff.length - accepted} rejected`,
+      `[searchMovieReleases] "${media.title}" — ${withinProfile.length} within profile (rank ≤ ${maxRank}), ${accepted} accepted, ${withinProfile.length - accepted} rejected`,
     );
-    if (accepted === 0 && withinCutoff.length > 0) {
-      const sample = withinCutoff
+    if (accepted === 0 && withinProfile.length > 0) {
+      const sample = withinProfile
         .slice(0, 5)
         .map((r) => `"${r.title}" [${r.rejections.join(', ')}]`);
       this.log.warn(
@@ -221,7 +228,7 @@ export class MovieDownloadService {
       );
     }
 
-    return sortReleasesByRelevance(withinCutoff);
+    return sortReleasesByRelevance(withinProfile);
   }
 
   async grabMovie(


### PR DESCRIPTION
## Summary

Three independent gaps prevented 4K hits from reaching the search-results table when the user assigned an Ultra HD-style profile.

- **Filter used `cutoff` instead of the allowed set.** Cutoff is the auto-grab "good enough" target, not the allowed-quality ceiling. A sub-2160p cutoff was silently stripping 4K from the manual list even when the profile explicitly allowed 4K. Now bounded by `maxAllowedRank(allowed)` in the movie, per-episode, and season-pack search paths. New helper added in `app-qualities.ts`.
- **Parser defaulted sourceless 2160p+ to HDTV.** Releases like `<title>.<year>.2160p.HDR.HEVC-<group>` (very common for scene 4K) parsed as `HDTV-2160p` (id 20) — a tier most Ultra HD profiles don't tick, so the frontend's `r.allowed` filter silently hid them. Default 2160p+ with no recognised source marker to `web`. 480p / 720p / 1080p behaviour is unchanged.
- **Series text-search fallback sent only the show title.** When the indexer can't tvsearch (or admin pinned the fallback), the result window filled with loud single-episode hits and 4K packs got crowded out of the indexer's result cap. Append the season tag (`S{NN}`) to `q` in `searchSeries` and `searchSeasonPack` — mirrors the movie search appending the year.

## Test plan

- [ ] Manual search on a series with an Ultra HD profile returns 4K season packs that previously didn't surface
- [ ] Manual search on a movie with the same profile still surfaces 4K releases
- [ ] Existing 1080p-only profile still hides 2160p releases (frontend filter on `r.allowed` covers this once parsing routes them outside the allowed set)
- [ ] Backend tests still pass (`npx jest src/modules/media src/common/release-parsing`)
- [ ] Type check clean (`npx tsc --noEmit`)