### PR TITLE
feat(media): cascade monitored toggle to seasons and episodes

### DIFF
--- a/backend/src/modules/media/media-service/media-mutation.service.spec.ts
+++ b/backend/src/modules/media/media-service/media-mutation.service.spec.ts
@@ -1,0 +1,143 @@
+import { MediaMutationService } from './media-mutation.service';
+import { Season } from '../entities/season.entity';
+
+/**
+ * Records the chainable `.update().set().where().execute()` calls a TypeORM
+ * query builder receives so a test can assert which bulk UPDATEs were issued.
+ */
+interface QueryBuilderRecorder {
+  set?: Record<string, unknown>;
+  where?: { clause: string; params?: Record<string, unknown> };
+  executed: boolean;
+}
+
+function fakeRepoWithBuilder(recorders: QueryBuilderRecorder[]) {
+  return {
+    createQueryBuilder: jest.fn(() => {
+      const rec: QueryBuilderRecorder = { executed: false };
+      recorders.push(rec);
+      const builder = {
+        update: () => builder,
+        set: (v: Record<string, unknown>) => {
+          rec.set = v;
+          return builder;
+        },
+        where: (clause: string, params?: Record<string, unknown>) => {
+          rec.where = { clause, params };
+          return builder;
+        },
+        whereInIds: () => builder,
+        execute: () => {
+          rec.executed = true;
+          return Promise.resolve({ affected: 1 });
+        },
+      };
+      return builder;
+    }),
+  };
+}
+
+describe('MediaMutationService monitoring cascade', () => {
+  let seasonRecorders: QueryBuilderRecorder[];
+  let episodeRecorders: QueryBuilderRecorder[];
+  let seasonRepo: ReturnType<typeof fakeRepoWithBuilder> & {
+    findOne: jest.Mock;
+    save: jest.Mock;
+  };
+  let episodeRepo: ReturnType<typeof fakeRepoWithBuilder>;
+  let mediaRepo: { save: jest.Mock };
+  let query: { findOne: jest.Mock };
+  let metadata: { updateSearchVector: jest.Mock };
+  let requestLifecycle: {
+    onMediaMonitorChange: jest.Mock;
+    onSeasonMonitorChange: jest.Mock;
+  };
+  let service: MediaMutationService;
+
+  beforeEach(() => {
+    seasonRecorders = [];
+    episodeRecorders = [];
+    seasonRepo = {
+      ...fakeRepoWithBuilder(seasonRecorders),
+      findOne: jest.fn(),
+      save: jest.fn(),
+    };
+    episodeRepo = fakeRepoWithBuilder(episodeRecorders);
+    mediaRepo = { save: jest.fn(async (m: unknown) => m) };
+    query = { findOne: jest.fn() };
+    metadata = { updateSearchVector: jest.fn() };
+    requestLifecycle = {
+      onMediaMonitorChange: jest.fn(),
+      onSeasonMonitorChange: jest.fn(),
+    };
+
+    service = new MediaMutationService(
+      mediaRepo as never,
+      seasonRepo as never,
+      episodeRepo as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      query as never,
+      metadata as never,
+      requestLifecycle as never,
+    );
+  });
+
+  it('cascades a series monitored toggle to its seasons and episodes', async () => {
+    query.findOne.mockResolvedValue({ id: 7, monitored: true });
+
+    await service.update(7, { monitored: false });
+
+    expect(seasonRecorders).toHaveLength(1);
+    expect(seasonRecorders[0].set).toEqual({ monitored: false });
+    expect(seasonRecorders[0].where?.params).toEqual({ mediaIds: [7] });
+    expect(seasonRecorders[0].executed).toBe(true);
+
+    expect(episodeRecorders).toHaveLength(1);
+    expect(episodeRecorders[0].set).toEqual({ monitored: false });
+    expect(episodeRecorders[0].where?.clause).toContain('seasons');
+    expect(episodeRecorders[0].executed).toBe(true);
+  });
+
+  it('does not cascade when the media update omits monitored', async () => {
+    query.findOne.mockResolvedValue({ id: 7, monitored: true });
+
+    await service.update(7, { title: 'x' } as never);
+
+    expect(seasonRecorders).toHaveLength(0);
+    expect(episodeRecorders).toHaveLength(0);
+  });
+
+  it('cascades a season monitored toggle to its episodes', async () => {
+    seasonRepo.findOne.mockResolvedValue({
+      id: 3,
+      seasonNumber: 2,
+      monitored: true,
+      media: { id: 7 },
+    });
+    seasonRepo.save.mockImplementation(async (s: Season) => s);
+
+    await service.updateSeason(3, { monitored: false });
+
+    expect(episodeRecorders).toHaveLength(1);
+    expect(episodeRecorders[0].set).toEqual({ monitored: false });
+    expect(episodeRecorders[0].where?.params).toEqual({ seasonId: 3 });
+    expect(episodeRecorders[0].executed).toBe(true);
+  });
+
+  it('does not cascade a season provider-only change to episodes', async () => {
+    seasonRepo.findOne.mockResolvedValue({
+      id: 3,
+      seasonNumber: 2,
+      monitored: true,
+      media: { id: 7 },
+    });
+    seasonRepo.save.mockImplementation(async (s: Season) => s);
+
+    await service.updateSeason(3, { preferredProvider: 'tvdb' });
+
+    expect(episodeRecorders).toHaveLength(0);
+  });
+});

--- a/backend/src/modules/media/media-service/media-mutation.service.ts
+++ b/backend/src/modules/media/media-service/media-mutation.service.ts
@@ -55,9 +55,42 @@ export class MediaMutationService {
     Object.assign(media, rest);
 
     const saved = await this.mediaRepo.save(media);
+    if (dto.monitored !== undefined) {
+      await this.cascadeMonitoredToChildren([saved.id], dto.monitored);
+    }
     await this.metadata.updateSearchVector(saved.id);
     await this.requestLifecycle.onMediaMonitorChange(saved, wasMonitored);
     return this.query.findOne(saved.id);
+  }
+
+  /**
+   * Propagate a series' monitored flag down to every season and episode it
+   * owns. Toggling monitoring on a series (or season) is an all-or-nothing
+   * intent: the children inherit the new state so the library doesn't keep
+   * grabbing episodes under an unmonitored series. A no-op for movies, which
+   * own no seasons. Plain bulk UPDATEs keep it to two statements regardless of
+   * how many episodes the series has.
+   */
+  private async cascadeMonitoredToChildren(
+    mediaIds: number[],
+    monitored: boolean,
+  ): Promise<void> {
+    if (mediaIds.length === 0) return;
+    await this.seasonRepo
+      .createQueryBuilder()
+      .update(Season)
+      .set({ monitored })
+      .where('"mediaId" IN (:...mediaIds)', { mediaIds })
+      .execute();
+    await this.episodeRepo
+      .createQueryBuilder()
+      .update(Episode)
+      .set({ monitored })
+      .where(
+        '"seasonId" IN (SELECT id FROM seasons WHERE "mediaId" IN (:...mediaIds))',
+        { mediaIds },
+      )
+      .execute();
   }
 
   /**
@@ -153,6 +186,10 @@ export class MediaMutationService {
       .whereInIds(dto.ids)
       .execute();
 
+    if (dto.monitored !== undefined) {
+      await this.cascadeMonitoredToChildren(dto.ids, dto.monitored);
+    }
+
     return { updated: result.affected ?? 0 };
   }
 
@@ -182,6 +219,14 @@ export class MediaMutationService {
     if (patch.preferredProvider !== undefined)
       season.preferredProvider = patch.preferredProvider;
     const saved = await this.seasonRepo.save(season);
+    if (patch.monitored !== undefined) {
+      await this.episodeRepo
+        .createQueryBuilder()
+        .update(Episode)
+        .set({ monitored: patch.monitored })
+        .where('"seasonId" = :seasonId', { seasonId })
+        .execute();
+    }
     if (season.media) {
       await this.requestLifecycle.onSeasonMonitorChange(
         season.media,

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -951,7 +951,15 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     try {
       const updated = await this.mediaService.toggleMonitored(m.id, !m.monitored);
       this.media.set(updated);
-      if (updated.type === 'series') this.syncActiveSeasonForSeriesFilter();
+      if (updated.type === 'series') {
+        this.syncActiveSeasonForSeriesFilter();
+        const open = this.episodeDrawerContext();
+        if (open) {
+          const s = updated.seasons?.find((x) => x.id === open.season.id);
+          const e = s?.episodes.find((x) => x.id === open.episode.id);
+          if (s && e) this.episodeDrawerContext.set({ season: s, episode: e });
+        }
+      }
     } finally {
       this.monitoredLoading.set(false);
     }
@@ -1252,13 +1260,26 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       const updated = await this.mediaService.updateSeasonMonitored(season.id, !season.monitored);
       const m = this.media();
       if (!m?.seasons) return;
-      this.media.set({
-        ...m,
-        seasons: m.seasons.map((s) =>
-          s.id === updated.id ? { ...s, monitored: updated.monitored } : s,
-        ),
-      });
+      const nextSeasons = m.seasons.map((s) =>
+        s.id === updated.id
+          ? {
+              ...s,
+              monitored: updated.monitored,
+              episodes: s.episodes.map((e) => ({
+                ...e,
+                monitored: updated.monitored,
+              })),
+            }
+          : s,
+      );
+      this.media.set({ ...m, seasons: nextSeasons });
       this.syncActiveSeasonForSeriesFilter();
+      const open = this.episodeDrawerContext();
+      if (open?.season.id === updated.id) {
+        const s = nextSeasons.find((x) => x.id === updated.id);
+        const e = s?.episodes.find((x) => x.id === open.episode.id);
+        if (s && e) this.episodeDrawerContext.set({ season: s, episode: e });
+      }
     } finally {
       this.seasonBusy.set(null);
     }


### PR DESCRIPTION
## What

Toggling the **monitored** flag on a series or a season now cascades:

- **Series → all its seasons and episodes**
- **Season → all its episodes**

## Why

Previously each toggle updated only its own row. Unmonitoring a series left
its seasons/episodes monitored, so the library kept grabbing episodes the
admin meant to stop. A monitored toggle is an all-or-nothing intent, so the
children should inherit the new state.

## How

- `MediaMutationService.update` (series) and `updateSeason` (season) propagate
  the flag via bulk `UPDATE`s — two statements regardless of episode count.
- `bulkUpdate` (multi-select monitored toggle from the library) cascades too,
  for consistency.
- Movies own no seasons → no-op.
- Frontend: the series detail endpoint re-reads the full tree, so the series
  toggle reflects the cascade automatically. The season toggle and any open
  episode drawer are reconciled client-side.

## Tests

Added `media-mutation.service.spec.ts` covering: series cascade, season
cascade, and the no-cascade paths (media update without `monitored`, season
provider-only change). Full backend suite green (94 tests).