### PR TITLE
fix(player): name audio by source codec in stats overlay, not transcode output

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -671,7 +671,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       formatAudioLabel(
         {
           language: src?.audioLanguage,
-          codec: activeVariant?.audioCodec ?? src?.audioCodec,
+          codec: src?.audioCodec,
           channels: src?.audioChannels,
         },
         this.translate,


### PR DESCRIPTION
## Quoi

Dans les « stats pour les nerds », le nom de la piste audio affichait le codec de **sortie** au lieu du codec **source** quand l'audio était transcodé.

## Pourquoi

Quand une piste audio unique est transcodée (ex. AC3 5.1 → AAC sur un navigateur qui ne lit pas l'AC3 5.1), elle n'est pas listée dans `availableAudioTracks`, donc le nom de l'overlay tombait sur le fallback `formatAudioLabel(...)` avec `activeVariant.audioCodec` = la sortie AAC (`mp4a.40.2`) → « Anglais (MP4A.40.2 - 5.1) ».

## Fix

Le nom identifie la piste **source** → utiliser `src.audioCodec` (« AC3 »). Le codec de sortie reste indiqué sur la ligne « → Transcodage (AAC) ». Les moteurs natifs (Android/iOS) listent la piste avec son label source, donc étaient déjà corrects (bug visible seulement sur desktop/Shaka).

## Vérifié
- Build Angular (`ng build`) exit 0.
- Testé sur desktop : affiche « Anglais (AC3 - 5.1) ».