### PR TITLE
fix(ffprobe): read stream language/title tags case-insensitively

### DIFF
--- a/backend/src/modules/subtitles/ffprobe.service.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.ts
@@ -117,7 +117,7 @@ interface FfprobeStream {
   channels?: number;
   channel_layout?: string;
   sample_rate?: string;
-  tags?: { language?: string; title?: string };
+  tags?: Record<string, string | undefined>;
   disposition?: {
     forced?: number;
     hearing_impaired?: number;
@@ -125,18 +125,39 @@ interface FfprobeStream {
   };
 }
 
-/** Resolve the language code of an ffprobe stream. `tags.language` is the
- *  authoritative source when set to anything other than `und`; otherwise
- *  fall back to inferring from `tags.title` (Emby / Plex muxers commonly
- *  carry the language name in the title, e.g. `"French AC3 5.1"`). Stays
- *  on `und` when neither is conclusive — auto-pick logic downstream
- *  handles the unknown-language case by ordering / size heuristics. */
+/** Case-insensitive ffprobe tag lookup. Matroska stores per-stream
+ *  metadata in its container-level Tags element with UPPERCASE keys
+ *  (`LANGUAGE`, `TITLE` — common when a file has been touched by
+ *  `mkvpropedit`), while the track-header path surfaces as lowercase
+ *  (`language`, `title`). ffprobe passes both through verbatim, so a
+ *  lowercase-only read silently misses the uppercase variant and the
+ *  track falls back to `und`. */
+function tag(
+  tags: Record<string, string | undefined> | undefined,
+  key: string,
+): string | undefined {
+  if (!tags) return undefined;
+  const want = key.toLowerCase();
+  for (const k of Object.keys(tags)) {
+    if (k.toLowerCase() === want) return tags[k];
+  }
+  return undefined;
+}
+
+/** Resolve the language code of an ffprobe stream. The `language` tag is
+ *  the authoritative source when set to anything other than `und`;
+ *  otherwise fall back to inferring from the `title` tag (Emby / Plex
+ *  muxers commonly carry the language name in the title, e.g.
+ *  `"French AC3 5.1"`). Stays on `und` when neither is conclusive —
+ *  auto-pick logic downstream handles the unknown-language case by
+ *  ordering / size heuristics. Both tags are read case-insensitively
+ *  (see {@link tag}). */
 function resolveStreamLanguage(s: {
-  tags?: { language?: string; title?: string };
+  tags?: Record<string, string | undefined>;
 }): string {
-  const explicit = s.tags?.language;
+  const explicit = tag(s.tags, 'language');
   if (explicit && explicit.toLowerCase() !== 'und') return explicit;
-  return inferLanguageCodeFromTitle(s.tags?.title) ?? 'und';
+  return inferLanguageCodeFromTitle(tag(s.tags, 'title')) ?? 'und';
 }
 
 @Injectable()
@@ -201,7 +222,7 @@ export class FfprobeService {
           type: s.codec_type as 'audio' | 'subtitle',
           codec: s.codec_name ?? 'unknown',
           language: resolveStreamLanguage(s),
-          title: s.tags?.title,
+          title: tag(s.tags, 'title'),
         }));
     } catch (err: unknown) {
       const e = err as { message?: string; stderr?: string };
@@ -235,7 +256,7 @@ export class FfprobeService {
         chapters?: {
           start_time?: string;
           end_time?: string;
-          tags?: { title?: string };
+          tags?: Record<string, string | undefined>;
         }[];
       };
       const streams = parsed.streams ?? [];
@@ -276,7 +297,7 @@ export class FfprobeService {
           streamIndex: s.index,
           codec: s.codec_name ?? 'unknown',
           language: resolveStreamLanguage(s),
-          title: s.tags?.title,
+          title: tag(s.tags, 'title'),
           channels: s.channels,
           channelLayout: s.channel_layout,
           sampleRate: s.sample_rate ? Number(s.sample_rate) : undefined,
@@ -290,7 +311,7 @@ export class FfprobeService {
           streamIndex: s.index,
           codec: s.codec_name ?? 'unknown',
           language: resolveStreamLanguage(s),
-          title: s.tags?.title,
+          title: tag(s.tags, 'title'),
           forced: s.disposition?.forced === 1,
           hearingImpaired: s.disposition?.hearing_impaired === 1,
           isImageBased: IMAGE_BASED_SUBTITLE_CODECS.has(s.codec_name ?? ''),
@@ -300,7 +321,7 @@ export class FfprobeService {
         .map((c) => ({
           startSeconds: c.start_time ? Number(c.start_time) : 0,
           endSeconds: c.end_time ? Number(c.end_time) : 0,
-          title: c.tags?.title,
+          title: tag(c.tags, 'title'),
         }))
         .filter((c) => c.endSeconds > c.startSeconds);
 


### PR DESCRIPTION
## Summary

**Root cause of the "audio shows `und`" reports.** Matroska stores per-stream metadata in its container-level Tags element with **UPPERCASE** keys (`LANGUAGE`, `TITLE`) — common once a file has been touched by `mkvpropedit` — while the track-header path surfaces as lowercase (`language`, `title`). ffprobe passes both through verbatim.

The extractor only read lowercase `tags.language`, so every stream whose language lived in the uppercase Tags element fell back to `und`, even though the language was present.

### Reproduction (real user file)

`Le Droit de tuer (1996) 1080p.mkv`, 2× AC3:

```
$ ffprobe -show_streams ...
audio idx 1: tags { 'LANGUAGE': 'fra', '_STATISTICS_WRITING_APP': "mkvpropedit ...", ... }
audio idx 2: tags { 'LANGUAGE': 'eng', ... }
```

Fliks read `tags.language` (lowercase) → `undefined` → `und` for both. Emby reads case-insensitively → French / English.

## Fix

- Adds a case-insensitive `tag(tags, key)` helper.
- Routes every stream + chapter language/title read through it (`detectEmbeddedSubtitles`, `detectStreams`, `detectMediaFileInfo` audio/subtitle/chapters).
- `FfprobeStream.tags` widened to `Record<string, string | undefined>`.

The #262 title-inference fallback still applies for files that genuinely lack any language tag (lowercase or uppercase).

## Relationship to #262

- #262: `tags.language` missing → infer from `tags.title` (e.g. `"French AC3 5.1"`).
- This PR: `tags.language` present but UPPERCASE → read it directly.

Different files hit different paths; both are needed.

## Notes on existing data

Existing media keep cached `streamInfo` — a rescan re-probes and picks up the corrected language per file.

## Test plan

- [ ] File with `LANGUAGE=fra` / `LANGUAGE=eng` (uppercase Tags element): both tracks resolve to `fra` / `eng`, player shows French / English.
- [ ] File with lowercase `language=fre`: unchanged.
- [ ] File with no language tag but `TITLE="French AC3 5.1"`: still inferred via #262 (uppercase title now also read).
- [ ] File with neither: stays `und`, player shows `Piste N`.
- [ ] Chapters with `TITLE`: chapter names populate.