### PR TITLE
test(streaming): isolate transcode-cache test roots to fix a parallel flake

### DIFF
--- a/backend/src/modules/streaming/streaming-lifecycle.spec.ts
+++ b/backend/src/modules/streaming/streaming-lifecycle.spec.ts
@@ -17,12 +17,23 @@
  * need a mocked `child_process.spawn` harness that's worth its own
  * scaffolding PR.
  */
+import * as fs from 'fs';
 import * as fsp from 'fs/promises';
+import * as os from 'os';
 import * as path from 'path';
 import { LiveSessionRegistry } from './live-session.service';
 import { TranscodeCacheService } from './transcoding/transcode-cache.service';
 
-const CACHE_ROOT = '/tmp/transcode/cache';
+// Isolated per-spec cache root so parallel jest workers don't stomp each other
+// (TranscodeCacheService.cacheRoot() honours TRANSCODE_CACHE_ROOT).
+const CACHE_ROOT = fs.mkdtempSync(
+  path.join(os.tmpdir(), 'fliks-transcode-cache-'),
+);
+process.env.TRANSCODE_CACHE_ROOT = CACHE_ROOT;
+
+afterAll(() => {
+  fs.rmSync(CACHE_ROOT, { recursive: true, force: true });
+});
 const ALICE = { userId: 1, username: 'alice' };
 const BOB = { userId: 2, username: 'bob' };
 const FILE_ID = 42;

--- a/backend/src/modules/streaming/transcoding/transcode-cache.service.spec.ts
+++ b/backend/src/modules/streaming/transcoding/transcode-cache.service.spec.ts
@@ -1,9 +1,20 @@
+import * as fs from 'fs';
 import * as fsp from 'fs/promises';
+import * as os from 'os';
 import * as path from 'path';
 import type { CacheEntry, QualityCache } from './transcode-cache.service';
 import { TranscodeCacheService } from './transcode-cache.service';
 
-const CACHE_ROOT = path.join('/tmp/transcode', 'cache');
+// Isolated per-spec cache root so parallel jest workers don't stomp each other
+// (TranscodeCacheService.cacheRoot() honours TRANSCODE_CACHE_ROOT).
+const CACHE_ROOT = fs.mkdtempSync(
+  path.join(os.tmpdir(), 'fliks-transcode-cache-'),
+);
+process.env.TRANSCODE_CACHE_ROOT = CACHE_ROOT;
+
+afterAll(() => {
+  fs.rmSync(CACHE_ROOT, { recursive: true, force: true });
+});
 
 async function writeFile(p: string, size: number): Promise<void> {
   await fsp.mkdir(path.dirname(p), { recursive: true });

--- a/backend/src/modules/streaming/transcoding/transcode-cache.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcode-cache.service.ts
@@ -58,7 +58,7 @@ export class TranscodeCacheService implements OnModuleInit, OnModuleDestroy {
   private readonly gcIntervalMs = StreamLifetime.cacheGcIntervalMs();
 
   async onModuleInit(): Promise<void> {
-    await fsp.mkdir(CACHE_LAYOUT_ROOT, { recursive: true });
+    await fsp.mkdir(this.cacheRoot(), { recursive: true });
     await this.rebuildIndex();
     this.gcTimer = setInterval(() => {
       this.runGc().catch((err) =>
@@ -224,11 +224,12 @@ export class TranscodeCacheService implements OnModuleInit, OnModuleDestroy {
     userId?: number,
   ): Promise<string[]> {
     const dirs: string[] = [];
-    for (const userDir of await readdirSafe(CACHE_LAYOUT_ROOT)) {
+    const root = this.cacheRoot();
+    for (const userDir of await readdirSafe(root)) {
       const uid = parseUserDir(userDir);
       if (uid === undefined) continue;
       if (userId != null && uid !== userId) continue;
-      const userPath = path.join(CACHE_LAYOUT_ROOT, userDir);
+      const userPath = path.join(root, userDir);
       for (const fileDir of await readdirSafe(userPath)) {
         const fid = Number.parseInt(fileDir, 10);
         if (!Number.isFinite(fid)) continue;
@@ -292,9 +293,12 @@ export class TranscodeCacheService implements OnModuleInit, OnModuleDestroy {
     return this.entries.size;
   }
 
-  /** Visible for tests. */
+  /** The cache root directory — single source of truth, resolved lazily so
+   *  every disk walk goes through it. Overridable via the `TRANSCODE_CACHE_ROOT`
+   *  env var so each test spec can point at an isolated mkdtemp dir; otherwise
+   *  parallel specs sharing the default root stomp each other's entries. */
   cacheRoot(): string {
-    return CACHE_LAYOUT_ROOT;
+    return process.env.TRANSCODE_CACHE_ROOT ?? CACHE_LAYOUT_ROOT;
   }
 
   /**
@@ -310,7 +314,7 @@ export class TranscodeCacheService implements OnModuleInit, OnModuleDestroy {
   ): string {
     const userSeg = userId == null ? 'anon' : `u${userId}`;
     const base = path.join(
-      CACHE_LAYOUT_ROOT,
+      this.cacheRoot(),
       userSeg,
       String(mediaFileId),
       profileHash,
@@ -364,9 +368,10 @@ export class TranscodeCacheService implements OnModuleInit, OnModuleDestroy {
    *  not mutate {@link entries}; the caller swaps it in. */
   private async scanIndexFromDisk(): Promise<Map<string, CacheEntry>> {
     const result = new Map<string, CacheEntry>();
+    const root = this.cacheRoot();
     let userDirs: string[];
     try {
-      userDirs = await fsp.readdir(CACHE_LAYOUT_ROOT);
+      userDirs = await fsp.readdir(root);
     } catch {
       return result;
     }
@@ -374,7 +379,7 @@ export class TranscodeCacheService implements OnModuleInit, OnModuleDestroy {
     for (const userDir of userDirs) {
       const userId = parseUserDir(userDir);
       if (userId === undefined) continue;
-      const userPath = path.join(CACHE_LAYOUT_ROOT, userDir);
+      const userPath = path.join(root, userDir);
       let mediaDirs: string[];
       try {
         mediaDirs = await fsp.readdir(userPath);


### PR DESCRIPTION
## Problem

`transcode-cache.service.spec` and `streaming-lifecycle.spec` both used the fixed `/tmp/transcode/cache` root and `rm`/recreated it in their hooks. When jest scheduled them on **different parallel workers** they stomped each other — `ENOTEMPTY rmdir`, `ENOENT utime`, and `size()` 0-vs-1 mismatches. It passed serially (`--runInBand`) and often in parallel by luck, but any newly-added spec (e.g. the Wave 2 service specs) shifts jest's worker split and trips it. Surfaced while extracting SegmentPackaging/SessionRouter.

## Fix

- `TranscodeCacheService.cacheRoot()` becomes the single, **lazily-resolved** source of truth, overridable via the `TRANSCODE_CACHE_ROOT` env var; the remaining direct `CACHE_LAYOUT_ROOT` disk-walk sites (init mkdir, dir-match walk, scan-from-disk, path builder) route through it.
- Each of the two specs points at its own `mkdtemp` root.

**Production behaviour unchanged** — env unset falls back to the same `/tmp/transcode/cache` default.

## Verified

Three consecutive **parallel** `jest src/modules/streaming` runs green (22 suites / 165 tests); `tsc --noEmit` clean. Unblocks reliable parallel testing as the rest of the Wave 2 controller split lands. (jest isn't a CI gate here, but this fixes local DX.)
EOF
