### PR TITLE
fix(requests): harden the home-load changes after adversarial review

### DIFF
--- a/backend/src/modules/counts/counts.service.spec.ts
+++ b/backend/src/modules/counts/counts.service.spec.ts
@@ -2,6 +2,7 @@ import { CountsService } from './counts.service';
 import type { User } from '../users/entities/user.entity';
 import { DownloadClient } from '../download-clients/entities/download-client.entity';
 import { FliksRequest } from '../requests/entities/request.entity';
+import { Media } from '../media/entities/media.entity';
 import { Action } from '../auth/casl/actions.enum';
 
 describe('CountsService.getCounts', () => {
@@ -10,6 +11,7 @@ describe('CountsService.getCounts', () => {
   function make(opts: {
     canReadDownloadClient: boolean;
     canManageRequests: boolean;
+    canReadMedia?: boolean;
   }) {
     const historyRepo = { count: jest.fn().mockResolvedValue(3) };
     const requestRepo = { count: jest.fn().mockResolvedValue(5) };
@@ -17,6 +19,7 @@ describe('CountsService.getCounts', () => {
       can: jest.fn((action: Action, subject: unknown) => {
         if (subject === DownloadClient) return opts.canReadDownloadClient;
         if (subject === FliksRequest) return opts.canManageRequests;
+        if (subject === Media) return opts.canReadMedia ?? true;
         return false;
       }),
     };
@@ -90,5 +93,17 @@ describe('CountsService.getCounts', () => {
     expect(libraries.getAccessibleLibraryIds).toHaveBeenCalledWith(user);
     expect(mediaService.getCountsByLibrary).toHaveBeenCalledWith([1, 2]);
     expect(counts.mediaByLibrary).toEqual({ 1: 10, 2: 20 });
+  });
+
+  it('returns empty media counts without the media read ability, without querying', async () => {
+    const { service, mediaService, libraries } = make({
+      canReadDownloadClient: true,
+      canManageRequests: false,
+      canReadMedia: false,
+    });
+    const counts = await service.getCounts(user);
+    expect(counts.mediaByLibrary).toEqual({});
+    expect(libraries.getAccessibleLibraryIds).not.toHaveBeenCalled();
+    expect(mediaService.getCountsByLibrary).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/counts/counts.service.ts
+++ b/backend/src/modules/counts/counts.service.ts
@@ -4,6 +4,7 @@ import { In, Repository } from 'typeorm';
 import { DownloadHistory } from '../media/entities/download-history.entity';
 import { FliksRequest } from '../requests/entities/request.entity';
 import { DownloadClient } from '../download-clients/entities/download-client.entity';
+import { Media } from '../media/entities/media.entity';
 import { User } from '../users/entities/user.entity';
 import { RequestStatus } from '../../common/enums';
 import {
@@ -43,7 +44,7 @@ export class CountsService {
     const [queueActive, pendingRequests, mediaByLibrary] = await Promise.all([
       this.countActiveQueue(ability),
       this.countPendingRequests(user, ability),
-      this.countMediaByLibrary(user),
+      this.countMediaByLibrary(user, ability),
     ]);
     return { queueActive, pendingRequests, mediaByLibrary };
   }
@@ -52,10 +53,17 @@ export class CountsService {
    * Downloads still doing work, from the history table. `grabbed` and
    * `importing` are the states the queue badge counts; `warning` maps to
    * "Quality not upgraded" and `failed`/`completed` are terminal, all three
-   * excluded from the badge. Unlike the live queue, history can't see
-   * client-side error states (tracker error, missing files), so a torrent
-   * erroring at the client stays counted until its row turns terminal — a
-   * transient over-count accepted in exchange for skipping the live fan-out.
+   * excluded from the badge.
+   *
+   * Known drift vs the live queue, accepted in exchange for skipping the
+   * client fan-out (the badge links to the queue page, where truth lives):
+   * - client-side error states (tracker error, missing files) and torrents
+   *   removed from the client stay counted until the orphan reaper flips
+   *   the row to `failed` (~30 min grace);
+   * - a row stuck in `importing` by a mid-import crash is counted until it
+   *   reaches a terminal status;
+   * - torrents living in the download client without a history row
+   *   (added outside the app) are not counted at all.
    */
   private async countActiveQueue(ability: AppAbility): Promise<number> {
     if (!ability.can(Action.Read, DownloadClient)) return 0;
@@ -81,9 +89,13 @@ export class CountsService {
     });
   }
 
+  /** Mirrors the gating of GET /media/counts-by-library: media.read
+   *  required, then scoped to the user's accessible libraries. */
   private async countMediaByLibrary(
     user: User,
+    ability: AppAbility,
   ): Promise<Record<number, number>> {
+    if (!ability.can(Action.Read, Media)) return {};
     const accessibleLibraryIds =
       await this.libraries.getAccessibleLibraryIds(user);
     return this.mediaService.getCountsByLibrary(accessibleLibraryIds);

--- a/backend/src/modules/images/image.controller.ts
+++ b/backend/src/modules/images/image.controller.ts
@@ -52,13 +52,24 @@ export class ImageController {
     const validTypes = ['media', 'person', 'episode', 'season', 'request'];
     if (!validTypes.includes(type)) throw new NotFoundException();
 
+    // Request art is keyed by `{mediaType}-{tmdbId}`; everything else by a
+    // numeric id. The strict pattern doubles as path-traversal protection,
+    // since the string key lands in a filesystem path.
+    let idArg: number | string;
+    if (type === 'request') {
+      if (!/^(movie|series)-\d+$/.test(id)) throw new NotFoundException();
+      idArg = id;
+    } else {
+      idArg = +id;
+    }
+
     const size: ImageSize = (VALID_SIZES as string[]).includes(sizeRaw ?? '')
       ? (sizeRaw as ImageSize)
       : 'full';
 
     let filePath = this.imageService.getDiskPath(
       type as ImageType,
-      +id,
+      idArg,
       variant as MediaImageVariant | undefined,
       size,
     );
@@ -69,7 +80,7 @@ export class ImageController {
     if (!existsSync(filePath) && size !== 'full') {
       filePath = this.imageService.getDiskPath(
         type as ImageType,
-        +id,
+        idArg,
         variant as MediaImageVariant | undefined,
         'full',
       );

--- a/backend/src/modules/images/image.service.ts
+++ b/backend/src/modules/images/image.service.ts
@@ -25,8 +25,9 @@ export type ImageSize = 'thumb' | 'medium' | 'full';
 const TMDB_SIZE_MAP: Record<string, Partial<Record<ImageSize, string>>> = {
   'media/poster': { thumb: 'w185', medium: 'w500', full: 'original' },
   'media/fanart': { thumb: 'w300', medium: 'w780', full: 'original' },
-  // Request card art — keyed by tmdbId (not a media id), so every request
-  // for the same title shares one stored file.
+  // Request card art — keyed by `{mediaType}-{tmdbId}` (TMDB ids are
+  // namespaced per media type, so a movie and a series can share the same
+  // number). Every request for the same title shares one stored file.
   'request/poster': { thumb: 'w185', medium: 'w500', full: 'original' },
   'request/fanart': { thumb: 'w300', medium: 'w780', full: 'original' },
   person: { thumb: 'w45', full: 'original' },
@@ -71,7 +72,7 @@ export class ImageService {
   async downloadAndStore(
     remoteUrl: string,
     type: ImageType,
-    id: number,
+    id: number | string,
     variant?: MediaImageVariant,
   ): Promise<string | null> {
     const sizes = TMDB_SIZE_MAP[sizeMapKey(type, variant)] ?? {
@@ -134,7 +135,7 @@ export class ImageService {
   /**
    * Delete all images (every size) for a given entity.
    */
-  deleteImages(type: ImageType, id: number): void {
+  deleteImages(type: ImageType, id: number | string): void {
     if (type === 'media' || type === 'request') {
       fs.rmSync(
         path.join(this.baseDir, type === 'media' ? 'media' : 'requests', String(id)),
@@ -159,7 +160,7 @@ export class ImageService {
    */
   getDiskPath(
     type: ImageType,
-    id: number,
+    id: number | string,
     variant?: MediaImageVariant,
     size: ImageSize = 'full',
   ): string {
@@ -189,7 +190,11 @@ export class ImageService {
   }
 
   /** Whether the full-size file for (type, id, variant) is already stored. */
-  hasImage(type: ImageType, id: number, variant?: MediaImageVariant): boolean {
+  hasImage(
+    type: ImageType,
+    id: number | string,
+    variant?: MediaImageVariant,
+  ): boolean {
     return fs.existsSync(this.getDiskPath(type, id, variant));
   }
 
@@ -197,7 +202,11 @@ export class ImageService {
    * Public API path stored in DB. Always size-agnostic — clients append
    * `?size=thumb|medium|full` at request time.
    */
-  getApiPath(type: ImageType, id: number, variant?: MediaImageVariant): string {
+  getApiPath(
+    type: ImageType,
+    id: number | string,
+    variant?: MediaImageVariant,
+  ): string {
     switch (type) {
       case 'media':
         return `/api/images/media/${id}/${variant ?? 'poster'}`;

--- a/backend/src/modules/requests/entities/request.entity.ts
+++ b/backend/src/modules/requests/entities/request.entity.ts
@@ -83,10 +83,11 @@ export class FliksRequest extends BaseEntity {
   seasons: number[] | null;
 
   /**
-   * Local card art (`/api/images/request/{tmdbId}/...`), stored at creation
-   * so cards render from the cached image pipeline without a metadata
-   * round-trip. Null when the download failed or the request predates local
-   * request art — the client falls back to the metadata lookup.
+   * Local card art (`/api/images/request/{mediaType}-{tmdbId}/...`), stored
+   * at creation so cards render from the cached image pipeline without a
+   * metadata round-trip. Null when the download failed or the request
+   * predates local request art — the client falls back to the metadata
+   * lookup.
    */
   @Column({ type: 'text', nullable: true })
   posterUrl: string | null;

--- a/backend/src/modules/requests/requests.service.ts
+++ b/backend/src/modules/requests/requests.service.ts
@@ -219,6 +219,7 @@ export class RequestsService {
     };
     const row = this.requestRepo.create(partial);
     const saved = await this.requestRepo.save(row);
+    this.projectEmbeddedUsers(saved);
 
     const event = autoApprove ? 'request.approved' : 'request.created';
     void this.notifications.dispatch(event, {
@@ -467,12 +468,7 @@ export class RequestsService {
     if (!this.canManageRequests(user) && row.userId !== user.id) {
       throw new ForbiddenException();
     }
-    row.user = this.toPublicIdentity(row.user) as User;
-    row.approvedBy = this.toPublicIdentity(row.approvedBy) as User | null;
-    row.comments?.forEach((c) => {
-      c.user = this.toPublicIdentity(c.user) as User;
-    });
-    return row;
+    return this.projectEmbeddedUsers(row);
   }
 
   /**
@@ -487,6 +483,20 @@ export class RequestsService {
     if (!user) return null;
     const { id, username, avatar } = user;
     return { id, username, avatar };
+  }
+
+  /**
+   * In-place projection of every embedded user on a row about to be
+   * returned. Every request endpoint must route its response through this
+   * (or findOne) — the eager relations otherwise hydrate full accounts.
+   */
+  private projectEmbeddedUsers(row: FliksRequest): FliksRequest {
+    row.user = this.toPublicIdentity(row.user) as User;
+    row.approvedBy = this.toPublicIdentity(row.approvedBy) as User | null;
+    row.comments?.forEach((c) => {
+      c.user = this.toPublicIdentity(c.user) as User;
+    });
+    return row;
   }
 
   async update(
@@ -562,6 +572,7 @@ export class RequestsService {
     );
 
     const saved = await this.requestRepo.save(row);
+    this.projectEmbeddedUsers(saved);
     void this.notifications.dispatch('request.approved', {
       title: saved.title,
     });
@@ -665,6 +676,7 @@ export class RequestsService {
     row.approvedBy = admin;
     row.declinedReason = reason ?? null;
     const saved = await this.requestRepo.save(row);
+    this.projectEmbeddedUsers(saved);
     void this.notifications.dispatch('request.declined', {
       title: saved.title,
       reason: reason ?? '',
@@ -694,7 +706,10 @@ export class RequestsService {
       user,
       message: dto.message,
     });
-    return this.commentRepo.save(comment);
+    const saved = await this.commentRepo.save(comment);
+    saved.user = this.toPublicIdentity(saved.user) as User;
+    if (saved.request) this.projectEmbeddedUsers(saved.request);
+    return saved;
   }
 
   async getComments(requestId: number, user: User): Promise<RequestComment[]> {

--- a/backend/src/modules/requests/requests.service.ts
+++ b/backend/src/modules/requests/requests.service.ts
@@ -227,7 +227,15 @@ export class RequestsService {
       mediaType: dto.mediaType,
     });
 
-    await this.populateRequestArt(saved);
+    // Bounded wait: the art typically lands within a couple seconds and the
+    // first render gets it. On a degraded TMDB the response returns with
+    // null art after the deadline and the client's metadata fallback covers
+    // the row while the download finishes in the background (the columns
+    // are persisted by a separate UPDATE).
+    await Promise.race([
+      this.populateRequestArt(saved),
+      new Promise((resolve) => setTimeout(resolve, 5_000)),
+    ]);
 
     return saved;
   }
@@ -236,55 +244,46 @@ export class RequestsService {
    * Stores the title's poster/fanart through the local image pipeline and
    * stamps their API paths on the request, so cards render from the cached
    * `/api/images` endpoint instead of fetching metadata + the TMDB CDN per
-   * card. Art is keyed by tmdbId: requests for the same title share files,
-   * and a repeat request skips the network entirely. Best-effort — any
-   * failure leaves the columns null and the client falls back to the
-   * metadata lookup.
+   * card. Art is keyed by `{mediaType}-{tmdbId}` — TMDB ids are namespaced
+   * per media type — so requests for the same title share files and a
+   * repeat request only downloads whichever variant is still missing.
+   * Best-effort: any failure leaves the columns null and the client falls
+   * back to the metadata lookup.
    */
   private async populateRequestArt(row: FliksRequest): Promise<void> {
     try {
-      let posterUrl: string | null = null;
-      let fanartUrl: string | null = null;
+      const key = `${row.mediaType}-${row.tmdbId}`;
+      let posterUrl = this.imageService.hasImage('request', key, 'poster')
+        ? this.imageService.getApiPath('request', key, 'poster')
+        : null;
+      let fanartUrl = this.imageService.hasImage('request', key, 'fanart')
+        ? this.imageService.getApiPath('request', key, 'fanart')
+        : null;
 
-      const hasPoster = this.imageService.hasImage(
-        'request',
-        row.tmdbId,
-        'poster',
-      );
-      const hasFanart = this.imageService.hasImage(
-        'request',
-        row.tmdbId,
-        'fanart',
-      );
-      if (hasPoster || hasFanart) {
-        posterUrl = hasPoster
-          ? this.imageService.getApiPath('request', row.tmdbId, 'poster')
-          : null;
-        fanartUrl = hasFanart
-          ? this.imageService.getApiPath('request', row.tmdbId, 'fanart')
-          : null;
-      } else {
+      if (!posterUrl || !fanartUrl) {
         const details =
           row.mediaType === MediaType.MOVIE
             ? await this.tmdb.getMovieDetails(String(row.tmdbId))
             : await this.tmdb.getTvShowDetails(String(row.tmdbId));
         [posterUrl, fanartUrl] = await Promise.all([
-          details.posterUrl
-            ? this.imageService.downloadAndStore(
-                details.posterUrl,
-                'request',
-                row.tmdbId,
-                'poster',
-              )
-            : Promise.resolve(null),
-          details.fanartUrl
-            ? this.imageService.downloadAndStore(
-                details.fanartUrl,
-                'request',
-                row.tmdbId,
-                'fanart',
-              )
-            : Promise.resolve(null),
+          posterUrl ??
+            (details.posterUrl
+              ? this.imageService.downloadAndStore(
+                  details.posterUrl,
+                  'request',
+                  key,
+                  'poster',
+                )
+              : Promise.resolve(null)),
+          fanartUrl ??
+            (details.fanartUrl
+              ? this.imageService.downloadAndStore(
+                  details.fanartUrl,
+                  'request',
+                  key,
+                  'fanart',
+                )
+              : Promise.resolve(null)),
         ]);
       }
 


### PR DESCRIPTION
Follow-up to #399 / #400 / #401 — these three commits were pushed to the original branches right as they were squash-merged, so they never landed. Each addresses a finding from an adversarial review pass over the three diffs (every finding independently verified against the code before fixing).

## 1. `fix(requests): project embedded users on mutation responses too` (follow-up to #399)

`create`/`approve`/`decline`/`addComment` returned rows whose eager user relations carried the full account (email, quotas, admin flags — **not** the hash, which the merged fix strips everywhere) even after the read endpoints were narrowed. The `toPublicIdentity` projection now applies to every request payload via a shared `projectEmbeddedUsers` helper.

## 2. `fix(counts): gate library counts on media.read and document badge drift` (follow-up to #400)

- The dedicated `/media/counts-by-library` endpoint requires the `media.read` ability; the aggregated `/api/counts` silently skipped that check (parity regression for roles with library access but no media.read — scoping itself was never affected). Now returns `{}` without the ability, with a spec.
- The queue-count comment now documents the full drift envelope: orphaned rows awaiting the ~30 min reaper, rows stuck in `importing` after a mid-import crash, and untracked client torrents (not counted at all).

## 3. `fix(requests): key request art by media type and bound the create wait` (follow-up to #401, **the important one**)

- **TMDB ids are namespaced per media type** — a movie and a series can share the same number. Art keyed by tmdbId alone meant the first-requested title's poster got permanently stamped onto the other type's request (wrong art for an unrelated title). The key is now `{mediaType}-{tmdbId}` (`images/requests/movie-550/…`), with a strict `(movie|series)-\d+` pattern check in the image controller since the string key lands in a filesystem path.
- The POST no longer gates on a degraded TMDB: bounded 5 s wait, the art download finishes in the background and persists via its own UPDATE (worst case before: ~40 s of spinner on a cold title).
- A partially stored title (poster ok, fanart failed) now retries the missing variant instead of pinning it null forever.

## Verification

- Backend build + 21 suites / 161 tests green; client `ng build` green.
- Live E2E re-run on the dev DB: created request → `posterUrl: "/api/images/request/movie-{tmdbId}/poster"`, files under `images/requests/movie-{tmdbId}/`, image GETs 200 with cache headers, path-traversal probe and legacy numeric keys → 404. Test rows deleted.
- Note: requests created while #401 was on main without this fix may carry `/api/images/request/{tmdbId}/…` paths that now 404 → their cards fall back to the (cached) metadata lookup, same as pre-#401 rows. Harmless, self-corrects per title on the next request.