### PR TITLE
fix(player): refresh sid via playback-info on cast disconnect

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1765,12 +1765,25 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     try {
       if (this.engine) this.engine.muted = false;
       if (this.engine && this.mediaFileId) {
+        // Mint a fresh sid: the browser's pre-cast LiveSession was
+        // GC'd while the cast receiver held the only live entry, so
+        // reusing `this.playbackInfo?.sessionId` would race against
+        // the heartbeat fallback path and flash a reload.
+        const deviceProfile = this.deviceProfileService.getProfile();
+        this.playbackInfo = await this.streamingApi.getPlaybackInfo(
+          this.mediaFileId,
+          deviceProfile,
+          this.activeBurnInId ?? undefined,
+          this.activeAudioStreamIndex ?? undefined,
+          undefined,
+          castPos > 0 ? Math.floor(castPos) : undefined,
+        );
+        const sid = this.playbackInfo.sessionId;
         const mode = this.playbackMode();
         const savedQualityId = this.activeQualityId();
         const startQuality = mode !== 'direct' && savedQualityId !== 'auto'
           ? savedQualityId
           : undefined;
-        const sid = this.playbackInfo?.sessionId;
         const url = mode === 'direct'
           ? this.streamingApi.getStreamUrl(this.mediaFileId, sid)
           : this.streamingApi.getHlsUrl(this.mediaFileId, startQuality, undefined, sid);


### PR DESCRIPTION
## Summary
- \`resumeLocalAfterCast\` reused \`this.playbackInfo?.sessionId\`, but the browser's pre-cast \`LiveSession\` had already been GC'd by the time cast ended (only the cast receiver was heart-beating).
- The stale sid forced the backend onto its fallback-attach heuristic and produced a visible reload when handing playback back to the local engine.
- Now we call \`getPlaybackInfo\` at the top of the resume path with the current device profile, current burn-in / audio-stream selections, and the cast position as \`startAt\` so ffmpeg pre-spawns at the right offset.

Refs: #291

## Test plan
- [ ] Start playback in the browser, cast for ~1 min (long enough for the original browser sid to be GC'd), disconnect cast — local engine resumes at the cast position without a visible reload.
- [ ] Resume happens whether the mode is direct/remux/transcode.
- [ ] Burn-in + alternate-audio selections survive the cast → local hand-back.