### PR TITLE
refactor(streaming): remove dead isVariantOf helper

### DIFF
--- a/backend/src/modules/streaming/transcoding/index.ts
+++ b/backend/src/modules/streaming/transcoding/index.ts
@@ -22,7 +22,6 @@ export {
   VARIANT_MAIN,
   VARIANT_REMUX,
   baseProfileHash,
-  isVariantOf,
   variantHash,
   variantSuffix,
 } from './variant';

--- a/backend/src/modules/streaming/transcoding/variant.spec.ts
+++ b/backend/src/modules/streaming/transcoding/variant.spec.ts
@@ -3,7 +3,6 @@ import {
   VARIANT_MAIN,
   VARIANT_REMUX,
   baseProfileHash,
-  isVariantOf,
   variantHash,
   variantSuffix,
 } from './variant';
@@ -46,26 +45,6 @@ describe('baseProfileHash', () => {
   it('leaves non-variant trailing dashes alone', () => {
     expect(baseProfileHash(`${base}-foo`)).toBe(`${base}-foo`);
     expect(baseProfileHash(`${base}-aX`)).toBe(`${base}-aX`);
-  });
-});
-
-describe('isVariantOf', () => {
-  const base = 'cafebabe01';
-  it('matches the base itself', () => {
-    expect(isVariantOf(base, base)).toBe(true);
-  });
-  it('matches any known variant suffix', () => {
-    expect(isVariantOf(`${base}-early`, base)).toBe(true);
-    expect(isVariantOf(`${base}-remux`, base)).toBe(true);
-    expect(isVariantOf(`${base}-a5`, base)).toBe(true);
-  });
-  it('rejects unrelated cache keys with the same prefix length', () => {
-    expect(isVariantOf('cafebabe02', base)).toBe(false);
-    expect(isVariantOf('cafebabe02-early', base)).toBe(false);
-  });
-  it('rejects hashes that merely contain the base as a substring', () => {
-    expect(isVariantOf(`xxx${base}`, base)).toBe(false);
-    expect(isVariantOf(`xxx${base}-early`, base)).toBe(false);
   });
 });
 

--- a/backend/src/modules/streaming/transcoding/variant.ts
+++ b/backend/src/modules/streaming/transcoding/variant.ts
@@ -64,10 +64,3 @@ const VARIANT_SUFFIX_RE = /-(?:early|remux|a\d+)$/;
 export function baseProfileHash(cacheKey: string): string {
   return cacheKey.replace(VARIANT_SUFFIX_RE, '');
 }
-
-/** True when `cacheKey` is the main or any variant of `baseHash`.
- *  Used to find every ffmpeg job tied to a single client when, e.g.,
- *  that client explicitly stops. */
-export function isVariantOf(cacheKey: string, baseHash: string): boolean {
-  return cacheKey === baseHash || cacheKey.startsWith(`${baseHash}-`);
-}


### PR DESCRIPTION
Closes #352.

`isVariantOf` had zero production callers (only the barrel re-export + its own spec). The stop-by-base-hash path uses exact `baseProfileHash` equality, never prefix matching, so the doc was misleading too. Removed the function, export, and spec block. `tsc` clean; variant spec green.