### PR TITLE
fix(subtitles): demote no-embedded-subtitles log to debug

### DIFF
--- a/backend/src/modules/subtitles/embedded-subtitle.service.ts
+++ b/backend/src/modules/subtitles/embedded-subtitle.service.ts
@@ -36,7 +36,9 @@ export class EmbeddedSubtitleService {
 
     const streams = await this.ffprobe.detectEmbeddedSubtitles(videoPath);
     if (!streams.length) {
-      this.logger.log(`No embedded subtitles in "${path.basename(videoPath)}"`);
+      this.logger.debug(
+        `No embedded subtitles in "${path.basename(videoPath)}"`,
+      );
       return [];
     }
 


### PR DESCRIPTION
Logged at `log` level once per file with no embedded track — a line per item on every rescan/import sweep. Demoted to `debug`; the "Found N embedded subtitle(s)" line is unchanged.