### PR TITLE
fix(bottom-sheet): animate slide-down close for every dismiss path

### DIFF
--- a/client/src/app/shared/components/bottom-sheet.ts
+++ b/client/src/app/shared/components/bottom-sheet.ts
@@ -7,6 +7,7 @@ import {
   ElementRef,
   viewChild,
   effect,
+  untracked,
   DestroyRef,
   inject,
 } from '@angular/core';
@@ -18,22 +19,28 @@ import { TvService } from '../../core/services/tv.service';
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    @if (open()) {
+    @if (visible()) {
       <!-- Backdrop — CSS @starting-style handles the fade-in declaratively
            (browser interpolates from opacity 0 on element creation), so the
            component does not need a JS-side toggling pattern. -->
       <div
-        [class]="'bottom-sheet-backdrop fixed inset-0 z-[100] transition-opacity duration-200 ' + (showBackdrop() ? 'bg-black/60' : '')"
+        [class]="
+          'bottom-sheet-backdrop fixed inset-0 z-[100] transition-opacity duration-150 ' +
+          (showBackdrop() ? 'bg-black/60' : '')
+        "
         [class.opacity-0]="dismissing()"
         (click)="dismiss()"
       ></div>
       <!-- Sheet -->
       <div
         #sheet
-        [class]="'fixed bottom-0 z-[101] bg-neutral/95 backdrop-blur-xl rounded-t-2xl shadow-2xl max-h-[70vh] overflow-y-auto portrait:left-1 portrait:right-1 landscape:right-2 landscape:w-[28rem] landscape:max-w-md landscape:rounded-2xl landscape:bottom-1 ' + (rightAligned() ? 'landscape:left-auto' : 'landscape:left-2 landscape:mx-auto')"
+        [class]="
+          'fixed bottom-0 z-[101] bg-neutral/95 backdrop-blur-xl rounded-t-2xl shadow-2xl max-h-[70vh] overflow-y-auto portrait:left-1 portrait:right-1 landscape:right-2 landscape:w-[28rem] landscape:max-w-md landscape:rounded-2xl landscape:bottom-1 ' +
+          (rightAligned() ? 'landscape:left-auto' : 'landscape:left-2 landscape:mx-auto')
+        "
         [class.animate-slide-up]="!dismissing()"
         [style.transform]="sheetTransform()"
-        [style.transition]="dragging() ? 'none' : 'transform 0.25s ease-out'"
+        [style.transition]="dragging() ? 'none' : 'transform 0.18s ease-out'"
         [style.padding-bottom]="'env(safe-area-inset-bottom)'"
         (touchstart)="onTouchStart($event)"
         (touchmove)="onTouchMove($event)"
@@ -59,6 +66,10 @@ export class BottomSheetComponent {
   readonly dragging = signal(false);
   readonly dismissing = signal(false);
   readonly dragOffset = signal(0);
+  /** Drives the DOM `@if`, decoupled from `open` so the sheet can play its
+   *  slide-down exit before it is removed. */
+  readonly visible = signal(false);
+  private exitTimer: ReturnType<typeof setTimeout> | null = null;
 
   private readonly dismissStack = inject(DismissableStackService);
   private readonly tv = inject(TvService);
@@ -88,9 +99,7 @@ export class BottomSheetComponent {
     if (!sheetEl) return;
     const target = e.target as HTMLElement | null;
     if (!target || sheetEl.contains(target)) return;
-    const first = sheetEl.querySelector<HTMLElement>(
-      BottomSheetComponent.FOCUSABLE_SELECTOR,
-    );
+    const first = sheetEl.querySelector<HTMLElement>(BottomSheetComponent.FOCUSABLE_SELECTOR);
     first?.focus({ preventScroll: true });
   };
 
@@ -98,102 +107,83 @@ export class BottomSheetComponent {
     const destroyRef = inject(DestroyRef);
 
     effect(() => {
-      if (this.open()) {
-        this.dismissing.set(false);
-        this.dragOffset.set(0);
-        // Lock the page scroll behind the sheet. Save+restore the previous
-        // inline overflow so we don't trample a parent component's setting.
-        // On TV body has a scale transform that makes html the scrolling
-        // element — lock both. On other form factors body is the scroller
-        // and locking html on tablet landscape (pinned drawer) shifts the
-        // sidebar upward.
-        if (typeof document !== 'undefined') {
-          this.prevBodyOverflow = document.body.style.overflow;
-          document.body.style.overflow = 'hidden';
-          if (this.tv.isTv()) {
-            this.prevHtmlOverflow = document.documentElement.style.overflow;
-            document.documentElement.style.overflow = 'hidden';
+      const isOpen = this.open();
+      // `open()` is the only intended dependency; the body reads and writes
+      // several other signals, so run it untracked to avoid re-entrancy.
+      untracked(() => {
+        if (isOpen) {
+          if (this.exitTimer) {
+            clearTimeout(this.exitTimer);
+            this.exitTimer = null;
           }
-        }
-        // Register on the dismiss stack so the hardware/gesture back closes
-        // this sheet before falling through to the route-level back handler.
-        if (!this.registered) {
-          this.dismissStack.push(this.dismissCallback);
-          this.registered = true;
-        }
-        if (this.tv.isTv() && !this.focusTrapActive && typeof document !== 'undefined') {
-          // Snapshot the trigger before the trap can bounce focus inside.
-          // Restored on close so the user lands back on the element they
-          // pressed (e.g. a <select appTvSelect>) — not on the option they
-          // happened to highlight last in the sheet.
-          this.prevFocused = document.activeElement as HTMLElement | null;
-          document.addEventListener('focusin', this.onFocusIn);
-          this.focusTrapActive = true;
-          // Move focus to the first item inside the sheet on open. Without
-          // this, the D-pad still operates on the trigger row (or the
-          // previously-focused tile in the route), so up/down moves to a
-          // background element and the focus-trap fires AFTER the user
-          // has already left the sheet visually — feels unresponsive.
-          // queueMicrotask waits until @if has materialised the sheet
-          // content; rAF would defer one extra frame and let the WebView
-          // paint the focus halo on the wrong element first.
-          queueMicrotask(() => {
-            if (!this.open()) return;
-            const sheetEl = this.sheet()?.nativeElement;
-            const first = sheetEl?.querySelector<HTMLElement>(
-              BottomSheetComponent.FOCUSABLE_SELECTOR,
-            );
-            first?.focus({ preventScroll: true });
-          });
-        }
-      } else {
-        if (this.prevBodyOverflow !== null) {
+          this.visible.set(true);
+          this.dismissing.set(false);
+          this.dragOffset.set(0);
+          // Lock the page scroll behind the sheet. Save+restore the previous
+          // inline overflow so we don't trample a parent component's setting.
+          // On TV body has a scale transform that makes html the scrolling
+          // element — lock both. On other form factors body is the scroller
+          // and locking html on tablet landscape (pinned drawer) shifts the
+          // sidebar upward.
           if (typeof document !== 'undefined') {
-            document.body.style.overflow = this.prevBodyOverflow;
-            document.documentElement.style.overflow = this.prevHtmlOverflow ?? '';
+            this.prevBodyOverflow = document.body.style.overflow;
+            document.body.style.overflow = 'hidden';
+            if (this.tv.isTv()) {
+              this.prevHtmlOverflow = document.documentElement.style.overflow;
+              document.documentElement.style.overflow = 'hidden';
+            }
           }
-          this.prevBodyOverflow = null;
-          this.prevHtmlOverflow = null;
-        }
-        if (this.registered) {
-          this.dismissStack.remove(this.dismissCallback);
-          this.registered = false;
-        }
-        if (this.focusTrapActive && typeof document !== 'undefined') {
-          document.removeEventListener('focusin', this.onFocusIn);
-          this.focusTrapActive = false;
-          if (this.prevFocused && document.contains(this.prevFocused)) {
-            this.prevFocused.focus({ preventScroll: true });
+          // Register on the dismiss stack so the hardware/gesture back closes
+          // this sheet before falling through to the route-level back handler.
+          if (!this.registered) {
+            this.dismissStack.push(this.dismissCallback);
+            this.registered = true;
           }
-          this.prevFocused = null;
+          if (this.tv.isTv() && !this.focusTrapActive && typeof document !== 'undefined') {
+            // Snapshot the trigger before the trap can bounce focus inside.
+            // Restored on close so the user lands back on the element they
+            // pressed (e.g. a <select appTvSelect>) — not on the option they
+            // happened to highlight last in the sheet.
+            this.prevFocused = document.activeElement as HTMLElement | null;
+            document.addEventListener('focusin', this.onFocusIn);
+            this.focusTrapActive = true;
+            // Move focus to the first item inside the sheet on open. Without
+            // this, the D-pad still operates on the trigger row (or the
+            // previously-focused tile in the route), so up/down moves to a
+            // background element and the focus-trap fires AFTER the user
+            // has already left the sheet visually — feels unresponsive.
+            // queueMicrotask waits until @if has materialised the sheet
+            // content; rAF would defer one extra frame and let the WebView
+            // paint the focus halo on the wrong element first.
+            queueMicrotask(() => {
+              if (!this.open()) return;
+              const sheetEl = this.sheet()?.nativeElement;
+              const first = sheetEl?.querySelector<HTMLElement>(
+                BottomSheetComponent.FOCUSABLE_SELECTOR,
+              );
+              first?.focus({ preventScroll: true });
+            });
+          }
+        } else {
+          // Animate the slide-down exit instead of an instant teardown, whatever
+          // caused the close (item select flipping `open`, or backdrop/drag/back
+          // via dismiss()).
+          this.beginClose();
         }
-      }
+      });
     });
 
-    // Belt: ensure scroll is unlocked + stack is clean even if the component
-    // is destroyed while still open (route change, navigation, etc.).
+    // Belt: ensure scroll is unlocked, the stack is clean, the exit timer is
+    // cleared, and (TV) focus is restored even if the component is destroyed
+    // while still open — e.g. a route change, or a parent `@if` tearing the
+    // sheet down (PopoverMenu hardcodes `[open]="true"`, so the effect's close
+    // branch never runs for that path).
     destroyRef.onDestroy(() => {
-      if (this.prevBodyOverflow !== null && typeof document !== 'undefined') {
-        document.body.style.overflow = this.prevBodyOverflow;
-        document.documentElement.style.overflow = this.prevHtmlOverflow ?? '';
-        this.prevBodyOverflow = null;
-        this.prevHtmlOverflow = null;
+      if (this.exitTimer) {
+        clearTimeout(this.exitTimer);
+        this.exitTimer = null;
       }
-      if (this.registered) {
-        this.dismissStack.remove(this.dismissCallback);
-        this.registered = false;
-      }
-      if (this.focusTrapActive && typeof document !== 'undefined') {
-        document.removeEventListener('focusin', this.onFocusIn);
-        this.focusTrapActive = false;
-      }
-      // PopoverMenu hardcodes `[open]="true"` and tears the sheet down via
-      // a parent `@if`, so the close branch of the effect above never runs
-      // for that path. Restore focus here as well to cover both lifecycles.
-      if (this.prevFocused && typeof document !== 'undefined' && document.contains(this.prevFocused)) {
-        this.prevFocused.focus({ preventScroll: true });
-      }
-      this.prevFocused = null;
+      this.releaseOpenState();
     });
   }
 
@@ -240,8 +230,48 @@ export class BottomSheetComponent {
   }
 
   dismiss() {
+    this.beginClose();
+  }
+
+  /** Slide the sheet down, then remove it from the DOM and notify the parent.
+   *  Idempotent — a close already in flight is not restarted. Every close path
+   *  funnels through here so selecting an item animates out exactly like a
+   *  backdrop tap or a drag-down. */
+  private beginClose() {
+    if (this.exitTimer || !this.visible()) return;
+    this.releaseOpenState();
     this.dismissing.set(true);
     this.dragOffset.set(0);
-    setTimeout(() => this.closed.emit(), 250);
+    this.exitTimer = setTimeout(() => {
+      this.exitTimer = null;
+      this.visible.set(false);
+      this.dismissing.set(false);
+      this.closed.emit();
+    }, 180);
+  }
+
+  /** Undo the open-time side effects: restore page scroll, leave the dismiss
+   *  stack, and (TV) drop the focus trap and restore the trigger's focus. */
+  private releaseOpenState() {
+    if (this.prevBodyOverflow !== null) {
+      if (typeof document !== 'undefined') {
+        document.body.style.overflow = this.prevBodyOverflow;
+        document.documentElement.style.overflow = this.prevHtmlOverflow ?? '';
+      }
+      this.prevBodyOverflow = null;
+      this.prevHtmlOverflow = null;
+    }
+    if (this.registered) {
+      this.dismissStack.remove(this.dismissCallback);
+      this.registered = false;
+    }
+    if (this.focusTrapActive && typeof document !== 'undefined') {
+      document.removeEventListener('focusin', this.onFocusIn);
+      this.focusTrapActive = false;
+      if (this.prevFocused && document.contains(this.prevFocused)) {
+        this.prevFocused.focus({ preventScroll: true });
+      }
+      this.prevFocused = null;
+    }
   }
 }

--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
@@ -1,77 +1,82 @@
-@if (service.open()) {
-  @if (useDropdown()) {
-    <!-- TV / desktop: anchored dropdown — DaisyUI menu styling -->
-    <div
-      class="fixed inset-0 z-[100]"
-      (click)="onClose()"
-    ></div>
-    <div
-      #menu
-      class="card-actions-menu fixed z-[101] bg-base-200 rounded-box shadow-xl overflow-hidden"
-      [style.top.px]="position()?.top"
-      [style.left.px]="position()?.left"
-      [style.width.px]="position()?.width"
-      (keydown)="onMenuKey($event)"
-    >
-      @if (title()) {
-        <div class="px-4 pt-3 pb-1 text-xs uppercase tracking-wider text-base-content/60 truncate">
-          {{ title() }}
-        </div>
-      }
-      <ul role="menu" class="menu p-2 gap-0.5 w-full">
-        @for (a of actions(); track a; let i = $index) {
-          <li [class.disabled]="a.disabled">
-            <button
-              type="button"
-              role="menuitem"
-              data-action
-              [disabled]="a.disabled"
-              class="flex items-center gap-3"
-              [class.text-error]="a.tone === 'danger'"
-              [class.menu-active]="i === activeIndex()"
-              (click)="trigger(a)"
-            >
-              @switch (a.icon) {
-                @case ('play') { <svg lucidePlay class="h-4 w-4 shrink-0 opacity-70"></svg> }
-                @case ('external-link') { <svg lucideExternalLink class="h-4 w-4 shrink-0 opacity-70"></svg> }
-                @case ('eye') { <svg lucideEye class="h-4 w-4 shrink-0 opacity-70"></svg> }
-                @case ('eye-off') { <svg lucideEyeOff class="h-4 w-4 shrink-0 opacity-70"></svg> }
-                @case ('trash-2') { <svg lucideTrash2 class="h-4 w-4 shrink-0 opacity-70"></svg> }
-              }
-              <span class="flex-1 truncate text-left">{{ a.labelKey ? (a.labelKey | translate) : a.label }}</span>
-            </button>
-          </li>
-        }
-      </ul>
-    </div>
-  } @else {
-    <!-- Mobile / TV: bottom sheet -->
-    <app-bottom-sheet [open]="true" (closed)="onClose()">
-      <div #sheet data-tv-modal class="px-2 pb-2">
-        @if (title()) {
-          <div class="px-4 py-2 text-white/60 text-sm font-medium truncate">{{ title() }}</div>
-        }
-        @for (a of actions(); track a) {
+@if (service.open() && useDropdown()) {
+  <!-- TV / desktop: anchored dropdown — DaisyUI menu styling -->
+  <div
+    class="fixed inset-0 z-[100]"
+    (click)="onClose()"
+  ></div>
+  <div
+    #menu
+    class="card-actions-menu fixed z-[101] bg-base-200 rounded-box shadow-xl overflow-hidden"
+    [style.top.px]="position()?.top"
+    [style.left.px]="position()?.left"
+    [style.width.px]="position()?.width"
+    (keydown)="onMenuKey($event)"
+  >
+    @if (title()) {
+      <div class="px-4 pt-3 pb-1 text-xs uppercase tracking-wider text-base-content/60 truncate">
+        {{ title() }}
+      </div>
+    }
+    <ul role="menu" class="menu p-2 gap-0.5 w-full">
+      @for (a of actions(); track a; let i = $index) {
+        <li [class.disabled]="a.disabled">
           <button
             type="button"
+            role="menuitem"
+            data-action
             [disabled]="a.disabled"
-            class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base rounded-lg active:bg-white/10"
-            [class.text-white]="a.tone !== 'danger'"
+            class="flex items-center gap-3"
             [class.text-error]="a.tone === 'danger'"
-            [class.opacity-40]="a.disabled"
+            [class.menu-active]="i === activeIndex()"
             (click)="trigger(a)"
           >
             @switch (a.icon) {
-              @case ('play') { <svg lucidePlay class="h-5 w-5 shrink-0 opacity-80"></svg> }
-              @case ('external-link') { <svg lucideExternalLink class="h-5 w-5 shrink-0 opacity-80"></svg> }
-              @case ('eye') { <svg lucideEye class="h-5 w-5 shrink-0 opacity-80"></svg> }
-              @case ('eye-off') { <svg lucideEyeOff class="h-5 w-5 shrink-0 opacity-80"></svg> }
-              @case ('trash-2') { <svg lucideTrash2 class="h-5 w-5 shrink-0 opacity-80"></svg> }
+              @case ('play') { <svg lucidePlay class="h-4 w-4 shrink-0 opacity-70"></svg> }
+              @case ('external-link') { <svg lucideExternalLink class="h-4 w-4 shrink-0 opacity-70"></svg> }
+              @case ('eye') { <svg lucideEye class="h-4 w-4 shrink-0 opacity-70"></svg> }
+              @case ('eye-off') { <svg lucideEyeOff class="h-4 w-4 shrink-0 opacity-70"></svg> }
+              @case ('trash-2') { <svg lucideTrash2 class="h-4 w-4 shrink-0 opacity-70"></svg> }
             }
-            <span class="flex-1">{{ a.labelKey ? (a.labelKey | translate) : a.label }}</span>
+            <span class="flex-1 truncate text-left">{{ a.labelKey ? (a.labelKey | translate) : a.label }}</span>
           </button>
-        }
-      </div>
-    </app-bottom-sheet>
-  }
+        </li>
+      }
+    </ul>
+  </div>
+}
+@if (!useDropdown()) {
+  <!-- Mobile / TV: bottom sheet. Kept mounted (driven by [open], not gated
+       behind @if(service.open())) so service.close() plays the sheet's
+       slide-down exit. The sheet gates <ng-content> behind its own
+       @if(visible()), so the projected list is only instantiated while the
+       sheet is on screen. The list survives the slide-out because close()
+       keeps actions() populated until clear() runs once closed; actions()
+       falls back to [] so the @for/@if below stay null-safe. -->
+  <app-bottom-sheet [open]="service.open()" (closed)="onClose()">
+    <div #sheet data-tv-modal class="px-2 pb-2">
+      @if (title()) {
+        <div class="px-4 py-2 text-white/60 text-sm font-medium truncate">{{ title() }}</div>
+      }
+      @for (a of actions(); track a) {
+        <button
+          type="button"
+          [disabled]="a.disabled"
+          class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base rounded-lg active:bg-white/10"
+          [class.text-white]="a.tone !== 'danger'"
+          [class.text-error]="a.tone === 'danger'"
+          [class.opacity-40]="a.disabled"
+          (click)="trigger(a)"
+        >
+          @switch (a.icon) {
+            @case ('play') { <svg lucidePlay class="h-5 w-5 shrink-0 opacity-80"></svg> }
+            @case ('external-link') { <svg lucideExternalLink class="h-5 w-5 shrink-0 opacity-80"></svg> }
+            @case ('eye') { <svg lucideEye class="h-5 w-5 shrink-0 opacity-80"></svg> }
+            @case ('eye-off') { <svg lucideEyeOff class="h-5 w-5 shrink-0 opacity-80"></svg> }
+            @case ('trash-2') { <svg lucideTrash2 class="h-5 w-5 shrink-0 opacity-80"></svg> }
+          }
+          <span class="flex-1">{{ a.labelKey ? (a.labelKey | translate) : a.label }}</span>
+        </button>
+      }
+    </div>
+  </app-bottom-sheet>
 }

--- a/client/src/app/shared/components/dropdown-menu.ts
+++ b/client/src/app/shared/components/dropdown-menu.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   ElementRef,
   computed,
   effect,
@@ -94,6 +95,8 @@ export class DropdownMenuComponent {
   private readonly sheet = viewChild('sheet', { read: ElementRef });
   private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
   private wasOpen = false;
+  /** The sheet host once it's been moved under <html> (see below). */
+  private reparentedSheet: HTMLElement | null = null;
 
   constructor() {
     if (typeof document === 'undefined') return;
@@ -101,9 +104,17 @@ export class DropdownMenuComponent {
       const ref = this.sheet();
       if (!ref || this.useDropdown()) return;
       queueMicrotask(() => {
+        this.reparentedSheet = ref.nativeElement;
         document.documentElement.appendChild(ref.nativeElement);
       });
     });
+    // The sheet host is moved under <html> to escape the drawer's stacking
+    // context, so Angular no longer owns its DOM position and won't remove it
+    // when this component is destroyed. Detach it ourselves — otherwise a
+    // sheet torn down mid-close (its slide-down exit still running, e.g. an
+    // item tap that navigates away) orphans its full-screen backdrop, which
+    // keeps blocking clicks across the app.
+    inject(DestroyRef).onDestroy(() => this.reparentedSheet?.remove());
     // Sheet branch (touch / TV) doesn't go through DropdownToggleDirective,
     // so refocus the projected trigger ourselves on close — keeps Enter /
     // tap parity with the dropdown branch (re-activating re-opens).

--- a/client/src/app/shared/components/popover-menu.ts
+++ b/client/src/app/shared/components/popover-menu.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   computed,
   effect,
   ElementRef,
@@ -63,8 +64,13 @@ import { DismissableStackService } from '../../core/services/dismissable-stack.s
       >
         <ng-container *ngTemplateOutlet="content"></ng-container>
       </div>
-    } @else if (open() && !useDropdown()) {
-      <app-bottom-sheet [open]="true" (closed)="close()">
+    }
+    @if (!useDropdown()) {
+      <!-- Kept mounted so [open]->false plays the sheet's slide-down exit.
+           The sheet gates <ng-content> behind its own @if(visible()), so the
+           projected content (and its bindings) is only instantiated while the
+           sheet is on screen — safe to leave the outlet unguarded here. -->
+      <app-bottom-sheet [open]="open()" (closed)="close()">
         <div data-tv-modal class="px-2 pb-2">
           <ng-container *ngTemplateOutlet="content"></ng-container>
         </div>
@@ -90,8 +96,20 @@ export class PopoverMenuComponent {
    *  `position()` computed re-reads the anchor's `getBoundingClientRect`
    *  and the `position: fixed` box stays glued to the trigger. */
   private readonly viewportTick = signal(0);
+  /** True once the host has been moved out of its Angular-owned position. */
+  private reparented = false;
 
   constructor() {
+    // The host is moved under <html>/the open dialog's top-layer on open (see
+    // the open effect below), so Angular no longer owns its DOM position and
+    // won't remove the relocated node on destroy. Detach it ourselves —
+    // otherwise a popover torn down mid-close (its sheet's slide-down exit
+    // still running) orphans the sheet's full-screen backdrop, which keeps
+    // blocking clicks across the app.
+    inject(DestroyRef).onDestroy(() => {
+      if (this.reparented) this.host.nativeElement.remove();
+    });
+
     // Focus the first focusable inside the menu on every open. autofocus
     // is unreliable on Capacitor's Android WebView for dynamically added
     // content, so we do it programmatically.
@@ -119,6 +137,7 @@ export class PopoverMenuComponent {
         const target = openDialog ?? document.documentElement;
         if (this.host.nativeElement.parentElement !== target) {
           target.appendChild(this.host.nativeElement);
+          this.reparented = true;
         }
       }
       queueMicrotask(() => {

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -136,9 +136,8 @@
        via showModal() — otherwise the modal would paint over it
        regardless of z-index. `position: fixed` on the popover-menu's
        content escapes modal-box's overflow on its own. -->
-  @if (actionsSub()) {
     <app-popover-menu
-      [open]="true"
+      [open]="actionsMenuOpen()"
       [anchor]="actionsAnchor()"
       placement="top-end"
       (closed)="closeSubActions()"
@@ -209,7 +208,6 @@
         </button>
       }
     </app-popover-menu>
-  }
 
   <form method="dialog" class="modal-backdrop">
     <button>close</button>

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -129,6 +129,11 @@ export class SubtitlesModalComponent {
    *  resolves the active row's data inside the popover template. */
   readonly actionsOpenForId = signal<number | null>(null);
   readonly actionsAnchor = signal<HTMLElement | null>(null);
+  /** Drives the actions popover's `[open]`. Kept separate from
+   *  `actionsOpenForId` so the content stays rendered through the slide-down
+   *  exit — the row id (content source) is cleared only once `(closed)` fires
+   *  after the animation, so the menu's buttons don't flip mid-slide. */
+  readonly actionsMenuOpen = signal(false);
   readonly actionsSub = computed(() => {
     const id = this.actionsOpenForId();
     return id == null ? null : this.subtitles().find((s) => s.id === id) ?? null;
@@ -152,15 +157,21 @@ export class SubtitlesModalComponent {
   protected openSubActions(sub: SubtitleFileRow, anchor: HTMLElement) {
     this.actionsAnchor.set(anchor);
     this.actionsOpenForId.set(sub.id);
+    this.actionsMenuOpen.set(true);
   }
+  /** `(closed)` handler — fires after the slide-down completes, so the row's
+   *  data is safe to drop here. */
   protected closeSubActions() {
+    this.actionsMenuOpen.set(false);
     this.actionsOpenForId.set(null);
     this.actionsAnchor.set(null);
   }
   protected runSubAction(action: (sub: SubtitleFileRow) => void): void {
     const sub = this.actionsSub();
     if (!sub) return;
-    this.closeSubActions();
+    // Start the close animation but keep the row's data until `(closed)` clears
+    // it, so the menu's buttons don't flip while the sheet slides out.
+    this.actionsMenuOpen.set(false);
     action(sub);
   }
   readonly subSearchLang = signal('en');

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -188,7 +188,7 @@ body.native.hero-page {
 }
 
 .animate-slide-up {
-  animation: slide-up 0.25s ease-out;
+  animation: slide-up 0.18s ease-out;
 }
 
 /* Indeterminate seekbar loading sweep: a full-width gradient strip whose


### PR DESCRIPTION
Selecting a value in a mobile bottom-sheet closed it **abruptly** — the sheet was gated behind `@if(open())` and torn out of the DOM the instant a parent flipped `open`.

## What

- **Animated slide-down on every close** — decouple an internal `visible()` signal from the `[open]` input so the component plays its own slide-down exit on *any* dismiss path: item select, backdrop tap, drag-down, or back. Tightened to **0.18s** (sheet + backdrop), with the backdrop fade shortened to match the removal timer.
- **Kept-mounted consumers** — `popover-menu`, `card-actions-panel` and `subtitles-modal` previously destroyed their sheet on close (gated by an `@if`); they're now kept mounted and driven by `[open]` so selecting a value animates out too.
- **Reparented-backdrop leak fix** (regression this exposed) — `dropdown-menu` and `popover-menu` move their host under `<html>` to escape the drawer's stacking context, and Angular can't remove a relocated node on destroy. With the close now spanning 180ms, navigating away mid-slide (e.g. tapping an admin link in the user menu, which leaves the layout route → destroys the navbar) orphaned the host **with its full-screen backdrop still inside**, blocking all clicks. Both now detach the reparented node on destroy.

## Verification
Production AOT build passes. Confirmed on-device: slide-down on select for the player/dropdown sheets, and the admin-navigation backdrop leak is gone.