### PR TITLE
fix(quality): share resolution bucketing across backend and client

### DIFF
--- a/backend/src/common/utils/resolution.util.ts
+++ b/backend/src/common/utils/resolution.util.ts
@@ -1,0 +1,55 @@
+/**
+ * Bucket a (width × height) pair to its canonical height step
+ * (144 / 240 / 360 / 480 / 720 / 1080 / 2160).
+ *
+ * Ceilings on **both** axes — anamorphic, scope and IMAX crops sit a
+ * couple of pixels below the round number on their non-primary axis, so
+ * width-only or height-only thresholds mis-bucket them. Concrete cases
+ * this avoids:
+ *
+ *   • 1918×872 (2.20:1 letterboxed 1080p master): width-only fails the
+ *     `>= 1920` check, height-only fails `>= 1080`, both mis-label it
+ *     720p. With ceilings on both we get 1080p, which matches the file's
+ *     parsed quality and the transcode ladder.
+ *   • 3840×2024 (IMAX 4K): height-only fails `>= 2160`, mis-labels it
+ *     1080p and drops the 2160p ladder rung. Width-ceiling rescues it.
+ *   • 854×480 (16:9 widescreen SD): the legacy `w <= 720` 480 ceiling
+ *     mis-bucketed this as 720p; bumping the width ceiling to 854
+ *     (matching the 480p profile width) returns 480 as expected.
+ *
+ * Returns 480 when both inputs are zero / missing — safest fallback for
+ * legacy probes that hadn't recorded dimensions yet. Shared by
+ * `profileFitsSource` (transcode ladder filtering) and `resolveQuality`
+ * (parsed-quality storage) so the player and the file badge agree on
+ * what bucket a source belongs to.
+ */
+export function bucketResolutionHeight(
+  width?: number | null,
+  height?: number | null,
+): number {
+  const w = width ?? 0;
+  const h = height ?? 0;
+  if (!w && !h) return 480;
+  if (w <= 256 && h <= 192) return 144;
+  if (w <= 426 && h <= 320) return 240;
+  if (w <= 640 && h <= 432) return 360;
+  if (w <= 854 && h <= 576) return 480;
+  if (w <= 1280 && h <= 962) return 720;
+  if (w <= 1920 && h <= 1440) return 1080;
+  return 2160;
+}
+
+/**
+ * Display label for a (width × height) pair — `"4K"` for 2160 buckets,
+ * `"<bucket>p"` for everything else, `null` when both inputs are
+ * zero/missing. Mirrors the client's `bucketResolutionLabel` so badge
+ * text matches across the stack.
+ */
+export function bucketResolutionLabel(
+  width?: number | null,
+  height?: number | null,
+): string | null {
+  if (!(width ?? 0) && !(height ?? 0)) return null;
+  const bucket = bucketResolutionHeight(width, height);
+  return bucket === 2160 ? '4K' : `${bucket}p`;
+}

--- a/backend/src/modules/media/media-service/media-rescan.service.ts
+++ b/backend/src/modules/media/media-service/media-rescan.service.ts
@@ -28,6 +28,7 @@ import {
 import { MediaServersService } from '../../media-servers/media-servers.service';
 import { clearMediaCache } from '../../../common/utils/media-cache.util';
 import { relativePathUnderMediaRoot } from '../../../common/utils/media-path.util';
+import { bucketResolutionHeight } from '../../../common/utils/resolution.util';
 
 type ProbeResult = Awaited<ReturnType<FfprobeService['detectMediaFileInfo']>>;
 
@@ -842,18 +843,11 @@ export class MediaRescanService {
     actualHeight?: number,
     actualWidth?: number,
   ): string {
-    // Resolution bucket from frame dimensions: first ceiling that fits BOTH
-    // width AND height wins. Ceilings on both axes absorb anamorphic / scope
-    // crops (e.g. a 1080p source encoded as 1796x1076 or 1920x800) which a
-    // width-only threshold mis-buckets as 720p.
-    const w = actualWidth ?? 0;
-    const h = actualHeight ?? 0;
-    let resolution: number;
-    if (!w && !h) resolution = 480;
-    else if (w <= 720 && h <= 576) resolution = 480;
-    else if (w <= 1280 && h <= 962) resolution = 720;
-    else if (w <= 1920 && h <= 1440) resolution = 1080;
-    else resolution = 2160;
+    // Bucket by dimensions, clamped to APP_QUALITIES' supported resolutions
+    // (480 / 720 / 1080 / 2160). Tiny sub-480 sources fall back to 480 here
+    // because we don't ship 144/240/360 entries in APP_QUALITIES.
+    const bucket = bucketResolutionHeight(actualWidth, actualHeight);
+    const resolution = bucket >= 2160 ? 2160 : bucket <= 480 ? 480 : bucket;
 
     // Determine source from filename (bluray, web, remux, etc.)
     const t = filename.replace(/\./g, ' ').toLowerCase();

--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -37,6 +37,7 @@ import { ActiveStreamTracker } from '../streaming/active-stream-tracker.service'
 import { PlaybackService } from '../streaming/playback.service';
 import { MediaFile } from '../media/entities/media-file.entity';
 import { Episode } from '../media/entities/episode.entity';
+import { bucketResolutionLabel } from '../../common/utils/resolution.util';
 
 const APP_VERSION: string = (() => {
   try {
@@ -427,13 +428,8 @@ export class SystemController {
 
       const sourceResLabel =
         v?.width && v?.height
-          ? v.height >= 2160
-            ? '4K'
-            : v.height >= 1080
-              ? '1080p'
-              : v.height >= 720
-                ? '720p'
-                : `${v.width}x${v.height}`
+          ? (bucketResolutionLabel(v.width, v.height) ??
+            `${v.width}x${v.height}`)
           : null;
       // For transcode sessions, show the target quality, not the source resolution
       const resLabel =

--- a/backend/src/modules/streaming/transcoding/profiles.ts
+++ b/backend/src/modules/streaming/transcoding/profiles.ts
@@ -1,3 +1,4 @@
+import { bucketResolutionHeight } from '../../../common/utils/resolution.util';
 import type { DeviceType, TranscodeProfile } from './types';
 
 /** Threshold above which source bitrate earns its own "Original" rung
@@ -209,18 +210,22 @@ export function isHdrProfile(name: string): boolean {
   return name.endsWith('-hdr');
 }
 
-/** True when a profile is small enough to encode on the source — either
- *  axis fitting is enough so cinema-aspect 4K (e.g. 3840×2024 IMAX)
- *  still gets the 2160p ladder rung. A strict `maxHeight <= sourceHeight`
- *  check drops the top rung for any source whose vertical resolution
- *  falls below the profile's category label, which is wrong for most
- *  theatrical 4K masters. */
+/** True when a profile is small enough to encode on the source. Compares
+ *  the *bucketed* heights on both sides so anamorphic / scope / IMAX
+ *  crops snap to the right rung — the previous `<=` on either axis
+ *  rescued IMAX 4K (3840×2024) but still dropped letterboxed 1080p
+ *  masters like 1918×872 to the 720p rung because both axes sat one or
+ *  two pixels under the round number. See {@link bucketResolutionHeight}
+ *  for the bucket boundaries. */
 export function profileFitsSource(
   p: { maxWidth: number; maxHeight: number },
   sourceWidth: number,
   sourceHeight: number,
 ): boolean {
-  return p.maxWidth <= sourceWidth || p.maxHeight <= sourceHeight;
+  return (
+    bucketResolutionHeight(p.maxWidth, p.maxHeight) <=
+    bucketResolutionHeight(sourceWidth, sourceHeight)
+  );
 }
 
 /** Compute output dimensions for a profile against a source. Width is

--- a/client/src/app/core/services/quality-manager.service.ts
+++ b/client/src/app/core/services/quality-manager.service.ts
@@ -263,17 +263,20 @@ export class QualityManagerService {
   }
 
   /**
-   * Map variant track height to transcode profile name.
+   * Map a variant track's dimensions to its transcode profile name. Uses
+   * the shared {@link bucketResolutionLabel} so a letterboxed 1918×872
+   * variant maps to "1080p" instead of falling through to "720p" — same
+   * fix as the file-badge bucketing.
+   *
+   * Accepts width as well as height because Shaka variants for cropped
+   * sources expose their cropped dimensions; height alone is misleading
+   * for anamorphic / scope tracks.
    */
-  transcodeTierFromVariantHeight(h: number): string | null {
+  transcodeTierFromVariantHeight(h: number, w?: number): string | null {
     if (h <= 0) return null;
-    if (h >= 2160) return '2160p';
-    if (h >= 1080) return '1080p';
-    if (h >= 720) return '720p';
-    if (h >= 480) return '480p';
-    if (h >= 360) return '360p';
-    if (h >= 240) return '240p';
-    return '144p';
+    const label = bucketResolutionLabel(w, h);
+    if (!label) return null;
+    return label === '4K' ? '2160p' : label;
   }
 
   // ── Private helpers ──

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -471,7 +471,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     if (rateMap && qId !== 'auto' && qId !== 'original' && rateMap[qId]) {
       selectedRateEntry = rateMap[qId];
     } else if (rateMap && (qId === 'auto' || qId === 'original')) {
-      const tier = urlMatch?.[1] ?? this.qualityManager.transcodeTierFromVariantHeight(activeVariant?.height ?? 0);
+      const tier = urlMatch?.[1] ?? this.qualityManager.transcodeTierFromVariantHeight(activeVariant?.height ?? 0, activeVariant?.width);
       if (tier && rateMap[tier]) selectedRateEntry = rateMap[tier];
     }
 


### PR DESCRIPTION
## Summary

The letterboxed-1080p mis-labeling fix from #251 plugged the file badge, but the same bug lived in **three more places** that didn't go through the shared bucketing util:

| Location | Bug | Effect |
|---|---|---|
| `profileFitsSource` (`backend/.../transcoding/profiles.ts`) | `maxWidth <= sourceWidth \|\| maxHeight <= sourceHeight` (OR with raw dims) | For 1918×872 both fail → 1080p profile dropped from the ladder → **player quality picker capped at 720p** |
| `resolveQuality` (`backend/.../media-rescan.service.ts`) | Inline bucket table, private | Stored quality string could disagree with new badge bucketing for edge cases (854×480, …) |
| `sourceResLabel` (`backend/.../system.controller.ts:430`) | height-only thresholds | Admin streams dashboard shows "720p" for the same letterboxed source the badge shows as "1080p" |
| `transcodeTierFromVariantHeight` (`client/.../quality-manager.service.ts`) | height-only thresholds | Bitrate-map lookup mis-keyed for letterboxed variants |

## What this PR does

Introduces a single backend helper in `backend/src/common/utils/resolution.util.ts`:

- `bucketResolutionHeight(w, h): number` — canonical height bucket (144 / 240 / 360 / 480 / 720 / 1080 / 2160) with **ceilings on both axes**.
- `bucketResolutionLabel(w, h): string | null` — sibling helper returning `"4K"` / `"<n>p"`, mirroring the client's `bucketResolutionLabel`.

Then wires all four sites through it:
- `profileFitsSource` compares bucketed heights instead of raw dims.
- `resolveQuality` delegates the bucketing.
- `system.controller`'s active-streams dashboard uses `bucketResolutionLabel`.
- Client's `transcodeTierFromVariantHeight` takes an optional `width` param and routes through the existing client-side `bucketResolutionLabel`.

## Bucket coverage (relevant edge cases)

| Source | Before | After |
|---|---|---|
| **1918×872** (2.20:1 letterboxed 1080p) | 720p (bug) | 1080p ✅ |
| 1920×800 (2.40:1 letterboxed 1080p) | 1080p | 1080p ✅ |
| 3840×2024 (IMAX 4K) | 2160p (rescued by the old OR) | 2160p ✅ |
| 854×480 (16:9 SD widescreen) | 720p (legacy 480-bucket width=720) | 480p ✅ |
| 1920×1080 (standard 1080p) | 1080p | 1080p ✅ |

## Test plan

- [ ] Player: open a letterboxed 1080p source (e.g. 1918×872 or 1920×800). Quality picker now shows 1080p as the top rung, not 720p.
- [ ] File badge: same source, badge already shows 1080p (unchanged from #251), now agrees with the player.
- [ ] Admin streams dashboard (`/system/active-streams`): row for the letterboxed source shows 1080p instead of 720p.
- [ ] Standard 1920×1080 / 3840×2160 sources: unchanged.
- [ ] 4K IMAX-aspect source (3840×2024 or 3840×1600): 2160p still in the ladder.

## Note

Existing files keep their stored quality string until they're rescanned — the badge label fix in #251 only relabels post-rescan content. The player and dashboard fixes here take effect immediately because they compute from live source dimensions, not the stored string.