### PR TITLE
fix(spatial-nav): land on first item when changing rows

### DIFF
--- a/client/src/app/core/services/tv-spatial-nav.service.ts
+++ b/client/src/app/core/services/tv-spatial-nav.service.ts
@@ -16,10 +16,9 @@ import { FOCUSABLE_SELECTOR } from './focusable.constants';
  *    `[appTvSection]` (vertical) / `[appTvRow]` (horizontal). Each
  *    directive registers its element here, building a logical tree that
  *    groups focusables by intent. Within an annotated zone the focus
- *    walks the tree (last-active child memorised per container), so
- *    `↓` from the bottom-right card always lands on the next row's
- *    last-focused card — never on a sibling that just happens to be
- *    geometrically closer.
+ *    walks the tree (last-active child memorised per container). A
+ *    vertical step into a new row lands on that row's first item; a
+ *    horizontal step within a row still restores the last-focused card.
  *
  * 2. **Rect-based fallback** — for any focus that lives outside an
  *    annotated container the original three-pass scoring runs (in-line
@@ -522,7 +521,10 @@ export class TvSpatialNavService {
             nextIdx = (nextIdx + children.length) % children.length;
           }
           if (nextIdx >= 0 && nextIdx < children.length) {
-            return this.digDown(children[nextIdx]);
+            // A vertical step crosses into a different row: land on that row's
+            // first item, not wherever focus last sat there. A horizontal step
+            // walks to the literal sibling, so keep the leaf as-is.
+            return this.digDown(children[nextIdx], !horizontal);
           }
         }
       }
@@ -535,7 +537,9 @@ export class TvSpatialNavService {
     // the next logical region.
     if (topMost) {
       const peer = this.findPeerContainer(topMost, dir);
-      if (peer) return this.digDown(peer.el);
+      // Peer bridging only ever fires for up/down (see findPeerContainer), so
+      // entering the peer region lands on its first item.
+      if (peer) return this.digDown(peer.el, true);
     }
     return null;
   }
@@ -589,25 +593,30 @@ export class TvSpatialNavService {
   }
 
   /**
-   * Resolve a navigable child to a focusable leaf. Priority order:
+   * Resolve a navigable child to a focusable leaf. When `preferFirst` is
+   * false (horizontal entry), priority order:
    *   1. The container's remembered activeChild (last-focused memory).
    *   2. A descendant with the `autofocus` attribute — page authors mark
    *      the natural starting point (e.g. the "Reprendre" button on a
    *      detail page) with this, so on first entry we land directly there
    *      instead of crawling DOM-order to whichever focusable comes first.
    *   3. The first navigable child, recursed.
+   * When `preferFirst` is true (vertical entry into a new row/region),
+   * skip memory and autofocus and land on the first navigable child.
    */
-  private digDown(el: HTMLElement): HTMLElement | null {
+  private digDown(el: HTMLElement, preferFirst = false): HTMLElement | null {
     const c = this.containers.get(el);
     if (!c) return el; // it's a leaf focusable
-    if (c.activeChild && c.el.contains(c.activeChild) && isVisibleFocusable(c.activeChild)) {
+    if (!preferFirst && c.activeChild && c.el.contains(c.activeChild) && isVisibleFocusable(c.activeChild)) {
       return c.activeChild;
     }
-    const auto = c.el.querySelector<HTMLElement>('[autofocus]');
-    if (auto && isVisibleFocusable(auto)) return auto;
+    if (!preferFirst) {
+      const auto = c.el.querySelector<HTMLElement>('[autofocus]');
+      if (auto && isVisibleFocusable(auto)) return auto;
+    }
     const children = this.getNavigableChildren(c);
     for (const child of children) {
-      const dug = this.digDown(child);
+      const dug = this.digDown(child, preferFirst);
       if (dug) return dug;
     }
     return null;

--- a/client/src/app/shared/directives/tv-row.directive.ts
+++ b/client/src/app/shared/directives/tv-row.directive.ts
@@ -5,8 +5,8 @@ import { TvService } from '../../core/services/tv.service';
 /**
  * Horizontal-orientation container in the spatial-nav tree. `←/→` step
  * between siblings, `↑/↓` exit the row and propagate to the parent
- * section. Last-active card is remembered, so re-entering the row from
- * above/below lands back on it instead of the first card.
+ * section. Last-active card is remembered for horizontal `←/→` moves;
+ * `↑/↓` into the row from another row lands on the first card.
  *
  * Apply on horizontal scrollers / card lanes:
  *


### PR DESCRIPTION
## Summary
- When navigating vertically between rows (TV D-pad or keyboard arrows), focus now lands on the first item of the target row instead of restoring the last-focused card from a previous visit.
- Horizontal moves within a row keep the existing last-active memory behaviour.

## Test plan
- [ ] On home/library, focus a card mid-row, move down/up to another row → first card of that row is selected
- [ ] Move left/right within a row → focus stays on adjacent cards as before
- [ ] Re-enter a row horizontally after visiting another card in the same row → last-focused card is still restored


Made with [Cursor](https://cursor.com)