### PR TITLE
chore(transcoding): strip phase comments in qsv decoders

### DIFF
--- a/backend/src/modules/streaming/transcoding/codec/decoders/index.ts
+++ b/backend/src/modules/streaming/transcoding/codec/decoders/index.ts
@@ -30,7 +30,7 @@ const DESCRIPTORS: readonly DecoderDescriptor[] = [
   // Intel modern path. Default qsv decoder emits VAAPI surfaces (drop-
   // in compatible with the scale_vaapi-based encoder chains). A
   // qsv-native variant emits QSV surfaces directly — selected only by
-  // paths that opt in (vpp_qsv crop in Phase 5+).
+  // paths that opt in (e.g. vpp_qsv crop).
   h264QsvDecoder,
   hevcQsvDecoder,
   av1QsvDecoder,
@@ -101,7 +101,7 @@ export const ALL_DECODERS: readonly DecoderDescriptor[] = [
 ];
 
 /** Lookup a qsv-native decoder by source codec — exposed for the
- *  Phase 5 vpp_qsv crop path that bypasses the registry resolver. */
+ *  vpp_qsv crop path that bypasses the registry resolver. */
 export function findQsvNativeDecoder(
   codec: 'h264' | 'hevc' | 'av1',
 ): DecoderDescriptor | null {

--- a/backend/src/modules/streaming/transcoding/codec/decoders/qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/decoders/qsv.ts
@@ -16,9 +16,9 @@ function qsvDecoder(codec: VideoCodec, maxBitDepth: 8 | 10): DecoderDescriptor {
     sourceCodec: codec,
     maxBitDepth,
     // 'vaapi' rather than 'qsv': the decoder produces VAAPI surfaces
-    // that the qsv encoder filter chain hwmap's into qsv format. A
-    // future encoder chain that consumes qsv surfaces directly (Phase
-    // 5: vpp_qsv crop) opts into the qsv-native decoder below.
+    // that the qsv encoder filter chain hwmap's into qsv format. The
+    // qsv-native variant below emits QSV surfaces directly for chains
+    // (e.g. vpp_qsv crop) that consume them without hwmap.
     outputSurface: 'vaapi',
     supports: () => true,
     buildInputArgs: () => [
@@ -40,9 +40,9 @@ function qsvDecoder(codec: VideoCodec, maxBitDepth: 8 | 10): DecoderDescriptor {
 }
 
 /** QSV-native decoder variant — same iGPU but emits QSV surfaces
- *  directly. Used by `vpp_qsv` crop / scale paths in Phase 5; the
- *  default qsv decoder above stays VAAPI-output for compatibility
- *  with the existing scale_vaapi-based encoder chains. */
+ *  directly. Selected by `vpp_qsv` crop / scale paths that consume
+ *  QSV surfaces; the default qsv decoder above stays VAAPI-output for
+ *  compatibility with the scale_vaapi-based encoder chains. */
 function qsvNativeDecoder(
   codec: VideoCodec,
   maxBitDepth: 8 | 10,


### PR DESCRIPTION
## Summary
- Removes the four remaining \`Phase 5\` references in \`backend/src/modules/streaming/transcoding/codec/decoders/qsv.ts\` and \`.../decoders/index.ts\`.
- Rewrites each doc-block to describe today's contract (default qsv decoder emits VAAPI surfaces; the qsv-native variant emits QSV surfaces for chains that consume them directly).
- Matches the project's no-phase-comments policy and closes the only remaining occurrences flagged in #291.

Refs: #291

## Test plan
- [ ] \`grep -ri "phase" backend/src/modules/streaming/transcoding/codec/decoders/\` returns nothing
- [ ] Existing transcoding behaviour unchanged (comment-only edits)