### PR TITLE
fix(requests, media): unify metadata workflow and kick auto-grab on every approval/refresh

### DIFF
--- a/backend/src/modules/imports/disk-import.service.ts
+++ b/backend/src/modules/imports/disk-import.service.ts
@@ -20,6 +20,7 @@ import { MediaType } from '../../common/enums';
 import { parseReleaseQuality } from '../../common/release-parsing';
 import { ImportFileEntry } from './dto/confirm-disk-import.dto';
 import { MediaService } from '../media/media.service';
+import { MediaMetadataService } from '../media/media-service/media-metadata.service';
 import { NamingService } from '../scheduler/naming.service';
 import { SubtitleSchedulerService } from '../scheduler/subtitle-scheduler.service';
 import { LibrariesService } from '../libraries/libraries.service';
@@ -76,6 +77,8 @@ export class DiskImportService {
     private readonly naming: NamingService,
     private readonly libraries: LibrariesService,
     private readonly fileTransfer: FileTransferService,
+    @Inject(forwardRef(() => MediaMetadataService))
+    private readonly metadata: MediaMetadataService,
   ) {}
 
   async scanFolder(folderPath: string): Promise<ScanCandidate[]> {
@@ -100,7 +103,27 @@ export class DiskImportService {
       select: ['id', 'title', 'originalTitle', 'year', 'type'],
     });
 
-    return Promise.all(videoFiles.map((f) => this.buildCandidate(f, allMedia)));
+    // `buildCandidate` may invent a fresh season / episode slot for any file
+    // that references one we haven't pulled metadata for yet. Collect the
+    // owning media so we can backfill those rows (titles, overviews, stills)
+    // via the shared series refresh, instead of leaving them bare in the UI.
+    const dirty = new Set<number>();
+    const candidates = await Promise.all(
+      videoFiles.map((f) => this.buildCandidate(f, allMedia, dirty)),
+    );
+    for (const mediaId of dirty) {
+      try {
+        const media = await this.mediaRepo.findOne({ where: { id: mediaId } });
+        if (media && media.type === MediaType.SERIES) {
+          await this.metadata.refreshSeriesEpisodes(media);
+        }
+      } catch (err) {
+        this.logger.warn(
+          `Disk scan: refreshSeriesEpisodes #${mediaId} failed — ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    return candidates;
   }
 
   /**
@@ -347,6 +370,7 @@ export class DiskImportService {
   private async buildCandidate(
     filePath: string,
     allMedia: Pick<Media, 'id' | 'title' | 'originalTitle' | 'year' | 'type'>[],
+    dirtyMediaIds?: Set<number>,
   ): Promise<ScanCandidate> {
     const filename = path.basename(filePath);
     let size = 0;
@@ -376,6 +400,7 @@ export class DiskImportService {
             monitored: true,
           }),
         );
+        dirtyMediaIds?.add(matched.id);
       }
       let ep = await this.episodeRepo.findOne({
         where: { season: { id: season.id }, episodeNumber: epNums.episode },
@@ -389,6 +414,7 @@ export class DiskImportService {
             monitored: true,
           }),
         );
+        dirtyMediaIds?.add(matched.id);
       } else if (
         epNums.episodeEnd != null &&
         ep.endEpisodeNumber !== epNums.episodeEnd

--- a/backend/src/modules/media/media-service/media-import.service.ts
+++ b/backend/src/modules/media/media-service/media-import.service.ts
@@ -380,28 +380,18 @@ export class MediaImportService {
     await this.metadata.downloadMediaImages(saved.id, details);
 
     for (const sd of seasons) {
-      const season = this.seasonRepo.create({
-        media: saved,
-        seasonNumber: sd.seasonNumber,
-        monitored: true,
-      });
-      const sSaved = await this.seasonRepo.save(season);
-      if (sd.episodes.length > 0) {
-        await this.episodeRepo.insert(
-          sd.episodes.map((ep) => ({
-            season: sSaved,
-            episodeNumber: ep.episodeNumber,
-            title: ep.title || undefined,
-            overview: ep.overview || undefined,
-            airDate: ep.airDate || undefined,
-            runtime: ep.runtime ?? undefined,
-            monitored: true,
-          })),
-        );
-      }
-      if (sd.posterUrl) {
-        await this.metadata.downloadSeasonPoster(sSaved.id, sd.posterUrl);
-      }
+      const sSaved = await this.seasonRepo.save(
+        this.seasonRepo.create({
+          media: saved,
+          seasonNumber: sd.seasonNumber,
+          monitored: true,
+        }),
+      );
+      // Defer to the same per-season routine the metadata refresh uses, so
+      // import and refresh end up with identical episode rows, stills and
+      // season posters — diverging here is exactly what left every episode
+      // sharing the series fanart until a manual refresh.
+      await this.metadata.applySeasonDetails(sSaved, sd);
     }
 
     await this.metadata.updateSearchVector(saved.id);

--- a/backend/src/modules/media/media-service/media-metadata.service.ts
+++ b/backend/src/modules/media/media-service/media-metadata.service.ts
@@ -238,8 +238,11 @@ export class MediaMetadataService {
     }
   }
 
-  /** Upsert episodes of one DB season from provider season details. */
-  private async applySeasonDetails(
+  /** Upsert episodes of one DB season from provider season details, download
+   *  per-episode stills and the season poster. Shared by the metadata refresh
+   *  flow and the initial library import so both end up with the same set of
+   *  artwork — diverging here meant stills were missing right after import. */
+  async applySeasonDetails(
     dbSeason: Season,
     sd: SeasonDetails,
   ): Promise<void> {

--- a/backend/src/modules/media/media-service/media-metadata.service.ts
+++ b/backend/src/modules/media/media-service/media-metadata.service.ts
@@ -23,6 +23,7 @@ import {
 } from '../../metadata-providers/interfaces/metadata-provider.interface';
 import { MediaType } from '../../../common/enums';
 import { ImageService } from '../../images/image.service';
+import { SchedulerService } from '../../scheduler/scheduler.service';
 import { mapWithConcurrency } from '../../../common/utils/concurrency';
 import { buildMediaFieldsFromTmdb } from './tmdb-mapping.util';
 
@@ -47,6 +48,7 @@ export class MediaMetadataService {
     private readonly tmdb: TmdbProvider,
     private readonly providerRegistry: MetadataProviderRegistry,
     private readonly imageService: ImageService,
+    private readonly scheduler: SchedulerService,
   ) {}
 
   async refreshMetadata(id: number): Promise<Media> {
@@ -81,7 +83,16 @@ export class MediaMetadataService {
       });
       await this.downloadMediaImages(media.id, details);
       await this.persistMediaMetadata(media, details);
-      await this.refreshSeriesEpisodes(media, { provider, externalId });
+      const { insertedCount } = await this.refreshSeriesEpisodes(media, {
+        provider,
+        externalId,
+      });
+      // New episodes appeared on the provider (typically a fresh season
+      // drop): kick the auto-grab pipeline now instead of waiting up to 6 h
+      // for the next scheduler tick. Mirrors the post-approval kick.
+      if (insertedCount > 0) {
+        void this.scheduler.searchMissingForMedia([media.id]);
+      }
     }
 
     await this.updateSearchVector(media.id);
@@ -144,7 +155,7 @@ export class MediaMetadataService {
   async refreshSeriesEpisodes(
     media: Media,
     preResolved?: { provider: IMetadataProvider; externalId: string },
-  ): Promise<void> {
+  ): Promise<{ insertedCount: number }> {
     // 1. Media-level provider enumerates all seasons and provides defaults.
     //    `refreshMetadata` has already resolved the provider — accept it
     //    so we don't re-emit the `resolveProvider:` log and skip the DB
@@ -160,6 +171,8 @@ export class MediaMetadataService {
       relations: ['episodes'],
     });
     const dbSeasonMap = new Map(dbSeasons.map((s) => [s.seasonNumber, s]));
+
+    let insertedCount = 0;
 
     // 2. Upsert seasons + apply media-level episode data, skipping seasons
     //    whose override points elsewhere (handled in the second pass).
@@ -182,7 +195,7 @@ export class MediaMetadataService {
       ) {
         continue;
       }
-      await this.applySeasonDetails(dbSeason, sd);
+      insertedCount += (await this.applySeasonDetails(dbSeason, sd)).insertedCount;
     }
 
     // 3. Second pass: re-fetch overridden seasons from their own provider.
@@ -193,7 +206,7 @@ export class MediaMetadataService {
         s.preferredProvider &&
         s.preferredProvider !== mediaResolve.provider.name,
     );
-    if (!overridden.length) return;
+    if (!overridden.length) return { insertedCount };
     const cache = new Map<string, SeasonDetails[]>();
     for (const dbSeason of overridden) {
       let overrideResolve: {
@@ -213,7 +226,9 @@ export class MediaMetadataService {
         const fallback = mediaSeasons.find(
           (s) => s.seasonNumber === dbSeason.seasonNumber,
         );
-        if (fallback) await this.applySeasonDetails(dbSeason, fallback);
+        if (fallback) {
+          insertedCount += (await this.applySeasonDetails(dbSeason, fallback)).insertedCount;
+        }
         continue;
       }
       const seasonData = await this.fetchSingleSeason(
@@ -231,21 +246,26 @@ export class MediaMetadataService {
         const fallback = mediaSeasons.find(
           (s) => s.seasonNumber === dbSeason.seasonNumber,
         );
-        if (fallback) await this.applySeasonDetails(dbSeason, fallback);
+        if (fallback) {
+          insertedCount += (await this.applySeasonDetails(dbSeason, fallback)).insertedCount;
+        }
         continue;
       }
-      await this.applySeasonDetails(dbSeason, seasonData);
+      insertedCount += (await this.applySeasonDetails(dbSeason, seasonData)).insertedCount;
     }
+    return { insertedCount };
   }
 
   /** Upsert episodes of one DB season from provider season details, download
    *  per-episode stills and the season poster. Shared by the metadata refresh
    *  flow and the initial library import so both end up with the same set of
-   *  artwork — diverging here meant stills were missing right after import. */
+   *  artwork — diverging here meant stills were missing right after import.
+   *  Returns the number of fresh episode rows it created so the caller can
+   *  decide whether to kick the auto-grab pipeline. */
   async applySeasonDetails(
     dbSeason: Season,
     sd: SeasonDetails,
-  ): Promise<void> {
+  ): Promise<{ insertedCount: number }> {
     const dbEpMap = new Map(
       (dbSeason.episodes ?? []).map((e) => [e.episodeNumber, e]),
     );
@@ -322,6 +342,7 @@ export class MediaMetadataService {
     if (sd.posterUrl) {
       await this.downloadSeasonPoster(dbSeason.id, sd.posterUrl);
     }
+    return { insertedCount: insertedRows.length };
   }
 
   /**

--- a/backend/src/modules/media/media-service/media-rescan.service.ts
+++ b/backend/src/modules/media/media-service/media-rescan.service.ts
@@ -26,6 +26,7 @@ import {
   buildSpriteLabel,
 } from '../../streaming/thumbnail.service';
 import { MediaServersService } from '../../media-servers/media-servers.service';
+import { MediaMetadataService } from './media-metadata.service';
 import { clearMediaCache } from '../../../common/utils/media-cache.util';
 import { relativePathUnderMediaRoot } from '../../../common/utils/media-path.util';
 import { bucketResolutionHeight } from '../../../common/utils/resolution.util';
@@ -63,6 +64,7 @@ export class MediaRescanService {
     private readonly subtitleStream: SubtitleStreamService,
     private readonly thumbnailService: ThumbnailService,
     private readonly mediaServers: MediaServersService,
+    private readonly metadata: MediaMetadataService,
   ) {}
 
   /**
@@ -307,6 +309,10 @@ export class MediaRescanService {
         `Media #${mediaId} has no root path configured`,
       );
     }
+    // Set whenever a file forces us to invent a fresh season/episode slot.
+    // After the rescan we backfill metadata (titles, stills) for those slots
+    // by running the shared series refresh so they don't show up empty.
+    let metadataSlotsCreated = false;
 
     // Wipe the whole per-media `.cache/` tree (subtitles + any other cached
     // artefact) — streamInfo is about to be re-read so anything derived
@@ -438,11 +444,12 @@ export class MediaRescanService {
         const epNums = this.naming.parseEpisodeNumbers(filename);
         if (epNums && dbFile.episodeId == null) {
           try {
-            const ep = await this.ensureSeasonAndEpisode(
+            const { ep, created } = await this.ensureSeasonAndEpisode(
               media,
               epNums,
               mediaId,
             );
+            if (created) metadataSlotsCreated = true;
             if (ep) {
               dbFile.episode = ep;
               try {
@@ -556,11 +563,12 @@ export class MediaRescanService {
         const epNums = this.naming.parseEpisodeNumbers(filename);
         if (epNums) {
           try {
-            const ep = await this.ensureSeasonAndEpisode(
+            const { ep, created } = await this.ensureSeasonAndEpisode(
               media,
               epNums,
               mediaId,
             );
+            if (created) metadataSlotsCreated = true;
             episodeId = ep?.id;
           } catch (err) {
             this.log.error(
@@ -678,6 +686,20 @@ export class MediaRescanService {
       });
     }
 
+    // Slots invented to host newly-discovered files start out as bare rows
+    // (episodeNumber + monitored). Run the shared series refresh so they
+    // gain titles, overviews, stills and the season poster — the same
+    // routine the manual "Refresh metadata" button uses.
+    if (metadataSlotsCreated) {
+      try {
+        await this.metadata.refreshSeriesEpisodes(media);
+      } catch (err) {
+        this.log.warn(
+          `Rescan[media #${mediaId}]: refreshSeriesEpisodes failed — ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
     return {
       added,
       removed,
@@ -705,7 +727,8 @@ export class MediaRescanService {
       episodeEnd?: number | null;
     },
     mediaId: number,
-  ): Promise<Episode | null> {
+  ): Promise<{ ep: Episode | null; created: boolean }> {
+    let created = false;
     let season = await this.seasonRepo.findOne({
       where: { media: { id: media.id }, seasonNumber: epNums.season },
     });
@@ -717,6 +740,7 @@ export class MediaRescanService {
           monitored: true,
         }),
       );
+      created = true;
       this.log.log(
         `Rescan: created season ${epNums.season} for media #${mediaId}`,
       );
@@ -736,6 +760,7 @@ export class MediaRescanService {
           monitored: true,
         }),
       );
+      created = true;
       this.log.log(
         `Rescan: created episode S${String(epNums.season).padStart(2, '0')}E${String(epNums.episode).padStart(2, '0')} for media #${mediaId}`,
       );
@@ -746,7 +771,7 @@ export class MediaRescanService {
       ep.endEpisodeNumber = epNums.episodeEnd;
       await this.episodeRepo.save(ep);
     }
-    return ep;
+    return { ep, created };
   }
 
   /**

--- a/backend/src/modules/media/media.module.ts
+++ b/backend/src/modules/media/media.module.ts
@@ -80,6 +80,11 @@ import { StreamingModule } from '../streaming/streaming.module';
     TorrentAutoMatcher,
     NamingService,
   ],
-  exports: [MediaService, AutoGrabPipelineService, TorrentAutoMatcher],
+  exports: [
+    MediaService,
+    MediaMetadataService,
+    AutoGrabPipelineService,
+    TorrentAutoMatcher,
+  ],
 })
 export class MediaModule {}

--- a/backend/src/modules/requests/requests.service.ts
+++ b/backend/src/modules/requests/requests.service.ts
@@ -25,6 +25,7 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { MediaService } from '../media/media.service';
 import { Media } from '../media/entities/media.entity';
 import { ProfilesService } from '../profiles/profiles.service';
+import { SchedulerService } from '../scheduler/scheduler.service';
 import { CaslAbilityFactory } from '../auth/casl/casl-ability.factory';
 import { Action } from '../auth/casl/actions.enum';
 import {
@@ -50,6 +51,7 @@ export class RequestsService {
     private readonly notifications: NotificationsService,
     private readonly mediaService: MediaService,
     private readonly profilesService: ProfilesService,
+    private readonly scheduler: SchedulerService,
     private readonly caslAbilityFactory: CaslAbilityFactory,
   ) {}
 
@@ -451,6 +453,13 @@ export class RequestsService {
     void this.notifications.dispatch('request.approved', {
       title: saved.title,
     });
+    // Kick an immediate SearchMissing on the approved media so the user
+    // doesn't wait for the next scheduler tick (up to 6 h). The lifecycle
+    // path already does this on auto-approval; the manual approve was the
+    // outlier — fire-and-forget so the HTTP response stays snappy.
+    if (saved.media) {
+      void this.scheduler.searchMissingForMedia([saved.media.id]);
+    }
     return saved;
   }
 


### PR DESCRIPTION
Fixes two reported bugs and the cluster of similar divergences they surfaced.

## Bugs reported

- After approving a request manually, no download pack started — even though a manual search found packs.
- After importing a series, every episode shared the same image until the user hit "Refresh metadata".

## What was happening

- **Manual approval didn't trigger SearchMissing** — only the auto-approval path (`request-lifecycle.onMediaImported`) called `searchMissingForMedia`; the manual `approve()` saved the row, notified, and stopped. The auto-grab pipeline then had to wait up to 6 h for the next scheduler tick.
- **Series import skipped per-episode stills** — `persistImportedSeries` duplicated the per-season insert + still-download logic instead of reusing `applySeasonDetails`, and the duplicate forgot the per-episode stills. Manual refresh worked because `applySeasonDetails` does pull them.
- **Same divergence elsewhere** — `disk-import.buildCandidate` and `media-rescan.ensureSeasonAndEpisode` quietly invent fresh season/episode rows when a scanned file references a slot we don't have metadata for, but leave those rows bare (`episodeNumber` + `monitored` only). The library then shows unnamed episodes with the series fanart until the user hits Refresh.
- **Refresh discovered new episodes but didn't auto-grab** — when a new season drops on TMDB and the user refreshes, `refreshSeriesEpisodes` inserts the new rows but never kicked `SearchMissing`. Same scheduler-tick wait as the approval bug.

## Changes (one commit per concern)

1. `fix(requests): kick SearchMissing after a manual approval` — `RequestsService` now mirrors what the lifecycle does on auto-approval.
2. `refactor(media): unify import + refresh metadata workflow` — expose `applySeasonDetails`; have `persistImportedSeries` delegate so import and refresh share one routine and can't drift apart again.
3. `feat(media): kick SearchMissing when refresh discovers new episodes` — bubble the per-call insert count through `applySeasonDetails` → `refreshSeriesEpisodes` → `refreshMetadata` and fire-and-forget `searchMissingForMedia` when the refresh actually grew the catalogue.
4. `fix(rescan): populate metadata for slots created during rescan` — `ensureSeasonAndEpisode` reports whether it invented a row; `rescanFiles` runs the shared series refresh once at the end when any did.
5. `fix(disk-import): populate metadata for slots created during scan` — same pattern, threaded through `scanFolder` via a dirty-media set; exports `MediaMetadataService` from `MediaModule` so the imports module can reach it.

## Test plan

- [x] Backend `tsc --noEmit` clean
- [ ] Manual approval (with profile-matched media in library) — download pack kicks off without waiting for the scheduler
- [ ] Series import — all episode tiles show their own stills out of the gate, no manual refresh needed
- [ ] Disk scan against a folder whose files reference a season we don't have — the candidate list / library has proper episode titles after confirm
- [ ] Rescan a series whose folder gained a brand-new file referencing a fresh episode — that episode picks up its title/still automatically
- [ ] Refresh a series whose provider has a freshly-dropped season — the auto-grab pipeline starts trying for the new episodes immediately