### PR TITLE
feat(settings): toggles for auto-grab on approval and marker auto-detect

### DIFF
--- a/backend/src/modules/requests/request-lifecycle.service.ts
+++ b/backend/src/modules/requests/request-lifecycle.service.ts
@@ -18,6 +18,7 @@ import { ProfilesService } from '../profiles/profiles.service';
 import { EventsService } from '../scheduler/events.service';
 import { SchedulerService } from '../scheduler/scheduler.service';
 import { NotificationsService } from '../notifications/notifications.service';
+import { SettingsService } from '../settings/settings.service';
 import { User } from '../users/entities/user.entity';
 import {
   IN_FLIGHT_REQUEST_STATUSES,
@@ -66,6 +67,7 @@ export class RequestLifecycleService
     @Inject(forwardRef(() => SchedulerService))
     private readonly scheduler: SchedulerService,
     private readonly notifications: NotificationsService,
+    private readonly settings: SettingsService,
   ) {}
 
   /**
@@ -74,11 +76,11 @@ export class RequestLifecycleService
    * SearchMissing tick. Default is "yes" — users expect the download
    * to start right after the green check.
    *
-   * TODO(#212): replace with an awaited `SettingsService.get(...)` read
-   * so the admin can opt out from the UI. Default stays `true`.
+   * Admin-toggleable from the General settings page; defaults to `true`
+   * (an unset key reads as enabled) to preserve behaviour on existing installs.
    */
-  private autoGrabOnApproval(): boolean {
-    return true;
+  private async autoGrabOnApproval(): Promise<boolean> {
+    return (await this.settings.get('requests_auto_grab_on_approval')) !== 'false';
   }
 
   onModuleInit(): void {
@@ -165,7 +167,7 @@ export class RequestLifecycleService
     // an immediate SearchMissing for that media so the user doesn't
     // wait up to 6 h for the next scheduled tick. Fire-and-forget;
     // failures (missing indexer, etc.) are logged inside the scheduler.
-    if (touched.length && this.autoGrabOnApproval()) {
+    if (touched.length && (await this.autoGrabOnApproval())) {
       void this.scheduler.searchMissingForMedia([media.id]);
     }
   }

--- a/backend/src/modules/requests/requests.module.ts
+++ b/backend/src/modules/requests/requests.module.ts
@@ -5,6 +5,7 @@ import { RequestComment } from './entities/request-comment.entity';
 import { AutoApprovalRule } from './entities/auto-approval-rule.entity';
 import { AuthModule } from '../auth/auth.module';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { SettingsModule } from '../settings/settings.module';
 import { MediaModule } from '../media/media.module';
 import { ProfilesModule } from '../profiles/profiles.module';
 import { FliksSchedulerModule } from '../scheduler/scheduler.module';
@@ -18,6 +19,7 @@ import { AutoApprovalRulesController } from './auto-approval-rules.controller';
     TypeOrmModule.forFeature([FliksRequest, RequestComment, AutoApprovalRule]),
     AuthModule,
     NotificationsModule,
+    SettingsModule,
     // forwardRef: MediaModule injects RequestLifecycleService for the
     // import / remove / unmonitor hooks, and we inject MediaService here
     // for the monitoring + 409 fallback lookups.

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -101,11 +101,11 @@ export class CompletionService {
    * detection. Default on — most users want skip-intro working right
    * after a series finishes downloading.
    *
-   * TODO(#212): replace with an awaited `SettingsService.get(...)` read
-   * so the admin can opt out from the UI. Default stays `true`.
+   * Admin-toggleable from the General settings page; defaults to `true`
+   * (an unset key reads as enabled) to preserve behaviour on existing installs.
    */
-  private autoDetectMarkersOnImport(): boolean {
-    return true;
+  private async autoDetectMarkersOnImport(): Promise<boolean> {
+    return (await this.settings.get('markers_auto_detect_on_import')) !== 'false';
   }
 
   /**
@@ -818,8 +818,9 @@ export class CompletionService {
     // we dedupe per season. Fire-and-forget; the detection itself is
     // queued via a Command row, and the in-flight guard skips seasons
     // already being scanned.
-    if (media.type === 'series' && this.autoDetectMarkersOnImport()) {
+    if (media.type === 'series') {
       void (async () => {
+        if (!(await this.autoDetectMarkersOnImport())) return;
         const seasonIds = new Set<number>();
         for (const { episodeId: epId } of importedFiles) {
           if (epId == null) continue;

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1168,6 +1168,8 @@
       "rss_interval": "Intervalle de synchro RSS (minutes)",
       "rss_interval_hint": "Fréquence de vérification des flux RSS des indexers.",
       "search_missing_auto": "Rechercher automatiquement les médias manquants",
+      "auto_grab_on_approval": "Télécharger automatiquement après l'approbation d'une demande",
+      "auto_detect_markers_on_import": "Détecter les intros / génériques à l'import des séries",
       "saved": "Paramètres enregistrés.",
       "save_error": "Impossible d'enregistrer.",
       "load_error": "Impossible de charger les paramètres.",

--- a/client/src/app/features/settings/general/general.html
+++ b/client/src/app/features/settings/general/general.html
@@ -90,6 +90,26 @@
           <span class="label-text">{{ 'settings.general.search_missing_auto' | translate }}</span>
         </label>
 
+        <label class="label cursor-pointer justify-start gap-3 max-w-max">
+          <input
+            type="checkbox"
+            class="toggle toggle-sm"
+            [ngModel]="autoGrabOnApproval() === 'true'"
+            (ngModelChange)="autoGrabOnApproval.set($event ? 'true' : 'false')"
+          />
+          <span class="label-text">{{ 'settings.general.auto_grab_on_approval' | translate }}</span>
+        </label>
+
+        <label class="label cursor-pointer justify-start gap-3 max-w-max">
+          <input
+            type="checkbox"
+            class="toggle toggle-sm"
+            [ngModel]="autoDetectMarkersOnImport() === 'true'"
+            (ngModelChange)="autoDetectMarkersOnImport.set($event ? 'true' : 'false')"
+          />
+          <span class="label-text">{{ 'settings.general.auto_detect_markers_on_import' | translate }}</span>
+        </label>
+
         <label class="form-control w-full">
           <div class="label">
             <span class="label-text">{{ 'settings.general.companion_extensions' | translate }}</span>

--- a/client/src/app/features/settings/general/general.ts
+++ b/client/src/app/features/settings/general/general.ts
@@ -32,6 +32,8 @@ export class GeneralSettingsComponent implements OnInit {
 
   // Automation
   readonly searchMissingAuto = signal('true');
+  readonly autoGrabOnApproval = signal('true');
+  readonly autoDetectMarkersOnImport = signal('true');
   readonly rssSyncInterval = signal('15');
   readonly companionFileExtensions = signal('');
   readonly savingAutomation = signal(false);
@@ -46,6 +48,8 @@ export class GeneralSettingsComponent implements OnInit {
       this.serverName.set(map['server_name'] ?? '');
       this.publicUrl.set(map['public_url'] ?? '');
       this.searchMissingAuto.set(map['search_missing_auto'] ?? 'true');
+      this.autoGrabOnApproval.set(map['requests_auto_grab_on_approval'] ?? 'true');
+      this.autoDetectMarkersOnImport.set(map['markers_auto_detect_on_import'] ?? 'true');
       this.rssSyncInterval.set(map['rss_sync_interval'] ?? '15');
       this.postImportScript.set(map['post_import_script'] ?? '');
       this.companionFileExtensions.set(
@@ -75,6 +79,8 @@ export class GeneralSettingsComponent implements OnInit {
     try {
       await this.api.setBulk({
         search_missing_auto: this.searchMissingAuto(),
+        requests_auto_grab_on_approval: this.autoGrabOnApproval(),
+        markers_auto_detect_on_import: this.autoDetectMarkersOnImport(),
         rss_sync_interval: this.rssSyncInterval(),
         companion_file_extensions: this.companionFileExtensions(),
       });


### PR DESCRIPTION
Closes #212.

Both post-import triggers were hardcoded `return true`. Now each reads a per-instance setting via SettingsService:
- `requests_auto_grab_on_approval` → RequestLifecycleService
- `markers_auto_detect_on_import` → CompletionService

Default stays **true** (an unset key reads as enabled via `!== 'false'`), so existing installs are byte-for-byte unchanged. No DB migration. Both helpers became `async`; the call sites were already in async contexts.

**Placement note (deviates from the issue):** the issue named a *Requests* settings page and a *System/Markers* settings page — neither exists. Both toggles are automation behaviors, so I put them under **General → Automation** next to the existing auto-search toggle rather than scaffolding two new pages + routes + nav entries for one toggle each. Easy to relocate if you'd rather have dedicated pages.

Verified: backend `tsc` clean, frontend `ng build` green, fr.json valid.