### PR TITLE
chore(requests): widen the row poster on mobile

### DIFF
--- a/client/src/app/features/requests/requests.html
+++ b/client/src/app/features/requests/requests.html
@@ -32,7 +32,7 @@
           [attr.title]="row.title"
         >
           <figure
-            class="relative w-20 sm:w-24 md:w-28 shrink-0 aspect-2/3 bg-base-300 overflow-hidden"
+            class="relative w-24 sm:w-24 md:w-28 shrink-0 aspect-2/3 bg-base-300 overflow-hidden"
           >
             @defer (on viewport) {
               <app-request-poster


### PR DESCRIPTION
Bumps the request-row thumbnail from \`w-20\` (80 px) to \`w-24\` (96 px) under sm. Tablet and desktop sizes are unchanged.