### PR TITLE
fix(streaming): don't grid-snap remux segment tfdt

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -579,6 +579,7 @@ export class StreamingController {
     res: Response,
     filePath: string,
     contentType: string,
+    skipTimelineRewrite = false,
   ): Promise<void> {
     // TS segments aren't fMP4/CMAF — the CMAF rewrite and tfdt anchoring below
     // are no-ops on them, and running an ISO-BMFF box parser over MPEG-TS bytes
@@ -609,7 +610,15 @@ export class StreamingController {
       if (!res.headersSent) res.status(404).end();
       return;
     }
-    const out = await this.anchorSegmentTimeline(filePath, buf);
+    // Remux (`-c:v copy`) segments carry an absolute, GOP-aligned -copyts
+    // timeline; the grid tfdt anchor assumes forced-keyframe transcode output
+    // (seg-N decodes at N*SEG) and would shift each remux segment by its own
+    // IDR-vs-grid offset, breaking the single monotonic timeline (#349).
+    // Transcode output is grid-aligned so the anchor is a no-op — only remux
+    // must skip it.
+    const out = skipTimelineRewrite
+      ? buf
+      : await this.anchorSegmentTimeline(filePath, buf);
     res.setHeader('Content-Type', contentType);
     res.setHeader('Content-Length', String(out.length));
     res.setHeader('Access-Control-Allow-Origin', '*');
@@ -1861,7 +1870,16 @@ export class StreamingController {
       sendTransientUnavailable(res);
       return;
     }
-    await this.serveCmafFile(res, segPath, segmentContentType(segment));
+    // Remux segments skip the tfdt anchor — they already carry an absolute
+    // -copyts timeline (see serveCmafFile / #349). The early-probe paths above
+    // never run for remux (gated on quality !== 'remux'), so this main serve
+    // is the only remux-reachable tfdt path.
+    await this.serveCmafFile(
+      res,
+      segPath,
+      segmentContentType(segment),
+      quality === 'remux',
+    );
   }
 
   // ---------------------------------------------------------------------------

--- a/backend/src/modules/streaming/transcoding/timeline.spec.ts
+++ b/backend/src/modules/streaming/transcoding/timeline.spec.ts
@@ -1,0 +1,80 @@
+import { parseInitTracks, rewriteSegmentTfdt } from './timeline';
+
+// Minimal ISO-BMFF box builders — just enough structure for parseInitTracks /
+// collectTfdts to walk (moov>trak>[tkhd, mdia>[mdhd, hdlr]] and moof>traf>[tfhd,
+// tfdt]). Offsets match what timeline.ts reads.
+const TS = 1000; // timescale (ticks/sec)
+
+function u32(n: number): Buffer {
+  const b = Buffer.alloc(4);
+  b.writeUInt32BE(n >>> 0, 0);
+  return b;
+}
+
+function box(type: string, payload: Buffer): Buffer {
+  const head = Buffer.alloc(8);
+  head.writeUInt32BE(8 + payload.length, 0);
+  head.write(type, 4, 'latin1');
+  return Buffer.concat([head, payload]);
+}
+
+function buildInit(trackId = 1, timescale = TS, handler = 'vide'): Buffer {
+  // tkhd v0: version+flags(4) creation(4) modification(4) track_ID(4) → id @12
+  const tkhd = box('tkhd', Buffer.concat([Buffer.alloc(12), u32(trackId)]));
+  // mdhd v0: version+flags(4) creation(4) modification(4) timescale(4) → ts @12
+  const mdhd = box('mdhd', Buffer.concat([Buffer.alloc(12), u32(timescale)]));
+  // hdlr: fullbox(4) pre_defined(4) handler_type(4) → handler @8
+  const hdlr = box(
+    'hdlr',
+    Buffer.concat([Buffer.alloc(8), Buffer.from(handler, 'latin1')]),
+  );
+  const mdia = box('mdia', Buffer.concat([mdhd, hdlr]));
+  const trak = box('trak', Buffer.concat([tkhd, mdia]));
+  return box('moov', trak);
+}
+
+function buildSeg(tfdtValue: number, trackId = 1): Buffer {
+  // tfhd: fullbox(4) track_ID(4) → id @4
+  const tfhd = box('tfhd', Buffer.concat([Buffer.alloc(4), u32(trackId)]));
+  // tfdt v0: version(1)+flags(3) baseMediaDecodeTime(4) → value @4
+  const tfdt = box('tfdt', Buffer.concat([Buffer.from([0, 0, 0, 0]), u32(tfdtValue)]));
+  const traf = box('traf', Buffer.concat([tfhd, tfdt]));
+  return Buffer.concat([box('moof', traf), box('mdat', Buffer.alloc(4))]);
+}
+
+function readTfdt(buf: Buffer): number {
+  // box: size(4) type(4) version+flags(4) value(4) → value 8 bytes after 'tfdt'
+  const i = buf.indexOf(Buffer.from('tfdt', 'latin1'));
+  return buf.readUInt32BE(i + 8);
+}
+
+describe('rewriteSegmentTfdt', () => {
+  const tracks = parseInitTracks(buildInit());
+  const SEG = 4;
+
+  it('parses the synthetic init (sanity)', () => {
+    expect(tracks.size).toBe(1);
+    expect(tracks.get(1)).toEqual({ timescale: TS, isVideo: true });
+  });
+
+  it('is a no-op when the segment is already grid-aligned (transcode)', () => {
+    // seg-25's tfdt already at 25*4=100s → runStart 0 → left untouched.
+    const out = rewriteSegmentTfdt(buildSeg(100 * TS), tracks, 25, SEG);
+    expect(readTfdt(out)).toBe(100 * TS);
+  });
+
+  it('shifts a run-relative tfdt onto its absolute grid position', () => {
+    // A mid-file transcode run reset tfdt to 0 for seg-25 → anchored to 100s.
+    const out = rewriteSegmentTfdt(buildSeg(0), tracks, 25, SEG);
+    expect(readTfdt(out)).toBe(100 * TS);
+  });
+
+  it('snaps a sub-grid tfdt onto the grid — why remux must skip the anchor (#349)', () => {
+    // A remux seg-25 (GOP-aligned -c:v copy + -copyts) carries its true source
+    // IDR PTS (98s), NOT the 100s grid. The anchor wrongly shifts it +2s onto
+    // the grid; because each remux segment's IDR offset differs, the timeline
+    // becomes non-monotonic — so serveCmafFile skips the anchor for remux.
+    const out = rewriteSegmentTfdt(buildSeg(98 * TS), tracks, 25, SEG);
+    expect(readTfdt(out)).toBe(100 * TS); // 98s corrupted to 100s — the bug
+  });
+});


### PR DESCRIPTION
Closes #349.

`anchorSegmentTimeline` rewrote every `seg-N.m4s` tfdt to `N*segmentDuration` — right for the forced-keyframe **transcode** path (grid-aligned → `runStart 0` → no-op), wrong for **remux** (`-c:v copy`, GOP-aligned, `-copyts` absolute timeline). A remux seg-25 carries its true source IDR PTS (e.g. 98s, not the 100s grid) → the anchor shifted it +2s, and since each segment's IDR-vs-grid offset differs the timeline went **non-monotonic on resume/seek** (A/V + subtitle desync). Cold start was safe.

`serveCmafFile` now skips the tfdt anchor for remux (its `-copyts` timeline is already absolute); transcode keeps it (no-op on grid output). Early-probe paths are gated `quality !== 'remux'`, so the main serve is the only remux-reachable tfdt path — verified by reading the full flow.

**Can't device-test (per your call), so verified by:** rigorous reasoning of the `-copyts`/`-ss`/forced-IDR args (transcode `runStart=0` vs remux `runStart>0`), a new `timeline.spec.ts` demonstrating the 98s→100s corruption the skip prevents, `tsc` clean, full streaming suite (97) green. Transcode (the dominant path) is untouched.