### PR TITLE
feat(updates): in-app update awareness for desktop and web

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -44,18 +44,29 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Linux ships both .deb (no in-app update — dpkg needs root) and
+          # AppImage (electron-updater self-updates it). macOS ships the .dmg
+          # (first install) plus a .zip (the artifact Squirrel.Mac updates from).
           - os: ubuntu-latest
             label: deb
             dist_script: dist:linux
-            artifact_glob: desktop/release/*.deb
+            artifact_glob: |
+              desktop/release/*.deb
+              desktop/release/*.AppImage
+              desktop/release/latest-linux.yml
           - os: macos-latest
             label: dmg
             dist_script: dist:mac
-            artifact_glob: desktop/release/*.dmg
+            artifact_glob: |
+              desktop/release/*.dmg
+              desktop/release/*.zip
+              desktop/release/latest-mac.yml
           - os: windows-latest
             label: exe
             dist_script: dist:win
-            artifact_glob: desktop/release/*.exe
+            artifact_glob: |
+              desktop/release/*.exe
+              desktop/release/latest.yml
 
     steps:
       - uses: actions/checkout@v6
@@ -264,40 +275,42 @@ jobs:
         run: echo "$KEY_P8" | base64 -d > "$RUNNER_TEMP/notary-AuthKey.p8"
 
       # ── Package the installer for this OS ──
-      # electron-builder publishes to a Release when GH_TOKEN is set and the ref
-      # is a tag; we keep that explicit via the attach step below instead, so we
-      # disable auto-publish here and just produce the artifact.
-      # No GH_TOKEN here: with a token set, electron-builder auto-configures a
-      # GitHub publisher and tries to build auto-update metadata (latest*.yml),
-      # which crashes in computeChannelNames (Cannot read properties of null
-      # reading 'channel'). We don't auto-update via electron-builder — the
-      # release artifacts are attached by the softprops step below — so build
-      # with publishing fully off.
+      # With the github `publish` provider configured in electron-builder.yml,
+      # `--publish always` (tag builds) generates the auto-update metadata
+      # (latest.yml / latest-mac.yml / latest-linux.yml) and uploads it + the
+      # installers to the matching GitHub Release; electron-updater in the app
+      # reads it from there. Non-tag (workflow_dispatch / dev) runs build with
+      # `--publish never` and only produce workflow artifacts. The explicit
+      # provider also fixes the old computeChannelNames crash that happened when
+      # GH_TOKEN was set without a configured publisher.
       - name: Build installer
         working-directory: desktop
         shell: bash
         # macOS-only signing + notarization env. Empty strings on Linux/Windows
         # so electron-builder doesn't try to use the mac Developer ID cert as a
-        # Windows Authenticode cert (CSC_LINK is per-platform).
+        # Windows Authenticode cert (CSC_LINK is per-platform). GH_TOKEN lets
+        # electron-builder publish to the GitHub Release on tag builds.
         env:
           CSC_LINK: ${{ runner.os == 'macOS' && secrets.MAC_DEVELOPER_ID_CERT_P12_BASE64 || '' }}
           CSC_KEY_PASSWORD: ${{ runner.os == 'macOS' && secrets.MAC_DEVELOPER_ID_CERT_PASSWORD || '' }}
           APPLE_API_KEY: ${{ runner.os == 'macOS' && format('{0}/notary-AuthKey.p8', runner.temp) || '' }}
           APPLE_API_KEY_ID: ${{ runner.os == 'macOS' && secrets.APPSTORE_API_KEY_ID || '' }}
           APPLE_API_ISSUER: ${{ runner.os == 'macOS' && secrets.APPSTORE_API_ISSUER_ID || '' }}
-        run: npm run ${{ matrix.dist_script }} -- --publish never -c.extraMetadata.version=${{ steps.version.outputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* || "$GITHUB_REF" == refs/tags/desktop-v* ]]; then
+            publish=always
+          else
+            publish=never
+          fi
+          npm run ${{ matrix.dist_script }} -- --publish "$publish" -c.extraMetadata.version=${{ steps.version.outputs.version }}
 
-      # ── Upload the installer as a workflow artifact (always) ──
+      # ── Upload the installers + update metadata as a workflow artifact ──
+      # On tag builds electron-builder already attached these to the Release; the
+      # workflow artifact is for inspection / non-tag runs.
       - name: Upload installer artifact
         uses: actions/upload-artifact@v4
         with:
           name: fliks-desktop-${{ matrix.label }}-${{ steps.version.outputs.version }}
           path: ${{ matrix.artifact_glob }}
-          if-no-files-found: error
-
-      # ── Attach to the GitHub Release on a desktop tag push ──
-      - name: Attach to GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/desktop-v')
-        uses: softprops/action-gh-release@v3
-        with:
-          files: ${{ matrix.artifact_glob }}
+          if-no-files-found: warn

--- a/backend/src/modules/scheduler/scheduler.module.ts
+++ b/backend/src/modules/scheduler/scheduler.module.ts
@@ -15,6 +15,7 @@ import { CompletionService } from './completion.service';
 import { NamingService } from './naming.service';
 import { BackupService } from './backup.service';
 import { LogBufferService } from './log-buffer.service';
+import { UpdateCheckService } from './update-check.service';
 import { CommandsController } from './commands.controller';
 import { SystemController } from './system.controller';
 import { IndexersModule } from '../indexers/indexers.module';
@@ -79,6 +80,7 @@ import { Library } from '../libraries/entities/library.entity';
     NamingService,
     BackupService,
     LogBufferService,
+    UpdateCheckService,
     SubtitleSchedulerService,
   ],
   exports: [

--- a/backend/src/modules/scheduler/system.controller.spec.ts
+++ b/backend/src/modules/scheduler/system.controller.spec.ts
@@ -97,6 +97,7 @@ describe('SystemController.activeStreams recency filter', () => {
       playbackService as never,
       mediaFileRepo as never,
       {} as never, // episodeRepo
+      {} as never, // updateCheck
     );
 
     return { controller };
@@ -185,6 +186,7 @@ describe('SystemController.sendPlayerCommand', () => {
       {} as never,
       activeStreamTracker as never,
       liveSessions as never,
+      {} as never,
       {} as never,
       {} as never,
       {} as never,

--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -30,6 +30,7 @@ import { User } from '../users/entities/user.entity';
 import { BackupService } from './backup.service';
 import { LogBufferService } from './log-buffer.service';
 import { EventsService } from './events.service';
+import { UpdateCheckService, type UpdateStatus } from './update-check.service';
 import { Observable } from 'rxjs';
 import {
   type HwAccelType,
@@ -196,6 +197,7 @@ export class SystemController {
     private readonly mediaFileRepo: Repository<MediaFile>,
     @InjectRepository(Episode)
     private readonly episodeRepo: Repository<Episode>,
+    private readonly updateCheck: UpdateCheckService,
   ) {}
 
   @Sse('events')
@@ -219,6 +221,12 @@ export class SystemController {
       indexers,
       downloadClients: clients,
     };
+  }
+
+  @Get('update')
+  @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
+  async update(): Promise<UpdateStatus> {
+    return this.updateCheck.getStatus();
   }
 
   private async checkDatabase(): Promise<ServiceStatus> {

--- a/backend/src/modules/scheduler/update-check.service.ts
+++ b/backend/src/modules/scheduler/update-check.service.ts
@@ -1,0 +1,148 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** GitHub repo to poll for releases. Override with FLIKS_GITHUB_REPO for forks
+ *  or test repositories. The repo is public, so the API needs no token. */
+const GITHUB_REPO = process.env.FLIKS_GITHUB_REPO ?? 'fliks-app/fliks';
+
+/** How long a successful GitHub lookup is reused before re-fetching. The latest
+ *  release changes at most a few times a month, so a long TTL keeps the app off
+ *  GitHub's unauthenticated rate limit (60 req/h per IP) while staying fresh. */
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+
+/** Cap the GitHub request so a slow or unreachable api.github.com never stalls
+ *  the /system/update response. */
+const FETCH_TIMEOUT_MS = 5000;
+
+const CURRENT_VERSION: string = (() => {
+  try {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'),
+    ) as { version?: string };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+})();
+
+export interface UpdateStatus {
+  currentVersion: string;
+  latestVersion: string | null;
+  updateAvailable: boolean;
+  releaseUrl: string | null;
+  releaseNotes: string | null;
+  publishedAt: string | null;
+}
+
+interface GithubRelease {
+  tag_name?: string;
+  name?: string;
+  html_url?: string;
+  body?: string;
+  published_at?: string;
+  draft?: boolean;
+  prerelease?: boolean;
+}
+
+/** Parse a "1.12.3" / "v1.12.3" string into numeric components, dropping any
+ *  pre-release/build suffix. Returns null when nothing numeric can be read. */
+function parseVersion(raw: string | null | undefined): number[] | null {
+  if (!raw) return null;
+  const core = raw.trim().replace(/^v/i, '').split(/[-+]/)[0];
+  const parts = core.split('.').map((p) => Number.parseInt(p, 10));
+  if (parts.length === 0 || parts.some((n) => Number.isNaN(n))) return null;
+  return parts;
+}
+
+/** True when `latest` is strictly greater than `current` (semantic order). */
+function isNewer(latest: string | null, current: string): boolean {
+  const a = parseVersion(latest);
+  const b = parseVersion(current);
+  if (!a || !b) return false;
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const l = a[i] ?? 0;
+    const c = b[i] ?? 0;
+    if (l > c) return true;
+    if (l < c) return false;
+  }
+  return false;
+}
+
+/** Resolves whether a newer Fliks release than the running server exists by
+ *  polling the public GitHub releases API. Used by /system/update so the web
+ *  client can tell an admin their server is behind the latest release. */
+@Injectable()
+export class UpdateCheckService {
+  private readonly logger = new Logger(UpdateCheckService.name);
+  private cache: { status: UpdateStatus; fetchedAt: number } | null = null;
+
+  /** The version baked into the running server's package.json. */
+  get currentVersion(): string {
+    return CURRENT_VERSION;
+  }
+
+  async getStatus(): Promise<UpdateStatus> {
+    if (this.cache && Date.now() - this.cache.fetchedAt < CACHE_TTL_MS) {
+      return this.cache.status;
+    }
+
+    const status = await this.fetchStatus();
+    // Only cache a real lookup; a failed fetch falls back to "no update known"
+    // without poisoning the cache, so the next call retries.
+    if (status.latestVersion !== null) {
+      this.cache = { status, fetchedAt: Date.now() };
+    }
+    return status;
+  }
+
+  private async fetchStatus(): Promise<UpdateStatus> {
+    const fallback: UpdateStatus = {
+      currentVersion: CURRENT_VERSION,
+      latestVersion: null,
+      updateAvailable: false,
+      releaseUrl: null,
+      releaseNotes: null,
+      publishedAt: null,
+    };
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+      const res = await fetch(
+        `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`,
+        {
+          headers: {
+            Accept: 'application/vnd.github+json',
+            'User-Agent': 'fliks-server',
+          },
+          signal: controller.signal,
+        },
+      );
+      if (!res.ok) {
+        this.logger.warn(`GitHub release lookup failed: HTTP ${res.status}`);
+        return fallback;
+      }
+      const release = (await res.json()) as GithubRelease;
+      if (release.draft) return fallback;
+
+      const latestVersion = release.tag_name ?? release.name ?? null;
+      return {
+        currentVersion: CURRENT_VERSION,
+        latestVersion,
+        updateAvailable: isNewer(latestVersion, CURRENT_VERSION),
+        releaseUrl: release.html_url ?? null,
+        releaseNotes: release.body ?? null,
+        publishedAt: release.published_at ?? null,
+      };
+    } catch (e) {
+      this.logger.warn(
+        `GitHub release lookup error: ${(e as Error).message}`,
+      );
+      return fallback;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/backend/src/modules/scheduler/update-check.service.ts
+++ b/backend/src/modules/scheduler/update-check.service.ts
@@ -12,8 +12,10 @@ const GITHUB_REPO = process.env.FLIKS_GITHUB_REPO ?? 'fliks-app/fliks';
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 
 /** Cap the GitHub request so a slow or unreachable api.github.com never stalls
- *  the /system/update response. */
-const FETCH_TIMEOUT_MS = 5000;
+ *  the /system/update response. Generous enough to absorb a cold TLS handshake
+ *  (observed >10s on a first connection) — the call is async + cached 6h, so a
+ *  long ceiling only ever affects the single cold-cache request. */
+const FETCH_TIMEOUT_MS = 15000;
 
 const CURRENT_VERSION: string = (() => {
   try {

--- a/backend/src/modules/scheduler/update-check.service.ts
+++ b/backend/src/modules/scheduler/update-check.service.ts
@@ -2,19 +2,10 @@ import { Injectable, Logger } from '@nestjs/common';
 import * as fs from 'fs';
 import * as path from 'path';
 
-/** GitHub repo to poll for releases. Override with FLIKS_GITHUB_REPO for forks
- *  or test repositories. The repo is public, so the API needs no token. */
+// Public repo (no token needed); overridable for forks / test repos.
 const GITHUB_REPO = process.env.FLIKS_GITHUB_REPO ?? 'fliks-app/fliks';
-
-/** How long a successful GitHub lookup is reused before re-fetching. The latest
- *  release changes at most a few times a month, so a long TTL keeps the app off
- *  GitHub's unauthenticated rate limit (60 req/h per IP) while staying fresh. */
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
-
-/** Cap the GitHub request so a slow or unreachable api.github.com never stalls
- *  the /system/update response. Generous enough to absorb a cold TLS handshake
- *  (observed >10s on a first connection) — the call is async + cached 6h, so a
- *  long ceiling only ever affects the single cold-cache request. */
+// Generous ceiling for a cold TLS handshake; the call is async + cached.
 const FETCH_TIMEOUT_MS = 15000;
 
 const CURRENT_VERSION: string = (() => {
@@ -47,8 +38,7 @@ interface GithubRelease {
   prerelease?: boolean;
 }
 
-/** Parse a "1.12.3" / "v1.12.3" string into numeric components, dropping any
- *  pre-release/build suffix. Returns null when nothing numeric can be read. */
+/** "1.12.3" / "v1.12.3" → numeric parts, dropping any pre-release/build suffix. */
 function parseVersion(raw: string | null | undefined): number[] | null {
   if (!raw) return null;
   const core = raw.trim().replace(/^v/i, '').split(/[-+]/)[0];
@@ -57,7 +47,6 @@ function parseVersion(raw: string | null | undefined): number[] | null {
   return parts;
 }
 
-/** True when `latest` is strictly greater than `current` (semantic order). */
 function isNewer(latest: string | null, current: string): boolean {
   const a = parseVersion(latest);
   const b = parseVersion(current);
@@ -72,15 +61,13 @@ function isNewer(latest: string | null, current: string): boolean {
   return false;
 }
 
-/** Resolves whether a newer Fliks release than the running server exists by
- *  polling the public GitHub releases API. Used by /system/update so the web
- *  client can tell an admin their server is behind the latest release. */
+/** Tells whether a newer Fliks release than the running server exists, by
+ *  polling the public GitHub releases API. Backs /system/update. */
 @Injectable()
 export class UpdateCheckService {
   private readonly logger = new Logger(UpdateCheckService.name);
   private cache: { status: UpdateStatus; fetchedAt: number } | null = null;
 
-  /** The version baked into the running server's package.json. */
   get currentVersion(): string {
     return CURRENT_VERSION;
   }
@@ -89,10 +76,8 @@ export class UpdateCheckService {
     if (this.cache && Date.now() - this.cache.fetchedAt < CACHE_TTL_MS) {
       return this.cache.status;
     }
-
     const status = await this.fetchStatus();
-    // Only cache a real lookup; a failed fetch falls back to "no update known"
-    // without poisoning the cache, so the next call retries.
+    // Don't cache a failed lookup, so the next call retries.
     if (status.latestVersion !== null) {
       this.cache = { status, fetchedAt: Date.now() };
     }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -32,6 +32,7 @@
         "@ngx-translate/http-loader": "^17.0.0",
         "@tailwindcss/postcss": "^4.2.2",
         "daisyui": "^5.5.19",
+        "marked": "^14.1.4",
         "postcss": "^8.5.8",
         "rxjs": "~7.8.0",
         "shaka-player": "^5.0.9",
@@ -13485,6 +13486,18 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.4.tgz",
+      "integrity": "sha512-vkVZ8ONmUdPnjCKc5uTRvmkRbx4EAi2OkTOXmfTDhZz3OFqMNBM1oTTWwTr4HY4uAEojhzPf+Fy8F1DWa3Sndg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {

--- a/client/package.json
+++ b/client/package.json
@@ -46,6 +46,7 @@
     "@ngx-translate/http-loader": "^17.0.0",
     "@tailwindcss/postcss": "^4.2.2",
     "daisyui": "^5.5.19",
+    "marked": "^14.1.4",
     "postcss": "^8.5.8",
     "rxjs": "~7.8.0",
     "shaka-player": "^5.0.9",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1979,5 +1979,16 @@
     "reset": "Réinitialiser",
     "reset_confirm_title": "Réinitialiser les zones",
     "reset_confirm": "Remettre l'ordre et la visibilité des zones de l'accueil par défaut ?"
+  },
+  "update": {
+    "title": "Mise à jour disponible",
+    "version_transition": "Version {{current}} → {{next}}",
+    "version_available": "Version {{version}}",
+    "no_notes": "Aucune note de version disponible.",
+    "downloading": "Téléchargement… {{percent}} %",
+    "installing": "Installation et redémarrage…",
+    "install": "Installer",
+    "open_release": "Voir la version",
+    "error": "Échec de la mise à jour"
   }
 }

--- a/client/src/app/core/plugins/desktop-updater.bridge.ts
+++ b/client/src/app/core/plugins/desktop-updater.bridge.ts
@@ -1,0 +1,46 @@
+// Bridge to the Electron desktop shell's in-app updater, exposed on
+// `window.fliksUpdater` by the desktop preload. The Angular AppUpdateService
+// consumes this to drive the update button + changelog modal. Types mirror
+// desktop/src/shared/contract.ts (the two live in separate build workspaces).
+
+export interface DesktopUpdateInfo {
+  version: string;
+  releaseName: string | null;
+  releaseNotes: string | null;
+  releaseDate: string | null;
+  releaseUrl: string | null;
+}
+
+export type DesktopUpdateStatus =
+  | { state: 'idle' }
+  | { state: 'checking' }
+  | { state: 'available'; info: DesktopUpdateInfo }
+  | { state: 'not-available' }
+  | { state: 'downloading'; percent: number }
+  | { state: 'downloaded'; info: DesktopUpdateInfo }
+  | { state: 'error'; message: string };
+
+export interface DesktopUpdateCapability {
+  canInstall: boolean;
+  currentVersion: string;
+  releasesUrl: string;
+}
+
+export interface FliksUpdaterApi {
+  getCapability(): Promise<DesktopUpdateCapability>;
+  check(): Promise<void>;
+  install(): Promise<void>;
+  openReleases(): Promise<void>;
+  onStatus(handler: (status: DesktopUpdateStatus) => void): () => void;
+}
+
+declare global {
+  interface Window {
+    fliksUpdater?: FliksUpdaterApi;
+  }
+}
+
+/** The desktop updater bridge, or null when not running in the Electron shell. */
+export function desktopUpdaterOrNull(): FliksUpdaterApi | null {
+  return typeof window !== 'undefined' ? (window.fliksUpdater ?? null) : null;
+}

--- a/client/src/app/core/services/app-update.service.ts
+++ b/client/src/app/core/services/app-update.service.ts
@@ -8,11 +8,8 @@ import {
   type DesktopUpdateStatus,
 } from '../plugins/desktop-updater.bridge';
 
-/** Where the "update available" signal comes from:
- *  - `desktop` — the Electron app updates itself (electron-updater / download).
- *  - `server`  — the connected server is behind the latest GitHub release
- *               (admin-only, informational; the server is updated out of band).
- *  - `none`    — nothing to surface (regular web user, or no update). */
+/** `desktop` = the Electron app updates itself; `server` = the connected
+ *  server is behind the latest release (admin-only, informational); `none`. */
 export type UpdateMode = 'desktop' | 'server' | 'none';
 
 export type UpdateState =
@@ -40,9 +37,8 @@ interface ServerUpdateStatus {
   publishedAt: string | null;
 }
 
-/** Drives the in-app update affordance (the topbar button + changelog modal).
- *  On the desktop app it wraps the Electron updater bridge; on web/mobile it
- *  surfaces "your server is behind the latest release" to admins only. */
+/** Drives the topbar update button + changelog modal: wraps the Electron
+ *  updater on desktop, or the admin-only server-version check on web/mobile. */
 @Injectable({ providedIn: 'root' })
 export class AppUpdateService {
   private readonly device = inject(DeviceService);
@@ -60,14 +56,13 @@ export class AppUpdateService {
   readonly state = signal<UpdateState>('idle');
   readonly info = signal<UpdateInfoView | null>(null);
   readonly progress = signal(0);
-  /** Whether the desktop build can self-install (false for .deb / dev → the
-   *  modal offers a download link instead). Always false in server mode. */
+  /** False for .deb / dev (→ download link) and always false in server mode. */
   readonly canInstall = signal(false);
   readonly currentVersion = signal<string | null>(null);
   readonly releasesUrl = signal<string | null>(null);
   readonly errorMessage = signal<string | null>(null);
 
-  /** The single gate for showing the topbar update button. */
+  /** Gate for showing the topbar update button. */
   readonly available = computed(
     () => this.state() === 'available' || this.state() === 'downloaded',
   );
@@ -77,9 +72,7 @@ export class AppUpdateService {
   constructor() {
     if (this.desktop) this.wireDesktop();
 
-    // Server-mode check runs once the user is known to be an admin. It re-runs
-    // if admin status flips (e.g. after login) but only the first successful
-    // fetch matters — the server version doesn't change mid-session.
+    // Server-mode check fires once the user is known to be an admin.
     effect(() => {
       if (this.mode() === 'server' && !this.serverChecked) {
         this.serverChecked = true;
@@ -98,8 +91,7 @@ export class AppUpdateService {
     }
   }
 
-  /** Apply the update. Desktop+installable → download & relaunch; otherwise
-   *  open the releases page / the server's release notes externally. */
+  /** Desktop+installable → download & relaunch; otherwise open the release. */
   async install(): Promise<void> {
     if (this.mode() === 'desktop' && this.desktop) {
       if (this.canInstall()) {
@@ -125,8 +117,6 @@ export class AppUpdateService {
       .catch(() => undefined);
 
     updater.onStatus((status) => this.applyDesktopStatus(status));
-    // Kick a check so the button can appear without waiting for the main
-    // process's own initial timer.
     void updater.check().catch(() => undefined);
   }
 
@@ -172,8 +162,7 @@ export class AppUpdateService {
         this.state.set('not-available');
       }
     } catch {
-      // A failed check is silent — no button, no toast (the global interceptor
-      // already toasts hard errors; a missed update check shouldn't nag).
+      // A failed check is silent — no button, no toast.
       this.state.set('error');
     }
   }

--- a/client/src/app/core/services/app-update.service.ts
+++ b/client/src/app/core/services/app-update.service.ts
@@ -1,0 +1,180 @@
+import { Injectable, computed, effect, inject, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { DeviceService } from './device.service';
+import { AuthService } from './auth.service';
+import {
+  desktopUpdaterOrNull,
+  type DesktopUpdateStatus,
+} from '../plugins/desktop-updater.bridge';
+
+/** Where the "update available" signal comes from:
+ *  - `desktop` — the Electron app updates itself (electron-updater / download).
+ *  - `server`  — the connected server is behind the latest GitHub release
+ *               (admin-only, informational; the server is updated out of band).
+ *  - `none`    — nothing to surface (regular web user, or no update). */
+export type UpdateMode = 'desktop' | 'server' | 'none';
+
+export type UpdateState =
+  | 'idle'
+  | 'checking'
+  | 'available'
+  | 'not-available'
+  | 'downloading'
+  | 'downloaded'
+  | 'error';
+
+export interface UpdateInfoView {
+  version: string;
+  releaseNotes: string | null;
+  releaseUrl: string | null;
+  releaseDate: string | null;
+}
+
+interface ServerUpdateStatus {
+  currentVersion: string;
+  latestVersion: string | null;
+  updateAvailable: boolean;
+  releaseUrl: string | null;
+  releaseNotes: string | null;
+  publishedAt: string | null;
+}
+
+/** Drives the in-app update affordance (the topbar button + changelog modal).
+ *  On the desktop app it wraps the Electron updater bridge; on web/mobile it
+ *  surfaces "your server is behind the latest release" to admins only. */
+@Injectable({ providedIn: 'root' })
+export class AppUpdateService {
+  private readonly device = inject(DeviceService);
+  private readonly auth = inject(AuthService);
+  private readonly http = inject(HttpClient);
+
+  private readonly desktop = desktopUpdaterOrNull();
+
+  readonly mode = computed<UpdateMode>(() => {
+    if (this.device.isDesktopNative() && this.desktop) return 'desktop';
+    if (this.auth.canAccessSettings()) return 'server';
+    return 'none';
+  });
+
+  readonly state = signal<UpdateState>('idle');
+  readonly info = signal<UpdateInfoView | null>(null);
+  readonly progress = signal(0);
+  /** Whether the desktop build can self-install (false for .deb / dev → the
+   *  modal offers a download link instead). Always false in server mode. */
+  readonly canInstall = signal(false);
+  readonly currentVersion = signal<string | null>(null);
+  readonly releasesUrl = signal<string | null>(null);
+  readonly errorMessage = signal<string | null>(null);
+
+  /** The single gate for showing the topbar update button. */
+  readonly available = computed(
+    () => this.state() === 'available' || this.state() === 'downloaded',
+  );
+
+  private serverChecked = false;
+
+  constructor() {
+    if (this.desktop) this.wireDesktop();
+
+    // Server-mode check runs once the user is known to be an admin. It re-runs
+    // if admin status flips (e.g. after login) but only the first successful
+    // fetch matters — the server version doesn't change mid-session.
+    effect(() => {
+      if (this.mode() === 'server' && !this.serverChecked) {
+        this.serverChecked = true;
+        void this.checkServer();
+      }
+    });
+  }
+
+  /** Trigger a fresh check (used by a manual "check for updates" action). */
+  async check(): Promise<void> {
+    if (this.mode() === 'desktop') {
+      await this.desktop?.check();
+    } else if (this.mode() === 'server') {
+      this.serverChecked = true;
+      await this.checkServer();
+    }
+  }
+
+  /** Apply the update. Desktop+installable → download & relaunch; otherwise
+   *  open the releases page / the server's release notes externally. */
+  async install(): Promise<void> {
+    if (this.mode() === 'desktop' && this.desktop) {
+      if (this.canInstall()) {
+        await this.desktop.install();
+      } else {
+        await this.desktop.openReleases();
+      }
+      return;
+    }
+    const url = this.info()?.releaseUrl ?? this.releasesUrl();
+    if (url) window.open(url, '_blank', 'noopener');
+  }
+
+  private wireDesktop(): void {
+    const updater = this.desktop!;
+    void updater
+      .getCapability()
+      .then((cap) => {
+        this.canInstall.set(cap.canInstall);
+        this.currentVersion.set(cap.currentVersion);
+        this.releasesUrl.set(cap.releasesUrl);
+      })
+      .catch(() => undefined);
+
+    updater.onStatus((status) => this.applyDesktopStatus(status));
+    // Kick a check so the button can appear without waiting for the main
+    // process's own initial timer.
+    void updater.check().catch(() => undefined);
+  }
+
+  private applyDesktopStatus(status: DesktopUpdateStatus): void {
+    this.state.set(status.state);
+    switch (status.state) {
+      case 'available':
+      case 'downloaded':
+        this.info.set({
+          version: status.info.version,
+          releaseNotes: status.info.releaseNotes,
+          releaseUrl: status.info.releaseUrl,
+          releaseDate: status.info.releaseDate,
+        });
+        this.errorMessage.set(null);
+        break;
+      case 'downloading':
+        this.progress.set(status.percent);
+        break;
+      case 'error':
+        this.errorMessage.set(status.message);
+        break;
+    }
+  }
+
+  private async checkServer(): Promise<void> {
+    this.state.set('checking');
+    try {
+      const status = await firstValueFrom(
+        this.http.get<ServerUpdateStatus>('/api/system/update'),
+      );
+      this.currentVersion.set(status.currentVersion);
+      this.releasesUrl.set(status.releaseUrl);
+      if (status.updateAvailable && status.latestVersion) {
+        this.info.set({
+          version: status.latestVersion.replace(/^v/i, ''),
+          releaseNotes: status.releaseNotes,
+          releaseUrl: status.releaseUrl,
+          releaseDate: status.publishedAt,
+        });
+        this.state.set('available');
+      } else {
+        this.state.set('not-available');
+      }
+    } catch {
+      // A failed check is silent — no button, no toast (the global interceptor
+      // already toasts hard errors; a missed update check shouldn't nag).
+      this.state.set('error');
+    }
+  }
+}

--- a/client/src/app/shared/components/app-update-modal/app-update-modal.html
+++ b/client/src/app/shared/components/app-update-modal/app-update-modal.html
@@ -1,0 +1,70 @@
+<dialog #dialog class="modal">
+  <div class="modal-box max-w-lg">
+    <form method="dialog">
+      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+    </form>
+
+    <div class="flex items-center gap-2 mb-1">
+      <svg lucideRocket class="h-5 w-5 text-primary"></svg>
+      <h3 class="text-lg font-bold">{{ 'update.title' | translate }}</h3>
+    </div>
+
+    @if (update.info(); as info) {
+      <p class="text-sm opacity-70 mb-3">
+        @if (update.currentVersion(); as current) {
+          {{ 'update.version_transition' | translate: { current: current, next: info.version } }}
+        } @else {
+          {{ 'update.version_available' | translate: { version: info.version } }}
+        }
+        @if (info.releaseDate) {
+          · {{ info.releaseDate | date: 'mediumDate' }}
+        }
+      </p>
+
+      <div class="rounded-box bg-base-200 p-3 max-h-72 overflow-y-auto mb-4">
+        @if (info.releaseNotes) {
+          <pre class="whitespace-pre-wrap break-words text-sm font-sans">{{ info.releaseNotes }}</pre>
+        } @else {
+          <p class="text-sm opacity-60">{{ 'update.no_notes' | translate }}</p>
+        }
+      </div>
+
+      @if (downloading()) {
+        <div class="mb-4">
+          <progress class="progress progress-primary w-full" [value]="update.progress()" max="100"></progress>
+          <p class="text-xs opacity-70 mt-1 text-center">
+            {{ 'update.downloading' | translate: { percent: update.progress() } }}
+          </p>
+        </div>
+      } @else if (update.errorMessage(); as err) {
+        <p class="text-sm text-error mb-3">{{ 'update.error' | translate }}: {{ err }}</p>
+      }
+
+      <div class="modal-action">
+        <form method="dialog">
+          <button class="btn btn-ghost">{{ 'common.close' | translate }}</button>
+        </form>
+
+        @if (installing()) {
+          <button class="btn btn-primary" disabled>
+            <span class="loading loading-spinner loading-sm"></span>
+            {{ 'update.installing' | translate }}
+          </button>
+        } @else if (canInstallInApp()) {
+          <button class="btn btn-primary" [disabled]="downloading()" (click)="onAction()">
+            <svg lucideDownload class="h-4 w-4"></svg>
+            {{ 'update.install' | translate }}
+          </button>
+        } @else {
+          <button class="btn btn-primary" (click)="onAction()">
+            <svg lucideExternalLink class="h-4 w-4"></svg>
+            {{ 'update.open_release' | translate }}
+          </button>
+        }
+      </div>
+    }
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>{{ 'common.close' | translate }}</button>
+  </form>
+</dialog>

--- a/client/src/app/shared/components/app-update-modal/app-update-modal.html
+++ b/client/src/app/shared/components/app-update-modal/app-update-modal.html
@@ -23,7 +23,7 @@
 
       <div class="rounded-box bg-base-200 p-3 max-h-72 overflow-y-auto mb-4">
         @if (info.releaseNotes) {
-          <pre class="whitespace-pre-wrap break-words text-sm font-sans">{{ info.releaseNotes }}</pre>
+          <div class="changelog-md text-sm break-words" [innerHTML]="info.releaseNotes | markdown"></div>
         } @else {
           <p class="text-sm opacity-60">{{ 'update.no_notes' | translate }}</p>
         }

--- a/client/src/app/shared/components/app-update-modal/app-update-modal.ts
+++ b/client/src/app/shared/components/app-update-modal/app-update-modal.ts
@@ -10,15 +10,31 @@ import { DatePipe } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { LucideDownload, LucideExternalLink, LucideRocket } from '@lucide/angular';
 import { AppUpdateService } from '../../../core/services/app-update.service';
+import { MarkdownPipe } from '../../pipes/markdown.pipe';
 
 /** Changelog + install dialog for the topbar update button. Reads everything
  *  from AppUpdateService; the action adapts to the platform (in-app install on
  *  desktop, external release link on web/.deb). */
 @Component({
   selector: 'app-update-modal',
-  imports: [DatePipe, TranslateModule, LucideDownload, LucideExternalLink, LucideRocket],
+  imports: [DatePipe, TranslateModule, MarkdownPipe, LucideDownload, LucideExternalLink, LucideRocket],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './app-update-modal.html',
+  styles: [
+    `
+      .changelog-md h1, .changelog-md h2, .changelog-md h3 { font-weight: 700; margin: 0.75rem 0 0.35rem; line-height: 1.3; }
+      .changelog-md h1 { font-size: 1.05rem; }
+      .changelog-md h2 { font-size: 1rem; }
+      .changelog-md h3 { font-size: 0.9rem; opacity: 0.85; }
+      .changelog-md > :first-child { margin-top: 0; }
+      .changelog-md ul, .changelog-md ol { padding-left: 1.25rem; margin: 0.35rem 0; list-style: revert; }
+      .changelog-md li { margin: 0.15rem 0; }
+      .changelog-md p { margin: 0.4rem 0; }
+      .changelog-md a { color: var(--color-primary); text-decoration: underline; }
+      .changelog-md code { font-family: monospace; background: rgba(127, 127, 127, 0.18); padding: 0 0.25rem; border-radius: 0.25rem; }
+      .changelog-md hr { margin: 0.6rem 0; border-color: rgba(127, 127, 127, 0.3); }
+    `,
+  ],
 })
 export class AppUpdateModalComponent {
   readonly update = inject(AppUpdateService);

--- a/client/src/app/shared/components/app-update-modal/app-update-modal.ts
+++ b/client/src/app/shared/components/app-update-modal/app-update-modal.ts
@@ -1,0 +1,50 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  computed,
+  inject,
+  viewChild,
+} from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
+import { LucideDownload, LucideExternalLink, LucideRocket } from '@lucide/angular';
+import { AppUpdateService } from '../../../core/services/app-update.service';
+
+/** Changelog + install dialog for the topbar update button. Reads everything
+ *  from AppUpdateService; the action adapts to the platform (in-app install on
+ *  desktop, external release link on web/.deb). */
+@Component({
+  selector: 'app-update-modal',
+  imports: [DatePipe, TranslateModule, LucideDownload, LucideExternalLink, LucideRocket],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './app-update-modal.html',
+})
+export class AppUpdateModalComponent {
+  readonly update = inject(AppUpdateService);
+
+  private readonly dialog = viewChild<ElementRef<HTMLDialogElement>>('dialog');
+
+  /** True while the desktop app is downloading the update. */
+  readonly downloading = computed(() => this.update.state() === 'downloading');
+  /** True once downloaded — the app is about to relaunch to apply it. */
+  readonly installing = computed(() => this.update.state() === 'downloaded');
+
+  /** Desktop builds that can self-install show "Install"; everything else
+   *  (server mode, .deb, dev) shows an external "open release" link. */
+  readonly canInstallInApp = computed(
+    () => this.update.mode() === 'desktop' && this.update.canInstall(),
+  );
+
+  open(): void {
+    this.dialog()?.nativeElement.showModal();
+  }
+
+  close(): void {
+    this.dialog()?.nativeElement.close();
+  }
+
+  onAction(): void {
+    void this.update.install();
+  }
+}

--- a/client/src/app/shared/components/app-update-modal/app-update-modal.ts
+++ b/client/src/app/shared/components/app-update-modal/app-update-modal.ts
@@ -22,17 +22,22 @@ import { MarkdownPipe } from '../../pipes/markdown.pipe';
   templateUrl: './app-update-modal.html',
   styles: [
     `
-      .changelog-md h1, .changelog-md h2, .changelog-md h3 { font-weight: 700; margin: 0.75rem 0 0.35rem; line-height: 1.3; }
-      .changelog-md h1 { font-size: 1.05rem; }
-      .changelog-md h2 { font-size: 1rem; }
-      .changelog-md h3 { font-size: 0.9rem; opacity: 0.85; }
-      .changelog-md > :first-child { margin-top: 0; }
-      .changelog-md ul, .changelog-md ol { padding-left: 1.25rem; margin: 0.35rem 0; list-style: revert; }
-      .changelog-md li { margin: 0.15rem 0; }
-      .changelog-md p { margin: 0.4rem 0; }
-      .changelog-md a { color: var(--color-primary); text-decoration: underline; }
-      .changelog-md code { font-family: monospace; background: rgba(127, 127, 127, 0.18); padding: 0 0.25rem; border-radius: 0.25rem; }
-      .changelog-md hr { margin: 0.6rem 0; border-color: rgba(127, 127, 127, 0.3); }
+      /* ::ng-deep — the changelog HTML is injected via [innerHTML], so it
+         carries no encapsulation attribute and plain component styles miss it. */
+      :host ::ng-deep .changelog-md { line-height: 1.55; }
+      :host ::ng-deep .changelog-md > :first-child { margin-top: 0; }
+      :host ::ng-deep .changelog-md h1,
+      :host ::ng-deep .changelog-md h2 { font-size: 1.1rem; font-weight: 700; margin: 1rem 0 0.45rem; }
+      :host ::ng-deep .changelog-md h3 { font-size: 0.95rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em; opacity: 0.75; margin: 0.9rem 0 0.35rem; }
+      :host ::ng-deep .changelog-md ul,
+      :host ::ng-deep .changelog-md ol { list-style: disc; padding-left: 1.4rem; margin: 0.4rem 0; }
+      :host ::ng-deep .changelog-md ol { list-style: decimal; }
+      :host ::ng-deep .changelog-md li { margin: 0.3rem 0; padding-left: 0.15rem; }
+      :host ::ng-deep .changelog-md li::marker { color: var(--color-primary); }
+      :host ::ng-deep .changelog-md p { margin: 0.5rem 0; }
+      :host ::ng-deep .changelog-md a { color: var(--color-primary); text-decoration: underline; }
+      :host ::ng-deep .changelog-md code { font-family: monospace; font-size: 0.85em; background: rgba(127, 127, 127, 0.18); padding: 0.05rem 0.3rem; border-radius: 0.25rem; }
+      :host ::ng-deep .changelog-md hr { margin: 0.75rem 0; border: 0; border-top: 1px solid rgba(127, 127, 127, 0.3); }
     `,
   ],
 })

--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -69,6 +69,15 @@
         }
       </div>
       <div class="flex-none flex items-center gap-1 md:gap-1.5">
+        @if (appUpdate.available()) {
+          <button class="btn btn-ghost btn-circle" (click)="openUpdateModal()"
+                  [attr.aria-label]="'update.title' | translate">
+            <div class="indicator">
+              <span class="indicator-item badge badge-xs badge-primary"></span>
+              <svg lucideRocket class="h-5 w-5 md:h-6 md:w-6"></svg>
+            </div>
+          </button>
+        }
         @if (castPlayer.hasMedia()) {
           <button class="btn btn-ghost btn-sm gap-1" (click)="toggleCastOverlay()">
             <svg lucideCast class="h-5 w-5 text-info"></svg>
@@ -81,15 +90,6 @@
             } @else {
               <svg lucideCast class="h-5 w-5 md:h-6 md:w-6" [class.text-info]="castService.isConnected()"></svg>
             }
-          </button>
-        }
-        @if (appUpdate.available()) {
-          <button class="btn btn-ghost btn-circle" (click)="openUpdateModal()"
-                  [attr.aria-label]="'update.title' | translate">
-            <div class="indicator">
-              <span class="indicator-item badge badge-xs badge-primary"></span>
-              <svg lucideRocket class="h-5 w-5 md:h-6 md:w-6"></svg>
-            </div>
           </button>
         }
         <app-user-menu />
@@ -129,6 +129,15 @@
       </div>
       <!-- Cast + user (right) -->
       <div class="flex items-center gap-1.5">
+        @if (appUpdate.available()) {
+          <button class="btn btn-ghost btn-circle" (click)="openUpdateModal()"
+                  [attr.aria-label]="'update.title' | translate">
+            <div class="indicator">
+              <span class="indicator-item badge badge-xs badge-primary"></span>
+              <svg lucideRocket class="h-5 w-5 md:h-6 md:w-6"></svg>
+            </div>
+          </button>
+        }
         @if (castPlayer.hasMedia()) {
           <button class="btn btn-ghost btn-sm gap-2" (click)="toggleCastOverlay()">
             <svg lucideCast class="h-5 w-5 text-info"></svg>
@@ -141,15 +150,6 @@
             } @else {
               <svg lucideCast class="h-5 w-5 md:h-6 md:w-6" [class.text-info]="castService.isConnected()"></svg>
             }
-          </button>
-        }
-        @if (appUpdate.available()) {
-          <button class="btn btn-ghost btn-circle" (click)="openUpdateModal()"
-                  [attr.aria-label]="'update.title' | translate">
-            <div class="indicator">
-              <span class="indicator-item badge badge-xs badge-primary"></span>
-              <svg lucideRocket class="h-5 w-5 md:h-6 md:w-6"></svg>
-            </div>
           </button>
         }
         <app-user-menu />

--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -83,6 +83,15 @@
             }
           </button>
         }
+        @if (appUpdate.available()) {
+          <button class="btn btn-ghost btn-circle" (click)="openUpdateModal()"
+                  [attr.aria-label]="'update.title' | translate">
+            <div class="indicator">
+              <span class="indicator-item badge badge-xs badge-primary"></span>
+              <svg lucideRocket class="h-5 w-5 md:h-6 md:w-6"></svg>
+            </div>
+          </button>
+        }
         <app-user-menu />
       </div>
     </nav>
@@ -132,6 +141,15 @@
             } @else {
               <svg lucideCast class="h-5 w-5 md:h-6 md:w-6" [class.text-info]="castService.isConnected()"></svg>
             }
+          </button>
+        }
+        @if (appUpdate.available()) {
+          <button class="btn btn-ghost btn-circle" (click)="openUpdateModal()"
+                  [attr.aria-label]="'update.title' | translate">
+            <div class="indicator">
+              <span class="indicator-item badge badge-xs badge-primary"></span>
+              <svg lucideRocket class="h-5 w-5 md:h-6 md:w-6"></svg>
+            </div>
           </button>
         }
         <app-user-menu />
@@ -259,6 +277,9 @@
         }
     }
   </div>
+
+  <!-- App-update changelog + install dialog (opened from the topbar button) -->
+  <app-update-modal />
 
   <!-- Cast overlay (chip + card) — global, persists across navigation -->
   <app-cast-overlay />

--- a/client/src/app/shared/layout/layout.ts
+++ b/client/src/app/shared/layout/layout.ts
@@ -8,6 +8,7 @@ import {
   OnInit,
   OnDestroy,
   DestroyRef,
+  viewChild,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Title } from '@angular/platform-browser';
@@ -31,6 +32,8 @@ import { NetworkService } from '../../core/services/network.service';
 import { CastOverlayComponent } from '../cast-overlay/cast-overlay';
 import { CardActionsPanelComponent } from '../components/card-actions-panel/card-actions-panel';
 import { UserMenuComponent } from '../components/user-menu';
+import { AppUpdateModalComponent } from '../components/app-update-modal/app-update-modal';
+import { AppUpdateService } from '../../core/services/app-update.service';
 import { LucideIconComponent } from '../components/lucide-icon';
 import { TvRowDirective } from '../directives/tv-row.directive';
 import { BackgroundComponent } from '../components/background/background';
@@ -50,6 +53,7 @@ import {
   LucideEllipsisVertical,
   LucideUsers,
   LucidePin,
+  LucideRocket,
 } from '@lucide/angular';
 
 
@@ -59,10 +63,11 @@ import {
     RouterOutlet, RouterLink, RouterLinkActive, TranslateModule,
     LucideMenu, LucideChevronLeft, LucideHome, LucideSearch,
     LucideClipboardList, LucideDownload, LucideCalendar, LucideCast,
-    LucideHistory, LucideEllipsisVertical, LucideUsers, LucidePin,
+    LucideHistory, LucideEllipsisVertical, LucideUsers, LucidePin, LucideRocket,
     CastOverlayComponent,
     CardActionsPanelComponent,
     UserMenuComponent,
+    AppUpdateModalComponent,
     LucideIconComponent,
     TvRowDirective,
     BackgroundComponent,
@@ -88,7 +93,13 @@ export class LayoutComponent implements OnInit, OnDestroy {
   readonly tv = inject(TvService);
   readonly device = inject(DeviceService);
   readonly castPlayer = inject(CastPlayerService);
+  readonly appUpdate = inject(AppUpdateService);
+  private readonly updateModal = viewChild(AppUpdateModalComponent);
   private readonly title = inject(Title);
+
+  openUpdateModal(): void {
+    this.updateModal()?.open();
+  }
   private readonly translate = inject(TranslateService);
   private readonly destroyRef = inject(DestroyRef);
   /** Bumps when language changes so the document title effect re-reads `app.name`. */

--- a/client/src/app/shared/pipes/markdown.pipe.ts
+++ b/client/src/app/shared/pipes/markdown.pipe.ts
@@ -1,0 +1,14 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { marked } from 'marked';
+
+/** Renders a markdown string to HTML (e.g. GitHub release notes). Bind the
+ *  result with `[innerHTML]` — Angular sanitizes it. Links get target=_blank
+ *  so a click doesn't navigate the app/webview away. */
+@Pipe({ name: 'markdown' })
+export class MarkdownPipe implements PipeTransform {
+  transform(value: string | null | undefined): string {
+    if (!value) return '';
+    const html = marked.parse(value, { async: false, gfm: true }) as string;
+    return html.replace(/<a /g, '<a target="_blank" rel="noopener noreferrer" ');
+  }
+}

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -20,6 +20,17 @@ productName: Fliks
 # Fliks-Server-<ver>-<arch>.dmg); both attach to the same release-please v*
 # release, so a shared filename would overwrite. e.g. Fliks-Client-1.2.3-x64.dmg.
 artifactName: ${productName}-Client-${version}-${arch}.${ext}
+# In-app auto-update source. With an explicit github provider, `--publish always`
+# (set on tag builds in desktop-release.yml) generates the update metadata
+# (latest.yml / latest-mac.yml / latest-linux.yml) and uploads it + the installers
+# to the matching GitHub Release; electron-updater in the app reads it from here.
+# The repo is public, so clients need no token. Declaring the provider also fixes
+# the earlier computeChannelNames crash that happened when a GH_TOKEN was present
+# without a configured publisher.
+publish:
+  provider: github
+  owner: fliks-app
+  repo: fliks
 directories:
   output: release
   buildResources: build
@@ -47,8 +58,13 @@ mac:
   # arm64 (Apple Silicon) only for this iteration. The vendored libmpv.dylib +
   # the native addon are built arm64 (see desktop-release.yml); a universal build
   # would need a lipo'd dylib + an x64 addon. Revisit for Intel support.
+  # dmg = first-install image; zip = the artifact Squirrel.Mac auto-updates from
+  # (electron-updater can't update from a .dmg). Both are arm64 and signed +
+  # notarized; latest-mac.yml references the zip.
   target:
     - target: dmg
+      arch: arm64
+    - target: zip
       arch: arm64
   category: public.app-category.entertainment
   # Developer ID signed + hardened-runtime + notarized. electron-builder signs

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,15 @@
 {
   "name": "fliks-desktop",
-  "version": "1.11.0",
+  "version": "1.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fliks-desktop",
-      "version": "1.11.0",
+      "version": "1.12.3",
+      "dependencies": {
+        "electron-updater": "^6.8.9"
+      },
       "devDependencies": {
         "@types/node": "^25.9.3",
         "electron": "^42.4.0",
@@ -1282,7 +1285,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/asn1js": {
@@ -1438,7 +1440,6 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
       "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -1697,7 +1698,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2005,6 +2005,34 @@
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "mime": "^2.5.2"
+      }
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/electron-winstaller": {
@@ -2351,7 +2379,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -2577,7 +2604,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -2799,7 +2825,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
       "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2857,7 +2882,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -2880,7 +2904,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash": {
@@ -2888,6 +2911,19 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lowercase-keys": {
@@ -3057,7 +3093,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-abi": {
@@ -3581,7 +3616,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -3834,6 +3868,12 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -3937,7 +3977,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -9,18 +9,21 @@
   "main": "dist/main/index.cjs",
   "scripts": {
     "typecheck": "tsc -p tsconfig.json",
-    "build:main": "esbuild src/main/index.ts --bundle --platform=node --target=node20 --format=cjs --external:electron --outfile=dist/main/index.cjs",
+    "build:main": "esbuild src/main/index.ts --bundle --platform=node --target=node20 --format=cjs --external:electron --external:electron-updater --outfile=dist/main/index.cjs",
     "build:preload": "esbuild src/preload/index.ts --bundle --platform=node --target=node20 --format=cjs --external:electron --outfile=dist/preload/index.cjs",
     "build": "npm run build:main && npm run build:preload",
     "start": "npm run build && electron .",
     "dev:linux": "bash scripts/dev-linux.sh",
     "dist": "electron-builder",
-    "dist:linux": "electron-builder --linux deb",
-    "dist:mac": "electron-builder --mac dmg",
+    "dist:linux": "electron-builder --linux AppImage deb",
+    "dist:mac": "electron-builder --mac dmg zip",
     "dist:win": "electron-builder --win nsis"
   },
   "engines": {
     "node": ">=20"
+  },
+  "dependencies": {
+    "electron-updater": "^6.8.9"
   },
   "devDependencies": {
     "@types/node": "^25.9.3",

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -6,6 +6,7 @@ import { execFileSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { registerAppSchemePrivileged, registerAppProtocol, APP_URL } from './protocol';
 import { installCorsBypass } from './cors';
+import { setupUpdater } from './updater';
 import { IPC, type DesktopEvent, type DesktopSubtitleStyle } from '../shared/contract';
 import { mpvSubtitleProps } from './mpv/subtitle-style';
 
@@ -267,6 +268,11 @@ app.whenReady().then(async () => {
     systemName: systemName(),
     deviceName: deviceName(),
   }));
+
+  // In-app updater (electron-updater on installable builds, GitHub-release
+  // detect-only on .deb/dev). Registered on every platform path so the renderer
+  // can always query capability + listen for status.
+  setupUpdater();
 
   const dir = webDir();
   const haveApp = fs.existsSync(path.join(dir, 'index.html'));

--- a/desktop/src/main/updater.ts
+++ b/desktop/src/main/updater.ts
@@ -1,0 +1,199 @@
+import { app, BrowserWindow, ipcMain, shell } from 'electron';
+import electronUpdater from 'electron-updater';
+import {
+  UPDATE_IPC,
+  type DesktopUpdateCapability,
+  type DesktopUpdateInfo,
+  type DesktopUpdateStatus,
+} from '../shared/contract';
+
+const { autoUpdater } = electronUpdater;
+
+// Public repo → the GitHub releases API and page need no token. Overridable for
+// forks / test repos (mirrors the backend's FLIKS_GITHUB_REPO).
+const GITHUB_REPO = process.env.FLIKS_GITHUB_REPO ?? 'fliks-app/fliks';
+const RELEASES_URL = `https://github.com/${GITHUB_REPO}/releases`;
+
+// Re-check periodically while the app stays open, plus once shortly after launch.
+const INITIAL_CHECK_DELAY_MS = 10_000;
+const PERIODIC_CHECK_MS = 6 * 60 * 60 * 1000;
+
+/** electron-updater can self-install only from an NSIS exe (Windows), a signed
+ *  .app via a zip (macOS), or an AppImage (Linux). A .deb has no in-place update
+ *  path (dpkg needs root), and dev runs aren't packaged. Those fall back to a
+ *  "download from the releases page" flow. */
+function canSelfInstall(): boolean {
+  if (!app.isPackaged) return false;
+  if (process.platform === 'linux') return !!process.env.APPIMAGE;
+  return true;
+}
+
+function capability(): DesktopUpdateCapability {
+  return {
+    canInstall: canSelfInstall(),
+    currentVersion: app.getVersion(),
+    releasesUrl: RELEASES_URL,
+  };
+}
+
+/** electron-updater's release notes can be a string or an array of
+ *  {version, note} blocks (fullChangelog). Flatten to plain text/HTML. */
+function normalizeNotes(notes: unknown): string | null {
+  if (!notes) return null;
+  if (typeof notes === 'string') return notes;
+  if (Array.isArray(notes)) {
+    return notes
+      .map((n) => (n && typeof n === 'object' && 'note' in n ? String((n as { note: unknown }).note ?? '') : ''))
+      .filter(Boolean)
+      .join('\n\n');
+  }
+  return null;
+}
+
+/**
+ * Wires the in-app updater: registers the renderer-invokable channels
+ * (check/install/openReleases/getCapability) and broadcasts status updates so
+ * the Angular AppUpdateService can drive the update button + modal.
+ *
+ * On installable builds it uses electron-updater (autoDownload off so the user
+ * confirms in the modal); on a .deb or in dev it does a lightweight GitHub
+ * release lookup just to surface availability + a download link.
+ */
+export function setupUpdater(): void {
+  const installable = canSelfInstall();
+
+  const broadcast = (status: DesktopUpdateStatus): void => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed()) win.webContents.send(UPDATE_IPC.status, status);
+    }
+  };
+
+  ipcMain.handle(UPDATE_IPC.getCapability, () => capability());
+  ipcMain.handle(UPDATE_IPC.openReleases, () => shell.openExternal(RELEASES_URL));
+
+  if (installable) {
+    autoUpdater.autoDownload = false;
+    autoUpdater.autoInstallOnAppQuit = true;
+    // Differential downloads pull in lzma-native (a native module that isn't
+    // bundled); full-file downloads avoid it and are fine for our installer sizes.
+    autoUpdater.disableDifferentialDownload = true;
+
+    const toInfo = (u: electronUpdater.UpdateInfo): DesktopUpdateInfo => ({
+      version: u.version,
+      releaseName: u.releaseName ?? null,
+      releaseNotes: normalizeNotes(u.releaseNotes),
+      releaseDate: u.releaseDate ?? null,
+      releaseUrl: `${RELEASES_URL}/tag/v${u.version}`,
+    });
+
+    autoUpdater.on('checking-for-update', () => broadcast({ state: 'checking' }));
+    autoUpdater.on('update-available', (u) => broadcast({ state: 'available', info: toInfo(u) }));
+    autoUpdater.on('update-not-available', () => broadcast({ state: 'not-available' }));
+    autoUpdater.on('download-progress', (p) =>
+      broadcast({ state: 'downloading', percent: Math.round(p.percent) }),
+    );
+    autoUpdater.on('update-downloaded', (u) => {
+      broadcast({ state: 'downloaded', info: toInfo(u) });
+      // Quit and apply the update. autoInstallOnAppQuit also covers a normal quit.
+      autoUpdater.quitAndInstall();
+    });
+    autoUpdater.on('error', (e) =>
+      broadcast({ state: 'error', message: e?.message ?? String(e) }),
+    );
+
+    ipcMain.handle(UPDATE_IPC.check, () =>
+      autoUpdater.checkForUpdates().catch((e) => {
+        broadcast({ state: 'error', message: (e as Error)?.message ?? String(e) });
+      }),
+    );
+    ipcMain.handle(UPDATE_IPC.install, () =>
+      autoUpdater.downloadUpdate().catch((e) => {
+        broadcast({ state: 'error', message: (e as Error)?.message ?? String(e) });
+      }),
+    );
+  } else {
+    // .deb / dev: detect-only via the public GitHub release, install = open page.
+    ipcMain.handle(UPDATE_IPC.check, () => githubFallbackCheck(broadcast));
+    ipcMain.handle(UPDATE_IPC.install, () => shell.openExternal(RELEASES_URL));
+  }
+
+  // Kick an initial check shortly after launch, then on a long interval.
+  const check = (): void => {
+    const fn = installable ? () => autoUpdater.checkForUpdates() : () => githubFallbackCheck(broadcast);
+    Promise.resolve(fn()).catch((e) =>
+      console.warn('[updater] check failed', (e as Error)?.message ?? e),
+    );
+  };
+  setTimeout(check, INITIAL_CHECK_DELAY_MS);
+  setInterval(check, PERIODIC_CHECK_MS);
+}
+
+function parseVersion(raw: string | null | undefined): number[] | null {
+  if (!raw) return null;
+  const core = raw.trim().replace(/^v/i, '').split(/[-+]/)[0];
+  const parts = core.split('.').map((p) => Number.parseInt(p, 10));
+  if (parts.length === 0 || parts.some((n) => Number.isNaN(n))) return null;
+  return parts;
+}
+
+function isNewer(latest: string | null, current: string): boolean {
+  const a = parseVersion(latest);
+  const b = parseVersion(current);
+  if (!a || !b) return false;
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const l = a[i] ?? 0;
+    const c = b[i] ?? 0;
+    if (l > c) return true;
+    if (l < c) return false;
+  }
+  return false;
+}
+
+/** Detect-only update check for builds electron-updater can't self-install. */
+async function githubFallbackCheck(
+  broadcast: (s: DesktopUpdateStatus) => void,
+): Promise<void> {
+  broadcast({ state: 'checking' });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5000);
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`,
+      {
+        headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'fliks-desktop' },
+        signal: controller.signal,
+      },
+    );
+    if (!res.ok) {
+      broadcast({ state: 'not-available' });
+      return;
+    }
+    const release = (await res.json()) as {
+      tag_name?: string;
+      name?: string;
+      html_url?: string;
+      body?: string;
+      published_at?: string;
+    };
+    const latest = release.tag_name ?? release.name ?? null;
+    if (isNewer(latest, app.getVersion())) {
+      broadcast({
+        state: 'available',
+        info: {
+          version: (latest ?? '').replace(/^v/i, ''),
+          releaseName: release.name ?? null,
+          releaseNotes: release.body ?? null,
+          releaseDate: release.published_at ?? null,
+          releaseUrl: release.html_url ?? RELEASES_URL,
+        },
+      });
+    } else {
+      broadcast({ state: 'not-available' });
+    }
+  } catch (e) {
+    broadcast({ state: 'error', message: (e as Error)?.message ?? String(e) });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/desktop/src/main/updater.ts
+++ b/desktop/src/main/updater.ts
@@ -156,7 +156,9 @@ async function githubFallbackCheck(
 ): Promise<void> {
   broadcast({ state: 'checking' });
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 5000);
+  // Generous ceiling for a cold TLS handshake to api.github.com (the check is
+  // async + retried on the periodic timer, so a long timeout is harmless).
+  const timer = setTimeout(() => controller.abort(), 15000);
   try {
     const res = await fetch(
       `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`,

--- a/desktop/src/main/updater.ts
+++ b/desktop/src/main/updater.ts
@@ -9,19 +9,15 @@ import {
 
 const { autoUpdater } = electronUpdater;
 
-// Public repo → the GitHub releases API and page need no token. Overridable for
-// forks / test repos (mirrors the backend's FLIKS_GITHUB_REPO).
+// Public repo (no token); overridable for forks / test repos.
 const GITHUB_REPO = process.env.FLIKS_GITHUB_REPO ?? 'fliks-app/fliks';
 const RELEASES_URL = `https://github.com/${GITHUB_REPO}/releases`;
 
-// Re-check periodically while the app stays open, plus once shortly after launch.
 const INITIAL_CHECK_DELAY_MS = 10_000;
 const PERIODIC_CHECK_MS = 6 * 60 * 60 * 1000;
 
-/** electron-updater can self-install only from an NSIS exe (Windows), a signed
- *  .app via a zip (macOS), or an AppImage (Linux). A .deb has no in-place update
- *  path (dpkg needs root), and dev runs aren't packaged. Those fall back to a
- *  "download from the releases page" flow. */
+/** electron-updater self-installs only from an NSIS exe, a signed .app zip, or
+ *  an AppImage. A .deb (dpkg needs root) and dev runs fall back to a download. */
 function canSelfInstall(): boolean {
   if (!app.isPackaged) return false;
   if (process.platform === 'linux') return !!process.env.APPIMAGE;
@@ -36,8 +32,7 @@ function capability(): DesktopUpdateCapability {
   };
 }
 
-/** electron-updater's release notes can be a string or an array of
- *  {version, note} blocks (fullChangelog). Flatten to plain text/HTML. */
+/** Release notes can be a string or an array of {version, note} blocks. */
 function normalizeNotes(notes: unknown): string | null {
   if (!notes) return null;
   if (typeof notes === 'string') return notes;
@@ -50,15 +45,9 @@ function normalizeNotes(notes: unknown): string | null {
   return null;
 }
 
-/**
- * Wires the in-app updater: registers the renderer-invokable channels
- * (check/install/openReleases/getCapability) and broadcasts status updates so
- * the Angular AppUpdateService can drive the update button + modal.
- *
- * On installable builds it uses electron-updater (autoDownload off so the user
- * confirms in the modal); on a .deb or in dev it does a lightweight GitHub
- * release lookup just to surface availability + a download link.
- */
+/** Wires the in-app updater: renderer-invokable channels + status broadcasts.
+ *  Installable builds use electron-updater (autoDownload off); .deb/dev do a
+ *  GitHub release lookup to surface availability + a download link. */
 export function setupUpdater(): void {
   const installable = canSelfInstall();
 
@@ -74,8 +63,7 @@ export function setupUpdater(): void {
   if (installable) {
     autoUpdater.autoDownload = false;
     autoUpdater.autoInstallOnAppQuit = true;
-    // Differential downloads pull in lzma-native (a native module that isn't
-    // bundled); full-file downloads avoid it and are fine for our installer sizes.
+    // Avoid lzma-native (not bundled); full-file downloads are fine here.
     autoUpdater.disableDifferentialDownload = true;
 
     const toInfo = (u: electronUpdater.UpdateInfo): DesktopUpdateInfo => ({

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,11 +1,14 @@
 import { contextBridge, ipcRenderer } from 'electron';
 import {
   IPC,
+  UPDATE_IPC,
   type DesktopEvent,
   type DesktopLoadOptions,
   type DesktopRect,
   type DesktopSubtitleStyle,
+  type DesktopUpdateStatus,
   type FliksDesktopApi,
+  type FliksUpdaterApi,
 } from '../shared/contract';
 
 // Exposes the native player surface on `window.fliksDesktop`. The Angular-side
@@ -42,3 +45,19 @@ const api: FliksDesktopApi = {
 };
 
 contextBridge.exposeInMainWorld('fliksDesktop', api);
+
+// Exposes the in-app updater on `window.fliksUpdater`, consumed by the Angular
+// AppUpdateService to drive the update button + changelog modal.
+const updater: FliksUpdaterApi = {
+  getCapability: () => ipcRenderer.invoke(UPDATE_IPC.getCapability),
+  check: () => ipcRenderer.invoke(UPDATE_IPC.check),
+  install: () => ipcRenderer.invoke(UPDATE_IPC.install),
+  openReleases: () => ipcRenderer.invoke(UPDATE_IPC.openReleases),
+  onStatus: (handler: (status: DesktopUpdateStatus) => void) => {
+    const listener = (_e: unknown, status: DesktopUpdateStatus) => handler(status);
+    ipcRenderer.on(UPDATE_IPC.status, listener);
+    return () => ipcRenderer.removeListener(UPDATE_IPC.status, listener);
+  },
+};
+
+contextBridge.exposeInMainWorld('fliksUpdater', updater);

--- a/desktop/src/shared/contract.ts
+++ b/desktop/src/shared/contract.ts
@@ -95,6 +95,58 @@ export const IPC = {
   event: 'player:event',
 } as const;
 
+/** Info about an available app update (from electron-updater, or the GitHub
+ *  release on the .deb fallback path). */
+export interface DesktopUpdateInfo {
+  version: string;
+  releaseName: string | null;
+  releaseNotes: string | null;
+  releaseDate: string | null;
+  releaseUrl: string | null;
+}
+
+/** main → renderer update lifecycle, sent on the UPDATE_IPC.status channel. */
+export type DesktopUpdateStatus =
+  | { state: 'idle' }
+  | { state: 'checking' }
+  | { state: 'available'; info: DesktopUpdateInfo }
+  | { state: 'not-available' }
+  | { state: 'downloading'; percent: number }
+  | { state: 'downloaded'; info: DesktopUpdateInfo }
+  | { state: 'error'; message: string };
+
+/** What the renderer needs to render the right action button. `canInstall`
+ *  is false on builds electron-updater can't self-install (Linux .deb, dev
+ *  runs) — there the UI offers a download link to `releasesUrl` instead. */
+export interface DesktopUpdateCapability {
+  canInstall: boolean;
+  currentVersion: string;
+  releasesUrl: string;
+}
+
+/** renderer → main update channels + the single main → renderer status channel. */
+export const UPDATE_IPC = {
+  check: 'update:check',
+  install: 'update:install',
+  openReleases: 'update:openReleases',
+  getCapability: 'update:getCapability',
+  /** main → renderer (discriminated by DesktopUpdateStatus.state). */
+  status: 'update:status',
+} as const;
+
+/** The surface exposed on `window.fliksUpdater` by the preload bridge. */
+export interface FliksUpdaterApi {
+  /** Capability + current version, resolved natively. */
+  getCapability(): Promise<DesktopUpdateCapability>;
+  /** Trigger a check now; results arrive via the status channel. */
+  check(): Promise<void>;
+  /** Download (if needed) and install + relaunch. No-op when !canInstall. */
+  install(): Promise<void>;
+  /** Open the GitHub releases page (the .deb / dev fallback). */
+  openReleases(): Promise<void>;
+  onStatus(handler: (status: DesktopUpdateStatus) => void): () => void;
+}
+
 /** The surface exposed on `window.fliksDesktop` by the preload bridge. */
 export interface FliksDesktopApi {
   runtime: 'electron';

--- a/desktop/src/shared/contract.ts
+++ b/desktop/src/shared/contract.ts
@@ -95,8 +95,6 @@ export const IPC = {
   event: 'player:event',
 } as const;
 
-/** Info about an available app update (from electron-updater, or the GitHub
- *  release on the .deb fallback path). */
 export interface DesktopUpdateInfo {
   version: string;
   releaseName: string | null;
@@ -105,7 +103,6 @@ export interface DesktopUpdateInfo {
   releaseUrl: string | null;
 }
 
-/** main → renderer update lifecycle, sent on the UPDATE_IPC.status channel. */
 export type DesktopUpdateStatus =
   | { state: 'idle' }
   | { state: 'checking' }
@@ -115,16 +112,14 @@ export type DesktopUpdateStatus =
   | { state: 'downloaded'; info: DesktopUpdateInfo }
   | { state: 'error'; message: string };
 
-/** What the renderer needs to render the right action button. `canInstall`
- *  is false on builds electron-updater can't self-install (Linux .deb, dev
- *  runs) — there the UI offers a download link to `releasesUrl` instead. */
+/** `canInstall` is false where electron-updater can't self-install (.deb, dev)
+ *  → the UI offers a download link to `releasesUrl` instead. */
 export interface DesktopUpdateCapability {
   canInstall: boolean;
   currentVersion: string;
   releasesUrl: string;
 }
 
-/** renderer → main update channels + the single main → renderer status channel. */
 export const UPDATE_IPC = {
   check: 'update:check',
   install: 'update:install',
@@ -134,15 +129,12 @@ export const UPDATE_IPC = {
   status: 'update:status',
 } as const;
 
-/** The surface exposed on `window.fliksUpdater` by the preload bridge. */
+/** Exposed on `window.fliksUpdater` by the preload bridge. */
 export interface FliksUpdaterApi {
-  /** Capability + current version, resolved natively. */
   getCapability(): Promise<DesktopUpdateCapability>;
-  /** Trigger a check now; results arrive via the status channel. */
   check(): Promise<void>;
-  /** Download (if needed) and install + relaunch. No-op when !canInstall. */
+  /** Download + install + relaunch. No-op when !canInstall. */
   install(): Promise<void>;
-  /** Open the GitHub releases page (the .deb / dev fallback). */
   openReleases(): Promise<void>;
   onStatus(handler: (status: DesktopUpdateStatus) => void): () => void;
 }


### PR DESCRIPTION
## What

Adds a third topbar button (next to **cast** / **user**) that appears when an update is available and opens a **changelog modal** with a platform-aware action.

| Platform | Source of "update available" | Modal action |
|---|---|---|
| **Desktop (Electron)** | `electron-updater` → app release on GitHub | **Install** in-app (download + relaunch) |
| **Web / mobile** | connected **server version < latest GitHub release** (admin-only) | **Open release** (informational; server is updated out of band) |

## Backend
- `UpdateCheckService` polls the public GitHub `releases/latest` (cached 6h, no token, 5s timeout) and compares to the running server version.
- `GET /api/system/update` — admin-gated (`Action.Read, 'Settings'`, same as `/system/health`).

## Desktop / CI
- `electron-updater` (autoDownload off — the user confirms in the modal). `.deb` and dev runs can't self-install → fall back to a releases-page download link.
- `electron-builder.yml`: explicit `publish: github` provider (also fixes the old `computeChannelNames` crash), **macOS `zip` target** (Squirrel.Mac updates from a zip, not the dmg).
- `desktop-release.yml`: builds `latest*.yml` and publishes on tag builds via `--publish always`; non-tag runs stay `--publish never`. Linux now also builds an **AppImage** (self-updatable) alongside the `.deb`.

## OS limitations (by design)
- **macOS** ✅ (signed + notarized already; updates from the zip).
- **Windows** ✅ (NSIS; works unsigned, but SmartScreen warns until Authenticode signing is added — TODO).
- **Linux AppImage** ✅ self-updates; **Linux `.deb`** ❌ no in-place update (dpkg needs root) → download-link fallback.

## Frontend
- `AppUpdateService` unifies both providers behind one button + modal, choosing by platform and gating the server provider on `canAccessSettings`.
- Distinct from the existing PWA service-worker auto-reload (new frontend bundles ≠ server/app version).

## Verification
- Compile-checked: backend `tsc`, desktop `tsc` + esbuild bundle, Angular `ng build` (all clean).
- **Not yet runtime-verified**: the electron-updater install path needs a packaged **signed** build + a newer release; the CI publish needs a real tag run. The first tagged release after merge is the real validation point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)