### PR TITLE
ci(desktop): attach client installers to the release-please release

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -19,6 +19,11 @@
         },
         {
           "type": "json",
+          "path": "desktop/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "client/webos/appinfo.json",
           "jsonpath": "$.version"
         },

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -25,9 +25,10 @@ name: Desktop release
 on:
   workflow_dispatch:
   push:
-    # Dedicated desktop tag namespace so this does not fire on release-please's
-    # `v*` tags (those drive the macos/ SwiftUI host's macos-dmg.yml).
-    tags: ['desktop-v*']
+    # release-please's `v*` tags ship the client installers on the main release
+    # alongside the SwiftUI server-host DMG (macos-dmg.yml). `desktop-v*` stays
+    # as a dedicated namespace for desktop-only test releases off-cycle.
+    tags: ['v*', 'desktop-v*']
 
 # Needed to attach installers to a GitHub Release on a tag push.
 permissions:
@@ -70,6 +71,8 @@ jobs:
         run: |
           if [[ "$GITHUB_REF" == refs/tags/desktop-v* ]]; then
             v="${GITHUB_REF#refs/tags/desktop-v}"
+          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            v="${GITHUB_REF#refs/tags/v}"
           else
             base=$(node -p "require('./desktop/package.json').version")
             v="${base}-dev.$(git rev-parse --short HEAD)"
@@ -236,7 +239,7 @@ jobs:
 
       # ── Attach to the GitHub Release on a desktop tag push ──
       - name: Attach to GitHub Release
-        if: startsWith(github.ref, 'refs/tags/desktop-v')
+        if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/desktop-v')
         uses: softprops/action-gh-release@v3
         with:
           files: ${{ matrix.artifact_glob }}

--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v4
         with:
-          name: Fliks-${{ steps.version.outputs.version }}-arm64.dmg
+          name: Fliks-Server-${{ steps.version.outputs.version }}-arm64.dmg
           path: macos/build/Fliks-*.dmg
           if-no-files-found: error
 

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -15,8 +15,11 @@
 appId: media.fliks.desktop
 productName: Fliks
 # Bake the version into every installer filename (the CI injects the resolved
-# version via -c.extraMetadata.version). e.g. Fliks-1.2.3-x64.dmg / -amd64.deb.
-artifactName: ${productName}-${version}-${arch}.${ext}
+# version via -c.extraMetadata.version). The "Client" marker distinguishes these
+# thin-client installers from the SwiftUI server-host DMG (macos-dmg.yml ships
+# Fliks-Server-<ver>-<arch>.dmg); both attach to the same release-please v*
+# release, so a shared filename would overwrite. e.g. Fliks-Client-1.2.3-x64.dmg.
+artifactName: ${productName}-Client-${version}-${arch}.${ext}
 directories:
   output: release
   buildResources: build

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fliks-desktop",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Fliks native desktop client (macOS / Windows / Linux)",
   "author": "Clément Delestre <contact@fliks.media>",
   "homepage": "https://github.com/fliks-app/fliks",

--- a/macos/Scripts/make-dmg.sh
+++ b/macos/Scripts/make-dmg.sh
@@ -6,7 +6,7 @@
 #
 # Usage: ./make-dmg.sh
 #
-# Output: macos/build/Fliks-<version>-arm64.dmg
+# Output: macos/build/Fliks-Server-<version>-arm64.dmg
 
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -21,7 +21,7 @@ fi
 
 # Extract version from Info.plist.
 VERSION="$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "$APP_BUNDLE/Contents/Info.plist" 2>/dev/null || echo "1.0.0")"
-DMG_NAME="Fliks-${VERSION}-arm64"
+DMG_NAME="Fliks-Server-${VERSION}-arm64"
 DMG_PATH="$BUILD_DIR/$DMG_NAME.dmg"
 
 # Remove previous DMG if it exists.


### PR DESCRIPTION
## Problem

The 1.12.0 release shipped with no `.deb`/`.exe`/`.dmg` for the desktop client. `desktop-release.yml` only triggered on the dedicated `desktop-v*` tag namespace, which release-please never pushes — it pushes `v*`. So the desktop build never ran for the release.

## Fix

- **`desktop-release.yml`** now fires on `v*` tags too (keeps `desktop-v*` for off-cycle desktop-only test builds), resolves the version from either tag, and attaches the installers to that release.
- **Filename collision fix**: the Electron client `.dmg` and the SwiftUI server-host `.dmg` (`macos-dmg.yml`) both attach to the same `v*` release. They previously shared `Fliks-<ver>-arm64.dmg` and would overwrite each other. Now:
  - client installers → `Fliks-Client-<ver>-<arch>` (.deb/.exe/.dmg)
  - server-host DMG → `Fliks-Server-<ver>-arm64.dmg`
- **release-please**: added `desktop/package.json` to `extra-files` (its version was stuck at 1.11.0) and bumped it to 1.12.0 to catch up.