### PR TITLE
ci(desktop): sign and notarize the macOS dmg

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -254,6 +254,15 @@ jobs:
           mkdir -p desktop/web
           cp -r client/dist/client/browser/. desktop/web/
 
+      # macOS: stage the App Store Connect API key so electron-builder's notarize
+      # step (notarytool) can authenticate. Same key the iOS App Store build uses.
+      - name: Stage notarization API key (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          KEY_P8: ${{ secrets.APPSTORE_API_KEY_P8_BASE64 }}
+        run: echo "$KEY_P8" | base64 -d > "$RUNNER_TEMP/notary-AuthKey.p8"
+
       # ── Package the installer for this OS ──
       # electron-builder publishes to a Release when GH_TOKEN is set and the ref
       # is a tag; we keep that explicit via the attach step below instead, so we
@@ -267,6 +276,15 @@ jobs:
       - name: Build installer
         working-directory: desktop
         shell: bash
+        # macOS-only signing + notarization env. Empty strings on Linux/Windows
+        # so electron-builder doesn't try to use the mac Developer ID cert as a
+        # Windows Authenticode cert (CSC_LINK is per-platform).
+        env:
+          CSC_LINK: ${{ runner.os == 'macOS' && secrets.MAC_DEVELOPER_ID_CERT_P12_BASE64 || '' }}
+          CSC_KEY_PASSWORD: ${{ runner.os == 'macOS' && secrets.MAC_DEVELOPER_ID_CERT_PASSWORD || '' }}
+          APPLE_API_KEY: ${{ runner.os == 'macOS' && format('{0}/notary-AuthKey.p8', runner.temp) || '' }}
+          APPLE_API_KEY_ID: ${{ runner.os == 'macOS' && secrets.APPSTORE_API_KEY_ID || '' }}
+          APPLE_API_ISSUER: ${{ runner.os == 'macOS' && secrets.APPSTORE_API_ISSUER_ID || '' }}
         run: npm run ${{ matrix.dist_script }} -- --publish never -c.extraMetadata.version=${{ steps.version.outputs.version }}
 
       # ── Upload the installer as a workflow artifact (always) ──

--- a/desktop/build/entitlements.mac.plist
+++ b/desktop/build/entitlements.mac.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Electron/V8 JIT under the hardened runtime (required for notarization). -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <!-- The app dlopen's the vendored libmpv.dylib (+ its bundled deps) and the
+       native addon; allow loading those even if a nested lib's signature isn't
+       the app's Team ID. -->
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -51,12 +51,17 @@ mac:
     - target: dmg
       arch: arm64
   category: public.app-category.entertainment
-  # TODO(signing): hardened runtime + notarization are intentionally omitted for
-  # iteration 1. Unsigned .dmg is fine for internal testing; production needs a
-  # Developer ID cert, CSC_LINK/CSC_KEY_PASSWORD, and notarytool credentials.
-  # NOTE: the vendored libmpv.dylib + its bundled deps are ad-hoc signed; a
-  # hardened-runtime/notarized build will need them signed with the Developer ID
-  # (or the disable-library-validation entitlement).
+  # Developer ID signed + hardened-runtime + notarized. electron-builder signs
+  # every nested Mach-O (the .node addon + the vendored libmpv.dylib & its bundled
+  # deps, overriding their ad-hoc signatures) with the Developer ID cert from
+  # CSC_LINK/CSC_KEY_PASSWORD, then notarizes via notarytool using the App Store
+  # Connect API key (APPLE_API_KEY / _ID / _ISSUER). All env is wired per-OS in
+  # desktop-release.yml so a notarized .dmg opens without the Gatekeeper warning.
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  entitlements: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.plist
+  notarize: true
 win:
   target: [nsis]
   # TODO(signing): Authenticode signing omitted for now (WIN_CSC_LINK/…).


### PR DESCRIPTION
## Why
The unsigned `.dmg` trips Gatekeeper ("Fliks is damaged and can't be opened"), forcing testers to `xattr -dr com.apple.quarantine` by hand.

## Change
Sign the macOS app with the **Developer ID** cert under the **hardened runtime** and **notarize** via notarytool, reusing the App Store Connect API key already used by the iOS build.
- electron-builder re-signs every nested Mach-O (the native addon + the vendored `libmpv.dylib` and its bundled deps, overriding their ad-hoc signatures) with the Developer ID cert.
- `build/entitlements.mac.plist` allows JIT (Electron/V8) and disables library validation for the dlopen'd libmpv.
- Signing env is **scoped to macOS** so the Windows/Linux jobs keep building unsigned as before (`CSC_LINK` is per-platform).

## Required secrets (already added)
- `MAC_DEVELOPER_ID_CERT_P12_BASE64`, `MAC_DEVELOPER_ID_CERT_PASSWORD`
- notarization reuses `APPSTORE_API_KEY_P8_BASE64` / `APPSTORE_API_KEY_ID` / `APPSTORE_API_ISSUER_ID`

🤖 Generated with [Claude Code](https://claude.com/claude-code)