### PR TITLE
fix(spatial-nav): make home request cards a single focus leaf

### DIFF
--- a/client/src/app/features/requests/request-card/request-card.html
+++ b/client/src/app/features/requests/request-card/request-card.html
@@ -13,7 +13,11 @@
 
   <div class="relative flex flex-1 flex-col gap-1.5 p-4">
     <h3 class="text-lg font-semibold leading-snug line-clamp-1 m-0">
-      <a [routerLink]="mediaLink()" class="link link-hover text-base-content hover:opacity-80">
+      <a
+        [routerLink]="mediaLink()"
+        class="link link-hover text-base-content hover:opacity-80"
+        tabindex="-1"
+      >
         {{ request().media?.title || request().title }}
       </a>
     </h3>
@@ -64,7 +68,8 @@
           type="button"
           class="btn btn-success btn-sm flex-1"
           [disabled]="busy()"
-          (click)="approve.emit(request().id)"
+          tabindex="-1"
+          (click)="$event.stopPropagation(); approve.emit(request().id)"
         >
           {{ 'requests.approve' | translate }}
         </button>
@@ -72,7 +77,8 @@
           type="button"
           class="btn btn-warning btn-sm flex-1"
           [disabled]="busy()"
-          (click)="decline.emit(request().id)"
+          tabindex="-1"
+          (click)="$event.stopPropagation(); decline.emit(request().id)"
         >
           {{ 'requests.decline' | translate }}
         </button>

--- a/client/src/app/features/requests/request-card/request-card.ts
+++ b/client/src/app/features/requests/request-card/request-card.ts
@@ -2,11 +2,12 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  inject,
   input,
   output,
 } from '@angular/core';
 import { DatePipe } from '@angular/common';
-import { RouterLink } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { RequestPosterComponent } from '../request-poster';
 import { RequestStatusBadgeComponent } from '../request-status-badge/request-status-badge.component';
@@ -31,10 +32,25 @@ import { FliksRequestRow } from '../../../core/services/api/requests.service';
   // The host is the scroller flex item: fixed width, and a column flex so the
   // inner card fills the row's stretched height (all cards same height).
   // Compact on mobile, growing to full size on desktop/TV.
-  host: { class: 'flex shrink-0 w-64 sm:w-72 lg:w-80' },
+  // The host is the single focusable unit (like a media card): it carries
+  // tabindex/role and the focus ring (via its data-home-focus attribute on the
+  // home page), while inner links/buttons sit at tabindex=-1 so keyboard and
+  // D-pad navigation move card-to-card instead of into the card. Activating the
+  // card opens the linked media.
+  host: {
+    class: 'flex shrink-0 w-64 sm:w-72 lg:w-80 cursor-pointer rounded-box',
+    tabindex: '0',
+    role: 'button',
+    '[attr.aria-label]': 'ariaLabel()',
+    '(click)': 'onCardActivate($event)',
+    '(keydown.enter)': 'onCardActivate($event)',
+    '(keydown.space)': 'onCardActivate($event)',
+  },
   templateUrl: './request-card.html',
 })
 export class RequestCardComponent {
+  private readonly router = inject(Router);
+
   readonly request = input.required<FliksRequestRow>();
   readonly canManage = input(false);
   readonly qualityProfileName = input('—');
@@ -45,6 +61,18 @@ export class RequestCardComponent {
   readonly decline = output<number>();
   /** Forwarded up from the status badge: open the download-detail modal. */
   readonly badgeClick = output<void>();
+
+  protected readonly ariaLabel = computed(
+    () => this.request().media?.title ?? this.request().title,
+  );
+
+  /** Activate the whole card (Enter / Space / click) → open the linked media,
+   *  mirroring a media card. Inner controls stop propagation so they still fire
+   *  their own action without also navigating. */
+  protected onCardActivate(event?: Event): void {
+    event?.preventDefault();
+    void this.router.navigate(this.mediaLink());
+  }
 
   /** Backdrop art: the request's own stored fanart, falling back to the
    *  linked media's (both local `/api/images` paths). Null lets the poster


### PR DESCRIPTION
The home "recent requests" cards exposed their inner title link and approve/decline buttons as separate focus stops, so keyboard and D-pad navigation landed inside a card instead of moving card-to-card, with no whole-card focus ring.

Mirror the **media-card** pattern on every form factor:
- The host `<app-request-card>` is the single focusable unit — `tabindex="0"` + `role="button"`, and `rounded-box` so the focus ring (reused via its existing `data-home-focus` attribute) hugs the card's rounded corners. No new CSS.
- Inner title link and Approve/Decline buttons drop to `tabindex="-1"` so keyboard/D-pad move card-to-card.
- Activating the card (Enter / Space / click) opens the linked media. Inner action buttons `stopPropagation` so they still fire without also navigating.

## Trade-off
Approve/Decline on the home card are no longer keyboard-tabbable (mouse-click only), matching the media-card single-unit model. Both remain reachable on the Requests page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)