### PR TITLE
fix(layout): tablet native top toolbar offset and dock nav swap

### DIFF
--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -95,7 +95,7 @@
     <div appTvRow
          [appTvRowSnap]="true"
          class="hidden items-center justify-end gap-1 absolute right-4 z-50 pointer-events-none [&>*]:pointer-events-auto"
-         [style.top]="tv.isTv() ? 'calc(4rem + env(safe-area-inset-top, 0px))' : 'calc(1.5rem + env(safe-area-inset-top, 0px))'"
+         [style.top]="tv.isTv() ? 'calc(4rem + env(safe-area-inset-top, 0px))' : isNative ? 'calc(0.3rem + env(safe-area-inset-top, 1.5rem))' : '1.5rem'"
          [class.lg:flex]="device.isDesktop() || (device.isTv() && navbar.effectiveSidebarPinned())"
          [class.md:flex]="device.isTablet() && navbar.effectiveSidebarPinned()">
       @if (castPlayer.hasMedia()) {
@@ -123,9 +123,8 @@
     <main
       class="min-w-0 flex-1 p-4 lg:p-8"
       [class.overflow-x-clip]="!navbar.isHeroPage()"
-      [class.lg:pt-20]="!navbar.isHeroPage() && !isNative && !navbar.mobileNavbarVisible()"
+      [class.lg:pt-20]="!navbar.isHeroPage() && !navbar.mobileNavbarVisible()"
       [class.pt-8]="!navbar.isHeroPage() && !isNative && navbar.mobileNavbarVisible()"
-      [style.padding-top]="!navbar.isHeroPage() && isNative && !navbar.mobileNavbarVisible() ? 'calc(env(safe-area-inset-top, 0px) + 1rem)' : null"
     >
       @if (!networkService.isOnline()) {
         <div class="alert alert-warning mb-4 flex items-center justify-between py-2">
@@ -159,10 +158,10 @@
              4 nav items distribute evenly across 5 columns. The FAB sits
              outside the dock to keep .dock's position:fixed intact. -->
         <span aria-hidden="true" class="invisible"></span>
-        <a routerLink="/requests" routerLinkActive="dock-active" [routerLinkActiveOptions]="{ exact: false }"
+        <a routerLink="/history" routerLinkActive="dock-active" [routerLinkActiveOptions]="{ exact: false }"
            (click)="resetNavHistory()">
-          <svg lucideClipboardList class="h-5 w-5"></svg>
-          <span class="dock-label truncate max-w-full">{{ 'nav.requests' | translate }}</span>
+          <svg lucideHistory class="h-5 w-5"></svg>
+          <span class="dock-label truncate max-w-full">{{ 'nav.history' | translate }}</span>
         </a>
         <button (click)="toggleBottomMenu()" [class.dock-active]="bottomMenuOpen()"
                 class="[&.dock-active]:before:hidden [&.dock-active]:after:hidden">
@@ -222,9 +221,14 @@
                 </a>
               </li>
               <li>
-                <a routerLink="/history" routerLinkActive="active" (click)="resetNavHistory()">
-                  <svg lucideHistory class="h-5 w-5"></svg>
-                  {{ 'nav.history' | translate }}
+                <a routerLink="/requests" routerLinkActive="active" class="justify-between" (click)="resetNavHistory()">
+                  <span class="flex items-center gap-2">
+                    <svg lucideClipboardList class="h-5 w-5"></svg>
+                    {{ 'nav.requests' | translate }}
+                  </span>
+                  @if (pendingRequestCount() > 0) {
+                    <span class="badge badge-sm badge-warning">{{ pendingRequestCount() }}</span>
+                  }
                 </a>
               </li>
               <li>


### PR DESCRIPTION
## Summary
- Use `safe-area-inset-top` for the absolute-positioned cast/user toolbar when running natively, so it no longer collides with the status bar on tablets where the sidebar is pinned.
- Drop the per-native `padding-top` fork on `<main>` — the spacer above already accounts for the inset.
- Move `/requests` from the phone dock into the more menu (with the pending-count badge), and promote `/history` into the dock slot.

## Test plan
- [ ] Native tablet build with sidebar pinned: top-right toolbar sits clear of the status bar
- [ ] Web tablet: no regression on the toolbar position
- [ ] Phone dock: history visible in the dock, requests appears in the more menu with the pending badge