### PR TITLE
ci(macos): sign and notarize the Fliks server dmg

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -82,20 +82,65 @@ jobs:
         working-directory: macos
         run: xcodegen generate
 
+      # ── Import the Developer ID cert into a throwaway keychain ──
+      # build-app.sh signs the .app + every bundled binary with it (hardened
+      # runtime + entitlements), so the DMG can be notarized below.
+      - name: Import Developer ID certificate
+        env:
+          CERT_P12_BASE64: ${{ secrets.MAC_DEVELOPER_ID_CERT_P12_BASE64 }}
+          CERT_PASSWORD: ${{ secrets.MAC_DEVELOPER_ID_CERT_PASSWORD }}
+        run: |
+          CERT_PATH="$RUNNER_TEMP/devid.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+          KEYCHAIN_PWD="$(openssl rand -base64 24)"
+          echo "$CERT_P12_BASE64" | base64 -d > "$CERT_PATH"
+          security create-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PWD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" \
+            $(security list-keychains -d user | sed -e 's/^[[:space:]]*//' -e 's/"//g')
+          rm -f "$CERT_PATH"
+
       # ── Build .app + bundle resources + dylibs ──
       # API keys are baked into Info.plist via Xcode build settings,
-      # then read at runtime by BuildConfig.swift.
+      # then read at runtime by BuildConfig.swift. MAC_SIGN_IDENTITY tells
+      # build-app.sh to Developer ID sign (hardened runtime) instead of ad-hoc;
+      # the single imported cert matches the identity prefix uniquely.
       - name: Build Fliks.app
         working-directory: macos
         env:
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
           TVDB_API_KEY: ${{ secrets.TVDB_API_KEY }}
+          MAC_SIGN_IDENTITY: Developer ID Application
         run: ./Scripts/build-app.sh --skip-web
 
       # ── Create DMG ──
       - name: Create DMG
         working-directory: macos
         run: ./Scripts/make-dmg.sh
+
+      # ── Notarize + staple the DMG ──
+      # Without notarization a downloaded DMG is blocked by Gatekeeper
+      # ("damaged" / "Apple cannot check it"). notarytool reuses the App Store
+      # Connect API key (same one the iOS build uses); --wait blocks on Apple's
+      # verdict, then the ticket is stapled so it opens offline.
+      - name: Notarize and staple DMG
+        env:
+          KEY_P8: ${{ secrets.APPSTORE_API_KEY_P8_BASE64 }}
+          KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+          ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+        run: |
+          p8="$RUNNER_TEMP/notary.p8"
+          echo "$KEY_P8" | base64 -d > "$p8"
+          dmg="$(find macos/build -name 'Fliks-*.dmg' | head -1)"
+          test -n "$dmg" || { echo "::error::DMG not found for notarization"; exit 1; }
+          xcrun notarytool submit "$dmg" \
+            --key "$p8" --key-id "$KEY_ID" --issuer "$ISSUER_ID" --wait
+          xcrun stapler staple "$dmg"
+          xcrun stapler validate "$dmg"
+          rm -f "$p8"
 
       # ── Upload DMG as artifact (always) ──
       - name: Upload DMG artifact

--- a/macos/Fliks/Fliks.entitlements
+++ b/macos/Fliks/Fliks.entitlements
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+  <!-- Node's V8 JIT under the hardened runtime (required for notarization). -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <!-- The bundled node / postgres / ffmpeg load relocated Homebrew dylibs; allow
+       loading libraries not signed with this app's Team ID. -->
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
 </plist>

--- a/macos/Scripts/build-app.sh
+++ b/macos/Scripts/build-app.sh
@@ -173,16 +173,30 @@ cp -R "$REPO_ROOT/client/dist/client/browser/"* "$RESOURCES/client/"
 echo "    [done] All resources copied"
 
 # ── Code sign everything ──
-echo "==> Code signing..."
-# Sign all dylibs first.
-find "$RESOURCES" -name "*.dylib" -exec codesign --force --sign - {} \; 2>/dev/null
-# Sign binaries.
-codesign --force --sign - "$RESOURCES/node/bin/node"
-find "$RESOURCES/postgres/bin" -type f -perm +111 -exec codesign --force --sign - {} \;
-codesign --force --sign - "$RESOURCES/ffmpeg/bin/ffmpeg"
-[ -f "$RESOURCES/ffmpeg/bin/ffprobe" ] && codesign --force --sign - "$RESOURCES/ffmpeg/bin/ffprobe"
-# Re-sign the outer app bundle.
-codesign --force --sign - "$APP_BUNDLE"
+# Local dev signs ad-hoc ("-"). CI passes a Developer ID identity via
+# MAC_SIGN_IDENTITY for a NOTARIZABLE build: hardened runtime + secure timestamp
+# + entitlements. Sign inside-out — every nested Mach-O first, the .app last.
+SIGN_ID="${MAC_SIGN_IDENTITY:--}"
+ENTITLEMENTS="$MACOS_DIR/Fliks/Fliks.entitlements"
+echo "==> Code signing (identity: $SIGN_ID)..."
+sign() {
+    if [ "$SIGN_ID" = "-" ]; then
+        codesign --force --sign - "$1" 2>/dev/null || true
+    else
+        codesign --force --options runtime --timestamp \
+            --entitlements "$ENTITLEMENTS" --sign "$SIGN_ID" "$1"
+    fi
+}
+
+# Every Mach-O inside the bundle: dylibs, the node/postgres/ffmpeg helpers, AND
+# native .node addons under backend/node_modules — notarization rejects any
+# unsigned executable. `file` filters out the (many) non-binary files.
+while IFS= read -r -d '' f; do
+    if file "$f" 2>/dev/null | grep -q 'Mach-O'; then sign "$f"; fi
+done < <(find "$RESOURCES" -type f -print0)
+
+# Outer app bundle last (seals the signed contents).
+sign "$APP_BUNDLE"
 echo "    [done]"
 
 echo ""


### PR DESCRIPTION
## Why
The SwiftUI **server host** (`macos/`) shipped **ad-hoc signed with hardened runtime off**, so the downloaded DMG was blocked by Gatekeeper ("damaged" / "Apple cannot check it for malicious software") — same problem the Electron client had.

## Change
- **Developer ID sign** the app + **every bundled Mach-O** — `node`, `postgres` bins, `ffmpeg`/`ffprobe`, all `.dylib`, and native `.node` addons under the backend `node_modules` — under the **hardened runtime** with JIT + `disable-library-validation` entitlements. `build-app.sh` does a Mach-O sweep, inside-out, the `.app` last.
- **Notarize + staple** the DMG via `notarytool` (reuses the App Store Connect API key the iOS build uses).
- `build-app.sh` stays **ad-hoc for local dev**; switches to Developer ID only when `MAC_SIGN_IDENTITY` is set (CI).

## Secrets (already configured)
`MAC_DEVELOPER_ID_CERT_P12_BASE64` / `_PASSWORD`, and `APPSTORE_API_KEY_P8_BASE64` / `APPSTORE_API_KEY_ID` / `APPSTORE_API_ISSUER_ID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)