### PR TITLE
fix(ios-player): re-emit tracks after media selection group populates

### DIFF
--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -681,6 +681,14 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             switch item.status {
             case .readyToPlay:
                 self?.emitTracksChanged()
+                // AVPlayer often reports `.readyToPlay` before the
+                // alternate-audio rendition playlists have been fetched, so
+                // the `.audible` selection group is still empty. Without
+                // this re-emit the client's `audioTracksChanged` upgrade
+                // guard rejects the short list, leaves the `si-*` fallback
+                // in place, and every language switch falls back to a full
+                // backend reload (re-encode). See issue #378.
+                self?.ensureMediaSelectionPopulated()
             case .failed:
                 let nsError = item.error as NSError?
                 let msg = nsError?.localizedDescription ?? "Playback failed"
@@ -867,6 +875,28 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         """
         DispatchQueue.main.async { [weak self] in
             self?.bridge?.webView?.evaluateJavaScript(js)
+        }
+    }
+
+    private func ensureMediaSelectionPopulated(retries: Int = 8) {
+        guard let item = player?.currentItem else { return }
+        let asset = item.asset
+        let key = "availableMediaCharacteristicsWithMediaSelectionOptions"
+        asset.loadValuesAsynchronously(forKeys: [key]) { [weak self] in
+            DispatchQueue.main.async {
+                guard let self = self, self.player?.currentItem === item else { return }
+                let audible = asset.mediaSelectionGroup(forMediaCharacteristic: .audible)?.options.count ?? 0
+                let legible = asset.mediaSelectionGroup(forMediaCharacteristic: .legible)?.options.count ?? 0
+                if audible > 0 || legible > 0 {
+                    self.emitTracksChanged()
+                    return
+                }
+                if retries > 0 {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+                        self?.ensureMediaSelectionPopulated(retries: retries - 1)
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Loads `availableMediaCharacteristicsWithMediaSelectionOptions` async on `.readyToPlay` and re-emits `nativePlayerTracksChanged` once the audible/legible group exposes options (bounded retry, ~2 s window).
- Lets the client picker upgrade from the `si-*` streamInfo fallback to engine `audio-*` tracks, so iOS audio-language switches stay in-engine — no `playback-info`, no ffmpeg restart, no video re-encode.

Fixes #378.

## Test plan
- [ ] iOS app, transcoded multi-audio 4K HDR HEVC file → open audio menu after start: language options listed.
- [ ] Switch audio language: backend logs show no new `FFmpeg start` / `audioDecision`; playback does not rebuffer.
- [ ] Selected language persists and is highlighted in the menu.