### PR TITLE
fix(desktop): force mpv unpause on load so reopened player autoplays

### DIFF
--- a/desktop/src/main/mpv/mpv-player.ts
+++ b/desktop/src/main/mpv/mpv-player.ts
@@ -283,6 +283,10 @@ export class MpvPlayer extends EventEmitter {
     const cmd: unknown[] = ['loadfile', opts.url, 'replace', 0];
     if (opts.startTime && opts.startTime > 0) cmd.push(`start=${opts.startTime}`);
     await this.command(cmd);
+    // The persistent mpv keeps its pause state across loads; force playback so a
+    // freshly opened file always autoplays. The JS side treats this engine like
+    // the mobile native player (playWhenReady) and never calls play() itself.
+    await this.set('pause', false);
     for (const s of opts.subtitles ?? []) {
       await this.command(['sub-add', s.url, 'auto', s.label ?? '', s.language ?? '']);
     }


### PR DESCRIPTION
## Problem

On the **Windows** desktop client only (not Linux): open the player (autoplay works), pause, close the player, then reopen it. The controls show the **play** icon (UI thinks it is playing) but playback is actually **paused** — you have to click play/pause **twice** to resume.

## Root cause

The persistent mpv subprocess used by the Windows/macOS JSON-IPC backend (`MpvPlayer`) keeps its pause state across loads. After closing while paused, reopening reloads the file but mpv stays `pause=true`. No pause-property event fires (the state did not change), so the `DesktopEngine` `firstFrame` workaround asserts the playing state — controls show play while playback is paused.

Linux is unaffected because its compositor addon (`native/compositor/addon.cc`) already forces `pause=no` after every `loadfile`. That backend is a different code path, not used on Windows/macOS.

## Fix

Mirror the Linux behaviour: clear `pause` right after the `loadfile` command in `MpvPlayer.load()`, guaranteeing a freshly opened file autoplays and the real transport state matches the UI.

## Testing

- Linux dev box cannot exercise this backend (Linux uses the C++ addon path). Needs validation on a Windows build.
- Triggered the Desktop release workflow (windows-latest → .exe) on this branch to produce an installer for on-device verification.