### PR TITLE
feat(streams): show client device on the active-streams dashboard

### DIFF
--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -66,6 +66,7 @@ export interface ActiveStreamDto {
   mode: 'transcode' | 'remux' | 'directplay';
   quality: string;
   hwAccel: string;
+  device: string | null;
   startedAt: string;
   lastActivity: string;
   // Progress
@@ -454,6 +455,9 @@ export class SystemController {
         mode: s.mode,
         quality: s.quality,
         hwAccel: s.hwAccelVal,
+        device: s.userId
+          ? this.activeStreamTracker.getDeviceName(s.userId, s.mediaFileId)
+          : null,
         startedAt: s.startedAt,
         lastActivity: s.lastActivity,
         positionSeconds,

--- a/backend/src/modules/streaming/active-stream-tracker.service.ts
+++ b/backend/src/modules/streaming/active-stream-tracker.service.ts
@@ -61,6 +61,21 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
 
   unregister(userId: number, mediaFileId: number) {
     this.sessions.delete(`${userId}-${mediaFileId}`);
+    this.deviceNameCache.delete(`${userId}-${mediaFileId}`);
+  }
+
+  /** Human-readable client device captured at playback-info ("Chrome — macOS",
+   *  "iPhone", "Chromecast — Living Room"). Keyed per (user, file) so two users
+   *  watching the same file from different devices don't collide. Shown only on
+   *  the admin streams dashboard. */
+  private readonly deviceNameCache = new Map<string, string>();
+
+  setDeviceName(userId: number, mediaFileId: number, name: string) {
+    if (name) this.deviceNameCache.set(`${userId}-${mediaFileId}`, name);
+  }
+
+  getDeviceName(userId: number, mediaFileId: number): string | null {
+    return this.deviceNameCache.get(`${userId}-${mediaFileId}`) ?? null;
   }
 
   private readonly tonemappingCache = new Map<number, boolean>();
@@ -301,6 +316,7 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
     for (const [key, session] of this.sessions) {
       if (session.lastActivity.getTime() <= cutoff) {
         this.sessions.delete(key);
+        this.deviceNameCache.delete(key);
       }
     }
   }

--- a/backend/src/modules/streaming/dto/device-profile.dto.ts
+++ b/backend/src/modules/streaming/dto/device-profile.dto.ts
@@ -77,6 +77,12 @@ export class DeviceProfileDto {
   @IsOptional()
   deviceType?: 'mobile' | 'desktop';
 
+  /** Human-readable client device for the admin streams dashboard
+   *  ("Chrome — macOS", "iPhone", "Chromecast — Living Room"). Cosmetic only. */
+  @IsString()
+  @IsOptional()
+  deviceName?: string;
+
   /**
    * Force MPEG-TS segments for every transcode session of this device.
    * Hard override, used as an emergency switch (admin / debug). The

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -581,6 +581,11 @@ export class StreamingController {
       mediaFileId,
       deviceProfile.deviceType ?? 'desktop',
     );
+    this.activeStreamTracker.setDeviceName(
+      (req.user as User).id,
+      mediaFileId,
+      deviceProfile.deviceName ?? '',
+    );
     // Resolve the effective `useTs`. The explicit profile flag wins as
     // an admin / debug hard override. Otherwise Tizen-style profiles
     // opt into TS only when the source has zero or one audio track

--- a/client/src/app/core/services/api/streams-api.service.ts
+++ b/client/src/app/core/services/api/streams-api.service.ts
@@ -16,6 +16,7 @@ export interface ActiveStream {
   mode: 'transcode' | 'remux' | 'directplay';
   quality: string;
   hwAccel: string;
+  device: string | null;
   startedAt: string;
   lastActivity: string;
   positionSeconds: number;

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { Capacitor, registerPlugin } from '@capacitor/core';
 import { PlayerSettingsService } from './player-settings.service';
 import { DeviceService } from './device.service';
+import { getDeviceName } from '../utils/device-info';
 
 interface HdrPlugin {
   isSupported(): Promise<{ supported: boolean }>;
@@ -60,6 +61,9 @@ export interface DeviceProfile {
   /** Client device category — selects the backend bitrate ladder.
    *  Capacitor native (iOS/Android app) → 'mobile'; web (incl. Cast sender) → 'desktop'. */
   deviceType: 'mobile' | 'desktop';
+  /** Human-readable device shown on the admin streams dashboard
+   *  ("Chrome — macOS", "iPhone"). Cosmetic only. */
+  deviceName?: string;
   /** Hard force MPEG-TS HLS for every transcode session of this client.
    *  Defaults to `false`; the only switch in shipping configs is the
    *  narrower `useTsOnSingleAudio` below. Opt-in via
@@ -291,6 +295,7 @@ export class BrowserDeviceProfileService {
       maxAudioChannels,
       supportsHdr,
       deviceType: Capacitor.isNativePlatform() ? 'mobile' : 'desktop',
+      deviceName: getDeviceName(),
       useTs,
       // Tizen-style profiles opt into MPEG-TS on single-audio sources
       // (AVPlay's HLS-fMP4 rendition-probe stall, issue #148). Multi-

--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -154,6 +154,7 @@ export class CastPlayerService {
       maxAudioChannels: maxChannels,
       supportsHdr: cs.hdr ?? false,
       deviceType: 'desktop',
+      deviceName: deviceName ? `Chromecast — ${deviceName}` : 'Chromecast',
       // HLS-TS is disabled on Cast in every scenario. Originally
       // introduced as a workaround for the fMP4 + AAC encoder priming
       // desync (Shaka ignores the init segment `edts/elst` atom), but it

--- a/client/src/app/features/system/streams/streams.html
+++ b/client/src/app/features/system/streams/streams.html
@@ -110,9 +110,12 @@
 
         <div class="divider my-0 mx-3"></div>
 
-        <!-- User -->
+        <!-- User + device -->
         <div class="text-center text-xs text-base-content/60 py-1.5">
           {{ s.username ?? '—' }}
+          @if (s.device) {
+            <div class="text-base-content/40">{{ s.device }}</div>
+          }
         </div>
 
         <!-- Controls (centered, Emby style) -->


### PR DESCRIPTION
## Summary
- Admin "Activités vidéos" cards now show the **device** each session plays on, under the username (e.g. `Chrome — macOS`, `iPhone`, `Samsung TV`, `Chromecast — Living Room`).
- The client sends a `deviceName` with the `playback-info` device profile: derived from the existing `getDeviceName()` UA helper for web/native/TV, and `Chromecast — <receiver>` on the cast path (the sender knows reliably it's casting).
- Backend stores it per `(userId, mediaFileId)` session in `ActiveStreamTracker` (cleared on stop/expiry) and exposes it as `ActiveStreamDto.device`.

## Notes
- Best-effort, UA-based (same approach as the device-pairing display) — good enough to recognize a device, not 100% exact.
- No i18n needed: the value is already a human-readable free string. Paths that don't send `deviceName` simply hide the line.

## Test plan
- [ ] Play in a desktop browser → card shows `Chrome — macOS` (or matching browser/OS).
- [ ] Play on the iOS/Android app → shows `iPhone` / phone model.
- [ ] Cast to a Chromecast → shows `Chromecast — <receiver name>`.
- [ ] Two users on the same file from different devices → each card shows its own device.