### PR TITLE
fix(streaming): 410 gone for stale sids + cross-engine recovery

### DIFF
--- a/backend/src/modules/streaming/session-expired.exception.spec.ts
+++ b/backend/src/modules/streaming/session-expired.exception.spec.ts
@@ -1,0 +1,26 @@
+import { HttpStatus } from '@nestjs/common';
+import { SessionExpiredException } from './session-expired.exception';
+
+describe('SessionExpiredException', () => {
+  it('serialises to a 410 Gone with the stable error shape', () => {
+    const ex = new SessionExpiredException('abc-123');
+    expect(ex.getStatus()).toBe(HttpStatus.GONE);
+    expect(ex.getResponse()).toEqual({
+      code: 'session_expired',
+      sid: 'abc-123',
+      message: 'live session no longer exists',
+    });
+  });
+
+  it('accepts a null sid (anonymous fetches)', () => {
+    const ex = new SessionExpiredException(null);
+    expect(ex.getStatus()).toBe(HttpStatus.GONE);
+    expect((ex.getResponse() as { sid: unknown }).sid).toBeNull();
+  });
+
+  it('carries a custom reason when provided', () => {
+    const ex = new SessionExpiredException('xyz', 'profileHash mismatch');
+    const body = ex.getResponse() as { message: string };
+    expect(body.message).toBe('profileHash mismatch');
+  });
+});

--- a/backend/src/modules/streaming/session-expired.exception.ts
+++ b/backend/src/modules/streaming/session-expired.exception.ts
@@ -1,0 +1,24 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+/**
+ * 410 Gone for HLS requests that carry a `sid` query the
+ * LiveSessionRegistry no longer knows. Surfaces a deterministic signal
+ * the client can react to (refetch `/playback-info`, reload the engine)
+ * instead of the indefinite 5xx retry storm that follows a generic
+ * `Error` thrown deep in the transcode setup path.
+ *
+ * The body shape is stable across players:
+ *   { code: 'session_expired', sid, message }
+ *
+ * Shaka response filter and the Tizen / Capacitor / webOS native engine
+ * wrappers all match on `code === 'session_expired'` to trigger the
+ * shared {@link refreshSidAndReload} recovery flow.
+ */
+export class SessionExpiredException extends HttpException {
+  constructor(sid: string | null, reason = 'live session no longer exists') {
+    super(
+      { code: 'session_expired', sid, message: reason },
+      HttpStatus.GONE,
+    );
+  }
+}

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -43,6 +43,7 @@ import { resolveTonemapPath } from './transcoding/tonemap-path';
 import { ThumbnailService } from './thumbnail.service';
 import { StreamBuilderService } from './stream-builder.service';
 import { ActiveStreamTracker } from './active-stream-tracker.service';
+import { SessionExpiredException } from './session-expired.exception';
 import { SubtitleBurnInService } from './subtitle-burn-in.service';
 import { PlaybackService } from './playback.service';
 import { MarkersService } from '../markers/markers.service';
@@ -325,6 +326,27 @@ export class StreamingController {
     return this.liveSessions.findCurrent(userId, mediaFileId);
   }
 
+  /**
+   * 410-gate HLS routes against a stale `?sid=`. When the URL carries a
+   * sid the LiveSessionRegistry no longer knows (typical after a
+   * backend restart or a long-idle GC pass), refuse the request with a
+   * typed body the player can pattern-match. The Shaka response filter
+   * and the Tizen / Capacitor / webOS engine wrappers all react to
+   * `code === 'session_expired'` by triggering the shared
+   * refreshSidAndReload recovery flow.
+   *
+   * Without a sid we let the request through — legacy direct-URL
+   * fetches and pre-#302 callers fall back to the userId-based
+   * `findCurrent` lookup downstream.
+   */
+  private assertFreshSession(req: Request): void {
+    const sid = firstQueryString(req.query, 'sid');
+    if (!sid) return;
+    if (!this.liveSessions.get(sid)) {
+      throw new SessionExpiredException(sid);
+    }
+  }
+
   private buildSessionContext(
     req: Request,
     resolved: ResolvedFile,
@@ -383,11 +405,11 @@ export class StreamingController {
       isSourceHdr: !!si?.video?.[0]?.hdrFormat,
       // Variant chosen by stream-builder's codec selector at
       // playback-info time, threaded through every session spawn so
-      // ffmpeg-args resolves the matching encoder descriptor. A
-      // segment request that arrives before playback-info has created
-      // the LiveSession hits `buildFfmpegArgs`'s explicit throw, which
-      // surfaces as a 5xx the player retries after the next
-      // playback-info call.
+      // ffmpeg-args resolves the matching encoder descriptor. HLS
+      // routes 410-gate stale `?sid=` upstream via assertFreshSession,
+      // so videoVariant is undefined here only for legacy callers that
+      // never sent a sid — those route through the
+      // userId-based `findCurrent` fallback.
       videoVariant: live?.videoVariant ?? undefined,
     };
   }
@@ -969,6 +991,7 @@ export class StreamingController {
     @Req() req: Request,
     @Res() res: Response,
   ) {
+    this.assertFreshSession(req);
     const resolved = await this.streamingService.resolveFile(
       mediaFileId,
       req.user as User,
@@ -1123,6 +1146,7 @@ export class StreamingController {
     @Req() req: Request,
     @Res() res: Response,
   ) {
+    this.assertFreshSession(req);
     const resolved = await this.streamingService.resolveFile(
       mediaFileId,
       req.user as User,
@@ -1180,6 +1204,7 @@ export class StreamingController {
     @Req() req: Request,
     @Res() res: Response,
   ) {
+    this.assertFreshSession(req);
     const AUDIO_SEG_RE = /^(init(_\d+)?\.mp4|seg-\d{3,4}\.(m4s|ts))$/;
     if (!AUDIO_SEG_RE.test(segment)) {
       throw new BadRequestException(`Invalid audio segment name: ${segment}`);
@@ -1290,6 +1315,7 @@ export class StreamingController {
     if (!VALID_QUALITIES.has(quality)) {
       throw new BadRequestException(`Invalid quality: ${quality}`);
     }
+    this.assertFreshSession(req);
     const resolved = await this.streamingService.resolveFile(
       mediaFileId,
       req.user as User,
@@ -1388,6 +1414,7 @@ export class StreamingController {
     if (!VALID_QUALITIES.has(quality)) {
       throw new BadRequestException(`Invalid quality: ${quality}`);
     }
+    this.assertFreshSession(req);
     const VIDEO_SEG_RE = /^(seg-\d{3,4}\.(m4s|ts)|init(_\d+)?\.mp4)$/;
     if (!VIDEO_SEG_RE.test(segment)) {
       throw new BadRequestException(`Invalid segment name: ${segment}`);

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -305,15 +305,16 @@ export function buildFfmpegArgs(
   // the formats supported by the filter`.
   //
   // `videoVariant` is required: callers must thread it from the
-  // ActiveStreamTracker so the segment bitstream matches the master
-  // playlist's CODECS string. Heuristic inference (profile name +
-  // hwAccel) silently produced HEVC when the manifest claimed H.264
-  // (or vice-versa) on cache misses — MSE then rejected the segments.
-  // Fail fast so the player retries after the next playback-info call
-  // repopulates the variant tracker.
+  // LiveSession the request resolves to, so the segment bitstream
+  // matches the master playlist's CODECS string. Heuristic inference
+  // (profile name + hwAccel) silently produced HEVC when the manifest
+  // claimed H.264 (or vice-versa) on cache misses — MSE then rejected
+  // the segments. HLS routes 410-gate stale sids upstream via
+  // assertFreshSession; reaching this throw means a non-HLS caller
+  // bypassed playback-info entirely.
   if (!videoVariant) {
     throw new Error(
-      `buildFfmpegArgs: missing videoVariant for profile "${profile.name}" — caller must pass it from ActiveStreamTracker`,
+      `buildFfmpegArgs: missing videoVariant for profile "${profile.name}" — caller must thread it from the LiveSession`,
     );
   }
   const variant: CodecVariant = videoVariant;

--- a/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
@@ -215,6 +215,17 @@ public class NativePlayerPlugin extends Plugin {
         mainHandler.post(() -> {
             if (player != null) player.release();
 
+            // SubtitleView holds whatever cues the previous player last emitted —
+            // ExoPlayer.release() doesn't drop them, and a fresh load (especially
+            // the silent session-expired recovery, which keeps the same view
+            // and just swaps the source URL) starts with text rendering
+            // disabled by default. The stale cue then sits on screen until the
+            // user manually seeks (which already clears it below) — clear here
+            // too so a load looks identical from the user's perspective.
+            if (subtitleView != null) {
+                subtitleView.setCues(java.util.Collections.emptyList());
+            }
+
             // HTTP data source with auth headers
             Map<String, String> headerMap = new HashMap<>();
             if (headers != null) {

--- a/client/src/app/core/services/playback-engine/native-engine.ts
+++ b/client/src/app/core/services/playback-engine/native-engine.ts
@@ -45,6 +45,15 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
    *  the position-advance fallback below would otherwise fire on every
    *  later timeUpdate). Reset on each load(). */
   private firstFrameEmitted = false;
+
+  /** One-shot guard for the optimistic-recovery branch in the
+   *  `nativePlayerError` bridge. ExoPlayer / AVPlayer can't tell us the
+   *  HTTP status that triggered the error, so the first error during
+   *  stable playback is routed to `sessionExpired` (which makes the
+   *  player call /playback-info + reload). If a second error follows
+   *  before the next load() clears the flag, fall through to a real
+   *  fatal `error` so the UI isn't stuck retrying a broken stream. */
+  private recoveryAttempted = false;
   /** Last `timeUpdate.position` seen, used to detect that playback is
    *  actually advancing (Android's onRenderedFirstFrame is unreliable on
    *  some devices: it fires late or never on transcode → ABR switches,
@@ -97,6 +106,7 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
     headers?: Record<string, string>,
   ): Promise<void> {
     this.firstFrameEmitted = false;
+    this.recoveryAttempted = false;
     this.lastTimeUpdatePos = -1;
     const subtitles = this._preloadedSubtitles.length > 0
       ? this._preloadedSubtitles
@@ -106,6 +116,15 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
     // Apply subtitle style settings
     if (this._subtitleStyle) {
       await NativePlayer.setSubtitleStyle(this._subtitleStyle);
+    }
+
+    // Restore the previously-active subtitle selection. ExoPlayer disables
+    // text tracks by default on every new MediaItem, so a silent reload
+    // (session-expired recovery, cast handoff) would otherwise drop the
+    // user's pick and leave the SubtitleView blank. The plugin's
+    // pendingSubtitleTrackId queues this until onTracksChanged fires.
+    if (this._activeTrackId) {
+      NativePlayer.selectSubtitleTrack({ id: this._activeTrackId }).catch(() => {});
     }
   }
 
@@ -249,8 +268,8 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
 
   selectTextTrack(track: any): void {
     const id = typeof track === 'string' ? track : null;
+    this._activeTrackId = id;
     if (this._isIos) {
-      this._activeTrackId = id;
       this._subtitleVisible = !!id;
       this.updateSubtitleOverlay();
     } else {
@@ -266,6 +285,7 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
         this.updateSubtitleOverlay();
       }
     } else if (!visible) {
+      this._activeTrackId = null;
       NativePlayer.selectSubtitleTrack({ id: null });
     }
   }
@@ -342,6 +362,17 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
 
     bind('nativePlayerError', (e: Event) => {
       const d = (e as CustomEvent).detail;
+      // ExoPlayer / AVPlayer hide the HTTP status of the failing
+      // segment fetch — we can't tell a 410 (session expired) from a
+      // 5xx (ffmpeg crash). Heuristic: if a frame has played and we
+      // haven't tried recovery yet, treat the first error as a
+      // possible session-expired and let the player attempt a single
+      // /playback-info + reload before surfacing a fatal error.
+      if (this.firstFrameEmitted && !this.recoveryAttempted) {
+        this.recoveryAttempted = true;
+        this.emit('sessionExpired', undefined);
+        return;
+      }
       this._state = 'error';
       this.emit('error', d);
     });

--- a/client/src/app/core/services/playback-engine/playback-engine.ts
+++ b/client/src/app/core/services/playback-engine/playback-engine.ts
@@ -51,6 +51,17 @@ export type EngineEventMap = {
    *  Distinct from `stateChanged: 'playing'` which fires on play() (the
    *  user-facing first frame is what matters for the loading veil). */
   firstFrame: void;
+  /** Backend returned 410 Gone with `code: 'session_expired'` on a
+   *  segment / playlist request — the LiveSession registered at
+   *  /playback-info is gone (typical after a backend restart or a
+   *  long-idle GC). The player should mint a fresh sid via a new
+   *  /playback-info call and reload the engine. Shaka detects this via
+   *  a NetworkingEngine response filter; native players (AVPlay / iOS /
+   *  Android) can't read the response body so they translate any
+   *  segment-level HTTP error during stable playback into this event
+   *  and the player tries one cheap recovery before surfacing a fatal
+   *  error to the UI. */
+  sessionExpired: void;
 };
 
 export type EngineEvent = keyof EngineEventMap;

--- a/client/src/app/core/services/playback-engine/shaka-engine.ts
+++ b/client/src/app/core/services/playback-engine/shaka-engine.ts
@@ -28,6 +28,13 @@ export class ShakaEngine extends AbstractPlaybackEngine implements PlaybackEngin
    *  once per session, gated on requestVideoFrameCallback. */
   private firstFrameEmitted = false;
 
+  /** Set briefly after the 410 response filter has emitted
+   *  `sessionExpired`. Shaka also surfaces the thrown filter error
+   *  through its `error` event — we suppress the bridged `error`
+   *  emission for one tick so the UI doesn't flash a fatal-error overlay
+   *  on top of the in-flight recovery. */
+  private sessionExpiredInFlight = false;
+
   // ─── Lifecycle ──────────────────────────────────────────────────────
 
   async init(container: HTMLElement): Promise<void> {
@@ -68,8 +75,59 @@ export class ShakaEngine extends AbstractPlaybackEngine implements PlaybackEngin
       },
     } as any);
 
+    this.installSessionExpiredFilter();
     this.bridgeVideoEvents();
     this.bridgeShakaEvents();
+  }
+
+  /**
+   * NetworkingEngine response filter that turns the backend's 410
+   * "session_expired" body into a synchronous `sessionExpired` engine
+   * event. Without it Shaka would retry the segment per its
+   * `streaming.retryParameters` schedule (~5 attempts, exponential
+   * backoff → ~2 min before the heartbeat-driven recovery #302 kicks
+   * in). Reacting on the very first 410 collapses that window down to
+   * the time it takes to call /playback-info + reload (~1 s).
+   *
+   * Throwing a 1001 BAD_HTTP_STATUS error from the filter aborts
+   * Shaka's retry loop and surfaces as a regular `error` event, so the
+   * engine never silently swallows the failure if no listener consumes
+   * the `sessionExpired` signal.
+   */
+  private installSessionExpiredFilter(): void {
+    if (!this.player) return;
+    const ne = this.player.getNetworkingEngine?.();
+    if (!ne) return;
+    ne.registerResponseFilter((type, response: any) => {
+      if (response?.status !== 410) return;
+      const RequestType = shaka.net.NetworkingEngine.RequestType;
+      // SEGMENT covers init + media segments (the basic enum doesn't
+      // split them — that's only on AdvancedRequestType).
+      if (type !== RequestType.SEGMENT && type !== RequestType.MANIFEST) {
+        return;
+      }
+      let body: { code?: string } | null = null;
+      try {
+        const decoder = new TextDecoder('utf-8');
+        body = JSON.parse(decoder.decode(response.data));
+      } catch { /* malformed body — fall through and trust the status */ }
+      if (body?.code && body.code !== 'session_expired') return;
+      this.sessionExpiredInFlight = true;
+      // Window covers Shaka's own retry burst (the filter throws on
+      // every retried 410); cleared after a tick so a later, unrelated
+      // error from the bridge isn't accidentally suppressed.
+      setTimeout(() => { this.sessionExpiredInFlight = false; }, 2000);
+      this.emit('sessionExpired', undefined as any);
+      throw new shaka.util.Error(
+        shaka.util.Error.Severity.CRITICAL,
+        shaka.util.Error.Category.NETWORK,
+        shaka.util.Error.Code.BAD_HTTP_STATUS,
+        response.uri,
+        410,
+        response.data,
+        type,
+      );
+    });
   }
 
   async destroy(): Promise<void> {
@@ -102,6 +160,7 @@ export class ShakaEngine extends AbstractPlaybackEngine implements PlaybackEngin
   async load(url: string, startTime?: number, mimeType?: string, _headers?: Record<string, string>): Promise<void> {
     if (!this.player) throw new Error('ShakaEngine not initialised');
     this.firstFrameEmitted = false;
+    this.sessionExpiredInFlight = false;
     await this.player.load(url, startTime, mimeType);
   }
 
@@ -375,6 +434,12 @@ export class ShakaEngine extends AbstractPlaybackEngine implements PlaybackEngin
     // Shaka error events (separate from HTMLVideoElement errors)
     this.addShakaListener('error', (e: any) => {
       const detail = e.detail;
+      if (this.sessionExpiredInFlight) {
+        // 410 recovery is taking over — swallow the fatal-error event
+        // so the UI doesn't render the error overlay before the engine
+        // reloads with a fresh sid.
+        return;
+      }
       console.error('[Shaka] Player error:', detail?.code, detail?.category, detail?.message, detail?.data);
       this.emit('error', {
         code: detail?.code ?? 0,

--- a/client/src/app/core/services/playback-engine/tizen-engine.ts
+++ b/client/src/app/core/services/playback-engine/tizen-engine.ts
@@ -91,6 +91,15 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
   private _seekInFlight = false;
   private _pendingSeek: number | null = null;
 
+  /** One-shot guard for the optimistic-recovery branch in
+   *  {@link handleError}. AVPlay can't surface HTTP status, so the
+   *  first network-shaped error during stable playback is treated as a
+   *  possible session-expired event and emits `sessionExpired` instead
+   *  of a fatal `error`. Subsequent errors fall through normally. Reset
+   *  on every {@link load} so a fresh playback starts with a fresh
+   *  budget. */
+  private recoveryAttempted = false;
+
   /** DOM-rendered subtitle overlay shared with the webOS engine. AVPlay's
    *  `setExternalSubtitlePath` only accepts local file paths, not HTTPS,
    *  so we parse VTT ourselves and paint cues into a positioned div. */
@@ -150,6 +159,7 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
   ): Promise<void> {
     this._lastLoadedUrl = url;
     this.firstFrameEmitted = false;
+    this.recoveryAttempted = false;
     this._currentTime = 0;
     this._duration = 0;
 
@@ -287,6 +297,24 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
     if (this._seekInFlight) return;
     const msg = String(err);
     if (msg.includes('SEEK_FAILED')) return;
+
+    // AVPlay swallows the HTTP status of the failed segment fetch — we
+    // can't tell a 410 (session expired) from a 500 (ffmpeg crash) from
+    // here. Heuristic: if playback was healthy (firstFrame fired, no
+    // pending seek) and the connection errored mid-stream, optimistically
+    // ask the player for one cheap recovery attempt before surfacing the
+    // fatal error. If recovery succeeds the engine reloads transparently;
+    // if it fails the next error after `recoveryAttempted` falls through
+    // to the regular error path.
+    if (
+      this.firstFrameEmitted &&
+      !this.recoveryAttempted &&
+      /CONNECTION|HTTP|NETWORK|PLAYER_ERROR_INVALID_URI/i.test(msg)
+    ) {
+      this.recoveryAttempted = true;
+      this.emit('sessionExpired', undefined);
+      return;
+    }
     this.emit('error', { code: -1, message: msg });
     this.emit('stateChanged', { state: 'error' });
   }

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1175,6 +1175,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     engine.on('firstFrame', () => {
       this.state.videoStarted.set(true);
     });
+    this.wireSessionExpiredRecovery(engine);
     // Volume sync for template
     video.addEventListener('volumechange', () => {
       this.state.volume.set(video.muted ? 0 : video.volume);
@@ -1239,6 +1240,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     engine.on('firstFrame', () => {
       this.state.videoStarted.set(true);
     });
+    this.wireSessionExpiredRecovery(engine);
 
     // Tizen audio-tracks listener is deliberately NOT wired. With MPEG-TS
     // HLS the variant has a single muxed audio, so AVPlay's
@@ -1274,6 +1276,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     engine.on('firstFrame', () => {
       this.state.videoStarted.set(true);
     });
+    this.wireSessionExpiredRecovery(engine);
 
     // Listen for audio tracks from native engine.
     // ExoPlayer may emit this multiple times (e.g. rendition switch) —
@@ -1842,6 +1845,19 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
    * surface `sessionLost: true` in the interval.
    */
   private recoveringFromLostSession = false;
+
+  /**
+   * Hook into the engine's `sessionExpired` event so a backend 410 on
+   * a segment / playlist request triggers recovery on the very next
+   * tick instead of waiting for the 10 s heartbeat. Idempotent across
+   * engines (Shaka / Tizen AVPlay / Capacitor native) — they all share
+   * the same event contract on the PlaybackEngine interface.
+   */
+  private wireSessionExpiredRecovery(engine: PlaybackEngine): void {
+    engine.on('sessionExpired', () => {
+      void this.recoverFromLostSession();
+    });
+  }
 
   /**
    * The carried `sid` is no longer known to the backend (restart or


### PR DESCRIPTION
## Summary

Backend hot-reload (or a long-idle GC) wipes the `LiveSessionRegistry`. The player keeps requesting HLS segments with the stale sid, today's deep `buildFfmpegArgs: missing videoVariant` error surfaces as a 5xx, Shaka retries through its full backoff schedule (~2 min), and only then does the heartbeat-based recovery (#302) mint a fresh sid.

This branch makes the boundary explicit and collapses the recovery window to one segment.

### Backend
- New `SessionExpiredException` → HTTP 410 Gone, stable body `{ code: 'session_expired', sid, message }`.
- New `StreamingController.assertFreshSession(req)` gates every HLS route (master / quality playlist / segment / audio playlist / audio segment). When the URL carries a `?sid=` the registry no longer knows, the request is refused with the typed body before any transcode setup runs.
- Legacy callers without `?sid=` still fall through to the userId-based `findCurrent` lookup downstream.

### Frontend — cross-engine `sessionExpired` event
- New `sessionExpired` engine event on `PlaybackEngine`. `wireSessionExpiredRecovery` is called from each engine factory (Shaka / Native / Tizen) and routes to the existing `recoverFromLostSession`.
- **Shaka** (web / desktop browsers): `NetworkingEngine` response filter parses the 410 body, emits `sessionExpired`, throws `BAD_HTTP_STATUS` to kill Shaka's retry burst, and a 2 s `sessionExpiredInFlight` window suppresses the bridged `error` event so the UI doesn't flash a fatal overlay during the reload.
- **NativeEngine** (iOS AVPlayer / Android ExoPlayer via Capacitor): can't read HTTP status — heuristic. First `nativePlayerError` after `firstFrame` routes to `sessionExpired` once (gated by `recoveryAttempted`, reset on every load). Repeat errors fall through to fatal.
- **TizenEngine** (AVPlay): same heuristic, scoped to error messages matching `/CONNECTION|HTTP|NETWORK|PLAYER_ERROR_INVALID_URI/`.
- **webOS**: engine doesn't exist yet (V2 per the TV-platforms plan). The event contract is engine-agnostic — a future webOS wrapper just emits `sessionExpired` from its error handler and the recovery flow picks it up.
- **Chromecast**: out of scope. The receiver owns its own session lifecycle and `recoverFromLostSession` already skips while casting.

### Android subtitle freeze
Found while testing the recovery path on Android:
- Java: `SubtitleView.setCues(emptyList())` at the start of `load()`. `ExoPlayer.release()` doesn't drop the last cues — they stayed pinned on screen until the user seeked (which already had this cleanup).
- TS: `_activeTrackId` is now captured on both iOS and Android branches of `selectTextTrack` / `setTextVisibility` (was iOS-only). After `NativePlayer.load()` resolves, the engine re-issues `selectSubtitleTrack({ id: _activeTrackId })`; the plugin's existing `pendingSubtitleTrackId` queues it until `onTracksChanged` fires. Without it, the new ExoPlayer instance disabled text tracks by default and the user's selection silently dropped.

Refs: #301

## Test plan
- [ ] Backend tests: `npx jest --testPathPatterns=session-expired` (3 specs pass).
- [ ] Manual: start a Shaka playback, `docker compose restart backend` while watching → recovery in ~one segment, no error overlay.
- [ ] Manual: same scenario on Android Capacitor app → subtitles disappear briefly then resume at the new playhead with the previous track active.
- [ ] Manual: same on Tizen TV (AVPlay) → recovery on first network error.
- [ ] Confirm cast playback unaffected (sender skips recovery).