### PR TITLE
fix(player): stop sessions on close and cap the native reload loop

### DIFF
--- a/client/src/app/core/services/playback-engine/native-engine.ts
+++ b/client/src/app/core/services/playback-engine/native-engine.ts
@@ -44,9 +44,12 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
    *  `nativePlayerError` bridge. ExoPlayer / AVPlayer can't tell us the
    *  HTTP status that triggered the error, so the first error during
    *  stable playback is routed to `sessionExpired` (which makes the
-   *  player call /playback-info + reload). If a second error follows
-   *  before the next load() clears the flag, fall through to a real
-   *  fatal `error` so the UI isn't stuck retrying a broken stream. */
+   *  player call /playback-info + reload). A second error before the
+   *  guard is re-armed falls through to a real fatal `error` so the UI
+   *  isn't stuck retrying a broken stream. The guard is re-armed only by
+   *  {@link resetRecoveryGuard} — on a user-initiated (re)load or once a
+   *  recovery has sustained playback, never on every load() — so a
+   *  recovery reload that immediately re-fails can't loop forever. */
   private recoveryAttempted = false;
   /** Last `timeUpdate.position` seen, used to detect that playback is
    *  actually advancing (Android's onRenderedFirstFrame is unreliable on
@@ -112,6 +115,13 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
   /** Mark next load() as offline — uses CacheDataSource on Android. */
   setOffline(offline: boolean) { this._offline = offline; }
 
+  /** Re-arm the one-shot {@link recoveryAttempted} guard so a fresh stream
+   *  gets its single optimistic recovery again. Called by the player on a
+   *  user-initiated (re)load and after a recovery sustains playback. */
+  resetRecoveryGuard(): void {
+    this.recoveryAttempted = false;
+  }
+
   async load(
     url: string,
     startTime?: number,
@@ -119,7 +129,6 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
     headers?: Record<string, string>,
   ): Promise<void> {
     this.firstFrameEmitted = false;
-    this.recoveryAttempted = false;
     this.lastTimeUpdatePos = -1;
     // Subtitles are delivered as HLS SUBTITLES renditions in the master
     // playlist, not sidecar SubtitleConfigurations, so the player surfaces

--- a/client/src/app/core/services/playback-engine/playback-engine.ts
+++ b/client/src/app/core/services/playback-engine/playback-engine.ts
@@ -119,6 +119,10 @@ export interface PlaybackEngine {
   destroy(): Promise<void>;
   load(url: string, startTime?: number, mimeType?: string, headers?: Record<string, string>): Promise<void>;
   unload(): Promise<void>;
+  /** Re-arm the native optimistic-recovery one-shot guard. No-op on engines
+   *  that read a real HTTP status (Shaka). Called on a user-initiated
+   *  (re)load and after a recovery sustains playback. */
+  resetRecoveryGuard?(): void;
 
   // ── Playback ──
   play(): Promise<void>;

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1970,6 +1970,16 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     opts: { preservePause: boolean; unmute: boolean },
   ): Promise<void> {
     if (!this.engine || !this.mediaFileId) return;
+    // Drop the prior sid before minting a new one. A recovery loop that
+    // re-mints without this leaks one LiveSession per iteration, each
+    // surfacing as its own row on the admin activity dashboard. Fire-and-
+    // forget — a stale/expired sid 204s. (reloadStream already does this.)
+    const prevSid = this.playbackInfo?.sessionId;
+    if (prevSid) {
+      this.streamingApi
+        .stopSessions(this.mediaFileId, prevSid)
+        .catch(() => {});
+    }
     if (opts.unmute) this.engine.muted = false;
     const wasPaused = opts.preservePause ? this.paused() : false;
     const deviceProfile = this.deviceProfileService.getProfile();
@@ -2043,13 +2053,21 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
    * surface `sessionLost: true` in the interval.
    */
   private recoveringFromLostSession = false;
-  /** Failed recovery attempts in the current loss episode. Reset to 0 on a
-   *  successful reload; once it reaches {@link maxRecoverAttempts} we stop
-   *  retrying and surface a terminal error instead of reloading forever. */
+  /** Recovery attempts in the current loss episode. Cleared only once a
+   *  reload sustains playback (see {@link recoverConfirmPending}), NOT on the
+   *  instant a reload resolves — a reload that succeeds then re-fails within
+   *  seconds must keep counting toward {@link maxRecoverAttempts}, or it
+   *  re-mints a fresh sid every iteration and loops forever. */
   private recoverAttempts = 0;
   private readonly maxRecoverAttempts = 3;
   /** Pending backoff retry between failed recovery attempts (2s → 4s). */
   private recoverRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  /** A recovery reload just resolved; the episode counter and the native
+   *  recovery guard are cleared only after the playhead advances for
+   *  {@link recoverConfirmMs} (confirmed in checkStall). */
+  private recoverConfirmPending = false;
+  private recoverConfirmAt = 0;
+  private readonly recoverConfirmMs = 5_000;
   /** Set in ngOnDestroy. Blocks any late async (heartbeat sessionLost,
    *  sessionExpired event, Cast resume) from reloading the engine after the
    *  player has been torn down — otherwise a fresh native player relaunches
@@ -2085,7 +2103,12 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     if (this.castService.isConnected()) return;
     // Not trying to play, or not playing yet → no stall to detect; keep the
     // baseline fresh so resuming/finishing-load doesn't trip the timer.
-    if (this.paused() || this.state.loading() || this.recoveringFromLostSession) {
+    if (
+      this.paused() ||
+      this.state.loading() ||
+      this.recoveringFromLostSession ||
+      this.reloadingStream
+    ) {
       this.resetStallWatchdog();
       return;
     }
@@ -2100,6 +2123,17 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     if (Math.abs(pos - this.lastProgressPos) > 0.25) {
       this.lastProgressPos = pos;
       this.lastProgressAt = Date.now();
+      // A recovery that has sustained playback for recoverConfirmMs is clean:
+      // clear the episode counter and re-arm the native one-shot guard so a
+      // later, unrelated blip gets its own recovery instead of going fatal.
+      if (
+        this.recoverConfirmPending &&
+        Date.now() - this.recoverConfirmAt >= this.recoverConfirmMs
+      ) {
+        this.recoverConfirmPending = false;
+        this.recoverAttempts = 0;
+        this.engine?.resetRecoveryGuard?.();
+      }
       return;
     }
     if (Date.now() - this.lastProgressAt >= this.stallTimeoutMs) {
@@ -2139,9 +2173,13 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         preservePause: true,
         unmute: false,
       });
-      this.recoverAttempts = 0;
       this.resetStallWatchdog();
       this.state.setRecovering(false);
+      // Don't clear the episode counter yet — only once the reload proves it
+      // plays (checkStall confirms sustained progress). A reload that resolves
+      // then immediately re-fails keeps counting toward the cap.
+      this.recoverConfirmPending = true;
+      this.recoverConfirmAt = Date.now();
     } catch {
       this.recoverAttempts += 1;
       if (this.recoverAttempts >= this.maxRecoverAttempts) {
@@ -2732,8 +2770,26 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
   // ── Private helpers ──
 
-  /** Reload the stream (e.g. when toggling burn-in subtitles or switching audio). */
+  /** Guards against overlapping reloads: a user switch racing a recovery (or
+   *  a second quick switch) must not run two getPlaybackInfo + load cycles at
+   *  once — that races the engine and leaks a session. */
+  private reloadingStream = false;
+
+  /** Reload the stream (e.g. when toggling burn-in subtitles or switching
+   *  audio). User-initiated, so re-arm the native recovery guard and serialise
+   *  against any concurrent reload/recovery. */
   private async reloadStream() {
+    if (!this.engine || this.reloadingStream) return;
+    this.reloadingStream = true;
+    this.engine.resetRecoveryGuard?.();
+    try {
+      await this.doReloadStream();
+    } finally {
+      this.reloadingStream = false;
+    }
+  }
+
+  private async doReloadStream() {
     if (!this.engine) return;
     const currentPos = this.engine.currentTime;
     // Capture the user's play/pause intent before tearing the stream down — a
@@ -2801,7 +2857,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   }
 
   private fireAndForgetStopSessions() {
-    if (!this.mediaFileId || this.playbackMode() === 'direct') return;
+    // Release this device's session on exit — DirectPlay included, so its
+    // "now watching" dashboard row clears at once instead of lingering until
+    // the backend idle reap (transcode/remux paths also stop their ffmpeg).
+    if (!this.mediaFileId) return;
     const url = this.streamingApi.getStopSessionsUrl(
       this.mediaFileId,
       this.activeSessionId(),


### PR DESCRIPTION
Fixes two session-lifecycle holes behind the iOS "many sessions at once" report and lingering admin-activity rows.

## P3 — close didn't always stop the session
`fireAndForgetStopSessions` early-returned for `playbackMode()==='direct'`, so a **DirectPlay** close never released its session and the "now watching" row lingered until the backend idle reap. Dropped the early-return — every play method stops on exit (kept the `keepalive` fetch; `sendBeacon` can't issue a DELETE). Pairs with PR #493 which clears the DirectPlay tracker row backend-side.

## P4 — native reload-recovery loop spawning sessions
The native engine can't read a segment's HTTP status, so the first error in stable playback is optimistically routed to one recovery (re-mint sid + reload). Two defects made it unbounded:
- `refreshSidAndReload` minted a fresh LiveSession **without stopping the prior sid** → one leaked session (= one dashboard row) per iteration.
- both the player `recoverAttempts` counter **and** the native one-shot guard reset on every reload → a reload that played one frame then re-failed recovered forever.

Fixes:
- stop the old sid before each re-mint (mirrors `reloadStream`);
- the episode counter + the native guard clear **only after a reload sustains playback** (confirmed in the stall watchdog), not the instant it resolves;
- `reloadStream` serialises behind a re-entrancy lock so a user switch can't race a recovery into two concurrent `getPlaybackInfo + load` cycles;
- `resetRecoveryGuard()` added as an optional `PlaybackEngine` method (Shaka, which reads real HTTP status, leaves it unimplemented).

Deliberately **not** done (avoids regressions): no aggressive stop-on-`visibilitychange`/App-pause — `pagehide` already releases on iOS background and the backend keeps a deliberate 30s+grace reconnect window; no absolute recovery ceiling — a genuinely flaky-but-recovering stream should keep recovering, and the per-iteration leak is already closed by stop-old-sid.

## Verification
`tsc --noEmit -p tsconfig.app.json` clean. The iOS reload-loop behaviour needs **on-device validation** (can't repro the native opaque-error path here). Two pre-existing `tsconfig.spec.json` errors (`device.service.ts` `fliksDesktop`, `engine-traits.spec.ts` missing `DESKTOP`) are inherited from the desktop-client merge, not this PR.