### PR TITLE
fix(streaming): scale to mod-2 so encode height matches the manifest

### DIFF
--- a/backend/src/modules/streaming/transcoding/codec/encoders/av1-cpu.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/av1-cpu.ts
@@ -2,7 +2,7 @@ import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { av1CodecString } from '../codec-strings';
 import { hdrColorArgs } from './helpers/hdr-variants';
 import { masterDisplayString, maxCllString } from './helpers/hdr-metadata';
-import { scaleMod16Height } from './helpers/scale-filter';
+import { scaleEvenHeight } from './helpers/scale-filter';
 
 /** Maps a named ffmpeg preset onto the SVT-AV1 integer preset namespace
  *  (`0` slowest / highest-quality, `13` fastest). Values picked to match
@@ -74,7 +74,7 @@ export const av1Cpu: EncoderDescriptor = {
       '-bufsize',
       bufsize,
       '-vf',
-      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleEvenHeight(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
       '-g',
       String(target.gopSize),
       '-keyint_min',
@@ -116,7 +116,7 @@ export const av1CpuHdr10: EncoderDescriptor = {
       '-svtav1-params',
       `enable-hdr=1:mastering-display=${masterDisplayString(input.hdrMetadata)}:content-light=${maxCllString(input.hdrMetadata)}`,
       '-vf',
-      `${filters.cpuCropPrefix}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p10le${filters.burnInFilter}`,
+      `${filters.cpuCropPrefix}scale=${w}:${scaleEvenHeight(w)}:flags=lanczos,format=yuv420p10le${filters.burnInFilter}`,
       '-g',
       String(target.gopSize),
       '-keyint_min',
@@ -160,7 +160,7 @@ export const av1CpuHlg: EncoderDescriptor = {
       '-svtav1-params',
       'color-primaries=9:transfer-characteristics=18:matrix-coefficients=9',
       '-vf',
-      `${filters.cpuCropPrefix}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p10le${filters.burnInFilter}`,
+      `${filters.cpuCropPrefix}scale=${w}:${scaleEvenHeight(w)}:flags=lanczos,format=yuv420p10le${filters.burnInFilter}`,
       '-g',
       String(target.gopSize),
       '-keyint_min',

--- a/backend/src/modules/streaming/transcoding/codec/encoders/av1-nvenc.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/av1-nvenc.ts
@@ -2,7 +2,7 @@ import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { av1CodecString } from '../codec-strings';
 import { hdrColorArgs } from './helpers/hdr-variants';
 import { masterDisplayString, maxCllString } from './helpers/hdr-metadata';
-import { scaleMod16Height } from './helpers/scale-filter';
+import { scaleEvenHeight } from './helpers/scale-filter';
 
 /** NVIDIA NVENC AV1 encoder — Ada Lovelace (RTX 4000 series) and later.
  *  Pascal, Turing and Ampere don't ship the AV1 encode unit, so
@@ -44,7 +44,7 @@ export const av1Nvenc: EncoderDescriptor = {
       return [
         ...common,
         '-vf',
-        `hwdownload,format=p010le,${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}`,
+        `hwdownload,format=p010le,${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleEvenHeight(w)}`,
         ...trailing,
       ];
     }

--- a/backend/src/modules/streaming/transcoding/codec/encoders/av1-vaapi.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/av1-vaapi.ts
@@ -31,7 +31,7 @@ export const av1Vaapi: EncoderDescriptor = {
       return [
         ...common,
         '-vf',
-        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi}`,
+        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-2:extra_hw_frames=24${filters.tonemapVaapi}`,
         ...trailing,
       ];
     }
@@ -39,14 +39,14 @@ export const av1Vaapi: EncoderDescriptor = {
       return [
         ...common,
         '-vf',
-        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=vaapi:mode=write:reverse=1,format=vaapi`,
+        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-2:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=vaapi:mode=write:reverse=1,format=vaapi`,
         ...trailing,
       ];
     }
     return [
       ...common,
       '-vf',
-      `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:format=nv12`,
+      `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-2:format=nv12`,
       ...trailing,
     ];
   },
@@ -76,7 +76,7 @@ export const av1VaapiHdr10: EncoderDescriptor = {
       '-maxrate',
       bitrate,
       '-vf',
-      `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:format=p010le`,
+      `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-2:format=p010le`,
       '-g',
       String(target.gopSize),
       '-keyint_min',

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-cpu.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-cpu.ts
@@ -1,6 +1,6 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { h264CodecString } from '../codec-strings';
-import { scaleMod16Height } from './helpers/scale-filter';
+import { scaleEvenHeight } from './helpers/scale-filter';
 
 /** Universal libx264 fallback. Threads capped at 4 so seg-0 ships
  *  before a long `(threads-1)` frame pre-buffer fills (CPU encoders
@@ -44,7 +44,7 @@ export const h264Cpu: EncoderDescriptor = {
       '-bufsize',
       libx264BufsizeMb,
       '-vf',
-      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleEvenHeight(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
       '-force_key_frames',
       input.forceKeyframesExpr,
       '-sc_threshold:v:0',

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-nvenc.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-nvenc.ts
@@ -1,6 +1,6 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { h264CodecString } from '../codec-strings';
-import { scaleMod16Height } from './helpers/scale-filter';
+import { scaleEvenHeight } from './helpers/scale-filter';
 
 /** NVIDIA NVENC H.264 encoder — Kepler and later. Tonemap path round-trips
  *  via CPU (hwdownload + scale + tonemap chain) because the CUDA filter
@@ -40,7 +40,7 @@ export const h264Nvenc: EncoderDescriptor = {
       return [
         ...common,
         '-vf',
-        `hwdownload,format=p010le,${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}`,
+        `hwdownload,format=p010le,${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleEvenHeight(w)}`,
         ...trailing,
       ];
     }

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-vaapi.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-vaapi.ts
@@ -31,7 +31,7 @@ export const h264Vaapi: EncoderDescriptor = {
       return [
         ...common,
         '-vf',
-        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi}`,
+        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-2:extra_hw_frames=24${filters.tonemapVaapi}`,
         ...trailing,
       ];
     }
@@ -39,14 +39,14 @@ export const h264Vaapi: EncoderDescriptor = {
       return [
         ...common,
         '-vf',
-        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=vaapi:mode=write:reverse=1,format=vaapi`,
+        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-2:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=vaapi:mode=write:reverse=1,format=vaapi`,
         ...trailing,
       ];
     }
     return [
       ...common,
       '-vf',
-      `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:format=nv12`,
+      `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-2:format=nv12`,
       ...trailing,
     ];
   },

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-videotoolbox.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-videotoolbox.ts
@@ -1,6 +1,6 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { h264CodecString } from '../codec-strings';
-import { scaleMod16Height } from './helpers/scale-filter';
+import { scaleEvenHeight } from './helpers/scale-filter';
 
 /** Apple VideoToolbox H.264 encoder — Mac 2011+ and all Apple Silicon.
  *  Two paths: full Metal pipeline with `scale_vt` HDR tonemap (no CPU
@@ -51,7 +51,7 @@ export const h264Videotoolbox: EncoderDescriptor = {
     return [
       ...common,
       '-vf',
-      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleEvenHeight(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
       ...trailing,
     ];
   },

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
@@ -56,12 +56,12 @@ export function qsvScaleFilter8bit(input: EncoderInput): string {
   // (the 'fixed-size pool' rejection only fires when the pool changes
   // size mid-chain, which scale_vaapi avoids by reallocating).
   if (filters.tonemapVaapi) {
-    return `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`;
+    return `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-2:extra_hw_frames=24${filters.tonemapVaapi},hwmap=derive_device=qsv,format=qsv`;
   }
   if (filters.tonemapOpencl) {
-    return `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`;
+    return `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-2:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`;
   }
-  return `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`;
+  return `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-2:format=nv12:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`;
 }
 
 /** Build the `-vf` value for a 10-bit QSV encode (hevc_qsv main10,
@@ -85,7 +85,7 @@ export function qsvScaleFilter10bit(input: EncoderInput): string {
       : '';
     return `vpp_qsv=${cropOpts}w=${w}:h=${targetH}:format=p010le`;
   }
-  return `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:format=p010le:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`;
+  return `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-2:format=p010le:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`;
 }
 
 function parseCropStr(

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/scale-filter.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/scale-filter.ts
@@ -1,17 +1,15 @@
-/** Build the height argument for ffmpeg's software `scale` filter so the
- *  CPU pipeline produces mod-16 output — matching what HW encoders emit
- *  (`scale_vaapi=h=-16`) and what the master playlist advertises
- *  (`profileResolution` snaps to mod-16). `scale=W:-2` alone produces
- *  mod-2, which drifts on theatrical 4K masters (3840×2024 → 2024 mod-2
- *  vs 2016 mod-16); a `-2`/`-16` mismatch between the bitstream and the
- *  master `RESOLUTION` attribute can trip MSE on append and leaves the
- *  player guessing about the pixel grid.
+/** Build the height argument for ffmpeg's software `scale` filter, preserving
+ *  source aspect and rounding to the nearest even (mod-2) value. mod-2 is the
+ *  codec minimum for 4:2:0 and what `profileResolution` advertises in the
+ *  master `RESOLUTION`, so manifest and bitstream agree on a clean square-pixel
+ *  size — e.g. 1920x1080 (SAR 1:1), the standard streaming rung. Forcing mod-16
+ *  instead yields 1920x1088 with a 136:135 SAR (a non-standard aspect hack):
+ *  mod-16 is the encoder's internal macroblock/CTU grid, handled transparently
+ *  via the conformance window, never an output dimension. Matches the HW paths
+ *  (`scale_cuda=h=-2`, `scale_vt=h=-2`, `scale_vaapi=h=-2`).
  *
- *  Inline expression preserves source aspect via `ih*W/iw` and rounds
- *  the height down to the nearest multiple of 16. No `max(…)` guard:
- *  any `,` inside a filter option ends the current filter, and even an
- *  escaped one is fragile across ffmpeg builds — real video sources
- *  are always large enough that mod-16 is non-zero. */
-export function scaleMod16Height(targetWidth: number): string {
-  return `ceil(ih*${targetWidth}/iw/16)*16`;
+ *  Inline expression (no `max(…)` guard): a `,` inside a filter option ends the
+ *  filter, and real sources are always large enough that mod-2 is non-zero. */
+export function scaleEvenHeight(targetWidth: number): string {
+  return `ceil(ih*${targetWidth}/iw/2)*2`;
 }

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-cpu.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-cpu.ts
@@ -2,7 +2,7 @@ import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
 import { hdrColorArgs } from './helpers/hdr-variants';
 import { masterDisplayString, maxCllString } from './helpers/hdr-metadata';
-import { scaleMod16Height } from './helpers/scale-filter';
+import { scaleEvenHeight } from './helpers/scale-filter';
 
 /** Universal libx265 HEVC SDR fallback. Same thread cap as libx264 (4):
  *  first-segment latency stays bounded because the frame thread pool
@@ -32,7 +32,7 @@ export const hevcCpu: EncoderDescriptor = {
       '-maxrate',
       bitrate,
       '-vf',
-      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleEvenHeight(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
       '-g',
       String(target.gopSize),
       '-keyint_min',
@@ -84,7 +84,7 @@ export const hevcCpuHdr10: EncoderDescriptor = {
       '-maxrate',
       bitrate,
       '-vf',
-      `${filters.cpuCropPrefix}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p10le${filters.burnInFilter}`,
+      `${filters.cpuCropPrefix}scale=${w}:${scaleEvenHeight(w)}:flags=lanczos,format=yuv420p10le${filters.burnInFilter}`,
       '-g',
       String(target.gopSize),
       '-keyint_min',
@@ -133,7 +133,7 @@ export const hevcCpuHlg: EncoderDescriptor = {
       '-maxrate',
       bitrate,
       '-vf',
-      `${filters.cpuCropPrefix}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p10le${filters.burnInFilter}`,
+      `${filters.cpuCropPrefix}scale=${w}:${scaleEvenHeight(w)}:flags=lanczos,format=yuv420p10le${filters.burnInFilter}`,
       '-g',
       String(target.gopSize),
       '-keyint_min',

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-nvenc.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-nvenc.ts
@@ -2,7 +2,7 @@ import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
 import { hdrColorArgs, hlgFromHdr10 } from './helpers/hdr-variants';
 import { masterDisplayString, maxCllString } from './helpers/hdr-metadata';
-import { scaleMod16Height } from './helpers/scale-filter';
+import { scaleEvenHeight } from './helpers/scale-filter';
 
 /** NVIDIA NVENC HEVC SDR encoder — Maxwell 2nd gen (GM20x) and later.
  *  Tonemap path round-trips via CPU because mainline FFmpeg still has no
@@ -45,7 +45,7 @@ export const hevcNvenc: EncoderDescriptor = {
       return [
         ...common,
         '-vf',
-        `hwdownload,format=p010le,${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}`,
+        `hwdownload,format=p010le,${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleEvenHeight(w)}`,
         ...trailing,
       ];
     }

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-vaapi.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-vaapi.ts
@@ -41,7 +41,7 @@ export const hevcVaapi: EncoderDescriptor = {
       return [
         ...common,
         '-vf',
-        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapVaapi}`,
+        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-2:extra_hw_frames=24${filters.tonemapVaapi}`,
         ...trailing,
       ];
     }
@@ -49,14 +49,14 @@ export const hevcVaapi: EncoderDescriptor = {
       return [
         ...common,
         '-vf',
-        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=vaapi:mode=write:reverse=1,format=vaapi`,
+        `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-2:extra_hw_frames=24${filters.tonemapOpencl},hwmap=derive_device=vaapi:mode=write:reverse=1,format=vaapi`,
         ...trailing,
       ];
     }
     return [
       ...common,
       '-vf',
-      `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:format=nv12`,
+      `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-2:format=nv12`,
       ...trailing,
     ];
   },
@@ -89,7 +89,7 @@ export const hevcVaapiHdr10: EncoderDescriptor = {
       '-maxrate',
       bitrate,
       '-vf',
-      `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-16:format=p010le`,
+      `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-2:format=p010le`,
       '-g',
       String(target.gopSize),
       '-keyint_min',

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-videotoolbox.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-videotoolbox.ts
@@ -1,7 +1,7 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
 import { hdrColorArgs, hlgFromHdr10 } from './helpers/hdr-variants';
-import { scaleMod16Height } from './helpers/scale-filter';
+import { scaleEvenHeight } from './helpers/scale-filter';
 
 /** Apple VideoToolbox HEVC SDR encoder — Mac 2017+ (T2 / Apple Silicon).
  *  VT decode emits CPU-backed buffers, so the filter chain mirrors the
@@ -59,7 +59,7 @@ export const hevcVideotoolbox: EncoderDescriptor = {
     return [
       ...common,
       '-vf',
-      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
+      `${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleEvenHeight(w)}:flags=lanczos,format=yuv420p${filters.burnInFilter}`,
       ...trailing,
     ];
   },
@@ -95,7 +95,7 @@ export const hevcVideotoolboxHdr10: EncoderDescriptor = {
       '-maxrate',
       bitrate,
       '-vf',
-      `${filters.cpuCropPrefix}scale=${w}:${scaleMod16Height(w)}:flags=lanczos,format=p010le`,
+      `${filters.cpuCropPrefix}scale=${w}:${scaleEvenHeight(w)}:flags=lanczos,format=p010le`,
       '-g',
       String(target.gopSize),
       '-keyint_min',

--- a/backend/src/modules/streaming/transcoding/profiles.ts
+++ b/backend/src/modules/streaming/transcoding/profiles.ts
@@ -228,18 +228,15 @@ export function profileFitsSource(
   );
 }
 
-/** Compute output dimensions for a profile against a source. Width is
- *  capped at the source (no upscale); height follows the source aspect
- *  ratio, snapped UP to a multiple of 2 (HEVC/H.264 minimum encode
- *  granularity). We deliberately do NOT round to a multiple of 16:
- *  scale_vaapi treats `h=-16` as a divisibility hint, not a hard
- *  constraint, and Intel VPP/QSV happily emits source-height bitstreams
- *  (e.g. 1080 from a 1920×1080 source) regardless of what we declare.
- *  Rounding the master to 1088 while the bitstream stays at 1080 leaves
- *  Chrome MSE with a SourceBuffer dimensioned for 1088 receiving a 1080
- *  init.mp4 — appendBuffer is rejected as MEDIA_SOURCE_OPERATION_FAILED
- *  (Shaka 3014). Multiple-of-2 matches what every HEVC encoder we ship
- *  actually emits and keeps the master in sync. */
+/** Compute output dimensions for a profile against a source. Width is capped
+ *  at the source (no upscale); height follows the source aspect ratio, snapped
+ *  UP to a multiple of 2 — the 4:2:0 codec minimum and the standard streaming
+ *  rung (1920x1080, not 1088). Every encoder's scale filter rounds to mod-2 too
+ *  (`scaleEvenHeight`, `scale_*=h=-2`), so the master `RESOLUTION` matches the
+ *  bitstream's display size exactly. mod-16 is only the encoder's internal
+ *  macroblock/CTU grid (cropped back via the conformance window) — it is never
+ *  an output dimension; rounding the master to it would advertise 1088 with a
+ *  136:135 SAR that no encoder actually produces. */
 export function profileResolution(
   p: { maxWidth: number },
   sourceWidth: number,


### PR DESCRIPTION
Closes #344.

**Empirically settled** on this VAAPI box (measured, 3840x2160 -> 1920 wide): `scale_vaapi=h=-16` **and** the CPU `scaleMod16Height` emit **1088**; `scale_cuda`/`scale_vt` (`h=-2`) and `profileResolution` emit **1080**. So encoders disagreed with each other and with the manifest, and **both in-code comments were wrong** (`scale_vaapi=h=-16` emits 1088 not source-height; the manifest is mod-2 not mod-16).

What a real streaming server does is **mod-2 / standard rungs** (1080, not 1088) — mod-16 is the encoder's internal macroblock grid, cropped via the conformance window, never an output dimension (forcing it yields 1920x1088 with a 136:135 SAR hack). So: unify every scale to mod-2 (`scaleMod16Height`->`scaleEvenHeight`, `scale_*=h=-16`->`h=-2`). Verified the new filters emit clean **1920x1080 SAR 1:1** on both VAAPI and CPU.

**Advisory** (MSE takes dims from init.mp4, so it wasn't a playback break) but now the RESOLUTION is honest + square-pixel standard. **Changes encode height 1088->1080 on VAAPI/QSV/CPU**, so holding for your playback test: transcode a true **16:9 4K** title to a 1080p (or 540p/360p) rung and confirm clean playback on web/Shaka + Android (720p/480p rungs are already mod-16 so unchanged). `tsc` + full streaming suite (102) green.