### PR TITLE
fix(streaming): isolate ActiveStreamTracker caches per (user, file)

### DIFF
--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -405,7 +405,10 @@ export class SystemController {
       // Single source of truth: the audio plan stream-builder stored at
       // playback-info time. mode/codec/bitrate are read directly — no
       // re-derivation, no string comparison gymnastics.
-      const audioPlan = this.activeStreamTracker.getAudioPlan(s.mediaFileId);
+      const audioPlan =
+        s.userId != null
+          ? this.activeStreamTracker.getAudioPlan(s.userId, s.mediaFileId)
+          : null;
 
       if (s.mode === 'transcode') {
         videoPlaybackMode = `Transcodage (${HW_ACCEL_LABEL[hwAccel] ?? hwAccel.toUpperCase()})`;

--- a/backend/src/modules/streaming/active-stream-tracker.service.spec.ts
+++ b/backend/src/modules/streaming/active-stream-tracker.service.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for the per-(user, file) keying contract on ActiveStreamTracker.
+ * Asserts the isolation flagged in #291: two users on the same media
+ * file must never clobber each other's audio plan, mux flavour, audio
+ * track pick, etc. Source-dimension caches stay file-scoped because
+ * they describe the file itself, identical across users.
+ */
+import { ActiveStreamTracker } from './active-stream-tracker.service';
+
+describe('ActiveStreamTracker — per-(user, file) keying', () => {
+  let tracker: ActiveStreamTracker;
+  const FILE_ID = 7;
+  const ALICE = 1;
+  const BOB = 2;
+
+  beforeEach(() => {
+    tracker = new ActiveStreamTracker();
+    tracker.onModuleInit();
+  });
+
+  afterEach(() => {
+    tracker.onModuleDestroy();
+  });
+
+  it('useTs is isolated per user (Tizen vs browser on the same file)', () => {
+    tracker.setUseTs(ALICE, FILE_ID, true);
+    tracker.setUseTs(BOB, FILE_ID, false);
+    expect(tracker.getUseTs(ALICE, FILE_ID)).toBe(true);
+    expect(tracker.getUseTs(BOB, FILE_ID)).toBe(false);
+  });
+
+  it('audioPlan is isolated per user (different bitrates / codecs)', () => {
+    tracker.setAudioPlan(ALICE, FILE_ID, {
+      mode: 'transcode',
+      codec: 'aac',
+      bitrateBps: 128_000,
+    });
+    tracker.setAudioPlan(BOB, FILE_ID, { mode: 'copy', codec: 'eac3' });
+    expect(tracker.getAudioPlan(ALICE, FILE_ID)).toEqual({
+      mode: 'transcode',
+      codec: 'aac',
+      bitrateBps: 128_000,
+    });
+    expect(tracker.getAudioPlan(BOB, FILE_ID)).toEqual({
+      mode: 'copy',
+      codec: 'eac3',
+    });
+  });
+
+  it('audioStreamCount is isolated per user (device-driven cap)', () => {
+    tracker.setAudioStreamCount(ALICE, FILE_ID, 3);
+    tracker.setAudioStreamCount(BOB, FILE_ID, 1);
+    expect(tracker.getAudioStreamCount(ALICE, FILE_ID)).toBe(3);
+    expect(tracker.getAudioStreamCount(BOB, FILE_ID)).toBe(1);
+  });
+
+  it('deviceType and hdrLadder are isolated per user', () => {
+    tracker.setDeviceType(ALICE, FILE_ID, 'mobile');
+    tracker.setDeviceType(BOB, FILE_ID, 'desktop');
+    tracker.setHdrLadder(ALICE, FILE_ID, true);
+    tracker.setHdrLadder(BOB, FILE_ID, false);
+    expect(tracker.getDeviceType(ALICE, FILE_ID)).toBe('mobile');
+    expect(tracker.getDeviceType(BOB, FILE_ID)).toBe('desktop');
+    expect(tracker.getHdrLadder(ALICE, FILE_ID)).toBe(true);
+    expect(tracker.getHdrLadder(BOB, FILE_ID)).toBe(false);
+  });
+
+  it('useExtXMedia and canCopy{Video,Audio} are isolated per user', () => {
+    tracker.setUseExtXMedia(ALICE, FILE_ID, true);
+    tracker.setUseExtXMedia(BOB, FILE_ID, false);
+    tracker.setCanCopyVideo(ALICE, FILE_ID, true);
+    tracker.setCanCopyVideo(BOB, FILE_ID, false);
+    tracker.setCanCopyAudio(ALICE, FILE_ID, true);
+    tracker.setCanCopyAudio(BOB, FILE_ID, false);
+
+    expect(tracker.getUseExtXMedia(ALICE, FILE_ID)).toBe(true);
+    expect(tracker.getUseExtXMedia(BOB, FILE_ID)).toBe(false);
+    expect(tracker.getCanCopyVideo(ALICE, FILE_ID)).toBe(true);
+    expect(tracker.getCanCopyVideo(BOB, FILE_ID)).toBe(false);
+    expect(tracker.getCanCopyAudio(ALICE, FILE_ID)).toBe(true);
+    expect(tracker.getCanCopyAudio(BOB, FILE_ID)).toBe(false);
+  });
+
+  it('audioStreamIndex and burnIn are isolated per user', () => {
+    tracker.setAudioStreamIndex(ALICE, FILE_ID, 0);
+    tracker.setAudioStreamIndex(BOB, FILE_ID, 2);
+    tracker.setBurnIn(ALICE, FILE_ID, {
+      filter: "subtitles=':si=0'",
+      streamIndex: 3,
+      type: 'pgs',
+    });
+    tracker.setBurnIn(BOB, FILE_ID, undefined);
+    expect(tracker.getAudioStreamIndex(ALICE, FILE_ID)).toBe(0);
+    expect(tracker.getAudioStreamIndex(BOB, FILE_ID)).toBe(2);
+    expect(tracker.getBurnIn(ALICE, FILE_ID)?.streamIndex).toBe(3);
+    expect(tracker.getBurnIn(BOB, FILE_ID)).toBeUndefined();
+  });
+
+  it('transcodeReasons, tonemapping, encoderPreset, videoVariant are isolated per user', () => {
+    tracker.setTranscodeReasons(ALICE, FILE_ID, [{ flag: 'codec', message: 'hevc' }]);
+    tracker.setTranscodeReasons(BOB, FILE_ID, []);
+    tracker.setTonemapping(ALICE, FILE_ID, true);
+    tracker.setTonemapping(BOB, FILE_ID, false);
+    tracker.setEncoderPreset(ALICE, FILE_ID, 'fast');
+    tracker.setEncoderPreset(BOB, FILE_ID, 'medium');
+    tracker.setVideoVariant(ALICE, FILE_ID, {
+      codec: 'h264',
+      profile: 'high',
+      level: '40',
+      hdr: null,
+    });
+    tracker.setVideoVariant(BOB, FILE_ID, null);
+
+    expect(tracker.getTranscodeReasons(ALICE, FILE_ID)).toHaveLength(1);
+    expect(tracker.getTranscodeReasons(BOB, FILE_ID)).toHaveLength(0);
+    expect(tracker.getTonemapping(ALICE, FILE_ID)).toBe(true);
+    expect(tracker.getTonemapping(BOB, FILE_ID)).toBe(false);
+    expect(tracker.getEncoderPreset(ALICE, FILE_ID)).toBe('fast');
+    expect(tracker.getEncoderPreset(BOB, FILE_ID)).toBe('medium');
+    expect(tracker.getVideoVariant(ALICE, FILE_ID)?.codec).toBe('h264');
+    expect(tracker.getVideoVariant(BOB, FILE_ID)).toBeUndefined();
+  });
+
+  it('source dimensions stay file-scoped (a file property identical across users)', () => {
+    // Source W/H describe the underlying file; both users see the same
+    // value regardless of which one set it last. Kept mediaFileId-keyed
+    // by design.
+    tracker.setSourceDimensions(FILE_ID, 1920, 1080);
+    expect(tracker.getSourceWidth(FILE_ID)).toBe(1920);
+    expect(tracker.getSourceHeight(FILE_ID)).toBe(1080);
+  });
+
+  it('unregister drops every per-(user, file) cache entry for that pair', () => {
+    tracker.setUseTs(ALICE, FILE_ID, true);
+    tracker.setAudioPlan(ALICE, FILE_ID, { mode: 'copy', codec: 'aac' });
+    tracker.setDeviceType(ALICE, FILE_ID, 'mobile');
+    // Bob shares the same file but unregister(Alice) must not touch him.
+    tracker.setUseTs(BOB, FILE_ID, false);
+
+    tracker.unregister(ALICE, FILE_ID);
+
+    expect(tracker.getUseTs(ALICE, FILE_ID)).toBe(false); // default
+    expect(tracker.getAudioPlan(ALICE, FILE_ID)).toBeNull();
+    expect(tracker.getDeviceType(ALICE, FILE_ID)).toBe('desktop'); // default
+    // Bob untouched.
+    expect(tracker.getUseTs(BOB, FILE_ID)).toBe(false);
+  });
+
+  it('register tracks (user, file) so two users coexist on the same file', () => {
+    tracker.register(ALICE, 'alice', FILE_ID, 'movie', 'movie', null);
+    tracker.register(BOB, 'bob', FILE_ID, 'movie', 'movie', null);
+    const active = tracker.getActive();
+    expect(active).toHaveLength(2);
+    expect(active.map((s) => s.userId).sort()).toEqual([ALICE, BOB]);
+  });
+});

--- a/backend/src/modules/streaming/active-stream-tracker.service.ts
+++ b/backend/src/modules/streaming/active-stream-tracker.service.ts
@@ -15,14 +15,13 @@ export interface DirectPlaySession {
 
 const STALE_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
 
+function userFileKey(userId: number, mediaFileId: number): string {
+  return `${userId}-${mediaFileId}`;
+}
+
 @Injectable()
 export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
   private readonly sessions = new Map<string, DirectPlaySession>();
-  /** Cache transcode reasons per mediaFileId (set during playback-info, read by dashboard) */
-  private readonly transcodeReasonsCache = new Map<
-    number,
-    { flag: string; message: string }[]
-  >();
   private cleanupTimer: ReturnType<typeof setInterval> | null = null;
 
   onModuleInit() {
@@ -41,7 +40,7 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
     mediaType: string,
     posterUrl: string | null,
   ) {
-    const key = `${userId}-${mediaFileId}`;
+    const key = userFileKey(userId, mediaFileId);
     const existing = this.sessions.get(key);
     if (existing) {
       existing.lastActivity = new Date();
@@ -60,8 +59,23 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
   }
 
   unregister(userId: number, mediaFileId: number) {
-    this.sessions.delete(`${userId}-${mediaFileId}`);
-    this.deviceNameCache.delete(`${userId}-${mediaFileId}`);
+    const key = userFileKey(userId, mediaFileId);
+    this.sessions.delete(key);
+    this.deviceNameCache.delete(key);
+    this.transcodeReasonsCache.delete(key);
+    this.tonemappingCache.delete(key);
+    this.burnInCache.delete(key);
+    this.audioStreamIndexCache.delete(key);
+    this.audioStreamCountCache.delete(key);
+    this.deviceTypeCache.delete(key);
+    this.useExtXMediaCache.delete(key);
+    this.useTsCache.delete(key);
+    this.encoderPresetCache.delete(key);
+    this.hdrLadderCache.delete(key);
+    this.videoVariantCache.delete(key);
+    this.canCopyVideoCache.delete(key);
+    this.canCopyAudioCache.delete(key);
+    this.audioPlanCache.delete(key);
   }
 
   /** Human-readable client device captured at playback-info ("Chrome — macOS",
@@ -71,36 +85,61 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
   private readonly deviceNameCache = new Map<string, string>();
 
   setDeviceName(userId: number, mediaFileId: number, name: string) {
-    if (name) this.deviceNameCache.set(`${userId}-${mediaFileId}`, name);
+    if (name) this.deviceNameCache.set(userFileKey(userId, mediaFileId), name);
   }
 
   getDeviceName(userId: number, mediaFileId: number): string | null {
-    return this.deviceNameCache.get(`${userId}-${mediaFileId}`) ?? null;
+    return this.deviceNameCache.get(userFileKey(userId, mediaFileId)) ?? null;
   }
 
-  private readonly tonemappingCache = new Map<number, boolean>();
+  /** Cache transcode reasons per (user, file) (set during playback-info, read by dashboard) */
+  private readonly transcodeReasonsCache = new Map<
+    string,
+    { flag: string; message: string }[]
+  >();
 
   setTranscodeReasons(
+    userId: number,
     mediaFileId: number,
     reasons: { flag: string; message: string }[],
   ) {
-    this.transcodeReasonsCache.set(mediaFileId, reasons);
+    this.transcodeReasonsCache.set(userFileKey(userId, mediaFileId), reasons);
   }
 
   getTranscodeReasons(
+    userId: number,
     mediaFileId: number,
   ): { flag: string; message: string }[] {
-    return this.transcodeReasonsCache.get(mediaFileId) ?? [];
+    return this.transcodeReasonsCache.get(userFileKey(userId, mediaFileId)) ?? [];
   }
 
-  private readonly burnInCache = new Map<number, BurnInSubtitle>();
+  private readonly tonemappingCache = new Map<string, boolean>();
 
-  setTonemapping(mediaFileId: number, value: boolean) {
-    this.tonemappingCache.set(mediaFileId, value);
+  setTonemapping(userId: number, mediaFileId: number, value: boolean) {
+    this.tonemappingCache.set(userFileKey(userId, mediaFileId), value);
   }
 
-  getTonemapping(mediaFileId: number): boolean {
-    return this.tonemappingCache.get(mediaFileId) ?? false;
+  getTonemapping(userId: number, mediaFileId: number): boolean {
+    return this.tonemappingCache.get(userFileKey(userId, mediaFileId)) ?? false;
+  }
+
+  private readonly burnInCache = new Map<string, BurnInSubtitle>();
+
+  setBurnIn(
+    userId: number,
+    mediaFileId: number,
+    info: BurnInSubtitle | undefined,
+  ) {
+    const key = userFileKey(userId, mediaFileId);
+    if (info) {
+      this.burnInCache.set(key, info);
+    } else {
+      this.burnInCache.delete(key);
+    }
+  }
+
+  getBurnIn(userId: number, mediaFileId: number): BurnInSubtitle | undefined {
+    return this.burnInCache.get(userFileKey(userId, mediaFileId)) ?? undefined;
   }
 
   /** HDR ladder eligibility — set at playback-info by stream-builder
@@ -109,90 +148,98 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
    *  playlist can emit the HEVC HDR ladder instead of the H.264 SDR
    *  ladder. Default false keeps the existing behaviour for callers
    *  that never reach playback-info (e.g. legacy direct URLs). */
-  private readonly hdrLadderCache = new Map<number, boolean>();
-  setHdrLadder(mediaFileId: number, value: boolean) {
-    this.hdrLadderCache.set(mediaFileId, value);
+  private readonly hdrLadderCache = new Map<string, boolean>();
+  setHdrLadder(userId: number, mediaFileId: number, value: boolean) {
+    this.hdrLadderCache.set(userFileKey(userId, mediaFileId), value);
   }
-  getHdrLadder(mediaFileId: number): boolean {
-    return this.hdrLadderCache.get(mediaFileId) ?? false;
+  getHdrLadder(userId: number, mediaFileId: number): boolean {
+    return this.hdrLadderCache.get(userFileKey(userId, mediaFileId)) ?? false;
   }
 
   /** Output codec variant chosen by stream-builder's selector. Read by
    *  the controller when building the SessionContext so ffmpeg-args
    *  resolves the right encoder descriptor. Single-codec-per-master
-   *  rule: only one variant per file at a time. */
-  private readonly videoVariantCache = new Map<number, CodecVariant>();
-  setVideoVariant(mediaFileId: number, variant: CodecVariant | null) {
-    if (variant) this.videoVariantCache.set(mediaFileId, variant);
-    else this.videoVariantCache.delete(mediaFileId);
+   *  rule: only one variant per (user, file) at a time. */
+  private readonly videoVariantCache = new Map<string, CodecVariant>();
+  setVideoVariant(
+    userId: number,
+    mediaFileId: number,
+    variant: CodecVariant | null,
+  ) {
+    const key = userFileKey(userId, mediaFileId);
+    if (variant) this.videoVariantCache.set(key, variant);
+    else this.videoVariantCache.delete(key);
   }
-  getVideoVariant(mediaFileId: number): CodecVariant | undefined {
-    return this.videoVariantCache.get(mediaFileId);
-  }
-
-  setBurnIn(mediaFileId: number, info: BurnInSubtitle | undefined) {
-    if (info) {
-      this.burnInCache.set(mediaFileId, info);
-    } else {
-      this.burnInCache.delete(mediaFileId);
-    }
-  }
-
-  getBurnIn(mediaFileId: number): BurnInSubtitle | undefined {
-    return this.burnInCache.get(mediaFileId) ?? undefined;
+  getVideoVariant(
+    userId: number,
+    mediaFileId: number,
+  ): CodecVariant | undefined {
+    return this.videoVariantCache.get(userFileKey(userId, mediaFileId));
   }
 
   private readonly audioStreamIndexCache = new Map<
-    number,
+    string,
     number | undefined
   >();
 
-  /** Number of audio streams per media file — used to decide multi-audio HLS mode */
-  private readonly audioStreamCountCache = new Map<number, number>();
+  /** Number of audio streams the user's device is exposed to — used to
+   *  decide multi-audio HLS mode. Per-(user, file) because a profile
+   *  that caps maxAudioStreams may see fewer streams than another. */
+  private readonly audioStreamCountCache = new Map<string, number>();
 
-  setAudioStreamCount(mediaFileId: number, count: number) {
-    this.audioStreamCountCache.set(mediaFileId, count);
+  setAudioStreamCount(userId: number, mediaFileId: number, count: number) {
+    this.audioStreamCountCache.set(userFileKey(userId, mediaFileId), count);
   }
 
-  getAudioStreamCount(mediaFileId: number): number {
-    return this.audioStreamCountCache.get(mediaFileId) ?? 0;
+  getAudioStreamCount(userId: number, mediaFileId: number): number {
+    return this.audioStreamCountCache.get(userFileKey(userId, mediaFileId)) ?? 0;
   }
 
   /** Client device category ('mobile' | 'desktop') captured at playback-info.
    *  Used by hlsMaster and HLS segment endpoints to pick the right bitrate ladder. */
-  private readonly deviceTypeCache = new Map<number, 'mobile' | 'desktop'>();
+  private readonly deviceTypeCache = new Map<string, 'mobile' | 'desktop'>();
 
-  setDeviceType(mediaFileId: number, value: 'mobile' | 'desktop') {
-    this.deviceTypeCache.set(mediaFileId, value);
+  setDeviceType(
+    userId: number,
+    mediaFileId: number,
+    value: 'mobile' | 'desktop',
+  ) {
+    this.deviceTypeCache.set(userFileKey(userId, mediaFileId), value);
   }
 
-  getDeviceType(mediaFileId: number): 'mobile' | 'desktop' {
-    return this.deviceTypeCache.get(mediaFileId) ?? 'desktop';
+  getDeviceType(userId: number, mediaFileId: number): 'mobile' | 'desktop' {
+    return (
+      this.deviceTypeCache.get(userFileKey(userId, mediaFileId)) ?? 'desktop'
+    );
   }
 
   /** Whether master.m3u8 decided to use separate audio renditions (EXT-X-MEDIA). */
-  private readonly useExtXMediaCache = new Map<number, boolean>();
+  private readonly useExtXMediaCache = new Map<string, boolean>();
 
-  setUseExtXMedia(mediaFileId: number, value: boolean) {
-    this.useExtXMediaCache.set(mediaFileId, value);
+  setUseExtXMedia(userId: number, mediaFileId: number, value: boolean) {
+    this.useExtXMediaCache.set(userFileKey(userId, mediaFileId), value);
   }
 
-  getUseExtXMedia(mediaFileId: number): boolean {
-    return this.useExtXMediaCache.get(mediaFileId) ?? false;
+  getUseExtXMedia(userId: number, mediaFileId: number): boolean {
+    return (
+      this.useExtXMediaCache.get(userFileKey(userId, mediaFileId)) ?? false
+    );
   }
 
   /** Set when the playback target is a Tizen TV that needs the MPEG-TS
    *  fallback (issue #148 — AVPlay rejects HLS-fMP4 from the HLS muxer).
    *  Drives the HLS segment container choice (mpegts vs fmp4) in
-   *  `buildFfmpegArgs`. Cast / browser / native mobile never set this. */
-  private readonly useTsCache = new Map<number, boolean>();
+   *  `buildFfmpegArgs`. Cast / browser / native mobile never set this.
+   *  Per-(user, file) because two devices on the same file can disagree
+   *  on the container — e.g. a Tizen + a browser session. */
+  private readonly useTsCache = new Map<string, boolean>();
 
-  setUseTs(mediaFileId: number, value: boolean) {
-    this.useTsCache.set(mediaFileId, value);
+  setUseTs(userId: number, mediaFileId: number, value: boolean) {
+    this.useTsCache.set(userFileKey(userId, mediaFileId), value);
   }
 
-  getUseTs(mediaFileId: number): boolean {
-    return this.useTsCache.get(mediaFileId) ?? false;
+  getUseTs(userId: number, mediaFileId: number): boolean {
+    return this.useTsCache.get(userFileKey(userId, mediaFileId)) ?? false;
   }
 
   private segmentDurationCache = 3;
@@ -205,25 +252,35 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
     return this.segmentDurationCache;
   }
 
-  setAudioStreamIndex(mediaFileId: number, index: number | undefined) {
-    if (index != null) this.audioStreamIndexCache.set(mediaFileId, index);
-    else this.audioStreamIndexCache.delete(mediaFileId);
+  setAudioStreamIndex(
+    userId: number,
+    mediaFileId: number,
+    index: number | undefined,
+  ) {
+    const key = userFileKey(userId, mediaFileId);
+    if (index != null) this.audioStreamIndexCache.set(key, index);
+    else this.audioStreamIndexCache.delete(key);
   }
 
-  getAudioStreamIndex(mediaFileId: number): number | undefined {
-    return this.audioStreamIndexCache.get(mediaFileId);
+  getAudioStreamIndex(
+    userId: number,
+    mediaFileId: number,
+  ): number | undefined {
+    return this.audioStreamIndexCache.get(userFileKey(userId, mediaFileId));
   }
 
   // ── Admin streaming settings forwarded to transcode sessions ──
-  private readonly encoderPresetCache = new Map<number, string>();
+  private readonly encoderPresetCache = new Map<string, string>();
   private qsvLowPowerCache = false;
 
-  setEncoderPreset(mediaFileId: number, preset: string) {
-    this.encoderPresetCache.set(mediaFileId, preset);
+  setEncoderPreset(userId: number, mediaFileId: number, preset: string) {
+    this.encoderPresetCache.set(userFileKey(userId, mediaFileId), preset);
   }
 
-  getEncoderPreset(mediaFileId: number): string {
-    return this.encoderPresetCache.get(mediaFileId) ?? 'faster';
+  getEncoderPreset(userId: number, mediaFileId: number): string {
+    return (
+      this.encoderPresetCache.get(userFileKey(userId, mediaFileId)) ?? 'faster'
+    );
   }
 
   /** QSV advanced options are global (driven by admin streaming settings). */
@@ -245,30 +302,35 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
 
   // ── Source-vs-client compat captured at playback-info time, read at
   //    master.m3u8 time to decide whether to emit a smart-remux variant ──
-  private readonly canCopyVideoCache = new Map<number, boolean>();
-  private readonly canCopyAudioCache = new Map<number, boolean>();
+  private readonly canCopyVideoCache = new Map<string, boolean>();
+  private readonly canCopyAudioCache = new Map<string, boolean>();
+  // Source dimensions are a property of the file, identical across users.
   private readonly sourceWidthCache = new Map<number, number>();
   private readonly sourceHeightCache = new Map<number, number>();
 
-  setCanCopyVideo(mediaFileId: number, value: boolean) {
-    this.canCopyVideoCache.set(mediaFileId, value);
+  setCanCopyVideo(userId: number, mediaFileId: number, value: boolean) {
+    this.canCopyVideoCache.set(userFileKey(userId, mediaFileId), value);
   }
-  getCanCopyVideo(mediaFileId: number): boolean {
-    return this.canCopyVideoCache.get(mediaFileId) ?? false;
+  getCanCopyVideo(userId: number, mediaFileId: number): boolean {
+    return (
+      this.canCopyVideoCache.get(userFileKey(userId, mediaFileId)) ?? false
+    );
   }
 
-  setCanCopyAudio(mediaFileId: number, value: boolean) {
-    this.canCopyAudioCache.set(mediaFileId, value);
+  setCanCopyAudio(userId: number, mediaFileId: number, value: boolean) {
+    this.canCopyAudioCache.set(userFileKey(userId, mediaFileId), value);
   }
-  getCanCopyAudio(mediaFileId: number): boolean {
-    return this.canCopyAudioCache.get(mediaFileId) ?? false;
+  getCanCopyAudio(userId: number, mediaFileId: number): boolean {
+    return (
+      this.canCopyAudioCache.get(userFileKey(userId, mediaFileId)) ?? false
+    );
   }
 
   /** Canonical audio output decision computed by `stream-builder` at
    *  `playback-info` time. Every consumer (ffmpeg-args, master-playlist,
    *  admin dashboard) reads from here — no re-derivation downstream. */
   private readonly audioPlanCache = new Map<
-    number,
+    string,
     | { mode: 'copy'; codec: string }
     | {
         mode: 'transcode';
@@ -278,6 +340,7 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
   >();
 
   setAudioPlan(
+    userId: number,
     mediaFileId: number,
     plan:
       | { mode: 'copy'; codec: string }
@@ -287,10 +350,10 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
           bitrateBps: number;
         },
   ) {
-    this.audioPlanCache.set(mediaFileId, plan);
+    this.audioPlanCache.set(userFileKey(userId, mediaFileId), plan);
   }
-  getAudioPlan(mediaFileId: number) {
-    return this.audioPlanCache.get(mediaFileId) ?? null;
+  getAudioPlan(userId: number, mediaFileId: number) {
+    return this.audioPlanCache.get(userFileKey(userId, mediaFileId)) ?? null;
   }
 
   setSourceDimensions(mediaFileId: number, width: number, height: number) {
@@ -313,10 +376,9 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
 
   private cleanup() {
     const cutoff = Date.now() - STALE_TIMEOUT_MS;
-    for (const [key, session] of this.sessions) {
+    for (const session of this.sessions.values()) {
       if (session.lastActivity.getTime() <= cutoff) {
-        this.sessions.delete(key);
-        this.deviceNameCache.delete(key);
+        this.unregister(session.userId, session.mediaFileId);
       }
     }
   }

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -48,6 +48,7 @@ export class StreamBuilderService {
    * Evaluate a media file against a device profile and return the playback decision.
    */
   evaluate(
+    userId: number,
     resolved: ResolvedFile,
     profile: DeviceProfileDto,
     tokenParam: string,
@@ -130,7 +131,7 @@ export class StreamBuilderService {
     // HDR ladder. Anything that re-encodes via H.264 needs the tonemap
     // filter or AVPlayer rejects with -12927 (mismatched VUI vs codec).
     const needsTonemapping = isSourceHdr && !useHdrLadder;
-    this.activeStreamTracker.setHdrLadder(resolved.mediaFile.id, useHdrLadder);
+    this.activeStreamTracker.setHdrLadder(userId, resolved.mediaFile.id, useHdrLadder);
 
     // Codec selector: picks the variant the encoder pipeline will produce
     // when the playback path lands on transcode. The result is stored in
@@ -155,6 +156,7 @@ export class StreamBuilderService {
       userAgent,
     );
     this.activeStreamTracker.setVideoVariant(
+      userId,
       resolved.mediaFile.id,
       selectedVariant,
     );

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -298,7 +298,8 @@ export class StreamingController {
     resolved: ResolvedFile,
     mediaFileId: number,
   ): SessionContext {
-    const user = req.user;
+    const user = req.user as User;
+    const userId = user.id;
     const si = resolved.mediaFile.streamInfo;
     // Ensure audio stream count is set from streamInfo if the tracker lost it
     // (e.g. after backend restart, Shaka may replay cached manifest segments
@@ -306,13 +307,14 @@ export class StreamingController {
     const audioCount = si?.audio?.length ?? 0;
     if (
       audioCount > 0 &&
-      this.activeStreamTracker.getAudioStreamCount(mediaFileId) === 0
+      this.activeStreamTracker.getAudioStreamCount(userId, mediaFileId) === 0
     ) {
-      this.activeStreamTracker.setAudioStreamCount(mediaFileId, audioCount);
+      this.activeStreamTracker.setAudioStreamCount(userId, mediaFileId, audioCount);
     }
     const trackedAudioCount =
-      this.activeStreamTracker.getAudioStreamCount(mediaFileId);
+      this.activeStreamTracker.getAudioStreamCount(userId, mediaFileId);
     const muxFlavour: 'ts' | 'fmp4' = this.activeStreamTracker.getUseTs(
+      userId,
       mediaFileId,
     )
       ? 'ts'
@@ -320,17 +322,17 @@ export class StreamingController {
     const useMultiAudioLayout =
       pickAudioLayout(trackedAudioCount, muxFlavour) === 'var-stream-map';
     return {
-      userId: user?.id,
-      username: user?.username,
+      userId,
+      username: user.username,
       mediaTitle: resolved.media?.title,
       mediaType: resolved.media?.type,
       posterUrl: resolved.media?.posterUrl ?? null,
       transcodeReasons:
-        this.activeStreamTracker.getTranscodeReasons(mediaFileId),
-      tonemap: this.activeStreamTracker.getTonemapping(mediaFileId),
-      burnInSubtitle: this.activeStreamTracker.getBurnIn(mediaFileId),
+        this.activeStreamTracker.getTranscodeReasons(userId, mediaFileId),
+      tonemap: this.activeStreamTracker.getTonemapping(userId, mediaFileId),
+      burnInSubtitle: this.activeStreamTracker.getBurnIn(userId, mediaFileId),
       audioStreamIndex:
-        this.activeStreamTracker.getAudioStreamIndex(mediaFileId),
+        this.activeStreamTracker.getAudioStreamIndex(userId, mediaFileId),
       crop: si?.video?.[0]?.crop ?? undefined,
       // Multi-audio: produce video-only segments and let ffmpeg's var_stream_map
       // emit one audio rendition per track (subdirs 1..N) so Shaka can switch
@@ -341,9 +343,9 @@ export class StreamingController {
       // audio enumeration. `useMultiAudioLayout` only gates the var_stream_map
       // branch, not the presence of the data.
       audioStreams: si?.audio ?? undefined,
-      deviceType: this.activeStreamTracker.getDeviceType(mediaFileId),
-      useTs: this.activeStreamTracker.getUseTs(mediaFileId),
-      encoderPreset: this.activeStreamTracker.getEncoderPreset(mediaFileId),
+      deviceType: this.activeStreamTracker.getDeviceType(userId, mediaFileId),
+      useTs: this.activeStreamTracker.getUseTs(userId, mediaFileId),
+      encoderPreset: this.activeStreamTracker.getEncoderPreset(userId, mediaFileId),
       qsvOptions: this.activeStreamTracker.getQsvOptions(),
       tonemapAlgo: this.activeStreamTracker.getTonemapAlgo(),
       // Source framerate (e.g. "24", "23.976", "29.97") — used to compute an
@@ -357,7 +359,7 @@ export class StreamingController {
       // in the tracker, threaded through here so respawns / quality
       // switches stay coherent with what playback-info promised.
       audioPlan:
-        this.activeStreamTracker.getAudioPlan(mediaFileId) ?? undefined,
+        this.activeStreamTracker.getAudioPlan(userId, mediaFileId) ?? undefined,
       sourceVideoCodec:
         (si?.video?.[0]?.codec ?? '').toLowerCase() || undefined,
       sourceWidth: si?.video?.[0]?.width,
@@ -370,7 +372,7 @@ export class StreamingController {
       // a segment request that arrives before playback-info has populated
       // the tracker hits `buildFfmpegArgs`'s explicit throw, which surfaces
       // as a 5xx the player retries after the next playback-info call.
-      videoVariant: this.activeStreamTracker.getVideoVariant(mediaFileId),
+      videoVariant: this.activeStreamTracker.getVideoVariant(userId, mediaFileId),
     };
   }
 
@@ -435,8 +437,10 @@ export class StreamingController {
       // doesn't spawn a doomed SDR session that the player will
       // immediately kill and replace with the matching HDR rung.
       const targetQuality =
-        this.activeStreamTracker.getHdrLadder(mediaFileId) &&
-        !startQuality.endsWith('-hdr')
+        this.activeStreamTracker.getHdrLadder(
+          (req.user as User).id,
+          mediaFileId,
+        ) && !startQuality.endsWith('-hdr')
           ? `${startQuality}-hdr`
           : startQuality;
       const startSegment = Math.max(0, secondsToSegmentIndex(effectiveStartAt));
@@ -635,7 +639,9 @@ export class StreamingController {
 
     const ss = await this.getStreamingSettings();
 
+    const userId = (req.user as User).id;
     const result = this.streamBuilder.evaluate(
+      userId,
       resolved,
       deviceProfile,
       tokenParam,
@@ -644,18 +650,19 @@ export class StreamingController {
     // Cache transcode reasons for the admin dashboard
     if (result.transcodeReasons.length) {
       this.activeStreamTracker.setTranscodeReasons(
+        userId,
         mediaFileId,
         result.transcodeReasons,
       );
     }
-    this.activeStreamTracker.setTonemapping(mediaFileId, result.tonemapping);
+    this.activeStreamTracker.setTonemapping(userId, mediaFileId, result.tonemapping);
     // Cache burn-in info for HLS endpoints
     if (burnInSubtitleId) {
       this.subtitleBurnIn
         .resolve(burnInSubtitleId, mediaFileId)
         .then((info) => {
           const filter = this.subtitleBurnIn.buildFilter(info);
-          this.activeStreamTracker.setBurnIn(mediaFileId, {
+          this.activeStreamTracker.setBurnIn(userId, mediaFileId, {
             filter,
             streamIndex: info.streamIndex,
             type: info.type,
@@ -663,15 +670,16 @@ export class StreamingController {
         })
         .catch(() => {});
     } else {
-      this.activeStreamTracker.setBurnIn(mediaFileId, undefined);
+      this.activeStreamTracker.setBurnIn(userId, mediaFileId, undefined);
     }
-    this.activeStreamTracker.setAudioStreamIndex(mediaFileId, audioStreamIndex);
+    this.activeStreamTracker.setAudioStreamIndex(userId, mediaFileId, audioStreamIndex);
     this.activeStreamTracker.setDeviceType(
+      userId,
       mediaFileId,
       deviceProfile.deviceType ?? 'desktop',
     );
     this.activeStreamTracker.setDeviceName(
-      (req.user as User).id,
+      userId,
       mediaFileId,
       deviceProfile.deviceName ?? '',
     );
@@ -684,14 +692,14 @@ export class StreamingController {
     const effectiveUseTs =
       !!deviceProfile.useTs ||
       (!!deviceProfile.useTsOnSingleAudio && sourceAudioCount <= 1);
-    this.activeStreamTracker.setUseTs(mediaFileId, effectiveUseTs);
+    this.activeStreamTracker.setUseTs(userId, mediaFileId, effectiveUseTs);
     this.activeStreamTracker.setStreamingDuration(ss.segmentDuration);
     // Update module-level constants used by buildVodPlaylist and transcoding
     SEG_DURATION = ss.segmentDuration;
     this.transcodingService.setSegmentDuration(ss.segmentDuration);
 
     // Persist encoder preset + QSV advanced options for downstream sessions.
-    this.activeStreamTracker.setEncoderPreset(mediaFileId, ss.qsvPreset);
+    this.activeStreamTracker.setEncoderPreset(userId, mediaFileId, ss.qsvPreset);
     this.activeStreamTracker.setQsvOptions({
       lowPower: ss.qsvLowPower,
     });
@@ -701,17 +709,19 @@ export class StreamingController {
     // smart-remux variant when the user's quality lock matches the source
     // resolution (and video codec is copy-compatible).
     this.activeStreamTracker.setCanCopyVideo(
+      userId,
       mediaFileId,
       result.videoCopyStream,
     );
     this.activeStreamTracker.setCanCopyAudio(
+      userId,
       mediaFileId,
       result.audioCopyStream,
     );
     // Canonical audio decision computed by stream-builder. Drives the
     // ffmpeg-args codec branch, master-playlist CODECS string and admin
     // dashboard rendering — single source of truth.
-    this.activeStreamTracker.setAudioPlan(mediaFileId, result.audioPlan);
+    this.activeStreamTracker.setAudioPlan(userId, mediaFileId, result.audioPlan);
     const sv = resolved.mediaFile.streamInfo?.video?.[0];
     this.activeStreamTracker.setSourceDimensions(
       mediaFileId,
@@ -978,9 +988,10 @@ export class StreamingController {
     // time and cached in the tracker. Independent from `includeRemux`:
     // even a /master.m3u8 without `?remux=1` should emit the HDR ladder
     // when the source + client combination warrant it.
+    const userId = (req.user as User).id;
     const sourceHdrFormat = v?.hdrFormat as 'HDR10' | 'HLG' | undefined;
     const hdrPassThrough =
-      this.activeStreamTracker.getHdrLadder(mediaFileId) && sourceHdrFormat
+      this.activeStreamTracker.getHdrLadder(userId, mediaFileId) && sourceHdrFormat
         ? {
             hdrFormat: sourceHdrFormat,
             videoBitRateBps: v?.bitRate ?? undefined,
@@ -992,8 +1003,9 @@ export class StreamingController {
     // player can switch audio client-side without a reload. Every rendition
     // is listed even when the user has picked a specific track — the picked
     // track is marked DEFAULT=YES so the player preselects it.
-    const pickedIdx = this.activeStreamTracker.getAudioStreamIndex(mediaFileId);
+    const pickedIdx = this.activeStreamTracker.getAudioStreamIndex(userId, mediaFileId);
     const muxFlavour: 'ts' | 'fmp4' = this.activeStreamTracker.getUseTs(
+      userId,
       mediaFileId,
     )
       ? 'ts'
@@ -1007,10 +1019,10 @@ export class StreamingController {
     const deviceType: 'mobile' | 'desktop' =
       deviceParam === 'mobile' || deviceParam === 'desktop'
         ? deviceParam
-        : this.activeStreamTracker.getDeviceType(mediaFileId);
-    this.activeStreamTracker.setDeviceType(mediaFileId, deviceType);
+        : this.activeStreamTracker.getDeviceType(userId, mediaFileId);
+    this.activeStreamTracker.setDeviceType(userId, mediaFileId, deviceType);
 
-    const sdrVariant = this.activeStreamTracker.getVideoVariant(mediaFileId);
+    const sdrVariant = this.activeStreamTracker.getVideoVariant(userId, mediaFileId);
     const sourceFrameRate = parseFloat(v?.frameRate ?? '') || undefined;
     const playlist = this.transcodingService.generateMasterPlaylist(
       mediaFileId,
@@ -1028,7 +1040,7 @@ export class StreamingController {
       onlyQuality,
       pickedIdx ?? 0,
       deviceType,
-      (this.activeStreamTracker.getAudioPlan(mediaFileId)?.codec ?? 'aac') as
+      (this.activeStreamTracker.getAudioPlan(userId, mediaFileId)?.codec ?? 'aac') as
         | 'aac'
         | 'ac3'
         | 'eac3',
@@ -1040,10 +1052,11 @@ export class StreamingController {
     );
 
     this.activeStreamTracker.setAudioStreamCount(
+      userId,
       mediaFileId,
       audioStreams.length,
     );
-    this.activeStreamTracker.setUseExtXMedia(mediaFileId, useExtXMedia);
+    this.activeStreamTracker.setUseExtXMedia(userId, mediaFileId, useExtXMedia);
 
     res.setHeader('Content-Type', 'application/vnd.apple.mpegurl');
     res.setHeader('Access-Control-Allow-Origin', '*');
@@ -1131,20 +1144,20 @@ export class StreamingController {
     }
 
     // Audio is produced by the video session whenever the master picked the
-    // var_stream_map layout (`setUseExtXMedia`). That's now true for any
+    // var_stream_map layout (`setUseExtXMedia`). That's the case for any
     // fMP4 source with audio (issue #148, Tizen) and for multi-audio
     // sources regardless of mux flavour. Only the muxed TS / muxed-fMP4
-    // legacy path needs a separate audio-only session as a fallback.
+    // path needs a separate audio-only session as a fallback.
+    const userId = (req.user as User).id;
     const useExtXMedia =
-      this.activeStreamTracker.getUseExtXMedia(mediaFileId);
+      this.activeStreamTracker.getUseExtXMedia(userId, mediaFileId);
     if (!useExtXMedia) {
-      const user = req.user;
       void this.transcodingService.getOrCreateAudioSession(
         mediaFileId,
         audioIndex,
         resolved.absolutePath,
         0,
-        { userId: user?.id },
+        { userId },
       );
     }
 
@@ -1152,7 +1165,7 @@ export class StreamingController {
     const sid = firstQueryString(req.query, 'sid');
     const tokenParam = streamQuery({ token, sid });
     const basePath = `/api/stream/${mediaFileId}/audio/${audioIndex}`;
-    const useTs = this.activeStreamTracker.getUseTs(mediaFileId);
+    const useTs = this.activeStreamTracker.getUseTs(userId, mediaFileId);
     const segExt = useTs ? 'ts' : 'm4s';
     const playlist = buildVodPlaylist(
       duration,
@@ -1201,8 +1214,9 @@ export class StreamingController {
         req.user as User,
       );
       const ctx = this.buildSessionContext(req, resolved, mediaFileId);
+      const sessionUserId = (req.user as User).id;
       const deviceType =
-        this.activeStreamTracker.getDeviceType(mediaFileId) ?? 'desktop';
+        this.activeStreamTracker.getDeviceType(sessionUserId, mediaFileId) ?? 'desktop';
       const sourceW =
         this.activeStreamTracker.getSourceWidth(mediaFileId) || 1920;
       const sourceH =
@@ -1220,7 +1234,7 @@ export class StreamingController {
       // quality-change path. Translate to the HDR rung when the master
       // is publishing the HDR ladder so the spawned session matches.
       const quality =
-        this.activeStreamTracker.getHdrLadder(mediaFileId) &&
+        this.activeStreamTracker.getHdrLadder(sessionUserId, mediaFileId) &&
         !baseQuality.endsWith('-hdr')
           ? `${baseQuality}-hdr`
           : baseQuality;
@@ -1342,8 +1356,9 @@ export class StreamingController {
     const tokenParam = streamQuery({ token, sid });
     const basePath = `/api/stream/${mediaFileId}/${quality}`;
     // Use the master.m3u8 decision — must match to avoid init filename mismatch.
-    const multiAudio = this.activeStreamTracker.getUseExtXMedia(mediaFileId);
-    const useTs = this.activeStreamTracker.getUseTs(mediaFileId);
+    const userId = (req.user as User).id;
+    const multiAudio = this.activeStreamTracker.getUseExtXMedia(userId, mediaFileId);
+    const useTs = this.activeStreamTracker.getUseTs(userId, mediaFileId);
     // Tizen TV sessions can opt into MPEG-TS segments (no init segment)
     // to bypass AVPlay's HLS-fMP4 rejection (issue #148). The fMP4 path
     // is post-processed to CMAF (`cmaf-rewrite.ts`) so it works on
@@ -1418,11 +1433,12 @@ export class StreamingController {
     // `getSegmentPath` waits the full 60s timeout before the slow path can
     // kill the old session and spawn the right one — a hard 60s stall to
     // first frame.
+    const userId = (req.user as User).id;
     const sessionQualityMatches =
       existing != null &&
       (quality === 'remux' ? !!existing.remux : existing.quality === quality);
     if (segment.startsWith('init') && existing && sessionQualityMatches) {
-      const ma = this.activeStreamTracker.getUseExtXMedia(mediaFileId);
+      const ma = this.activeStreamTracker.getUseExtXMedia(userId, mediaFileId);
       // Same caveat as the segment path: remux video-only doesn't use
       // var_stream_map, so the `0/` prefix would 404 on the init lookup.
       const initFile = ma && quality !== 'remux' ? `0/${segment}` : segment;
@@ -1473,7 +1489,7 @@ export class StreamingController {
     // (exitCode !== null) still have valid segments in cache — don't skip them.
     if (existing && existing.quality === quality) {
       const varStreamMap =
-        this.activeStreamTracker.getUseExtXMedia(mediaFileId);
+        this.activeStreamTracker.getUseExtXMedia(userId, mediaFileId);
       const segName =
         varStreamMap && quality !== 'remux' ? `0/${segment}` : segment;
       const segPath = `${existing.cachePath}/${segName}`;
@@ -1525,7 +1541,7 @@ export class StreamingController {
       );
       if (earlySession && earlySession.quality === quality) {
         const varStreamMap =
-          this.activeStreamTracker.getUseExtXMedia(mediaFileId);
+          this.activeStreamTracker.getUseExtXMedia(userId, mediaFileId);
         const segName = varStreamMap ? `0/${segment}` : segment;
         const segPath = await this.transcodingService.getSegmentPath(
           earlySession,
@@ -1550,7 +1566,7 @@ export class StreamingController {
 
     // For remux sessions, copy audio only when the source codec is compatible
     // (captured at playback-info); otherwise transcode audio to AAC.
-    const copyAudio = this.activeStreamTracker.getCanCopyAudio(mediaFileId);
+    const copyAudio = this.activeStreamTracker.getCanCopyAudio(userId, mediaFileId);
     const session =
       quality === 'remux'
         ? await this.transcodingService.getOrCreateRemuxSession(
@@ -1571,7 +1587,7 @@ export class StreamingController {
     // With var_stream_map (fMP4 + multi-audio), video segments are in
     // subdirectory "0/". The remux session keeps a flat layout (no
     // var_stream_map), so the `0/` prefix would 404 there.
-    const varStreamMap = this.activeStreamTracker.getUseExtXMedia(mediaFileId);
+    const varStreamMap = this.activeStreamTracker.getUseExtXMedia(userId, mediaFileId);
     const usesVarStreamMapLayout = varStreamMap && quality !== 'remux';
     const segName = usesVarStreamMapLayout ? `0/${segment}` : segment;
 


### PR DESCRIPTION
## Summary

Fourteen of the tracker's caches were keyed by \`mediaFileId\` alone, so two users on the same file were clobbering each other's settings every time one of them called \`playback-info\`. The bite is real on heterogeneous device pairs:

- **Tizen TV + browser** → \`useTs\` flips under the browser session → wrong container
- **mobile + desktop** → wrong bitrate ladder served
- **HDR + non-HDR client** → wrong ladder
- **different audio track / burn-in picks** → wrong rendition served

Migrates the user-derived caches to a \`\${userId}-\${mediaFileId}\` key: \`useTs\`, \`audioPlan\`, \`audioStreamIndex\`, \`audioStreamCount\`, \`useExtXMedia\`, \`deviceType\`, \`hdrLadder\`, \`videoVariant\`, \`transcodeReasons\`, \`tonemapping\`, \`burnIn\`, \`encoderPreset\`, \`canCopyVideo\`, \`canCopyAudio\`. Source dimensions stay file-keyed (file property, identical across users). QSV options, tonemap algo and segment duration are global admin settings and remain so.

\`unregister(user, file)\` now drops every per-(user, file) cache entry, so the cleanup follows the live session away.

Adds \`active-stream-tracker.service.spec.ts\` to lock in the isolation contract.

Refs: #291

## Test plan

- [x] \`npx jest src/modules/streaming/\` — 59/59 specs pass (49 pre-existing + 10 new tracker specs)
- [x] \`npx tsc --noEmit\` clean
- [ ] Smoke test: start playback on two devices (Tizen + browser) for the same file, confirm both keep their own \`useTs\` flag and ladder
- [ ] Two users on the same file, one picks a different audio track — verify each gets their own pick