### PR TITLE
feat(subtitles): hide burn-required subtitles behind an app setting

### DIFF
--- a/backend/src/common/constants/subtitle-codecs.ts
+++ b/backend/src/common/constants/subtitle-codecs.ts
@@ -1,0 +1,17 @@
+/**
+ * Bitmap subtitle codecs. These carry rendered images rather than text, so
+ * they can't be served as WebVTT/SRT and must be burned into the video to be
+ * shown — or OCR'd to text first. Kept in one place so detection, burn-in and
+ * the OCR pipeline can't drift apart.
+ */
+export const IMAGE_BASED_SUBTITLE_CODECS = new Set([
+  'hdmv_pgs_subtitle',
+  'dvd_subtitle',
+  'dvb_subtitle',
+  'xsub',
+]);
+
+/** True for bitmap subtitles (PGS, VOBSUB, DVB, XSUB) that need burn-in. */
+export function isImageBasedSubtitleCodec(codec: string | null | undefined): boolean {
+  return IMAGE_BASED_SUBTITLE_CODECS.has(codec ?? '');
+}

--- a/backend/src/modules/streaming/subtitle-burn-in.service.ts
+++ b/backend/src/modules/streaming/subtitle-burn-in.service.ts
@@ -4,19 +4,13 @@ import { Repository } from 'typeorm';
 import { SubtitleFile } from '../subtitles/entities/subtitle-file.entity';
 import { StreamingService } from './streaming.service';
 import { resolveSubtitleAbsolutePath } from '../subtitles/subtitle-path.util';
+import { isImageBasedSubtitleCodec } from '../../common/constants/subtitle-codecs';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);
-
-const IMAGE_BASED_CODECS = new Set([
-  'hdmv_pgs_subtitle',
-  'dvd_subtitle',
-  'dvb_subtitle',
-  'xsub',
-]);
 
 export interface BurnInInfo {
   /** 'text' for SRT/ASS/SSA, 'image' for PGS/VOBSUB */
@@ -55,7 +49,7 @@ export class SubtitleBurnInService {
 
     const resolved = await this.streamingService.resolveFile(mediaFileId);
     const videoPath = resolved.absolutePath;
-    const isImage = IMAGE_BASED_CODECS.has(sub.codec ?? '');
+    const isImage = isImageBasedSubtitleCodec(sub.codec);
 
     if (sub.relativePath) {
       // External subtitle file

--- a/backend/src/modules/subtitles/ffprobe.service.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.ts
@@ -3,6 +3,7 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import * as path from 'path';
 import { inferLanguageCodeFromTitle } from '../../common/release-parsing/language.parser';
+import { isImageBasedSubtitleCodec } from '../../common/constants/subtitle-codecs';
 
 const execFileAsync = promisify(execFile);
 
@@ -66,13 +67,6 @@ export interface AudioStreamInfo {
   bitRate?: number;
   isDefault?: boolean;
 }
-
-const IMAGE_BASED_SUBTITLE_CODECS = new Set([
-  'hdmv_pgs_subtitle',
-  'dvd_subtitle',
-  'dvb_subtitle',
-  'xsub',
-]);
 
 export interface SubtitleStreamInfo {
   streamIndex: number;
@@ -265,7 +259,7 @@ export class FfprobeService {
         language: resolveStreamLanguage(s),
         forced: s.disposition?.forced === 1,
         hearingImpaired: s.disposition?.hearing_impaired === 1,
-        isImageBased: IMAGE_BASED_SUBTITLE_CODECS.has(s.codec_name ?? ''),
+        isImageBased: isImageBasedSubtitleCodec(s.codec_name),
       }));
     } catch (err) {
       this.logger.warn(
@@ -396,7 +390,7 @@ export class FfprobeService {
           title: tag(s.tags, 'title'),
           forced: s.disposition?.forced === 1,
           hearingImpaired: s.disposition?.hearing_impaired === 1,
-          isImageBased: IMAGE_BASED_SUBTITLE_CODECS.has(s.codec_name ?? ''),
+          isImageBased: isImageBasedSubtitleCodec(s.codec_name),
         }));
 
       const chapters: Chapter[] = (parsed.chapters ?? [])

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1779,6 +1779,8 @@
       "encode_utf8": "Ré-encoder en UTF-8 après téléchargement",
       "section_cleaning": "Nettoyage",
       "remove_hi_tags": "Supprimer les tags HI ([musique], (soupir), ♪, etc.)",
+      "hide_burn_in": "Masquer les sous-titres à graver (image) du lecteur",
+      "hide_burn_in_hint": "Les sous-titres image (PGS, VOBSUB…) ne peuvent pas être affichés comme du texte et nécessitent une gravure. Tant que la gravure n'est pas disponible, ils sont masqués du sélecteur du lecteur et de la fiche média.",
       "custom_exclusions": "Exclusions personnalisées (regex)",
       "custom_exclusions_placeholder": "opensubtitles\nadvertise\nwww\\.example\\.com",
       "custom_exclusions_hint": "Une regex par ligne. Les sous-titres contenant ces motifs seront supprimés.",

--- a/client/src/app/core/services/app-settings.service.ts
+++ b/client/src/app/core/services/app-settings.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { SettingsApiService } from './api/settings-api.service';
+
+/**
+ * Lazily-cached read access to server-side application settings for surfaces
+ * that need a flag but don't own the settings page. Loads `/api/settings` once
+ * and exposes signals; call `refresh()` after a save to re-read.
+ */
+@Injectable({ providedIn: 'root' })
+export class AppSettingsService {
+  private readonly api = inject(SettingsApiService);
+  private readonly all = signal<Record<string, string | null> | null>(null);
+  private loadPromise: Promise<Record<string, string | null>> | null = null;
+
+  /** Load the settings once (no-op once cached). Safe to call repeatedly. */
+  async ensureLoaded(): Promise<void> {
+    if (this.all()) return;
+    if (!this.loadPromise) {
+      this.loadPromise = this.api.getAll().catch(() => ({}) as Record<string, string | null>);
+    }
+    this.all.set(await this.loadPromise);
+  }
+
+  /** Re-read from the server (e.g. after the settings page saves). */
+  async refresh(): Promise<void> {
+    this.loadPromise = this.api.getAll().catch(() => ({}) as Record<string, string | null>);
+    this.all.set(await this.loadPromise);
+  }
+
+  /**
+   * Hide burn-required (image-based) subtitles from the player / cast pickers
+   * and the media-detail header. Defaults to `true` — burn-in is currently
+   * non-functional, so a visible-but-unusable track is worse than hidden.
+   */
+  readonly hideBurnInSubtitles = computed(() => {
+    const v = this.all()?.['subtitle_hide_burn_in'];
+    return v == null ? true : v !== 'false';
+  });
+}

--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -4,6 +4,8 @@ import { CastService } from './cast.service';
 import { CastSettingsService } from './cast-settings.service';
 import { StreamingApiService } from './api/streaming-api.service';
 import { SubtitlesApiService } from './api/subtitles-api.service';
+import { AppSettingsService } from './app-settings.service';
+import { isImageBasedSubtitleCodec } from '../utils/subtitle-codecs';
 import { AuthService } from './auth.service';
 import { DeviceProfile } from './browser-device-profile.service';
 import { ServerConfigService } from './server-config.service';
@@ -97,6 +99,7 @@ export class CastPlayerService {
   private readonly castSettings = inject(CastSettingsService);
   private readonly streamingApi = inject(StreamingApiService);
   private readonly subtitlesApi = inject(SubtitlesApiService);
+  private readonly appSettings = inject(AppSettingsService);
   private readonly authService = inject(AuthService);
   private readonly serverConfig = inject(ServerConfigService);
   private readonly playerSettings = inject(PlayerSettingsService);
@@ -712,11 +715,13 @@ export class CastPlayerService {
     );
 
     // Build subtitle list from the parallel fetch
+    await this.appSettings.ensureLoaded();
+    const hideBurnIn = this.appSettings.hideBurnInSubtitles();
     const subtitleInfos: SubtitleInfo[] = [];
-    const bitmapCodecs = new Set(['hdmv_pgs_subtitle', 'dvd_subtitle', 'dvb_subtitle']);
     for (const sub of subsResult) {
       if (sub.mediaFileId !== opts.mediaFileId) continue;
-      const isBitmap = bitmapCodecs.has(sub.codec ?? '');
+      const isBitmap = isImageBasedSubtitleCodec(sub.codec);
+      if (hideBurnIn && isBitmap) continue;
       if (sub.relativePath) {
         subtitleInfos.push({
           id: `ext-${sub.id}`, label: formatSubtitleLabel(sub, this.translate),

--- a/client/src/app/core/services/download-manager.service.ts
+++ b/client/src/app/core/services/download-manager.service.ts
@@ -3,6 +3,7 @@ import { Capacitor } from '@capacitor/core';
 import { StreamingApiService } from './api/streaming-api.service';
 import { SubtitlesApiService } from './api/subtitles-api.service';
 import { MediaService } from './api/media.service';
+import { isImageBasedSubtitleCodec } from '../utils/subtitle-codecs';
 import { OfflineStorageService } from './offline-storage.service';
 import { DownloadCacheService, DownloadTask } from './download-cache.service';
 import { DownloadNotificationService } from './download-notification.service';
@@ -226,10 +227,9 @@ export class DownloadManagerService {
     const task = this.cache.load().find((t) => t.id === taskId);
     if (!task?.mediaId || !task.mediaFileId) return;
     try {
-      const bitmapCodecs = new Set(['hdmv_pgs_subtitle', 'dvd_subtitle', 'dvb_subtitle']);
       const allSubs = await this.subtitlesApi.getForMedia(task.mediaId);
       const subs = allSubs.filter(
-        (s) => s.mediaFileId === task.mediaFileId && !bitmapCodecs.has(s.codec ?? ''),
+        (s) => s.mediaFileId === task.mediaFileId && !isImageBasedSubtitleCodec(s.codec),
       );
       const offlineSubs: { key: string; language: string; label: string; forced?: boolean }[] = [];
       for (const sub of subs) {

--- a/client/src/app/core/services/track-manager.service.ts
+++ b/client/src/app/core/services/track-manager.service.ts
@@ -3,7 +3,9 @@ import { TranslateService } from '@ngx-translate/core';
 import { PlayerSettingsService, normalizeLang } from './player-settings.service';
 import { SubtitlesApiService } from './api/subtitles-api.service';
 import { StreamingApiService } from './api/streaming-api.service';
+import { AppSettingsService } from './app-settings.service';
 import { formatSubtitleLabel } from '../utils/player.utils';
+import { isImageBasedSubtitleCodec } from '../utils/subtitle-codecs';
 import type { PlaybackEngine, AudioTrack } from './playback-engine/playback-engine';
 
 export interface SubtitleOption {
@@ -23,6 +25,7 @@ export interface SubtitleOption {
 export class TrackManagerService {
   private readonly playerSettings = inject(PlayerSettingsService);
   private readonly subtitlesApi = inject(SubtitlesApiService);
+  private readonly appSettings = inject(AppSettingsService);
   private readonly translate = inject(TranslateService);
 
   // ── Audio track methods ──
@@ -135,14 +138,16 @@ export class TrackManagerService {
     if (!mediaId) return [];
 
     try {
+      await this.appSettings.ensureLoaded();
+      const hideBurnIn = this.appSettings.hideBurnInSubtitles();
       const options: SubtitleOption[] = [];
       const subs = await this.subtitlesApi.getForMedia(mediaId);
-      const bitmapCodecs = new Set(['hdmv_pgs_subtitle', 'dvd_subtitle', 'dvb_subtitle']);
       const seen = new Set<string>();
 
       for (const sub of subs) {
         if (sub.mediaFileId !== mediaFileId) continue;
-        const isBitmap = bitmapCodecs.has(sub.codec ?? '');
+        const isBitmap = isImageBasedSubtitleCodec(sub.codec);
+        if (hideBurnIn && isBitmap) continue;
 
         if (sub.relativePath) {
           const key = `ext-${sub.language}-${sub.forced}-${sub.hearingImpaired}`;
@@ -181,8 +186,7 @@ export class TrackManagerService {
           const key = `emb-${emb.streamIndex}`;
           if (seen.has(key)) continue;
           seen.add(key);
-          const isBitmap = bitmapCodecs.has(emb.codec);
-          if (isBitmap) continue; // Bitmap from streamInfo only (no DB ID for burn-in)
+          if (isImageBasedSubtitleCodec(emb.codec)) continue; // Bitmap from streamInfo only (no DB ID for burn-in)
           options.push({
             id: key,
             label: formatSubtitleLabel(emb, this.translate),

--- a/client/src/app/core/utils/subtitle-codecs.ts
+++ b/client/src/app/core/utils/subtitle-codecs.ts
@@ -1,0 +1,16 @@
+/**
+ * Bitmap subtitle codecs (PGS, VOBSUB, DVB, XSUB). They carry rendered images,
+ * not text, so they can't be served as WebVTT and must be burned into the video.
+ * Single source of truth so the player, cast and media-detail surfaces agree.
+ */
+const IMAGE_BASED_SUBTITLE_CODECS = new Set([
+  'hdmv_pgs_subtitle',
+  'dvd_subtitle',
+  'dvb_subtitle',
+  'xsub',
+]);
+
+/** True for bitmap subtitles that need burn-in. */
+export function isImageBasedSubtitleCodec(codec: string | null | undefined): boolean {
+  return IMAGE_BASED_SUBTITLE_CODECS.has(codec ?? '');
+}

--- a/client/src/app/features/settings/subtitles/subtitles-settings.html
+++ b/client/src/app/features/settings/subtitles/subtitles-settings.html
@@ -89,6 +89,14 @@
           <span class="label-text">{{ 'settings.subtitles.remove_hi_tags' | translate }}</span>
         </label>
 
+        <label class="label cursor-pointer justify-start gap-3 max-w-max">
+          <input type="checkbox" class="toggle toggle-sm"
+            [ngModel]="hideBurnIn() === 'true'"
+            (ngModelChange)="hideBurnIn.set($event ? 'true' : 'false')" />
+          <span class="label-text">{{ 'settings.subtitles.hide_burn_in' | translate }}</span>
+        </label>
+        <p class="text-xs text-base-content/50 -mt-1 max-w-lg">{{ 'settings.subtitles.hide_burn_in_hint' | translate }}</p>
+
         <label class="form-control w-full max-w-lg">
           <div class="label">
             <span class="label-text">{{ 'settings.subtitles.custom_exclusions' | translate }}</span>

--- a/client/src/app/features/settings/subtitles/subtitles-settings.ts
+++ b/client/src/app/features/settings/subtitles/subtitles-settings.ts
@@ -8,6 +8,7 @@ import {
 import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { SettingsApiService } from '../../../core/services/api/settings-api.service';
+import { AppSettingsService } from '../../../core/services/app-settings.service';
 import { ToastService } from '../../../core/services/toast.service';
 
 @Component({
@@ -18,6 +19,7 @@ import { ToastService } from '../../../core/services/toast.service';
 })
 export class SubtitlesSettingsComponent implements OnInit {
   private readonly api = inject(SettingsApiService);
+  private readonly appSettings = inject(AppSettingsService);
   private readonly translate = inject(TranslateService);
   private readonly toast = inject(ToastService);
 
@@ -32,6 +34,7 @@ export class SubtitlesSettingsComponent implements OnInit {
   readonly autoSync = signal('false');
   readonly encodeUtf8 = signal('true');
   readonly removeHiTags = signal('false');
+  readonly hideBurnIn = signal('true');
   readonly customExclusions = signal('');
 
   async ngOnInit() {
@@ -45,6 +48,7 @@ export class SubtitlesSettingsComponent implements OnInit {
       this.autoSync.set(map['subtitle_auto_sync'] ?? 'false');
       this.encodeUtf8.set(map['subtitle_encode_utf8'] ?? 'true');
       this.removeHiTags.set(map['subtitle_remove_hi_tags'] ?? 'false');
+      this.hideBurnIn.set(map['subtitle_hide_burn_in'] ?? 'true');
       this.customExclusions.set(map['subtitle_custom_exclusions'] ?? '');
     } catch {
       this.toast.error(this.translate.instant('settings.subtitles.load_error'));
@@ -65,8 +69,10 @@ export class SubtitlesSettingsComponent implements OnInit {
         subtitle_auto_sync: this.autoSync(),
         subtitle_encode_utf8: this.encodeUtf8(),
         subtitle_remove_hi_tags: this.removeHiTags(),
+        subtitle_hide_burn_in: this.hideBurnIn(),
         subtitle_custom_exclusions: this.customExclusions(),
       });
+      await this.appSettings.refresh();
       this.toast.success(this.translate.instant('settings.subtitles.saved'));
     } catch {
       // handled by global interceptor

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -29,6 +29,8 @@ import {
 } from '@lucide/angular';
 import { LocalizeLanguagePipe } from '../../../core/pipes/localize-language.pipe';
 import { formatSubtitleLabel } from '../../../core/utils/player.utils';
+import { isImageBasedSubtitleCodec } from '../../../core/utils/subtitle-codecs';
+import { AppSettingsService } from '../../../core/services/app-settings.service';
 import { SubtitleFilenamePipe } from '../../pipes/subtitle-filename.pipe';
 import {
   MediaStream,
@@ -98,6 +100,12 @@ export class SubtitlesModalComponent {
   private readonly toast = inject(ToastService);
   private readonly profilesApi = inject(ProfilesService);
   private readonly sse = inject(SseService);
+  private readonly appSettings = inject(AppSettingsService);
+
+  constructor() {
+    // Header subtitle chips honour the hide-burn-in app setting; load it once.
+    void this.appSettings.ensureLoaded();
+  }
 
   // ── Inputs ──
   readonly mediaId = input.required<number>();
@@ -224,7 +232,10 @@ export class SubtitlesModalComponent {
 
   /** Formatted subtitles for the media-info-header dropdown */
   readonly headerSubtitles = computed<MediaInfoHeaderSubtitle[]>(() => {
-    const subs = this.filteredSubtitles();
+    const hideBurnIn = this.appSettings.hideBurnInSubtitles();
+    const subs = this.filteredSubtitles().filter(
+      (s) => !(hideBurnIn && isImageBasedSubtitleCodec(s.codec)),
+    );
     return subs.map((s) => {
       const id = s.streamIndex != null ? `emb-${s.streamIndex}` : `ext-${s.id}`;
       return {


### PR DESCRIPTION
First part of the burn-required-subtitles plan: **hide them**. (OCR extraction is the separate follow-up.)

## Why

Image-based subtitles (PGS / VOBSUB / DVB / XSUB) carry rendered images, not text — they can't be served as WebVTT and must be burned into the video. That burn-in path is currently non-functional, so selecting such a track in the player did nothing useful.

## What

- **New app setting `subtitle_hide_burn_in`** (default **on**), toggled on the **Settings → Subtitles** page. When on, image-based subtitles are hidden from:
  - the player subtitle picker (`track-manager`),
  - the cast picker (`cast-player`),
  - the media-detail header chips (`subtitles-modal.headerSubtitles`).
  The subtitle **management modal** still lists them (so they stay visible/manageable and available to the upcoming OCR step).
- The client reads the setting via a small cached `AppSettingsService`; the settings page refreshes that cache on save.

## Cleanup (no duplication)

The bitmap-codec check was duplicated **four times** on the client — and inconsistent (`xsub` was missing) — and **twice** on the backend. Both sides now share one `isImageBasedSubtitleCodec` helper (`common/constants/subtitle-codecs.ts` / `core/utils/subtitle-codecs.ts`), which also fixes the missing `xsub`.

## Verification

- Backend `tsc --noEmit` clean; frontend AOT build clean.
- Default-on means existing installs immediately stop offering the broken tracks in the player; admins can re-enable from Settings → Subtitles.

Part 2 (extract + OCR image subs to servable text, stored as `OCR` provider, auto-on-import or manual from the management modal) will follow in its own PR — it needs OCR tooling (tesseract + pgsrip/vobsub2srt) added to the image and real-media testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)