### PR TITLE
fix(streaming): reap stale sessions and cap per-user concurrency

### DIFF
--- a/backend/src/modules/scheduler/system.controller.spec.ts
+++ b/backend/src/modules/scheduler/system.controller.spec.ts
@@ -1,0 +1,136 @@
+import { SystemController } from './system.controller';
+import type { LiveSessionSnapshot } from '../streaming/live-session.service';
+
+/**
+ * Recency-filter coverage for the streams dashboard. `activeStreams()`
+ * reads `LiveSessionRegistry.list()` (which returns every entry, stale or
+ * not, by design) and must drop entries whose last beat is older than the
+ * live-session TTL so a client that died doesn't linger on the dashboard
+ * until the next GC sweep.
+ */
+describe('SystemController.activeStreams recency filter', () => {
+  const ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...ENV };
+  });
+
+  afterEach(() => {
+    process.env = ENV;
+  });
+
+  function snapshot(
+    overrides: Partial<LiveSessionSnapshot> & { lastBeat: Date },
+  ): LiveSessionSnapshot {
+    return {
+      sessionId: 'sid',
+      userId: 1,
+      username: 'alice',
+      mediaFileId: 42,
+      mediaTitle: 'title',
+      mediaType: 'movie',
+      posterUrl: null,
+      profileHash: null,
+      quality: null,
+      kind: 'directplay',
+      deviceLabel: null,
+      startedAt: new Date(overrides.lastBeat),
+      position: 0,
+      state: 'playing',
+      audioTrackIndex: null,
+      subtitleTrackIndex: null,
+      useTs: false,
+      audioPlan: null,
+      audioTrackPlans: null,
+      audioStreamIndex: null,
+      audioStreamCount: 0,
+      useExtXMedia: false,
+      deviceType: 'desktop',
+      hdrLadder: false,
+      supportsHlsSubtitles: false,
+      probesSegZero: true,
+      videoVariant: null,
+      tonemapping: false,
+      transcodeReasons: [],
+      burnIn: null,
+      encoderPreset: 'faster',
+      canCopyVideo: false,
+      canCopyAudio: false,
+      pinned: false,
+      ...overrides,
+    };
+  }
+
+  function makeController(snapshots: LiveSessionSnapshot[]) {
+    const transcodingService = {
+      getDetectedHwAccel: jest.fn().mockReturnValue('none'),
+      getActiveSessions: jest.fn().mockReturnValue([]),
+    };
+    const liveSessions = {
+      list: jest.fn().mockReturnValue(snapshots),
+    };
+    const activeStreamTracker = {
+      getActive: jest.fn().mockReturnValue([]),
+      getDeviceName: jest.fn().mockReturnValue(null),
+    };
+    const playbackService = {
+      getState: jest.fn().mockResolvedValue(null),
+    };
+    const mediaFileRepo = {
+      findByIds: jest.fn().mockResolvedValue([]),
+    };
+
+    const controller = new SystemController(
+      {} as never, // dataSource
+      {} as never, // indexerRepo
+      {} as never, // clientRepo
+      {} as never, // libraryRepo
+      {} as never, // qbittorrent
+      {} as never, // backup
+      {} as never, // logBuffer
+      {} as never, // eventsService
+      transcodingService as never,
+      {} as never, // transcodeCache
+      activeStreamTracker as never,
+      liveSessions as never,
+      playbackService as never,
+      mediaFileRepo as never,
+      {} as never, // episodeRepo
+    );
+
+    return { controller };
+  }
+
+  it('hides a session whose lastBeat is older than the TTL', async () => {
+    process.env.STREAM_LIVE_SESSION_TTL_MS = '30000';
+    const fresh = snapshot({
+      sessionId: 'fresh',
+      lastBeat: new Date(Date.now() - 1_000),
+    });
+    const stale = snapshot({
+      sessionId: 'stale',
+      lastBeat: new Date(Date.now() - 60_000),
+    });
+    const { controller } = makeController([fresh, stale]);
+
+    const streams = await controller.activeStreams();
+
+    const ids = streams.map((s) => s.sessionId);
+    expect(ids).toContain('fresh');
+    expect(ids).not.toContain('stale');
+  });
+
+  it('honours STREAM_LIVE_SESSION_TTL_MS when sizing the cutoff', async () => {
+    // With a tiny TTL even a 1 s-old beat is stale.
+    process.env.STREAM_LIVE_SESSION_TTL_MS = '500';
+    const stale = snapshot({
+      sessionId: 'stale',
+      lastBeat: new Date(Date.now() - 1_000),
+    });
+    const { controller } = makeController([stale]);
+
+    const streams = await controller.activeStreams();
+
+    expect(streams).toHaveLength(0);
+  });
+});

--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -43,6 +43,7 @@ import {
   type LiveSessionSnapshot,
   LiveSessionRegistry,
 } from '../streaming/live-session.service';
+import { StreamLifetime } from '../streaming/lifetime-constants';
 import { PlaybackService } from '../streaming/playback.service';
 import { MediaFile } from '../media/entities/media-file.entity';
 import { Episode } from '../media/entities/episode.entity';
@@ -315,7 +316,14 @@ export class SystemController {
     // currently watching". Each playback gets its own sid, so two
     // devices on the same (user, file) coexist as two distinct
     // entries — no clobber, no dedup destroying multi-device.
-    const live = this.liveSessions.list();
+    // Show only genuinely-live sessions. `list()` returns every entry (the
+    // bulk DELETE handler relies on that), so a client that died still shows
+    // here until the next GC sweep. Filter to the same TTL the registry GCs
+    // on so a dead session drops off the dashboard at once.
+    const liveTtlMs = StreamLifetime.liveSessionTtlMs();
+    const live = this.liveSessions
+      .list()
+      .filter((s) => s.lastBeat.getTime() > Date.now() - liveTtlMs);
     const transcodeSessions = this.transcodingService.getActiveSessions();
     const findTranscodeSession = (
       userId: number | null,

--- a/backend/src/modules/streaming/lifetime-constants.ts
+++ b/backend/src/modules/streaming/lifetime-constants.ts
@@ -7,6 +7,7 @@
  *
  *   STREAM_LIVE_SESSION_TTL_MS         live-session.service.ts
  *   STREAM_LIVE_SESSION_GC_INTERVAL_MS live-session.service.ts
+ *   STREAM_MAX_SESSIONS_PER_USER       live-session.service.ts
  *   STREAM_JOB_GRACE_MS                transcoding/constants.ts
  *   STREAM_JOB_FALLBACK_TIMEOUT_MS     transcoding/constants.ts
  *   TRANSCODE_CACHE_TTL_MS             transcode-cache.service.ts
@@ -16,6 +17,7 @@
 
 const DEFAULT_LIVE_SESSION_TTL_MS = 30_000;
 const DEFAULT_LIVE_SESSION_GC_INTERVAL_MS = 5_000;
+const DEFAULT_MAX_SESSIONS_PER_USER = 10;
 const DEFAULT_JOB_GRACE_MS = 60_000;
 const DEFAULT_JOB_FALLBACK_TIMEOUT_MS = 30 * 60 * 1000;
 const DEFAULT_CACHE_TTL_MS = 4 * 60 * 60 * 1000;
@@ -36,6 +38,11 @@ export const StreamLifetime = {
     readEnvPositiveInt(
       'STREAM_LIVE_SESSION_GC_INTERVAL_MS',
       DEFAULT_LIVE_SESSION_GC_INTERVAL_MS,
+    ),
+  maxSessionsPerUser: (): number =>
+    readEnvPositiveInt(
+      'STREAM_MAX_SESSIONS_PER_USER',
+      DEFAULT_MAX_SESSIONS_PER_USER,
     ),
   jobGraceMs: (): number =>
     readEnvPositiveInt('STREAM_JOB_GRACE_MS', DEFAULT_JOB_GRACE_MS),

--- a/backend/src/modules/streaming/live-session.service.spec.ts
+++ b/backend/src/modules/streaming/live-session.service.spec.ts
@@ -245,3 +245,92 @@ describe('LiveSessionRegistry GC', () => {
     expect(svc.size()).toBe(1);
   });
 });
+
+describe('LiveSessionRegistry per-user cap', () => {
+  const ENV = process.env;
+  let svc: LiveSessionRegistry;
+
+  beforeEach(() => {
+    process.env = { ...ENV };
+  });
+
+  afterEach(() => {
+    svc?.onModuleDestroy();
+    process.env = ENV;
+  });
+
+  it('evicts the oldest-lastBeat session once a user is over the cap', async () => {
+    process.env.STREAM_MAX_SESSIONS_PER_USER = '2';
+    svc = new LiveSessionRegistry();
+    svc.onModuleInit();
+
+    const first = svc.create(BASE);
+    await new Promise((r) => setTimeout(r, 5));
+    const second = svc.create(BASE);
+    // The user is at the cap (2). The third create evicts the
+    // oldest-beaten entry (first) rather than rejecting the new one.
+    await new Promise((r) => setTimeout(r, 5));
+    const third = svc.create(BASE);
+
+    expect(svc.get(first.sessionId)).toBeNull();
+    expect(svc.get(second.sessionId)).not.toBeNull();
+    expect(svc.get(third.sessionId)).not.toBeNull();
+    expect(svc.size()).toBe(2);
+  });
+
+  it('evicts the least-recently-beaten session, not the first inserted', async () => {
+    process.env.STREAM_MAX_SESSIONS_PER_USER = '2';
+    svc = new LiveSessionRegistry();
+    svc.onModuleInit();
+
+    const first = svc.create(BASE);
+    await new Promise((r) => setTimeout(r, 5));
+    const second = svc.create(BASE);
+    // Beat `first` so `second` becomes the stalest entry.
+    await new Promise((r) => setTimeout(r, 5));
+    svc.heartbeat(first.sessionId, { position: 1 });
+    await new Promise((r) => setTimeout(r, 5));
+    const third = svc.create(BASE);
+
+    expect(svc.get(second.sessionId)).toBeNull();
+    expect(svc.get(first.sessionId)).not.toBeNull();
+    expect(svc.get(third.sessionId)).not.toBeNull();
+    expect(svc.size()).toBe(2);
+  });
+
+  it('caps each user independently and never blocks a fresh session', () => {
+    process.env.STREAM_MAX_SESSIONS_PER_USER = '2';
+    svc = new LiveSessionRegistry();
+    svc.onModuleInit();
+
+    svc.create(BASE);
+    svc.create(BASE);
+    svc.create(BASE); // evicts alice's oldest, alice stays at 2
+    svc.create({ ...BASE, userId: 99, username: 'bob' });
+
+    expect(svc.size()).toBe(3);
+    expect(svc.listForJob(1, 42, 'aaaaaaaaaa')).toHaveLength(2);
+  });
+
+  it('does not cap anonymous (null userId) sessions', () => {
+    process.env.STREAM_MAX_SESSIONS_PER_USER = '1';
+    svc = new LiveSessionRegistry();
+    svc.onModuleInit();
+
+    svc.create({ ...BASE, userId: null, username: null });
+    svc.create({ ...BASE, userId: null, username: null });
+    svc.create({ ...BASE, userId: null, username: null });
+
+    expect(svc.size()).toBe(3);
+  });
+
+  it('defaults the cap to 10 when the env var is unset', () => {
+    delete process.env.STREAM_MAX_SESSIONS_PER_USER;
+    svc = new LiveSessionRegistry();
+    svc.onModuleInit();
+
+    for (let i = 0; i < 11; i++) svc.create(BASE);
+    // The 11th create evicts the oldest — the user never exceeds 10.
+    expect(svc.size()).toBe(10);
+  });
+});

--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -185,6 +185,7 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
 
   private readonly ttlMs = StreamLifetime.liveSessionTtlMs();
   private readonly gcIntervalMs = StreamLifetime.liveSessionGcIntervalMs();
+  private readonly maxSessionsPerUser = StreamLifetime.maxSessionsPerUser();
   /** Idle window for pinned (download) sessions. Active segment fetches keep
    *  them warm; this only bounds how long a paused or finished download holds
    *  its session before GC reclaims it. */
@@ -246,6 +247,22 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
       canCopyAudio: input.canCopyAudio ?? false,
       pinned: input.pinned ?? false,
     };
+    // Per-user concurrent-session cap. Legit multi-device viewing must never
+    // be blocked, so we evict the user's oldest-beaten session rather than
+    // reject the new one — this only bounds runaway session leaks from a
+    // client that keeps issuing fresh playback-info without ever stopping.
+    if (input.userId != null) {
+      const own = [...this.sessions.values()].filter(
+        (s) => s.userId === input.userId,
+      );
+      if (own.length >= this.maxSessionsPerUser) {
+        const oldest = own.reduce((a, b) => (a.lastBeat <= b.lastBeat ? a : b));
+        this.sessions.delete(oldest.sessionId);
+        this.log.log(
+          `evicted oldest session ${oldest.sessionId} for user ${input.userId} (cap ${this.maxSessionsPerUser})`,
+        );
+      }
+    }
     this.sessions.set(session.sessionId, session);
     return session;
   }

--- a/backend/src/modules/streaming/streaming.controller.spec.ts
+++ b/backend/src/modules/streaming/streaming.controller.spec.ts
@@ -1,0 +1,130 @@
+import { StreamingController } from './streaming.controller';
+import type { LiveSession } from './live-session.service';
+
+/**
+ * Focused unit tests for the sid-scoped stop handler. The controller is
+ * instantiated directly with stub collaborators — `stopLiveSession` only
+ * touches the live-session registry, the DirectPlay tracker, and the
+ * transcoding service, so the rest of the (large) constructor surface is
+ * irrelevant here.
+ */
+describe('StreamingController.stopLiveSession', () => {
+  function makeController(live: LiveSession | null) {
+    const liveSessions = {
+      get: jest.fn().mockReturnValue(live),
+      stop: jest.fn(),
+      listForJob: jest.fn().mockReturnValue([]),
+    };
+    const activeStreamTracker = {
+      unregister: jest.fn(),
+    };
+    const transcodingService = {
+      getSessionsForFileUser: jest.fn().mockReturnValue([]),
+      killSessionById: jest.fn(),
+    };
+
+    const controller = new StreamingController(
+      {} as never, // streamingService
+      {} as never, // subtitleStreamService
+      transcodingService as never,
+      {} as never, // streamBuilder
+      activeStreamTracker as never,
+      {} as never, // subtitleBurnIn
+      {} as never, // thumbnailService
+      {} as never, // playbackService
+      {} as never, // markersService
+      {} as never, // streamingSettingsCache
+      liveSessions as never,
+      {} as never, // segmentPackaging
+      {} as never, // sessionRouter
+      {} as never, // sessionContextBuilder
+    );
+
+    return { controller, liveSessions, activeStreamTracker, transcodingService };
+  }
+
+  function makeLive(overrides: Partial<LiveSession>): LiveSession {
+    return {
+      sessionId: 'sid-1',
+      userId: 7,
+      username: 'alice',
+      mediaFileId: 42,
+      mediaTitle: null,
+      mediaType: null,
+      posterUrl: null,
+      profileHash: null,
+      quality: null,
+      kind: 'directplay',
+      deviceLabel: null,
+      startedAt: Date.now(),
+      lastBeat: Date.now(),
+      position: 0,
+      state: 'playing',
+      audioTrackIndex: null,
+      subtitleTrackIndex: null,
+      useTs: false,
+      audioPlan: null,
+      audioTrackPlans: null,
+      audioStreamIndex: null,
+      audioStreamCount: 0,
+      useExtXMedia: false,
+      deviceType: 'desktop',
+      hdrLadder: false,
+      supportsHlsSubtitles: false,
+      probesSegZero: true,
+      videoVariant: null,
+      tonemapping: false,
+      transcodeReasons: [],
+      burnIn: null,
+      encoderPreset: 'faster',
+      canCopyVideo: false,
+      canCopyAudio: false,
+      pinned: false,
+      ...overrides,
+    };
+  }
+
+  it('unregisters the now-watching row for a DirectPlay sid (null profileHash)', () => {
+    const live = makeLive({ profileHash: null, userId: 7, mediaFileId: 42 });
+    const { controller, liveSessions, activeStreamTracker, transcodingService } =
+      makeController(live);
+
+    controller.stopLiveSession('sid-1');
+
+    expect(liveSessions.stop).toHaveBeenCalledWith('sid-1');
+    // DirectPlay has no profileHash, so the ffmpeg-kill path is skipped —
+    // the tracker row must still be cleared immediately.
+    expect(activeStreamTracker.unregister).toHaveBeenCalledWith(7, 42);
+    expect(transcodingService.killSessionById).not.toHaveBeenCalled();
+  });
+
+  it('also unregisters for a transcode sid, then walks the ffmpeg-kill path', () => {
+    const live = makeLive({ profileHash: 'abc123', userId: 7, mediaFileId: 42 });
+    const { controller, activeStreamTracker, liveSessions } =
+      makeController(live);
+
+    controller.stopLiveSession('sid-1');
+
+    expect(activeStreamTracker.unregister).toHaveBeenCalledWith(7, 42);
+    expect(liveSessions.listForJob).toHaveBeenCalledWith(7, 42, 'abc123');
+  });
+
+  it('is a no-op on an unknown sid', () => {
+    const { controller, activeStreamTracker, liveSessions } =
+      makeController(null);
+
+    controller.stopLiveSession('missing');
+
+    expect(liveSessions.stop).toHaveBeenCalledWith('missing');
+    expect(activeStreamTracker.unregister).not.toHaveBeenCalled();
+  });
+
+  it('does not unregister when the session has no userId', () => {
+    const live = makeLive({ profileHash: null, userId: null, mediaFileId: 42 });
+    const { controller, activeStreamTracker } = makeController(live);
+
+    controller.stopLiveSession('sid-1');
+
+    expect(activeStreamTracker.unregister).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -814,6 +814,13 @@ export class StreamingController {
   stopLiveSession(@Param('sessionId') sessionId: string) {
     const live = this.liveSessions.get(sessionId);
     this.liveSessions.stop(sessionId);
+    // Clear the "now watching" tracker row immediately. DirectPlay has no
+    // profileHash, so the ffmpeg-kill path below is skipped and would never
+    // unregister this (user, file) — leaving the dashboard row up until the
+    // tracker's stale timeout.
+    if (live?.userId != null) {
+      this.activeStreamTracker.unregister(live.userId, live.mediaFileId);
+    }
     if (!live || !live.profileHash) return;
     // Only kill the underlying ffmpeg job(s) when no other live
     // session is still referencing this (user, file, profileHash) —


### PR DESCRIPTION
## Why

Three observability/leak issues in streaming session management surfaced while auditing the "now watching" dashboard:

1. A DirectPlay close left its dashboard row up for up to 2 min (the `ActiveStreamTracker` stale timeout).
2. A client that simply died (no explicit stop) lingered on the dashboard until the next live-session GC sweep.
3. A misbehaving client that keeps re-issuing `playback-info` without stopping could leak unbounded live-session entries for one user.

## What

**Change 1 — clear the now-watching row on DirectPlay stop** (`streaming.controller.ts`)
The sid-scoped `DELETE /sessions/:sid` handler returned at the `!live.profileHash` guard before unregistering the tracker row. DirectPlay sessions carry no `profileHash`, so they hit that guard and the row was only ever cleared by the deprecated bulk DELETE. The handler now unregisters the `(userId, mediaFileId)` tracker row up-front, before the ffmpeg-kill path that DirectPlay skips.

**Change 2a — dashboard recency filter** (`system.controller.ts`)
`activeStreams()` read `LiveSessionRegistry.list()`, which returns every entry by design (the bulk DELETE handler relies on it), so a dead session showed until the next GC. The dashboard view now filters to entries whose `lastBeat` is newer than the live-session TTL (`StreamLifetime.liveSessionTtlMs()`). `list()` itself is unchanged.

**Change 2b — per-user concurrent-session cap** (`live-session.service.ts`, `lifetime-constants.ts`)
`create()` now enforces an env-tunable cap (`STREAM_MAX_SESSIONS_PER_USER`, default 10). When a user is at/over the cap, the oldest-`lastBeat` session for that user is **evicted** (never rejected — legit multi-device must not be blocked). Anonymous (null `userId`) sessions are exempt. An eviction logs the userId + evicted sessionId.

## Tests

- `streaming.controller.spec.ts` (new): `stopLiveSession` unregisters the tracker row for a DirectPlay sid (null `profileHash`), also for a transcode sid, no-op on unknown sid, and skips unregister when `userId` is null.
- `system.controller.spec.ts` (new): `activeStreams()` hides a session whose `lastBeat` is older than the TTL, and honours `STREAM_LIVE_SESSION_TTL_MS`.
- `live-session.service.spec.ts` (extended): evicts the oldest-beaten session over the cap, evicts least-recently-beaten (not first-inserted), caps each user independently, exempts anonymous sessions, defaults to 10.

`npx tsc --noEmit` clean. `jest --runInBand live-session streaming.controller system.controller` → 28 passed; `streaming-lifecycle` → 6 passed (regression check).