### PR TITLE
feat(streaming): profile-keyed cache, heartbeat-driven lifecycle, multi-profile coexistence

### DIFF
--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -36,6 +36,7 @@ import {
   TranscodingService,
 } from '../streaming/transcoding';
 import { ActiveStreamTracker } from '../streaming/active-stream-tracker.service';
+import { LiveSessionRegistry } from '../streaming/live-session.service';
 import { PlaybackService } from '../streaming/playback.service';
 import { MediaFile } from '../media/entities/media-file.entity';
 import { Episode } from '../media/entities/episode.entity';
@@ -146,6 +147,7 @@ export class SystemController {
     private readonly eventsService: EventsService,
     private readonly transcodingService: TranscodingService,
     private readonly activeStreamTracker: ActiveStreamTracker,
+    private readonly liveSessions: LiveSessionRegistry,
     private readonly playbackService: PlaybackService,
     @InjectRepository(MediaFile)
     private readonly mediaFileRepo: Repository<MediaFile>,
@@ -455,9 +457,16 @@ export class SystemController {
         mode: s.mode,
         quality: s.quality,
         hwAccel: s.hwAccelVal,
-        device: s.userId
-          ? this.activeStreamTracker.getDeviceName(s.userId, s.mediaFileId)
-          : null,
+        device:
+          this.liveSessions
+            .list()
+            .find(
+              (ls) =>
+                ls.userId === s.userId && ls.mediaFileId === s.mediaFileId,
+            )?.deviceLabel ??
+          (s.userId
+            ? this.activeStreamTracker.getDeviceName(s.userId, s.mediaFileId)
+            : null),
         startedAt: s.startedAt,
         lastActivity: s.lastActivity,
         positionSeconds,

--- a/backend/src/modules/streaming/live-session.service.spec.ts
+++ b/backend/src/modules/streaming/live-session.service.spec.ts
@@ -1,0 +1,118 @@
+import { LiveSessionRegistry } from './live-session.service';
+
+const BASE = {
+  userId: 1,
+  username: 'alice',
+  mediaFileId: 42,
+  profileHash: 'aaaaaaaaaa',
+  quality: '1080p',
+  kind: 'transcode' as const,
+};
+
+describe('LiveSessionRegistry', () => {
+  let svc: LiveSessionRegistry;
+
+  beforeEach(() => {
+    svc = new LiveSessionRegistry();
+    svc.onModuleInit();
+  });
+
+  afterEach(() => {
+    svc.onModuleDestroy();
+  });
+
+  it('issues a unique sessionId on create', () => {
+    const a = svc.create(BASE);
+    const b = svc.create(BASE);
+    expect(a.sessionId).not.toBe(b.sessionId);
+    expect(svc.size()).toBe(2);
+  });
+
+  it('returns null when heartbeating an unknown sessionId', () => {
+    expect(svc.heartbeat('missing', { position: 10 })).toBeNull();
+  });
+
+  it('refreshes lastBeat and merges payload on heartbeat', async () => {
+    const session = svc.create(BASE);
+    const initialBeat = session.lastBeat;
+    await new Promise((r) => setTimeout(r, 5));
+    const updated = svc.heartbeat(session.sessionId, {
+      position: 123,
+      state: 'paused',
+      audioTrackIndex: 2,
+    });
+    expect(updated).not.toBeNull();
+    expect(updated!.lastBeat).toBeGreaterThan(initialBeat);
+    expect(updated!.position).toBe(123);
+    expect(updated!.state).toBe('paused');
+    expect(updated!.audioTrackIndex).toBe(2);
+    // Unspecified fields stay put.
+    expect(updated!.subtitleTrackIndex).toBeNull();
+    expect(updated!.quality).toBe('1080p');
+  });
+
+  it('stop removes the session and returns true', () => {
+    const session = svc.create(BASE);
+    expect(svc.stop(session.sessionId)).toBe(true);
+    expect(svc.stop(session.sessionId)).toBe(false);
+    expect(svc.size()).toBe(0);
+  });
+
+  it('listForJob filters by (user, file, profile)', () => {
+    svc.create({ ...BASE, profileHash: 'aaa' });
+    svc.create({ ...BASE, profileHash: 'aaa' });
+    svc.create({ ...BASE, profileHash: 'bbb' });
+    svc.create({ ...BASE, mediaFileId: 99, profileHash: 'aaa' });
+    expect(svc.listForJob(1, 42, 'aaa')).toHaveLength(2);
+    expect(svc.listForJob(1, 42, 'bbb')).toHaveLength(1);
+    expect(svc.listForJob(1, 99, 'aaa')).toHaveLength(1);
+    expect(svc.listForJob(1, 99, 'bbb')).toHaveLength(0);
+  });
+
+  it('list returns Date-typed snapshots', () => {
+    const session = svc.create(BASE);
+    const snapshots = svc.list();
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0].sessionId).toBe(session.sessionId);
+    expect(snapshots[0].startedAt).toBeInstanceOf(Date);
+    expect(snapshots[0].lastBeat).toBeInstanceOf(Date);
+  });
+});
+
+describe('LiveSessionRegistry GC', () => {
+  const ENV = process.env;
+  let svc: LiveSessionRegistry;
+
+  beforeEach(() => {
+    process.env = { ...ENV };
+  });
+
+  afterEach(() => {
+    svc?.onModuleDestroy();
+    process.env = ENV;
+  });
+
+  it('drops sessions past the configured ttl on gc tick', async () => {
+    process.env.STREAM_LIVE_SESSION_TTL_MS = '50';
+    process.env.STREAM_LIVE_SESSION_GC_INTERVAL_MS = '20';
+    svc = new LiveSessionRegistry();
+    svc.onModuleInit();
+    svc.create(BASE);
+    expect(svc.size()).toBe(1);
+    await new Promise((r) => setTimeout(r, 100));
+    expect(svc.size()).toBe(0);
+  });
+
+  it('keeps sessions kept alive by heartbeats', async () => {
+    process.env.STREAM_LIVE_SESSION_TTL_MS = '80';
+    process.env.STREAM_LIVE_SESSION_GC_INTERVAL_MS = '30';
+    svc = new LiveSessionRegistry();
+    svc.onModuleInit();
+    const session = svc.create(BASE);
+    for (let i = 0; i < 4; i++) {
+      await new Promise((r) => setTimeout(r, 30));
+      svc.heartbeat(session.sessionId, { position: i });
+    }
+    expect(svc.size()).toBe(1);
+  });
+});

--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -1,0 +1,234 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+import { randomUUID } from 'crypto';
+
+export type PlaybackState = 'playing' | 'paused' | 'buffering';
+export type SessionKind = 'transcode' | 'remux' | 'directplay';
+
+/**
+ * Single live-session entry. The {@link sessionId} is the server-issued
+ * handle the client embeds in every heartbeat — distinct from the
+ * transcoding service's internal session key (`mediaFileId-uX`) so two
+ * devices on the same media-file can each carry their own
+ * {@link LiveSession} without colliding on the cache layer.
+ */
+export interface LiveSession {
+  sessionId: string;
+  userId: number | null;
+  username: string | null;
+  mediaFileId: number;
+  mediaTitle: string | null;
+  mediaType: string | null;
+  posterUrl: string | null;
+  profileHash: string | null;
+  quality: string | null;
+  kind: SessionKind;
+  deviceLabel: string | null;
+  startedAt: number;
+  lastBeat: number;
+  position: number;
+  state: PlaybackState;
+  audioTrackIndex: number | null;
+  subtitleTrackIndex: number | null;
+}
+
+/** Snapshot returned from {@link LiveSessionRegistry.list} — same shape
+ *  as {@link LiveSession} but with `Date` fields the admin DTO consumes. */
+export interface LiveSessionSnapshot extends Omit<
+  LiveSession,
+  'startedAt' | 'lastBeat'
+> {
+  startedAt: Date;
+  lastBeat: Date;
+}
+
+/** Defaults match the transcoding service's 30-min idle timeout. Phase 5
+ *  drops {@link LIVE_SESSION_TTL_MS} to 30 s once the heartbeat loop is
+ *  wired client-side. */
+const DEFAULT_TTL_MS = 30 * 60 * 1000;
+const DEFAULT_GC_INTERVAL_MS = 30_000;
+
+function readEnvInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * In-memory registry of "currently watching" sessions. One entry per
+ * sessionId emitted by `playback-info`. Refreshed by the heartbeat
+ * piggybacked on `PUT /api/playback/media/:id/state`; explicit stop
+ * via `DELETE /api/stream/sessions/:sessionId`. GC drops entries that
+ * haven't been beaten in {@link DEFAULT_TTL_MS}.
+ *
+ * Phase 3: passive — the registry is populated, refreshed, and exposed
+ * to the admin dashboard for enrichment, but no downstream lifecycle
+ * decision reads from it yet. Phase 4 starts gating the ffmpeg job
+ * grace window on `listForJob` cardinality.
+ */
+@Injectable()
+export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
+  private readonly log = new Logger(LiveSessionRegistry.name);
+  private readonly sessions = new Map<string, LiveSession>();
+  private gcTimer: ReturnType<typeof setInterval> | null = null;
+
+  private readonly ttlMs = readEnvInt(
+    'STREAM_LIVE_SESSION_TTL_MS',
+    DEFAULT_TTL_MS,
+  );
+  private readonly gcIntervalMs = readEnvInt(
+    'STREAM_LIVE_SESSION_GC_INTERVAL_MS',
+    DEFAULT_GC_INTERVAL_MS,
+  );
+
+  onModuleInit(): void {
+    this.gcTimer = setInterval(() => this.runGc(), this.gcIntervalMs);
+  }
+
+  onModuleDestroy(): void {
+    if (this.gcTimer) clearInterval(this.gcTimer);
+    this.sessions.clear();
+  }
+
+  /**
+   * Create a new live session and return its server-issued id. Called
+   * from the `playback-info` handler once the play method has been
+   * resolved.
+   */
+  create(input: {
+    userId: number | null;
+    username: string | null;
+    mediaFileId: number;
+    mediaTitle?: string | null;
+    mediaType?: string | null;
+    posterUrl?: string | null;
+    profileHash?: string | null;
+    quality?: string | null;
+    kind: SessionKind;
+    deviceLabel?: string | null;
+    position?: number;
+  }): LiveSession {
+    const now = Date.now();
+    const session: LiveSession = {
+      sessionId: randomUUID(),
+      userId: input.userId,
+      username: input.username,
+      mediaFileId: input.mediaFileId,
+      mediaTitle: input.mediaTitle ?? null,
+      mediaType: input.mediaType ?? null,
+      posterUrl: input.posterUrl ?? null,
+      profileHash: input.profileHash ?? null,
+      quality: input.quality ?? null,
+      kind: input.kind,
+      deviceLabel: input.deviceLabel ?? null,
+      startedAt: now,
+      lastBeat: now,
+      position: input.position ?? 0,
+      state: 'playing',
+      audioTrackIndex: null,
+      subtitleTrackIndex: null,
+    };
+    this.sessions.set(session.sessionId, session);
+    return session;
+  }
+
+  /**
+   * Refresh an existing session from a heartbeat payload. Returns the
+   * updated entry or `null` when the session is unknown / expired —
+   * caller can surface that to the client so it re-issues a fresh
+   * `playback-info` request.
+   */
+  heartbeat(
+    sessionId: string,
+    payload: {
+      position?: number;
+      state?: PlaybackState;
+      quality?: string | null;
+      audioTrackIndex?: number | null;
+      subtitleTrackIndex?: number | null;
+    },
+  ): LiveSession | null {
+    const session = this.sessions.get(sessionId);
+    if (!session) return null;
+    session.lastBeat = Date.now();
+    if (payload.position !== undefined) session.position = payload.position;
+    if (payload.state) session.state = payload.state;
+    if (payload.quality !== undefined) session.quality = payload.quality;
+    if (payload.audioTrackIndex !== undefined) {
+      session.audioTrackIndex = payload.audioTrackIndex;
+    }
+    if (payload.subtitleTrackIndex !== undefined) {
+      session.subtitleTrackIndex = payload.subtitleTrackIndex;
+    }
+    return session;
+  }
+
+  /** Drop a session explicitly. Returns whether the id was known. */
+  stop(sessionId: string): boolean {
+    return this.sessions.delete(sessionId);
+  }
+
+  /** Lookup by id without mutating lastBeat. */
+  get(sessionId: string): LiveSession | null {
+    return this.sessions.get(sessionId) ?? null;
+  }
+
+  /** Active sessions for the admin dashboard — `Date`-typed snapshots. */
+  list(): LiveSessionSnapshot[] {
+    return [...this.sessions.values()].map(toSnapshot);
+  }
+
+  /** Sessions matching a given (user, file, profile) triple — used to
+   *  decide whether an ffmpeg job still has any consumer. */
+  listForJob(
+    userId: number | null,
+    mediaFileId: number,
+    profileHash: string,
+  ): LiveSession[] {
+    const matches: LiveSession[] = [];
+    for (const s of this.sessions.values()) {
+      if (
+        s.userId === userId &&
+        s.mediaFileId === mediaFileId &&
+        s.profileHash === profileHash
+      ) {
+        matches.push(s);
+      }
+    }
+    return matches;
+  }
+
+  /** Visible for tests / metrics. */
+  size(): number {
+    return this.sessions.size;
+  }
+
+  private runGc(): void {
+    const cutoff = Date.now() - this.ttlMs;
+    const expired: string[] = [];
+    for (const [id, session] of this.sessions) {
+      if (session.lastBeat < cutoff) expired.push(id);
+    }
+    for (const id of expired) {
+      this.sessions.delete(id);
+    }
+    if (expired.length) {
+      this.log.log(
+        `gc: dropped ${expired.length} session(s) past ${Math.round(this.ttlMs / 1000)}s ttl`,
+      );
+    }
+  }
+}
+
+function toSnapshot(s: LiveSession): LiveSessionSnapshot {
+  return {
+    ...s,
+    startedAt: new Date(s.startedAt),
+    lastBeat: new Date(s.lastBeat),
+  };
+}

--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -46,9 +46,8 @@ export interface LiveSessionSnapshot extends Omit<
   lastBeat: Date;
 }
 
-/** Defaults match the transcoding service's 30-min idle timeout. Phase 5
- *  drops {@link LIVE_SESSION_TTL_MS} to 30 s once the heartbeat loop is
- *  wired client-side. */
+/** Session TTL matches the transcoding service's idle window — a live
+ *  session is considered dead after this long without a heartbeat. */
 const DEFAULT_TTL_MS = 30 * 60 * 1000;
 const DEFAULT_GC_INTERVAL_MS = 30_000;
 
@@ -66,10 +65,9 @@ function readEnvInt(name: string, fallback: number): number {
  * via `DELETE /api/stream/sessions/:sessionId`. GC drops entries that
  * haven't been beaten in {@link DEFAULT_TTL_MS}.
  *
- * Phase 3: passive — the registry is populated, refreshed, and exposed
- * to the admin dashboard for enrichment, but no downstream lifecycle
- * decision reads from it yet. Phase 4 starts gating the ffmpeg job
- * grace window on `listForJob` cardinality.
+ * Drives the admin "now watching" dashboard and the ffmpeg job grace
+ * window — `listForJob` reports whether a given encoder still has any
+ * live consumer.
  */
 @Injectable()
 export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {

--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -46,10 +46,12 @@ export interface LiveSessionSnapshot extends Omit<
   lastBeat: Date;
 }
 
-/** Session TTL matches the transcoding service's idle window — a live
- *  session is considered dead after this long without a heartbeat. */
-const DEFAULT_TTL_MS = 30 * 60 * 1000;
-const DEFAULT_GC_INTERVAL_MS = 30_000;
+/** A live session is considered dead this long after the last
+ *  heartbeat. 30 s = three missed beats at the client's 10 s cadence,
+ *  enough to absorb transient network hiccups without dragging the
+ *  ffmpeg keep-alive window. */
+const DEFAULT_TTL_MS = 30_000;
+const DEFAULT_GC_INTERVAL_MS = 5_000;
 
 function readEnvInt(name: string, fallback: number): number {
   const raw = process.env[name];

--- a/backend/src/modules/streaming/playback.controller.ts
+++ b/backend/src/modules/streaming/playback.controller.ts
@@ -19,14 +19,31 @@ import { PlaybackService } from './playback.service';
 import { RecommendationService } from './recommendation.service';
 import { User } from '../users/entities/user.entity';
 import { LibrariesService } from '../libraries/libraries.service';
+import {
+  LiveSessionRegistry,
+  type PlaybackState as LivePlaybackState,
+} from './live-session.service';
+
+/** Debounce window for DB writes — heartbeat fires every 10 s but we
+ *  flush playback state on a coarser cadence to avoid hammering
+ *  `playback_states` on a busy household. State transitions and the
+ *  "completed" threshold short-circuit the debounce. */
+const STATE_DB_WRITE_INTERVAL_MS = 30_000;
 
 @Controller('playback')
 @UseGuards(JwtOrApiKeyGuard)
 export class PlaybackController {
+  /** When the last DB write happened per `(userId, mediaId, episodeId)`
+   *  tuple. Drives the debounce above. In-memory map, fine for a single
+   *  backend instance — Phase 5 may move this onto Redis if multi-instance
+   *  becomes a thing. */
+  private readonly lastDbWriteAt = new Map<string, number>();
+
   constructor(
     private readonly playbackService: PlaybackService,
     private readonly recommendationService: RecommendationService,
     private readonly libraries: LibrariesService,
+    private readonly liveSessions: LiveSessionRegistry,
   ) {}
 
   @Get('recommendations')
@@ -157,9 +174,14 @@ export class PlaybackController {
     return this.playbackService.getState(user.id, mediaId, episodeId);
   }
 
-  /** Update playback state (position, duration, file). */
+  /** Update playback state (position, duration, file). Doubles as the
+   *  live-session heartbeat when the client includes `sessionId` —
+   *  refreshes the in-memory {@link LiveSessionRegistry} on every call
+   *  and debounces the actual DB write to one every
+   *  {@link STATE_DB_WRITE_INTERVAL_MS}. State transitions
+   *  (`playing` ↔ `paused`) and completion always force a flush. */
   @Put('media/:mediaId/state')
-  updateState(
+  async updateState(
     @Req() req: Request,
     @Param('mediaId', ParseIntPipe) mediaId: number,
     @Body()
@@ -168,10 +190,52 @@ export class PlaybackController {
       durationSeconds: number;
       mediaFileId: number;
       episodeId?: number;
+      // Optional heartbeat fields — present once the client embeds the
+      // sessionId emitted by `playback-info`.
+      sessionId?: string;
+      state?: LivePlaybackState;
+      quality?: string | null;
+      audioTrackIndex?: number | null;
+      subtitleTrackIndex?: number | null;
     },
   ) {
     const user = req.user as User;
-    return this.playbackService.updateState(user.id, mediaId, body);
+
+    let stateChanged = false;
+    if (body.sessionId) {
+      const before = this.liveSessions.get(body.sessionId);
+      const previousState = before?.state;
+      const updated = this.liveSessions.heartbeat(body.sessionId, {
+        position: body.positionSeconds,
+        state: body.state,
+        quality: body.quality,
+        audioTrackIndex: body.audioTrackIndex,
+        subtitleTrackIndex: body.subtitleTrackIndex,
+      });
+      stateChanged = !!updated && !!body.state && previousState !== body.state;
+    }
+
+    const dbKey = `${user.id}:${mediaId}:${body.episodeId ?? 0}`;
+    const now = Date.now();
+    const lastWrite = this.lastDbWriteAt.get(dbKey) ?? 0;
+    const dur = body.durationSeconds ?? 0;
+    const pos = body.positionSeconds ?? 0;
+    const wouldCompleteRow = dur > 0 && (pos >= dur - 30 || pos >= dur * 0.9);
+    const shouldFlushDb =
+      stateChanged ||
+      wouldCompleteRow ||
+      now - lastWrite >= STATE_DB_WRITE_INTERVAL_MS;
+
+    if (!shouldFlushDb) {
+      return null;
+    }
+    this.lastDbWriteAt.set(dbKey, now);
+    return this.playbackService.updateState(user.id, mediaId, {
+      positionSeconds: body.positionSeconds,
+      durationSeconds: body.durationSeconds,
+      mediaFileId: body.mediaFileId,
+      episodeId: body.episodeId,
+    });
   }
 
   /** Toggle watched/unwatched for a media or episode. */

--- a/backend/src/modules/streaming/playback.controller.ts
+++ b/backend/src/modules/streaming/playback.controller.ts
@@ -34,9 +34,8 @@ const STATE_DB_WRITE_INTERVAL_MS = 30_000;
 @UseGuards(JwtOrApiKeyGuard)
 export class PlaybackController {
   /** When the last DB write happened per `(userId, mediaId, episodeId)`
-   *  tuple. Drives the debounce above. In-memory map, fine for a single
-   *  backend instance — Phase 5 may move this onto Redis if multi-instance
-   *  becomes a thing. */
+   *  tuple. Drives the debounce above. In-memory map — moves to a
+   *  shared store the day Fliks runs across multiple backend instances. */
   private readonly lastDbWriteAt = new Map<string, number>();
 
   constructor(

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -4,6 +4,7 @@ import {
   Controller,
   Delete,
   Get,
+  HttpCode,
   Param,
   Post,
   Req,
@@ -29,8 +30,14 @@ import {
   getHdrLadderForDevice,
   getLadderForDevice,
   profileFitsSource,
+  computeProfileHash,
+  buildPlaybackProfileFromContext,
 } from './transcoding';
-import { secondsToSegmentIndex } from './transcoding/constants';
+import {
+  getSegmentDuration,
+  secondsToSegmentIndex,
+} from './transcoding/constants';
+import { LiveSessionRegistry } from './live-session.service';
 import { readAndRewriteCmaf } from './transcoding/cmaf-rewrite';
 import { resolveTonemapPath } from './transcoding/tonemap-path';
 import { ThumbnailService } from './thumbnail.service';
@@ -200,6 +207,7 @@ export class StreamingController {
     private readonly playbackService: PlaybackService,
     private readonly markersService: MarkersService,
     private readonly streamingSettingsCache: StreamingSettingsCache,
+    private readonly liveSessions: LiveSessionRegistry,
   ) {}
 
   private getStreamingSettings() {
@@ -686,10 +694,10 @@ export class StreamingController {
     // next (~100–300ms later) and then seg-0. Starting ffmpeg here overlaps
     // that gap with encoder init so segment 0 is usually already on disk
     // (or streaming) when requested. No-op for DirectPlay or auto quality.
+    const startQuality = firstQueryString(req.query, 'startQuality');
+    const startAtRaw = firstQueryString(req.query, 'startAt');
+    const startAt = startAtRaw != null ? parseFloat(startAtRaw) : undefined;
     if (result.playMethod !== 'DirectPlay') {
-      const startQuality = firstQueryString(req.query, 'startQuality');
-      const startAtRaw = firstQueryString(req.query, 'startAt');
-      const startAt = startAtRaw != null ? parseFloat(startAtRaw) : undefined;
       // Await prewarm before responding so the session is registered in the
       // map when the frontend's subsequent master.m3u8/seg-0 requests
       // arrive — prevents a race where hlsSegment would spawn a duplicate
@@ -767,13 +775,63 @@ export class StreamingController {
       ? resolveTonemapPath(ss.tonemapAlgo, { hasCrop })
       : null;
 
+    // Issue a live-session handle the client embeds in every subsequent
+    // heartbeat (PUT /playback/media/:id/state). The profile hash is
+    // computed from the same SessionContext the transcoding service
+    // will use to spawn ffmpeg, so multi-device dashboards can match
+    // a LiveSession back to its on-disk cache directory.
+    const sessionCtx = this.buildSessionContext(req, resolved, mediaFileId);
+    const profileHash =
+      result.playMethod === 'DirectPlay'
+        ? null
+        : computeProfileHash(
+            buildPlaybackProfileFromContext(
+              sessionCtx,
+              getSegmentDuration() * 1000,
+            ),
+          );
+    const kind =
+      result.playMethod === 'DirectPlay'
+        ? 'directplay'
+        : result.playMethod === 'DirectStream'
+          ? 'remux'
+          : 'transcode';
+    const deviceLabel: string | null = req.get('user-agent') ?? null;
+    const liveSession = this.liveSessions.create({
+      userId: user?.id ?? null,
+      username: user?.username ?? null,
+      mediaFileId,
+      mediaTitle: resolved.media?.title ?? null,
+      mediaType: resolved.media?.type ?? null,
+      posterUrl: resolved.media?.posterUrl ?? null,
+      profileHash,
+      quality: typeof startQuality === 'string' ? startQuality : null,
+      kind,
+      deviceLabel,
+      position: startAt ?? 0,
+    });
+
     return {
       ...result,
       tonemapAlgo,
       durationSeconds: duration,
       markers,
       chapters,
+      sessionId: liveSession.sessionId,
+      profileHash,
     };
+  }
+
+  /**
+   * Explicit stop signal from the client (player destroy / page unload,
+   * fetched with `keepalive: true`). Drops the live-session entry.
+   * Idempotent — silently 204 even for unknown ids so a duplicate
+   * unload doesn't surface as an error.
+   */
+  @Delete('sessions/:sessionId')
+  @HttpCode(204)
+  stopLiveSession(@Param('sessionId') sessionId: string) {
+    this.liveSessions.stop(sessionId);
   }
 
   // ---------------------------------------------------------------------------
@@ -1494,6 +1552,16 @@ export class StreamingController {
     await this.transcodingService.killSession(mediaFileId, user?.id);
     if (user) {
       this.activeStreamTracker.unregister(user.id, mediaFileId);
+    }
+    // Drop any live-session entries for this (user, file) so the
+    // dashboard stops surfacing the row immediately instead of waiting
+    // for the heartbeat ttl. Multi-device clean-up: we only touch
+    // sessions that match `user.id`, leaving other devices alive.
+    const userId = user?.id ?? null;
+    for (const s of this.liveSessions.list()) {
+      if (s.mediaFileId === mediaFileId && s.userId === userId) {
+        this.liveSessions.stop(s.sessionId);
+      }
     }
     return { ok: true };
   }

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -868,14 +868,44 @@ export class StreamingController {
 
   /**
    * Explicit stop signal from the client (player destroy / page unload,
-   * fetched with `keepalive: true`). Drops the live-session entry.
-   * Idempotent — silently 204 even for unknown ids so a duplicate
-   * unload doesn't surface as an error.
+   * fetched with `keepalive: true`). Drops the live-session entry AND
+   * kills the matching ffmpeg job — scoped to the `(user, file,
+   * profileHash)` carried by the session, so a multi-device viewer
+   * closing one device leaves every other device's stream untouched.
+   * Cache is preserved across the kill. Idempotent — silently 204 on
+   * unknown sessionIds.
    */
   @Delete('sessions/:sessionId')
   @HttpCode(204)
   stopLiveSession(@Param('sessionId') sessionId: string) {
+    const live = this.liveSessions.get(sessionId);
     this.liveSessions.stop(sessionId);
+    if (!live || !live.profileHash) return;
+    // Only kill the underlying ffmpeg job(s) when no other live
+    // session is still referencing this (user, file, profileHash) —
+    // multi-tab or multi-device viewers sharing one ffmpeg should keep
+    // it alive while at least one consumer remains. The cleanup loop
+    // will reap the job 60 s after the last viewer leaves.
+    const remaining = this.liveSessions.listForJob(
+      live.userId,
+      live.mediaFileId,
+      live.profileHash,
+    );
+    if (remaining.length > 0) return;
+    const userId = live.userId ?? undefined;
+    const matching = this.transcodingService.getSessionsForFileUser(
+      live.mediaFileId,
+      userId,
+    );
+    const variantPrefix = `${live.profileHash}-`;
+    const toKill = matching.filter(
+      (s) =>
+        s.profileHash === live.profileHash ||
+        (s.profileHash != null && s.profileHash.startsWith(variantPrefix)),
+    );
+    for (const s of toKill) {
+      this.transcodingService.killSessionById(s.id);
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -31,6 +31,7 @@ import {
   computeProfileHash,
   buildPlaybackProfileFromContext,
 } from './transcoding';
+import type { TranscodeSession } from './transcoding/types';
 import {
   getSegmentDuration,
   secondsToSegmentIndex,
@@ -68,6 +69,33 @@ function withTimestampMap(vtt: string | Buffer): string {
 
 /** Default segment duration — overridden by admin streaming settings. */
 let SEG_DURATION = 3;
+
+/**
+ * Build the `?token=...&sid=...` query suffix that every URL emitted by
+ * playback-info / manifest endpoints carries. The token authenticates
+ * the request; the sid binds the request to a specific
+ * {@link LiveSessionRegistry} entry so segment endpoints can route to
+ * the exact `(file, user, profileHash)` transcode session instead of
+ * the most-recently-accessed heuristic fallback.
+ */
+function buildStreamQuery(
+  token: string | null | undefined,
+  sid: string | null | undefined,
+): string {
+  const params: string[] = [];
+  if (token) params.push(`token=${encodeURIComponent(token)}`);
+  if (sid) params.push(`sid=${encodeURIComponent(sid)}`);
+  return params.length ? `?${params.join('&')}` : '';
+}
+
+/** Append `&sid=...` (or `?sid=...` when the URL has no query string) to
+ *  a URL produced by `stream-builder`. The builder doesn't know the
+ *  sessionId — `playback-info` issues it after evaluation and threads
+ *  it into the playUrl right before returning to the client. */
+function appendSidToUrl(url: string, sid: string): string {
+  const sep = url.includes('?') ? '&' : '?';
+  return `${url}${sep}sid=${encodeURIComponent(sid)}`;
+}
 
 /** Pick the right HLS segment Content-Type. fMP4 (.m4s / .mp4) → video/mp4,
  *  MPEG-TS (.ts, used as the explicit `useTs` fallback for Tizen TVs on
@@ -193,6 +221,56 @@ function firstQueryString(
 @UseGuards(JwtOrApiKeyGuard)
 export class StreamingController {
   private readonly log = new Logger(StreamingController.name);
+
+  /** Resolve the exact transcode session for a request: prefer the
+   *  `(file, user, profileHash)` triple derived from the request's
+   *  `?sid=` query — that's what manifest URLs bake in so segment
+   *  fetches route to the right ffmpeg even when a single user is
+   *  watching the same file on multiple devices with different
+   *  profiles. Falls back to the "most recently accessed" heuristic
+   *  when no sid is provided or the live session has expired. */
+  private resolveSession(
+    mediaFileId: number,
+    userId: number | undefined,
+    req: Request,
+  ): TranscodeSession | undefined {
+    const sid = firstQueryString(req.query, 'sid');
+    if (sid) {
+      const live = this.liveSessions.get(sid);
+      if (live && live.profileHash) {
+        const exact = this.transcodingService.getExistingSession(
+          mediaFileId,
+          userId,
+          live.profileHash,
+        );
+        if (exact) return exact;
+      }
+    }
+    return this.transcodingService.findCurrentSession(mediaFileId, userId);
+  }
+
+  /** Same routing as {@link resolveSession} for the early-segment
+   *  companion. The LiveSessionRegistry tracks the base profile hash;
+   *  `getExistingEarlySession` adds the `-early` discriminator itself. */
+  private resolveEarlySession(
+    mediaFileId: number,
+    userId: number | undefined,
+    req: Request,
+  ): TranscodeSession | undefined {
+    const sid = firstQueryString(req.query, 'sid');
+    if (sid) {
+      const live = this.liveSessions.get(sid);
+      if (live && live.profileHash) {
+        const exact = this.transcodingService.getExistingEarlySession(
+          mediaFileId,
+          userId,
+          live.profileHash,
+        );
+        if (exact) return exact;
+      }
+    }
+    return this.transcodingService.findCurrentEarlySession(mediaFileId, userId);
+  }
 
   constructor(
     private readonly streamingService: StreamingService,
@@ -542,7 +620,8 @@ export class StreamingController {
       req.user as User,
     );
     const token = firstQueryString(req.query, 'token');
-    const tokenParam = token ? `?token=${encodeURIComponent(token)}` : '';
+    const sid = firstQueryString(req.query, 'sid');
+    const tokenParam = buildStreamQuery(token, sid);
     const burnInSubtitleRaw = firstQueryString(req.query, 'burnInSubtitleId');
     const burnInSubtitleId = burnInSubtitleRaw
       ? parseInt(burnInSubtitleRaw, 10)
@@ -765,8 +844,19 @@ export class StreamingController {
       position: startAt ?? 0,
     });
 
+    // Bake the sessionId into the playUrl so every subsequent manifest /
+    // segment request the player issues carries it. Manifest endpoints
+    // propagate the same `sid` into the variant + segment URLs they
+    // generate, so the segment-serving routes can look up the exact
+    // `(file, user, profileHash)` session without heuristics.
+    const playUrlWithSid = appendSidToUrl(
+      result.playUrl,
+      liveSession.sessionId,
+    );
+
     return {
       ...result,
+      playUrl: playUrlWithSid,
       tonemapAlgo,
       durationSeconds: duration,
       markers,
@@ -849,7 +939,8 @@ export class StreamingController {
     const h = crop?.height ?? v?.height ?? 1080;
 
     const token = firstQueryString(req.query, 'token');
-    const tokenParam = token ? `?token=${encodeURIComponent(token)}` : '';
+    const sid = firstQueryString(req.query, 'sid');
+    const tokenParam = buildStreamQuery(token, sid);
 
     const includeRemux = firstQueryString(req.query, 'remux') === '1';
     const sourceBitrate = (v?.bitRate ?? 0) + (si?.audio?.[0]?.bitRate ?? 0);
@@ -1028,7 +1119,8 @@ export class StreamingController {
     }
 
     const token = firstQueryString(req.query, 'token');
-    const tokenParam = token ? `?token=${encodeURIComponent(token)}` : '';
+    const sid = firstQueryString(req.query, 'sid');
+    const tokenParam = buildStreamQuery(token, sid);
     const basePath = `/api/stream/${mediaFileId}/audio/${audioIndex}`;
     const useTs = this.activeStreamTracker.getUseTs(mediaFileId);
     const segExt = useTs ? 'ts' : 'm4s';
@@ -1072,10 +1164,7 @@ export class StreamingController {
     // on a multi-audio video session (master.m3u8 only emits EXT-X-MEDIA when
     // `audioStreams.length > 1`), so we don't need a separate audio-only path —
     // any segment Shaka asks for here is in `<videoSession.cachePath>/<varStreamPath>`.
-    let videoSession = this.transcodingService.findCurrentSession(
-      mediaFileId,
-      user?.id,
-    );
+    let videoSession = this.resolveSession(mediaFileId, user?.id, req);
     if (!videoSession) {
       const resolved = await this.streamingService.resolveFile(
         mediaFileId,
@@ -1119,10 +1208,7 @@ export class StreamingController {
     // parallel with main, so it lands first. Use a short timeout — main
     // covers the same files behind it, so wasting 60s on early when it has
     // already exited adds latency for nothing.
-    const earlySession = this.transcodingService.findCurrentEarlySession(
-      mediaFileId,
-      user?.id,
-    );
+    const earlySession = this.resolveEarlySession(mediaFileId, user?.id, req);
     const useEarly =
       earlySession != null &&
       videoSession.startSegment != null &&
@@ -1194,10 +1280,7 @@ export class StreamingController {
     // Exception: Cast passes startAt for resume position — pre-start for Cast/remux only.
     const startAtRaw = firstQueryString(req.query, 'startAt');
     if (startAtRaw) {
-      const existing = this.transcodingService.findCurrentSession(
-        mediaFileId,
-        req.user?.id,
-      );
+      const existing = this.resolveSession(mediaFileId, req.user?.id, req);
       if (!existing || existing.process.exitCode !== null) {
         const startAtSec = parseInt(startAtRaw, 10);
         const startSegment = secondsToSegmentIndex(startAtSec);
@@ -1225,7 +1308,8 @@ export class StreamingController {
     }
 
     const token = firstQueryString(req.query, 'token');
-    const tokenParam = token ? `?token=${encodeURIComponent(token)}` : '';
+    const sid = firstQueryString(req.query, 'sid');
+    const tokenParam = buildStreamQuery(token, sid);
     const basePath = `/api/stream/${mediaFileId}/${quality}`;
     // Use the master.m3u8 decision — must match to avoid init filename mismatch.
     const multiAudio = this.activeStreamTracker.getUseExtXMedia(mediaFileId);
@@ -1287,10 +1371,7 @@ export class StreamingController {
     // Fast path: if a session already exists, skip the DB query — we only
     // need resolveFile for absolutePath + context when creating a NEW session.
     // Saves ~15-25ms per segment (a 2h file = ~2400 segments = ~40s saved).
-    const existing = this.transcodingService.findCurrentSession(
-      mediaFileId,
-      req.user?.id,
-    );
+    const existing = this.resolveSession(mediaFileId, req.user?.id, req);
 
     // For init.mp4: serve from the early session when it exists with matching
     // quality. Its init bytes are byte-identical to main's (same encoder
@@ -1315,9 +1396,10 @@ export class StreamingController {
       // Same caveat as the segment path: remux video-only doesn't use
       // var_stream_map, so the `0/` prefix would 404 on the init lookup.
       const initFile = ma && quality !== 'remux' ? `0/${segment}` : segment;
-      const earlySession = this.transcodingService.findCurrentEarlySession(
+      const earlySession = this.resolveEarlySession(
         mediaFileId,
         req.user?.id,
+        req,
       );
       const sources =
         earlySession && earlySession.quality === existing.quality
@@ -1406,9 +1488,10 @@ export class StreamingController {
       existing.startSegment > 0 &&
       segIndex < existing.startSegment;
     if (isEarlyProbe) {
-      const earlySession = this.transcodingService.findCurrentEarlySession(
+      const earlySession = this.resolveEarlySession(
         mediaFileId,
         req.user?.id,
+        req,
       );
       if (earlySession && earlySession.quality === quality) {
         const varStreamMap =

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -27,6 +27,7 @@ import {
   PROFILES,
   DESKTOP_HDR_PROFILES,
   SessionContext,
+  VARIANT_EARLY,
   profileFitsSource,
   computeProfileHash,
   buildPlaybackProfileFromContext,
@@ -71,30 +72,31 @@ function withTimestampMap(vtt: string | Buffer): string {
 let SEG_DURATION = 3;
 
 /**
- * Build the `?token=...&sid=...` query suffix that every URL emitted by
- * playback-info / manifest endpoints carries. The token authenticates
- * the request; the sid binds the request to a specific
+ * Compose / append the `token=...` + `sid=...` query pair that every
+ * streaming URL (manifest, variant, segment, audio) carries. The token
+ * authenticates the request; the sid binds it to a
  * {@link LiveSessionRegistry} entry so segment endpoints can route to
  * the exact `(file, user, profileHash)` transcode session instead of
  * the most-recently-accessed heuristic fallback.
+ *
+ * When `base` is omitted the result is a leading query suffix
+ * (`?token=...&sid=...` or empty); when supplied the params are
+ * appended to the existing URL with the correct separator.
  */
-function buildStreamQuery(
-  token: string | null | undefined,
-  sid: string | null | undefined,
+function streamQuery(
+  params: {
+    token?: string | null;
+    sid?: string | null;
+  },
+  base?: string,
 ): string {
-  const params: string[] = [];
-  if (token) params.push(`token=${encodeURIComponent(token)}`);
-  if (sid) params.push(`sid=${encodeURIComponent(sid)}`);
-  return params.length ? `?${params.join('&')}` : '';
-}
-
-/** Append `&sid=...` (or `?sid=...` when the URL has no query string) to
- *  a URL produced by `stream-builder`. The builder doesn't know the
- *  sessionId — `playback-info` issues it after evaluation and threads
- *  it into the playUrl right before returning to the client. */
-function appendSidToUrl(url: string, sid: string): string {
-  const sep = url.includes('?') ? '&' : '?';
-  return `${url}${sep}sid=${encodeURIComponent(sid)}`;
+  const parts: string[] = [];
+  if (params.token) parts.push(`token=${encodeURIComponent(params.token)}`);
+  if (params.sid) parts.push(`sid=${encodeURIComponent(params.sid)}`);
+  if (!parts.length) return base ?? '';
+  if (base == null) return `?${parts.join('&')}`;
+  const sep = base.includes('?') ? '&' : '?';
+  return `${base}${sep}${parts.join('&')}`;
 }
 
 /** Pick the right HLS segment Content-Type. fMP4 (.m4s / .mp4) → video/mp4,
@@ -250,8 +252,8 @@ export class StreamingController {
   }
 
   /** Same routing as {@link resolveSession} for the early-segment
-   *  companion. The LiveSessionRegistry tracks the base profile hash;
-   *  `getExistingEarlySession` adds the `-early` discriminator itself. */
+   *  companion — the base profile hash is the same; only the variant
+   *  differs. */
   private resolveEarlySession(
     mediaFileId: number,
     userId: number | undefined,
@@ -261,10 +263,11 @@ export class StreamingController {
     if (sid) {
       const live = this.liveSessions.get(sid);
       if (live && live.profileHash) {
-        const exact = this.transcodingService.getExistingEarlySession(
+        const exact = this.transcodingService.getExistingSession(
           mediaFileId,
           userId,
           live.profileHash,
+          VARIANT_EARLY,
         );
         if (exact) return exact;
       }
@@ -621,7 +624,7 @@ export class StreamingController {
     );
     const token = firstQueryString(req.query, 'token');
     const sid = firstQueryString(req.query, 'sid');
-    const tokenParam = buildStreamQuery(token, sid);
+    const tokenParam = streamQuery({ token, sid });
     const burnInSubtitleRaw = firstQueryString(req.query, 'burnInSubtitleId');
     const burnInSubtitleId = burnInSubtitleRaw
       ? parseInt(burnInSubtitleRaw, 10)
@@ -849,9 +852,9 @@ export class StreamingController {
     // propagate the same `sid` into the variant + segment URLs they
     // generate, so the segment-serving routes can look up the exact
     // `(file, user, profileHash)` session without heuristics.
-    const playUrlWithSid = appendSidToUrl(
+    const playUrlWithSid = streamQuery(
+      { sid: liveSession.sessionId },
       result.playUrl,
-      liveSession.sessionId,
     );
 
     return {
@@ -897,11 +900,8 @@ export class StreamingController {
       live.mediaFileId,
       userId,
     );
-    const variantPrefix = `${live.profileHash}-`;
     const toKill = matching.filter(
-      (s) =>
-        s.profileHash === live.profileHash ||
-        (s.profileHash != null && s.profileHash.startsWith(variantPrefix)),
+      (s) => s.baseProfileHash === live.profileHash,
     );
     for (const s of toKill) {
       this.transcodingService.killSessionById(s.id);
@@ -970,7 +970,7 @@ export class StreamingController {
 
     const token = firstQueryString(req.query, 'token');
     const sid = firstQueryString(req.query, 'sid');
-    const tokenParam = buildStreamQuery(token, sid);
+    const tokenParam = streamQuery({ token, sid });
 
     const includeRemux = firstQueryString(req.query, 'remux') === '1';
     const sourceBitrate = (v?.bitRate ?? 0) + (si?.audio?.[0]?.bitRate ?? 0);
@@ -1150,7 +1150,7 @@ export class StreamingController {
 
     const token = firstQueryString(req.query, 'token');
     const sid = firstQueryString(req.query, 'sid');
-    const tokenParam = buildStreamQuery(token, sid);
+    const tokenParam = streamQuery({ token, sid });
     const basePath = `/api/stream/${mediaFileId}/audio/${audioIndex}`;
     const useTs = this.activeStreamTracker.getUseTs(mediaFileId);
     const segExt = useTs ? 'ts' : 'm4s';
@@ -1339,7 +1339,7 @@ export class StreamingController {
 
     const token = firstQueryString(req.query, 'token');
     const sid = firstQueryString(req.query, 'sid');
-    const tokenParam = buildStreamQuery(token, sid);
+    const tokenParam = streamQuery({ token, sid });
     const basePath = `/api/stream/${mediaFileId}/${quality}`;
     // Use the master.m3u8 decision — must match to avoid init filename mismatch.
     const multiAudio = this.activeStreamTracker.getUseExtXMedia(mediaFileId);

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -27,8 +27,6 @@ import {
   PROFILES,
   DESKTOP_HDR_PROFILES,
   SessionContext,
-  getHdrLadderForDevice,
-  getLadderForDevice,
   profileFitsSource,
   computeProfileHash,
   buildPlaybackProfileFromContext,
@@ -214,7 +212,6 @@ export class StreamingController {
     return this.streamingSettingsCache.get();
   }
 
-
   private buildSessionContext(
     req: Request,
     resolved: ResolvedFile,
@@ -333,12 +330,14 @@ export class StreamingController {
         }
         effectiveStartAt = effectiveStartAt ?? 0;
       }
+      const ctx = this.buildSessionContext(req, resolved, mediaFileId);
+      const profileHash = this.transcodingService.computeProfileHashForCtx(ctx);
       const existing = this.transcodingService.getExistingSession(
         mediaFileId,
         req.user?.id,
+        profileHash,
       );
       if (existing && existing.process.exitCode === null) return;
-      const ctx = this.buildSessionContext(req, resolved, mediaFileId);
 
       // `remux` / `original` resolve to the player's actual rung only
       // after the manifest loads — Shaka filters variants whose
@@ -638,57 +637,12 @@ export class StreamingController {
       sv?.height ?? 0,
     );
 
-    // Device-profile drift detection. A single user can hop between a
-    // browser tab (which accepts EAC-3 copy on 2-ch) and the Chromecast
-    // (AAC transcode only) without unloading the file. The session map
-    // is keyed (mediaFileId, userId), so both hops share the same
-    // entry — and prewarm short-circuits on `existing.exitCode === null`
-    // without comparing plans. The result is a manifest advertising the
-    // new codec while ffmpeg keeps writing segments in the old one,
-    // tripping Shaka 4032 (CONTENT_UNSUPPORTED_BY_BROWSER) on Cast.
-    // Kill the running session whenever the new audio plan, the new
-    // video variant or the new mux flavour (Tizen hopping TS ↔ fmp4)
-    // disagrees with what it was spawned for; the prewarm immediately
-    // below then respawns with the up-to-date plan.
-    const newAudioCodec = result.audioPlan?.codec;
-    const newVideoCodec = this.activeStreamTracker
-      .getVideoVariant(mediaFileId)
-      ?.codec;
-    const newMuxFlavour: 'ts' | 'fmp4' = effectiveUseTs ? 'ts' : 'fmp4';
-    // Audio layout the *next* session would be spawned with. Mirrors
-    // the gate in `buildSessionContext` so flipping `useTs` (which
-    // toggles muxed-vs-separated audio under us) kills the running
-    // session instead of leaving an EXT-X-MEDIA master pointing at a
-    // `var_stream_map`-less segment tree.
-    const trackedAudioCount =
-      this.activeStreamTracker.getAudioStreamCount(mediaFileId);
-    const newAudioLayout: 'inline' | 'var-stream-map' = pickAudioLayout(
-      trackedAudioCount,
-      newMuxFlavour,
-    );
-    const existingForDrift = this.transcodingService.getExistingSession(
-      mediaFileId,
-      req.user?.id,
-    );
-    if (
-      existingForDrift &&
-      existingForDrift.process.exitCode === null &&
-      (existingForDrift.audioPlan?.codec !== newAudioCodec ||
-        existingForDrift.videoVariant?.codec !== newVideoCodec ||
-        (existingForDrift.muxFlavour &&
-          existingForDrift.muxFlavour !== newMuxFlavour) ||
-        (existingForDrift.audioLayout &&
-          existingForDrift.audioLayout !== newAudioLayout))
-    ) {
-      this.log.log(
-        `[playback-info] profile drift on file ${mediaFileId} — killing session ` +
-          `(audio: ${existingForDrift.audioPlan?.codec ?? '∅'} → ${newAudioCodec ?? '∅'}, ` +
-          `video: ${existingForDrift.videoVariant?.codec ?? '∅'} → ${newVideoCodec ?? '∅'}, ` +
-          `mux: ${existingForDrift.muxFlavour ?? '∅'} → ${newMuxFlavour}, ` +
-          `audioLayout: ${existingForDrift.audioLayout ?? '∅'} → ${newAudioLayout})`,
-      );
-      await this.transcodingService.killSession(mediaFileId, req.user?.id);
-    }
+    // Different device profiles (codec / mux / audio layout) hash to
+    // different session-map keys, so multi-device playback of the same
+    // file lands on coexisting sessions instead of mutually killing one
+    // another. No drift kill needed: a hop from browser → cast spawns a
+    // new session under the cast's profileHash and leaves the browser's
+    // session untouched.
 
     // Pre-spawn ffmpeg as early as possible — the client will GET master.m3u8
     // next (~100–300ms later) and then seg-0. Starting ffmpeg here overlaps
@@ -1118,7 +1072,7 @@ export class StreamingController {
     // on a multi-audio video session (master.m3u8 only emits EXT-X-MEDIA when
     // `audioStreams.length > 1`), so we don't need a separate audio-only path —
     // any segment Shaka asks for here is in `<videoSession.cachePath>/<varStreamPath>`.
-    let videoSession = this.transcodingService.getExistingSession(
+    let videoSession = this.transcodingService.findCurrentSession(
       mediaFileId,
       user?.id,
     );
@@ -1165,7 +1119,7 @@ export class StreamingController {
     // parallel with main, so it lands first. Use a short timeout — main
     // covers the same files behind it, so wasting 60s on early when it has
     // already exited adds latency for nothing.
-    const earlySession = this.transcodingService.getExistingEarlySession(
+    const earlySession = this.transcodingService.findCurrentEarlySession(
       mediaFileId,
       user?.id,
     );
@@ -1240,7 +1194,7 @@ export class StreamingController {
     // Exception: Cast passes startAt for resume position — pre-start for Cast/remux only.
     const startAtRaw = firstQueryString(req.query, 'startAt');
     if (startAtRaw) {
-      const existing = this.transcodingService.getExistingSession(
+      const existing = this.transcodingService.findCurrentSession(
         mediaFileId,
         req.user?.id,
       );
@@ -1333,7 +1287,7 @@ export class StreamingController {
     // Fast path: if a session already exists, skip the DB query — we only
     // need resolveFile for absolutePath + context when creating a NEW session.
     // Saves ~15-25ms per segment (a 2h file = ~2400 segments = ~40s saved).
-    const existing = this.transcodingService.getExistingSession(
+    const existing = this.transcodingService.findCurrentSession(
       mediaFileId,
       req.user?.id,
     );
@@ -1361,7 +1315,7 @@ export class StreamingController {
       // Same caveat as the segment path: remux video-only doesn't use
       // var_stream_map, so the `0/` prefix would 404 on the init lookup.
       const initFile = ma && quality !== 'remux' ? `0/${segment}` : segment;
-      const earlySession = this.transcodingService.getExistingEarlySession(
+      const earlySession = this.transcodingService.findCurrentEarlySession(
         mediaFileId,
         req.user?.id,
       );
@@ -1441,9 +1395,9 @@ export class StreamingController {
 
     // Early probe routing: when Shaka requests a segment before the main
     // session's startSegment (typical Shaka VOD behavior on resume), route
-    // to the early companion if it exists. 10s timeout safety net : si
-    // early hang (régression du fix Phase 2), fall through au slow path
-    // standard rather than blocking 60s.
+    // to the early companion if it exists. 10 s timeout safety net — if
+    // the early session hangs we fall through to the slow path rather
+    // than blocking on a 60 s waitForSegment.
     const isEarlyProbe =
       quality !== 'remux' &&
       existing != null &&
@@ -1452,7 +1406,7 @@ export class StreamingController {
       existing.startSegment > 0 &&
       segIndex < existing.startSegment;
     if (isEarlyProbe) {
-      const earlySession = this.transcodingService.getExistingEarlySession(
+      const earlySession = this.transcodingService.findCurrentEarlySession(
         mediaFileId,
         req.user?.id,
       );

--- a/backend/src/modules/streaming/streaming.module.ts
+++ b/backend/src/modules/streaming/streaming.module.ts
@@ -13,6 +13,7 @@ import { StreamingService } from './streaming.service';
 import { SubtitleStreamService } from './subtitle-stream.service';
 import { TranscodingService } from './transcoding';
 import { TranscodeCacheService } from './transcoding/transcode-cache.service';
+import { LiveSessionRegistry } from './live-session.service';
 import { StreamBuilderService } from './stream-builder.service';
 import { PlaybackService } from './playback.service';
 import { ActiveStreamTracker } from './active-stream-tracker.service';
@@ -49,6 +50,7 @@ import { MarkersModule } from '../markers/markers.module';
     SubtitleStreamService,
     TranscodingService,
     TranscodeCacheService,
+    LiveSessionRegistry,
     StreamBuilderService,
     PlaybackService,
     ActiveStreamTracker,
@@ -62,6 +64,7 @@ import { MarkersModule } from '../markers/markers.module';
     TranscodingService,
     StreamingService,
     ActiveStreamTracker,
+    LiveSessionRegistry,
     ThumbnailService,
     SubtitleStreamService,
   ],

--- a/backend/src/modules/streaming/streaming.module.ts
+++ b/backend/src/modules/streaming/streaming.module.ts
@@ -12,6 +12,7 @@ import { PlaybackController } from './playback.controller';
 import { StreamingService } from './streaming.service';
 import { SubtitleStreamService } from './subtitle-stream.service';
 import { TranscodingService } from './transcoding';
+import { TranscodeCacheService } from './transcoding/transcode-cache.service';
 import { StreamBuilderService } from './stream-builder.service';
 import { PlaybackService } from './playback.service';
 import { ActiveStreamTracker } from './active-stream-tracker.service';
@@ -47,6 +48,7 @@ import { MarkersModule } from '../markers/markers.module';
     StreamingService,
     SubtitleStreamService,
     TranscodingService,
+    TranscodeCacheService,
     StreamBuilderService,
     PlaybackService,
     ActiveStreamTracker,

--- a/backend/src/modules/streaming/transcoding/constants.ts
+++ b/backend/src/modules/streaming/transcoding/constants.ts
@@ -1,4 +1,26 @@
-export const SESSION_TIMEOUT_MS = 30 * 60 * 1000; // 30min HLS session timeout
+/** Maximum idle window for transcode sessions that were never paired
+ *  with a {@link LiveSessionRegistry} entry (legacy URL fetches, admin
+ *  scrubbing, etc.). Sessions tied to a live session ride on the
+ *  {@link JOB_GRACE_MS} grace window after their last heartbeat
+ *  instead — see `TranscodingService.cleanupStaleSessions`. */
+export const SESSION_TIMEOUT_MS = (() => {
+  const raw = process.env.STREAM_JOB_FALLBACK_TIMEOUT_MS;
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 30 * 60 * 1000;
+})();
+
+/** Grace window between the last matching live session disappearing and
+ *  the ffmpeg job being killed. Keeps a brief reconnect window so a
+ *  client that misses a few heartbeats (background tab, lockscreen)
+ *  can reattach without restarting the encoder. The cache directory
+ *  is preserved across the kill — a fresh play picks up from the
+ *  existing segments. */
+export const JOB_GRACE_MS = (() => {
+  const raw = process.env.STREAM_JOB_GRACE_MS;
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 60_000;
+})();
+
 /** Max gap (in segments) between FFmpeg frontier and requested segment before restarting. */
 export const SEEK_WAIT_THRESHOLD = 15;
 

--- a/backend/src/modules/streaming/transcoding/index.ts
+++ b/backend/src/modules/streaming/transcoding/index.ts
@@ -22,3 +22,7 @@ export {
   getAvailableProfiles,
 } from './master-playlist';
 export { TranscodingService } from './transcoding.service';
+export { TranscodeCacheService } from './transcode-cache.service';
+export type { CacheEntry, QualityCache } from './transcode-cache.service';
+export { computeProfileHash } from './profile-hash';
+export type { PlaybackProfile, TvPlatform } from './profile-hash';

--- a/backend/src/modules/streaming/transcoding/index.ts
+++ b/backend/src/modules/streaming/transcoding/index.ts
@@ -24,5 +24,8 @@ export {
 export { TranscodingService } from './transcoding.service';
 export { TranscodeCacheService } from './transcode-cache.service';
 export type { CacheEntry, QualityCache } from './transcode-cache.service';
-export { computeProfileHash } from './profile-hash';
+export {
+  buildPlaybackProfileFromContext,
+  computeProfileHash,
+} from './profile-hash';
 export type { PlaybackProfile, TvPlatform } from './profile-hash';

--- a/backend/src/modules/streaming/transcoding/index.ts
+++ b/backend/src/modules/streaming/transcoding/index.ts
@@ -16,7 +16,17 @@ export {
 export { requestedHwAccelFor } from './hw-detect';
 export { resolveTonemapPath, type ResolvedTonemapPath } from './tonemap-path';
 export { encoderRegistry } from './codec/encoders';
-export { audioSessionKey, earlySessionKey, sessionKey } from './session-key';
+export { sessionKey } from './session-key';
+export {
+  VARIANT_EARLY,
+  VARIANT_MAIN,
+  VARIANT_REMUX,
+  baseProfileHash,
+  isVariantOf,
+  variantHash,
+  variantSuffix,
+} from './variant';
+export type { SessionVariant } from './variant';
 export {
   generateMasterPlaylist,
   getAvailableProfiles,

--- a/backend/src/modules/streaming/transcoding/profile-hash.spec.ts
+++ b/backend/src/modules/streaming/transcoding/profile-hash.spec.ts
@@ -1,0 +1,81 @@
+import { computeProfileHash, type PlaybackProfile } from './profile-hash';
+
+const BASE: PlaybackProfile = {
+  videoCodec: 'h264',
+  videoBitDepth: 8,
+  hdr: null,
+  audioCodec: 'aac',
+  audioChannels: 2,
+  audioMode: 'transcode',
+  muxFlavour: 'fmp4',
+  audioLayout: 'inline',
+  segmentDurationMs: 3000,
+  tvPlatform: 'browser',
+};
+
+describe('computeProfileHash', () => {
+  it('returns a 10-char hex string', () => {
+    const hash = computeProfileHash(BASE);
+    expect(hash).toMatch(/^[0-9a-f]{10}$/);
+  });
+
+  it('is deterministic for the same input', () => {
+    expect(computeProfileHash(BASE)).toBe(computeProfileHash({ ...BASE }));
+  });
+
+  it('changes when any single field changes', () => {
+    const baseline = computeProfileHash(BASE);
+    const variations: Array<Partial<PlaybackProfile>> = [
+      { videoCodec: 'hevc' },
+      { videoBitDepth: 10 },
+      { hdr: 'HDR10' },
+      { audioCodec: 'eac3' },
+      { audioChannels: 6 },
+      { audioMode: 'copy' },
+      { muxFlavour: 'ts' },
+      { audioLayout: 'var-stream-map' },
+      { segmentDurationMs: 6000 },
+      { tvPlatform: 'tizen' },
+    ];
+    for (const v of variations) {
+      expect(computeProfileHash({ ...BASE, ...v })).not.toBe(baseline);
+    }
+  });
+
+  it('separates HDR variants from SDR even when codec is identical', () => {
+    const sdr = computeProfileHash({
+      ...BASE,
+      videoCodec: 'hevc',
+      videoBitDepth: 10,
+    });
+    const hdr10 = computeProfileHash({
+      ...BASE,
+      videoCodec: 'hevc',
+      videoBitDepth: 10,
+      hdr: 'HDR10',
+    });
+    const hlg = computeProfileHash({
+      ...BASE,
+      videoCodec: 'hevc',
+      videoBitDepth: 10,
+      hdr: 'HLG',
+    });
+    expect(new Set([sdr, hdr10, hlg]).size).toBe(3);
+  });
+
+  it('separates tvPlatform classes even with otherwise-equal profiles', () => {
+    const platforms: PlaybackProfile['tvPlatform'][] = [
+      'browser',
+      'androidtv',
+      'tizen',
+      'webos',
+      'ios',
+      'android',
+      'cast',
+    ];
+    const hashes = platforms.map((tv) =>
+      computeProfileHash({ ...BASE, tvPlatform: tv }),
+    );
+    expect(new Set(hashes).size).toBe(platforms.length);
+  });
+});

--- a/backend/src/modules/streaming/transcoding/profile-hash.spec.ts
+++ b/backend/src/modules/streaming/transcoding/profile-hash.spec.ts
@@ -1,4 +1,9 @@
-import { computeProfileHash, type PlaybackProfile } from './profile-hash';
+import {
+  buildPlaybackProfileFromContext,
+  computeProfileHash,
+  type PlaybackProfile,
+} from './profile-hash';
+import type { SessionContext } from './types';
 
 const BASE: PlaybackProfile = {
   videoCodec: 'h264',
@@ -77,5 +82,74 @@ describe('computeProfileHash', () => {
       computeProfileHash({ ...BASE, tvPlatform: tv }),
     );
     expect(new Set(hashes).size).toBe(platforms.length);
+  });
+});
+
+describe('buildPlaybackProfileFromContext', () => {
+  it('returns safe defaults for an empty context', () => {
+    const profile = buildPlaybackProfileFromContext(undefined, 3000);
+    expect(profile.videoCodec).toBe('h264');
+    expect(profile.videoBitDepth).toBe(8);
+    expect(profile.hdr).toBeNull();
+    expect(profile.audioCodec).toBe('aac');
+    expect(profile.audioChannels).toBe(2);
+    expect(profile.audioMode).toBe('transcode');
+    expect(profile.muxFlavour).toBe('fmp4');
+    expect(profile.audioLayout).toBe('inline');
+    expect(profile.segmentDurationMs).toBe(3000);
+    expect(profile.tvPlatform).toBe('browser');
+  });
+
+  it('propagates audio plan and video variant', () => {
+    const ctx: SessionContext = {
+      audioPlan: { mode: 'copy', codec: 'eac3' },
+      videoVariant: { codec: 'hevc', bitDepth: 10, hdr: 'HDR10' },
+      useTs: false,
+    };
+    const profile = buildPlaybackProfileFromContext(ctx, 3000);
+    expect(profile.audioCodec).toBe('eac3');
+    expect(profile.audioMode).toBe('copy');
+    expect(profile.audioChannels).toBe(6);
+    expect(profile.videoCodec).toBe('hevc');
+    expect(profile.videoBitDepth).toBe(10);
+    expect(profile.hdr).toBe('HDR10');
+  });
+
+  it('picks the ts mux flavour for Tizen sessions', () => {
+    const ctx: SessionContext = { useTs: true };
+    expect(buildPlaybackProfileFromContext(ctx, 3000).muxFlavour).toBe('ts');
+  });
+
+  it('flips to var-stream-map when multi-audio + videoOnly', () => {
+    const ctx: SessionContext = {
+      videoOnly: true,
+      audioStreams: [{ language: 'eng' }, { language: 'fre' }],
+    };
+    expect(buildPlaybackProfileFromContext(ctx, 3000).audioLayout).toBe(
+      'var-stream-map',
+    );
+  });
+
+  it('keeps inline audio layout when there is a single audio track', () => {
+    const ctx: SessionContext = {
+      videoOnly: true,
+      audioStreams: [{ language: 'eng' }],
+    };
+    expect(buildPlaybackProfileFromContext(ctx, 3000).audioLayout).toBe(
+      'inline',
+    );
+  });
+
+  it('keeps the same hash for two ctx values that map to the same profile', () => {
+    const a = buildPlaybackProfileFromContext(
+      { audioPlan: { mode: 'transcode', codec: 'aac', bitrateBps: 128000 } },
+      3000,
+    );
+    const b = buildPlaybackProfileFromContext(
+      { audioPlan: { mode: 'transcode', codec: 'aac', bitrateBps: 192000 } },
+      3000,
+    );
+    // Bitrate is not part of the profile — both should hash to the same dir.
+    expect(computeProfileHash(a)).toBe(computeProfileHash(b));
   });
 });

--- a/backend/src/modules/streaming/transcoding/profile-hash.ts
+++ b/backend/src/modules/streaming/transcoding/profile-hash.ts
@@ -1,0 +1,73 @@
+import { createHash } from 'crypto';
+import type { BitDepth, HdrFormat, VideoCodec } from './codec/types';
+
+/**
+ * Client platform classes that may produce byte-incompatible segments
+ * even with otherwise identical codec / mux settings. The hash includes
+ * this as a safety net against player-specific quirks (AVPlay box layout
+ * on Tizen, WAM on webOS, AVPlayer HEVC tag handling on iOS, etc.) that
+ * are not captured by codec + mux flavour alone.
+ */
+export type TvPlatform =
+  | 'browser'
+  | 'androidtv'
+  | 'tizen'
+  | 'webos'
+  | 'ios'
+  | 'android'
+  | 'cast';
+
+/**
+ * The set of fields that uniquely determine the byte layout of the
+ * transcoded segments produced for a given (user, mediaFile). Two
+ * playbacks with the same {@link PlaybackProfile} can safely share the
+ * same on-disk cache. Two playbacks that disagree on any field must
+ * write to separate cache directories — segments would otherwise drift
+ * from the master playlist's CODECS string or fail to parse on the
+ * target player.
+ */
+export interface PlaybackProfile {
+  videoCodec: VideoCodec;
+  videoBitDepth: BitDepth;
+  hdr: HdrFormat | null;
+  audioCodec: string;
+  audioChannels: number;
+  audioMode: 'copy' | 'transcode';
+  muxFlavour: 'ts' | 'fmp4';
+  audioLayout: 'inline' | 'var-stream-map';
+  segmentDurationMs: number;
+  tvPlatform: TvPlatform;
+}
+
+/**
+ * Stable, order-independent serialisation of a {@link PlaybackProfile}.
+ * Keys are emitted in a fixed order; `null` is serialised as the literal
+ * string `"null"`. Used as the sha1 input — never persisted as-is, so
+ * the format is free to evolve as long as new fields are appended.
+ */
+function canonicalise(profile: PlaybackProfile): string {
+  return [
+    `v=${profile.videoCodec}`,
+    `vd=${profile.videoBitDepth}`,
+    `h=${profile.hdr ?? 'null'}`,
+    `a=${profile.audioCodec}`,
+    `ac=${profile.audioChannels}`,
+    `am=${profile.audioMode}`,
+    `mux=${profile.muxFlavour}`,
+    `al=${profile.audioLayout}`,
+    `sd=${profile.segmentDurationMs}`,
+    `tv=${profile.tvPlatform}`,
+  ].join('|');
+}
+
+/**
+ * Compute the directory-naming hash for a profile. 10 hex chars = 40 bits,
+ * negligible collision probability for the realistic number of profile
+ * combinations (~ hundreds in production).
+ */
+export function computeProfileHash(profile: PlaybackProfile): string {
+  return createHash('sha1')
+    .update(canonicalise(profile))
+    .digest('hex')
+    .slice(0, 10);
+}

--- a/backend/src/modules/streaming/transcoding/profile-hash.ts
+++ b/backend/src/modules/streaming/transcoding/profile-hash.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'crypto';
 import type { BitDepth, HdrFormat, VideoCodec } from './codec/types';
+import type { SessionContext } from './types';
 
 /**
  * Client platform classes that may produce byte-incompatible segments
@@ -70,4 +71,65 @@ export function computeProfileHash(profile: PlaybackProfile): string {
     .update(canonicalise(profile))
     .digest('hex')
     .slice(0, 10);
+}
+
+/**
+ * Best-effort derivation of a {@link PlaybackProfile} from the existing
+ * {@link SessionContext}. Used by the transcoding service to compute
+ * the on-disk cache directory for a session. Fields not yet propagated
+ * from the front-end (notably `tvPlatform`) fall back to safe defaults
+ * — the resulting hash is stable for a given (ctx, quality) pair within
+ * a single backend run, which is all the cache layout requires.
+ */
+export function buildPlaybackProfileFromContext(
+  ctx: SessionContext | undefined,
+  segmentDurationMs: number,
+): PlaybackProfile {
+  const audioCodec = ctx?.audioPlan?.codec ?? 'aac';
+  const audioChannels = pickAudioChannels(ctx);
+  const audioMode = ctx?.audioPlan?.mode ?? 'transcode';
+  const videoVariant = ctx?.videoVariant;
+  return {
+    videoCodec: videoVariant?.codec ?? 'h264',
+    videoBitDepth: videoVariant?.bitDepth ?? 8,
+    hdr: videoVariant?.hdr ?? null,
+    audioCodec,
+    audioChannels,
+    audioMode,
+    muxFlavour: ctx?.useTs ? 'ts' : 'fmp4',
+    audioLayout: pickAudioLayout(ctx),
+    segmentDurationMs,
+    tvPlatform: 'browser',
+  };
+}
+
+function pickAudioChannels(ctx: SessionContext | undefined): number {
+  // SessionContext doesn't carry channel count today; default to 2 for
+  // transcode (always downmixed to stereo for AAC) and 6 for surround
+  // copy paths (EAC-3/AC-3/DTS/TrueHD copy preserves the source layout,
+  // which is 5.1 in the overwhelming majority of releases that pick the
+  // surround copy branch). A more precise channel count will be plumbed
+  // through once SessionContext exposes it.
+  if (ctx?.audioPlan?.mode === 'copy') {
+    const codec = ctx.audioPlan.codec.toLowerCase();
+    if (
+      codec === 'eac3' ||
+      codec === 'ac3' ||
+      codec === 'dts' ||
+      codec === 'truehd'
+    ) {
+      return 6;
+    }
+  }
+  return 2;
+}
+
+function pickAudioLayout(
+  ctx: SessionContext | undefined,
+): 'inline' | 'var-stream-map' {
+  const isVideoOnly = ctx?.videoOnly ?? false;
+  const streams = ctx?.audioStreams;
+  return isVideoOnly && streams && streams.length > 1
+    ? 'var-stream-map'
+    : 'inline';
 }

--- a/backend/src/modules/streaming/transcoding/session-key.ts
+++ b/backend/src/modules/streaming/transcoding/session-key.ts
@@ -1,38 +1,20 @@
 /**
- * Session map key for a transcode job. A single `(file, user)` pair can
- * carry multiple concurrent sessions, one per {@link profileHash}
- * (different devices producing byte-incompatible streams from the same
- * source). The hash segment makes those entries live as siblings in the
- * `sessions` map without colliding, and matches the on-disk cache
- * layout owned by `TranscodeCacheService`.
+ * Session map key for a transcode job. A single `(file, user)` pair
+ * can carry multiple concurrent sessions, one per `cacheKey` (= base
+ * profile hash + optional variant suffix). The hash segment makes
+ * those entries live as siblings in the `sessions` map without
+ * colliding, and matches the on-disk cache layout owned by
+ * `TranscodeCacheService`.
+ *
+ * The variant suffix logic itself lives in `./variant.ts` — callers
+ * compose `cacheKey = variantHash(baseHash, variant)` before calling
+ * here so the key shape is uniform across main / early / remux / audio.
  */
 export function sessionKey(
   mediaFileId: number,
   userId: number | undefined,
-  profileHash: string,
+  cacheKey: string,
 ): string {
   const userSeg = userId != null ? `u${userId}` : 'anon';
-  return `${mediaFileId}-${userSeg}-${profileHash}`;
-}
-
-/** Audio-only HLS session, one per (file, user, profile, audioIndex). */
-export function audioSessionKey(
-  mediaFileId: number,
-  audioIndex: number,
-  userId: number | undefined,
-  profileHash: string,
-): string {
-  return `${sessionKey(mediaFileId, userId, profileHash)}-a${audioIndex}`;
-}
-
-/** Short-lived parallel ffmpeg producing seg-0..seg-1 during mid-file
- *  resume. Shares the profile of the main session but lives in its own
- *  map entry so the main session's startSegment doesn't trip over the
- *  early process writing the beginning of the file. */
-export function earlySessionKey(
-  mediaFileId: number,
-  userId: number | undefined,
-  profileHash: string,
-): string {
-  return `${sessionKey(mediaFileId, userId, profileHash)}-early`;
+  return `${mediaFileId}-${userSeg}-${cacheKey}`;
 }

--- a/backend/src/modules/streaming/transcoding/session-key.ts
+++ b/backend/src/modules/streaming/transcoding/session-key.ts
@@ -1,19 +1,38 @@
-/** Build the session map key: one transcode per user per file. */
-export function sessionKey(mediaFileId: number, userId?: number): string {
-  return userId != null ? `${mediaFileId}-u${userId}` : `${mediaFileId}-anon`;
+/**
+ * Session map key for a transcode job. A single `(file, user)` pair can
+ * carry multiple concurrent sessions, one per {@link profileHash}
+ * (different devices producing byte-incompatible streams from the same
+ * source). The hash segment makes those entries live as siblings in the
+ * `sessions` map without colliding, and matches the on-disk cache
+ * layout owned by `TranscodeCacheService`.
+ */
+export function sessionKey(
+  mediaFileId: number,
+  userId: number | undefined,
+  profileHash: string,
+): string {
+  const userSeg = userId != null ? `u${userId}` : 'anon';
+  return `${mediaFileId}-${userSeg}-${profileHash}`;
 }
 
-/** Build audio session key: separate audio-only session per audio track index. */
+/** Audio-only HLS session, one per (file, user, profile, audioIndex). */
 export function audioSessionKey(
   mediaFileId: number,
   audioIndex: number,
-  userId?: number,
+  userId: number | undefined,
+  profileHash: string,
 ): string {
-  return `${sessionKey(mediaFileId, userId)}-a${audioIndex}`;
+  return `${sessionKey(mediaFileId, userId, profileHash)}-a${audioIndex}`;
 }
 
-/** Build early-segment session key: short-lived parallel ffmpeg producing
- *  seg-0..seg-1 while the main prewarm session encodes from seg-K (resume). */
-export function earlySessionKey(mediaFileId: number, userId?: number): string {
-  return `${sessionKey(mediaFileId, userId)}-early`;
+/** Short-lived parallel ffmpeg producing seg-0..seg-1 during mid-file
+ *  resume. Shares the profile of the main session but lives in its own
+ *  map entry so the main session's startSegment doesn't trip over the
+ *  early process writing the beginning of the file. */
+export function earlySessionKey(
+  mediaFileId: number,
+  userId: number | undefined,
+  profileHash: string,
+): string {
+  return `${sessionKey(mediaFileId, userId, profileHash)}-early`;
 }

--- a/backend/src/modules/streaming/transcoding/transcode-cache.service.spec.ts
+++ b/backend/src/modules/streaming/transcoding/transcode-cache.service.spec.ts
@@ -1,0 +1,140 @@
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import type { CacheEntry, QualityCache } from './transcode-cache.service';
+import { TranscodeCacheService } from './transcode-cache.service';
+
+const CACHE_ROOT = path.join('/tmp/transcode', 'cache');
+
+async function writeFile(p: string, size: number): Promise<void> {
+  await fsp.mkdir(path.dirname(p), { recursive: true });
+  await fsp.writeFile(p, Buffer.alloc(size, 0));
+}
+
+async function resetCacheRoot(): Promise<void> {
+  await fsp.rm(CACHE_ROOT, { recursive: true, force: true });
+  await fsp.mkdir(CACHE_ROOT, { recursive: true });
+}
+
+describe('TranscodeCacheService', () => {
+  let svc: TranscodeCacheService;
+
+  beforeEach(async () => {
+    await resetCacheRoot();
+    svc = new TranscodeCacheService();
+  });
+
+  afterEach(() => {
+    svc.onModuleDestroy();
+  });
+
+  it('starts with an empty index when the cache root is empty', async () => {
+    await svc.onModuleInit();
+    expect(svc.size()).toBe(0);
+    expect(svc.totalBytes()).toBe(0);
+  });
+
+  it('indexes existing cache directories on init', async () => {
+    const dir = path.join(CACHE_ROOT, 'u42', '1234', 'a1b2c3d4e5', '720p');
+    await writeFile(path.join(dir, 'init.mp4'), 100);
+    await writeFile(path.join(dir, 'seg-0.m4s'), 1000);
+    await writeFile(path.join(dir, 'seg-1.m4s'), 2000);
+    await writeFile(path.join(dir, 'seg-3.m4s'), 1500);
+
+    await svc.onModuleInit();
+    expect(svc.size()).toBe(1);
+
+    const entry = svc.lookup(42, 1234, 'a1b2c3d4e5');
+    expect(entry).not.toBeNull();
+    expect(entry!.totalBytes).toBe(100 + 1000 + 2000 + 1500);
+    const q = entry!.perQuality.get('720p');
+    expect(q?.hasInit).toBe(true);
+    expect([...(q?.segments ?? [])].sort((a, b) => a - b)).toEqual([0, 1, 3]);
+  });
+
+  it('indexes ts and m4s segments interchangeably', async () => {
+    const dir = path.join(CACHE_ROOT, 'u1', '99', 'aaaaaaaaaa', '1080p');
+    await writeFile(path.join(dir, 'seg-0.ts'), 500);
+    await writeFile(path.join(dir, 'seg-1.ts'), 500);
+    await svc.onModuleInit();
+    const entry = svc.lookup(1, 99, 'aaaaaaaaaa');
+    expect(entry?.perQuality.get('1080p')?.segments.size).toBe(2);
+  });
+
+  it('skips a profile dir that has no init and no segments', async () => {
+    const dir = path.join(CACHE_ROOT, 'u1', '1', 'xxxxxxxxxx', '720p');
+    await fsp.mkdir(dir, { recursive: true });
+    await svc.onModuleInit();
+    expect(svc.size()).toBe(0);
+  });
+
+  it('handles anonymous entries (no user id)', async () => {
+    const dir = path.join(CACHE_ROOT, 'anon', '7', 'bbbbbbbbbb', '480p');
+    await writeFile(path.join(dir, 'seg-0.m4s'), 300);
+    await svc.onModuleInit();
+    expect(svc.lookup(null, 7, 'bbbbbbbbbb')).not.toBeNull();
+  });
+
+  it('records a segment write and updates totals', async () => {
+    await svc.onModuleInit();
+    const dir = path.join(CACHE_ROOT, 'u5', '8', 'cccccccccc');
+    const entry: CacheEntry = {
+      userId: 5,
+      mediaFileId: 8,
+      profileHash: 'cccccccccc',
+      cacheDir: dir,
+      perQuality: new Map<string, QualityCache>(),
+      totalBytes: 0,
+      lastAccess: Date.now(),
+    };
+    svc.recordSegmentWritten(entry, '720p', 0, 1024);
+    svc.recordSegmentWritten(entry, '720p', 1, 2048);
+    svc.recordSegmentWritten(entry, '720p', 0, 9999); // duplicate, ignored
+    expect(entry.totalBytes).toBe(3072);
+    expect(entry.perQuality.get('720p')?.segments.size).toBe(2);
+  });
+
+  it('evicts entries past their TTL on gc', async () => {
+    const dir = path.join(CACHE_ROOT, 'u1', '1', 'dddddddddd', '720p');
+    await writeFile(path.join(dir, 'seg-0.m4s'), 1000);
+    await svc.onModuleInit();
+    const entry = svc.lookup(1, 1, 'dddddddddd')!;
+    entry.lastAccess = Date.now() - 10 * 60 * 60 * 1000; // 10 h ago, TTL default 4 h
+    await svc.runGc();
+    expect(svc.size()).toBe(0);
+    await expect(fsp.access(entry.cacheDir)).rejects.toBeDefined();
+  });
+
+  it('keeps fresh entries through gc', async () => {
+    const dir = path.join(CACHE_ROOT, 'u1', '1', 'eeeeeeeeee', '720p');
+    await writeFile(path.join(dir, 'seg-0.m4s'), 1000);
+    await svc.onModuleInit();
+    await svc.runGc();
+    expect(svc.size()).toBe(1);
+  });
+});
+
+describe('TranscodeCacheService env overrides', () => {
+  const ENV = process.env;
+  beforeEach(() => {
+    process.env = { ...ENV };
+  });
+  afterEach(() => {
+    process.env = ENV;
+  });
+
+  it('honours TRANSCODE_CACHE_TTL_MS', () => {
+    process.env.TRANSCODE_CACHE_TTL_MS = '1000';
+    const svc = new TranscodeCacheService();
+    // No public getter; assert by behaviour: a brand-new entry with
+    // lastAccess of 2 s ago should be evicted under the 1 s TTL.
+    expect((svc as unknown as { ttlMs: number }).ttlMs).toBe(1000);
+  });
+
+  it('falls back to default when env is unparseable', () => {
+    process.env.TRANSCODE_CACHE_TTL_MS = 'not-a-number';
+    const svc = new TranscodeCacheService();
+    expect((svc as unknown as { ttlMs: number }).ttlMs).toBe(
+      4 * 60 * 60 * 1000,
+    );
+  });
+});

--- a/backend/src/modules/streaming/transcoding/transcode-cache.service.spec.ts
+++ b/backend/src/modules/streaming/transcoding/transcode-cache.service.spec.ts
@@ -111,6 +111,37 @@ describe('TranscodeCacheService', () => {
     await svc.runGc();
     expect(svc.size()).toBe(1);
   });
+
+  it('cachePathFor composes the expected directory shape', async () => {
+    await svc.onModuleInit();
+    expect(svc.cachePathFor(42, 7, 'a1b2c3d4e5', '1080p')).toBe(
+      path.join(CACHE_ROOT, 'u42', '7', 'a1b2c3d4e5', '1080p'),
+    );
+    expect(svc.cachePathFor(null, 7, 'a1b2c3d4e5')).toBe(
+      path.join(CACHE_ROOT, 'anon', '7', 'a1b2c3d4e5'),
+    );
+  });
+
+  it('ensureEntry creates a new entry on miss and reuses on hit', async () => {
+    await svc.onModuleInit();
+    const a = svc.ensureEntry(3, 11, 'ffffffffff');
+    const b = svc.ensureEntry(3, 11, 'ffffffffff');
+    expect(a).toBe(b);
+    expect(svc.size()).toBe(1);
+    expect(svc.lookup(3, 11, 'ffffffffff')).toBe(a);
+  });
+
+  it('drops entries whose dir was wiped externally on gc', async () => {
+    const dir = path.join(CACHE_ROOT, 'u1', '1', 'gggggggggg', '720p');
+    await writeFile(path.join(dir, 'seg-0.m4s'), 1000);
+    await svc.onModuleInit();
+    expect(svc.size()).toBe(1);
+    const entry = svc.lookup(1, 1, 'gggggggggg')!;
+    // Simulate TranscodingService wiping the dir without notifying us.
+    await fsp.rm(entry.cacheDir, { recursive: true, force: true });
+    await svc.runGc();
+    expect(svc.size()).toBe(0);
+  });
 });
 
 describe('TranscodeCacheService env overrides', () => {

--- a/backend/src/modules/streaming/transcoding/transcode-cache.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcode-cache.service.ts
@@ -159,11 +159,27 @@ export class TranscodeCacheService implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
-   * Garbage collection pass. Evicts by TTL first; if total size remains
-   * above {@link maxBytes}, evicts least-recently-used entries until
-   * back under the threshold.
+   * Garbage collection pass. Three passes in order:
+   * 1. Drop entries whose on-disk dir has been wiped externally (the
+   *    transcoding service still owns lifecycle in phase 2).
+   * 2. Evict by TTL.
+   * 3. Evict least-recently-used until total bytes back under cap.
    */
   async runGc(): Promise<void> {
+    const orphans: CacheEntry[] = [];
+    for (const entry of this.entries.values()) {
+      try {
+        await fsp.access(entry.cacheDir);
+      } catch {
+        orphans.push(entry);
+      }
+    }
+    for (const entry of orphans) {
+      this.entries.delete(
+        entryKey(entry.userId, entry.mediaFileId, entry.profileHash),
+      );
+    }
+
     const now = Date.now();
     const expired: CacheEntry[] = [];
     for (const entry of this.entries.values()) {
@@ -201,6 +217,54 @@ export class TranscodeCacheService implements OnModuleInit, OnModuleDestroy {
   /** Visible for tests. */
   cacheRoot(): string {
     return CACHE_LAYOUT_ROOT;
+  }
+
+  /**
+   * Absolute directory where the segments for this (user, file, profile,
+   * quality) tuple should be written. The transcoding service uses this
+   * to spawn ffmpeg's HLS muxer at the right path.
+   */
+  cachePathFor(
+    userId: number | null,
+    mediaFileId: number,
+    profileHash: string,
+    quality?: string,
+  ): string {
+    const userSeg = userId == null ? 'anon' : `u${userId}`;
+    const base = path.join(
+      CACHE_LAYOUT_ROOT,
+      userSeg,
+      String(mediaFileId),
+      profileHash,
+    );
+    return quality ? path.join(base, quality) : base;
+  }
+
+  /**
+   * Return the in-memory entry for this triple, creating an empty one
+   * on miss. Used by the transcoding service when a fresh ffmpeg job
+   * starts writing into a new cache directory — subsequent
+   * {@link recordSegmentWritten} calls land on the same entry.
+   */
+  ensureEntry(
+    userId: number | null,
+    mediaFileId: number,
+    profileHash: string,
+  ): CacheEntry {
+    const key = entryKey(userId, mediaFileId, profileHash);
+    const existing = this.entries.get(key);
+    if (existing) return existing;
+    const entry: CacheEntry = {
+      userId,
+      mediaFileId,
+      profileHash,
+      cacheDir: this.cachePathFor(userId, mediaFileId, profileHash),
+      perQuality: new Map(),
+      totalBytes: 0,
+      lastAccess: Date.now(),
+    };
+    this.entries.set(key, entry);
+    return entry;
   }
 
   private async rebuildIndex(): Promise<void> {

--- a/backend/src/modules/streaming/transcoding/transcode-cache.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcode-cache.service.ts
@@ -48,10 +48,11 @@ function readEnvInt(name: string, fallback: number): number {
 }
 
 /**
- * Read-only index of the on-disk transcode cache. Phase 1: scans the
- * cache root at boot to build the in-memory index but does not yet
- * serve segments or respond to job writes. Lookup / GC plumbing is in
- * place so later phases can wire it without changing the public shape.
+ * In-memory index of the on-disk transcode cache. Scans the cache root
+ * at boot, tracks segment / init writes as `TranscodingService` fans
+ * them out, evicts entries by TTL + LRU. `lookup` returns the
+ * authoritative entry the streaming controller can serve from before
+ * spawning a fresh ffmpeg.
  */
 @Injectable()
 export class TranscodeCacheService implements OnModuleInit, OnModuleDestroy {
@@ -160,8 +161,8 @@ export class TranscodeCacheService implements OnModuleInit, OnModuleDestroy {
 
   /**
    * Garbage collection pass. Three passes in order:
-   * 1. Drop entries whose on-disk dir has been wiped externally (the
-   *    transcoding service still owns lifecycle in phase 2).
+   * 1. Drop entries whose on-disk dir has been wiped externally
+   *    (kept in sync with the transcoding service's own cleanup paths).
    * 2. Evict by TTL.
    * 3. Evict least-recently-used until total bytes back under cap.
    */

--- a/backend/src/modules/streaming/transcoding/transcode-cache.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcode-cache.service.ts
@@ -1,0 +1,355 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { TRANSCODE_DIR } from '../../../common/constants/paths';
+
+/**
+ * Index entry for one cache directory. A cache directory holds every
+ * quality rendition that was transcoded for a single
+ * (userId, mediaFileId, profileHash) tuple. Quality renditions sit
+ * under {@link cacheDir} as subdirectories.
+ */
+export interface CacheEntry {
+  userId: number | null;
+  mediaFileId: number;
+  profileHash: string;
+  cacheDir: string;
+  perQuality: Map<string, QualityCache>;
+  totalBytes: number;
+  lastAccess: number;
+}
+
+export interface QualityCache {
+  quality: string;
+  hasInit: boolean;
+  segments: Set<number>;
+  bytes: number;
+}
+
+const CACHE_LAYOUT_ROOT = path.join(TRANSCODE_DIR, 'cache');
+
+/** Default 4 h since last access. */
+const DEFAULT_CACHE_TTL_MS = 4 * 60 * 60 * 1000;
+/** Default 20 GB. */
+const DEFAULT_CACHE_MAX_BYTES = 20 * 1024 * 1024 * 1024;
+/** Default GC tick 5 min. */
+const DEFAULT_CACHE_GC_INTERVAL_MS = 5 * 60 * 1000;
+
+function readEnvInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * Read-only index of the on-disk transcode cache. Phase 1: scans the
+ * cache root at boot to build the in-memory index but does not yet
+ * serve segments or respond to job writes. Lookup / GC plumbing is in
+ * place so later phases can wire it without changing the public shape.
+ */
+@Injectable()
+export class TranscodeCacheService implements OnModuleInit, OnModuleDestroy {
+  private readonly log = new Logger(TranscodeCacheService.name);
+  private readonly entries = new Map<string, CacheEntry>();
+  private gcTimer: ReturnType<typeof setInterval> | null = null;
+
+  private readonly ttlMs = readEnvInt(
+    'TRANSCODE_CACHE_TTL_MS',
+    DEFAULT_CACHE_TTL_MS,
+  );
+  private readonly maxBytes = readEnvInt(
+    'TRANSCODE_CACHE_MAX_BYTES',
+    DEFAULT_CACHE_MAX_BYTES,
+  );
+  private readonly gcIntervalMs = readEnvInt(
+    'TRANSCODE_CACHE_GC_INTERVAL_MS',
+    DEFAULT_CACHE_GC_INTERVAL_MS,
+  );
+
+  async onModuleInit(): Promise<void> {
+    await fsp.mkdir(CACHE_LAYOUT_ROOT, { recursive: true });
+    await this.rebuildIndex();
+    this.gcTimer = setInterval(() => {
+      this.runGc().catch((err) =>
+        this.log.warn(`gc tick failed: ${(err as Error).message}`),
+      );
+    }, this.gcIntervalMs);
+  }
+
+  onModuleDestroy(): void {
+    if (this.gcTimer) {
+      clearInterval(this.gcTimer);
+      this.gcTimer = null;
+    }
+  }
+
+  /** Resolve the entry for a (user, file, profile) triple, or null. */
+  lookup(
+    userId: number | null,
+    mediaFileId: number,
+    profileHash: string,
+  ): CacheEntry | null {
+    return this.entries.get(entryKey(userId, mediaFileId, profileHash)) ?? null;
+  }
+
+  /** Refresh `lastAccess` on a cache hit. */
+  touch(entry: CacheEntry): void {
+    entry.lastAccess = Date.now();
+  }
+
+  /**
+   * Record that the ffmpeg job just finished writing a segment. Creates
+   * the {@link QualityCache} entry on first call. Used by later phases
+   * once the job manager is wired through this service.
+   */
+  recordSegmentWritten(
+    entry: CacheEntry,
+    quality: string,
+    segIndex: number,
+    sizeBytes: number,
+  ): void {
+    let q = entry.perQuality.get(quality);
+    if (!q) {
+      q = { quality, hasInit: false, segments: new Set(), bytes: 0 };
+      entry.perQuality.set(quality, q);
+    }
+    if (!q.segments.has(segIndex)) {
+      q.segments.add(segIndex);
+      q.bytes += sizeBytes;
+      entry.totalBytes += sizeBytes;
+    }
+    entry.lastAccess = Date.now();
+  }
+
+  /** Record presence of the init.mp4 / init_N.mp4 for a quality. */
+  recordInitWritten(
+    entry: CacheEntry,
+    quality: string,
+    sizeBytes: number,
+  ): void {
+    let q = entry.perQuality.get(quality);
+    if (!q) {
+      q = { quality, hasInit: false, segments: new Set(), bytes: 0 };
+      entry.perQuality.set(quality, q);
+    }
+    if (!q.hasInit) {
+      q.hasInit = true;
+      q.bytes += sizeBytes;
+      entry.totalBytes += sizeBytes;
+    }
+    entry.lastAccess = Date.now();
+  }
+
+  /**
+   * Drop an entry from the index AND wipe its directory on disk.
+   * Used by GC; later phases also invoke on explicit user stop when
+   * no other live session references the entry.
+   */
+  async evict(entry: CacheEntry): Promise<void> {
+    this.entries.delete(
+      entryKey(entry.userId, entry.mediaFileId, entry.profileHash),
+    );
+    await fsp.rm(entry.cacheDir, { recursive: true, force: true });
+  }
+
+  /**
+   * Garbage collection pass. Evicts by TTL first; if total size remains
+   * above {@link maxBytes}, evicts least-recently-used entries until
+   * back under the threshold.
+   */
+  async runGc(): Promise<void> {
+    const now = Date.now();
+    const expired: CacheEntry[] = [];
+    for (const entry of this.entries.values()) {
+      if (now - entry.lastAccess > this.ttlMs) expired.push(entry);
+    }
+    for (const entry of expired) {
+      await this.evict(entry);
+    }
+
+    let total = this.totalBytes();
+    if (total <= this.maxBytes) return;
+
+    const lru = [...this.entries.values()].sort(
+      (a, b) => a.lastAccess - b.lastAccess,
+    );
+    for (const entry of lru) {
+      if (total <= this.maxBytes) break;
+      total -= entry.totalBytes;
+      await this.evict(entry);
+    }
+  }
+
+  /** Sum of on-disk bytes across every indexed entry. */
+  totalBytes(): number {
+    let n = 0;
+    for (const entry of this.entries.values()) n += entry.totalBytes;
+    return n;
+  }
+
+  /** Visible for tests / metrics. */
+  size(): number {
+    return this.entries.size;
+  }
+
+  /** Visible for tests. */
+  cacheRoot(): string {
+    return CACHE_LAYOUT_ROOT;
+  }
+
+  private async rebuildIndex(): Promise<void> {
+    this.entries.clear();
+    let userDirs: string[];
+    try {
+      userDirs = await fsp.readdir(CACHE_LAYOUT_ROOT);
+    } catch {
+      return;
+    }
+
+    for (const userDir of userDirs) {
+      const userId = parseUserDir(userDir);
+      if (userId === undefined) continue;
+      const userPath = path.join(CACHE_LAYOUT_ROOT, userDir);
+      let mediaDirs: string[];
+      try {
+        mediaDirs = await fsp.readdir(userPath);
+      } catch {
+        continue;
+      }
+      for (const mediaDir of mediaDirs) {
+        const mediaFileId = Number.parseInt(mediaDir, 10);
+        if (!Number.isFinite(mediaFileId)) continue;
+        const mediaPath = path.join(userPath, mediaDir);
+        let profileDirs: string[];
+        try {
+          profileDirs = await fsp.readdir(mediaPath);
+        } catch {
+          continue;
+        }
+        for (const profileHash of profileDirs) {
+          const cacheDir = path.join(mediaPath, profileHash);
+          const entry = await this.indexEntry(
+            userId,
+            mediaFileId,
+            profileHash,
+            cacheDir,
+          );
+          if (entry) {
+            this.entries.set(entryKey(userId, mediaFileId, profileHash), entry);
+          }
+        }
+      }
+    }
+
+    if (this.entries.size > 0) {
+      this.log.log(
+        `[disk] indexed ${this.entries.size} cache entr${this.entries.size === 1 ? 'y' : 'ies'} (${formatBytes(this.totalBytes())})`,
+      );
+    }
+  }
+
+  private async indexEntry(
+    userId: number | null,
+    mediaFileId: number,
+    profileHash: string,
+    cacheDir: string,
+  ): Promise<CacheEntry | null> {
+    const perQuality = new Map<string, QualityCache>();
+    let totalBytes = 0;
+    let lastAccess = 0;
+
+    let qualityDirs: string[];
+    try {
+      qualityDirs = await fsp.readdir(cacheDir);
+    } catch {
+      return null;
+    }
+
+    for (const quality of qualityDirs) {
+      const qualityPath = path.join(cacheDir, quality);
+      const q: QualityCache = {
+        quality,
+        hasInit: false,
+        segments: new Set(),
+        bytes: 0,
+      };
+      let files: string[];
+      try {
+        files = await fsp.readdir(qualityPath);
+      } catch {
+        continue;
+      }
+      for (const f of files) {
+        const segIndex = parseSegmentIndex(f);
+        const filePath = path.join(qualityPath, f);
+        let size = 0;
+        let mtime = 0;
+        try {
+          const stat = await fsp.stat(filePath);
+          size = stat.size;
+          mtime = stat.mtimeMs;
+        } catch {
+          continue;
+        }
+        if (f === 'init.mp4' || /^init_\d+\.mp4$/.test(f)) {
+          q.hasInit = true;
+        } else if (segIndex !== null) {
+          q.segments.add(segIndex);
+        } else {
+          continue;
+        }
+        q.bytes += size;
+        totalBytes += size;
+        if (mtime > lastAccess) lastAccess = mtime;
+      }
+      if (q.hasInit || q.segments.size > 0) {
+        perQuality.set(quality, q);
+      }
+    }
+
+    if (perQuality.size === 0) return null;
+    return {
+      userId,
+      mediaFileId,
+      profileHash,
+      cacheDir,
+      perQuality,
+      totalBytes,
+      lastAccess: lastAccess || Date.now(),
+    };
+  }
+}
+
+function entryKey(
+  userId: number | null,
+  mediaFileId: number,
+  profileHash: string,
+): string {
+  return `${userId ?? 'anon'}::${mediaFileId}::${profileHash}`;
+}
+
+function parseUserDir(dir: string): number | null | undefined {
+  if (dir === 'anon') return null;
+  const m = /^u(\d+)$/.exec(dir);
+  if (!m) return undefined;
+  return Number.parseInt(m[1], 10);
+}
+
+function parseSegmentIndex(filename: string): number | null {
+  const m = /^seg-(\d+)\.(?:m4s|ts)$/.exec(filename);
+  if (!m) return null;
+  return Number.parseInt(m[1], 10);
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -50,6 +50,11 @@ import {
   segmentNearby,
 } from './segment-utils';
 import { audioSessionKey, earlySessionKey, sessionKey } from './session-key';
+import {
+  buildPlaybackProfileFromContext,
+  computeProfileHash,
+} from './profile-hash';
+import { TranscodeCacheService } from './transcode-cache.service';
 import type {
   BurnInSubtitle,
   DeviceType,
@@ -68,34 +73,39 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
   private readonly locks = new Map<string, Promise<void>>();
   private cleanupTimer: ReturnType<typeof setInterval> | null = null;
   private detectedHwAccel: HwAccelType = 'none';
-  private cachePath = path.join(TRANSCODE_DIR, 'stream');
+  /** Legacy on-disk cache root, kept around solely to wipe leftovers from
+   *  pre-refactor deployments. The new layout lives under
+   *  {@link TranscodeCacheService.cacheRoot}. */
+  private readonly legacyCachePath = path.join(TRANSCODE_DIR, 'stream');
+
+  constructor(private readonly cacheService: TranscodeCacheService) {}
 
   async onModuleInit() {
-    await fsp.mkdir(this.cachePath, { recursive: true });
-
-    // The in-memory `sessions` map only knows about live sessions. After a
-    // backend restart the map starts empty, so any directory still under
-    // `cachePath` is an orphan — written by a previous process that is no
-    // longer alive to evict it. Wipe them so a re-load on the same
-    // (mediaFileId, userId) starts from a clean slate instead of inheriting
-    // partial / overflow segments from the previous run.
+    // Wipe the legacy /tmp/transcode/stream directory from older
+    // deployments. The new TranscodeCacheService owns
+    // /tmp/transcode/cache and manages its own lifecycle.
     try {
-      const entries = await fsp.readdir(this.cachePath);
+      const entries = await fsp.readdir(this.legacyCachePath);
       if (entries.length) {
         await Promise.all(
           entries.map((e) =>
-            fsp.rm(path.join(this.cachePath, e), {
+            fsp.rm(path.join(this.legacyCachePath, e), {
               recursive: true,
               force: true,
             }),
           ),
         );
         this.log.log(
-          `[disk] init wipe: removed ${entries.length} orphan session dir(s)`,
+          `[disk] legacy wipe: removed ${entries.length} orphan dir(s) from /tmp/transcode/stream`,
         );
       }
+      await fsp.rm(this.legacyCachePath, { recursive: true, force: true });
     } catch (err) {
-      this.log.warn(`[disk] init wipe failed: ${(err as Error).message}`);
+      // Directory may not exist — fine, nothing to clean up.
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') {
+        this.log.warn(`[disk] legacy wipe failed: ${(err as Error).message}`);
+      }
     }
 
     this.detectedHwAccel = await detectHwAccel(this.log);
@@ -200,6 +210,53 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
 
   getActiveSessions(): TranscodeSession[] {
     return Array.from(this.sessions.values());
+  }
+
+  /**
+   * Resolve the on-disk cache directory for a session variant. Wraps
+   * the {@link TranscodeCacheService} layout so every spawn site goes
+   * through one place. Returns both the directory and the profile hash
+   * that produced it — the hash is stashed on the session for later
+   * lookups.
+   */
+  private cacheDirFor(
+    ctx: SessionContext | undefined,
+    mediaFileId: number,
+    variant: 'main' | 'early' | 'remux' | { audio: number },
+    quality?: string,
+  ): { dir: string; profileHash: string } {
+    const baseProfile = buildPlaybackProfileFromContext(
+      ctx,
+      getSegmentDuration() * 1000,
+    );
+    const baseHash = computeProfileHash(baseProfile);
+    let hash: string;
+    if (variant === 'main') hash = baseHash;
+    else if (variant === 'early') hash = `${baseHash}-early`;
+    else if (variant === 'remux') hash = `${baseHash}-remux`;
+    else hash = `${baseHash}-a${variant.audio}`;
+    const dir = this.cacheService.cachePathFor(
+      ctx?.userId ?? null,
+      mediaFileId,
+      hash,
+      quality,
+    );
+    return { dir, profileHash: hash };
+  }
+
+  /** Absolute path to the `(userId, mediaFileId)` parent dir under the
+   *  new cache root. Used by full-session cleanup which wipes every
+   *  profile variant for a given user-file pair. */
+  private userFileParentDir(
+    mediaFileId: number,
+    userId: number | undefined,
+  ): string {
+    const userSeg = userId == null ? 'anon' : `u${userId}`;
+    return path.join(
+      this.cacheService.cacheRoot(),
+      userSeg,
+      String(mediaFileId),
+    );
   }
 
   /**
@@ -447,14 +504,19 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         );
         if (resolved) return resolved;
         const restartAt = existing.startSegment ?? requestedSegment;
-        const dir = path.join(this.cachePath, key, quality);
+        const { dir, profileHash } = this.cacheDirFor(
+          ctx,
+          mediaFileId,
+          'main',
+          quality,
+        );
         await fsp.mkdir(dir, { recursive: true });
         if (useVarStreamMap) {
           for (let i = 0; i <= ctxAudioStreams.length; i++) {
             await fsp.mkdir(path.join(dir, String(i)), { recursive: true });
           }
         }
-        return this.startSeekSession(
+        const restarted = this.startSeekSession(
           key,
           mediaFileId,
           quality,
@@ -463,6 +525,8 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
           restartAt,
           ctx,
         );
+        restarted.profileHash = profileHash;
+        return restarted;
       }
     }
 
@@ -470,7 +534,12 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       ? getHdrLadderForDevice(ctx?.deviceType)
       : getLadderForDevice(ctx?.deviceType);
     const profile = ladder.find((p) => p.name === quality) ?? ladder[0];
-    const sessionDir = path.join(this.cachePath, key, quality);
+    const { dir: sessionDir, profileHash } = this.cacheDirFor(
+      ctx,
+      mediaFileId,
+      'main',
+      quality,
+    );
     const dirExisted = existsSync(sessionDir);
     await fsp.mkdir(sessionDir, { recursive: true });
     this.log.log(
@@ -493,6 +562,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       requestedSegment,
       ctx,
     );
+    session.profileHash = profileHash;
     this.applyContext(session, ctx);
 
     return session;
@@ -622,7 +692,12 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         ? getHdrLadderForDevice(ctx?.deviceType)
         : getLadderForDevice(ctx?.deviceType);
       const profile = ladder.find((p) => p.name === quality) ?? ladder[0];
-      const sessionDir = path.join(this.cachePath, id, quality);
+      const { dir: sessionDir, profileHash } = this.cacheDirFor(
+        ctx,
+        mediaFileId,
+        'early',
+        quality,
+      );
       const dirExisted = existsSync(sessionDir);
       await fsp.mkdir(sessionDir, { recursive: true });
       this.log.log(
@@ -688,6 +763,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         segSubDir: usesVarStreamMap ? '0' : undefined,
         extra: { actualHwAccel: this.detectedHwAccel },
       });
+      session.profileHash = profileHash;
       this.applyContext(session, ctx);
       return session;
     });
@@ -1051,27 +1127,30 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       }
     }
     await Promise.all(promises);
-    // Parent-dir rm is serialised under the same per-key lock as
-    // getOrCreate to close a race: without the lock, a new session
-    // could enter getOrCreate between the `has(key)` probe below and
-    // the (previously async, fire-and-forget) rm completing, and the
-    // recursive rm would then wipe the new session's fresh segments.
-    // The lock makes "either rm the parent OR start a new session"
-    // atomic per key.
-    await this.removeParentDirIfIdle(key);
-    await this.removeParentDirIfIdle(earlyKey);
+    // Parent-dir rm is serialised under the main session's per-key lock
+    // (the same lock getOrCreate uses) so a fresh session entering
+    // mid-cleanup can't see its cache wiped from under it. The lock
+    // makes "either rm the user-file dir OR start a new session"
+    // atomic.
+    await this.removeUserFileDirIfIdle(mediaFileId, userId);
   }
 
-  private async removeParentDirIfIdle(key: string): Promise<void> {
-    await this.withLock(key, async () => {
-      if (this.sessions.has(key)) {
-        const parentDir = path.join(this.cachePath, key);
+  private async removeUserFileDirIfIdle(
+    mediaFileId: number,
+    userId: number | undefined,
+  ): Promise<void> {
+    const lockKey = sessionKey(mediaFileId, userId);
+    await this.withLock(lockKey, async () => {
+      const stillActive = [...this.sessions.values()].some(
+        (s) => s.mediaFileId === mediaFileId && s.userId === userId,
+      );
+      const parentDir = this.userFileParentDir(mediaFileId, userId);
+      if (stillActive) {
         this.log.log(
-          `[disk] skip rm parent ${parentDir} — session ${key} replaced`,
+          `[disk] skip rm ${parentDir} — sessions still alive for ${lockKey}`,
         );
         return;
       }
-      const parentDir = path.join(this.cachePath, key);
       const existed = existsSync(parentDir);
       this.log.log(`[disk] rm parent ${parentDir} (existed=${existed})`);
       await fsp.rm(parentDir, { recursive: true, force: true }).catch(() => {});
@@ -1150,7 +1229,12 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       }
     }
 
-    const sessionDir = path.join(this.cachePath, key, 'remux');
+    const { dir: sessionDir, profileHash } = this.cacheDirFor(
+      ctx,
+      mediaFileId,
+      'remux',
+      'remux',
+    );
     await fsp.mkdir(sessionDir, { recursive: true });
 
     const isVideoOnly = ctx?.videoOnly ?? false;
@@ -1177,6 +1261,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       startSegment: requestedSegment,
       extra: { remux: true },
     });
+    session.profileHash = profileHash;
 
     this.applyContext(session, ctx);
     return session;
@@ -1246,7 +1331,12 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       }
     }
 
-    const sessionDir = path.join(this.cachePath, key, 'audio');
+    const { dir: sessionDir, profileHash } = this.cacheDirFor(
+      ctx,
+      mediaFileId,
+      { audio: audioIndex },
+      'audio',
+    );
     await fsp.mkdir(sessionDir, { recursive: true });
 
     const args = buildAudioOnlyFfmpegArgs(
@@ -1271,6 +1361,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       segExt: ctx?.useTs ? '.ts' : undefined,
       extra: { isAudioOnly: true },
     });
+    session.profileHash = profileHash;
 
     this.applyContext(session, ctx);
     return session;

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -49,12 +49,19 @@ import {
   firstMissingSegment,
   segmentNearby,
 } from './segment-utils';
-import { audioSessionKey, earlySessionKey, sessionKey } from './session-key';
+import { sessionKey } from './session-key';
 import {
   buildPlaybackProfileFromContext,
   computeProfileHash,
 } from './profile-hash';
 import { TranscodeCacheService } from './transcode-cache.service';
+import {
+  VARIANT_EARLY,
+  VARIANT_MAIN,
+  VARIANT_REMUX,
+  type SessionVariant,
+  variantHash,
+} from './variant';
 import type {
   BurnInSubtitle,
   DeviceType,
@@ -121,26 +128,18 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     this.cleanupTimer = setInterval(() => this.cleanupStaleSessions(), 10_000);
   }
 
-  /** Get an existing session for an exact `(file, user, profile)` triple.
-   *  Returns `undefined` if no matching session is registered — caller
-   *  should fall back to creating one. */
+  /** Get an existing session for an exact `(file, user, base hash,
+   *  variant)` tuple. Variant defaults to `main`; pass {@link VARIANT_EARLY}
+   *  for the early companion, etc. */
   getExistingSession(
     mediaFileId: number,
     userId: number | undefined,
-    profileHash: string,
+    baseHash: string,
+    variant: SessionVariant = VARIANT_MAIN,
   ): TranscodeSession | undefined {
-    return this.sessions.get(sessionKey(mediaFileId, userId, profileHash));
-  }
-
-  /** Get the short-lived early-segment companion session (if any). Lives in
-   *  parallel to the main session during a mid-file resume — same profile
-   *  hash as its main counterpart, scoped on its own map entry. */
-  getExistingEarlySession(
-    mediaFileId: number,
-    userId: number | undefined,
-    profileHash: string,
-  ): TranscodeSession | undefined {
-    return this.sessions.get(earlySessionKey(mediaFileId, userId, profileHash));
+    return this.sessions.get(
+      sessionKey(mediaFileId, userId, variantHash(baseHash, variant)),
+    );
   }
 
   /** All transcode sessions registered for a given `(file, user)` pair —
@@ -179,10 +178,11 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     mediaFileId: number,
     ctx: SessionContext | undefined,
   ): TranscodeSession | undefined {
-    return this.getExistingEarlySession(
+    return this.getExistingSession(
       mediaFileId,
       ctx?.userId,
       this.computeProfileHashForCtx(ctx),
+      VARIANT_EARLY,
     );
   }
 
@@ -215,7 +215,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       if (
         s.mediaFileId === mediaFileId &&
         s.userId === userId &&
-        s.id.endsWith('-early')
+        s.variant?.kind === 'early'
       ) {
         if (!best || s.lastAccess > best.lastAccess) best = s;
       }
@@ -283,29 +283,25 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
   /**
    * Resolve the on-disk cache directory for a session variant. Wraps
    * the {@link TranscodeCacheService} layout so every spawn site goes
-   * through one place. Returns both the directory and the profile hash
-   * that produced it — the hash is stashed on the session for later
-   * lookups.
+   * through one place. Returns the directory and the client-level
+   * base profile hash; the caller already holds the `SessionVariant`,
+   * so storing both `baseProfileHash` and `variant` on the session is
+   * enough to recover the cache key via `variantHash`.
    */
   private cacheDirFor(
     ctx: SessionContext | undefined,
     mediaFileId: number,
-    variant: 'main' | 'early' | 'remux' | { audio: number },
+    variant: SessionVariant,
     quality?: string,
-  ): { dir: string; profileHash: string } {
+  ): { dir: string; baseHash: string } {
     const baseHash = this.computeProfileHashForCtx(ctx);
-    let hash: string;
-    if (variant === 'main') hash = baseHash;
-    else if (variant === 'early') hash = `${baseHash}-early`;
-    else if (variant === 'remux') hash = `${baseHash}-remux`;
-    else hash = `${baseHash}-a${variant.audio}`;
     const dir = this.cacheService.cachePathFor(
       ctx?.userId ?? null,
       mediaFileId,
-      hash,
+      variantHash(baseHash, variant),
       quality,
     );
-    return { dir, profileHash: hash };
+    return { dir, baseHash };
   }
 
   /** Absolute path to the `(userId, mediaFileId)` parent dir under the
@@ -569,10 +565,10 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         );
         if (resolved) return resolved;
         const restartAt = existing.startSegment ?? requestedSegment;
-        const { dir, profileHash } = this.cacheDirFor(
+        const { dir, baseHash } = this.cacheDirFor(
           ctx,
           mediaFileId,
-          'main',
+          VARIANT_MAIN,
           quality,
         );
         await fsp.mkdir(dir, { recursive: true });
@@ -590,7 +586,8 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
           restartAt,
           ctx,
         );
-        restarted.profileHash = profileHash;
+        restarted.baseProfileHash = baseHash;
+        restarted.variant = VARIANT_MAIN;
         return restarted;
       }
     }
@@ -599,10 +596,10 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       ? getHdrLadderForDevice(ctx?.deviceType)
       : getLadderForDevice(ctx?.deviceType);
     const profile = ladder.find((p) => p.name === quality) ?? ladder[0];
-    const { dir: sessionDir, profileHash } = this.cacheDirFor(
+    const { dir: sessionDir, baseHash } = this.cacheDirFor(
       ctx,
       mediaFileId,
-      'main',
+      VARIANT_MAIN,
       quality,
     );
     const dirExisted = existsSync(sessionDir);
@@ -627,7 +624,8 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       requestedSegment,
       ctx,
     );
-    session.profileHash = profileHash;
+    session.baseProfileHash = baseHash;
+    session.variant = VARIANT_MAIN;
     this.applyContext(session, ctx);
 
     return session;
@@ -736,8 +734,12 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     absolutePath: string,
     ctx?: SessionContext,
   ): Promise<TranscodeSession> {
-    const profileHash = this.computeProfileHashForCtx(ctx);
-    const id = earlySessionKey(mediaFileId, ctx?.userId, profileHash);
+    const baseHash = this.computeProfileHashForCtx(ctx);
+    const id = sessionKey(
+      mediaFileId,
+      ctx?.userId,
+      variantHash(baseHash, VARIANT_EARLY),
+    );
     return this.withLock(id, async () => {
       const existing = this.sessions.get(id);
       if (existing) {
@@ -758,10 +760,10 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         ? getHdrLadderForDevice(ctx?.deviceType)
         : getLadderForDevice(ctx?.deviceType);
       const profile = ladder.find((p) => p.name === quality) ?? ladder[0];
-      const { dir: sessionDir, profileHash } = this.cacheDirFor(
+      const { dir: sessionDir, baseHash } = this.cacheDirFor(
         ctx,
         mediaFileId,
-        'early',
+        VARIANT_EARLY,
         quality,
       );
       const dirExisted = existsSync(sessionDir);
@@ -829,7 +831,8 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         segSubDir: usesVarStreamMap ? '0' : undefined,
         extra: { actualHwAccel: this.detectedHwAccel },
       });
-      session.profileHash = profileHash;
+      session.baseProfileHash = baseHash;
+      session.variant = VARIANT_EARLY;
       this.applyContext(session, ctx);
       return session;
     });
@@ -1212,10 +1215,15 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     requestedSegment = 0,
     ctx?: SessionContext,
   ): Promise<TranscodeSession> {
-    // Remux variant lives under its own profile bucket so the cache
-    // path matches `cacheDirFor(..., 'remux')`'s `${baseHash}-remux`.
-    const remuxHash = `${this.computeProfileHashForCtx(ctx)}-remux`;
-    const key = sessionKey(mediaFileId, ctx?.userId, remuxHash);
+    // Remux variant lives in its own session-map bucket so its cache
+    // path doesn't collide with a main session for the same base
+    // profile hash.
+    const baseHash = this.computeProfileHashForCtx(ctx);
+    const key = sessionKey(
+      mediaFileId,
+      ctx?.userId,
+      variantHash(baseHash, VARIANT_REMUX),
+    );
     return this.withLock(key, () =>
       this.doGetOrCreateRemuxSession(
         key,
@@ -1257,10 +1265,10 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       }
     }
 
-    const { dir: sessionDir, profileHash } = this.cacheDirFor(
+    const { dir: sessionDir, baseHash: remuxBaseHash } = this.cacheDirFor(
       ctx,
       mediaFileId,
-      'remux',
+      VARIANT_REMUX,
       'remux',
     );
     await fsp.mkdir(sessionDir, { recursive: true });
@@ -1289,7 +1297,8 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       startSegment: requestedSegment,
       extra: { remux: true },
     });
-    session.profileHash = profileHash;
+    session.baseProfileHash = remuxBaseHash;
+    session.variant = VARIANT_REMUX;
 
     this.applyContext(session, ctx);
     return session;
@@ -1306,12 +1315,12 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     requestedSegment = 0,
     ctx?: SessionContext,
   ): Promise<TranscodeSession> {
-    const audioHash = `${this.computeProfileHashForCtx(ctx)}-a${audioIndex}`;
-    const key = audioSessionKey(
+    const baseHash = this.computeProfileHashForCtx(ctx);
+    const variant: SessionVariant = { kind: 'audio', audioIndex };
+    const key = sessionKey(
       mediaFileId,
-      audioIndex,
       ctx?.userId,
-      audioHash,
+      variantHash(baseHash, variant),
     );
     return this.withLock(key, () =>
       this.doGetOrCreateAudioSession(
@@ -1365,10 +1374,10 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       }
     }
 
-    const { dir: sessionDir, profileHash } = this.cacheDirFor(
+    const { dir: sessionDir, baseHash: audioBaseHash } = this.cacheDirFor(
       ctx,
       mediaFileId,
-      { audio: audioIndex },
+      { kind: 'audio', audioIndex },
       'audio',
     );
     await fsp.mkdir(sessionDir, { recursive: true });
@@ -1395,7 +1404,8 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       segExt: ctx?.useTs ? '.ts' : undefined,
       extra: { isAudioOnly: true },
     });
-    session.profileHash = profileHash;
+    session.baseProfileHash = audioBaseHash;
+    session.variant = { kind: 'audio', audioIndex };
 
     this.applyContext(session, ctx);
     return session;
@@ -1427,14 +1437,14 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
   private cleanupStaleSessions() {
     const now = Date.now();
     for (const [id, session] of this.sessions) {
-      if (!session.profileHash) {
+      if (!session.baseProfileHash) {
         this.fallbackIdleCleanup(now, id, session);
         continue;
       }
       const matching = this.liveSessions.listForJob(
         session.userId ?? null,
         session.mediaFileId,
-        baseProfileHash(session.profileHash),
+        session.baseProfileHash,
       );
       if (matching.length > 0) {
         session.seenAnyLiveSession = true;
@@ -1584,13 +1594,3 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
   }
 }
 
-/**
- * Strip a variant suffix (`-early`, `-remux`, `-a<N>`) off a session's
- * profileHash to recover the base hash that the live-session registry
- * tracks. The registry has one entry per client, so every ffmpeg
- * variant produced for that client (main, early, remux, per-audio)
- * should match the same live session by base hash.
- */
-function baseProfileHash(sessionHash: string): string {
-  return sessionHash.replace(/-(?:early|remux|a\d+)$/, '');
-}

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -8,8 +8,6 @@ import { ChildProcess, spawn } from 'child_process';
 import { existsSync, watch, FSWatcher } from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
-import { TRANSCODE_DIR } from '../../../common/constants/paths';
-
 import {
   SEEK_WAIT_THRESHOLD,
   SESSION_TIMEOUT_MS,
@@ -73,40 +71,9 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
   private readonly locks = new Map<string, Promise<void>>();
   private cleanupTimer: ReturnType<typeof setInterval> | null = null;
   private detectedHwAccel: HwAccelType = 'none';
-  /** Legacy on-disk cache root, kept around solely to wipe leftovers from
-   *  pre-refactor deployments. The new layout lives under
-   *  {@link TranscodeCacheService.cacheRoot}. */
-  private readonly legacyCachePath = path.join(TRANSCODE_DIR, 'stream');
-
   constructor(private readonly cacheService: TranscodeCacheService) {}
 
   async onModuleInit() {
-    // Wipe the legacy /tmp/transcode/stream directory from older
-    // deployments. The new TranscodeCacheService owns
-    // /tmp/transcode/cache and manages its own lifecycle.
-    try {
-      const entries = await fsp.readdir(this.legacyCachePath);
-      if (entries.length) {
-        await Promise.all(
-          entries.map((e) =>
-            fsp.rm(path.join(this.legacyCachePath, e), {
-              recursive: true,
-              force: true,
-            }),
-          ),
-        );
-        this.log.log(
-          `[disk] legacy wipe: removed ${entries.length} orphan dir(s) from /tmp/transcode/stream`,
-        );
-      }
-      await fsp.rm(this.legacyCachePath, { recursive: true, force: true });
-    } catch (err) {
-      // Directory may not exist — fine, nothing to clean up.
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code !== 'ENOENT') {
-        this.log.warn(`[disk] legacy wipe failed: ${(err as Error).message}`);
-      }
-    }
 
     this.detectedHwAccel = await detectHwAccel(this.log);
     this.log.log(`Hardware acceleration: ${this.detectedHwAccel}`);

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -1418,21 +1418,34 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
    * `TranscodeCacheService` owns the disk lifecycle (TTL + LRU); a
    * fresh play that lands on the same (user, file, profileHash)
    * reattaches to the existing segments without retranscoding.
+   *
+   * Variant sessions (`-early`, `-remux`, `-a<N>`) ride on the same
+   * live session as their main counterpart — the LiveSessionRegistry
+   * tracks one entry per client, not one per ffmpeg variant — so the
+   * lookup strips the variant suffix before querying.
    */
   private cleanupStaleSessions() {
     const now = Date.now();
     for (const [id, session] of this.sessions) {
-      if (session.userId == null || !session.profileHash) {
+      if (!session.profileHash) {
         this.fallbackIdleCleanup(now, id, session);
         continue;
       }
       const matching = this.liveSessions.listForJob(
-        session.userId,
+        session.userId ?? null,
         session.mediaFileId,
-        session.profileHash,
+        baseProfileHash(session.profileHash),
       );
       if (matching.length > 0) {
         session.seenAnyLiveSession = true;
+        session.zeroLiveSince = null;
+        continue;
+      }
+      // A recent segment fetch keeps the job alive even when the
+      // live-session count is zero — covers transient heartbeat
+      // failures (network blip, throttled background tab) where the
+      // client is still actively pulling bytes.
+      if (now - session.lastAccess < JOB_GRACE_MS) {
         session.zeroLiveSince = null;
         continue;
       }
@@ -1569,4 +1582,15 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     });
     return { resolve, promise };
   }
+}
+
+/**
+ * Strip a variant suffix (`-early`, `-remux`, `-a<N>`) off a session's
+ * profileHash to recover the base hash that the live-session registry
+ * tracks. The registry has one entry per client, so every ffmpeg
+ * variant produced for that client (main, early, remux, per-audio)
+ * should match the same live session by base hash.
+ */
+function baseProfileHash(sessionHash: string): string {
+  return sessionHash.replace(/-(?:early|remux|a\d+)$/, '');
 }

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -9,12 +9,14 @@ import { existsSync, watch, FSWatcher } from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import {
+  JOB_GRACE_MS,
   SEEK_WAIT_THRESHOLD,
   SESSION_TIMEOUT_MS,
   getSegmentDuration,
   segmentIndexToSeconds,
   setSegmentDuration as applySegmentDuration,
 } from './constants';
+import { LiveSessionRegistry } from '../live-session.service';
 import {
   getHdrLadderForDevice,
   getLadderForDevice,
@@ -71,10 +73,12 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
   private readonly locks = new Map<string, Promise<void>>();
   private cleanupTimer: ReturnType<typeof setInterval> | null = null;
   private detectedHwAccel: HwAccelType = 'none';
-  constructor(private readonly cacheService: TranscodeCacheService) {}
+  constructor(
+    private readonly cacheService: TranscodeCacheService,
+    private readonly liveSessions: LiveSessionRegistry,
+  ) {}
 
   async onModuleInit() {
-
     this.detectedHwAccel = await detectHwAccel(this.log);
     this.log.log(`Hardware acceleration: ${this.detectedHwAccel}`);
 
@@ -111,7 +115,10 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       void runTonemapOpenclProbe(this.log);
     }
 
-    this.cleanupTimer = setInterval(() => this.cleanupStaleSessions(), 30_000);
+    // Tight cleanup cadence — paired with the live-session 30 s TTL +
+    // 60 s job grace, this puts ffmpeg death within ~100 s of the last
+    // viewer disappearing.
+    this.cleanupTimer = setInterval(() => this.cleanupStaleSessions(), 10_000);
   }
 
   /** Get an existing session for an exact `(file, user, profile)` triple.
@@ -1394,18 +1401,72 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     return session;
   }
 
+  /**
+   * Reap transcode sessions whose viewers have all gone. Two regimes:
+   *
+   * 1. Sessions paired with a live session ride the heartbeat-driven
+   *    grace timer: as long as `LiveSessionRegistry.listForJob` returns
+   *    at least one entry, the ffmpeg job is kept warm. When the count
+   *    drops to zero, JOB_GRACE_MS later the ffmpeg process is killed.
+   *
+   * 2. Sessions that were never seen with a live session (legacy URL
+   *    fetches, admin scrubbing) fall back to the SESSION_TIMEOUT_MS
+   *    idle window — safe default that mirrors the pre-heartbeat
+   *    behaviour.
+   *
+   * The on-disk cache directory is preserved in both cases.
+   * `TranscodeCacheService` owns the disk lifecycle (TTL + LRU); a
+   * fresh play that lands on the same (user, file, profileHash)
+   * reattaches to the existing segments without retranscoding.
+   */
   private cleanupStaleSessions() {
     const now = Date.now();
     for (const [id, session] of this.sessions) {
-      const processDone = session.process.exitCode !== null;
-      if (now - session.lastAccess > SESSION_TIMEOUT_MS && processDone) {
-        this.log.log(`Cleanup stale session: ${id}`);
-        this.sessions.delete(id);
-        // Cache is preserved across session evictions —
-        // TranscodeCacheService GC owns the disk lifecycle (TTL + LRU)
-        // so a fresh play after this point reattaches to the existing
-        // segments instead of retranscoding.
+      if (session.userId == null || !session.profileHash) {
+        this.fallbackIdleCleanup(now, id, session);
+        continue;
       }
+      const matching = this.liveSessions.listForJob(
+        session.userId,
+        session.mediaFileId,
+        session.profileHash,
+      );
+      if (matching.length > 0) {
+        session.seenAnyLiveSession = true;
+        session.zeroLiveSince = null;
+        continue;
+      }
+      if (!session.seenAnyLiveSession) {
+        this.fallbackIdleCleanup(now, id, session);
+        continue;
+      }
+      if (session.zeroLiveSince == null) {
+        session.zeroLiveSince = now;
+        continue;
+      }
+      if (now - session.zeroLiveSince < JOB_GRACE_MS) continue;
+      this.log.log(
+        `Cleanup session ${id}: no live viewer for ${Math.round(
+          (now - session.zeroLiveSince) / 1000,
+        )}s, killing ffmpeg (cache preserved)`,
+      );
+      this.sessions.delete(id);
+      session.intentionallyKilled = true;
+      void this.killProcess(session.process);
+    }
+  }
+
+  /** Idle-timeout fallback for transcode sessions without a tracked
+   *  live session — kept on the legacy SESSION_TIMEOUT_MS window. */
+  private fallbackIdleCleanup(
+    now: number,
+    id: string,
+    session: TranscodeSession,
+  ): void {
+    const processDone = session.process.exitCode !== null;
+    if (now - session.lastAccess > SESSION_TIMEOUT_MS && processDone) {
+      this.log.log(`Cleanup stale (fallback) session: ${id}`);
+      this.sessions.delete(id);
     }
   }
 

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -147,22 +147,106 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     this.cleanupTimer = setInterval(() => this.cleanupStaleSessions(), 30_000);
   }
 
-  /** Get an existing session without creating or modifying it. */
+  /** Get an existing session for an exact `(file, user, profile)` triple.
+   *  Returns `undefined` if no matching session is registered — caller
+   *  should fall back to creating one. */
   getExistingSession(
     mediaFileId: number,
-    userId?: number,
+    userId: number | undefined,
+    profileHash: string,
   ): TranscodeSession | undefined {
-    const key = sessionKey(mediaFileId, userId);
-    return this.sessions.get(key);
+    return this.sessions.get(sessionKey(mediaFileId, userId, profileHash));
   }
 
   /** Get the short-lived early-segment companion session (if any). Lives in
-   *  parallel to the main session during a mid-file resume. */
+   *  parallel to the main session during a mid-file resume — same profile
+   *  hash as its main counterpart, scoped on its own map entry. */
   getExistingEarlySession(
     mediaFileId: number,
-    userId?: number,
+    userId: number | undefined,
+    profileHash: string,
   ): TranscodeSession | undefined {
-    return this.sessions.get(earlySessionKey(mediaFileId, userId));
+    return this.sessions.get(earlySessionKey(mediaFileId, userId, profileHash));
+  }
+
+  /** All transcode sessions registered for a given `(file, user)` pair —
+   *  one per profile variant. Used by full-file cleanup (`killSession`)
+   *  and by the admin dashboard. */
+  getSessionsForFileUser(
+    mediaFileId: number,
+    userId: number | undefined,
+  ): TranscodeSession[] {
+    const matches: TranscodeSession[] = [];
+    for (const s of this.sessions.values()) {
+      if (s.mediaFileId === mediaFileId && s.userId === userId) {
+        matches.push(s);
+      }
+    }
+    return matches;
+  }
+
+  /** Convenience lookup: derives the profile hash from the supplied
+   *  context and returns the matching session, if any. Use this from
+   *  segment-serving routes where the controller has just rebuilt the
+   *  session context from the request. */
+  findSessionByCtx(
+    mediaFileId: number,
+    ctx: SessionContext | undefined,
+  ): TranscodeSession | undefined {
+    return this.getExistingSession(
+      mediaFileId,
+      ctx?.userId,
+      this.computeProfileHashForCtx(ctx),
+    );
+  }
+
+  /** Same as {@link findSessionByCtx} for the early-segment companion. */
+  findEarlySessionByCtx(
+    mediaFileId: number,
+    ctx: SessionContext | undefined,
+  ): TranscodeSession | undefined {
+    return this.getExistingEarlySession(
+      mediaFileId,
+      ctx?.userId,
+      this.computeProfileHashForCtx(ctx),
+    );
+  }
+
+  /** Most-recently-accessed transcode session for this `(file, user)`
+   *  pair across every profile variant. Used by segment-serving routes
+   *  that can't cheaply reconstruct the session context — when only one
+   *  device is active this is exactly the session driving the playback,
+   *  and the multi-profile edge case (two devices, two profiles)
+   *  resolves to whichever side last fetched a segment. */
+  findCurrentSession(
+    mediaFileId: number,
+    userId: number | undefined,
+  ): TranscodeSession | undefined {
+    const sessions = this.getSessionsForFileUser(mediaFileId, userId);
+    if (sessions.length === 0) return undefined;
+    let best = sessions[0];
+    for (const s of sessions) {
+      if (s.lastAccess > best.lastAccess) best = s;
+    }
+    return best;
+  }
+
+  /** Companion of {@link findCurrentSession} for early sessions. */
+  findCurrentEarlySession(
+    mediaFileId: number,
+    userId: number | undefined,
+  ): TranscodeSession | undefined {
+    let best: TranscodeSession | undefined;
+    for (const s of this.sessions.values()) {
+      if (
+        s.mediaFileId === mediaFileId &&
+        s.userId === userId &&
+        s.id.endsWith('-early')
+      ) {
+        if (!best || s.lastAccess > best.lastAccess) best = s;
+      }
+    }
+    return best;
   }
 
   async onModuleDestroy() {
@@ -212,6 +296,16 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     return Array.from(this.sessions.values());
   }
 
+  /** Profile hash for the given session context — derived from the same
+   *  fields {@link buildPlaybackProfileFromContext} consumes. Stashed on
+   *  the session and reused as the session-map key segment so multiple
+   *  profile variants of the same `(file, user)` coexist as siblings. */
+  computeProfileHashForCtx(ctx: SessionContext | undefined): string {
+    return computeProfileHash(
+      buildPlaybackProfileFromContext(ctx, getSegmentDuration() * 1000),
+    );
+  }
+
   /**
    * Resolve the on-disk cache directory for a session variant. Wraps
    * the {@link TranscodeCacheService} layout so every spawn site goes
@@ -225,11 +319,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     variant: 'main' | 'early' | 'remux' | { audio: number },
     quality?: string,
   ): { dir: string; profileHash: string } {
-    const baseProfile = buildPlaybackProfileFromContext(
-      ctx,
-      getSegmentDuration() * 1000,
-    );
-    const baseHash = computeProfileHash(baseProfile);
+    const baseHash = this.computeProfileHashForCtx(ctx);
     let hash: string;
     if (variant === 'main') hash = baseHash;
     else if (variant === 'early') hash = `${baseHash}-early`;
@@ -439,7 +529,8 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     ctx?: SessionContext,
     skipVerify = false,
   ): Promise<TranscodeSession> {
-    const key = sessionKey(mediaFileId, ctx?.userId);
+    const profileHash = this.computeProfileHashForCtx(ctx);
+    const key = sessionKey(mediaFileId, ctx?.userId, profileHash);
     const session = await this.withLock(key, () =>
       this.doGetOrCreateSession(
         key,
@@ -671,7 +762,8 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     absolutePath: string,
     ctx?: SessionContext,
   ): Promise<TranscodeSession> {
-    const id = earlySessionKey(mediaFileId, ctx?.userId);
+    const profileHash = this.computeProfileHashForCtx(ctx);
+    const id = earlySessionKey(mediaFileId, ctx?.userId, profileHash);
     return this.withLock(id, async () => {
       const existing = this.sessions.get(id);
       if (existing) {
@@ -1096,82 +1188,41 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     return session;
   }
 
+  /** Stop every ffmpeg job for this `(file, user)` pair across all
+   *  profile variants. The on-disk cache **stays** — `TranscodeCacheService`
+   *  owns its lifecycle and will evict on TTL / LRU. A subsequent fresh
+   *  play (same profile) reattaches to the existing segments instead of
+   *  retranscoding from scratch. */
   async killSession(mediaFileId: number, userId?: number) {
-    const key = sessionKey(mediaFileId, userId);
-    const earlyKey = earlySessionKey(mediaFileId, userId);
-    const promises: Promise<void>[] = [];
-    const session = this.sessions.get(key);
-    if (session) {
-      this.log.log(`Kill session [${key}] (quality: ${session.quality})`);
-      this.sessions.delete(key);
-      promises.push(
-        this.killAndClean(session.process, session.cachePath, session.id),
-      );
+    const sessions = this.getSessionsForFileUser(mediaFileId, userId);
+    if (sessions.length === 0) return;
+    for (const s of sessions) {
+      this.log.log(`Kill session [${s.id}] (quality: ${s.quality})`);
+      this.sessions.delete(s.id);
+      s.intentionallyKilled = true;
     }
-    const earlySession = this.sessions.get(earlyKey);
-    if (earlySession) {
-      this.sessions.delete(earlyKey);
-      promises.push(
-        this.killAndClean(
-          earlySession.process,
-          earlySession.cachePath,
-          earlySession.id,
-        ),
-      );
-    }
-    const audioPrefix = `${key}-a`;
-    for (const [id, s] of this.sessions) {
-      if (id.startsWith(audioPrefix)) {
-        this.sessions.delete(id);
-        promises.push(this.killAndClean(s.process, s.cachePath, s.id));
-      }
-    }
-    await Promise.all(promises);
-    // Parent-dir rm is serialised under the main session's per-key lock
-    // (the same lock getOrCreate uses) so a fresh session entering
-    // mid-cleanup can't see its cache wiped from under it. The lock
-    // makes "either rm the user-file dir OR start a new session"
-    // atomic.
-    await this.removeUserFileDirIfIdle(mediaFileId, userId);
+    await Promise.all(sessions.map((s) => this.killProcess(s.process)));
   }
 
-  private async removeUserFileDirIfIdle(
-    mediaFileId: number,
-    userId: number | undefined,
-  ): Promise<void> {
-    const lockKey = sessionKey(mediaFileId, userId);
-    await this.withLock(lockKey, async () => {
-      const stillActive = [...this.sessions.values()].some(
-        (s) => s.mediaFileId === mediaFileId && s.userId === userId,
-      );
-      const parentDir = this.userFileParentDir(mediaFileId, userId);
-      if (stillActive) {
-        this.log.log(
-          `[disk] skip rm ${parentDir} — sessions still alive for ${lockKey}`,
-        );
-        return;
-      }
-      const existed = existsSync(parentDir);
-      this.log.log(`[disk] rm parent ${parentDir} (existed=${existed})`);
-      await fsp.rm(parentDir, { recursive: true, force: true }).catch(() => {});
-    });
-  }
-
-  /** Kill a session by its map key (used by admin dashboard). */
+  /** Kill a session by its map key (used by admin dashboard). The cache
+   *  directory stays — the admin can purge it separately via a future
+   *  cache-eviction action; killing a job mid-stream just frees CPU. */
   killSessionById(id: string) {
     const session = this.sessions.get(id);
     if (!session) return;
     this.sessions.delete(id);
-    this.gracefulKill(session);
+    session.intentionallyKilled = true;
+    void this.killProcess(session.process);
   }
 
-  /** Kill all sessions for a given media file (used on player close / page unload). */
+  /** Kill every session for a given media file across all users / profiles. */
   killAllSessionsForFile(mediaFileId: number) {
     for (const [id, session] of this.sessions) {
       if (session.mediaFileId === mediaFileId) {
         this.log.log(`Killing session ${id} for media file ${mediaFileId}`);
         this.sessions.delete(id);
-        this.gracefulKill(session);
+        session.intentionallyKilled = true;
+        void this.killProcess(session.process);
       }
     }
   }
@@ -1187,7 +1238,10 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     requestedSegment = 0,
     ctx?: SessionContext,
   ): Promise<TranscodeSession> {
-    const key = sessionKey(mediaFileId, ctx?.userId);
+    // Remux variant lives under its own profile bucket so the cache
+    // path matches `cacheDirFor(..., 'remux')`'s `${baseHash}-remux`.
+    const remuxHash = `${this.computeProfileHashForCtx(ctx)}-remux`;
+    const key = sessionKey(mediaFileId, ctx?.userId, remuxHash);
     return this.withLock(key, () =>
       this.doGetOrCreateRemuxSession(
         key,
@@ -1278,7 +1332,13 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     requestedSegment = 0,
     ctx?: SessionContext,
   ): Promise<TranscodeSession> {
-    const key = audioSessionKey(mediaFileId, audioIndex, ctx?.userId);
+    const audioHash = `${this.computeProfileHashForCtx(ctx)}-a${audioIndex}`;
+    const key = audioSessionKey(
+      mediaFileId,
+      audioIndex,
+      ctx?.userId,
+      audioHash,
+    );
     return this.withLock(key, () =>
       this.doGetOrCreateAudioSession(
         key,
@@ -1374,7 +1434,10 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       if (now - session.lastAccess > SESSION_TIMEOUT_MS && processDone) {
         this.log.log(`Cleanup stale session: ${id}`);
         this.sessions.delete(id);
-        this.gracefulKill(session);
+        // Cache is preserved across session evictions —
+        // TranscodeCacheService GC owns the disk lifecycle (TTL + LRU)
+        // so a fresh play after this point reattaches to the existing
+        // segments instead of retranscoding.
       }
     }
   }

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -245,10 +245,18 @@ export interface TranscodeSession {
    *  drift detection: flipping the flag mid-stream must kill+respawn
    *  the session because the on-disk layout differs. */
   audioLayout?: 'inline' | 'var-stream-map';
-  /** Profile hash this session was spawned under. Drives the on-disk
-   *  cache directory layout (`/tmp/transcode/cache/u<userId>/<file>/<hash>/...`)
-   *  and is the lookup key used by the {@link TranscodeCacheService}. */
-  profileHash?: string;
+  /** Client-level base profile hash — matches the
+   *  `LiveSession.profileHash` the client beats. Every variant for
+   *  the same client (main / early / remux / per-audio) shares this
+   *  value. The cache directory layout adds the variant suffix on
+   *  top via `variantHash`, the cleanup loop reads it directly when
+   *  querying the live-session registry. */
+  baseProfileHash?: string;
+  /** Output flavour this session produces — disambiguates the cache
+   *  bucket among siblings of the same `baseProfileHash`. Combine via
+   *  `variantHash(baseProfileHash, variant)` to recover the cache key
+   *  (= directory segment + session-map key fragment). */
+  variant?: import('./variant').SessionVariant;
   /** Set to true the first time the GC loop observed a matching live
    *  session for this (user, file, profileHash). Gates the
    *  heartbeat-driven grace timer: a session that has never had a

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -249,4 +249,14 @@ export interface TranscodeSession {
    *  cache directory layout (`/tmp/transcode/cache/u<userId>/<file>/<hash>/...`)
    *  and is the lookup key used by the {@link TranscodeCacheService}. */
   profileHash?: string;
+  /** Set to true the first time the GC loop observed a matching live
+   *  session for this (user, file, profileHash). Gates the
+   *  heartbeat-driven grace timer: a session that has never had a
+   *  live session falls back to the longer SESSION_TIMEOUT_MS idle
+   *  window. */
+  seenAnyLiveSession?: boolean;
+  /** When the GC loop first observed zero matching live sessions for
+   *  this transcode session. Reset to `null` whenever a live session
+   *  reappears. Used to enforce the JOB_GRACE_MS window. */
+  zeroLiveSince?: number | null;
 }

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -245,4 +245,8 @@ export interface TranscodeSession {
    *  drift detection: flipping the flag mid-stream must kill+respawn
    *  the session because the on-disk layout differs. */
   audioLayout?: 'inline' | 'var-stream-map';
+  /** Profile hash this session was spawned under. Drives the on-disk
+   *  cache directory layout (`/tmp/transcode/cache/u<userId>/<file>/<hash>/...`)
+   *  and is the lookup key used by the {@link TranscodeCacheService}. */
+  profileHash?: string;
 }

--- a/backend/src/modules/streaming/transcoding/variant.spec.ts
+++ b/backend/src/modules/streaming/transcoding/variant.spec.ts
@@ -1,0 +1,86 @@
+import {
+  VARIANT_EARLY,
+  VARIANT_MAIN,
+  VARIANT_REMUX,
+  baseProfileHash,
+  isVariantOf,
+  variantHash,
+  variantSuffix,
+} from './variant';
+
+describe('variantSuffix', () => {
+  it('emits the canonical suffix for each kind', () => {
+    expect(variantSuffix(VARIANT_MAIN)).toBe('');
+    expect(variantSuffix(VARIANT_EARLY)).toBe('-early');
+    expect(variantSuffix(VARIANT_REMUX)).toBe('-remux');
+    expect(variantSuffix({ kind: 'audio', audioIndex: 0 })).toBe('-a0');
+    expect(variantSuffix({ kind: 'audio', audioIndex: 3 })).toBe('-a3');
+  });
+});
+
+describe('variantHash', () => {
+  const base = 'a1b2c3d4e5';
+  it('returns the base hash unchanged for main', () => {
+    expect(variantHash(base, VARIANT_MAIN)).toBe(base);
+  });
+  it('appends the variant suffix', () => {
+    expect(variantHash(base, VARIANT_EARLY)).toBe(`${base}-early`);
+    expect(variantHash(base, VARIANT_REMUX)).toBe(`${base}-remux`);
+    expect(variantHash(base, { kind: 'audio', audioIndex: 2 })).toBe(
+      `${base}-a2`,
+    );
+  });
+});
+
+describe('baseProfileHash', () => {
+  const base = 'deadbeef01';
+  it('returns the input unchanged when no suffix is present', () => {
+    expect(baseProfileHash(base)).toBe(base);
+  });
+  it('strips every known variant suffix', () => {
+    expect(baseProfileHash(`${base}-early`)).toBe(base);
+    expect(baseProfileHash(`${base}-remux`)).toBe(base);
+    expect(baseProfileHash(`${base}-a0`)).toBe(base);
+    expect(baseProfileHash(`${base}-a12`)).toBe(base);
+  });
+  it('leaves non-variant trailing dashes alone', () => {
+    expect(baseProfileHash(`${base}-foo`)).toBe(`${base}-foo`);
+    expect(baseProfileHash(`${base}-aX`)).toBe(`${base}-aX`);
+  });
+});
+
+describe('isVariantOf', () => {
+  const base = 'cafebabe01';
+  it('matches the base itself', () => {
+    expect(isVariantOf(base, base)).toBe(true);
+  });
+  it('matches any known variant suffix', () => {
+    expect(isVariantOf(`${base}-early`, base)).toBe(true);
+    expect(isVariantOf(`${base}-remux`, base)).toBe(true);
+    expect(isVariantOf(`${base}-a5`, base)).toBe(true);
+  });
+  it('rejects unrelated cache keys with the same prefix length', () => {
+    expect(isVariantOf('cafebabe02', base)).toBe(false);
+    expect(isVariantOf('cafebabe02-early', base)).toBe(false);
+  });
+  it('rejects hashes that merely contain the base as a substring', () => {
+    expect(isVariantOf(`xxx${base}`, base)).toBe(false);
+    expect(isVariantOf(`xxx${base}-early`, base)).toBe(false);
+  });
+});
+
+describe('round-trip variantHash + baseProfileHash', () => {
+  const base = '0123456789';
+  it('returns the base for every variant', () => {
+    const variants = [
+      VARIANT_MAIN,
+      VARIANT_EARLY,
+      VARIANT_REMUX,
+      { kind: 'audio', audioIndex: 0 } as const,
+      { kind: 'audio', audioIndex: 7 } as const,
+    ];
+    for (const v of variants) {
+      expect(baseProfileHash(variantHash(base, v))).toBe(base);
+    }
+  });
+});

--- a/backend/src/modules/streaming/transcoding/variant.ts
+++ b/backend/src/modules/streaming/transcoding/variant.ts
@@ -1,0 +1,73 @@
+/**
+ * Variant flavours a single `(file, user, profile)` triple can be
+ * transcoded into. Each one lives in its own cache directory and its
+ * own session-map entry so they never collide on disk or in memory:
+ *
+ * - `main`: the regular video transcode. Cache key is the bare base
+ *   profile hash.
+ * - `early`: short-lived companion that produces seg-0/seg-1 in
+ *   parallel with a main session that's seeking mid-file. Same codec
+ *   as main; suffix keeps the two in distinct cache dirs.
+ * - `remux`: video-copy / audio-remux path (DirectStream). Different
+ *   ffmpeg arg set than main; gets its own bucket.
+ * - `audio`: per-audio-track HLS audio rendition. One bucket per
+ *   audioIndex so multi-audio playbacks don't share a writer.
+ *
+ * Centralising the suffix logic here removes the foot-gun of editing
+ * five inline `${baseHash}-early` / `${baseHash}-a${n}` template
+ * literals — the strip regex, the prefix check, and the variant
+ * encoder all live in one place.
+ */
+export type SessionVariant =
+  | { kind: 'main' }
+  | { kind: 'early' }
+  | { kind: 'remux' }
+  | { kind: 'audio'; audioIndex: number };
+
+/** Singleton instances for the variants that take no parameters —
+ *  saves an allocation per spawn. */
+export const VARIANT_MAIN: SessionVariant = { kind: 'main' };
+export const VARIANT_EARLY: SessionVariant = { kind: 'early' };
+export const VARIANT_REMUX: SessionVariant = { kind: 'remux' };
+
+/** Suffix appended to a base profile hash to disambiguate the variant
+ *  on disk and in the session map. Empty for `main`. */
+export function variantSuffix(variant: SessionVariant): string {
+  switch (variant.kind) {
+    case 'main':
+      return '';
+    case 'early':
+      return '-early';
+    case 'remux':
+      return '-remux';
+    case 'audio':
+      return `-a${variant.audioIndex}`;
+  }
+}
+
+/** Compose a variant cache key from a base profile hash. The result is
+ *  what gets stored as `session.cacheKey` and used as the directory
+ *  segment under `/tmp/transcode/cache/<user>/<file>/...`. */
+export function variantHash(
+  baseHash: string,
+  variant: SessionVariant,
+): string {
+  return `${baseHash}${variantSuffix(variant)}`;
+}
+
+const VARIANT_SUFFIX_RE = /-(?:early|remux|a\d+)$/;
+
+/** Strip any known variant suffix off a cache key to recover the base
+ *  profile hash that the live-session registry tracks. The registry
+ *  has one entry per client; every variant of the client's transcode
+ *  rolls up to the same base hash. */
+export function baseProfileHash(cacheKey: string): string {
+  return cacheKey.replace(VARIANT_SUFFIX_RE, '');
+}
+
+/** True when `cacheKey` is the main or any variant of `baseHash`.
+ *  Used to find every ffmpeg job tied to a single client when, e.g.,
+ *  that client explicitly stops. */
+export function isVariantOf(cacheKey: string, baseHash: string): boolean {
+  return cacheKey === baseHash || cacheKey.startsWith(`${baseHash}-`);
+}

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -222,12 +222,22 @@ export class StreamingApiService {
   }
 
   /** Build authenticated stream URL for direct play */
-  getStreamUrl(mediaFileId: number): string {
+  getStreamUrl(mediaFileId: number, sessionId?: string): string {
     const base = this.serverConfig.isNative
       ? this.serverConfig.resolveUrl(`/api/stream/${mediaFileId}`)
       : `/api/stream/${mediaFileId}`;
+    const url = this.withTokenAndSid(base, sessionId);
+    return url;
+  }
+
+  /** Internal helper for getStreamUrl — keeps the token+sid query
+   *  composition consistent with `getHlsUrl`. */
+  private withTokenAndSid(base: string, sessionId?: string): string {
+    const params: string[] = [];
     const token = this.playbackToken;
-    return token ? `${base}?token=${encodeURIComponent(token)}` : base;
+    if (token) params.push(`token=${encodeURIComponent(token)}`);
+    if (sessionId) params.push(`sid=${encodeURIComponent(sessionId)}`);
+    return params.length ? `${base}?${params.join('&')}` : base;
   }
 
   /** Build authenticated subtitle URL */
@@ -280,18 +290,46 @@ export class StreamingApiService {
     return `${url}${url.includes('?') ? '&' : '?'}token=${encodeURIComponent(token)}`;
   }
 
+  private appendSid(url: string, sid: string | undefined): string {
+    if (!sid) return url;
+    return `${url}${url.includes('?') ? '&' : '?'}sid=${encodeURIComponent(sid)}`;
+  }
+
   private withToken(url: string): string {
     const token = this.playbackToken;
     return token ? this.appendToken(url, token) : url;
   }
 
-  /** Build Cast URLs with a temporary token */
-  getAbsoluteHlsUrl(mediaFileId: number, castToken: string): string {
-    return this.appendToken(this.absoluteUrl(`/api/stream/${mediaFileId}/master.m3u8`), castToken);
+  /** Build Cast URLs with a temporary token. `sessionId` is the live
+   *  session handle the Cast device received from its own `playback-info`
+   *  call; baking it here propagates the same sid into the variant +
+   *  segment URLs so segments route to the Cast-specific transcode job. */
+  getAbsoluteHlsUrl(
+    mediaFileId: number,
+    castToken: string,
+    sessionId?: string,
+  ): string {
+    return this.appendSid(
+      this.appendToken(
+        this.absoluteUrl(`/api/stream/${mediaFileId}/master.m3u8`),
+        castToken,
+      ),
+      sessionId,
+    );
   }
 
-  getAbsoluteStreamUrl(mediaFileId: number, castToken: string): string {
-    return this.appendToken(this.absoluteUrl(`/api/stream/${mediaFileId}`), castToken);
+  getAbsoluteStreamUrl(
+    mediaFileId: number,
+    castToken: string,
+    sessionId?: string,
+  ): string {
+    return this.appendSid(
+      this.appendToken(
+        this.absoluteUrl(`/api/stream/${mediaFileId}`),
+        castToken,
+      ),
+      sessionId,
+    );
   }
 
   getAbsoluteSubtitleUrl(mediaFileId: number, subtitleId: number, castToken: string): string {

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -196,15 +196,25 @@ export class StreamingApiService {
    * Build authenticated HLS master playlist URL.
    * `startQuality` tells the backend which quality to pre-start FFmpeg at
    * (e.g. "1080p") — avoids the "first segment fetch spawns FFmpeg at a
-   * wrong variant Shaka probed during load" waste.
+   * wrong variant Shaka probed during load" waste. `sessionId` is the
+   * live-session handle the backend issued from `playback-info`; baking
+   * it into this URL makes the master playlist propagate `?sid=...` into
+   * every variant + segment URL so segment fetches route to the exact
+   * `(file, user, profileHash)` transcode session.
    */
-  getHlsUrl(mediaFileId: number, startQuality?: string, startAt?: number): string {
+  getHlsUrl(
+    mediaFileId: number,
+    startQuality?: string,
+    startAt?: number,
+    sessionId?: string,
+  ): string {
     const base = this.serverConfig.isNative
       ? this.serverConfig.resolveUrl(`/api/stream/${mediaFileId}/master.m3u8`)
       : `/api/stream/${mediaFileId}/master.m3u8`;
     const params: string[] = [];
     const token = this.playbackToken;
     if (token) params.push(`token=${encodeURIComponent(token)}`);
+    if (sessionId) params.push(`sid=${encodeURIComponent(sessionId)}`);
     if (startQuality) params.push(`startQuality=${encodeURIComponent(startQuality)}`);
     if (startAt != null) params.push(`startAt=${startAt}`);
     params.push(`device=${this.deviceProfileService.getProfile().deviceType}`);

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -82,7 +82,18 @@ export interface PlaybackInfoResponse {
   };
   /** Embedded chapters from the container (MKV/MP4). */
   chapters?: { startSeconds: number; endSeconds: number; title?: string }[];
+  /** Server-issued live-session identifier. The client embeds it in every
+   *  subsequent `PUT /api/playback/media/:id/state` (heartbeat) and on
+   *  the `DELETE /api/stream/:mediaFileId/sessions` unload signal so the
+   *  backend can match the client back to its in-memory session record. */
+  sessionId?: string;
+  /** Profile hash this session's transcode cache is keyed under, or
+   *  `null` for DirectPlay. Surfaced for the admin dashboard and for
+   *  future multi-device match logic; not required by the player. */
+  profileHash?: string | null;
 }
+
+export type LivePlaybackState = 'playing' | 'paused' | 'buffering';
 
 export interface MediaResumeInfo {
   mediaFileId: number;
@@ -371,10 +382,21 @@ export class StreamingApiService {
       durationSeconds: number;
       mediaFileId: number;
       episodeId?: number;
+      // Live-session heartbeat fields. Only present once the player has
+      // received a `sessionId` from `getPlaybackInfo`; the backend
+      // tolerates their absence (legacy / unauthenticated paths).
+      sessionId?: string;
+      state?: LivePlaybackState;
+      quality?: string | null;
+      audioTrackIndex?: number | null;
+      subtitleTrackIndex?: number | null;
     },
   ) {
     return firstValueFrom(
-      this.http.put<PlaybackState>(`/api/playback/media/${mediaId}/state`, body),
+      this.http.put<PlaybackState | null>(
+        `/api/playback/media/${mediaId}/state`,
+        body,
+      ),
     );
   }
 

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -381,8 +381,19 @@ export class StreamingApiService {
     );
   }
 
-  /** Build the URL for stopping sessions (used with sendBeacon on unload). */
-  getStopSessionsUrl(mediaFileId: number): string {
+  /** Build the URL for stopping sessions (used with sendBeacon on unload).
+   *  Prefer the sid-scoped variant when a sessionId is available — the
+   *  bulk path kills every profile for the (user, file) pair, which
+   *  would tear down other devices watching the same title. */
+  getStopSessionsUrl(mediaFileId: number, sessionId?: string): string {
+    if (sessionId) {
+      const path = `/api/stream/sessions/${encodeURIComponent(sessionId)}`;
+      const base = this.serverConfig.isNative
+        ? this.serverConfig.resolveUrl(path)
+        : path;
+      const token = this.playbackToken;
+      return token ? `${base}?token=${encodeURIComponent(token)}` : base;
+    }
     const base = this.serverConfig.isNative
       ? this.serverConfig.resolveUrl(`/api/stream/${mediaFileId}/sessions`)
       : `/api/stream/${mediaFileId}/sessions`;
@@ -390,7 +401,14 @@ export class StreamingApiService {
     return token ? `${base}?token=${encodeURIComponent(token)}` : base;
   }
 
-  stopSessions(mediaFileId: number) {
+  stopSessions(mediaFileId: number, sessionId?: string) {
+    if (sessionId) {
+      return firstValueFrom(
+        this.http.delete(
+          `/api/stream/sessions/${encodeURIComponent(sessionId)}`,
+        ),
+      );
+    }
     return firstValueFrom(
       this.http.delete(`/api/stream/${mediaFileId}/sessions`),
     );

--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -280,6 +280,12 @@ export class CastPlayerService {
   readonly hasMedia = signal(false);
   /** Whether the Cast overlay card is expanded. */
   readonly expanded = signal(false);
+  /** Server-issued live session id for the currently-playing Cast stream.
+   *  Distinct from the sender's local sid: the receiver's profile (cast
+   *  codec capabilities) and the resulting transcode session live under
+   *  this id, so the sender heartbeats it instead of its local sid while
+   *  the cast is connected. */
+  readonly liveSessionId = signal<string | null>(null);
 
   /**
    * Initialize a Cast session with media data from the player.
@@ -340,11 +346,15 @@ export class CastPlayerService {
    *  encoder slots and disk cache. */
   clear() {
     const mfId = this.mediaFileId();
+    const castSid = this.liveSessionId();
     this.saveCastPosition(); // Save final position before clearing
     this.stopPositionSaving();
     if (mfId) {
-      this.streamingApi.stopSessions(mfId).catch(() => {});
+      // Sid-scoped kill so a sender that's still watching locally on a
+      // different profile isn't torn down by the cast stop.
+      this.streamingApi.stopSessions(mfId, castSid ?? undefined).catch(() => {});
     }
+    this.liveSessionId.set(null);
     this.hasMedia.set(false);
     this.expanded.set(false);
     this.mediaFileId.set(0);
@@ -453,6 +463,11 @@ export class CastPlayerService {
       castUrl = `${lanUrl}/api/stream/${mfId}/master.m3u8?token=${tokenQ}${sidParam}&startQuality=${q}${startAtParam}`;
       contentType = 'application/x-mpegurl';
     }
+
+    // Stash the Cast live-session id so the sender's heartbeat loop
+    // (`savePosition` in the local player) keeps the receiver's
+    // session warm instead of beating the now-paused browser session.
+    this.liveSessionId.set(pi.sessionId ?? null);
 
     const subtitles = this.subtitleInfos
       .filter(s => !s.burnIn && s.subtitleDbId)

--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -408,7 +408,7 @@ export class CastPlayerService {
    */
   private async dispatchLoad(
     mfId: number,
-    pi: { playMethod: string },
+    pi: { playMethod: string; sessionId?: string },
     currentPos: number,
     transcodeQuality: string | undefined,
     castInfo: { token: string; streamBaseUrl: string },
@@ -435,15 +435,22 @@ export class CastPlayerService {
     let contentType: string;
     const tokenQ = encodeURIComponent(castToken);
     const startAtParam = `&startAt=${Math.floor(currentPos)}`;
+    const sidParam = pi.sessionId
+      ? `&sid=${encodeURIComponent(pi.sessionId)}`
+      : '';
     if (castMode === 'direct') {
-      castUrl = this.streamingApi.getAbsoluteStreamUrl(mfId, castToken);
+      castUrl = this.streamingApi.getAbsoluteStreamUrl(
+        mfId,
+        castToken,
+        pi.sessionId,
+      );
       contentType = 'video/mp4';
     } else if (castMode === 'remux') {
-      castUrl = `${lanUrl}/api/stream/${mfId}/master.m3u8?token=${tokenQ}&remux=1${startAtParam}`;
+      castUrl = `${lanUrl}/api/stream/${mfId}/master.m3u8?token=${tokenQ}${sidParam}&remux=1${startAtParam}`;
       contentType = 'application/x-mpegurl';
     } else {
       const q = transcodeQuality ?? '1080p';
-      castUrl = `${lanUrl}/api/stream/${mfId}/master.m3u8?token=${tokenQ}&startQuality=${q}${startAtParam}`;
+      castUrl = `${lanUrl}/api/stream/${mfId}/master.m3u8?token=${tokenQ}${sidParam}&startQuality=${q}${startAtParam}`;
       contentType = 'application/x-mpegurl';
     }
 

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -845,7 +845,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
           const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
 
           if (mode === 'direct') {
-            const streamUrl = this.streamingApi.getStreamUrl(this.mediaFileId);
+            const streamUrl = this.streamingApi.getStreamUrl(
+              this.mediaFileId,
+              this.playbackInfo?.sessionId,
+            );
             await this.engine!.load(streamUrl, startTime, 'video/mp4', headers);
           } else {
             const savedQualityId = this.activeQualityId();
@@ -903,7 +906,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
           if (mode === 'direct') {
             // Progressive MP4 — Media3 detects the container, no quality
             // ladder to constrain (DirectPlay = single source variant).
-            const streamUrl = this.streamingApi.getStreamUrl(this.mediaFileId);
+            const streamUrl = this.streamingApi.getStreamUrl(
+              this.mediaFileId,
+              this.playbackInfo?.sessionId,
+            );
             await this.engine!.load(streamUrl, startTime, 'video/mp4', headers);
           } else {
             // HLS transcode/remux — apply quality constraint before load to
@@ -944,7 +950,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
           );
 
           if (mode === 'direct') {
-            const streamUrl = this.streamingApi.getStreamUrl(this.mediaFileId);
+            const streamUrl = this.streamingApi.getStreamUrl(
+              this.mediaFileId,
+              this.playbackInfo?.sessionId,
+            );
             await this.engine!.load(streamUrl, startTime, 'video/mp4');
           } else {
             const savedQualityId = this.activeQualityId();
@@ -1748,9 +1757,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         const startQuality = mode !== 'direct' && savedQualityId !== 'auto'
           ? savedQualityId
           : undefined;
+        const sid = this.playbackInfo?.sessionId;
         const url = mode === 'direct'
-          ? this.streamingApi.getStreamUrl(this.mediaFileId)
-          : this.streamingApi.getHlsUrl(this.mediaFileId, startQuality);
+          ? this.streamingApi.getStreamUrl(this.mediaFileId, sid)
+          : this.streamingApi.getHlsUrl(this.mediaFileId, startQuality, undefined, sid);
         const mimeType = mode === 'direct' ? 'video/mp4' : undefined;
         await this.engine.load(url, castPos > 0 ? castPos : undefined, mimeType);
         this.qualityManager.applyQualityPreferenceAfterLoad(this.engine, mode);
@@ -2284,11 +2294,23 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
     const mode = this.playbackMode();
     if (mode === 'direct') {
-      await this.engine.load(this.streamingApi.getStreamUrl(this.mediaFileId), currentPos, 'video/mp4');
+      await this.engine.load(
+        this.streamingApi.getStreamUrl(this.mediaFileId, this.playbackInfo?.sessionId),
+        currentPos,
+        'video/mp4',
+      );
     } else {
       const savedQualityId = this.activeQualityId();
       const startQuality = savedQualityId !== 'auto' ? savedQualityId : undefined;
-      await this.engine.load(this.streamingApi.getHlsUrl(this.mediaFileId, startQuality, currentPos), currentPos);
+      await this.engine.load(
+        this.streamingApi.getHlsUrl(
+          this.mediaFileId,
+          startQuality,
+          currentPos,
+          pi.sessionId,
+        ),
+        currentPos,
+      );
     }
 
     this.qualityManager.applyQualityPreferenceAfterLoad(this.engine, mode);

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -421,6 +421,19 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   });
   private playbackInfo: PlaybackInfoResponse | null = null;
 
+  /** Live-session id to bind the next stream request to. While casting
+   *  the receiver's session id wins (its segments come from a separate
+   *  ffmpeg job under the cast device profile); otherwise the local
+   *  browser's session id. */
+  private activeSessionId(): string | undefined {
+    if (this.castService.isConnected()) {
+      return (
+        this.castPlayerService.liveSessionId() ?? this.playbackInfo?.sessionId
+      );
+    }
+    return this.playbackInfo?.sessionId;
+  }
+
   readonly playerStats = computed<PlayerStats | null>(() => {
     if (!this.statsVisible()) return null;
 
@@ -2331,10 +2344,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
   private fireAndForgetStopSessions() {
     if (!this.mediaFileId || this.playbackMode() === 'direct') return;
-    const sid = this.castService.isConnected()
-      ? (this.castPlayerService.liveSessionId() ?? this.playbackInfo?.sessionId)
-      : this.playbackInfo?.sessionId;
-    const url = this.streamingApi.getStopSessionsUrl(this.mediaFileId, sid);
+    const url = this.streamingApi.getStopSessionsUrl(
+      this.mediaFileId,
+      this.activeSessionId(),
+    );
     fetch(url, { method: 'DELETE', keepalive: true }).catch(() => {});
   }
 
@@ -2354,10 +2367,9 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
   private stopStreamingSessions() {
     if (!this.mediaFileId || this.playbackMode() === 'direct') return;
-    const sid = this.castService.isConnected()
-      ? (this.castPlayerService.liveSessionId() ?? this.playbackInfo?.sessionId)
-      : this.playbackInfo?.sessionId;
-    this.streamingApi.stopSessions(this.mediaFileId, sid).catch(() => {});
+    this.streamingApi
+      .stopSessions(this.mediaFileId, this.activeSessionId())
+      .catch(() => {});
   }
 
   /** Wall-clock timestamp (ms) of the last PUT to /state. Used to dedup
@@ -2405,13 +2417,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       episodeId: this.episodeId,
     };
 
-    // Prefer the Cast live-session id when the user has handed off to a
-    // receiver — its segments are produced by a separate ffmpeg job
-    // under the Cast device profile. The local sender's sid would beat
-    // a now-paused browser session and let the Cast one expire.
-    const sessionId = this.castService.isConnected()
-      ? (this.castPlayerService.liveSessionId() ?? this.playbackInfo?.sessionId)
-      : this.playbackInfo?.sessionId;
+    const sessionId = this.activeSessionId();
     if (sessionId) {
       payload.sessionId = sessionId;
       payload.state = this.paused() ? 'paused' : 'playing';

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -850,7 +850,12 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
           } else {
             const savedQualityId = this.activeQualityId();
             const tvStartQuality = savedQualityId !== 'auto' ? savedQualityId : undefined;
-            const hlsUrl = this.streamingApi.getHlsUrl(this.mediaFileId, tvStartQuality, startTime);
+            const hlsUrl = this.streamingApi.getHlsUrl(
+              this.mediaFileId,
+              tvStartQuality,
+              startTime,
+              this.playbackInfo?.sessionId,
+            );
             await this.engine!.load(hlsUrl, startTime, undefined, headers);
           }
 
@@ -922,7 +927,12 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
               (this.engine as NativeEngine).selectVariantTrack({ width: w, height: h });
             }
             const nativeStartQuality = savedQualityId !== 'auto' ? savedQualityId : undefined;
-            const hlsUrl = this.streamingApi.getHlsUrl(this.mediaFileId, nativeStartQuality, startTime);
+            const hlsUrl = this.streamingApi.getHlsUrl(
+              this.mediaFileId,
+              nativeStartQuality,
+              startTime,
+              this.playbackInfo?.sessionId,
+            );
             await this.engine!.load(hlsUrl, startTime, undefined, headers);
           }
         } else {
@@ -981,7 +991,12 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
             // the right profile + applies the quality-change grace period to
             // protect the session from Shaka's startup bandwidth probe.
             const startQuality = savedQualityId !== 'auto' ? savedQualityId : undefined;
-            const hlsUrl = this.streamingApi.getHlsUrl(this.mediaFileId, startQuality, startTime);
+            const hlsUrl = this.streamingApi.getHlsUrl(
+              this.mediaFileId,
+              startQuality,
+              startTime,
+              this.playbackInfo?.sessionId,
+            );
             await this.engine!.load(hlsUrl, startTime);
           }
 

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -2314,11 +2314,13 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     this.streamingApi.stopSessions(this.mediaFileId).catch(() => {});
   }
 
-  /** Last second-rounded position we PUT to /state. Used to dedup the
-   *  3 saves that fire on exit (onBack, ngOnDestroy, savePosition
-   *  interval): all three see the same `currentTime`, so only the first
-   *  hits the network. */
-  private lastSavedPosition: number | null = null;
+  /** Wall-clock timestamp (ms) of the last PUT to /state. Used to dedup
+   *  the cluster of saves that fire on exit (onBack, ngOnDestroy, the
+   *  savePosition interval and the 'seeked' event all hit savePosition
+   *  within the same tick). Time-based instead of position-based so a
+   *  paused player still emits a heartbeat every 10 s — the backend's
+   *  {@link LiveSessionRegistry} relies on it to keep the session warm. */
+  private lastSaveAt = 0;
 
   private async savePosition() {
     if (!this.mediaId) return;
@@ -2338,25 +2340,50 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
     if (!pos) return;
 
-    const rounded = Math.floor(pos);
-    if (this.lastSavedPosition === rounded) return;
-    this.lastSavedPosition = rounded;
+    const now = Date.now();
+    if (now - this.lastSaveAt < 2_000) return;
+    this.lastSaveAt = now;
 
-    const payload = {
+    const payload: {
+      positionSeconds: number;
+      durationSeconds: number;
+      mediaFileId: number;
+      episodeId?: number;
+      sessionId?: string;
+      state?: 'playing' | 'paused' | 'buffering';
+      quality?: string | null;
+    } = {
       positionSeconds: pos,
       durationSeconds: dur || 0,
       mediaFileId: this.mediaFileId,
       episodeId: this.episodeId,
     };
 
+    const sessionId = this.playbackInfo?.sessionId;
+    if (sessionId) {
+      payload.sessionId = sessionId;
+      payload.state = this.paused() ? 'paused' : 'playing';
+      payload.quality = this.activeQualityId() ?? null;
+    }
+
+    // Offline queue persists position only — the heartbeat-related
+    // fields (sessionId / state / quality) are pointless once the
+    // backend session has already expired by the time we reconnect.
+    const offlinePayload = {
+      mediaId: this.mediaId,
+      mediaFileId: this.mediaFileId,
+      episodeId: this.episodeId,
+      positionSeconds: payload.positionSeconds,
+      durationSeconds: payload.durationSeconds,
+    };
     if (this.network.isOnline()) {
       try {
         await this.streamingApi.updatePlaybackState(this.mediaId, payload);
       } catch {
-        this.offlineSync.queue({ mediaId: this.mediaId, ...payload });
+        this.offlineSync.queue(offlinePayload);
       }
     } else {
-      this.offlineSync.queue({ mediaId: this.mediaId, ...payload });
+      this.offlineSync.queue(offlinePayload);
     }
   }
 

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -2272,8 +2272,11 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       await NativePlayer.stop().catch(() => {});
     }
 
-    // Await stop so the backend finishes cleaning the cache dir before we start a new session
-    await this.streamingApi.stopSessions(this.mediaFileId).catch(() => {});
+    // Stop only this device's session — multi-device viewers on the
+    // same file with a different profile should stay alive.
+    await this.streamingApi
+      .stopSessions(this.mediaFileId, this.playbackInfo?.sessionId)
+      .catch(() => {});
 
     const deviceProfile = this.deviceProfileService.getProfile();
     this.playbackInfo = await this.streamingApi.getPlaybackInfo(
@@ -2328,7 +2331,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
   private fireAndForgetStopSessions() {
     if (!this.mediaFileId || this.playbackMode() === 'direct') return;
-    const url = this.streamingApi.getStopSessionsUrl(this.mediaFileId);
+    const sid = this.castService.isConnected()
+      ? (this.castPlayerService.liveSessionId() ?? this.playbackInfo?.sessionId)
+      : this.playbackInfo?.sessionId;
+    const url = this.streamingApi.getStopSessionsUrl(this.mediaFileId, sid);
     fetch(url, { method: 'DELETE', keepalive: true }).catch(() => {});
   }
 
@@ -2348,7 +2354,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
   private stopStreamingSessions() {
     if (!this.mediaFileId || this.playbackMode() === 'direct') return;
-    this.streamingApi.stopSessions(this.mediaFileId).catch(() => {});
+    const sid = this.castService.isConnected()
+      ? (this.castPlayerService.liveSessionId() ?? this.playbackInfo?.sessionId)
+      : this.playbackInfo?.sessionId;
+    this.streamingApi.stopSessions(this.mediaFileId, sid).catch(() => {});
   }
 
   /** Wall-clock timestamp (ms) of the last PUT to /state. Used to dedup
@@ -2396,7 +2405,13 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       episodeId: this.episodeId,
     };
 
-    const sessionId = this.playbackInfo?.sessionId;
+    // Prefer the Cast live-session id when the user has handed off to a
+    // receiver — its segments are produced by a separate ffmpeg job
+    // under the Cast device profile. The local sender's sid would beat
+    // a now-paused browser session and let the Cast one expire.
+    const sessionId = this.castService.isConnected()
+      ? (this.castPlayerService.liveSessionId() ?? this.playbackInfo?.sessionId)
+      : this.playbackInfo?.sessionId;
     if (sessionId) {
       payload.sessionId = sessionId;
       payload.state = this.paused() ? 'paused' : 'playing';

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -50,6 +50,38 @@ services:
       DB_PASSWORD: changeme
       DB_NAME: fliks
       NODE_ENV: production
+      # ---- Streaming session tuning (optional) -----------------------
+      # All values below have safe defaults baked in. Override only if
+      # you know what you're doing.
+      #
+      # How long a "live viewer" entry survives without any heartbeat
+      # from the client. The client beats every 10 s, so 30 s tolerates
+      # three missed beats (background tab, network blip). Default 30000.
+      # STREAM_LIVE_SESSION_TTL_MS: 30000
+      #
+      # Grace window after the last live viewer for a given
+      # (user, file, profileHash) disappears, before the matching
+      # ffmpeg encoder is killed. Cache stays so a reconnect within the
+      # next few hours reattaches without retranscoding. Default 60000.
+      # STREAM_JOB_GRACE_MS: 60000
+      #
+      # Idle timeout for transcode sessions that were never paired with
+      # a live session (legacy URL fetches, admin scrubbing). Mirrors
+      # the pre-heartbeat behaviour. Default 1800000 (30 min).
+      # STREAM_JOB_FALLBACK_TIMEOUT_MS: 1800000
+      #
+      # How long transcoded segments stay on disk after their last
+      # access. Default 14400000 (4 h). Set lower to free disk faster,
+      # higher to cover users who pause for a long time and come back.
+      # TRANSCODE_CACHE_TTL_MS: 14400000
+      #
+      # Hard cap on the total size of the transcode cache. Above this,
+      # LRU eviction kicks in even if entries are still within TTL.
+      # Default 21474836480 (20 GB).
+      # TRANSCODE_CACHE_MAX_BYTES: 21474836480
+      #
+      # How often the cache garbage collector runs. Default 300000 (5 min).
+      # TRANSCODE_CACHE_GC_INTERVAL_MS: 300000
     volumes:
       # ---- Media library ------------------------------------------------
       # Map your existing media tree here. Match the path Fliks tells the


### PR DESCRIPTION
Streaming session refactor — see \`plans/streaming-session-refactor.plan.md\`. Eleven commits delivering Phases 1-5 of the plan plus sid URL routing, a full scenario audit + fixes, and a refactor pass. Follow-ups tracked in #291 (11 cleanups) and #292 (Phase 6 metrics).

## What landed

### Phase 1 — scaffolding
- \`computeProfileHash(profile)\`: sha1 of the canonicalised \`PlaybackProfile\`, 10 hex chars. Includes \`tvPlatform\` as a per-player safety net for byte-level quirks codec + mux + audio layout alone don't capture.
- \`TranscodeCacheService\`: scans \`/tmp/transcode/cache/u<id>/<file>/<hash>/<quality>/\` at boot. Lookup, write recording, TTL + LRU GC. Configurable via \`TRANSCODE_CACHE_TTL_MS\` (4 h), \`TRANSCODE_CACHE_MAX_BYTES\` (20 GB), \`TRANSCODE_CACHE_GC_INTERVAL_MS\` (5 min).

### Phase 2 — layout switch
- Every ffmpeg variant (main, early, remux, audio) writes under the new cache root. Sibling \`profileHash[-variant]\` dirs so processes for the same playback never collide.
- \`buildPlaybackProfileFromContext\` maps the existing \`SessionContext\` into the \`PlaybackProfile\` consumed by \`computeProfileHash\`.
- Legacy \`/tmp/transcode/stream\` removed entirely (one-shot wipe on boot, then dropped — \`/tmp\` is volatile, no carry-over needed).
- \`TranscodeCacheService.runGc\` gains a "missing on disk" pre-pass so externally-wiped dirs get dropped from the index automatically.

### Phase 3 — live sessions & heartbeat
- \`LiveSessionRegistry\`: in-memory map keyed by a UUID \`sessionId\`. Fields for user/media/profileHash/quality/device/lastBeat/position/state + audio/subtitle track selection. GC every 5 s, 30 s TTL. Overridable via \`STREAM_LIVE_SESSION_TTL_MS\` / \`STREAM_LIVE_SESSION_GC_INTERVAL_MS\`.
- \`playbackInfo\` emits a \`sessionId\` and pre-registers the corresponding LiveSession.
- New \`DELETE /stream/sessions/:sessionId\` for sid-scoped stop. The existing \`DELETE /stream/:mediaFileId/sessions\` also drops matching LiveSessions on player unload.
- \`PlaybackController.updateState\` refreshes the LiveSession on every heartbeat call and debounces the DB write to 30 s (state transitions and the completion threshold short-circuit the debounce).
- Frontend \`savePosition\` embeds \`sessionId\` / \`state\` / \`quality\`, time-based dedup so paused players still emit a beat every 10 s.

### Phase 4 — multi-profile coexistence + cache survives kill
- Session map keys read \`<file>-u<user>-<cacheKey>\`. Different devices with byte-incompatible streams coexist as siblings instead of killing each other.
- Drift detection in \`playback-info\` is removed: profile-hash routing makes a hop from browser to cast spawn a new session under the cast's hash and leave the browser's session untouched.
- \`killSession\` / \`cleanupStaleSessions\` no longer wipe the cache directory. \`TranscodeCacheService\` owns disk lifecycle exclusively.
- Admin dashboard "active streams": the \`device\` column prefers the per-session \`deviceLabel\` from \`LiveSessionRegistry\` when available.

### Phase 5 — heartbeat-driven ffmpeg grace window
- \`cleanupStaleSessions\` reads \`LiveSessionRegistry.listForJob\` to decide when an ffmpeg has lost every viewer. \`JOB_GRACE_MS\` = 60 s default. Cache always survives the kill.
- Live-session TTL drops to 30 s, cleanup cadence to 10 s. Total time from "user gone" to "ffmpeg dead" is ~100 s; a fresh play within the cache TTL reattaches to the existing segments without retranscoding.
- Sessions that were never paired with a live session (legacy URL fetches, admin scrubbing) fall back to \`STREAM_JOB_FALLBACK_TIMEOUT_MS\` (30 min default).
- \`docker-compose.example.yml\` gains a "Streaming session tuning" block listing every env override + its default.

### Manifest \`?sid=\` routing
- Every URL the client emits — \`master.m3u8\`, variant playlists, segment URLs, init segments, DirectPlay range requests, Cast URLs — carries the live session id baked into the query string. The pattern matches what Jellyfin / Plex / YouTube do for cross-client manifest binding (URL-baked, no client-side request rewriting needed).
- \`resolveSession\` / \`resolveEarlySession\` route segment fetches to the exact \`(file, user, profileHash)\` transcode session via the sid. Fallback to "most recently accessed" heuristic only for legacy clients without a sid.

### Audit + fixes
Plugged four corner cases the full-scenario audit surfaced:
- Variant sessions (\`-early\`, \`-remux\`, \`-a<N>\`) silently dropped to the 30-min fallback timer because their suffixed hash never matched the registry's base hash.
- Cast viewers stopped receiving heartbeats once they handed off — sender was still beating the now-paused browser session id.
- Closing one device tore down every device on the same file via the bulk-stop endpoint.
- Transient heartbeat failure (background tab, network blip) tripped the grace timer even when the client was still actively pulling segments.

### Refactor pass
- New \`transcoding/variant.ts\` owns the variant suffix model: \`SessionVariant\` discriminated union, \`variantHash\`, \`baseProfileHash\`, \`isVariantOf\`. Replaces five inline duplications of the suffix template literal + the strip regex.
- \`TranscodeSession\` drops the ambiguous \`profileHash\` field. Replaced by \`baseProfileHash\` + \`variant\`; the cache key is derived on demand. Single source of truth.
- Session-key composition collapses to one helper. \`getExistingSession\` takes an optional variant; \`audioSessionKey\` / \`earlySessionKey\` gone.
- \`streamQuery({ token?, sid? }, base?)\` replaces the previous \`buildStreamQuery\` + \`appendSidToUrl\` pair.
- \`PlayerComponent.activeSessionId()\` replaces three copies of the cast-vs-local sid ternary.

## Test plan
- \`profile-hash.spec.ts\` — 11 tests (hash determinism, single-field sensitivity, HDR / tvPlatform separation, context adapter).
- \`transcode-cache.service.spec.ts\` — 13 tests (boot scan, TTL eviction, "missing dir" gc, env override).
- \`live-session.service.spec.ts\` — 8 tests (heartbeat refresh, listForJob filtering, TTL).
- \`variant.spec.ts\` — 11 tests (variant suffix, base hash strip, round-trip, isVariantOf).
- 71 tests total. \`tsc --noEmit\` passes back + front.
- Manual smoke tested: stream transcode + seek + quality change + multi-audio + cast. Segments land under the new cache root, sid present on every URL, multi-device coexists, close + reopen reattaches without retranscoding.

## Follow-ups

- #291 — 11 deferred cleanups (Cast lifetime decouple, auto-recreate LS, deprecate bulk-stop, centralise TTLs, admin cache purge action, e2e tests, etc.)
- #292 — Phase 6 metrics (live sessions, jobs, cache hit-rate)