### PR TITLE
fix(scheduler): align availability gates across SearchMissing and RSS

### DIFF
--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -993,6 +993,7 @@ export class SchedulerService implements OnModuleInit {
     const delayProfiles = await this.delayProfileRepo.find({
       order: { order: 'ASC' },
     });
+    const today = new Date().toISOString().slice(0, 10);
 
     for (let i = 0; i < indexers.length; i++) {
       const indexer = indexers[i];
@@ -1022,6 +1023,9 @@ export class SchedulerService implements OnModuleInit {
           const parsed = parseSeasonEpisode(release.title);
           const movieMatch = this.matchMovieRelease(release, movieCandidates);
           if (movieMatch) {
+            // Same availability gate as SearchMissing: don't grab a title
+            // that hasn't reached its minimum availability yet.
+            if (!this.isAvailable(movieMatch, today)) continue;
             if (this.releaseTooFresh(release, movieMatch, delayProfiles))
               continue;
             await this.grabRssRelease({
@@ -1059,8 +1063,15 @@ export class SchedulerService implements OnModuleInit {
           const onDiskNums = onDiskEpisodeNumbers(season.episodes ?? []);
 
           if (parsed.isFullSeason) {
+            // A pack is only worth grabbing when it covers a monitored,
+            // not-on-disk episode that has already aired — mirroring the
+            // airDate gate SearchMissing applies per episode.
             const wanted = (season.episodes ?? []).some(
-              (e) => e.monitored && !onDiskNums.has(e.episodeNumber),
+              (e) =>
+                e.monitored &&
+                !onDiskNums.has(e.episodeNumber) &&
+                !!e.airDate &&
+                e.airDate <= today,
             );
             if (!wanted) continue;
             packTriedThisPull.add(packKey);
@@ -1086,6 +1097,9 @@ export class SchedulerService implements OnModuleInit {
           );
           if (!ep || !ep.monitored || onDiskNums.has(ep.episodeNumber))
             continue;
+          // Don't grab an episode that hasn't aired yet — same airDate gate
+          // SearchMissing enforces in its query.
+          if (!ep.airDate || ep.airDate > today) continue;
           // Intra-pull Phase 1: a pack for this season was already handed
           // off above; skip the individual episode.
           if (packTriedThisPull.has(packKey)) continue;

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -20,7 +20,7 @@ import {
   onDiskSql,
   onDiskEpisodeNumbers,
 } from '../media/episode-coverage.util';
-import { MediaType, MinimumAvailability } from '../../common/enums';
+import { MediaStatus, MediaType, MinimumAvailability } from '../../common/enums';
 import { ConfigService } from '@nestjs/config';
 import { CompletionService } from './completion.service';
 import { SubtitleSchedulerService } from './subtitle-scheduler.service';
@@ -1470,12 +1470,25 @@ export class SchedulerService implements OnModuleInit {
       case MinimumAvailability.IN_CINEMAS:
         return !!(media.inCinemas && media.inCinemas <= today);
       case MinimumAvailability.RELEASED:
-        return !!(
-          (media.digitalRelease && media.digitalRelease <= today) ||
-          (media.physicalRelease && media.physicalRelease <= today)
-        );
+        // Home-media dates first, then fall back to the cinema date plus a
+        // grace window, the primary release date, and finally the catalogue
+        // status — so titles whose digital/physical dates are absent from the
+        // metadata source (typical for older catalogue films) still resolve.
+        if (media.digitalRelease && media.digitalRelease <= today) return true;
+        if (media.physicalRelease && media.physicalRelease <= today)
+          return true;
+        if (media.inCinemas && this.addDaysIso(media.inCinemas, 90) <= today)
+          return true;
+        if (media.releaseDate && media.releaseDate <= today) return true;
+        return media.status === MediaStatus.RELEASED;
       default:
         return true;
     }
+  }
+
+  private addDaysIso(isoDate: string, days: number): string {
+    const d = new Date(isoDate);
+    d.setUTCDate(d.getUTCDate() + days);
+    return d.toISOString().slice(0, 10);
   }
 }


### PR DESCRIPTION
## What

Aligns the auto-grab availability gates so they behave consistently across **SearchMissing** and **RSS sync**, and fixes date-less released catalogue movies never grabbing.

Closes #442.

## Why

Two related gaps in the availability gating:

1. **Date-less released movies never auto-grab.** `isAvailable()` (`scheduler.service.ts`) gated the `RELEASED` minimum-availability mode purely on `digitalRelease` / `physicalRelease`. The metadata source routinely leaves both null for older catalogue titles (those release types don't exist for them), so they were treated as not-yet-released and skipped on **every** SearchMissing run — via a bare `continue`, with no log. Symptom: an approved request logged a successful release search with many accepted releases, yet nothing was sent to qBittorrent. The manual search modal showed the same grabbable releases because it never gates on availability — hence the confusing asymmetry.

2. **RSS sync ignored availability entirely.** RSS sync grabbed any monitored match regardless of availability, while SearchMissing gates on it. So a feed could pull a movie that hadn't reached its minimum availability, or an episode that hadn't aired — the exact case the sibling pipeline refuses.

## Changes

**`isAvailable()` — fallback cascade for the `RELEASED` mode:**

```
1. digitalRelease ≤ today OR physicalRelease ≤ today   → available  (unchanged)
2. else inCinemas + 90d ≤ today                         → available  (home-media grace window)
3. else releaseDate ≤ today                             → available  (primary release date)
4. else status === RELEASED                             → available  (catalogue backstop, no dates)
else                                                    → not yet available
```

`releaseDate` and `status` are reliably populated from the metadata layer at both manual-add and request-approval, so this resolves date-less catalogue films at once. Genuinely upcoming titles (no past date and `status != released`) stay correctly gated.

**RSS sync — apply the same gates SearchMissing uses:**

- Movies go through `isAvailable()` before grabbing (parity with SearchMissing movies).
- Season packs require a monitored, not-on-disk episode whose `airDate` has passed.
- Individual episodes require `airDate ≤ today` — mirroring the per-episode `airDate` filter SearchMissing applies in its query.

Localized to one file (plus a small ISO date-offset helper). No migration, no DTO change, no import-flow change.

## Testing

`tsc --noEmit` passes. The gated methods are private and the surrounding flow needs live indexers + a download client, so no unit test is added; the cascade and gates are pure logic verified by the typecheck.
