### PR TITLE
fix(playback): only record watch history after 5s of playback

### DIFF
--- a/backend/src/modules/streaming/playback.service.spec.ts
+++ b/backend/src/modules/streaming/playback.service.spec.ts
@@ -1,0 +1,55 @@
+import { PlaybackService } from './playback.service';
+import { PlaybackState } from './entities/playback-state.entity';
+
+/**
+ * `updateState` only needs `findState` + `repo`, so we exercise it on a bare
+ * prototype instance rather than the full multi-dependency constructor. The
+ * contract under test: a media enters the watch history (`playedAt`) only once
+ * at least 5 s of progress is reported.
+ */
+function buildService(existing: Partial<PlaybackState> | null) {
+  const service = Object.create(PlaybackService.prototype) as PlaybackService;
+  const save = jest.fn(async (x: unknown) => x);
+  const wired = service as unknown as { repo: unknown; findState: unknown };
+  wired.repo = { save, create: (x: unknown) => ({ ...(x as object) }) };
+  wired.findState = jest.fn(async () => existing);
+  return { service, save };
+}
+
+const body = (positionSeconds: number) => ({
+  positionSeconds,
+  durationSeconds: 1000,
+  mediaFileId: 9,
+});
+
+describe('PlaybackService.updateState — history 5s threshold', () => {
+  it('does not stamp playedAt below 5s on a fresh row', async () => {
+    const { service, save } = buildService(null);
+    await service.updateState(1, 2, body(3));
+    expect(save.mock.calls[0][0]).toMatchObject({ playedAt: null });
+  });
+
+  it('stamps playedAt at or above 5s on a fresh row', async () => {
+    const { service, save } = buildService(null);
+    await service.updateState(1, 2, body(7));
+    expect((save.mock.calls[0][0] as PlaybackState).playedAt).toBeInstanceOf(
+      Date,
+    );
+  });
+
+  it('refreshes playedAt for a watched existing row', async () => {
+    const existing = { positionSeconds: 0, playedAt: null } as Partial<PlaybackState>;
+    const { service } = buildService(existing);
+    await service.updateState(1, 2, body(50));
+    expect(existing.playedAt).toBeInstanceOf(Date);
+  });
+
+  it('keeps a prior history stamp when a brief re-touch is below 5s', async () => {
+    const prior = new Date(Date.now() - 100_000);
+    const existing = { positionSeconds: 0, playedAt: prior } as Partial<PlaybackState>;
+    const { service } = buildService(existing);
+    await service.updateState(1, 2, body(3));
+    // Below threshold must not pull the item back out of (or re-stamp) history.
+    expect(existing.playedAt).toBe(prior);
+  });
+});

--- a/backend/src/modules/streaming/playback.service.ts
+++ b/backend/src/modules/streaming/playback.service.ts
@@ -65,6 +65,13 @@ export interface MediaResumeInfo {
  */
 const RESUME_FROM_START_UNDER_SECONDS = 10;
 
+/**
+ * Minimum watched position before a media enters the watch history
+ * (`playedAt` stamp). Keeps an accidental click that's closed within a few
+ * seconds out of the history — only a real watch (≥ 5 s) records.
+ */
+const HISTORY_MIN_WATCH_SECONDS = 5;
+
 /** Postgres foreign-key violation. Library refresh can drop the parent media
  *  row mid-session; cascade clears existing playback_states, then a beacon
  *  arrives for that mediaId and the fresh INSERT trips this FK. */
@@ -270,13 +277,20 @@ export class PlaybackService implements OnModuleInit {
     const dur = body.durationSeconds ?? 0;
     const pos = body.positionSeconds ?? 0;
     const completed = dur > 0 && (pos >= dur - 30 || pos >= dur * 0.9);
+    const now = new Date();
+    // Enter (or refresh) the watch history only once a real watch threshold is
+    // crossed, so an accidental click closed within a few seconds never lands
+    // in history. `playedAt` is the history marker; below the threshold we
+    // leave it untouched (null on a fresh row).
+    const watched = pos >= HISTORY_MIN_WATCH_SECONDS;
 
     if (state) {
       state.positionSeconds = pos;
       if (dur > 0) state.durationSeconds = dur;
       state.completed = completed;
       state.hiddenFromContinueWatching = false;
-      state.lastPlayedAt = new Date();
+      state.lastPlayedAt = now;
+      if (watched) state.playedAt = now;
       state.mediaFile = { id: body.mediaFileId } as MediaFile;
     } else {
       state = this.repo.create({
@@ -288,7 +302,8 @@ export class PlaybackService implements OnModuleInit {
         positionSeconds: pos,
         durationSeconds: dur || 0,
         completed,
-        lastPlayedAt: new Date(),
+        lastPlayedAt: now,
+        playedAt: watched ? now : null,
       });
     }
 
@@ -301,9 +316,11 @@ export class PlaybackService implements OnModuleInit {
   }
 
   /**
-   * Mark a playback session as started. Creates the playback_states row if
-   * missing and stamps `playedAt = NOW()` so the media appears in the user's
-   * watch history (history = sessions started, not a progress threshold).
+   * Mark a playback session as started: ensure the playback_states row exists
+   * and refresh `lastPlayedAt` / the linked file. The watch-history stamp
+   * (`playedAt`) is intentionally NOT set here — a media enters the history
+   * only once {@link HISTORY_MIN_WATCH_SECONDS} of progress is reported through
+   * {@link updateState}, so an instant click-and-close never lands in it.
    * Called by the streaming controller at playback-info time.
    */
   async markSessionStarted(
@@ -315,7 +332,6 @@ export class PlaybackService implements OnModuleInit {
     const state = await this.findState(userId, mediaId, episodeId ?? undefined);
     const now = new Date();
     if (state) {
-      state.playedAt = now;
       state.lastPlayedAt = now;
       if (mediaFileId) state.mediaFileId = mediaFileId;
       await this.repo.save(state);
@@ -329,7 +345,6 @@ export class PlaybackService implements OnModuleInit {
         durationSeconds: 0,
         completed: false,
         lastPlayedAt: now,
-        playedAt: now,
       } as Partial<PlaybackState>);
     }
   }


### PR DESCRIPTION
## Bug
A media landed in the watch history the instant playback started — a misfired click closed within a second or two still showed up.

## Cause
`markSessionStarted` stamped `playedAt` (the history marker `getHistory` filters on) at playback-info time, before any watched duration was known.

## Fix
- `markSessionStarted` no longer stamps `playedAt` — it just ensures the resume row exists.
- `updateState` stamps `playedAt` once `positionSeconds >= 5` (`HISTORY_MIN_WATCH_SECONDS`).

A real watch — or a resume (position already ≥ 5) — still records and bumps to the top of history; a sub-5s play is left out, and an item already in history isn't pulled back out by a brief re-touch.

## Verification
`tsc` clean; new `playback.service.spec.ts` (4 tests: below/at threshold × fresh/existing row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)