### PR TITLE
feat(home): mark a recommendation watched from its card menu

### DIFF
--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -68,6 +68,7 @@
                 [status]="rec.media.available ? null : 'missing'"
                 [playable]="rec.media.available"
                 [dismissable]="true"
+                [extraActions]="recommendationActions(rec)"
                 (played)="playRecommendation(rec)"
                 (dismissed)="dismissRecommendation(rec)"
               />

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -24,6 +24,7 @@ import { BackgroundService } from '../../core/services/background.service';
 import { DisplaySettingsService } from '../../core/services/display-settings.service';
 import { HomeSettingsService } from '../../core/services/home-settings.service';
 import { TvService } from '../../core/services/tv.service';
+import { CardAction } from '../../core/services/card-actions.service';
 import { MediaCardComponent } from '../../shared/components/media-card/media-card';
 import { HorizontalScrollerComponent } from '../../shared/components/horizontal-scroller';
 import { LucideIconComponent } from '../../shared/components/lucide-icon';
@@ -531,6 +532,39 @@ export class HomeComponent implements OnInit, OnDestroy {
       }, false);
     } catch {
       /* error handled by global interceptor */
+    }
+  }
+
+  /** Context-menu action(s) for a recommendation card: just "mark watched".
+   *  Recommendations are pre-filtered to unwatched media, so no inline watched
+   *  indicator is needed — only the menu action that marks it and drops it. */
+  recommendationActions(rec: RecommendationItem): CardAction[] {
+    return [
+      {
+        labelKey: 'media_card.mark_watched',
+        icon: 'eye',
+        run: () => void this.markRecommendationWatched(rec),
+      },
+    ];
+  }
+
+  /** Mark a recommended title watched (series → bulk; movie → its first file,
+   *  fetched on demand since the lean DTO carries no file id) and drop it from
+   *  the list, which is filtered to unwatched titles. */
+  private async markRecommendationWatched(rec: RecommendationItem) {
+    const id = rec.media.id;
+    try {
+      if (rec.media.type === 'series') {
+        await this.streamingApi.toggleSeriesWatched(id, true);
+      } else {
+        const media = await this.mediaService.getOne(id);
+        const fileId = media.files?.[0]?.id;
+        if (!fileId) return;
+        await this.streamingApi.toggleWatched(id, fileId);
+      }
+      this.recommendations.update((list) => list.filter((r) => r.media.id !== id));
+    } catch {
+      /* global error toast */
     }
   }
 

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -112,6 +112,10 @@ export class MediaCardComponent {
    * change, otherwise the click does nothing.
    */
   readonly interactiveWatched = input(false);
+  /** Extra context-menu actions injected by the parent (e.g. "mark watched"
+   *  on recommendation cards). Appended after the built-in actions, before the
+   *  danger "remove" entry. Pure menu actions — no inline indicator. */
+  readonly extraActions = input<CardAction[]>([]);
 
   // Events
   readonly clicked = output<void>();
@@ -369,6 +373,7 @@ export class MediaCardComponent {
         run: () => this.watchedToggled.emit(!watched),
       });
     }
+    actions.push(...this.extraActions());
     if (this.dismissable()) {
       actions.push({
         labelKey: 'media_card.remove_from_list',


### PR DESCRIPTION
## What

Recommendation scroller cards now expose a **« Marquer comme vu »** action in their context menu (long-press / right-click / ⋯).

No inline watched indicator is shown — recommendations are already filtered to unwatched titles, so the only useful affordance is the action itself, which marks the title and drops it from the list.

## How

- Re-introduces media-card's generic `extraActions` input (menu-only actions, no indicator).
- `home.recommendationActions(rec)` injects a single `mark_watched` action; `markRecommendationWatched(rec)` marks it: series via the bulk `toggleSeriesWatched`, movies via `toggleWatched` on their first file (fetched on demand, since the lean recommendation DTO carries no file id), then removes the row.

Reuses the existing `media_card.mark_watched` i18n key. Frontend-only; `ng build` passes.