### PR TITLE
fix(player): clean session-recovery reload (spinner, prewarmed resume)

### DIFF
--- a/client/src/app/core/services/player-state.service.ts
+++ b/client/src/app/core/services/player-state.service.ts
@@ -34,14 +34,27 @@ export class PlayerStateService {
 
   private engine: PlaybackEngine | null = null;
 
+  /** True while a lost-session recovery is re-minting the sid and reloading
+   *  the engine. The reload tears the current stream down, so the engine
+   *  briefly emits a fatal error (Shaka's `<video>` element error, ExoPlayer's
+   *  one-shot error bridge) that recovery is about to resolve. While set, that
+   *  error surfaces as buffering — the spinner — instead of the terminal
+   *  "Playback error" overlay. Owned by PlayerComponent's recovery flow. */
+  private recovering = false;
+
+  setRecovering(value: boolean): void {
+    this.recovering = value;
+    if (value) this.error.set(null);
+  }
+
   /** Bind a playback engine's events to our signals. Call this when the engine changes. */
   bindEngine(engine: PlaybackEngine): void {
     this.engine = engine;
 
     engine.on('stateChanged', (e) => {
       this.paused.set(e.state === 'paused' || e.state === 'idle');
-      this.buffering.set(e.state === 'buffering');
-      if (e.state === 'error') this.error.set('Playback error');
+      this.buffering.set(e.state === 'buffering' || (this.recovering && e.state === 'error'));
+      if (e.state === 'error' && !this.recovering) this.error.set('Playback error');
       // videoStarted is intentionally NOT flipped here — Shaka emits 'playing'
       // on DOM 'play' (= play() called), well before the first frame is
       // actually painted. PlayerComponent owns the flip per engine: rvfc on
@@ -56,6 +69,10 @@ export class PlayerStateService {
     });
 
     engine.on('error', (e) => {
+      if (this.recovering) {
+        this.buffering.set(true);
+        return;
+      }
       this.error.set(e.message);
     });
   }

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -2211,7 +2211,11 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // EXCLUSION: the Tizen Return key (keyCode 10009 / `XF86Back`) must
     // bubble up to the window-level handler in `app.ts` — otherwise the
     // user can't exit the player. Same for `Escape` on dev keyboards.
-    const isBackKey = e.keyCode === 10009 || e.key === 'XF86Back' || e.key === 'GoBack' || e.key === 'Escape';
+    // Tizen reports 10009 with no reliable `e.key` on older firmware, so the
+    // legacy code stays load-bearing; read it through a plain typed view to
+    // keep clear of the lib.dom `keyCode` deprecation.
+    const legacyKeyCode = (e as { keyCode: number }).keyCode;
+    const isBackKey = legacyKeyCode === 10009 || e.key === 'XF86Back' || e.key === 'GoBack' || e.key === 'Escape';
     if (!isBackKey && !this.controlsVisible() && this.device.isTv()) {
       this.showControls();
       e.preventDefault();

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -50,7 +50,7 @@ import { NativePlayer } from '../../core/plugins/native-player.plugin';
 import { NativeEngine } from '../../core/services/playback-engine/native-engine';
 import { PlayerStateService } from '../../core/services/player-state.service';
 import { TrackManagerService, SubtitleOption } from '../../core/services/track-manager.service';
-import { QualityManagerService, findVariantByProfileName, findBestVariantForHeight } from '../../core/services/quality-manager.service';
+import { QualityManagerService } from '../../core/services/quality-manager.service';
 import { DeviceService } from '../../core/services/device.service';
 
 interface ImmersivePlugin {
@@ -2456,15 +2456,6 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       this.activeSessionId(),
     );
     fetch(url, { method: 'DELETE', keepalive: true }).catch(() => {});
-  }
-
-  /** Find a variant track matching a quality id (e.g. '480p', 'original') by URL or height fallback. */
-  private findVariantByQualityId(qualityId: string, targetHeight: number): any | null {
-    if (!this.engine) return null;
-    const tracks = this.engine.getVariantTracks();
-    if (!tracks.length) return null;
-    return findVariantByProfileName(tracks, qualityId)
-      ?? findBestVariantForHeight(tracks, targetHeight);
   }
 
   /** Get the currently active variant track. */

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1818,12 +1818,17 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     if (opts.unmute) this.engine.muted = false;
     const wasPaused = opts.preservePause ? this.paused() : false;
     const deviceProfile = this.deviceProfileService.getProfile();
+    // Pass the active rung as startQuality so the backend prewarms ffmpeg at
+    // the resume position — main session at -ss pos plus the bounded early
+    // session that absorbs Shaka's seg-0 VOD probe. Mirrors the initial load.
+    const activeQuality = this.activeQualityId();
+    const prewarmQuality = activeQuality !== 'auto' ? activeQuality : undefined;
     this.playbackInfo = await this.streamingApi.getPlaybackInfo(
       this.mediaFileId,
       deviceProfile,
       this.activeBurnInId ?? undefined,
       this.activeAudioStreamIndex ?? undefined,
-      undefined,
+      prewarmQuality,
       pos > 0 ? Math.floor(pos) : undefined,
     );
     const { url, mimeType } = this.buildPlayUrl({

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1877,6 +1877,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     if (this.castService.isConnected()) return;
     if (!this.engine || !this.mediaFileId) return;
     this.recoveringFromLostSession = true;
+    // Suppress the fatal-error overlay the engine tears off as the stream
+    // reloads — recovery is about to resume playback, so the reload window
+    // reads as buffering, not "Playback error".
+    this.state.setRecovering(true);
     try {
       await this.refreshSidAndReload(this.engine.currentTime || 0, {
         preservePause: true,
@@ -1885,6 +1889,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     } catch { /* heartbeat is fire-and-forget; next one retries */ }
     finally {
       this.recoveringFromLostSession = false;
+      this.state.setRecovering(false);
     }
   }
 


### PR DESCRIPTION
## What

Improves the player's behaviour when a streaming session is lost mid-playback
(backend restart, idle GC, long pause → backend 410). Recovery does a clean
reload at the saved position; this makes that reload smooth and quiet.

## Changes

- **Prewarm the resume position on recovery** — `refreshSidAndReload` now passes
  the active rung as `startQuality`, so the backend prewarms ffmpeg at the
  resume point (mirrors the initial-load path). Faster pickup after a reload.
- **Suppress the fatal-error overlay during recovery** — while a recovery reload
  is in flight, an engine error surfaces as buffering (the spinner) instead of
  the terminal "Playback error" flash; cleared on entry, released when the
  reload settles, so a genuine post-recovery failure still surfaces.
- **Cleanup**: read the Tizen back key's legacy `keyCode` through a typed view
  (drops the lib.dom deprecation warning, behaviour unchanged) and remove the
  unused `findVariantByQualityId` helper + its now-orphan imports.

## Scope

Deliberately client-side only. A backend restart mid-stream is rare, so this
favours a clean reload-at-saved-position over a seamless cross-restart
continuation (which would need heavier, riskier transcode-timeline changes).
No backend/transcode changes — no risk to normal playback.

## Verification

Client + backend typecheck clean; backend suite green (94 tests).