### PR TITLE
fix(client): restore spec-build compile after the desktop client merge

### DIFF
--- a/client/src/app/core/plugins/desktop-bridge.d.ts
+++ b/client/src/app/core/plugins/desktop-bridge.d.ts
@@ -1,0 +1,12 @@
+import type { FliksDesktopApi } from './desktop-player.bridge';
+
+// Ambient `Window.fliksDesktop` augmentation. Kept in a `.d.ts` (matched by
+// every tsconfig's `src/**/*.d.ts` include) so the global type is visible to
+// the spec project too — the bridge module that injects it isn't pulled into
+// the spec program, so a sibling `declare global` there isn't seen by specs.
+declare global {
+  interface Window {
+    /** Injected by the Electron desktop preload; absent in browser / native. */
+    fliksDesktop?: FliksDesktopApi;
+  }
+}

--- a/client/src/app/core/services/engine-traits.spec.ts
+++ b/client/src/app/core/services/engine-traits.spec.ts
@@ -16,6 +16,12 @@ const EXPECTED: Record<EngineKind, EngineTraits> = {
     probesSegZero: false,
     supportsDirectPlay: true,
   },
+  [EngineKind.DESKTOP]: {
+    useTsOnSingleAudio: false,
+    supportsHlsSubtitles: true,
+    probesSegZero: true,
+    supportsDirectPlay: true,
+  },
   [EngineKind.ANDROID_TV]: {
     useTsOnSingleAudio: false,
     supportsHlsSubtitles: true,
@@ -58,6 +64,11 @@ describe('engineKindFor', () => {
 
   it('maps webos to WEBOS', () => {
     expect(engineKindFor('webos', true)).toBe(EngineKind.WEBOS);
+  });
+
+  it('maps isDesktop=true to DESKTOP, ahead of the native split', () => {
+    // Electron is also isNative (its UA matches), so isDesktop must win.
+    expect(engineKindFor(null, true, true)).toBe(EngineKind.DESKTOP);
   });
 });
 


### PR DESCRIPTION
`tsc --noEmit -p tsconfig.spec.json` broke on `main` after the desktop client merge (`ef3a30c4`):

1. `engine-traits.spec.ts` — `EngineKind.DESKTOP` was added to `ENGINE_TRAITS` but not to the spec's `Record<EngineKind, EngineTraits>` expectation → TS2741 (missing key).
2. `device.service.ts:142` — reads `window.fliksDesktop`, but the `declare global { interface Window { fliksDesktop } }` lives in `desktop-player.bridge.ts`, a module no spec imports, so the spec program never saw the augmentation → TS2339.

## Fix
- New `desktop-bridge.d.ts` carrying the `Window.fliksDesktop` augmentation (importing the existing `FliksDesktopApi` type). `.d.ts` is matched by `src/**/*.d.ts` in every tsconfig, so app **and** spec see the global. (The bridge's own `declare global` is left in place — identical augmentations merge harmlessly.)
- Added the `DESKTOP` row to the spec's `EXPECTED` table and an `engineKindFor(null, true, true) → DESKTOP` case (the `isDesktop` param the desktop merge added was untested).

`tsc --noEmit` clean on both `tsconfig.app.json` and `tsconfig.spec.json`.