### PR TITLE
fix(media): make the cutoff-unmet series filter multi-episode aware

### DIFF
--- a/backend/src/modules/media/episode-coverage.util.ts
+++ b/backend/src/modules/media/episode-coverage.util.ts
@@ -46,6 +46,26 @@ export function isEpisodeOnDisk(
 }
 
 /**
+ * Episode numbers in a season that are "shadowed" — covered by another
+ * episode's multi-episode range `(episodeNumber..endEpisodeNumber]`. These
+ * rows are real (provider-created) but represented by their owner's file, so
+ * per-episode logic (display, cutoff evaluation) should skip them and use the
+ * owner instead. Range-only — independent of `hasFile`.
+ */
+export function shadowedEpisodeNumbers(
+  episodes: { episodeNumber: number; endEpisodeNumber?: number | null }[],
+): Set<number> {
+  const shadowed = new Set<number>();
+  for (const owner of episodes) {
+    const end = owner.endEpisodeNumber;
+    if (end != null && end > owner.episodeNumber) {
+      for (let n = owner.episodeNumber + 1; n <= end; n++) shadowed.add(n);
+    }
+  }
+  return shadowed;
+}
+
+/**
  * SQL boolean expression equivalent to {@link isEpisodeOnDisk}, for queries.
  * `epAlias` is the episodes-table alias in scope. The correlated subquery finds
  * an owner episode in the same season whose multi-episode range covers this row.

--- a/backend/src/modules/media/media-service/media-query.service.ts
+++ b/backend/src/modules/media/media-service/media-query.service.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../common/constants/app-qualities';
 import { rankFromQualityString } from '../release-rejection.helper';
 import { parseReleaseQuality } from '../../../common/release-parsing';
-import { onDiskSql } from '../episode-coverage.util';
+import { onDiskSql, shadowedEpisodeNumbers } from '../episode-coverage.util';
 
 export type CutoffState =
   | 'unmonitored'
@@ -316,15 +316,34 @@ export class MediaQueryService {
       const seriesIds = enriched
         .filter((m) => m.type === MediaType.SERIES && cutoffByMedia.has(m.id))
         .map((m) => m.id);
-      const epBestByMedia = new Map<number, Map<number, number>>();
+      // Per (media, season) → best file rank per monitored episode, plus the
+      // season's shadowed episode numbers. A shadowed episode (covered by a
+      // multi-episode file's range) has no file of its own, so evaluating it
+      // would falsely read rank 0; we skip it and rely on its owner — matching
+      // the tracking modal which hides shadowed episodes.
+      const epInfoByMedia = new Map<
+        number,
+        Map<
+          number,
+          {
+            episodeNumber: number;
+            endEpisodeNumber: number | null;
+            rank: number;
+          }
+        >
+      >();
       if (seriesIds.length) {
         const epRows: {
           mediaId: number;
           epId: number;
+          episodeNumber: number;
+          endEpisodeNumber: number | null;
           quality: string | null;
         }[] = await this.dataSource.query(
           `SELECT s."mediaId" AS "mediaId",
                   e.id      AS "epId",
+                  e."episodeNumber" AS "episodeNumber",
+                  e."endEpisodeNumber" AS "endEpisodeNumber",
                   f."quality" AS "quality"
              FROM seasons s
              JOIN episodes e ON e."seasonId" = s.id
@@ -335,14 +354,22 @@ export class MediaQueryService {
           [seriesIds],
         );
         for (const row of epRows) {
-          let byEp = epBestByMedia.get(row.mediaId);
+          let byEp = epInfoByMedia.get(row.mediaId);
           if (!byEp) {
             byEp = new Map();
-            epBestByMedia.set(row.mediaId, byEp);
+            epInfoByMedia.set(row.mediaId, byEp);
           }
           const rank = rankFromQualityString(row.quality);
           const prev = byEp.get(row.epId);
-          if (prev == null || rank > prev) byEp.set(row.epId, rank);
+          if (prev) {
+            if (rank > prev.rank) prev.rank = rank;
+          } else {
+            byEp.set(row.epId, {
+              episodeNumber: row.episodeNumber,
+              endEpisodeNumber: row.endEpisodeNumber,
+              rank,
+            });
+          }
         }
       }
       enriched = enriched.filter((m) => {
@@ -356,10 +383,13 @@ export class MediaQueryService {
           }
           return rank < cutoffRank;
         }
-        const byEp = epBestByMedia.get(m.id);
+        const byEp = epInfoByMedia.get(m.id);
         if (!byEp || byEp.size === 0) return false;
-        for (const rank of byEp.values()) {
-          if (rank < cutoffRank) return true;
+        const eps = [...byEp.values()];
+        const shadowed = shadowedEpisodeNumbers(eps);
+        for (const ep of eps) {
+          if (shadowed.has(ep.episodeNumber)) continue;
+          if (ep.rank < cutoffRank) return true;
         }
         return false;
       });


### PR DESCRIPTION
## Problem
In prod, filtering series by "cutoff non atteint" listed series like The Office, yet its tracking modal showed every episode at cutoff. Cause: the `cutoffUnmet` library filter (`media-query.findAll`) evaluates each monitored episode's best file rank via a `media_files` join. A shadowed episode of a multi-episode file (`S06E17-E18` → E18 has no file of its own) reads rank 0 < cutoff and flags the whole series — while the modal hides shadowed episodes and evaluates the owner (which is at cutoff).

This was a coverage reader the previous audit missed: it compares per-episode file ranks rather than reading `hasFile`.

## Fix
The filter now skips shadowed episodes (covered by an owner's `[episodeNumber..endEpisodeNumber]` range) using the shared `shadowedEpisodeNumbers` helper, relying on the owner episode's file — consistent with the tracking modal. Genuinely missing episodes (no file, not shadowed) still flag the series as before.

## Test plan
- [ ] A series whose only "below cutoff" episodes are shadowed (multi-episode files at cutoff) no longer appears under the cutoff-unmet filter — matching its modal.
- [ ] A series with a genuinely missing or below-cutoff monitored episode still appears.
- [ ] Movies unaffected.