### PR TITLE
chore: ignore the local .claude config directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ plans/
 docker-compose.yml
 docker-compose.prod.yml
 .worktrees/
+.claude/
 
 release/
 


### PR DESCRIPTION
Keeps the Claude Code session/config dir out of version control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)