### PR TITLE
fix(streaming): stop cache GC evicting live dirs; track post-boot growth

### DIFF
--- a/backend/src/modules/streaming/streaming-lifecycle.spec.ts
+++ b/backend/src/modules/streaming/streaming-lifecycle.spec.ts
@@ -197,19 +197,24 @@ describe('streaming lifecycle — LiveSessionRegistry × TranscodeCacheService',
     await writeSegment(cache, ALICE.userId, 2, PROFILE, '1080p', 0, 1000);
     await writeSegment(cache, ALICE.userId, 3, PROFILE, '1080p', 0, 1000);
 
-    const fresh = cache.lookup(ALICE.userId, 1, PROFILE)!;
     const stale1 = cache.lookup(ALICE.userId, 2, PROFILE)!;
     const stale2 = cache.lookup(ALICE.userId, 3, PROFILE)!;
 
-    // 1080p TTL window is 4 h; push two of the three past it.
-    const FIVE_HOURS_AGO = Date.now() - 5 * 60 * 60 * 1000;
-    stale1.lastAccess = FIVE_HOURS_AGO;
-    stale2.lastAccess = FIVE_HOURS_AGO;
+    // GC derives lastAccess from the newest file mtime; push two of the three
+    // segment files past the 4 h 1080p TTL. (The fresh one keeps its mtime.)
+    const fiveHoursAgo = new Date(Date.now() - 5 * 60 * 60 * 1000);
+    for (const fid of [2, 3]) {
+      const seg = path.join(
+        cache.cachePathFor(ALICE.userId, fid, PROFILE, '1080p'),
+        'seg-0000.m4s',
+      );
+      await fsp.utimes(seg, fiveHoursAgo, fiveHoursAgo);
+    }
 
     await cache.runGc();
 
     expect(cache.size()).toBe(1);
-    expect(cache.lookup(ALICE.userId, 1, PROFILE)).toBe(fresh);
+    expect(cache.lookup(ALICE.userId, 1, PROFILE)).not.toBeNull();
     expect(cache.lookup(ALICE.userId, 2, PROFILE)).toBeNull();
     expect(cache.lookup(ALICE.userId, 3, PROFILE)).toBeNull();
     await expect(fsp.access(stale1.cacheDir)).rejects.toBeDefined();

--- a/backend/src/modules/streaming/transcoding/transcode-cache.service.spec.ts
+++ b/backend/src/modules/streaming/transcoding/transcode-cache.service.spec.ts
@@ -95,13 +95,15 @@ describe('TranscodeCacheService', () => {
 
   it('evicts entries past their TTL on gc', async () => {
     const dir = path.join(CACHE_ROOT, 'u1', '1', 'dddddddddd', '720p');
-    await writeFile(path.join(dir, 'seg-0.m4s'), 1000);
+    const seg = path.join(dir, 'seg-0.m4s');
+    await writeFile(seg, 1000);
+    // GC derives lastAccess from the newest file mtime; age it past the 4 h TTL.
+    const old = new Date(Date.now() - 10 * 60 * 60 * 1000);
+    await fsp.utimes(seg, old, old);
     await svc.onModuleInit();
-    const entry = svc.lookup(1, 1, 'dddddddddd')!;
-    entry.lastAccess = Date.now() - 10 * 60 * 60 * 1000; // 10 h ago, TTL default 4 h
     await svc.runGc();
     expect(svc.size()).toBe(0);
-    await expect(fsp.access(entry.cacheDir)).rejects.toBeDefined();
+    await expect(fsp.access(dir)).rejects.toBeDefined();
   });
 
   it('keeps fresh entries through gc', async () => {
@@ -110,6 +112,41 @@ describe('TranscodeCacheService', () => {
     await svc.onModuleInit();
     await svc.runGc();
     expect(svc.size()).toBe(1);
+  });
+
+  it('gc indexes dirs created after boot, then TTL-manages them', async () => {
+    await svc.onModuleInit();
+    expect(svc.size()).toBe(0);
+    const dir = path.join(CACHE_ROOT, 'u9', '70', 'aaaaaaaaaa', '720p');
+    const seg = path.join(dir, 'seg-0.m4s');
+    await writeFile(seg, 4000);
+    // Fresh post-boot dir: gc now sees it (boot index never did) and keeps it.
+    await svc.runGc();
+    expect(svc.size()).toBe(1);
+    expect(svc.totalBytes()).toBe(4000);
+    // Age it past TTL: the next gc reclaims it — post-boot dirs no longer escape.
+    const old = new Date(Date.now() - 10 * 60 * 60 * 1000);
+    await fsp.utimes(seg, old, old);
+    await svc.runGc();
+    expect(svc.size()).toBe(0);
+  });
+
+  it('never evicts a directory backed by a live session, even past TTL', async () => {
+    const dir = path.join(CACHE_ROOT, 'u1', '1', 'liveliveee', '720p');
+    const seg = path.join(dir, 'seg-0.m4s');
+    await writeFile(seg, 1000);
+    const old = new Date(Date.now() - 10 * 60 * 60 * 1000); // past TTL
+    await fsp.utimes(seg, old, old);
+    await svc.onModuleInit();
+    // Session path is the quality subdir of the entry dir — matched by prefix.
+    svc.registerLiveDirProvider(() => new Set([dir]));
+    await svc.runGc();
+    expect(svc.size()).toBe(1);
+    await expect(fsp.access(dir)).resolves.toBeUndefined();
+    // Session ends → next gc reclaims it.
+    svc.registerLiveDirProvider(() => new Set());
+    await svc.runGc();
+    expect(svc.size()).toBe(0);
   });
 
   it('cachePathFor composes the expected directory shape', async () => {

--- a/backend/src/modules/streaming/transcoding/transcode-cache.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcode-cache.service.ts
@@ -47,6 +47,11 @@ export class TranscodeCacheService implements OnModuleInit, OnModuleDestroy {
   private readonly log = new Logger(TranscodeCacheService.name);
   private readonly entries = new Map<string, CacheEntry>();
   private gcTimer: ReturnType<typeof setInterval> | null = null;
+  /** Returns the cache directories currently backed by a live transcode
+   *  session. GC never evicts a directory an active ffmpeg job is still
+   *  writing to / serving from. Registered by TranscodingService (via
+   *  {@link registerLiveDirProvider}) to avoid a circular import. */
+  private liveDirProvider: (() => Set<string>) | null = null;
 
   private readonly ttlMs = StreamLifetime.cacheTtlMs();
   private readonly maxBytes = StreamLifetime.cacheMaxBytes();
@@ -67,6 +72,22 @@ export class TranscodeCacheService implements OnModuleInit, OnModuleDestroy {
       clearInterval(this.gcTimer);
       this.gcTimer = null;
     }
+  }
+
+  /** Wire the live-session lookup {@link runGc} uses to skip directories an
+   *  active ffmpeg job is still writing to / serving from. */
+  registerLiveDirProvider(provider: () => Set<string>): void {
+    this.liveDirProvider = provider;
+  }
+
+  /** True when `cacheDir` (a profile-level entry dir) holds, or is, a live
+   *  session's directory. Session paths are quality subdirs of the entry dir,
+   *  so a prefix match covers both levels. */
+  private isLiveDir(cacheDir: string, live: Set<string>): boolean {
+    for (const p of live) {
+      if (p === cacheDir || p.startsWith(cacheDir + path.sep)) return true;
+    }
+    return false;
   }
 
   /** Resolve the entry for a (user, file, profile) triple, or null. */
@@ -219,32 +240,29 @@ export class TranscodeCacheService implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
-   * Garbage collection pass. Three passes in order:
-   * 1. Drop entries whose on-disk dir has been wiped externally
-   *    (kept in sync with the transcoding service's own cleanup paths).
+   * Garbage collection pass:
+   * 1. Refresh the index from disk so it reflects reality — dirs created
+   *    since boot are seen, current sizes/mtimes are read, and externally
+   *    removed dirs drop out. The in-memory index is otherwise only built at
+   *    boot (the segment-write hooks are not on the ffmpeg path), so without
+   *    this refresh post-boot dirs escape TTL+LRU and the byte total drifts.
    * 2. Evict by TTL.
-   * 3. Evict least-recently-used until total bytes back under cap.
+   * 3. Evict least-recently-used until total bytes are back under the cap.
+   *
+   * Both eviction passes skip any directory a live transcode session is still
+   * writing to / serving from, so GC can never wipe an active playback's cache.
    */
   async runGc(): Promise<void> {
-    const orphans: CacheEntry[] = [];
-    for (const entry of this.entries.values()) {
-      try {
-        await fsp.access(entry.cacheDir);
-      } catch {
-        orphans.push(entry);
-      }
-    }
-    for (const entry of orphans) {
-      this.entries.delete(
-        entryKey(entry.userId, entry.mediaFileId, entry.profileHash),
-      );
-    }
+    await this.rebuildIndex(/* quiet */ true);
 
+    const live = this.liveDirProvider?.() ?? new Set<string>();
     const now = Date.now();
-    const expired: CacheEntry[] = [];
-    for (const entry of this.entries.values()) {
-      if (now - entry.lastAccess > this.ttlMs) expired.push(entry);
-    }
+
+    const expired = [...this.entries.values()].filter(
+      (entry) =>
+        !this.isLiveDir(entry.cacheDir, live) &&
+        now - entry.lastAccess > this.ttlMs,
+    );
     for (const entry of expired) {
       await this.evict(entry);
     }
@@ -252,9 +270,9 @@ export class TranscodeCacheService implements OnModuleInit, OnModuleDestroy {
     let total = this.totalBytes();
     if (total <= this.maxBytes) return;
 
-    const lru = [...this.entries.values()].sort(
-      (a, b) => a.lastAccess - b.lastAccess,
-    );
+    const lru = [...this.entries.values()]
+      .filter((entry) => !this.isLiveDir(entry.cacheDir, live))
+      .sort((a, b) => a.lastAccess - b.lastAccess);
     for (const entry of lru) {
       if (total <= this.maxBytes) break;
       total -= entry.totalBytes;
@@ -327,13 +345,30 @@ export class TranscodeCacheService implements OnModuleInit, OnModuleDestroy {
     return entry;
   }
 
-  private async rebuildIndex(): Promise<void> {
+  private async rebuildIndex(quiet = false): Promise<void> {
+    const scanned = await this.scanIndexFromDisk();
+    // Atomic swap: the clear + set loop is synchronous, so a concurrent
+    // lookup() sees either the old index or the fully-rebuilt one, never a
+    // half-populated map mid-scan.
     this.entries.clear();
+    for (const [key, entry] of scanned) this.entries.set(key, entry);
+
+    if (!quiet && this.entries.size > 0) {
+      this.log.log(
+        `[disk] indexed ${this.entries.size} cache entr${this.entries.size === 1 ? 'y' : 'ies'} (${formatBytes(this.totalBytes())})`,
+      );
+    }
+  }
+
+  /** Walk the cache root and build a fresh index map from disk. Pure — does
+   *  not mutate {@link entries}; the caller swaps it in. */
+  private async scanIndexFromDisk(): Promise<Map<string, CacheEntry>> {
+    const result = new Map<string, CacheEntry>();
     let userDirs: string[];
     try {
       userDirs = await fsp.readdir(CACHE_LAYOUT_ROOT);
     } catch {
-      return;
+      return result;
     }
 
     for (const userDir of userDirs) {
@@ -365,17 +400,12 @@ export class TranscodeCacheService implements OnModuleInit, OnModuleDestroy {
             cacheDir,
           );
           if (entry) {
-            this.entries.set(entryKey(userId, mediaFileId, profileHash), entry);
+            result.set(entryKey(userId, mediaFileId, profileHash), entry);
           }
         }
       }
     }
-
-    if (this.entries.size > 0) {
-      this.log.log(
-        `[disk] indexed ${this.entries.size} cache entr${this.entries.size === 1 ? 'y' : 'ies'} (${formatBytes(this.totalBytes())})`,
-      );
-    }
+    return result;
   }
 
   private async indexEntry(

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -87,6 +87,18 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
   ) {}
 
   async onModuleInit() {
+    // Let the cache GC see which directories are backed by a live session so
+    // it never evicts one mid-playback. Session cache paths are quality
+    // subdirs of the cache entry dirs; the cache matches by prefix.
+    this.cacheService.registerLiveDirProvider(
+      () =>
+        new Set(
+          [...this.sessions.values()]
+            .map((s) => s.cachePath)
+            .filter((p): p is string => typeof p === 'string' && p.length > 0),
+        ),
+    );
+
     this.detectedHwAccel = await detectHwAccel(this.log);
     this.log.log(`Hardware acceleration: ${this.detectedHwAccel}`);
 


### PR DESCRIPTION
Closes #343.

The transcode-cache index was built **only at boot** (the segment-write hooks were dead code), so `runGc` had a frozen view: it never saw dirs created after boot, the byte cap drifted, and `lastAccess` never advanced — letting the 4 h TTL `rm` a directory a **live ffmpeg job was still writing to and a client still reading from** (mid-playback 404s), while post-boot growth escaped TTL+LRU entirely.

**Fix:**
- `runGc` refreshes the index from disk each cycle (atomic clear+set swap → a concurrent `lookup()` never sees a half-built map). Current dirs / sizes / mtimes are always accurate → fixes the byte cap + the post-boot blind spot. `lastAccess` is now the newest file mtime (an actively-written dir stays fresh).
- Both eviction passes (TTL + LRU) **skip any directory backed by a live session**. `TranscodingService` registers a live-dir provider (its session `cachePath`s); the cache prefix-matches them against entry dirs, so no circular import.

**Tested:** new unit specs for TTL eviction via file mtime, the live-session guard (prefix match on the quality subdir), and post-boot dir indexing; updated the two prior tests that mutated in-memory `lastAccess` (now superseded by the mtime-driven refresh). `tsc` clean, full streaming suite (73 tests) green.

**Trade-off:** GC now does a full disk walk each cycle (every 5 min by default), same as `diskUsage`/`purge` already do — chosen over wiring the write-hooks into the ffmpeg path (more invasive). The previously-dead index-mutation methods remain as a public API; a follow-up can remove them.