### PR TITLE
feat(webos): native LG TV player and platform fixes

### DIFF
--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -41,7 +41,7 @@ export class App implements OnInit, OnDestroy {
   private readonly pwaAutoUpdate = inject(PwaAutoUpdateService);
   private backButtonListener?: { remove: () => Promise<void> };
   private resumeListener?: { remove: () => Promise<void> };
-  private tizenKeyListener?: (e: KeyboardEvent) => void;
+  private tvBackKeyListener?: (e: KeyboardEvent) => void;
   private escapeKeyListener?: (e: KeyboardEvent) => void;
 
   ngOnInit() {
@@ -113,21 +113,26 @@ export class App implements OnInit, OnDestroy {
     };
     window.addEventListener('keydown', this.escapeKeyListener, true);
 
-    // Samsung Tizen "Return" remote key. Capacitor's `backButton` event
-    // never fires here (we're not running through Capacitor on Tizen), so
-    // without an explicit handler the player gets stuck on the AVPlay
-    // error screen with no way out. The Return key surfaces as keyCode
-    // 10009 on Tizen 6.5 — Smart TV remotes have no Android-style back
-    // gesture, the user hits a physical button. Same logic as the
-    // Capacitor handler, factored out into `handleBackButton`.
-    if (this.tv.tvPlatform() === 'tizen') {
+    // Smart TV "Return" remote key. Capacitor's `backButton` event never
+    // fires here (Tizen/webOS don't run through Capacitor), so without an
+    // explicit handler the player gets stuck with no way out. The button
+    // surfaces as keyCode 10009 on Tizen and 461 (`key: 'GoBack'`) on
+    // webOS — physical buttons, no Android-style back gesture. Same logic
+    // as the Capacitor handler, factored out into `handleBackButton`.
+    const platform = this.tv.tvPlatform();
+    if (platform === 'tizen' || platform === 'webos') {
       const handler = (e: KeyboardEvent) => {
-        if (e.keyCode === 10009 || e.key === 'XF86Back' || e.key === 'GoBack') {
+        if (
+          e.keyCode === 10009 ||
+          e.keyCode === 461 ||
+          e.key === 'XF86Back' ||
+          e.key === 'GoBack'
+        ) {
           e.preventDefault();
           this.handleBackButton();
         }
       };
-      this.tizenKeyListener = handler;
+      this.tvBackKeyListener = handler;
       window.addEventListener('keydown', handler);
     }
   }
@@ -206,16 +211,24 @@ export class App implements OnInit, OnDestroy {
       this.navbar.goBack();
       return;
     }
-    // Top-level with no in-app history. On Tizen we let the OS minimise
-    // the app (the default behaviour when no preventDefault was called
-    // — but we DID preventDefault above to suppress the WebApp default
-    // exit confirmation; re-fire it explicitly so the user can leave).
-    if (this.tv.tvPlatform() === 'tizen') {
+    // Top-level with no in-app history: leave the app. We preventDefault'd
+    // the Return key above (to suppress the WebApp default exit prompt), so
+    // re-fire the platform's own exit explicitly — Tizen's application.exit,
+    // webOS's platformBack (returns to the launcher / previous app).
+    const platform = this.tv.tvPlatform();
+    if (platform === 'tizen') {
       const tizen = (window as unknown as { tizen?: { application?: { getCurrentApplication: () => { exit: () => void } } } }).tizen;
       try {
         tizen?.application?.getCurrentApplication().exit();
       } catch {
         /* exit() can throw on dev profiles — ignore */
+      }
+    } else if (platform === 'webos') {
+      const sys = (window as unknown as { webOSSystem?: { platformBack?: () => void } }).webOSSystem;
+      try {
+        sys?.platformBack?.();
+      } catch {
+        /* platformBack unavailable on some firmware — ignore */
       }
     }
   }
@@ -223,8 +236,8 @@ export class App implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.backButtonListener?.remove();
     this.resumeListener?.remove();
-    if (this.tizenKeyListener) {
-      window.removeEventListener('keydown', this.tizenKeyListener);
+    if (this.tvBackKeyListener) {
+      window.removeEventListener('keydown', this.tvBackKeyListener);
     }
     if (this.escapeKeyListener) {
       window.removeEventListener('keydown', this.escapeKeyListener, true);

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -180,6 +180,7 @@ export class BrowserDeviceProfileService {
     // the backend pick HEVC again skips a transcode for HEVC sources on
     // Q-series TVs.
     const isTv = this.device.isTv();
+    const tvPlatform = this.device.tvPlatform();
     if (
       this.testCodec(video, hasMSE, 'video/mp4', 'hvc1.1.6.L120.B0') ||
       this.testCodec(video, hasMSE, 'video/mp4', 'hev1.1.6.L120.B0')
@@ -259,6 +260,16 @@ export class BrowserDeviceProfileService {
     if (this.nativeAudio) {
       maxAudioChannels = Math.max(maxAudioChannels, this.nativeAudio.maxChannels);
     }
+    // webOS: the WebView's AudioContext caps at 2ch, but the native <video>
+    // pipeline decodes Dolby and renders/passes it (TV speakers downmix, eARC
+    // passes through). Declaring 5.1 when AC3/EAC3 is supported lets the
+    // backend DirectStream multichannel Dolby instead of downmixing to stereo.
+    if (
+      tvPlatform === 'webos' &&
+      (audioCodecs.includes('eac3') || audioCodecs.includes('ac3'))
+    ) {
+      maxAudioChannels = Math.max(maxAudioChannels, 6);
+    }
 
     // --- HDR support ---
     let supportsHdr: boolean;
@@ -297,13 +308,13 @@ export class BrowserDeviceProfileService {
       deviceType: Capacitor.isNativePlatform() ? 'mobile' : 'desktop',
       deviceName: getDeviceName(),
       useTs,
-      // Tizen-style profiles opt into MPEG-TS on single-audio sources
-      // (AVPlay's HLS-fMP4 rendition-probe stall, issue #148). Multi-
-      // audio sources stay on fMP4 + var_stream_map — that path works
-      // because the master exposes ≥2 audio renditions and AVPlay
-      // engages its probe. Browser, Cast and native mobile leave the
-      // flag off and consume muxed fMP4 across the board.
-      useTsOnSingleAudio: isTv,
+      // Tizen opts into MPEG-TS on single-audio sources (AVPlay's HLS-fMP4
+      // rendition-probe stall, issue #148). Multi-audio sources stay on
+      // fMP4 + var_stream_map — that path works because the master exposes
+      // ≥2 audio renditions and AVPlay engages its probe. webOS, browser,
+      // Cast and native mobile consume muxed fMP4 across the board (webOS's
+      // native <video> has no such stall and fMP4 keeps Dolby pass-through).
+      useTsOnSingleAudio: tvPlatform === 'tizen',
     };
   }
 

--- a/client/src/app/core/services/playback-engine/index.ts
+++ b/client/src/app/core/services/playback-engine/index.ts
@@ -10,3 +10,5 @@ export type {
 export { NativeEngine } from './native-engine';
 export { ShakaEngine } from './shaka-engine';
 export { TizenEngine, isTizenAvplayAvailable } from './tizen-engine';
+export { WebOsEngine } from './webos-engine';
+export { SubtitleOverlay } from './subtitle-overlay.util';

--- a/client/src/app/core/services/playback-engine/subtitle-overlay.util.ts
+++ b/client/src/app/core/services/playback-engine/subtitle-overlay.util.ts
@@ -1,0 +1,173 @@
+import {
+  SUBTITLE_SIZE_MAP,
+  SUBTITLE_COLOR_MAP,
+  SUBTITLE_SHADOW_MAP,
+  SUBTITLE_BG_MAP,
+} from '../player-settings.service';
+
+/**
+ * DOM-rendered subtitle overlay shared by the TV engines (Tizen AVPlay,
+ * webOS native `<video>`). Those pipelines either reject HTTPS external
+ * subtitle paths (AVPlay) or give no styleable cue API, so we fetch the
+ * WebVTT ourselves, parse the cues, and paint the active one into a
+ * fixed positioned div on top of the hardware video surface.
+ */
+
+interface VttCue {
+  start: number;
+  end: number;
+  text: string;
+}
+
+export class SubtitleOverlay {
+  private el: HTMLDivElement | null = null;
+  private cues: VttCue[] = [];
+  private visible = false;
+  private lastText = '';
+
+  /** Parse a remote WebVTT file and arm it as the active track. */
+  async show(url: string): Promise<void> {
+    this.visible = true;
+    try {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error('VTT fetch ' + res.status);
+      this.cues = parseVtt(await res.text());
+    } catch {
+      this.cues = [];
+    }
+  }
+
+  setVisible(visible: boolean): void {
+    this.visible = visible;
+    if (!visible) this.render('');
+  }
+
+  clear(): void {
+    this.visible = false;
+    this.cues = [];
+    this.render('');
+  }
+
+  /** Render the cue active at `timeSec` (called on every time update). */
+  updateAt(timeSec: number): void {
+    if (!this.visible) {
+      if (this.lastText) this.render('');
+      return;
+    }
+    if (!this.cues.length) return;
+    const active = this.cues.find((c) => timeSec >= c.start && timeSec <= c.end);
+    this.render(active?.text ?? '');
+  }
+
+  /** Same preset enums Shaka consumes from `player-settings.service`. */
+  setStyle(style: {
+    size?: string;
+    color?: string;
+    shadow?: string;
+    background?: string;
+    bottomMargin?: number;
+  }): void {
+    const el = this.ensureEl();
+    if (!el) return;
+    if (style.size) {
+      el.style.fontSize = SUBTITLE_SIZE_MAP[style.size] ?? SUBTITLE_SIZE_MAP['normal'];
+    }
+    if (style.color) {
+      el.style.color = SUBTITLE_COLOR_MAP[style.color] ?? SUBTITLE_COLOR_MAP['white'];
+    }
+    if (style.shadow) {
+      el.style.textShadow = SUBTITLE_SHADOW_MAP[style.shadow] ?? SUBTITLE_SHADOW_MAP['drop'];
+    }
+    if (style.background) {
+      el.style.background = SUBTITLE_BG_MAP[style.background] ?? SUBTITLE_BG_MAP['transparent'];
+    }
+    if (typeof style.bottomMargin === 'number') {
+      el.style.bottom = `${Math.max(0, style.bottomMargin)}vh`;
+    }
+  }
+
+  destroy(): void {
+    if (this.el?.parentElement) this.el.parentElement.removeChild(this.el);
+    this.el = null;
+    this.cues = [];
+    this.visible = false;
+    this.lastText = '';
+  }
+
+  private ensureEl(): HTMLDivElement | null {
+    if (this.el?.isConnected) return this.el;
+    if (typeof document === 'undefined') return null;
+    const el = document.createElement('div');
+    el.id = 'fliks-tv-subtitle';
+    el.style.cssText = [
+      'position: fixed',
+      'left: 50%',
+      'bottom: 10vh',
+      'transform: translateX(-50%)',
+      'max-width: 80vw',
+      'padding: 6px 14px',
+      'background: transparent',
+      'color: #fff',
+      'font-size: 3vh',
+      'font-weight: 500',
+      'line-height: 1.3',
+      'text-align: center',
+      'text-shadow: 0 2px 4px rgba(0, 0, 0, 0.9)',
+      'pointer-events: none',
+      'z-index: 1000',
+      'white-space: pre-wrap',
+      'display: none',
+    ].join(';');
+    document.body.appendChild(el);
+    this.el = el;
+    return el;
+  }
+
+  private render(text: string): void {
+    const el = this.ensureEl();
+    if (!el) return;
+    if (text === this.lastText) return;
+    this.lastText = text;
+    if (text) {
+      el.innerHTML = text;
+      el.style.display = 'block';
+    } else {
+      el.style.display = 'none';
+    }
+  }
+}
+
+function parseVtt(raw: string): VttCue[] {
+  const cues: VttCue[] = [];
+  const blocks = raw.replace(/\r\n/g, '\n').split('\n\n');
+  for (const block of blocks) {
+    const lines = block.trim().split('\n');
+    const timeLine = lines.find((l) => l.includes('-->'));
+    if (!timeLine) continue;
+    const [startStr, endStr] = timeLine.split('-->').map((s) => s.trim());
+    const start = vttTimeToSec(startStr);
+    const end = vttTimeToSec(endStr);
+    if (isNaN(start) || isNaN(end)) continue;
+    const textLines = lines.slice(lines.indexOf(timeLine) + 1);
+    // Allow <b>, <i>, <u>, <br> so `innerHTML` is safe (third-party sub
+    // files; backend just proxies).
+    const text = textLines.join('<br>').replace(/<\/?[^>]*>/g, (tag) => {
+      if (/^<\/?(b|i|u|br)\s*\/?>$/i.test(tag)) return tag;
+      return '';
+    });
+    if (text) cues.push({ start, end, text });
+  }
+  return cues;
+}
+
+function vttTimeToSec(ts: string): number {
+  const clean = ts.split(' ')[0];
+  const parts = clean.split(':');
+  if (parts.length === 3) {
+    return +parts[0] * 3600 + +parts[1] * 60 + parseFloat(parts[2]);
+  }
+  if (parts.length === 2) {
+    return +parts[0] * 60 + parseFloat(parts[1]);
+  }
+  return NaN;
+}

--- a/client/src/app/core/services/playback-engine/tizen-engine.ts
+++ b/client/src/app/core/services/playback-engine/tizen-engine.ts
@@ -5,12 +5,7 @@ import {
   PlaybackEngine,
   PlaybackState,
 } from './playback-engine';
-import {
-  SUBTITLE_SIZE_MAP,
-  SUBTITLE_COLOR_MAP,
-  SUBTITLE_SHADOW_MAP,
-  SUBTITLE_BG_MAP,
-} from '../player-settings.service';
+import { SubtitleOverlay } from './subtitle-overlay.util';
 
 /**
  * Samsung Tizen AVPlay backend.
@@ -69,12 +64,6 @@ export const isTizenAvplayAvailable = (): boolean => {
   );
 };
 
-interface VttCue {
-  start: number;
-  end: number;
-  text: string;
-}
-
 export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngine {
   /** Most recently `init()`'d instance. The shared AVPlay surface and
    *  native listener fan out to whoever holds this slot. */
@@ -102,13 +91,10 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
   private _seekInFlight = false;
   private _pendingSeek: number | null = null;
 
-  /** DOM-rendered subtitle overlay. AVPlay's `setExternalSubtitlePath`
-   *  only accepts local file paths, not HTTPS — we parse VTT
-   *  ourselves and render into a positioned div. */
-  private subtitleEl: HTMLDivElement | null = null;
-  private parsedCues: VttCue[] = [];
-  private subtitleVisible = false;
-  private lastCueText = '';
+  /** DOM-rendered subtitle overlay shared with the webOS engine. AVPlay's
+   *  `setExternalSubtitlePath` only accepts local file paths, not HTTPS,
+   *  so we parse VTT ourselves and paint cues into a positioned div. */
+  private readonly subtitles = new SubtitleOverlay();
 
   // ── Lifecycle ───────────────────────────────────────────────────────
 
@@ -142,13 +128,7 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
       TizenEngine.activeEngine = null;
     }
     this.avObject = null;
-    if (this.subtitleEl?.parentElement) {
-      this.subtitleEl.parentElement.removeChild(this.subtitleEl);
-    }
-    this.subtitleEl = null;
-    this.parsedCues = [];
-    this.subtitleVisible = false;
-    this.lastCueText = '';
+    this.subtitles.destroy();
     this.clearHandlers();
   }
 
@@ -293,7 +273,7 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
       duration: this._duration,
       buffered: this._buffered,
     });
-    this.updateSubtitleAt(this._currentTime);
+    this.subtitles.updateAt(this._currentTime);
     if (!this.firstFrameEmitted && ms > 0) {
       this.firstFrameEmitted = true;
       this.emit('firstFrame', undefined);
@@ -489,20 +469,15 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
 
   selectTextTrack(track: unknown): void {
     if (!track || typeof track !== 'object') {
-      this.subtitleVisible = false;
-      this.parsedCues = [];
-      this.renderSubtitle('');
+      this.subtitles.clear();
       return;
     }
     const url = (track as { url?: string }).url;
-    if (!url) return;
-    this.subtitleVisible = true;
-    void this.loadVttCues(url);
+    if (url) void this.subtitles.show(url);
   }
 
   setTextVisibility(visible: boolean): void {
-    this.subtitleVisible = visible;
-    if (!visible) this.renderSubtitle('');
+    this.subtitles.setVisible(visible);
   }
 
   /** Same preset enums Shaka consumes from `player-settings.service`. */
@@ -513,122 +488,7 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
     background?: string;
     bottomMargin?: number;
   }): void {
-    const el = this.ensureSubtitleEl();
-    if (!el) return;
-    if (style.size) {
-      el.style.fontSize = SUBTITLE_SIZE_MAP[style.size] ?? SUBTITLE_SIZE_MAP['normal'];
-    }
-    if (style.color) {
-      el.style.color = SUBTITLE_COLOR_MAP[style.color] ?? SUBTITLE_COLOR_MAP['white'];
-    }
-    if (style.shadow) {
-      el.style.textShadow = SUBTITLE_SHADOW_MAP[style.shadow] ?? SUBTITLE_SHADOW_MAP['drop'];
-    }
-    if (style.background) {
-      el.style.background = SUBTITLE_BG_MAP[style.background] ?? SUBTITLE_BG_MAP['transparent'];
-    }
-    if (typeof style.bottomMargin === 'number') {
-      el.style.bottom = `${Math.max(0, style.bottomMargin)}vh`;
-    }
-  }
-
-  private async loadVttCues(url: string): Promise<void> {
-    try {
-      const res = await fetch(url);
-      if (!res.ok) throw new Error('VTT fetch ' + res.status);
-      const raw = await res.text();
-      this.parsedCues = this.parseVtt(raw);
-    } catch {
-      this.parsedCues = [];
-    }
-  }
-
-  private ensureSubtitleEl(): HTMLDivElement | null {
-    if (this.subtitleEl?.isConnected) return this.subtitleEl;
-    if (typeof document === 'undefined') return null;
-    const el = document.createElement('div');
-    el.id = 'fliks-avplay-subtitle';
-    el.style.cssText = [
-      'position: fixed',
-      'left: 50%',
-      'bottom: 10vh',
-      'transform: translateX(-50%)',
-      'max-width: 80vw',
-      'padding: 6px 14px',
-      'background: transparent',
-      'color: #fff',
-      'font-size: 3vh',
-      'font-weight: 500',
-      'line-height: 1.3',
-      'text-align: center',
-      'text-shadow: 0 2px 4px rgba(0, 0, 0, 0.9)',
-      'pointer-events: none',
-      'z-index: 1000',
-      'white-space: pre-wrap',
-      'display: none',
-    ].join(';');
-    document.body.appendChild(el);
-    this.subtitleEl = el;
-    return el;
-  }
-
-  private renderSubtitle(text: string): void {
-    const el = this.ensureSubtitleEl();
-    if (!el) return;
-    if (text === this.lastCueText) return;
-    this.lastCueText = text;
-    if (text) {
-      el.innerHTML = text;
-      el.style.display = 'block';
-    } else {
-      el.style.display = 'none';
-    }
-  }
-
-  private updateSubtitleAt(timeSec: number): void {
-    if (!this.subtitleVisible) {
-      if (this.lastCueText) this.renderSubtitle('');
-      return;
-    }
-    const cues = this.parsedCues;
-    if (!cues.length) return;
-    const active = cues.find((c) => timeSec >= c.start && timeSec <= c.end);
-    this.renderSubtitle(active?.text ?? '');
-  }
-
-  private parseVtt(raw: string): VttCue[] {
-    const cues: VttCue[] = [];
-    const blocks = raw.replace(/\r\n/g, '\n').split('\n\n');
-    for (const block of blocks) {
-      const lines = block.trim().split('\n');
-      const timeLine = lines.find((l) => l.includes('-->'));
-      if (!timeLine) continue;
-      const [startStr, endStr] = timeLine.split('-->').map((s) => s.trim());
-      const start = this.vttTimeToSec(startStr);
-      const end = this.vttTimeToSec(endStr);
-      if (isNaN(start) || isNaN(end)) continue;
-      const textLines = lines.slice(lines.indexOf(timeLine) + 1);
-      // Allow <b>, <i>, <u>, <br> so `innerHTML` is safe (third-party
-      // sub files; backend just proxies).
-      const text = textLines.join('<br>').replace(/<\/?[^>]*>/g, (tag) => {
-        if (/^<\/?(b|i|u|br)\s*\/?>$/i.test(tag)) return tag;
-        return '';
-      });
-      if (text) cues.push({ start, end, text });
-    }
-    return cues;
-  }
-
-  private vttTimeToSec(ts: string): number {
-    const clean = ts.split(' ')[0];
-    const parts = clean.split(':');
-    if (parts.length === 3) {
-      return +parts[0] * 3600 + +parts[1] * 60 + parseFloat(parts[2]);
-    }
-    if (parts.length === 2) {
-      return +parts[0] * 60 + parseFloat(parts[1]);
-    }
-    return NaN;
+    this.subtitles.setStyle(style);
   }
 
   // ── Quality — AVPlay handles ABR internally ────────────────────────

--- a/client/src/app/core/services/playback-engine/webos-engine.ts
+++ b/client/src/app/core/services/playback-engine/webos-engine.ts
@@ -1,0 +1,483 @@
+import {
+  AbstractPlaybackEngine,
+  AudioTrack,
+  EngineStats,
+  PlaybackEngine,
+} from './playback-engine';
+import { SubtitleOverlay } from './subtitle-overlay.util';
+
+/** Open HLS a few rungs up so the picture isn't a soft 256×144 while the
+ *  native ABR ramps. ~8 Mbps suits a TV display. */
+const WEBOS_START_BITRATE = 8_000_000;
+
+/** Collapse a burst of out-of-buffer seeks (repeated remote presses) into a
+ *  single reload after the user settles. Rapid `<video>` reloads crash the
+ *  webOS media pipeline, so this debounce is load-bearing, not cosmetic. */
+const SEEK_DEBOUNCE_MS = 280;
+
+/**
+ * LG webOS native backend.
+ *
+ * webOS renders the HTML5 `<video>` element on its own hardware media
+ * pipeline — native HLS, HW decode of HEVC (8/10-bit), AV1 and Dolby
+ * (AC3/EAC3) pass-through, plus HDR. It's a normal in-WebView element
+ * (no transparent hardware plane like Tizen AVPlay), so we drive the same
+ * `<video>` the Shaka path uses.
+ *
+ * Two webOS-specific behaviours are handled here:
+ *
+ *  - `mediaOption`: webOS takes a JSON blob on the `<source>` `type`
+ *    attribute that the media pipeline consumes. We use `playTime.start`
+ *    for a NATIVE resume and `adaptiveStreaming.bps.start` to open at a
+ *    high ABR rung (the native ABR otherwise opens at the lowest rung and
+ *    ramps slowly). A firmware that rejects the schema falls back to a
+ *    plain `src` load so playback still works.
+ *
+ *  - Reload-on-seek: our backend serves a full VOD playlist but only
+ *    transcodes around the current position; seeking far away makes it
+ *    return a transient 503 for the target segment while ffmpeg respawns
+ *    there. Shaka/ExoPlayer retry the 503; the native `<video>` does NOT —
+ *    a `currentTime` seek to an ungenerated segment sticks in `seeking`
+ *    forever. So an out-of-buffer seek RELOADS the stream positioned at the
+ *    target (same path as resume, which works), while in-buffer seeks stay
+ *    instant via native `currentTime`.
+ *
+ * Stream URLs carry the auth token as a query param, so the element needs
+ * no request headers. Subtitles use the shared {@link SubtitleOverlay}
+ * because webOS gives no styleable cue API for the renditions we emit.
+ */
+export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngine {
+  private video: HTMLVideoElement | null = null;
+  private readonly subtitles = new SubtitleOverlay();
+  private firstFrameEmitted = false;
+  private _duration = 0;
+  /** Last URL handed to `load()` — the base for reload-on-seek. */
+  private loadedUrl = '';
+  private boundListeners: Array<[keyof HTMLMediaElementEventMap, EventListener]> = [];
+  private frameCbHandle: number | null = null;
+  /** Suppress the persistent `error` handler while a (re)load is in flight —
+   *  a mediaOption rejection is recovered via the fallback, not surfaced. */
+  private loadingPhase = false;
+
+  /** Optimistic position reported while a seek settles, so the seekbar stays
+   *  pinned and relative (±10s) steps accumulate even though the real clock
+   *  hasn't moved yet (reload-based seeks take a few seconds). */
+  private seekIntent: number | null = null;
+  /** Latest out-of-buffer seek target awaiting a (debounced) reload. */
+  private pendingReloadTarget: number | null = null;
+  /** Single-flight guard: only one reload runs at a time (rapid reloads
+   *  crash webOS), the latest pending target wins when it finishes. */
+  private reloadInFlight = false;
+  private seekDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // ── Lifecycle ───────────────────────────────────────────────────────
+
+  async init(video: HTMLElement): Promise<void> {
+    this.video = video as HTMLVideoElement;
+    this.video.style.display = '';
+    this.wireListeners();
+  }
+
+  async destroy(): Promise<void> {
+    this.clearSeekDebounce();
+    this.seekIntent = null;
+    this.pendingReloadTarget = null;
+    const v = this.video;
+    if (v) {
+      for (const [event, fn] of this.boundListeners) v.removeEventListener(event, fn);
+      if (this.frameCbHandle != null && 'cancelVideoFrameCallback' in v) {
+        (v as any).cancelVideoFrameCallback(this.frameCbHandle);
+      }
+      try {
+        v.pause();
+        this.clearSources();
+        v.load();
+      } catch { /* element may already be detached */ }
+    }
+    this.boundListeners = [];
+    this.frameCbHandle = null;
+    this.video = null;
+    this.subtitles.destroy();
+    this.clearHandlers();
+  }
+
+  private wireListeners(): void {
+    const v = this.video;
+    if (!v) return;
+    const add = (event: keyof HTMLMediaElementEventMap, fn: EventListener) => {
+      v.addEventListener(event, fn);
+      this.boundListeners.push([event, fn]);
+    };
+
+    add('loadedmetadata', () => {
+      this._duration = isFinite(v.duration) ? v.duration : 0;
+    });
+    add('durationchange', () => {
+      if (isFinite(v.duration) && v.duration > 0) this._duration = v.duration;
+    });
+    add('playing', () => {
+      this.emit('stateChanged', { state: 'playing' });
+      this.emitFirstFrame();
+    });
+    add('play', () => this.emit('stateChanged', { state: 'playing' }));
+    add('pause', () => {
+      if (!v.ended) this.emit('stateChanged', { state: 'paused' });
+    });
+    add('waiting', () => this.emit('stateChanged', { state: 'buffering' }));
+    add('canplay', () => {
+      if (!v.paused) this.emit('stateChanged', { state: 'playing' });
+    });
+    add('timeupdate', () => {
+      // Drop the optimistic seek target once the real clock catches up to it.
+      if (this.seekIntent != null && Math.abs(v.currentTime - this.seekIntent) < 1.5) {
+        this.seekIntent = null;
+      }
+      this.subtitles.updateAt(v.currentTime);
+      this.emit('timeUpdate', {
+        position: this.currentTime, // intent-aware: pins the bar during a seek
+        duration: this._duration || v.duration || 0,
+        buffered: this.bufferedEnd(),
+      });
+      if (v.currentTime > 0) this.emitFirstFrame();
+    });
+    add('ended', () => {
+      this.emit('stateChanged', { state: 'ended' });
+      this.emit('ended', undefined);
+    });
+    add('error', () => {
+      if (this.loadingPhase) return; // recovered via the load() fallback
+      const err = v.error;
+      this.emit('error', { code: err?.code ?? -1, message: mediaErrorMessage(err) });
+      this.emit('stateChanged', { state: 'error' });
+    });
+
+    // requestVideoFrameCallback fires once a frame is actually composited —
+    // a tighter "first frame" signal than the `playing` DOM event.
+    if ('requestVideoFrameCallback' in v) {
+      this.frameCbHandle = (v as any).requestVideoFrameCallback(() => {
+        this.frameCbHandle = null;
+        this.emitFirstFrame();
+      });
+    }
+  }
+
+  private emitFirstFrame(): void {
+    if (this.firstFrameEmitted) return;
+    this.firstFrameEmitted = true;
+    this.emit('firstFrame', undefined);
+  }
+
+  // ── Loading ─────────────────────────────────────────────────────────
+
+  async load(url: string, startTime?: number): Promise<void> {
+    if (!this.video) throw new Error('WebOsEngine not initialised');
+    this.loadedUrl = url;
+    this.firstFrameEmitted = false;
+    this.clearSeekDebounce();
+    this.pendingReloadTarget = null;
+    const start = startTime && startTime > 0 ? startTime : 0;
+    this.seekIntent = start > 0 ? start : null; // pin the bar at the resume point
+    await this.loadInternal(url, start);
+  }
+
+  /** Attach + play at `start`, trying mediaOption first, then plain `src`. */
+  private async loadInternal(url: string, start: number): Promise<void> {
+    this._duration = 0;
+    this.loadingPhase = true;
+    try {
+      try {
+        // Preferred path: native resume + start-bitrate via mediaOption.
+        await this.attachAndPlay(url, start, true);
+      } catch {
+        // Firmware rejected the mediaOption schema — plain src still plays;
+        // resume falls back to a post-load currentTime seek.
+        await this.attachAndPlay(url, start, false);
+      }
+    } finally {
+      this.loadingPhase = false;
+    }
+  }
+
+  private attachAndPlay(
+    url: string,
+    startTime: number,
+    useMediaOption: boolean,
+  ): Promise<void> {
+    const v = this.video!;
+    this.clearSources();
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const timer = setTimeout(
+        () => finish(() => reject(new Error('webOS <video> load timeout (30s)'))),
+        30000,
+      );
+      const finish = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        v.removeEventListener('loadedmetadata', onMeta);
+        v.removeEventListener('error', onErr);
+        fn();
+      };
+      const onMeta = () => {
+        // mediaOption.playTime.start already positioned the stream; only the
+        // plain-src fallback needs a manual resume seek.
+        if (!useMediaOption && startTime > 0 && isFinite(v.duration)) {
+          try { v.currentTime = startTime; } catch { /* applied on retry */ }
+        }
+        v.play().catch(() => { /* autoplay gate — controls let the user resume */ });
+        finish(resolve);
+      };
+      const onErr = () => finish(() => reject(new Error(mediaErrorMessage(v.error))));
+      v.addEventListener('loadedmetadata', onMeta);
+      v.addEventListener('error', onErr);
+
+      if (useMediaOption) {
+        const source = document.createElement('source');
+        source.src = url;
+        source.setAttribute('type', webOsSourceType(url, startTime));
+        v.appendChild(source);
+      } else {
+        v.src = url;
+      }
+      v.load();
+    });
+  }
+
+  private clearSources(): void {
+    const v = this.video;
+    if (!v) return;
+    while (v.firstChild) v.removeChild(v.firstChild);
+    v.removeAttribute('src');
+  }
+
+  async unload(): Promise<void> {
+    this.clearSeekDebounce();
+    this.seekIntent = null;
+    this.pendingReloadTarget = null;
+    const v = this.video;
+    if (!v) return;
+    try {
+      v.pause();
+      this.clearSources();
+      v.load();
+    } catch { /* ok */ }
+  }
+
+  // ── Playback ────────────────────────────────────────────────────────
+
+  async play(): Promise<void> {
+    try { await this.video?.play(); } catch { /* user gesture may be required */ }
+  }
+  async pause(): Promise<void> {
+    this.video?.pause();
+  }
+
+  async seek(position: number): Promise<void> {
+    const v = this.video;
+    if (!v || !isFinite(position)) return;
+    const target = Math.max(0, position);
+    // Report the target immediately so the bar pins and a follow-up relative
+    // step (±10s) is computed from here, not the stale clock.
+    this.seekIntent = target;
+
+    // Forward in-buffer: native seek is instant and the UA coalesces rapid
+    // ones. Backward seeks are NOT done natively even when "in buffer" — on
+    // webOS a backward native seek into an on-demand transcode sticks in
+    // `seeking` forever (the pipeline re-requests the behind-playhead segment,
+    // gets a 503, and never retries). See #279 for the proper backend fix
+    // (long-poll segments) that will let us drop the reload path entirely.
+    const backward = target < v.currentTime - 0.5;
+    if (!backward && this.isBuffered(target)) {
+      this.pendingReloadTarget = null;
+      this.clearSeekDebounce();
+      try { v.currentTime = target; } catch { /* out of range — ignore */ }
+      return;
+    }
+
+    // Backward, or forward out-of-buffer: a native seek would request an
+    // un-transcoded segment, get a 503, and stick in `seeking` forever.
+    // Reload positioned at the target (the resume path, which works) — but
+    // DEBOUNCED + single-flight: a burst of small backward steps must
+    // collapse to one reload, because rapid `<video>` reloads crash the
+    // webOS pipeline.
+    this.pendingReloadTarget = target;
+    this.clearSeekDebounce();
+    this.seekDebounceTimer = setTimeout(() => {
+      this.seekDebounceTimer = null;
+      this.runReloadIfIdle();
+    }, SEEK_DEBOUNCE_MS);
+  }
+
+  private runReloadIfIdle(): void {
+    // An in-flight reload will pick up `pendingReloadTarget` when it finishes.
+    if (this.reloadInFlight) return;
+    const target = this.pendingReloadTarget;
+    if (target == null) return;
+    this.pendingReloadTarget = null;
+    this.reloadInFlight = true;
+    this.loadInternal(setStartAt(this.loadedUrl, target), target)
+      .catch(() => { /* surfaced via the engine error event */ })
+      .finally(() => {
+        this.reloadInFlight = false;
+        // A newer target arrived mid-reload — honour the latest, once.
+        if (this.pendingReloadTarget != null) this.runReloadIfIdle();
+      });
+  }
+
+  private clearSeekDebounce(): void {
+    if (this.seekDebounceTimer != null) {
+      clearTimeout(this.seekDebounceTimer);
+      this.seekDebounceTimer = null;
+    }
+  }
+
+  /** Whether `pos` sits inside a buffered range with enough margin to play
+   *  from (epsilon at the start, ≥0.5s ahead) — so a native seek serves it
+   *  instantly instead of triggering a reload. */
+  private isBuffered(pos: number): boolean {
+    const v = this.video;
+    if (!v) return false;
+    for (let i = 0; i < v.buffered.length; i++) {
+      if (pos >= v.buffered.start(i) - 0.1 && pos <= v.buffered.end(i) - 0.5) return true;
+    }
+    return false;
+  }
+
+  // ── State getters ───────────────────────────────────────────────────
+
+  get currentTime(): number {
+    if (this.seekIntent != null) return this.seekIntent;
+    return this.video?.currentTime ?? 0;
+  }
+  get duration(): number { return this._duration || this.video?.duration || 0; }
+  get paused(): boolean { return this.video?.paused ?? true; }
+  get buffered(): number { return this.bufferedEnd(); }
+  get playbackRate(): number { return this.video?.playbackRate ?? 1; }
+  set playbackRate(rate: number) { if (this.video) this.video.playbackRate = rate; }
+  get volume(): number { return this.video?.volume ?? 1; }
+  set volume(v: number) { if (this.video) this.video.volume = v; }
+  get muted(): boolean { return this.video?.muted ?? false; }
+  set muted(m: boolean) { if (this.video) this.video.muted = m; }
+
+  private bufferedEnd(): number {
+    const v = this.video;
+    if (!v || v.buffered.length === 0) return 0;
+    try { return v.buffered.end(v.buffered.length - 1); } catch { return 0; }
+  }
+
+  // ── Audio tracks (native AudioTrackList) ────────────────────────────
+
+  getAudioTracks(): AudioTrack[] {
+    const list = this.audioTrackList();
+    if (!list) return [];
+    const tracks: AudioTrack[] = [];
+    for (let i = 0; i < list.length; i++) {
+      const t = list[i];
+      tracks.push({
+        id: 'audio-' + (t.id || i),
+        language: t.language || 'und',
+        label: t.label || t.language || 'Track ' + (i + 1),
+      });
+    }
+    return tracks;
+  }
+
+  async selectAudioTrack(id: string): Promise<void> {
+    const list = this.audioTrackList();
+    if (!list) return;
+    for (let i = 0; i < list.length; i++) {
+      const t = list[i];
+      t.enabled = 'audio-' + (t.id || i) === id;
+    }
+  }
+
+  private audioTrackList(): (AudioTrack & { enabled: boolean; id: string })[] | null {
+    const v = this.video as unknown as { audioTracks?: any };
+    const list = v?.audioTracks;
+    return list && typeof list.length === 'number' && list.length > 0 ? list : null;
+  }
+
+  // ── Subtitles (shared DOM overlay) ──────────────────────────────────
+
+  async addTextTrack(url: string, language: string, label: string): Promise<unknown> {
+    return { url, language, label };
+  }
+  selectTextTrack(track: unknown): void {
+    if (!track || typeof track !== 'object') {
+      this.subtitles.clear();
+      return;
+    }
+    const url = (track as { url?: string }).url;
+    if (url) void this.subtitles.show(url);
+  }
+  setTextVisibility(visible: boolean): void {
+    this.subtitles.setVisible(visible);
+  }
+  setSubtitleStyle(style: {
+    size?: string;
+    color?: string;
+    shadow?: string;
+    background?: string;
+    bottomMargin?: number;
+  }): void {
+    this.subtitles.setStyle(style);
+  }
+
+  // ── Quality — native ABR ────────────────────────────────────────────
+
+  getVariantTracks(): unknown[] { return []; }
+  selectVariantTrack(_track: unknown, _clearBuffer?: boolean): void { /* native ABR; pinned via reload */ }
+  configure(_config: unknown): void { /* Shaka-specific */ }
+
+  // ── Stats ───────────────────────────────────────────────────────────
+
+  getStats(): EngineStats {
+    const v = this.video;
+    const q = v && 'getVideoPlaybackQuality' in v ? v.getVideoPlaybackQuality() : null;
+    return {
+      droppedFrames: q?.droppedVideoFrames ?? 0,
+      activeVariant: v
+        ? { width: v.videoWidth || undefined, height: v.videoHeight || undefined }
+        : undefined,
+    };
+  }
+}
+
+/** Replace (or append) the `startAt` query param so the backend pre-spawns
+ *  ffmpeg at the seek target — paired with mediaOption `playTime.start`. */
+function setStartAt(url: string, position: number): string {
+  const p = Math.max(0, Math.floor(position));
+  if (/[?&]startAt=/.test(url)) return url.replace(/([?&]startAt=)[^&]*/, `$1${p}`);
+  return url + (url.includes('?') ? '&' : '?') + 'startAt=' + p;
+}
+
+/**
+ * Build the `<source>` `type` with webOS's `mediaOption` JSON. `playTime.start`
+ * resumes natively (ms); `adaptiveStreaming.bps.start` opens HLS at a high rung.
+ * Unknown keys are ignored by the pipeline, so this is safe to send always.
+ */
+function webOsSourceType(url: string, startTime: number): string {
+  const isHls = /\.m3u8(\?|$)/i.test(url);
+  const option: Record<string, unknown> = {};
+  if (startTime > 0) {
+    option['transmission'] = { playTime: { start: Math.round(startTime * 1000) } };
+  }
+  if (isHls) {
+    option['adaptiveStreaming'] = { bps: { start: WEBOS_START_BITRATE }, seamlessPlay: true };
+  }
+  const mediaOption = { mediaTransportType: isHls ? 'HLS' : 'URI', option };
+  const mime = isHls ? 'application/vnd.apple.mpegurl' : 'video/mp4';
+  return `${mime};mediaOption=${encodeURI(JSON.stringify(mediaOption))}`;
+}
+
+function mediaErrorMessage(err: MediaError | null): string {
+  if (!err) return 'webOS playback error';
+  const names: Record<number, string> = {
+    1: 'MEDIA_ERR_ABORTED',
+    2: 'MEDIA_ERR_NETWORK',
+    3: 'MEDIA_ERR_DECODE',
+    4: 'MEDIA_ERR_SRC_NOT_SUPPORTED',
+  };
+  return err.message || names[err.code] || 'webOS playback error (' + err.code + ')';
+}

--- a/client/src/app/core/services/tv-spatial-nav.service.ts
+++ b/client/src/app/core/services/tv-spatial-nav.service.ts
@@ -65,6 +65,16 @@ export class TvSpatialNavService {
     // skip every other card on horizontal nav.
     window.addEventListener('keydown', handler, { capture: true });
     this.destroyRef.onDestroy(() => window.removeEventListener('keydown', handler, { capture: true } as any));
+    // The LG Magic Remote's scroll wheel emits standard `wheel` events
+    // (deltaY ±120 per notch) but the webOS WebView never scrolls the page
+    // in response, so the wheel feels dead. Translate vertical wheel into
+    // the same up/down focus moves the D-pad makes — TV only, so the mouse
+    // wheel keeps its native page-scroll on desktop. Non-passive so the
+    // (no-op on webOS) default can be suppressed and double-scroll avoided
+    // on any platform that does scroll natively.
+    const wheelHandler = (e: WheelEvent) => this.onWheel(e);
+    window.addEventListener('wheel', wheelHandler, { capture: true, passive: false });
+    this.destroyRef.onDestroy(() => window.removeEventListener('wheel', wheelHandler, { capture: true } as any));
     // Track the deepest focused element inside each registered container so
     // re-entering a container can dig back to the same leaf (last-active-child
     // memory). Bubble phase is fine: focusin always reaches the document.
@@ -235,6 +245,41 @@ export class TvSpatialNavService {
     // so the user hitting the boundary inside a menu doesn't drift the
     // page underneath.
     if (!this.openModals().length && (dir === 'down' || dir === 'up')) {
+      window.scrollBy({ top: dir === 'down' ? 300 : -300, behavior: 'smooth' });
+    }
+  }
+
+  /** Accumulated wheel deltaY between focus-step emissions, so one notch
+   *  (≈120) maps to exactly one up/down move regardless of the platform's
+   *  delta granularity. */
+  private wheelAcc = 0;
+
+  private onWheel(e: WheelEvent) {
+    if (!this.tv.isTv()) return;
+    // Ignore predominantly-horizontal wheels (trackpads, tilt) — those
+    // belong to the horizontal-scroller rows, not vertical navigation.
+    if (Math.abs(e.deltaY) < Math.abs(e.deltaX)) return;
+    e.preventDefault();
+    this.wheelAcc += e.deltaY;
+    const STEP = 100;
+    while (Math.abs(this.wheelAcc) >= STEP) {
+      const dir = this.wheelAcc > 0 ? 'down' : 'up';
+      this.wheelAcc -= dir === 'down' ? STEP : -STEP;
+      this.navigateVertical(dir);
+    }
+  }
+
+  /** Move focus to the up/down neighbour, falling back to a manual page
+   *  scroll when none exists. Mirrors the up/down tail of {@link onKey} so
+   *  the wheel and the D-pad share one notion of "scroll vertically". */
+  private navigateVertical(dir: 'up' | 'down') {
+    const next = this.findNeighbor(dir);
+    if (next) {
+      next.focus({ preventScroll: true });
+      next.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'smooth' });
+      return;
+    }
+    if (!this.openModals().length) {
       window.scrollBy({ top: dir === 'down' ? 300 : -300, behavior: 'smooth' });
     }
   }

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -45,6 +45,7 @@ import { Capacitor, registerPlugin } from '@capacitor/core';
 import { PlaybackEngine } from '../../core/services/playback-engine/playback-engine';
 import { ShakaEngine } from '../../core/services/playback-engine/shaka-engine';
 import { TizenEngine, isTizenAvplayAvailable } from '../../core/services/playback-engine/tizen-engine';
+import { WebOsEngine } from '../../core/services/playback-engine/webos-engine';
 import { NativePlayer } from '../../core/plugins/native-player.plugin';
 import { NativeEngine } from '../../core/services/playback-engine/native-engine';
 import { PlayerStateService } from '../../core/services/player-state.service';
@@ -190,6 +191,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
    *  from `isNative` (Capacitor) and from `device.isTv()` (which is true
    *  on any TV form factor including the placeholder browser preview). */
   readonly isTizen = isTizenAvplayAvailable();
+  /** LG webOS TV. Plays through the native `<video>` media pipeline
+   *  (HW HEVC/AV1, Dolby, HDR, native HLS) — a regular in-WebView element,
+   *  so it groups with the Shaka UX, not the transparent-plane native one. */
+  readonly isWebOs = this.device.tvPlatform() === 'webos';
 
   /** Template binding — true when using native (ExoPlayer/AVPlayer) engine. */
   get nativeEngine(): boolean {
@@ -829,17 +834,28 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         // the WebView — Shaka chokes on Tizen 6.5 MSE: e.g. EAC3 audio
         // claims support but `addSourceBuffer` throws).
         // Web (browser) keeps the Shaka path.
-        if (this.isTizen) {
-          await this.createTizenEngine();
+        if (this.isTizen || this.isWebOs) {
+          // Both TV pipelines (Samsung AVPlay, LG native <video>) share the
+          // same shape: a native HW decoder with a DOM subtitle overlay and
+          // the streamInfo audio fallback — no Shaka/MSE. They differ only in
+          // the engine instance.
+          if (this.isWebOs) {
+            await this.createWebOsEngine();
+          } else {
+            await this.createTizenEngine();
+          }
+          this.applyNativeSubtitleStyle();
 
           // Subtitle fetch in parallel with engine load — AVPlay's
           // `setExternalSubtitlePath` waits for the player to be in
           // READY/PLAYING state, so we load(...) first, then attach
           // the active subtitle after prepareAsync resolves.
-          const tizenSubsPromise = this.trackManager.loadSubtitles(
+          const tvSubsPromise = this.trackManager.loadSubtitles(
             this.mediaId, this.mediaFileId, this.streamingApi, this.media,
           );
 
+          // Auth rides in the URL query (?token=); the Bearer header is for
+          // AVPlay/ExoPlayer only — the webOS <video> ignores it.
           const token =
             this.authService.streamToken() ?? this.authService.accessToken;
           const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
@@ -857,7 +873,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
           // Subtitles loaded — expose to the picker. The full auto-pick
           // path (remembered selection, language match, forced subs) is
           // shared with native/Shaka further down, via `autoSelectSubtitle`.
-          const subs = await tizenSubsPromise;
+          const subs = await tvSubsPromise;
           this.availableSubtitles.set(subs);
           await this.trackManager.autoSelectSubtitle(
             subs,
@@ -1163,6 +1179,31 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       this.state.volume.set(video.muted ? 0 : video.volume);
     });
     // durationchange fallback: only use if we don't already have a reliable duration
+    video.addEventListener('durationchange', () => {
+      const current = this.state.duration();
+      if (!current && isFinite(video.duration) && video.duration > 0) {
+        this.state.duration.set(video.duration);
+      }
+    });
+  }
+
+  private async createWebOsEngine(): Promise<void> {
+    const video = this.videoEl()!.nativeElement;
+    // webOS plays through the same visible <video> the Shaka path uses —
+    // the platform pipeline decodes natively. No transparent hardware
+    // plane (Tizen/Capacitor), so the Shaka UX (isNativeEngine=false) fits.
+    const engine = new WebOsEngine();
+    await engine.init(video);
+    this.engine = engine;
+    this.isNativeEngine.set(false);
+    this.state.bindEngine(engine);
+
+    engine.on('firstFrame', () => {
+      this.state.videoStarted.set(true);
+    });
+    video.addEventListener('volumechange', () => {
+      this.state.volume.set(video.muted ? 0 : video.volume);
+    });
     video.addEventListener('durationchange', () => {
       const current = this.state.duration();
       if (!current && isFinite(video.duration) && video.duration > 0) {

--- a/client/src/app/utils/translate-loader.ts
+++ b/client/src/app/utils/translate-loader.ts
@@ -13,7 +13,11 @@ export function translateBrowserLoaderFactory(
   const http = new HttpClient(backend);
   return {
     getTranslation(lang: string): Observable<TranslationObject> {
-      return http.get<TranslationObject>(`/i18n/${lang}.json?v=${Date.now()}`);
+      // Relative to <base href> so it resolves against the app bundle: on
+      // web that's the server root, on Smart TV (file:// with baseHref "./")
+      // it's the app directory where the JSON ships. A leading "/" resolves
+      // to the filesystem root on TV and 404s.
+      return http.get<TranslationObject>(`i18n/${lang}.json?v=${Date.now()}`);
     },
   };
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -205,15 +205,25 @@ body.tv {
    drifted up as the user scrolled (the body's transform scaled the
    scroll-relative offset). Modern TVs overscan horizontally far more
    than vertically; the vertical edge isn't worth the positioning
-   headaches. Excluded on Tizen: the Samsung WebView already trims
-   ~4% on each axis, so adding our own margin would double-clip. */
-body.tv:not(.tv-tizen) {
+   headaches. Excluded on Smart TVs (Tizen, webOS): their WebViews
+   already trim ~4% on each axis, so adding our own margin would
+   double-clip. Only AndroidTV needs the compensation. */
+body.tv:not(.tv-tizen):not(.tv-webos) {
   transform: scaleX(0.96);
   transform-origin: top center;
 }
 /* Player (immersive) needs the full screen — no overscan compensation */
 body.tv.immersive {
   transform: none;
+}
+/* webOS lays the app out at a 1920×1080 logical viewport, whereas the
+   Tizen WebView reports ~1280×720. At 1920 every element is ~⅔ the
+   physical size of its Tizen counterpart, so the 10-foot UI reads as
+   tiny from the couch. Zoom 1.5 (1920÷1280) brings the effective density
+   back in line with Tizen. Excluded while immersive so the fullscreen
+   player isn't scaled past the panel edges. */
+body.tv-webos:not(.immersive) {
+  zoom: 1.5;
 }
 /* Backfill html so the WebView doesn't show its default white during route
    transitions, before bootstrap, or in the 4% bottom band the scale leaves.


### PR DESCRIPTION
Brings the LG webOS build up to parity with the Tizen TV experience: a native player plus the platform glue (i18n, 10-foot layout, remote wheel + back key). All verified live on an LG webOS 10 set.

## Changes

- **Native player** (`WebOsEngine`): webOS previously fell into the Capacitor native-engine branch (a plugin that doesn't exist there) and crashed on load. It now drives the platform `<video>` element — native HLS with HW HEVC/AV1, Dolby (AC3/EAC3) and HDR via DirectStream. The device profile advertises those codecs so the backend direct-streams instead of transcoding (validated direct-streaming 4K HEVC). MPEG-TS stays Tizen-only.
- **Shared subtitle overlay**: the Tizen VTT DOM overlay is extracted into `subtitle-overlay.util.ts` and reused by both TV engines (no duplication).
- **i18n**: translation files are now requested relative to the base href, so they load from the bundle on TV (the absolute `/i18n/...` path 404'd under `file://`).
- **10-foot UI**: exclude webOS from the horizontal overscan (no more side padding, like Tizen) and `zoom: 1.5` so the UI isn't ~2/3 size (webOS lays out at 1920 vs Tizen's ~1280).
- **Remote wheel**: the Magic Remote scroll wheel now drives vertical focus navigation (the webOS WebView ignores native `wheel` scrolling).
- **Back key**: handle webOS `GoBack` / keyCode 461 (was Tizen-only), exiting via `platformBack` at the app root.

## Known limitation (tracked)

Far and **backward** seeks reload the stream at the target as a stopgap, because a native backward seek freezes on webOS (the on-demand transcode returns a transient 503 that the native `<video>` won't retry). The clean fix is backend-side (long-poll segments) — see #279. Forward in-buffer seeks are instant; backward/far seeks rebuffer ~2-5s.

## Test plan

- [x] Translations render (not raw keys)
- [x] No side padding; readable 10-foot density
- [x] Magic Remote wheel scrolls; D-pad + Back button work
- [x] Playback + resume, incl. 4K HEVC HDR DirectStream
- [x] Forward seek instant (in buffer); far/backward seek rebuffers without crashing
- [ ] Tizen regression check (shared subtitle overlay refactor)