### PR TITLE
fix(streaming): 410 segment requests with no resolvable live session

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -1505,6 +1505,14 @@ export class StreamingController {
         req.user as User,
       );
       const ctx = this.buildSessionContext(req, resolved, mediaFileId);
+      // No resolvable LiveSession means no codec variant to thread into
+      // ffmpeg (player closed / torn down while segment requests were still
+      // in flight — e.g. a rapid open/close — or a stale sid). 410 so the
+      // client re-establishes via playback-info instead of a 500, and we
+      // never spawn a transcode for a stream nobody is watching.
+      if (!ctx.videoVariant) {
+        throw new SessionExpiredException(firstQueryString(req.query, 'sid') ?? null);
+      }
       ctx.spawnReason = 'seg-race';
       const live = this.findRequestSession(req, mediaFileId);
       const deviceType = live?.deviceType ?? 'desktop';
@@ -1838,6 +1846,13 @@ export class StreamingController {
     );
 
     const ctx = this.buildSessionContext(req, resolved, mediaFileId);
+    // No resolvable LiveSession → no codec variant to thread into ffmpeg
+    // (player closed / torn down with segment requests still in flight, or a
+    // stale sid). 410 so the client re-establishes instead of a 500 from
+    // buildFfmpegArgs; nothing is spawned for a stream nobody is watching.
+    if (!ctx.videoVariant) {
+      throw new SessionExpiredException(firstQueryString(req.query, 'sid') ?? null);
+    }
     ctx.spawnReason = 'seg-request';
 
     // Early probe routing: the seg-0/seg-1 init probe a player fires on


### PR DESCRIPTION
## Bug
Opening and closing the Shaka player in quick succession threw a 500 in the backend:
`buildFfmpegArgs: missing videoVariant for profile "…" — caller must thread it from the LiveSession`.

## Cause
The player creates a LiveSession on open and tears it down on close. Segment requests still in flight arrive after the teardown, find no session to thread the codec `videoVariant` from, and the seg-race / seg-request spawn reaches `buildFfmpegArgs` with no variant → throw → 500.

## Fix
Both segment spawn paths (`hlsSegment`, `hlsAudioSegment`) now return **410 `session_expired`** when the resolved context has no `videoVariant`, instead of attempting a transcode that can't be configured:
- still-open player → re-establishes via playback-info (existing 410 recovery);
- closed player → request dropped, **no ffmpeg spawned** for a stream nobody is watching.

## Verification
`tsc` clean; guard live in the running backend. (The `transcode-cache.service.spec` flakiness is pre-existing test-isolation, confirmed present with and without this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)