### PR TITLE
feat(clearlogo): show title clearlogos across the app

### DIFF
--- a/backend/src/migrations/1779800000000-add-media-logo-url.ts
+++ b/backend/src/migrations/1779800000000-add-media-logo-url.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Clearlogo (transparent PNG title treatment) for media, stored as a local
+ * image API path. Nullable — media without a provider logo, and rows created
+ * before this migration, keep it null until the next metadata refresh.
+ */
+export class AddMediaLogoUrl1779800000000 implements MigrationInterface {
+  name = 'AddMediaLogoUrl1779800000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "media"
+        ADD COLUMN IF NOT EXISTS "logoUrl" character varying
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "media"
+        DROP COLUMN IF EXISTS "logoUrl"
+    `);
+  }
+}

--- a/backend/src/modules/images/image.service.ts
+++ b/backend/src/modules/images/image.service.ts
@@ -8,7 +8,11 @@ export type ImageType = 'media' | 'person' | 'episode' | 'season' | 'request';
  *  fanarts kept for randomised page backgrounds — they share `fanart`'s
  *  size pipeline (thumb / medium / full) so frontends can request any
  *  size without an extra round-trip to the source provider. */
-export type MediaImageVariant = 'poster' | 'fanart' | `fanart-${number}`;
+export type MediaImageVariant =
+  | 'poster'
+  | 'fanart'
+  | `fanart-${number}`
+  | 'logo';
 export type ImageSize = 'thumb' | 'medium' | 'full';
 
 /**
@@ -25,6 +29,8 @@ export type ImageSize = 'thumb' | 'medium' | 'full';
 const TMDB_SIZE_MAP: Record<string, Partial<Record<ImageSize, string>>> = {
   'media/poster': { thumb: 'w185', medium: 'w500', full: 'original' },
   'media/fanart': { thumb: 'w300', medium: 'w780', full: 'original' },
+  // Clearlogo (transparent PNG title treatment).
+  'media/logo': { thumb: 'w185', medium: 'w500', full: 'original' },
   // Request card art — keyed by `{mediaType}-{tmdbId}` (TMDB ids are
   // namespaced per media type, so a movie and a series can share the same
   // number). Every request for the same title shares one stored file.
@@ -165,13 +171,16 @@ export class ImageService {
     size: ImageSize = 'full',
   ): string {
     const suffix = size === 'full' ? '' : `-${size}`;
+    // Logos are transparent PNGs — keep the .png extension so sendFile serves
+    // image/png (a .jpg-named PNG would be flattened/blocked under nosniff).
+    const ext = variant === 'logo' ? 'png' : 'jpg';
     switch (type) {
       case 'media':
         return path.join(
           this.baseDir,
           'media',
           String(id),
-          `${variant ?? 'poster'}${suffix}.jpg`,
+          `${variant ?? 'poster'}${suffix}.${ext}`,
         );
       case 'request':
         return path.join(

--- a/backend/src/modules/media/entities/media.entity.ts
+++ b/backend/src/modules/media/entities/media.entity.ts
@@ -118,6 +118,11 @@ export class Media extends BaseEntity {
   @Column({ nullable: true })
   fanartUrl: string;
 
+  /** Transparent PNG "clearlogo" (title treatment), stored as a local API
+   *  path. Null when the provider has no logo for the title. */
+  @Column({ nullable: true })
+  logoUrl: string;
+
   /** Extra fanarts pulled from the provider (top N by score), stored
    *  as local API paths (variants `fanart-1`, `fanart-2`, …). Mixed
    *  with {@link fanartUrl} to randomise the page background. */

--- a/backend/src/modules/media/media-service/media-metadata.service.ts
+++ b/backend/src/modules/media/media-service/media-metadata.service.ts
@@ -608,6 +608,15 @@ export class MediaMetadataService {
       );
       if (local) updates.fanartUrl = local;
     }
+    if (details.logoUrl) {
+      const local = await this.imageService.downloadAndStore(
+        details.logoUrl,
+        'media',
+        mediaId,
+        'logo',
+      );
+      if (local) updates.logoUrl = local;
+    }
 
     // Extra fanarts (variants fanart-1..N). Downloaded in parallel
     // since each entry is an independent CDN GET. Slots are

--- a/backend/src/modules/media/media-service/tmdb-mapping.util.ts
+++ b/backend/src/modules/media/media-service/tmdb-mapping.util.ts
@@ -51,6 +51,7 @@ export function buildMediaFieldsFromTmdb(
     status: mapTmdbStatusToMediaStatus(type, details.status),
     posterUrl: details.posterUrl ?? undefined,
     fanartUrl: details.fanartUrl ?? undefined,
+    logoUrl: details.logoUrl ?? undefined,
     rating: details.rating ?? undefined,
     genres: details.genres?.length ? details.genres : [],
     runtime: details.runtime ?? undefined,

--- a/backend/src/modules/metadata-providers/interfaces/metadata-provider.interface.ts
+++ b/backend/src/modules/metadata-providers/interfaces/metadata-provider.interface.ts
@@ -17,6 +17,9 @@ export interface MetadataDetails extends MetadataSearchResult {
   imdbId: string | null;
   tvdbId: number | null;
   fanartUrl: string | null;
+  /** Transparent PNG "clearlogo" title treatment, when the provider has one
+   *  (TMDB logos). Null otherwise. */
+  logoUrl: string | null;
   /** Extra fanarts (top-N) returned by the provider, used to
    *  randomise the page background. Empty array when the provider
    *  has no additional artwork. */

--- a/backend/src/modules/metadata-providers/providers/tmdb.provider.ts
+++ b/backend/src/modules/metadata-providers/providers/tmdb.provider.ts
@@ -52,6 +52,30 @@ function pickAdditionalFanarts(
 }
 
 /**
+ * Pick the best "clearlogo" from a TMDB images payload. Logos are
+ * language-tagged transparent PNGs; prefer French, then English, then a
+ * language-neutral / any logo, breaking ties on the community vote. Returns
+ * the original-size URL (the PNG keeps its transparency) or null when the
+ * title has no logo. Requires the details request to set
+ * `include_image_language` so non-`fr-FR` logos are actually returned.
+ */
+function pickLogo(images: TmdbImages | undefined): string | null {
+  const logos = (images?.logos ?? []).filter((l) => l.file_path);
+  if (!logos.length) return null;
+  // Community vote is the best proxy for "the clean official title logo":
+  // promotional banners (cast names, "in theatres" dates) get uploaded but
+  // rarely upvoted, so they sink below the real logo. Language only adds a
+  // small bonus that tips otherwise-close calls toward the user's locale —
+  // never enough to override a clearly better-voted logo in another language.
+  const langBonus = (lang: string | null | undefined): number =>
+    lang === 'fr' ? 0.5 : lang === 'en' ? 0.25 : 0;
+  const score = (l: { vote_average?: number; iso_639_1?: string | null }): number =>
+    (l.vote_average ?? 0) + langBonus(l.iso_639_1);
+  const best = [...logos].sort((a, b) => score(b) - score(a))[0];
+  return `${TMDB_IMAGE_BASE}/original${best.file_path}`;
+}
+
+/**
  * Pull alternative_titles out of a TMDB movie / tv details response.
  * The two endpoints differ on field name (`titles` vs `results`) and item
  * key (`title` vs `name`). Output is deduplicated against `data.title /
@@ -141,6 +165,9 @@ export class TmdbProvider implements IMetadataProvider {
       {
         params: {
           language: 'fr-FR',
+          // Logos are language-tagged; request fr + en + language-neutral so
+          // pickLogo has fallbacks beyond the fr-FR `language` default.
+          include_image_language: 'fr,en,null',
           append_to_response:
             'external_ids,images,release_dates,credits,videos,keywords,alternative_titles',
         },
@@ -164,6 +191,7 @@ export class TmdbProvider implements IMetadataProvider {
       fanartUrl: data.backdrop_path
         ? `${TMDB_IMAGE_BASE}/original${data.backdrop_path}`
         : null,
+      logoUrl: pickLogo(data.images),
       additionalFanartUrls: pickAdditionalFanarts(
         data.images,
         data.backdrop_path,
@@ -224,6 +252,9 @@ export class TmdbProvider implements IMetadataProvider {
       {
         params: {
           language: 'fr-FR',
+          // Logos are language-tagged; request fr + en + language-neutral so
+          // pickLogo has fallbacks beyond the fr-FR `language` default.
+          include_image_language: 'fr,en,null',
           append_to_response:
             'external_ids,images,credits,videos,keywords,alternative_titles',
         },
@@ -244,6 +275,7 @@ export class TmdbProvider implements IMetadataProvider {
       fanartUrl: data.backdrop_path
         ? `${TMDB_IMAGE_BASE}/original${data.backdrop_path}`
         : null,
+      logoUrl: pickLogo(data.images),
       additionalFanartUrls: pickAdditionalFanarts(
         data.images,
         data.backdrop_path,

--- a/backend/src/modules/metadata-providers/providers/tvdb.provider.ts
+++ b/backend/src/modules/metadata-providers/providers/tvdb.provider.ts
@@ -58,6 +58,9 @@ function dedupeAliases(
 /** Artwork type IDs: 2=poster, 3=background/fanart, 7=banner, 12=clearart */
 const ART_POSTER = 2;
 const ART_BACKGROUND = 3;
+// TVDB clearlogo artwork type — distinct id per record kind (series vs movie).
+const ART_CLEARLOGO_SERIES = 23;
+const ART_CLEARLOGO_MOVIE = 25;
 
 @Injectable()
 export class TvdbProvider implements IMetadataProvider {
@@ -152,6 +155,7 @@ export class TvdbProvider implements IMetadataProvider {
       year: m.year ? parseInt(m.year) : null,
       posterUrl: this.pickArtwork(m.artworks, ART_POSTER) ?? m.image ?? null,
       fanartUrl: this.pickArtwork(m.artworks, ART_BACKGROUND) ?? null,
+      logoUrl: this.pickArtwork(m.artworks, ART_CLEARLOGO_MOVIE) ?? null,
       additionalFanartUrls: this.pickArtworks(
         m.artworks,
         ART_BACKGROUND,
@@ -223,6 +227,7 @@ export class TvdbProvider implements IMetadataProvider {
       year: s.year ? parseInt(s.year) : null,
       posterUrl: this.pickArtwork(s.artworks, ART_POSTER) ?? s.image ?? null,
       fanartUrl: this.pickArtwork(s.artworks, ART_BACKGROUND) ?? null,
+      logoUrl: this.pickArtwork(s.artworks, ART_CLEARLOGO_SERIES) ?? null,
       additionalFanartUrls: this.pickArtworks(
         s.artworks,
         ART_BACKGROUND,

--- a/client/src/app/core/services/api/media.service.ts
+++ b/client/src/app/core/services/api/media.service.ts
@@ -92,6 +92,8 @@ export interface Media {
   library?: { id: number; name: string } | null;
   posterUrl: string | null;
   fanartUrl: string | null;
+  /** Transparent PNG clearlogo (title treatment), or null. */
+  logoUrl: string | null;
   /** Extra fanarts kept locally (variants `fanart-1`..`fanart-N`).
    *  Mixed with {@link fanartUrl} for the randomised page background. */
   additionalFanartUrls: string[];

--- a/client/src/app/core/services/navbar.service.ts
+++ b/client/src/app/core/services/navbar.service.ts
@@ -10,6 +10,9 @@ import { DeviceService } from './device.service';
 export class NavbarService {
   /** When set, the navbar shows this title instead of "Fliks" on scroll. */
   readonly heroTitle = signal('');
+  /** Clearlogo for the current hero page, shown in the topbar / back row in
+   *  place of the title text. Null when the page has no logo. */
+  readonly heroLogoUrl = signal<string | null>(null);
   /** Whether the current page has a hero fanart. */
   readonly isHeroPage = signal(false);
   /** Resolved title for non-hero routes (set from route data or by components). */
@@ -172,11 +175,12 @@ export class NavbarService {
   );
 
   /** Mark the current page as having a hero fanart (enables transparent navbar + white icons). */
-  enterHeroPage(title: string) {
+  enterHeroPage(title: string, logoUrl: string | null = null) {
     document.body.classList.add('hero-page');
     this.isHeroPage.set(true);
     this.pageTitle.set('');
     this.heroTitle.set(title);
+    this.heroLogoUrl.set(logoUrl);
     // Re-evaluate scrollAtTop from the actual position. Without this, the
     // navbar stays opaque after returning from /watch — the scroll value
     // is whatever the previous page left it at and no scroll event fires
@@ -190,6 +194,7 @@ export class NavbarService {
     document.body.classList.remove('hero-page');
     this.isHeroPage.set(false);
     this.heroTitle.set('');
+    this.heroLogoUrl.set(null);
   }
 
   toggleSidebarPinned() {

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -50,7 +50,6 @@
           [posterUrl]="ep.stillUrl ?? m.fanartUrl ?? null"
           [posterMode]="'still'"
           [backRoute]="episodeSeriesRoute()"
-          [backLabel]="m.title"
           [subtitles]="subtitleSection()?.headerSubtitles() ?? []"
           [files]="episodeFiles()"
           [selectedFileId]="episodeActiveFileId()"

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -835,7 +835,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       this.episodeMode.set(false);
       this.focusedSeason.set(null);
       this.focusedEpisode.set(null);
-      this.navbarService.enterHeroPage(m.title);
+      this.navbarService.enterHeroPage(m.title, m.logoUrl);
       return;
     }
     const episodeId = Number(episodeIdParam);
@@ -860,6 +860,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     const en = String(foundEpisode.episodeNumber).padStart(2, '0');
     this.navbarService.enterHeroPage(
       `${m.title} — S${sn}:E${en} — ${foundEpisode.title ?? ''}`,
+      m.logoUrl,
     );
   }
 

--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -14,12 +14,18 @@
   [class.pointer-events-none]="!visible()"
 >
   <!-- Left: back + title -->
-  <div class="flex items-center gap-2 min-w-0">
+  <div class="flex items-center gap-4 min-w-0">
     <button type="button" class="btn btn-ghost btn-circle text-white" [class]="isMobileTouch() ? 'btn-sm' : 'btn-md'" [attr.aria-label]="'player.back' | translate" (click)="back.emit()">
       <!-- lucide:chevron-left -->
       <svg lucideChevronLeft [class]="isMobileTouch() ? 'h-6 w-6' : 'h-7 w-7'"></svg>
     </button>
-    <span class="text-white font-semibold truncate" [class]="isMobileTouch() ? 'text-lg' : 'text-xl'">{{ mediaTitle() }}</span>
+    @if (logoUrl()) {
+      <img [src]="logoUrl()! | resolveUrl:'medium'" [alt]="mediaTitle()"
+           class="w-auto object-contain object-left [filter:drop-shadow(0_1px_2px_rgb(0_0_0/0.5))]"
+           [class]="isMobileTouch() ? 'h-7' : 'h-9'" />
+    } @else {
+      <span class="text-white font-semibold truncate" [class]="isMobileTouch() ? 'text-lg' : 'text-xl'">{{ mediaTitle() }}</span>
+    }
   </div>
 
   <!-- Right -->

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -21,6 +21,7 @@ import { BottomSheetComponent } from '../../../shared/components/bottom-sheet';
 import { TranslateModule } from '@ngx-translate/core';
 import { formatTime, SpriteMetadata } from '../../../core/utils/player.utils';
 import { SeekbarComponent } from '../../../shared/components/seekbar/seekbar';
+import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 import {
   LucideCaptions,
   LucideCheck,
@@ -63,6 +64,7 @@ import {
     NgTemplateOutlet,
     BottomSheetComponent,
     SeekbarComponent,
+    ResolveUrlPipe,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './player-controls.html',
@@ -147,6 +149,8 @@ export class PlayerControlsComponent {
   readonly volume = input(1);
   readonly playbackRate = input(1);
   readonly mediaTitle = input('');
+  /** Clearlogo shown in place of the title text in the top-left overlay. */
+  readonly logoUrl = input<string | null>(null);
   readonly episodeTitle = input('');
   readonly hasNextEpisode = input(false);
   readonly hasPrevEpisode = input(false);

--- a/client/src/app/features/player/player.html
+++ b/client/src/app/features/player/player.html
@@ -100,6 +100,7 @@
     [volume]="volume()"
     [playbackRate]="playbackRate()"
     [mediaTitle]="mediaTitle()"
+    [logoUrl]="mediaLogoUrl()"
     [episodeTitle]="episodeTitle()"
     [hasNextEpisode]="nextEpisodeContext() !== null"
     [hasPrevEpisode]="false"

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -420,6 +420,9 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   private activeAudioStreamIndex: number | undefined;
 
   readonly mediaTitle = signal('');
+  /** Clearlogo for the playing media, shown in the player's top-left overlay
+   *  in place of the title text. */
+  readonly mediaLogoUrl = signal<string | null>(null);
   readonly episodeTitle = signal('');
   readonly fanartUrl = signal<string | null>(null);
 
@@ -775,6 +778,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         this.media = media;
         this.mediaLoadedTick.update(v => v + 1);
         this.mediaTitle.set(media.title);
+        this.mediaLogoUrl.set(media.logoUrl ?? null);
         if (media.fanartUrl) this.fanartUrl.set(this.serverConfig.resolveUrl(media.fanartUrl));
 
         const file = media.files?.find((f: any) => f.id === this.mediaFileId);

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -137,14 +137,6 @@
 
 <!-- ===== DESKTOP layout ===== -->
 <div class="hidden md:block tv:block relative">
-  @if (fanartUrl()) {
-    @if (!navbar.mobileNavbarVisible()) {
-      <button type="button" (click)="goBack()" class="relative z-10 btn btn-ghost btn gap-1 mb-4 text-base-content/80 hover:text-base-content">
-        <svg lucideChevronLeft class="h-4 w-4"></svg>
-        {{ backLabel() ?? ('media_detail.back' | translate) }}
-      </button>
-    }
-  }
 
   <div
     class="flex gap-6 lg:gap-10 relative z-20 tv:pt-24!"

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -16,7 +16,6 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { FormsModule } from '@angular/forms';
 import {
   LucideCaptions,
-  LucideChevronLeft,
   LucideCheck,
   LucideClipboardList,
   LucideDownload,
@@ -86,7 +85,7 @@ interface AudioTrack {
     TvSelectDirective,
     NgTemplateOutlet,
     DecimalPipe, FormsModule, RouterLink, TranslateModule,
-    LucideCaptions, LucideChevronLeft, LucideCheck, LucideClipboardList, LucideDownload,
+    LucideCaptions, LucideCheck, LucideClipboardList, LucideDownload,
     LucideEllipsisVertical, LucideEye, LucideEyeOff,
     LucideFilm, LucideFolder, LucideListChecks, LucidePlay, LucideRotateCcw, LucideScanLine,
     LucideSearch, LucideSettings, LucideSkipForward, LucideTrash2,
@@ -130,8 +129,8 @@ export class MediaInfoHeaderComponent {
   readonly fanartUrl = input<string | null>(null);
   readonly posterUrl = input<string | null>(null);
   readonly posterMode = input<'poster' | 'still'>('poster');
+  /** Route the title text links to (e.g. the series, from an episode page). */
   readonly backRoute = input<string[]>(['/']);
-  readonly backLabel = input<string | null>(null);
 
   // ── Inputs: subtitles (built by parent from SubtitleFileRow[]) ──
   readonly subtitles = input<MediaInfoHeaderSubtitle[]>([]);
@@ -468,9 +467,6 @@ export class MediaInfoHeaderComponent {
     return `${(bytes / 1_073_741_824).toFixed(2)} GB`;
   }
 
-  goBack() {
-    this.navbar.goBack(this.backRoute());
-  }
 
   async onDeleteFileClick() {
     const fileId = this.selectedFileId();

--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -40,13 +40,18 @@
         }
       </div>
       <div class="flex-1 min-w-0">
-        @if (navbarTransparent()) {
-          @if (navbar.heroTitle()) {
-            <span
-              class="block min-w-0 pl-2 text-lg font-semibold truncate [text-shadow:0_1px_2px_rgb(0_0_0/0.45)]"
-              [attr.title]="navbar.heroTitle()"
-              >{{ navbar.heroTitle() }}</span>
-          }
+        @if (navbar.heroLogoUrl()) {
+          <!-- Hero clearlogo — kept whether the navbar is transparent (at top)
+               or opaque (scrolled), so it doesn't revert to the title text. -->
+          <img
+            [src]="navbar.heroLogoUrl()! | resolveUrl:'medium'"
+            [alt]="navbar.heroTitle()"
+            class="h-7 w-auto max-w-[55%] object-contain object-left pl-2 [filter:drop-shadow(0_1px_2px_rgb(0_0_0/0.45))]" />
+        } @else if (navbarTransparent() && navbar.heroTitle()) {
+          <span
+            class="block min-w-0 pl-2 text-lg font-semibold truncate [text-shadow:0_1px_2px_rgb(0_0_0/0.45)]"
+            [attr.title]="navbar.heroTitle()"
+            >{{ navbar.heroTitle() }}</span>
         } @else if (isNative && isHomeRoute() && navbar.mobileNavTitle()) {
           <span class="flex items-center gap-2 pl-2 text-lg font-bold min-w-0">
             <img src="fliks-mark.png" alt="" class="h-7 w-7 shrink-0" />
@@ -94,25 +99,42 @@
     <!-- Desktop top-right: Cast + User -->
     <div appTvRow
          [appTvRowSnap]="true"
-         class="hidden items-center justify-end gap-1 absolute right-4 z-50 pointer-events-none [&>*]:pointer-events-auto"
-         [style.top]="tv.isTv() ? 'calc(4rem + env(safe-area-inset-top, 0px))' : isNative ? 'calc(0.3rem + env(safe-area-inset-top, 1.5rem))' : '1.5rem'"
+         class="hidden items-center justify-between gap-1 px-4 relative z-30"
+         [style.padding-top]="tv.isTv() ? 'calc(4rem + env(safe-area-inset-top, 0px))' : isNative ? 'calc(0.3rem + env(safe-area-inset-top, 1.5rem))' : '1rem'"
          [class.lg:flex]="device.isDesktop() || (device.isTv() && navbar.effectiveSidebarPinned())"
          [class.md:flex]="device.isTablet() && navbar.effectiveSidebarPinned()">
-      @if (castPlayer.hasMedia()) {
-        <button class="btn btn-ghost btn-sm gap-2" (click)="toggleCastOverlay()">
-          <svg lucideCast class="h-5 w-5 text-info"></svg>
-          <span class="text-xs font-medium truncate max-w-32">{{ castPlayer.mediaTitle() }}</span>
-        </button>
-      } @else if (castService.isAvailable()) {
-        <button class="btn btn-ghost btn-circle" (click)="onToggleCastConnection()" [disabled]="castService.connecting()">
-          @if (castService.connecting()) {
-            <span class="loading loading-spinner loading-sm"></span>
-          } @else {
-            <svg lucideCast class="h-6 w-6" [class.text-info]="castService.isConnected()"></svg>
-          }
-        </button>
-      }
-      <app-user-menu />
+      <!-- Hero back + clearlogo (left) -->
+      <div class="flex items-center gap-3 min-w-0">
+        @if (navbar.isHeroPage() && canGoBack()) {
+          <button type="button" (click)="goBack()"
+                  [attr.aria-label]="'media_detail.back' | translate"
+                  class="btn btn-ghost btn-circle">
+            <svg lucideChevronLeft class="h-5 w-5"></svg>
+          </button>
+        }
+        @if (navbar.heroLogoUrl()) {
+          <img [src]="navbar.heroLogoUrl()! | resolveUrl:'medium'" [alt]="navbar.heroTitle()"
+               class="h-7 lg:h-8 w-auto max-w-[280px] object-contain [filter:drop-shadow(0_1px_2px_rgb(0_0_0/0.45))]" />
+        }
+      </div>
+      <!-- Cast + user (right) -->
+      <div class="flex items-center gap-1">
+        @if (castPlayer.hasMedia()) {
+          <button class="btn btn-ghost btn-sm gap-2" (click)="toggleCastOverlay()">
+            <svg lucideCast class="h-5 w-5 text-info"></svg>
+            <span class="text-xs font-medium truncate max-w-32">{{ castPlayer.mediaTitle() }}</span>
+          </button>
+        } @else if (castService.isAvailable()) {
+          <button class="btn btn-ghost btn-circle" (click)="onToggleCastConnection()" [disabled]="castService.connecting()">
+            @if (castService.connecting()) {
+              <span class="loading loading-spinner loading-sm"></span>
+            } @else {
+              <svg lucideCast class="h-6 w-6" [class.text-info]="castService.isConnected()"></svg>
+            }
+          </button>
+        }
+        <app-user-menu />
+      </div>
     </div>
     <!-- overflow-x: clip clips horizontal overflow without forcing the
          element into a scroll container — `overflow-x: hidden` coerces
@@ -121,9 +143,8 @@
          `position: sticky` on descendants (sticky would anchor to <main>
          and never engage because the actual scroll happens on the page). -->
     <main
-      class="min-w-0 flex-1 p-4 lg:p-8"
+      class="min-w-0 flex-1 p-4"
       [class.overflow-x-clip]="!navbar.isHeroPage()"
-      [class.lg:pt-20]="!navbar.isHeroPage() && !navbar.mobileNavbarVisible()"
       [class.pt-8]="!navbar.isHeroPage() && !isNative && navbar.mobileNavbarVisible()"
     >
       @if (!networkService.isOnline()) {

--- a/client/src/app/shared/layout/layout.ts
+++ b/client/src/app/shared/layout/layout.ts
@@ -34,6 +34,7 @@ import { UserMenuComponent } from '../components/user-menu';
 import { LucideIconComponent } from '../components/lucide-icon';
 import { TvRowDirective } from '../directives/tv-row.directive';
 import { BackgroundComponent } from '../components/background/background';
+import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
 import { BackgroundService } from '../../core/services/background.service';
 import { SearchStateService } from '../../core/services/search-state.service';
 import {
@@ -65,6 +66,7 @@ import {
     LucideIconComponent,
     TvRowDirective,
     BackgroundComponent,
+    ResolveUrlPipe,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './layout.html',


### PR DESCRIPTION
Transparent PNG "clearlogo" title treatments, fetched + stored, shown in place of the title text across the app.

## Pipeline
- **TMDB** — pick the best logo by community **vote** (promotional banners with cast names / "in theatres" dates sink below the real logo), with a small locale bonus; request `fr,en,null` via `include_image_language`.
- **TVDB** — pick the `clearlogo` artwork (series type 23, movie type 25).
- Stored as **PNG** through the image pipeline (new `media.logoUrl` column + migration) so transparency + `Content-Type` are preserved.

## Display
- **media-detail**: desktop back row (round back + logo) and **mobile topbar** (kept on scroll, not just at top).
- **player**: top-left overlay (round back + logo).
- The desktop Cast/User row moves **in-flow** (was `absolute`) so it no longer overlaps page content — `lg:pt-20` clearance on `<main>` dropped accordingly.

Titles without a logo fall back to text everywhere.

## Verification
backend `tsc` + 181 tests pass; client `tsc` clean; validated end-to-end on TVDB (Arcane) and TMDB (movies) titles.

## Deploy
Backend redeploy (+ migration) and an APK/client rebuild. Existing media get a logo on their next metadata refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)