### PR TITLE
fix(streaming): propagate source HDR10 static metadata to encoders

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -425,6 +425,7 @@ export class StreamingController {
       sourceWidth: si?.video?.[0]?.width,
       sourceHeight: si?.video?.[0]?.height,
       isSourceHdr: !!si?.video?.[0]?.hdrFormat,
+      hdrMetadata: si?.video?.[0]?.hdrMetadata,
       // Variant chosen by stream-builder's codec selector at
       // playback-info time, threaded through every session spawn so
       // ffmpeg-args resolves the matching encoder descriptor. HLS

--- a/backend/src/modules/streaming/transcoding/codec/encoders/av1-cpu.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/av1-cpu.ts
@@ -1,6 +1,7 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { av1CodecString } from '../codec-strings';
 import { hdrColorArgs } from './helpers/hdr-variants';
+import { masterDisplayString, maxCllString } from './helpers/hdr-metadata';
 import { scaleMod16Height } from './helpers/scale-filter';
 
 /** Maps a named ffmpeg preset onto the SVT-AV1 integer preset namespace
@@ -113,7 +114,7 @@ export const av1CpuHdr10: EncoderDescriptor = {
       '-bufsize',
       bufsize,
       '-svtav1-params',
-      'enable-hdr=1:mastering-display=G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(10000000,1):content-light=1000,400',
+      `enable-hdr=1:mastering-display=${masterDisplayString(input.hdrMetadata)}:content-light=${maxCllString(input.hdrMetadata)}`,
       '-vf',
       `${filters.cpuCropPrefix}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p10le${filters.burnInFilter}`,
       '-g',

--- a/backend/src/modules/streaming/transcoding/codec/encoders/av1-nvenc.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/av1-nvenc.ts
@@ -1,6 +1,7 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { av1CodecString } from '../codec-strings';
 import { hdrColorArgs } from './helpers/hdr-variants';
+import { masterDisplayString, maxCllString } from './helpers/hdr-metadata';
 import { scaleMod16Height } from './helpers/scale-filter';
 
 /** NVIDIA NVENC AV1 encoder — Ada Lovelace (RTX 4000 series) and later.
@@ -99,9 +100,9 @@ export const av1NvencHdr10: EncoderDescriptor = {
       input.forceKeyframesExpr,
       ...hdrColorArgs('HDR10'),
       '-master_display',
-      'G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(10000000,1)',
+      masterDisplayString(input.hdrMetadata),
       '-max_cll',
-      '1000,400',
+      maxCllString(input.hdrMetadata),
     ];
   },
 };

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/hdr-metadata.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/hdr-metadata.spec.ts
@@ -3,7 +3,8 @@ import { masterDisplayString, maxCllString } from './hdr-metadata';
 const GENERIC_DISPLAY =
   'G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(10000000,1)';
 const SOURCE = {
-  masteringDisplay: 'G(8500,39850)B(6550,2300)R(35400,14600)WP(15635,16450)L(40000000,50)',
+  masteringDisplay:
+    'G(8500,39850)B(6550,2300)R(35400,14600)WP(15635,16450)L(40000000,50)',
   maxCll: 4000,
   maxFall: 600,
 };
@@ -22,7 +23,13 @@ describe('maxCllString', () => {
     expect(maxCllString(SOURCE)).toBe('4000,600');
   });
   it('emits the valid "0,0" unknown signal when the source had no CLL', () => {
-    expect(maxCllString({ masteringDisplay: SOURCE.masteringDisplay, maxCll: 0, maxFall: 0 })).toBe('0,0');
+    expect(
+      maxCllString({
+        masteringDisplay: SOURCE.masteringDisplay,
+        maxCll: 0,
+        maxFall: 0,
+      }),
+    ).toBe('0,0');
   });
   it('falls back to the generic reference when absent', () => {
     expect(maxCllString(undefined)).toBe('1000,400');

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/hdr-metadata.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/hdr-metadata.spec.ts
@@ -1,0 +1,30 @@
+import { masterDisplayString, maxCllString } from './hdr-metadata';
+
+const GENERIC_DISPLAY =
+  'G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(10000000,1)';
+const SOURCE = {
+  masteringDisplay: 'G(8500,39850)B(6550,2300)R(35400,14600)WP(15635,16450)L(40000000,50)',
+  maxCll: 4000,
+  maxFall: 600,
+};
+
+describe('masterDisplayString', () => {
+  it('returns the source mastering display when present', () => {
+    expect(masterDisplayString(SOURCE)).toBe(SOURCE.masteringDisplay);
+  });
+  it('falls back to the generic 1000-nit reference when absent', () => {
+    expect(masterDisplayString(undefined)).toBe(GENERIC_DISPLAY);
+  });
+});
+
+describe('maxCllString', () => {
+  it('formats the source content-light level as "maxCLL,maxFALL"', () => {
+    expect(maxCllString(SOURCE)).toBe('4000,600');
+  });
+  it('emits the valid "0,0" unknown signal when the source had no CLL', () => {
+    expect(maxCllString({ masteringDisplay: SOURCE.masteringDisplay, maxCll: 0, maxFall: 0 })).toBe('0,0');
+  });
+  it('falls back to the generic reference when absent', () => {
+    expect(maxCllString(undefined)).toBe('1000,400');
+  });
+});

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/hdr-metadata.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/hdr-metadata.ts
@@ -1,0 +1,28 @@
+import type { HdrStaticMetadata } from '../../types';
+
+/** Generic 1000-nit BT.2020 HDR10 reference, used when the source carried no
+ *  ST 2086 mastering-display metadata — the encoder still emits a valid (if
+ *  approximate) signal. Replaced by the source's real values when probed. */
+const GENERIC_MASTER_DISPLAY =
+  'G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(10000000,1)';
+const GENERIC_MAX_CLL = '1000,400';
+
+/**
+ * `master-display` value — the source's mastering display when probed, else the
+ * generic 1000-nit reference. The `G(gx,gy)B(bx,by)R(rx,ry)WP(wx,wy)L(max,min)`
+ * format is shared by x265 (`master-display=`), SVT-AV1 (`mastering-display=`)
+ * and ffmpeg (`-master_display`).
+ */
+export function masterDisplayString(meta?: HdrStaticMetadata): string {
+  return meta?.masteringDisplay || GENERIC_MASTER_DISPLAY;
+}
+
+/**
+ * `max-cll` value (`maxCLL,maxFALL`) — the source's content light level when
+ * probed (`0,0` when the source had mastering metadata but no CLL, which is the
+ * valid "unknown" signal), else the generic reference.
+ */
+export function maxCllString(meta?: HdrStaticMetadata): string {
+  if (!meta) return GENERIC_MAX_CLL;
+  return `${meta.maxCll},${meta.maxFall}`;
+}

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-cpu.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-cpu.ts
@@ -1,6 +1,7 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
 import { hdrColorArgs } from './helpers/hdr-variants';
+import { masterDisplayString, maxCllString } from './helpers/hdr-metadata';
 import { scaleMod16Height } from './helpers/scale-filter';
 
 /** Universal libx265 HEVC SDR fallback. Same thread cap as libx264 (4):
@@ -44,20 +45,6 @@ export const hevcCpu: EncoderDescriptor = {
   },
 };
 
-/** Reference HDR10 master-display string for `x265-params`. The values
- *  describe a BT.2020 display mastered at 1000-nit peak / 0.0001-nit
- *  black point — a sane default for a home-server that re-encodes from
- *  consumer HDR sources without per-title color analysis. Units follow
- *  x265's convention: chromaticities are `0.00002`-step integers and
- *  luminance is `0.0001 cd/m2`. */
-const X265_MASTER_DISPLAY =
-  'G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(10000000,1)';
-
-/** Default MaxCLL / MaxFALL — 1000 / 400 nits. Reasonable HDR10 envelope
- *  for streaming-grade content; conservative enough that downstream
- *  displays don't see clipped highlights. */
-const X265_MAX_CLL = '1000,400';
-
 /** libx265 HEVC Main10 HDR10 — universal CPU fallback for HDR rungs
  *  whenever the platform's HW path either can't emit Main10 or can't
  *  write the `mdcv` / `clli` SEI reliably. `hdr-opt=1` enables PQ
@@ -80,8 +67,8 @@ export const hevcCpuHdr10: EncoderDescriptor = {
       'colorprim=bt2020',
       'transfer=smpte2084',
       'colormatrix=bt2020nc',
-      `master-display=${X265_MASTER_DISPLAY}`,
-      `max-cll=${X265_MAX_CLL}`,
+      `master-display=${masterDisplayString(input.hdrMetadata)}`,
+      `max-cll=${maxCllString(input.hdrMetadata)}`,
     ].join(':');
     return [
       '-c:v',

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-nvenc.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-nvenc.ts
@@ -1,6 +1,7 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
 import { hdrColorArgs, hlgFromHdr10 } from './helpers/hdr-variants';
+import { masterDisplayString, maxCllString } from './helpers/hdr-metadata';
 import { scaleMod16Height } from './helpers/scale-filter';
 
 /** NVIDIA NVENC HEVC SDR encoder — Maxwell 2nd gen (GM20x) and later.
@@ -101,6 +102,18 @@ export const hevcNvencHdr10: EncoderDescriptor = {
       '-force_key_frames',
       input.forceKeyframesExpr,
       ...hdrColorArgs('HDR10'),
+      // When the source's HDR10 static metadata was probed, emit it explicitly
+      // so the mastering-display / content-light SEI is guaranteed rather than
+      // depending on the AVFrame side-data surviving scale_cuda. Absent → fall
+      // back to NVENC's own input-derived SEI (#354).
+      ...(input.hdrMetadata
+        ? [
+            '-master_display',
+            masterDisplayString(input.hdrMetadata),
+            '-max_cll',
+            maxCllString(input.hdrMetadata),
+          ]
+        : []),
       '-tag:v',
       'hvc1',
     ];

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-qsv.ts
@@ -1,6 +1,7 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
 import { hdrColorArgs, hlgFromHdr10 } from './helpers/hdr-variants';
+import { masterDisplayString, maxCllString } from './helpers/hdr-metadata';
 import { qsvScaleFilter8bit, qsvScaleFilter10bit } from './helpers/qsv-filters';
 
 /** Intel QSV HEVC Main 8-bit encoder — Skylake gen6 and above. Native
@@ -94,6 +95,17 @@ export const hevcQsvHdr10: EncoderDescriptor = {
       '-force_key_frames',
       input.forceKeyframesExpr,
       ...hdrColorArgs('HDR10'),
+      // Emit the probed source mastering-display / content-light SEI explicitly
+      // when available, rather than relying solely on AVFrame metadata
+      // propagation through the QSV filter chain. Absent → input-derived (#354).
+      ...(input.hdrMetadata
+        ? [
+            '-master_display',
+            masterDisplayString(input.hdrMetadata),
+            '-max_cll',
+            maxCllString(input.hdrMetadata),
+          ]
+        : []),
       '-tag:v',
       'hvc1',
     ];

--- a/backend/src/modules/streaming/transcoding/codec/types.ts
+++ b/backend/src/modules/streaming/transcoding/codec/types.ts
@@ -19,6 +19,18 @@ export type BitDepth = 8 | 10;
  *  passthrough is deferred to #368. */
 export type HdrFormat = 'HDR10' | 'HLG';
 
+/** Source HDR10 static metadata (SMPTE ST 2086 mastering display + CTA-861.3
+ *  content light level), probed from the source and propagated into the encoder
+ *  so the display tonemaps against the real peak luminance instead of a generic
+ *  1000-nit reference. `maxCll`/`maxFall` are 0 when unknown. `masteringDisplay`
+ *  is the `G(gx,gy)B(bx,by)R(rx,ry)WP(wx,wy)L(max,min)` string shared by x265
+ *  `master-display`, SVT-AV1 `mastering-display`, and ffmpeg `-master_display`. */
+export interface HdrStaticMetadata {
+  masteringDisplay: string;
+  maxCll: number;
+  maxFall: number;
+}
+
 /** The triple that uniquely identifies a video output format. Resolution
  *  and bitrate are not part of identity — those live on `LadderRung`. */
 export interface CodecVariant {
@@ -105,6 +117,9 @@ export interface EncoderInput {
    *  both crop and scale; when it receives VAAPI surfaces (default
    *  Linux path) it stays on the `scale_vaapi → hwmap=qsv` chain. */
   inputSurface: import('./decoders/types').SurfaceFormat;
+  /** Source HDR10 static metadata, when the probe recovered it. Encoders feed
+   *  it into `master-display` / `max-cll`; absent → generic 1000-nit fallback. */
+  hdrMetadata?: HdrStaticMetadata;
 }
 
 /** A single encoder binding — one ffmpeg encoder × one platform × one

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -15,6 +15,7 @@ import type {
   BitDepth,
   CodecVariant,
   EncoderInput,
+  HdrStaticMetadata,
   VideoCodec,
 } from './codec/types';
 import { decoderRegistry, findQsvNativeDecoder } from './codec/decoders';
@@ -62,6 +63,11 @@ export interface BuildFfmpegArgsOptions {
    *  defaults to the profile's raw `maxWidth × maxHeight`. */
   sourceWidth?: number;
   sourceHeight?: number;
+  /** Source HDR10 static metadata (mastering display + content light), probed
+   *  from the source. Fed into the encoder's master-display / max-cll so the
+   *  display tonemaps to the real peak luminance; the encoders fall back to a
+   *  generic 1000-nit reference when absent. */
+  sourceHdrMetadata?: HdrStaticMetadata;
   /** Audio output decision — see {@link SessionContext.audioPlan}. When
    *  omitted, ffmpeg-args falls back to AAC stereo at the profile bitrate
    *  (safe default that plays everywhere). */
@@ -140,6 +146,7 @@ export function buildFfmpegArgs(
     sourceBitDepth = 8,
     sourceWidth = 0,
     sourceHeight = 0,
+    sourceHdrMetadata,
     tonemapAlgo = 'auto',
   } = opts;
 
@@ -539,6 +546,7 @@ export function buildFfmpegArgs(
     tonemapPath,
     hasBurnIn: !!burnIn?.filter,
     hasCrop: !!crop,
+    hdrMetadata: sourceHdrMetadata,
     // Override to 'videotoolbox' when the Metal fast path is active —
     // the descriptor's static `outputSurface` is `'cpu'` because every
     // OTHER VT consumer expects CPU buffers, but we just told the

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -837,6 +837,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
           sourceBitDepth: ctx?.isSourceHdr ? 10 : 8,
           sourceWidth: ctx?.sourceWidth,
           sourceHeight: ctx?.sourceHeight,
+          sourceHdrMetadata: ctx?.hdrMetadata,
         },
         this.log,
       );
@@ -1146,6 +1147,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         sourceBitDepth: ctx?.isSourceHdr ? 10 : 8,
         sourceWidth: ctx?.sourceWidth,
         sourceHeight: ctx?.sourceHeight,
+        sourceHdrMetadata: ctx?.hdrMetadata,
       },
       this.log,
     );

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -198,6 +198,10 @@ export interface SessionContext {
    * contradict the master playlist's CODECS string.
    */
   videoVariant?: import('./codec/types').CodecVariant;
+  /** Source HDR10 static metadata, threaded from the probed streamInfo so the
+   *  encoder signals the source's real mastering display / content light
+   *  instead of a generic 1000-nit reference. */
+  hdrMetadata?: import('./codec/types').HdrStaticMetadata;
 }
 
 export interface TranscodeSession {

--- a/backend/src/modules/subtitles/ffprobe.service.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.ts
@@ -47,6 +47,11 @@ export interface VideoStreamInfo {
   colorTransfer?: string;
   colorPrimaries?: string;
   hdrFormat?: HdrFormat;
+  /** Source HDR10 static metadata (SMPTE ST 2086 mastering display + CTA-861.3
+   *  content light), probed via frame side-data for HDR10 sources. Drives the
+   *  encoder's master-display / max-cll so the display tonemaps to the source's
+   *  real peak luminance instead of a generic 1000-nit reference. */
+  hdrMetadata?: { masteringDisplay: string; maxCll: number; maxFall: number };
   crop?: CropInfo;
 }
 
@@ -158,6 +163,74 @@ function resolveStreamLanguage(s: {
   const explicit = tag(s.tags, 'language');
   if (explicit && explicit.toLowerCase() !== 'und') return explicit;
   return inferLanguageCodeFromTitle(tag(s.tags, 'title')) ?? 'und';
+}
+
+export interface HdrStaticMetadataDto {
+  masteringDisplay: string;
+  maxCll: number;
+  maxFall: number;
+}
+
+/** Scale an ffprobe metadata value to its integer SEI unit. ffprobe emits
+ *  rationals (`"13250/50000"`) on modern builds and bare decimals on older
+ *  ones; both resolve to the same scaled integer. Returns null when unparseable
+ *  so the caller can drop incomplete metadata rather than emit garbage. */
+function scaleMetaValue(
+  raw: string | number | undefined,
+  unit: number,
+): number | null {
+  if (raw == null) return null;
+  if (typeof raw === 'number') return Math.round(raw * unit);
+  const [n, d] = raw.split('/');
+  const num = Number(n);
+  const den = d != null ? Number(d) : 1;
+  if (!Number.isFinite(num) || !Number.isFinite(den) || den === 0) return null;
+  return Math.round((num / den) * unit);
+}
+
+/**
+ * Parse ffprobe frame `side_data_list` into HDR10 static metadata. Builds the
+ * `G()B()R()WP()L()` mastering-display string (coordinates in 0.00002 units,
+ * luminance in 0.0001 cd/m²) plus MaxCLL/MaxFALL. Returns null when no
+ * mastering-display side-data is present (HLG, SDR, or HDR10 without metadata)
+ * or when it is incomplete.
+ */
+export function parseHdrStaticMetadata(
+  sideDataList: unknown[] | undefined,
+): HdrStaticMetadataDto | null {
+  if (!Array.isArray(sideDataList)) return null;
+  const typeOf = (d: unknown): string =>
+    String((d as { side_data_type?: unknown })?.side_data_type ?? '');
+  const md = sideDataList.find((d) => /mastering display/i.test(typeOf(d))) as
+    | Record<string, string | number>
+    | undefined;
+  if (!md) return null;
+  const cl = sideDataList.find((d) => /content light/i.test(typeOf(d))) as
+    | Record<string, string | number>
+    | undefined;
+
+  const gx = scaleMetaValue(md.green_x, 50000);
+  const gy = scaleMetaValue(md.green_y, 50000);
+  const bx = scaleMetaValue(md.blue_x, 50000);
+  const by = scaleMetaValue(md.blue_y, 50000);
+  const rx = scaleMetaValue(md.red_x, 50000);
+  const ry = scaleMetaValue(md.red_y, 50000);
+  const wx = scaleMetaValue(md.white_point_x, 50000);
+  const wy = scaleMetaValue(md.white_point_y, 50000);
+  const maxL = scaleMetaValue(md.max_luminance, 10000);
+  const minL = scaleMetaValue(md.min_luminance, 10000);
+  if ([gx, gy, bx, by, rx, ry, wx, wy, maxL, minL].some((v) => v == null)) {
+    return null;
+  }
+
+  const masteringDisplay = `G(${gx},${gy})B(${bx},${by})R(${rx},${ry})WP(${wx},${wy})L(${maxL},${minL})`;
+  const maxCll = cl?.max_content != null ? Number(cl.max_content) : 0;
+  const maxFall = cl?.max_average != null ? Number(cl.max_average) : 0;
+  return {
+    masteringDisplay,
+    maxCll: Number.isFinite(maxCll) ? maxCll : 0,
+    maxFall: Number.isFinite(maxFall) ? maxFall : 0,
+  };
 }
 
 @Injectable()
@@ -291,6 +364,15 @@ export class FfprobeService {
           hdrFormat: this.deriveHdrFormat(s.color_transfer, s.color_primaries),
         }));
 
+      // HDR10 sources: probe the first frame's side-data for mastering-display
+      // + content-light so the encoder signals the source's real peak luminance
+      // instead of a generic 1000-nit reference. Gated to HDR10 (one extra
+      // frame-decoding ffprobe pass); SDR / HLG imports skip it.
+      if (video[0]?.hdrFormat === 'HDR10') {
+        const meta = await this.probeHdrStaticMetadata(videoPath);
+        if (meta) video[0].hdrMetadata = meta;
+      }
+
       const audio: AudioStreamInfo[] = streams
         .filter((s) => s.codec_type === 'audio')
         .map((s) => ({
@@ -370,6 +452,42 @@ export class FfprobeService {
     if (colorTransfer === 'smpte2084' && isBt2020) return 'HDR10';
     if (colorTransfer === 'arib-std-b67' && isBt2020) return 'HLG';
     return undefined;
+  }
+
+  /** Probe the first video frame's side-data for HDR10 static metadata
+   *  (mastering display + content light). Gated to HDR10 sources by the caller
+   *  so non-HDR imports skip the extra (frame-decoding) ffprobe pass. Returns
+   *  null when the source carries no such metadata. */
+  private async probeHdrStaticMetadata(
+    videoPath: string,
+  ): Promise<HdrStaticMetadataDto | null> {
+    try {
+      const { stdout } = await execFileAsync(
+        'ffprobe',
+        [
+          '-v',
+          'error',
+          '-print_format',
+          'json',
+          '-select_streams',
+          'v:0',
+          '-read_intervals',
+          '%+#1',
+          '-show_frames',
+          '-show_entries',
+          'frame=side_data_list',
+          videoPath,
+        ],
+        { timeout: 15_000 },
+      );
+      const frames = (JSON.parse(stdout) as { frames?: { side_data_list?: unknown[] }[] }).frames;
+      return parseHdrStaticMetadata(frames?.[0]?.side_data_list);
+    } catch (err) {
+      this.logger.warn(
+        `HDR static-metadata probe failed for "${videoPath}": ${(err as Error).message}`,
+      );
+      return null;
+    }
   }
 
   private parseFrameRate(rate?: string): string | undefined {

--- a/backend/src/modules/subtitles/hdr-static-metadata.spec.ts
+++ b/backend/src/modules/subtitles/hdr-static-metadata.spec.ts
@@ -24,9 +24,9 @@ const EXPECTED_DISPLAY =
 
 describe('parseHdrStaticMetadata', () => {
   it('parses full HDR10 side-data (rational form)', () => {
-    expect(
-      parseHdrStaticMetadata([MASTERING_RATIONAL, CONTENT_LIGHT]),
-    ).toEqual({ masteringDisplay: EXPECTED_DISPLAY, maxCll: 1000, maxFall: 400 });
+    expect(parseHdrStaticMetadata([MASTERING_RATIONAL, CONTENT_LIGHT])).toEqual(
+      { masteringDisplay: EXPECTED_DISPLAY, maxCll: 1000, maxFall: 400 },
+    );
   });
 
   it('parses the same values in decimal form (older ffprobe)', () => {

--- a/backend/src/modules/subtitles/hdr-static-metadata.spec.ts
+++ b/backend/src/modules/subtitles/hdr-static-metadata.spec.ts
@@ -1,0 +1,72 @@
+import { parseHdrStaticMetadata } from './ffprobe.service';
+
+const MASTERING_RATIONAL = {
+  side_data_type: 'Mastering display metadata',
+  red_x: '34000/50000',
+  red_y: '16000/50000',
+  green_x: '13250/50000',
+  green_y: '34500/50000',
+  blue_x: '7500/50000',
+  blue_y: '3000/50000',
+  white_point_x: '15635/50000',
+  white_point_y: '16450/50000',
+  min_luminance: '50/10000',
+  max_luminance: '10000000/10000',
+};
+const CONTENT_LIGHT = {
+  side_data_type: 'Content light level metadata',
+  max_content: 1000,
+  max_average: 400,
+};
+// Coordinates scale by 50000, luminance by 10000 (0.0001 cd/m²).
+const EXPECTED_DISPLAY =
+  'G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(10000000,50)';
+
+describe('parseHdrStaticMetadata', () => {
+  it('parses full HDR10 side-data (rational form)', () => {
+    expect(
+      parseHdrStaticMetadata([MASTERING_RATIONAL, CONTENT_LIGHT]),
+    ).toEqual({ masteringDisplay: EXPECTED_DISPLAY, maxCll: 1000, maxFall: 400 });
+  });
+
+  it('parses the same values in decimal form (older ffprobe)', () => {
+    const decimal = {
+      side_data_type: 'Mastering display metadata',
+      red_x: 0.68,
+      red_y: 0.32,
+      green_x: 0.265,
+      green_y: 0.69,
+      blue_x: 0.15,
+      blue_y: 0.06,
+      white_point_x: 0.3127,
+      white_point_y: 0.329,
+      min_luminance: 0.005,
+      max_luminance: 1000,
+    };
+    expect(parseHdrStaticMetadata([decimal, CONTENT_LIGHT])).toEqual({
+      masteringDisplay: EXPECTED_DISPLAY,
+      maxCll: 1000,
+      maxFall: 400,
+    });
+  });
+
+  it('returns maxCll/maxFall 0 when content-light side-data is absent', () => {
+    expect(parseHdrStaticMetadata([MASTERING_RATIONAL])).toEqual({
+      masteringDisplay: EXPECTED_DISPLAY,
+      maxCll: 0,
+      maxFall: 0,
+    });
+  });
+
+  it('returns null when there is no mastering-display side-data (HLG / SDR)', () => {
+    expect(parseHdrStaticMetadata([CONTENT_LIGHT])).toBeNull();
+    expect(parseHdrStaticMetadata([])).toBeNull();
+    expect(parseHdrStaticMetadata(undefined)).toBeNull();
+  });
+
+  it('returns null when the mastering-display block is incomplete', () => {
+    const partial = { ...MASTERING_RATIONAL };
+    delete (partial as Record<string, unknown>).max_luminance;
+    expect(parseHdrStaticMetadata([partial])).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #354.

HDR10 re-encodes hardcoded a generic 1000-nit mastering display + 1000/400 MaxCLL regardless of source, so a 4000-nit master was signalled as 1000-nit → wrong tonemapping (clipped highlights). Now the source's ST 2086 mastering display + CTA-861.3 CLL is probed (gated to HDR10, frame side-data), threaded `streamInfo → SessionContext → EncoderInput`, and emitted by every HDR10 encoder (libx265 / SVT-AV1 / av1_nvenc: source-or-generic; hevc_nvenc / hevc_qsv: explicit `-master_display`/`-max_cll` when probed). Remux already copies the SEI through.

Parser is robust to ffprobe's rational (`13250/50000`) and decimal forms; **falls back to the existing generic constants when the source has no metadata or the probe fails → no regression for HDR without static metadata or non-HDR.** tsc clean; new parser+formatter unit specs (10) + full streaming/subtitles suites (123) green.

**Behavioral (changes the HDR10 bitstream SEI) — holding merge for your Android test.** To exercise it you need the server to **re-encode** an HDR10 title (the HDR ladder / a quality cap forcing transcode — DirectPlay/remux just copies the original SEI). Verify: HDR10 still plays + signals HDR on the device, no encode failure, and ideally that a high-nit master's highlights tonemap better than before. Merge once confirmed.