### PR TITLE
fix(seekbar): keep position fill through seeks and show buffering sweep

### DIFF
--- a/client/src/app/shared/components/seekbar/seekbar.html
+++ b/client/src/app/shared/components/seekbar/seekbar.html
@@ -74,9 +74,9 @@
     }
     <!-- Progress. `rounded-l-full` matches the track's left cap; right side
          stays square so the progress ends on a crisp vertical edge instead of
-         a curved bulge. Kept visible while loading IF the user is seeking, so
-         the position fill tracks the drag instead of vanishing into the sweep;
-         otherwise hidden so fill + sweep don't show at once. -->
+         a curved bulge. Shown whenever the media is loaded so the fill never
+         drops out mid-seek (the engine re-buffers on every seek); the sweep
+         below only takes over on the cold start, before there's a position. -->
     @if (showPositionFill()) {
       <div
         class="absolute inset-y-0 left-0 rounded-l-full"
@@ -84,11 +84,12 @@
         [style.width.%]="displayPercent()"
       ></div>
     }
-    <!-- Indeterminate loading sweep — a soft highlight crosses the track
-         while the engine is fetching/buffering, so the bar shows activity
-         even when the playhead isn't advancing. Shown only when buffering
-         outside a user seek; sits below the chapter ticks. -->
-    @if (loading() && !showPositionFill()) {
+    <!-- Indeterminate loading sweep — a soft highlight that travels across the
+         track whenever the engine is buffering, painted over the bars (later in
+         the DOM). It reads only on the darker, unfilled track to the right of
+         the playhead: white-on-white over the solid fill leaves no visible
+         animation there, so the fill itself stays static. Below the ticks. -->
+    @if (loading()) {
       <div [class]="loadingSweepClass()"></div>
     }
     <!-- Chapter ticks -->

--- a/client/src/app/shared/components/seekbar/seekbar.ts
+++ b/client/src/app/shared/components/seekbar/seekbar.ts
@@ -68,7 +68,12 @@ export class SeekbarComponent {
   readonly displayTime = computed(() => {
     if (this.dragging()) return this.dragTime();
     if (this.seekPending()) {
-      if (Math.abs(this.currentTime() - this.seekTarget) < 2) {
+      // Only consider the seek settled once the playhead reached the target
+      // AND buffering finished. Clearing on position alone, while the engine is
+      // still buffering (loading), drops the determinate fill into the
+      // indeterminate sweep for a frame — the white bar flickering away right
+      // as the seek lands (very visible on Tizen, where the seek re-buffers).
+      if (Math.abs(this.currentTime() - this.seekTarget) < 2 && !this.loading()) {
         setTimeout(() => this.seekPending.set(false), 0);
         return this.currentTime();
       }
@@ -82,14 +87,15 @@ export class SeekbarComponent {
     return (this.displayTime() / d) * 100;
   });
 
-  /** Show the determinate position fill — always when not loading, and ALSO
-   *  while the user is actively choosing a seek target (drag / pending seek)
-   *  even if the engine flipped to buffering, so the white bar tracks the seek
-   *  instead of vanishing into the indeterminate sweep. Very visible on Tizen,
-   *  where every seek re-buffers the transcode (loading → fill was hidden). */
-  readonly showPositionFill = computed(
-    () => !this.loading() || this.dragging() || this.seekPending(),
-  );
+  /** Show the determinate position fill whenever the media is loaded, i.e. we
+   *  have a real position to draw. Deliberately independent of `loading` and
+   *  `seekPending`: a seek re-buffers and the playhead jumps to the target a
+   *  frame before `loading` flips true, so any condition mixing those signals
+   *  races and drops the fill for a frame between seek-end and resume — on the
+   *  browser as much as on Tizen. The indeterminate sweep is reserved for the
+   *  cold start (no position yet, `duration === 0`); `displayTime` still parks
+   *  the fill on the seek target while buffering. */
+  readonly showPositionFill = computed(() => this.duration() > 0);
 
   /** Track height + tint class string. Slim baseline (`h-1`),
    *  thickens to `h-2.5` during interaction:


### PR DESCRIPTION
The white position fill vanished for a frame between the end of a seek and
playback resuming. It was gated on a mix of `loading`/`seekPending`/
`currentTime`, but the playhead jumps to the seek target a frame before
`loading` flips true, so the gate raced and dropped the determinate fill into
the indeterminate sweep. Very visible on the Tizen TV (every seek re-buffers
the transcode), but present on the browser too.

## Changes
- `showPositionFill` now derives from `duration > 0`, independent of the
  racing signals — the fill shows whenever the media is loaded and never
  flickers out mid-seek.
- `displayTime` keeps the fill parked on the seek target until both the
  playhead arrives **and** buffering ends, so it doesn't snap to the old
  position then back.
- The indeterminate sweep now shows whenever the engine is buffering. It reads
  on the darker unfilled track to the right of the playhead; over the solid
  white fill it's white-on-white, so the fill itself shows no animation.

Built, signed and tested on the Tizen TV.