### PR TITLE
fix(streaming): scope admin stop to one device session

### DIFF
--- a/backend/src/modules/scheduler/events.service.ts
+++ b/backend/src/modules/scheduler/events.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { Subject, Observable, Subscription } from 'rxjs';
-import { filter, map } from 'rxjs/operators';
+import { randomUUID } from 'crypto';
 
 export type SseEvent =
   | {
@@ -81,7 +81,14 @@ export type SseEvent =
     }
   | { type: 'rescan.failed'; mediaId: number; title: string; error: string }
   | {
+      // Handshake on SSE connect — tells the client which connection id to
+      // bind to its live sessions so admin remote-control targets one device.
+      type: 'sse.connected';
+      connectionId: string;
+    }
+  | {
       type: 'player.command';
+      sessionId: string;
       mediaFileId: number;
       userId: number;
       action: 'pause' | 'play' | 'stop' | 'message';
@@ -144,40 +151,86 @@ export type SseEvent =
     };
 
 /**
- * Wraps an `SseEvent` with its delivery audience. `audience: null` is a
- * broadcast (everyone connected); a numeric array restricts the SSE push to
- * those user IDs. Backend-internal `subscribe()` listeners ignore the audience
- * and always see the event — the audience only gates the client-facing stream.
+ * Wraps an `SseEvent` with its delivery audience.
+ *   - `audience: null` + `connectionIds: null` → every SSE connection.
+ *   - `audience: [userId, …]` → every connection owned by those users.
+ *   - `connectionIds: [id, …]` → only those specific SSE connections.
+ * Backend-internal `subscribe()` listeners ignore the audience and always see
+ * the event — the audience only gates the client-facing stream.
  */
 interface SseEnvelope {
   audience: number[] | null;
+  connectionIds: string[] | null;
   event: SseEvent;
 }
 
 @Injectable()
 export class EventsService {
   private readonly subject = new Subject<SseEnvelope>();
+  private readonly connections = new Map<string, { userId: number }>();
 
   /** Broadcast to every connected client. */
   emit(event: SseEvent): void {
-    this.subject.next({ audience: null, event });
+    this.subject.next({ audience: null, connectionIds: null, event });
   }
 
   /** Deliver only to the given user's SSE connections. */
   emitToUser(userId: number, event: SseEvent): void {
-    this.subject.next({ audience: [userId], event });
+    this.subject.next({ audience: [userId], connectionIds: null, event });
   }
 
   /** Deliver only to the given users' SSE connections. Empty list = nobody. */
   emitToUsers(userIds: number[], event: SseEvent): void {
-    this.subject.next({ audience: userIds, event });
+    this.subject.next({ audience: userIds, connectionIds: null, event });
+  }
+
+  /** Deliver only to one SSE connection (multi-device remote control). */
+  emitToConnection(connectionId: string, event: SseEvent): void {
+    if (!this.connections.has(connectionId)) return;
+    this.subject.next({
+      audience: null,
+      connectionIds: [connectionId],
+      event,
+    });
+  }
+
+  hasConnection(connectionId: string): boolean {
+    return this.connections.has(connectionId);
   }
 
   getStream(userId: number): Observable<MessageEvent> {
-    return this.subject.asObservable().pipe(
-      filter((env) => env.audience === null || env.audience.includes(userId)),
-      map((env) => ({ data: JSON.stringify(env.event) }) as MessageEvent),
-    );
+    return new Observable((subscriber) => {
+      const connectionId = randomUUID();
+      this.connections.set(connectionId, { userId });
+
+      subscriber.next({
+        data: JSON.stringify({
+          type: 'sse.connected',
+          connectionId,
+        } satisfies SseEvent),
+      } as MessageEvent);
+
+      const sub = this.subject.subscribe((env) => {
+        if (!this.shouldDeliver(env, userId, connectionId)) return;
+        subscriber.next({ data: JSON.stringify(env.event) } as MessageEvent);
+      });
+
+      return () => {
+        sub.unsubscribe();
+        this.connections.delete(connectionId);
+      };
+    });
+  }
+
+  private shouldDeliver(
+    env: SseEnvelope,
+    userId: number,
+    connectionId: string,
+  ): boolean {
+    if (env.audience === null && env.connectionIds === null) return true;
+    if (env.connectionIds?.includes(connectionId)) return true;
+    if (env.audience?.includes(userId)) return true;
+    return false;
   }
 
   /** Backend-internal listener — used by services that react to other modules' events. */

--- a/backend/src/modules/scheduler/system.controller.spec.ts
+++ b/backend/src/modules/scheduler/system.controller.spec.ts
@@ -34,6 +34,7 @@ describe('SystemController.activeStreams recency filter', () => {
       quality: null,
       kind: 'directplay',
       deviceLabel: null,
+      sseConnectionId: null,
       startedAt: new Date(overrides.lastBeat),
       position: 0,
       state: 'playing',
@@ -131,5 +132,115 @@ describe('SystemController.activeStreams recency filter', () => {
     const streams = await controller.activeStreams();
 
     expect(streams).toHaveLength(0);
+  });
+});
+
+describe('SystemController.sendPlayerCommand', () => {
+  function makeCommandController(liveOverrides: Record<string, unknown> = {}) {
+    const eventsService = {
+      emitToUser: jest.fn(),
+      emitToConnection: jest.fn(),
+      hasConnection: jest.fn().mockReturnValue(false),
+    };
+    const liveSession = {
+      sessionId: 'linux-sid',
+      userId: 1,
+      mediaFileId: 42,
+      profileHash: 'profile-linux',
+      kind: 'directplay' as const,
+      sseConnectionId: null,
+      ...liveOverrides,
+    };
+    const liveSessions = {
+      get: jest.fn((id: string) =>
+        id === 'linux-sid' ? liveSession : null,
+      ),
+      stop: jest.fn().mockReturnValue(true),
+      list: jest.fn().mockReturnValue([
+        {
+          sessionId: 'android-sid',
+          userId: 1,
+          mediaFileId: 42,
+        },
+      ]),
+      listForJob: jest.fn().mockReturnValue([]),
+    };
+    const activeStreamTracker = { unregister: jest.fn() };
+    const transcodingService = {
+      getActiveSessions: jest.fn().mockReturnValue([]),
+      killSessionsForJob: jest.fn(),
+    };
+
+    const controller = new SystemController(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      eventsService as never,
+      transcodingService as never,
+      {} as never,
+      activeStreamTracker as never,
+      liveSessions as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+
+    return {
+      controller,
+      eventsService,
+      liveSessions,
+      activeStreamTracker,
+      transcodingService,
+    };
+  }
+
+  it('includes sessionId in the player.command SSE payload', () => {
+    const { controller, eventsService } = makeCommandController();
+
+    controller.sendPlayerCommand('linux-sid', { action: 'pause' });
+
+    expect(eventsService.emitToUser).toHaveBeenCalledWith(1, {
+      type: 'player.command',
+      sessionId: 'linux-sid',
+      mediaFileId: 42,
+      userId: 1,
+      action: 'pause',
+      message: undefined,
+    });
+    expect(eventsService.emitToConnection).not.toHaveBeenCalled();
+  });
+
+  it('routes player.command to the bound SSE connection when present', () => {
+    const { controller, eventsService } = makeCommandController({
+      sseConnectionId: 'conn-1',
+    });
+    eventsService.hasConnection.mockReturnValue(true);
+
+    controller.sendPlayerCommand('linux-sid', { action: 'pause' });
+
+    expect(eventsService.emitToConnection).toHaveBeenCalledWith('conn-1', {
+      type: 'player.command',
+      sessionId: 'linux-sid',
+      mediaFileId: 42,
+      userId: 1,
+      action: 'pause',
+      message: undefined,
+    });
+    expect(eventsService.emitToUser).not.toHaveBeenCalled();
+  });
+
+  it('stops only the targeted live session and keeps sibling viewers', () => {
+    const { controller, liveSessions, activeStreamTracker, transcodingService } =
+      makeCommandController();
+
+    controller.sendPlayerCommand('linux-sid', { action: 'stop' });
+
+    expect(liveSessions.stop).toHaveBeenCalledWith('linux-sid');
+    expect(activeStreamTracker.unregister).not.toHaveBeenCalled();
+    expect(transcodingService.killSessionsForJob).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -688,28 +688,55 @@ export class SystemController {
       throw new BadRequestException('Session not found');
     }
 
-    this.eventsService.emitToUser(target.userId, {
-      type: 'player.command',
+    const live = this.liveSessions.get(sessionId);
+    const cmdEvent = {
+      type: 'player.command' as const,
+      sessionId,
       mediaFileId: target.mediaFileId,
       userId: target.userId,
       action: body.action,
       message: body.message,
-    });
+    };
+    const sseConnectionId = live?.sseConnectionId;
+    if (sseConnectionId && this.eventsService.hasConnection(sseConnectionId)) {
+      this.eventsService.emitToConnection(sseConnectionId, cmdEvent);
+    } else {
+      // Legacy clients without a bound SSE connection: every tab/device for
+      // this user receives the command — they must filter on sessionId.
+      this.eventsService.emitToUser(target.userId, cmdEvent);
+    }
 
     if (body.action === 'stop') {
+      this.liveSessions.stop(sessionId);
       if (target.isDirectPlay) {
-        this.activeStreamTracker.unregister(target.userId, target.mediaFileId);
+        const remainingForFile = [...this.liveSessions.list()].filter(
+          (s) =>
+            s.userId === target.userId &&
+            s.mediaFileId === target.mediaFileId,
+        );
+        if (remainingForFile.length === 0) {
+          this.activeStreamTracker.unregister(
+            target.userId,
+            target.mediaFileId,
+          );
+        }
       } else if (target.profileHash) {
-        // Admin stop is a force-kill: reap every ffmpeg variant of the job
-        // (main / early / remux / per-audio), not just the main one — the
-        // companions would otherwise idle on until the reaper sweeps them.
-        this.transcodingService.killSessionsForJob(
-          target.mediaFileId,
+        const remaining = this.liveSessions.listForJob(
           target.userId,
+          target.mediaFileId,
           target.profileHash,
         );
+        if (remaining.length === 0) {
+          // Admin stop is a force-kill: reap every ffmpeg variant of the job
+          // (main / early / remux / per-audio), not just the main one — the
+          // companions would otherwise idle on until the reaper sweeps them.
+          this.transcodingService.killSessionsForJob(
+            target.mediaFileId,
+            target.userId,
+            target.profileHash,
+          );
+        }
       }
-      this.liveSessions.stop(sessionId);
     }
 
     return { ok: true };

--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -47,6 +47,9 @@ export interface LiveSession {
   quality: string | null;
   kind: SessionKind;
   deviceLabel: string | null;
+  /** SSE connection that owns this playback — admin remote-control is routed
+   *  here so a second device on the same (user, file) is left untouched. */
+  sseConnectionId: string | null;
   startedAt: number;
   lastBeat: number;
   position: number;
@@ -114,6 +117,7 @@ export interface CreateLiveSessionInput {
   quality?: string | null;
   kind: SessionKind;
   deviceLabel?: string | null;
+  sseConnectionId?: string | null;
   position?: number;
   useTs?: boolean;
   audioPlan?: AudioPlan | null;
@@ -218,6 +222,7 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
       quality: input.quality ?? null,
       kind: input.kind,
       deviceLabel: input.deviceLabel ?? null,
+      sseConnectionId: input.sseConnectionId ?? null,
       startedAt: now,
       lastBeat: now,
       position: input.position ?? 0,
@@ -281,6 +286,7 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
       quality?: string | null;
       audioTrackIndex?: number | null;
       subtitleTrackIndex?: number | null;
+      sseConnectionId?: string | null;
     },
   ): LiveSession | null {
     const session = this.sessions.get(sessionId);
@@ -294,6 +300,9 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
     }
     if (payload.subtitleTrackIndex !== undefined) {
       session.subtitleTrackIndex = payload.subtitleTrackIndex;
+    }
+    if (payload.sseConnectionId) {
+      session.sseConnectionId = payload.sseConnectionId;
     }
     return session;
   }

--- a/backend/src/modules/streaming/playback.controller.ts
+++ b/backend/src/modules/streaming/playback.controller.ts
@@ -202,9 +202,12 @@ export class PlaybackController {
       quality?: string | null;
       audioTrackIndex?: number | null;
       subtitleTrackIndex?: number | null;
+      sseConnectionId?: string;
     },
   ): Promise<{ sessionLost?: true; state?: unknown } | null> {
     const user = req.user as User;
+    const sseConnectionId =
+      body.sseConnectionId ?? req.get('x-fliks-sse-connection') ?? undefined;
 
     let stateChanged = false;
     let sessionLost = false;
@@ -217,6 +220,7 @@ export class PlaybackController {
         quality: body.quality,
         audioTrackIndex: body.audioTrackIndex,
         subtitleTrackIndex: body.subtitleTrackIndex,
+        sseConnectionId,
       });
       stateChanged = !!updated && !!body.state && previousState !== body.state;
       // The client believes the session is alive but the registry

--- a/backend/src/modules/streaming/streaming.controller.spec.ts
+++ b/backend/src/modules/streaming/streaming.controller.spec.ts
@@ -13,6 +13,7 @@ describe('StreamingController.stopLiveSession', () => {
     const liveSessions = {
       get: jest.fn().mockReturnValue(live),
       stop: jest.fn(),
+      list: jest.fn().mockReturnValue([]),
       listForJob: jest.fn().mockReturnValue([]),
     };
     const activeStreamTracker = {
@@ -55,6 +56,7 @@ describe('StreamingController.stopLiveSession', () => {
       quality: null,
       kind: 'directplay',
       deviceLabel: null,
+      sseConnectionId: null,
       startedAt: Date.now(),
       lastBeat: Date.now(),
       position: 0,
@@ -121,6 +123,18 @@ describe('StreamingController.stopLiveSession', () => {
     controller.stopLiveSession('missing');
 
     expect(liveSessions.stop).toHaveBeenCalledWith('missing');
+    expect(activeStreamTracker.unregister).not.toHaveBeenCalled();
+  });
+
+  it('skips unregister when another live session remains on the same file', () => {
+    const live = makeLive({ profileHash: null, userId: 7, mediaFileId: 42 });
+    const { controller, liveSessions, activeStreamTracker } = makeController(live);
+    liveSessions.list.mockReturnValue([
+      { sessionId: 'sid-2', userId: 7, mediaFileId: 42 },
+    ]);
+
+    controller.stopLiveSession('sid-1');
+
     expect(activeStreamTracker.unregister).not.toHaveBeenCalled();
   });
 

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -688,6 +688,7 @@ export class StreamingController {
           ? 'remux'
           : 'transcode';
     const deviceLabel: string | null = req.get('user-agent') ?? null;
+    const sseConnectionId = req.get('x-fliks-sse-connection') ?? null;
 
     // Seed the session playhead with the effective resume offset, not the raw
     // `startAt`: a client that resumes by relying on the saved position (no
@@ -714,6 +715,7 @@ export class StreamingController {
       quality: typeof startQuality === 'string' ? startQuality : null,
       kind,
       deviceLabel,
+      sseConnectionId,
       position: resumePosition,
       useTs: effectiveUseTs,
       audioPlan: response.audioPlan,
@@ -814,10 +816,15 @@ export class StreamingController {
   stopLiveSession(@Param('sessionId') sessionId: string) {
     const live = this.liveSessions.get(sessionId);
     this.liveSessions.stop(sessionId);
-    // Release this (user, file)'s cached device name. The "now watching" row is
-    // the LiveSession itself, already stopped above.
+    // Release this (user, file)'s cached device name only when no sibling
+    // session remains — multi-device viewers share the same user+file pair.
     if (live?.userId != null) {
-      this.activeStreamTracker.unregister(live.userId, live.mediaFileId);
+      const remainingForFile = [...this.liveSessions.list()].filter(
+        (s) => s.userId === live.userId && s.mediaFileId === live.mediaFileId,
+      );
+      if (remainingForFile.length === 0) {
+        this.activeStreamTracker.unregister(live.userId, live.mediaFileId);
+      }
     }
     if (!live || !live.profileHash) return;
     // Only kill the underlying ffmpeg job(s) when no other live

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -9,6 +9,9 @@ import {
   BrowserDeviceProfileService,
   DeviceProfile,
 } from '../browser-device-profile.service';
+import { SseService } from '../sse.service';
+
+const SSE_CONNECTION_HEADER = 'X-Fliks-Sse-Connection';
 
 export type PlayMethod = 'DirectPlay' | 'DirectStream' | 'Transcode';
 
@@ -209,6 +212,12 @@ export class StreamingApiService {
   private readonly serverConfig = inject(ServerConfigService);
   private readonly castService = inject(CastService);
   private readonly deviceProfileService = inject(BrowserDeviceProfileService);
+  private readonly sse = inject(SseService);
+
+  private sseConnectionHeaders(): Record<string, string> | undefined {
+    const id = this.sse.connectionId();
+    return id ? { [SSE_CONNECTION_HEADER]: id } : undefined;
+  }
 
   /**
    * Token embedded into every streaming URL (manifest, segment, subtitle,
@@ -426,6 +435,7 @@ export class StreamingApiService {
       this.http.post<PlaybackInfoResponse>(
         `/api/stream/${mediaFileId}/playback-info${params}`,
         deviceProfile,
+        { headers: this.sseConnectionHeaders() },
       ),
     );
   }
@@ -511,6 +521,7 @@ export class StreamingApiService {
       this.http.put<HeartbeatResponse | null>(
         `/api/playback/media/${mediaId}/state`,
         body,
+        { headers: this.sseConnectionHeaders() },
       ),
     );
   }

--- a/client/src/app/core/services/sse.service.ts
+++ b/client/src/app/core/services/sse.service.ts
@@ -30,6 +30,9 @@ export class SseService implements OnDestroy {
 
   readonly activeProgress = signal<Map<string, TaskProgress>>(new Map());
   readonly lastEvent = signal<SseEvent | null>(null);
+  /** Issued by the backend on SSE connect — bound to live sessions so admin
+   *  remote-control reaches only this device/tab. */
+  readonly connectionId = signal<string | null>(null);
   private eventSource: EventSource | null = null;
   private retryDelay = 5000;
 
@@ -60,6 +63,13 @@ export class SseService implements OnDestroy {
     this.eventSource.onmessage = (event) => {
       try {
         const data = JSON.parse(event.data) as SseEvent;
+        if (data.type === 'sse.connected') {
+          const id = data['connectionId'];
+          if (typeof id === 'string' && id) {
+            this.connectionId.set(id);
+          }
+          return;
+        }
         this.handleEvent(data);
         // Don't update lastEvent for high-frequency progress events
         // (handled via dedicated signals/stores instead)
@@ -73,6 +83,7 @@ export class SseService implements OnDestroy {
     this.eventSource.onerror = () => {
       this.eventSource?.close();
       this.eventSource = null;
+      this.connectionId.set(null);
       if (!navigator.onLine) {
         // Offline — wait for online event instead of polling
         window.addEventListener('online', () => this.connect(), { once: true });

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -354,6 +354,13 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     const currentUserId = this.authService.user()?.id;
     if (cmd.mediaFileId !== this.mediaFileId || cmd.userId !== currentUserId) return;
 
+    // The same user can watch the same file on several devices at once —
+    // only the targeted live session should react.
+    if (cmd.sessionId) {
+      const sid = this.activeSessionId();
+      if (!sid || cmd.sessionId !== sid) return;
+    }
+
     if (cmd.action === 'message') {
       const text = (cmd.message as string)?.trim();
       if (text) this.showAdminMessage(text);


### PR DESCRIPTION
## Summary
- Register a per-SSE-connection id (`sse.connected`) and bind each live session to it via `X-Fliks-Sse-Connection` on playback-info / heartbeats
- Route admin `player.command` (stop/pause/play/message) to that connection only instead of every tab/device for the user
- Keep `sessionId` client-side filtering as a fallback for legacy clients
- Skip tracker unregister / ffmpeg kill when a sibling live session remains on the same (user, file)

## Test plan
- [ ] Play the same episode on Android and Linux desktop with the same account
- [ ] Stop one session from Admin → Activités vidéos — only that device exits playback
- [ ] Confirm pause/message also affect only the targeted card's device
- [ ] Stop the last remaining session — dashboard row clears as before

Made with [Cursor](https://cursor.com)