### PR TITLE
fix(player): Shaka subtitle select/disable, desktop Escape, buffer flicker and subtitle polish

### DIFF
--- a/client/src/app/core/services/playback-engine/shaka-engine.ts
+++ b/client/src/app/core/services/playback-engine/shaka-engine.ts
@@ -304,10 +304,16 @@ export class ShakaEngine extends AbstractPlaybackEngine implements PlaybackEngin
   }
 
   setTextVisibility(visible: boolean): void {
+    // Shaka 5.x merged text visibility into track selection: the standalone
+    // `setTextVisibility(boolean)` method was removed, so the old bare call
+    // threw (silently caught) and disabling subtitles never took effect.
+    // Showing is handled by `selectTextTrack(track)` in selectTextTrack();
+    // to hide, deselect the track with `selectTextTrack(null)`.
+    if (visible) return;
     try {
-      (this.player as any)?.setTextVisibility(visible);
+      (this.player as any)?.selectTextTrack(null);
     } catch {
-      // Shaka may throw if no text tracks exist
+      // no player / no active text track
     }
   }
 

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -2532,9 +2532,14 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         if (!this.isOfflinePlayback) await this.reloadStream();
       }
       const track = await this.engine.addTextTrack(sub.url, sub.language, sub.label, sub.forced);
+      // Keep the engine track's own id intact: Shaka's selectTextTrack matches
+      // the rendition by its numeric track id, so overriding it with the app's
+      // `sub.id` made the selection a no-op (subtitles only appeared after a
+      // quality switch, whose reload passes the raw track). Native/desktop/TV
+      // engines key off language/forced/embIndex, not id, so this is a no-op
+      // for them — embIndex is still threaded through for desktop embedded subs.
       this.engine.selectTextTrack({
         ...track,
-        id: sub.id,
         embIndex: sub.id.startsWith('emb-') ? Number(sub.id.slice(4)) : null,
       });
       try { this.engine.setTextVisibility(true); } catch {}
@@ -2700,6 +2705,17 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   };
 
   private onPlayerBackEvent = () => {
+    // Desktop: Escape leaves the native (SDL) compositor fullscreen first —
+    // before closing the controls bar or exiting the player — matching the
+    // universal "Escape exits fullscreen" convention.
+    if (
+      this.isDesktopNative &&
+      this.engine instanceof DesktopEngine &&
+      this.engine.fullscreen
+    ) {
+      this.engine.setFullscreen(false);
+      return;
+    }
     // TV remote Return and desktop Escape first close a visible controls bar,
     // then exit on the next press — back mirrors the on-screen close. (On
     // desktop this event only ever comes from Escape, a deliberate keyboard

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -12,6 +12,14 @@ it is NOT the menu-bar server host under `macos/`.
   the single visible window. It composites **mpv video** (rendered into a GL FBO
   via libmpv's render API) under the **Angular UI bitmap**.
 - Embedded **mpv** comes from a self-contained static **libmpv** (render API).
+- ⚠️ **Two mpv backends — know which one you're debugging.** On **Linux**, mpv
+  runs **inside the native C++ addon** (libmpv render API); its property/event
+  plumbing (`time-pos`, `demuxer-cache-time`, `paused-for-cache`, `timeUpdate`,
+  `stateChanged`) lives in `native/compositor/addon.cc` + the `addon.onEvent` /
+  `emitPosition` wiring in `src/main/index.ts`. The `MpvPlayer` subprocess class
+  in `src/main/mpv/mpv-player.ts` is the **other** backend (Windows/macOS embed,
+  JSON-IPC) and is **NOT used on Linux** — editing it has no effect on the Linux
+  client. Both share `src/main/mpv/subtitle-style.ts` (`mpvSubtitleProps`).
 - This single-window compositor is the only model that works under **Mutter/X11**:
   an embedded mpv child window can't be composited beneath a sibling transparent
   overlay there, so we composite ourselves.

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -13,6 +13,7 @@
     "build:preload": "esbuild src/preload/index.ts --bundle --platform=node --target=node20 --format=cjs --external:electron --outfile=dist/preload/index.cjs",
     "build": "npm run build:main && npm run build:preload",
     "start": "npm run build && electron .",
+    "dev:linux": "bash scripts/dev-linux.sh",
     "dist": "electron-builder",
     "dist:linux": "electron-builder --linux deb",
     "dist:mac": "electron-builder --mac dmg",

--- a/desktop/scripts/dev-linux.sh
+++ b/desktop/scripts/dev-linux.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Build + launch the Fliks Linux desktop client (Electron + embedded mpv).
+#
+# Rebuilds the Angular client and the desktop main/preload bundle, kills any
+# running instance, then relaunches Electron under XWayland. See
+# desktop/CLAUDE.md for the architecture and first-time prerequisites
+# (vendored libmpv, native compositor addon, system build deps).
+#
+# Usage (run from anywhere — paths resolve from the script location):
+#   desktop/scripts/dev-linux.sh              # rebuild client + desktop, relaunch
+#   desktop/scripts/dev-linux.sh --no-client  # skip the Angular build (desktop-only edits)
+#   desktop/scripts/dev-linux.sh --addon      # also rebuild the native C++ compositor addon
+#
+# Background it (keep the terminal + accumulate logs):
+#   desktop/scripts/dev-linux.sh &
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# ng build output-path; Electron reads the client from "$OUT/browser". Lives
+# under /tmp because client/dist/ has root-owned PWA assets (EACCES on rebuild).
+OUT="/tmp/fliks-verify"
+
+build_client=1
+build_addon=0
+for arg in "$@"; do
+  case "$arg" in
+    --no-client) build_client=0 ;;
+    --addon)     build_addon=1 ;;
+    -h|--help)
+      cat >&2 <<'USAGE'
+dev-linux.sh — build + launch the Fliks Linux desktop client.
+
+  dev-linux.sh              rebuild client + desktop, then relaunch
+  dev-linux.sh --no-client  skip the Angular build (desktop-only edits)
+  dev-linux.sh --addon      also rebuild the native C++ compositor addon
+
+Append '&' to background it and keep the logs flowing.
+USAGE
+      exit 0 ;;
+    *) echo "dev-linux: unknown option '$arg'" >&2; exit 2 ;;
+  esac
+done
+
+# Fail fast on missing native bits — otherwise Electron crashes cryptically.
+[ -f "$ROOT/desktop/native/vendor/libmpv.so.2" ] || {
+  echo "dev-linux: missing desktop/native/vendor/libmpv.so.2 (vendored, gitignored) — see desktop/CLAUDE.md" >&2; exit 1; }
+[ -f "$ROOT/desktop/native/build/Release/fliks_compositor.node" ] || {
+  echo "dev-linux: missing native addon — re-run with --addon (or see desktop/CLAUDE.md)" >&2; exit 1; }
+
+if [ "$build_client" = 1 ]; then
+  echo "==> [1/3] Angular client → $OUT"
+  ( cd "$ROOT/client" && npx ng build --configuration development --output-path "$OUT" )
+fi
+
+if [ "$build_addon" = 1 ]; then
+  echo "==> native compositor addon (Electron 42 ABI)"
+  ( cd "$ROOT/desktop/native" && ../node_modules/.bin/node-gyp rebuild \
+      --target=42.4.0 --dist-url=https://electronjs.org/headers --arch=x64 )
+fi
+
+# ALWAYS the full build (main AND preload). Building only `build:main` leaves a
+# stale preload — `subAdd` goes missing and subtitles silently break on Linux.
+echo "==> [2/3] desktop main + preload"
+( cd "$ROOT/desktop" && npm run build )
+
+echo "==> [3/3] relaunch Electron"
+pkill -x electron 2>/dev/null || true
+
+cd "$ROOT/desktop"
+# DISPLAY=:0 forces XWayland — the OSR compositor doesn't run on native Wayland.
+FLIKS_WEB_DIR="$OUT/browser" DISPLAY="${DISPLAY:-:0}" \
+  exec ./node_modules/.bin/electron . --no-sandbox

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -278,7 +278,17 @@ app.whenReady().then(async () => {
     }
     switch (raw.type) {
       case 'timeUpdate':
-        send({ type: 'timeUpdate', payload: { position: raw.position, duration: raw.duration, buffered: 0 } });
+        // Read the real buffered position (matches the polled emitPosition).
+        // Hardcoding 0 here made bufferedEnd flip 0 <-> real as these events
+        // interleaved with the poll, so the seekbar's buffered zone flickered.
+        send({
+          type: 'timeUpdate',
+          payload: {
+            position: raw.position,
+            duration: raw.duration,
+            buffered: num(addon.getProperty('demuxer-cache-time')),
+          },
+        });
         break;
       case 'stateChanged':
         // Only an actively-playing session should drive the position timer;

--- a/desktop/src/main/mpv/mpv-player.ts
+++ b/desktop/src/main/mpv/mpv-player.ts
@@ -212,7 +212,10 @@ export class MpvPlayer extends EventEmitter {
         this.duration = data ?? 0;
         break;
       case 'demuxer-cache-time':
-        this.cacheEnd = data ?? 0;
+        // mpv reports null for this between HLS segments; keep the last value
+        // instead of zeroing it, otherwise the seekbar's buffered zone (drawn
+        // `@if (bufferedEnd())`) collapses to 0 and flickers on every gap.
+        if (data != null) this.cacheEnd = data;
         break;
       case 'pause':
         this.emit('stateChanged', { state: data ? 'paused' : 'playing' });

--- a/desktop/src/main/mpv/subtitle-style.ts
+++ b/desktop/src/main/mpv/subtitle-style.ts
@@ -3,7 +3,7 @@ import type { DesktopSubtitleStyle } from '../../shared/contract';
 // Base subtitle size the app's fontScale presets multiply. mpv's own default
 // (55) renders far too large, so we calibrate lower — at scale 1.0 this lands
 // around a typical caption height once mpv scales it to the window.
-export const MPV_BASE_SUB_FONT_SIZE = 28;
+export const MPV_BASE_SUB_FONT_SIZE = 26;
 
 /** Translate the app's subtitle style presets to mpv `sub-*` property pairs.
  *  Shared by every playback backend (the Linux compositor and the embed
@@ -26,6 +26,11 @@ export function mpvSubtitleProps(s: DesktopSubtitleStyle): Array<[string, string
     ['sub-border-style', hasBox ? 'background-box' : 'outline-and-shadow'],
     ['sub-back-color', hasBox ? s.backgroundColor : '#00000000'],
     ['sub-pos', String(Math.max(0, Math.min(100, 100 - (s.bottomMarginPercent || 0))))],
+    // mpv's default bottom margin (sub-margin-y ~22) parks subtitles well above
+    // the bottom edge, so at 0% bottom-margin they sat much higher than the web
+    // player (whose 0% is the near-edge browser default). Shrink it so sub-pos
+    // 100 is "almost glued to the bottom", matching Shaka.
+    ['sub-margin-y', '6'],
   ];
   // Every branch sets outline-size / shadow-offset / blur explicitly: these are
   // sticky mpv properties, so a preset that omits one would inherit a stale
@@ -48,14 +53,14 @@ export function mpvSubtitleProps(s: DesktopSubtitleStyle): Array<[string, string
       break;
     case 'drop_shadow':
     default:
-      // A soft glow behind the text with NO directional offset — a blurred,
-      // half-opacity black outline. The blur lands on the outline (not the
-      // fill), so the glyphs stay crisp; the offset is zero, so there's no
-      // displaced ghost copy. Opacity is kept low so it reads as a light shadow
-      // rather than a dark band around the text.
+      // A soft glow behind the text with NO directional offset — a blurred
+      // black outline. The blur lands on the outline (not the fill), so the
+      // glyphs stay crisp; the offset is zero, so there's no displaced ghost
+      // copy. Opacity is kept moderate so it reads as a shadow that lifts the
+      // text off bright backdrops without becoming a hard band around it.
       props.push(
-        ['sub-outline-size', '1.5'], ['sub-outline-color', '#4D000000'],
-        ['sub-shadow-offset', '0'], ['sub-shadow-color', '#00000000'], ['sub-blur', '0.5'],
+        ['sub-outline-size', '0.5'], ['sub-outline-color', '#AA000000'],
+        ['sub-shadow-offset', '0'], ['sub-shadow-color', '#00000000'], ['sub-blur', '1'],
       );
       break;
   }


### PR DESCRIPTION
## Player + desktop fixes (all validated on-device)

**Shaka subtitles (web) — regression fixes**
- Selecting a subtitle took effect only after a quality switch: `selectSubtitle` overrode the engine track's numeric id with the app's `sub.id`, so Shaka's `selectTextTrack` matched nothing. Keep the real id (embIndex still threaded for desktop).
- Disabling subtitles did nothing: Shaka 5.x **removed `setTextVisibility`** (merged into selection), so the bare call threw and was swallowed. Disable now uses `selectTextTrack(null)`.

**Desktop**
- **Escape** leaves the native (SDL) compositor fullscreen first, before closing the player.
- **Seekbar buffered-zone flicker**: the addon's `timeUpdate` event hardcoded `buffered: 0`, interleaving with the polled `emitPosition` (real `demuxer-cache-time`) → `bufferedEnd` flipped 0↔real and the zone blinked. Both now report the real value.
- Subtitle **bottom margin**: shrink mpv `sub-margin-y` so 0% sits near the bottom edge like the web player.
- Subprocess backend (`mpv-player.ts`): keep the last cache value on a null `demuxer-cache-time`.

**Tooling / docs**
- `desktop/scripts/dev-linux.sh` (+ `npm run dev:linux`): rebuild client + desktop and relaunch under XWayland.
- `desktop/CLAUDE.md`: document that on Linux mpv runs in the native C++ addon (`addon.cc` + `index.ts`), **not** `mpv-player.ts` (subprocess backend, Win/macOS).
