### PR TITLE
fix(settings): tab title as "page | layout" on own-layout shells

### DIFF
--- a/client/src/app/shared/components/settings-drawer/settings-drawer.html
+++ b/client/src/app/shared/components/settings-drawer/settings-drawer.html
@@ -4,7 +4,7 @@
      controls visibility, no class toggle, no `display:none` override,
      no DaisyUI animation quirks to dance around. -->
 <div class="drawer min-h-screen" [class.lg:drawer-open]="!tv.isTv()">
-  <input [id]="drawerId" #drawerToggle type="checkbox" class="drawer-toggle" />
+  <input [id]="drawerId()" #drawerToggle type="checkbox" class="drawer-toggle" />
   <div class="drawer-content flex flex-col relative min-w-0">
     <!-- Top bar — `lg:hidden` on desktop only. On TV the navbar is
          permanent (drawer is transient there, the hamburger is the
@@ -21,12 +21,12 @@
         <button type="button" class="btn btn-square btn-ghost" (click)="goBack()">
           <svg lucideChevronLeft class="h-5 w-5"></svg>
         </button>
-        <label [for]="drawerId" tabindex="0" role="button" class="btn btn-square btn-ghost">
+        <label [for]="drawerId()" tabindex="0" role="button" class="btn btn-square btn-ghost">
           <svg lucideMenu class="h-5 w-5"></svg>
         </label>
       </div>
       <div class="flex-1">
-        <span class="text-lg font-bold">{{ title }}</span>
+        <span class="text-lg font-bold">{{ title() }}</span>
       </div>
     </nav>
     <!-- Spacer pushes content below the fixed navbar (visible on TV too
@@ -43,7 +43,7 @@
   </div>
 
   <div class="drawer-side z-40">
-    <label [for]="drawerId" class="drawer-overlay"></label>
+    <label [for]="drawerId()" class="drawer-overlay"></label>
     <aside class="bg-base-100 w-64 min-h-full flex flex-col"
       style="
         padding-top: calc(env(safe-area-inset-top, 0px) / 2 );
@@ -54,11 +54,11 @@
       <div class="p-4 border-b border-base-200">
         <a routerLink="/" class="flex items-center gap-2 px-2 py-1 rounded-lg text-base-content/60 hover:text-base-content text-sm mb-2 mt-4">
           <svg lucideChevronLeft class="h-4 w-4"></svg>
-          {{ backLabel }}
+          {{ backLabel() }}
         </a>
         <h2 class="text-xl font-bold flex items-center gap-2">
           <ng-content select="[drawerIcon]"></ng-content>
-          {{ title }}
+          {{ title() }}
         </h2>
       </div>
 

--- a/client/src/app/shared/components/settings-drawer/settings-drawer.ts
+++ b/client/src/app/shared/components/settings-drawer/settings-drawer.ts
@@ -1,9 +1,24 @@
 import {
-  Component, ChangeDetectionStrategy, Input, signal, OnInit, OnDestroy, ElementRef, viewChild,
+  Component,
+  ChangeDetectionStrategy,
+  signal,
+  effect,
+  input,
+  inject,
+  OnInit,
+  OnDestroy,
+  ElementRef,
+  viewChild,
 } from '@angular/core';
-import { RouterOutlet, RouterLink } from '@angular/router';
+import {
+  RouterOutlet,
+  RouterLink,
+  Router,
+  NavigationEnd,
+} from '@angular/router';
+import { Title } from '@angular/platform-browser';
 import { Location } from '@angular/common';
-import { inject } from '@angular/core';
+import { Subscription, filter } from 'rxjs';
 import { LucideChevronLeft, LucideMenu } from '@lucide/angular';
 import { TvService } from '../../../core/services/tv.service';
 
@@ -15,13 +30,34 @@ import { TvService } from '../../../core/services/tv.service';
 })
 export class SettingsDrawerComponent implements OnInit, OnDestroy {
   private readonly location = inject(Location);
+  private readonly router = inject(Router);
+  private readonly titleService = inject(Title);
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
 
-  @Input() title = '';
-  @Input() backLabel = 'Retour';
-  @Input() drawerId = 'settings-drawer';
+  /** Layout name — shown in the header and used as the tab-title suffix. */
+  readonly title = input('');
+  readonly backLabel = input('Retour');
+  readonly drawerId = input('settings-drawer');
 
   readonly navbarHidden = signal(false);
   readonly tv = inject(TvService);
+
+  /** Active sidebar entry label, re-read from the menu on each navigation. */
+  private readonly activePage = signal('');
+  private routerSub?: Subscription;
+
+  /**
+   * Drives the browser tab title: `"<active page> | <layout>"` (e.g.
+   * "Général | Administration"), or the layout name alone before a page
+   * resolves. These shells live outside the main LayoutComponent that otherwise
+   * owns document.title, so without this the title keeps whatever the previous
+   * page (e.g. a media detail) left.
+   */
+  private readonly titleEffect = effect(() => {
+    const page = this.activePage();
+    const layout = this.title();
+    this.titleService.setTitle(page ? `${page} | ${layout}` : layout);
+  });
 
   private readonly drawerToggleEl =
     viewChild<ElementRef<HTMLInputElement>>('drawerToggle');
@@ -46,10 +82,42 @@ export class SettingsDrawerComponent implements OnInit, OnDestroy {
       });
     }
     window.addEventListener('scroll', this.onScroll, { passive: true });
+
+    this.routerSub = this.router.events
+      .pipe(filter((e) => e instanceof NavigationEnd))
+      .subscribe(() => this.activePage.set(this.readActivePageLabel()));
+    // Initial read — a direct load fires no NavigationEnd after mount.
+    queueMicrotask(() => this.activePage.set(this.readActivePageLabel()));
   }
 
   ngOnDestroy() {
     window.removeEventListener('scroll', this.onScroll);
+    this.routerSub?.unsubscribe();
+  }
+
+  /** Label of the deepest sidebar entry whose route prefixes the current URL.
+   *  Scoped to the menu (so routed-content links don't leak in) and matched by
+   *  href prefix rather than the `.active` class, so it doesn't depend on
+   *  routerLinkActive's update timing. */
+  private readActivePageLabel(): string {
+    const menu = this.host.nativeElement.querySelector('ul.menu');
+    if (!menu) return '';
+    const url = this.router.url.split(/[?#]/)[0];
+    let best: HTMLAnchorElement | null = null;
+    let bestLen = -1;
+    for (const a of Array.from(
+      menu.querySelectorAll<HTMLAnchorElement>('a[href]'),
+    )) {
+      const href = a.getAttribute('href') ?? '';
+      if (
+        (url === href || url.startsWith(`${href}/`)) &&
+        href.length > bestLen
+      ) {
+        bestLen = href.length;
+        best = a;
+      }
+    }
+    return best ? (best.textContent ?? '').replace(/\s+/g, ' ').trim() : '';
   }
 
   goBack() {


### PR DESCRIPTION
On a media detail page the browser tab shows the movie name; opening an admin / settings / account section left the tab title **stuck on the movie name**.

**Cause:** the admin / account / app-settings shells have their own layout (outside the main `LayoutComponent`), which is what otherwise drives `document.title`. The shells never updated it.

**Fix:** the shared `SettingsDrawerComponent` (used by all three shells) now sets the tab title to `"<active section> | <layout>"` — e.g. `Général | Administration`, `Lecteur | Paramètres de l'app`. The active section is read from the sidebar's active entry on each navigation (scoped to the menu, matched by route prefix so it's independent of `routerLinkActive` timing). The main `LayoutComponent` reclaims the title when leaving the shell.

Also migrates the drawer's `title` / `backLabel` / `drawerId` from `@Input()` to signal `input()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)