### PR TITLE
fix(device-profile): probe MP3 inside MP4 for the browser profile

### DIFF
--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -329,7 +329,16 @@ export class BrowserDeviceProfileService {
     } else {
       audioCodecs = [];
       if (this.testCodec(video, hasMSE, 'audio/mp4', 'mp4a.40.2')) audioCodecs.push('aac');
-      if (this.testCodec(video, hasMSE, 'audio/mpeg', '')) audioCodecs.push('mp3');
+      // MP3 probed wrapped in MP4 (mp4a.6B/mp4a.69), the form we deliver —
+      // Chrome's MSE rejects it though 'audio/mpeg' passes. webOS plays it
+      // through its native <video>.
+      if (
+        this.testCodec(video, hasMSE, 'audio/mp4', 'mp4a.6B') ||
+        this.testCodec(video, hasMSE, 'audio/mp4', 'mp4a.69') ||
+        tvPlatform === 'webos'
+      ) {
+        audioCodecs.push('mp3');
+      }
       if (this.testCodec(video, hasMSE, 'audio/mp4', 'ac-3')) audioCodecs.push('ac3');
       if (this.testCodec(video, hasMSE, 'audio/mp4', 'ec-3')) audioCodecs.push('eac3');
       if (this.testCodec(video, hasMSE, 'audio/mp4', 'opus') ||


### PR DESCRIPTION
On the browser, a source whose audio track is MP3 played with broken/no audio:
it was served as DirectPlay (the original MP4) even though the Shaka/MSE path
can't play MP3 wrapped in MP4.

## Cause
The browser device profile probed `audio/mpeg` for MP3 — the raw MPEG
bytestream, for which Chrome's `MediaSource.isTypeSupported` returns `true` —
and advertised `mp3` as direct-playable. But we deliver MP3 inside MP4
(`mp4a.6B`), which Chrome's MSE rejects on append. The backend matched `mp3` in
the profile, chose DirectPlay, and served the original file. The backend
already guards this on the DirectStream path, but DirectPlay runs first.

## Fix
Probe MP3 in the form we actually deliver — wrapped in MP4 (`mp4a.6B` /
`mp4a.69`). Chrome returns `false`, so `mp3` drops out of the browser profile
and the backend falls through to DirectStream: video copied, audio transcoded
to AAC.

- **webOS** keeps MP3 — it renders direct play through its native `<video>`,
  which decodes MP3-in-MP4.
- **Tizen** is unaffected (it never direct plays; DirectStream transcodes MP3
  regardless).
- **Native Android/iOS** use their own capability plugins, not this probe.

Client-only change. Verified on the desktop browser.