### PR TITLE
fix(activity): stack release name under the badges on phones

### DIFF
--- a/client/src/app/features/activity/queue/queue.html
+++ b/client/src/app/features/activity/queue/queue.html
@@ -64,8 +64,10 @@
       @for (item of group.items; track item.hash) {
       <div class="card bg-base-100 border border-base-200 shadow-sm">
         <div class="card-body py-3 px-4 gap-2">
-          <div class="flex flex-wrap items-start justify-between gap-2">
-            <div class="flex-1 min-w-0">
+          <!-- Phone: badges + menu on their own line, release name below.
+               md and up: name left, badges right on a single line. -->
+          <div class="flex flex-col gap-2 md:flex-row md:flex-wrap md:items-start md:justify-between">
+            <div class="min-w-0 md:flex-1">
               @if (item.mediaId) {
                 <a
                   [routerLink]="['/' + (item.mediaType === 'series' ? 'series' : 'movies'), item.mediaId]"
@@ -99,7 +101,7 @@
                 }
               </div>
             </div>
-            <div class="flex items-center gap-1 shrink-0">
+            <div class="flex items-center justify-end gap-1 shrink-0 order-first md:order-none">
               <span class="badge badge-sm badge-ghost">{{ torrentStatusLabel(item.trackerStatus) }}</span>
               @if (item.status) {
                 <span class="badge badge-sm" [ngClass]="appStateClass(item.status)">


### PR DESCRIPTION
Follow-up to #398 — this commit was part of the branch but a silent push failure left it out of the squash.

On narrow viewports the release name and the badge cluster competed for one line even with proper truncation. Below the `md` breakpoint (the app's phone boundary) the badges and the row menu now sit alone on the first line, right-aligned, with the release name on its own full-width line underneath. Tablet and desktop keep the single-line layout from #398.