### PR TITLE
fix(player): correct Tizen/webOS/Cast teardown and reload edge cases

### DIFF
--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -390,7 +390,9 @@ export class CastPlayerService {
     const mfId = this.mediaFileId();
     if (!mfId) return;
 
-    await this.streamingApi.stopSessions(mfId).catch(() => {});
+    // Scope the stop to the Cast session's own sid so a concurrent local
+    // session on the same file (another profile/device) is not torn down too.
+    await this.streamingApi.stopSessions(mfId, this.liveSessionId() ?? undefined).catch(() => {});
 
     const currentPos = positionOverride ?? this.cast.currentTime();
     const audioIdx = this.activeAudioStreamIndex

--- a/client/src/app/core/services/playback-engine/tizen-engine.ts
+++ b/client/src/app/core/services/playback-engine/tizen-engine.ts
@@ -124,15 +124,18 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
   }
 
   async destroy(): Promise<void> {
-    try {
-      const s = webapis.avplay.getState();
-      if (s !== 'NONE' && s !== 'IDLE') webapis.avplay.stop();
-    } catch { /* ok */ }
     if (this.orientationHandler) {
       window.removeEventListener('resize', this.orientationHandler);
       this.orientationHandler = null;
     }
+    // Only stop the shared AVPlay surface if this engine still owns it — a
+    // stale engine tearing down after a newer one took over must not stop
+    // the newer engine's playback.
     if (TizenEngine.activeEngine === this) {
+      try {
+        const s = webapis.avplay.getState();
+        if (s !== 'NONE' && s !== 'IDLE') webapis.avplay.stop();
+      } catch { /* ok */ }
       if (this.avObject) this.avObject.style.display = 'none';
       TizenEngine.activeEngine = null;
     }

--- a/client/src/app/core/services/playback-engine/webos-engine.ts
+++ b/client/src/app/core/services/playback-engine/webos-engine.ts
@@ -340,7 +340,12 @@ export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngin
     this.pendingReloadTarget = null;
     this.reloadInFlight = true;
     this.loadInternal(setStartAt(this.loadedUrl, target), target)
-      .catch(() => { /* surfaced via the engine error event */ })
+      .catch(() => {
+        // loadInternal does not emit during its loading phase, so a failed
+        // reload-seek would leave seekIntent pinning the seekbar at the
+        // unreachable target forever — clear it so the bar tracks the real clock.
+        this.seekIntent = null;
+      })
       .finally(() => {
         this.reloadInFlight = false;
         // A newer target arrived mid-reload — honour the latest, once.

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -275,6 +275,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
   /** Audio tracks from streamInfo for the Cast remote */
   readonly castAudioOptions = computed<CastAudioOption[]>(() => {
+    this.mediaLoadedTick(); // recompute once this.media is populated on load
     const file = this.media?.files?.find((f: any) => f.id === this.mediaFileId);
     return buildCastAudioOptions(file?.streamInfo?.audio, this.translate);
   });


### PR DESCRIPTION
Four clean, code-grounded correctness fixes from the #325 audit:

- **Tizen** `destroy()`: stop the shared AVPlay surface only when this engine still owns it (move `getState()/stop()` inside the ownership guard) — a stale engine could otherwise kill a newer one.
- **webOS** `runReloadIfIdle()`: clear `seekIntent` when the reload-seek fails, so the seekbar unpins from the unreachable target.
- **Cast** `reloadCastStream()`: scope `stopSessions` to the Cast session's own sid so a concurrent local session on the same file is not torn down.
- **Cast** `castAudioOptions`: depend on `mediaLoadedTick` so the computed recomputes after media load.

Verified with `ng build` (green).

The issue's remaining items need design/measurement decisions (si-* audio reload policy, language-keyed audio save/restore, Tizen runSeek failure sequencing, webOS mediaOption fallback discrimination) or are stale (native text-0 ids, reworked by #330) — see the follow-up comment. Refs #325 (left open).