### PR TITLE
feat(home): add "Demandes récentes" zone with request cards

### DIFF
--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1879,6 +1879,7 @@
     "mode_file": "Fichiers récemment ajoutés",
     "mode_both": "Les deux",
     "only_my_requests": "Afficher uniquement les médias que j'ai demandé",
-    "only_my_requests_hint": "Filtre les sections « Récemment ajoutés » et « Bientôt disponible » de l'accueil pour ne garder que les médias que vous avez demandés."
+    "only_my_requests_hint": "Filtre les sections « Récemment ajoutés » et « Bientôt disponible » de l'accueil pour ne garder que les médias que vous avez demandés.",
+    "reset": "Réinitialiser"
   }
 }

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -189,7 +189,8 @@
     "coming_soon": "Bientôt disponible",
     "recent_media": "Récemment ajoutés",
     "recommendations": "Recommandations",
-    "recent_media_in": "Récemment ajouté – {{library}}"
+    "recent_media_in": "Récemment ajouté – {{library}}",
+    "requests_recent": "Demandes récentes"
   },
   "playback_settings": {
     "title": "Paramètres de lecture",
@@ -1864,7 +1865,8 @@
       "continue_watching": "Reprendre la lecture",
       "recommendations": "Recommandations",
       "recently_added": "Récemment ajouté",
-      "coming_soon": "Bientôt disponible"
+      "coming_soon": "Bientôt disponible",
+      "requests_recent": "Demandes récentes"
     },
     "section_library_recent": "Récemment ajouté – {{library}}",
     "drag": "Déplacer",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1880,6 +1880,8 @@
     "mode_both": "Les deux",
     "only_my_requests": "Afficher uniquement les médias que j'ai demandé",
     "only_my_requests_hint": "Filtre les sections « Récemment ajoutés » et « Bientôt disponible » de l'accueil pour ne garder que les médias que vous avez demandés.",
-    "reset": "Réinitialiser"
+    "reset": "Réinitialiser",
+    "reset_confirm_title": "Réinitialiser les zones",
+    "reset_confirm": "Remettre l'ordre et la visibilité des zones de l'accueil par défaut ?"
   }
 }

--- a/client/src/app/core/services/api/requests.service.ts
+++ b/client/src/app/core/services/api/requests.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { MediaType } from '../../enums/media-type.enum';
+import { CACHE_BYPASS_HEADER } from '../../interceptors/cache.interceptor';
 
 export interface RequestUser {
   id: number;
@@ -85,14 +86,20 @@ export class RequestsService {
     return firstValueFrom(this.http.patch<FliksRequestRow>(`/api/requests/${id}`, body));
   }
 
-  list(params: ListRequestsParams = {}) {
+  list(params: ListRequestsParams = {}, opts: { force?: boolean } = {}) {
     let httpParams = new HttpParams();
     for (const [key, value] of Object.entries(params)) {
       if (value !== undefined && value !== null && value !== '') {
         httpParams = httpParams.set(key, String(value));
       }
     }
-    return firstValueFrom(this.http.get<RequestsPage>('/api/requests', { params: httpParams }));
+    const headers = opts.force ? { [CACHE_BYPASS_HEADER]: '1' } : undefined;
+    return firstValueFrom(
+      this.http.get<RequestsPage>(
+        '/api/requests',
+        headers ? { params: httpParams, headers } : { params: httpParams },
+      ),
+    );
   }
 
   remove(id: number) {

--- a/client/src/app/core/services/home-settings.service.ts
+++ b/client/src/app/core/services/home-settings.service.ts
@@ -102,6 +102,17 @@ export class HomeSettingsService {
     this.persist({ ...this.settings(), recentlyAddedMode });
   }
 
+  /** Reset zone order + visibility to defaults (built-ins visible in their
+   *  canonical order; permission-gated and per-library zones fall back to
+   *  their default placement via {@link resolve}). Leaves the recently-added
+   *  mode untouched. */
+  resetLayout(): void {
+    this.persist({
+      ...this.settings(),
+      order: DEFAULTS.order.map((p) => ({ ...p })),
+    });
+  }
+
   /**
    * Reconcile the saved order with what's actually available now: keep the
    * saved order for still-present zones, append any missing built-ins (default
@@ -133,10 +144,14 @@ export class HomeSettingsService {
         seen.add(key);
       }
     }
-    // Permission-gated built-in: only offered when the user can use requests,
-    // visible by default, appended after the other built-ins.
+    // Permission-gated built-in: only offered when the user can use requests.
+    // With no saved preference it defaults visible, slotted between
+    // "recently-added" and "coming-soon"; a saved order (handled above) wins.
     if (opts.requests && !seen.has('requests-recent')) {
-      merged.push({ key: 'requests-recent', visible: true });
+      const pref: HomeSectionPref = { key: 'requests-recent', visible: true };
+      const after = merged.findIndex((p) => p.key === 'recently-added');
+      if (after >= 0) merged.splice(after + 1, 0, pref);
+      else merged.push(pref);
       seen.add('requests-recent');
     }
     for (const lib of libraries) {

--- a/client/src/app/core/services/home-settings.service.ts
+++ b/client/src/app/core/services/home-settings.service.ts
@@ -145,12 +145,12 @@ export class HomeSettingsService {
       }
     }
     // Permission-gated built-in: only offered when the user can use requests.
-    // With no saved preference it defaults visible, slotted between
-    // "recently-added" and "coming-soon"; a saved order (handled above) wins.
+    // With no saved preference it defaults visible, slotted just above
+    // "recently-added"; a saved order (handled above) wins.
     if (opts.requests && !seen.has('requests-recent')) {
       const pref: HomeSectionPref = { key: 'requests-recent', visible: true };
-      const after = merged.findIndex((p) => p.key === 'recently-added');
-      if (after >= 0) merged.splice(after + 1, 0, pref);
+      const at = merged.findIndex((p) => p.key === 'recently-added');
+      if (at >= 0) merged.splice(at, 0, pref);
       else merged.push(pref);
       seen.add('requests-recent');
     }

--- a/client/src/app/core/services/home-settings.service.ts
+++ b/client/src/app/core/services/home-settings.service.ts
@@ -8,6 +8,7 @@ export type HomeSectionKey =
   | 'recommendations'
   | 'recently-added'
   | 'coming-soon'
+  | 'requests-recent'
   | `library-recent:${number}`;
 
 export type HomeSectionType =
@@ -16,6 +17,7 @@ export type HomeSectionType =
   | 'recommendations'
   | 'recently-added'
   | 'coming-soon'
+  | 'requests-recent'
   | 'library-recent';
 
 /** What the "Recently added" zones rank by — must match the backend
@@ -106,9 +108,13 @@ export class HomeSettingsService {
    * visible) in their canonical position, append one zone per library (default
    * hidden — opt-in), and drop entries for libraries that no longer exist.
    */
-  resolve(libraries: { id: number; name: string }[]): ResolvedHomeSection[] {
+  resolve(
+    libraries: { id: number; name: string }[],
+    opts: { requests?: boolean } = {},
+  ): ResolvedHomeSection[] {
     const libName = new Map(libraries.map((l) => [l.id, l.name]));
     const available = new Set<HomeSectionKey>(BUILTIN_ORDER);
+    if (opts.requests) available.add('requests-recent');
     for (const lib of libraries) {
       available.add(`${LIBRARY_RECENT_PREFIX}${lib.id}` as HomeSectionKey);
     }
@@ -126,6 +132,12 @@ export class HomeSettingsService {
         merged.push({ key, visible: true });
         seen.add(key);
       }
+    }
+    // Permission-gated built-in: only offered when the user can use requests,
+    // visible by default, appended after the other built-ins.
+    if (opts.requests && !seen.has('requests-recent')) {
+      merged.push({ key: 'requests-recent', visible: true });
+      seen.add('requests-recent');
     }
     for (const lib of libraries) {
       const key = `${LIBRARY_RECENT_PREFIX}${lib.id}` as HomeSectionKey;

--- a/client/src/app/features/app-settings/home-settings/home-settings.html
+++ b/client/src/app/features/app-settings/home-settings/home-settings.html
@@ -7,7 +7,7 @@
         <h2 class="font-semibold">{{ 'home_settings.sections_title' | translate }}</h2>
         <p class="text-sm text-base-content/60">{{ 'home_settings.sections_hint' | translate }}</p>
       </div>
-      <button type="button" class="btn btn-ghost btn-sm shrink-0" (click)="reset()">
+      <button type="button" class="btn btn-error btn-outline btn-sm shrink-0" (click)="reset()">
         {{ 'home_settings.reset' | translate }}
       </button>
     </div>

--- a/client/src/app/features/app-settings/home-settings/home-settings.html
+++ b/client/src/app/features/app-settings/home-settings/home-settings.html
@@ -2,9 +2,14 @@
 
 <div class="card bg-base-100 border border-base-200 mb-6">
   <div class="card-body gap-4">
-    <div>
-      <h2 class="font-semibold">{{ 'home_settings.sections_title' | translate }}</h2>
-      <p class="text-sm text-base-content/60">{{ 'home_settings.sections_hint' | translate }}</p>
+    <div class="flex items-start justify-between gap-3">
+      <div>
+        <h2 class="font-semibold">{{ 'home_settings.sections_title' | translate }}</h2>
+        <p class="text-sm text-base-content/60">{{ 'home_settings.sections_hint' | translate }}</p>
+      </div>
+      <button type="button" class="btn btn-ghost btn-sm shrink-0" (click)="reset()">
+        {{ 'home_settings.reset' | translate }}
+      </button>
     </div>
 
     <div cdkDropList (cdkDropListDropped)="drop($event)" class="flex flex-col gap-2">

--- a/client/src/app/features/app-settings/home-settings/home-settings.ts
+++ b/client/src/app/features/app-settings/home-settings/home-settings.ts
@@ -60,6 +60,9 @@ export class HomeSettingsPageComponent implements OnInit {
   readonly mode = signal<RecentlyAddedMode>('media');
   readonly onlyMyRequests = signal(false);
 
+  /** Cached so reset/rebuild can re-resolve without refetching libraries. */
+  private libs: { id: number; name: string }[] = [];
+
   private readonly BUILTIN_LABELS: Record<string, string> = {
     libraries: 'home_settings.section.libraries',
     'continue-watching': 'home_settings.section.continue_watching',
@@ -72,19 +75,35 @@ export class HomeSettingsPageComponent implements OnInit {
   async ngOnInit() {
     this.mode.set(this.home.settings().recentlyAddedMode);
     this.onlyMyRequests.set(this.displaySettings.get().onlyMyRequests);
-    let libs: { id: number; name: string }[] = [];
     try {
-      libs = (await this.librariesApi.listMine()).map((l) => ({
+      this.libs = (await this.librariesApi.listMine()).map((l) => ({
         id: l.id,
         name: l.name,
       }));
     } catch {
       /* error handled by global interceptor */
     }
-    const requests =
+    this.rebuild();
+  }
+
+  private get requestsAllowed(): boolean {
+    return (
       this.auth.hasPermission('requests.create') ||
-      this.auth.hasPermission('requests.manage');
-    this.rows.set(this.home.resolve(libs, { requests }));
+      this.auth.hasPermission('requests.manage')
+    );
+  }
+
+  /** Re-derive the rendered rows from the persisted settings + current libs. */
+  private rebuild() {
+    this.rows.set(
+      this.home.resolve(this.libs, { requests: this.requestsAllowed }),
+    );
+  }
+
+  /** Reset zone order + visibility to defaults. */
+  reset() {
+    this.home.resetLayout();
+    this.rebuild();
   }
 
   /** Translation key for a built-in zone's label. */

--- a/client/src/app/features/app-settings/home-settings/home-settings.ts
+++ b/client/src/app/features/app-settings/home-settings/home-settings.ts
@@ -5,7 +5,7 @@ import {
   signal,
   OnInit,
 } from '@angular/core';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { FormsModule } from '@angular/forms';
 import {
   CdkDropList,
@@ -27,6 +27,7 @@ import {
 import { LibrariesApiService } from '../../../core/services/api/libraries-api.service';
 import { TvService } from '../../../core/services/tv.service';
 import { AuthService } from '../../../core/services/auth.service';
+import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { DisplaySettingsService } from '../../../core/services/display-settings.service';
 import { SelectFieldComponent } from '../../../shared/components/forms/select-field/select-field';
 import { ToggleFieldComponent } from '../../../shared/components/forms/toggle-field/toggle-field';
@@ -53,6 +54,8 @@ export class HomeSettingsPageComponent implements OnInit {
   private readonly librariesApi = inject(LibrariesApiService);
   private readonly displaySettings = inject(DisplaySettingsService);
   private readonly auth = inject(AuthService);
+  private readonly confirmation = inject(ConfirmationService);
+  private readonly translate = inject(TranslateService);
   readonly tv = inject(TvService);
 
   /** The rendered, reorderable rows — the working copy persisted on change. */
@@ -100,8 +103,15 @@ export class HomeSettingsPageComponent implements OnInit {
     );
   }
 
-  /** Reset zone order + visibility to defaults. */
-  reset() {
+  /** Reset zone order + visibility to defaults, after confirmation. */
+  async reset() {
+    const confirmed = await this.confirmation.confirm({
+      title: this.translate.instant('home_settings.reset_confirm_title'),
+      message: this.translate.instant('home_settings.reset_confirm'),
+      confirmLabel: this.translate.instant('home_settings.reset'),
+      variant: 'danger',
+    });
+    if (!confirmed) return;
     this.home.resetLayout();
     this.rebuild();
   }

--- a/client/src/app/features/app-settings/home-settings/home-settings.ts
+++ b/client/src/app/features/app-settings/home-settings/home-settings.ts
@@ -26,6 +26,7 @@ import {
 } from '../../../core/services/home-settings.service';
 import { LibrariesApiService } from '../../../core/services/api/libraries-api.service';
 import { TvService } from '../../../core/services/tv.service';
+import { AuthService } from '../../../core/services/auth.service';
 import { DisplaySettingsService } from '../../../core/services/display-settings.service';
 import { SelectFieldComponent } from '../../../shared/components/forms/select-field/select-field';
 import { ToggleFieldComponent } from '../../../shared/components/forms/toggle-field/toggle-field';
@@ -51,6 +52,7 @@ export class HomeSettingsPageComponent implements OnInit {
   private readonly home = inject(HomeSettingsService);
   private readonly librariesApi = inject(LibrariesApiService);
   private readonly displaySettings = inject(DisplaySettingsService);
+  private readonly auth = inject(AuthService);
   readonly tv = inject(TvService);
 
   /** The rendered, reorderable rows — the working copy persisted on change. */
@@ -64,6 +66,7 @@ export class HomeSettingsPageComponent implements OnInit {
     recommendations: 'home_settings.section.recommendations',
     'recently-added': 'home_settings.section.recently_added',
     'coming-soon': 'home_settings.section.coming_soon',
+    'requests-recent': 'home_settings.section.requests_recent',
   };
 
   async ngOnInit() {
@@ -78,7 +81,10 @@ export class HomeSettingsPageComponent implements OnInit {
     } catch {
       /* error handled by global interceptor */
     }
-    this.rows.set(this.home.resolve(libs));
+    const requests =
+      this.auth.hasPermission('requests.create') ||
+      this.auth.hasPermission('requests.manage');
+    this.rows.set(this.home.resolve(libs, { requests }));
   }
 
   /** Translation key for a built-in zone's label. */

--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -113,6 +113,26 @@
         }
       }
 
+      <!-- Recent requests (permission-gated) -->
+      @case ('requests-recent') {
+        @if (recentRequests().length) {
+          <app-horizontal-scroller [title]="'home.requests_recent' | translate">
+            @for (req of recentRequests(); track req.id) {
+              <app-request-card
+                [attr.data-home-focus]="'request:' + req.id"
+                [request]="req"
+                [canManage]="canManageRequests"
+                [qualityProfileName]="qualityProfileDisplay(req.qualityProfileId)"
+                [languageProfileName]="languageProfileDisplay(req.languageProfileId)"
+                [busy]="requestActionBusyId() === req.id"
+                (approve)="approveRequest($event)"
+                (decline)="openDecline($event)"
+              />
+            }
+          </app-horizontal-scroller>
+        }
+      }
+
       <!-- Recently Added — per library (opt-in) -->
       @case ('library-recent') {
         @if (libraryRecent().get(section.libraryId!)?.length) {
@@ -136,3 +156,12 @@
   }
 
 </div>
+
+<app-request-decline-modal
+  [requestId]="declineForId()"
+  [reasonText]="declineReasonText()"
+  [submitBusy]="requestActionBusyId() === declineForId()"
+  (reasonTextChange)="declineReasonText.set($event)"
+  (dismissed)="closeDecline()"
+  (submitted)="submitDecline()"
+/>

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject, signal, computed, effect, OnInit, OnDestroy, Injector, afterNextRender } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, signal, computed, effect, OnInit, OnDestroy, Injector, afterNextRender, viewChild } from '@angular/core';
 import { ActivatedRoute, NavigationStart, Router, RouterLink } from '@angular/router';
 import { Subscription, filter } from 'rxjs';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
@@ -6,6 +6,8 @@ import { TranslateModule } from '@ngx-translate/core';
 import { MediaService, Media, CalendarEntry } from '../../core/services/api/media.service';
 import { StreamingApiService, ContinueWatchingItem, RecommendationItem } from '../../core/services/api/streaming-api.service';
 import { LibrariesApiService, LibrarySummary } from '../../core/services/api/libraries-api.service';
+import { RequestsService, FliksRequestRow } from '../../core/services/api/requests.service';
+import { ProfilesService } from '../../core/services/api/profiles.service';
 import { ConfirmationService } from '../../core/services/confirmation.service';
 import { PlayableMediaService } from '../../core/services/playable-media.service';
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
@@ -21,6 +23,8 @@ import { LucideIconComponent } from '../../shared/components/lucide-icon';
 import { SetupChecklistComponent } from '../../shared/components/setup-checklist/setup-checklist';
 import { TvSectionDirective } from '../../shared/directives/tv-section.directive';
 import { AuthService } from '../../core/services/auth.service';
+import { RequestCardComponent } from '../requests/request-card/request-card';
+import { RequestDeclineModalComponent } from '../requests/request-decline-modal/request-decline-modal.component';
 
 /**
  * # Home page
@@ -64,6 +68,8 @@ import { AuthService } from '../../core/services/auth.service';
     LucideIconComponent,
     SetupChecklistComponent,
     TvSectionDirective,
+    RequestCardComponent,
+    RequestDeclineModalComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './home.html',
@@ -75,6 +81,8 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly router = inject(Router);
   private readonly playableMedia = inject(PlayableMediaService);
   private readonly librariesApi = inject(LibrariesApiService);
+  private readonly requestsService = inject(RequestsService);
+  private readonly profilesApi = inject(ProfilesService);
   private readonly scrollMemory = inject(ScrollMemoryService);
   private readonly focusMemory = inject(FocusMemoryService);
   private readonly navbar = inject(NavbarService);
@@ -94,6 +102,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   private navStartSub?: Subscription;
   private attachedSub?: Subscription;
   private detachedSub?: Subscription;
+  private readonly declineModal = viewChild(RequestDeclineModalComponent);
 
   readonly libraries = signal<LibrarySummary[]>([]);
   readonly continueWatching = signal<ContinueWatchingItem[]>([]);
@@ -102,15 +111,48 @@ export class HomeComponent implements OnInit, OnDestroy {
   readonly recommendations = signal<RecommendationItem[]>([]);
   /** Recently-added items per library, keyed by library id (opt-in zones). */
   readonly libraryRecent = signal<Map<number, Media[]>>(new Map());
+  /** Latest requests (scoped to rights by the backend) for the optional
+   *  "Demandes récentes" zone. */
+  readonly recentRequests = signal<FliksRequestRow[]>([]);
+  readonly requestActionBusyId = signal<number | null>(null);
+  readonly declineForId = signal<number | null>(null);
+  readonly declineReasonText = signal('');
+  private qualityProfileNames = signal<Map<number, string>>(new Map());
+  private languageProfileNames = signal<Map<number, string>>(new Map());
+
+  /** Whether the user may have requests at all (own via create, or all via
+   *  manage) — gates the "Demandes récentes" zone in home + settings. */
+  get requestsAllowed(): boolean {
+    return (
+      this.auth.hasPermission('requests.create') ||
+      this.auth.hasPermission('requests.manage')
+    );
+  }
+  /** Managers can approve/decline and see the requester. */
+  get canManageRequests(): boolean {
+    return this.auth.hasPermission('requests.manage');
+  }
 
   /** The user's resolved home layout (order + visibility), reconciled with
    *  the libraries they can currently access. Drives template rendering. */
   readonly sections = computed(() =>
-    this.home.resolve(this.libraries().map((l) => ({ id: l.id, name: l.name }))),
+    this.home.resolve(
+      this.libraries().map((l) => ({ id: l.id, name: l.name })),
+      { requests: this.requestsAllowed },
+    ),
   );
   readonly visibleSections = computed(() =>
     this.sections().filter((s) => s.visible),
   );
+
+  qualityProfileDisplay(id: number | null): string {
+    if (id == null) return '—';
+    return this.qualityProfileNames().get(id) ?? `#${id}`;
+  }
+  languageProfileDisplay(id: number | null): string {
+    if (id == null) return '—';
+    return this.languageProfileNames().get(id) ?? `#${id}`;
+  }
 
   /** Once the recommendations land, randomise the page background
    *  using their fanarts (primary + extras). One pick per visit;
@@ -171,6 +213,9 @@ export class HomeComponent implements OnInit, OnDestroy {
   async ngOnInit() {
     this.arrivedViaBack = this.navbar.lastWasBack();
     this.scrollMemory.activate(HomeComponent.SCROLL_KEY);
+    // Profile names for the request cards are resolved client-side (same as
+    // the requests page); load them once for users who can have requests.
+    if (this.requestsAllowed) void this.loadRequestProfiles();
     // Each section guards itself with `@if (().length)` so sections paint
     // independently as their data arrives. No global loading gate.
     await this.loadAllSections();
@@ -304,9 +349,12 @@ export class HomeComponent implements OnInit, OnDestroy {
     const libSections = this.visibleSections().filter(
       (s) => s.type === 'library-recent' && s.libraryId != null,
     );
+    const wantRequests = this.visibleSections().some(
+      (s) => s.type === 'requests-recent',
+    );
 
     try {
-      const [recent, calendar, libEntries] = await Promise.all([
+      const [recent, calendar, libEntries, requests] = await Promise.all([
         this.mediaService.getRecentlyAdded(
           {
             mode,
@@ -334,9 +382,16 @@ export class HomeComponent implements OnInit, OnDestroy {
               .catch(() => [s.libraryId as number, [] as Media[]] as const),
           ),
         ),
+        wantRequests
+          ? this.requestsService
+              .list({ limit: 12 }, { force })
+              .then((r) => r.data)
+              .catch(() => null)
+          : Promise.resolve(null),
       ]);
       this.recentMedia.set(recent);
       this.libraryRecent.set(new Map(libEntries));
+      if (requests) this.recentRequests.set(requests);
       const upcoming = calendar
         .filter((e) => !e.hasFile && (e.event === 'digital' || e.event === 'airing' || e.event === 'release'))
         .sort((a, b) => a.date.localeCompare(b.date));
@@ -349,6 +404,63 @@ export class HomeComponent implements OnInit, OnDestroy {
         }),
       );
     } catch { /* ignore */ }
+  }
+
+  private async loadRequestProfiles() {
+    try {
+      const [qp, lp] = await Promise.all([
+        this.profilesApi.getQualityProfiles(),
+        this.profilesApi.getLanguageProfiles(),
+      ]);
+      this.qualityProfileNames.set(new Map(qp.map((p) => [p.id, p.name])));
+      this.languageProfileNames.set(new Map(lp.map((p) => [p.id, p.name])));
+    } catch {
+      /* profiles optional — cards fall back to "#id" */
+    }
+  }
+
+  async approveRequest(id: number) {
+    this.requestActionBusyId.set(id);
+    try {
+      this.patchRequest(await this.requestsService.approve(id));
+    } catch {
+      /* global error toast */
+    } finally {
+      this.requestActionBusyId.set(null);
+    }
+  }
+
+  openDecline(id: number) {
+    this.declineForId.set(id);
+    this.declineReasonText.set('');
+    this.declineModal()?.showModal();
+  }
+
+  closeDecline() {
+    this.declineModal()?.close();
+    this.declineForId.set(null);
+  }
+
+  async submitDecline() {
+    const id = this.declineForId();
+    if (id == null) return;
+    this.requestActionBusyId.set(id);
+    try {
+      this.patchRequest(
+        await this.requestsService.decline(id, this.declineReasonText()),
+      );
+      this.closeDecline();
+    } catch {
+      /* global error toast */
+    } finally {
+      this.requestActionBusyId.set(null);
+    }
+  }
+
+  private patchRequest(updated: FliksRequestRow) {
+    this.recentRequests.update((list) =>
+      list.map((r) => (r.id === updated.id ? updated : r)),
+    );
   }
 
   /**

--- a/client/src/app/features/requests/request-card/request-card.html
+++ b/client/src/app/features/requests/request-card/request-card.html
@@ -1,0 +1,83 @@
+<div class="relative w-72 sm:w-80 shrink-0 overflow-hidden rounded-box border border-base-200 bg-base-100 shadow-md">
+  <!-- Fanart backdrop + dimming gradient so the overlaid text stays legible. -->
+  <div class="absolute inset-0" aria-hidden="true">
+    <app-request-poster
+      class="absolute inset-0"
+      [tmdbId]="request().tmdbId"
+      [mediaType]="request().mediaType"
+      mode="backdrop"
+    />
+    <div class="absolute inset-0 bg-gradient-to-br from-base-100/55 via-base-100/80 to-base-100"></div>
+  </div>
+
+  <div class="relative flex flex-col gap-1.5 p-4">
+    <h3 class="text-lg font-semibold leading-snug line-clamp-1 m-0">
+      <a [routerLink]="mediaLink()" class="link link-hover text-base-content hover:opacity-80">
+        {{ request().media?.title || request().title }}
+      </a>
+    </h3>
+
+    <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-base-content/70">
+      <span class="badge badge-sm whitespace-nowrap" [class]="statusBadgeClass(request().status)">
+        {{ ('requests.status.' + request().status) | translate }}
+      </span>
+      <span>
+        @if (request().mediaType === 'movie') {
+          {{ 'requests.type_movie' | translate }}
+        } @else {
+          {{ 'requests.type_series' | translate }}
+        }
+      </span>
+    </div>
+
+    @if (request().mediaType === 'series' && request().seasons?.length) {
+      <p class="text-sm text-base-content/70 m-0">
+        <span class="text-base-content/50">{{ 'requests.seasons_label' | translate }} · </span>
+        {{ request().seasons?.join(', ') }}
+      </p>
+    }
+
+    @if (canManage()) {
+      <p class="text-sm text-base-content/70 m-0">
+        <span class="text-base-content/50">{{ 'requests.requested_by' | translate }}</span>
+        <span class="font-medium text-base-content">{{ request().user.username }}</span>
+      </p>
+    }
+
+    <div class="flex flex-col gap-0.5 text-xs text-base-content/65">
+      <p class="m-0">
+        <span class="text-base-content/50">{{ 'requests.date_label' | translate }}</span>
+        {{ request().createdAt | date: 'short' }}
+      </p>
+      <p class="m-0">
+        <span class="text-base-content/50">{{ 'discover.quality_profile' | translate }} · </span>
+        {{ qualityProfileName() }}
+      </p>
+      <p class="m-0">
+        <span class="text-base-content/50">{{ 'discover.language_profile' | translate }} · </span>
+        {{ languageProfileName() }}
+      </p>
+    </div>
+
+    @if (canManage() && request().status === 'pending') {
+      <div class="mt-2 flex gap-2">
+        <button
+          type="button"
+          class="btn btn-success btn-sm flex-1"
+          [disabled]="busy()"
+          (click)="approve.emit(request().id)"
+        >
+          {{ 'requests.approve' | translate }}
+        </button>
+        <button
+          type="button"
+          class="btn btn-warning btn-sm flex-1"
+          [disabled]="busy()"
+          (click)="decline.emit(request().id)"
+        >
+          {{ 'requests.decline' | translate }}
+        </button>
+      </div>
+    }
+  </div>
+</div>

--- a/client/src/app/features/requests/request-card/request-card.html
+++ b/client/src/app/features/requests/request-card/request-card.html
@@ -1,4 +1,4 @@
-<div class="relative w-72 sm:w-80 shrink-0 overflow-hidden rounded-box border border-base-200 bg-base-100 shadow-md">
+<div class="relative flex flex-1 flex-col overflow-hidden rounded-box border border-base-200 bg-base-100 shadow-md">
   <!-- Fanart backdrop + dimming gradient so the overlaid text stays legible. -->
   <div class="absolute inset-0" aria-hidden="true">
     <app-request-poster
@@ -10,7 +10,7 @@
     <div class="absolute inset-0 bg-gradient-to-br from-base-100/55 via-base-100/80 to-base-100"></div>
   </div>
 
-  <div class="relative flex flex-col gap-1.5 p-4">
+  <div class="relative flex flex-1 flex-col gap-1.5 p-4">
     <h3 class="text-lg font-semibold leading-snug line-clamp-1 m-0">
       <a [routerLink]="mediaLink()" class="link link-hover text-base-content hover:opacity-80">
         {{ request().media?.title || request().title }}
@@ -60,7 +60,7 @@
     </div>
 
     @if (canManage() && request().status === 'pending') {
-      <div class="mt-2 flex gap-2">
+      <div class="mt-auto pt-2 flex gap-2">
         <button
           type="button"
           class="btn btn-success btn-sm flex-1"

--- a/client/src/app/features/requests/request-card/request-card.ts
+++ b/client/src/app/features/requests/request-card/request-card.ts
@@ -24,6 +24,9 @@ import {
   selector: 'app-request-card',
   imports: [DatePipe, RouterLink, TranslateModule, RequestPosterComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  // The host is the scroller flex item: fixed width, and a column flex so the
+  // inner card fills the row's stretched height (all cards same height).
+  host: { class: 'flex shrink-0 w-72 sm:w-80' },
   templateUrl: './request-card.html',
 })
 export class RequestCardComponent {

--- a/client/src/app/features/requests/request-card/request-card.ts
+++ b/client/src/app/features/requests/request-card/request-card.ts
@@ -1,0 +1,68 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output,
+} from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { RequestPosterComponent } from '../request-poster';
+import {
+  FliksRequestRow,
+  FliksRequestStatus,
+} from '../../../core/services/api/requests.service';
+
+/**
+ * Compact request card for the home "Demandes récentes" scroller: a fanart
+ * backdrop with the request summary overlaid and (for managers, on pending
+ * requests) Approuver / Refuser actions. The parent owns data + actions and
+ * resolves the profile names; this card is presentational.
+ */
+@Component({
+  selector: 'app-request-card',
+  imports: [DatePipe, RouterLink, TranslateModule, RequestPosterComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './request-card.html',
+})
+export class RequestCardComponent {
+  readonly request = input.required<FliksRequestRow>();
+  readonly canManage = input(false);
+  readonly qualityProfileName = input('—');
+  readonly languageProfileName = input('—');
+  readonly busy = input(false);
+
+  readonly approve = output<number>();
+  readonly decline = output<number>();
+
+  /** Route to the linked media, or to the add page when not yet imported.
+   *  Mirrors `RequestsComponent.mediaLink`. */
+  readonly mediaLink = computed<(string | number)[]>(() => {
+    const r = this.request();
+    const id = r.media?.id;
+    if (id) {
+      return r.mediaType === 'movie' ? ['/movies', id] : ['/series', id];
+    }
+    return r.mediaType === 'movie'
+      ? ['/add', 'movie', r.tmdbId]
+      : ['/add', 'tv', r.tmdbId];
+  });
+
+  statusBadgeClass(status: FliksRequestStatus): string {
+    switch (status) {
+      case 'pending':
+        return 'badge-warning';
+      case 'approved':
+      case 'available':
+        return 'badge-success';
+      case 'declined':
+      case 'failed':
+        return 'badge-error';
+      case 'processing':
+        return 'badge-info';
+      default:
+        return 'badge-ghost';
+    }
+  }
+}


### PR DESCRIPTION
Adds a new home zone **"Demandes récentes"** showing the latest media requests, scoped to the user's rights.

## What's new
- **New compact `RequestCardComponent`** (fanart backdrop + status badge, requester, date, quality/language profiles) sized for the horizontal scroller — matches the requested card style. Managers get **Approuver / Refuser** on pending cards; Refuser reuses the existing `app-request-decline-modal`.
- **Permission-gated zone**: offered (home + App settings → Accueil) only to users with `requests.create` or `requests.manage`. Managers see all requests; requesters see their own (no actions, no "Demandé par").
- **Visible by default** for permitted users, **slotted between "Recently added" and "Coming soon"** when there's no saved layout; reorderable/hideable like the other zones (a saved order wins).
- **Reset button** in the "Zones de l'accueil" settings section → restores default zone order + visibility (mode left untouched).

## Backend
**None.** `GET /requests?limit=N` already orders by `createdAt DESC` and is permission-scoped (own vs all). Profile names are resolved client-side like the requests page. `RequestsService.list()` gains a `force` passthrough so a return-to-home re-attach revalidates request statuses.

## Verification
- `cd client && npx ng build` clean (only the pre-existing shaka-player CommonJS warning).
- Manual: as a **manager**, the row shows pending cards → Approuver flips to approved, Refuser opens the reason modal. As a **requester** (create-only), own requests show without action buttons. As a user **without request rights**, the row is absent. Toggle/reorder/reset from App settings → Accueil.

Refs: #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)