### PR TITLE
fix(ffprobe): infer stream language from tags.title when language is und

### DIFF
--- a/backend/src/common/release-parsing/language.parser.ts
+++ b/backend/src/common/release-parsing/language.parser.ts
@@ -82,6 +82,61 @@ function lang(isoCode: string): AppLanguageDefinition {
 }
 
 /**
+ * Strict version of {@link parseReleaseLanguage} for stream / file
+ * title fields (audio track titles like `"French AC3 5.1"`, subtitle
+ * track titles like `"English SDH"`, etc.). Returns `null` when no
+ * language keyword is recognised — unlike `parseReleaseLanguage`,
+ * which defaults to English because the vast majority of untagged
+ * torrent names ARE English. A muxer that omitted both the
+ * `tags.language` and a language-naming `tags.title` shouldn't be
+ * silently coerced to English: keep `und` so downstream auto-pick
+ * logic can fall back to ordering / size heuristics instead.
+ *
+ * Returns the canonical ISO 639-2/B code (`'fre'`, `'eng'`, …) so
+ * callers can drop it straight into ffprobe-shaped `language` fields.
+ */
+export function inferLanguageCodeFromTitle(
+  title: string | null | undefined,
+): string | null {
+  if (!title) return null;
+  const t = norm(title);
+  if (/\b(french|francais|fran[cç]ais|vff|vfi|vf|truefrench|vostfr|vost)\b/.test(t))
+    return 'fre';
+  if (/\b(english|anglais|eng)\b/.test(t)) return 'eng';
+  if (/\b(german|deutsch|allemand|ger\b|deu\b)\b/.test(t)) return 'ger';
+  if (/\b(spanish|espanol|espa[nñ]ol|espagnol|esp\b|spa\b|latino)\b/.test(t))
+    return 'spa';
+  if (/\b(italian|italiano|italien|ita\b)\b/.test(t)) return 'ita';
+  if (/\b(portuguese|portugu[eê]s|portugais|pt[\- ]br|ptbr|por\b)\b/.test(t))
+    return 'por';
+  if (/\b(japanese|japon[ae]s|japonais|jap\b|jpn\b)\b/.test(t)) return 'jpn';
+  if (/\b(korean|cor[eé]en|kor\b)\b/.test(t)) return 'kor';
+  if (/\b(chinese|chinois|chi\b|chn\b|mandarin|cantonese)\b/.test(t))
+    return 'chi';
+  if (/\b(russian|russe|rus\b)\b/.test(t)) return 'rus';
+  if (/\b(arabic|arabe|ara\b)\b/.test(t)) return 'ara';
+  if (/\b(dutch|n[ée]erlandais|n[ée]er\b|flemish|nld\b|dut\b)\b/.test(t))
+    return 'dut';
+  if (/\b(polish|polonais|pol\b)\b/.test(t)) return 'pol';
+  if (/\b(turkish|turc|tur\b)\b/.test(t)) return 'tur';
+  if (/\b(swedish|su[eè]dois|swe\b)\b/.test(t)) return 'swe';
+  if (/\b(danish|danois|dan\b)\b/.test(t)) return 'dan';
+  if (/\b(norwegian|norv[eé]gien|nor\b)\b/.test(t)) return 'nor';
+  if (/\b(finnish|finlandais|fin\b)\b/.test(t)) return 'fin';
+  if (/\b(hindi|hin\b)\b/.test(t)) return 'hin';
+  if (/\b(czech|tch[eè]que|ces\b|cze\b)\b/.test(t)) return 'cze';
+  if (/\b(romanian|roumain|ron\b|rum\b)\b/.test(t)) return 'rum';
+  if (/\b(hungarian|hongrois|hun\b)\b/.test(t)) return 'hun';
+  if (/\b(thai|thai[ée]?landais|tha\b)\b/.test(t)) return 'tha';
+  if (/\b(vietnamese|vietnamien|vie\b)\b/.test(t)) return 'vie';
+  if (/\b(hebrew|h[eé]breu|heb\b)\b/.test(t)) return 'heb';
+  if (/\b(greek|grec|ell\b|gre\b)\b/.test(t)) return 'gre';
+  if (/\b(ukrainian|ukrainien|ukr\b)\b/.test(t)) return 'ukr';
+  if (/\b(indonesian|indon[eé]sien|ind\b)\b/.test(t)) return 'ind';
+  return null;
+}
+
+/**
  * If parsed language is UNKNOWN and the indexer has an unknownLanguageIsoCode mapping,
  * remap to that language.
  */

--- a/backend/src/modules/subtitles/ffprobe.service.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import * as path from 'path';
+import { inferLanguageCodeFromTitle } from '../../common/release-parsing/language.parser';
 
 const execFileAsync = promisify(execFile);
 
@@ -124,6 +125,20 @@ interface FfprobeStream {
   };
 }
 
+/** Resolve the language code of an ffprobe stream. `tags.language` is the
+ *  authoritative source when set to anything other than `und`; otherwise
+ *  fall back to inferring from `tags.title` (Emby / Plex muxers commonly
+ *  carry the language name in the title, e.g. `"French AC3 5.1"`). Stays
+ *  on `und` when neither is conclusive — auto-pick logic downstream
+ *  handles the unknown-language case by ordering / size heuristics. */
+function resolveStreamLanguage(s: {
+  tags?: { language?: string; title?: string };
+}): string {
+  const explicit = s.tags?.language;
+  if (explicit && explicit.toLowerCase() !== 'und') return explicit;
+  return inferLanguageCodeFromTitle(s.tags?.title) ?? 'und';
+}
+
 @Injectable()
 export class FfprobeService {
   private readonly logger = new Logger(FfprobeService.name);
@@ -153,7 +168,7 @@ export class FfprobeService {
       return streams.map((s) => ({
         streamIndex: s.index,
         codec: s.codec_name ?? 'unknown',
-        language: s.tags?.language ?? 'und',
+        language: resolveStreamLanguage(s),
         forced: s.disposition?.forced === 1,
         hearingImpaired: s.disposition?.hearing_impaired === 1,
         isImageBased: IMAGE_BASED_SUBTITLE_CODECS.has(s.codec_name ?? ''),
@@ -185,7 +200,7 @@ export class FfprobeService {
           streamIndex: s.index,
           type: s.codec_type as 'audio' | 'subtitle',
           codec: s.codec_name ?? 'unknown',
-          language: s.tags?.language ?? 'und',
+          language: resolveStreamLanguage(s),
           title: s.tags?.title,
         }));
     } catch (err: unknown) {
@@ -260,7 +275,7 @@ export class FfprobeService {
         .map((s) => ({
           streamIndex: s.index,
           codec: s.codec_name ?? 'unknown',
-          language: s.tags?.language ?? 'und',
+          language: resolveStreamLanguage(s),
           title: s.tags?.title,
           channels: s.channels,
           channelLayout: s.channel_layout,
@@ -274,7 +289,7 @@ export class FfprobeService {
         .map((s) => ({
           streamIndex: s.index,
           codec: s.codec_name ?? 'unknown',
-          language: s.tags?.language ?? 'und',
+          language: resolveStreamLanguage(s),
           title: s.tags?.title,
           forced: s.disposition?.forced === 1,
           hearingImpaired: s.disposition?.hearing_impaired === 1,

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -52,7 +52,9 @@
     "remux": "Remux",
     "off": "Désactivé",
     "error": "Erreur de lecture",
-    "low_bandwidth": "faible consommation"
+    "low_bandwidth": "faible consommation",
+    "audio_track_n": "Piste {{index}}",
+    "subtitle_track_n": "Sous-titre {{index}}"
   },
   "sse": {
     "subtitle_synced": "Sous-titre synchronisé avec succès.",

--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -44,7 +44,7 @@ export function buildCastAudioOptions(
     const lang = a.language ?? 'und';
     return {
       id: `audio-${i}`,
-      label: formatAudioLabel(a, translate),
+      label: formatAudioLabel(a, translate, i + 1),
       language: lang,
       name: a.title || lang,
     };

--- a/client/src/app/core/utils/player.utils.ts
+++ b/client/src/app/core/utils/player.utils.ts
@@ -1,5 +1,5 @@
 import type { TranslateService } from '@ngx-translate/core';
-import { localizeLanguage } from './language.utils';
+import { localizeLanguage, normalizeLangCode } from './language.utils';
 
 /** Pixel widths backing each ladder rung id (must match the backend
  *  `PROFILES` table). Used by NativeEngine + quality-manager to set
@@ -132,12 +132,23 @@ function audioChannelsLabel(channels: number | null | undefined): string {
  *
  * Format: `"<langue> (CODEC - channels)"`, e.g. `"Français (EAC3 - 5.1)"`.
  * Codec and/or channels are dropped when missing.
+ *
+ * `trackIndex` is the 1-based position of the track in the file's audio
+ * list — used to produce a translated `Piste N` / `Audio N` head when
+ * the language tag is `und` / `xx`, so the dropdown doesn't surface
+ * `und` to the user. Omit the index to keep the literal `und` head
+ * (legacy / non-listed callers).
  */
 export function formatAudioLabel(
   audio: { language?: string; title?: string; codec?: string; channels?: number },
   translate: TranslateService,
+  trackIndex?: number,
 ): string {
-  const head = localizeLanguage(audio.language, translate);
+  const norm = normalizeLangCode(audio.language);
+  const head =
+    trackIndex != null && (norm === 'und' || norm === 'xx')
+      ? translate.instant('player.audio_track_n', { index: trackIndex })
+      : localizeLanguage(audio.language, translate);
   const codec = (audio.codec ?? '').toUpperCase().replace('TRUEHD', 'TrueHD');
   const channels = audioChannelsLabel(audio.channels);
   const tail = [codec, channels].filter(Boolean).join(' - ');
@@ -160,8 +171,13 @@ export function formatSubtitleLabel(
     relativePath?: string | null;
   },
   translate: TranslateService,
+  trackIndex?: number,
 ): string {
-  const head = localizeLanguage(sub.language, translate);
+  const norm = normalizeLangCode(sub.language);
+  const head =
+    trackIndex != null && (norm === 'und' || norm === 'xx')
+      ? translate.instant('player.subtitle_track_n', { index: trackIndex })
+      : localizeLanguage(sub.language, translate);
   const parts: string[] = [];
   if (sub.hearingImpaired) parts.push('HI');
   if (sub.forced) parts.push('Forced');

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1224,7 +1224,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       const audioList = (file?.streamInfo as any)?.audio ?? [];
       const tracks = e.tracks.map((t: any, i: number) => ({
         id: t.id,
-        label: audioList[i] ? formatAudioLabel(audioList[i], this.translate) : t.label,
+        label: audioList[i] ? formatAudioLabel(audioList[i], this.translate, i + 1) : t.label,
         language: normalizeLang(t.language),
         selected: !!t.selected,
       }));

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -263,7 +263,7 @@ export class MediaInfoHeaderComponent {
     if (!audio?.length) return [];
     return audio.map((a: any, i: number) => ({
       index: i,
-      label: formatAudioLabel(a, this.translate),
+      label: formatAudioLabel(a, this.translate, i + 1),
       language: a.language ?? 'und',
     }));
   });


### PR DESCRIPTION
## Summary

Audio and subtitle stream language detection in `ffprobe.service.ts` only looked at ffprobe's `tags.language`, falling back to `und` whenever the muxer left it empty. Files that come from Emby / Plex re-mux pipelines often carry the language *name* in `tags.title` instead (e.g. `"French AC3 5.1"`, `"English SDH"`) — those streams stay on `und` in Fliks while the same file shows the language correctly in Emby.

User-reported case: a movie with two AC3 5.1 tracks, both `tags.language` empty, `tags.title` = `"French AC3 5.1"` / `"English AC3 5.1"`. Fliks shows `und` for both; Emby shows French / English.

## Changes

- **`language.parser.ts`** — adds `inferLanguageCodeFromTitle(title)` returning an ISO 639-2/B code (`'fre'`, `'eng'`, …) or `null`. Strict variant of `parseReleaseLanguage`: returns `null` when nothing matches instead of defaulting to English. Torrent-name parsing keeps the English default; stream titles shouldn't be silently coerced because they're tagged metadata, not user-typed text.
- **`ffprobe.service.ts`** — adds a small `resolveStreamLanguage(s)` helper used by all four stream-mapping sites:
  - `detectEmbeddedSubtitles`
  - `detectStreams`
  - `detectMediaFileInfo` (audio)
  - `detectMediaFileInfo` (subtitle)
  Each returns `tags.language` when set to anything other than `und`; otherwise falls back to `inferLanguageCodeFromTitle(tags.title)`; otherwise stays on `und`.

## Notes on existing data

Existing media keep their cached `streamInfo` — a rescan or re-analyse picks up the new inference on a per-file basis. We're not migrating the DB.

## Test plan

- [ ] File with both `tags.language` set to a real code (e.g. `fre`): unchanged, picks the explicit code.
- [ ] File with `tags.language` missing or `und` AND `tags.title = "French AC3 5.1"`: streams come back as `fre`.
- [ ] File with `tags.language` = `und` AND `tags.title` empty: streams stay on `und` (no false English).
- [ ] Subtitle streams: same three cases.
- [ ] Re-analyse the user-reported AC3 file from the conversation: both tracks show "French" and "English" in the player audio menu, not "und".