### PR TITLE
fix(auth): reset credentials on server switch so streaming re-mints

### DIFF
--- a/client/src/app/core/services/auth.service.ts
+++ b/client/src/app/core/services/auth.service.ts
@@ -532,6 +532,33 @@ export class AuthService {
     void this.router.navigate(['/select-user'], { replaceUrl: true });
   }
 
+  /**
+   * Drop every credential scoped to the previously-active server so the next
+   * request re-mints against the server the user just switched to. Tokens are
+   * stored under fixed, non-server-keyed names, so a switch must WIPE rather
+   * than swap: the old access/refresh/stream tokens would otherwise leak into
+   * the Bearer header (credentials interceptor) and into every streaming URL
+   * (StreamingApiService.playbackToken prefers the cached stream token), which
+   * the new server rejects with 401 — breaking the whole playback path.
+   *
+   * Unlike {@link clearLocalSession} this does NOT navigate: the switch sites
+   * (setup save/useKnown, select-user changeServer) own their own redirect.
+   * In-flight refresh / stream-token fetches tied to the old server are dropped
+   * so they can't repopulate state after the wipe.
+   */
+  async resetForServerSwitch(): Promise<void> {
+    this._refreshInFlight = null;
+    this._streamTokenInFlight = null;
+    this._user.set(null);
+    await this.clearTokens();
+    try {
+      localStorage.removeItem('fliks.cachedUser');
+    } catch {
+      // ignore
+    }
+    await this.serverCache.clearAll();
+  }
+
   // ---------------------------------------------------------------------------
   // Token persistence — Preferences on native (survives app restarts reliably),
   // localStorage as fallback on web or if Preferences fails.

--- a/client/src/app/features/select-user/select-user.ts
+++ b/client/src/app/features/select-user/select-user.ts
@@ -132,6 +132,9 @@ export class SelectUserComponent {
   async changeServer() {
     await this.serverCache.clearAll();
     await this.serverConfig.clear();
+    // Drop the old server's access/refresh/stream tokens too — clearAll only
+    // wipes cached view data, leaving credentials that the next server rejects.
+    await this.auth.resetForServerSwitch();
     void this.router.navigate(['/setup']);
   }
 

--- a/client/src/app/features/setup/setup.ts
+++ b/client/src/app/features/setup/setup.ts
@@ -10,6 +10,7 @@ import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ServerConfigService, KnownServer } from '../../core/services/server-config.service';
+import { AuthService } from '../../core/services/auth.service';
 
 @Component({
   selector: 'app-setup',
@@ -19,6 +20,7 @@ import { ServerConfigService, KnownServer } from '../../core/services/server-con
 })
 export class SetupComponent {
   private readonly serverConfig = inject(ServerConfigService);
+  private readonly auth = inject(AuthService);
   private readonly http = inject(HttpClient);
   private readonly router = inject(Router);
   private readonly translate = inject(TranslateService);
@@ -57,12 +59,18 @@ export class SetupComponent {
     const result = this.testResult();
     if (!result?.ok) return;
     await this.serverConfig.save(this.url().trim());
+    // Drop the previous server's credentials so playback-info and every
+    // streaming URL re-mint against the server just picked.
+    await this.auth.resetForServerSwitch();
     void this.router.navigate(['/select-user']);
   }
 
   /** One-tap "use this server" — already known, skip the test step. */
   async useKnown(server: KnownServer) {
     await this.serverConfig.save(server.url);
+    // Worst case for stale credentials: this path can skip login() entirely
+    // when a session is still hydrated, so wipe the old server's tokens here.
+    await this.auth.resetForServerSwitch();
     void this.router.navigate(['/select-user'], {
       queryParams: server.lastUsername ? { username: server.lastUsername } : undefined,
     });


### PR DESCRIPTION
## Why

Switching servers in the mobile app broke the whole streaming path (401 loop / player retry-reload), not just DirectPlay.

Tokens are stored under fixed, non-server-keyed names (`fliks_access_token` / `fliks_refresh_token` + in-memory `_accessToken` / `_refreshToken` / `_streamToken`). A switch swapped the active server URL but never cleared `AuthService` credentials, so the old server's tokens leaked into every `/api` Bearer header and into every streaming URL (`StreamingApiService.playbackToken = streamToken() ?? accessToken`). The new server 401-rejected the foreign token, the refresh path replayed the stale refresh token, and the player dropped into its retry/reload loop.

The cached **stream token** was the worst offender — preserved by `serverCache.clearAll()`, valid ~12h, and preferred over the access token, so even a fresh login on the new server kept emitting stale streaming URLs.

## Fix

`AuthService.resetForServerSwitch()` — the same credential wipe as the logout path (`clearTokens()` nulls `_accessToken` / `_refreshToken` / `_streamToken` / `_streamTokenExpiresAt` and removes the persisted keys from **both** Preferences and localStorage), plus `_user.set(null)`, remove `fliks.cachedUser`, `serverCache.clearAll()`, and null `_refreshInFlight` / `_streamTokenInFlight` so an in-flight old-server fetch can't repopulate state — but **without** the router navigation (the switch sites own their own redirect).

Wired into all three switch entry points:
- `setup.ts` `save()` (manual URL)
- `setup.ts` `useKnown()` (one-tap known server — worst case, can skip `login()`)
- `select-user.ts` `changeServer()`

After the reset both `auth.streamToken()` and `auth.accessToken` are null, so `playbackToken` returns null and the interceptor attaches no Bearer until the new login re-mints against the new server.

## Scope / risk

Touches only the three server-**switch** paths; normal single-server sessions are untouched. `serverCache.clearAll()` preserves downloaded media (offline downloads survive a switch).

`tsc --noEmit -p tsconfig.app.json` clean.

## Device validation (recommended post-merge)

Native build + two servers: log into A → playback OK; switch to B via **both** `save()` and `useKnown()`, plus select-user "Change server"; expect first-try success on playback-info / master.m3u8 / segments / direct-play, no 401 loop, no bounce to `/select-user`.