### PR TITLE
refactor(streaming): remove dead Dolby Vision code, document fallback

### DIFF
--- a/backend/src/modules/streaming/transcoding/codec/codec-strings.ts
+++ b/backend/src/modules/streaming/transcoding/codec/codec-strings.ts
@@ -1,4 +1,4 @@
-import type { EncoderTarget, HdrFormat } from './types';
+import type { EncoderTarget } from './types';
 
 /** RFC 6381 CODECS attribute generators. Each function returns the
  *  string that goes inside `CODECS="..."` on an `EXT-X-STREAM-INF`
@@ -81,39 +81,6 @@ export function av1CodecString(
   bitDepth: 8 | 10,
 ): string {
   return `av01.0.${av1Level(target)}M.${String(bitDepth).padStart(2, '0')}`;
-}
-
-/** Dolby Vision — `dvh1.PP.LL`. Apple HLS requires `dvh1` (parameter sets
- *  in moov), never `dvhe`. Profile and level pulled from the source's DV
- *  RPU sidedata when present. Listed for completeness — we don't transcode
- *  to DV, only pass through on DirectPlay. */
-export function dolbyVisionCodecString(profile: number, level: number): string {
-  return `dvh1.${pad2(profile)}.${pad2(level)}`;
-}
-
-/** Generates `SUPPLEMENTAL-CODECS` value for HDR10+/DV backward-compat
- *  variants. Apple HLS 2024+. */
-export function supplementalCodecsBrand(hdr: HdrFormat): string | null {
-  switch (hdr) {
-    case 'HDR10':
-      return null; // No supplemental codec for vanilla HDR10
-    case 'HLG':
-      return null;
-    case 'DV5':
-      return null; // Profile 5 has no HDR10/HLG fallback
-    case 'DV81':
-      return 'db1p'; // DV 8.1 → HDR10 BL
-    case 'DV84':
-      return 'db4h'; // DV 8.4 → HLG BL
-  }
-}
-
-/** VIDEO-RANGE master-playlist attribute. iOS AVPlayer reads this to
- *  filter variants by display transfer-function compatibility. */
-export function videoRange(hdr: HdrFormat | null): 'SDR' | 'PQ' | 'HLG' {
-  if (hdr == null) return 'SDR';
-  if (hdr === 'HLG') return 'HLG';
-  return 'PQ'; // HDR10, DV5, DV81, DV84 all carry PQ-tagged transfer
 }
 
 // ───────────────────────── helpers ─────────────────────────

--- a/backend/src/modules/streaming/transcoding/codec/fallback.ts
+++ b/backend/src/modules/streaming/transcoding/codec/fallback.ts
@@ -82,22 +82,11 @@ const APPLE_TV_PRE_A17_NO_AV1: ClientQuirk = {
   reason: 'iOS / Apple TV without A17 HW AV1 decoder',
 };
 
-const DROP_DV_TRANSCODE: ClientQuirk = {
-  id: 'no-dv-transcode',
-  matches: () => true,
-  filter: (variants) =>
-    variants.filter(
-      (v) => v.hdr !== 'DV5' && v.hdr !== 'DV81' && v.hdr !== 'DV84',
-    ),
-  reason: 'Dolby Vision transcode is not implemented (DirectPlay only)',
-};
-
 const REGISTRY: readonly ClientQuirk[] = [
   CCWGTV_HD_NO_4K_HEVC_HDR,
   CCWGTV_HD_NO_4K,
   OLDER_CHROMECAST_NO_AV1,
   APPLE_TV_PRE_A17_NO_AV1,
-  DROP_DV_TRANSCODE,
 ];
 
 /** Run every applicable quirk against the candidate variants. Returns

--- a/backend/src/modules/streaming/transcoding/codec/types.ts
+++ b/backend/src/modules/streaming/transcoding/codec/types.ts
@@ -11,9 +11,13 @@ export type BitDepth = 8 | 10;
 /** HDR transfer / signaling. `null` means SDR.
  *  - HDR10: BT.2020 primaries + SMPTE-ST-2084 (PQ) transfer + static metadata
  *  - HLG:   BT.2020 primaries + ARIB STD-B67 transfer
- *  - DV*:   Dolby Vision profiles; transcode support is intentionally out of
- *           scope (DirectPlay only). Listed for typing completeness. */
-export type HdrFormat = 'HDR10' | 'HLG' | 'DV5' | 'DV81' | 'DV84';
+ *
+ *  Dolby Vision is NOT detected or signaled: ffprobe classifies HDR purely by
+ *  colour tags, so a DV source resolves to HDR10 (profile 8.1 — its PQ base
+ *  layer plays as HDR10, a graceful downgrade) or SDR (profile 5 — tonemapped
+ *  imperfectly, since ffmpeg can't process the DV RPU). Full DV detection +
+ *  passthrough is deferred to #368. */
+export type HdrFormat = 'HDR10' | 'HLG';
 
 /** The triple that uniquely identifies a video output format. Resolution
  *  and bitrate are not part of identity — those live on `LadderRung`. */


### PR DESCRIPTION
Closes #353. (Option B — full DV implementation deferred to #368.)

DV was never detected — ffprobe classifies HDR purely by colour tags (HDR10/HLG/undefined, never DV) — so the DV codec helpers were unreachable dead code that *also* documented a DirectPlay DV passthrough the codebase never had. Removed `dolbyVisionCodecString` / `supplementalCodecsBrand` / `videoRange` (zero callers), the `DV5/DV81/DV84` HdrFormat members (only those fns + the no-op `DROP_DV_TRANSCODE` quirk used them), and `DROP_DV_TRANSCODE` (filtered DV variants the probe can't produce).

Documented the real behaviour on `HdrFormat`: DV 8.1 → HDR10 (graceful, PQ base), DV 5 → tonemapped-as-SDR (imperfect). **No behaviour change — all removed code was unreachable.** `tsc` clean; full streaming suite (93) green.