### PR TITLE
fix(streaming): cap HEVC transcode bitrate to Main-tier ceiling

### DIFF
--- a/backend/src/modules/streaming/transcoding/codec/codec-strings.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/codec-strings.spec.ts
@@ -1,4 +1,22 @@
-import { audioCodecString, audioRenditionChannels } from './codec-strings';
+import {
+  audioCodecString,
+  audioRenditionChannels,
+  hevcMain10CodecString,
+  hevcMainTierCapBps,
+} from './codec-strings';
+import type { EncoderTarget } from './types';
+
+const target = (
+  width: number,
+  height: number,
+  frameRate: number,
+): EncoderTarget => ({
+  width,
+  height,
+  frameRate,
+  videoBitrateBps: 0,
+  gopSize: 0,
+});
 
 describe('audioCodecString', () => {
   it('maps the fMP4-compatible codecs to their RFC 6381 strings', () => {
@@ -38,5 +56,38 @@ describe('audioRenditionChannels', () => {
   it('falls back to 2 when the source channel count is unknown or invalid', () => {
     expect(audioRenditionChannels('eac3', undefined)).toBe(2);
     expect(audioRenditionChannels('eac3', 0)).toBe(2);
+  });
+});
+
+describe('hevcMainTierCapBps', () => {
+  // Cap maps to the level the existing luma-rate buckets pick (the buckets are
+  // ~half the HEVC Annex A MaxLumaSr — preserved verbatim from hevcLevel).
+  it('returns the Main-tier MaxBR for the level the luma rate selects', () => {
+    // 720p24 = 22.1M → L3.1 (cap 10 Mbps)
+    expect(hevcMainTierCapBps(target(1280, 720, 24))).toBe(10_000_000);
+    // 1080p24 = 49.8M → L4.0 (cap 12 Mbps)
+    expect(hevcMainTierCapBps(target(1920, 1080, 24))).toBe(12_000_000);
+    // cropped 4K @24 = 150.4M → L5.0 (cap 25 Mbps) — the #474 repro case
+    expect(hevcMainTierCapBps(target(3840, 1632, 24))).toBe(25_000_000);
+    // full 4K @24 = 199.1M → L5.0 (cap 25 Mbps)
+    expect(hevcMainTierCapBps(target(3840, 2160, 24))).toBe(25_000_000);
+    // 4K @60 = 497.7M → L5.1 (cap 40 Mbps): the same 28 Mbps rung stays Main
+    expect(hevcMainTierCapBps(target(3840, 2160, 60))).toBe(40_000_000);
+  });
+
+  it('caps the #474 cropped-4K-HDR rung (28 Mbps @24fps) to the L5.0 ceiling', () => {
+    const cap = hevcMainTierCapBps(target(3840, 1632, 24));
+    expect(Math.min(28_000_000, cap)).toBe(25_000_000);
+  });
+});
+
+describe('hevcMain10CodecString', () => {
+  it('declares the Main-tier level (L) — the encode is clamped to keep it Main', () => {
+    // Regression lock: the cropped-4K @24fps case stays hvc1.2.4.L150.B0
+    // (Main tier). hevcMainTierCapBps keeps the encode within L5.0's 25 Mbps
+    // Main ceiling so the declared level matches the bitstream tier.
+    expect(hevcMain10CodecString(target(3840, 1632, 24))).toBe('hvc1.2.4.L150.B0');
+    expect(hevcMain10CodecString(target(3840, 2160, 24))).toBe('hvc1.2.4.L150.B0');
+    expect(hevcMain10CodecString(target(1920, 1080, 24))).toBe('hvc1.2.4.L120.B0');
   });
 });

--- a/backend/src/modules/streaming/transcoding/codec/codec-strings.ts
+++ b/backend/src/modules/streaming/transcoding/codec/codec-strings.ts
@@ -85,6 +85,26 @@ export function av1CodecString(
 
 // ───────────────────────── helpers ─────────────────────────
 
+/** HEVC level + its Main-tier bitrate ceiling, resolved from one luma-rate
+ *  table so the declared CODECS level and the encode bitrate cap can never
+ *  disagree. `idc = level * 30`; `mainTierMaxBitrateBps` is the HEVC Annex A
+ *  `MaxBR` for the Main tier at that level (High tier allows ~4× more, but we
+ *  declare and stay on Main — see {@link hevcMainTierCapBps}). */
+interface HevcLevelInfo {
+  idc: number;
+  mainTierMaxBitrateBps: number;
+}
+
+function hevcLevelInfo(target: EncoderTarget): HevcLevelInfo {
+  const lumaPerSec = target.width * target.height * target.frameRate;
+  if (lumaPerSec <= 33_177_600) return { idc: 93, mainTierMaxBitrateBps: 10_000_000 }; //   L3.1
+  if (lumaPerSec <= 66_846_720) return { idc: 120, mainTierMaxBitrateBps: 12_000_000 }; //  L4.0
+  if (lumaPerSec <= 133_693_440) return { idc: 123, mainTierMaxBitrateBps: 20_000_000 }; // L4.1
+  if (lumaPerSec <= 267_386_880) return { idc: 150, mainTierMaxBitrateBps: 25_000_000 }; // L5.0
+  if (lumaPerSec <= 534_773_760) return { idc: 153, mainTierMaxBitrateBps: 40_000_000 }; // L5.1
+  return { idc: 156, mainTierMaxBitrateBps: 60_000_000 }; //                                L5.2
+}
+
 /** HEVC level encoded as `L<level_idc>` where `level_idc = level * 30`.
  *  Picked to match the level the encoder will pick on its own — both
  *  HEVC Spec Annex A and every encoder we drive (hevc_qsv, hevc_vaapi,
@@ -96,13 +116,19 @@ export function av1CodecString(
  *  not supported by the QSV runtime"), so we match what the encoder
  *  emits instead of telling it what to emit. */
 function hevcLevel(target: EncoderTarget): string {
-  const lumaPerSec = target.width * target.height * target.frameRate;
-  if (lumaPerSec <= 33_177_600) return 'L93'; //   L3.1
-  if (lumaPerSec <= 66_846_720) return 'L120'; //  L4.0
-  if (lumaPerSec <= 133_693_440) return 'L123'; // L4.1
-  if (lumaPerSec <= 267_386_880) return 'L150'; // L5.0
-  if (lumaPerSec <= 534_773_760) return 'L153'; // L5.1
-  return 'L156'; //                                L5.2
+  return `L${hevcLevelInfo(target).idc}`;
+}
+
+/** Main-tier `MaxBR` (bits/s) for the level {@link hevcLevel} resolves to.
+ *  The CODECS string always declares the Main tier (`hvc1.1.6.L*` /
+ *  `hvc1.2.4.L*`), but HEVC encoders auto-flip `general_tier_flag` to High
+ *  when the encode bitrate exceeds the Main-tier ceiling for the level — and a
+ *  High-tier bitstream behind a Main-tier manifest claim is rejected by strict
+ *  hardware MediaCodec decoders (Shaka 3014). Clamp the encode `-b:v`/`-maxrate`
+ *  to this ceiling for HEVC rungs so the bitstream stays Main tier and matches
+ *  the declared `L<level>`. */
+export function hevcMainTierCapBps(target: EncoderTarget): number {
+  return hevcLevelInfo(target).mainTierMaxBitrateBps;
 }
 
 /** AV1 level encoded as `<level_idc>` (decimal). Levels follow the AV1

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -32,6 +32,7 @@ import {
 } from './codec/tonemap-opencl-probe';
 import { resolveTonemapPath } from './tonemap-path';
 import { normaliseSourceCodec } from './codec/normalise';
+import { hevcMainTierCapBps } from './codec/codec-strings';
 
 /**
  * Probe ceiling (bytes) for the trusted-streamInfo fast path. Paired with
@@ -327,16 +328,50 @@ export function buildFfmpegArgs(
     args.push('-ss', String(seekSeconds));
   }
 
+  // Output dimensions cap the source aspect to the profile's `maxWidth`.
+  // `vpp_qsv` / `scale_qsv` don't honour the `-2` auto-height token, so a
+  // 2.39:1 cinemascope title (1920×804) needs its height computed up front to
+  // land at 1920×804 instead of being stretched to 1920×1080 by an explicit
+  // `h=maxHeight`. The result matches the RESOLUTION attribute the master
+  // playlist already advertises for this rung — display aspect stays stable
+  // across the session even if the player re-parses the manifest. Resolved here
+  // (ahead of the bitrate) so the HEVC Main-tier clamp below can use it.
+  const outDims =
+    sourceWidth > 0 && sourceHeight > 0
+      ? profileResolution(profile, sourceWidth, sourceHeight)
+      : { width: profile.maxWidth, height: profile.maxHeight };
+  const w = outDims.width;
+  const h = outDims.height;
+
   // parseBitrateToBps handles both "8M" and "200k" correctly. Using parseInt()*1e6
   // would give 200 Mbps for "200k" (it drops the suffix and multiplies as if M).
   // Capped to the source bitrate (codec-aware) so a forced transcode never
   // inflates a low-bitrate source up to the rung's nominal target.
-  const bitrateNum = cappedTranscodeVideoBitrateBps(
+  let bitrateNum = cappedTranscodeVideoBitrateBps(
     parseBitrateToBps(profile.videoBitrate),
     sourceVideoBitrateBps,
     sourceVideoCodec,
     videoVariant?.codec ?? sourceVideoCodec,
   );
+  // HEVC declares the Main tier (`L<level>`) in the manifest CODECS string, but
+  // the encoder flips `general_tier_flag` to High when the rate exceeds the
+  // level's Main-tier ceiling — a High-tier bitstream behind a Main-tier
+  // manifest claim is rejected by strict hardware MediaCodec decoders (surfaces
+  // as Shaka 3014). Clamp HEVC rungs to the Main-tier ceiling so the bitstream
+  // stays Main and matches the declared `L<level>`. Runs before the VBV bufsize
+  // derivations below so they size to the capped rate.
+  if (videoVariant?.codec === 'hevc') {
+    bitrateNum = Math.min(
+      bitrateNum,
+      hevcMainTierCapBps({
+        width: w,
+        height: h,
+        videoBitrateBps: 0,
+        gopSize: 0,
+        frameRate: fps,
+      }),
+    );
+  }
 
   // Pre-flight: can we keep the whole pipeline on QSV (decode + filter
   // + encode without bouncing through VAAPI)?
@@ -557,20 +592,6 @@ export function buildFfmpegArgs(
     args.push('-ss', String(seekSeconds));
   }
 
-  // Output dimensions cap the source aspect to the profile's
-  // `maxWidth`. `vpp_qsv` / `scale_qsv` don't honour the `-2`
-  // auto-height token, so a 2.39:1 cinemascope title (1920×804) needs
-  // its height computed up front to land at 1920×804 instead of being
-  // stretched to 1920×1080 by an explicit `h=maxHeight`. The result
-  // matches the RESOLUTION attribute the master playlist already
-  // advertises for this rung — display aspect stays stable across the
-  // session even if the player re-parses the manifest.
-  const outDims =
-    sourceWidth > 0 && sourceHeight > 0
-      ? profileResolution(profile, sourceWidth, sourceHeight)
-      : { width: profile.maxWidth, height: profile.maxHeight };
-  const w = outDims.width;
-  const h = outDims.height;
   const cropStr = crop
     ? `crop=${crop.width}:${crop.height}:${crop.x}:${crop.y}`
     : '';

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -20,6 +20,7 @@ import {
   h264CodecString,
   hevcMain10CodecString,
   hevcMainCodecString,
+  hevcMainTierCapBps,
 } from './codec/codec-strings';
 
 /** Format frame rate for the HLS `FRAME-RATE` attribute. Apple's spec
@@ -268,19 +269,33 @@ export function generateMasterPlaylist(
         /* hdrSuffix */ true,
       );
       for (const p of hdrLadder) {
-        const avg =
-          cappedTranscodeVideoBitrateBps(
-            parseBitrateToBps(p.videoBitrate),
-            sourceVideoBitrateBps,
-            sourceVideoCodec,
-            'hevc',
-          ) + parseBitrateToBps(p.audioBitrate);
-        const bw = Math.round(avg * 1.5);
         const { width: w, height: h } = profileResolution(
           p,
           sourceWidth,
           sourceHeight,
         );
+        // HEVC HDR rungs are clamped to the level's Main-tier ceiling so the
+        // advertised AVERAGE-BANDWIDTH tracks the capped encode (same clamp
+        // hevcMainTierCapBps applies in ffmpeg-args) — a High-tier bitstream
+        // behind the Main-tier `hvc1.2.4.L*` claim is rejected by strict
+        // hardware decoders (Shaka 3014).
+        const avg =
+          Math.min(
+            cappedTranscodeVideoBitrateBps(
+              parseBitrateToBps(p.videoBitrate),
+              sourceVideoBitrateBps,
+              sourceVideoCodec,
+              'hevc',
+            ),
+            hevcMainTierCapBps({
+              width: w,
+              height: h,
+              videoBitrateBps: 0,
+              gopSize: 0,
+              frameRate: sourceFrameRate,
+            }),
+          ) + parseBitrateToBps(p.audioBitrate);
+        const bw = Math.round(avg * 1.5);
         // Level driven by luma sample rate (width × height × fps) so
         // cropped 4K sources (e.g. 3840×2024 cinemascope, height < 2160)
         // still get L5.x — height-only bucketing under-declared L4.1
@@ -352,24 +367,40 @@ export function generateMasterPlaylist(
   profiles = applyQualityPin(profiles, onlyQuality, sourceWidth, sourceHeight);
 
   for (const p of profiles) {
-    const avg =
-      cappedTranscodeVideoBitrateBps(
-        parseBitrateToBps(p.videoBitrate),
-        sourceVideoBitrateBps,
-        sourceVideoCodec,
-        sdrVariant?.codec,
-      ) + parseBitrateToBps(p.audioBitrate);
+    const { width: w, height: h } = profileResolution(
+      p,
+      sourceWidth,
+      sourceHeight,
+    );
+    let cappedVideo = cappedTranscodeVideoBitrateBps(
+      parseBitrateToBps(p.videoBitrate),
+      sourceVideoBitrateBps,
+      sourceVideoCodec,
+      sdrVariant?.codec,
+    );
+    // HEVC declares the Main tier in CODECS; clamp the advertised rate to the
+    // level's Main-tier ceiling so AVERAGE-BANDWIDTH matches the capped encode
+    // (mirrors the clamp in ffmpeg-args). H.264 has no tier and AV1's Main-tier
+    // ceiling is far above the current ladder, so they are left unchanged.
+    if (sdrVariant?.codec === 'hevc') {
+      cappedVideo = Math.min(
+        cappedVideo,
+        hevcMainTierCapBps({
+          width: w,
+          height: h,
+          videoBitrateBps: 0,
+          gopSize: 0,
+          frameRate: sourceFrameRate,
+        }),
+      );
+    }
+    const avg = cappedVideo + parseBitrateToBps(p.audioBitrate);
     // BANDWIDTH must reflect the peak segment bitrate (HLS spec). With
     // `-maxrate == -b:v` the encoder is near-CBR but VBV bursts still
     // push individual segments ~30% above nominal. Declaring BANDWIDTH
     // ~1.5× nominal gives AVPlayer ABR a stable hysteresis margin and
     // stops it from down-/up-shifting on every VBV spike.
     const bw = Math.round(avg * 1.5);
-    const { width: w, height: h } = profileResolution(
-      p,
-      sourceWidth,
-      sourceHeight,
-    );
     // Codec string MUST be derived from the actual emitted height (`h`),
     // not `p.maxHeight`. Cropped content (e.g. 2.39:1 cinemascope on a
     // 1920×1080 source → 1920×816) advertises a height below the


### PR DESCRIPTION
## Summary

Fixes the `CODECS`↔bitstream tier mismatch from #474: HEVC transcode rungs declare the **Main tier** (`hvc1.*.L<level>`) but the encoder emits a **High tier** (`H`) bitstream whenever the rung bitrate exceeds the level's Main-tier `MaxBR` ceiling. Strict hardware `MediaCodec` decoders reject the mismatched append (Shaka **3014**); lenient software decoders play it, so it presents as "works on desktop, fails on some hardware".

Concrete trigger: a cropped-4K HEVC rung at **28 Mbps** lands on **L5.0** at ~24fps (Main-tier cap **25 Mbps**) → encoder flips `general_tier_flag=1`.

## Approach (issue Option A — cap the encode)

- `codec-strings.ts`: resolve the HEVC level **and** its Main-tier ceiling from one shared `hevcLevelInfo` table; expose `hevcMainTierCapBps(target)`. `hevcLevel` keeps emitting the exact same `L<idc>` strings (byte-identical level buckets preserved).
- `ffmpeg-args.ts`: clamp the HEVC encode `-b:v`/`-maxrate` (`bitrateNum`) to the ceiling. The `outDims`/`w`/`h` resolution is hoisted above the bitrate so the clamp — and the VBV bufsize derivations that follow — size to the capped rate.
- `master-playlist.ts`: clamp the advertised `AVERAGE-BANDWIDTH` to the same ceiling for HEVC rungs (both HDR and SDR branches) so the manifest tracks the capped encode.

H.264 (no tier) and AV1 (Main-tier ceiling far above the current ladder) are left unchanged. Only the 28 Mbps 4K rung at <60fps is touched (28→25 Mbps); every other rung is already under its cap. The declared `L<level>` is unchanged — it's now correct because the encode stays Main tier.

## Tests

- `codec-strings.spec.ts`: `hevcMainTierCapBps` thresholds (720p24→10M/L3.1, 1080p24→12M/L4.0, cropped-4K@24 & 4K@24→25M/L5.0, 4K@60→40M/L5.1) + regression-lock that `hevcMain10CodecString` stays `hvc1.2.4.L150.B0` for the cropped-4K case.
- All 15 streaming suites / 125 tests pass; `tsc --noEmit` clean.

## Not covered (follow-up)

`av1Level` / `h264CodecString` share the same tier/level-vs-bitrate blindness but are not at practical risk at the current ladder bitrates — noted for a future audit if higher-bitrate AV1 4K60 rungs are added.

Refs: #474
