### PR TITLE
fix(streaming): emit keyframe-aligned segment durations in the remux playlist

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -39,7 +39,11 @@ import {
   getSegmentDuration,
   secondsToSegmentIndex,
 } from './transcoding/constants';
-import { getRemuxSegmentDurations } from './transcoding/segment-boundaries';
+import {
+  getRemuxSegmentDurations,
+  boundariesFromDurations,
+  secondsToSegmentIndex as boundarySecondsToIndex,
+} from './transcoding/segment-boundaries';
 import { LiveSessionRegistry } from './live-session.service';
 import * as path from 'path';
 import { SegmentPackagingService } from './services/segment-packaging.service';
@@ -324,11 +328,26 @@ export class StreamingController {
   private resumeFloor(
     live: { position: number } | null | undefined,
     existing: { startSegment?: number | null } | null | undefined,
+    boundaries?: number[],
   ): number {
-    return Math.max(
-      existing?.startSegment ?? 0,
-      live ? secondsToSegmentIndex(live.position) : 0,
-    );
+    const posIndex = live
+      ? boundaries
+        ? boundarySecondsToIndex(boundaries, live.position)
+        : secondsToSegmentIndex(live.position)
+      : 0;
+    return Math.max(existing?.startSegment ?? 0, posIndex);
+  }
+
+  /** Keyframe-aligned cumulative segment boundaries for the remux/copy path,
+   *  or null when keyframes can't be probed (fall back to the uniform grid).
+   *  Cached per file by {@link getRemuxSegmentDurations}; the playlist is
+   *  fetched before segments, so segment-time lookups hit the warm cache. */
+  private async remuxBoundaries(
+    absolutePath: string,
+    durationHint = 0,
+  ): Promise<number[] | null> {
+    const durations = await getRemuxSegmentDurations(absolutePath, durationHint);
+    return durations ? boundariesFromDurations(durations) : null;
   }
 
   /**
@@ -344,8 +363,9 @@ export class StreamingController {
     existing: { startSegment?: number | null } | null | undefined,
     isInit: boolean,
     segIndex: number,
+    boundaries?: number[],
   ): number {
-    return isInit ? this.resumeFloor(live, existing) : segIndex;
+    return isInit ? this.resumeFloor(live, existing, boundaries) : segIndex;
   }
 
   /**
@@ -1491,25 +1511,34 @@ export class StreamingController {
       const existing = this.sessionRouter.resolveSession(mediaFileId, req.user?.id, req);
       if (!existing || existing.process.exitCode !== null) {
         const startAtSec = parseInt(startAtRaw, 10);
-        const startSegment = secondsToSegmentIndex(startAtSec);
         const ctx = this.sessionContextBuilder.build(req, resolved, mediaFileId);
         ctx.spawnReason = 'variant-prespawn';
         if (quality === 'remux') {
           const copyAudio =
             firstQueryString(req.query, 'copyAudio') !== 'false';
+          // Copied video is keyframe-cut, so map the resume time to a segment
+          // (and seek) via the real keyframe boundaries, not the uniform grid.
+          const boundaries = await this.remuxBoundaries(
+            resolved.absolutePath,
+            duration,
+          );
+          const startSegment = boundaries
+            ? boundarySecondsToIndex(boundaries, startAtSec)
+            : secondsToSegmentIndex(startAtSec);
           void this.transcodingService.getOrCreateRemuxSession(
             mediaFileId,
             resolved.absolutePath,
             copyAudio,
             startSegment,
             ctx,
+            boundaries ?? undefined,
           );
         } else {
           void this.transcodingService.getOrCreateSession(
             mediaFileId,
             quality,
             resolved.absolutePath,
-            startSegment,
+            secondsToSegmentIndex(startAtSec),
             ctx,
           );
         }
@@ -1807,7 +1836,20 @@ export class StreamingController {
     // For remux sessions, copy audio only when the source codec is compatible
     // (captured at playback-info); otherwise transcode audio to AAC.
     const copyAudio = live?.canCopyAudio ?? false;
-    const anchorSeg = this.anchorSegment(live, existing, isInit, segIndex);
+    // Remux: anchor + seek on the real keyframe boundaries (cached) so a resume
+    // / forward seek lands on the right content and the post-seek playlist stays
+    // aligned. Non-remux keeps the uniform grid (force_key_frames makes it true).
+    const remuxBounds =
+      quality === 'remux'
+        ? ((await this.remuxBoundaries(resolved.absolutePath)) ?? undefined)
+        : undefined;
+    const anchorSeg = this.anchorSegment(
+      live,
+      existing,
+      isInit,
+      segIndex,
+      remuxBounds,
+    );
     const session =
       quality === 'remux'
         ? await this.transcodingService.getOrCreateRemuxSession(
@@ -1816,6 +1858,7 @@ export class StreamingController {
             copyAudio,
             anchorSeg,
             ctx,
+            remuxBounds,
           )
         : await this.transcodingService.getOrCreateSession(
             mediaFileId,

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -39,6 +39,7 @@ import {
   getSegmentDuration,
   secondsToSegmentIndex,
 } from './transcoding/constants';
+import { getRemuxSegmentDurations } from './transcoding/segment-boundaries';
 import { LiveSessionRegistry } from './live-session.service';
 import * as path from 'path';
 import { SegmentPackagingService } from './services/segment-packaging.service';
@@ -211,6 +212,36 @@ function buildVodPlaylist(
     const segLen = Math.min(SEG_DURATION, duration - segStart);
     if (segLen <= 0) break;
     lines.push(`#EXTINF:${segLen.toFixed(3)},`);
+    lines.push(segmentUrl(String(i).padStart(4, '0')));
+  }
+  lines.push('#EXT-X-ENDLIST');
+  return lines.join('\n');
+}
+
+/** VOD playlist with explicit per-segment durations. Used by the remux/copy
+ *  path, where ffmpeg cuts at source keyframes so segments are variable-length
+ *  and a uniform `EXTINF` grid would mislead strict players (AVPlayer) into a
+ *  progressive A/V drift. `durations` mirror ffmpeg's actual segment lengths
+ *  (see {@link getRemuxSegmentDurations}). */
+function buildVariableVodPlaylist(
+  durations: number[],
+  segmentUrl: (index: string) => string,
+  initUrl?: string,
+): string {
+  const target = Math.ceil(durations.reduce((m, d) => Math.max(m, d), 0));
+  const lines = [
+    '#EXTM3U',
+    '#EXT-X-VERSION:7',
+    `#EXT-X-TARGETDURATION:${target}`,
+    '#EXT-X-MEDIA-SEQUENCE:0',
+    '#EXT-X-PLAYLIST-TYPE:VOD',
+    '#EXT-X-INDEPENDENT-SEGMENTS',
+  ];
+  if (initUrl) {
+    lines.push(`#EXT-X-MAP:URI="${initUrl}"`);
+  }
+  for (let i = 0; i < durations.length; i++) {
+    lines.push(`#EXTINF:${durations[i].toFixed(3)},`);
     lines.push(segmentUrl(String(i).padStart(4, '0')));
   }
   lines.push('#EXT-X-ENDLIST');
@@ -1507,11 +1538,25 @@ export class StreamingController {
         ? 'init_0.mp4'
         : 'init.mp4';
 
-    const playlist = buildVodPlaylist(
-      duration,
-      (seg) => `${basePath}/seg-${seg}.${segExt}${tokenParam}`,
-      initName ? `${basePath}/${initName}${tokenParam}` : undefined,
-    );
+    const segmentUrl = (seg: string) =>
+      `${basePath}/seg-${seg}.${segExt}${tokenParam}`;
+    const initRef = initName ? `${basePath}/${initName}${tokenParam}` : undefined;
+
+    // Remux copies the source video, so ffmpeg cuts at its (irregular)
+    // keyframes — the uniform grid would emit wrong EXTINF durations and drift
+    // AVPlayer out of A/V sync. Emit the real keyframe-aligned durations; fall
+    // back to the uniform grid when keyframes can't be probed (no regression).
+    // fMP4 only — the Tizen MPEG-TS fallback keeps the uniform path.
+    let remuxDurations: number[] | null = null;
+    if (quality === 'remux' && !useTs) {
+      remuxDurations = await getRemuxSegmentDurations(
+        resolved.absolutePath,
+        duration,
+      );
+    }
+    const playlist = remuxDurations
+      ? buildVariableVodPlaylist(remuxDurations, segmentUrl, initRef)
+      : buildVodPlaylist(duration, segmentUrl, initRef);
 
     res.setHeader('Content-Type', 'application/vnd.apple.mpegurl');
     res.setHeader('Access-Control-Allow-Origin', '*');

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -825,6 +825,11 @@ export function buildRemuxArgs(
   sourceVideoCodec?: string,
   /** Cached streamInfo audio array. See {@link AudioStreamMeta}. */
   audioStreams?: AudioStreamMeta[],
+  /** Keyframe-aligned segment start times (`boundaries[i]` = start of seg-`i`).
+   *  Copied video is cut at the source keyframes, so a resume/seek must seek to
+   *  the real start of `startSegment` — not the uniform-grid `index * segDur`,
+   *  which lands on the wrong content and desyncs the post-seek playlist. */
+  segmentBoundaries?: number[],
 ): string[] {
   const SEGMENT_DURATION = getSegmentDuration();
 
@@ -840,7 +845,10 @@ export function buildRemuxArgs(
   }
 
   const remuxSeekSeconds =
-    startSegment > 0 ? segmentIndexToSeconds(startSegment) : 0;
+    startSegment > 0
+      ? (segmentBoundaries?.[startSegment] ??
+        segmentIndexToSeconds(startSegment))
+      : 0;
   if (startSegment > 0) {
     args.push('-ss', String(remuxSeekSeconds));
   }

--- a/backend/src/modules/streaming/transcoding/segment-boundaries.spec.ts
+++ b/backend/src/modules/streaming/transcoding/segment-boundaries.spec.ts
@@ -1,0 +1,51 @@
+import {
+  computeSegmentDurations,
+  boundariesFromDurations,
+  secondsToSegmentIndex,
+  segmentIndexToSeconds,
+} from './segment-boundaries';
+
+describe('computeSegmentDurations', () => {
+  it('cuts at the first keyframe past each advancing target, tail to duration', () => {
+    // SEG=6. Keyframes [0,2,4,7,9,13,15], duration 18.
+    //  target 6  → cut at kf 7  (seg 0..7  = 7s), target 12
+    //  target 12 → cut at kf 13 (seg 7..13 = 6s), target 18
+    //  tail      → 13..18 = 5s
+    const durs = computeSegmentDurations([0, 2, 4, 7, 9, 13, 15], 18, 6);
+    expect(durs).toEqual([7, 6, 5]);
+  });
+
+  it('extends the timeline when a keyframe sits past the reported duration', () => {
+    // Last keyframe (20) > reported duration (15): total becomes 20, no negative tail.
+    const durs = computeSegmentDurations([0, 5, 10, 20], 15, 6);
+    expect(durs.reduce((a, b) => a + b, 0)).toBeCloseTo(20, 3);
+    expect(durs.every((d) => d > 0)).toBe(true);
+  });
+
+  it('returns empty when there are no keyframes', () => {
+    expect(computeSegmentDurations([], 100, 6)).toEqual([]);
+  });
+});
+
+describe('boundary helpers', () => {
+  const boundaries = boundariesFromDurations([7, 6, 5]); // [0,7,13,18]
+
+  it('builds cumulative start times plus the final end', () => {
+    expect(boundaries).toEqual([0, 7, 13, 18]);
+  });
+
+  it('maps a time to the segment whose window contains it', () => {
+    expect(secondsToSegmentIndex(boundaries, 0)).toBe(0);
+    expect(secondsToSegmentIndex(boundaries, 6.9)).toBe(0);
+    expect(secondsToSegmentIndex(boundaries, 7)).toBe(1);
+    expect(secondsToSegmentIndex(boundaries, 12.9)).toBe(1);
+    expect(secondsToSegmentIndex(boundaries, 13)).toBe(2);
+    expect(secondsToSegmentIndex(boundaries, 999)).toBe(2);
+  });
+
+  it('maps a segment index back to its start time (consistent with the playlist)', () => {
+    expect(segmentIndexToSeconds(boundaries, 0)).toBe(0);
+    expect(segmentIndexToSeconds(boundaries, 1)).toBe(7);
+    expect(segmentIndexToSeconds(boundaries, 2)).toBe(13);
+  });
+});

--- a/backend/src/modules/streaming/transcoding/segment-boundaries.ts
+++ b/backend/src/modules/streaming/transcoding/segment-boundaries.ts
@@ -1,0 +1,157 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { Logger } from '@nestjs/common';
+import { statSync } from 'fs';
+import { getSegmentDuration } from './constants';
+
+const execFileAsync = promisify(execFile);
+const log = new Logger('SegmentBoundaries');
+
+/**
+ * Keyframe-accurate HLS segment grid for the REMUX / copy-video path.
+ *
+ * Transcoded video forces an IDR every `segmentDuration`s (`-force_key_frames`),
+ * so its segments — and the served playlist — sit on a uniform grid. Copied
+ * video can't force keyframes: ffmpeg's HLS muxer cuts at the source keyframes,
+ * producing wildly variable segment lengths (seen 1–15s on a Blu-ray HEVC rip).
+ * Serving a uniform `EXTINF` for those segments makes strict players (AVPlayer)
+ * drift progressively out of A/V sync — they trust `EXTINF` for the timeline,
+ * unlike Shaka/ExoPlayer which re-anchor on each fragment's `tfdt`.
+ *
+ * We mirror ffmpeg's copy segmentation by reading the source keyframes and
+ * cutting at the first keyframe at/after a target that advances by
+ * `segmentDuration` per cut. This reproduces ffmpeg's actual `index.m3u8`
+ * boundaries to within a few milliseconds.
+ */
+
+interface CacheEntry {
+  mtimeMs: number;
+  segDur: number;
+  durations: number[];
+}
+
+const cache = new Map<string, CacheEntry>();
+
+/** Video keyframe presentation times (seconds, ascending) of the source. */
+export async function extractKeyframeTimes(filePath: string): Promise<number[]> {
+  const { stdout } = await execFileAsync(
+    'ffprobe',
+    [
+      '-v',
+      'error',
+      '-select_streams',
+      'v:0',
+      '-skip_frame',
+      'nokey',
+      '-show_entries',
+      'frame=pts_time',
+      '-of',
+      'csv=p=0',
+      filePath,
+    ],
+    { maxBuffer: 128 * 1024 * 1024, timeout: 120_000 },
+  );
+  return stdout
+    .split('\n')
+    .map((line) => parseFloat(line))
+    .filter((t) => Number.isFinite(t) && t >= 0)
+    .sort((a, b) => a - b);
+}
+
+/**
+ * Per-segment durations (seconds) ffmpeg's HLS muxer produces when copying a
+ * keyframe-cut video. Cut at the first keyframe ≥ a target that advances by
+ * `segDur` after each cut; the tail runs to `totalDuration`. Matches Jellyfin's
+ * `ComputeSegments` and our ffmpeg's real output (verified to within ~7ms).
+ */
+export function computeSegmentDurations(
+  keyframeTimes: number[],
+  totalDuration: number,
+  segDur: number = getSegmentDuration(),
+): number[] {
+  if (keyframeTimes.length === 0 || segDur <= 0) return [];
+  // A keyframe past the container-reported duration extends the timeline so the
+  // tail segment isn't negative (Jellyfin #16703).
+  const last = keyframeTimes[keyframeTimes.length - 1];
+  const total = Math.max(totalDuration, last);
+  if (total <= 0) return [];
+
+  const durations: number[] = [];
+  let lastCut = 0;
+  let target = segDur;
+  for (const kf of keyframeTimes) {
+    if (kf >= target) {
+      durations.push(kf - lastCut);
+      lastCut = kf;
+      target += segDur;
+    }
+  }
+  const remaining = total - lastCut;
+  if (remaining > 0.001) durations.push(remaining);
+  return durations;
+}
+
+/** Cumulative segment start times; `boundaries[i]` is the start of seg-`i`,
+ *  the last entry is the total end. */
+export function boundariesFromDurations(durations: number[]): number[] {
+  const boundaries = [0];
+  for (const d of durations) {
+    boundaries.push(boundaries[boundaries.length - 1] + d);
+  }
+  return boundaries;
+}
+
+/** Segment index whose `[start, end)` window contains `seconds`. */
+export function secondsToSegmentIndex(
+  boundaries: number[],
+  seconds: number,
+): number {
+  if (seconds <= 0 || boundaries.length < 2) return 0;
+  for (let i = 0; i < boundaries.length - 1; i++) {
+    if (seconds < boundaries[i + 1]) return i;
+  }
+  return boundaries.length - 2;
+}
+
+/** Start time (seconds) of segment `index`. */
+export function segmentIndexToSeconds(
+  boundaries: number[],
+  index: number,
+): number {
+  if (index <= 0) return 0;
+  return boundaries[Math.min(index, boundaries.length - 1)] ?? 0;
+}
+
+/**
+ * Resolve (and cache) the keyframe-aligned segment durations for a source.
+ * Returns null when keyframes can't be read — the caller then falls back to the
+ * uniform grid (no regression). Cache is keyed by path + mtime + segment length.
+ */
+export async function getRemuxSegmentDurations(
+  filePath: string,
+  totalDuration: number,
+  segDur: number = getSegmentDuration(),
+): Promise<number[] | null> {
+  let mtimeMs = 0;
+  try {
+    mtimeMs = statSync(filePath).mtimeMs;
+  } catch {
+    return null;
+  }
+  const hit = cache.get(filePath);
+  if (hit && hit.mtimeMs === mtimeMs && hit.segDur === segDur) {
+    return hit.durations;
+  }
+  try {
+    const keyframes = await extractKeyframeTimes(filePath);
+    const durations = computeSegmentDurations(keyframes, totalDuration, segDur);
+    if (durations.length === 0) return null;
+    cache.set(filePath, { mtimeMs, segDur, durations });
+    return durations;
+  } catch (err) {
+    log.warn(
+      `Keyframe probe failed for ${filePath}; falling back to uniform grid: ${(err as Error).message}`,
+    );
+    return null;
+  }
+}

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -1247,6 +1247,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     copyAudio: boolean,
     requestedSegment = 0,
     ctx?: SessionContext,
+    segmentBoundaries?: number[],
   ): Promise<TranscodeSession> {
     // Remux variant lives in its own session-map bucket so its cache
     // path doesn't collide with a main session for the same base
@@ -1265,6 +1266,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         copyAudio,
         requestedSegment,
         ctx,
+        segmentBoundaries,
       ),
     );
   }
@@ -1276,6 +1278,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     copyAudio: boolean,
     requestedSegment: number,
     ctx?: SessionContext,
+    segmentBoundaries?: number[],
   ): Promise<TranscodeSession> {
     const existing = this.sessions.get(key);
     if (existing) {
@@ -1319,6 +1322,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       this.log,
       ctx?.sourceVideoCodec,
       ctx?.audioStreams,
+      segmentBoundaries,
     );
 
     const session = this.spawnFfmpegSession({


### PR DESCRIPTION
## Problem

On iPhone only, video direct-play + transcoded audio (the **remux** path) drifts **progressively** out of A/V sync over a long title. Web (Shaka) and Android (ExoPlayer) play the same content fine.

## Root cause

The remux playlist was built on a **uniform grid** (every `EXTINF = segmentDuration`). But the remux path **copies** the video, so ffmpeg cuts at the **source keyframes** — real segments are variable (measured 1.0–14.7s on a Blu-ray HEVC rip with irregular GOPs). The inaccurate `EXTINF` violates Apple's HLS spec (±0.5s) and makes **AVPlayer drift progressively** — it trusts `EXTINF` for its timeline, whereas Shaka/ExoPlayer re-anchor on each fragment's `tfdt`. The media bytes are correct; only the playlist metadata lied.

Same distinction Jellyfin makes: uniform segments for transcodes (ffmpeg forces keyframes), keyframe-derived variable segments for remux (`DynamicHlsPlaylistGenerator.ComputeSegments`).

## Fix

- New `transcoding/segment-boundaries.ts`: probe source keyframes (`ffprobe -skip_frame nokey`, cached per file+mtime+segDur) and compute real per-segment durations, mirroring ffmpeg's copy segmentation. **Verified to reproduce ffmpeg's `index.m3u8` within ~7ms (560/560 segments).**
- `streaming.controller.ts`: for `quality === 'remux'` (fMP4), emit variable-EXTINF playlist; fall back to the uniform grid when keyframes can't be probed.
- **Seek/resume mapping routed on the same keyframe boundaries** (not the uniform grid): `resumeFloor`/`anchorSegment`, the prespawn `startSegment`, and `buildRemuxArgs`'s `-ss` all use `boundaries[index]`. Without this, a resume or forward seek into an uncached region would seek to `index*segmentDuration` while the playlist placed the segment at its real keyframe start — landing off and desyncing the post-seek playlist.

Transcode and Tizen-TS paths are untouched (uniform grid stays exact there via `-force_key_frames`).

## Scope / limitation

Targets **from-start linear playback** (the reported bug) — the single ffmpeg spawn from t=0 matches the computed boundaries exactly, and cached seeks now land correctly. A **forward seek into a not-yet-transcoded region** triggers an ffmpeg respawn whose cuts re-accumulate from the seek point and can't be matched by a precomputed grid without per-segment muxing; the seek now *lands* correctly but the post-seek tail in that narrow window (remux caches the whole file in ~90s) can still re-drift. Fully solving it needs deterministic cut control (`segment` muxer + `-segment_times`, or per-segment production) — a separate, higher-risk muxer migration deferred until the residual is shown to matter in practice.

## Tests

`segment-boundaries.spec.ts` (6 cases) + full streaming suite (205 tests) pass; typecheck clean.

## Follow-ups (not here)

- Persist keyframe times at rescan (we already probe there) to drop the cold-start probe latency and survive restarts.
- iOS EAC3/AV1 capability advertisement (separate change) — avoids the unnecessary audio transcode; independent of this drift fix.