### PR TITLE
perf(requests): serve request card art from the local image pipeline

### DIFF
--- a/backend/src/migrations/1779700000000-add-request-poster-fanart-urls.ts
+++ b/backend/src/migrations/1779700000000-add-request-poster-fanart-urls.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Local card art for requests: poster/fanart API paths stored at creation
+ * so request cards render from the cached image pipeline instead of
+ * fetching metadata + the TMDB CDN per card. Nullable — requests created
+ * before this migration keep the client-side metadata fallback.
+ */
+export class AddRequestPosterFanartUrls1779700000000
+  implements MigrationInterface
+{
+  name = 'AddRequestPosterFanartUrls1779700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "requests"
+        ADD COLUMN IF NOT EXISTS "posterUrl" text,
+        ADD COLUMN IF NOT EXISTS "fanartUrl" text
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "requests"
+        DROP COLUMN IF EXISTS "posterUrl",
+        DROP COLUMN IF EXISTS "fanartUrl"
+    `);
+  }
+}

--- a/backend/src/modules/images/image.controller.ts
+++ b/backend/src/modules/images/image.controller.ts
@@ -49,7 +49,7 @@ export class ImageController {
     sizeRaw: string | undefined,
     res: Response,
   ) {
-    const validTypes = ['media', 'person', 'episode', 'season'];
+    const validTypes = ['media', 'person', 'episode', 'season', 'request'];
     if (!validTypes.includes(type)) throw new NotFoundException();
 
     const size: ImageSize = (VALID_SIZES as string[]).includes(sizeRaw ?? '')

--- a/backend/src/modules/images/image.service.ts
+++ b/backend/src/modules/images/image.service.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import * as fs from 'fs';
 import * as path from 'path';
 
-export type ImageType = 'media' | 'person' | 'episode' | 'season';
+export type ImageType = 'media' | 'person' | 'episode' | 'season' | 'request';
 /** Variant of a media image. `fanart-${N}` (N≥1) addresses the extra
  *  fanarts kept for randomised page backgrounds — they share `fanart`'s
  *  size pipeline (thumb / medium / full) so frontends can request any
@@ -25,6 +25,10 @@ export type ImageSize = 'thumb' | 'medium' | 'full';
 const TMDB_SIZE_MAP: Record<string, Partial<Record<ImageSize, string>>> = {
   'media/poster': { thumb: 'w185', medium: 'w500', full: 'original' },
   'media/fanart': { thumb: 'w300', medium: 'w780', full: 'original' },
+  // Request card art — keyed by tmdbId (not a media id), so every request
+  // for the same title shares one stored file.
+  'request/poster': { thumb: 'w185', medium: 'w500', full: 'original' },
+  'request/fanart': { thumb: 'w300', medium: 'w780', full: 'original' },
   person: { thumb: 'w45', full: 'original' },
   episode: { thumb: 'w300', full: 'original' },
   season: { thumb: 'w185', medium: 'w500', full: 'original' },
@@ -33,11 +37,11 @@ const TMDB_SIZE_MAP: Record<string, Partial<Record<ImageSize, string>>> = {
 const TMDB_HOST = /^https?:\/\/image\.tmdb\.org\//;
 
 function sizeMapKey(type: ImageType, variant?: MediaImageVariant): string {
-  if (type === 'media') {
+  if (type === 'media' || type === 'request') {
     const v = variant ?? 'poster';
     // Indexed fanarts share the parent `fanart` size pipeline.
     const base = /^fanart-\d+$/.test(v) ? 'fanart' : v;
-    return `media/${base}`;
+    return `${type}/${base}`;
   }
   return type;
 }
@@ -131,11 +135,11 @@ export class ImageService {
    * Delete all images (every size) for a given entity.
    */
   deleteImages(type: ImageType, id: number): void {
-    if (type === 'media') {
-      fs.rmSync(path.join(this.baseDir, 'media', String(id)), {
-        recursive: true,
-        force: true,
-      });
+    if (type === 'media' || type === 'request') {
+      fs.rmSync(
+        path.join(this.baseDir, type === 'media' ? 'media' : 'requests', String(id)),
+        { recursive: true, force: true },
+      );
       return;
     }
 
@@ -168,6 +172,13 @@ export class ImageService {
           String(id),
           `${variant ?? 'poster'}${suffix}.jpg`,
         );
+      case 'request':
+        return path.join(
+          this.baseDir,
+          'requests',
+          String(id),
+          `${variant ?? 'poster'}${suffix}.jpg`,
+        );
       case 'person':
         return path.join(this.baseDir, 'persons', `${id}${suffix}.jpg`);
       case 'episode':
@@ -175,6 +186,11 @@ export class ImageService {
       case 'season':
         return path.join(this.baseDir, 'seasons', `${id}${suffix}.jpg`);
     }
+  }
+
+  /** Whether the full-size file for (type, id, variant) is already stored. */
+  hasImage(type: ImageType, id: number, variant?: MediaImageVariant): boolean {
+    return fs.existsSync(this.getDiskPath(type, id, variant));
   }
 
   /**
@@ -185,6 +201,8 @@ export class ImageService {
     switch (type) {
       case 'media':
         return `/api/images/media/${id}/${variant ?? 'poster'}`;
+      case 'request':
+        return `/api/images/request/${id}/${variant ?? 'poster'}`;
       case 'person':
         return `/api/images/person/${id}`;
       case 'episode':

--- a/backend/src/modules/requests/entities/request.entity.ts
+++ b/backend/src/modules/requests/entities/request.entity.ts
@@ -82,6 +82,18 @@ export class FliksRequest extends BaseEntity {
   @Column({ type: 'jsonb', nullable: true })
   seasons: number[] | null;
 
+  /**
+   * Local card art (`/api/images/request/{tmdbId}/...`), stored at creation
+   * so cards render from the cached image pipeline without a metadata
+   * round-trip. Null when the download failed or the request predates local
+   * request art — the client falls back to the metadata lookup.
+   */
+  @Column({ type: 'text', nullable: true })
+  posterUrl: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  fanartUrl: string | null;
+
   @OneToMany(() => RequestComment, (comment) => comment.request, {
     cascade: true,
   })

--- a/backend/src/modules/requests/requests.module.ts
+++ b/backend/src/modules/requests/requests.module.ts
@@ -9,6 +9,8 @@ import { SettingsModule } from '../settings/settings.module';
 import { MediaModule } from '../media/media.module';
 import { ProfilesModule } from '../profiles/profiles.module';
 import { FliksSchedulerModule } from '../scheduler/scheduler.module';
+import { ImageModule } from '../images/image.module';
+import { MetadataProvidersModule } from '../metadata-providers/metadata-providers.module';
 import { RequestsService } from './requests.service';
 import { RequestLifecycleService } from './request-lifecycle.service';
 import { RequestsController } from './requests.controller';
@@ -29,6 +31,10 @@ import { AutoApprovalRulesController } from './auto-approval-rules.controller';
     // which already imports RequestsModule via forwardRef — defensive to
     // avoid the cycle resolver throwing on a clean cold boot.
     forwardRef(() => FliksSchedulerModule),
+    // Local request-card art stored at creation (ImageService) from the
+    // provider's TMDB URLs (TmdbProvider).
+    ImageModule,
+    MetadataProvidersModule,
   ],
   controllers: [RequestsController, AutoApprovalRulesController],
   providers: [RequestsService, RequestLifecycleService],

--- a/backend/src/modules/requests/requests.service.ts
+++ b/backend/src/modules/requests/requests.service.ts
@@ -1,5 +1,6 @@
 import {
   Injectable,
+  Logger,
   NotFoundException,
   ForbiddenException,
   ConflictException,
@@ -28,6 +29,8 @@ import { ProfilesService } from '../profiles/profiles.service';
 import { SchedulerService } from '../scheduler/scheduler.service';
 import { CaslAbilityFactory } from '../auth/casl/casl-ability.factory';
 import { Action } from '../auth/casl/actions.enum';
+import { ImageService } from '../images/image.service';
+import { TmdbProvider } from '../metadata-providers/providers/tmdb.provider';
 import {
   ACTIVE_REQUEST_STATUSES,
   SATISFIABLE_REQUEST_STATUSES,
@@ -53,7 +56,11 @@ export class RequestsService {
     private readonly profilesService: ProfilesService,
     private readonly scheduler: SchedulerService,
     private readonly caslAbilityFactory: CaslAbilityFactory,
+    private readonly imageService: ImageService,
+    private readonly tmdb: TmdbProvider,
   ) {}
+
+  private readonly logger = new Logger(RequestsService.name);
 
   /** Aligné sur PoliciesGuard / CaslAbilityFactory (manage:all → Manage sur tout). */
   private canManageRequests(user: User): boolean {
@@ -219,7 +226,77 @@ export class RequestsService {
       mediaType: dto.mediaType,
     });
 
+    await this.populateRequestArt(saved);
+
     return saved;
+  }
+
+  /**
+   * Stores the title's poster/fanart through the local image pipeline and
+   * stamps their API paths on the request, so cards render from the cached
+   * `/api/images` endpoint instead of fetching metadata + the TMDB CDN per
+   * card. Art is keyed by tmdbId: requests for the same title share files,
+   * and a repeat request skips the network entirely. Best-effort — any
+   * failure leaves the columns null and the client falls back to the
+   * metadata lookup.
+   */
+  private async populateRequestArt(row: FliksRequest): Promise<void> {
+    try {
+      let posterUrl: string | null = null;
+      let fanartUrl: string | null = null;
+
+      const hasPoster = this.imageService.hasImage(
+        'request',
+        row.tmdbId,
+        'poster',
+      );
+      const hasFanart = this.imageService.hasImage(
+        'request',
+        row.tmdbId,
+        'fanart',
+      );
+      if (hasPoster || hasFanart) {
+        posterUrl = hasPoster
+          ? this.imageService.getApiPath('request', row.tmdbId, 'poster')
+          : null;
+        fanartUrl = hasFanart
+          ? this.imageService.getApiPath('request', row.tmdbId, 'fanart')
+          : null;
+      } else {
+        const details =
+          row.mediaType === MediaType.MOVIE
+            ? await this.tmdb.getMovieDetails(String(row.tmdbId))
+            : await this.tmdb.getTvShowDetails(String(row.tmdbId));
+        [posterUrl, fanartUrl] = await Promise.all([
+          details.posterUrl
+            ? this.imageService.downloadAndStore(
+                details.posterUrl,
+                'request',
+                row.tmdbId,
+                'poster',
+              )
+            : Promise.resolve(null),
+          details.fanartUrl
+            ? this.imageService.downloadAndStore(
+                details.fanartUrl,
+                'request',
+                row.tmdbId,
+                'fanart',
+              )
+            : Promise.resolve(null),
+        ]);
+      }
+
+      if (!posterUrl && !fanartUrl) return;
+      row.posterUrl = posterUrl;
+      row.fanartUrl = fanartUrl;
+      await this.requestRepo.update(row.id, { posterUrl, fanartUrl });
+    } catch (err) {
+      // Never block request creation on artwork.
+      this.logger.warn(
+        `Request #${row.id}: art prefetch failed: ${(err as Error).message}`,
+      );
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/client/src/app/core/interceptors/cache.interceptor.ts
+++ b/client/src/app/core/interceptors/cache.interceptor.ts
@@ -30,6 +30,9 @@ const CACHEABLE_PREFIXES = [
   '/api/libraries',
   '/api/profiles/quality',
   '/api/profiles/language',
+  // Title details barely change; the request-poster fallback (rows without
+  // stored local art) re-fetches them on every cold page open otherwise.
+  '/api/metadata',
 ];
 
 const EXCLUDED_PREFIXES = [

--- a/client/src/app/core/services/api/requests.service.ts
+++ b/client/src/app/core/services/api/requests.service.ts
@@ -37,6 +37,10 @@ export interface RequestMedia {
   id: number;
   title: string;
   year: number | null;
+  /** Local `/api/images` paths of the imported media — secondary art source
+   *  for requests created before local request art existed. */
+  posterUrl: string | null;
+  fanartUrl: string | null;
 }
 
 export interface FliksRequestRow {
@@ -58,6 +62,10 @@ export interface FliksRequestRow {
    *  title (the cached `title` field may be stale or empty). */
   media: RequestMedia | null;
   seasons: number[] | null;
+  /** Local card art (`/api/images/request/...`) stored at creation; null on
+   *  requests that predate local request art (metadata fallback applies). */
+  posterUrl: string | null;
+  fanartUrl: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/client/src/app/features/requests/request-card/request-card.html
+++ b/client/src/app/features/requests/request-card/request-card.html
@@ -5,6 +5,7 @@
       class="absolute inset-0"
       [tmdbId]="request().tmdbId"
       [mediaType]="request().mediaType"
+      [fanart]="fanartArt()"
       mode="backdrop"
     />
     <div class="absolute inset-0 bg-gradient-to-br from-base-100/55 via-base-100/80 to-base-100"></div>

--- a/client/src/app/features/requests/request-card/request-card.ts
+++ b/client/src/app/features/requests/request-card/request-card.ts
@@ -40,6 +40,13 @@ export class RequestCardComponent {
   readonly approve = output<number>();
   readonly decline = output<number>();
 
+  /** Backdrop art: the request's own stored fanart, falling back to the
+   *  linked media's (both local `/api/images` paths). Null lets the poster
+   *  component fall back to the metadata lookup (pre-existing requests). */
+  readonly fanartArt = computed(
+    () => this.request().fanartUrl ?? this.request().media?.fanartUrl ?? null,
+  );
+
   /** Route to the linked media, or to the add page when not yet imported.
    *  Mirrors `RequestsComponent.mediaLink`. */
   readonly mediaLink = computed<(string | number)[]>(() => {

--- a/client/src/app/features/requests/request-poster.ts
+++ b/client/src/app/features/requests/request-poster.ts
@@ -9,6 +9,7 @@ import {
 } from '@angular/core';
 import { MetadataService } from '../../core/services/api/metadata.service';
 import { MediaType } from '../../core/enums/media-type.enum';
+import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
 
 /** Per-process cache for the metadata detail fetch — multiple instances of
  *  `app-request-poster` on the same row (poster chip + mobile backdrop)
@@ -21,12 +22,13 @@ const detailsCache = new Map<
 
 @Component({
   selector: 'app-request-poster',
+  imports: [ResolveUrlPipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'block w-full h-full min-h-0' },
   template: `
     @if (imageUrl()) {
       <img
-        [src]="imageUrl()!"
+        [src]="imageUrl()! | resolveUrl: (mode() === 'backdrop' ? 'medium' : 'thumb')"
         [alt]="titleText()"
         class="w-full h-full object-cover"
         loading="lazy"
@@ -67,16 +69,29 @@ export class RequestPosterComponent implements OnInit {
    *  with no fallback — meant to sit behind a gradient and stay silent when
    *  there's nothing to render. */
   readonly mode = input<'poster' | 'backdrop'>('poster');
+  /** Pre-resolved art (the request row's local `/api/images` paths). When the
+   *  current mode's URL is provided, the component renders it directly and
+   *  skips the metadata lookup entirely. */
+  readonly poster = input<string | null>(null);
+  readonly fanart = input<string | null>(null);
 
-  readonly posterUrl = signal<string | null>(null);
-  readonly fanartUrl = signal<string | null>(null);
+  private readonly fetchedPoster = signal<string | null>(null);
+  private readonly fetchedFanart = signal<string | null>(null);
   readonly loaded = signal(false);
 
   readonly imageUrl = computed(() =>
-    this.mode() === 'backdrop' ? this.fanartUrl() : this.posterUrl(),
+    this.mode() === 'backdrop'
+      ? (this.fanart() ?? this.fetchedFanart())
+      : (this.poster() ?? this.fetchedPoster()),
   );
 
   async ngOnInit() {
+    const provided =
+      this.mode() === 'backdrop' ? this.fanart() : this.poster();
+    if (provided) {
+      this.loaded.set(true);
+      return;
+    }
     const key = `${this.mediaType()}:${this.tmdbId()}`;
     let promise = detailsCache.get(key);
     if (!promise) {
@@ -90,8 +105,8 @@ export class RequestPosterComponent implements OnInit {
       detailsCache.set(key, promise);
     }
     const details = await promise;
-    this.posterUrl.set(details.posterUrl);
-    this.fanartUrl.set(details.fanartUrl);
+    this.fetchedPoster.set(details.posterUrl);
+    this.fetchedFanart.set(details.fanartUrl);
     this.loaded.set(true);
   }
 }

--- a/client/src/app/features/requests/requests.html
+++ b/client/src/app/features/requests/requests.html
@@ -38,6 +38,7 @@
               class="absolute inset-0"
               [tmdbId]="row.tmdbId"
               [mediaType]="row.mediaType"
+              [fanart]="row.fanartUrl ?? row.media?.fanartUrl ?? null"
               mode="backdrop"
             />
             <div class="absolute inset-0 bg-gradient-to-b from-base-100/45 via-base-100/80 to-base-100"></div>
@@ -127,6 +128,7 @@
                 [tmdbId]="row.tmdbId"
                 [mediaType]="row.mediaType"
                 [titleText]="row.title"
+                [poster]="row.posterUrl ?? row.media?.posterUrl ?? null"
               />
             } @placeholder {
               <div class="absolute inset-0 skeleton rounded-none"></div>

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -28,6 +28,9 @@
     :where(html) { background-color: #1d232a; }
   </style>
   <link rel="preconnect" href="https://www.gstatic.com" crossorigin>
+  <!-- Request art falls back to the TMDB CDN for rows without stored local
+       images — pre-open the connection so that first fetch skips DNS+TLS. -->
+  <link rel="preconnect" href="https://image.tmdb.org" crossorigin>
   <script src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1" async></script>
 </head>
 <body>


### PR DESCRIPTION
## Problem

The request cards (home « Demandes récentes » scroller + requests page) were the only cards bypassing the local image pipeline: `app-request-poster` fetched `/api/metadata/{movie,tv}/:tmdbId` (not SWR-cached → backend → TMDB on every cold open) and bound the returned **raw TMDB CDN URL** into `<img [src]>`. The app's `Cache-Control: public, max-age=86400` never applied, each card paid a metadata round-trip + a cold cross-origin CDN fetch, and backdrops visibly lagged on home load.

## Change

**Backend**
- New `'request'` `ImageType` (size maps mirror `media/*`, disk path `images/requests/{tmdbId}/`, API path `/api/images/request/{tmdbId}/{variant}`). Keyed by **tmdbId**, so N requests for the same title share one stored file and a repeat request skips the network entirely (`hasImage` short-circuit).
- `FliksRequest.posterUrl/fanartUrl` columns (+ idempotent migration), stamped in `create()`: details fetched **server-side** via the TMDB provider (no client-supplied URLs → no SSRF surface), stored through `ImageService.downloadAndStore` (thumb/medium/full). Entirely best-effort inside try/catch — failure leaves the columns null, request creation never blocks on artwork.
- No cleanup on request deletion: files are shared across same-title requests, and no image type cleans up today (`deleteImages` has no callers). Bounded orphans (≤6 small JPEGs per distinct requested title).

**Client**
- `app-request-poster` takes optional `poster`/`fanart` inputs; when the current mode's URL is provided it renders directly — zero metadata fetch. URLs go through `resolveUrl` (server-base resolution for native platforms + `?size=` variants: backdrop→medium, poster→thumb).
- Fallback chain for old rows: `request.posterUrl` → linked `media.posterUrl` (already in the findAll join) → metadata lookup, now in the SWR cache allowlist + `preconnect` to the TMDB CDN.

## Verification

- Backend build + full suite green; client `ng build` green.
- Live E2E on the dev DB (ephemeral boot): created a request → response carries `posterUrl: "/api/images/request/{tmdbId}/poster"`, all 6 size variants on disk, `GET /api/images/request/{tmdbId}/poster?size=thumb` → 200 `image/jpeg` with `Cache-Control: public, max-age=86400`. Test request deleted afterwards.
- Note: requests created **before** this PR keep the (now cached) metadata fallback — no backfill on the read path by design.