### PR TITLE
fix(player): lower default subtitle bottom margin to 5%

### DIFF
--- a/client/src/app/core/services/player-settings.service.ts
+++ b/client/src/app/core/services/player-settings.service.ts
@@ -50,7 +50,7 @@ const DEFAULTS: PlayerSettings = {
   subtitleColor: 'white',
   subtitleShadow: 'drop',
   subtitleBackground: 'transparent',
-  subtitleBottomMargin: 10,
+  subtitleBottomMargin: 5,
   subtitleTopMargin: 5,
   autoSkipIntro: false,
 };


### PR DESCRIPTION
## Why
The default subtitle position lifted cues **10%** of the video height off the bottom edge, floating them noticeably high on most content. Drop the default to **5%** — just above the edge, still clear of the controls bar.

## What
`player-settings.service.ts` `DEFAULTS.subtitleBottomMargin: 10 → 5`. `5` is already a `BOTTOM_MARGIN_OPTIONS` entry ("5%"), so the picker range is unchanged. Flows to web/Shaka, native iOS/Android and Tizen/webOS overlays through the existing `subtitleBottomMargin` plumbing.

## Migration
**None** (by decision): `load()` merges `{...defaults, ...stored}`, so users with a saved value keep it — only fresh installs get 5%.

`tsc --noEmit -p tsconfig.app.json` clean.