### PR TITLE
fix: spatial-nav, library UX and direct-play binding

### DIFF
--- a/backend/src/modules/images/image.controller.ts
+++ b/backend/src/modules/images/image.controller.ts
@@ -76,7 +76,11 @@ export class ImageController {
 
     // Fall back to `full` when the requested size hasn't been generated yet
     // (e.g. images downloaded before multi-size support, or non-TMDB sources
-    // that only yield a single file).
+    // that only yield a single file). NOTE: `full` is the original (~2000px),
+    // so an old library serves oversized bytes for grid thumbs — the
+    // X-Image-Size-Served header below makes that downgrade observable. The
+    // proper fix is a variant backfill (re-fetch the missing TMDB sizes).
+    let servedSize: ImageSize = size;
     if (!existsSync(filePath) && size !== 'full') {
       filePath = this.imageService.getDiskPath(
         type as ImageType,
@@ -84,11 +88,13 @@ export class ImageController {
         variant as MediaImageVariant | undefined,
         'full',
       );
+      servedSize = 'full';
     }
 
     if (!existsSync(filePath)) throw new NotFoundException();
 
     res.set('Cache-Control', 'public, max-age=86400');
+    if (servedSize !== size) res.set('X-Image-Size-Served', servedSize);
     res.sendFile(filePath);
   }
 }

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -686,12 +686,24 @@ export class StreamBuilderService {
     let videoSupported = false;
     let audioSupported = false;
 
-    // Check against each DirectPlayProfile
+    // Per-flag support across all profiles — kept for DirectStream's per-codec
+    // copy decision and the reason messages below (those answer "is this codec
+    // playable at all", independent of container).
     for (const dp of profile.directPlayProfiles) {
       if (dp.containers.includes(source.container)) containerSupported = true;
       if (dp.videoCodecs.includes(source.videoCodec)) videoSupported = true;
       if (dp.audioCodecs.includes(source.audioCodec)) audioSupported = true;
     }
+
+    // Direct Play requires ONE profile entry to bind all three together — a
+    // container from one entry paired with a codec from another is a
+    // combination the device never claimed it can play as-is.
+    const boundMatch = profile.directPlayProfiles.some(
+      (dp) =>
+        dp.containers.includes(source.container) &&
+        dp.videoCodecs.includes(source.videoCodec) &&
+        dp.audioCodecs.includes(source.audioCodec),
+    );
 
     // Check fine-grained codec conditions on video
     let videoConditionsMet = true;
@@ -796,11 +808,9 @@ export class StreamBuilderService {
       });
     }
 
-    const canDirectPlay =
-      containerSupported &&
-      videoSupported &&
-      audioSupported &&
-      videoConditionsMet;
+    // boundMatch already implies container + video + audio are supported (in one
+    // entry); audioSupported additionally carries the channel-count constraint.
+    const canDirectPlay = boundMatch && audioSupported && videoConditionsMet;
     return {
       canDirectPlay,
       containerSupported,

--- a/client/postcss/tv-fallbacks.cjs
+++ b/client/postcss/tv-fallbacks.cjs
@@ -121,6 +121,22 @@ function isLevel3SimpleSelector(s) {
   return tokens.join('') === s && tokens.length === 1;
 }
 
+/** `translate: x [y]` (Chrome 104+) → an equivalent transform function for
+ *  Chromium 85, which drops the standalone property. */
+function translateToFn(value) {
+  const parts = value.trim().split(/\s+/);
+  if (parts.length <= 1) return `translateX(${parts[0] || '0'})`;
+  return `translate(${parts[0]}, ${parts[1]})`;
+}
+
+/** `scale: x [y]` → `scale(...)`, converting the percentage form (`95%` → `.95`)
+ *  the `scale()` function doesn't accept. */
+function scaleToFn(value) {
+  const toNum = (v) => (v.endsWith('%') ? String(parseFloat(v) / 100) : v);
+  const parts = value.trim().split(/\s+/).map(toNum);
+  return parts.length <= 1 ? `scale(${parts[0]})` : `scale(${parts[0]}, ${parts[1]})`;
+}
+
 const CQ_UNIT = /\d(cqi|cqw|cqh|cqb)\b/;
 const DROP_PROPS = new Set(['text-wrap', 'field-sizing']);
 const SCROLL_INLINE_MAP = {
@@ -158,6 +174,33 @@ module.exports = () => ({
       if (next.length === 0) rule.remove();
       else rule.selector = next.join(',');
     }
+    // Tailwind v4 emits the individual transform properties `translate` /
+    // `rotate` / `scale` (Chrome 104+); Chromium 85 silently drops them, so
+    // centering, hover-scale, indicators etc. break. Fold whatever a rule
+    // carries into ONE `transform` — in spec order (translate → rotate →
+    // scale) so several on one rule compose instead of clobbering, and so a
+    // `transition: translate` (rewritten below) still animates it.
+    let tx = null;
+    let rot = null;
+    let sc = null;
+    rule.walkDecls((d) => {
+      if (d.prop === 'translate') tx = translateToFn(d.value);
+      else if (d.prop === 'rotate') rot = `rotate(${d.value})`;
+      else if (d.prop === 'scale') sc = scaleToFn(d.value);
+    });
+    if (tx || rot || sc) {
+      rule.walkDecls((d) => {
+        if (d.prop === 'translate' || d.prop === 'rotate' || d.prop === 'scale') {
+          d.remove();
+        }
+      });
+      const composed = [tx, rot, sc].filter(Boolean).join(' ');
+      const existing = rule.nodes.find(
+        (n) => n.type === 'decl' && n.prop === 'transform',
+      );
+      if (existing) existing.value = `${composed} ${existing.value}`;
+      else rule.append({ prop: 'transform', value: composed });
+    }
   },
   AtRule: {
     container: (atRule) => {
@@ -170,6 +213,15 @@ module.exports = () => ({
     if (DROP_PROPS.has(decl.prop)) {
       decl.remove();
       return;
+    }
+    // The transform-property → `transform` rewrite (Rule handler) leaves any
+    // `transition: translate …` animating a property that no longer exists —
+    // point it at `transform` instead.
+    if (
+      (decl.prop === 'transition' || decl.prop === 'transition-property') &&
+      /\b(?:translate|rotate|scale)\b/.test(decl.value)
+    ) {
+      decl.value = decl.value.replace(/\b(?:translate|rotate|scale)\b/g, 'transform');
     }
     const inlineMap = SCROLL_INLINE_MAP[decl.prop];
     if (inlineMap) {

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -232,7 +232,9 @@
     "recent_media": "Récemment ajoutés",
     "recommendations": "Recommandations",
     "recent_media_in": "Récemment ajouté – {{library}}",
-    "requests_recent": "Demandes récentes"
+    "requests_recent": "Demandes récentes",
+    "cw_remove_title": "Retirer",
+    "cw_remove_message": "Retirer « {{title}} » de la liste ?"
   },
   "playback_settings": {
     "title": "Paramètres de lecture",

--- a/client/src/app/core/services/default-focus.service.ts
+++ b/client/src/app/core/services/default-focus.service.ts
@@ -2,10 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { DeviceService } from './device.service';
 import { FocusMemoryService } from './focus-memory.service';
 import { NavbarService } from './navbar.service';
-
-/** Focusable selector for the default-focus pass — anchors, enabled buttons,
- *  and explicit tab stops (media-card figures carry `tabindex="0"`). */
-const FOCUSABLE = 'a[href], button:not([disabled]), [tabindex="0"]';
+import { FOCUSABLE_SELECTOR } from './focusable.constants';
 
 /** How long to wait for an async-loaded target to render before giving up and
  *  focusing whatever's there (so a slow/empty list doesn't sit unfocused). */
@@ -165,8 +162,8 @@ export class DefaultFocusService {
    *  descendant. Null when nothing visible is focusable. */
   private firstVisibleFocusable(el: HTMLElement | null): HTMLElement | null {
     if (!el) return null;
-    if (el.matches(FOCUSABLE) && this.isVisible(el)) return el;
-    for (const c of Array.from(el.querySelectorAll<HTMLElement>(FOCUSABLE))) {
+    if (el.matches(FOCUSABLE_SELECTOR) && this.isVisible(el)) return el;
+    for (const c of Array.from(el.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))) {
       if (this.isVisible(c)) return c;
     }
     return null;

--- a/client/src/app/core/services/default-focus.service.ts
+++ b/client/src/app/core/services/default-focus.service.ts
@@ -1,0 +1,179 @@
+import { Injectable, inject } from '@angular/core';
+import { DeviceService } from './device.service';
+import { FocusMemoryService } from './focus-memory.service';
+import { NavbarService } from './navbar.service';
+
+/** Focusable selector for the default-focus pass — anchors, enabled buttons,
+ *  and explicit tab stops (media-card figures carry `tabindex="0"`). */
+const FOCUSABLE = 'a[href], button:not([disabled]), [tabindex="0"]';
+
+/** How long to wait for an async-loaded target to render before giving up and
+ *  focusing whatever's there (so a slow/empty list doesn't sit unfocused). */
+const WAIT_FOR_TARGET_MS = 4000;
+
+/** A page's default-focus declaration, supplied by the appDefaultFocus directive. */
+export interface DefaultFocusTarget {
+  /** The directive host (search root for the default target + memory restore). */
+  host: HTMLElement;
+  /** CSS selector (within host) of the first element to focus; '' → first focusable. */
+  selector: string;
+  /** Focus-memory key for back-nav restore; '' → no memory. */
+  focusKey: string;
+  /** Data-attribute identifying restorable items (e.g. 'data-home-focus'). */
+  focusIdAttr: string;
+}
+
+/**
+ * Applies a page's default focus on arrival (Home → first library, Library →
+ * first card, detail → Play button), gated to keyboard / TV input so mouse and
+ * touch users never get focus stolen or a ring painted. Restores the previously
+ * focused item on back-navigation. Resolution is visibility-aware: responsive
+ * layouts render hidden duplicates (e.g. a mobile + desktop Play button), and
+ * focusing a `display:none` one leaves the page unfocused — so we skip hidden
+ * matches and fall back to the first visible focusable. The declared target
+ * often renders after an async data load, so when it isn't there yet we wait
+ * for it via a MutationObserver. Shared by every page via the directive.
+ */
+@Injectable({ providedIn: 'root' })
+export class DefaultFocusService {
+  private readonly device = inject(DeviceService);
+  private readonly focusMemory = inject(FocusMemoryService);
+  private readonly navbar = inject(NavbarService);
+
+  private pendingObserver: MutationObserver | null = null;
+  private pendingTimeout: ReturnType<typeof setTimeout> | null = null;
+  private readonly registered = new Set<() => DefaultFocusTarget>();
+
+  /** True when the user is on a keyboard / D-pad — the only case where we steal
+   *  focus on arrival (and where the ring is shown, gated identically in CSS). */
+  private shouldAutoFocus(): boolean {
+    if (typeof document === 'undefined') return false;
+    return this.device.isTv() || document.body.classList.contains('keyboard-modality');
+  }
+
+  /** Focus the page's default target on arrival — the previously focused item
+   *  on back-nav, else the declared first element. If the declared target isn't
+   *  rendered yet (async load), wait for it. No-op for mouse / touch. */
+  applyOnArrival(t: DefaultFocusTarget): void {
+    this.stopWaiting();
+    if (!this.shouldAutoFocus()) return;
+    const target = this.resolveTarget(t);
+    if (target) {
+      target.focus({ preventScroll: false });
+      return;
+    }
+    // A declared selector that doesn't match anything visible yet means the
+    // content is still loading — wait rather than grabbing a stray focusable.
+    if (t.selector) this.waitForTarget(t);
+  }
+
+  /** Remember the focused item (while it's still in the host) so a later
+   *  back-navigation can return to it. Called on NavigationStart. */
+  saveFocus(t: DefaultFocusTarget): void {
+    if (!t.focusKey || typeof document === 'undefined') return;
+    const active = document.activeElement as HTMLElement | null;
+    if (!active || !t.host.contains(active)) return;
+    const id = active.closest<HTMLElement>(`[${t.focusIdAttr}]`)?.getAttribute(t.focusIdAttr);
+    if (id) this.focusMemory.save(t.focusKey, id);
+  }
+
+  /** Register a page's default-focus target so spatial-nav can land on it when
+   *  nothing is focused (e.g. first key press after a cold load, where the
+   *  arrival-time pass was skipped because the user hadn't used the keyboard). */
+  register(getTarget: () => DefaultFocusTarget): void {
+    this.registered.add(getTarget);
+  }
+
+  unregister(getTarget: () => DefaultFocusTarget): void {
+    this.registered.delete(getTarget);
+  }
+
+  /** The active page's default focusable — the only registered target whose host
+   *  is still connected (cached/detached pages are skipped). Consulted by
+   *  spatial-nav instead of blindly focusing the first document focusable. */
+  currentTarget(): HTMLElement | null {
+    for (const get of this.registered) {
+      const t = get();
+      if (!t.host.isConnected) continue;
+      const declared = t.selector ? this.firstVisibleMatch(t.host, t.selector) : null;
+      return declared ?? this.firstVisibleFocusable(t.host);
+    }
+    return null;
+  }
+
+  /** The element to focus right now, or null if the declared target isn't ready. */
+  private resolveTarget(t: DefaultFocusTarget): HTMLElement | null {
+    const restored = this.tryRestore(t);
+    if (restored) return restored;
+    if (t.selector) return this.firstVisibleMatch(t.host, t.selector);
+    return this.firstVisibleFocusable(t.host);
+  }
+
+  private waitForTarget(t: DefaultFocusTarget): void {
+    if (typeof MutationObserver === 'undefined') return;
+    const obs = new MutationObserver(() => {
+      if (!this.shouldAutoFocus()) {
+        this.stopWaiting();
+        return;
+      }
+      const target = this.resolveTarget(t);
+      if (target) {
+        target.focus({ preventScroll: false });
+        this.stopWaiting();
+      }
+    });
+    this.pendingObserver = obs;
+    obs.observe(t.host, { childList: true, subtree: true });
+    // Give up after a window: focus the first visible focusable so the page is
+    // never left unfocused if the declared target never renders (empty list).
+    this.pendingTimeout = setTimeout(() => {
+      this.stopWaiting();
+      if (this.shouldAutoFocus()) {
+        this.firstVisibleFocusable(t.host)?.focus({ preventScroll: false });
+      }
+    }, WAIT_FOR_TARGET_MS);
+  }
+
+  private stopWaiting(): void {
+    this.pendingObserver?.disconnect();
+    this.pendingObserver = null;
+    if (this.pendingTimeout !== null) {
+      clearTimeout(this.pendingTimeout);
+      this.pendingTimeout = null;
+    }
+  }
+
+  private tryRestore(t: DefaultFocusTarget): HTMLElement | null {
+    if (!t.focusKey || !this.navbar.lastWasBack()) return null;
+    const saved = this.focusMemory.retrieve(t.focusKey);
+    if (!saved) return null;
+    const item = t.host.querySelector<HTMLElement>(`[${t.focusIdAttr}="${CSS.escape(saved)}"]`);
+    return this.firstVisibleFocusable(item);
+  }
+
+  /** First selector match (in DOM order) that yields a visible focusable —
+   *  skips hidden responsive duplicates. */
+  private firstVisibleMatch(host: HTMLElement, selector: string): HTMLElement | null {
+    for (const el of Array.from(host.querySelectorAll<HTMLElement>(selector))) {
+      const focusable = this.firstVisibleFocusable(el);
+      if (focusable) return focusable;
+    }
+    return null;
+  }
+
+  /** `el` itself if it's a visible focusable, else its first visible focusable
+   *  descendant. Null when nothing visible is focusable. */
+  private firstVisibleFocusable(el: HTMLElement | null): HTMLElement | null {
+    if (!el) return null;
+    if (el.matches(FOCUSABLE) && this.isVisible(el)) return el;
+    for (const c of Array.from(el.querySelectorAll<HTMLElement>(FOCUSABLE))) {
+      if (this.isVisible(c)) return c;
+    }
+    return null;
+  }
+
+  /** Rendered (not display:none on itself or an ancestor). */
+  private isVisible(el: HTMLElement): boolean {
+    return el.offsetParent !== null;
+  }
+}

--- a/client/src/app/core/services/focusable.constants.ts
+++ b/client/src/app/core/services/focusable.constants.ts
@@ -1,0 +1,11 @@
+/**
+ * The set of elements treated as focus targets by both spatial navigation
+ * (D-pad / arrow keys) and the default-focus pass. Kept in one place so the two
+ * agree — a divergence makes the default-focus landing differ from what the
+ * first D-pad press then discovers, causing focus to jump.
+ *
+ * `[tabindex="-1"]` is excluded (explicit opt-out); media-card figures and other
+ * custom targets carry `tabindex="0"` or `[data-tv-focusable]`.
+ */
+export const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]), [data-tv-focusable]';

--- a/client/src/app/core/services/navbar.service.ts
+++ b/client/src/app/core/services/navbar.service.ts
@@ -81,13 +81,23 @@ export class NavbarService {
         // between two URLs forever.
         if (this.isPoppingBack) {
           this.isPoppingBack = false;
-        } else if (lastUrl && lastUrl !== e.urlAfterRedirects) {
+        } else if (lastUrl && this.pathOf(lastUrl) !== this.pathOf(e.urlAfterRedirects)) {
+          // Only a real page change (path differs) pushes a back entry. A
+          // query-only change on the same path — library tabs, filters, sort,
+          // all written with replaceUrl — is in-page state, so back returns to
+          // the previous PAGE, not the previous tab, matching browser back.
           this.history.push(lastUrl);
         }
         lastUrl = e.urlAfterRedirects;
         this.canGoBack.set(this.history.length > 0 && this.router.url !== '/');
       }
     });
+  }
+
+  /** URL path without query/fragment — query-only changes on the same path are
+   *  in-page state (tabs / filters), not navigations to push onto the stack. */
+  private pathOf(url: string): string {
+    return url.split(/[?#]/)[0];
   }
 
   /**

--- a/client/src/app/core/services/tv-spatial-nav.service.ts
+++ b/client/src/app/core/services/tv-spatial-nav.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject, DestroyRef } from '@angular/core';
 import { TvService } from './tv.service';
 import { DefaultFocusService } from './default-focus.service';
+import { FOCUSABLE_SELECTOR } from './focusable.constants';
 
 /**
  * Spatial navigation for D-pad input on Android TV — and keyboard
@@ -46,6 +47,10 @@ interface ContainerNode {
  *  retargets the animation. Pace moves to this interval; the dispatcher is
  *  leading + trailing so no press is dropped, only delayed. */
 const NAV_MIN_INTERVAL_MS = 300;
+
+/** Page scroll step (px) when an up/down move has no focusable neighbour — lets
+ *  the user reach non-focusable info content below the last card. */
+const PAGE_SCROLL_AMOUNT_PX = 300;
 
 @Injectable({ providedIn: 'root' })
 export class TvSpatialNavService {
@@ -320,7 +325,7 @@ export class TvSpatialNavService {
     // No focusable neighbour: scroll the page so the user can reach info content
     // below the last card. Held keys stay put; up/down only; not in a modal.
     if (crossZones && !this.openModals().length && (dir === 'down' || dir === 'up')) {
-      window.scrollBy({ top: dir === 'down' ? 300 : -300, behavior: 'smooth' });
+      window.scrollBy({ top: dir === 'down' ? PAGE_SCROLL_AMOUNT_PX : -PAGE_SCROLL_AMOUNT_PX, behavior: 'smooth' });
     }
   }
 
@@ -352,19 +357,12 @@ export class TvSpatialNavService {
     }
   }
 
-  /** Move focus to the up/down neighbour, falling back to a manual page
-   *  scroll when none exists. Mirrors the up/down tail of {@link onKey} so
-   *  the wheel and the D-pad share one notion of "scroll vertically". */
+  /** Magic-Remote wheel vertical step. Routes through the same paced dispatcher
+   *  as the D-pad so a fast spin can't fire smooth scrolls faster than they
+   *  settle. crossZones=true: a wheel is a scroll gesture, not a discrete press,
+   *  so it may scroll out of a zone (unlike a held D-pad key). */
   private navigateVertical(dir: 'up' | 'down') {
-    const next = this.findNeighbor(dir);
-    if (next) {
-      next.focus({ preventScroll: true });
-      next.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'smooth' });
-      return;
-    }
-    if (!this.openModals().length) {
-      window.scrollBy({ top: dir === 'down' ? 300 : -300, behavior: 'smooth' });
-    }
+    this.dispatchMove(dir, true);
   }
 
   /** Currently-open overlays that scope spatial navigation. Bottom sheets
@@ -680,9 +678,6 @@ const KEYCODE_TO_DIR: Record<number, 'left' | 'right' | 'up' | 'down' | undefine
   39: 'right',
   40: 'down',
 };
-
-const FOCUSABLE_SELECTOR =
-  'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]), [data-tv-focusable]';
 
 function collectFocusables(root: ParentNode = document): HTMLElement[] {
   const nodes = Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));

--- a/client/src/app/core/services/tv-spatial-nav.service.ts
+++ b/client/src/app/core/services/tv-spatial-nav.service.ts
@@ -40,11 +40,21 @@ interface ContainerNode {
   activeChild: HTMLElement | null;
 }
 
+/** Minimum ms between focus moves. A held key (auto-repeat) and fast taps both
+ *  fire faster than a smooth scroll settles, which judders as each move
+ *  retargets the animation. Pace moves to this interval; the dispatcher is
+ *  leading + trailing so no press is dropped, only delayed. */
+const NAV_MIN_INTERVAL_MS = 300;
+
 @Injectable({ providedIn: 'root' })
 export class TvSpatialNavService {
   private readonly tv = inject(TvService);
   private readonly destroyRef = inject(DestroyRef);
   private bound = false;
+  /** Timestamp of the last performed spatial-nav move (for pacing). */
+  private lastNavAt = 0;
+  private pendingNavTimer: ReturnType<typeof setTimeout> | null = null;
+  private pendingNavDir: 'left' | 'right' | 'up' | 'down' = 'down';
   /** Registered containers, keyed by their host element. */
   private readonly containers = new Map<HTMLElement, ContainerNode>();
   /** Cached whole-document focusable list, reused until the DOM mutates. When
@@ -254,25 +264,46 @@ export class TvSpatialNavService {
     if (active?.matches('[role="slider"], [data-tv-skip-spatial], [data-tv-skip-spatial] *')) {
       if (dir === 'left' || dir === 'right') return;
     }
-    const next = this.findNeighbor(dir);
     e.preventDefault();
+    this.dispatchMove(dir);
+  }
+
+  /** Pace focus moves: a held key or a fast double-tap can fire smooth scrolls
+   *  faster than they settle, which judders. Leading + trailing — the first
+   *  move runs now, any move within the window is coalesced into one trailing
+   *  move at the window's end (latest direction wins), so no press is lost. */
+  private dispatchMove(dir: 'left' | 'right' | 'up' | 'down') {
+    if (this.pendingNavTimer !== null) {
+      this.pendingNavDir = dir;
+      return;
+    }
+    const wait = NAV_MIN_INTERVAL_MS - (Date.now() - this.lastNavAt);
+    if (wait <= 0) {
+      this.lastNavAt = Date.now();
+      this.performMove(dir);
+      return;
+    }
+    this.pendingNavDir = dir;
+    this.pendingNavTimer = setTimeout(() => {
+      this.pendingNavTimer = null;
+      this.lastNavAt = Date.now();
+      this.performMove(this.pendingNavDir);
+    }, wait);
+  }
+
+  /** Move focus to the neighbour in `dir`, or scroll the page when none exists. */
+  private performMove(dir: 'left' | 'right' | 'up' | 'down') {
+    const next = this.findNeighbor(dir);
     if (next) {
-      // `preventScroll: true` keeps the browser's instant auto-scroll from
-      // firing on every focus tick. We then call `scrollIntoView` smooth
-      // with `block: 'nearest'` so an off-screen card animates in, while
-      // horizontal-scroller's `focusin` handler owns vertical row-top
-      // alignment when focus crosses rows. Two coordinated smooth
-      // scrolls instead of a jarring instant→smooth one-two punch.
+      // preventScroll keeps the browser's instant auto-scroll off; the smooth
+      // scrollIntoView animates an off-screen card in (block:'nearest'), while
+      // horizontal-scroller's focusin handler owns vertical row-top alignment.
       next.focus({ preventScroll: true });
       next.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'smooth' });
       return;
     }
-    // No focusable neighbour: scroll the page manually so the user can
-    // reach informational content (file infos, descriptions, etc.) that
-    // sits below the last focusable card. Up/down only — left/right at a
-    // boundary should just block (intra-row). Skip while a modal is open
-    // so the user hitting the boundary inside a menu doesn't drift the
-    // page underneath.
+    // No focusable neighbour: scroll the page so the user can reach info content
+    // below the last card. Up/down only; skip while a modal is open.
     if (!this.openModals().length && (dir === 'down' || dir === 'up')) {
       window.scrollBy({ top: dir === 'down' ? 300 : -300, behavior: 'smooth' });
     }

--- a/client/src/app/core/services/tv-spatial-nav.service.ts
+++ b/client/src/app/core/services/tv-spatial-nav.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, inject, DestroyRef } from '@angular/core';
 import { TvService } from './tv.service';
+import { DefaultFocusService } from './default-focus.service';
 
 /**
  * Spatial navigation for D-pad input on Android TV — and keyboard
@@ -49,6 +50,7 @@ const NAV_MIN_INTERVAL_MS = 300;
 @Injectable({ providedIn: 'root' })
 export class TvSpatialNavService {
   private readonly tv = inject(TvService);
+  private readonly defaultFocus = inject(DefaultFocusService);
   private readonly destroyRef = inject(DestroyRef);
   private bound = false;
   /** Timestamp of the last performed spatial-nav move (for pacing). */
@@ -404,7 +406,9 @@ export class TvSpatialNavService {
     if (!all.length) return null;
 
     if (!active || active === document.body) {
-      return all[0] ?? null;
+      // Nothing focused yet (cold load) — prefer the active page's declared
+      // default focus over the first document focusable (which is the topbar).
+      return this.defaultFocus.currentTarget() ?? all[0] ?? null;
     }
 
     const fromRect = active.getBoundingClientRect();

--- a/client/src/app/core/services/tv-spatial-nav.service.ts
+++ b/client/src/app/core/services/tv-spatial-nav.service.ts
@@ -55,6 +55,7 @@ export class TvSpatialNavService {
   private lastNavAt = 0;
   private pendingNavTimer: ReturnType<typeof setTimeout> | null = null;
   private pendingNavDir: 'left' | 'right' | 'up' | 'down' = 'down';
+  private pendingCrossZones = false;
   /** Registered containers, keyed by their host element. */
   private readonly containers = new Map<HTMLElement, ContainerNode>();
   /** Cached whole-document focusable list, reused until the DOM mutates. When
@@ -265,36 +266,48 @@ export class TvSpatialNavService {
       if (dir === 'left' || dir === 'right') return;
     }
     e.preventDefault();
-    this.dispatchMove(dir);
+    // crossZones = !e.repeat: a deliberate (non-repeat) press may leave the
+    // current zone; a held key's repeats stay inside it.
+    this.dispatchMove(dir, !e.repeat);
   }
 
   /** Pace focus moves: a held key or a fast double-tap can fire smooth scrolls
    *  faster than they settle, which judders. Leading + trailing — the first
    *  move runs now, any move within the window is coalesced into one trailing
    *  move at the window's end (latest direction wins), so no press is lost. */
-  private dispatchMove(dir: 'left' | 'right' | 'up' | 'down') {
+  private dispatchMove(dir: 'left' | 'right' | 'up' | 'down', crossZones: boolean) {
     if (this.pendingNavTimer !== null) {
       this.pendingNavDir = dir;
+      // A fresh press (repeat=false → crossZones true) mid-window re-enables
+      // crossing for the trailing move; held repeats keep it false.
+      this.pendingCrossZones ||= crossZones;
       return;
     }
     const wait = NAV_MIN_INTERVAL_MS - (Date.now() - this.lastNavAt);
     if (wait <= 0) {
       this.lastNavAt = Date.now();
-      this.performMove(dir);
+      this.performMove(dir, crossZones);
       return;
     }
     this.pendingNavDir = dir;
+    this.pendingCrossZones = crossZones;
     this.pendingNavTimer = setTimeout(() => {
       this.pendingNavTimer = null;
       this.lastNavAt = Date.now();
-      this.performMove(this.pendingNavDir);
+      this.performMove(this.pendingNavDir, this.pendingCrossZones);
     }, wait);
   }
 
-  /** Move focus to the neighbour in `dir`, or scroll the page when none exists. */
-  private performMove(dir: 'left' | 'right' | 'up' | 'down') {
+  /** Move focus to the neighbour in `dir`, or scroll the page when none exists.
+   *  `crossZones` false (a held key) keeps focus inside its current zone. */
+  private performMove(dir: 'left' | 'right' | 'up' | 'down', crossZones: boolean) {
+    const active = document.activeElement as HTMLElement | null;
     const next = this.findNeighbor(dir);
     if (next) {
+      // Held key stays inside the current zone (a TV row, the library grid):
+      // a deliberate press crosses out, a held one doesn't, so you can't
+      // overshoot out of a row / grid by leaning on the D-pad.
+      if (!crossZones && this.exitsZone(active, next)) return;
       // preventScroll keeps the browser's instant auto-scroll off; the smooth
       // scrollIntoView animates an off-screen card in (block:'nearest'), while
       // horizontal-scroller's focusin handler owns vertical row-top alignment.
@@ -303,10 +316,18 @@ export class TvSpatialNavService {
       return;
     }
     // No focusable neighbour: scroll the page so the user can reach info content
-    // below the last card. Up/down only; skip while a modal is open.
-    if (!this.openModals().length && (dir === 'down' || dir === 'up')) {
+    // below the last card. Held keys stay put; up/down only; not in a modal.
+    if (crossZones && !this.openModals().length && (dir === 'down' || dir === 'up')) {
       window.scrollBy({ top: dir === 'down' ? 300 : -300, behavior: 'smooth' });
     }
+  }
+
+  /** True when moving to `next` would leave the [data-tv-zone] that currently
+   *  holds focus. Elements outside any zone never block. */
+  private exitsZone(active: HTMLElement | null, next: HTMLElement): boolean {
+    const zone = active?.closest('[data-tv-zone]');
+    if (!zone) return false;
+    return !zone.contains(next);
   }
 
   /** Accumulated wheel deltaY between focus-step emissions, so one notch

--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -3,7 +3,7 @@
 }
 
 
-<div appTvSection class="flex flex-col gap-8">
+<div appTvSection appDefaultFocus="a[data-home-focus^='library:']" focusKey="home" focusIdAttr="data-home-focus" class="flex flex-col gap-8">
 
   @for (section of visibleSections(); track section.key) {
     @switch (section.type) {

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -2,7 +2,7 @@ import { Component, ChangeDetectionStrategy, inject, signal, computed, effect, O
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Subscription, filter } from 'rxjs';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { MediaService, Media, CalendarEntry } from '../../core/services/api/media.service';
 import { StreamingApiService, ContinueWatchingItem, RecommendationItem } from '../../core/services/api/streaming-api.service';
 import { LibrariesApiService, LibrarySummary } from '../../core/services/api/libraries-api.service';
@@ -95,6 +95,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly profilesApi = inject(ProfilesService);
   private readonly scrollMemory = inject(ScrollMemoryService);
   private readonly navbar = inject(NavbarService);
+  private readonly translate = inject(TranslateService);
   private readonly appResume = inject(AppResumeService);
   private readonly backgroundService = inject(BackgroundService);
   private readonly displaySettings = inject(DisplaySettingsService);
@@ -610,8 +611,8 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   async removeContinueWatching(item: ContinueWatchingItem) {
     const confirmed = await this.confirmation.confirm({
-      title: 'Retirer',
-      message: `Retirer "${item.mediaTitle}" de la liste ?`,
+      title: this.translate.instant('home.cw_remove_title'),
+      message: this.translate.instant('home.cw_remove_message', { title: item.mediaTitle }),
     });
     if (!confirmed) return;
     try {

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -1,5 +1,5 @@
-import { Component, ChangeDetectionStrategy, inject, signal, computed, effect, OnInit, OnDestroy, Injector, afterNextRender, viewChild } from '@angular/core';
-import { ActivatedRoute, NavigationStart, Router, RouterLink } from '@angular/router';
+import { Component, ChangeDetectionStrategy, inject, signal, computed, effect, OnInit, OnDestroy, Injector, viewChild } from '@angular/core';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Subscription, filter } from 'rxjs';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
 import { TranslateModule } from '@ngx-translate/core';
@@ -17,7 +17,7 @@ import { ProfilesService } from '../../core/services/api/profiles.service';
 import { ConfirmationService } from '../../core/services/confirmation.service';
 import { PlayableMediaService } from '../../core/services/playable-media.service';
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
-import { FocusMemoryService } from '../../core/services/focus-memory.service';
+import { DefaultFocusDirective } from '../../shared/directives/default-focus.directive';
 import { NavbarService } from '../../core/services/navbar.service';
 import { AppResumeService } from '../../core/services/app-resume.service';
 import { BackgroundService } from '../../core/services/background.service';
@@ -69,7 +69,7 @@ import { RequestDeclineModalComponent } from '../requests/request-decline-modal/
 @Component({
   selector: 'app-home',
   imports: [
-    RouterLink, TranslateModule,
+    RouterLink, TranslateModule, DefaultFocusDirective,
     MediaCardComponent,
     HorizontalScrollerComponent,
     LucideIconComponent,
@@ -94,7 +94,6 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly downloadProgress = inject(DownloadProgressService);
   private readonly profilesApi = inject(ProfilesService);
   private readonly scrollMemory = inject(ScrollMemoryService);
-  private readonly focusMemory = inject(FocusMemoryService);
   private readonly navbar = inject(NavbarService);
   private readonly appResume = inject(AppResumeService);
   private readonly backgroundService = inject(BackgroundService);
@@ -107,10 +106,6 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly reuseStrategy = inject(CachingReuseStrategy);
 
   private static readonly SCROLL_KEY = 'home';
-  private static readonly FOCUS_KEY = 'home';
-  /** Captured at ngOnInit before NavbarService.lastWasBack auto-resets. */
-  private arrivedViaBack = false;
-  private navStartSub?: Subscription;
   private attachedSub?: Subscription;
   private detachedSub?: Subscription;
   private resumeSub?: Subscription;
@@ -249,7 +244,6 @@ export class HomeComponent implements OnInit, OnDestroy {
   }
 
   async ngOnInit() {
-    this.arrivedViaBack = this.navbar.lastWasBack();
     this.scrollMemory.activate(HomeComponent.SCROLL_KEY);
     // Profile names for the request cards are resolved client-side (same as
     // the requests page); load them once for users who can have requests.
@@ -265,20 +259,6 @@ export class HomeComponent implements OnInit, OnDestroy {
     // overwrites in place; no spinner, no flash.
     queueMicrotask(() => void this.loadAllSections({ force: true }));
     this.scrollMemory.restore(HomeComponent.SCROLL_KEY, this.injector);
-    if (this.tv.isTv()) {
-      afterNextRender(() => this.applyDefaultFocus(), { injector: this.injector });
-      // NavigationStart fires the moment a click triggers a route change,
-      // before Angular tears down this component — activeElement is still
-      // the focused card so we can capture its data-home-focus once.
-      this.navStartSub = this.router.events
-        .pipe(filter((e): e is NavigationStart => e instanceof NavigationStart))
-        .subscribe(() => {
-          const active = document.activeElement as HTMLElement | null;
-          const container = active?.closest<HTMLElement>('[data-home-focus]');
-          const sel = container?.dataset['homeFocus'];
-          if (sel) this.focusMemory.save(HomeComponent.FOCUS_KEY, sel);
-        });
-    }
     // The route is detached/cached on navigate-away (see CachingReuseStrategy
     // + `data: { reuse: true }` on the home route). On return, ngOnInit does
     // NOT fire again — refresh data + scroll + focus through this hook
@@ -298,10 +278,6 @@ export class HomeComponent implements OnInit, OnDestroy {
       void this.loadAllSections();
       queueMicrotask(() => void this.loadAllSections({ force: true }));
       this.scrollMemory.restoreSticky(HomeComponent.SCROLL_KEY);
-      if (this.tv.isTv()) {
-        this.arrivedViaBack = true;
-        afterNextRender(() => this.applyDefaultFocus(), { injector: this.injector });
-      }
     });
     // ngOnDestroy doesn't fire when detaching, so the active scroll key would
     // stay pointing at us — and a NavigationStart on the next page would then
@@ -326,7 +302,6 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.scrollMemory.deactivate();
-    this.navStartSub?.unsubscribe();
     this.attachedSub?.unsubscribe();
     this.detachedSub?.unsubscribe();
     this.resumeSub?.unsubscribe();
@@ -361,27 +336,6 @@ export class HomeComponent implements OnInit, OnDestroy {
       if (recs) this.recommendations.set(recs);
     } catch { /* ignore */ }
     await this.loadFilteredSections({ force });
-  }
-
-  private applyDefaultFocus() {
-    const root = document.querySelector<HTMLElement>('app-home') ?? document.body;
-    const FOCUSABLE = 'a[href], button:not([disabled]), [tabindex="0"]';
-    if (this.arrivedViaBack) {
-      const saved = this.focusMemory.retrieve(HomeComponent.FOCUS_KEY);
-      const container = saved
-        ? root.querySelector<HTMLElement>(`[data-home-focus="${CSS.escape(saved)}"]`)
-        : null;
-      const target =
-        container?.matches(FOCUSABLE)
-          ? container
-          : container?.querySelector<HTMLElement>(FOCUSABLE) ?? null;
-      if (target) {
-        target.focus({ preventScroll: false });
-        return;
-      }
-    }
-    // Default: first focusable in DOM order = first library card.
-    root.querySelector<HTMLElement>(FOCUSABLE)?.focus({ preventScroll: false });
   }
 
   private async loadFilteredSections(opts: { force?: boolean } = {}) {

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -284,7 +284,7 @@
         </div>
       }
       <div class="flex gap-1">
-        <div #cardGrid class="flex-1 min-w-0 grid content-start grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-1.5 sm:gap-4"
+        <div #cardGrid data-tv-zone class="flex-1 min-w-0 grid content-start grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-1.5 sm:gap-4"
           [class.pr-4]="sortBy() === 'title' && sortOrder() === 'ASC'"
           [class.pr-2]="sortBy() !== 'title' || sortOrder() !== 'ASC'"
           [style.paddingTop.px]="list.padTop()"

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -289,7 +289,7 @@
         </div>
       }
       <div class="flex gap-1">
-        <div #cardGrid data-tv-zone class="flex-1 min-w-0 grid content-start grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-1.5 sm:gap-4"
+        <div #cardGrid data-tv-zone class="flex-1 min-w-0 grid content-start grid-cols-3 sm:grid-cols-3 md:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-1.5 sm:gap-4"
           [class.pr-4]="sortBy() === 'title' && sortOrder() === 'ASC'"
           [class.pr-2]="sortBy() !== 'title' || sortOrder() !== 'ASC'"
           [style.paddingTop.px]="list.padTop()"

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -10,8 +10,10 @@
     <h1 class="text-2xl font-bold">{{ libraryName() }}</h1>
   }
 
-  <!-- View tabs (own row, centered like the reference) -->
-  <nav class="flex items-center gap-1 overflow-x-auto py-2 -my-2 px-2 -mx-2">
+  <!-- View tabs — a spatial-nav row so `↑` from the content below lands on the
+       tabs (the nearest registered container) instead of bridging past them to
+       the fixed topbar. -->
+  <nav appTvRow class="flex items-center gap-1 overflow-x-auto py-2 -my-2 px-2 -mx-2">
     <button
       type="button"
       class="px-4 py-1.5 rounded-full text-sm font-medium transition-colors whitespace-nowrap"

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -1,4 +1,9 @@
-<div class="flex flex-col gap-4 h-full">
+<div
+  appDefaultFocus="[data-library-focus^='media:']"
+  [focusKey]="'library-' + (library()?.id ?? '')"
+  focusIdAttr="data-library-focus"
+  class="flex flex-col gap-4 h-full"
+>
   <!-- Library title — hidden when the mobile topbar already shows it
        (avoids the duplicated heading on small screens). -->
   @if (!navbar.mobileNavbarVisible()) {

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -248,12 +248,13 @@ export class LibraryComponent implements OnInit, OnDestroy {
       this.sortOrder.set(
         (qp.get('sortOrder') ?? stored['sortOrder'] ?? 'ASC') as SortOrder,
       );
-      this.viewMode.set(
-        (qp.get('view') ?? stored['view'] ?? 'all') as LibraryViewMode,
-      );
-      this.selectedGenre.set(qp.get('genre') ?? stored['genre'] ?? '');
-      const storedColl = qp.get('collectionId') ?? stored['collectionId'];
-      this.selectedCollectionId.set(storedColl ? Number(storedColl) : null);
+      // View / genre / collection are navigation state, read only from the URL
+      // (within-session back/forward, deep links) — never from the persisted
+      // filters — so opening a library fresh lands on the `all` tab.
+      this.viewMode.set((qp.get('view') ?? 'all') as LibraryViewMode);
+      this.selectedGenre.set(qp.get('genre') ?? '');
+      const collId = qp.get('collectionId');
+      this.selectedCollectionId.set(collId ? Number(collId) : null);
 
       this.scrollMemory.activate(scrollKey);
       this.list.trackScroll('media');
@@ -545,12 +546,12 @@ export class LibraryComponent implements OnInit, OnDestroy {
     }
   }
 
-  /** Reflect the current state in the URL. `push` adds a real history
-   *  entry instead of replacing — used for the genres-list → genre-filter
-   *  transition so the browser back button returns to the Genres list. */
-  /** The filter / view state serialized identically to URL query params and to
-   *  localStorage — built once, used by both syncQueryParams and saveFilters. */
-  private buildFilterParams(): Record<string, string> {
+  /** Filter/sort *preferences* persisted to localStorage and restored when a
+   *  library is opened fresh. Deliberately excludes the active tab and its
+   *  in-tab selection (view / genre / collection): those are navigation state,
+   *  not preferences, so reopening the app lands on the library root rather
+   *  than the tab the user happened to leave open. */
+  private buildStoredParams(): Record<string, string> {
     const p: Record<string, string> = {};
     if (this.searchQuery()) p['q'] = this.searchQuery();
     if (this.filterMonitored()) p['monitored'] = this.filterMonitored();
@@ -558,15 +559,26 @@ export class LibraryComponent implements OnInit, OnDestroy {
     if (this.filterWatched()) p['watched'] = this.filterWatched();
     if (this.sortBy() !== 'title') p['sortBy'] = this.sortBy();
     if (this.sortOrder() !== 'ASC') p['sortOrder'] = this.sortOrder();
+    return p;
+  }
+
+  /** The full state mirrored into the URL — the persisted preferences plus the
+   *  active tab and its selection — so within-session back/forward and deep
+   *  links restore the exact view. */
+  private buildUrlParams(): Record<string, string> {
+    const p = this.buildStoredParams();
     if (this.viewMode() !== 'all') p['view'] = this.viewMode();
     if (this.selectedGenre()) p['genre'] = this.selectedGenre();
     if (this.selectedCollectionId()) p['collectionId'] = String(this.selectedCollectionId());
     return p;
   }
 
+  /** Reflect the current state in the URL. `push` adds a real history entry
+   *  instead of replacing — used for the genres-list → genre-filter transition
+   *  so the browser back button returns to the Genres list. */
   private syncQueryParams(push = false) {
     this.skipQueryParamSync = true;
-    void this.router.navigate([], { queryParams: this.buildFilterParams(), replaceUrl: !push });
+    void this.router.navigate([], { queryParams: this.buildUrlParams(), replaceUrl: !push });
     this.saveFilters();
   }
 
@@ -575,7 +587,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   }
 
   private saveFilters() {
-    localStorage.setItem(this.storageKey, JSON.stringify(this.buildFilterParams()));
+    localStorage.setItem(this.storageKey, JSON.stringify(this.buildStoredParams()));
   }
 
   private loadFilters(name: string): Record<string, string> {

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -28,6 +28,7 @@ import type {
 } from '../../core/services/api/streaming-api.service';
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
 import { DefaultFocusDirective } from '../../shared/directives/default-focus.directive';
+import { TvRowDirective } from '../../shared/directives/tv-row.directive';
 import { NavbarService } from '../../core/services/navbar.service';
 import { TvService } from '../../core/services/tv.service';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
@@ -61,6 +62,7 @@ const NATURAL_ORDER_BY_SORT: Record<string, SortOrder> = {
   imports: [
     MediaCardComponent,
     DefaultFocusDirective,
+    TvRowDirective,
     DropdownMenuComponent,
     TvSelectDirective,
     HorizontalScrollerComponent,

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -9,7 +9,6 @@ import {
   OnDestroy,
   ElementRef,
   ViewChild,
-  effect,
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription, filter } from 'rxjs';
@@ -92,6 +91,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   private readonly translate = inject(TranslateService);
   private readonly reuseStrategy = inject(CachingReuseStrategy);
   private readonly appResume = inject(AppResumeService);
+  private paramSub?: Subscription;
   private attachedSub?: Subscription;
   private detachedSub?: Subscription;
   private queryParamSub?: Subscription;
@@ -192,12 +192,6 @@ export class LibraryComponent implements OnInit, OnDestroy {
    *  for the previous library can't overwrite the current view. */
   private loadGen = 0;
 
-  /** Re-load when route param changes (e.g. clicking another library in sidebar). */
-  private readonly paramEffect = effect(() => {
-    // Angular signal-based route params aren't available yet in 21.x for
-    // lazy routes, so we subscribe manually in ngOnInit below.
-  }, { allowSignalWrites: true });
-
   ngOnInit() {
     if (this.tv.isTv()) {
       // DOM windowing for the `all` grid: only render a row-aligned slice
@@ -208,7 +202,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
       window.addEventListener('resize', this.onResize, { passive: true });
     }
     // Subscribe to route param changes (handles initial load + sidebar nav).
-    this.route.params.subscribe(async (params) => {
+    this.paramSub = this.route.params.subscribe(async (params) => {
       const rawName = params['libraryName'] as string;
       if (!rawName) return;
       const name = decodeURIComponent(rawName);
@@ -348,6 +342,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
     this.list.destroy();
     if (this.onResize) window.removeEventListener('resize', this.onResize);
     this.navbar.clearPageTitle();
+    this.paramSub?.unsubscribe();
     this.attachedSub?.unsubscribe();
     this.detachedSub?.unsubscribe();
     this.queryParamSub?.unsubscribe();
@@ -553,19 +548,25 @@ export class LibraryComponent implements OnInit, OnDestroy {
   /** Reflect the current state in the URL. `push` adds a real history
    *  entry instead of replacing — used for the genres-list → genre-filter
    *  transition so the browser back button returns to the Genres list. */
+  /** The filter / view state serialized identically to URL query params and to
+   *  localStorage — built once, used by both syncQueryParams and saveFilters. */
+  private buildFilterParams(): Record<string, string> {
+    const p: Record<string, string> = {};
+    if (this.searchQuery()) p['q'] = this.searchQuery();
+    if (this.filterMonitored()) p['monitored'] = this.filterMonitored();
+    if (this.filterStatus()) p['status'] = this.filterStatus();
+    if (this.filterWatched()) p['watched'] = this.filterWatched();
+    if (this.sortBy() !== 'title') p['sortBy'] = this.sortBy();
+    if (this.sortOrder() !== 'ASC') p['sortOrder'] = this.sortOrder();
+    if (this.viewMode() !== 'all') p['view'] = this.viewMode();
+    if (this.selectedGenre()) p['genre'] = this.selectedGenre();
+    if (this.selectedCollectionId()) p['collectionId'] = String(this.selectedCollectionId());
+    return p;
+  }
+
   private syncQueryParams(push = false) {
-    const params: Record<string, string> = {};
-    if (this.searchQuery()) params['q'] = this.searchQuery();
-    if (this.filterMonitored()) params['monitored'] = this.filterMonitored();
-    if (this.filterStatus()) params['status'] = this.filterStatus();
-    if (this.filterWatched()) params['watched'] = this.filterWatched();
-    if (this.sortBy() !== 'title') params['sortBy'] = this.sortBy();
-    if (this.sortOrder() !== 'ASC') params['sortOrder'] = this.sortOrder();
-    if (this.viewMode() !== 'all') params['view'] = this.viewMode();
-    if (this.selectedGenre()) params['genre'] = this.selectedGenre();
-    if (this.selectedCollectionId()) params['collectionId'] = String(this.selectedCollectionId());
     this.skipQueryParamSync = true;
-    void this.router.navigate([], { queryParams: params, replaceUrl: !push });
+    void this.router.navigate([], { queryParams: this.buildFilterParams(), replaceUrl: !push });
     this.saveFilters();
   }
 
@@ -574,17 +575,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   }
 
   private saveFilters() {
-    const data: Record<string, string> = {};
-    if (this.searchQuery()) data['q'] = this.searchQuery();
-    if (this.filterMonitored()) data['monitored'] = this.filterMonitored();
-    if (this.filterStatus()) data['status'] = this.filterStatus();
-    if (this.filterWatched()) data['watched'] = this.filterWatched();
-    if (this.sortBy() !== 'title') data['sortBy'] = this.sortBy();
-    if (this.sortOrder() !== 'ASC') data['sortOrder'] = this.sortOrder();
-    if (this.viewMode() !== 'all') data['view'] = this.viewMode();
-    if (this.selectedGenre()) data['genre'] = this.selectedGenre();
-    if (this.selectedCollectionId()) data['collectionId'] = String(this.selectedCollectionId());
-    localStorage.setItem(this.storageKey, JSON.stringify(data));
+    localStorage.setItem(this.storageKey, JSON.stringify(this.buildFilterParams()));
   }
 
   private loadFilters(name: string): Record<string, string> {

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -9,10 +9,9 @@ import {
   OnDestroy,
   ElementRef,
   ViewChild,
-  afterNextRender,
   effect,
 } from '@angular/core';
-import { ActivatedRoute, NavigationStart, Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription, filter } from 'rxjs';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -29,7 +28,7 @@ import type {
   RecommendationItem,
 } from '../../core/services/api/streaming-api.service';
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
-import { FocusMemoryService } from '../../core/services/focus-memory.service';
+import { DefaultFocusDirective } from '../../shared/directives/default-focus.directive';
 import { NavbarService } from '../../core/services/navbar.service';
 import { TvService } from '../../core/services/tv.service';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
@@ -62,6 +61,7 @@ const NATURAL_ORDER_BY_SORT: Record<string, SortOrder> = {
   selector: 'app-library',
   imports: [
     MediaCardComponent,
+    DefaultFocusDirective,
     DropdownMenuComponent,
     TvSelectDirective,
     HorizontalScrollerComponent,
@@ -86,15 +86,12 @@ export class LibraryComponent implements OnInit, OnDestroy {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly scrollMemory = inject(ScrollMemoryService);
-  private readonly focusMemory = inject(FocusMemoryService);
   readonly navbar = inject(NavbarService);
   private readonly tv = inject(TvService);
   private readonly injector = inject(Injector);
   private readonly translate = inject(TranslateService);
   private readonly reuseStrategy = inject(CachingReuseStrategy);
   private readonly appResume = inject(AppResumeService);
-  private arrivedViaBack = false;
-  private navStartSub?: Subscription;
   private attachedSub?: Subscription;
   private detachedSub?: Subscription;
   private queryParamSub?: Subscription;
@@ -202,7 +199,6 @@ export class LibraryComponent implements OnInit, OnDestroy {
   }, { allowSignalWrites: true });
 
   ngOnInit() {
-    this.arrivedViaBack = this.navbar.lastWasBack();
     if (this.tv.isTv()) {
       // DOM windowing for the `all` grid: only render a row-aligned slice
       // around the viewport so a large library doesn't pile hundreds of cards
@@ -210,17 +206,6 @@ export class LibraryComponent implements OnInit, OnDestroy {
       this.list.enableWindowing(() => this.readGridMetrics(), 4);
       this.onResize = () => this.list.onWindowScroll();
       window.addEventListener('resize', this.onResize, { passive: true });
-    }
-    if (this.tv.isTv()) {
-      this.navStartSub = this.router.events
-        .pipe(filter((e): e is NavigationStart => e instanceof NavigationStart))
-        .subscribe(() => {
-          const active = document.activeElement as HTMLElement | null;
-          const container = active?.closest<HTMLElement>('[data-library-focus]');
-          const sel = container?.dataset['libraryFocus'];
-          const lib = this.library();
-          if (sel && lib) this.focusMemory.save(`library-${lib.id}`, sel);
-        });
     }
     // Subscribe to route param changes (handles initial load + sidebar nav).
     this.route.params.subscribe(async (params) => {
@@ -291,9 +276,6 @@ export class LibraryComponent implements OnInit, OnDestroy {
         void this.loadCollections();
       }
       this.scrollMemory.restore(scrollKey, this.injector);
-      if (this.tv.isTv()) {
-        afterNextRender(() => this.applyDefaultFocus(lib.id), { injector: this.injector });
-      }
     });
 
     // Each /libraries/:libraryName has its own cache slot (CachingReuseStrategy
@@ -317,10 +299,6 @@ export class LibraryComponent implements OnInit, OnDestroy {
         void this.loadGenres();
       }
       this.scrollMemory.restoreSticky(scrollKey);
-      if (this.tv.isTv()) {
-        this.arrivedViaBack = true;
-        afterNextRender(() => this.applyDefaultFocus(lib.id), { injector: this.injector });
-      }
     });
     this.detachedSub = this.reuseStrategy.detached$.subscribe((key) => {
       if (key !== ownKey) return;
@@ -370,35 +348,10 @@ export class LibraryComponent implements OnInit, OnDestroy {
     this.list.destroy();
     if (this.onResize) window.removeEventListener('resize', this.onResize);
     this.navbar.clearPageTitle();
-    this.navStartSub?.unsubscribe();
     this.attachedSub?.unsubscribe();
     this.detachedSub?.unsubscribe();
     this.queryParamSub?.unsubscribe();
     this.resumeSub?.unsubscribe();
-  }
-
-  private applyDefaultFocus(libraryId: number) {
-    const root = document.querySelector<HTMLElement>('app-library') ?? document.body;
-    const FOCUSABLE = 'a[href], button:not([disabled]), [tabindex="0"]';
-    if (this.arrivedViaBack) {
-      const saved = this.focusMemory.retrieve(`library-${libraryId}`);
-      const container = saved
-        ? root.querySelector<HTMLElement>(`[data-library-focus="${CSS.escape(saved)}"]`)
-        : null;
-      const target = container?.matches(FOCUSABLE)
-        ? container
-        : container?.querySelector<HTMLElement>(FOCUSABLE) ?? null;
-      if (target) {
-        target.focus({ preventScroll: false });
-        return;
-      }
-    }
-    // Default: first card in the grid.
-    const firstCard = root.querySelector<HTMLElement>('[data-library-focus^="media:"]');
-    const target = firstCard?.matches(FOCUSABLE)
-      ? firstCard
-      : firstCard?.querySelector<HTMLElement>(FOCUSABLE);
-    target?.focus({ preventScroll: false });
   }
 
   scrollToLetter(letter: string) {

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -1,4 +1,4 @@
-<div appTvSection class="flex flex-col gap-4">
+<div appTvSection appDefaultFocus="[autofocus]" class="flex flex-col gap-4">
 
   @if (loading()) {
     <!-- Skeleton: same vertical rhythm as the loaded layout so the page

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -41,6 +41,7 @@ import {
 import { MediaInfoExtraComponent } from '../../shared/components/media-info-extra/media-info-extra';
 import { SubtitlesModalComponent } from '../../shared/components/subtitles-modal/subtitles-modal';
 import { MediaFileInfoComponent } from '../../shared/components/media-file-info';
+import { DefaultFocusDirective } from '../../shared/directives/default-focus.directive';
 import { MediaDetailSeasonsComponent } from './components/media-detail-seasons/media-detail-seasons.component';
 import { ReleasesModalComponent } from './components/releases-modal/releases-modal.component';
 import {
@@ -88,6 +89,7 @@ function readEpisodesHasFileOnlyFromStorage(): boolean {
   selector: 'app-media-detail',
   imports: [
     TranslateModule,
+    DefaultFocusDirective,
     MediaInfoHeaderComponent,
     MediaInfoExtraComponent,
     SubtitlesModalComponent,

--- a/client/src/app/shared/components/horizontal-scroller.html
+++ b/client/src/app/shared/components/horizontal-scroller.html
@@ -28,7 +28,7 @@
     #scroller
     appTvRow
     data-tv-zone
-    class="flex gap-2 lg:gap-4 overflow-x-auto scrollbar-none [scroll-behavior:smooth] py-5 -my-5 px-4 -mx-4 scroll-px-4"
+    class="flex gap-2 lg:gap-4 overflow-x-auto scrollbar-none [scroll-behavior:smooth] py-5 -my-5 px-4 -mx-4 scroll-px-16"
     (scroll)="updateArrows()"
   >
     <ng-content />

--- a/client/src/app/shared/components/horizontal-scroller.html
+++ b/client/src/app/shared/components/horizontal-scroller.html
@@ -27,6 +27,7 @@
   <div
     #scroller
     appTvRow
+    data-tv-zone
     class="flex gap-2 lg:gap-4 overflow-x-auto scrollbar-none [scroll-behavior:smooth] py-5 -my-5 px-4 -mx-4 scroll-px-4"
     (scroll)="updateArrows()"
   >

--- a/client/src/app/shared/components/mosaic-card/mosaic-card.ts
+++ b/client/src/app/shared/components/mosaic-card/mosaic-card.ts
@@ -15,10 +15,11 @@ import { ImgFadeInDirective } from '../../directives/img-fade-in.directive';
   template: `
     <button
       type="button"
+      data-no-focus-ring
       class="group flex flex-col items-stretch gap-2 text-left focus:outline-none min-w-0 w-full"
       (click)="clicked.emit()"
     >
-      <div class="aspect-square rounded-xl overflow-hidden bg-base-300 ring-1 ring-base-300 group-hover:ring-primary group-focus-visible:ring-primary group-focus-visible:ring-2 transition-colors">
+      <div class="mosaic-art aspect-square rounded-xl overflow-hidden bg-base-300 ring-1 ring-base-300 transition-shadow group-hover:ring-primary">
         @if (posters().length >= 4) {
           <div class="grid grid-cols-2 grid-rows-2 w-full h-full">
             @for (p of posters().slice(0, 4); track p) {

--- a/client/src/app/shared/directives/default-focus.directive.ts
+++ b/client/src/app/shared/directives/default-focus.directive.ts
@@ -1,0 +1,82 @@
+import {
+  Directive,
+  ElementRef,
+  OnDestroy,
+  OnInit,
+  afterNextRender,
+  inject,
+  input,
+} from '@angular/core';
+import { ActivatedRoute, NavigationStart, Router } from '@angular/router';
+import { Subscription, filter } from 'rxjs';
+import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
+import {
+  DefaultFocusService,
+  DefaultFocusTarget,
+} from '../../core/services/default-focus.service';
+
+/**
+ * Declares a page's default-focus target. On arrival (fresh navigation or
+ * back-nav re-attach) the {@link DefaultFocusService} focuses it — gated to
+ * keyboard / TV so mouse and touch are untouched — and restores the previously
+ * focused item on back-navigation. Drop it on any page's root container:
+ *
+ *   <div appDefaultFocus="a[data-home-focus^='library:']"
+ *        focusKey="home" focusIdAttr="data-home-focus"> … </div>
+ */
+@Directive({ selector: '[appDefaultFocus]', standalone: true })
+export class DefaultFocusDirective implements OnInit, OnDestroy {
+  /** CSS selector (within host) of the first element to focus; '' → first focusable. */
+  readonly appDefaultFocus = input<string>('');
+  /** Focus-memory key for back-nav restore; '' → no restore. */
+  readonly focusKey = input<string>('');
+  /** Data-attribute identifying restorable items (reuses existing markers). */
+  readonly focusIdAttr = input<string>('data-focus-id');
+
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly svc = inject(DefaultFocusService);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
+  private readonly reuseStrategy = inject(CachingReuseStrategy);
+  private readonly subs = new Subscription();
+  private readonly targetGetter = (): DefaultFocusTarget => this.target();
+
+  constructor() {
+    // Fresh navigation: the directive is created with the component, so the
+    // next render is the arrival. A back-nav re-attach reuses the component
+    // (no re-render), so attached$ below covers that case.
+    afterNextRender(() => this.svc.applyOnArrival(this.target()));
+  }
+
+  ngOnInit(): void {
+    // Let spatial-nav land here when nothing is focused (cold-load + first key).
+    this.svc.register(this.targetGetter);
+    const ownKey = this.reuseStrategy.keyFor(this.route.snapshot);
+    this.subs.add(
+      this.reuseStrategy.attached$
+        .pipe(filter((key) => key === ownKey))
+        .subscribe(() => this.svc.applyOnArrival(this.target())),
+    );
+    // Capture the focused item the instant a navigation starts (host still in
+    // the DOM) so a later back-navigation can return to it.
+    this.subs.add(
+      this.router.events
+        .pipe(filter((e): e is NavigationStart => e instanceof NavigationStart))
+        .subscribe(() => this.svc.saveFocus(this.target())),
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subs.unsubscribe();
+    this.svc.unregister(this.targetGetter);
+  }
+
+  private target(): DefaultFocusTarget {
+    return {
+      host: this.host.nativeElement,
+      selector: this.appDefaultFocus(),
+      focusKey: this.focusKey(),
+      focusIdAttr: this.focusIdAttr(),
+    };
+  }
+}

--- a/client/src/app/shared/utils/infinite-scroll-list.ts
+++ b/client/src/app/shared/utils/infinite-scroll-list.ts
@@ -37,6 +37,8 @@ export class InfiniteScrollList<T extends { id: number }> {
   private metricsFn: (() => GridMetrics | null) | null = null;
   private bufferRows = 4;
   private windowRaf: number | null = null;
+  private windowedOnce = false;
+  private warnedWindowFail = false;
 
   /** All items (reactive — use in computed for counts/stats). */
   readonly all = signal<T[]>([]);
@@ -137,6 +139,16 @@ export class InfiniteScrollList<T extends { id: number }> {
     if (!m || m.rowHeight <= 0 || m.cols < 1) {
       // Metrics not ready yet (grid not laid out) — render everything, which
       // is exactly the non-windowed behavior, so never worse than before.
+      // Warn once if windowing previously succeeded then broke: that's a grid
+      // CSS / measurement regression silently disabling the DOM cap, not the
+      // benign first-render case.
+      if (this.windowedOnce && this.allItems.length && !this.warnedWindowFail) {
+        this.warnedWindowFail = true;
+        console.warn(
+          '[InfiniteScrollList] grid metrics unavailable after windowing succeeded — ' +
+            'rendering all items. A grid layout change likely broke readGridMetrics().',
+        );
+      }
       this.visible.set(this.allItems.slice());
       this.padTop.set(0);
       this.padBottom.set(0);
@@ -150,6 +162,8 @@ export class InfiniteScrollList<T extends { id: number }> {
   }
 
   private applyWindow(m: GridMetrics, startRowRaw: number, endRowRaw: number) {
+    this.windowedOnce = true;
+    this.warnedWindowFail = false;
     const total = this.allItems.length;
     const cols = m.cols;
     const totalRows = Math.ceil(total / cols);

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -282,6 +282,16 @@ html.tv-host {
   scroll-padding-top: 96px;
   scroll-padding-bottom: 20vh;
 }
+/* Same focus-into-view breathing room on the browser when navigating by
+   keyboard: arrow / Tab focus scrolls via scrollIntoView({block:'nearest'}) (or
+   sequential focus nav), which otherwise parks the focused card against the
+   bottom edge. Scoped through :has to keyboard modality so mouse scrolling is
+   untouched. TVs already get this via html.tv-host above; :has never matches on
+   the TV WebView's Chrome 85, which is fine. */
+html:has(body.keyboard-modality) {
+  scroll-padding-top: 96px;
+  scroll-padding-bottom: 20vh;
+}
 /* Disable hover styles on TV — there is no pointer */
 body.tv *:hover {
   background-color: revert;

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -322,7 +322,8 @@ body.native select {
 }
 body:not(.keyboard-modality):not(.tv) app-media-card figure:focus-visible,
 body:not(.keyboard-modality):not(.tv) [data-home-focus]:focus-visible,
-body:not(.keyboard-modality):not(.tv) [data-tv-focusable]:focus-visible {
+body:not(.keyboard-modality):not(.tv) [data-tv-focusable]:focus-visible,
+body:not(.keyboard-modality):not(.tv) app-mosaic-card button:focus-visible .mosaic-art {
   transform: none !important;
 }
 
@@ -368,14 +369,16 @@ body.tv .btn-ghost:focus-visible {
    selected card "lifts" off the grid. Smaller bump on desktop (mouse
    users already get hover feedback), bigger on TV for the 10-foot UI. */
 app-media-card figure:focus-visible,
-[data-home-focus]:focus-visible {
+[data-home-focus]:focus-visible,
+app-mosaic-card button:focus-visible .mosaic-art {
   transform: scale(1.04);
   transition: transform 0.15s ease-out;
 }
 body.tv .media-card:focus-within,
 body.tv app-media-card figure:focus-visible,
 body.tv [data-home-focus]:focus-visible,
-body.tv [data-tv-focusable]:focus-visible {
+body.tv [data-tv-focusable]:focus-visible,
+body.tv app-mosaic-card button:focus-visible .mosaic-art {
   transform: scale(1.06);
 }
 
@@ -411,7 +414,8 @@ body.tv app-media-card .opacity-0.group-hover\:opacity-100 {
    the card's `border-radius` — needed because Tizen 6.5 Chromium 85
    would otherwise paint a rectangle (outline-without-radius). */
 app-media-card figure:focus-visible,
-[data-home-focus]:focus-visible {
+[data-home-focus]:focus-visible,
+app-mosaic-card button:focus-visible .mosaic-art {
   outline: none !important;
   box-shadow:
     0 0 0 2px var(--color-base-100, #1d232a),
@@ -425,7 +429,8 @@ app-media-card figure:focus-visible,
    Drop the blurs on every TV, keep the crisp 2-step ring (cheap, no blur).
    Desktop keeps the full Lumen look. */
 body.tv app-media-card figure:focus-visible,
-body.tv [data-home-focus]:focus-visible {
+body.tv [data-home-focus]:focus-visible,
+body.tv app-mosaic-card button:focus-visible .mosaic-art {
   box-shadow:
     0 0 0 2px var(--color-base-100, #1d232a),
     0 0 0 6px var(--color-primary, #7a3ff2) !important;

--- a/client/tizen/build-wgt.mjs
+++ b/client/tizen/build-wgt.mjs
@@ -45,6 +45,35 @@ for (const f of stylesFiles) {
   console.log(`[tizen] downlevelled ${f}: ${before.length} → ${after.length} bytes`);
 }
 
+// Guard: a Chromium-85-unsafe token surviving the downlevel pass means a
+// pipeline gap (e.g. a new Tailwind feature) would ship a silently-broken WGT —
+// fail the build here instead. Each token below is one the pipeline is supposed
+// to have folded/flattened/dropped. (color-mix is intentionally NOT listed: its
+// @supports fallback path is kept on purpose.)
+const UNSAFE_TOKENS = [
+  [/[;{](?:translate|rotate|scale):/, 'individual transform property — should fold into `transform`'],
+  // Negative lookbehind excludes Tailwind's escaped container-query CLASSES
+  // (`.\@container`, `.\@md\:…`) — only the real at-rules are unsafe.
+  [/(?<!\\)@container[\s({]/, '@container query'],
+  [/(?<!\\)@starting-style[\s{]/, '@starting-style'],
+  [/\d(?:cqi|cqw|cqh|cqb)\b/, 'container-query length unit'],
+  [/:where\(/, ':where()'],
+];
+for (const f of stylesFiles) {
+  const css = readFileSync(resolve(stage, f), 'utf8');
+  for (const [re, label] of UNSAFE_TOKENS) {
+    const m = css.match(re);
+    if (m) {
+      const ctx = css.slice(Math.max(0, m.index - 50), m.index + 60);
+      console.error(
+        `[tizen] BUILD BLOCKED — Chromium-85-unsafe CSS survived downlevel in ${f}: ${label}\n  …${ctx}…`,
+      );
+      process.exit(1);
+    }
+  }
+}
+console.log('[tizen] CSS downlevel guard passed');
+
 // Force the stylesheet `<link>` to load synchronously (render-blocking).
 // Angular's build pipeline emits the lazy pattern
 // `<link rel="stylesheet" href="X" media="print" onload="this.media='all'">`


### PR DESCRIPTION
Branch accumulated over a session of TV/keyboard navigation and library work, plus a few adjacent fixes. Every commit is conventional; squash-merging.

## Spatial navigation / focus
- Pace focus moves (leading+trailing throttle) and pad keyboard scroll-into-view.
- Keep held-key D-pad nav inside the current `[data-tv-zone]` (deliberate press crosses out, a held one doesn't).
- Reusable default-focus on arrival via `appDefaultFocus` directive + `DefaultFocusService` (Home → first library, Library → first card, media-detail → Play), gated to keyboard/TV, visibility-aware, waits for async content.
- Widen the horizontal-scroller focus scroll-into-view margin.
- Register the library view tabs `<nav>` as an `appTvRow` so `↑` from a content row lands on the active tab instead of bridging past it to the fixed topbar (cast icon).
- Audit cleanup: shared `FOCUSABLE_SELECTOR`, wheel routed through the paced dispatcher, modal cache.

## Library
- Land on the library root after an app restart, not the last tab: split the state serialization so the active tab / genre / collection live only in the URL, not localStorage (filter/sort preferences still persist). Adversarially reviewed across fix-correctness, regressions and sibling features.
- Navbar back-stack ignores query-only changes, so Android back / Escape on a library tab returns to the previous page.
- Library smells cleanup (dead effect, route-param subscription leak, dedup) + windowing warn-once.
- Genres / collections mosaic cards now match the media-card focus treatment (gapped primary ring + glow + drop shadow + scale-up, crisp blur-free ring on TV), hugging the rounded poster instead of a square ring around the whole card.

## Backend / cross-platform
- DirectPlay: bind container + video codec + audio codec to a single profile entry instead of OR-accumulating across entries.
- Tizen: fold Tailwind individual transform properties into `transform` in the downlevel pass and guard the WGT build against Chromium-85-unsafe CSS.
- Images: expose `X-Image-Size-Served` when a sized variant falls back to the full-res original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)