### PR TITLE
fix(streaming): validate direct-play Range header (RFC 7233)

### DIFF
--- a/backend/src/modules/streaming/byte-range.util.spec.ts
+++ b/backend/src/modules/streaming/byte-range.util.spec.ts
@@ -1,0 +1,62 @@
+import { parseByteRange } from './byte-range.util';
+
+describe('parseByteRange', () => {
+  const SIZE = 1000; // bytes 0..999
+
+  it('parses a normal closed range', () => {
+    expect(parseByteRange('bytes=0-99', SIZE)).toEqual({ start: 0, end: 99 });
+    expect(parseByteRange('bytes=200-499', SIZE)).toEqual({
+      start: 200,
+      end: 499,
+    });
+  });
+
+  it('parses an open-ended range to EOF', () => {
+    expect(parseByteRange('bytes=500-', SIZE)).toEqual({ start: 500, end: 999 });
+  });
+
+  it('parses a suffix range as the last N bytes', () => {
+    expect(parseByteRange('bytes=-500', SIZE)).toEqual({ start: 500, end: 999 });
+  });
+
+  it('clamps a suffix larger than the file to the whole file', () => {
+    expect(parseByteRange('bytes=-5000', SIZE)).toEqual({ start: 0, end: 999 });
+  });
+
+  it('clamps an end past EOF to the last byte', () => {
+    expect(parseByteRange('bytes=0-99999', SIZE)).toEqual({ start: 0, end: 999 });
+  });
+
+  it('honours only the first range of a multi-range request', () => {
+    expect(parseByteRange('bytes=0-99,200-299', SIZE)).toEqual({
+      start: 0,
+      end: 99,
+    });
+  });
+
+  it('tolerates whitespace', () => {
+    expect(parseByteRange('bytes= 10 - 20 ', SIZE)).toEqual({
+      start: 10,
+      end: 20,
+    });
+  });
+
+  it.each([
+    ['start > end', 'bytes=5-1'],
+    ['start at EOF', 'bytes=1000-'],
+    ['start past EOF', 'bytes=1500-1600'],
+    ['non-numeric start', 'bytes=abc-'],
+    ['non-numeric end', 'bytes=0-xyz'],
+    ['non-numeric suffix', 'bytes=-abc'],
+    ['zero suffix', 'bytes=-0'],
+    ['empty', 'bytes='],
+    ['no dash', 'bytes=100'],
+    ['bare empty range', 'bytes=-'],
+  ])('returns null (→ 416) for %s', (_label, header) => {
+    expect(parseByteRange(header, SIZE)).toBeNull();
+  });
+
+  it('returns null for any range against a zero-byte file', () => {
+    expect(parseByteRange('bytes=0-', 0)).toBeNull();
+  });
+});

--- a/backend/src/modules/streaming/byte-range.util.ts
+++ b/backend/src/modules/streaming/byte-range.util.ts
@@ -1,0 +1,44 @@
+/**
+ * Parse a single HTTP `Range` header against a known file size (RFC 7233).
+ *
+ * Returns the resolved `[start, end]` (inclusive, clamped to the file) for a
+ * satisfiable range, or `null` when the range is unsatisfiable / malformed —
+ * the caller answers `null` with `416 Range Not Satisfiable`
+ * (`Content-Range: bytes *​/<size>`). Only the first range of a (rare)
+ * multi-range request is honoured, matching the single-stream response the
+ * direct-play endpoint produces.
+ *
+ * Handles the forms the previous bare `parseInt` split mishandled:
+ *  - `bytes=S-E`   normal range; `E` clamped to the last byte
+ *  - `bytes=S-`    open-ended; serves S..EOF
+ *  - `bytes=-N`    suffix; serves the last N bytes (N>file → whole file)
+ *  - garbage / `start>end` / `start>=size` / negative → `null` (→ 416)
+ */
+export function parseByteRange(
+  rangeHeader: string,
+  fileSize: number,
+): { start: number; end: number } | null {
+  const spec = (rangeHeader.replace(/^bytes=/, '').split(',')[0] ?? '').trim();
+  const dash = spec.indexOf('-');
+  if (dash < 0) return null;
+
+  const startStr = spec.slice(0, dash).trim();
+  const endStr = spec.slice(dash + 1).trim();
+
+  // Suffix range: `bytes=-N` → last N bytes.
+  if (startStr === '') {
+    const n = Number(endStr);
+    if (!Number.isInteger(n) || n <= 0) return null;
+    return { start: Math.max(0, fileSize - n), end: Math.max(0, fileSize - 1) };
+  }
+
+  const start = Number(startStr);
+  if (!Number.isInteger(start) || start < 0 || start >= fileSize) return null;
+
+  let end = endStr === '' ? fileSize - 1 : Number(endStr);
+  if (!Number.isInteger(end)) return null;
+  end = Math.min(end, fileSize - 1);
+  if (end < start) return null;
+
+  return { start, end };
+}

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -20,6 +20,7 @@ import * as fs from 'fs';
 const execFileAsync = promisify(execFile);
 import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { parseByteRange } from './byte-range.util';
 import { User } from '../users/entities/user.entity';
 import { StreamingService, ResolvedFile } from './streaming.service';
 import { SubtitleStreamService } from './subtitle-stream.service';
@@ -1915,9 +1916,15 @@ export class StreamingController {
       return;
     }
 
-    const parts = range.replace(/bytes=/, '').split('-');
-    const start = parseInt(parts[0], 10);
-    const end = parts[1] ? parseInt(parts[1], 10) : fileSize - 1;
+    const parsed = parseByteRange(range, fileSize);
+    if (!parsed) {
+      // RFC 7233 §4.4 — unsatisfiable / malformed range.
+      res.status(416);
+      res.setHeader('Content-Range', `bytes */${fileSize}`);
+      res.end();
+      return;
+    }
+    const { start, end } = parsed;
     const chunkSize = end - start + 1;
 
     res.status(206);


### PR DESCRIPTION
Closes #350.

The direct-play byte-range endpoint parsed `Range` with a bare split + `parseInt` and zero validation. Reproduced failure modes: suffix range `bytes=-N` → `start=NaN` → broken 206 + sync `createReadStream` throw after headers sent; `start>end` → negative `Content-Length`; oversized end never clamped; unsatisfiable start never returned **416**.

Extracted `parseByteRange` (pure fn) that validates + clamps per RFC 7233 — suffix form, open-ended, end-clamp to EOF, and `null` → **416** with `Content-Range: bytes */<size>`. Auth-gated endpoint, backend-only.

`tsc` clean; 18-case unit spec (normal/open/suffix/clamp/multi-range/whitespace + 11 malformed→null) green.