### PR TITLE
fix(streaming): report real audio channel count in EXT-X-MEDIA CHANNELS

### DIFF
--- a/backend/src/modules/streaming/transcoding/codec/codec-strings.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/codec-strings.spec.ts
@@ -1,4 +1,4 @@
-import { audioCodecString } from './codec-strings';
+import { audioCodecString, audioRenditionChannels } from './codec-strings';
 
 describe('audioCodecString', () => {
   it('maps the fMP4-compatible codecs to their RFC 6381 strings', () => {
@@ -18,5 +18,25 @@ describe('audioCodecString', () => {
     expect(audioCodecString('truehd')).toBeNull();
     expect(audioCodecString('dts')).toBeNull();
     expect(audioCodecString('')).toBeNull();
+  });
+});
+
+describe('audioRenditionChannels', () => {
+  it('downmixes AAC output to stereo regardless of the source layout', () => {
+    expect(audioRenditionChannels('aac', 6)).toBe(2);
+    expect(audioRenditionChannels('aac', 1)).toBe(2);
+    expect(audioRenditionChannels('AAC', undefined)).toBe(2);
+  });
+
+  it('keeps the source channel count for copy / AC-3 / E-AC-3 (no -ac)', () => {
+    expect(audioRenditionChannels('eac3', 6)).toBe(6);
+    expect(audioRenditionChannels('ac3', 6)).toBe(6);
+    expect(audioRenditionChannels('opus', 8)).toBe(8);
+    expect(audioRenditionChannels('flac', 2)).toBe(2);
+  });
+
+  it('falls back to 2 when the source channel count is unknown or invalid', () => {
+    expect(audioRenditionChannels('eac3', undefined)).toBe(2);
+    expect(audioRenditionChannels('eac3', 0)).toBe(2);
   });
 });

--- a/backend/src/modules/streaming/transcoding/codec/codec-strings.ts
+++ b/backend/src/modules/streaming/transcoding/codec/codec-strings.ts
@@ -176,6 +176,20 @@ export function audioCodecString(codec: string): string | null {
   return AUDIO_CODEC_STRINGS[codec.toLowerCase() as AudioOutputCodec] ?? null;
 }
 
+/**
+ * CHANNELS value for an EXT-X-MEDIA audio rendition. AAC output is always
+ * downmixed to stereo (`-ac 2`); copy / AC-3 / E-AC-3 keep the source layout
+ * (no `-ac`), so they report the source channel count. Falls back to 2 when
+ * the source count is unknown.
+ */
+export function audioRenditionChannels(
+  outputAudioCodec: string,
+  sourceChannels: number | undefined,
+): number {
+  if (outputAudioCodec.toLowerCase() === 'aac') return 2;
+  return sourceChannels && sourceChannels > 0 ? sourceChannels : 2;
+}
+
 function pad2(n: number): string {
   return n.toString().padStart(2, '0');
 }

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -14,6 +14,7 @@ import type {
 import type { CodecVariant } from './codec/types';
 import {
   audioCodecString,
+  audioRenditionChannels,
   av1CodecString,
   h264CodecString,
   hevcMain10CodecString,
@@ -230,7 +231,7 @@ export function generateMasterPlaylist(
         // probes the renditions, single-audio doesn't trigger the
         // probe when the hint is missing).
         lines.push(
-          `#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="${names[i]}",LANGUAGE="${lang}",DEFAULT=${isDefault},AUTOSELECT=${isDefault},CHANNELS="2",URI="/api/stream/${mediaFileId}/audio/${i}/index.m3u8${tokenParam}"`,
+          `#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="${names[i]}",LANGUAGE="${lang}",DEFAULT=${isDefault},AUTOSELECT=${isDefault},CHANNELS="${audioRenditionChannels(outputAudioCodec, a.channels)}",URI="/api/stream/${mediaFileId}/audio/${i}/index.m3u8${tokenParam}"`,
         );
       }
     }
@@ -303,13 +304,13 @@ export function generateMasterPlaylist(
       const a = audioStreams[i];
       const lang = a.language || 'und';
       const isDefault = i === pickedIdx ? 'YES' : 'NO';
-      // `CHANNELS="2"` matches what ffmpeg emits (`-ac 2`) and what
-      // Apple's reference fMP4 master ships — Tizen AVPlay uses this
-      // hint to pre-allocate the right audio decoder before fetching
-      // the rendition. Without it the single-audio variant doesn't
+      // CHANNELS reports the rendition's real output layout (AAC downmixes
+      // to 2 via `-ac 2`; copy / AC-3 / E-AC-3 keep the source layout) — Tizen
+      // AVPlay uses this hint to pre-allocate the right audio decoder before
+      // fetching the rendition. Without it the single-audio variant doesn't
       // trigger a rendition probe (issue #148 bisection).
       lines.push(
-        `#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="${names[i]}",LANGUAGE="${lang}",DEFAULT=${isDefault},AUTOSELECT=${isDefault},CHANNELS="2",URI="/api/stream/${mediaFileId}/audio/${i}/index.m3u8${tokenParam}"`,
+        `#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="${names[i]}",LANGUAGE="${lang}",DEFAULT=${isDefault},AUTOSELECT=${isDefault},CHANNELS="${audioRenditionChannels(outputAudioCodec, a.channels)}",URI="/api/stream/${mediaFileId}/audio/${i}/index.m3u8${tokenParam}"`,
       );
     }
   }

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -23,6 +23,10 @@ export interface AudioStreamMeta {
   language?: string;
   title?: string;
   streamIndex?: number;
+  /** Source channel count (from ffprobe streamInfo). Drives the EXT-X-MEDIA
+   *  CHANNELS attribute for copy / AC-3 / E-AC-3 renditions, which keep the
+   *  source layout; AAC renditions are downmixed to 2 regardless. */
+  channels?: number;
 }
 
 /**


### PR DESCRIPTION
Closes #348.

Alternate-audio renditions hardcoded `CHANNELS="2"`, but copy / AC-3 / E-AC-3 keep the source layout (no `-ac`), so a 5.1/7.1 rendition was advertised as stereo. Per RFC 8216 §4.3.4.1 CHANNELS is the rendition's channel count; declaring 2 for a 6-channel rendition misleads Apple/Shaka decoder pre-allocation + surround/AirPlay routing.

The source channel count was already on `streamInfo`'s `AudioStreamInfo` (populated by ffprobe) — now typed on `AudioStreamMeta` too — and `audioRenditionChannels()` emits **2 for AAC downmix, the source count for copy/AC-3/E-AC-3**. Manifest-only change (advisory attribute, narrow var-stream-map+surround path).

`tsc` clean; new unit spec (downmix / passthrough / unknown→2) + full streaming suite (93) green. The end-to-end surround-routing benefit is a device-verifiable bonus; the manifest correctness is what this fixes.