### PR TITLE
refactor(streaming): unify HDR/SDR ladder into one variant-driven emitter

### DIFF
--- a/backend/src/modules/streaming/transcoding/hls-variant-ladder.spec.ts
+++ b/backend/src/modules/streaming/transcoding/hls-variant-ladder.spec.ts
@@ -1,0 +1,104 @@
+import {
+  buildUniqueAudioNames,
+  emitAudioRenditions,
+  emitVariantLadder,
+  type VariantLadderOptions,
+} from './hls-variant-ladder';
+import type { CodecVariant } from './codec/types';
+import type { TranscodeProfile } from './types';
+
+const PROFILE: TranscodeProfile = {
+  name: '1080p',
+  maxWidth: 1920,
+  maxHeight: 1080,
+  videoBitrate: '8M',
+  audioBitrate: '192k',
+};
+
+function emit(variant: CodecVariant, range?: 'PQ' | 'HLG'): string[] {
+  const lines: string[] = [];
+  const opts: VariantLadderOptions = {
+    profiles: [PROFILE],
+    variant,
+    range,
+    audioAttr: '',
+    subsAttr: '',
+    frameRateAttr: ',FRAME-RATE=24',
+    codecsTail: ',mp4a.40.2',
+    sourceWidth: 1920,
+    sourceHeight: 1080,
+    sourceFrameRate: 24,
+    sourceVideoBitrateBps: 100_000_000,
+    sourceVideoCodec: 'hevc',
+    mediaFileId: 1,
+    tokenParam: '',
+  };
+  emitVariantLadder(lines, opts);
+  return lines;
+}
+
+describe('emitVariantLadder — codec string + VIDEO-RANGE from the variant', () => {
+  it('HEVC HDR → Main10 codec string + VIDEO-RANGE', () => {
+    const [inf] = emit({ codec: 'hevc', bitDepth: 10, hdr: 'HDR10' }, 'PQ');
+    expect(inf).toContain('CODECS="hvc1.2.4.');
+    expect(inf).toContain('VIDEO-RANGE=PQ');
+  });
+
+  it('HEVC SDR → Main codec string, no VIDEO-RANGE', () => {
+    const [inf] = emit({ codec: 'hevc', bitDepth: 8, hdr: null });
+    expect(inf).toContain('CODECS="hvc1.1.6.');
+    expect(inf).not.toContain('VIDEO-RANGE');
+  });
+
+  it('AV1 → av01 codec string at its bit depth', () => {
+    expect(emit({ codec: 'av1', bitDepth: 10, hdr: 'HDR10' }, 'PQ')[0]).toMatch(
+      /CODECS="av01\.0\.\d+M\.10/,
+    );
+    expect(emit({ codec: 'av1', bitDepth: 8, hdr: null })[0]).toMatch(
+      /CODECS="av01\.0\.\d+M\.08/,
+    );
+  });
+
+  it('H.264 → avc1 codec string', () => {
+    expect(emit({ codec: 'h264', bitDepth: 8, hdr: null })[0]).toContain(
+      'CODECS="avc1.',
+    );
+  });
+
+  it('emits a STREAM-INF + URI pair per rung', () => {
+    const lines = emit({ codec: 'h264', bitDepth: 8, hdr: null });
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toMatch(/^#EXT-X-STREAM-INF:/);
+    expect(lines[1]).toBe('/api/stream/1/1080p/index.m3u8');
+  });
+});
+
+describe('emitAudioRenditions', () => {
+  it('emits one EXT-X-MEDIA per stream with the right CHANNELS', () => {
+    const lines: string[] = [];
+    emitAudioRenditions(
+      lines,
+      [
+        { language: 'eng', channels: 6 },
+        { language: 'fre', channels: 2 },
+      ],
+      0,
+      'eac3', // copy/eac3 keeps the source layout
+      1,
+      '',
+    );
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('DEFAULT=YES');
+    expect(lines[0]).toContain('CHANNELS="6"');
+    expect(lines[1]).toContain('DEFAULT=NO');
+    expect(lines[1]).toContain('CHANNELS="2"');
+  });
+});
+
+describe('buildUniqueAudioNames', () => {
+  it('disambiguates duplicate display names with #2, #3', () => {
+    expect(
+      buildUniqueAudioNames([{ language: 'und' }, { language: 'und' }]),
+    ).toEqual(['und', 'und #2']);
+  });
+});

--- a/backend/src/modules/streaming/transcoding/hls-variant-ladder.ts
+++ b/backend/src/modules/streaming/transcoding/hls-variant-ladder.ts
@@ -1,0 +1,183 @@
+import {
+  cappedTranscodeVideoBitrateBps,
+  parseBitrateToBps,
+  profileResolution,
+} from './profiles';
+import {
+  audioRenditionChannels,
+  av1CodecString,
+  h264CodecString,
+  hevcMain10CodecString,
+  hevcMainCodecString,
+  hevcMainTierCapBps,
+} from './codec/codec-strings';
+import type { CodecVariant, EncoderTarget } from './codec/types';
+import type { AudioStreamMeta, TranscodeProfile } from './types';
+
+/** SDR fallback variant for legacy callers that don't thread `sdrVariant`
+ *  (H.264 High 8-bit). Keeps the codec-string + bitrate-cap behaviour identical
+ *  to the pre-variant default (`h264` has CODEC_BITRATE_FACTOR 1, same as the
+ *  former `undefined` target codec). */
+export const SDR_H264_VARIANT: CodecVariant = {
+  codec: 'h264',
+  bitDepth: 8,
+  hdr: null,
+};
+
+/** RFC 6381 CODECS string for a rung, picked from the resolved output variant:
+ *  AV1 at its bit depth, HEVC Main10 for HDR / Main for SDR, H.264 otherwise.
+ *  Single source of truth shared by the HDR and SDR ladders so the manifest
+ *  never declares a codec the segments don't carry. */
+function videoCodecString(
+  variant: CodecVariant,
+  target: EncoderTarget,
+): string {
+  if (variant.codec === 'av1') return av1CodecString(target, variant.bitDepth);
+  if (variant.codec === 'hevc')
+    return variant.hdr != null
+      ? hevcMain10CodecString(target)
+      : hevcMainCodecString(target);
+  return h264CodecString(target);
+}
+
+/** Build a unique NAME per rendition for `EXT-X-MEDIA` (audio or subtitle).
+ *  When two tracks resolve to the same display string (typical case: MKV with
+ *  two audio streams both falling back to `und` because the container left
+ *  language + title empty), AVPlayer dedupes them into a single
+ *  `AVMediaSelectionOption` and the user can no longer switch between them.
+ *  Append `#2`, `#3`, … when the base name has already been used earlier. */
+export function buildUniqueAudioNames(
+  streams: { language?: string; title?: string }[],
+): string[] {
+  const seen = new Map<string, number>();
+  return streams.map((s) => {
+    const base = s.title || s.language || 'und';
+    const count = (seen.get(base) ?? 0) + 1;
+    seen.set(base, count);
+    return count === 1 ? base : `${base} #${count}`;
+  });
+}
+
+/** Emit one `EXT-X-MEDIA:TYPE=AUDIO` rendition per source audio stream, sharing
+ *  the `audio` group. CHANNELS reports the rendition's real output layout (AAC
+ *  downmixes to 2 via `-ac 2`; copy / AC-3 / E-AC-3 keep the source layout) —
+ *  Tizen AVPlay needs the hint to pre-allocate the decoder before fetching the
+ *  rendition, else the single-audio fMP4 path never follows the rendition link
+ *  (issue #148). */
+export function emitAudioRenditions(
+  lines: string[],
+  audioStreams: AudioStreamMeta[],
+  defaultAudioIndex: number,
+  outputAudioCodec: string,
+  mediaFileId: number,
+  tokenParam: string,
+): void {
+  const pickedIdx =
+    defaultAudioIndex >= 0 && defaultAudioIndex < audioStreams.length
+      ? defaultAudioIndex
+      : 0;
+  const names = buildUniqueAudioNames(audioStreams);
+  for (let i = 0; i < audioStreams.length; i++) {
+    const a = audioStreams[i];
+    const lang = a.language || 'und';
+    const isDefault = i === pickedIdx ? 'YES' : 'NO';
+    lines.push(
+      `#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="${names[i]}",LANGUAGE="${lang}",DEFAULT=${isDefault},AUTOSELECT=${isDefault},CHANNELS="${audioRenditionChannels(outputAudioCodec, a.channels)}",URI="/api/stream/${mediaFileId}/audio/${i}/index.m3u8${tokenParam}"`,
+    );
+  }
+}
+
+export interface VariantLadderOptions {
+  profiles: TranscodeProfile[];
+  /** Resolved output variant — drives the codec string + the bitrate cap. */
+  variant: CodecVariant;
+  /** VIDEO-RANGE attribute value; omitted (SDR) leaves the attribute off. */
+  range?: 'PQ' | 'HLG';
+  audioAttr: string;
+  subsAttr: string;
+  frameRateAttr: string;
+  codecsTail: string;
+  sourceWidth: number;
+  sourceHeight: number;
+  sourceFrameRate: number;
+  sourceVideoBitrateBps: number | undefined;
+  sourceVideoCodec: string | undefined;
+  mediaFileId: number;
+  tokenParam: string;
+}
+
+/** Emit one `EXT-X-STREAM-INF` + URI per rung for a single resolved output
+ *  variant. Drives the HDR and SDR ladders through one path — they differ only
+ *  in the ladder, the VIDEO-RANGE attribute and the codec string, all derived
+ *  from `variant`. The per-rung level and Main-tier bitrate clamp are computed
+ *  from the actual emitted resolution (cropped scope content sits below the
+ *  profile nominal) so the declared CODECS level + tier match the bitstream. */
+export function emitVariantLadder(
+  lines: string[],
+  opts: VariantLadderOptions,
+): void {
+  const {
+    profiles,
+    variant,
+    range,
+    audioAttr,
+    subsAttr,
+    frameRateAttr,
+    codecsTail,
+    sourceWidth,
+    sourceHeight,
+    sourceFrameRate,
+    sourceVideoBitrateBps,
+    sourceVideoCodec,
+    mediaFileId,
+    tokenParam,
+  } = opts;
+  const rangeAttr = range ? `,VIDEO-RANGE=${range}` : '';
+  for (const p of profiles) {
+    const { width: w, height: h } = profileResolution(
+      p,
+      sourceWidth,
+      sourceHeight,
+    );
+    let cappedVideo = cappedTranscodeVideoBitrateBps(
+      parseBitrateToBps(p.videoBitrate),
+      sourceVideoBitrateBps,
+      sourceVideoCodec,
+      variant.codec,
+    );
+    // HEVC declares the Main tier in CODECS; clamp the advertised
+    // AVERAGE-BANDWIDTH to the level's Main-tier ceiling so it tracks the capped
+    // encode (mirrors ffmpeg-args). A High-tier bitstream behind a Main-tier
+    // claim is rejected by strict hardware decoders (Shaka 3014). H.264 has no
+    // tier and AV1's ceiling is far above the current ladder.
+    if (variant.codec === 'hevc') {
+      cappedVideo = Math.min(
+        cappedVideo,
+        hevcMainTierCapBps({
+          width: w,
+          height: h,
+          videoBitrateBps: 0,
+          gopSize: 0,
+          frameRate: sourceFrameRate,
+        }),
+      );
+    }
+    const avg = cappedVideo + parseBitrateToBps(p.audioBitrate);
+    // BANDWIDTH ~1.5x nominal: with -maxrate == -b:v the encoder is near-CBR but
+    // VBV bursts push segments ~30% above nominal; the margin gives AVPlayer ABR
+    // stable hysteresis.
+    const bw = Math.round(avg * 1.5);
+    const target = {
+      width: w,
+      height: h,
+      videoBitrateBps: 0,
+      gopSize: 0,
+      frameRate: sourceFrameRate,
+    };
+    const codec = videoCodecString(variant, target);
+    lines.push(
+      `#EXT-X-STREAM-INF:BANDWIDTH=${bw},AVERAGE-BANDWIDTH=${avg},RESOLUTION=${w}x${h}${rangeAttr}${frameRateAttr},NAME="${p.name}",CODECS="${codec}${codecsTail}"${audioAttr}${subsAttr}`,
+      `/api/stream/${mediaFileId}/${p.name}/index.m3u8${tokenParam}`,
+    );
+  }
+}

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -1,8 +1,6 @@
 import {
-  cappedTranscodeVideoBitrateBps,
   getHdrLadderForDevice,
   getLadderForDevice,
-  parseBitrateToBps,
   profileFitsSource,
   profileResolution,
 } from './profiles';
@@ -13,15 +11,13 @@ import type {
   TranscodeProfile,
 } from './types';
 import type { CodecVariant } from './codec/types';
+import { audioCodecString } from './codec/codec-strings';
 import {
-  audioCodecString,
-  audioRenditionChannels,
-  av1CodecString,
-  h264CodecString,
-  hevcMain10CodecString,
-  hevcMainCodecString,
-  hevcMainTierCapBps,
-} from './codec/codec-strings';
+  buildUniqueAudioNames,
+  emitAudioRenditions,
+  emitVariantLadder,
+  SDR_H264_VARIANT,
+} from './hls-variant-ladder';
 
 /** Format frame rate for the HLS `FRAME-RATE` attribute. Apple's spec
  *  says "decimal-floating-point describing the maximum frame rate …
@@ -217,30 +213,17 @@ export function generateMasterPlaylist(
   if (hdrPassThrough) {
     const range = hdrPassThrough.hdrFormat === 'HLG' ? 'HLG' : 'PQ';
 
-    // Multi-audio: each HEVC HDR variant references the shared audio
-    // group via AUDIO="audio". Audio is served from /audio/<i>/ as
-    // standalone AAC renditions, same wiring as the SDR ladder.
+    // Each HDR variant references the shared `audio` group; renditions are
+    // served from /audio/<i>/, same wiring as the SDR ladder.
     if (multiAudio) {
-      const pickedIdx =
-        defaultAudioIndex >= 0 && defaultAudioIndex < audioStreams.length
-          ? defaultAudioIndex
-          : 0;
-      const names = buildUniqueAudioNames(audioStreams);
-      for (let i = 0; i < audioStreams.length; i++) {
-        const a = audioStreams[i];
-        const lang = a.language || 'und';
-        const isDefault = i === pickedIdx ? 'YES' : 'NO';
-        // CHANNELS hint matches Apple's reference master and lets
-        // Tizen AVPlay pre-allocate the right audio decoder before
-        // the variant playlist + init are fetched. Without it the
-        // single-audio fMP4 path doesn't follow the rendition link
-        // (issue #148 bisection — multi-audio works because AVPlay
-        // probes the renditions, single-audio doesn't trigger the
-        // probe when the hint is missing).
-        lines.push(
-          `#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="${names[i]}",LANGUAGE="${lang}",DEFAULT=${isDefault},AUTOSELECT=${isDefault},CHANNELS="${audioRenditionChannels(outputAudioCodec, a.channels)}",URI="/api/stream/${mediaFileId}/audio/${i}/index.m3u8${tokenParam}"`,
-        );
-      }
+      emitAudioRenditions(
+        lines,
+        audioStreams,
+        defaultAudioIndex,
+        outputAudioCodec,
+        mediaFileId,
+        tokenParam,
+      );
     }
     const hdrAudioAttr = multiAudio ? ',AUDIO="audio"' : '';
     pushSubtitleMedia(lines);
@@ -268,82 +251,36 @@ export function generateMasterPlaylist(
         sourceHeight,
         /* hdrSuffix */ true,
       );
-      for (const p of hdrLadder) {
-        const { width: w, height: h } = profileResolution(
-          p,
-          sourceWidth,
-          sourceHeight,
-        );
-        let cappedVideo = cappedTranscodeVideoBitrateBps(
-          parseBitrateToBps(p.videoBitrate),
-          sourceVideoBitrateBps,
-          sourceVideoCodec,
-          hdrVariant.codec,
-        );
-        // HEVC declares the Main tier; clamp the advertised AVERAGE-BANDWIDTH to
-        // the level's Main-tier ceiling so it tracks the capped encode (same
-        // clamp hevcMainTierCapBps applies in ffmpeg-args) — a High-tier
-        // bitstream behind a Main-tier `hvc1.2.4.L*` claim is rejected by strict
-        // hardware decoders (Shaka 3014). AV1 HDR has no Main-tier bitrate gate
-        // at the current ladder, so it is left unclamped.
-        if (hdrVariant.codec === 'hevc') {
-          cappedVideo = Math.min(
-            cappedVideo,
-            hevcMainTierCapBps({
-              width: w,
-              height: h,
-              videoBitrateBps: 0,
-              gopSize: 0,
-              frameRate: sourceFrameRate,
-            }),
-          );
-        }
-        const avg = cappedVideo + parseBitrateToBps(p.audioBitrate);
-        const bw = Math.round(avg * 1.5);
-        // Codec string per rung, driven by luma sample rate (width × height ×
-        // fps) so cropped 4K sources (e.g. 3840×2024 cinemascope, height <
-        // 2160) still get L5.x — height-only bucketing under-declared L4.1 and
-        // AVPlayer rejected every variant (NSURLErrorUnsupportedURL on iOS).
-        const target = {
-          width: w,
-          height: h,
-          videoBitrateBps: 0,
-          gopSize: 0,
-          frameRate: sourceFrameRate,
-        };
-        const videoCodec =
-          hdrVariant.codec === 'av1'
-            ? av1CodecString(target, hdrVariant.bitDepth)
-            : hevcMain10CodecString(target);
-        lines.push(
-          `#EXT-X-STREAM-INF:BANDWIDTH=${bw},AVERAGE-BANDWIDTH=${avg},RESOLUTION=${w}x${h},VIDEO-RANGE=${range}${frameRateAttr},NAME="${p.name}",CODECS="${videoCodec}${codecsTail}"${hdrAudioAttr}${subsAttr}`,
-          `/api/stream/${mediaFileId}/${p.name}/index.m3u8${tokenParam}`,
-        );
-      }
+      emitVariantLadder(lines, {
+        profiles: hdrLadder,
+        variant: hdrVariant,
+        range,
+        audioAttr: hdrAudioAttr,
+        subsAttr,
+        frameRateAttr,
+        codecsTail,
+        sourceWidth,
+        sourceHeight,
+        sourceFrameRate,
+        sourceVideoBitrateBps,
+        sourceVideoCodec,
+        mediaFileId,
+        tokenParam,
+      });
     }
     return lines.join('\n');
   }
 
   // Multi-audio: declare alternate audio renditions via EXT-X-MEDIA
   if (multiAudio) {
-    const pickedIdx =
-      defaultAudioIndex >= 0 && defaultAudioIndex < audioStreams.length
-        ? defaultAudioIndex
-        : 0;
-    const names = buildUniqueAudioNames(audioStreams);
-    for (let i = 0; i < audioStreams.length; i++) {
-      const a = audioStreams[i];
-      const lang = a.language || 'und';
-      const isDefault = i === pickedIdx ? 'YES' : 'NO';
-      // CHANNELS reports the rendition's real output layout (AAC downmixes
-      // to 2 via `-ac 2`; copy / AC-3 / E-AC-3 keep the source layout) — Tizen
-      // AVPlay uses this hint to pre-allocate the right audio decoder before
-      // fetching the rendition. Without it the single-audio variant doesn't
-      // trigger a rendition probe (issue #148 bisection).
-      lines.push(
-        `#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="${names[i]}",LANGUAGE="${lang}",DEFAULT=${isDefault},AUTOSELECT=${isDefault},CHANNELS="${audioRenditionChannels(outputAudioCodec, a.channels)}",URI="/api/stream/${mediaFileId}/audio/${i}/index.m3u8${tokenParam}"`,
-      );
-    }
+    emitAudioRenditions(
+      lines,
+      audioStreams,
+      defaultAudioIndex,
+      outputAudioCodec,
+      mediaFileId,
+      tokenParam,
+    );
   }
 
   // Always declare CODECS on EXT-X-STREAM-INF. For HLS-TS, this lets Shaka
@@ -372,92 +309,22 @@ export function generateMasterPlaylist(
   // chosen quality.
   profiles = applyQualityPin(profiles, onlyQuality, sourceWidth, sourceHeight);
 
-  for (const p of profiles) {
-    const { width: w, height: h } = profileResolution(
-      p,
-      sourceWidth,
-      sourceHeight,
-    );
-    let cappedVideo = cappedTranscodeVideoBitrateBps(
-      parseBitrateToBps(p.videoBitrate),
-      sourceVideoBitrateBps,
-      sourceVideoCodec,
-      sdrVariant?.codec,
-    );
-    // HEVC declares the Main tier in CODECS; clamp the advertised rate to the
-    // level's Main-tier ceiling so AVERAGE-BANDWIDTH matches the capped encode
-    // (mirrors the clamp in ffmpeg-args). H.264 has no tier and AV1's Main-tier
-    // ceiling is far above the current ladder, so they are left unchanged.
-    if (sdrVariant?.codec === 'hevc') {
-      cappedVideo = Math.min(
-        cappedVideo,
-        hevcMainTierCapBps({
-          width: w,
-          height: h,
-          videoBitrateBps: 0,
-          gopSize: 0,
-          frameRate: sourceFrameRate,
-        }),
-      );
-    }
-    const avg = cappedVideo + parseBitrateToBps(p.audioBitrate);
-    // BANDWIDTH must reflect the peak segment bitrate (HLS spec). With
-    // `-maxrate == -b:v` the encoder is near-CBR but VBV bursts still
-    // push individual segments ~30% above nominal. Declaring BANDWIDTH
-    // ~1.5× nominal gives AVPlayer ABR a stable hysteresis margin and
-    // stops it from down-/up-shifting on every VBV spike.
-    const bw = Math.round(avg * 1.5);
-    // Codec string MUST be derived from the actual emitted height (`h`),
-    // not `p.maxHeight`. Cropped content (e.g. 2.39:1 cinemascope on a
-    // 1920×1080 source → 1920×816) advertises a height below the
-    // profile nominal, so `h264CodecString({height: 720})` would
-    // declare avc1 L3.2 in the master while the bitstream SPS carries
-    // L3.1 for the actual 1280×544 frames. The mismatch (declared > SPS)
-    // can leave ExoPlayer's track selector stuck on cold prepare —
-    // visible as the "buffering forever, no decoder allocated"
-    // pattern on Android with cropped masters.
-    const target = {
-      width: w,
-      height: h,
-      videoBitrateBps: 0,
-      gopSize: 0,
-      frameRate: sourceFrameRate,
-    };
-    // Codec string must agree with what the encoder will actually emit —
-    // mismatched CODECS makes Shaka fail with HLS_COULD_NOT_GUESS_CODECS
-    // (3014) after it tries to sniff the segment and the bitstream
-    // doesn't parse as the declared codec.
-    const videoCodec =
-      sdrVariant?.codec === 'hevc'
-        ? hevcMainCodecString(target)
-        : sdrVariant?.codec === 'av1'
-          ? av1CodecString(target, sdrVariant.bitDepth)
-          : h264CodecString(target);
-    const codecsAttr = `,CODECS="${videoCodec}${codecsTail}"`;
-    lines.push(
-      `#EXT-X-STREAM-INF:BANDWIDTH=${bw},AVERAGE-BANDWIDTH=${avg},RESOLUTION=${w}x${h}${frameRateAttr},NAME="${p.name}"${codecsAttr}${audioAttr}${subsAttr}`,
-      `/api/stream/${mediaFileId}/${p.name}/index.m3u8${tokenParam}`,
-    );
-  }
+  emitVariantLadder(lines, {
+    profiles,
+    variant: sdrVariant ?? SDR_H264_VARIANT,
+    audioAttr,
+    subsAttr,
+    frameRateAttr,
+    codecsTail,
+    sourceWidth,
+    sourceHeight,
+    sourceFrameRate,
+    sourceVideoBitrateBps,
+    sourceVideoCodec,
+    mediaFileId,
+    tokenParam,
+  });
   return lines.join('\n');
 }
 
-/** Build a unique NAME per audio rendition for `EXT-X-MEDIA`. When two
- *  tracks resolve to the same display string (typical case: MKV with two
- *  audio streams both falling back to `und` because the container left
- *  language + title empty), AVPlayer dedupes them into a single
- *  `AVMediaSelectionOption` and the user can no longer switch between
- *  them. Append `#2`, `#3`, … when the base name has already been used
- *  earlier in the list. */
-function buildUniqueAudioNames(
-  streams: { language?: string; title?: string }[],
-): string[] {
-  const seen = new Map<string, number>();
-  return streams.map((s) => {
-    const base = s.title || s.language || 'und';
-    const count = (seen.get(base) ?? 0) + 1;
-    seen.set(base, count);
-    return count === 1 ? base : `${base} #${count}`;
-  });
-}
 


### PR DESCRIPTION
First incremental step of Wave 2 (`plans/streaming-rearchitecture.plan.md` → "variant-driven HlsManifestWriter"), gated by the Wave 0 golden harness.

## What

The master playlist built the HDR and SDR ABR ladders with **two near-duplicate loops** that diverged on codec-string selection — the exact split that let the HDR branch hardcode HEVC (the root cause behind #464). This collapses them into:

- **`emitVariantLadder()`** — one loop driven by the resolved `CodecVariant`. Codec string (`videoCodecString`), the HEVC Main-tier bitrate clamp, and the `VIDEO-RANGE` attribute are all derived from the variant. HDR vs SDR now differ only in *which ladder* and *whether a range is passed*.
- **`emitAudioRenditions()`** — one `EXT-X-MEDIA` audio emitter replacing the block that was duplicated verbatim in both branches.

Both move into a focused **`hls-variant-ladder.ts`** (with `buildUniqueAudioNames`). `master-playlist.ts` drops **463 → 330 lines** and is now just the orchestrator (profile selection + subtitle renditions + the audio-codec tail).

## Safety

- **Output is byte-identical** — the Wave 0 golden manifest snapshots (`master-playlist.golden.spec`) pass **without `-u`**, and the #464 `master-playlist.spec` is unchanged.
- New focused unit spec (`hls-variant-ladder.spec`) locks the codec-string-from-variant + VIDEO-RANGE mapping.
- 149 streaming tests pass; `tsc --noEmit` clean.

No behaviour change — pure de-duplication + extraction. Sets up the follow-up to drive the codec string from `descriptor.codecString` and to add Dolby Vision (#368) as one more variant attribute in a single place rather than two divergent branches.
