### PR TITLE
fix(streaming): skip the seg-0 early-start companion for native players

### DIFF
--- a/backend/src/modules/streaming/dto/device-profile.dto.ts
+++ b/backend/src/modules/streaming/dto/device-profile.dto.ts
@@ -84,6 +84,19 @@ export class DeviceProfileDto {
   @IsOptional()
   supportsHlsSubtitles?: boolean;
 
+  /**
+   * Engine fetches the first VOD segment (seg-0) when it loads the playlist
+   * and then seeks to the resume point — Shaka (web) and the Cast receiver do
+   * this. The backend pre-spawns a short seg-0 "early-start" companion next to
+   * the main session so that probe lands instantly. Native engines (AVPlayer,
+   * ExoPlayer, AVPlay, webOS) seek straight to the target segment and never
+   * request seg-0, so they leave this false and the backend skips the
+   * companion — for them it is a wasted parallel transcode.
+   */
+  @IsBoolean()
+  @IsOptional()
+  probesSegZero?: boolean;
+
   @IsIn(['mobile', 'desktop'])
   @IsOptional()
   deviceType?: 'mobile' | 'desktop';

--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -66,6 +66,11 @@ export interface LiveSession {
    *  cues show in PiP / AirPlay / lock-screen. Web (Shaka) leaves this false
    *  and keeps fetching sidecar VTT. Sourced from the device profile. */
   supportsHlsSubtitles: boolean;
+  /** Engine fetches seg-0 on a load-then-seek (Shaka / Cast), so the seg-0
+   *  early-start companion is worth spawning. Native engines seek straight to
+   *  the resume segment and never request seg-0 — false skips the companion.
+   *  Sourced from the device profile. */
+  probesSegZero: boolean;
   videoVariant: CodecVariant | null;
   tonemapping: boolean;
   transcodeReasons: TranscodeReason[];
@@ -107,6 +112,7 @@ export interface CreateLiveSessionInput {
   deviceType?: 'mobile' | 'desktop';
   hdrLadder?: boolean;
   supportsHlsSubtitles?: boolean;
+  probesSegZero?: boolean;
   videoVariant?: CodecVariant | null;
   tonemapping?: boolean;
   transcodeReasons?: TranscodeReason[];
@@ -204,6 +210,11 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
       deviceType: input.deviceType ?? 'desktop',
       hdrLadder: input.hdrLadder ?? false,
       supportsHlsSubtitles: input.supportsHlsSubtitles ?? false,
+      // Default true: only a client that explicitly declares it seeks straight
+      // to the resume segment opts out of the seg-0 companion. Pre-flag clients
+      // keep the companion (a wasted seg-0 probe is harmless; a missing one
+      // makes a seg-0-probing engine restart from scratch).
+      probesSegZero: input.probesSegZero ?? true,
       videoVariant: input.videoVariant ?? null,
       tonemapping: input.tonemapping ?? false,
       transcodeReasons: input.transcodeReasons ?? [],

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -497,17 +497,21 @@ export class StreamingController {
       // (`1080p`), so translate to the HDR equivalent so prewarm
       // doesn't spawn a doomed SDR session that the player will
       // immediately kill and replace with the matching HDR rung.
+      const session = this.findRequestSession(req, mediaFileId);
       const targetQuality =
-        (this.findRequestSession(req, mediaFileId)?.hdrLadder ?? false) &&
-        !startQuality.endsWith('-hdr')
+        (session?.hdrLadder ?? false) && !startQuality.endsWith('-hdr')
           ? `${startQuality}-hdr`
           : startQuality;
       const startSegment = Math.max(0, secondsToSegmentIndex(effectiveStartAt));
 
-      // Spawn early en PARALLÈLE de main (fire-and-forget). hlsSegment
-      // routera vers cette session pour seg-0 via isEarlyProbe pendant
-      // que main encode forward depuis seg-K.
-      if (startSegment > 0) {
+      // The seg-0 early-start companion runs in parallel with main and serves
+      // seg-0 instantly while main encodes forward from seg-K. It only earns
+      // its keep for engines that fetch seg-0 on a load-then-seek (Shaka /
+      // Cast). Native engines (AVPlayer, ExoPlayer, AVPlay, webOS) seek
+      // straight to seg-K and never request seg-0, so the parallel seg-0
+      // transcode would be pure wasted GPU — skip it. Capability rides the
+      // device profile and is stored on the session.
+      if (startSegment > 0 && (session?.probesSegZero ?? true)) {
         void this.transcodingService
           .getOrCreateEarlySession(
             mediaFileId,
@@ -942,6 +946,7 @@ export class StreamingController {
       deviceType,
       hdrLadder: useHdrLadder,
       supportsHlsSubtitles: !!deviceProfile.supportsHlsSubtitles,
+      probesSegZero: deviceProfile.probesSegZero,
       videoVariant,
       tonemapping: response.tonemapping,
       transcodeReasons: response.transcodeReasons,

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -37,14 +37,14 @@ function formatFrameRate(fps: number): string {
  *  init.mp4 fetch triggers a ffmpeg kill+respawn on the backend
  *  when the requested quality doesn't match the active session.
  *
- *  - `remux` / `original` collapse to the top SDR profile that fits
- *    the source resolution (no upscale). HDR ladder ignores these
- *    pseudo-labels because the source-resolution HDR rung is emitted
- *    via the separate `hdrPassThrough` block. Fitting is delegated
- *    to {@link profileFitsSource} (bucket on both axes) so anamorphic
- *    or scope crops (e.g. 1918×872) keep their 1080p top rung — a
- *    strict `maxWidth <= sourceWidth` check sat one or two pixels
- *    short and dropped the user back to 720p.
+ *  - `remux` / `original` collapse to the single top profile that fits
+ *    the source resolution (no upscale), in both the SDR and HDR
+ *    ladders — one variant so AVPlayer / ExoPlayer have no other rung
+ *    to ABR-switch to and stay locked at the source quality. Fitting is
+ *    delegated to {@link profileFitsSource} (bucket on both axes) so
+ *    anamorphic or scope crops (e.g. 1918×872) keep their 1080p top
+ *    rung — a strict `maxWidth <= sourceWidth` check sat one or two
+ *    pixels short and dropped the user back to 720p.
  *  - When `hdrSuffix` is true, an input `1080p` is matched against
  *    `1080p-hdr` (HDR ladder rungs carry the suffix); already
  *    `*-hdr` inputs pass through unchanged.
@@ -59,7 +59,6 @@ function applyQualityPin(
 ): TranscodeProfile[] {
   if (!onlyQuality) return ladder;
   if (onlyQuality === 'remux' || onlyQuality === 'original') {
-    if (hdrSuffix) return ladder;
     const top =
       ladder.find((p) => profileFitsSource(p, sourceWidth, sourceHeight)) ??
       ladder[0];

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { Capacitor, registerPlugin } from '@capacitor/core';
 import { PlayerSettingsService } from './player-settings.service';
 import { DeviceService } from './device.service';
+import { ServerConfigService } from './server-config.service';
 import { getDeviceName } from '../utils/device-info';
 
 interface HdrPlugin {
@@ -87,6 +88,14 @@ export interface DeviceProfile {
    *  VTT. True for phone/desktop (iOS, Android, web/Shaka); false for TVs,
    *  whose AVPlay/webOS cue APIs are limited so they keep a DOM overlay. */
   supportsHlsSubtitles?: boolean;
+
+  /** Engine fetches seg-0 when it loads the playlist and then seeks to the
+   *  resume point — true for the web/Shaka path (and the Cast receiver). The
+   *  backend uses it to decide whether to pre-spawn the seg-0 early-start
+   *  companion. Native engines (AVPlayer/ExoPlayer/AVPlay/webOS) seek straight
+   *  to the target segment and never request seg-0, so they send false and the
+   *  backend skips the companion (a wasted parallel transcode for them). */
+  probesSegZero?: boolean;
 }
 
 /** True when `localStorage['fliks.useTs']` is set to a truthy value.
@@ -101,6 +110,7 @@ function readUseTsOverride(): boolean {
 export class BrowserDeviceProfileService {
   private readonly playerSettings = inject(PlayerSettingsService);
   private readonly device = inject(DeviceService);
+  private readonly serverConfig = inject(ServerConfigService);
   private cachedProfile: DeviceProfile | null = null;
   private nativeHdr: boolean | null = null;
   private nativeAudio: { codecs: string[]; maxChannels: number } | null = null;
@@ -329,6 +339,11 @@ export class BrowserDeviceProfileService {
       // they have no PiP and their AVPlay/webOS cue APIs are limited, so the
       // Tizen/webOS engines keep their DOM overlay (fed by sidecar VTT).
       supportsHlsSubtitles: !isTv,
+      // Only the web/Shaka path probes seg-0 on a load-then-seek; that is
+      // exactly the `!isNative` engine branch (Capacitor mobile + every TV go
+      // through native players that seek straight to the resume segment). The
+      // Cast receiver sets this true in its own profile.
+      probesSegZero: !this.serverConfig.isNative,
     };
   }
 

--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -164,6 +164,9 @@ export class CastPlayerService {
       // and its backend plumbing are kept as dead code so we can flip
       // back later without re-doing the plumbing.
       useTs: false,
+      // The Cast receiver runs Shaka, which fetches seg-0 on a load-then-seek,
+      // so keep the backend's seg-0 early-start companion for resumes.
+      probesSegZero: true,
     };
   }
 


### PR DESCRIPTION
**Stacked on #377** (base = its branch; diff shows only the seg-0 change. Merge #377 first, then this — GitHub will retarget the base to `main`).

## Problem
On every resume / quality switch, the backend spawns a parallel **seg-0 early-start companion** (`FFmpeg start [..-early] .. ss=0`) alongside the main session. It exists to serve **Shaka's** seg-0 VOD probe on a load-then-seek. But native engines (AVPlayer/ExoPlayer/AVPlay/webOS) seek straight to the resume segment and **never fetch seg-0** — logs confirm iOS requests only `init_0.mp4`, never `seg-0000.m4s`. So on native the companion is a full **second 4K HDR HEVC encode from frame 0** that nothing consumes — double GPU load per switch.

## Fix
New `probesSegZero` capability on the device profile:
- **true** — web/Shaka (`!serverConfig.isNative`, the exact engine-selection signal) and the Cast receiver.
- **false** — native engines.

Stored on the `LiveSession`; the prewarm gates the companion spawn on it (`startSegment > 0 && session.probesSegZero`). Default true when absent, so pre-flag clients keep current behavior (a wasted seg-0 probe is harmless; a missing one would make a seg-0-probing engine restart from scratch).

Result: native resumes / quality switches run a single transcode. Web + Cast unchanged.

Backend `tsc` + client `ng build` both green. Test image `:test-player-fixes` (this branch, includes #377) dispatched for on-device verification — **not merging until confirmed.**