### PR TITLE
fix(android): keep the status bar edge-to-edge on cold start

### DIFF
--- a/client/android/app/src/main/java/media/fliks/app/ImmersivePlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/ImmersivePlugin.java
@@ -70,6 +70,14 @@ public class ImmersivePlugin extends Plugin {
     }
 
     @PluginMethod()
+    public void applyEdgeToEdge(PluginCall call) {
+        if (getActivity() instanceof MainActivity) {
+            ((MainActivity) getActivity()).reapplyEdgeToEdge();
+        }
+        call.resolve();
+    }
+
+    @PluginMethod()
     public void setLightStatusBar(PluginCall call) {
         boolean light = call.getBoolean("light", false);
         getActivity().runOnUiThread(() -> {

--- a/client/android/app/src/main/java/media/fliks/app/MainActivity.java
+++ b/client/android/app/src/main/java/media/fliks/app/MainActivity.java
@@ -113,6 +113,22 @@ public class MainActivity extends BridgeActivity {
         getWindow().getDecorView().post(this::applyLightStatusBar);
     }
 
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        // The launch splash (and Capacitor bridge setup) keep the window in
+        // the launch theme's opaque-bar state while they're up, so the
+        // edge-to-edge call in onCreate — and even the first onResume, which
+        // runs while the splash still covers the activity — don't stick: the
+        // status bar only turns transparent once the window truly gains
+        // focus after the splash is removed. That focus gain is exactly what
+        // a recents → return cycle reproduces, which is why it "fixes itself"
+        // there. Re-assert here so the first post-splash frame is edge-to-edge.
+        if (hasFocus) {
+            reapplyEdgeToEdge();
+        }
+    }
+
     /**
      * Asserts the window's edge-to-edge layout + transparent system
      * bars. Safe to call multiple times; idempotent.
@@ -131,6 +147,26 @@ public class MainActivity extends BridgeActivity {
         WindowCompat.setDecorFitsSystemWindows(window, false);
         window.setStatusBarColor(Color.TRANSPARENT);
         window.setNavigationBarColor(Color.TRANSPARENT);
+        // Force a fresh window-insets dispatch down to the WebView. On a cold
+        // start the bars are reset to opaque while the splash is up and the
+        // insets that drive CSS env(safe-area-inset-*) arrive as zero, so the
+        // top bar doesn't extend under the status bar (black strip) until the
+        // next relayout. Requesting it explicitly re-publishes the real insets.
+        window.getDecorView().requestApplyInsets();
+    }
+
+    /**
+     * Re-asserts edge-to-edge + status-bar icon color. Used both on window
+     * focus gain and from JS (ImmersivePlugin) right after the splash is
+     * hidden — the first cold-start moment the layout is settled enough for
+     * the transparent status bar + insets to actually stick. Marshals onto the
+     * UI thread so it's safe to call from the plugin's binder thread too.
+     */
+    public void reapplyEdgeToEdge() {
+        runOnUiThread(() -> {
+            applyEdgeToEdge();
+            getWindow().getDecorView().post(this::applyLightStatusBar);
+        });
     }
 
     /** Called by ImmersivePlugin. */

--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -1,7 +1,7 @@
 import { Component, ChangeDetectionStrategy, inject, OnInit, OnDestroy } from '@angular/core';
 import { NavigationEnd, Router, RouterOutlet } from '@angular/router';
 import { filter, take } from 'rxjs';
-import { Capacitor } from '@capacitor/core';
+import { Capacitor, registerPlugin } from '@capacitor/core';
 import { App as CapApp } from '@capacitor/app';
 import { SplashScreen } from '@capacitor/splash-screen';
 import { AuthService } from './core/services/auth.service';
@@ -68,6 +68,16 @@ export class App implements OnInit, OnDestroy {
         // the splash fades out — otherwise the user briefly sees a blank app.
         requestAnimationFrame(() => {
           void SplashScreen.hide({ fadeOutDuration: 200 });
+          // On a cold start the status bar is left opaque (a black strip under
+          // it) until a relayout, because the splash teardown drops the window
+          // insets that drive env(safe-area-inset-*). Re-assert edge-to-edge a
+          // short beat after hide() — once the window has settled the insets
+          // re-publish and the status bar goes transparent. (Chaining directly
+          // on hide() resolves too early and the re-assert doesn't take.)
+          if (Capacitor.getPlatform() === 'android') {
+            const Immersive = registerPlugin<{ applyEdgeToEdge(): Promise<void> }>('Immersive');
+            setTimeout(() => void Immersive.applyEdgeToEdge().catch(() => {}), 100);
+          }
         });
       });
 


### PR DESCRIPTION
On a cold start the status bar rendered as an opaque **black strip** on the home until a relayout (recents → return, or reopening a still-alive activity) — never on the splash, which stayed immersive.

**Cause**: the splash teardown drops the window insets that drive CSS `env(safe-area-inset-*)`, so the top bar stops extending under the status bar until the insets are re-published.

**Fix** — re-assert edge-to-edge at the moments the layout has actually settled:
- `onWindowFocusChanged` → covers warm start / recents return;
- a JS re-assert (`Immersive.applyEdgeToEdge()`) fired shortly after `SplashScreen.hide()` for the cold-start path, where focus is gained while the splash still covers the activity;
- `applyEdgeToEdge` now also calls `requestApplyInsets()` so `env(safe-area-inset-*)` re-publishes to the WebView.

Leaves a barely-visible sub-frame flash on cold start (accepted). Native shell only; client `ng build` clean.