### PR TITLE
feat(scroller): reveal large edge arrows on cursor proximity

### DIFF
--- a/client/src/app/shared/components/horizontal-scroller.css
+++ b/client/src/app/shared/components/horizontal-scroller.css
@@ -1,0 +1,57 @@
+.scrollbar-none {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.scrollbar-none::-webkit-scrollbar {
+  display: none;
+}
+
+/* Large edge scroll affordances. Centred on the row, they fade in while the
+   row is hovered and scroll one viewport-width on click. Mouse-only — on
+   touch they get in the way of swiping, and on TV the row is driven by
+   spatial navigation. */
+.scroll-edge {
+  position: absolute;
+  top: 50%;
+  z-index: 10;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.92);
+  color: #1d232a;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 160ms ease, background-color 120ms ease, transform 120ms ease;
+}
+.scroll-edge--left {
+  left: 0.5rem;
+}
+.scroll-edge--right {
+  right: 0.5rem;
+}
+
+.scroll-edge.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+.scroll-edge:hover {
+  background: #ffffff;
+  transform: translateY(-50%) scale(1.06);
+}
+.scroll-edge:active {
+  transform: translateY(-50%) scale(0.97);
+}
+
+:host-context(body.tv) .scroll-edge {
+  display: none;
+}
+@media (hover: none) {
+  .scroll-edge {
+    display: none;
+  }
+}

--- a/client/src/app/shared/components/horizontal-scroller.html
+++ b/client/src/app/shared/components/horizontal-scroller.html
@@ -1,0 +1,47 @@
+<div class="mb-3">
+  <h2 class="text-lg font-bold">{{ title() }}</h2>
+</div>
+
+<!-- Scroll affordances overlay the row's edges and fade in on hover; the
+     scroller itself owns the smooth scroll. Vertical / horizontal padding
+     (with matching negative margin so neighbours don't shift) makes room
+     for the focus ring + media-card scale-up — both extend past the row and
+     would otherwise be clipped by overflow-x:auto's implicit overflow-y. -->
+<div
+  class="relative scroll-wrap"
+  (mousemove)="onPointerMove($event)"
+  (mouseleave)="onPointerLeave()"
+>
+  @if (!atStart()) {
+    <button
+      type="button"
+      tabindex="-1"
+      class="scroll-edge scroll-edge--left"
+      [class.is-visible]="showLeft()"
+      (click)="scrollLeft()"
+    >
+      <svg lucideChevronLeft class="h-8 w-8"></svg>
+    </button>
+  }
+
+  <div
+    #scroller
+    appTvRow
+    class="flex gap-2 lg:gap-4 overflow-x-auto scrollbar-none [scroll-behavior:smooth] py-5 -my-5 px-4 -mx-4 lg:px-5 lg:-mx-5 scroll-px-4 lg:scroll-px-5"
+    (scroll)="updateArrows()"
+  >
+    <ng-content />
+  </div>
+
+  @if (!atEnd()) {
+    <button
+      type="button"
+      tabindex="-1"
+      class="scroll-edge scroll-edge--right"
+      [class.is-visible]="showRight()"
+      (click)="scrollRight()"
+    >
+      <svg lucideChevronRight class="h-8 w-8"></svg>
+    </button>
+  }
+</div>

--- a/client/src/app/shared/components/horizontal-scroller.ts
+++ b/client/src/app/shared/components/horizontal-scroller.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   ChangeDetectionStrategy,
+  DestroyRef,
   HostListener,
   inject,
   input,
@@ -10,79 +11,33 @@ import {
   AfterViewInit,
   OnDestroy,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { LucideChevronLeft, LucideChevronRight } from '@lucide/angular';
 import { TvRowDirective } from '../directives/tv-row.directive';
 import { TvService } from '../../core/services/tv.service';
+import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
 
 @Component({
   selector: 'app-horizontal-scroller',
   imports: [LucideChevronLeft, LucideChevronRight, TvRowDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  template: `
-    <!-- Header: title + arrows (arrows are mouse-only — hidden on touch/TV,
-         and when content fits without scrolling so we don't show two grey
-         disabled chevrons doing nothing). -->
-    <div class="flex items-center justify-between mb-3">
-      <h2 class="text-lg font-bold">{{ title() }}</h2>
-      @if (!atStart() || !atEnd()) {
-        <div class="flex gap-1 scroll-arrows">
-          <button
-            type="button"
-            tabindex="-1"
-            class="btn btn-ghost btn-sm btn-circle"
-            [disabled]="atStart()"
-            (click)="scrollLeft()"
-          >
-            <svg lucideChevronLeft class="h-5 w-5"></svg>
-          </button>
-          <button
-            type="button"
-            tabindex="-1"
-            class="btn btn-ghost btn-sm btn-circle"
-            [disabled]="atEnd()"
-            (click)="scrollRight()"
-          >
-            <svg lucideChevronRight class="h-5 w-5"></svg>
-          </button>
-        </div>
-      }
-    </div>
-    <!-- Scrollable content (no visible scrollbar). Vertical / horizontal
-         padding (with matching negative margin so neighbours don't shift)
-         makes room for the focus ring + media-card scale-up — both extend
-         past the row and would otherwise be clipped by overflow-x:auto's
-         implicit overflow-y. -->
-    <div
-      #scroller
-      appTvRow
-      class="flex gap-2 lg:gap-4 overflow-x-auto scrollbar-none [scroll-behavior:smooth] py-5 -my-5 px-4 -mx-4 lg:px-5 lg:-mx-5 scroll-px-4 lg:scroll-px-5"
-      (scroll)="updateArrows()"
-    >
-      <ng-content />
-    </div>
-  `,
-  styles: [`
-    .scrollbar-none {
-      scrollbar-width: none;
-      -ms-overflow-style: none;
-    }
-    .scrollbar-none::-webkit-scrollbar {
-      display: none;
-    }
-    /* Hide the < > scroll arrows on touch / TV — they're mouse-only ergonomy.
-       Use both a body.tv selector (reliable) and a hover-media query (web touch). */
-    :host-context(body.tv) .scroll-arrows { display: none; }
-    @media (hover: none) {
-      .scroll-arrows { display: none; }
-    }
-  `],
+  templateUrl: './horizontal-scroller.html',
+  styleUrl: './horizontal-scroller.css',
 })
 export class HorizontalScrollerComponent implements AfterViewInit, OnDestroy {
   private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
   private readonly tv = inject(TvService);
+  private readonly reuse = inject(CachingReuseStrategy);
+  private readonly destroyRef = inject(DestroyRef);
   readonly title = input('');
   readonly atStart = signal(true);
   readonly atEnd = signal(false);
+  /** Edge arrows reveal only while the cursor sits within {@link EDGE_ZONE_PX}
+   *  of that edge, not on a whole-row hover — so they don't cover the middle
+   *  cards and only show where they act. */
+  readonly showLeft = signal(false);
+  readonly showRight = signal(false);
+  private static readonly EDGE_ZONE_PX = 80;
 
   private readonly scrollerEl = viewChild<ElementRef<HTMLElement>>('scroller');
   private resizeObserver?: ResizeObserver;
@@ -132,6 +87,20 @@ export class HorizontalScrollerComponent implements AfterViewInit, OnDestroy {
       this.resizeObserver = new ResizeObserver(() => this.updateArrows());
       this.resizeObserver.observe(el);
     }
+    // Routes flagged `reuse: true` detach this row's DOM on navigate-away and
+    // reattach it on return without re-running ngAfterViewInit. The reattach
+    // can reset the rail's scrollLeft and leaves atStart/atEnd stale, so the
+    // arrows show the wrong state coming back from a detail page. Recompute
+    // once the page is reattached (next frame, after layout settles).
+    this.reuse.attached$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        // The cursor isn't necessarily over the row on return — drop any
+        // stale proximity state, then recompute the scroll extents.
+        this.showLeft.set(false);
+        this.showRight.set(false);
+        requestAnimationFrame(() => this.updateArrows());
+      });
   }
 
   ngOnDestroy() {
@@ -153,5 +122,23 @@ export class HorizontalScrollerComponent implements AfterViewInit, OnDestroy {
   scrollRight() {
     const el = this.scrollerEl()?.nativeElement;
     if (el) el.scrollBy({ left: el.clientWidth * 0.8, behavior: 'smooth' });
+  }
+
+  /** Reveal an edge arrow only when the cursor is within the edge zone on
+   *  that side. Signals are written only on change so the high-frequency
+   *  mousemove doesn't thrash change detection. */
+  onPointerMove(event: MouseEvent) {
+    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const zone = HorizontalScrollerComponent.EDGE_ZONE_PX;
+    const left = x <= zone;
+    const right = x >= rect.width - zone;
+    if (this.showLeft() !== left) this.showLeft.set(left);
+    if (this.showRight() !== right) this.showRight.set(right);
+  }
+
+  onPointerLeave() {
+    if (this.showLeft()) this.showLeft.set(false);
+    if (this.showRight()) this.showRight.set(false);
   }
 }


### PR DESCRIPTION
## What
Replace the small header chevrons on horizontal rows with **large circular arrows overlaid on the left/right edges**, revealed only while the cursor is within **80px of that edge** (not on a whole-row hover) — so they don't cover the middle cards and only show where they act.

- Left/right gated by the existing `atStart`/`atEnd` extents; **mouse-only** (hidden on TV via `body.tv` and on touch via `@media (hover: none)`).
- Proximity tracked with a `mousemove` handler; signals written only on change so it doesn't thrash change detection.

## Bug fix: stale arrows when returning from a detail page
Home and library are route-reuse cached (`reuse: true`), so their DOM reattaches **without re-running `ngAfterViewInit`** — which can reset a rail's `scrollLeft` and leaves `atStart`/`atEnd` stale, showing the wrong arrows. The scroller now subscribes to `CachingReuseStrategy.attached$` (the API the strategy documents for exactly this) to reset proximity state and recompute the extents on reattach.

## Misc
Template + styles moved to external files (`horizontal-scroller.html` / `.css`) per the project convention. Build verified clean.