### PR TITLE
refactor(player): dedupe URL build and sid-refresh paths

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -99,6 +99,16 @@ function streamQuery(
   return `${base}${sep}${parts.join('&')}`;
 }
 
+/** Lift `?token=` and `?sid=` off the incoming request and serialise
+ *  them back into a `?token=…&sid=…` suffix. Used to propagate the
+ *  caller's auth + live-session handle into the segment / playlist
+ *  URLs returned in HLS manifests. */
+function buildTokenParam(req: Request): string {
+  const token = firstQueryString(req.query, 'token');
+  const sid = firstQueryString(req.query, 'sid');
+  return streamQuery({ token, sid });
+}
+
 /** Pick the right HLS segment Content-Type. fMP4 (.m4s / .mp4) → video/mp4,
  *  MPEG-TS (.ts, used as the explicit `useTs` fallback for Tizen TVs on
  *  older firmwares — issue #148) → video/MP2T. */
@@ -630,9 +640,7 @@ export class StreamingController {
       mediaFileId,
       req.user as User,
     );
-    const token = firstQueryString(req.query, 'token');
-    const sid = firstQueryString(req.query, 'sid');
-    const tokenParam = streamQuery({ token, sid });
+    const tokenParam = buildTokenParam(req);
     const burnInSubtitleRaw = firstQueryString(req.query, 'burnInSubtitleId');
     const burnInSubtitleId = burnInSubtitleRaw
       ? parseInt(burnInSubtitleRaw, 10)
@@ -972,9 +980,7 @@ export class StreamingController {
     const w = crop?.width ?? v?.width ?? 1920;
     const h = crop?.height ?? v?.height ?? 1080;
 
-    const token = firstQueryString(req.query, 'token');
-    const sid = firstQueryString(req.query, 'sid');
-    const tokenParam = streamQuery({ token, sid });
+    const tokenParam = buildTokenParam(req);
 
     const includeRemux = firstQueryString(req.query, 'remux') === '1';
     const sourceBitrate = (v?.bitRate ?? 0) + (si?.audio?.[0]?.bitRate ?? 0);
@@ -1149,9 +1155,7 @@ export class StreamingController {
       );
     }
 
-    const token = firstQueryString(req.query, 'token');
-    const sid = firstQueryString(req.query, 'sid');
-    const tokenParam = streamQuery({ token, sid });
+    const tokenParam = buildTokenParam(req);
     const basePath = `/api/stream/${mediaFileId}/audio/${audioIndex}`;
     const useTs = live?.useTs ?? false;
     const segExt = useTs ? 'ts' : 'm4s';
@@ -1338,9 +1342,7 @@ export class StreamingController {
       }
     }
 
-    const token = firstQueryString(req.query, 'token');
-    const sid = firstQueryString(req.query, 'sid');
-    const tokenParam = streamQuery({ token, sid });
+    const tokenParam = buildTokenParam(req);
     const basePath = `/api/stream/${mediaFileId}/${quality}`;
     // Use the master.m3u8 decision — must match to avoid init filename mismatch.
     const live = this.findRequestSession(req, mediaFileId);

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -857,23 +857,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
             this.authService.streamToken() ?? this.authService.accessToken;
           const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
 
-          if (mode === 'direct') {
-            const streamUrl = this.streamingApi.getStreamUrl(
-              this.mediaFileId,
-              this.playbackInfo?.sessionId,
-            );
-            await this.engine!.load(streamUrl, startTime, 'video/mp4', headers);
-          } else {
-            const savedQualityId = this.activeQualityId();
-            const tvStartQuality = savedQualityId !== 'auto' ? savedQualityId : undefined;
-            const hlsUrl = this.streamingApi.getHlsUrl(
-              this.mediaFileId,
-              tvStartQuality,
-              startTime,
-              this.playbackInfo?.sessionId,
-            );
-            await this.engine!.load(hlsUrl, startTime, undefined, headers);
-          }
+          const { url: tizenUrl, mimeType: tizenMimeType } = this.buildPlayUrl({
+            startTime,
+          });
+          await this.engine!.load(tizenUrl, startTime, tizenMimeType, headers);
 
           // Subtitles loaded — expose to the picker. The full auto-pick
           // path (remembered selection, language match, forced subs) is
@@ -916,21 +903,13 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
             this.authService.streamToken() ?? this.authService.accessToken;
           const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
 
-          if (mode === 'direct') {
-            // Progressive MP4 — Media3 detects the container, no quality
-            // ladder to constrain (DirectPlay = single source variant).
-            const streamUrl = this.streamingApi.getStreamUrl(
-              this.mediaFileId,
-              this.playbackInfo?.sessionId,
-            );
-            await this.engine!.load(streamUrl, startTime, 'video/mp4', headers);
-          } else {
-            // HLS transcode/remux — apply quality constraint before load to
-            // stop ExoPlayer from picking 4K on a phone (slow transcode →
-            // A/V desync). `auto`: no constraint, ExoPlayer's ABR picks
-            // adaptively. `original`: pin to source dimensions so ABR
-            // can't downgrade (the user explicitly forced top quality).
-            // Specific rung: pin to that rung's width/height.
+          // HLS transcode/remux — apply quality constraint before load to
+          // stop ExoPlayer from picking 4K on a phone (slow transcode →
+          // A/V desync). `auto`: no constraint, ExoPlayer's ABR picks
+          // adaptively. `original`: pin to source dimensions so ABR
+          // can't downgrade (the user explicitly forced top quality).
+          // Specific rung: pin to that rung's width/height.
+          if (mode !== 'direct') {
             const savedQualityId = this.activeQualityId();
             if (savedQualityId !== 'auto') {
               let w: number;
@@ -945,15 +924,11 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
               }
               (this.engine as NativeEngine).selectVariantTrack({ width: w, height: h });
             }
-            const nativeStartQuality = savedQualityId !== 'auto' ? savedQualityId : undefined;
-            const hlsUrl = this.streamingApi.getHlsUrl(
-              this.mediaFileId,
-              nativeStartQuality,
-              startTime,
-              this.playbackInfo?.sessionId,
-            );
-            await this.engine!.load(hlsUrl, startTime, undefined, headers);
           }
+          const { url: nativeUrl, mimeType: nativeMimeType } = this.buildPlayUrl({
+            startTime,
+          });
+          await this.engine!.load(nativeUrl, startTime, nativeMimeType, headers);
         } else {
           await this.createShakaEngine();
 
@@ -962,13 +937,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
             this.mediaId, this.mediaFileId, this.streamingApi, this.media,
           );
 
-          if (mode === 'direct') {
-            const streamUrl = this.streamingApi.getStreamUrl(
-              this.mediaFileId,
-              this.playbackInfo?.sessionId,
-            );
-            await this.engine!.load(streamUrl, startTime, 'video/mp4');
-          } else {
+          if (mode !== 'direct') {
             const savedQualityId = this.activeQualityId();
             if (savedQualityId === 'auto') {
               this.qualityManager.selectQuality(
@@ -1008,21 +977,16 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
               },
               ...(preferredLang ? { preferredAudioLanguage: preferredLang } : {}),
             });
-
-            // Tell the backend the target quality so it pre-starts FFmpeg at
-            // the right profile + applies the quality-change grace period to
-            // protect the session from Shaka's startup bandwidth probe.
-            const startQuality = savedQualityId !== 'auto' ? savedQualityId : undefined;
-            const hlsUrl = this.streamingApi.getHlsUrl(
-              this.mediaFileId,
-              startQuality,
-              startTime,
-              this.playbackInfo?.sessionId,
-            );
-            await this.engine!.load(hlsUrl, startTime);
           }
 
-
+          // `buildPlayUrl` threads `startTime` into HLS URLs so the
+          // backend pre-spawns FFmpeg at the right offset + applies the
+          // quality-change grace period; direct play gets the explicit
+          // `video/mp4` mimeType for Shaka.
+          const { url: shakaUrl, mimeType: shakaMimeType } = this.buildPlayUrl({
+            startTime,
+          });
+          await this.engine!.load(shakaUrl, startTime, shakaMimeType);
         }
       }
 
@@ -1761,6 +1725,76 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   }
 
   /**
+   * Compose the engine's stream URL for the current `playbackMode`.
+   * Returns `{ url, mimeType }` — direct play needs the explicit
+   * `video/mp4` content type for native + Tizen engines, HLS lets the
+   * engine sniff. `startTime` is only consumed by HLS (lets the
+   * backend pre-spawn ffmpeg at the right offset); reload paths
+   * intentionally omit it because the engine seeks after `load`.
+   */
+  private buildPlayUrl(opts: {
+    sid?: string | null;
+    startTime?: number;
+  } = {}): { url: string; mimeType?: string } {
+    const mode = this.playbackMode();
+    const sid = opts.sid ?? this.playbackInfo?.sessionId;
+    if (mode === 'direct') {
+      return {
+        url: this.streamingApi.getStreamUrl(this.mediaFileId, sid),
+        mimeType: 'video/mp4',
+      };
+    }
+    const savedQualityId = this.activeQualityId();
+    const startQuality = savedQualityId !== 'auto' ? savedQualityId : undefined;
+    return {
+      url: this.streamingApi.getHlsUrl(
+        this.mediaFileId,
+        startQuality,
+        opts.startTime,
+        sid,
+      ),
+    };
+  }
+
+  /**
+   * Mint a fresh LiveSession via `playback-info` and reload the
+   * engine at `pos` with the new sid. Shared body between
+   * {@link resumeLocalAfterCast} (Cast disconnect — also unmutes) and
+   * {@link recoverFromLostSession} (heartbeat said sid is unknown —
+   * preserves a pre-existing pause). HLS routes intentionally drop
+   * `startTime` on the URL because the engine handles the seek after
+   * `load`.
+   */
+  private async refreshSidAndReload(
+    pos: number,
+    opts: { preservePause: boolean; unmute: boolean },
+  ): Promise<void> {
+    if (!this.engine || !this.mediaFileId) return;
+    if (opts.unmute) this.engine.muted = false;
+    const wasPaused = opts.preservePause ? this.paused() : false;
+    const deviceProfile = this.deviceProfileService.getProfile();
+    this.playbackInfo = await this.streamingApi.getPlaybackInfo(
+      this.mediaFileId,
+      deviceProfile,
+      this.activeBurnInId ?? undefined,
+      this.activeAudioStreamIndex ?? undefined,
+      undefined,
+      pos > 0 ? Math.floor(pos) : undefined,
+    );
+    const { url, mimeType } = this.buildPlayUrl({
+      sid: this.playbackInfo.sessionId,
+    });
+    await this.engine.load(url, pos > 0 ? pos : undefined, mimeType);
+    this.qualityManager.applyQualityPreferenceAfterLoad(
+      this.engine,
+      this.playbackMode(),
+    );
+    if (!wasPaused) {
+      this.engine.play().catch(() => {});
+    }
+  }
+
+  /**
    * Guard so a slow recovery (~1-2 s of playback-info + reload) can't
    * race against the next 10-second heartbeat: we only fire one
    * recoverFromLostSession at a time, no matter how many heartbeats
@@ -1781,70 +1815,27 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     if (!this.engine || !this.mediaFileId) return;
     this.recoveringFromLostSession = true;
     try {
-      const currentPos = this.engine.currentTime || 0;
-      const deviceProfile = this.deviceProfileService.getProfile();
-      this.playbackInfo = await this.streamingApi.getPlaybackInfo(
-        this.mediaFileId,
-        deviceProfile,
-        this.activeBurnInId ?? undefined,
-        this.activeAudioStreamIndex ?? undefined,
-        undefined,
-        currentPos > 0 ? Math.floor(currentPos) : undefined,
-      );
-      const sid = this.playbackInfo.sessionId;
-      const mode = this.playbackMode();
-      const savedQualityId = this.activeQualityId();
-      const startQuality = mode !== 'direct' && savedQualityId !== 'auto'
-        ? savedQualityId
-        : undefined;
-      const url = mode === 'direct'
-        ? this.streamingApi.getStreamUrl(this.mediaFileId, sid)
-        : this.streamingApi.getHlsUrl(this.mediaFileId, startQuality, undefined, sid);
-      const mimeType = mode === 'direct' ? 'video/mp4' : undefined;
-      const wasPaused = this.paused();
-      await this.engine.load(url, currentPos > 0 ? currentPos : undefined, mimeType);
-      this.qualityManager.applyQualityPreferenceAfterLoad(this.engine, mode);
-      if (!wasPaused) {
-        this.engine.play().catch(() => {});
-      }
+      await this.refreshSidAndReload(this.engine.currentTime || 0, {
+        preservePause: true,
+        unmute: false,
+      });
     } catch { /* heartbeat is fire-and-forget; next one retries */ }
     finally {
       this.recoveringFromLostSession = false;
     }
   }
 
-  /** Reload local engine and resume after Cast disconnect. */
+  /** Reload local engine and resume after Cast disconnect. The
+   *  browser's pre-cast LiveSession was GC'd while the cast receiver
+   *  held the only live entry, so we mint a fresh sid before
+   *  reloading — reusing `this.playbackInfo?.sessionId` would race
+   *  against the heartbeat fallback path and flash a reload. */
   private async resumeLocalAfterCast(castPos: number) {
     try {
-      if (this.engine) this.engine.muted = false;
-      if (this.engine && this.mediaFileId) {
-        // Mint a fresh sid: the browser's pre-cast LiveSession was
-        // GC'd while the cast receiver held the only live entry, so
-        // reusing `this.playbackInfo?.sessionId` would race against
-        // the heartbeat fallback path and flash a reload.
-        const deviceProfile = this.deviceProfileService.getProfile();
-        this.playbackInfo = await this.streamingApi.getPlaybackInfo(
-          this.mediaFileId,
-          deviceProfile,
-          this.activeBurnInId ?? undefined,
-          this.activeAudioStreamIndex ?? undefined,
-          undefined,
-          castPos > 0 ? Math.floor(castPos) : undefined,
-        );
-        const sid = this.playbackInfo.sessionId;
-        const mode = this.playbackMode();
-        const savedQualityId = this.activeQualityId();
-        const startQuality = mode !== 'direct' && savedQualityId !== 'auto'
-          ? savedQualityId
-          : undefined;
-        const url = mode === 'direct'
-          ? this.streamingApi.getStreamUrl(this.mediaFileId, sid)
-          : this.streamingApi.getHlsUrl(this.mediaFileId, startQuality, undefined, sid);
-        const mimeType = mode === 'direct' ? 'video/mp4' : undefined;
-        await this.engine.load(url, castPos > 0 ? castPos : undefined, mimeType);
-        this.qualityManager.applyQualityPreferenceAfterLoad(this.engine, mode);
-        this.engine.play().catch(() => {});
-      }
+      await this.refreshSidAndReload(castPos, {
+        preservePause: false,
+        unmute: true,
+      });
     } catch { /* ignore */ }
   }
 
@@ -2375,25 +2366,8 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     this.qualityManager.buildQualityOptions(pi);
 
     const mode = this.playbackMode();
-    if (mode === 'direct') {
-      await this.engine.load(
-        this.streamingApi.getStreamUrl(this.mediaFileId, this.playbackInfo?.sessionId),
-        currentPos,
-        'video/mp4',
-      );
-    } else {
-      const savedQualityId = this.activeQualityId();
-      const startQuality = savedQualityId !== 'auto' ? savedQualityId : undefined;
-      await this.engine.load(
-        this.streamingApi.getHlsUrl(
-          this.mediaFileId,
-          startQuality,
-          currentPos,
-          pi.sessionId,
-        ),
-        currentPos,
-      );
-    }
+    const { url, mimeType } = this.buildPlayUrl({ startTime: currentPos });
+    await this.engine.load(url, currentPos, mimeType);
 
     this.qualityManager.applyQualityPreferenceAfterLoad(this.engine, mode);
     this.engine.play().catch(() => {});


### PR DESCRIPTION
## Summary

Three near-identical clusters were sprawling across \`player.ts\`:

1. **Sid-refresh body** — \`resumeLocalAfterCast\` (Cast disconnect) and \`recoverFromLostSession\` (heartbeat said sid is unknown) had nearly identical bodies: mint a fresh sid via \`playback-info\`, reload the engine at position, resume. Pulled into \`refreshSidAndReload(pos, opts)\` with the two public differences surfaced as \`opts\` (unmute on Cast, preserve-pause on recovery).
2. **URL compose** — \`if (mode === 'direct') getStreamUrl else getHlsUrl\` repeated five times (Tizen / Native / Shaka load paths + the two refresh paths + reloadStream). Pulled into \`buildPlayUrl({ sid?, startTime? }): { url, mimeType }\`.
3. **reloadStream** — load branch collapses into a single \`buildPlayUrl\` call.

Engine-specific configuration (Native variant pinning, Shaka ABR / \`preferredAudioLanguage\` / retryParameters) stays in its branch — only the URL composition is shared. Cast and recovery still pass \`startTime: undefined\` on HLS so the engine drives the seek post-load, matching prior behaviour.

## What stays untouched
- Auth header derivation (token → \`Authorization: Bearer …\`) — Tizen + Native specific.
- ExoPlayer variant track pinning before HLS load.
- Shaka ABR configure block (per-quality enabling, retry params, preferredAudioLanguage).
- Subtitle restore after reloadStream.

## Stats

- Net file: 2592 → 2566 lines (-26).
- ~130 lines of duplicated body replaced by two focused helpers (\`buildPlayUrl\`, \`refreshSidAndReload\`).

Stacked on **#303** (extract \`buildTokenParam\` backend helper) — rebase straightforward if #303 lands first.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Fresh play (DirectPlay, transcode, remux) on browser, native mobile, Tizen
- [ ] Cast → disconnect mid-playback → \`resumeLocalAfterCast\` resumes at correct position
- [ ] Backend restart mid-playback → \`recoverFromLostSession\` recovers at current position, paused state preserved
- [ ] Quality change in player → \`reloadStream\` plays at chosen quality, subtitle restored