### PR TITLE
fix(downloads): show ∞ for a stalled torrent's ETA, colon in the i18n string

### DIFF
--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -873,7 +873,7 @@
     "queue_error": "Impossible de charger la file de téléchargement.",
     "history_empty": "Aucun historique de téléchargement.",
     "history_error": "Impossible de charger l'historique.",
-    "eta": "Temps restant",
+    "eta": "Temps restant :",
     "col_title": "Release",
     "col_media": "Média",
     "col_quality": "Qualité",

--- a/client/src/app/features/activity/queue/queue.html
+++ b/client/src/app/features/activity/queue/queue.html
@@ -165,7 +165,7 @@
               <span>↑ {{ formatSpeed(item.upspeed) }}</span>
             }
             @if (item.eta > 0 && item.trackerStatus === 'Downloading') {
-              <span>{{ 'activity.eta' | translate }}: {{ formatEta(item.eta) }}</span>
+              <span>{{ 'activity.eta' | translate }} {{ formatEta(item.eta) }}</span>
             }
             @if (item.num_seeds > 0 || item.num_leechs > 0) {
               <span>S:{{ item.num_seeds }} L:{{ item.num_leechs }}</span>

--- a/client/src/app/shared/components/download-detail-modal/download-detail-modal.html
+++ b/client/src/app/shared/components/download-detail-modal/download-detail-modal.html
@@ -14,7 +14,7 @@
           <span class="font-medium">{{ overallStateLabelKey() | translate }}</span>
           @if (p.percent !== null) { <span class="tabular-nums">{{ p.percent }}%</span> }
           @if (speedLabel(); as sp) { <span>↓ {{ sp }}</span> }
-          @if (etaLabel(); as e) { <span>{{ 'activity.eta' | translate }}: {{ e }}</span> }
+          @if (etaLabel(); as e) { <span>{{ 'activity.eta' | translate }} {{ e }}</span> }
         </div>
       </div>
 

--- a/client/src/app/shared/utils/download-format.ts
+++ b/client/src/app/shared/utils/download-format.ts
@@ -27,7 +27,10 @@ export function formatSpeed(bytesPerSec: number): string {
 }
 
 export function formatEta(seconds: number): string {
-  if (seconds <= 0 || !isFinite(seconds)) return '—';
+  // qBittorrent reports 8640000s (100 days) as its "infinite" ETA sentinel for
+  // stalled / no-progress torrents — show ∞ rather than a bogus "2400h 0m".
+  if (!isFinite(seconds) || seconds >= 8640000) return '∞';
+  if (seconds <= 0) return '—';
   const h = Math.floor(seconds / 3600);
   const m = Math.floor((seconds % 3600) / 60);
   const s = seconds % 60;


### PR DESCRIPTION
A stalled torrent reports qBittorrent's "infinite" ETA sentinel (8640000s = 100 days), which the download-detail modal rendered as a bogus `Temps restant: 2400h 0m`.

- **`formatEta`** now returns **∞** for that sentinel (and any non-finite value).
- The colon moves **into the `activity.eta` translation** (`"Temps restant :"`) instead of being hardcoded in the template, so the space-before-colon is the locale's call. The hardcoded colon is dropped from both consumers — the detail modal **and** the Activity queue (which was inconsistent: `:` with no space).

Result: a stalled torrent reads `Bloqué · 26% · Temps restant : ∞`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)