### PR TITLE
refactor(streaming): move per-session state onto LiveSession

### DIFF
--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -33,10 +33,14 @@ import { Observable } from 'rxjs';
 import {
   HW_ACCEL_LABEL,
   type HwAccelType,
+  type TranscodeSession,
   TranscodingService,
 } from '../streaming/transcoding';
 import { ActiveStreamTracker } from '../streaming/active-stream-tracker.service';
-import { LiveSessionRegistry } from '../streaming/live-session.service';
+import {
+  type LiveSessionSnapshot,
+  LiveSessionRegistry,
+} from '../streaming/live-session.service';
 import { PlaybackService } from '../streaming/playback.service';
 import { MediaFile } from '../media/entities/media-file.entity';
 import { Episode } from '../media/entities/episode.entity';
@@ -304,8 +308,42 @@ export class SystemController {
     const hwAccel = this.transcodingService.getDetectedHwAccel();
     const streams: ActiveStreamDto[] = [];
 
-    // Collect all mediaFileIds to batch-load streamInfo and playback state
-    const allSessions: {
+    // LiveSessionRegistry is the single source of truth for "who is
+    // currently watching". Each playback gets its own sid, so two
+    // devices on the same (user, file) coexist as two distinct
+    // entries — no clobber, no dedup destroying multi-device.
+    const live = this.liveSessions.list();
+    const transcodeSessions = this.transcodingService.getActiveSessions();
+    const findTranscodeSession = (
+      userId: number | null,
+      mediaFileId: number,
+      profileHash: string | null,
+    ): TranscodeSession | undefined => {
+      if (profileHash == null) return undefined;
+      return transcodeSessions.find(
+        (ts) =>
+          ts.userId === userId &&
+          ts.mediaFileId === mediaFileId &&
+          ts.baseProfileHash === profileHash,
+      );
+    };
+
+    // Collect lookups before the per-session loop so we batch DB hits.
+    const mediaFileIds = [
+      ...new Set([
+        ...live.map((s) => s.mediaFileId),
+        // Legacy direct-play paths that bypass playback-info still
+        // surface here; their (user, file) pair isn't represented by
+        // any LiveSession so we have to read from the tracker.
+        ...this.activeStreamTracker.getActive().map((s) => s.mediaFileId),
+      ]),
+    ];
+    const mediaFiles = mediaFileIds.length
+      ? await this.mediaFileRepo.findByIds(mediaFileIds)
+      : [];
+    const mediaFileMap = new Map(mediaFiles.map((mf) => [mf.id, mf]));
+
+    type StreamWorkItem = {
       sessionId: string;
       userId: number | null;
       username: string | null;
@@ -318,53 +356,93 @@ export class SystemController {
       hwAccelVal: string;
       startedAt: string;
       lastActivity: string;
-    }[] = [];
+      deviceLabel: string | null;
+      transcodeSession: TranscodeSession | undefined;
+      audioPlan: LiveSessionSnapshot['audioPlan'];
+    };
 
-    for (const s of this.transcodingService.getActiveSessions()) {
-      allSessions.push({
-        sessionId: s.id,
-        userId: s.userId ?? null,
-        username: s.username ?? null,
-        mediaFileId: s.mediaFileId,
-        mediaTitle: s.mediaTitle ?? '',
-        mediaType: s.mediaType ?? '',
-        posterUrl: s.posterUrl ?? null,
-        mode: s.remux ? 'remux' : 'transcode',
-        quality: s.quality,
-        hwAccelVal: s.remux ? 'none' : (s.actualHwAccel ?? hwAccel),
-        startedAt: (s.startedAt ?? new Date()).toISOString(),
-        lastActivity: new Date(s.lastAccess).toISOString(),
+    const work: StreamWorkItem[] = [];
+
+    for (const session of live) {
+      const ts = findTranscodeSession(
+        session.userId,
+        session.mediaFileId,
+        session.profileHash,
+      );
+      const mode: 'transcode' | 'remux' | 'directplay' =
+        session.kind === 'directplay'
+          ? 'directplay'
+          : session.kind === 'remux'
+            ? 'remux'
+            : 'transcode';
+      const quality =
+        mode === 'directplay'
+          ? 'original'
+          : (ts?.quality ?? session.quality ?? 'original');
+      const hwAccelVal =
+        mode === 'directplay' || mode === 'remux'
+          ? 'none'
+          : (ts?.actualHwAccel ?? hwAccel);
+      work.push({
+        sessionId: session.sessionId,
+        userId: session.userId,
+        username: session.username,
+        mediaFileId: session.mediaFileId,
+        mediaTitle: session.mediaTitle ?? '',
+        mediaType: session.mediaType ?? '',
+        posterUrl: session.posterUrl,
+        mode,
+        quality,
+        hwAccelVal,
+        startedAt: session.startedAt.toISOString(),
+        lastActivity: session.lastBeat.toISOString(),
+        deviceLabel:
+          session.deviceLabel ??
+          (session.userId != null
+            ? this.activeStreamTracker.getDeviceName(
+                session.userId,
+                session.mediaFileId,
+              )
+            : null),
+        transcodeSession: ts,
+        audioPlan: session.audioPlan,
       });
     }
 
-    for (const s of this.activeStreamTracker.getActive()) {
-      allSessions.push({
-        sessionId: `dp-${s.userId}-${s.mediaFileId}`,
-        userId: s.userId,
-        username: s.username,
-        mediaFileId: s.mediaFileId,
-        mediaTitle: s.mediaTitle,
-        mediaType: s.mediaType,
-        posterUrl: s.posterUrl,
+    // Legacy direct-play fallback: tracker entries without a matching
+    // LiveSession (typically clients that hit /stream/:mediaFileId
+    // without a prior playback-info call).
+    const liveByKey = new Set(
+      live.map((s) => `${s.userId ?? 0}-${s.mediaFileId}`),
+    );
+    for (const dp of this.activeStreamTracker.getActive()) {
+      const key = `${dp.userId}-${dp.mediaFileId}`;
+      if (liveByKey.has(key)) continue;
+      work.push({
+        sessionId: `dp-${dp.userId}-${dp.mediaFileId}`,
+        userId: dp.userId,
+        username: dp.username,
+        mediaFileId: dp.mediaFileId,
+        mediaTitle: dp.mediaTitle,
+        mediaType: dp.mediaType,
+        posterUrl: dp.posterUrl,
         mode: 'directplay',
         quality: 'original',
         hwAccelVal: 'none',
-        startedAt: s.startedAt.toISOString(),
-        lastActivity: s.lastActivity.toISOString(),
+        startedAt: dp.startedAt.toISOString(),
+        lastActivity: dp.lastActivity.toISOString(),
+        deviceLabel: this.activeStreamTracker.getDeviceName(
+          dp.userId,
+          dp.mediaFileId,
+        ),
+        transcodeSession: undefined,
+        audioPlan: null,
       });
     }
 
-    // Track episodeId per stream index for resolution later
     const streamEpisodeIds: (number | null)[] = [];
 
-    // Batch-load media files for streamInfo
-    const mediaFileIds = [...new Set(allSessions.map((s) => s.mediaFileId))];
-    const mediaFiles = mediaFileIds.length
-      ? await this.mediaFileRepo.findByIds(mediaFileIds)
-      : [];
-    const mediaFileMap = new Map(mediaFiles.map((mf) => [mf.id, mf]));
-
-    for (const s of allSessions) {
+    for (const s of work) {
       const mf = mediaFileMap.get(s.mediaFileId);
       const si = mf?.streamInfo;
       const v = si?.video?.[0];
@@ -395,22 +473,15 @@ export class SystemController {
         }
       }
 
-      // Determine playback modes
+      // Output decisions: the LiveSession holds the authoritative
+      // `audioPlan`; mode/codec/bitrate read directly.
       let videoPlaybackMode = 'Lecture directe';
       let outputContainer: string | null = null;
       let outputBitrate: number | null = null;
       let audioOutputCodec: string | null = null;
       let audioOutputBitrateBps: number | null = null;
       let audioMode: 'direct' | 'copy' | 'transcode' = 'direct';
-      // Single source of truth: the audio plan stream-builder stored
-      // on the LiveSession at playback-info time. mode/codec/bitrate
-      // are read directly — no re-derivation, no string comparison
-      // gymnastics.
-      const liveForSession =
-        s.userId != null
-          ? this.liveSessions.findCurrent(s.userId, s.mediaFileId)
-          : null;
-      const audioPlan = liveForSession?.audioPlan ?? null;
+      const audioPlan = s.audioPlan;
 
       if (s.mode === 'transcode') {
         videoPlaybackMode = `Transcodage (${HW_ACCEL_LABEL[hwAccel] ?? hwAccel.toUpperCase()})`;
@@ -462,16 +533,7 @@ export class SystemController {
         mode: s.mode,
         quality: s.quality,
         hwAccel: s.hwAccelVal,
-        device:
-          this.liveSessions
-            .list()
-            .find(
-              (ls) =>
-                ls.userId === s.userId && ls.mediaFileId === s.mediaFileId,
-            )?.deviceLabel ??
-          (s.userId
-            ? this.activeStreamTracker.getDeviceName(s.userId, s.mediaFileId)
-            : null),
+        device: s.deviceLabel,
         startedAt: s.startedAt,
         lastActivity: s.lastActivity,
         positionSeconds,
@@ -523,63 +585,38 @@ export class SystemController {
       }
     }
 
-    // Fill transcode progress for non-directplay sessions
-    const transcodeSessions = this.transcodingService.getActiveSessions();
-    for (const stream of streams) {
-      if (stream.mode !== 'directplay') {
-        const ts = transcodeSessions.find((s) => s.id === stream.sessionId);
-        if (ts) {
-          if (stream.durationSeconds > 0) {
-            stream.transcodePercent =
-              await this.transcodingService.getTranscodePercent(
-                ts,
-                stream.durationSeconds,
-              );
-          }
-          // Deduplicate by flag (reasons can be pushed from multiple code paths)
-          const seen = new Set<string>();
-          const reasons = (ts.transcodeReasons ?? []).filter((r) => {
-            if (seen.has(r.flag)) return false;
-            seen.add(r.flag);
-            return true;
-          });
-          stream.videoReasons = reasons
-            .filter((r) => r.flag.startsWith('Video'))
-            .map((r) => r.message);
-          stream.audioReasons = reasons
-            .filter((r) => r.flag.startsWith('Audio'))
-            .map((r) => r.message);
-          stream.containerReasons = reasons
-            .filter((r) => r.flag.startsWith('Container'))
-            .map((r) => r.message);
-        }
+    // Fill transcode progress / reasons for sessions that have a
+    // matching ffmpeg session.
+    for (let i = 0; i < streams.length; i++) {
+      const stream = streams[i];
+      const ts = work[i].transcodeSession;
+      if (!ts || stream.mode === 'directplay') continue;
+      if (stream.durationSeconds > 0) {
+        stream.transcodePercent =
+          await this.transcodingService.getTranscodePercent(
+            ts,
+            stream.durationSeconds,
+          );
       }
+      // Deduplicate by flag (reasons can be pushed from multiple code paths)
+      const seen = new Set<string>();
+      const reasons = (ts.transcodeReasons ?? []).filter((r) => {
+        if (seen.has(r.flag)) return false;
+        seen.add(r.flag);
+        return true;
+      });
+      stream.videoReasons = reasons
+        .filter((r) => r.flag.startsWith('Video'))
+        .map((r) => r.message);
+      stream.audioReasons = reasons
+        .filter((r) => r.flag.startsWith('Audio'))
+        .map((r) => r.message);
+      stream.containerReasons = reasons
+        .filter((r) => r.flag.startsWith('Container'))
+        .map((r) => r.message);
     }
 
-    // Deduplicate: when a user switches quality, multiple transcode sessions
-    // exist for the same file. Keep only the most recently accessed one per user+file.
-    // Also prefer sessions accessed in the last 15s over stale ones.
-    const deduped = new Map<string, ActiveStreamDto>();
-    const recentCutoff = new Date(Date.now() - 15_000).toISOString();
-    for (const stream of streams) {
-      const key = `${stream.userId ?? 0}-${stream.mediaFileId}`;
-      const existing = deduped.get(key);
-      if (!existing) {
-        deduped.set(key, stream);
-      } else {
-        // Prefer the recently active session; if both recent or both stale, pick latest
-        const existingRecent = existing.lastActivity > recentCutoff;
-        const streamRecent = stream.lastActivity > recentCutoff;
-        if (
-          (!existingRecent && streamRecent) ||
-          stream.lastActivity > existing.lastActivity
-        ) {
-          deduped.set(key, stream);
-        }
-      }
-    }
-
-    return Array.from(deduped.values());
+    return streams;
   }
 
   @Delete('streams/:sessionId')

--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -402,10 +402,15 @@ export class SystemController {
       let audioOutputCodec: string | null = null;
       let audioOutputBitrateBps: number | null = null;
       let audioMode: 'direct' | 'copy' | 'transcode' = 'direct';
-      // Single source of truth: the audio plan stream-builder stored at
-      // playback-info time. mode/codec/bitrate are read directly — no
-      // re-derivation, no string comparison gymnastics.
-      const audioPlan = this.activeStreamTracker.getAudioPlan(s.mediaFileId);
+      // Single source of truth: the audio plan stream-builder stored
+      // on the LiveSession at playback-info time. mode/codec/bitrate
+      // are read directly — no re-derivation, no string comparison
+      // gymnastics.
+      const liveForSession =
+        s.userId != null
+          ? this.liveSessions.findCurrent(s.userId, s.mediaFileId)
+          : null;
+      const audioPlan = liveForSession?.audioPlan ?? null;
 
       if (s.mode === 'transcode') {
         videoPlaybackMode = `Transcodage (${HW_ACCEL_LABEL[hwAccel] ?? hwAccel.toUpperCase()})`;

--- a/backend/src/modules/streaming/active-stream-tracker.service.ts
+++ b/backend/src/modules/streaming/active-stream-tracker.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
-import type { BurnInSubtitle, TonemapAlgo } from './transcoding';
-import type { CodecVariant } from './transcoding/codec/types';
+import type { TonemapAlgo } from './transcoding';
 
 export interface DirectPlaySession {
   userId: number;
@@ -15,14 +14,22 @@ export interface DirectPlaySession {
 
 const STALE_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
 
+/**
+ * Dashboard / global-settings bookkeeping for streaming. Per-playback
+ * session state (mux flavour, audio plan, device type, picked tracks,
+ * etc.) used to live here but has moved onto {@link LiveSession} —
+ * this service now holds only:
+ *
+ *  - DirectPlay session presence for the admin "now watching" view
+ *    (`register` / `getActive` / `unregister`)
+ *  - Human-readable device name per (user, file)
+ *  - Intrinsic file dimensions (identical across users, kept here for
+ *    cheap reads in HLS routes)
+ *  - Global admin settings (segment duration, QSV options, tonemap algo)
+ */
 @Injectable()
 export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
   private readonly sessions = new Map<string, DirectPlaySession>();
-  /** Cache transcode reasons per mediaFileId (set during playback-info, read by dashboard) */
-  private readonly transcodeReasonsCache = new Map<
-    number,
-    { flag: string; message: string }[]
-  >();
   private cleanupTimer: ReturnType<typeof setInterval> | null = null;
 
   onModuleInit() {
@@ -60,8 +67,9 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
   }
 
   unregister(userId: number, mediaFileId: number) {
-    this.sessions.delete(`${userId}-${mediaFileId}`);
-    this.deviceNameCache.delete(`${userId}-${mediaFileId}`);
+    const key = `${userId}-${mediaFileId}`;
+    this.sessions.delete(key);
+    this.deviceNameCache.delete(key);
   }
 
   /** Human-readable client device captured at playback-info ("Chrome — macOS",
@@ -78,153 +86,8 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
     return this.deviceNameCache.get(`${userId}-${mediaFileId}`) ?? null;
   }
 
-  private readonly tonemappingCache = new Map<number, boolean>();
-
-  setTranscodeReasons(
-    mediaFileId: number,
-    reasons: { flag: string; message: string }[],
-  ) {
-    this.transcodeReasonsCache.set(mediaFileId, reasons);
-  }
-
-  getTranscodeReasons(
-    mediaFileId: number,
-  ): { flag: string; message: string }[] {
-    return this.transcodeReasonsCache.get(mediaFileId) ?? [];
-  }
-
-  private readonly burnInCache = new Map<number, BurnInSubtitle>();
-
-  setTonemapping(mediaFileId: number, value: boolean) {
-    this.tonemappingCache.set(mediaFileId, value);
-  }
-
-  getTonemapping(mediaFileId: number): boolean {
-    return this.tonemappingCache.get(mediaFileId) ?? false;
-  }
-
-  /** HDR ladder eligibility — set at playback-info by stream-builder
-   *  (`isSourceHdr && clientSupportsHdr && sourceVideoCodec==='hevc'
-   *  && !FLIKS_DISABLE_HEVC_HDR`). Read at master.m3u8 time so the
-   *  playlist can emit the HEVC HDR ladder instead of the H.264 SDR
-   *  ladder. Default false keeps the existing behaviour for callers
-   *  that never reach playback-info (e.g. legacy direct URLs). */
-  private readonly hdrLadderCache = new Map<number, boolean>();
-  setHdrLadder(mediaFileId: number, value: boolean) {
-    this.hdrLadderCache.set(mediaFileId, value);
-  }
-  getHdrLadder(mediaFileId: number): boolean {
-    return this.hdrLadderCache.get(mediaFileId) ?? false;
-  }
-
-  /** Output codec variant chosen by stream-builder's selector. Read by
-   *  the controller when building the SessionContext so ffmpeg-args
-   *  resolves the right encoder descriptor. Single-codec-per-master
-   *  rule: only one variant per file at a time. */
-  private readonly videoVariantCache = new Map<number, CodecVariant>();
-  setVideoVariant(mediaFileId: number, variant: CodecVariant | null) {
-    if (variant) this.videoVariantCache.set(mediaFileId, variant);
-    else this.videoVariantCache.delete(mediaFileId);
-  }
-  getVideoVariant(mediaFileId: number): CodecVariant | undefined {
-    return this.videoVariantCache.get(mediaFileId);
-  }
-
-  setBurnIn(mediaFileId: number, info: BurnInSubtitle | undefined) {
-    if (info) {
-      this.burnInCache.set(mediaFileId, info);
-    } else {
-      this.burnInCache.delete(mediaFileId);
-    }
-  }
-
-  getBurnIn(mediaFileId: number): BurnInSubtitle | undefined {
-    return this.burnInCache.get(mediaFileId) ?? undefined;
-  }
-
-  private readonly audioStreamIndexCache = new Map<
-    number,
-    number | undefined
-  >();
-
-  /** Number of audio streams per media file — used to decide multi-audio HLS mode */
-  private readonly audioStreamCountCache = new Map<number, number>();
-
-  setAudioStreamCount(mediaFileId: number, count: number) {
-    this.audioStreamCountCache.set(mediaFileId, count);
-  }
-
-  getAudioStreamCount(mediaFileId: number): number {
-    return this.audioStreamCountCache.get(mediaFileId) ?? 0;
-  }
-
-  /** Client device category ('mobile' | 'desktop') captured at playback-info.
-   *  Used by hlsMaster and HLS segment endpoints to pick the right bitrate ladder. */
-  private readonly deviceTypeCache = new Map<number, 'mobile' | 'desktop'>();
-
-  setDeviceType(mediaFileId: number, value: 'mobile' | 'desktop') {
-    this.deviceTypeCache.set(mediaFileId, value);
-  }
-
-  getDeviceType(mediaFileId: number): 'mobile' | 'desktop' {
-    return this.deviceTypeCache.get(mediaFileId) ?? 'desktop';
-  }
-
-  /** Whether master.m3u8 decided to use separate audio renditions (EXT-X-MEDIA). */
-  private readonly useExtXMediaCache = new Map<number, boolean>();
-
-  setUseExtXMedia(mediaFileId: number, value: boolean) {
-    this.useExtXMediaCache.set(mediaFileId, value);
-  }
-
-  getUseExtXMedia(mediaFileId: number): boolean {
-    return this.useExtXMediaCache.get(mediaFileId) ?? false;
-  }
-
-  /** Set when the playback target is a Tizen TV that needs the MPEG-TS
-   *  fallback (issue #148 — AVPlay rejects HLS-fMP4 from the HLS muxer).
-   *  Drives the HLS segment container choice (mpegts vs fmp4) in
-   *  `buildFfmpegArgs`. Cast / browser / native mobile never set this. */
-  private readonly useTsCache = new Map<number, boolean>();
-
-  setUseTs(mediaFileId: number, value: boolean) {
-    this.useTsCache.set(mediaFileId, value);
-  }
-
-  getUseTs(mediaFileId: number): boolean {
-    return this.useTsCache.get(mediaFileId) ?? false;
-  }
-
-  private segmentDurationCache = 3;
-
-  setStreamingDuration(segDuration: number) {
-    this.segmentDurationCache = segDuration;
-  }
-
-  getSegmentDuration(): number {
-    return this.segmentDurationCache;
-  }
-
-  setAudioStreamIndex(mediaFileId: number, index: number | undefined) {
-    if (index != null) this.audioStreamIndexCache.set(mediaFileId, index);
-    else this.audioStreamIndexCache.delete(mediaFileId);
-  }
-
-  getAudioStreamIndex(mediaFileId: number): number | undefined {
-    return this.audioStreamIndexCache.get(mediaFileId);
-  }
-
-  // ── Admin streaming settings forwarded to transcode sessions ──
-  private readonly encoderPresetCache = new Map<number, string>();
+  // ── Global admin streaming settings forwarded to transcode sessions ──
   private qsvLowPowerCache = false;
-
-  setEncoderPreset(mediaFileId: number, preset: string) {
-    this.encoderPresetCache.set(mediaFileId, preset);
-  }
-
-  getEncoderPreset(mediaFileId: number): string {
-    return this.encoderPresetCache.get(mediaFileId) ?? 'faster';
-  }
 
   /** QSV advanced options are global (driven by admin streaming settings). */
   setQsvOptions(opts: { lowPower: boolean }) {
@@ -243,55 +106,20 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
     return this.tonemapAlgoCache;
   }
 
-  // ── Source-vs-client compat captured at playback-info time, read at
-  //    master.m3u8 time to decide whether to emit a smart-remux variant ──
-  private readonly canCopyVideoCache = new Map<number, boolean>();
-  private readonly canCopyAudioCache = new Map<number, boolean>();
+  private segmentDurationCache = 3;
+
+  setStreamingDuration(segDuration: number) {
+    this.segmentDurationCache = segDuration;
+  }
+
+  getSegmentDuration(): number {
+    return this.segmentDurationCache;
+  }
+
+  // Source dimensions describe the underlying file — identical across
+  // users, kept here for cheap lookups in HLS routes.
   private readonly sourceWidthCache = new Map<number, number>();
   private readonly sourceHeightCache = new Map<number, number>();
-
-  setCanCopyVideo(mediaFileId: number, value: boolean) {
-    this.canCopyVideoCache.set(mediaFileId, value);
-  }
-  getCanCopyVideo(mediaFileId: number): boolean {
-    return this.canCopyVideoCache.get(mediaFileId) ?? false;
-  }
-
-  setCanCopyAudio(mediaFileId: number, value: boolean) {
-    this.canCopyAudioCache.set(mediaFileId, value);
-  }
-  getCanCopyAudio(mediaFileId: number): boolean {
-    return this.canCopyAudioCache.get(mediaFileId) ?? false;
-  }
-
-  /** Canonical audio output decision computed by `stream-builder` at
-   *  `playback-info` time. Every consumer (ffmpeg-args, master-playlist,
-   *  admin dashboard) reads from here — no re-derivation downstream. */
-  private readonly audioPlanCache = new Map<
-    number,
-    | { mode: 'copy'; codec: string }
-    | {
-        mode: 'transcode';
-        codec: 'aac' | 'ac3' | 'eac3';
-        bitrateBps: number;
-      }
-  >();
-
-  setAudioPlan(
-    mediaFileId: number,
-    plan:
-      | { mode: 'copy'; codec: string }
-      | {
-          mode: 'transcode';
-          codec: 'aac' | 'ac3' | 'eac3';
-          bitrateBps: number;
-        },
-  ) {
-    this.audioPlanCache.set(mediaFileId, plan);
-  }
-  getAudioPlan(mediaFileId: number) {
-    return this.audioPlanCache.get(mediaFileId) ?? null;
-  }
 
   setSourceDimensions(mediaFileId: number, width: number, height: number) {
     this.sourceWidthCache.set(mediaFileId, width);

--- a/backend/src/modules/streaming/live-session.service.spec.ts
+++ b/backend/src/modules/streaming/live-session.service.spec.ts
@@ -77,6 +77,106 @@ describe('LiveSessionRegistry', () => {
     expect(snapshots[0].startedAt).toBeInstanceOf(Date);
     expect(snapshots[0].lastBeat).toBeInstanceOf(Date);
   });
+
+  it('create stores per-session settings inline', () => {
+    const session = svc.create({
+      ...BASE,
+      useTs: true,
+      audioPlan: { mode: 'copy', codec: 'eac3' },
+      deviceType: 'mobile',
+      hdrLadder: true,
+      audioStreamCount: 3,
+    });
+    expect(session.useTs).toBe(true);
+    expect(session.audioPlan).toEqual({ mode: 'copy', codec: 'eac3' });
+    expect(session.deviceType).toBe('mobile');
+    expect(session.hdrLadder).toBe(true);
+    expect(session.audioStreamCount).toBe(3);
+    // Defaults apply for fields not supplied.
+    expect(session.useExtXMedia).toBe(false);
+    expect(session.canCopyVideo).toBe(false);
+    expect(session.canCopyAudio).toBe(false);
+    expect(session.transcodeReasons).toEqual([]);
+  });
+
+  it('update mutates supplied fields and leaves the rest alone', () => {
+    const session = svc.create({
+      ...BASE,
+      useTs: true,
+      audioStreamCount: 0,
+    });
+    const updated = svc.update(session.sessionId, {
+      audioStreamCount: 2,
+      useExtXMedia: true,
+    });
+    expect(updated).not.toBeNull();
+    expect(updated!.audioStreamCount).toBe(2);
+    expect(updated!.useExtXMedia).toBe(true);
+    expect(updated!.useTs).toBe(true);
+  });
+
+  it('update on an unknown sid returns null', () => {
+    expect(svc.update('missing', { useTs: true })).toBeNull();
+  });
+
+  it('findCurrent returns the most-recently-active session for (user, file)', async () => {
+    const older = svc.create(BASE);
+    await new Promise((r) => setTimeout(r, 5));
+    const newer = svc.create(BASE);
+    // Heartbeat older to reorder — newer was inserted last but older
+    // just sent a beat.
+    await new Promise((r) => setTimeout(r, 5));
+    svc.heartbeat(older.sessionId, { position: 1 });
+    const current = svc.findCurrent(BASE.userId, BASE.mediaFileId);
+    expect(current?.sessionId).toBe(older.sessionId);
+    // Brand new heartbeat on newer makes it win again.
+    await new Promise((r) => setTimeout(r, 5));
+    svc.heartbeat(newer.sessionId, { position: 1 });
+    expect(svc.findCurrent(BASE.userId, BASE.mediaFileId)?.sessionId).toBe(
+      newer.sessionId,
+    );
+  });
+
+  it('findCurrent isolates by (user, file) — does not bleed across users', () => {
+    const aliceSession = svc.create(BASE);
+    svc.create({ ...BASE, userId: 99, username: 'bob' });
+    expect(svc.findCurrent(BASE.userId, BASE.mediaFileId)?.sessionId).toBe(
+      aliceSession.sessionId,
+    );
+    expect(svc.findCurrent(99, BASE.mediaFileId)?.userId).toBe(99);
+    // Different file → no match.
+    expect(svc.findCurrent(BASE.userId, 999)).toBeNull();
+  });
+
+  it('same user on two devices for the same file keeps both states isolated', () => {
+    // Alice opens her browser (fMP4, desktop ladder) AND her Tizen TV
+    // (TS container, no HDR ladder) on the same file. Each session
+    // carries its own settings — there is no shared per-(user, file)
+    // state that the second playback-info could clobber.
+    const browser = svc.create({
+      ...BASE,
+      profileHash: 'browser-hash',
+      useTs: false,
+      deviceType: 'desktop',
+      hdrLadder: true,
+    });
+    const tv = svc.create({
+      ...BASE,
+      profileHash: 'tizen-hash',
+      useTs: true,
+      deviceType: 'desktop',
+      hdrLadder: false,
+    });
+    expect(browser.useTs).toBe(false);
+    expect(browser.hdrLadder).toBe(true);
+    expect(tv.useTs).toBe(true);
+    expect(tv.hdrLadder).toBe(false);
+    // listForJob also keeps them apart via profileHash.
+    expect(svc.listForJob(BASE.userId, BASE.mediaFileId, 'browser-hash'))
+      .toHaveLength(1);
+    expect(svc.listForJob(BASE.userId, BASE.mediaFileId, 'tizen-hash'))
+      .toHaveLength(1);
+  });
 });
 
 describe('LiveSessionRegistry GC', () => {

--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -6,9 +6,20 @@ import {
 } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { StreamLifetime } from './lifetime-constants';
+import type { TranscodeReason } from './dto/playback-info.dto';
+import type { BurnInSubtitle } from './transcoding';
+import type { CodecVariant } from './transcoding/codec/types';
 
 export type PlaybackState = 'playing' | 'paused' | 'buffering';
 export type SessionKind = 'transcode' | 'remux' | 'directplay';
+
+export type AudioPlan =
+  | { mode: 'copy'; codec: string }
+  | {
+      mode: 'transcode';
+      codec: 'aac' | 'ac3' | 'eac3';
+      bitrateBps: number;
+    };
 
 /**
  * Single live-session entry. The {@link sessionId} is the server-issued
@@ -16,6 +27,13 @@ export type SessionKind = 'transcode' | 'remux' | 'directplay';
  * transcoding service's internal session key (`mediaFileId-uX`) so two
  * devices on the same media-file can each carry their own
  * {@link LiveSession} without colliding on the cache layer.
+ *
+ * All per-playback session state (mux flavour, audio plan, device
+ * type, picked tracks, etc.) lives on this entry. The HLS routes
+ * resolve their session via the `?sid=...` URL param the client
+ * carries from `playback-info` onward, then read settings here —
+ * this guarantees same-user multi-device, multi-user same-file, and
+ * tab-vs-TV scenarios never clobber each other.
  */
 export interface LiveSession {
   sessionId: string;
@@ -35,6 +53,21 @@ export interface LiveSession {
   state: PlaybackState;
   audioTrackIndex: number | null;
   subtitleTrackIndex: number | null;
+  // ── Per-session settings owned by this entry ──
+  useTs: boolean;
+  audioPlan: AudioPlan | null;
+  audioStreamIndex: number | null;
+  audioStreamCount: number;
+  useExtXMedia: boolean;
+  deviceType: 'mobile' | 'desktop';
+  hdrLadder: boolean;
+  videoVariant: CodecVariant | null;
+  tonemapping: boolean;
+  transcodeReasons: TranscodeReason[];
+  burnIn: BurnInSubtitle | null;
+  encoderPreset: string;
+  canCopyVideo: boolean;
+  canCopyAudio: boolean;
 }
 
 /** Snapshot returned from {@link LiveSessionRegistry.list} — same shape
@@ -46,6 +79,60 @@ export interface LiveSessionSnapshot extends Omit<
   startedAt: Date;
   lastBeat: Date;
 }
+
+/** Optional initial values when creating a session. Anything not
+ *  supplied falls back to a safe default. */
+export interface CreateLiveSessionInput {
+  userId: number | null;
+  username: string | null;
+  mediaFileId: number;
+  mediaTitle?: string | null;
+  mediaType?: string | null;
+  posterUrl?: string | null;
+  profileHash?: string | null;
+  quality?: string | null;
+  kind: SessionKind;
+  deviceLabel?: string | null;
+  position?: number;
+  useTs?: boolean;
+  audioPlan?: AudioPlan | null;
+  audioStreamIndex?: number | null;
+  audioStreamCount?: number;
+  useExtXMedia?: boolean;
+  deviceType?: 'mobile' | 'desktop';
+  hdrLadder?: boolean;
+  videoVariant?: CodecVariant | null;
+  tonemapping?: boolean;
+  transcodeReasons?: TranscodeReason[];
+  burnIn?: BurnInSubtitle | null;
+  encoderPreset?: string;
+  canCopyVideo?: boolean;
+  canCopyAudio?: boolean;
+}
+
+/** Partial update applied via {@link LiveSessionRegistry.update}. Only
+ *  the fields supplied are touched. */
+export type LiveSessionPatch = Partial<
+  Pick<
+    LiveSession,
+    | 'useTs'
+    | 'audioPlan'
+    | 'audioStreamIndex'
+    | 'audioStreamCount'
+    | 'useExtXMedia'
+    | 'deviceType'
+    | 'hdrLadder'
+    | 'videoVariant'
+    | 'tonemapping'
+    | 'transcodeReasons'
+    | 'burnIn'
+    | 'encoderPreset'
+    | 'canCopyVideo'
+    | 'canCopyAudio'
+    | 'profileHash'
+    | 'quality'
+  >
+>;
 
 /**
  * In-memory registry of "currently watching" sessions. One entry per
@@ -80,23 +167,10 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
-   * Create a new live session and return its server-issued id. Called
-   * from the `playback-info` handler once the play method has been
-   * resolved.
+   * Create a new live session and return it. Called from the
+   * `playback-info` handler once the play method has been resolved.
    */
-  create(input: {
-    userId: number | null;
-    username: string | null;
-    mediaFileId: number;
-    mediaTitle?: string | null;
-    mediaType?: string | null;
-    posterUrl?: string | null;
-    profileHash?: string | null;
-    quality?: string | null;
-    kind: SessionKind;
-    deviceLabel?: string | null;
-    position?: number;
-  }): LiveSession {
+  create(input: CreateLiveSessionInput): LiveSession {
     const now = Date.now();
     const session: LiveSession = {
       sessionId: randomUUID(),
@@ -116,6 +190,20 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
       state: 'playing',
       audioTrackIndex: null,
       subtitleTrackIndex: null,
+      useTs: input.useTs ?? false,
+      audioPlan: input.audioPlan ?? null,
+      audioStreamIndex: input.audioStreamIndex ?? null,
+      audioStreamCount: input.audioStreamCount ?? 0,
+      useExtXMedia: input.useExtXMedia ?? false,
+      deviceType: input.deviceType ?? 'desktop',
+      hdrLadder: input.hdrLadder ?? false,
+      videoVariant: input.videoVariant ?? null,
+      tonemapping: input.tonemapping ?? false,
+      transcodeReasons: input.transcodeReasons ?? [],
+      burnIn: input.burnIn ?? null,
+      encoderPreset: input.encoderPreset ?? 'faster',
+      canCopyVideo: input.canCopyVideo ?? false,
+      canCopyAudio: input.canCopyAudio ?? false,
     };
     this.sessions.set(session.sessionId, session);
     return session;
@@ -152,6 +240,18 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
     return session;
   }
 
+  /**
+   * Apply a partial patch to a session. No-op when the session is
+   * unknown (caller is expected to have just created it or to silently
+   * fall through to defaults).
+   */
+  update(sessionId: string, patch: LiveSessionPatch): LiveSession | null {
+    const session = this.sessions.get(sessionId);
+    if (!session) return null;
+    Object.assign(session, patch);
+    return session;
+  }
+
   /** Drop a session explicitly. Returns whether the id was known. */
   stop(sessionId: string): boolean {
     return this.sessions.delete(sessionId);
@@ -160,6 +260,24 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
   /** Lookup by id without mutating lastBeat. */
   get(sessionId: string): LiveSession | null {
     return this.sessions.get(sessionId) ?? null;
+  }
+
+  /**
+   * Most-recently-active session for a (user, file). Fallback used by
+   * HLS routes when the URL omits `?sid=` (legacy clients, prewarm,
+   * etc.) — picks the freshest entry so the active session wins over a
+   * stale one. Returns null when nothing matches.
+   */
+  findCurrent(
+    userId: number | null,
+    mediaFileId: number,
+  ): LiveSession | null {
+    let best: LiveSession | null = null;
+    for (const s of this.sessions.values()) {
+      if (s.userId !== userId || s.mediaFileId !== mediaFileId) continue;
+      if (!best || s.lastBeat > best.lastBeat) best = s;
+    }
+    return best;
   }
 
   /** Active sessions for the admin dashboard — `Date`-typed snapshots. */

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -5,7 +5,6 @@ import {
   QualityOption,
   TranscodeReason,
 } from './dto/playback-info.dto';
-import { ActiveStreamTracker } from './active-stream-tracker.service';
 import { ResolvedFile } from './streaming.service';
 import {
   DeviceType,
@@ -26,6 +25,17 @@ import { pickPrimaryVariant } from './transcoding/codec/selector';
 import type { CodecVariant, VideoCodec } from './transcoding/codec/types';
 
 /**
+ * What stream-builder hands back: the public playback-info response,
+ * plus the two side-band decisions the controller threads onto the
+ * LiveSession (no more tracker side-effects from this service).
+ */
+export interface EvaluateResult {
+  response: PlaybackInfoResponse;
+  useHdrLadder: boolean;
+  videoVariant: CodecVariant | null;
+}
+
+/**
  * Decides how a media file should be played: DirectPlay, DirectStream (remux), or Transcode.
  *
  * Decision tree:
@@ -41,7 +51,6 @@ export class StreamBuilderService {
 
   constructor(
     private readonly transcodingService: TranscodingService,
-    private readonly activeStreamTracker: ActiveStreamTracker,
   ) {}
 
   /**
@@ -52,7 +61,7 @@ export class StreamBuilderService {
     profile: DeviceProfileDto,
     tokenParam: string,
     burnInSubtitleId?: number,
-  ): PlaybackInfoResponse {
+  ): EvaluateResult {
     const si = resolved.mediaFile.streamInfo;
     const v = si?.video?.[0];
     const a = si?.audio?.[0];
@@ -130,7 +139,6 @@ export class StreamBuilderService {
     // HDR ladder. Anything that re-encodes via H.264 needs the tonemap
     // filter or AVPlayer rejects with -12927 (mismatched VUI vs codec).
     const needsTonemapping = isSourceHdr && !useHdrLadder;
-    this.activeStreamTracker.setHdrLadder(resolved.mediaFile.id, useHdrLadder);
 
     // Codec selector: picks the variant the encoder pipeline will produce
     // when the playback path lands on transcode. The result is stored in
@@ -154,10 +162,14 @@ export class StreamBuilderService {
       detectedHwAccel,
       userAgent,
     );
-    this.activeStreamTracker.setVideoVariant(
-      resolved.mediaFile.id,
-      selectedVariant,
-    );
+    // useHdrLadder and selectedVariant are returned to the controller
+    // via EvaluateResult; the controller threads them onto the live
+    // session rather than the service writing side-effects.
+    const wrap = (response: PlaybackInfoResponse): EvaluateResult => ({
+      response,
+      useHdrLadder,
+      videoVariant: selectedVariant,
+    });
     const needsBurnIn = !!burnInSubtitleId;
     const needsCrop = !!v?.crop;
 
@@ -224,7 +236,7 @@ export class StreamBuilderService {
         `DirectPlay for file ${resolved.mediaFile.id}: ${sourceContainer}/${sourceVideoCodec}/${sourceAudioCodec}`,
       );
       const url = `/api/stream/${resolved.mediaFile.id}${tokenParam}`;
-      return {
+      return wrap({
         mediaFileId: resolved.mediaFile.id,
         playMethod: 'DirectPlay',
         playUrl: url,
@@ -240,7 +252,7 @@ export class StreamBuilderService {
         tonemapping: false,
         qualities: this.buildQualityList(source, 'DirectPlay', true, qualityLadder),
         source,
-      };
+      });
     }
 
     // --- Step 2: Try DirectStream (remux) ---
@@ -304,7 +316,7 @@ export class StreamBuilderService {
           totalBitrateBps: v + a,
         };
       }
-      return {
+      return wrap({
         mediaFileId: resolved.mediaFile.id,
         playMethod: 'DirectStream',
         playUrl: url,
@@ -334,7 +346,7 @@ export class StreamBuilderService {
         transcodeBitrateByQuality,
         qualities: this.buildQualityList(source, 'DirectStream', true, qualityLadder),
         source,
-      };
+      });
     }
 
     // --- Step 3: Full Transcode ---
@@ -442,7 +454,7 @@ export class StreamBuilderService {
         totalBitrateBps: v + a,
       };
     }
-    return {
+    return wrap({
       mediaFileId: resolved.mediaFile.id,
       playMethod: 'Transcode',
       playUrl: url,
@@ -465,7 +477,7 @@ export class StreamBuilderService {
       transcodeBitrateByQuality,
       qualities: this.buildQualityList(source, 'Transcode', false, qualityLadder),
       source,
-    };
+    });
   }
 
   /**

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -1662,6 +1662,14 @@ export class StreamingController {
         resolved.media?.posterUrl ?? null,
       );
     }
+    // Keep the LiveSession alive while the Range chunks roll in —
+    // the heartbeat endpoint only fires on HLS/transcode paths, so
+    // without this every direct-play would get GC'd 30 s after
+    // playback-info and disappear from the dashboard.
+    const sid = firstQueryString(req.query, 'sid');
+    if (sid) {
+      this.liveSessions.heartbeat(sid, {});
+    }
 
     const duration = resolved.mediaFile.streamInfo?.durationSeconds;
     if (duration) {

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -37,7 +37,7 @@ import {
   getSegmentDuration,
   secondsToSegmentIndex,
 } from './transcoding/constants';
-import { LiveSessionRegistry } from './live-session.service';
+import { LiveSession, LiveSessionRegistry } from './live-session.service';
 import { readAndRewriteCmaf } from './transcoding/cmaf-rewrite';
 import { resolveTonemapPath } from './transcoding/tonemap-path';
 import { ThumbnailService } from './thumbnail.service';
@@ -293,57 +293,66 @@ export class StreamingController {
     return this.streamingSettingsCache.get();
   }
 
+  /**
+   * Resolve the LiveSession this request belongs to. Honoured order:
+   *  1. `?sid=` on the URL (set by playback-info, threaded by manifests).
+   *  2. Most-recently-active session for (user, file) — fallback for
+   *     legacy callers that never sent `sid` (e.g. direct-URL fetches).
+   * Returns null when nothing matches — caller is expected to fall
+   * back to safe defaults.
+   */
+  private findRequestSession(
+    req: Request,
+    mediaFileId: number,
+  ): LiveSession | null {
+    const sid = firstQueryString(req.query, 'sid');
+    if (sid) {
+      const direct = this.liveSessions.get(sid);
+      if (direct) return direct;
+    }
+    const userId = (req.user as User | undefined)?.id;
+    if (userId == null) return null;
+    return this.liveSessions.findCurrent(userId, mediaFileId);
+  }
+
   private buildSessionContext(
     req: Request,
     resolved: ResolvedFile,
     mediaFileId: number,
   ): SessionContext {
-    const user = req.user;
+    const user = req.user as User | undefined;
     const si = resolved.mediaFile.streamInfo;
-    // Ensure audio stream count is set from streamInfo if the tracker lost it
-    // (e.g. after backend restart, Shaka may replay cached manifest segments
-    // without re-fetching master.m3u8).
+    const live = this.findRequestSession(req, mediaFileId);
+    // var_stream_map decision: same logic as playback-info — relies on
+    // the file's intrinsic audio-stream count, which doesn't drift
+    // across sessions.
     const audioCount = si?.audio?.length ?? 0;
-    if (
-      audioCount > 0 &&
-      this.activeStreamTracker.getAudioStreamCount(mediaFileId) === 0
-    ) {
-      this.activeStreamTracker.setAudioStreamCount(mediaFileId, audioCount);
-    }
-    const trackedAudioCount =
-      this.activeStreamTracker.getAudioStreamCount(mediaFileId);
-    const muxFlavour: 'ts' | 'fmp4' = this.activeStreamTracker.getUseTs(
-      mediaFileId,
-    )
-      ? 'ts'
-      : 'fmp4';
+    const useTs = live?.useTs ?? false;
     const useMultiAudioLayout =
-      pickAudioLayout(trackedAudioCount, muxFlavour) === 'var-stream-map';
+      pickAudioLayout(audioCount, useTs ? 'ts' : 'fmp4') === 'var-stream-map';
     return {
       userId: user?.id,
       username: user?.username,
       mediaTitle: resolved.media?.title,
       mediaType: resolved.media?.type,
       posterUrl: resolved.media?.posterUrl ?? null,
-      transcodeReasons:
-        this.activeStreamTracker.getTranscodeReasons(mediaFileId),
-      tonemap: this.activeStreamTracker.getTonemapping(mediaFileId),
-      burnInSubtitle: this.activeStreamTracker.getBurnIn(mediaFileId),
-      audioStreamIndex:
-        this.activeStreamTracker.getAudioStreamIndex(mediaFileId),
+      transcodeReasons: live?.transcodeReasons ?? [],
+      tonemap: live?.tonemapping ?? false,
+      burnInSubtitle: live?.burnIn ?? undefined,
+      audioStreamIndex: live?.audioStreamIndex ?? undefined,
       crop: si?.video?.[0]?.crop ?? undefined,
       // Multi-audio: produce video-only segments and let ffmpeg's var_stream_map
       // emit one audio rendition per track (subdirs 1..N) so Shaka can switch
       // client-side via EXT-X-MEDIA.
       videoOnly: useMultiAudioLayout,
-      // Always plumb the cached audio streams (incl. `streamIndex`) so the
+      // Always plumb the audio streams (incl. `streamIndex`) so the
       // single-track path can also resolve `-map 0:<abs>` and skip FFmpeg's
       // audio enumeration. `useMultiAudioLayout` only gates the var_stream_map
       // branch, not the presence of the data.
       audioStreams: si?.audio ?? undefined,
-      deviceType: this.activeStreamTracker.getDeviceType(mediaFileId),
-      useTs: this.activeStreamTracker.getUseTs(mediaFileId),
-      encoderPreset: this.activeStreamTracker.getEncoderPreset(mediaFileId),
+      deviceType: live?.deviceType ?? 'desktop',
+      useTs,
+      encoderPreset: live?.encoderPreset ?? 'faster',
       qsvOptions: this.activeStreamTracker.getQsvOptions(),
       tonemapAlgo: this.activeStreamTracker.getTonemapAlgo(),
       // Source framerate (e.g. "24", "23.976", "29.97") — used to compute an
@@ -353,11 +362,10 @@ export class StreamingController {
       // ffprobe ran at import/rescan and the result is cached in streamInfo —
       // tell FFmpeg to skip its own redundant avformat_find_stream_info scan.
       trustedStreamInfo: !!si?.video?.[0]?.codec,
-      // Canonical audio decision — computed once in stream-builder, lives
-      // in the tracker, threaded through here so respawns / quality
-      // switches stay coherent with what playback-info promised.
-      audioPlan:
-        this.activeStreamTracker.getAudioPlan(mediaFileId) ?? undefined,
+      // Canonical audio decision — computed once in stream-builder,
+      // stored on the LiveSession, threaded through here so respawns /
+      // quality switches stay coherent with what playback-info promised.
+      audioPlan: live?.audioPlan ?? undefined,
       sourceVideoCodec:
         (si?.video?.[0]?.codec ?? '').toLowerCase() || undefined,
       sourceWidth: si?.video?.[0]?.width,
@@ -365,12 +373,12 @@ export class StreamingController {
       isSourceHdr: !!si?.video?.[0]?.hdrFormat,
       // Variant chosen by stream-builder's codec selector at
       // playback-info time, threaded through every session spawn so
-      // ffmpeg-args resolves the matching encoder descriptor.
-      // ActiveStreamTracker holds it after a successful playback-info;
-      // a segment request that arrives before playback-info has populated
-      // the tracker hits `buildFfmpegArgs`'s explicit throw, which surfaces
-      // as a 5xx the player retries after the next playback-info call.
-      videoVariant: this.activeStreamTracker.getVideoVariant(mediaFileId),
+      // ffmpeg-args resolves the matching encoder descriptor. A
+      // segment request that arrives before playback-info has created
+      // the LiveSession hits `buildFfmpegArgs`'s explicit throw, which
+      // surfaces as a 5xx the player retries after the next
+      // playback-info call.
+      videoVariant: live?.videoVariant ?? undefined,
     };
   }
 
@@ -435,7 +443,7 @@ export class StreamingController {
       // doesn't spawn a doomed SDR session that the player will
       // immediately kill and replace with the matching HDR rung.
       const targetQuality =
-        this.activeStreamTracker.getHdrLadder(mediaFileId) &&
+        (this.findRequestSession(req, mediaFileId)?.hdrLadder ?? false) &&
         !startQuality.endsWith('-hdr')
           ? `${startQuality}-hdr`
           : startQuality;
@@ -634,47 +642,16 @@ export class StreamingController {
       audioStreamRaw != null ? parseInt(audioStreamRaw, 10) : undefined;
 
     const ss = await this.getStreamingSettings();
+    const user = req.user as User;
+    const userId = user.id;
 
-    const result = this.streamBuilder.evaluate(
+    const evaluateResult = this.streamBuilder.evaluate(
       resolved,
       deviceProfile,
       tokenParam,
       burnInSubtitleId,
     );
-    // Cache transcode reasons for the admin dashboard
-    if (result.transcodeReasons.length) {
-      this.activeStreamTracker.setTranscodeReasons(
-        mediaFileId,
-        result.transcodeReasons,
-      );
-    }
-    this.activeStreamTracker.setTonemapping(mediaFileId, result.tonemapping);
-    // Cache burn-in info for HLS endpoints
-    if (burnInSubtitleId) {
-      this.subtitleBurnIn
-        .resolve(burnInSubtitleId, mediaFileId)
-        .then((info) => {
-          const filter = this.subtitleBurnIn.buildFilter(info);
-          this.activeStreamTracker.setBurnIn(mediaFileId, {
-            filter,
-            streamIndex: info.streamIndex,
-            type: info.type,
-          });
-        })
-        .catch(() => {});
-    } else {
-      this.activeStreamTracker.setBurnIn(mediaFileId, undefined);
-    }
-    this.activeStreamTracker.setAudioStreamIndex(mediaFileId, audioStreamIndex);
-    this.activeStreamTracker.setDeviceType(
-      mediaFileId,
-      deviceProfile.deviceType ?? 'desktop',
-    );
-    this.activeStreamTracker.setDeviceName(
-      (req.user as User).id,
-      mediaFileId,
-      deviceProfile.deviceName ?? '',
-    );
+    const { response, useHdrLadder, videoVariant } = evaluateResult;
     // Resolve the effective `useTs`. The explicit profile flag wins as
     // an admin / debug hard override. Otherwise Tizen-style profiles
     // opt into TS only when the source has zero or one audio track
@@ -684,34 +661,23 @@ export class StreamingController {
     const effectiveUseTs =
       !!deviceProfile.useTs ||
       (!!deviceProfile.useTsOnSingleAudio && sourceAudioCount <= 1);
-    this.activeStreamTracker.setUseTs(mediaFileId, effectiveUseTs);
+    const deviceType = deviceProfile.deviceType ?? 'desktop';
+    const useExtXMedia =
+      pickAudioLayout(sourceAudioCount, effectiveUseTs ? 'ts' : 'fmp4') ===
+      'var-stream-map';
+
+    // File-scoped + global tracker state (kept in the tracker because
+    // these don't vary per playback session).
     this.activeStreamTracker.setStreamingDuration(ss.segmentDuration);
-    // Update module-level constants used by buildVodPlaylist and transcoding
     SEG_DURATION = ss.segmentDuration;
     this.transcodingService.setSegmentDuration(ss.segmentDuration);
-
-    // Persist encoder preset + QSV advanced options for downstream sessions.
-    this.activeStreamTracker.setEncoderPreset(mediaFileId, ss.qsvPreset);
-    this.activeStreamTracker.setQsvOptions({
-      lowPower: ss.qsvLowPower,
-    });
+    this.activeStreamTracker.setQsvOptions({ lowPower: ss.qsvLowPower });
     this.activeStreamTracker.setTonemapAlgo(ss.tonemapAlgo);
-
-    // Persist source→client codec compatibility so hlsMaster can pick a
-    // smart-remux variant when the user's quality lock matches the source
-    // resolution (and video codec is copy-compatible).
-    this.activeStreamTracker.setCanCopyVideo(
+    this.activeStreamTracker.setDeviceName(
+      userId,
       mediaFileId,
-      result.videoCopyStream,
+      deviceProfile.deviceName ?? '',
     );
-    this.activeStreamTracker.setCanCopyAudio(
-      mediaFileId,
-      result.audioCopyStream,
-    );
-    // Canonical audio decision computed by stream-builder. Drives the
-    // ffmpeg-args codec branch, master-playlist CODECS string and admin
-    // dashboard rendering — single source of truth.
-    this.activeStreamTracker.setAudioPlan(mediaFileId, result.audioPlan);
     const sv = resolved.mediaFile.streamInfo?.video?.[0];
     this.activeStreamTracker.setSourceDimensions(
       mediaFileId,
@@ -725,32 +691,12 @@ export class StreamingController {
     // another. No drift kill needed: a hop from browser → cast spawns a
     // new session under the cast's profileHash and leaves the browser's
     // session untouched.
-
-    // Pre-spawn ffmpeg as early as possible — the client will GET master.m3u8
-    // next (~100–300ms later) and then seg-0. Starting ffmpeg here overlaps
-    // that gap with encoder init so segment 0 is usually already on disk
-    // (or streaming) when requested. No-op for DirectPlay or auto quality.
     const startQuality = firstQueryString(req.query, 'startQuality');
     const startAtRaw = firstQueryString(req.query, 'startAt');
     const startAt = startAtRaw != null ? parseFloat(startAtRaw) : undefined;
-    if (result.playMethod !== 'DirectPlay') {
-      // Await prewarm before responding so the session is registered in the
-      // map when the frontend's subsequent master.m3u8/seg-0 requests
-      // arrive — prevents a race where hlsSegment would spawn a duplicate
-      // main at start_number=0 and force a kill+restart.
-      await this.prewarmTranscodeSession(
-        mediaFileId,
-        resolved,
-        req,
-        startQuality,
-        startAt,
-        deviceProfile.deviceType ?? 'desktop',
-      );
-    }
 
     // Mark a new watch-history entry (history = sessions started).
     // Fire-and-forget — a DB hiccup should not block stream start.
-    const user = req.user as User;
     if (user?.id && resolved.mediaFile.mediaId) {
       this.playbackService
         .markSessionStarted(
@@ -807,35 +753,45 @@ export class StreamingController {
     // running, not what was originally requested.
     const hasCrop =
       resolved.mediaFile.streamInfo?.video?.[0]?.crop != null;
-    const tonemapAlgo = result.tonemapping
+    const tonemapAlgo = response.tonemapping
       ? resolveTonemapPath(ss.tonemapAlgo, { hasCrop })
       : null;
 
-    // Issue a live-session handle the client embeds in every subsequent
-    // heartbeat (PUT /playback/media/:id/state). The profile hash is
-    // computed from the same SessionContext the transcoding service
-    // will use to spawn ffmpeg, so multi-device dashboards can match
-    // a LiveSession back to its on-disk cache directory.
-    const sessionCtx = this.buildSessionContext(req, resolved, mediaFileId);
+    // Compute the profile hash from the inputs we just derived — no
+    // tracker round-trip needed. The hash drives the cache directory
+    // shape and is matched against the same hash recomputed at every
+    // HLS request via the LiveSession we're about to create.
     const profileHash =
-      result.playMethod === 'DirectPlay'
+      response.playMethod === 'DirectPlay'
         ? null
         : computeProfileHash(
             buildPlaybackProfileFromContext(
-              sessionCtx,
-              getSegmentDuration() * 1000,
+              {
+                userId,
+                username: user.username,
+                audioPlan: response.audioPlan,
+                videoVariant: videoVariant ?? undefined,
+                useTs: effectiveUseTs,
+                videoOnly: useExtXMedia,
+                audioStreams: resolved.mediaFile.streamInfo?.audio,
+              },
+              ss.segmentDuration * 1000,
             ),
           );
     const kind =
-      result.playMethod === 'DirectPlay'
+      response.playMethod === 'DirectPlay'
         ? 'directplay'
-        : result.playMethod === 'DirectStream'
+        : response.playMethod === 'DirectStream'
           ? 'remux'
           : 'transcode';
     const deviceLabel: string | null = req.get('user-agent') ?? null;
+
+    // The LiveSession owns every per-playback setting: future HLS
+    // requests resolve it via `?sid=...` and read settings straight off
+    // this entry — no shared per-file mutable state to clobber.
     const liveSession = this.liveSessions.create({
-      userId: user?.id ?? null,
-      username: user?.username ?? null,
+      userId: userId ?? null,
+      username: user.username ?? null,
       mediaFileId,
       mediaTitle: resolved.media?.title ?? null,
       mediaType: resolved.media?.type ?? null,
@@ -845,7 +801,55 @@ export class StreamingController {
       kind,
       deviceLabel,
       position: startAt ?? 0,
+      useTs: effectiveUseTs,
+      audioPlan: response.audioPlan,
+      audioStreamIndex: audioStreamIndex ?? null,
+      audioStreamCount: sourceAudioCount,
+      useExtXMedia,
+      deviceType,
+      hdrLadder: useHdrLadder,
+      videoVariant,
+      tonemapping: response.tonemapping,
+      transcodeReasons: response.transcodeReasons,
+      burnIn: null,
+      encoderPreset: ss.qsvPreset,
+      canCopyVideo: response.videoCopyStream,
+      canCopyAudio: response.audioCopyStream,
     });
+
+    // Burn-in subtitle resolves async (PGS extraction + filter build);
+    // patch the LiveSession when ready.
+    if (burnInSubtitleId) {
+      this.subtitleBurnIn
+        .resolve(burnInSubtitleId, mediaFileId)
+        .then((info) => {
+          const filter = this.subtitleBurnIn.buildFilter(info);
+          this.liveSessions.update(liveSession.sessionId, {
+            burnIn: {
+              filter,
+              streamIndex: info.streamIndex,
+              type: info.type,
+            },
+          });
+        })
+        .catch(() => {});
+    }
+
+    // Pre-spawn ffmpeg as early as possible — the client will GET master.m3u8
+    // next (~100–300ms later) and then seg-0. Starting ffmpeg here overlaps
+    // that gap with encoder init so segment 0 is usually already on disk
+    // (or streaming) when requested. No-op for DirectPlay or auto quality.
+    // Runs after LiveSession creation so buildSessionContext can find it.
+    if (response.playMethod !== 'DirectPlay') {
+      await this.prewarmTranscodeSession(
+        mediaFileId,
+        resolved,
+        req,
+        startQuality,
+        startAt,
+        deviceType,
+      );
+    }
 
     // Bake the sessionId into the playUrl so every subsequent manifest /
     // segment request the player issues carries it. Manifest endpoints
@@ -854,11 +858,11 @@ export class StreamingController {
     // `(file, user, profileHash)` session without heuristics.
     const playUrlWithSid = streamQuery(
       { sid: liveSession.sessionId },
-      result.playUrl,
+      response.playUrl,
     );
 
     return {
-      ...result,
+      ...response,
       playUrl: playUrlWithSid,
       tonemapAlgo,
       durationSeconds: duration,
@@ -974,13 +978,14 @@ export class StreamingController {
 
     const includeRemux = firstQueryString(req.query, 'remux') === '1';
     const sourceBitrate = (v?.bitRate ?? 0) + (si?.audio?.[0]?.bitRate ?? 0);
+    const live = this.findRequestSession(req, mediaFileId);
     // HDR ladder eligibility — decided by stream-builder at playback-info
-    // time and cached in the tracker. Independent from `includeRemux`:
+    // time and stored on the LiveSession. Independent from `includeRemux`:
     // even a /master.m3u8 without `?remux=1` should emit the HDR ladder
     // when the source + client combination warrant it.
     const sourceHdrFormat = v?.hdrFormat as 'HDR10' | 'HLG' | undefined;
     const hdrPassThrough =
-      this.activeStreamTracker.getHdrLadder(mediaFileId) && sourceHdrFormat
+      (live?.hdrLadder ?? false) && sourceHdrFormat
         ? {
             hdrFormat: sourceHdrFormat,
             videoBitRateBps: v?.bitRate ?? undefined,
@@ -992,12 +997,8 @@ export class StreamingController {
     // player can switch audio client-side without a reload. Every rendition
     // is listed even when the user has picked a specific track — the picked
     // track is marked DEFAULT=YES so the player preselects it.
-    const pickedIdx = this.activeStreamTracker.getAudioStreamIndex(mediaFileId);
-    const muxFlavour: 'ts' | 'fmp4' = this.activeStreamTracker.getUseTs(
-      mediaFileId,
-    )
-      ? 'ts'
-      : 'fmp4';
+    const pickedIdx = live?.audioStreamIndex ?? null;
+    const muxFlavour: 'ts' | 'fmp4' = (live?.useTs ?? false) ? 'ts' : 'fmp4';
     const useExtXMedia =
       pickAudioLayout(audioStreams.length, muxFlavour) === 'var-stream-map';
     const onlyQuality = firstQueryString(req.query, 'startQuality');
@@ -1007,10 +1008,19 @@ export class StreamingController {
     const deviceType: 'mobile' | 'desktop' =
       deviceParam === 'mobile' || deviceParam === 'desktop'
         ? deviceParam
-        : this.activeStreamTracker.getDeviceType(mediaFileId);
-    this.activeStreamTracker.setDeviceType(mediaFileId, deviceType);
+        : (live?.deviceType ?? 'desktop');
+    // Persist the master.m3u8 decisions back on the session so segment
+    // requests stay coherent (especially for the URL-override device
+    // and the audio layout that callers downstream gate on).
+    if (live) {
+      this.liveSessions.update(live.sessionId, {
+        deviceType,
+        audioStreamCount: audioStreams.length,
+        useExtXMedia,
+      });
+    }
 
-    const sdrVariant = this.activeStreamTracker.getVideoVariant(mediaFileId);
+    const sdrVariant = live?.videoVariant ?? null;
     const sourceFrameRate = parseFloat(v?.frameRate ?? '') || undefined;
     const playlist = this.transcodingService.generateMasterPlaylist(
       mediaFileId,
@@ -1028,22 +1038,13 @@ export class StreamingController {
       onlyQuality,
       pickedIdx ?? 0,
       deviceType,
-      (this.activeStreamTracker.getAudioPlan(mediaFileId)?.codec ?? 'aac') as
-        | 'aac'
-        | 'ac3'
-        | 'eac3',
+      (live?.audioPlan?.codec ?? 'aac') as 'aac' | 'ac3' | 'eac3',
       hdrPassThrough,
       // Only the SDR ladder branch consumes this — the HDR branch
       // already drives its codec strings from `hdrPassThrough`.
       sdrVariant && sdrVariant.hdr == null ? sdrVariant : undefined,
       sourceFrameRate,
     );
-
-    this.activeStreamTracker.setAudioStreamCount(
-      mediaFileId,
-      audioStreams.length,
-    );
-    this.activeStreamTracker.setUseExtXMedia(mediaFileId, useExtXMedia);
 
     res.setHeader('Content-Type', 'application/vnd.apple.mpegurl');
     res.setHeader('Access-Control-Allow-Origin', '*');
@@ -1135,8 +1136,8 @@ export class StreamingController {
     // fMP4 source with audio (issue #148, Tizen) and for multi-audio
     // sources regardless of mux flavour. Only the muxed TS / muxed-fMP4
     // legacy path needs a separate audio-only session as a fallback.
-    const useExtXMedia =
-      this.activeStreamTracker.getUseExtXMedia(mediaFileId);
+    const live = this.findRequestSession(req, mediaFileId);
+    const useExtXMedia = live?.useExtXMedia ?? false;
     if (!useExtXMedia) {
       const user = req.user;
       void this.transcodingService.getOrCreateAudioSession(
@@ -1152,7 +1153,7 @@ export class StreamingController {
     const sid = firstQueryString(req.query, 'sid');
     const tokenParam = streamQuery({ token, sid });
     const basePath = `/api/stream/${mediaFileId}/audio/${audioIndex}`;
-    const useTs = this.activeStreamTracker.getUseTs(mediaFileId);
+    const useTs = live?.useTs ?? false;
     const segExt = useTs ? 'ts' : 'm4s';
     const playlist = buildVodPlaylist(
       duration,
@@ -1201,8 +1202,8 @@ export class StreamingController {
         req.user as User,
       );
       const ctx = this.buildSessionContext(req, resolved, mediaFileId);
-      const deviceType =
-        this.activeStreamTracker.getDeviceType(mediaFileId) ?? 'desktop';
+      const live = this.findRequestSession(req, mediaFileId);
+      const deviceType = live?.deviceType ?? 'desktop';
       const sourceW =
         this.activeStreamTracker.getSourceWidth(mediaFileId) || 1920;
       const sourceH =
@@ -1220,7 +1221,7 @@ export class StreamingController {
       // quality-change path. Translate to the HDR rung when the master
       // is publishing the HDR ladder so the spawned session matches.
       const quality =
-        this.activeStreamTracker.getHdrLadder(mediaFileId) &&
+        (live?.hdrLadder ?? false) &&
         !baseQuality.endsWith('-hdr')
           ? `${baseQuality}-hdr`
           : baseQuality;
@@ -1342,8 +1343,9 @@ export class StreamingController {
     const tokenParam = streamQuery({ token, sid });
     const basePath = `/api/stream/${mediaFileId}/${quality}`;
     // Use the master.m3u8 decision — must match to avoid init filename mismatch.
-    const multiAudio = this.activeStreamTracker.getUseExtXMedia(mediaFileId);
-    const useTs = this.activeStreamTracker.getUseTs(mediaFileId);
+    const live = this.findRequestSession(req, mediaFileId);
+    const multiAudio = live?.useExtXMedia ?? false;
+    const useTs = live?.useTs ?? false;
     // Tizen TV sessions can opt into MPEG-TS segments (no init segment)
     // to bypass AVPlay's HLS-fMP4 rejection (issue #148). The fMP4 path
     // is post-processed to CMAF (`cmaf-rewrite.ts`) so it works on
@@ -1397,6 +1399,7 @@ export class StreamingController {
         `[request] ${segment} mfid=${mediaFileId} quality=${quality}`,
       );
     }
+    const live = this.findRequestSession(req, mediaFileId);
 
     // Fast path: if a session already exists, skip the DB query — we only
     // need resolveFile for absolutePath + context when creating a NEW session.
@@ -1422,7 +1425,7 @@ export class StreamingController {
       existing != null &&
       (quality === 'remux' ? !!existing.remux : existing.quality === quality);
     if (segment.startsWith('init') && existing && sessionQualityMatches) {
-      const ma = this.activeStreamTracker.getUseExtXMedia(mediaFileId);
+      const ma = live?.useExtXMedia ?? false;
       // Same caveat as the segment path: remux video-only doesn't use
       // var_stream_map, so the `0/` prefix would 404 on the init lookup.
       const initFile = ma && quality !== 'remux' ? `0/${segment}` : segment;
@@ -1472,8 +1475,7 @@ export class StreamingController {
     // serve it without any DB query or session management. Completed sessions
     // (exitCode !== null) still have valid segments in cache — don't skip them.
     if (existing && existing.quality === quality) {
-      const varStreamMap =
-        this.activeStreamTracker.getUseExtXMedia(mediaFileId);
+      const varStreamMap = live?.useExtXMedia ?? false;
       const segName =
         varStreamMap && quality !== 'remux' ? `0/${segment}` : segment;
       const segPath = `${existing.cachePath}/${segName}`;
@@ -1524,8 +1526,7 @@ export class StreamingController {
         req,
       );
       if (earlySession && earlySession.quality === quality) {
-        const varStreamMap =
-          this.activeStreamTracker.getUseExtXMedia(mediaFileId);
+        const varStreamMap = live?.useExtXMedia ?? false;
         const segName = varStreamMap ? `0/${segment}` : segment;
         const segPath = await this.transcodingService.getSegmentPath(
           earlySession,
@@ -1550,7 +1551,7 @@ export class StreamingController {
 
     // For remux sessions, copy audio only when the source codec is compatible
     // (captured at playback-info); otherwise transcode audio to AAC.
-    const copyAudio = this.activeStreamTracker.getCanCopyAudio(mediaFileId);
+    const copyAudio = live?.canCopyAudio ?? false;
     const session =
       quality === 'remux'
         ? await this.transcodingService.getOrCreateRemuxSession(
@@ -1571,7 +1572,7 @@ export class StreamingController {
     // With var_stream_map (fMP4 + multi-audio), video segments are in
     // subdirectory "0/". The remux session keeps a flat layout (no
     // var_stream_map), so the `0/` prefix would 404 there.
-    const varStreamMap = this.activeStreamTracker.getUseExtXMedia(mediaFileId);
+    const varStreamMap = live?.useExtXMedia ?? false;
     const usesVarStreamMapLayout = varStreamMap && quality !== 'remux';
     const segName = usesVarStreamMapLayout ? `0/${segment}` : segment;
 


### PR DESCRIPTION
## Summary

\`ActiveStreamTracker\` used to hold fourteen per-playback caches keyed by \`mediaFileId\` alone (\`useTs\`, \`audioPlan\`, \`audioStreamIndex\`, \`useExtXMedia\`, \`deviceType\`, \`hdrLadder\`, \`videoVariant\`, \`tonemapping\`, \`transcodeReasons\`, \`burnIn\`, \`encoderPreset\`, \`canCopyVideo\`, \`canCopyAudio\`, \`audioStreamCount\`). That keying clobbered settings whenever two playbacks of the same file overlapped — not just multi-user, but the more common same-user multi-device case (a browser tab still open while the Tizen TV starts the same movie clobbered the browser's \`useTs\` / ladder / audio plan).

\`LiveSession\` is the natural owner of this state: each playback has a unique server-issued \`sid\` the client carries in every URL via \`?sid=\`. This PR moves all per-playback settings onto \`LiveSession\`.

- **\`LiveSession\`** gains the fourteen fields, all with sensible defaults.
- **\`LiveSessionRegistry\`** exposes \`update(sid, patch)\` and \`findCurrent(userId, mediaFileId)\` (fallback when \`sid\` isn't on the URL).
- **HLS routes** resolve the session via a new private \`findRequestSession(req, mediaFileId)\` — \`sid\` first, then \`findCurrent\` for legacy callers — and read settings off the matching entry.
- **\`StreamBuilderService.evaluate\`** returns \`{ response, useHdrLadder, videoVariant }\` (\`EvaluateResult\`) so the controller can thread those onto \`LiveSession\` on \`create\` rather than reading them back through the tracker. The service no longer touches \`ActiveStreamTracker\`.
- **\`ActiveStreamTracker\`** stays for: DirectPlay session presence (admin dashboard), per-(user, file) device label, intrinsic file dimensions (identical across users), and global admin settings (segment duration, QSV options, tonemap algo).
- **\`system.controller.ts\`** reads \`audioPlan\` from \`LiveSession\` (via \`findCurrent\`) instead of the tracker.

### Why this matters

The same-user multi-device case is now genuinely isolated. \`listForJob\` / \`findCurrent\` partition by \`(user, file, profileHash)\`; any playback with a distinct profile hash carries its own \`LiveSession\` with its own settings. No more clobber when:

- Tizen TV + browser tab on the same file
- Mobile + desktop on the same file
- HDR + non-HDR clients on the same file
- Two users picking different audio tracks / burn-in subs

### Architecture follow-ups now natural

This refactor lays the groundwork for #291 items #2 (auto-recreate \`LiveSession\` on heartbeat — the session now contains everything needed to rebuild from a heartbeat payload) and #5 (dashboard consolidation — the dashboard already reads from \`LiveSessionRegistry\` for audioPlan).

Refs: #291

## Test plan
- [x] \`npx jest src/modules/streaming/\` — 55/55 specs pass (49 pre-existing + 6 new live-session specs covering create-with-settings, update, findCurrent ordering, multi-user isolation, same-user multi-device coexistence)
- [x] \`npx jest\` full backend — 83/83 specs pass
- [x] \`npx tsc --noEmit\` clean
- [ ] Smoke test: open the same file on browser + Tizen TV simultaneously; confirm both sessions keep their own settings (each gets its own \`?sid=\`, the tracker no longer holds shared state)
- [ ] Smoke test: two users on the same file with different audio tracks — each gets their own pick
- [ ] Resume + cast scenarios still work as before