### PR TITLE
fix(desktop): add homepage and author for .deb package metadata

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -2,6 +2,8 @@
   "name": "fliks-desktop",
   "version": "1.11.0",
   "description": "Fliks native desktop client (macOS / Windows / Linux)",
+  "author": "Fliks <contact@fliks.media>",
+  "homepage": "https://github.com/fliks-app/fliks",
   "private": true,
   "type": "module",
   "main": "dist/main/index.cjs",


### PR DESCRIPTION
The desktop-release Linux job got past the schema fix and failed in fpm with *"Please specify project homepage"* (and a missing-author warning) — electron-builder's `.deb` target needs both for the package control fields. Added `homepage` + `author` to `desktop/package.json`.

This is the last blocker for the **Linux .deb** (which then carries the transparent icon via the generated `.desktop` + the versioned filename). macOS/Windows still fail earlier at `node-gyp` — the native addon needs an ANGLE-based cross-platform port (separate effort).