### PR TITLE
feat(cast): resilient mid-cast sessions, receiver recovery, and seekbar loading

### DIFF
--- a/backend/src/modules/streaming/live-session.service.spec.ts
+++ b/backend/src/modules/streaming/live-session.service.spec.ts
@@ -51,6 +51,20 @@ describe('LiveSessionRegistry', () => {
     expect(updated!.quality).toBe('1080p');
   });
 
+  it('touch refreshes lastBeat without mutating playback fields', async () => {
+    const session = svc.create({ ...BASE, position: 7 });
+    const initialBeat = session.lastBeat;
+    await new Promise((r) => setTimeout(r, 5));
+    expect(svc.touch(session.sessionId)).toBe(true);
+    expect(session.lastBeat).toBeGreaterThan(initialBeat);
+    // A fetch is liveness only — it must not touch the playhead.
+    expect(session.position).toBe(7);
+  });
+
+  it('touch returns false for an unknown sessionId', () => {
+    expect(svc.touch('missing')).toBe(false);
+  });
+
   it('stop removes the session and returns true', () => {
     const session = svc.create(BASE);
     expect(svc.stop(session.sessionId)).toBe(true);
@@ -212,6 +226,21 @@ describe('LiveSessionRegistry GC', () => {
     for (let i = 0; i < 4; i++) {
       await new Promise((r) => setTimeout(r, 30));
       svc.heartbeat(session.sessionId, { position: i });
+    }
+    expect(svc.size()).toBe(1);
+  });
+
+  it('keeps sessions kept alive by segment-fetch touches alone', async () => {
+    // No client heartbeat at all — the receiver pulling segments must be
+    // enough to survive the ttl (the Cast crash repro).
+    process.env.STREAM_LIVE_SESSION_TTL_MS = '80';
+    process.env.STREAM_LIVE_SESSION_GC_INTERVAL_MS = '30';
+    svc = new LiveSessionRegistry();
+    svc.onModuleInit();
+    const session = svc.create(BASE);
+    for (let i = 0; i < 4; i++) {
+      await new Promise((r) => setTimeout(r, 30));
+      expect(svc.touch(session.sessionId)).toBe(true);
     }
     expect(svc.size()).toBe(1);
   });

--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -259,6 +259,22 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
+   * Refresh `lastBeat` off real stream traffic — a segment or playlist
+   * fetch is itself proof the consumer is alive. Returns false when the
+   * session is unknown so the HLS routes can 410 a stale `?sid=`.
+   *
+   * Without this the registry depends solely on the client's heartbeat
+   * timer; a Cast receiver, whose only keep-alive is a flaky sender-side
+   * beat, gets GC'd mid-playback and 410s on its next segment.
+   */
+  touch(sessionId: string): boolean {
+    const session = this.sessions.get(sessionId);
+    if (!session) return false;
+    session.lastBeat = Date.now();
+    return true;
+  }
+
+  /**
    * Apply a partial patch to a session. No-op when the session is
    * unknown (caller is expected to have just created it or to silently
    * fall through to defaults).

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -368,7 +368,10 @@ export class StreamingController {
   private assertFreshSession(req: Request): void {
     const sid = firstQueryString(req.query, 'sid');
     if (!sid) return;
-    if (!this.liveSessions.get(sid)) {
+    // The fetch itself keeps the session warm: an actively-playing
+    // receiver pulls segments straight off these routes, so its session
+    // must not depend on a separate heartbeat channel to survive the ttl.
+    if (!this.liveSessions.touch(sid)) {
       throw new SessionExpiredException(sid);
     }
   }

--- a/cast-receiver/receiver.js
+++ b/cast-receiver/receiver.js
@@ -19,6 +19,12 @@
 const context = cast.framework.CastReceiverContext.getInstance();
 const playerManager = context.getPlayerManager();
 
+// Receiver → sender bus. A fatal player error is forwarded here so web
+// senders can recover (refresh the live-session sid) or toast. Keep in
+// sync with FLIKS_CAST_NAMESPACE in client cast.service.ts. Native senders
+// detect the same fatal state via the Cast SDK's IDLE/ERROR status.
+const FLIKS_NAMESPACE = 'urn:x-cast:media.fliks.app';
+
 // Verbose CAF + Shaka logging — surfaces in chrome://inspect on the
 // receiver, the only practical way to diagnose a Cast freeze or load
 // failure on a real device.
@@ -56,6 +62,24 @@ playerManager.addEventListener(
   (event) => {
     console.error('[fliks-cast] ERROR', JSON.stringify(event));
     document.body.classList.remove('playing');
+    // Forward to web senders so they can refresh the sid and resume; the
+    // sender classifies recoverable (network / 410) vs dead-end errors.
+    try {
+      const info = playerManager.getMediaInformation();
+      const shakaErr = event && event.error;
+      const data = shakaErr && Array.isArray(shakaErr.data) ? shakaErr.data : [];
+      const httpStatus = typeof data[1] === 'number' ? data[1] : undefined;
+      context.sendCustomMessage(FLIKS_NAMESPACE, undefined, {
+        kind: 'player_error',
+        detailedErrorCode: event ? event.detailedErrorCode : undefined,
+        shakaErrorCode: shakaErr ? shakaErr.code : undefined,
+        httpStatus: httpStatus,
+        reason: event ? event.reason : undefined,
+        mediaTitle: info && info.metadata ? info.metadata.title : undefined,
+      });
+    } catch (e) {
+      console.warn('[fliks-cast] error forward failed', e);
+    }
   },
 );
 

--- a/client/android/app/src/main/java/media/fliks/app/CastPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/CastPlugin.java
@@ -19,6 +19,7 @@ import com.google.android.gms.cast.CastMediaControlIntent;
 import com.google.android.gms.cast.MediaInfo;
 import com.google.android.gms.cast.MediaLoadRequestData;
 import com.google.android.gms.cast.MediaMetadata;
+import com.google.android.gms.cast.MediaStatus;
 import com.google.android.gms.cast.MediaTrack;
 import com.google.android.gms.cast.TextTrackStyle;
 import com.google.android.gms.cast.framework.CastContext;
@@ -166,6 +167,16 @@ public class CastPlugin extends Plugin {
     private void notifyJSTime(double time, double duration, boolean paused) {
         String js = "window.dispatchEvent(new CustomEvent('castMediaUpdate', { detail: { "
             + "currentTime: " + time + ", duration: " + duration + ", isPaused: " + paused + " } }));";
+        getBridge().getWebView().post(() ->
+            getBridge().getWebView().evaluateJavascript(js, null)
+        );
+    }
+
+    /** Tell the sender the receiver hit a fatal error so it can re-establish
+     *  a fresh stream session and resume at {@code position} seconds. */
+    private void notifyCastError(double position) {
+        String js = "window.dispatchEvent(new CustomEvent('castError', { detail: { position: "
+            + position + " } }));";
         getBridge().getWebView().post(() ->
             getBridge().getWebView().evaluateJavascript(js, null)
         );
@@ -345,6 +356,11 @@ public class CastPlugin extends Plugin {
                 Log.w(TAG, "Failed to set track style", e);
             }
         }, 2000);
+
+        // Re-arm error detection for this stream and seed the resume anchor
+        // with the load offset (polling overwrites it once playback ticks).
+        errorReported = false;
+        lastGoodPosition = currentTime;
 
         // Start position/state polling
         startMediaPolling(client);
@@ -586,6 +602,12 @@ public class CastPlugin extends Plugin {
 
     private Handler pollHandler;
     private Runnable pollRunnable;
+    /** Last playhead (seconds) seen while the receiver was actively playing —
+     *  handed to the sender on a fatal error so it resumes at the right spot. */
+    private double lastGoodPosition = 0;
+    /** Latches IDLE/ERROR so one fatal error fires a single castError, not one
+     *  per poll tick. Cleared when the receiver leaves the idle state. */
+    private boolean errorReported = false;
 
     private void startMediaPolling(RemoteMediaClient client) {
         stopMediaPolling();
@@ -599,10 +621,29 @@ public class CastPlugin extends Plugin {
                 }
                 try {
                     if (castSession == null || !castSession.isConnected()) return;
-                    double time = client.getApproximateStreamPosition() / 1000.0;
-                    double duration = client.getStreamDuration() / 1000.0;
-                    boolean paused = client.isPaused();
-                    notifyJSTime(time, duration, paused);
+                    MediaStatus status = client.getMediaStatus();
+                    int state = status != null
+                        ? status.getPlayerState()
+                        : MediaStatus.PLAYER_STATE_UNKNOWN;
+                    // A fatal receiver error (e.g. a segment 410 after the live
+                    // session was GC'd) surfaces as IDLE with reason ERROR.
+                    // Signal JS once so the sender re-establishes a fresh
+                    // session; an in-flight recovery load goes IDLE/INTERRUPTED,
+                    // not ERROR, so it won't misfire.
+                    if (state == MediaStatus.PLAYER_STATE_IDLE
+                            && status.getIdleReason() == MediaStatus.IDLE_REASON_ERROR) {
+                        if (!errorReported) {
+                            errorReported = true;
+                            notifyCastError(lastGoodPosition);
+                        }
+                    } else {
+                        if (state != MediaStatus.PLAYER_STATE_IDLE) errorReported = false;
+                        double time = client.getApproximateStreamPosition() / 1000.0;
+                        double duration = client.getStreamDuration() / 1000.0;
+                        boolean paused = client.isPaused();
+                        if (time > 0) lastGoodPosition = time;
+                        notifyJSTime(time, duration, paused);
+                    }
                     pollHandler.postDelayed(this, 1000);
                 } catch (Exception e) {
                     Log.w(TAG, "Polling error", e);

--- a/client/android/app/src/main/java/media/fliks/app/CastPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/CastPlugin.java
@@ -164,9 +164,10 @@ public class CastPlugin extends Plugin {
         );
     }
 
-    private void notifyJSTime(double time, double duration, boolean paused) {
+    private void notifyJSTime(double time, double duration, boolean paused, boolean buffering) {
         String js = "window.dispatchEvent(new CustomEvent('castMediaUpdate', { detail: { "
-            + "currentTime: " + time + ", duration: " + duration + ", isPaused: " + paused + " } }));";
+            + "currentTime: " + time + ", duration: " + duration + ", isPaused: " + paused
+            + ", buffering: " + buffering + " } }));";
         getBridge().getWebView().post(() ->
             getBridge().getWebView().evaluateJavascript(js, null)
         );
@@ -641,8 +642,10 @@ public class CastPlugin extends Plugin {
                         double time = client.getApproximateStreamPosition() / 1000.0;
                         double duration = client.getStreamDuration() / 1000.0;
                         boolean paused = client.isPaused();
+                        boolean buffering = state == MediaStatus.PLAYER_STATE_BUFFERING
+                            || state == MediaStatus.PLAYER_STATE_LOADING;
                         if (time > 0) lastGoodPosition = time;
-                        notifyJSTime(time, duration, paused);
+                        notifyJSTime(time, duration, paused, buffering);
                     }
                     pollHandler.postDelayed(this, 1000);
                 } catch (Exception e) {

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1839,6 +1839,7 @@
   "cast": {
     "error": {
       "generic": "Erreur de lecture sur le Chromecast (code {{code}}).",
+      "recovery_failed": "Impossible de reprendre la lecture sur le Chromecast. Relance le cast.",
       "shaka_1001": "Le Chromecast n'a pas pu joindre le serveur (code 1001).",
       "shaka_1002": "Délai dépassé en récupérant un segment depuis le Chromecast (code 1002).",
       "shaka_3015": "Le Chromecast a refusé un fragment (code 3015).",

--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -525,6 +525,11 @@ export class CastPlayerService {
       if (idx >= 0) activeSubtitleTrackId = idx + 1;
     }
 
+    // Show the loading sweep immediately rather than waiting for the first
+    // receiver state tick; the player-state feed reconciles it once playback
+    // (or a rebuffer) actually starts.
+    this.cast.buffering.set(true);
+
     await this.cast.loadMedia({
       url: castUrl,
       contentType,

--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -11,6 +11,7 @@ import { formatAudioLabel, formatSubtitleLabel, parseAudioIndex, SpriteMetadata 
 import { PlayerSettingsService } from './player-settings.service';
 import { TrackManagerService } from './track-manager.service';
 import { MediaService } from './api/media.service';
+import { ToastService } from './toast.service';
 
 export interface CastSubtitleOption {
   id: string;
@@ -102,6 +103,7 @@ export class CastPlayerService {
   private readonly trackManager = inject(TrackManagerService);
   private readonly mediaService = inject(MediaService);
   private readonly translate = inject(TranslateService);
+  private readonly toast = inject(ToastService);
 
   /** Chromecast profile, derived from the receiver-probed MSE codec list
    *  (see `probeReceiverCapabilities`). `videoCodecs: []` keeps every Cast
@@ -381,6 +383,37 @@ export class CastPlayerService {
         void this.probeReceiverCapabilities();
       }
     });
+    // Receiver reported a recoverable playback error (session GC'd → 410 on
+    // the next segment). Re-establish a fresh stream and resume. Root
+    // singleton, so the subscription lives for the app's lifetime.
+    this.cast.playbackError$.subscribe(({ position }) => {
+      void this.recoverFromCastError(position);
+    });
+  }
+
+  /** Recover from a fatal receiver error by reloading with a fresh sid at
+   *  the last known position. Throttled so a genuinely broken stream
+   *  (deleted file, lost ACL) can't drive an endless reload loop: isolated
+   *  errors recover freely, but three inside 30 s give up with a toast. */
+  private recoverAttempts = 0;
+  private lastRecoverAt = 0;
+
+  private async recoverFromCastError(position?: number): Promise<void> {
+    if (!this.hasMedia()) return;
+    const now = Date.now();
+    if (now - this.lastRecoverAt > 30_000) this.recoverAttempts = 0;
+    if (this.recoverAttempts >= 3) {
+      this.toast.error(this.translate.instant('cast.error.recovery_failed'));
+      return;
+    }
+    this.recoverAttempts++;
+    this.lastRecoverAt = now;
+    const pos = position && position > 0 ? position : this.cast.currentTime();
+    try {
+      await this.reloadCastStream(pos);
+    } catch {
+      /* a still-broken stream re-fires the error, subject to the throttle */
+    }
   }
 
   /**

--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -552,12 +552,31 @@ export class CastPlayerService {
     const dur = this.cast.duration();
     if (!pos || pos < 1) return;
     try {
-      await this.streamingApi.updatePlaybackState(mId, {
+      // Carry the Cast live-session id so the backend refreshes its
+      // lastBeat. Once the player page is gone this loop is the only
+      // keep-alive for the receiver's session; without the sid the
+      // backend GCs it after the ttl and 410s the next segment, which
+      // the receiver has no way to recover from.
+      const sid = this.liveSessionId();
+      const heartbeat = sid
+        ? {
+            sessionId: sid,
+            state: (this.cast.isPaused() ? 'paused' : 'playing') as
+              | 'paused'
+              | 'playing',
+          }
+        : {};
+      const response = await this.streamingApi.updatePlaybackState(mId, {
         positionSeconds: pos,
         durationSeconds: dur || 0,
         mediaFileId: mfId,
         episodeId: this.episodeId(),
+        ...heartbeat,
       });
+      // Backend lost the session (its keep-alive lapsed, a restart, …).
+      // The receiver can't self-heal a session_expired, so re-issue
+      // playback-info and reload the stream with a fresh sid.
+      if (response?.sessionLost) await this.reloadCastStream(pos);
     } catch { /* ignore */ }
   }
 

--- a/client/src/app/core/services/cast.service.ts
+++ b/client/src/app/core/services/cast.service.ts
@@ -98,6 +98,9 @@ export class CastService implements OnDestroy {
   readonly currentTime = signal(0);
   readonly duration = signal(0);
   readonly isPaused = signal(true);
+  /** Receiver is loading/buffering (not yet playing) — drives the
+   *  indeterminate seekbar sweep in the cast overlay. */
+  readonly buffering = signal(false);
   readonly mediaTitle = signal('');
   /** Base pour sous-titres / URLs Cast ; renseignée dans reloadCastStream via cast-info. */
   readonly castStreamBaseUrl = signal('');
@@ -151,6 +154,7 @@ export class CastService implements OnDestroy {
         const connected = e.detail?.connected ?? false;
         this.isConnected.set(connected);
         if (connected) this.connecting.set(false);
+        else this.buffering.set(false);
       }) as EventListener);
 
       // Picker dismissed without selecting a device
@@ -162,6 +166,7 @@ export class CastService implements OnDestroy {
         this.currentTime.set(e.detail?.currentTime ?? 0);
         this.duration.set(e.detail?.duration ?? 0);
         this.isPaused.set(e.detail?.isPaused ?? true);
+        this.buffering.set(e.detail?.buffering ?? false);
       }) as EventListener);
 
       // The plugin maps the receiver's IDLE/ERROR state to this event —
@@ -223,6 +228,14 @@ export class CastService implements OnDestroy {
         cast.framework.RemotePlayerEventType.DURATION_CHANGED,
         () => this.duration.set(this.remotePlayer.duration ?? 0),
       );
+      this.remotePlayerController.addEventListener(
+        cast.framework.RemotePlayerEventType.PLAYER_STATE_CHANGED,
+        () =>
+          this.buffering.set(
+            this.remotePlayer.playerState ===
+              chrome.cast.media.PlayerState.BUFFERING,
+          ),
+      );
       this.isAvailable.set(true);
     } catch {
       this.isAvailable.set(false);
@@ -233,6 +246,7 @@ export class CastService implements OnDestroy {
     const connected = this.remotePlayer?.isConnected ?? false;
     this.isConnected.set(connected);
     this.connecting.set(false);
+    if (!connected) this.buffering.set(false);
     this.session = connected
       ? cast.framework.CastContext.getInstance().getCurrentSession()
       : null;

--- a/client/src/app/core/services/cast.service.ts
+++ b/client/src/app/core/services/cast.service.ts
@@ -5,6 +5,7 @@ import { environment } from '../../../environments/environment';
 import { CastSettingsService, CastSubtitleStyle } from './cast-settings.service';
 import { ToastService } from './toast.service';
 import { CAST_SUBTITLE_SIZE_SCALE } from '../utils/subtitle-presets';
+import { Subject } from 'rxjs';
 
 /** Custom Cast message namespace shared between the Fliks receiver and
  *  every sender. Used today for receiver → sender error forwarding;
@@ -21,6 +22,9 @@ interface ReceiverPlayerError {
   detailedErrorCode?: number;
   severity?: number;
   shakaErrorCode?: number;
+  /** HTTP status the failed request returned, when the receiver could read
+   *  it — `410` is the live-session-expired signal a fresh sid recovers. */
+  httpStatus?: number;
   shakaErrorData?: unknown;
   reason?: string;
   mediaTitle?: string;
@@ -98,6 +102,13 @@ export class CastService implements OnDestroy {
   /** Base pour sous-titres / URLs Cast ; renseignée dans reloadCastStream via cast-info. */
   readonly castStreamBaseUrl = signal('');
 
+  /** Fires when the receiver hits a fatal playback error that a fresh
+   *  stream (new sid) can recover — a live session GC'd mid-cast 410s the
+   *  next segment. `position` is the last known playhead to resume from.
+   *  Fed by the native plugin's IDLE/ERROR signal and the web receiver's
+   *  custom error message; consumed by CastPlayerService to reload. */
+  readonly playbackError$ = new Subject<{ position?: number }>();
+
   private readonly isNative = Capacitor.isNativePlatform();
   private readonly castSettings = inject(CastSettingsService);
   private readonly toast = inject(ToastService);
@@ -151,6 +162,12 @@ export class CastService implements OnDestroy {
         this.currentTime.set(e.detail?.currentTime ?? 0);
         this.duration.set(e.detail?.duration ?? 0);
         this.isPaused.set(e.detail?.isPaused ?? true);
+      }) as EventListener);
+
+      // The plugin maps the receiver's IDLE/ERROR state to this event —
+      // the native equivalent of the web receiver's custom error message.
+      window.addEventListener('castError', ((e: CustomEvent) => {
+        this.playbackError$.next({ position: e.detail?.position });
       }) as EventListener);
 
       // Device discovery updates
@@ -237,7 +254,14 @@ export class CastService implements OnDestroy {
       session.addMessageListener(FLIKS_CAST_NAMESPACE, (_ns: string, raw: string) => {
         try {
           const payload = JSON.parse(raw) as ReceiverPlayerError;
-          if (payload?.kind === 'player_error') this.handleReceiverError(payload);
+          if (payload?.kind !== 'player_error') return;
+          // A session-expiry / network failure is recoverable: re-establish
+          // a fresh stream rather than just toasting a dead-end error.
+          if (this.isRecoverableReceiverError(payload)) {
+            this.playbackError$.next({});
+          } else {
+            this.handleReceiverError(payload);
+          }
         } catch {
           /* malformed messages are ignored — receiver is forward-compatible */
         }
@@ -246,6 +270,20 @@ export class CastService implements OnDestroy {
     } catch (err) {
       console.warn('Cast addMessageListener failed', err);
     }
+  }
+
+  /** Whether a receiver error is worth a fresh-stream reload rather than a
+   *  toast: a 410 (live session GC'd), Shaka's NETWORK category (1001-1006,
+   *  the 410 surfaces here as BAD_HTTP_STATUS), or CAF's network/HLS-network
+   *  detailed codes (300-399). Anything else (decode, unsupported codec) a
+   *  reload can't fix, so it falls through to the toast. */
+  private isRecoverableReceiverError(p: ReceiverPlayerError): boolean {
+    if (p.httpStatus === 410) return true;
+    const shaka = p.shakaErrorCode;
+    if (shaka != null && shaka >= 1001 && shaka <= 1006) return true;
+    const detailed = p.detailedErrorCode;
+    if (detailed != null && detailed >= 300 && detailed < 400) return true;
+    return false;
   }
 
   private handleReceiverError(payload: ReceiverPlayerError) {

--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -169,6 +169,7 @@
     [currentTime]="currentTime()"
     [duration]="duration()"
     [bufferedEnd]="bufferedEnd()"
+    [loading]="buffering() || loading()"
     [spriteUrl]="spriteUrl()"
     [spriteMetadata]="spriteMetadata()"
     [chapters]="chapters()"

--- a/client/src/app/shared/cast-overlay/cast-overlay.html
+++ b/client/src/app/shared/cast-overlay/cast-overlay.html
@@ -43,6 +43,7 @@
             <app-seekbar #seekbar
               [currentTime]="cast.currentTime()"
               [duration]="cast.duration()"
+              [loading]="cast.buffering()"
               [spriteUrl]="cp.spriteUrl()"
               [spriteMetadata]="cp.spriteMetadata()"
               variant="cast"

--- a/client/src/app/shared/components/seekbar/seekbar.html
+++ b/client/src/app/shared/components/seekbar/seekbar.html
@@ -77,6 +77,13 @@
       [class]="variant() === 'player' ? 'bg-white' : 'bg-info'"
       [style.width.%]="displayPercent()"
     ></div>
+    <!-- Indeterminate loading sweep — a soft highlight crosses the track
+         while the engine is fetching/buffering, so the bar shows activity
+         even when the playhead isn't advancing. Sits above the progress
+         fill but below the chapter ticks. -->
+    @if (loading()) {
+      <div [class]="loadingSweepClass()"></div>
+    }
     <!-- Chapter ticks -->
     @for (t of chapterTicks(); track t.percent) {
       <div

--- a/client/src/app/shared/components/seekbar/seekbar.html
+++ b/client/src/app/shared/components/seekbar/seekbar.html
@@ -69,18 +69,21 @@
         [style.width.%]="duration() ? (bufferedEnd() / duration()) * 100 : 0"
       ></div>
     }
-    <!-- Progress. `rounded-l-full` matches the track's left cap;
-         right side stays square so the progress ends on a crisp
-         vertical edge instead of a curved bulge. -->
-    <div
-      class="absolute inset-y-0 left-0 rounded-l-full"
-      [class]="variant() === 'player' ? 'bg-white' : 'bg-info'"
-      [style.width.%]="displayPercent()"
-    ></div>
+    <!-- Progress. `rounded-l-full` matches the track's left cap; right side
+         stays square so the progress ends on a crisp vertical edge instead of
+         a curved bulge. Hidden while loading so the determinate position fill
+         and the indeterminate sweep never show at once. -->
+    @if (!loading()) {
+      <div
+        class="absolute inset-y-0 left-0 rounded-l-full"
+        [class]="variant() === 'player' ? 'bg-white' : 'bg-base-content'"
+        [style.width.%]="displayPercent()"
+      ></div>
+    }
     <!-- Indeterminate loading sweep — a soft highlight crosses the track
          while the engine is fetching/buffering, so the bar shows activity
-         even when the playhead isn't advancing. Sits above the progress
-         fill but below the chapter ticks. -->
+         even when the playhead isn't advancing. Replaces the position fill
+         (above); sits below the chapter ticks. -->
     @if (loading()) {
       <div [class]="loadingSweepClass()"></div>
     }

--- a/client/src/app/shared/components/seekbar/seekbar.ts
+++ b/client/src/app/shared/components/seekbar/seekbar.ts
@@ -22,6 +22,10 @@ export class SeekbarComponent {
   readonly variant = input<'player' | 'cast'>('player');
   readonly showTooltip = input(true);
   readonly showBuffered = input(true);
+  /** Drives an indeterminate sweep across the track while the engine is
+   *  fetching/buffering, so the bar reads as "working" even when the
+   *  playhead isn't advancing. */
+  readonly loading = input(false);
   readonly chapters = input<{ startSeconds: number; endSeconds: number; title?: string }[]>([]);
 
   /** Chapter start times as % of duration for seekbar tick rendering. */
@@ -86,6 +90,16 @@ export class SeekbarComponent {
     const thick = this.dragging() || this.hovering();
     const base = 'bg-white/20 group-focus-visible:h-2.5';
     return `${base} ${thick ? 'h-2.5' : 'h-1'}`;
+  });
+
+  /** Full class list for the indeterminate sweep overlay. The player rides on
+   *  top of video (white reads on any frame); the cast card uses theme
+   *  surfaces, so there the sweep tracks the foreground colour to stay visible
+   *  on light + dark. Assembled here (like trackClass) so a single `[class]`
+   *  binding owns the element — no static/bound merge to reason about. */
+  readonly loadingSweepClass = computed(() => {
+    const via = this.variant() === 'cast' ? 'via-base-content/40' : 'via-white/60';
+    return `absolute inset-0 pointer-events-none bg-gradient-to-r from-transparent ${via} to-transparent animate-seekbar-indeterminate`;
   });
 
   // Sprite preview computeds

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -191,6 +191,30 @@ body.native.hero-page {
   animation: slide-up 0.25s ease-out;
 }
 
+/* Indeterminate seekbar loading sweep: a full-width gradient strip whose
+   transparent edges keep the reset from 100%→-100% from reading as a hard
+   gap, so the highlight appears to drift across the track on a loop. */
+@keyframes seekbar-indeterminate {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(100%);
+  }
+}
+
+.animate-seekbar-indeterminate {
+  animation: seekbar-indeterminate 1.4s ease-in-out infinite;
+  will-change: transform;
+}
+
+/* Honour reduced-motion: drop the loop, leaving a soft static highlight. */
+@media (prefers-reduced-motion: reduce) {
+  .animate-seekbar-indeterminate {
+    animation: none;
+  }
+}
+
 /* ============================================================================
    Android TV / 10-foot UI overrides — body.tv toggled by TvService
    ============================================================================ */


### PR DESCRIPTION
## What

Fixes Chromecast playback freezing ~30 s into a stream, and adds a loading indicator on the seekbar.

### Cast reliability
- **Session kept warm by segment fetches** — a live session was GC'd after `STREAM_LIVE_SESSION_TTL_MS` (30 s) even while the receiver was actively pulling segments, 410-ing the next request. `assertFreshSession` now touches `lastBeat` on every HLS fetch.
- **Sender heartbeat carries the sid** — the global cast keep-alive now sends the live-session id, so the backend actually refreshes it.
- **Receiver recovery** — on a `session_expired` (410) the cast re-establishes a fresh sid and resumes instead of freezing. Android detects it via the Cast SDK's IDLE/ERROR state; web via the receiver's error message. Throttled (3 / 30 s) against loops.

### Seekbar loading indicator
- Indeterminate sweep across the seekbar while loading/buffering — local player and cast overlay. Cast buffering is surfaced from the receiver player state.
- Position fill and sweep no longer stack; the cast bar drops the blue (info) fill for the neutral foreground colour. Honours `prefers-reduced-motion`.

## Deploy
- **Backend** redeploy — the segment-fetch keep-alive.
- **Android APK** rebuild — native cast error/buffering signals in `CastPlugin.java`.
- Cast receiver redeploy only if casting from web.

## Verification
- `tsc` clean; backend unit tests pass (live-session `touch` covered); Docker CI image built green from this branch.
- Java is inspection-only (no local Android toolchain here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)