### PR TITLE
chore(scheduler): raise stall progress tolerance to 30 MiB

### DIFF
--- a/backend/src/modules/scheduler/utils/stalled-progress.util.spec.ts
+++ b/backend/src/modules/scheduler/utils/stalled-progress.util.spec.ts
@@ -4,7 +4,7 @@ import {
   STALL_PROGRESS_TOLERANCE_BYTES,
 } from './stalled-progress.util';
 
-const MIB = Number(STALL_PROGRESS_TOLERANCE_BYTES);
+const TOLERANCE = Number(STALL_PROGRESS_TOLERANCE_BYTES);
 
 const samples = (...bytesNewestFirst: number[]) =>
   bytesNewestFirst.map((b) => ({ downloadedBytes: String(b) }));
@@ -15,15 +15,15 @@ describe('isNoProgress', () => {
   });
 
   it('treats a sub-tolerance trickle as no progress', () => {
-    expect(isNoProgress('1000', String(1000 + MIB - 1))).toBe(true);
+    expect(isNoProgress('1000', String(1000 + TOLERANCE - 1))).toBe(true);
   });
 
   it('treats exactly one tolerance worth of bytes as progress', () => {
-    expect(isNoProgress('1000', String(1000 + MIB))).toBe(false);
+    expect(isNoProgress('1000', String(1000 + TOLERANCE))).toBe(false);
   });
 
   it('treats a counter reset (negative delta) as progress', () => {
-    expect(isNoProgress(String(5 * MIB), '0')).toBe(false);
+    expect(isNoProgress(String(5 * TOLERANCE), '0')).toBe(false);
   });
 
   it('handles byte counts beyond Number.MAX_SAFE_INTEGER', () => {
@@ -51,22 +51,22 @@ describe('countStalledStrikes', () => {
   it('stops the run at the first progressing step', () => {
     // Newest-first: flat, flat, then a 2 MiB jump older in the series.
     expect(
-      countStalledStrikes(samples(5 * MIB, 5 * MIB, 5 * MIB, 3 * MIB)),
+      countStalledStrikes(samples(5 * TOLERANCE, 5 * TOLERANCE, 5 * TOLERANCE, 3 * TOLERANCE)),
     ).toBe(3);
   });
 
   it('returns 1 when the newest step shows progress', () => {
-    expect(countStalledStrikes(samples(5 * MIB, 3 * MIB, 3 * MIB))).toBe(1);
+    expect(countStalledStrikes(samples(5 * TOLERANCE, 3 * TOLERANCE, 3 * TOLERANCE))).toBe(1);
   });
 
   it('breaks the run on a counter reset', () => {
     // Newest-first: 0 after a recheck reset from 5 MiB.
-    expect(countStalledStrikes(samples(0, 5 * MIB, 5 * MIB))).toBe(1);
+    expect(countStalledStrikes(samples(0, 5 * TOLERANCE, 5 * TOLERANCE))).toBe(1);
   });
 
   it('tolerates a trickle inside the run', () => {
     expect(
-      countStalledStrikes(samples(1000 + 2 * (MIB - 1), 1000 + (MIB - 1), 1000)),
+      countStalledStrikes(samples(1000 + 2 * (TOLERANCE - 1), 1000 + (TOLERANCE - 1), 1000)),
     ).toBe(3);
   });
 });

--- a/backend/src/modules/scheduler/utils/stalled-progress.util.ts
+++ b/backend/src/modules/scheduler/utils/stalled-progress.util.ts
@@ -25,12 +25,13 @@ export const STALL_ELIGIBLE_STATES: ReadonlySet<string> = new Set([
 /**
  * Consecutive-snapshot delta below this counts as "no progress".
  *
- * 1 MiB tolerates the trickle of wasted bytes a stalled torrent keeps
- * receiving from churning peers (re-requested / discarded pieces) without
- * masking a genuinely progressing download: the shortest snapshot interval
- * is 20 minutes, where even a crawling 10 KiB/s nets ~11 MiB per interval.
+ * 30 MiB tolerates the trickle of wasted bytes a stalled torrent keeps
+ * receiving from churning peers (re-requested / discarded pieces). Over the
+ * shortest snapshot interval (20 minutes) it draws the progress line at
+ * ~26 KiB/s — a download crawling slower than that across a full window is
+ * treated as stuck.
  */
-export const STALL_PROGRESS_TOLERANCE_BYTES = 1n << 20n; // 1 MiB
+export const STALL_PROGRESS_TOLERANCE_BYTES = 30n << 20n; // 30 MiB
 
 /**
  * Whether the step from `olderBytes` to `newerBytes` counts as no progress.


### PR DESCRIPTION
## What

Raises `STALL_PROGRESS_TOLERANCE_BYTES` from **1 MiB to 30 MiB**.

## Effect

A torrent must net more than 30 MiB between two consecutive stall snapshots to count as progressing. On the shortest snapshot interval (20 min, the `fast` profile) this draws the progress line at **~26 KiB/s** — anything crawling slower than that across a full window is treated as stuck and goes toward its stall strikes.

Note this makes stall detection *more* aggressive on slow torrents, not more lenient.

## Changes

- `stalled-progress.util.ts`: constant `1n << 20n` → `30n << 20n`, comment updated to describe the new ~26 KiB/s progress line.
- `stalled-progress.util.spec.ts`: rename the tolerance-derived test constant `MIB` → `TOLERANCE` (it's no longer one MiB). Tests are relative to the constant and still pass (12/12).