### PR TITLE
fix(auth): stop multi-tab refresh races from revoking every session

### DIFF
--- a/backend/src/modules/auth/refresh-token.service.ts
+++ b/backend/src/modules/auth/refresh-token.service.ts
@@ -15,6 +15,16 @@ import { RefreshToken } from './entities/refresh-token.entity';
  *  stolen token can't be replayed forever. Configurable via env. */
 const DEFAULT_TTL_DAYS = 60;
 
+/**
+ * Window after a token is rotated during which presenting it AGAIN is treated
+ * as a benign concurrent-refresh race (e.g. a second browser tab that hadn't
+ * yet picked up the rotation) rather than theft: that one refresh is rejected,
+ * but the user's token family is left intact. A genuinely stolen token is
+ * replayed long after its rotation, well outside this window, and still trips
+ * the family-wide revoke below.
+ */
+const REUSE_GRACE_MS = 30_000;
+
 export interface IssuedRefresh {
   /** Plaintext token, returned to the client once and never stored. */
   token: string;
@@ -84,6 +94,16 @@ export class RefreshTokenService {
     if (!row) throw new UnauthorizedException('Invalid refresh token');
 
     if (row.revokedAt) {
+      const sinceRevokeMs = Date.now() - row.revokedAt.getTime();
+      if (sinceRevokeMs <= REUSE_GRACE_MS) {
+        // Benign race: a token rotated moments ago is presented again (a second
+        // tab still holding the previous value). Reject this one refresh but
+        // keep the family — the client recovers with the already-rotated token.
+        this.log.debug(
+          `RefreshToken: token re-presented ${sinceRevokeMs}ms after rotation for user #${row.userId} — benign concurrent-refresh, rejecting without revoke-all`,
+        );
+        throw new UnauthorizedException('Refresh token already rotated');
+      }
       this.log.warn(
         `RefreshToken: replay detected for user #${row.userId} — revoking every active refresh token of this user`,
       );

--- a/client/src/app/core/interceptors/credentials.interceptor.ts
+++ b/client/src/app/core/interceptors/credentials.interceptor.ts
@@ -59,13 +59,14 @@ export const credentialsInterceptor: HttpInterceptorFn = (req, next) => {
       }
       // 401 with a refresh token available → try to rotate.
       return from(auth.refreshAccessToken()).pipe(
-        switchMap((newToken): Observable<HttpEvent<unknown>> => {
-          if (!newToken) {
+        switchMap((refreshed): Observable<HttpEvent<unknown>> => {
+          if (!refreshed) {
             // Rotation failed: bubble the original 401 so the route
             // guard / error handler can react (redirect to login).
             return throwError(() => err);
           }
-          // Retry the original request with the fresh credentials.
+          // Retry with the fresh credentials — attach() reads them live
+          // from auth.accessToken / the session cookie.
           return next(attach(req));
         }),
       );

--- a/client/src/app/core/services/auth.service.ts
+++ b/client/src/app/core/services/auth.service.ts
@@ -75,12 +75,26 @@ export class AuthService {
   private _refreshToken: string | null = null;
   /** In-flight refresh request shared across concurrent 401s so we only
    *  rotate once even when 10 parallel calls all fail at the same time. */
-  private _refreshInFlight: Promise<string | null> | null = null;
+  private _refreshInFlight: Promise<boolean> | null = null;
   /** Long-lived stream JWT cached for the player + URL builders. See
    *  ensureStreamToken() for the lifecycle. */
   private _streamToken = signal<string | null>(null);
   private _streamTokenExpiresAt = 0;
   private _streamTokenInFlight: Promise<string | null> | null = null;
+
+  constructor() {
+    // Multi-tab: when another tab rotates the refresh token it persists the new
+    // value to localStorage, firing `storage` in every OTHER tab. Adopt it so a
+    // lagging tab never replays its now-stale token — which the server treats as
+    // reuse and revokes every session. Web-only (native runs a single webview).
+    if (typeof window !== 'undefined' && !this.serverConfig.isNative) {
+      window.addEventListener('storage', (e) => {
+        if (e.key === AuthService.REFRESH_KEY && e.newValue) {
+          this._refreshToken = e.newValue;
+        }
+      });
+    }
+  }
 
   get accessToken(): string | null {
     return this._accessToken;
@@ -229,56 +243,98 @@ export class AuthService {
   }
 
   /**
-   * Exchange the stored refresh token for a fresh access + refresh
-   * pair. Single-flight: parallel callers (e.g. 10 concurrent requests
-   * all 401-ing at once) share the same in-flight promise so the
-   * server only rotates the token once.
+   * Refresh the session by rotating the stored refresh token. Resolves `true`
+   * when usable credentials are in place afterwards (a fresh access token was
+   * obtained, or another tab had already rotated and we adopted it), `false`
+   * when refresh isn't possible — no stored token, or the server rejected ours.
    *
-   * Returns the new access token on success, or null if rotation is
-   * not possible (no refresh token stored, or the server rejected
-   * ours). A server rejection is treated as terminal: the local
-   * session is wiped and the user is sent back to /select-user.
-   * Network/5xx failures, by contrast, leave the tokens intact so a
-   * flaky-wifi user isn't logged out on every dropout.
+   * The boolean is a "retry the original request now?" signal: the fresh access
+   * token itself lands on {@link accessToken} / the session cookie as a side
+   * effect, which is what callers attach.
+   *
+   * Single-flight: parallel callers (e.g. 10 requests all 401-ing at once)
+   * share one in-flight promise so the server only rotates once. A server
+   * rejection is terminal — the local session is wiped and the user is sent
+   * back to /select-user. Network/5xx failures keep the tokens so a flaky
+   * connection doesn't log the user out.
    */
-  async refreshAccessToken(): Promise<string | null> {
+  async refreshAccessToken(): Promise<boolean> {
     if (this._refreshInFlight) return this._refreshInFlight;
-    const refresh = this._refreshToken;
-    if (!refresh) return null;
-    this._refreshInFlight = (async () => {
-      try {
-        const res = await firstValueFrom(
-          this.http.post<TokenPairResponse>('/api/auth/refresh', {
-            refreshToken: refresh,
-          }),
-        );
-        this._accessToken = res.accessToken;
-        this._refreshToken = res.refreshToken;
-        if (this.serverConfig.isNative) await this.saveToken(res.accessToken);
-        await this.saveRefreshToken(res.refreshToken);
-        return res.accessToken;
-      } catch (err) {
-        const status =
-          err instanceof HttpErrorResponse ? err.status : 0;
-        // 4xx = server-side rejection (refresh token expired, revoked,
-        // or theft-detection wiped every session). Terminal — force
-        // the user back to the picker so the next action goes through
-        // a fresh login.
-        // Anything else (0 = offline, 5xx = server hiccup) is treated
-        // as transient: keep the tokens, just signal "couldn't refresh
-        // right now" to the caller.
-        if (status >= 400 && status < 500) {
-          // Skip the /auth/logout round-trip: the server has already
-          // told us our credentials are dead, so posting them again
-          // would just 401 on top of the original failure.
-          await this.clearLocalSession();
-        }
-        return null;
-      } finally {
-        this._refreshInFlight = null;
-      }
-    })();
+    if (!this._refreshToken) return false;
+    this._refreshInFlight = this.runRefresh().finally(() => {
+      this._refreshInFlight = null;
+    });
     return this._refreshInFlight;
+  }
+
+  /**
+   * Cross-tab refresh coordination. Rotation invalidates the presented token,
+   * so two browser tabs racing to refresh would have the lagging one replay an
+   * already-rotated token — which the server treats as theft and revokes EVERY
+   * session. We serialise refreshes across tabs with the Web Locks API; the tab
+   * that wins the lock rotates, the others then see the token already changed
+   * and adopt it instead of replaying. Native/TV run a single webview, so they
+   * just refresh in-process (the {@link _refreshInFlight} single-flight covers
+   * the parallel-401 burst).
+   */
+  private async runRefresh(): Promise<boolean> {
+    const tokenAtStart = this._refreshToken;
+    const lockMgr =
+      typeof navigator !== 'undefined' ? navigator.locks : undefined;
+    if (!this.serverConfig.isNative && lockMgr) {
+      return lockMgr.request('fliks-token-refresh', () =>
+        this.rotateOrAdopt(tokenAtStart),
+      );
+    }
+    return this.rotateOrAdopt(tokenAtStart);
+  }
+
+  /** Re-read the freshest stored token; if another tab rotated it while we
+   *  waited for the lock, adopt it and skip the network call (that tab's
+   *  /refresh already set a fresh access cookie) so we don't replay a revoked
+   *  token. Otherwise perform the rotation ourselves. */
+  private async rotateOrAdopt(tokenAtStart: string | null): Promise<boolean> {
+    const stored = await this.loadRefreshToken();
+    if (!this.serverConfig.isNative && stored && stored !== tokenAtStart) {
+      this._refreshToken = stored;
+      return true;
+    }
+    return this.doRefresh(stored ?? tokenAtStart);
+  }
+
+  private async doRefresh(refresh: string | null): Promise<boolean> {
+    if (!refresh) return false;
+    try {
+      const res = await firstValueFrom(
+        this.http.post<TokenPairResponse>('/api/auth/refresh', {
+          refreshToken: refresh,
+        }),
+      );
+      this._accessToken = res.accessToken;
+      this._refreshToken = res.refreshToken;
+      if (this.serverConfig.isNative) await this.saveToken(res.accessToken);
+      await this.saveRefreshToken(res.refreshToken);
+      return true;
+    } catch (err) {
+      const status = err instanceof HttpErrorResponse ? err.status : 0;
+      // 4xx = server-side rejection (expired / revoked / theft-detection).
+      // Anything else (0 = offline, 5xx = hiccup) is transient: keep the tokens
+      // so a flaky connection doesn't log the user out.
+      if (status >= 400 && status < 500) {
+        // First check whether another tab rotated meanwhile: then our token was
+        // merely stale, not dead — adopt the new one and let the caller retry
+        // (against the fresh access cookie) instead of wiping the session.
+        const stored = await this.loadRefreshToken();
+        if (!this.serverConfig.isNative && stored && stored !== refresh) {
+          this._refreshToken = stored;
+          return true;
+        }
+        // Terminal — skip the /auth/logout round-trip (credentials are dead)
+        // and send the user back to the picker.
+        await this.clearLocalSession();
+      }
+      return false;
+    }
   }
 
   /**


### PR DESCRIPTION
## Symptom
`RefreshToken: replay detected for user #1 — revoking every active refresh token` in the logs, then the user is stuck (cached home, 401s everywhere, no library). Confirmed: only happens with **multiple browser tabs**.

## Cause
Refresh-token rotation invalidates the presented token. Two tabs refreshing at once → the lagging tab replays an already-rotated token → the server reads it as theft and revokes the user's whole token family → every session dies.

## Fix (two layers)
**Frontend** — cross-tab coordination:
- Serialize refresh across tabs with the **Web Locks API** (same pattern `supabase-js` uses): the tab that wins the lock rotates; the others re-read the freshly stored token and **adopt it** (their access cookie is already refreshed) instead of replaying.
- A `storage` listener keeps each tab's in-memory token in sync, and a 4xx refresh now adopts a sibling-tab rotation before wiping the session.
- Native/TV (single webview) keep the existing in-process single-flight.
- Refresh helpers now return a clear `Promise<boolean>` ("retry?" signal) instead of a stand-in token.

**Backend** — defense in depth:
- 30s **grace window** on rotation reuse-detection (Auth0's "reuse interval"): a token re-presented moments after its rotation is a benign concurrent-refresh race → rejected without revoking the family. A genuinely stolen token, replayed much later, still trips the family-wide revoke.

## Test
Open 2 tabs, let the access token expire (or force refresh on both) → no more cascading logout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)