### PR TITLE
refactor(streaming): extract a SessionContextBuilder service

### DIFF
--- a/backend/src/modules/streaming/services/session-context-builder.service.spec.ts
+++ b/backend/src/modules/streaming/services/session-context-builder.service.spec.ts
@@ -1,0 +1,75 @@
+import type { Request } from 'express';
+import { SessionContextBuilder } from './session-context-builder.service';
+import type { ResolvedFile } from '../streaming.service';
+
+function resolved(audioCount: number): ResolvedFile {
+  return {
+    media: { title: 'T', type: 'movie', posterUrl: null },
+    mediaFile: {
+      streamInfo: {
+        video: [{ codec: 'hevc', width: 3840, height: 2160, frameRate: '24' }],
+        audio: Array.from({ length: audioCount }, (_, i) => ({
+          language: `l${i}`,
+          bitRate: 128000,
+        })),
+        formatBitRate: 50_000_000,
+      },
+    },
+  } as unknown as ResolvedFile;
+}
+
+const req = { user: { id: 7, username: 'u' } } as unknown as Request;
+
+describe('SessionContextBuilder.build', () => {
+  let sessionRouter: { findRequestSession: jest.Mock };
+  let tracker: { getQsvOptions: jest.Mock; getTonemapAlgo: jest.Mock };
+  let builder: SessionContextBuilder;
+
+  beforeEach(() => {
+    sessionRouter = { findRequestSession: jest.fn().mockReturnValue(null) };
+    tracker = {
+      getQsvOptions: jest.fn().mockReturnValue({ lowPower: false }),
+      getTonemapAlgo: jest.fn().mockReturnValue('auto'),
+    };
+    builder = new SessionContextBuilder(tracker as never, sessionRouter as never);
+  });
+
+  it('sets videoOnly (var_stream_map) only for multi-audio sources', () => {
+    expect(builder.build(req, resolved(2), 1).videoOnly).toBe(true);
+    expect(builder.build(req, resolved(1), 1).videoOnly).toBe(false);
+    expect(builder.build(req, resolved(0), 1).videoOnly).toBe(false);
+  });
+
+  it('carries the intrinsic source facts off streamInfo', () => {
+    const ctx = builder.build(req, resolved(1), 1);
+    expect(ctx.sourceWidth).toBe(3840);
+    expect(ctx.sourceHeight).toBe(2160);
+    expect(ctx.sourceVideoCodec).toBe('hevc');
+    expect(ctx.sourceFps).toBe(24);
+    expect(ctx.userId).toBe(7);
+  });
+
+  it('threads the frozen decision off the LiveSession when present', () => {
+    sessionRouter.findRequestSession.mockReturnValue({
+      tonemapping: true,
+      deviceType: 'mobile',
+      useTs: true,
+      videoVariant: { codec: 'av1', bitDepth: 10, hdr: 'HDR10' },
+      audioPlan: { mode: 'copy', codec: 'eac3' },
+    });
+    const ctx = builder.build(req, resolved(1), 1);
+    expect(ctx.tonemap).toBe(true);
+    expect(ctx.deviceType).toBe('mobile');
+    expect(ctx.useTs).toBe(true);
+    expect(ctx.videoVariant).toEqual({ codec: 'av1', bitDepth: 10, hdr: 'HDR10' });
+    expect(ctx.audioPlan).toEqual({ mode: 'copy', codec: 'eac3' });
+  });
+
+  it('falls back to safe defaults with no LiveSession', () => {
+    const ctx = builder.build(req, resolved(1), 1);
+    expect(ctx.tonemap).toBe(false);
+    expect(ctx.deviceType).toBe('desktop');
+    expect(ctx.useTs).toBe(false);
+    expect(ctx.videoVariant).toBeUndefined();
+  });
+});

--- a/backend/src/modules/streaming/services/session-context-builder.service.ts
+++ b/backend/src/modules/streaming/services/session-context-builder.service.ts
@@ -1,0 +1,95 @@
+import { Injectable } from '@nestjs/common';
+import type { Request } from 'express';
+import { resolveSourceVideoBitrateBps } from '../transcoding';
+import type { SessionContext } from '../transcoding';
+import { pickAudioLayout } from '../transcoding/audio-layout';
+import { ActiveStreamTracker } from '../active-stream-tracker.service';
+import { SessionRouter } from './session-router.service';
+import type { ResolvedFile } from '../streaming.service';
+import { User } from '../../users/entities/user.entity';
+
+/**
+ * Assembles the SessionContext a transcode/segment route hands to the
+ * transcoder. Everything codec/quality-related is read back from the LiveSession
+ * (frozen by stream-builder at playback-info time) so respawns and quality
+ * switches stay coherent with what playback-info promised; only the intrinsic
+ * source facts (dimensions, fps, audio streams) come straight off streamInfo.
+ */
+@Injectable()
+export class SessionContextBuilder {
+  constructor(
+    private readonly activeStreamTracker: ActiveStreamTracker,
+    private readonly sessionRouter: SessionRouter,
+  ) {}
+
+  build(
+    req: Request,
+    resolved: ResolvedFile,
+    mediaFileId: number,
+  ): SessionContext {
+    const user = req.user as User | undefined;
+    const si = resolved.mediaFile.streamInfo;
+    const live = this.sessionRouter.findRequestSession(req, mediaFileId);
+    // var_stream_map decision: same logic as playback-info — relies on the
+    // file's intrinsic audio-stream count, which doesn't drift across sessions.
+    const audioCount = si?.audio?.length ?? 0;
+    const useTs = live?.useTs ?? false;
+    const useMultiAudioLayout =
+      pickAudioLayout(audioCount, useTs ? 'ts' : 'fmp4') === 'var-stream-map';
+    return {
+      userId: user?.id,
+      username: user?.username,
+      mediaTitle: resolved.media?.title,
+      mediaType: resolved.media?.type,
+      posterUrl: resolved.media?.posterUrl ?? null,
+      transcodeReasons: live?.transcodeReasons ?? [],
+      tonemap: live?.tonemapping ?? false,
+      burnInSubtitle: live?.burnIn ?? undefined,
+      audioStreamIndex: live?.audioStreamIndex ?? undefined,
+      crop: si?.video?.[0]?.crop ?? undefined,
+      // Multi-audio: produce video-only segments and let ffmpeg's var_stream_map
+      // emit one audio rendition per track (subdirs 1..N) so Shaka can switch
+      // client-side via EXT-X-MEDIA.
+      videoOnly: useMultiAudioLayout,
+      // Always plumb the audio streams (incl. `streamIndex`) so the single-track
+      // path can also resolve `-map 0:<abs>` and skip FFmpeg's audio
+      // enumeration. `useMultiAudioLayout` only gates the var_stream_map branch,
+      // not the presence of the data.
+      audioStreams: si?.audio ?? undefined,
+      deviceType: live?.deviceType ?? 'desktop',
+      useTs,
+      encoderPreset: live?.encoderPreset ?? 'faster',
+      qsvOptions: this.activeStreamTracker.getQsvOptions(),
+      tonemapAlgo: this.activeStreamTracker.getTonemapAlgo(),
+      // Source framerate (e.g. "24", "23.976", "29.97") — used to compute an
+      // accurate GOP so IDR frames fall on the same boundary regardless of
+      // source fps. Falls back to 24 when unknown.
+      sourceFps: parseFloat(si?.video?.[0]?.frameRate ?? '') || undefined,
+      // ffprobe ran at import/rescan and the result is cached in streamInfo —
+      // tell FFmpeg to skip its own redundant avformat_find_stream_info scan.
+      trustedStreamInfo: !!si?.video?.[0]?.codec,
+      // Canonical audio decision — computed once in stream-builder, stored on
+      // the LiveSession, threaded through here so respawns / quality switches
+      // stay coherent with what playback-info promised.
+      audioPlan: live?.audioPlan ?? undefined,
+      audioTrackPlans: live?.audioTrackPlans ?? undefined,
+      sourceVideoCodec:
+        (si?.video?.[0]?.codec ?? '').toLowerCase() || undefined,
+      sourceWidth: si?.video?.[0]?.width,
+      sourceHeight: si?.video?.[0]?.height,
+      sourceVideoBitrateBps: resolveSourceVideoBitrateBps(
+        si?.video?.[0]?.bitRate,
+        si?.formatBitRate,
+        (si?.audio ?? []).reduce((sum, a) => sum + (a?.bitRate ?? 0), 0),
+      ),
+      isSourceHdr: !!si?.video?.[0]?.hdrFormat,
+      hdrMetadata: si?.video?.[0]?.hdrMetadata,
+      // Variant chosen by stream-builder's codec selector at playback-info time,
+      // threaded through every session spawn so ffmpeg-args resolves the
+      // matching encoder descriptor. Undefined only for legacy callers that
+      // never sent a sid (they route through the userId-based findCurrent
+      // fallback).
+      videoVariant: live?.videoVariant ?? undefined,
+    };
+  }
+}

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -29,7 +29,6 @@ import {
   PROFILES,
   getLadderForDevice,
   getHdrLadderForDevice,
-  SessionContext,
   profileFitsSource,
   computeProfileHash,
   buildPlaybackProfileFromContext,
@@ -44,6 +43,8 @@ import { LiveSessionRegistry } from './live-session.service';
 import * as path from 'path';
 import { SegmentPackagingService } from './services/segment-packaging.service';
 import { SessionRouter } from './services/session-router.service';
+import { SessionContextBuilder } from './services/session-context-builder.service';
+import { pickAudioLayout } from './transcoding/audio-layout';
 import { resolveTonemapPath } from './transcoding/tonemap-path';
 import { ThumbnailService } from './thumbnail.service';
 import { StreamBuilderService } from './stream-builder.service';
@@ -123,33 +124,6 @@ function buildTokenParam(req: Request): string {
  *  older firmwares — issue #148) → video/MP2T. */
 function segmentContentType(segment: string): string {
   return segment.endsWith('.ts') ? 'video/MP2T' : 'video/mp4';
-}
-
-/** Decide whether ffmpeg should emit muxed segments (`inline`) or the
- *  EXT-X-MEDIA layout (`var-stream-map`, video-only main + audio served
- *  as separate renditions).
- *
- *  Rules (single source of truth, mirrored by `master-playlist.ts` and
- *  `ffmpeg-args.ts`):
- *    1. Zero audio sources → inline (degenerate, no audio rendition).
- *    2. Multi-audio sources → var-stream-map (Shaka / AVPlay pick the
- *       rendition client-side without a backend reload).
- *    3. Single-audio sources → inline regardless of mux flavour. The
- *       HLS muxer's hardcoded `+frag_custom+dash+delay_moov` movflags
- *       used to produce iso5+sidx fMP4 segments AVPlay rejected (issue
- *       #148), which forced the var_stream_map workaround. With the
- *       in-tree `cmaf-rewrite` post-processor stripping `sidx` /
- *       `styp` and stamping the `hlsf` brand on every served chunk,
- *       muxed segments parse on AVPlay too — and the single-variant
- *       master that comes with single-audio doesn't trigger AVPlay's
- *       audio-rendition probe, so leaving audio inline is the only
- *       layout that actually plays on Tizen single-audio fmp4. */
-export function pickAudioLayout(
-  audioCount: number,
-  _muxFlavour: 'ts' | 'fmp4',
-): 'inline' | 'var-stream-map' {
-  if (audioCount <= 1) return 'inline';
-  return 'var-stream-map';
 }
 
 /**
@@ -272,85 +246,13 @@ export class StreamingController {
     private readonly liveSessions: LiveSessionRegistry,
     private readonly segmentPackaging: SegmentPackagingService,
     private readonly sessionRouter: SessionRouter,
+    private readonly sessionContextBuilder: SessionContextBuilder,
   ) {}
 
   private getStreamingSettings() {
     return this.streamingSettingsCache.get();
   }
 
-  private buildSessionContext(
-    req: Request,
-    resolved: ResolvedFile,
-    mediaFileId: number,
-  ): SessionContext {
-    const user = req.user as User | undefined;
-    const si = resolved.mediaFile.streamInfo;
-    const live = this.sessionRouter.findRequestSession(req, mediaFileId);
-    // var_stream_map decision: same logic as playback-info — relies on
-    // the file's intrinsic audio-stream count, which doesn't drift
-    // across sessions.
-    const audioCount = si?.audio?.length ?? 0;
-    const useTs = live?.useTs ?? false;
-    const useMultiAudioLayout =
-      pickAudioLayout(audioCount, useTs ? 'ts' : 'fmp4') === 'var-stream-map';
-    return {
-      userId: user?.id,
-      username: user?.username,
-      mediaTitle: resolved.media?.title,
-      mediaType: resolved.media?.type,
-      posterUrl: resolved.media?.posterUrl ?? null,
-      transcodeReasons: live?.transcodeReasons ?? [],
-      tonemap: live?.tonemapping ?? false,
-      burnInSubtitle: live?.burnIn ?? undefined,
-      audioStreamIndex: live?.audioStreamIndex ?? undefined,
-      crop: si?.video?.[0]?.crop ?? undefined,
-      // Multi-audio: produce video-only segments and let ffmpeg's var_stream_map
-      // emit one audio rendition per track (subdirs 1..N) so Shaka can switch
-      // client-side via EXT-X-MEDIA.
-      videoOnly: useMultiAudioLayout,
-      // Always plumb the audio streams (incl. `streamIndex`) so the
-      // single-track path can also resolve `-map 0:<abs>` and skip FFmpeg's
-      // audio enumeration. `useMultiAudioLayout` only gates the var_stream_map
-      // branch, not the presence of the data.
-      audioStreams: si?.audio ?? undefined,
-      deviceType: live?.deviceType ?? 'desktop',
-      useTs,
-      encoderPreset: live?.encoderPreset ?? 'faster',
-      qsvOptions: this.activeStreamTracker.getQsvOptions(),
-      tonemapAlgo: this.activeStreamTracker.getTonemapAlgo(),
-      // Source framerate (e.g. "24", "23.976", "29.97") — used to compute an
-      // accurate GOP so IDR frames fall on the same boundary regardless of
-      // source fps. Falls back to 24 when unknown.
-      sourceFps: parseFloat(si?.video?.[0]?.frameRate ?? '') || undefined,
-      // ffprobe ran at import/rescan and the result is cached in streamInfo —
-      // tell FFmpeg to skip its own redundant avformat_find_stream_info scan.
-      trustedStreamInfo: !!si?.video?.[0]?.codec,
-      // Canonical audio decision — computed once in stream-builder,
-      // stored on the LiveSession, threaded through here so respawns /
-      // quality switches stay coherent with what playback-info promised.
-      audioPlan: live?.audioPlan ?? undefined,
-      audioTrackPlans: live?.audioTrackPlans ?? undefined,
-      sourceVideoCodec:
-        (si?.video?.[0]?.codec ?? '').toLowerCase() || undefined,
-      sourceWidth: si?.video?.[0]?.width,
-      sourceHeight: si?.video?.[0]?.height,
-      sourceVideoBitrateBps: resolveSourceVideoBitrateBps(
-        si?.video?.[0]?.bitRate,
-        si?.formatBitRate,
-        (si?.audio ?? []).reduce((sum, a) => sum + (a?.bitRate ?? 0), 0),
-      ),
-      isSourceHdr: !!si?.video?.[0]?.hdrFormat,
-      hdrMetadata: si?.video?.[0]?.hdrMetadata,
-      // Variant chosen by stream-builder's codec selector at
-      // playback-info time, threaded through every session spawn so
-      // ffmpeg-args resolves the matching encoder descriptor. HLS
-      // routes 410-gate stale `?sid=` upstream via assertFreshSession,
-      // so videoVariant is undefined here only for legacy callers that
-      // never sent a sid — those route through the
-      // userId-based `findCurrent` fallback.
-      videoVariant: live?.videoVariant ?? undefined,
-    };
-  }
 
   /**
    * Effective resume offset in seconds. The explicit `startAt` query wins when
@@ -439,7 +341,7 @@ export class StreamingController {
         resolved.mediaFile.mediaId,
         resolved.mediaFile.episodeId ?? undefined,
       );
-      const ctx = this.buildSessionContext(req, resolved, mediaFileId);
+      const ctx = this.sessionContextBuilder.build(req, resolved, mediaFileId);
       ctx.spawnReason = 'prewarm';
       const profileHash = this.transcodingService.computeProfileHashForCtx(ctx);
       const existing = this.transcodingService.getExistingSession(
@@ -860,7 +762,7 @@ export class StreamingController {
     // next (~100–300ms later) and then seg-0. Starting ffmpeg here overlaps
     // that gap with encoder init so segment 0 is usually already on disk
     // (or streaming) when requested. No-op for DirectPlay or auto quality.
-    // Runs after LiveSession creation so buildSessionContext can find it.
+    // Runs after LiveSession creation so the SessionContextBuilder can find it.
     // Fire-and-forget: the playback-info response (playUrl + sessionId) does
     // not depend on the spawn, so it must not block on ffmpeg init — same
     // pattern as the master.m3u8 prewarm. prewarmTranscodeSession swallows its
@@ -1347,7 +1249,7 @@ export class StreamingController {
         mediaFileId,
         req.user as User,
       );
-      const ctx = this.buildSessionContext(req, resolved, mediaFileId);
+      const ctx = this.sessionContextBuilder.build(req, resolved, mediaFileId);
       // No resolvable LiveSession means no codec variant to thread into
       // ffmpeg (player closed / torn down while segment requests were still
       // in flight — e.g. a rapid open/close — or a stale sid). 410 so the
@@ -1501,7 +1403,7 @@ export class StreamingController {
       if (!existing || existing.process.exitCode !== null) {
         const startAtSec = parseInt(startAtRaw, 10);
         const startSegment = secondsToSegmentIndex(startAtSec);
-        const ctx = this.buildSessionContext(req, resolved, mediaFileId);
+        const ctx = this.sessionContextBuilder.build(req, resolved, mediaFileId);
         ctx.spawnReason = 'variant-prespawn';
         if (quality === 'remux') {
           const copyAudio =
@@ -1708,7 +1610,7 @@ export class StreamingController {
       req.user as User,
     );
 
-    const ctx = this.buildSessionContext(req, resolved, mediaFileId);
+    const ctx = this.sessionContextBuilder.build(req, resolved, mediaFileId);
     // No resolvable LiveSession → no codec variant to thread into ffmpeg
     // (player closed / torn down with segment requests still in flight, or a
     // stale sid). 410 so the client re-establishes instead of a 500 from

--- a/backend/src/modules/streaming/streaming.module.ts
+++ b/backend/src/modules/streaming/streaming.module.ts
@@ -23,6 +23,7 @@ import { RecommendationService } from './recommendation.service';
 import { StreamingSettingsCache } from './streaming-settings-cache.service';
 import { SegmentPackagingService } from './services/segment-packaging.service';
 import { SessionRouter } from './services/session-router.service';
+import { SessionContextBuilder } from './services/session-context-builder.service';
 import { Command } from '../scheduler/entities/command.entity';
 import { AuthModule } from '../auth/auth.module';
 import { SettingsModule } from '../settings/settings.module';
@@ -62,6 +63,7 @@ import { MarkersModule } from '../markers/markers.module';
     StreamingSettingsCache,
     SegmentPackagingService,
     SessionRouter,
+    SessionContextBuilder,
   ],
   exports: [
     PlaybackService,

--- a/backend/src/modules/streaming/transcoding/audio-layout.ts
+++ b/backend/src/modules/streaming/transcoding/audio-layout.ts
@@ -14,3 +14,26 @@ export function varStreamMapLayout(
 ): boolean {
   return videoOnly && audioCount > 0;
 }
+
+/** Decide whether ffmpeg emits muxed segments (`inline`) or the EXT-X-MEDIA
+ *  layout (`var-stream-map`: a video-only main + audio served as separate
+ *  renditions). The controller asks this once and signals it by setting
+ *  `videoOnly` on the SessionContext; {@link varStreamMapLayout} is the
+ *  downstream "is it in effect" check.
+ *
+ *  Rules:
+ *    1. Zero audio sources → inline (no audio rendition to emit).
+ *    2. Multi-audio sources → var-stream-map (Shaka / AVPlay switch the
+ *       rendition client-side without a backend reload).
+ *    3. Single-audio sources → inline regardless of mux flavour. The
+ *       `cmaf-rewrite` post-processor makes muxed fMP4 parse on AVPlay too
+ *       (issue #148), and the single-variant master that comes with
+ *       single-audio doesn't trigger AVPlay's audio-rendition probe — so
+ *       inline is the only layout that plays on Tizen single-audio fMP4. */
+export function pickAudioLayout(
+  audioCount: number,
+  _muxFlavour: 'ts' | 'fmp4',
+): 'inline' | 'var-stream-map' {
+  if (audioCount <= 1) return 'inline';
+  return 'var-stream-map';
+}


### PR DESCRIPTION
Wave 2 — third controller-split step (after SegmentPackaging #481, SessionRouter #482).

## What
- Move `buildSessionContext` out of `StreamingController` into a **`SessionContextBuilder`** service under `streaming/services/`. It assembles the transcoder's `SessionContext` by reading the frozen decision back off the LiveSession (so respawns / quality switches stay coherent with what playback-info promised) plus the intrinsic source facts off `streamInfo`. 4 call sites repointed.
- Relocate the controller's `pickAudioLayout` helper into `transcoding/audio-layout.ts` next to `varStreamMapLayout` — both audio-layout decisions now live in one place, and it breaks the would-be circular import from the new service.

## Safety
- Behaviour-preserving; new unit spec (`session-context-builder.service.spec`) covers the `videoOnly`/var_stream_map decision and LiveSession field threading.
- `tsc --noEmit` clean; full streaming suite **169 green in parallel** (the test-isolation fix from #483 makes parallel reliable now).
- `streaming.controller.ts` 1995 → 1897.

Next: the playback-info negotiation seed (the largest remaining method) feeds into the PlaybackPlan keystone — the high-leverage central change, to be done incrementally behind the golden harness.