### PR TITLE
feat(requests): live download progress on requests and media-detail

### DIFF
--- a/backend/src/modules/media/episode-download.service.ts
+++ b/backend/src/modules/media/episode-download.service.ts
@@ -3,10 +3,13 @@ import {
   BadRequestException,
   NotFoundException,
   Logger,
+  Inject,
+  forwardRef,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Media } from './entities/media.entity';
+import { RequestLifecycleService } from '../requests/request-lifecycle.service';
 import { Season } from './entities/season.entity';
 import { Episode } from './entities/episode.entity';
 import { DownloadHistory } from './entities/download-history.entity';
@@ -104,6 +107,8 @@ export class EpisodeDownloadService {
     private readonly notifications: NotificationsService,
     private readonly qualityDefs: QualityDefinitionsService,
     private readonly profiles: ProfilesService,
+    @Inject(forwardRef(() => RequestLifecycleService))
+    private readonly requestLifecycle: RequestLifecycleService,
   ) {}
 
   private allowedQualityIds(
@@ -352,6 +357,14 @@ export class EpisodeDownloadService {
       quality: parsed.quality.name,
       sourceTitle,
     });
+
+    void this.requestLifecycle
+      .onReleaseGrabbed(mediaId, season.seasonNumber)
+      .catch((err) =>
+        this.log.warn(
+          `request-lifecycle: failed to flip requests to PROCESSING for media#${mediaId}: ${(err as Error).message}`,
+        ),
+      );
 
     return saved;
   }
@@ -616,6 +629,13 @@ export class EpisodeDownloadService {
         quality: parsed.quality.name,
         sourceTitle,
       });
+      void this.requestLifecycle
+        .onReleaseGrabbed(mediaId, season.seasonNumber)
+        .catch((err) =>
+          this.log.warn(
+            `request-lifecycle: failed to flip requests to PROCESSING for media#${mediaId}: ${(err as Error).message}`,
+          ),
+        );
       return { grabbed: 1, errors: [] };
     }
 
@@ -713,6 +733,13 @@ export class EpisodeDownloadService {
         quality: bestPack.qualityName,
         sourceTitle: bestPack.title,
       });
+      void this.requestLifecycle
+        .onReleaseGrabbed(mediaId, season.seasonNumber)
+        .catch((err) =>
+          this.log.warn(
+            `request-lifecycle: failed to flip requests to PROCESSING for media#${mediaId}: ${(err as Error).message}`,
+          ),
+        );
       return { grabbed: 1, errors: [] };
     }
 
@@ -831,6 +858,16 @@ export class EpisodeDownloadService {
     );
     if (grabbed === 0 && errors.length === 0) {
       errors.push('No matching release found for any episode in this season');
+    }
+
+    if (grabbed > 0) {
+      void this.requestLifecycle
+        .onReleaseGrabbed(mediaId, season.seasonNumber)
+        .catch((err) =>
+          this.log.warn(
+            `request-lifecycle: failed to flip requests to PROCESSING for media#${mediaId}: ${(err as Error).message}`,
+          ),
+        );
     }
 
     return { grabbed, errors };

--- a/backend/src/modules/media/media-service/media-import.service.ts
+++ b/backend/src/modules/media/media-service/media-import.service.ts
@@ -331,12 +331,15 @@ export class MediaImportService {
     });
     const saved = await this.mediaRepo.save(row);
     this.logLibraryAdded('movie', saved);
-    await this.metadata.downloadMediaImages(saved.id, details);
+    this.metadata.downloadMediaImagesInBackground(saved.id, details);
     await this.metadata.updateSearchVector(saved.id);
-    await this.metadata.persistMediaMetadata(saved, details);
     await this.requestLifecycle.onMediaImported(saved, addedByUserId ?? null);
     const reloaded = await this.mediaRepo.findOne({ where: { id: saved.id } });
     if (!reloaded) throw new Error(`Media #${saved.id} not found after save`);
+    // Cast/crew + per-person enrichment is detail-page data the badge,
+    // monitoring and auto-grab never read; its per-person TMDB fan-out is the
+    // bulk of an import's latency, so it lands after approval returns.
+    this.metadata.persistMediaMetadataInBackground(saved, details);
     return reloaded;
   }
 
@@ -377,7 +380,7 @@ export class MediaImportService {
     });
     const saved = await this.mediaRepo.save(row);
     this.logLibraryAdded('series', saved, `seasons=${seasons.length}`);
-    await this.metadata.downloadMediaImages(saved.id, details);
+    this.metadata.downloadMediaImagesInBackground(saved.id, details);
 
     for (const sd of seasons) {
       const sSaved = await this.seasonRepo.save(
@@ -387,18 +390,20 @@ export class MediaImportService {
           monitored: true,
         }),
       );
-      // Defer to the same per-season routine the metadata refresh uses, so
-      // import and refresh end up with identical episode rows, stills and
-      // season posters — diverging here is exactly what left every episode
-      // sharing the series fanart until a manual refresh.
-      await this.metadata.applySeasonDetails(sSaved, sd);
+      // Reuse the same per-season routine the metadata refresh uses so import
+      // and refresh produce identical episode rows, stills and season posters.
+      // deferImages pushes the still/poster CDN GETs to the background — the
+      // episode rows (which the auto-grab reads) are still written inline.
+      await this.metadata.applySeasonDetails(sSaved, sd, { deferImages: true });
     }
 
     await this.metadata.updateSearchVector(saved.id);
-    await this.metadata.persistMediaMetadata(saved, details);
     await this.requestLifecycle.onMediaImported(saved, addedByUserId ?? null);
     const reloaded = await this.mediaRepo.findOne({ where: { id: saved.id } });
     if (!reloaded) throw new Error(`Media #${saved.id} not found after save`);
+    // See persistImportedMovie: cast/crew enrichment is deferred. Season and
+    // episode rows above stay synchronous because the auto-grab reads them.
+    this.metadata.persistMediaMetadataInBackground(saved, details);
     return reloaded;
   }
 }

--- a/backend/src/modules/media/media-service/media-import.service.ts
+++ b/backend/src/modules/media/media-service/media-import.service.ts
@@ -269,7 +269,7 @@ export class MediaImportService {
    * The library is also required to have a configured `path` — every
    * import flow needs to know where to drop files.
    */
-  private async resolveImportTarget(
+  async resolveImportTarget(
     type: MediaType,
     dto: { libraryId?: number },
   ): Promise<{ libraryId: number }> {

--- a/backend/src/modules/media/media-service/media-metadata.service.ts
+++ b/backend/src/modules/media/media-service/media-metadata.service.ts
@@ -73,6 +73,9 @@ export class MediaMetadataService {
       await this.mediaRepo.update(media.id, {
         ...buildMediaFieldsFromTmdb(details, MediaType.MOVIE),
       });
+      // Refresh keeps images synchronous: a full-library refresh processes one
+      // media at a time, so awaiting here bounds concurrency and lets the UI
+      // track real per-item progress (vs the import path, which defers images).
       await this.downloadMediaImages(media.id, details);
       await this.persistMediaMetadata(media, details);
     } else {
@@ -84,6 +87,7 @@ export class MediaMetadataService {
       await this.mediaRepo.update(media.id, {
         ...buildMediaFieldsFromTmdb(details, MediaType.SERIES),
       });
+      // Refresh keeps images synchronous — see the movie branch above.
       await this.downloadMediaImages(media.id, details);
       await this.persistMediaMetadata(media, details);
       const { insertedCount } = await this.refreshSeriesEpisodes(media, {
@@ -268,6 +272,7 @@ export class MediaMetadataService {
   async applySeasonDetails(
     dbSeason: Season,
     sd: SeasonDetails,
+    opts: { deferImages?: boolean } = {},
   ): Promise<{ insertedCount: number }> {
     const dbEpMap = new Map(
       (dbSeason.episodes ?? []).map((e) => [e.episodeNumber, e]),
@@ -333,14 +338,25 @@ export class MediaMetadataService {
         stillUrl: inserts[i].stillUrl,
       })),
     ];
+    const deferredStills: { episodeId: number; stillUrl: string }[] = [];
     await mapWithConcurrency(jobs, 8, async ({ id, updates, stillUrl }) => {
       if (updates && Object.keys(updates).length > 0) {
         await this.episodeRepo.update(id, updates);
       }
       if (stillUrl) {
-        await this.downloadEpisodeStill(id, stillUrl);
+        if (opts.deferImages) deferredStills.push({ episodeId: id, stillUrl });
+        else await this.downloadEpisodeStill(id, stillUrl);
       }
     });
+
+    if (opts.deferImages) {
+      this.downloadSeasonImagesInBackground(
+        dbSeason.id,
+        deferredStills,
+        sd.posterUrl ?? null,
+      );
+      return { insertedCount: insertedRows.length };
+    }
 
     if (sd.posterUrl) {
       await this.downloadSeasonPoster(dbSeason.id, sd.posterUrl);
@@ -582,6 +598,27 @@ export class MediaMetadataService {
   }
 
   /**
+   * Fire-and-forget variant of {@link downloadMediaImages} for the import path.
+   * The media row is persisted with the source CDN image URLs (displayable
+   * as-is) before this runs, so an import — and the request approval that
+   * awaits it — isn't blocked on the CDN GETs, the slowest part of an import;
+   * the local copies replace the CDN URLs once downloaded. Metadata refresh
+   * keeps images synchronous so its per-item progress stays accurate.
+   */
+  downloadMediaImagesInBackground(
+    mediaId: number,
+    details: MetadataDetails,
+  ): void {
+    void this.downloadMediaImages(mediaId, details).catch((e) =>
+      this.log.warn(
+        `media #${mediaId} image download failed: ${
+          e instanceof Error ? e.message : e
+        }`,
+      ),
+    );
+  }
+
+  /**
    * Download poster + fanart from TMDB and update the media row with local paths.
    */
   async downloadMediaImages(
@@ -701,6 +738,54 @@ export class MediaMetadataService {
     if (local) {
       await this.seasonRepo.update(seasonId, { posterUrl: local });
     }
+  }
+
+  /**
+   * Fire-and-forget the deferred episode stills and season poster for the
+   * import path. The episode and season rows they attach to are already
+   * persisted, so the auto-grab and the monitored badge never wait on these
+   * CDN GETs; refresh downloads them inline so its per-item progress stays
+   * accurate. Concurrency is capped so a many-episode season doesn't open a
+   * download per still.
+   */
+  downloadSeasonImagesInBackground(
+    seasonId: number,
+    stills: { episodeId: number; stillUrl: string }[],
+    posterUrl: string | null,
+  ): void {
+    void (async () => {
+      await mapWithConcurrency(stills, 8, ({ episodeId, stillUrl }) =>
+        this.downloadEpisodeStill(episodeId, stillUrl),
+      );
+      if (posterUrl) await this.downloadSeasonPoster(seasonId, posterUrl);
+    })().catch((e) =>
+      this.log.warn(
+        `season #${seasonId} image download failed: ${
+          e instanceof Error ? e.message : e
+        }`,
+      ),
+    );
+  }
+
+  /**
+   * Fire-and-forget variant of {@link persistMediaMetadata} for the import
+   * path. Cast, crew and per-person enrichment (biographies, avatars) are
+   * detail-page data that the monitored badge, the library link and the
+   * auto-grab never read, yet the per-person TMDB fan-out below dominates an
+   * import's latency — so an import (and the request approval awaiting it)
+   * isn't blocked on it. Metadata refresh keeps it synchronous.
+   */
+  persistMediaMetadataInBackground(
+    media: Media,
+    details: MetadataDetails,
+  ): void {
+    void this.persistMediaMetadata(media, details).catch((e) =>
+      this.log.warn(
+        `media #${media.id} metadata persist failed: ${
+          e instanceof Error ? e.message : e
+        }`,
+      ),
+    );
   }
 
   async persistMediaMetadata(

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -46,6 +46,16 @@ export class MediaService {
     return this.imports.importFromTmdb(dto, addedByUserId);
   }
 
+  /**
+   * Resolve (and validate) the import target library for a media type, or throw
+   * a clear BadRequestException — no default library, missing root path, or
+   * type mismatch. Lets request approval fail loudly up front instead of
+   * importing into the void from the out-of-band tail.
+   */
+  assertImportTarget(type: MediaType, libraryId?: number) {
+    return this.imports.resolveImportTarget(type, { libraryId });
+  }
+
   importMedia(dto: ImportMediaDto, addedByUserId: number | null = null) {
     return this.imports.importMedia(dto, addedByUserId);
   }

--- a/backend/src/modules/media/movie-download.service.ts
+++ b/backend/src/modules/media/movie-download.service.ts
@@ -3,10 +3,13 @@ import {
   BadRequestException,
   NotFoundException,
   Logger,
+  Inject,
+  forwardRef,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Media } from './entities/media.entity';
+import { RequestLifecycleService } from '../requests/request-lifecycle.service';
 import { DownloadHistory } from './entities/download-history.entity';
 import { buildGrabHistoryRow } from './grab-history.util';
 import { Indexer } from '../indexers/entities/indexer.entity';
@@ -95,6 +98,8 @@ export class MovieDownloadService {
     private readonly notifications: NotificationsService,
     private readonly qualityDefs: QualityDefinitionsService,
     private readonly profiles: ProfilesService,
+    @Inject(forwardRef(() => RequestLifecycleService))
+    private readonly requestLifecycle: RequestLifecycleService,
   ) {}
 
   private allowedQualityIds(
@@ -339,6 +344,16 @@ export class MovieDownloadService {
       quality: parsed.quality.name,
       sourceTitle,
     });
+
+    // Flip any APPROVED request for this movie to PROCESSING (the auto-grab
+    // pipeline does this for its grabs; manual grabs route through here).
+    void this.requestLifecycle
+      .onReleaseGrabbed(mediaId)
+      .catch((err) =>
+        this.log.warn(
+          `request-lifecycle: failed to flip requests to PROCESSING for media#${mediaId}: ${(err as Error).message}`,
+        ),
+      );
 
     return saved;
   }

--- a/backend/src/modules/requests/request-lifecycle.service.ts
+++ b/backend/src/modules/requests/request-lifecycle.service.ts
@@ -213,6 +213,27 @@ export class RequestLifecycleService
           mediaType: r.mediaType,
         });
       }
+      // Push a 0% progress event to the requesters so the bar + PROCESSING
+      // state appear immediately, without waiting for the next poll tick.
+      const userIds = [
+        ...new Set(
+          touched
+            .map((r) => r.userId)
+            .filter((id): id is number => id != null),
+        ),
+      ];
+      if (userIds.length) {
+        this.events.emitToUsers(userIds, {
+          type: 'download.progress',
+          mediaId,
+          mediaType: touched[0].mediaType as 'movie' | 'series',
+          seasonNumber,
+          progress: 0,
+          dlspeed: 0,
+          eta: 0,
+          state: 'downloading',
+        });
+      }
     }
   }
 

--- a/backend/src/modules/requests/requests.service.ts
+++ b/backend/src/modules/requests/requests.service.ts
@@ -594,71 +594,73 @@ export class RequestsService {
     row.status = RequestStatus.APPROVED;
     row.approvedBy = admin;
     row.declinedReason = null;
+    await this.requestRepo.save(row);
 
-    const saved = await this.requestRepo.save(row);
-    this.projectEmbeddedUsers(saved);
-    void this.notifications.dispatch('request.approved', {
-      title: saved.title,
-    });
+    // Import (or reuse) the media SYNCHRONOUSLY so the response carries the
+    // real linked + monitored state — the client renders the correct badge
+    // immediately, no SSE/refresh needed. A failure here (TMDB error, profile
+    // conflict) rolls the approval back to PENDING and rethrows so the admin
+    // gets the error as a toast instead of an approved-but-empty request.
+    // Only the post-approval auto-grab (SearchMissing) stays asynchronous —
+    // the slow release search/download must not block the response.
+    let media: Media | null;
+    try {
+      media = await this.ensureMediaForApprovedRequest(
+        {
+          mediaType: row.mediaType,
+          tmdbId: row.tmdbId,
+          qualityProfileId: row.qualityProfileId ?? null,
+          languageProfileId: row.languageProfileId ?? null,
+          libraryId: row.libraryId ?? null,
+          seasons: row.seasons ?? null,
+        },
+        row.userId ?? null,
+      );
+    } catch (err) {
+      row.status = RequestStatus.PENDING;
+      row.approvedBy = null;
+      await this.requestRepo.save(row);
+      throw err;
+    }
 
-    // The media import (TMDB fetch + image downloads) and the immediate
-    // SearchMissing run out of band: the persisted status flip is all the
-    // client needs to render the approval, so the response returns without
-    // waiting on the network-bound import. The Media row is attributed to
-    // the requester (not the approving admin) so the "only the media I
-    // requested" filter — which matches `addedById = me OR
-    // requests.userId = me` — keeps surfacing it.
-    void this.finalizeApproval(
-      saved.id,
-      {
-        mediaType: row.mediaType,
-        tmdbId: row.tmdbId,
-        qualityProfileId: row.qualityProfileId ?? null,
-        languageProfileId: row.languageProfileId ?? null,
-        libraryId: row.libraryId ?? null,
-        seasons: row.seasons ?? null,
-      },
-      row.userId ?? null,
-    );
+    if (media) {
+      // A fresh import links the request inside onMediaImported; the
+      // existing-media path does not, so link here when still unlinked.
+      const linked = await this.requestRepo.findOne({ where: { id } });
+      if (linked && linked.status === RequestStatus.APPROVED && !linked.mediaId) {
+        linked.media = media;
+        await this.requestRepo.save(linked);
+      }
+      void this.scheduler.searchMissingForMedia([media.id]);
+    }
 
-    return saved;
+    void this.notifications.dispatch('request.approved', { title: row.title });
+
+    return this.findResolvedRow(id);
   }
 
   /**
-   * Out-of-band tail of {@link approve}: import (or reuse) the Media row,
-   * link it to the approved request, and trigger an immediate SearchMissing
-   * so the user doesn't wait for the next scheduler tick. Detached from the
-   * HTTP response — failures are logged and leave the request approved but
-   * unlinked rather than surfacing to the already-returned caller.
+   * Fetch a single request with its linked library media resolved by
+   * (tmdbId, type) — mirrors the list query so the monitored badge is accurate
+   * right after approval, without waiting on a list refresh.
    */
-  private async finalizeApproval(
-    requestId: number,
-    spec: {
-      mediaType: MediaType;
-      tmdbId: number;
-      qualityProfileId: number | null;
-      languageProfileId: number | null;
-      libraryId: number | null;
-      seasons: number[] | null;
-    },
-    userId: number | null,
-  ): Promise<void> {
-    try {
-      const media = await this.ensureMediaForApprovedRequest(spec, userId);
-      if (!media) return;
-      // A fresh import links the request inside onMediaImported; the
-      // existing-media path does not, so link here when still unlinked.
-      const req = await this.requestRepo.findOne({ where: { id: requestId } });
-      if (req && req.status === RequestStatus.APPROVED && !req.mediaId) {
-        req.media = media;
-        await this.requestRepo.save(req);
-      }
-      void this.scheduler.searchMissingForMedia([media.id]);
-    } catch (err) {
-      this.logger.warn(
-        `finalizeApproval: request #${requestId} import/link failed: ${(err as Error).message}`,
-      );
-    }
+  private async findResolvedRow(id: number): Promise<FliksRequest> {
+    const row = await this.requestRepo
+      .createQueryBuilder('r')
+      .leftJoin('r.user', 'user')
+      .addSelect(['user.id', 'user.username', 'user.avatar'])
+      .leftJoin('r.approvedBy', 'approvedBy')
+      .addSelect(['approvedBy.id', 'approvedBy.username', 'approvedBy.avatar'])
+      .leftJoinAndMapOne(
+        'r.media',
+        Media,
+        'media',
+        'media."tmdbId" = r."tmdbId" AND media.type::text = r."mediaType"::text',
+      )
+      .where('r.id = :id', { id })
+      .getOne();
+    if (!row) throw new NotFoundException(`Request #${id} not found`);
+    return this.projectEmbeddedUsers(row);
   }
 
   /**

--- a/backend/src/modules/requests/requests.service.ts
+++ b/backend/src/modules/requests/requests.service.ts
@@ -573,6 +573,24 @@ export class RequestsService {
       throw new ConflictException('Request is not pending');
     }
 
+    // Validate up front that the title can land in a library: a new import
+    // needs a resolvable target (the chosen library, or a configured default
+    // for the type). Resolving it here throws a clear error — surfaced to the
+    // admin as a toast — and leaves the request PENDING, instead of flipping to
+    // APPROVED and then failing silently in the out-of-band import tail when no
+    // default library is set. Skipped when the media already exists: that path
+    // only links/monitors, no import is needed.
+    const existingMedia = await this.mediaService.findByTmdbId(
+      row.tmdbId,
+      row.mediaType,
+    );
+    if (!existingMedia) {
+      await this.mediaService.assertImportTarget(
+        row.mediaType,
+        row.libraryId ?? undefined,
+      );
+    }
+
     row.status = RequestStatus.APPROVED;
     row.approvedBy = admin;
     row.declinedReason = null;

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -331,6 +331,9 @@ export class CompletionService {
       await this.reconcileOrphanHistory(allTorrents, grabbed, importing);
     }
 
+    // Push live progress for in-flight grabs to each media's request audience.
+    await this.emitDownloadProgress(allTorrents);
+
     // Phase 3 — import the completed torrents.
     const completedTorrents = allTorrents.filter(
       (t) =>
@@ -437,6 +440,47 @@ export class CompletionService {
    * emitted on any change so the sidebar badge refreshes live rather than
    * staying stale until the next navigation.
    */
+  /**
+   * Push a `download.progress` SSE for every in-flight torrent to that media's
+   * request audience. Reuses the same hash-first matcher as the queue endpoint;
+   * resolves the season/episode scope so a series renders per-season progress.
+   * Recipients are cached per tick so a multi-episode show resolves once.
+   */
+  private async emitDownloadProgress(
+    allTorrents: ReadonlyArray<QbittorrentTorrent>,
+  ): Promise<void> {
+    const downloading = allTorrents.filter((t) => t.progress < 1);
+    if (!downloading.length) return;
+    const rows = await this.historyRepo.find({
+      where: [{ status: 'grabbed' }, { status: 'importing' }],
+      relations: ['media', 'season', 'episode'],
+    });
+    if (!rows.length) return;
+
+    const recipientsByMedia = new Map<number, number[]>();
+    for (const t of downloading) {
+      const match = await this.historyMatcher.matchAndHeal(t, rows);
+      if (!match?.media) continue;
+      let recipients = recipientsByMedia.get(match.mediaId);
+      if (!recipients) {
+        recipients = await this.sseAudience.recipientsForMedia(match.mediaId);
+        recipientsByMedia.set(match.mediaId, recipients);
+      }
+      if (!recipients.length) continue;
+      this.events.emitToUsers(recipients, {
+        type: 'download.progress',
+        mediaId: match.mediaId,
+        mediaType: match.media.type as 'movie' | 'series',
+        seasonNumber: match.season?.seasonNumber,
+        episodeNumber: match.episode?.episodeNumber,
+        progress: t.progress,
+        dlspeed: t.dlspeed,
+        eta: t.eta,
+        state: t.state,
+      });
+    }
+  }
+
   private async reconcileOrphanHistory(
     allTorrents: ReadonlyArray<QbittorrentTorrent>,
     grabbed: DownloadHistory[],
@@ -843,10 +887,22 @@ export class CompletionService {
     const importRecipients = await this.sseAudience.recipientsForMedia(
       media.id,
     );
+    // Single-season series imports carry the season so the client retires only
+    // that season's live progress (other in-flight seasons keep advancing).
+    let importedSeasonNumber: number | undefined;
+    const importedSeasonId = completedPatch.season?.id;
+    if (importedSeasonId != null) {
+      const s = await this.seasonRepo.findOne({
+        where: { id: importedSeasonId },
+        select: ['id', 'seasonNumber'],
+      });
+      importedSeasonNumber = s?.seasonNumber;
+    }
     this.events.emitToUsers(importRecipients, {
       type: 'import.complete',
       mediaId: media.id,
       title: media.title,
+      seasonNumber: importedSeasonNumber,
     });
     this.events.emit({ type: 'queue.updated' });
 

--- a/backend/src/modules/scheduler/events.service.ts
+++ b/backend/src/modules/scheduler/events.service.ts
@@ -30,8 +30,31 @@ export type SseEvent =
       language: string;
       error: string;
     }
-  | { type: 'import.complete'; mediaId: number; title: string }
+  | {
+      type: 'import.complete';
+      mediaId: number;
+      title: string;
+      /** Season whose files just imported (single-season series import); unset
+       *  for movies and multi-season packs. Lets the client retire just that
+       *  season's live progress. */
+      seasonNumber?: number;
+    }
   | { type: 'import.failed'; mediaId: number; title: string; error: string }
+  | {
+      // Live torrent progress for an in-flight grab, delivered to the media's
+      // request audience. `progress` is 0–1; `state` is the raw qBittorrent
+      // state (the client maps it to a label/colour). Season/episode set for
+      // the matched scope of a series.
+      type: 'download.progress';
+      mediaId: number;
+      mediaType: 'movie' | 'series';
+      seasonNumber?: number;
+      episodeNumber?: number;
+      progress: number;
+      dlspeed: number;
+      eta: number;
+      state: string;
+    }
   | { type: 'stalled.removed'; title: string }
   | { type: 'queue.updated' }
   | { type: 'command.started'; name: string }

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -835,12 +835,14 @@
     "media_title_label": "Titre",
     "date_label": "Date · ",
     "seasons_label": "Saisons",
+    "badge_monitored": "Surveillé",
+    "badge_unmonitored": "Non surveillé",
     "status": {
       "pending": "En attente",
       "approved": "Acceptée",
       "declined": "Refusée",
       "processing": "En traitement",
-      "available": "Acceptée",
+      "available": "Téléchargé",
       "failed": "Échec"
     }
   },

--- a/client/src/app/core/services/api/requests.service.ts
+++ b/client/src/app/core/services/api/requests.service.ts
@@ -37,6 +37,10 @@ export interface RequestMedia {
   id: number;
   title: string;
   year: number | null;
+  /** Whether the library media is monitored — an approved request whose media
+   *  is monitored is being worked on (shown as "monitored" rather than just
+   *  "approved"). */
+  monitored?: boolean;
   /** Local `/api/images` paths of the imported media — secondary art source
    *  for requests created before local request art existed. */
   posterUrl: string | null;

--- a/client/src/app/core/services/download-progress.service.ts
+++ b/client/src/app/core/services/download-progress.service.ts
@@ -1,0 +1,175 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { MediaType } from '../enums/media-type.enum';
+import { DownloadClientsApiService } from './api/download-clients-api.service';
+
+/** Live download progress for one media, keyed by `mediaId`. For series the
+ *  `seasons` sub-map holds per-season progress and `percent` is their mean. */
+export interface MediaDownloadProgress {
+  mediaId: number;
+  mediaType: MediaType;
+  percent: number; // 0–100
+  state: string;
+  dlspeed: number;
+  eta: number;
+  seasons?: Map<number, { percent: number; state: string }>;
+}
+
+/** Payload of a `download.progress` SSE event (fields read off the generic
+ *  SseEvent and narrowed by the caller). */
+export interface DownloadProgressEvent {
+  mediaId: number;
+  mediaType: MediaType;
+  seasonNumber?: number;
+  episodeNumber?: number;
+  progress: number; // 0–1
+  dlspeed: number;
+  eta: number;
+  state: string;
+}
+
+function seasonsRollup(seasons: Map<number, { percent: number }>): number {
+  if (seasons.size === 0) return 0;
+  let sum = 0;
+  for (const v of seasons.values()) sum += v.percent;
+  return Math.round(sum / seasons.size);
+}
+
+/**
+ * App-wide store of in-flight download progress, fed primarily by
+ * `download.progress` SSE events (via {@link SseService}) and seeded once from
+ * the download queue when a surface mounts mid-download. One shared signal —
+ * the requests views and media-detail read it by `mediaId`. No client polling.
+ */
+@Injectable({ providedIn: 'root' })
+export class DownloadProgressService {
+  private readonly api = inject(DownloadClientsApiService);
+
+  readonly progress = signal<Map<number, MediaDownloadProgress>>(new Map());
+
+  /** Bumped on every live mutation (SSE apply/clear) so an in-flight seed()
+   *  can detect a fresher update landed during its fetch and not clobber it. */
+  private mutationGen = 0;
+
+  /** Apply a `download.progress` SSE event. Clears the entry on completion. */
+  applyProgress(e: DownloadProgressEvent): void {
+    const percent = Math.round(e.progress * 100);
+    this.mutationGen++;
+    this.progress.update((prev) => {
+      const next = new Map(prev);
+      const isSeriesSeason =
+        e.mediaType === 'series' && e.seasonNumber != null;
+
+      if (e.progress >= 1) {
+        const cur = next.get(e.mediaId);
+        if (cur?.seasons && isSeriesSeason) {
+          const seasons = new Map(cur.seasons);
+          seasons.delete(e.seasonNumber!);
+          if (seasons.size === 0) next.delete(e.mediaId);
+          else
+            next.set(e.mediaId, {
+              ...cur,
+              seasons,
+              percent: seasonsRollup(seasons),
+            });
+        } else {
+          next.delete(e.mediaId);
+        }
+        return next;
+      }
+
+      if (isSeriesSeason) {
+        const cur = next.get(e.mediaId);
+        const seasons = new Map(cur?.seasons ?? []);
+        seasons.set(e.seasonNumber!, { percent, state: e.state });
+        next.set(e.mediaId, {
+          mediaId: e.mediaId,
+          mediaType: 'series',
+          percent: seasonsRollup(seasons),
+          state: e.state,
+          dlspeed: e.dlspeed,
+          eta: e.eta,
+          seasons,
+        });
+      } else {
+        next.set(e.mediaId, {
+          mediaId: e.mediaId,
+          mediaType: e.mediaType,
+          percent,
+          state: e.state,
+          dlspeed: e.dlspeed,
+          eta: e.eta,
+        });
+      }
+      return next;
+    });
+  }
+
+  /** Retire progress for a finished import. With a `seasonNumber` on a series,
+   *  drop only that season (other in-flight seasons keep advancing); otherwise
+   *  drop the whole media entry. */
+  clearMedia(mediaId: number, seasonNumber?: number): void {
+    this.mutationGen++;
+    this.progress.update((prev) => {
+      const cur = prev.get(mediaId);
+      if (!cur) return prev;
+      const next = new Map(prev);
+      if (seasonNumber != null && cur.seasons) {
+        const seasons = new Map(cur.seasons);
+        seasons.delete(seasonNumber);
+        if (seasons.size === 0) next.delete(mediaId);
+        else
+          next.set(mediaId, {
+            ...cur,
+            seasons,
+            percent: seasonsRollup(seasons),
+          });
+      } else {
+        next.delete(mediaId);
+      }
+      return next;
+    });
+  }
+
+  /** Rebuild the map from the current download queue — covers a page opened
+   *  mid-download before the next SSE tick. Rebuilds (never merges) so a
+   *  finished torrent that left the queue drops out. Bails if a live SSE
+   *  mutation landed during the fetch (trusts the fresher live state). */
+  async seed(): Promise<void> {
+    const gen = this.mutationGen;
+    try {
+      const res = await this.api.getQueue({ pageSize: 100 });
+      if (gen !== this.mutationGen) return;
+      const map = new Map<number, MediaDownloadProgress>();
+      for (const it of res.items) {
+        if (it.mediaId == null || it.progress >= 1) continue;
+        const percent = Math.round(it.progress * 100);
+        if (it.mediaType === 'series' && it.seasonNumber != null) {
+          const cur = map.get(it.mediaId);
+          const seasons = new Map(cur?.seasons ?? []);
+          seasons.set(it.seasonNumber, { percent, state: it.state });
+          map.set(it.mediaId, {
+            mediaId: it.mediaId,
+            mediaType: 'series',
+            percent: seasonsRollup(seasons),
+            state: it.state,
+            dlspeed: it.dlspeed,
+            eta: it.eta,
+            seasons,
+          });
+        } else {
+          map.set(it.mediaId, {
+            mediaId: it.mediaId,
+            mediaType: it.mediaType ?? 'movie',
+            percent,
+            state: it.state,
+            dlspeed: it.dlspeed,
+            eta: it.eta,
+          });
+        }
+      }
+      this.progress.set(map);
+    } catch {
+      /* ignore — SSE will populate as events arrive */
+    }
+  }
+}

--- a/client/src/app/core/services/sse.service.ts
+++ b/client/src/app/core/services/sse.service.ts
@@ -3,6 +3,8 @@ import { TranslateService } from '@ngx-translate/core';
 import { ToastService } from './toast.service';
 import { ServerConfigService } from './server-config.service';
 import { AuthService } from './auth.service';
+import { DownloadProgressService } from './download-progress.service';
+import { MediaType } from '../enums/media-type.enum';
 import { invalidatePrefix } from '../interceptors/cache.interceptor';
 
 export interface SseEvent {
@@ -24,6 +26,7 @@ export class SseService implements OnDestroy {
   private readonly translate = inject(TranslateService);
   private readonly serverConfig = inject(ServerConfigService);
   private readonly auth = inject(AuthService);
+  private readonly downloadProgress = inject(DownloadProgressService);
 
   readonly activeProgress = signal<Map<string, TaskProgress>>(new Map());
   readonly lastEvent = signal<SseEvent | null>(null);
@@ -59,8 +62,8 @@ export class SseService implements OnDestroy {
         const data = JSON.parse(event.data) as SseEvent;
         this.handleEvent(data);
         // Don't update lastEvent for high-frequency progress events
-        // (they are handled via activeProgress signal instead)
-        if (data.type !== 'task.progress') {
+        // (handled via dedicated signals/stores instead)
+        if (data.type !== 'task.progress' && data.type !== 'download.progress') {
           this.lastEvent.set(data);
         }
       } catch { /* ignore parse errors */ }
@@ -105,7 +108,25 @@ export class SseService implements OnDestroy {
         void invalidatePrefix('/api/media');
         // Toasts are handled by the media-detail component (only on the right page).
         break;
+      case 'download.progress':
+        this.downloadProgress.applyProgress({
+          mediaId: Number(event['mediaId']),
+          mediaType: event['mediaType'] as MediaType,
+          seasonNumber: event['seasonNumber'] as number | undefined,
+          episodeNumber: event['episodeNumber'] as number | undefined,
+          progress: Number(event['progress']),
+          dlspeed: Number(event['dlspeed'] ?? 0),
+          eta: Number(event['eta'] ?? 0),
+          state: String(event['state'] ?? ''),
+        });
+        break;
       case 'import.complete':
+        // The download finished → retire its live progress (just the imported
+        // season for a series; the whole entry otherwise).
+        this.downloadProgress.clearMedia(
+          Number(event['mediaId']),
+          event['seasonNumber'] as number | undefined,
+        );
         this.toast.success(
           this.translate.instant('sse.import_complete', { title: event['title'] ?? '' }),
         );

--- a/client/src/app/features/activity/queue/queue.html
+++ b/client/src/app/features/activity/queue/queue.html
@@ -150,17 +150,10 @@
             </div>
           </div>
 
-          <div class="w-full bg-base-300 rounded-full h-1.5 overflow-hidden">
-            <div
-              class="h-1.5 rounded-full transition-all duration-500"
-              [class.bg-primary]="item.trackerStatus === 'Downloading' || item.trackerStatus === 'Downloading metadata'"
-              [class.bg-success]="item.trackerStatus === 'Seeding' || item.status === 'Imported'"
-              [class.bg-warning]="item.trackerStatus === 'Stalled' || item.status === 'Importing' || item.status === 'Quality not upgraded'"
-              [class.bg-error]="item.status === 'Import failed'"
-              [class.bg-base-content/20]="item.trackerStatus === 'Paused' || item.trackerStatus === 'Stopped'"
-              [style.width.%]="item.progress * 100"
-            ></div>
-          </div>
+          <app-progress-bar
+            [percent]="item.progress * 100"
+            [variant]="barVariant(item)"
+          />
 
           <div class="flex flex-wrap gap-x-4 gap-y-1 text-sm text-base-content/60">
             <span>{{ (item.progress * 100) | number:'1.1-1' }}%</span>

--- a/client/src/app/features/activity/queue/queue.ts
+++ b/client/src/app/features/activity/queue/queue.ts
@@ -40,10 +40,17 @@ import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 import { DropdownMenuComponent } from '../../../shared/components/dropdown-menu';
 import { PaginationComponent } from '../../../shared/components/pagination/pagination';
 import { ReleasesModalComponent } from '../../media-detail/components/releases-modal/releases-modal.component';
+import { ProgressBarComponent } from '../../../shared/components/progress-bar/progress-bar.component';
+import {
+  ProgressVariant,
+  formatBytes as fmtBytes,
+  formatSpeed as fmtSpeed,
+  formatEta as fmtEta,
+} from '../../../shared/utils/download-format';
 
 @Component({
   selector: 'app-activity-queue',
-  imports: [TranslateModule, DecimalPipe, NgClass, RouterLink, FormsModule, ResolveUrlPipe, DropdownMenuComponent, PaginationComponent, ReleasesModalComponent, LucideRotateCcw, LucideLink2, LucideEllipsisVertical, LucideTriangleAlert, LucideDownload, LucideSearch, LucideTrash2, LucideBan],
+  imports: [TranslateModule, DecimalPipe, NgClass, RouterLink, FormsModule, ResolveUrlPipe, DropdownMenuComponent, PaginationComponent, ReleasesModalComponent, ProgressBarComponent, LucideRotateCcw, LucideLink2, LucideEllipsisVertical, LucideTriangleAlert, LucideDownload, LucideSearch, LucideTrash2, LucideBan],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './queue.html',
 })
@@ -437,25 +444,36 @@ export class ActivityQueueComponent implements OnInit, OnDestroy {
   }
 
   formatBytes(bytes: number): string {
-    if (bytes === 0) return '0 B';
-    const k = 1024;
-    const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
+    return fmtBytes(bytes);
   }
 
   formatSpeed(bytesPerSec: number): string {
-    return `${this.formatBytes(bytesPerSec)}/s`;
+    return fmtSpeed(bytesPerSec);
   }
 
   formatEta(seconds: number): string {
-    if (seconds <= 0 || !isFinite(seconds)) return '—';
-    const h = Math.floor(seconds / 3600);
-    const m = Math.floor((seconds % 3600) / 60);
-    const s = seconds % 60;
-    if (h > 0) return `${h}h ${m}m`;
-    if (m > 0) return `${m}m ${s}s`;
-    return `${s}s`;
+    return fmtEta(seconds);
+  }
+
+  /** Progress-bar colour for a queue row, from its tracker + import status. */
+  barVariant(item: QueueItem): ProgressVariant {
+    if (item.status === 'Import failed') return 'error';
+    if (item.trackerStatus === 'Seeding' || item.status === 'Imported')
+      return 'success';
+    if (
+      item.trackerStatus === 'Stalled' ||
+      item.status === 'Importing' ||
+      item.status === 'Quality not upgraded'
+    )
+      return 'warning';
+    if (item.trackerStatus === 'Paused' || item.trackerStatus === 'Stopped')
+      return 'neutral';
+    if (
+      item.trackerStatus === 'Downloading' ||
+      item.trackerStatus === 'Downloading metadata'
+    )
+      return 'primary';
+    return 'neutral';
   }
 
   appStateClass(status: string): string {

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -7,6 +7,8 @@ import { MediaService, Media, CalendarEntry } from '../../core/services/api/medi
 import { StreamingApiService, ContinueWatchingItem, RecommendationItem } from '../../core/services/api/streaming-api.service';
 import { LibrariesApiService, LibrarySummary } from '../../core/services/api/libraries-api.service';
 import { RequestsService, FliksRequestRow } from '../../core/services/api/requests.service';
+import { SseService } from '../../core/services/sse.service';
+import { DownloadProgressService } from '../../core/services/download-progress.service';
 import { ProfilesService } from '../../core/services/api/profiles.service';
 import { ConfirmationService } from '../../core/services/confirmation.service';
 import { PlayableMediaService } from '../../core/services/playable-media.service';
@@ -83,6 +85,8 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly playableMedia = inject(PlayableMediaService);
   private readonly librariesApi = inject(LibrariesApiService);
   private readonly requestsService = inject(RequestsService);
+  private readonly sse = inject(SseService);
+  private readonly downloadProgress = inject(DownloadProgressService);
   private readonly profilesApi = inject(ProfilesService);
   private readonly scrollMemory = inject(ScrollMemoryService);
   private readonly focusMemory = inject(FocusMemoryService);
@@ -177,6 +181,21 @@ export class HomeComponent implements OnInit, OnDestroy {
       pool.push(...(r.media.additionalFanartUrls ?? []));
     }
     if (pool.length) this.backgroundService.setBackgrounds(pool);
+  });
+
+  /** When a download finishes, refresh the recent-requests row so a monitored
+   *  request flips to its downloaded badge without a manual reload. */
+  private readonly importEffect = effect(() => {
+    const ev = this.sse.lastEvent();
+    if (ev?.type !== 'import.complete') return;
+    const wantRequests = this.visibleSections().some(
+      (s) => s.type === 'requests-recent',
+    );
+    if (!wantRequests) return;
+    this.requestsService
+      .list({ limit: 12 }, { force: true })
+      .then((r) => this.recentRequests.set(r.data))
+      .catch(() => {});
   });
   /** Reactively re-filter the home rows whenever the user flips the
    *  "only my requests" toggle in display settings. Skips the very first
@@ -371,6 +390,16 @@ export class HomeComponent implements OnInit, OnDestroy {
     const wantRequests = this.visibleSections().some(
       (s) => s.type === 'requests-recent',
     );
+    // Seed live download progress so cards opened mid-download show the current
+    // percent before the next SSE tick. Only users allowed to read the queue
+    // (request/media creators) hit the endpoint; others get progress via SSE.
+    if (
+      wantRequests &&
+      (this.auth.hasPermission('requests.create') ||
+        this.auth.hasPermission('media.create'))
+    ) {
+      void this.downloadProgress.seed();
+    }
 
     try {
       const [recent, calendar, libEntries, requests] = await Promise.all([

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -183,6 +183,17 @@
           (openTracking)="openTracking(m.type === 'movie' ? { kind: 'movie' } : { kind: 'series' })"
         />
 
+        @if (activeDownload(); as dl) {
+          <div class="mt-3 flex flex-col gap-1.5">
+            <app-progress-bar [percent]="dl.percent" [variant]="activeDownloadVariant()" />
+            <div class="flex flex-wrap gap-x-3 gap-y-1 text-sm text-base-content/60">
+              <span>{{ dl.percent }}%</span>
+              @if (activeDownloadSpeed(); as sp) { <span>↓ {{ sp }}</span> }
+              @if (activeDownloadEta(); as e) { <span>{{ 'activity.eta' | translate }}: {{ e }}</span> }
+            </div>
+          </div>
+        }
+
         @if (m.type === 'movie') {
           <app-media-info-extra [media]="m" [directors]="directors()" />
         }

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -51,6 +51,13 @@ import { HorizontalScrollerComponent } from '../../shared/components/horizontal-
 import { MediaCardComponent } from '../../shared/components/media-card/media-card';
 import { DownloadQualityModalComponent } from '../../shared/components/download-quality-modal/download-quality-modal';
 import { DownloadManagerService } from '../../core/services/download-manager.service';
+import { ProgressBarComponent } from '../../shared/components/progress-bar/progress-bar.component';
+import { DownloadProgressService } from '../../core/services/download-progress.service';
+import {
+  qbStateVariant,
+  formatSpeed,
+  formatEta,
+} from '../../shared/utils/download-format';
 import {
   filesForEpisode,
   filterSeasonEpisodesOnDisk,
@@ -94,6 +101,7 @@ function readEpisodesHasFileOnlyFromStorage(): boolean {
     HorizontalScrollerComponent,
     MediaCardComponent,
     DownloadQualityModalComponent,
+    ProgressBarComponent,
     RouterLink,
     NgTemplateOutlet,
     ResolveUrlPipe,
@@ -120,6 +128,25 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   private readonly markersApi = inject(MarkersApiService);
   private readonly requestsApi = inject(RequestsService);
   private readonly downloadManager = inject(DownloadManagerService);
+  private readonly downloadProgress = inject(DownloadProgressService);
+
+  /** Live download progress for the media on screen (null when not
+   *  downloading). Fed by `download.progress` SSE + a one-shot seed on load. */
+  readonly activeDownload = computed(() => {
+    const m = this.media();
+    return m ? (this.downloadProgress.progress().get(m.id) ?? null) : null;
+  });
+  readonly activeDownloadSpeed = computed(() => {
+    const d = this.activeDownload();
+    return d && d.dlspeed > 0 ? formatSpeed(d.dlspeed) : null;
+  });
+  readonly activeDownloadEta = computed(() => {
+    const d = this.activeDownload();
+    return d && d.eta > 0 ? formatEta(d.eta) : null;
+  });
+  readonly activeDownloadVariant = computed(() =>
+    qbStateVariant(this.activeDownload()?.state ?? ''),
+  );
   private readonly downloadModal = viewChild<DownloadQualityModalComponent>('downloadModal');
   /** Same SSE payload must run handlers once; `media` updates (e.g. after rescan) re-run this effect. */
   private lastHandledSseEvent: SseEvent | null = null;
@@ -728,6 +755,14 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       // button — admins skip the round-trip).
       if (this.canRequest()) {
         void this.loadTitleState(m.tmdbId, m.type);
+      }
+      // Seed live download progress (users who can request/import may read the
+      // queue; SSE keeps it live after). Plain viewers skip — they get no feed.
+      if (
+        this.auth.hasPermission('requests.create') ||
+        this.auth.hasPermission('media.create')
+      ) {
+        void this.downloadProgress.seed();
       }
       // Load resume + watched episodes + per-episode progress for series
       const [resumeInfo, watchedIds, progress] = await Promise.all([

--- a/client/src/app/features/requests/request-card/request-card.html
+++ b/client/src/app/features/requests/request-card/request-card.html
@@ -19,9 +19,11 @@
     </h3>
 
     <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-base-content/70">
-      <span class="badge badge-sm whitespace-nowrap" [class]="statusBadgeClass(request().status)">
-        {{ ('requests.status.' + request().status) | translate }}
-      </span>
+      <app-progress-badge
+        [label]="badgeLabelKey() | translate"
+        [percent]="progressPercent()"
+        [badgeClass]="badgeClassFor()"
+      />
       <span>
         @if (request().mediaType === 'movie') {
           {{ 'requests.type_movie' | translate }}

--- a/client/src/app/features/requests/request-card/request-card.ts
+++ b/client/src/app/features/requests/request-card/request-card.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  inject,
   input,
   output,
 } from '@angular/core';
@@ -9,6 +10,8 @@ import { DatePipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { RequestPosterComponent } from '../request-poster';
+import { ProgressBadgeComponent } from '../../../shared/components/progress-badge/progress-badge.component';
+import { DownloadProgressService } from '../../../core/services/download-progress.service';
 import {
   FliksRequestRow,
   FliksRequestStatus,
@@ -22,7 +25,13 @@ import {
  */
 @Component({
   selector: 'app-request-card',
-  imports: [DatePipe, RouterLink, TranslateModule, RequestPosterComponent],
+  imports: [
+    DatePipe,
+    RouterLink,
+    TranslateModule,
+    RequestPosterComponent,
+    ProgressBadgeComponent,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   // The host is the scroller flex item: fixed width, and a column flex so the
   // inner card fills the row's stretched height (all cards same height).
@@ -31,6 +40,8 @@ import {
   templateUrl: './request-card.html',
 })
 export class RequestCardComponent {
+  private readonly downloadProgress = inject(DownloadProgressService);
+
   readonly request = input.required<FliksRequestRow>();
   readonly canManage = input(false);
   readonly qualityProfileName = input('—');
@@ -75,5 +86,43 @@ export class RequestCardComponent {
       default:
         return 'badge-ghost';
     }
+  }
+
+  /** Status badge key — approved/processing tracks the media's monitored state;
+   *  available reads as "downloaded". Mirrors the requests page. */
+  badgeLabelKey(): string {
+    const r = this.request();
+    if (r.status === 'approved' || r.status === 'processing') {
+      return r.media?.monitored
+        ? 'requests.badge_monitored'
+        : 'requests.badge_unmonitored';
+    }
+    return 'requests.status.' + r.status;
+  }
+
+  badgeClassFor(): string {
+    const r = this.request();
+    if (r.status === 'approved' || r.status === 'processing') {
+      return r.media?.monitored ? 'badge-info' : 'badge-ghost';
+    }
+    return this.statusBadgeClass(r.status);
+  }
+
+  progressPercent(): number | null {
+    const r = this.request();
+    if (r.status !== 'approved' && r.status !== 'processing') return null;
+    if (!r.media?.monitored) return null;
+    const id = r.media?.id;
+    if (id == null) return null;
+    const p = this.downloadProgress.progress().get(id);
+    if (!p) return null;
+    if (r.seasons?.length && p.seasons) {
+      const vals = r.seasons
+        .map((s) => p.seasons!.get(s)?.percent)
+        .filter((x): x is number => x != null);
+      if (!vals.length) return null;
+      return Math.round(vals.reduce((a, b) => a + b, 0) / vals.length);
+    }
+    return p.percent;
   }
 }

--- a/client/src/app/features/requests/requests.html
+++ b/client/src/app/features/requests/requests.html
@@ -149,12 +149,11 @@
               </h2>
 
               <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-base-content/70">
-                <span
-                  class="badge badge-sm whitespace-nowrap"
-                  [class]="statusBadgeClass(row.status)"
-                >
-                  {{ ('requests.status.' + row.status) | translate }}
-                </span>
+                <app-progress-badge
+                  [label]="badgeLabelKey(row) | translate"
+                  [percent]="progressPercent(row)"
+                  [badgeClass]="badgeClassFor(row)"
+                />
                 <span>
                   @if (row.mediaType === 'movie') {
                     {{ 'requests.type_movie' | translate }}

--- a/client/src/app/features/requests/requests.ts
+++ b/client/src/app/features/requests/requests.ts
@@ -4,6 +4,7 @@ import {
   signal,
   inject,
   computed,
+  effect,
   OnInit,
   OnDestroy,
   viewChild,
@@ -28,6 +29,9 @@ import { RequestDeclineModalComponent } from './request-decline-modal/request-de
 import { RequestViewDeclineModalComponent } from './request-view-decline-modal/request-view-decline-modal.component';
 import { RequestEditModalComponent } from './request-edit-modal/request-edit-modal.component';
 import { DropdownMenuComponent } from '../../shared/components/dropdown-menu';
+import { SseService } from '../../core/services/sse.service';
+import { DownloadProgressService } from '../../core/services/download-progress.service';
+import { ProgressBadgeComponent } from '../../shared/components/progress-badge/progress-badge.component';
 import { LucideEllipsisVertical, LucidePencil, LucideTrash2 } from '@lucide/angular';
 
 @Component({
@@ -42,6 +46,7 @@ import { LucideEllipsisVertical, LucidePencil, LucideTrash2 } from '@lucide/angu
     RequestViewDeclineModalComponent,
     RequestEditModalComponent,
     DropdownMenuComponent,
+    ProgressBadgeComponent,
     LucideEllipsisVertical,
     LucidePencil,
     LucideTrash2,
@@ -56,8 +61,17 @@ export class RequestsComponent implements OnInit, OnDestroy {
   private readonly confirmation = inject(ConfirmationService);
   private readonly toast = inject(ToastService);
   private readonly appResume = inject(AppResumeService);
+  private readonly sse = inject(SseService);
+  private readonly downloadProgress = inject(DownloadProgressService);
   readonly auth = inject(AuthService);
   private resumeSub?: Subscription;
+
+  /** When a download finishes, refetch so a monitored request flips to its
+   *  downloaded state and the progress badge clears. */
+  private readonly importEffect = effect(() => {
+    const ev = this.sse.lastEvent();
+    if (ev?.type === 'import.complete') void this.refreshStatuses();
+  });
 
   private readonly declineModal = viewChild(RequestDeclineModalComponent);
   private readonly viewDeclineModal = viewChild(RequestViewDeclineModalComponent);
@@ -92,9 +106,13 @@ export class RequestsComponent implements OnInit, OnDestroy {
 
   async ngOnInit() {
     this.reload();
+    this.seedProgress();
     // Native app-resume: this page only exists while it's the visible route
     // (no route reuse), so an unguarded reload is always the on-screen one.
-    this.resumeSub = this.appResume.resume$.subscribe(() => this.reload());
+    this.resumeSub = this.appResume.resume$.subscribe(() => {
+      this.reload();
+      this.seedProgress();
+    });
     try {
       const [qp, lp] = await Promise.all([
         this.profilesApi.getQualityProfiles(),
@@ -125,21 +143,54 @@ export class RequestsComponent implements OnInit, OnDestroy {
     this.fetch(false);
   }
 
-  private async fetch(append: boolean) {
+  private async fetch(append: boolean, force = false) {
     this.loading.set(true);
     const status = this.statusFilter();
     try {
-      const res = await this.requestsService.list({
-        page: this.page,
-        limit: 25,
-        ...(status ? { status } : {}),
-      });
+      const res = await this.requestsService.list(
+        {
+          page: this.page,
+          limit: 25,
+          ...(status ? { status } : {}),
+        },
+        { force },
+      );
       this.rows.update((prev) =>
         append ? [...prev, ...res.data] : res.data,
       );
       this.total.set(res.total);
     } finally {
       this.loading.set(false);
+    }
+  }
+
+  /** Seed live download progress only for users allowed to read the download
+   *  queue (request/media creators); others get progress via SSE only. */
+  private seedProgress(): void {
+    if (
+      this.auth.hasPermission('requests.create') ||
+      this.auth.hasPermission('media.create')
+    ) {
+      void this.downloadProgress.seed();
+    }
+  }
+
+  /** Force-refetch the currently-loaded rows so backend status transitions (a
+   *  download finishing → downloaded) surface without a manual reload, while
+   *  preserving the user's loaded page depth. */
+  private async refreshStatuses(): Promise<void> {
+    const status = this.statusFilter();
+    const limit = Math.max(25, this.rows().length);
+    try {
+      const res = await this.requestsService.list(
+        { page: 1, limit, ...(status ? { status } : {}) },
+        { force: true },
+      );
+      this.rows.set(res.data);
+      this.total.set(res.total);
+      this.page = Math.max(1, Math.ceil(res.data.length / 25));
+    } catch {
+      /* ignore — next reload/resume refreshes */
     }
   }
 
@@ -325,6 +376,46 @@ export class RequestsComponent implements OnInit, OnDestroy {
       default:
         return 'badge-ghost';
     }
+  }
+
+  /** Translate key for the status badge. An approved/processing request tracks
+   *  the media's real monitored state ("monitored" / "not monitored");
+   *  available reads as "downloaded". */
+  badgeLabelKey(row: FliksRequestRow): string {
+    if (row.status === 'approved' || row.status === 'processing') {
+      return row.media?.monitored
+        ? 'requests.badge_monitored'
+        : 'requests.badge_unmonitored';
+    }
+    return 'requests.status.' + row.status;
+  }
+
+  badgeClassFor(row: FliksRequestRow): string {
+    if (row.status === 'approved' || row.status === 'processing') {
+      return row.media?.monitored ? 'badge-info' : 'badge-ghost';
+    }
+    return this.statusBadgeClass(row.status);
+  }
+
+  /** Live download percent for a monitored, in-flight request — null when not
+   *  monitored, not downloading, or the media isn't linked yet. For a
+   *  per-season request, averages only the requested seasons (not the whole
+   *  series rollup). */
+  progressPercent(row: FliksRequestRow): number | null {
+    if (row.status !== 'approved' && row.status !== 'processing') return null;
+    if (!row.media?.monitored) return null;
+    const id = row.media?.id;
+    if (id == null) return null;
+    const p = this.downloadProgress.progress().get(id);
+    if (!p) return null;
+    if (row.seasons?.length && p.seasons) {
+      const vals = row.seasons
+        .map((s) => p.seasons!.get(s)?.percent)
+        .filter((x): x is number => x != null);
+      if (!vals.length) return null;
+      return Math.round(vals.reduce((a, b) => a + b, 0) / vals.length);
+    }
+    return p.percent;
   }
 
   qualityProfileDisplay(id: number | null): string {

--- a/client/src/app/shared/components/progress-badge/progress-badge.component.html
+++ b/client/src/app/shared/components/progress-badge/progress-badge.component.html
@@ -1,0 +1,14 @@
+<span
+  class="badge badge-sm whitespace-nowrap relative overflow-hidden"
+  [class]="badgeClass()"
+>
+  @if (percent() !== null) {
+    <span
+      class="absolute inset-y-0 right-0 bg-base-100/40"
+      [style.width.%]="100 - (percent() ?? 0)"
+    ></span>
+  }
+  <span class="relative"
+    >{{ label() }}@if (percent() !== null) { · {{ percent() }}%}</span
+  >
+</span>

--- a/client/src/app/shared/components/progress-badge/progress-badge.component.ts
+++ b/client/src/app/shared/components/progress-badge/progress-badge.component.ts
@@ -1,0 +1,17 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+/** A daisyUI badge that doubles as a progress indicator: when `percent` is set
+ *  the badge fills left-to-right and appends the value. Used by the request
+ *  views to show a download advancing inside the status badge. */
+@Component({
+  selector: 'app-progress-badge',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './progress-badge.component.html',
+})
+export class ProgressBadgeComponent {
+  readonly label = input('');
+  /** 0–100, or null for a plain badge with no progress fill. */
+  readonly percent = input<number | null>(null);
+  /** daisyUI colour class, e.g. `badge-info`. */
+  readonly badgeClass = input('');
+}

--- a/client/src/app/shared/components/progress-bar/progress-bar.component.html
+++ b/client/src/app/shared/components/progress-bar/progress-bar.component.html
@@ -1,0 +1,11 @@
+<div class="w-full bg-base-300 rounded-full h-1.5 overflow-hidden">
+  <div
+    class="h-1.5 rounded-full transition-all duration-500"
+    [class.bg-primary]="variant() === 'primary'"
+    [class.bg-success]="variant() === 'success'"
+    [class.bg-warning]="variant() === 'warning'"
+    [class.bg-error]="variant() === 'error'"
+    [class.bg-base-content/20]="variant() === 'neutral'"
+    [style.width.%]="percent()"
+  ></div>
+</div>

--- a/client/src/app/shared/components/progress-bar/progress-bar.component.ts
+++ b/client/src/app/shared/components/progress-bar/progress-bar.component.ts
@@ -1,0 +1,14 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ProgressVariant } from '../../utils/download-format';
+
+/** Thin reusable progress bar. `percent` is 0–100; `variant` drives the colour.
+ *  Shared by the Activity queue, request rows, and media-detail. */
+@Component({
+  selector: 'app-progress-bar',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './progress-bar.component.html',
+})
+export class ProgressBarComponent {
+  readonly percent = input(0);
+  readonly variant = input<ProgressVariant>('primary');
+}

--- a/client/src/app/shared/utils/download-format.ts
+++ b/client/src/app/shared/utils/download-format.ts
@@ -1,0 +1,66 @@
+/** Shared download-progress formatting + qBittorrent state mapping, used by the
+ *  Activity queue, the request rows, and media-detail so the numbers and the
+ *  progress-bar colour are rendered identically everywhere. */
+
+export type ProgressVariant =
+  | 'primary'
+  | 'success'
+  | 'warning'
+  | 'error'
+  | 'neutral';
+
+export function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
+}
+
+export function formatSpeed(bytesPerSec: number): string {
+  return `${formatBytes(bytesPerSec)}/s`;
+}
+
+export function formatEta(seconds: number): string {
+  if (seconds <= 0 || !isFinite(seconds)) return '—';
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+/** Map a raw qBittorrent torrent state to a progress-bar colour variant. */
+export function qbStateVariant(state: string): ProgressVariant {
+  switch (state) {
+    case 'downloading':
+    case 'forcedDL':
+    case 'metaDL':
+    case 'forcedMetaDL':
+    case 'allocating':
+      return 'primary';
+    case 'uploading':
+    case 'stalledUP':
+    case 'forcedUP':
+    case 'queuedUP':
+    case 'checkingUP':
+      return 'success';
+    case 'stalledDL':
+    case 'queuedDL':
+    case 'checkingDL':
+    case 'checkingResumeData':
+    case 'moving':
+      return 'warning';
+    case 'error':
+    case 'missingFiles':
+      return 'error';
+    case 'pausedDL':
+    case 'pausedUP':
+    case 'stoppedDL':
+    case 'stoppedUP':
+      return 'neutral';
+    default:
+      return 'primary';
+  }
+}


### PR DESCRIPTION
## What

Live download progress (%) wherever a downloading media appears — the requests views and the media-detail page — plus a fix so a request reliably reaches its monitored/downloaded state, including after a **manual** grab.

## Why

A downloading title showed no progress, and a request created earlier (still APPROVED at grab time) never moved to PROCESSING when an admin grabbed a release manually — only the auto-grab pipeline flipped it.

## Backend

- **`download.progress` SSE event** (`events.service.ts`) emitted to each media's request audience (`recipientsForMedia`) from the existing **every-minute** `processCompleted` qBittorrent poll (`completion.service.ts`, reusing `TorrentHistoryMatcher`), plus an immediate **0%** emit on grab (`onReleaseGrabbed`) so the bar/badge appear at once instead of up to ~60 s later.
- **Manual-grab fix:** `movie-download.service.ts` `grabMovie`, `episode-download.service.ts` `grabEpisode` + `grabSeason` (all branches) now call `requestLifecycle.onReleaseGrabbed(mediaId[, seasonNumber])` after recording the grab — mirroring the auto path (`auto-grab-pipeline.service.ts`). Injected via `@Inject(forwardRef(() => RequestLifecycleService))`.
- `import.complete` now carries the imported `seasonNumber` so the client retires only that season's progress on a multi-season series.

## Frontend

- **`DownloadProgressService`** root signal store, fed by SSE (`download.progress`) and seeded once from `GET /api/download-clients/queue` on mount (rebuild-not-merge, guarded against clobbering concurrent live updates, gated on the download-client read permission).
- Shared **`<app-progress-bar>`** (Activity queue refactored onto it + media-detail) and **`<app-progress-badge>`** components; shared format/colour helpers extracted from the queue page.
- **Requests page + home cards:** the status badge tracks the media's **real monitored state** — monitored → **"Surveillé"** with the download percent filling the badge; not monitored → **"Non surveillé"**; a finished request reads **"Téléchargé"**. Per-season requests average only their requested seasons. Status refresh on `import.complete` preserves the loaded page depth.
- **media-detail:** live percent + speed/ETA bar while downloading.

## Notes
- Granularity is ~60 s (the existing minute cron) plus instant transitions on grab and import.
- Adversarially reviewed; the multi-season clear, paginated-list reset, seed permission/race, and per-season badge-scope issues surfaced by the review are fixed in this branch.

## Testing
- Backend `tsc --noEmit` clean; frontend `ng build` clean (only the pre-existing shaka-player CommonJS warning).
- A Docker test image is built from this branch via the **Publish Docker image** workflow (tag `download-progress`) for end-to-end testing against a real qBittorrent.
- Manual end-to-end: approve a request, let it sit APPROVED, manually grab → flips to **Surveillé** with an advancing % badge; media-detail shows the bar; on import it reads **Téléchargé**; a per-season series grab advances only that season.
