### PR TITLE
fix(scheduler): skip at-cutoff media before indexer search

### DIFF
--- a/backend/src/modules/media/auto-grab-pipeline.service.spec.ts
+++ b/backend/src/modules/media/auto-grab-pipeline.service.spec.ts
@@ -1,0 +1,45 @@
+import { AutoGrabPipelineService } from './auto-grab-pipeline.service';
+import { Media } from './entities/media.entity';
+
+describe('AutoGrabPipelineService.shouldSearchMissing', () => {
+  const service = Object.create(
+    AutoGrabPipelineService.prototype,
+  ) as AutoGrabPipelineService;
+
+  const profile = {
+    cutoff: 16, // WEBDL-1080p rank 62
+    upgradeAllowed: true,
+    items: [],
+  };
+
+  const media = {
+    qualityProfile: profile,
+    languageProfile: { audioLanguages: [] },
+  } as unknown as Media;
+
+  it('returns true when there is no file on disk', () => {
+    expect(service.shouldSearchMissing(media, [])).toBe(true);
+  });
+
+  it('returns false when the file is already at cutoff', () => {
+    expect(
+      service.shouldSearchMissing(media, [{ quality: 'WEBDL-1080p' }]),
+    ).toBe(false);
+  });
+
+  it('returns true when upgrade is allowed and the file is below cutoff', () => {
+    expect(
+      service.shouldSearchMissing(media, [{ quality: 'HDTV-720p' }]),
+    ).toBe(true);
+  });
+
+  it('returns false when upgrades are disabled and a file exists', () => {
+    const noUpgrade = {
+      ...media,
+      qualityProfile: { ...profile, upgradeAllowed: false },
+    } as Media;
+    expect(
+      service.shouldSearchMissing(noUpgrade, [{ quality: 'HDTV-720p' }]),
+    ).toBe(false);
+  });
+});

--- a/backend/src/modules/media/auto-grab-pipeline.service.ts
+++ b/backend/src/modules/media/auto-grab-pipeline.service.ts
@@ -165,6 +165,16 @@ export class AutoGrabPipelineService {
     };
   }
 
+  /** Whether SearchMissing should query indexers for this media/files pair.
+   *  False when already at cutoff, upgrades disabled, or unprofiled. */
+  shouldSearchMissing(
+    media: Media,
+    files: { quality?: string | null }[],
+  ): boolean {
+    const decision = this.classifyForSearch(media, files);
+    return decision.mode === 'missing' || decision.mode === 'upgrade';
+  }
+
   /**
    * High-level auto-grab attempt. Returns `true` when a release was sent to
    * qBittorrent + recorded in `DownloadHistory`, `false` when the media is

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -460,7 +460,15 @@ export class SchedulerService implements OnModuleInit {
     if (mediaIds?.length) {
       qb.andWhere('m.id IN (:...mediaIds)', { mediaIds });
     }
-    const candidates = await qb.getMany();
+    const allCandidates = await qb.getMany();
+    const candidates = allCandidates.filter((m) =>
+      this.autoGrab.shouldSearchMissing(m, m.files ?? []),
+    );
+    if (allCandidates.length !== candidates.length) {
+      this.log.log(
+        `SearchMissing[movies]: ${candidates.length}/${allCandidates.length} need a search (${allCandidates.length - candidates.length} at cutoff, unprofiled, or upgrades disabled)`,
+      );
+    }
 
     this.logTargetedCandidateCount('movies', mediaIds, candidates.length);
     if (!candidates.length) return;
@@ -552,7 +560,7 @@ export class SchedulerService implements OnModuleInit {
     if (mediaIds?.length) {
       qb.andWhere('media.id IN (:...mediaIds)', { mediaIds });
     }
-    const episodes = await qb
+    let episodes = await qb
       .select([
         'ep.id',
         'ep.episodeNumber',
@@ -578,12 +586,11 @@ export class SchedulerService implements OnModuleInit {
       .addSelect('lp')
       .getMany();
 
-    this.logTargetedCandidateCount('episodes', mediaIds, episodes.length);
-    if (!episodes.length) return;
-
     // Batch-load the linked MediaFile quality for upgrade-candidate episodes
-    // so the cutoff comparison runs in JS without an N+1.
-    const upgradeEpIds = episodes.filter((e) => e.hasFile).map((e) => e.id);
+    // so the cutoff comparison runs without an N+1.
+    const upgradeEpIds = episodes
+      .filter((e) => e.hasFile)
+      .map((e) => e.id);
     const fileQualityByEpId = new Map<number, string>();
     if (upgradeEpIds.length) {
       const fileRows = await this.mediaFileRepo
@@ -604,6 +611,25 @@ export class SchedulerService implements OnModuleInit {
           fileQualityByEpId.set(row.episodeId, row.quality);
       }
     }
+
+    const episodeFiles = (ep: Episode): { quality?: string | null }[] =>
+      ep.hasFile ? [{ quality: fileQualityByEpId.get(ep.id) ?? null }] : [];
+
+    const allEpisodes = episodes;
+    const filteredEpisodes = allEpisodes.filter((ep) => {
+      const media = (ep as unknown as { season: Season }).season
+        .media as Media;
+      return this.autoGrab.shouldSearchMissing(media, episodeFiles(ep));
+    });
+    if (allEpisodes.length !== filteredEpisodes.length) {
+      this.log.log(
+        `SearchMissing[episodes]: ${filteredEpisodes.length}/${allEpisodes.length} need a search (${allEpisodes.length - filteredEpisodes.length} at cutoff, unprofiled, or upgrades disabled)`,
+      );
+    }
+    episodes = filteredEpisodes;
+
+    this.logTargetedCandidateCount('episodes', mediaIds, episodes.length);
+    if (!episodes.length) return;
 
     // Season-pack-first: a season missing more than one episode is better
     // served by one (usually far better seeded) pack than by scattered


### PR DESCRIPTION
## Summary
- Add `shouldSearchMissing` on the auto-grab pipeline (missing or upgrade only)
- Filter SearchMissing movie and episode candidates before any Torznab call
- Log a single recap line when items are dropped (at cutoff / unprofiled / upgrades off)

## Why
Upgrade-enabled series with files already at cutoff (e.g. The Office WEBDL-1080p) triggered an indexer round-trip per episode (~2s each) only to log `at/above cutoff (mode=skip)`.

## Test plan
- [x] `npx jest auto-grab-pipeline.service.spec.ts --runInBand`
- [ ] SearchMissing on a large library should finish much faster when most episodes are at cutoff
- [ ] Episodes below cutoff or missing on disk are still searched

Made with [Cursor](https://cursor.com)