### PR TITLE
fix(downloads): stop orphaning grabs when qBittorrent fetch fails

### DIFF
--- a/backend/src/modules/download-clients/qbittorrent.service.ts
+++ b/backend/src/modules/download-clients/qbittorrent.service.ts
@@ -64,6 +64,19 @@ export interface QbittorrentTorrentFile {
   priority: number;
 }
 
+/**
+ * A torrent fetch outcome that separates "the client holds no torrents" from
+ * "the client could not be reached". An unreachable or unauthenticated client
+ * returns the same empty list as one that genuinely holds nothing, so callers
+ * that take destructive action on a torrent's absence (the orphan-history
+ * sweep, stalled-torrent removal) read `ok` to skip a tick built on a fetch
+ * that never succeeded.
+ */
+export interface QbittorrentTorrentsResult {
+  ok: boolean;
+  torrents: QbittorrentTorrent[];
+}
+
 @Injectable()
 export class QbittorrentService {
   private readonly log = new Logger(QbittorrentService.name);
@@ -133,6 +146,19 @@ export class QbittorrentService {
   }
 
   async getTorrents(client: DownloadClient): Promise<QbittorrentTorrent[]> {
+    return (await this.getTorrentsResult(client)).torrents;
+  }
+
+  /**
+   * Fetch a client's torrents while reporting whether the fetch succeeded.
+   * `ok` is false on a missing host, failed auth, unreachable client or
+   * malformed body — every path where the empty list is an artefact of the
+   * failure rather than the client's real contents. See
+   * {@link QbittorrentTorrentsResult}.
+   */
+  async getTorrentsResult(
+    client: DownloadClient,
+  ): Promise<QbittorrentTorrentsResult> {
     const s = client.settings as {
       host?: string;
       username?: string;
@@ -142,7 +168,7 @@ export class QbittorrentService {
       category?: string;
     };
     const base = this.buildBaseUrl(s);
-    if (!base) return [];
+    if (!base) return { ok: false, torrents: [] };
     const http = axios.create({
       timeout: 15_000,
       headers: { 'User-Agent': 'Fliks/1.0' },
@@ -167,14 +193,14 @@ export class QbittorrentService {
         this.log.warn(
           `getTorrents: auth failed for client "${client.name}" at ${base}`,
         );
-        return [];
+        return { ok: false, torrents: [] };
       }
       cookieHeader = cookies.map((c: string) => c.split(';')[0]).join('; ');
     } catch (e) {
       this.log.warn(
         `getTorrents: cannot reach client "${client.name}" at ${base}: ${(e as Error).message}`,
       );
-      return [];
+      return { ok: false, torrents: [] };
     }
 
     try {
@@ -192,20 +218,21 @@ export class QbittorrentService {
         this.log.warn(
           `getTorrents: unexpected response from "${client.name}": ${typeof res.data}`,
         );
-        return [];
+        return { ok: false, torrents: [] };
       }
       // Decode HTML entities baked into the `.torrent` `name` field by
       // misbehaving indexers (`Berl&iacute;n` → `Berlín`). Anything
       // downstream — history matching, activity UI, sourceTitle —
       // gets the human-readable form.
-      return res.data.map((t) =>
+      const torrents = res.data.map((t) =>
         t.name ? { ...t, name: decodeHtmlEntities(t.name) } : t,
       );
+      return { ok: true, torrents };
     } catch (e) {
       this.log.warn(
         `getTorrents: error fetching torrents from "${client.name}": ${(e as Error).message}`,
       );
-      return [];
+      return { ok: false, torrents: [] };
     }
   }
 

--- a/backend/src/modules/scheduler/completion.service.spec.ts
+++ b/backend/src/modules/scheduler/completion.service.spec.ts
@@ -1,0 +1,122 @@
+import { CompletionService } from './completion.service';
+import { DownloadHistory } from '../media/entities/download-history.entity';
+import {
+  QbittorrentTorrent,
+  TorrentHistoryMatcher,
+} from '../download-clients/qbittorrent.service';
+
+/** The exact stamp the orphan sweep writes — pinned here so the test guards
+ *  the user-visible string the queue clears and re-applies. */
+const ORPHAN_MESSAGE = 'Torrent no longer present in download client';
+
+/**
+ * `reconcileOrphanHistory` is private and only touches `historyRepo`,
+ * `historyMatcher` and `log`, so we exercise it on a bare prototype instance
+ * rather than standing up the 27-dependency constructor.
+ */
+function buildService(matchByHash: Set<string>) {
+  const update = jest.fn().mockResolvedValue(undefined);
+  const service = Object.create(
+    CompletionService.prototype,
+  ) as CompletionService & Record<string, unknown>;
+
+  const matcher = {
+    findMatch: (t: QbittorrentTorrent, histories: DownloadHistory[]) => {
+      if (!t.hash || !matchByHash.has(t.hash)) return null;
+      const history = histories.find((h) => h.torrentHash === t.hash);
+      return history ? { history, matchedBy: 'hash' as const } : null;
+    },
+  } as unknown as TorrentHistoryMatcher;
+
+  service.historyRepo = { update } as unknown as never;
+  service.historyMatcher = matcher as unknown as never;
+  service.log = { warn: jest.fn(), log: jest.fn() } as unknown as never;
+  return { service, update };
+}
+
+function torrent(hash: string): QbittorrentTorrent {
+  return { hash, name: hash, state: 'metaDL' } as QbittorrentTorrent;
+}
+
+function history(over: Partial<DownloadHistory>): DownloadHistory {
+  return {
+    id: 1,
+    status: 'grabbed',
+    torrentHash: 'h1',
+    sourceTitle: 'h1',
+    statusMessage: null as unknown as string,
+    updatedAt: new Date(),
+    ...over,
+  } as DownloadHistory;
+}
+
+const HOUR_AGO = new Date(Date.now() - 60 * 60_000);
+
+describe('CompletionService.reconcileOrphanHistory', () => {
+  function run(torrents: QbittorrentTorrent[], rows: DownloadHistory[]) {
+    const present = new Set(torrents.map((t) => t.hash));
+    const { service, update } = buildService(present);
+    return {
+      update,
+      done: (
+        service as unknown as {
+          reconcileOrphanHistory: (
+            t: QbittorrentTorrent[],
+            g: DownloadHistory[],
+          ) => Promise<void>;
+        }
+      ).reconcileOrphanHistory(torrents, rows),
+    };
+  }
+
+  it('flips a grabbed row to failed once its torrent is gone past the grace', async () => {
+    const row = history({ id: 7, status: 'grabbed', updatedAt: HOUR_AGO });
+    const { update, done } = run([], [row]);
+    await done;
+    expect(update).toHaveBeenCalledWith([7], {
+      status: 'failed',
+      statusMessage: ORPHAN_MESSAGE,
+    });
+  });
+
+  it('leaves a grabbed row alone while its torrent is still present', async () => {
+    const row = history({ id: 7, status: 'grabbed', updatedAt: HOUR_AGO });
+    const { update, done } = run([torrent('h1')], [row]);
+    await done;
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('keeps a freshly-grabbed missing torrent inside the grace window', async () => {
+    const row = history({ id: 7, status: 'grabbed', updatedAt: new Date() });
+    const { update, done } = run([], [row]);
+    await done;
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('clears the orphan stamp when the torrent reappears', async () => {
+    const row = history({
+      id: 9,
+      status: 'failed',
+      statusMessage: ORPHAN_MESSAGE,
+      updatedAt: HOUR_AGO,
+    });
+    const { update, done } = run([torrent('h1')], [row]);
+    await done;
+    expect(update).toHaveBeenCalledWith([9], {
+      status: 'grabbed',
+      statusMessage: null,
+    });
+  });
+
+  it('does not revive a row that failed for a different reason', async () => {
+    const row = history({
+      id: 9,
+      status: 'failed',
+      statusMessage: 'Stalled — removed by aggressive cleanup profile',
+      updatedAt: HOUR_AGO,
+    });
+    const { update, done } = run([torrent('h1')], [row]);
+    await done;
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -55,6 +55,14 @@ import { MediaService } from '../media/media.service';
  */
 const ORPHAN_GRACE_MS = 30 * 60_000;
 
+/**
+ * Status message stamped on a row the orphan sweep flips to `failed`. Kept as
+ * a constant so the sweep can also recognise its own stamp and clear it when
+ * the torrent reappears, rather than leaving a row reading "no longer present"
+ * next to a torrent the client is still reporting.
+ */
+const ORPHAN_STATUS_MESSAGE = 'Torrent no longer present in download client';
+
 @Injectable()
 export class CompletionService {
   private readonly log = new Logger(CompletionService.name);
@@ -274,14 +282,21 @@ export class CompletionService {
       return;
     }
 
-    const allTorrents = (
-      await Promise.all(
-        qbitClients.map(async (c) => {
-          const torrents = await this.qbittorrent.getTorrents(c);
-          return torrents.map((t) => ({ ...t, _clientId: c.id, _client: c }));
-        }),
-      )
-    ).flat();
+    const fetches = await Promise.all(
+      qbitClients.map(async (c) => {
+        const { ok, torrents } = await this.qbittorrent.getTorrentsResult(c);
+        return {
+          ok,
+          torrents: torrents.map((t) => ({ ...t, _clientId: c.id, _client: c })),
+        };
+      }),
+    );
+    // A failed fetch yields an empty list indistinguishable from a client
+    // that genuinely holds nothing. The orphan sweep declares a torrent gone
+    // by its absence, so it runs only when every client answered — a single
+    // unreachable client would otherwise orphan every in-flight grab.
+    const allClientsResponded = fetches.every((f) => f.ok);
+    const allTorrents = fetches.flatMap((f) => f.torrents);
 
     // Phase 1 — auto-match orphan torrents (creates history rows for
     // qBit torrents that have no DB linkage yet).
@@ -299,10 +314,13 @@ export class CompletionService {
       ],
     });
 
-    // Phase 2 — orphan-history sweep: rows whose torrent has vanished
-    // from qBit for longer than the grace period flip to `failed`.
-    // Media link is preserved.
-    await this.markStaleHistoryAsFailed(allTorrents, grabbed);
+    // Phase 2 — reconcile grabbed rows against the live torrent list: flip
+    // ones whose torrent has been gone past the grace period to `failed`,
+    // and clear a prior orphan stamp off any row whose torrent reappeared.
+    // Media link is preserved either way. Skipped on a partial fetch.
+    if (allClientsResponded) {
+      await this.reconcileOrphanHistory(allTorrents, grabbed);
+    }
 
     // Phase 3 — import the completed torrents.
     const completedTorrents = allTorrents.filter(
@@ -392,14 +410,22 @@ export class CompletionService {
   }
 
   /**
-   * Flip history rows to `failed` when their torrent has been missing
-   * from qBit for at least {@link ORPHAN_GRACE_MS}. Extracted here so
-   * `processCompleted` reads as three crisp phases. The grace is
-   * measured off `updatedAt` because every status / hash heal write
-   * bumps it; a row whose torrent just arrived in qBit has a fresh
-   * timestamp and won't be flipped.
+   * Reconcile grabbed/failed rows against the live torrent list. Caller must
+   * pass a complete list (every client responded), since both directions key
+   * off a torrent's presence:
+   *
+   *  - A `grabbed` row whose torrent has been gone for at least
+   *    {@link ORPHAN_GRACE_MS} flips to `failed`. The grace is measured off
+   *    `updatedAt`, which every status / hash heal write bumps, so a row
+   *    whose torrent just arrived has a fresh timestamp and won't be flipped.
+   *  - A `failed` row carrying the {@link ORPHAN_STATUS_MESSAGE} stamp whose
+   *    torrent is matched again returns to `grabbed`, so the activity queue
+   *    never shows "no longer present" beside a torrent the client still
+   *    reports. A torrent that failed for any other reason keeps its status.
+   *
+   * The media link is preserved in both directions.
    */
-  private async markStaleHistoryAsFailed(
+  private async reconcileOrphanHistory(
     allTorrents: ReadonlyArray<QbittorrentTorrent>,
     grabbed: DownloadHistory[],
   ): Promise<void> {
@@ -409,6 +435,23 @@ export class CompletionService {
       const m = this.historyMatcher.findMatch(t, grabbed);
       if (m) matchedHistoryIds.add(m.history.id);
     }
+
+    const revived = grabbed.filter(
+      (h) =>
+        h.status === 'failed' &&
+        h.statusMessage === ORPHAN_STATUS_MESSAGE &&
+        matchedHistoryIds.has(h.id),
+    );
+    if (revived.length) {
+      await this.historyRepo.update(
+        revived.map((h) => h.id),
+        { status: 'grabbed', statusMessage: null as unknown as string },
+      );
+      this.log.log(
+        `Import: ${revived.length} entries reappeared in qBittorrent — cleared the orphan stamp and re-armed for import`,
+      );
+    }
+
     const cutoff = Date.now() - ORPHAN_GRACE_MS;
     const expired = grabbed.filter(
       (h) =>
@@ -421,7 +464,7 @@ export class CompletionService {
       expired.map((h) => h.id),
       {
         status: 'failed',
-        statusMessage: 'Torrent no longer present in download client',
+        statusMessage: ORPHAN_STATUS_MESSAGE,
       },
     );
     this.log.warn(


### PR DESCRIPTION
## Problème

Des entrées d'activité affichent **« Échec de l'import » + « Torrent no longer present in download client »** alors que le torrent est **toujours présent dans qBittorrent** (état live « Téléchargement métadonnées » / « Bloqué », badge de strikes 2/4).

Cause : `getTorrents()` renvoyait `[]` sur **n'importe quelle** erreur qBit (injoignable, auth refusée, corps malformé), indistinguable d'un client qui ne contient réellement aucun torrent. Le balayage orphelins (`markStaleHistoryAsFailed`, grâce de 30 min) interprète l'absence comme une suppression → un redémarrage/blip d'auth qBit > 30 min tamponne `failed` toutes les lignes `grabbed` en cours. Au retour de qBit, les torrents (souvent des releases mortes 0 seeder bloquées en `metaDL`) réapparaissent en traînant ce tampon périmé.

## Correctif

- **`getTorrentsResult()`** (nouveau) distingue « échec du fetch » de « zéro torrent » via `{ ok, torrents }`. `getTorrents()` délègue et garde sa signature → aucun autre appelant impacté.
- **Le balayage ne tourne que si tous les clients ont répondu** (`allClientsResponded`). Un seul qBit injoignable n'orpheline plus les grabs des autres. Un client qui répond OK avec une liste vide (torrents réellement supprimés) déclenche toujours le nettoyage légitime.
- **Auto-correction** : `reconcileOrphanHistory` efface son propre tampon « no longer present » dès que le torrent réapparaît (retour `grabbed`, message vidé). Les lignes mal étiquetées par une panne passée se nettoient au prochain tick propre. Un échec d'une autre cause (ex. « Stalled — removed by… ») n'est pas touché.

## Le nettoyage des torrents bloqués reste intact

`cleanStalledTorrents` n'est pas modifié. `metaDL` et `stalledDL` sont dans `STALL_ELIGIBLE_STATES` → les strikes continuent (badge 2/4) et le torrent est retiré au seuil avec son message « Stalled — removed by… ». Les deux mécanismes ne se contredisent plus.

## Tests

- 5 tests unitaires sur `reconcileOrphanHistory` (marquage orphelin, fenêtre de grâce, réapparition/auto-heal, non-revive d'un échec d'autre cause).
- `npx jest src/modules/scheduler` → 17/17 verts ; `tsc --noEmit` propre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
