### PR TITLE
refactor(device-profile): derive engine traits from a declarative table

### DIFF
--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -3,6 +3,7 @@ import { Capacitor, registerPlugin } from '@capacitor/core';
 import { PlayerSettingsService } from './player-settings.service';
 import { DeviceService } from './device.service';
 import { ServerConfigService } from './server-config.service';
+import { ENGINE_TRAITS, engineKindFor } from './engine-traits';
 import { getDeviceName } from '../utils/device-info';
 
 interface HdrPlugin {
@@ -235,6 +236,10 @@ export class BrowserDeviceProfileService {
     // Q-series TVs.
     const isTv = this.device.isTv();
     const tvPlatform = this.device.tvPlatform();
+    // The four engine-behavioural flags below come from one declarative
+    // row keyed on the engine kind (platform + native split). Adding a
+    // platform is a single row in `engine-traits.ts`.
+    const traits = ENGINE_TRAITS[engineKindFor(tvPlatform, this.serverConfig.isNative)];
     if (
       this.testCodec(video, hasMSE, 'video/mp4', 'hvc1.1.6.L120.B0') ||
       this.testCodec(video, hasMSE, 'video/mp4', 'hev1.1.6.L120.B0')
@@ -436,23 +441,23 @@ export class BrowserDeviceProfileService {
       // ≥2 audio renditions and AVPlay engages its probe. webOS, browser,
       // Cast and native mobile consume muxed fMP4 across the board (webOS's
       // native <video> has no such stall and fMP4 keeps Dolby pass-through).
-      useTsOnSingleAudio: tvPlatform === 'tizen',
+      useTsOnSingleAudio: traits.useTsOnSingleAudio,
       // Players that decode the master SUBTITLES renditions natively (iOS
       // AVPlayer, Android ExoPlayer — phone and TV alike, web Shaka) render
       // cues inside the player pipeline. Only Tizen and webOS opt out: their
       // AVPlay/webOS cue APIs are limited, so those engines drive a DOM
       // overlay fed by sidecar VTT instead of the HLS renditions.
-      supportsHlsSubtitles: tvPlatform !== 'tizen' && tvPlatform !== 'webos',
+      supportsHlsSubtitles: traits.supportsHlsSubtitles,
       // Only the web/Shaka path probes seg-0 on a load-then-seek; that is
       // exactly the `!isNative` engine branch (Capacitor mobile + every TV go
       // through native players that seek straight to the resume segment). The
       // Cast receiver sets this true in its own profile.
-      probesSegZero: !this.serverConfig.isNative,
+      probesSegZero: traits.probesSegZero,
       // Samsung Tizen AVPlay is HLS-only and cannot open a raw progressive
       // file, so it must never receive a DirectPlay decision — the backend
       // falls back to DirectStream (remux to HLS, codec-copy). Every other
       // engine (Shaka, ExoPlayer/AVPlayer, webOS <video>) plays raw files.
-      supportsDirectPlay: tvPlatform !== 'tizen',
+      supportsDirectPlay: traits.supportsDirectPlay,
     };
   }
 

--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -8,6 +8,7 @@ import { AppSettingsService } from './app-settings.service';
 import { buildSubtitleTracks } from '../utils/subtitle-tracks';
 import { AuthService } from './auth.service';
 import { DeviceProfile } from './browser-device-profile.service';
+import { ENGINE_TRAITS, EngineKind } from './engine-traits';
 import { ServerConfigService } from './server-config.service';
 import { formatAudioLabel, formatSubtitleLabel, parseAudioIndex, SpriteMetadata } from '../utils/player.utils';
 import { PlayerSettingsService } from './player-settings.service';
@@ -170,8 +171,10 @@ export class CastPlayerService {
       // back later without re-doing the plumbing.
       useTs: false,
       // The Cast receiver runs Shaka, which fetches seg-0 on a load-then-seek,
-      // so keep the backend's seg-0 early-start companion for resumes.
-      probesSegZero: true,
+      // so keep the backend's seg-0 early-start companion for resumes. The CAST
+      // row sets only `probesSegZero`, leaving useTsOnSingleAudio /
+      // supportsHlsSubtitles / supportsDirectPlay undefined on the wire.
+      ...ENGINE_TRAITS[EngineKind.CAST],
     };
   }
 

--- a/client/src/app/core/services/engine-traits.spec.ts
+++ b/client/src/app/core/services/engine-traits.spec.ts
@@ -1,0 +1,111 @@
+import { TvPlatform } from './device.service';
+import { ENGINE_TRAITS, EngineKind, EngineTraits, engineKindFor } from './engine-traits';
+
+/** The four engine traits transcribed from the audited schema. `undefined`
+ *  (an omitted key) is asserted via `toEqual`, so a stray `false` would fail. */
+const EXPECTED: Record<EngineKind, EngineTraits> = {
+  [EngineKind.WEB]: {
+    useTsOnSingleAudio: false,
+    supportsHlsSubtitles: true,
+    probesSegZero: true,
+    supportsDirectPlay: true,
+  },
+  [EngineKind.NATIVE]: {
+    useTsOnSingleAudio: false,
+    supportsHlsSubtitles: true,
+    probesSegZero: false,
+    supportsDirectPlay: true,
+  },
+  [EngineKind.ANDROID_TV]: {
+    useTsOnSingleAudio: false,
+    supportsHlsSubtitles: true,
+    probesSegZero: false,
+    supportsDirectPlay: true,
+  },
+  [EngineKind.TIZEN]: {
+    useTsOnSingleAudio: true,
+    supportsHlsSubtitles: false,
+    probesSegZero: false,
+    supportsDirectPlay: false,
+  },
+  [EngineKind.WEBOS]: {
+    useTsOnSingleAudio: false,
+    supportsHlsSubtitles: false,
+    probesSegZero: false,
+    supportsDirectPlay: true,
+  },
+  [EngineKind.CAST]: {
+    probesSegZero: true,
+  },
+};
+
+describe('engineKindFor', () => {
+  it('maps null + isNative=false to WEB', () => {
+    expect(engineKindFor(null, false)).toBe(EngineKind.WEB);
+  });
+
+  it('maps null + isNative=true to NATIVE', () => {
+    expect(engineKindFor(null, true)).toBe(EngineKind.NATIVE);
+  });
+
+  it('maps androidtv to ANDROID_TV', () => {
+    expect(engineKindFor('androidtv', true)).toBe(EngineKind.ANDROID_TV);
+  });
+
+  it('maps tizen to TIZEN', () => {
+    expect(engineKindFor('tizen', true)).toBe(EngineKind.TIZEN);
+  });
+
+  it('maps webos to WEBOS', () => {
+    expect(engineKindFor('webos', true)).toBe(EngineKind.WEBOS);
+  });
+});
+
+describe('ENGINE_TRAITS', () => {
+  for (const kind of Object.values(EngineKind)) {
+    it(`row for ${kind} deep-equals the audited expectation`, () => {
+      expect(ENGINE_TRAITS[kind]).toEqual(EXPECTED[kind]);
+    });
+  }
+
+  it('CAST omits the three non-seg-zero traits (undefined on the wire)', () => {
+    const cast = ENGINE_TRAITS[EngineKind.CAST];
+    expect(cast.probesSegZero).toBe(true);
+    expect(cast.useTsOnSingleAudio).toBeUndefined();
+    expect(cast.supportsHlsSubtitles).toBeUndefined();
+    expect(cast.supportsDirectPlay).toBeUndefined();
+  });
+});
+
+/**
+ * Behaviour-preserving oracle: recompute the four flags with the ORIGINAL
+ * inline ternaries from `browser-device-profile.service.ts` and assert the
+ * table reproduces them byte-for-byte for every REACHABLE (tvPlatform,
+ * isNative) combination. If anyone touches a row, this fails.
+ *
+ * Reachable set (see device.service.ts + server-config.service.ts): a non-null
+ * tvPlatform is only ever set by UA markers that also match the `isNative`
+ * regex, so the three TV platforms are always isNative=true. A null tvPlatform
+ * splits both ways (web vs Capacitor mobile).
+ */
+describe('ENGINE_TRAITS reproduces the original ternaries', () => {
+  const reachable: { tvPlatform: TvPlatform; isNative: boolean }[] = [
+    { tvPlatform: null, isNative: false },
+    { tvPlatform: null, isNative: true },
+    { tvPlatform: 'androidtv', isNative: true },
+    { tvPlatform: 'tizen', isNative: true },
+    { tvPlatform: 'webos', isNative: true },
+  ];
+
+  for (const { tvPlatform, isNative } of reachable) {
+    it(`tvPlatform=${tvPlatform} isNative=${isNative}`, () => {
+      const traits = ENGINE_TRAITS[engineKindFor(tvPlatform, isNative)];
+      expect(traits.useTsOnSingleAudio).toBe(tvPlatform === 'tizen');
+      expect(traits.supportsHlsSubtitles).toBe(
+        tvPlatform !== 'tizen' && tvPlatform !== 'webos',
+      );
+      expect(traits.probesSegZero).toBe(!isNative);
+      expect(traits.supportsDirectPlay).toBe(tvPlatform !== 'tizen');
+    });
+  }
+});

--- a/client/src/app/core/services/engine-traits.ts
+++ b/client/src/app/core/services/engine-traits.ts
@@ -1,0 +1,108 @@
+import { TvPlatform } from './device.service';
+
+/**
+ * Distinct playback-engine kinds, one per unique behavioural trait-row. The
+ * engine drives four flags the backend keys streaming decisions on
+ * (see `EngineTraits`). Every supported client maps to exactly one kind:
+ *
+ *  - WEB        — browser web build (Shaka / MSE).
+ *  - NATIVE     — Capacitor mobile (ExoPlayer on Android, AVPlayer on iOS).
+ *  - ANDROID_TV — Android TV box / 10-foot ExoPlayer build.
+ *  - TIZEN      — Samsung Smart TV (AVPlay, HLS-only).
+ *  - WEBOS      — LG Smart TV (native `<video>`).
+ *  - CAST       — Chromecast receiver (Shaka), built by the Cast player.
+ *
+ * Adding a platform is a single edit: a new `EngineKind` member, one
+ * `ENGINE_TRAITS` row, and one `engineKindFor` branch.
+ */
+export enum EngineKind {
+  WEB = 'web',
+  NATIVE = 'native',
+  ANDROID_TV = 'androidtv',
+  TIZEN = 'tizen',
+  WEBOS = 'webos',
+  CAST = 'cast',
+}
+
+/**
+ * The four engine-behavioural flags on `DeviceProfile`. Each is optional
+ * because `undefined` is load-bearing on the wire: the DTO marks them
+ * `@IsOptional()` and an absent `supportsDirectPlay` is read as `true` by the
+ * backend. A row that omits a key emits `undefined` (no key in the JSON),
+ * which must stay distinct from an explicit `false`.
+ */
+export interface EngineTraits {
+  /** Force MPEG-TS HLS only for single-audio sources (Tizen AVPlay). */
+  useTsOnSingleAudio?: boolean;
+  /** Engine consumes HLS `SUBTITLES` renditions natively. */
+  supportsHlsSubtitles?: boolean;
+  /** Engine fetches seg-0 on a load-then-seek (web/Shaka + Cast receiver). */
+  probesSegZero?: boolean;
+  /** Engine can play a raw progressive file as DirectPlay. */
+  supportsDirectPlay?: boolean;
+}
+
+/**
+ * Single source of truth for the four engine traits, one row per `EngineKind`.
+ *
+ * The CAST row sets only `probesSegZero` so the other three serialise as
+ * `undefined` (absent from the payload), matching the hand-rolled Cast
+ * profile. The TV-platform rows are always reached with `isNative === true`:
+ * the only UA markers that set a non-null `tvPlatform` also match the
+ * `isNative` regex, so no `isNative === false` TV row is reachable today.
+ */
+export const ENGINE_TRAITS: Record<EngineKind, EngineTraits> = {
+  [EngineKind.WEB]: {
+    useTsOnSingleAudio: false,
+    supportsHlsSubtitles: true,
+    probesSegZero: true,
+    supportsDirectPlay: true,
+  },
+  [EngineKind.NATIVE]: {
+    useTsOnSingleAudio: false,
+    supportsHlsSubtitles: true,
+    probesSegZero: false,
+    supportsDirectPlay: true,
+  },
+  [EngineKind.ANDROID_TV]: {
+    useTsOnSingleAudio: false,
+    supportsHlsSubtitles: true,
+    probesSegZero: false,
+    supportsDirectPlay: true,
+  },
+  [EngineKind.TIZEN]: {
+    useTsOnSingleAudio: true,
+    supportsHlsSubtitles: false,
+    probesSegZero: false,
+    supportsDirectPlay: false,
+  },
+  [EngineKind.WEBOS]: {
+    useTsOnSingleAudio: false,
+    supportsHlsSubtitles: false,
+    probesSegZero: false,
+    supportsDirectPlay: true,
+  },
+  [EngineKind.CAST]: {
+    probesSegZero: true,
+  },
+};
+
+/**
+ * Resolve the playback-engine kind from the detected platform and the
+ * `isNative` flag (`ServerConfigService.isNative`). A null `tvPlatform`
+ * splits into NATIVE (Capacitor mobile) vs WEB (browser) on `isNative`;
+ * that split is what `probesSegZero` keys on. CAST is selected explicitly by
+ * the Cast player and never resolved through this function.
+ */
+export function engineKindFor(tvPlatform: TvPlatform, isNative: boolean): EngineKind {
+  switch (tvPlatform) {
+    case 'tizen':
+      return EngineKind.TIZEN;
+    case 'webos':
+      return EngineKind.WEBOS;
+    case 'androidtv':
+      return EngineKind.ANDROID_TV;
+    default:
+      return isNative ? EngineKind.NATIVE : EngineKind.WEB;
+  }
+}


### PR DESCRIPTION
## Why

The four engine-behavioural flags on `DeviceProfile` (`useTsOnSingleAudio`, `supportsHlsSubtitles`, `probesSegZero`, `supportsDirectPlay`) were inline ternaries scattered across two builders, each re-deriving the platform split by hand. Adding a platform meant editing every ternary and hoping none drifted. This collapses them into one declarative `EngineKind → EngineTraits` table so a new platform is a single row.

Behaviour-preserving: no flag value changes for any reachable client.

## What

- New `core/services/engine-traits.ts`: `EngineKind` enum (WEB/NATIVE/ANDROID_TV/TIZEN/WEBOS/CAST), `EngineTraits` interface (four **optional** booleans — `undefined` is load-bearing on the wire), the `ENGINE_TRAITS` table, and `engineKindFor(tvPlatform, isNative)`.
- `browser-device-profile.service.ts`: the four ternaries now read `traits.<flag>` from one `ENGINE_TRAITS[engineKindFor(...)]` lookup. `useTs` / `deviceType` / `supportsHdr` / `maxAudioChannels` / the webOS Dolby bump / mp3-on-webos are untouched (not engine traits).
- `cast-player.service.ts`: the hand-set `probesSegZero: true` becomes `...ENGINE_TRAITS[EngineKind.CAST]`; the CAST row sets only `probesSegZero`, so the other three stay absent from the payload — byte-identical.

## Equivalence (table = old ternaries)

| flag | old expression | table |
|---|---|---|
| `useTsOnSingleAudio` | `tvPlatform === 'tizen'` | TIZEN `true`, else `false` |
| `supportsHlsSubtitles` | `tvPlatform !== 'tizen' && tvPlatform !== 'webos'` | TIZEN/WEBOS `false`, else `true` |
| `probesSegZero` | `!serverConfig.isNative` | WEB `true`, NATIVE/all-TV `false` |
| `supportsDirectPlay` | `tvPlatform !== 'tizen'` | TIZEN `false`, else `true` |

`probesSegZero` relies on a **reachability invariant**: every UA marker that sets a non-null `tvPlatform` also matches the `isNative` regex (`device.service.ts` vs `server-config.service.ts:38-43`), so the three TV kinds are always `isNative === true` and no `(TV, isNative=false)` row is reachable. Documented in `engine-traits.ts` and asserted by the spec's oracle (which loops only the reachable set).

## Tests

`engine-traits.spec.ts` (17 tests): `engineKindFor` mapping for all reachable inputs; deep-equality on every `ENGINE_TRAITS` row (verifies `undefined` keys); CAST omits the three non-seg-zero traits; and a **ternary-oracle** test that recomputes the OLD expressions over the reachable `(tvPlatform, isNative)` combos and asserts the table matches.

`tsc --noEmit` clean on `tsconfig.app.json` + `tsconfig.spec.json`.