### PR TITLE
fix(streaming): order low-consumption quality rungs after the normal one

### DIFF
--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -598,28 +598,39 @@ export class StreamBuilderService {
     // a forced transcode lists it as a normal rung instead. `isRemux` is true
     // only on the DirectStream path so the UI/stats can tell remux from a raw
     // direct play.
-    const qualities: QualityOption[] = [];
+    // Track a resolution `tier` (the profile's bucket maxHeight) alongside each
+    // rung, kept separate from the displayed height. The source-resolution
+    // `original` rung carries the actual source height, which for a letterboxed
+    // / scope source (e.g. a 3840×1606 4K) is below its own eco rung's bucket
+    // height (2160) — sorting on raw height would then list "4K eco" above "4K".
+    const entries: { option: QualityOption; tier: number }[] = [];
     for (const p of available) {
       if (isEcoProfile(p.name)) continue;
       const total = totalOf(p);
       if (p.name === topProfile.name && videoCopyStream) {
-        qualities.push({
-          id: 'original',
-          label: resolutionLabel,
-          height: originalHeight,
-          width: originalWidth,
-          totalBitrateBps: sourceTotal > 0 ? sourceTotal : total,
-          isRemux: playMethod === 'DirectStream',
+        entries.push({
+          option: {
+            id: 'original',
+            label: resolutionLabel,
+            height: originalHeight,
+            width: originalWidth,
+            totalBitrateBps: sourceTotal > 0 ? sourceTotal : total,
+            isRemux: playMethod === 'DirectStream',
+          },
+          tier: p.maxHeight,
         });
         continue;
       }
-      qualities.push({
-        id: p.name,
-        label: displayLabel(p.name),
-        height: p.maxHeight,
-        width: p.maxWidth,
-        totalBitrateBps: total,
-        isRemux: false,
+      entries.push({
+        option: {
+          id: p.name,
+          label: displayLabel(p.name),
+          height: p.maxHeight,
+          width: p.maxWidth,
+          totalBitrateBps: total,
+          isRemux: false,
+        },
+        tier: p.maxHeight,
       });
     }
 
@@ -629,24 +640,31 @@ export class StreamBuilderService {
     const savingRef = sourceTotal > 0 ? sourceTotal : totalOf(topProfile);
     for (const p of available) {
       if (!isEcoProfile(p.name) || totalOf(p) >= savingRef) continue;
-      qualities.push({
-        id: p.name,
-        label: displayLabel(p.name),
-        height: p.maxHeight,
-        width: p.maxWidth,
-        totalBitrateBps: totalOf(p),
-        isRemux: false,
-        lowBandwidth: true,
+      entries.push({
+        option: {
+          id: p.name,
+          label: displayLabel(p.name),
+          height: p.maxHeight,
+          width: p.maxWidth,
+          totalBitrateBps: totalOf(p),
+          isRemux: false,
+          lowBandwidth: true,
+        },
+        tier: p.maxHeight,
       });
     }
 
-    // Order by resolution then bitrate (both descending) so full and eco
-    // interleave naturally: 4K, 4K eco, 1080p, 1080p eco, 720p, 720p eco, …
-    qualities.sort(
-      (a, b) => b.height - a.height || b.totalBitrateBps - a.totalBitrateBps,
+    // Order by resolution tier (descending), then the full rung before its
+    // low-consumption sibling, then bitrate — so an eco rung always follows the
+    // normal rung of the same resolution: 4K, 4K eco, 1080p, 1080p eco, 720p, …
+    entries.sort(
+      (a, b) =>
+        b.tier - a.tier ||
+        Number(!!a.option.lowBandwidth) - Number(!!b.option.lowBandwidth) ||
+        (b.option.totalBitrateBps ?? 0) - (a.option.totalBitrateBps ?? 0),
     );
 
-    return qualities;
+    return entries.map((e) => e.option);
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
The player quality menu listed **"4K (faible consommation)" before "4K"** on a letterboxed/scope 4K source.

**Cause:** the source-resolution `original` rung sorted on the *actual* source height (e.g. 1606 for a 3840×1606 file), which falls below its own eco rung's bucket height (2160). Transcode rungs (1080p/720p) share the same `maxHeight` for normal and eco, so they were already ordered correctly.

**Fix:** sort on the profile's **resolution tier** (bucket `maxHeight`, not the raw source height) and place the full rung before its low-consumption sibling explicitly. Result: `4K`, `4K (faible)`, `1080p`, `1080p (faible)`, `720p`, `720p (faible)`…

🤖 Generated with [Claude Code](https://claude.com/claude-code)