### PR TITLE
feat(player): show target channel layout on transcoded audio

### DIFF
--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -61,6 +61,9 @@ export interface PlaybackInfoResponse {
     channels?: number;
     copy: boolean;
     outputCodec: string;
+    /** Output channel count when transcoded (downmixed to the device/codec
+     *  cap); source channels when copied. */
+    outputChannels?: number;
     reasonFlags: string[];
   }[];
   source: {

--- a/client/src/app/core/utils/player.utils.ts
+++ b/client/src/app/core/utils/player.utils.ts
@@ -120,7 +120,7 @@ function shortSubtitleCodec(codec: string | null | undefined, hasFile: boolean):
 }
 
 /** Channel count to a recognizable layout label (5.1, 7.1, 2.0, …). */
-function audioChannelsLabel(channels: number | null | undefined): string {
+export function audioChannelsLabel(channels: number | null | undefined): string {
   if (!channels) return '';
   if (channels === 6) return '5.1';
   if (channels === 8) return '7.1';

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -35,7 +35,7 @@ import { ServerConfigService } from '../../core/services/server-config.service';
 import { NavigationHistoryService } from '../../core/services/navigation-history.service';
 import { ToastService } from '../../core/services/toast.service';
 import { NavbarService } from '../../core/services/navbar.service';
-import { formatAudioLabel, parseAudioIndex, SpriteMetadata, widthForProfile } from '../../core/utils/player.utils';
+import { audioChannelsLabel, formatAudioLabel, parseAudioIndex, SpriteMetadata, widthForProfile } from '../../core/utils/player.utils';
 import {
   PlayerSettingsService, normalizeLang,
   SUBTITLE_SIZE_MAP, SUBTITLE_COLOR_MAP, SUBTITLE_SHADOW_MAP, SUBTITLE_BG_MAP,
@@ -719,10 +719,14 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     if (activeAudioCopy) {
       audioPlaybackMode = this.translate.instant('player.stats_direct_playback');
     } else {
+      // Show the TARGET codec + channel layout (e.g. "OPUS - 5.1") so a downmix
+      // is visible. `outputChannels` comes from the active track's plan.
       const outCodec = (
         activeAudioPlan?.outputCodec ?? pi?.outputAudioCodec ?? 'aac'
       ).toUpperCase();
-      audioPlaybackMode = this.translate.instant('player.stats_transcode_audio', { codec: outCodec });
+      const outLayout = audioChannelsLabel(activeAudioPlan?.outputChannels);
+      const codecLabel = outLayout ? `${outCodec} - ${outLayout}` : outCodec;
+      audioPlaybackMode = this.translate.instant('player.stats_transcode_audio', { codec: codecLabel });
     }
 
     return {


### PR DESCRIPTION
The "nerd stats" overlay shows the transcode output codec without its channel count — e.g. `→ Transcodage (OPUS)` for a 7.1 source downmixed to 5.1, so the downmix isn't visible.

Append the target layout from the active track's plan: `→ Transcodage (OPUS - 5.1)`. Uses the same channels→layout helper the source track label uses (`audioChannelsLabel`, now exported). The output channel count comes from `playback-info.audioTracks[].outputChannels` (already sent by the backend since #467). Copy mode and tracks without channel info are unchanged.

Independent of #468 (reads data already on `main`). Frontend-only; `tsc` clean.