### PR TITLE
fix(admin-streams): show direct-play label under container row

### DIFF
--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -950,6 +950,7 @@
     "tab_logs": "Journaux",
     "tab_streams": "Activités vidéos",
     "streams_subtitle": "Sessions de lecture en cours sur l'ensemble des clients.",
+    "streams_container_direct": "Lecture directe",
     "streams_audio_direct": "Lecture directe",
     "streams_audio_copy": "Copie bitstream ({{codec}})",
     "streams_audio_transcode": "Transcodage ({{codec}})",

--- a/client/src/app/features/system/streams/streams.html
+++ b/client/src/app/features/system/streams/streams.html
@@ -55,7 +55,9 @@
             <div>
               <span class="font-medium">{{ (s.container ?? '?') | uppercase }}</span>
               @if (s.videoBitrate) { ({{ formatBitrate(s.videoBitrate) }}) }
-              @if (s.outputContainer) {
+              @if (s.mode === 'directplay') {
+                <div class="text-base-content/50">&rarr; {{ 'system.streams_container_direct' | translate }}</div>
+              } @else if (s.outputContainer) {
                 <div class="text-base-content/50">&rarr; {{ s.outputContainer }}
                   @if (s.outputBitrate) { ({{ formatBitrate(s.outputBitrate) }}) }
                 </div>


### PR DESCRIPTION
## Summary
- Show `→ Lecture directe` under the Flux/container row when a session is in direct-play mode
- Aligns admin streams cards with the player stats-for-nerds overlay (remux/transcode already showed `→ HLS`)

## Test plan
- [ ] Start a direct-play session on a compatible file
- [ ] Open Admin → Activités vidéos and confirm the Flux row shows `→ Lecture directe` below the source container
- [ ] Confirm remux/transcode sessions still show `→ HLS` unchanged

Made with [Cursor](https://cursor.com)