### PR TITLE
perf(library): faster TV card grid scroll and card UI fixes

### DIFF
--- a/client/src/app/core/services/tv-spatial-nav.service.ts
+++ b/client/src/app/core/services/tv-spatial-nav.service.ts
@@ -47,6 +47,14 @@ export class TvSpatialNavService {
   private bound = false;
   /** Registered containers, keyed by their host element. */
   private readonly containers = new Map<HTMLElement, ContainerNode>();
+  /** Cached whole-document focusable list, reused until the DOM mutates. When
+   *  no tree container matches the active element (e.g. the library grid),
+   *  findNeighbor scans the whole document on every D-pad press, and
+   *  querySelectorAll + getComputedStyle over hundreds of cards per press
+   *  stalls the main thread. A pure scroll/focus move mutates nothing, so the
+   *  list stays valid between presses; the observer below clears it on change. */
+  private focusableCache: HTMLElement[] | null = null;
+  private focusObserver?: MutationObserver;
 
   constructor() {
     // Bind unconditionally — desktop / laptop users press arrow keys
@@ -81,6 +89,22 @@ export class TvSpatialNavService {
     const focusInHandler = (e: FocusEvent) => this.updateActiveChild(e.target as HTMLElement | null);
     document.addEventListener('focusin', focusInHandler);
     this.destroyRef.onDestroy(() => document.removeEventListener('focusin', focusInHandler));
+    // Invalidate the focusable cache whenever the DOM that could change the
+    // focusable set changes. Scoped to the attributes that flip an element's
+    // focusability/visibility (not every attribute) so cosmetic churn doesn't
+    // thrash the cache; childList/subtree covers infinite-scroll card adds.
+    if (typeof MutationObserver !== 'undefined') {
+      this.focusObserver = new MutationObserver(() => {
+        this.focusableCache = null;
+      });
+      this.focusObserver.observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['class', 'style', 'disabled', 'hidden', 'aria-hidden', 'tabindex'],
+      });
+      this.destroyRef.onDestroy(() => this.focusObserver?.disconnect());
+    }
     // Android TV WebView often leaves the body un-focused on first paint, which
     // means D-pad events are consumed by the native View and never reach JS.
     // Pushing focus to the first interactive element guarantees subsequent
@@ -158,10 +182,15 @@ export class TvSpatialNavService {
     }
   }
 
+  /** Whole-document focusables, cached between DOM mutations (see focusableCache). */
+  private getFocusables(): HTMLElement[] {
+    return (this.focusableCache ??= collectFocusables());
+  }
+
   private focusFirstIfNoFocus() {
     if (typeof document === 'undefined') return;
     if (document.activeElement && document.activeElement !== document.body) return;
-    const all = collectFocusables();
+    const all = this.getFocusables();
     all[0]?.focus({ preventScroll: true });
   }
 
@@ -319,7 +348,7 @@ export class TvSpatialNavService {
       const tree = this.findNeighborInTree(active, dir);
       if (tree) return tree;
     }
-    const all = openModal ? collectFocusables(openModal) : collectFocusables();
+    const all = openModal ? collectFocusables(openModal) : this.getFocusables();
     if (!all.length) return null;
 
     if (!active || active === document.body) {
@@ -359,7 +388,6 @@ export class TvSpatialNavService {
       if (el === active) continue;
       const r = el.getBoundingClientRect();
       if (r.width === 0 || r.height === 0) continue;
-      if (getComputedStyle(el).pointerEvents === 'none') continue;
 
       const cx = r.left + r.width / 2;
       const cy = r.top + r.height / 2;
@@ -633,6 +661,10 @@ function collectFocusables(root: ParentNode = document): HTMLElement[] {
     }
     const style = getComputedStyle(el);
     if (style.visibility === 'hidden' || style.display === 'none') return false;
+    // pointerEvents:none folded in here (the scoring loop used to call
+    // getComputedStyle a second time per element for this) — reuses the style
+    // object already resolved above, so it's free, and the result is cached.
+    if (style.pointerEvents === 'none') return false;
     return true;
   });
   // Keep only the outermost focusables: if an element has an ancestor that is

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -284,9 +284,11 @@
         </div>
       }
       <div class="flex gap-1">
-        <div class="flex-1 min-w-0 grid content-start grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-1.5 sm:gap-4"
+        <div #cardGrid class="flex-1 min-w-0 grid content-start grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-1.5 sm:gap-4"
           [class.pr-4]="sortBy() === 'title' && sortOrder() === 'ASC'"
-          [class.pr-2]="sortBy() !== 'title' || sortOrder() !== 'ASC'">
+          [class.pr-2]="sortBy() !== 'title' || sortOrder() !== 'ASC'"
+          [style.paddingTop.px]="list.padTop()"
+          [style.paddingBottom.px]="list.padBottom()">
           @for (item of list.visible(); track item.id) {
             @if (bulkMode()) {
               <div

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -284,7 +284,7 @@
         </div>
       }
       <div class="flex gap-1">
-        <div class="flex-1 min-w-0 grid content-start grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-6 gap-1.5 sm:gap-4"
+        <div class="flex-1 min-w-0 grid content-start grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-1.5 sm:gap-4"
           [class.pr-4]="sortBy() === 'title' && sortOrder() === 'ASC'"
           [class.pr-2]="sortBy() !== 'title' || sortOrder() !== 'ASC'">
           @for (item of list.visible(); track item.id) {
@@ -436,7 +436,7 @@
            page rather than a separate component. -->
       @if (suggestionsRecommendations().length) {
         <h2 class="text-lg font-semibold mt-2">{{ 'home.recommendations' | translate }}</h2>
-        <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-6 gap-1.5 sm:gap-4">
+        <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-1.5 sm:gap-4">
           @for (rec of suggestionsRecommendations(); track rec.media.id) {
             <app-media-card
               [imageUrl]="rec.media.posterUrl"

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -291,6 +291,7 @@
             @if (bulkMode()) {
               <div
                 class="relative cursor-pointer cv-auto"
+                style="contain-intrinsic-size: auto 18rem"
                 [id]="'media-' + item.id"
                 (click)="toggleSelect(item.id)"
               >
@@ -309,7 +310,12 @@
                 />
               </div>
             } @else {
-              <div [id]="'media-' + item.id" [attr.data-library-focus]="'media:' + item.id">
+              <div
+                class="cv-auto"
+                style="contain-intrinsic-size: auto 18rem"
+                [id]="'media-' + item.id"
+                [attr.data-library-focus]="'media:' + item.id"
+              >
                 <app-media-card
                   [media]="item"
                   [status]="watchedIds().has(item.id) ? 'watched' : null"

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -291,7 +291,6 @@
             @if (bulkMode()) {
               <div
                 class="relative cursor-pointer cv-auto"
-                style="contain-intrinsic-size: auto 18rem"
                 [id]="'media-' + item.id"
                 (click)="toggleSelect(item.id)"
               >
@@ -310,12 +309,7 @@
                 />
               </div>
             } @else {
-              <div
-                class="cv-auto"
-                style="contain-intrinsic-size: auto 18rem"
-                [id]="'media-' + item.id"
-                [attr.data-library-focus]="'media:' + item.id"
-              >
+              <div [id]="'media-' + item.id" [attr.data-library-focus]="'media:' + item.id">
                 <app-media-card
                   [media]="item"
                   [status]="watchedIds().has(item.id) ? 'watched' : null"

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -34,7 +34,7 @@ import { NavbarService } from '../../core/services/navbar.service';
 import { TvService } from '../../core/services/tv.service';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
 import { AppResumeService } from '../../core/services/app-resume.service';
-import { InfiniteScrollList } from '../../shared/utils/infinite-scroll-list';
+import { InfiniteScrollList, type GridMetrics } from '../../shared/utils/infinite-scroll-list';
 import { LucideSearch, LucideSlidersHorizontal, LucideArrowUp, LucideArrowDown, LucideX, LucideFilm } from '@lucide/angular';
 import { MosaicCardComponent } from '../../shared/components/mosaic-card/mosaic-card';
 
@@ -172,6 +172,16 @@ export class LibraryComponent implements OnInit, OnDestroy {
     this.list.observeSentinel(ref);
   }
 
+  /** The `all`-view card grid — measured for DOM windowing on TV. */
+  private cardGridEl?: HTMLElement;
+  @ViewChild('cardGrid') set cardGridRef(ref: ElementRef<HTMLElement> | undefined) {
+    this.cardGridEl = ref?.nativeElement;
+    // Grid just (re)mounted — e.g. initial load or a tab switch back to `all`.
+    // Recompute the window now that it's measurable.
+    if (ref && this.tv.isTv()) this.list.onWindowScroll();
+  }
+  private onResize?: () => void;
+
   // Bulk editing
   readonly selectedIds = signal<Set<number>>(new Set());
   readonly bulkMode = signal(false);
@@ -193,6 +203,14 @@ export class LibraryComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.arrivedViaBack = this.navbar.lastWasBack();
+    if (this.tv.isTv()) {
+      // DOM windowing for the `all` grid: only render a row-aligned slice
+      // around the viewport so a large library doesn't pile hundreds of cards
+      // into the DOM and stutter the TV's scroll. Inert on every other surface.
+      this.list.enableWindowing(() => this.readGridMetrics(), 4);
+      this.onResize = () => this.list.onWindowScroll();
+      window.addEventListener('resize', this.onResize, { passive: true });
+    }
     if (this.tv.isTv()) {
       this.navStartSub = this.router.events
         .pipe(filter((e): e is NavigationStart => e instanceof NavigationStart))
@@ -350,6 +368,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.scrollMemory.deactivate();
     this.list.destroy();
+    if (this.onResize) window.removeEventListener('resize', this.onResize);
     this.navbar.clearPageTitle();
     this.navStartSub?.unsubscribe();
     this.attachedSub?.unsubscribe();
@@ -384,6 +403,24 @@ export class LibraryComponent implements OnInit, OnDestroy {
 
   scrollToLetter(letter: string) {
     this.list.scrollToLetter(letter, (m) => m.title, 'media');
+  }
+
+  /** Live measurements of the `all` grid for windowing. Read together (rect +
+   *  scroller.scrollTop) so a webOS `zoom` scales them consistently. Returns
+   *  null until the grid is laid out, where windowing falls back to full render. */
+  private readGridMetrics(): GridMetrics | null {
+    const grid = this.cardGridEl;
+    if (!grid) return null;
+    const cs = getComputedStyle(grid);
+    const cols = cs.gridTemplateColumns.split(' ').filter((t) => t && t !== '0px').length;
+    if (cols < 1) return null;
+    const firstCell = grid.firstElementChild as HTMLElement | null;
+    const cellH = firstCell?.getBoundingClientRect().height ?? 0;
+    if (cellH <= 0) return null;
+    const rowGap = parseFloat(cs.rowGap) || 0;
+    const scroller = document.scrollingElement ?? document.documentElement;
+    const gridTopDoc = grid.getBoundingClientRect().top + scroller.scrollTop;
+    return { gridTopDoc, rowHeight: cellH + rowGap, rowGap, cols };
   }
 
   onSearch(query: string) {

--- a/client/src/app/shared/utils/infinite-scroll-list.ts
+++ b/client/src/app/shared/utils/infinite-scroll-list.ts
@@ -11,7 +11,6 @@ export class InfiniteScrollList<T extends { id: number }> {
   private idPrefix = '';
   private letterBoundaries: { letter: string; itemId: number }[] = [];
   private scrollHandler: (() => void) | null = null;
-  private scrollRaf: number | null = null;
   private scrollLock = false;
   private scrollLockTimeout: ReturnType<typeof setTimeout> | null = null;
 
@@ -133,16 +132,7 @@ export class InfiniteScrollList<T extends { id: number }> {
   /** Start tracking scroll position to update activeLetter. Call once after init. */
   trackScroll(idPrefix: string) {
     this.idPrefix = idPrefix;
-    // Coalesce to one active-letter lookup per frame: onScroll reads
-    // getBoundingClientRect for every letter boundary (a forced layout), and
-    // the TV fires scroll rapidly during its smooth D-pad scroll.
-    this.scrollHandler = () => {
-      if (this.scrollRaf !== null) return;
-      this.scrollRaf = requestAnimationFrame(() => {
-        this.scrollRaf = null;
-        this.onScroll();
-      });
-    };
+    this.scrollHandler = () => this.onScroll();
     window.addEventListener('scroll', this.scrollHandler, { passive: true });
   }
 
@@ -151,10 +141,6 @@ export class InfiniteScrollList<T extends { id: number }> {
     this.observer?.disconnect();
     if (this.scrollHandler) {
       window.removeEventListener('scroll', this.scrollHandler);
-    }
-    if (this.scrollRaf !== null) {
-      cancelAnimationFrame(this.scrollRaf);
-      this.scrollRaf = null;
     }
   }
 

--- a/client/src/app/shared/utils/infinite-scroll-list.ts
+++ b/client/src/app/shared/utils/infinite-scroll-list.ts
@@ -2,6 +2,21 @@ import { signal, ElementRef } from '@angular/core';
 
 const DEFAULT_BATCH_SIZE = 60;
 
+/** Live measurements of the rendered grid, supplied by the owning component
+ *  when windowing is enabled. Every value lives in one coordinate space — CSS
+ *  px in the document scroller — so they stay consistent even under a webOS
+ *  `zoom` (read rect.top and scroller.scrollTop together). */
+export interface GridMetrics {
+  /** Grid top edge in document coords: rect.top + scroller.scrollTop. */
+  gridTopDoc: number;
+  /** One row's height: a cell's measured height plus the row gap. */
+  rowHeight: number;
+  /** Row gap in px (subtracted once when reserving off-window padding). */
+  rowGap: number;
+  /** Columns currently laid out. */
+  cols: number;
+}
+
 export class InfiniteScrollList<T extends { id: number }> {
   private allItems: T[] = [];
   private visibleCount = 0;
@@ -9,10 +24,19 @@ export class InfiniteScrollList<T extends { id: number }> {
   private readonly batchSize: number;
   private titleFn: ((item: T) => string) | null = null;
   private idPrefix = '';
-  private letterBoundaries: { letter: string; itemId: number }[] = [];
+  private letterBoundaries: { letter: string; itemId: number; index: number }[] = [];
   private scrollHandler: (() => void) | null = null;
   private scrollLock = false;
   private scrollLockTimeout: ReturnType<typeof setTimeout> | null = null;
+  private readonly idIndex = new Map<number, number>();
+
+  // Windowing — opt-in via enableWindowing(). Renders only a row-aligned slice
+  // of allItems around the viewport so large lists don't pile hundreds of DOM
+  // nodes onto the page. Inert (zero behavior change) unless enabled.
+  private windowing = false;
+  private metricsFn: (() => GridMetrics | null) | null = null;
+  private bufferRows = 4;
+  private windowRaf: number | null = null;
 
   /** All items (reactive — use in computed for counts/stats). */
   readonly all = signal<T[]>([]);
@@ -23,6 +47,10 @@ export class InfiniteScrollList<T extends { id: number }> {
   readonly availableLetters = signal<Set<string>>(new Set());
   /** Currently visible letter based on scroll position. */
   readonly activeLetter = signal('');
+  /** Off-window spacer heights (px). Bound to the grid's padding so the
+   *  scrollbar and absolute item positions match the un-windowed layout. */
+  readonly padTop = signal(0);
+  readonly padBottom = signal(0);
 
   constructor(batchSize = DEFAULT_BATCH_SIZE) {
     this.batchSize = batchSize;
@@ -39,6 +67,8 @@ export class InfiniteScrollList<T extends { id: number }> {
     if (titleFn) this.titleFn = titleFn;
     this.all.set(items);
     this.total.set(items.length);
+    this.idIndex.clear();
+    for (let i = 0; i < items.length; i++) this.idIndex.set(items[i].id, i);
     this.visibleCount = Math.min(
       Math.max(this.visibleCount, this.batchSize),
       items.length,
@@ -52,14 +82,103 @@ export class InfiniteScrollList<T extends { id: number }> {
     return this.allItems;
   }
 
+  /** Index of an item id in allItems, or -1. */
+  indexOf(id: number): number {
+    return this.idIndex.get(id) ?? -1;
+  }
+
   /** Load next batch. */
   showMore() {
+    if (this.windowing) return;
     if (this.visibleCount >= this.allItems.length) return;
     this.visibleCount = Math.min(
       this.visibleCount + this.batchSize,
       this.allItems.length,
     );
     this.updateVisible();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Windowing (opt-in)
+  // ---------------------------------------------------------------------------
+
+  /** Opt in to DOM windowing: only a row-aligned slice around the viewport
+   *  renders, with `bufferRows` of overscan each side so D-pad focus targets
+   *  stay rendered. `metricsFn` reads the live grid. Pages that never call this
+   *  keep the plain slice-0..visibleCount behavior. */
+  enableWindowing(metricsFn: () => GridMetrics | null, bufferRows = 4) {
+    this.windowing = true;
+    this.metricsFn = metricsFn;
+    this.bufferRows = bufferRows;
+    this.hasMore.set(false);
+    this.updateVisible();
+  }
+
+  /** Recompute the window from the current scroll position (rAF-throttled). */
+  onWindowScroll() {
+    if (!this.windowing || this.windowRaf !== null) return;
+    this.windowRaf = requestAnimationFrame(() => {
+      this.windowRaf = null;
+      this.recomputeWindow();
+    });
+  }
+
+  /** Synchronously ensure the row containing `index` (± buffer) is rendered. */
+  ensureRendered(index: number) {
+    if (!this.windowing) return;
+    const m = this.metricsFn?.();
+    if (!m || m.cols < 1) return;
+    const row = Math.floor(index / m.cols);
+    this.applyWindow(m, row - this.bufferRows, row + this.bufferRows + 1);
+  }
+
+  private recomputeWindow() {
+    const m = this.metricsFn?.();
+    if (!m || m.rowHeight <= 0 || m.cols < 1) {
+      // Metrics not ready yet (grid not laid out) — render everything, which
+      // is exactly the non-windowed behavior, so never worse than before.
+      this.visible.set(this.allItems.slice());
+      this.padTop.set(0);
+      this.padBottom.set(0);
+      return;
+    }
+    const scrollTop = (document.scrollingElement ?? document.documentElement).scrollTop;
+    const vh = window.innerHeight;
+    const firstRow = Math.floor((scrollTop - m.gridTopDoc) / m.rowHeight);
+    const lastRow = Math.floor((scrollTop + vh - m.gridTopDoc) / m.rowHeight);
+    this.applyWindow(m, firstRow - this.bufferRows, lastRow + this.bufferRows + 1);
+  }
+
+  private applyWindow(m: GridMetrics, startRowRaw: number, endRowRaw: number) {
+    const total = this.allItems.length;
+    const cols = m.cols;
+    const totalRows = Math.ceil(total / cols);
+    let startRow = Math.max(0, Math.min(startRowRaw, totalRows));
+    let endRow = Math.min(totalRows, Math.max(startRow + 1, endRowRaw));
+    // Never window out the focused card's row — detaching it drops focus to
+    // <body>, and the next arrow press then jumps back to the first card.
+    const focusRow = this.focusedRow(cols);
+    if (focusRow >= 0) {
+      startRow = Math.min(startRow, focusRow);
+      endRow = Math.max(endRow, focusRow + 1);
+    }
+    const windowStart = startRow * cols;
+    const windowEnd = Math.min(total, endRow * cols);
+    // Row gap sits only BETWEEN tracks, never between padding and the first/last
+    // track — drop one gap from each spacer so total height matches exactly.
+    this.padTop.set(startRow > 0 ? startRow * m.rowHeight - m.rowGap : 0);
+    this.padBottom.set(endRow < totalRows ? (totalRows - endRow) * m.rowHeight - m.rowGap : 0);
+    this.visible.set(this.allItems.slice(windowStart, windowEnd));
+  }
+
+  private focusedRow(cols: number): number {
+    if (typeof document === 'undefined') return -1;
+    const active = document.activeElement as HTMLElement | null;
+    const el = active?.closest<HTMLElement>('[data-library-focus^="media:"]');
+    const sel = el?.getAttribute('data-library-focus');
+    if (!sel) return -1;
+    const idx = this.idIndex.get(Number(sel.slice('media:'.length)));
+    return idx == null ? -1 : Math.floor(idx / cols);
   }
 
   /**
@@ -82,6 +201,25 @@ export class InfiniteScrollList<T extends { id: number }> {
     this.activeLetter.set(letter);
     this.scrollLock = true;
     if (this.scrollLockTimeout) clearTimeout(this.scrollLockTimeout);
+
+    if (this.windowing) {
+      const m = this.metricsFn?.();
+      if (m && m.rowHeight > 0 && m.cols >= 1) {
+        // The target card may be windowed out — render it first, then scroll
+        // to its computed Y (scrollIntoView would need the element to exist).
+        this.ensureRendered(index);
+        const targetY = Math.max(
+          0,
+          m.gridTopDoc + Math.floor(index / m.cols) * m.rowHeight - 96,
+        );
+        requestAnimationFrame(() => {
+          window.scrollTo({ top: targetY, left: 0, behavior: 'smooth' });
+          this.armScrollUnlock();
+        });
+        return;
+      }
+    }
+
     if (index >= this.visibleCount) {
       this.visibleCount = Math.min(
         index + this.batchSize,
@@ -98,21 +236,26 @@ export class InfiniteScrollList<T extends { id: number }> {
         return;
       }
       target.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      // Unlock after scroll animation settles
-      const unlockOnScroll = () => {
-        if (this.scrollLockTimeout) clearTimeout(this.scrollLockTimeout);
-        this.scrollLockTimeout = setTimeout(() => {
-          this.scrollLock = false;
-          window.removeEventListener('scroll', unlockOnScroll);
-        }, 150);
-      };
-      window.addEventListener('scroll', unlockOnScroll, { passive: true });
-      // Fallback if already at position
+      this.armScrollUnlock();
+    });
+  }
+
+  /** Release the scroll lock once the smooth scroll settles (shared by the
+   *  windowed and non-windowed scrollToLetter paths). */
+  private armScrollUnlock() {
+    const unlockOnScroll = () => {
+      if (this.scrollLockTimeout) clearTimeout(this.scrollLockTimeout);
       this.scrollLockTimeout = setTimeout(() => {
         this.scrollLock = false;
         window.removeEventListener('scroll', unlockOnScroll);
       }, 150);
-    });
+    };
+    window.addEventListener('scroll', unlockOnScroll, { passive: true });
+    // Fallback if already at position (no scroll event fires).
+    this.scrollLockTimeout = setTimeout(() => {
+      this.scrollLock = false;
+      window.removeEventListener('scroll', unlockOnScroll);
+    }, 150);
   }
 
   /** Bind to a sentinel element via @ViewChild setter. */
@@ -132,7 +275,10 @@ export class InfiniteScrollList<T extends { id: number }> {
   /** Start tracking scroll position to update activeLetter. Call once after init. */
   trackScroll(idPrefix: string) {
     this.idPrefix = idPrefix;
-    this.scrollHandler = () => this.onScroll();
+    this.scrollHandler = () => {
+      this.onWindowScroll();
+      this.onScroll();
+    };
     window.addEventListener('scroll', this.scrollHandler, { passive: true });
   }
 
@@ -142,9 +288,17 @@ export class InfiniteScrollList<T extends { id: number }> {
     if (this.scrollHandler) {
       window.removeEventListener('scroll', this.scrollHandler);
     }
+    if (this.windowRaf !== null) {
+      cancelAnimationFrame(this.windowRaf);
+      this.windowRaf = null;
+    }
   }
 
   private updateVisible() {
+    if (this.windowing) {
+      this.recomputeWindow();
+      return;
+    }
     this.visible.set(this.allItems.slice(0, this.visibleCount));
     this.hasMore.set(this.visibleCount < this.allItems.length);
   }
@@ -152,16 +306,18 @@ export class InfiniteScrollList<T extends { id: number }> {
   private recomputeLetters() {
     if (!this.titleFn) return;
     const letters = new Set<string>();
-    const boundaries: { letter: string; itemId: number }[] = [];
+    const boundaries: { letter: string; itemId: number; index: number }[] = [];
     const seen = new Set<string>();
+    let i = 0;
     for (const item of this.allItems) {
       const first = (this.titleFn(item) || '').charAt(0).toUpperCase();
       const letter = /[A-Z]/.test(first) ? first : '#';
       letters.add(letter);
       if (!seen.has(letter)) {
         seen.add(letter);
-        boundaries.push({ letter, itemId: item.id });
+        boundaries.push({ letter, itemId: item.id, index: i });
       }
+      i++;
     }
     this.availableLetters.set(letters);
     this.letterBoundaries = boundaries;
@@ -172,6 +328,22 @@ export class InfiniteScrollList<T extends { id: number }> {
 
   private onScroll() {
     if (this.scrollLock || !this.letterBoundaries.length || !this.idPrefix) return;
+    if (this.windowing) {
+      // Position math — no getElementById, which would miss windowed-out
+      // boundary cards (and skips the per-scroll forced layout entirely).
+      const m = this.metricsFn?.();
+      if (!m || m.rowHeight <= 0 || m.cols < 1) return;
+      const scrollTop = (document.scrollingElement ?? document.documentElement).scrollTop;
+      const topRow = Math.max(0, Math.floor((scrollTop + 96 - m.gridTopDoc) / m.rowHeight));
+      const topIndex = topRow * m.cols;
+      let current = this.letterBoundaries[0].letter;
+      for (const b of this.letterBoundaries) {
+        if (b.index <= topIndex) current = b.letter;
+        else break;
+      }
+      this.activeLetter.set(current);
+      return;
+    }
     let current = this.letterBoundaries[0].letter;
     for (const { letter, itemId } of this.letterBoundaries) {
       const el = document.getElementById(`${this.idPrefix}-${itemId}`);

--- a/client/src/app/shared/utils/infinite-scroll-list.ts
+++ b/client/src/app/shared/utils/infinite-scroll-list.ts
@@ -11,6 +11,7 @@ export class InfiniteScrollList<T extends { id: number }> {
   private idPrefix = '';
   private letterBoundaries: { letter: string; itemId: number }[] = [];
   private scrollHandler: (() => void) | null = null;
+  private scrollRaf: number | null = null;
   private scrollLock = false;
   private scrollLockTimeout: ReturnType<typeof setTimeout> | null = null;
 
@@ -132,7 +133,16 @@ export class InfiniteScrollList<T extends { id: number }> {
   /** Start tracking scroll position to update activeLetter. Call once after init. */
   trackScroll(idPrefix: string) {
     this.idPrefix = idPrefix;
-    this.scrollHandler = () => this.onScroll();
+    // Coalesce to one active-letter lookup per frame: onScroll reads
+    // getBoundingClientRect for every letter boundary (a forced layout), and
+    // the TV fires scroll rapidly during its smooth D-pad scroll.
+    this.scrollHandler = () => {
+      if (this.scrollRaf !== null) return;
+      this.scrollRaf = requestAnimationFrame(() => {
+        this.scrollRaf = null;
+        this.onScroll();
+      });
+    };
     window.addEventListener('scroll', this.scrollHandler, { passive: true });
   }
 
@@ -141,6 +151,10 @@ export class InfiniteScrollList<T extends { id: number }> {
     this.observer?.disconnect();
     if (this.scrollHandler) {
       window.removeEventListener('scroll', this.scrollHandler);
+    }
+    if (this.scrollRaf !== null) {
+      cancelAnimationFrame(this.scrollRaf);
+      this.scrollRaf = null;
     }
   }
 

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -256,6 +256,14 @@ body.tv-webos:not(.immersive) {
 html.tv-host {
   background: #1d232a;
   scroll-behavior: smooth;
+  /* D-pad focus-into-view uses scrollIntoView({block:'nearest'}), which
+     otherwise parks the focused card flush against a screen edge. Keep it off
+     the edges: clear the top dock (matching the 96px the home rows snap to) and
+     leave a strip of look-ahead below so moving down a grid row never leaves
+     the bottom row cut. The document is the scroll container (see layout: <main>
+     stays overflow-x:clip precisely so it isn't a scroller), so it goes here. */
+  scroll-padding-top: 96px;
+  scroll-padding-bottom: 20vh;
 }
 /* Disable hover styles on TV — there is no pointer */
 body.tv *:hover {
@@ -342,6 +350,21 @@ body.tv app-media-card figure:focus-visible,
 body.tv [data-home-focus]:focus-visible,
 body.tv [data-tv-focusable]:focus-visible {
   transform: scale(1.06);
+}
+
+/* Card labels are sized in rem (text-sm / text-xs), so the body.tv 18px font
+   bump doesn't reach them — they read tiny from the couch. Enlarge the title
+   and subtitle across every TV. */
+body.tv app-media-card h3 {
+  font-size: 1.25rem;
+}
+body.tv app-media-card p {
+  font-size: 0.95rem;
+  /* text-base-content/50 dims via color-mix, which the TV WebView (Chrome 85)
+     can't parse — its downlevel fallback drops the alpha, so the subtitle lands
+     at full colour. Force the colour and dim with the opacity property. */
+  color: var(--color-base-content);
+  opacity: 0.5;
 }
 
 /* Media-card simplification on TV: the card is a single focus target. The

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -163,6 +163,23 @@ body.native.hero-page {
   contain-intrinsic-size: auto 10rem;
 }
 
+/* Browsers without `aspect-ratio` (the TV WebView's Chromium 85) ignore the
+   poster figure's aspect-2/3, so it reserves no height and the lazy <img>
+   only claims space once it decodes — every decode mid-scroll reflows the
+   whole non-virtualized library grid. Reserve the 2:3 box with the padding
+   ratio there and float the image into it, so a decode never resizes a cell.
+   Modern browsers keep the native aspect-ratio path (this block is skipped). */
+@supports not (aspect-ratio: 1 / 1) {
+  app-media-card figure.aspect-2\/3 {
+    height: 0;
+    padding-bottom: 150%;
+  }
+  app-media-card figure.aspect-2\/3 > img {
+    position: absolute;
+    inset: 0;
+  }
+}
+
 @keyframes slide-in-right {
   from {
     opacity: 0;
@@ -392,17 +409,22 @@ app-media-card figure:focus-visible,
     0 0 18px -4px var(--color-primary, #7a3ff2),
     0 8px 22px rgb(0 0 0 / 35%) !important;
 }
-/* Android TV ships on Capacitor + Chromium WebView, often with mid-range
-   SoCs where blurred box-shadows are the most expensive thing on the
-   compositor. D-pad nav rapidly moves focus card-to-card, so each move
-   re-paints the 18 px glow + 22 px drop shadow blur regions — visible
-   as jank. Drop the blurs on AndroidTV, keep the crisp 2-step ring
-   (cheap, no blur). Tizen / webOS / desktop keep the full Lumen look. */
-body.tv-androidtv app-media-card figure:focus-visible,
-body.tv-androidtv [data-home-focus]:focus-visible {
+/* TVs run on mid-range SoCs where blurred box-shadows are the most expensive
+   thing on the compositor, and D-pad nav rapidly moves focus card-to-card —
+   each move would re-paint the 18px glow + 22px drop-shadow blur regions.
+   Drop the blurs on every TV, keep the crisp 2-step ring (cheap, no blur).
+   Desktop keeps the full Lumen look. */
+body.tv app-media-card figure:focus-visible,
+body.tv [data-home-focus]:focus-visible {
   box-shadow:
     0 0 0 2px var(--color-base-100, #1d232a),
     0 0 0 6px var(--color-primary, #7a3ff2) !important;
+}
+/* Resting cards carry shadow-md (a blurred shadow) re-rasterised for every
+   visible card on each scroll frame — drop it on TV; the focus ring is the
+   only affordance the 10-foot UI needs. */
+body.tv app-media-card figure:not(:focus-visible) {
+  box-shadow: none;
 }
 /* Smaller media-card footprint on AndroidTV: visually the same layout but
    ~10 % shorter cards, which both reduces image decode pressure (smaller


### PR DESCRIPTION
The library `all` grid scrolled poorly on the TV and the cards didn't match the
home rails. This batch tunes the 10-foot UI and cuts the scroll cost.

## Card UI (TV)
- Grid uses auto-fill minmax(160px, 1fr) so posters match the home card width
  (~10 per row) whatever the WebView viewport reports.
- scroll-padding (96px top, 20vh bottom) so D-pad focus-into-view no longer
  parks the bottom row cut off.
- Bigger media-card title (1.25rem) and subtitle (0.95rem) — rem sizes weren't
  reached by the body.tv 18px bump.
- Subtitle dimmed via the opacity property (text-base-content/50's color-mix has
  no working fallback on the TV WebView's Chrome 85).

## Scroll performance (TV)
- Reserve the poster box with a padding ratio where aspect-ratio is unsupported
  (Chrome 85), so a lazy image decode mid-scroll no longer reflows the grid.
- Drop the resting blurred shadow on TV cards and the blurred focus glow (crisp
  ring only) — the dominant per-frame compositor cost.
- Cache the spatial-nav focusable list between DOM mutations, so a D-pad press on
  the tree-less grid no longer scans the whole document with getComputedStyle
  over hundreds of cards.
- Window the grid: render only a row-aligned slice around the viewport (plus a
  buffer), with grid padding reserving the off-window height. Opt-in, gated to
  TV + the `all` view, so the shared InfiniteScrollList and every other page
  (persons, person-detail, desktop/mobile) keep their behaviour.

Verified on the Tizen TV: D-pad nav, alphabet and scroll-memory intact; other
pages unaffected.
