### PR TITLE
fix(dropdown-menu): close other open menus when opening one

### DIFF
--- a/client/src/app/shared/directives/dropdown-toggle.directive.ts
+++ b/client/src/app/shared/directives/dropdown-toggle.directive.ts
@@ -27,6 +27,12 @@ const MENU_FOCUSABLE_SELECTOR =
   },
 })
 export class DropdownToggleDirective implements OnDestroy {
+  /** Close handler of the dropdown currently open, if any. Opening a
+   *  dropdown closes this one first so only one stays open — the trigger's
+   *  `stopPropagation` otherwise stops an open dropdown's outside-click
+   *  handler from firing when another trigger is clicked. */
+  private static openClose: (() => void) | null = null;
+
   private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
   private readonly dismissStack = inject(DismissableStackService);
   private outsideClickHandler: ((e: MouseEvent) => void) | null = null;
@@ -64,6 +70,9 @@ export class DropdownToggleDirective implements OnDestroy {
   }
 
   private open(dropdown: HTMLElement) {
+    // Close any other dropdown already open before opening this one.
+    DropdownToggleDirective.openClose?.();
+
     dropdown.classList.add('dropdown-open');
     const content = dropdown.querySelector<HTMLElement>('.dropdown-content');
     // Move focus into the menu so arrow keys step between items
@@ -80,6 +89,7 @@ export class DropdownToggleDirective implements OnDestroy {
       this.cleanup();
     };
     this.currentClose = close;
+    DropdownToggleDirective.openClose = close;
     this.dismissStack.push(close);
     this.outsideClickHandler = (e: MouseEvent) => {
       // Close on any click that isn't the trigger itself: outside the
@@ -142,6 +152,9 @@ export class DropdownToggleDirective implements OnDestroy {
     }
     if (this.currentClose) {
       this.dismissStack.remove(this.currentClose);
+      if (DropdownToggleDirective.openClose === this.currentClose) {
+        DropdownToggleDirective.openClose = null;
+      }
       this.currentClose = null;
     }
   }


### PR DESCRIPTION
## Problem

Opening a second command dropdown (System → Status) left the first one open — multiple menus visible at once.

## Cause

`DropdownToggleDirective.onClick` calls `event.stopPropagation()`, so the document-level outside-click handler of an already-open dropdown never fires when another trigger is clicked. Nothing closed the previous menu.

## Fix

Track the currently-open dropdown's close handler in a static field; `open()` dismisses it before opening the next, so only one dropdown is ever open. Cleared on close/destroy.

Client `tsc --noEmit` clean.