### PR TITLE
fix(subtitles): gate management on subtitles.manage, not media.grab

### DIFF
--- a/backend/src/modules/auth/casl/casl-ability.factory.ts
+++ b/backend/src/modules/auth/casl/casl-ability.factory.ts
@@ -92,6 +92,7 @@ export class CaslAbilityFactory {
     // --- subtitles ---
     if (perms.has('subtitles.manage')) {
       can(Action.Create, SubtitleFile);
+      can(Action.Update, SubtitleFile);
       can(Action.Delete, SubtitleFile);
     }
 

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -116,7 +116,7 @@
           [episodeId]="ep.id"
           [files]="m.files ?? []"
           [selectedFileId]="episodeActiveFileId()"
-          [canGrab]="canGrab()"
+          [canManage]="canManageSubtitles()"
           [searchDisabled]="!ep.hasFile"
           [languageProfileId]="m.languageProfile?.id ?? null"
         />
@@ -197,7 +197,7 @@
             [mediaId]="m.id"
             [files]="mediaFiles()"
             [selectedFileId]="activeFileId()"
-            [canGrab]="canGrab()"
+            [canManage]="canManageSubtitles()"
             [languageProfileId]="m.languageProfile?.id ?? null"
           />
         }

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -556,6 +556,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   readonly libraryPatchSaved = signal(false);
 
   readonly canGrab = computed(() => this.auth.hasPermission('media.grab'));
+  readonly canManageSubtitles = computed(() => this.auth.hasPermission('subtitles.manage'));
   readonly canEditProfiles = computed(() => this.auth.hasPermission('media.edit'));
   readonly canDelete = computed(() => this.auth.hasPermission('media.delete'));
   readonly isAdmin = computed(() => this.auth.hasPermission('settings.access'));

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -7,7 +7,7 @@
 
     <section class="space-y-3">
       <div class="flex flex-wrap items-center justify-between gap-2">
-        @if (canGrab()) {
+        @if (canManage()) {
           <div class="flex gap-2 ml-auto">
             @if (hasMissing()) {
               <button
@@ -100,7 +100,7 @@
                       @if (sub.codec) { <span class="badge badge-xs badge-ghost ml-1">{{ sub.codec }}</span> }
                     </td>
                     <td class="text-end">
-                      @if (canGrab() && rowHasActions(sub)) {
+                      @if (canManage() && rowHasActions(sub)) {
                         <button
                           #actionsTrigger
                           type="button"

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -113,7 +113,7 @@ export class SubtitlesModalComponent {
   /** All files for this media (or episode files) — used to filter subtitles + find active file */
   readonly files = input<{ id: number; episodeId?: number | null; streamInfo?: any }[]>([]);
   readonly selectedFileId = input<number | null>(null);
-  readonly canGrab = input(false);
+  readonly canManage = input(false);
   readonly searchDisabled = input(false);
   /** Language profile ID from the media — used to compute required subtitle languages */
   readonly languageProfileId = input<number | null>(null);


### PR DESCRIPTION
Follow-up to the subtitle-OCR work (#428) — fixes a permission mismatch.

## Problem
The subtitles modal gates its action buttons (Actions menu, search-missing, search) on **`media.grab`** (`canGrab`), but the backend subtitle endpoints require the **`SubtitleFile` CASL abilities** granted by **`subtitles.manage`**. So:
- a user with `media.grab` but not `subtitles.manage` saw the buttons → got **403** on click;
- a user with `subtitles.manage` but not `media.grab` was allowed by the backend but the buttons were **hidden**.

Also, the language-relabel endpoint (`PATCH …/subtitles/:id/language`) checks `Action.Update, SubtitleFile`, which `subtitles.manage` did **not** grant (only Create + Delete) — so "Change language" 403'd for everyone except a `manage:all` super-admin.

## Fix
- **Frontend**: gate the subtitles modal on `subtitles.manage` (renamed the input `canGrab` → `canManage`, fed by `auth.hasPermission('subtitles.manage')`). The release-grab buttons elsewhere keep `media.grab`.
- **Backend**: add `can(Action.Update, SubtitleFile)` to the `subtitles.manage` block so relabel works for subtitle managers.

Now front and back agree: **`subtitles.manage`** governs subtitle management (Admin has it by default; grant per-user as needed).

## Verification
- Backend `tsc --noEmit` clean; frontend AOT build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)