### PR TITLE
fix(auto-grab): format release rejections in logs instead of [object Object]

### DIFF
--- a/backend/src/modules/media/auto-grab-pipeline.service.ts
+++ b/backend/src/modules/media/auto-grab-pipeline.service.ts
@@ -24,6 +24,7 @@ import {
   rankFromQualityString,
   resolveSearchTitles,
   scoreAndSortReleases,
+  formatRejectionForLog,
 } from './release-rejection.helper';
 
 /**
@@ -302,7 +303,7 @@ export class AutoGrabPipelineService {
         .slice(0, 3)
         .map(
           (r) =>
-            `"${r.title}" → ${r.rejections.length ? r.rejections.join(', ') : `rank ${r.rank} out of [${decision.minRankExclusive + 1}..${decision.maxRankInclusive}]`}`,
+            `"${r.title}" → ${r.rejections.length ? r.rejections.map(formatRejectionForLog).join(', ') : `rank ${r.rank} out of [${decision.minRankExclusive + 1}..${decision.maxRankInclusive}]`}`,
         )
         .join(' | ');
       logSkip(

--- a/backend/src/modules/media/movie-download.service.ts
+++ b/backend/src/modules/media/movie-download.service.ts
@@ -38,6 +38,7 @@ import {
   resolveSearchTitles,
   scoreAndSortReleases,
   sortReleasesByRelevance,
+  formatRejectionForLog,
 } from './release-rejection.helper';
 
 function inferTitleFromTorrentUrl(url: string): string {
@@ -229,7 +230,10 @@ export class MovieDownloadService {
     if (accepted === 0 && withinProfile.length > 0) {
       const sample = withinProfile
         .slice(0, 5)
-        .map((r) => `"${r.title}" [${r.rejections.join(', ')}]`);
+        .map(
+          (r) =>
+            `"${r.title}" [${r.rejections.map(formatRejectionForLog).join(', ')}]`,
+        );
       this.log.warn(
         `[searchMovieReleases] all releases rejected — sample: ${sample.join(' | ')}`,
       );

--- a/backend/src/modules/media/release-rejection.helper.ts
+++ b/backend/src/modules/media/release-rejection.helper.ts
@@ -58,6 +58,18 @@ export interface ReleaseRejection {
   params?: Record<string, number | string>;
 }
 
+/** Render a rejection as a readable `code (k=v, …)` string for backend logs —
+ *  the i18n rendering lives on the frontend, so logs show the raw code/params
+ *  rather than `[object Object]`. */
+export function formatRejectionForLog(rejection: ReleaseRejection): string {
+  const params = rejection.params
+    ? Object.entries(rejection.params)
+        .map(([key, value]) => `${key}=${value}`)
+        .join(', ')
+    : '';
+  return params ? `${rejection.code} (${params})` : rejection.code;
+}
+
 /**
  * Detect the video codec from a release title and return a size scaling
  * factor relative to x264 (= 1.0). Quality definition size limits are


### PR DESCRIPTION
## Problem

AutoGrab/movie-download skip logs rendered rejection reasons as `[object Object]`:

```
… → rank 40 out of [41..55] | "…REMUX VC-1…" → [object Object], [object Object]
```

`ReleaseRejection` is a `{ code, params? }` object; the log lines joined the array directly into a string.

## Fix

Shared `formatRejectionForLog` renders each rejection as `code (k=v, …)` (the i18n rendering stays on the frontend; logs show the raw code/params). Applied in both `auto-grab-pipeline.service` (skip log) and `movie-download.service` (all-rejected sample).

Verified with `tsc --noEmit` (the lone `auto-grab-pipeline.service.spec.ts` error pre-exists on `main`).