### PR TITLE
feat(streaming): auto-recover player when backend loses the LiveSession

### DIFF
--- a/backend/src/modules/streaming/playback.controller.ts
+++ b/backend/src/modules/streaming/playback.controller.ts
@@ -178,7 +178,13 @@ export class PlaybackController {
    *  refreshes the in-memory {@link LiveSessionRegistry} on every call
    *  and debounces the actual DB write to one every
    *  {@link STATE_DB_WRITE_INTERVAL_MS}. State transitions
-   *  (`playing` ↔ `paused`) and completion always force a flush. */
+   *  (`playing` ↔ `paused`) and completion always force a flush.
+   *
+   *  When the carried `sessionId` is unknown to the registry (backend
+   *  restart, GC after a long idle, …) the response carries
+   *  `{ sessionLost: true }` so the client knows to recover by
+   *  re-issuing `playback-info` and reloading the stream URL with
+   *  the fresh sid. */
   @Put('media/:mediaId/state')
   async updateState(
     @Req() req: Request,
@@ -197,10 +203,11 @@ export class PlaybackController {
       audioTrackIndex?: number | null;
       subtitleTrackIndex?: number | null;
     },
-  ) {
+  ): Promise<{ sessionLost?: true; state?: unknown } | null> {
     const user = req.user as User;
 
     let stateChanged = false;
+    let sessionLost = false;
     if (body.sessionId) {
       const before = this.liveSessions.get(body.sessionId);
       const previousState = before?.state;
@@ -212,6 +219,9 @@ export class PlaybackController {
         subtitleTrackIndex: body.subtitleTrackIndex,
       });
       stateChanged = !!updated && !!body.state && previousState !== body.state;
+      // The client believes the session is alive but the registry
+      // doesn't know it — surface that so the client can recover.
+      sessionLost = !updated;
     }
 
     const dbKey = `${user.id}:${mediaId}:${body.episodeId ?? 0}`;
@@ -226,15 +236,17 @@ export class PlaybackController {
       now - lastWrite >= STATE_DB_WRITE_INTERVAL_MS;
 
     if (!shouldFlushDb) {
-      return null;
+      return sessionLost ? { sessionLost: true } : null;
     }
     this.lastDbWriteAt.set(dbKey, now);
-    return this.playbackService.updateState(user.id, mediaId, {
+    const state = await this.playbackService.updateState(user.id, mediaId, {
       positionSeconds: body.positionSeconds,
       durationSeconds: body.durationSeconds,
       mediaFileId: body.mediaFileId,
       episodeId: body.episodeId,
     });
+    if (sessionLost) return { sessionLost: true, state };
+    return { state };
   }
 
   /** Toggle watched/unwatched for a media or episode. */

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -115,6 +115,19 @@ export interface PlaybackState {
   lastPlayedAt: string;
 }
 
+/**
+ * Response from the heartbeat endpoint (PUT /playback/media/:id/state).
+ * `sessionLost: true` means the carried `sid` is no longer known to
+ * the backend (restart, GC, …) — caller must re-issue `playback-info`
+ * and reload the stream URL with the fresh sid. `state` carries the
+ * persisted PlaybackState row when the call flushed to the DB
+ * (debounced); the field is omitted on a no-op tick.
+ */
+export interface HeartbeatResponse {
+  sessionLost?: true;
+  state?: PlaybackState;
+}
+
 export interface WatchHistoryItem {
   id: number;
   mediaId: number;
@@ -459,7 +472,7 @@ export class StreamingApiService {
     },
   ) {
     return firstValueFrom(
-      this.http.put<PlaybackState | null>(
+      this.http.put<HeartbeatResponse | null>(
         `/api/playback/media/${mediaId}/state`,
         body,
       ),

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1760,6 +1760,59 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     await this.castPlayerService.reloadCastStream(position);
   }
 
+  /**
+   * Guard so a slow recovery (~1-2 s of playback-info + reload) can't
+   * race against the next 10-second heartbeat: we only fire one
+   * recoverFromLostSession at a time, no matter how many heartbeats
+   * surface `sessionLost: true` in the interval.
+   */
+  private recoveringFromLostSession = false;
+
+  /**
+   * The carried `sid` is no longer known to the backend (restart or
+   * GC after a long idle). Mint a fresh LiveSession via playback-info
+   * and reload the engine's stream URL with the new sid at the
+   * current position. Cast playbacks are skipped — the cast receiver
+   * owns its own session lifecycle.
+   */
+  private async recoverFromLostSession(): Promise<void> {
+    if (this.recoveringFromLostSession) return;
+    if (this.castService.isConnected()) return;
+    if (!this.engine || !this.mediaFileId) return;
+    this.recoveringFromLostSession = true;
+    try {
+      const currentPos = this.engine.currentTime || 0;
+      const deviceProfile = this.deviceProfileService.getProfile();
+      this.playbackInfo = await this.streamingApi.getPlaybackInfo(
+        this.mediaFileId,
+        deviceProfile,
+        this.activeBurnInId ?? undefined,
+        this.activeAudioStreamIndex ?? undefined,
+        undefined,
+        currentPos > 0 ? Math.floor(currentPos) : undefined,
+      );
+      const sid = this.playbackInfo.sessionId;
+      const mode = this.playbackMode();
+      const savedQualityId = this.activeQualityId();
+      const startQuality = mode !== 'direct' && savedQualityId !== 'auto'
+        ? savedQualityId
+        : undefined;
+      const url = mode === 'direct'
+        ? this.streamingApi.getStreamUrl(this.mediaFileId, sid)
+        : this.streamingApi.getHlsUrl(this.mediaFileId, startQuality, undefined, sid);
+      const mimeType = mode === 'direct' ? 'video/mp4' : undefined;
+      const wasPaused = this.paused();
+      await this.engine.load(url, currentPos > 0 ? currentPos : undefined, mimeType);
+      this.qualityManager.applyQualityPreferenceAfterLoad(this.engine, mode);
+      if (!wasPaused) {
+        this.engine.play().catch(() => {});
+      }
+    } catch { /* heartbeat is fire-and-forget; next one retries */ }
+    finally {
+      this.recoveringFromLostSession = false;
+    }
+  }
+
   /** Reload local engine and resume after Cast disconnect. */
   private async resumeLocalAfterCast(castPos: number) {
     try {
@@ -2449,7 +2502,17 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     };
     if (this.network.isOnline()) {
       try {
-        await this.streamingApi.updatePlaybackState(this.mediaId, payload);
+        const response = await this.streamingApi.updatePlaybackState(
+          this.mediaId,
+          payload,
+        );
+        // The backend has GC'd / lost our LiveSession (restart, long
+        // idle, …). Re-issue playback-info and reload the engine
+        // with the fresh sid at the current position before the
+        // player's buffer drains.
+        if (response?.sessionLost) {
+          void this.recoverFromLostSession();
+        }
       } catch {
         this.offlineSync.queue(offlinePayload);
       }


### PR DESCRIPTION
## Summary

A backend restart (or a long-idle GC) wipes \`LiveSessionRegistry\`. The player keeps fetching with its old sid, but the registry no longer knows it — the heartbeat silently fails, and a few seconds later \`cleanupStaleSessions\` kills the ffmpeg with no matching live viewer. The user sees the stream stall until they seek (which triggers a fresh \`playback-info\`).

This PR closes the loop:

**Backend** — \`PUT /api/playback/media/:id/state\` now returns \`{ sessionLost: true }\` when the carried sid isn't in the registry. The previous \`null\` / state return shapes are preserved (state is wrapped inside the envelope on a flush tick), so any caller that ignores the response is unaffected.

**Frontend** — on the very next heartbeat (~10 s cadence):
- \`savePosition\` reads the response.
- \`recoverFromLostSession\` re-issues \`getPlaybackInfo\` with the current playhead as \`startAt\`, takes the fresh sid, and reloads the engine's stream URL.
- Skipped while casting (the cast receiver owns its own session lifecycle).
- A \`recoveringFromLostSession\` guard prevents concurrent recoveries when multiple heartbeats overlap the recovery window.

## UX

- If Shaka's buffer is ≥ ~15 s ahead of the playhead, the swap happens behind playback and the user sees nothing.
- With a thinner buffer, the spinner is bounded to ~10 s (next heartbeat) + cold ffmpeg spawn — vs the current behaviour of stalling until the user seeks.
- A follow-up could route recovery off segment-fetch failures too (faster reaction); deferring until we see real-world spinner pain.

Refs: #291 item #2

## Test plan

- [x] \`npx jest src/modules/streaming/\` — 55/55 specs pass.
- [x] \`npx tsc --noEmit\` clean on both backend and client.
- [ ] Smoke test: restart the backend container mid-playback → confirm the player resumes within ~10 s without manual seek.
- [ ] Same test while casting → confirm recovery is *not* triggered locally (cast keeps playing).
- [ ] Pause the player, restart the backend, confirm recovery preserves the paused state (no auto-play).