### PR TITLE
fix(media-detail): compact header on mobile landscape + clamp synopsis

### DIFF
--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -95,7 +95,7 @@
           <app-horizontal-scroller [title]="'media_detail.other_seasons_of' | translate:{ title: m.title }">
             @for (other of otherSeasons(); track other.id) {
               <app-media-card
-                class="shrink-0 w-28 sm:w-40"
+                class="shrink-0 w-28 sm:w-32 lg:w-40"
                 [aspect]="'portrait'"
                 [imageUrl]="other.posterUrl ?? m.posterUrl"
                 [title]="('media_detail.season' | translate) + ' ' + other.seasonNumber"

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -150,11 +150,12 @@
     class="flex gap-6 lg:gap-10 relative z-20 tv:pt-24!"
     [style.padding-top]="!navbar.isHeroPage() || navbar.effectiveSidebarPinned() ? null : navbar.mobileNavbarVisible() ? 'calc(env(safe-area-inset-top, 0px) + 3rem)' : null"
   >
-    <!-- Poster / Still (desktop only). Smaller poster on the lg-to-xl range
-         (sidebar pinned + tablet/desktop window) so the content next to it
-         keeps room to breathe; full 280 px from xl up. -->
+    <!-- Poster / Still (desktop only). Compact on the md-to-lg range (landscape
+         phones / small windows) so the title keeps room in a short viewport;
+         200 px from lg, 220 from xl, full 280 px from 2xl up. -->
     <div class="shrink-0"
-         [class.w-[200px]]="posterMode() === 'poster'"
+         [class.w-[140px]]="posterMode() === 'poster'"
+         [class.lg:w-[200px]]="posterMode() === 'poster'"
          [class.xl:w-[220px]]="posterMode() === 'poster'"
          [class.2xl:w-[280px]]="posterMode() === 'poster'"
          [class.w-[20%]]="posterMode() === 'still'">
@@ -181,7 +182,7 @@
 
     <div class="flex-1 min-w-0 pt-2">
       <!-- Title -->
-      <h1 class="text-4xl font-bold tracking-tight">
+      <h1 class="text-2xl lg:text-4xl font-bold tracking-tight">
         @if (episodeLabel()) {
           <a [routerLink]="backRoute()" class="hover:underline rounded">{{ title() }}</a>
         } @else {
@@ -308,7 +309,14 @@
 
       <!-- Overview -->
       @if (overview()) {
-        <p class="mt-4 text-base-content/90 leading-relaxed whitespace-pre-line">{{ overview() }}</p>
+        <p #overviewText
+           class="mt-4 text-base-content/90 leading-relaxed whitespace-pre-line"
+           [class.line-clamp-4]="!overviewExpanded()">{{ overview() }}</p>
+        @if (overviewClamped() || overviewExpanded()) {
+          <button type="button" class="link link-primary no-underline hover:underline text-sm mt-1" (click)="toggleOverview()">
+            {{ (overviewExpanded() ? 'common.show_less' : 'common.show_more') | translate }}
+          </button>
+        }
       }
 
     </div>

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -8,7 +8,7 @@ import {
   input,
   output,
   signal,
-  viewChild,
+  viewChildren,
 } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
@@ -201,8 +201,10 @@ export class MediaInfoHeaderComponent {
   readonly selectedAudioIndex = signal<number | null>(null);
   readonly selectedSubtitleId = signal<string | null>(null);
 
-  // Mobile overview clamp / expand
-  private readonly overviewTextRef = viewChild<ElementRef<HTMLParagraphElement>>('overviewText');
+  // Overview clamp / expand. The mobile and desktop layouts each render an
+  // `#overviewText` paragraph (both live in the DOM; CSS hides one), so we
+  // measure whichever is actually on screen.
+  private readonly overviewTextRefs = viewChildren<ElementRef<HTMLParagraphElement>>('overviewText');
   readonly overviewClamped = signal(false);
   readonly overviewExpanded = signal(false);
 
@@ -211,7 +213,10 @@ export class MediaInfoHeaderComponent {
     this.overview();
     this.overviewExpanded.set(false);
     requestAnimationFrame(() => {
-      const el = this.overviewTextRef()?.nativeElement;
+      const refs = this.overviewTextRefs();
+      const el =
+        refs.map((r) => r.nativeElement).find((n) => n.offsetParent !== null) ??
+        refs[0]?.nativeElement;
       if (el) this.overviewClamped.set(el.scrollHeight > el.clientHeight + 1);
       else this.overviewClamped.set(false);
     });


### PR DESCRIPTION
On the media-detail page, the side-by-side header layout starts at `md` (768px), so a **phone in landscape** rendered an oversized poster (200px) and a `text-4xl` title in a short viewport.

- **Poster**: `w-140` on the md→lg range, restored to `200/220/280px` at `lg/xl/2xl`.
- **Title**: `text-2xl` on md→lg, `text-4xl` at `lg`.
- **Synopsis**: the desktop layout now has the same **"Voir plus / Voir moins"** clamp the mobile layout already had. Both layouts render an `#overviewText` paragraph (both live in the DOM, CSS hides one), so the clamp effect now measures whichever is actually on screen (`viewChildren` + `offsetParent` check).

`ng build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)