### PR TITLE
ci(ios): keep the login keychain in the signing search list

### DIFF
--- a/.github/workflows/appstore-publish.yml
+++ b/.github/workflows/appstore-publish.yml
@@ -105,7 +105,12 @@ jobs:
           security unlock-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN_PATH"
           security import "$CERT_PATH" -P "$CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PWD" "$KEYCHAIN_PATH"
-          security list-keychain -d user -s "$KEYCHAIN_PATH"
+          # ADD the temp keychain to the search list — don't replace it. Archive
+          # still needs the login keychain so -allowProvisioningUpdates can
+          # create/find the iOS Development cert; the temp keychain only supplies
+          # the (now reused) Apple Distribution cert.
+          security list-keychains -d user -s "$KEYCHAIN_PATH" \
+            $(security list-keychains -d user | sed -e 's/^[[:space:]]*//' -e 's/"//g')
           rm -f "$CERT_PATH"
         working-directory: ${{ github.workspace }}
 


### PR DESCRIPTION
## Why
The cert-import step (#543) **replaced** the keychain search list with the throwaway keychain (Apple Distribution only). The App Store archive then failed:

> error: No signing certificate "iOS Development" found … with a private key

`-allowProvisioningUpdates` needs the **login** keychain to create/find the **iOS Development** cert during archive (the Capacitor project's automatic signing requires one).

## Fix
**Append** the temp keychain to the search list instead of replacing it: Apple **Distribution** is reused from the temp keychain (the original goal — no more regeneration of the capped cert), **Development** stays auto-managed in login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)