### PR TITLE
fix(streaming): keep transcode cache to one timeline across restarts and seeks

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -170,6 +170,13 @@ async function awaitFileNonEmpty(
   return false;
 }
 
+/** Segments the early companion covers. Its ffmpeg is bound to `-t 4`
+ *  (see getOrCreateEarlySession), which at a 3 s segment grid yields seg-0
+ *  and seg-1 — the window a player's seg-0 VOD probe falls in. Requests
+ *  below this are absorbed by the early session; anything higher is a real
+ *  seek the main session handles. */
+const EARLY_PROBE_SEGMENTS = 2;
+
 /** Send a transient unavailability response. Players with sane HTTP
  *  retry policies (Shaka, Media3's loader when given a backoff)
  *  treat 503 as retryable, unlike 404 which Media3 marks as a
@@ -1549,11 +1556,31 @@ export class StreamingController {
       existing.startSegment > 0 &&
       segIndex < existing.startSegment;
     if (isEarlyProbe) {
-      const earlySession = this.resolveEarlySession(
+      let earlySession = this.resolveEarlySession(
         mediaFileId,
         req.user?.id,
         req,
       );
+      // Absorb a seg-0/seg-1 probe at the requested quality even when the
+      // prewarmed early companion is absent or on a different rung (prewarm
+      // picks a rung from the saved preference; the player may commit to
+      // another). Falling through for a segment below the main's startSegment
+      // routes it to getOrCreateSession, which relocates the forward-producing
+      // main back to that low segment. Higher segments are a genuine backward
+      // seek the main owns.
+      if (
+        segIndex < EARLY_PROBE_SEGMENTS &&
+        (!earlySession || earlySession.quality !== quality)
+      ) {
+        earlySession = await this.transcodingService
+          .getOrCreateEarlySession(
+            mediaFileId,
+            quality,
+            resolved.absolutePath,
+            ctx,
+          )
+          .catch(() => undefined);
+      }
       if (earlySession && earlySession.quality === quality) {
         const varStreamMap = live?.useExtXMedia ?? false;
         const segName = varStreamMap ? `0/${segment}` : segment;

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -1543,35 +1543,35 @@ export class StreamingController {
 
     const ctx = this.buildSessionContext(req, resolved, mediaFileId);
 
-    // Early probe routing: when Shaka requests a segment before the main
-    // session's startSegment (typical Shaka VOD behavior on resume), route
-    // to the early companion if it exists. 10 s timeout safety net — if
-    // the early session hangs we fall through to the slow path rather
-    // than blocking on a 60 s waitForSegment.
+    // Early probe routing: the seg-0/seg-1 init probe a player fires on
+    // resume must be served by the bounded early companion, never spawn or
+    // relocate the forward-producing main. The floor is the higher of the
+    // main's startSegment and the live playhead (secondsToSegmentIndex of the
+    // session position) — the playhead survives an in-memory session loss
+    // because the recovery playback-info re-seeds it, so a probe arriving
+    // after a server restart (no main yet) still routes to early instead of
+    // anchoring a fresh main at segment 0. A segment at or past the floor is a
+    // genuine seek/forward read the main owns. 10 s timeout safety net falls
+    // through to the slow path rather than blocking on a 60 s waitForSegment.
+    const resumeFloor = Math.max(
+      existing?.startSegment ?? 0,
+      live ? secondsToSegmentIndex(live.position) : 0,
+    );
     const isEarlyProbe =
       quality !== 'remux' &&
-      existing != null &&
-      existing.quality === quality &&
-      existing.startSegment != null &&
-      existing.startSegment > 0 &&
-      segIndex < existing.startSegment;
+      resumeFloor > EARLY_PROBE_SEGMENTS &&
+      segIndex < EARLY_PROBE_SEGMENTS;
     if (isEarlyProbe) {
       let earlySession = this.resolveEarlySession(
         mediaFileId,
         req.user?.id,
         req,
       );
-      // Absorb a seg-0/seg-1 probe at the requested quality even when the
-      // prewarmed early companion is absent or on a different rung (prewarm
-      // picks a rung from the saved preference; the player may commit to
-      // another). Falling through for a segment below the main's startSegment
-      // routes it to getOrCreateSession, which relocates the forward-producing
-      // main back to that low segment. Higher segments are a genuine backward
-      // seek the main owns.
-      if (
-        segIndex < EARLY_PROBE_SEGMENTS &&
-        (!earlySession || earlySession.quality !== quality)
-      ) {
+      // (Re)spawn the early companion at the requested quality when it is
+      // absent or on a different rung — prewarm picks a rung from the saved
+      // preference and the player may commit to another, leaving a stale
+      // early that the quality gate below would skip.
+      if (!earlySession || earlySession.quality !== quality) {
         earlySession = await this.transcodingService
           .getOrCreateEarlySession(
             mediaFileId,

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -1553,14 +1553,21 @@ export class StreamingController {
     // anchoring a fresh main at segment 0. A segment at or past the floor is a
     // genuine seek/forward read the main owns. 10 s timeout safety net falls
     // through to the slow path rather than blocking on a 60 s waitForSegment.
+    const isInit = segment.startsWith('init');
     const resumeFloor = Math.max(
       existing?.startSegment ?? 0,
       live ? secondsToSegmentIndex(live.position) : 0,
     );
+    // An init segment is position-independent, so it never anchors the main —
+    // otherwise an init request landing right after a restart (before recovery
+    // re-seeds the live playhead) would spawn a fresh main at segment 0. A
+    // seg-0/seg-1 probe routes to early only while the playhead sits past the
+    // early window (a resume); at the start it is the real first read the main
+    // owns.
     const isEarlyProbe =
       quality !== 'remux' &&
-      resumeFloor > EARLY_PROBE_SEGMENTS &&
-      segIndex < EARLY_PROBE_SEGMENTS;
+      (isInit ||
+        (resumeFloor > EARLY_PROBE_SEGMENTS && segIndex < EARLY_PROBE_SEGMENTS));
     if (isEarlyProbe) {
       let earlySession = this.resolveEarlySession(
         mediaFileId,

--- a/backend/src/modules/streaming/transcoding/purge-segments.spec.ts
+++ b/backend/src/modules/streaming/transcoding/purge-segments.spec.ts
@@ -1,0 +1,78 @@
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { purgeSegmentsFrom } from './segment-utils';
+
+const ROOT = '/tmp/fliks-purge-test';
+
+function seg(n: number): string {
+  return `seg-${String(n).padStart(4, '0')}.m4s`;
+}
+
+async function writeSegs(
+  dir: string,
+  from: number,
+  to: number,
+  withInit = false,
+): Promise<void> {
+  await fsp.mkdir(dir, { recursive: true });
+  if (withInit) await fsp.writeFile(path.join(dir, 'init_0.mp4'), 'x');
+  for (let n = from; n <= to; n++) {
+    await fsp.writeFile(path.join(dir, seg(n)), 'x');
+  }
+}
+
+async function listSegs(dir: string): Promise<number[]> {
+  const files = await fsp.readdir(dir).catch(() => [] as string[]);
+  return files
+    .map((f) => /^seg-(\d+)\.m4s$/.exec(f)?.[1])
+    .filter((v): v is string => v != null)
+    .map((v) => parseInt(v, 10))
+    .sort((a, b) => a - b);
+}
+
+describe('purgeSegmentsFrom', () => {
+  beforeEach(async () => {
+    await fsp.rm(ROOT, { recursive: true, force: true });
+  });
+  afterEach(async () => {
+    await fsp.rm(ROOT, { recursive: true, force: true });
+  });
+
+  it('drops segments >= fromSegment in the flat layout, keeps the rest + init', async () => {
+    const dir = path.join(ROOT, 'flat');
+    await writeSegs(dir, 0, 10, /* withInit */ true);
+
+    await purgeSegmentsFrom(dir, 5);
+
+    expect(await listSegs(dir)).toEqual([0, 1, 2, 3, 4]);
+    await expect(fsp.access(path.join(dir, 'init_0.mp4'))).resolves.toBeUndefined();
+  });
+
+  it('purges across var_stream_map numeric subdirs (0/,1/,2/)', async () => {
+    const dir = path.join(ROOT, 'vsm');
+    await writeSegs(path.join(dir, '0'), 100, 110);
+    await writeSegs(path.join(dir, '1'), 100, 110);
+    await writeSegs(path.join(dir, '2'), 100, 110);
+
+    await purgeSegmentsFrom(dir, 105);
+
+    for (const v of ['0', '1', '2']) {
+      expect(await listSegs(path.join(dir, v))).toEqual([100, 101, 102, 103, 104]);
+    }
+  });
+
+  it('fromSegment=0 clears every segment (cold-restart wipe)', async () => {
+    const dir = path.join(ROOT, 'wipe');
+    await writeSegs(path.join(dir, '0'), 2089, 2095);
+
+    await purgeSegmentsFrom(dir, 0);
+
+    expect(await listSegs(path.join(dir, '0'))).toEqual([]);
+  });
+
+  it('is a no-op on a missing directory', async () => {
+    await expect(
+      purgeSegmentsFrom(path.join(ROOT, 'does-not-exist'), 3),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/backend/src/modules/streaming/transcoding/segment-utils.ts
+++ b/backend/src/modules/streaming/transcoding/segment-utils.ts
@@ -31,6 +31,54 @@ export async function segmentNearby(
 }
 
 /**
+ * Delete cached segments numbered `>= fromSegment` across the flat layout and
+ * any var_stream_map numeric subdirs (`0/`, `1/`, …). Called when a run
+ * (re)starts at a new seek point: each run's segments carry a tfdt that is
+ * 0-based at its own `-ss`, so leaving a previous run's segments ahead of the
+ * new start makes the decode timeline jump backward at the boundary and stalls
+ * the player. Purging everything from the new start forward guarantees the
+ * play-forward path only ever sees the current run's timeline. `init_*.mp4` is
+ * left intact — codec config is identical across runs.
+ */
+export async function purgeSegmentsFrom(
+  cacheDir: string,
+  fromSegment: number,
+): Promise<void> {
+  const segRe = /^seg-(\d+)\.(m4s|ts)$/;
+  const dirs = [cacheDir];
+  let top: import('fs').Dirent[];
+  try {
+    top = await fsp.readdir(cacheDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of top) {
+    if (e.isDirectory() && /^\d+$/.test(e.name)) {
+      dirs.push(path.join(cacheDir, e.name));
+    }
+  }
+  await Promise.all(
+    dirs.map(async (dir) => {
+      let files: string[];
+      try {
+        files = await fsp.readdir(dir);
+      } catch {
+        return;
+      }
+      await Promise.all(
+        files.map((f) => {
+          const m = segRe.exec(f);
+          if (m && parseInt(m[1], 10) >= fromSegment) {
+            return fsp.unlink(path.join(dir, f)).catch(() => undefined);
+          }
+          return undefined;
+        }),
+      );
+    }),
+  );
+}
+
+/**
  * Starting from `fromSegment`, find the first segment number NOT on disk.
  * Returns `null` when every segment up to a reasonable lookahead exists.
  */

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -47,6 +47,7 @@ import {
 import {
   fileExists,
   firstMissingSegment,
+  purgeSegmentsFrom,
   segmentNearby,
 } from './segment-utils';
 import { sessionKey } from './session-key';
@@ -577,6 +578,11 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
             await fsp.mkdir(path.join(dir, String(i)), { recursive: true });
           }
         }
+        // Drop any segments from the previous run at/after the new start: they
+        // carry that run's 0-based-at-its-own-ss timeline, which collides with
+        // this run's at the boundary and stalls the player. Keeps the cache to
+        // a single timeline forward of the restart point.
+        await purgeSegmentsFrom(dir, restartAt);
         const restarted = this.startSeekSession(
           key,
           mediaFileId,
@@ -613,6 +619,10 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         await fsp.mkdir(path.join(sessionDir, String(i)), { recursive: true });
       }
     }
+    // Single-timeline cache: clear any prior run's segments at/after this
+    // start so the forward path never crosses a backward tfdt jump (see
+    // purgeSegmentsFrom). A cold first play finds nothing to drop.
+    await purgeSegmentsFrom(sessionDir, requestedSegment);
     const session = this.startFfmpeg(
       key,
       mediaFileId,

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1839,6 +1839,29 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       this.engine,
       this.playbackMode(),
     );
+    // Shaka/webOS drop sidecar text tracks on a fresh load(), so a recovery
+    // reload silently loses the user's subtitle. Re-add + re-select the active
+    // soft subtitle. Native restores its own pick inside load(); burn-in is
+    // re-baked server-side via the activeBurnInId passed to playback-info above.
+    if (!this.isNativeEngine()) {
+      const activeId = this.activeSubtitleId();
+      const sub = activeId
+        ? this.availableSubtitles().find((s) => s.id === activeId)
+        : null;
+      if (sub && !sub.burnIn && sub.url) {
+        try {
+          const track = await this.engine.addTextTrack(
+            sub.url,
+            sub.language,
+            sub.label,
+          );
+          this.engine.selectTextTrack(track);
+          this.engine.setTextVisibility(true);
+        } catch (e) {
+          console.error('[Player] re-apply subtitle after reload failed:', e);
+        }
+      }
+    }
     if (!wasPaused) {
       this.engine.play().catch(() => {});
     }


### PR DESCRIPTION
## Problem

On-the-fly transcode seeks with input `-ss`, so each ffmpeg run's fMP4 `tfdt`
is 0-based at that run's own start. When a run (re)starts at a new point —
seek, crash-recovery, pause-GC resume — the previous run's segments stay
cached *ahead* of the new start with an incompatible timeline. Crossing that
boundary makes the decode time jump backward and the player stalls or crashes.

Observed: resume-after-backend-restart freezing/cutting, and (same root cause)
**resume → seek back → play forward crashes exactly at the resume point**,
where the resume run's segments meet the seek-back run's in the cache.

## Fix

Two complementary pieces:

1. **seg-0 / init probe → early companion** — a player's seg-0/init VOD probe
   on resume must never restart the forward main session at segment 0. Route
   it (spawning on demand at the requested quality) to the bounded early
   session instead, anchored on the live playhead so it works even after a
   restart wipes the in-memory session. Without this the next change would be
   catastrophic (a probe would purge the whole cache).

2. **single-timeline cache** — when a transcode run (re)starts at
   `start_number=N`, purge cached segments numbered `>= N` (flat layout + every
   var_stream_map subdir) before producing. The play-forward path then only
   ever sees the current run's timeline. `init_*.mp4` is left intact (identical
   across runs).

Plus a client follow-up: **re-apply the active soft subtitle after a
session-recovery reload** on Shaka/webOS (they add sidecar text tracks
post-load, which a fresh `load()` drops). Native restores its own selection
inside `load()`; burn-in is re-baked server-side — both left untouched.

## Trade-off

Where a run restarts at a base different from the cached one (scrub back into
already-transcoded content, warm re-open at a different point), this
re-transcodes instead of serving the stale cache — but those are exactly the
cases that glitch today, so it trades a visible jump for a clean re-buffer.

## Verification

Backend tsc clean, 98 tests (incl. new `purgeSegmentsFrom` spec); client tsc
clean. Validated on device/web: resume-after-restart, seek-back-then-forward,
and Shaka subtitle restore on recovery.