### PR TITLE
fix(desktop): publish release assets onto the published GitHub release

### DIFF
--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -20,17 +20,23 @@ productName: Fliks
 # Fliks-Server-<ver>-<arch>.dmg); both attach to the same release-please v*
 # release, so a shared filename would overwrite. e.g. Fliks-Client-1.2.3-x64.dmg.
 artifactName: ${productName}-Client-${version}-${arch}.${ext}
-# In-app auto-update source. With an explicit github provider, `--publish always`
-# (set on tag builds in desktop-release.yml) generates the update metadata
-# (latest.yml / latest-mac.yml / latest-linux.yml) and uploads it + the installers
-# to the matching GitHub Release; electron-updater in the app reads it from here.
-# The repo is public, so clients need no token. Declaring the provider also fixes
-# the earlier computeChannelNames crash that happened when a GH_TOKEN was present
-# without a configured publisher.
+# In-app auto-update source. `--publish always` (tag builds, see
+# desktop-release.yml) generates the update metadata (latest.yml /
+# latest-mac.yml / latest-linux.yml) and uploads it + the installers to the
+# GitHub Release; electron-updater reads it from here. The repo is public, so
+# clients need no token.
+#
+# releaseType: release is REQUIRED here. release-please publishes the v* release
+# (as a full, non-draft release) before this workflow runs, and electron-builder
+# defaults to publishingType=draft — which it considers incompatible with an
+# already-published release, so it SKIPS every asset ("existing type not
+# compatible with publishing type"). Matching releaseType=release lets it upload
+# onto release-please's published release instead.
 publish:
   provider: github
   owner: fliks-app
   repo: fliks
+  releaseType: release
 directories:
   output: release
   buildResources: build


### PR DESCRIPTION
## Problem

v1.13.0 shipped with **no desktop client installers** (`Fliks-Client-*.deb/dmg/exe/AppImage`) and no `latest*.yml`, even though the desktop workflow ran and succeeded.

Root cause, from the run logs:
```
• GitHub release not created  reason=existing type not compatible with publishing type
  tag=v1.13.0 version=1.13.0 existingType=release publishingType=draft
• skipped publishing  file=Fliks-Client-1.13.0-arm64.dmg ...
• skipped publishing  file=latest-mac.yml ...
```

`release-please` publishes the `v*` release as a **full (non-draft) release** before the desktop workflow runs. `electron-builder` defaults to `publishingType=draft`, which it considers **incompatible** with an already-published release → it **skips every asset**. (The previous `softprops` attach step, removed in #549, had masked this.)

## Fix

Set `publish.releaseType: release` in `electron-builder.yml` so electron-builder uploads onto release-please's published release instead of trying to manage a draft.

## v1.13.0 backfill

v1.13.0 has been **backfilled manually** from that run's workflow artifacts (the installers were built + signed/notarized fine, just not attached) — it now carries all desktop installers + `latest*.yml`, so desktop auto-update is testable against it now. Future releases attach automatically with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)