### PR TITLE
fix(streaming): emit av01.* CODECS for AV1 HLS variants

### DIFF
--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -8,6 +8,7 @@ import {
 import type { AudioStreamMeta, DeviceType, TranscodeProfile } from './types';
 import type { CodecVariant } from './codec/types';
 import {
+  av1CodecString,
   h264CodecString,
   hevcMain10CodecString,
   hevcMainCodecString,
@@ -317,10 +318,16 @@ export function generateMasterPlaylist(
       gopSize: 0,
       frameRate: sourceFrameRate,
     };
+    // Codec string must agree with what the encoder will actually emit —
+    // mismatched CODECS makes Shaka fail with HLS_COULD_NOT_GUESS_CODECS
+    // (3014) after it tries to sniff the segment and the bitstream
+    // doesn't parse as the declared codec.
     const videoCodec =
       sdrVariant?.codec === 'hevc'
         ? hevcMainCodecString(target)
-        : h264CodecString(target);
+        : sdrVariant?.codec === 'av1'
+          ? av1CodecString(target, sdrVariant.bitDepth)
+          : h264CodecString(target);
     const codecsAttr = `,CODECS="${videoCodec}${codecsTail}"`;
     lines.push(
       `#EXT-X-STREAM-INF:BANDWIDTH=${bw},AVERAGE-BANDWIDTH=${avg},RESOLUTION=${w}x${h}${frameRateAttr},NAME="${p.name}"${codecsAttr}${audioAttr}`,


### PR DESCRIPTION
## Summary

The SDR-ladder master-playlist ternary only branched on `hevc` vs `h264` and fell through to `h264CodecString` for any other codec. When the SDR variant carries `codec: 'av1'`, the master then declared `avc1.*` CODECS on a variant whose segments contained AV1 bitstream. Shaka's chunk demuxer couldn't reconcile the two (logged as `Unable to determine bitstream format for CEA parsing`) and bailed with `HLS_COULD_NOT_GUESS_CODECS (3014)` before MSE got a single sample.

Wires `av1CodecString` into the ternary, passing through the variant's `bitDepth` so 8-bit and 10-bit profiles get the right `av01.0.<level>M.<bd>` suffix. `codec-strings` already exports both the builder and the level table; no other plumbing change.

## Test plan

- [ ] Manual: open an AV1 source in the player, confirm Shaka no longer logs `Unable to determine bitstream format`
- [ ] Verify the emitted master playlist `CODECS=` attribute starts with `av01.` for AV1 variants
- [ ] Unchanged: HEVC and H.264 variants still emit `hvc1.*` / `avc1.*` respectively