### PR TITLE
fix(subtitles): drop provider results outside the requested language

### DIFF
--- a/backend/src/modules/subtitles/providers/yify.provider.ts
+++ b/backend/src/modules/subtitles/providers/yify.provider.ts
@@ -73,7 +73,7 @@ export class YifyProvider implements SubtitleProviderInterface {
     const html = await res.text();
     const targetLang = LANG_MAP[params.language]?.toLowerCase();
 
-    return this.parseResults(html, targetLang);
+    return this.parseResults(html, targetLang, params.language);
   }
 
   async download(result: SubtitleSearchResult): Promise<Buffer> {
@@ -133,6 +133,7 @@ export class YifyProvider implements SubtitleProviderInterface {
   private parseResults(
     html: string,
     targetLang: string | undefined,
+    isoCode: string,
   ): SubtitleSearchResult[] {
     const results: SubtitleSearchResult[] = [];
 
@@ -184,7 +185,7 @@ export class YifyProvider implements SubtitleProviderInterface {
         providerFileId: pagePath,
         title: releaseName,
         releaseName,
-        language,
+        language: isoCode,
         forced: false,
         hearingImpaired,
         score: 0,

--- a/backend/src/modules/subtitles/subtitles.service.ts
+++ b/backend/src/modules/subtitles/subtitles.service.ts
@@ -113,9 +113,22 @@ export class SubtitlesService {
     const blacklistSet = new Set(
       blacklisted.map((b) => `${b.providerType}:${b.providerFileId}`),
     );
-    const filtered = allResults.filter(
+    const blacklistFiltered = allResults.filter(
       (r) => !blacklistSet.has(`${r.providerType}:${r.providerFileId}`),
     );
+
+    // Keep only candidates whose language, folded to canonical ISO 639-1,
+    // matches the requested one.
+    const wantedLang = normalizeLanguageCode(params.language);
+    const filtered = blacklistFiltered.filter(
+      (r) => normalizeLanguageCode(r.language) === wantedLang,
+    );
+    const droppedForLang = blacklistFiltered.length - filtered.length;
+    if (droppedForLang > 0) {
+      this.logger.debug(
+        `Subtitle search [${params.language}]: dropped ${droppedForLang} candidate(s) in other languages`,
+      );
+    }
 
     // Hearing-impaired hard filter. `require` keeps only HI candidates,
     // `forbid` drops them; `prefer` / `avoid` leave the candidate set


### PR DESCRIPTION
## Problem

Subtitles in languages absent from the media's language profile were being downloaded (e.g. `tr`, `no`, `fi`, `da`, `es`, `sv` for a series whose profile only wanted a couple of languages).

## Root cause

`SubtitlesService.searchSubtitles()` queries each provider for a single language, but nothing downstream re-checked the language of the returned candidates. Subdl in particular ignores an unrecognised language code and returns subtitles in **every** language it has; those flowed straight through blacklist/HI filters, scoring (which ignores language entirely) and into the download.

## Fix

- Add a hard language filter in `searchSubtitles()`, right after the blacklist filter: keep only candidates whose language, folded to canonical ISO 639-1 via the existing `normalizeLanguageCode` helper, equals the requested one. This reuses the helper that already handles regional (`pt-BR`→`pt`) and 639-2 (`fra`/`fre`→`fr`) spellings, and acts as a permanent safety net for any provider that returns extra languages.
- YIFY emitted a display name (`english`) instead of a code, which the new filter would have rejected; it now emits the canonical ISO code it already self-filters on.

## Notes

Already-downloaded out-of-profile subtitles remain in the DB; this only prevents new ones. Verified with `tsc --noEmit` (the lone pre-existing error in `auto-grab-pipeline.service.spec.ts` is unrelated).