### PR TITLE
feat(streaming): show the low-consumption rung on forced transcode

### DIFF
--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -601,6 +601,22 @@ export class StreamBuilderService {
       });
     }
 
+    // Forced transcode (no remux → no `original`, e.g. HEVC/AV1 on desktop):
+    // there's no split, so the eco rung above wasn't emitted. Still surface
+    // one low-consumption choice at source resolution, right after the top
+    // rung. Desktop-only — mobile's top rung is already the low one and is
+    // present in the list above.
+    if (deviceType === 'desktop' && lowProfile && !videoCopyStream) {
+      qualities.splice(1, 0, {
+        id: lowProfile.name,
+        label: resolutionLabel,
+        height: originalHeight,
+        totalBitrateBps: lowTotal,
+        isRemux: false,
+        lowBandwidth: true,
+      });
+    }
+
     return qualities;
   }
 


### PR DESCRIPTION
Follow-up to #389. The desktop "faible consommation" rung only showed next to `original` (remuxable sources). Force-transcoded sources (HEVC/AV1/4K, no remux) listed the full ladder with no low option at source resolution.

Now, when there's no `original` (`!videoCopyStream`), the desktop eco rung is inserted right after the top rung — e.g. `4K` + `4K faible consommation` (8M) + `1080p`… Desktop-only; mobile's top rung is already the low one. All eco plumbing (profiles, master, transcode, VALID_QUALITIES) already landed in #389, so this is a small buildQualityList change. Backend tsc clean.