### PR TITLE
fix(android): draw under the landscape display cutout

### DIFF
--- a/client/android/app/src/main/java/media/fliks/app/ImmersivePlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/ImmersivePlugin.java
@@ -103,11 +103,13 @@ public class ImmersivePlugin extends Plugin {
                 ((MainActivity) getActivity()).setImmersiveMode(false);
             }
 
-            // Reset cutout mode to default
+            // Keep drawing into the short-edge cutout (the app-wide baseline),
+            // not DEFAULT — DEFAULT re-letterboxes the landscape punch-hole
+            // with a black bar once the player closes.
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 WindowManager.LayoutParams lp = window.getAttributes();
                 lp.layoutInDisplayCutoutMode =
-                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT;
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
                 window.setAttributes(lp);
             }
 
@@ -128,6 +130,14 @@ public class ImmersivePlugin extends Plugin {
                     | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
                     | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
                 );
+            }
+            // Re-assert edge-to-edge now the bars are shown again: keep the
+            // WebView drawing under them (full width) and re-dispatch the
+            // insets + transparent bar colours. Without this the returning
+            // bars take layout space — the status bar goes opaque (black) and
+            // the narrower viewport flips the form factor back to phone.
+            if (getActivity() instanceof MainActivity) {
+                ((MainActivity) getActivity()).reapplyEdgeToEdge();
             }
             call.resolve();
         });

--- a/client/android/app/src/main/java/media/fliks/app/MainActivity.java
+++ b/client/android/app/src/main/java/media/fliks/app/MainActivity.java
@@ -12,6 +12,7 @@ import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.Window;
+import android.view.WindowManager;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.core.view.WindowCompat;
@@ -147,6 +148,17 @@ public class MainActivity extends BridgeActivity {
         WindowCompat.setDecorFitsSystemWindows(window, false);
         window.setStatusBarColor(Color.TRANSPARENT);
         window.setNavigationBarColor(Color.TRANSPARENT);
+        // Draw into the display cutout on the short edges. In landscape the
+        // punch-hole sits on a short (left/right) edge; the default mode
+        // letterboxes it with a black bar. SHORT_EDGES lets the app background
+        // reach the edge while body.native's env(safe-area-inset-left/right)
+        // padding keeps content clear of the camera.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            WindowManager.LayoutParams lp = window.getAttributes();
+            lp.layoutInDisplayCutoutMode =
+                WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+            window.setAttributes(lp);
+        }
         // Force a fresh window-insets dispatch down to the WebView. On a cold
         // start the bars are reset to opaque while the splash is up and the
         // insets that drive CSS env(safe-area-inset-*) arrive as zero, so the
@@ -218,10 +230,13 @@ public class MainActivity extends BridgeActivity {
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
-        // Android resets the WindowInsetsController appearance bits on orientation
-        // changes; reapply the last requested state so nav/status icons keep their
-        // theme-matching color (white on dark, dark on light).
-        getWindow().getDecorView().post(this::applyLightStatusBar);
+        // An orientation change drops the edge-to-edge layout and the
+        // WindowInsetsController appearance bits, so reassert both to keep the
+        // status bar transparent with content drawn under it. Repeat on the
+        // next frame because the insets that drive env(safe-area-inset-*) land
+        // once the rotated layout has settled.
+        reapplyEdgeToEdge();
+        getWindow().getDecorView().post(this::reapplyEdgeToEdge);
     }
 
     /** True when the device is in television (leanback) UI mode. */

--- a/client/android/app/src/main/res/values-v31/styles.xml
+++ b/client/android/app/src/main/res/values-v31/styles.xml
@@ -10,5 +10,9 @@
         <item name="android:background">@drawable/splash_themed</item>
         <item name="android:windowBackground">@drawable/splash_themed</item>
         <item name="splashBackground">@color/splash_bg_dark</item>
+        <!-- Draw into short-edge cutouts so the landscape punch-hole isn't
+             letterboxed with a black bar; content is kept clear of the camera
+             by env(safe-area-inset-left/right) padding. -->
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
 </resources>

--- a/client/android/app/src/main/res/values/styles.xml
+++ b/client/android/app/src/main/res/values/styles.xml
@@ -28,5 +28,9 @@
         <item name="windowNoTitle">true</item>
         <item name="android:windowBackground">@drawable/splash_themed</item>
         <item name="splashBackground">@color/splash_bg_dark</item>
+        <!-- Draw into short-edge cutouts so the landscape punch-hole isn't
+             letterboxed with a black bar; content is kept clear of the camera
+             by env(safe-area-inset-left/right) padding. -->
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
 </resources>

--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -76,7 +76,7 @@ export class App implements OnInit, OnDestroy {
           // on hide() resolves too early and the re-assert doesn't take.)
           if (Capacitor.getPlatform() === 'android') {
             const Immersive = registerPlugin<{ applyEdgeToEdge(): Promise<void> }>('Immersive');
-            setTimeout(() => void Immersive.applyEdgeToEdge().catch(() => {}), 100);
+            setTimeout(() => void Immersive.applyEdgeToEdge().catch(() => {}), 200);
           }
         });
       });


### PR DESCRIPTION
## Symptom
In **landscape on OnePlus/OxygenOS**, a black bar appeared down the **left edge** (and the bottom dock wrongly returned), most noticeably after closing the native player.

## Cause
The black bar was the **display-cutout letterbox**: in landscape the punch-hole sits on a short edge and the default cutout mode masks it with an opaque black bar. That bar also narrowed the viewport, crossing the phone/tablet width breakpoint, so `device.isPhone()` flipped and the dock came back. `ImmersivePlugin.exit()` reset the cutout mode to `DEFAULT`, which re-letterboxed it every time the player closed.

(Confirmed with an on-device `screencap` — the bar is the cutout strip, not the status bar or the window background, which is why earlier window-colour tweaks did nothing.)

## Fix
- Opt the window into `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES` — app background reaches the edge, content stays clear of the camera via the existing `env(safe-area-inset-left/right)` padding. Set as the **launch-theme baseline** (deterministic from the first splash frame) + re-asserted at runtime.
- `ImmersivePlugin.exit()` keeps `SHORT_EDGES` instead of resetting to `DEFAULT`, and re-dispatches the window insets after restoring the system bars so the top bar keeps extending under a transparent status bar.
- Reassert edge-to-edge on `onConfigurationChanged` (rotation otherwise dropped the transparent bars).

Native shell + a one-line `app.ts` cold-start timing tweak. Verified on OnePlus 9 (OxygenOS 14): landscape cold start and player exit no longer show the black bar, and the dock no longer flips. Builds on #392.