### PR TITLE
refactor(streaming): one per-rung video-bitrate helper (cap + HEVC clamp)

### DIFF
--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -22,6 +22,10 @@ import {
   requestedHwAccelFor,
   resolveSourceVideoBitrateBps,
 } from './transcoding';
+import {
+  cappedRungVideoBitrateBps,
+  type RungBitrateContext,
+} from './transcoding/quality-ladder';
 import { bucketResolutionHeight } from '../../common/utils/resolution.util';
 import { isDecoderEnabled } from './transcoding/codec/decoder-probe';
 import { isVppQsvTonemapEnabled } from './transcoding/codec/vpp-qsv-probe';
@@ -432,13 +436,9 @@ export class StreamBuilderService {
       // suffix) so the stats overlay can resolve the selected rung's bitrate.
       // Using the SDR `ladder` here left HDR / eco-hdr rungs unmatched, and
       // the overlay fell back to the full remux bandwidth.
+      const rungCtx = this.rungBitrateCtx(source, selectedVariant.codec);
       for (const p of qualityLadder) {
-        const v = cappedTranscodeVideoBitrateBps(
-          parseBitrateToBps(p.videoBitrate),
-          source.videoBitRate,
-          source.videoCodec,
-          selectedVariant.codec,
-        );
+        const v = cappedRungVideoBitrateBps(p, rungCtx);
         const a = parseBitrateToBps(p.audioBitrate);
         transcodeBitrateByQuality[p.name] = {
           videoBitrateBps: v,
@@ -582,13 +582,9 @@ export class StreamBuilderService {
     // Key by the offered ladder (HDR/eco-hdr rungs carry `-hdr`) so the stats
     // overlay resolves the selected rung instead of falling back to the full
     // remux bandwidth.
+    const rungCtx = this.rungBitrateCtx(source, selectedVariant.codec);
     for (const p of qualityLadder) {
-      const v = cappedTranscodeVideoBitrateBps(
-        parseBitrateToBps(p.videoBitrate),
-        source.videoBitRate,
-        source.videoCodec,
-        selectedVariant.codec,
-      );
+      const v = cappedRungVideoBitrateBps(p, rungCtx);
       const a = outputAudioBitrateBps ?? parseBitrateToBps(p.audioBitrate);
       transcodeBitrateByQuality[p.name] = {
         videoBitrateBps: v,
@@ -621,6 +617,23 @@ export class StreamBuilderService {
       audioTracks: this.buildAudioTracks(audioStreams, profile, 'Transcode'),
       source,
     });
+  }
+
+  /** Per-rung bitrate context from the source + chosen output codec, so the
+   *  playback-info bitrate hints go through the same cappedRungVideoBitrateBps
+   *  as the manifest BANDWIDTH and the encoder (cap + HEVC Main-tier clamp). */
+  private rungBitrateCtx(
+    source: PlaybackInfoResponse['source'],
+    outputCodec: string | undefined,
+  ): RungBitrateContext {
+    return {
+      outputCodec,
+      sourceWidth: source.width ?? 0,
+      sourceHeight: source.height ?? 0,
+      sourceFrameRate: parseFloat(source.frameRate ?? '') || 24,
+      sourceVideoBitrateBps: source.videoBitRate,
+      sourceVideoCodec: source.videoCodec,
+    };
   }
 
   /**
@@ -666,13 +679,9 @@ export class StreamBuilderService {
     // the encode and the master BANDWIDTH — a forced transcode never inflates a
     // low-bitrate source up to the rung nominal, so the stats overlay (which
     // reads this list) shows the real target.
+    const rungCtx = this.rungBitrateCtx(source, targetCodec);
     const totalOf = (p: TranscodeProfile) =>
-      cappedTranscodeVideoBitrateBps(
-        parseBitrateToBps(p.videoBitrate),
-        source.videoBitRate,
-        source.videoCodec,
-        targetCodec,
-      ) + parseBitrateToBps(p.audioBitrate);
+      cappedRungVideoBitrateBps(p, rungCtx) + parseBitrateToBps(p.audioBitrate);
 
     // First non-eco entry = the source-resolution (top) rung.
     const topProfile =

--- a/backend/src/modules/streaming/transcoding/hls-variant-ladder.ts
+++ b/backend/src/modules/streaming/transcoding/hls-variant-ladder.ts
@@ -1,16 +1,12 @@
-import {
-  cappedTranscodeVideoBitrateBps,
-  parseBitrateToBps,
-  profileResolution,
-} from './profiles';
+import { parseBitrateToBps, profileResolution } from './profiles';
 import {
   audioRenditionChannels,
   av1CodecString,
   h264CodecString,
   hevcMain10CodecString,
   hevcMainCodecString,
-  hevcMainTierCapBps,
 } from './codec/codec-strings';
+import { cappedRungVideoBitrateBps } from './quality-ladder';
 import type { CodecVariant, EncoderTarget } from './codec/types';
 import type { AudioStreamMeta, TranscodeProfile } from './types';
 
@@ -139,29 +135,14 @@ export function emitVariantLadder(
       sourceWidth,
       sourceHeight,
     );
-    let cappedVideo = cappedTranscodeVideoBitrateBps(
-      parseBitrateToBps(p.videoBitrate),
+    const cappedVideo = cappedRungVideoBitrateBps(p, {
+      outputCodec: variant.codec,
+      sourceWidth,
+      sourceHeight,
+      sourceFrameRate,
       sourceVideoBitrateBps,
       sourceVideoCodec,
-      variant.codec,
-    );
-    // HEVC declares the Main tier in CODECS; clamp the advertised
-    // AVERAGE-BANDWIDTH to the level's Main-tier ceiling so it tracks the capped
-    // encode (mirrors ffmpeg-args). A High-tier bitstream behind a Main-tier
-    // claim is rejected by strict hardware decoders (Shaka 3014). H.264 has no
-    // tier and AV1's ceiling is far above the current ladder.
-    if (variant.codec === 'hevc') {
-      cappedVideo = Math.min(
-        cappedVideo,
-        hevcMainTierCapBps({
-          width: w,
-          height: h,
-          videoBitrateBps: 0,
-          gopSize: 0,
-          frameRate: sourceFrameRate,
-        }),
-      );
-    }
+    });
     const avg = cappedVideo + parseBitrateToBps(p.audioBitrate);
     // BANDWIDTH ~1.5x nominal: with -maxrate == -b:v the encoder is near-CBR but
     // VBV bursts push segments ~30% above nominal; the margin gives AVPlayer ABR

--- a/backend/src/modules/streaming/transcoding/quality-ladder.spec.ts
+++ b/backend/src/modules/streaming/transcoding/quality-ladder.spec.ts
@@ -1,0 +1,55 @@
+import { cappedRungVideoBitrateBps, type RungBitrateContext } from './quality-ladder';
+import type { TranscodeProfile } from './types';
+
+const rung = (videoBitrate: string): TranscodeProfile => ({
+  name: '2160p',
+  maxWidth: 3840,
+  maxHeight: 2160,
+  videoBitrate,
+  audioBitrate: '192k',
+});
+
+const ctx = (over: Partial<RungBitrateContext> = {}): RungBitrateContext => ({
+  outputCodec: 'hevc',
+  sourceWidth: 3840,
+  sourceHeight: 2160,
+  sourceFrameRate: 24,
+  sourceVideoBitrateBps: undefined,
+  sourceVideoCodec: 'hevc',
+  ...over,
+});
+
+describe('cappedRungVideoBitrateBps', () => {
+  it('clamps a HEVC 4K@24 rung to the L5.0 Main-tier ceiling (#474)', () => {
+    expect(cappedRungVideoBitrateBps(rung('28M'), ctx())).toBe(25_000_000);
+  });
+
+  it('leaves AV1 and H.264 unclamped (no Main-tier gate at this ladder)', () => {
+    expect(cappedRungVideoBitrateBps(rung('28M'), ctx({ outputCodec: 'av1' }))).toBe(
+      28_000_000,
+    );
+    expect(
+      cappedRungVideoBitrateBps(rung('28M'), ctx({ outputCodec: 'h264' })),
+    ).toBe(28_000_000);
+  });
+
+  it('does not clamp HEVC 4K@60 (L5.1 ceiling is 40 Mbps)', () => {
+    expect(
+      cappedRungVideoBitrateBps(rung('28M'), ctx({ sourceFrameRate: 60 })),
+    ).toBe(28_000_000);
+  });
+
+  it('caps to the source bitrate before the tier clamp', () => {
+    // HEVC source 10M → capped to 10M (below the 25M L5.0 ceiling).
+    expect(
+      cappedRungVideoBitrateBps(
+        rung('28M'),
+        ctx({ sourceVideoBitrateBps: 10_000_000 }),
+      ),
+    ).toBe(10_000_000);
+  });
+
+  it('keeps a rung already below both caps', () => {
+    expect(cappedRungVideoBitrateBps(rung('5500k'), ctx())).toBe(5_500_000);
+  });
+});

--- a/backend/src/modules/streaming/transcoding/quality-ladder.ts
+++ b/backend/src/modules/streaming/transcoding/quality-ladder.ts
@@ -1,0 +1,58 @@
+import {
+  cappedTranscodeVideoBitrateBps,
+  parseBitrateToBps,
+  profileResolution,
+} from './profiles';
+import { hevcMainTierCapBps } from './codec/codec-strings';
+import type { TranscodeProfile } from './types';
+
+export interface RungBitrateContext {
+  /** Output codec the rung transcodes to ('hevc' / 'av1' / 'h264'); only HEVC
+   *  is Main-tier-clamped. Undefined falls back to the H.264 baseline. */
+  outputCodec: string | undefined;
+  sourceWidth: number;
+  sourceHeight: number;
+  sourceFrameRate: number;
+  /** Resolved source video bitrate (resolveSourceVideoBitrateBps), used to cap
+   *  a forced transcode to the source so it never inflates a low-bitrate file. */
+  sourceVideoBitrateBps: number | undefined;
+  sourceVideoCodec: string | undefined;
+}
+
+/**
+ * The video bitrate one ABR rung actually encodes at — the single source of
+ * truth shared by the manifest BANDWIDTH, the playback-info per-quality hint and
+ * the encoder `-b:v`, so they can't drift apart. The rung nominal, capped to the
+ * (codec-efficiency-scaled) source bitrate, then — for HEVC — clamped to the
+ * level's Main-tier ceiling so the bitstream stays Main tier and matches the
+ * declared `L<level>` CODECS string (#474).
+ */
+export function cappedRungVideoBitrateBps(
+  rung: TranscodeProfile,
+  ctx: RungBitrateContext,
+): number {
+  let bps = cappedTranscodeVideoBitrateBps(
+    parseBitrateToBps(rung.videoBitrate),
+    ctx.sourceVideoBitrateBps,
+    ctx.sourceVideoCodec,
+    ctx.outputCodec,
+  );
+  if (ctx.outputCodec === 'hevc') {
+    const { width, height } = profileResolution(
+      rung,
+      ctx.sourceWidth,
+      ctx.sourceHeight,
+    );
+    bps = Math.min(
+      bps,
+      hevcMainTierCapBps({
+        width,
+        height,
+        videoBitrateBps: 0,
+        gopSize: 0,
+        frameRate: ctx.sourceFrameRate,
+      }),
+    );
+  }
+  return bps;
+}


### PR DESCRIPTION
Wave 2 — collapses diagnosis #2 (the per-rung bitrate ladder computed in 5+ places).

## What
The per-rung transcode video bitrate was computed in **four** display sites — the manifest BANDWIDTH (`hls-variant-ladder`), the two playback-info `transcodeBitrateByQuality` loops, and the qualities list — but **only the manifest applied the #474 HEVC Main-tier clamp**. So the playback-info per-quality hint could over-state a HEVC 4K rung relative to the manifest and the actual encode — the exact drift the DTO comment warns about ("keep numerically equal to the master playlist").

Extract **`cappedRungVideoBitrateBps`** (cap to the codec-efficiency-scaled source bitrate, then clamp HEVC to the level's Main-tier ceiling) and route all four sites through it.

## Behaviour
- **Manifest: byte-identical** — the Wave 0 golden snapshots pass unchanged.
- **playback-info hints: now clamped** — a HEVC 4K rung above the Main-tier ceiling now reports the clamped value (e.g. 28→25 Mbps), matching the manifest BANDWIDTH and the encoder `-b:v`. Strictly more accurate; the stats overlay reads this. No spec asserted the old (unclamped) value.
- The DirectPlay "reduced quality" **reason-flag** site keeps the raw cap (it's a decision input, not a display hint) — decision behaviour unchanged.

## Safety
- New unit spec for the helper (cap, HEVC clamp at L5.0/L5.1, AV1/H.264 unclamped, source-cap-before-clamp).
- `tsc --noEmit` clean; full streaming suite **169 green in parallel**.