### PR TITLE
feat(ios): advertise native codec support from the OS decode APIs

### DIFF
--- a/client/ios/App/App/AudioCapabilitiesPlugin.swift
+++ b/client/ios/App/App/AudioCapabilitiesPlugin.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Capacitor
-import UIKit
+import AudioToolbox
 
 @objc(AudioCapabilitiesPlugin)
 public class AudioCapabilitiesPlugin: CAPPlugin, CAPBridgedPlugin {
@@ -10,30 +10,39 @@ public class AudioCapabilitiesPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "getSupported", returnType: CAPPluginReturnPromise),
     ]
 
-    /// Reports the audio codecs the device's media stack decodes.
-    /// iOS doesn't expose a MediaCodecList equivalent, so we hard-code by
-    /// device class — accurate to within ~95% of real-world behaviour.
+    /// Our codec identifiers mapped to the Core Audio format IDs that stand for
+    /// them. A codec is reported only when the system actually lists it as
+    /// decodable (see `decodableFormatIDs`).
+    private static let codecFormatIDs: [(name: String, id: AudioFormatID)] = [
+        ("aac", kAudioFormatMPEG4AAC),
+        ("aac", kAudioFormatMPEG4AAC_HE),
+        ("alac", kAudioFormatAppleLossless),
+        ("mp3", kAudioFormatMPEGLayer3),
+        ("flac", kAudioFormatFLAC),
+        ("ac3", kAudioFormatAC3),
+        ("eac3", kAudioFormatEnhancedAC3),
+        ("opus", kAudioFormatOpus),
+    ]
+
+    /// Reports the audio codecs the device's media stack decodes, queried at
+    /// runtime from Core Audio rather than guessed per device class — iOS has
+    /// no MediaCodecList, but `kAudioFormatProperty_DecodeFormatIDs` is the
+    /// system's own list of decodable formats.
     @objc func getSupported(_ call: CAPPluginCall) {
-        var codecs: [String] = ["aac", "alac", "mp3"]
-        // AVPlayer decodes multichannel (AAC / ALAC / FLAC) and the OS downmixes
-        // to the real output, so report the DECODE capability (8 = 7.1), not the
-        // stereo speaker count — a 5.1/7.1 source then DirectPlays and downmixes
-        // on-device. (No MediaCodecList equivalent on iOS, so this stays a
-        // device-class estimate.)
-        var maxChannels = 8
-
-        if #available(iOS 11, tvOS 11, *) {
-            codecs.append("flac")
+        let decodable = Self.decodableFormatIDs()
+        var codecs: [String] = []
+        for (name, id) in Self.codecFormatIDs where decodable.contains(id) {
+            if !codecs.contains(name) { codecs.append(name) }
         }
+        // AAC is always decodable; guarantee it even if the query comes back
+        // empty on some OS revision.
+        if !codecs.contains("aac") { codecs.insert("aac", at: 0) }
 
-        let idiom = UIDevice.current.userInterfaceIdiom
-        if idiom == .tv {
-            // Apple TV → AC-3 / E-AC-3 / Atmos via HDMI.
-            codecs.append(contentsOf: ["ac3", "eac3"])
-        }
-
-        // Per-codec decode estimate (no MediaCodecList equivalent on iOS): MP3
-        // is stereo; the rest decode multichannel and the OS downmixes.
+        // AVFoundation decodes multichannel and the OS downmixes to the active
+        // output (built-in speakers, headphones) or passes through over HDMI /
+        // AirPlay, so report the decode ceiling, not the speaker count — a
+        // 5.1/7.1 source then Direct Plays and downmixes on-device.
+        let maxChannels = 8
         var channelsByCodec: [String: Int] = [:]
         for c in codecs {
             channelsByCodec[c] = (c == "mp3") ? 2 : maxChannels
@@ -44,5 +53,19 @@ public class AudioCapabilitiesPlugin: CAPPlugin, CAPBridgedPlugin {
             "maxChannels": maxChannels,
             "channelsByCodec": channelsByCodec,
         ])
+    }
+
+    /// The set of audio format IDs the system can decode.
+    private static func decodableFormatIDs() -> Set<AudioFormatID> {
+        var size: UInt32 = 0
+        guard AudioFormatGetPropertyInfo(
+                kAudioFormatProperty_DecodeFormatIDs, 0, nil, &size) == noErr,
+              size > 0 else { return [] }
+        let count = Int(size) / MemoryLayout<AudioFormatID>.size
+        var ids = [AudioFormatID](repeating: 0, count: count)
+        guard AudioFormatGetProperty(
+                kAudioFormatProperty_DecodeFormatIDs, 0, nil, &size, &ids) == noErr
+        else { return [] }
+        return Set(ids)
     }
 }

--- a/client/ios/App/App/VideoCapabilitiesPlugin.swift
+++ b/client/ios/App/App/VideoCapabilitiesPlugin.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Capacitor
-import UIKit
+import VideoToolbox
+import CoreMedia
 
 @objc(VideoCapabilitiesPlugin)
 public class VideoCapabilitiesPlugin: CAPPlugin, CAPBridgedPlugin {
@@ -10,25 +11,32 @@ public class VideoCapabilitiesPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "getSupported", returnType: CAPPluginReturnPromise),
     ]
 
-    /// Reports the video codecs AVPlayer can decode on this device so the
-    /// profile reflects VideoToolbox capability rather than the WebView MSE
-    /// (which under-reports HEVC). H.264 is universal; HEVC — including Main10
-    /// — is hardware-decoded across the iOS 11+ device range (A9 and newer).
-    /// AVPlayer demuxes the ISO-BMFF family only, so MKV/WebM are never
-    /// advertised (those still remux/transcode server-side).
+    /// Reports the video codecs the device can hardware-decode, queried at
+    /// runtime from VideoToolbox rather than guessed from the OS version — H.264
+    /// is universal; HEVC and AV1 are asked of `VTIsHardwareDecodeSupported` so
+    /// only devices with the actual decoder (HEVC: A9+, AV1: A17 Pro / M3+) are
+    /// told they can Direct Play them. Their hardware decoders are 10-bit, so the
+    /// Main10 flags follow the codec. AVPlayer demuxes the ISO-BMFF family only,
+    /// so MKV/WebM are never advertised (those still remux/transcode server-side).
     @objc func getSupported(_ call: CAPPluginCall) {
         var codecs: [String] = ["h264"]
-        var hevcMain10 = false
+        var hevc = false
+        var av1 = false
 
         if #available(iOS 11.0, tvOS 11.0, *) {
-            codecs.append("hevc")
-            hevcMain10 = true
+            hevc = VTIsHardwareDecodeSupported(kCMVideoCodecType_HEVC)
+            if hevc { codecs.append("hevc") }
+        }
+
+        if #available(iOS 16.0, tvOS 16.0, *) {
+            av1 = VTIsHardwareDecodeSupported(kCMVideoCodecType_AV1)
+            if av1 { codecs.append("av1") }
         }
 
         call.resolve([
             "videoCodecs": codecs,
-            "hevcMain10": hevcMain10,
-            "av1Main10": false,
+            "hevcMain10": hevc,
+            "av1Main10": av1,
             "containers": ["mp4", "m4v", "mov"],
         ])
     }


### PR DESCRIPTION
## Problem

Both iOS capability plugins hard-coded their codec lists by device class:

- **Audio**: AC-3 / E-AC-3 were only advertised on Apple TV (`idiom == .tv`). On iPhone/iPad the profile reported no Dolby support, so the backend **transcoded EAC3 → AAC** on every Dolby source — unnecessary, since iOS decodes AC-3/E-AC-3 natively and downmixes.
- **Video**: HEVC was advertised for every iOS 11+ device, including A8 chips (iPhone 6) that have **no HEVC hardware decoder** — those could be told to Direct Play HEVC they can't decode.

## Fix

Query the OS at runtime instead of guessing by device class:

- **Audio** → Core Audio `kAudioFormatProperty_DecodeFormatIDs` (the system's own list of decodable formats). AAC/ALAC/MP3/FLAC/Opus/AC-3/E-AC-3 are reported exactly when the device decodes them, on **every idiom**. AAC is guaranteed as a safety net.
- **Video** → VideoToolbox `VTIsHardwareDecodeSupported` for HEVC and AV1, so only devices with the real hardware decoder advertise them (HEVC: A9+; AV1: A17 Pro / M3+). The `hevcMain10` / `av1Main10` flags follow the codec, since those decoders are 10-bit.

The client already maps an `av1` native codec into the device profile, so AV1 Direct Play flows through unchanged on capable devices.

## Relationship to the A/V sync fix

Independent of #530 (the remux playlist drift). This one removes the **unnecessary audio transcode** on iPhone (efficiency + keeps multichannel) and fixes HEVC over-advertisement; it does **not** affect the playlist/segment timing.

## Validation

Swift can't be compiled in CI here — needs an **iOS build** to confirm it compiles and that `ec-3` / `av1` surface correctly on a real device (and that EAC3 then Direct Plays instead of transcoding). The symbols used are standard and guarded by `#available`.