### PR TITLE
fix(player): reduce max height of the clearlogo overlay

### DIFF
--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -22,7 +22,7 @@
     @if (logoUrl()) {
       <img [src]="logoUrl()! | resolveUrl:'medium'" [alt]="mediaTitle()"
            class="w-auto object-contain object-left [filter:drop-shadow(0_1px_2px_rgb(0_0_0/0.5))]"
-           [class]="isMobileTouch() ? 'h-7' : 'h-9'" />
+           [class]="isMobileTouch() ? 'h-6' : 'h-8'" />
     } @else {
       <span class="text-white font-semibold truncate" [class]="isMobileTouch() ? 'text-lg' : 'text-xl'">{{ mediaTitle() }}</span>
     }


### PR DESCRIPTION
Reduce the player top-left clearlogo a notch so it sits less prominently over the video: desktop `h-9`→`h-8` (36px→32px), mobile `h-7`→`h-6` (28px→24px).