### PR TITLE
fix(streaming): pin HDR original/remux to a single master variant

### DIFF
--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -37,14 +37,14 @@ function formatFrameRate(fps: number): string {
  *  init.mp4 fetch triggers a ffmpeg kill+respawn on the backend
  *  when the requested quality doesn't match the active session.
  *
- *  - `remux` / `original` collapse to the top SDR profile that fits
- *    the source resolution (no upscale). HDR ladder ignores these
- *    pseudo-labels because the source-resolution HDR rung is emitted
- *    via the separate `hdrPassThrough` block. Fitting is delegated
- *    to {@link profileFitsSource} (bucket on both axes) so anamorphic
- *    or scope crops (e.g. 1918×872) keep their 1080p top rung — a
- *    strict `maxWidth <= sourceWidth` check sat one or two pixels
- *    short and dropped the user back to 720p.
+ *  - `remux` / `original` collapse to the single top profile that fits
+ *    the source resolution (no upscale), in both the SDR and HDR
+ *    ladders — one variant so AVPlayer / ExoPlayer have no other rung
+ *    to ABR-switch to and stay locked at the source quality. Fitting is
+ *    delegated to {@link profileFitsSource} (bucket on both axes) so
+ *    anamorphic or scope crops (e.g. 1918×872) keep their 1080p top
+ *    rung — a strict `maxWidth <= sourceWidth` check sat one or two
+ *    pixels short and dropped the user back to 720p.
  *  - When `hdrSuffix` is true, an input `1080p` is matched against
  *    `1080p-hdr` (HDR ladder rungs carry the suffix); already
  *    `*-hdr` inputs pass through unchanged.
@@ -59,7 +59,6 @@ function applyQualityPin(
 ): TranscodeProfile[] {
   if (!onlyQuality) return ladder;
   if (onlyQuality === 'remux' || onlyQuality === 'original') {
-    if (hdrSuffix) return ladder;
     const top =
       ladder.find((p) => profileFitsSource(p, sourceWidth, sourceHeight)) ??
       ladder[0];


### PR DESCRIPTION
## Problem
On iOS, switching the player quality to **4K** on an HDR source made playback step through several qualities (480p-hdr → 720p → 1080p-hdr) instead of locking to the top rung. Backend logs showed iOS AVPlayer ABR-ramping through a multi-variant master, each switch forcing a ffmpeg kill+respawn.

## Cause
The top "4K" option on a remux-capable HDR source has id `original`. `applyQualityPin('original', hdrSuffix=true)` hit a special-case that returned the **full HDR ladder** (the SDR branch already collapsed `original`/`remux` to the single top rung). The HDR branch historically relied on a separate remux pass-through variant to carry the source rung as one variant; that pass-through was removed, leaving `original` on HDR with no single-variant pin → full multi-variant master → AVPlayer ABR ramp.

## Fix
Collapse `original`/`remux` to the top fitting rung in **both** the SDR and HDR ladders, so the master exposes a single variant and the player has no other rung to ABR-switch to.

Backend `tsc` type-clean. Test image dispatched (`:test-hdr-pin`) for on-device verification — **not merging until the 4K switch is confirmed fixed on iOS.**