### PR TITLE
fix(streaming): make the TS (Tizen) path .m4s/.ts agnostic

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -574,6 +574,30 @@ export class StreamingController {
     filePath: string,
     contentType: string,
   ): Promise<void> {
+    // TS segments aren't fMP4/CMAF — the CMAF rewrite and tfdt anchoring below
+    // are no-ops on them, and running an ISO-BMFF box parser over MPEG-TS bytes
+    // is meaningless. Read + serve verbatim. Buffered (not streamed) to keep
+    // the same read-after-unlink safety the fMP4 path relies on.
+    if (filePath.endsWith('.ts')) {
+      let tsBuf: Buffer;
+      try {
+        tsBuf = await fs.promises.readFile(filePath);
+      } catch {
+        if (!res.headersSent) res.status(404).end();
+        return;
+      }
+      if (tsBuf.length === 0) {
+        if (!res.headersSent) res.status(404).end();
+        return;
+      }
+      res.setHeader('Content-Type', contentType);
+      res.setHeader('Content-Length', String(tsBuf.length));
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Cache-Control', 'no-store');
+      res.end(tsBuf);
+      return;
+    }
+
     const buf = await readAndRewriteCmaf(filePath);
     if (!buf || buf.length === 0) {
       if (!res.headersSent) res.status(404).end();

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -422,7 +422,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
           continue;
         }
         for (const f of files) {
-          const m = f.match(/^seg-(\d+)\.m4s$/);
+          const m = f.match(/^seg-(\d+)\.(?:m4s|ts)$/);
           if (m) {
             const n = parseInt(m[1], 10);
             if (n > maxSeg) maxSeg = n;
@@ -870,7 +870,8 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     for (let i = 0; i < 120; i++) {
       if (await fileExists(playlistPath)) {
         const content = await fsp.readFile(playlistPath, 'utf-8');
-        if (content.includes('.m4s')) return content;
+        // Ready once ffmpeg has written segment lines — fMP4 (.m4s) or TS (.ts).
+        if (content.includes('.m4s') || content.includes('.ts')) return content;
       }
       await new Promise((r) => setTimeout(r, 500));
     }


### PR DESCRIPTION
Closes #357.

Three fMP4-only (`.m4s`) assumptions that mishandled MPEG-TS (`useTs` / Tizen):
- **getTranscodePercent** matched only `seg-N.m4s` → admin dashboard showed **0%** for every TS session. Now `.m4s|.ts` (the set `segment-utils` already uses).
- **getPlaylist** readiness gate `content.includes('.m4s')` never matches a TS playlist → would exhaust the 60s poll. Now accepts `.ts`.
- **serveCmafFile** ran the CMAF rewrite + tfdt anchoring (ISO-BMFF box parser) over TS bytes; both no-op on TS, so `.ts` short-circuits to a verbatim buffered serve (kept buffered for the same read-after-unlink safety as fMP4).

No behavior change on the fMP4 path (the `.ts` branch is isolated). `tsc` clean; full streaming suite (94 tests) green.