### PR TITLE
feat(search): watched badge + resume progress on library result cards

### DIFF
--- a/backend/src/modules/media/media-service/media-query.service.ts
+++ b/backend/src/modules/media/media-service/media-query.service.ts
@@ -356,7 +356,67 @@ export class MediaQueryService {
       });
     }
 
+    if (userId) await this.attachWatchedProgress(enriched, userId);
+
     return { data: enriched, total };
+  }
+
+  /**
+   * Annotate each result with `watched` (movie completed / series fully
+   * watched) and `progressPercent` (movie resume %, 0 for series). Scoped to
+   * the current page's ids — one bounded query, mirroring
+   * {@link attachEpisodeStats} — so it never scans beyond the rows on screen.
+   */
+  private async attachWatchedProgress(
+    data: Media[],
+    userId: number,
+  ): Promise<void> {
+    if (data.length === 0) return;
+    const ids = data.map((m) => m.id);
+    const rows: { id: number; watched: boolean; progress: number }[] =
+      await this.mediaRepo.query(
+        `SELECT m.id::int AS id,
+           (
+             (m.type = 'movie' AND EXISTS (
+               SELECT 1 FROM playback_states ps
+               WHERE ps."userId" = $1 AND ps."mediaId" = m.id AND ps.completed = true
+             ))
+             OR
+             (m.type = 'series'
+               AND EXISTS (
+                 SELECT 1 FROM seasons s JOIN episodes e ON e."seasonId" = s.id
+                 WHERE s."mediaId" = m.id AND s."seasonNumber" > 0 AND e."hasFile" = true
+               )
+               AND NOT EXISTS (
+                 SELECT 1 FROM seasons s JOIN episodes e ON e."seasonId" = s.id
+                 WHERE s."mediaId" = m.id AND s."seasonNumber" > 0 AND e."hasFile" = true
+                   AND NOT EXISTS (
+                     SELECT 1 FROM playback_states ps2
+                     WHERE ps2."userId" = $1 AND ps2."episodeId" = e.id AND ps2.completed = true
+                   )
+               )
+             )
+           ) AS watched,
+           CASE WHEN m.type = 'movie' THEN COALESCE((
+             SELECT ROUND((ps."positionSeconds" / ps."durationSeconds") * 100)::int
+             FROM playback_states ps
+             WHERE ps."userId" = $1 AND ps."mediaId" = m.id AND ps."episodeId" IS NULL
+               AND ps.completed = false AND ps."durationSeconds" > 0
+             ORDER BY ps."lastPlayedAt" DESC LIMIT 1
+           ), 0) ELSE 0 END AS progress
+         FROM media m
+         WHERE m.id = ANY($2::int[])`,
+        [userId, ids],
+      );
+    const byId = new Map(rows.map((r) => [Number(r.id), r]));
+    for (const m of data) {
+      const r = byId.get(m.id);
+      if (!r) continue;
+      Object.assign(m, {
+        watched: r.watched === true,
+        progressPercent: Number(r.progress) || 0,
+      });
+    }
   }
 
   /**

--- a/client/src/app/core/services/api/media.service.ts
+++ b/client/src/app/core/services/api/media.service.ts
@@ -111,6 +111,11 @@ export interface Media {
   minimumAvailability?: 'announced' | 'inCinemas' | 'released';
   sizeOnDisk?: number;
   episodeStats?: { totalEpisodes: number; downloadedEpisodes: number };
+  /** Fully watched (movie completed / series all-episodes watched). Populated
+   *  by the list endpoint for the current user. */
+  watched?: boolean;
+  /** Resume progress 0-100 (movies only; 0 for series). */
+  progressPercent?: number;
   preferredProvider?: 'tmdb' | 'tvdb' | null;
   imdbId?: string | null;
   metadata?: MediaMetadataBrief | null;

--- a/client/src/app/features/search/search.html
+++ b/client/src/app/features/search/search.html
@@ -60,7 +60,13 @@
         <h2 class="text-lg font-semibold mb-3">{{ 'search.section_library' | translate }}</h2>
         <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 gap-3 sm:gap-4">
           @for (media of state.localResults(); track media.id) {
-            <app-media-card [media]="media" />
+            <app-media-card
+              [media]="media"
+              [status]="media.watched ? 'watched' : null"
+              [progressPercent]="media.watched ? 0 : (media.progressPercent ?? 0)"
+              [interactiveWatched]="canMarkMediaWatched(media)"
+              (watchedToggled)="toggleMediaWatched(media, $event)"
+            />
           }
         </div>
       </div>

--- a/client/src/app/features/search/search.ts
+++ b/client/src/app/features/search/search.ts
@@ -15,7 +15,8 @@ import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
-import { MediaService } from '../../core/services/api/media.service';
+import { MediaService, Media } from '../../core/services/api/media.service';
+import { StreamingApiService } from '../../core/services/api/streaming-api.service';
 import {
   MetadataService,
   MetadataSearchResult,
@@ -48,6 +49,7 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly scrollMemory = inject(ScrollMemoryService);
   private readonly reuseStrategy = inject(CachingReuseStrategy);
   private readonly injector = inject(Injector);
+  private readonly streamingApi = inject(StreamingApiService);
   readonly state = inject(SearchStateService);
 
   readonly searchInput = viewChild<ElementRef<HTMLInputElement>>('searchInput');
@@ -199,6 +201,33 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
   clearQuery() {
     this.state.clear();
     this.searchInput()?.nativeElement.focus();
+  }
+
+  /** Series toggle via the bulk endpoint; movies need a local file. */
+  canMarkMediaWatched(m: Media): boolean {
+    return m.type === 'series' || !!m.files?.length;
+  }
+
+  async toggleMediaWatched(m: Media, watched: boolean) {
+    try {
+      if (m.type === 'series') {
+        await this.streamingApi.toggleSeriesWatched(m.id, watched);
+      } else {
+        const fileId = m.files?.[0]?.id;
+        if (!fileId) return;
+        await this.streamingApi.toggleWatched(m.id, fileId);
+      }
+      // Reflect on the visible card without a refetch.
+      this.state.localResults.update((list) =>
+        list.map((x) =>
+          x.id === m.id
+            ? { ...x, watched, progressPercent: watched ? 0 : x.progressPercent }
+            : x,
+        ),
+      );
+    } catch {
+      /* global error toast */
+    }
   }
 
   private async runSearch() {


### PR DESCRIPTION
## What

Library search-result cards now show a **watched badge**, a **resume progress bar** (movies), and a **mark watched/unwatched** toggle — all from data that ships with the results, no separate global fetch.

## Why this design (perf)

The previous approach reused the library page's `getWatchedMediaIds()` — a **global** query/payload bounded by the user's total watched count, run on the search page even before any search. On a library of several thousand titles that's disproportionate just to annotate a handful of results.

Instead the list endpoint (`MediaQueryService.findAll`) now annotates each row with `watched` + `progressPercent` via **one page-scoped query** (`attachWatchedProgress`, mirroring the existing `attachEpisodeStats`). Cost is bounded by the **result count** (≤ page size), not the library size or watched count — it scales.

- **Movies**: `watched` = a completed playback state; `progressPercent` = resume % from the latest in-progress state.
- **Series**: `watched` = every downloaded episode watched; no progress bar (an episode-fraction would misread as a resume position).

## Frontend

- `Media` gains `watched?` / `progressPercent?`.
- Search cards bind `[status]`, `[progressPercent]` (hidden when watched), `[interactiveWatched]` + `(watchedToggled)`; the toggle updates the row optimistically. The global `getWatchedMediaIds` fetch is removed from the search page.

The fields are populated for any `findAll` consumer (only when authenticated); the library page could later drop its separate watched fetch too (follow-up). Backend typecheck + `ng build` pass.