### PR TITLE
feat(transcoding): prefer HW-encodable codecs over source-codec match

### DIFF
--- a/backend/src/modules/streaming/transcoding/codec/selector.ts
+++ b/backend/src/modules/streaming/transcoding/codec/selector.ts
@@ -1,8 +1,26 @@
-import type { CodecVariant, VideoCodec } from './types';
+import type { CodecVariant, EncoderDescriptor, VideoCodec } from './types';
 import type { DeviceProfileDto } from '../../dto/device-profile.dto';
 import type { HwAccelType } from '../types';
 import { encoderRegistry } from './encoders';
 import { applyQuirks, type QuirkContext } from './fallback';
+
+/**
+ * Resolve an encoder for `variant` whose `hwAccel` matches the detected
+ * backend. Returns null when the only match would be the CPU fallback,
+ * so the selector can move on to the next codec in `codecOrder` instead
+ * of locking in a CPU encode. `hwAccel === 'none'` accepts CPU encoders
+ * unconditionally — that's the configuration of every deployment
+ * without a usable HW backend.
+ */
+function resolveHwEncoder(
+  variant: CodecVariant,
+  hwAccel: HwAccelType,
+): EncoderDescriptor | null {
+  const enc = encoderRegistry.resolve(variant, hwAccel);
+  if (!enc) return null;
+  if (hwAccel === 'none') return enc;
+  return enc.hwAccel === hwAccel ? enc : null;
+}
 
 /** Pick the codec variant(s) we'll expose to a given client. Order of
  *  preference (within each HDR/SDR group):
@@ -43,28 +61,56 @@ export function pickVariants(
 
   // HDR path — only meaningful when source is HDR AND client supports
   // an HDR display (browser caps + display gamut probe). H.264 is
-  // skipped (8-bit only). First codec with a resolvable HDR encoder
-  // (HW + HDR metadata, or CPU libx265/libsvtav1 fallback) wins.
+  // skipped (8-bit only). Two passes: the HW pass picks the first
+  // codec with a HW HDR encoder; the CPU pass runs only when no
+  // candidate codec has a HW HDR encoder — that's the CPU
+  // libx265/libsvtav1 HDR path on boxes without QSV/VAAPI/NVENC.
   if (source.hdr && profile.supportsHdr === true) {
+    const beforeHdr = candidates.length;
     for (const codec of codecOrder) {
       if (codec === 'h264') continue;
       if (!clientSupports(clientCodecs, codec)) continue;
       const variant: CodecVariant = { codec, bitDepth: 10, hdr: source.hdr };
-      if (encoderRegistry.resolve(variant, hwAccel)) {
+      if (resolveHwEncoder(variant, hwAccel)) {
         candidates.push(variant);
         break;
       }
     }
+    if (candidates.length === beforeHdr) {
+      for (const codec of codecOrder) {
+        if (codec === 'h264') continue;
+        if (!clientSupports(clientCodecs, codec)) continue;
+        const variant: CodecVariant = { codec, bitDepth: 10, hdr: source.hdr };
+        if (encoderRegistry.resolve(variant, hwAccel)) {
+          candidates.push(variant);
+          break;
+        }
+      }
+    }
   }
 
-  // SDR ladder — always present, even on HDR clients (they can tone-map
-  // for the SDR fallback when the HDR encoder path is unavailable, and
-  // they need an SDR base anyway for legacy non-HDR sources).
+  // SDR ladder — always present, even on HDR clients (they can tone-
+  // map for the SDR fallback when the HDR encoder path is unavailable,
+  // and they need an SDR base anyway for non-HDR sources). HW-first:
+  // walk `codecOrder` accepting only encoders that match the detected
+  // HW backend, so a HW runner-up beats a CPU-only source-codec match.
+  // The CPU pass underneath only runs when no candidate codec has a
+  // HW encoder at all — typical on hosts with no QSV/VAAPI/NVENC.
+  const beforeSdr = candidates.length;
   for (const codec of codecOrder) {
     if (!clientSupports(clientCodecs, codec)) continue;
     const variant: CodecVariant = { codec, bitDepth: 8, hdr: null };
-    if (encoderRegistry.resolve(variant, hwAccel)) {
+    if (resolveHwEncoder(variant, hwAccel)) {
       candidates.push(variant);
+    }
+  }
+  if (candidates.length === beforeSdr) {
+    for (const codec of codecOrder) {
+      if (!clientSupports(clientCodecs, codec)) continue;
+      const variant: CodecVariant = { codec, bitDepth: 8, hdr: null };
+      if (encoderRegistry.resolve(variant, hwAccel)) {
+        candidates.push(variant);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

When a HW backend is detected, the codec selector now picks the first codec in its priority order whose encoder actually runs on that backend. Source-codec preference is preserved as a tie-breaker between HW-capable codecs.

### The case this fixes

Intel 12th-gen iGPU has HW AV1 **decode** but no HW AV1 **encode**. On that hardware the previous selector logic:

1. Detected `hwAccel = 'qsv'` ✅
2. Iterated `codecOrder = [av1, hevc, h264]` because the source was AV1 and the client supported it.
3. `encoderRegistry.resolve({codec: 'av1'}, 'qsv')` returned `libsvtav1` via the registry's Pass-2 CPU fallback.
4. Selector accepted that variant first → encoder = `libsvtav1` → `effectiveHwAccel = 'none'` → input pipeline dropped `-hwaccel qsv`, decode also went to CPU.

Production log on a 1080p AV1 source: `dec=cpu enc=libsvtav1`. Both ends of the pipeline on CPU on a host with two working HW backends (QSV + VAAPI) and HW AV1 decode available.

### After

The selector walks the SDR (and HDR) ladder twice:

1. **HW pass** (`resolveHwEncoder`) — accept the codec only if `encoderRegistry.resolve` returns an encoder whose `hwAccel` matches the detected backend.
2. **CPU fallback** — only if the HW pass produced no candidates, accept anything (including the CPU encoder). Preserves behaviour on hosts with no HW backend or no HW encoder for any candidate codec.

Outcomes:

| Host | Source codec | Selector picks | Pipeline |
|---|---|---|---|
| Intel 12th-gen QSV | AV1 | HEVC | `dec=qsv` / `enc=hevc_qsv` (full HW) |
| Intel 12th-gen QSV | HEVC | HEVC | `dec=qsv` / `enc=hevc_qsv` (unchanged) |
| Intel Arc A370M | AV1 | AV1 | `dec=qsv` / `enc=av1_qsv` (unchanged — `av1_qsv` survives the HW pass) |
| No HW host | AV1 | AV1 | `dec=cpu` / `enc=libsvtav1` (unchanged) |

## Notes

- DirectPlay / DirectStream still preferred when applicable — this PR only touches the case where transcode is forced (downscale, client codec mismatch, etc.).
- The HDR loop applies the same two-pass logic so HDR sources on hosts without a HW HDR encoder still fall through to the CPU `libx265-hdr10` / `libsvtav1-hdr10` paths.

## Test plan

- [ ] On the 12th-gen QSV host: re-trigger a 720p transcode from an AV1 source. Expect `dec=qsv enc=hevc_qsv` (or `h264_qsv` for clients that don't list HEVC).
- [ ] On the Arc A370M dev box: confirm an AV1 source still picks `av1_qsv` for both decode and encode.
- [ ] Confirm HEVC HDR sources still pick `hevc_qsv` HDR10 (unchanged path).
- [ ] On a host without `/dev/dri`: confirm CPU encoders still resolve as before.