### PR TITLE
feat(quick-connect): use the real device name, not the UA model

### DIFF
--- a/client/src/app/core/plugins/desktop-player.bridge.ts
+++ b/client/src/app/core/plugins/desktop-player.bridge.ts
@@ -47,10 +47,11 @@ export interface DesktopPositionInfo {
   buffered: number;
 }
 
-/** Native host OS identity (e.g. { systemName: "macOS 26" }). The browser UA
- *  can't give a real OS version, so the main process resolves it. */
+/** Native host identity. `systemName` = OS name+version ("macOS 26");
+ *  `deviceName` = the user-assigned computer name ("MacBook de Clément"). */
 export interface DesktopSystemInfo {
   systemName: string;
+  deviceName: string;
 }
 
 export type DesktopPlayerState = 'idle' | 'playing' | 'paused' | 'buffering' | 'ended' | 'error';

--- a/client/src/app/core/services/system-info.service.ts
+++ b/client/src/app/core/services/system-info.service.ts
@@ -11,24 +11,31 @@ const MOBILE_OS: Record<string, string> = {
 };
 
 /**
- * Resolves a human host-OS string ("macOS 26", "Windows 11", "iOS 18.5") from
- * the best NATIVE source — the browser UA can't expose a real OS version, so we
- * read it natively where possible and fall back to the UA OS *name* on the web.
+ * Resolves the host's real identity from the best NATIVE source — the browser UA
+ * can't expose a real OS version nor the user-assigned device name, so we read
+ * them natively where possible:
+ *   • systemName — OS name+version ("macOS 26", "Ubuntu 24.04", "iOS 18.5").
+ *   • deviceName — user-assigned machine name ("MacBook de Clément", "Samsung de
+ *     Clément"); '' on web and on iOS without the device-name entitlement.
  *
- * Resolution order: Electron preload bridge → Capacitor `Device.getInfo()` →
- * UA name only. Resolved once at construction into a signal; callers that must
- * have the value before sending it (pairing) should `await ready()` first.
+ * Order: Electron preload bridge → Capacitor `Device.getInfo()` → UA (OS name
+ * only). Resolved once at construction; callers that must have the value before
+ * sending it (pairing) should `await ready()` first.
  */
 @Injectable({ providedIn: 'root' })
 export class SystemInfoService {
   private readonly _systemName = signal('');
+  private readonly _deviceName = signal('');
   private readonly _ready: Promise<void>;
 
   constructor() {
     this._ready = this.resolve()
-      .then((name) => this._systemName.set(name))
+      .then((r) => {
+        this._systemName.set(r.systemName);
+        this._deviceName.set(r.deviceName);
+      })
       .catch(() => {
-        /* leave '' — display falls back to the UA-derived label */
+        /* leave '' — callers fall back to the UA-derived label */
       });
   }
 
@@ -38,34 +45,43 @@ export class SystemInfoService {
     return this._systemName();
   }
 
+  /** User-assigned device/computer name, or '' when unavailable (web, or iOS
+   *  without the device-name entitlement). */
+  deviceName(): string {
+    return this._deviceName();
+  }
+
   /** Resolves once the native lookup has completed (or failed). */
   ready(): Promise<void> {
     return this._ready;
   }
 
-  private async resolve(): Promise<string> {
-    // 1. Electron desktop shell — real OS name + version from the main process.
+  private async resolve(): Promise<{ systemName: string; deviceName: string }> {
+    // 1. Electron desktop shell — real OS + machine name from the main process.
     const bridge = typeof window !== 'undefined' ? window.fliksDesktop : undefined;
     if (bridge?.getSystemInfo) {
       try {
         const info = await bridge.getSystemInfo();
-        if (info?.systemName) return info.systemName;
+        return { systemName: info?.systemName ?? '', deviceName: info?.deviceName ?? '' };
       } catch {
         /* fall through */
       }
     }
-    // 2. Capacitor native (iOS / Android) — Device.getInfo gives a real version.
+    // 2. Capacitor native (iOS / Android) — real version + (Android) device name.
     if (Capacitor.isNativePlatform()) {
       try {
         const info = await Device.getInfo();
         const os = MOBILE_OS[info.operatingSystem] ?? info.operatingSystem;
-        return info.osVersion ? `${os} ${info.osVersion}` : os;
+        return {
+          systemName: info.osVersion ? `${os} ${info.osVersion}` : os,
+          deviceName: info.name ?? '',
+        };
       } catch {
         /* fall through */
       }
     }
-    // 3. Web — OS name only (the UA freezes the version).
+    // 3. Web — OS name only (the UA freezes the version; no device name).
     const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
-    return detectOs(ua) ?? '';
+    return { systemName: detectOs(ua) ?? '', deviceName: '' };
   }
 }

--- a/client/src/app/features/quick-connect/quick-connect-wait.ts
+++ b/client/src/app/features/quick-connect/quick-connect-wait.ts
@@ -71,6 +71,10 @@ export class QuickConnectWaitComponent implements OnInit, OnDestroy {
       // device name itself stays the recognizable getDeviceName() label.
       await this.systemInfo.ready();
       this.systemName.set(this.systemInfo.systemName());
+      // Prefer the real user-assigned device name ("MacBook de Clément") over the
+      // UA-derived model fallback when a native source provides it.
+      const realName = this.systemInfo.deviceName();
+      if (realName) this.deviceName.set(realName);
       const { pairingId, expiresIn } = await this.auth.pairingRequest(
         this.userId,
         this.deviceId,

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -124,6 +124,29 @@ function computeSystemName(): string {
   return process.platform;
 }
 
+// User-assigned machine name ("MacBook de Clément"), resolved natively. Cached.
+let cachedDeviceName: string | null = null;
+function deviceName(): string {
+  if (cachedDeviceName != null) return cachedDeviceName;
+  cachedDeviceName = computeDeviceName();
+  return cachedDeviceName;
+}
+function computeDeviceName(): string {
+  try {
+    if (process.platform === 'darwin') {
+      // The friendly name set in System Settings ("MacBook de Clément"), not the
+      // dotted local hostname.
+      const name = execFileSync('scutil', ['--get', 'ComputerName'], {
+        encoding: 'utf8',
+      }).trim();
+      if (name) return name;
+    }
+  } catch {
+    /* fall through to hostname */
+  }
+  return os.hostname().replace(/\.local$/, '');
+}
+
 function parseTracks(json: string | null): {
   audioTracks: unknown[];
   subtitleTracks: unknown[];
@@ -240,7 +263,10 @@ app.whenReady().then(async () => {
 
   // Available on every platform path (embed / compositor / ui-only) so the
   // renderer can label this device with its real OS + version.
-  ipcMain.handle(IPC.getSystemInfo, () => ({ systemName: systemName() }));
+  ipcMain.handle(IPC.getSystemInfo, () => ({
+    systemName: systemName(),
+    deviceName: deviceName(),
+  }));
 
   const dir = webDir();
   const haveApp = fs.existsSync(path.join(dir, 'index.html'));

--- a/desktop/src/shared/contract.ts
+++ b/desktop/src/shared/contract.ts
@@ -48,11 +48,13 @@ export interface DesktopPositionInfo {
   buffered: number;
 }
 
-/** Host OS identity resolved natively in the main process (the browser UA can't
- *  give a real OS version). `systemName` is a human string like "macOS 26",
- *  "Windows 11" or "Ubuntu 24.04". */
+/** Host identity resolved natively in the main process (the browser UA can't
+ *  give a real OS version nor the machine name). `systemName` is a human OS
+ *  string like "macOS 26" / "Ubuntu 24.04"; `deviceName` is the user-assigned
+ *  computer name like "MacBook de Clément". */
 export interface DesktopSystemInfo {
   systemName: string;
+  deviceName: string;
 }
 
 /** main → renderer event envelope, sent on the single IPC.event channel. */


### PR DESCRIPTION
## Why
Quick-connect showed a UA-derived model ("Chrome — Linux") instead of the recognizable user-assigned device name ("Mac mini de Clément", "Samsung de Clément").

## Change
The UA can't expose the machine name, so resolve it natively (extends the existing `getSystemInfo` bridge with `deviceName`):
- **Electron** → computer name (`scutil --get ComputerName` on macOS, `os.hostname()` elsewhere).
- **Capacitor** → `Device.getInfo().name` (Android device name; iOS needs the device-name entitlement, else falls back).
- **Web** → previous `getDeviceName()` UA label.

`SystemInfoService` now exposes `deviceName()`; the quick-connect waiter prefers it and sends it as the pairing `deviceName`. The OS info line ("Application macOS 26") added previously stays as the second line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)