### PR TITLE
fix(quality): route remaining bucketing through the shared helper

### DIFF
--- a/backend/src/modules/streaming/transcoding/codec/fallback.ts
+++ b/backend/src/modules/streaming/transcoding/codec/fallback.ts
@@ -1,3 +1,4 @@
+import { bucketResolutionHeight } from '../../../../common/utils/resolution.util';
 import type { CodecVariant } from './types';
 import type { DeviceProfileDto } from '../../dto/device-profile.dto';
 
@@ -23,8 +24,12 @@ export interface ClientQuirk {
 
 export interface QuirkContext {
   profile: DeviceProfileDto;
-  /** Source video dimensions — required to filter "X codec but only
-   *  ≤ 1080p" quirks like CCwGTV HD silently failing HEVC Main10 @ 4K. */
+  /** Source frame dimensions. Both axes are required so resolution-
+   *  gated quirks ("X codec but only ≤ 1080p", e.g. CCwGTV HD silently
+   *  failing HEVC Main10 @ 4K) can bucket via
+   *  {@link bucketResolutionHeight} — height alone mis-classifies
+   *  anamorphic / scope crops like 1918×872. */
+  sourceWidth: number;
   sourceHeight: number;
   /** Lowercased `User-Agent` header. Optional — quirks that key on
    *  HTTP-only signals (e.g. specific Chromecast firmware versions)
@@ -37,7 +42,7 @@ const CCWGTV_HD_NO_4K_HEVC_HDR: ClientQuirk = {
   matches: (ctx) =>
     /chromecast.+google.+tv/i.test(ctx.userAgent) &&
     !/4k/i.test(ctx.userAgent) &&
-    ctx.sourceHeight > 1080,
+    bucketResolutionHeight(ctx.sourceWidth, ctx.sourceHeight) > 1080,
   filter: (variants) =>
     variants.filter((v) => !(v.codec === 'hevc' && v.hdr !== null)),
   reason:

--- a/backend/src/modules/streaming/transcoding/codec/selector.ts
+++ b/backend/src/modules/streaming/transcoding/codec/selector.ts
@@ -116,6 +116,7 @@ export function pickVariants(
 
   const ctx: QuirkContext = {
     profile,
+    sourceWidth: source.width,
     sourceHeight: source.height,
     userAgent: userAgent.toLowerCase(),
   };

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -33,7 +33,11 @@ function formatFrameRate(fps: number): string {
  *  - `remux` / `original` collapse to the top SDR profile that fits
  *    the source resolution (no upscale). HDR ladder ignores these
  *    pseudo-labels because the source-resolution HDR rung is emitted
- *    via the separate `hdrPassThrough` block.
+ *    via the separate `hdrPassThrough` block. Fitting is delegated
+ *    to {@link profileFitsSource} (bucket on both axes) so anamorphic
+ *    or scope crops (e.g. 1918×872) keep their 1080p top rung — a
+ *    strict `maxWidth <= sourceWidth` check sat one or two pixels
+ *    short and dropped the user back to 720p.
  *  - When `hdrSuffix` is true, an input `1080p` is matched against
  *    `1080p-hdr` (HDR ladder rungs carry the suffix); already
  *    `*-hdr` inputs pass through unchanged.
@@ -43,12 +47,15 @@ function applyQualityPin(
   ladder: TranscodeProfile[],
   onlyQuality: string | undefined,
   sourceWidth: number,
+  sourceHeight: number,
   hdrSuffix = false,
 ): TranscodeProfile[] {
   if (!onlyQuality) return ladder;
   if (onlyQuality === 'remux' || onlyQuality === 'original') {
     if (hdrSuffix) return ladder;
-    const top = ladder.find((p) => p.maxWidth <= sourceWidth) ?? ladder[0];
+    const top =
+      ladder.find((p) => profileFitsSource(p, sourceWidth, sourceHeight)) ??
+      ladder[0];
     return [top];
   }
   const wanted =
@@ -208,6 +215,7 @@ export function generateMasterPlaylist(
         baseHdrLadder,
         onlyQuality,
         sourceWidth,
+        sourceHeight,
         /* hdrSuffix */ true,
       );
       for (const p of hdrLadder) {
@@ -286,7 +294,7 @@ export function generateMasterPlaylist(
   // master exposes a single variant — AVPlayer / ExoPlayer have no
   // other rung to ABR-switch to and playback stays locked at the
   // chosen quality.
-  profiles = applyQualityPin(profiles, onlyQuality, sourceWidth);
+  profiles = applyQualityPin(profiles, onlyQuality, sourceWidth, sourceHeight);
 
   for (const p of profiles) {
     const avg =


### PR DESCRIPTION
## Summary

Two more sites still made their own raw dim comparisons instead of going through `bucketResolutionHeight` / `profileFitsSource`. Both mis-classify letterboxed / anamorphic sources the same way #251 and #256 did. This PR fixes them and adds an audit-grep checklist saved to memory so the next pass catches all the sites in one go.

### Sites fixed

#### 1. `master-playlist.applyQualityPin` (the visible production bug)

When the player's saved quality is `original` or `remux`, the master playlist needs to pin itself to a single top-of-ladder variant. The previous logic used:

```ts
const top = ladder.find((p) => p.maxWidth <= sourceWidth) ?? ladder[0];
```

For a 1918×872 source (2.20:1 letterboxed 1080p AV1, the actual prod case), the 1080p profile (maxWidth=1920) fails `1920 <= 1918` **by two pixels** and falls back to 720p. The master playlist is then pinned to a single 720p variant — Shaka has no 1080p variant to switch to, so even though the dropdown shows "1080p" as the active pick the backend keeps serving `/720p/seg-XXXX.m4s`.

Now delegates to `profileFitsSource` which buckets on both axes.

#### 2. `codec/fallback.QuirkContext.sourceHeight > 1080`

The CCwGTV-HD HEVC Main10 quirk gates on `ctx.sourceHeight > 1080`. Height-only on a letterboxed 1080p master (height 872 < 1080) silently bypasses the quirk even though the source IS 1080p. The inverse — anamorphic 4K with height under 1080 — would silently arm it.

`QuirkContext` gains `sourceWidth` and the predicate buckets via `bucketResolutionHeight(w, h) > 1080`.

## Audit checklist saved to memory

The grep patterns I should have run during #256 and didn't, now saved as a memory rule so the next pass catches:
- Profile-dim vs source-dim comparisons (`maxWidth <= sourceWidth`, etc.)
- `sourceWidth` / `sourceHeight` / `ctx.sourceHeight` compared to a literal
- `ladder.find` / `ladder.filter` that doesn't route through `profileFitsSource`
- Hardcoded resolution thresholds (144 / 240 / … / 2160 / 2560 / 3840)

## Test plan

- [ ] Letterboxed 1080p source (e.g. 1918×872): pick "1080p" / "Original" in the player dropdown. Backend log shows `/1080p/seg-XXXX.m4s` requested, not `/720p/`.
- [ ] Stats overlay: `→ 1918x872` (or whatever the source dimensions are) instead of `→ 1280x582`.
- [ ] Standard 1920×1080 / 3840×2160 / 3840×2024 IMAX sources: unchanged behaviour.
- [ ] CCwGTV HD: quirk still arms for true >1080p sources (3840×2160), still skips for true ≤1080p ones.