### PR TITLE
feat(native): refresh data pages when the app resumes from background

### DIFF
--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -17,6 +17,7 @@ import { SelectPickerComponent } from './shared/components/select-picker';
 import { DismissableStackService } from './core/services/dismissable-stack.service';
 import { NavbarService } from './core/services/navbar.service';
 import { PwaAutoUpdateService } from './core/services/pwa-auto-update.service';
+import { AppResumeService } from './core/services/app-resume.service';
 
 @Component({
   selector: 'app-root',
@@ -39,8 +40,10 @@ export class App implements OnInit, OnDestroy {
   private readonly dismissStack = inject(DismissableStackService);
   private readonly navbar = inject(NavbarService);
   private readonly pwaAutoUpdate = inject(PwaAutoUpdateService);
+  private readonly appResume = inject(AppResumeService);
   private backButtonListener?: { remove: () => Promise<void> };
   private resumeListener?: { remove: () => Promise<void> };
+  private pauseListener?: { remove: () => Promise<void> };
   private tvBackKeyListener?: (e: KeyboardEvent) => void;
   private escapeKeyListener?: (e: KeyboardEvent) => void;
 
@@ -87,9 +90,19 @@ export class App implements OnInit, OnDestroy {
         this.backButtonListener = handle;
       });
 
-      // Reconnect SSE when app comes back from background
+      // Stamp the background-entry time so the resume handler can tell a real
+      // away-spell from a momentary interruption (see AppResumeService).
+      CapApp.addListener('pause', () => {
+        this.appResume.markBackgrounded();
+      }).then((handle) => {
+        this.pauseListener = handle;
+      });
+
+      // On return from background: reconnect SSE, and let data pages refresh
+      // themselves if we were away long enough for the backend to have moved on.
       CapApp.addListener('resume', () => {
         this.sse.reconnect();
+        this.appResume.markResumed();
       }).then((handle) => {
         this.resumeListener = handle;
       });
@@ -246,6 +259,7 @@ export class App implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.backButtonListener?.remove();
     this.resumeListener?.remove();
+    this.pauseListener?.remove();
     if (this.tvBackKeyListener) {
       window.removeEventListener('keydown', this.tvBackKeyListener);
     }

--- a/client/src/app/core/services/app-resume.service.ts
+++ b/client/src/app/core/services/app-resume.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
+
+/**
+ * Broadcasts a "the app came back to the foreground after a meaningful spell
+ * in the background" signal so data pages can silently refresh themselves.
+ *
+ * Native only: the root {@link App} component feeds it from Capacitor's
+ * `pause` / `resume` listeners (web/desktop never call it, so `resume$` simply
+ * never emits there). The threshold filters out brief interruptions — Control
+ * Centre, a permission sheet, a glance at the app switcher — where the backend
+ * data can't realistically have changed and a refetch would be wasted work.
+ */
+@Injectable({ providedIn: 'root' })
+export class AppResumeService {
+  /** Minimum time backgrounded before a resume counts as refresh-worthy. */
+  private static readonly MIN_BACKGROUND_MS = 30_000;
+
+  private readonly _resume$ = new Subject<void>();
+  /** Emits once each time the app resumes after ≥ MIN_BACKGROUND_MS away. */
+  readonly resume$: Observable<void> = this._resume$.asObservable();
+
+  private backgroundedAt: number | null = null;
+
+  /** Call when the app goes to the background (Capacitor `pause`). */
+  markBackgrounded(): void {
+    this.backgroundedAt = Date.now();
+  }
+
+  /**
+   * Call when the app returns to the foreground (Capacitor `resume`). Emits
+   * `resume$` iff it had been backgrounded long enough to be worth a refetch.
+   * Clears the marker so a second resume without an intervening pause is a
+   * no-op.
+   */
+  markResumed(): void {
+    const at = this.backgroundedAt;
+    this.backgroundedAt = null;
+    if (at !== null && Date.now() - at >= AppResumeService.MIN_BACKGROUND_MS) {
+      this._resume$.next();
+    }
+  }
+}

--- a/client/src/app/features/activity/queue/queue.ts
+++ b/client/src/app/features/activity/queue/queue.ts
@@ -24,6 +24,8 @@ import {
 } from '../../../core/services/api/media.service';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { ToastService } from '../../../core/services/toast.service';
+import { AppResumeService } from '../../../core/services/app-resume.service';
+import { Subscription } from 'rxjs';
 import {
   LucideRotateCcw,
   LucideLink2,
@@ -51,6 +53,7 @@ export class ActivityQueueComponent implements OnInit, OnDestroy {
   private readonly translate = inject(TranslateService);
   private readonly confirmation = inject(ConfirmationService);
   private readonly toast = inject(ToastService);
+  private readonly appResume = inject(AppResumeService);
 
   readonly queue = signal<QueueItem[]>([]);
   readonly queueLoading = signal(true);
@@ -139,15 +142,22 @@ export class ActivityQueueComponent implements OnInit, OnDestroy {
   });
 
   private intervalId: ReturnType<typeof setInterval> | null = null;
+  private resumeSub?: Subscription;
 
   ngOnInit() {
     this.refreshQueue();
     this.intervalId = setInterval(() => this.refreshQueue(), 10_000);
+    // Native app-resume: pull the queue immediately on foreground rather than
+    // waiting up to 10s for the next interval tick (timers are throttled while
+    // backgrounded). This page has no route reuse, so it's always the visible
+    // one when alive.
+    this.resumeSub = this.appResume.resume$.subscribe(() => this.refreshQueue());
   }
 
   ngOnDestroy() {
     if (this.intervalId !== null) clearInterval(this.intervalId);
     if (this.searchTimer) clearTimeout(this.searchTimer);
+    this.resumeSub?.unsubscribe();
   }
 
   /** Local YYYY-MM-DD key for grouping (added_on is unix seconds). */

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -13,6 +13,7 @@ import { PlayableMediaService } from '../../core/services/playable-media.service
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
 import { FocusMemoryService } from '../../core/services/focus-memory.service';
 import { NavbarService } from '../../core/services/navbar.service';
+import { AppResumeService } from '../../core/services/app-resume.service';
 import { BackgroundService } from '../../core/services/background.service';
 import { DisplaySettingsService } from '../../core/services/display-settings.service';
 import { HomeSettingsService } from '../../core/services/home-settings.service';
@@ -86,6 +87,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly scrollMemory = inject(ScrollMemoryService);
   private readonly focusMemory = inject(FocusMemoryService);
   private readonly navbar = inject(NavbarService);
+  private readonly appResume = inject(AppResumeService);
   private readonly backgroundService = inject(BackgroundService);
   private readonly displaySettings = inject(DisplaySettingsService);
   private readonly home = inject(HomeSettingsService);
@@ -102,6 +104,10 @@ export class HomeComponent implements OnInit, OnDestroy {
   private navStartSub?: Subscription;
   private attachedSub?: Subscription;
   private detachedSub?: Subscription;
+  private resumeSub?: Subscription;
+  /** True while this cached instance is detached (some other route is shown).
+   *  Gates the app-resume refresh so only the visible home refetches. */
+  private detached = false;
   private readonly declineModal = viewChild(RequestDeclineModalComponent);
 
   readonly libraries = signal<LibrarySummary[]>([]);
@@ -250,6 +256,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     const ownKey = this.reuseStrategy.keyFor(this.route.snapshot);
     this.attachedSub = this.reuseStrategy.attached$.subscribe((key) => {
       if (key !== ownKey) return;
+      this.detached = false;
       this.scrollMemory.activate(HomeComponent.SCROLL_KEY);
       // The cached signals stay visible; refresh cache-first for an instant
       // repaint, then force a network round-trip so a return to home reflects
@@ -270,7 +277,18 @@ export class HomeComponent implements OnInit, OnDestroy {
     // next route already claimed scrollMemory in its own ngOnInit, we leave
     // its key alone.
     this.detachedSub = this.reuseStrategy.detached$.subscribe((key) => {
-      if (key === ownKey) this.scrollMemory.deactivateIf(HomeComponent.SCROLL_KEY);
+      if (key !== ownKey) return;
+      this.detached = true;
+      this.scrollMemory.deactivateIf(HomeComponent.SCROLL_KEY);
+    });
+    // Native app-resume: when the app returns to the foreground after a spell
+    // in the background and home is the page on screen, refresh it. Same
+    // two-pass SWR as the reuse-attach path — cached signals stay visible for
+    // an instant repaint, then a forced round-trip pulls fresh data.
+    this.resumeSub = this.appResume.resume$.subscribe(() => {
+      if (this.detached) return;
+      void this.loadAllSections();
+      queueMicrotask(() => void this.loadAllSections({ force: true }));
     });
   }
 
@@ -279,6 +297,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     this.navStartSub?.unsubscribe();
     this.attachedSub?.unsubscribe();
     this.detachedSub?.unsubscribe();
+    this.resumeSub?.unsubscribe();
     this.backgroundService.clear();
   }
 

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -33,6 +33,7 @@ import { FocusMemoryService } from '../../core/services/focus-memory.service';
 import { NavbarService } from '../../core/services/navbar.service';
 import { TvService } from '../../core/services/tv.service';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
+import { AppResumeService } from '../../core/services/app-resume.service';
 import { InfiniteScrollList } from '../../shared/utils/infinite-scroll-list';
 import { LucideSearch, LucideSlidersHorizontal, LucideArrowUp, LucideArrowDown, LucideX, LucideFilm } from '@lucide/angular';
 import { MosaicCardComponent } from '../../shared/components/mosaic-card/mosaic-card';
@@ -91,11 +92,16 @@ export class LibraryComponent implements OnInit, OnDestroy {
   private readonly injector = inject(Injector);
   private readonly translate = inject(TranslateService);
   private readonly reuseStrategy = inject(CachingReuseStrategy);
+  private readonly appResume = inject(AppResumeService);
   private arrivedViaBack = false;
   private navStartSub?: Subscription;
   private attachedSub?: Subscription;
   private detachedSub?: Subscription;
   private queryParamSub?: Subscription;
+  private resumeSub?: Subscription;
+  /** True while this cached instance is detached (some other route is shown).
+   *  Gates the app-resume refresh so only the visible library refetches. */
+  private detached = false;
   /** Set while a state-driven `syncQueryParams` is being applied to the
    *  URL, so the `queryParamMap` subscription that fires right after
    *  can ignore the round-trip instead of re-applying our own write. */
@@ -278,6 +284,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
     const ownKey = this.reuseStrategy.keyFor(this.route.snapshot);
     this.attachedSub = this.reuseStrategy.attached$.subscribe((key) => {
       if (key !== ownKey) return;
+      this.detached = false;
       const lib = this.library();
       if (!lib) return;
       const scrollKey = `library-${lib.id}`;
@@ -299,8 +306,16 @@ export class LibraryComponent implements OnInit, OnDestroy {
     });
     this.detachedSub = this.reuseStrategy.detached$.subscribe((key) => {
       if (key !== ownKey) return;
+      this.detached = true;
       const lib = this.library();
       if (lib) this.scrollMemory.deactivateIf(`library-${lib.id}`);
+    });
+    // Native app-resume: refresh the grid when the app returns to the
+    // foreground after a spell away and this library is the visible page.
+    this.resumeSub = this.appResume.resume$.subscribe(() => {
+      if (this.detached) return;
+      const lib = this.library();
+      if (lib) void this.load(lib.id, true);
     });
 
     // Re-apply state on browser back/forward (same route, queryParams
@@ -340,6 +355,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
     this.attachedSub?.unsubscribe();
     this.detachedSub?.unsubscribe();
     this.queryParamSub?.unsubscribe();
+    this.resumeSub?.unsubscribe();
   }
 
   private applyDefaultFocus(libraryId: number) {

--- a/client/src/app/features/requests/requests.ts
+++ b/client/src/app/features/requests/requests.ts
@@ -5,8 +5,10 @@ import {
   inject,
   computed,
   OnInit,
+  OnDestroy,
   viewChild,
 } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { FormsModule } from '@angular/forms';
 import { DatePipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
@@ -20,6 +22,7 @@ import {
 } from '../../core/services/api/requests.service';
 import { ProfilesService } from '../../core/services/api/profiles.service';
 import { ToastService } from '../../core/services/toast.service';
+import { AppResumeService } from '../../core/services/app-resume.service';
 import { RequestPosterComponent } from './request-poster';
 import { RequestDeclineModalComponent } from './request-decline-modal/request-decline-modal.component';
 import { RequestViewDeclineModalComponent } from './request-view-decline-modal/request-view-decline-modal.component';
@@ -46,13 +49,15 @@ import { LucideEllipsisVertical, LucidePencil, LucideTrash2 } from '@lucide/angu
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './requests.html',
 })
-export class RequestsComponent implements OnInit {
+export class RequestsComponent implements OnInit, OnDestroy {
   private readonly requestsService = inject(RequestsService);
   private readonly profilesApi = inject(ProfilesService);
   private readonly translate = inject(TranslateService);
   private readonly confirmation = inject(ConfirmationService);
   private readonly toast = inject(ToastService);
+  private readonly appResume = inject(AppResumeService);
   readonly auth = inject(AuthService);
+  private resumeSub?: Subscription;
 
   private readonly declineModal = viewChild(RequestDeclineModalComponent);
   private readonly viewDeclineModal = viewChild(RequestViewDeclineModalComponent);
@@ -87,6 +92,9 @@ export class RequestsComponent implements OnInit {
 
   async ngOnInit() {
     this.reload();
+    // Native app-resume: this page only exists while it's the visible route
+    // (no route reuse), so an unguarded reload is always the on-screen one.
+    this.resumeSub = this.appResume.resume$.subscribe(() => this.reload());
     try {
       const [qp, lp] = await Promise.all([
         this.profilesApi.getQualityProfiles(),
@@ -95,6 +103,10 @@ export class RequestsComponent implements OnInit {
       this.qualityProfiles.set(qp.map((p) => ({ id: p.id, name: p.name })));
       this.languageProfiles.set(lp.map((p) => ({ id: p.id, name: p.name })));
     } catch { /* profiles optional */ }
+  }
+
+  ngOnDestroy() {
+    this.resumeSub?.unsubscribe();
   }
 
   onStatusChange(value: string) {

--- a/client/src/app/features/watch-history/watch-history.ts
+++ b/client/src/app/features/watch-history/watch-history.ts
@@ -8,6 +8,7 @@ import { PlaybackState, StreamingApiService, WatchHistoryItem } from '../../core
 import { ConfirmationService } from '../../core/services/confirmation.service';
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
+import { AppResumeService } from '../../core/services/app-resume.service';
 import { PaginationComponent } from '../../shared/components/pagination/pagination';
 import { DropdownMenuComponent } from '../../shared/components/dropdown-menu';
 
@@ -24,10 +25,15 @@ export class WatchHistoryComponent implements OnInit, OnDestroy {
   private readonly route = inject(ActivatedRoute);
   private readonly scrollMemory = inject(ScrollMemoryService);
   private readonly reuseStrategy = inject(CachingReuseStrategy);
+  private readonly appResume = inject(AppResumeService);
   private readonly injector = inject(Injector);
   private static readonly SCROLL_KEY = 'history';
   private attachedSub?: Subscription;
   private detachedSub?: Subscription;
+  private resumeSub?: Subscription;
+  /** True while this cached instance is detached (some other route is shown).
+   *  Gates the app-resume refresh so only the visible history refetches. */
+  private detached = false;
 
   readonly loading = signal(true);
   readonly items = signal<WatchHistoryItem[]>([]);
@@ -49,12 +55,20 @@ export class WatchHistoryComponent implements OnInit, OnDestroy {
     const ownKey = this.reuseStrategy.keyFor(this.route.snapshot);
     this.attachedSub = this.reuseStrategy.attached$.subscribe((key) => {
       if (key !== ownKey) return;
+      this.detached = false;
       this.scrollMemory.activate(WatchHistoryComponent.SCROLL_KEY);
       void this.load(true);
       this.scrollMemory.restoreSticky(WatchHistoryComponent.SCROLL_KEY);
     });
     this.detachedSub = this.reuseStrategy.detached$.subscribe((key) => {
-      if (key === ownKey) this.scrollMemory.deactivateIf(WatchHistoryComponent.SCROLL_KEY);
+      if (key !== ownKey) return;
+      this.detached = true;
+      this.scrollMemory.deactivateIf(WatchHistoryComponent.SCROLL_KEY);
+    });
+    // Native app-resume: silently revalidate the current page when the app
+    // returns to the foreground after a spell away and history is on screen.
+    this.resumeSub = this.appResume.resume$.subscribe(() => {
+      if (!this.detached) void this.load(true);
     });
   }
 
@@ -62,6 +76,7 @@ export class WatchHistoryComponent implements OnInit, OnDestroy {
     this.scrollMemory.deactivate();
     this.attachedSub?.unsubscribe();
     this.detachedSub?.unsubscribe();
+    this.resumeSub?.unsubscribe();
   }
 
   async load(silent = false) {


### PR DESCRIPTION
## What

On native (iOS/Android), when the app returns to the foreground after a real spell in the background, the visible data page silently re-fetches so it reflects changes made elsewhere (new media, watched-status flips, download/queue progress) without a manual reload.

## How

New `AppResumeService` fed by Capacitor `pause`/`resume` (wired in `app.ts` under `isNativePlatform()` only):
- `pause` stamps the background-entry time.
- `resume` emits `resume$` **only if backgrounded ≥ 30s** — filters out brief interruptions (Control Centre, a permission sheet, the app switcher) where backend data can't have changed.

Pages subscribe and refresh on screen:

| Page | Refresh | Visibility guard |
|------|---------|------------------|
| Home | `loadAllSections()` + force (2-pass SWR) | `detached` flag (route reuse) |
| Library | `load(id, true)` | `detached` flag (per cached instance) |
| Watch history | `load(true)` (silent 2-pass SWR) | `detached` flag (route reuse) |
| Requests | `reload()` | unconditional — destroyed when not visible |
| Activity queue | `refreshQueue()` | unconditional — destroyed when not visible |

Reuse-cached pages gate on a `detached` flag (set via the reuse strategy's `attached$`/`detached$`) so only the on-screen instance refetches. All resume subscriptions are torn down in `ngOnDestroy`. Web/desktop are unaffected (listeners never wired there).

## Test

`ng build` → bundle generation complete, no errors. Verified on native by the reporter: resuming after a while lands on a refreshed page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)