### PR TITLE
feat(thumbnail): use VAAPI/QSV to accelerate sprite extraction

### DIFF
--- a/backend/src/modules/streaming/thumbnail-extractors/index.ts
+++ b/backend/src/modules/streaming/thumbnail-extractors/index.ts
@@ -1,0 +1,71 @@
+import { existsSync } from 'fs';
+import { QsvExtractor } from './qsv.extractor';
+import { SwExtractor } from './sw.extractor';
+import type { CropArea, ExtractorBackend } from './types';
+import { VaapiExtractor } from './vaapi.extractor';
+import { VideoToolboxExtractor } from './videotoolbox.extractor';
+
+export type { CropArea, ExtractArgs, ExtractorBackend } from './types';
+
+/**
+ * HW render node for accelerated decode on Linux (VAAPI / QSV). Honors
+ * `THUMB_HWACCEL_DEVICE` env var — set to `off` to force SW, or to a
+ * specific `/dev/dri/renderD12X` path. With no override we prefer the
+ * higher-numbered render node — discrete GPUs (Arc, AMD dGPU) typically
+ * enumerate after the iGPU and have a much faster decoder.
+ */
+const HWACCEL_DEVICE: string | null = (() => {
+  const env = process.env.THUMB_HWACCEL_DEVICE;
+  if (env === 'off') return null;
+  const candidates = env
+    ? [env]
+    : ['/dev/dri/renderD129', '/dev/dri/renderD128'];
+  for (const dev of candidates) {
+    if (existsSync(dev)) return dev;
+  }
+  return null;
+})();
+
+/**
+ * Ordered list of available backends. The factory walks this list and
+ * returns the first one whose {@link ExtractorBackend.supports} accepts
+ * the requested crop config. {@link SwExtractor} accepts anything, so the
+ * list always terminates.
+ *
+ * Order matters:
+ *   • VAAPI before QSV — VAAPI is markedly faster on no-crop sprites.
+ *   • QSV before SW — QSV's `vpp_qsv` handles HW crop+scale.
+ *   • VideoToolbox on Darwin replaces the Linux HW pair entirely.
+ */
+const BACKENDS: ExtractorBackend[] = (() => {
+  if (process.platform === 'darwin') {
+    return [new VideoToolboxExtractor(), new SwExtractor()];
+  }
+  if (HWACCEL_DEVICE) {
+    return [
+      new VaapiExtractor(HWACCEL_DEVICE),
+      new QsvExtractor(HWACCEL_DEVICE),
+      new SwExtractor(),
+    ];
+  }
+  return [new SwExtractor()];
+})();
+
+/** Pick the highest-priority backend that can handle the given crop. */
+export function pickExtractor(crop?: CropArea): ExtractorBackend {
+  for (const b of BACKENDS) {
+    if (b.supports(crop)) return b;
+  }
+  // Unreachable — SwExtractor.supports() always returns true.
+  return new SwExtractor();
+}
+
+/** Whether any HW-accelerated backend is configured. Used by the service
+ *  to size its worker pool (HW saturates earlier than CPU). */
+export const HWACCEL_AVAILABLE = BACKENDS.some((b) => b.name !== 'sw');
+
+/** Human-readable summary of the configured backends — logged once at
+ *  service init so deployments can confirm HW is being used. */
+export function describeBackends(): string {
+  return BACKENDS.map((b) => b.describe()).join(' → ');
+}

--- a/backend/src/modules/streaming/thumbnail-extractors/qsv.extractor.ts
+++ b/backend/src/modules/streaming/thumbnail-extractors/qsv.extractor.ts
@@ -1,0 +1,76 @@
+import type { CropArea, ExtractArgs, ExtractorBackend } from './types';
+
+/**
+ * QSV backend — used for the crop case because `vpp_qsv` can crop AND
+ * scale on the GPU in one filter. Without HW crop, we'd have to either
+ * download the full-res decoded frame (catastrophic for 4K — collapses
+ * throughput by ~200×) or compute scaled crop coordinates on a small
+ * downloaded frame (needs source dimensions piped through everywhere).
+ *
+ * Benched on Intel Arc A370M / 1080p HEVC letterboxed: ~420 ms wall for
+ * 10 frames at 4 workers. Slightly slower than {@link VaapiExtractor}
+ * on the no-crop 4K path (~1700 ms vs 960 ms) because QSV's libvpl-based
+ * decoder has higher per-invocation init, so we keep VAAPI for no-crop
+ * and only use QSV when crop is requested.
+ */
+export class QsvExtractor implements ExtractorBackend {
+  readonly name = 'qsv';
+  constructor(private readonly device: string) {}
+
+  describe(): string {
+    return `qsv(${this.device})`;
+  }
+
+  supports(crop?: CropArea): boolean {
+    return !!crop;
+  }
+
+  buildArgs({
+    inputPath,
+    seekSeconds,
+    outputPath,
+    crop,
+    thumbWidth,
+  }: ExtractArgs): string[] {
+    if (!crop) {
+      // supports() should have routed this elsewhere, but type-narrow safely.
+      throw new Error('QsvExtractor requires a crop config');
+    }
+    // Output height preserves the crop region's aspect ratio. Rounded to
+    // an even number — required by most video filters / encoders.
+    const outH = Math.round((crop.height * thumbWidth) / crop.width / 2) * 2;
+    return [
+      '-nostdin',
+      '-hide_banner',
+      '-loglevel',
+      'error',
+      '-threads',
+      '1',
+      '-init_hw_device',
+      `qsv=hw:${this.device}`,
+      '-filter_hw_device',
+      'hw',
+      '-hwaccel',
+      'qsv',
+      '-hwaccel_output_format',
+      'qsv',
+      '-noaccurate_seek',
+      '-ss',
+      String(seekSeconds),
+      '-an',
+      '-sn',
+      '-i',
+      inputPath,
+      '-frames:v',
+      '1',
+      // vpp_qsv crops with cw/ch/cx/cy and scales to w/h in a single pass
+      // on the GPU. We hwdownload the small output tile only.
+      '-vf',
+      `vpp_qsv=w=${thumbWidth}:h=${outH}:cw=${crop.width}:ch=${crop.height}:cx=${crop.x}:cy=${crop.y}:format=nv12,hwdownload,format=nv12`,
+      '-q:v',
+      '5',
+      '-y',
+      outputPath,
+    ];
+  }
+}

--- a/backend/src/modules/streaming/thumbnail-extractors/sw.extractor.ts
+++ b/backend/src/modules/streaming/thumbnail-extractors/sw.extractor.ts
@@ -1,0 +1,59 @@
+import type { CropArea, ExtractArgs, ExtractorBackend } from './types';
+
+/**
+ * Software backend — always-available fallback when no HW device is
+ * exposed (no `/dev/dri/*`, env override forced off, etc.). Decodes the
+ * single keyframe in libavcodec and runs crop+scale in libavfilter on the
+ * CPU. Slow on heavy 4K HEVC 10-bit content (~3 s per frame on the
+ * benched box) but works everywhere.
+ */
+export class SwExtractor implements ExtractorBackend {
+  readonly name = 'sw';
+
+  describe(): string {
+    return 'sw';
+  }
+
+  supports(_crop?: CropArea): boolean {
+    return true;
+  }
+
+  buildArgs({
+    inputPath,
+    seekSeconds,
+    outputPath,
+    crop,
+    thumbWidth,
+  }: ExtractArgs): string[] {
+    const vf = crop
+      ? `crop=${crop.width}:${crop.height}:${crop.x}:${crop.y},scale=${thumbWidth}:-1`
+      : `scale=${thumbWidth}:-1`;
+    return [
+      '-nostdin',
+      '-hide_banner',
+      '-loglevel',
+      'error',
+      '-threads',
+      '1',
+      '-noaccurate_seek',
+      '-ss',
+      String(seekSeconds),
+      // Minimise per-process startup cost: we're spawning one ffmpeg per
+      // thumbnail and don't need a full stream probe.
+      '-analyzeduration',
+      '0',
+      '-probesize',
+      '200000',
+      '-i',
+      inputPath,
+      '-frames:v',
+      '1',
+      '-vf',
+      vf,
+      '-q:v',
+      '5',
+      '-y',
+      outputPath,
+    ];
+  }
+}

--- a/backend/src/modules/streaming/thumbnail-extractors/types.ts
+++ b/backend/src/modules/streaming/thumbnail-extractors/types.ts
@@ -1,0 +1,30 @@
+/** Pre-detected content area inside the source frame. When set, sprite
+ *  tiles carry the active picture only — no letterbox / pillarbox bars. */
+export interface CropArea {
+  width: number;
+  height: number;
+  x: number;
+  y: number;
+}
+
+export interface ExtractArgs {
+  inputPath: string;
+  seekSeconds: number;
+  outputPath: string;
+  crop?: CropArea;
+  thumbWidth: number;
+}
+
+/** One backend = one ffmpeg invocation strategy. The factory in `index.ts`
+ *  picks the first available backend in priority order. Each backend
+ *  decides whether it can handle a given crop request via {@link supports}. */
+export interface ExtractorBackend {
+  /** Short name for logs (e.g. `vaapi`, `qsv`, `sw`). */
+  readonly name: string;
+  /** Build a human-readable label including the device path (when relevant). */
+  describe(): string;
+  /** True when this backend can produce a frame for the given crop config. */
+  supports(crop?: CropArea): boolean;
+  /** Build the ffmpeg argv (no `ffmpeg` prefix) for one frame extract. */
+  buildArgs(opts: ExtractArgs): string[];
+}

--- a/backend/src/modules/streaming/thumbnail-extractors/vaapi.extractor.ts
+++ b/backend/src/modules/streaming/thumbnail-extractors/vaapi.extractor.ts
@@ -1,0 +1,67 @@
+import type { CropArea, ExtractArgs, ExtractorBackend } from './types';
+
+/**
+ * VAAPI backend — fastest path on Intel / AMD Linux GPUs for the no-crop
+ * case. `scale_vaapi` runs the entire pipeline on the GPU, downloading
+ * only the final 240px tile. Moving the scale to SW (i.e. downloading the
+ * full-res decoded frame first) collapses throughput, so we deliberately
+ * leave the crop path to {@link QsvExtractor} which has a HW crop+scale
+ * filter (`vpp_qsv`). VAAPI has no equivalent crop-on-surface filter.
+ *
+ * Benched on Intel Arc A370M / 4K HEVC 10-bit: ~960 ms wall for 10 frames
+ * at 4 workers (4.4× the SW path, stable across 4-16 workers).
+ */
+export class VaapiExtractor implements ExtractorBackend {
+  readonly name = 'vaapi';
+  constructor(private readonly device: string) {}
+
+  describe(): string {
+    return `vaapi(${this.device})`;
+  }
+
+  supports(crop?: CropArea): boolean {
+    return !crop;
+  }
+
+  buildArgs({
+    inputPath,
+    seekSeconds,
+    outputPath,
+    thumbWidth,
+  }: ExtractArgs): string[] {
+    return [
+      '-nostdin',
+      '-hide_banner',
+      '-loglevel',
+      'error',
+      // Single-thread per ffmpeg: each process only emits one frame so
+      // multi-threaded decode adds context-switch overhead without
+      // shortening the critical path.
+      '-threads',
+      '1',
+      '-hwaccel',
+      'vaapi',
+      '-hwaccel_device',
+      this.device,
+      '-hwaccel_output_format',
+      'vaapi',
+      // Demuxer-only seek to the nearest keyframe. Sub-second precision
+      // is fine for thumbnails and avoids decoding forward.
+      '-noaccurate_seek',
+      '-ss',
+      String(seekSeconds),
+      '-an',
+      '-sn',
+      '-i',
+      inputPath,
+      '-frames:v',
+      '1',
+      '-vf',
+      `scale_vaapi=${thumbWidth}:-2:format=nv12,hwdownload,format=nv12`,
+      '-q:v',
+      '5',
+      '-y',
+      outputPath,
+    ];
+  }
+}

--- a/backend/src/modules/streaming/thumbnail-extractors/videotoolbox.extractor.ts
+++ b/backend/src/modules/streaming/thumbnail-extractors/videotoolbox.extractor.ts
@@ -1,0 +1,64 @@
+import type { CropArea, ExtractArgs, ExtractorBackend } from './types';
+
+/**
+ * VideoToolbox backend — Apple's HW decode API, used on macOS / Apple
+ * Silicon (M-series). Selected by the factory only when running on
+ * `darwin`. Not benched in our Linux dev environment; ffmpeg's
+ * VideoToolbox accelerator handles HEVC / H.264 / ProRes / AV1 on
+ * recent SoCs.
+ *
+ * Notes:
+ *   • No `scale_vt` filter is reliably available across ffmpeg builds, so
+ *     we keep the decoded frames on the CPU side after download and run
+ *     crop+scale in SW. The decode is the heavy bit — even pure-SW scale
+ *     on a 4K frame is sub-millisecond compared with the decode itself.
+ *   • Single-threaded ffmpegs again — one frame per process.
+ */
+export class VideoToolboxExtractor implements ExtractorBackend {
+  readonly name = 'videotoolbox';
+
+  describe(): string {
+    return 'videotoolbox';
+  }
+
+  supports(_crop?: CropArea): boolean {
+    return true;
+  }
+
+  buildArgs({
+    inputPath,
+    seekSeconds,
+    outputPath,
+    crop,
+    thumbWidth,
+  }: ExtractArgs): string[] {
+    const vf = crop
+      ? `crop=${crop.width}:${crop.height}:${crop.x}:${crop.y},scale=${thumbWidth}:-1`
+      : `scale=${thumbWidth}:-1`;
+    return [
+      '-nostdin',
+      '-hide_banner',
+      '-loglevel',
+      'error',
+      '-threads',
+      '1',
+      '-hwaccel',
+      'videotoolbox',
+      '-noaccurate_seek',
+      '-ss',
+      String(seekSeconds),
+      '-an',
+      '-sn',
+      '-i',
+      inputPath,
+      '-frames:v',
+      '1',
+      '-vf',
+      vf,
+      '-q:v',
+      '5',
+      '-y',
+      outputPath,
+    ];
+  }
+}

--- a/backend/src/modules/streaming/thumbnail.service.ts
+++ b/backend/src/modules/streaming/thumbnail.service.ts
@@ -8,6 +8,12 @@ import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { EventsService } from '../scheduler/events.service';
 import { Command } from '../scheduler/entities/command.entity';
+import {
+  describeBackends,
+  HWACCEL_AVAILABLE,
+  pickExtractor,
+  type CropArea,
+} from './thumbnail-extractors';
 
 const execFileAsync = promisify(execFile);
 
@@ -29,9 +35,11 @@ export interface SpriteMetadata {
 
 const BASE_DIR = path.join(process.cwd(), 'images', 'thumbnails');
 const FRAMES_TMP_DIR = path.join(process.cwd(), 'images', 'thumbnails-tmp');
-/** Concurrent ffmpeg `-ss` seeks per sprite. Saturates the GPU / CPU for
- *  fast extraction while leaving headroom for concurrent streams. */
-const SEEK_CONCURRENCY = 8;
+
+/** Concurrent ffmpeg `-ss` seeks per sprite. HW decode saturates much
+ *  earlier than the CPU pool — the GPU's decoder-session count caps useful
+ *  parallelism around 4. SW path keeps the previous 8-wide setting. */
+const SEEK_CONCURRENCY = HWACCEL_AVAILABLE ? 4 : 8;
 
 /**
  * Build a human-readable label for a sprite: "S01E03 — Episode Title" for a
@@ -63,17 +71,6 @@ const THUMB_WIDTH = 240;
 /** Max concurrent sprite generations */
 const SPRITE_CONCURRENCY = 2;
 
-/** Optional content-area crop pre-detected by the rescan pipeline. When
- *  set, each extracted frame is passed through `crop=W:H:X:Y` before
- *  scaling, so the sprite tiles carry the active picture only — no
- *  letterbox bars baked into the preview. */
-interface CropArea {
-  width: number;
-  height: number;
-  x: number;
-  y: number;
-}
-
 interface QueueItem {
   mediaFileId: number;
   absolutePath: string;
@@ -98,7 +95,11 @@ export class ThumbnailService {
     private readonly eventsService: EventsService,
     @InjectRepository(Command)
     private readonly commandRepo: Repository<Command>,
-  ) {}
+  ) {
+    this.log.log(
+      `Thumbnail extraction backends: ${describeBackends()} (SEEK_CONCURRENCY=${SEEK_CONCURRENCY}, SPRITE_CONCURRENCY=${SPRITE_CONCURRENCY})`,
+    );
+  }
 
   /**
    * Convenience wrapper that resolves the absolute file path + sprite label
@@ -250,8 +251,26 @@ export class ThumbnailService {
     const progressKey = `GenerateSprite:${mediaFileId}`;
     const t0 = Date.now();
 
+    // Source file size + concurrent sprite jobs: useful to correlate slow
+    // runs with I/O contention or large-file seek cost on HDD/network mounts.
+    let srcSizeMb: number | null = null;
+    try {
+      const st = await fsp.stat(absolutePath);
+      srcSizeMb = Math.round(st.size / (1024 * 1024));
+    } catch {
+      /* file disappeared or unreadable — generate() will fail with a clearer error */
+    }
+    // `this.running` was incremented in processQueue() before calling generate(),
+    // so subtract 1 to get *other* sprite jobs running in parallel with this one.
+    const otherRunning = Math.max(0, this.running - 1);
+
+    // Ask the factory which backend will run, so the log line matches
+    // exactly what ffmpeg sees per frame.
+    const decode = pickExtractor(crop).describe();
     this.log.log(
-      `Sprite START for "${label}" (file #${mediaFileId}): ${count} thumbs @ ${interval}s interval`,
+      `Sprite START for "${label}" (file #${mediaFileId}): ${count} thumbs @ ${interval}s interval, workers=${SEEK_CONCURRENCY}, decode=${decode}, otherSprites=${otherRunning}, queued=${this.queue.length}, srcSize=${srcSizeMb ?? '?'}MB, crop=${
+        crop ? `${crop.width}x${crop.height}+${crop.x},${crop.y}` : 'none'
+      }, src=${absolutePath}`,
     );
 
     // Record task in DB (skip when called from batch command)
@@ -296,12 +315,15 @@ export class ThumbnailService {
       ),
     );
 
+    let extractMs = 0;
+    let tileMs = 0;
     try {
       await Promise.race([
         (async () => {
           // Two-pass via seek: spawn N parallel `ffmpeg -ss` processes (one per
           // thumbnail timestamp) that extract a single frame each — much faster
           // than sequentially decoding the full video. Then tile the frames.
+          const tExtract = Date.now();
           await this.extractFramesBySeek(
             absolutePath,
             framesDir,
@@ -312,8 +334,21 @@ export class ThumbnailService {
             progressKey,
             crop,
           );
+          extractMs = Date.now() - tExtract;
 
+          const tTile = Date.now();
           await this.tileSprite(framesDir, spritePath, rows);
+          tileMs = Date.now() - tTile;
+          let spriteKb: number | null = null;
+          try {
+            const st = await fsp.stat(spritePath);
+            spriteKb = Math.round(st.size / 1024);
+          } catch {
+            /* sprite missing — would have thrown above */
+          }
+          this.log.log(
+            `Sprite TILE done for "${label}" in ${(tileMs / 1000).toFixed(2)}s (${count} frames → sprite.jpg, ${spriteKb ?? '?'}KB)`,
+          );
         })(),
         timeoutPromise,
       ]);
@@ -347,8 +382,9 @@ export class ThumbnailService {
       };
 
       await fsp.writeFile(metaPath, JSON.stringify(meta));
+      const totalMs = Date.now() - t0;
       this.log.log(
-        `Sprite DONE for "${label}" in ${((Date.now() - t0) / 1000).toFixed(1)}s (${count} thumbs)`,
+        `Sprite DONE for "${label}" in ${(totalMs / 1000).toFixed(1)}s (${count} thumbs) — extract ${(extractMs / 1000).toFixed(1)}s, tile ${(tileMs / 1000).toFixed(2)}s, overhead ${((totalMs - extractMs - tileMs) / 1000).toFixed(2)}s`,
       );
 
       if (cmd) {
@@ -422,6 +458,10 @@ export class ThumbnailService {
     let aborted = false;
     let nextIndex = 0;
     const MAX_FAILS = 5;
+    // Track timings keyed by frame index (= file position) so we can break
+    // them down by head/tail quartile to spot HDD seek patterns.
+    const frameTimings: { idx: number; ms: number; ts: number }[] = [];
+    const extractStart = Date.now();
 
     const runOne = async (): Promise<void> => {
       while (true) {
@@ -433,8 +473,10 @@ export class ThumbnailService {
           framesDir,
           `frame-${String(idx + 1).padStart(4, '0')}.jpg`,
         );
+        const tFrame = Date.now();
         try {
           await this.extractFrameAt(inputPath, timestamp, outPath, crop);
+          frameTimings.push({ idx, ms: Date.now() - tFrame, ts: timestamp });
           completed++;
         } catch (err) {
           failed++;
@@ -470,6 +512,38 @@ export class ThumbnailService {
 
     const workers = Math.min(SEEK_CONCURRENCY, count);
     await Promise.all(Array.from({ length: workers }, () => runOne()));
+
+    const wallMs = Date.now() - extractStart;
+    if (frameTimings.length > 0) {
+      const sortedByMs = [...frameTimings].sort((a, b) => a.ms - b.ms);
+      const msAt = (q: number) =>
+        sortedByMs[Math.min(sortedByMs.length - 1, Math.floor(sortedByMs.length * q))].ms;
+      const sumMs = sortedByMs.reduce((a, b) => a + b.ms, 0);
+      const avg = Math.round(sumMs / sortedByMs.length);
+      const fps = (sortedByMs.length / (wallMs / 1000)).toFixed(2);
+      // Wall × workers ≈ theoretical max throughput if every worker stayed
+      // busy. sumMs / (wall × workers) measures how saturated the worker
+      // pool actually was — a low ratio means workers were starved
+      // (likely I/O / scheduler contention from `ionice -c3`).
+      const saturation = Math.round((sumMs / (wallMs * workers)) * 100);
+      // Head vs tail quartile: if extracting from late in the file is
+      // markedly slower, the bottleneck is seek I/O (HDD / network mount)
+      // rather than decode CPU.
+      const byIdx = [...frameTimings].sort((a, b) => a.idx - b.idx);
+      const qSize = Math.max(1, Math.ceil(byIdx.length / 4));
+      const headAvg = Math.round(
+        byIdx.slice(0, qSize).reduce((s, x) => s + x.ms, 0) / qSize,
+      );
+      const tailAvg = Math.round(
+        byIdx.slice(-qSize).reduce((s, x) => s + x.ms, 0) /
+          Math.min(qSize, byIdx.length),
+      );
+      const slowest = sortedByMs[sortedByMs.length - 1];
+      this.log.log(
+        `Sprite EXTRACT done for "${label}" in ${(wallMs / 1000).toFixed(2)}s — ${sortedByMs.length}/${count} frames @ ${fps} fps (workers=${workers}, sat=${saturation}%, per-frame avg=${avg}ms p50=${msAt(0.5)}ms p95=${msAt(0.95)}ms max=${slowest.ms}ms @${slowest.ts}s, head25%=${headAvg}ms tail25%=${tailAvg}ms${failed > 0 ? `, failed=${failed}` : ''})`,
+      );
+    }
+
     if (failed > count * 0.1) {
       throw new Error(
         `Too many frame extractions failed (${failed}/${count}) — sprite would be mostly empty`,
@@ -481,6 +555,10 @@ export class ThumbnailService {
    * Extract a single frame at a specific timestamp via fast keyframe seek.
    * `-ss` BEFORE `-i` uses the demuxer seek (keyframe index) — much faster
    * than accurate seek, with sub-second precision sufficient for thumbnails.
+   *
+   * The actual ffmpeg argv is built by whichever backend in
+   * `./thumbnail-extractors` claims it can handle the crop config (or
+   * the lack thereof). See that folder for the per-backend rationale.
    */
   private extractFrameAt(
     inputPath: string,
@@ -489,40 +567,13 @@ export class ThumbnailService {
     crop?: CropArea,
   ): Promise<void> {
     return new Promise((resolve, reject) => {
-      // SW decode for thumbnails: we only decode ONE I-frame per process
-      // (`-noaccurate_seek` lands on the keyframe, no B/P propagation).
-      // HW accel saved ~200ms of decode but cost ~200ms of init and — more
-      // critically — serialized at the GPU's decoder-session limit
-      // (2–8 on consumer HW), causing random init hangs under the 16
-      // concurrent processes we spawn for sprite generation.
-      const args = [
-        '-nostdin',
-        '-hide_banner',
-        '-loglevel',
-        'error',
-        '-noaccurate_seek',
-        '-ss',
-        String(seekSeconds),
-        '-analyzeduration',
-        '0',
-        '-probesize',
-        '200000',
-        '-i',
+      const args = pickExtractor(crop).buildArgs({
         inputPath,
-        '-frames:v',
-        '1',
-        '-vf',
-        // Strip pre-detected letterbox / pillarbox before scaling so
-        // the sprite tiles carry the active picture only. When no
-        // crop is set the source aspect goes straight through.
-        crop
-          ? `crop=${crop.width}:${crop.height}:${crop.x}:${crop.y},scale=${THUMB_WIDTH}:-1`
-          : `scale=${THUMB_WIDTH}:-1`,
-        '-q:v',
-        '5',
-        '-y',
+        seekSeconds,
         outputPath,
-      ];
+        crop,
+        thumbWidth: THUMB_WIDTH,
+      });
       const proc = spawnLowPriority('ffmpeg', args);
       let stderr = '';
       proc.stderr?.on('data', (chunk: Buffer) => {


### PR DESCRIPTION
## Summary

Sprite generation was bottlenecked on CPU HEVC decode. With both sprites for a movie generating concurrently (SPRITE_CONCURRENCY=2, each spawning 8 ffmpeg workers = 16 procs), the workers oversubscribed cores and fought for memory — a 4K HEVC 10-bit movie took **264s** and a 1080p letterboxed one **138s**.

This PR routes sprite extraction through a pluggable extractor layer that picks the best ffmpeg backend per (crop, platform) pair, dropping both end-to-end times by **7.4×**.

### Backends

| Extractor | When it's picked | Why |
|---|---|---|
| `VaapiExtractor` | Linux + render node + no crop | `scale_vaapi` keeps the whole pipeline on the GPU, downloading only the final 240px tile. Fastest combo on the benched Intel Arc A370M. |
| `QsvExtractor` | Linux + render node + crop | `vpp_qsv` does HW crop+scale in a single filter — `scale_vaapi` has no crop equivalent, and downloading the full-res decoded frame for a SW crop collapses throughput by ~200×. |
| `SwExtractor` | No HW device (or `THUMB_HWACCEL_DEVICE=off`) | libavcodec fallback. Always available. |
| `VideoToolboxExtractor` | macOS / Apple Silicon | Matches ffmpeg docs but not benched on our Linux dev box. |

### Configuration

`THUMB_HWACCEL_DEVICE` env var:
- unset: auto-detect, preferring the higher-numbered `/dev/dri/renderD12X` (discrete GPUs typically enumerate after iGPU)
- `/dev/dri/renderD129`: pin to a specific device
- `off`: force SW fallback

`SEEK_CONCURRENCY` drops from 8 to 4 under HW because the GPU's decoder-session count caps useful parallelism around there — beyond 4 workers VAAPI Arc became unstable and slower in benches.

### Benchmarks — end-to-end, both sprites generating concurrently

| Source | Backend chosen | Before | After | Speedup |
|---|---|---|---|---|
| 4K HEVC 10-bit (no crop) | VAAPI | 264.5 s | 35.6 s | **7.4×** |
| 1080p HEVC + letterbox crop | QSV | 138.4 s | 18.7 s | **7.4×** |

Per-frame stats from the new logging (4K run): `avg=416ms p95=996ms sat=100% head25%=433ms tail25%=374ms` — workers fully saturated, no I/O degradation with file position.

### Observability

`Sprite START` and `Sprite EXTRACT done` log lines now include:
- the picked backend (`decode=vaapi(/dev/dri/renderD129)`, etc.)
- source file size + concurrent sprite-job count → spots contention
- per-frame `head25%` vs `tail25%` timings → spots HDD seek degradation
- slowest-frame timestamp → spots pathological seek points

Service init also logs the resolved backend order:

```
Thumbnail extraction backends: vaapi(/dev/dri/renderD129) → qsv(/dev/dri/renderD129) → sw
  (SEEK_CONCURRENCY=4, SPRITE_CONCURRENCY=2)
```

## Test plan

- [x] Backend type-checks (`tsc --noEmit`)
- [x] Backend container restarts cleanly with VAAPI auto-detected
- [x] End-to-end regen of a 4K HEVC 10-bit no-crop file: 264.5s → 35.6s
- [x] End-to-end regen of a 1080p HEVC letterboxed file: 138.4s → 18.7s
- [ ] Verify on a deployment without `/dev/dri` exposed — service should log `sw` and fall back without errors
- [ ] Verify with `THUMB_HWACCEL_DEVICE=off` — same expected behaviour
- [ ] Verify a sprite preview renders correctly in the player on both new sprites