### PR TITLE
feat(player): add a direct-play arrow under the stats container line

### DIFF
--- a/client/src/app/features/player/overlay/player-stats-overlay.html
+++ b/client/src/app/features/player/overlay/player-stats-overlay.html
@@ -15,7 +15,9 @@
         <div class="font-bold text-white/90 mb-0.5 text-xs sm:text-sm">{{ 'player.stats_stream' | translate }}</div>
         <div class="text-white/80 pl-2 space-y-0.5">
           <div class="font-semibold">{{ s.container | uppercase }} ({{ s.containerBitrate }})</div>
-          @if (s.outputFormat) {
+          @if (s.directPlay) {
+            <div class="text-white/60">&rarr; {{ 'player.stats_direct_playback' | translate }}</div>
+          } @else if (s.outputFormat) {
             <div class="text-white/60">&rarr; {{ s.outputFormat | uppercase }}@if (s.outputFps) { ({{ s.outputFps }}) }</div>
           }
         </div>

--- a/client/src/app/features/player/overlay/player-stats-overlay.ts
+++ b/client/src/app/features/player/overlay/player-stats-overlay.ts
@@ -7,6 +7,9 @@ export interface PlayerStats {
   containerBitrate: string;
   outputFormat: string;
   outputFps: string;
+  /** True when the session is served as-is (DirectPlay) — no remux or
+   *  transcode. Drives the "Lecture directe" arrow under the container. */
+  directPlay: boolean;
 
   videoLabel: string;
   videoStreamBitrate: string;

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -735,6 +735,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       containerBitrate,
       outputFormat,
       outputFps,
+      directPlay: pi?.playMethod === 'DirectPlay',
       videoLabel,
       videoStreamBitrate,
       videoProfileLine,


### PR DESCRIPTION
## Request

When the session is in **Direct Play**, show a "Lecture directe" arrow under the container in the player stats overlay.

## Before / after

The Stream section only drew an arrow under the container when the session was remuxed/transcoded (`→ HLS`). On Direct Play it showed nothing — inconsistent with the video and audio sections, which always render a `→ <mode>` line.

```
Flux
  MKV (8.5 Mbps)
  → Lecture directe        ← new (DirectPlay only)
```

## Change

- `playerStats` exposes `directPlay` (`pi.playMethod === 'DirectPlay'`).
- The overlay renders `→ Lecture directe` under the container when `directPlay`, else keeps the existing `→ <outputFormat>` line.

Reuses the existing `player.stats_direct_playback` key (no i18n change). Client-only.
