### PR TITLE
ci(play-store): stop setting changesNotSentForReview on the edit commit

### DIFF
--- a/.github/workflows/play-store-publish.yml
+++ b/.github/workflows/play-store-publish.yml
@@ -176,11 +176,7 @@ jobs:
           # `completed` so each upload rolls out automatically to the
           # selected track.
           status: draft
-          # While the app has never had a production release approved,
-          # the Edit API refuses to submit changes for automatic review
-          # ("Changes cannot be sent for review automatically…"). Skip
-          # the auto-submission; the changes still land as a draft and
-          # can be promoted from the Play Console UI. Remove (or flip
-          # to false) once the first production rollout is live.
-          changesNotSentForReview: true
+          # Commit the edit normally so Google sends the changes for review:
+          # the track auto-reviews and the Edit API rejects the upload when
+          # changesNotSentForReview is set on it.
           whatsNewDirectory: client/android/app/src/main/play/release-notes


### PR DESCRIPTION
## Why

Every release tag since 1.6.1 fails at **Publish Android to Play Store** — the AAB uploads (`Successfully uploaded 1 artifacts`) but `Committing the Edit` errors:

> Changes are sent for review automatically. The query parameter changesNotSentForReview must not be set.

A failed commit discards the whole edit, so **nothing has reached the Play Console library since 1.5.1** (code 54) — 1.6.x→1.9.0 never landed.

The `changesNotSentForReview: true` flag was added in 1.6.1's cycle (#170) when the API said the opposite ("changes *cannot* be sent for review"). The app's track has since moved to auto-review, which rejects the flag.

## Fix

Drop the flag so the edit commits normally (changes sent for review automatically). `status: draft` is kept; releases promote from the Play Console UI.

## After merge

Re-run the Play Store publish via **workflow_dispatch from main** (track `internal`, `apk_tag` empty) to actually push the current build — versionCode is `git rev-list --count HEAD` = 367, well above the library's max of 54.