### PR TITLE
fix(subtitles): clear the iOS overlay when subtitles are disabled

### DIFF
--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -471,8 +471,10 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
                     item.select(group.options[index], in: group)
                 }
             } else {
-                // Disable subtitles
+                // Disable subtitles. Deselecting alone only stops cue delivery;
+                // the last cue stays frozen in the overlay, so clear it too.
                 item.select(nil, in: group)
+                self?.subtitleOverlay?.render([])
             }
 
             call.resolve()


### PR DESCRIPTION
## Problem

On iOS, disabling subtitles stopped them from updating but left the last line frozen on screen.

`selectSubtitleTrack(null)` calls `item.select(nil, in: group)`, which deselects the legible track so AVPlayer stops feeding cues to our `AVPlayerItemLegibleOutputPushDelegate`. That stop in cue delivery is what looked like "subtitles no longer refreshing" — but the last rendered cue stayed frozen in the custom `SubtitleOverlayView` because nothing cleared it.

## Fix

Render an empty cue list on disable, mirroring the `clearNativeCaption` path already used on PiP exit (which documents the same "re-suppressing alone leaves the last cue frozen" caveat).

## Test

`xcodebuild -workspace App.xcworkspace -scheme App -sdk iphonesimulator` → BUILD SUCCEEDED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)