### PR TITLE
fix(player): set the browser tab title from the playing media

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -168,13 +168,15 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   /** Set the browser tab title from the loaded media. The player route lives
    *  outside the main layout, so the layout's title effect doesn't run here —
    *  without this the tab keeps whichever title the previous page set (e.g.
-   *  "Accueil" when launched from the home continue-watching row). */
+   *  "Accueil" when launched from the home continue-watching row). Keep that
+   *  previous title until the media name resolves so the tab doesn't flicker
+   *  through a bare app name in between. */
   private readonly tabTitleEffect = effect(() => {
     const media = this.mediaTitle();
     const episode = this.episodeTitle();
-    const app = this.translate.instant('app.name');
     const main = episode ? (media ? `${media} - ${episode}` : episode) : media;
-    this.title.setTitle(main ? `${main} · ${app}` : app);
+    if (!main) return;
+    this.title.setTitle(`${main} · ${this.translate.instant('app.name')}`);
   });
 
   // New extracted services

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -13,6 +13,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { Title } from '@angular/platform-browser';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { StreamingApiService, PlaybackInfoResponse } from '../../core/services/api/streaming-api.service';
 import { MediaService, Media } from '../../core/services/api/media.service';
@@ -162,6 +163,19 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   private readonly toast = inject(ToastService);
   private readonly navbar = inject(NavbarService);
   private readonly translate = inject(TranslateService);
+  private readonly title = inject(Title);
+
+  /** Set the browser tab title from the loaded media. The player route lives
+   *  outside the main layout, so the layout's title effect doesn't run here —
+   *  without this the tab keeps whichever title the previous page set (e.g.
+   *  "Accueil" when launched from the home continue-watching row). */
+  private readonly tabTitleEffect = effect(() => {
+    const media = this.mediaTitle();
+    const episode = this.episodeTitle();
+    const app = this.translate.instant('app.name');
+    const main = episode ? (media ? `${media} - ${episode}` : episode) : media;
+    this.title.setTitle(main ? `${main} · ${app}` : app);
+  });
 
   // New extracted services
   private readonly state = inject(PlayerStateService);

--- a/client/src/app/shared/layout/layout.ts
+++ b/client/src/app/shared/layout/layout.ts
@@ -127,9 +127,9 @@ export class LayoutComponent implements OnInit, OnDestroy {
 
   private readonly documentTitleEffect = effect(() => {
     this.langTick();
-    const app = this.translate.instant('app.name');
     const main = this.navbar.mobileNavTitle();
-    this.title.setTitle(main ? `${main} · ${app}` : app);
+    if (!main) return;
+    this.title.setTitle(`${main} · ${this.translate.instant('app.name')}`);
   });
   private lastScrollY = 0;
   private readonly onScroll = () => {


### PR DESCRIPTION
## Problem

Opening the player from the home page's "À reprendre" (continue-watching) row left the browser tab title stale (e.g. "Accueil") instead of showing the media being played.

## Root cause

The player route (`/watch/:mediaFileId`) lives outside the main layout, so the layout's document-title effect doesn't run while watching. The player never set `document.title` itself — the tab simply kept whatever the previous page had set. From a media detail page that happened to already be the media name (so it looked correct); from the home row it stayed generic.

## Fix

Add an effect in the player that sets the tab title from the loaded media/episode signals, in the same `<title> · <app>` format the layout uses. When the player is left, the layout's own title effect takes over again.

## Tests

Client build passes (`ng build --configuration=development`). Behaviour to confirm on device: launch playback from the home continue-watching row and check the tab title shows the media name.