### PR TITLE
feat(streaming): expose full quality ladder, gate direct play on quality

### DIFF
--- a/backend/src/common/filters/client-abort-exception.filter.ts
+++ b/backend/src/common/filters/client-abort-exception.filter.ts
@@ -20,22 +20,41 @@ export class ClientAbortExceptionFilter extends BaseExceptionFilter {
   private readonly logger = new Logger(ClientAbortExceptionFilter.name);
 
   catch(exception: unknown, host: ArgumentsHost): void {
-    if (host.getType() === 'http') {
-      const req = host.switchToHttp().getRequest<Request>();
-      const socket = req?.socket;
-      const clientGone =
-        req?.aborted === true ||
-        (req as { readableAborted?: boolean })?.readableAborted === true ||
-        socket?.destroyed === true;
-      if (clientGone) {
-        this.logger.debug(
-          `Dropped error after client disconnect: ${
-            exception instanceof Error ? exception.message : String(exception)
-          }`,
-        );
-        return;
-      }
+    if (host.getType() === 'http' && this.isClientAbort(exception, host)) {
+      this.logger.debug(
+        `Dropped error after client disconnect: ${
+          exception instanceof Error ? exception.message : String(exception)
+        }`,
+      );
+      return;
     }
     super.catch(exception, host);
+  }
+
+  private isClientAbort(exception: unknown, host: ArgumentsHost): boolean {
+    const req = host.switchToHttp().getRequest<Request>();
+    const socket = req?.socket;
+    if (
+      req?.aborted === true ||
+      (req as { readableAborted?: boolean })?.readableAborted === true ||
+      socket?.destroyed === true
+    ) {
+      return true;
+    }
+    // Node's internal HTTP socket error handler throws "this.removeListener is
+    // not a function" when a socket errors after being detached (client RST /
+    // cancelled request). It surfaces through whatever async work was in flight
+    // (often the response serialization), so socket state may already read as
+    // alive by the time we get here — match the signature instead.
+    if (exception instanceof Error) {
+      const stack = exception.stack ?? '';
+      if (
+        /removeListener is not a function/i.test(exception.message) &&
+        /socketOnError|_http_server/i.test(stack)
+      ) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/backend/src/common/filters/client-abort-exception.filter.ts
+++ b/backend/src/common/filters/client-abort-exception.filter.ts
@@ -1,0 +1,41 @@
+import { ArgumentsHost, Catch, Logger } from '@nestjs/common';
+import { BaseExceptionFilter } from '@nestjs/core';
+import type { Request } from 'express';
+
+/**
+ * Drops errors that only surface because a client aborted a request in flight.
+ *
+ * When a browser/native client cancels an in-flight request — e.g. a superseded
+ * `playback-info` fetch when the user switches quality, which Angular's
+ * HttpClient aborts on unsubscribe — the TCP socket is destroyed. Node's
+ * internal `socketOnError` can then throw `this.removeListener is not a
+ * function` while the response is still being serialized, and any attempt to
+ * write an error body fails again against the dead socket. There is nothing to
+ * send to a client that is already gone and nothing actionable to report, so
+ * swallow it instead of logging a spurious 500. Errors on a live connection
+ * fall through to the default handler unchanged.
+ */
+@Catch()
+export class ClientAbortExceptionFilter extends BaseExceptionFilter {
+  private readonly logger = new Logger(ClientAbortExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    if (host.getType() === 'http') {
+      const req = host.switchToHttp().getRequest<Request>();
+      const socket = req?.socket;
+      const clientGone =
+        req?.aborted === true ||
+        (req as { readableAborted?: boolean })?.readableAborted === true ||
+        socket?.destroyed === true;
+      if (clientGone) {
+        this.logger.debug(
+          `Dropped error after client disconnect: ${
+            exception instanceof Error ? exception.message : String(exception)
+          }`,
+        );
+        return;
+      }
+    }
+    super.catch(exception, host);
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -6,6 +6,7 @@ import { ClassSerializerInterceptor, ValidationPipe } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import { AppModule } from './app.module';
 import { LogBufferService } from './modules/scheduler/log-buffer.service';
+import { ClientAbortExceptionFilter } from './common/filters/client-abort-exception.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -83,6 +84,11 @@ async function bootstrap() {
   // every entity instance a controller returns. Plain-object responses pass
   // through unchanged; @Res()/SSE handlers bypass interceptors entirely.
   app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
+  // Swallow errors that only fire because a client aborted a request mid-flight
+  // (e.g. a superseded playback-info fetch) — Node's socketOnError throws during
+  // response serialization against the dead socket. Live-connection errors keep
+  // the default handling.
+  app.useGlobalFilters(new ClientAbortExceptionFilter(app.getHttpAdapter()));
 
   const port = Number(process.env.PORT) || 4848;
   await app.listen(port);

--- a/backend/src/modules/settings/entities/app-setting.entity.ts
+++ b/backend/src/modules/settings/entities/app-setting.entity.ts
@@ -15,6 +15,7 @@ import { BaseEntity } from '../../../common/entities/base.entity';
  *   companion_file_extensions — comma-separated list, e.g. ".nfo,.srt,.jpg"
  *   search_missing_auto   — "true" | "false"
  *   rss_sync_interval     — minutes, e.g. "15"
+ *   streaming_auto_quality_mode — "directplay" | "abr" (how "Auto" quality resolves)
  */
 @Entity('app_settings')
 export class AppSetting extends BaseEntity {

--- a/backend/src/modules/streaming/dto/device-profile.dto.ts
+++ b/backend/src/modules/streaming/dto/device-profile.dto.ts
@@ -74,6 +74,18 @@ export class DeviceProfileDto {
   supportsHdr?: boolean;
 
   /**
+   * Client engine can play a raw progressive file served as-is (Direct Play).
+   * Shaka (web), ExoPlayer/AVPlayer (native mobile) and webOS `<video>` all
+   * can. Samsung Tizen AVPlay is HLS-only and cannot open a raw file, so it
+   * sends `false`: the backend then never returns `DirectPlay` for it and
+   * falls back to DirectStream (remux to HLS, codec-copy — still no
+   * re-encode). Unset is treated as `true` for backward compatibility.
+   */
+  @IsBoolean()
+  @IsOptional()
+  supportsDirectPlay?: boolean;
+
+  /**
    * Client renders HLS `SUBTITLES` renditions natively (AVPlayer, ExoPlayer,
    * Tizen AVPlay, webOS), so the master advertises a subtitle group and cues
    * show in PiP / AirPlay / lock-screen. Web (Shaka) leaves this unset and

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -157,7 +157,13 @@ export class StreamBuilderService {
       {
         width: source.width ?? 0,
         height: source.height ?? 0,
-        hdr: (source.hdrFormat as CodecVariant['hdr']) ?? null,
+        // Only carry HDR into the variant when we actually emit the HDR ladder.
+        // An HDR source tonemapped to SDR (useHdrLadder=false) is encoded as an
+        // 8-bit SDR variant, so selecting an HDR (Main10) variant here
+        // mismatches the real encoder — which left effectiveHwAccel resolving to
+        // the CPU fallback (stats showed "CPU") while ffmpeg actually ran
+        // hevc_qsv.
+        hdr: useHdrLadder ? ((source.hdrFormat as CodecVariant['hdr']) ?? null) : null,
         codec: normaliseSourceCodec(source.videoCodec) ?? undefined,
       },
       profile,

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -61,6 +61,8 @@ export class StreamBuilderService {
     profile: DeviceProfileDto,
     tokenParam: string,
     burnInSubtitleId?: number,
+    requestedQuality?: string,
+    autoQualityMode: 'directplay' | 'abr' = 'directplay',
   ): EvaluateResult {
     const si = resolved.mediaFile.streamInfo;
     const v = si?.video?.[0];
@@ -219,6 +221,54 @@ export class StreamBuilderService {
       });
     }
 
+    // --- Quality / engine routing gate ---
+    // The full quality ladder is always exposed (see buildQualityList). Direct
+    // Play — and remux at source resolution — is only what the client wants
+    // when it asks for the source rung. A lower explicit rung routes to the
+    // transcode ladder; "Auto" routes there too when the admin picked
+    // autoQualityMode='abr'. HLS-only engines (Tizen AVPlay) can never open a
+    // raw file, so they skip DirectPlay but still remux to HLS.
+    const wantsSourceRung =
+      requestedQuality == null ||
+      requestedQuality === 'auto' ||
+      requestedQuality === 'original';
+    const autoOnLadder =
+      (requestedQuality == null || requestedQuality === 'auto') &&
+      autoQualityMode === 'abr';
+    // Lower explicit rung OR ABR-on-auto: skip both DirectPlay and remux so the
+    // backend re-encodes at the requested rung (and the master carries the ABR
+    // ladder).
+    const forceLadder = autoOnLadder || !wantsSourceRung;
+
+    // Whether the source can be served at its own resolution without
+    // re-encoding (raw direct play or codec-copy remux). Independent of the
+    // quality gate so the `original` rung stays in the menu even while the user
+    // is currently watching a lower transcoded rung — letting them switch back.
+    const sourceCopyable =
+      directPlayResult.videoSupported &&
+      directPlayResult.videoConditionsMet &&
+      !needsTonemapping &&
+      !needsBurnIn &&
+      !needsCrop;
+
+    if (profile.supportsDirectPlay === false && directPlayResult.canDirectPlay) {
+      directPlayResult.canDirectPlay = false;
+      reasons.push({
+        flag: 'ClientRequiresHls',
+        message: 'Client requires an HLS container (no raw direct play)',
+      });
+    }
+    if (forceLadder) {
+      if (directPlayResult.canDirectPlay)
+        directPlayResult.canDirectPlay = false;
+      reasons.push({
+        flag: 'QualitySelection',
+        message: autoOnLadder
+          ? 'Adaptive bitrate (ABR) mode'
+          : `Requested quality below source (${requestedQuality})`,
+      });
+    }
+
     const deviceType: DeviceType = profile.deviceType ?? 'desktop';
     const ladder = getLadderForDevice(deviceType);
     // Quality ladder shown to the UI matches what the backend will
@@ -250,20 +300,17 @@ export class StreamBuilderService {
         outputContainer: sourceContainer,
         hwAccel: 'none',
         tonemapping: false,
-        qualities: this.buildQualityList(source, 'DirectPlay', true, qualityLadder),
+        qualities: this.buildQualityList(source, 'DirectPlay', sourceCopyable, qualityLadder),
         source,
       });
     }
 
     // --- Step 2: Try DirectStream (remux) ---
     // Video codec must be supported; only container or audio may differ
-    // Cannot remux if tone mapping or burn-in is needed (video must be re-encoded)
-    const canCopyVideo =
-      directPlayResult.videoSupported &&
-      directPlayResult.videoConditionsMet &&
-      !needsTonemapping &&
-      !needsBurnIn &&
-      !needsCrop;
+    // Cannot remux if tone mapping or burn-in is needed (video must be re-encoded).
+    // A lower explicit rung / ABR-on-auto wants a re-encoded ladder, not a
+    // source-resolution remux copy, so `forceLadder` skips this path too.
+    const canCopyVideo = sourceCopyable && !forceLadder;
     if (canCopyVideo) {
       // Some audio codecs the device profile claims to support are
       // only playable in their NATIVE container (e.g. MP3 via
@@ -348,7 +395,7 @@ export class StreamBuilderService {
         tonemapping: false,
         remuxMasterBandwidthBps: remuxBw > 0 ? remuxBw : undefined,
         transcodeBitrateByQuality,
-        qualities: this.buildQualityList(source, 'DirectStream', true, qualityLadder),
+        qualities: this.buildQualityList(source, 'DirectStream', sourceCopyable, qualityLadder),
         source,
       });
     }
@@ -482,7 +529,7 @@ export class StreamBuilderService {
       hwAccel: effectiveHwAccel,
       tonemapping: needsTonemapping,
       transcodeBitrateByQuality,
-      qualities: this.buildQualityList(source, 'Transcode', false, qualityLadder),
+      qualities: this.buildQualityList(source, 'Transcode', sourceCopyable, qualityLadder),
       source,
     });
   }
@@ -490,9 +537,12 @@ export class StreamBuilderService {
   /**
    * Build the server-authoritative quality list shown in the player UI.
    *
-   * Rules:
-   * - DirectPlay → single `original` entry at source resolution.
-   * - Transcode / DirectStream → iterate the device ladder filtered to source.
+   * The full ladder is always exposed (DirectPlay included) so the user can
+   * downshift to a transcoded rung; picking a rung below source re-negotiates
+   * playback to the HLS ladder. Rules:
+   * - The source-resolution rung is `original` (raw on DirectPlay, copy on
+   *   DirectStream — only the latter sets `isRemux`).
+   * - Iterate the device ladder filtered to source.
    *   At the source-resolution rung:
    *     - If remux is possible (`videoCopyStream`) and `sourceTotal > ladderTotal × 1.3`:
    *       expose BOTH entries, `original` first (the remux path, full quality) and
@@ -532,22 +582,11 @@ export class StreamBuilderService {
     const originalHeight = sourceH || topProfile.maxHeight;
     const originalWidth = sourceW || topProfile.maxWidth;
 
-    if (playMethod === 'DirectPlay') {
-      return [
-        {
-          id: 'original',
-          label: resolutionLabel,
-          height: originalHeight,
-          width: originalWidth,
-          totalBitrateBps: sourceTotal,
-          isRemux: false,
-        },
-      ];
-    }
-
-    // Full-quality rungs. The top rung collapses into `original` (remux) when
-    // the source video can be copied; a forced transcode lists it as a normal
-    // rung instead.
+    // Full-quality rungs. The top rung collapses into `original` when the
+    // source video can be served untouched (DirectPlay) or copied (remux);
+    // a forced transcode lists it as a normal rung instead. `isRemux` is true
+    // only on the DirectStream path so the UI/stats can tell remux from a raw
+    // direct play.
     const qualities: QualityOption[] = [];
     for (const p of available) {
       if (isEcoProfile(p.name)) continue;
@@ -559,7 +598,7 @@ export class StreamBuilderService {
           height: originalHeight,
           width: originalWidth,
           totalBitrateBps: sourceTotal > 0 ? sourceTotal : total,
-          isRemux: true,
+          isRemux: playMethod === 'DirectStream',
         });
         continue;
       }

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -261,12 +261,17 @@ export class StreamBuilderService {
     if (forceLadder) {
       if (directPlayResult.canDirectPlay)
         directPlayResult.canDirectPlay = false;
-      reasons.push({
-        flag: 'QualitySelection',
-        message: autoOnLadder
-          ? 'Adaptive bitrate (ABR) mode'
-          : `Requested quality below source (${requestedQuality})`,
-      });
+      // `Video*` prefix so the player stats overlay surfaces it in the video
+      // section: a quality-driven transcode is not a defect, the user should
+      // see it was their bitrate/quality choice, not an incompatibility.
+      reasons.push(
+        autoOnLadder
+          ? { flag: 'VideoAbr', message: 'Adaptive bitrate (ABR) mode' }
+          : {
+              flag: 'VideoQualityReduced',
+              message: `Reduced-quality rung selected (${requestedQuality})`,
+            },
+      );
     }
 
     const deviceType: DeviceType = profile.deviceType ?? 'desktop';

--- a/backend/src/modules/streaming/streaming-settings-cache.service.ts
+++ b/backend/src/modules/streaming/streaming-settings-cache.service.ts
@@ -18,16 +18,31 @@ export interface StreamingSettings {
   /** HDR → SDR tone-mapping algorithm. See {@link TonemapAlgo}. Default
    *  is `'auto'` which currently routes through tonemap_opencl. */
   tonemapAlgo: TonemapAlgo;
+  /**
+   * What the "Auto" quality resolves to when a compatible source could be
+   * direct-played:
+   *   - `'directplay'` (default): serve the original untouched — zero
+   *     transcoding, but no adaptive bitrate on direct-play sources.
+   *   - `'abr'`: always route "Auto" through the adaptive HLS ladder so the
+   *     bitrate follows the network, at the cost of transcoding every "Auto"
+   *     playback.
+   * Explicit quality picks are unaffected either way.
+   */
+  autoQualityMode: AutoQualityMode;
 }
+
+export type AutoQualityMode = 'directplay' | 'abr';
 
 const KEYS = [
   'streaming_segment_duration',
   'streaming_qsv_preset',
   'streaming_qsv_low_power',
   'streaming_tonemap_algo',
+  'streaming_auto_quality_mode',
 ] as const;
 
 const TONEMAP_ALGOS: TonemapAlgo[] = ['auto', 'opencl', 'vaapi', 'qsv'];
+const AUTO_QUALITY_MODES: AutoQualityMode[] = ['directplay', 'abr'];
 
 @Injectable()
 export class StreamingSettingsCache implements OnModuleInit {
@@ -58,7 +73,8 @@ export class StreamingSettingsCache implements OnModuleInit {
 
   private async load(): Promise<StreamingSettings> {
     const values = await Promise.all(KEYS.map((k) => this.settings.get(k)));
-    const [duration, qsvPreset, qsvLowPower, tonemapAlgo] = values;
+    const [duration, qsvPreset, qsvLowPower, tonemapAlgo, autoQualityMode] =
+      values;
     return {
       segmentDuration: parseFloat(duration ?? '3') || 3,
       qsvPreset: (qsvPreset ?? 'faster') as StreamingSettings['qsvPreset'],
@@ -66,6 +82,11 @@ export class StreamingSettingsCache implements OnModuleInit {
       tonemapAlgo: TONEMAP_ALGOS.includes(tonemapAlgo as TonemapAlgo)
         ? (tonemapAlgo as TonemapAlgo)
         : 'auto',
+      autoQualityMode: AUTO_QUALITY_MODES.includes(
+        autoQualityMode as AutoQualityMode,
+      )
+        ? (autoQualityMode as AutoQualityMode)
+        : 'directplay',
     };
   }
 }

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -1056,8 +1056,12 @@ export class StreamingController {
     // that gap with encoder init so segment 0 is usually already on disk
     // (or streaming) when requested. No-op for DirectPlay or auto quality.
     // Runs after LiveSession creation so buildSessionContext can find it.
+    // Fire-and-forget: the playback-info response (playUrl + sessionId) does
+    // not depend on the spawn, so it must not block on ffmpeg init — same
+    // pattern as the master.m3u8 prewarm. prewarmTranscodeSession swallows its
+    // own errors.
     if (response.playMethod !== 'DirectPlay') {
-      await this.prewarmTranscodeSession(
+      void this.prewarmTranscodeSession(
         mediaFileId,
         resolved,
         req,

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -836,11 +836,17 @@ export class StreamingController {
     const user = req.user as User;
     const userId = user.id;
 
+    // Quality the client is requesting (absent / 'auto' = let the server
+    // decide per autoQualityMode; 'original' = source rung; anything else =
+    // a lower rung that must transcode). Drives DirectPlay-vs-ladder routing.
+    const startQuality = firstQueryString(req.query, 'startQuality');
     const evaluateResult = this.streamBuilder.evaluate(
       resolved,
       deviceProfile,
       tokenParam,
       burnInSubtitleId,
+      startQuality,
+      ss.autoQualityMode,
     );
     const { response, useHdrLadder, videoVariant } = evaluateResult;
     // Resolve the effective `useTs`. The explicit profile flag wins as
@@ -882,7 +888,6 @@ export class StreamingController {
     // another. No drift kill needed: a hop from browser → cast spawns a
     // new session under the cast's profileHash and leaves the browser's
     // session untouched.
-    const startQuality = firstQueryString(req.query, 'startQuality');
     const startAtRaw = firstQueryString(req.query, 'startAt');
     const startAt = startAtRaw != null ? parseFloat(startAtRaw) : undefined;
     // Offline download: the native DownloadManager pulls segments straight off

--- a/client/android/app/src/main/java/media/fliks/app/MainActivity.java
+++ b/client/android/app/src/main/java/media/fliks/app/MainActivity.java
@@ -32,6 +32,7 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(PipPlugin.class);
         registerPlugin(HdrPlugin.class);
         registerPlugin(AudioCapabilitiesPlugin.class);
+        registerPlugin(VideoCapabilitiesPlugin.class);
         registerPlugin(CastPlugin.class);
         registerPlugin(DownloadNotificationPlugin.class);
         registerPlugin(NativePlayerPlugin.class);

--- a/client/android/app/src/main/java/media/fliks/app/VideoCapabilitiesPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/VideoCapabilitiesPlugin.java
@@ -1,0 +1,103 @@
+package media.fliks.app;
+
+import android.media.MediaCodecInfo;
+import android.media.MediaCodecList;
+
+import com.getcapacitor.JSArray;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Reports the video codecs the device's MediaCodec stack actually decodes, plus
+ * the containers ExoPlayer demuxes. Playback on Android goes through ExoPlayer,
+ * not the WebView, but the device profile's video codec list is otherwise built
+ * from {@code MediaSource.isTypeSupported()} — which under-reports HEVC/AV1 on
+ * the Android System WebView even when MediaCodec can decode them. That makes
+ * HEVC sources fall back to a full H.264 transcode. Sourcing the codec list
+ * from MediaCodecList instead lets HEVC (and MKV via the container list below)
+ * Direct Play / remux with no re-encode.
+ */
+@CapacitorPlugin(name = "VideoCapabilities")
+public class VideoCapabilitiesPlugin extends Plugin {
+
+    @PluginMethod()
+    public void getSupported(PluginCall call) {
+        Set<String> codecs = new HashSet<>();
+        boolean hevcMain10 = false;
+        boolean av1Main10 = false;
+        try {
+            MediaCodecList list = new MediaCodecList(MediaCodecList.REGULAR_CODECS);
+            for (MediaCodecInfo info : list.getCodecInfos()) {
+                if (info.isEncoder()) continue;
+                for (String type : info.getSupportedTypes()) {
+                    String key = mimeToCodecKey(type);
+                    if (key == null) continue;
+                    codecs.add(key);
+                    try {
+                        MediaCodecInfo.CodecCapabilities caps = info.getCapabilitiesForType(type);
+                        if ("hevc".equals(key) && supportsMain10(caps, true)) hevcMain10 = true;
+                        if ("av1".equals(key) && supportsMain10(caps, false)) av1Main10 = true;
+                    } catch (Throwable ignored) { /* per-codec best-effort */ }
+                }
+            }
+        } catch (Throwable ignored) { /* best-effort */ }
+
+        JSArray arr = new JSArray();
+        for (String c : codecs) arr.put(c);
+
+        // ExoPlayer demuxes these containers regardless of device. mkv/webm are
+        // the wins over the WebView (which can only Direct Play mp4/webm).
+        JSArray containers = new JSArray();
+        containers.put("mp4");
+        containers.put("m4v");
+        containers.put("mov");
+        containers.put("webm");
+        containers.put("mkv");
+
+        JSObject result = new JSObject();
+        result.put("videoCodecs", arr);
+        result.put("hevcMain10", hevcMain10);
+        result.put("av1Main10", av1Main10);
+        result.put("containers", containers);
+        call.resolve(result);
+    }
+
+    /** True when the decoder advertises a 10-bit (Main10) or HDR profile. */
+    private static boolean supportsMain10(MediaCodecInfo.CodecCapabilities caps, boolean hevc) {
+        if (caps == null || caps.profileLevels == null) return false;
+        for (MediaCodecInfo.CodecProfileLevel pl : caps.profileLevels) {
+            if (hevc) {
+                // HEVCProfileMain10 = 2, plus HDR10 / HDR10Plus variants.
+                if (pl.profile == MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10
+                        || pl.profile == 0x1000
+                        || pl.profile == 0x2000) {
+                    return true;
+                }
+            } else {
+                // AV1ProfileMain10 = 2, plus HDR10 / HDR10Plus variants.
+                if (pl.profile == 2 || pl.profile == 0x1000 || pl.profile == 0x2000
+                        || pl.profile == 0x4000) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static String mimeToCodecKey(String mime) {
+        switch (mime.toLowerCase()) {
+            case "video/avc":            return "h264";
+            case "video/hevc":           return "hevc";
+            case "video/av01":           return "av1";
+            case "video/x-vnd.on2.vp9":  return "vp9";
+            case "video/x-vnd.on2.vp8":  return "vp8";
+            default: return null;
+        }
+    }
+}

--- a/client/ios/App/App/VideoCapabilitiesPlugin.swift
+++ b/client/ios/App/App/VideoCapabilitiesPlugin.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Capacitor
+import UIKit
+
+@objc(VideoCapabilitiesPlugin)
+public class VideoCapabilitiesPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "VideoCapabilitiesPlugin"
+    public let jsName = "VideoCapabilities"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "getSupported", returnType: CAPPluginReturnPromise),
+    ]
+
+    /// Reports the video codecs AVPlayer can decode on this device so the
+    /// profile reflects VideoToolbox capability rather than the WebView MSE
+    /// (which under-reports HEVC). H.264 is universal; HEVC — including Main10
+    /// — is hardware-decoded across the iOS 11+ device range (A9 and newer).
+    /// AVPlayer demuxes the ISO-BMFF family only, so MKV/WebM are never
+    /// advertised (those still remux/transcode server-side).
+    @objc func getSupported(_ call: CAPPluginCall) {
+        var codecs: [String] = ["h264"]
+        var hevcMain10 = false
+
+        if #available(iOS 11.0, tvOS 11.0, *) {
+            codecs.append("hevc")
+            hevcMain10 = true
+        }
+
+        call.resolve([
+            "videoCodecs": codecs,
+            "hevcMain10": hevcMain10,
+            "av1Main10": false,
+            "containers": ["mp4", "m4v", "mov"],
+        ])
+    }
+}

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1147,6 +1147,12 @@
     "streaming": {
       "title": "Streaming",
       "description": "Configuration du format et de la taille des segments HLS. Affecte la vitesse de démarrage et le changement de qualité.",
+      "auto_quality_mode": "Comportement de la qualité « Auto »",
+      "auto_quality_mode_help": "Définit ce que fait la qualité « Auto ». Les choix de qualité explicites ne sont pas affectés : « Original » reste en lecture directe si l'appareil est compatible.",
+      "auto_quality_mode_directplay": "Lecture directe priorisée (recommandé NAS)",
+      "auto_quality_mode_directplay_help": "En « Auto », le serveur envoie le fichier original sans transcodage quand l'appareil est compatible : charge serveur quasi nulle. Inconvénient : pas d'adaptation automatique au débit — sur une connexion lente, choisissez manuellement une qualité inférieure.",
+      "auto_quality_mode_abr": "Streaming adaptatif priorisé (ABR)",
+      "auto_quality_mode_abr_help": "En « Auto », le serveur transcode en HLS adaptatif qui ajuste la qualité au débit réseau en temps réel. Inconvénient : chaque lecture « Auto » sollicite le transcodage (CPU/GPU) — à réserver aux serveurs avec accélération matérielle.",
       "segment_duration": "Durée des segments",
       "segment_duration_help": "Segments plus courts = démarrage plus rapide mais plus de requêtes HTTP. 3s est un bon compromis.",
       "init_time": "Durée du premier segment",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -82,7 +82,21 @@
     "stats_crop": "Recadrage",
     "stats_tonemapping": "Mappage tonal",
     "stats_reasons": "Raisons",
-    "stats_sample_rate": "Fréquence d'échantillonnage"
+    "stats_sample_rate": "Fréquence d'échantillonnage",
+    "transcode_reason": {
+      "VideoCodecNotSupported": "Codec vidéo non supporté",
+      "VideoHdrNotSupported": "HDR → SDR (mappage tonal)",
+      "VideoProfileNotSupported": "Profil vidéo non supporté",
+      "VideoLevelNotSupported": "Niveau vidéo trop élevé",
+      "VideoBitDepthNotSupported": "10-bit non supporté",
+      "VideoResolutionNotSupported": "Résolution trop élevée",
+      "VideoCrop": "Suppression des bandes noires",
+      "VideoQualityReduced": "Bitrate réduit (qualité choisie)",
+      "VideoAbr": "Bitrate adaptatif (ABR)",
+      "SubtitleBurnIn": "Sous-titres incrustés",
+      "AudioCodecNotSupported": "Codec audio non supporté",
+      "AudioChannelsNotSupported": "Trop de canaux audio"
+    }
   },
   "sse": {
     "subtitle_synced": "Sous-titre synchronisé avec succès.",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -64,7 +64,7 @@
     "auto_resolution": "Auto ({{res}})",
     "stats_direct_playback": "Lecture directe",
     "stats_transcoding": "Transcodage ({{hw}})",
-    "stats_transcode_audio": "Transcodage ({{codec}} 192 kbps)",
+    "stats_transcode_audio": "Transcodage ({{codec}})",
     "offline_not_found": "Contenu hors-ligne introuvable. Re-téléchargez le média.",
     "settings": "Paramètres",
     "quality": "Qualité",

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -15,6 +15,17 @@ interface AudioCapabilitiesPlugin {
 }
 const AudioCaps = registerPlugin<AudioCapabilitiesPlugin>('AudioCapabilities');
 
+interface NativeVideoCaps {
+  videoCodecs: string[];
+  hevcMain10: boolean;
+  av1Main10: boolean;
+  containers: string[];
+}
+interface VideoCapabilitiesPlugin {
+  getSupported(): Promise<NativeVideoCaps>;
+}
+const VideoCaps = registerPlugin<VideoCapabilitiesPlugin>('VideoCapabilities');
+
 /** Probe Tizen's `webapis.avinfo.isHdrTvSupport()` synchronously. The
  *  Samsung runtime exposes a panel-level HDR capability flag that's
  *  more reliable than `matchMedia('(dynamic-range: high)')` on
@@ -120,9 +131,11 @@ export class BrowserDeviceProfileService {
   private cachedProfile: DeviceProfile | null = null;
   private nativeHdr: boolean | null = null;
   private nativeAudio: { codecs: string[]; maxChannels: number } | null = null;
+  private nativeVideo: NativeVideoCaps | null = null;
 
   constructor() {
-    // Pre-fetch native HDR + audio capabilities (async, cached for later sync use)
+    // Pre-fetch native HDR + audio + video capabilities (async, cached for
+    // later sync use)
     if (Capacitor.isNativePlatform()) {
       Hdr.isSupported()
         .then((r) => { this.nativeHdr = r.supported; })
@@ -130,6 +143,9 @@ export class BrowserDeviceProfileService {
       AudioCaps.getSupported()
         .then((r) => { this.nativeAudio = r; this.cachedProfile = null; })
         .catch(() => { this.nativeAudio = null; });
+      VideoCaps.getSupported()
+        .then((r) => { this.nativeVideo = r; this.cachedProfile = null; })
+        .catch(() => { this.nativeVideo = null; });
     }
   }
 
@@ -248,6 +264,58 @@ export class BrowserDeviceProfileService {
     // VP8
     if (this.testCodec(video, hasMSE, 'video/webm', 'vp8')) {
       videoCodecs.push('vp8');
+    }
+
+    // Native engines (Capacitor: ExoPlayer on Android, AVPlayer on iOS) decode
+    // through the OS media stack, not the WebView — whose MSE under-reports
+    // HEVC/AV1 on Android even when the device decodes them, forcing needless
+    // H.264 transcodes. When the native video-capability plugin answered, trust
+    // it for video codecs, their conditions, and the containers it can demux
+    // (incl. mkv on ExoPlayer). Smart TVs (Tizen AVPlay / webOS) run as web
+    // apps with no plugin: declare HEVC for them too, since their WebView MSE
+    // probe can miss it while the panel hardware-decodes it.
+    if (this.nativeVideo && this.nativeVideo.videoCodecs.length) {
+      const nv = this.nativeVideo;
+      videoCodecs.length = 0;
+      codecConditions.length = 0;
+      containers.length = 0;
+      containers.push(...nv.containers);
+      for (const c of nv.videoCodecs) {
+        if (c === 'h264') {
+          videoCodecs.push('h264', 'avc1');
+          codecConditions.push({
+            codec: 'h264',
+            profiles: ['baseline', 'constrained baseline', 'main', 'high'],
+            maxBitDepth: 8,
+          });
+        } else if (c === 'hevc') {
+          videoCodecs.push('hevc', 'h265', 'hvc1', 'hev1');
+          codecConditions.push({
+            codec: 'hevc',
+            profiles: nv.hevcMain10 ? ['main', 'main 10'] : ['main'],
+            maxBitDepth: nv.hevcMain10 ? 10 : 8,
+          });
+        } else if (c === 'av1') {
+          videoCodecs.push('av1');
+          codecConditions.push({
+            codec: 'av1',
+            profiles: nv.av1Main10 ? ['main', 'high'] : ['main'],
+            maxBitDepth: nv.av1Main10 ? 10 : 8,
+          });
+        } else {
+          videoCodecs.push(c); // vp9 / vp8 — no fine-grained conditions
+        }
+      }
+    } else if (
+      (tvPlatform === 'tizen' || tvPlatform === 'webos') &&
+      !videoCodecs.includes('hevc')
+    ) {
+      videoCodecs.push('hevc', 'h265', 'hvc1', 'hev1');
+      codecConditions.push({
+        codec: 'hevc',
+        profiles: ['main', 'main 10'],
+        maxBitDepth: 10,
+      });
     }
 
     // --- Detect supported audio codecs ---

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -96,6 +96,12 @@ export interface DeviceProfile {
    *  to the target segment and never request seg-0, so they send false and the
    *  backend skips the companion (a wasted parallel transcode for them). */
   probesSegZero?: boolean;
+
+  /** Client engine can play a raw progressive file (DirectPlay served as-is).
+   *  True for Shaka (web), ExoPlayer/AVPlayer (native) and webOS `<video>`.
+   *  False for Tizen AVPlay (HLS-only): the backend then never returns
+   *  DirectPlay and falls back to DirectStream (remux to HLS). Unset = true. */
+  supportsDirectPlay?: boolean;
 }
 
 /** True when `localStorage['fliks.useTs']` is set to a truthy value.
@@ -344,6 +350,11 @@ export class BrowserDeviceProfileService {
       // through native players that seek straight to the resume segment). The
       // Cast receiver sets this true in its own profile.
       probesSegZero: !this.serverConfig.isNative,
+      // Samsung Tizen AVPlay is HLS-only and cannot open a raw progressive
+      // file, so it must never receive a DirectPlay decision — the backend
+      // falls back to DirectStream (remux to HLS, codec-copy). Every other
+      // engine (Shaka, ExoPlayer/AVPlayer, webOS <video>) plays raw files.
+      supportsDirectPlay: tvPlatform !== 'tizen',
     };
   }
 

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -478,10 +478,14 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     const playingWidth = activeVariant?.width ?? src?.width;
     const playingHeight = activeVariant?.height ?? src?.height;
 
-    // Determine effective copy/transcode state based on selected quality
+    // Video re-encodes on any pinned rung below the source. Audio is decided
+    // independently by the backend — a lower video rung still copies a
+    // supported audio track (e.g. AC3 5.1) verbatim — so reflect the backend's
+    // audioCopyStream, not the video rung. Forcing it off the rung mislabelled a
+    // copied AC3 stream as an AAC transcode.
     const isTranscodeQuality = !['auto', 'original'].includes(_quality);
     const effectiveVideoCopy = isTranscodeQuality ? false : (pi?.videoCopyStream ?? true);
-    const effectiveAudioCopy = isTranscodeQuality ? false : (pi?.audioCopyStream ?? true);
+    const effectiveAudioCopy = pi?.audioCopyStream ?? true;
 
     const formatBitrateBps = (bps: number): string => {
       if (bps >= 1_000_000) return `${(bps / 1_000_000).toFixed(1)} Mbps`;
@@ -681,7 +685,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     if (effectiveAudioCopy) {
       audioPlaybackMode = this.translate.instant('player.stats_direct_playback');
     } else {
-      const outCodec = isTranscodeQuality ? 'AAC' : (pi?.outputAudioCodec ?? 'aac').toUpperCase();
+      const outCodec = (pi?.outputAudioCodec ?? 'aac').toUpperCase();
       audioPlaybackMode = this.translate.instant('player.stats_transcode_audio', { codec: outCodec });
     }
 

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1931,16 +1931,22 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         }
       }
     }
-    // Enforce the pre-reload play state. The native engine (ExoPlayer
-    // playWhenReady) autoplays on load(), so a recovery that should preserve a
-    // pause must actively pause after load — merely skipping play() lets it
-    // resume. A server restart (lost session → recovery reload) must not start
-    // playback the user had paused.
-    if (wasPaused) {
-      this.engine.pause().catch(() => {});
-    } else {
-      this.engine.play().catch(() => {});
-    }
+    this.restorePlayState(wasPaused);
+  }
+
+  /**
+   * Restore the engine to the play/pause state the user intended before a
+   * reload. Every reload — quality / audio / subtitle switch and lost-session
+   * recovery — must preserve whether playback is running; only the initial
+   * launch autoplays. The native engine (ExoPlayer playWhenReady) autoplays on
+   * load(), so a paused user must be actively re-paused after load, not merely
+   * left unplayed. The single enforcement point keeps every reload path
+   * consistent.
+   */
+  private restorePlayState(wasPaused: boolean): void {
+    if (!this.engine) return;
+    if (wasPaused) this.engine.pause().catch(() => {});
+    else this.engine.play().catch(() => {});
   }
 
   /**
@@ -2615,6 +2621,9 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   private async reloadStream() {
     if (!this.engine) return;
     const currentPos = this.engine.currentTime;
+    // Capture the user's play/pause intent before tearing the stream down — a
+    // quality / audio / subtitle switch must not resume a paused player.
+    const wasPaused = this.paused();
 
     // Remember active subtitle so we can restore it after reload
     const activeSub = this.activeSubtitleId()
@@ -2664,7 +2673,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     await this.engine.load(url, currentPos, mimeType);
 
     this.qualityManager.applyQualityPreferenceAfterLoad(this.engine, mode);
-    this.engine.play().catch(() => {});
+    this.restorePlayState(wasPaused);
 
     // Restore active subtitle (non burn-in) after Shaka reload
     if (activeSub && !activeSub.burnIn && activeSub.url) {

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -632,12 +632,22 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // the "\u2192 HLS" line of the stream section, and it doesn't tell you
     // anything about why this codec specifically had to change.
     const allFlags = (pi?.transcodeReasons ?? []).map((r) => r.flag);
+    // Translate each flag to a human label (e.g. VideoQualityReduced → "Bitrate
+    // réduit (qualité choisie)") so the overlay explains bitrate/quality-driven
+    // transcodes, not just raw codes. Unknown flags fall back to the raw token.
+    const reasonLabel = (flag: string) => {
+      const key = `player.transcode_reason.${flag}`;
+      const label = this.translate.instant(key);
+      return label === key ? flag : label;
+    };
     const videoTranscodeReasons = effectiveVideoCopy
       ? []
-      : allFlags.filter((f) => f.startsWith('Video') || f === 'SubtitleBurnIn');
+      : allFlags
+          .filter((f) => f.startsWith('Video') || f === 'SubtitleBurnIn')
+          .map(reasonLabel);
     const audioTranscodeReasons = effectiveAudioCopy
       ? []
-      : allFlags.filter((f) => f.startsWith('Audio'));
+      : allFlags.filter((f) => f.startsWith('Audio')).map(reasonLabel);
 
     // --- Audio ---
     // Derive from the SELECTED track, not the source's primary stream, so the

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -2562,18 +2562,16 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     const option = this.availableQualities().find(q => q.id === id);
     if (!option) return;
     const mode = this.playbackMode();
-    // User picked this explicitly → persist at app level. In non-direct mode
-    // the imminent reloadStream() re-applies the quality after load
-    // (applyQualityPreferenceAfterLoad), so pass engine=null here to only
-    // persist and avoid selecting a variant the full reload throws away.
-    this.qualityManager.selectQuality(option, mode !== 'direct' ? null : this.engine, mode, false, true);
-
-    // Transcode mode: the backend emits a single-variant master playlist
-    // (the one matching savedQualityId), so switching quality requires a
-    // full stream reload — same trade-off the native path already makes.
-    // The reload is done so that Shaka can't probe lower variants during
-    // startup (which would spin up FFmpeg at the wrong quality).
-    if (mode !== 'direct') {
+    // Picking a rung below source — or any rung while already on the HLS
+    // ladder — re-negotiates playback: reloadStream() re-requests playback-info
+    // with the chosen quality, the backend re-decides DirectPlay vs the
+    // transcode ladder, and the engine swaps the raw file for the HLS master.
+    // Staying on `original` while direct-playing needs no reload. When we WILL
+    // reload, pass engine=null so we don't select a variant the reload throws
+    // away (it re-applies the quality after load via applyQualityPreferenceAfterLoad).
+    const willReload = mode !== 'direct' || id !== 'original';
+    this.qualityManager.selectQuality(option, willReload ? null : this.engine, mode, false, true);
+    if (willReload) {
       await this.reloadStream();
     }
 
@@ -2618,8 +2616,18 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       .catch(() => {});
 
     const deviceProfile = this.deviceProfileService.getProfile();
+    // Pass the requested rung so the backend re-decides DirectPlay vs the
+    // transcode ladder: a rung below source forces the ladder, 'auto' lets the
+    // server apply its autoQualityMode.
+    const activeQuality = this.activeQualityId();
+    const requestedQuality =
+      activeQuality && activeQuality !== 'auto' ? activeQuality : undefined;
     this.playbackInfo = await this.streamingApi.getPlaybackInfo(
-      this.mediaFileId, deviceProfile, this.activeBurnInId ?? undefined, this.activeAudioStreamIndex,
+      this.mediaFileId,
+      deviceProfile,
+      this.activeBurnInId ?? undefined,
+      this.activeAudioStreamIndex,
+      requestedQuality,
     );
     const pi = this.playbackInfo;
     this.introMarker.set(pi.markers?.intro ?? null);

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -661,11 +661,21 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     const selectedAudio = this.availableAudioTracks().find(
       (t) => t.id === _audioTrackId,
     );
-    const channelLabel = src?.audioChannelLayout ?? (src?.audioChannels ? `${src.audioChannels}ch` : '');
-    const rawLang = selectedAudio?.language || src?.audioLanguage;
-    const langLabel = rawLang ? rawLang.charAt(0).toUpperCase() + rawLang.slice(1) : '?';
-    const audioCodecUpper = (activeVariant?.audioCodec ?? src?.audioCodec ?? '?').toUpperCase();
-    const audioLabel = `${langLabel} ${audioCodecUpper} ${channelLabel}`;
+    // Show the audio NAME exactly as the track selector renders it:
+    // selectedAudio.label is built by formatAudioLabel, which localizes the
+    // language and falls back to "Piste audio N" for untagged tracks instead of
+    // a raw "Und". Fall back to formatAudioLabel on the source's primary stream
+    // when no track is selected yet (tracks not populated).
+    const audioLabel =
+      selectedAudio?.label ??
+      formatAudioLabel(
+        {
+          language: src?.audioLanguage,
+          codec: activeVariant?.audioCodec ?? src?.audioCodec,
+          channels: src?.audioChannels,
+        },
+        this.translate,
+      );
 
     let audioStreamBitrate = '';
     if (selectedRateEntry) {

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1931,7 +1931,14 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         }
       }
     }
-    if (!wasPaused) {
+    // Enforce the pre-reload play state. The native engine (ExoPlayer
+    // playWhenReady) autoplays on load(), so a recovery that should preserve a
+    // pause must actively pause after load — merely skipping play() lets it
+    // resume. A server restart (lost session → recovery reload) must not start
+    // playback the user had paused.
+    if (wasPaused) {
+      this.engine.pause().catch(() => {});
+    } else {
       this.engine.play().catch(() => {});
     }
   }

--- a/client/src/app/features/settings/streaming/streaming.html
+++ b/client/src/app/features/settings/streaming/streaming.html
@@ -5,6 +5,20 @@
     <h2 class="text-xl font-semibold">{{ 'settings.streaming.title' | translate }}</h2>
     <p class="text-base-content/60">{{ 'settings.streaming.description' | translate }}</p>
 
+    <!-- "Auto" quality behavior: Direct Play (zero transcode) vs adaptive ABR.
+         The help line below shows the trade-off of the selected mode. -->
+    <div class="form-control">
+      <label class="label"><span class="label-text font-medium">{{ 'settings.streaming.auto_quality_mode' | translate }}</span></label>
+      <select class="select select-bordered w-full" [ngModel]="autoQualityMode()" (ngModelChange)="autoQualityMode.set($event)">
+        <option value="directplay">{{ 'settings.streaming.auto_quality_mode_directplay' | translate }} ({{ 'settings.streaming.default' | translate }})</option>
+        <option value="abr">{{ 'settings.streaming.auto_quality_mode_abr' | translate }}</option>
+      </select>
+      <label class="label"><span class="label-text-alt text-base-content/50">{{ 'settings.streaming.auto_quality_mode_help' | translate }}</span></label>
+      <div class="mt-1 rounded-lg bg-base-200 p-3 text-sm text-base-content/70">
+        {{ ('settings.streaming.auto_quality_mode_' + autoQualityMode() + '_help') | translate }}
+      </div>
+    </div>
+
     <!-- Segment duration -->
     <div class="form-control">
       <label class="label"><span class="label-text font-medium">{{ 'settings.streaming.segment_duration' | translate }}</span></label>

--- a/client/src/app/features/settings/streaming/streaming.ts
+++ b/client/src/app/features/settings/streaming/streaming.ts
@@ -32,6 +32,11 @@ export class StreamingSettingsComponent implements OnInit {
   readonly qsvPreset = signal('faster');
   readonly qsvLowPower = signal(false);
   readonly tonemapAlgo = signal('auto');
+  /** How the "Auto" quality resolves: 'directplay' tries Direct Play first
+   *  (zero transcoding when compatible), 'abr' always uses the adaptive HLS
+   *  ladder. Explicit quality picks are unaffected. */
+  readonly autoQualityMode = signal<'directplay' | 'abr'>('directplay');
+  readonly autoQualityModes = ['directplay', 'abr'] as const;
   /** Tonemap algorithms the server reports as runnable on this host.
    *  When the list has a single entry (`['auto']` — e.g. macOS, or a
    *  Linux box with no OpenCL stack and no Intel iGPU), we hide the
@@ -49,6 +54,9 @@ export class StreamingSettingsComponent implements OnInit {
       this.segmentDuration.set(all['streaming_segment_duration'] ?? '3');
       this.qsvPreset.set(all['streaming_qsv_preset'] ?? 'faster');
       this.qsvLowPower.set(all['streaming_qsv_low_power'] === 'true');
+      this.autoQualityMode.set(
+        all['streaming_auto_quality_mode'] === 'abr' ? 'abr' : 'directplay',
+      );
       this.tonemapAlgosAvailable.set(algos.available ?? ['auto']);
       // If the persisted value isn't runnable on this host (e.g. opencl
       // saved on a box where the probe failed after a driver change),
@@ -70,6 +78,7 @@ export class StreamingSettingsComponent implements OnInit {
         streaming_qsv_preset: this.qsvPreset(),
         streaming_qsv_low_power: String(this.qsvLowPower()),
         streaming_tonemap_algo: this.tonemapAlgo(),
+        streaming_auto_quality_mode: this.autoQualityMode(),
       });
       this.toast.success(this.translate.instant('settings.streaming.saved'));
     } catch { /* interceptor */ }


### PR DESCRIPTION
## Quoi

Refonte du Direct Play alignée sur Plex/Jellyfin, en 3 volets :

### 1. Échelle de qualité complète + Direct Play quality-gated
- Le player reçoit **toujours l'échelle complète** ; le Direct Play ne s'active que si la qualité demandée = la source et qu'elle est compatible. Un rung inférieur → transcode HLS. Avant : un seul rung `original`, aucun switch possible.
- Réglage admin **`autoQualityMode` (directplay | abr, défaut directplay)** : `directplay` = zéro-transcodage pour « Auto » (idéal NAS) ; `abr` = ladder adaptatif. Trade-off affiché dans l'UI.
- **Garde-fou Tizen** : AVPlay ne lit pas un fichier brut → `supportsDirectPlay=false`, le backend redescend en remux HLS.

### 2. Raison de transcodage dans les « stats pour les nerds »
- Un transcodage dû à un **choix de bitrate/qualité** (rung eco, ABR) était invisible dans l'overlay (le flag ne commençait pas par `Video`). Flags renommés `VideoQualityReduced` / `VideoAbr`, et **tous les flags traduits** en libellés lisibles (fallback token brut). « 1080p faible consommation » affiche désormais « Bitrate réduit (qualité choisie) ».

### 3. Annonce native des codecs vidéo (corrige le transcodage HEVC)
- Le profil listait les codecs vidéo via le WebView (`MSE.isTypeSupported`), mais les clients natifs lisent via **ExoPlayer/AVPlayer**. Le WebView Android sous-déclare le HEVC/AV1 → les sources HEVC étaient transcodées en H.264 inutilement.
- Nouveau plugin **`VideoCapabilities`** (miroir de `AudioCapabilities`) : Android sonde `MediaCodecList` (codecs réels + Main10/HDR + conteneurs ExoPlayer dont **mkv**) ; iOS déclare HEVC Main10 (iOS 11+/A9+) + conteneurs ISO-BMFF (pas de mkv). Tizen/webOS (apps web, pas de plugin) : HEVC déclaré directement.
- **Aucun changement backend** : `DIRECT_PLAY_EXTS` est inutilisé, la décision est pilotée par le profil, et servir du mkv/hevc brut est sûr pour les players natifs.

## Vérifié
- Typecheck backend (`tsc --noEmit`) propre.
- Build client Angular (`ng build`) exit 0 (3 commits).

## À tester en conditions réelles (par form factor — code natif Java/Swift non compilable ici)
- **Android / AndroidTV (ExoPlayer)** : un HEVC (mp4 **et** mkv) doit passer en **Direct Play** (overlay : pas de raison de transcodage) ; vérifier le sniff Content-Type sur l'URL brute sans extension + la bascule qualité raw→HLS.
- **iOS (AVPlayer)** : HEVC mp4/mov en Direct Play.
- **Tizen (AVPlay)** : HEVC → **DirectStream remux** (jamais d'URL brute) ; vérifier que `original` ne casse pas `open()`.
- **webOS** : HEVC mp4 Direct Play ; bascule raw→HLS = reload complet, tester position + seek pendant reload.
- **Diagnostic** : l'overlay stats montre maintenant la vraie raison (`Codec vidéo non supporté` = gap codec ; `Bitrate réduit` = choix qualité).

## Décisions
- Défaut `autoQualityMode = directplay`. Badge « Direct/sans transcode » sur le rung original → follow-up (flag `isRemux` déjà exposé).
