### PR TITLE
fix(tmdb-preview): drop duplicate back arrow and show the clearlogo

### DIFF
--- a/client/src/app/core/services/api/metadata.service.ts
+++ b/client/src/app/core/services/api/metadata.service.ts
@@ -25,6 +25,8 @@ export interface MetadataDetails extends MetadataSearchResult {
   imdbId: string | null;
   tvdbId: number | null;
   fanartUrl: string | null;
+  /** Transparent PNG "clearlogo" title treatment when the provider has one. */
+  logoUrl: string | null;
   runtime: number | null;
   releaseDate: string | null;
   inCinemas: string | null;

--- a/client/src/app/features/tmdb-preview/tmdb-preview.html
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.html
@@ -105,15 +105,6 @@
        media-detail) — no inline bleed div here. md+ matches the
        breakpoint media-info-header uses for its own desktop split. -->
   <div class="hidden md:block relative">
-    @if (m.fanartUrl) {
-      @if (!navbar.mobileNavbarVisible()) {
-        <button type="button" (click)="goBack()" class="relative z-10 btn btn-ghost btn gap-1 mb-4 text-base-content/80 hover:text-base-content">
-          <svg lucideChevronLeft class="h-4 w-4"></svg>
-          {{ 'media_detail.back' | translate }}
-        </button>
-      }
-    }
-
     <div
       class="flex gap-6 lg:gap-10 relative z-20 tv:pt-24!"
       [style.padding-top]="!navbar.isHeroPage() || navbar.effectiveSidebarPinned() ? null : navbar.mobileNavbarVisible() ? 'calc(env(safe-area-inset-top, 0px) + 3rem)' : null"

--- a/client/src/app/features/tmdb-preview/tmdb-preview.ts
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.ts
@@ -26,13 +26,13 @@ import { FliksRequestRow, RequestsService } from '../../core/services/api/reques
 import { RequestModalComponent } from './components/request-modal/request-modal.component';
 import { ImportModalComponent } from './components/import-modal/import-modal.component';
 import { MediaType } from '../../core/enums/media-type.enum';
-import { LucideFilm, LucideChevronLeft } from '@lucide/angular';
+import { LucideFilm } from '@lucide/angular';
 import { MobileFanartHeroComponent } from '../../shared/components/mobile-fanart-hero';
 import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
 
 @Component({
   selector: 'app-tmdb-preview',
-  imports: [FormsModule, CurrencyPipe, DatePipe, DecimalPipe, TranslateModule, ResolveUrlPipe, RequestModalComponent, ImportModalComponent, MobileFanartHeroComponent, LucideFilm, LucideChevronLeft],
+  imports: [FormsModule, CurrencyPipe, DatePipe, DecimalPipe, TranslateModule, ResolveUrlPipe, RequestModalComponent, ImportModalComponent, MobileFanartHeroComponent, LucideFilm],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './tmdb-preview.html',
 })
@@ -59,12 +59,6 @@ export class TmdbPreviewComponent implements OnInit, OnDestroy {
     }
     this.backgroundService.setBackgrounds([m.fanartUrl]);
   });
-
-  /** Back to the previous in-app URL — falls back to `/` when no history.
-   *  Same contract as media-detail's back button on desktop. */
-  goBack() {
-    this.navbar.goBack(['/']);
-  }
 
   readonly media = signal<MetadataDetails | null>(null);
   readonly loading = signal(true);
@@ -161,7 +155,7 @@ export class TmdbPreviewComponent implements OnInit, OnDestroy {
     try {
       const details = await this.metadata.getDetails(provider, type, externalId);
       this.media.set(details);
-      this.navbar.enterHeroPage(details.title);
+      this.navbar.enterHeroPage(details.title, details.logoUrl);
       // Only relevant when the Request button could show: admins who can
       // import never see the "déjà demandé" badge anyway.
       if (this.canRequest()) {


### PR DESCRIPTION
## What

On the add/preview page (`/add/movie` and `/add/tv`):

- **Double back arrow (tablet/desktop)** — the page rendered its own "Retour à la liste" button while it also registers as a hero page, so the navbar's hero back chevron *and* the inline button both appeared. Now mirrors media-detail, which relies solely on the navbar hero back. Removed the inline button and its now-unused `goBack()` + chevron import.
- **Clearlogo** — the metadata provider already returns a `logoUrl` (TMDB clearlogo) for both movies and series; the frontend `MetadataDetails` interface just didn't declare it. Declared it and passed it to `enterHeroPage`, so the add page surfaces the title logo like media-detail (falls back to the title text when none exists).

## Scope

Same `TmdbPreviewComponent` serves movie and series routes, so both fixes apply to series too.