### PR TITLE
feat(indexers): skip indexers in cooldown during release searches

### DIFF
--- a/backend/src/modules/indexers/indexer-throttle.service.spec.ts
+++ b/backend/src/modules/indexers/indexer-throttle.service.spec.ts
@@ -1,0 +1,52 @@
+import { IndexerThrottle } from './indexer-throttle.service';
+import { Indexer } from './entities/indexer.entity';
+
+const indexer = (over: Partial<Indexer> = {}): Indexer =>
+  ({ id: 1, name: 'test', requestDelay: 0, ...over }) as Indexer;
+
+describe('IndexerThrottle cooldown gate', () => {
+  it('reports no cooldown for an untouched indexer', () => {
+    const t = new IndexerThrottle();
+    expect(t.cooldownRemainingMs(1)).toBe(0);
+  });
+
+  it('opens a cooldown window on the first failure', () => {
+    const t = new IndexerThrottle();
+    t.notifyFailure(indexer());
+    // First failure backs off 30s.
+    expect(t.cooldownRemainingMs(1)).toBeGreaterThan(25_000);
+    expect(t.cooldownRemainingMs(1)).toBeLessThanOrEqual(30_000);
+  });
+
+  it('extends the window on consecutive failures', () => {
+    const t = new IndexerThrottle();
+    t.notifyFailure(indexer());
+    const afterOne = t.cooldownRemainingMs(1);
+    t.notifyFailure(indexer());
+    // Second failure escalates 30s -> 2min.
+    expect(t.cooldownRemainingMs(1)).toBeGreaterThan(afterOne);
+  });
+
+  it('clears the cooldown on confirmed success', () => {
+    const t = new IndexerThrottle();
+    t.notifyFailure(indexer());
+    expect(t.cooldownRemainingMs(1)).toBeGreaterThan(0);
+    t.notifySuccess(1);
+    expect(t.cooldownRemainingMs(1)).toBe(0);
+  });
+
+  it('honours Retry-After as a cooldown window', () => {
+    const t = new IndexerThrottle();
+    t.setRetryAfter(indexer(), '120');
+    expect(t.cooldownRemainingMs(1)).toBeGreaterThan(110_000);
+    expect(t.cooldownRemainingMs(1)).toBeLessThanOrEqual(120_000);
+  });
+
+  it('does not count routine request spacing as a cooldown', async () => {
+    const t = new IndexerThrottle();
+    // A healthy call bumps the per-indexer request-delay gate but must not
+    // make the indexer read as "in cooldown" — searches still query it.
+    await t.run(indexer({ requestDelay: 5 }), async () => 'ok');
+    expect(t.cooldownRemainingMs(1)).toBe(0);
+  });
+});

--- a/backend/src/modules/indexers/indexer-throttle.service.ts
+++ b/backend/src/modules/indexers/indexer-throttle.service.ts
@@ -32,6 +32,11 @@ export class IndexerThrottle {
   private nextAllowedAt = new Map<number, number>();
   /** Consecutive failure count — drives progressive cooldown. */
   private failureCount = new Map<number, number>();
+  /** Earliest wall-clock ms a *penalised* indexer may be retried — written
+   *  only by failure backoff and Retry-After, never by routine request
+   *  spacing. Lets searches skip a backing-off indexer instead of queueing
+   *  behind its full cooldown. */
+  private cooldownUntil = new Map<number, number>();
 
   /** Queue `fn` against `indexer`. Returns whatever `fn` resolves to.
    *  Rejections propagate untouched (so callers can pattern-match on
@@ -71,9 +76,7 @@ export class IndexerThrottle {
   setRetryAfter(indexer: Indexer, headerValue: string | undefined): void {
     const ms = parseRetryAfter(headerValue);
     if (ms <= 0) return;
-    const until = Date.now() + ms;
-    const current = this.nextAllowedAt.get(indexer.id) ?? 0;
-    if (until > current) this.nextAllowedAt.set(indexer.id, until);
+    this.bumpCooldown(indexer.id, Date.now() + ms);
     this.log.warn(
       `[${indexer.name}] Retry-After honoured — next request in ${Math.round(ms / 1000)}s`,
     );
@@ -86,9 +89,7 @@ export class IndexerThrottle {
     this.failureCount.set(indexer.id, n);
     const cooldownMs = backoffFor(n);
     if (cooldownMs <= 0) return;
-    const until = Date.now() + cooldownMs;
-    const current = this.nextAllowedAt.get(indexer.id) ?? 0;
-    if (until > current) this.nextAllowedAt.set(indexer.id, until);
+    this.bumpCooldown(indexer.id, Date.now() + cooldownMs);
     this.log.warn(
       `[${indexer.name}] consecutive failure #${n} — cooldown ${Math.round(cooldownMs / 1000)}s`,
     );
@@ -97,6 +98,26 @@ export class IndexerThrottle {
   /** Reset the backoff state for an indexer on confirmed success. */
   notifySuccess(indexerId: number): void {
     this.failureCount.delete(indexerId);
+    this.cooldownUntil.delete(indexerId);
+  }
+
+  /** Remaining failure / Retry-After cooldown for an indexer, in ms (0 when
+   *  ready). Routine request-delay spacing is deliberately excluded so a
+   *  healthy indexer queried seconds ago still reads as ready. */
+  cooldownRemainingMs(indexerId: number): number {
+    const until = this.cooldownUntil.get(indexerId) ?? 0;
+    return Math.max(0, until - Date.now());
+  }
+
+  /** Push a backpressure window onto an indexer: bumps both the queue's
+   *  earliest-start gate (so a request that does get queued still waits) and
+   *  the skip gate (so searches can drop it from the fan-out). Monotonic —
+   *  only ever extends the window, never shortens it. */
+  private bumpCooldown(indexerId: number, until: number): void {
+    const curNext = this.nextAllowedAt.get(indexerId) ?? 0;
+    if (until > curNext) this.nextAllowedAt.set(indexerId, until);
+    const curCooldown = this.cooldownUntil.get(indexerId) ?? 0;
+    if (until > curCooldown) this.cooldownUntil.set(indexerId, until);
   }
 }
 

--- a/backend/src/modules/indexers/torznab.service.ts
+++ b/backend/src/modules/indexers/torznab.service.ts
@@ -160,6 +160,31 @@ export class TorznabService {
     private readonly throttle: IndexerThrottle,
   ) {}
 
+  /** Drop indexers currently serving a failure / Retry-After cooldown from a
+   *  search fan-out. Without this the throttle would let the next queued call
+   *  sleep out the full backoff (up to 6h) before firing, stalling the whole
+   *  `Promise.all` — and an interactive release search with it — on a single
+   *  broken host. Skipped indexers are picked back up automatically once their
+   *  cooldown lapses; a healthy indexer queried seconds ago is never skipped. */
+  filterReadyIndexers(indexers: Indexer[]): Indexer[] {
+    const ready: Indexer[] = [];
+    const skipped: string[] = [];
+    for (const ix of indexers) {
+      const remainingMs = this.throttle.cooldownRemainingMs(ix.id);
+      if (remainingMs > 0) {
+        skipped.push(`${ix.name} (${Math.ceil(remainingMs / 1000)}s)`);
+      } else {
+        ready.push(ix);
+      }
+    }
+    if (skipped.length) {
+      this.log.warn(
+        `skipping ${skipped.length} indexer(s) in cooldown: ${skipped.join(', ')}`,
+      );
+    }
+    return ready;
+  }
+
   /** Detect Retry-After-bearing responses (429, 503) and feed the
    *  header to the throttle so subsequent queued calls wait. Returns
    *  true if the error was rate-limit-shaped — caller treats it as a

--- a/backend/src/modules/media/episode-download.service.ts
+++ b/backend/src/modules/media/episode-download.service.ts
@@ -167,8 +167,9 @@ export class EpisodeDownloadService {
     const { searchTitle: queryTitle, expectedTitles: expectedTitle } =
       resolveSearchTitles(media, customQuery);
     const externalIds = { tvdbId: media.tvdbId, imdbId: media.imdbId };
+    const ready = this.torznab.filterReadyIndexers(indexers);
     const batches = await Promise.all(
-      indexers.map((ix) =>
+      ready.map((ix) =>
         this.torznab.searchSeries(
           ix,
           queryTitle,
@@ -481,8 +482,9 @@ export class EpisodeDownloadService {
     const { searchTitle, expectedTitles: expectedTitle } =
       resolveSearchTitles(media, customQuery);
     const externalIds = { tvdbId: media.tvdbId, imdbId: media.imdbId };
+    const ready = this.torznab.filterReadyIndexers(indexers);
     const batches = await Promise.all(
-      indexers.map((ix) =>
+      ready.map((ix) =>
         this.torznab.searchSeasonPack(
           ix,
           searchTitle,
@@ -634,8 +636,9 @@ export class EpisodeDownloadService {
 
     const externalIds = { tvdbId: media.tvdbId, imdbId: media.imdbId };
     const { searchTitle, expectedTitles } = resolveSearchTitles(media);
+    const ready = this.torznab.filterReadyIndexers(indexers);
     const packBatches = await Promise.all(
-      indexers.map((ix) =>
+      ready.map((ix) =>
         this.torznab.searchSeasonPack(
           ix,
           searchTitle,
@@ -743,7 +746,7 @@ export class EpisodeDownloadService {
       const epLabel = `S${String(season.seasonNumber).padStart(2, '0')}E${String(ep.episodeNumber).padStart(2, '0')}`;
       try {
         const epBatches = await Promise.all(
-          indexers.map((ix) =>
+          ready.map((ix) =>
             this.torznab.searchSeries(
               ix,
               searchTitle,

--- a/backend/src/modules/media/movie-download.service.ts
+++ b/backend/src/modules/media/movie-download.service.ts
@@ -183,13 +183,14 @@ export class MovieDownloadService {
       this.log.warn(`[searchMovieReleases] no enabled indexers found`);
       return [];
     }
+    const ready = this.torznab.filterReadyIndexers(indexers);
     const customTitle = customQuery?.trim();
     const query = customTitle || this.searchQueryForMedia(media);
     this.log.log(
-      `[searchMovieReleases] "${media.title}" — query="${query}", indexers=[${indexers.map((i) => i.name).join(', ')}]`,
+      `[searchMovieReleases] "${media.title}" — query="${query}", indexers=[${ready.map((i) => i.name).join(', ')}]`,
     );
     const batches = await Promise.all(
-      indexers.map((ix) => this.searchIndexer(ix, query, media)),
+      ready.map((ix) => this.searchIndexer(ix, query, media)),
     );
     const flat = batches.flat();
     this.log.log(


### PR DESCRIPTION
## Problem

A release search fans out across every enabled indexer with `Promise.all`, so the call only resolves once the **slowest** indexer does. The per-indexer throttle applies its failure backoff (30s → 2min → 15min → 1h → 6h) as a *pre-request delay inside the queued call* (`runOne` sleeps until `nextAllowedAt`, then fires) — not a skip. A broken indexer in, say, a 15-min cooldown would make the next queued search sleep out the full window before even firing, stalling the whole fan-out — and an interactive "search releases" click with it — for minutes.

## Fix

- **`indexer-throttle.service.ts`**: track the failure / `Retry-After` cooldown in a new `cooldownUntil` map, written only by `notifyFailure` / `setRetryAfter` (via a shared `bumpCooldown`) and never by routine request spacing. Expose `cooldownRemainingMs(indexerId)`; clear it on `notifySuccess`. The `runOne` wait behaviour for indexers that *do* get queued is unchanged.
- **`torznab.service.ts`**: `filterReadyIndexers()` partitions out indexers with an open cooldown and logs which were skipped.
- **`movie-download.service.ts` / `episode-download.service.ts`**: all five search fan-outs (movie, series/episode, season-pack auto + per-episode fallback) run over `ready = filterReadyIndexers(indexers)`.

Skipped indexers are picked back up automatically once their cooldown lapses (recovery probing still happens after the window). A healthy indexer queried seconds ago — only subject to routine `requestDelay` spacing — is never skipped.

## Behaviour note

The first time a broken indexer is hit still pays its 90s HTTP timeout — there's no way to know it's broken until one request fails. That failure opens the cooldown; subsequent searches within the window skip it.

## Scope

Applies to grab/release searches. Scheduled RSS sync and caps refresh still route through the throttle's wait by design (background flows where waiting is tolerable).

## Verification

- New `indexer-throttle.service.spec.ts` (6 cases) ✅
- Backend `tsc --noEmit` ✅