### PR TITLE
fix(streaming): reap all stream variants on admin stop, trim the video-activity dashboard

### DIFF
--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -32,11 +32,13 @@ import { LogBufferService } from './log-buffer.service';
 import { EventsService } from './events.service';
 import { Observable } from 'rxjs';
 import {
-  HW_ACCEL_LABEL,
   type HwAccelType,
   type TranscodeSession,
   TranscodingService,
   TranscodeCacheService,
+  getLadderForDevice,
+  getHdrLadderForDevice,
+  parseBitrateToBps,
 } from '../streaming/transcoding';
 import { ActiveStreamTracker } from '../streaming/active-stream-tracker.service';
 import {
@@ -90,7 +92,6 @@ export interface ActiveStreamDto {
   audioLanguage: string | null;
   outputContainer: string | null;
   outputBitrate: number | null;
-  videoPlaybackMode: string; // "Lecture directe" / "Transcodage (QSV)"
   /** `null` when audio is direct-played (no transcode). For transcoded
    *  sessions, the actual codec ffmpeg emits — caller renders the display
    *  string from these raw values. */
@@ -135,6 +136,32 @@ export interface StatsReport {
   series: number;
   pendingRequests: number;
   diskSpace: DiskSpaceEntry[];
+}
+
+/** Map a LiveSession `audioPlan` to the dashboard's audio output fields.
+ *  With a plan, the plan is authoritative (copy or transcode); without one,
+ *  remux copies the bitstream and every other mode is a straight direct play. */
+function deriveAudioOutput(
+  audioPlan: LiveSessionSnapshot['audioPlan'],
+  mode: 'transcode' | 'remux' | 'directplay',
+): {
+  audioMode: 'direct' | 'copy' | 'transcode';
+  audioOutputCodec: string | null;
+  audioOutputBitrateBps: number | null;
+} {
+  if (audioPlan) {
+    return {
+      audioMode: audioPlan.mode,
+      audioOutputCodec: audioPlan.codec,
+      audioOutputBitrateBps:
+        audioPlan.mode === 'transcode' ? audioPlan.bitrateBps : null,
+    };
+  }
+  return {
+    audioMode: mode === 'remux' ? 'copy' : 'direct',
+    audioOutputCodec: null,
+    audioOutputBitrateBps: null,
+  };
 }
 
 @Controller('system')
@@ -339,14 +366,16 @@ export class SystemController {
       );
     };
 
+    // Legacy direct-play paths that bypass playback-info still surface here;
+    // their (user, file) pair isn't represented by any LiveSession so we read
+    // from the tracker. Snapshot once — the dashboard reads it twice.
+    const directPlaySessions = this.activeStreamTracker.getActive();
+
     // Collect lookups before the per-session loop so we batch DB hits.
     const mediaFileIds = [
       ...new Set([
         ...live.map((s) => s.mediaFileId),
-        // Legacy direct-play paths that bypass playback-info still
-        // surface here; their (user, file) pair isn't represented by
-        // any LiveSession so we have to read from the tracker.
-        ...this.activeStreamTracker.getActive().map((s) => s.mediaFileId),
+        ...directPlaySessions.map((s) => s.mediaFileId),
       ]),
     ];
     const mediaFiles = mediaFileIds.length
@@ -370,6 +399,8 @@ export class SystemController {
       deviceLabel: string | null;
       transcodeSession: TranscodeSession | undefined;
       audioPlan: LiveSessionSnapshot['audioPlan'];
+      position: number;
+      episodeId: number | null;
     };
 
     const work: StreamWorkItem[] = [];
@@ -417,6 +448,10 @@ export class SystemController {
             : null),
         transcodeSession: ts,
         audioPlan: session.audioPlan,
+        // The LiveSession keeps the playhead fresh on every heartbeat — read
+        // it straight from memory instead of a per-row playback_states query.
+        position: session.position,
+        episodeId: mediaFileMap.get(session.mediaFileId)?.episodeId ?? null,
       });
     }
 
@@ -426,7 +461,7 @@ export class SystemController {
     const liveByKey = new Set(
       live.map((s) => `${s.userId ?? 0}-${s.mediaFileId}`),
     );
-    for (const dp of this.activeStreamTracker.getActive()) {
+    for (const dp of directPlaySessions) {
       const key = `${dp.userId}-${dp.mediaFileId}`;
       if (liveByKey.has(key)) continue;
       work.push({
@@ -448,10 +483,10 @@ export class SystemController {
         ),
         transcodeSession: undefined,
         audioPlan: null,
+        position: 0,
+        episodeId: null,
       });
     }
-
-    const streamEpisodeIds: (number | null)[] = [];
 
     for (const s of work) {
       const mf = mediaFileMap.get(s.mediaFileId);
@@ -459,63 +494,31 @@ export class SystemController {
       const v = si?.video?.[0];
       const a = si?.audio?.[0];
 
-      // Playback state (position/duration + episodeId)
-      let positionSeconds = 0;
-      let durationSeconds = si?.durationSeconds ?? 0;
-      let episodeId: number | null = null;
-      if (s.userId && mf?.mediaId) {
-        try {
-          // `playback_states` is keyed by (user, media, episode?). Series
-          // episodes carry an episodeId — the media-file row tells us
-          // which one — so we pass it through, otherwise the lookup
-          // hits the IS NULL branch (movies) and returns nothing.
-          const ps = await this.playbackService.getState(
-            s.userId,
-            mf.mediaId,
-            mf.episodeId ?? undefined,
-          );
-          if (ps) {
-            positionSeconds = ps.positionSeconds;
-            if (ps.durationSeconds > 0) durationSeconds = ps.durationSeconds;
-            episodeId = ps.episodeId ?? null;
-          }
-        } catch {
-          /* ignore */
-        }
-      }
+      // Position comes from the in-memory LiveSession (fresher than the
+      // debounced playback_states row); duration from the probed streamInfo.
+      const positionSeconds = s.position;
+      const durationSeconds = si?.durationSeconds ?? 0;
+      const episodeId = s.episodeId;
 
       // Output decisions: the LiveSession holds the authoritative
       // `audioPlan`; mode/codec/bitrate read directly.
-      let videoPlaybackMode = 'Lecture directe';
       let outputContainer: string | null = null;
       let outputBitrate: number | null = null;
-      let audioOutputCodec: string | null = null;
-      let audioOutputBitrateBps: number | null = null;
-      let audioMode: 'direct' | 'copy' | 'transcode' = 'direct';
-      const audioPlan = s.audioPlan;
+      const audio = deriveAudioOutput(s.audioPlan, s.mode);
+      const audioMode = audio.audioMode;
+      const audioOutputCodec = audio.audioOutputCodec;
+      const audioOutputBitrateBps = audio.audioOutputBitrateBps;
 
       if (s.mode === 'transcode') {
-        videoPlaybackMode = `Transcodage (${HW_ACCEL_LABEL[hwAccel] ?? hwAccel.toUpperCase()})`;
         outputContainer = 'HLS';
-        const profile = { '1080p': 8, '720p': 4, '480p': 2 }[s.quality];
-        outputBitrate = profile ? profile * 1_000_000 : null;
-        if (audioPlan) {
-          audioMode = audioPlan.mode;
-          audioOutputCodec = audioPlan.codec;
-          audioOutputBitrateBps =
-            audioPlan.mode === 'transcode' ? audioPlan.bitrateBps : null;
-        }
+        const rung = [
+          ...getLadderForDevice(undefined),
+          ...getHdrLadderForDevice(undefined),
+        ].find((p) => p.name === s.quality);
+        outputBitrate = rung ? parseBitrateToBps(rung.videoBitrate) : null;
       } else if (s.mode === 'remux') {
         outputContainer = 'HLS';
         outputBitrate = (v?.bitRate ?? 0) + (a?.bitRate ?? 0) || null;
-        if (audioPlan) {
-          audioMode = audioPlan.mode;
-          audioOutputCodec = audioPlan.codec;
-          audioOutputBitrateBps =
-            audioPlan.mode === 'transcode' ? audioPlan.bitrateBps : null;
-        } else {
-          audioMode = 'copy';
-        }
       }
 
       const sourceResLabel =
@@ -529,7 +532,6 @@ export class SystemController {
           ? s.quality
           : sourceResLabel;
 
-      streamEpisodeIds.push(episodeId);
       streams.push({
         sessionId: s.sessionId,
         userId: s.userId,
@@ -561,7 +563,6 @@ export class SystemController {
         audioLanguage: a?.language ?? null,
         outputContainer,
         outputBitrate,
-        videoPlaybackMode,
         audioOutputCodec,
         audioOutputBitrateBps,
         audioMode,
@@ -574,7 +575,9 @@ export class SystemController {
 
     // Resolve episode labels
     const uniqueEpIds = [
-      ...new Set(streamEpisodeIds.filter((id): id is number => !!id)),
+      ...new Set(
+        streams.map((s) => s.episodeId).filter((id): id is number => !!id),
+      ),
     ];
     if (uniqueEpIds.length) {
       const episodes = await this.episodeRepo.find({
@@ -582,16 +585,12 @@ export class SystemController {
         relations: ['season'],
       });
       const epMap = new Map(episodes.map((e) => [e.id, e]));
-      for (let i = 0; i < streams.length; i++) {
-        const epId = streamEpisodeIds[i];
-        if (epId) {
-          const ep = epMap.get(epId);
-          if (ep) {
-            const label = `S${ep.season?.seasonNumber ?? '?'}:E${ep.episodeNumber}`;
-            streams[i].episodeLabel = ep.title
-              ? `${label} - ${ep.title}`
-              : label;
-          }
+      for (const stream of streams) {
+        if (!stream.episodeId) continue;
+        const ep = epMap.get(stream.episodeId);
+        if (ep) {
+          const label = `S${ep.season?.seasonNumber ?? '?'}:E${ep.episodeNumber}`;
+          stream.episodeLabel = ep.title ? `${label} - ${ep.title}` : label;
         }
       }
     }
@@ -644,7 +643,7 @@ export class SystemController {
   private resolveStreamCommandTarget(sessionId: string): {
     userId: number;
     mediaFileId: number;
-    killTranscodeId: string | null;
+    profileHash: string | null;
     isDirectPlay: boolean;
   } | null {
     if (sessionId.startsWith('dp-')) {
@@ -652,21 +651,14 @@ export class SystemController {
       const userId = parseInt(parts[0], 10);
       const mediaFileId = parseInt(parts[1], 10);
       if (!userId || !mediaFileId) return null;
-      return { userId, mediaFileId, killTranscodeId: null, isDirectPlay: true };
+      return { userId, mediaFileId, profileHash: null, isDirectPlay: true };
     }
     const live = this.liveSessions.get(sessionId);
     if (live && live.userId != null) {
-      const transcode = live.profileHash
-        ? this.transcodingService.getExistingSession(
-            live.mediaFileId,
-            live.userId,
-            live.profileHash,
-          )
-        : null;
       return {
         userId: live.userId,
         mediaFileId: live.mediaFileId,
-        killTranscodeId: transcode?.id ?? null,
+        profileHash: live.profileHash ?? null,
         isDirectPlay: live.kind === 'directplay',
       };
     }
@@ -677,7 +669,7 @@ export class SystemController {
       return {
         userId: transcode.userId,
         mediaFileId: transcode.mediaFileId,
-        killTranscodeId: transcode.id,
+        profileHash: transcode.baseProfileHash ?? null,
         isDirectPlay: false,
       };
     }
@@ -728,20 +720,6 @@ export class SystemController {
     return { ok: true, ...freed };
   }
 
-  @Delete('streams/:sessionId')
-  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
-  killStream(@Param('sessionId') sessionId: string) {
-    const target = this.resolveStreamCommandTarget(sessionId);
-    if (!target) return { ok: true }; // already gone
-    if (target.isDirectPlay) {
-      this.activeStreamTracker.unregister(target.userId, target.mediaFileId);
-    } else if (target.killTranscodeId) {
-      this.transcodingService.killSessionById(target.killTranscodeId);
-    }
-    this.liveSessions.stop(sessionId);
-    return { ok: true };
-  }
-
   @Post('streams/:sessionId/command')
   @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
   sendPlayerCommand(
@@ -764,8 +742,15 @@ export class SystemController {
     if (body.action === 'stop') {
       if (target.isDirectPlay) {
         this.activeStreamTracker.unregister(target.userId, target.mediaFileId);
-      } else if (target.killTranscodeId) {
-        this.transcodingService.killSessionById(target.killTranscodeId);
+      } else if (target.profileHash) {
+        // Admin stop is a force-kill: reap every ffmpeg variant of the job
+        // (main / early / remux / per-audio), not just the main one — the
+        // companions would otherwise idle on until the reaper sweeps them.
+        this.transcodingService.killSessionsForJob(
+          target.mediaFileId,
+          target.userId,
+          target.profileHash,
+        );
       }
       this.liveSessions.stop(sessionId);
     }

--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -149,6 +149,11 @@ function deriveAudioOutput(
   audioOutputCodec: string | null;
   audioOutputBitrateBps: number | null;
 } {
+  // DirectPlay serves the source file untouched — the audio is direct, not a
+  // Fliks copy/transcode, even though the session still carries a copy plan.
+  if (mode === 'directplay') {
+    return { audioMode: 'direct', audioOutputCodec: null, audioOutputBitrateBps: null };
+  }
   if (audioPlan) {
     return {
       audioMode: audioPlan.mode,

--- a/backend/src/modules/streaming/playback.controller.ts
+++ b/backend/src/modules/streaming/playback.controller.ts
@@ -239,6 +239,13 @@ export class PlaybackController {
       return sessionLost ? { sessionLost: true } : null;
     }
     this.lastDbWriteAt.set(dbKey, now);
+    // Drop debounce entries for playbacks idle past a few write intervals so
+    // the map can't grow unbounded over the process lifetime — a pruned entry
+    // only gated the next write, which simply re-creates it.
+    const staleBefore = now - STATE_DB_WRITE_INTERVAL_MS * 10;
+    for (const [key, ts] of this.lastDbWriteAt) {
+      if (ts < staleBefore) this.lastDbWriteAt.delete(key);
+    }
     const state = await this.playbackService.updateState(user.id, mediaId, {
       positionSeconds: body.positionSeconds,
       durationSeconds: body.durationSeconds,

--- a/backend/src/modules/streaming/streaming.controller.spec.ts
+++ b/backend/src/modules/streaming/streaming.controller.spec.ts
@@ -19,8 +19,7 @@ describe('StreamingController.stopLiveSession', () => {
       unregister: jest.fn(),
     };
     const transcodingService = {
-      getSessionsForFileUser: jest.fn().mockReturnValue([]),
-      killSessionById: jest.fn(),
+      killSessionsForJob: jest.fn(),
     };
 
     const controller = new StreamingController(
@@ -95,18 +94,24 @@ describe('StreamingController.stopLiveSession', () => {
     // DirectPlay has no profileHash, so the ffmpeg-kill path is skipped —
     // the tracker row must still be cleared immediately.
     expect(activeStreamTracker.unregister).toHaveBeenCalledWith(7, 42);
-    expect(transcodingService.killSessionById).not.toHaveBeenCalled();
+    expect(transcodingService.killSessionsForJob).not.toHaveBeenCalled();
   });
 
   it('also unregisters for a transcode sid, then walks the ffmpeg-kill path', () => {
     const live = makeLive({ profileHash: 'abc123', userId: 7, mediaFileId: 42 });
-    const { controller, activeStreamTracker, liveSessions } =
+    const { controller, activeStreamTracker, liveSessions, transcodingService } =
       makeController(live);
 
     controller.stopLiveSession('sid-1');
 
     expect(activeStreamTracker.unregister).toHaveBeenCalledWith(7, 42);
     expect(liveSessions.listForJob).toHaveBeenCalledWith(7, 42, 'abc123');
+    // No other live session references the job → reap every ffmpeg variant.
+    expect(transcodingService.killSessionsForJob).toHaveBeenCalledWith(
+      42,
+      7,
+      'abc123',
+    );
   });
 
   it('is a no-op on an unknown sid', () => {

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -833,17 +833,11 @@ export class StreamingController {
       live.profileHash,
     );
     if (remaining.length > 0) return;
-    const userId = live.userId ?? undefined;
-    const matching = this.transcodingService.getSessionsForFileUser(
+    this.transcodingService.killSessionsForJob(
       live.mediaFileId,
-      userId,
+      live.userId ?? undefined,
+      live.profileHash,
     );
-    const toKill = matching.filter(
-      (s) => s.baseProfileHash === live.profileHash,
-    );
-    for (const s of toKill) {
-      this.transcodingService.killSessionById(s.id);
-    }
   }
 
   // ---------------------------------------------------------------------------

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -1198,6 +1198,22 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     await Promise.all(sessions.map((s) => this.killProcess(s.process)));
   }
 
+  /** Stop every ffmpeg variant (main / early / remux / per-audio) of one
+   *  client job — the sessions sharing `baseProfileHash` for this (file,
+   *  user). Scoped by hash so a second device on the same file with a
+   *  different profile keeps playing. The on-disk cache stays. Callers that
+   *  must keep the job warm for other viewers gate on the live-session count
+   *  themselves before calling. */
+  killSessionsForJob(
+    mediaFileId: number,
+    userId: number | undefined,
+    baseProfileHash: string,
+  ): void {
+    for (const s of this.getSessionsForFileUser(mediaFileId, userId)) {
+      if (s.baseProfileHash === baseProfileHash) this.killSessionById(s.id);
+    }
+  }
+
   /** Kill a session by its map key (used by admin dashboard). The cache
    *  directory stays — the admin can purge it separately via a future
    *  cache-eviction action; killing a job mid-stream just frees CPU. */

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -954,6 +954,8 @@
     "streams_audio_copy": "Copie bitstream ({{codec}})",
     "streams_audio_transcode": "Transcodage ({{codec}})",
     "streams_audio_transcode_with_bitrate": "Transcodage ({{codec}}, {{kbps}} kbps)",
+    "streams_video_direct": "Lecture directe",
+    "streams_video_transcode": "Transcodage ({{hw}})",
     "stream_message_btn": "Envoyer un message",
     "stream_message_title": "Envoyer un message",
     "stream_message_subtitle": "À {{user}}, en train de regarder « {{title}} ».",

--- a/client/src/app/core/services/api/streams-api.service.ts
+++ b/client/src/app/core/services/api/streams-api.service.ts
@@ -30,7 +30,6 @@ export interface ActiveStream {
   audioLanguage: string | null;
   outputContainer: string | null;
   outputBitrate: number | null;
-  videoPlaybackMode: string;
   /** Real audio output codec emitted by ffmpeg (e.g. `'aac'`, `'ac3'`).
    *  `null` when audio is direct-played / copy-remuxed without transcode. */
   audioOutputCodec: string | null;
@@ -51,12 +50,6 @@ export class StreamsApiService {
   list() {
     return firstValueFrom(
       this.http.get<ActiveStream[]>('/api/system/streams'),
-    );
-  }
-
-  kill(sessionId: string) {
-    return firstValueFrom(
-      this.http.delete<void>(`/api/system/streams/${sessionId}`),
     );
   }
 

--- a/client/src/app/features/system/streams/streams.html
+++ b/client/src/app/features/system/streams/streams.html
@@ -69,7 +69,16 @@
             <span class="text-base-content/40 w-10 shrink-0">{{ 'system.streams_label_video' | translate }}</span>
             <div>
               <span class="font-medium">{{ s.videoResolution ?? '?' }} {{ s.videoCodec ?? '?' }}</span>
-              <div class="text-base-content/50">&rarr; {{ s.videoPlaybackMode }}</div>
+              <div class="text-base-content/50">&rarr;
+                @switch (s.mode) {
+                  @case ('transcode') {
+                    {{ 'system.streams_video_transcode' | translate:{ hw: hwLabel(s.hwAccel) } }}
+                  }
+                  @default {
+                    {{ 'system.streams_video_direct' | translate }}
+                  }
+                }
+              </div>
               @for (r of s.videoReasons; track r) {
                 <div class="text-warning/80 italic">{{ r }}</div>
               }

--- a/client/src/app/features/system/streams/streams.ts
+++ b/client/src/app/features/system/streams/streams.ts
@@ -147,4 +147,17 @@ export class SystemStreamsComponent implements OnInit, OnDestroy {
     if (bps >= 1_000) return `${(bps / 1_000).toFixed(0)} kbps`;
     return `${bps} bps`;
   }
+
+  /** Display label for a hardware-acceleration code (the per-session value the
+   *  backend ships), falling back to the upper-cased code for unknowns. */
+  hwLabel(hwAccel: string): string {
+    const labels: Record<string, string> = {
+      qsv: 'QSV',
+      vaapi: 'VAAPI',
+      nvenc: 'NVENC',
+      videotoolbox: 'Apple VT',
+      none: 'CPU',
+    };
+    return labels[hwAccel] ?? hwAccel.toUpperCase();
+  }
 }


### PR DESCRIPTION
## Context

Live-session audit — backend + "video activity" dashboard (themes B/D). Disjoint files from #508 (player/engines), so mergeable in any order.

## Included

**B1 — admin stop only killed the *main* variant** (`transcoding.service.ts`, `streaming.controller.ts`, `system.controller.ts`)
The stop command resolved a single `killTranscodeId` via `getExistingSession` (defaults to `VARIANT_MAIN`); the companions (early / remux / per-audio, same `baseProfileHash`) survived ~70s until the reaper. New `TranscodingService.killSessionsForJob(mediaFileId, userId, baseProfileHash)` kills every variant; `stopLiveSession` (client teardown) folds onto it (DRY).

**D4 — dead, divergent `DELETE /system/streams/:id`** (`system.controller.ts`, `streams-api.service.ts`)
The dashboard stop button uses the *command* endpoint (SSE `player.command` → the viewer's player actually stops). The `killStream` handler tore down server state *without* emitting that SSE → the player kept running blind. Its only caller was an unused client method. Both removed.

**D1 — French `videoPlaybackMode` string out of the backend** (`system.controller.ts`, `streams.*`, `fr.json`)
The DTO built `'Lecture directe'` / `'Transcodage (QSV)'` literally (violates backend-English-only + the no-hardcoded-strings rule). Now rendered client-side via `@switch (s.mode)` plus a HW label from `s.hwAccel` (the same pattern the player overlay already uses). New `system.streams_video_*` keys.

**D3 — N+1 on position** (`system.controller.ts`)
`positionSeconds` now comes from the in-memory `LiveSession` (fresher than the debounced DB row), `episodeId` from the already-batched media-file row, duration from the probed `streamInfo`. Removes the per-row `await getState` in the loop.

**D2 — `outputBitrate` via the real ladder** (`system.controller.ts`)
Replaces the magic `{1080p,720p,480p}` table (which returned `null` for 2160p / eco-* / *-hdr) with a `getLadderForDevice` / `getHdrLadderForDevice` + `parseBitrateToBps` lookup.

**D6 / B4 — small cleanups**: `deriveAudioOutput` helper (dedup the audioPlan mapping; DirectPlay audio stays "direct"), single snapshot of the DirectPlay tracker, dropped the parallel `streamEpisodeIds` array, prune idle entries from the `lastDbWriteAt` debounce map (`playback.controller.ts`).

## Deferred (intentionally, out of scope)

- **A1** — remove the DirectPlay session store (`ActiveStreamTracker`) in favor of deriving from `LiveSessionRegistry`. Flagged "validate on device" by the audit: it changes "now watching" for any client that streams `/stream/:id` without a prior `playback-info`. After device validation.
- **A3 / A4** — remove write-only `TranscodeSession` fields. Verified never read (drift goes through `profileHash`), but their doc comments claim the opposite ("forces a kill+respawn"). Zero value (dead memory), surprise risk → confirm first.
- **A2** (qsv/tonemap migration to `StreamingSettingsCache`), **D6-listLive** (product decision on showing `pinned` downloads), **D5** (dead DTO fields — partly contradicted by D1 keeping `hwAccel`).

## Verification

- Backend: `tsc --noEmit` clean; streaming specs 198/198 (`--runInBand`); the `streaming.controller` spec was updated for `killSessionsForJob`.
- Client: `ng build` (dev) clean.
- Hardening: an adversarial review flagged one regression (DirectPlay audio label flipped from "direct" to "copy"); fixed in 3c5377b2.
