### PR TITLE
revert(layout): put requests back in the phone dock and history in the more menu

### DIFF
--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -158,10 +158,10 @@
              4 nav items distribute evenly across 5 columns. The FAB sits
              outside the dock to keep .dock's position:fixed intact. -->
         <span aria-hidden="true" class="invisible"></span>
-        <a routerLink="/history" routerLinkActive="dock-active" [routerLinkActiveOptions]="{ exact: false }"
+        <a routerLink="/requests" routerLinkActive="dock-active" [routerLinkActiveOptions]="{ exact: false }"
            (click)="resetNavHistory()">
-          <svg lucideHistory class="h-5 w-5"></svg>
-          <span class="dock-label truncate max-w-full">{{ 'nav.history' | translate }}</span>
+          <svg lucideClipboardList class="h-5 w-5"></svg>
+          <span class="dock-label truncate max-w-full">{{ 'nav.requests' | translate }}</span>
         </a>
         <button (click)="toggleBottomMenu()" [class.dock-active]="bottomMenuOpen()"
                 class="[&.dock-active]:before:hidden [&.dock-active]:after:hidden">
@@ -221,14 +221,9 @@
                 </a>
               </li>
               <li>
-                <a routerLink="/requests" routerLinkActive="active" class="justify-between" (click)="resetNavHistory()">
-                  <span class="flex items-center gap-2">
-                    <svg lucideClipboardList class="h-5 w-5"></svg>
-                    {{ 'nav.requests' | translate }}
-                  </span>
-                  @if (pendingRequestCount() > 0) {
-                    <span class="badge badge-sm badge-warning">{{ pendingRequestCount() }}</span>
-                  }
+                <a routerLink="/history" routerLinkActive="active" (click)="resetNavHistory()">
+                  <svg lucideHistory class="h-5 w-5"></svg>
+                  {{ 'nav.history' | translate }}
                 </a>
               </li>
               <li>


### PR DESCRIPTION
## Summary
- Reverts the dock-swap portion of #293: \`/requests\` (with \`lucideClipboardList\`) goes back into the phone dock, and \`/history\` (simple link) returns to the more menu.
- The other two changes from #293 (tablet native top toolbar offset, \`<main>\` padding-top simplification) are left intact.

## Test plan
- [ ] Phone dock shows the Requests item with the clipboard icon
- [ ] Opening the "more" menu shows the History entry without a badge