### PR TITLE
fix(media-detail): hide profiles + monitored badge below lg

### DIFF
--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -195,7 +195,7 @@
 
       <!-- Metadata row: rating, date, runtime, end time, library badge -->
       <div class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-3 text-base-content/60">
-        @if (!monitored()) { <span class="badge badge-ghost">{{ 'media_detail.unmonitored' | translate }}</span> }
+        @if (!monitored()) { <span class="hidden lg:inline-flex badge badge-ghost">{{ 'media_detail.unmonitored' | translate }}</span> }
         @if (rating()) {
           <span class="flex items-center gap-1 text-warning font-semibold">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
@@ -217,7 +217,7 @@
       <!-- Quality / language profiles + tags (library badge moved up next to
            end-time; genres moved to the media-info-extra panel). -->
       @if (qualityProfileName() || languageProfileName() || tags().length) {
-        <div class="flex flex-wrap gap-x-8 gap-y-2 mt-4">
+        <div class="hidden lg:flex flex-wrap gap-x-8 gap-y-2 mt-4">
           @if (qualityProfileName()) {
             <div class="flex flex-col">
               <span class="text-base-content/40 text-sm">{{ 'media_detail.quality_profile_label' | translate }}</span>


### PR DESCRIPTION
On the media-detail header, the **quality/language-profile row** and the **unmonitored badge** showed from `md` up. Now gated to `lg+` (`hidden lg:flex` / `hidden lg:inline-flex`) so they're hidden below `lg` (md/tablet shows the rest of the header without them). Shared `media-info-header`, so episode headers get the same treatment. `ng build` green.