### PR TITLE
fix(media-info-header): label letterboxed 1080p sources correctly

### DIFF
--- a/client/src/app/core/services/quality-manager.service.ts
+++ b/client/src/app/core/services/quality-manager.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, signal } from '@angular/core';
 import type { PlaybackEngine } from './playback-engine/playback-engine';
-import { widthForProfile } from '../utils/player.utils';
+import { bucketResolutionLabel, widthForProfile } from '../utils/player.utils';
 
 export interface QualityOption {
   id: string;      // 'auto' | 'original' | '2160p' | '1080p' | '720p' | '480p' | ...
@@ -254,16 +254,12 @@ export class QualityManagerService {
   }
 
   /**
-   * Human-readable resolution label from width/height.
+   * Human-readable resolution label from width/height. Delegates to
+   * the shared bucketing helper so anamorphic / scope crops bucket the
+   * same way the file badge does (e.g. 1918×872 → 1080p, not 720p).
    */
   resolutionLabel(w?: number, h?: number): string {
-    if (!w || !h) return '?';
-    if (w >= 3840 || h >= 2160) return '4K';
-    if (w >= 2560 || h >= 1440) return '1440p';
-    if (w >= 1920 || h >= 1080) return '1080p';
-    if (w >= 1280 || h >= 720) return '720p';
-    if (w >= 854 || h >= 480) return '480p';
-    return `${w}x${h}`;
+    return bucketResolutionLabel(w, h) ?? (w && h ? `${w}x${h}` : '?');
   }
 
   /**

--- a/client/src/app/core/utils/player.utils.ts
+++ b/client/src/app/core/utils/player.utils.ts
@@ -29,6 +29,44 @@ export function widthForProfile(id: string): number | undefined {
   return PROFILE_WIDTHS[base];
 }
 
+/**
+ * Bucket a width × height pair to a display label (`"4K"`, `"1080p"`,
+ * `"720p"`, …). Uses ceilings on **both** axes — anamorphic and scope
+ * crops (e.g. 1918×872, 1920×800) would mis-bucket with a width-only or
+ * height-only threshold because their non-primary axis sits one or two
+ * pixels below the round number. Mirrors the backend's `resolveQuality`
+ * bucketing so the badge matches the parsed quality stored on the file.
+ *
+ * Returns null when neither dimension is known.
+ */
+export function bucketResolutionLabel(
+  width?: number | null,
+  height?: number | null,
+): string | null {
+  const w = width ?? 0;
+  const h = height ?? 0;
+  if (!w && !h) return null;
+  if (w <= 720 && h <= 576) return '480p';
+  if (w <= 1280 && h <= 962) return '720p';
+  if (w <= 1920 && h <= 1440) return '1080p';
+  if (w <= 2560 && h <= 1920) return '1440p';
+  return '4K';
+}
+
+/**
+ * Extract the resolution token (`"1080p"`, `"4K"`, …) from a parsed
+ * quality name like `"HDTV-1080p"` or `"WEBDL-2160p"`. Quality strings
+ * without a resolution suffix (`"CAM"`, `"DVD"`, …) return null so
+ * callers can fall back to dimension-based bucketing.
+ */
+export function resolutionFromQualityName(
+  quality?: string | null,
+): string | null {
+  const m = quality?.match(/-(\d+)p$/i);
+  if (!m) return null;
+  return m[1] === '2160' ? '4K' : `${m[1]}p`;
+}
+
 /** Format seconds to h:mm:ss or m:ss. */
 export function formatTime(seconds: number): string {
   if (!seconds || !isFinite(seconds)) return '0:00';

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -43,7 +43,11 @@ import { NavbarService } from '../../../core/services/navbar.service';
 import { TvService } from '../../../core/services/tv.service';
 import { MobileFanartHeroComponent } from '../mobile-fanart-hero';
 import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
-import { formatAudioLabel } from '../../../core/utils/player.utils';
+import {
+  bucketResolutionLabel,
+  formatAudioLabel,
+  resolutionFromQualityName,
+} from '../../../core/utils/player.utils';
 import { DropdownMenuComponent } from '../dropdown-menu';
 import { ImgFadeInDirective } from '../../directives/img-fade-in.directive';
 import { TvRowDirective } from '../../directives/tv-row.directive';
@@ -375,18 +379,14 @@ export class MediaInfoHeaderComponent {
     if (!file?.streamInfo?.video?.[0]) return null;
     const v = file.streamInfo.video[0];
     const parts: string[] = [];
-    if (v.height || v.width) {
-      // Use width too so cinematic widescreen sources (e.g. 1920×960,
-      // 2.00:1 aspect) get the right label — their height alone sits
-      // below the 1080 bucket but they're still 1080p-class content.
-      const w = v.width ?? 0;
-      const h = v.height ?? 0;
-      if (w >= 3840 || h >= 2160) parts.push('4K');
-      else if (w >= 2560 || h >= 1440) parts.push('1440p');
-      else if (w >= 1920 || h >= 1080) parts.push('1080p');
-      else if (w >= 1280 || h >= 720) parts.push('720p');
-      else parts.push(`${h}p`);
-    }
+    // Prefer the parsed quality stored on the file — the backend's
+    // resolveQuality already handles letterbox crops correctly using
+    // ceilings on both axes. Fall back to dimension bucketing for
+    // files imported before the quality was parsed.
+    const res =
+      resolutionFromQualityName(file.quality) ??
+      bucketResolutionLabel(v.width, v.height);
+    if (res) parts.push(res);
     if (v.hdrFormat) parts.push(v.hdrFormat);
     else if (v.colorTransfer === 'smpte2084') parts.push('HDR10');
     else if (v.colorTransfer === 'arib-std-b67') parts.push('HLG');


### PR DESCRIPTION
## Summary

The video badge at the top of the media-detail header re-derived its resolution from raw `width/height` with `w >= 1920 || h >= 1080 → "1080p"`. Letterboxed 1080p sources sit a couple of pixels below 1920 wide (e.g. 1918×872 for a 2.20:1 crop) **and** well below 1080 tall, so they fell through to the 720p bucket — even though the file's stored quality already said 1080p.

## Changes

- `media-info-header.videoLabel` now prefers the parsed quality stored on the file (the backend's `resolveQuality` already buckets letterbox crops correctly with ceilings on both axes). Width/height bucketing is only the fallback for files imported before parsing ran.
- Added shared helpers in `player.utils.ts`:
  - `bucketResolutionLabel(width, height)` — ceiling-on-both-axes bucketing, mirrors the backend's `resolveQuality`.
  - `resolutionFromQualityName(quality)` — extracts the resolution token from a stored quality string like `"HDTV-1080p"` → `"1080p"`, `"WEBDL-2160p"` → `"4K"`.
- `QualityManager.resolutionLabel` delegates to `bucketResolutionLabel` so the in-player resolution label uses the same logic.

## Test plan

- [ ] Open a 1918×872 source whose stored quality is `HDTV-1080p` — badge reads `1080p <codec>` (was `720p <codec>`).
- [ ] Standard 1920×1080 file → still `1080p`.
- [ ] Standard 3840×2160 file → still `4K`.
- [ ] HLS playback — variant labels in the player still match the URL profile (`/720p/…` → "720p").