### PR TITLE
fix(streaming): label copy-mode Opus/FLAC audio correctly in CODECS

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -1149,7 +1149,7 @@ export class StreamingController {
       onlyQuality,
       pickedIdx ?? 0,
       deviceType,
-      (live?.audioPlan?.codec ?? 'aac') as 'aac' | 'ac3' | 'eac3',
+      live?.audioPlan?.codec ?? 'aac',
       hdrPassThrough,
       // Only the SDR ladder branch consumes this — the HDR branch
       // already drives its codec strings from `hdrPassThrough`.

--- a/backend/src/modules/streaming/transcoding/codec/codec-strings.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/codec-strings.spec.ts
@@ -1,0 +1,22 @@
+import { audioCodecString } from './codec-strings';
+
+describe('audioCodecString', () => {
+  it('maps the fMP4-compatible codecs to their RFC 6381 strings', () => {
+    expect(audioCodecString('aac')).toBe('mp4a.40.2');
+    expect(audioCodecString('ac3')).toBe('ac-3');
+    expect(audioCodecString('eac3')).toBe('ec-3');
+    expect(audioCodecString('opus')).toBe('Opus');
+    expect(audioCodecString('flac')).toBe('fLaC');
+  });
+
+  it('is case-insensitive', () => {
+    expect(audioCodecString('OPUS')).toBe('Opus');
+    expect(audioCodecString('FLAC')).toBe('fLaC');
+  });
+
+  it('returns null for an unknown codec so the caller omits it (never mislabels as AAC)', () => {
+    expect(audioCodecString('truehd')).toBeNull();
+    expect(audioCodecString('dts')).toBeNull();
+    expect(audioCodecString('')).toBeNull();
+  });
+});

--- a/backend/src/modules/streaming/transcoding/codec/codec-strings.ts
+++ b/backend/src/modules/streaming/transcoding/codec/codec-strings.ts
@@ -151,6 +151,31 @@ function av1Level(target: EncoderTarget): string {
   return '04'; //                                 L3.0 — 720p30
 }
 
+/** Audio codecs we can emit an RFC 6381 CODECS string for: transcode targets
+ *  AAC / AC-3 / E-AC-3, copy-mode additionally passes through Opus / FLAC. The
+ *  `Record` below is keyed by this type, so adding a codec is a compile error
+ *  until its CODECS string is supplied. */
+export type AudioOutputCodec = 'aac' | 'ac3' | 'eac3' | 'opus' | 'flac';
+
+const AUDIO_CODEC_STRINGS: Record<AudioOutputCodec, string> = {
+  aac: 'mp4a.40.2',
+  ac3: 'ac-3',
+  eac3: 'ec-3',
+  opus: 'Opus',
+  flac: 'fLaC',
+};
+
+/**
+ * RFC 6381 CODECS string for an output audio codec, or null when the codec is
+ * outside {@link AudioOutputCodec}. Input is `string` — copy-mode passes the
+ * raw source codec (see AudioPlan), which can be anything (e.g. truehd, dts).
+ * An unrecognised codec must be omitted from CODECS rather than mislabeled as
+ * AAC: a wrong codec hard-rejects on MSE append, a missing one is probed.
+ */
+export function audioCodecString(codec: string): string | null {
+  return AUDIO_CODEC_STRINGS[codec.toLowerCase() as AudioOutputCodec] ?? null;
+}
+
 function pad2(n: number): string {
   return n.toString().padStart(2, '0');
 }

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -13,6 +13,7 @@ import type {
 } from './types';
 import type { CodecVariant } from './codec/types';
 import {
+  audioCodecString,
   av1CodecString,
   h264CodecString,
   hevcMain10CodecString,
@@ -102,7 +103,7 @@ export function generateMasterPlaylist(
    *  must match or the receiver rejects the segment at MSE chunk-demuxer
    *  append. Recognised values: `'aac'` (AAC-LC), `'ac3'` (Dolby Digital),
    *  `'eac3'` (Dolby Digital Plus). Defaults to AAC for legacy callers. */
-  outputAudioCodec: 'aac' | 'ac3' | 'eac3' = 'aac',
+  outputAudioCodec: string = 'aac',
   /** When set, the master advertises a single HEVC HDR variant pointing at
    *  the `remux/index.m3u8` path instead of the H.264 transcode ladder.
    *  The remux session does `-c:v copy` so the HDR metadata (BT.2020/PQ
@@ -165,9 +166,8 @@ export function generateMasterPlaylist(
   const noAudio = audioStreams != null && audioStreams.length === 0;
   const lines = ['#EXTM3U', '#EXT-X-VERSION:7', '#EXT-X-INDEPENDENT-SEGMENTS'];
 
-  const audioCodecMap = { aac: 'mp4a.40.2', ac3: 'ac-3', eac3: 'ec-3' };
-  const audioCodec = audioCodecMap[outputAudioCodec] ?? 'mp4a.40.2';
-  const codecsTail = noAudio ? '' : `,${audioCodec}`;
+  const audioCodec = audioCodecString(outputAudioCodec);
+  const codecsTail = noAudio || !audioCodec ? '' : `,${audioCodec}`;
 
   const frameRateAttr = `,FRAME-RATE=${formatFrameRate(sourceFrameRate)}`;
 

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -459,7 +459,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     onlyQuality?: string,
     defaultAudioIndex = 0,
     deviceType: DeviceType = 'desktop',
-    outputAudioCodec: 'aac' | 'ac3' | 'eac3' = 'aac',
+    outputAudioCodec: string = 'aac',
     hdrPassThrough?: {
       hdrFormat: 'HDR10' | 'HLG';
       videoBitRateBps?: number;


### PR DESCRIPTION
Closes #347.

Copy-mode audio forwarded the raw source codec into a 3-entry map that defaulted unknowns to `mp4a.40.2`, so Opus/FLAC copied into fMP4 (allowed by stream-builder when the client supports it) was advertised as **AAC** in `EXT-X-STREAM-INF` CODECS — a strict MSE append rejects the mismatch (RFC 6381 / 8216 §4.3.4.2).

`audioCodecString()` maps a named `AudioOutputCodec` type (aac/ac3/eac3/opus/flac → mp4a.40.2/ac-3/ec-3/Opus/fLaC) and returns **null** for anything outside the set — unhandled codecs are omitted from CODECS rather than mislabeled (wrong codec hard-rejects; missing one is probed). Boundary stays `string` because the copy-mode source codec is genuinely arbitrary (`AudioPlan.codec`, e.g. truehd at stream-builder.ts:249). Removes the `as 'aac'|'ac3'|'eac3'` cast.

`tsc` clean; 3-case unit spec (known/case-insensitive/unknown→null) green.