### PR TITLE
fix(desktop): move deb options to the config root for electron-builder

### DIFF
--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -61,11 +61,12 @@ linux:
       StartupWMClass: fliks
   target: [AppImage, deb]
   category: AudioVideo
-  # deb runtime deps: the addon links SDL2/GLES/EGL and dlopen's libmpv. The
-  # vendored libmpv is self-contained, but SDL2 + GL are expected on the host.
-  # TODO: confirm this list against a real .deb install on a clean Ubuntu box.
-  deb:
-    depends:
-      - libsdl2-2.0-0
-      - libgles2
-      - libegl1
+# deb runtime deps live at the ROOT (DebOptions), not under `linux`. The addon
+# links SDL2/GLES/EGL and dlopen's libmpv; the vendored libmpv is self-contained
+# but SDL2 + GL are expected on the host.
+# TODO: confirm this list against a real .deb install on a clean Ubuntu box.
+deb:
+  depends:
+    - libsdl2-2.0-0
+    - libgles2
+    - libegl1


### PR DESCRIPTION
The first desktop-release CI run failed at the **Build installer** step on Linux: electron-builder 26 schema-rejected the config because `deb` was nested under `linux`. `deb` is a **root-level** `DebOptions` key (confirmed against app-builder-lib's `scheme.json` — `executableName`/`desktop`/`target`/`category` are valid under `linux`, `deb` is not). Moved `deb:` to the config root. Validated the corrected YAML against the electron-builder schema (0 errors).

(macOS/Windows still fail earlier at `node-gyp` — the binding.gyp is Linux-only; that's a separate, known scaffold TODO.)