### PR TITLE
fix(layout): align horizontal-scroller bleed with the main padding

### DIFF
--- a/client/src/app/shared/components/horizontal-scroller.html
+++ b/client/src/app/shared/components/horizontal-scroller.html
@@ -27,7 +27,7 @@
   <div
     #scroller
     appTvRow
-    class="flex gap-2 lg:gap-4 overflow-x-auto scrollbar-none [scroll-behavior:smooth] py-5 -my-5 px-4 -mx-4 lg:px-5 lg:-mx-5 scroll-px-4 lg:scroll-px-5"
+    class="flex gap-2 lg:gap-4 overflow-x-auto scrollbar-none [scroll-behavior:smooth] py-5 -my-5 px-4 -mx-4 scroll-px-4"
     (scroll)="updateArrows()"
   >
     <ng-content />


### PR DESCRIPTION
## Bug
On the episode-detail page (a hero page) the horizontal scrollers caused a slight horizontal page scroll on tablet — not on phone/desktop.

## Cause
`<main>` padding is `p-4` (1rem) at every breakpoint, but the scroller kept `lg:-mx-5 / lg:px-5` (1.25rem) of negative-margin bleed. At the `lg` breakpoint (e.g. landscape tablets) the 1.25rem bleed overshot the 1rem padding by 0.25rem each side. Non-hero `<main>` clips x-overflow so it was invisible there, but hero pages don't clip → slight X scroll.

## Fix
Drop the `lg:` overrides so the scroller bleed stays `-mx-4 / px-4` (1rem) everywhere, matching `<main>`'s padding — no overshoot, cards still sit flush with the content edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)