### PR TITLE
fix(player): label untagged audio tracks by index instead of und

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -699,6 +699,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
           channels: src?.audioChannels,
         },
         this.translate,
+        1,
       );
 
     let audioStreamBitrate = '';
@@ -2315,7 +2316,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         if (audioList?.length > 1) {
           const tracks = audioList.map((a: any, i: number) => ({
             id: `si-${i}`,
-            label: formatAudioLabel(a, this.translate),
+            label: formatAudioLabel(a, this.translate, i + 1),
             language: normalizeLang(a.language),
           }));
           this.availableAudioTracks.set(tracks);
@@ -2341,7 +2342,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       const audioList = (file?.streamInfo as any)?.audio ?? [];
       const tracks = engineTracks.map((t, i) => ({
         id: t.id,
-        label: audioList[i] ? formatAudioLabel(audioList[i], this.translate) : t.label,
+        label: audioList[i] ? formatAudioLabel(audioList[i], this.translate, i + 1) : t.label,
         language: normalizeLang(t.language),
       }));
 


### PR DESCRIPTION
## Bug

The audio language selector showed different text for the same track depending on where you opened it: **"Piste 1" / "Piste 2"** on the media-detail page, but **"und"** in the player.

## Root cause

`formatAudioLabel(audio, translate, trackIndex?)` is the shared builder for both menus. It renders a translated `Piste N` head for tracks tagged `und`/`xx` **only when a 1-based `trackIndex` is supplied**; omit it and the head stays the literal `und`.

The media-detail audio menu (`media-info-header.ts`), the Cast selector (`cast-player.service.ts`) and one player path (`player.ts:1399`) all pass `i + 1`. But the player's two main selector-population paths — the `streamInfo` fallback and the engine-track→`streamInfo` mapping — omitted it, so untagged tracks surfaced `und`.

## Fix

Pass `i + 1` at both player sites (and at the stats-overlay primary-stream fallback, whose comment already claimed a `Piste N` fallback it wasn't getting). Every language selector now shares the one builder and renders identical text.

No i18n change — `player.audio_track_n` = `"Piste {{index}}"` already exists and is what media-detail uses.
