### PR TITLE
fix(streaming): derive early-companion read window from segment duration

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -36,6 +36,7 @@ import {
 } from './transcoding';
 import type { TranscodeSession } from './transcoding/types';
 import {
+  EARLY_PROBE_SEGMENTS,
   getSegmentDuration,
   secondsToSegmentIndex,
 } from './transcoding/constants';
@@ -178,13 +179,6 @@ async function awaitFileNonEmpty(
   }
   return false;
 }
-
-/** Segments the early companion covers. Its ffmpeg is bound to `-t 4`
- *  (see getOrCreateEarlySession), which at a 3 s segment grid yields seg-0
- *  and seg-1 — the window a player's seg-0 VOD probe falls in. Requests
- *  below this are absorbed by the early session; anything higher is a real
- *  seek the main session handles. */
-const EARLY_PROBE_SEGMENTS = 2;
 
 /** Send a transient unavailability response. Players with sane HTTP
  *  retry policies (Shaka, Media3's loader when given a backoff)
@@ -1474,7 +1468,10 @@ export class StreamingController {
       videoSession.startSegment != null &&
       videoSession.startSegment > 0 &&
       earlySession.quality === videoSession.quality &&
-      (isInit || segIndex < videoSession.startSegment);
+      // Only seg-0 .. seg-(EARLY_PROBE_SEGMENTS-1) live in the early session —
+      // bound to the same window the video path uses. (Was `< startSegment`,
+      // which on a deep resume routed segments the early session never wrote.)
+      (isInit || segIndex < EARLY_PROBE_SEGMENTS);
 
     let segPath: string | null = null;
     if (useEarly && earlySession) {

--- a/backend/src/modules/streaming/transcoding/constants.ts
+++ b/backend/src/modules/streaming/transcoding/constants.ts
@@ -20,6 +20,13 @@ export const JOB_GRACE_MS = StreamLifetime.jobGraceMs();
 /** Max gap (in segments) between FFmpeg frontier and requested segment before restarting. */
 export const SEEK_WAIT_THRESHOLD = 15;
 
+/** Number of leading segments (seg-0 .. seg-(N-1)) the early-start companion
+ *  pre-encodes at position 0 while the main session spins up at the resume
+ *  point. Drives BOTH how long the early ffmpeg reads (its `-t`) and how many
+ *  segment requests route to it — the two must agree, or a resume probe hits a
+ *  session that never wrote that segment. Independent of segment duration. */
+export const EARLY_PROBE_SEGMENTS = 2;
+
 /** Mutable runtime state for HLS segment duration. Updated from admin
  *  streaming settings via `setSegmentDuration()`. Read by FFmpeg arg
  *  builders and the session manager. */

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -9,6 +9,7 @@ import { existsSync, watch, FSWatcher } from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import {
+  EARLY_PROBE_SEGMENTS,
   JOB_GRACE_MS,
   SEEK_WAIT_THRESHOLD,
   SESSION_TIMEOUT_MS,
@@ -742,9 +743,11 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
    * the main session would force a kill+restart from K back to 0 — wiping
    * out the prewarm work and adding a second 4K cold-start.
    *
-   * Bounded by `-t 4` (input-side limit) so ffmpeg exits ~5s after spawn
-   * once it has flushed seg-0 (1s, INIT_TIME) + seg-1 (3s) plus the trailer.
-   * Same encoder profile + audio layout as the main session so segments and
+   * Bounded by an input-side `-t` of EARLY_PROBE_SEGMENTS segments (+1s) so
+   * ffmpeg exits shortly after flushing seg-0 .. seg-(EARLY_PROBE_SEGMENTS-1),
+   * each a full `getSegmentDuration()` long (there is no `hls_init_time`, so
+   * seg-0 is not shortened). Same encoder profile + audio layout as the main
+   * session so segments and
    * init.mp4 are decode-compatible (Shaka can mix-and-match across the two
    * sessions seamlessly).
    *
@@ -837,10 +840,14 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         },
         this.log,
       );
-      // Bound input read to 4s — enough for seg-0 + seg-1, then ffmpeg
-      // exits cleanly. Insert as INPUT option (before -i).
+      // Bound the input read so the early session writes EARLY_PROBE_SEGMENTS
+      // full segments (+1s so the last one closes past its boundary), then
+      // ffmpeg exits cleanly. Derived from the configured segment duration —
+      // a hardcoded 4s only covered two segments at the 3s default and left
+      // seg-1 unwritten at 4s/6s grids. Insert as an INPUT option (before -i).
+      const earlyReadSec = EARLY_PROBE_SEGMENTS * getSegmentDuration() + 1;
       const inputIdx = args.indexOf('-i');
-      if (inputIdx >= 0) args.splice(inputIdx, 0, '-t', '4');
+      if (inputIdx >= 0) args.splice(inputIdx, 0, '-t', String(earlyReadSec));
 
       const usesVarStreamMap =
         isVideoOnly && ctxAudioStreams && ctxAudioStreams.length > 1;


### PR DESCRIPTION
Closes #346.

The early-start companion hardcoded `-t 4` + a local `EARLY_PROBE_SEGMENTS=2`, both assuming a **3s grid**. At 4s/6s the early ffmpeg read only 4s → seg-0 truncated, seg-1 never written — yet resume probes still routed seg-0/seg-1 to it, dropping to the slow cold-start the companion exists to prevent. The audio path was worse: it routed every segment `< videoSession.startSegment` (≈100 on a deep resume) to the early session, which only wrote the first two.

- `EARLY_PROBE_SEGMENTS` moved to shared transcoding constants — the early read window and routing window are now one source of truth.
- early `-t` = `EARLY_PROBE_SEGMENTS * segmentDuration + 1` → always writes that many full segments on any grid.
- audio early routing bounded to `segIndex < EARLY_PROBE_SEGMENTS` (matches the video path).
- stale `-t 4` / `hls_init_time` / "seg-0 (1s)" comments fixed.

`tsc` clean; full streaming suite (93) green. **Behavioral / latency-path — not auto-merged.** Please playback-test at the 6s segment setting: cold start + a seek/resume past seg-2 (verify no stall/slow-cold-start, smooth handoff). Merge once confirmed.