### PR TITLE
refactor(player): consolidate engine recovery guards and fix reload loops

### DIFF
--- a/client/src/app/core/services/playback-engine/desktop-engine.ts
+++ b/client/src/app/core/services/playback-engine/desktop-engine.ts
@@ -40,8 +40,6 @@ export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEng
   private _state: PlaybackState = 'idle';
   private _audioTracks: AudioTrack[] = [];
 
-  private firstFrameEmitted = false;
-  private recoveryAttempted = false;
   /** Set in destroy() so a leaked late event (the mpv player is a persistent
    *  singleton) can't drive a torn-down engine into recovery. */
   private dead = false;
@@ -96,8 +94,7 @@ export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEng
     _mimeType?: string,
     headers?: Record<string, string>,
   ): Promise<void> {
-    this.firstFrameEmitted = false;
-    this.recoveryAttempted = false;
+    this.resetFirstFrame();
     await this.bridge.load({ url, startTime, headers });
     if (this._subtitleStyle) {
       await this.bridge.setSubtitleStyle(this._subtitleStyle);
@@ -335,9 +332,8 @@ export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEng
         break;
       }
       case 'firstFrame': {
-        if (this.firstFrameEmitted) return;
-        this.firstFrameEmitted = true;
-        this.emit('firstFrame', undefined);
+        if (this.firstFrameEmitted) break;
+        this.emitFirstFrameOnce();
         // The persistent mpv may not fire a pause-property change on a fresh
         // load (it was already unpaused from a prior session), so the UI's
         // paused signal would stay stuck on its default. Assert the playing
@@ -351,11 +347,7 @@ export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEng
         // mpv can't expose the failing segment's HTTP status either; mirror the
         // native heuristic — first error after a frame played → try one
         // session-expired recovery before surfacing a fatal error.
-        if (this.firstFrameEmitted && !this.recoveryAttempted) {
-          this.recoveryAttempted = true;
-          this.emit('sessionExpired', undefined);
-          return;
-        }
+        if (this.maybeEmitSessionExpired()) return;
         this._state = 'error';
         this.emit('error', event.payload);
         break;

--- a/client/src/app/core/services/playback-engine/native-engine.ts
+++ b/client/src/app/core/services/playback-engine/native-engine.ts
@@ -34,23 +34,6 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
 
   private listeners: Array<{ event: string; fn: EventListener }> = [];
 
-  /** Guards against double-emit of 'firstFrame' (engine listeners use
-   *  it to clear the loading veil — flipping it twice is harmless but
-   *  the position-advance fallback below would otherwise fire on every
-   *  later timeUpdate). Reset on each load(). */
-  private firstFrameEmitted = false;
-
-  /** One-shot guard for the optimistic-recovery branch in the
-   *  `nativePlayerError` bridge. ExoPlayer / AVPlayer can't tell us the
-   *  HTTP status that triggered the error, so the first error during
-   *  stable playback is routed to `sessionExpired` (which makes the
-   *  player call /playback-info + reload). A second error before the
-   *  guard is re-armed falls through to a real fatal `error` so the UI
-   *  isn't stuck retrying a broken stream. The guard is re-armed only by
-   *  {@link resetRecoveryGuard} — on a user-initiated (re)load or once a
-   *  recovery has sustained playback, never on every load() — so a
-   *  recovery reload that immediately re-fails can't loop forever. */
-  private recoveryAttempted = false;
   /** Last `timeUpdate.position` seen, used to detect that playback is
    *  actually advancing (Android's onRenderedFirstFrame is unreliable on
    *  some devices: it fires late or never on transcode → ABR switches,
@@ -115,20 +98,13 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
   /** Mark next load() as offline — uses CacheDataSource on Android. */
   setOffline(offline: boolean) { this._offline = offline; }
 
-  /** Re-arm the one-shot {@link recoveryAttempted} guard so a fresh stream
-   *  gets its single optimistic recovery again. Called by the player on a
-   *  user-initiated (re)load and after a recovery sustains playback. */
-  resetRecoveryGuard(): void {
-    this.recoveryAttempted = false;
-  }
-
   async load(
     url: string,
     startTime?: number,
     _mimeType?: string,
     headers?: Record<string, string>,
   ): Promise<void> {
-    this.firstFrameEmitted = false;
+    this.resetFirstFrame();
     this.lastTimeUpdatePos = -1;
     // Subtitles are delivered as HLS SUBTITLES renditions in the master
     // playlist, not sidecar SubtitleConfigurations, so the player surfaces
@@ -400,8 +376,7 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
         this.lastTimeUpdatePos >= 0 &&
         d.position > this.lastTimeUpdatePos
       ) {
-        this.firstFrameEmitted = true;
-        this.emit('firstFrame', undefined);
+        this.emitFirstFrameOnce();
       }
       this.lastTimeUpdatePos = d.position;
     });
@@ -414,11 +389,7 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
       // haven't tried recovery yet, treat the first error as a
       // possible session-expired and let the player attempt a single
       // /playback-info + reload before surfacing a fatal error.
-      if (this.firstFrameEmitted && !this.recoveryAttempted) {
-        this.recoveryAttempted = true;
-        this.emit('sessionExpired', undefined);
-        return;
-      }
+      if (this.maybeEmitSessionExpired()) return;
       this._state = 'error';
       this.emit('error', d);
     });
@@ -433,9 +404,7 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
     });
 
     bind('nativePlayerFirstFrame', () => {
-      if (this.firstFrameEmitted) return;
-      this.firstFrameEmitted = true;
-      this.emit('firstFrame', undefined);
+      this.emitFirstFrameOnce();
     });
   }
 

--- a/client/src/app/core/services/playback-engine/playback-engine.ts
+++ b/client/src/app/core/services/playback-engine/playback-engine.ts
@@ -87,6 +87,23 @@ export type EngineEventHandler<E extends EngineEvent> = (
 export abstract class AbstractPlaybackEngine {
   private handlers = new Map<EngineEvent, Set<EngineEventHandler<any>>>();
 
+  /** Whether `firstFrame` has been emitted for the current load. Subclasses
+   *  drive the emit via {@link emitFirstFrameOnce} and clear it in load() via
+   *  {@link resetFirstFrame}; the recovery heuristic reads it so a pre-frame
+   *  failure goes straight to a fatal error instead of optimistic recovery. */
+  protected firstFrameEmitted = false;
+
+  /** One-shot guard for the optimistic session-expired recovery. The native /
+   *  desktop / TV engines can't read the HTTP status of a failed segment fetch,
+   *  so the first error during stable playback is routed to `sessionExpired`
+   *  (which makes the player mint a fresh sid + reload). A second error before
+   *  the guard is re-armed falls through to a fatal `error`, so a reload that
+   *  immediately re-fails can't loop forever. Re-armed only by
+   *  {@link resetRecoveryGuard} — never on every load() — so a recovery reload
+   *  doesn't reset its own budget. Shaka reads a real 410 instead and never
+   *  touches this. */
+  protected recoveryAttempted = false;
+
   on<E extends EngineEvent>(event: E, handler: EngineEventHandler<E>): void {
     if (!this.handlers.has(event)) this.handlers.set(event, new Set());
     this.handlers.get(event)!.add(handler);
@@ -107,6 +124,43 @@ export abstract class AbstractPlaybackEngine {
   protected clearHandlers(): void {
     this.handlers.clear();
   }
+
+  /** Re-arm the optimistic-recovery one-shot. Called by the player on a
+   *  user-initiated (re)load and after a recovery sustains playback. No-op in
+   *  effect for engines that read a real HTTP status (Shaka). */
+  resetRecoveryGuard(): void {
+    this.recoveryAttempted = false;
+  }
+
+  /** Clear the first-frame latch at the start of a load() so the next stream
+   *  re-emits `firstFrame`. */
+  protected resetFirstFrame(): void {
+    this.firstFrameEmitted = false;
+  }
+
+  /** Emit `firstFrame` exactly once per load. Subclasses call this from
+   *  whichever signal first proves a frame was presented (rvfc, position
+   *  delta, native first-frame callback). */
+  protected emitFirstFrameOnce(): void {
+    if (this.firstFrameEmitted) return;
+    this.firstFrameEmitted = true;
+    this.emit('firstFrame', undefined);
+  }
+
+  /** Route a post-first-frame stream error to a single optimistic
+   *  `sessionExpired` recovery. Returns true when it consumed the error (the
+   *  caller should stop and not surface a fatal error), false when the guard
+   *  is spent / no frame has played and the caller must fall through to a real
+   *  error. Engines with a platform-specific precondition (e.g. a
+   *  network-shaped error string) gate on it before calling this. */
+  protected maybeEmitSessionExpired(): boolean {
+    if (this.firstFrameEmitted && !this.recoveryAttempted) {
+      this.recoveryAttempted = true;
+      this.emit('sessionExpired', undefined);
+      return true;
+    }
+    return false;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -121,8 +175,9 @@ export interface PlaybackEngine {
   unload(): Promise<void>;
   /** Re-arm the native optimistic-recovery one-shot guard. No-op on engines
    *  that read a real HTTP status (Shaka). Called on a user-initiated
-   *  (re)load and after a recovery sustains playback. */
-  resetRecoveryGuard?(): void;
+   *  (re)load and after a recovery sustains playback. Provided by
+   *  {@link AbstractPlaybackEngine}. */
+  resetRecoveryGuard(): void;
 
   // ── Playback ──
   play(): Promise<void>;

--- a/client/src/app/core/services/playback-engine/shaka-engine.ts
+++ b/client/src/app/core/services/playback-engine/shaka-engine.ts
@@ -25,10 +25,6 @@ export class ShakaEngine extends AbstractPlaybackEngine implements PlaybackEngin
   private videoListeners: Array<{ event: string; handler: EventListener }> = [];
   private shakaListeners: Array<{ event: string; handler: EventListener }> = [];
 
-  /** Tracks whether 'firstFrame' has been emitted for this load — fires
-   *  once per session, gated on requestVideoFrameCallback. */
-  private firstFrameEmitted = false;
-
   /** Set briefly after the 410 response filter has emitted
    *  `sessionExpired`. Shaka also surfaces the thrown filter error
    *  through its `error` event — we suppress the bridged `error`
@@ -160,7 +156,7 @@ export class ShakaEngine extends AbstractPlaybackEngine implements PlaybackEngin
 
   async load(url: string, startTime?: number, mimeType?: string, _headers?: Record<string, string>): Promise<void> {
     if (!this.player) throw new Error('ShakaEngine not initialised');
-    this.firstFrameEmitted = false;
+    this.resetFirstFrame();
     this.sessionExpiredInFlight = false;
     await this.player.load(url, startTime, mimeType);
   }
@@ -421,12 +417,7 @@ export class ShakaEngine extends AbstractPlaybackEngine implements PlaybackEngin
       // compositor (the DOM 'playing' event can precede the first paint).
       if (!this.firstFrameEmitted) {
         const rvfc = (video as any).requestVideoFrameCallback;
-        const fire = () => {
-          if (!this.firstFrameEmitted) {
-            this.firstFrameEmitted = true;
-            this.emit('firstFrame', undefined as any);
-          }
-        };
+        const fire = () => this.emitFirstFrameOnce();
         if (typeof rvfc === 'function') rvfc.call(video, fire);
         else fire();
       }

--- a/client/src/app/core/services/playback-engine/tizen-engine.ts
+++ b/client/src/app/core/services/playback-engine/tizen-engine.ts
@@ -86,19 +86,9 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
   /** AVPlay exposes no `getCurrentAudioTrack()` — track it ourselves
    *  so the dropdown reflects the active language. */
   private _currentAudioIndex = 0;
-  private firstFrameEmitted = false;
   private orientationHandler: (() => void) | null = null;
   private _seekInFlight = false;
   private _pendingSeek: number | null = null;
-
-  /** One-shot guard for the optimistic-recovery branch in
-   *  {@link handleError}. AVPlay can't surface HTTP status, so the
-   *  first network-shaped error during stable playback is treated as a
-   *  possible session-expired event and emits `sessionExpired` instead
-   *  of a fatal `error`. Subsequent errors fall through normally. Reset
-   *  on every {@link load} so a fresh playback starts with a fresh
-   *  budget. */
-  private recoveryAttempted = false;
 
   /** Timestamp of the last resume issued from PAUSED. AVPlay can throw a
    *  transient network-shaped error while re-priming the decoder on resume;
@@ -170,8 +160,7 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
     _headers?: Record<string, string>,
   ): Promise<void> {
     this._lastLoadedUrl = url;
-    this.firstFrameEmitted = false;
-    this.recoveryAttempted = false;
+    this.resetFirstFrame();
     this._currentTime = 0;
     this._duration = 0;
 
@@ -296,10 +285,7 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
       buffered: this._buffered,
     });
     this.subtitles.updateAt(this._currentTime);
-    if (!this.firstFrameEmitted && ms > 0) {
-      this.firstFrameEmitted = true;
-      this.emit('firstFrame', undefined);
-    }
+    if (ms > 0) this.emitFirstFrameOnce();
   }
   private handleError(err: unknown): void {
     // Seek failures go through `runSeek`'s per-call error path (which
@@ -328,12 +314,9 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
     // if it fails the next error after `recoveryAttempted` falls through
     // to the regular error path.
     if (
-      this.firstFrameEmitted &&
-      !this.recoveryAttempted &&
-      /CONNECTION|HTTP|NETWORK|PLAYER_ERROR_INVALID_URI/i.test(msg)
+      /CONNECTION|HTTP|NETWORK|PLAYER_ERROR_INVALID_URI/i.test(msg) &&
+      this.maybeEmitSessionExpired()
     ) {
-      this.recoveryAttempted = true;
-      this.emit('sessionExpired', undefined);
       return;
     }
     this.emit('error', { code: -1, message: msg, errorKey: 'player.playback_error' });

--- a/client/src/app/core/services/playback-engine/webos-engine.ts
+++ b/client/src/app/core/services/playback-engine/webos-engine.ts
@@ -49,7 +49,6 @@ const SEEK_DEBOUNCE_MS = 280;
 export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngine {
   private video: HTMLVideoElement | null = null;
   private readonly subtitles = new SubtitleOverlay();
-  private firstFrameEmitted = false;
   private _duration = 0;
   /** Last URL handed to `load()` — the base for reload-on-seek. */
   private loadedUrl = '';
@@ -58,15 +57,6 @@ export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngin
   /** Suppress the persistent `error` handler while a (re)load is in flight —
    *  a mediaOption rejection is recovered via the fallback, not surfaced. */
   private loadingPhase = false;
-
-  /** One-shot guard for the optimistic-recovery branch in the `error`
-   *  bridge. webOS's native HLS pipeline hides the HTTP status of the
-   *  failing segment fetch — we can't tell a backend 410 from a real
-   *  decode failure. First network-shaped MediaError after a frame has
-   *  played is routed to `sessionExpired`; the player tries one cheap
-   *  /playback-info reload before surfacing a fatal error. Reset on
-   *  every {@link load} so a fresh playback starts with a fresh budget. */
-  private recoveryAttempted = false;
 
   /** Optimistic position reported while a seek settles, so the seekbar stays
    *  pinned and relative (±10s) steps accumulate even though the real clock
@@ -126,7 +116,7 @@ export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngin
     });
     add('playing', () => {
       this.emit('stateChanged', { state: 'playing' });
-      this.emitFirstFrame();
+      this.emitFirstFrameOnce();
     });
     add('play', () => this.emit('stateChanged', { state: 'playing' }));
     add('pause', () => {
@@ -147,7 +137,7 @@ export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngin
         duration: this._duration || v.duration || 0,
         buffered: this.bufferedEnd(),
       });
-      if (v.currentTime > 0) this.emitFirstFrame();
+      if (v.currentTime > 0) this.emitFirstFrameOnce();
     });
     add('ended', () => {
       this.emit('stateChanged', { state: 'ended' });
@@ -164,11 +154,7 @@ export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngin
       const networkShaped =
         err?.code === MediaError.MEDIA_ERR_NETWORK ||
         err?.code === MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED;
-      if (this.firstFrameEmitted && !this.recoveryAttempted && networkShaped) {
-        this.recoveryAttempted = true;
-        this.emit('sessionExpired', undefined);
-        return;
-      }
+      if (networkShaped && this.maybeEmitSessionExpired()) return;
       this.emit('error', {
         code: err?.code ?? -1,
         message: mediaErrorMessage(err),
@@ -182,15 +168,9 @@ export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngin
     if ('requestVideoFrameCallback' in v) {
       this.frameCbHandle = (v as any).requestVideoFrameCallback(() => {
         this.frameCbHandle = null;
-        this.emitFirstFrame();
+        this.emitFirstFrameOnce();
       });
     }
-  }
-
-  private emitFirstFrame(): void {
-    if (this.firstFrameEmitted) return;
-    this.firstFrameEmitted = true;
-    this.emit('firstFrame', undefined);
   }
 
   // ── Loading ─────────────────────────────────────────────────────────
@@ -198,8 +178,7 @@ export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngin
   async load(url: string, startTime?: number): Promise<void> {
     if (!this.video) throw new Error('WebOsEngine not initialised');
     this.loadedUrl = url;
-    this.firstFrameEmitted = false;
-    this.recoveryAttempted = false;
+    this.resetFirstFrame();
     this.clearSeekDebounce();
     this.pendingReloadTarget = null;
     const start = startTime && startTime > 0 ? startTime : 0;

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -2133,7 +2133,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       ) {
         this.recoverConfirmPending = false;
         this.recoverAttempts = 0;
-        this.engine?.resetRecoveryGuard?.();
+        this.engine?.resetRecoveryGuard();
       }
       return;
     }
@@ -2164,6 +2164,13 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // reloads — recovery is about to resume playback, so the reload window
     // reads as buffering, not "Playback error".
     this.state.setRecovering(true);
+    // Count the attempt up front, not only on failure: a reload that resolves
+    // then re-fails within seconds must keep counting toward maxRecoverAttempts.
+    // On the Shaka path there is no per-engine one-shot latch, so a fresh sid
+    // that 410s again on the next segment would otherwise re-enter with the
+    // counter still at 0 and loop unbounded. The counter clears only after
+    // playback sustains for recoverConfirmMs (checkStall).
+    this.recoverAttempts += 1;
     // engine.currentTime can read 0 right after an error (e.g. Tizen AVPlay),
     // which would reload from the start — fall back to the last mirrored
     // position in that case.
@@ -2182,7 +2189,6 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       this.recoverConfirmPending = true;
       this.recoverConfirmAt = Date.now();
     } catch {
-      this.recoverAttempts += 1;
       if (this.recoverAttempts >= this.maxRecoverAttempts) {
         this.state.setRecovering(false);
         this.state.error.set(this.translate.instant('player.playback_error'));
@@ -2782,7 +2788,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   private async reloadStream() {
     if (!this.engine || this.reloadingStream) return;
     this.reloadingStream = true;
-    this.engine.resetRecoveryGuard?.();
+    this.engine.resetRecoveryGuard();
     try {
       await this.doReloadStream();
     } finally {
@@ -2898,7 +2904,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       return;
     }
 
-    if (!pos) return;
+    // Heartbeat even at position 0 — a player paused at the very start is
+    // still live and the backend refreshes the LiveSession TTL off this PUT.
+    // Only bail on a non-finite reading (engine not ready), never on 0.
+    if (!Number.isFinite(pos)) return;
 
     const now = Date.now();
     if (now - this.lastSaveAt < 2_000) return;


### PR DESCRIPTION
## Context

Live-session audit (theme C). Three fixes, all client-side — the backend is untouched.

## Fixes

**C1 — Desktop/Tizen/webOS re-armed the recovery guard on every `load()`** (`desktop-engine.ts`, `tizen-engine.ts`, `webos-engine.ts`)
Only `NativeEngine` held the documented anti-loop (the guard is re-armed solely via `resetRecoveryGuard()`). The other three reset `recoveryAttempted = false` inside `load()`, so `refreshSidAndReload()` — which calls `engine.load()` every iteration — re-armed the guard each pass, making the shell's `resetRecoveryGuard()` a no-op on them. A fresh sid that re-failed after the reload could keep minting backend sessions instead of going fatal on the second failure.

**C2 — the reload-loop cap only counted failed recoveries** (`player.ts` `recoverFromLostSession`)
`recoverAttempts` was incremented only in the `catch`. On the Shaka path (no per-engine one-shot latch), a reload that resolved then re-failed on the next segment re-entered with the counter at 0 → unbounded loop. The attempt is now counted up front; it still clears only after `recoverConfirmMs` of sustained progress (`checkStall`), so a genuine one-off recovery is unaffected.

**B2 — heartbeat skipped at position 0** (`player.ts` `savePosition`)
`if (!pos) return;` also skipped `pos === 0`: a player paused at the very start emitted no heartbeat → its `LiveSession` could be GC'd at the 30s TTL while still alive, triggering a pointless lost-session recovery. It now bails only on a non-finite reading; the backend refreshes the session off a position-0 PUT.

## Mechanism (C3/C4/C5 refactor)

`firstFrameEmitted` / `recoveryAttempted` plus helpers `emitFirstFrameOnce`, `resetFirstFrame`, `resetRecoveryGuard`, `maybeEmitSessionExpired` are hoisted into `AbstractPlaybackEngine`, and `resetRecoveryGuard` is non-optional on the interface. Engines now reset only the first-frame latch in `load()`; the recovery guard is re-armed only via `resetRecoveryGuard` (user reload + sustained progress).

Per-platform preconditions stay where they belong: Native's position-delta first-frame fallback, Tizen's network-shaped error regex + resume grace, webOS's `networkShaped` check, Desktop's `dead` guard + post-first-frame play-state assertion, Shaka's 410 response filter.

## Verification

- `ng build` (dev): clean.
- No unit specs on these files; manual per-engine behavior-preservation review.
- Episode advance confirmed: it remounts the component (detour through `/`) → fresh engine → fresh guard, so no C1 regression risk.

## Deferred (cosmetic, separate)

C6 (shared TV subtitle overlay, ABR no-op defaults, timeout scaffold) and C7 (reload-helper extraction in `player.ts`): pure dedup, low value; the audit itself deprioritizes them.
