### PR TITLE
perf(requests): return approval immediately and import media out of band

### DIFF
--- a/backend/src/modules/requests/requests.service.ts
+++ b/backend/src/modules/requests/requests.service.ts
@@ -554,11 +554,21 @@ export class RequestsService {
     row.approvedBy = admin;
     row.declinedReason = null;
 
-    // Attribute the new Media row to the requester (not the approving
-    // admin) so the "Afficher uniquement les médias que j'ai demandé"
-    // filter — which matches `addedById = me OR requests.userId = me`
-    // — keeps surfacing it even if the request row is later purged.
-    row.media = await this.ensureMediaForApprovedRequest(
+    const saved = await this.requestRepo.save(row);
+    this.projectEmbeddedUsers(saved);
+    void this.notifications.dispatch('request.approved', {
+      title: saved.title,
+    });
+
+    // The media import (TMDB fetch + image downloads) and the immediate
+    // SearchMissing run out of band: the persisted status flip is all the
+    // client needs to render the approval, so the response returns without
+    // waiting on the network-bound import. The Media row is attributed to
+    // the requester (not the approving admin) so the "only the media I
+    // requested" filter — which matches `addedById = me OR
+    // requests.userId = me` — keeps surfacing it.
+    void this.finalizeApproval(
+      saved.id,
       {
         mediaType: row.mediaType,
         tmdbId: row.tmdbId,
@@ -570,19 +580,44 @@ export class RequestsService {
       row.userId ?? null,
     );
 
-    const saved = await this.requestRepo.save(row);
-    this.projectEmbeddedUsers(saved);
-    void this.notifications.dispatch('request.approved', {
-      title: saved.title,
-    });
-    // Kick an immediate SearchMissing on the approved media so the user
-    // doesn't wait for the next scheduler tick (up to 6 h). The lifecycle
-    // path already does this on auto-approval; the manual approve was the
-    // outlier — fire-and-forget so the HTTP response stays snappy.
-    if (saved.media) {
-      void this.scheduler.searchMissingForMedia([saved.media.id]);
-    }
     return saved;
+  }
+
+  /**
+   * Out-of-band tail of {@link approve}: import (or reuse) the Media row,
+   * link it to the approved request, and trigger an immediate SearchMissing
+   * so the user doesn't wait for the next scheduler tick. Detached from the
+   * HTTP response — failures are logged and leave the request approved but
+   * unlinked rather than surfacing to the already-returned caller.
+   */
+  private async finalizeApproval(
+    requestId: number,
+    spec: {
+      mediaType: MediaType;
+      tmdbId: number;
+      qualityProfileId: number | null;
+      languageProfileId: number | null;
+      libraryId: number | null;
+      seasons: number[] | null;
+    },
+    userId: number | null,
+  ): Promise<void> {
+    try {
+      const media = await this.ensureMediaForApprovedRequest(spec, userId);
+      if (!media) return;
+      // A fresh import links the request inside onMediaImported; the
+      // existing-media path does not, so link here when still unlinked.
+      const req = await this.requestRepo.findOne({ where: { id: requestId } });
+      if (req && req.status === RequestStatus.APPROVED && !req.mediaId) {
+        req.media = media;
+        await this.requestRepo.save(req);
+      }
+      void this.scheduler.searchMissingForMedia([media.id]);
+    } catch (err) {
+      this.logger.warn(
+        `finalizeApproval: request #${requestId} import/link failed: ${(err as Error).message}`,
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
## What

Make request approval return as soon as the status flip is persisted, and run the media import + auto-grab out of band. Applies to both approve entry points (home card and requests page) since they hit the same endpoint.

## Why

`RequestsService.approve()` awaited `ensureMediaForApprovedRequest()` before responding. That call:

- fetches the title from TMDB (1 HTTP call for a movie, 2 for a series), then
- downloads poster / fanart / logo (+ extra fanarts, and per-season/episode art for series) to local storage, then
- persists metadata and runs the lifecycle hook.

All of it was awaited before the HTTP response, so the approve button stayed busy for as long as the network-bound import took (commonly several hundred ms to a few seconds). The `SearchMissing` kick was already fire-and-forget — the import was the bottleneck.

## Change

- Set `status = APPROVED`, save, dispatch the notification, and **return immediately**.
- A detached `finalizeApproval()` then imports/reuses the Media row, links it to the request, and triggers the immediate `SearchMissing`.
- A fresh import links the request through `onMediaImported` (APPROVED is in `IN_FLIGHT_REQUEST_STATUSES`); the existing-media path links inside the finalizer once the row is known.
- Failures are logged and leave the request approved-but-unlinked rather than surfacing to the already-returned caller.

The client only needs the persisted status flip to render the approval, and request cards draw their own cached art (`request.posterUrl` / `fanartUrl`), so the deferred `media` relation doesn't block the UI.

## Behaviour notes / trade-offs

- **Deferred media link:** the approve response no longer carries the `media` relation (it's backfilled async). The frontend patches the row from the response and doesn't listen for request-row updates over SSE, so the "go to library media" link only resolves after the next list refresh. Card art and the Approved status are unaffected.
- **Profile-conflict validation moved out of band:** previously, approving when the title already exists in the library under an incompatible profile returned a synchronous 409. Now approval returns OK and the conflict is logged in `finalizeApproval` (request stays approved but unlinked). If you'd prefer this surfaced — e.g. revert-to-pending or a failure notification — say so and I'll add it.

## Testing

`tsc --noEmit` passes. No unit test added — `approve()`/`finalizeApproval()` depend on TMDB + image-download + scheduler collaborators; the change is a reordering verified by typecheck and trace.
