### PR TITLE
fix(player): Tizen/keyboard seek + controls UX fixes

### DIFF
--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -115,7 +115,15 @@ export class PlayerControlsComponent {
       const visible = this.visible();
       const wasVisible = this.lastVisible;
       this.lastVisible = visible;
-      if (visible && !wasVisible && this.isTv()) {
+      // Focus play/pause when the bar appears under keyboard / D-pad — on TV
+      // (always) and on the browser in keyboard modality — so the next
+      // Enter/Space toggles playback. Skipped for pointer (mouse-revealed
+      // controls shouldn't steal focus). An arrow-seek re-focuses the seekbar
+      // afterwards (player.focusSeekbar), which wins the deferred race.
+      const keyboardModality =
+        typeof document !== 'undefined' &&
+        document.body.classList.contains('keyboard-modality');
+      if (visible && !wasVisible && (this.isTv() || keyboardModality)) {
         this.closeDropdown();
         this.playPauseBtn()?.nativeElement.focus({ preventScroll: true });
       }
@@ -253,6 +261,11 @@ export class PlayerControlsComponent {
   readonly activeSheet = signal<'subtitles' | 'audio' | 'speed' | 'settings' | null>(null);
 
   readonly seekbar = viewChild(SeekbarComponent);
+
+  /** Focus the seekbar track (used when an arrow press wakes hidden controls). */
+  focusSeekbar(): void {
+    this.seekbar()?.focus();
+  }
   /** Desktop/TV play-pause button — focused on TV every time the controls
    *  bar reappears, so the next D-pad center triggers play/pause. */
   private readonly playPauseBtn = viewChild<ElementRef<HTMLButtonElement>>('playPauseBtn');

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -177,6 +177,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
   private readonly videoEl = viewChild<ElementRef<HTMLVideoElement>>('videoElement');
   private readonly containerEl = viewChild<ElementRef<HTMLDivElement>>('playerContainer');
+  private readonly controls = viewChild(PlayerControlsComponent);
 
   /** Active engine (Shaka for web HLS, Native for Android/iOS). Cast
    *  bypasses the engine abstraction and is driven by `castPlayerService`
@@ -1409,6 +1410,13 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     this.resetHideTimer();
   }
 
+  /** Move focus to the seekbar after the controls bar has rendered/become
+   *  visible. Deferred so it lands after the controls' own "focus play/pause on
+   *  reappear" effect, which would otherwise win the focus race on TV. */
+  private focusSeekbar() {
+    setTimeout(() => this.controls()?.focusSeekbar(), 0);
+  }
+
   private hideControls() {
     if (this.controlsTimeout) clearTimeout(this.controlsTimeout);
     this.controlsVisible.set(false);
@@ -1432,7 +1440,12 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // 5 s on TV: focus is visual only, give the user time to read the labels.
     const delay = this.device.isTv() ? 5000 : 3000;
     this.controlsTimeout = setTimeout(() => {
-      if (!this.paused() && !this.isDropdownOpen() && !this.seekDragging) this.controlsVisible.set(false);
+      // Route through hideControls() (not a bare set(false)) so it also blurs
+      // the focused control. After an arrow-seek lands focus on the seekbar,
+      // the seekbar's keydown stops propagation — without blurring on auto-hide
+      // the next arrow never reaches the global handler, so the controls would
+      // stay hidden on the second seek.
+      if (!this.paused() && !this.isDropdownOpen() && !this.seekDragging) this.hideControls();
     }, delay);
   }
 
@@ -2452,6 +2465,24 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // keep clear of the lib.dom `keyCode` deprecation.
     const legacyKeyCode = (e as { keyCode: number }).keyCode;
     const isBackKey = legacyKeyCode === 10009 || e.key === 'XF86Back' || e.key === 'GoBack' || e.key === 'Escape';
+    // Controls hidden + Left/Right: wake the bar, seek, and land focus on the
+    // seekbar so the next presses scrub it — on every device (keyboard + TV
+    // remote), matching the seekbar-focused scrub when the bar is already up.
+    if (
+      !this.controlsVisible() &&
+      (e.key === 'ArrowLeft' || e.key === 'ArrowRight')
+    ) {
+      this.showControls();
+      this.onSeek(this.engine.currentTime + (e.key === 'ArrowLeft' ? -10 : 10));
+      this.focusSeekbar();
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+
+    // TV only: any other key while the bar is hidden just WAKES it — never
+    // activates the invisible focused button (e.g. OK would hit the back arrow
+    // and quit). The back key bubbles to app.ts so the user can still exit.
     if (!isBackKey && !this.controlsVisible() && this.device.isTv()) {
       this.showControls();
       e.preventDefault();
@@ -2554,12 +2585,12 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   };
 
   private onPlayerBackEvent = () => {
-    // TV: D-pad navigation needs an explicit "dismiss controls" step
-    // before exiting the player, so back/Return on the remote first
-    // closes the controls bar, then leaves on the second press.
-    // Phones and tablets get the direct exit — touch users dismiss
+    // TV remote Return and desktop Escape first close a visible controls bar,
+    // then exit on the next press — back mirrors the on-screen close. (On
+    // desktop this event only ever comes from Escape, a deliberate keyboard
+    // press.) Phones and tablets get the direct exit: touch users dismiss the
     // controls by tapping the video surface, not via hardware back.
-    if (this.device.isTv() && this.controlsVisible()) {
+    if ((this.device.isTv() || this.device.isDesktop()) && this.controlsVisible()) {
       this.hideControls();
       return;
     }

--- a/client/src/app/shared/components/seekbar/seekbar.html
+++ b/client/src/app/shared/components/seekbar/seekbar.html
@@ -1,4 +1,5 @@
 <div
+  #trackRoot
   data-no-focus-ring
   class="group relative w-full flex items-center cursor-pointer touch-none focus:outline-none"
   [class]="variant() === 'player' ? 'h-6' : 'h-5'"
@@ -16,8 +17,9 @@
   <!-- Seek tooltip -->
   @if (showTooltip() && (hovering() || dragging()) && duration()) {
     <div
-      class="absolute bottom-full mb-3 pointer-events-none z-50 -translate-x-1/2"
+      class="absolute bottom-full mb-3 pointer-events-none z-50"
       [style.left]="tooltipLeft()"
+      [style.transform]="'translateX(-50%)'"
     >
       <div class="relative">
         <div class="bg-neutral/95 backdrop-blur-sm rounded-lg shadow-2xl overflow-hidden">
@@ -49,7 +51,8 @@
              rounded box so the box's overflow-hidden doesn't clip it.
              Sits flush against the bottom edge, centered horizontally. -->
         <div
-          class="absolute left-1/2 top-full -translate-x-1/2 w-0 h-0 border-x-[6px] border-x-transparent border-t-[6px] border-t-neutral/95"
+          class="absolute left-1/2 top-full w-0 h-0 border-x-[6px] border-x-transparent border-t-[6px] border-t-neutral/95"
+          style="transform: translateX(-50%)"
         ></div>
       </div>
     </div>
@@ -71,9 +74,10 @@
     }
     <!-- Progress. `rounded-l-full` matches the track's left cap; right side
          stays square so the progress ends on a crisp vertical edge instead of
-         a curved bulge. Hidden while loading so the determinate position fill
-         and the indeterminate sweep never show at once. -->
-    @if (!loading()) {
+         a curved bulge. Kept visible while loading IF the user is seeking, so
+         the position fill tracks the drag instead of vanishing into the sweep;
+         otherwise hidden so fill + sweep don't show at once. -->
+    @if (showPositionFill()) {
       <div
         class="absolute inset-y-0 left-0 rounded-l-full"
         [class]="variant() === 'player' ? 'bg-white' : 'bg-base-content'"
@@ -82,9 +86,9 @@
     }
     <!-- Indeterminate loading sweep — a soft highlight crosses the track
          while the engine is fetching/buffering, so the bar shows activity
-         even when the playhead isn't advancing. Replaces the position fill
-         (above); sits below the chapter ticks. -->
-    @if (loading()) {
+         even when the playhead isn't advancing. Shown only when buffering
+         outside a user seek; sits below the chapter ticks. -->
+    @if (loading() && !showPositionFill()) {
       <div [class]="loadingSweepClass()"></div>
     }
     <!-- Chapter ticks -->

--- a/client/src/app/shared/components/seekbar/seekbar.ts
+++ b/client/src/app/shared/components/seekbar/seekbar.ts
@@ -1,10 +1,12 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   computed,
   input,
   output,
   signal,
+  viewChild,
 } from '@angular/core';
 import { formatTime, calcDragTime, calcHoverPercent, SpriteMetadata } from '../../../core/utils/player.utils';
 
@@ -51,6 +53,15 @@ export class SeekbarComponent {
   readonly hoverTime = signal(0);
   readonly hoverPercent = signal(0);
 
+  /** The focusable track element (role=slider). */
+  private readonly trackRoot = viewChild<ElementRef<HTMLElement>>('trackRoot');
+
+  /** Focus the seekbar track. Used when an arrow press wakes hidden controls so
+   *  subsequent D-pad presses scrub here instead of nudging another control. */
+  focus(): void {
+    this.trackRoot()?.nativeElement.focus();
+  }
+
   readonly formatTime = formatTime;
 
   /** The displayed position: dragTime during drag/seekPending, currentTime otherwise */
@@ -70,6 +81,15 @@ export class SeekbarComponent {
     const d = this.duration() || 1;
     return (this.displayTime() / d) * 100;
   });
+
+  /** Show the determinate position fill — always when not loading, and ALSO
+   *  while the user is actively choosing a seek target (drag / pending seek)
+   *  even if the engine flipped to buffering, so the white bar tracks the seek
+   *  instead of vanishing into the indeterminate sweep. Very visible on Tizen,
+   *  where every seek re-buffers the transcode (loading → fill was hidden). */
+  readonly showPositionFill = computed(
+    () => !this.loading() || this.dragging() || this.seekPending(),
+  );
 
   /** Track height + tint class string. Slim baseline (`h-1`),
    *  thickens to `h-2.5` during interaction:
@@ -150,12 +170,12 @@ export class SeekbarComponent {
 
   readonly tooltipLeft = computed(() => {
     const pct = this.dragging() ? this.displayPercent() : this.hoverPercent();
-    const half = this.previewWidth() / 2 || 120;
-    // No left-side clamp: at low seek positions the tooltip should
-    // happily overlap the overlay title rather than freeze at the
-    // edge. Right-side cap stays so the preview doesn't run off the
-    // player frame.
-    return `min(${pct}%, calc(100% - ${half}px))`;
+    // Centre the tooltip on the seek point (the element carries
+    // `-translate-x-1/2`). Plain `%` only — a CSS min()/calc() cap is ignored
+    // by Tizen's older Chromium in `left`, which left the preview stuck
+    // off-centre on the TV. The tooltip can overshoot the frame edges (the
+    // left side already did); a CSS-only right cap needs min()/clamp().
+    return `${pct}%`;
   });
 
   onProgressDown(event: PointerEvent) {


### PR DESCRIPTION
A batch of player UX fixes, most surfacing on the Tizen TV (Chromium 76) but applied across keyboard/web too. Confirmed on the test TV + browser.

- **Seek-preview thumbnail centred on the seek point** — the Tailwind v4 `-translate-x-1/2` compiles to the CSS `translate:` property (Chromium 104+), which Tizen's Chromium ignores and `downlevel-css.mjs` doesn't convert, so the preview drifted right. Use `transform: translateX(-50%)` (tooltip + arrow), and drop the `min()` cap (also unsupported on the TV) for a plain `left: %`.
- **Seekbar fill follows the seek while buffering** — the determinate fill was hidden the moment `loading()` flipped (every Tizen seek re-buffers the transcode), leaving no white bar. Keep it visible during drag / pending seek; the indeterminate sweep shows only for buffering outside a seek.
- **Hidden controls + ←/→** (keyboard or D-pad) wake the bar, seek, and land focus on the seekbar so the next presses scrub it.
- **Auto-hide blurs the focused control** (routes through `hideControls()`) — otherwise the seekbar kept focus and its `stopPropagation` swallowed the next arrow, leaving the controls stuck hidden on a second seek.
- **Controls appearing under keyboard modality focus play/pause** (like TV) so the next Enter/Space toggles playback.
- **Escape (= the TV Return button) closes a visible controls bar before exiting** — on desktop too, not just TV.

> Note: Tailwind v4's `translate`/`scale`/`rotate` utilities all emit modern CSS properties unsupported on Tizen 6.5 and not downlevelled — a systemic gap worth a separate follow-up (extend `downlevel-css.mjs`). This PR fixes the one user-visible spot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)