### PR TITLE
fix(auth): use userRole relation when rotating refresh tokens

### DIFF
--- a/backend/src/modules/auth/refresh-token.service.ts
+++ b/backend/src/modules/auth/refresh-token.service.ts
@@ -79,7 +79,7 @@ export class RefreshTokenService {
     const hash = this.hash(raw);
     const row = await this.repo.findOne({
       where: { tokenHash: hash },
-      relations: ['user', 'user.role'],
+      relations: ['user', 'user.userRole'],
     });
     if (!row) throw new UnauthorizedException('Invalid refresh token');
 


### PR DESCRIPTION
## Summary

`RefreshTokenService.rotate` loaded the user with `relations: ['user', 'user.role']`, but the `User` entity exposes the role as `userRole`. TypeORM bails with:

```
EntityPropertyNotFoundError: Property "role" was not found in "User". Make sure your query is correct.
```

…the first time a persistent native session tries to refresh — the mobile app surfaces this on cold start, since that's when the cached refresh token hits the rotate endpoint. Stable web sessions don't hit it because their access token is usually still valid when the page is reloaded.

The token-rotation feature shipped in #248 with the wrong relation name and stayed latent until a client actually exercised the rotate path.

## Test plan

- [ ] Open the mobile app with a persistent refresh token cached. No `EntityPropertyNotFoundError` in backend logs, app loads past the splash screen.
- [ ] Web session unaffected (access token path, unchanged).
- [ ] Replay-detection branch (already-revoked token reuse) still triggers — the relation only matters when the rotate succeeds and the loaded `user.userRole.permissions` propagate downstream.