### PR TITLE
feat(downloads): add original-file download to the quality modal

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -2085,6 +2085,17 @@ export class StreamingController {
     const contentType = resolved.contentType;
     const absolutePath = resolved.absolutePath;
 
+    // Browser "save the original file" path: force an attachment download with
+    // the source container's own name. Only embedded streams travel inside the
+    // container — sidecar subtitle files live next to it and aren't included.
+    if (firstQueryString(req.query, 'download')) {
+      const filename = path.basename(resolved.relativePath);
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename*=UTF-8''${encodeURIComponent(filename)}`,
+      );
+    }
+
     if (!range) {
       res.setHeader('Content-Type', contentType);
       res.setHeader('Content-Length', fileSize);

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1049,6 +1049,8 @@
     "download": "Télécharger",
     "choose_quality": "Choisir la qualité",
     "original": "Original",
+    "original_file": "Fichier original",
+    "original_file_note": "Les sous-titres externes ne seront pas inclus",
     "started": "Téléchargement lancé",
     "error": "Erreur lors du téléchargement",
     "empty": "Aucun téléchargement",

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -245,6 +245,20 @@ export class StreamingApiService {
     return url;
   }
 
+  /** Authenticated URL that downloads the raw source file as an attachment.
+   *  Browser-only — the offline pipeline transcodes/remuxes into HLS, this
+   *  hands back the untouched container (embedded streams only, no sidecar
+   *  subtitles). `download=1` flips the backend to a Content-Disposition. */
+  getOriginalDownloadUrl(mediaFileId: number): string {
+    const base = this.serverConfig.isNative
+      ? this.serverConfig.resolveUrl(`/api/stream/${mediaFileId}`)
+      : `/api/stream/${mediaFileId}`;
+    const params: string[] = ['download=1'];
+    const token = this.playbackToken;
+    if (token) params.push(`token=${encodeURIComponent(token)}`);
+    return `${base}?${params.join('&')}`;
+  }
+
   /** Internal helper for getStreamUrl — keeps the token+sid query
    *  composition consistent with `getHlsUrl`. */
   private withTokenAndSid(base: string, sessionId?: string): string {

--- a/client/src/app/shared/components/download-quality-modal/download-quality-modal.ts
+++ b/client/src/app/shared/components/download-quality-modal/download-quality-modal.ts
@@ -8,11 +8,13 @@ import {
   ViewChild,
   ElementRef,
 } from '@angular/core';
+import { Capacitor } from '@capacitor/core';
 import { TranslateModule } from '@ngx-translate/core';
 import {
   StreamingApiService,
   DownloadQuality,
 } from '../../../core/services/api/streaming-api.service';
+import { AuthService } from '../../../core/services/auth.service';
 import { LucideDownload, LucideX } from '@lucide/angular';
 
 @Component({
@@ -49,6 +51,21 @@ import { LucideDownload, LucideX } from '@lucide/angular';
               </button>
             }
           </div>
+
+          @if (!isNative) {
+            <div class="divider my-2"></div>
+            <button
+              class="btn btn-outline justify-start gap-2 w-full"
+              [disabled]="downloading()"
+              (click)="downloadOriginal()"
+            >
+              <svg lucideDownload class="h-4 w-4"></svg>
+              {{ 'downloads.original_file' | translate }}
+            </button>
+            <p class="text-xs text-base-content/60 mt-1">
+              {{ 'downloads.original_file_note' | translate }}
+            </p>
+          }
         }
 
         @if (downloading()) {
@@ -64,6 +81,11 @@ import { LucideDownload, LucideX } from '@lucide/angular';
 })
 export class DownloadQualityModalComponent {
   private readonly streamingApi = inject(StreamingApiService);
+  private readonly auth = inject(AuthService);
+
+  /** Original-file download is a browser save-to-disk — hidden on native,
+   *  which uses the ExoPlayer/AVAsset offline pipeline instead. */
+  readonly isNative = Capacitor.isNativePlatform();
 
   @ViewChild('dialog') dialogRef!: ElementRef<HTMLDialogElement>;
 
@@ -92,6 +114,21 @@ export class DownloadQualityModalComponent {
 
   selectQuality(quality: string) {
     this.download.emit({ mediaFileId: this.mediaFileId, quality });
+    this.close();
+  }
+
+  /** Stream the untouched source file straight to the browser's downloads.
+   *  Mint a long-lived stream token first: the file can be several GB and a
+   *  1h access token would expire on a resumed range request mid-download. */
+  async downloadOriginal() {
+    await this.auth.ensureStreamToken();
+    const url = this.streamingApi.getOriginalDownloadUrl(this.mediaFileId);
+    const a = document.createElement('a');
+    a.href = url;
+    a.rel = 'noopener';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
     this.close();
   }
 


### PR DESCRIPTION
## What

Adds a browser-only **Original file** option to the download quality modal. Selecting it streams the untouched source container straight to the browser's downloads, alongside the existing transcoded/remuxed quality rungs.

## Why

The offline download flow only ever produced transcoded/remuxed HLS stored for in-app offline playback. There was no way to grab the raw file as-is.

## How

- **Backend** (`streaming.controller.ts`): the direct-play route `GET /api/stream/:mediaFileId` now honours a `download=1` query param, setting `Content-Disposition: attachment` with the source container's own name (RFC 5987 encoded) so the browser saves rather than streams inline.
- **Frontend**: `StreamingApiService.getOriginalDownloadUrl()` builds the authenticated `?download=1&token=…` URL; the modal renders the new entry (and a note that **external sidecar subtitles aren't included** — only embedded streams travel inside the container) and triggers an anchor download. A long-lived stream token is minted first so multi-GB downloads survive past the 1h access-token TTL on resumed range requests.
- **i18n**: new `downloads.original_file` / `downloads.original_file_note` keys.

## Scope

- Hidden on native (`Capacitor.isNativePlatform()`) — there's no raw-file offline playback path there; native keeps the HLS offline pipeline.

## Verification

- `tsc --noEmit` passes on both backend and frontend.
- `ng build` (dev) completes with no template type errors.