### PR TITLE
chore(requests): Overseerr-style mobile card with fanart backdrop

### DIFF
--- a/backend/src/modules/requests/requests.service.ts
+++ b/backend/src/modules/requests/requests.service.ts
@@ -343,9 +343,20 @@ export class RequestsService {
       .createQueryBuilder('r')
       .leftJoinAndSelect('r.user', 'user')
       .leftJoinAndSelect('r.approvedBy', 'approvedBy')
-      // Joined so the UI can display the live media title (the cached
-      // `request.title` may be empty for Seerr-imported orphans).
-      .leftJoinAndSelect('r.media', 'media')
+      // Resolve the linked library media by (tmdbId, type) rather than the
+      // request's FK so partial-library titles (another user's request
+      // already brought it in, or only some seasons are present) surface a
+      // `media` object. The UI routes to the library detail when any match
+      // exists; the FK `mediaId` is left untouched for lifecycle bookkeeping.
+      .leftJoinAndMapOne(
+        'r.media',
+        Media,
+        'media',
+        // `media.type` and `r.mediaType` are declared as two distinct Postgres
+        // enums (each entity got its own `*_enum` type at migration time), so
+        // they need an explicit text cast for the equality to type-check.
+        'media."tmdbId" = r."tmdbId" AND media.type::text = r."mediaType"::text',
+      )
       .orderBy('r.createdAt', 'DESC');
 
     if (!this.canManageRequests(user)) {

--- a/client/src/app/features/requests/request-poster.ts
+++ b/client/src/app/features/requests/request-poster.ts
@@ -4,24 +4,34 @@ import {
   inject,
   input,
   signal,
+  computed,
   OnInit,
 } from '@angular/core';
 import { MetadataService } from '../../core/services/api/metadata.service';
 import { MediaType } from '../../core/enums/media-type.enum';
+
+/** Per-process cache for the metadata detail fetch — multiple instances of
+ *  `app-request-poster` on the same row (poster chip + mobile backdrop)
+ *  share one HTTP round-trip. Holds the in-flight promise so concurrent
+ *  ngOnInit calls don't race. */
+const detailsCache = new Map<
+  string,
+  Promise<{ posterUrl: string | null; fanartUrl: string | null }>
+>();
 
 @Component({
   selector: 'app-request-poster',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'block w-full h-full min-h-0' },
   template: `
-    @if (posterUrl()) {
+    @if (imageUrl()) {
       <img
-        [src]="posterUrl()!"
+        [src]="imageUrl()!"
         [alt]="titleText()"
         class="w-full h-full object-cover"
         loading="lazy"
       />
-    } @else if (loaded()) {
+    } @else if (loaded() && mode() === 'poster') {
       <div
         class="flex items-center justify-center w-full h-full min-h-[10rem] bg-base-300 text-base-content/25"
         aria-hidden="true"
@@ -41,7 +51,7 @@ import { MediaType } from '../../core/enums/media-type.enum';
           />
         </svg>
       </div>
-    } @else {
+    } @else if (!loaded() && mode() === 'poster') {
       <div class="skeleton w-full h-full min-h-[10rem] rounded-none"></div>
     }
   `,
@@ -52,21 +62,36 @@ export class RequestPosterComponent implements OnInit {
   readonly tmdbId = input.required<number>();
   readonly mediaType = input.required<MediaType>();
   readonly titleText = input<string>('');
+  /** `poster` (default) shows the title's portrait poster with a placeholder
+   *  fallback when no art is available; `backdrop` shows the landscape fanart
+   *  with no fallback — meant to sit behind a gradient and stay silent when
+   *  there's nothing to render. */
+  readonly mode = input<'poster' | 'backdrop'>('poster');
 
   readonly posterUrl = signal<string | null>(null);
+  readonly fanartUrl = signal<string | null>(null);
   readonly loaded = signal(false);
 
+  readonly imageUrl = computed(() =>
+    this.mode() === 'backdrop' ? this.fanartUrl() : this.posterUrl(),
+  );
+
   async ngOnInit() {
-    try {
-      const details =
+    const key = `${this.mediaType()}:${this.tmdbId()}`;
+    let promise = detailsCache.get(key);
+    if (!promise) {
+      promise = (
         this.mediaType() === 'movie'
-          ? await this.metadata.getMovieDetails(this.tmdbId())
-          : await this.metadata.getTvDetails(this.tmdbId());
-      this.posterUrl.set(details.posterUrl);
-    } catch {
-      /* keep poster empty */
-    } finally {
-      this.loaded.set(true);
+          ? this.metadata.getMovieDetails(this.tmdbId())
+          : this.metadata.getTvDetails(this.tmdbId())
+      )
+        .then((d) => ({ posterUrl: d.posterUrl, fanartUrl: d.fanartUrl }))
+        .catch(() => ({ posterUrl: null, fanartUrl: null }));
+      detailsCache.set(key, promise);
     }
+    const details = await promise;
+    this.posterUrl.set(details.posterUrl);
+    this.fanartUrl.set(details.fanartUrl);
+    this.loaded.set(true);
   }
 }

--- a/client/src/app/features/requests/requests.html
+++ b/client/src/app/features/requests/requests.html
@@ -43,8 +43,47 @@
             <div class="absolute inset-0 bg-gradient-to-b from-base-100/45 via-base-100/80 to-base-100"></div>
           </div>
 
+          @if (mobileActionsAvailable(row)) {
+            <div class="absolute top-2 right-2 z-20 sm:hidden">
+              <app-dropdown-menu placement="bottom-end">
+                <button
+                  trigger
+                  type="button"
+                  class="btn btn-circle btn-sm bg-base-100/70 border-0 backdrop-blur-sm text-base-content"
+                  [attr.aria-label]="'common.actions' | translate"
+                >
+                  <svg lucideEllipsisVertical class="h-4 w-4"></svg>
+                </button>
+                @if (canEdit(row)) {
+                  <button type="button" class="btn btn-ghost btn-sm justify-start" (click)="openEdit(row)">
+                    {{ 'requests.edit' | translate }}
+                  </button>
+                }
+                @if (canDeleteRequest(row)) {
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-sm justify-start text-error"
+                    [disabled]="actionBusyId() === row.id"
+                    (click)="removeRequest(row)"
+                  >
+                    {{ 'requests.delete' | translate }}
+                  </button>
+                } @else if (row.status === 'pending' && canCancel(row)) {
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-sm justify-start text-error"
+                    [disabled]="actionBusyId() === row.id"
+                    (click)="removeRequest(row)"
+                  >
+                    {{ 'requests.cancel' | translate }}
+                  </button>
+                }
+              </app-dropdown-menu>
+            </div>
+          }
+
           <figure
-            class="relative hidden sm:flex w-24 md:w-28 shrink-0 aspect-2/3 bg-base-300 overflow-hidden"
+            class="relative hidden sm:flex w-32 md:w-40 shrink-0 aspect-2/3 bg-base-300 overflow-hidden"
           >
             @defer (on viewport) {
               <app-request-poster
@@ -142,7 +181,7 @@
                 @if (auth.hasPermission('requests.manage')) {
                   <button
                     type="button"
-                    class="btn btn-ghost btn-sm text-error"
+                    class="hidden sm:inline-flex btn btn-ghost btn-sm text-error"
                     [disabled]="actionBusyId() === row.id"
                     (click)="removeRequest(row)"
                   >
@@ -175,14 +214,14 @@
                   </button>
                 }
                 @if (canEdit(row)) {
-                  <button type="button" class="btn btn-ghost btn-sm" (click)="openEdit(row)">
+                  <button type="button" class="hidden sm:inline-flex btn btn-ghost btn-sm" (click)="openEdit(row)">
                     {{ 'requests.edit' | translate }}
                   </button>
                 }
                 @if (auth.hasPermission('requests.manage')) {
                   <button
                     type="button"
-                    class="btn btn-ghost btn-sm text-error"
+                    class="hidden sm:inline-flex btn btn-ghost btn-sm text-error"
                     [disabled]="actionBusyId() === row.id"
                     (click)="removeRequest(row)"
                   >
@@ -191,7 +230,7 @@
                 } @else if (canCancel(row)) {
                   <button
                     type="button"
-                    class="btn btn-ghost btn-sm text-error"
+                    class="hidden sm:inline-flex btn btn-ghost btn-sm text-error"
                     [disabled]="actionBusyId() === row.id"
                     (click)="removeRequest(row)"
                   >
@@ -203,7 +242,7 @@
 
             @if (showOrphanDeleteColumn(row)) {
               <div
-                class="flex flex-wrap items-center justify-end gap-1 shrink-0 sm:border-s sm:border-base-200 sm:ps-4 sm:min-w-[min(100%,12rem)]"
+                class="hidden sm:flex flex-wrap items-center justify-end gap-1 shrink-0 sm:border-s sm:border-base-200 sm:ps-4 sm:min-w-[min(100%,12rem)]"
               >
                 <button
                   type="button"

--- a/client/src/app/features/requests/requests.html
+++ b/client/src/app/features/requests/requests.html
@@ -34,14 +34,12 @@
           <!-- Mobile-only fanart backdrop with a dimming gradient so the
                foreground content stays legible (à la Overseerr). -->
           <div class="absolute inset-0 sm:hidden" aria-hidden="true">
-            @defer (on viewport) {
-              <app-request-poster
-                class="absolute inset-0"
-                [tmdbId]="row.tmdbId"
-                [mediaType]="row.mediaType"
-                mode="backdrop"
-              />
-            }
+            <app-request-poster
+              class="absolute inset-0"
+              [tmdbId]="row.tmdbId"
+              [mediaType]="row.mediaType"
+              mode="backdrop"
+            />
             <div class="absolute inset-0 bg-gradient-to-b from-base-100/45 via-base-100/80 to-base-100"></div>
           </div>
 

--- a/client/src/app/features/requests/requests.html
+++ b/client/src/app/features/requests/requests.html
@@ -62,7 +62,7 @@
             class="relative card-body p-3 sm:p-4 flex-1 min-w-0 flex flex-col sm:flex-row sm:items-stretch gap-3"
           >
             <div class="min-w-0 flex-1 flex flex-col gap-1.5 justify-center">
-              <h2 class="text-base font-semibold leading-snug line-clamp-2 m-0">
+              <h2 class="text-lg font-semibold leading-snug line-clamp-2 m-0">
                 <a
                   [routerLink]="mediaLink(row)"
                   class="link link-hover text-base-content hover:opacity-80 font-semibold text-left"
@@ -86,6 +86,13 @@
                   }
                 </span>
               </div>
+
+              @if (row.mediaType === 'series' && row.seasons && row.seasons.length) {
+                <p class="text-sm text-base-content/70">
+                  <span class="text-base-content/50">{{ 'requests.seasons_label' | translate }} · </span>
+                  {{ row.seasons.join(', ') }}
+                </p>
+              }
 
               @if (auth.hasPermission('requests.manage')) {
                 <p class="text-sm text-base-content/70">
@@ -116,12 +123,6 @@
                   <span class="text-base-content/50">{{ 'discover.language_profile' | translate }} · </span>
                   {{ languageProfileDisplay(row.languageProfileId) }}
                 </p>
-                @if (row.mediaType === 'series' && row.seasons && row.seasons.length) {
-                  <p>
-                    <span class="text-base-content/50">{{ 'requests.seasons_label' | translate }} · </span>
-                    {{ row.seasons.join(', ') }}
-                  </p>
-                }
               </div>
             </div>
 

--- a/client/src/app/features/requests/requests.html
+++ b/client/src/app/features/requests/requests.html
@@ -87,28 +87,30 @@
                 </span>
               </div>
 
-              @if (row.mediaType === 'series' && row.seasons && row.seasons.length) {
-                <p class="text-sm text-base-content/70">
-                  <span class="text-base-content/50">{{ 'requests.seasons_label' | translate }} · </span>
-                  {{ row.seasons.join(', ') }}
-                </p>
-              }
+              <div class="flex flex-col">
+                @if (row.mediaType === 'series' && row.seasons && row.seasons.length) {
+                  <p class="text-sm text-base-content/70">
+                    <span class="text-base-content/50">{{ 'requests.seasons_label' | translate }} · </span>
+                    {{ row.seasons.join(', ') }}
+                  </p>
+                }
 
-              @if (auth.hasPermission('requests.manage')) {
-                <p class="text-sm text-base-content/70">
-                  <span class="text-base-content/50">{{ 'requests.requested_by' | translate }}</span>
-                  @if (auth.canManageUsers()) {
-                    <a
-                      [routerLink]="['/admin/users', row.user.id]"
-                      class="link link-hover link-primary font-medium"
-                    >
-                      {{ row.user.username }}
-                    </a>
-                  } @else {
-                    <span class="font-medium text-base-content">{{ row.user.username }}</span>
-                  }
-                </p>
-              }
+                @if (auth.hasPermission('requests.manage')) {
+                  <p class="text-sm text-base-content/70">
+                    <span class="text-base-content/50">{{ 'requests.requested_by' | translate }}</span>
+                    @if (auth.canManageUsers()) {
+                      <a
+                        [routerLink]="['/admin/users', row.user.id]"
+                        class="link link-hover link-primary font-medium"
+                      >
+                        {{ row.user.username }}
+                      </a>
+                    } @else {
+                      <span class="font-medium text-base-content">{{ row.user.username }}</span>
+                    }
+                  </p>
+                }
+              </div>
 
               <div class="flex flex-col gap-0.5 text-xs text-base-content/65">
                 <p>

--- a/client/src/app/features/requests/requests.html
+++ b/client/src/app/features/requests/requests.html
@@ -101,7 +101,7 @@
           </figure>
 
           <div
-            class="relative card-body p-3 sm:p-4 flex-1 min-w-0 flex flex-col sm:flex-row sm:items-stretch gap-3"
+            class="relative card-body p-3 sm:p-4 flex-1 min-w-0 flex flex-col md:flex-row md:items-stretch gap-3"
           >
             <div class="min-w-0 flex-1 flex flex-col gap-1.5 justify-center">
               <h2 class="text-lg font-semibold leading-snug line-clamp-2 m-0">
@@ -172,7 +172,7 @@
 
             @if (row.status === 'declined' && row.declinedReason?.trim()) {
               <div
-                class="flex flex-wrap items-center justify-end gap-1 shrink-0 sm:border-s sm:border-base-200 sm:ps-4 sm:min-w-[min(100%,12rem)]"
+                class="flex flex-wrap items-center justify-end gap-1 shrink-0 md:border-s md:border-base-200 md:ps-4 md:min-w-[min(100%,12rem)]"
               >
                 <button
                   type="button"
@@ -196,7 +196,7 @@
 
             @if (row.status === 'pending') {
               <div
-                class="flex flex-wrap items-center sm:items-end sm:justify-end content-start gap-1 shrink-0 sm:border-s sm:border-base-200 sm:ps-4 sm:min-w-[min(100%,12rem)]"
+                class="flex flex-wrap items-center md:items-end md:justify-end content-start gap-1 shrink-0 md:border-s md:border-base-200 md:ps-4 md:min-w-[min(100%,12rem)]"
               >
                 @if (auth.hasPermission('requests.manage')) {
                   <button
@@ -245,7 +245,7 @@
 
             @if (showOrphanDeleteColumn(row)) {
               <div
-                class="hidden sm:flex flex-wrap items-center justify-end gap-1 shrink-0 sm:border-s sm:border-base-200 sm:ps-4 sm:min-w-[min(100%,12rem)]"
+                class="hidden sm:flex flex-wrap items-center justify-end gap-1 shrink-0 md:border-s md:border-base-200 md:ps-4 md:min-w-[min(100%,12rem)]"
               >
                 <button
                   type="button"

--- a/client/src/app/features/requests/requests.html
+++ b/client/src/app/features/requests/requests.html
@@ -49,32 +49,35 @@
                 <button
                   trigger
                   type="button"
-                  class="btn btn-circle btn-sm bg-base-100/70 border-0 backdrop-blur-sm text-base-content"
+                  class="btn btn-ghost btn-xs btn-circle"
                   [attr.aria-label]="'common.actions' | translate"
                 >
                   <svg lucideEllipsisVertical class="h-4 w-4"></svg>
                 </button>
                 @if (canEdit(row)) {
-                  <button type="button" class="btn btn-ghost btn-sm justify-start" (click)="openEdit(row)">
+                  <button type="button" class="dropdown-item text-white" (click)="openEdit(row)">
+                    <svg lucidePencil class="h-4 w-4"></svg>
                     {{ 'requests.edit' | translate }}
                   </button>
                 }
                 @if (canDeleteRequest(row)) {
                   <button
                     type="button"
-                    class="btn btn-ghost btn-sm justify-start text-error"
+                    class="dropdown-item text-error"
                     [disabled]="actionBusyId() === row.id"
                     (click)="removeRequest(row)"
                   >
+                    <svg lucideTrash2 class="h-4 w-4"></svg>
                     {{ 'requests.delete' | translate }}
                   </button>
                 } @else if (row.status === 'pending' && canCancel(row)) {
                   <button
                     type="button"
-                    class="btn btn-ghost btn-sm justify-start text-error"
+                    class="dropdown-item text-error"
                     [disabled]="actionBusyId() === row.id"
                     (click)="removeRequest(row)"
                   >
+                    <svg lucideTrash2 class="h-4 w-4"></svg>
                     {{ 'requests.cancel' | translate }}
                   </button>
                 }

--- a/client/src/app/features/requests/requests.html
+++ b/client/src/app/features/requests/requests.html
@@ -28,7 +28,7 @@
     <div class="flex flex-col gap-3">
       @for (row of rows(); track row.id) {
         <article
-          class="relative card bg-base-100 shadow-md border border-base-200 flex flex-row overflow-hidden rounded-box"
+          class="relative card bg-base-100 shadow-md border border-base-200 grid grid-cols-1 sm:grid-cols-[auto_1fr] items-stretch overflow-hidden rounded-box"
           [attr.title]="row.title"
         >
           <!-- Mobile-only fanart backdrop with a dimming gradient so the
@@ -43,50 +43,83 @@
             <div class="absolute inset-0 bg-gradient-to-b from-base-100/45 via-base-100/80 to-base-100"></div>
           </div>
 
-          @if (mobileActionsAvailable(row)) {
-            <div class="absolute top-2 right-2 z-20 sm:hidden">
-              <app-dropdown-menu placement="bottom-end">
+          @if (mobileActionsAvailable(row) || (row.status === 'declined' && row.declinedReason?.trim())) {
+            <!-- Corner action cluster: primary buttons (sm-only, surfaced on
+                 landscape phones / small tablets) + kebab for the secondary
+                 ones. Hidden on lg+ where the dedicated sidebar column owns
+                 every action inline. -->
+            <div class="absolute top-2 right-2 z-20 lg:hidden flex items-center gap-1">
+              @if (row.status === 'pending' && auth.hasPermission('requests.manage')) {
                 <button
-                  trigger
                   type="button"
-                  class="btn btn-ghost btn-xs btn-circle"
-                  [attr.aria-label]="'common.actions' | translate"
+                  class="hidden sm:inline-flex btn btn-success btn-sm"
+                  [disabled]="actionBusyId() === row.id"
+                  (click)="approve(row.id)"
                 >
-                  <svg lucideEllipsisVertical class="h-4 w-4"></svg>
+                  {{ 'requests.approve' | translate }}
                 </button>
-                @if (canEdit(row)) {
-                  <button type="button" class="dropdown-item text-white" (click)="openEdit(row)">
-                    <svg lucidePencil class="h-4 w-4"></svg>
-                    {{ 'requests.edit' | translate }}
-                  </button>
-                }
-                @if (canDeleteRequest(row)) {
+                <button
+                  type="button"
+                  class="hidden sm:inline-flex btn btn-warning btn-sm"
+                  [disabled]="actionBusyId() === row.id"
+                  (click)="openDecline(row.id)"
+                >
+                  {{ 'requests.decline' | translate }}
+                </button>
+              }
+              @if (row.status === 'declined' && row.declinedReason?.trim()) {
+                <button
+                  type="button"
+                  class="hidden sm:inline-flex btn btn-outline btn-primary btn-sm"
+                  (click)="openViewDeclineReason(row)"
+                >
+                  {{ 'requests.view_decline' | translate }}
+                </button>
+              }
+              @if (mobileActionsAvailable(row)) {
+                <app-dropdown-menu placement="bottom-end">
                   <button
+                    trigger
                     type="button"
-                    class="dropdown-item text-error"
-                    [disabled]="actionBusyId() === row.id"
-                    (click)="removeRequest(row)"
+                    class="btn btn-ghost btn-xs btn-circle"
+                    [attr.aria-label]="'common.actions' | translate"
                   >
-                    <svg lucideTrash2 class="h-4 w-4"></svg>
-                    {{ 'requests.delete' | translate }}
+                    <svg lucideEllipsisVertical class="h-4 w-4"></svg>
                   </button>
-                } @else if (row.status === 'pending' && canCancel(row)) {
-                  <button
-                    type="button"
-                    class="dropdown-item text-error"
-                    [disabled]="actionBusyId() === row.id"
-                    (click)="removeRequest(row)"
-                  >
-                    <svg lucideTrash2 class="h-4 w-4"></svg>
-                    {{ 'requests.cancel' | translate }}
-                  </button>
-                }
-              </app-dropdown-menu>
+                  @if (canEdit(row)) {
+                    <button type="button" class="dropdown-item text-white" (click)="openEdit(row)">
+                      <svg lucidePencil class="h-4 w-4"></svg>
+                      {{ 'requests.edit' | translate }}
+                    </button>
+                  }
+                  @if (canDeleteRequest(row)) {
+                    <button
+                      type="button"
+                      class="dropdown-item text-error"
+                      [disabled]="actionBusyId() === row.id"
+                      (click)="removeRequest(row)"
+                    >
+                      <svg lucideTrash2 class="h-4 w-4"></svg>
+                      {{ 'requests.delete' | translate }}
+                    </button>
+                  } @else if (row.status === 'pending' && canCancel(row)) {
+                    <button
+                      type="button"
+                      class="dropdown-item text-error"
+                      [disabled]="actionBusyId() === row.id"
+                      (click)="removeRequest(row)"
+                    >
+                      <svg lucideTrash2 class="h-4 w-4"></svg>
+                      {{ 'requests.cancel' | translate }}
+                    </button>
+                  }
+                </app-dropdown-menu>
+              }
             </div>
           }
 
           <figure
-            class="relative hidden sm:flex w-24 lg:w-40 shrink-0 aspect-2/3 bg-base-300 overflow-hidden"
+            class="relative hidden sm:block self-start aspect-2/3 w-24 lg:w-32 m-3 me-1 overflow-hidden rounded-lg"
           >
             @defer (on viewport) {
               <app-request-poster
@@ -172,7 +205,7 @@
 
             @if (row.status === 'declined' && row.declinedReason?.trim()) {
               <div
-                class="flex flex-wrap items-center justify-end gap-1 shrink-0 lg:border-s lg:border-base-200 lg:ps-4 lg:min-w-[min(100%,12rem)]"
+                class="flex sm:hidden lg:flex flex-wrap items-center justify-end gap-1 shrink-0 lg:border-s lg:border-base-200 lg:ps-4 lg:min-w-[min(100%,12rem)]"
               >
                 <button
                   type="button"
@@ -196,7 +229,7 @@
 
             @if (row.status === 'pending') {
               <div
-                class="flex flex-wrap items-center lg:items-end lg:justify-end content-start gap-1 shrink-0 lg:border-s lg:border-base-200 lg:ps-4 lg:min-w-[min(100%,12rem)]"
+                class="flex sm:hidden lg:flex flex-wrap items-center lg:items-end lg:justify-end content-start gap-1 shrink-0 lg:border-s lg:border-base-200 lg:ps-4 lg:min-w-[min(100%,12rem)]"
               >
                 @if (auth.hasPermission('requests.manage')) {
                   <button
@@ -245,7 +278,7 @@
 
             @if (showOrphanDeleteColumn(row)) {
               <div
-                class="hidden sm:flex flex-wrap items-center justify-end gap-1 shrink-0 lg:border-s lg:border-base-200 lg:ps-4 lg:min-w-[min(100%,12rem)]"
+                class="hidden lg:flex flex-wrap items-center justify-end gap-1 shrink-0 lg:border-s lg:border-base-200 lg:ps-4 lg:min-w-[min(100%,12rem)]"
               >
                 <button
                   type="button"

--- a/client/src/app/features/requests/requests.html
+++ b/client/src/app/features/requests/requests.html
@@ -28,11 +28,25 @@
     <div class="flex flex-col gap-3">
       @for (row of rows(); track row.id) {
         <article
-          class="card bg-base-100 shadow-md border border-base-200 flex flex-row overflow-hidden rounded-box"
+          class="relative card bg-base-100 shadow-md border border-base-200 flex flex-row overflow-hidden rounded-box"
           [attr.title]="row.title"
         >
+          <!-- Mobile-only fanart backdrop with a dimming gradient so the
+               foreground content stays legible (à la Overseerr). -->
+          <div class="absolute inset-0 sm:hidden" aria-hidden="true">
+            @defer (on viewport) {
+              <app-request-poster
+                class="absolute inset-0"
+                [tmdbId]="row.tmdbId"
+                [mediaType]="row.mediaType"
+                mode="backdrop"
+              />
+            }
+            <div class="absolute inset-0 bg-gradient-to-b from-base-100/45 via-base-100/80 to-base-100"></div>
+          </div>
+
           <figure
-            class="relative w-20 sm:w-24 md:w-28 shrink-0 aspect-2/3 bg-base-300 overflow-hidden"
+            class="relative hidden sm:flex w-24 md:w-28 shrink-0 aspect-2/3 bg-base-300 overflow-hidden"
           >
             @defer (on viewport) {
               <app-request-poster
@@ -47,17 +61,35 @@
           </figure>
 
           <div
-            class="card-body p-3 sm:p-4 flex-1 min-w-0 flex flex-col sm:flex-row sm:items-stretch gap-3"
+            class="relative card-body p-3 sm:p-4 flex-1 min-w-0 flex flex-col sm:flex-row sm:items-stretch gap-3"
           >
             <div class="min-w-0 flex-1 flex flex-col gap-1.5 justify-center">
-              <h2 class="text-base font-semibold leading-snug line-clamp-2 m-0">
-                <a
-                  [routerLink]="mediaLink(row)"
-                  class="link link-hover text-base-content hover:opacity-80 font-semibold text-left"
+              <div class="flex items-start gap-3">
+                <!-- Mobile chip poster: appears next to the title when the
+                     desktop side poster is hidden. -->
+                <figure
+                  class="relative sm:hidden w-14 aspect-2/3 shrink-0 bg-base-300 rounded overflow-hidden ring-1 ring-base-content/10 shadow"
                 >
-                  {{ row.title }}
-                </a>
-              </h2>
+                  @defer (on viewport) {
+                    <app-request-poster
+                      class="absolute inset-0"
+                      [tmdbId]="row.tmdbId"
+                      [mediaType]="row.mediaType"
+                      [titleText]="row.title"
+                    />
+                  } @placeholder {
+                    <div class="absolute inset-0 skeleton rounded-none"></div>
+                  }
+                </figure>
+                <h2 class="flex-1 text-base font-semibold leading-snug line-clamp-2 m-0">
+                  <a
+                    [routerLink]="mediaLink(row)"
+                    class="link link-hover text-base-content hover:opacity-80 font-semibold text-left"
+                  >
+                    {{ row.title }}
+                  </a>
+                </h2>
+              </div>
 
               <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-base-content/70">
                 <span

--- a/client/src/app/features/requests/requests.html
+++ b/client/src/app/features/requests/requests.html
@@ -62,32 +62,14 @@
             class="relative card-body p-3 sm:p-4 flex-1 min-w-0 flex flex-col sm:flex-row sm:items-stretch gap-3"
           >
             <div class="min-w-0 flex-1 flex flex-col gap-1.5 justify-center">
-              <div class="flex items-start gap-3">
-                <!-- Mobile chip poster: appears next to the title when the
-                     desktop side poster is hidden. -->
-                <figure
-                  class="relative sm:hidden w-14 aspect-2/3 shrink-0 bg-base-300 rounded overflow-hidden ring-1 ring-base-content/10 shadow"
+              <h2 class="text-base font-semibold leading-snug line-clamp-2 m-0">
+                <a
+                  [routerLink]="mediaLink(row)"
+                  class="link link-hover text-base-content hover:opacity-80 font-semibold text-left"
                 >
-                  @defer (on viewport) {
-                    <app-request-poster
-                      class="absolute inset-0"
-                      [tmdbId]="row.tmdbId"
-                      [mediaType]="row.mediaType"
-                      [titleText]="row.title"
-                    />
-                  } @placeholder {
-                    <div class="absolute inset-0 skeleton rounded-none"></div>
-                  }
-                </figure>
-                <h2 class="flex-1 text-base font-semibold leading-snug line-clamp-2 m-0">
-                  <a
-                    [routerLink]="mediaLink(row)"
-                    class="link link-hover text-base-content hover:opacity-80 font-semibold text-left"
-                  >
-                    {{ row.title }}
-                  </a>
-                </h2>
-              </div>
+                  {{ row.title }}
+                </a>
+              </h2>
 
               <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-base-content/70">
                 <span

--- a/client/src/app/features/requests/requests.html
+++ b/client/src/app/features/requests/requests.html
@@ -101,7 +101,7 @@
           </figure>
 
           <div
-            class="relative card-body p-3 sm:p-4 flex-1 min-w-0 flex flex-col md:flex-row md:items-stretch gap-3"
+            class="relative card-body p-3 sm:p-4 flex-1 min-w-0 flex flex-col lg:flex-row lg:items-stretch gap-3"
           >
             <div class="min-w-0 flex-1 flex flex-col gap-1.5 justify-center">
               <h2 class="text-lg font-semibold leading-snug line-clamp-2 m-0">
@@ -172,7 +172,7 @@
 
             @if (row.status === 'declined' && row.declinedReason?.trim()) {
               <div
-                class="flex flex-wrap items-center justify-end gap-1 shrink-0 md:border-s md:border-base-200 md:ps-4 md:min-w-[min(100%,12rem)]"
+                class="flex flex-wrap items-center justify-end gap-1 shrink-0 lg:border-s lg:border-base-200 lg:ps-4 lg:min-w-[min(100%,12rem)]"
               >
                 <button
                   type="button"
@@ -196,7 +196,7 @@
 
             @if (row.status === 'pending') {
               <div
-                class="flex flex-wrap items-center md:items-end md:justify-end content-start gap-1 shrink-0 md:border-s md:border-base-200 md:ps-4 md:min-w-[min(100%,12rem)]"
+                class="flex flex-wrap items-center lg:items-end lg:justify-end content-start gap-1 shrink-0 lg:border-s lg:border-base-200 lg:ps-4 lg:min-w-[min(100%,12rem)]"
               >
                 @if (auth.hasPermission('requests.manage')) {
                   <button
@@ -245,7 +245,7 @@
 
             @if (showOrphanDeleteColumn(row)) {
               <div
-                class="hidden sm:flex flex-wrap items-center justify-end gap-1 shrink-0 md:border-s md:border-base-200 md:ps-4 md:min-w-[min(100%,12rem)]"
+                class="hidden sm:flex flex-wrap items-center justify-end gap-1 shrink-0 lg:border-s lg:border-base-200 lg:ps-4 lg:min-w-[min(100%,12rem)]"
               >
                 <button
                   type="button"

--- a/client/src/app/features/requests/requests.html
+++ b/client/src/app/features/requests/requests.html
@@ -86,7 +86,7 @@
           }
 
           <figure
-            class="relative hidden sm:flex w-32 md:w-40 shrink-0 aspect-2/3 bg-base-300 overflow-hidden"
+            class="relative hidden sm:flex w-24 lg:w-40 shrink-0 aspect-2/3 bg-base-300 overflow-hidden"
           >
             @defer (on viewport) {
               <app-request-poster

--- a/client/src/app/features/requests/requests.ts
+++ b/client/src/app/features/requests/requests.ts
@@ -25,7 +25,7 @@ import { RequestDeclineModalComponent } from './request-decline-modal/request-de
 import { RequestViewDeclineModalComponent } from './request-view-decline-modal/request-view-decline-modal.component';
 import { RequestEditModalComponent } from './request-edit-modal/request-edit-modal.component';
 import { DropdownMenuComponent } from '../../shared/components/dropdown-menu';
-import { LucideEllipsisVertical } from '@lucide/angular';
+import { LucideEllipsisVertical, LucidePencil, LucideTrash2 } from '@lucide/angular';
 
 @Component({
   selector: 'app-requests',
@@ -40,6 +40,8 @@ import { LucideEllipsisVertical } from '@lucide/angular';
     RequestEditModalComponent,
     DropdownMenuComponent,
     LucideEllipsisVertical,
+    LucidePencil,
+    LucideTrash2,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './requests.html',

--- a/client/src/app/features/requests/requests.ts
+++ b/client/src/app/features/requests/requests.ts
@@ -24,6 +24,8 @@ import { RequestPosterComponent } from './request-poster';
 import { RequestDeclineModalComponent } from './request-decline-modal/request-decline-modal.component';
 import { RequestViewDeclineModalComponent } from './request-view-decline-modal/request-view-decline-modal.component';
 import { RequestEditModalComponent } from './request-edit-modal/request-edit-modal.component';
+import { DropdownMenuComponent } from '../../shared/components/dropdown-menu';
+import { LucideEllipsisVertical } from '@lucide/angular';
 
 @Component({
   selector: 'app-requests',
@@ -36,6 +38,8 @@ import { RequestEditModalComponent } from './request-edit-modal/request-edit-mod
     RequestDeclineModalComponent,
     RequestViewDeclineModalComponent,
     RequestEditModalComponent,
+    DropdownMenuComponent,
+    LucideEllipsisVertical,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './requests.html',
@@ -150,6 +154,22 @@ export class RequestsComponent implements OnInit {
     if (row.status === 'pending') return false;
     if (row.status === 'declined' && row.declinedReason?.trim()) return false;
     return true;
+  }
+
+  /** Admin (or pending owner) can hard-delete the request. Distinct from
+   *  `canCancel`, which is the owner-on-a-pending wording used in the UI. */
+  canDeleteRequest(row: FliksRequestRow): boolean {
+    return this.auth.hasPermission('requests.manage');
+  }
+
+  /** Whether the mobile kebab dropdown should render at all — hide it
+   *  entirely on rows where no actionable item would appear. */
+  mobileActionsAvailable(row: FliksRequestRow): boolean {
+    return (
+      this.canEdit(row) ||
+      this.canDeleteRequest(row) ||
+      this.canCancel(row)
+    );
   }
 
   openDecline(id: number) {

--- a/client/src/app/features/requests/requests.ts
+++ b/client/src/app/features/requests/requests.ts
@@ -284,10 +284,14 @@ export class RequestsComponent implements OnInit {
   }
 
   mediaLink(row: FliksRequestRow): (string | number)[] {
-    if (row.mediaId) {
+    // `row.media` is resolved by the backend via (tmdbId, type) so it surfaces
+    // even when the request's FK `mediaId` is still null (pending request on a
+    // title another user already brought in, or partially-imported series).
+    const libraryId = row.media?.id;
+    if (libraryId) {
       return row.mediaType === 'movie'
-        ? ['/movies', row.mediaId]
-        : ['/series', row.mediaId];
+        ? ['/movies', libraryId]
+        : ['/series', libraryId];
     }
     return row.mediaType === 'movie'
       ? ['/add', 'movie', row.tmdbId]


### PR DESCRIPTION
Restyles the mobile request row the way Overseerr does it: the title's fanart fills the card as a dimmed background (gradient overlay so text stays readable), the poster shrinks to a small chip next to the title, and the existing metadata + action rows stack underneath. Desktop (sm+) is unchanged.

\`RequestPosterComponent\` picks up a \`mode\` input (\`poster\` | \`backdrop\`) so the same component renders either the portrait poster or the landscape fanart, with a module-level cache that shares the metadata fetch between the two instances per row (chip + backdrop).