### PR TITLE
fix(streaming): batch of A/V timing correctness fixes (seek grid, tfdt, sprite)

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -38,6 +38,7 @@ import {
 import {
   EARLY_PROBE_SEGMENTS,
   getSegmentDuration,
+  realSegmentSeconds,
   secondsToSegmentIndex,
 } from './transcoding/constants';
 import {
@@ -184,20 +185,10 @@ function statSizeOrNull(filePath: string): number | null {
 }
 
 /** Generate a VOD HLS playlist for a given duration and segment URL pattern.
- *  Uniform segment grid: each segment is SEG_DURATION seconds, seg-N covers
- *  `[N*SEG, (N+1)*SEG)`. The EXTINF values mirror what FFmpeg actually emits
- *  so Shaka's presentation timeline stays aligned with the moof PTS the
- *  segments carry. */
-/** On-disk length of a uniform transcoded segment: the encoder pins one GOP of
- *  `round(SEGMENT_DURATION · fps)` frames per segment, so it spans `gop / fps`
- *  seconds — equal to SEGMENT_DURATION for integer fps, longer for fractional
- *  rates (24000/1001 → 3.003s at a 3s setting). */
-function transcodeSegmentSeconds(fps: number | undefined): number {
-  if (!fps || fps <= 0) return SEG_DURATION;
-  const gop = Math.max(1, Math.round(SEG_DURATION * fps));
-  return gop / fps;
-}
-
+ *  `segDuration` is the real per-segment length (see `realSegmentSeconds`);
+ *  seg-N covers `[N*segDuration, (N+1)*segDuration)`, so the EXTINF values
+ *  mirror what FFmpeg actually emits and the presentation timeline stays
+ *  aligned with the moof PTS the segments carry. */
 function buildVodPlaylist(
   duration: number,
   segmentUrl: (index: string) => string,
@@ -339,13 +330,16 @@ export class StreamingController {
    */
   private resumeFloor(
     live: { position: number } | null | undefined,
-    existing: { startSegment?: number | null } | null | undefined,
+    existing:
+      | { startSegment?: number | null; sourceFps?: number }
+      | null
+      | undefined,
     boundaries?: number[],
   ): number {
     const posIndex = live
       ? boundaries
         ? boundarySecondsToIndex(boundaries, live.position)
-        : secondsToSegmentIndex(live.position)
+        : secondsToSegmentIndex(live.position, existing?.sourceFps)
       : 0;
     return Math.max(existing?.startSegment ?? 0, posIndex);
   }
@@ -433,7 +427,10 @@ export class StreamingController {
         (session?.hdrLadder ?? false) && !startQuality.endsWith('-hdr')
           ? `${startQuality}-hdr`
           : startQuality;
-      const startSegment = Math.max(0, secondsToSegmentIndex(effectiveStartAt));
+      const startSegment = Math.max(
+        0,
+        secondsToSegmentIndex(effectiveStartAt, ctx.sourceFps),
+      );
 
       // The seg-0 early-start companion runs in parallel with main and serves
       // seg-0 instantly while main encodes forward from seg-K. It only earns
@@ -1281,7 +1278,7 @@ export class StreamingController {
       parseFloat(resolved.mediaFile.streamInfo?.video?.[0]?.frameRate ?? '') ||
       undefined;
     const audioSegDuration =
-      useExtXMedia && !useTs ? transcodeSegmentSeconds(sourceFps) : SEG_DURATION;
+      useExtXMedia && !useTs ? realSegmentSeconds(sourceFps) : SEG_DURATION;
     const playlist = buildVodPlaylist(
       duration,
       (seg) => `${basePath}/seg-${seg}.${segExt}${tokenParam}`,
@@ -1493,7 +1490,7 @@ export class StreamingController {
       segPath,
       segmentContentType(segment),
       {
-        segDuration: SEG_DURATION,
+        segDuration: realSegmentSeconds(videoSession.sourceFps),
       },
     );
   }
@@ -1565,7 +1562,7 @@ export class StreamingController {
             mediaFileId,
             quality,
             resolved.absolutePath,
-            secondsToSegmentIndex(startAtSec),
+            secondsToSegmentIndex(startAtSec, ctx.sourceFps),
             ctx,
           );
         }
@@ -1623,7 +1620,7 @@ export class StreamingController {
           duration,
           segmentUrl,
           initRef,
-          transcodeFmp4 ? transcodeSegmentSeconds(sourceFps) : SEG_DURATION,
+          transcodeFmp4 ? realSegmentSeconds(sourceFps) : SEG_DURATION,
         );
 
     res.setHeader('Content-Type', 'application/vnd.apple.mpegurl');
@@ -1731,7 +1728,7 @@ export class StreamingController {
           res,
           initPath,
           segmentContentType(segment),
-          { segDuration: SEG_DURATION },
+          { segDuration: realSegmentSeconds(src.sourceFps) },
         );
         return;
       }
@@ -1767,7 +1764,7 @@ export class StreamingController {
           segPath,
           segmentContentType(segment),
           {
-            segDuration: SEG_DURATION,
+            segDuration: realSegmentSeconds(existing.sourceFps),
           },
         );
         return;
@@ -1860,7 +1857,7 @@ export class StreamingController {
             segPath,
             segmentContentType(segment),
             {
-              segDuration: SEG_DURATION,
+              segDuration: realSegmentSeconds(earlySession.sourceFps),
             },
           );
           return;
@@ -1950,7 +1947,7 @@ export class StreamingController {
       segPath,
       segmentContentType(segment),
       {
-        segDuration: SEG_DURATION,
+        segDuration: realSegmentSeconds(session.sourceFps),
         skipTimelineRewrite: quality === 'remux',
       },
     );

--- a/backend/src/modules/streaming/thumbnail.service.ts
+++ b/backend/src/modules/streaming/thumbnail.service.ts
@@ -549,6 +549,36 @@ export class ThumbnailService {
         `Too many frame extractions failed (${failed}/${count}) — sprite would be mostly empty`,
       );
     }
+
+    // A transient seek failure leaves a hole in the frame-NNNN sequence; the
+    // image2 tiler stops at the first gap and blanks every later tile. Fill
+    // missing indices from the nearest present frame so the tiler reads a
+    // contiguous sequence.
+    if (failed > 0) await this.backfillMissingFrames(framesDir, count);
+  }
+
+  /** Copy the nearest extracted frame into any missing `frame-NNNN.jpg` slot so
+   *  the tiler's image2 input stays gap-free. No-op when nothing is missing. */
+  private async backfillMissingFrames(
+    framesDir: string,
+    count: number,
+  ): Promise<void> {
+    const frameFile = (i: number) =>
+      path.join(framesDir, `frame-${String(i).padStart(4, '0')}.jpg`);
+    const present = Array.from({ length: count + 1 }, (_, i) =>
+      i === 0 ? false : existsSync(frameFile(i)),
+    );
+    for (let i = 1; i <= count; i++) {
+      if (present[i]) continue;
+      let src = -1;
+      for (let d = 1; d < count && src === -1; d++) {
+        if (i - d >= 1 && present[i - d]) src = i - d;
+        else if (i + d <= count && present[i + d]) src = i + d;
+      }
+      if (src === -1) return; // nothing extracted at all
+      await fsp.copyFile(frameFile(src), frameFile(i));
+      present[i] = true;
+    }
   }
 
   /**
@@ -616,6 +646,8 @@ export class ThumbnailService {
         '-hide_banner',
         '-loglevel',
         'error',
+        '-start_number',
+        '1',
         '-i',
         path.join(framesDir, 'frame-%04d.jpg'),
         '-vf',

--- a/backend/src/modules/streaming/transcoding/constants.ts
+++ b/backend/src/modules/streaming/transcoding/constants.ts
@@ -40,16 +40,24 @@ export function setSegmentDuration(seg: number): void {
   segmentDuration = seg;
 }
 
-/** Convert a presentation time (seconds) to the FFmpeg segment number
- *  that contains it. Uniform grid: every segment is `segmentDuration`
- *  long, seg-N covers `[N*SEG, (N+1)*SEG)`. */
-export function secondsToSegmentIndex(seconds: number): number {
+/** Real length of one transcoded segment = a pinned GOP of
+ *  `round(segmentDuration · fps)` frames = `gop / fps` seconds. Equals
+ *  `segmentDuration` for integer / unknown fps; differs only for fractional
+ *  rates (24000/1001 → 3.003s at a 3s setting). */
+export function realSegmentSeconds(fps?: number): number {
+  if (!fps || fps <= 0) return segmentDuration;
+  return Math.max(1, Math.round(segmentDuration * fps)) / fps;
+}
+
+/** Presentation time (seconds) → containing FFmpeg segment number, on the
+ *  `fps`-aware real-duration grid. */
+export function secondsToSegmentIndex(seconds: number, fps?: number): number {
   if (seconds <= 0) return 0;
-  return Math.floor(seconds / segmentDuration);
+  return Math.floor(seconds / realSegmentSeconds(fps));
 }
 
 /** Inverse of `secondsToSegmentIndex` — start time of an FFmpeg segment. */
-export function segmentIndexToSeconds(segment: number): number {
+export function segmentIndexToSeconds(segment: number, fps?: number): number {
   if (segment <= 0) return 0;
-  return segment * segmentDuration;
+  return segment * realSegmentSeconds(fps);
 }

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -1,6 +1,10 @@
 import { Logger } from '@nestjs/common';
 import * as path from 'path';
-import { getSegmentDuration, segmentIndexToSeconds } from './constants';
+import {
+  getSegmentDuration,
+  realSegmentSeconds,
+  segmentIndexToSeconds,
+} from './constants';
 import {
   cappedTranscodeVideoBitrateBps,
   isHdrProfile,
@@ -260,18 +264,21 @@ export function buildFfmpegArgs(
   // Fallback to 24 fps when source fps is unknown (safe for most content).
   const fps = sourceFps && sourceFps > 0 ? sourceFps : 24;
   const gopSize = Math.max(1, Math.round(SEGMENT_DURATION * fps));
+  // Real segment length on the wire (gop/fps). The seek grid, the force-IDR
+  // cadence, the playlist EXTINF and the fMP4 tfdt all anchor on this so they
+  // agree on fractional-fps sources. Equals SEGMENT_DURATION for integer fps.
+  const realSeg = realSegmentSeconds(sourceFps);
 
   // Resume point for mid-file seek (`startSegment > 0`). Seek to T,
   // then `-copyts` (set after `-i` below) threads source PTS through
   // to the muxer so the first segment lands at tfdt = T × timescale.
   const seekSeconds =
-    startSegment > 0 ? segmentIndexToSeconds(startSegment) : 0;
+    startSegment > 0 ? segmentIndexToSeconds(startSegment, sourceFps) : 0;
 
-  // Force an IDR every `SEGMENT_DURATION` seconds so the HLS muxer can
-  // cut segments on a uniform grid. On a seek-resume we use `-copyts`
-  // so the encoder's `t` is in source time — the expression anchors at
-  // `seekSeconds` and IDRs land on the same grid as before the seek.
-  const forceKeyframesExpr = `expr:gte(t,${seekSeconds}+n_forced*${SEGMENT_DURATION})`;
+  // Force an IDR every `realSeg` seconds so the HLS muxer cuts on the same grid
+  // the playlist declares. `-copyts` keeps the encoder's `t` in source time, so
+  // the expression anchors at `seekSeconds` and IDRs survive a seek-resume.
+  const forceKeyframesExpr = `expr:gte(t,${seekSeconds}+n_forced*${realSeg})`;
   // Closed-GOP, deterministic IDR placement on h264_qsv:
   //  - `-forced_idr 1` : every `force_key_frames` tick lands as a real
   //    IDR (without it, qsvenc emits some as plain I, breaking HLS

--- a/backend/src/modules/streaming/transcoding/timeline.ts
+++ b/backend/src/modules/streaming/transcoding/timeline.ts
@@ -188,6 +188,12 @@ export function rewriteSegmentTfdt(
       buf.writeBigUInt64BE(BigInt(value), f.valueOffset);
     } else if (value <= 0xffffffff) {
       buf.writeUInt32BE(value, f.valueOffset);
+    } else {
+      // Widening a version-0 tfdt would change the box size (forbidden here);
+      // fail loudly rather than silently leave a colliding run-relative tfdt.
+      throw new RangeError(
+        `tfdt ${value} exceeds the 32-bit version-0 box at offset ${f.valueOffset}`,
+      );
     }
   }
   return buf;

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -1598,6 +1598,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     )
       ? 'var-stream-map'
       : 'inline';
+    session.sourceFps = ctx.sourceFps;
     if (!session.startedAt) session.startedAt = new Date();
   }
 

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -253,6 +253,9 @@ export interface TranscodeSession {
    *  whether a cache gap is ahead of (reachable) or behind (unreachable)
    *  the current encoding position. */
   startSegment?: number;
+  /** Source frame rate this session encodes at. Lets the segment-serve path
+   *  resolve the real segment-duration grid without re-probing streamInfo. */
+  sourceFps?: number;
   /** Marks the session as killed intentionally (seek restart, quality
    *  change, etc.) so the close handler doesn't log a spurious "exited
    *  WITHOUT producing first segment" warning. */


### PR DESCRIPTION
Follow-up to the fractional-fps EXTINF fix (#572): an adversarial sweep of the
streaming pipeline surfaced a class of "declared value ≠ produced value" bugs.
This ships the three that are clean and a strict no-op for the common case.

## Fixes

### 1. Anchor seek/resume + tfdt on the real fps-aware segment grid
#572 moved the playlist EXTINF to the real per-segment length `round(seg·fps)/fps`,
but the resume seek, the force-IDR cadence and the fMP4 `tfdt` anchor stayed on
the nominal integer grid. On fractional-fps transcodes (24000/1001) a deep
seek/resume therefore landed progressively earlier than the scrub target
(~N·3ms, e.g. ~3.6s at 1h) and Shaka's resumed `tfdt` drifted from the playlist.

Centralised the grid in `realSegmentSeconds(fps)` and routed every transcode-path
consumer through it (encoder `-ss` + `force_key_frames`, the `startSegment`
buckets, and the segment-serve `tfdt` anchor via the session's stored `sourceFps`).
`realSegmentSeconds === segmentDuration` for integer fps → **no-op for
24/25/30/50/60fps content**; remux (keyframe boundaries) and the Tizen TS path
are untouched.

### 2. Fail loudly on 32-bit tfdt overflow
The version-0 `tfdt` rewrite silently wrote nothing past the 32-bit range
(~13.3h at 90kHz), serving a colliding run-relative timeline. Now throws a
`RangeError`. Unreachable for real-runtime content; turns silent corruption into
an observable error.

### 3. Backfill missing seek-preview frames
A transient frame-extraction failure left a hole in the `frame-NNNN` sequence;
the image2 tiler stops at the first gap and blanks every later sprite tile.
Backfill missing indices from the nearest extracted frame before tiling, and pin
the tiler to `-start_number 1`. No-op when every frame extracted.

## Validation
- `tsc --noEmit` clean; full streaming suite green (208 tests); the ffmpeg-args
  golden snapshots are unchanged (confirms #1 is a no-op for integer fps).
- Reviewed adversarially: #1/#2/#3 confirmed clean (no-op for their common case).

## Deferred (need more than a clean small change — not in this PR)
- **External subtitle offset on TS rips**: needs a new `start_time` ffprobe field
  + a subtitle→mediaFile lookup in the external-sub route.
- **Remux first-EXTINF over-declaration** (non-zero source start PTS): needs a
  segment-boundaries API change to separate content-relative durations from the
  absolute seek array, and wants validation on a real TS rip.
- **AC-3/E-AC-3 master BANDWIDTH undercount** and **EXT-X-MEDIA CHANNELS for
  copied 7.1**: both need the real per-track output bitrate/channels threaded
  through the (already 17-positional-param) `generateMasterPlaylist`; deferred to
  avoid bloating that signature for advisory-only attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)