### PR TITLE
refactor(streaming): extract the video filter-graph builder

### DIFF
--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -26,6 +26,7 @@ import { normaliseSourceCodec } from './codec/normalise';
 import { hevcMainTierCapBps } from './codec/codec-strings';
 import { varStreamMapLayout } from './audio-layout';
 import { resolveEncodePipeline } from './encode-pipeline';
+import { buildVideoFilters } from './ffmpeg-filter-graph';
 
 /**
  * Probe ceiling (bytes) for the trusted-streamInfo fast path. Paired with
@@ -529,43 +530,6 @@ export function buildFfmpegArgs(
     args.push('-ss', String(seekSeconds));
   }
 
-  const cropStr = crop
-    ? `crop=${crop.width}:${crop.height}:${crop.x}:${crop.y}`
-    : '';
-  const cpuCropPrefix = cropStr ? `${cropStr},` : '';
-  const burnInFilter = burnIn?.filter ? `,${burnIn.filter}` : '';
-  const tonemapOpencl =
-    tonemap && !useVaapiTonemap && !burnIn?.filter
-      ? ',hwmap=derive_device=opencl:mode=read,tonemap_opencl=format=nv12:p=bt709:t=bt709:m=bt709:tonemap=reinhard:desat=0'
-      : '';
-  const tonemapVaapi =
-    useVaapiTonemap && !burnIn?.filter
-      ? ',tonemap_vaapi=format=nv12:t=bt709:p=bt709:m=bt709'
-      : '';
-  // CPU tonemap chain: HDR (PQ/HLG BT.2020) → SDR (BT.709).
-  // convert to float → tonemap → back to yuv420p. The `tonemap` filter
-  // handles PQ/HLG linearisation internally. No zscale/libzimg dependency
-  // (not available in stock Homebrew FFmpeg on macOS).
-  const tonemapCpu = tonemap
-    ? `format=gbrpf32le,tonemap=mobius:desat=0,format=yuv420p,`
-    : '';
-
-  // For HW paths with crop: hwdownload to CPU, crop, then hwupload back.
-  // The intermediate `format=` is explicit on purpose — without it
-  // ffmpeg can insert an `auto_scale_0` between hwdownload and crop
-  // (the crop filter refuses some HW-adjacent formats), and that
-  // auto-scaler trips scale_vaapi's "fixed-size pool" check
-  // downstream. Pick the format that matches the source bit depth so
-  // crop runs in the same colour space as the decoded surface: for a
-  // 10-bit HDR source, `format=nv12` would silently downconvert to
-  // 8-bit BT.709-clamped pixels before the tonemap filter ever runs,
-  // which is what produced the dark image on cropped 2160p HDR10
-  // sources.
-  const cropPxFmt = sourceBitDepth === 10 ? 'p010le' : 'nv12';
-  const hwCropPrefix = cropStr
-    ? `hwdownload,format=${cropPxFmt},${cropStr},hwupload=derive_device=vaapi,`
-    : '';
-
   const encoderInput: EncoderInput = {
     variant,
     target: {
@@ -586,15 +550,13 @@ export function buildFfmpegArgs(
       bufsize: qsvBufsize,
     },
     libx264BufsizeMb,
-    filters: {
-      cropStr,
-      cpuCropPrefix,
-      hwCropPrefix,
-      burnInFilter,
-      tonemapVaapi,
-      tonemapOpencl,
-      tonemapCpu,
-    },
+    filters: buildVideoFilters({
+      crop,
+      burnIn,
+      tonemap,
+      useVaapiTonemap,
+      sourceBitDepth,
+    }),
     tonemap,
     tonemapPath,
     hasBurnIn: !!burnIn?.filter,

--- a/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.spec.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.spec.ts
@@ -1,0 +1,69 @@
+import { buildVideoFilters } from './ffmpeg-filter-graph';
+
+const base = {
+  crop: undefined,
+  burnIn: undefined,
+  tonemap: false,
+  useVaapiTonemap: false,
+  sourceBitDepth: 8,
+};
+
+describe('buildVideoFilters', () => {
+  it('is all-empty for a plain SDR scale (no crop / tonemap / burn-in)', () => {
+    expect(buildVideoFilters(base)).toEqual({
+      cropStr: '',
+      cpuCropPrefix: '',
+      hwCropPrefix: '',
+      burnInFilter: '',
+      tonemapVaapi: '',
+      tonemapOpencl: '',
+      tonemapCpu: '',
+    });
+  });
+
+  it('builds crop strings + a 10-bit HW round-trip for cropped HDR', () => {
+    const f = buildVideoFilters({
+      ...base,
+      crop: { width: 3840, height: 1632, x: 0, y: 264 },
+      sourceBitDepth: 10,
+    });
+    expect(f.cropStr).toBe('crop=3840:1632:0:264');
+    expect(f.cpuCropPrefix).toBe('crop=3840:1632:0:264,');
+    expect(f.hwCropPrefix).toBe(
+      'hwdownload,format=p010le,crop=3840:1632:0:264,hwupload=derive_device=vaapi,',
+    );
+  });
+
+  it('8-bit crop uses nv12 in the round-trip', () => {
+    const f = buildVideoFilters({
+      ...base,
+      crop: { width: 1920, height: 800, x: 0, y: 140 },
+    });
+    expect(f.hwCropPrefix).toContain('format=nv12,');
+  });
+
+  it('opencl tone-map when tonemap + not vaapi + no burn-in', () => {
+    const f = buildVideoFilters({ ...base, tonemap: true });
+    expect(f.tonemapOpencl).toContain('tonemap_opencl=');
+    expect(f.tonemapVaapi).toBe('');
+    expect(f.tonemapCpu).toContain('tonemap=mobius');
+  });
+
+  it('vaapi tone-map when useVaapiTonemap', () => {
+    const f = buildVideoFilters({ ...base, tonemap: true, useVaapiTonemap: true });
+    expect(f.tonemapVaapi).toContain('tonemap_vaapi=');
+    expect(f.tonemapOpencl).toBe('');
+  });
+
+  it('burn-in forces CPU tone-map (HW tone-maps suppressed)', () => {
+    const f = buildVideoFilters({
+      ...base,
+      tonemap: true,
+      burnIn: { filter: 'subtitles=/tmp/x.ass' } as never,
+    });
+    expect(f.tonemapOpencl).toBe('');
+    expect(f.tonemapVaapi).toBe('');
+    expect(f.burnInFilter).toBe(',subtitles=/tmp/x.ass');
+    expect(f.tonemapCpu).toContain('tonemap=mobius');
+  });
+});

--- a/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.ts
@@ -1,0 +1,71 @@
+import type { BurnInSubtitle } from './types';
+import type { EncoderInput } from './codec/types';
+
+export interface VideoFilterContext {
+  crop?: { width: number; height: number; x: number; y: number };
+  burnIn?: BurnInSubtitle;
+  /** HDR → SDR tone-map active. */
+  tonemap: boolean;
+  /** tonemap_vaapi is the chosen tone-map step (vs opencl / CPU). */
+  useVaapiTonemap: boolean;
+  /** Source bit depth — picks the crop round-trip pixel format (10-bit → p010le
+   *  so the HDR colour space survives the hwdownload → crop → hwupload trip). */
+  sourceBitDepth: number;
+}
+
+/**
+ * Build the per-step `-vf` filter pieces the encoder descriptors splice into
+ * their scale/encode chain. Kept as separate strings (not one graph) because
+ * each descriptor assembles them differently around its own scale filter
+ * (vpp_qsv / scale_vaapi / CPU scale):
+ *  - crop: a CPU prefix (`crop,`) and a HW round-trip prefix (hwdownload → crop
+ *    → hwupload) for paths that crop off-GPU; the round-trip format matches the
+ *    source bit depth so 10-bit HDR isn't silently clamped to 8-bit before the
+ *    tone-map runs.
+ *  - tone-map: three mutually-exclusive variants — opencl (vpp_qsv → hwmap
+ *    opencl → tonemap_opencl → hwmap qsv), vaapi (tonemap_vaapi), and CPU
+ *    (float → tonemap mobius → yuv420p). Burn-in forces the CPU path (libass
+ *    needs CPU buffers), so the HW tone-maps are gated on no burn-in.
+ */
+export function buildVideoFilters(
+  ctx: VideoFilterContext,
+): EncoderInput['filters'] {
+  const { crop, burnIn, tonemap, useVaapiTonemap, sourceBitDepth } = ctx;
+  const cropStr = crop
+    ? `crop=${crop.width}:${crop.height}:${crop.x}:${crop.y}`
+    : '';
+  const cpuCropPrefix = cropStr ? `${cropStr},` : '';
+  const burnInFilter = burnIn?.filter ? `,${burnIn.filter}` : '';
+  const tonemapOpencl =
+    tonemap && !useVaapiTonemap && !burnIn?.filter
+      ? ',hwmap=derive_device=opencl:mode=read,tonemap_opencl=format=nv12:p=bt709:t=bt709:m=bt709:tonemap=reinhard:desat=0'
+      : '';
+  const tonemapVaapi =
+    useVaapiTonemap && !burnIn?.filter
+      ? ',tonemap_vaapi=format=nv12:t=bt709:p=bt709:m=bt709'
+      : '';
+  // CPU tonemap chain: HDR (PQ/HLG BT.2020) → SDR (BT.709). Float → tonemap →
+  // yuv420p; the `tonemap` filter handles PQ/HLG linearisation internally (no
+  // zscale/libzimg dependency).
+  const tonemapCpu = tonemap
+    ? `format=gbrpf32le,tonemap=mobius:desat=0,format=yuv420p,`
+    : '';
+  // HW-crop round-trip: hwdownload → crop → hwupload. The explicit `format=`
+  // matches the source bit depth (p010le for 10-bit) so crop runs in the
+  // decoded surface's colour space — `nv12` here downconverts a 10-bit HDR
+  // source to 8-bit BT.709-clamped pixels before the tone-map, producing a dark
+  // image on cropped 2160p HDR10 sources.
+  const cropPxFmt = sourceBitDepth === 10 ? 'p010le' : 'nv12';
+  const hwCropPrefix = cropStr
+    ? `hwdownload,format=${cropPxFmt},${cropStr},hwupload=derive_device=vaapi,`
+    : '';
+  return {
+    cropStr,
+    cpuCropPrefix,
+    hwCropPrefix,
+    burnInFilter,
+    tonemapVaapi,
+    tonemapOpencl,
+    tonemapCpu,
+  };
+}


### PR DESCRIPTION
First step of the FfmpegCommand staging — pull the gnarliest chunk out of the 562-line `buildFfmpegArgs`.

## What
Extract the seven per-step `-vf` filter pieces — crop (CPU prefix + HW round-trip), burn-in, and the mutually-exclusive **opencl / vaapi / CPU** tone-map variants — into a focused `buildVideoFilters()` in `ffmpeg-filter-graph.ts`. The encoder descriptors still splice these around their own scale filter, so the emitted argv is unchanged.

## Safety
- **Byte-identical**: the QSV/VAAPI argv golden matrix passes unchanged; a live 4K HDR10 opencl-tonemap transcode on Intel QSV produced the identical 3.17 MB segment.
- New unit spec locks the filter strings (crop pixel format by source bit depth — p010le for 10-bit so HDR isn't clamped; the three tone-map variants; burn-in forcing the CPU path).
- `tsc` clean; 189 streaming tests green; 12 argv snapshots unchanged.

## Deferred (scoping note)
The other FfmpegCommand-staging items — unifying the seek handling and the HLS-muxer tail (the **double `-ss` in buildAudioOnlyFfmpegArgs** and the remux `useTs` inconsistency) — change ffmpeg arg *order* and touch the **resume/seek path**, which has known unfixed bugs (var_stream_map audio-410, force_key_frames resume misalignment). Those belong with the hardware-gated seek work (resume-path testing), not a blind byte-identical extraction.