### PR TITLE
feat(media-detail): clickable download status badge with detail modal

### DIFF
--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -653,6 +653,7 @@
     "analyze_launch_error": "Impossible de lancer l'analyse",
     "not_found": "Contenu introuvable",
     "download_section": "Téléchargement",
+    "download_detail_title": "Téléchargement en cours",
     "quality_profile_label": "Profil de qualité",
     "no_quality_profile": "Aucun profil de qualité : configurez-en un (ou réimportez) pour activer la recherche de releases.",
     "search_releases": "Chercher des releases",
@@ -837,6 +838,7 @@
     "seasons_label": "Saisons",
     "badge_monitored": "Surveillé",
     "badge_unmonitored": "Non surveillé",
+    "badge_downloading": "Téléchargement",
     "status": {
       "pending": "En attente",
       "approved": "Acceptée",

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -181,18 +181,9 @@
           (editSubtitles)="openSubtitles()"
           (requestMedia)="openRequestForMedia()"
           (openTracking)="openTracking(m.type === 'movie' ? { kind: 'movie' } : { kind: 'series' })"
+          [badge]="headerBadge()"
+          (openDownloadDetail)="openDownloadDetailModal()"
         />
-
-        @if (activeDownload(); as dl) {
-          <div class="mt-3 flex flex-col gap-1.5">
-            <app-progress-bar [percent]="dl.percent" [variant]="activeDownloadVariant()" />
-            <div class="flex flex-wrap gap-x-3 gap-y-1 text-sm text-base-content/60">
-              <span>{{ dl.percent }}%</span>
-              @if (activeDownloadSpeed(); as sp) { <span>↓ {{ sp }}</span> }
-              @if (activeDownloadEta(); as e) { <span>{{ 'activity.eta' | translate }}: {{ e }}</span> }
-            </div>
-          </div>
-        }
 
         @if (m.type === 'movie') {
           <app-media-info-extra [media]="m" [directors]="directors()" />
@@ -328,6 +319,7 @@
         (save)="saveLibrary()"
       />
       <app-download-quality-modal #downloadModal (download)="onDownload($event)" />
+      <app-download-detail-modal #downloadDetailModal [progress]="activeDownload()" />
     </div>
 
   }

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -34,7 +34,10 @@ import { BackgroundService } from '../../core/services/background.service';
 import { StreamingApiService, MediaResumeInfo } from '../../core/services/api/streaming-api.service';
 import { MarkersApiService } from '../../core/services/api/markers-api.service';
 import { RequestsService, TitleRequestState } from '../../core/services/api/requests.service';
-import { MediaInfoHeaderComponent } from '../../shared/components/media-info-header/media-info-header';
+import {
+  MediaInfoHeaderComponent,
+  MediaInfoHeaderBadge,
+} from '../../shared/components/media-info-header/media-info-header';
 import { MediaInfoExtraComponent } from '../../shared/components/media-info-extra/media-info-extra';
 import { SubtitlesModalComponent } from '../../shared/components/subtitles-modal/subtitles-modal';
 import { MediaFileInfoComponent } from '../../shared/components/media-file-info';
@@ -51,13 +54,8 @@ import { HorizontalScrollerComponent } from '../../shared/components/horizontal-
 import { MediaCardComponent } from '../../shared/components/media-card/media-card';
 import { DownloadQualityModalComponent } from '../../shared/components/download-quality-modal/download-quality-modal';
 import { DownloadManagerService } from '../../core/services/download-manager.service';
-import { ProgressBarComponent } from '../../shared/components/progress-bar/progress-bar.component';
+import { DownloadDetailModalComponent } from '../../shared/components/download-detail-modal/download-detail-modal';
 import { DownloadProgressService } from '../../core/services/download-progress.service';
-import {
-  qbStateVariant,
-  formatSpeed,
-  formatEta,
-} from '../../shared/utils/download-format';
 import {
   filesForEpisode,
   filterSeasonEpisodesOnDisk,
@@ -101,7 +99,7 @@ function readEpisodesHasFileOnlyFromStorage(): boolean {
     HorizontalScrollerComponent,
     MediaCardComponent,
     DownloadQualityModalComponent,
-    ProgressBarComponent,
+    DownloadDetailModalComponent,
     RouterLink,
     NgTemplateOutlet,
     ResolveUrlPipe,
@@ -136,18 +134,47 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     const m = this.media();
     return m ? (this.downloadProgress.progress().get(m.id) ?? null) : null;
   });
-  readonly activeDownloadSpeed = computed(() => {
-    const d = this.activeDownload();
-    return d && d.dlspeed > 0 ? formatSpeed(d.dlspeed) : null;
+
+  /** Status badge shown next to the kebab on the movie/series header. Hidden
+   *  once the content is downloaded (movie file present / every episode in).
+   *  While a download is in flight it shows the mean percent and is clickable
+   *  (opens the detail modal); otherwise it reflects the monitored state. */
+  readonly headerBadge = computed<MediaInfoHeaderBadge | null>(() => {
+    const m = this.media();
+    if (!m) return null;
+    const downloaded =
+      m.type === 'series'
+        ? !!m.episodeStats &&
+          m.episodeStats.totalEpisodes > 0 &&
+          m.episodeStats.downloadedEpisodes >= m.episodeStats.totalEpisodes
+        : this.mediaFiles().length > 0;
+    if (downloaded) return null;
+    const dl = this.activeDownload();
+    if (dl) {
+      return {
+        labelKey: 'activity.tstatus_downloading',
+        percent: dl.percent,
+        badgeClass: 'badge-info',
+        clickable: true,
+      };
+    }
+    return m.monitored
+      ? {
+          labelKey: 'requests.badge_monitored',
+          percent: null,
+          badgeClass: 'badge-info',
+          clickable: false,
+        }
+      : {
+          labelKey: 'requests.badge_unmonitored',
+          percent: null,
+          badgeClass: 'badge-ghost',
+          clickable: false,
+        };
   });
-  readonly activeDownloadEta = computed(() => {
-    const d = this.activeDownload();
-    return d && d.eta > 0 ? formatEta(d.eta) : null;
-  });
-  readonly activeDownloadVariant = computed(() =>
-    qbStateVariant(this.activeDownload()?.state ?? ''),
-  );
   private readonly downloadModal = viewChild<DownloadQualityModalComponent>('downloadModal');
+  private readonly downloadDetailModal =
+    viewChild<DownloadDetailModalComponent>('downloadDetailModal');
   /** Same SSE payload must run handlers once; `media` updates (e.g. after rescan) re-run this effect. */
   private lastHandledSseEvent: SseEvent | null = null;
 
@@ -1076,6 +1103,10 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   openDownloadModal() {
     const fileId = this.episodeMode() ? this.episodeActiveFileId() : this.activeFileId();
     if (fileId) this.downloadModal()?.open(fileId);
+  }
+
+  openDownloadDetailModal() {
+    this.downloadDetailModal()?.open();
   }
 
   openSubtitles() {

--- a/client/src/app/features/requests/request-card/request-card.html
+++ b/client/src/app/features/requests/request-card/request-card.html
@@ -19,11 +19,7 @@
     </h3>
 
     <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-base-content/70">
-      <app-progress-badge
-        [label]="badgeLabelKey() | translate"
-        [percent]="progressPercent()"
-        [badgeClass]="badgeClassFor()"
-      />
+      <app-request-status-badge [request]="request()" />
       <span>
         @if (request().mediaType === 'movie') {
           {{ 'requests.type_movie' | translate }}

--- a/client/src/app/features/requests/request-card/request-card.ts
+++ b/client/src/app/features/requests/request-card/request-card.ts
@@ -2,7 +2,6 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
-  inject,
   input,
   output,
 } from '@angular/core';
@@ -10,12 +9,8 @@ import { DatePipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { RequestPosterComponent } from '../request-poster';
-import { ProgressBadgeComponent } from '../../../shared/components/progress-badge/progress-badge.component';
-import { DownloadProgressService } from '../../../core/services/download-progress.service';
-import {
-  FliksRequestRow,
-  FliksRequestStatus,
-} from '../../../core/services/api/requests.service';
+import { RequestStatusBadgeComponent } from '../request-status-badge/request-status-badge.component';
+import { FliksRequestRow } from '../../../core/services/api/requests.service';
 
 /**
  * Compact request card for the home "Demandes récentes" scroller: a fanart
@@ -30,7 +25,7 @@ import {
     RouterLink,
     TranslateModule,
     RequestPosterComponent,
-    ProgressBadgeComponent,
+    RequestStatusBadgeComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   // The host is the scroller flex item: fixed width, and a column flex so the
@@ -40,8 +35,6 @@ import {
   templateUrl: './request-card.html',
 })
 export class RequestCardComponent {
-  private readonly downloadProgress = inject(DownloadProgressService);
-
   readonly request = input.required<FliksRequestRow>();
   readonly canManage = input(false);
   readonly qualityProfileName = input('—');
@@ -71,58 +64,4 @@ export class RequestCardComponent {
       : ['/add', 'tv', r.tmdbId];
   });
 
-  statusBadgeClass(status: FliksRequestStatus): string {
-    switch (status) {
-      case 'pending':
-        return 'badge-warning';
-      case 'approved':
-      case 'available':
-        return 'badge-success';
-      case 'declined':
-      case 'failed':
-        return 'badge-error';
-      case 'processing':
-        return 'badge-info';
-      default:
-        return 'badge-ghost';
-    }
-  }
-
-  /** Status badge key — approved/processing tracks the media's monitored state;
-   *  available reads as "downloaded". Mirrors the requests page. */
-  badgeLabelKey(): string {
-    const r = this.request();
-    if (r.status === 'approved' || r.status === 'processing') {
-      return r.media?.monitored
-        ? 'requests.badge_monitored'
-        : 'requests.badge_unmonitored';
-    }
-    return 'requests.status.' + r.status;
-  }
-
-  badgeClassFor(): string {
-    const r = this.request();
-    if (r.status === 'approved' || r.status === 'processing') {
-      return r.media?.monitored ? 'badge-info' : 'badge-ghost';
-    }
-    return this.statusBadgeClass(r.status);
-  }
-
-  progressPercent(): number | null {
-    const r = this.request();
-    if (r.status !== 'approved' && r.status !== 'processing') return null;
-    if (!r.media?.monitored) return null;
-    const id = r.media?.id;
-    if (id == null) return null;
-    const p = this.downloadProgress.progress().get(id);
-    if (!p) return null;
-    if (r.seasons?.length && p.seasons) {
-      const vals = r.seasons
-        .map((s) => p.seasons!.get(s)?.percent)
-        .filter((x): x is number => x != null);
-      if (!vals.length) return null;
-      return Math.round(vals.reduce((a, b) => a + b, 0) / vals.length);
-    }
-    return p.percent;
-  }
 }

--- a/client/src/app/features/requests/request-status-badge/request-status-badge.component.html
+++ b/client/src/app/features/requests/request-status-badge/request-status-badge.component.html
@@ -1,0 +1,5 @@
+<app-progress-badge
+  [label]="labelKey() | translate"
+  [percent]="percent()"
+  [badgeClass]="badgeClass()"
+/>

--- a/client/src/app/features/requests/request-status-badge/request-status-badge.component.ts
+++ b/client/src/app/features/requests/request-status-badge/request-status-badge.component.ts
@@ -1,0 +1,91 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+} from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { ProgressBadgeComponent } from '../../../shared/components/progress-badge/progress-badge.component';
+import { DownloadProgressService } from '../../../core/services/download-progress.service';
+import {
+  FliksRequestRow,
+  FliksRequestStatus,
+} from '../../../core/services/api/requests.service';
+
+/**
+ * Status badge for a request row, shared by the requests list and the home
+ * request card so the label, colour and live download percent are computed in
+ * one place. An approved/processing request with an in-flight download reads as
+ * "downloading" (with the mean percent, per-season requests averaging only
+ * their requested seasons); otherwise it tracks the media's monitored state.
+ * Other statuses (pending, declined, available…) read as their status label.
+ */
+@Component({
+  selector: 'app-request-status-badge',
+  standalone: true,
+  imports: [TranslateModule, ProgressBadgeComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  // Transparent to layout so the inner badge stays the flex item it replaced.
+  host: { class: 'contents' },
+  templateUrl: './request-status-badge.component.html',
+})
+export class RequestStatusBadgeComponent {
+  private readonly downloadProgress = inject(DownloadProgressService);
+
+  readonly request = input.required<FliksRequestRow>();
+
+  readonly percent = computed<number | null>(() => {
+    const r = this.request();
+    if (r.status !== 'approved' && r.status !== 'processing') return null;
+    if (!r.media?.monitored) return null;
+    const id = r.media?.id;
+    if (id == null) return null;
+    const p = this.downloadProgress.progress().get(id);
+    if (!p) return null;
+    if (r.seasons?.length && p.seasons) {
+      const vals = r.seasons
+        .map((s) => p.seasons!.get(s)?.percent)
+        .filter((x): x is number => x != null);
+      if (!vals.length) return null;
+      return Math.round(vals.reduce((a, b) => a + b, 0) / vals.length);
+    }
+    return p.percent;
+  });
+
+  readonly labelKey = computed<string>(() => {
+    const r = this.request();
+    if (r.status === 'approved' || r.status === 'processing') {
+      if (this.percent() !== null) return 'requests.badge_downloading';
+      return r.media?.monitored
+        ? 'requests.badge_monitored'
+        : 'requests.badge_unmonitored';
+    }
+    return 'requests.status.' + r.status;
+  });
+
+  readonly badgeClass = computed<string>(() => {
+    const r = this.request();
+    if (r.status === 'approved' || r.status === 'processing') {
+      return r.media?.monitored ? 'badge-info' : 'badge-ghost';
+    }
+    return this.statusBadgeClass(r.status);
+  });
+
+  private statusBadgeClass(status: FliksRequestStatus): string {
+    switch (status) {
+      case 'pending':
+        return 'badge-warning';
+      case 'approved':
+      case 'available':
+        return 'badge-success';
+      case 'declined':
+      case 'failed':
+        return 'badge-error';
+      case 'processing':
+        return 'badge-info';
+      default:
+        return 'badge-ghost';
+    }
+  }
+}

--- a/client/src/app/features/requests/requests.html
+++ b/client/src/app/features/requests/requests.html
@@ -149,11 +149,7 @@
               </h2>
 
               <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-base-content/70">
-                <app-progress-badge
-                  [label]="badgeLabelKey(row) | translate"
-                  [percent]="progressPercent(row)"
-                  [badgeClass]="badgeClassFor(row)"
-                />
+                <app-request-status-badge [request]="row" />
                 <span>
                   @if (row.mediaType === 'movie') {
                     {{ 'requests.type_movie' | translate }}

--- a/client/src/app/features/requests/requests.ts
+++ b/client/src/app/features/requests/requests.ts
@@ -31,7 +31,7 @@ import { RequestEditModalComponent } from './request-edit-modal/request-edit-mod
 import { DropdownMenuComponent } from '../../shared/components/dropdown-menu';
 import { SseService } from '../../core/services/sse.service';
 import { DownloadProgressService } from '../../core/services/download-progress.service';
-import { ProgressBadgeComponent } from '../../shared/components/progress-badge/progress-badge.component';
+import { RequestStatusBadgeComponent } from './request-status-badge/request-status-badge.component';
 import { LucideEllipsisVertical, LucidePencil, LucideTrash2 } from '@lucide/angular';
 
 @Component({
@@ -46,7 +46,7 @@ import { LucideEllipsisVertical, LucidePencil, LucideTrash2 } from '@lucide/angu
     RequestViewDeclineModalComponent,
     RequestEditModalComponent,
     DropdownMenuComponent,
-    ProgressBadgeComponent,
+    RequestStatusBadgeComponent,
     LucideEllipsisVertical,
     LucidePencil,
     LucideTrash2,
@@ -361,62 +361,6 @@ export class RequestsComponent implements OnInit, OnDestroy {
       : ['/add', 'tv', row.tmdbId];
   }
 
-  statusBadgeClass(status: FliksRequestStatus): string {
-    switch (status) {
-      case 'pending':
-        return 'badge-warning';
-      case 'approved':
-      case 'available':
-        return 'badge-success';
-      case 'declined':
-      case 'failed':
-        return 'badge-error';
-      case 'processing':
-        return 'badge-info';
-      default:
-        return 'badge-ghost';
-    }
-  }
-
-  /** Translate key for the status badge. An approved/processing request tracks
-   *  the media's real monitored state ("monitored" / "not monitored");
-   *  available reads as "downloaded". */
-  badgeLabelKey(row: FliksRequestRow): string {
-    if (row.status === 'approved' || row.status === 'processing') {
-      return row.media?.monitored
-        ? 'requests.badge_monitored'
-        : 'requests.badge_unmonitored';
-    }
-    return 'requests.status.' + row.status;
-  }
-
-  badgeClassFor(row: FliksRequestRow): string {
-    if (row.status === 'approved' || row.status === 'processing') {
-      return row.media?.monitored ? 'badge-info' : 'badge-ghost';
-    }
-    return this.statusBadgeClass(row.status);
-  }
-
-  /** Live download percent for a monitored, in-flight request — null when not
-   *  monitored, not downloading, or the media isn't linked yet. For a
-   *  per-season request, averages only the requested seasons (not the whole
-   *  series rollup). */
-  progressPercent(row: FliksRequestRow): number | null {
-    if (row.status !== 'approved' && row.status !== 'processing') return null;
-    if (!row.media?.monitored) return null;
-    const id = row.media?.id;
-    if (id == null) return null;
-    const p = this.downloadProgress.progress().get(id);
-    if (!p) return null;
-    if (row.seasons?.length && p.seasons) {
-      const vals = row.seasons
-        .map((s) => p.seasons!.get(s)?.percent)
-        .filter((x): x is number => x != null);
-      if (!vals.length) return null;
-      return Math.round(vals.reduce((a, b) => a + b, 0) / vals.length);
-    }
-    return p.percent;
-  }
 
   qualityProfileDisplay(id: number | null): string {
     if (id == null) return '—';

--- a/client/src/app/shared/components/download-detail-modal/download-detail-modal.html
+++ b/client/src/app/shared/components/download-detail-modal/download-detail-modal.html
@@ -1,0 +1,45 @@
+<dialog #dialog class="modal">
+  <div class="modal-box max-w-lg">
+    <form method="dialog">
+      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+    </form>
+    <h3 class="text-lg font-bold mb-4">{{ 'media_detail.download_detail_title' | translate }}</h3>
+
+    @if (progress(); as p) {
+      <div class="flex flex-col gap-1.5">
+        <app-progress-bar [percent]="p.percent" [variant]="overallVariant()" />
+        <div class="flex flex-wrap gap-x-3 gap-y-1 text-sm text-base-content/60">
+          <span class="tabular-nums">{{ p.percent }}%</span>
+          @if (speedLabel(); as sp) { <span>↓ {{ sp }}</span> }
+          @if (etaLabel(); as e) { <span>{{ 'activity.eta' | translate }}: {{ e }}</span> }
+        </div>
+      </div>
+
+      @if (seasonRows().length) {
+        <div class="divider my-3"></div>
+        <div class="flex flex-col gap-3 max-h-[50vh] overflow-y-auto">
+          @for (s of seasonRows(); track s.seasonNumber) {
+            <div class="flex flex-col gap-1">
+              <div class="flex items-center justify-between gap-3">
+                <span class="text-sm font-medium">{{ 'tracking.season' | translate:{ number: s.seasonNumber } }}</span>
+                <span class="text-sm tabular-nums text-base-content/60">{{ s.percent }}%</span>
+              </div>
+              <app-progress-bar [percent]="s.percent" [variant]="s.variant" />
+            </div>
+          }
+        </div>
+      }
+    } @else {
+      <p class="text-sm text-base-content/50 py-4 text-center">
+        {{ 'activity.queue_empty' | translate }}
+      </p>
+    }
+
+    <div class="modal-action">
+      <button type="button" class="btn btn-sm" (click)="close()">
+        {{ 'common.close' | translate }}
+      </button>
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+</dialog>

--- a/client/src/app/shared/components/download-detail-modal/download-detail-modal.ts
+++ b/client/src/app/shared/components/download-detail-modal/download-detail-modal.ts
@@ -1,0 +1,72 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  computed,
+  input,
+  viewChild,
+} from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { MediaDownloadProgress } from '../../../core/services/download-progress.service';
+import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
+import {
+  qbStateVariant,
+  formatSpeed,
+  formatEta,
+  ProgressVariant,
+} from '../../utils/download-format';
+
+/**
+ * Detail view behind the header download badge. The header badge shows only the
+ * mean percent (a single chip can't faithfully represent several concurrent
+ * season/pack downloads); opening this modal breaks that mean down into the
+ * overall speed/ETA and a per-season progress list. The parent passes its live
+ * `activeDownload()` so the modal keeps updating from SSE while it stays open.
+ */
+@Component({
+  selector: 'app-download-detail-modal',
+  standalone: true,
+  imports: [TranslateModule, ProgressBarComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './download-detail-modal.html',
+})
+export class DownloadDetailModalComponent {
+  readonly progress = input<MediaDownloadProgress | null>(null);
+
+  private readonly dialog =
+    viewChild<ElementRef<HTMLDialogElement>>('dialog');
+
+  readonly overallVariant = computed<ProgressVariant>(() =>
+    qbStateVariant(this.progress()?.state ?? ''),
+  );
+  readonly speedLabel = computed(() => {
+    const d = this.progress();
+    return d && d.dlspeed > 0 ? formatSpeed(d.dlspeed) : null;
+  });
+  readonly etaLabel = computed(() => {
+    const d = this.progress();
+    return d && d.eta > 0 ? formatEta(d.eta) : null;
+  });
+
+  /** Per-season rows for a series, sorted by season number. Empty for a movie
+   *  or a series downloaded as one flat torrent. */
+  readonly seasonRows = computed(() => {
+    const seasons = this.progress()?.seasons;
+    if (!seasons) return [];
+    return [...seasons.entries()]
+      .sort((a, b) => a[0] - b[0])
+      .map(([seasonNumber, v]) => ({
+        seasonNumber,
+        percent: v.percent,
+        variant: qbStateVariant(v.state),
+      }));
+  });
+
+  open(): void {
+    this.dialog()?.nativeElement.showModal();
+  }
+
+  close(): void {
+    this.dialog()?.nativeElement.close();
+  }
+}

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -80,8 +80,16 @@
     }
 
     <!-- Action icons row -->
-    <div class="flex items-center justify-center gap-6 mt-4">
-      @if (!selectedFileId()) { <div class="flex-1"></div> }
+    <div
+      class="flex items-center gap-6 mt-4"
+      [class.justify-between]="badge()"
+      [class.justify-center]="!badge()"
+    >
+      @if (badge()) {
+        <ng-container *ngTemplateOutlet="downloadBadge"></ng-container>
+      } @else if (!selectedFileId()) {
+        <div class="flex-1"></div>
+      }
       @if (selectedFileId()) {
         <button class="flex flex-col items-center gap-1 text-sm" [class.text-success]="watched()" (click)="onToggleWatched()">
           <svg lucideCheck class="h-5 w-5"></svg>
@@ -268,6 +276,7 @@
             </button>
           }
         }
+        <ng-container *ngTemplateOutlet="downloadBadge"></ng-container>
         <app-dropdown-menu placement="bottom-end">
           <button trigger type="button" class="btn btn-ghost btn btn-circle">
             <svg lucideEllipsisVertical class="h-5 w-5"></svg>
@@ -314,6 +323,34 @@
     </div>
   </div>
 </div>
+
+<!-- Download status / progress chip, shared by the mobile metadata row and the
+     desktop action row. Clickable (opens the detail modal) only while a grab is
+     in flight; otherwise a plain status chip. -->
+<ng-template #downloadBadge>
+  @if (badge(); as b) {
+    @if (b.clickable) {
+      <button
+        type="button"
+        class="btn btn-ghost btn-sm px-1.5"
+        [title]="'media_detail.download_detail_title' | translate"
+        (click)="openDownloadDetail.emit()"
+      >
+        <app-progress-badge
+          [label]="b.labelKey | translate"
+          [percent]="b.percent"
+          [badgeClass]="b.badgeClass"
+        />
+      </button>
+    } @else {
+      <app-progress-badge
+        [label]="b.labelKey | translate"
+        [percent]="b.percent"
+        [badgeClass]="b.badgeClass"
+      />
+    }
+  }
+</ng-template>
 
 <!-- Shared between mobile + desktop: Video (or file select) / Audio / Subtitles
      (hidden on series overview). Single source of truth so we don't drift

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -48,6 +48,7 @@ import {
   resolutionFromQualityName,
 } from '../../../core/utils/player.utils';
 import { DropdownMenuComponent } from '../dropdown-menu';
+import { ProgressBadgeComponent } from '../progress-badge/progress-badge.component';
 import { ImgFadeInDirective } from '../../directives/img-fade-in.directive';
 import { TvRowDirective } from '../../directives/tv-row.directive';
 import { TvSelectDirective } from '../../directives/tv-select.directive';
@@ -68,6 +69,17 @@ export interface MediaInfoHeaderSubtitle {
   forced?: boolean;
 }
 
+export interface MediaInfoHeaderBadge {
+  /** ngx-translate key for the badge text. */
+  labelKey: string;
+  /** 0–100 progress fill, or null for a plain status chip. */
+  percent: number | null;
+  /** daisyUI colour class, e.g. `badge-info` / `badge-ghost`. */
+  badgeClass: string;
+  /** When true the badge renders as a button that emits openDownloadDetail. */
+  clickable: boolean;
+}
+
 interface AudioTrack {
   index: number;
   label: string;
@@ -80,6 +92,7 @@ interface AudioTrack {
     MobileFanartHeroComponent,
     ResolveUrlPipe,
     DropdownMenuComponent,
+    ProgressBadgeComponent,
     ImgFadeInDirective,
     TvRowDirective,
     TvSelectDirective,
@@ -156,6 +169,10 @@ export class MediaInfoHeaderComponent {
   readonly grabBusy = input<string | null>(null);
   readonly monitoredLoading = input(false);
   readonly deleteLoading = input(false);
+  /** Status badge rendered next to the kebab menu (download progress, or the
+   *  monitored state), or null to show none. A clickable badge emits
+   *  openDownloadDetail. */
+  readonly badge = input<MediaInfoHeaderBadge | null>(null);
 
   // ── Inputs: series-specific ──
   readonly mediaType = input<string>('movie');
@@ -184,6 +201,9 @@ export class MediaInfoHeaderComponent {
   /** Open the tracking-status modal scoped to this header's context
    *  (whole series / the movie / the current episode). */
   readonly openTracking = output<void>();
+  /** Open the download-detail modal (per-season breakdown) from the header
+   *  download badge. */
+  readonly openDownloadDetail = output<void>();
   /** Viewer (regular requester) asks to (re-)request the current title. */
   readonly requestMedia = output<void>();
   /** Emitted after a series-level bulk watched toggle. Parent should refresh its episode watched list. */


### PR DESCRIPTION
Replaces the media-detail header's full-width download progress bar (which showed a broken ETA, e.g. "Temps restant: 2400h 0m") with a compact status badge next to the kebab menu.

## Behaviour
- Shown in every state **except** when the content is downloaded.
- Reads **`Téléchargement · X%`** while a grab is in flight (mean percent across a series' downloading seasons), otherwise the monitored state (**`Surveillé`** / **`Non surveillé`**).
- The downloading badge is **clickable** → opens a detail modal that breaks the mean down into overall speed/ETA + a per-season progress list (the detail a single chip can't convey).

## Mobile
- Badge sits in the action row to the left of the kebab, `justify-between` (the action icons only appear when a file is present, i.e. when the badge is hidden, so centring is preserved in that case).

## Shared / refactor
- Request badges (list + card) gain the same "downloading" label.
- Their duplicated label/percent/colour trio is extracted into a shared `RequestStatusBadgeComponent` so the two surfaces stay in sync.
- The download-progress badge markup is a single `<ng-template>` reused by the mobile + desktop header layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)