### PR TITLE
fix(player): report the selected audio track on iOS

### DIFF
--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -386,12 +386,14 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
 
             if let item = self?.player?.currentItem,
                let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: .audible) {
+                let selected = item.currentMediaSelection.selectedMediaOption(in: group)
                 for (index, option) in group.options.enumerated() {
                     let locale = option.locale ?? Locale(identifier: "und")
                     tracks.append([
                         "id": "audio-\(index)",
                         "language": locale.languageCode ?? "und",
                         "label": option.displayName,
+                        "selected": option == selected,
                     ])
                 }
             }
@@ -420,6 +422,10 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             }
 
             item.select(group.options[index], in: group)
+            // Surface the new selected-state so the audio menu updates — the
+            // AVPlayer media-selection change emits no event of its own
+            // (Android's onTracksChanged does this automatically).
+            self?.emitTracksChanged()
             call.resolve()
         }
     }
@@ -869,12 +875,14 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
 
         var audioTracks: [[String: Any]] = []
         if let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: .audible) {
+            let selected = item.currentMediaSelection.selectedMediaOption(in: group)
             for (index, option) in group.options.enumerated() {
                 let locale = option.locale ?? Locale(identifier: "und")
                 audioTracks.append([
                     "id": "audio-\(index)",
                     "language": locale.languageCode ?? "und",
                     "label": option.displayName,
+                    "selected": option == selected,
                 ])
             }
         }

--- a/client/src/app/core/plugins/native-player.plugin.ts
+++ b/client/src/app/core/plugins/native-player.plugin.ts
@@ -8,6 +8,8 @@ export interface NativeAudioTrack {
   id: string;
   language: string;
   label: string;
+  /** True for the currently active audio track, so the menu highlights it. */
+  selected?: boolean;
 }
 
 export interface NativeSubtitleTrack {


### PR DESCRIPTION
iOS getAudioTracks/emitTracksChanged omitted `selected` and selectAudioTrack emitted no follow-up event, so the audio menu always highlighted track 0 and never updated on switch (Android already reports it). Emit `selected` (option == currentMediaSelection.selectedMediaOption) in both track lists and fire emitTracksChanged after selecting. Confirmed on an iOS device build.

Refs #323 — the native ABR/config parity item stays open.