### PR TITLE
feat(card-actions): Emby-style header on the card context menu

### DIFF
--- a/client/src/app/core/services/card-actions.service.ts
+++ b/client/src/app/core/services/card-actions.service.ts
@@ -61,6 +61,10 @@ export class CardActionsService {
   readonly placement = signal<CardActionsPlacement>('card');
   /** Title shown at the top of the panel (typically the card title). */
   readonly title = signal<string>('');
+  /** Poster/thumbnail shown in the panel header (Emby-style). Null = none. */
+  readonly imageUrl = signal<string | null>(null);
+  /** Secondary line under the title in the panel header (e.g. year). */
+  readonly subtitle = signal<string>('');
   /** Whether the panel is currently open. */
   readonly open = signal(false);
   readonly hasActions = computed(() => (this.actions()?.length ?? 0) > 0);
@@ -81,11 +85,15 @@ export class CardActionsService {
     actions: CardAction[];
     anchor: HTMLElement;
     title?: string;
+    imageUrl?: string | null;
+    subtitle?: string;
     placement?: CardActionsPlacement;
   }) {
     this.actions.set(payload.actions);
     this.anchor.set(payload.anchor);
     this.title.set(payload.title ?? '');
+    this.imageUrl.set(payload.imageUrl ?? null);
+    this.subtitle.set(payload.subtitle ?? '');
     this.placement.set(payload.placement ?? 'card');
   }
 
@@ -99,6 +107,8 @@ export class CardActionsService {
       this.actions.set(null);
       this.anchor.set(null);
       this.title.set('');
+      this.imageUrl.set(null);
+      this.subtitle.set('');
     }
   }
 

--- a/client/src/app/core/services/card-actions.service.ts
+++ b/client/src/app/core/services/card-actions.service.ts
@@ -61,7 +61,7 @@ export class CardActionsService {
   readonly placement = signal<CardActionsPlacement>('card');
   /** Title shown at the top of the panel (typically the card title). */
   readonly title = signal<string>('');
-  /** Poster/thumbnail shown in the panel header (Emby-style). Null = none. */
+  /** Poster/thumbnail shown in the panel header. Null = none. */
   readonly imageUrl = signal<string | null>(null);
   /** Aspect ratio of the header thumbnail — portrait posters (movie/series/
    *  season) vs landscape stills (episode). */

--- a/client/src/app/core/services/card-actions.service.ts
+++ b/client/src/app/core/services/card-actions.service.ts
@@ -63,6 +63,9 @@ export class CardActionsService {
   readonly title = signal<string>('');
   /** Poster/thumbnail shown in the panel header (Emby-style). Null = none. */
   readonly imageUrl = signal<string | null>(null);
+  /** Aspect ratio of the header thumbnail — portrait posters (movie/series/
+   *  season) vs landscape stills (episode). */
+  readonly imageAspect = signal<'portrait' | 'landscape'>('portrait');
   /** Secondary line under the title in the panel header (e.g. year). */
   readonly subtitle = signal<string>('');
   /** Whether the panel is currently open. */
@@ -86,6 +89,7 @@ export class CardActionsService {
     anchor: HTMLElement;
     title?: string;
     imageUrl?: string | null;
+    imageAspect?: 'portrait' | 'landscape';
     subtitle?: string;
     placement?: CardActionsPlacement;
   }) {
@@ -93,6 +97,7 @@ export class CardActionsService {
     this.anchor.set(payload.anchor);
     this.title.set(payload.title ?? '');
     this.imageUrl.set(payload.imageUrl ?? null);
+    this.imageAspect.set(payload.imageAspect ?? 'portrait');
     this.subtitle.set(payload.subtitle ?? '');
     this.placement.set(payload.placement ?? 'card');
   }
@@ -108,6 +113,7 @@ export class CardActionsService {
       this.anchor.set(null);
       this.title.set('');
       this.imageUrl.set(null);
+      this.imageAspect.set('portrait');
       this.subtitle.set('');
     }
   }

--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
@@ -16,11 +16,12 @@
       <div class="flex items-start gap-3 px-4 py-3 border-b border-base-content/10">
         @if (imageUrl(); as img) {
           <img [src]="img | resolveUrl" alt="" loading="lazy"
-            class="h-12 shrink-0 rounded object-cover bg-base-300"
+            class="shrink-0 rounded object-cover bg-base-300"
+            [style.width.px]="imageAspect() === 'landscape' ? 80 : 44"
             [style.aspect-ratio]="imageAspect() === 'landscape' ? '16 / 9' : '2 / 3'" />
         }
         <div class="min-w-0">
-          <div class="font-semibold line-clamp-2">{{ title() }}</div>
+          <div class="text-sm font-semibold line-clamp-2">{{ title() }}</div>
           @if (subtitle()) {
             <div class="text-xs text-base-content/60 line-clamp-2">{{ subtitle() }}</div>
           }
@@ -68,11 +69,12 @@
         <div class="flex items-start gap-3 px-4 py-3 mb-1 border-b border-white/10">
           @if (imageUrl(); as img) {
             <img [src]="img | resolveUrl" alt="" loading="lazy"
-              class="h-14 shrink-0 rounded object-cover bg-white/10"
+              class="shrink-0 rounded object-cover bg-white/10"
+              [style.width.px]="imageAspect() === 'landscape' ? 92 : 52"
               [style.aspect-ratio]="imageAspect() === 'landscape' ? '16 / 9' : '2 / 3'" />
           }
           <div class="min-w-0">
-            <div class="text-white font-semibold line-clamp-2">{{ title() }}</div>
+            <div class="text-white text-sm font-semibold line-clamp-2">{{ title() }}</div>
             @if (subtitle()) {
               <div class="text-white/60 text-sm line-clamp-2">{{ subtitle() }}</div>
             }

--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
@@ -17,7 +17,7 @@
         @if (imageUrl(); as img) {
           <img [src]="img | resolveUrl" alt="" loading="lazy"
             class="shrink-0 rounded object-cover bg-base-300"
-            [style.width.px]="imageAspect() === 'landscape' ? 80 : 44"
+            [style.width.px]="imageAspect() === 'landscape' ? 80 : 60"
             [style.aspect-ratio]="imageAspect() === 'landscape' ? '16 / 9' : '2 / 3'" />
         }
         <div class="min-w-0">
@@ -70,11 +70,11 @@
           @if (imageUrl(); as img) {
             <img [src]="img | resolveUrl" alt="" loading="lazy"
               class="shrink-0 rounded object-cover bg-white/10"
-              [style.width.px]="imageAspect() === 'landscape' ? 92 : 52"
+              [style.width.px]="imageAspect() === 'landscape' ? 92 : 70"
               [style.aspect-ratio]="imageAspect() === 'landscape' ? '16 / 9' : '2 / 3'" />
           }
           <div class="min-w-0">
-            <div class="text-white text-sm font-semibold line-clamp-2">{{ title() }}</div>
+            <div class="text-white text-base font-semibold line-clamp-2">{{ title() }}</div>
             @if (subtitle()) {
               <div class="text-white/60 text-sm line-clamp-2">{{ subtitle() }}</div>
             }

--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
@@ -13,15 +13,16 @@
     (keydown)="onMenuKey($event)"
   >
     @if (title()) {
-      <div class="flex items-center gap-3 px-4 py-3 border-b border-base-content/10">
+      <div class="flex items-start gap-3 px-4 py-3 border-b border-base-content/10">
         @if (imageUrl(); as img) {
           <img [src]="img | resolveUrl" alt="" loading="lazy"
-            class="h-12 w-9 shrink-0 rounded object-cover bg-base-300" />
+            class="h-12 shrink-0 rounded object-cover bg-base-300"
+            [style.aspect-ratio]="imageAspect() === 'landscape' ? '16 / 9' : '2 / 3'" />
         }
         <div class="min-w-0">
-          <div class="font-semibold truncate">{{ title() }}</div>
+          <div class="font-semibold line-clamp-2">{{ title() }}</div>
           @if (subtitle()) {
-            <div class="text-xs text-base-content/60 truncate">{{ subtitle() }}</div>
+            <div class="text-xs text-base-content/60 line-clamp-2">{{ subtitle() }}</div>
           }
         </div>
       </div>
@@ -64,15 +65,16 @@
   <app-bottom-sheet [open]="service.open()" (closed)="onClose()">
     <div #sheet data-tv-modal class="px-2 pb-2">
       @if (title()) {
-        <div class="flex items-center gap-3 px-4 py-3 mb-1 border-b border-white/10">
+        <div class="flex items-start gap-3 px-4 py-3 mb-1 border-b border-white/10">
           @if (imageUrl(); as img) {
             <img [src]="img | resolveUrl" alt="" loading="lazy"
-              class="h-14 w-10 shrink-0 rounded object-cover bg-white/10" />
+              class="h-14 shrink-0 rounded object-cover bg-white/10"
+              [style.aspect-ratio]="imageAspect() === 'landscape' ? '16 / 9' : '2 / 3'" />
           }
           <div class="min-w-0">
-            <div class="text-white font-semibold truncate">{{ title() }}</div>
+            <div class="text-white font-semibold line-clamp-2">{{ title() }}</div>
             @if (subtitle()) {
-              <div class="text-white/60 text-sm truncate">{{ subtitle() }}</div>
+              <div class="text-white/60 text-sm line-clamp-2">{{ subtitle() }}</div>
             }
           </div>
         </div>

--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
@@ -13,8 +13,17 @@
     (keydown)="onMenuKey($event)"
   >
     @if (title()) {
-      <div class="px-4 pt-3 pb-1 text-xs uppercase tracking-wider text-base-content/60 truncate">
-        {{ title() }}
+      <div class="flex items-center gap-3 px-4 py-3 border-b border-base-content/10">
+        @if (imageUrl(); as img) {
+          <img [src]="img | resolveUrl" alt="" loading="lazy"
+            class="h-12 w-9 shrink-0 rounded object-cover bg-base-300" />
+        }
+        <div class="min-w-0">
+          <div class="font-semibold truncate">{{ title() }}</div>
+          @if (subtitle()) {
+            <div class="text-xs text-base-content/60 truncate">{{ subtitle() }}</div>
+          }
+        </div>
       </div>
     }
     <ul role="menu" class="menu p-2 gap-0.5 w-full">
@@ -55,7 +64,18 @@
   <app-bottom-sheet [open]="service.open()" (closed)="onClose()">
     <div #sheet data-tv-modal class="px-2 pb-2">
       @if (title()) {
-        <div class="px-4 py-2 text-white/60 text-sm font-medium truncate">{{ title() }}</div>
+        <div class="flex items-center gap-3 px-4 py-3 mb-1 border-b border-white/10">
+          @if (imageUrl(); as img) {
+            <img [src]="img | resolveUrl" alt="" loading="lazy"
+              class="h-14 w-10 shrink-0 rounded object-cover bg-white/10" />
+          }
+          <div class="min-w-0">
+            <div class="text-white font-semibold truncate">{{ title() }}</div>
+            @if (subtitle()) {
+              <div class="text-white/60 text-sm truncate">{{ subtitle() }}</div>
+            }
+          </div>
+        </div>
       }
       @for (a of actions(); track a) {
         <button

--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.ts
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.ts
@@ -76,6 +76,7 @@ export class CardActionsPanelComponent {
   readonly actions = computed(() => this.service.actions() ?? []);
   readonly title = this.service.title;
   readonly imageUrl = this.service.imageUrl;
+  readonly imageAspect = this.service.imageAspect;
   readonly subtitle = this.service.subtitle;
   readonly isTv = this.tv.isTv;
   /**

--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.ts
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.ts
@@ -20,6 +20,7 @@ import { CardAction, CardActionsService } from '../../../core/services/card-acti
 import { TvService } from '../../../core/services/tv.service';
 import { DeviceService } from '../../../core/services/device.service';
 import { BottomSheetComponent } from '../bottom-sheet';
+import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 
 /**
  * Singleton panel mounted once at the layout level. Picks its presentation
@@ -39,6 +40,7 @@ import { BottomSheetComponent } from '../bottom-sheet';
   imports: [
     TranslateModule,
     BottomSheetComponent,
+    ResolveUrlPipe,
     LucidePlay,
     LucideExternalLink,
     LucideEye,
@@ -73,6 +75,8 @@ export class CardActionsPanelComponent {
 
   readonly actions = computed(() => this.service.actions() ?? []);
   readonly title = this.service.title;
+  readonly imageUrl = this.service.imageUrl;
+  readonly subtitle = this.service.subtitle;
   readonly isTv = this.tv.isTv;
   /**
    * Anchored dropdown only on desktop with a mouse. TV and touch surfaces

--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -14,6 +14,7 @@
     [appCardActions]="cardActions()"
     [actionsTitle]="_title()"
     [actionsImageUrl]="_img()"
+    [actionsImageAspect]="aspect()"
     [actionsSubtitle]="_subtitle() ?? ''"
     (click)="onCardClick()"
     (keydown.enter)="onCardClick()"

--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -13,6 +13,8 @@
     [attr.aria-label]="_title()"
     [appCardActions]="cardActions()"
     [actionsTitle]="_title()"
+    [actionsImageUrl]="_img()"
+    [actionsSubtitle]="_subtitle() ?? ''"
     (click)="onCardClick()"
     (keydown.enter)="onCardClick()"
     (keydown.space)="onCardClick(); $event.preventDefault()"

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -183,6 +183,7 @@ export class MediaCardComponent {
       anchor: button,
       title: this._title(),
       imageUrl: this._img(),
+      imageAspect: this.aspect(),
       subtitle: this._subtitle(),
       placement: 'button',
     });

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -182,6 +182,8 @@ export class MediaCardComponent {
       actions: this.cardActions(),
       anchor: button,
       title: this._title(),
+      imageUrl: this._img(),
+      subtitle: this._subtitle(),
       placement: 'button',
     });
     this.cardActionsService.show();

--- a/client/src/app/shared/directives/card-actions.directive.ts
+++ b/client/src/app/shared/directives/card-actions.directive.ts
@@ -41,6 +41,8 @@ export class CardActionsDirective implements OnDestroy {
   readonly actionsTitle = input<string>('');
   /** Optional poster/thumbnail shown in the panel header (Emby-style). */
   readonly actionsImageUrl = input<string | null>(null);
+  /** Aspect of the header thumbnail (portrait poster vs landscape still). */
+  readonly actionsImageAspect = input<'portrait' | 'landscape'>('portrait');
   /** Optional secondary line under the title in the panel header (e.g. year). */
   readonly actionsSubtitle = input<string>('');
 
@@ -89,6 +91,7 @@ export class CardActionsDirective implements OnDestroy {
       anchor: this.host.nativeElement,
       title: this.actionsTitle(),
       imageUrl: this.actionsImageUrl(),
+      imageAspect: this.actionsImageAspect(),
       subtitle: this.actionsSubtitle(),
     });
   }
@@ -110,6 +113,7 @@ export class CardActionsDirective implements OnDestroy {
         anchor: this.host.nativeElement,
         title: this.actionsTitle(),
         imageUrl: this.actionsImageUrl(),
+        imageAspect: this.actionsImageAspect(),
         subtitle: this.actionsSubtitle(),
       });
       this.service.show();

--- a/client/src/app/shared/directives/card-actions.directive.ts
+++ b/client/src/app/shared/directives/card-actions.directive.ts
@@ -39,7 +39,7 @@ export class CardActionsDirective implements OnDestroy {
   readonly appCardActions = input<CardAction[] | null | undefined>([]);
   /** Optional title shown atop the panel (typically the card title). */
   readonly actionsTitle = input<string>('');
-  /** Optional poster/thumbnail shown in the panel header (Emby-style). */
+  /** Optional poster/thumbnail shown in the panel header. */
   readonly actionsImageUrl = input<string | null>(null);
   /** Aspect of the header thumbnail (portrait poster vs landscape still). */
   readonly actionsImageAspect = input<'portrait' | 'landscape'>('portrait');

--- a/client/src/app/shared/directives/card-actions.directive.ts
+++ b/client/src/app/shared/directives/card-actions.directive.ts
@@ -39,6 +39,10 @@ export class CardActionsDirective implements OnDestroy {
   readonly appCardActions = input<CardAction[] | null | undefined>([]);
   /** Optional title shown atop the panel (typically the card title). */
   readonly actionsTitle = input<string>('');
+  /** Optional poster/thumbnail shown in the panel header (Emby-style). */
+  readonly actionsImageUrl = input<string | null>(null);
+  /** Optional secondary line under the title in the panel header (e.g. year). */
+  readonly actionsSubtitle = input<string>('');
 
   private longPressTimer: number | null = null;
   private touchStartX = 0;
@@ -84,6 +88,8 @@ export class CardActionsDirective implements OnDestroy {
       actions,
       anchor: this.host.nativeElement,
       title: this.actionsTitle(),
+      imageUrl: this.actionsImageUrl(),
+      subtitle: this.actionsSubtitle(),
     });
   }
 
@@ -103,6 +109,8 @@ export class CardActionsDirective implements OnDestroy {
         actions,
         anchor: this.host.nativeElement,
         title: this.actionsTitle(),
+        imageUrl: this.actionsImageUrl(),
+        subtitle: this.actionsSubtitle(),
       });
       this.service.show();
       this.longPressTimer = null;


### PR DESCRIPTION
## What

The media-card context menu (long-press / right-click / ⋯ dropdown, and the mobile bottom-sheet) now opens with an **Emby-style header**: poster thumbnail + title + subtitle (e.g. year), replacing the bare uppercase title line.

## How

- `CardActionsService`: `register()` now also carries `imageUrl` + `subtitle` (new signals, cleared on `clear()`).
- `CardActionsDirective`: new `actionsImageUrl` / `actionsSubtitle` inputs, forwarded on focus (TV) and long-press (mobile).
- `media-card`: passes its resolved image (`_img()`) and `_subtitle()` to both the directive and the desktop ⋯ trigger.
- `card-actions-panel`: renders the header (thumbnail via `ResolveUrlPipe`, title, subtitle) in both the dropdown and the bottom-sheet.

Applies to every card that uses the shared menu (movies, series, seasons, episodes, …). Frontend-only; `ng build` passes.