### PR TITLE
fix(streaming): enforce library ACL on subtitle routes (IDOR)

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -19,6 +19,7 @@ import { promisify } from 'util';
 import * as fs from 'fs';
 const execFileAsync = promisify(execFile);
 import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { User } from '../users/entities/user.entity';
 import { StreamingService, ResolvedFile } from './streaming.service';
 import { SubtitleStreamService } from './subtitle-stream.service';
@@ -1120,7 +1121,7 @@ export class StreamingController {
     // sidecar VTT.
     const subtitleRenditions = (live?.supportsHlsSubtitles ?? false)
       ? await this.subtitleStreamService
-          .listTextSubtitleRenditions(mediaFileId)
+          .listTextSubtitleRenditions(mediaFileId, req.user as User)
           .catch((e) => {
             this.log.warn(
               `subtitle renditions failed for #${mediaFileId}: ${e instanceof Error ? e.message : e}`,
@@ -1184,11 +1185,13 @@ export class StreamingController {
   async embeddedSubtitle(
     @Param('mediaFileId', ParseIntPipe) mediaFileId: number,
     @Param('streamIndex', ParseIntPipe) streamIndex: number,
+    @CurrentUser() user: User | undefined,
     @Res() res: Response,
   ) {
     const stream = await this.subtitleStreamService.extractEmbeddedSubtitle(
       mediaFileId,
       streamIndex,
+      user,
     );
     // Buffer the FFmpeg output so we can send Content-Length
     // (ExoPlayer needs it for subtitle loading)
@@ -1206,9 +1209,13 @@ export class StreamingController {
   @Get(':mediaFileId/subtitles/:subtitleId')
   async subtitle(
     @Param('subtitleId', ParseIntPipe) subtitleId: number,
+    @CurrentUser() user: User | undefined,
     @Res() res: Response,
   ) {
-    const vtt = await this.subtitleStreamService.getSubtitleAsVtt(subtitleId);
+    const vtt = await this.subtitleStreamService.getSubtitleAsVtt(
+      subtitleId,
+      user,
+    );
     res.setHeader('Content-Type', 'text/vtt; charset=utf-8');
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.send(withTimestampMap(vtt));
@@ -1263,7 +1270,10 @@ export class StreamingController {
     mediaFileId: number,
     vttPath: string,
   ): Promise<void> {
-    const resolved = await this.streamingService.resolveFile(mediaFileId);
+    const resolved = await this.streamingService.resolveFile(
+      mediaFileId,
+      req.user as User,
+    );
     const duration = resolved.mediaFile.streamInfo?.durationSeconds ?? 0;
     const tokenParam = buildTokenParam(req);
     const target = Math.max(1, Math.ceil(duration || 1));

--- a/backend/src/modules/streaming/streaming.service.spec.ts
+++ b/backend/src/modules/streaming/streaming.service.spec.ts
@@ -1,0 +1,53 @@
+import { NotFoundException } from '@nestjs/common';
+import { StreamingService } from './streaming.service';
+import type { User } from '../users/entities/user.entity';
+
+describe('StreamingService.assertLibraryAccess', () => {
+  const user = { id: 1 } as User;
+
+  function make(accessible: number[] | null) {
+    const libraries = {
+      getAccessibleLibraryIds: jest.fn().mockResolvedValue(accessible),
+    };
+    return new StreamingService(
+      {} as never,
+      {} as never,
+      libraries as never,
+    );
+  }
+
+  it('no-ops for an internal caller (no user), even if the library would be denied', async () => {
+    const svc = make([99]);
+    await expect(
+      svc.assertLibraryAccess(5, undefined, 'nf'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('allows access when getAccessibleLibraryIds returns null (full-access / admin)', async () => {
+    const svc = make(null);
+    await expect(
+      svc.assertLibraryAccess(5, user, 'nf'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('allows a library the user can access', async () => {
+    const svc = make([1, 5]);
+    await expect(
+      svc.assertLibraryAccess(5, user, 'nf'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws NotFound for a library outside the user access list (IDOR guard)', async () => {
+    const svc = make([1, 2]);
+    await expect(svc.assertLibraryAccess(5, user, 'nf')).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('throws NotFound when the resource has no library and access is restricted', async () => {
+    const svc = make([1, 2]);
+    await expect(svc.assertLibraryAccess(null, user, 'nf')).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+});

--- a/backend/src/modules/streaming/streaming.service.ts
+++ b/backend/src/modules/streaming/streaming.service.ts
@@ -45,6 +45,28 @@ export class StreamingService {
   ) {}
 
   /**
+   * Throw NotFoundException — the same "missing" shape as a non-existent file,
+   * so callers can't probe library existence — when `user` lacks access to
+   * `libraryId`. No-op for internal callers that pass no `user`. Shared by
+   * {@link resolveFile} and the subtitle routes so every streaming entry point
+   * enforces one identical library ACL.
+   */
+  async assertLibraryAccess(
+    libraryId: number | null,
+    user: User | undefined,
+    notFoundMessage: string,
+  ): Promise<void> {
+    if (!user) return;
+    const accessible = await this.libraries.getAccessibleLibraryIds(user);
+    if (
+      accessible !== null &&
+      (libraryId == null || !accessible.includes(libraryId))
+    ) {
+      throw new NotFoundException(notFoundMessage);
+    }
+  }
+
+  /**
    * Resolve a media file for streaming/download. When `user` is passed,
    * enforces library ACL — non-admin users get NotFoundException for media
    * outside their accessible libraries (same shape as "missing" so we don't
@@ -61,16 +83,11 @@ export class StreamingService {
 
     const media = file.media;
 
-    if (user) {
-      const accessible = await this.libraries.getAccessibleLibraryIds(user);
-      if (accessible !== null) {
-        if (media.libraryId == null || !accessible.includes(media.libraryId)) {
-          // Mirror the "not found" shape so users can't probe for media in
-          // libraries they don't have access to.
-          throw new NotFoundException(`MediaFile #${mediaFileId} not found`);
-        }
-      }
-    }
+    await this.assertLibraryAccess(
+      media?.libraryId ?? null,
+      user,
+      `MediaFile #${mediaFileId} not found`,
+    );
 
     if (!media?.path) {
       throw new NotFoundException(

--- a/backend/src/modules/streaming/subtitle-stream.service.ts
+++ b/backend/src/modules/streaming/subtitle-stream.service.ts
@@ -14,6 +14,7 @@ import * as fsSync from 'fs';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { StreamingService } from './streaming.service';
+import { User } from '../users/entities/user.entity';
 import { EventsService } from '../scheduler/events.service';
 import { Command } from '../scheduler/entities/command.entity';
 import { resolveSubtitleAbsolutePath } from '../subtitles/subtitle-path.util';
@@ -85,11 +86,18 @@ export class SubtitleStreamService {
   /**
    * Get an external subtitle file converted to WebVTT.
    */
-  async getSubtitleAsVtt(subtitleId: number): Promise<string> {
+  async getSubtitleAsVtt(subtitleId: number, user?: User): Promise<string> {
     const sub = await this.subtitleFileRepo.findOne({
       where: { id: subtitleId },
       relations: ['media', 'media.library'],
     });
+    // Library ACL on the subtitle's OWN media, so a foreign subtitle id can't
+    // be read regardless of the mediaFileId in the request path (IDOR).
+    await this.streamingService.assertLibraryAccess(
+      sub?.media?.libraryId ?? null,
+      user,
+      `Subtitle #${subtitleId} not found`,
+    );
     if (!sub?.relativePath) {
       throw new NotFoundException(`Subtitle #${subtitleId} not found`);
     }
@@ -138,9 +146,10 @@ export class SubtitleStreamService {
    */
   async listTextSubtitleRenditions(
     mediaFileId: number,
+    user?: User,
   ): Promise<SubtitleRenditionMeta[]> {
     const out: SubtitleRenditionMeta[] = [];
-    const resolved = await this.streamingService.resolveFile(mediaFileId);
+    const resolved = await this.streamingService.resolveFile(mediaFileId, user);
     for (const s of resolved.mediaFile.streamInfo?.subtitles ?? []) {
       if (s.isImageBased) continue;
       out.push({
@@ -188,6 +197,7 @@ export class SubtitleStreamService {
   async extractEmbeddedSubtitle(
     mediaFileId: number,
     streamIndex: number,
+    user?: User,
   ): Promise<Readable> {
     if (
       !Number.isInteger(streamIndex) ||
@@ -197,7 +207,7 @@ export class SubtitleStreamService {
       throw new BadRequestException(`Invalid stream index: ${streamIndex}`);
     }
 
-    const resolved = await this.streamingService.resolveFile(mediaFileId);
+    const resolved = await this.streamingService.resolveFile(mediaFileId, user);
     const mediaRoot = resolved.media.path;
     if (!mediaRoot) {
       throw new NotFoundException(


### PR DESCRIPTION
Closes #345.

The subtitle routes resolved files **without the requesting user**, so an authenticated user could read subtitle text + track metadata for media in libraries they cannot access (IDOR / OWASP API1). Fixed by threading the user through all subtitle entry points and gating `getSubtitleAsVtt` on the subtitle's **own** media library (closes the by-id IDOR independent of the path param).

- New `StreamingService.assertLibraryAccess(libraryId, user, msg)` — single source of the library ACL; `resolveFile` now delegates to it.
- `extractEmbeddedSubtitle` / `listTextSubtitleRenditions` thread `user` → `resolveFile(id, user)`.
- `getSubtitleAsVtt(id, user)` gates on `sub.media.libraryId`.
- Routes use `@CurrentUser()` where they didn't already need `@Req`.

Internal/worker callers still pass no user (documented bypass) — no playback regression. Verified: `tsc` clean, new `assertLibraryAccess` unit spec (5 cases) + full streaming suite (71 tests) green.