### PR TITLE
fix(scheduler): use original title for auto series grabs

### DIFF
--- a/backend/src/modules/media/release-rejection.helper.spec.ts
+++ b/backend/src/modules/media/release-rejection.helper.spec.ts
@@ -1,4 +1,7 @@
-import { sortReleasesByRelevance } from './release-rejection.helper';
+import {
+  releaseContainsAnyTitle,
+  sortReleasesByRelevance,
+} from './release-rejection.helper';
 
 type Row = Parameters<typeof sortReleasesByRelevance>[0][number];
 
@@ -69,5 +72,28 @@ describe('sortReleasesByRelevance', () => {
     });
     const clean = row({ id: 'clean', rank: 100, seeders: 1 });
     expect(order([rejected, clean])).toEqual(['clean', 'rejected']);
+  });
+});
+
+describe('releaseContainsAnyTitle', () => {
+  const rickFr = {
+    title: 'Rick et Morty',
+    originalTitle: 'Rick and Morty',
+    alternativeTitles: null,
+  };
+
+  it('matches an English scene release when the library title is localized', () => {
+    expect(
+      releaseContainsAnyTitle(
+        'Rick.and.Morty.S09E04.1080p.WEB-DL.x264-GROUP',
+        rickFr,
+      ),
+    ).toBe(true);
+  });
+
+  it('does not match an unrelated show', () => {
+    expect(
+      releaseContainsAnyTitle('Abbott.Elementary.S05E10.1080p.x264-GROUP', rickFr),
+    ).toBe(false);
   });
 });

--- a/backend/src/modules/media/release-rejection.helper.ts
+++ b/backend/src/modules/media/release-rejection.helper.ts
@@ -92,6 +92,24 @@ export function resolveSearchTitles(
   return { searchTitle, expectedTitles };
 }
 
+/** RSS / feed matching: true when the release title plausibly refers to the
+ *  show under any of its known names (canonical, original, TMDB/TVDB aliases).
+ *  Uses the same token logic as {@link titleMatchesExpectation} so dotted
+ *  scene names like `Rick.and.Morty` match `Rick and Morty`. */
+export function releaseContainsAnyTitle(
+  releaseTitle: string,
+  media: {
+    title: string;
+    originalTitle?: string | null;
+    alternativeTitles?: string[] | null;
+  },
+): boolean {
+  return titleMatchesExpectation(
+    releaseTitle,
+    resolveSearchTitles(media).expectedTitles,
+  );
+}
+
 /**
  * Returns the codec-adjusted absolute deviation of a release's MB/h
  * rate from the quality's preferred MB/h, normalised by preferred.

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -36,7 +36,7 @@ import {
   AutoGrabScoringContext,
 } from '../media/auto-grab-pipeline.service';
 import { MarkersService } from '../markers/markers.service';
-import { rankFromQualityString } from '../media/release-rejection.helper';
+import { rankFromQualityString, resolveSearchTitles, releaseContainsAnyTitle } from '../media/release-rejection.helper';
 import { parseSeasonEpisode } from '../../common/release-parsing';
 
 // Note: scoring/profile/blocklist/quality-definition wiring lives in
@@ -476,7 +476,8 @@ export class SchedulerService implements OnModuleInit {
 
       if (!this.isAvailable(media, today)) continue;
 
-      const query = [media.title, media.year].filter(Boolean).join(' ');
+      const { searchTitle, expectedTitles } = resolveSearchTitles(media);
+      const query = [searchTitle, media.year].filter(Boolean).join(' ');
       const batches = await Promise.allSettled(
         indexers.map((ix) =>
           this.torznab.searchMovie(ix, query, {
@@ -497,7 +498,7 @@ export class SchedulerService implements OnModuleInit {
         scoring,
         mediaType: 'movie',
         label: media.title,
-        expectedTitle: [media.title, ...(media.alternativeTitles ?? [])],
+        expectedTitle: expectedTitles,
         runtimeMinutes: media.runtime ?? 0,
         pendingCheck: async () => {
           const pending = await this.historyRepo.findOne({
@@ -558,6 +559,7 @@ export class SchedulerService implements OnModuleInit {
       .addSelect([
         'media.id',
         'media.title',
+        'media.originalTitle',
         'media.year',
         'media.runtime',
         'media.tvdbId',
@@ -631,11 +633,12 @@ export class SchedulerService implements OnModuleInit {
         ? [{ quality: fileQualityByEpId.get(ep.id) ?? null }]
         : [];
 
+      const { searchTitle, expectedTitles } = resolveSearchTitles(media);
       const batches = await Promise.allSettled(
         indexers.map((ix) =>
           this.torznab.searchSeries(
             ix,
-            media.title,
+            searchTitle,
             season.seasonNumber,
             ep.episodeNumber,
             { tvdbId: media.tvdbId, imdbId: media.imdbId },
@@ -654,7 +657,7 @@ export class SchedulerService implements OnModuleInit {
         scoring,
         mediaType: 'series',
         label: `${media.title} ${epLabel}`,
-        expectedTitle: [media.title, ...(media.alternativeTitles ?? [])],
+        expectedTitle: expectedTitles,
         // Episodes are typically 20-60 min; 30 min fallback for size check.
         runtimeMinutes: media.runtime ?? 30,
         seasonNumber: season.seasonNumber,
@@ -748,9 +751,10 @@ export class SchedulerService implements OnModuleInit {
         continue;
       }
 
+      const { searchTitle, expectedTitles } = resolveSearchTitles(media);
       const packBatches = await Promise.allSettled(
         indexers.map((ix) =>
-          this.torznab.searchSeasonPack(ix, media.title, season.seasonNumber, {
+          this.torznab.searchSeasonPack(ix, searchTitle, season.seasonNumber, {
             tvdbId: media.tvdbId,
             imdbId: media.imdbId,
           }),
@@ -795,7 +799,7 @@ export class SchedulerService implements OnModuleInit {
         scoring,
         mediaType: 'series',
         label: `${media.title} ${seasonLabel} (pack)`,
-        expectedTitle: [media.title, ...(media.alternativeTitles ?? [])],
+        expectedTitle: expectedTitles,
         runtimeMinutes: (media.runtime ?? 45) * epCount,
         seasonNumber: season.seasonNumber,
         seasonId: season.id,
@@ -1377,8 +1381,7 @@ export class SchedulerService implements OnModuleInit {
     release: TorznabRelease,
     candidates: Media[],
   ): Media | undefined {
-    const lower = release.title.toLowerCase();
-    return candidates.find((m) => lower.includes(m.title.toLowerCase()));
+    return candidates.find((m) => releaseContainsAnyTitle(release.title, m));
   }
 
   private releaseTooFresh(
@@ -1419,10 +1422,7 @@ export class SchedulerService implements OnModuleInit {
       scoring: args.scoring,
       mediaType: args.mediaType,
       label: args.label,
-      expectedTitle: [
-        args.media.title,
-        ...(args.media.alternativeTitles ?? []),
-      ],
+      expectedTitle: resolveSearchTitles(args.media).expectedTitles,
       runtimeMinutes: args.runtimeMinutes,
       seasonNumber: args.seasonNumber,
       pendingCheck: async () => {


### PR DESCRIPTION
## Summary
- Align SearchMissing / season-pack search with manual search via `resolveSearchTitles` (`originalTitle` + aliases for indexer queries and scoring)
- Fix RSS series matching to accept releases named after the English/original title when the library title is localized (e.g. Rick et Morty)
- Load `originalTitle` in the SearchMissing episode query (was omitted from the partial select)

## Why
Auto-grab left no row in Activities: jobs ran but returned zero matching releases. Manual search already used `originalTitle` ("Rick and Morty") while auto used "Rick et Morty".

## Test plan
- [ ] Deploy backend, trigger SearchMissing or wait for RssSync on a localized series with a missing aired episode
- [ ] Confirm a grab appears in Activities when English releases exist
- [ ] `npx jest release-rejection.helper.spec.ts --runInBand`

Made with [Cursor](https://cursor.com)