### PR TITLE
fix(streaming): declare real transcoded segment duration to stop A/V drift

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -188,10 +188,21 @@ function statSizeOrNull(filePath: string): number | null {
  *  `[N*SEG, (N+1)*SEG)`. The EXTINF values mirror what FFmpeg actually emits
  *  so Shaka's presentation timeline stays aligned with the moof PTS the
  *  segments carry. */
+/** On-disk length of a uniform transcoded segment: the encoder pins one GOP of
+ *  `round(SEGMENT_DURATION · fps)` frames per segment, so it spans `gop / fps`
+ *  seconds — equal to SEGMENT_DURATION for integer fps, longer for fractional
+ *  rates (24000/1001 → 3.003s at a 3s setting). */
+function transcodeSegmentSeconds(fps: number | undefined): number {
+  if (!fps || fps <= 0) return SEG_DURATION;
+  const gop = Math.max(1, Math.round(SEG_DURATION * fps));
+  return gop / fps;
+}
+
 function buildVodPlaylist(
   duration: number,
   segmentUrl: (index: string) => string,
   initUrl?: string,
+  segDuration: number = SEG_DURATION,
 ): string {
   // Subtract small epsilon before ceil to avoid phantom last segment when
   // ffprobe duration has floating-point imprecision (e.g. 120.001 → ceil
@@ -199,12 +210,12 @@ function buildVodPlaylist(
   const epsilon = 0.05;
   const segCount = Math.max(
     1,
-    Math.ceil(Math.max(0, duration - epsilon) / SEG_DURATION),
+    Math.ceil(Math.max(0, duration - epsilon) / segDuration),
   );
   const lines = [
     '#EXTM3U',
     '#EXT-X-VERSION:7',
-    `#EXT-X-TARGETDURATION:${Math.ceil(SEG_DURATION)}`,
+    `#EXT-X-TARGETDURATION:${Math.ceil(segDuration)}`,
     '#EXT-X-MEDIA-SEQUENCE:0',
     '#EXT-X-PLAYLIST-TYPE:VOD',
     '#EXT-X-INDEPENDENT-SEGMENTS',
@@ -213,8 +224,8 @@ function buildVodPlaylist(
     lines.push(`#EXT-X-MAP:URI="${initUrl}"`);
   }
   for (let i = 0; i < segCount; i++) {
-    const segStart = i * SEG_DURATION;
-    const segLen = Math.min(SEG_DURATION, duration - segStart);
+    const segStart = i * segDuration;
+    const segLen = Math.min(segDuration, duration - segStart);
     if (segLen <= 0) break;
     lines.push(`#EXTINF:${segLen.toFixed(3)},`);
     lines.push(segmentUrl(String(i).padStart(4, '0')));
@@ -1264,10 +1275,18 @@ export class StreamingController {
     const basePath = `/api/stream/${mediaFileId}/audio/${audioIndex}`;
     const useTs = live?.useTs ?? false;
     const segExt = useTs ? 'ts' : 'm4s';
+    // var_stream_map audio renditions are cut on the video GOP grid, so they
+    // share the video's real per-segment duration.
+    const sourceFps =
+      parseFloat(resolved.mediaFile.streamInfo?.video?.[0]?.frameRate ?? '') ||
+      undefined;
+    const audioSegDuration =
+      useExtXMedia && !useTs ? transcodeSegmentSeconds(sourceFps) : SEG_DURATION;
     const playlist = buildVodPlaylist(
       duration,
       (seg) => `${basePath}/seg-${seg}.${segExt}${tokenParam}`,
       useTs ? undefined : `${basePath}/init_${audioIndex + 1}.mp4${tokenParam}`,
+      audioSegDuration,
     );
 
     res.setHeader('Content-Type', 'application/vnd.apple.mpegurl');
@@ -1591,9 +1610,21 @@ export class StreamingController {
         duration,
       );
     }
+    // Transcoded fMP4 segments span one GOP each — declare their real length
+    // so fractional-fps streams stay in A/V sync. Remux (variable) and TS keep
+    // their own paths.
+    const sourceFps =
+      parseFloat(resolved.mediaFile.streamInfo?.video?.[0]?.frameRate ?? '') ||
+      undefined;
+    const transcodeFmp4 = quality !== 'remux' && !useTs;
     const playlist = remuxDurations
       ? buildVariableVodPlaylist(remuxDurations, segmentUrl, initRef)
-      : buildVodPlaylist(duration, segmentUrl, initRef);
+      : buildVodPlaylist(
+          duration,
+          segmentUrl,
+          initRef,
+          transcodeFmp4 ? transcodeSegmentSeconds(sourceFps) : SEG_DURATION,
+        );
 
     res.setHeader('Content-Type', 'application/vnd.apple.mpegurl');
     res.setHeader('Access-Control-Allow-Origin', '*');


### PR DESCRIPTION
## Problem

Progressive audio/video desync reported on iOS, Shaka (Chrome) and the Windows app, growing over an episode (~2.5–2.7s at 45 min), correlated with 23.976fps content.

Root cause is server-side, in the per-segment playlist clock — not the encode (the fps is correct everywhere; no `-r`/`-fps_mode`).

The encoder pins the GOP to `round(segmentDuration × fps)` frames (`-g`/`-keyint_min`) and the HLS muxer cuts one GOP per segment, so a transcoded fMP4 segment really spans `gop / fps` seconds. For fractional rates that exceeds the nominal grid — at 24000/1001 fps with a 3s setting each segment is 72 frames = **3.003s** — but `buildVodPlaylist` declared a flat **3.000s** `#EXTINF` for both the video and the var_stream_map audio renditions. Strict players (AVPlayer, mpv) schedule segments end-to-end by `#EXTINF` and accumulate the ~3ms/segment gap into seconds of desync.

The remux path was already fixed (`buildVariableVodPlaylist` + probed keyframe durations); the transcode and audio-rendition paths were not.

## Fix

Declare the true per-segment length `round(segmentDuration × fps) / fps`:
- transcode video media playlist
- var_stream_map audio renditions (cut on the same video GOP grid)

`round(S × fps) / fps === S` for integer fps, so this is a **no-op for 24/25/30/60fps content** — only fractional rates (23.976/29.97/59.94) change (3.000 → 3.003). Remux (variable) and the Tizen TS path are untouched. `timeline.ts` (tfdt rewrite) is deliberately not touched: from-start playback early-returns from it, so the tfdt already carries true PTS.

## Validation

- `tsc --noEmit` clean.
- Diagnosis confirmed by code reading (uniform pinned-GOP segments) and by the symptom itself: a flat-fps no-op fix matching "only fractional-fps content drifts".
- Not exercised on-device (no 23.976 test stream available); the no-op-for-integer-fps property bounds the blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)