### PR TITLE
feat(home): personalizable zones + per-library recently added

### DIFF
--- a/backend/src/modules/media/dto/recently-added.dto.ts
+++ b/backend/src/modules/media/dto/recently-added.dto.ts
@@ -1,0 +1,40 @@
+import { IsIn, IsBoolean, IsNumber, IsOptional } from 'class-validator';
+import { Type, Transform } from 'class-transformer';
+
+/**
+ * Ranking basis for "recently added": by the media's own add time, by the
+ * newest imported file, or by whichever of the two is more recent.
+ */
+export type RecentlyAddedMode = 'media' | 'file' | 'both';
+
+export const RECENTLY_ADDED_MODES: RecentlyAddedMode[] = [
+  'media',
+  'file',
+  'both',
+];
+
+export class RecentlyAddedDto {
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  libraryId?: number;
+
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  limit?: number;
+
+  @IsIn(RECENTLY_ADDED_MODES)
+  @IsOptional()
+  mode?: RecentlyAddedMode;
+
+  @IsBoolean()
+  @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
+  excludeWatched?: boolean;
+
+  @IsBoolean()
+  @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
+  requestedByMe?: boolean;
+}

--- a/backend/src/modules/media/media-service/media-query.service.ts
+++ b/backend/src/modules/media/media-service/media-query.service.ts
@@ -431,7 +431,7 @@ export class MediaQueryService {
     const {
       libraryId,
       limit = 20,
-      mode = 'media',
+      mode = 'file',
       excludeWatched,
       requestedByMe,
       userId,

--- a/backend/src/modules/media/media-service/media-query.service.ts
+++ b/backend/src/modules/media/media-service/media-query.service.ts
@@ -8,6 +8,7 @@ import { MediaCast } from '../entities/media-cast.entity';
 import { MediaCrew } from '../entities/media-crew.entity';
 import { SearchMediaDto } from '../dto/search-media.dto';
 import { CalendarQueryDto } from '../dto/calendar-query.dto';
+import { RecentlyAddedMode } from '../dto/recently-added.dto';
 import { MediaType } from '../../../common/enums';
 import {
   getAppQualityById,
@@ -257,47 +258,7 @@ export class MediaQueryService {
 
     const [data, total] = await qb.getManyAndCount();
 
-    // For series: attach episode stats
-    const seriesIds = data
-      .filter((m) => m.type === MediaType.SERIES)
-      .map((m) => m.id);
-    let episodeStatsMap = new Map<
-      number,
-      { totalEpisodes: number; downloadedEpisodes: number }
-    >();
-    if (seriesIds.length) {
-      const stats: { mediaId: number; total: string; downloaded: string }[] =
-        await this.dataSource.query(
-          // "downloaded" = episodes whose content is on disk (coverage),
-          // including the shadowed episodes of a multi-episode file. Counting
-          // MediaFile rows or hasFile alone would undercount those.
-          `SELECT s."mediaId",
-                  COUNT(e.id) AS total,
-                  COUNT(e.id) FILTER (WHERE ${onDiskSql('e')}) AS downloaded
-           FROM seasons s
-           JOIN episodes e ON e."seasonId" = s.id
-           WHERE s."mediaId" = ANY($1) AND s."seasonNumber" > 0
-           GROUP BY s."mediaId"`,
-          [seriesIds],
-        );
-      episodeStatsMap = new Map(
-        stats.map((s) => [
-          s.mediaId,
-          {
-            totalEpisodes: parseInt(s.total, 10),
-            downloadedEpisodes: parseInt(s.downloaded, 10),
-          },
-        ]),
-      );
-    }
-
-    let enriched = data.map((m) => {
-      const stats = episodeStatsMap.get(m.id);
-      return Object.assign(m, {
-        sizeOnDisk: (m.files ?? []).reduce((sum, f) => sum + Number(f.size), 0),
-        episodeStats: stats ?? undefined,
-      });
-    });
+    let enriched = await this.attachEpisodeStats(data);
 
     if (query.cutoffUnmet === true) {
       // Cutoff comparison must reach below the cutoff *on the unit that gets
@@ -396,6 +357,146 @@ export class MediaQueryService {
     }
 
     return { data: enriched, total };
+  }
+
+  /**
+   * Attach the per-media derived fields media cards rely on: `sizeOnDisk`
+   * (sum of file sizes) and, for series, `episodeStats` (total +
+   * downloaded episode coverage). Mutates and returns the same rows.
+   */
+  private async attachEpisodeStats(data: Media[]): Promise<Media[]> {
+    const seriesIds = data
+      .filter((m) => m.type === MediaType.SERIES)
+      .map((m) => m.id);
+    let episodeStatsMap = new Map<
+      number,
+      { totalEpisodes: number; downloadedEpisodes: number }
+    >();
+    if (seriesIds.length) {
+      const stats: { mediaId: number; total: string; downloaded: string }[] =
+        await this.dataSource.query(
+          // "downloaded" = episodes whose content is on disk (coverage),
+          // including the shadowed episodes of a multi-episode file. Counting
+          // MediaFile rows or hasFile alone would undercount those.
+          `SELECT s."mediaId",
+                  COUNT(e.id) AS total,
+                  COUNT(e.id) FILTER (WHERE ${onDiskSql('e')}) AS downloaded
+           FROM seasons s
+           JOIN episodes e ON e."seasonId" = s.id
+           WHERE s."mediaId" = ANY($1) AND s."seasonNumber" > 0
+           GROUP BY s."mediaId"`,
+          [seriesIds],
+        );
+      episodeStatsMap = new Map(
+        stats.map((s) => [
+          s.mediaId,
+          {
+            totalEpisodes: parseInt(s.total, 10),
+            downloadedEpisodes: parseInt(s.downloaded, 10),
+          },
+        ]),
+      );
+    }
+
+    return data.map((m) => {
+      const stats = episodeStatsMap.get(m.id);
+      return Object.assign(m, {
+        sizeOnDisk: (m.files ?? []).reduce((sum, f) => sum + Number(f.size), 0),
+        episodeStats: stats ?? undefined,
+      });
+    });
+  }
+
+  /**
+   * "Recently added" feed for the home page, optionally scoped to one
+   * library. The ranking basis is the caller-supplied {@link RecentlyAddedMode}:
+   *   • `media` — `Media.createdAt` (when the title entered the library)
+   *   • `file`  — newest `MediaFile.createdAt` (only titles that have a file);
+   *     surfaces a series again when a fresh episode file lands
+   *   • `both`  — the more recent of the two
+   *
+   * Two passes keep the ranking exact: pass 1 ranks + limits media ids in a
+   * flat query (no collection join to skew the limit or the order
+   * expression), pass 2 hydrates the full entities and restores the order.
+   */
+  async findRecentlyAdded(opts: {
+    libraryId?: number;
+    limit?: number;
+    mode?: RecentlyAddedMode;
+    excludeWatched?: boolean;
+    requestedByMe?: boolean;
+    userId?: number;
+    accessibleLibraryIds?: number[];
+  }): Promise<Media[]> {
+    const {
+      libraryId,
+      limit = 20,
+      mode = 'media',
+      excludeWatched,
+      requestedByMe,
+      userId,
+      accessibleLibraryIds = [],
+    } = opts;
+
+    const idQb = this.mediaRepo
+      .createQueryBuilder('media')
+      .select('media.id', 'id');
+    this.applyLibraryAcl(idQb, accessibleLibraryIds);
+
+    if (libraryId) {
+      idQb.andWhere('media."libraryId" = :libraryId', { libraryId });
+    }
+    if (excludeWatched && userId) {
+      idQb.andWhere(`media.id NOT IN (${WATCHED_MEDIA_IDS_SUBQUERY})`, {
+        userId,
+      });
+    }
+    if (requestedByMe && userId) {
+      idQb.andWhere('media."addedById" = :reqUserId', { reqUserId: userId });
+    }
+
+    if (mode === 'media') {
+      idQb.orderBy('media."createdAt"', 'DESC');
+    } else {
+      // Newest imported file per media.
+      idQb.leftJoin(
+        (sub) =>
+          sub
+            .select('mf."mediaId"', 'mediaId')
+            .addSelect('MAX(mf."createdAt")', 'added')
+            .from('media_files', 'mf')
+            .groupBy('mf."mediaId"'),
+        'lf',
+        'lf."mediaId" = media.id',
+      );
+      if (mode === 'file') {
+        idQb.andWhere('lf.added IS NOT NULL').orderBy('lf.added', 'DESC');
+      } else {
+        idQb.orderBy(
+          'GREATEST(media."createdAt", COALESCE(lf.added, media."createdAt"))',
+          'DESC',
+        );
+      }
+    }
+
+    const idRows = await idQb.limit(limit).getRawMany<{ id: number }>();
+    const ids = idRows.map((r) => r.id);
+    if (ids.length === 0) return [];
+
+    const rows = await this.mediaRepo
+      .createQueryBuilder('media')
+      .leftJoinAndSelect('media.library', 'library')
+      .leftJoinAndSelect('media.qualityProfile', 'qualityProfile')
+      .leftJoinAndSelect('media.languageProfile', 'languageProfile')
+      .leftJoinAndSelect('media.files', 'files')
+      .where('media.id IN (:...ids)', { ids })
+      .getMany();
+    const byId = new Map(rows.map((m) => [m.id, m]));
+    const ordered = ids
+      .map((id) => byId.get(id))
+      .filter((m): m is Media => m != null);
+
+    return this.attachEpisodeStats(ordered);
   }
 
   /** When `accessibleLibraryIds` is omitted the lookup is unscoped — used

--- a/backend/src/modules/media/media.controller.ts
+++ b/backend/src/modules/media/media.controller.ts
@@ -27,6 +27,7 @@ import { GrabMovieDto } from './dto/grab-movie.dto';
 import { UpdateMediaProfilesDto } from './dto/update-media-profiles.dto';
 import { BulkUpdateMediaDto } from './dto/bulk-update-media.dto';
 import { CalendarQueryDto } from './dto/calendar-query.dto';
+import { RecentlyAddedDto } from './dto/recently-added.dto';
 import { PatchMonitoredDto } from './dto/patch-monitored.dto';
 import { PatchSeasonDto } from './dto/patch-season.dto';
 import { APP_QUALITIES } from '../../common/constants/app-qualities';
@@ -98,6 +99,26 @@ export class MediaController {
         : undefined,
       accessibleLibraryIds,
     );
+  }
+
+  @Get('recently-added')
+  @CheckPolicies((ability) => ability.can(Action.Read, Media))
+  async recentlyAdded(
+    @Query() query: RecentlyAddedDto,
+    @CurrentUser() user: User,
+  ) {
+    const accessibleLibraryIds =
+      await this.libraries.getAccessibleLibraryIds(user);
+    return this.mediaService.findRecentlyAdded({
+      libraryId: query.libraryId,
+      limit: query.limit ?? 20,
+      mode: query.mode ?? 'media',
+      excludeWatched: query.excludeWatched,
+      requestedByMe: query.requestedByMe,
+      userId:
+        query.excludeWatched || query.requestedByMe ? user?.id : undefined,
+      accessibleLibraryIds,
+    });
   }
 
   @Get('counts')

--- a/backend/src/modules/media/media.controller.ts
+++ b/backend/src/modules/media/media.controller.ts
@@ -112,7 +112,7 @@ export class MediaController {
     return this.mediaService.findRecentlyAdded({
       libraryId: query.libraryId,
       limit: query.limit ?? 20,
-      mode: query.mode ?? 'media',
+      mode: query.mode ?? 'file',
       excludeWatched: query.excludeWatched,
       requestedByMe: query.requestedByMe,
       userId:

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -80,6 +80,10 @@ export class MediaService {
     return this.query.findAll(query, userId, accessibleLibraryIds);
   }
 
+  findRecentlyAdded(opts: Parameters<MediaQueryService['findRecentlyAdded']>[0]) {
+    return this.query.findRecentlyAdded(opts);
+  }
+
   findByTmdbId(
     tmdbId: number,
     type: MediaType,

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -118,9 +118,7 @@
   "display_settings": {
     "title": "Affichage",
     "home_background": "Image de fond sur l'accueil",
-    "home_background_hint": "Affiche une affiche en plein écran derrière les sections de l'accueil.",
-    "only_my_requests": "Afficher uniquement les médias que j'ai demandé",
-    "only_my_requests_hint": "Filtre les sections « Récemment ajoutés » et « Bientôt disponible » de l'accueil pour ne garder que les médias que vous avez demandés."
+    "home_background_hint": "Affiche une affiche en plein écran derrière les sections de l'accueil."
   },
   "storage_settings": {
     "clear_cache": "Vider le cache",
@@ -1877,6 +1875,8 @@
     "recently_added_mode_hint": "Détermine ce qui alimente toutes les zones « Récemment ajouté » : les médias récemment ajoutés à la bibliothèque, ceux dont un fichier vient d'être ajouté, ou les deux.",
     "mode_media": "Médias récemment ajoutés",
     "mode_file": "Fichiers récemment ajoutés",
-    "mode_both": "Les deux"
+    "mode_both": "Les deux",
+    "only_my_requests": "Afficher uniquement les médias que j'ai demandé",
+    "only_my_requests_hint": "Filtre les sections « Récemment ajoutés » et « Bientôt disponible » de l'accueil pour ne garder que les médias que vous avez demandés."
   }
 }

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -111,7 +111,8 @@
       "subtitles": "Sous-titres",
       "cast": "Chromecast",
       "display": "Affichage",
-      "storage": "Stockage"
+      "storage": "Stockage",
+      "home": "Accueil"
     }
   },
   "display_settings": {
@@ -189,7 +190,8 @@
     "continue_watching": "Reprendre la lecture",
     "coming_soon": "Bientôt disponible",
     "recent_media": "Récemment ajoutés",
-    "recommendations": "Recommandations"
+    "recommendations": "Recommandations",
+    "recent_media_in": "Récemment ajouté – {{library}}"
   },
   "playback_settings": {
     "title": "Paramètres de lecture",
@@ -1854,5 +1856,27 @@
     "total": "Total :",
     "monitored": "Surveillés :",
     "unmonitored": "Non surveillés :"
+  },
+  "home_settings": {
+    "title": "Accueil",
+    "sections_title": "Zones de l'accueil",
+    "sections_hint": "Choisissez les zones à afficher et leur ordre. Glissez pour réordonner, ou utilisez les flèches.",
+    "section": {
+      "libraries": "Bibliothèques",
+      "continue_watching": "Reprendre la lecture",
+      "recommendations": "Recommandations",
+      "recently_added": "Récemment ajouté",
+      "coming_soon": "Bientôt disponible"
+    },
+    "section_library_recent": "Récemment ajouté – {{library}}",
+    "drag": "Déplacer",
+    "move_up": "Monter",
+    "move_down": "Descendre",
+    "toggle_visible": "Afficher la zone",
+    "recently_added_mode": "Contenu de « Récemment ajouté »",
+    "recently_added_mode_hint": "Détermine ce qui alimente toutes les zones « Récemment ajouté » : les médias récemment ajoutés à la bibliothèque, ceux dont un fichier vient d'être ajouté, ou les deux.",
+    "mode_media": "Médias récemment ajoutés",
+    "mode_file": "Fichiers récemment ajoutés",
+    "mode_both": "Les deux"
   }
 }

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -246,6 +246,13 @@ export const routes: Routes = [
     children: [
       { path: '', pathMatch: 'full', redirectTo: 'display' },
       {
+        path: 'home',
+        loadComponent: () =>
+          import('./features/app-settings/home-settings/home-settings').then(
+            (m) => m.HomeSettingsPageComponent,
+          ),
+      },
+      {
         path: 'player',
         loadComponent: () =>
           import('./features/playback-settings/player-settings/player-settings').then(

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -244,7 +244,7 @@ export const routes: Routes = [
       import('./features/app-settings/app-settings-shell').then((m) => m.AppSettingsShellComponent),
     canActivate: [serverConfigGuard, authGuard, passwordChangeGuard],
     children: [
-      { path: '', pathMatch: 'full', redirectTo: 'display' },
+      { path: '', pathMatch: 'full', redirectTo: 'home' },
       {
         path: 'home',
         loadComponent: () =>

--- a/client/src/app/core/services/api/media.service.ts
+++ b/client/src/app/core/services/api/media.service.ts
@@ -329,6 +329,33 @@ export class MediaService {
     );
   }
 
+  /** Home "Recently added" feed. `mode` picks the ranking basis (media
+   *  add time / newest file / both); `libraryId` scopes to one library. */
+  getRecentlyAdded(
+    params: {
+      libraryId?: number;
+      limit?: number;
+      mode?: 'media' | 'file' | 'both';
+      excludeWatched?: boolean;
+      requestedByMe?: boolean;
+    } = {},
+    opts: { force?: boolean } = {},
+  ) {
+    let httpParams = new HttpParams();
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== null) {
+        httpParams = httpParams.set(key, String(value));
+      }
+    }
+    const headers = opts.force ? { [CACHE_BYPASS_HEADER]: '1' } : undefined;
+    return firstValueFrom(
+      this.http.get<Media[]>(
+        '/api/media/recently-added',
+        headers ? { params: httpParams, headers } : { params: httpParams },
+      ),
+    );
+  }
+
   getTracking(id: number) {
     return firstValueFrom(
       this.http.get<TrackingStatus>(`/api/media/${id}/tracking`),

--- a/client/src/app/core/services/home-settings.service.ts
+++ b/client/src/app/core/services/home-settings.service.ts
@@ -53,7 +53,7 @@ const BUILTIN_ORDER: HomeSectionKey[] = [
 
 const DEFAULTS: HomeSettings = {
   order: BUILTIN_ORDER.map((key) => ({ key, visible: true })),
-  recentlyAddedMode: 'media',
+  recentlyAddedMode: 'file',
 };
 
 /**

--- a/client/src/app/core/services/home-settings.service.ts
+++ b/client/src/app/core/services/home-settings.service.ts
@@ -1,0 +1,161 @@
+import { Injectable, signal } from '@angular/core';
+
+/** Stable identity of a home zone. Built-ins are fixed; per-library
+ *  "recently added" zones are keyed by their library id. */
+export type HomeSectionKey =
+  | 'libraries'
+  | 'continue-watching'
+  | 'recommendations'
+  | 'recently-added'
+  | 'coming-soon'
+  | `library-recent:${number}`;
+
+export type HomeSectionType =
+  | 'libraries'
+  | 'continue-watching'
+  | 'recommendations'
+  | 'recently-added'
+  | 'coming-soon'
+  | 'library-recent';
+
+/** What the "Recently added" zones rank by — must match the backend
+ *  `RecentlyAddedMode`. */
+export type RecentlyAddedMode = 'media' | 'file' | 'both';
+
+export interface HomeSectionPref {
+  key: HomeSectionKey;
+  visible: boolean;
+}
+
+export interface ResolvedHomeSection {
+  key: HomeSectionKey;
+  type: HomeSectionType;
+  visible: boolean;
+  libraryId?: number;
+  libraryName?: string;
+}
+
+export interface HomeSettings {
+  order: HomeSectionPref[];
+  recentlyAddedMode: RecentlyAddedMode;
+}
+
+const STORAGE_KEY = 'home.settings';
+const LIBRARY_RECENT_PREFIX = 'library-recent:';
+
+const BUILTIN_ORDER: HomeSectionKey[] = [
+  'libraries',
+  'continue-watching',
+  'recommendations',
+  'recently-added',
+  'coming-soon',
+];
+
+const DEFAULTS: HomeSettings = {
+  order: BUILTIN_ORDER.map((key) => ({ key, visible: true })),
+  recentlyAddedMode: 'media',
+};
+
+/**
+ * Per-user, per-device home personalization (zone visibility + order and the
+ * "recently added" ranking mode), persisted to localStorage exactly like
+ * `DisplaySettingsService` / `PlayerSettingsService`. No backend involvement.
+ */
+@Injectable({ providedIn: 'root' })
+export class HomeSettingsService {
+  readonly settings = signal<HomeSettings>(this.load());
+
+  private load(): HomeSettings {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as Partial<HomeSettings>;
+        return {
+          order: Array.isArray(parsed.order) ? parsed.order : DEFAULTS.order,
+          recentlyAddedMode: parsed.recentlyAddedMode ?? DEFAULTS.recentlyAddedMode,
+        };
+      }
+    } catch {
+      /* private mode / corrupt value */
+    }
+    return { order: [...DEFAULTS.order], recentlyAddedMode: DEFAULTS.recentlyAddedMode };
+  }
+
+  private persist(next: HomeSettings): void {
+    this.settings.set(next);
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    } catch {
+      /* private mode / SSR */
+    }
+  }
+
+  /** Persist the full ordered list of prefs (the settings page rebuilds it
+   *  from the rendered rows on every reorder/toggle). */
+  setOrder(order: HomeSectionPref[]): void {
+    this.persist({ ...this.settings(), order });
+  }
+
+  setMode(recentlyAddedMode: RecentlyAddedMode): void {
+    this.persist({ ...this.settings(), recentlyAddedMode });
+  }
+
+  /**
+   * Reconcile the saved order with what's actually available now: keep the
+   * saved order for still-present zones, append any missing built-ins (default
+   * visible) in their canonical position, append one zone per library (default
+   * hidden — opt-in), and drop entries for libraries that no longer exist.
+   */
+  resolve(libraries: { id: number; name: string }[]): ResolvedHomeSection[] {
+    const libName = new Map(libraries.map((l) => [l.id, l.name]));
+    const available = new Set<HomeSectionKey>(BUILTIN_ORDER);
+    for (const lib of libraries) {
+      available.add(`${LIBRARY_RECENT_PREFIX}${lib.id}` as HomeSectionKey);
+    }
+
+    const seen = new Set<HomeSectionKey>();
+    const merged: HomeSectionPref[] = [];
+    for (const pref of this.settings().order) {
+      if (available.has(pref.key) && !seen.has(pref.key)) {
+        merged.push(pref);
+        seen.add(pref.key);
+      }
+    }
+    for (const key of BUILTIN_ORDER) {
+      if (!seen.has(key)) {
+        merged.push({ key, visible: true });
+        seen.add(key);
+      }
+    }
+    for (const lib of libraries) {
+      const key = `${LIBRARY_RECENT_PREFIX}${lib.id}` as HomeSectionKey;
+      if (!seen.has(key)) {
+        merged.push({ key, visible: false });
+        seen.add(key);
+      }
+    }
+
+    return merged.map((pref) => this.describe(pref, libName));
+  }
+
+  private describe(
+    pref: HomeSectionPref,
+    libName: Map<number, string>,
+  ): ResolvedHomeSection {
+    if (pref.key.startsWith(LIBRARY_RECENT_PREFIX)) {
+      const libraryId = Number(pref.key.slice(LIBRARY_RECENT_PREFIX.length));
+      return {
+        key: pref.key,
+        type: 'library-recent',
+        visible: pref.visible,
+        libraryId,
+        libraryName: libName.get(libraryId),
+      };
+    }
+    return {
+      key: pref.key,
+      type: pref.key as HomeSectionType,
+      visible: pref.visible,
+    };
+  }
+}

--- a/client/src/app/features/app-settings/app-settings-shell.html
+++ b/client/src/app/features/app-settings/app-settings-shell.html
@@ -6,6 +6,7 @@
   <svg drawerIcon lucideSettings class="h-5 w-5"></svg>
 
   <ng-container drawerMenu>
+    <li><a routerLink="/app-settings/home" routerLinkActive="active"><svg lucideHouse class="h-4 w-4"></svg>{{ 'app_settings.nav.home' | translate }}</a></li>
     <li><a routerLink="/app-settings/display" routerLinkActive="active"><svg lucideMonitor class="h-4 w-4"></svg>{{ 'app_settings.nav.display' | translate }}</a></li>
     <li><a routerLink="/app-settings/player" routerLinkActive="active"><svg lucidePlay class="h-4 w-4"></svg>{{ 'app_settings.nav.player' | translate }}</a></li>
     <li><a routerLink="/app-settings/subtitles" routerLinkActive="active"><svg lucideCaptions class="h-4 w-4"></svg>{{ 'app_settings.nav.subtitles' | translate }}</a></li>

--- a/client/src/app/features/app-settings/app-settings-shell.ts
+++ b/client/src/app/features/app-settings/app-settings-shell.ts
@@ -2,7 +2,7 @@ import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { SettingsDrawerComponent } from '../../shared/components/settings-drawer/settings-drawer';
-import { LucideSettings, LucidePlay, LucideCaptions, LucideCast, LucideHardDrive, LucideMonitor } from '@lucide/angular';
+import { LucideSettings, LucidePlay, LucideCaptions, LucideCast, LucideHardDrive, LucideMonitor, LucideHouse } from '@lucide/angular';
 import { TvService } from '../../core/services/tv.service';
 
 @Component({
@@ -10,7 +10,7 @@ import { TvService } from '../../core/services/tv.service';
   imports: [
     RouterLink, RouterLinkActive, TranslateModule,
     SettingsDrawerComponent,
-    LucideSettings, LucidePlay, LucideCaptions, LucideCast, LucideHardDrive, LucideMonitor,
+    LucideSettings, LucidePlay, LucideCaptions, LucideCast, LucideHardDrive, LucideMonitor, LucideHouse,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './app-settings-shell.html',

--- a/client/src/app/features/app-settings/display-settings/display-settings.html
+++ b/client/src/app/features/app-settings/display-settings/display-settings.html
@@ -7,14 +7,5 @@
       [label]="'display_settings.home_background' | translate"
       [hint]="'display_settings.home_background_hint' | translate"
     />
-
-    <div class="divider my-0"></div>
-
-    <app-toggle-field
-      [value]="onlyMyRequests()"
-      (valueChange)="onOnlyMyRequestsChange($event)"
-      [label]="'display_settings.only_my_requests' | translate"
-      [hint]="'display_settings.only_my_requests_hint' | translate"
-    />
   </div>
 </div>

--- a/client/src/app/features/app-settings/display-settings/display-settings.ts
+++ b/client/src/app/features/app-settings/display-settings/display-settings.ts
@@ -13,21 +13,14 @@ export class DisplaySettingsPageComponent implements OnInit {
   private readonly displaySettings = inject(DisplaySettingsService);
 
   readonly homeBackground = signal(true);
-  readonly onlyMyRequests = signal(false);
 
   ngOnInit() {
     const s = this.displaySettings.get();
     this.homeBackground.set(s.homeBackground);
-    this.onlyMyRequests.set(s.onlyMyRequests);
   }
 
   onHomeBackgroundChange(value: boolean) {
     this.homeBackground.set(value);
     this.displaySettings.save({ homeBackground: value });
-  }
-
-  onOnlyMyRequestsChange(value: boolean) {
-    this.onlyMyRequests.set(value);
-    this.displaySettings.save({ onlyMyRequests: value });
   }
 }

--- a/client/src/app/features/app-settings/home-settings/home-settings.html
+++ b/client/src/app/features/app-settings/home-settings/home-settings.html
@@ -1,0 +1,61 @@
+<h1 class="text-2xl font-bold mb-4">{{ 'home_settings.title' | translate }}</h1>
+
+<div class="card bg-base-100 border border-base-200 mb-6">
+  <div class="card-body gap-4">
+    <div>
+      <h2 class="font-semibold">{{ 'home_settings.sections_title' | translate }}</h2>
+      <p class="text-sm text-base-content/60">{{ 'home_settings.sections_hint' | translate }}</p>
+    </div>
+
+    <div cdkDropList (cdkDropListDropped)="drop($event)" class="flex flex-col gap-2">
+      @for (section of rows(); track section.key; let i = $index) {
+        <div cdkDrag class="flex items-center gap-2 rounded-lg border border-base-200 bg-base-200/40 px-3 py-2">
+          <button type="button" cdkDragHandle
+                  class="cursor-grab text-base-content/40 hover:text-base-content/70"
+                  [attr.aria-label]="'home_settings.drag' | translate">
+            <svg lucideGripVertical class="h-4 w-4"></svg>
+          </button>
+
+          <span class="flex-1 font-medium">
+            @if (section.type === 'library-recent') {
+              {{ 'home_settings.section_library_recent' | translate: { library: section.libraryName } }}
+            } @else {
+              {{ builtinLabel(section) | translate }}
+            }
+          </span>
+
+          <button type="button" class="btn btn-ghost btn-xs btn-square"
+                  [disabled]="i === 0" (click)="move(i, -1)"
+                  [attr.aria-label]="'home_settings.move_up' | translate">
+            <svg lucideArrowUp class="h-4 w-4"></svg>
+          </button>
+          <button type="button" class="btn btn-ghost btn-xs btn-square"
+                  [disabled]="i === rows().length - 1" (click)="move(i, 1)"
+                  [attr.aria-label]="'home_settings.move_down' | translate">
+            <svg lucideArrowDown class="h-4 w-4"></svg>
+          </button>
+
+          <input type="checkbox" class="toggle toggle-primary toggle-sm ml-1"
+                 [checked]="section.visible"
+                 (change)="setVisible(i, $any($event.target).checked)"
+                 [attr.aria-label]="'home_settings.toggle_visible' | translate" />
+        </div>
+      }
+    </div>
+  </div>
+</div>
+
+<div class="card bg-base-100 border border-base-200">
+  <div class="card-body">
+    <app-select-field
+      [value]="mode()"
+      (valueChange)="onModeChange($event)"
+      [label]="'home_settings.recently_added_mode' | translate"
+      [hint]="'home_settings.recently_added_mode_hint' | translate"
+    >
+      <option [ngValue]="'media'">{{ 'home_settings.mode_media' | translate }}</option>
+      <option [ngValue]="'file'">{{ 'home_settings.mode_file' | translate }}</option>
+      <option [ngValue]="'both'">{{ 'home_settings.mode_both' | translate }}</option>
+    </app-select-field>
+  </div>
+</div>

--- a/client/src/app/features/app-settings/home-settings/home-settings.html
+++ b/client/src/app/features/app-settings/home-settings/home-settings.html
@@ -50,7 +50,7 @@
 </div>
 
 <div class="card bg-base-100 border border-base-200">
-  <div class="card-body">
+  <div class="card-body gap-5">
     <app-select-field
       [value]="mode()"
       (valueChange)="onModeChange($event)"
@@ -61,5 +61,14 @@
       <option [value]="'file'">{{ 'home_settings.mode_file' | translate }}</option>
       <option [value]="'both'">{{ 'home_settings.mode_both' | translate }}</option>
     </app-select-field>
+
+    <div class="divider my-0"></div>
+
+    <app-toggle-field
+      [value]="onlyMyRequests()"
+      (valueChange)="onOnlyMyRequestsChange($event)"
+      [label]="'home_settings.only_my_requests' | translate"
+      [hint]="'home_settings.only_my_requests_hint' | translate"
+    />
   </div>
 </div>

--- a/client/src/app/features/app-settings/home-settings/home-settings.html
+++ b/client/src/app/features/app-settings/home-settings/home-settings.html
@@ -9,12 +9,14 @@
 
     <div cdkDropList (cdkDropListDropped)="drop($event)" class="flex flex-col gap-2">
       @for (section of rows(); track section.key; let i = $index) {
-        <div cdkDrag class="flex items-center gap-2 rounded-lg border border-base-200 bg-base-200/40 px-3 py-2">
-          <button type="button" cdkDragHandle
-                  class="cursor-grab text-base-content/40 hover:text-base-content/70"
-                  [attr.aria-label]="'home_settings.drag' | translate">
-            <svg lucideGripVertical class="h-4 w-4"></svg>
-          </button>
+        <div cdkDrag [cdkDragDisabled]="tv.isTv()" class="flex items-center gap-2 rounded-lg border border-base-200 bg-base-200/40 px-3 py-2">
+          @if (!tv.isTv()) {
+            <button type="button" cdkDragHandle
+                    class="cursor-grab text-base-content/40 hover:text-base-content/70"
+                    [attr.aria-label]="'home_settings.drag' | translate">
+              <svg lucideGripVertical class="h-4 w-4"></svg>
+            </button>
+          }
 
           <span class="flex-1 font-medium">
             @if (section.type === 'library-recent') {
@@ -24,16 +26,18 @@
             }
           </span>
 
-          <button type="button" class="btn btn-ghost btn-xs btn-square"
-                  [disabled]="i === 0" (click)="move(i, -1)"
-                  [attr.aria-label]="'home_settings.move_up' | translate">
-            <svg lucideArrowUp class="h-4 w-4"></svg>
-          </button>
-          <button type="button" class="btn btn-ghost btn-xs btn-square"
-                  [disabled]="i === rows().length - 1" (click)="move(i, 1)"
-                  [attr.aria-label]="'home_settings.move_down' | translate">
-            <svg lucideArrowDown class="h-4 w-4"></svg>
-          </button>
+          @if (tv.isTv()) {
+            <button type="button" class="btn btn-ghost btn-xs btn-square"
+                    [disabled]="i === 0" (click)="move(i, -1)"
+                    [attr.aria-label]="'home_settings.move_up' | translate">
+              <svg lucideArrowUp class="h-4 w-4"></svg>
+            </button>
+            <button type="button" class="btn btn-ghost btn-xs btn-square"
+                    [disabled]="i === rows().length - 1" (click)="move(i, 1)"
+                    [attr.aria-label]="'home_settings.move_down' | translate">
+              <svg lucideArrowDown class="h-4 w-4"></svg>
+            </button>
+          }
 
           <input type="checkbox" class="toggle toggle-primary toggle-sm ml-1"
                  [checked]="section.visible"

--- a/client/src/app/features/app-settings/home-settings/home-settings.html
+++ b/client/src/app/features/app-settings/home-settings/home-settings.html
@@ -53,9 +53,9 @@
       [label]="'home_settings.recently_added_mode' | translate"
       [hint]="'home_settings.recently_added_mode_hint' | translate"
     >
-      <option [ngValue]="'media'">{{ 'home_settings.mode_media' | translate }}</option>
-      <option [ngValue]="'file'">{{ 'home_settings.mode_file' | translate }}</option>
-      <option [ngValue]="'both'">{{ 'home_settings.mode_both' | translate }}</option>
+      <option [value]="'media'">{{ 'home_settings.mode_media' | translate }}</option>
+      <option [value]="'file'">{{ 'home_settings.mode_file' | translate }}</option>
+      <option [value]="'both'">{{ 'home_settings.mode_both' | translate }}</option>
     </app-select-field>
   </div>
 </div>

--- a/client/src/app/features/app-settings/home-settings/home-settings.ts
+++ b/client/src/app/features/app-settings/home-settings/home-settings.ts
@@ -25,6 +25,7 @@ import {
   RecentlyAddedMode,
 } from '../../../core/services/home-settings.service';
 import { LibrariesApiService } from '../../../core/services/api/libraries-api.service';
+import { TvService } from '../../../core/services/tv.service';
 import { SelectFieldComponent } from '../../../shared/components/forms/select-field/select-field';
 
 @Component({
@@ -46,6 +47,7 @@ import { SelectFieldComponent } from '../../../shared/components/forms/select-fi
 export class HomeSettingsPageComponent implements OnInit {
   private readonly home = inject(HomeSettingsService);
   private readonly librariesApi = inject(LibrariesApiService);
+  readonly tv = inject(TvService);
 
   /** The rendered, reorderable rows — the working copy persisted on change. */
   readonly rows = signal<ResolvedHomeSection[]>([]);

--- a/client/src/app/features/app-settings/home-settings/home-settings.ts
+++ b/client/src/app/features/app-settings/home-settings/home-settings.ts
@@ -1,0 +1,115 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  inject,
+  signal,
+  OnInit,
+} from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { FormsModule } from '@angular/forms';
+import {
+  CdkDropList,
+  CdkDrag,
+  CdkDragHandle,
+  CdkDragDrop,
+  moveItemInArray,
+} from '@angular/cdk/drag-drop';
+import {
+  LucideGripVertical,
+  LucideArrowUp,
+  LucideArrowDown,
+} from '@lucide/angular';
+import {
+  HomeSettingsService,
+  ResolvedHomeSection,
+  RecentlyAddedMode,
+} from '../../../core/services/home-settings.service';
+import { LibrariesApiService } from '../../../core/services/api/libraries-api.service';
+import { SelectFieldComponent } from '../../../shared/components/forms/select-field/select-field';
+
+@Component({
+  selector: 'app-home-settings',
+  imports: [
+    TranslateModule,
+    FormsModule,
+    CdkDropList,
+    CdkDrag,
+    CdkDragHandle,
+    LucideGripVertical,
+    LucideArrowUp,
+    LucideArrowDown,
+    SelectFieldComponent,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './home-settings.html',
+})
+export class HomeSettingsPageComponent implements OnInit {
+  private readonly home = inject(HomeSettingsService);
+  private readonly librariesApi = inject(LibrariesApiService);
+
+  /** The rendered, reorderable rows — the working copy persisted on change. */
+  readonly rows = signal<ResolvedHomeSection[]>([]);
+  readonly mode = signal<RecentlyAddedMode>('media');
+
+  private readonly BUILTIN_LABELS: Record<string, string> = {
+    libraries: 'home_settings.section.libraries',
+    'continue-watching': 'home_settings.section.continue_watching',
+    recommendations: 'home_settings.section.recommendations',
+    'recently-added': 'home_settings.section.recently_added',
+    'coming-soon': 'home_settings.section.coming_soon',
+  };
+
+  async ngOnInit() {
+    this.mode.set(this.home.settings().recentlyAddedMode);
+    let libs: { id: number; name: string }[] = [];
+    try {
+      libs = (await this.librariesApi.listMine()).map((l) => ({
+        id: l.id,
+        name: l.name,
+      }));
+    } catch {
+      /* error handled by global interceptor */
+    }
+    this.rows.set(this.home.resolve(libs));
+  }
+
+  /** Translation key for a built-in zone's label. */
+  builtinLabel(section: ResolvedHomeSection): string {
+    return this.BUILTIN_LABELS[section.type] ?? section.type;
+  }
+
+  private persist() {
+    this.home.setOrder(
+      this.rows().map((r) => ({ key: r.key, visible: r.visible })),
+    );
+  }
+
+  drop(event: CdkDragDrop<ResolvedHomeSection[]>) {
+    const next = [...this.rows()];
+    moveItemInArray(next, event.previousIndex, event.currentIndex);
+    this.rows.set(next);
+    this.persist();
+  }
+
+  /** Reorder via the arrow buttons (TV remote / keyboard path). */
+  move(index: number, delta: number) {
+    const next = [...this.rows()];
+    const target = index + delta;
+    if (target < 0 || target >= next.length) return;
+    [next[index], next[target]] = [next[target], next[index]];
+    this.rows.set(next);
+    this.persist();
+  }
+
+  setVisible(index: number, visible: boolean) {
+    const next = [...this.rows()];
+    next[index] = { ...next[index], visible };
+    this.rows.set(next);
+    this.persist();
+  }
+
+  onModeChange(mode: RecentlyAddedMode) {
+    this.mode.set(mode);
+    this.home.setMode(mode);
+  }
+}

--- a/client/src/app/features/app-settings/home-settings/home-settings.ts
+++ b/client/src/app/features/app-settings/home-settings/home-settings.ts
@@ -26,7 +26,9 @@ import {
 } from '../../../core/services/home-settings.service';
 import { LibrariesApiService } from '../../../core/services/api/libraries-api.service';
 import { TvService } from '../../../core/services/tv.service';
+import { DisplaySettingsService } from '../../../core/services/display-settings.service';
 import { SelectFieldComponent } from '../../../shared/components/forms/select-field/select-field';
+import { ToggleFieldComponent } from '../../../shared/components/forms/toggle-field/toggle-field';
 
 @Component({
   selector: 'app-home-settings',
@@ -40,6 +42,7 @@ import { SelectFieldComponent } from '../../../shared/components/forms/select-fi
     LucideArrowUp,
     LucideArrowDown,
     SelectFieldComponent,
+    ToggleFieldComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './home-settings.html',
@@ -47,11 +50,13 @@ import { SelectFieldComponent } from '../../../shared/components/forms/select-fi
 export class HomeSettingsPageComponent implements OnInit {
   private readonly home = inject(HomeSettingsService);
   private readonly librariesApi = inject(LibrariesApiService);
+  private readonly displaySettings = inject(DisplaySettingsService);
   readonly tv = inject(TvService);
 
   /** The rendered, reorderable rows — the working copy persisted on change. */
   readonly rows = signal<ResolvedHomeSection[]>([]);
   readonly mode = signal<RecentlyAddedMode>('media');
+  readonly onlyMyRequests = signal(false);
 
   private readonly BUILTIN_LABELS: Record<string, string> = {
     libraries: 'home_settings.section.libraries',
@@ -63,6 +68,7 @@ export class HomeSettingsPageComponent implements OnInit {
 
   async ngOnInit() {
     this.mode.set(this.home.settings().recentlyAddedMode);
+    this.onlyMyRequests.set(this.displaySettings.get().onlyMyRequests);
     let libs: { id: number; name: string }[] = [];
     try {
       libs = (await this.librariesApi.listMine()).map((l) => ({
@@ -113,5 +119,10 @@ export class HomeSettingsPageComponent implements OnInit {
   onModeChange(mode: RecentlyAddedMode) {
     this.mode.set(mode);
     this.home.setMode(mode);
+  }
+
+  onOnlyMyRequestsChange(value: boolean) {
+    this.onlyMyRequests.set(value);
+    this.displaySettings.save({ onlyMyRequests: value });
   }
 }

--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -5,99 +5,134 @@
 
 <div appTvSection class="flex flex-col gap-8">
 
-    <!-- Libraries -->
-    @if (libraries().length) {
-      <app-horizontal-scroller [title]="'home.libraries' | translate">
-        @for (lib of libraries(); track lib.id) {
-          <a [routerLink]="libraryUrl(lib)"
-             [attr.data-home-focus]="'library:' + lib.id"
-             class="shrink-0 w-36 h-20 sm:w-48 sm:h-28 rounded-xl border flex items-center gap-3 px-4 sm:px-5 hover:shadow-lg transition-shadow"
-             [style.background]="'linear-gradient(135deg, color-mix(in oklch, ' + libraryColor(lib) + ' 20%, transparent), color-mix(in oklch, ' + libraryColor(lib) + ' 5%, transparent))'"
-             [style.border-color]="'color-mix(in oklch, ' + libraryColor(lib) + ' 15%, transparent)'"
-          >
-            <app-lucide-icon [name]="lib.icon || 'library'" class="h-6 w-6 sm:h-8 sm:w-8 shrink-0" [style.color]="libraryColor(lib)" />
-            <span class="text-sm sm:text-base font-semibold">{{ lib.name }}</span>
-          </a>
-        }
-      </app-horizontal-scroller>
-    }
+  @for (section of visibleSections(); track section.key) {
+    @switch (section.type) {
 
-    <!-- Continue Watching -->
-    @if (continueWatching().length) {
-      <app-horizontal-scroller [title]="'home.continue_watching' | translate">
-        @for (item of continueWatching(); track item.id) {
-          <app-media-card [aspect]="'landscape'"
-            [attr.data-home-focus]="'cw:' + item.id"
-            [imageUrl]="item.stillUrl ?? item.fanartUrl ?? item.posterUrl"
-            [title]="item.mediaTitle"
-            [subtitle]="item.episodeLabel ?? undefined"
-            [progressPercent]="item.progressPercent"
-            [playable]="true"
-            [link]="['/' + (item.mediaType === 'series' ? 'series' : 'movies'), '' + item.mediaId]"
-            [subtitleLink]="item.episodeId ? ['/series', '' + item.mediaId, 'episode', '' + item.episodeId] : null"
-            [dismissable]="true"
-            [interactiveWatched]="true"
-            [clickIntent]="'play'"
-            (clicked)="playContinueWatching(item)"
-            (dismissed)="removeContinueWatching(item)"
-            (watchedToggled)="toggleContinueWatchingWatched(item, $event)"
-          />
+      <!-- Libraries -->
+      @case ('libraries') {
+        @if (libraries().length) {
+          <app-horizontal-scroller [title]="'home.libraries' | translate">
+            @for (lib of libraries(); track lib.id) {
+              <a [routerLink]="libraryUrl(lib)"
+                 [attr.data-home-focus]="'library:' + lib.id"
+                 class="shrink-0 w-36 h-20 sm:w-48 sm:h-28 rounded-xl border flex items-center gap-3 px-4 sm:px-5 hover:shadow-lg transition-shadow"
+                 [style.background]="'linear-gradient(135deg, color-mix(in oklch, ' + libraryColor(lib) + ' 20%, transparent), color-mix(in oklch, ' + libraryColor(lib) + ' 5%, transparent))'"
+                 [style.border-color]="'color-mix(in oklch, ' + libraryColor(lib) + ' 15%, transparent)'"
+              >
+                <app-lucide-icon [name]="lib.icon || 'library'" class="h-6 w-6 sm:h-8 sm:w-8 shrink-0" [style.color]="libraryColor(lib)" />
+                <span class="text-sm sm:text-base font-semibold">{{ lib.name }}</span>
+              </a>
+            }
+          </app-horizontal-scroller>
         }
-      </app-horizontal-scroller>
-    }
+      }
 
-    <!-- Recommendations -->
-    @if (recommendations().length) {
-      <app-horizontal-scroller [title]="'home.recommendations' | translate">
-        @for (rec of recommendations(); track rec.media.id) {
-          <app-media-card
-            class="shrink-0 w-28 sm:w-40"
-            [attr.data-home-focus]="'rec:' + rec.media.id"
-            [imageUrl]="rec.media.posterUrl"
-            [title]="rec.media.title"
-            [subtitle]="'' + rec.media.year"
-            [link]="['/' + (rec.media.type === 'series' ? 'series' : 'movies'), '' + rec.media.id]"
-            [status]="rec.media.available ? null : 'missing'"
-            [playable]="rec.media.available"
-            [dismissable]="true"
-            (played)="playRecommendation(rec)"
-            (dismissed)="dismissRecommendation(rec)"
-          />
+      <!-- Continue Watching -->
+      @case ('continue-watching') {
+        @if (continueWatching().length) {
+          <app-horizontal-scroller [title]="'home.continue_watching' | translate">
+            @for (item of continueWatching(); track item.id) {
+              <app-media-card [aspect]="'landscape'"
+                [attr.data-home-focus]="'cw:' + item.id"
+                [imageUrl]="item.stillUrl ?? item.fanartUrl ?? item.posterUrl"
+                [title]="item.mediaTitle"
+                [subtitle]="item.episodeLabel ?? undefined"
+                [progressPercent]="item.progressPercent"
+                [playable]="true"
+                [link]="['/' + (item.mediaType === 'series' ? 'series' : 'movies'), '' + item.mediaId]"
+                [subtitleLink]="item.episodeId ? ['/series', '' + item.mediaId, 'episode', '' + item.episodeId] : null"
+                [dismissable]="true"
+                [interactiveWatched]="true"
+                [clickIntent]="'play'"
+                (clicked)="playContinueWatching(item)"
+                (dismissed)="removeContinueWatching(item)"
+                (watchedToggled)="toggleContinueWatchingWatched(item, $event)"
+              />
+            }
+          </app-horizontal-scroller>
         }
-      </app-horizontal-scroller>
-    }
+      }
 
-    <!-- Recently Added -->
-    @if (recentMedia().length) {
-      <app-horizontal-scroller [title]="'home.recent_media' | translate">
-        @for (m of recentMedia(); track m.id) {
-          <app-media-card
-            class="shrink-0 w-28 sm:w-40"
-            [attr.data-home-focus]="'recent:' + m.id"
-            [media]="m"
-            [subtitle]="'' + m.year"
-            [hideStatusBar]="true"
-            [interactiveWatched]="canMarkMediaWatched(m)"
-            (watchedToggled)="toggleRecentMediaWatched(m, $event)"
-          />
+      <!-- Recommendations -->
+      @case ('recommendations') {
+        @if (recommendations().length) {
+          <app-horizontal-scroller [title]="'home.recommendations' | translate">
+            @for (rec of recommendations(); track rec.media.id) {
+              <app-media-card
+                class="shrink-0 w-28 sm:w-40"
+                [attr.data-home-focus]="'rec:' + rec.media.id"
+                [imageUrl]="rec.media.posterUrl"
+                [title]="rec.media.title"
+                [subtitle]="'' + rec.media.year"
+                [link]="['/' + (rec.media.type === 'series' ? 'series' : 'movies'), '' + rec.media.id]"
+                [status]="rec.media.available ? null : 'missing'"
+                [playable]="rec.media.available"
+                [dismissable]="true"
+                (played)="playRecommendation(rec)"
+                (dismissed)="dismissRecommendation(rec)"
+              />
+            }
+          </app-horizontal-scroller>
         }
-      </app-horizontal-scroller>
-    }
+      }
 
-    <!-- Coming Soon -->
-    @if (comingSoon().length) {
-      <app-horizontal-scroller [title]="'home.coming_soon' | translate">
-        @for (entry of comingSoon(); track entry.id) {
-          <app-media-card
-            class="shrink-0 w-28 sm:w-40"
-            [attr.data-home-focus]="'soon:' + entry.id"
-            [imageUrl]="entry.posterUrl"
-            [title]="entry.title"
-            [subtitle]="entry.date"
-            [link]="['/' + (entry.type === 'series' ? 'series' : 'movies'), '' + entry.mediaId]"
-          />
+      <!-- Recently Added -->
+      @case ('recently-added') {
+        @if (recentMedia().length) {
+          <app-horizontal-scroller [title]="'home.recent_media' | translate">
+            @for (m of recentMedia(); track m.id) {
+              <app-media-card
+                class="shrink-0 w-28 sm:w-40"
+                [attr.data-home-focus]="'recent:' + m.id"
+                [media]="m"
+                [subtitle]="'' + m.year"
+                [hideStatusBar]="true"
+                [interactiveWatched]="canMarkMediaWatched(m)"
+                (watchedToggled)="toggleRecentMediaWatched(m, $event)"
+              />
+            }
+          </app-horizontal-scroller>
         }
-      </app-horizontal-scroller>
-    }
+      }
 
-  </div>
+      <!-- Coming Soon -->
+      @case ('coming-soon') {
+        @if (comingSoon().length) {
+          <app-horizontal-scroller [title]="'home.coming_soon' | translate">
+            @for (entry of comingSoon(); track entry.id) {
+              <app-media-card
+                class="shrink-0 w-28 sm:w-40"
+                [attr.data-home-focus]="'soon:' + entry.id"
+                [imageUrl]="entry.posterUrl"
+                [title]="entry.title"
+                [subtitle]="entry.date"
+                [link]="['/' + (entry.type === 'series' ? 'series' : 'movies'), '' + entry.mediaId]"
+              />
+            }
+          </app-horizontal-scroller>
+        }
+      }
+
+      <!-- Recently Added — per library (opt-in) -->
+      @case ('library-recent') {
+        @if (libraryRecent().get(section.libraryId!)?.length) {
+          <app-horizontal-scroller [title]="'home.recent_media_in' | translate: { library: section.libraryName }">
+            @for (m of libraryRecent().get(section.libraryId!) ?? []; track m.id) {
+              <app-media-card
+                class="shrink-0 w-28 sm:w-40"
+                [attr.data-home-focus]="'libRecent:' + section.libraryId + ':' + m.id"
+                [media]="m"
+                [subtitle]="'' + m.year"
+                [hideStatusBar]="true"
+                [interactiveWatched]="canMarkMediaWatched(m)"
+                (watchedToggled)="toggleLibraryRecentWatched(section.libraryId!, m, $event)"
+              />
+            }
+          </app-horizontal-scroller>
+        }
+      }
+
+    }
+  }
+
+</div>

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject, signal, effect, OnInit, OnDestroy, Injector, afterNextRender } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, signal, computed, effect, OnInit, OnDestroy, Injector, afterNextRender } from '@angular/core';
 import { ActivatedRoute, NavigationStart, Router, RouterLink } from '@angular/router';
 import { Subscription, filter } from 'rxjs';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
@@ -13,6 +13,7 @@ import { FocusMemoryService } from '../../core/services/focus-memory.service';
 import { NavbarService } from '../../core/services/navbar.service';
 import { BackgroundService } from '../../core/services/background.service';
 import { DisplaySettingsService } from '../../core/services/display-settings.service';
+import { HomeSettingsService } from '../../core/services/home-settings.service';
 import { TvService } from '../../core/services/tv.service';
 import { MediaCardComponent } from '../../shared/components/media-card/media-card';
 import { HorizontalScrollerComponent } from '../../shared/components/horizontal-scroller';
@@ -78,6 +79,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly navbar = inject(NavbarService);
   private readonly backgroundService = inject(BackgroundService);
   private readonly displaySettings = inject(DisplaySettingsService);
+  private readonly home = inject(HomeSettingsService);
   readonly auth = inject(AuthService);
   private readonly tv = inject(TvService);
   private readonly injector = inject(Injector);
@@ -97,6 +99,17 @@ export class HomeComponent implements OnInit, OnDestroy {
   readonly recentMedia = signal<Media[]>([]);
   readonly comingSoon = signal<CalendarEntry[]>([]);
   readonly recommendations = signal<RecommendationItem[]>([]);
+  /** Recently-added items per library, keyed by library id (opt-in zones). */
+  readonly libraryRecent = signal<Map<number, Media[]>>(new Map());
+
+  /** The user's resolved home layout (order + visibility), reconciled with
+   *  the libraries they can currently access. Drives template rendering. */
+  readonly sections = computed(() =>
+    this.home.resolve(this.libraries().map((l) => ({ id: l.id, name: l.name }))),
+  );
+  readonly visibleSections = computed(() =>
+    this.sections().filter((s) => s.visible),
+  );
 
   /** Once the recommendations land, randomise the page background
    *  using their fanarts (primary + extras). One pick per visit;
@@ -125,6 +138,18 @@ export class HomeComponent implements OnInit, OnDestroy {
     void this.displaySettings.settings().onlyMyRequests;
     if (this.firstOnlyMyRequestsRun) {
       this.firstOnlyMyRequestsRun = false;
+      return;
+    }
+    void this.loadFilteredSections();
+  });
+  /** Re-fetch the recently-added rows when the user changes the ranking mode
+   *  or enables/reorders zones from the home settings page. Skips the initial
+   *  run — ngOnInit already loads the sections. */
+  private firstHomeSettingsRun = true;
+  private readonly homeSettingsEffect = effect(() => {
+    void this.home.settings();
+    if (this.firstHomeSettingsRun) {
+      this.firstHomeSettingsRun = false;
       return;
     }
     void this.loadFilteredSections();
@@ -258,6 +283,7 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   private async loadFilteredSections() {
     const mine = this.displaySettings.settings().onlyMyRequests;
+    const mode = this.home.settings().recentlyAddedMode;
     const today = new Date();
     const threeDaysAgo = new Date(today);
     threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
@@ -266,18 +292,37 @@ export class HomeComponent implements OnInit, OnDestroy {
     const startStr = threeDaysAgo.toISOString().slice(0, 10);
     const in30dStr = in30d.toISOString().slice(0, 10);
 
+    // Only fetch per-library rows the user has actually enabled (opt-in).
+    const libSections = this.visibleSections().filter(
+      (s) => s.type === 'library-recent' && s.libraryId != null,
+    );
+
     try {
-      const [recent, calendar] = await Promise.all([
-        this.mediaService.getAll({
-          sortBy: 'createdAt',
-          sortOrder: 'DESC',
+      const [recent, calendar, libEntries] = await Promise.all([
+        this.mediaService.getRecentlyAdded({
+          mode,
           limit: 20,
           excludeWatched: true,
           requestedByMe: mine || undefined,
         }),
         this.mediaService.getCalendar(startStr, in30dStr, true, mine).catch(() => []),
+        Promise.all(
+          libSections.map((s) =>
+            this.mediaService
+              .getRecentlyAdded({
+                libraryId: s.libraryId,
+                mode,
+                limit: 20,
+                excludeWatched: true,
+                requestedByMe: mine || undefined,
+              })
+              .then((items) => [s.libraryId as number, items] as const)
+              .catch(() => [s.libraryId as number, [] as Media[]] as const),
+          ),
+        ),
       ]);
-      this.recentMedia.set(recent.data);
+      this.recentMedia.set(recent);
+      this.libraryRecent.set(new Map(libEntries));
       const upcoming = calendar
         .filter((e) => !e.hasFile && (e.event === 'digital' || e.event === 'airing' || e.event === 'release'))
         .sort((a, b) => a.date.localeCompare(b.date));
@@ -387,6 +432,29 @@ export class HomeComponent implements OnInit, OnDestroy {
         // row would vanish on the next refresh anyway — remove it now to
         // match the visible expectation.
         this.recentMedia.update(list => list.filter(x => x.id !== m.id));
+      }
+    } catch { /* global error toast */ }
+  }
+
+  /** Same as {@link toggleRecentMediaWatched} for a per-library recently-added
+   *  row — drops the watched item from that library's bucket. */
+  async toggleLibraryRecentWatched(libraryId: number, m: Media, watched: boolean) {
+    try {
+      if (m.type === 'series') {
+        await this.streamingApi.toggleSeriesWatched(m.id, watched);
+      } else {
+        const fileId = m.files?.[0]?.id;
+        if (!fileId) return;
+        await this.streamingApi.toggleWatched(m.id, fileId);
+      }
+      if (watched) {
+        this.libraryRecent.update((map) => {
+          const items = map.get(libraryId);
+          if (!items) return map;
+          const next = new Map(map);
+          next.set(libraryId, items.filter((x) => x.id !== m.id));
+          return next;
+        });
       }
     } catch { /* global error toast */ }
   }

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -206,7 +206,13 @@ export class HomeComponent implements OnInit, OnDestroy {
     this.attachedSub = this.reuseStrategy.attached$.subscribe((key) => {
       if (key !== ownKey) return;
       this.scrollMemory.activate(HomeComponent.SCROLL_KEY);
+      // The cached signals stay visible; refresh cache-first for an instant
+      // repaint, then force a network round-trip so a return to home reflects
+      // additions / watched flips made elsewhere — same SWR contract as the
+      // initial ngOnInit load (a plain reuse-attach would otherwise sit on
+      // stale data until the cache TTL expired).
       void this.loadAllSections();
+      queueMicrotask(() => void this.loadAllSections({ force: true }));
       this.scrollMemory.restoreSticky(HomeComponent.SCROLL_KEY);
       if (this.tv.isTv()) {
         this.arrivedViaBack = true;
@@ -258,7 +264,7 @@ export class HomeComponent implements OnInit, OnDestroy {
       if (cw) this.continueWatching.set(cw);
       if (recs) this.recommendations.set(recs);
     } catch { /* ignore */ }
-    await this.loadFilteredSections();
+    await this.loadFilteredSections({ force });
   }
 
   private applyDefaultFocus() {
@@ -282,7 +288,8 @@ export class HomeComponent implements OnInit, OnDestroy {
     root.querySelector<HTMLElement>(FOCUSABLE)?.focus({ preventScroll: false });
   }
 
-  private async loadFilteredSections() {
+  private async loadFilteredSections(opts: { force?: boolean } = {}) {
+    const force = !!opts.force;
     const mine = this.displaySettings.settings().onlyMyRequests;
     const mode = this.home.settings().recentlyAddedMode;
     const today = new Date();
@@ -300,23 +307,29 @@ export class HomeComponent implements OnInit, OnDestroy {
 
     try {
       const [recent, calendar, libEntries] = await Promise.all([
-        this.mediaService.getRecentlyAdded({
-          mode,
-          limit: 20,
-          excludeWatched: true,
-          requestedByMe: mine || undefined,
-        }),
-        this.mediaService.getCalendar(startStr, in30dStr, true, mine).catch(() => []),
+        this.mediaService.getRecentlyAdded(
+          {
+            mode,
+            limit: 20,
+            excludeWatched: true,
+            requestedByMe: mine || undefined,
+          },
+          { force },
+        ),
+        this.mediaService.getCalendar(startStr, in30dStr, true, mine, { force }).catch(() => []),
         Promise.all(
           libSections.map((s) =>
             this.mediaService
-              .getRecentlyAdded({
-                libraryId: s.libraryId,
-                mode,
-                limit: 20,
-                excludeWatched: true,
-                requestedByMe: mine || undefined,
-              })
+              .getRecentlyAdded(
+                {
+                  libraryId: s.libraryId,
+                  mode,
+                  limit: 20,
+                  excludeWatched: true,
+                  requestedByMe: mine || undefined,
+                },
+                { force },
+              )
               .then((items) => [s.libraryId as number, items] as const)
               .catch(() => [s.libraryId as number, [] as Media[]] as const),
           ),

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -45,9 +45,10 @@ import { AuthService } from '../../core/services/auth.service';
  * Deduplicated by mediaId (earliest date kept).
  *
  * ## Récemment ajoutés
- * Last 20 media added to the library (movies + series mixed),
- * excluding already-watched entries. Includes items still awaiting download.
- * Data: `GET /api/media?sortBy=createdAt&sortOrder=DESC&limit=20&excludeWatched=true`.
+ * Last 20 media (movies + series mixed), excluding already-watched entries,
+ * ranked by the user's `recentlyAddedMode` (media add time / newest file /
+ * both). Opt-in per-library variants render the same feed scoped to one
+ * library. Data: `GET /api/media/recently-added`.
  *
  * ## Recommandations
  * Genre-based suggestions derived from the user's watch history.


### PR DESCRIPTION
Lets each user personalize the home page and adds a per-library "Recently added" feed.

## What's new
**Per-user home personalization** (App settings → Accueil, all in localStorage like display/player settings):
- Choose which zones are visible and in what order.
- Reorder by **drag-and-drop** *and* **up/down arrow buttons** (so it works by TV remote / keyboard).
- Opt-in **"Récemment ajouté – <library>"** zones, one per library (hidden by default).
- A **recently-added mode** selector that applies to *all* "Recently added" zones: `media` (titles recently added to the library), `file` (titles whose file was recently imported), or `both`. **Defaults to `file`.**

**Backend** — `GET /api/media/recently-added` (`MediaQueryService.findRecentlyAdded`):
- Optional `libraryId`; `mode` query param drives the ranking: `media.createdAt`, newest `media_files.createdAt` (file modes also require a file → surfaces a series when a fresh episode lands), or `GREATEST(...)` for `both`. Fallback mode `file`.
- Ranking + paging run in a flat id pass (exact limit + order), then entities are hydrated and re-ordered. The episode-stats / sizeOnDisk enrichment is extracted from `findAll` and reused.

## Defaults / migration
No saved settings → built-ins in today's order, all visible, per-library zones hidden, mode `file`. Zone order/visibility is unchanged until the user opts in.

## Verification
- Backend `tsc --noEmit` clean; client `ng build` clean (only the pre-existing shaka-player CommonJS warning).
- No automated DB test for the ordering query: the media module has no DB-backed test harness (`GREATEST` etc. need real Postgres), so it was **not** unit-tested. Manual check: `GET /api/media/recently-added?mode=both|file|media[&libraryId=]` and confirm a series with a freshly added episode file surfaces under `file`/`both` but not `media`.
- Manual UI: App settings → Accueil → toggle/reorder (drag + arrows), enable a per-library zone, change mode and confirm the rows re-rank after refresh.

Refs: #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)