### PR TITLE
feat(media-detail): mark a season watched from the other-seasons cards

### DIFF
--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -101,6 +101,7 @@
                 [subtitle]="other.episodes.length + ' ' + ('media_detail.episodes' | translate)"
                 [link]="seasonLink(m, other)"
                 [replaceUrl]="true"
+                [extraActions]="seasonCardActions(other)"
               />
             }
           </app-horizontal-scroller>

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -101,8 +101,9 @@
                 [subtitle]="other.episodes.length + ' ' + ('media_detail.episodes' | translate)"
                 [link]="seasonLink(m, other)"
                 [replaceUrl]="true"
+                [interactiveWatched]="true"
                 [status]="seasonFullyWatched(other) ? 'watched' : null"
-                [extraActions]="seasonCardActions(other)"
+                (watchedToggled)="onToggleSeasonWatched(m.id, other, $event)"
               />
             }
           </app-horizontal-scroller>

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -101,6 +101,7 @@
                 [subtitle]="other.episodes.length + ' ' + ('media_detail.episodes' | translate)"
                 [link]="seasonLink(m, other)"
                 [replaceUrl]="true"
+                [status]="seasonFullyWatched(other) ? 'watched' : null"
                 [extraActions]="seasonCardActions(other)"
               />
             }

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -53,7 +53,6 @@ import { MediaDetailLibraryModalComponent } from './components/media-detail-libr
 import { RequestModalComponent } from '../tmdb-preview/components/request-modal/request-modal.component';
 import { HorizontalScrollerComponent } from '../../shared/components/horizontal-scroller';
 import { MediaCardComponent } from '../../shared/components/media-card/media-card';
-import { CardAction } from '../../core/services/card-actions.service';
 import { DownloadQualityModalComponent } from '../../shared/components/download-quality-modal/download-quality-modal';
 import { DownloadManagerService } from '../../core/services/download-manager.service';
 import { DownloadDetailModalComponent } from '../../shared/components/download-detail-modal/download-detail-modal';
@@ -436,27 +435,6 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     return total > 0;
   }
 
-  /** Context-menu actions for an "other seasons" card: mark the whole season
-   *  watched / unwatched. Label flips on the season's current state — partially
-   *  watched still offers "mark watched". */
-  seasonCardActions(season: Season): CardAction[] {
-    const m = this.media();
-    if (!m) return [];
-    const fully = this.seasonFullyWatched(season);
-    return [
-      {
-        labelKey: fully ? 'media_card.mark_unwatched' : 'media_card.mark_watched',
-        icon: fully ? 'eye-off' : 'eye',
-        run: () => {
-          void this.onToggleSeasonWatched(
-            m.id,
-            season,
-            !this.seasonFullyWatched(season),
-          );
-        },
-      },
-    ];
-  }
 
   /**
    * When the focused episode changes on the episode detail page, bring the

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -53,6 +53,7 @@ import { MediaDetailLibraryModalComponent } from './components/media-detail-libr
 import { RequestModalComponent } from '../tmdb-preview/components/request-modal/request-modal.component';
 import { HorizontalScrollerComponent } from '../../shared/components/horizontal-scroller';
 import { MediaCardComponent } from '../../shared/components/media-card/media-card';
+import { CardAction } from '../../core/services/card-actions.service';
 import { DownloadQualityModalComponent } from '../../shared/components/download-quality-modal/download-quality-modal';
 import { DownloadManagerService } from '../../core/services/download-manager.service';
 import { DownloadDetailModalComponent } from '../../shared/components/download-detail-modal/download-detail-modal';
@@ -420,6 +421,43 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     const first = season.episodes?.[0];
     if (!first) return null;
     return ['/series', String(m.id), 'episode', String(first.id)];
+  }
+
+  /** True iff every downloaded episode of `season` is watched. Drives the
+   *  watch/unwatch label on the season card menu. */
+  private seasonFullyWatched(season: Season): boolean {
+    const watched = this.watchedEpisodeIds();
+    let total = 0;
+    for (const ep of season.episodes ?? []) {
+      if (!ep.hasFile) continue;
+      total++;
+      if (!watched.has(ep.id)) return false;
+    }
+    return total > 0;
+  }
+
+  /** Context-menu actions for an "other seasons" card: mark the whole season
+   *  watched / unwatched. Label flips on the season's current state — partially
+   *  watched still offers "mark watched". */
+  seasonCardActions(season: Season): CardAction[] {
+    const m = this.media();
+    if (!m) return [];
+    const fully = this.seasonFullyWatched(season);
+    return [
+      {
+        labelKey: fully
+          ? 'media_detail.mark_season_unwatched'
+          : 'media_detail.mark_season_watched',
+        icon: fully ? 'eye-off' : 'eye',
+        run: () => {
+          void this.onToggleSeasonWatched(
+            m.id,
+            season,
+            !this.seasonFullyWatched(season),
+          );
+        },
+      },
+    ];
   }
 
   /**

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -424,8 +424,8 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   }
 
   /** True iff every downloaded episode of `season` is watched. Drives the
-   *  watch/unwatch label on the season card menu. */
-  private seasonFullyWatched(season: Season): boolean {
+   *  watch/unwatch label on the season card menu and the card's watched badge. */
+  seasonFullyWatched(season: Season): boolean {
     const watched = this.watchedEpisodeIds();
     let total = 0;
     for (const ep of season.episodes ?? []) {
@@ -445,9 +445,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     const fully = this.seasonFullyWatched(season);
     return [
       {
-        labelKey: fully
-          ? 'media_detail.mark_season_unwatched'
-          : 'media_detail.mark_season_watched',
+        labelKey: fully ? 'media_card.mark_unwatched' : 'media_card.mark_watched',
         icon: fully ? 'eye-off' : 'eye',
         run: () => {
           void this.onToggleSeasonWatched(

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -113,6 +113,11 @@ export class MediaCardComponent {
    */
   readonly interactiveWatched = input(false);
 
+  /** Extra context-menu actions the parent injects (e.g. season-level
+   *  mark-watched on the "other seasons" cards). Appended after the built-in
+   *  actions, before the danger "remove" entry. */
+  readonly extraActions = input<CardAction[]>([]);
+
   // Events
   readonly clicked = output<void>();
   readonly played = output<void>();
@@ -366,6 +371,7 @@ export class MediaCardComponent {
         run: () => this.watchedToggled.emit(!watched),
       });
     }
+    actions.push(...this.extraActions());
     if (this.dismissable()) {
       actions.push({
         labelKey: 'media_card.remove_from_list',

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -113,11 +113,6 @@ export class MediaCardComponent {
    */
   readonly interactiveWatched = input(false);
 
-  /** Extra context-menu actions the parent injects (e.g. season-level
-   *  mark-watched on the "other seasons" cards). Appended after the built-in
-   *  actions, before the danger "remove" entry. */
-  readonly extraActions = input<CardAction[]>([]);
-
   // Events
   readonly clicked = output<void>();
   readonly played = output<void>();
@@ -371,7 +366,6 @@ export class MediaCardComponent {
         run: () => this.watchedToggled.emit(!watched),
       });
     }
-    actions.push(...this.extraActions());
     if (this.dismissable()) {
       actions.push({
         labelKey: 'media_card.remove_from_list',


### PR DESCRIPTION
## What

On the media-detail page, the **« Autres saisons de… »** cards now expose a context-menu action (long-press / right-click / ⋯ dropdown) to mark the whole season **watched / unwatched**.

The label reflects the season's current state: a fully-watched season offers *« Marquer la saison comme non vue »*; a partially- or un-watched season offers *« Marquer la saison comme vue »* (so watching only a few episodes still lets you mark the rest).

## How

- `media-card`: new generic `extraActions` input — parent-supplied `CardAction[]` appended to the card's built-in context menu (before the danger "remove" entry).
- `media-detail`: `seasonCardActions(season)` builds the toggle (label/icon from a new `seasonFullyWatched` helper) and runs the existing `onToggleSeasonWatched` → reuses the `toggleSeasonWatched` API and the optimistic `watchedEpisodeIds` update, so the badge/state refresh instantly.
- Reuses existing i18n keys (`media_detail.mark_season_watched` / `mark_season_unwatched`).

## Tests

Client builds (`ng build`). Frontend-only.