### PR TITLE
fix(ci): select Xcode via maxim-lobanov/setup-xcode action

### DIFF
--- a/.github/workflows/appstore-publish.yml
+++ b/.github/workflows/appstore-publish.yml
@@ -50,13 +50,14 @@ jobs:
           cache: npm
           cache-dependency-path: client/package-lock.json
 
-      # Pin Xcode to the build version Apple requires for App Store
-      # uploads. Apple raised the minimum SDK to iOS 26 (Xcode 26.x)
-      # on the 2026 cutover — anything older fails validation with
-      # "SDK version issue" at upload time. macos-15 ships Xcode
-      # 26.x; macos-14 caps out at Xcode 16.
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_26.app
+      # Apple raised the minimum SDK to iOS 26 (Xcode 26.x) on the
+      # 2026 cutover — anything older fails altool validation with
+      # "SDK version issue". `latest-stable` rides along when GitHub
+      # bumps the macos-15 image; pin to `'26.x'` explicitly to
+      # freeze a known-good combo.
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
 
       - name: Install client dependencies
         run: npm ci


### PR DESCRIPTION
Hardcoded `/Applications/Xcode_26.app` doesn't exist — runner images install Xcode under versioned paths (`Xcode_26.0.app`, …). The action resolves the path from a semver spec; `latest-stable` picks the newest Xcode the image ships so the workflow rides image bumps automatically.