### PR TITLE
feat(player): leaf icon by the quality value when an eco rung is active

### DIFF
--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -316,7 +316,10 @@
       @if (availableQualities().length > 1) {
         <button class="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm text-white active:bg-white/10" (click)="settingsPanel.set('quality')">
           <span class="flex-1 text-left">{{ 'player.quality' | translate }}</span>
-          <span class="text-white/40 text-xs">{{ activeQualityLabel() }}</span>
+          <span class="flex items-center gap-1 text-white/40 text-xs">
+            {{ activeQualityLabel() }}
+            @if (showEcoLeaf()) { <svg lucideLeaf class="h-3.5 w-3.5 shrink-0"></svg> }
+          </span>
           <svg lucideChevronRight class="h-4 w-4 text-white/30 shrink-0"></svg>
         </button>
       }
@@ -364,7 +367,10 @@
         @if (availableQualities().length > 1) {
           <button class="w-full flex items-center gap-3 px-4 py-2.5 rounded-lg text-sm text-white hover:bg-white/10" (click)="settingsPanel.set('quality')">
             <span class="flex-1 text-left">{{ 'player.quality' | translate }}</span>
-            <span class="text-white/50 text-xs">{{ activeQualityLabel() }}</span>
+            <span class="flex items-center gap-1 text-white/50 text-xs">
+              {{ activeQualityLabel() }}
+              @if (showEcoLeaf()) { <svg lucideLeaf class="h-3.5 w-3.5 shrink-0"></svg> }
+            </span>
             <svg lucideChevronRight class="h-4 w-4 text-white/40 shrink-0"></svg>
           </button>
         }

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -37,6 +37,7 @@ import {
   LucideSkipForward,
   LucideCast,
   LucideHeadphones,
+  LucideLeaf,
   LucideVolume2,
   LucideVolumeX,
 } from '@lucide/angular';
@@ -55,6 +56,7 @@ import {
     LucideSkipForward,
     LucideCast,
     LucideHeadphones,
+    LucideLeaf,
     LucideVolume2,
     LucideVolumeX,
     LucideSettings,
@@ -79,6 +81,16 @@ export class PlayerControlsComponent {
    *  every visible rung is eco then, so the tag is just noise. */
   readonly showEcoBadge = computed(
     () => !this.playerSettings.settings().ecoByDefault,
+  );
+  /** Show a leaf next to the quality value when the active rung is a
+   *  low-consumption one — and the eco-by-default setting hasn't already made
+   *  the tag redundant (every rung eco then). */
+  readonly showEcoLeaf = computed(
+    () =>
+      this.showEcoBadge() &&
+      (this.availableQualities().find((q) => q.id === this.activeQualityId())
+        ?.lowBandwidth ??
+        false),
   );
 
   constructor() {


### PR DESCRIPTION
The settings dropdown's quality row showed the rung label but nothing flagged a low-consumption ("faible consommation") rung at a glance.

Add a leaf icon **after** the quality value when the active rung is eco, in the font's own colour (`currentColor`, no green tint). Gated behind `showEcoBadge` so it stays hidden when eco-by-default already makes every rung eco (the tag is redundant then). Added on both the mobile and desktop settings layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)