### PR TITLE
fix(system-streams): target commands via LiveSession id

### DIFF
--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -619,21 +619,71 @@ export class SystemController {
     return streams;
   }
 
-  @Delete('streams/:sessionId')
-  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
-  killStream(@Param('sessionId') sessionId: string) {
+  /**
+   * Resolve a dashboard `sessionId` to the (user, mediaFile) pair the
+   * command targets. The dashboard hands us three flavours of id:
+   *   - `dp-<userId>-<mediaFileId>` — legacy direct-play tracker entry.
+   *   - A `LiveSession.sessionId` UUID — the canonical id since #300.
+   *   - A `TranscodeSession.id` hash — left in for completeness; the
+   *     dashboard hasn't emitted these in a while but a stale client
+   *     tab could still send one.
+   * Returns null when none of the three lookups produces a (user, file)
+   * pair the command can act on.
+   */
+  private resolveStreamCommandTarget(sessionId: string): {
+    userId: number;
+    mediaFileId: number;
+    killTranscodeId: string | null;
+    isDirectPlay: boolean;
+  } | null {
     if (sessionId.startsWith('dp-')) {
-      // Direct play session — can't really kill it, just untrack
       const parts = sessionId.replace('dp-', '').split('-');
       const userId = parseInt(parts[0], 10);
       const mediaFileId = parseInt(parts[1], 10);
-      if (userId && mediaFileId) {
-        this.activeStreamTracker.unregister(userId, mediaFileId);
-      }
-    } else {
-      // Transcode session — kill by session map key directly
-      this.transcodingService.killSessionById(sessionId);
+      if (!userId || !mediaFileId) return null;
+      return { userId, mediaFileId, killTranscodeId: null, isDirectPlay: true };
     }
+    const live = this.liveSessions.get(sessionId);
+    if (live && live.userId != null) {
+      const transcode = live.profileHash
+        ? this.transcodingService.getExistingSession(
+            live.mediaFileId,
+            live.userId,
+            live.profileHash,
+          )
+        : null;
+      return {
+        userId: live.userId,
+        mediaFileId: live.mediaFileId,
+        killTranscodeId: transcode?.id ?? null,
+        isDirectPlay: live.kind === 'directplay',
+      };
+    }
+    const transcode = this.transcodingService
+      .getActiveSessions()
+      .find((s) => s.id === sessionId);
+    if (transcode && transcode.userId != null) {
+      return {
+        userId: transcode.userId,
+        mediaFileId: transcode.mediaFileId,
+        killTranscodeId: transcode.id,
+        isDirectPlay: false,
+      };
+    }
+    return null;
+  }
+
+  @Delete('streams/:sessionId')
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
+  killStream(@Param('sessionId') sessionId: string) {
+    const target = this.resolveStreamCommandTarget(sessionId);
+    if (!target) return { ok: true }; // already gone
+    if (target.isDirectPlay) {
+      this.activeStreamTracker.unregister(target.userId, target.mediaFileId);
+    } else if (target.killTranscodeId) {
+      this.transcodingService.killSessionById(target.killTranscodeId);
+    }
+    this.liveSessions.stop(sessionId);
     return { ok: true };
   }
 
@@ -643,44 +693,26 @@ export class SystemController {
     @Param('sessionId') sessionId: string,
     @Body() body: { action: 'pause' | 'play' | 'stop' | 'message'; message?: string },
   ) {
-    // Parse userId and mediaFileId from sessionId
-    let userId = 0;
-    let mediaFileId = 0;
-
-    if (sessionId.startsWith('dp-')) {
-      const parts = sessionId.replace('dp-', '').split('-');
-      userId = parseInt(parts[0], 10);
-      mediaFileId = parseInt(parts[1], 10);
-    } else {
-      // Transcode session — look up from active sessions
-      const session = this.transcodingService
-        .getActiveSessions()
-        .find((s) => s.id === sessionId);
-      if (session) {
-        userId = session.userId ?? 0;
-        mediaFileId = session.mediaFileId;
-      }
-    }
-
-    if (!userId || !mediaFileId) {
+    const target = this.resolveStreamCommandTarget(sessionId);
+    if (!target) {
       throw new BadRequestException('Session not found');
     }
 
-    this.eventsService.emitToUser(userId, {
+    this.eventsService.emitToUser(target.userId, {
       type: 'player.command',
-      mediaFileId,
-      userId,
+      mediaFileId: target.mediaFileId,
+      userId: target.userId,
       action: body.action,
       message: body.message,
     });
 
-    // If stop, also kill the transcode session
     if (body.action === 'stop') {
-      if (sessionId.startsWith('dp-')) {
-        this.activeStreamTracker.unregister(userId, mediaFileId);
-      } else {
-        this.transcodingService.killSessionById(sessionId);
+      if (target.isDirectPlay) {
+        this.activeStreamTracker.unregister(target.userId, target.mediaFileId);
+      } else if (target.killTranscodeId) {
+        this.transcodingService.killSessionById(target.killTranscodeId);
       }
+      this.liveSessions.stop(sessionId);
     }
 
     return { ok: true };

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -893,7 +893,6 @@
     "stream_message_placeholder": "Votre message…",
     "stream_message_send": "Envoyer",
     "stream_message_sent": "Message envoyé",
-    "stream_message_failed": "Échec de l'envoi du message",
     "streams_empty": "Aucune activité vidéo en cours",
     "streams_label_stream": "Flux",
     "streams_label_video": "Vidéo",

--- a/client/src/app/features/system/streams/streams.ts
+++ b/client/src/app/features/system/streams/streams.ts
@@ -92,7 +92,8 @@ export class SystemStreamsComponent implements OnInit, OnDestroy {
       this.toast.success(this.translate.instant('system.stream_message_sent'));
       this.closeMessage();
     } catch {
-      this.toast.error(this.translate.instant('system.stream_message_failed'));
+      // Failure toast is owned by the global error interceptor — surfacing
+      // a generic "send failed" here on top would just stack two toasts.
     } finally {
       this.messageBusy.set(false);
     }


### PR DESCRIPTION
## Summary

Clicking **Pause / Stop / Message** on the admin streams dashboard surfaced two toasts — a backend `Session not found` 400 from the global interceptor, and a local "Échec de l'envoi du message" stacked on top.

One root cause behind both:

The dashboard has emitted `LiveSession.sessionId` (UUID) as the row id since #300, but `system.controller.ts` still resolved commands by looking the id up in `transcodingService.getActiveSessions()` — whose ids are `mediaFileId-userId-profileHash` hashes, never a UUID. Every command for a LiveSession-backed stream therefore fell into the `!userId || !mediaFileId` branch and threw `Session not found`. Stop calls silently no-op'd because the resolver landed nowhere.

## Changes

- Extract `resolveStreamCommandTarget(sessionId)` on `SystemController`. It now accepts:
  - `dp-<userId>-<mediaFileId>` — legacy direct-play tracker entry (preserved for the eventual #301 cleanup).
  - `LiveSession.sessionId` UUID — canonical since #300; user and media file come straight off the registry, the backing transcode session is looked up via `(mediaFileId, userId, profileHash)` for the kill step.
  - `TranscodeSession.id` hash — left in for older clients with a stale dashboard tab open.
- `killStream` and `sendPlayerCommand` consume the resolver, share the stop semantics (notify the player + kill the transcode + drop the LiveSession), and return 400 only when none of the three lookups matches.
- Drop the local error toast in `sendMessage` and the `stream_message_failed` translation key. The global error interceptor already toasts client errors with the backend message; stacking a generic French string on top was both noisy and erased the real reason.

## Test plan
- [ ] Start a transcode session.
- [ ] Open the admin streams panel. Click Pause / Play / Stop / Message on the row.
- [ ] Confirm: command lands, single toast on success, single toast (with backend message) on failure.
- [ ] Stop button now actually kills the transcode session and the LiveSession (verify on the dashboard refresh tick).
- [ ] `npx jest --testPathPatterns="streaming|session-expired"` — 58 specs green.