### PR TITLE
fix(auto-grab): reject wrong-movie hits in search missing

### DIFF
--- a/backend/src/modules/media/release-rejection.helper.spec.ts
+++ b/backend/src/modules/media/release-rejection.helper.spec.ts
@@ -1,4 +1,5 @@
 import {
+  releaseMatchesMedia,
   resolveSearchTitles,
   sortReleasesByRelevance,
   titleMatchesExpectation,
@@ -73,6 +74,35 @@ describe('sortReleasesByRelevance', () => {
     });
     const clean = row({ id: 'clean', rank: 100, seeders: 1 });
     expect(order([rejected, clean])).toEqual(['clean', 'rejected']);
+  });
+});
+
+describe('releaseMatchesMedia', () => {
+  const movie = {
+    title: 'Titre localisé',
+    originalTitle: 'Original Movie Title',
+    year: 2004,
+    alternativeTitles: null,
+  };
+
+  it('rejects an unrelated same-year theatrical', () => {
+    expect(
+      releaseMatchesMedia(
+        'Other.Movie.2004.2160p.UHD.BluRay.x265-GROUP',
+        movie,
+        { requireYearInTitle: true },
+      ),
+    ).toBe(false);
+  });
+
+  it('accepts a release named after the original title', () => {
+    expect(
+      releaseMatchesMedia(
+        'Original.Movie.Title.2004.1080p.WEB-DL.x264-GROUP',
+        movie,
+        { requireYearInTitle: true },
+      ),
+    ).toBe(true);
   });
 });
 

--- a/backend/src/modules/media/release-rejection.helper.ts
+++ b/backend/src/modules/media/release-rejection.helper.ts
@@ -104,6 +104,33 @@ export function resolveSearchTitles(
   return { searchTitle, expectedTitles };
 }
 
+/** True when a release title plausibly refers to `media` under any of its
+ *  known names. Movies may pass `requireYearInTitle` so a same-year
+ *  unrelated hit (e.g. two 2004 theatricals) is rejected. */
+export function releaseMatchesMedia(
+  releaseTitle: string,
+  media: {
+    title: string;
+    originalTitle?: string | null;
+    alternativeTitles?: string[] | null;
+    year?: number | null;
+  },
+  options?: { requireYearInTitle?: boolean },
+): boolean {
+  if (
+    !titleMatchesExpectation(
+      releaseTitle,
+      resolveSearchTitles(media).expectedTitles,
+    )
+  ) {
+    return false;
+  }
+  if (options?.requireYearInTitle && media.year) {
+    return releaseTitle.includes(String(media.year));
+  }
+  return true;
+}
+
 /**
  * Returns the codec-adjusted absolute deviation of a release's MB/h
  * rate from the quality's preferred MB/h, normalised by preferred.

--- a/backend/src/modules/media/torrent-auto-matcher.service.ts
+++ b/backend/src/modules/media/torrent-auto-matcher.service.ts
@@ -158,14 +158,14 @@ export class TorrentAutoMatcher {
       .where('m.type = :type', { type })
       .andWhere(
         `(
-          regexp_replace(LOWER(m.title), '[^a-z0-9]+', '', 'g') LIKE :key
-          OR regexp_replace(LOWER(COALESCE(m."originalTitle", '')), '[^a-z0-9]+', '', 'g') LIKE :key
+          regexp_replace(LOWER(m.title), '[^a-z0-9]+', '', 'g') = :key
+          OR regexp_replace(LOWER(COALESCE(m."originalTitle", '')), '[^a-z0-9]+', '', 'g') = :key
           OR EXISTS (
             SELECT 1 FROM jsonb_array_elements_text(m."alternativeTitles") alt
-            WHERE regexp_replace(LOWER(alt), '[^a-z0-9]+', '', 'g') LIKE :key
+            WHERE regexp_replace(LOWER(alt), '[^a-z0-9]+', '', 'g') = :key
           )
         )`,
-        { key: `%${parsed.searchKey}%`, type },
+        { key: parsed.searchKey, type },
       )
       .take(50)
       .getMany();

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -38,8 +38,8 @@ import {
 import { MarkersService } from '../markers/markers.service';
 import {
   rankFromQualityString,
+  releaseMatchesMedia,
   resolveSearchTitles,
-  titleMatchesExpectation,
 } from '../media/release-rejection.helper';
 import { parseSeasonEpisode, matchesSeasonPack } from '../../common/release-parsing';
 
@@ -490,9 +490,11 @@ export class SchedulerService implements OnModuleInit {
           }),
         ),
       );
-      const releases = batches.flatMap((r) =>
-        r.status === 'fulfilled' ? r.value : [],
-      );
+      const releases = batches
+        .flatMap((r) => (r.status === 'fulfilled' ? r.value : []))
+        .filter((r) =>
+          releaseMatchesMedia(r.title, media, { requireYearInTitle: true }),
+        );
 
       await this.autoGrab.tryAutoGrab({
         media,
@@ -1371,18 +1373,11 @@ export class SchedulerService implements OnModuleInit {
     candidates: Media[],
     yearGuard: boolean,
   ): Media | undefined {
-    return candidates.find((m) => {
-      if (
-        !titleMatchesExpectation(
-          release.title,
-          resolveSearchTitles(m).expectedTitles,
-        )
-      ) {
-        return false;
-      }
-      if (!yearGuard || !m.year) return true;
-      return release.title.includes(String(m.year));
-    });
+    return candidates.find((m) =>
+      releaseMatchesMedia(release.title, m, {
+        requireYearInTitle: yearGuard,
+      }),
+    );
   }
 
   private matchMovieRelease(


### PR DESCRIPTION
## Summary
- Pre-filter movie SearchMissing results with `releaseMatchesMedia` (title tokens + year in release name)
- Reuse the same helper for RSS movie matching
- Tighten orphan torrent SQL lookup to exact normalized title equality (no `LIKE %key%` substring false positives)

## Why
#520 fixed season-pack season numbers but not cross-movie grabs: an indexer returning another 2004 theatrical (e.g. during an upgrade search) could still be sent to qBittorrent for the wrong media if matching was too loose.

## Test plan
- [x] `npx jest release-rejection.helper.spec.ts --runInBand`
- [ ] SearchMissing upgrade on a 2004 movie must not grab unrelated same-year releases

Made with [Cursor](https://cursor.com)