### PR TITLE
ci: move actions off the deprecated node 20 runtime

### DIFF
--- a/.github/workflows/appstore-publish.yml
+++ b/.github/workflows/appstore-publish.yml
@@ -38,13 +38,13 @@ jobs:
         working-directory: client
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Full history → `git rev-list --count HEAD` gives a real
           # commit count for the build number.
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -13,7 +13,7 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v6

--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -46,8 +46,8 @@ jobs:
       DB_NAME: fliks
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/deploy-cast-receiver.yml
+++ b/.github/workflows/deploy-cast-receiver.yml
@@ -33,7 +33,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,7 +61,7 @@ jobs:
         target: ${{ fromJSON(needs.setup.outputs.platforms) }}
     runs-on: ${{ matrix.target.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Sanitize platform for cache key
         id: sanitize

--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -18,7 +18,7 @@ jobs:
   build-dmg:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # ── Resolve version + patch Info.plist BEFORE build ──
       # The DMG name comes from Info.plist's CFBundleShortVersionString
@@ -45,7 +45,7 @@ jobs:
           echo "Patched Info.plist: CFBundleShortVersionString=$SHORT (from $RAW)"
 
       # ── Node.js for building client + backend ──
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -108,6 +108,6 @@ jobs:
       # ── Attach DMG to GitHub Release (tag pushes only) ──
       - name: Attach to GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: macos/build/Fliks-*.dmg

--- a/.github/workflows/play-store-publish.yml
+++ b/.github/workflows/play-store-publish.yml
@@ -52,7 +52,7 @@ jobs:
       run:
         working-directory: client
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # `apk_tag` rebuilds an already-released tag (its tree carries the
           # old workflow, so we run main's workflow against the tag's source).
@@ -62,18 +62,18 @@ jobs:
           # a meaningful commit count for the versionCode.
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
           cache-dependency-path: client/package-lock.json
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21
 
-      - uses: android-actions/setup-android@v3
+      - uses: android-actions/setup-android@v4
 
       - name: Install client dependencies
         run: npm ci
@@ -134,7 +134,7 @@ jobs:
 
       - name: Attach signed APK to the GitHub release
         if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.apk_tag != ''
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.apk.outputs.tag }}
           files: ${{ steps.apk.outputs.path }}

--- a/.github/workflows/tizen-publish.yml
+++ b/.github/workflows/tizen-publish.yml
@@ -25,9 +25,9 @@ jobs:
       run:
         working-directory: client
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -53,7 +53,7 @@ jobs:
 
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: ${{ steps.art.outputs.path }}
           fail_on_unmatched_files: true

--- a/.github/workflows/webos-publish.yml
+++ b/.github/workflows/webos-publish.yml
@@ -23,9 +23,9 @@ jobs:
       run:
         working-directory: client
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -51,7 +51,7 @@ jobs:
 
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: ${{ steps.art.outputs.path }}
           fail_on_unmatched_files: true


### PR DESCRIPTION
## Why
GitHub forces Node 20 JS actions to Node 24 on **2026-06-16** and removes the Node 20 runner on **2026-09-16** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The v1.8.0 Android release run already emitted the deprecation warning.

## What
Bump the flagged actions to their latest Node 24 majors across all 9 workflows:

| action | from | to |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/setup-node | v4 | v6 |
| actions/setup-java | v4 | v5 |
| android-actions/setup-android | v3 | v4 |
| softprops/action-gh-release | v2 | v3 |

Verified the breaking changes don't touch our usage: gh-release v3 and checkout v6 are runtime-only; setup-node v5 adds opt-in auto-cache (we already set `cache: npm` explicitly); setup-java v5 only skips JetBrains pre-releases (we use temurin); setup-android v4 defaults cmdline-tools 20.0 (gradle manages its own SDK components). All workflow YAML re-validated.