### PR TITLE
fix(streaming): unblock AV1 seeks and surface ffmpeg errors in logs

### DIFF
--- a/backend/src/modules/streaming/thumbnail-extractors/sw.extractor.ts
+++ b/backend/src/modules/streaming/thumbnail-extractors/sw.extractor.ts
@@ -38,12 +38,14 @@ export class SwExtractor implements ExtractorBackend {
       '-noaccurate_seek',
       '-ss',
       String(seekSeconds),
-      // Minimise per-process startup cost: we're spawning one ffmpeg per
-      // thumbnail and don't need a full stream probe.
+      // `-analyzeduration 0` keeps per-thumbnail startup minimal; the 5 MB
+      // probe is a ceiling read only when the demuxer needs it. AV1-in-Matroska
+      // requires it so the decoder is set up for the `-ss` seek — under ~3 MB
+      // the post-seek decode yields no frame and the thumbnail comes out blank.
       '-analyzeduration',
       '0',
       '-probesize',
-      '200000',
+      '5000000',
       '-i',
       inputPath,
       '-frames:v',

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -28,6 +28,22 @@ import {
 import { resolveTonemapPath } from './tonemap-path';
 import { normaliseSourceCodec } from './codec/normalise';
 
+/**
+ * Probe ceiling (bytes) for the trusted-streamInfo fast path. Paired with
+ * `-analyzeduration 0` so it stays a read *ceiling*, not a target — FFmpeg
+ * stops as soon as it has stream parameters, keeping cold-start open time at
+ * the same ~70 ms regardless of the value.
+ *
+ * 5 MB rather than a few hundred KB because AV1-in-Matroska needs the demuxer
+ * to ingest enough of the bitstream up front to set the decoder up for a
+ * mid-file input seek. Under ~3 MB the demuxer delivers no decodable sequence
+ * after `-ss`, the decoder emits zero frames, and the HLS muxer writes no
+ * segments — every resume/scrub on such a source stalls. The larger ceiling
+ * is read only when the demuxer actually needs it, so it carries no measurable
+ * startup cost on the common (small-header) case.
+ */
+const TRUSTED_PROBE_SIZE = '5000000';
+
 export interface BuildFfmpegArgsOptions {
   inputPath: string;
   profile: TranscodeProfile;
@@ -218,8 +234,8 @@ export function buildFfmpegArgs(
   // headers and stops. Otherwise fall back to a balanced 1s/1MB budget.
   // Default FFmpeg is 5s/5MB which burns 3-5s on cold start of large 4K MKVs.
   if (trustedStreamInfo) {
-    log.debug?.('Probe: using cached streamInfo (0s / 200KB scan)');
-    args.push('-analyzeduration', '0', '-probesize', '200000');
+    log.debug?.('Probe: using cached streamInfo (0s / 5MB ceiling)');
+    args.push('-analyzeduration', '0', '-probesize', TRUSTED_PROBE_SIZE);
   } else {
     // Keep the no-cache fallback at LOG — cold-start scans are expected
     // only on rescan / import races, so each one is worth surfacing.
@@ -725,9 +741,9 @@ export function buildAudioOnlyFfmpegArgs(
   const args = ['-hide_banner', '-loglevel', 'warning'];
   if (trustedStreamInfo) {
     log.debug?.(
-      'Probe [audio-only]: using cached streamInfo (0s / 200KB scan)',
+      'Probe [audio-only]: using cached streamInfo (0s / 5MB ceiling)',
     );
-    args.push('-analyzeduration', '0', '-probesize', '200000');
+    args.push('-analyzeduration', '0', '-probesize', TRUSTED_PROBE_SIZE);
   } else {
     log.log(
       'Probe [audio-only]: no cached streamInfo — running full FFmpeg scan (1s / 1MB)',
@@ -808,8 +824,8 @@ export function buildRemuxArgs(
 
   const args = ['-hide_banner', '-loglevel', 'warning'];
   if (trustedStreamInfo) {
-    log?.log('Probe [remux]: using cached streamInfo (0s / 200KB scan)');
-    args.push('-analyzeduration', '0', '-probesize', '200000');
+    log?.log('Probe [remux]: using cached streamInfo (0s / 5MB ceiling)');
+    args.push('-analyzeduration', '0', '-probesize', TRUSTED_PROBE_SIZE);
   } else {
     log?.log(
       'Probe [remux]: no cached streamInfo — running full FFmpeg scan (1s / 1MB)',

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -952,7 +952,17 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         }
       }, 500);
 
-      timeout = setTimeout(() => finish(null), timeoutMs);
+      timeout = setTimeout(() => {
+        // ffmpeg launched but the segment never landed in time. Don't fail the
+        // request silently — surface the stall (slow/unsupported decode, e.g.
+        // CPU AV1, or a stuck input) with ffmpeg's state + last stderr so a
+        // seek that "does nothing" is traceable in prod.
+        const running = session.process.exitCode === null;
+        this.log.warn(
+          `[${session.id}] segment ${name} not produced within ${timeoutMs}ms — ffmpeg ${running ? 'still running' : `exited ${session.process.exitCode}`}${session.stderr ? `\nlast stderr:\n${session.stderr.slice(-1500)}` : ''}`,
+        );
+        finish(null);
+      }, timeoutMs);
     });
   }
 
@@ -1076,13 +1086,14 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         resolved = true;
         readyResolve();
       }
-      if (code && code !== 0 && code !== 255) {
+      if (!session.intentionallyKilled && code !== 0) {
+        // Any exit we didn't ask for is a real failure — decode error, corrupt
+        // or unsupported input, OOM kill, etc. Surface it loudly with the
+        // ffmpeg tail so it's diagnosable in prod (where there's no terminal).
+        // `code !== 0` also catches a null code (process killed by a signal we
+        // didn't issue); our own kills set `intentionallyKilled` and skip this.
         this.log.error(
-          `FFmpeg [${id}] exited ${code}:\n${stderr.slice(-2000)}`,
-        );
-      } else if (!firstSegProduced && !session.intentionallyKilled) {
-        this.log.warn(
-          `FFmpeg [${id}] exited code=${code} WITHOUT producing first segment ${firstSegName}\nstderr:\n${stderr.slice(-2000)}`,
+          `FFmpeg [${id}] exited code=${code}${firstSegProduced ? '' : ` before producing ${firstSegName}`}:\n${stderr.slice(-2000)}`,
         );
       }
     });


### PR DESCRIPTION
## Why

A film failed to play on **seek** in prod — an AV1 1080p 10-bit source. It
looked like "ffmpeg never launches", with nothing in the logs to tell a decode
error from a corrupt file from a slow decode. Investigation found two distinct
problems: the logs went silent on the failure, **and** the seek genuinely
produced no segments.

## What

### 1. Unblock the seek (the actual bug)

The trusted-streamInfo fast path pinned the ffmpeg probe to 200 KB
(`-analyzeduration 0 -probesize 200000`). On AV1-in-Matroska sources the demuxer
then ingests too little of the bitstream to set the decoder up for a mid-file
input seek: after `-ss` it delivers no decodable sequence, the decoder emits
zero frames, and the HLS muxer writes nothing — every resume/scrub stalls. The
software thumbnail extractor shared the pattern, leaving seek-preview frames
blank on the same sources.

Raise the ceiling to 5 MB. Paired with `-analyzeduration 0` it stays a read
*ceiling*, not a target, so the demuxer reads it only when it needs the extra
bitstream. Measured cold-start open time is unchanged (~70 ms at both 200 KB and
5 MB). Reproduced deterministically: probe < 3 MB -> 0 frames decoded after the
seek; >= 3 MB -> seek decodes and segments are written.

### 2. Surface the failure in the logs

- Log **every ffmpeg exit we didn't initiate** at `error` with the stderr tail -
  gated on `intentionallyKilled` instead of `code !== 255`, so 255 / signal-kill
  / OOM are no longer swallowed (our own seek/quality/GC kills still skip).
- Log a **warning on segment-wait timeout**: whether ffmpeg is still running or
  exited, plus the last stderr - so a seek that "does nothing" is traceable.

## Notes

Backend `tsc` clean. The logging change is behaviour-neutral on the transcode
itself; the probe change only widens a read ceiling.
