### PR TITLE
fix(streaming): downmix every multi-audio rendition with -ac:a:i

### DIFF
--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -151,8 +151,13 @@ function hasNoAudio(streams: AudioStreamMeta[] | undefined): boolean {
  * the single `-c:a` form. The group's output codec is uniform (HLS CODECS
  * requirement), but copy and transcode mix per rendition: a track already in
  * the output codec copies; the rest re-encode, downmixed to `outputChannels`.
+ *
+ * Every per-stream option uses the audio-relative specifier (`-c:a:i`,
+ * `-b:a:i`, `-ac:a:i`): the muxed output carries the video at stream 0, so a
+ * bare `-ac:i` would target the wrong output stream and leave the last
+ * rendition at its source channel count.
  */
-function perStreamAudioArgs(
+export function perStreamAudioArgs(
   audioStreams: AudioStreamMeta[],
   plans:
     | { copy: boolean; outputCodec: string; outputChannels?: number }[]
@@ -167,7 +172,7 @@ function perStreamAudioArgs(
       return;
     }
     if (p.outputCodec === 'aac') {
-      out.push(`-c:a:${i}`, 'aac', `-b:a:${i}`, aacBitrate, `-ac:${i}`, '2');
+      out.push(`-c:a:${i}`, 'aac', `-b:a:${i}`, aacBitrate, `-ac:a:${i}`, '2');
       return;
     }
     if (p.outputCodec === 'opus') {
@@ -175,14 +180,14 @@ function perStreamAudioArgs(
       // for 5.1 (Opus is far more efficient than EAC-3 at the same quality).
       out.push(`-c:a:${i}`, 'libopus', `-b:a:${i}`, '256k');
       if (p.outputChannels != null) {
-        out.push(`-ac:${i}`, String(p.outputChannels));
+        out.push(`-ac:a:${i}`, String(p.outputChannels));
       }
       return;
     }
     // EAC-3 / AC-3 at 640 kbps, downmixed to the planned channel count (≤ 5.1).
     out.push(`-c:a:${i}`, p.outputCodec, `-b:a:${i}`, '640k');
     if (p.outputChannels != null) {
-      out.push(`-ac:${i}`, String(p.outputChannels));
+      out.push(`-ac:a:${i}`, String(p.outputChannels));
     }
   });
   return out;

--- a/backend/src/modules/streaming/transcoding/per-stream-audio-args.spec.ts
+++ b/backend/src/modules/streaming/transcoding/per-stream-audio-args.spec.ts
@@ -1,0 +1,85 @@
+import { perStreamAudioArgs } from './ffmpeg-args';
+import type { AudioStreamMeta } from './types';
+
+/**
+ * The multi-audio `var_stream_map` output muxes the video at stream 0, so the
+ * per-rendition channel option must use the audio-relative specifier
+ * (`-ac:a:i`). A bare `-ac:i` targets the wrong output stream and leaves the
+ * last rendition at its source channel count — the master then declares
+ * CHANNELS="2"/AAC-LC while shipping a 5.1 init, and the browser rejects the
+ * append (Shaka error 3014) on every non-default language.
+ */
+describe('perStreamAudioArgs', () => {
+  const twoSurround: AudioStreamMeta[] = [
+    { language: 'ita', channels: 6 },
+    { language: 'eng', channels: 6 },
+  ];
+
+  it('downmixes every AAC rendition with an audio-relative -ac:a:i', () => {
+    const args = perStreamAudioArgs(
+      twoSurround,
+      [
+        { copy: false, outputCodec: 'aac', outputChannels: 2 },
+        { copy: false, outputCodec: 'aac', outputChannels: 2 },
+      ],
+      '128k',
+    );
+
+    const joined = args!.join(' ');
+    expect(joined).toContain('-ac:a:0 2');
+    expect(joined).toContain('-ac:a:1 2');
+    // Never the bare specifier: it would hit the video at stream 0 / the wrong
+    // audio rendition.
+    expect(args).not.toContain('-ac:0');
+    expect(args).not.toContain('-ac:1');
+  });
+
+  it('uses -ac:a:i for the EAC-3 surround downmix too', () => {
+    const args = perStreamAudioArgs(
+      twoSurround,
+      [
+        { copy: false, outputCodec: 'eac3', outputChannels: 6 },
+        { copy: false, outputCodec: 'eac3', outputChannels: 6 },
+      ],
+      '128k',
+    );
+
+    const joined = args!.join(' ');
+    expect(joined).toContain('-c:a:0 eac3');
+    expect(joined).toContain('-ac:a:0 6');
+    expect(joined).toContain('-ac:a:1 6');
+  });
+
+  it('copies a fitting rendition without a channel arg', () => {
+    const args = perStreamAudioArgs(
+      twoSurround,
+      [
+        { copy: true, outputCodec: 'eac3' },
+        { copy: false, outputCodec: 'aac', outputChannels: 2 },
+      ],
+      '128k',
+    );
+
+    expect(args).toEqual([
+      '-c:a:0',
+      'copy',
+      '-c:a:1',
+      'aac',
+      '-b:a:1',
+      '128k',
+      '-ac:a:1',
+      '2',
+    ]);
+  });
+
+  it('returns null when the plan count does not match the stream count', () => {
+    expect(
+      perStreamAudioArgs(
+        twoSurround,
+        [{ copy: false, outputCodec: 'aac', outputChannels: 2 }],
+        '128k',
+      ),
+    ).toBeNull();
+    expect(perStreamAudioArgs(twoSurround, undefined, '128k')).toBeNull();
+  });
+});


### PR DESCRIPTION
## The bug

On a source with multiple audio tracks, **every non-default language failed to play** in the browser with Shaka **error 3014** (`MEDIA_SOURCE_OPERATION_FAILED`) — on **both desktop and mobile** Chrome. The default track played fine.

## Root cause

The multi-audio `var_stream_map` path builds per-rendition audio args in `perStreamAudioArgs`. The codec and bitrate options used the **audio-relative** specifier (`-c:a:i`, `-b:a:i`), but the channel-count option used a **bare/absolute** output-stream specifier (`-ac:i`).

The muxed output carries the video at stream 0, so the indices were off by one:

| arg | intended | actually hit |
|-----|----------|--------------|
| `-ac:0 2` | audio 0 | **video** (no-op) |
| `-ac:1 2` | audio 1 | audio 0 |
| *(none)* | — | audio 1 → **never downmixed** |

The last audio rendition kept its **source channel count** (e.g. EAC-3 5.1 → AAC **6ch**) while the master playlist declared `CHANNELS="2"` / AAC-LC. The browser rejected the mismatched audio append → 3014. The default track only played because the off-by-one accidentally landed a stereo downmix on it.

This is HDR-, video-codec- and resolution-independent — which is why it reproduced on 1080p, 4K, desktop and mobile alike, always on the non-default language.

## Fix

Use the audio-relative specifier `-ac:a:i` (matching the already-correct `-c:a:i` / `-b:a:i`).

## Verification

Reproduced the exact `var_stream_map` shape with a 2× EAC-3 5.1 source:

```
before:  init_1 (audio0) → aac, 2ch     init_2 (audio1) → aac, 6ch   ✗
after:   init_1 (audio0) → aac, 2ch     init_2 (audio1) → aac, 2ch   ✓
```

Added `per-stream-audio-args.spec.ts` (4 tests) asserting every rendition gets `-ac:a:i` and never the bare form.

> [!NOTE]
> The transcode cache holds the old 6-channel segments — clear it (or play a not-yet-cached title) when validating, otherwise the stale bad rendition is served.
