### PR TITLE
fix(cache): revalidate browsing pages after the cache preload

### DIFF
--- a/client/src/app/core/services/api/media.service.ts
+++ b/client/src/app/core/services/api/media.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { MediaType } from '../../enums/media-type.enum';
+import { CACHE_BYPASS_HEADER } from '../../interceptors/cache.interceptor';
 
 export interface QualityProfileBrief {
   id: number;
@@ -318,8 +319,11 @@ export class MediaService {
     return firstValueFrom(this.http.get<MediaPage>('/api/media', { params: httpParams }));
   }
 
-  getOne(id: number) {
-    return firstValueFrom(this.http.get<Media>(`/api/media/${id}`));
+  getOne(id: number, opts: { force?: boolean } = {}) {
+    const headers = opts.force ? { [CACHE_BYPASS_HEADER]: '1' } : undefined;
+    return firstValueFrom(
+      this.http.get<Media>(`/api/media/${id}`, headers ? { headers } : {}),
+    );
   }
 
   getTracking(id: number) {

--- a/client/src/app/core/services/api/media.service.ts
+++ b/client/src/app/core/services/api/media.service.ts
@@ -291,32 +291,35 @@ export class MediaService {
     );
   }
 
-  getGenres(libraryId?: number) {
-    const params = libraryId
-      ? { params: { libraryId: String(libraryId) } }
-      : {};
+  getGenres(libraryId?: number, opts: { force?: boolean } = {}) {
+    const reqOpts: { params?: { libraryId: string }; headers?: { [k: string]: string } } = {};
+    if (libraryId) reqOpts.params = { libraryId: String(libraryId) };
+    if (opts.force) reqOpts.headers = { [CACHE_BYPASS_HEADER]: '1' };
     return firstValueFrom(
-      this.http.get<GenreSummary[]>('/api/media/genres', params),
+      this.http.get<GenreSummary[]>('/api/media/genres', reqOpts),
     );
   }
 
-  getCollections(libraryId?: number) {
-    const params = libraryId
-      ? { params: { libraryId: String(libraryId) } }
-      : {};
+  getCollections(libraryId?: number, opts: { force?: boolean } = {}) {
+    const reqOpts: { params?: { libraryId: string }; headers?: { [k: string]: string } } = {};
+    if (libraryId) reqOpts.params = { libraryId: String(libraryId) };
+    if (opts.force) reqOpts.headers = { [CACHE_BYPASS_HEADER]: '1' };
     return firstValueFrom(
-      this.http.get<CollectionSummary[]>('/api/media/collections', params),
+      this.http.get<CollectionSummary[]>('/api/media/collections', reqOpts),
     );
   }
 
-  getAll(params: SearchParams = {}) {
+  getAll(params: SearchParams = {}, opts: { force?: boolean } = {}) {
     let httpParams = new HttpParams();
     for (const [key, value] of Object.entries(params)) {
       if (value !== undefined && value !== null && value !== '') {
         httpParams = httpParams.set(key, String(value));
       }
     }
-    return firstValueFrom(this.http.get<MediaPage>('/api/media', { params: httpParams }));
+    const headers = opts.force ? { [CACHE_BYPASS_HEADER]: '1' } : undefined;
+    return firstValueFrom(
+      this.http.get<MediaPage>('/api/media', headers ? { params: httpParams, headers } : { params: httpParams }),
+    );
   }
 
   getOne(id: number, opts: { force?: boolean } = {}) {
@@ -395,12 +398,13 @@ export class MediaService {
     return firstValueFrom(this.http.put<Media>(`/api/media/${id}`, { monitored }));
   }
 
-  getCalendar(start: string, end: string, monitoredOnly = false, requestedByMe = false) {
+  getCalendar(start: string, end: string, monitoredOnly = false, requestedByMe = false, opts: { force?: boolean } = {}) {
     const params: Record<string, string> = { start, end };
     if (monitoredOnly) params['monitoredOnly'] = 'true';
     if (requestedByMe) params['requestedByMe'] = 'true';
+    const headers = opts.force ? { [CACHE_BYPASS_HEADER]: '1' } : undefined;
     return firstValueFrom(
-      this.http.get<CalendarEntry[]>('/api/media/calendar', { params }),
+      this.http.get<CalendarEntry[]>('/api/media/calendar', headers ? { params, headers } : { params }),
     );
   }
 

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -430,11 +430,14 @@ export class StreamingApiService {
     );
   }
 
-  getHistory(page = 1, limit = 25) {
+  getHistory(page = 1, limit = 25, opts: { force?: boolean } = {}) {
+    const reqOpts: {
+      params: Record<string, string>;
+      headers?: { [k: string]: string };
+    } = { params: { page: String(page), limit: String(limit) } };
+    if (opts.force) reqOpts.headers = { [CACHE_BYPASS_HEADER]: '1' };
     return firstValueFrom(
-      this.http.get<{ data: WatchHistoryItem[]; total: number }>('/api/playback/history', {
-        params: { page: String(page), limit: String(limit) },
-      }),
+      this.http.get<{ data: WatchHistoryItem[]; total: number }>('/api/playback/history', reqOpts),
     );
   }
 
@@ -445,8 +448,11 @@ export class StreamingApiService {
     );
   }
 
-  getWatchedMediaIds(): Promise<number[]> {
-    return firstValueFrom(this.http.get<number[]>('/api/playback/watched-ids'));
+  getWatchedMediaIds(opts: { force?: boolean } = {}): Promise<number[]> {
+    const headers = opts.force ? { [CACHE_BYPASS_HEADER]: '1' } : undefined;
+    return firstValueFrom(
+      this.http.get<number[]>('/api/playback/watched-ids', headers ? { headers } : {}),
+    );
   }
 
   toggleWatched(mediaId: number, mediaFileId: number, episodeId?: number) {

--- a/client/src/app/features/calendar/calendar.ts
+++ b/client/src/app/features/calendar/calendar.ts
@@ -119,19 +119,24 @@ export class CalendarComponent implements OnInit {
     const d = this.currentDate();
     const start = new Date(d.getFullYear(), d.getMonth(), 1 - 7);
     const end = new Date(d.getFullYear(), d.getMonth() + 1, 7);
+    const startStr = this.toDateStr(start);
+    const endStr = this.toDateStr(end);
     this.loading.set(true);
     this.error.set('');
     try {
-      const data = await this.mediaService.getCalendar(
-        this.toDateStr(start),
-        this.toDateStr(end),
-      );
+      const data = await this.mediaService.getCalendar(startStr, endStr);
       this.entries.set(data);
     } catch {
       this.error.set('calendar.load_error');
     } finally {
       this.loading.set(false);
     }
+    queueMicrotask(() => {
+      void this.mediaService
+        .getCalendar(startStr, endStr, false, false, { force: true })
+        .then((fresh) => this.entries.set(fresh))
+        .catch(() => { /* keep cached entries */ });
+    });
   }
 
   private toDateStr(d: Date): string {

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -175,6 +175,9 @@ export class LibraryComponent implements OnInit, OnDestroy {
   readonly qualityProfiles = signal<QualityProfile[]>([]);
 
   private allLibraries: LibrarySummary[] = [];
+  /** Bumped on every `load()` so a stale background revalidation kicked off
+   *  for the previous library can't overwrite the current view. */
+  private loadGen = 0;
 
   /** Re-load when route param changes (e.g. clicking another library in sidebar). */
   private readonly paramEffect = effect(() => {
@@ -590,24 +593,26 @@ export class LibraryComponent implements OnInit, OnDestroy {
     if (!libraryId) return;
     if (!silent) this.loading.set(true);
     const monitored = this.filterMonitored();
+    const fs = this.filterStatus();
+    const fw = this.filterWatched();
+    const params = {
+      libraryId,
+      q: this.searchQuery() || undefined,
+      sortBy: this.sortBy(),
+      sortOrder: this.sortOrder(),
+      genre: this.selectedGenre() || undefined,
+      collectionId: this.selectedCollectionId() ?? undefined,
+      monitored: monitored ? monitored === 'true' : undefined,
+      missing: fs === 'missing' ? true : fs === 'downloaded' ? false : undefined,
+      cutoffUnmet: fs === 'cutoffUnmet' ? true : undefined,
+      onlyWatched: fw === 'watched' ? true : undefined,
+      excludeWatched: fw === 'unwatched' ? true : undefined,
+      limit: 0,
+    } as const;
+    const gen = ++this.loadGen;
     try {
-      const fs = this.filterStatus();
-      const fw = this.filterWatched();
       const [res, watchedIds] = await Promise.all([
-        this.mediaService.getAll({
-          libraryId,
-          q: this.searchQuery() || undefined,
-          sortBy: this.sortBy(),
-          sortOrder: this.sortOrder(),
-          genre: this.selectedGenre() || undefined,
-          collectionId: this.selectedCollectionId() ?? undefined,
-          monitored: monitored ? monitored === 'true' : undefined,
-          missing: fs === 'missing' ? true : fs === 'downloaded' ? false : undefined,
-          cutoffUnmet: fs === 'cutoffUnmet' ? true : undefined,
-          onlyWatched: fw === 'watched' ? true : undefined,
-          excludeWatched: fw === 'unwatched' ? true : undefined,
-          limit: 0,
-        }),
+        this.mediaService.getAll(params),
         this.streamingApi.getWatchedMediaIds().catch(() => [] as number[]),
       ]);
       this.list.setItems(res.data, (m) => m.title);
@@ -615,6 +620,21 @@ export class LibraryComponent implements OnInit, OnDestroy {
     } finally {
       if (!silent) this.loading.set(false);
     }
+    queueMicrotask(() => {
+      // Cached lists paint instantly; revalidate so a media imported / files
+      // landed / watched-toggled since the last visit shows up without
+      // waiting on the 5 min TTL. Generation check drops a stale background
+      // result when the user has already moved to another library.
+      if (gen !== this.loadGen) return;
+      void Promise.all([
+        this.mediaService.getAll(params, { force: true }).catch(() => null),
+        this.streamingApi.getWatchedMediaIds({ force: true }).catch(() => null),
+      ]).then(([res, watchedIds]) => {
+        if (gen !== this.loadGen) return;
+        if (res) this.list.setItems(res.data, (m) => m.title);
+        if (watchedIds) this.watchedIds.set(new Set(watchedIds));
+      });
+    });
   }
 
   /** Series always toggleable (bulk endpoint, no file needed). Movies need

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -679,6 +679,14 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
         return;
       }
       this.media.set(m);
+      queueMicrotask(() => {
+        void this.mediaService
+          .getOne(id, { force: true })
+          .then((fresh) => {
+            if (fresh.type === kind) this.media.set(fresh);
+          })
+          .catch(() => { /* network failure — cached body keeps showing */ });
+      });
 
       // Episode focus (series/:id/episode/:episodeId) is applied reactively
       // by episodeFocusEffect as soon as `media` is set, so no imperative

--- a/client/src/app/features/search/search.ts
+++ b/client/src/app/features/search/search.ts
@@ -210,14 +210,28 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
 
     // Search local library first
     this.state.localLoading.set(true);
+    const localParams = { q, type, limit: 20, sortBy: 'title' } as const;
     try {
-      const res = await this.mediaService.getAll({ q, type, limit: 20, sortBy: 'title' });
+      const res = await this.mediaService.getAll(localParams);
       this.state.localResults.set(res.data);
     } catch {
       this.state.localResults.set([]);
     } finally {
       this.state.localLoading.set(false);
     }
+    queueMicrotask(() => {
+      // Revalidate: cached result paints instantly, then catch up to fresh
+      // matches (a media imported since the last identical query lands here).
+      if (this.state.query().trim() !== q || this.state.filter() !== filter) return;
+      void this.mediaService
+        .getAll(localParams, { force: true })
+        .then((fresh) => {
+          if (this.state.query().trim() === q && this.state.filter() === filter) {
+            this.state.localResults.set(fresh.data);
+          }
+        })
+        .catch(() => { /* keep cached results */ });
+    });
 
     // Then search external providers (if enabled)
     if (!this.state.externalEnabled()) return;

--- a/client/src/app/features/watch-history/watch-history.ts
+++ b/client/src/app/features/watch-history/watch-history.ts
@@ -72,6 +72,15 @@ export class WatchHistoryComponent implements OnInit, OnDestroy {
       this.total.set(res.total);
     } catch { /* ignore */ }
     if (!silent) this.loading.set(false);
+    queueMicrotask(() => {
+      void this.streamingApi
+        .getHistory(this.currentPage(), this.pageSize, { force: true })
+        .then((fresh) => {
+          this.items.set(fresh.data);
+          this.total.set(fresh.total);
+        })
+        .catch(() => { /* keep cached body */ });
+    });
   }
 
   async goToPage(page: number) {


### PR DESCRIPTION
## Bug

On a media-detail page, after a state change on that media (a freshly-imported movie, a download landing on disk, a manual file add), refreshing the browser kept showing the pre-change body — Play button missing, library affordances stale — until the user opened a private window or waited out the cache.

## Cause

The HTTP cache interceptor serves \`/api/media/:id\` from IndexedDB with **TTL_DETAIL = 4 h** (\`cache.interceptor.ts\`). When the entry is still fresh the interceptor returns the cached body and \`subscriber.complete()\`s — no background revalidation. Private windows have no IDB so they always hit the network and looked fine.

## Fix

Mirror the home page's two-pass pattern (\`home.ts\` does \`loadAllSections()\` then \`queueMicrotask(() => loadAllSections({ force: true }))\`):

1. \`mediaService.getOne(id, opts?: { force?: boolean })\` — passing \`force: true\` sets the \`X-Cache-Bypass\` header so the cache interceptor goes to the network (the header is stripped before the request leaves).
2. \`media-detail.ts\` ngOnInit: the first \`getOne\` paints instantly from cache; a follow-up \`getOne(id, { force: true })\` in a microtask re-\`set()\`s the \`media\` signal once the fresh body arrives. UI rebinds without waiting on the 4 h TTL.

Cast / crew / resume info etc. don't need the same treatment — cast and crew change rarely (cached SWR is fine) and resume info isn't cached.

## Test plan

- [x] Client \`tsc\` clean
- [ ] Open a media-detail page, add files (or trigger any state change server-side), refresh — fresh state appears within a moment (not after 4 h, and without a private window)
- [ ] First paint still uses the cache — no extra network blocking the initial render