### PR TITLE
fix(auto-grab): match season packs and optional resolution upgrades

### DIFF
--- a/backend/src/common/release-parsing/season-episode.parser.spec.ts
+++ b/backend/src/common/release-parsing/season-episode.parser.spec.ts
@@ -1,4 +1,4 @@
-import { parseSeasonEpisode } from './season-episode.parser';
+import { matchesSeasonPack, parseSeasonEpisode } from './season-episode.parser';
 
 describe('parseSeasonEpisode', () => {
   it('parses SxxExx', () => {
@@ -54,5 +54,35 @@ describe('parseSeasonEpisode', () => {
     expect(r.isFullSeason).toBe(false);
     expect(r.season).toBe(2);
     expect(r.episode).toBe(5);
+  });
+
+  it('parses season-only Sxx before x265 codec tags', () => {
+    expect(
+      parseSeasonEpisode('Show.Name.Spinoff.S01.1080p.x265-GROUP'),
+    ).toEqual({
+      season: 1,
+      episode: null,
+      isFullSeason: true,
+    });
+  });
+
+  it('does not treat x265 codec as a legacy season×episode tag', () => {
+    expect(parseSeasonEpisode('Show.Name.S09.1080p.x265-GROUP')).toEqual({
+      season: 9,
+      episode: null,
+      isFullSeason: true,
+    });
+  });
+});
+
+describe('matchesSeasonPack', () => {
+  const s01Pack = 'Show.Name.Spinoff.S01.1080p.x265-GROUP';
+
+  it('matches the parsed season', () => {
+    expect(matchesSeasonPack(s01Pack, 1)).toBe(true);
+  });
+
+  it('rejects a different target season', () => {
+    expect(matchesSeasonPack(s01Pack, 9)).toBe(false);
   });
 });

--- a/backend/src/common/release-parsing/season-episode.parser.ts
+++ b/backend/src/common/release-parsing/season-episode.parser.ts
@@ -26,7 +26,9 @@ export interface ParsedSeasonEpisode {
 const SE_RE = /\bS(\d{1,2})E(\d{1,3})\b/i;
 const SEASON_ONLY_RE = /\bS(\d{1,2})(?!E\d)\b/i;
 const SEASON_KEYWORD_RE = /\bSeason[\s._-]?(\d{1,2})\b/i;
-const LEGACY_RE = /\b(\d{1,2})x(\d{1,3})\b/;
+/** Legacy `1x02` — require a digit before `x` so `x265` / `HEVCx265`
+ *  never parse as season 26 episode 5. */
+const LEGACY_RE = /(?<![a-zA-Z])(\d{1,2})x(\d{1,3})\b/i;
 
 export function parseSeasonEpisode(title: string): ParsedSeasonEpisode {
   // 1. SxxExx — most common.
@@ -66,4 +68,13 @@ export function parseSeasonEpisode(title: string): ParsedSeasonEpisode {
     };
   }
   return { season: null, episode: null, isFullSeason: false };
+}
+
+/** True when `title` is a full-season pack for the requested season. */
+export function matchesSeasonPack(
+  title: string,
+  seasonNumber: number,
+): boolean {
+  const p = parseSeasonEpisode(title);
+  return p.isFullSeason && p.season === seasonNumber;
 }

--- a/backend/src/migrations/1780500000000-add-quality-profile-resolution-upgrade-only.ts
+++ b/backend/src/migrations/1780500000000-add-quality-profile-resolution-upgrade-only.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddQualityProfileResolutionUpgradeOnly1780500000000
+  implements MigrationInterface
+{
+  name = 'AddQualityProfileResolutionUpgradeOnly1780500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "quality_profiles"
+        ADD COLUMN IF NOT EXISTS "resolutionUpgradeOnly" boolean NOT NULL DEFAULT false
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "quality_profiles"
+        DROP COLUMN IF EXISTS "resolutionUpgradeOnly"
+    `);
+  }
+}

--- a/backend/src/modules/media/auto-grab-pipeline.service.ts
+++ b/backend/src/modules/media/auto-grab-pipeline.service.ts
@@ -7,7 +7,7 @@ import { DownloadHistory } from './entities/download-history.entity';
 import { buildGrabHistoryRow } from './grab-history.util';
 import { Indexer } from '../indexers/entities/indexer.entity';
 import { TorznabRelease } from '../indexers/torznab.service';
-import { parseSeasonEpisode } from '../../common/release-parsing';
+import { parseReleaseQuality, parseSeasonEpisode } from '../../common/release-parsing';
 import { DownloadClient } from '../download-clients/entities/download-client.entity';
 import { QbittorrentService } from '../download-clients/qbittorrent.service';
 import { CustomFormatsService } from '../profiles/custom-formats.service';
@@ -20,6 +20,7 @@ import {
   ScoredRelease,
   SizeLimits,
   buildIndexerMinSeeders,
+  maxResolutionFromQualityStrings,
   rankFromQualityString,
   resolveSearchTitles,
   scoreAndSortReleases,
@@ -265,12 +266,27 @@ export class AutoGrabPipelineService {
         isBlocked: (title) => this.blocklist.isBlocked(title),
       },
     );
-    const pick = sorted.find(
-      (r) =>
-        r.rejections.length === 0 &&
-        r.rank > decision.minRankExclusive &&
-        r.rank <= decision.maxRankInclusive,
-    );
+    const resolutionUpgradeOnly =
+      decision.mode === 'upgrade' &&
+      !!args.media.qualityProfile?.resolutionUpgradeOnly;
+    const currentResolution = resolutionUpgradeOnly
+      ? maxResolutionFromQualityStrings(args.files)
+      : 0;
+    const pick = sorted.find((r) => {
+      if (r.rejections.length > 0) return false;
+      if (
+        r.rank <= decision.minRankExclusive ||
+        r.rank > decision.maxRankInclusive
+      ) {
+        return false;
+      }
+      if (resolutionUpgradeOnly) {
+        const releaseResolution = parseReleaseQuality(r.title).quality
+          .resolution;
+        if (releaseResolution <= currentResolution) return false;
+      }
+      return true;
+    });
     if (!pick) {
       const topRejections = sorted
         .slice(0, 3)

--- a/backend/src/modules/media/episode-download.service.ts
+++ b/backend/src/modules/media/episode-download.service.ts
@@ -23,6 +23,7 @@ import {
   parseReleaseLanguage,
   parseReleaseQuality,
   parseSeasonEpisode,
+  matchesSeasonPack,
   resolveUnknownLanguage,
 } from '../../common/release-parsing';
 import { maxAllowedRank } from '../../common/constants/app-qualities';
@@ -683,7 +684,7 @@ export class EpisodeDownloadService {
     const packRows = await Promise.all(
       packBatches
         .flat()
-        .filter((r) => parseSeasonEpisode(r.title).isFullSeason)
+        .filter((r) => matchesSeasonPack(r.title, season.seasonNumber))
         .map((r) =>
           this.buildReleaseRow(
             r,

--- a/backend/src/modules/media/movie-download.service.ts
+++ b/backend/src/modules/media/movie-download.service.ts
@@ -34,6 +34,7 @@ import {
   buildIndexerMinSeeders,
   buildAllowedQualityIds,
   allowedAudioLanguageIds,
+  maxResolutionFromQualityStrings,
   resolveSearchTitles,
   scoreAndSortReleases,
   sortReleasesByRelevance,
@@ -428,8 +429,19 @@ export class MovieDownloadService {
     );
 
     // Only keep releases that are strictly better than current AND within cutoff
+    const currentResolution = profile.resolutionUpgradeOnly
+      ? maxResolutionFromQualityStrings(files)
+      : 0;
     return sortReleasesByRelevance(
-      rows.filter((r) => r.rank > currentRank && r.rank <= cutoffRank),
+      rows.filter((r) => {
+        if (r.rank <= currentRank || r.rank > cutoffRank) return false;
+        if (profile.resolutionUpgradeOnly) {
+          const releaseResolution = parseReleaseQuality(r.title).quality
+            .resolution;
+          if (releaseResolution <= currentResolution) return false;
+        }
+        return true;
+      }),
     );
   }
 
@@ -520,6 +532,14 @@ export class MovieDownloadService {
       throw new BadRequestException(
         `This release (${parsed.quality.name}) is not better than the current quality`,
       );
+    }
+    if (profile.resolutionUpgradeOnly) {
+      const currentResolution = maxResolutionFromQualityStrings(files);
+      if (parsed.quality.resolution <= currentResolution) {
+        throw new BadRequestException(
+          `This release (${parsed.quality.resolution}p) does not increase resolution above the current file (${currentResolution}p)`,
+        );
+      }
     }
     if (parsed.quality.rank > cutoffRank) {
       throw new BadRequestException(

--- a/backend/src/modules/media/release-rejection.helper.spec.ts
+++ b/backend/src/modules/media/release-rejection.helper.spec.ts
@@ -77,27 +77,27 @@ describe('sortReleasesByRelevance', () => {
 });
 
 describe('resolveSearchTitles + titleMatchesExpectation', () => {
-  const rickFr = {
-    title: 'Rick et Morty',
-    originalTitle: 'Rick and Morty',
+  const localizedShow = {
+    title: 'Série localisée',
+    originalTitle: 'Original Show Title',
     alternativeTitles: null,
   };
 
   it('matches an English scene release when the library title is localized', () => {
-    const { expectedTitles } = resolveSearchTitles(rickFr);
+    const { expectedTitles } = resolveSearchTitles(localizedShow);
     expect(
       titleMatchesExpectation(
-        'Rick.and.Morty.S09E04.1080p.WEB-DL.x264-GROUP',
+        'Original.Show.Title.S09E04.1080p.WEB-DL.x264-GROUP',
         expectedTitles,
       ),
     ).toBe(true);
   });
 
   it('does not match an unrelated show', () => {
-    const { expectedTitles } = resolveSearchTitles(rickFr);
+    const { expectedTitles } = resolveSearchTitles(localizedShow);
     expect(
       titleMatchesExpectation(
-        'Abbott.Elementary.S05E10.1080p.x264-GROUP',
+        'Other.Series.S05E10.1080p.x264-GROUP',
         expectedTitles,
       ),
     ).toBe(false);

--- a/backend/src/modules/media/release-rejection.helper.ts
+++ b/backend/src/modules/media/release-rejection.helper.ts
@@ -23,6 +23,18 @@ export function rankFromQualityString(
   return parseReleaseQuality(quality).quality.rank;
 }
 
+/** Highest resolution (px height) among on-disk file quality strings. */
+export function maxResolutionFromQualityStrings(
+  files: { quality?: string | null }[],
+): number {
+  let max = 0;
+  for (const f of files) {
+    const res = parseReleaseQuality(f.quality ?? '').quality.resolution;
+    if (res > max) max = res;
+  }
+  return max;
+}
+
 /**
  * Convert a language profile's audio language items into a set of app-language IDs
  * for rejection checking. Empty set = no language restriction.

--- a/backend/src/modules/profiles/dto/create-quality-profile.dto.ts
+++ b/backend/src/modules/profiles/dto/create-quality-profile.dto.ts
@@ -43,6 +43,10 @@ export class CreateQualityProfileDto {
   @IsOptional()
   upgradeAllowed?: boolean;
 
+  @IsBoolean()
+  @IsOptional()
+  resolutionUpgradeOnly?: boolean;
+
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => QualityItemDto)

--- a/backend/src/modules/profiles/entities/quality-profile.entity.ts
+++ b/backend/src/modules/profiles/entities/quality-profile.entity.ts
@@ -14,6 +14,12 @@ export class QualityProfile extends BaseEntity {
 
   @Column({ default: false })
   upgradeAllowed: boolean;
+
+  /** When true, auto/manual upgrades only grab releases whose resolution
+   *  exceeds the best on-disk file — skips same-resolution tier hops
+   *  (e.g. WEBDL-1080p → Bluray-1080p). */
+  @Column({ default: false })
+  resolutionUpgradeOnly: boolean;
 }
 
 export interface QualityProfileItem {

--- a/backend/src/modules/profiles/profiles.service.ts
+++ b/backend/src/modules/profiles/profiles.service.ts
@@ -132,6 +132,7 @@ export class ProfilesService {
       name: dto.name,
       cutoff: dto.cutoff,
       upgradeAllowed: dto.upgradeAllowed ?? false,
+      resolutionUpgradeOnly: dto.resolutionUpgradeOnly ?? false,
       items: dto.items.map((i) => ({
         quality: {
           id: i.qualityId,
@@ -166,6 +167,8 @@ export class ProfilesService {
     profile.name = dto.name;
     profile.cutoff = dto.cutoff;
     profile.upgradeAllowed = dto.upgradeAllowed ?? profile.upgradeAllowed;
+    profile.resolutionUpgradeOnly =
+      dto.resolutionUpgradeOnly ?? profile.resolutionUpgradeOnly;
     profile.items = dto.items.map((i) => ({
       quality: {
         id: i.qualityId,

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -41,7 +41,7 @@ import {
   resolveSearchTitles,
   titleMatchesExpectation,
 } from '../media/release-rejection.helper';
-import { parseSeasonEpisode } from '../../common/release-parsing';
+import { parseSeasonEpisode, matchesSeasonPack } from '../../common/release-parsing';
 
 // Note: scoring/profile/blocklist/quality-definition wiring lives in
 // AutoGrabPipelineService. This file only orchestrates the high-level
@@ -767,7 +767,7 @@ export class SchedulerService implements OnModuleInit {
       // never a stray single episode that slipped into the result set.
       const packs = packBatches
         .flatMap((r) => (r.status === 'fulfilled' ? r.value : []))
-        .filter((r) => parseSeasonEpisode(r.title).isFullSeason);
+        .filter((r) => matchesSeasonPack(r.title, season.seasonNumber));
       if (!packs.length) continue;
 
       // Cutoff gate for the pack. The per-episode path hands each file's

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1296,6 +1296,7 @@
       "field_name": "Nom du profil",
       "field_cutoff": "Qualité seuil (cutoff)",
       "field_upgrade": "Autoriser les mises à jour de qualité",
+      "field_resolution_upgrade_only": "Mise à jour uniquement si la résolution augmente",
       "qualities_group": "Qualités autorisées pour la recherche",
       "save": "Enregistrer",
       "cancel": "Annuler",

--- a/client/src/app/core/services/api/profiles.service.ts
+++ b/client/src/app/core/services/api/profiles.service.ts
@@ -7,6 +7,7 @@ export interface QualityProfile {
   name: string;
   cutoff: number;
   upgradeAllowed: boolean;
+  resolutionUpgradeOnly: boolean;
   items: {
     quality: { id: number; name: string; resolution: number; source: string };
     allowed: boolean;
@@ -19,6 +20,7 @@ export interface CreateQualityProfilePayload {
   name: string;
   cutoff: number;
   upgradeAllowed?: boolean;
+  resolutionUpgradeOnly?: boolean;
   items: {
     qualityId: number;
     qualityName: string;

--- a/client/src/app/features/settings/quality-profiles/quality-profiles.html
+++ b/client/src/app/features/settings/quality-profiles/quality-profiles.html
@@ -97,7 +97,7 @@
             }
           </select>
         </label>
-        <label class="label cursor-pointer justify-start gap-3">
+        <label class="label cursor-pointer justify-start items-center gap-3">
           <input
             type="checkbox"
             class="toggle toggle-sm toggle-primary"
@@ -106,6 +106,17 @@
           />
           <span class="label-text">{{ 'settings.quality_profiles.field_upgrade' | translate }}</span>
         </label>
+        @if (formUpgrade()) {
+          <label class="label cursor-pointer justify-start items-center gap-3">
+            <input
+              type="checkbox"
+              class="toggle toggle-sm toggle-primary"
+              [ngModel]="formResolutionUpgradeOnly()"
+              (ngModelChange)="formResolutionUpgradeOnly.set($event)"
+            />
+            <span class="label-text">{{ 'settings.quality_profiles.field_resolution_upgrade_only' | translate }}</span>
+          </label>
+        }
         <div>
           <p class="text-sm font-medium mb-2">{{ 'settings.quality_profiles.qualities_group' | translate }}</p>
           <div class="rounded-lg border border-base-200 divide-y divide-base-200 max-h-[28rem] overflow-y-auto">

--- a/client/src/app/features/settings/quality-profiles/quality-profiles.ts
+++ b/client/src/app/features/settings/quality-profiles/quality-profiles.ts
@@ -45,6 +45,7 @@ export class QualityProfilesComponent implements OnInit {
   readonly formName = signal('');
   readonly formCutoff = signal(16);
   readonly formUpgrade = signal(true);
+  readonly formResolutionUpgradeOnly = signal(false);
   readonly allowedIds = signal<Set<number>>(new Set());
 
   ngOnInit() {
@@ -84,6 +85,7 @@ export class QualityProfilesComponent implements OnInit {
     this.formName.set('');
     this.formCutoff.set(16);
     this.formUpgrade.set(true);
+    this.formResolutionUpgradeOnly.set(false);
     this.allowedIds.set(new Set());
     this.editorDialog()?.nativeElement.showModal();
   }
@@ -93,6 +95,7 @@ export class QualityProfilesComponent implements OnInit {
     this.formName.set(p.name);
     this.formCutoff.set(p.cutoff);
     this.formUpgrade.set(p.upgradeAllowed);
+    this.formResolutionUpgradeOnly.set(p.resolutionUpgradeOnly ?? false);
     const allowed = new Set(
       p.items.filter((i) => i.allowed).map((i) => i.quality.id),
     );
@@ -122,6 +125,7 @@ export class QualityProfilesComponent implements OnInit {
       name: this.formName().trim(),
       cutoff: this.formCutoff(),
       upgradeAllowed: this.formUpgrade(),
+      resolutionUpgradeOnly: this.formResolutionUpgradeOnly(),
       items: defs.map((q, index) => ({
         qualityId: q.id,
         qualityName: q.name,


### PR DESCRIPTION
## Summary
- Filter season-pack grabs with `matchesSeasonPack(title, seasonNumber)` so unrelated S01 packs are not sent while hunting another season
- Harden legacy `1x02` parsing so `x265` codec tags are never read as season×episode
- Add **resolutionUpgradeOnly** on quality profiles (opt-in) to skip same-resolution tier hops during auto/manual upgrades
- Align resolution-upgrade toggle in quality profile editor

## Test plan
- [x] `npx jest season-episode.parser.spec.ts release-rejection.helper.spec.ts --runInBand`
- [ ] SearchMissing must not grab a wrong-season pack
- [ ] Enable resolution-only upgrades on UHD profile — no 1080p→1080p YIFY-style grabs

Made with [Cursor](https://cursor.com)