### PR TITLE
fix(watch-history): show the episode still, not the series art

### DIFF
--- a/backend/src/modules/streaming/playback.service.ts
+++ b/backend/src/modules/streaming/playback.service.ts
@@ -26,6 +26,8 @@ export interface WatchHistoryItem {
   mediaType: string;
   posterUrl: string | null;
   fanartUrl: string | null;
+  /** Episode still — null for movie rows or when TMDB had no still. */
+  stillUrl: string | null;
   episodeLabel: string | null;
 }
 
@@ -497,7 +499,7 @@ export class PlaybackService implements OnModuleInit {
          ps."positionSeconds", ps."durationSeconds", ps.completed,
          ps."lastPlayedAt",
          m.title AS "mediaTitle", m.type AS "mediaType",
-         m."posterUrl", m."fanartUrl",
+         m."posterUrl", m."fanartUrl", e."stillUrl",
          CASE WHEN ps."durationSeconds" > 0
               THEN ROUND((ps."positionSeconds" / ps."durationSeconds") * 100)
               ELSE 0 END AS "progressPercent",

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -142,6 +142,8 @@ export interface WatchHistoryItem {
   mediaType: string;
   posterUrl: string | null;
   fanartUrl: string | null;
+  /** Episode still — null for movies or when TMDB had no still. */
+  stillUrl: string | null;
   episodeLabel: string | null;
 }
 

--- a/client/src/app/features/watch-history/watch-history.html
+++ b/client/src/app/features/watch-history/watch-history.html
@@ -19,7 +19,9 @@
             (click)="goToMedia(item)"
           >
             <div class="absolute inset-0 overflow-hidden rounded-md">
-              @if (item.fanartUrl) {
+              @if (item.stillUrl) {
+                <img [src]="item.stillUrl | resolveUrl:'thumb'" [alt]="item.mediaTitle" class="h-full w-full object-contain" loading="lazy" />
+              } @else if (item.fanartUrl) {
                 <img [src]="item.fanartUrl | resolveUrl:'thumb'" [alt]="item.mediaTitle" class="h-full w-full object-contain" loading="lazy" />
               } @else if (item.posterUrl) {
                 <img [src]="item.posterUrl | resolveUrl:'thumb'" [alt]="item.mediaTitle" class="h-full w-full object-contain" loading="lazy" />


### PR DESCRIPTION
The watch-history list carried no episode-level image, so every episode reused the series fanart/poster instead of its own still.

- `getHistory` now selects `e."stillUrl"` (the `episodes` join was already present) and `WatchHistoryItem` carries it (backend + client).
- The thumbnail prefers `stillUrl → fanartUrl → posterUrl`, mirroring the continue-watching list.

Movies and episodes with no TMDB still keep the fanart/poster fallback. Backend `tsc` + client `ng build` clean.