### PR TITLE
refactor(streaming): centralize resume anchoring + tag spawn origin

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -464,6 +464,39 @@ export class StreamingController {
   }
 
   /**
+   * Highest segment the main session legitimately owns: the larger of its
+   * current start and the live playhead. The playhead survives an in-memory
+   * session loss (recovery re-seeds it), so a probe arriving after a restart
+   * still floors at the resume point instead of segment 0.
+   */
+  private resumeFloor(
+    live: { position: number } | null | undefined,
+    existing: { startSegment?: number | null } | null | undefined,
+  ): number {
+    return Math.max(
+      existing?.startSegment ?? 0,
+      live ? secondsToSegmentIndex(live.position) : 0,
+    );
+  }
+
+  /**
+   * Segment a freshly-spawned main should start at for a request. An init
+   * segment is position-independent, so it anchors at the resume floor (the
+   * session playhead) rather than its nominal segment 0; a real segment read
+   * anchors at the requested segment. Single source of truth for resume
+   * anchoring across the spawn paths that fire when the prewarm didn't pre-warm
+   * the main — keeps them from diverging (the "fix one, miss the others" trap).
+   */
+  private anchorSegment(
+    live: { position: number } | null | undefined,
+    existing: { startSegment?: number | null } | null | undefined,
+    isInit: boolean,
+    segIndex: number,
+  ): number {
+    return isInit ? this.resumeFloor(live, existing) : segIndex;
+  }
+
+  /**
    * Pre-spawn ffmpeg for the first segment the player will request. Handles
    * both fresh play (startAt=0) and resume (startAt>0 from URL or from the
    * user's saved playbackState). Fire-and-forget — the session is reused
@@ -488,6 +521,7 @@ export class StreamingController {
         resolved.mediaFile.episodeId ?? undefined,
       );
       const ctx = this.buildSessionContext(req, resolved, mediaFileId);
+      ctx.spawnReason = 'prewarm';
       const profileHash = this.transcodingService.computeProfileHashForCtx(ctx);
       const existing = this.transcodingService.getExistingSession(
         mediaFileId,
@@ -1464,6 +1498,7 @@ export class StreamingController {
         req.user as User,
       );
       const ctx = this.buildSessionContext(req, resolved, mediaFileId);
+      ctx.spawnReason = 'seg-race';
       const live = this.findRequestSession(req, mediaFileId);
       const deviceType = live?.deviceType ?? 'desktop';
       const sourceW =
@@ -1487,13 +1522,10 @@ export class StreamingController {
         !baseQuality.endsWith('-hdr')
           ? `${baseQuality}-hdr`
           : baseQuality;
-      // Anchor a freshly-spawned main at the session's known playhead
-      // (`live.position`, seeded by playback-info from the resume offset), not
-      // segment 0 — so a resume starts ffmpeg at the resume segment directly
-      // rather than at 0 followed by an immediate seek-restart forward.
-      const startSeg = live
-        ? Math.max(0, secondsToSegmentIndex(live.position))
-        : 0;
+      // No existing main and we're spawning to serve a request: anchor at the
+      // resume floor (the session playhead), not segment 0, so a resume starts
+      // ffmpeg at the resume segment directly. See {@link anchorSegment}.
+      const startSeg = this.anchorSegment(live, null, true, 0);
       videoSession = await this.transcodingService.getOrCreateSession(
         mediaFileId,
         quality,
@@ -1589,6 +1621,7 @@ export class StreamingController {
         const startAtSec = parseInt(startAtRaw, 10);
         const startSegment = secondsToSegmentIndex(startAtSec);
         const ctx = this.buildSessionContext(req, resolved, mediaFileId);
+        ctx.spawnReason = 'variant-prespawn';
         if (quality === 'remux') {
           const copyAudio =
             firstQueryString(req.query, 'copyAudio') !== 'false';
@@ -1783,6 +1816,7 @@ export class StreamingController {
     );
 
     const ctx = this.buildSessionContext(req, resolved, mediaFileId);
+    ctx.spawnReason = 'seg-request';
 
     // Early probe routing: the seg-0/seg-1 init probe a player fires on
     // resume must be served by the bounded early companion, never spawn or
@@ -1795,10 +1829,7 @@ export class StreamingController {
     // genuine seek/forward read the main owns. 10 s timeout safety net falls
     // through to the slow path rather than blocking on a 60 s waitForSegment.
     const isInit = segment.startsWith('init');
-    const resumeFloor = Math.max(
-      existing?.startSegment ?? 0,
-      live ? secondsToSegmentIndex(live.position) : 0,
-    );
+    const resumeFloor = this.resumeFloor(live, existing);
     // An init segment is position-independent, so it never anchors the main —
     // otherwise an init request landing right after a restart (before recovery
     // re-seeds the live playhead) would spawn a fresh main at segment 0. A
@@ -1861,11 +1892,7 @@ export class StreamingController {
     // For remux sessions, copy audio only when the source codec is compatible
     // (captured at playback-info); otherwise transcode audio to AAC.
     const copyAudio = live?.canCopyAudio ?? false;
-    // An init segment is position-independent, so anchor a freshly-spawned main
-    // at the resume floor (the session playhead) rather than init's nominal
-    // segment 0 — otherwise a resume's first request (the init) spins main up at
-    // 0 and immediately seek-restarts forward to the resume segment.
-    const anchorSeg = isInit ? resumeFloor : segIndex;
+    const anchorSeg = this.anchorSegment(live, existing, isInit, segIndex);
     const session =
       quality === 'remux'
         ? await this.transcodingService.getOrCreateRemuxSession(

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -438,6 +438,32 @@ export class StreamingController {
   }
 
   /**
+   * Effective resume offset in seconds. The explicit `startAt` query wins when
+   * supplied (including `0` = restart from the top, which must override a saved
+   * position); otherwise fall back to the saved playback position when it's a
+   * meaningful resume (>10 s in, not finished), else 0. Shared by the prewarm
+   * and the LiveSession `position` seed so the session's playhead matches where
+   * ffmpeg actually starts — otherwise a resume that relies on the saved
+   * position leaves `position` at 0, and a fresh main spawned off it anchors at
+   * segment 0 instead of the resume segment.
+   */
+  private async resolveEffectiveStartAt(
+    startAt: number | undefined,
+    userId: number | undefined,
+    mediaId: number | undefined,
+    episodeId: number | undefined,
+  ): Promise<number> {
+    if (startAt !== undefined) return startAt;
+    if (userId != null && mediaId != null) {
+      const state = await this.playbackService.getState(userId, mediaId, episodeId);
+      if (state && !state.completed && state.positionSeconds > 10) {
+        return state.positionSeconds;
+      }
+    }
+    return 0;
+  }
+
+  /**
    * Pre-spawn ffmpeg for the first segment the player will request. Handles
    * both fresh play (startAt=0) and resume (startAt>0 from URL or from the
    * user's saved playbackState). Fire-and-forget — the session is reused
@@ -455,25 +481,12 @@ export class StreamingController {
   ): Promise<void> {
     if (!startQuality || startQuality === 'auto') return;
     try {
-      // Auto-resume only when the caller did NOT supply a startAt query
-      // param (fresh open). An explicit `startAt=0` means the user clicked
-      // "restart from beginning" and must override the saved position.
-      let effectiveStartAt = startAt;
-      if (effectiveStartAt === undefined) {
-        const userId = req.user?.id;
-        const mediaId = resolved.mediaFile.mediaId;
-        if (userId && mediaId) {
-          const state = await this.playbackService.getState(
-            userId,
-            mediaId,
-            resolved.mediaFile.episodeId ?? undefined,
-          );
-          if (state && !state.completed && state.positionSeconds > 10) {
-            effectiveStartAt = state.positionSeconds;
-          }
-        }
-        effectiveStartAt = effectiveStartAt ?? 0;
-      }
+      const effectiveStartAt = await this.resolveEffectiveStartAt(
+        startAt,
+        req.user?.id,
+        resolved.mediaFile.mediaId,
+        resolved.mediaFile.episodeId ?? undefined,
+      );
       const ctx = this.buildSessionContext(req, resolved, mediaFileId);
       const profileHash = this.transcodingService.computeProfileHashForCtx(ctx);
       const existing = this.transcodingService.getExistingSession(
@@ -923,6 +936,17 @@ export class StreamingController {
           : 'transcode';
     const deviceLabel: string | null = req.get('user-agent') ?? null;
 
+    // Seed the session playhead with the effective resume offset, not the raw
+    // `startAt`: a client that resumes by relying on the saved position (no
+    // `startAt` query) would otherwise leave `position` at 0, and a fresh main
+    // spawned off `position` (segment-handler race) would anchor at segment 0.
+    const resumePosition = await this.resolveEffectiveStartAt(
+      startAt,
+      userId,
+      resolved.mediaFile.mediaId,
+      episodeId ?? undefined,
+    );
+
     // The LiveSession owns every per-playback setting: future HLS
     // requests resolve it via `?sid=...` and read settings straight off
     // this entry — no shared per-file mutable state to clobber.
@@ -937,7 +961,7 @@ export class StreamingController {
       quality: typeof startQuality === 'string' ? startQuality : null,
       kind,
       deviceLabel,
-      position: startAt ?? 0,
+      position: resumePosition,
       useTs: effectiveUseTs,
       audioPlan: response.audioPlan,
       audioStreamIndex: audioStreamIndex ?? null,
@@ -1463,11 +1487,18 @@ export class StreamingController {
         !baseQuality.endsWith('-hdr')
           ? `${baseQuality}-hdr`
           : baseQuality;
+      // Anchor a freshly-spawned main at the session's known playhead
+      // (`live.position`, seeded by playback-info from the resume offset), not
+      // segment 0 — so a resume starts ffmpeg at the resume segment directly
+      // rather than at 0 followed by an immediate seek-restart forward.
+      const startSeg = live
+        ? Math.max(0, secondsToSegmentIndex(live.position))
+        : 0;
       videoSession = await this.transcodingService.getOrCreateSession(
         mediaFileId,
         quality,
         resolved.absolutePath,
-        0,
+        startSeg,
         ctx,
         /* skipVerify */ true,
       );
@@ -1776,6 +1807,11 @@ export class StreamingController {
     // owns.
     const isEarlyProbe =
       quality !== 'remux' &&
+      // Only engines that fetch seg-0 on a load-then-seek (Shaka / Cast) use
+      // the early companion. Native players seek straight to the main's
+      // segment and only fetch the position-independent init, so routing that
+      // init here would spawn a companion they never read — keep them on main.
+      (live?.probesSegZero ?? true) &&
       (isInit ||
         (resumeFloor > EARLY_PROBE_SEGMENTS && segIndex < EARLY_PROBE_SEGMENTS));
     if (isEarlyProbe) {
@@ -1825,20 +1861,25 @@ export class StreamingController {
     // For remux sessions, copy audio only when the source codec is compatible
     // (captured at playback-info); otherwise transcode audio to AAC.
     const copyAudio = live?.canCopyAudio ?? false;
+    // An init segment is position-independent, so anchor a freshly-spawned main
+    // at the resume floor (the session playhead) rather than init's nominal
+    // segment 0 — otherwise a resume's first request (the init) spins main up at
+    // 0 and immediately seek-restarts forward to the resume segment.
+    const anchorSeg = isInit ? resumeFloor : segIndex;
     const session =
       quality === 'remux'
         ? await this.transcodingService.getOrCreateRemuxSession(
             mediaFileId,
             resolved.absolutePath,
             copyAudio,
-            segIndex,
+            anchorSeg,
             ctx,
           )
         : await this.transcodingService.getOrCreateSession(
             mediaFileId,
             quality,
             resolved.absolutePath,
-            segIndex,
+            anchorSeg,
             ctx,
           );
 

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -861,6 +861,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         startSegment: 0,
         segExt: ctx?.useTs ? '.ts' : '.m4s',
         segSubDir: usesVarStreamMap ? '0' : undefined,
+        reason: ctx?.spawnReason,
         extra: { actualHwAccel: this.detectedHwAccel },
       });
       session.baseProfileHash = baseHash;
@@ -969,6 +970,8 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     segExt?: string;
     /** Subdirectory for first segment check (e.g. '0' for var_stream_map) */
     segSubDir?: string;
+    /** Diagnostic origin label, surfaced in the "FFmpeg start" log. */
+    reason?: string;
     extra?: Partial<TranscodeSession>;
   }): TranscodeSession {
     const {
@@ -980,6 +983,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       startSegment,
       segExt = '.m4s',
       segSubDir,
+      reason,
       extra,
     } = opts;
     const { resolve: readyResolve, promise: readyPromise } =
@@ -1015,7 +1019,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
           ? 'qsv'
           : hwaccel;
     this.log.log(
-      `FFmpeg start [${id}] ${quality} dec=${decoder} enc=${encoder} ss=${ss} start_number=${startNumber}`,
+      `FFmpeg start [${id}] ${quality} dec=${decoder} enc=${encoder} ss=${ss} start_number=${startNumber}${reason ? ` reason=${reason}` : ''}`,
     );
     this.log.debug(`FFmpeg argv [${id}]: ffmpeg ${args.join(' ')}`);
 
@@ -1163,6 +1167,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       startSegment,
       segExt: ctx?.useTs ? '.ts' : '.m4s',
       segSubDir: usesVarStreamMap ? '0' : undefined,
+      reason: ctx?.spawnReason,
       extra: {
         actualHwAccel: hwAccel,
       },
@@ -1329,6 +1334,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       args,
       sessionDir,
       startSegment: requestedSegment,
+      reason: ctx?.spawnReason,
       extra: { remux: true },
     });
     session.baseProfileHash = remuxBaseHash;
@@ -1436,6 +1442,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       sessionDir,
       startSegment: requestedSegment,
       segExt: ctx?.useTs ? '.ts' : undefined,
+      reason: ctx?.spawnReason,
       extra: { isAudioOnly: true },
     });
     session.baseProfileHash = audioBaseHash;

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -96,6 +96,11 @@ export interface SessionContext {
   audioStreams?: AudioStreamMeta[];
   /** Client device category — selects the per-device bitrate ladder. */
   deviceType?: DeviceType;
+  /** Diagnostic label for the request path that triggered the spawn
+   *  (`prewarm`, `seg-request`, `seg-race`, `variant-prespawn`). Echoed in the
+   *  "FFmpeg start" log so a mis-anchored session can be traced to its origin
+   *  without ad-hoc debug logging. Purely observational — never affects output. */
+  spawnReason?: string;
   /**
    * FFmpeg encoder preset ('veryfast' | 'faster' | 'fast' | 'medium' | 'slow').
    * Applied to h264_qsv and libx264; VAAPI/NVENC ignore it (different naming).


### PR DESCRIPTION
**Stacked on #381** (base = its branch; merge #381 first). The de-trap follow-up requested after the native-resume debugging.

## Why
The "where does a fresh main start" rule was computed inline in **three** spawn paths, each slightly different (`live.position` / `max(existing,live)` / `isInit?floor:segIndex`). That fragmentation is exactly why the seg-0 anchoring bug hid in one path while the others were fixed — fix one, miss the rest.

## What
- **`resumeFloor()` + `anchorSegment()` helpers** — single source of truth for resume anchoring (init = position-independent → resume floor; real segment → requested index). The segment handlers and the audio-rendition race spawn now call them.
- **`spawnReason` on `SessionContext`** → echoed in the `FFmpeg start` log: `… reason=(prewarm|seg-request|seg-race|variant-prespawn)`. Next mis-anchored spawn is one grep away, no debug logs needed.

No behaviour change — pure extraction + an observational log field. Backend `tsc` green.