### PR TITLE
feat(media-detail): recompute intros/outros option in the analyze modal

### DIFF
--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -651,6 +651,8 @@
     "analyze_crop_hint": "Relance la détection des bandes noires (letterbox / pillarbox).",
     "analyze_subtitle_cache": "Reconstruire le cache de sous-titres",
     "analyze_subtitle_cache_hint": "Réextrait les sous-titres embarqués pour accélérer le premier lancement.",
+    "analyze_markers": "Recalculer les intros / outros",
+    "analyze_markers_hint": "Relance la détection automatique des génériques (intro / outro) sur les épisodes.",
     "analyze_apply": "Lancer",
     "analyze_launched": "Analyse lancée.",
     "analyze_launch_error": "Impossible de lancer l'analyse",

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -411,6 +411,19 @@
           <span class="text-xs text-base-content/60">{{ 'media_detail.analyze_subtitle_cache_hint' | translate }}</span>
         </span>
       </label>
+      @if (analyzeShowMarkers()) {
+        <label class="flex items-start gap-3 cursor-pointer" [class.opacity-50]="analyzeOpts().rescan">
+          <input
+            type="checkbox" class="checkbox checkbox-primary mt-0.5"
+            [checked]="analyzeOpts().markers" [disabled]="analyzeOpts().rescan"
+            (change)="setAnalyzeOpt('markers', $any($event.target).checked)"
+          />
+          <span>
+            <span class="font-medium block">{{ 'media_detail.analyze_markers' | translate }}</span>
+            <span class="text-xs text-base-content/60">{{ 'media_detail.analyze_markers_hint' | translate }}</span>
+          </span>
+        </label>
+      }
     </div>
     <div class="modal-action">
       <button type="button" class="btn btn-ghost" (click)="closeAnalyzeModal()">

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -1148,12 +1148,25 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     sprites: boolean;
     crop: boolean;
     subtitleCache: boolean;
-  }>({ rescan: false, sprites: false, crop: false, subtitleCache: false });
+    markers: boolean;
+  }>({
+    rescan: false,
+    sprites: false,
+    crop: false,
+    subtitleCache: false,
+    markers: false,
+  });
 
   readonly analyzeHasSelection = computed(() => {
     const o = this.analyzeOpts();
-    return o.rescan || o.sprites || o.crop || o.subtitleCache;
+    return o.rescan || o.sprites || o.crop || o.subtitleCache || o.markers;
   });
+
+  /** Intro/outro detection is episode-based, so the analyze option only
+   *  applies to series. */
+  readonly analyzeShowMarkers = computed(
+    () => this.media()?.type === 'series',
+  );
 
   /** Refs to the native <dialog>. `showModal()` gives us focus trapping,
    *  Tab cycling and Escape-to-close for free — no manual keydown
@@ -1169,6 +1182,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       sprites: false,
       crop: false,
       subtitleCache: false,
+      markers: false,
     });
     const dlg = this.analyzeDialog()?.nativeElement;
     if (!dlg) return;
@@ -1184,7 +1198,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   }
 
   setAnalyzeOpt(
-    key: 'rescan' | 'sprites' | 'crop' | 'subtitleCache',
+    key: 'rescan' | 'sprites' | 'crop' | 'subtitleCache' | 'markers',
     value: boolean,
   ) {
     this.analyzeOpts.update((o) => ({ ...o, [key]: value }));
@@ -1200,13 +1214,19 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       // redundant because rescan re-runs everything. Hit /rescan alone so
       // the existing SSE event stream still fires.
       if (opts.rescan) {
+        // Rescan already re-runs intro/outro detection on completion.
         await this.mediaService.rescanFiles(m.id);
       } else {
-        await this.mediaService.analyzeMedia(m.id, {
-          sprites: opts.sprites,
-          crop: opts.crop,
-          subtitleCache: opts.subtitleCache,
-        });
+        if (opts.sprites || opts.crop || opts.subtitleCache) {
+          await this.mediaService.analyzeMedia(m.id, {
+            sprites: opts.sprites,
+            crop: opts.crop,
+            subtitleCache: opts.subtitleCache,
+          });
+        }
+        if (opts.markers) {
+          await this.markersApi.detectSeries(m.id);
+        }
       }
       this.toast.success(
         this.translate.instant('media_detail.analyze_launched'),


### PR DESCRIPTION
## What

The media-detail **Analyze** modal gains a **« Recalculer les intros / outros »** option that re-runs the automatic intro/outro marker detection.

Shown **only for series** (markers are episode-based). A full rescan already re-runs detection on completion, so the option sits in the granular (non-rescan) path and is disabled when rescan is ticked, like the other options.

## How

Frontend-only — reuses the existing markers endpoint (`POST /api/markers/series/:id/detect-all`, already called by the header's `detectIntros`). `runAnalyze()` calls `markersApi.detectSeries(id)` when the option is checked, alongside the granular `analyzeMedia` call for the other flags. No backend change (avoids injecting MarkersService into the rescan service).

New i18n keys `media_detail.analyze_markers` / `_hint`. `ng build` passes.