### PR TITLE
fix(player): cross-platform audio + seek correctness fixes

### DIFF
--- a/client/src/app/core/services/playback-engine/tizen-engine.ts
+++ b/client/src/app/core/services/playback-engine/tizen-engine.ts
@@ -396,6 +396,12 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
                 reject(new Error(`seek failed: ${err}`));
                 return;
               }
+              // Recover by reloading at the target. Clear the in-flight flag
+              // and drop any seek queued during this failed one first, so the
+              // reload's own seek isn't blocked and a now-stale pending seek
+              // isn't replayed on top of the recovered position.
+              this._seekInFlight = false;
+              this._pendingSeek = null;
               try {
                 await this.load(this._lastLoadedUrl, position);
                 resolve();

--- a/client/src/app/core/services/playback-engine/webos-engine.ts
+++ b/client/src/app/core/services/playback-engine/webos-engine.ts
@@ -215,9 +215,13 @@ export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngin
       try {
         // Preferred path: native resume + start-bitrate via mediaOption.
         await this.attachAndPlay(url, start, true);
-      } catch {
-        // Firmware rejected the mediaOption schema — plain src still plays;
-        // resume falls back to a post-load currentTime seek.
+      } catch (e) {
+        // Only a mediaOption *schema* rejection (firmware refusing the
+        // <source type> payload, surfaced as a media error) is worth a plain-src
+        // retry — plain src still plays, with resume via a post-load seek. A
+        // load timeout means the stream itself is slow; retrying would just burn
+        // another 30s (60s total), so surface it instead of falling back.
+        if (e instanceof Error && e.name === 'WebOsLoadTimeout') throw e;
         await this.attachAndPlay(url, start, false);
       }
     } finally {
@@ -235,7 +239,13 @@ export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngin
     return new Promise<void>((resolve, reject) => {
       let settled = false;
       const timer = setTimeout(
-        () => finish(() => reject(new Error('webOS <video> load timeout (30s)'))),
+        () => finish(() => {
+          // Tagged so loadInternal can tell a slow-stream timeout (don't retry)
+          // from a mediaOption schema rejection (fall back to plain src).
+          const e = new Error('webOS <video> load timeout (30s)');
+          e.name = 'WebOsLoadTimeout';
+          reject(e);
+        }),
         30000,
       );
       const finish = (fn: () => void) => {

--- a/client/src/app/core/services/player-settings.service.ts
+++ b/client/src/app/core/services/player-settings.service.ts
@@ -124,7 +124,9 @@ export class PlayerSettingsService {
     // Priority 1: remembered selection always wins (even with "use default" enabled)
     // Uses mediaId (series/movie) so the choice carries across episodes.
     if (s.rememberAudioSelections && mediaId) {
-      const savedLang = this.getRememberedAudioTrack(mediaId);
+      // The stored value may carry a ":n" ordinal (same-language disambiguator);
+      // the backend index resolves by language, so strip it here.
+      const savedLang = this.getRememberedAudioTrack(mediaId)?.split(':')[0];
       if (savedLang) {
         const idx = audioStreams.findIndex(
           (a) => normalizeLang(a.language) === savedLang,

--- a/client/src/app/core/services/track-manager.service.ts
+++ b/client/src/app/core/services/track-manager.service.ts
@@ -52,11 +52,16 @@ export class TrackManagerService {
       !!this.playerSettings.getRememberedAudioTrack(key);
     if (settings.useDefaultAudioStream && !hasSavedSelection) return;
 
-    // Priority 1: remembered selection for this media (saved as language code)
+    // Priority 1: remembered selection for this media (saved as "language" or
+    // "language:ordinal" — see saveAudioSelection). The ordinal picks the Nth
+    // same-language rendition; it falls back to the first if the layout drifted.
     if (settings.rememberAudioSelections) {
-      const savedLang = this.playerSettings.getRememberedAudioTrack(key);
-      if (savedLang) {
-        const match = tracks.find((t) => t.language === savedLang);
+      const saved = this.playerSettings.getRememberedAudioTrack(key);
+      if (saved) {
+        const [savedLang, ordStr] = saved.split(':');
+        const ordinal = ordStr ? parseInt(ordStr, 10) : 0;
+        const sameLang = tracks.filter((t) => t.language === savedLang);
+        const match = sameLang[ordinal] ?? sameLang[0];
         if (match && match.id !== activeAudioTrackId) {
           onSelect(match.id);
           return;
@@ -87,8 +92,18 @@ export class TrackManagerService {
     if (!this.playerSettings.get().rememberAudioSelections) return;
     const track = tracks.find((t) => t.id === trackId);
     const lang = track?.language ?? trackId;
+    // Disambiguate multiple same-language renditions (e.g. 5.1 vs stereo) by
+    // their ordinal among same-language tracks — language alone can never reach
+    // the 2nd one. Reproducible across episodes when the audio layout is
+    // consistent. The ":n" suffix is only added past the first, so single-track
+    // languages stay a plain code; the language-keyed pre-load paths strip it.
+    const sameLang = tracks.filter((t) => (t.language ?? '') === lang);
+    const ordinal = sameLang.findIndex((t) => t.id === trackId);
     const key = mediaId;
-    this.playerSettings.saveRememberedAudioTrack(key, lang);
+    this.playerSettings.saveRememberedAudioTrack(
+      key,
+      ordinal > 0 ? `${lang}:${ordinal}` : lang,
+    );
   }
 
   /** Save subtitle selection for this media. Pass null = user explicitly disabled.

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -970,8 +970,11 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
             const audioSettings = this.playerSettings.get();
             let preferredLang: string | undefined;
             if (audioSettings.rememberAudioSelections && this.mediaId) {
+              // Strip any ":n" ordinal — Shaka pre-picks the variant by
+              // language; autoSelectAudioTrack corrects to the Nth post-load.
               preferredLang =
-                this.playerSettings.getRememberedAudioTrack(this.mediaId) ?? undefined;
+                this.playerSettings.getRememberedAudioTrack(this.mediaId)?.split(':')[0] ??
+                undefined;
             }
             if (!preferredLang && !audioSettings.useDefaultAudioStream) {
               preferredLang = audioSettings.preferredAudioLanguage || undefined;
@@ -2188,17 +2191,17 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       return;
     }
 
-    // si-* tracks are the streamInfo fallback. For HLS, the manifest always
-    // exposes every audio rendition via EXT-X-MEDIA so Shaka switches
-    // client-side — any transient si-* list upgrades to shaka-* as soon as
-    // Shaka fires trackschanged, and the user picks the real track then.
-    // For direct MP4 play, switching audio requires a backend reload with a
-    // new audioStreamIndex. Offline: no backend.
+    // si-* tracks are the streamInfo fallback list shown before the engine
+    // surfaces client-switchable tracks. For HLS the transient si-* list
+    // upgrades to shaka-* once Shaka fires trackschanged, and a shaka-* pick
+    // switches client-side. But a si-* pick means there is no engine-level
+    // track for that rendition yet, so the only way to honour it — in direct,
+    // remux or transcode alike — is a backend reload that marks the new
+    // audioStreamIndex DEFAULT (set above from the si-* index). Offline: no
+    // backend, nothing to reload.
     if (this.isOfflinePlayback) return;
     if (!trackId.startsWith('si-')) return;
-    if (this.playbackMode() === 'direct') {
-      await this.reloadStream();
-    }
+    await this.reloadStream();
   }
 
   async selectSubtitle(sub: SubtitleOption | null) {


### PR DESCRIPTION
Closes #325. The four remaining MED items from the audit (the HIGH + cast/webOS-seekIntent items shipped in #333).

- **web si-\* audio (testable)** — selecting a `si-*` rendition in remux/transcode silently no-opped (only direct MP4 reloaded). Now reloads the stream with the new `audioStreamIndex` in every mode.
- **same-language audio identity (testable)** — save/restore now keys on `language:ordinal`, so a 2nd same-language rendition (5.1 vs stereo) is reachable. The language-keyed pre-load paths (backend index, Shaka pre-pick) strip the ordinal → single-track languages are byte-for-byte unchanged; only the rare 2-same-lang case gains a post-load correction.
- **Tizen `runSeek`** — failure-reload ran with `_seekInFlight` still set and replayed a stale `_pendingSeek`; both cleared before the reload.
- **webOS mediaOption fallback** — retried plain `src` on ANY rejection incl. the 30s timeout (60s stall). Now only falls back on a schema rejection (tagged the timeout error to discriminate).

**LOW items intentionally not done:** native-engine `text-0` id collision is stale (the subtitle path was reworked to match by language+forced this cycle); Tizen `play()` emitting `playing` in NONE/IDLE is benign and the fix risks the untestable initial-play state; Shaka audio-only `clearBuffer=true` is defensible (`false` would delay the switch by the whole buffer).

build: `ng build` green. Tizen/webOS paths not device-tested here; web paths are. **Holding merge for your test.**