### PR TITLE
fix(users): stop leaking password hashes in api responses

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,8 @@
 // Must be set before any I/O — libuv initializes the pool on first use.
 process.env.UV_THREADPOOL_SIZE = '16';
 
-import { NestFactory } from '@nestjs/core';
-import { ValidationPipe } from '@nestjs/common';
+import { NestFactory, Reflector } from '@nestjs/core';
+import { ClassSerializerInterceptor, ValidationPipe } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import { AppModule } from './app.module';
 import { LogBufferService } from './modules/scheduler/log-buffer.service';
@@ -79,6 +79,10 @@ async function bootstrap() {
       transform: true,
     }),
   );
+  // Honor class-transformer decorators (@Exclude on credential columns) on
+  // every entity instance a controller returns. Plain-object responses pass
+  // through unchanged; @Res()/SSE handlers bypass interceptors entirely.
+  app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
 
   const port = Number(process.env.PORT) || 4848;
   await app.listen(port);

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -137,10 +137,14 @@ export class AuthService {
     username: string,
     password: string,
   ): Promise<{ accessToken: string; user: PublicUser }> {
-    const user = await this.userRepo.findOne({
-      where: { username },
-      relations: ['userRole'],
-    });
+    // passwordHash is select:false on the entity — the bcrypt compare below
+    // is the one read path that must opt back in.
+    const user = await this.userRepo
+      .createQueryBuilder('user')
+      .addSelect('user.passwordHash')
+      .leftJoinAndSelect('user.userRole', 'userRole')
+      .where('user.username = :username', { username })
+      .getOne();
     if (!user?.passwordHash) {
       throw new UnauthorizedException('Invalid credentials');
     }

--- a/backend/src/modules/requests/requests.service.ts
+++ b/backend/src/modules/requests/requests.service.ts
@@ -341,8 +341,13 @@ export class RequestsService {
     const limit = query.limit ?? 25;
     const qb = this.requestRepo
       .createQueryBuilder('r')
-      .leftJoinAndSelect('r.user', 'user')
-      .leftJoinAndSelect('r.approvedBy', 'approvedBy')
+      // Embedded users are projected down to the public identity fields —
+      // the full User row carries credentials and account settings that
+      // don't belong in a request payload.
+      .leftJoin('r.user', 'user')
+      .addSelect(['user.id', 'user.username', 'user.avatar'])
+      .leftJoin('r.approvedBy', 'approvedBy')
+      .addSelect(['approvedBy.id', 'approvedBy.username', 'approvedBy.avatar'])
       // Resolve the linked library media by (tmdbId, type) rather than the
       // request's FK so partial-library titles (another user's request
       // already brought it in, or only some seasons are present) surface a
@@ -385,7 +390,26 @@ export class RequestsService {
     if (!this.canManageRequests(user) && row.userId !== user.id) {
       throw new ForbiddenException();
     }
+    row.user = this.toPublicIdentity(row.user) as User;
+    row.approvedBy = this.toPublicIdentity(row.approvedBy) as User | null;
+    row.comments?.forEach((c) => {
+      c.user = this.toPublicIdentity(c.user) as User;
+    });
     return row;
+  }
+
+  /**
+   * Projects an embedded User down to its public identity. Request payloads
+   * expose who acted, never the account itself — and a nested FindOptions
+   * `select` can't enforce this because eager relations hydrate all columns
+   * regardless.
+   */
+  private toPublicIdentity(
+    user: User | null,
+  ): Pick<User, 'id' | 'username' | 'avatar'> | null {
+    if (!user) return null;
+    const { id, username, avatar } = user;
+    return { id, username, avatar };
   }
 
   async update(
@@ -605,11 +629,15 @@ export class RequestsService {
     if (!this.canManageRequests(user) && request.userId !== user.id) {
       throw new ForbiddenException();
     }
-    return this.commentRepo.find({
+    const comments = await this.commentRepo.find({
       where: { request: { id: requestId } },
       relations: ['user'],
       order: { createdAt: 'ASC' },
     });
+    comments.forEach((c) => {
+      c.user = this.toPublicIdentity(c.user) as User;
+    });
+    return comments;
   }
 
   async removeComment(commentId: number, user: User): Promise<void> {
@@ -625,4 +653,3 @@ export class RequestsService {
     await this.commentRepo.remove(comment);
   }
 }
-

--- a/backend/src/modules/users/entities/user.entity.spec.ts
+++ b/backend/src/modules/users/entities/user.entity.spec.ts
@@ -1,0 +1,90 @@
+import 'reflect-metadata';
+import { readdirSync } from 'fs';
+import { join } from 'path';
+import { getMetadataArgsStorage } from 'typeorm';
+import { instanceToPlain } from 'class-transformer';
+import { User } from './user.entity';
+
+/**
+ * Credential columns must never reach an API response. The contract is
+ * two-layered: `select: false` keeps the value out of every default load,
+ * and `@Exclude` makes the global ClassSerializerInterceptor strip it from
+ * any instance that was loaded explicitly. This spec enforces the contract
+ * on every entity in the app, so adding a password column without both
+ * locks fails CI.
+ */
+
+/** Imports every entity file so its decorators register their metadata. */
+function loadAllEntities(dir: string): void {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      loadAllEntities(full);
+    } else if (entry.name.endsWith('.entity.ts')) {
+      // The decorators only register on import; a static list would silently
+      // skip newly added entities.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require(full);
+    }
+  }
+}
+loadAllEntities(join(__dirname, '../../..'));
+
+// Restricted to `password` on purpose: `hash`/`token` would flag
+// RefreshToken.tokenHash, which is a server-side lookup key that never
+// serializes raw (auth responses are hand-mapped DTOs).
+const SENSITIVE = /password/i;
+
+// Name-matches the pattern but holds no secret material.
+const NON_CREDENTIAL = new Set(['User.requirePasswordChange']);
+
+describe('credential column hardening', () => {
+  const sensitiveColumns = getMetadataArgsStorage().columns.filter(
+    (c) =>
+      SENSITIVE.test(c.propertyName) &&
+      !NON_CREDENTIAL.has(
+        `${(c.target as { name?: string }).name}.${c.propertyName}`,
+      ),
+  );
+
+  it('covers User.passwordHash', () => {
+    expect(
+      sensitiveColumns.some(
+        (c) => c.target === User && c.propertyName === 'passwordHash',
+      ),
+    ).toBe(true);
+  });
+
+  it('every password column is select: false', () => {
+    const offenders = sensitiveColumns
+      .filter((c) => c.options?.select !== false)
+      .map((c) => `${(c.target as { name?: string }).name}.${c.propertyName}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it('every password column is stripped by serialization', () => {
+    const offenders = sensitiveColumns
+      .filter((c) => {
+        const instance = new (c.target as new () => object)();
+        (instance as Record<string, unknown>)[c.propertyName] =
+          'sentinel-secret-value';
+        return JSON.stringify(instanceToPlain(instance)).includes(
+          'sentinel-secret-value',
+        );
+      })
+      .map((c) => `${(c.target as { name?: string }).name}.${c.propertyName}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it('a serialized User carries no passwordHash', () => {
+    const user = new User();
+    Object.assign(user, {
+      id: 1,
+      username: 'someone',
+      passwordHash: '$2b$12$secret-hash-value',
+    });
+    const plain = instanceToPlain(user);
+    expect(plain).not.toHaveProperty('passwordHash');
+    expect(JSON.stringify(plain)).not.toContain('secret-hash-value');
+  });
+});

--- a/backend/src/modules/users/entities/user.entity.ts
+++ b/backend/src/modules/users/entities/user.entity.ts
@@ -1,4 +1,5 @@
 import { Entity, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { Exclude } from 'class-transformer';
 import { BaseEntity } from '../../../common/entities/base.entity';
 import { MediaServerType } from '../../../common/enums';
 import { Role } from '../../roles/entities/role.entity';
@@ -11,7 +12,14 @@ export class User extends BaseEntity {
   @Column({ nullable: true })
   email: string;
 
-  @Column({ nullable: true })
+  /**
+   * Bcrypt hash. Double-locked against leaking through API responses:
+   * `select: false` keeps it out of every default load (readers must
+   * `addSelect` it explicitly), and `@Exclude` strips it from any User
+   * instance that still reaches the global ClassSerializerInterceptor.
+   */
+  @Column({ nullable: true, select: false })
+  @Exclude()
   passwordHash: string;
 
   @Column({ nullable: true })


### PR DESCRIPTION
## Problem

Every `/api/requests` endpoint returned raw TypeORM entities whose eager `user` / `approvedBy` / `comments.user` relations carried the full `User` row — including the bcrypt `passwordHash`, email, quotas and account flags. The home page hits `GET /api/requests?limit=12` on every render, so any logged-in user received their own hash (and managers received every requester's and approver's hash in one response).

Root cause: `User.passwordHash` was a bare `@Column` with no `select:false` and no `@Exclude`, and no `ClassSerializerInterceptor` was registered — nothing between a loaded entity and the JSON response.

## Fix (layered)

1. **DB layer** — `select: false` on the column: the hash never loads unless explicitly requested. The only runtime reader (the login bcrypt compare) now opts back in via `addSelect`. All other usages are writes, which are unaffected (TypeORM omits undefined props from UPDATEs).
2. **Serialization layer** — `@Exclude()` on the column + a global `ClassSerializerInterceptor`: any User instance that still reaches a response (e.g. the in-memory authenticated user attached on create) is stripped. `@Res()`/SSE handlers bypass interceptors, POJO responses pass through unchanged.
3. **Payload narrowing** — request payloads now project embedded users down to `id`/`username`/`avatar` (the only fields the client consumes): `findAll` via `leftJoin`+`addSelect`, `findOne`/`getComments` via an explicit projection (a nested FindOptions `select` is ignored for eager relations).
4. **Regression guard** — a spec sweeps every entity's column metadata: any `/password/i` column missing either lock fails CI, and a serialized `User` is asserted hash-free.

## Verification

- `npm test`: 19 suites / 143 tests green (includes the new guard spec).
- `npm run build` green.
- Verified against the dev DB (read-only script): default user loads and both request query shapes carry no `passwordHash`; the login query builder returns it; `findAll` embedded users contain exactly `id,username,avatar`.

## Out of scope

Admin-gated connector credentials (indexer/media-server api keys, download-client and notification secrets) are returned in clear to admins by design today; masking them needs write-only settings-form semantics and is deliberately not part of this fix.