### PR TITLE
fix(media): forwardRef the SchedulerService dep on MediaMetadataService

### DIFF
--- a/backend/src/modules/media/media-service/media-metadata.service.ts
+++ b/backend/src/modules/media/media-service/media-metadata.service.ts
@@ -50,9 +50,6 @@ export class MediaMetadataService {
     private readonly tmdb: TmdbProvider,
     private readonly providerRegistry: MetadataProviderRegistry,
     private readonly imageService: ImageService,
-    // forwardRef: MediaModule ↔ FliksSchedulerModule is a mutual-forwardRef
-    // cycle; without the class-level forwardRef Nest tries to resolve
-    // SchedulerService while the scheduler module isn't ready yet.
     @Inject(forwardRef(() => SchedulerService))
     private readonly scheduler: SchedulerService,
   ) {}

--- a/backend/src/modules/media/media-service/media-metadata.service.ts
+++ b/backend/src/modules/media/media-service/media-metadata.service.ts
@@ -3,6 +3,8 @@ import {
   Logger,
   NotFoundException,
   BadRequestException,
+  Inject,
+  forwardRef,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
@@ -48,6 +50,10 @@ export class MediaMetadataService {
     private readonly tmdb: TmdbProvider,
     private readonly providerRegistry: MetadataProviderRegistry,
     private readonly imageService: ImageService,
+    // forwardRef: MediaModule ↔ FliksSchedulerModule is a mutual-forwardRef
+    // cycle; without the class-level forwardRef Nest tries to resolve
+    // SchedulerService while the scheduler module isn't ready yet.
+    @Inject(forwardRef(() => SchedulerService))
     private readonly scheduler: SchedulerService,
   ) {}
 


### PR DESCRIPTION
## What

Backend boot fails since #281 with:

\`\`\`
UndefinedDependencyException: Nest can't resolve dependencies of the
MediaMetadataService (..., ?). Please make sure that the argument at
index [10] is available in the current module.
\`\`\`

Argument [10] is the new \`SchedulerService\` injection added in #281 (kick \`SearchMissing\` when a metadata refresh discovers fresh episodes).

## Why

\`MediaModule\` and \`FliksSchedulerModule\` import each other via \`forwardRef\` (the cycle is intentional — the scheduler walks media to schedule grabs, and media uses the scheduler to kick searches). For a class-level dep across that cycle, the module-level forwardRef isn't enough: Nest tries to read \`SchedulerService\` while the scheduler module's providers aren't instantiated yet.

## Fix

Wrap the parameter with \`@Inject(forwardRef(() => SchedulerService))\`, the same pattern \`RequestLifecycleService\` already uses for the same dep across the same cycle.

## Test plan

- [x] \`tsc --noEmit\` clean
- [ ] Backend boots without the UndefinedDependencyException
- [ ] Refresh that discovers fresh episodes still kicks the search (the behaviour from #281)