### PR TITLE
fix(downloads): stuck-torrent cleanup reliability and activity queue UX

### DIFF
--- a/backend/src/modules/download-clients/download-clients.module.ts
+++ b/backend/src/modules/download-clients/download-clients.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { DownloadClient } from './entities/download-client.entity';
 import { DownloadHistory } from '../media/entities/download-history.entity';
+import { StalledCheck } from '../scheduler/entities/stalled-check.entity';
+import { CleanupProfile } from '../cleanup-profiles/entities/cleanup-profile.entity';
 import { QbittorrentService } from './qbittorrent.service';
 import { DownloadClientsService } from './download-clients.service';
 import { DownloadClientsController } from './download-clients.controller';
@@ -11,7 +13,12 @@ import { BlocklistModule } from '../blocklist/blocklist.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([DownloadClient, DownloadHistory]),
+    TypeOrmModule.forFeature([
+      DownloadClient,
+      DownloadHistory,
+      StalledCheck,
+      CleanupProfile,
+    ]),
     AuthModule,
     BlocklistModule,
   ],

--- a/backend/src/modules/download-clients/download-clients.service.ts
+++ b/backend/src/modules/download-clients/download-clients.service.ts
@@ -1,9 +1,16 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, In, Repository } from 'typeorm';
 import { DownloadClient } from './entities/download-client.entity';
 import { DownloadHistory } from '../media/entities/download-history.entity';
 import { Media } from '../media/entities/media.entity';
+import { StalledCheck } from '../scheduler/entities/stalled-check.entity';
+import { CleanupProfile } from '../cleanup-profiles/entities/cleanup-profile.entity';
+import { StalledCleanupProfileKey } from '../../common/constants/stalled-cleanup-profiles';
+import {
+  countStalledStrikes,
+  STALL_ELIGIBLE_STATES,
+} from '../scheduler/utils/stalled-progress.util';
 import { QbittorrentService, QbittorrentTorrent } from './qbittorrent.service';
 import { CreateDownloadClientDto } from './dto/create-download-client.dto';
 import { UpdateDownloadClientDto } from './dto/update-download-client.dto';
@@ -26,8 +33,20 @@ export interface QueueEntry extends QbittorrentTorrent {
   episodeNumber?: number;
   /** Episode title where known. */
   episodeTitle?: string | null;
+  /** Linked episode id (single-episode grabs) — lets the client open the
+   *  episode releases modal for this exact target. */
+  episodeId?: number;
+  /** Linked season id (episode grabs carry the parent season, packs the pack's). */
+  seasonId?: number;
   /** Indexer the torrent was grabbed from (resolved through DownloadHistory). */
   indexerName?: string;
+  /** Consecutive no-progress stall snapshots for this torrent, computed with
+   *  the same tolerance as the stalled cleanup. Present only when the item's
+   *  media→library carries a cleanup profile. */
+  stalledStrikes?: number;
+  /** The profile's sample count — the cleanup removes the torrent when
+   *  `stalledStrikes` reaches this. */
+  stalledStrikesRequired?: number;
   /** Download client status (Downloading, Seeding, Paused, Stalled…) */
   trackerStatus: string;
   /** App-level status (Awaiting import, Importing, Imported, Import failed…) */
@@ -88,6 +107,10 @@ export class DownloadClientsService {
     private readonly repo: Repository<DownloadClient>,
     @InjectRepository(DownloadHistory)
     private readonly historyRepo: Repository<DownloadHistory>,
+    @InjectRepository(StalledCheck)
+    private readonly stalledCheckRepo: Repository<StalledCheck>,
+    @InjectRepository(CleanupProfile)
+    private readonly cleanupProfileRepo: Repository<CleanupProfile>,
     private readonly qbittorrent: QbittorrentService,
     private readonly historyMatcher: TorrentHistoryMatcher,
     private readonly blocklist: BlocklistService,
@@ -367,6 +390,11 @@ export class DownloadClientsService {
       relations: ['media', 'indexer', 'episode', 'season'],
     });
 
+    // Cleanup profile key per entry, resolved during the match (media.library
+    // is eager-loaded). Side map rather than an entry field so the internal
+    // key never serializes to the client.
+    const profileKeyByEntry = new Map<QueueEntry, StalledCleanupProfileKey>();
+
     for (const entry of results) {
       const match = await this.historyMatcher.matchAndHeal(
         entry,
@@ -376,6 +404,8 @@ export class DownloadClientsService {
         entry.mediaId = match.mediaId;
         entry.mediaTitle = match.media.title;
         entry.mediaType = match.media.type;
+        const profileKey = match.media.library?.stalledCleanupProfile;
+        if (profileKey) profileKeyByEntry.set(entry, profileKey);
       }
       if (match?.indexer) {
         entry.indexerName = match.indexer.name;
@@ -390,6 +420,12 @@ export class DownloadClientsService {
       }
       if (match?.season) {
         entry.seasonNumber = match.season.seasonNumber;
+      }
+      if (match?.episodeId != null) {
+        entry.episodeId = match.episodeId;
+      }
+      if (match?.seasonId != null) {
+        entry.seasonId = match.seasonId;
       }
 
       // App-level status from history
@@ -433,11 +469,62 @@ export class DownloadClientsService {
 
     const total = filtered.length;
     const start = (page - 1) * pageSize;
-    return {
-      items: filtered.slice(start, start + pageSize),
-      total,
-      page,
-      pageSize,
-    };
+    const items = filtered.slice(start, start + pageSize);
+
+    await this.annotateStalledStrikes(items, profileKeyByEntry);
+
+    return { items, total, page, pageSize };
+  }
+
+  /**
+   * Fills `stalledStrikes` / `stalledStrikesRequired` on queue items whose
+   * media→library carries a cleanup profile, using the same no-progress
+   * tolerance and run-length logic as the stalled cleanup. The count is
+   * clamped to the profile's sample target so the display stays "x/N" even
+   * when a torrent outlives the firing threshold (e.g. the client refused
+   * the deletion). Runs on the page slice only — the queue is polled every
+   * 10 s, so queries stay bounded to one page.
+   *
+   * Only torrents currently subject to stall monitoring are annotated:
+   * paused/seeding/imported items would otherwise surface stale snapshots
+   * (rows live until removal or the 24 h prune, not until import).
+   */
+  private async annotateStalledStrikes(
+    items: QueueEntry[],
+    profileKeyByEntry: Map<QueueEntry, StalledCleanupProfileKey>,
+  ): Promise<void> {
+    const eligible = items.filter(
+      (it) =>
+        it.hash &&
+        it.progress < 1 &&
+        STALL_ELIGIBLE_STATES.has(it.state) &&
+        profileKeyByEntry.has(it),
+    );
+    if (!eligible.length) return;
+
+    const profiles = await this.cleanupProfileRepo.find();
+    const profileByKey = new Map(profiles.map((p) => [p.key, p]));
+
+    const hashes = eligible.map((it) => it.hash);
+    const rows = await this.stalledCheckRepo.find({
+      where: { torrentHash: In(hashes) },
+      order: { checkedAt: 'DESC' },
+    });
+    // Global DESC order preserves each hash's own DESC order on grouping.
+    const snapsByHash = new Map<string, StalledCheck[]>();
+    for (const row of rows) {
+      const key = row.torrentHash.toLowerCase();
+      const list = snapsByHash.get(key);
+      if (list) list.push(row);
+      else snapsByHash.set(key, [row]);
+    }
+
+    for (const it of eligible) {
+      const profile = profileByKey.get(profileKeyByEntry.get(it)!);
+      if (!profile) continue;
+      const snaps = snapsByHash.get(it.hash.toLowerCase()) ?? [];
+      it.stalledStrikes = Math.min(countStalledStrikes(snaps), profile.samples);
+      it.stalledStrikesRequired = profile.samples;
+    }
   }
 }

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -31,6 +31,10 @@ import { MediaType } from '../../common/enums';
 import { relativePathUnderMediaRoot } from '../../common/utils/media-path.util';
 import { enqueueCommand } from '../../common/utils/command-queue.util';
 import { StalledCheck } from './entities/stalled-check.entity';
+import {
+  countStalledStrikes,
+  STALL_ELIGIBLE_STATES,
+} from './utils/stalled-progress.util';
 import { CleanupProfile } from '../cleanup-profiles/entities/cleanup-profile.entity';
 import { Library } from '../libraries/entities/library.entity';
 import { TorrentHistoryMatcher } from '../media/torrent-history-matcher.service';
@@ -922,8 +926,9 @@ export class CompletionService {
    *
    * For every active downloading torrent that can be traced back to a library
    * with a cleanup profile (fast/medium/slow), we snapshot the `downloaded` byte
-   * counter at the profile's interval. When the last N snapshots are all equal,
-   * the download is considered stalled and is removed + blocklisted.
+   * counter at the profile's interval. When the last N snapshots show no
+   * meaningful progress, the download is considered stalled and is removed
+   * + blocklisted.
    *
    * Whether a new search is triggered depends on:
    *   - the profile's `autoRestart` flag,
@@ -953,6 +958,21 @@ export class CompletionService {
     const allowManualRestart =
       (await this.settings.get('cleanup_restart_manual_grabs')) === 'true';
 
+    // Candidate histories for the torrent↔history match, loaded once for all
+    // clients. `completed` rows are excluded — a finished import is no longer
+    // an in-flight download. The matcher falls back to name matching and
+    // self-heals missing hashes, so grabs whose hash was never recovered at
+    // add time are still covered (the old hash-only lookup skipped them).
+    const histories = await this.historyRepo.find({
+      where: [
+        { status: 'grabbed' },
+        { status: 'failed' },
+        { status: 'warning' },
+        { status: 'importing' },
+      ],
+      relations: ['media'],
+    });
+
     const mediaToResearch = new Set<number>();
     const now = Date.now();
 
@@ -964,46 +984,19 @@ export class CompletionService {
         continue;
       }
 
-      // Only examine torrents that are still downloading AND not paused by the user.
-      // Paused/stopped torrents make no progress by design and should never be flagged.
       const downloading = torrents.filter(
         (t) =>
           t.progress < 1 &&
           t.hash &&
           t.hash.length > 0 &&
-          t.state !== 'pausedDL' &&
-          t.state !== 'stoppedDL',
+          STALL_ELIGIBLE_STATES.has(t.state),
       );
       if (!downloading.length) continue;
 
-      // Bulk-load all histories matching these hashes in one query.
-      const hashes = downloading.map((t) => t.hash.toLowerCase());
-      const histories = await this.historyRepo.find({
-        where: { torrentHash: In(hashes) },
-      });
-      const historyByHash = new Map(
-        histories.map((h) => [h.torrentHash.toLowerCase(), h]),
-      );
-
-      // Pre-load the media rows we need (to resolve libraryId).
-      const mediaIds = Array.from(
-        new Set(
-          histories
-            .map((h) => h.mediaId)
-            .filter((id): id is number => id != null),
-        ),
-      );
-      const medias = mediaIds.length
-        ? await this.mediaRepo.find({ where: { id: In(mediaIds) } })
-        : [];
-      const mediaById = new Map(medias.map((m) => [m.id, m]));
-
       for (const t of downloading) {
-        const history = historyByHash.get(t.hash.toLowerCase());
+        const history = await this.historyMatcher.matchAndHeal(t, histories);
         if (!history) continue; // Untracked torrent — not our business.
-        const media = history.mediaId
-          ? mediaById.get(history.mediaId)
-          : undefined;
+        const media = history.media; // library is eager-loaded with the media
         if (!media?.libraryId) continue;
         const library = libraryById.get(media.libraryId);
         if (!library?.stalledCleanupProfile) continue;
@@ -1081,7 +1074,8 @@ export class CompletionService {
 
   /**
    * Records a snapshot if the interval has elapsed, then checks whether the
-   * last `profile.samples` snapshots all have the same `downloadedBytes`.
+   * last `profile.samples` snapshots form an unbroken no-progress run (each
+   * step within the tolerance of `stalled-progress.util`).
    */
   private async evaluateStalled(
     torrent: QbittorrentTorrent,
@@ -1116,11 +1110,19 @@ export class CompletionService {
     });
 
     if (recent.length < profile.samples) return false;
-    const first = recent[0].downloadedBytes;
-    return recent.every((s) => s.downloadedBytes === first);
+    // `recent` is DESC by checkedAt — exactly the order the strike counter
+    // expects. Tolerant comparison: a stalled torrent keeps receiving a
+    // trickle of wasted bytes from churning peers, so strict byte equality
+    // would never fire.
+    return countStalledStrikes(recent) >= profile.samples;
   }
 
-  /** Deletes stalled-check rows older than 24 h to keep the table small. */
+  /**
+   * Deletes stalled-check rows older than 24 h to keep the table small.
+   * Assumes every profile's detection window (`(samples - 1) × interval`)
+   * stays under 24 h — a longer custom window would lose its oldest
+   * snapshots before the run could complete.
+   */
   private async pruneOldStalledChecks(): Promise<void> {
     const cutoff = new Date(Date.now() - 24 * 60 * 60_000);
     await this.stalledCheckRepo.delete({ checkedAt: LessThan(cutoff) });

--- a/backend/src/modules/scheduler/utils/stalled-progress.util.spec.ts
+++ b/backend/src/modules/scheduler/utils/stalled-progress.util.spec.ts
@@ -1,0 +1,72 @@
+import {
+  countStalledStrikes,
+  isNoProgress,
+  STALL_PROGRESS_TOLERANCE_BYTES,
+} from './stalled-progress.util';
+
+const MIB = Number(STALL_PROGRESS_TOLERANCE_BYTES);
+
+const samples = (...bytesNewestFirst: number[]) =>
+  bytesNewestFirst.map((b) => ({ downloadedBytes: String(b) }));
+
+describe('isNoProgress', () => {
+  it('treats equal byte counts as no progress', () => {
+    expect(isNoProgress('1000', '1000')).toBe(true);
+  });
+
+  it('treats a sub-tolerance trickle as no progress', () => {
+    expect(isNoProgress('1000', String(1000 + MIB - 1))).toBe(true);
+  });
+
+  it('treats exactly one tolerance worth of bytes as progress', () => {
+    expect(isNoProgress('1000', String(1000 + MIB))).toBe(false);
+  });
+
+  it('treats a counter reset (negative delta) as progress', () => {
+    expect(isNoProgress(String(5 * MIB), '0')).toBe(false);
+  });
+
+  it('handles byte counts beyond Number.MAX_SAFE_INTEGER', () => {
+    const big = 2n ** 60n;
+    expect(isNoProgress(String(big), String(big + 5n))).toBe(true);
+    expect(
+      isNoProgress(String(big), String(big + STALL_PROGRESS_TOLERANCE_BYTES)),
+    ).toBe(false);
+  });
+});
+
+describe('countStalledStrikes', () => {
+  it('returns 0 with no snapshots', () => {
+    expect(countStalledStrikes([])).toBe(0);
+  });
+
+  it('counts a lone snapshot as 1 strike', () => {
+    expect(countStalledStrikes(samples(1000))).toBe(1);
+  });
+
+  it('counts N flat snapshots as N strikes', () => {
+    expect(countStalledStrikes(samples(1000, 1000, 1000, 1000))).toBe(4);
+  });
+
+  it('stops the run at the first progressing step', () => {
+    // Newest-first: flat, flat, then a 2 MiB jump older in the series.
+    expect(
+      countStalledStrikes(samples(5 * MIB, 5 * MIB, 5 * MIB, 3 * MIB)),
+    ).toBe(3);
+  });
+
+  it('returns 1 when the newest step shows progress', () => {
+    expect(countStalledStrikes(samples(5 * MIB, 3 * MIB, 3 * MIB))).toBe(1);
+  });
+
+  it('breaks the run on a counter reset', () => {
+    // Newest-first: 0 after a recheck reset from 5 MiB.
+    expect(countStalledStrikes(samples(0, 5 * MIB, 5 * MIB))).toBe(1);
+  });
+
+  it('tolerates a trickle inside the run', () => {
+    expect(
+      countStalledStrikes(samples(1000 + 2 * (MIB - 1), 1000 + (MIB - 1), 1000)),
+    ).toBe(3);
+  });
+});

--- a/backend/src/modules/scheduler/utils/stalled-progress.util.ts
+++ b/backend/src/modules/scheduler/utils/stalled-progress.util.ts
@@ -1,0 +1,67 @@
+/** A stall snapshot reduced to its bytes counter (bigint-as-string). */
+export interface ProgressSample {
+  downloadedBytes: string;
+}
+
+/**
+ * qBit raw states eligible for stall detection — states where download
+ * progress is expected, so a flat byte counter means the torrent is stuck.
+ * Everything else (paused/stopped/queued/checking/allocating/moving and
+ * every seeding-side state) makes no progress by design and must never be
+ * flagged. `error` and `missingFiles` go through the same stall window as
+ * the rest: a transient error (tracker down, disk briefly unmounted) gets
+ * the full window to recover before removal.
+ */
+export const STALL_ELIGIBLE_STATES: ReadonlySet<string> = new Set([
+  'downloading',
+  'forcedDL',
+  'stalledDL',
+  'metaDL',
+  'forcedMetaDL',
+  'error',
+  'missingFiles',
+]);
+
+/**
+ * Consecutive-snapshot delta below this counts as "no progress".
+ *
+ * 1 MiB tolerates the trickle of wasted bytes a stalled torrent keeps
+ * receiving from churning peers (re-requested / discarded pieces) without
+ * masking a genuinely progressing download: the shortest snapshot interval
+ * is 20 minutes, where even a crawling 10 KiB/s nets ~11 MiB per interval.
+ */
+export const STALL_PROGRESS_TOLERANCE_BYTES = 1n << 20n; // 1 MiB
+
+/**
+ * Whether the step from `olderBytes` to `newerBytes` counts as no progress.
+ *
+ * A negative delta means the client reset its `downloaded` counter (qBit
+ * does this on recheck) — treated as progress so the strike run restarts
+ * from the reset rather than counting the drop as a flat step.
+ */
+export function isNoProgress(olderBytes: string, newerBytes: string): boolean {
+  const delta = BigInt(newerBytes) - BigInt(olderBytes);
+  if (delta < 0n) return false;
+  return delta < STALL_PROGRESS_TOLERANCE_BYTES;
+}
+
+/**
+ * Run-length of trailing snapshots showing no progress, for samples ordered
+ * newest-first (DESC by `checkedAt`) — the order both call sites query in.
+ *
+ * A lone snapshot counts as 1 strike; N flat snapshots count as N. The
+ * stalled cleanup fires when the count reaches the profile's `samples`.
+ */
+export function countStalledStrikes(
+  samplesDescByCheckedAt: ProgressSample[],
+): number {
+  if (!samplesDescByCheckedAt.length) return 0;
+  let strikes = 1;
+  for (let i = 0; i + 1 < samplesDescByCheckedAt.length; i++) {
+    const newer = samplesDescByCheckedAt[i].downloadedBytes;
+    const older = samplesDescByCheckedAt[i + 1].downloadedBytes;
+    if (!isNoProgress(older, newer)) break;
+    strikes++;
+  }
+  return strikes;
+}

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -885,7 +885,12 @@
     "fstatus_importing": "Import en cours",
     "fstatus_imported": "Importé",
     "fstatus_quality_not_upgraded": "Qualité non améliorée",
-    "fstatus_import_failed": "Échec de l'import"
+    "fstatus_import_failed": "Échec de l'import",
+    "stall_strikes_tooltip": "Nettoyage : {{current}} sur {{required}} vérifications sans progression",
+    "search_another": "Chercher un autre torrent",
+    "search_no_target": "Impossible de déterminer la cible de recherche pour cet élément.",
+    "replacement_grabbed": "Remplacement récupéré — ancien torrent bloqué et supprimé",
+    "replacement_grabbed_block_failed": "Remplacement récupéré, mais la suppression de l'ancien torrent a échoué"
   },
   "tracking": {
     "menu_item": "Voir l'état du suivi",

--- a/client/src/app/core/services/api/download-clients-api.service.ts
+++ b/client/src/app/core/services/api/download-clients-api.service.ts
@@ -61,8 +61,13 @@ export interface QueueItem {
   seasonNumber?: number;
   episodeNumber?: number;
   episodeTitle?: string | null;
+  episodeId?: number;
+  seasonId?: number;
   indexerName?: string;
   statusMessage?: string;
+  /** Consecutive no-progress cleanup checks; removal fires at `stalledStrikesRequired`. */
+  stalledStrikes?: number;
+  stalledStrikesRequired?: number;
 }
 
 export interface QueueResult {

--- a/client/src/app/features/activity/queue/queue.html
+++ b/client/src/app/features/activity/queue/queue.html
@@ -69,7 +69,7 @@
               @if (item.mediaId) {
                 <a
                   [routerLink]="['/' + (item.mediaType === 'series' ? 'series' : 'movies'), item.mediaId]"
-                  class="font-medium text-sm leading-tight truncate text-primary hover:underline"
+                  class="block font-medium text-sm leading-tight truncate text-primary hover:underline"
                   [title]="item.name"
                 >{{ item.name }}</a>
                 @if (item.episodeNumber != null) {

--- a/client/src/app/features/activity/queue/queue.html
+++ b/client/src/app/features/activity/queue/queue.html
@@ -106,10 +106,26 @@
                   {{ fliksStatusLabel(item.status) }}
                 </span>
               }
+              @if (showStallStrikes(item)) {
+                <span
+                  class="badge badge-sm gap-1"
+                  [ngClass]="stallStrikeClass(item)"
+                  [title]="'activity.stall_strikes_tooltip' | translate:{ current: item.stalledStrikes, required: item.stalledStrikesRequired }"
+                >
+                  <svg lucideTriangleAlert class="h-3 w-3"></svg>
+                  {{ item.stalledStrikes }}/{{ item.stalledStrikesRequired }}
+                </span>
+              }
               <app-dropdown-menu placement="bottom-end">
                 <button trigger type="button" class="btn btn-ghost btn-xs btn-circle">
                   <svg lucideEllipsisVertical class="h-4 w-4"></svg>
                 </button>
+                @if (item.mediaId) {
+                  <button type="button" class="dropdown-item text-white" (click)="searchReplacement(item)">
+                    <svg lucideSearch class="h-4 w-4"></svg>
+                    {{ 'activity.search_another' | translate }}
+                  </button>
+                }
                 @if (item.status === 'Imported' || item.status === 'Quality not upgraded' || item.status === 'Import failed' || (!item.status && item.progress >= 1)) {
                   <button type="button" class="dropdown-item text-white" (click)="reimportAndTrigger(item)">
                     <svg lucideRotateCcw class="h-4 w-4"></svg>
@@ -274,3 +290,16 @@
   </div>
   <form method="dialog" class="modal-backdrop"><button>close</button></form>
 </dialog>
+
+<!-- Search a replacement release for a queue item -->
+<app-releases-modal #replacementModal
+  [title]="replacementTitle()"
+  [releases]="replacementReleases()"
+  [loading]="replacementLoading()"
+  [searched]="replacementSearched()"
+  [error]="replacementError()"
+  [grabBusy]="replacementGrabBusy()"
+  [grabState]="replacementGrabState()"
+  grabPrefix="rep"
+  (grab)="grabReplacement($event.release, $event.index)"
+/>

--- a/client/src/app/features/activity/queue/queue.ts
+++ b/client/src/app/features/activity/queue/queue.ts
@@ -20,6 +20,7 @@ import {
 import {
   MediaService,
   Media,
+  MovieRelease,
 } from '../../../core/services/api/media.service';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { ToastService } from '../../../core/services/toast.service';
@@ -36,10 +37,11 @@ import {
 import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 import { DropdownMenuComponent } from '../../../shared/components/dropdown-menu';
 import { PaginationComponent } from '../../../shared/components/pagination/pagination';
+import { ReleasesModalComponent } from '../../media-detail/components/releases-modal/releases-modal.component';
 
 @Component({
   selector: 'app-activity-queue',
-  imports: [TranslateModule, DecimalPipe, NgClass, RouterLink, FormsModule, ResolveUrlPipe, DropdownMenuComponent, PaginationComponent, LucideRotateCcw, LucideLink2, LucideEllipsisVertical, LucideTriangleAlert, LucideDownload, LucideSearch, LucideTrash2, LucideBan],
+  imports: [TranslateModule, DecimalPipe, NgClass, RouterLink, FormsModule, ResolveUrlPipe, DropdownMenuComponent, PaginationComponent, ReleasesModalComponent, LucideRotateCcw, LucideLink2, LucideEllipsisVertical, LucideTriangleAlert, LucideDownload, LucideSearch, LucideTrash2, LucideBan],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './queue.html',
 })
@@ -109,6 +111,32 @@ export class ActivityQueueComponent implements OnInit, OnDestroy {
   readonly linkSearching = signal(false);
   readonly linkSelectedMediaId = signal<number | null>(null);
   readonly linkSaving = signal(false);
+
+  // Replacement-release modal: searches the indexers for the same target as
+  // a queue item, so a stuck torrent can be swapped for another release.
+  private readonly replacementModal = viewChild<ReleasesModalComponent>('replacementModal');
+  readonly replacementItem = signal<QueueItem | null>(null);
+  readonly replacementReleases = signal<MovieRelease[]>([]);
+  readonly replacementLoading = signal(false);
+  readonly replacementSearched = signal(false);
+  readonly replacementError = signal('');
+  readonly replacementGrabBusy = signal<string | null>(null);
+  readonly replacementGrabState = signal<Map<string, 'ok' | 'error'>>(new Map());
+
+  readonly replacementTitle = computed(() => {
+    const it = this.replacementItem();
+    if (!it) return '';
+    const base = it.mediaTitle ?? it.name;
+    if (it.episodeNumber != null) {
+      const s = String(it.seasonNumber ?? 0).padStart(2, '0');
+      const e = String(it.episodeNumber).padStart(2, '0');
+      return `${base} — S${s}E${e}`;
+    }
+    if (it.seasonNumber != null) {
+      return `${base} — ${this.translate.instant('activity.season_pack', { season: it.seasonNumber })}`;
+    }
+    return base;
+  });
 
   private intervalId: ReturnType<typeof setInterval> | null = null;
 
@@ -234,6 +262,116 @@ export class ActivityQueueComponent implements OnInit, OnDestroy {
     } finally {
       this.linkSaving.set(false);
     }
+  }
+
+  async searchReplacement(item: QueueItem) {
+    if (!item.mediaId) return;
+    // Full reset so reopening for another item never shows stale results.
+    this.replacementItem.set(item);
+    this.replacementReleases.set([]);
+    this.replacementSearched.set(false);
+    this.replacementError.set('');
+    this.replacementGrabBusy.set(null);
+    this.replacementGrabState.set(new Map());
+    this.replacementLoading.set(true);
+    this.replacementModal()?.showModal();
+    try {
+      const rows = await this.loadReplacementReleases(item);
+      this.replacementReleases.set(rows);
+      this.replacementSearched.set(true);
+    } catch (err: unknown) {
+      const httpErr = err as { error?: { message?: string } };
+      this.replacementSearched.set(true);
+      this.replacementError.set(
+        httpErr.error?.message ??
+          this.translate.instant('media_detail.releases_error'),
+      );
+    } finally {
+      this.replacementLoading.set(false);
+    }
+  }
+
+  private loadReplacementReleases(item: QueueItem): Promise<MovieRelease[]> {
+    const mediaId = item.mediaId!;
+    if (item.mediaType === 'series') {
+      if (item.episodeId != null) {
+        return this.mediaService.getEpisodeReleases(mediaId, item.episodeId);
+      }
+      if (item.seasonId != null) {
+        return this.mediaService.getSeasonReleases(mediaId, item.seasonId);
+      }
+      // No episode/season scope resolved — searching the whole series could
+      // grab the wrong thing, so surface the error instead of guessing.
+      return Promise.reject({
+        error: { message: this.translate.instant('activity.search_no_target') },
+      });
+    }
+    return this.mediaService.getMovieReleases(mediaId);
+  }
+
+  async grabReplacement(r: MovieRelease, index: number) {
+    const item = this.replacementItem();
+    if (!item?.mediaId) return;
+    const key = `rep-${index}`;
+    this.replacementGrabBusy.set(key);
+    try {
+      await this.grabReplacementTarget(item, r);
+      this.replacementGrabState.update((s) => new Map(s).set(key, 'ok'));
+      // The replacement is grabbed — retire the stuck torrent without asking:
+      // blockTorrent removes it (files included), blocklists its release and
+      // marks the history failed. The scoped re-search it queues server-side
+      // no-ops since the target is no longer missing.
+      try {
+        await this.downloadApi.blockTorrent(item.hash, item.clientId);
+        this.queue.update((q) => q.filter((i) => i.hash !== item.hash));
+        this.toast.success(this.translate.instant('activity.replacement_grabbed'));
+      } catch {
+        this.toast.warning(
+          this.translate.instant('activity.replacement_grabbed_block_failed'),
+        );
+      }
+      await this.refreshQueue();
+    } catch {
+      this.replacementGrabState.update((s) => new Map(s).set(key, 'error'));
+    } finally {
+      this.replacementGrabBusy.set(null);
+    }
+  }
+
+  private grabReplacementTarget(item: QueueItem, r: MovieRelease): Promise<unknown> {
+    const mediaId = item.mediaId!;
+    const body = {
+      downloadUrl: r.downloadUrl,
+      sourceTitle: r.title,
+      indexerId: r.indexerId,
+    };
+    if (item.mediaType === 'series') {
+      if (item.episodeId != null) {
+        return this.mediaService.grabEpisode(mediaId, item.episodeId, body);
+      }
+      if (item.seasonId != null) {
+        return this.mediaService.grabSeason(mediaId, item.seasonId, body);
+      }
+      return Promise.reject(new Error('no replacement target'));
+    }
+    return this.mediaService.grabMovie(mediaId, body);
+  }
+
+  showStallStrikes(item: QueueItem): boolean {
+    // 1 strike is just the baseline snapshot — only surface the badge once
+    // at least one full interval has passed without progress.
+    return (
+      item.stalledStrikes != null &&
+      item.stalledStrikesRequired != null &&
+      item.stalledStrikes >= 2
+    );
+  }
+
+  /** Warning until the last check before cleanup, then error. */
+  stallStrikeClass(item: QueueItem): string {
+    const current = item.stalledStrikes ?? 0;
+    const required = item.stalledStrikesRequired ?? 0;
+    return current >= required - 1 ? 'badge-error' : 'badge-warning';
   }
 
   async refreshQueue(): Promise<void> {


### PR DESCRIPTION
## Summary

Four fixes/features around stuck downloads, from a full audit of the cleanup + activity pipeline:

### Cleanup reliability (backend)
- **Explicit stall-eligible state allowlist**: detection now covers `downloading`, `forcedDL`, `stalledDL`, `metaDL`, `forcedMetaDL`, `error`, `missingFiles` — and no longer flags `queuedDL`/`checking`/`allocating`/`moving` torrents, which make no progress by design.
- **Tolerant no-progress detection**: strict byte equality never fired on stalled torrents receiving a trickle of wasted bytes from churning peers; snapshots within 1 MiB now count as no progress (shared helper + unit spec, with a counter-reset guard for rechecks).
- **Three-tier history matching**: the cron used a hash-only lookup while the queue uses `TorrentHistoryMatcher`; grabs whose hash was never recovered at add time were invisible to cleanup. Both paths now share `matchAndHeal`.

### Activity queue (frontend + API)
- **Mobile overflow fix**: the linked release name was an inline anchor, so `truncate` never applied and the name overflowed under the badges/menu. It now renders as a block element.
- **Stall-strike badge**: monitored torrents show `x/N` cleanup checks without progress (warning → error one check before removal). Only shown from the second strike — the first snapshot is just the baseline. Backend exposes `stalledStrikes`/`stalledStrikesRequired` on the queue, computed per page with the same tolerance helper as the cron, gated to actively-monitored states, clamped to the profile target.
- **Search a replacement release**: new row action opens the releases modal for the exact same target (movie / episode / season pack via the newly exposed `episodeId`/`seasonId`). Grabbing a replacement automatically blocklists and removes the stuck torrent with its files.

## Test plan
- [x] Backend: `tsc --noEmit` clean, 151/151 jest tests pass (12 new for the tolerance/strike helper)
- [x] Client: `ng build` clean
- [ ] Manual: stalled torrent shows the strike badge progressing each interval, removed + blocklisted at N
- [ ] Manual: `queuedDL`/`checking` torrents are not cleaned
- [ ] Manual: mobile (<768px) release name truncates with ellipsis
- [ ] Manual: « Chercher un autre torrent » on a movie and an episode — grab swaps the torrent