### PR TITLE
refactor(streaming): centralise session/transcode lifetime constants

### DIFF
--- a/backend/src/modules/streaming/lifetime-constants.ts
+++ b/backend/src/modules/streaming/lifetime-constants.ts
@@ -1,0 +1,56 @@
+/**
+ * Single tuning surface for streaming-session lifetimes. Every env
+ * var that controls how long a live session, a transcode job or a
+ * cache entry survives is declared here, with its default. Services
+ * read the matching getter on instantiation — lazy reads keep the
+ * unit tests able to mutate process.env per-case.
+ *
+ *   STREAM_LIVE_SESSION_TTL_MS         live-session.service.ts
+ *   STREAM_LIVE_SESSION_GC_INTERVAL_MS live-session.service.ts
+ *   STREAM_JOB_GRACE_MS                transcoding/constants.ts
+ *   STREAM_JOB_FALLBACK_TIMEOUT_MS     transcoding/constants.ts
+ *   TRANSCODE_CACHE_TTL_MS             transcode-cache.service.ts
+ *   TRANSCODE_CACHE_MAX_BYTES          transcode-cache.service.ts
+ *   TRANSCODE_CACHE_GC_INTERVAL_MS     transcode-cache.service.ts
+ */
+
+const DEFAULT_LIVE_SESSION_TTL_MS = 30_000;
+const DEFAULT_LIVE_SESSION_GC_INTERVAL_MS = 5_000;
+const DEFAULT_JOB_GRACE_MS = 60_000;
+const DEFAULT_JOB_FALLBACK_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_CACHE_TTL_MS = 4 * 60 * 60 * 1000;
+const DEFAULT_CACHE_MAX_BYTES = 20 * 1024 * 1024 * 1024;
+const DEFAULT_CACHE_GC_INTERVAL_MS = 5 * 60 * 1000;
+
+function readEnvPositiveInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export const StreamLifetime = {
+  liveSessionTtlMs: (): number =>
+    readEnvPositiveInt('STREAM_LIVE_SESSION_TTL_MS', DEFAULT_LIVE_SESSION_TTL_MS),
+  liveSessionGcIntervalMs: (): number =>
+    readEnvPositiveInt(
+      'STREAM_LIVE_SESSION_GC_INTERVAL_MS',
+      DEFAULT_LIVE_SESSION_GC_INTERVAL_MS,
+    ),
+  jobGraceMs: (): number =>
+    readEnvPositiveInt('STREAM_JOB_GRACE_MS', DEFAULT_JOB_GRACE_MS),
+  jobFallbackTimeoutMs: (): number =>
+    readEnvPositiveInt(
+      'STREAM_JOB_FALLBACK_TIMEOUT_MS',
+      DEFAULT_JOB_FALLBACK_TIMEOUT_MS,
+    ),
+  cacheTtlMs: (): number =>
+    readEnvPositiveInt('TRANSCODE_CACHE_TTL_MS', DEFAULT_CACHE_TTL_MS),
+  cacheMaxBytes: (): number =>
+    readEnvPositiveInt('TRANSCODE_CACHE_MAX_BYTES', DEFAULT_CACHE_MAX_BYTES),
+  cacheGcIntervalMs: (): number =>
+    readEnvPositiveInt(
+      'TRANSCODE_CACHE_GC_INTERVAL_MS',
+      DEFAULT_CACHE_GC_INTERVAL_MS,
+    ),
+} as const;

--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -5,6 +5,7 @@ import {
   OnModuleInit,
 } from '@nestjs/common';
 import { randomUUID } from 'crypto';
+import { StreamLifetime } from './lifetime-constants';
 
 export type PlaybackState = 'playing' | 'paused' | 'buffering';
 export type SessionKind = 'transcode' | 'remux' | 'directplay';
@@ -46,26 +47,15 @@ export interface LiveSessionSnapshot extends Omit<
   lastBeat: Date;
 }
 
-/** A live session is considered dead this long after the last
- *  heartbeat. 30 s = three missed beats at the client's 10 s cadence,
- *  enough to absorb transient network hiccups without dragging the
- *  ffmpeg keep-alive window. */
-const DEFAULT_TTL_MS = 30_000;
-const DEFAULT_GC_INTERVAL_MS = 5_000;
-
-function readEnvInt(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (!raw) return fallback;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
-
 /**
  * In-memory registry of "currently watching" sessions. One entry per
  * sessionId emitted by `playback-info`. Refreshed by the heartbeat
  * piggybacked on `PUT /api/playback/media/:id/state`; explicit stop
  * via `DELETE /api/stream/sessions/:sessionId`. GC drops entries that
- * haven't been beaten in {@link DEFAULT_TTL_MS}.
+ * haven't been beaten inside `STREAM_LIVE_SESSION_TTL_MS` (30 s
+ * default — three missed beats at the client's 10 s cadence, enough
+ * to absorb transient network hiccups without dragging the ffmpeg
+ * keep-alive window).
  *
  * Drives the admin "now watching" dashboard and the ffmpeg job grace
  * window — `listForJob` reports whether a given encoder still has any
@@ -77,14 +67,8 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
   private readonly sessions = new Map<string, LiveSession>();
   private gcTimer: ReturnType<typeof setInterval> | null = null;
 
-  private readonly ttlMs = readEnvInt(
-    'STREAM_LIVE_SESSION_TTL_MS',
-    DEFAULT_TTL_MS,
-  );
-  private readonly gcIntervalMs = readEnvInt(
-    'STREAM_LIVE_SESSION_GC_INTERVAL_MS',
-    DEFAULT_GC_INTERVAL_MS,
-  );
+  private readonly ttlMs = StreamLifetime.liveSessionTtlMs();
+  private readonly gcIntervalMs = StreamLifetime.liveSessionGcIntervalMs();
 
   onModuleInit(): void {
     this.gcTimer = setInterval(() => this.runGc(), this.gcIntervalMs);

--- a/backend/src/modules/streaming/transcoding/constants.ts
+++ b/backend/src/modules/streaming/transcoding/constants.ts
@@ -1,25 +1,21 @@
+import { StreamLifetime } from '../lifetime-constants';
+
 /** Maximum idle window for transcode sessions that were never paired
  *  with a {@link LiveSessionRegistry} entry (legacy URL fetches, admin
  *  scrubbing, etc.). Sessions tied to a live session ride on the
  *  {@link JOB_GRACE_MS} grace window after their last heartbeat
- *  instead — see `TranscodingService.cleanupStaleSessions`. */
-export const SESSION_TIMEOUT_MS = (() => {
-  const raw = process.env.STREAM_JOB_FALLBACK_TIMEOUT_MS;
-  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 30 * 60 * 1000;
-})();
+ *  instead — see `TranscodingService.cleanupStaleSessions`. Sourced
+ *  from `STREAM_JOB_FALLBACK_TIMEOUT_MS` — see lifetime-constants.ts. */
+export const SESSION_TIMEOUT_MS = StreamLifetime.jobFallbackTimeoutMs();
 
 /** Grace window between the last matching live session disappearing and
  *  the ffmpeg job being killed. Keeps a brief reconnect window so a
  *  client that misses a few heartbeats (background tab, lockscreen)
  *  can reattach without restarting the encoder. The cache directory
  *  is preserved across the kill — a fresh play picks up from the
- *  existing segments. */
-export const JOB_GRACE_MS = (() => {
-  const raw = process.env.STREAM_JOB_GRACE_MS;
-  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 60_000;
-})();
+ *  existing segments. Sourced from `STREAM_JOB_GRACE_MS` — see
+ *  lifetime-constants.ts. */
+export const JOB_GRACE_MS = StreamLifetime.jobGraceMs();
 
 /** Max gap (in segments) between FFmpeg frontier and requested segment before restarting. */
 export const SEEK_WAIT_THRESHOLD = 15;

--- a/backend/src/modules/streaming/transcoding/transcode-cache.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcode-cache.service.ts
@@ -7,6 +7,7 @@ import {
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { TRANSCODE_DIR } from '../../../common/constants/paths';
+import { StreamLifetime } from '../lifetime-constants';
 
 /**
  * Index entry for one cache directory. A cache directory holds every
@@ -33,26 +34,13 @@ export interface QualityCache {
 
 const CACHE_LAYOUT_ROOT = path.join(TRANSCODE_DIR, 'cache');
 
-/** Default 4 h since last access. */
-const DEFAULT_CACHE_TTL_MS = 4 * 60 * 60 * 1000;
-/** Default 20 GB. */
-const DEFAULT_CACHE_MAX_BYTES = 20 * 1024 * 1024 * 1024;
-/** Default GC tick 5 min. */
-const DEFAULT_CACHE_GC_INTERVAL_MS = 5 * 60 * 1000;
-
-function readEnvInt(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (!raw) return fallback;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
-
 /**
  * In-memory index of the on-disk transcode cache. Scans the cache root
  * at boot, tracks segment / init writes as `TranscodingService` fans
  * them out, evicts entries by TTL + LRU. `lookup` returns the
  * authoritative entry the streaming controller can serve from before
- * spawning a fresh ffmpeg.
+ * spawning a fresh ffmpeg. TTL / max-bytes / GC cadence come from
+ * `TRANSCODE_CACHE_*` env vars — see lifetime-constants.ts.
  */
 @Injectable()
 export class TranscodeCacheService implements OnModuleInit, OnModuleDestroy {
@@ -60,18 +48,9 @@ export class TranscodeCacheService implements OnModuleInit, OnModuleDestroy {
   private readonly entries = new Map<string, CacheEntry>();
   private gcTimer: ReturnType<typeof setInterval> | null = null;
 
-  private readonly ttlMs = readEnvInt(
-    'TRANSCODE_CACHE_TTL_MS',
-    DEFAULT_CACHE_TTL_MS,
-  );
-  private readonly maxBytes = readEnvInt(
-    'TRANSCODE_CACHE_MAX_BYTES',
-    DEFAULT_CACHE_MAX_BYTES,
-  );
-  private readonly gcIntervalMs = readEnvInt(
-    'TRANSCODE_CACHE_GC_INTERVAL_MS',
-    DEFAULT_CACHE_GC_INTERVAL_MS,
-  );
+  private readonly ttlMs = StreamLifetime.cacheTtlMs();
+  private readonly maxBytes = StreamLifetime.cacheMaxBytes();
+  private readonly gcIntervalMs = StreamLifetime.cacheGcIntervalMs();
 
   async onModuleInit(): Promise<void> {
     await fsp.mkdir(CACHE_LAYOUT_ROOT, { recursive: true });


### PR DESCRIPTION
## Summary
- Adds \`backend/src/modules/streaming/lifetime-constants.ts\` as the single tuning surface for every env-driven streaming lifetime knob (\`STREAM_LIVE_SESSION_TTL_MS\`, \`STREAM_LIVE_SESSION_GC_INTERVAL_MS\`, \`STREAM_JOB_GRACE_MS\`, \`STREAM_JOB_FALLBACK_TIMEOUT_MS\`, \`TRANSCODE_CACHE_TTL_MS\`, \`TRANSCODE_CACHE_MAX_BYTES\`, \`TRANSCODE_CACHE_GC_INTERVAL_MS\`).
- Services now call \`StreamLifetime.<name>()\` instead of duplicating the \`readEnvInt\` helper + default value. Reads stay lazy (per-instance, not per-module) so the existing unit specs that mutate \`process.env\` per case still pass.
- Defaults preserved exactly; no behaviour change.

Refs: #291

## Test plan
- [x] \`npx jest src/modules/streaming/\` — 43/43 specs pass.
- [x] \`npx tsc --noEmit\` clean.
- [ ] Smoke-test a transcode session at runtime (ensure TTLs still apply).