### PR TITLE
ci(macos): rename the workflow to Build macOS server

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -4,7 +4,7 @@
 # Triggers:
 #   - release tag `v*` (from release-please) → attaches DMG to the release
 #   - manual workflow_dispatch               → uploads artifact for testing
-name: Build macOS DMG
+name: Build macOS server
 
 on:
   push:


### PR DESCRIPTION
Display name only (file stays `macos-dmg.yml` to keep run history + `gh workflow run` refs).