### PR TITLE
feat(desktop): native linux client with embedded mpv compositor

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -1301,16 +1301,40 @@ export class StreamingController {
     // parallel with main, so it lands first. Use a short timeout — main
     // covers the same files behind it, so wasting 60s on early when it has
     // already exited adds latency for nothing.
-    const earlySession = this.sessionRouter.resolveEarlySession(mediaFileId, user?.id, req);
-    const useEarly =
-      earlySession != null &&
+    let earlySession = this.sessionRouter.resolveEarlySession(mediaFileId, user?.id, req);
+    const wantEarly =
       videoSession.startSegment != null &&
       videoSession.startSegment > 0 &&
-      earlySession.quality === videoSession.quality &&
       // Only seg-0 .. seg-(EARLY_PROBE_SEGMENTS-1) live in the early session —
       // bound to the same window the video path uses. (Was `< startSegment`,
       // which on a deep resume routed segments the early session never wrote.)
       (isInit || segIndex < EARLY_PROBE_SEGMENTS);
+    // (Re)spawn the companion when it is absent or on a different rung, mirroring
+    // the video route. The audio rendition rides the video session and is served
+    // from the companion's `<audioIndex+1>/` subdir; without this its seg-0/init
+    // has no producer when prewarm hasn't landed (or committed to another rung)
+    // and the main — anchored at the resume floor — never writes it, so a
+    // seg-0-probing client (Shaka, Cast, desktop mpv) gets a 404 on the rendition
+    // init. Resolve file/ctx lazily so the common in-window serve adds no work.
+    if (wantEarly && (!earlySession || earlySession.quality !== videoSession.quality)) {
+      const resolvedEarly = await this.streamingService.resolveFile(
+        mediaFileId,
+        req.user as User,
+      );
+      const earlyCtx = this.sessionContextBuilder.build(req, resolvedEarly, mediaFileId);
+      earlySession = await this.transcodingService
+        .getOrCreateEarlySession(
+          mediaFileId,
+          videoSession.quality,
+          resolvedEarly.absolutePath,
+          earlyCtx,
+        )
+        .catch(() => undefined);
+    }
+    const useEarly =
+      wantEarly &&
+      earlySession != null &&
+      earlySession.quality === videoSession.quality;
 
     let segPath: string | null = null;
     if (useEarly && earlySession) {

--- a/client/src/app/core/plugins/desktop-player.bridge.ts
+++ b/client/src/app/core/plugins/desktop-player.bridge.ts
@@ -1,0 +1,101 @@
+// Bridge to the Electron desktop shell's embedded mpv player, exposed on
+// `window.fliksDesktop` by the desktop preload. The Angular DesktopEngine
+// consumes this exactly as NativeEngine consumes the NativePlayer Capacitor
+// plugin. Types mirror desktop/src/shared/contract.ts — the two live in
+// separate build workspaces, so the shape is intentionally duplicated here.
+
+export interface DesktopAudioTrack {
+  id: string;
+  language: string;
+  label: string;
+  selected: boolean;
+}
+
+export interface DesktopSubtitleTrack {
+  id: string;
+  language: string;
+  label: string;
+  forced: boolean;
+  selected: boolean;
+}
+
+export interface DesktopLoadOptions {
+  url: string;
+  startTime?: number;
+  headers?: Record<string, string>;
+  subtitles?: { url: string; language: string; label: string; forced?: boolean }[];
+}
+
+export interface DesktopSubtitleStyle {
+  fontScale: number;
+  foregroundColor: string;
+  backgroundColor: string;
+  edgeType?: string;
+  bottomMarginPercent: number;
+}
+
+export interface DesktopRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface DesktopPositionInfo {
+  position: number;
+  duration: number;
+  buffered: number;
+}
+
+export type DesktopPlayerState = 'idle' | 'playing' | 'paused' | 'buffering' | 'ended' | 'error';
+
+export type DesktopEvent =
+  | { type: 'ready' }
+  | { type: 'stateChanged'; payload: { state: DesktopPlayerState } }
+  | { type: 'timeUpdate'; payload: DesktopPositionInfo }
+  | {
+      type: 'tracksChanged';
+      payload: { audioTracks: DesktopAudioTrack[]; subtitleTracks: DesktopSubtitleTrack[] };
+    }
+  | { type: 'firstFrame' }
+  | { type: 'error'; payload: { code: number; message: string } };
+
+export interface FliksDesktopApi {
+  runtime: 'electron';
+  load(opts: DesktopLoadOptions): Promise<void>;
+  play(): Promise<void>;
+  pause(): Promise<void>;
+  seek(position: number): Promise<void>;
+  stop(): Promise<void>;
+  setPlaybackRate(rate: number): Promise<void>;
+  setVolume(volume: number): Promise<void>;
+  setMuted(muted: boolean): Promise<void>;
+  getPosition(): Promise<DesktopPositionInfo>;
+  getAudioTracks(): Promise<DesktopAudioTrack[]>;
+  selectAudioTrack(id: string): Promise<void>;
+  getSubtitleTracks(): Promise<DesktopSubtitleTrack[]>;
+  selectSubtitleTrack(id: string | null): Promise<void>;
+  setSubtitleStyle(style: DesktopSubtitleStyle): Promise<void>;
+  resize(rect: DesktopRect): Promise<void>;
+  setFullscreen(enabled: boolean): Promise<void>;
+  destroy(): Promise<void>;
+  on(handler: (event: DesktopEvent) => void): () => void;
+}
+
+declare global {
+  interface Window {
+    fliksDesktop?: FliksDesktopApi;
+  }
+}
+
+/** The desktop bridge, or null when not running in the Electron shell. */
+export function desktopBridgeOrNull(): FliksDesktopApi | null {
+  return typeof window !== 'undefined' ? (window.fliksDesktop ?? null) : null;
+}
+
+/** The desktop bridge; throws when not running in the Electron shell. */
+export function desktopBridge(): FliksDesktopApi {
+  const api = desktopBridgeOrNull();
+  if (!api) throw new Error('fliksDesktop bridge unavailable (not in Electron shell)');
+  return api;
+}

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -239,7 +239,10 @@ export class BrowserDeviceProfileService {
     // The four engine-behavioural flags below come from one declarative
     // row keyed on the engine kind (platform + native split). Adding a
     // platform is a single row in `engine-traits.ts`.
-    const traits = ENGINE_TRAITS[engineKindFor(tvPlatform, this.serverConfig.isNative)];
+    const traits =
+      ENGINE_TRAITS[
+        engineKindFor(tvPlatform, this.serverConfig.isNative, this.device.isDesktopNative())
+      ];
     if (
       this.testCodec(video, hasMSE, 'video/mp4', 'hvc1.1.6.L120.B0') ||
       this.testCodec(video, hasMSE, 'video/mp4', 'hev1.1.6.L120.B0')
@@ -395,6 +398,29 @@ export class BrowserDeviceProfileService {
       (audioCodecs.includes('eac3') || audioCodecs.includes('ac3'))
     ) {
       maxAudioChannels = Math.max(maxAudioChannels, 6);
+    }
+
+    // Desktop native shell (Electron + embedded mpv): mpv/ffmpeg decode
+    // virtually any codec/container, but the Chromium MSE probe wildly
+    // under-reports (no HEVC, no E-AC3), which would force the backend to
+    // transcode everything. Advertise mpv's broad capability set so sources
+    // Direct Play / copy straight through.
+    if (this.device.isDesktopNative()) {
+      containers.length = 0;
+      containers.push('mp4', 'mkv', 'webm', 'mov', 'ts', 'm4v', 'avi', 'flv');
+      videoCodecs.length = 0;
+      videoCodecs.push(
+        'h264', 'avc1', 'hevc', 'h265', 'hvc1', 'hev1',
+        'av1', 'vp9', 'vp8', 'mpeg2video', 'mpeg4',
+      );
+      codecConditions.length = 0;
+      codecConditions.push(
+        { codec: 'h264', profiles: ['baseline', 'constrained baseline', 'main', 'high'], maxBitDepth: 8 },
+        { codec: 'hevc', profiles: ['main', 'main 10'], maxBitDepth: 10 },
+        { codec: 'av1', profiles: ['main', 'high'], maxBitDepth: 10 },
+      );
+      audioCodecs = ['aac', 'ac3', 'eac3', 'opus', 'flac', 'alac', 'mp3', 'dts', 'truehd', 'vorbis'];
+      maxAudioChannels = Math.max(maxAudioChannels, 8);
     }
 
     // --- HDR support ---

--- a/client/src/app/core/services/device.service.ts
+++ b/client/src/app/core/services/device.service.ts
@@ -10,6 +10,11 @@ export type FormFactor = 'desktop' | 'phone' | 'tablet' | 'tv';
  * and the platform enum only for OS-bound capabilities.
  */
 export type TvPlatform = 'androidtv' | 'tizen' | 'webos' | null;
+/**
+ * Desktop shell underneath a `formFactor=desktop`. Drives the native-player
+ * engine selection and packaging glue, the desktop counterpart of TvPlatform.
+ */
+export type DesktopPlatform = 'electron' | null;
 
 const TABLET_MIN_WIDTH = 768;
 const OVERRIDE_KEY = 'fliks.deviceOverride';
@@ -45,7 +50,10 @@ export class DeviceService {
   readonly input = signal<InputMode>('mouse');
   readonly formFactor = signal<FormFactor>('desktop');
   readonly tvPlatform = signal<TvPlatform>(null);
+  readonly desktopPlatform = signal<DesktopPlatform>(null);
 
+  /** Running inside the native desktop shell (Electron + embedded mpv). */
+  readonly isDesktopNative = computed(() => this.desktopPlatform() !== null);
   readonly isTv = computed(() => this.formFactor() === 'tv');
   readonly isTablet = computed(() => this.formFactor() === 'tablet');
   readonly isPhone = computed(() => this.formFactor() === 'phone');
@@ -59,6 +67,7 @@ export class DeviceService {
     this.input.set(detected.input);
     this.formFactor.set(detected.formFactor);
     this.tvPlatform.set(detected.tvPlatform);
+    this.desktopPlatform.set(this.detectDesktopPlatform());
     this.syncBodyClasses();
     this.bindResize();
     // Visible in remote debug (chrome://inspect) — invisible in normal use.
@@ -124,6 +133,17 @@ export class DeviceService {
 
     // 8. Default
     return { input: 'mouse', formFactor: 'desktop', tvPlatform: null };
+  }
+
+  /** Electron desktop shell: the preload bridge is authoritative; the UA tag
+   *  is a fallback for the brief window before it attaches. */
+  private detectDesktopPlatform(): DesktopPlatform {
+    if (typeof window === 'undefined') return null;
+    if (window.fliksDesktop) return 'electron';
+    if (typeof navigator !== 'undefined' && /\bElectron\//.test(navigator.userAgent)) {
+      return 'electron';
+    }
+    return null;
   }
 
   /** Re-detect on resize (covers tablet rotation crossing the 768 px breakpoint). */

--- a/client/src/app/core/services/engine-traits.ts
+++ b/client/src/app/core/services/engine-traits.ts
@@ -7,6 +7,7 @@ import { TvPlatform } from './device.service';
  *
  *  - WEB        — browser web build (Shaka / MSE).
  *  - NATIVE     — Capacitor mobile (ExoPlayer on Android, AVPlayer on iOS).
+ *  - DESKTOP    — Electron desktop client (embedded mpv).
  *  - ANDROID_TV — Android TV box / 10-foot ExoPlayer build.
  *  - TIZEN      — Samsung Smart TV (AVPlay, HLS-only).
  *  - WEBOS      — LG Smart TV (native `<video>`).
@@ -18,6 +19,7 @@ import { TvPlatform } from './device.service';
 export enum EngineKind {
   WEB = 'web',
   NATIVE = 'native',
+  DESKTOP = 'desktop',
   ANDROID_TV = 'androidtv',
   TIZEN = 'tizen',
   WEBOS = 'webos',
@@ -64,6 +66,16 @@ export const ENGINE_TRAITS: Record<EngineKind, EngineTraits> = {
     probesSegZero: false,
     supportsDirectPlay: true,
   },
+  // Embedded mpv: renders behind the UI like NATIVE, but its ffmpeg HLS
+  // demuxer fetches seg-0 on load then seeks (like Shaka), so it needs the
+  // seg-0 early-start companion — otherwise resuming HLS content (e.g. an HDR
+  // transcode) 404s on seg-0 and mpv aborts with an end-file error.
+  [EngineKind.DESKTOP]: {
+    useTsOnSingleAudio: false,
+    supportsHlsSubtitles: true,
+    probesSegZero: true,
+    supportsDirectPlay: true,
+  },
   [EngineKind.ANDROID_TV]: {
     useTsOnSingleAudio: false,
     supportsHlsSubtitles: true,
@@ -90,11 +102,16 @@ export const ENGINE_TRAITS: Record<EngineKind, EngineTraits> = {
 /**
  * Resolve the playback-engine kind from the detected platform and the
  * `isNative` flag (`ServerConfigService.isNative`). A null `tvPlatform`
- * splits into NATIVE (Capacitor mobile) vs WEB (browser) on `isNative`;
- * that split is what `probesSegZero` keys on. CAST is selected explicitly by
- * the Cast player and never resolved through this function.
+ * splits into DESKTOP (Electron + embedded mpv), NATIVE (Capacitor mobile),
+ * or WEB (browser); that split is what `probesSegZero` keys on. CAST is
+ * selected explicitly by the Cast player and never resolved through this
+ * function.
  */
-export function engineKindFor(tvPlatform: TvPlatform, isNative: boolean): EngineKind {
+export function engineKindFor(
+  tvPlatform: TvPlatform,
+  isNative: boolean,
+  isDesktop = false,
+): EngineKind {
   switch (tvPlatform) {
     case 'tizen':
       return EngineKind.TIZEN;
@@ -103,6 +120,9 @@ export function engineKindFor(tvPlatform: TvPlatform, isNative: boolean): Engine
     case 'androidtv':
       return EngineKind.ANDROID_TV;
     default:
+      // Desktop is also `isNative` (the Electron UA matches), so it must be
+      // checked first.
+      if (isDesktop) return EngineKind.DESKTOP;
       return isNative ? EngineKind.NATIVE : EngineKind.WEB;
   }
 }

--- a/client/src/app/core/services/playback-engine/desktop-engine.ts
+++ b/client/src/app/core/services/playback-engine/desktop-engine.ts
@@ -1,0 +1,361 @@
+import {
+  AbstractPlaybackEngine,
+  type PlaybackEngine,
+  type AudioTrack,
+  type EngineStats,
+  type PlaybackState,
+} from './playback-engine';
+import {
+  NATIVE_SUBTITLE_SIZE_SCALE,
+  SUBTITLE_FG_HEX,
+  SUBTITLE_BG_ARGB,
+  SUBTITLE_EDGE_KEY,
+} from '../../utils/subtitle-presets';
+import { normalizeLangCode } from '../../utils/language.utils';
+import {
+  desktopBridge,
+  type DesktopEvent,
+  type DesktopSubtitleTrack,
+  type FliksDesktopApi,
+} from '../../plugins/desktop-player.bridge';
+
+/**
+ * PlaybackEngine backed by the Electron desktop shell's embedded mpv player
+ * (window.fliksDesktop). mpv renders into a window behind the transparent UI —
+ * the same model as NativeEngine on mobile, so this mirrors that engine: the
+ * desktop bridge replaces the Capacitor NativePlayer plugin, and mpv's event
+ * stream replaces the native window CustomEvents.
+ */
+export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEngine {
+  private readonly bridge: FliksDesktopApi = desktopBridge();
+  private unsubscribe: (() => void) | null = null;
+
+  private _currentTime = 0;
+  private _duration = 0;
+  private _buffered = 0;
+  private _paused = true;
+  private _playbackRate = 1;
+  private _volume = 1;
+  private _muted = false;
+  private _state: PlaybackState = 'idle';
+  private _audioTracks: AudioTrack[] = [];
+
+  private firstFrameEmitted = false;
+  private recoveryAttempted = false;
+  /** Set in destroy() so a leaked late event (the mpv player is a persistent
+   *  singleton) can't drive a torn-down engine into recovery. */
+  private dead = false;
+
+  private _initialized = false;
+
+  // ── Subtitles ──
+  // mpv renders subtitles in its own pipeline; selection is by (language,
+  // forced) against the track list mpv reports, mirroring NativeEngine.
+  private _activeTrackId: string | null = null;
+  private _desiredSubtitle: { language: string; forced: boolean; embIndex: number | null } | null = null;
+  private _nativeSubtitleTracks: DesktopSubtitleTrack[] = [];
+  /** mpv's own audio track ids, indexed parallel to the `audio-<i>` ids the
+   *  player expects (mpv ids are bare ints; the player keys off the prefix). */
+  private _mpvAudioIds: string[] = [];
+  private _fullscreen = false;
+
+  private _subtitleStyle: {
+    fontScale: number;
+    foregroundColor: string;
+    backgroundColor: string;
+    edgeType: string;
+    bottomMarginPercent: number;
+  } | null = null;
+
+  // ── Lifecycle ──
+
+  async init(_container: HTMLElement): Promise<void> {
+    // The video window + mpv already exist in the Electron main process; just
+    // wire the event stream (and re-apply any style set before init).
+    this.subscribe();
+    this._initialized = true;
+    if (this._subtitleStyle) {
+      this.bridge.setSubtitleStyle(this._subtitleStyle).catch(() => {});
+    }
+  }
+
+  async destroy(): Promise<void> {
+    this.dead = true;
+    this._initialized = false;
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this._activeTrackId = null;
+    this.clearHandlers();
+    await this.bridge.stop().catch(() => {});
+  }
+
+  async load(
+    url: string,
+    startTime?: number,
+    _mimeType?: string,
+    headers?: Record<string, string>,
+  ): Promise<void> {
+    this.firstFrameEmitted = false;
+    this.recoveryAttempted = false;
+    await this.bridge.load({ url, startTime, headers });
+    if (this._subtitleStyle) {
+      await this.bridge.setSubtitleStyle(this._subtitleStyle);
+    }
+    // Fresh media → fresh track ids; let the desired selection re-apply once
+    // mpv reports the new track list (tracksChanged).
+    this._activeTrackId = null;
+    this._nativeSubtitleTracks = [];
+  }
+
+  async unload(): Promise<void> {
+    await this.bridge.stop();
+    this._state = 'idle';
+    this._currentTime = 0;
+    this._duration = 0;
+  }
+
+  // ── Playback ──
+
+  async play(): Promise<void> {
+    await this.bridge.play();
+    this._paused = false;
+  }
+
+  async pause(): Promise<void> {
+    await this.bridge.pause();
+    this._paused = true;
+  }
+
+  async seek(position: number): Promise<void> {
+    await this.bridge.seek(position);
+    this._currentTime = position;
+  }
+
+  // ── State ──
+
+  get currentTime(): number {
+    return this._currentTime;
+  }
+  get duration(): number {
+    return this._duration;
+  }
+  get paused(): boolean {
+    return this._paused;
+  }
+  get buffered(): number {
+    return this._buffered;
+  }
+  get playbackRate(): number {
+    return this._playbackRate;
+  }
+  set playbackRate(rate: number) {
+    this._playbackRate = rate;
+    this.bridge.setPlaybackRate(rate).catch(() => {});
+  }
+
+  // Desktop has an in-app volume control (unlike mobile, which defers to the
+  // OS slider): drive mpv's volume/mute directly.
+  get volume(): number {
+    return this._volume;
+  }
+  set volume(v: number) {
+    this._volume = v;
+    this.bridge.setVolume(Math.round(v * 100)).catch(() => {});
+  }
+  get muted(): boolean {
+    return this._muted;
+  }
+  set muted(m: boolean) {
+    this._muted = m;
+    this.bridge.setMuted(m).catch(() => {});
+  }
+
+  // ── Audio tracks ──
+
+  getAudioTracks(): AudioTrack[] {
+    return this._audioTracks;
+  }
+
+  async selectAudioTrack(id: string): Promise<void> {
+    // The player sends `audio-<i>` ids; translate back to mpv's own aid.
+    const idx = parseInt(id.replace(/^audio-/, ''), 10);
+    const mpvId = this._mpvAudioIds[idx] ?? String(idx + 1);
+    await this.bridge.selectAudioTrack(mpvId);
+  }
+
+  /** Toggle the native (SDL) compositor window fullscreen. */
+  async setFullscreen(enabled: boolean): Promise<void> {
+    this._fullscreen = enabled;
+    await this.bridge.setFullscreen(enabled).catch(() => {});
+  }
+  get fullscreen(): boolean {
+    return this._fullscreen;
+  }
+
+  // ── Subtitles ──
+
+  async addTextTrack(
+    _url: string,
+    language: string,
+    _label: string,
+    forced = false,
+  ): Promise<{ language: string; forced: boolean }> {
+    // Subtitles arrive as HLS SUBTITLES renditions; mpv surfaces them as text
+    // tracks. Return the desired descriptor — selection resolves against the
+    // reported track list (see resolveSubtitle).
+    return { language, forced };
+  }
+
+  selectTextTrack(track: any): void {
+    this._desiredSubtitle =
+      track && typeof track === 'object' && track.language
+        ? { language: track.language, forced: !!track.forced, embIndex: track.embIndex ?? null }
+        : null;
+    this.resolveSubtitle();
+  }
+
+  setTextVisibility(visible: boolean): void {
+    if (!visible) {
+      this._desiredSubtitle = null;
+      this._activeTrackId = null;
+      this.bridge.selectSubtitleTrack(null).catch(() => {});
+    }
+  }
+
+  private resolveSubtitle(): void {
+    if (!this._desiredSubtitle) return;
+    const { language, forced, embIndex } = this._desiredSubtitle;
+    const want = normalizeLangCode(language);
+    const tracks = this._nativeSubtitleTracks;
+    // (lang+forced) → lang → the picked ordinal (embedded subs often report
+    // lang "und") → first track, so a deliberate pick is never silently dropped.
+    const match =
+      tracks.find((t) => normalizeLangCode(t.language) === want && !!t.forced === !!forced) ??
+      tracks.find((t) => normalizeLangCode(t.language) === want) ??
+      (embIndex != null ? tracks[embIndex] : undefined) ??
+      (tracks.length ? tracks[0] : undefined);
+    const selectedId = match?.id ?? null;
+    if (selectedId) {
+      this._activeTrackId = selectedId;
+      this.bridge.selectSubtitleTrack(selectedId).catch(() => {});
+    }
+  }
+
+  /** Match NativeEngine.setSubtitleStyle: maps the player's preset keys to the
+   *  native style payload and pushes it to mpv. */
+  setSubtitleStyle(settings: {
+    size: string;
+    color: string;
+    shadow: string;
+    background: string;
+    bottomMargin: number;
+  }): void {
+    this._subtitleStyle = {
+      fontScale: NATIVE_SUBTITLE_SIZE_SCALE[settings.size] ?? 1.0,
+      foregroundColor: SUBTITLE_FG_HEX[settings.color] ?? '#FFFFFF',
+      backgroundColor: SUBTITLE_BG_ARGB[settings.background] ?? 'transparent',
+      edgeType: SUBTITLE_EDGE_KEY[settings.shadow] ?? 'drop_shadow',
+      bottomMarginPercent: settings.bottomMargin,
+    };
+    if (this._initialized) {
+      this.bridge.setSubtitleStyle(this._subtitleStyle).catch(() => {});
+    }
+  }
+
+  // ── Stats ──
+
+  getStats(): EngineStats {
+    return { droppedFrames: 0 };
+  }
+
+  // ── Quality ──
+  // mpv handles ABR over the HLS master internally; the backend ladder already
+  // bounds the rungs, so variant pinning is a no-op here (kept for the
+  // PlaybackEngine contract).
+  getVariantTracks(): any[] {
+    return [];
+  }
+  selectVariantTrack(_track: any, _clearBuffer?: boolean): void {
+    /* mpv-driven ABR */
+  }
+  configure(_config: any): void {
+    /* mpv-driven ABR */
+  }
+
+  // ── Event bridge ──
+
+  private subscribe(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = this.bridge.on((event) => this.onEvent(event));
+  }
+
+  private onEvent(event: DesktopEvent): void {
+    if (this.dead) return;
+    switch (event.type) {
+      case 'stateChanged': {
+        const state = event.payload.state;
+        this._state = state;
+        this._paused = state === 'paused' || state === 'idle';
+        this.emit('stateChanged', { state });
+        if (state === 'ended') this.emit('ended', undefined);
+        break;
+      }
+      case 'timeUpdate': {
+        const d = event.payload;
+        this._currentTime = d.position;
+        this._duration = d.duration;
+        this._buffered = d.buffered;
+        this.emit('timeUpdate', d);
+        // firstFrame is driven by mpv's authoritative 'playback-restart' (the
+        // 'firstFrame' case). Deriving it from a position delta mis-fires on a
+        // stale time-pos the persistent mpv replays after a reopen, which would
+        // flip a fresh engine into the sessionExpired recovery path.
+        break;
+      }
+      case 'tracksChanged': {
+        const raw = event.payload.audioTracks ?? [];
+        // Emit the `audio-<i>` id contract the player keys off; keep mpv's real
+        // ids for selectAudioTrack to map back.
+        this._mpvAudioIds = raw.map((t) => t.id);
+        this._audioTracks = raw.map((t, i) => ({
+          id: `audio-${i}`,
+          language: t.language,
+          label: t.label,
+          selected: !!t.selected,
+        }));
+        this.emit('audioTracksChanged', { tracks: this._audioTracks });
+        this._nativeSubtitleTracks = event.payload.subtitleTracks ?? [];
+        this.resolveSubtitle();
+        break;
+      }
+      case 'firstFrame': {
+        if (this.firstFrameEmitted) return;
+        this.firstFrameEmitted = true;
+        this.emit('firstFrame', undefined);
+        // The persistent mpv may not fire a pause-property change on a fresh
+        // load (it was already unpaused from a prior session), so the UI's
+        // paused signal would stay stuck on its default. Assert the playing
+        // state once frames start flowing so the controls show pause, not play.
+        this._paused = false;
+        this._state = 'playing';
+        this.emit('stateChanged', { state: 'playing' });
+        break;
+      }
+      case 'error': {
+        // mpv can't expose the failing segment's HTTP status either; mirror the
+        // native heuristic — first error after a frame played → try one
+        // session-expired recovery before surfacing a fatal error.
+        if (this.firstFrameEmitted && !this.recoveryAttempted) {
+          this.recoveryAttempted = true;
+          this.emit('sessionExpired', undefined);
+          return;
+        }
+        this._state = 'error';
+        this.emit('error', event.payload);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+}

--- a/client/src/app/core/services/playback-engine/playback-engine.ts
+++ b/client/src/app/core/services/playback-engine/playback-engine.ts
@@ -14,6 +14,7 @@ export interface AudioTrack {
   id: string;
   language: string;
   label: string;
+  selected?: boolean;
 }
 
 export interface SubtitleTrack {

--- a/client/src/app/core/services/server-config.service.ts
+++ b/client/src/app/core/services/server-config.service.ts
@@ -26,11 +26,11 @@ export class ServerConfigService {
   readonly knownServers = this._knownServers.asReadonly();
   readonly isConfigured = computed(() => this._serverUrl().length > 0);
   /** "Native" = the app runs standalone, with no backend host serving its
-   * shell — true for Capacitor (iOS/Android), Smart TV (Tizen/webOS) and
-   * any other bundle loaded via `file://`. The bundle is responsible for
-   * resolving every `/api/...` request against a server URL the user
-   * picked at setup. Web builds (served by the backend) keep relative
-   * URLs and have `isNative = false`.
+   * shell — true for Capacitor (iOS/Android), Smart TV (Tizen/webOS), the
+   * Electron desktop client and any other bundle loaded from a non-HTTP
+   * origin. The bundle is responsible for resolving every `/api/...` request
+   * against a server URL the user picked at setup. Web builds (served by the
+   * backend) keep relative URLs and have `isNative = false`.
    * Plain boolean so the dozens of existing `if (serverConfig.isNative)`
    * call sites stay non-reactive; computed from the UA at construction
    * time rather than via `DeviceService.isTv()` to avoid a circular
@@ -39,7 +39,7 @@ export class ServerConfigService {
     if (Capacitor.isNativePlatform()) return true;
     if (typeof navigator === 'undefined') return false;
     const ua = navigator.userAgent;
-    return /AndroidTV\/\d|\bTizen\b|SMART-TV|Web0S|webOS|BRAVIA|SHIELD|AFT[A-Z0-9]+|GoogleTV/i.test(ua);
+    return /AndroidTV\/\d|\bTizen\b|SMART-TV|Web0S|webOS|BRAVIA|SHIELD|AFT[A-Z0-9]+|GoogleTV|\bElectron\//i.test(ua);
   })();
   /** @deprecated Same as `isNative` since Smart TV got folded in.
    *  Kept as a signal alias for call sites still using it. */

--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -492,7 +492,7 @@
      plugin already runs the WebView fullscreen). `size` is one of
      'sm' | 'md'; defaults to 'md'. -->
 <ng-template #fullscreenBtn let-size>
-  @if (!isNative()) {
+  @if (!isNative() || isDesktop()) {
     @let isSm = size === 'sm';
     <button
       type="button"

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -187,6 +187,9 @@ export class PlayerControlsComponent {
   readonly hasPrevEpisode = input(false);
   readonly activeQualityLabel = input('Auto');
   readonly isNative = input(false);
+  /** Desktop (Electron) — native engine but mouse-driven; keeps the fullscreen
+   *  button which is otherwise hidden for native (mobile/TV) engines. */
+  readonly isDesktop = input(false);
   readonly subtitlePickerOpen = input(false);
   readonly qualityPickerOpen = input(false);
   readonly availableSubtitles = input<{ id: string; label: string; burnIn?: boolean }[]>([]);

--- a/client/src/app/features/player/player.html
+++ b/client/src/app/features/player/player.html
@@ -5,7 +5,7 @@
   [class.hide-cursor]="!controlsVisible()"
   [class.native-player]="!!nativeEngine"
   [class.hidden]="castService.isConnected()"
-  (mousemove)="device.isTouch() || isNative ? null : showControls()"
+  (mousemove)="device.isTouch() || device.isDpad() ? null : showControls()"
 >
   <!-- Backdrop until video renders its first frame. Rendered for both
        web (Shaka) and native (ExoPlayer) — on native the WebView is
@@ -106,6 +106,7 @@
     [hasPrevEpisode]="false"
     [activeQualityLabel]="activeQualityLabel()"
     [isNative]="isNative"
+    [isDesktop]="isDesktopNative"
     (togglePlay)="onTogglePlay()"
     (tapOverlay)="toggleControls()"
     (seek)="onSeek($event)"

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -48,6 +48,7 @@ import { TizenEngine, isTizenAvplayAvailable } from '../../core/services/playbac
 import { WebOsEngine } from '../../core/services/playback-engine/webos-engine';
 import { NativePlayer } from '../../core/plugins/native-player.plugin';
 import { NativeEngine } from '../../core/services/playback-engine/native-engine';
+import { DesktopEngine } from '../../core/services/playback-engine/desktop-engine';
 import { PlayerStateService } from '../../core/services/player-state.service';
 import { TrackManagerService, SubtitleOption } from '../../core/services/track-manager.service';
 import { QualityManagerService } from '../../core/services/quality-manager.service';
@@ -196,6 +197,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
    *  (HW HEVC/AV1, Dolby, HDR, native HLS) — a regular in-WebView element,
    *  so it groups with the Shaka UX, not the transparent-plane native one. */
   readonly isWebOs = this.device.tvPlatform() === 'webos';
+  /** Native desktop shell (Electron + embedded mpv). Plays through the
+   *  DesktopEngine — same transparent-overlay UX as the Capacitor native
+   *  engine, with mpv behind the UI instead of ExoPlayer/AVPlayer. */
+  readonly isDesktopNative = this.device.desktopPlatform() === 'electron';
 
   /** Template binding — true when using native (ExoPlayer/AVPlayer) engine. */
   get nativeEngine(): boolean {
@@ -998,17 +1003,19 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
           // complete duplicate — it skipped visibility / burn-in handling).
           const subs = await tvSubsPromise;
           this.availableSubtitles.set(subs);
-        } else if (this.isNative) {
-          // Subtitles arrive as HLS SUBTITLES renditions in the master
-          // playlist, so the ExoPlayer MediaItem doesn't depend on this
-          // fetch. Run it in parallel and resolve it after load() (like the
-          // Shaka path below) — awaiting it before load() only adds a network
-          // round-trip to the time-to-first-frame critical path.
+        } else if (this.isDesktopNative || this.isNative) {
+          // Native player path (Electron+mpv on desktop, ExoPlayer/AVPlayer on
+          // Capacitor mobile). Subtitles arrive as HLS SUBTITLES renditions in
+          // the master playlist, so the player doesn't depend on this fetch.
+          // Run it in parallel and resolve it after load() (like the Shaka path
+          // below) — awaiting it before load() only adds a network round-trip
+          // to the time-to-first-frame critical path.
           subsPromise = this.trackManager.loadSubtitles(
             this.mediaId, this.mediaFileId, this.streamingApi, this.media,
           );
 
-          await this.createNativeEngine();
+          if (this.isDesktopNative) await this.createDesktopEngine();
+          else await this.createNativeEngine();
 
           this.applyNativeSubtitleStyle();
 
@@ -1186,14 +1193,14 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       // during load(). Force the player UI back into a visible-DOM state
       // so the user can read what blew up instead of staring at the
       // pre-paint bg-base-200 plane.
-      if (this.isTizenEngine() && this.engine) {
+      if ((this.isTizenEngine() || this.isDesktopNative || this.isNativeEngine()) && this.engine) {
         document.documentElement.classList.remove('native-player-active');
         const video = this.videoEl()?.nativeElement;
         if (video) video.style.display = '';
         try {
           await this.engine.destroy();
         } catch {
-          /* AVPlay state may already be torn down — fine */
+          /* engine state may already be torn down — fine */
         }
         this.engine = null;
         this.isTizenEngine.set(false);
@@ -1368,32 +1375,50 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // Force transparent background so native player shows through
     document.documentElement.classList.add('native-player-active');
 
+    this.wireNativePlayerEngine(engine);
+  }
+
+  private async createDesktopEngine(): Promise<void> {
+    const video = this.videoEl()!.nativeElement;
+    video.style.display = 'none';
+
+    const engine = new DesktopEngine();
+    const container = this.containerEl()?.nativeElement ?? video.parentElement!;
+    await engine.init(container);
+
+    // Transparent page above the mpv video window — same hook the Capacitor
+    // native engine uses to show the hardware surface through the WebView.
+    document.documentElement.classList.add('native-player-active');
+
+    this.wireNativePlayerEngine(engine);
+  }
+
+  /** Shared wiring for the transparent-overlay native engines (Capacitor
+   *  ExoPlayer/AVPlayer and Electron mpv): bind state, surface the first
+   *  frame, arm session-expired recovery, and reconcile the audio-track list
+   *  against the backend streamInfo so labels match the media-detail header. */
+  private wireNativePlayerEngine(engine: PlaybackEngine): void {
     this.engine = engine;
     this.isNativeEngine.set(true);
     this.state.bindEngine(engine);
 
-    // videoStarted flips on the engine 'firstFrame' event (forwarded from
-    // ExoPlayer.Listener.onRenderedFirstFrame via the native plugin), so
-    // the spinner+fanart stay until the surface is actually painting. No
-    // separate stateChanged 'playing' hook needed — that fires on
-    // STATE_READY which can precede the first frame on cold starts.
+    // videoStarted flips on the engine 'firstFrame' event so the
+    // spinner+fanart stay until the surface is actually painting. No separate
+    // stateChanged 'playing' hook needed — that can precede the first frame.
     engine.on('firstFrame', () => {
       this.state.videoStarted.set(true);
     });
     this.wireSessionExpiredRecovery(engine);
 
-    // Listen for audio tracks from native engine.
-    // ExoPlayer may emit this multiple times (e.g. rendition switch) —
-    // never overwrite a good list with a smaller one. BUT: always let
+    // Engine audio tracks may emit multiple times (e.g. rendition switch) —
+    // never overwrite a good list with a smaller one. BUT always let
     // engine-sourced tracks (audio-* / shaka-*) replace the streamInfo
     // fallback (si-*), even at equal length — their IDs enable client-side
     // PID switching instead of a full backend reload.
     engine.on('audioTracksChanged', (e) => {
       // Cross-reference engine tracks with streamInfo.audio so the dropdown
-      // label matches what the media-detail header shows (e.g.
-      // "Français (EAC3 - 5.1)" instead of Shaka's raw "fre" / "English (eng)").
-      // Engine emits tracks in streamInfo order — see comment at the
-      // streamInfo-fallback branch below.
+      // label matches what the media-detail header shows. Engine emits tracks
+      // in streamInfo order.
       const file = this.media?.files?.find((f: any) => f.id === this.mediaFileId);
       const audioList = (file?.streamInfo as any)?.audio ?? [];
       const tracks = e.tracks.map((t: any, i: number) => ({
@@ -1409,13 +1434,11 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       const existingIsFallback =
         existing.length > 0 && existing[0].id.startsWith('si-');
       // Upgrade ONLY when incoming has at least as many tracks as existing —
-      // otherwise a transient partial emission (e.g. 1 audio track during
-      // ExoPlayer's initial parse) would wipe the full 3-track si-* list.
+      // otherwise a transient partial emission would wipe the full si-* list.
       const upgradeFromFallback =
         newIsEngineSourced && existingIsFallback && tracks.length >= existing.length;
       if (tracks.length <= existing.length && !upgradeFromFallback) return;
       this.availableAudioTracks.set(tracks);
-      // Use the track ExoPlayer reports as selected, fallback to first
       const selected = tracks.find((t: any) => t.selected) ?? tracks[0];
       this.activeAudioTrackId.set(selected.id);
       this.trackManager.autoSelectAudioTrack(
@@ -1756,6 +1779,12 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   }
 
   onToggleFullscreen() {
+    // Desktop compositor: the visible surface is the native (SDL) window owned
+    // by the addon, not this offscreen WebView, so toggle fullscreen there.
+    if (this.isDesktopNative && this.engine instanceof DesktopEngine) {
+      this.engine.setFullscreen(!this.engine.fullscreen);
+      return;
+    }
     // iOS Safari rejects the standard Fullscreen API on arbitrary elements
     // (and `document.fullscreenEnabled` is false). The only path to a
     // fullscreen video there is the legacy `webkitEnterFullscreen` on the
@@ -2168,6 +2197,12 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
   onBack() {
     this.savePosition();
+    // Desktop compositor: leaving the player drops the native (SDL) window out
+    // of fullscreen so the rest of the app isn't stuck fullscreen. Episode
+    // switches route through goToNextEpisode(), not onBack(), so they keep it.
+    if (this.isDesktopNative && this.engine instanceof DesktopEngine && this.engine.fullscreen) {
+      this.engine.setFullscreen(false);
+    }
     // Explicit navigation rather than history.back() — nav-inside-player
     // (e.g. next-episode) leaves multiple /watch entries on the stack, and
     // router-reuse across same routes means history.back() only rewrites
@@ -2452,7 +2487,11 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         if (!this.isOfflinePlayback) await this.reloadStream();
       }
       const track = await this.engine.addTextTrack(sub.url, sub.language, sub.label, sub.forced);
-      this.engine.selectTextTrack(track);
+      this.engine.selectTextTrack({
+        ...track,
+        id: sub.id,
+        embIndex: sub.id.startsWith('emb-') ? Number(sub.id.slice(4)) : null,
+      });
       try { this.engine.setTextVisibility(true); } catch {}
     } catch (e) {
       console.error('[Player] Failed to load subtitle:', e);

--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+release/
+vendor/
+*.log

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1,0 +1,147 @@
+# Fliks desktop client (Linux) — rebuild / run / test
+
+Native desktop client (macOS/Windows/Linux target; Linux is the dev platform).
+A **thin client**: it connects to a remote Fliks server like the mobile apps —
+it is NOT the menu-bar server host under `macos/`.
+
+## Architecture (why the build has three parts)
+
+- **Electron** loads the Angular client **offscreen** (`offscreen: true,
+  transparent: true`) and paints it to a BGRA bitmap.
+- A **native N-API addon** (`native/compositor/addon.cc`, SDL2 + GLES 3.2) owns
+  the single visible window. It composites **mpv video** (rendered into a GL FBO
+  via libmpv's render API) under the **Angular UI bitmap**.
+- Embedded **mpv** comes from a self-contained static **libmpv** (render API).
+- This single-window compositor is the only model that works under **Mutter/X11**:
+  an embedded mpv child window can't be composited beneath a sibling transparent
+  overlay there, so we composite ourselves.
+- Consequence: **HDR is SDR-tonemapped on Linux** (render API uses `vo_gpu`, not
+  gpu-next). Video plays; it just isn't true-HDR on screen.
+
+The three buildable units: **native addon** (C++), **main/preload bundle**
+(esbuild), **Angular client** (`../client`).
+
+## Dependencies (first-time setup)
+
+System packages (Debian/Ubuntu) — the C++ addon compiles against these via
+`pkg-config` and node-gyp needs a C++17 toolchain:
+```bash
+sudo apt install -y build-essential python3 pkg-config \
+  libsdl2-dev libgles2-mesa-dev libegl1-mesa-dev libmpv-dev
+```
+- `build-essential` + `python3` → node-gyp.
+- `pkg-config` + `libsdl2-dev` + `libgles2-mesa-dev` + `libegl1-mesa-dev` →
+  the addon links SDL2 / GLESv2 / EGL.
+- `libmpv-dev` → addon **compiles** against mpv's headers (`client.h`,
+  `render_gl.h`). Runtime uses the vendored self-contained libmpv below, not the
+  system one.
+
+Node packages (Node ≥ 20):
+```bash
+cd desktop && npm install
+```
+
+## Prerequisite: vendored libmpv (gitignored)
+
+`native/vendor/libmpv.so.2` is required but **not in git** (`vendor/` is ignored;
+it's a ~38 MB binary). It must be a *self-contained static* libmpv with hidden
+FFmpeg symbols, or Electron's bundled `libffmpeg.so` (libav 58) clashes with
+libmpv's libav 60 and crashes (`free(): invalid pointer` / abort).
+
+Kill-switch check — this MUST print nothing:
+```bash
+nm -D native/vendor/libmpv.so.2 | grep ' av_'
+```
+If the file is missing, rebuild/obtain it before anything else. Override its path
+with `FLIKS_MPV_PATH`.
+
+## Build
+
+Run from the repo root unless noted. Use **absolute paths** or `cd` inside one
+compound command (a bare `cd` between tool calls can prompt for permission).
+
+1. **Native addon** (after editing `native/compositor/addon.cc` or `binding.gyp`).
+   Targets the Electron 42 ABI:
+   ```bash
+   cd desktop/native && ../node_modules/.bin/node-gyp rebuild \
+     --target=42.4.0 --dist-url=https://electronjs.org/headers --arch=x64
+   ```
+   Output: `native/build/Release/fliks_compositor.node`.
+
+2. **Main + preload bundle** (after editing `src/main/**` or `src/preload/**`):
+   ```bash
+   cd desktop && npm run build      # esbuild → dist/main/index.cjs + dist/preload/index.cjs
+   # or just the main bundle: npm run build:main
+   ```
+
+3. **Angular client** (after editing `../client/**`):
+   ```bash
+   cd client && npx ng build --configuration=development
+   ```
+   - `--output-path` is overridden by `angular.json`; output always lands in
+     `client/dist/client/browser`.
+   - `client/dist/` has root-owned PWA assets (EACCES on overwrite), so the
+     desktop app reads from a `/tmp` copy instead. After every client build:
+     ```bash
+     rm -rf /tmp/fliks-verify/browser && mkdir -p /tmp/fliks-verify/browser \
+       && cp -r client/dist/client/browser/. /tmp/fliks-verify/browser/
+     ```
+
+**What to rebuild for a given edit:** addon.cc → step 1. `src/main`/`src/preload`
+→ step 2. `client/**` → step 3 (+ the `/tmp` sync). Only the changed unit needs
+rebuilding; the addon is reloaded fresh on each Electron start.
+
+## Run
+
+From `desktop/` (Electron resolves `.` and `node_modules` there):
+```bash
+cd desktop && FLIKS_WEB_DIR=/tmp/fliks-verify/browser DISPLAY=:0 \
+  ./node_modules/.bin/electron . --no-sandbox
+```
+Launch it as a **background task** so its stdout (logs) accumulates and you keep
+working. `app.disableHardwareAcceleration()` is set: Chromium's GPU process
+can't init on this box, so OSR uses CPU readback.
+
+### Env vars
+
+| var | default | purpose |
+|-----|---------|---------|
+| `FLIKS_WEB_DIR` | packaged `web/` | dir of the built Angular `index.html` |
+| `FLIKS_MPV_PATH` | `native/vendor/libmpv.so.2` | self-contained libmpv |
+| `FLIKS_HWDEC` | `no` | mpv `hwdec` (e.g. `auto-copy`) |
+| `FLIKS_MPV_LOGLEVEL` | `v` | libmpv log level (`warn` to quiet, `debug` for more) |
+
+## Process management
+
+Kill by **comm name**, never by `-f` path (that also matches your own shells):
+```bash
+pkill -x electron        # NOT  pkill -f .../desktop
+```
+
+## Logs (in the Electron stdout)
+
+- `[compositor]` — native addon (GL/mpv init, fullscreen, resize).
+- `[mpv]` — libmpv (verbose: every HLS segment URL + HTTP status; decode/render).
+- `[renderer]` — Angular console.
+- `[ipc]` / `[input]` — main process (load URLs, SDL input forwarding).
+
+## Testing against a backend
+
+- The server URL is chosen **in-app** on the native server-setup screen. Point it
+  at a local backend or prod there.
+- **Local backend** for backend iteration: docker `fliks-backend-1` on
+  `localhost:3001`, bind-mounts `backend/src`, runs `npm run start:dev` (NestJS
+  watch → edits hot-reload; watch for `Found 0 errors` / `Nest application
+  successfully started`). JWT secret `change-me-in-production`, 7-day expiry.
+- Prod (`fliks.delestre.me`) is a different machine — you can't inspect its files.
+
+## Known constraints / gotchas
+
+- **HDR** → SDR tonemap only (see Architecture). Expected, not a bug.
+- **Resume into a transcode** (seek to a high segment): the backend produces
+  seg-0/init a beat after the playlist. mpv's ffmpeg HLS demuxer is configured to
+  **reconnect on HTTP 4xx/5xx** (`demuxer-lavf-o` in `addon.cc`) so it retries
+  like Shaka instead of aborting on the first 404/503.
+- `isNative` is true for Electron (the UA matches `\bElectron\/`), so the desktop
+  resolves to the `DESKTOP` engine kind (`client/.../engine-traits.ts`), which
+  sets `probesSegZero: true` (Shaka-like: backend pre-spawns the seg-0 companion).

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,0 +1,71 @@
+# Fliks desktop client
+
+Native desktop client for macOS / Windows / Linux. A **thin client** that
+connects to a remote Fliks server like the mobile apps (not the menu-bar server
+host under `macos/`). Linux is the current dev platform.
+
+## Architecture
+
+```
+Electron main
+  ├─ OSR BrowserWindow (offscreen, transparent)  → built Angular app, painted to a BGRA bitmap
+  └─ native addon (SDL2 + GLES 3.2)              → the single visible window:
+        mpv video (libmpv render API → GL FBO)  composited under  the Angular UI bitmap
+```
+
+- `native/compositor/addon.cc` — owns the visible SDL/GLES window; runs mpv via
+  the **render API**, uploads the UI bitmap as a GL texture, composites the two,
+  and forwards SDL input + mpv events to the main process (N-API).
+- `src/main/index.ts` — Electron main: the offscreen UI window, loads the addon,
+  routes player IPC (`window.fliksDesktop`) and mpv events to/from the renderer.
+- `src/preload/index.ts` — exposes `window.fliksDesktop`, consumed by the Angular
+  `DesktopEngine` (`client/src/app/core/services/playback-engine/`).
+- `src/main/{protocol,cors}.ts` — `fliks://` SPA protocol + CORS bypass.
+- `src/shared/contract.ts` — the IPC contract.
+
+We composite ourselves (rather than embedding an mpv child window) because under
+**Mutter/X11** an embedded child can't be stacked beneath a sibling transparent
+overlay. mpv runs from a self-contained static **libmpv**, so on Linux HDR is
+**SDR tone-mapped** (render API uses `vo_gpu`).
+
+## Develop
+
+### Dependencies
+
+System packages (Debian/Ubuntu) — for compiling the native addon:
+```bash
+sudo apt install -y build-essential python3 pkg-config \
+  libsdl2-dev libgles2-mesa-dev libegl1-mesa-dev libmpv-dev
+```
+Node packages (Node ≥ 20):
+```bash
+npm install
+```
+A self-contained `native/vendor/libmpv.so.2` is also required at runtime (it is
+gitignored — see `CLAUDE.md`).
+
+### Build & run
+
+```bash
+# 1. native addon (Electron 42 ABI)
+cd native && ../node_modules/.bin/node-gyp rebuild \
+  --target=42.4.0 --dist-url=https://electronjs.org/headers --arch=x64 && cd ..
+
+# 2. main + preload bundle
+npm run build            # → dist/main/index.cjs, dist/preload/index.cjs
+
+# 3. Angular client (from repo root) + copy to a writable dir
+cd ../client && npx ng build --configuration=development && cd ../desktop
+rm -rf /tmp/fliks-verify/browser && mkdir -p /tmp/fliks-verify/browser \
+  && cp -r ../client/dist/client/browser/. /tmp/fliks-verify/browser/
+
+# run (dev box needs --no-sandbox)
+FLIKS_WEB_DIR=/tmp/fliks-verify/browser DISPLAY=:0 \
+  ./node_modules/.bin/electron . --no-sandbox
+
+npm run typecheck        # tsc --noEmit
+```
+
+See **`CLAUDE.md`** for which unit to rebuild per edit, env vars
+(`FLIKS_MPV_PATH`, `FLIKS_HWDEC`, `FLIKS_MPV_LOGLEVEL`), logs, process
+management, and testing against a local backend.

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -1,0 +1,27 @@
+# electron-builder config (seed). Produces one installer per OS from the same
+# Electron app: macOS .dmg, Windows NSIS .exe, Linux AppImage + .deb.
+#
+# The built Angular client and the vendored mpv binary are bundled as extra
+# resources (wired up with the macOS/Windows/Linux packaging milestone).
+appId: media.fliks.desktop
+productName: Fliks
+directories:
+  output: release
+  buildResources: build
+files:
+  - dist/**
+  - src/renderer/**
+extraResources:
+  # Vendored mpv binary per OS lands here (see scripts/fetch-vendored).
+  - from: vendor/${os}
+    to: mpv
+    filter: ['**/*']
+mac:
+  target: [dmg]
+  category: public.app-category.entertainment
+  # Notarization + hardened runtime wired with the signing milestone.
+win:
+  target: [nsis]
+linux:
+  target: [AppImage, deb]
+  category: AudioVideo

--- a/desktop/native/binding.gyp
+++ b/desktop/native/binding.gyp
@@ -1,0 +1,20 @@
+{
+  "targets": [
+    {
+      "target_name": "fliks_compositor",
+      "sources": [
+        "compositor/addon.cc"
+      ],
+      "include_dirs": [
+        "<!@(node -p \"require('node-addon-api').include_dir\")",
+        "<!@(pkg-config --cflags-only-I sdl2 glesv2 egl mpv | sed 's/-I//g')"
+      ],
+      "libraries": [
+        "<!@(pkg-config --libs sdl2 glesv2 egl)",
+        "-ldl"
+      ],
+      "cflags_cc": [ "-std=c++17", "-fexceptions" ],
+      "defines": [ "NAPI_VERSION=8", "NAPI_CPP_EXCEPTIONS" ]
+    }
+  ]
+}

--- a/desktop/native/compositor/addon.cc
+++ b/desktop/native/compositor/addon.cc
@@ -1,0 +1,672 @@
+// fliks_compositor — native single-window GL compositor (Electron+mpv, Option C).
+//
+// One SDL2/GLES window. mpv (self-contained libmpv, plain dlopen — FFmpeg
+// statically linked + symbols hidden, so no clash with Electron's libffmpeg)
+// renders video via the RENDER API into a GL FBO; the Electron OSR UI bitmap is
+// uploaded to a GL texture; both are composited (video then UI, premult-alpha)
+// into the window. Three threads: Node/main (N-API), render (GL ctx), and mpv
+// event poll. mpv FBO + OSR UI are both top-down → flipped in-shader (mpv's
+// FLIP_Y param is unsupported); UI is BGRA → swizzled.
+#define _GNU_SOURCE 1
+#include <napi.h>
+
+#include <SDL.h>
+#include <GLES3/gl32.h>
+
+#include <mpv/client.h>
+#include <mpv/render.h>
+#include <mpv/render_gl.h>
+
+#include <dlfcn.h>
+
+#include <atomic>
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+// ── dlopen'd self-contained libmpv ───────────────────────────────────────────
+namespace M {
+mpv_handle* (*create)(void) = nullptr;
+int (*set_option_string)(mpv_handle*, const char*, const char*) = nullptr;
+int (*set_property_string)(mpv_handle*, const char*, const char*) = nullptr;
+char* (*get_property_string)(mpv_handle*, const char*) = nullptr;
+int (*get_property)(mpv_handle*, const char*, mpv_format, void*) = nullptr;
+int (*observe_property)(mpv_handle*, uint64_t, const char*, mpv_format) = nullptr;
+int (*request_log_messages)(mpv_handle*, const char*) = nullptr;
+void (*mpv_free)(void*) = nullptr;
+int (*initialize)(mpv_handle*) = nullptr;
+int (*command)(mpv_handle*, const char**) = nullptr;
+mpv_event* (*wait_event)(mpv_handle*, double) = nullptr;
+void (*destroy)(mpv_handle*) = nullptr;
+const char* (*error_string)(int) = nullptr;
+int (*rc_create)(mpv_render_context**, mpv_handle*, mpv_render_param*) = nullptr;
+void (*rc_set_update_callback)(mpv_render_context*, mpv_render_update_fn, void*) = nullptr;
+uint64_t (*rc_update)(mpv_render_context*) = nullptr;
+int (*rc_render)(mpv_render_context*, mpv_render_param*) = nullptr;
+void (*rc_report_swap)(mpv_render_context*) = nullptr;
+void (*rc_free)(mpv_render_context*) = nullptr;
+
+bool Load() {
+  if (create) return true;
+  const char* path = getenv("FLIKS_MPV_PATH");
+  if (!path) path = "libmpv.so.2";
+  void* h = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+  if (!h) {
+    fprintf(stderr, "[compositor] dlopen libmpv failed: %s\n", dlerror());
+    return false;
+  }
+  fprintf(stderr, "[compositor] libmpv loaded: %s\n", path);
+#define SYM(field, name)                                     \
+  field = reinterpret_cast<decltype(field)>(dlsym(h, name)); \
+  if (!field) { fprintf(stderr, "[compositor] missing %s\n", name); return false; }
+  SYM(create, "mpv_create")
+  SYM(set_option_string, "mpv_set_option_string")
+  SYM(set_property_string, "mpv_set_property_string")
+  SYM(get_property_string, "mpv_get_property_string")
+  SYM(get_property, "mpv_get_property")
+  SYM(observe_property, "mpv_observe_property")
+  SYM(request_log_messages, "mpv_request_log_messages")
+  SYM(mpv_free, "mpv_free")
+  SYM(initialize, "mpv_initialize")
+  SYM(command, "mpv_command")
+  SYM(wait_event, "mpv_wait_event")
+  SYM(destroy, "mpv_terminate_destroy")
+  SYM(error_string, "mpv_error_string")
+  SYM(rc_create, "mpv_render_context_create")
+  SYM(rc_set_update_callback, "mpv_render_context_set_update_callback")
+  SYM(rc_update, "mpv_render_context_update")
+  SYM(rc_render, "mpv_render_context_render")
+  SYM(rc_report_swap, "mpv_render_context_report_swap")
+  SYM(rc_free, "mpv_render_context_free")
+#undef SYM
+  return true;
+}
+}  // namespace M
+
+// ── thread-safe event marshalling to JS ──────────────────────────────────────
+void CallJs(Napi::Env env, Napi::Function cb, void*, std::string* data) {
+  if (env != nullptr && cb != nullptr) cb.Call({Napi::String::New(env, *data)});
+  delete data;
+}
+using EventTSFN = Napi::TypedThreadSafeFunction<void, std::string, CallJs>;
+EventTSFN g_tsfn;        // mpv events → JS
+EventTSFN g_inputTsfn;   // SDL input → JS (forwarded to the OSR webContents)
+std::atomic<bool> g_tsfnReady{false};
+std::atomic<bool> g_inputReady{false};
+
+struct GlState {
+  SDL_Window* window = nullptr;
+  SDL_GLContext gl = nullptr;
+  int width = 1280;
+  int height = 800;
+  std::string title = "Fliks";
+  std::atomic<bool> run{false};
+  std::atomic<int> fsRequest{-1};  // -1 none, 0 windowed, 1 fullscreen-desktop
+  std::thread renderThread;
+  std::thread eventThread;
+
+  GLuint program = 0;
+  GLuint vao = 0;
+  GLuint uiTex = 0;
+  GLuint videoTex = 0;
+  GLuint videoFbo = 0;
+  int fboW = 0;
+  int fboH = 0;
+
+  std::mutex uiMutex;
+  std::vector<uint8_t> uiPending;
+  int uiW = 0;
+  int uiH = 0;
+  bool uiDirty = false;
+
+  mpv_handle* mpv = nullptr;
+  mpv_render_context* mpvGl = nullptr;
+  double duration = 0;
+};
+
+GlState g_state;
+
+const char* kVert = R"(#version 320 es
+out vec2 v_uv;
+uniform float u_flipY;
+void main() {
+  vec2 p = vec2(float((gl_VertexID & 1) << 2) - 1.0,
+                float((gl_VertexID & 2) << 1) - 1.0);
+  gl_Position = vec4(p, 0.0, 1.0);
+  float ty = p.y * 0.5 + 0.5;
+  v_uv = vec2(p.x * 0.5 + 0.5, (u_flipY > 0.5) ? (1.0 - ty) : ty);
+}
+)";
+
+const char* kFrag = R"(#version 320 es
+precision mediump float;
+in vec2 v_uv;
+uniform sampler2D u_tex;
+uniform int u_bgra;
+out vec4 frag;
+void main() {
+  vec4 c = texture(u_tex, v_uv);
+  frag = (u_bgra == 1) ? c.bgra : c;
+}
+)";
+
+GLuint Compile(GLenum type, const char* src) {
+  GLuint s = glCreateShader(type);
+  glShaderSource(s, 1, &src, nullptr);
+  glCompileShader(s);
+  GLint ok = 0;
+  glGetShaderiv(s, GL_COMPILE_STATUS, &ok);
+  if (!ok) {
+    char log[1024];
+    glGetShaderInfoLog(s, sizeof(log), nullptr, log);
+    fprintf(stderr, "[compositor] shader compile error: %s\n", log);
+  }
+  return s;
+}
+
+GLuint LinkProgram(const char* vs, const char* fs) {
+  GLuint v = Compile(GL_VERTEX_SHADER, vs);
+  GLuint f = Compile(GL_FRAGMENT_SHADER, fs);
+  GLuint p = glCreateProgram();
+  glAttachShader(p, v);
+  glAttachShader(p, f);
+  glLinkProgram(p);
+  glDeleteShader(v);
+  glDeleteShader(f);
+  return p;
+}
+
+void EnsureVideoFbo(GlState* s, int w, int h) {
+  if (s->videoFbo && s->fboW == w && s->fboH == h) return;
+  if (!s->videoTex) glGenTextures(1, &s->videoTex);
+  if (!s->videoFbo) glGenFramebuffers(1, &s->videoFbo);
+  glBindTexture(GL_TEXTURE_2D, s->videoTex);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glBindFramebuffer(GL_FRAMEBUFFER, s->videoFbo);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, s->videoTex, 0);
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+  s->fboW = w;
+  s->fboH = h;
+}
+
+void DrawTex(GlState* s, GLuint tex, float flipY, int bgra) {
+  glUseProgram(s->program);
+  glActiveTexture(GL_TEXTURE0);
+  glBindTexture(GL_TEXTURE_2D, tex);
+  glUniform1i(glGetUniformLocation(s->program, "u_tex"), 0);
+  glUniform1f(glGetUniformLocation(s->program, "u_flipY"), flipY);
+  glUniform1i(glGetUniformLocation(s->program, "u_bgra"), bgra);
+  glBindVertexArray(s->vao);
+  glDrawArrays(GL_TRIANGLES, 0, 3);
+}
+
+void InitGl(GlState* s) {
+  s->program = LinkProgram(kVert, kFrag);
+  glGenVertexArrays(1, &s->vao);
+  glGenTextures(1, &s->uiTex);
+  glBindTexture(GL_TEXTURE_2D, s->uiTex);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+}
+
+void* GetProc(void*, const char* name) { return SDL_GL_GetProcAddress(name); }
+void OnMpvUpdate(void*) { /* continuous render loop polls rc_update */ }
+
+void MpvRenderInit(GlState* s) {
+  if (!s->mpv) return;
+  mpv_opengl_init_params gl_init{};
+  gl_init.get_proc_address = GetProc;
+  gl_init.get_proc_address_ctx = nullptr;
+  int advanced = 1;
+  mpv_render_param params[] = {
+      {MPV_RENDER_PARAM_API_TYPE, const_cast<char*>(MPV_RENDER_API_TYPE_OPENGL)},
+      {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &gl_init},
+      {MPV_RENDER_PARAM_ADVANCED_CONTROL, &advanced},
+      {static_cast<mpv_render_param_type>(0), nullptr},
+  };
+  int rc = M::rc_create(&s->mpvGl, s->mpv, params);
+  if (rc < 0) {
+    fprintf(stderr, "[compositor] rc_create failed: %s\n", M::error_string(rc));
+    return;
+  }
+  M::rc_set_update_callback(s->mpvGl, OnMpvUpdate, s);
+  fprintf(stderr, "[compositor] mpv render context ready\n");
+}
+
+void RenderThreadMain(GlState* s) {
+  if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+    fprintf(stderr, "[compositor] SDL_Init failed: %s\n", SDL_GetError());
+    return;
+  }
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
+  SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+  s->window = SDL_CreateWindow(
+      s->title.c_str(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, s->width,
+      s->height, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_SHOWN);
+  if (!s->window) {
+    fprintf(stderr, "[compositor] SDL_CreateWindow failed: %s\n", SDL_GetError());
+    SDL_Quit();
+    return;
+  }
+  s->gl = SDL_GL_CreateContext(s->window);
+  SDL_GL_MakeCurrent(s->window, s->gl);
+  SDL_GL_SetSwapInterval(1);
+  fprintf(stderr, "[compositor] GL %s | %s\n", glGetString(GL_VERSION), glGetString(GL_RENDERER));
+  SDL_StartTextInput();
+  InitGl(s);
+  MpvRenderInit(s);
+
+  auto emitInput = [](const std::string& j) {
+    if (g_inputReady.load()) g_inputTsfn.BlockingCall(new std::string(j));
+  };
+  char ib[256];
+  int lastW = -1, lastH = -1;
+
+  while (s->run.load(std::memory_order_acquire)) {
+    SDL_Event ev;
+    while (SDL_PollEvent(&ev)) {
+      switch (ev.type) {
+        case SDL_QUIT:
+          s->run.store(false);
+          break;
+        case SDL_MOUSEMOTION:
+          snprintf(ib, sizeof(ib), "{\"kind\":\"move\",\"x\":%d,\"y\":%d}", ev.motion.x, ev.motion.y);
+          emitInput(ib);
+          break;
+        case SDL_MOUSEBUTTONDOWN:
+        case SDL_MOUSEBUTTONUP: {
+          const char* btn = ev.button.button == SDL_BUTTON_RIGHT  ? "right"
+                            : ev.button.button == SDL_BUTTON_MIDDLE ? "middle"
+                                                                    : "left";
+          snprintf(ib, sizeof(ib),
+                   "{\"kind\":\"button\",\"down\":%s,\"x\":%d,\"y\":%d,\"button\":\"%s\",\"clicks\":%d}",
+                   ev.type == SDL_MOUSEBUTTONDOWN ? "true" : "false", ev.button.x, ev.button.y, btn,
+                   ev.button.clicks);
+          emitInput(ib);
+          break;
+        }
+        case SDL_MOUSEWHEEL: {
+          int mx, my;
+          SDL_GetMouseState(&mx, &my);
+          snprintf(ib, sizeof(ib), "{\"kind\":\"wheel\",\"x\":%d,\"y\":%d,\"dx\":%d,\"dy\":%d}", mx,
+                   my, ev.wheel.x, ev.wheel.y);
+          emitInput(ib);
+          break;
+        }
+        case SDL_KEYDOWN:
+        case SDL_KEYUP: {
+          snprintf(ib, sizeof(ib), "{\"kind\":\"key\",\"down\":%s,\"key\":\"%s\"}",
+                   ev.type == SDL_KEYDOWN ? "true" : "false", SDL_GetKeyName(ev.key.keysym.sym));
+          emitInput(ib);
+          break;
+        }
+        case SDL_TEXTINPUT: {
+          // escape the text minimally for JSON
+          std::string t = ev.text.text;
+          std::string esc;
+          for (char c : t) {
+            if (c == '"' || c == '\\') esc += '\\';
+            esc += c;
+          }
+          emitInput("{\"kind\":\"text\",\"text\":\"" + esc + "\"}");
+          break;
+        }
+        default:
+          break;
+      }
+    }
+    int fs = s->fsRequest.exchange(-1, std::memory_order_acq_rel);
+    if (fs >= 0)
+      SDL_SetWindowFullscreen(s->window, fs == 1 ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
+
+    int w, h;
+    SDL_GL_GetDrawableSize(s->window, &w, &h);
+    if (w != lastW || h != lastH) {
+      lastW = w;
+      lastH = h;
+      snprintf(ib, sizeof(ib), "{\"kind\":\"resize\",\"w\":%d,\"h\":%d}", w, h);
+      emitInput(ib);
+    }
+    EnsureVideoFbo(s, w, h);
+
+    if (s->mpvGl) {
+      uint64_t flags = M::rc_update(s->mpvGl);
+      if (flags & MPV_RENDER_UPDATE_FRAME) {
+        mpv_opengl_fbo fbo{static_cast<int>(s->videoFbo), w, h, 0};
+        mpv_render_param rp[] = {
+            {MPV_RENDER_PARAM_OPENGL_FBO, &fbo},
+            {static_cast<mpv_render_param_type>(0), nullptr},
+        };
+        M::rc_render(s->mpvGl, rp);
+      }
+    }
+
+    {
+      std::lock_guard<std::mutex> lk(s->uiMutex);
+      if (s->uiDirty && !s->uiPending.empty()) {
+        glBindTexture(GL_TEXTURE_2D, s->uiTex);
+        glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, s->uiW, s->uiH, 0, GL_RGBA,
+                     GL_UNSIGNED_BYTE, s->uiPending.data());
+        s->uiDirty = false;
+      }
+    }
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glViewport(0, 0, w, h);
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glDisable(GL_BLEND);
+    DrawTex(s, s->videoTex, /*flipY=*/1.0f, /*bgra=*/0);  // mpv render-API FBO is top-down
+    if (s->uiW > 0) {
+      glEnable(GL_BLEND);
+      glBlendFuncSeparate(GL_ONE, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+      DrawTex(s, s->uiTex, /*flipY=*/1.0f, /*bgra=*/1);
+      glDisable(GL_BLEND);
+    }
+    SDL_GL_SwapWindow(s->window);
+    if (s->mpvGl) M::rc_report_swap(s->mpvGl);
+  }
+
+  if (s->mpvGl) {
+    M::rc_free(s->mpvGl);  // free render context ON the render thread
+    s->mpvGl = nullptr;
+  }
+  SDL_GL_DeleteContext(s->gl);
+  SDL_DestroyWindow(s->window);
+  SDL_Quit();
+  s->gl = nullptr;
+  s->window = nullptr;
+}
+
+void Emit(const std::string& json) {
+  if (g_tsfnReady.load()) g_tsfn.BlockingCall(new std::string(json));
+}
+
+void EventThreadMain(GlState* s) {
+  char buf[64];
+  while (s->run.load(std::memory_order_acquire)) {
+    mpv_event* ev = M::wait_event(s->mpv, 0.1);
+    if (!ev || ev->event_id == MPV_EVENT_NONE) continue;
+    switch (ev->event_id) {
+      case MPV_EVENT_PROPERTY_CHANGE: {
+        auto* p = static_cast<mpv_event_property*>(ev->data);
+        if (!p) break;
+        // track-list is observed with MPV_FORMAT_NONE, so its change event
+        // carries no data — handle it before the data guard the value-bearing
+        // properties need.
+        if (std::strcmp(p->name, "track-list") == 0) {
+          Emit("{\"type\":\"tracksChanged\"}");
+          break;
+        }
+        if (!p->data) break;
+        if (std::strcmp(p->name, "time-pos") == 0 && p->format == MPV_FORMAT_DOUBLE) {
+          double t = *static_cast<double*>(p->data);
+          snprintf(buf, sizeof(buf), "%.3f", t);
+          std::string d;
+          snprintf(buf, sizeof(buf), "%.3f", s->duration);
+          d = buf;
+          char pb[32];
+          snprintf(pb, sizeof(pb), "%.3f", t);
+          Emit(std::string("{\"type\":\"timeUpdate\",\"position\":") + pb +
+               ",\"duration\":" + d + "}");
+        } else if (std::strcmp(p->name, "duration") == 0 && p->format == MPV_FORMAT_DOUBLE) {
+          s->duration = *static_cast<double*>(p->data);
+        } else if (std::strcmp(p->name, "pause") == 0 && p->format == MPV_FORMAT_FLAG) {
+          int paused = *static_cast<int*>(p->data);
+          Emit(std::string("{\"type\":\"stateChanged\",\"state\":\"") +
+               (paused ? "paused" : "playing") + "\"}");
+        }
+        break;
+      }
+      case MPV_EVENT_LOG_MESSAGE: {
+        auto* m = static_cast<mpv_event_log_message*>(ev->data);
+        if (m) fprintf(stderr, "[mpv] %s: %s", m->prefix, m->text);
+        break;
+      }
+      case MPV_EVENT_PLAYBACK_RESTART:
+        Emit("{\"type\":\"firstFrame\"}");
+        break;
+      case MPV_EVENT_END_FILE: {
+        auto* e = static_cast<mpv_event_end_file*>(ev->data);
+        if (e && e->reason == MPV_END_FILE_REASON_EOF)
+          Emit("{\"type\":\"stateChanged\",\"state\":\"ended\"}");
+        else if (e && e->reason == MPV_END_FILE_REASON_ERROR)
+          Emit("{\"type\":\"error\",\"message\":\"end-file error\"}");
+        break;
+      }
+      default:
+        break;
+    }
+  }
+}
+
+// ── N-API surface ────────────────────────────────────────────────────────────
+
+Napi::Value Start(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (g_state.run.load()) return env.Undefined();
+  if (info.Length() > 0 && info[0].IsObject()) {
+    Napi::Object o = info[0].As<Napi::Object>();
+    if (o.Has("width")) g_state.width = o.Get("width").As<Napi::Number>().Int32Value();
+    if (o.Has("height")) g_state.height = o.Get("height").As<Napi::Number>().Int32Value();
+    if (o.Has("title")) g_state.title = o.Get("title").As<Napi::String>().Utf8Value();
+  }
+  if (!M::Load()) {
+    Napi::Error::New(env, "libmpv load failed").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  g_state.mpv = M::create();
+  if (g_state.mpv) {
+    M::set_option_string(g_state.mpv, "vo", "libmpv");
+    M::set_option_string(g_state.mpv, "hwdec", getenv("FLIKS_HWDEC") ? getenv("FLIKS_HWDEC") : "no");
+    M::set_option_string(g_state.mpv, "ytdl", "no");
+    M::set_option_string(g_state.mpv, "terminal", "no");
+    M::set_option_string(g_state.mpv, "load-unsafe-playlists", "yes");
+    // The backend produces transcode segments on demand: it answers 404 (seg-0/
+    // init on a resume, before the early companion writes them) or 503 (the
+    // resume segment while ffmpeg is still encoding it). Shaka/ExoPlayer retry
+    // and recover — mpv's ffmpeg HLS demuxer aborts/skips on the first error.
+    // Make its child segment/init opens reconnect on BOTH 4xx and 5xx with
+    // backoff so a transient miss doesn't kill the load or skip the resume
+    // segment. The `4xx,5xx` value carries a comma, so it uses mpv's `%len%`
+    // escaping (7 = strlen("4xx,5xx")) to survive the key-value-list parser.
+    M::set_option_string(g_state.mpv, "demuxer-lavf-o",
+        "reconnect=1,reconnect_streamed=1,reconnect_on_http_error=%7%4xx,5xx,reconnect_delay_max=30");
+    if (M::initialize(g_state.mpv) < 0) fprintf(stderr, "[compositor] mpv_initialize failed\n");
+    M::observe_property(g_state.mpv, 1, "time-pos", MPV_FORMAT_DOUBLE);
+    M::observe_property(g_state.mpv, 2, "duration", MPV_FORMAT_DOUBLE);
+    M::observe_property(g_state.mpv, 3, "pause", MPV_FORMAT_FLAG);
+    M::observe_property(g_state.mpv, 4, "track-list", MPV_FORMAT_NONE);
+    // Default to verbose so the ffmpeg HLS demuxer logs every segment URL it
+    // opens and the HTTP status it gets back (diagnosing transcode/seg-0
+    // failures). Override with FLIKS_MPV_LOGLEVEL (warn / info / v / debug).
+    M::request_log_messages(g_state.mpv, getenv("FLIKS_MPV_LOGLEVEL") ? getenv("FLIKS_MPV_LOGLEVEL") : "v");
+    fprintf(stderr, "[compositor] mpv ready (hwdec=auto-copy)\n");
+  }
+  g_state.run.store(true);
+  g_state.renderThread = std::thread(RenderThreadMain, &g_state);
+  g_state.eventThread = std::thread(EventThreadMain, &g_state);
+  return env.Undefined();
+}
+
+// onEvent(cb): register the JS callback that receives event JSON strings.
+Napi::Value OnEvent(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsFunction()) return env.Undefined();
+  g_tsfn = EventTSFN::New(env, info[0].As<Napi::Function>(), "fliksMpvEvents", 0, 1);
+  g_tsfnReady.store(true);
+  return env.Undefined();
+}
+
+// onInput(cb): register the JS callback that receives SDL input JSON strings.
+Napi::Value OnInput(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsFunction()) return env.Undefined();
+  g_inputTsfn = EventTSFN::New(env, info[0].As<Napi::Function>(), "fliksInput", 0, 1);
+  g_inputReady.store(true);
+  return env.Undefined();
+}
+
+// load({url, startTime?, headers?, subtitles?})
+Napi::Value Load(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (!g_state.mpv || info.Length() < 1 || !info[0].IsObject()) return env.Undefined();
+  Napi::Object o = info[0].As<Napi::Object>();
+  std::string url = o.Get("url").As<Napi::String>().Utf8Value();
+  std::vector<std::string> opts;
+  if (o.Has("startTime") && o.Get("startTime").IsNumber()) {
+    double t = o.Get("startTime").As<Napi::Number>().DoubleValue();
+    if (t > 0) {
+      char b[48];
+      snprintf(b, sizeof(b), "start=+%.3f", t);
+      opts.emplace_back(b);
+    }
+  }
+  if (o.Has("headers") && o.Get("headers").IsObject()) {
+    Napi::Object h = o.Get("headers").As<Napi::Object>();
+    Napi::Array keys = h.GetPropertyNames();
+    std::string fields;
+    for (uint32_t i = 0; i < keys.Length(); i++) {
+      std::string k = keys.Get(i).ToString().Utf8Value();
+      std::string v = h.Get(k).ToString().Utf8Value();
+      if (!fields.empty()) fields += ",";
+      fields += k + ": " + v;
+    }
+    if (!fields.empty()) opts.push_back("http-header-fields=" + fields);
+  }
+  std::string optstr;
+  for (size_t i = 0; i < opts.size(); i++) {
+    if (i) optstr += ",";
+    optstr += opts[i];
+  }
+  if (optstr.empty()) {
+    const char* cmd[] = {"loadfile", url.c_str(), nullptr};
+    M::command(g_state.mpv, cmd);
+  } else {
+    // mpv 0.39+ loadfile signature: <url> <flags> <index> <options>.
+    // index -1 = default (ignored for "replace"); options is the 4th arg.
+    const char* cmd[] = {"loadfile", url.c_str(), "replace", "-1", optstr.c_str(), nullptr};
+    M::command(g_state.mpv, cmd);
+  }
+  // The persistent mpv keeps its pause state across loads; force playback so a
+  // freshly opened file always autoplays. The JS side treats this engine like
+  // the mobile native player (playWhenReady) and never calls play() itself.
+  M::set_property_string(g_state.mpv, "pause", "no");
+  // sidecar subtitles
+  if (o.Has("subtitles") && o.Get("subtitles").IsArray()) {
+    Napi::Array subs = o.Get("subtitles").As<Napi::Array>();
+    for (uint32_t i = 0; i < subs.Length(); i++) {
+      Napi::Object su = subs.Get(i).As<Napi::Object>();
+      std::string surl = su.Get("url").ToString().Utf8Value();
+      std::string lang = su.Has("language") ? su.Get("language").ToString().Utf8Value() : "";
+      const char* sc[] = {"sub-add", surl.c_str(), "auto", "", lang.c_str(), nullptr};
+      M::command(g_state.mpv, sc);
+    }
+  }
+  return env.Undefined();
+}
+
+Napi::Value Command(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (!g_state.mpv || info.Length() < 1 || !info[0].IsArray()) return env.Undefined();
+  Napi::Array arr = info[0].As<Napi::Array>();
+  std::vector<std::string> parts;
+  for (uint32_t i = 0; i < arr.Length(); i++) parts.push_back(arr.Get(i).ToString().Utf8Value());
+  std::vector<const char*> argv;
+  for (auto& p : parts) argv.push_back(p.c_str());
+  argv.push_back(nullptr);
+  M::command(g_state.mpv, argv.data());
+  return env.Undefined();
+}
+
+// getProperty(name) → string (mpv formats track-list etc. as JSON)
+Napi::Value GetProperty(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (!g_state.mpv || info.Length() < 1) return env.Null();
+  std::string name = info[0].As<Napi::String>().Utf8Value();
+  char* v = M::get_property_string(g_state.mpv, name.c_str());
+  if (!v) return env.Null();
+  Napi::Value r = Napi::String::New(env, v);
+  M::mpv_free(v);
+  return r;
+}
+
+Napi::Value SetProperty(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (!g_state.mpv || info.Length() < 2) return env.Undefined();
+  std::string name = info[0].As<Napi::String>().Utf8Value();
+  std::string val = info[1].ToString().Utf8Value();
+  int rc = M::set_property_string(g_state.mpv, name.c_str(), val.c_str());
+  if (rc < 0)
+    fprintf(stderr, "[compositor] set_property %s=%s failed (%d)\n", name.c_str(), val.c_str(), rc);
+  return env.Undefined();
+}
+
+Napi::Value SetFullscreen(const Napi::CallbackInfo& info) {
+  bool on = info.Length() > 0 && info[0].ToBoolean().Value();
+  g_state.fsRequest.store(on ? 1 : 0, std::memory_order_release);
+  return info.Env().Undefined();
+}
+
+Napi::Value UploadUi(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 3 || !info[0].IsBuffer()) return env.Undefined();
+  auto buf = info[0].As<Napi::Buffer<uint8_t>>();
+  int w = info[1].As<Napi::Number>().Int32Value();
+  int h = info[2].As<Napi::Number>().Int32Value();
+  size_t need = static_cast<size_t>(w) * h * 4;
+  if (buf.Length() < need) return env.Undefined();
+  {
+    std::lock_guard<std::mutex> lk(g_state.uiMutex);
+    g_state.uiPending.assign(buf.Data(), buf.Data() + need);
+    g_state.uiW = w;
+    g_state.uiH = h;
+    g_state.uiDirty = true;
+  }
+  return env.Undefined();
+}
+
+Napi::Value Stop(const Napi::CallbackInfo& info) {
+  g_state.run.store(false);
+  if (g_state.eventThread.joinable()) g_state.eventThread.join();
+  if (g_state.renderThread.joinable()) g_state.renderThread.join();
+  if (g_tsfnReady.exchange(false)) g_tsfn.Release();
+  if (g_inputReady.exchange(false)) g_inputTsfn.Release();
+  if (g_state.mpv) {
+    M::destroy(g_state.mpv);  // mpv_terminate_destroy
+    g_state.mpv = nullptr;
+  }
+  return info.Env().Undefined();
+}
+
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  exports.Set("start", Napi::Function::New(env, Start));
+  exports.Set("onEvent", Napi::Function::New(env, OnEvent));
+  exports.Set("onInput", Napi::Function::New(env, OnInput));
+  exports.Set("uploadUi", Napi::Function::New(env, UploadUi));
+  exports.Set("load", Napi::Function::New(env, Load));
+  exports.Set("command", Napi::Function::New(env, Command));
+  exports.Set("getProperty", Napi::Function::New(env, GetProperty));
+  exports.Set("setProperty", Napi::Function::New(env, SetProperty));
+  exports.Set("setFullscreen", Napi::Function::New(env, SetFullscreen));
+  exports.Set("stop", Napi::Function::New(env, Stop));
+  return exports;
+}
+
+}  // namespace
+
+NODE_API_MODULE(fliks_compositor, Init)

--- a/desktop/native/test-load.cjs
+++ b/desktop/native/test-load.cjs
@@ -1,0 +1,10 @@
+const { app } = require('electron');
+app.whenReady().then(() => {
+  try {
+    const addon = require('./build/Release/fliks_compositor.node');
+    console.log('[addon-load]', addon.hello());
+  } catch (e) {
+    console.error('[addon-load] FAILED:', e.message);
+  }
+  app.quit();
+});

--- a/desktop/native/test-ui.cjs
+++ b/desktop/native/test-ui.cjs
@@ -1,0 +1,26 @@
+const { app, BrowserWindow } = require('electron');
+const { spawn } = require('child_process');
+app.commandLine.appendSwitch('ozone-platform', 'x11');
+app.whenReady().then(() => {
+  const addon = require('./build/Release/fliks_compositor.node');
+  addon.start({ width: 960, height: 540, title: 'FLIKS_COMPOSITOR' });
+  const win = new BrowserWindow({ width: 960, height: 540, show: false, webPreferences: { offscreen: true } });
+  win.webContents.setFrameRate(30);
+  const html = `<body style="margin:0;width:960px;height:540px;background:#1d232a;font-family:sans-serif;overflow:hidden">
+    <div style="position:absolute;top:0;left:0;width:140px;height:140px;background:red"></div>
+    <div style="position:absolute;top:0;right:0;width:140px;height:140px;background:lime"></div>
+    <div style="position:absolute;bottom:0;left:0;right:0;height:90px;background:blue"></div>
+    <h1 style="color:#fff;position:absolute;top:210px;left:250px">FLIKS compositor UI ✓</h1></body>`;
+  win.loadURL('data:text/html,' + encodeURIComponent(html));
+  let painted = 0;
+  win.webContents.on('paint', (e, dirty, image) => {
+    painted++;
+    const sz = image.getSize();
+    addon.uploadUi(image.getBitmap(), sz.width, sz.height);
+  });
+  setTimeout(() => {
+    console.log('[test] paint events:', painted);
+    const cmd = 'W=$(xwininfo -root -tree -display :0 2>/dev/null | grep -i FLIKS_COMPOSITOR | grep -oE "0x[0-9a-f]+" | head -1); import -display :0 -window "$W" /tmp/fliks-gate3.png 2>&1 | head -1; ls -l /tmp/fliks-gate3.png 2>&1 | tail -1';
+    spawn('sh', ['-c', cmd], { env: process.env, stdio: 'inherit' }).on('exit', () => { addon.stop(); app.quit(); });
+  }, 5000);
+});

--- a/desktop/native/test-video.cjs
+++ b/desktop/native/test-video.cjs
@@ -1,0 +1,39 @@
+const { app, BrowserWindow } = require('electron');
+const { spawn } = require('child_process');
+app.commandLine.appendSwitch('ozone-platform', 'x11');
+app.whenReady().then(() => {
+  const addon = require('./build/Release/fliks_compositor.node');
+  addon.start({ width: 1280, height: 720, title: 'FLIKS_COMPOSITOR' });
+
+  const counts = {};
+  let lastTime = -1;
+  addon.onEvent((json) => {
+    let ev;
+    try { ev = JSON.parse(json); } catch { return; }
+    counts[ev.type] = (counts[ev.type] || 0) + 1;
+    if (ev.type === 'timeUpdate') lastTime = ev.position;
+    if (ev.type === 'firstFrame' || ev.type === 'stateChanged') console.log('[event]', json);
+  });
+
+  const win = new BrowserWindow({ width: 1280, height: 720, show: false, transparent: true, backgroundColor: '#00000000', webPreferences: { offscreen: true } });
+  win.webContents.setFrameRate(30);
+  const html = `<body style="margin:0;width:1280px;height:720px;background:transparent;font-family:sans-serif;overflow:hidden">
+    <div style="position:absolute;top:16px;left:16px;padding:8px 14px;background:rgba(29,35,42,.78);color:#fff;border-radius:10px;font-weight:600">Fliks compositor (events + headers)</div>
+    <div style="position:absolute;left:0;right:0;bottom:0;height:90px;background:linear-gradient(to top,rgba(0,0,0,.85),transparent);display:flex;align-items:center;gap:16px;padding:0 24px;box-sizing:border-box">
+      <div style="width:54px;height:54px;border-radius:50%;background:#36d399"></div>
+      <div style="flex:1;height:6px;border-radius:3px;background:rgba(255,255,255,.3);position:relative"><i style="position:absolute;left:0;top:0;bottom:0;width:40%;background:#36d399;border-radius:3px"></i></div>
+      <span style="color:#fff">12:34</span>
+    </div></body>`;
+  win.loadURL('data:text/html,' + encodeURIComponent(html));
+  win.webContents.on('paint', (e, dirty, image) => {
+    const sz = image.getSize();
+    addon.uploadUi(image.getBitmap(), sz.width, sz.height);
+  });
+
+  setTimeout(() => addon.load({ url: '/tmp/fliks-gate4.mp4' }), 800);
+  setTimeout(() => {
+    console.log('[test] event counts:', JSON.stringify(counts), 'lastTime=', lastTime.toFixed(2));
+    const cmd = 'W=$(xwininfo -root -tree -display :0 2>/dev/null | grep -i FLIKS_COMPOSITOR | grep -oE "0x[0-9a-f]+" | head -1); import -display :0 -window "$W" /tmp/fliks-gate4.png 2>&1 | head -1';
+    spawn('sh', ['-c', cmd], { env: process.env, stdio: 'inherit' }).on('exit', () => { addon.stop(); app.quit(); });
+  }, 5000);
+});

--- a/desktop/native/test-window.cjs
+++ b/desktop/native/test-window.cjs
@@ -1,0 +1,17 @@
+const { app } = require('electron');
+const { spawn } = require('child_process');
+app.commandLine.appendSwitch('ozone-platform', 'x11');
+app.whenReady().then(() => {
+  let addon;
+  try { addon = require('./build/Release/fliks_compositor.node'); }
+  catch (e) { console.error('[load] FAIL', e.message); app.quit(); return; }
+  console.log('[test] starting compositor window');
+  addon.start({ width: 960, height: 540, title: 'FLIKS_COMPOSITOR' });
+  setTimeout(() => {
+    const cmd = 'echo "--- window ---"; xwininfo -root -tree -display :0 2>/dev/null | grep -i FLIKS_COMPOSITOR; '
+      + 'W=$(xwininfo -root -tree -display :0 2>/dev/null | grep -i FLIKS_COMPOSITOR | grep -oE "0x[0-9a-f]+" | head -1); '
+      + 'import -display :0 -window "$W" /tmp/fliks-compositor.png 2>&1 | head -1; ls -l /tmp/fliks-compositor.png 2>&1 | tail -1';
+    const g = spawn('sh', ['-c', cmd], { env: process.env, stdio: 'inherit' });
+    g.on('exit', () => { addon.stop(); app.quit(); });
+  }, 3500);
+});

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,0 +1,942 @@
+{
+  "name": "fliks-desktop",
+  "version": "1.11.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fliks-desktop",
+      "version": "1.11.0",
+      "devDependencies": {
+        "@types/node": "^25.9.3",
+        "electron": "^42.4.0",
+        "esbuild": "^0.28.1",
+        "node-addon-api": "^8.8.0",
+        "node-gyp": "^12.4.0",
+        "typescript": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.3.tgz",
+      "integrity": "sha512-OjKpjB7gohtEjZiq6nDx1egqjZJhGPN1iFOIED+NFhB/MMkXw/XRcHjh1DGXKT5z2W9eW7Jy2UKU3gpjvusFTQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
+        "progress": "^2.0.3",
+        "semver": "^7.6.3",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "optionalDependencies": {
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@electron/get/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@electron/get/node_modules/undici": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron": {
+      "version": "42.4.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.4.0.tgz",
+      "integrity": "sha512-OXXqh9LD9KxXPv2Fe25EfU9N9AvWTuV6V81sfhQaNvTAXCd9ONA+Q4OWvMe+CmYD6xIwjFxGGtG/ZphDYYC5OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
+      },
+      "bin": {
+        "electron": "cli.js",
+        "install-electron": "install.js"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      }
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/electron/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+      "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "fliks-desktop",
+  "version": "1.11.0",
+  "description": "Fliks native desktop client (macOS / Windows / Linux)",
+  "private": true,
+  "type": "module",
+  "main": "dist/main/index.cjs",
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json",
+    "build:main": "esbuild src/main/index.ts --bundle --platform=node --target=node20 --format=cjs --external:electron --outfile=dist/main/index.cjs",
+    "build:preload": "esbuild src/preload/index.ts --bundle --platform=node --target=node20 --format=cjs --external:electron --outfile=dist/preload/index.cjs",
+    "build": "npm run build:main && npm run build:preload",
+    "start": "npm run build && electron .",
+    "smoke:mpv": "node spike/smoke-mpv.mjs"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.3",
+    "electron": "^42.4.0",
+    "esbuild": "^0.28.1",
+    "node-addon-api": "^8.8.0",
+    "node-gyp": "^12.4.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/desktop/spike/electron-embed/main.mjs
+++ b/desktop/spike/electron-embed/main.mjs
@@ -1,0 +1,125 @@
+// Spike: prove the desktop playback compositing on Electron.
+//
+// Architecture (the production target): TWO stacked, geometry-synced windows.
+//   • videoWin (bottom): borderless, hosts mpv embedded via `--wid` — pure video.
+//   • uiWin (top): transparent, frameless, always-on-top, hosts the web UI
+//     (here a test overlay; in production the built Angular app). Its
+//     transparent regions reveal the video below; opaque chrome (title,
+//     control bar) composites on top.
+//
+// Single-window `--wid` embedding was rejected up front: on X11 the mpv child
+// surface stacks ABOVE the Chromium content, hiding the UI. Two windows give a
+// deterministic z-order and match the mobile model (native video behind a
+// transparent UI layer).
+//
+// Run: DISPLAY=:0 npx electron spike/electron-embed/main.mjs --no-sandbox
+
+import { app, BrowserWindow } from 'electron';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Force the X11/XWayland backend so getNativeWindowHandle() yields an X11 XID
+// that mpv --wid can embed into. (Native Wayland subsurface embedding is a
+// later concern; X11 is the reliable spike path.)
+app.commandLine.appendSwitch('ozone-platform', 'x11');
+
+const BOUNDS = { x: 120, y: 90, width: 960, height: 540 };
+const CLIP = path.join(os.tmpdir(), 'fliks-mpv-smoke.mp4'); // made by smoke-mpv.mjs
+
+let videoWin;
+let uiWin;
+let mpv;
+
+function xidFromHandle(buf) {
+  // On X11, Electron's native handle buffer carries the window XID. Try the
+  // common encodings and log them; the screenshot confirms which embedded.
+  const u32 = buf.length >= 4 ? buf.readUInt32LE(0) : null;
+  const u64 = buf.length >= 8 ? Number(buf.readBigUInt64LE(0)) : null;
+  return { u32, u64 };
+}
+
+function createWindows() {
+  videoWin = new BrowserWindow({
+    ...BOUNDS,
+    frame: false,
+    backgroundColor: '#000000',
+    title: 'FLIKS_VIDEO',
+    webPreferences: { offscreen: false },
+  });
+  // Nothing to load in the video window — mpv paints it.
+  videoWin.loadURL('data:text/html,<body style="margin:0;background:#000"></body>');
+
+  uiWin = new BrowserWindow({
+    ...BOUNDS,
+    frame: false,
+    transparent: true,
+    backgroundColor: '#00000000',
+    hasShadow: false,
+    resizable: true,
+    title: 'FLIKS_UI',
+    parent: videoWin,
+  });
+  uiWin.setAlwaysOnTop(true, 'screen-saver');
+  uiWin.loadFile(path.join(__dirname, 'overlay.html'));
+
+  // Glue: keep the transparent UI exactly over the video window.
+  const sync = () => uiWin?.setBounds(videoWin.getBounds());
+  videoWin.on('move', sync);
+  videoWin.on('resize', sync);
+
+  videoWin.webContents.once('did-finish-load', () => {
+    const handle = videoWin.getNativeWindowHandle();
+    const { u32, u64 } = xidFromHandle(handle);
+    console.log('[spike] videoWin handle bytes:', handle.toString('hex'));
+    console.log('[spike] candidate XIDs → u32:', u32, 'u64:', u64);
+    embedMpv(u32);
+  });
+}
+
+function embedMpv(xid) {
+  const sockPath = path.join(os.tmpdir(), `fliks-spike-mpv.sock`);
+  const args = [
+    `--wid=${xid}`,
+    '--vo=gpu-next',
+    '--hwdec=auto-safe',
+    '--target-colorspace-hint=yes',
+    '--loop-file=inf',
+    '--no-config',
+    '--no-terminal',
+    '--keep-open=yes',
+    `--input-ipc-server=${sockPath}`,
+    CLIP,
+  ];
+  console.log('[spike] spawning mpv --wid into', xid);
+  mpv = spawn('mpv', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+  mpv.stdout.on('data', (d) => process.stdout.write(`[mpv] ${d}`));
+  mpv.stderr.on('data', (d) => process.stderr.write(`[mpv!] ${d}`));
+  mpv.on('exit', (c) => console.log('[spike] mpv exited', c));
+
+  // Self-capture path (SPIKE_CAPTURE=1): let video + overlay settle, grab the
+  // screen with grim, then quit — bounded run, no interactive display needed.
+  if (process.env.SPIKE_CAPTURE === '1') {
+    setTimeout(() => {
+      const cmd =
+        process.env.SPIKE_CAP_CMD ??
+        'grim ' + (process.env.SPIKE_SHOT ?? '/tmp/fliks-spike.png');
+      console.log('[spike] capture cmd:', cmd);
+      const g = spawn('sh', ['-c', cmd], { env: process.env, stdio: 'inherit' });
+      g.on('exit', (code) => {
+        console.log('[spike] capture exited', code);
+        mpv?.kill('SIGTERM');
+        app.quit();
+      });
+    }, 4500);
+  }
+}
+
+app.whenReady().then(createWindows);
+app.on('window-all-closed', () => {
+  mpv?.kill('SIGTERM');
+  app.quit();
+});

--- a/desktop/spike/electron-embed/overlay.html
+++ b/desktop/spike/electron-embed/overlay.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        /* Transparent: the mpv video window below must show through. */
+        background: transparent;
+        overflow: hidden;
+        font-family: system-ui, sans-serif;
+        color: #fff;
+        -webkit-user-select: none;
+      }
+      /* Top-left title chip — proves the UI composites OVER the video. */
+      .title {
+        position: absolute;
+        top: 16px;
+        left: 16px;
+        padding: 8px 14px;
+        background: rgba(29, 35, 42, 0.72);
+        border-radius: 10px;
+        font-weight: 600;
+        letter-spacing: 0.3px;
+        box-shadow: 0 2px 12px rgba(0, 0, 0, 0.4);
+      }
+      /* Bottom control bar — semi-opaque, gradient like the real player. */
+      .controls {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        height: 84px;
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        padding: 0 20px;
+        background: linear-gradient(to top, rgba(0, 0, 0, 0.78), rgba(0, 0, 0, 0));
+      }
+      button {
+        width: 48px;
+        height: 48px;
+        border-radius: 50%;
+        border: none;
+        background: #36d399;
+        color: #04110b;
+        font-size: 20px;
+        cursor: pointer;
+      }
+      .bar {
+        flex: 1;
+        height: 6px;
+        border-radius: 3px;
+        background: rgba(255, 255, 255, 0.25);
+        position: relative;
+      }
+      .bar > i {
+        position: absolute;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        width: 35%;
+        border-radius: 3px;
+        background: #36d399;
+      }
+      /* A translucent center watermark so transparency is unmistakable. */
+      .center {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 13px;
+        color: rgba(255, 255, 255, 0.65);
+        pointer-events: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="title">Fliks · overlay UI (z-top)</div>
+    <div class="center">video should be visible behind this text</div>
+    <div class="controls">
+      <button id="pp">⏸</button>
+      <div class="bar"><i></i></div>
+      <span id="clock">0:00</span>
+    </div>
+    <script>
+      // Spike-only: a fake clock so the screenshot shows a live overlay.
+      let t = 0;
+      setInterval(() => {
+        t += 1;
+        const m = Math.floor(t / 60),
+          s = String(t % 60).padStart(2, '0');
+        document.getElementById('clock').textContent = `${m}:${s}`;
+      }, 1000);
+    </script>
+  </body>
+</html>

--- a/desktop/spike/mpv-player.mjs
+++ b/desktop/spike/mpv-player.mjs
@@ -1,0 +1,343 @@
+// Spike: libmpv control plane over mpv's JSON IPC socket.
+//
+// Proves the desktop playback control surface headlessly, before wiring it
+// to Electron. The method surface intentionally mirrors the mobile
+// `NativePlayer` Capacitor plugin contract (create/load/play/pause/seek/stop,
+// audio + subtitle track listing/selection, subtitle styling, position),
+// so the production `DesktopEngine` can be a near-copy of `native-engine.ts`.
+//
+// Transport: mpv runs with `--input-ipc-server=<unix socket>`; commands are
+// newline-delimited JSON with a `request_id` correlated to the reply, and mpv
+// pushes `event` / `property-change` frames we surface as engine events.
+
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import { EventEmitter } from 'node:events';
+import { randomUUID } from 'node:crypto';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const CONNECT_RETRY_MS = 30;
+const CONNECT_TIMEOUT_MS = 5000;
+
+export class MpvPlayer extends EventEmitter {
+  /**
+   * @param {object} [opts]
+   * @param {string} [opts.mpvPath]   path to the (vendored) mpv binary
+   * @param {boolean} [opts.headless] vo=null/ao=null — for tests, no window
+   * @param {number}  [opts.wid]      native window id to embed into (--wid)
+   * @param {boolean} [opts.hdr]      enable HDR passthrough hint (gpu-next)
+   */
+  constructor(opts = {}) {
+    super();
+    this._mpvPath = opts.mpvPath ?? 'mpv';
+    this._headless = !!opts.headless;
+    this._wid = opts.wid;
+    this._hdr = opts.hdr ?? true;
+    /** @type {import('node:child_process').ChildProcess | null} */
+    this._proc = null;
+    /** @type {net.Socket | null} */
+    this._sock = null;
+    this._sockPath = path.join(
+      os.tmpdir(),
+      `fliks-mpv-${process.pid}-${Math.floor(performance.now())}.sock`,
+    );
+    this._reqId = 0;
+    /** @type {Map<number, {resolve:Function, reject:Function}>} */
+    this._pending = new Map();
+    this._buf = '';
+    this._observeId = 0;
+    this._sawFirstFrame = false;
+  }
+
+  // ── Lifecycle ──────────────────────────────────────────────────────────
+
+  /** Spawn mpv idle and connect to its IPC socket. */
+  async start() {
+    const args = [
+      '--idle=yes',
+      '--no-config',
+      '--no-terminal',
+      '--keep-open=yes', // hold the last frame on EOF instead of quitting
+      `--input-ipc-server=${this._sockPath}`,
+    ];
+    if (this._headless) {
+      args.push('--vo=null', '--ao=null');
+    } else {
+      // Hardware decode + HDR passthrough. gpu-next + colorspace hint pass
+      // HDR10/DV metadata to the display on macOS (EDR) / Windows (D3D11).
+      args.push('--vo=gpu-next', '--hwdec=auto-safe');
+      if (this._hdr) args.push('--target-colorspace-hint=yes');
+      if (this._wid != null) args.push(`--wid=${this._wid}`);
+    }
+
+    this._proc = spawn(this._mpvPath, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    this._proc.on('exit', (code) => {
+      this.emit('stateChanged', { state: 'idle' });
+      this.emit('exit', { code });
+    });
+    this._proc.stderr?.on('data', (d) => this.emit('log', String(d)));
+
+    await this._connect();
+    await this._setupObservers();
+    return this;
+  }
+
+  async _connect() {
+    const deadline = performance.now() + CONNECT_TIMEOUT_MS;
+    for (;;) {
+      if (fs.existsSync(this._sockPath)) {
+        try {
+          await this._open();
+          return;
+        } catch {
+          /* socket file exists but not accepting yet — retry */
+        }
+      }
+      if (performance.now() > deadline) {
+        throw new Error(`mpv IPC socket never appeared at ${this._sockPath}`);
+      }
+      await new Promise((r) => setTimeout(r, CONNECT_RETRY_MS));
+    }
+  }
+
+  _open() {
+    return new Promise((resolve, reject) => {
+      const sock = net.createConnection(this._sockPath);
+      sock.once('connect', () => {
+        this._sock = sock;
+        sock.on('data', (chunk) => this._onData(chunk));
+        sock.on('error', (e) => this.emit('error', { code: -1, message: String(e) }));
+        resolve();
+      });
+      sock.once('error', reject);
+    });
+  }
+
+  _onData(chunk) {
+    this._buf += chunk.toString('utf8');
+    let nl;
+    while ((nl = this._buf.indexOf('\n')) >= 0) {
+      const line = this._buf.slice(0, nl).trim();
+      this._buf = this._buf.slice(nl + 1);
+      if (!line) continue;
+      let msg;
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (msg.request_id != null && this._pending.has(msg.request_id)) {
+        const { resolve, reject } = this._pending.get(msg.request_id);
+        this._pending.delete(msg.request_id);
+        if (msg.error && msg.error !== 'success') reject(new Error(msg.error));
+        else resolve(msg.data);
+      } else if (msg.event) {
+        this._onEvent(msg);
+      }
+    }
+  }
+
+  _onEvent(msg) {
+    switch (msg.event) {
+      case 'property-change':
+        this._onProperty(msg.name, msg.data);
+        break;
+      case 'playback-restart':
+        if (!this._sawFirstFrame) {
+          this._sawFirstFrame = true;
+          this.emit('firstFrame');
+        }
+        break;
+      case 'end-file':
+        if (msg.reason === 'eof') this.emit('stateChanged', { state: 'ended' });
+        else if (msg.reason === 'error')
+          this.emit('error', { code: -1, message: msg.file_error ?? 'end-file error' });
+        break;
+      default:
+        break;
+    }
+  }
+
+  _onProperty(name, data) {
+    switch (name) {
+      case 'time-pos':
+        this._time = data ?? 0;
+        this.emit('timeUpdate', {
+          position: this._time,
+          duration: this._duration ?? 0,
+          buffered: this._cacheEnd ?? 0,
+        });
+        break;
+      case 'duration':
+        this._duration = data ?? 0;
+        break;
+      case 'demuxer-cache-time':
+        this._cacheEnd = data ?? 0;
+        break;
+      case 'pause':
+        this.emit('stateChanged', { state: data ? 'paused' : 'playing' });
+        break;
+      case 'paused-for-cache':
+        if (data) this.emit('stateChanged', { state: 'buffering' });
+        break;
+      case 'track-list':
+        this.emit('tracksChanged', this._mapTracks(data ?? []));
+        break;
+      default:
+        break;
+    }
+  }
+
+  async _setupObservers() {
+    for (const prop of [
+      'time-pos',
+      'duration',
+      'demuxer-cache-time',
+      'pause',
+      'paused-for-cache',
+      'track-list',
+    ]) {
+      await this._command(['observe_property', ++this._observeId, prop]);
+    }
+  }
+
+  // ── Command transport ──────────────────────────────────────────────────
+
+  _command(command) {
+    return new Promise((resolve, reject) => {
+      if (!this._sock) return reject(new Error('mpv socket not connected'));
+      const request_id = ++this._reqId;
+      this._pending.set(request_id, { resolve, reject });
+      this._sock.write(JSON.stringify({ command, request_id }) + '\n');
+    });
+  }
+
+  _get(prop) {
+    return this._command(['get_property', prop]);
+  }
+
+  _set(prop, value) {
+    return this._command(['set_property', prop, value]);
+  }
+
+  // ── NativePlayer-equivalent surface ──────────────────────────────────────
+
+  /**
+   * @param {object} o
+   * @param {string} o.url
+   * @param {number} [o.startTime]   seconds
+   * @param {Record<string,string>} [o.headers]
+   * @param {{url:string,language:string,label:string}[]} [o.subtitles]
+   */
+  async load({ url, startTime = 0, headers, subtitles = [] }) {
+    this._sawFirstFrame = false;
+    const opts = [];
+    if (startTime > 0) opts.push(`start=+${startTime}`);
+    if (headers && Object.keys(headers).length) {
+      const fields = Object.entries(headers)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join(',');
+      opts.push(`http-header-fields=${fields}`);
+    }
+    await this._command(['loadfile', url, 'replace', opts.join(',')]);
+    for (const s of subtitles) {
+      await this._command(['sub-add', s.url, 'auto', s.label ?? '', s.language ?? '']);
+    }
+  }
+
+  play() {
+    return this._set('pause', false);
+  }
+
+  pause() {
+    return this._set('pause', true);
+  }
+
+  seek(position) {
+    return this._command(['seek', position, 'absolute']);
+  }
+
+  stop() {
+    return this._command(['stop']);
+  }
+
+  setPlaybackRate(rate) {
+    return this._set('speed', rate);
+  }
+
+  async getPosition() {
+    return {
+      position: (await this._get('time-pos').catch(() => 0)) ?? 0,
+      duration: (await this._get('duration').catch(() => 0)) ?? 0,
+      buffered: (await this._get('demuxer-cache-time').catch(() => 0)) ?? 0,
+    };
+  }
+
+  _mapTracks(list) {
+    const audio = [];
+    const subtitle = [];
+    for (const t of list) {
+      if (t.type === 'audio')
+        audio.push({ id: String(t.id), language: t.lang ?? '', label: t.title ?? '', selected: !!t.selected });
+      else if (t.type === 'sub')
+        subtitle.push({
+          id: String(t.id),
+          language: t.lang ?? '',
+          label: t.title ?? '',
+          forced: !!t.forced,
+          selected: !!t.selected,
+        });
+    }
+    return { audioTracks: audio, subtitleTracks: subtitle };
+  }
+
+  async getAudioTracks() {
+    return this._mapTracks((await this._get('track-list')) ?? []).audioTracks;
+  }
+
+  selectAudioTrack(id) {
+    return this._set('aid', id);
+  }
+
+  async getSubtitleTracks() {
+    return this._mapTracks((await this._get('track-list')) ?? []).subtitleTracks;
+  }
+
+  selectSubtitleTrack(id) {
+    return this._set('sid', id == null ? 'no' : id);
+  }
+
+  /**
+   * @param {object} s
+   * @param {number} s.fontScale        relative to mpv default
+   * @param {string} s.foregroundColor  #RRGGBB
+   * @param {string} s.backgroundColor  #RRGGBB or 'transparent'
+   * @param {number} s.bottomMarginPercent
+   */
+  async setSubtitleStyle(s) {
+    await this._set('sub-font-size', Math.round(55 * (s.fontScale ?? 1)));
+    if (s.foregroundColor) await this._set('sub-color', s.foregroundColor);
+    if (s.backgroundColor && s.backgroundColor !== 'transparent') {
+      await this._set('sub-back-color', s.backgroundColor);
+      await this._set('sub-border-style', 'background-box');
+    }
+    if (s.bottomMarginPercent != null) await this._set('sub-pos', 100 - s.bottomMarginPercent);
+  }
+
+  async destroy() {
+    try {
+      await this._command(['quit']);
+    } catch {
+      /* socket may already be gone */
+    }
+    this._sock?.destroy();
+    this._proc?.kill('SIGTERM');
+    try {
+      fs.existsSync(this._sockPath) && fs.unlinkSync(this._sockPath);
+    } catch {
+      /* best effort */
+    }
+  }
+}

--- a/desktop/spike/osr-probe.mjs
+++ b/desktop/spike/osr-probe.mjs
@@ -1,0 +1,90 @@
+// Spike step-1 gate: does Electron OSR with useSharedTexture emit a GPU shared
+// texture (dmabuf on Linux/Intel) we can later import into our GL compositor?
+// Logs the full shape of whatever the 'paint' event delivers, then quits.
+//
+// Run: DISPLAY=:0 ./node_modules/.bin/electron spike/osr-probe.mjs --no-sandbox
+
+import { app, BrowserWindow } from 'electron';
+
+app.commandLine.appendSwitch('ozone-platform', 'x11');
+
+function dump(label, obj) {
+  try {
+    console.log(
+      label,
+      JSON.stringify(
+        obj,
+        (k, v) =>
+          typeof v === 'bigint'
+            ? `bigint:${v.toString()}`
+            : Buffer.isBuffer(v)
+              ? `buffer[${v.length}]:${v.toString('hex').slice(0, 32)}`
+              : v,
+        2,
+      ),
+    );
+  } catch (e) {
+    console.log(label, '(unserializable)', Object.keys(obj ?? {}));
+  }
+}
+
+app.whenReady().then(() => {
+  // FLIKS_OSR_SHARED=1 → GPU shared texture (zero-copy, needs working GPU
+  // process); otherwise regular OSR → CPU bitmap in the paint event.
+  const shared = process.env.FLIKS_OSR_SHARED === '1';
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    show: false,
+    webPreferences: {
+      offscreen: shared ? { useSharedTexture: true } : true,
+    },
+  });
+
+  win.loadURL(
+    'data:text/html,<body style="margin:0;background:linear-gradient(45deg,%23f00,%2300f)"><h1 style="color:%23fff;font-family:sans-serif">OSR probe</h1></body>',
+  );
+
+  let n = 0;
+  win.webContents.on('paint', (...args) => {
+    n++;
+    if (n === 1) {
+      console.log('[paint] arg count:', args.length);
+      const ev = args[0];
+      console.log('[paint] arg0 keys:', Object.keys(ev ?? {}));
+      // Regular OSR: a NativeImage bitmap is delivered (event.image or arg[2]).
+      const image = ev?.image ?? args.find((a) => a && typeof a.getSize === 'function');
+      if (image && typeof image.getSize === 'function') {
+        const sz = image.getSize();
+        const bmp = image.getBitmap?.();
+        console.log('[paint] CPU bitmap OK — size', JSON.stringify(sz), 'bytes', bmp?.length);
+      } else {
+        console.log('[paint] no CPU image on event');
+      }
+      const tex = ev?.texture ?? args.find((a) => a && a.textureInfo);
+      if (tex) {
+        console.log('[paint] texture keys:', Object.keys(tex));
+        dump('[paint] texture.textureInfo:', tex.textureInfo ?? tex);
+        try {
+          tex.release();
+          console.log('[paint] texture.release() ok');
+        } catch (e) {
+          console.log('[paint] release error:', e?.message);
+        }
+      } else {
+        console.log('[paint] NO shared texture on event — useSharedTexture not active');
+        dump('[paint] arg0:', ev);
+      }
+    }
+    if (n >= 2) {
+      app.quit();
+    }
+  });
+  win.webContents.setFrameRate(8);
+
+  // Safety: quit after a few seconds even if no paint arrives.
+  setTimeout(() => {
+    if (n === 0) console.log('[probe] no paint event in 6s');
+    app.quit();
+  }, 6000);
+});

--- a/desktop/spike/smoke-mpv.mjs
+++ b/desktop/spike/smoke-mpv.mjs
@@ -1,0 +1,93 @@
+// Headless smoke test for the mpv control plane (no GUI required).
+//
+// Generates a short A/V test clip with ffmpeg, drives it through MpvPlayer
+// over the JSON IPC socket, and asserts the control surface behaves:
+//   spawn → load → firstFrame → time advances → seek → tracks → speed → stop.
+//
+// Run: node spike/smoke-mpv.mjs   (from desktop/)
+
+import { execFileSync } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+import { MpvPlayer } from './mpv-player.mjs';
+
+const CLIP = path.join(os.tmpdir(), 'fliks-mpv-smoke.mp4');
+
+function makeClip() {
+  if (fs.existsSync(CLIP)) return;
+  execFileSync('ffmpeg', [
+    '-y', '-loglevel', 'error',
+    '-f', 'lavfi', '-i', 'testsrc=duration=6:size=320x240:rate=10',
+    '-f', 'lavfi', '-i', 'sine=frequency=440:duration=6',
+    '-c:v', 'libx264', '-pix_fmt', 'yuv420p', '-c:a', 'aac',
+    CLIP,
+  ]);
+}
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+let pass = 0;
+let fail = 0;
+function check(label, ok, detail = '') {
+  (ok ? pass++ : fail++);
+  console.log(`  ${ok ? '✓' : '✗'} ${label}${detail ? ` — ${detail}` : ''}`);
+}
+
+async function main() {
+  console.log('• generating test clip…');
+  makeClip();
+
+  const mpv = new MpvPlayer({ headless: true });
+  let firstFrame = false;
+  let lastTime = -1;
+  const states = [];
+  mpv.on('firstFrame', () => (firstFrame = true));
+  mpv.on('timeUpdate', (e) => (lastTime = e.position));
+  mpv.on('stateChanged', (e) => states.push(e.state));
+  mpv.on('error', (e) => console.log('  [mpv error]', e.message));
+
+  console.log('• starting mpv…');
+  await mpv.start();
+  check('mpv spawned + IPC connected', true);
+
+  console.log('• loading clip…');
+  await mpv.load({ url: CLIP });
+  await mpv.play();
+
+  // Let playback run a beat.
+  await wait(1200);
+  check('playback-restart → firstFrame fired', firstFrame);
+  check('time-pos advancing', lastTime > 0, `pos=${lastTime?.toFixed(2)}s`);
+
+  const dur = (await mpv.getPosition()).duration;
+  check('duration reported', dur > 5 && dur < 7, `${dur?.toFixed(2)}s`);
+
+  console.log('• seeking to 4.0s…');
+  await mpv.seek(4.0);
+  await wait(400);
+  const afterSeek = (await mpv.getPosition()).position;
+  check('seek landed near target', afterSeek >= 3.5, `pos=${afterSeek?.toFixed(2)}s`);
+
+  const audio = await mpv.getAudioTracks();
+  check('audio track listed', audio.length >= 1, `${audio.length} track(s)`);
+
+  console.log('• setting speed 1.5x…');
+  await mpv.setPlaybackRate(1.5);
+  check('set speed ok', (await mpv._get('speed')) === 1.5);
+
+  console.log('• pause…');
+  await mpv.pause();
+  await wait(150);
+  check('pause → paused state', states.includes('paused'));
+
+  await mpv.destroy();
+  check('destroyed cleanly', true);
+
+  console.log(`\n${fail === 0 ? 'PASS' : 'FAIL'} — ${pass} passed, ${fail} failed`);
+  process.exit(fail === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error('SMOKE ERROR:', e);
+  process.exit(1);
+});

--- a/desktop/src/main/cors.ts
+++ b/desktop/src/main/cors.ts
@@ -1,0 +1,29 @@
+import { session } from 'electron';
+import { APP_SCHEME } from './protocol';
+
+const APP_ORIGIN = `${APP_SCHEME}://app`;
+
+/**
+ * The Angular client runs at origin `fliks://app` and calls the user's Fliks
+ * server cross-origin. Servers only allowlist the known web/mobile origins, so
+ * their responses lack `Access-Control-Allow-Origin: fliks://app` and the
+ * browser blocks them. A trusted desktop client is the same situation as the
+ * mobile apps, which bypass CORS via Capacitor's native HTTP layer — here we
+ * reflect the app origin onto every response so credentialed API calls pass.
+ * No backend change required.
+ */
+export function installCorsBypass(): void {
+  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    const headers = details.responseHeaders ?? {};
+    // Drop any existing (case-variant) CORS headers before setting ours.
+    for (const key of Object.keys(headers)) {
+      const k = key.toLowerCase();
+      if (k === 'access-control-allow-origin' || k === 'access-control-allow-credentials') {
+        delete headers[key];
+      }
+    }
+    headers['Access-Control-Allow-Origin'] = [APP_ORIGIN];
+    headers['Access-Control-Allow-Credentials'] = ['true'];
+    callback({ responseHeaders: headers });
+  });
+}

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -1,0 +1,302 @@
+import { app, BrowserWindow, ipcMain, Menu } from 'electron';
+import path from 'node:path';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import { registerAppSchemePrivileged, registerAppProtocol, APP_URL } from './protocol';
+import { installCorsBypass } from './cors';
+import { IPC, type DesktopEvent, type DesktopSubtitleStyle } from '../shared/contract';
+
+// Force software OSR: Chromium's GPU process can't init here, and a
+// GPU-composited OSR window never recovers from a GPU-process crash.
+app.disableHardwareAcceleration();
+if (process.platform === 'linux') app.commandLine.appendSwitch('ozone-platform', 'x11');
+registerAppSchemePrivileged();
+
+process.on('uncaughtException', (e) => console.error('[main:uncaughtException]', e?.stack ?? e));
+process.on('unhandledRejection', (e) => console.error('[main:unhandledRejection]', e));
+
+const WIDTH = 1280;
+const HEIGHT = 800;
+
+// The native compositor addon (single SDL/GLES window: mpv video + OSR UI).
+// Loaded via a real require so esbuild leaves the .node resolution to runtime.
+const nativeRequire = createRequire(__filename);
+type Addon = {
+  start(o: { width: number; height: number; title: string }): void;
+  onEvent(cb: (json: string) => void): void;
+  onInput(cb: (json: string) => void): void;
+  uploadUi(buf: Buffer, w: number, h: number): void;
+  load(o: { url: string; startTime?: number; headers?: Record<string, string>; subtitles?: unknown[] }): void;
+  command(args: string[]): void;
+  getProperty(name: string): string | null;
+  setProperty(name: string, value: string): void;
+  setFullscreen(enabled: boolean): void;
+  stop(): void;
+};
+
+function webDir(): string {
+  if (process.env.FLIKS_WEB_DIR) return process.env.FLIKS_WEB_DIR;
+  if (app.isPackaged) return path.join(process.resourcesPath, 'web');
+  return path.resolve(app.getAppPath(), '..', 'client', 'dist', 'client', 'browser');
+}
+
+const num = (v: string | null): number => {
+  const n = v == null ? NaN : parseFloat(v);
+  return Number.isFinite(n) ? n : 0;
+};
+
+function parseTracks(json: string | null): {
+  audioTracks: unknown[];
+  subtitleTracks: unknown[];
+} {
+  let list: any[] = [];
+  try {
+    list = JSON.parse(json ?? '[]') ?? [];
+  } catch {
+    /* not ready */
+  }
+  const audioTracks: unknown[] = [];
+  const subtitleTracks: unknown[] = [];
+  for (const t of list) {
+    if (t.type === 'audio')
+      audioTracks.push({ id: String(t.id), language: t.lang ?? '', label: t.title ?? '', selected: !!t.selected });
+    else if (t.type === 'sub')
+      subtitleTracks.push({
+        id: String(t.id),
+        language: t.lang ?? '',
+        label: t.title ?? '',
+        forced: !!t.forced,
+        selected: !!t.selected,
+      });
+  }
+  return { audioTracks, subtitleTracks };
+}
+
+// Base subtitle size the app's fontScale presets multiply. mpv's own default
+// (55) renders far too large in the compositor window, so we calibrate lower —
+// at scale 1.0 this lands around a typical caption height once mpv scales it to
+// the window.
+const MPV_BASE_SUB_FONT_SIZE = 32;
+
+/** Translate the app's subtitle style presets to mpv `sub-*` property pairs.
+ *  Both the app and mpv use #AARRGGBB with 00 = transparent / FF = opaque, so
+ *  colours pass through unchanged. `sub-ass-override=force` lets the app style
+ *  win over a subtitle track's embedded ASS/SSA styling, matching the mobile
+ *  native player. `background-box` draws the configured backdrop behind the
+ *  text; with no backdrop we fall back to outline-and-shadow so the edge effect
+ *  is what's visible. */
+function mpvSubtitleProps(s: DesktopSubtitleStyle): Array<[string, string]> {
+  const hasBox = !!s.backgroundColor && s.backgroundColor !== 'transparent';
+  const props: Array<[string, string]> = [
+    ['sub-ass-override', 'force'],
+    ['sub-font-size', String(Math.round(MPV_BASE_SUB_FONT_SIZE * (s.fontScale || 1)))],
+    ['sub-color', s.foregroundColor || '#FFFFFF'],
+    ['sub-border-style', hasBox ? 'background-box' : 'outline-and-shadow'],
+    ['sub-back-color', hasBox ? s.backgroundColor : '#00000000'],
+    ['sub-pos', String(Math.max(0, Math.min(100, 100 - (s.bottomMarginPercent || 0))))],
+  ];
+  // Every branch sets outline-size / shadow-offset / blur explicitly: these are
+  // sticky mpv properties, so a preset that omits one would inherit a stale
+  // value from the previous preset.
+  switch (s.edgeType) {
+    case 'none':
+      props.push(['sub-outline-size', '0'], ['sub-shadow-offset', '0'], ['sub-blur', '0']);
+      break;
+    case 'outline':
+      props.push(
+        ['sub-outline-size', '3'], ['sub-outline-color', '#FF000000'],
+        ['sub-shadow-offset', '0'], ['sub-blur', '0'],
+      );
+      break;
+    case 'raised':
+      props.push(
+        ['sub-outline-size', '1'], ['sub-outline-color', '#FF000000'],
+        ['sub-shadow-offset', '1'], ['sub-shadow-color', '#FF000000'], ['sub-blur', '0'],
+      );
+      break;
+    case 'drop_shadow':
+    default:
+      // A soft glow behind the text with NO directional offset — a blurred,
+      // half-opacity black outline. The blur lands on the outline (not the
+      // fill), so the glyphs stay crisp; the offset is zero, so there's no
+      // displaced ghost copy. Opacity is kept low so it reads as a light shadow
+      // rather than a dark band around the text.
+      props.push(
+        ['sub-outline-size', '1.5'], ['sub-outline-color', '#4D000000'],
+        ['sub-shadow-offset', '0'], ['sub-shadow-color', '#00000000'], ['sub-blur', '0.5'],
+      );
+      break;
+  }
+  return props;
+}
+
+const KEYMAP: Record<string, string> = {
+  Return: 'Enter',
+  Backspace: 'Backspace',
+  Tab: 'Tab',
+  Escape: 'Escape',
+  Space: 'Space',
+  Left: 'Left',
+  Right: 'Right',
+  Up: 'Up',
+  Down: 'Down',
+  Delete: 'Delete',
+  Home: 'Home',
+  End: 'End',
+};
+
+let uiWin: BrowserWindow | null = null;
+const inputCounts: Record<string, number> = {};
+
+function send(ev: DesktopEvent): void {
+  if (uiWin && !uiWin.isDestroyed()) uiWin.webContents.send(IPC.event, ev);
+}
+
+app.whenReady().then(() => {
+  Menu.setApplicationMenu(null);
+  installCorsBypass();
+
+  const dir = webDir();
+  const haveApp = fs.existsSync(path.join(dir, 'index.html'));
+  if (haveApp) registerAppProtocol(dir);
+
+  if (!process.env.FLIKS_MPV_PATH) {
+    process.env.FLIKS_MPV_PATH = path.join(app.getAppPath(), 'native', 'vendor', 'libmpv.so.2');
+  }
+  const addon = nativeRequire(
+    path.join(app.getAppPath(), 'native', 'build', 'Release', 'fliks_compositor.node'),
+  ) as Addon;
+
+  // The OFFSCREEN window renders the Angular UI to a transparent bitmap; the
+  // addon's SDL window is the only visible surface.
+  uiWin = new BrowserWindow({
+    width: WIDTH,
+    height: HEIGHT,
+    show: false,
+    transparent: true,
+    backgroundColor: '#00000000',
+    webPreferences: {
+      offscreen: true,
+      preload: path.join(app.getAppPath(), 'dist', 'preload', 'index.cjs'),
+      contextIsolation: true,
+      sandbox: false,
+    },
+  });
+  uiWin.webContents.setFrameRate(60);
+  uiWin.webContents.on('paint', (_e, _dirty, image) => {
+    const s = image.getSize();
+    if (s.width > 0) addon.uploadUi(image.toBitmap(), s.width, s.height);
+  });
+  uiWin.webContents.on('console-message', (_e, _l, m) => console.log('[renderer]', m));
+
+  addon.start({ width: WIDTH, height: HEIGHT, title: 'Fliks' });
+
+  // mpv events → reshape to the DesktopEvent contract → renderer.
+  addon.onEvent((json) => {
+    let raw: any;
+    try {
+      raw = JSON.parse(json);
+    } catch {
+      return;
+    }
+    switch (raw.type) {
+      case 'timeUpdate':
+        send({ type: 'timeUpdate', payload: { position: raw.position, duration: raw.duration, buffered: 0 } });
+        break;
+      case 'stateChanged':
+        send({ type: 'stateChanged', payload: { state: raw.state } });
+        break;
+      case 'tracksChanged':
+        send({ type: 'tracksChanged', payload: parseTracks(addon.getProperty('track-list')) as any });
+        break;
+      case 'firstFrame':
+        send({ type: 'firstFrame' });
+        break;
+      case 'error':
+        send({ type: 'error', payload: { code: -1, message: raw.message ?? 'error' } });
+        break;
+    }
+  });
+
+  // SDL input (the addon owns the visible window) → the offscreen webContents.
+  addon.onInput((json) => {
+    let i: any;
+    try {
+      i = JSON.parse(json);
+    } catch {
+      return;
+    }
+    if (!uiWin || uiWin.isDestroyed()) return;
+    // Keep the OSR render size == the compositor window size so SDL input
+    // coords map 1:1 to the offscreen webContents.
+    if (i.kind === 'resize') {
+      if (i.w > 0 && i.h > 0) uiWin.setContentSize(i.w, i.h);
+      return;
+    }
+    inputCounts[i.kind] = (inputCounts[i.kind] || 0) + 1;
+    if (inputCounts[i.kind] === 1 || (i.kind === 'move' && inputCounts.move % 60 === 0))
+      console.log('[input]', i.kind, 'x=', i.x, 'y=', i.y, 'count=', inputCounts[i.kind]);
+    const wc = uiWin.webContents;
+    if (i.kind !== 'move' && i.kind !== 'wheel') wc.focus();
+    if (i.kind === 'move') wc.sendInputEvent({ type: 'mouseMove', x: i.x, y: i.y } as any);
+    else if (i.kind === 'button')
+      wc.sendInputEvent({ type: i.down ? 'mouseDown' : 'mouseUp', x: i.x, y: i.y, button: i.button, clickCount: i.clicks || 1 } as any);
+    else if (i.kind === 'wheel')
+      wc.sendInputEvent({ type: 'mouseWheel', x: i.x, y: i.y, deltaX: i.dx * 40, deltaY: i.dy * 40, canScroll: true } as any);
+    else if (i.kind === 'text') wc.sendInputEvent({ type: 'char', keyCode: i.text } as any);
+    else if (i.kind === 'key') {
+      const k = KEYMAP[i.key];
+      if (k) wc.sendInputEvent({ type: i.down ? 'keyDown' : 'keyUp', keyCode: k } as any);
+    }
+  });
+
+  // Route the renderer's player IPC to the addon (control via mpv properties).
+  ipcMain.handle(IPC.load, (_e, opts) => {
+    console.log('[ipc] load', opts?.url, 'start=', opts?.startTime, 'headers=', Object.keys(opts?.headers ?? {}).join(','));
+    return addon.load(opts);
+  });
+  ipcMain.handle(IPC.play, () => addon.setProperty('pause', 'no'));
+  ipcMain.handle(IPC.pause, () => addon.setProperty('pause', 'yes'));
+  ipcMain.handle(IPC.seek, (_e, position: number) => addon.command(['seek', String(position), 'absolute']));
+  ipcMain.handle(IPC.stop, () => addon.command(['stop']));
+  ipcMain.handle(IPC.setPlaybackRate, (_e, r: number) => addon.setProperty('speed', String(r)));
+  ipcMain.handle(IPC.setVolume, (_e, v: number) => addon.setProperty('volume', String(v)));
+  ipcMain.handle(IPC.setMuted, (_e, m: boolean) => addon.setProperty('mute', m ? 'yes' : 'no'));
+  ipcMain.handle(IPC.getPosition, () => ({
+    position: num(addon.getProperty('time-pos')),
+    duration: num(addon.getProperty('duration')),
+    buffered: num(addon.getProperty('demuxer-cache-time')),
+  }));
+  ipcMain.handle(IPC.getAudioTracks, () => parseTracks(addon.getProperty('track-list')).audioTracks);
+  ipcMain.handle(IPC.selectAudioTrack, (_e, id: string) => addon.setProperty('aid', id));
+  ipcMain.handle(IPC.getSubtitleTracks, () => parseTracks(addon.getProperty('track-list')).subtitleTracks);
+  ipcMain.handle(IPC.selectSubtitleTrack, (_e, id: string | null) => {
+    if (id == null) {
+      addon.setProperty('sid', 'no');
+      addon.setProperty('sub-visibility', 'no');
+    } else {
+      addon.setProperty('sid', id);
+      addon.setProperty('sub-visibility', 'yes');
+    }
+  });
+  ipcMain.handle(IPC.setFullscreen, (_e, enabled: boolean) => addon.setFullscreen(enabled));
+  ipcMain.handle(IPC.setSubtitleStyle, (_e, s: DesktopSubtitleStyle) => {
+    if (!s) return;
+    for (const [name, value] of mpvSubtitleProps(s)) addon.setProperty(name, value);
+  });
+  ipcMain.handle(IPC.resize, () => {});
+  ipcMain.handle(IPC.destroy, () => addon.command(['stop']));
+
+  uiWin.loadURL(haveApp ? APP_URL : 'data:text/html,<body style="background:%231d232a"></body>');
+  uiWin.webContents.once('did-finish-load', () => send({ type: 'ready' }));
+
+  app.on('before-quit', () => {
+    try {
+      addon.stop();
+    } catch {
+      /* already stopped */
+    }
+  });
+});
+
+app.on('window-all-closed', () => app.quit());

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -1,0 +1,41 @@
+import { ipcMain } from 'electron';
+import { IPC } from '../shared/contract';
+import type { PlayerSession } from './window/player-session';
+import type {
+  DesktopLoadOptions,
+  DesktopRect,
+  DesktopSubtitleStyle,
+} from '../shared/contract';
+
+/** Wire the renderer→main invoke channels to the session's mpv player. */
+export function registerPlayerIpc(session: PlayerSession): void {
+  ipcMain.handle(IPC.load, (_e, opts: DesktopLoadOptions) => {
+    console.log('[ipc] load:', opts.url, 'start=', opts.startTime ?? 0, 'headers=', Object.keys(opts.headers ?? {}).join(','));
+    return session.player.load(opts);
+  });
+  ipcMain.handle(IPC.play, () => {
+    console.log('[ipc] play');
+    return session.player.play();
+  });
+  ipcMain.handle(IPC.pause, () => session.player.pause());
+  ipcMain.handle(IPC.seek, (_e, position: number) => {
+    console.log('[ipc] seek:', position);
+    return session.player.seek(position);
+  });
+  ipcMain.handle(IPC.stop, () => session.player.stop());
+  ipcMain.handle(IPC.setPlaybackRate, (_e, rate: number) => session.player.setPlaybackRate(rate));
+  ipcMain.handle(IPC.setVolume, (_e, volume: number) => session.player.setVolume(volume));
+  ipcMain.handle(IPC.setMuted, (_e, muted: boolean) => session.player.setMuted(muted));
+  ipcMain.handle(IPC.getPosition, () => session.player.getPosition());
+  ipcMain.handle(IPC.getAudioTracks, () => session.player.getAudioTracks());
+  ipcMain.handle(IPC.selectAudioTrack, (_e, id: string) => session.player.selectAudioTrack(id));
+  ipcMain.handle(IPC.getSubtitleTracks, () => session.player.getSubtitleTracks());
+  ipcMain.handle(IPC.selectSubtitleTrack, (_e, id: string | null) =>
+    session.player.selectSubtitleTrack(id),
+  );
+  ipcMain.handle(IPC.setSubtitleStyle, (_e, style: DesktopSubtitleStyle) =>
+    session.player.setSubtitleStyle(style),
+  );
+  ipcMain.handle(IPC.resize, (_e, rect: DesktopRect) => session.resize(rect));
+  ipcMain.handle(IPC.destroy, () => session.destroy());
+}

--- a/desktop/src/main/mpv/mpv-player.ts
+++ b/desktop/src/main/mpv/mpv-player.ts
@@ -1,0 +1,368 @@
+// libmpv control plane over mpv's JSON IPC socket.
+//
+// Transport + control only: video output / hardware decode / embedding args
+// are injected as `baseArgs` by the platform embed backend, keeping this class
+// OS-agnostic. The method surface mirrors the mobile `NativePlayer` contract.
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import net from 'node:net';
+import { EventEmitter } from 'node:events';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+import type {
+  DesktopAudioTrack,
+  DesktopLoadOptions,
+  DesktopPositionInfo,
+  DesktopSubtitleStyle,
+  DesktopSubtitleTrack,
+} from '../../shared/contract';
+
+const CONNECT_RETRY_MS = 30;
+const CONNECT_TIMEOUT_MS = 5000;
+
+interface MpvTrack {
+  id: number;
+  type: string;
+  lang?: string;
+  title?: string;
+  selected?: boolean;
+  forced?: boolean;
+}
+
+interface Pending {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+}
+
+export interface MpvPlayerOptions {
+  /** Output / decode / embedding args from the platform backend (e.g. --wid, --vo). */
+  baseArgs: string[];
+  mpvPath?: string;
+  /** Environment for the mpv process (e.g. X11-forced env from the backend). */
+  env?: NodeJS.ProcessEnv;
+}
+
+export class MpvPlayer extends EventEmitter {
+  private readonly mpvPath: string;
+  private readonly baseArgs: string[];
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly sockPath: string;
+  private proc: ChildProcess | null = null;
+  private sock: net.Socket | null = null;
+  private reqId = 0;
+  private observeId = 0;
+  private readonly pending = new Map<number, Pending>();
+  private buf = '';
+  private sawFirstFrame = false;
+  private duration = 0;
+  private cacheEnd = 0;
+
+  constructor(opts: MpvPlayerOptions) {
+    super();
+    this.mpvPath = opts.mpvPath ?? 'mpv';
+    this.baseArgs = opts.baseArgs;
+    this.env = opts.env ?? process.env;
+    this.sockPath = path.join(
+      os.tmpdir(),
+      `fliks-mpv-${process.pid}-${this.reqId}-${Math.floor(performance.now())}.sock`,
+    );
+  }
+
+  // ── Lifecycle ──────────────────────────────────────────────────────────
+
+  async start(): Promise<this> {
+    const args = [
+      ...this.baseArgs,
+      '--idle=yes',
+      '--no-config',
+      '--no-terminal',
+      '--keep-open=yes',
+      // The Fliks HLS references tokenised same-host segment/rendition URLs;
+      // mpv's playlist safety check otherwise refuses them on the fallback path.
+      '--load-unsafe-playlists=yes',
+      `--input-ipc-server=${this.sockPath}`,
+    ];
+    console.log('[mpv] spawn:', this.mpvPath, args.join(' '));
+    this.proc = spawn(this.mpvPath, args, { stdio: ['ignore', 'pipe', 'pipe'], env: this.env });
+    this.proc.on('exit', (code) => {
+      this.emit('stateChanged', { state: 'idle' });
+      this.emit('exit', { code });
+    });
+    this.proc.stderr?.on('data', (d: Buffer) => this.emit('log', d.toString()));
+
+    await this.connect();
+    await this.setupObservers();
+    // Surface mpv's own warn/error log over IPC (ffmpeg HTTP/TLS/decode
+    // failures) — `--no-terminal` suppresses stderr, so this is how we see why
+    // a load failed.
+    await this.command(['request_log_messages', 'warn']).catch(() => {});
+    return this;
+  }
+
+  private async connect(): Promise<void> {
+    const deadline = performance.now() + CONNECT_TIMEOUT_MS;
+    for (;;) {
+      if (fs.existsSync(this.sockPath)) {
+        try {
+          await this.open();
+          return;
+        } catch {
+          /* socket file exists but not accepting yet — retry */
+        }
+      }
+      if (performance.now() > deadline) {
+        throw new Error(`mpv IPC socket never appeared at ${this.sockPath}`);
+      }
+      await new Promise((r) => setTimeout(r, CONNECT_RETRY_MS));
+    }
+  }
+
+  private open(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const sock = net.createConnection(this.sockPath);
+      sock.once('connect', () => {
+        this.sock = sock;
+        sock.on('data', (chunk: Buffer) => this.onData(chunk));
+        sock.on('error', (e) => this.emit('error', { code: -1, message: String(e) }));
+        resolve();
+      });
+      sock.once('error', reject);
+    });
+  }
+
+  private onData(chunk: Buffer): void {
+    this.buf += chunk.toString('utf8');
+    let nl: number;
+    while ((nl = this.buf.indexOf('\n')) >= 0) {
+      const line = this.buf.slice(0, nl).trim();
+      this.buf = this.buf.slice(nl + 1);
+      if (!line) continue;
+      let msg: any;
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (msg.request_id != null && this.pending.has(msg.request_id)) {
+        const p = this.pending.get(msg.request_id)!;
+        this.pending.delete(msg.request_id);
+        if (msg.error && msg.error !== 'success') p.reject(new Error(msg.error));
+        else p.resolve(msg.data);
+      } else if (msg.event) {
+        this.onEvent(msg);
+      }
+    }
+  }
+
+  private onEvent(msg: any): void {
+    switch (msg.event) {
+      case 'property-change':
+        this.onProperty(msg.name, msg.data);
+        break;
+      case 'log-message':
+        this.emit('log', `[${msg.level}] ${msg.prefix}: ${msg.text}`);
+        break;
+      case 'playback-restart':
+        if (!this.sawFirstFrame) {
+          this.sawFirstFrame = true;
+          this.emit('firstFrame');
+        }
+        break;
+      case 'end-file':
+        if (msg.reason === 'eof') this.emit('stateChanged', { state: 'ended' });
+        else if (msg.reason === 'error')
+          this.emit('error', { code: -1, message: msg.file_error ?? 'end-file error' });
+        break;
+      default:
+        break;
+    }
+  }
+
+  private onProperty(name: string, data: any): void {
+    switch (name) {
+      case 'time-pos':
+        this.emit('timeUpdate', {
+          position: data ?? 0,
+          duration: this.duration,
+          buffered: this.cacheEnd,
+        } satisfies DesktopPositionInfo);
+        break;
+      case 'duration':
+        this.duration = data ?? 0;
+        break;
+      case 'demuxer-cache-time':
+        this.cacheEnd = data ?? 0;
+        break;
+      case 'pause':
+        this.emit('stateChanged', { state: data ? 'paused' : 'playing' });
+        break;
+      case 'paused-for-cache':
+        if (data) this.emit('stateChanged', { state: 'buffering' });
+        break;
+      case 'track-list':
+        this.emit('tracksChanged', this.mapTracks(data ?? []));
+        break;
+      default:
+        break;
+    }
+  }
+
+  private async setupObservers(): Promise<void> {
+    for (const prop of [
+      'time-pos',
+      'duration',
+      'demuxer-cache-time',
+      'pause',
+      'paused-for-cache',
+      'track-list',
+    ]) {
+      await this.command(['observe_property', ++this.observeId, prop]);
+    }
+  }
+
+  // ── Command transport ──────────────────────────────────────────────────
+
+  private command(command: unknown[]): Promise<any> {
+    return new Promise((resolve, reject) => {
+      if (!this.sock) return reject(new Error('mpv socket not connected'));
+      const request_id = ++this.reqId;
+      this.pending.set(request_id, { resolve, reject });
+      this.sock.write(JSON.stringify({ command, request_id }) + '\n');
+    });
+  }
+
+  private get(prop: string): Promise<any> {
+    return this.command(['get_property', prop]);
+  }
+
+  private set(prop: string, value: unknown): Promise<void> {
+    return this.command(['set_property', prop, value]);
+  }
+
+  // ── NativePlayer-equivalent surface ──────────────────────────────────────
+
+  async load(opts: DesktopLoadOptions): Promise<void> {
+    this.sawFirstFrame = false;
+    const fileOpts: string[] = [];
+    if (opts.startTime && opts.startTime > 0) fileOpts.push(`start=+${opts.startTime}`);
+    if (opts.headers && Object.keys(opts.headers).length) {
+      const fields = Object.entries(opts.headers)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join(',');
+      fileOpts.push(`http-header-fields=${fields}`);
+    }
+    await this.command(['loadfile', opts.url, 'replace', fileOpts.join(',')]);
+    for (const s of opts.subtitles ?? []) {
+      await this.command(['sub-add', s.url, 'auto', s.label ?? '', s.language ?? '']);
+    }
+  }
+
+  play(): Promise<void> {
+    return this.set('pause', false);
+  }
+
+  pause(): Promise<void> {
+    return this.set('pause', true);
+  }
+
+  seek(position: number): Promise<void> {
+    return this.command(['seek', position, 'absolute']).then(() => undefined);
+  }
+
+  stop(): Promise<void> {
+    // Reset baselines so the persistent player can't replay a stale first-frame
+    // / position into the next session after a back-navigation.
+    this.sawFirstFrame = false;
+    this.duration = 0;
+    this.cacheEnd = 0;
+    return this.command(['stop']).then(() => undefined);
+  }
+
+  setPlaybackRate(rate: number): Promise<void> {
+    return this.set('speed', rate);
+  }
+
+  setVolume(volume: number): Promise<void> {
+    return this.set('volume', volume);
+  }
+
+  setMuted(muted: boolean): Promise<void> {
+    return this.set('mute', muted);
+  }
+
+  async getPosition(): Promise<DesktopPositionInfo> {
+    return {
+      position: (await this.get('time-pos').catch(() => 0)) ?? 0,
+      duration: (await this.get('duration').catch(() => 0)) ?? 0,
+      buffered: (await this.get('demuxer-cache-time').catch(() => 0)) ?? 0,
+    };
+  }
+
+  private mapTracks(list: MpvTrack[]): {
+    audioTracks: DesktopAudioTrack[];
+    subtitleTracks: DesktopSubtitleTrack[];
+  } {
+    const audioTracks: DesktopAudioTrack[] = [];
+    const subtitleTracks: DesktopSubtitleTrack[] = [];
+    for (const t of list) {
+      if (t.type === 'audio')
+        audioTracks.push({
+          id: String(t.id),
+          language: t.lang ?? '',
+          label: t.title ?? '',
+          selected: !!t.selected,
+        });
+      else if (t.type === 'sub')
+        subtitleTracks.push({
+          id: String(t.id),
+          language: t.lang ?? '',
+          label: t.title ?? '',
+          forced: !!t.forced,
+          selected: !!t.selected,
+        });
+    }
+    return { audioTracks, subtitleTracks };
+  }
+
+  async getAudioTracks(): Promise<DesktopAudioTrack[]> {
+    return this.mapTracks((await this.get('track-list')) ?? []).audioTracks;
+  }
+
+  selectAudioTrack(id: string): Promise<void> {
+    return this.set('aid', id);
+  }
+
+  async getSubtitleTracks(): Promise<DesktopSubtitleTrack[]> {
+    return this.mapTracks((await this.get('track-list')) ?? []).subtitleTracks;
+  }
+
+  selectSubtitleTrack(id: string | null): Promise<void> {
+    return this.set('sid', id == null ? 'no' : id);
+  }
+
+  async setSubtitleStyle(s: DesktopSubtitleStyle): Promise<void> {
+    await this.set('sub-font-size', Math.round(55 * (s.fontScale ?? 1)));
+    if (s.foregroundColor) await this.set('sub-color', s.foregroundColor);
+    if (s.backgroundColor && s.backgroundColor !== 'transparent') {
+      await this.set('sub-back-color', s.backgroundColor);
+      await this.set('sub-border-style', 'background-box');
+    }
+    if (s.bottomMarginPercent != null) await this.set('sub-pos', 100 - s.bottomMarginPercent);
+  }
+
+  async destroy(): Promise<void> {
+    try {
+      await this.command(['quit']);
+    } catch {
+      /* socket may already be gone */
+    }
+    this.sock?.destroy();
+    this.proc?.kill('SIGTERM');
+    try {
+      if (fs.existsSync(this.sockPath)) fs.unlinkSync(this.sockPath);
+    } catch {
+      /* best effort */
+    }
+  }
+}

--- a/desktop/src/main/protocol.ts
+++ b/desktop/src/main/protocol.ts
@@ -1,0 +1,43 @@
+import { protocol, net } from 'electron';
+import path from 'node:path';
+import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+// Serves the built Angular client over a custom scheme so client-side routing
+// and absolute asset paths work (file:// breaks both). Deep links with no file
+// extension fall back to index.html, letting the Angular router take over.
+export const APP_SCHEME = 'fliks';
+export const APP_URL = `${APP_SCHEME}://app/`;
+
+/** Must run before app `ready`. */
+export function registerAppSchemePrivileged(): void {
+  protocol.registerSchemesAsPrivileged([
+    {
+      scheme: APP_SCHEME,
+      privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true },
+    },
+  ]);
+}
+
+export function registerAppProtocol(webDir: string): void {
+  const root = path.resolve(webDir);
+  protocol.handle(APP_SCHEME, async (request) => {
+    const { pathname } = new URL(request.url);
+    const rel = decodeURIComponent(pathname).replace(/^\/+/, '');
+    let filePath = path.join(root, rel);
+
+    // SPA fallback: a route (no file extension) → index.html.
+    if (!path.extname(rel)) {
+      filePath = path.join(root, 'index.html');
+    }
+
+    // Block path traversal outside the web root.
+    if (!filePath.startsWith(root)) {
+      return new Response('forbidden', { status: 403 });
+    }
+    if (!fs.existsSync(filePath)) {
+      return new Response('not found', { status: 404 });
+    }
+    return net.fetch(pathToFileURL(filePath).toString());
+  });
+}

--- a/desktop/src/main/window/backends/index.ts
+++ b/desktop/src/main/window/backends/index.ts
@@ -1,0 +1,16 @@
+import type { EmbedBackend } from './types';
+import { X11EmbedBackend } from './x11';
+
+export type { EmbedBackend } from './types';
+
+/** Pick the embed backend for the current OS. */
+export function createEmbedBackend(): EmbedBackend {
+  switch (process.platform) {
+    case 'linux':
+      return new X11EmbedBackend();
+    // 'darwin' (child NSView) and 'win32' (child HWND) backends land with the
+    // macOS/Windows milestones.
+    default:
+      throw new Error(`no embed backend for platform '${process.platform}' yet`);
+  }
+}

--- a/desktop/src/main/window/backends/types.ts
+++ b/desktop/src/main/window/backends/types.ts
@@ -1,0 +1,14 @@
+import type { BrowserWindow } from 'electron';
+
+/**
+ * Resolves how mpv embeds into / renders onto the video window for a given OS.
+ * Linux (X11/XWayland) is the only backend wired today; macOS (child NSView),
+ * Windows (child HWND) and a future Wayland-native backend slot in behind this
+ * same interface without touching the player or the cross-platform layers.
+ */
+export interface EmbedBackend {
+  readonly id: string;
+  /** mpv output/embed args (e.g. `--wid`, `--vo`, `--hwdec`) and an optional
+   *  environment override (e.g. forcing X11 over Wayland) for this window. */
+  resolve(videoWin: BrowserWindow): { args: string[]; env?: NodeJS.ProcessEnv };
+}

--- a/desktop/src/main/window/backends/x11.ts
+++ b/desktop/src/main/window/backends/x11.ts
@@ -1,0 +1,41 @@
+import type { BrowserWindow } from 'electron';
+import type { EmbedBackend } from './types';
+
+/**
+ * Linux embedding via X11 (XWayland). mpv's `--wid` reparents its video output
+ * into the Electron video window's native X11 surface (Electron runs with
+ * ozone-platform=x11 so getNativeWindowHandle() yields a usable XID).
+ *
+ * Output is the SOFTWARE X11 VO (--vo=x11), not GL. A GL VO presents via
+ * DRI3/Present directly to screen, which under Mutter bypasses the compositor
+ * over the video rect and draws ON TOP of the transparent UI overlay, hiding
+ * the player controls. --vo=x11 pushes frames through the X server into the
+ * window's backing pixmap, so Mutter composites them and the overlay (a higher
+ * top-level) draws above. Trade-off: no GL/HDR display path on Linux; hardware
+ * DECODE is still used via --hwdec=auto-copy (decode in HW, read back to RAM).
+ * The GL/HDR display path needs the libmpv render-API re-architecture (later).
+ */
+export class X11EmbedBackend implements EmbedBackend {
+  readonly id = 'linux-x11';
+
+  resolve(videoWin: BrowserWindow): { args: string[]; env?: NodeJS.ProcessEnv } {
+    const handle = videoWin.getNativeWindowHandle();
+    const wid = handle.readUInt32LE(0); // X11 Window XID
+
+    // `--wid` embedding is X11-only. On a Wayland session mpv would otherwise
+    // pick its Wayland VO and open its OWN window, ignoring --wid. Drop
+    // WAYLAND_DISPLAY for the mpv process so it uses X11 via XWayland.
+    const env = { ...process.env };
+    delete env.WAYLAND_DISPLAY;
+
+    return {
+      args: [
+        `--wid=${wid}`,
+        '--vo=x11',
+        '--hwdec=auto-copy',
+        '--x11-bypass-compositor=no',
+      ],
+      env,
+    };
+  }
+}

--- a/desktop/src/main/window/player-session.ts
+++ b/desktop/src/main/window/player-session.ts
@@ -1,0 +1,150 @@
+import { BrowserWindow } from 'electron';
+import { MpvPlayer } from '../mpv/mpv-player';
+import { createEmbedBackend } from './backends';
+import { IPC, type DesktopEvent, type DesktopRect } from '../../shared/contract';
+
+export interface PlayerSessionOptions {
+  rendererUrl: string;
+  preloadPath: string;
+  iconPath?: string;
+}
+
+/**
+ * Owns the two stacked, geometry-synced windows and the mpv player:
+ *   • videoWin — the FRAMED main window (title bar, close, taskbar entry,
+ *     icon). Opaque; mpv embeds into its content area via the platform backend.
+ *   • uiWin — frameless transparent child pinned over videoWin's content area,
+ *     hosting the web UI. Its transparent regions reveal the video below; the
+ *     app's own opaque pages cover it while browsing.
+ */
+export class PlayerSession {
+  private videoWin!: BrowserWindow;
+  private uiWin!: BrowserWindow;
+  private mpv: MpvPlayer | null = null;
+
+  async start(opts: PlayerSessionOptions): Promise<void> {
+    const { rendererUrl, preloadPath, iconPath } = opts;
+    this.videoWin = new BrowserWindow({
+      width: 1280,
+      height: 800,
+      minWidth: 800,
+      minHeight: 500,
+      frame: true,
+      backgroundColor: '#1d232a', // Fliks brand background
+      title: 'Fliks',
+      ...(iconPath ? { icon: iconPath } : {}),
+    });
+    await this.videoWin.loadURL(
+      'data:text/html,<body style="margin:0;background:%231d232a"></body>',
+    );
+
+    this.uiWin = new BrowserWindow({
+      ...this.videoWin.getContentBounds(),
+      frame: false,
+      transparent: true,
+      backgroundColor: '#00000000',
+      hasShadow: false,
+      // Child of videoWin: stays above its parent (so the controls draw over
+      // the software-composited video) without a global always-on-top, and the
+      // framed videoWin keeps the title bar + taskbar entry.
+      skipTaskbar: true,
+      parent: this.videoWin,
+      title: 'Fliks UI',
+      webPreferences: {
+        preload: preloadPath,
+        contextIsolation: true,
+        sandbox: false,
+      },
+    });
+
+    // Surface the Angular app's console (device detection, engine selection,
+    // errors) in the main process log.
+    this.uiWin.webContents.on('console-message', (_e, _level, message) => {
+      console.log('[renderer]', message);
+    });
+    this.uiWin.webContents.on('render-process-gone', (_e, details) =>
+      console.error('[uiWin render-process-gone]', JSON.stringify(details)),
+    );
+    this.uiWin.webContents.on('unresponsive', () =>
+      console.error('[uiWin] unresponsive'),
+    );
+
+
+    // Keep the transparent UI exactly over the framed window's content area.
+    const sync = () => {
+      if (!this.uiWin.isDestroyed() && !this.videoWin.isDestroyed()) {
+        this.uiWin.setBounds(this.videoWin.getContentBounds());
+      }
+    };
+    // All these window events take a `() => void` listener; cast to one literal
+    // so the overload resolves (a union of event names matches none).
+    for (const ev of [
+      'move',
+      'resize',
+      'maximize',
+      'unmaximize',
+      'restore',
+      'enter-full-screen',
+      'leave-full-screen',
+    ] as const) {
+      this.videoWin.on(ev as 'resize', sync);
+    }
+    this.videoWin.on('closed', () => this.destroy());
+
+    await this.uiWin.loadURL(rendererUrl);
+    sync();
+
+    // The video window's native handle is only valid once it has painted.
+    const backend = createEmbedBackend();
+    const { args, env } = backend.resolve(this.videoWin);
+    this.mpv = new MpvPlayer({ baseArgs: args, env });
+    this.forwardEvents(this.mpv);
+    await this.mpv.start();
+    this.emit({ type: 'ready' });
+  }
+
+  private forwardEvents(mpv: MpvPlayer): void {
+    mpv.on('log', (s: string) => process.stderr.write(`[mpv] ${s}`));
+    mpv.on('exit', (e) => console.error('[mpv] process exit', JSON.stringify(e)));
+    mpv.on('stateChanged', (p) => {
+      console.log('[player] state:', (p as { state?: string }).state);
+      this.emit({ type: 'stateChanged', payload: p });
+    });
+    mpv.on('timeUpdate', (p) => this.emit({ type: 'timeUpdate', payload: p }));
+    mpv.on('tracksChanged', (p) => {
+      console.log('[player] tracks:', JSON.stringify(p));
+      this.emit({ type: 'tracksChanged', payload: p });
+    });
+    mpv.on('firstFrame', () => {
+      console.log('[player] firstFrame');
+      this.emit({ type: 'firstFrame' });
+    });
+    mpv.on('error', (p) => {
+      console.log('[player] error:', JSON.stringify(p));
+      this.emit({ type: 'error', payload: p });
+    });
+  }
+
+  private emit(event: DesktopEvent): void {
+    if (this.uiWin && !this.uiWin.isDestroyed()) {
+      this.uiWin.webContents.send(IPC.event, event);
+    }
+  }
+
+  /** The mpv player; throws if accessed before start() completes. */
+  get player(): MpvPlayer {
+    if (!this.mpv) throw new Error('player not started');
+    return this.mpv;
+  }
+
+  resize(rect: DesktopRect): void {
+    if (!this.videoWin.isDestroyed()) this.videoWin.setBounds(rect);
+  }
+
+  async destroy(): Promise<void> {
+    await this.mpv?.destroy();
+    this.mpv = null;
+    if (this.uiWin && !this.uiWin.isDestroyed()) this.uiWin.destroy();
+    if (this.videoWin && !this.videoWin.isDestroyed()) this.videoWin.destroy();
+  }
+}

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,0 +1,41 @@
+import { contextBridge, ipcRenderer } from 'electron';
+import {
+  IPC,
+  type DesktopEvent,
+  type DesktopLoadOptions,
+  type DesktopRect,
+  type DesktopSubtitleStyle,
+  type FliksDesktopApi,
+} from '../shared/contract';
+
+// Exposes the native player surface on `window.fliksDesktop`. The Angular-side
+// DesktopEngine consumes this exactly as NativeEngine consumes the Capacitor
+// NativePlayer plugin.
+const api: FliksDesktopApi = {
+  runtime: 'electron',
+  load: (opts: DesktopLoadOptions) => ipcRenderer.invoke(IPC.load, opts),
+  play: () => ipcRenderer.invoke(IPC.play),
+  pause: () => ipcRenderer.invoke(IPC.pause),
+  seek: (position: number) => ipcRenderer.invoke(IPC.seek, position),
+  stop: () => ipcRenderer.invoke(IPC.stop),
+  setPlaybackRate: (rate: number) => ipcRenderer.invoke(IPC.setPlaybackRate, rate),
+  setVolume: (volume: number) => ipcRenderer.invoke(IPC.setVolume, volume),
+  setMuted: (muted: boolean) => ipcRenderer.invoke(IPC.setMuted, muted),
+  setFullscreen: (enabled: boolean) => ipcRenderer.invoke(IPC.setFullscreen, enabled),
+  getPosition: () => ipcRenderer.invoke(IPC.getPosition),
+  getAudioTracks: () => ipcRenderer.invoke(IPC.getAudioTracks),
+  selectAudioTrack: (id: string) => ipcRenderer.invoke(IPC.selectAudioTrack, id),
+  getSubtitleTracks: () => ipcRenderer.invoke(IPC.getSubtitleTracks),
+  selectSubtitleTrack: (id: string | null) => ipcRenderer.invoke(IPC.selectSubtitleTrack, id),
+  setSubtitleStyle: (style: DesktopSubtitleStyle) =>
+    ipcRenderer.invoke(IPC.setSubtitleStyle, style),
+  resize: (rect: DesktopRect) => ipcRenderer.invoke(IPC.resize, rect),
+  destroy: () => ipcRenderer.invoke(IPC.destroy),
+  on: (handler: (event: DesktopEvent) => void) => {
+    const listener = (_e: unknown, event: DesktopEvent) => handler(event);
+    ipcRenderer.on(IPC.event, listener);
+    return () => ipcRenderer.removeListener(IPC.event, listener);
+  },
+};
+
+contextBridge.exposeInMainWorld('fliksDesktop', api);

--- a/desktop/src/renderer/placeholder.html
+++ b/desktop/src/renderer/placeholder.html
@@ -1,0 +1,139 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: transparent;
+        overflow: hidden;
+        font-family: system-ui, sans-serif;
+        color: #fff;
+        -webkit-user-select: none;
+      }
+      .title {
+        position: absolute;
+        top: 16px;
+        left: 16px;
+        padding: 8px 14px;
+        background: rgba(29, 35, 42, 0.72);
+        border-radius: 10px;
+        font-weight: 600;
+        box-shadow: 0 2px 12px rgba(0, 0, 0, 0.4);
+      }
+      .state {
+        position: absolute;
+        top: 16px;
+        right: 16px;
+        padding: 8px 14px;
+        background: rgba(29, 35, 42, 0.72);
+        border-radius: 10px;
+        font-variant-numeric: tabular-nums;
+      }
+      .center {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 13px;
+        color: rgba(255, 255, 255, 0.65);
+        pointer-events: none;
+      }
+      .controls {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        height: 84px;
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        padding: 0 20px;
+        background: linear-gradient(to top, rgba(0, 0, 0, 0.78), rgba(0, 0, 0, 0));
+      }
+      button {
+        width: 48px;
+        height: 48px;
+        border-radius: 50%;
+        border: none;
+        background: #36d399;
+        color: #04110b;
+        font-size: 20px;
+        cursor: pointer;
+      }
+      .bar {
+        flex: 1;
+        height: 6px;
+        border-radius: 3px;
+        background: rgba(255, 255, 255, 0.25);
+        position: relative;
+      }
+      .bar > i {
+        position: absolute;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        width: 0%;
+        border-radius: 3px;
+        background: #36d399;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="title">Fliks desktop · DesktopPlayer bridge</div>
+    <div class="state" id="state">connecting…</div>
+    <div class="center">video composites behind this transparent UI</div>
+    <div class="controls">
+      <button id="pp">⏸</button>
+      <div class="bar"><i id="prog"></i></div>
+      <span id="clock">0:00 / 0:00</span>
+    </div>
+    <script>
+      // M1 placeholder renderer: drives playback through window.fliksDesktop to
+      // exercise the full preload → IPC → mpv chain. Replaced by the Angular app.
+      const fmt = (s) => {
+        s = Math.max(0, Math.floor(s || 0));
+        return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
+      };
+      const $ = (id) => document.getElementById(id);
+      const params = new URLSearchParams(location.search);
+      const clip = params.get('clip');
+      let paused = false;
+
+      const api = window.fliksDesktop;
+      if (!api) {
+        $('state').textContent = 'no fliksDesktop bridge!';
+      } else {
+        $('state').textContent = `runtime: ${api.runtime}`;
+        api.on(async (ev) => {
+          if (ev.type === 'ready') {
+            $('state').textContent = 'ready · loading clip';
+            if (clip) {
+              await api.load({ url: clip });
+              await api.play();
+            }
+          } else if (ev.type === 'firstFrame') {
+            $('state').textContent = 'playing (first frame)';
+          } else if (ev.type === 'stateChanged') {
+            $('state').textContent = ev.payload.state;
+          } else if (ev.type === 'timeUpdate') {
+            const { position, duration } = ev.payload;
+            $('clock').textContent = `${fmt(position)} / ${fmt(duration)}`;
+            $('prog').style.width = duration ? `${(position / duration) * 100}%` : '0%';
+          } else if (ev.type === 'error') {
+            $('state').textContent = `error: ${ev.payload.message}`;
+          }
+        });
+      }
+
+      $('pp').addEventListener('click', async () => {
+        paused = !paused;
+        $('pp').textContent = paused ? '▶' : '⏸';
+        await (paused ? api.pause() : api.play());
+      });
+    </script>
+  </body>
+</html>

--- a/desktop/src/shared/contract.ts
+++ b/desktop/src/shared/contract.ts
@@ -1,0 +1,108 @@
+// Contract shared between the Electron main process and the preload bridge.
+//
+// The method surface mirrors the mobile `NativePlayer` Capacitor plugin so the
+// Angular-side `DesktopEngine` stays a near-copy of `native-engine.ts`.
+
+export interface DesktopAudioTrack {
+  id: string;
+  language: string;
+  label: string;
+  selected: boolean;
+}
+
+export interface DesktopSubtitleTrack {
+  id: string;
+  language: string;
+  label: string;
+  forced: boolean;
+  selected: boolean;
+}
+
+export interface DesktopLoadOptions {
+  url: string;
+  startTime?: number;
+  headers?: Record<string, string>;
+  subtitles?: { url: string; language: string; label: string; forced?: boolean }[];
+}
+
+export interface DesktopSubtitleStyle {
+  fontScale: number;
+  foregroundColor: string;
+  backgroundColor: string;
+  edgeType?: string;
+  bottomMarginPercent: number;
+}
+
+export interface DesktopRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export type DesktopPlayerState = 'idle' | 'playing' | 'paused' | 'buffering' | 'ended' | 'error';
+
+export interface DesktopPositionInfo {
+  position: number;
+  duration: number;
+  buffered: number;
+}
+
+/** main → renderer event envelope, sent on the single IPC.event channel. */
+export type DesktopEvent =
+  | { type: 'ready' }
+  | { type: 'stateChanged'; payload: { state: DesktopPlayerState } }
+  | { type: 'timeUpdate'; payload: DesktopPositionInfo }
+  | {
+      type: 'tracksChanged';
+      payload: { audioTracks: DesktopAudioTrack[]; subtitleTracks: DesktopSubtitleTrack[] };
+    }
+  | { type: 'firstFrame' }
+  | { type: 'error'; payload: { code: number; message: string } };
+
+/** renderer → main invoke channels. */
+export const IPC = {
+  load: 'player:load',
+  play: 'player:play',
+  pause: 'player:pause',
+  seek: 'player:seek',
+  stop: 'player:stop',
+  setPlaybackRate: 'player:setPlaybackRate',
+  setVolume: 'player:setVolume',
+  setMuted: 'player:setMuted',
+  setFullscreen: 'player:setFullscreen',
+  getPosition: 'player:getPosition',
+  getAudioTracks: 'player:getAudioTracks',
+  selectAudioTrack: 'player:selectAudioTrack',
+  getSubtitleTracks: 'player:getSubtitleTracks',
+  selectSubtitleTrack: 'player:selectSubtitleTrack',
+  setSubtitleStyle: 'player:setSubtitleStyle',
+  resize: 'player:resize',
+  destroy: 'player:destroy',
+  /** main → renderer (one channel, discriminated by DesktopEvent.type). */
+  event: 'player:event',
+} as const;
+
+/** The surface exposed on `window.fliksDesktop` by the preload bridge. */
+export interface FliksDesktopApi {
+  runtime: 'electron';
+  load(opts: DesktopLoadOptions): Promise<void>;
+  play(): Promise<void>;
+  pause(): Promise<void>;
+  seek(position: number): Promise<void>;
+  stop(): Promise<void>;
+  setPlaybackRate(rate: number): Promise<void>;
+  /** 0..100 (mpv volume scale). */
+  setVolume(volume: number): Promise<void>;
+  setMuted(muted: boolean): Promise<void>;
+  setFullscreen(enabled: boolean): Promise<void>;
+  getPosition(): Promise<DesktopPositionInfo>;
+  getAudioTracks(): Promise<DesktopAudioTrack[]>;
+  selectAudioTrack(id: string): Promise<void>;
+  getSubtitleTracks(): Promise<DesktopSubtitleTrack[]>;
+  selectSubtitleTrack(id: string | null): Promise<void>;
+  setSubtitleStyle(style: DesktopSubtitleStyle): Promise<void>;
+  resize(rect: DesktopRect): Promise<void>;
+  destroy(): Promise<void>;
+  on(handler: (event: DesktopEvent) => void): () => void;
+}

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
Native desktop client (macOS / Windows / Linux; Linux is the dev platform) — a thin client connecting to a remote Fliks server like the mobile apps.

- **Compositor**: the Angular UI renders offscreen (transparent OSR) and is composited over mpv video by a native SDL2/GLES N-API addon owning a single window — the only model that works under Mutter/X11. mpv runs from a self-contained static libmpv (render API); HDR is SDR-tone-mapped on Linux.
- **Client integration**: a `DesktopEngine`, a `DESKTOP` engine kind (`probesSegZero`, like Shaka), fullscreen, audio-track + subtitle wiring, an SDR subtitle-style mapping, and mpv HLS reconnect on HTTP 4xx/5xx so a resumed transcode's segments aren't dropped while the backend produces them.
- **Backend**: the audio segment route now respawns the seg-0 early companion on a resume, mirroring the video route (fixes a fatal 404 on the rendition init/seg-0).

Docs: `desktop/README.md` + `desktop/CLAUDE.md` (dependencies, build, run, test).

## Status
Checkpoint — playback works (subtitles, audio switch, fullscreen, autoplay, resume). Known open item: cold 4K-HDR **resume** latency (backend tonemap cold-start at the seek point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)