### PR TITLE
fix(episodes): treat multi-episode files as on-disk via derived coverage

### DIFF
--- a/backend/src/modules/media/entities/episode.entity.ts
+++ b/backend/src/modules/media/entities/episode.entity.ts
@@ -49,6 +49,11 @@ export class Episode extends BaseEntity {
   @Column({ default: true })
   monitored: boolean;
 
+  /** True when this episode has its OWN media file. Drives playback, intro
+   *  detection and watched tracking — things that need a directly playable
+   *  file. A shadowed episode of a multi-episode file stays `false` here; its
+   *  "on disk" status is derived via `episode-coverage.util` (coverage), not
+   *  stored. */
   @Column({ default: false })
   hasFile: boolean;
 

--- a/backend/src/modules/media/episode-coverage.util.ts
+++ b/backend/src/modules/media/episode-coverage.util.ts
@@ -1,0 +1,63 @@
+/**
+ * Single source of truth for "is an episode's content on disk" (coverage).
+ *
+ * `episode.hasFile` means "this episode has its OWN file" — used by playback,
+ * intro detection and watched tracking. Coverage is broader: an episode is on
+ * disk when it has its own file OR it's a shadowed episode of a multi-episode
+ * file, i.e. inside the `[episodeNumber..endEpisodeNumber]` range of an owner
+ * episode that has a file ("S06E17-E18.mkv" → E17 owns the file, E18 covered).
+ *
+ * Coverage is DERIVED, never stored, so it can't drift and needs no migration.
+ * Missing/search/request/stats logic must use the helpers here, NOT raw
+ * `hasFile`. The SQL fragment and the TS helper implement the same rule — keep
+ * them in sync.
+ */
+
+/** Minimal episode shape the coverage rule needs. */
+export interface CoverageEpisode {
+  episodeNumber: number;
+  endEpisodeNumber?: number | null;
+  hasFile: boolean;
+}
+
+/** Episode numbers in a season whose content is on disk (own file or covered
+ *  by a multi-episode file). Compute once per season, then `.has(epNumber)`. */
+export function onDiskEpisodeNumbers(
+  seasonEpisodes: CoverageEpisode[],
+): Set<number> {
+  const numbers = new Set<number>();
+  for (const owner of seasonEpisodes) {
+    if (!owner.hasFile) continue;
+    numbers.add(owner.episodeNumber);
+    const end = owner.endEpisodeNumber;
+    if (end != null && end > owner.episodeNumber) {
+      for (let n = owner.episodeNumber + 1; n <= end; n++) numbers.add(n);
+    }
+  }
+  return numbers;
+}
+
+/** Whether a single episode's content is on disk, given its season siblings. */
+export function isEpisodeOnDisk(
+  episode: CoverageEpisode,
+  seasonEpisodes: CoverageEpisode[],
+): boolean {
+  return onDiskEpisodeNumbers(seasonEpisodes).has(episode.episodeNumber);
+}
+
+/**
+ * SQL boolean expression equivalent to {@link isEpisodeOnDisk}, for queries.
+ * `epAlias` is the episodes-table alias in scope. The correlated subquery finds
+ * an owner episode in the same season whose multi-episode range covers this row.
+ */
+export function onDiskSql(epAlias: string): string {
+  const e = `"${epAlias}"`;
+  return `(${e}."hasFile" = true OR EXISTS (
+    SELECT 1 FROM "episodes" cov
+    WHERE cov."seasonId" = ${e}."seasonId"
+      AND cov."hasFile" = true
+      AND cov."endEpisodeNumber" IS NOT NULL
+      AND ${e}."episodeNumber" > cov."episodeNumber"
+      AND ${e}."episodeNumber" <= cov."endEpisodeNumber"
+  ))`;
+}

--- a/backend/src/modules/media/episode-download.service.ts
+++ b/backend/src/modules/media/episode-download.service.ts
@@ -11,6 +11,7 @@ import { Season } from './entities/season.entity';
 import { Episode } from './entities/episode.entity';
 import { DownloadHistory } from './entities/download-history.entity';
 import { buildGrabHistoryRow } from './grab-history.util';
+import { onDiskEpisodeNumbers } from './episode-coverage.util';
 import { Indexer } from '../indexers/entities/indexer.entity';
 import { DownloadClient } from '../download-clients/entities/download-client.entity';
 import { TorznabService } from '../indexers/torznab.service';
@@ -708,8 +709,13 @@ export class EpisodeDownloadService {
     this.log.log(`No season pack found, falling back to per-episode grab`);
     const today = new Date().toISOString().slice(0, 10);
     const allEpisodes = season.episodes ?? [];
+    const onDiskNums = onDiskEpisodeNumbers(allEpisodes);
     const missingEpisodes = allEpisodes.filter(
-      (ep) => ep.monitored && !ep.hasFile && ep.airDate && ep.airDate <= today,
+      (ep) =>
+        ep.monitored &&
+        !onDiskNums.has(ep.episodeNumber) &&
+        ep.airDate &&
+        ep.airDate <= today,
     );
     const skippedCount = allEpisodes.length - missingEpisodes.length;
     this.log.log(

--- a/backend/src/modules/media/media-service/media-query.service.ts
+++ b/backend/src/modules/media/media-service/media-query.service.ts
@@ -1,11 +1,6 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import {
-  Brackets,
-  DataSource,
-  Repository,
-  SelectQueryBuilder,
-} from 'typeorm';
+import { Brackets, DataSource, Repository, SelectQueryBuilder } from 'typeorm';
 import { Media } from '../entities/media.entity';
 import { Season } from '../entities/season.entity';
 import { Episode } from '../entities/episode.entity';
@@ -20,6 +15,7 @@ import {
 } from '../../../common/constants/app-qualities';
 import { rankFromQualityString } from '../release-rejection.helper';
 import { parseReleaseQuality } from '../../../common/release-parsing';
+import { onDiskSql } from '../episode-coverage.util';
 
 export type CutoffState =
   | 'unmonitored'
@@ -41,6 +37,8 @@ export interface TrackingEpisode extends TrackingItemState {
   episodeId: number;
   seasonNumber: number;
   episodeNumber: number;
+  /** Last episode number when this row is a multi-episode file (else null). */
+  endEpisodeNumber: number | null;
   title: string | null;
 }
 
@@ -270,12 +268,14 @@ export class MediaQueryService {
     if (seriesIds.length) {
       const stats: { mediaId: number; total: string; downloaded: string }[] =
         await this.dataSource.query(
+          // "downloaded" = episodes whose content is on disk (coverage),
+          // including the shadowed episodes of a multi-episode file. Counting
+          // MediaFile rows or hasFile alone would undercount those.
           `SELECT s."mediaId",
                   COUNT(e.id) AS total,
-                  COUNT(mf.id) AS downloaded
+                  COUNT(e.id) FILTER (WHERE ${onDiskSql('e')}) AS downloaded
            FROM seasons s
            JOIN episodes e ON e."seasonId" = s.id
-           LEFT JOIN media_files mf ON mf."episodeId" = e.id
            WHERE s."mediaId" = ANY($1) AND s."seasonNumber" > 0
            GROUP BY s."mediaId"`,
           [seriesIds],
@@ -481,11 +481,11 @@ export class MediaQueryService {
           .map((f) => f.episodeId)
           .filter((id): id is number => id != null && id > 0),
       );
+      // In-memory heal of own-file hasFile from the loaded files (coverage is
+      // derived on read via episode-coverage.util, not stored here).
       for (const s of media.seasons) {
         for (const e of s.episodes ?? []) {
-          if (epIdsWithTrackedFile.has(e.id)) {
-            e.hasFile = true;
-          }
+          if (epIdsWithTrackedFile.has(e.id)) e.hasFile = true;
         }
       }
     }
@@ -517,7 +517,11 @@ export class MediaQueryService {
         if (!best || def.rank > best.rank) best = def;
       }
       if (best && best.rank >= cutoffDef.rank) {
-        return { monitored, state: 'met', currentQuality: this.qualityLabel(best) };
+        return {
+          monitored,
+          state: 'met',
+          currentQuality: this.qualityLabel(best),
+        };
       }
       // Same resolution but a lower-ranked source (e.g. HDTV-2160p vs the
       // Bluray-2160p cutoff) would render as "2160p → 2160p" and look like a
@@ -532,7 +536,9 @@ export class MediaQueryService {
             ? best.name
             : this.qualityLabel(best)
           : undefined,
-        targetQuality: sameResolution ? cutoffDef.name : targetQuality ?? undefined,
+        targetQuality: sameResolution
+          ? cutoffDef.name
+          : (targetQuality ?? undefined),
       };
     };
 
@@ -544,6 +550,9 @@ export class MediaQueryService {
       };
     }
 
+    // The multi-episode file is linked to its owner episode (E17); the shadowed
+    // episodes (E18) are hidden below, so mapping each file to its owner is
+    // enough to render the owner's state.
     const filesByEpisode = new Map<number, { quality: string }[]>();
     for (const f of media.files ?? []) {
       if (f.episodeId == null) continue;
@@ -552,16 +561,34 @@ export class MediaQueryService {
       filesByEpisode.set(f.episodeId, list);
     }
 
-    const seasons = (media.seasons ?? []).map((s) => ({
-      seasonNumber: s.seasonNumber,
-      episodes: (s.episodes ?? []).map((e) => ({
-        episodeId: e.id,
+    const seasons = (media.seasons ?? []).map((s) => {
+      // Hide shadowed episodes (covered by another episode's range) and label
+      // the owner with its range — same convention as the episode grid.
+      const shadowed = new Set<number>();
+      for (const e of s.episodes ?? []) {
+        if (
+          e.endEpisodeNumber != null &&
+          e.endEpisodeNumber > e.episodeNumber
+        ) {
+          for (let n = e.episodeNumber + 1; n <= e.endEpisodeNumber; n++) {
+            shadowed.add(n);
+          }
+        }
+      }
+      return {
         seasonNumber: s.seasonNumber,
-        episodeNumber: e.episodeNumber,
-        title: e.title,
-        ...stateOf(e.monitored, filesByEpisode.get(e.id) ?? []),
-      })),
-    }));
+        episodes: (s.episodes ?? [])
+          .filter((e) => !shadowed.has(e.episodeNumber))
+          .map((e) => ({
+            episodeId: e.id,
+            seasonNumber: s.seasonNumber,
+            episodeNumber: e.episodeNumber,
+            endEpisodeNumber: e.endEpisodeNumber ?? null,
+            title: e.title,
+            ...stateOf(e.monitored, filesByEpisode.get(e.id) ?? []),
+          })),
+      };
+    });
 
     return { type: media.type, hasProfile: !!profile, seasons };
   }
@@ -720,9 +747,16 @@ export class MediaQueryService {
           accessibleLibraryIds,
         });
       }
-      const episodes = await epQb.getMany();
+      // Compute coverage (on disk) per episode so a shadowed multi-episode
+      // entry shows as downloaded — derived in SQL, not stored.
+      epQb.addSelect(onDiskSql('ep'), 'ep_onDisk');
+      const { entities, raw } = await epQb.getRawAndEntities();
+      const onDiskByEpId = new Map<number, boolean>();
+      for (const r of raw as { ep_id: number; ep_onDisk: boolean }[]) {
+        onDiskByEpId.set(r.ep_id, r.ep_onDisk);
+      }
 
-      for (const ep of episodes) {
+      for (const ep of entities) {
         results.push({
           id: ep.id,
           mediaId: ep.season.media.id,
@@ -736,7 +770,8 @@ export class MediaQueryService {
           seasonNumber: ep.season.seasonNumber,
           episodeNumber: ep.episodeNumber,
           episodeTitle: ep.title,
-          hasFile: ep.hasFile,
+          // "downloaded" badge = content on disk (coverage).
+          hasFile: onDiskByEpId.get(ep.id) ?? ep.hasFile,
         });
       }
     }

--- a/backend/src/modules/requests/request-lifecycle.service.ts
+++ b/backend/src/modules/requests/request-lifecycle.service.ts
@@ -13,6 +13,7 @@ import { FliksRequest } from './entities/request.entity';
 import { MediaType, RequestStatus } from '../../common/enums';
 import { Media } from '../media/entities/media.entity';
 import { MediaService } from '../media/media.service';
+import { onDiskEpisodeNumbers } from '../media/episode-coverage.util';
 import { ProfilesService } from '../profiles/profiles.service';
 import { EventsService } from '../scheduler/events.service';
 import { SchedulerService } from '../scheduler/scheduler.service';
@@ -340,7 +341,11 @@ export class RequestLifecycleService
       const monitoredEps = (s.episodes ?? []).filter((e) => e.monitored);
       if (monitoredEps.length === 0) continue;
       anyChecked = true;
-      if (!monitoredEps.every((e) => e.hasFile)) return false;
+      // Coverage, not own-file: a shadowed episode of a multi-episode file is
+      // satisfied even though it has no file of its own.
+      const onDiskNums = onDiskEpisodeNumbers(s.episodes ?? []);
+      if (!monitoredEps.every((e) => onDiskNums.has(e.episodeNumber)))
+        return false;
     }
     // Nothing left to wait for (scope past the library, all unmonitored)
     // — treat as delivered rather than stranding the request forever.

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -16,6 +16,10 @@ import { TorznabService, TorznabRelease } from '../indexers/torznab.service';
 import { QbittorrentService } from '../download-clients/qbittorrent.service';
 import { TmdbProvider } from '../metadata-providers/providers/tmdb.provider';
 import { MediaService } from '../media/media.service';
+import {
+  onDiskSql,
+  onDiskEpisodeNumbers,
+} from '../media/episode-coverage.util';
 import { MediaType, MinimumAvailability } from '../../common/enums';
 import { ConfigService } from '@nestjs/config';
 import { CompletionService } from './completion.service';
@@ -533,7 +537,12 @@ export class SchedulerService implements OnModuleInit {
       .andWhere('ep.monitored = true')
       .andWhere('ep.airDate IS NOT NULL')
       .andWhere('ep.airDate <= :today', { today })
-      .andWhere('(ep.hasFile = false OR qp."upgradeAllowed" = true)');
+      // Missing → search when the content isn't on disk (coverage, so multi-
+      // episode shadowed episodes aren't re-searched). Upgrade → only episodes
+      // with their OWN file (hasFile); a shadowed episode upgrades via its owner.
+      .andWhere(
+        `(NOT ${onDiskSql('ep')} OR (ep.hasFile = true AND qp."upgradeAllowed" = true))`,
+      );
     if (mediaIds?.length) {
       qb.andWhere('media.id IN (:...mediaIds)', { mediaIds });
     }
@@ -905,10 +914,11 @@ export class SchedulerService implements OnModuleInit {
           );
           if (!season) continue;
           const packKey = `${seriesMatch.id}:${parsed.season}`;
+          const onDiskNums = onDiskEpisodeNumbers(season.episodes ?? []);
 
           if (parsed.isFullSeason) {
             const wanted = (season.episodes ?? []).some(
-              (e) => e.monitored && !e.hasFile,
+              (e) => e.monitored && !onDiskNums.has(e.episodeNumber),
             );
             if (!wanted) continue;
             packTriedThisPull.add(packKey);
@@ -932,7 +942,8 @@ export class SchedulerService implements OnModuleInit {
           const ep = (season.episodes ?? []).find(
             (e) => e.episodeNumber === parsed.episode,
           );
-          if (!ep || !ep.monitored || ep.hasFile) continue;
+          if (!ep || !ep.monitored || onDiskNums.has(ep.episodeNumber))
+            continue;
           // Intra-pull Phase 1: a pack for this season was already handed
           // off above; skip the individual episode.
           if (packTriedThisPull.has(packKey)) continue;

--- a/client/src/app/core/services/api/media.service.ts
+++ b/client/src/app/core/services/api/media.service.ts
@@ -57,6 +57,8 @@ export interface Episode {
   overview: string | null;
   airDate: string | null;
   monitored: boolean;
+  /** Has its own file (playback / watched). "On disk" coverage incl. multi-
+   *  episode files is derived client-side via media-detail.utils. */
   hasFile: boolean;
   runtime?: number | null;
   stillUrl?: string | null;
@@ -129,6 +131,7 @@ export interface TrackingEpisode extends TrackingItemState {
   episodeId: number;
   seasonNumber: number;
   episodeNumber: number;
+  endEpisodeNumber: number | null;
   title: string | null;
 }
 

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -35,6 +35,7 @@ import {
   episodeBadgeLabel,
   filesForEpisode,
   filterSeasonEpisodesOnDisk,
+  onDiskEpisodeNumbers,
   seasonsVisibleWithDiskFilter,
 } from '../../media-detail.utils';
 import { PlayableMediaService } from '../../../../core/services/playable-media.service';
@@ -106,14 +107,18 @@ export class MediaDetailSeasonsComponent {
   }
 
   tabEpisodeCount(season: Season): number {
-    return filterSeasonEpisodesOnDisk(season, this.media(), this.episodesHasFileOnly()).length;
+    return filterSeasonEpisodesOnDisk(season, this.episodesHasFileOnly()).length;
   }
 
-  /** True when at least one episode of the season has no file — the
-   *  prerequisite for surfacing a Demander entry. */
+  /** True when at least one episode of the season isn't on disk — the
+   *  prerequisite for surfacing a Demander entry. Uses coverage so a season
+   *  fully covered by multi-episode files isn't flagged as missing. */
   seasonHasMissingEpisodes(season: Season | null): boolean {
     if (!season) return false;
-    return (season.episodes ?? []).some((ep) => !ep.hasFile);
+    const onDisk = onDiskEpisodeNumbers(season.episodes ?? []);
+    return (season.episodes ?? []).some(
+      (ep) => !onDisk.has(ep.episodeNumber),
+    );
   }
 
   /** True when the viewer already has an active request covering this

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -1200,7 +1200,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   filteredSeasonEpisodes(season: Season): Episode[] {
     const m = this.media();
     if (!m) return season.episodes;
-    return filterSeasonEpisodesOnDisk(season, m, this.episodesHasFileOnly());
+    return filterSeasonEpisodesOnDisk(season, this.episodesHasFileOnly());
   }
 
   activeSeason(m: Media): Season | null {

--- a/client/src/app/features/media-detail/media-detail.utils.ts
+++ b/client/src/app/features/media-detail/media-detail.utils.ts
@@ -40,20 +40,34 @@ export function formatMediaDetailBytes(bytes: number): string {
   return `${(n / Math.pow(1024, i)).toFixed(i >= 3 ? 1 : 0)} ${units[i]}`;
 }
 
-/** Episodes with fichier (hasFile ou fichier tracké avec episodeId). */
+/** Visible episodes of a season, optionally only those on disk (coverage). */
 export function filterSeasonEpisodesOnDisk(
   season: Season,
-  media: Media,
   onlyOnDisk: boolean,
 ): Episode[] {
   const eps = hideShadowedEpisodes(season.episodes);
   if (!onlyOnDisk) return eps;
-  const fileEpisodeIds = new Set(
-    (media.files ?? [])
-      .map((f) => f.episodeId)
-      .filter((id): id is number => id != null && id > 0),
-  );
-  return eps.filter((e) => e.hasFile || fileEpisodeIds.has(e.id));
+  const onDisk = onDiskEpisodeNumbers(season.episodes);
+  return eps.filter((e) => onDisk.has(e.episodeNumber));
+}
+
+/**
+ * Episode numbers in a season whose content is on disk — own file (`hasFile`)
+ * OR covered by a multi-episode file (inside an owner's
+ * `[episodeNumber..endEpisodeNumber]`). Mirror of the backend
+ * `episode-coverage.util`. Use this, not raw `hasFile`, for "missing" logic.
+ */
+export function onDiskEpisodeNumbers(episodes: Episode[]): Set<number> {
+  const numbers = new Set<number>();
+  for (const owner of episodes) {
+    if (!owner.hasFile) continue;
+    numbers.add(owner.episodeNumber);
+    const end = owner.endEpisodeNumber;
+    if (end != null && end > owner.episodeNumber) {
+      for (let n = owner.episodeNumber + 1; n <= end; n++) numbers.add(n);
+    }
+  }
+  return numbers;
 }
 
 /**
@@ -86,7 +100,7 @@ export function episodeBadgeLabel(ep: Episode): string {
 export function seasonsVisibleWithDiskFilter(media: Media, onlyOnDisk: boolean): Season[] {
   const list = media.seasons ?? [];
   if (!onlyOnDisk) return list;
-  return list.filter((s) => filterSeasonEpisodesOnDisk(s, media, true).length > 0);
+  return list.filter((s) => filterSeasonEpisodesOnDisk(s, true).length > 0);
 }
 
 export type MediaFileRow = NonNullable<Media['files']>[number];

--- a/client/src/app/shared/components/tracking-status-modal/tracking-status-modal.ts
+++ b/client/src/app/shared/components/tracking-status-modal/tracking-status-modal.ts
@@ -89,7 +89,12 @@ export class TrackingStatusModalComponent {
   });
 
   episodeLabel(ep: TrackingEpisode): string {
-    const code = `S${String(ep.seasonNumber).padStart(2, '0')}E${String(ep.episodeNumber).padStart(2, '0')}`;
+    const s = String(ep.seasonNumber).padStart(2, '0');
+    const e = String(ep.episodeNumber).padStart(2, '0');
+    let code = `S${s}E${e}`;
+    if (ep.endEpisodeNumber != null && ep.endEpisodeNumber > ep.episodeNumber) {
+      code += `-E${String(ep.endEpisodeNumber).padStart(2, '0')}`;
+    }
     return ep.title ? `${code} — ${ep.title}` : code;
   }
 }


### PR DESCRIPTION
## Problem
A double-episode file (`S06E17-E18.mkv`) is linked to its owner episode only (E17, with `endEpisodeNumber=18`). The shadowed episode E18 had `hasFile=false` and was wrongly treated as **missing**: SearchMissing re-grabbed it, request availability got stuck (never AVAILABLE), stats/calendar undercounted, and the tracking modal showed it "Manquant".

## Approach
`episode.hasFile` was overloaded as both "has its own file" (playback/intro/watched) and "on disk" (missing logic) — fine for normal episodes, wrong for shadowed ones. Rather than:
- overloading `hasFile` = coverage → **breaks** watched (series never fully watched) + intro-detection (runs on a fileless episode), or
- migrating to a file→N-episodes schema → 42 files, needs playback rework, and a backfill that wouldn't run in a dev-mode instance (mass re-grab),

coverage is now **derived, never stored**: an episode is on disk when it has its own file OR is inside an owner's `[episodeNumber..endEpisodeNumber]` range.

- One rule: `backend/.../media/episode-coverage.util.ts` — `onDiskSql()` (queries), `onDiskEpisodeNumbers()`/`isEpisodeOnDisk()` (in-memory). Mirrored client-side in `media-detail.utils.ts`.
- `hasFile` keeps its strict "own file" meaning → playback / intro detection / watched **untouched** (no regression).
- Coverage readers switched: SearchMissing, RssSync, manual episode search, request-availability, episode stats, calendar, frontend "missing"/"on disk" + Demander.
- **No column, no migration, no sync** → no dev/prod hazard, no drift.
- Tracking modal hides shadowed episodes and labels the owner `S06E17-E18`.

## Test plan
- [ ] Import a `S06E17-E18` file → E18 no longer shows "Manquant"; stats count both; SearchMissing doesn't re-grab E18; a request covering E18 reaches AVAILABLE.
- [ ] Series with a multi-ep file can still be marked fully watched (watched unchanged).
- [ ] Intro detection runs only on episodes with their own file.
- [ ] Normal single-episode missing/upgrade flows unchanged.
- [ ] Calendar shows the covered episode as downloaded.