### PR TITLE
fix(subtitles): canonical language codes and atomic upgrade replace

### DIFF
--- a/backend/src/migrations/1780400000000-normalize-subtitle-language-codes.ts
+++ b/backend/src/migrations/1780400000000-normalize-subtitle-language-codes.ts
@@ -1,0 +1,50 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Canonicalise stored subtitle language codes to ISO 639-1 so language
+ * matching against a language-profile isoCode can never miss on a variant.
+ * Providers (e.g. OpenSubtitles) return regional forms like `pt-BR`/`zh-CN`
+ * and embedded streams can carry `fr-FR`/`fre`; those were stored verbatim and
+ * never strict-equalled the canonical `pt`/`zh`/`fr`, so the auto-grab kept
+ * re-downloading a language that was already present. New writes are folded by
+ * the SubtitleFile.language column transformer; this backfills existing rows.
+ */
+export class NormalizeSubtitleLanguageCodes1780400000000 implements MigrationInterface {
+  name = 'NormalizeSubtitleLanguageCodes1780400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 1) Fold regional/script subtags to the base subtag and lowercase
+    //    (pt-BR -> pt, fr_FR -> fr, zh-Hans -> zh).
+    await queryRunner.query(
+      `UPDATE "subtitle_files"
+          SET "language" = lower(split_part(split_part("language", '-', 1), '_', 1))
+        WHERE "language" ~ '[-_]'`,
+    );
+
+    // 2) Map ISO 639-2 (B/T) three-letter codes to ISO 639-1, matching
+    //    ISO_639_2_TO_1 in src/common/constants/app-languages.ts. Codes not in
+    //    the table are left as-is (same as the runtime normalizer's fallback).
+    await queryRunner.query(
+      `UPDATE "subtitle_files" sf
+          SET "language" = m.iso1
+         FROM (VALUES
+           ('eng','en'),('fre','fr'),('fra','fr'),('ger','de'),('deu','de'),
+           ('spa','es'),('ita','it'),('por','pt'),('jpn','ja'),('kor','ko'),
+           ('zho','zh'),('chi','zh'),('rus','ru'),('ara','ar'),('nld','nl'),
+           ('dut','nl'),('pol','pl'),('tur','tr'),('swe','sv'),('dan','da'),
+           ('nor','no'),('fin','fi'),('hin','hi'),('ces','cs'),('cze','cs'),
+           ('ron','ro'),('rum','ro'),('hun','hu'),('tha','th'),('vie','vi'),
+           ('heb','he'),('ell','el'),('gre','el'),('ukr','uk'),('bul','bg'),
+           ('hrv','hr'),('srp','sr'),('slv','sl'),('slk','sk'),('slo','sk'),
+           ('cat','ca'),('eus','eu'),('baq','eu'),('glg','gl'),('ind','id'),
+           ('msa','ms'),('may','ms')
+         ) AS m(iso2, iso1)
+        WHERE lower(sf."language") = m.iso2`,
+    );
+  }
+
+  public async down(): Promise<void> {
+    // No rollback: the original regional/639-2 spellings aren't recoverable,
+    // and the canonical codes remain valid language tags.
+  }
+}

--- a/backend/src/modules/scheduler/subtitle-scheduler.service.ts
+++ b/backend/src/modules/scheduler/subtitle-scheduler.service.ts
@@ -41,7 +41,9 @@ export class SubtitleSchedulerService {
     private readonly mediaServers: MediaServersService,
   ) {}
 
-  /** Check every minute if it's time to run search or upgrade */
+  /** Every 6 hours, run the search/upgrade passes whose configured interval
+   *  has elapsed (intervals shorter than the tick are effectively floored to
+   *  6 hours). */
   @Cron(CronExpression.EVERY_6_HOURS)
   async tick(): Promise<void> {
     const now = Date.now();
@@ -245,6 +247,7 @@ export class SubtitleSchedulerService {
     const threshold = Number(
       (await this.settings.get('subtitle_upgrade_threshold')) ?? '90',
     );
+    const opts = await this.resolveSearchOpts();
 
     const lowScoreSubs = await this.subtitleFileRepo
       .createQueryBuilder('sf')
@@ -314,7 +317,17 @@ export class SubtitleSchedulerService {
         const better = candidates.find((r) => r.score > sub.score);
         if (!better) continue;
 
-        await this.subtitlesService.upgradeSubtitle(sub.id, better);
+        const upgraded = await this.subtitlesService.upgradeSubtitle(
+          sub.id,
+          better,
+        );
+
+        if (opts.encodeUtf8) {
+          await this.subtitleSync.reencodeToUtf8(upgraded.id);
+        }
+        if (opts.autoSyncEnabled) {
+          await this.subtitleSync.syncSubtitle(upgraded.id);
+        }
 
         void this.notifications.dispatch('subtitle.upgraded', {
           title: sub.media?.title,

--- a/backend/src/modules/subtitles/embedded-subtitle.service.ts
+++ b/backend/src/modules/subtitles/embedded-subtitle.service.ts
@@ -9,15 +9,7 @@ import { FfprobeService } from './ffprobe.service';
 import { SettingsService } from '../settings/settings.service';
 import { SubtitleProviderType, SubtitleStatus } from '../../common/enums';
 
-import { ISO_639_2_TO_1 } from '../../common/constants/app-languages';
-
-function normalizeLanguage(lang: string): string {
-  const lower = lang.toLowerCase();
-  // Already ISO 639-1 (2 chars)?
-  if (lower.length === 2) return lower;
-  // Map from ISO 639-2
-  return ISO_639_2_TO_1[lower] ?? lower;
-}
+import { normalizeLanguageCode } from '../../common/constants/app-languages';
 
 @Injectable()
 export class EmbeddedSubtitleService {
@@ -84,7 +76,7 @@ export class EmbeddedSubtitleService {
       media: { id: mediaId },
       mediaFile: { id: mediaFileId },
       episode: episodeId ? { id: episodeId } : null,
-      language: normalizeLanguage(stream.language),
+      language: normalizeLanguageCode(stream.language),
       forced: stream.forced,
       hearingImpaired: stream.hearingImpaired,
       providerType: SubtitleProviderType.EMBEDDED,

--- a/backend/src/modules/subtitles/entities/subtitle-file.entity.ts
+++ b/backend/src/modules/subtitles/entities/subtitle-file.entity.ts
@@ -4,6 +4,7 @@ import { SubtitleProviderType, SubtitleStatus } from '../../../common/enums';
 import { Media } from '../../media/entities/media.entity';
 import { MediaFile } from '../../media/entities/media-file.entity';
 import { Episode } from '../../media/entities/episode.entity';
+import { normalizeLanguageCode } from '../../../common/constants/app-languages';
 
 @Entity('subtitle_files')
 export class SubtitleFile extends BaseEntity {
@@ -28,7 +29,19 @@ export class SubtitleFile extends BaseEntity {
   @RelationId((sf: SubtitleFile) => sf.mediaFile)
   mediaFileId: number;
 
-  @Column()
+  /**
+   * Stored canonical: the transformer folds every write to an ISO 639-1 code
+   * (regional/script forms like `pt-BR`→`pt`, ISO 639-2 like `fre`→`fr`) so
+   * language matching against a profile isoCode never misses on a variant.
+   * NB: raw QueryBuilder writes bypass transformers — always persist via the
+   * repository so this invariant holds.
+   */
+  @Column({
+    transformer: {
+      to: (value: string | null | undefined) => normalizeLanguageCode(value),
+      from: (value: string) => value,
+    },
+  })
   language: string;
 
   @Column({ default: false })

--- a/backend/src/modules/subtitles/subtitle-ocr.service.ts
+++ b/backend/src/modules/subtitles/subtitle-ocr.service.ts
@@ -19,6 +19,7 @@ import { cleanSubtitle } from './subtitle-cleaner';
 import { relativePathUnderMediaRoot } from '../../common/utils/media-path.util';
 import { isImageBasedSubtitleCodec } from '../../common/constants/subtitle-codecs';
 import { SubtitleProviderType, SubtitleStatus } from '../../common/enums';
+import { normalizeLanguageCode } from '../../common/constants/app-languages';
 
 const execFileAsync = promisify(execFile);
 
@@ -85,7 +86,7 @@ export class SubtitleOcrService {
     // Caller-chosen language wins (used when the track is untagged 'und' and
     // the language can't be inferred from metadata). It tags the result and
     // drives the OCR engine's language pack.
-    if (language?.trim()) source.language = language.trim().toLowerCase();
+    if (language?.trim()) source.language = normalizeLanguageCode(language);
 
     this.log.log(
       `OCR start — sub #${subtitleId} "${source.media?.title ?? '?'}" [${source.language}] codec=${source.codec} stream=${source.streamIndex}`,

--- a/backend/src/modules/subtitles/subtitles.service.ts
+++ b/backend/src/modules/subtitles/subtitles.service.ts
@@ -30,6 +30,7 @@ import { relativePathUnderMediaRoot } from '../../common/utils/media-path.util';
 import {
   APP_LANGUAGES,
   ISO_639_2_TO_1,
+  normalizeLanguageCode,
 } from '../../common/constants/app-languages';
 import {
   SubtitleScore,
@@ -246,11 +247,12 @@ export class SubtitlesService {
       );
     }
 
+    const lang = normalizeLanguageCode(searchResult.language);
     const langSuffix = searchResult.forced
-      ? `${searchResult.language}.forced`
+      ? `${lang}.forced`
       : searchResult.hearingImpaired
-        ? `${searchResult.language}.hi`
-        : searchResult.language;
+        ? `${lang}.hi`
+        : lang;
 
     const parsed = path.parse(absolutePath);
     let subtitlePath = path.join(
@@ -316,7 +318,7 @@ export class SubtitlesService {
       media: { id: mediaId },
       mediaFile: { id: mediaFileId },
       episode: episodeId ? { id: episodeId } : null,
-      language: searchResult.language,
+      language: lang,
       forced: searchResult.forced,
       hearingImpaired: searchResult.hearingImpaired,
       providerType: provider.type,
@@ -384,9 +386,8 @@ export class SubtitlesService {
   async setLanguage(subtitleId: number, language: string): Promise<SubtitleFile> {
     const sub = await this.repo.findOne({ where: { id: subtitleId } });
     if (!sub) throw new NotFoundException(`Subtitle #${subtitleId} not found`);
-    const lang = (language ?? '').trim().toLowerCase();
-    if (!lang) throw new BadRequestException('Language is required');
-    sub.language = lang;
+    if (!language?.trim()) throw new BadRequestException('Language is required');
+    sub.language = normalizeLanguageCode(language);
     return this.repo.save(sub);
   }
 
@@ -707,7 +708,25 @@ export class SubtitlesService {
     if (existing.providerType === SubtitleProviderType.EMBEDDED) {
       throw new BadRequestException('Cannot upgrade an embedded subtitle');
     }
+    if (existing.providerType === SubtitleProviderType.OCR) {
+      throw new BadRequestException('Cannot upgrade an OCR subtitle');
+    }
 
+    // Download the replacement BEFORE removing the existing file/row, so a
+    // failed download leaves the working subtitle untouched (atomic swap).
+    const updated = await this.downloadSubtitle(
+      existing.mediaId,
+      existing.mediaFileId,
+      existing.episodeId,
+      newResult,
+    );
+    updated.status = SubtitleStatus.UPGRADED;
+    // Carry over attributes that should survive a file replacement.
+    updated.locked = existing.locked;
+    updated.tags = existing.tags ?? [];
+    await this.repo.save(updated);
+
+    // Replacement is persisted — now drop the old file and row.
     const oldAbs = await this.resolveSubtitleAbsolute(existing);
     if (oldAbs) {
       try {
@@ -716,16 +735,6 @@ export class SubtitlesService {
         this.logger.warn(`Could not delete old file: ${oldAbs}`);
       }
     }
-
-    const updated = await this.downloadSubtitle(
-      existing.mediaId,
-      existing.mediaFileId,
-      existing.episodeId,
-      newResult,
-    );
-    updated.status = SubtitleStatus.UPGRADED;
-    await this.repo.save(updated);
-
     await this.repo.remove(existing);
     return updated;
   }


### PR DESCRIPTION
Two reliability fixes in the subtitle subsystem.

## 1. Language codes re-downloaded despite being present

Stored codes could be regional/variant forms — OpenSubtitles returns `pt-BR`/`zh-CN`, embedded streams carry `fr-FR`/`fre` — while language profiles use canonical ISO 639-1 (`pt`/`zh`/`fr`). The auto-grab compared them with strict `===`, so an already-present language never matched and was **re-downloaded every pass**.

**Structural fix (normalize on write), not per-site patching:**
- A **column transformer** on `SubtitleFile.language` folds every persisted value to ISO 639-1.
- A **backfill migration** canonicalizes existing rows (`pt-BR`→`pt`, `fre`→`fr`, …).
- The few in-memory pre-save spots (embedded detection, OCR language, download filename suffix) use the shared normalizer.

The stored column is now always canonical, so the existing comparisons — and the client modal that reads the served codes — just work. Invariant documented on the entity: persist via the repository (raw QueryBuilder writes bypass transformers).

## 2. Upgrade replacement bugs

- **Non-atomic replace (data loss):** the old file was deleted *before* the replacement download, so a failed download lost the working subtitle and orphaned the row. Now **downloads first, removes the old file/row only on success**.
- **Skipped post-processing:** the upgrade path didn't re-encode to UTF-8 or auto-sync (which the missing/import paths do by default), leaving an upgraded sub raw/un-synced. Now applies the **same re-encode + sync**.
- **Guards:** OCR subs are refused like embedded; `locked` and `tags` are **preserved** across the replacement (the manual upgrade endpoint no longer silently unlocks a sub).

## Notes (verified, left unchanged)
The core upgrade flow (score < threshold → search → replace if strictly better) was confirmed correct: consistent 0-100 score scale, descending-sorted candidates (best is picked), embedded/locked/hash-matched correctly excluded.

## Verification
Backend typechecks clean (`tsc --noEmit`). Migration auto-runs in prod (`migrationsRun`).