### PR TITLE
fix(downloads): mint a live session so offline downloads resolve a codec variant

### DIFF
--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -78,6 +78,10 @@ export interface LiveSession {
   encoderPreset: string;
   canCopyVideo: boolean;
   canCopyAudio: boolean;
+  /** Download sessions: kept past the short playback TTL so a paused
+   *  download can resume without its segments 410ing. Active segment fetches
+   *  keep it warm; GC reclaims it after a long idle window. */
+  pinned: boolean;
 }
 
 /** Snapshot returned from {@link LiveSessionRegistry.list} — same shape
@@ -120,6 +124,7 @@ export interface CreateLiveSessionInput {
   encoderPreset?: string;
   canCopyVideo?: boolean;
   canCopyAudio?: boolean;
+  pinned?: boolean;
 }
 
 /** Partial update applied via {@link LiveSessionRegistry.update}. Only
@@ -168,6 +173,10 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
 
   private readonly ttlMs = StreamLifetime.liveSessionTtlMs();
   private readonly gcIntervalMs = StreamLifetime.liveSessionGcIntervalMs();
+  /** Idle window for pinned (download) sessions. Active segment fetches keep
+   *  them warm; this only bounds how long a paused or finished download holds
+   *  its session before GC reclaims it. */
+  private readonly pinnedTtlMs = 60 * 60 * 1000;
 
   onModuleInit(): void {
     this.gcTimer = setInterval(() => this.runGc(), this.gcIntervalMs);
@@ -222,6 +231,7 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
       encoderPreset: input.encoderPreset ?? 'faster',
       canCopyVideo: input.canCopyVideo ?? false,
       canCopyAudio: input.canCopyAudio ?? false,
+      pinned: input.pinned ?? false,
     };
     this.sessions.set(session.sessionId, session);
     return session;
@@ -345,10 +355,11 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
   }
 
   private runGc(): void {
-    const cutoff = Date.now() - this.ttlMs;
+    const now = Date.now();
     const expired: string[] = [];
     for (const [id, session] of this.sessions) {
-      if (session.lastBeat < cutoff) expired.push(id);
+      const ttl = session.pinned ? this.pinnedTtlMs : this.ttlMs;
+      if (session.lastBeat < now - ttl) expired.push(id);
     }
     for (const id of expired) {
       this.sessions.delete(id);

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -885,10 +885,16 @@ export class StreamingController {
     const startQuality = firstQueryString(req.query, 'startQuality');
     const startAtRaw = firstQueryString(req.query, 'startAt');
     const startAt = startAtRaw != null ? parseFloat(startAtRaw) : undefined;
+    // Offline download: the native DownloadManager pulls segments straight off
+    // the HLS routes (no heartbeat channel), and the download can be paused.
+    // Pin the session so it outlives the short playback TTL.
+    const isDownload = firstQueryString(req.query, 'download') === '1';
 
     // Mark a new watch-history entry (history = sessions started).
     // Fire-and-forget — a DB hiccup should not block stream start.
-    if (user?.id && resolved.mediaFile.mediaId) {
+    // Skipped for downloads: fetching for offline isn't watching, so it
+    // shouldn't land in history / "continue watching".
+    if (!isDownload && user?.id && resolved.mediaFile.mediaId) {
       this.playbackService
         .markSessionStarted(
           user.id,
@@ -1019,6 +1025,7 @@ export class StreamingController {
       encoderPreset: ss.qsvPreset,
       canCopyVideo: response.videoCopyStream,
       canCopyAudio: response.audioCopyStream,
+      pinned: isDownload,
     });
 
     // Burn-in subtitle resolves async (PGS extraction + filter build);

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -373,6 +373,7 @@ export class StreamingApiService {
     audioStreamIndex?: number,
     startQuality?: string,
     startAt?: number,
+    download?: boolean,
   ): Promise<PlaybackInfoResponse> {
     const token = this.playbackToken;
     let params = token ? `?token=${encodeURIComponent(token)}` : '';
@@ -387,6 +388,9 @@ export class StreamingApiService {
     }
     if (startAt != null) {
       params += (params ? '&' : '?') + `startAt=${startAt}`;
+    }
+    if (download) {
+      params += (params ? '&' : '?') + 'download=1';
     }
     return firstValueFrom(
       this.http.post<PlaybackInfoResponse>(

--- a/client/src/app/core/services/download-manager.service.ts
+++ b/client/src/app/core/services/download-manager.service.ts
@@ -7,6 +7,7 @@ import { OfflineStorageService } from './offline-storage.service';
 import { DownloadCacheService, DownloadTask } from './download-cache.service';
 import { DownloadNotificationService } from './download-notification.service';
 import { AuthService } from './auth.service';
+import { BrowserDeviceProfileService } from './browser-device-profile.service';
 
 export interface DownloadEvent {
   type: 'progress' | 'ready' | 'failed' | 'complete';
@@ -38,6 +39,7 @@ export class DownloadManagerService {
   private readonly cache = inject(DownloadCacheService);
   private readonly notif = inject(DownloadNotificationService);
   private readonly auth = inject(AuthService);
+  private readonly deviceProfile = inject(BrowserDeviceProfileService);
 
   private readonly titles = new Map<number, { title: string; episode?: string }>();
   private activeCount = 0;
@@ -119,7 +121,25 @@ export class DownloadManagerService {
     // hours so we can't rely on the 1h access token.
     await this.auth.ensureStreamToken();
 
-    const hlsUrl = this.streamingApi.getHlsUrl(mediaFileId, quality);
+    // Establish a live session the way playback does: the HLS segment routes
+    // resolve the codec variant off the session via ?sid= and reject (410)
+    // any segment request that can't resolve one. Thread the returned sid
+    // into the baked URL; active segment fetches keep the session warm.
+    const playbackInfo = await this.streamingApi.getPlaybackInfo(
+      mediaFileId,
+      this.deviceProfile.getProfile(),
+      undefined,
+      undefined,
+      quality,
+      undefined,
+      /* download */ true,
+    );
+    const hlsUrl = this.streamingApi.getHlsUrl(
+      mediaFileId,
+      quality,
+      undefined,
+      playbackInfo.sessionId,
+    );
     task.hlsUrl = hlsUrl;
 
     this.titles.set(taskId, { title, episode });


### PR DESCRIPTION
## Why

Offline downloads were broken on **both Android (ExoPlayer) and web (Shaka offline)** — confirmed on device. The native downloader looped on `init.mp4` + `seg-0000.m4s` with exponential backoff and ultimately failed silently.

**Root cause (regression, ~3 weeks unnoticed):** `createDownload` built a session-less `master.m3u8` URL (`getHlsUrl(mediaFileId, quality)` — no `sid`) and never called `playback-info`, so no `LiveSession` existed. Once the codec `videoVariant` became mandatory for a segment spawn (`b2b8011a`, 2026-05-17) and the no-session segment path was turned into a typed `SessionExpiredException` → **HTTP 410** (`432eda4d`, 2026-06-05), every download segment request 410'd. The frontend swallows the native start error and optimistically toasts "started", so it failed silently.

## Fix

- **`createDownload` mints a session via `playback-info`** (the same path the player uses) and threads the returned `sid` into the baked HLS URL, so every segment resolves the variant. Fixes native **and** web.
- **Pinned session**: downloads are long, pausable, and have no heartbeat channel. The session is `pinned` so it outlives the short playback TTL (kept warm by active segment fetches) and is GC'd only after a long idle window — a paused download can resume without its segments 410ing.
- **No watch history for downloads**: fetching for offline isn't watching, so it no longer lands in history / "continue watching".

Single-variant master is already handled by the existing `onlyQuality` path (the download URL carries `startQuality`).

## Verification

- Frontend `tsc` ✅, backend `tsc` ✅.
- **Confirmed on device**: downloads now progress and complete; offline subtitles work.

## Known minor follow-up (not blocking)

A brief "stuck at 100%" before the download validates — the on-demand transcode tail (ExoPlayer outruns ffmpeg near the end and waits for the final segments) plus ExoPlayer's finalization. It does complete. Can be investigated separately.