### PR TITLE
fix(player): faster native startup and play/pause A/V desync hardening

### DIFF
--- a/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
@@ -27,10 +27,12 @@ import androidx.media3.common.util.UnstableApi;
 import androidx.media3.datasource.DataSource;
 import androidx.media3.datasource.DefaultDataSource;
 import androidx.media3.datasource.DefaultHttpDataSource;
+import androidx.media3.exoplayer.DecoderCounters;
 import androidx.media3.exoplayer.DefaultLoadControl;
 import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.exoplayer.LoadControl;
+import androidx.media3.exoplayer.analytics.AnalyticsListener;
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
 import java.util.ArrayList;
 import java.util.List;
@@ -79,6 +81,17 @@ public class NativePlayerPlugin extends Plugin {
     // programmatic micro-seek in `onTracksChanged` that mimics that
     // path when we detect the failure signature.
     private boolean videoBootstrapDone = false;
+    // Set once the first frame has been signalled to the WebView. Both
+    // onRenderedFirstFrame (unreliable on some devices: fires late or never)
+    // and the onIsPlayingChanged fallback dispatch the event, so this guard
+    // keeps them idempotent and stops a re-dispatch on every later resume.
+    // Reset on each load().
+    private boolean firstFrameSignaled = false;
+    // Set when ExoPlayer's video renderer actually enables. Separates a
+    // healthy-but-slow start (renderer enabled, still fetching bytes) from the
+    // cold-prepare race below where the video renderer never enables — only the
+    // latter warrants the unstick seek. Reset on each load().
+    private boolean videoRendererEnabled = false;
     private final List<MediaItem.SubtitleConfiguration> subtitleConfigs = new ArrayList<>();
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
     private Handler positionHandler;
@@ -331,6 +344,11 @@ public class NativePlayerPlugin extends Plugin {
 
                 @Override public void onIsPlayingChanged(boolean isPlaying) {
                     if (isPlaying) {
+                        // Playback is advancing ⇒ decoded frames are presenting.
+                        // Lift the loading veil now even if onRenderedFirstFrame
+                        // misfired, instead of waiting on the ~1 Hz position
+                        // fallback in native-engine.ts (which can't fire for ~2 s).
+                        emitFirstFrame();
                         emitStateChanged("playing");
                     } else if (player.getPlaybackState() == Player.STATE_BUFFERING) {
                         emitStateChanged("buffering");
@@ -382,20 +400,24 @@ public class NativePlayerPlugin extends Plugin {
                             }
                         }
                         if (videoSelected) {
-                            // Common case: video track picked. Watchdog reads
-                            // playback state 1.5 s later; if the renderer
-                            // actually started (state != BUFFERING) the seek is
-                            // skipped, so healthy playback is untouched. When
-                            // the bug strikes, state is still BUFFERING and we
-                            // issue a 1 ms forward seek — imperceptible drift
-                            // (well below one frame at 24 fps).
+                            // Common case: video track picked. The watchdog only
+                            // issues the 1 ms unstick seek when the video renderer
+                            // never enabled (onVideoEnabled hasn't fired) AND state
+                            // is still BUFFERING — the exact cold-prepare signature.
+                            // A healthy-but-slow start has the renderer enabled and
+                            // is merely fetching, so it is left alone (seeking there
+                            // would cancel in-flight loads and delay the first
+                            // frame). Gating on the renderer signal lets the check
+                            // run early without punishing slow links. The seek is a
+                            // sub-frame nudge (1 ms ≪ one frame at 24 fps).
                             videoBootstrapDone = true;
                             mainHandler.postDelayed(() -> {
                                 if (player == null) return;
-                                if (player.getPlaybackState() == Player.STATE_BUFFERING) {
+                                if (!videoRendererEnabled
+                                        && player.getPlaybackState() == Player.STATE_BUFFERING) {
                                     player.seekTo(player.getCurrentPosition() + 1);
                                 }
-                            }, 1500);
+                            }, 500);
                         } else if (videoSupported) {
                             // Less common signature: the selector dropped the
                             // video group entirely (audio surfaced first, the
@@ -430,6 +452,19 @@ public class NativePlayerPlugin extends Plugin {
 
             });
 
+            // The video renderer enabling is the signal that separates a
+            // healthy start from the cold-prepare race (where the video
+            // renderer never enables). The bootstrap watchdog reads this flag
+            // so it only issues the unstick seek when the renderer is genuinely
+            // stuck, not when a healthy start is merely slow to buffer.
+            player.addAnalyticsListener(new AnalyticsListener() {
+                @Override public void onVideoEnabled(
+                        @NonNull AnalyticsListener.EventTime eventTime,
+                        @NonNull DecoderCounters counters) {
+                    videoRendererEnabled = true;
+                }
+            });
+
             MediaItem.Builder itemBuilder = new MediaItem.Builder()
                     .setUri(Uri.parse(currentHlsUrl));
             if (!subtitleConfigs.isEmpty()) {
@@ -438,6 +473,8 @@ public class NativePlayerPlugin extends Plugin {
             player.setMediaItem(itemBuilder.build());
             lastAudioTrackCount = -1; // Reset so emitTracksChanged fires for new media
             videoBootstrapDone = false; // Arm cold-prepare bug bootstrap
+            firstFrameSignaled = false; // Re-arm the first-frame veil signal
+            videoRendererEnabled = false; // Re-arm the cold-prepare renderer probe
 
             // Disable text tracks by default — user selects via UI
             player.setTrackSelectionParameters(
@@ -894,6 +931,8 @@ public class NativePlayerPlugin extends Plugin {
     }
 
     private void emitFirstFrame() {
+        if (firstFrameSignaled) return;
+        firstFrameSignaled = true;
         getBridge().getWebView().evaluateJavascript(
                 "window.dispatchEvent(new CustomEvent('nativePlayerFirstFrame'));", null);
     }

--- a/client/src/app/core/services/player-state.service.ts
+++ b/client/src/app/core/services/player-state.service.ts
@@ -66,9 +66,10 @@ export class PlayerStateService {
       }
       // videoStarted is intentionally NOT flipped here — Shaka emits 'playing'
       // on DOM 'play' (= play() called), well before the first frame is
-      // actually painted. PlayerComponent owns the flip per engine: rvfc on
-      // the local <video> for Shaka, stateChanged 'playing' for native (where
-      // ExoPlayer's surface is already painting by then).
+      // actually painted. PlayerComponent owns the flip per engine, always via
+      // the engine 'firstFrame' event: rvfc on the local <video> for Shaka,
+      // ExoPlayer onRenderedFirstFrame (with an onIsPlayingChanged fallback)
+      // for native.
     });
 
     engine.on('timeUpdate', (e) => {

--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -22,7 +22,7 @@
     @if (logoUrl()) {
       <img [src]="logoUrl()! | resolveUrl:'medium'" [alt]="mediaTitle()"
            class="w-auto object-contain object-left [filter:drop-shadow(0_1px_2px_rgb(0_0_0/0.5))]"
-           [class]="isMobileTouch() ? 'h-7' : 'h-9'" />
+           [class]="isMobileTouch() ? 'h-6' : 'h-8'" />
     } @else {
       <span class="text-white font-semibold truncate" [class]="isMobileTouch() ? 'text-lg' : 'text-xl'">{{ mediaTitle() }}</span>
     }

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -273,6 +273,13 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   readonly chapters = signal<{ startSeconds: number; endSeconds: number; title?: string }[]>([]);
   /** Set after a manual seek to suppress auto-skip for a short window. */
   private autoSkipSuppressedUntil = 0;
+  /** Timestamp of the last processed play/pause toggle — coalesces rapid
+   *  taps so a burst can't interleave a play()/pause() with an in-flight
+   *  MSE append and drift A/V. */
+  private lastTogglePlayAt = 0;
+  /** Coalesce window for play/pause toggles. Sized to bridge an MSE append,
+   *  not human double-tap cadence. */
+  private readonly togglePlayCoalesceMs = 250;
   /** Tracks last episodeId we auto-skipped for to ensure we only auto-skip once per session. */
   private autoSkipFiredForEpisode: number | null = null;
   readonly spriteUrl = signal<string | null>(null);
@@ -936,24 +943,18 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
           const subs = await tvSubsPromise;
           this.availableSubtitles.set(subs);
         } else if (this.isNative) {
-          // Start subtitle fetch in parallel with native engine creation so
-          // the network round-trip doesn't block ExoPlayer's init.
-          const nativeSubsPromise = this.trackManager.loadSubtitles(
+          // Subtitles arrive as HLS SUBTITLES renditions in the master
+          // playlist, so the ExoPlayer MediaItem doesn't depend on this
+          // fetch. Run it in parallel and resolve it after load() (like the
+          // Shaka path below) — awaiting it before load() only adds a network
+          // round-trip to the time-to-first-frame critical path.
+          subsPromise = this.trackManager.loadSubtitles(
             this.mediaId, this.mediaFileId, this.streamingApi, this.media,
           );
 
           await this.createNativeEngine();
 
           this.applyNativeSubtitleStyle();
-
-          // Await subs before building the ExoPlayer MediaItem (preloaded
-          // subs avoid a rebuild). Likely already resolved by this point.
-          const subs = await nativeSubsPromise;
-          this.availableSubtitles.set(subs);
-          const nonBurnInSubs = subs
-            .filter((s) => !s.burnIn && s.url)
-            .map((s) => ({ url: s.url, language: s.language, label: s.label }));
-          (this.engine as NativeEngine).setPreloadedSubtitles(nonBurnInSubs);
 
           const token =
             this.authService.streamToken() ?? this.authService.accessToken;
@@ -1057,8 +1058,8 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         await this.loadOfflineSubtitles();
         this.loadAudioTracks();
       } else if (!this.availableSubtitles().length) {
-        // subsPromise was started in parallel with engine.load (Shaka path)
-        // For native path, subtitles are already preloaded above
+        // subsPromise was started in parallel with engine.load (Shaka + native);
+        // resolve it here, falling back to a direct fetch if none was started.
         const subs = subsPromise
           ? await subsPromise
           : await this.trackManager.loadSubtitles(this.mediaId, this.mediaFileId, this.streamingApi, this.media);
@@ -1443,7 +1444,18 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
   onTogglePlay() {
     if (!this.engine) return;
-    if (this.paused()) {
+    // Coalesce rapid taps (spacebar / k / button spam): a second toggle
+    // inside this window is dropped so a burst can't interleave a
+    // play()/pause() with an in-flight MSE append and desync A/V.
+    const now = Date.now();
+    if (now - this.lastTogglePlayAt < this.togglePlayCoalesceMs) return;
+    this.lastTogglePlayAt = now;
+    // Decide off the engine's live transport state rather than the `paused()`
+    // signal, which mirrors the async DOM/bridge play/pause events and lags a
+    // tap, so reading it can issue two same-direction commands. On the web
+    // <video> the getter is exact (paused flips synchronously); the native
+    // engine mirrors its bridge state, which the coalesce window covers.
+    if (this.engine.paused) {
       this.engine.play().catch(() => {});
       this.resetHideTimer();
     } else {


### PR DESCRIPTION
## Why

Two reported player issues, root-caused via a multi-agent audit:

1. **Android: long black screen on start** (not buffering, then plays).
2. **Windows (web): rare A/V desync after repeated play/pause.**

## Changes

**Windows desync — `onTogglePlay` (`player.ts`)**
Decided on the `paused()` signal, an async mirror of the DOM/bridge play/pause events that lags a tap. A rapid double-tap could read the stale value and issue two same-direction commands, interleaving a `play()/pause()` with an in-flight MSE append and drifting A/V. Now decides off the engine's live transport state and coalesces a burst of taps within a short window (`togglePlayCoalesceMs`).

**Android startup — native subtitle round-trip (`player.ts`)**
The native branch awaited the subtitle fetch *before* `engine.load()`, adding a network round-trip to time-to-first-frame — even though subtitles arrive as HLS SUBTITLES renditions and the preload field is never forwarded to the plugin. Now runs in parallel and resolves after `load()`, mirroring the Shaka path.

**Android startup — loading veil (`NativePlayerPlugin.java`)**
The veil only lifted on `onRenderedFirstFrame` (fires late/never on some devices) or a 2-tick 1 Hz position fallback, lingering ~2s after frames decoded. Now also lifts on `onIsPlayingChanged(true)`, idempotently.

**Android startup — cold-prepare watchdog (`NativePlayerPlugin.java`)**
The Media3 cold-prepare race watchdog waited a fixed 1500ms before the unstick micro-seek. Gated on an `onVideoEnabled` signal so the seek only fires when the video renderer never enabled (the actual race), making it safe to cut the delay to 500ms without delaying a slow-but-healthy start.

## Verification

- Frontend: `tsc --noEmit` clean.
- Java: reviewed against Media3 1.10.1 semantics (`@OptIn(UnstableApi)` covers the new `AnalyticsListener`/`DecoderCounters`); not locally compilable — to validate on a device build.
- Adversarial audit cleared the changes; comment cleanups applied for the two comments the changes made inaccurate.