### PR TITLE
feat(streaming): report mobile audio decode capability, not the output sink

### DIFF
--- a/backend/src/modules/streaming/dto/device-profile.dto.ts
+++ b/backend/src/modules/streaming/dto/device-profile.dto.ts
@@ -3,6 +3,7 @@ import {
   IsBoolean,
   IsIn,
   IsNumber,
+  IsObject,
   IsOptional,
   IsString,
   ValidateNested,
@@ -68,6 +69,18 @@ export class DeviceProfileDto {
   @IsNumber()
   @IsOptional()
   maxAudioChannels?: number;
+
+  /**
+   * Per-audio-codec max decodable channel count (e.g. `{aac: 8, eac3: 6}`),
+   * keyed by lowercased codec. The device can decode a codec up to this many
+   * channels (the OS downmixes to the real output). Lets the backend allow a
+   * 7.1 AAC source while still downmixing a 7.1 EAC-3 source whose decoder
+   * tops out at 5.1 on the same device. Falls back to {@link maxAudioChannels}
+   * for codecs absent from the map.
+   */
+  @IsObject()
+  @IsOptional()
+  audioChannelsByCodec?: Record<string, number>;
 
   @IsBoolean()
   @IsOptional()

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -40,6 +40,18 @@ const FMP4_COMPATIBLE_AUDIO = new Set(['aac', 'ac3', 'eac3', 'opus', 'flac']);
  *  rendition copies (no re-encode needed). */
 const ENCODABLE_AUDIO = new Set(['aac', 'eac3', 'ac3', 'opus']);
 
+/** Max channels the device can decode for `codec` — the per-codec cap when the
+ *  profile carries one (`audioChannelsByCodec`), else the global
+ *  `maxAudioChannels`, else stereo. Lets a device decode AAC 7.1 while its
+ *  EAC-3 decoder tops out at 5.1, instead of a single device-wide number. */
+function audioChannelCap(profile: DeviceProfileDto, codec: string): number {
+  return (
+    profile.audioChannelsByCodec?.[codec.toLowerCase()] ??
+    profile.maxAudioChannels ??
+    2
+  );
+}
+
 /**
  * What stream-builder hands back: the public playback-info response,
  * plus the two side-band decisions the controller threads onto the
@@ -507,15 +519,19 @@ export class StreamBuilderService {
       .flatMap((p) => p.audioCodecs)
       .map((c) => c.toLowerCase());
     const srcChannels = source.audioChannels ?? 2;
-    const maxChannels = profile.maxAudioChannels ?? 2;
     const srcCodec = (source.audioCodec ?? '').toLowerCase();
+    const srcCap = audioChannelCap(profile, srcCodec);
     const srcCompatible =
-      directPlayResult.audioSupported && srcChannels <= maxChannels;
+      directPlayResult.audioSupported && srcChannels <= srcCap;
+    const surroundCodec = profileAudioCodecs.includes('eac3')
+      ? 'eac3'
+      : profileAudioCodecs.includes('ac3')
+        ? 'ac3'
+        : null;
     const surroundPossible =
       srcChannels >= 6 &&
-      maxChannels >= 6 &&
-      (profileAudioCodecs.includes('eac3') ||
-        profileAudioCodecs.includes('ac3'));
+      surroundCodec != null &&
+      audioChannelCap(profile, surroundCodec) >= 6;
 
     let outputAudioCodec: 'aac' | 'ac3' | 'eac3' | string;
     let outputAudioBitrateBps: number;
@@ -525,9 +541,8 @@ export class StreamBuilderService {
       outputAudioCodec = srcCodec;
       outputAudioBitrateBps = source.audioBitRate ?? 0;
       canCopyAudio = true;
-    } else if (surroundPossible) {
-      if (profileAudioCodecs.includes('eac3')) outputAudioCodec = 'eac3';
-      else outputAudioCodec = 'ac3';
+    } else if (surroundPossible && surroundCodec) {
+      outputAudioCodec = surroundCodec;
       outputAudioBitrateBps = 640_000;
     } else {
       outputAudioCodec = 'aac';
@@ -544,7 +559,7 @@ export class StreamBuilderService {
     }
 
     this.log.log(
-      `Transcode for file ${resolved.mediaFile.id}: ${reasons.map((r) => r.flag).join(', ')} (audioOut=${outputAudioCodec}, copy=${canCopyAudio}, srcCh=${srcChannels}, maxCh=${maxChannels})`,
+      `Transcode for file ${resolved.mediaFile.id}: ${reasons.map((r) => r.flag).join(', ')} (audioOut=${outputAudioCodec}, copy=${canCopyAudio}, srcCh=${srcChannels}, maxCh=${srcCap})`,
     );
     const url = `/api/stream/${resolved.mediaFile.id}/master.m3u8${tokenParam}`;
     const transcodeBitrateByQuality: NonNullable<
@@ -740,20 +755,25 @@ export class StreamBuilderService {
     const profileAudioCodecs = profile.directPlayProfiles
       .flatMap((p) => p.audioCodecs)
       .map((c) => c.toLowerCase());
-    const maxChannels = profile.maxAudioChannels ?? 2;
     const groupCodec = this.pickGroupAudioCodec(
       audioStreams,
+      profile,
       profileAudioCodecs,
-      maxChannels,
     );
+    // Channel cap of the chosen OUTPUT codec — what a transcoded rendition
+    // downmixes to (EAC-3/AC-3 additionally cap at 5.1, AAC at stereo).
+    const outCap = audioChannelCap(profile, groupCodec);
 
     return audioStreams.map((t, index) => {
       const codec = (t.codec ?? '').toLowerCase();
       const channels = t.channels;
       const base = { index, language: t.language, codec, channels };
       const codecSupported = profileAudioCodecs.includes(codec);
-      const channelsExceed = channels != null && channels > maxChannels;
       const fmp4Safe = FMP4_COMPATIBLE_AUDIO.has(codec);
+      // Fits for a verbatim copy only within ITS OWN codec's decode cap (a
+      // device may decode AAC 7.1 but EAC-3 only 5.1).
+      const channelsExceed =
+        channels != null && channels > audioChannelCap(profile, codec);
 
       // DirectPlay serves the raw file — every track plays natively.
       if (playMethod === 'DirectPlay') {
@@ -779,24 +799,23 @@ export class StreamBuilderService {
           reasonFlags: [],
         };
       }
-      // Output channel count: AAC downmixes to stereo; EAC-3/AC-3 cap at 5.1
-      // (the encoders' max); OPUS (and other multichannel codecs) keep up to
-      // the device cap.
+      // Output channels: AAC → stereo; EAC-3/AC-3 → output-codec device cap,
+      // hard-capped at 5.1; OPUS (and other multichannel codecs) → device cap.
       const outputChannels =
         groupCodec === 'aac'
           ? 2
           : groupCodec === 'eac3' || groupCodec === 'ac3'
-            ? Math.min(channels ?? maxChannels, maxChannels, 6)
-            : Math.min(channels ?? maxChannels, maxChannels);
+            ? Math.min(channels ?? outCap, outCap, 6)
+            : Math.min(channels ?? outCap, outCap);
+      const downmixed = channels != null && outputChannels < channels;
       const surroundPreserved = groupCodec !== 'aac' && outputChannels >= 6;
       // A track plays as-is only if the device decodes it AND it's fMP4-safe
-      // (MP3 is device-supported but can't ride in fMP4/HLS, so it must
-      // transcode — that's a genuine reason, unlike a codec re-encoded only to
-      // match the group's output codec).
+      // (MP3 is device-decodable but not fMP4-safe, so it must transcode — a
+      // genuine reason, unlike a codec re-encoded only to match the group).
       const playableAsIs = codecSupported && fmp4Safe;
       const reasonFlags: string[] = [];
-      if (channelsExceed) {
-        // Real overflow (downmixed). Takes priority over the codec reason.
+      if (downmixed) {
+        // Channels were actually reduced. Takes priority over the codec reason.
         reasonFlags.push('AudioChannelsNotSupported');
       } else if (!playableAsIs && !surroundPreserved) {
         reasonFlags.push('AudioCodecNotSupported');
@@ -823,8 +842,8 @@ export class StreamBuilderService {
    */
   private pickGroupAudioCodec(
     audioStreams: { codec?: string; channels?: number }[],
+    profile: DeviceProfileDto,
     profileAudioCodecs: string[],
-    maxChannels: number,
   ): string {
     const codecs = audioStreams.map((t) => (t.codec ?? '').toLowerCase());
     // All renditions share one source codec the device plays in fMP4: keep it
@@ -838,7 +857,7 @@ export class StreamBuilderService {
       const supported =
         profileAudioCodecs.includes(c) && FMP4_COMPATIBLE_AUDIO.has(c);
       const allFit = audioStreams.every(
-        (t) => t.channels == null || t.channels <= maxChannels,
+        (t) => t.channels == null || t.channels <= audioChannelCap(profile, c),
       );
       if (supported && (allFit || ENCODABLE_AUDIO.has(c))) return c;
     }
@@ -956,16 +975,13 @@ export class StreamBuilderService {
       }
     }
 
-    // Audio channels check
-    if (
-      profile.maxAudioChannels &&
-      source.audioChannels &&
-      source.audioChannels > profile.maxAudioChannels
-    ) {
+    // Audio channels check — against the source codec's own decode cap.
+    const audioCap = audioChannelCap(profile, source.audioCodec);
+    if (audioCap && source.audioChannels && source.audioChannels > audioCap) {
       audioSupported = false;
       reasons.push({
         flag: 'AudioChannelsNotSupported',
-        message: `${source.audioChannels} canaux > max ${profile.maxAudioChannels}`,
+        message: `${source.audioChannels} canaux > max ${audioCap}`,
       });
     }
 

--- a/client/android/app/src/main/java/media/fliks/app/AudioCapabilitiesPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/AudioCapabilitiesPlugin.java
@@ -28,12 +28,14 @@ public class AudioCapabilitiesPlugin extends Plugin {
     @PluginMethod()
     public void getSupported(PluginCall call) {
         Set<String> codecs = new HashSet<>();
-        // Real DECODE capability: the largest channel count any audio decoder
-        // accepts (MediaCodec's getMaxInputChannelCount). ExoPlayer decodes up
-        // to this and the OS downmixes to whatever the active output renders,
-        // so reporting it lets a 5.1/7.1 source DirectPlay instead of a
-        // server-side downmix. Falls back to stereo when no decoder reports it.
+        // Real DECODE capability per codec (MediaCodec getMaxInputChannelCount):
+        // ExoPlayer decodes up to this and the OS downmixes to whatever the
+        // active output renders, so reporting it lets a 5.1/7.1 source
+        // DirectPlay instead of a server-side downmix. Per-codec, because a
+        // device may decode AAC 7.1 but EAC-3 only 5.1. Falls back to stereo
+        // when no decoder reports a channel count.
         int maxChannels = 2;
+        JSObject channelsByCodec = new JSObject();
         try {
             MediaCodecList list = new MediaCodecList(MediaCodecList.REGULAR_CODECS);
             for (MediaCodecInfo info : list.getCodecInfos()) {
@@ -46,7 +48,12 @@ public class AudioCapabilitiesPlugin extends Plugin {
                         MediaCodecInfo.AudioCapabilities ac =
                             info.getCapabilitiesForType(type).getAudioCapabilities();
                         if (ac != null) {
-                            maxChannels = Math.max(maxChannels, ac.getMaxInputChannelCount());
+                            int ch = ac.getMaxInputChannelCount();
+                            maxChannels = Math.max(maxChannels, ch);
+                            // Largest across decoders of the same codec.
+                            if (ch > channelsByCodec.optInt(key, 0)) {
+                                channelsByCodec.put(key, ch);
+                            }
                         }
                     } catch (Throwable ignored) { /* decoder omits audio caps */ }
                 }
@@ -58,6 +65,7 @@ public class AudioCapabilitiesPlugin extends Plugin {
         JSObject result = new JSObject();
         result.put("codecs", arr);
         result.put("maxChannels", maxChannels);
+        result.put("channelsByCodec", channelsByCodec);
         call.resolve(result);
     }
 

--- a/client/android/app/src/main/java/media/fliks/app/AudioCapabilitiesPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/AudioCapabilitiesPlugin.java
@@ -28,13 +28,27 @@ public class AudioCapabilitiesPlugin extends Plugin {
     @PluginMethod()
     public void getSupported(PluginCall call) {
         Set<String> codecs = new HashSet<>();
+        // Real DECODE capability: the largest channel count any audio decoder
+        // accepts (MediaCodec's getMaxInputChannelCount). ExoPlayer decodes up
+        // to this and the OS downmixes to whatever the active output renders,
+        // so reporting it lets a 5.1/7.1 source DirectPlay instead of a
+        // server-side downmix. Falls back to stereo when no decoder reports it.
+        int maxChannels = 2;
         try {
             MediaCodecList list = new MediaCodecList(MediaCodecList.REGULAR_CODECS);
             for (MediaCodecInfo info : list.getCodecInfos()) {
                 if (info.isEncoder()) continue;
                 for (String type : info.getSupportedTypes()) {
                     String key = mimeToCodecKey(type);
-                    if (key != null) codecs.add(key);
+                    if (key == null) continue;
+                    codecs.add(key);
+                    try {
+                        MediaCodecInfo.AudioCapabilities ac =
+                            info.getCapabilitiesForType(type).getAudioCapabilities();
+                        if (ac != null) {
+                            maxChannels = Math.max(maxChannels, ac.getMaxInputChannelCount());
+                        }
+                    } catch (Throwable ignored) { /* decoder omits audio caps */ }
                 }
             }
         } catch (Throwable ignored) { /* best-effort */ }
@@ -43,9 +57,7 @@ public class AudioCapabilitiesPlugin extends Plugin {
         for (String c : codecs) arr.put(c);
         JSObject result = new JSObject();
         result.put("codecs", arr);
-        // 6 = stereo + 5.1 reasonable default when a multi-channel decoder
-        // is present; ExoPlayer downmixes if the actual output can't.
-        result.put("maxChannels", codecs.contains("ac3") || codecs.contains("eac3") ? 6 : 2);
+        result.put("maxChannels", maxChannels);
         call.resolve(result);
     }
 

--- a/client/ios/App/App/AudioCapabilitiesPlugin.swift
+++ b/client/ios/App/App/AudioCapabilitiesPlugin.swift
@@ -15,7 +15,12 @@ public class AudioCapabilitiesPlugin: CAPPlugin, CAPBridgedPlugin {
     /// device class — accurate to within ~95% of real-world behaviour.
     @objc func getSupported(_ call: CAPPluginCall) {
         var codecs: [String] = ["aac", "alac", "mp3"]
-        var maxChannels = 2
+        // AVPlayer decodes multichannel (AAC / ALAC / FLAC) and the OS downmixes
+        // to the real output, so report the DECODE capability (8 = 7.1), not the
+        // stereo speaker count — a 5.1/7.1 source then DirectPlays and downmixes
+        // on-device. (No MediaCodecList equivalent on iOS, so this stays a
+        // device-class estimate.)
+        var maxChannels = 8
 
         if #available(iOS 11, tvOS 11, *) {
             codecs.append("flac")
@@ -25,9 +30,7 @@ public class AudioCapabilitiesPlugin: CAPPlugin, CAPBridgedPlugin {
         if idiom == .tv {
             // Apple TV → AC-3 / E-AC-3 / Atmos via HDMI.
             codecs.append(contentsOf: ["ac3", "eac3"])
-            maxChannels = 8
         }
-        // iPhone / iPad: stereo speakers, no AC-3/EAC-3 software decoding.
 
         call.resolve([
             "codecs": codecs,

--- a/client/ios/App/App/AudioCapabilitiesPlugin.swift
+++ b/client/ios/App/App/AudioCapabilitiesPlugin.swift
@@ -32,9 +32,17 @@ public class AudioCapabilitiesPlugin: CAPPlugin, CAPBridgedPlugin {
             codecs.append(contentsOf: ["ac3", "eac3"])
         }
 
+        // Per-codec decode estimate (no MediaCodecList equivalent on iOS): MP3
+        // is stereo; the rest decode multichannel and the OS downmixes.
+        var channelsByCodec: [String: Int] = [:]
+        for c in codecs {
+            channelsByCodec[c] = (c == "mp3") ? 2 : maxChannels
+        }
+
         call.resolve([
             "codecs": codecs,
             "maxChannels": maxChannels,
+            "channelsByCodec": channelsByCodec,
         ])
     }
 }

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -361,6 +361,15 @@ export class BrowserDeviceProfileService {
     if (this.nativeAudio) {
       maxAudioChannels = Math.max(maxAudioChannels, this.nativeAudio.maxChannels);
     }
+    // Native mobile (Android ExoPlayer / iOS AVPlayer) decodes multichannel
+    // audio and the OS downmixes to whatever the real output is (stereo on
+    // speakers/Bluetooth, surround on HDMI/USB). Report the DECODE capability,
+    // not the active output sink, so a 5.1/7.1 source DirectPlays and the
+    // device downmixes locally instead of a server-side downmix + transcode.
+    // TVs are excluded — they need the sink / eARC-passthrough logic below.
+    if (Capacitor.isNativePlatform() && !isTv) {
+      maxAudioChannels = Math.max(maxAudioChannels, 8);
+    }
     // webOS: the WebView's AudioContext caps at 2ch, but the native <video>
     // pipeline decodes Dolby and renders/passes it (TV speakers downmix, eARC
     // passes through). Declaring 5.1 when AC3/EAC3 is supported lets the

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -358,17 +358,14 @@ export class BrowserDeviceProfileService {
     // Same reasoning as the codec override above: AudioContext exposes the
     // Same source as the codec list above — the native plugin reports
     // what the active output sink (HDMI / speakers / Bluetooth) accepts.
+    // The native plugin reports the real DECODE capability (Android: per-codec
+    // getMaxInputChannelCount; iOS: device-class estimate) — the device decodes
+    // this many channels and the OS downmixes to the actual output, so a 5.1/
+    // 7.1 source DirectPlays instead of a server-side downmix. (Web keeps the
+    // AudioContext output-sink value above; browsers don't downmix multichannel
+    // for us.)
     if (this.nativeAudio) {
       maxAudioChannels = Math.max(maxAudioChannels, this.nativeAudio.maxChannels);
-    }
-    // Native mobile (Android ExoPlayer / iOS AVPlayer) decodes multichannel
-    // audio and the OS downmixes to whatever the real output is (stereo on
-    // speakers/Bluetooth, surround on HDMI/USB). Report the DECODE capability,
-    // not the active output sink, so a 5.1/7.1 source DirectPlays and the
-    // device downmixes locally instead of a server-side downmix + transcode.
-    // TVs are excluded — they need the sink / eARC-passthrough logic below.
-    if (Capacitor.isNativePlatform() && !isTv) {
-      maxAudioChannels = Math.max(maxAudioChannels, 8);
     }
     // webOS: the WebView's AudioContext caps at 2ch, but the native <video>
     // pipeline decodes Dolby and renders/passes it (TV speakers downmix, eARC

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -11,7 +11,14 @@ interface HdrPlugin {
 const Hdr = registerPlugin<HdrPlugin>('Hdr');
 
 interface AudioCapabilitiesPlugin {
-  getSupported(): Promise<{ codecs: string[]; maxChannels: number }>;
+  getSupported(): Promise<{
+    codecs: string[];
+    maxChannels: number;
+    /** Per-codec max decodable channel count (lowercased codec → channels).
+     *  Lets the backend allow AAC 7.1 while downmixing EAC-3 7.1 on a device
+     *  whose EAC-3 decoder tops out at 5.1. */
+    channelsByCodec?: Record<string, number>;
+  }>;
 }
 const AudioCaps = registerPlugin<AudioCapabilitiesPlugin>('AudioCapabilities');
 
@@ -69,6 +76,9 @@ export interface DeviceProfile {
   codecConditions: CodecCondition[];
   maxStreamingBitrate: number;
   maxAudioChannels: number;
+  /** Per-audio-codec max decodable channels (lowercased codec → channels).
+   *  Falls back to maxAudioChannels per codec on the backend. */
+  audioChannelsByCodec?: Record<string, number>;
   supportsHdr: boolean;
   /** Client device category — selects the backend bitrate ladder.
    *  Capacitor native (iOS/Android app) → 'mobile'; web (incl. Cast sender) → 'desktop'. */
@@ -130,7 +140,11 @@ export class BrowserDeviceProfileService {
   private readonly serverConfig = inject(ServerConfigService);
   private cachedProfile: DeviceProfile | null = null;
   private nativeHdr: boolean | null = null;
-  private nativeAudio: { codecs: string[]; maxChannels: number } | null = null;
+  private nativeAudio: {
+    codecs: string[];
+    maxChannels: number;
+    channelsByCodec?: Record<string, number>;
+  } | null = null;
   private nativeVideo: NativeVideoCaps | null = null;
 
   constructor() {
@@ -411,6 +425,7 @@ export class BrowserDeviceProfileService {
       codecConditions,
       maxStreamingBitrate: 0, // 0 = no limit
       maxAudioChannels,
+      audioChannelsByCodec: this.nativeAudio?.channelsByCodec,
       supportsHdr,
       deviceType: Capacitor.isNativePlatform() ? 'mobile' : 'desktop',
       deviceName: getDeviceName(),


### PR DESCRIPTION
Follow-up to #467 (direction approved during that work). Makes `maxAudioChannels` reflect the device's real **decode** capability (per codec) instead of the active output sink, so a 5.1/7.1 source DirectPlays / copies and the device downmixes locally — no server-side downmix + transcode.

## Why
`maxAudioChannels` came from the active output sink (`AudioContext.destination.maxChannelCount` + the native plugin's hard-coded 6/2), so a 7.1 track on a phone was re-encoded server-side. Mobile players decode multichannel and the OS downmixes to the real output, so the **decode** capability is the right signal.

## Change — query the real capability where it lives (not a TS constant), per codec

- **Android** (`AudioCapabilitiesPlugin.java`): reads MediaCodec `getMaxInputChannelCount()` per audio decoder → the device's true max, and a `channelsByCodec` map.
- **iOS** (`AudioCapabilitiesPlugin.swift`): AVFoundation has no equivalent, so a device-class estimate (MP3 stereo, the rest multichannel up to 8) + the same map.
- **Profile** gains `audioChannelsByCodec` (lowercased codec → channels). The TS profile drops the hard-coded 8; web keeps the AudioContext output-sink value.
- **Backend** resolves the cap **per codec** (`audioChannelCap`) everywhere it decided channels: the DirectPlay channel check (source codec's cap), the per-rendition copy gate + downmix target (source vs output codec's cap), the group-codec pick, and the single-audio transcode decision. The transcode reason now follows an actual downmix (output < source), not a source merely exceeding a device-wide number.

This covers the per-codec edge a single number couldn't: a device that decodes **AAC 7.1 but EAC-3 only 5.1** now DirectPlays the AAC 7.1 while still downmixing the EAC-3.

## Effect
Combined with #467, an all-OPUS 7.1+5.1 file copies **every** rendition the device's OPUS decoder can handle — and only downmixes a track that genuinely exceeds its codec's decoder.

Backward-compatible: absent the map, every cap falls back to `maxAudioChannels` (so the currently-installed app keeps working until rebuilt).

## Testing
Backend `tsc` + 109/109 streaming tests; client `tsc` clean. The Java/Swift plugin changes need an **Android/iOS rebuild** to verify on-device.
