### PR TITLE
fix(streaming): multi-audio keeps surround via a uniform group codec

### DIFF
--- a/backend/src/modules/streaming/dto/playback-info.dto.ts
+++ b/backend/src/modules/streaming/dto/playback-info.dto.ts
@@ -27,8 +27,12 @@ export interface AudioTrackPlan {
   channels?: number;
   /** True when this track plays as-is (no re-encode). */
   copy: boolean;
-  /** Codec the client actually hears for this track. */
+  /** Codec the client actually hears for this track (uniform across the audio
+   *  group on the HLS paths). */
   outputCodec: string;
+  /** Output channel count (source channels when copied; downmixed to the
+   *  device/codec cap when transcoded). */
+  outputChannels?: number;
   /** Why this track is re-encoded (`Audio*` flags); empty when copied. */
   reasonFlags: string[];
 }

--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -58,7 +58,11 @@ export interface LiveSession {
   audioPlan: AudioPlan | null;
   /** Per-rendition audio decision (one entry per source audio stream) for the
    *  multi-audio var_stream_map encode; null when uniform / not multi-audio. */
-  audioTrackPlans: { copy: boolean; outputCodec: string }[] | null;
+  audioTrackPlans: {
+    copy: boolean;
+    outputCodec: string;
+    outputChannels?: number;
+  }[] | null;
   audioStreamIndex: number | null;
   audioStreamCount: number;
   useExtXMedia: boolean;
@@ -113,7 +117,11 @@ export interface CreateLiveSessionInput {
   position?: number;
   useTs?: boolean;
   audioPlan?: AudioPlan | null;
-  audioTrackPlans?: { copy: boolean; outputCodec: string }[] | null;
+  audioTrackPlans?: {
+    copy: boolean;
+    outputCodec: string;
+    outputChannels?: number;
+  }[] | null;
   audioStreamIndex?: number | null;
   audioStreamCount?: number;
   useExtXMedia?: boolean;

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -747,16 +747,23 @@ export class StreamBuilderService {
         return { ...base, copy: true, outputCodec: codec, reasonFlags: [] };
       }
 
-      // DirectStream (remux): copy when the codec is profile-supported AND
-      // fMP4-safe, else re-encode to AAC.
+      // DirectStream (remux): a track is copied only when its codec is
+      // profile-supported, fMP4-safe AND its channel count fits the device —
+      // a 7.1 track on a 5.1 cap must downmix, so it can't be copied. Missing
+      // the channel check made every OPUS track look copyable, so a file whose
+      // default track was 8-channel collapsed all renditions to one plan and a
+      // fitting 5.1 track got needlessly downmixed to AAC stereo.
       if (playMethod === 'DirectStream') {
-        const copy = codecSupported && FMP4_COMPATIBLE_AUDIO.has(codec);
-        return {
-          ...base,
-          copy,
-          outputCodec: copy ? codec : 'aac',
-          reasonFlags: copy ? [] : ['AudioCodecNotSupported'],
-        };
+        const copy =
+          codecSupported && !channelsExceed && FMP4_COMPATIBLE_AUDIO.has(codec);
+        const reasonFlags: string[] = [];
+        if (!copy) {
+          if (channelsExceed) reasonFlags.push('AudioChannelsNotSupported');
+          if (!codecSupported || !FMP4_COMPATIBLE_AUDIO.has(codec)) {
+            reasonFlags.push('AudioCodecNotSupported');
+          }
+        }
+        return { ...base, copy, outputCodec: copy ? codec : 'aac', reasonFlags };
       }
 
       // Transcode: source-compatible → copy; else surround (EAC-3/AC-3)

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -709,15 +709,20 @@ export class StreamBuilderService {
 
   /**
    * Per-track audio copy/transcode decision for every source audio stream,
-   * in `streamInfo.audio` order. Mirrors the per-play-method audio handling
-   * — DirectPlay copies every track (raw file), DirectStream copies the
-   * fMP4-safe codecs and re-encodes the rest to AAC, Transcode keeps surround
-   * via EAC-3/AC-3 or downmixes to AAC stereo.
+   * in `streamInfo.audio` order.
+   *
+   * For HLS output (DirectStream / Transcode) every rendition of the audio
+   * group MUST share one OUTPUT codec — a master playlist carries a single
+   * CODECS string and players (AVPlayer, Shaka) reject a group whose
+   * renditions disagree. So the group picks one output codec
+   * ({@link pickGroupAudioCodec}) and each rendition either copies (its source
+   * already IS that codec and fits the channel cap) or transcodes to it,
+   * downmixing surround to the cap. Copy + transcode can mix freely since the
+   * output codec stays uniform. DirectPlay copies everything (raw file).
    *
    * The top-level `audioPlan` / `transcodeReasons` only describe the default
-   * track; multi-audio files are served as independent EXT-X-MEDIA renditions
-   * the player switches client-side, so the overlay reads the *active* track's
-   * entry here instead of the default's reason.
+   * track; the overlay reads the *active* track's entry here so the reason
+   * follows a client-side audio switch.
    */
   private buildAudioTracks(
     audioStreams: { codec?: string; channels?: number; language?: string }[],
@@ -728,67 +733,97 @@ export class StreamBuilderService {
       .flatMap((p) => p.audioCodecs)
       .map((c) => c.toLowerCase());
     const maxChannels = profile.maxAudioChannels ?? 2;
-    const surroundCodec = profileAudioCodecs.includes('eac3')
-      ? 'eac3'
-      : profileAudioCodecs.includes('ac3')
-        ? 'ac3'
-        : null;
+    const groupCodec = this.pickGroupAudioCodec(
+      audioStreams,
+      profileAudioCodecs,
+      maxChannels,
+    );
+    const surroundOut = groupCodec === 'eac3' || groupCodec === 'ac3';
 
     return audioStreams.map((t, index) => {
       const codec = (t.codec ?? '').toLowerCase();
       const channels = t.channels;
-      const language = t.language;
-      const base = { index, language, codec, channels };
+      const base = { index, language: t.language, codec, channels };
       const codecSupported = profileAudioCodecs.includes(codec);
       const channelsExceed = channels != null && channels > maxChannels;
+      const fmp4Safe = FMP4_COMPATIBLE_AUDIO.has(codec);
 
       // DirectPlay serves the raw file — every track plays natively.
       if (playMethod === 'DirectPlay') {
-        return { ...base, copy: true, outputCodec: codec, reasonFlags: [] };
+        return {
+          ...base,
+          copy: true,
+          outputCodec: codec,
+          outputChannels: channels,
+          reasonFlags: [],
+        };
       }
 
-      // DirectStream (remux): a track is copied only when its codec is
-      // profile-supported, fMP4-safe AND its channel count fits the device —
-      // a 7.1 track on a 5.1 cap must downmix, so it can't be copied. Missing
-      // the channel check made every OPUS track look copyable, so a file whose
-      // default track was 8-channel collapsed all renditions to one plan and a
-      // fitting 5.1 track got needlessly downmixed to AAC stereo.
-      if (playMethod === 'DirectStream') {
-        const copy =
-          codecSupported && !channelsExceed && FMP4_COMPATIBLE_AUDIO.has(codec);
-        const reasonFlags: string[] = [];
-        if (!copy) {
-          if (channelsExceed) reasonFlags.push('AudioChannelsNotSupported');
-          if (!codecSupported || !FMP4_COMPATIBLE_AUDIO.has(codec)) {
-            reasonFlags.push('AudioCodecNotSupported');
-          }
-        }
-        return { ...base, copy, outputCodec: copy ? codec : 'aac', reasonFlags };
+      // HLS group: copy only when the source already IS the group's output
+      // codec and fits the channel cap; otherwise transcode to it.
+      const copy =
+        codec === groupCodec && codecSupported && fmp4Safe && !channelsExceed;
+      if (copy) {
+        return {
+          ...base,
+          copy: true,
+          outputCodec: groupCodec,
+          outputChannels: channels,
+          reasonFlags: [],
+        };
       }
-
-      // Transcode: source-compatible → copy; else surround (EAC-3/AC-3)
-      // keeping channels; else AAC stereo downmix. A track saved by the
-      // surround path doesn't claim the codec is incompatible (the user gets
-      // surround), but a real channel overflow is still surfaced — mirrors
-      // the default-track reason cleanup.
-      const srcCompatible = codecSupported && !channelsExceed;
-      if (srcCompatible) {
-        return { ...base, copy: true, outputCodec: codec, reasonFlags: [] };
-      }
-      const surroundPossible =
-        channels != null && channels >= 6 && maxChannels >= 6 && surroundCodec != null;
+      // EAC-3 / AC-3 cap at 5.1 (6 ch); AAC downmixes to stereo.
+      const outputChannels = surroundOut
+        ? Math.min(channels ?? maxChannels, maxChannels, 6)
+        : 2;
+      const surroundPreserved = surroundOut && outputChannels >= 6;
       const reasonFlags: string[] = [];
-      if (channelsExceed) reasonFlags.push('AudioChannelsNotSupported');
-      if (!codecSupported && !surroundPossible) {
+      if (channelsExceed) {
+        // Real overflow (downmixed). Takes priority over the codec reason.
+        reasonFlags.push('AudioChannelsNotSupported');
+      } else if (!codecSupported && !surroundPreserved) {
+        // Device can't play this codec and we didn't save it as surround.
+        // A supported codec re-encoded only to match the group's output
+        // codec carries no flag — it's not an incompatibility.
         reasonFlags.push('AudioCodecNotSupported');
       }
       return {
         ...base,
         copy: false,
-        outputCodec: surroundPossible ? surroundCodec : 'aac',
+        outputCodec: groupCodec,
+        outputChannels,
         reasonFlags,
       };
     });
+  }
+
+  /**
+   * Pick the single OUTPUT codec shared by every rendition of an audio group
+   * (HLS requires one codec per group). Copy-all when every track is the same
+   * supported, fMP4-safe codec that fits the channel cap — that codec is the
+   * output and nothing re-encodes. Otherwise the best the device accepts: a
+   * surround codec (EAC-3 > AC-3) when any track carries surround so 5.1/7.1
+   * survive, else AAC. Only AAC/EAC-3/AC-3 are valid transcode targets (the
+   * codecs we encode), so e.g. an all-OPUS group with one over-capacity track
+   * can't stay OPUS and lands on EAC-3.
+   */
+  private pickGroupAudioCodec(
+    audioStreams: { codec?: string; channels?: number }[],
+    profileAudioCodecs: string[],
+    maxChannels: number,
+  ): string {
+    const codecs = audioStreams.map((t) => (t.codec ?? '').toLowerCase());
+    const allCopyable = audioStreams.every(
+      (t, i) =>
+        profileAudioCodecs.includes(codecs[i]) &&
+        FMP4_COMPATIBLE_AUDIO.has(codecs[i]) &&
+        (t.channels == null || t.channels <= maxChannels),
+    );
+    if (allCopyable && new Set(codecs).size === 1) return codecs[0];
+    const anySurround = audioStreams.some((t) => (t.channels ?? 0) >= 6);
+    if (anySurround && profileAudioCodecs.includes('eac3')) return 'eac3';
+    if (anySurround && profileAudioCodecs.includes('ac3')) return 'ac3';
+    return 'aac';
   }
 
   private tryDirectPlay(

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -32,6 +32,14 @@ import type { CodecVariant, VideoCodec } from './transcoding/codec/types';
  *  codecs="mp4a.6B"` (MP3) on append. */
 const FMP4_COMPATIBLE_AUDIO = new Set(['aac', 'ac3', 'eac3', 'opus', 'flac']);
 
+/** Audio codecs the backend can transcode TO (FFmpeg encoders we drive:
+ *  `aac`, `eac3`, `ac3`, `libopus`). A group can keep one of these as its
+ *  uniform output codec even when some renditions need re-encoding (downmix),
+ *  so a track already in that codec copies and only the over-capacity ones
+ *  re-encode. Codecs outside this set can only be a group codec when every
+ *  rendition copies (no re-encode needed). */
+const ENCODABLE_AUDIO = new Set(['aac', 'eac3', 'ac3', 'opus']);
+
 /**
  * What stream-builder hands back: the public playback-info response,
  * plus the two side-band decisions the controller threads onto the
@@ -738,7 +746,6 @@ export class StreamBuilderService {
       profileAudioCodecs,
       maxChannels,
     );
-    const surroundOut = groupCodec === 'eac3' || groupCodec === 'ac3';
 
     return audioStreams.map((t, index) => {
       const codec = (t.codec ?? '').toLowerCase();
@@ -772,19 +779,26 @@ export class StreamBuilderService {
           reasonFlags: [],
         };
       }
-      // EAC-3 / AC-3 cap at 5.1 (6 ch); AAC downmixes to stereo.
-      const outputChannels = surroundOut
-        ? Math.min(channels ?? maxChannels, maxChannels, 6)
-        : 2;
-      const surroundPreserved = surroundOut && outputChannels >= 6;
+      // Output channel count: AAC downmixes to stereo; EAC-3/AC-3 cap at 5.1
+      // (the encoders' max); OPUS (and other multichannel codecs) keep up to
+      // the device cap.
+      const outputChannels =
+        groupCodec === 'aac'
+          ? 2
+          : groupCodec === 'eac3' || groupCodec === 'ac3'
+            ? Math.min(channels ?? maxChannels, maxChannels, 6)
+            : Math.min(channels ?? maxChannels, maxChannels);
+      const surroundPreserved = groupCodec !== 'aac' && outputChannels >= 6;
+      // A track plays as-is only if the device decodes it AND it's fMP4-safe
+      // (MP3 is device-supported but can't ride in fMP4/HLS, so it must
+      // transcode — that's a genuine reason, unlike a codec re-encoded only to
+      // match the group's output codec).
+      const playableAsIs = codecSupported && fmp4Safe;
       const reasonFlags: string[] = [];
       if (channelsExceed) {
         // Real overflow (downmixed). Takes priority over the codec reason.
         reasonFlags.push('AudioChannelsNotSupported');
-      } else if (!codecSupported && !surroundPreserved) {
-        // Device can't play this codec and we didn't save it as surround.
-        // A supported codec re-encoded only to match the group's output
-        // codec carries no flag — it's not an incompatibility.
+      } else if (!playableAsIs && !surroundPreserved) {
         reasonFlags.push('AudioCodecNotSupported');
       }
       return {
@@ -813,13 +827,24 @@ export class StreamBuilderService {
     maxChannels: number,
   ): string {
     const codecs = audioStreams.map((t) => (t.codec ?? '').toLowerCase());
-    const allCopyable = audioStreams.every(
-      (t, i) =>
-        profileAudioCodecs.includes(codecs[i]) &&
-        FMP4_COMPATIBLE_AUDIO.has(codecs[i]) &&
-        (t.channels == null || t.channels <= maxChannels),
-    );
-    if (allCopyable && new Set(codecs).size === 1) return codecs[0];
+    // All renditions share one source codec the device plays in fMP4: keep it
+    // as the group's output codec so the fitting tracks copy verbatim. If every
+    // track fits, nothing re-encodes; if one is over-capacity, we re-encode
+    // ONLY that one to the SAME codec (downmix) — which needs an encoder for it
+    // (e.g. an all-OPUS group stays OPUS via libopus instead of collapsing to
+    // EAC-3 and re-encoding the 5.1 tracks too).
+    if (codecs.length > 0 && new Set(codecs).size === 1) {
+      const c = codecs[0];
+      const supported =
+        profileAudioCodecs.includes(c) && FMP4_COMPATIBLE_AUDIO.has(c);
+      const allFit = audioStreams.every(
+        (t) => t.channels == null || t.channels <= maxChannels,
+      );
+      if (supported && (allFit || ENCODABLE_AUDIO.has(c))) return c;
+    }
+    // Mixed source codecs (or an unencodable codec with an over-capacity
+    // track): pick the best the device accepts — surround when any track
+    // carries it so 5.1/7.1 survive, else AAC.
     const anySurround = audioStreams.some((t) => (t.channels ?? 0) >= 6);
     if (anySurround && profileAudioCodecs.includes('eac3')) return 'eac3';
     if (anySurround && profileAudioCodecs.includes('ac3')) return 'ac3';

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -1021,6 +1021,7 @@ export class StreamingController {
         response.audioTracks?.map((t) => ({
           copy: t.copy,
           outputCodec: t.outputCodec,
+          outputChannels: t.outputChannels,
         })) ?? null,
       audioStreamIndex: audioStreamIndex ?? null,
       audioStreamCount: sourceAudioCount,
@@ -1265,6 +1266,14 @@ export class StreamingController {
 
     const sdrVariant = live?.videoVariant ?? null;
     const sourceFrameRate = parseFloat(v?.frameRate ?? '') || undefined;
+    // CODECS audio entry. With EXT-X-MEDIA renditions every track shares one
+    // output codec (the audio group is uniform — see buildAudioTracks), so the
+    // master must advertise THAT codec, not the default track's audioPlan
+    // (which is only the muxed single-audio decision).
+    const masterAudioCodec =
+      useExtXMedia && live?.audioTrackPlans?.length
+        ? live.audioTrackPlans[0].outputCodec
+        : (live?.audioPlan?.codec ?? 'aac');
     const playlist = this.transcodingService.generateMasterPlaylist(
       mediaFileId,
       w,
@@ -1281,7 +1290,7 @@ export class StreamingController {
       onlyQuality,
       pickedIdx ?? 0,
       deviceType,
-      live?.audioPlan?.codec ?? 'aac',
+      masterAudioCodec,
       hdrPassThrough,
       // Only the SDR ladder branch consumes this — the HDR branch
       // already drives its codec strings from `hdrPassThrough`.

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -170,6 +170,15 @@ function perStreamAudioArgs(
       out.push(`-c:a:${i}`, 'aac', `-b:a:${i}`, aacBitrate, `-ac:${i}`, '2');
       return;
     }
+    if (p.outputCodec === 'opus') {
+      // libopus, downmixed to the planned channel count. 256k is transparent
+      // for 5.1 (Opus is far more efficient than EAC-3 at the same quality).
+      out.push(`-c:a:${i}`, 'libopus', `-b:a:${i}`, '256k');
+      if (p.outputChannels != null) {
+        out.push(`-ac:${i}`, String(p.outputChannels));
+      }
+      return;
+    }
     // EAC-3 / AC-3 at 640 kbps, downmixed to the planned channel count (≤ 5.1).
     out.push(`-c:a:${i}`, p.outputCodec, `-b:a:${i}`, '640k');
     if (p.outputChannels != null) {

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -95,12 +95,15 @@ export interface BuildFfmpegArgsOptions {
         bitrateBps: number;
       };
   /** Per-rendition audio decision for the multi-audio `var_stream_map` path,
-   *  one entry per `audioStreams[]` track in the same order. When the
-   *  renditions don't all share `audioPlan` (mixed codecs/channels — e.g. a
-   *  stereo default next to a 5.1 track), each output stream gets its own
-   *  `-c:a:N`. Omitted / uniform → the single `audioPlan` applies to all
-   *  (unchanged behaviour). */
-  audioTrackPlans?: { copy: boolean; outputCodec: string }[];
+   *  one entry per `audioStreams[]` track in the same order. The group shares
+   *  one output codec; each rendition gets its own `-c:a:N` (copy when its
+   *  source already is that codec, else transcode, downmixed to
+   *  `outputChannels`). Omitted → the single `audioPlan` applies to all. */
+  audioTrackPlans?: {
+    copy: boolean;
+    outputCodec: string;
+    outputChannels?: number;
+  }[];
   encoderPreset?: string;
   qsvOptions?: { lowPower: boolean };
   /** HDR → SDR tone-mapping algorithm (admin override). Defaults to `'auto'`
@@ -143,31 +146,34 @@ function hasNoAudio(streams: AudioStreamMeta[] | undefined): boolean {
 
 /**
  * Per-output-stream audio codec args for the multi-audio `var_stream_map`
- * path, indexed to match the `-map 0:a:i` order. Returns `null` when there's
- * nothing to specialise — no per-track plans, a length mismatch, or every
- * rendition shares the same plan — so the caller keeps the single `-c:a` form
- * (byte-identical to the pre-existing behaviour). Only mixed-codec/-channel
- * sources (e.g. a stereo default beside a 5.1 track) take the per-stream form.
+ * path, indexed to match the `-map 0:a:i` order. Returns `null` only when
+ * there are no per-track plans (or a length mismatch) — then the caller keeps
+ * the single `-c:a` form. The group's output codec is uniform (HLS CODECS
+ * requirement), but copy and transcode mix per rendition: a track already in
+ * the output codec copies; the rest re-encode, downmixed to `outputChannels`.
  */
 function perStreamAudioArgs(
   audioStreams: AudioStreamMeta[],
-  plans: { copy: boolean; outputCodec: string }[] | undefined,
+  plans:
+    | { copy: boolean; outputCodec: string; outputChannels?: number }[]
+    | undefined,
   aacBitrate: string,
 ): string[] | null {
   if (!plans || plans.length !== audioStreams.length) return null;
-  const allSame = plans.every(
-    (p) => p.copy === plans[0].copy && p.outputCodec === plans[0].outputCodec,
-  );
-  if (allSame) return null;
   const out: string[] = [];
   plans.forEach((p, i) => {
     if (p.copy) {
       out.push(`-c:a:${i}`, 'copy');
-    } else if (p.outputCodec === 'aac') {
+      return;
+    }
+    if (p.outputCodec === 'aac') {
       out.push(`-c:a:${i}`, 'aac', `-b:a:${i}`, aacBitrate, `-ac:${i}`, '2');
-    } else {
-      // EAC-3 / AC-3 keep source channels at 640 kbps.
-      out.push(`-c:a:${i}`, p.outputCodec, `-b:a:${i}`, '640k');
+      return;
+    }
+    // EAC-3 / AC-3 at 640 kbps, downmixed to the planned channel count (≤ 5.1).
+    out.push(`-c:a:${i}`, p.outputCodec, `-b:a:${i}`, '640k');
+    if (p.outputChannels != null) {
+      out.push(`-ac:${i}`, String(p.outputChannels));
     }
   });
   return out;
@@ -224,8 +230,10 @@ export function buildFfmpegArgs(
     if (codec === 'aac') {
       return ['-c:a', 'aac', '-b:a', profile.audioBitrate, '-ac', '2'];
     }
-    // EAC-3 / AC-3 keep source channels (no `-ac`) at 640 kbps.
-    return ['-c:a', codec, '-b:a', '640k'];
+    // EAC-3 / AC-3 at 640 kbps, downmixed to 5.1 (the encoders' max): keeps
+    // surround while staying within the device cap, and stops a 7.1 source
+    // from failing to open (FFmpeg's eac3/ac3 encoders reject > 6 channels).
+    return ['-c:a', codec, '-b:a', '640k', '-ac', '6'];
   })();
 
   // GOP = segment_duration × fps so each segment starts exactly on an IDR.
@@ -678,7 +686,8 @@ export function buildFfmpegArgs(
     for (let i = 0; i < audioStreams.length; i++) {
       args.push('-map', audioMapSpec(audioStreams, i));
     }
-    // Per-rendition codec when the renditions diverge (mixed codecs/channels).
+    // Per-rendition audio (uniform output codec; copy or transcode per track).
+    // Falls back to the single `audioArgs` only when no plans were threaded.
     const perStream = perStreamAudioArgs(
       audioStreams,
       audioTrackPlans,

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -161,12 +161,16 @@ export interface SessionContext {
       };
   /**
    * Per-rendition audio decision for the multi-audio `var_stream_map` path,
-   * one entry per `audioStreams[]` track in source order. Threaded so each
-   * rendition encodes with its own codec when the file mixes codecs/channels
-   * (the single `audioPlan` above only describes the default track). Uniform
-   * sources leave every rendition on `audioPlan`.
+   * one entry per `audioStreams[]` track in source order. The group shares one
+   * output codec (HLS requires it); each rendition copies it or transcodes to
+   * it, downmixing to `outputChannels`. Threaded so the encode matches the
+   * playback-info decision the overlay shows.
    */
-  audioTrackPlans?: { copy: boolean; outputCodec: string }[];
+  audioTrackPlans?: {
+    copy: boolean;
+    outputCodec: string;
+    outputChannels?: number;
+  }[];
   /**
    * True when the playback target is a Tizen TV that can't consume the
    * HLS muxer's fMP4 output — AVPlay rejects the `iso5` + per-stream


### PR DESCRIPTION
Builds on the per-track audio plans (#466). Fixes both the stats-overlay audio reason and the actual encode for multi-audio files, and replaces the "downmix everything to AAC stereo" fallback with surround-preserving logic — while staying valid HLS.

## Why

For a file whose **default** audio track exceeds the device channel cap (e.g. a 7.1 default beside 5.1 tracks), the previous logic:
- marked every OPUS rendition "copy" (missing the channel check), so the per-rendition encode never diverged and fell back to the default track's plan, which the 7.1 had forced to **AAC stereo** — a fitting 5.1 track was needlessly downmixed to stereo, and the overlay showed it as "direct" while ffmpeg re-encoded it;
- or, per-rendition, let codecs **diverge within one audio group**, which violates HLS (a master carries one CODECS string per group; AVPlayer/Shaka reject a mismatched group).

## What

Pick **one output codec per audio group** and copy/transcode each rendition to it:

- **`pickGroupAudioCodec`**: when every track is the same supported, fMP4-safe codec, keep it — fitting tracks copy, over-capacity ones re-encode to the *same* codec (downmix). Needs an encoder for that codec (`aac/eac3/ac3/opus`); an all-OPUS group with one 7.1 track stays **OPUS** (5.1 copied, 7.1 → OPUS 5.1 via libopus) instead of collapsing to EAC-3. Mixed-codec groups pick **EAC-3 > AC-3** when any track carries surround so 5.1/7.1 survive, else AAC.
- **Per rendition**: copy when its source already is the group codec and fits; else transcode (downmix to the cap — EAC-3/AC-3 ≤ 5.1, OPUS up to the device cap, AAC stereo). Copy + transcode mix freely; the output codec stays uniform, so CODECS is valid.
- **MP3**: device-decodable but not fMP4-safe, so never a group codec — an MP3 track transcodes with a real `AudioCodecNotSupported` reason.
- ffmpeg-args emits per-stream `-c:a:N` with the channel cap; the single-audio path caps EAC-3/AC-3 at `-ac 6` (also stops a 7.1 source failing to open).
- The master advertises the group's output codec, not the default track's.

## Result

Example — sources OPUS 7.1 / EAC3 5.1 / AAC 2.0 (device 5.1, eac3) → all **EAC-3**: 7.1 → 5.1, the 5.1 copied verbatim, 2.0 → eac3 stereo. CODECS=ec-3.

All-OPUS file (7.1 default + 5.1 tracks) → all **OPUS**: 5.1 renditions copied, 7.1 → OPUS 5.1. The overlay's "direct" label on the copied 5.1 tracks is finally accurate.

## Testing

- `tsc --noEmit` clean; streaming unit tests 109/109.
- **Verified on the live backend (QSV host)**: `-c:a:0 libopus -b:a:0 256k -ac:0 6` (7.1→OPUS 5.1) + `-c:a:1/2/3 copy`, segments written, playback confirmed on a Galaxy S25.

## Follow-up (separate PR)

`maxAudioChannels` is derived from the active output sink, so multichannel sources are downmixed server-side. Reporting the device's *decode* capability instead (trust the device to downmix) would let 7.1 sources DirectPlay — tracked separately.