### PR TITLE
fix(media): delete on-disk files when removing media from the library

### DIFF
--- a/backend/src/modules/media/media-service/media-mutation.service.spec.ts
+++ b/backend/src/modules/media/media-service/media-mutation.service.spec.ts
@@ -189,42 +189,50 @@ describe('MediaMutationService remove disk cleanup', () => {
 
   afterEach(() => rmSpy.mockRestore());
 
-  it('deletes the media folder on disk before removing the DB record', async () => {
+  it('removes the DB record and returns the folder to delete', async () => {
     query.findOne.mockResolvedValue(mediaIn('/library/movies', 'Some Movie (2020)'));
 
-    await service.remove(1);
+    const result = await service.remove(1);
 
-    expect(rmSpy).toHaveBeenCalledWith(
-      path.resolve('/library/movies/Some Movie (2020)'),
-      { recursive: true, force: true },
-    );
+    expect(result.diskPath).toBe(path.resolve('/library/movies/Some Movie (2020)'));
     expect(mediaRepo.remove).toHaveBeenCalled();
+    // Disk deletion is deferred to the caller, not done inside remove().
+    expect(rmSpy).not.toHaveBeenCalled();
   });
 
-  it('skips disk deletion when the media has no folder path', async () => {
+  it('returns no folder when the media has no folder path', async () => {
     query.findOne.mockResolvedValue(mediaIn('/library/movies', undefined));
 
-    await service.remove(1);
+    const result = await service.remove(1);
 
-    expect(rmSpy).not.toHaveBeenCalled();
+    expect(result.diskPath).toBeNull();
     expect(mediaRepo.remove).toHaveBeenCalled();
   });
 
-  it('refuses to delete a path that escapes the library root', async () => {
+  it('returns no folder when the path escapes the library root', async () => {
     query.findOne.mockResolvedValue(mediaIn('/library/movies', '../../etc'));
 
-    await service.remove(1);
+    const result = await service.remove(1);
 
-    expect(rmSpy).not.toHaveBeenCalled();
+    expect(result.diskPath).toBeNull();
     expect(mediaRepo.remove).toHaveBeenCalled();
   });
 
-  it('refuses to delete the library root itself', async () => {
+  it('returns no folder when the path resolves to the library root', async () => {
     query.findOne.mockResolvedValue(mediaIn('/library/movies', '.'));
 
-    await service.remove(1);
+    const result = await service.remove(1);
 
-    expect(rmSpy).not.toHaveBeenCalled();
+    expect(result.diskPath).toBeNull();
     expect(mediaRepo.remove).toHaveBeenCalled();
+  });
+
+  it('deleteMediaFolder removes the folder recursively', async () => {
+    await service.deleteMediaFolder('/library/movies/Some Movie (2020)');
+
+    expect(rmSpy).toHaveBeenCalledWith('/library/movies/Some Movie (2020)', {
+      recursive: true,
+      force: true,
+    });
   });
 });

--- a/backend/src/modules/media/media-service/media-mutation.service.spec.ts
+++ b/backend/src/modules/media/media-service/media-mutation.service.spec.ts
@@ -1,3 +1,5 @@
+import * as fs from 'fs';
+import * as path from 'path';
 import { MediaMutationService } from './media-mutation.service';
 import { Season } from '../entities/season.entity';
 
@@ -139,5 +141,90 @@ describe('MediaMutationService monitoring cascade', () => {
     await service.updateSeason(3, { preferredProvider: 'tvdb' });
 
     expect(episodeRecorders).toHaveLength(0);
+  });
+});
+
+describe('MediaMutationService remove disk cleanup', () => {
+  let mediaRepo: { remove: jest.Mock };
+  let mediaServers: { dispatch: jest.Mock };
+  let query: { findOne: jest.Mock };
+  let requestLifecycle: { onMediaRemoved: jest.Mock };
+  let rmSpy: jest.SpyInstance;
+  let service: MediaMutationService;
+
+  /** Build a media whose virtual `path` getter resolves to root/folderName. */
+  function mediaIn(root: string | undefined, folderName: string | undefined) {
+    return {
+      id: 1,
+      title: 'placeholder',
+      library: root ? { path: root } : undefined,
+      get path() {
+        return this.library?.path && folderName
+          ? path.join(this.library.path, folderName)
+          : null;
+      },
+    };
+  }
+
+  beforeEach(() => {
+    mediaRepo = { remove: jest.fn() };
+    mediaServers = { dispatch: jest.fn() };
+    query = { findOne: jest.fn() };
+    requestLifecycle = { onMediaRemoved: jest.fn() };
+    rmSpy = jest.spyOn(fs.promises, 'rm').mockResolvedValue(undefined);
+
+    service = new MediaMutationService(
+      mediaRepo as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      mediaServers as never,
+      query as never,
+      {} as never,
+      requestLifecycle as never,
+    );
+  });
+
+  afterEach(() => rmSpy.mockRestore());
+
+  it('deletes the media folder on disk before removing the DB record', async () => {
+    query.findOne.mockResolvedValue(mediaIn('/library/movies', 'Some Movie (2020)'));
+
+    await service.remove(1);
+
+    expect(rmSpy).toHaveBeenCalledWith(
+      path.resolve('/library/movies/Some Movie (2020)'),
+      { recursive: true, force: true },
+    );
+    expect(mediaRepo.remove).toHaveBeenCalled();
+  });
+
+  it('skips disk deletion when the media has no folder path', async () => {
+    query.findOne.mockResolvedValue(mediaIn('/library/movies', undefined));
+
+    await service.remove(1);
+
+    expect(rmSpy).not.toHaveBeenCalled();
+    expect(mediaRepo.remove).toHaveBeenCalled();
+  });
+
+  it('refuses to delete a path that escapes the library root', async () => {
+    query.findOne.mockResolvedValue(mediaIn('/library/movies', '../../etc'));
+
+    await service.remove(1);
+
+    expect(rmSpy).not.toHaveBeenCalled();
+    expect(mediaRepo.remove).toHaveBeenCalled();
+  });
+
+  it('refuses to delete the library root itself', async () => {
+    query.findOne.mockResolvedValue(mediaIn('/library/movies', '.'));
+
+    await service.remove(1);
+
+    expect(rmSpy).not.toHaveBeenCalled();
+    expect(mediaRepo.remove).toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/media/media-service/media-mutation.service.ts
+++ b/backend/src/modules/media/media-service/media-mutation.service.ts
@@ -8,6 +8,8 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { promises as fsp } from 'fs';
+import * as nodePath from 'path';
 import { Media } from '../entities/media.entity';
 import { MediaFile } from '../entities/media-file.entity';
 import { Season } from '../entities/season.entity';
@@ -198,11 +200,39 @@ export class MediaMutationService {
     const title = media.title;
     const mediaPath = media.path;
     await this.requestLifecycle.onMediaRemoved(media);
+    await this.removeMediaFolderFromDisk(media);
     await this.mediaRepo.remove(media);
     void this.mediaServers.dispatch('media.deleted', {
       title,
       path: mediaPath,
     });
+  }
+
+  /**
+   * Delete the media's own folder on disk so removing it from the library
+   * leaves no orphan video/subtitle/artwork files behind. Guarded to stay
+   * strictly inside the library root: it never touches the root itself and
+   * rejects a folderName that would escape it (e.g. via '..').
+   */
+  private async removeMediaFolderFromDisk(media: Media): Promise<void> {
+    const root = media.library?.path;
+    const dir = media.path;
+    if (!root || !dir) return;
+
+    const resolvedRoot = nodePath.resolve(root);
+    const resolvedDir = nodePath.resolve(dir);
+    if (
+      resolvedDir === resolvedRoot ||
+      !resolvedDir.startsWith(resolvedRoot + nodePath.sep)
+    ) {
+      this.log.warn(
+        `Refusing to delete media folder outside library root: ${resolvedDir}`,
+      );
+      return;
+    }
+
+    await fsp.rm(resolvedDir, { recursive: true, force: true });
+    this.log.log(`Deleted media folder on disk: ${resolvedDir}`);
   }
 
   async updateSeason(

--- a/backend/src/modules/media/media-service/media-mutation.service.ts
+++ b/backend/src/modules/media/media-service/media-mutation.service.ts
@@ -195,29 +195,35 @@ export class MediaMutationService {
     return { updated: result.affected ?? 0 };
   }
 
-  async remove(id: number): Promise<void> {
+  /**
+   * Remove the media's DB records and return the on-disk folder that should be
+   * deleted afterwards (or null when there is nothing safe to delete). Disk
+   * deletion is left to the caller so it can run after the HTTP response and
+   * report a failure back to the initiating client without blocking the UI.
+   */
+  async remove(id: number): Promise<{ title: string; diskPath: string | null }> {
     const media = await this.query.findOne(id);
     const title = media.title;
     const mediaPath = media.path;
+    const diskPath = this.resolveSafeMediaDir(media);
     await this.requestLifecycle.onMediaRemoved(media);
-    await this.removeMediaFolderFromDisk(media);
     await this.mediaRepo.remove(media);
     void this.mediaServers.dispatch('media.deleted', {
       title,
       path: mediaPath,
     });
+    return { title, diskPath };
   }
 
   /**
-   * Delete the media's own folder on disk so removing it from the library
-   * leaves no orphan video/subtitle/artwork files behind. Guarded to stay
-   * strictly inside the library root: it never touches the root itself and
-   * rejects a folderName that would escape it (e.g. via '..').
+   * Resolve the media's own folder, guarded to stay strictly inside the library
+   * root: it never returns the root itself and rejects a folderName that would
+   * escape it (e.g. via '..'). Returns null when there is no folder to delete.
    */
-  private async removeMediaFolderFromDisk(media: Media): Promise<void> {
+  private resolveSafeMediaDir(media: Media): string | null {
     const root = media.library?.path;
     const dir = media.path;
-    if (!root || !dir) return;
+    if (!root || !dir) return null;
 
     const resolvedRoot = nodePath.resolve(root);
     const resolvedDir = nodePath.resolve(dir);
@@ -228,11 +234,19 @@ export class MediaMutationService {
       this.log.warn(
         `Refusing to delete media folder outside library root: ${resolvedDir}`,
       );
-      return;
+      return null;
     }
+    return resolvedDir;
+  }
 
-    await fsp.rm(resolvedDir, { recursive: true, force: true });
-    this.log.log(`Deleted media folder on disk: ${resolvedDir}`);
+  /**
+   * Delete a media folder on disk so removing it from the library leaves no
+   * orphan video/subtitle/artwork files behind. Tolerates an already-missing
+   * folder; throws on any other filesystem error so the caller can notify.
+   */
+  async deleteMediaFolder(dir: string): Promise<void> {
+    await fsp.rm(dir, { recursive: true, force: true });
+    this.log.log(`Deleted media folder on disk: ${dir}`);
   }
 
   async updateSeason(

--- a/backend/src/modules/media/media.controller.ts
+++ b/backend/src/modules/media/media.controller.ts
@@ -782,7 +782,23 @@ export class MediaController {
     @CurrentUser() user: User,
   ) {
     await this.assertMediaAccessible(id, user);
-    return this.mediaService.remove(id);
+    const { title, diskPath } = await this.mediaService.remove(id);
+    // Delete the files after the response so the UI isn't blocked by disk I/O.
+    // On failure, notify only the client that triggered the deletion.
+    if (diskPath) {
+      void this.mediaService.deleteMediaFolder(diskPath).catch((err) => {
+        this.logger.error(
+          `Media file deletion failed — id=${id} title="${title}" path="${diskPath}" error=${(err as Error).message}`,
+          err instanceof Error ? err.stack : err,
+        );
+        this.eventsService.emitToUser(user.id, {
+          type: 'media.files.delete_failed',
+          mediaId: id,
+          title,
+        });
+      });
+    }
+    return { ok: true };
   }
 
   @Patch('seasons/:seasonId')

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -160,6 +160,10 @@ export class MediaService {
     return this.mutation.remove(id);
   }
 
+  deleteMediaFolder(dir: string) {
+    return this.mutation.deleteMediaFolder(dir);
+  }
+
   updateSeason(
     seasonId: number,
     patch: { monitored?: boolean; preferredProvider?: 'tmdb' | 'tvdb' | null },

--- a/backend/src/modules/scheduler/events.service.ts
+++ b/backend/src/modules/scheduler/events.service.ts
@@ -80,6 +80,7 @@ export type SseEvent =
       subtitleRemovedDuplicates?: number;
     }
   | { type: 'rescan.failed'; mediaId: number; title: string; error: string }
+  | { type: 'media.files.delete_failed'; mediaId: number; title: string }
   | {
       // Handshake on SSE connect — tells the client which connection id to
       // bind to its live sessions so admin remote-control targets one device.

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -106,7 +106,8 @@
     "rescan_started": "Scan en cours : {{title}}",
     "rescan_completed": "Scan terminé : {{title}} — {{added}} ajouté(s), {{removed}} supprimé(s), {{updated}} mis à jour",
     "rescan_subtitles_cleaned": "{{missing}} entrée(s) sous-titre sans fichier supprimée(s), {{duplicates}} doublon(s) fusionné(s)",
-    "rescan_failed": "Erreur lors du scan : {{title}}"
+    "rescan_failed": "Erreur lors du scan : {{title}}",
+    "media_files_delete_failed": "Les fichiers de « {{title}} » n'ont pas pu être supprimés du disque"
   },
   "permissions": {
     "media.read": "Voir les médias",
@@ -688,7 +689,7 @@
     "delete": "Supprimer",
     "delete_from_library": "Supprimer de la bibliothèque",
     "delete_short": "Suppr.",
-    "confirm_delete": "Supprimer « {{title}} » de la bibliothèque ?",
+    "confirm_delete": "Supprimer « {{title}} » de la bibliothèque ? Les fichiers associés seront également supprimés du disque. Cette action est irréversible.",
     "library_details": "Détails bibliothèque",
     "episode_progress": "Progression des épisodes",
     "ep_no_overview": "Aucun synopsis pour cet épisode.",

--- a/client/src/app/core/services/sse.service.ts
+++ b/client/src/app/core/services/sse.service.ts
@@ -178,6 +178,13 @@ export class SseService implements OnDestroy {
           this.translate.instant('sse.rescan_failed', { title: event['title'] ?? '' }),
         );
         break;
+      case 'media.files.delete_failed':
+        this.toast.error(
+          this.translate.instant('sse.media_files_delete_failed', {
+            title: event['title'] ?? '',
+          }),
+        );
+        break;
     }
   }
 


### PR DESCRIPTION
## Problem

Removing a media from the library only deleted its DB records. The video, subtitle and artwork files were left on disk as orphans — dead files the user had to clean up manually.

## Fix

1. **Delete the on-disk folder.** `MediaMutationService.remove()` resolves the media's own folder (`library.path + folderName`) and the delete endpoint removes it, so nothing is orphaned. Guarded: skips when there is no resolvable folder, and **refuses** the library root itself or any path that escapes it (e.g. a `folderName` containing `..`).

2. **Asynchronous deletion.** The DB records are removed first and the endpoint returns immediately (`{ ok: true }`); the folder removal runs fire-and-forget so the UI isn't blocked by disk I/O on large libraries.

3. **Per-client failure notification.** If the disk deletion fails, only the client that triggered it is notified via a new `media.files.delete_failed` SSE event (`emitToUser`), which the frontend surfaces as an error toast — no broadcast to other clients.

4. **Clearer confirmation.** The delete dialog now states that the associated files are deleted from disk and that the action is irreversible.

## Tests

`media-mutation.service.spec.ts`: `remove()` returns the folder to delete and removes the DB record without deleting inline; returns null for missing/escaping/root paths; `deleteMediaFolder()` removes recursively. All 9 specs pass. Backend typechecks clean (the lone `tsc` error is pre-existing in `auto-grab-pipeline.service.spec.ts`).