### PR TITLE
fix(search): prefix-match local search, add watched + progress to cards

### DIFF
--- a/backend/src/modules/media/media-service/media-query.service.ts
+++ b/backend/src/modules/media/media-service/media-query.service.ts
@@ -356,7 +356,67 @@ export class MediaQueryService {
       });
     }
 
+    if (userId) await this.attachWatchedProgress(enriched, userId);
+
     return { data: enriched, total };
+  }
+
+  /**
+   * Annotate each result with `watched` (movie completed / series fully
+   * watched) and `progressPercent` (movie resume %, 0 for series). One query
+   * scoped to the current page's ids — mirrors {@link attachEpisodeStats}, so
+   * cost is bounded by the page, never the library or watched count.
+   */
+  private async attachWatchedProgress(
+    data: Media[],
+    userId: number,
+  ): Promise<void> {
+    if (data.length === 0) return;
+    const ids = data.map((m) => m.id);
+    const rows: { id: number; watched: boolean; progress: number }[] =
+      await this.mediaRepo.query(
+        `SELECT m.id::int AS id,
+           (
+             (m.type = 'movie' AND EXISTS (
+               SELECT 1 FROM playback_states ps
+               WHERE ps."userId" = $1 AND ps."mediaId" = m.id AND ps.completed = true
+             ))
+             OR
+             (m.type = 'series'
+               AND EXISTS (
+                 SELECT 1 FROM seasons s JOIN episodes e ON e."seasonId" = s.id
+                 WHERE s."mediaId" = m.id AND s."seasonNumber" > 0 AND e."hasFile" = true
+               )
+               AND NOT EXISTS (
+                 SELECT 1 FROM seasons s JOIN episodes e ON e."seasonId" = s.id
+                 WHERE s."mediaId" = m.id AND s."seasonNumber" > 0 AND e."hasFile" = true
+                   AND NOT EXISTS (
+                     SELECT 1 FROM playback_states ps2
+                     WHERE ps2."userId" = $1 AND ps2."episodeId" = e.id AND ps2.completed = true
+                   )
+               )
+             )
+           ) AS watched,
+           CASE WHEN m.type = 'movie' THEN COALESCE((
+             SELECT ROUND((ps."positionSeconds" / ps."durationSeconds") * 100)::int
+             FROM playback_states ps
+             WHERE ps."userId" = $1 AND ps."mediaId" = m.id AND ps."episodeId" IS NULL
+               AND ps.completed = false AND ps."durationSeconds" > 0
+             ORDER BY ps."lastPlayedAt" DESC LIMIT 1
+           ), 0) ELSE 0 END AS progress
+         FROM media m
+         WHERE m.id = ANY($2::int[])`,
+        [userId, ids],
+      );
+    const byId = new Map(rows.map((r) => [Number(r.id), r]));
+    for (const m of data) {
+      const r = byId.get(m.id);
+      if (!r) continue;
+      Object.assign(m, {
+        watched: r.watched === true,
+        progressPercent: Number(r.progress) || 0,
+      });
+    }
   }
 
   /**
@@ -993,18 +1053,31 @@ export class MediaQueryService {
     qb: SelectQueryBuilder<Media>,
     searchTerm: string,
   ): void {
-    qb.addSelect(
-      `ts_rank(media."searchVector", plainto_tsquery('french', :q))`,
-      'rank',
-    );
+    // Prefix tsquery (`word:*`) so a partial last word still matches while
+    // typing — `plainto_tsquery` stems whole words, so "impos" would miss
+    // "impossible". Each word is stripped to alphanumerics to keep the
+    // generated tsquery free of operator characters. Falls back to a plain
+    // query when nothing tsquery-able remains.
+    const prefixTsq = searchTerm
+      .trim()
+      .split(/\s+/)
+      .map((w) => w.replace(/[^\p{L}\p{N}]/gu, ''))
+      .filter(Boolean)
+      .map((w) => `${w}:*`)
+      .join(' & ');
+    const tsqExpr = prefixTsq
+      ? `to_tsquery('french', :tsq)`
+      : `plainto_tsquery('french', :q)`;
+
+    qb.addSelect(`ts_rank(media."searchVector", ${tsqExpr})`, 'rank');
     qb.andWhere(
       `(
-        media."searchVector" @@ plainto_tsquery('french', :q)
+        media."searchVector" @@ ${tsqExpr}
         OR media.title ILIKE :like
         OR media."originalTitle" ILIKE :like
         OR similarity(media.title, :q) > 0.8
       )`,
-      { q: searchTerm, like: `%${searchTerm}%` },
+      { q: searchTerm, like: `%${searchTerm}%`, tsq: prefixTsq },
     );
     qb.orderBy('rank', 'DESC');
   }

--- a/backend/src/modules/media/media.controller.ts
+++ b/backend/src/modules/media/media.controller.ts
@@ -96,13 +96,7 @@ export class MediaController {
   async findAll(@Query() query: SearchMediaDto, @CurrentUser() user: User) {
     const accessibleLibraryIds =
       await this.libraries.getAccessibleLibraryIds(user);
-    return this.mediaService.findAll(
-      query,
-      query.excludeWatched || query.onlyWatched || query.requestedByMe
-        ? user?.id
-        : undefined,
-      accessibleLibraryIds,
-    );
+    return this.mediaService.findAll(query, user?.id, accessibleLibraryIds);
   }
 
   @Get('recently-added')

--- a/client/src/app/core/services/api/media.service.ts
+++ b/client/src/app/core/services/api/media.service.ts
@@ -111,6 +111,10 @@ export interface Media {
   minimumAvailability?: 'announced' | 'inCinemas' | 'released';
   sizeOnDisk?: number;
   episodeStats?: { totalEpisodes: number; downloadedEpisodes: number };
+  /** Fully watched (movie completed / series all episodes watched), per user. */
+  watched?: boolean;
+  /** Resume progress 0-100 (movies only; 0 for series). */
+  progressPercent?: number;
   preferredProvider?: 'tmdb' | 'tvdb' | null;
   imdbId?: string | null;
   metadata?: MediaMetadataBrief | null;

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -313,6 +313,7 @@
                 <app-media-card
                   [media]="item"
                   [status]="watchedIds().has(item.id) ? 'watched' : null"
+                  [progressPercent]="item.progressPercent ?? 0"
                   [interactiveWatched]="canMarkMediaWatched(item)"
                   (watchedToggled)="toggleMediaWatched(item, $event)"
                 />
@@ -322,6 +323,7 @@
                 <app-media-card
                   [media]="item"
                   [status]="watchedIds().has(item.id) ? 'watched' : null"
+                  [progressPercent]="item.progressPercent ?? 0"
                   [interactiveWatched]="canMarkMediaWatched(item)"
                   (watchedToggled)="toggleMediaWatched(item, $event)"
                 />

--- a/client/src/app/features/search/search.html
+++ b/client/src/app/features/search/search.html
@@ -60,7 +60,13 @@
         <h2 class="text-lg font-semibold mb-3">{{ 'search.section_library' | translate }}</h2>
         <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 gap-3 sm:gap-4">
           @for (media of state.localResults(); track media.id) {
-            <app-media-card [media]="media" />
+            <app-media-card
+              [media]="media"
+              [status]="media.watched ? 'watched' : null"
+              [progressPercent]="media.watched ? 0 : (media.progressPercent ?? 0)"
+              [interactiveWatched]="canMarkMediaWatched(media)"
+              (watchedToggled)="toggleMediaWatched(media, $event)"
+            />
           }
         </div>
       </div>

--- a/client/src/app/features/search/search.ts
+++ b/client/src/app/features/search/search.ts
@@ -15,7 +15,8 @@ import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
-import { MediaService } from '../../core/services/api/media.service';
+import { MediaService, Media } from '../../core/services/api/media.service';
+import { StreamingApiService } from '../../core/services/api/streaming-api.service';
 import {
   MetadataService,
   MetadataSearchResult,
@@ -48,6 +49,7 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly scrollMemory = inject(ScrollMemoryService);
   private readonly reuseStrategy = inject(CachingReuseStrategy);
   private readonly injector = inject(Injector);
+  private readonly streamingApi = inject(StreamingApiService);
   readonly state = inject(SearchStateService);
 
   readonly searchInput = viewChild<ElementRef<HTMLInputElement>>('searchInput');
@@ -199,6 +201,32 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
   clearQuery() {
     this.state.clear();
     this.searchInput()?.nativeElement.focus();
+  }
+
+  /** Series toggle via the bulk endpoint; movies need a local file. */
+  canMarkMediaWatched(m: Media): boolean {
+    return m.type === 'series' || !!m.files?.length;
+  }
+
+  async toggleMediaWatched(m: Media, watched: boolean) {
+    try {
+      if (m.type === 'series') {
+        await this.streamingApi.toggleSeriesWatched(m.id, watched);
+      } else {
+        const fileId = m.files?.[0]?.id;
+        if (!fileId) return;
+        await this.streamingApi.toggleWatched(m.id, fileId);
+      }
+      this.state.localResults.update((list) =>
+        list.map((x) =>
+          x.id === m.id
+            ? { ...x, watched, progressPercent: watched ? 0 : x.progressPercent }
+            : x,
+        ),
+      );
+    } catch {
+      /* global error toast */
+    }
   }
 
   private async runSearch() {


### PR DESCRIPTION
## Search fix (pre-existing bug)

Local library search used `plainto_tsquery`, which stems whole words. A partial last word while typing (`impos`) didn't match `impossible`, and the `ILIKE '%…%'` fallback missed `Mission : Impossible` (the ` : `). So a query like **"mission impos"** returned only overview hits on unrelated titles (Harry Potter, Mickey 17) while the actual Mission Impossible films — which are in the library — never showed in **Ma bibliothèque**.

Fix: build a **prefix tsquery** (`mission:* & impos:*`, each word stripped to alphanumerics) so as-you-type partial words match; the right titles now rank first. Verified against the DB.

## Watched + progress on cards

`findAll` now annotates each result with `watched` (movie completed / series fully watched) and `progressPercent` (movie resume %), in **one page-scoped query** (`attachWatchedProgress`, mirroring `attachEpisodeStats`) — bounded by the page, not the library or watched count. The controller passes the user unconditionally so the annotation runs.

Surfaced on:
- **Search** result cards: watched badge, movie resume bar, mark-watched toggle (optimistic). Drops the previous global `getWatchedMediaIds` fetch on the search page.
- **Library** cards: resume progress bar (badge already present).

Supersedes #539 (same feature, folded in with the search fix). Backend typecheck + `ng build` pass.