### PR TITLE
feat(media-detail): hide the open episode and jump to the next

### DIFF
--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -76,12 +76,12 @@
           (openTracking)="openTracking({ kind: 'episode', episodeId: ep.id })"
         />
 
-        @if (currentSeasonEpisodes().length > 1) {
+        @if (moreFromSeasonEpisodes().length > 0) {
           <app-media-detail-seasons
             [media]="m"
             [selectedSeason]="s"
             [activeSeasonId]="s.id"
-            [filteredEpisodes]="currentSeasonEpisodes()"
+            [filteredEpisodes]="moreFromSeasonEpisodes()"
             [watchedEpisodeIds]="watchedEpisodeIds()"
             [episodeProgress]="episodeProgress()"
             [hideControls]="true"

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -341,6 +341,16 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   });
 
   /**
+   * Episodes shown in the "Plus de saison X" row — the focused season minus the
+   * episode already open above it: listing the active episode in its own
+   * "more from this season" row is redundant.
+   */
+  readonly moreFromSeasonEpisodes = computed<Episode[]>(() => {
+    const activeId = this.focusedEpisode()?.id;
+    return this.currentSeasonEpisodes().filter((e) => e.id !== activeId);
+  });
+
+  /**
    * Sibling seasons rendered as cards under the "more from season N" row on
    * the episode detail page. Hides the currently-focused season and any
    * empty season (no episodes → no link target).
@@ -364,18 +374,30 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * When the focused episode changes on the episode detail page, center the
-   * "Plus de saison X" scroller on its card. Retries across rAF ticks
-   * because the card and its scroll container mount through
-   * app-media-detail-seasons → app-horizontal-scroller → ng-content, which
-   * can take a couple of change-detection passes to settle — a single rAF
-   * sometimes fires before the element (or its layout) exists.
+   * When the focused episode changes on the episode detail page, bring the
+   * "Plus de saison X" scroller to the episode AFTER the active one — the
+   * active episode is hidden from the row, so we surface what comes next.
+   * When the active episode is the season's last, scroll the row to its end
+   * instead. The setTimeout lets the card and its scroll container mount
+   * through app-media-detail-seasons → app-horizontal-scroller → ng-content
+   * before we measure — they can take a change-detection pass or two to settle.
    */
   private readonly scrollToFocusedEpisodeEffect = effect(() => {
-    const ep = this.focusedEpisode();
-    const hasEpisodes = this.currentSeasonEpisodes().length > 1;
-    if (!ep || !this.episodeMode() || !hasEpisodes) return;
-    setTimeout(() => this.scrollToEpisode(ep.id), 30);
+    const active = this.focusedEpisode();
+    const eps = this.currentSeasonEpisodes();
+    if (
+      !active ||
+      !this.episodeMode() ||
+      this.moreFromSeasonEpisodes().length === 0
+    ) {
+      return;
+    }
+    const idx = eps.findIndex((e) => e.id === active.id);
+    const next = idx >= 0 ? eps[idx + 1] : undefined;
+    setTimeout(() => {
+      if (next) this.scrollToEpisode(next.id);
+      else this.scrollToEpisodesRowEnd();
+    }, 30);
   });
 
   private scrollToEpisode(epId: number): void {
@@ -389,6 +411,20 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       scroller.scrollLeft + (elRect.left - scrollerRect.left)
       - scroller.clientWidth / 2 + el.offsetWidth / 2;
     scroller.scrollTo({ left: Math.max(0, target), behavior: 'smooth' });
+  }
+
+  /** Scroll the "Plus de saison X" row to its far end — used when the active
+   *  episode (hidden from the row) is the season's last, so there is no "next"
+   *  card to center on. Anchors off the last rendered card to find the row's
+   *  scroller. */
+  private scrollToEpisodesRowEnd(): void {
+    const last = this.moreFromSeasonEpisodes().at(-1);
+    if (!last) return;
+    const el = document.getElementById(`episode-${last.id}`);
+    if (!el) return;
+    const scroller = this.findHorizontalScrollParent(el);
+    if (!scroller) return;
+    scroller.scrollTo({ left: scroller.scrollWidth, behavior: 'smooth' });
   }
 
   private findHorizontalScrollParent(el: HTMLElement): HTMLElement | null {

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -2060,6 +2060,15 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     this.playbackRate.set(rate);
   }
 
+  /** Whether the episode reached the completion threshold — mirrors the
+   *  backend (within 30s of the end, or past 90%). Drives the "back" target:
+   *  a finished episode returns to the next one. */
+  private episodeFinished(): boolean {
+    const dur = this.duration();
+    const pos = this.currentTime();
+    return dur > 0 && (pos >= dur - 30 || pos >= dur * 0.9);
+  }
+
   onBack() {
     this.savePosition();
     // Explicit navigation rather than history.back() — nav-inside-player
@@ -2073,10 +2082,17 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       target = '/';
     } else {
       const kind = this.media?.type === 'series' ? 'series' : 'movies';
-      target =
-        this.episodeId && kind === 'series'
-          ? `/series/${this.mediaId}/episode/${this.episodeId}`
-          : `/${kind}/${this.mediaId}`;
+      if (this.episodeId && kind === 'series') {
+        // A finished episode returns to the NEXT episode's detail page so the
+        // user lands ready to continue; an episode left mid-watch returns to
+        // its own page (to resume).
+        const next = this.nextEpisodeContext();
+        const epId =
+          this.episodeFinished() && next ? next.episodeId : this.episodeId;
+        target = `/series/${this.mediaId}/episode/${epId}`;
+      } else {
+        target = `/${kind}/${this.mediaId}`;
+      }
     }
     // If the previous URL is already the target, just pop /watch off the
     // browser stack — replaceUrl would otherwise stack a duplicate


### PR DESCRIPTION
Episode-navigation polish on the series detail page + player exit.

- **Hide the open episode** in the "Plus de saison X" row — listing the episode already shown above it is redundant (`moreFromSeasonEpisodes` computed).
- **Scroll to what's next**: that row now scrolls to the episode after the active one; when the active episode is the season's last, it scrolls to the row's end instead (the old centring targeted the now-hidden active card).
- **Continue on finish**: finishing an episode and closing the player returns to the NEXT episode's detail page (backend completion threshold — within 30s of the end, or past 90%) rather than the one just watched. An episode left mid-watch still returns to its own page to resume.

## Verification
`tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)