### PR TITLE
fix(streaming): surface both audio transcode reasons when both apply

### DIFF
--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -813,11 +813,17 @@ export class StreamBuilderService {
       // (MP3 is device-decodable but not fMP4-safe, so it must transcode — a
       // genuine reason, unlike a codec re-encoded only to match the group).
       const playableAsIs = codecSupported && fmp4Safe;
+      // Both reasons can apply at once: a browser fed EAC-3 5.1 transcodes to
+      // AAC 2.0 because the codec ISN'T decodable AND the channels overflow —
+      // surface both, not just one. A supported codec that's only downmixed
+      // shows the channel reason alone (no codec flag); a codec re-encoded
+      // purely to match the group's output codec (playable as-is, or saved as
+      // surround) shows neither.
       const reasonFlags: string[] = [];
       if (downmixed) {
-        // Channels were actually reduced. Takes priority over the codec reason.
         reasonFlags.push('AudioChannelsNotSupported');
-      } else if (!playableAsIs && !surroundPreserved) {
+      }
+      if (!playableAsIs && !surroundPreserved) {
         reasonFlags.push('AudioCodecNotSupported');
       }
       return {


### PR DESCRIPTION
On a browser, an EAC-3 5.1 source transcoded to AAC 2.0 shows only **"Trop de canaux audio"** — but it's transcoded for two reasons: the browser can't decode EAC-3 **and** 5.1 overflows the 2-channel cap. The codec reason was hidden.

`buildAudioTracks` used `if (downmixed) … else if (codec) …`, so any downmix suppressed the codec reason. Made them independent:
- `AudioChannelsNotSupported` on an actual downmix (output channels < source).
- `AudioCodecNotSupported` when the source can't ride in the HLS output as-is (not device-decodable, or not fMP4-safe) and wasn't saved as surround.

Now both show for the browser EAC-3 case. Unchanged: a supported codec that's only downmixed shows the channel reason alone; a codec re-encoded purely to match the group's output codec (playable as-is, or kept as surround) shows neither.

Backend-only; `tsc` + 109/109 streaming tests.