### PR TITLE
fix(webos-player): emit sessionExpired for 410 recovery

### DIFF
--- a/client/src/app/core/services/playback-engine/webos-engine.ts
+++ b/client/src/app/core/services/playback-engine/webos-engine.ts
@@ -59,6 +59,15 @@ export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngin
    *  a mediaOption rejection is recovered via the fallback, not surfaced. */
   private loadingPhase = false;
 
+  /** One-shot guard for the optimistic-recovery branch in the `error`
+   *  bridge. webOS's native HLS pipeline hides the HTTP status of the
+   *  failing segment fetch — we can't tell a backend 410 from a real
+   *  decode failure. First network-shaped MediaError after a frame has
+   *  played is routed to `sessionExpired`; the player tries one cheap
+   *  /playback-info reload before surfacing a fatal error. Reset on
+   *  every {@link load} so a fresh playback starts with a fresh budget. */
+  private recoveryAttempted = false;
+
   /** Optimistic position reported while a seek settles, so the seekbar stays
    *  pinned and relative (±10s) steps accumulate even though the real clock
    *  hasn't moved yet (reload-based seeks take a few seconds). */
@@ -147,6 +156,19 @@ export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngin
     add('error', () => {
       if (this.loadingPhase) return; // recovered via the load() fallback
       const err = v.error;
+      // Network / unsupported-source errors mid-playback are the signature
+      // of a backend 410 on a segment (LiveSession gone) or any other
+      // transient stream loss the recovery flow handles. Optimistically
+      // route the first one to `sessionExpired`; the player swaps to a
+      // fresh sid via /playback-info. Repeat errors fall through to fatal.
+      const networkShaped =
+        err?.code === MediaError.MEDIA_ERR_NETWORK ||
+        err?.code === MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED;
+      if (this.firstFrameEmitted && !this.recoveryAttempted && networkShaped) {
+        this.recoveryAttempted = true;
+        this.emit('sessionExpired', undefined);
+        return;
+      }
       this.emit('error', { code: err?.code ?? -1, message: mediaErrorMessage(err) });
       this.emit('stateChanged', { state: 'error' });
     });
@@ -173,6 +195,7 @@ export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngin
     if (!this.video) throw new Error('WebOsEngine not initialised');
     this.loadedUrl = url;
     this.firstFrameEmitted = false;
+    this.recoveryAttempted = false;
     this.clearSeekDebounce();
     this.pendingReloadTarget = null;
     const start = startTime && startTime > 0 ? startTime : 0;

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1203,6 +1203,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     engine.on('firstFrame', () => {
       this.state.videoStarted.set(true);
     });
+    this.wireSessionExpiredRecovery(engine);
     video.addEventListener('volumechange', () => {
       this.state.volume.set(video.muted ? 0 : video.volume);
     });


### PR DESCRIPTION
## Summary

#306 wired the cross-engine recovery flow (`sessionExpired` event → `recoverFromLostSession`) for Shaka, Tizen AVPlay and the Capacitor NativeEngine. The webOS native-HLS engine added in #280 still emitted a fatal `error` on every mid-stream MediaError, so a backend hot-reload or long-idle GC stalled the LG player until the 10 s heartbeat-driven fallback eventually kicked in.

Apply the same opportunistic-recovery heuristic used for Tizen / Capacitor: the first `MEDIA_ERR_NETWORK` / `MEDIA_ERR_SRC_NOT_SUPPORTED` after `firstFrame` routes to `sessionExpired` once (gated by `recoveryAttempted`, reset on every `load`). Repeat errors fall through to fatal, so a genuinely broken stream still surfaces an error UI.

Subtitle overlay needs no extra work — webOS uses the shared `SubtitleOverlay` (DOM-based, time-driven via `timeupdate`). Cues are kept in memory and rendered against the video element's `currentTime` on every tick, so the silent reload at the same playhead naturally replays the right cue. (Contrast with Android in #306 follow-up, where `SubtitleView.setCues` was sticky across `ExoPlayer.release` and needed an explicit clear.)

## Test plan
- [ ] Start a webOS LG TV session.
- [ ] `docker compose restart backend` while watching.
- [ ] Player recovers within one segment (~3 s) instead of stalling for ~10 s waiting on the heartbeat.
- [ ] Subtitles, if active, keep rendering at the right timestamp through the reload.
- [ ] A real network outage (DNS unplug) still surfaces a fatal error after the first recovery attempt fails.

Refs: #306, #280