### PR TITLE
perf(player): raise web buffering goal to 30s

### DIFF
--- a/client/src/app/core/services/playback-engine/shaka-engine.ts
+++ b/client/src/app/core/services/playback-engine/shaka-engine.ts
@@ -70,7 +70,7 @@ export class ShakaEngine extends AbstractPlaybackEngine implements PlaybackEngin
     // Sensible streaming defaults
     this.player.configure({
       streaming: {
-        bufferingGoal: 20,
+        bufferingGoal: 30,
         rebufferingGoal: 1,
         bufferBehind: 60,
       },


### PR DESCRIPTION
## What

Raise the Shaka web player's `bufferingGoal` from 20s to 30s (`shaka-engine.ts`). `rebufferingGoal` (1s) and `bufferBehind` (60s) are unchanged.

## Why

A 20s forward buffer left little cushion against transient network dips on remote or otherwise degraded links — a single slow segment fetch could drain the buffer and stall playback.

30s adds resilience while staying deliberately modest:
- **ABR stays responsive** — a much larger forward buffer would commit quality decisions far in advance, so a low-quality stretch would persist long after the network recovered.
- **JIT transcode stays bounded** — web playback is transcoded on the fly, so an aggressive buffer would push ffmpeg to race far ahead of the playhead and waste CPU on content that is skipped or abandoned. The browser's MSE SourceBuffer quota would cap the effective buffer well before any multi-minute target anyway.

## Scope

Web only. The native (ExoPlayer) buffer tuning is intentionally left out of this PR pending on-device validation on a degraded network.

## Test

Compile-level change to a single streaming constant; no behavioural test added. Validation is observational — fewer rebuffer events on a throttled/remote connection.