### PR TITLE
feat(streaming): admin toggle to keep black bars instead of cropping

### DIFF
--- a/backend/src/modules/streaming/active-stream-tracker.service.ts
+++ b/backend/src/modules/streaming/active-stream-tracker.service.ts
@@ -57,6 +57,17 @@ export class ActiveStreamTracker {
     return this.tonemapAlgoCache;
   }
 
+  /** Whether detected black bars are cropped (admin-configurable, global).
+   *  Cropping forces a re-encode; disabling it lets letterboxed sources
+   *  Direct Play / remux untouched on low-power servers. Default on. */
+  private autoCropEnabledCache = true;
+  setAutoCropEnabled(enabled: boolean) {
+    this.autoCropEnabledCache = enabled;
+  }
+  getAutoCropEnabled(): boolean {
+    return this.autoCropEnabledCache;
+  }
+
   private segmentDurationCache = 3;
 
   setStreamingDuration(segDuration: number) {

--- a/backend/src/modules/streaming/services/session-context-builder.service.spec.ts
+++ b/backend/src/modules/streaming/services/session-context-builder.service.spec.ts
@@ -22,7 +22,11 @@ const req = { user: { id: 7, username: 'u' } } as unknown as Request;
 
 describe('SessionContextBuilder.build', () => {
   let sessionRouter: { findRequestSession: jest.Mock };
-  let tracker: { getQsvOptions: jest.Mock; getTonemapAlgo: jest.Mock };
+  let tracker: {
+    getQsvOptions: jest.Mock;
+    getTonemapAlgo: jest.Mock;
+    getAutoCropEnabled: jest.Mock;
+  };
   let builder: SessionContextBuilder;
 
   beforeEach(() => {
@@ -30,6 +34,7 @@ describe('SessionContextBuilder.build', () => {
     tracker = {
       getQsvOptions: jest.fn().mockReturnValue({ lowPower: false }),
       getTonemapAlgo: jest.fn().mockReturnValue('auto'),
+      getAutoCropEnabled: jest.fn().mockReturnValue(true),
     };
     builder = new SessionContextBuilder(tracker as never, sessionRouter as never);
   });
@@ -47,6 +52,28 @@ describe('SessionContextBuilder.build', () => {
     expect(ctx.sourceVideoCodec).toBe('hevc');
     expect(ctx.sourceFps).toBe(24);
     expect(ctx.userId).toBe(7);
+  });
+
+  it('gates the crop on the auto-crop toggle', () => {
+    const cropRect = { width: 3840, height: 1606, x: 0, y: 277 };
+    const withCrop = {
+      media: { title: 'T', type: 'movie', posterUrl: null },
+      mediaFile: {
+        streamInfo: {
+          video: [
+            { codec: 'hevc', width: 3840, height: 2160, frameRate: '24', crop: cropRect },
+          ],
+          audio: [{ language: 'en', bitRate: 128000 }],
+          formatBitRate: 50_000_000,
+        },
+      },
+    } as unknown as ResolvedFile;
+
+    tracker.getAutoCropEnabled.mockReturnValue(true);
+    expect(builder.build(req, withCrop, 1).crop).toEqual(cropRect);
+
+    tracker.getAutoCropEnabled.mockReturnValue(false);
+    expect(builder.build(req, withCrop, 1).crop).toBeUndefined();
   });
 
   it('threads the frozen decision off the LiveSession when present', () => {

--- a/backend/src/modules/streaming/services/session-context-builder.service.ts
+++ b/backend/src/modules/streaming/services/session-context-builder.service.ts
@@ -46,7 +46,12 @@ export class SessionContextBuilder {
       tonemap: live?.tonemapping ?? false,
       burnInSubtitle: live?.burnIn ?? undefined,
       audioStreamIndex: live?.audioStreamIndex ?? undefined,
-      crop: si?.video?.[0]?.crop ?? undefined,
+      // Honour the admin auto-crop toggle: when off, never feed a crop to the
+      // ffmpeg filter graph, so even a session that transcodes for another
+      // reason keeps the black bars instead of cropping them.
+      crop: this.activeStreamTracker.getAutoCropEnabled()
+        ? (si?.video?.[0]?.crop ?? undefined)
+        : undefined,
       // Multi-audio: produce video-only segments and let ffmpeg's var_stream_map
       // emit one audio rendition per track (subdirs 1..N) so Shaka can switch
       // client-side via EXT-X-MEDIA.

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -203,7 +203,9 @@ export class StreamBuilderService {
       videoVariant: selectedVariant,
     });
     const needsBurnIn = !!burnInSubtitleId;
-    const needsCrop = !!v?.crop;
+    // Cropping black bars forces a re-encode. When the admin disables auto-crop
+    // (low-power servers), keep the bars and let the source Direct Play / remux.
+    const needsCrop = !!v?.crop && this.activeStreamTracker.getAutoCropEnabled();
 
     const reasons: TranscodeReason[] = [];
 

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -127,6 +127,11 @@ export class StreamBuilderService {
     const sourceVideoCodec = (v?.codec ?? '').toLowerCase();
     const sourceAudioCodec = (a?.codec ?? '').toLowerCase();
 
+    // Admin auto-crop toggle. Gates both the play-method decision (needsCrop)
+    // and the crop surfaced in the response, so the stats overlay shows the
+    // crop actually applied — not merely the one cropdetect found at import.
+    const autoCropEnabled = this.activeStreamTracker.getAutoCropEnabled();
+
     const source = {
       container: sourceContainer,
       videoCodec: sourceVideoCodec,
@@ -149,7 +154,7 @@ export class StreamBuilderService {
       colorSpace: v?.colorSpace,
       colorTransfer: v?.colorTransfer,
       colorPrimaries: v?.colorPrimaries,
-      crop: v?.crop,
+      crop: autoCropEnabled ? v?.crop : undefined,
     };
 
     // HDR detection
@@ -205,7 +210,7 @@ export class StreamBuilderService {
     const needsBurnIn = !!burnInSubtitleId;
     // Cropping black bars forces a re-encode. When the admin disables auto-crop
     // (low-power servers), keep the bars and let the source Direct Play / remux.
-    const needsCrop = !!v?.crop && this.activeStreamTracker.getAutoCropEnabled();
+    const needsCrop = !!source.crop;
 
     const reasons: TranscodeReason[] = [];
 

--- a/backend/src/modules/streaming/streaming-settings-cache.service.ts
+++ b/backend/src/modules/streaming/streaming-settings-cache.service.ts
@@ -29,6 +29,13 @@ export interface StreamingSettings {
    * Explicit quality picks are unaffected either way.
    */
   autoQualityMode: AutoQualityMode;
+  /**
+   * Whether detected black bars (letterbox/pillarbox) are cropped during
+   * playback. Cropping forces a re-encode, so on low-power servers an admin
+   * can disable it (default `true`) to let otherwise-compatible sources
+   * Direct Play / remux with the black bars intact instead of transcoding.
+   */
+  autoCropEnabled: boolean;
 }
 
 export type AutoQualityMode = 'directplay' | 'abr';
@@ -39,6 +46,7 @@ const KEYS = [
   'streaming_qsv_low_power',
   'streaming_tonemap_algo',
   'streaming_auto_quality_mode',
+  'streaming_auto_crop_enabled',
 ] as const;
 
 const TONEMAP_ALGOS: TonemapAlgo[] = ['auto', 'opencl', 'vaapi', 'qsv'];
@@ -73,8 +81,14 @@ export class StreamingSettingsCache implements OnModuleInit {
 
   private async load(): Promise<StreamingSettings> {
     const values = await Promise.all(KEYS.map((k) => this.settings.get(k)));
-    const [duration, qsvPreset, qsvLowPower, tonemapAlgo, autoQualityMode] =
-      values;
+    const [
+      duration,
+      qsvPreset,
+      qsvLowPower,
+      tonemapAlgo,
+      autoQualityMode,
+      autoCropEnabled,
+    ] = values;
     return {
       segmentDuration: parseFloat(duration ?? '3') || 3,
       qsvPreset: (qsvPreset ?? 'faster') as StreamingSettings['qsvPreset'],
@@ -87,6 +101,9 @@ export class StreamingSettingsCache implements OnModuleInit {
       )
         ? (autoQualityMode as AutoQualityMode)
         : 'directplay',
+      // Default on (preserve current behaviour); only the explicit string
+      // 'false' disables cropping.
+      autoCropEnabled: autoCropEnabled !== 'false',
     };
   }
 }

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -623,6 +623,7 @@ export class StreamingController {
     this.transcodingService.setSegmentDuration(ss.segmentDuration);
     this.activeStreamTracker.setQsvOptions({ lowPower: ss.qsvLowPower });
     this.activeStreamTracker.setTonemapAlgo(ss.tonemapAlgo);
+    this.activeStreamTracker.setAutoCropEnabled(ss.autoCropEnabled);
     this.activeStreamTracker.setDeviceName(
       userId,
       mediaFileId,

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1183,6 +1183,8 @@
       "auto_quality_mode_abr_help": "En « Auto », le serveur transcode en HLS adaptatif qui ajuste la qualité au débit réseau en temps réel. Inconvénient : chaque lecture « Auto » sollicite le transcodage (CPU/GPU) — à réserver aux serveurs avec accélération matérielle.",
       "segment_duration": "Durée des segments",
       "segment_duration_help": "Segments plus courts = démarrage plus rapide mais plus de requêtes HTTP. 3s est un bon compromis.",
+      "auto_crop": "Recadrage automatique des barres noires",
+      "auto_crop_help": "Détecte et supprime les barres noires (letterbox/pillarbox). Le recadrage force un ré-encodage : à désactiver sur les serveurs peu puissants pour lire la source telle quelle (barres noires conservées) sans transcoder.",
       "init_time": "Durée du premier segment",
       "init_time_help": "Le premier segment peut être plus court pour accélérer le démarrage. Les suivants utilisent la durée normale.",
       "qsv_preset": "Preset d'encodage (QSV / libx264)",

--- a/client/src/app/features/settings/streaming/streaming.html
+++ b/client/src/app/features/settings/streaming/streaming.html
@@ -31,6 +31,16 @@
       <label class="label"><span class="label-text-alt text-base-content/50">{{ 'settings.streaming.segment_duration_help' | translate }}</span></label>
     </div>
 
+    <!-- Auto-crop black bars. Off = keep the bars and Direct Play / remux
+         instead of forcing a re-encode just to crop (low-power servers). -->
+    <div class="form-control">
+      <label class="label cursor-pointer justify-start gap-3">
+        <input type="checkbox" class="toggle" [ngModel]="autoCropEnabled()" (ngModelChange)="autoCropEnabled.set($event)" />
+        <span class="label-text font-medium">{{ 'settings.streaming.auto_crop' | translate }}</span>
+      </label>
+      <label class="label"><span class="label-text-alt text-base-content/50">{{ 'settings.streaming.auto_crop_help' | translate }}</span></label>
+    </div>
+
     <!-- QSV / libx264 encoder preset -->
     <div class="form-control">
       <label class="label"><span class="label-text font-medium">{{ 'settings.streaming.qsv_preset' | translate }}</span></label>

--- a/client/src/app/features/settings/streaming/streaming.ts
+++ b/client/src/app/features/settings/streaming/streaming.ts
@@ -32,6 +32,9 @@ export class StreamingSettingsComponent implements OnInit {
   readonly qsvPreset = signal('faster');
   readonly qsvLowPower = signal(false);
   readonly tonemapAlgo = signal('auto');
+  /** When off, detected black bars are kept instead of cropped — avoids a
+   *  forced re-encode on low-power servers. Default on. */
+  readonly autoCropEnabled = signal(true);
   /** How the "Auto" quality resolves: 'directplay' tries Direct Play first
    *  (zero transcoding when compatible), 'abr' always uses the adaptive HLS
    *  ladder. Explicit quality picks are unaffected. */
@@ -54,6 +57,7 @@ export class StreamingSettingsComponent implements OnInit {
       this.segmentDuration.set(all['streaming_segment_duration'] ?? '3');
       this.qsvPreset.set(all['streaming_qsv_preset'] ?? 'faster');
       this.qsvLowPower.set(all['streaming_qsv_low_power'] === 'true');
+      this.autoCropEnabled.set(all['streaming_auto_crop_enabled'] !== 'false');
       this.autoQualityMode.set(
         all['streaming_auto_quality_mode'] === 'abr' ? 'abr' : 'directplay',
       );
@@ -79,6 +83,7 @@ export class StreamingSettingsComponent implements OnInit {
         streaming_qsv_low_power: String(this.qsvLowPower()),
         streaming_tonemap_algo: this.tonemapAlgo(),
         streaming_auto_quality_mode: this.autoQualityMode(),
+        streaming_auto_crop_enabled: String(this.autoCropEnabled()),
       });
       this.toast.success(this.translate.instant('settings.streaming.saved'));
     } catch { /* interceptor */ }


### PR DESCRIPTION
## Why

Cropping detected black bars (letterbox/pillarbox) forces a **re-encode**: a source that could otherwise Direct Play / remux gets transcoded purely to remove the bars. On low-power servers that's a bad trade.

## What

**Settings → Streaming** toggle *« Recadrage automatique des barres noires »* (`streaming_auto_crop_enabled`, **default on**). When off, black bars are kept and the source plays without a crop-induced re-encode.

## How (gated at every layer)

The toggle (`autoCropEnabled`) flows through `StreamingSettingsCache` → `ActiveStreamTracker`, and gates crop at all three points it would otherwise apply:

1. **Play-method decision** (`stream-builder`): `needsCrop` is false when off → no crop reason forcing transcode → Direct Play / remux.
2. **ffmpeg filter graph** (`session-context-builder`): `SessionContext.crop` is dropped when off → even a session that transcodes **for another reason** keeps the bars instead of cropping. (Without this, the toggle only changed the decision, not the actual crop.)
3. **Stats overlay / response** (`stream-builder` `source.crop`): the playback-info `crop` is reported only when actually applied → the player overlay shows 'Recadrage' and a cropped output resolution **only when a crop really happens**, not whenever cropdetect found bars at import.

## Tests

`session-context-builder.service.spec.ts` gains a case asserting crop is carried when enabled and dropped when disabled; full streaming suite (205) passes; typecheck clean. Default preserves current behaviour.