### PR TITLE
fix(ci): bump iOS publish workflow to Xcode 26 / iOS 26 SDK

### DIFF
--- a/.github/workflows/appstore-publish.yml
+++ b/.github/workflows/appstore-publish.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   build-and-publish:
-    runs-on: macos-14
+    runs-on: macos-15
     defaults:
       run:
         working-directory: client
@@ -50,11 +50,13 @@ jobs:
           cache: npm
           cache-dependency-path: client/package-lock.json
 
-      # Pin Xcode to the same major Apple ships in App Store Connect's
-      # review environment. macos-14 image ships 15.4 by default, which
-      # is fine; bump explicitly when Apple bumps the build target.
+      # Pin Xcode to the build version Apple requires for App Store
+      # uploads. Apple raised the minimum SDK to iOS 26 (Xcode 26.x)
+      # on the 2026 cutover — anything older fails validation with
+      # "SDK version issue" at upload time. macos-15 ships Xcode
+      # 26.x; macos-14 caps out at Xcode 16.
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_15.4.app
+        run: sudo xcode-select -s /Applications/Xcode_26.app
 
       - name: Install client dependencies
         run: npm ci

--- a/client/ios/App/ExportOptions.plist
+++ b/client/ios/App/ExportOptions.plist
@@ -7,8 +7,10 @@
 	     -authenticationKey…`, this lets the CI Mac runner pull a fresh
 	     distribution cert + provisioning profile per build — no P12 / .mobile-
 	     provision artefacts to maintain in repo secrets. -->
+	<!-- `app-store-connect` is the current name; the old `app-store`
+	     value still works but xcodebuild logs a deprecation warning. -->
 	<key>method</key>
-	<string>app-store</string>
+	<string>app-store-connect</string>
 	<key>teamID</key>
 	<string>85ZC7Y8WQ2</string>
 	<key>signingStyle</key>


### PR DESCRIPTION
## Summary

Apple's App Store ingestion now rejects uploads built with anything older than the iOS 26 SDK (Xcode 26+). The previous workflow run failed at the `altool` upload step with:

> SDK version issue. This app was built with the iOS 17.5 SDK. All iOS and iPadOS apps must be built with the iOS 26 SDK or later, included in Xcode 26 or later

## Changes

- `runs-on` → `macos-15`. macos-14 (Sonoma) caps at Xcode 16; the Sequoia image ships Xcode 26.x.
- `Select Xcode` step → `/Applications/Xcode_26.app`.
- `ExportOptions.plist.method` → `app-store-connect`. The legacy `app-store` value still works but xcodebuild logs a deprecation warning on every run.

## Test plan

- [ ] `gh workflow run appstore-publish.yml --ref main` after merge — verify the upload step completes and the build shows up in TestFlight.