### PR TITLE
fix(confirmation): render in the top layer to stack above modals

### DIFF
--- a/client/src/app/shared/components/confirmation-modal.html
+++ b/client/src/app/shared/components/confirmation-modal.html
@@ -1,4 +1,4 @@
-<dialog class="modal" [class.modal-open]="isOpen()" role="dialog" aria-modal="true">
+<dialog #dialog class="modal" role="dialog" aria-modal="true" (close)="onDialogClose()">
   <div class="modal-box">
     <h3 class="text-lg font-bold">{{ title() }}</h3>
     <p class="py-4">{{ message() }}</p>

--- a/client/src/app/shared/components/confirmation-modal.ts
+++ b/client/src/app/shared/components/confirmation-modal.ts
@@ -1,4 +1,12 @@
-import { Component, ChangeDetectionStrategy, inject, computed } from '@angular/core';
+import {
+  Component,
+  ChangeDetectionStrategy,
+  inject,
+  computed,
+  effect,
+  viewChild,
+  ElementRef,
+} from '@angular/core';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ConfirmationService } from '../../core/services/confirmation.service';
 
@@ -11,6 +19,9 @@ import { ConfirmationService } from '../../core/services/confirmation.service';
 export class ConfirmationModalComponent {
   readonly confirmService = inject(ConfirmationService);
   private readonly translate = inject(TranslateService);
+
+  private readonly dialog =
+    viewChild<ElementRef<HTMLDialogElement>>('dialog');
 
   readonly isOpen = computed(() => !!this.confirmService.state());
   readonly title = computed(() => this.confirmService.state()?.title ?? '');
@@ -41,4 +52,29 @@ export class ConfirmationModalComponent {
     };
     return map[this.variant()] ?? 'btn-primary';
   });
+
+  constructor() {
+    // Open through the native dialog API so the confirmation lands in the
+    // browser top layer — above any modal already opened with showModal()
+    // (e.g. the subtitles modal). A CSS/z-index modal can never sit above a
+    // top-layer one.
+    effect(() => {
+      const el = this.dialog()?.nativeElement;
+      if (!el) return;
+      if (this.isOpen()) {
+        if (!el.open) el.showModal();
+      } else if (el.open) {
+        el.close();
+      }
+    });
+  }
+
+  /** ESC / backdrop dismissal closes the native dialog — resolve the pending
+   *  request the same way the buttons would. No-op when a button already
+   *  resolved it (the service calls are idempotent). */
+  onDialogClose() {
+    if (!this.confirmService.state()) return;
+    if (this.dismissLabel()) this.confirmService.dismiss();
+    else this.confirmService.cancel();
+  }
 }


### PR DESCRIPTION
## Problem

On desktop, deleting a subtitle pops the confirmation dialog **behind** the subtitles modal — it's unreachable.

## Root cause

The shared confirmation dialog (`confirmation-modal`) was shown purely via daisyUI's `modal-open` class — a CSS/z-index overlay. The subtitles modal (and other dialogs) open with the **native `dialog.showModal()`**, which promotes them to the browser **top layer**. A z-index overlay can never paint above the top layer, so the confirmation always lost the stacking contest. This was global: the confirm dialog would sit behind *any* `showModal()`-opened modal.

## Fix

Open the confirmation through the native dialog API too:

- An `effect()` drives `showModal()` / `close()` off the open state, so two native modals stack in the top layer in open order — the confirmation lands on top.
- The native `close` event (ESC / backdrop) resolves the pending request the same way the buttons do. The service's `accept`/`cancel`/`dismiss` are idempotent (optional-chained + `set(null)`), so a button-initiated close is a harmless no-op on the second pass — no double-resolution, no re-open loop.
- Dropped the `[class.modal-open]` binding; visibility is now driven by the native `[open]` attribute, which daisyUI already styles (`dialog.modal[open]`) — the same markup the subtitles modal uses successfully.

## Verification

- Frontend AOT build clean (validates the `#dialog` ref, `(close)` binding, `onDialogClose()`).
- Manual: delete a subtitle from the modal → the confirmation now appears on top; Confirm/Cancel/ESC/backdrop all resolve and close correctly, leaving the subtitles modal open underneath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)