### PR TITLE
refactor(streaming): derive DirectPlay presence from the live-session registry

### DIFF
--- a/backend/src/modules/scheduler/system.controller.spec.ts
+++ b/backend/src/modules/scheduler/system.controller.spec.ts
@@ -70,7 +70,6 @@ describe('SystemController.activeStreams recency filter', () => {
       list: jest.fn().mockReturnValue(snapshots),
     };
     const activeStreamTracker = {
-      getActive: jest.fn().mockReturnValue([]),
       getDeviceName: jest.fn().mockReturnValue(null),
     };
     const playbackService = {

--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -371,18 +371,10 @@ export class SystemController {
       );
     };
 
-    // Legacy direct-play paths that bypass playback-info still surface here;
-    // their (user, file) pair isn't represented by any LiveSession so we read
-    // from the tracker. Snapshot once — the dashboard reads it twice.
-    const directPlaySessions = this.activeStreamTracker.getActive();
-
     // Collect lookups before the per-session loop so we batch DB hits.
-    const mediaFileIds = [
-      ...new Set([
-        ...live.map((s) => s.mediaFileId),
-        ...directPlaySessions.map((s) => s.mediaFileId),
-      ]),
-    ];
+    // DirectPlay is a LiveSession (kind='directplay') like any other mode, so
+    // the registry is the only source — no separate tracker to merge in.
+    const mediaFileIds = [...new Set(live.map((s) => s.mediaFileId))];
     const mediaFiles = mediaFileIds.length
       ? await this.mediaFileRepo.findByIds(mediaFileIds)
       : [];
@@ -457,39 +449,6 @@ export class SystemController {
         // it straight from memory instead of a per-row playback_states query.
         position: session.position,
         episodeId: mediaFileMap.get(session.mediaFileId)?.episodeId ?? null,
-      });
-    }
-
-    // Legacy direct-play fallback: tracker entries without a matching
-    // LiveSession (typically clients that hit /stream/:mediaFileId
-    // without a prior playback-info call).
-    const liveByKey = new Set(
-      live.map((s) => `${s.userId ?? 0}-${s.mediaFileId}`),
-    );
-    for (const dp of directPlaySessions) {
-      const key = `${dp.userId}-${dp.mediaFileId}`;
-      if (liveByKey.has(key)) continue;
-      work.push({
-        sessionId: `dp-${dp.userId}-${dp.mediaFileId}`,
-        userId: dp.userId,
-        username: dp.username,
-        mediaFileId: dp.mediaFileId,
-        mediaTitle: dp.mediaTitle,
-        mediaType: dp.mediaType,
-        posterUrl: dp.posterUrl,
-        mode: 'directplay',
-        quality: 'original',
-        hwAccelVal: 'none',
-        startedAt: dp.startedAt.toISOString(),
-        lastActivity: dp.lastActivity.toISOString(),
-        deviceLabel: this.activeStreamTracker.getDeviceName(
-          dp.userId,
-          dp.mediaFileId,
-        ),
-        transcodeSession: undefined,
-        audioPlan: null,
-        position: 0,
-        episodeId: null,
       });
     }
 
@@ -636,14 +595,14 @@ export class SystemController {
 
   /**
    * Resolve a dashboard `sessionId` to the (user, mediaFile) pair the
-   * command targets. The dashboard hands us three flavours of id:
-   *   - `dp-<userId>-<mediaFileId>` — legacy direct-play tracker entry.
-   *   - A `LiveSession.sessionId` UUID — the canonical id since #300.
+   * command targets. The dashboard hands us two flavours of id:
+   *   - A `LiveSession.sessionId` UUID — the canonical id (every mode,
+   *     DirectPlay included, is a LiveSession).
    *   - A `TranscodeSession.id` hash — left in for completeness; the
    *     dashboard hasn't emitted these in a while but a stale client
    *     tab could still send one.
-   * Returns null when none of the three lookups produces a (user, file)
-   * pair the command can act on.
+   * Returns null when neither lookup produces a (user, file) pair the
+   * command can act on.
    */
   private resolveStreamCommandTarget(sessionId: string): {
     userId: number;
@@ -651,13 +610,6 @@ export class SystemController {
     profileHash: string | null;
     isDirectPlay: boolean;
   } | null {
-    if (sessionId.startsWith('dp-')) {
-      const parts = sessionId.replace('dp-', '').split('-');
-      const userId = parseInt(parts[0], 10);
-      const mediaFileId = parseInt(parts[1], 10);
-      if (!userId || !mediaFileId) return null;
-      return { userId, mediaFileId, profileHash: null, isDirectPlay: true };
-    }
     const live = this.liveSessions.get(sessionId);
     if (live && live.userId != null) {
       return {

--- a/backend/src/modules/streaming/active-stream-tracker.service.ts
+++ b/backend/src/modules/streaming/active-stream-tracker.service.ts
@@ -19,7 +19,9 @@ export class ActiveStreamTracker {
    *  "iPhone", "Chromecast — Living Room"). Keyed per (user, file) so two users
    *  watching the same file from different devices don't collide. Shown on the
    *  admin streams dashboard as a fallback when the LiveSession has no raw
-   *  User-Agent label. */
+   *  User-Agent label. Cleared on stop ({@link unregister}); a playback that
+   *  never sends a clean stop leaves one small string entry until restart —
+   *  bounded by distinct (user, file) pairs and overwritten per key. */
   private readonly deviceNameCache = new Map<string, string>();
 
   setDeviceName(userId: number, mediaFileId: number, name: string) {

--- a/backend/src/modules/streaming/active-stream-tracker.service.ts
+++ b/backend/src/modules/streaming/active-stream-tracker.service.ts
@@ -1,81 +1,25 @@
-import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import type { TonemapAlgo } from './transcoding';
 
-export interface DirectPlaySession {
-  userId: number;
-  username: string;
-  mediaFileId: number;
-  mediaTitle: string;
-  mediaType: string;
-  posterUrl: string | null;
-  startedAt: Date;
-  lastActivity: Date;
-}
-
-const STALE_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
-
 /**
- * Dashboard / global-settings bookkeeping for streaming. Per-playback
- * session state (mux flavour, audio plan, device type, picked tracks,
- * etc.) used to live here but has moved onto {@link LiveSession} —
- * this service now holds only:
+ * Cross-cutting bookkeeping for streaming. Per-playback session state lives on
+ * {@link LiveSession} — including DirectPlay presence, which the admin "now
+ * watching" view reads straight off the registry (`kind === 'directplay'`).
+ * This service holds only the bits that don't vary per playback session:
  *
- *  - DirectPlay session presence for the admin "now watching" view
- *    (`register` / `getActive` / `unregister`)
- *  - Human-readable device name per (user, file)
- *  - Intrinsic file dimensions (identical across users, kept here for
- *    cheap reads in HLS routes)
+ *  - Human-readable device name per (user, file) — a dashboard fallback for
+ *    when the LiveSession carries no raw User-Agent label
+ *  - Intrinsic file dimensions (identical across users, kept here for cheap
+ *    reads in HLS routes)
  *  - Global admin settings (segment duration, QSV options, tonemap algo)
  */
 @Injectable()
-export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
-  private readonly sessions = new Map<string, DirectPlaySession>();
-  private cleanupTimer: ReturnType<typeof setInterval> | null = null;
-
-  onModuleInit() {
-    this.cleanupTimer = setInterval(() => this.cleanup(), 30_000);
-  }
-
-  onModuleDestroy() {
-    if (this.cleanupTimer) clearInterval(this.cleanupTimer);
-  }
-
-  register(
-    userId: number,
-    username: string,
-    mediaFileId: number,
-    mediaTitle: string,
-    mediaType: string,
-    posterUrl: string | null,
-  ) {
-    const key = `${userId}-${mediaFileId}`;
-    const existing = this.sessions.get(key);
-    if (existing) {
-      existing.lastActivity = new Date();
-      return;
-    }
-    this.sessions.set(key, {
-      userId,
-      username,
-      mediaFileId,
-      mediaTitle,
-      mediaType,
-      posterUrl,
-      startedAt: new Date(),
-      lastActivity: new Date(),
-    });
-  }
-
-  unregister(userId: number, mediaFileId: number) {
-    const key = `${userId}-${mediaFileId}`;
-    this.sessions.delete(key);
-    this.deviceNameCache.delete(key);
-  }
-
+export class ActiveStreamTracker {
   /** Human-readable client device captured at playback-info ("Chrome — macOS",
    *  "iPhone", "Chromecast — Living Room"). Keyed per (user, file) so two users
-   *  watching the same file from different devices don't collide. Shown only on
-   *  the admin streams dashboard. */
+   *  watching the same file from different devices don't collide. Shown on the
+   *  admin streams dashboard as a fallback when the LiveSession has no raw
+   *  User-Agent label. */
   private readonly deviceNameCache = new Map<string, string>();
 
   setDeviceName(userId: number, mediaFileId: number, name: string) {
@@ -84,6 +28,11 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
 
   getDeviceName(userId: number, mediaFileId: number): string | null {
     return this.deviceNameCache.get(`${userId}-${mediaFileId}`) ?? null;
+  }
+
+  /** Release a (user, file)'s cached device name when its playback stops. */
+  unregister(userId: number, mediaFileId: number) {
+    this.deviceNameCache.delete(`${userId}-${mediaFileId}`);
   }
 
   // ── Global admin streaming settings forwarded to transcode sessions ──
@@ -130,22 +79,5 @@ export class ActiveStreamTracker implements OnModuleInit, OnModuleDestroy {
   }
   getSourceHeight(mediaFileId: number): number {
     return this.sourceHeightCache.get(mediaFileId) ?? 0;
-  }
-
-  getActive(): DirectPlaySession[] {
-    const cutoff = Date.now() - STALE_TIMEOUT_MS;
-    return Array.from(this.sessions.values()).filter(
-      (s) => s.lastActivity.getTime() > cutoff,
-    );
-  }
-
-  private cleanup() {
-    const cutoff = Date.now() - STALE_TIMEOUT_MS;
-    for (const [key, session] of this.sessions) {
-      if (session.lastActivity.getTime() <= cutoff) {
-        this.sessions.delete(key);
-        this.deviceNameCache.delete(key);
-      }
-    }
   }
 }

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -1877,25 +1877,23 @@ export class StreamingController {
       req.user as User,
     );
 
-    // Track direct play session
     const user = req.user;
-    if (user) {
-      this.activeStreamTracker.register(
-        user.id,
-        user.username,
-        mediaFileId,
-        resolved.media?.title ?? '',
-        resolved.media?.type ?? '',
-        resolved.media?.posterUrl ?? null,
-      );
-    }
-    // Keep the LiveSession alive while the Range chunks roll in —
-    // the heartbeat endpoint only fires on HLS/transcode paths, so
-    // without this every direct-play would get GC'd 30 s after
-    // playback-info and disappear from the dashboard.
+    // Keep the LiveSession alive while the Range chunks roll in — the
+    // heartbeat endpoint only fires on HLS/transcode paths, so without this
+    // every direct-play would get GC'd 30 s after playback-info and disappear
+    // from the dashboard. DirectPlay presence on the admin dashboard is the
+    // LiveSession itself (kind='directplay'), minted at playback-info.
     const sid = firstQueryString(req.query, 'sid');
     if (sid) {
       this.liveSessions.heartbeat(sid, {});
+    } else if (!firstQueryString(req.query, 'download')) {
+      // Canary for the removed direct-play tracker: a playback reaching this
+      // route without a sid never went through playback-info, so it has no
+      // LiveSession and won't appear on the activity dashboard. If this never
+      // logs in real use, the legacy no-playback-info path is confirmed dead.
+      this.log.warn(
+        `direct-play stream without sid (mediaFileId=${mediaFileId}, userId=${user?.id ?? 'anon'}) — no LiveSession, not shown on the activity dashboard`,
+      );
     }
 
     const duration = resolved.mediaFile.streamInfo?.durationSeconds;

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -814,10 +814,8 @@ export class StreamingController {
   stopLiveSession(@Param('sessionId') sessionId: string) {
     const live = this.liveSessions.get(sessionId);
     this.liveSessions.stop(sessionId);
-    // Clear the "now watching" tracker row immediately. DirectPlay has no
-    // profileHash, so the ffmpeg-kill path below is skipped and would never
-    // unregister this (user, file) — leaving the dashboard row up until the
-    // tracker's stale timeout.
+    // Release this (user, file)'s cached device name. The "now watching" row is
+    // the LiveSession itself, already stopped above.
     if (live?.userId != null) {
       this.activeStreamTracker.unregister(live.userId, live.mediaFileId);
     }


### PR DESCRIPTION
## What

Audit item **A1** (the structural keystone): remove the second DirectPlay presence store from `ActiveStreamTracker` and derive "now watching" for DirectPlay from `LiveSessionRegistry` alone.

## Why

Every playback — DirectPlay included — already mints a `LiveSession` (`kind='directplay'`) at `playback-info`, and the Range route keeps it warm via `liveSessions.heartbeat(sid)`. The tracker held a parallel `register`/`getActive`/`unregister` store with its own 2-min TTL, so:

- a DirectPlay was double-counted (LiveSession + tracker), de-duped by the dashboard;
- the two TTLs diverged (30s registry vs 2min tracker) → a paused DirectPlay could show inconsistent "now watching" state;
- the `dp-<user>-<file>` fallback rows only ever covered a client streaming `/stream/:id` **without** a prior `playback-info` — a path no current client takes.

## Changes

- `active-stream-tracker.service.ts` — drop the `sessions` map, `register` / `getActive` / `cleanup` / the 2-min TTL timer + lifecycle hooks. `unregister` now only releases the cached device name. Kept: device-name fallback, global admin settings, source dimensions.
- `system.controller.ts` (dashboard) — DirectPlay rows come from the live loop (`kind==='directplay'`); removed the `dp-` fallback loop, the `getActive()` snapshot, and the `dp-` branch of `resolveStreamCommandTarget`. DirectPlay admin stop/command resolves via the LiveSession sid (`isDirectPlay = kind==='directplay'`).
- `streaming.controller.ts` (Range route) — removed the tracker `register()`. Added a **canary**: a playback reaching `/stream/:id` without a `sid` (so no LiveSession) logs a warning — confirms the legacy no-playback-info path is dead before any further removal.

## Risk / validation

DirectPlay through the normal client flow is unaffected — it stays on the dashboard via its LiveSession. The only behaviour change is for a hypothetical client that streams `/stream/:id` without calling `playback-info` first: it would no longer appear, and would trip the canary warn. **Validate on device** that the canary never fires across real playbacks before relying on this. Pre-A1 savepoint: branch `savepoint/session-refactor-merged`.

## Known trade-off

The device-name cache lost its 2-min sweep along with the sessions store; it's now cleared only on a clean stop. A playback that never stops cleanly leaves one small `(user, file)` string entry until restart — bounded by distinct pairs, overwritten per key. Negligible for a self-hosted server; a LiveSession-keyed prune could restore parity if it ever matters.

## Review

Adversarial review (7 risk points): **no behavior regressions**. DirectPlay visibility via the LiveSession row; liveness via the sid heartbeat plus the client 10s `PUT /state`; device-label fallback unchanged; admin stop/command resolves the DirectPlay UUID via the LiveSession branch; the canary cannot false-positive (every normal direct play carries `?sid=`, downloads excluded). The device-name lifecycle note above is the only flagged item.

## Verification

- Backend: `tsc --noEmit` clean; streaming + `system.controller` specs **200/200** (`--runInBand`).
