### PR TITLE
fix(scroller): keep nav arrow above a card's hover play overlay

### DIFF
--- a/client/src/app/shared/components/horizontal-scroller.css
+++ b/client/src/app/shared/components/horizontal-scroller.css
@@ -13,7 +13,9 @@
 .scroll-edge {
   position: absolute;
   top: 50%;
-  z-index: 10;
+  /* Above a card's hover play overlay (z-10) so the nav arrow stays clickable
+     when it overlaps a card edge. */
+  z-index: 20;
   transform: translateY(-50%);
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
The horizontal row scroller's prev/next navigation arrow and a media card's hover **play** button were both at `z-index: 10`, so when the arrow overlapped a card edge the play overlay (later in the DOM) covered it. Bump the scroller arrow to `z-index: 20`.

## Test plan
- [ ] Hover a row card so its play button shows under a scroller arrow → the arrow stays visible and clickable on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)