### PR TITLE
fix(subtitles): normalize score so non-hash matches can clear min-score

### DIFF
--- a/backend/src/modules/scheduler/subtitle-scheduler.service.ts
+++ b/backend/src/modules/scheduler/subtitle-scheduler.service.ts
@@ -409,7 +409,12 @@ export class SubtitleSchedulerService {
         });
 
         const best = results.find((r) => r.score >= minScore);
-        if (!best) continue;
+        if (!best) {
+          this.log.log(
+            `PostImport: no ${langItem.isoCode} subtitle for "${media.title}" cleared min score ${minScore} (best candidate ${results[0]?.score ?? 'none'})`,
+          );
+          continue;
+        }
 
         const sub = await this.subtitlesService.downloadSubtitle(
           mediaId,

--- a/backend/src/modules/subtitles/subtitle-scorer.spec.ts
+++ b/backend/src/modules/subtitles/subtitle-scorer.spec.ts
@@ -8,68 +8,63 @@ import {
 
 const EPISODE_CTX = {
   kind: 'episode' as const,
-  videoReleaseName: 'Mr.Robot.S01E01.1080p.BluRay.x265.DTS-CtrlHD',
-  title: 'Mr. Robot',
+  videoReleaseName: 'Sample.Show.S01E01.1080p.BluRay.x265.DTS-CtrlHD',
+  title: 'Sample Show',
   year: 2015,
   season: 1,
   episode: 1,
-  imdbId: 'tt4158110',
+  imdbId: 'tt0000001',
 };
 
 const MOVIE_CTX = {
   kind: 'movie' as const,
-  videoReleaseName: 'Dune.2021.2160p.UHD.BluRay.x265.DV.HDR.DTS-HD.MA.7.1-CtrlHD',
-  title: 'Dune',
+  videoReleaseName: 'Sample.Movie.2021.2160p.UHD.BluRay.x265.DV.HDR.DTS-HD.MA.7.1-CtrlHD',
+  title: 'Sample Movie',
   year: 2021,
-  imdbId: 'tt1160419',
+  imdbId: 'tt0000002',
 };
 
 describe('subtitle-scorer', () => {
   describe('hash match', () => {
-    it('awards near-max score for an episode hash match', () => {
-      // No releaseName / videoReleaseName here so only hash + id-style
-      // bonuses + the default-non-HI bit are credited.
+    it('scores an episode hash match as a perfect 100% on hash alone', () => {
+      // A hash collision is exclusive: it discards every other match.
       const s = scoreSubtitle({ hashMatched: true }, {
         ...EPISODE_CTX,
         videoReleaseName: null,
       });
-      expect(s.matches).toContain('hash');
-      expect(s.matches).toContain('series');
-      expect(s.matches).toContain('season');
-      expect(s.matches).toContain('episode');
-      expect(s.matches).toContain('year');
-      const expectedRaw =
-        EPISODE_WEIGHTS.hash +
-        EPISODE_WEIGHTS.series +
-        EPISODE_WEIGHTS.season +
-        EPISODE_WEIGHTS.episode +
-        EPISODE_WEIGHTS.year +
-        EPISODE_WEIGHTS.hearingImpaired;
-      expect(s.raw).toBe(expectedRaw);
+      expect(s.matches).toEqual(['hash']);
+      expect(s.raw).toBe(EPISODE_WEIGHTS.hash);
       expect(s.max).toBe(MAX_EPISODE_SCORE);
+      expect(s.percent).toBe(100);
     });
 
-    it('awards hash + title + year for a movie hash match', () => {
+    it('scores a movie hash match as a perfect 100% on hash alone', () => {
       const s = scoreSubtitle({ hashMatched: true }, {
         ...MOVIE_CTX,
         videoReleaseName: null,
       });
-      expect(s.matches).toEqual(
-        expect.arrayContaining(['hash', 'title', 'year']),
+      expect(s.matches).toEqual(['hash']);
+      expect(s.raw).toBe(MOVIE_WEIGHTS.hash);
+      expect(s.max).toBe(MAX_MOVIE_SCORE);
+      expect(s.percent).toBe(100);
+    });
+
+    it('ignores release-name attributes once the hash matches', () => {
+      const s = scoreSubtitle(
+        {
+          hashMatched: true,
+          releaseName: 'Sample.Movie.2021.2160p.UHD.BluRay.x265-CtrlHD',
+        },
+        MOVIE_CTX,
       );
-      expect(s.raw).toBe(
-        MOVIE_WEIGHTS.hash +
-          MOVIE_WEIGHTS.title +
-          MOVIE_WEIGHTS.year +
-          MOVIE_WEIGHTS.hearingImpaired,
-      );
+      expect(s.matches).toEqual(['hash']);
     });
   });
 
   describe('release-name matching', () => {
     it('matches release group, source, resolution, codecs on an exact episode release', () => {
       const s = scoreSubtitle(
-        { releaseName: 'Mr.Robot.S01E01.1080p.BluRay.x265.DTS-CtrlHD' },
+        { releaseName: 'Sample.Show.S01E01.1080p.BluRay.x265.DTS-CtrlHD' },
         EPISODE_CTX,
       );
       expect(s.matches).toEqual(
@@ -88,11 +83,11 @@ describe('subtitle-scorer', () => {
 
     it('scores lower when the source/resolution differ', () => {
       const good = scoreSubtitle(
-        { releaseName: 'Mr.Robot.S01E01.1080p.BluRay.x265-CtrlHD' },
+        { releaseName: 'Sample.Show.S01E01.1080p.BluRay.x265-CtrlHD' },
         EPISODE_CTX,
       );
       const bad = scoreSubtitle(
-        { releaseName: 'Mr.Robot.S01E01.720p.WEB-DL.x264-FGT' },
+        { releaseName: 'Sample.Show.S01E01.720p.WEB-DL.x264-FGT' },
         EPISODE_CTX,
       );
       expect(good.raw).toBeGreaterThan(bad.raw);
@@ -101,13 +96,13 @@ describe('subtitle-scorer', () => {
 
   describe('imdb equivalence', () => {
     it('credits series + year when imdb matches and release name is empty', () => {
-      const s = scoreSubtitle({ imdbId: 'tt4158110' }, EPISODE_CTX);
+      const s = scoreSubtitle({ imdbId: EPISODE_CTX.imdbId }, EPISODE_CTX);
       expect(s.matches).toContain('series');
       expect(s.matches).toContain('year');
     });
 
     it('strips tt prefix for comparison', () => {
-      const s = scoreSubtitle({ imdbId: 'tt1160419' }, MOVIE_CTX);
+      const s = scoreSubtitle({ imdbId: MOVIE_CTX.imdbId }, MOVIE_CTX);
       expect(s.matches).toContain('title');
     });
   });
@@ -143,17 +138,38 @@ describe('subtitle-scorer', () => {
     });
   });
 
-  describe('percent normalisation', () => {
-    it('returns 100 when every applicable attribute matches an episode', () => {
+  describe('non-hash normalisation', () => {
+    it('scores a movie title+year (imdb) match at 76%', () => {
+      const s = scoreSubtitle({ imdbId: MOVIE_CTX.imdbId }, MOVIE_CTX);
+      expect(s.matches).toEqual(expect.arrayContaining(['title', 'year']));
+      expect(s.matches).not.toContain('hash');
+      expect(s.percent).toBe(76);
+    });
+
+    it('scores a loose title-only movie match at 51%', () => {
+      const s = scoreSubtitle({ releaseName: MOVIE_CTX.title }, MOVIE_CTX);
+      expect(s.matches).toContain('title');
+      expect(s.matches).not.toContain('year');
+      expect(s.percent).toBe(51);
+    });
+
+    it('scores a perfect non-hash episode release at 100%', () => {
       const s = scoreSubtitle(
         {
-          hashMatched: true,
-          releaseName: 'Mr.Robot.S01E01.1080p.BluRay.x265.DTS-CtrlHD',
-          imdbId: 'tt4158110',
+          releaseName: EPISODE_CTX.videoReleaseName,
+          imdbId: EPISODE_CTX.imdbId,
           hearingImpaired: false,
         },
         EPISODE_CTX,
       );
+      expect(s.matches).not.toContain('hash');
+      expect(s.percent).toBe(100);
+    });
+  });
+
+  describe('percent normalisation', () => {
+    it('returns 100 for a hash match', () => {
+      const s = scoreSubtitle({ hashMatched: true }, EPISODE_CTX);
       expect(s.percent).toBe(100);
     });
 

--- a/backend/src/modules/subtitles/subtitle-scorer.ts
+++ b/backend/src/modules/subtitles/subtitle-scorer.ts
@@ -5,12 +5,13 @@ import {
 } from '../../common/release-parsing';
 
 /**
- * Bazarr-style scoring weights (mirrored from
- * `subliminal_patch/score.py`). Each weight is the credit awarded when
- * the attribute MATCHES between the candidate subtitle and the local
- * video file. `MAX_*` is the sum of all weights for that kind, used to
- * normalise the score to a 0-100 percentage so the user-facing thresholds
- * stay portable across episode / movie regardless of which weights drift.
+ * Scoring weights mirrored from subliminal's `score.py`. Each weight is the
+ * credit awarded when the attribute MATCHES between the candidate subtitle and
+ * the local video file. By construction the `hash` weight equals the sum of
+ * every other weight, so the 0-100 normalisation denominator (`MAX_*`) is the
+ * hash weight: a hash hit — or a perfect non-hash release match — normalises to
+ * 100%, and partial release-name matches scale across the full range. This
+ * keeps the user-facing thresholds portable across episode / movie.
  */
 export const EPISODE_WEIGHTS = {
   hash: 359,
@@ -39,14 +40,8 @@ export const MOVIE_WEIGHTS = {
   hearingImpaired: 1,
 } as const;
 
-export const MAX_EPISODE_SCORE = Object.values(EPISODE_WEIGHTS).reduce(
-  (a, b) => a + b,
-  0,
-);
-export const MAX_MOVIE_SCORE = Object.values(MOVIE_WEIGHTS).reduce(
-  (a, b) => a + b,
-  0,
-);
+export const MAX_EPISODE_SCORE = EPISODE_WEIGHTS.hash;
+export const MAX_MOVIE_SCORE = MOVIE_WEIGHTS.hash;
 
 export interface SubtitleScoreCandidate {
   /** Release name the provider returned for this subtitle (preferred field
@@ -121,22 +116,12 @@ export function scoreSubtitle(
     matches.push(name);
   };
 
-  // Hash matching is treated as Bazarr-style perfect identification:
-  // every "id-style" attribute (series / title / year / season / episode)
-  // is credited because a movie/episode hash collision is effectively
-  // impossible. We DON'T short-circuit — release-name attributes still
-  // get credited below when present, so a hash + perfect-release combo
-  // can reach 100% while hash + missing-release tops out lower.
+  // A hash collision is perfect identification. Mirror subliminal: discard
+  // every other match and score the hash weight alone. Since the hash weight
+  // equals the sum of all other weights, this normalises to exactly 100% —
+  // strictly at or above any non-hash candidate.
   if (candidate.hashMatched) {
-    award('hash', weights.hash);
-    if (isEpisode) {
-      award('series', (weights as typeof EPISODE_WEIGHTS).series);
-      award('season', (weights as typeof EPISODE_WEIGHTS).season);
-      award('episode', (weights as typeof EPISODE_WEIGHTS).episode);
-    } else {
-      award('title', (weights as typeof MOVIE_WEIGHTS).title);
-    }
-    if (context.year) award('year', weights.year);
+    return finalize(weights.hash, max, ['hash']);
   }
 
   // IMDB equivalence: a confirmed imdb-id match means the provider


### PR DESCRIPTION
## Problem

Post-import subtitle auto-search **silently downloaded nothing** for a language whenever the provider had no `moviehash` match for the local file — the common case for community French subtitles. Yet the manual search listed plenty of FR candidates (all scored **< 50 %**).

## Root cause

`subtitle-scorer.ts` normalised the score wrong, making the default `subtitle_min_score = 70` **mathematically unreachable without a hash match**:

1. The denominator was `MAX_* = sum of every weight, hash included` (238 for a movie).
2. A hash hit was **stacked** on top of title/year instead of being exclusive.

So a non-hash candidate topped out at `119/238 = 50 %`. With the 70 threshold, the per-language loop in `subtitle-scheduler.service.ts` hit a **silent** `continue` (`results.find(r => r.score >= minScore)` → `undefined`) and downloaded nothing. Manual search applies no threshold, so it still showed those subs.

The weights themselves were a correct mirror of upstream subliminal (`hash == sum of all other weights`); only the normalisation and hash handling diverged.

## Fix

Port the two upstream mechanisms into the scorer:

- **Hash is exclusive** — a hash hit scores the hash weight alone (`return finalize(weights.hash, max, ['hash'])`).
- **Denominator = hash weight** (`MAX_* = WEIGHTS.hash`), which by construction equals the sum of all other weights.

Resulting movie percentages (max 119):

| Match | Before | After |
|---|---|---|
| hash | 88 % | **100 %** |
| perfect non-hash release | 50 % (ceiling) | **~100 %** |
| title + year | 38 % | **76 %** ✅ clears 70 |
| loose title only | — | 51 % |

The `subtitle_min_score` default stays **70** — it now means "the title/series was positively identified" instead of "a hash matched".

Also added a `log` line on the post-import "searched but nothing cleared the threshold" branch — that silent `continue` is exactly what made this bug invisible in prod.

## Tests

`subtitle-scorer.spec.ts`: hash-match assertions updated for the exclusive behaviour, new non-hash normalisation cases (title+year → 76 %, loose-title → 51 %, perfect non-hash release → 100 %). Real titles in fixtures replaced with placeholders. 17/17 green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)