### PR TITLE
chore(layout): swap history and requests in the mobile menu

### DIFF
--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -159,10 +159,10 @@
              4 nav items distribute evenly across 5 columns. The FAB sits
              outside the dock to keep .dock's position:fixed intact. -->
         <span aria-hidden="true" class="invisible"></span>
-        <a routerLink="/history" routerLinkActive="dock-active" [routerLinkActiveOptions]="{ exact: false }"
+        <a routerLink="/requests" routerLinkActive="dock-active" [routerLinkActiveOptions]="{ exact: false }"
            (click)="resetNavHistory()">
-          <svg lucideHistory class="h-5 w-5"></svg>
-          <span class="dock-label truncate max-w-full">{{ 'nav.history' | translate }}</span>
+          <svg lucideClipboardList class="h-5 w-5"></svg>
+          <span class="dock-label truncate max-w-full">{{ 'nav.requests' | translate }}</span>
         </a>
         <button (click)="toggleBottomMenu()" [class.dock-active]="bottomMenuOpen()"
                 class="[&.dock-active]:before:hidden [&.dock-active]:after:hidden">
@@ -222,14 +222,9 @@
                 </a>
               </li>
               <li>
-                <a routerLink="/requests" routerLinkActive="active" class="justify-between" (click)="resetNavHistory()">
-                  <span class="flex items-center gap-2">
-                    <svg lucideClipboardList class="h-5 w-5"></svg>
-                    {{ 'nav.requests' | translate }}
-                  </span>
-                  @if (pendingRequestCount() > 0) {
-                    <span class="badge badge-sm badge-warning">{{ pendingRequestCount() }}</span>
-                  }
+                <a routerLink="/history" routerLinkActive="active" (click)="resetNavHistory()">
+                  <svg lucideHistory class="h-5 w-5"></svg>
+                  {{ 'nav.history' | translate }}
                 </a>
               </li>
               <li>


### PR DESCRIPTION
Promotes Requests to the mobile dock and demotes History to the bottom \"more\" menu — requests follow-up is a more frequent action than scrolling watch history on a phone. Desktop drawer is unchanged.