### PR TITLE
feat(updates): document the GitHub update check and add an opt-out flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ have `nvidia-container-toolkit` installed and a different Compose
 snippet — the [transcoding docs](docs/transcoding-pipelines.md) cover
 both paths.
 
+### Update checks
+
+Fliks checks for new releases via the **public GitHub releases API**
+(`api.github.com`): the server does it to tell admins when their server is
+behind the latest release, and the desktop app does it to offer in-app
+updates. It's a single read request (no token, no telemetry, no data sent),
+cached for hours.
+
+To turn it off on the server, set `FLIKS_DISABLE_UPDATE_CHECK=1` — the
+`/api/system/update` endpoint then always reports "up to date" and never
+contacts GitHub.
+
 ## Layout
 
 - **`backend/`** — NestJS + TypeORM + PostgreSQL + FFmpeg.

--- a/backend/src/modules/scheduler/update-check.service.ts
+++ b/backend/src/modules/scheduler/update-check.service.ts
@@ -4,6 +4,13 @@ import * as path from 'path';
 
 // Public repo (no token needed); overridable for forks / test repos.
 const GITHUB_REPO = process.env.FLIKS_GITHUB_REPO ?? 'fliks-app/fliks';
+
+/** Lets a self-hoster opt out of the GitHub update check entirely (no outbound
+ *  request). Read live so it can be toggled without a rebuild. */
+function updateCheckDisabled(): boolean {
+  const v = (process.env.FLIKS_DISABLE_UPDATE_CHECK ?? '').trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes';
+}
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 // Generous ceiling for a cold TLS handshake; the call is async + cached.
 const FETCH_TIMEOUT_MS = 15000;
@@ -73,6 +80,16 @@ export class UpdateCheckService {
   }
 
   async getStatus(): Promise<UpdateStatus> {
+    if (updateCheckDisabled()) {
+      return {
+        currentVersion: CURRENT_VERSION,
+        latestVersion: null,
+        updateAvailable: false,
+        releaseUrl: null,
+        releaseNotes: null,
+        publishedAt: null,
+      };
+    }
     if (this.cache && Date.now() - this.cache.fetchedAt < CACHE_TTL_MS) {
       return this.cache.status;
     }

--- a/desktop/src/main/updater.ts
+++ b/desktop/src/main/updater.ts
@@ -18,6 +18,13 @@ const PERIODIC_CHECK_MS = 6 * 60 * 60 * 1000;
 
 /** electron-updater self-installs only from an NSIS exe, a signed .app zip, or
  *  an AppImage. A .deb (dpkg needs root) and dev runs fall back to a download. */
+/** Opt out of the update check entirely (no outbound api.github.com request),
+ *  matching the backend's FLIKS_DISABLE_UPDATE_CHECK. */
+function updateCheckDisabled(): boolean {
+  const v = (process.env.FLIKS_DISABLE_UPDATE_CHECK ?? '').trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes';
+}
+
 function canSelfInstall(): boolean {
   if (!app.isPackaged) return false;
   if (process.platform === 'linux') return !!process.env.APPIMAGE;
@@ -59,6 +66,14 @@ export function setupUpdater(): void {
 
   ipcMain.handle(UPDATE_IPC.getCapability, () => capability());
   ipcMain.handle(UPDATE_IPC.openReleases, () => shell.openExternal(RELEASES_URL));
+
+  // Opted out: register no-op channels (so renderer calls resolve) and never
+  // contact GitHub. The check reports "up to date", so no update button shows.
+  if (updateCheckDisabled()) {
+    ipcMain.handle(UPDATE_IPC.check, () => broadcast({ state: 'not-available' }));
+    ipcMain.handle(UPDATE_IPC.install, () => shell.openExternal(RELEASES_URL));
+    return;
+  }
 
   if (installable) {
     autoUpdater.autoDownload = false;

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -55,6 +55,10 @@ services:
       DB_PASSWORD: changeme
       DB_NAME: fliks
       NODE_ENV: production
+      # Set to disable the GitHub update check: no outbound api.github.com
+      # request, and /api/system/update always reports "up to date". Default:
+      # enabled (a single cached read request, no token, no data sent).
+      # FLIKS_DISABLE_UPDATE_CHECK: '1'
       # ---- Streaming session tuning (optional) -----------------------
       # All values below have safe defaults baked in. Override only if
       # you know what you're doing.


### PR DESCRIPTION
## Transparency

README now discloses that the server (admin "server behind latest" badge) and the desktop app (in-app updates) poll the **public GitHub releases API** to detect updates — a single cached read request, no token, no telemetry, no data sent.

## Opt-out

New `FLIKS_DISABLE_UPDATE_CHECK` env flag (`1`/`true`/`yes`), honored by:
- **backend** — `/api/system/update` returns "up to date" without any outbound request (verified: `fetch` not called when set);
- **desktop** — the updater registers no-op channels and never contacts GitHub.

Documented in `docker-compose.example.yml`.

No new dependencies; the GitHub API calls and the bundled npm deps (electron-updater, marked — both MIT) don't require third-party-notice entries (that file's scope is non-npm embedded binaries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)