### PR TITLE
fix(auto-grab): grab only the targeted episode and heal history links

### DIFF
--- a/backend/src/modules/media/auto-grab-pipeline.service.ts
+++ b/backend/src/modules/media/auto-grab-pipeline.service.ts
@@ -7,6 +7,7 @@ import { DownloadHistory } from './entities/download-history.entity';
 import { buildGrabHistoryRow } from './grab-history.util';
 import { Indexer } from '../indexers/entities/indexer.entity';
 import { TorznabRelease } from '../indexers/torznab.service';
+import { parseSeasonEpisode } from '../../common/release-parsing';
 import { DownloadClient } from '../download-clients/entities/download-client.entity';
 import { QbittorrentService } from '../download-clients/qbittorrent.service';
 import { CustomFormatsService } from '../profiles/custom-formats.service';
@@ -72,6 +73,36 @@ export class AutoGrabPipelineService {
     @Inject(forwardRef(() => RequestLifecycleService))
     private readonly requestLifecycle: RequestLifecycleService,
   ) {}
+
+  /**
+   * Keep only releases compatible with a single-episode target. A release
+   * is dropped when it positively parses to a different season, or to a
+   * different individual episode of the same season. Releases we can't pin
+   * (no parseable S/E) and full-season packs of the right season are kept.
+   * No-op unless both `seasonNumber` and `episodeNumber` are provided.
+   */
+  private filterToTargetEpisode(
+    releases: TorznabRelease[],
+    seasonNumber: number | undefined,
+    episodeNumber: number | undefined,
+    label: string,
+  ): TorznabRelease[] {
+    if (seasonNumber == null || episodeNumber == null) return releases;
+    const kept = releases.filter((r) => {
+      const p = parseSeasonEpisode(r.title);
+      if (p.season == null) return true; // unparseable — leave to the scorer
+      if (p.season !== seasonNumber) return false;
+      if (p.episode != null && p.episode !== episodeNumber) return false;
+      return true;
+    });
+    const dropped = releases.length - kept.length;
+    if (dropped) {
+      this.log.log(
+        `AutoGrab[series]: "${label}" — dropped ${dropped} release(s) belonging to another episode`,
+      );
+    }
+    return kept;
+  }
 
   async buildScoringContext(
     indexers: Indexer[],
@@ -157,6 +188,11 @@ export class AutoGrabPipelineService {
      *  the lifecycle hook can flip only the matching per-season
      *  requests. Whole-series and movie grabs pass undefined. */
     seasonNumber?: number;
+    /** Episode number targeted by this grab. When set together with
+     *  `seasonNumber`, releases that positively parse to a *different*
+     *  episode are rejected — indexer text search is loose and routinely
+     *  returns sibling episodes for a single-episode query. */
+    episodeNumber?: number;
     /** Season + episode primary keys — persisted on the
      *  `DownloadHistory` row so Activities can show "Show — S01E03"
      *  for a single-episode grab without joining back through the
@@ -189,11 +225,27 @@ export class AutoGrabPipelineService {
       return false;
     }
 
+    // Episode-targeted search: drop releases that positively belong to a
+    // different episode. Indexer text search is loose and returns sibling
+    // episodes (and the scorer would happily pick the highest-quality one,
+    // recording it under the searched episode). Season packs of the right
+    // season are kept — they cover the episode and import per-file.
+    const releases = this.filterToTargetEpisode(
+      args.releases,
+      args.seasonNumber,
+      args.episodeNumber,
+      args.label,
+    );
+    if (!releases.length) {
+      logSkip('no release matched the targeted episode');
+      return false;
+    }
+
     const { allowed, allowedLangs } = this.profiles.resolveAllowedForMedia(
       args.media,
     );
     const sorted = await scoreAndSortReleases(
-      args.releases,
+      releases,
       {
         allowed,
         allowedLangs,

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -572,6 +572,7 @@ export class CompletionService {
     const importedFiles: {
       savedFile: MediaFile;
       episodeId?: number;
+      seasonId?: number;
       destPath: string;
     }[] = [];
 
@@ -583,6 +584,7 @@ export class CompletionService {
       let newFilename: string;
       let destDir: string;
       let episodeId: number | undefined;
+      let seasonId: number | undefined;
 
       if (media.type === MediaType.MOVIE) {
         newFilename = this.naming.applyMovieFormat(movieFormat, {
@@ -614,6 +616,7 @@ export class CompletionService {
             where: { media: { id: media.id }, seasonNumber: epNums.season },
           });
           if (season) {
+            seasonId = season.id;
             const episode = await this.episodeRepo.findOne({
               where: {
                 season: { id: season.id },
@@ -721,10 +724,45 @@ export class CompletionService {
         await this.episodeRepo.update(episodeId, { hasFile: true });
       }
 
-      importedFiles.push({ savedFile, episodeId, destPath });
+      importedFiles.push({ savedFile, episodeId, seasonId, destPath });
     }
 
-    await this.historyRepo.update(history.id, { status: 'completed' });
+    // Reconcile the history row with what was actually imported. Its
+    // episode/season were set at grab time to the episode we *searched
+    // for*; a loose indexer match can land a different episode's release,
+    // leaving Activities showing the wrong episode. Re-point from the
+    // imported files: a single episode pins both; a season pack pins the
+    // season and clears the episode. This also self-heals legacy mislinked
+    // rows on re-import.
+    const completedPatch: {
+      status: 'completed';
+      episode?: Episode | null;
+      season?: Season | null;
+    } = { status: 'completed' };
+    if (media.type === MediaType.SERIES) {
+      const epIds = [
+        ...new Set(
+          importedFiles
+            .map((f) => f.episodeId)
+            .filter((id): id is number => id != null),
+        ),
+      ];
+      const seasonIds = [
+        ...new Set(
+          importedFiles
+            .map((f) => f.seasonId)
+            .filter((id): id is number => id != null),
+        ),
+      ];
+      if (epIds.length === 1 && seasonIds.length === 1) {
+        completedPatch.episode = { id: epIds[0] } as Episode;
+        completedPatch.season = { id: seasonIds[0] } as Season;
+      } else if (seasonIds.length === 1) {
+        completedPatch.episode = null;
+        completedPatch.season = { id: seasonIds[0] } as Season;
+      }
+    }
+    await this.historyRepo.update(history.id, completedPatch);
     this.log.log(
       `Import[${history.sourceTitle}]: completed successfully (${importedFiles.length} file(s))`,
     );

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -634,6 +634,7 @@ export class SchedulerService implements OnModuleInit {
         // Episodes are typically 20-60 min; 30 min fallback for size check.
         runtimeMinutes: media.runtime ?? 30,
         seasonNumber: season.seasonNumber,
+        episodeNumber: ep.episodeNumber,
         seasonId: season.id,
         episodeId: ep.id,
         pendingCheck: async () => {


### PR DESCRIPTION
## Problem
An Activity row showed `Stargate SG-1 S01E07 …` (sourceTitle) but resolved to the episode label `S01E01 — Adieu monde cruel`. Root cause: episode-targeted `SearchMissing` records the history row with the episode it *searched for* (`episodeId = E01`) while storing whatever release the scorer picked (`sourceTitle = …S01E07…`). Indexer text search is loose and returns sibling episodes, and `tryAutoGrab` never checked that the picked release's parsed S/E matched the target. Import only re-links the media file (re-parsed correctly to E07) and never reconciles the history row, so the stale grab-time `episodeId` stays and Activities shows the wrong episode.

## Fix
- **Root cause** — `tryAutoGrab` now drops releases that positively parse to a *different* episode before scoring (season packs of the right season and unparseable titles are kept). A single-episode search can no longer grab another episode. `episodeNumber` is now passed from the scheduler's per-episode search.
- **Self-heal / display** — at import, `processOne` re-points the history row's `episode`/`season` to what was actually imported: a single episode pins both, a season pack pins the season and clears the episode. Legacy mislinked rows self-heal on re-import.

## Notes
- Already-imported bad rows won't fix themselves until re-imported (the heal runs at import time). A retroactive reconciliation script could be added separately if needed.
- Multi-episode releases (`S01E01E02`) parse to their first episode, so they may be conservatively dropped for a later-episode search — safe (just skips that release).
- Other `tryAutoGrab` callers (movies, RSS, season packs) don't pass `episodeNumber`, so the filter is a no-op for them.

## Test plan
- [ ] SearchMissing for a missing episode where the indexer returns sibling episodes → only the targeted episode (or a season pack) is grabbed; logs show dropped releases.
- [ ] Import a single-episode torrent → Activity row shows the correct episode even if grabbed under a different one.
- [ ] Import a season pack → row shows the season, files map to their episodes.
- [ ] Re-import a previously mislinked row → it corrects to the right episode.