### PR TITLE
feat(media-detail): add tracking-status modal per item

### DIFF
--- a/backend/src/modules/media/media-service/media-query.service.ts
+++ b/backend/src/modules/media/media-service/media-query.service.ts
@@ -16,8 +16,42 @@ import { CalendarQueryDto } from '../dto/calendar-query.dto';
 import { MediaType } from '../../../common/enums';
 import {
   getAppQualityById,
+  AppQualityDefinition,
 } from '../../../common/constants/app-qualities';
 import { rankFromQualityString } from '../release-rejection.helper';
+import { parseReleaseQuality } from '../../../common/release-parsing';
+
+export type CutoffState =
+  | 'unmonitored'
+  | 'no-profile'
+  | 'missing'
+  | 'below'
+  | 'met';
+
+export interface TrackingItemState {
+  monitored: boolean;
+  state: CutoffState;
+  /** Resolution label of the best file on disk (e.g. "1080p"), when present. */
+  currentQuality?: string;
+  /** Profile cutoff label (e.g. "2160p"), set when state is `below`. */
+  targetQuality?: string;
+}
+
+export interface TrackingEpisode extends TrackingItemState {
+  episodeId: number;
+  seasonNumber: number;
+  episodeNumber: number;
+  title: string | null;
+}
+
+export interface TrackingStatus {
+  type: MediaType;
+  hasProfile: boolean;
+  /** Movie only. */
+  movie?: TrackingItemState;
+  /** Series only. */
+  seasons?: { seasonNumber: number; episodes: TrackingEpisode[] }[];
+}
 
 /**
  * Subquery returning every media.id that the user (`:userId` bind) has
@@ -456,6 +490,84 @@ export class MediaQueryService {
       }
     }
     return media;
+  }
+
+  /**
+   * Per-item monitoring + cutoff state for the "tracking status" modal.
+   * Movie → a single state; series → every episode grouped by season (each
+   * episode keeps its own state so the UI can show "not monitored", "cutoff
+   * met", or the reason it isn't: missing / below cutoff / no profile).
+   */
+  async getTrackingStatus(id: number): Promise<TrackingStatus> {
+    const media = await this.findOne(id);
+    const profile = media.qualityProfile;
+    const cutoffDef = profile ? getAppQualityById(profile.cutoff) : undefined;
+    const targetQuality = cutoffDef ? this.qualityLabel(cutoffDef) : null;
+
+    const stateOf = (
+      monitored: boolean,
+      files: { quality: string }[],
+    ): TrackingItemState => {
+      if (!monitored) return { monitored, state: 'unmonitored' };
+      if (!cutoffDef) return { monitored, state: 'no-profile' };
+      if (!files.length) return { monitored, state: 'missing' };
+      let best: AppQualityDefinition | undefined;
+      for (const f of files) {
+        const def = parseReleaseQuality(f.quality).quality;
+        if (!best || def.rank > best.rank) best = def;
+      }
+      if (best && best.rank >= cutoffDef.rank) {
+        return { monitored, state: 'met', currentQuality: this.qualityLabel(best) };
+      }
+      // Same resolution but a lower-ranked source (e.g. HDTV-2160p vs the
+      // Bluray-2160p cutoff) would render as "2160p → 2160p" and look like a
+      // bug — fall back to the full quality names when resolutions collide so
+      // the actual gap is visible.
+      const sameResolution = !!best && best.resolution === cutoffDef.resolution;
+      return {
+        monitored,
+        state: 'below',
+        currentQuality: best
+          ? sameResolution
+            ? best.name
+            : this.qualityLabel(best)
+          : undefined,
+        targetQuality: sameResolution ? cutoffDef.name : targetQuality ?? undefined,
+      };
+    };
+
+    if (media.type === MediaType.MOVIE) {
+      return {
+        type: media.type,
+        hasProfile: !!profile,
+        movie: stateOf(media.monitored, media.files ?? []),
+      };
+    }
+
+    const filesByEpisode = new Map<number, { quality: string }[]>();
+    for (const f of media.files ?? []) {
+      if (f.episodeId == null) continue;
+      const list = filesByEpisode.get(f.episodeId) ?? [];
+      list.push({ quality: f.quality });
+      filesByEpisode.set(f.episodeId, list);
+    }
+
+    const seasons = (media.seasons ?? []).map((s) => ({
+      seasonNumber: s.seasonNumber,
+      episodes: (s.episodes ?? []).map((e) => ({
+        episodeId: e.id,
+        seasonNumber: s.seasonNumber,
+        episodeNumber: e.episodeNumber,
+        title: e.title,
+        ...stateOf(e.monitored, filesByEpisode.get(e.id) ?? []),
+      })),
+    }));
+
+    return { type: media.type, hasProfile: !!profile, seasons };
+  }
+
+  private qualityLabel(def: AppQualityDefinition): string {
+    return def.resolution > 0 ? `${def.resolution}p` : def.name;
   }
 
   async getCalendar(

--- a/backend/src/modules/media/media.controller.ts
+++ b/backend/src/modules/media/media.controller.ts
@@ -170,6 +170,16 @@ export class MediaController {
     return this.mediaService.bulkUpdate(dto);
   }
 
+  @Get(':id/tracking')
+  @CheckPolicies((ability) => ability.can(Action.Read, Media))
+  async tracking(
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentUser() user: User,
+  ) {
+    await this.assertMediaAccessible(id, user);
+    return this.mediaService.getTrackingStatus(id);
+  }
+
   @Get(':id/releases')
   @CheckPolicies((ability) => ability.can(Action.Read, Media))
   async movieReleases(

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -92,6 +92,10 @@ export class MediaService {
     return this.query.findOne(id);
   }
 
+  getTrackingStatus(id: number) {
+    return this.query.getTrackingStatus(id);
+  }
+
   getCast(mediaId: number): Promise<MediaCast[]> {
     return this.query.getCast(mediaId);
   }

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -854,6 +854,17 @@
     "fstatus_quality_not_upgraded": "Qualité non améliorée",
     "fstatus_import_failed": "Échec de l'import"
   },
+  "tracking": {
+    "menu_item": "Voir l'état du suivi",
+    "title": "État du suivi",
+    "this_movie": "Ce film",
+    "season": "Saison {{number}}",
+    "not_monitored": "Non surveillé",
+    "cutoff_met": "Cutoff atteint",
+    "missing": "Manquant",
+    "no_profile": "Aucun profil qualité",
+    "empty": "Rien à afficher"
+  },
   "calendar": {
     "title": "Calendrier",
     "load_error": "Impossible de charger le calendrier.",

--- a/client/src/app/core/services/api/media.service.ts
+++ b/client/src/app/core/services/api/media.service.ts
@@ -111,6 +111,34 @@ export interface Media {
   metadata?: MediaMetadataBrief | null;
 }
 
+export type CutoffState =
+  | 'unmonitored'
+  | 'no-profile'
+  | 'missing'
+  | 'below'
+  | 'met';
+
+export interface TrackingItemState {
+  monitored: boolean;
+  state: CutoffState;
+  currentQuality?: string;
+  targetQuality?: string;
+}
+
+export interface TrackingEpisode extends TrackingItemState {
+  episodeId: number;
+  seasonNumber: number;
+  episodeNumber: number;
+  title: string | null;
+}
+
+export interface TrackingStatus {
+  type: 'movie' | 'series';
+  hasProfile: boolean;
+  movie?: TrackingItemState;
+  seasons?: { seasonNumber: number; episodes: TrackingEpisode[] }[];
+}
+
 /** Extended TMDB fields rendered in the media-detail info panel. */
 export interface MediaMetadataBrief {
   budget: number | null;
@@ -289,6 +317,12 @@ export class MediaService {
 
   getOne(id: number) {
     return firstValueFrom(this.http.get<Media>(`/api/media/${id}`));
+  }
+
+  getTracking(id: number) {
+    return firstValueFrom(
+      this.http.get<TrackingStatus>(`/api/media/${id}/tracking`),
+    );
   }
 
   getCast(id: number) {

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -18,6 +18,16 @@
         <span class="flex-1">{{ 'media_detail.episodes_available_only' | translate }}</span>
       </label>
       @if (selSeason) {
+        @if (selSeason.monitored) {
+          <button
+            type="button"
+            class="dropdown-item text-white"
+            (click)="viewSeasonTracking.emit(selSeason.seasonNumber)"
+          >
+            <svg lucideListChecks class="h-5 w-5 shrink-0 opacity-80"></svg>
+            <span class="flex-1">{{ 'tracking.menu_item' | translate }}</span>
+          </button>
+        }
         <button
           type="button"
           [disabled]="seasonWatchedBusyId() === selSeason.id"

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -16,6 +16,7 @@ import {
   LucideEllipsisVertical,
   LucideEye,
   LucideEyeOff,
+  LucideListChecks,
   LucidePackage,
   LucideX,
 } from '@lucide/angular';
@@ -41,7 +42,7 @@ import { PlayableMediaService } from '../../../../core/services/playable-media.s
 
 @Component({
   selector: 'app-media-detail-seasons',
-  imports: [TranslateModule, FormsModule, UpperCasePipe, HorizontalScrollerComponent, MediaCardComponent, DropdownMenuComponent, TvSelectDirective, TvRowDirective, LucideCheck, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucidePackage, LucideX],
+  imports: [TranslateModule, FormsModule, UpperCasePipe, HorizontalScrollerComponent, MediaCardComponent, DropdownMenuComponent, TvSelectDirective, TvRowDirective, LucideCheck, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideListChecks, LucidePackage, LucideX],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-seasons.component.html',
 })
@@ -87,6 +88,8 @@ export class MediaDetailSeasonsComponent {
   readonly toggleEpisodeWatched = output<{ episode: Episode; watched: boolean }>();
   /** Viewer (regular requester) asks to (re-)request this season. */
   readonly requestSeason = output<Season>();
+  /** Open the tracking-status modal for this season (emits the season number). */
+  readonly viewSeasonTracking = output<number>();
   readonly seasonWatchedBusyId = input<number | null>(null);
 
   /** Every episode with a file in the season is in the watched set. */

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -73,6 +73,7 @@
           (editSubtitles)="openSubtitles()"
           (episodeWatchedToggled)="onEpisodeWatchedToggledFromHeader($event)"
           (requestMedia)="openRequestForMedia()"
+          (openTracking)="openTracking({ kind: 'episode', episodeId: ep.id })"
         />
 
         @if (currentSeasonEpisodes().length > 1) {
@@ -180,6 +181,7 @@
           (seriesWatchedToggled)="onSeriesWatchedToggled($event)"
           (editSubtitles)="openSubtitles()"
           (requestMedia)="openRequestForMedia()"
+          (openTracking)="openTracking(m.type === 'movie' ? { kind: 'movie' } : { kind: 'series' })"
         />
 
         @if (m.type === 'movie') {
@@ -232,6 +234,7 @@
             (toggleSeasonWatched)="onToggleSeasonWatched(m.id, $event.season, $event.watched)"
             (toggleEpisodeWatched)="onToggleEpisodeWatched(m.id, $event.episode, $event.watched)"
             (requestSeason)="openRequestForSeason($event)"
+            (viewSeasonTracking)="openTracking({ kind: 'season', seasonNumber: $event })"
           />
         }
 
@@ -250,6 +253,7 @@
 
     <!-- Modals (shared between modes) -->
     <div>
+      <app-tracking-status-modal #trackingModal />
       <app-releases-modal #movieReleasesModal
         [title]="'media_detail.download_section' | translate"
         [releases]="releases()"

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -40,6 +40,10 @@ import { SubtitlesModalComponent } from '../../shared/components/subtitles-modal
 import { MediaFileInfoComponent } from '../../shared/components/media-file-info';
 import { MediaDetailSeasonsComponent } from './components/media-detail-seasons/media-detail-seasons.component';
 import { ReleasesModalComponent } from './components/releases-modal/releases-modal.component';
+import {
+  TrackingStatusModalComponent,
+  TrackingScope,
+} from '../../shared/components/tracking-status-modal/tracking-status-modal';
 import { MediaDetailProfilesModalComponent } from './components/media-detail-profiles-modal/media-detail-profiles-modal.component';
 import { MediaDetailLibraryModalComponent } from './components/media-detail-library-modal/media-detail-library-modal.component';
 import { RequestModalComponent } from '../tmdb-preview/components/request-modal/request-modal.component';
@@ -83,6 +87,7 @@ function readEpisodesHasFileOnlyFromStorage(): boolean {
     MediaFileInfoComponent,
     MediaDetailSeasonsComponent,
     ReleasesModalComponent,
+    TrackingStatusModalComponent,
     MediaDetailProfilesModalComponent,
     MediaDetailLibraryModalComponent,
     RequestModalComponent,
@@ -590,6 +595,13 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   readonly profilesModal = viewChild(MediaDetailProfilesModalComponent);
   readonly libraryModal = viewChild(MediaDetailLibraryModalComponent);
   readonly subtitleSection = viewChild(SubtitlesModalComponent);
+  readonly trackingModal = viewChild(TrackingStatusModalComponent);
+
+  openTracking(scope: TrackingScope): void {
+    const id = this.media()?.id;
+    if (id == null) return;
+    void this.trackingModal()?.open(id, scope);
+  }
 
   readonly episodeDialogFiles = computed(() => {
     const c = this.episodeDrawerContext();

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -374,6 +374,12 @@
       <span class="flex-1">{{ (watched() ? 'media_detail.mark_series_unwatched' : 'media_detail.mark_series_watched') | translate }}</span>
     </button>
   }
+  @if (monitored()) {
+    <button type="button" class="dropdown-item text-white" (click)="openTracking.emit()">
+      <svg lucideListChecks class="h-5 w-5 shrink-0 opacity-80"></svg>
+      <span class="flex-1">{{ 'tracking.menu_item' | translate }}</span>
+    </button>
+  }
   <!-- Grab + Search releases are per-unit (movie or single episode). Hide
        on the series-level header — the user picks a specific episode
        from the seasons grid first, which renders its own header with

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -26,6 +26,7 @@ import {
   LucideFileText,
   LucideFilm,
   LucideFolder,
+  LucideListChecks,
   LucidePlay,
   LucideRotateCcw,
   LucideScanLine,
@@ -88,7 +89,7 @@ interface AudioTrack {
     DecimalPipe, FormsModule, RouterLink, TranslateModule,
     LucideCaptions, LucideChevronLeft, LucideCheck, LucideClipboardList, LucideDownload,
     LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideFileText,
-    LucideFilm, LucideFolder, LucidePlay, LucideRotateCcw, LucideScanLine,
+    LucideFilm, LucideFolder, LucideListChecks, LucidePlay, LucideRotateCcw, LucideScanLine,
     LucideSearch, LucideSettings, LucideSkipForward, LucideTrash2,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -182,6 +183,9 @@ export class MediaInfoHeaderComponent {
   readonly openAnalyze = output<void>();
   readonly detectIntros = output<void>();
   readonly editSubtitles = output<void>();
+  /** Open the tracking-status modal scoped to this header's context
+   *  (whole series / the movie / the current episode). */
+  readonly openTracking = output<void>();
   /** Viewer (regular requester) asks to (re-)request the current title. */
   readonly requestMedia = output<void>();
   /** Emitted after a series-level bulk watched toggle. Parent should refresh its episode watched list. */

--- a/client/src/app/shared/components/tracking-status-modal/tracking-status-modal.html
+++ b/client/src/app/shared/components/tracking-status-modal/tracking-status-modal.html
@@ -1,0 +1,92 @@
+<dialog #dialog class="modal">
+  <div class="modal-box max-w-lg">
+    <form method="dialog">
+      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+    </form>
+    <h3 class="text-lg font-bold mb-3">{{ 'tracking.title' | translate }}</h3>
+
+    @if (loading()) {
+      <div class="flex justify-center py-10">
+        <span class="loading loading-spinner loading-lg"></span>
+      </div>
+    } @else if (data(); as d) {
+      @if (!d.hasProfile) {
+        <div role="alert" class="alert alert-warning text-sm mb-3">
+          {{ 'tracking.no_profile' | translate }}
+        </div>
+      }
+
+      @if (d.type === 'movie' && d.movie) {
+        <div class="flex items-center justify-between gap-3 py-1.5">
+          <span class="text-sm font-medium">{{ 'tracking.this_movie' | translate }}</span>
+          <ng-container *ngTemplateOutlet="line; context: { $implicit: d.movie }"></ng-container>
+        </div>
+      } @else {
+        <div class="flex flex-col gap-3 max-h-[60vh] overflow-y-auto">
+          @for (s of seasons(); track s.seasonNumber) {
+            <div>
+              @if (scope().kind === 'series') {
+                <div class="text-xs font-semibold uppercase tracking-wide text-base-content/50 mb-1">
+                  {{ 'tracking.season' | translate:{ number: s.seasonNumber } }}
+                </div>
+              }
+              <div class="flex flex-col">
+                @for (ep of s.episodes; track ep.episodeId) {
+                  <div class="flex items-center justify-between gap-3 py-1.5 border-b border-base-200 last:border-0">
+                    <span class="text-sm truncate">{{ episodeLabel(ep) }}</span>
+                    <ng-container *ngTemplateOutlet="line; context: { $implicit: ep }"></ng-container>
+                  </div>
+                }
+              </div>
+            </div>
+          } @empty {
+            <p class="text-sm text-base-content/50 py-4 text-center">
+              {{ 'tracking.empty' | translate }}
+            </p>
+          }
+        </div>
+      }
+    } @else {
+      <p class="text-sm text-base-content/50 py-4 text-center">
+        {{ 'tracking.empty' | translate }}
+      </p>
+    }
+
+    <div class="modal-action">
+      <button type="button" class="btn btn-sm" (click)="close()">
+        {{ 'common.close' | translate }}
+      </button>
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+</dialog>
+
+<ng-template #line let-s>
+  <span class="text-sm shrink-0 inline-flex items-center gap-1">
+    @switch (s.state) {
+      @case ('unmonitored') {
+        <span class="text-base-content/50 inline-flex items-center gap-1">
+          <svg lucideEyeOff class="h-4 w-4"></svg>{{ 'tracking.not_monitored' | translate }}
+        </span>
+      }
+      @case ('met') {
+        <span class="text-success inline-flex items-center gap-1">
+          <svg lucideCheck class="h-4 w-4"></svg>{{ 'tracking.cutoff_met' | translate }}
+        </span>
+      }
+      @case ('missing') {
+        <span class="text-warning inline-flex items-center gap-1">
+          <svg lucideCircleAlert class="h-4 w-4"></svg>{{ 'tracking.missing' | translate }}
+        </span>
+      }
+      @case ('below') {
+        <span class="text-warning inline-flex items-center gap-1">
+          {{ s.currentQuality }}<svg lucideArrowRight class="h-4 w-4"></svg>{{ s.targetQuality }}
+        </span>
+      }
+      @case ('no-profile') {
+        <span class="text-base-content/50">{{ 'tracking.no_profile' | translate }}</span>
+      }
+    }
+  </span>
+</ng-template>

--- a/client/src/app/shared/components/tracking-status-modal/tracking-status-modal.ts
+++ b/client/src/app/shared/components/tracking-status-modal/tracking-status-modal.ts
@@ -1,0 +1,95 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  computed,
+  inject,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
+import {
+  LucideArrowRight,
+  LucideCheck,
+  LucideCircleAlert,
+  LucideEyeOff,
+} from '@lucide/angular';
+import {
+  MediaService,
+  TrackingEpisode,
+  TrackingStatus,
+} from '../../../core/services/api/media.service';
+
+export type TrackingScope =
+  | { kind: 'movie' }
+  | { kind: 'series' }
+  | { kind: 'season'; seasonNumber: number }
+  | { kind: 'episode'; episodeId: number };
+
+@Component({
+  selector: 'app-tracking-status-modal',
+  standalone: true,
+  imports: [
+    NgTemplateOutlet,
+    TranslateModule,
+    LucideArrowRight,
+    LucideCheck,
+    LucideCircleAlert,
+    LucideEyeOff,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './tracking-status-modal.html',
+})
+export class TrackingStatusModalComponent {
+  private readonly media = inject(MediaService);
+  private readonly dialog =
+    viewChild<ElementRef<HTMLDialogElement>>('dialog');
+
+  readonly loading = signal(false);
+  readonly data = signal<TrackingStatus | null>(null);
+  readonly scope = signal<TrackingScope>({ kind: 'series' });
+
+  /** Open the modal for a media, scoped to the whole series / a season /
+   *  a single episode / a movie. Fetches fresh tracking state each time. */
+  async open(mediaId: number, scope: TrackingScope): Promise<void> {
+    this.scope.set(scope);
+    this.data.set(null);
+    this.loading.set(true);
+    this.dialog()?.nativeElement.showModal();
+    try {
+      this.data.set(await this.media.getTracking(mediaId));
+    } catch {
+      this.data.set(null);
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  close(): void {
+    this.dialog()?.nativeElement.close();
+  }
+
+  /** Seasons to render, filtered to the active scope. */
+  readonly seasons = computed(() => {
+    const d = this.data();
+    if (!d?.seasons) return [];
+    const sc = this.scope();
+    if (sc.kind === 'season') {
+      return d.seasons.filter((s) => s.seasonNumber === sc.seasonNumber);
+    }
+    if (sc.kind === 'episode') {
+      for (const s of d.seasons) {
+        const ep = s.episodes.find((e) => e.episodeId === sc.episodeId);
+        if (ep) return [{ seasonNumber: s.seasonNumber, episodes: [ep] }];
+      }
+      return [];
+    }
+    return d.seasons;
+  });
+
+  episodeLabel(ep: TrackingEpisode): string {
+    const code = `S${String(ep.seasonNumber).padStart(2, '0')}E${String(ep.episodeNumber).padStart(2, '0')}`;
+    return ep.title ? `${code} — ${ep.title}` : code;
+  }
+}


### PR DESCRIPTION
## Summary
- New **"Voir l'état du suivi"** action in the movie / series / season / episode menus, opening a modal that shows the monitoring + cutoff state per item.
- Per episode: `SxxExx — Title` + a dynamic line — **Non surveillé** / ✓ **Cutoff atteint** / **Manquant** / `current → target` quality / **Aucun profil qualité**. Scoped to the whole series (grouped by season), a season, a single episode, or the movie.
- State is computed server-side: `GET /media/:id/tracking` (`MediaQueryService.getTrackingStatus`) using the authoritative quality ranks (`rankFromQualityString` + `getAppQualityById(profile.cutoff)`). No migration.

## Notes
- A lower-ranked same-resolution source (e.g. `HDTV-2160p` with a `Bluray-2160p` cutoff) is correctly **below cutoff**; the label shows full quality names (`HDTV-2160p → Bluray-2160p`) instead of a confusing `2160p → 2160p`. Different resolutions stay concise (`1080p → 2160p`).
- The option is **hidden when the scoped item isn't monitored**. The `unmonitored` state still renders per-episode inside a monitored series/season.

## Test plan
- [ ] Movie below cutoff (HDTV-2160p vs Bluray-2160p) → modal shows `HDTV-2160p → Bluray-2160p`.
- [ ] Series → modal lists episodes grouped by season with each state; season/episode menus scope correctly.
- [ ] Unmonitored movie/episode/season → option hidden.
- [ ] Episode below cutoff in a different resolution → `1080p → 2160p`.