### PR TITLE
fix(streaming): only pick an HDR codec the client decodes at 10-bit

### DIFF
--- a/backend/src/modules/streaming/transcoding/codec/selector.ts
+++ b/backend/src/modules/streaming/transcoding/codec/selector.ts
@@ -70,6 +70,7 @@ export function pickVariants(
     for (const codec of codecOrder) {
       if (codec === 'h264') continue;
       if (!clientSupports(clientCodecs, codec)) continue;
+      if (!clientSupports10bit(profile, codec)) continue;
       const variant: CodecVariant = { codec, bitDepth: 10, hdr: source.hdr };
       if (resolveHwEncoder(variant, hwAccel)) {
         candidates.push(variant);
@@ -80,6 +81,7 @@ export function pickVariants(
       for (const codec of codecOrder) {
         if (codec === 'h264') continue;
         if (!clientSupports(clientCodecs, codec)) continue;
+        if (!clientSupports10bit(profile, codec)) continue;
         const variant: CodecVariant = { codec, bitDepth: 10, hdr: source.hdr };
         if (encoderRegistry.resolve(variant, hwAccel)) {
           candidates.push(variant);
@@ -145,6 +147,22 @@ export interface SourceInfoForSelector {
    *  `VideoCodec` union). When set, the selector prefers transcoding to
    *  the same codec for fidelity and HW path predictability. */
   codec?: VideoCodec;
+}
+
+/** True when the client declares it decodes `codec` at 10-bit (per-codec
+ *  `maxBitDepth` in the profile's codecConditions). HDR is 10-bit, so an HDR
+ *  variant must target a codec the client supports AT 10-bit — a browser that
+ *  lists HEVC (Main, 8-bit) but only has a 10-bit decoder for AV1 must not be
+ *  handed HEVC Main10: its MSE SourceBuffer rejects the segment (Shaka 3014 /
+ *  MEDIA_SOURCE_OPERATION_FAILED). Absent a condition, assume 8-bit (no HDR). */
+function clientSupports10bit(
+  profile: DeviceProfileDto,
+  codec: VideoCodec,
+): boolean {
+  const cond = profile.codecConditions?.find(
+    (c) => c.codec.toLowerCase() === codec,
+  );
+  return (cond?.maxBitDepth ?? 8) >= 10;
 }
 
 /** Codec name list comparison — clients send aliases (`hvc1`/`hev1` for


### PR DESCRIPTION
## Problem

A mobile browser playing an HEVC HDR episode failed with **Shaka 3014 / `MEDIA_SOURCE_OPERATION_FAILED`** — the SourceBuffer rejected the first segment.

The HDR codec selection (`selector.ts`) gated only on codec **presence** (`clientSupports`), not bit depth. A browser that lists HEVC (Main, 8-bit) and is HDR-capable via *another* codec's 10-bit decoder was handed **HEVC Main10 HDR**, which it can't append (`isTypeSupported` over-reports HEVC — already documented in `browser-device-profile.service.ts`).

## Fix

Require the client's per-codec `maxBitDepth >= 10` (from `codecConditions`) for an HDR variant. A client that only decodes HEVC at 8-bit skips it and falls to the next HDR-capable codec, or tonemaps to SDR — instead of being served a stream it can't decode. Native apps (HEVC Main10) are unaffected.

## Caveat

If the browser over-reports HEVC **Main10 itself** (`isTypeSupported('hvc1.2.4…') === true` but append still fails), this gate passes and 3014 persists — that deeper case needs `MediaCapabilities.decodingInfo` (more reliable than `isTypeSupported`) in the device profile. A test image is building to confirm which case this is.

Backend-only; `tsc` + 109/109 streaming tests.