### PR TITLE
feat(player): native HLS subtitle renditions (PiP) + absolute timeline

### DIFF
--- a/backend/src/modules/streaming/dto/device-profile.dto.ts
+++ b/backend/src/modules/streaming/dto/device-profile.dto.ts
@@ -73,6 +73,17 @@ export class DeviceProfileDto {
   @IsOptional()
   supportsHdr?: boolean;
 
+  /**
+   * Client renders HLS `SUBTITLES` renditions natively (AVPlayer, ExoPlayer,
+   * Tizen AVPlay, webOS), so the master advertises a subtitle group and cues
+   * show in PiP / AirPlay / lock-screen. Web (Shaka) leaves this unset and
+   * keeps fetching sidecar VTT, which renders better multi-line cues via its
+   * own text displayer.
+   */
+  @IsBoolean()
+  @IsOptional()
+  supportsHlsSubtitles?: boolean;
+
   @IsIn(['mobile', 'desktop'])
   @IsOptional()
   deviceType?: 'mobile' | 'desktop';

--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -61,6 +61,11 @@ export interface LiveSession {
   useExtXMedia: boolean;
   deviceType: 'mobile' | 'desktop';
   hdrLadder: boolean;
+  /** Client renders HLS `SUBTITLES` renditions natively (AVPlayer,
+   *  ExoPlayer, AVPlay, webOS) — the master advertises a subtitle group so
+   *  cues show in PiP / AirPlay / lock-screen. Web (Shaka) leaves this false
+   *  and keeps fetching sidecar VTT. Sourced from the device profile. */
+  supportsHlsSubtitles: boolean;
   videoVariant: CodecVariant | null;
   tonemapping: boolean;
   transcodeReasons: TranscodeReason[];
@@ -101,6 +106,7 @@ export interface CreateLiveSessionInput {
   useExtXMedia?: boolean;
   deviceType?: 'mobile' | 'desktop';
   hdrLadder?: boolean;
+  supportsHlsSubtitles?: boolean;
   videoVariant?: CodecVariant | null;
   tonemapping?: boolean;
   transcodeReasons?: TranscodeReason[];
@@ -197,6 +203,7 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
       useExtXMedia: input.useExtXMedia ?? false,
       deviceType: input.deviceType ?? 'desktop',
       hdrLadder: input.hdrLadder ?? false,
+      supportsHlsSubtitles: input.supportsHlsSubtitles ?? false,
       videoVariant: input.videoVariant ?? null,
       tonemapping: input.tonemapping ?? false,
       transcodeReasons: input.transcodeReasons ?? [],

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -845,6 +845,7 @@ export class StreamingController {
       useExtXMedia,
       deviceType,
       hdrLadder: useHdrLadder,
+      supportsHlsSubtitles: !!deviceProfile.supportsHlsSubtitles,
       videoVariant,
       tonemapping: response.tonemapping,
       transcodeReasons: response.transcodeReasons,
@@ -1056,6 +1057,19 @@ export class StreamingController {
       });
     }
 
+    // Native HLS subtitle renditions — gated by the client's
+    // `supportsHlsSubtitles` capability (sent in the device profile at
+    // playback-info, stored on the session), so cues render inside the
+    // player pipeline (PiP / AirPlay / lock-screen). Decoupled from the
+    // video transcode: each rendition wraps the WebVTT the subtitle service
+    // already extracts. Web (Shaka) leaves the flag off and keeps fetching
+    // sidecar VTT.
+    const subtitleRenditions = (live?.supportsHlsSubtitles ?? false)
+      ? await this.subtitleStreamService
+          .listTextSubtitleRenditions(mediaFileId)
+          .catch(() => undefined)
+      : undefined;
+
     const sdrVariant = live?.videoVariant ?? null;
     const sourceFrameRate = parseFloat(v?.frameRate ?? '') || undefined;
     const playlist = this.transcodingService.generateMasterPlaylist(
@@ -1080,6 +1094,7 @@ export class StreamingController {
       // already drives its codec strings from `hdrPassThrough`.
       sdrVariant && sdrVariant.hdr == null ? sdrVariant : undefined,
       sourceFrameRate,
+      subtitleRenditions,
     );
 
     res.setHeader('Content-Type', 'application/vnd.apple.mpegurl');
@@ -1138,6 +1153,75 @@ export class StreamingController {
     res.setHeader('Content-Type', 'text/vtt; charset=utf-8');
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.send(withTimestampMap(vtt));
+  }
+
+  // HLS subtitle media playlists (single WebVTT segment) — referenced by the
+  // master's SUBTITLES group. The extra `/index.m3u8` segment keeps these
+  // from colliding with the plain VTT routes above. Embedded route is
+  // declared first so "embedded" is never read as a numeric subtitleId.
+
+  /** Subtitle media playlist for an embedded stream. */
+  @Get(':mediaFileId/subtitles/embedded/:streamIndex/index.m3u8')
+  async embeddedSubtitlePlaylist(
+    @Param('mediaFileId', ParseIntPipe) mediaFileId: number,
+    @Param('streamIndex', ParseIntPipe) streamIndex: number,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    await this.sendSubtitlePlaylist(
+      res,
+      req,
+      mediaFileId,
+      `subtitles/embedded/${streamIndex}`,
+    );
+  }
+
+  /** Subtitle media playlist for an external subtitle file. */
+  @Get(':mediaFileId/subtitles/:subtitleId/index.m3u8')
+  async externalSubtitlePlaylist(
+    @Param('mediaFileId', ParseIntPipe) mediaFileId: number,
+    @Param('subtitleId', ParseIntPipe) subtitleId: number,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    await this.sendSubtitlePlaylist(
+      res,
+      req,
+      mediaFileId,
+      `subtitles/${subtitleId}`,
+    );
+  }
+
+  /** Build + send a single-segment VOD WebVTT media playlist whose one
+   *  segment is the matching VTT endpoint. Native HLS players consume this
+   *  as a SUBTITLES rendition so cues render inside the player pipeline
+   *  (PiP / AirPlay / lock-screen) rather than an app overlay. The VTT
+   *  itself carries the `X-TIMESTAMP-MAP` (via `withTimestampMap`) needed to
+   *  align cue times with the media timeline. */
+  private async sendSubtitlePlaylist(
+    res: Response,
+    req: Request,
+    mediaFileId: number,
+    vttPath: string,
+  ): Promise<void> {
+    const resolved = await this.streamingService.resolveFile(mediaFileId);
+    const duration = resolved.mediaFile.streamInfo?.durationSeconds ?? 0;
+    const tokenParam = buildTokenParam(req);
+    const target = Math.max(1, Math.ceil(duration || 1));
+    const playlist = [
+      '#EXTM3U',
+      '#EXT-X-VERSION:7',
+      '#EXT-X-PLAYLIST-TYPE:VOD',
+      `#EXT-X-TARGETDURATION:${target}`,
+      '#EXT-X-MEDIA-SEQUENCE:0',
+      `#EXTINF:${(duration || target).toFixed(3)},`,
+      `/api/stream/${mediaFileId}/${vttPath}${tokenParam}`,
+      '#EXT-X-ENDLIST',
+    ].join('\n');
+    res.setHeader('Content-Type', 'application/vnd.apple.mpegurl');
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Cache-Control', 'no-store');
+    res.send(playlist);
   }
 
   // ---------------------------------------------------------------------------

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -39,6 +39,8 @@ import {
 } from './transcoding/constants';
 import { LiveSession, LiveSessionRegistry } from './live-session.service';
 import { readAndRewriteCmaf } from './transcoding/cmaf-rewrite';
+import { parseInitTracks, rewriteSegmentTfdt } from './transcoding/timeline';
+import * as path from 'path';
 import { resolveTonemapPath } from './transcoding/tonemap-path';
 import { ThumbnailService } from './thumbnail.service';
 import { StreamBuilderService } from './stream-builder.service';
@@ -71,6 +73,11 @@ function withTimestampMap(vtt: string | Buffer): string {
 
 /** Default segment duration — overridden by admin streaming settings. */
 let SEG_DURATION = 3;
+
+/** Per-cache-dir track info (timescale + video flag), parsed once from each
+ *  rendition's init segment and reused to anchor that rendition's segments
+ *  onto the absolute presentation timeline (see {@link rewriteSegmentTfdt}). */
+const initTrackCache = new Map<string, ReturnType<typeof parseInitTracks>>();
 
 /**
  * Compose / append the `token=...` + `sid=...` query pair that every
@@ -570,8 +577,9 @@ export class StreamingController {
       if (!res.headersSent) res.status(404).end();
       return;
     }
+    const out = await this.anchorSegmentTimeline(filePath, buf);
     res.setHeader('Content-Type', contentType);
-    res.setHeader('Content-Length', String(buf.length));
+    res.setHeader('Content-Length', String(out.length));
     res.setHeader('Access-Control-Allow-Origin', '*');
     // Cloudflare (and any intermediate CDN) will gladly cache a 0-byte
     // 200 response under the URL and serve it back for 4h by default —
@@ -579,7 +587,53 @@ export class StreamingController {
     // permanent failure. Mark each fMP4 chunk un-cacheable so a CDN
     // refusing the upstream length check never pins a broken response.
     res.setHeader('Cache-Control', 'no-store');
-    res.end(buf);
+    res.end(out);
+  }
+
+  /** Anchor a media segment onto the single absolute presentation timeline:
+   *  rewrite its `tfdt` so `seg-N` decodes at its true content time
+   *  `N · SEG_DURATION` (per-track timescale), instead of FFmpeg's per-run
+   *  0-based reset. This is the packaging layer owning the timeline so all
+   *  renditions (video, audio, subtitle) stay coherent across resume / seek
+   *  runs (HLS requires one shared timeline). Init segments and MPEG-TS
+   *  segments carry no `tfdt` and pass through unchanged. */
+  private async anchorSegmentTimeline(
+    filePath: string,
+    buf: Buffer,
+  ): Promise<Buffer> {
+    const m = /(?:^|\/)seg-(\d+)\.m4s$/.exec(filePath);
+    if (!m) return buf;
+    const tracks = await this.tracksForDir(path.dirname(filePath));
+    if (tracks.size === 0) return buf;
+    return rewriteSegmentTfdt(buf, tracks, Number(m[1]), SEG_DURATION);
+  }
+
+  /** Track info for a rendition's cache dir, parsed once from its init
+   *  segment. Cached only once populated so a cold-start race (init not yet
+   *  flushed) retries on the next segment instead of caching empty. */
+  private async tracksForDir(
+    dir: string,
+  ): Promise<ReturnType<typeof parseInitTracks>> {
+    const cached = initTrackCache.get(dir);
+    if (cached) return cached;
+    let initBuf: Buffer | null = null;
+    try {
+      initBuf = await fs.promises.readFile(path.join(dir, 'init.mp4'));
+    } catch {
+      // var_stream_map renditions may name the init `init_<n>.mp4`.
+      try {
+        const entry = (await fs.promises.readdir(dir)).find((f) =>
+          /^init.*\.mp4$/.test(f),
+        );
+        if (entry) initBuf = await fs.promises.readFile(path.join(dir, entry));
+      } catch {
+        return new Map();
+      }
+    }
+    if (!initBuf) return new Map();
+    const tracks = parseInitTracks(initBuf);
+    if (tracks.size > 0) initTrackCache.set(dir, tracks);
+    return tracks;
   }
 
   /** Available download qualities for a media file (used by download-quality modal). */
@@ -1067,7 +1121,12 @@ export class StreamingController {
     const subtitleRenditions = (live?.supportsHlsSubtitles ?? false)
       ? await this.subtitleStreamService
           .listTextSubtitleRenditions(mediaFileId)
-          .catch(() => undefined)
+          .catch((e) => {
+            this.log.warn(
+              `subtitle renditions failed for #${mediaFileId}: ${e instanceof Error ? e.message : e}`,
+            );
+            return undefined;
+          })
       : undefined;
 
     const sdrVariant = live?.videoVariant ?? null;

--- a/backend/src/modules/streaming/subtitle-stream.service.ts
+++ b/backend/src/modules/streaming/subtitle-stream.service.ts
@@ -149,16 +149,27 @@ export class SubtitleStreamService {
         forced: s.forced,
       });
     }
-    const external = await this.subtitleFileRepo.find({ where: { mediaFileId } });
-    for (const sf of external) {
-      if (!sf.relativePath) continue;
-      out.push({
-        kind: 'external',
-        key: sf.id,
-        language: sf.language,
-        name: sf.language || 'Subtitle',
-        forced: sf.forced,
+    // External subtitle files. Query through the relation — `mediaFileId` on
+    // SubtitleFile is a @RelationId (virtual), which TypeORM rejects in a
+    // `where`. Isolated so a query failure can never drop the embedded subs.
+    try {
+      const external = await this.subtitleFileRepo.find({
+        where: { mediaFile: { id: mediaFileId } },
       });
+      for (const sf of external) {
+        if (!sf.relativePath) continue;
+        out.push({
+          kind: 'external',
+          key: sf.id,
+          language: sf.language,
+          name: sf.language || 'Subtitle',
+          forced: sf.forced,
+        });
+      }
+    } catch (e) {
+      this.log.warn(
+        `listTextSubtitleRenditions: external query failed for #${mediaFileId}: ${e instanceof Error ? e.message : e}`,
+      );
     }
     return out;
   }

--- a/backend/src/modules/streaming/subtitle-stream.service.ts
+++ b/backend/src/modules/streaming/subtitle-stream.service.ts
@@ -17,6 +17,7 @@ import { StreamingService } from './streaming.service';
 import { EventsService } from '../scheduler/events.service';
 import { Command } from '../scheduler/entities/command.entity';
 import { resolveSubtitleAbsolutePath } from '../subtitles/subtitle-path.util';
+import type { SubtitleRenditionMeta } from './transcoding/types';
 
 const execFileAsync = promisify(execFile);
 
@@ -122,6 +123,44 @@ export class SubtitleStreamService {
 
     // Fallback: try SRT conversion
     return this.srtToVtt(content);
+  }
+
+  /**
+   * Text subtitle tracks for the HLS master's `SUBTITLES` rendition group:
+   * embedded non-bitmap streams (from cached `streamInfo`) plus external
+   * subtitle files on disk. Bitmap subtitles (PGS/DVD/DVB) are excluded —
+   * they have no WebVTT form and stay on the burn-in path. Each entry's
+   * `key` feeds the existing VTT endpoints (`subtitles/embedded/:idx` for
+   * embedded, `subtitles/:id` for external), which the subtitle media
+   * playlist references as its single segment.
+   */
+  async listTextSubtitleRenditions(
+    mediaFileId: number,
+  ): Promise<SubtitleRenditionMeta[]> {
+    const out: SubtitleRenditionMeta[] = [];
+    const resolved = await this.streamingService.resolveFile(mediaFileId);
+    for (const s of resolved.mediaFile.streamInfo?.subtitles ?? []) {
+      if (s.isImageBased) continue;
+      out.push({
+        kind: 'embedded',
+        key: s.streamIndex,
+        language: s.language,
+        name: s.title || s.language || 'Subtitle',
+        forced: s.forced,
+      });
+    }
+    const external = await this.subtitleFileRepo.find({ where: { mediaFileId } });
+    for (const sf of external) {
+      if (!sf.relativePath) continue;
+      out.push({
+        kind: 'external',
+        key: sf.id,
+        language: sf.language,
+        name: sf.language || 'Subtitle',
+        forced: sf.forced,
+      });
+    }
+    return out;
   }
 
   /**

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -188,7 +188,7 @@ export function generateMasterPlaylist(
           ? `subtitles/embedded/${s.key}`
           : `subtitles/${s.key}`;
       out.push(
-        `#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="${names[i]}",LANGUAGE="${lang}",DEFAULT=NO,AUTOSELECT=YES,FORCED=${s.forced ? 'YES' : 'NO'},URI="/api/stream/${mediaFileId}/${path}/index.m3u8${tokenParam}"`,
+        `#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="${names[i]}",LANGUAGE="${lang}",DEFAULT=NO,AUTOSELECT=NO,FORCED=${s.forced ? 'YES' : 'NO'},URI="/api/stream/${mediaFileId}/${path}/index.m3u8${tokenParam}"`,
       );
     });
   };

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -5,7 +5,12 @@ import {
   profileFitsSource,
   profileResolution,
 } from './profiles';
-import type { AudioStreamMeta, DeviceType, TranscodeProfile } from './types';
+import type {
+  AudioStreamMeta,
+  DeviceType,
+  SubtitleRenditionMeta,
+  TranscodeProfile,
+} from './types';
 import type { CodecVariant } from './codec/types';
 import {
   av1CodecString,
@@ -134,6 +139,17 @@ export function generateMasterPlaylist(
    *  so legacy callers without source info still produce a valid
    *  manifest. */
   sourceFrameRate = 24,
+  /** Text subtitle tracks to advertise as an HLS `SUBTITLES` rendition
+   *  group. When non-empty, a `#EXT-X-MEDIA:TYPE=SUBTITLES` line is emitted
+   *  per track and every `#EXT-X-STREAM-INF` gains `SUBTITLES="subs"`, so a
+   *  native HLS player (AVPlayer, ExoPlayer, AVPlay, webOS) renders cues
+   *  inside its own pipeline — visible in PiP / AirPlay / lock-screen.
+   *  Empty / undefined keeps the manifest subtitle-free (web + older
+   *  clients keep fetching sidecar VTT). The renditions are decoupled from
+   *  the video transcode: each URI points at a tiny media playlist wrapping
+   *  the WebVTT the subtitle service already extracts, so the HEVC
+   *  `var_stream_map` is untouched (no decoder-buffer regression). */
+  subtitleRenditions?: SubtitleRenditionMeta[],
 ): string {
   // The "multi-audio" flag is really an "EXT-X-MEDIA layout" toggle —
   // the caller decided whether to split audio into renditions. Single-
@@ -154,6 +170,28 @@ export function generateMasterPlaylist(
   const codecsTail = noAudio ? '' : `,${audioCodec}`;
 
   const frameRateAttr = `,FRAME-RATE=${formatFrameRate(sourceFrameRate)}`;
+
+  // Subtitle renditions: one shared `subs` group, referenced by every
+  // variant via `SUBTITLES="subs"`. Emitted in both the SDR and HDR
+  // branches so the group is present whichever ladder the master uses.
+  const hasSubs = subtitleRenditions != null && subtitleRenditions.length > 0;
+  const subsAttr = hasSubs ? ',SUBTITLES="subs"' : '';
+  const pushSubtitleMedia = (out: string[]): void => {
+    if (!hasSubs) return;
+    const names = buildUniqueAudioNames(
+      subtitleRenditions.map((s) => ({ title: s.name, language: s.language })),
+    );
+    subtitleRenditions.forEach((s, i) => {
+      const lang = s.language || 'und';
+      const path =
+        s.kind === 'embedded'
+          ? `subtitles/embedded/${s.key}`
+          : `subtitles/${s.key}`;
+      out.push(
+        `#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="${names[i]}",LANGUAGE="${lang}",DEFAULT=NO,AUTOSELECT=YES,FORCED=${s.forced ? 'YES' : 'NO'},URI="/api/stream/${mediaFileId}/${path}/index.m3u8${tokenParam}"`,
+      );
+    });
+  };
 
   // HDR pass-through path — emitted when the source is HEVC HDR and
   // the client claims HDR support. Outputs a full HEVC HDR ladder
@@ -193,6 +231,7 @@ export function generateMasterPlaylist(
       }
     }
     const hdrAudioAttr = multiAudio ? ',AUDIO="audio"' : '';
+    pushSubtitleMedia(lines);
 
     // HEVC HDR rungs are pure transcodes (hevc_qsv Main10 with forced
     // 3-second keyframes), gated on `canEncodeHevcHdr`. The former
@@ -241,7 +280,7 @@ export function generateMasterPlaylist(
           frameRate: sourceFrameRate,
         });
         lines.push(
-          `#EXT-X-STREAM-INF:BANDWIDTH=${bw},AVERAGE-BANDWIDTH=${avg},RESOLUTION=${w}x${h},VIDEO-RANGE=${range}${frameRateAttr},NAME="${p.name}",CODECS="${videoCodec}${codecsTail}"${hdrAudioAttr}`,
+          `#EXT-X-STREAM-INF:BANDWIDTH=${bw},AVERAGE-BANDWIDTH=${avg},RESOLUTION=${w}x${h},VIDEO-RANGE=${range}${frameRateAttr},NAME="${p.name}",CODECS="${videoCodec}${codecsTail}"${hdrAudioAttr}${subsAttr}`,
           `/api/stream/${mediaFileId}/${p.name}/index.m3u8${tokenParam}`,
         );
       }
@@ -280,6 +319,7 @@ export function generateMasterPlaylist(
   // (L4.0) for every rung makes iOS AVPlayer reject 4K segments whose
   // bitstream signals L5.x — visible as decoder reinit / frame freeze.
   const audioAttr = multiAudio ? ',AUDIO="audio"' : '';
+  pushSubtitleMedia(lines);
 
   // The HLS master never advertises the `/remux/` variant — it proved
   // unreliable on ExoPlayer (Android), which would ABR-downgrade from the
@@ -338,7 +378,7 @@ export function generateMasterPlaylist(
           : h264CodecString(target);
     const codecsAttr = `,CODECS="${videoCodec}${codecsTail}"`;
     lines.push(
-      `#EXT-X-STREAM-INF:BANDWIDTH=${bw},AVERAGE-BANDWIDTH=${avg},RESOLUTION=${w}x${h}${frameRateAttr},NAME="${p.name}"${codecsAttr}${audioAttr}`,
+      `#EXT-X-STREAM-INF:BANDWIDTH=${bw},AVERAGE-BANDWIDTH=${avg},RESOLUTION=${w}x${h}${frameRateAttr},NAME="${p.name}"${codecsAttr}${audioAttr}${subsAttr}`,
       `/api/stream/${mediaFileId}/${p.name}/index.m3u8${tokenParam}`,
     );
   }

--- a/backend/src/modules/streaming/transcoding/timeline.ts
+++ b/backend/src/modules/streaming/transcoding/timeline.ts
@@ -1,0 +1,194 @@
+/**
+ * HLS presentation-timeline normalisation for fMP4 segments.
+ *
+ * FFmpeg's HLS muxer restarts the fragment decode timeline at 0 on every
+ * transcode run: a segment produced by a run that started mid-file carries
+ * `tfdt.baseMediaDecodeTime` relative to that run's start, not the segment's
+ * true content time. That breaks the HLS requirement that all renditions of a
+ * presentation share one coherent, monotonic timeline (RFC 8216 §6.2; Apple
+ * HLS Authoring Spec) — the player anchors video and a `SUBTITLES` rendition
+ * to different origins, so subtitles drift by the resume offset, and two runs
+ * writing the same segment index collide on a backward jump.
+ *
+ * The packaging layer (the in-memory rewrite already applied to every served
+ * segment — see {@link cmafRewrite}) owns the canonical timeline instead of
+ * the encoder. Segments sit on a uniform `segmentDuration` grid (forced IDR
+ * every `segmentDuration`s, `start_number = secondsToSegmentIndex`), so
+ * `seg-N`'s video fragment decodes at exactly `N · segmentDuration`. We use
+ * that to recover the run's content start `S` (the run's first segment index ×
+ * `segmentDuration`), then SHIFT every track's `tfdt` by `S` — preserving each
+ * track's intra-run timing and A/V relationship rather than snapping audio to
+ * the video grid (audio fragments are ~whole-AAC-frame, slightly off the video
+ * grid; snapping would desync).
+ *
+ * Result: one absolute, monotonic timeline shared by every rendition, and
+ * idempotent segments — `seg-N` carries the same `tfdt` no matter which run
+ * produced it, so the cross-run collision cannot occur.
+ *
+ * The rewrite is in-place over a Buffer copy and never changes box sizes (the
+ * `tfdt` value is written in its existing 32- or 64-bit width).
+ */
+
+interface Box {
+  type: string;
+  start: number;
+  size: number;
+  payloadStart: number;
+}
+
+interface TrackInfo {
+  timescale: number;
+  isVideo: boolean;
+}
+
+/** Iterate the boxes in `buf[start, end)`. */
+function* boxes(buf: Buffer, start: number, end: number): Generator<Box> {
+  let off = start;
+  while (off + 8 <= end) {
+    let size = buf.readUInt32BE(off);
+    const type = buf.toString('latin1', off + 4, off + 8);
+    let payloadStart = off + 8;
+    if (size === 1) {
+      size = Number(buf.readBigUInt64BE(off + 8));
+      payloadStart = off + 16;
+    } else if (size === 0) {
+      size = end - off;
+    }
+    if (size < 8 || off + size > end) break;
+    yield { type, start: off, size, payloadStart };
+    off += size;
+  }
+}
+
+function findBox(
+  buf: Buffer,
+  start: number,
+  end: number,
+  type: string,
+): Box | null {
+  for (const b of boxes(buf, start, end)) if (b.type === type) return b;
+  return null;
+}
+
+/**
+ * Parse `trackId → { timescale, isVideo }` from an init segment's `moov`.
+ * Empty when the buffer isn't a parseable init (the caller then leaves the
+ * segment untouched).
+ */
+export function parseInitTracks(initBuf: Buffer): Map<number, TrackInfo> {
+  const out = new Map<number, TrackInfo>();
+  const moov = findBox(initBuf, 0, initBuf.length, 'moov');
+  if (!moov) return out;
+  for (const trak of boxes(initBuf, moov.payloadStart, moov.start + moov.size)) {
+    if (trak.type !== 'trak') continue;
+    const trakEnd = trak.start + trak.size;
+    const tkhd = findBox(initBuf, trak.payloadStart, trakEnd, 'tkhd');
+    const mdia = findBox(initBuf, trak.payloadStart, trakEnd, 'mdia');
+    if (!tkhd || !mdia) continue;
+    const mdiaEnd = mdia.start + mdia.size;
+    // tkhd: fullbox, then (v0) creation(4) modification(4) track_ID(4) …
+    //                       (v1) creation(8) modification(8) track_ID(4) …
+    const tkVer = initBuf[tkhd.payloadStart];
+    const trackId = initBuf.readUInt32BE(
+      tkhd.payloadStart + (tkVer === 1 ? 20 : 12),
+    );
+    const mdhd = findBox(initBuf, mdia.payloadStart, mdiaEnd, 'mdhd');
+    if (!mdhd) continue;
+    // mdhd: fullbox, then (v0) creation(4) modification(4) timescale(4) …
+    //                     (v1) creation(8) modification(8) timescale(4) …
+    const mdVer = initBuf[mdhd.payloadStart];
+    const timescale = initBuf.readUInt32BE(
+      mdhd.payloadStart + (mdVer === 1 ? 20 : 12),
+    );
+    if (timescale <= 0) continue;
+    // hdlr: fullbox(4) pre_defined(4) handler_type(4 = 'vide' | 'soun' | …)
+    const hdlr = findBox(initBuf, mdia.payloadStart, mdiaEnd, 'hdlr');
+    const handler = hdlr
+      ? initBuf.toString('latin1', hdlr.payloadStart + 8, hdlr.payloadStart + 12)
+      : '';
+    out.set(trackId, { timescale, isVideo: handler === 'vide' });
+  }
+  return out;
+}
+
+interface FragTfdt {
+  trackId: number;
+  valueOffset: number;
+  version: number;
+  original: number;
+}
+
+/** Collect every fragment's tfdt (trackId via tfhd, value + offset). */
+function collectTfdts(buf: Buffer): FragTfdt[] {
+  const out: FragTfdt[] = [];
+  for (const moof of boxes(buf, 0, buf.length)) {
+    if (moof.type !== 'moof') continue;
+    for (const traf of boxes(buf, moof.payloadStart, moof.start + moof.size)) {
+      if (traf.type !== 'traf') continue;
+      const trafEnd = traf.start + traf.size;
+      const tfhd = findBox(buf, traf.payloadStart, trafEnd, 'tfhd');
+      const tfdt = findBox(buf, traf.payloadStart, trafEnd, 'tfdt');
+      if (!tfhd || !tfdt) continue;
+      const trackId = buf.readUInt32BE(tfhd.payloadStart + 4); // fullbox(4) track_ID(4)
+      const version = buf[tfdt.payloadStart];
+      const valueOffset = tfdt.payloadStart + 4;
+      const original =
+        version === 1
+          ? Number(buf.readBigUInt64BE(valueOffset))
+          : buf.readUInt32BE(valueOffset);
+      out.push({ trackId, valueOffset, version, original });
+    }
+  }
+  return out;
+}
+
+/**
+ * Shift every fragment's `tfdt` so the segment sits at its true content time
+ * on the shared absolute timeline. Returns a new Buffer; box sizes unchanged.
+ *
+ * The shift `S` (run content-start) is recovered from the video fragment,
+ * which decodes exactly on the grid: `S = segIndex·segDuration − videoTfdt/ts`.
+ * Every track is then shifted by `S` (scaled to its timescale), preserving
+ * the audio fragment's true position relative to video. Audio-only segments
+ * (no video fragment, e.g. var_stream_map renditions) fall back to snapping
+ * the run start to the nearest grid point — exact for runs shorter than
+ * ~`segDuration / 0.008`s, which covers the early/main session pattern.
+ */
+export function rewriteSegmentTfdt(
+  segBuf: Buffer,
+  tracks: Map<number, TrackInfo>,
+  segIndex: number,
+  segDuration: number,
+): Buffer {
+  if (tracks.size === 0) return segBuf;
+  const frags = collectTfdts(segBuf);
+  if (frags.length === 0) return segBuf;
+
+  const segStart = segIndex * segDuration;
+  const video = frags.find((f) => tracks.get(f.trackId)?.isVideo);
+  let runStart: number;
+  if (video) {
+    const ts = tracks.get(video.trackId)!.timescale;
+    runStart = segStart - video.original / ts;
+  } else {
+    const ref = frags[0];
+    const ts = tracks.get(ref.trackId)?.timescale;
+    if (!ts) return segBuf;
+    runStart =
+      Math.round((segStart - ref.original / ts) / segDuration) * segDuration;
+  }
+  if (runStart <= 0) return segBuf; // already absolute (run started at 0)
+
+  const buf = Buffer.from(segBuf);
+  for (const f of frags) {
+    const ts = tracks.get(f.trackId)?.timescale;
+    if (!ts) continue;
+    const value = f.original + Math.round(runStart * ts);
+    if (f.version === 1) {
+      buf.writeBigUInt64BE(BigInt(value), f.valueOffset);
+    } else if (value <= 0xffffffff) {
+      buf.writeUInt32BE(value, f.valueOffset);
+    }
+  }
+  return buf;
+}

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -455,6 +455,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     },
     sdrVariant?: import('./codec/types').CodecVariant,
     sourceFrameRate?: number,
+    subtitleRenditions?: import('./types').SubtitleRenditionMeta[],
   ): string {
     // Ask the encoder registry whether any HEVC Main10 HDR10 encoder is
     // probed-OK on the detected hwAccel (or CPU fallback). When false,
@@ -484,6 +485,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       canEncodeHevcHdr,
       sdrVariant,
       sourceFrameRate,
+      subtitleRenditions,
     );
   }
 

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -25,6 +25,23 @@ export interface AudioStreamMeta {
   streamIndex?: number;
 }
 
+/**
+ * A text subtitle track surfaced as an HLS `SUBTITLES` rendition in the
+ * master playlist. `kind` selects the segment source: an embedded stream
+ * (extracted to WebVTT by `SubtitleStreamService`) or an external subtitle
+ * file row. `key` is the ffprobe stream index (embedded) or the
+ * `SubtitleFile` id (external) — the master builder turns it into the
+ * rendition's media-playlist URI. Bitmap subtitles (PGS/DVD/DVB) are never
+ * renditions: they stay on the burn-in path.
+ */
+export interface SubtitleRenditionMeta {
+  kind: 'embedded' | 'external';
+  key: number;
+  language?: string;
+  name: string;
+  forced?: boolean;
+}
+
 export type HwAccelType = 'vaapi' | 'nvenc' | 'qsv' | 'videotoolbox' | 'none';
 
 /** Short human-readable label for each HW accel type (used in admin

--- a/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
@@ -787,14 +787,19 @@ public class NativePlayerPlugin extends Plugin {
         try { targetIndex = Integer.parseInt(id.replace("text-", "")); }
         catch (NumberFormatException e) { return false; }
 
-        // ExoPlayer may auto-detect extra text tracks (CEA-608 from HLS) before our sidecar subs.
-        // Offset by the number of non-sidecar text tracks so text-0 maps to our first SubtitleConfiguration.
+        // When sidecar SubtitleConfigurations are present, ExoPlayer may
+        // auto-detect extra text tracks (CEA-608 from HLS) before them, so
+        // text-0 must skip those. With subtitles delivered as HLS SUBTITLES
+        // renditions (no sidecar), the text groups ARE the renditions and
+        // "text-N" maps straight to the Nth text group — getSubtitleTracks
+        // enumerates them in the same order, so the offset must be 0.
         int totalTextGroups = 0;
         for (Tracks.Group group : player.getCurrentTracks().getGroups()) {
             if (group.getType() == C.TRACK_TYPE_TEXT) totalTextGroups++;
         }
-        int sidecarOffset = totalTextGroups - subtitleConfigs.size();
-        if (sidecarOffset < 0) sidecarOffset = 0;
+        int sidecarOffset = subtitleConfigs.isEmpty()
+                ? 0
+                : Math.max(0, totalTextGroups - subtitleConfigs.size());
         int exoIndex = targetIndex + sidecarOffset;
 
         int idx = 0;

--- a/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
@@ -578,14 +578,6 @@ public class NativePlayerPlugin extends Plugin {
         });
     }
 
-    @PluginMethod()
-    public void addExternalSubtitle(PluginCall call) {
-        // Subtitles are preloaded at load() time. This just returns an ID
-        // for the frontend to track. The actual selection is done via selectSubtitleTrack.
-        String id = call.getString("url", "ext-sub-" + System.currentTimeMillis());
-        call.resolve(new JSObject().put("id", id));
-    }
-
     // ── Subtitle Style ──
 
     @PluginMethod()

--- a/client/ios/App/App.xcodeproj/project.pbxproj
+++ b/client/ios/App/App.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		F1000001AAAA000000000005 /* PipPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1000001AAAA000000000015 /* PipPlugin.swift */; };
 		F1000001AAAA000000000006 /* CastPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1000001AAAA000000000016 /* CastPlugin.swift */; };
 		F1000001AAAA000000000007 /* AudioCapabilitiesPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1000001AAAA000000000017 /* AudioCapabilitiesPlugin.swift */; };
+		F1000001AAAA000000000008 /* SubtitleOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1000001AAAA000000000018 /* SubtitleOverlayView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -43,6 +44,7 @@
 		F1000001AAAA000000000015 /* PipPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipPlugin.swift; sourceTree = "<group>"; };
 		F1000001AAAA000000000016 /* CastPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CastPlugin.swift; sourceTree = "<group>"; };
 		F1000001AAAA000000000017 /* AudioCapabilitiesPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCapabilitiesPlugin.swift; sourceTree = "<group>"; };
+		F1000001AAAA000000000018 /* SubtitleOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtitleOverlayView.swift; sourceTree = "<group>"; };
 		FC68EB0AF532CFC21C3344DD /* Pods-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-App/Pods-App.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -96,6 +98,7 @@
 				F1000001AAAA000000000015 /* PipPlugin.swift */,
 				F1000001AAAA000000000016 /* CastPlugin.swift */,
 				F1000001AAAA000000000017 /* AudioCapabilitiesPlugin.swift */,
+				F1000001AAAA000000000018 /* SubtitleOverlayView.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -252,6 +255,7 @@
 				F1000001AAAA000000000005 /* PipPlugin.swift in Sources */,
 				F1000001AAAA000000000006 /* CastPlugin.swift in Sources */,
 				F1000001AAAA000000000007 /* AudioCapabilitiesPlugin.swift in Sources */,
+				F1000001AAAA000000000008 /* SubtitleOverlayView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -504,11 +504,15 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             attrs[kCMTextMarkupAttribute_ForegroundColorARGB as String] = fg
         }
         // "transparent" → fully transparent ARGB so no caption box is drawn.
+        // Set BOTH backgrounds: AVPlayer draws the visible box behind WebVTT
+        // cues from the *character* background, so clearing only the region
+        // `BackgroundColorARGB` leaves a semi-opaque box behind.
         let bg: [CGFloat] =
             backgroundColor == "transparent"
             ? [0, 0, 0, 0]
             : (parseColor(backgroundColor) ?? [0, 0, 0, 0])
         attrs[kCMTextMarkupAttribute_BackgroundColorARGB as String] = bg
+        attrs[kCMTextMarkupAttribute_CharacterBackgroundColorARGB as String] = bg
         // Font size as a percentage of video height (~5% ≈ AVPlayer's default
         // caption size), scaled by the user's size factor.
         attrs[kCMTextMarkupAttribute_BaseFontSizePercentageRelativeToVideoHeight as String] =

--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -2,6 +2,7 @@ import Foundation
 import Capacitor
 import AVFoundation
 import AVKit
+import CoreMedia
 
 /// UIView subclass that keeps its first CALayer sublayer (the AVPlayerLayer) sized to bounds.
 private class PlayerContainerView: UIView {
@@ -33,27 +34,26 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "selectAudioTrack", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getSubtitleTracks", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "selectSubtitleTrack", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "addExternalSubtitle", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setSubtitleStyle", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setBrightness", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setMaxResolution", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getPosition", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setPlaybackRate", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "setSubtitleText", returnType: CAPPluginReturnPromise),
     ]
 
     private var player: AVPlayer?
     private var playerLayer: AVPlayerLayer?
     private var playerView: UIView?
-    private var subtitleLabel: UILabel?
-    private var subtitleView: UIView?
-    private var subtitleBottomConstraint: NSLayoutConstraint?
     private var timeObserver: Any?
     private var statusObserver: NSKeyValueObservation?
     private var timeControlObserver: NSKeyValueObservation?
     private var firstFrameObserver: NSKeyValueObservation?
     private var firstFrameEmitted = false
     private var savedBrightness: CGFloat?
+    /// AVTextStyleRule built from the app's subtitle-style settings, applied
+    /// to each AVPlayerItem so native (legible) caption rendering honours the
+    /// chosen colours / background instead of AVPlayer's default grey box.
+    private var subtitleStyleRules: [AVTextStyleRule] = []
 
     /// Exposed for PipPlugin to access the player layer.
     public var activePlayerLayer: AVPlayerLayer? { playerLayer }
@@ -96,48 +96,6 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             webView.scrollView.backgroundColor = .clear
 
             self.playerView = view
-
-            // Create subtitle view between player and WebView
-            let subContainer = UIView(frame: parentBounds)
-            subContainer.backgroundColor = .clear
-            subContainer.isUserInteractionEnabled = false
-            if isFullScreen {
-                subContainer.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-            }
-            webView.superview?.insertSubview(subContainer, belowSubview: webView)
-
-            let label = UILabel()
-            label.translatesAutoresizingMaskIntoConstraints = false
-            label.textColor = .white
-            label.font = .systemFont(ofSize: 20, weight: .semibold)
-            label.textAlignment = .center
-            label.numberOfLines = 0
-            label.layer.shadowColor = UIColor.black.cgColor
-            label.layer.shadowOffset = CGSize(width: 0, height: 1)
-            label.layer.shadowRadius = 4
-            label.layer.shadowOpacity = 0.9
-            subContainer.addSubview(label)
-
-            // Anchor to the container's raw `bottomAnchor`, not its
-            // `safeAreaLayoutGuide.bottomAnchor`. iPhones with a home
-            // indicator have ~34 pt of safe-area padding at the bottom,
-            // so anchoring to the safe area left a permanent ~34 pt gap
-            // even when the user set the subtitle margin to 0 %. With
-            // the raw anchor, `bottomMarginPercent` is the only thing
-            // that decides where the subtitle sits — 0 % means flush
-            // with the screen bottom. The home indicator auto-hides
-            // during video playback anyway, so subtitles never collide
-            // with a visible system gesture handle.
-            let bottomConstraint = label.bottomAnchor.constraint(equalTo: subContainer.bottomAnchor, constant: -40)
-            NSLayoutConstraint.activate([
-                label.leadingAnchor.constraint(equalTo: subContainer.leadingAnchor, constant: 24),
-                label.trailingAnchor.constraint(equalTo: subContainer.trailingAnchor, constant: -24),
-                bottomConstraint,
-            ])
-            self.subtitleBottomConstraint = bottomConstraint
-
-            self.subtitleLabel = label
-            self.subtitleView = subContainer
 
             // Keep screen awake during playback
             UIApplication.shared.isIdleTimerDisabled = true
@@ -305,6 +263,11 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
     /// user explicitly picks a quality.
     @discardableResult
     private func attachPlayerItem(_ item: AVPlayerItem) -> AVPlayer {
+        // Carry the chosen subtitle styling onto every new item (set before
+        // the first load, kept across loads).
+        if !subtitleStyleRules.isEmpty {
+            item.textStyleRules = subtitleStyleRules
+        }
         if let existing = player {
             existing.replaceCurrentItem(with: item)
             existing.automaticallyWaitsToMinimizeStalling = true
@@ -491,13 +454,6 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
-    @objc func addExternalSubtitle(_ call: CAPPluginCall) {
-        // External subtitle support via AVPlayer requires AVMutableComposition.
-        // Return stub ID — frontend handles subtitle display via HTML overlay.
-        let id = "ext-sub-\(Int(Date().timeIntervalSince1970 * 1000))"
-        call.resolve(["id": id])
-    }
-
     // MARK: - Subtitle Style
 
     @objc func setSubtitleStyle(_ call: CAPPluginCall) {
@@ -505,62 +461,70 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         let foregroundColor = call.getString("foregroundColor") ?? "#FFFFFF"
         let backgroundColor = call.getString("backgroundColor") ?? "transparent"
         let edgeType = call.getString("edgeType") ?? "none"
-        let bottomMargin = CGFloat(call.getFloat("bottomMarginPercent") ?? 8.0)
+        // `bottomMarginPercent` has no AVTextStyleRule equivalent — native
+        // legible captions position themselves; the setting is honoured on
+        // the web/TV (overlay) engines only.
 
         DispatchQueue.main.async { [weak self] in
-            guard let label = self?.subtitleLabel,
-                  let container = self?.subtitleView else {
+            guard let self = self else {
                 call.resolve()
                 return
             }
 
-            // Font size: base 20pt scaled
-            let baseSize: CGFloat = 20.0
-            label.font = .systemFont(ofSize: baseSize * CGFloat(fontScale), weight: .semibold)
-
-            // Foreground color
-            if let argb = self?.parseColor(foregroundColor) {
-                label.textColor = UIColor(
-                    red: argb[1], green: argb[2], blue: argb[3], alpha: argb[0]
-                )
-            }
-
-            // Background
-            if backgroundColor == "transparent" {
-                label.backgroundColor = .clear
-            } else if let argb = self?.parseColor(backgroundColor) {
-                label.backgroundColor = UIColor(
-                    red: argb[1], green: argb[2], blue: argb[3], alpha: argb[0]
-                )
-            }
-
-            // Shadow / edge type
-            switch edgeType {
-            case "drop_shadow":
-                label.layer.shadowColor = UIColor.black.cgColor
-                label.layer.shadowOffset = CGSize(width: 0, height: 2)
-                label.layer.shadowRadius = 4
-                label.layer.shadowOpacity = 0.9
-            case "outline":
-                label.layer.shadowColor = UIColor.black.cgColor
-                label.layer.shadowOffset = .zero
-                label.layer.shadowRadius = 2
-                label.layer.shadowOpacity = 1.0
-            case "raised":
-                label.layer.shadowColor = UIColor.black.cgColor
-                label.layer.shadowOffset = CGSize(width: 1, height: 1)
-                label.layer.shadowRadius = 6
-                label.layer.shadowOpacity = 0.8
-            default:
-                label.layer.shadowOpacity = 0
-            }
-
-            // Bottom margin
-            let screenHeight = UIScreen.main.bounds.height
-            self?.subtitleBottomConstraint?.constant = -(screenHeight * bottomMargin / 100)
-
+            // Native legible rendering: drive AVPlayer's caption styling via
+            // AVTextStyleRule so the app's subtitle settings actually apply.
+            // Without it AVPlayer draws its built-in caption box (grey, semi-
+            // opaque) regardless of the chosen background. Stored so each
+            // newly attached item picks the same rules up (see attachPlayerItem).
+            let rules = self.buildSubtitleStyleRules(
+                fontScale: fontScale,
+                foregroundColor: foregroundColor,
+                backgroundColor: backgroundColor,
+                edgeType: edgeType
+            )
+            self.subtitleStyleRules = rules
+            self.player?.currentItem?.textStyleRules = rules
             call.resolve()
         }
+    }
+
+    /// Map the app's subtitle-style settings to AVTextStyleRule attributes so
+    /// AVPlayer's native legible caption rendering honours them — most
+    /// importantly a transparent background (no caption box) when the user
+    /// hasn't chosen one. Returns an empty list if the markup attributes can't
+    /// be formed, leaving AVPlayer's defaults in place.
+    private func buildSubtitleStyleRules(
+        fontScale: Float,
+        foregroundColor: String,
+        backgroundColor: String,
+        edgeType: String
+    ) -> [AVTextStyleRule] {
+        var attrs: [String: Any] = [:]
+        if let fg = parseColor(foregroundColor) {
+            attrs[kCMTextMarkupAttribute_ForegroundColorARGB as String] = fg
+        }
+        // "transparent" → fully transparent ARGB so no caption box is drawn.
+        let bg: [CGFloat] =
+            backgroundColor == "transparent"
+            ? [0, 0, 0, 0]
+            : (parseColor(backgroundColor) ?? [0, 0, 0, 0])
+        attrs[kCMTextMarkupAttribute_BackgroundColorARGB as String] = bg
+        // Font size as a percentage of video height (~5% ≈ AVPlayer's default
+        // caption size), scaled by the user's size factor.
+        attrs[kCMTextMarkupAttribute_BaseFontSizePercentageRelativeToVideoHeight as String] =
+            Double(5.0 * fontScale)
+        let edge: CFString
+        switch edgeType {
+        case "drop_shadow": edge = kCMTextMarkupCharacterEdgeStyle_DropShadow
+        case "outline": edge = kCMTextMarkupCharacterEdgeStyle_Uniform
+        case "raised": edge = kCMTextMarkupCharacterEdgeStyle_Raised
+        default: edge = kCMTextMarkupCharacterEdgeStyle_None
+        }
+        attrs[kCMTextMarkupAttribute_CharacterEdgeStyle as String] = edge
+        guard let rule = AVTextStyleRule(textMarkupAttributes: attrs) else {
+            return []
+        }
+        return [rule]
     }
 
     // MARK: - Brightness
@@ -629,16 +593,6 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         case 360..<480: return 1_500_000     // profile 1M, next 2M
         case 240..<360: return 750_000       // profile 500k, next 1M
         default: return 350_000              // 144p profile 200k, next 500k
-        }
-    }
-
-    // MARK: - Subtitles (HTML-free overlay)
-
-    @objc func setSubtitleText(_ call: CAPPluginCall) {
-        let text = call.getString("text") ?? ""
-        DispatchQueue.main.async { [weak self] in
-            self?.subtitleLabel?.text = text.isEmpty ? nil : text
-            call.resolve()
         }
     }
 
@@ -816,11 +770,7 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         playerLayer = nil
         playerView?.removeFromSuperview()
         playerView = nil
-        subtitleView?.removeFromSuperview()
-        subtitleView = nil
-        subtitleLabel = nil
-        subtitleBottomConstraint = nil
-
+        subtitleStyleRules = []
 
         // Restore brightness
         if let saved = savedBrightness {

--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -488,29 +488,31 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
-    /// Map the app's subtitle-style settings to AVTextStyleRule attributes so
-    /// AVPlayer's native legible caption rendering honours them — most
-    /// importantly a transparent background (no caption box) when the user
-    /// hasn't chosen one. Returns an empty list if the markup attributes can't
-    /// be formed, leaving AVPlayer's defaults in place.
+    /// Map the app's subtitle-style settings to AVTextStyleRule rules for
+    /// AVPlayer's native legible caption rendering. Returns two rules: a
+    /// global one (foreground / size / edge / background) and a second
+    /// background rule scoped via `textSelector` to target the caption box
+    /// specifically — the global rule's background appears to apply to the
+    /// text run rather than the box, leaving a semi-opaque box behind.
     private func buildSubtitleStyleRules(
         fontScale: Float,
         foregroundColor: String,
         backgroundColor: String,
         edgeType: String
     ) -> [AVTextStyleRule] {
-        var attrs: [String: Any] = [:]
-        if let fg = parseColor(foregroundColor) {
-            attrs[kCMTextMarkupAttribute_ForegroundColorARGB as String] = fg
-        }
-        // "transparent" → fully transparent ARGB so no caption box is drawn.
-        // Set BOTH backgrounds: AVPlayer draws the visible box behind WebVTT
-        // cues from the *character* background, so clearing only the region
-        // `BackgroundColorARGB` leaves a semi-opaque box behind.
+        var rules: [AVTextStyleRule] = []
+
+        // "transparent" → fully transparent ARGB ([alpha, red, green, blue]).
         let bg: [CGFloat] =
             backgroundColor == "transparent"
             ? [0, 0, 0, 0]
             : (parseColor(backgroundColor) ?? [0, 0, 0, 0])
+
+        // Global rule: foreground, size, edge, and background.
+        var attrs: [String: Any] = [:]
+        if let fg = parseColor(foregroundColor) {
+            attrs[kCMTextMarkupAttribute_ForegroundColorARGB as String] = fg
+        }
         attrs[kCMTextMarkupAttribute_BackgroundColorARGB as String] = bg
         attrs[kCMTextMarkupAttribute_CharacterBackgroundColorARGB as String] = bg
         // Font size as a percentage of video height (~5% ≈ AVPlayer's default
@@ -525,10 +527,24 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         default: edge = kCMTextMarkupCharacterEdgeStyle_None
         }
         attrs[kCMTextMarkupAttribute_CharacterEdgeStyle as String] = edge
-        guard let rule = AVTextStyleRule(textMarkupAttributes: attrs) else {
-            return []
+        if let rule = AVTextStyleRule(textMarkupAttributes: attrs) {
+            rules.append(rule)
         }
-        return [rule]
+
+        // Background-scoped rule: target the caption box background directly
+        // via a textSelector so a transparent value clears the box (the
+        // global rule's background may land on the text run instead).
+        if let bgRule = AVTextStyleRule(
+            textMarkupAttributes: [
+                kCMTextMarkupAttribute_BackgroundColorARGB as String: bg,
+                kCMTextMarkupAttribute_CharacterBackgroundColorARGB as String: bg,
+            ],
+            textSelector: "background"
+        ) {
+            rules.append(bgRule)
+        }
+
+        return rules
     }
 
     // MARK: - Brightness

--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -470,27 +470,18 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
     // MARK: - Subtitle Style
 
     @objc func setSubtitleStyle(_ call: CAPPluginCall) {
-        let fontScale = CGFloat(call.getFloat("fontScale") ?? 1.0)
-        let foregroundColor = call.getString("foregroundColor") ?? "#FFFFFF"
-        let backgroundColor = call.getString("backgroundColor") ?? "transparent"
-        let edgeType = call.getString("edgeType") ?? "none"
-        let bottomMarginPercent = CGFloat(call.getFloat("bottomMarginPercent") ?? 8.0)
-
+        let style = SubtitleStyle(
+            fontScale: CGFloat(call.getFloat("fontScale") ?? 1.0),
+            foregroundHex: call.getString("foregroundColor") ?? "#FFFFFF",
+            backgroundHex: call.getString("backgroundColor") ?? "transparent",
+            edgeType: call.getString("edgeType") ?? "none",
+            bottomMarginPercent: CGFloat(call.getFloat("bottomMarginPercent") ?? 8.0)
+        )
         DispatchQueue.main.async { [weak self] in
             guard let self = self else {
                 call.resolve()
                 return
             }
-            var style = SubtitleStyle()
-            style.fontScale = fontScale
-            style.foregroundColor = Self.uiColor(from: foregroundColor) ?? .white
-            // "transparent" (or an unparseable value) → no box; a real colour
-            // is honoured directly because we own the rendering now.
-            style.backgroundColor = backgroundColor == "transparent"
-                ? nil
-                : Self.uiColor(from: backgroundColor)
-            style.edgeType = edgeType
-            style.bottomMarginFraction = max(0, min(0.45, bottomMarginPercent / 100.0))
             self.currentSubtitleStyle = style
             self.subtitleOverlay?.apply(style)
             call.resolve()
@@ -516,47 +507,40 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
     public func setSubtitleRenderingForPiP(_ inPiP: Bool) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
-            self.subtitleOutput?.suppressesPlayerRendering = !inPiP
-            self.subtitleOverlay?.isHidden = inPiP
-            if !inPiP {
-                // Re-enabling suppression stops future native draws but leaves
-                // the last caption the player rendered during PiP stuck on the
-                // layer (frozen, no longer updating) while the overlay also
-                // draws live cues — a double render. Re-selecting the legible
-                // option forces the player to clear it; the overlay then owns
-                // rendering again.
-                self.flushNativeCaption()
+            if inPiP {
+                self.subtitleOutput?.suppressesPlayerRendering = false
+                self.subtitleOverlay?.isHidden = true
+                return
+            }
+            // Re-enabling suppression stops future native draws but leaves the
+            // last caption the player rendered during PiP stuck on the layer
+            // (frozen). Keep the overlay hidden until that boxed caption is
+            // cleared, then reveal it — otherwise the two briefly overlap.
+            self.subtitleOutput?.suppressesPlayerRendering = true
+            self.subtitleOverlay?.isHidden = true
+            self.flushNativeCaption { [weak self] in
+                self?.subtitleOverlay?.isHidden = false
             }
         }
     }
 
     /// Force the native legible renderer to drop whatever caption it has on
     /// screen by momentarily deselecting and re-selecting the active option.
-    /// The re-select runs on the next runloop hop so the clear is processed
-    /// before the option comes back (a same-tick toggle gets coalesced).
-    private func flushNativeCaption() {
+    /// The re-select (and the completion) run on the next runloop hop so the
+    /// clear is processed before the option comes back — a same-tick toggle
+    /// gets coalesced and the box never clears.
+    private func flushNativeCaption(completion: @escaping () -> Void) {
         guard let item = player?.currentItem,
               let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: .legible),
-              let option = item.currentMediaSelection.selectedMediaOption(in: group) else { return }
+              let option = item.currentMediaSelection.selectedMediaOption(in: group) else {
+            completion()
+            return
+        }
         item.select(nil, in: group)
         DispatchQueue.main.async {
             item.select(option, in: group)
+            completion()
         }
-    }
-
-    /// Flatten a delivered cue into runs that carry only bold / italic; colour,
-    /// size, edge and background all come from the app style in the overlay.
-    private static func runs(from attributed: NSAttributedString) -> [SubtitleRun] {
-        var runs: [SubtitleRun] = []
-        let full = NSRange(location: 0, length: attributed.length)
-        attributed.enumerateAttributes(in: full, options: []) { attrs, range, _ in
-            let text = attributed.attributedSubstring(from: range).string
-            guard !text.isEmpty else { return }
-            let bold = (attrs[NSAttributedString.Key(kCMTextMarkupAttribute_BoldStyle as String)] as? Bool) ?? false
-            let italic = (attrs[NSAttributedString.Key(kCMTextMarkupAttribute_ItalicStyle as String)] as? Bool) ?? false
-            runs.append(SubtitleRun(text: text, bold: bold, italic: italic))
-        }
-        return runs
     }
 
     // MARK: - Brightness
@@ -825,29 +809,6 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         return 0
     }
 
-    /// Parse a hex colour string (#RRGGBB or #AARRGGBB) into a UIColor.
-    private static func uiColor(from hex: String) -> UIColor? {
-        var h = hex.trimmingCharacters(in: .whitespacesAndNewlines)
-        if h.hasPrefix("#") { h.removeFirst() }
-        guard let val = UInt64(h, radix: 16) else { return nil }
-
-        var a: CGFloat = 1.0, r: CGFloat = 1.0, g: CGFloat = 1.0, b: CGFloat = 1.0
-        switch h.count {
-        case 6: // RRGGBB
-            r = CGFloat((val >> 16) & 0xFF) / 255.0
-            g = CGFloat((val >> 8) & 0xFF) / 255.0
-            b = CGFloat(val & 0xFF) / 255.0
-        case 8: // AARRGGBB
-            a = CGFloat((val >> 24) & 0xFF) / 255.0
-            r = CGFloat((val >> 16) & 0xFF) / 255.0
-            g = CGFloat((val >> 8) & 0xFF) / 255.0
-            b = CGFloat(val & 0xFF) / 255.0
-        default:
-            return nil
-        }
-        return UIColor(red: r, green: g, blue: b, alpha: a)
-    }
-
     // MARK: - Event Emitters
 
     private func emitStateChanged(_ state: String) {
@@ -937,142 +898,9 @@ extension NativePlayerPlugin: AVPlayerItemLegibleOutputPushDelegate {
         nativeSampleBuffers nativeSamples: [Any],
         forItemTime itemTime: CMTime
     ) {
-        let cues = strings.map { NativePlayerPlugin.runs(from: $0) }
+        let cues = strings.map { SubtitleRun.runs(from: $0) }
         DispatchQueue.main.async { [weak self] in
             self?.subtitleOverlay?.render(cues)
         }
-    }
-}
-
-// MARK: - Subtitle overlay
-
-/// App-controlled subtitle appearance, mapped from the JS `setSubtitleStyle`.
-private struct SubtitleStyle {
-    var fontScale: CGFloat = 1.0
-    var foregroundColor: UIColor = .white
-    /// nil = transparent (no box). A real colour paints a tight per-line
-    /// highlight behind the text — fully under app control, unlike the
-    /// user-preference-gated system caption box.
-    var backgroundColor: UIColor?
-    var edgeType: String = "none"
-    /// Distance from the bottom edge as a fraction of view height.
-    var bottomMarginFraction: CGFloat = 0.08
-}
-
-/// One styled span of a cue. Only bold / italic are carried from the source;
-/// every other visual is applied from `SubtitleStyle`.
-private struct SubtitleRun {
-    let text: String
-    let bold: Bool
-    let italic: Bool
-}
-
-/// Draws subtitle cues as a no-box, app-styled overlay. Sits above the
-/// AVPlayerLayer and below the transparent WebView. Font size tracks view
-/// height so it scales with rotation and surface size.
-private final class SubtitleOverlayView: UIView {
-    private let label = UILabel()
-    private var style = SubtitleStyle()
-    private var cues: [[SubtitleRun]] = []
-
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        isUserInteractionEnabled = false
-        backgroundColor = .clear
-        label.numberOfLines = 0
-        label.textAlignment = .center
-        label.lineBreakMode = .byWordWrapping
-        addSubview(label)
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
-
-    func apply(_ style: SubtitleStyle) {
-        self.style = style
-        rebuild()
-    }
-
-    /// Replace the displayed cues. Empty array clears the overlay.
-    func render(_ cues: [[SubtitleRun]]) {
-        self.cues = cues
-        rebuild()
-    }
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        rebuild()
-    }
-
-    private func rebuild() {
-        guard bounds.height > 0 else { return }
-        let visible = cues.filter { !$0.isEmpty }
-        if visible.isEmpty {
-            label.attributedText = nil
-            label.isHidden = true
-            return
-        }
-        label.isHidden = false
-        label.attributedText = buildAttributed(visible)
-        positionLabel()
-    }
-
-    private func buildAttributed(_ lines: [[SubtitleRun]]) -> NSAttributedString {
-        let pointSize = max(8, bounds.height * 0.05 * style.fontScale)
-        let base = UIFont.systemFont(ofSize: pointSize, weight: .semibold)
-        let out = NSMutableAttributedString()
-        for (lineIdx, runs) in lines.enumerated() {
-            if lineIdx > 0 { out.append(NSAttributedString(string: "\n")) }
-            for run in runs {
-                var traits: UIFontDescriptor.SymbolicTraits = []
-                if run.bold { traits.insert(.traitBold) }
-                if run.italic { traits.insert(.traitItalic) }
-                let font: UIFont
-                if !traits.isEmpty, let desc = base.fontDescriptor.withSymbolicTraits(traits) {
-                    font = UIFont(descriptor: desc, size: pointSize)
-                } else {
-                    font = base
-                }
-                var attrs: [NSAttributedString.Key: Any] = [
-                    .font: font,
-                    .foregroundColor: style.foregroundColor,
-                ]
-                if let bg = style.backgroundColor {
-                    attrs[.backgroundColor] = bg
-                }
-                applyEdge(&attrs, pointSize: pointSize)
-                out.append(NSAttributedString(string: run.text, attributes: attrs))
-            }
-        }
-        return out
-    }
-
-    private func applyEdge(_ attrs: inout [NSAttributedString.Key: Any], pointSize: CGFloat) {
-        switch style.edgeType {
-        case "drop_shadow", "raised":
-            let shadow = NSShadow()
-            shadow.shadowColor = UIColor.black.withAlphaComponent(0.9)
-            shadow.shadowOffset = CGSize(width: 0, height: 1)
-            shadow.shadowBlurRadius = pointSize * 0.12
-            attrs[.shadow] = shadow
-        case "outline":
-            attrs[.strokeColor] = UIColor.black
-            attrs[.strokeWidth] = -3.0
-        default:
-            break
-        }
-    }
-
-    private func positionLabel() {
-        let maxWidth = bounds.width * 0.9
-        let fit = label.sizeThatFits(CGSize(width: maxWidth, height: bounds.height))
-        let w = min(fit.width, maxWidth)
-        let bottomInset = bounds.height * style.bottomMarginFraction
-        label.frame = CGRect(
-            x: (bounds.width - w) / 2,
-            y: max(0, bounds.height - bottomInset - fit.height),
-            width: w,
-            height: fit.height
-        )
     }
 }

--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -59,6 +59,9 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
     private var subtitleOverlay: SubtitleOverlayView?
     private var currentSubtitleStyle = SubtitleStyle()
     private let legibleQueue = DispatchQueue(label: "fliks.subtitle.legible")
+    /// Legible option deselected to clear the native caption while leaving PiP,
+    /// restored once PiP has fully exited.
+    private var pipDeselectedSubtitle: AVMediaSelectionOption?
 
     /// Exposed for PipPlugin to access the player layer.
     public var activePlayerLayer: AVPlayerLayer? { playerLayer }
@@ -504,43 +507,51 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
     /// PiP can only mirror the AVPlayerLayer, not the overlay subview. While
     /// PiP is active, lift suppression so AVPlayer renders the (boxed) native
     /// caption into the mirrored layer; restore the overlay on exit.
+    /// PiP enter / will-stop. Entering: let AVPlayer draw the (boxed) native
+    /// caption into the mirrored layer and hide the overlay. Will-stop:
+    /// re-suppress and clear the native caption, but keep the overlay hidden —
+    /// it is revealed only once PiP has fully exited (`finishSubtitlePiPExit`),
+    /// otherwise it overlaps the boxed caption during the restore animation.
     public func setSubtitleRenderingForPiP(_ inPiP: Bool) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             if inPiP {
                 self.subtitleOutput?.suppressesPlayerRendering = false
                 self.subtitleOverlay?.isHidden = true
-                return
-            }
-            // Re-enabling suppression stops future native draws but leaves the
-            // last caption the player rendered during PiP stuck on the layer
-            // (frozen). Keep the overlay hidden until that boxed caption is
-            // cleared, then reveal it — otherwise the two briefly overlap.
-            self.subtitleOutput?.suppressesPlayerRendering = true
-            self.subtitleOverlay?.isHidden = true
-            self.flushNativeCaption { [weak self] in
-                self?.subtitleOverlay?.isHidden = false
+            } else {
+                self.subtitleOutput?.suppressesPlayerRendering = true
+                self.subtitleOverlay?.isHidden = true
+                self.clearNativeCaption()
             }
         }
     }
 
-    /// Force the native legible renderer to drop whatever caption it has on
-    /// screen by momentarily deselecting and re-selecting the active option.
-    /// The re-select (and the completion) run on the next runloop hop so the
-    /// clear is processed before the option comes back — a same-tick toggle
-    /// gets coalesced and the box never clears.
-    private func flushNativeCaption(completion: @escaping () -> Void) {
+    /// Called once PiP has fully stopped (after the restore animation). Restores
+    /// the legible cue flow to the output and reveals the no-box overlay.
+    public func finishSubtitlePiPExit() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.restoreLegibleSelection()
+            self.subtitleOverlay?.isHidden = false
+        }
+    }
+
+    /// Deselect the legible option to drop the caption the player rendered
+    /// during PiP (re-suppressing alone leaves the last cue frozen on screen).
+    /// The option is remembered so cue delivery can be restored on exit.
+    private func clearNativeCaption() {
         guard let item = player?.currentItem,
-              let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: .legible),
-              let option = item.currentMediaSelection.selectedMediaOption(in: group) else {
-            completion()
-            return
-        }
+              let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: .legible) else { return }
+        pipDeselectedSubtitle = item.currentMediaSelection.selectedMediaOption(in: group)
         item.select(nil, in: group)
-        DispatchQueue.main.async {
-            item.select(option, in: group)
-            completion()
-        }
+    }
+
+    private func restoreLegibleSelection() {
+        guard let option = pipDeselectedSubtitle,
+              let item = player?.currentItem,
+              let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: .legible) else { return }
+        item.select(option, in: group)
+        pipDeselectedSubtitle = nil
     }
 
     // MARK: - Brightness

--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -515,8 +515,32 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
     /// caption into the mirrored layer; restore the overlay on exit.
     public func setSubtitleRenderingForPiP(_ inPiP: Bool) {
         DispatchQueue.main.async { [weak self] in
-            self?.subtitleOutput?.suppressesPlayerRendering = !inPiP
-            self?.subtitleOverlay?.isHidden = inPiP
+            guard let self = self else { return }
+            self.subtitleOutput?.suppressesPlayerRendering = !inPiP
+            self.subtitleOverlay?.isHidden = inPiP
+            if !inPiP {
+                // Re-enabling suppression stops future native draws but leaves
+                // the last caption the player rendered during PiP stuck on the
+                // layer (frozen, no longer updating) while the overlay also
+                // draws live cues — a double render. Re-selecting the legible
+                // option forces the player to clear it; the overlay then owns
+                // rendering again.
+                self.flushNativeCaption()
+            }
+        }
+    }
+
+    /// Force the native legible renderer to drop whatever caption it has on
+    /// screen by momentarily deselecting and re-selecting the active option.
+    /// The re-select runs on the next runloop hop so the clear is processed
+    /// before the option comes back (a same-tick toggle gets coalesced).
+    private func flushNativeCaption() {
+        guard let item = player?.currentItem,
+              let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: .legible),
+              let option = item.currentMediaSelection.selectedMediaOption(in: group) else { return }
+        item.select(nil, in: group)
+        DispatchQueue.main.async {
+            item.select(option, in: group)
         }
     }
 

--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -295,7 +295,6 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             // Index 0 keeps the video beneath the subtitle overlay subview.
             view.layer.insertSublayer(layer, at: 0)
             playerLayer = layer
-            subtitleOverlay?.videoLayer = layer
         } else {
             playerLayer?.player = player
         }

--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -50,10 +50,15 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
     private var firstFrameObserver: NSKeyValueObservation?
     private var firstFrameEmitted = false
     private var savedBrightness: CGFloat?
-    /// AVTextStyleRule built from the app's subtitle-style settings, applied
-    /// to each AVPlayerItem so native (legible) caption rendering honours the
-    /// chosen colours / background instead of AVPlayer's default grey box.
-    private var subtitleStyleRules: [AVTextStyleRule] = []
+    /// Cues are pulled off the selected legible track via this output with
+    /// player rendering suppressed, then drawn by `subtitleOverlay` so the app
+    /// fully controls styling and no system caption box appears. Inside PiP
+    /// (where the overlay isn't captured) suppression is lifted so the native
+    /// track draws into the mirrored layer instead.
+    private var subtitleOutput: AVPlayerItemLegibleOutput?
+    private var subtitleOverlay: SubtitleOverlayView?
+    private var currentSubtitleStyle = SubtitleStyle()
+    private let legibleQueue = DispatchQueue(label: "fliks.subtitle.legible")
 
     /// Exposed for PipPlugin to access the player layer.
     public var activePlayerLayer: AVPlayerLayer? { playerLayer }
@@ -96,6 +101,14 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             webView.scrollView.backgroundColor = .clear
 
             self.playerView = view
+
+            // Custom subtitle overlay above the AVPlayerLayer (and below the
+            // transparent WebView, so Angular controls stay on top).
+            let overlay = SubtitleOverlayView(frame: view.bounds)
+            overlay.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+            overlay.apply(self.currentSubtitleStyle)
+            view.addSubview(overlay)
+            self.subtitleOverlay = overlay
 
             // Keep screen awake during playback
             UIApplication.shared.isIdleTimerDisabled = true
@@ -149,6 +162,7 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             self.removeObservers()
             self.firstFrameEmitted = false
             self.player?.pause()
+            self.subtitleOverlay?.render([])
 
             // Audio session can be flipped out of `.playback` by a phone
             // call, route change, or Siri. AppDelegate sets it once at
@@ -263,11 +277,9 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
     /// user explicitly picks a quality.
     @discardableResult
     private func attachPlayerItem(_ item: AVPlayerItem) -> AVPlayer {
-        // Carry the chosen subtitle styling onto every new item (set before
-        // the first load, kept across loads).
-        if !subtitleStyleRules.isEmpty {
-            item.textStyleRules = subtitleStyleRules
-        }
+        // Pull cues off the legible track ourselves (player rendering
+        // suppressed) so the custom overlay can draw them box-free.
+        attachLegibleOutput(to: item)
         if let existing = player {
             existing.replaceCurrentItem(with: item)
             existing.automaticallyWaitsToMinimizeStalling = true
@@ -280,7 +292,8 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             let layer = AVPlayerLayer(player: player)
             layer.frame = view.bounds
             layer.videoGravity = .resizeAspect
-            view.layer.addSublayer(layer)
+            // Index 0 keeps the video beneath the subtitle overlay subview.
+            view.layer.insertSublayer(layer, at: 0)
             playerLayer = layer
         } else {
             playerLayer?.player = player
@@ -457,94 +470,69 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
     // MARK: - Subtitle Style
 
     @objc func setSubtitleStyle(_ call: CAPPluginCall) {
-        let fontScale = call.getFloat("fontScale") ?? 1.0
+        let fontScale = CGFloat(call.getFloat("fontScale") ?? 1.0)
         let foregroundColor = call.getString("foregroundColor") ?? "#FFFFFF"
         let backgroundColor = call.getString("backgroundColor") ?? "transparent"
         let edgeType = call.getString("edgeType") ?? "none"
-        // `bottomMarginPercent` has no AVTextStyleRule equivalent — native
-        // legible captions position themselves; the setting is honoured on
-        // the web/TV (overlay) engines only.
+        let bottomMarginPercent = CGFloat(call.getFloat("bottomMarginPercent") ?? 8.0)
 
         DispatchQueue.main.async { [weak self] in
             guard let self = self else {
                 call.resolve()
                 return
             }
-
-            // Native legible rendering: drive AVPlayer's caption styling via
-            // AVTextStyleRule so the app's subtitle settings actually apply.
-            // Without it AVPlayer draws its built-in caption box (grey, semi-
-            // opaque) regardless of the chosen background. Stored so each
-            // newly attached item picks the same rules up (see attachPlayerItem).
-            let rules = self.buildSubtitleStyleRules(
-                fontScale: fontScale,
-                foregroundColor: foregroundColor,
-                backgroundColor: backgroundColor,
-                edgeType: edgeType
-            )
-            self.subtitleStyleRules = rules
-            self.player?.currentItem?.textStyleRules = rules
+            var style = SubtitleStyle()
+            style.fontScale = fontScale
+            style.foregroundColor = Self.uiColor(from: foregroundColor) ?? .white
+            // "transparent" (or an unparseable value) → no box; a real colour
+            // is honoured directly because we own the rendering now.
+            style.backgroundColor = backgroundColor == "transparent"
+                ? nil
+                : Self.uiColor(from: backgroundColor)
+            style.edgeType = edgeType
+            style.bottomMarginFraction = max(0, min(0.45, bottomMarginPercent / 100.0))
+            self.currentSubtitleStyle = style
+            self.subtitleOverlay?.apply(style)
             call.resolve()
         }
     }
 
-    /// Map the app's subtitle-style settings to AVTextStyleRule rules for
-    /// AVPlayer's native legible caption rendering. Returns two rules: a
-    /// global one (foreground / size / edge / background) and a second
-    /// background rule scoped via `textSelector` to target the caption box
-    /// specifically — the global rule's background appears to apply to the
-    /// text run rather than the box, leaving a semi-opaque box behind.
-    private func buildSubtitleStyleRules(
-        fontScale: Float,
-        foregroundColor: String,
-        backgroundColor: String,
-        edgeType: String
-    ) -> [AVTextStyleRule] {
-        var rules: [AVTextStyleRule] = []
+    /// Attach a legible output to the item with player rendering suppressed:
+    /// cues are delivered to the delegate (and drawn by `subtitleOverlay`)
+    /// while AVPlayer draws no caption box. `.sourceAndRulesOnly` keeps the
+    /// system's user-preference styling (the box) out of the delivered cues.
+    private func attachLegibleOutput(to item: AVPlayerItem) {
+        let output = AVPlayerItemLegibleOutput()
+        output.suppressesPlayerRendering = true
+        output.textStylingResolution = .sourceAndRulesOnly
+        output.setDelegate(self, queue: legibleQueue)
+        item.add(output)
+        subtitleOutput = output
+    }
 
-        // "transparent" → fully transparent ARGB ([alpha, red, green, blue]).
-        let bg: [CGFloat] =
-            backgroundColor == "transparent"
-            ? [0, 0, 0, 0]
-            : (parseColor(backgroundColor) ?? [0, 0, 0, 0])
+    /// PiP can only mirror the AVPlayerLayer, not the overlay subview. While
+    /// PiP is active, lift suppression so AVPlayer renders the (boxed) native
+    /// caption into the mirrored layer; restore the overlay on exit.
+    public func setSubtitleRenderingForPiP(_ inPiP: Bool) {
+        DispatchQueue.main.async { [weak self] in
+            self?.subtitleOutput?.suppressesPlayerRendering = !inPiP
+            self?.subtitleOverlay?.isHidden = inPiP
+        }
+    }
 
-        // Global rule: foreground, size, edge, and background.
-        var attrs: [String: Any] = [:]
-        if let fg = parseColor(foregroundColor) {
-            attrs[kCMTextMarkupAttribute_ForegroundColorARGB as String] = fg
+    /// Flatten a delivered cue into runs that carry only bold / italic; colour,
+    /// size, edge and background all come from the app style in the overlay.
+    private static func runs(from attributed: NSAttributedString) -> [SubtitleRun] {
+        var runs: [SubtitleRun] = []
+        let full = NSRange(location: 0, length: attributed.length)
+        attributed.enumerateAttributes(in: full, options: []) { attrs, range, _ in
+            let text = attributed.attributedSubstring(from: range).string
+            guard !text.isEmpty else { return }
+            let bold = (attrs[NSAttributedString.Key(kCMTextMarkupAttribute_BoldStyle as String)] as? Bool) ?? false
+            let italic = (attrs[NSAttributedString.Key(kCMTextMarkupAttribute_ItalicStyle as String)] as? Bool) ?? false
+            runs.append(SubtitleRun(text: text, bold: bold, italic: italic))
         }
-        attrs[kCMTextMarkupAttribute_BackgroundColorARGB as String] = bg
-        attrs[kCMTextMarkupAttribute_CharacterBackgroundColorARGB as String] = bg
-        // Font size as a percentage of video height (~5% ≈ AVPlayer's default
-        // caption size), scaled by the user's size factor.
-        attrs[kCMTextMarkupAttribute_BaseFontSizePercentageRelativeToVideoHeight as String] =
-            Double(5.0 * fontScale)
-        let edge: CFString
-        switch edgeType {
-        case "drop_shadow": edge = kCMTextMarkupCharacterEdgeStyle_DropShadow
-        case "outline": edge = kCMTextMarkupCharacterEdgeStyle_Uniform
-        case "raised": edge = kCMTextMarkupCharacterEdgeStyle_Raised
-        default: edge = kCMTextMarkupCharacterEdgeStyle_None
-        }
-        attrs[kCMTextMarkupAttribute_CharacterEdgeStyle as String] = edge
-        if let rule = AVTextStyleRule(textMarkupAttributes: attrs) {
-            rules.append(rule)
-        }
-
-        // Background-scoped rule: target the caption box background directly
-        // via a textSelector so a transparent value clears the box (the
-        // global rule's background may land on the text run instead).
-        if let bgRule = AVTextStyleRule(
-            textMarkupAttributes: [
-                kCMTextMarkupAttribute_BackgroundColorARGB as String: bg,
-                kCMTextMarkupAttribute_CharacterBackgroundColorARGB as String: bg,
-            ],
-            textSelector: "background"
-        ) {
-            rules.append(bgRule)
-        }
-
-        return rules
+        return runs
     }
 
     // MARK: - Brightness
@@ -790,7 +778,9 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         playerLayer = nil
         playerView?.removeFromSuperview()
         playerView = nil
-        subtitleStyleRules = []
+        subtitleOutput = nil
+        subtitleOverlay?.removeFromSuperview()
+        subtitleOverlay = nil
 
         // Restore brightness
         if let saved = savedBrightness {
@@ -811,18 +801,13 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         return 0
     }
 
-    /// Parse hex color string (#RGB, #RRGGBB, #AARRGGBB) into ARGB array for CMTextMarkup.
-    private func parseColor(_ hex: String) -> [CGFloat]? {
+    /// Parse a hex colour string (#RRGGBB or #AARRGGBB) into a UIColor.
+    private static func uiColor(from hex: String) -> UIColor? {
         var h = hex.trimmingCharacters(in: .whitespacesAndNewlines)
         if h.hasPrefix("#") { h.removeFirst() }
-
-        var a: CGFloat = 1.0
-        var r: CGFloat = 1.0
-        var g: CGFloat = 1.0
-        var b: CGFloat = 1.0
-
         guard let val = UInt64(h, radix: 16) else { return nil }
 
+        var a: CGFloat = 1.0, r: CGFloat = 1.0, g: CGFloat = 1.0, b: CGFloat = 1.0
         switch h.count {
         case 6: // RRGGBB
             r = CGFloat((val >> 16) & 0xFF) / 255.0
@@ -836,8 +821,7 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         default:
             return nil
         }
-
-        return [a, r, g, b]
+        return UIColor(red: r, green: g, blue: b, alpha: a)
     }
 
     // MARK: - Event Emitters
@@ -917,5 +901,154 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         DispatchQueue.main.async { [weak self] in
             self?.bridge?.webView?.evaluateJavaScript(js)
         }
+    }
+}
+
+// MARK: - Legible output delegate
+
+extension NativePlayerPlugin: AVPlayerItemLegibleOutputPushDelegate {
+    public func legibleOutput(
+        _ output: AVPlayerItemLegibleOutput,
+        didOutputAttributedStrings strings: [NSAttributedString],
+        nativeSampleBuffers nativeSamples: [Any],
+        forItemTime itemTime: CMTime
+    ) {
+        let cues = strings.map { NativePlayerPlugin.runs(from: $0) }
+        DispatchQueue.main.async { [weak self] in
+            self?.subtitleOverlay?.render(cues)
+        }
+    }
+}
+
+// MARK: - Subtitle overlay
+
+/// App-controlled subtitle appearance, mapped from the JS `setSubtitleStyle`.
+private struct SubtitleStyle {
+    var fontScale: CGFloat = 1.0
+    var foregroundColor: UIColor = .white
+    /// nil = transparent (no box). A real colour paints a tight per-line
+    /// highlight behind the text — fully under app control, unlike the
+    /// user-preference-gated system caption box.
+    var backgroundColor: UIColor?
+    var edgeType: String = "none"
+    /// Distance from the bottom edge as a fraction of view height.
+    var bottomMarginFraction: CGFloat = 0.08
+}
+
+/// One styled span of a cue. Only bold / italic are carried from the source;
+/// every other visual is applied from `SubtitleStyle`.
+private struct SubtitleRun {
+    let text: String
+    let bold: Bool
+    let italic: Bool
+}
+
+/// Draws subtitle cues as a no-box, app-styled overlay. Sits above the
+/// AVPlayerLayer and below the transparent WebView. Font size tracks view
+/// height so it scales with rotation and surface size.
+private final class SubtitleOverlayView: UIView {
+    private let label = UILabel()
+    private var style = SubtitleStyle()
+    private var cues: [[SubtitleRun]] = []
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isUserInteractionEnabled = false
+        backgroundColor = .clear
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.lineBreakMode = .byWordWrapping
+        addSubview(label)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func apply(_ style: SubtitleStyle) {
+        self.style = style
+        rebuild()
+    }
+
+    /// Replace the displayed cues. Empty array clears the overlay.
+    func render(_ cues: [[SubtitleRun]]) {
+        self.cues = cues
+        rebuild()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        rebuild()
+    }
+
+    private func rebuild() {
+        guard bounds.height > 0 else { return }
+        let visible = cues.filter { !$0.isEmpty }
+        if visible.isEmpty {
+            label.attributedText = nil
+            label.isHidden = true
+            return
+        }
+        label.isHidden = false
+        label.attributedText = buildAttributed(visible)
+        positionLabel()
+    }
+
+    private func buildAttributed(_ lines: [[SubtitleRun]]) -> NSAttributedString {
+        let pointSize = max(8, bounds.height * 0.05 * style.fontScale)
+        let base = UIFont.systemFont(ofSize: pointSize, weight: .semibold)
+        let out = NSMutableAttributedString()
+        for (lineIdx, runs) in lines.enumerated() {
+            if lineIdx > 0 { out.append(NSAttributedString(string: "\n")) }
+            for run in runs {
+                var traits: UIFontDescriptor.SymbolicTraits = []
+                if run.bold { traits.insert(.traitBold) }
+                if run.italic { traits.insert(.traitItalic) }
+                let font: UIFont
+                if !traits.isEmpty, let desc = base.fontDescriptor.withSymbolicTraits(traits) {
+                    font = UIFont(descriptor: desc, size: pointSize)
+                } else {
+                    font = base
+                }
+                var attrs: [NSAttributedString.Key: Any] = [
+                    .font: font,
+                    .foregroundColor: style.foregroundColor,
+                ]
+                if let bg = style.backgroundColor {
+                    attrs[.backgroundColor] = bg
+                }
+                applyEdge(&attrs, pointSize: pointSize)
+                out.append(NSAttributedString(string: run.text, attributes: attrs))
+            }
+        }
+        return out
+    }
+
+    private func applyEdge(_ attrs: inout [NSAttributedString.Key: Any], pointSize: CGFloat) {
+        switch style.edgeType {
+        case "drop_shadow", "raised":
+            let shadow = NSShadow()
+            shadow.shadowColor = UIColor.black.withAlphaComponent(0.9)
+            shadow.shadowOffset = CGSize(width: 0, height: 1)
+            shadow.shadowBlurRadius = pointSize * 0.12
+            attrs[.shadow] = shadow
+        case "outline":
+            attrs[.strokeColor] = UIColor.black
+            attrs[.strokeWidth] = -3.0
+        default:
+            break
+        }
+    }
+
+    private func positionLabel() {
+        let maxWidth = bounds.width * 0.9
+        let fit = label.sizeThatFits(CGSize(width: maxWidth, height: bounds.height))
+        let w = min(fit.width, maxWidth)
+        let bottomInset = bounds.height * style.bottomMarginFraction
+        label.frame = CGRect(
+            x: (bounds.width - w) / 2,
+            y: max(0, bounds.height - bottomInset - fit.height),
+            width: w,
+            height: fit.height
+        )
     }
 }

--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -295,6 +295,7 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             // Index 0 keeps the video beneath the subtitle overlay subview.
             view.layer.insertSublayer(layer, at: 0)
             playerLayer = layer
+            subtitleOverlay?.videoLayer = layer
         } else {
             playerLayer?.player = player
         }

--- a/client/ios/App/App/PipPlugin.swift
+++ b/client/ios/App/App/PipPlugin.swift
@@ -113,11 +113,14 @@ public class PipPlugin: CAPPlugin, CAPBridgedPlugin, AVPictureInPictureControlle
     }
 
     public func pictureInPictureControllerWillStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
-        // Back to fullscreen: restore the no-box overlay.
+        // Re-suppress and clear the native caption now; the overlay is revealed
+        // only once PiP has fully exited (didStop) so it doesn't overlap the
+        // boxed caption during the restore animation.
         nativePlayer?.setSubtitleRenderingForPiP(false)
     }
 
     public func pictureInPictureControllerDidStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+        nativePlayer?.finishSubtitlePiPExit()
         emitPipModeChanged(false)
         pipController = nil
     }

--- a/client/ios/App/App/PipPlugin.swift
+++ b/client/ios/App/App/PipPlugin.swift
@@ -78,14 +78,17 @@ public class PipPlugin: CAPPlugin, CAPBridgedPlugin, AVPictureInPictureControlle
 
     // MARK: - Private
 
+    private var nativePlayer: NativePlayerPlugin? {
+        bridge?.plugin(withName: "NativePlayer") as? NativePlayerPlugin
+    }
+
     private func getOrCreateController() -> AVPictureInPictureController? {
         if let existing = pipController { return existing }
 
         guard AVPictureInPictureController.isPictureInPictureSupported() else { return nil }
 
         // Get the player layer from NativePlayerPlugin
-        guard let nativePlayer = bridge?.plugin(withName: "NativePlayer") as? NativePlayerPlugin,
-              let playerLayer = nativePlayer.activePlayerLayer else {
+        guard let playerLayer = nativePlayer?.activePlayerLayer else {
             return nil
         }
 
@@ -99,8 +102,19 @@ public class PipPlugin: CAPPlugin, CAPBridgedPlugin, AVPictureInPictureControlle
 
     // MARK: - AVPictureInPictureControllerDelegate
 
+    public func pictureInPictureControllerWillStartPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+        // The custom subtitle overlay isn't captured by PiP — hand rendering to
+        // the native (boxed) caption track for the duration of the PiP window.
+        nativePlayer?.setSubtitleRenderingForPiP(true)
+    }
+
     public func pictureInPictureControllerDidStartPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
         emitPipModeChanged(true)
+    }
+
+    public func pictureInPictureControllerWillStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+        // Back to fullscreen: restore the no-box overlay.
+        nativePlayer?.setSubtitleRenderingForPiP(false)
     }
 
     public func pictureInPictureControllerDidStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {

--- a/client/ios/App/App/SubtitleOverlayView.swift
+++ b/client/ios/App/App/SubtitleOverlayView.swift
@@ -1,5 +1,4 @@
 import UIKit
-import AVFoundation
 import CoreMedia
 
 // MARK: - Style
@@ -100,21 +99,6 @@ final class SubtitleOverlayView: UIView {
     private var style = SubtitleStyle()
     private var cues: [[SubtitleRun]] = []
 
-    /// The player layer the subtitles belong to. Captions size and anchor to
-    /// the video rectangle, not the full surface, so a 16:9 video letterboxed
-    /// into a portrait screen gets video-sized (not screen-sized) text.
-    weak var videoLayer: AVPlayerLayer?
-
-    /// The rectangle the video occupies (letterboxed under `.resizeAspect`),
-    /// in this view's coordinate space — the player layer is sized to the same
-    /// bounds. Falls back to full bounds before the video dimensions are known.
-    private var videoRect: CGRect {
-        if let rect = videoLayer?.videoRect, rect.width > 1, rect.height > 1 {
-            return rect
-        }
-        return bounds
-    }
-
     override init(frame: CGRect) {
         super.init(frame: frame)
         isUserInteractionEnabled = false
@@ -158,7 +142,11 @@ final class SubtitleOverlayView: UIView {
     }
 
     private func buildAttributed(_ lines: [[SubtitleRun]]) -> NSAttributedString {
-        let pointSize = max(8, videoRect.height * 0.05 * style.fontScale)
+        // Size to the screen's short side so captions stay the same size in
+        // portrait and landscape (the short side is orientation-invariant),
+        // rather than the full height (oversized in portrait) or the
+        // letterboxed video band (undersized in portrait).
+        let pointSize = max(8, min(bounds.width, bounds.height) * 0.05 * style.fontScale)
         let base = UIFont.systemFont(ofSize: pointSize, weight: .semibold)
         let out = NSMutableAttributedString()
         for (lineIdx, runs) in lines.enumerated() {
@@ -204,14 +192,15 @@ final class SubtitleOverlayView: UIView {
     }
 
     private func positionLabel() {
-        let area = videoRect
-        let maxWidth = area.width * 0.9
-        let fit = label.sizeThatFits(CGSize(width: maxWidth, height: area.height))
+        // Anchored to the bottom of the surface (the screen in fullscreen), not
+        // the video rect, so captions sit below a letterboxed video in portrait.
+        let maxWidth = bounds.width * 0.9
+        let fit = label.sizeThatFits(CGSize(width: maxWidth, height: bounds.height))
         let w = min(fit.width, maxWidth)
-        let bottomInset = area.height * style.bottomMarginFraction
+        let bottomInset = bounds.height * style.bottomMarginFraction
         label.frame = CGRect(
-            x: area.minX + (area.width - w) / 2,
-            y: max(area.minY, area.maxY - bottomInset - fit.height),
+            x: (bounds.width - w) / 2,
+            y: max(0, bounds.height - bottomInset - fit.height),
             width: w,
             height: fit.height
         )

--- a/client/ios/App/App/SubtitleOverlayView.swift
+++ b/client/ios/App/App/SubtitleOverlayView.swift
@@ -1,0 +1,202 @@
+import UIKit
+import CoreMedia
+
+// MARK: - Style
+
+/// App-controlled subtitle appearance, mapped from the JS `setSubtitleStyle`.
+struct SubtitleStyle {
+    var fontScale: CGFloat = 1.0
+    var foregroundColor: UIColor = .white
+    /// nil = transparent (no box). A real colour paints a tight per-line
+    /// highlight behind the text — fully under app control, unlike the
+    /// user-preference-gated system caption box.
+    var backgroundColor: UIColor?
+    var edgeType: String = "none"
+    /// Distance from the bottom edge as a fraction of view height.
+    var bottomMarginFraction: CGFloat = 0.08
+}
+
+extension SubtitleStyle {
+    /// Build from the raw JS `setSubtitleStyle` parameters.
+    init(
+        fontScale: CGFloat,
+        foregroundHex: String,
+        backgroundHex: String,
+        edgeType: String,
+        bottomMarginPercent: CGFloat
+    ) {
+        self.init()
+        self.fontScale = fontScale
+        self.foregroundColor = SubtitleStyle.color(fromHex: foregroundHex) ?? .white
+        // "transparent" (or an unparseable value) → no box; a real colour is
+        // honoured directly because the overlay owns the rendering.
+        self.backgroundColor = backgroundHex == "transparent"
+            ? nil
+            : SubtitleStyle.color(fromHex: backgroundHex)
+        self.edgeType = edgeType
+        self.bottomMarginFraction = max(0, min(0.45, bottomMarginPercent / 100.0))
+    }
+
+    /// Parse a hex colour string (#RRGGBB or #AARRGGBB) into a UIColor.
+    static func color(fromHex hex: String) -> UIColor? {
+        var h = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if h.hasPrefix("#") { h.removeFirst() }
+        guard let val = UInt64(h, radix: 16) else { return nil }
+
+        var a: CGFloat = 1.0, r: CGFloat = 1.0, g: CGFloat = 1.0, b: CGFloat = 1.0
+        switch h.count {
+        case 6: // RRGGBB
+            r = CGFloat((val >> 16) & 0xFF) / 255.0
+            g = CGFloat((val >> 8) & 0xFF) / 255.0
+            b = CGFloat(val & 0xFF) / 255.0
+        case 8: // AARRGGBB
+            a = CGFloat((val >> 24) & 0xFF) / 255.0
+            r = CGFloat((val >> 16) & 0xFF) / 255.0
+            g = CGFloat((val >> 8) & 0xFF) / 255.0
+            b = CGFloat(val & 0xFF) / 255.0
+        default:
+            return nil
+        }
+        return UIColor(red: r, green: g, blue: b, alpha: a)
+    }
+}
+
+// MARK: - Cue runs
+
+/// One styled span of a cue. Only bold / italic are carried from the source;
+/// every other visual is applied from `SubtitleStyle`.
+struct SubtitleRun {
+    let text: String
+    let bold: Bool
+    let italic: Bool
+}
+
+extension SubtitleRun {
+    /// Flatten a cue delivered by `AVPlayerItemLegibleOutput` into runs that
+    /// carry only bold / italic; colour, size, edge and background come from
+    /// the app style applied in the overlay.
+    static func runs(from attributed: NSAttributedString) -> [SubtitleRun] {
+        var runs: [SubtitleRun] = []
+        let full = NSRange(location: 0, length: attributed.length)
+        attributed.enumerateAttributes(in: full, options: []) { attrs, range, _ in
+            let text = attributed.attributedSubstring(from: range).string
+            guard !text.isEmpty else { return }
+            let bold = (attrs[NSAttributedString.Key(kCMTextMarkupAttribute_BoldStyle as String)] as? Bool) ?? false
+            let italic = (attrs[NSAttributedString.Key(kCMTextMarkupAttribute_ItalicStyle as String)] as? Bool) ?? false
+            runs.append(SubtitleRun(text: text, bold: bold, italic: italic))
+        }
+        return runs
+    }
+}
+
+// MARK: - Overlay view
+
+/// Draws subtitle cues as a no-box, app-styled overlay. Sits above the
+/// AVPlayerLayer and below the transparent WebView. Font size tracks view
+/// height so it scales with rotation and surface size.
+final class SubtitleOverlayView: UIView {
+    private let label = UILabel()
+    private var style = SubtitleStyle()
+    private var cues: [[SubtitleRun]] = []
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isUserInteractionEnabled = false
+        backgroundColor = .clear
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.lineBreakMode = .byWordWrapping
+        addSubview(label)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func apply(_ style: SubtitleStyle) {
+        self.style = style
+        rebuild()
+    }
+
+    /// Replace the displayed cues. Empty array clears the overlay.
+    func render(_ cues: [[SubtitleRun]]) {
+        self.cues = cues
+        rebuild()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        rebuild()
+    }
+
+    private func rebuild() {
+        guard bounds.height > 0 else { return }
+        let visible = cues.filter { !$0.isEmpty }
+        if visible.isEmpty {
+            label.attributedText = nil
+            label.isHidden = true
+            return
+        }
+        label.isHidden = false
+        label.attributedText = buildAttributed(visible)
+        positionLabel()
+    }
+
+    private func buildAttributed(_ lines: [[SubtitleRun]]) -> NSAttributedString {
+        let pointSize = max(8, bounds.height * 0.05 * style.fontScale)
+        let base = UIFont.systemFont(ofSize: pointSize, weight: .semibold)
+        let out = NSMutableAttributedString()
+        for (lineIdx, runs) in lines.enumerated() {
+            if lineIdx > 0 { out.append(NSAttributedString(string: "\n")) }
+            for run in runs {
+                var traits: UIFontDescriptor.SymbolicTraits = []
+                if run.bold { traits.insert(.traitBold) }
+                if run.italic { traits.insert(.traitItalic) }
+                let font: UIFont
+                if !traits.isEmpty, let desc = base.fontDescriptor.withSymbolicTraits(traits) {
+                    font = UIFont(descriptor: desc, size: pointSize)
+                } else {
+                    font = base
+                }
+                var attrs: [NSAttributedString.Key: Any] = [
+                    .font: font,
+                    .foregroundColor: style.foregroundColor,
+                ]
+                if let bg = style.backgroundColor {
+                    attrs[.backgroundColor] = bg
+                }
+                applyEdge(&attrs, pointSize: pointSize)
+                out.append(NSAttributedString(string: run.text, attributes: attrs))
+            }
+        }
+        return out
+    }
+
+    private func applyEdge(_ attrs: inout [NSAttributedString.Key: Any], pointSize: CGFloat) {
+        switch style.edgeType {
+        case "drop_shadow", "raised":
+            let shadow = NSShadow()
+            shadow.shadowColor = UIColor.black.withAlphaComponent(0.9)
+            shadow.shadowOffset = CGSize(width: 0, height: 1)
+            shadow.shadowBlurRadius = pointSize * 0.12
+            attrs[.shadow] = shadow
+        case "outline":
+            attrs[.strokeColor] = UIColor.black
+            attrs[.strokeWidth] = -3.0
+        default:
+            break
+        }
+    }
+
+    private func positionLabel() {
+        let maxWidth = bounds.width * 0.9
+        let fit = label.sizeThatFits(CGSize(width: maxWidth, height: bounds.height))
+        let w = min(fit.width, maxWidth)
+        let bottomInset = bounds.height * style.bottomMarginFraction
+        label.frame = CGRect(
+            x: (bounds.width - w) / 2,
+            y: max(0, bounds.height - bottomInset - fit.height),
+            width: w,
+            height: fit.height
+        )
+    }
+}

--- a/client/ios/App/App/SubtitleOverlayView.swift
+++ b/client/ios/App/App/SubtitleOverlayView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import AVFoundation
 import CoreMedia
 
 // MARK: - Style
@@ -99,6 +100,21 @@ final class SubtitleOverlayView: UIView {
     private var style = SubtitleStyle()
     private var cues: [[SubtitleRun]] = []
 
+    /// The player layer the subtitles belong to. Captions size and anchor to
+    /// the video rectangle, not the full surface, so a 16:9 video letterboxed
+    /// into a portrait screen gets video-sized (not screen-sized) text.
+    weak var videoLayer: AVPlayerLayer?
+
+    /// The rectangle the video occupies (letterboxed under `.resizeAspect`),
+    /// in this view's coordinate space — the player layer is sized to the same
+    /// bounds. Falls back to full bounds before the video dimensions are known.
+    private var videoRect: CGRect {
+        if let rect = videoLayer?.videoRect, rect.width > 1, rect.height > 1 {
+            return rect
+        }
+        return bounds
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         isUserInteractionEnabled = false
@@ -142,7 +158,7 @@ final class SubtitleOverlayView: UIView {
     }
 
     private func buildAttributed(_ lines: [[SubtitleRun]]) -> NSAttributedString {
-        let pointSize = max(8, bounds.height * 0.05 * style.fontScale)
+        let pointSize = max(8, videoRect.height * 0.05 * style.fontScale)
         let base = UIFont.systemFont(ofSize: pointSize, weight: .semibold)
         let out = NSMutableAttributedString()
         for (lineIdx, runs) in lines.enumerated() {
@@ -188,13 +204,14 @@ final class SubtitleOverlayView: UIView {
     }
 
     private func positionLabel() {
-        let maxWidth = bounds.width * 0.9
-        let fit = label.sizeThatFits(CGSize(width: maxWidth, height: bounds.height))
+        let area = videoRect
+        let maxWidth = area.width * 0.9
+        let fit = label.sizeThatFits(CGSize(width: maxWidth, height: area.height))
         let w = min(fit.width, maxWidth)
-        let bottomInset = bounds.height * style.bottomMarginFraction
+        let bottomInset = area.height * style.bottomMarginFraction
         label.frame = CGRect(
-            x: (bounds.width - w) / 2,
-            y: max(0, bounds.height - bottomInset - fit.height),
+            x: area.minX + (area.width - w) / 2,
+            y: max(area.minY, area.maxY - bottomInset - fit.height),
             width: w,
             height: fit.height
         )

--- a/client/src/app/core/plugins/native-player.plugin.ts
+++ b/client/src/app/core/plugins/native-player.plugin.ts
@@ -84,13 +84,6 @@ export interface NativePlayerPlugin {
   getSubtitleTracks(): Promise<{ tracks: NativeSubtitleTrack[] }>;
   selectSubtitleTrack(options: { id: string | null }): Promise<void>;
 
-  /** Load an external subtitle (WebVTT) by URL. */
-  addExternalSubtitle(options: {
-    url: string;
-    language: string;
-    label: string;
-  }): Promise<{ id: string }>;
-
   // ── Subtitle style ──
 
   /** Apply subtitle appearance settings to the native SubtitleView. */
@@ -116,9 +109,6 @@ export interface NativePlayerPlugin {
 
   getPosition(): Promise<NativePlayerPosition>;
   setPlaybackRate(options: { rate: number }): Promise<void>;
-
-  /** Update the native subtitle label text (iOS: rendered between player and WebView). */
-  setSubtitleText(options: { text: string }): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -79,6 +79,14 @@ export interface DeviceProfile {
    *  side-stepping the probe — at the cost of Dolby pass-through.
    *  Multi-audio Tizen sources stay on fMP4 + var_stream_map. */
   useTsOnSingleAudio?: boolean;
+
+  /** Client consumes HLS `SUBTITLES` renditions from the master playlist
+   *  natively (cues render inside the player pipeline, so they show in
+   *  Picture-in-Picture / AirPlay). When false the backend omits the
+   *  subtitle group and the client renders subtitles itself from a sidecar
+   *  VTT. True for phone/desktop (iOS, Android, web/Shaka); false for TVs,
+   *  whose AVPlay/webOS cue APIs are limited so they keep a DOM overlay. */
+  supportsHlsSubtitles?: boolean;
 }
 
 /** True when `localStorage['fliks.useTs']` is set to a truthy value.
@@ -315,6 +323,12 @@ export class BrowserDeviceProfileService {
       // Cast and native mobile consume muxed fMP4 across the board (webOS's
       // native <video> has no such stall and fMP4 keeps Dolby pass-through).
       useTsOnSingleAudio: tvPlatform === 'tizen',
+      // Phone/desktop clients (iOS AVPlayer, Android ExoPlayer, web Shaka)
+      // consume the master SUBTITLES renditions natively, so cues render
+      // inside the player (PiP / AirPlay / browser PiP). TVs stay false:
+      // they have no PiP and their AVPlay/webOS cue APIs are limited, so the
+      // Tizen/webOS engines keep their DOM overlay (fed by sidecar VTT).
+      supportsHlsSubtitles: !isTv,
     };
   }
 

--- a/client/src/app/core/services/playback-engine/native-engine.ts
+++ b/client/src/app/core/services/playback-engine/native-engine.ts
@@ -1,4 +1,3 @@
-import { Capacitor } from '@capacitor/core';
 import { NativePlayer } from '../../plugins/native-player.plugin';
 import {
   AbstractPlaybackEngine,
@@ -13,12 +12,7 @@ import {
   SUBTITLE_BG_ARGB,
   SUBTITLE_EDGE_KEY,
 } from '../../utils/subtitle-presets';
-
-interface VttCue {
-  start: number;
-  end: number;
-  text: string;
-}
+import { normalizeLangCode } from '../../utils/language.utils';
 
 /**
  * PlaybackEngine implementation backed by the NativePlayer Capacitor plugin
@@ -63,12 +57,23 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
    *  belt-and-suspenders signal. */
   private lastTimeUpdatePos = -1;
 
-  // ── Native subtitle overlay (iOS) ──
-  private readonly _isIos = Capacitor.getPlatform() === 'ios';
-  private _parsedTracks = new Map<string, VttCue[]>();
+  // ── Subtitles ──
+  // Subtitles ship as HLS SUBTITLES renditions in the master playlist; the
+  // native player (AVPlayer legible group / ExoPlayer text tracks) renders
+  // them in its own pipeline so they show in PiP / AirPlay — no app overlay.
+  /** Player's own id ("text-N") of the currently selected track. */
   private _activeTrackId: string | null = null;
-  private _subtitleVisible = false;
-  private _lastCueText = '';
+  /** Desired subtitle (by language/forced), kept until the player surfaces
+   *  its text tracks. The default/saved selection is applied right after
+   *  load() — before ExoPlayer has parsed the manifest's text tracks — so we
+   *  hold the intent and (re)apply it on `nativePlayerTracksChanged`. */
+  private _desiredSubtitle: { language: string; forced: boolean } | null = null;
+  /** Text tracks the player currently reports, refreshed on track changes. */
+  private _nativeSubtitleTracks: {
+    id: string;
+    language: string;
+    label: string;
+  }[] = [];
 
   // ── Lifecycle ──
 
@@ -88,7 +93,7 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
   async destroy(): Promise<void> {
     this._initialized = false;
     this.unbindWindowEvents();
-    this.destroySubtitleOverlay();
+    this._activeTrackId = null;
     // Drop engine event subscribers (every other engine does this in destroy).
     // Without it, each player navigation leaks the previous component's
     // listeners onto the long-lived NativePlayer bridge.
@@ -112,24 +117,22 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
     this.firstFrameEmitted = false;
     this.recoveryAttempted = false;
     this.lastTimeUpdatePos = -1;
-    const subtitles = this._preloadedSubtitles.length > 0
-      ? this._preloadedSubtitles
-      : undefined;
-    await NativePlayer.load({ url, startTime, headers, subtitles, offline: this._offline });
+    // Subtitles are delivered as HLS SUBTITLES renditions in the master
+    // playlist, not sidecar SubtitleConfigurations, so the player surfaces
+    // them as native text tracks — nothing to preload here.
+    await NativePlayer.load({ url, startTime, headers, offline: this._offline });
 
     // Apply subtitle style settings
     if (this._subtitleStyle) {
       await NativePlayer.setSubtitleStyle(this._subtitleStyle);
     }
 
-    // Restore the previously-active subtitle selection. ExoPlayer disables
-    // text tracks by default on every new MediaItem, so a silent reload
-    // (session-expired recovery, cast handoff) would otherwise drop the
-    // user's pick and leave the SubtitleView blank. The plugin's
-    // pendingSubtitleTrackId queues this until onTracksChanged fires.
-    if (this._activeTrackId) {
-      NativePlayer.selectSubtitleTrack({ id: this._activeTrackId }).catch(() => {});
-    }
+    // A new MediaItem resurfaces fresh text tracks: drop the stale resolved
+    // id and let the desired selection (kept across a silent reload —
+    // session-expired recovery, cast handoff) re-apply against the new track
+    // list once `nativePlayerTracksChanged` fires.
+    this._activeTrackId = null;
+    this._nativeSubtitleTracks = [];
   }
 
   private _subtitleStyle: {
@@ -248,50 +251,62 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
   }
 
   async addTextTrack(
-    url: string,
-    _language: string,
+    _url: string,
+    language: string,
     _label: string,
-  ): Promise<string> {
-    // Find the index of this URL in the preloaded subtitles
-    const idx = this._subtitleUrls.indexOf(url);
-    const trackId = idx >= 0 ? `text-${idx}` : `text-0`;
-
-    // On iOS: fetch and parse WebVTT for HTML overlay rendering
-    if (this._isIos && !this._parsedTracks.has(trackId)) {
-      try {
-        const resp = await fetch(url);
-        const vtt = await resp.text();
-        this._parsedTracks.set(trackId, this.parseVtt(vtt));
-      } catch {
-        this._parsedTracks.set(trackId, []);
-      }
-    }
-
-    return trackId;
+    forced = false,
+  ): Promise<{ language: string; forced: boolean }> {
+    // Subtitles are HLS SUBTITLES renditions; the player surfaces them as
+    // native text tracks. Return the desired track descriptor — actual
+    // selection is resolved by language against the player's reported tracks,
+    // which only appear after the manifest is parsed (see resolveSubtitle).
+    return { language, forced };
   }
 
   selectTextTrack(track: any): void {
-    const id = typeof track === 'string' ? track : null;
-    this._activeTrackId = id;
-    if (this._isIos) {
-      this._subtitleVisible = !!id;
-      this.updateSubtitleOverlay();
-    } else {
+    this._desiredSubtitle =
+      track && typeof track === 'object' && track.language
+        ? { language: track.language, forced: !!track.forced }
+        : null;
+    this.resolveSubtitle();
+  }
+
+  setTextVisibility(visible: boolean): void {
+    if (!visible) {
+      this._desiredSubtitle = null;
+      this._activeTrackId = null;
+      NativePlayer.selectSubtitleTrack({ id: null });
+    }
+  }
+
+  /** Map the desired subtitle (by language) to the player's own track id and
+   *  select it. No-op until the player has surfaced its text tracks — the
+   *  `nativePlayerTracksChanged` handler re-runs this, so a default selection
+   *  applied right after load() takes effect as soon as the tracks are ready
+   *  (fixes "subtitle selected by default but hidden" on ExoPlayer). */
+  private resolveSubtitle(): void {
+    if (!this._desiredSubtitle) return;
+    const want = normalizeLangCode(this._desiredSubtitle.language);
+    const id =
+      this._nativeSubtitleTracks.find(
+        (t) => normalizeLangCode(t.language) === want,
+      )?.id ?? null;
+    if (id && id !== this._activeTrackId) {
+      this._activeTrackId = id;
       NativePlayer.selectSubtitleTrack({ id });
     }
   }
 
-  setTextVisibility(visible: boolean): void {
-    if (this._isIos) {
-      this._subtitleVisible = visible;
-      if (!visible) {
-        this._activeTrackId = null;
-        this.updateSubtitleOverlay();
-      }
-    } else if (!visible) {
-      this._activeTrackId = null;
-      NativePlayer.selectSubtitleTrack({ id: null });
-    }
+  /** Refresh the reported text-track list, then (re)apply the desired
+   *  selection. Queried from the plugin because the Android bridge reports an
+   *  empty subtitle list on the track-change event. */
+  private refreshSubtitleTracks(): void {
+    NativePlayer.getSubtitleTracks()
+      .then(({ tracks }) => {
+        this._nativeSubtitleTracks = tracks ?? [];
+        this.resolveSubtitle();
+      })
+      .catch(() => {});
   }
 
   // ── Stats ──
@@ -350,7 +365,6 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
       this._duration = d.duration;
       this._buffered = d.buffered;
       this.emit('timeUpdate', d);
-      this.updateSubtitleOverlay();
       // Fallback for the missing onRenderedFirstFrame case: native only
       // fires nativePlayerTimeUpdate when `player.isPlaying()`, so a
       // position that grows between two updates is a strong signal that
@@ -389,6 +403,9 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
       const d = (e as CustomEvent).detail;
       this._audioTracks = d.audioTracks ?? [];
       this.emit('audioTracksChanged', { tracks: this._audioTracks });
+      // Text tracks are now available — refresh them and apply any pending
+      // (default / saved) subtitle selection that raced ahead of load().
+      this.refreshSubtitleTracks();
     });
 
     bind('nativePlayerFirstFrame', () => {
@@ -403,72 +420,5 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
       window.removeEventListener(event, fn);
     }
     this.listeners = [];
-  }
-
-  // ── Native Subtitle Overlay (iOS) ──
-
-  private updateSubtitleOverlay(): void {
-    if (!this._isIos) return;
-    if (!this._subtitleVisible || !this._activeTrackId) {
-      if (this._lastCueText) {
-        this._lastCueText = '';
-        NativePlayer.setSubtitleText({ text: '' }).catch(() => {});
-      }
-      return;
-    }
-    const cues = this._parsedTracks.get(this._activeTrackId);
-    if (!cues) return;
-    const t = this._currentTime;
-    const active = cues.find(c => t >= c.start && t <= c.end);
-    const text = active?.text?.replace(/<br>/g, '\n').replace(/<[^>]*>/g, '') ?? '';
-    if (text !== this._lastCueText) {
-      this._lastCueText = text;
-      NativePlayer.setSubtitleText({ text }).catch(() => {});
-    }
-  }
-
-  private destroySubtitleOverlay(): void {
-    if (this._isIos) {
-      NativePlayer.setSubtitleText({ text: '' }).catch(() => {});
-    }
-    this._parsedTracks.clear();
-    this._activeTrackId = null;
-    this._subtitleVisible = false;
-    this._lastCueText = '';
-  }
-
-  private parseVtt(raw: string): VttCue[] {
-    const cues: VttCue[] = [];
-    const blocks = raw.replace(/\r\n/g, '\n').split('\n\n');
-    for (const block of blocks) {
-      const lines = block.trim().split('\n');
-      const timeLine = lines.find(l => l.includes('-->'));
-      if (!timeLine) continue;
-      const [startStr, endStr] = timeLine.split('-->').map(s => s.trim());
-      const start = this.vttTimeToSec(startStr);
-      const end = this.vttTimeToSec(endStr);
-      if (isNaN(start) || isNaN(end)) continue;
-      const textLines = lines.slice(lines.indexOf(timeLine) + 1);
-      const text = textLines.join('<br>').replace(/<\/?[^>]*>/g, (tag) => {
-        // Allow <b>, <i>, <u>, <br> — strip everything else
-        if (/^<\/?(b|i|u|br)\s*\/?>$/i.test(tag)) return tag;
-        return '';
-      });
-      if (text) cues.push({ start, end, text });
-    }
-    return cues;
-  }
-
-  private vttTimeToSec(ts: string): number {
-    // Remove positioning metadata (e.g. "00:01:23.456 align:start")
-    const clean = ts.split(' ')[0];
-    const parts = clean.split(':');
-    if (parts.length === 3) {
-      return +parts[0] * 3600 + +parts[1] * 60 + parseFloat(parts[2]);
-    }
-    if (parts.length === 2) {
-      return +parts[0] * 60 + parseFloat(parts[1]);
-    }
-    return NaN;
   }
 }

--- a/client/src/app/core/services/playback-engine/playback-engine.ts
+++ b/client/src/app/core/services/playback-engine/playback-engine.ts
@@ -134,7 +134,11 @@ export interface PlaybackEngine {
   selectAudioTrack(id: string): Promise<void>;
 
   // ── Subtitles ──
-  addTextTrack(url: string, language: string, label: string): Promise<any>;
+  // Subtitles are HLS SUBTITLES renditions in the master playlist; each
+  // engine maps a chosen track to its player's own track by (language,
+  // forced) and returns a handle for `selectTextTrack`. `forced`
+  // disambiguates a full vs forced track of the same language.
+  addTextTrack(url: string, language: string, label: string, forced?: boolean): Promise<any>;
   selectTextTrack(track: any): void;
   setTextVisibility(visible: boolean): void;
 

--- a/client/src/app/core/services/playback-engine/shaka-engine.ts
+++ b/client/src/app/core/services/playback-engine/shaka-engine.ts
@@ -6,6 +6,7 @@ import {
   PlaybackEngine,
   PlaybackState,
 } from './playback-engine';
+import { normalizeLangCode } from '../../utils/language.utils';
 
 /**
  * Shaka Player implementation of the PlaybackEngine interface.
@@ -272,13 +273,38 @@ export class ShakaEngine extends AbstractPlaybackEngine implements PlaybackEngin
 
   // ─── Subtitles ─────────────────────────────────────────────────────
 
-  async addTextTrack(url: string, language: string, label: string): Promise<any> {
+  async addTextTrack(
+    _url: string,
+    language: string,
+    _label: string,
+    forced?: boolean,
+  ): Promise<any> {
     if (!this.player) throw new Error('ShakaEngine not initialised');
-    return this.player.addTextTrackAsync(url, language, 'subtitles', 'text/vtt', undefined, label);
+    // Subtitles ship as HLS SUBTITLES renditions in the manifest. Shaka
+    // parses them into text tracks and still renders them through the
+    // configured UITextDisplayer (so multi-line cue styling is preserved),
+    // so we match the chosen track by (language, forced) instead of loading
+    // a sidecar VTT. Match on normalised language codes — the manifest
+    // LANGUAGE may be 2-letter (`en`) while the option carries 3-letter
+    // (`eng`). Falls back to a language-only match, then the first track.
+    const want = normalizeLangCode(language);
+    const tracks: any[] = this.player.getTextTracks();
+    return (
+      tracks.find((t) => normalizeLangCode(t.language) === want && !!t.forced === !!forced) ??
+      tracks.find((t) => normalizeLangCode(t.language) === want) ??
+      tracks[0] ??
+      null
+    );
   }
 
   selectTextTrack(track: any): void {
+    if (!track) return;
     this.player?.selectTextTrack(track);
+    try {
+      (this.player as any)?.setTextVisibility(true);
+    } catch {
+      // Shaka may throw if no text tracks exist
+    }
   }
 
   setTextVisibility(visible: boolean): void {

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1869,6 +1869,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
             sub.url,
             sub.language,
             sub.label,
+            sub.forced,
           );
           this.engine.selectTextTrack(track);
           this.engine.setTextVisibility(true);
@@ -2233,7 +2234,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         this.activeBurnInId = null;
         if (!this.isOfflinePlayback) await this.reloadStream();
       }
-      const track = await this.engine.addTextTrack(sub.url, sub.language, sub.label);
+      const track = await this.engine.addTextTrack(sub.url, sub.language, sub.label, sub.forced);
       this.engine.selectTextTrack(track);
       try { this.engine.setTextVisibility(true); } catch {}
     } catch (e) {
@@ -2493,7 +2494,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // Restore active subtitle (non burn-in) after Shaka reload
     if (activeSub && !activeSub.burnIn && activeSub.url) {
       try {
-        const track = await this.engine.addTextTrack(activeSub.url, activeSub.language, activeSub.label);
+        const track = await this.engine.addTextTrack(activeSub.url, activeSub.language, activeSub.label, activeSub.forced);
         this.engine.selectTextTrack(track);
         this.engine.setTextVisibility(true);
       } catch {}


### PR DESCRIPTION
> ⚠️ **Do not merge yet** — confirmed on web + Android; **iOS device test pending**, and a Swift dead-code cleanup follows once iOS is confirmed.

## Why

Subtitles were delivered as **sidecar VTT** rendered by the app (a WebView overlay on iOS, Shaka's text displayer on web). That overlay can't appear in **Picture-in-Picture / AirPlay** (the system lifts only the player surface), and on a mid-file **resume** the cues drifted because the transcode timeline reset per run. Net: subtitles invisible in PiP (#319) and "subtitles start from the beginning" after *Reprendre*.

The root issue is an HLS-spec violation: every rendition of a presentation must share **one coherent, absolute timeline** (RFC 8216 §6.2; Apple HLS Authoring Spec), but FFmpeg's HLS muxer restarts the fragment decode timeline at `0` on each transcode run.

## What

**Subtitles become first-class HLS `SUBTITLES` renditions** in the master playlist, rendered natively by each player; and the **packaging layer owns an absolute timeline** so all renditions stay coherent.

**Backend**
- `master-playlist.ts`: emit `#EXT-X-MEDIA:TYPE=SUBTITLES` per text track + `SUBTITLES="subs"` on every variant, gated by a `supportsHlsSubtitles` device-profile capability; `AUTOSELECT=NO` (client owns selection).
- New subtitle media-playlist endpoint wrapping the VTT the subtitle service already extracts (no `var_stream_map` change → no VAAPI-decoder regression).
- **Absolute timeline (`transcoding/timeline.ts`)**: on serve, each fMP4 segment's `tfdt` is shifted onto the absolute grid (`seg-N → N·D`), recovered from the video fragment and applied per-track so audio keeps its true position (A/V intact). Segments become **idempotent** → the cross-run `tfdt` collision (the resume crash) can't recur. Runs starting at 0 are untouched.
- Fixed `listTextSubtitleRenditions` querying `subtitle_files` by a `@RelationId` (TypeORM rejected it → the master shipped no group).

**Client**
- iOS AVPlayer / Android ExoPlayer consume the legible/text tracks; web Shaka reads the manifest text tracks + keeps `UITextDisplayer` (styling preserved). Match by normalised language (+forced where reported).
- `native-engine` holds the desired selection by language and applies it once the player surfaces its text tracks → fixes the default subtitle being *selected-but-hidden* on ExoPlayer (a load-vs-track-ready race).
- No client timeline changes needed (it reads `video.currentTime`, now absolute).

| Platform | Subtitle path | Status |
|---|---|---|
| Web (Shaka) | manifest rendition → `UITextDisplayer` | ✅ confirmed |
| Android (ExoPlayer) | manifest rendition → native text track | ✅ confirmed |
| iOS (AVPlayer) | manifest rendition → `.legible` (PiP/AirPlay) | ⏳ device test |
| Tizen / webOS | unchanged (DOM overlay; capability off) | n/a |

## Verified

Backend + client typecheck, production build (exit 0). `tfdt` box-math verified on real cached segments: resume `seg-411` `0 → 1233.000s`, video on-grid, audio preserved, monotonic, sizes unchanged. The change set was also run through adversarial review workflows (per-platform regression + timeline design).

## Follow-ups (after iOS confirm)
- Remove the now-dead iOS Swift overlay (`subtitleLabel`/`subContainer`, `setSubtitleText`, the overlay branch in `setSubtitleStyle`, the `addExternalSubtitle` stub).
- iOS subtitle styling currently defers to the OS caption settings (native rendering); add `AVTextStyleRule` only if app-controlled styling is wanted.
- Add `forced` to the native `getSubtitleTracks` payload for precise full-vs-forced disambiguation (currently language-only on native).
- Extend the rendition to multi-audio `var_stream_map` audio renditions (the audio-only `tfdt` anchor uses a grid-snap fallback).
