### PR TITLE
fix(auth): derive cookie Secure flag from request protocol, not NODE_ENV

### DIFF
--- a/backend/src/modules/auth/cookie-opts.util.ts
+++ b/backend/src/modules/auth/cookie-opts.util.ts
@@ -11,38 +11,38 @@ export function isCrossOriginNative(req: Request): boolean {
   return NATIVE_ORIGINS.includes(origin);
 }
 
+/** Whether the request reached us over HTTPS. `trust proxy` is enabled (see
+ *  main.ts), so `req.secure` already honors `X-Forwarded-Proto` from a TLS-
+ *  terminating reverse proxy; the header is checked too as a belt-and-braces.
+ *
+ *  Cookies must NOT carry `Secure` over plain HTTP — the browser drops them,
+ *  which breaks auth for prod instances served over HTTP (LAN / IP:port / a
+ *  proxy without TLS). And `SameSite=None` is only valid with `Secure`, so on
+ *  HTTP we fall back to `Lax`. */
+function isRequestSecure(req: Request): boolean {
+  if (req.secure) return true;
+  const xfp = req.headers['x-forwarded-proto'];
+  const proto = (Array.isArray(xfp) ? xfp[0] : xfp) ?? '';
+  return proto.split(',')[0].trim().toLowerCase() === 'https';
+}
+
 export function cookieOpts(req: Request, maxAgeMs: number) {
-  if (isCrossOriginNative(req)) {
-    return {
-      httpOnly: true,
-      secure: true,
-      sameSite: 'none' as const,
-      path: '/',
-      maxAge: maxAgeMs,
-    };
-  }
+  const secure = isRequestSecure(req);
   return {
     httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax' as const,
+    secure,
+    sameSite: isCrossOriginNative(req) && secure ? ('none' as const) : ('lax' as const),
     path: '/',
     maxAge: maxAgeMs,
   };
 }
 
 export function clearOpts(req: Request) {
-  if (isCrossOriginNative(req)) {
-    return {
-      path: '/',
-      httpOnly: true,
-      secure: true,
-      sameSite: 'none' as const,
-    };
-  }
+  const secure = isRequestSecure(req);
   return {
     path: '/',
     httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax' as const,
+    secure,
+    sameSite: isCrossOriginNative(req) && secure ? ('none' as const) : ('lax' as const),
   };
 }


### PR DESCRIPTION
## Bug

Auth was broken on **production instances served over plain HTTP** (LAN, `IP:4848`, a reverse proxy without TLS). The cookie options forced `Secure: true` whenever `NODE_ENV=production`:

```ts
secure: process.env.NODE_ENV === 'production'
```

A `Secure` cookie is never stored/sent by the browser over HTTP → the `fliks_access` cookie silently vanished → login appeared to succeed but the next `/auth/me` had no cookie → not authenticated.

## Fix

Base `Secure` on the **actual request protocol** instead of `NODE_ENV`:
- `req.secure` (with `trust proxy` already enabled in `main.ts`, this honors `X-Forwarded-Proto` from a TLS-terminating proxy), plus a direct `X-Forwarded-Proto` header check as a fallback.
- `SameSite=None` requires `Secure`, so the native cross-origin path falls back to `Lax` over HTTP (native clients authenticate via Bearer anyway).

Verified across the matrix:

| Request | Secure | SameSite |
|---|---|---|
| HTTP web (the bug) | false | lax |
| HTTPS web | true | lax |
| HTTP behind TLS proxy (`X-Forwarded-Proto: https`) | true | lax |
| native over HTTPS | true | none |
| native over HTTP | false | lax |

HTTPS behavior is unchanged; HTTP now works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)