### PR TITLE
fix(activity): use shared pagination in the subtitles tab

### DIFF
--- a/client/src/app/features/activity/subtitles/subtitles.html
+++ b/client/src/app/features/activity/subtitles/subtitles.html
@@ -73,16 +73,11 @@
   </div>
 
   @if (subHistoryTotalPages > 1) {
-    <div class="flex justify-center mt-4">
-      <div class="join">
-        @for (p of [].constructor(subHistoryTotalPages); track $index) {
-          <button
-            class="join-item btn btn-sm"
-            [class.btn-active]="subHistoryPage() === $index + 1"
-            (click)="loadSubHistory($index + 1)"
-          >{{ $index + 1 }}</button>
-        }
-      </div>
-    </div>
+    <app-pagination
+      class="pt-1"
+      [current]="subHistoryPage()"
+      [total]="subHistoryTotalPages"
+      (pageChange)="loadSubHistory($event)"
+    />
   }
 }

--- a/client/src/app/features/activity/subtitles/subtitles.ts
+++ b/client/src/app/features/activity/subtitles/subtitles.ts
@@ -13,10 +13,11 @@ import {
   SubtitlesApiService,
   SubtitleHistoryEntry,
 } from '../../../core/services/api/subtitles-api.service';
+import { PaginationComponent } from '../../../shared/components/pagination/pagination';
 
 @Component({
   selector: 'app-activity-subtitles',
-  imports: [TranslateModule, DatePipe, NgClass, RouterLink, FormsModule],
+  imports: [TranslateModule, DatePipe, NgClass, RouterLink, FormsModule, PaginationComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './subtitles.html',
 })


### PR DESCRIPTION
The subtitles activity tab hand-rolled its table pagination as a `join`/button `@for` loop instead of the shared `<app-pagination>` component every other table uses (the sibling **queue** tab, status, blocklist, watch-history, …).

Swapped to `app-pagination`, wiring `[current]`/`[total]` to `subHistoryPage()`/`subHistoryTotalPages` and `(pageChange)` to `loadSubHistory` — for consistent paging UX (prev/next, sibling pages, compact mode) instead of one button per page.

AOT build passes.