### PR TITLE
docs(auth): record the stream-token security envelope rationale

### DIFF
--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -231,6 +231,23 @@ export class AuthService {
    * re-ask Angular for a fresh one, so a 2h film with a 1h token would
    * break halfway. This token gives the engines a window large enough
    * to cover essentially any single playback session.
+   *
+   * Security envelope (deliberately accepted — see issue #356). The token is
+   * long-lived, stateless and carries no per-file or per-session claim, so a
+   * leaked manifest URL is replayable until expiry. The blast radius is bounded
+   * on four sides and the residual risk is judged acceptable rather than
+   * traded against the playback breakage a shorter TTL or session-binding would
+   * introduce (engines can't re-bake mid-stream):
+   *   1. user-scoped via `sub` — replays only the holder's OWN content;
+   *   2. every stream route still runs `resolveFile(mediaFileId, user)` under
+   *      `JwtOrApiKeyGuard`, enforcing the live library ACL on each request;
+   *   3. the manifest / segment routes are sid-gated (`assertFreshSession`
+   *      410s a stopped/GC'd session), so URLs die with their LiveSession;
+   *   4. disabling/deleting the user invalidates the token on its next use
+   *      (the strategy re-checks `enabled`).
+   * Tightening further (jti=sid binding, shorter TTL) is tracked but not done:
+   * it reworks the client's token-reuse flow and risks mid-playback reloads for
+   * a marginal gain over the above.
    */
   generateStreamToken(user: User): string {
     const ttl = this.config.get<string>('STREAM_TOKEN_TTL', '12h');


### PR DESCRIPTION
Closes #356 (accept + document).

After investigating, the stream JWT's risk is **bounded on four sides** — user-scoped (`sub`), per-request library ACL (`resolveFile(mediaFileId, user)` under the guard), sid-gating (`assertFreshSession` 410s a stopped/GC'd session), and user-disable revocation — so a leaked URL replays only the holder's own content, on live sessions, until expiry or user-disable.

The **12h TTL is load-bearing**: engines bake the token at `load()` and never re-bake mid-stream, so a shorter TTL or session-binding (`jti=sid`) would risk mid-playback reloads + a client token-reuse rework, for a marginal gain over the above. So the residual risk is **deliberately accepted and documented** on `generateStreamToken` rather than hardened. Comment-only, no behaviour change.