### PR TITLE
fix(cast): show the eco indicator in the Chromecast quality dropdown

### DIFF
--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -67,7 +67,9 @@ export interface CastQualityOption {
  *  derived from the rung id itself (`parseInt('Np')`) so adding a new
  *  rung server-side requires no client change. */
 export function buildCastQualityOptions(
-  qualities: { id: string; label: string; height: number }[] | undefined,
+  qualities:
+    | { id: string; label: string; height: number; lowBandwidth?: boolean }[]
+    | undefined,
   maxQuality: string | undefined,
 ): CastQualityOption[] {
   if (!qualities?.length) return [];
@@ -77,7 +79,7 @@ export function buildCastQualityOptions(
       : Infinity;
   return qualities
     .filter(q => q.id !== 'original' && q.height <= heightCap)
-    .map(q => ({ id: q.id, label: q.label }));
+    .map(q => ({ id: q.id, label: q.label, lowBandwidth: q.lowBandwidth }));
 }
 
 interface SubtitleInfo {


### PR DESCRIPTION
## Summary
On the Chromecast quality dropdown, eco ("faible consommation") rungs weren't distinguished from normal rungs of the same resolution, so they looked like unexplained duplicates.

`buildCastQualityOptions` copied only `id`/`label` and dropped the `lowBandwidth` flag coming from the backend. The `cast-remote` template already renders `({{ 'player.low_bandwidth' | translate }})` when the flag is set — this just propagates it.

## Test plan
- [ ] While casting, open the quality dropdown: eco rungs show "(faible consommation)" like the local player.

🤖 Generated with [Claude Code](https://claude.com/claude-code)