### PR TITLE
fix(streaming): gate eco quality rungs on source video bitrate

### DIFF
--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -733,11 +733,25 @@ export class StreamBuilderService {
     }
 
     // Low-consumption rungs at every fitting resolution (4K eco, 1080p eco,
-    // 720p eco…). Same on every device. Only listed when genuinely lighter
-    // than the source — no point offering an eco rung heavier than the file.
+    // 720p eco…). Same on every device. Gated on the source VIDEO bitrate: an
+    // eco rung is only worth a forced re-encode when it genuinely shrinks the
+    // video. Comparing against the source TOTAL would wrongly offer an eco rung
+    // whose only "saving" is a fat audio track (downmixed on any rung anyway),
+    // re-encoding the video for no gain. Falls back to total-vs-total when the
+    // source video bitrate is unknown.
+    const sourceVideoBps = resolveSourceVideoBitrateBps(
+      source.videoBitRate,
+      source.formatBitRate,
+      source.audioBitRate ?? 0,
+    );
     const savingRef = sourceTotal > 0 ? sourceTotal : totalOf(topProfile);
     for (const p of available) {
-      if (!isEcoProfile(p.name) || totalOf(p) >= savingRef) continue;
+      if (!isEcoProfile(p.name)) continue;
+      const reducesVideo =
+        sourceVideoBps && sourceVideoBps > 0
+          ? cappedRungVideoBitrateBps(p, rungCtx) < sourceVideoBps
+          : totalOf(p) < savingRef;
+      if (!reducesVideo) continue;
       entries.push({
         option: {
           id: p.name,


### PR DESCRIPTION
## Summary
An eco ("faible consommation") rung was listed whenever its **total** bitrate beat the **source total**. For a low-bitrate video carrying a heavy audio track (e.g. a 1080p HEVC ~2 Mbps source with EAC3 5.1), the eco rung's only "saving" was the audio downmix — which already happens on the normal rung — so picking it **re-encoded the video for no bandwidth gain**, costing CPU and a bit of quality.

Now each eco rung is gated on the source **video** bitrate: it's only offered when its codec-capped video target is genuinely below the source video bitrate. Falls back to the previous total-vs-total comparison when the source video bitrate is unknown.

## Effect
- 1080p HEVC ~2 Mbps source → "1080p (faible consommation)" disappears (no real video reduction); "720p eco" still shown.
- 4K AV1 ~5.6 Mbps source → no "4K eco" (AV1→HEVC re-encode would inflate); 1080p/720p eco still shown.
- Genuinely high-bitrate sources keep their eco rungs.

## Test plan
- [x] 1080p HEVC ~2 Mbps + EAC3 5.1 → no 1080p eco after restarting playback.
- [ ] High-bitrate 1080p still offers 1080p eco.
- [ ] 4K AV1 behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)