### PR TITLE
fix(player): add a colon to the stats overlay Reasons label

### DIFF
--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -81,7 +81,7 @@
     "stats_dropped_frames": "Images perdues",
     "stats_crop": "Recadrage",
     "stats_tonemapping": "Mappage tonal",
-    "stats_reasons": "Raisons",
+    "stats_reasons": "Raisons :",
     "stats_sample_rate": "Fréquence d'échantillonnage",
     "transcode_reason": {
       "VideoCodecNotSupported": "Codec vidéo non supporté",


### PR DESCRIPTION
Small i18n tweak: the nerd-stats audio/video `Raisons` label now reads `Raisons :` (French typography, space before colon) so the reason text reads as a clear label-value pair. `fr.json` only (the app ships French i18n).