### PR TITLE
fix(player): send HLS subtitle renditions to Android TV

### DIFF
--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -437,12 +437,12 @@ export class BrowserDeviceProfileService {
       // Cast and native mobile consume muxed fMP4 across the board (webOS's
       // native <video> has no such stall and fMP4 keeps Dolby pass-through).
       useTsOnSingleAudio: tvPlatform === 'tizen',
-      // Phone/desktop clients (iOS AVPlayer, Android ExoPlayer, web Shaka)
-      // consume the master SUBTITLES renditions natively, so cues render
-      // inside the player (PiP / AirPlay / browser PiP). TVs stay false:
-      // they have no PiP and their AVPlay/webOS cue APIs are limited, so the
-      // Tizen/webOS engines keep their DOM overlay (fed by sidecar VTT).
-      supportsHlsSubtitles: !isTv,
+      // Players that decode the master SUBTITLES renditions natively (iOS
+      // AVPlayer, Android ExoPlayer — phone and TV alike, web Shaka) render
+      // cues inside the player pipeline. Only Tizen and webOS opt out: their
+      // AVPlay/webOS cue APIs are limited, so those engines drive a DOM
+      // overlay fed by sidecar VTT instead of the HLS renditions.
+      supportsHlsSubtitles: tvPlatform !== 'tizen' && tvPlatform !== 'webos',
       // Only the web/Shaka path probes seg-0 on a load-then-seek; that is
       // exactly the `!isNative` engine branch (Capacitor mobile + every TV go
       // through native players that seek straight to the resume segment). The


### PR DESCRIPTION
## Problem

Subtitles never appeared on **Android TV only** — phone/tablet Android, web, Tizen and webOS were all fine.

## Root cause

Android TV plays through the native ExoPlayer engine (`NativeEngine`), which surfaces subtitles **only** from the master playlist's `#EXT-X-MEDIA:TYPE=SUBTITLES` renditions (see `player.ts` native branch and `native-engine.ts`). But the client device profile sent `supportsHlsSubtitles: !isTv`, so every TV form factor — Android TV included — reported `false`. The backend honors that flag (`streaming.controller.ts`) and drops the subtitle renditions from the manifest.

Tizen and webOS also send `false`, but they render cues through a sidecar-fed DOM overlay (`SubtitleOverlay`), so they're unaffected. Android TV has no such fallback, so it ended up with neither HLS renditions nor an overlay → nothing rendered.

## Fix

Narrow the opt-out to Tizen and webOS (whose AVPlay/webOS cue APIs are limited). Android TV, running the same ExoPlayer as the Android phone client, now receives the HLS subtitle renditions:

```ts
supportsHlsSubtitles: tvPlatform !== 'tizen' && tvPlatform !== 'webos',
```

## Testing

Verified on a real Android TV device: soft subtitle tracks now appear and switch correctly. Tizen/webOS overlays and the phone/web paths are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)