### PR TITLE
fix(setup): store the post-redirect server URL so login POST isn't downgraded

### DIFF
--- a/client/src/app/core/services/server-config.service.ts
+++ b/client/src/app/core/services/server-config.service.ts
@@ -67,8 +67,32 @@ export class ServerConfigService {
 
   async save(url: string): Promise<void> {
     const cleaned = url.replace(/\/+$/, '');
-    this._serverUrl.set(cleaned);
-    await this.writePreference(STORAGE_KEY, cleaned);
+    const canonical = this.isNative
+      ? await this.resolveCanonicalUrl(cleaned)
+      : cleaned;
+    this._serverUrl.set(canonical);
+    await this.writePreference(STORAGE_KEY, canonical);
+  }
+
+  /**
+   * Follow any redirect the host issues on its first request (e.g. an
+   * http→https upgrade) and return the post-redirect base. A 301/302 downgrades
+   * a POST to GET, so a server reached through such a redirect would turn the
+   * login POST into `GET /api/auth/login`. Storing the canonical base makes
+   * every API call hit the final host directly. Best effort: the entered URL is
+   * kept on any network/CORS failure.
+   */
+  private async resolveCanonicalUrl(base: string): Promise<string> {
+    if (!base) return base;
+    const probe = '/api/auth/me';
+    try {
+      const res = await fetch(base + probe, { method: 'GET', redirect: 'follow' });
+      const idx = res.url.indexOf(probe);
+      if (idx > 0) return res.url.slice(0, idx);
+    } catch {
+      /* unreachable / blocked — keep the entered URL */
+    }
+    return base;
   }
 
   async clear(): Promise<void> {


### PR DESCRIPTION
## Problem

On one Windows desktop, login failed with `Cannot GET /api/auth/login` while the public user list loaded fine. Same build, another Windows worked.

## Root cause

The configured server URL on the failing machine was reached through a **redirect** (e.g. `http://` → `https://`). The signature is decisive:
- the **GET** that loads `/api/auth/users-public` follows the 301/302 transparently → user list loads;
- the login **POST** is **downgraded to GET** by the same redirect (301/302 do not preserve the method) → it arrives as `GET /api/auth/login`, and the POST-only route returns `Cannot GET /api/auth/login`.

The working machine had the canonical (post-redirect) URL configured, so no redirect, no downgrade.

## Fix

`ServerConfigService.save()` now resolves the canonical base before storing it: a single `fetch(base + '/api/auth/me', { redirect: 'follow' })` and we read `response.url`, stripping the probe path to get the final host. Every subsequent API call then hits the canonical host directly, so the login POST is never redirected/downgraded.

Best effort and scoped to native shells (`isNative`): on any network/CORS failure the entered URL is kept, and known-server entries inherit the canonical value since they are stored from the already-normalized active URL.

## Tests

Client build passes (`ng build --configuration=development`). To confirm on the affected machine: enter the `http://` URL and verify it is stored as the canonical `https://` host and that login succeeds.