### PR TITLE
feat(downloads): rank releases by availability and prefer season packs

### DIFF
--- a/backend/src/modules/media/episode-download.service.ts
+++ b/backend/src/modules/media/episode-download.service.ts
@@ -240,7 +240,15 @@ export class EpisodeDownloadService {
     const packs = sortReleasesByRelevance(
       withinProfile.filter((x) => x.isPack).map((x) => x.row),
     );
-    return [...singles, ...packs];
+    // Singles-before-packs holds only among live releases: a dead single
+    // can't import, so a well-seeded pack covering the episode outranks it.
+    const alive = (r: { seeders: number }) => r.seeders > 0;
+    return [
+      ...singles.filter(alive),
+      ...packs.filter(alive),
+      ...singles.filter((r) => !alive(r)),
+      ...packs.filter((r) => !alive(r)),
+    ];
   }
 
   async grabEpisode(

--- a/backend/src/modules/media/release-rejection.helper.spec.ts
+++ b/backend/src/modules/media/release-rejection.helper.spec.ts
@@ -1,0 +1,73 @@
+import { sortReleasesByRelevance } from './release-rejection.helper';
+
+type Row = Parameters<typeof sortReleasesByRelevance>[0][number];
+
+function row(over: Partial<Row> & { id: string }): Row & { id: string } {
+  return {
+    rank: 100,
+    allowed: true,
+    blocklisted: false,
+    languageAllowed: true,
+    rejections: [],
+    customFormatScore: 0,
+    seeders: 10,
+    leechers: 0,
+    freeleech: false,
+    sizeDeviation: 0,
+    ...over,
+  };
+}
+
+/** Order the rows and return their ids for terse assertions. */
+function order(rows: ReturnType<typeof row>[]): string[] {
+  return sortReleasesByRelevance(rows).map((r) => r.id);
+}
+
+describe('sortReleasesByRelevance', () => {
+  it('sinks a dead release below a lower-quality live one', () => {
+    const deadHd = row({ id: 'dead-1080p', rank: 200, seeders: 0 });
+    const liveSd = row({ id: 'live-720p', rank: 100, seeders: 5 });
+    expect(order([deadHd, liveSd])).toEqual(['live-720p', 'dead-1080p']);
+  });
+
+  it('keeps quality first between two live releases', () => {
+    const liveHdFewSeeds = row({ id: 'hd', rank: 200, seeders: 5 });
+    const liveSdManySeeds = row({ id: 'sd', rank: 100, seeders: 500 });
+    expect(order([liveSdManySeeds, liveHdFewSeeds])).toEqual(['hd', 'sd']);
+  });
+
+  it('orders by seeders within the same quality tier, above size proximity', () => {
+    // The worse-seeded row sits closer to the preferred size; seeders win.
+    const fewSeedsBetterSize = row({
+      id: 'few',
+      seeders: 5,
+      sizeDeviation: 0,
+    });
+    const manySeedsWorseSize = row({
+      id: 'many',
+      seeders: 200,
+      sizeDeviation: 0.4,
+    });
+    expect(order([fewSeedsBetterSize, manySeedsWorseSize])).toEqual([
+      'many',
+      'few',
+    ]);
+  });
+
+  it('breaks a seeder tie toward the busier swarm (more leechers)', () => {
+    const quiet = row({ id: 'quiet', seeders: 100, leechers: 1 });
+    const busy = row({ id: 'busy', seeders: 100, leechers: 80 });
+    expect(order([quiet, busy])).toEqual(['busy', 'quiet']);
+  });
+
+  it('still ranks a clean release above a rejected one', () => {
+    const rejected = row({
+      id: 'rejected',
+      rank: 300,
+      seeders: 999,
+      rejections: [{ code: 'QUALITY_NOT_ALLOWED' }],
+    });
+    const clean = row({ id: 'clean', rank: 100, seeders: 1 });
+    expect(order([rejected, clean])).toEqual(['clean', 'rejected']);
+  });
+});

--- a/backend/src/modules/media/release-rejection.helper.ts
+++ b/backend/src/modules/media/release-rejection.helper.ts
@@ -388,11 +388,19 @@ export function computeRejections(opts: {
  * 1. No rejections > has rejections
  * 2. Not blocklisted > blocklisted
  * 3. Language allowed > not allowed
- * 4. Freeleech bonus
+ * 4. Alive (seeders > 0) > dead — a zero-seeder release can't be downloaded,
+ *    so it sinks below every live release regardless of quality.
  * 5. Quality rank (higher = better)
- * 6. Custom format score (higher = better)
- * 7. Seeders (more = better, log scale to avoid over-weighting)
- * 8. Size closer to preferred (less deviation = better)
+ * 6. Freeleech bonus
+ * 7. Custom format score (higher = better)
+ * 8. Seeders (more = better, log scale to avoid over-weighting)
+ * 9. Leechers (more = better, same scale) — breaks seeder ties toward the
+ *    busier swarm.
+ * 10. Size closer to preferred (less deviation = better)
+ *
+ * Availability (4, 8, 9) outranks quality only at the dead/alive boundary;
+ * between two live releases quality wins, and seeders/leechers order releases
+ * within the same quality tier ahead of the weaker size-proximity signal.
  */
 export function sortReleasesByRelevance<
   T extends {
@@ -403,10 +411,16 @@ export function sortReleasesByRelevance<
     rejections: ReleaseRejection[];
     customFormatScore: number;
     seeders: number;
+    leechers: number;
     freeleech: boolean;
     sizeDeviation?: number | null;
   },
 >(rows: T[]): T[] {
+  // log2 gap that counts as a real difference (~19%); smaller gaps are noise
+  // and fall through to the next tiebreak rather than flipping the order.
+  const SWARM_EPSILON = 0.25;
+  const swarmScore = (count: number) => Math.log2(Math.max(count, 0) + 1);
+
   return rows.sort((a, b) => {
     // 1. No rejections first
     const aClean = a.rejections.length === 0 ? 1 : 0;
@@ -420,28 +434,38 @@ export function sortReleasesByRelevance<
     if (a.languageAllowed !== b.languageAllowed)
       return a.languageAllowed ? -1 : 1;
 
-    // 4. Quality rank desc
+    // 4. Live releases first — a dead torrent never imports.
+    const aAlive = a.seeders > 0 ? 1 : 0;
+    const bAlive = b.seeders > 0 ? 1 : 0;
+    if (aAlive !== bAlive) return bAlive - aAlive;
+
+    // 5. Quality rank desc
     if (a.rank !== b.rank) return b.rank - a.rank;
 
-    // 5. Freeleech bonus
+    // 6. Freeleech bonus
     if (a.freeleech !== b.freeleech) return a.freeleech ? -1 : 1;
 
-    // 6. Custom format score desc
+    // 7. Custom format score desc
     if (a.customFormatScore !== b.customFormatScore)
       return b.customFormatScore - a.customFormatScore;
 
-    // 7. Closer to preferred size wins (only when both rows expose it
-    //    and the gap is big enough to matter — within 5% of each other
-    //    counts as tied, otherwise tiny noise would flip the order).
+    // 8. Seeders desc (log scale)
+    const aSeed = swarmScore(a.seeders);
+    const bSeed = swarmScore(b.seeders);
+    if (Math.abs(aSeed - bSeed) > SWARM_EPSILON) return bSeed - aSeed;
+
+    // 9. Leechers desc (log scale) — tie-break toward the busier swarm.
+    const aLeech = swarmScore(a.leechers);
+    const bLeech = swarmScore(b.leechers);
+    if (Math.abs(aLeech - bLeech) > SWARM_EPSILON) return bLeech - aLeech;
+
+    // 10. Closer to preferred size wins (only when both rows expose it
+    //     and the gap is big enough to matter — within 5% of each other
+    //     counts as tied, otherwise tiny noise would flip the order).
     if (a.sizeDeviation != null && b.sizeDeviation != null) {
       const diff = Math.abs(a.sizeDeviation - b.sizeDeviation);
       if (diff > 0.05) return a.sizeDeviation - b.sizeDeviation;
     }
-
-    // 8. Seeders desc (log scale)
-    const aSeed = Math.log2(a.seeders + 1);
-    const bSeed = Math.log2(b.seeders + 1);
-    if (Math.abs(aSeed - bSeed) > 0.5) return bSeed - aSeed;
 
     return 0;
   });

--- a/backend/src/modules/scheduler/completion.service.spec.ts
+++ b/backend/src/modules/scheduler/completion.service.spec.ts
@@ -1,9 +1,7 @@
 import { CompletionService } from './completion.service';
 import { DownloadHistory } from '../media/entities/download-history.entity';
-import {
-  QbittorrentTorrent,
-  TorrentHistoryMatcher,
-} from '../download-clients/qbittorrent.service';
+import { QbittorrentTorrent } from '../download-clients/qbittorrent.service';
+import { TorrentHistoryMatcher } from '../media/torrent-history-matcher.service';
 
 /** The exact stamp the orphan sweep writes — pinned here so the test guards
  *  the user-visible string the queue clears and re-applies. */
@@ -16,9 +14,7 @@ const ORPHAN_MESSAGE = 'Torrent no longer present in download client';
  */
 function buildService(matchByHash: Set<string>) {
   const update = jest.fn().mockResolvedValue(undefined);
-  const service = Object.create(
-    CompletionService.prototype,
-  ) as CompletionService & Record<string, unknown>;
+  const service = Object.create(CompletionService.prototype) as CompletionService;
 
   const matcher = {
     findMatch: (t: QbittorrentTorrent, histories: DownloadHistory[]) => {
@@ -28,9 +24,16 @@ function buildService(matchByHash: Set<string>) {
     },
   } as unknown as TorrentHistoryMatcher;
 
-  service.historyRepo = { update } as unknown as never;
-  service.historyMatcher = matcher as unknown as never;
-  service.log = { warn: jest.fn(), log: jest.fn() } as unknown as never;
+  // Assign the few collaborators the method touches onto the bare instance.
+  // Cast away `private readonly` since there's no constructor to set them.
+  const wired = service as unknown as {
+    historyRepo: unknown;
+    historyMatcher: unknown;
+    log: unknown;
+  };
+  wired.historyRepo = { update };
+  wired.historyMatcher = matcher;
+  wired.log = { warn: jest.fn(), log: jest.fn() };
   return { service, update };
 }
 

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -598,8 +598,22 @@ export class SchedulerService implements OnModuleInit {
       }
     }
 
-    for (let i = 0; i < episodes.length; i++) {
-      const ep = episodes[i];
+    // Season-pack-first: a season missing more than one episode is better
+    // served by one (usually far better seeded) pack than by scattered
+    // per-episode grabs. Episodes a grabbed pack covers drop out of the
+    // per-episode search below.
+    const coveredByPack = await this.grabMissingSeasonPacks(
+      episodes,
+      indexers,
+      qbitClient,
+      scoring,
+    );
+    const toSearch = coveredByPack.size
+      ? episodes.filter((e) => !coveredByPack.has(e.id))
+      : episodes;
+
+    for (let i = 0; i < toSearch.length; i++) {
+      const ep = toSearch[i];
       const season = (ep as unknown as { season: Season }).season;
       const media = (season as unknown as { media: Media }).media;
       const epLabel = `S${String(season.seasonNumber).padStart(2, '0')}E${String(ep.episodeNumber).padStart(2, '0')}`;
@@ -608,7 +622,7 @@ export class SchedulerService implements OnModuleInit {
         type: 'task.progress',
         command: 'SearchMissing',
         current: i,
-        total: episodes.length,
+        total: toSearch.length,
         message: `${media.title} ${epLabel}`,
       });
 
@@ -663,10 +677,114 @@ export class SchedulerService implements OnModuleInit {
     this.eventsService.emit({
       type: 'task.progress',
       command: 'SearchMissing',
-      current: episodes.length,
-      total: episodes.length,
+      current: toSearch.length,
+      total: toSearch.length,
       message: 'SearchMissing',
     });
+  }
+
+  /**
+   * Season-pack-first pass for SearchMissing. Groups the missing episodes by
+   * season and, for any season missing more than one episode, tries to grab a
+   * single full-season pack instead of scattered per-episode releases — packs
+   * are usually far better seeded and import per-file. Returns the ids of the
+   * episodes a grabbed pack now covers so the caller skips their per-episode
+   * search. A season missing a single episode is left to the per-episode path:
+   * pulling a whole-season pack for one file wastes bandwidth and disk.
+   */
+  private async grabMissingSeasonPacks(
+    episodes: Episode[],
+    indexers: Indexer[],
+    qbitClient: DownloadClient,
+    scoring: AutoGrabScoringContext,
+  ): Promise<Set<number>> {
+    const covered = new Set<number>();
+
+    const groups = new Map<
+      number,
+      { season: Season; media: Media; eps: Episode[] }
+    >();
+    for (const ep of episodes) {
+      const season = (ep as unknown as { season: Season }).season;
+      const media = (season as unknown as { media: Media }).media;
+      const group = groups.get(season.id);
+      if (group) group.eps.push(ep);
+      else groups.set(season.id, { season, media, eps: [ep] });
+    }
+    const multi = [...groups.values()].filter((g) => g.eps.length >= 2);
+    if (!multi.length) return covered;
+
+    // Total episode count per season drives the pack's runtime for the size
+    // check — a pack covers the whole season, not just the missing episodes.
+    const counts = await this.episodeRepo
+      .createQueryBuilder('ep')
+      .select('ep.seasonId', 'seasonId')
+      .addSelect('COUNT(*)', 'cnt')
+      .where('ep.seasonId IN (:...ids)', { ids: multi.map((g) => g.season.id) })
+      .groupBy('ep.seasonId')
+      .getRawMany<{ seasonId: number; cnt: string }>();
+    const episodeCountBySeason = new Map(
+      counts.map((c) => [Number(c.seasonId), Number(c.cnt)]),
+    );
+
+    for (const { season, media, eps } of multi) {
+      const seasonLabel = `S${String(season.seasonNumber).padStart(2, '0')}`;
+
+      // A grabbed pack records a season-scoped history row (no episodeId). If
+      // one is already downloading, the episodes are already covered: mark
+      // them so the per-episode pass doesn't grab singles alongside the pack
+      // (that pass keys off the episode tag, which a pack title doesn't carry).
+      const packPending = await this.historyRepo
+        .createQueryBuilder('h')
+        .where('h.mediaId = :mediaId', { mediaId: media.id })
+        .andWhere('h.status = :status', { status: 'grabbed' })
+        .andWhere('h.seasonId = :seasonId', { seasonId: season.id })
+        .andWhere('h.episodeId IS NULL')
+        .getOne();
+      if (packPending) {
+        for (const ep of eps) covered.add(ep.id);
+        continue;
+      }
+
+      const packBatches = await Promise.allSettled(
+        indexers.map((ix) =>
+          this.torznab.searchSeasonPack(ix, media.title, season.seasonNumber, {
+            tvdbId: media.tvdbId,
+            imdbId: media.imdbId,
+          }),
+        ),
+      );
+      // Indexer `season=` filtering is unreliable (notably text-mode
+      // backends), so keep only releases that parse as a full-season pack —
+      // never a stray single episode that slipped into the result set.
+      const packs = packBatches
+        .flatMap((r) => (r.status === 'fulfilled' ? r.value : []))
+        .filter((r) => parseSeasonEpisode(r.title).isFullSeason);
+      if (!packs.length) continue;
+
+      const epCount = episodeCountBySeason.get(season.id) ?? eps.length;
+      const grabbed = await this.autoGrab.tryAutoGrab({
+        media,
+        files: [],
+        releases: packs,
+        qbitClient,
+        scoring,
+        mediaType: 'series',
+        label: `${media.title} ${seasonLabel} (pack)`,
+        expectedTitle: [media.title, ...(media.alternativeTitles ?? [])],
+        runtimeMinutes: (media.runtime ?? 45) * epCount,
+        seasonNumber: season.seasonNumber,
+        seasonId: season.id,
+      });
+      if (grabbed) {
+        for (const ep of eps) covered.add(ep.id);
+        this.log.log(
+          `SearchMissing: grabbed a ${media.title} ${seasonLabel} pack covering ${eps.length} missing episode(s)`,
+        );
+      }
+    }
+
+    return covered;
   }
 
   private async doRefreshMetadata(): Promise<void> {


### PR DESCRIPTION
## Contexte

Dans la modale des releases (et donc aussi à l'auto-grab, même fonction de tri), des releases **0 seed** (mortes, non téléchargeables) pouvaient finir en tête, et le cron `SearchMissing` grabait des **épisodes individuels morts** alors qu'un **season pack bien seedé** existait. Fait suite à l'incident des torrents bloqués « no longer present ».

## 1. Classement par disponibilité (`sortReleasesByRelevance`)

Nouveau cascade :

```
1. clean (0 rejet)   2. non-blocklisté   3. langue OK
4. ★ VIVANTE (seeders>0) > morte        ← au-dessus de la qualité
5. qualité (rank)    6. freeleech        7. custom format
8. ★ seeders desc    9. ★ leechers desc  ← remontés au-dessus de la taille
10. taille proche du préféré
```

- Une release **0 seed coule sous toutes les vivantes**, quelle que soit sa qualité (elle n'importera jamais).
- Entre vivantes, **la qualité reste prioritaire** ; les seeds/leech ordonnent à l'intérieur d'un même palier, devant le signal plus faible de proximité de taille.
- **Modale épisode** : on garde « singles avant packs », mais **seulement entre vivantes** — un single 0 seed ne passe plus devant un pack bien seedé qui couvre l'épisode.

## 2. `SearchMissing` : pack d'abord (cron)

Avant : recherche **par épisode**, pack rangé à égalité. Maintenant :
- Regroupe les épisodes manquants par saison.
- Pour une saison à **≥ 2 épisodes manquants** → tente un **full-season pack** d'abord (`searchSeasonPack` + filtre `isFullSeason` + scoring/validation profil via `tryAutoGrab`). Pack acceptable → grab, et les épisodes couverts sortent de la recherche par épisode.
- **1 seul manquant** ou **aucun pack acceptable** → fallback recherche par épisode (comportement actuel).
- Runtime du pack = nb total d'épisodes de la saison × runtime (pour le contrôle de taille).
- Une saison dont **un pack est déjà en téléchargement** est considérée couverte → la passe par épisode ne grab pas de singles en doublon du pack.

## Tests

- `release-rejection.helper.spec.ts` (nouveau, 5 cas) : mort coulé sous vivant, qualité prioritaire entre vivants, seeders > proximité de taille, tiebreak leechers, clean > rejeté.
- `npx jest src/modules/media src/modules/scheduler` → 31/31 verts ; `tsc --noEmit` propre.
- Inclut une correction d'import + assignation `readonly` dans `completion.service.spec.ts` (latente depuis #404) pour garder le type-check dev propre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
