### PR TITLE
perf(android): widen native player buffer for degraded links

### DIFF
--- a/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
@@ -266,9 +266,16 @@ public class NativePlayerPlugin extends Plugin {
             final DataSource.Factory dataSourceFactory = offline
                     ? new DefaultDataSource.Factory(getContext(), FlixDownloadUtil.getCacheDataSourceFactory(getContext()))
                     : new DefaultDataSource.Factory(getContext(), httpFactory);
-            // 500ms instead of ExoPlayer's default 2500ms — short-segment LAN HLS.
+            // Buffer sized as multiples of the production ~6s HLS segment: ~3
+            // segments (18s) min, up to ~8 segments (48s) ahead, so a slow
+            // segment fetch on a degraded link doesn't drain to empty and stall.
+            // 48s stays under the backend's 15-segment seek-restart threshold
+            // (~90s at 6s segments), so forward fill never forces an ffmpeg
+            // restart. bufferForPlaybackMs stays 500ms (vs ExoPlayer's 2500ms
+            // default) for a snappy start/seek; resume-after-rebuffer waits one
+            // full segment (6s) to avoid re-stalling mid-segment.
             LoadControl loadControl = new DefaultLoadControl.Builder()
-                    .setBufferDurationsMs(3000, 8000, 500, 3000)
+                    .setBufferDurationsMs(18000, 48000, 500, 6000)
                     .build();
             // Renderers tuned for AV receivers / TVs that decode surround:
             // - setEnableAudioFloatOutput(false) keeps the audio path on 16-bit


### PR DESCRIPTION
## What

Widen the ExoPlayer `LoadControl` buffer durations in `NativePlayerPlugin.java`:

| Param | Before | After |
|---|---|---|
| `minBufferMs` | 3s | 18s (~3 segments) |
| `maxBufferMs` | 8s | 48s (~8 segments) |
| `bufferForPlaybackMs` | 500ms | 500ms (unchanged — snappy start/seek) |
| `bufferForPlaybackAfterRebufferMs` | 3s | 6s (one full segment) |

## Why

ExoPlayer fills its buffer in whole HLS segments. With ~6s production segments, the old 8s `maxBufferMs` left roughly one segment of headroom — a single slow segment fetch on a remote or throttled connection drained the buffer to empty and stalled playback. `minBufferMs` (3s) and the resume-after-rebuffer target (3s) both sat below a single segment.

Sizing the buffer as multiples of the segment gives real resilience. 48s (~8 segments) stays comfortably under the backend's 15-segment seek-restart threshold (~90s at 6s segments), so steady forward fill never pushes ffmpeg far enough ahead to trigger a restart. The fast-start behaviour is preserved by leaving `bufferForPlaybackMs` at 500ms.

## Test

Buffer-tuning constant change. Best validated on a real device over a degraded/remote connection (fewer rebuffer events); no difference is visible on LAN.