### PR TITLE
fix(streaming): block the 0-byte audio rendition init to avoid a fatal 404

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -1383,6 +1383,34 @@ export class StreamingController {
       return;
     }
 
+    // 0-byte guard, mirroring the video routes (hlsSegment init/seg paths).
+    // var_stream_map writes the rendition init (`<idx+1>/init_<idx+1>.mp4`) with
+    // a `creat()`-then-moov-write gap and no `+temp_file` atomic rename for
+    // inits, so getSegmentPath can hand back a path the instant the entry
+    // appears — while it is still 0 bytes. Passing that straight to
+    // segmentPackaging.serve() makes readAndRewriteCmaf return null, which
+    // serve() turns into a SILENT 404 (no controller log). A native HLS demuxer
+    // (libmpv/ffmpeg) opens the whole master at once and treats a failed
+    // alt-audio EXT-X-MAP init as fatal — no retry — so that one 0-byte read
+    // crashes the load. Block the init read until the moov lands; on timeout
+    // surface a retryable 503 instead of letting serve() emit the fatal 404.
+    if (isInit) {
+      const ready = await awaitFileNonEmpty(segPath, 5000);
+      if (!ready) {
+        this.log.warn(
+          `Audio segment 503 (0-byte init): ${segment} (audioIndex=${audioIndex}, mfid=${mediaFileId})`,
+        );
+        sendTransientUnavailable(res);
+        return;
+      }
+    } else {
+      const segSize = statSizeOrNull(segPath);
+      if (segSize === null || segSize === 0) {
+        sendTransientUnavailable(res);
+        return;
+      }
+    }
+
     await this.segmentPackaging.serve(
       res,
       segPath,


### PR DESCRIPTION
## Problem

Native HLS players that open the whole master playlist in a single demuxer pass (e.g. the desktop libmpv/ffmpeg client) crash **instantly** when loading a **multi-audio** source — `hls: Failed to open an initialization section in playlist N` → `avformat_open_input() failed` → load aborts. The same titles play fine in the browser, and **single-audio** titles play fine everywhere.

## Root cause

A multi-audio source emits a separate `EXT-X-MEDIA` audio rendition whose fMP4 init is produced by `var_stream_map` at `<audioIndex+1>/init_<audioIndex+1>.mp4`. ffmpeg writes that init `creat()`-then-moov with **no `+temp_file` atomic rename for inits**, so there is a brief window where the file exists at **0 bytes**. `getSegmentPath` returns a path as soon as the entry exists (size-agnostic), and `hlsAudioSegment` passed it straight to segment serving — where the CMAF reader returns `null` on an empty file and the response degrades to a **silent 404** (no controller log, which is why nothing showed up server-side).

A native HLS demuxer opens every rendition up front and treats a failed alternate-rendition `EXT-X-MAP` init as **fatal with no retry**, so that one empty read kills the entire load. Browser players open renditions lazily and retry, so they never saw it; single-audio sources have no separate rendition to fail.

## Fix

Add the same 0-byte guard the **video** routes already carry, right before serving in `hlsAudioSegment`:
- **init**: `awaitFileNonEmpty(segPath, 5000)` — block until the moov lands, then serve a real 200; on a genuine stall return a retryable **503** (never the fatal silent 404).
- **segment**: size check → 503 on a 0-byte read.

This makes the audio-rendition init/seg a reliable blocking 200 during cold-start, matching the video init contract.

## Verification

- `tsc --noEmit` clean; `jest src/modules/streaming` 198/198 pass.
- Confirmed on-device: the multi-audio title now plays from-beginning **and** on resume.
- No behavior change for the browser, single-audio, remux, live, or Tizen/TS paths (the guard is additive, between an already-non-null path and serving, and mirrors the existing video-route 503-on-0-byte contract). Independent adversarial review across regression/correctness/completeness found no regression.