### PR TITLE
fix(seekbar): shrink sprite preview on phones + crop letterbox from tiles

### DIFF
--- a/backend/src/modules/streaming/thumbnail.service.ts
+++ b/backend/src/modules/streaming/thumbnail.service.ts
@@ -63,12 +63,24 @@ const THUMB_WIDTH = 240;
 /** Max concurrent sprite generations */
 const SPRITE_CONCURRENCY = 2;
 
+/** Optional content-area crop pre-detected by the rescan pipeline. When
+ *  set, each extracted frame is passed through `crop=W:H:X:Y` before
+ *  scaling, so the sprite tiles carry the active picture only — no
+ *  letterbox bars baked into the preview. */
+interface CropArea {
+  width: number;
+  height: number;
+  x: number;
+  y: number;
+}
+
 interface QueueItem {
   mediaFileId: number;
   absolutePath: string;
   durationSeconds: number;
   mediaTitle?: string;
   skipTracking?: boolean;
+  crop?: CropArea;
   resolve: (meta: SpriteMetadata | null) => void;
 }
 
@@ -98,7 +110,10 @@ export class ThumbnailService {
     file: {
       id: number;
       relativePath: string;
-      streamInfo?: { durationSeconds?: number } | null;
+      streamInfo?: {
+        durationSeconds?: number;
+        video?: { crop?: CropArea }[];
+      } | null;
     },
     media: { path: string | null; title: string },
     label: string,
@@ -117,6 +132,7 @@ export class ThumbnailService {
       label,
       options.force ?? false,
       options.skipTracking ?? false,
+      file.streamInfo?.video?.[0]?.crop,
     );
   }
 
@@ -127,6 +143,7 @@ export class ThumbnailService {
     mediaTitle?: string,
     force = false,
     skipTracking = false,
+    crop?: CropArea,
   ): Promise<SpriteMetadata | null> {
     const dir = path.join(BASE_DIR, String(mediaFileId));
     const metaPath = path.join(dir, 'sprite.json');
@@ -150,6 +167,7 @@ export class ThumbnailService {
         durationSeconds,
         mediaTitle,
         skipTracking,
+        crop,
         resolve,
       });
       this.processQueue();
@@ -194,6 +212,7 @@ export class ThumbnailService {
         item.durationSeconds,
         item.mediaTitle,
         item.skipTracking,
+        item.crop,
       )
         .then((meta) => item.resolve(meta))
         .catch((err) => {
@@ -218,6 +237,7 @@ export class ThumbnailService {
     durationSeconds: number,
     mediaTitle?: string,
     skipTracking = false,
+    crop?: CropArea,
   ): Promise<SpriteMetadata | null> {
     const dir = path.join(BASE_DIR, String(mediaFileId));
     const spritePath = path.join(dir, 'sprite.jpg');
@@ -290,6 +310,7 @@ export class ThumbnailService {
             total,
             label,
             progressKey,
+            crop,
           );
 
           await this.tileSprite(framesDir, spritePath, rows);
@@ -394,6 +415,7 @@ export class ThumbnailService {
     totalSeconds: number,
     label: string,
     progressKey: string,
+    crop?: CropArea,
   ): Promise<void> {
     let completed = 0;
     let failed = 0;
@@ -412,7 +434,7 @@ export class ThumbnailService {
           `frame-${String(idx + 1).padStart(4, '0')}.jpg`,
         );
         try {
-          await this.extractFrameAt(inputPath, timestamp, outPath);
+          await this.extractFrameAt(inputPath, timestamp, outPath, crop);
           completed++;
         } catch (err) {
           failed++;
@@ -464,6 +486,7 @@ export class ThumbnailService {
     inputPath: string,
     seekSeconds: number,
     outputPath: string,
+    crop?: CropArea,
   ): Promise<void> {
     return new Promise((resolve, reject) => {
       // SW decode for thumbnails: we only decode ONE I-frame per process
@@ -489,7 +512,12 @@ export class ThumbnailService {
         '-frames:v',
         '1',
         '-vf',
-        `scale=${THUMB_WIDTH}:-1`,
+        // Strip pre-detected letterbox / pillarbox before scaling so
+        // the sprite tiles carry the active picture only. When no
+        // crop is set the source aspect goes straight through.
+        crop
+          ? `crop=${crop.width}:${crop.height}:${crop.x}:${crop.y},scale=${THUMB_WIDTH}:-1`
+          : `scale=${THUMB_WIDTH}:-1`,
         '-q:v',
         '5',
         '-y',

--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -106,11 +106,17 @@
      branching). The inline padding-left/right/bottom uses max(--ctrl-px,
      env(safe-area-inset-...)) so a notch always wins; --ctrl-px / --ctrl-pb
      are themselves responsive via the [--var:value] arbitrary utilities. -->
+<!-- z-40 by default so the mobile big buttons (z-50) stay tappable when
+     the bottom bar grows tall. While the user is scrubbing, promote to
+     z-[55] so the sprite preview tooltip pops above those buttons —
+     they're not relevant while the user is dragging the seek thumb and
+     the preview is far more useful in that moment. -->
 <div
-  class="absolute bottom-0 left-0 right-0 z-40 bg-gradient-to-t from-black/80 via-black/40 to-transparent transition-opacity duration-300 pt-12
+  class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent transition-opacity duration-300 pt-12
          [--ctrl-px:1rem] [--ctrl-pb:0.5rem]
          sm:[--ctrl-px:2rem] sm:[--ctrl-pb:1rem]
          lg:[--ctrl-px:2.5rem] lg:[--ctrl-pb:1rem]"
+  [class]="seekDragging() ? 'z-[55]' : 'z-40'"
   style="padding-left: max(var(--ctrl-px), env(safe-area-inset-left)); padding-right: max(var(--ctrl-px), env(safe-area-inset-right)); padding-bottom: max(var(--ctrl-pb), env(safe-area-inset-bottom));"
   [class.opacity-0]="!visible()"
   [class.pointer-events-none]="!visible()"
@@ -164,7 +170,7 @@
     [chapters]="chapters()"
     variant="player"
     (seek)="seek.emit($event)"
-    (dragChange)="seekDragChange.emit($event)"
+    (dragChange)="seekDragging.set($event); seekDragChange.emit($event)"
   />
 
   <!-- Duration row -->

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -187,6 +187,11 @@ export class PlayerControlsComponent {
   readonly toggleFillScreen = output<void>();
   readonly openMedia = output<void>();
   readonly seekDragChange = output<boolean>();
+  /** Mirror of the seekbar's drag state for local layout — true while the
+   *  user is scrubbing. Drives a z-index bump on the bottom bar so the
+   *  sprite preview tooltip pops above the mobile center buttons (which
+   *  sit at z-50 to stay tappable when the bar grows tall). */
+  readonly seekDragging = signal(false);
   /**
    * Fires whenever any of the controls' own panels (desktop dropdown OR
    * mobile bottom sheet) opens or closes. Lets the parent player pause its

--- a/client/src/app/shared/components/seekbar/seekbar.ts
+++ b/client/src/app/shared/components/seekbar/seekbar.ts
@@ -92,7 +92,14 @@ export class SeekbarComponent {
   private readonly previewScale = computed(() => {
     const meta = this.spriteMetadata();
     if (!meta) return 1.5;
-    const maxW = window.innerWidth < 640 ? 176 : 224;
+    // Tighter cap on phones: the tooltip lives directly above the
+    // seekbar, which sits directly above the mobile big buttons (rewind
+    // / play / forward), and a wide thumbnail visually crowds that
+    // stack on small viewports. Gate on the SHORTER viewport dimension
+    // so landscape phones (e.g. S25 at 915×412) still get the small
+    // cap — width alone misses them because landscape > 640 px wide.
+    const shortSide = Math.min(window.innerWidth, window.innerHeight);
+    const maxW = shortSide < 640 ? 144 : 224;
     return Math.min(1.5, maxW / meta.thumbWidth);
   });
 


### PR DESCRIPTION
## Summary

Two related improvements to the seekbar sprite preview that were sitting on the same branch.

### `fix(seekbar): shrink sprite preview on phones, pop it above mobile buttons`

Two adjustments to the seek-preview tooltip on small viewports:

- Cap the sprite preview width at 144 px (was 176 px) when the **shorter** viewport dimension is under 640 px. Width-only gating missed landscape phones (e.g. 915×412); using the short side catches both orientations. At a 240 px source thumb the preview now renders at ~144×80 instead of ~176×100, leaving the title row above and the big buttons below visual room on a phone.
- The bottom-bar container stayed at `z-40` to keep the mobile big buttons (rewind / play / forward, `z-50`) tappable when the bar grows tall. While the user is actively scrubbing, the bar is promoted to `z-[55]` so the sprite preview tooltip stacks above those buttons — they're not useful in that moment and the preview was getting occluded.

### `feat(thumbnail): crop letterbox from sprite tiles`

Pipes the file's pre-detected `crop` (computed by the rescan pipeline, stored on `streamInfo.video[0].crop`) through `generateForFile` → `getOrGenerate` → the per-frame ffmpeg invocation. When set, each extraction prepends `crop=W:H:X:Y` before the existing scale filter so the sprite tile carries the active picture only. Files without detected letterbox keep the current scale-only path unchanged.

Existing sprites stay cached as-is; regeneration (rescan or the `GenerateSprites` bulk system task with `force=true`) re-bakes them with the crop applied.

## Test plan

- [ ] Phone (portrait + landscape): scrub the seekbar, confirm sprite preview is ~144 px wide and visually above the mobile big buttons
- [ ] Desktop: no regression, sprite preview unchanged
- [ ] Letterboxed 1080p source: trigger sprite regen, confirm the tile shows only the active picture (no black bars)
- [ ] Non-letterboxed source: tile aspect unchanged

## Note

PR #252 (`feat/sprite-hwaccel`) is currently branched on top of this one, so it includes both commits in its diff. Once this PR merges to `main`, #252's diff will shrink to just the hwaccel work.