### PR TITLE
fix(streaming): drop -master_display/-max_cll from hevc_qsv (NVENC-only opt)

### DIFF
--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-qsv.ts
@@ -1,7 +1,6 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
 import { hdrColorArgs, hlgFromHdr10 } from './helpers/hdr-variants';
-import { masterDisplayString, maxCllString } from './helpers/hdr-metadata';
 import { qsvScaleFilter8bit, qsvScaleFilter10bit } from './helpers/qsv-filters';
 
 /** Intel QSV HEVC Main 8-bit encoder — Skylake gen6 and above. Native
@@ -94,18 +93,10 @@ export const hevcQsvHdr10: EncoderDescriptor = {
       String(target.gopSize),
       '-force_key_frames',
       input.forceKeyframesExpr,
+      // hevc_qsv has no -master_display / -max_cll option (it's NVENC-private)
+      // and rejects them ("Unrecognized option") — QSV carries the source HDR10
+      // static metadata through from the input AVFrame instead. See #354.
       ...hdrColorArgs('HDR10'),
-      // Emit the probed source mastering-display / content-light SEI explicitly
-      // when available, rather than relying solely on AVFrame metadata
-      // propagation through the QSV filter chain. Absent → input-derived (#354).
-      ...(input.hdrMetadata
-        ? [
-            '-master_display',
-            masterDisplayString(input.hdrMetadata),
-            '-max_cll',
-            maxCllString(input.hdrMetadata),
-          ]
-        : []),
       '-tag:v',
       'hvc1',
     ];


### PR DESCRIPTION
**Hotfix for the Android playback stall** (found in the backend logs).

#354 added `-master_display`/`-max_cll` to `hevc_qsv`, but those are **NVENC-private** encoder options. `hevc_qsv` rejects them — `Unrecognized option 'master_display'`, exit 8 — so every HDR10 QSV transcode crashed and fell back to **CPU libx265**, which can't sustain realtime 4K HDR HEVC → buffering/stall on the client.

QSV propagates the source HDR10 static metadata from the input AVFrame, so the explicit args were unnecessary there. The CPU (`-x265-params master-display=`) and NVENC (`-master_display` is valid for nvenc) paths keep the #354 source metadata. Verified empirically: the real `hevc_qsv` HDR10 command exits **0** without the args (exited **8** with them); tsc + 102-test streaming suite green.