### PR TITLE
fix(subtitles): search every missing profile language from the modal

### DIFF
--- a/backend/src/modules/media/media.controller.ts
+++ b/backend/src/modules/media/media.controller.ts
@@ -41,6 +41,7 @@ import { SubtitleSyncService } from '../subtitles/subtitle-sync.service';
 import { FfprobeService } from '../subtitles/ffprobe.service';
 import { SubtitleFile } from '../subtitles/entities/subtitle-file.entity';
 import { EventsService } from '../scheduler/events.service';
+import { SubtitleSchedulerService } from '../scheduler/subtitle-scheduler.service';
 import { LibrariesService } from '../libraries/libraries.service';
 import type { User } from '../users/entities/user.entity';
 
@@ -57,6 +58,7 @@ export class MediaController {
     private readonly subtitleSync: SubtitleSyncService,
     private readonly ffprobe: FfprobeService,
     private readonly eventsService: EventsService,
+    private readonly subtitleScheduler: SubtitleSchedulerService,
     private readonly libraries: LibrariesService,
   ) {}
 
@@ -594,6 +596,17 @@ export class MediaController {
         episode,
       },
     );
+  }
+
+  @Post(':id/subtitles/search-missing')
+  @CheckPolicies((ability) => ability.can(Action.Create, SubtitleFile))
+  async searchMissingSubtitles(
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentUser() user: User,
+    @Body() body: { mediaFileId: number },
+  ) {
+    await this.assertMediaAccessible(id, user);
+    return this.subtitleScheduler.searchMissingForMedia(id, body.mediaFileId);
   }
 
   @Post(':id/subtitles/download')

--- a/backend/src/modules/scheduler/subtitle-scheduler.service.ts
+++ b/backend/src/modules/scheduler/subtitle-scheduler.service.ts
@@ -64,18 +64,7 @@ export class SubtitleSchedulerService {
     const autoSearch = await this.settings.get('subtitle_auto_search');
     if (autoSearch === 'false') return;
 
-    // `subtitle_min_score` / `subtitle_upgrade_threshold` are now read as
-    // PERCENT (0-100) of the centralised scorer's max — see
-    // `subtitle-scorer.ts`. Existing rows persisted under the previous
-    // per-provider 0-100 scale stay readable; the upgrade pass naturally
-    // re-scores them via the central scorer on the next run.
-    const minScore = Number(
-      (await this.settings.get('subtitle_min_score')) ?? '70',
-    );
-    const autoSyncEnabled =
-      (await this.settings.get('subtitle_auto_sync')) === 'true';
-    const encodeUtf8 =
-      (await this.settings.get('subtitle_encode_utf8')) !== 'false';
+    const opts = await this.resolveSearchOpts();
 
     const mediaList = await this.mediaRepo.find({
       where: { monitored: true },
@@ -88,98 +77,159 @@ export class SubtitleSchedulerService {
     });
 
     for (const media of mediaList) {
-      const subtitleLangs: SubtitleLanguageItem[] =
-        media.languageProfile?.subtitleLanguages ?? [];
-      if (!subtitleLangs.length) continue;
       if (!media.files?.length) continue;
-
       for (const file of media.files) {
-        // Ensure embedded subtitles are detected before checking for missing ones
-        await this.embeddedSubtitle.detectAndStore(
+        await this.searchMissingForFile(media, file, opts);
+      }
+    }
+  }
+
+  /** Read the shared search/download settings in one place (no per-call drift). */
+  private async resolveSearchOpts(): Promise<{
+    minScore: number;
+    autoSyncEnabled: boolean;
+    encodeUtf8: boolean;
+  }> {
+    // `subtitle_min_score` is read as PERCENT (0-100) of the centralised
+    // scorer's max — see `subtitle-scorer.ts`.
+    return {
+      minScore: Number((await this.settings.get('subtitle_min_score')) ?? '70'),
+      autoSyncEnabled:
+        (await this.settings.get('subtitle_auto_sync')) === 'true',
+      encodeUtf8: (await this.settings.get('subtitle_encode_utf8')) !== 'false',
+    };
+  }
+
+  /**
+   * Search and download every required subtitle language still missing on one
+   * file. A non-FAILED sub (downloaded or EMBEDDED) counts as present, so an
+   * embedded track suppresses its language. Shared by the scheduled pass and
+   * the manual "search missing" action. Returns the iso codes downloaded.
+   */
+  private async searchMissingForFile(
+    media: Media,
+    file: MediaFile,
+    opts: { minScore: number; autoSyncEnabled: boolean; encodeUtf8: boolean },
+  ): Promise<string[]> {
+    const subtitleLangs: SubtitleLanguageItem[] =
+      media.languageProfile?.subtitleLanguages ?? [];
+    if (!subtitleLangs.length) return [];
+
+    // Ensure embedded subtitles are detected before checking for missing ones
+    await this.embeddedSubtitle.detectAndStore(
+      media.id,
+      file.id,
+      file.episodeId ?? undefined,
+    );
+
+    const existingSubs = await this.subtitleFileRepo.find({
+      where: { mediaFile: { id: file.id } },
+    });
+
+    const videoReleaseName = path.basename(
+      file.relativePath,
+      path.extname(file.relativePath),
+    );
+    const fileSeason = file.episode?.season?.seasonNumber ?? undefined;
+    const fileEpisode = file.episode?.episodeNumber ?? undefined;
+
+    const downloaded: string[] = [];
+
+    for (const langItem of subtitleLangs) {
+      const hasSub = existingSubs.some(
+        (s) =>
+          s.language === langItem.isoCode &&
+          s.status !== SubtitleStatus.FAILED,
+      );
+      if (hasSub) continue;
+
+      try {
+        const results = await this.subtitlesService.searchSubtitles({
+          imdbId: media.imdbId ?? undefined,
+          tmdbId: media.tmdbId,
+          title: media.title,
+          year: media.year ?? undefined,
+          language: langItem.isoCode,
+          season: fileSeason,
+          episode: fileEpisode,
+          videoReleaseName,
+          moviehash: file.osdbHash ?? undefined,
+          moviebytesize: file.osdbBytesize ?? undefined,
+          hearingImpairedMode: resolveHearingImpairedMode(langItem),
+        });
+
+        const best = results.find((r) => r.score >= opts.minScore);
+        if (!best) continue;
+
+        const sub = await this.subtitlesService.downloadSubtitle(
           media.id,
           file.id,
           file.episodeId ?? undefined,
+          best,
         );
 
-        const existingSubs = await this.subtitleFileRepo.find({
-          where: { mediaFile: { id: file.id } },
+        if (opts.encodeUtf8) {
+          await this.subtitleSync.reencodeToUtf8(sub.id);
+        }
+        if (opts.autoSyncEnabled) {
+          await this.subtitleSync.syncSubtitle(sub.id);
+        }
+
+        void this.notifications.dispatch('subtitle.downloaded', {
+          title: media.title,
+          language: langItem.isoCode,
+          provider: best.providerName,
+          score: best.score,
         });
 
-        const videoReleaseName = path.basename(
-          file.relativePath,
-          path.extname(file.relativePath),
+        void this.mediaServers.dispatch('subtitle.downloaded', {
+          title: media.title,
+          path: media.path,
+        });
+
+        downloaded.push(langItem.isoCode);
+
+        this.log.log(
+          `SubtitleSearch: downloaded ${langItem.isoCode} sub for "${media.title}" (score: ${best.score})`,
         );
-        const fileSeason = file.episode?.season?.seasonNumber ?? undefined;
-        const fileEpisode = file.episode?.episodeNumber ?? undefined;
-
-        for (const langItem of subtitleLangs) {
-          const hasSub = existingSubs.some(
-            (s) =>
-              s.language === langItem.isoCode &&
-              s.status !== SubtitleStatus.FAILED,
-          );
-          if (hasSub) continue;
-
-          try {
-            const results = await this.subtitlesService.searchSubtitles({
-              imdbId: media.imdbId ?? undefined,
-              tmdbId: media.tmdbId,
-              title: media.title,
-              year: media.year ?? undefined,
-              language: langItem.isoCode,
-              season: fileSeason,
-              episode: fileEpisode,
-              videoReleaseName,
-              moviehash: file.osdbHash ?? undefined,
-              moviebytesize: file.osdbBytesize ?? undefined,
-              hearingImpairedMode: resolveHearingImpairedMode(langItem),
-            });
-
-            const best = results.find((r) => r.score >= minScore);
-            if (!best) continue;
-
-            const sub = await this.subtitlesService.downloadSubtitle(
-              media.id,
-              file.id,
-              file.episodeId ?? undefined,
-              best,
-            );
-
-            if (encodeUtf8) {
-              await this.subtitleSync.reencodeToUtf8(sub.id);
-            }
-            if (autoSyncEnabled) {
-              await this.subtitleSync.syncSubtitle(sub.id);
-            }
-
-            void this.notifications.dispatch('subtitle.downloaded', {
-              title: media.title,
-              language: langItem.isoCode,
-              provider: best.providerName,
-              score: best.score,
-            });
-
-            void this.mediaServers.dispatch('subtitle.downloaded', {
-              title: media.title,
-              path: media.path,
-            });
-
-            this.log.log(
-              `SubtitleSearch: downloaded ${langItem.isoCode} sub for "${media.title}" (score: ${best.score})`,
-            );
-          } catch (err) {
-            this.log.warn(
-              `SubtitleSearch: failed for "${media.title}" [${langItem.isoCode}]: ${err}`,
-            );
-            void this.notifications.dispatch('subtitle.failed', {
-              title: media.title,
-              language: langItem.isoCode,
-              error: String(err),
-            });
-          }
-        }
+      } catch (err) {
+        this.log.warn(
+          `SubtitleSearch: failed for "${media.title}" [${langItem.isoCode}]: ${err}`,
+        );
+        void this.notifications.dispatch('subtitle.failed', {
+          title: media.title,
+          language: langItem.isoCode,
+          error: String(err),
+        });
       }
     }
+
+    return downloaded;
+  }
+
+  /**
+   * Manual "search missing" for one media file. Same gap-filling logic as the
+   * scheduled pass, but user-initiated, so it deliberately ignores the
+   * `subtitle_auto_search` toggle (that gate governs only the automatic passes).
+   */
+  async searchMissingForMedia(
+    mediaId: number,
+    mediaFileId: number,
+  ): Promise<{ downloaded: string[] }> {
+    const media = await this.mediaRepo.findOne({
+      where: { id: mediaId },
+      relations: [
+        'languageProfile',
+        'files',
+        'files.episode',
+        'files.episode.season',
+      ],
+    });
+    const file = media?.files?.find((f) => f.id === mediaFileId);
+    if (!media || !file) return { downloaded: [] };
+
+    const opts = await this.resolveSearchOpts();
+    return { downloaded: await this.searchMissingForFile(media, file, opts) };
   }
 
   async upgradeSubtitles(): Promise<void> {

--- a/client/src/app/core/services/api/subtitles-api.service.ts
+++ b/client/src/app/core/services/api/subtitles-api.service.ts
@@ -64,6 +64,15 @@ export class SubtitlesApiService {
     );
   }
 
+  searchMissing(mediaId: number, body: { mediaFileId: number }) {
+    return firstValueFrom(
+      this.http.post<{ downloaded: string[] }>(
+        `/api/media/${mediaId}/subtitles/search-missing`,
+        body,
+      ),
+    );
+  }
+
   download(mediaId: number, body: { searchResult: SubtitleSearchResult; mediaFileId: number; episodeId?: number }) {
     return firstValueFrom(
       this.http.post<SubtitleFileRow>(`/api/media/${mediaId}/subtitles/download`, body),

--- a/client/src/app/core/services/subtitle-actions.service.ts
+++ b/client/src/app/core/services/subtitle-actions.service.ts
@@ -53,14 +53,13 @@ export class SubtitleActionsService {
     }
   }
 
-  async autoDownload(
-    mediaId: number, mediaFileId: number, language: string,
+  async searchMissing(
+    mediaId: number, mediaFileId: number,
     subtitles: WritableSignal<SubtitleFileRow[]>, busy: WritableSignal<boolean>,
-    episodeId?: number,
   ) {
     busy.set(true);
     try {
-      await this.subtitlesApi.autoDownload(mediaId, { mediaFileId, episodeId, language });
+      await this.subtitlesApi.searchMissing(mediaId, { mediaFileId });
       subtitles.set(await this.subtitlesApi.getForMedia(mediaId));
     } finally {
       busy.set(false);

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -15,7 +15,7 @@
                 class="btn btn-ghost btn-sm shrink-0"
                 [disabled]="searchDisabled() || subtitleActionBusy()"
                 [attr.title]="searchDisabled() ? ('media_detail.subtitles_need_episode_file' | translate) : null"
-                (click)="autoSubtitle()"
+                (click)="searchMissing()"
               >
                 @if (subtitleActionBusy()) {
                   <span class="loading loading-spinner loading-xs"></span>

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -387,16 +387,14 @@ export class SubtitlesModalComponent {
     }
   }
 
-  async autoSubtitle() {
+  async searchMissing() {
     const fileId = this.selectedFileId();
     if (!fileId) return;
-    await this.subActions.autoDownload(
+    await this.subActions.searchMissing(
       this.mediaId(),
       fileId,
-      this.subSearchLang(),
       this.subtitles,
       this.subtitleActionBusy,
-      this.episodeId(),
     );
   }
 


### PR DESCRIPTION
## Problem

From the subtitle modal, **"Rechercher manquant"** kept downloading **English** even though English was already **embedded** and the profile's missing language was **French**.

## Root cause

- **Frontend** (`subtitles-modal.ts` `autoSubtitle()`): sent `subSearchLang()` — the manual-search language picker, whose default is `'en'` — instead of the missing language.
- **Backend** (`subtitles.service.ts` `autoDownload`): a single-language primitive. It searches the one language it's given and grabs `results[0]` with **no `detectAndStore`, no check of existing subs, no profile iteration, and no min-score floor**.

So the button asked for EN, and the backend happily fetched an EN sub — ignoring the embedded EN and never searching the missing FR.

The correct "missing" logic already existed, but only in the scheduled cron pass `SubtitleSchedulerService.searchMissingSubtitles()` (detect embedded → any non-`FAILED` sub counts as present → loop every required language → min-score threshold).

## Fix

Route the button through a **server-authoritative per-file gap filler** that **reuses the scheduled pass's logic** — no duplicated behaviour:

- Extracted the per-file body of the cron pass into a shared private `searchMissingForFile(media, file, opts)`. The cron loop and the new path both call it (single source of truth).
- Added `searchMissingForMedia(mediaId, mediaFileId)` + `POST /media/:id/subtitles/search-missing`.
- Frontend button now calls it with **no language** — the server computes the gaps. Removed the now-dead single-language wrapper on the actions service.

`/subtitles/auto` + `autoDownload` stay — the Settings → Subtitles stats page still uses them to grab one **explicit** language.

The manual action **ignores the `subtitle_auto_search` toggle on purpose**: that gate governs only the automatic passes; a user clicking the button expects it to run.

## Result

Clicking "Rechercher manquant" on the affected film: embedded EN is detected and counted as present (**no duplicate EN**), and **FR** is searched and downloaded if it clears the score threshold (70, post-scorer-fix). Behaviour is now identical to the scheduled pass.

## Verification

- Backend `tsc --noEmit` clean; frontend AOT build clean (validates the `(click)="searchMissing()"` binding and the removed methods).
- DI: `SubtitleSchedulerService` is exported by `FliksSchedulerModule` (already imported by `MediaModule` via `forwardRef`); it has no dependency on `MediaController`/`MediaService`, so there's no instantiation cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)