### PR TITLE
fix(downloads): reconcile the queue badge when torrents vanish

### DIFF
--- a/backend/src/modules/scheduler/completion.service.spec.ts
+++ b/backend/src/modules/scheduler/completion.service.spec.ts
@@ -14,6 +14,7 @@ const ORPHAN_MESSAGE = 'Torrent no longer present in download client';
  */
 function buildService(matchByHash: Set<string>) {
   const update = jest.fn().mockResolvedValue(undefined);
+  const emit = jest.fn();
   const service = Object.create(CompletionService.prototype) as CompletionService;
 
   const matcher = {
@@ -30,11 +31,13 @@ function buildService(matchByHash: Set<string>) {
     historyRepo: unknown;
     historyMatcher: unknown;
     log: unknown;
+    events: unknown;
   };
   wired.historyRepo = { update };
   wired.historyMatcher = matcher;
   wired.log = { warn: jest.fn(), log: jest.fn() };
-  return { service, update };
+  wired.events = { emit };
+  return { service, update, emit };
 }
 
 function torrent(hash: string): QbittorrentTorrent {
@@ -56,19 +59,25 @@ function history(over: Partial<DownloadHistory>): DownloadHistory {
 const HOUR_AGO = new Date(Date.now() - 60 * 60_000);
 
 describe('CompletionService.reconcileOrphanHistory', () => {
-  function run(torrents: QbittorrentTorrent[], rows: DownloadHistory[]) {
+  function run(
+    torrents: QbittorrentTorrent[],
+    rows: DownloadHistory[],
+    importingRows: DownloadHistory[] = [],
+  ) {
     const present = new Set(torrents.map((t) => t.hash));
-    const { service, update } = buildService(present);
+    const { service, update, emit } = buildService(present);
     return {
       update,
+      emit,
       done: (
         service as unknown as {
           reconcileOrphanHistory: (
             t: QbittorrentTorrent[],
             g: DownloadHistory[],
+            i: DownloadHistory[],
           ) => Promise<void>;
         }
-      ).reconcileOrphanHistory(torrents, rows),
+      ).reconcileOrphanHistory(torrents, rows, importingRows),
     };
   }
 
@@ -121,5 +130,44 @@ describe('CompletionService.reconcileOrphanHistory', () => {
     const { update, done } = run([torrent('h1')], [row]);
     await done;
     expect(update).not.toHaveBeenCalled();
+  });
+
+  it('flips an importing row to failed once its torrent is gone past the grace', async () => {
+    const row = history({
+      id: 12,
+      status: 'importing',
+      torrentHash: 'h2',
+      updatedAt: HOUR_AGO,
+    });
+    const { update, done } = run([], [], [row]);
+    await done;
+    expect(update).toHaveBeenCalledWith([12], {
+      status: 'failed',
+      statusMessage: ORPHAN_MESSAGE,
+    });
+  });
+
+  it('leaves an importing row alone while its torrent is still present', async () => {
+    const row = history({
+      id: 12,
+      status: 'importing',
+      torrentHash: 'h2',
+      updatedAt: HOUR_AGO,
+    });
+    const { update, done } = run([torrent('h2')], [], [row]);
+    await done;
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('emits queue.updated on a change, and stays silent when nothing moved', async () => {
+    const gone = history({ id: 7, status: 'grabbed', updatedAt: HOUR_AGO });
+    const flip = run([], [gone]);
+    await flip.done;
+    expect(flip.emit).toHaveBeenCalledWith({ type: 'queue.updated' });
+
+    const stillThere = history({ id: 8, status: 'grabbed', updatedAt: HOUR_AGO });
+    const noop = run([torrent('h1')], [stillThere]);
+    await noop.done;
+    expect(noop.emit).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -46,14 +46,16 @@ import { FileTransferService } from '../../common/services/file-transfer.service
 import { MediaService } from '../media/media.service';
 
 /**
- * How long a `grabbed` history row may stay without a matching qBit
- * torrent before we mark it `failed`. Picked at 30 min so a transient
- * mismatch (HTML-entity decode drift between qBit and the indexer's raw
- * title, a brief qBit unavailability, a torrent rename mid-tick) can't
- * trip the orphan handler. The row is NEVER deleted; only its status
+ * How long a `grabbed` or `importing` history row may stay without a
+ * matching qBit torrent before we mark it `failed`. The sweep only runs once
+ * every client has answered (a partial fetch is skipped upstream), so a
+ * torrent's absence is reliable; 5 min then absorbs the short-lived
+ * mismatches that remain — a freshly-grabbed row whose torrent hasn't
+ * surfaced yet, an HTML-entity decode drift between qBit and the indexer's
+ * raw title, a rename mid-tick. The row is NEVER deleted; only its status
  * flips so the user sees the failure in Activities and can re-grab.
  */
-const ORPHAN_GRACE_MS = 30 * 60_000;
+const ORPHAN_GRACE_MS = 5 * 60_000;
 
 /**
  * Status message stamped on a row the orphan sweep flips to `failed`. Kept as
@@ -313,13 +315,20 @@ export class CompletionService {
         { status: 'warning' },
       ],
     });
+    // Importing rows are reconciled too, but kept out of `grabbed`: that array
+    // also feeds Phase 3's matchAndHeal, which must not treat an already-
+    // importing row as a fresh grab to match a completed torrent against.
+    const importing = await this.historyRepo.find({
+      where: { status: 'importing' },
+    });
 
-    // Phase 2 — reconcile grabbed rows against the live torrent list: flip
-    // ones whose torrent has been gone past the grace period to `failed`,
-    // and clear a prior orphan stamp off any row whose torrent reappeared.
-    // Media link is preserved either way. Skipped on a partial fetch.
+    // Phase 2 — reconcile grabbed/importing rows against the live torrent
+    // list: flip ones whose torrent has been gone past the grace period to
+    // `failed`, and clear a prior orphan stamp off any row whose torrent
+    // reappeared. Media link is preserved either way. Skipped on a partial
+    // fetch.
     if (allClientsResponded) {
-      await this.reconcileOrphanHistory(allTorrents, grabbed);
+      await this.reconcileOrphanHistory(allTorrents, grabbed, importing);
     }
 
     // Phase 3 — import the completed torrents.
@@ -410,31 +419,40 @@ export class CompletionService {
   }
 
   /**
-   * Reconcile grabbed/failed rows against the live torrent list. Caller must
-   * pass a complete list (every client responded), since both directions key
-   * off a torrent's presence:
+   * Reconcile grabbed/importing/failed rows against the live torrent list.
+   * Caller must pass a complete list (every client responded), since every
+   * direction keys off a torrent's presence:
    *
-   *  - A `grabbed` row whose torrent has been gone for at least
-   *    {@link ORPHAN_GRACE_MS} flips to `failed`. The grace is measured off
-   *    `updatedAt`, which every status / hash heal write bumps, so a row
+   *  - A `grabbed` or `importing` row whose torrent has been gone for at least
+   *    {@link ORPHAN_GRACE_MS} flips to `failed` — this is what reconciles a
+   *    torrent the user removed from the client by hand. The grace is measured
+   *    off `updatedAt`, which every status / hash heal write bumps, so a row
    *    whose torrent just arrived has a fresh timestamp and won't be flipped.
    *  - A `failed` row carrying the {@link ORPHAN_STATUS_MESSAGE} stamp whose
    *    torrent is matched again returns to `grabbed`, so the activity queue
    *    never shows "no longer present" beside a torrent the client still
    *    reports. A torrent that failed for any other reason keeps its status.
    *
-   * The media link is preserved in both directions.
+   * The media link is preserved in every direction. A `queue.updated` event is
+   * emitted on any change so the sidebar badge refreshes live rather than
+   * staying stale until the next navigation.
    */
   private async reconcileOrphanHistory(
     allTorrents: ReadonlyArray<QbittorrentTorrent>,
     grabbed: DownloadHistory[],
+    importing: DownloadHistory[],
   ): Promise<void> {
-    if (!grabbed.length) return;
+    if (!grabbed.length && !importing.length) return;
+    // Match torrents against both sets so a live torrent keeps either kind of
+    // row off the orphan list.
+    const candidates = [...grabbed, ...importing];
     const matchedHistoryIds = new Set<number>();
     for (const t of allTorrents) {
-      const m = this.historyMatcher.findMatch(t, grabbed);
+      const m = this.historyMatcher.findMatch(t, candidates);
       if (m) matchedHistoryIds.add(m.history.id);
     }
+
+    let changed = false;
 
     const revived = grabbed.filter(
       (h) =>
@@ -447,29 +465,34 @@ export class CompletionService {
         revived.map((h) => h.id),
         { status: 'grabbed', statusMessage: null as unknown as string },
       );
+      changed = true;
       this.log.log(
         `Import: ${revived.length} entries reappeared in qBittorrent — cleared the orphan stamp and re-armed for import`,
       );
     }
 
     const cutoff = Date.now() - ORPHAN_GRACE_MS;
-    const expired = grabbed.filter(
+    const expired = candidates.filter(
       (h) =>
-        h.status === 'grabbed' &&
+        (h.status === 'grabbed' || h.status === 'importing') &&
         !matchedHistoryIds.has(h.id) &&
         h.updatedAt.getTime() < cutoff,
     );
-    if (!expired.length) return;
-    await this.historyRepo.update(
-      expired.map((h) => h.id),
-      {
-        status: 'failed',
-        statusMessage: ORPHAN_STATUS_MESSAGE,
-      },
-    );
-    this.log.warn(
-      `Import: ${expired.length} grabbed entries lost their torrent in qBittorrent for > ${ORPHAN_GRACE_MS / 60_000}min — marked failed (media link preserved)`,
-    );
+    if (expired.length) {
+      await this.historyRepo.update(
+        expired.map((h) => h.id),
+        {
+          status: 'failed',
+          statusMessage: ORPHAN_STATUS_MESSAGE,
+        },
+      );
+      changed = true;
+      this.log.warn(
+        `Import: ${expired.length} grabbed/importing entries lost their torrent in qBittorrent for > ${ORPHAN_GRACE_MS / 60_000}min — marked failed (media link preserved)`,
+      );
+    }
+
+    if (changed) this.events.emit({ type: 'queue.updated' });
   }
 
   private async processOne(


### PR DESCRIPTION
## Bug
After manually removing torrents from qBittorrent, the sidebar queue badge stayed stale (e.g. `(16)`).

## Why
The badge counts `grabbed` + `importing` history rows (cheap DB aggregate, no live qBit fan-out). The orphan sweep that reconciles those rows:
- only flipped **`grabbed`** rows (never `importing`) after a **30-min** grace → a torrent deleted mid-import stuck the count forever;
- never emitted `queue.updated` → even once the DB reconciled, the open badge didn't refresh until a navigation.

## Fix
- **Emit `queue.updated`** whenever the sweep flips or revives a row → badge refreshes live.
- **Reconcile `importing` rows** the same way (absent torrent past grace → `failed`), via a separate query so Phase 3's `matchAndHeal` set is untouched. Confirmed safe: the import flow never removes the torrent during `importing` (only `SeedCleanup` removes completed/seeding torrents later).
- **Grace 30 min → 5 min**: since #404 the sweep runs only when *every* client answered, so a torrent's absence is reliable; 5 min just covers a freshly-grabbed torrent not yet surfaced.

Badge stays cheap (DB + SSE), self-heals within ~5 min of any manual deletion, refreshes live, and never sticks forever.

## Verification
`tsc` clean; completion.service spec extended (8 tests: grabbed + importing reconcile, revive, grace window, emit on change / silent on no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)