### PR TITLE
fix(player): keep mobile play button slot during loading

### DIFF
--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -74,8 +74,11 @@
   (dblclick)="isMobileTouch() ? null : toggleFullscreen.emit()"
 ></div>
 
-<!-- Mobile: big center controls (rewind / play / forward) -->
-@if (isMobileTouch() && !loading() && !buffering() && videoStarted()) {
+<!-- Mobile: big center controls (rewind / play / forward).
+     The play/pause button is kept in the layout (only `invisible`) while
+     loading/buffering so the seek arrows don't slide inward — the centered
+     spinner overlay sits in its place. -->
+@if (isMobileTouch() && videoStarted()) {
   <div
     class="absolute inset-0 z-50 flex items-center justify-center pointer-events-none transition-opacity duration-200"
     [class.opacity-0]="!visible()"
@@ -86,7 +89,7 @@
         <svg lucideRotateCcw class="h-7 w-7" [strokeWidth]="1.5"></svg>
       </button>
       <!-- lucide:play / lucide:pause -->
-      <button type="button" class="p-6 -m-2 text-white active:scale-90 transition-transform pointer-events-auto" [class.pointer-events-none]="!visible()" (click)="togglePlay.emit(); $event.stopPropagation()">
+      <button type="button" class="p-6 -m-2 text-white active:scale-90 transition-transform pointer-events-auto" [class.pointer-events-none]="!visible()" [class.invisible]="loading() || buffering()" (click)="togglePlay.emit(); $event.stopPropagation()">
         @if (paused()) {
           <svg xmlns="http://www.w3.org/2000/svg" class="h-14 w-14 drop-shadow-lg" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M5 5a2 2 0 0 1 3.008-1.728l11.997 6.998a2 2 0 0 1 .003 3.458l-12 7A2 2 0 0 1 5 19z"/></svg>
         } @else {


### PR DESCRIPTION
## Summary

The mobile center-controls block (rewind / play / forward) was hidden entirely on `loading() || buffering()`, so when playback hit a stall the play/pause button vanished and the two seek arrows slid inward to fill the freed space. The motion read as a layout glitch rather than a buffering state.

This PR keeps the block rendered as soon as `videoStarted()` is true and instead applies `invisible` to just the play/pause button while loading or buffering. The centered spinner overlay already lives in that slot, so the user sees a spinner where the play button was, with the seek arrows holding their position.

## Test plan

- [ ] Mobile: start playback, then induce a buffering stall (slow network or seek into uncached region). Confirm the rewind / forward arrows stay put and a spinner sits where the play button was.
- [ ] Mobile: stall on initial buffering — same expected behaviour as soon as `videoStarted()` flips true.
- [ ] Desktop: unaffected (block is `isMobileTouch()`-gated).