### PR TITLE
perf(layout): replace home queue fetch with a counts endpoint

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -25,6 +25,7 @@ import { PersonsModule } from './modules/persons/persons.module';
 import { ImageModule } from './modules/images/image.module';
 import { ImportsModule } from './modules/imports/imports.module';
 import { SetupChecklistModule } from './modules/setup-checklist/setup-checklist.module';
+import { CountsModule } from './modules/counts/counts.module';
 import { CommonModule } from './common/common.module';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
@@ -97,6 +98,7 @@ import { join } from 'path';
     MarkersModule,
     ImportsModule,
     SetupChecklistModule,
+    CountsModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/modules/counts/counts.controller.ts
+++ b/backend/src/modules/counts/counts.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { CountsService } from './counts.service';
+import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { User } from '../users/entities/user.entity';
+
+/**
+ * Badge counts for the app shell. Auth-only on purpose: each count applies
+ * its own ability check inside the service (a user without download-clients
+ * read simply gets 0), so one endpoint serves every role.
+ */
+@Controller('counts')
+@UseGuards(JwtOrApiKeyGuard)
+export class CountsController {
+  constructor(private readonly counts: CountsService) {}
+
+  @Get()
+  get(@CurrentUser() user: User) {
+    return this.counts.getCounts(user);
+  }
+}

--- a/backend/src/modules/counts/counts.module.ts
+++ b/backend/src/modules/counts/counts.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DownloadHistory } from '../media/entities/download-history.entity';
+import { FliksRequest } from '../requests/entities/request.entity';
+import { CountsService } from './counts.service';
+import { CountsController } from './counts.controller';
+import { AuthModule } from '../auth/auth.module';
+import { MediaModule } from '../media/media.module';
+import { LibrariesModule } from '../libraries/libraries.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([DownloadHistory, FliksRequest]),
+    AuthModule,
+    MediaModule,
+    LibrariesModule,
+  ],
+  controllers: [CountsController],
+  providers: [CountsService],
+})
+export class CountsModule {}

--- a/backend/src/modules/counts/counts.service.spec.ts
+++ b/backend/src/modules/counts/counts.service.spec.ts
@@ -1,0 +1,94 @@
+import { CountsService } from './counts.service';
+import type { User } from '../users/entities/user.entity';
+import { DownloadClient } from '../download-clients/entities/download-client.entity';
+import { FliksRequest } from '../requests/entities/request.entity';
+import { Action } from '../auth/casl/actions.enum';
+
+describe('CountsService.getCounts', () => {
+  const user = { id: 7 } as User;
+
+  function make(opts: {
+    canReadDownloadClient: boolean;
+    canManageRequests: boolean;
+  }) {
+    const historyRepo = { count: jest.fn().mockResolvedValue(3) };
+    const requestRepo = { count: jest.fn().mockResolvedValue(5) };
+    const ability = {
+      can: jest.fn((action: Action, subject: unknown) => {
+        if (subject === DownloadClient) return opts.canReadDownloadClient;
+        if (subject === FliksRequest) return opts.canManageRequests;
+        return false;
+      }),
+    };
+    const caslAbilityFactory = { createForUser: jest.fn().mockReturnValue(ability) };
+    const mediaService = {
+      getCountsByLibrary: jest.fn().mockResolvedValue({ 1: 10, 2: 20 }),
+    };
+    const libraries = {
+      getAccessibleLibraryIds: jest.fn().mockResolvedValue([1, 2]),
+    };
+    const service = new CountsService(
+      historyRepo as never,
+      requestRepo as never,
+      caslAbilityFactory as never,
+      mediaService as never,
+      libraries as never,
+    );
+    return { service, historyRepo, requestRepo, mediaService, libraries };
+  }
+
+  it('counts active queue rows for a user who can read download clients', async () => {
+    const { service, historyRepo } = make({
+      canReadDownloadClient: true,
+      canManageRequests: false,
+    });
+    const counts = await service.getCounts(user);
+    expect(counts.queueActive).toBe(3);
+    const where = historyRepo.count.mock.calls[0][0].where as {
+      status: { value: string[] };
+    };
+    expect(where.status.value).toEqual(['grabbed', 'importing']);
+  });
+
+  it('returns 0 queue items without the download-clients read ability, without querying', async () => {
+    const { service, historyRepo } = make({
+      canReadDownloadClient: false,
+      canManageRequests: false,
+    });
+    const counts = await service.getCounts(user);
+    expect(counts.queueActive).toBe(0);
+    expect(historyRepo.count).not.toHaveBeenCalled();
+  });
+
+  it('scopes pending requests to the user when they cannot manage requests', async () => {
+    const { service, requestRepo } = make({
+      canReadDownloadClient: true,
+      canManageRequests: false,
+    });
+    await service.getCounts(user);
+    expect(requestRepo.count).toHaveBeenCalledWith({
+      where: expect.objectContaining({ user: { id: 7 } }) as object,
+    });
+  });
+
+  it('counts all pending requests for a manager', async () => {
+    const { service, requestRepo } = make({
+      canReadDownloadClient: true,
+      canManageRequests: true,
+    });
+    await service.getCounts(user);
+    const where = requestRepo.count.mock.calls[0][0].where as object;
+    expect(where).not.toHaveProperty('user');
+  });
+
+  it('passes the accessible library ids through to the media counts', async () => {
+    const { service, mediaService, libraries } = make({
+      canReadDownloadClient: true,
+      canManageRequests: false,
+    });
+    const counts = await service.getCounts(user);
+    expect(libraries.getAccessibleLibraryIds).toHaveBeenCalledWith(user);
+    expect(mediaService.getCountsByLibrary).toHaveBeenCalledWith([1, 2]);
+    expect(counts.mediaByLibrary).toEqual({ 1: 10, 2: 20 });
+  });
+});

--- a/backend/src/modules/counts/counts.service.ts
+++ b/backend/src/modules/counts/counts.service.ts
@@ -1,0 +1,91 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { DownloadHistory } from '../media/entities/download-history.entity';
+import { FliksRequest } from '../requests/entities/request.entity';
+import { DownloadClient } from '../download-clients/entities/download-client.entity';
+import { User } from '../users/entities/user.entity';
+import { RequestStatus } from '../../common/enums';
+import {
+  AppAbility,
+  CaslAbilityFactory,
+} from '../auth/casl/casl-ability.factory';
+import { Action } from '../auth/casl/actions.enum';
+import { MediaService } from '../media/media.service';
+import { LibrariesService } from '../libraries/libraries.service';
+
+export interface SidebarCounts {
+  queueActive: number;
+  pendingRequests: number;
+  mediaByLibrary: Record<number, number>;
+}
+
+/**
+ * Aggregated badge counts for the app shell, in one round-trip. Every count
+ * is a plain DB aggregate — in particular the queue count reads the download
+ * history instead of fanning out to the live download clients, which is what
+ * makes this endpoint cheap enough to refresh on every SSE event.
+ */
+@Injectable()
+export class CountsService {
+  constructor(
+    @InjectRepository(DownloadHistory)
+    private readonly historyRepo: Repository<DownloadHistory>,
+    @InjectRepository(FliksRequest)
+    private readonly requestRepo: Repository<FliksRequest>,
+    private readonly caslAbilityFactory: CaslAbilityFactory,
+    private readonly mediaService: MediaService,
+    private readonly libraries: LibrariesService,
+  ) {}
+
+  async getCounts(user: User): Promise<SidebarCounts> {
+    const ability = this.caslAbilityFactory.createForUser(user);
+    const [queueActive, pendingRequests, mediaByLibrary] = await Promise.all([
+      this.countActiveQueue(ability),
+      this.countPendingRequests(user, ability),
+      this.countMediaByLibrary(user),
+    ]);
+    return { queueActive, pendingRequests, mediaByLibrary };
+  }
+
+  /**
+   * Downloads still doing work, from the history table. `grabbed` and
+   * `importing` are the states the queue badge counts; `warning` maps to
+   * "Quality not upgraded" and `failed`/`completed` are terminal, all three
+   * excluded from the badge. Unlike the live queue, history can't see
+   * client-side error states (tracker error, missing files), so a torrent
+   * erroring at the client stays counted until its row turns terminal — a
+   * transient over-count accepted in exchange for skipping the live fan-out.
+   */
+  private async countActiveQueue(ability: AppAbility): Promise<number> {
+    if (!ability.can(Action.Read, DownloadClient)) return 0;
+    return this.historyRepo.count({
+      where: { status: In(['grabbed', 'importing']) },
+    });
+  }
+
+  /** Same scoping as RequestsService.findAll: managers count everything,
+   *  other users count their own pending requests. */
+  private async countPendingRequests(
+    user: User,
+    ability: AppAbility,
+  ): Promise<number> {
+    const canManage = ability.can(Action.Manage, FliksRequest);
+    // userId is a @RelationId (not a queryable column) — scope through the
+    // relation instead.
+    return this.requestRepo.count({
+      where: {
+        status: RequestStatus.PENDING,
+        ...(canManage ? {} : { user: { id: user.id } }),
+      },
+    });
+  }
+
+  private async countMediaByLibrary(
+    user: User,
+  ): Promise<Record<number, number>> {
+    const accessibleLibraryIds =
+      await this.libraries.getAccessibleLibraryIds(user);
+    return this.mediaService.getCountsByLibrary(accessibleLibraryIds);
+  }
+}

--- a/client/src/app/core/services/api/counts-api.service.ts
+++ b/client/src/app/core/services/api/counts-api.service.ts
@@ -1,0 +1,22 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+
+export interface SidebarCounts {
+  /** Downloads still doing work (grabbed / importing), from the history table. */
+  queueActive: number;
+  /** Pending requests visible to the user (own only without requests.manage). */
+  pendingRequests: number;
+  /** Media count per accessible library id. */
+  mediaByLibrary: Record<number, number>;
+}
+
+/** Aggregated badge counts for the app shell, one round-trip for the sidebar. */
+@Injectable({ providedIn: 'root' })
+export class CountsApiService {
+  private readonly http = inject(HttpClient);
+
+  get() {
+    return firstValueFrom(this.http.get<SidebarCounts>('/api/counts'));
+  }
+}

--- a/client/src/app/shared/layout/layout.ts
+++ b/client/src/app/shared/layout/layout.ts
@@ -16,10 +16,8 @@ import { Capacitor, registerPlugin } from '@capacitor/core';
 import { Keyboard } from '@capacitor/keyboard';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { AuthService } from '../../core/services/auth.service';
-import { MediaService } from '../../core/services/api/media.service';
 import { LibrariesApiService, LibrarySummary } from '../../core/services/api/libraries-api.service';
-import { DownloadClientsApiService, QueueItem } from '../../core/services/api/download-clients-api.service';
-import { RequestsService } from '../../core/services/api/requests.service';
+import { CountsApiService } from '../../core/services/api/counts-api.service';
 import { ServerCacheService } from '../../core/services/server-cache.service';
 import { ServerConfigService } from '../../core/services/server-config.service';
 import { SseService } from '../../core/services/sse.service';
@@ -74,10 +72,8 @@ import {
 export class LayoutComponent implements OnInit, OnDestroy {
   readonly auth = inject(AuthService);
   private readonly router = inject(Router);
-  private readonly mediaService = inject(MediaService);
   private readonly librariesApi = inject(LibrariesApiService);
-  private readonly downloadApi = inject(DownloadClientsApiService);
-  private readonly requestsService = inject(RequestsService);
+  private readonly countsApi = inject(CountsApiService);
   readonly serverConfig = inject(ServerConfigService);
   private readonly serverCache = inject(ServerCacheService);
   private readonly sse = inject(SseService);
@@ -156,15 +152,10 @@ export class LayoutComponent implements OnInit, OnDestroy {
       // receives them), so library counts ride the broadcast queue.updated that
       // follows every import — otherwise non-requesters' sidebars go stale.
       case 'queue.updated':
-        this.refreshMediaCounts();
-        this.refreshQueueCount();
-        break;
       case 'stalled.removed':
-        this.refreshQueueCount();
-        break;
       case 'request.approved':
       case 'request.declined':
-        this.refreshRequestCount();
+        this.refreshSidebarCounts();
         break;
     }
   });
@@ -227,34 +218,27 @@ export class LayoutComponent implements OnInit, OnDestroy {
 
   async refreshCounts() {
     try {
-      const [libs, counts, queue, requests] = await Promise.all([
+      const [libs, counts] = await Promise.all([
         this.librariesApi.listMine(),
-        this.mediaService.getCountsByLibrary(),
-        this.downloadApi.getQueue({ pageSize: 100 }),
-        this.requestsService.list({ status: 'pending', limit: 1 }),
+        this.countsApi.get(),
       ]);
       this.libraries.set(libs);
-      this.libraryCounts.set(counts);
-      this.queueCount.set(queue.items.filter((q) => this.isActiveDownload(q)).length);
-      this.pendingRequestCount.set(requests.total);
+      this.libraryCounts.set(counts.mediaByLibrary);
+      this.queueCount.set(counts.queueActive);
+      this.pendingRequestCount.set(counts.pendingRequests);
     } catch {
       // silently ignore — counts are non-critical
     }
   }
 
-  /** Sidebar badge counts only torrents still doing work — excludes the
-   *  terminal Fliks states (imported, failed, quality-not-upgraded) and the
-   *  download-client error states (error, missing files). */
-  private isActiveDownload(q: QueueItem): boolean {
-    const doneStatuses = ['Imported', 'Import failed', 'Quality not upgraded'];
-    const errorTracker = ['Error', 'Missing files'];
-    return !doneStatuses.includes(q.status) && !errorTracker.includes(q.trackerStatus);
-  }
-
-  private async refreshMediaCounts() {
+  /** Refreshes the badge counts only (no library list re-fetch) — the SSE
+   *  handlers ride this for every count-bearing event. */
+  private async refreshSidebarCounts() {
     try {
-      const counts = await this.mediaService.getCountsByLibrary();
-      this.libraryCounts.set(counts);
+      const counts = await this.countsApi.get();
+      this.libraryCounts.set(counts.mediaByLibrary);
+      this.queueCount.set(counts.queueActive);
+      this.pendingRequestCount.set(counts.pendingRequests);
     } catch { /* ignore */ }
   }
 
@@ -265,20 +249,6 @@ export class LayoutComponent implements OnInit, OnDestroy {
   /** Icon key for a library: explicit icon > default 'library'. */
   libraryIcon(lib: LibrarySummary): string {
     return lib.icon || 'library';
-  }
-
-  private async refreshQueueCount() {
-    try {
-      const queue = await this.downloadApi.getQueue({ pageSize: 100 });
-      this.queueCount.set(queue.items.filter((q) => this.isActiveDownload(q)).length);
-    } catch { /* ignore */ }
-  }
-
-  private async refreshRequestCount() {
-    try {
-      const requests = await this.requestsService.list({ status: 'pending', limit: 1 });
-      this.pendingRequestCount.set(requests.total);
-    } catch { /* ignore */ }
   }
 
 


### PR DESCRIPTION
## Problem

`LayoutComponent.refreshCounts()` fetched the full download queue (`GET /download-clients/queue?pageSize=100`) on every app-shell load and on every `queue.updated` SSE event — solely to count active items for the sidebar badge. The queue endpoint fans out **live** to every enabled download client (fresh login + torrent listing, 15 s timeout each), loads all non-terminal download history with 4 eager relations and runs match-and-heal per torrent. With many items this stalls the home load for seconds. The shell also issued a paginated `GET /api/requests?status=pending` just for its `total`.

## Change

**Backend** — new `GET /api/counts` (`CountsModule`, no contact with the download-clients module): three plain DB aggregates in one round-trip, each gated per-field by the caller's CASL abilities:
- `queueActive`: `COUNT(*)` of history rows in `grabbed`/`importing` (`warning` maps to "Quality not upgraded" and is excluded, matching the old badge filter). Returns 0 without the download-clients read ability. Documented drift: history can't see client-side error states, so an erroring torrent stays counted until its row turns terminal — accepted in exchange for dropping the live fan-out.
- `pendingRequests`: same scoping as the requests list (managers count all, others their own).
- `mediaByLibrary`: reuses `MediaService.getCountsByLibrary` with the user's accessible libraries.

**Client** — `refreshCounts()` drops the queue and requests calls (4 requests → 2); the three SSE refreshers collapse into one `refreshSidebarCounts()` hitting `/api/counts`. Deliberately not SWR-cached: it's live badge data refreshed by SSE.

## Verification

- New `counts.service.spec.ts` (5 tests): ability gating (no DownloadClient read → 0 without querying), manager vs scoped request counts, accessible-library pass-through. Full backend suite + build green; client `ng build` green.
- Live smoke against the dev DB (ephemeral boot on :4849): admin gets `{"queueActive":0,"pendingRequests":2,"mediaByLibrary":{"5":669,"6":167}}`, non-manager gets own-scoped zeros — both cross-checked against the tables. Caught and fixed a real bug this way: `userId` is a `@RelationId`, not a queryable column — scoping goes through `user: { id }`.

The Activity queue page and its polling are untouched — only the shell badge stops hitting the live queue.