### PR TITLE
fix(player): re-present iOS video layer on foreground and PiP exit

### DIFF
--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -3,6 +3,7 @@ import Capacitor
 import AVFoundation
 import AVKit
 import CoreMedia
+import UIKit
 
 /// UIView subclass that keeps its first CALayer sublayer (the AVPlayerLayer) sized to bounds.
 private class PlayerContainerView: UIView {
@@ -67,6 +68,36 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
     public var activePlayerLayer: AVPlayerLayer? { playerLayer }
     /// Exposed for PipPlugin to access the player.
     public var activePlayer: AVPlayer? { player }
+
+    /// Re-present the AVPlayerLayer after a background round-trip or a PiP
+    /// exit. iOS can release the layer's backing render surface for the
+    /// off-screen scene (and an auto-PiP exit can leave the inline layer
+    /// detached) while AVPlayer keeps decoding audio and the subtitle overlay
+    /// keeps drawing — so the inline video returns black over the container's
+    /// black backdrop. Rebinding the player, re-stamping the frame and (when
+    /// the layer isn't presenting) toggling videoGravity force a recomposite.
+    /// Idempotent; safe to call when already presenting.
+    func reassertVideoPresentation() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self,
+                  let layer = self.playerLayer,
+                  let player = self.player,
+                  let view = self.playerView else { return }
+            // Diagnostic — surfaces on-device whether the returning layer is
+            // detached / not-ready (vs ready-but-black) so the recomposite
+            // path can be tuned from real logs.
+            let state = "ready=\(layer.isReadyForDisplay) attached=\(layer.player != nil) size=\(Int(view.bounds.width))x\(Int(view.bounds.height))"
+            self.bridge?.webView?.evaluateJavaScript("console.warn('[NativePlayer] reassert: \(state)');")
+
+            if layer.player !== player { layer.player = player }
+            layer.frame = view.bounds
+            if !layer.isReadyForDisplay {
+                let gravity = layer.videoGravity
+                layer.videoGravity = .resize
+                layer.videoGravity = gravity
+            }
+        }
+    }
 
     // MARK: - Lifecycle
 
@@ -772,6 +803,29 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             name: .AVPlayerItemDidPlayToEndTime,
             object: player.currentItem
         )
+
+        // Returning from background / becoming active: iOS can drop the
+        // AVPlayerLayer's backing surface for the off-screen scene (or an
+        // auto-PiP exit leaves the inline layer detached) while audio and the
+        // subtitle overlay keep running — the video returns black. Re-present
+        // it. Torn down by removeObservers() and re-added on the next load(),
+        // matching the item observers above.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAppDidForeground),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAppDidForeground),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+    }
+
+    @objc private func handleAppDidForeground() {
+        reassertVideoPresentation()
     }
 
     @objc private func handleNewErrorLogEntry(_ notification: Notification) {

--- a/client/ios/App/App/PipPlugin.swift
+++ b/client/ios/App/App/PipPlugin.swift
@@ -121,8 +121,18 @@ public class PipPlugin: CAPPlugin, CAPBridgedPlugin, AVPictureInPictureControlle
 
     public func pictureInPictureControllerDidStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
         nativePlayer?.finishSubtitlePiPExit()
+        // PiP transferred the shared AVPlayerLayer into its window; the inline
+        // layer can come back not-presenting (black) once PiP releases it.
+        nativePlayer?.reassertVideoPresentation()
         emitPipModeChanged(false)
         pipController = nil
+    }
+
+    public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void) {
+        // Re-present the inline layer before signalling the restore is done,
+        // so the full-app UI never reappears over a black (sourceless) layer.
+        nativePlayer?.reassertVideoPresentation()
+        completionHandler(true)
     }
 
     public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, failedToStartPictureInPictureWithError error: Error) {


### PR DESCRIPTION
> **DRAFT — needs a macOS/Xcode build + on-device test before merge.** This is iOS-native Swift that cannot be compiled or validated in the Linux dev environment. Do not merge until confirmed on a device.

## Why
The iOS player is an `AVPlayerLayer` behind a transparent WebView; subtitles are a separate overlay on top. After the app backgrounds — or an auto-PiP session ends — iOS can release the layer's backing render surface for the off-screen scene while `AVPlayer` keeps decoding audio and the overlay keeps drawing. Result: **video returns black, audio + subtitles keep going**. Nothing re-presented the layer (no app-lifecycle observers, no PiP-stop restore handler).

## What
- `NativePlayerPlugin.reassertVideoPresentation()` — rebind `layer.player`, re-stamp `layer.frame`, and (only when `!isReadyForDisplay`) toggle `videoGravity` to force a recomposite. Idempotent, main-thread.
- Registered `willEnterForeground` + `didBecomeActive` observers in `setupObservers()` (they ride the existing `removeObservers()`→`setupObservers()` cycle on each `load()`, same as the item observers — confirmed pattern; `CastPlugin` already uses `willEnterForegroundNotification`).
- `PipPlugin`: re-present on `didStopPictureInPicture` **and** implement `restoreUserInterfaceForPictureInPictureStop(completionHandler:)` (re-present, then `completionHandler(true)`).
- A diagnostic `console.warn('[NativePlayer] reassert: ready=… attached=… size=…')` logs the returning layer's state so we can confirm the failure signature (detached vs ready-but-black) from device logs and tune.

## Device test
1. Cold-launch a transcode title → picture appears (no black-with-audio).
2. Background mid-playback, wait, foreground → picture returns.
3. Trigger auto-PiP, then return to full app → picture returns.
4. Lock/unlock during playback.
Capture the `[NativePlayer] reassert:` logs (Safari Web Inspector). If they show `ready=true` while the screen is black, drop the `!isReadyForDisplay` guard so the `videoGravity` toggle always runs.

## Not included (lower-confidence, pending device diagnostics)
The launch-time first-present race (one-shot `firstFrameEmitted` latch + the TS position-growth fallback) is left for a follow-up — gating the TS veil teardown risks a stuck spinner on devices where `isReadyForDisplay` is unreliable, so it should be driven by the diagnostic logs above.