### PR TITLE
feat(ci): publish iOS to App Store Connect on every release tag

### DIFF
--- a/.github/workflows/appstore-publish.yml
+++ b/.github/workflows/appstore-publish.yml
@@ -1,0 +1,141 @@
+# Builds a signed IPA of the Fliks iOS client and uploads it to App
+# Store Connect on every release tag (`v*` produced by release-please)
+# plus on manual `workflow_dispatch` for ad-hoc re-uploads. The build
+# lands in TestFlight after Apple's processing (~10-30 min); promotion
+# to the public App Store still requires clicking "Submit for Review"
+# from App Store Connect.
+#
+# Build number (CFBundleVersion / CURRENT_PROJECT_VERSION) comes from
+# `git rev-list --count HEAD` so each upload is monotonically higher
+# than the last regardless of marketing version — Apple rejects
+# duplicate build numbers across an app's history.
+#
+# Required repo secrets (one-shot setup):
+#   - APPSTORE_API_KEY_ID         (10-char hex shown next to the key)
+#   - APPSTORE_API_ISSUER_ID      (UUID at the top of the Keys page)
+#   - APPSTORE_API_KEY_P8_BASE64  (the .p8 file, base64-encoded)
+#   - APPLE_TEAM_ID               (Developer team ID — e.g. 85ZC7Y8WQ2)
+#
+# How to mint the API key:
+#   App Store Connect → Users and Access → Keys → App Store Connect API
+#   → "+" → role "App Manager" → download the .p8 (one-shot, save it).
+#   Base64-encode for the secret: `base64 -i AuthKey_XXX.p8 | pbcopy`.
+name: Publish iOS to App Store Connect
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    runs-on: macos-14
+    defaults:
+      run:
+        working-directory: client
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history → `git rev-list --count HEAD` gives a real
+          # commit count for the build number.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+
+      # Pin Xcode to the same major Apple ships in App Store Connect's
+      # review environment. macos-14 image ships 15.4 by default, which
+      # is fine; bump explicitly when Apple bumps the build target.
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_15.4.app
+
+      - name: Install client dependencies
+        run: npm ci
+
+      - name: Build Angular client
+        run: npx ng build --configuration=production
+
+      - name: Capacitor sync to iOS shell
+        run: npx cap sync ios
+
+      - name: Compute build number from commit count
+        id: bnum
+        run: echo "value=$(git rev-list --count HEAD)" >> "$GITHUB_OUTPUT"
+        working-directory: ${{ github.workspace }}
+
+      # Materialise the App Store Connect API key on the runner. Xcode
+      # discovers it via `~/.appstoreconnect/private_keys/AuthKey_<id>.p8`
+      # — no path-shuffling needed past the decode.
+      - name: Stage App Store Connect API key
+        env:
+          KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+          KEY_P8: ${{ secrets.APPSTORE_API_KEY_P8_BASE64 }}
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo "$KEY_P8" | base64 -d \
+            > ~/.appstoreconnect/private_keys/AuthKey_$KEY_ID.p8
+          chmod 600 ~/.appstoreconnect/private_keys/AuthKey_$KEY_ID.p8
+
+      - name: Install CocoaPods
+        run: pod install
+        working-directory: client/ios/App
+
+      - name: Archive iOS app
+        working-directory: client/ios/App
+        env:
+          KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+          ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+        run: |
+          xcodebuild \
+            -workspace App.xcworkspace \
+            -scheme App \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            -archivePath build/App.xcarchive \
+            -allowProvisioningUpdates \
+            -authenticationKeyID "$KEY_ID" \
+            -authenticationKeyIssuerID "$ISSUER_ID" \
+            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_$KEY_ID.p8 \
+            CURRENT_PROJECT_VERSION=${{ steps.bnum.outputs.value }} \
+            DEVELOPMENT_TEAM=${{ secrets.APPLE_TEAM_ID }} \
+            clean archive
+
+      - name: Export signed IPA
+        working-directory: client/ios/App
+        env:
+          KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+          ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+        run: |
+          xcodebuild \
+            -exportArchive \
+            -archivePath build/App.xcarchive \
+            -exportOptionsPlist ExportOptions.plist \
+            -exportPath build/export \
+            -allowProvisioningUpdates \
+            -authenticationKeyID "$KEY_ID" \
+            -authenticationKeyIssuerID "$ISSUER_ID" \
+            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_$KEY_ID.p8
+
+      # `altool --upload-app` is the only ASC upload path that takes an
+      # API key on the command line — `xcrun notarytool` is for
+      # notarisation, `xcrun stapler` for stapling. The deprecation
+      # warning on altool has been "any release now" for years; the
+      # command is still the documented App Store upload entry point.
+      - name: Upload IPA to App Store Connect
+        env:
+          KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+          ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+        run: |
+          xcrun altool --upload-app \
+            --type ios \
+            --file client/ios/App/build/export/App.ipa \
+            --apiKey "$KEY_ID" \
+            --apiIssuer "$ISSUER_ID"
+        working-directory: ${{ github.workspace }}

--- a/client/ios/App/ExportOptions.plist
+++ b/client/ios/App/ExportOptions.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- App Store distribution method. Combined with `signingStyle=automatic`
+	     and the App Store Connect API key passed to `xcodebuild
+	     -authenticationKey…`, this lets the CI Mac runner pull a fresh
+	     distribution cert + provisioning profile per build — no P12 / .mobile-
+	     provision artefacts to maintain in repo secrets. -->
+	<key>method</key>
+	<string>app-store</string>
+	<key>teamID</key>
+	<string>85ZC7Y8WQ2</string>
+	<key>signingStyle</key>
+	<string>automatic</string>
+	<key>uploadBitcode</key>
+	<false/>
+	<key>uploadSymbols</key>
+	<true/>
+	<key>stripSwiftSymbols</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Mirrors `play-store-publish.yml` for iOS. On every `v*` tag (release-please output) and on manual `workflow_dispatch`, the workflow builds the Angular client, cap-syncs the iOS shell, archives + signs with Xcode automatic-signing driven by an App Store Connect API key, and uploads the IPA to App Store Connect via `xcrun altool`.

Builds land in TestFlight after Apple's ~10-30 min processing. Promotion to the public App Store still needs a manual "Submit for Review" click in App Store Connect — deliberate guardrail so a bad commit can't go straight to prod.

## Build number strategy

`CURRENT_PROJECT_VERSION` is derived from `git rev-list --count HEAD` per run. Apple rejects duplicate build numbers across an app's history regardless of marketing version; the commit count is monotonically increasing and globally unique without state.

## Code signing

Automatic signing in combination with `-allowProvisioningUpdates` + `-authenticationKey*` flags lets the runner pull a fresh distribution certificate + provisioning profile per build via the App Store Connect API. No P12 / `.mobileprovision` artefacts to maintain in repo secrets.

## Required secrets (one-shot setup)

| Secret | Where to get it |
|---|---|
| `APPSTORE_API_KEY_ID` | App Store Connect → Users and Access → Keys (10-char hex next to the key name) |
| `APPSTORE_API_ISSUER_ID` | Same page, UUID at the top |
| `APPSTORE_API_KEY_P8_BASE64` | Download the .p8 once at key creation, `base64 -i AuthKey_XXX.p8` |
| `APPLE_TEAM_ID` | The Developer team ID (e.g. `85ZC7Y8WQ2`) |

The key role must be at least **App Manager**.

## Test plan

- [ ] Configure the four secrets in repo settings.
- [ ] `gh workflow run appstore-publish.yml --ref main` (manual trigger) — verify the upload succeeds and the build shows up under TestFlight.
- [ ] Cut a release-please PR + merge → tag pushed → workflow auto-runs.