### PR TITLE
fix(desktop): poll mpv time-pos so playback progress advances

### DIFF
--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -148,6 +148,13 @@ const KEYMAP: Record<string, string> = {
 let uiWin: BrowserWindow | null = null;
 const inputCounts: Record<string, number> = {};
 
+// Cadence of the periodic position emit while playing. The addon only observes
+// `time-pos` for duration/seek transitions, not as playback advances, so the
+// renderer's seekbar and its 10s save heartbeat stay frozen unless the main
+// process pushes the position itself. ~250ms (4Hz) keeps the bar smooth and
+// feeds the renderer's per-second stats refresh without flooding IPC.
+const POSITION_POLL_MS = 250;
+
 function send(ev: DesktopEvent): void {
   if (uiWin && !uiWin.isDestroyed()) uiWin.webContents.send(IPC.event, ev);
 }
@@ -191,6 +198,31 @@ app.whenReady().then(() => {
 
   addon.start({ width: WIDTH, height: HEIGHT, title: 'Fliks' });
 
+  // Periodic position emit. The addon's `time-pos` observe doesn't push while
+  // playback advances, so poll mpv on a timer and forward a `timeUpdate` — this
+  // is what advances the seekbar and feeds the renderer's resume-save heartbeat.
+  let positionTimer: ReturnType<typeof setInterval> | null = null;
+  const emitPosition = (): void => {
+    send({
+      type: 'timeUpdate',
+      payload: {
+        position: num(addon.getProperty('time-pos')),
+        duration: num(addon.getProperty('duration')),
+        buffered: num(addon.getProperty('demuxer-cache-time')),
+      },
+    });
+  };
+  const startPositionTimer = (): void => {
+    if (positionTimer) return; // idempotent — never stack intervals
+    emitPosition(); // emit immediately so the bar doesn't wait a full tick
+    positionTimer = setInterval(emitPosition, POSITION_POLL_MS);
+  };
+  const stopPositionTimer = (): void => {
+    if (!positionTimer) return;
+    clearInterval(positionTimer);
+    positionTimer = null;
+  };
+
   // mpv events → reshape to the DesktopEvent contract → renderer.
   addon.onEvent((json) => {
     let raw: any;
@@ -204,15 +236,25 @@ app.whenReady().then(() => {
         send({ type: 'timeUpdate', payload: { position: raw.position, duration: raw.duration, buffered: 0 } });
         break;
       case 'stateChanged':
+        // Only an actively-playing session should drive the position timer;
+        // pausing / ending / going idle stops it so a torn-down or paused
+        // player can't keep emitting (and leaking the interval).
+        if (raw.state === 'playing') startPositionTimer();
+        else stopPositionTimer();
         send({ type: 'stateChanged', payload: { state: raw.state } });
         break;
       case 'tracksChanged':
         send({ type: 'tracksChanged', payload: parseTracks(addon.getProperty('track-list')) as any });
         break;
       case 'firstFrame':
+        // mpv autoplays on load (addon forces pause=no) but may not emit a
+        // pause-property change, so the playing stateChanged can be missing on
+        // a fresh load — arm the timer on the first frame as well.
+        startPositionTimer();
         send({ type: 'firstFrame' });
         break;
       case 'error':
+        stopPositionTimer();
         send({ type: 'error', payload: { code: -1, message: raw.message ?? 'error' } });
         break;
     }
@@ -258,7 +300,10 @@ app.whenReady().then(() => {
   ipcMain.handle(IPC.play, () => addon.setProperty('pause', 'no'));
   ipcMain.handle(IPC.pause, () => addon.setProperty('pause', 'yes'));
   ipcMain.handle(IPC.seek, (_e, position: number) => addon.command(['seek', String(position), 'absolute']));
-  ipcMain.handle(IPC.stop, () => addon.command(['stop']));
+  ipcMain.handle(IPC.stop, () => {
+    stopPositionTimer();
+    return addon.command(['stop']);
+  });
   ipcMain.handle(IPC.setPlaybackRate, (_e, r: number) => addon.setProperty('speed', String(r)));
   ipcMain.handle(IPC.setVolume, (_e, v: number) => addon.setProperty('volume', String(v)));
   ipcMain.handle(IPC.setMuted, (_e, m: boolean) => addon.setProperty('mute', m ? 'yes' : 'no'));
@@ -285,12 +330,16 @@ app.whenReady().then(() => {
     for (const [name, value] of mpvSubtitleProps(s)) addon.setProperty(name, value);
   });
   ipcMain.handle(IPC.resize, () => {});
-  ipcMain.handle(IPC.destroy, () => addon.command(['stop']));
+  ipcMain.handle(IPC.destroy, () => {
+    stopPositionTimer();
+    return addon.command(['stop']);
+  });
 
   uiWin.loadURL(haveApp ? APP_URL : 'data:text/html,<body style="background:%231d232a"></body>');
   uiWin.webContents.once('did-finish-load', () => send({ type: 'ready' }));
 
   app.on('before-quit', () => {
+    stopPositionTimer();
     try {
       addon.stop();
     } catch {


### PR DESCRIPTION
## Why

On the Linux desktop client (Electron + native compositor addon), **playback progress never updates**: the seekbar / current-time display stays frozen during playback and the resume position is never saved to the server. Audio and video play fine — only the position doesn't advance.

The live playback path is the native compositor addon (`desktop/src/main/index.ts` → `fliks_compositor.node`), not the older JS-IPC spike (`src/main/mpv/mpv-player.ts`). The addon **observes** `time-pos`, but in the render-API setup it only pushes a `timeUpdate` on duration/seek transitions, not as playback advances — so the addon path emits no periodic position.

Everything downstream is wired correctly and was simply starved:
- `DesktopEngine` (`client/.../playback-engine/desktop-engine.ts`) handles `timeUpdate` → sets `_currentTime`; the `currentTime` getter returns it.
- `PlayerStateService.bindEngine` subscribes to the engine `timeUpdate` to drive `state.currentTime` (the seekbar).
- `player.ts` `savePosition()` (10s heartbeat) reads `engine.currentTime`.

With no periodic `timeUpdate`, the bar froze and the resume save had nothing to persist.

## What

Drive the position from the **main process** instead of relying on the addon's observe:

- A 250ms (`POSITION_POLL_MS`) interval polls `time-pos` / `duration` / `demuxer-cache-time` via `addon.getProperty(...)` and `send`s a `timeUpdate`, mirroring the JS-IPC spike's per-tick emit.
- The timer is **idempotent** (never stacked) and emits once immediately on start so the bar doesn't wait a full tick.
- **Starts** on the `playing` stateChange and on `firstFrame` (a fresh autoplaying load — the addon forces `pause=no` — may not emit a pause-property change).
- **Stops** on pause / idle / ended / error, and on `stop` / `destroy` / `before-quit`, so a paused or torn-down player can't keep emitting or leak the interval.

No client changes were needed — the renderer/engine path was already correct.

## How to verify on the running app

Build only the changed unit (main bundle) and run per `desktop/CLAUDE.md`:

```bash
cd desktop && npm run build:main
cd desktop && FLIKS_WEB_DIR=/tmp/fliks-verify/browser DISPLAY=:0 \
  ./node_modules/.bin/electron . --no-sandbox
```

1. Start any media. Confirm the **seekbar fills and the current-time display advances** continuously (~4Hz) during playback.
2. **Pause** → the time stops advancing; **resume** → it advances again.
3. Let it play >10s, then quit. Relaunch and reopen the same media → it **resumes** at the saved position (the 10s heartbeat now has a moving `currentTime` to persist).
4. **Seek** → the bar tracks the new position and keeps advancing from there.

## tsc

- `desktop`: `npm run typecheck` (`tsc -p tsconfig.json`) — clean.
- `client`: `tsc --noEmit -p tsconfig.app.json` — clean.
- `esbuild` bundle of `src/main/index.ts` — clean.

## Caveats

- I could not drive the GUI here (no display/build toolchain in this worktree) — verification steps above are for on-device.
- I could not rebuild the C++ addon here, so the fix deliberately lives in the TS main process (only `src/main/index.ts` changed; rebuild with `npm run build:main`, no addon rebuild needed). The addon's own (sparse) `time-pos` observe is left in place — the poll is the authoritative source now; the two are harmless together.