### PR TITLE
fix(streaming): anchor remux segment grid at the source start PTS

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -42,8 +42,7 @@ import {
   secondsToSegmentIndex,
 } from './transcoding/constants';
 import {
-  getRemuxSegmentDurations,
-  boundariesFromDurations,
+  getRemuxSegmentGrid,
   secondsToSegmentIndex as boundarySecondsToIndex,
 } from './transcoding/segment-boundaries';
 import { LiveSessionRegistry } from './live-session.service';
@@ -229,7 +228,7 @@ function buildVodPlaylist(
  *  path, where ffmpeg cuts at source keyframes so segments are variable-length
  *  and a uniform `EXTINF` grid would mislead strict players (AVPlayer) into a
  *  progressive A/V drift. `durations` mirror ffmpeg's actual segment lengths
- *  (see {@link getRemuxSegmentDurations}). */
+ *  (see {@link getRemuxSegmentGrid}). */
 function buildVariableVodPlaylist(
   durations: number[],
   segmentUrl: (index: string) => string,
@@ -346,14 +345,14 @@ export class StreamingController {
 
   /** Keyframe-aligned cumulative segment boundaries for the remux/copy path,
    *  or null when keyframes can't be probed (fall back to the uniform grid).
-   *  Cached per file by {@link getRemuxSegmentDurations}; the playlist is
+   *  Cached per file by {@link getRemuxSegmentGrid}; the playlist is
    *  fetched before segments, so segment-time lookups hit the warm cache. */
   private async remuxBoundaries(
     absolutePath: string,
     durationHint = 0,
   ): Promise<number[] | null> {
-    const durations = await getRemuxSegmentDurations(absolutePath, durationHint);
-    return durations ? boundariesFromDurations(durations) : null;
+    const grid = await getRemuxSegmentGrid(absolutePath, durationHint);
+    return grid ? grid.boundaries : null;
   }
 
   /**
@@ -1602,10 +1601,9 @@ export class StreamingController {
     // fMP4 only — the Tizen MPEG-TS fallback keeps the uniform path.
     let remuxDurations: number[] | null = null;
     if (quality === 'remux' && !useTs) {
-      remuxDurations = await getRemuxSegmentDurations(
-        resolved.absolutePath,
-        duration,
-      );
+      remuxDurations =
+        (await getRemuxSegmentGrid(resolved.absolutePath, duration))
+          ?.durations ?? null;
     }
     // Transcoded fMP4 segments span one GOP each — declare their real length
     // so fractional-fps streams stay in A/V sync. Remux (variable) and TS keep

--- a/backend/src/modules/streaming/transcoding/segment-boundaries.spec.ts
+++ b/backend/src/modules/streaming/transcoding/segment-boundaries.spec.ts
@@ -22,6 +22,15 @@ describe('computeSegmentDurations', () => {
     expect(durs.every((d) => d > 0)).toBe(true);
   });
 
+  it('anchors at the first keyframe for sources with a non-zero start PTS', () => {
+    // TS rip: first PTS 1.4s. SEG=3, duration 10.4. Cuts advance from 1.4, so
+    // the first segment is firstCut - start (= 3.0), not firstCut (= 4.4).
+    const durs = computeSegmentDurations([1.4, 4.4, 7.4], 10.4, 3);
+    expect(durs).toHaveLength(3);
+    durs.forEach((d) => expect(d).toBeCloseTo(3, 6));
+    expect(durs.reduce((a, b) => a + b, 0)).toBeCloseTo(9, 6); // total - start
+  });
+
   it('returns empty when there are no keyframes', () => {
     expect(computeSegmentDurations([], 100, 6)).toEqual([]);
   });
@@ -47,5 +56,12 @@ describe('boundary helpers', () => {
     expect(segmentIndexToSeconds(boundaries, 0)).toBe(0);
     expect(segmentIndexToSeconds(boundaries, 1)).toBe(7);
     expect(segmentIndexToSeconds(boundaries, 2)).toBe(13);
+  });
+
+  it('offsets cumulative boundaries by the source start PTS', () => {
+    // Content durations [3,3,3] from a TS rip starting at 1.4s seek to the
+    // absolute keyframes 1.4 / 4.4 / 7.4, ending at the real total 10.4.
+    const b = boundariesFromDurations([3, 3, 3], 1.4);
+    [1.4, 4.4, 7.4, 10.4].forEach((v, i) => expect(b[i]).toBeCloseTo(v, 6));
   });
 });

--- a/backend/src/modules/streaming/transcoding/segment-boundaries.ts
+++ b/backend/src/modules/streaming/transcoding/segment-boundaries.ts
@@ -24,10 +24,20 @@ const log = new Logger('SegmentBoundaries');
  * boundaries to within a few milliseconds.
  */
 
+/** Real per-segment content durations (for the playlist EXTINF) plus the
+ *  absolute cut times in source PTS (for resume seeking). Kept together because
+ *  both come from one keyframe walk and a source whose first PTS is non-zero
+ *  (TS / PVR rips) must declare content-relative durations while still seeking
+ *  to the absolute keyframe. */
+export interface SegmentGrid {
+  durations: number[];
+  boundaries: number[];
+}
+
 interface CacheEntry {
   mtimeMs: number;
   segDur: number;
-  durations: number[];
+  grid: SegmentGrid;
 }
 
 const cache = new Map<string, CacheEntry>();
@@ -76,9 +86,14 @@ export function computeSegmentDurations(
   const total = Math.max(totalDuration, last);
   if (total <= 0) return [];
 
+  // Anchor at the first keyframe: ffmpeg measures each segment's elapsed time
+  // from its own first packet, so on a source with start PTS > 0 (TS / PVR
+  // rips) cuts advance from `start`, not 0, and the first segment's real
+  // duration is `firstCut - start`. For start === 0 this is unchanged.
+  const start = keyframeTimes[0];
   const durations: number[] = [];
-  let lastCut = 0;
-  let target = segDur;
+  let lastCut = start;
+  let target = start + segDur;
   for (const kf of keyframeTimes) {
     if (kf >= target) {
       durations.push(kf - lastCut);
@@ -91,10 +106,14 @@ export function computeSegmentDurations(
   return durations;
 }
 
-/** Cumulative segment start times; `boundaries[i]` is the start of seg-`i`,
- *  the last entry is the total end. */
-export function boundariesFromDurations(durations: number[]): number[] {
-  const boundaries = [0];
+/** Cumulative segment start times from `start`; `boundaries[i]` is the start of
+ *  seg-`i`, the last entry is the total end. `start` is the source's first PTS
+ *  (0 for MP4/MKV) so the boundaries stay in absolute source time for seeking. */
+export function boundariesFromDurations(
+  durations: number[],
+  start = 0,
+): number[] {
+  const boundaries = [start];
   for (const d of durations) {
     boundaries.push(boundaries[boundaries.length - 1] + d);
   }
@@ -123,15 +142,16 @@ export function segmentIndexToSeconds(
 }
 
 /**
- * Resolve (and cache) the keyframe-aligned segment durations for a source.
+ * Resolve (and cache) the keyframe-aligned segment grid for a source: real
+ * per-segment durations (playlist EXTINF) and absolute cut times (seeking).
  * Returns null when keyframes can't be read — the caller then falls back to the
  * uniform grid (no regression). Cache is keyed by path + mtime + segment length.
  */
-export async function getRemuxSegmentDurations(
+export async function getRemuxSegmentGrid(
   filePath: string,
   totalDuration: number,
   segDur: number = getSegmentDuration(),
-): Promise<number[] | null> {
+): Promise<SegmentGrid | null> {
   let mtimeMs = 0;
   try {
     mtimeMs = statSync(filePath).mtimeMs;
@@ -140,14 +160,18 @@ export async function getRemuxSegmentDurations(
   }
   const hit = cache.get(filePath);
   if (hit && hit.mtimeMs === mtimeMs && hit.segDur === segDur) {
-    return hit.durations;
+    return hit.grid;
   }
   try {
     const keyframes = await extractKeyframeTimes(filePath);
     const durations = computeSegmentDurations(keyframes, totalDuration, segDur);
     if (durations.length === 0) return null;
-    cache.set(filePath, { mtimeMs, segDur, durations });
-    return durations;
+    const grid: SegmentGrid = {
+      durations,
+      boundaries: boundariesFromDurations(durations, keyframes[0]),
+    };
+    cache.set(filePath, { mtimeMs, segDur, grid });
+    return grid;
   } catch (err) {
     log.warn(
       `Keyframe probe failed for ${filePath}; falling back to uniform grid: ${(err as Error).message}`,


### PR DESCRIPTION
From the streaming bug-hunt: the remux/copy HLS playlist over-declared its first
`#EXTINF` (and total duration) by the source's first-keyframe PTS when the
source starts at a non-zero PTS (TS / PVR captures, first PTS ≈ 1.4s).

`computeSegmentDurations` anchored `lastCut = 0`, but ffmpeg measures each HLS
segment's elapsed time from its own first packet, so seg-0 really runs from the
first keyframe. The first EXTINF therefore included the start offset (overshot
the scrubber/EOF by ~start, and skewed the first window's seek mapping); strict
EXTINF-trusting players (AVPlayer) could wait at a phantom tail.

## Fix
Anchor the grid at `keyframeTimes[0]`: durations become true content lengths for
the playlist, while `getRemuxSegmentGrid` returns the absolute keyframe cut times
for resume seeking alongside them (one keyframe walk, returned together so the
EXTINF can be content-relative while the seek stays absolute). `boundariesFromDurations`
gains a `start` offset for the same reason.

**No-op for MP4/MKV** (start PTS 0 → identical durations + boundaries[0]=0); only
non-zero-start remux sources change. Seek boundaries for index ≥ 1 are unchanged
(still the absolute keyframes), so resume is unaffected.

## Validation
- `tsc` clean; full streaming suite green (210 tests, incl. a new non-zero-start case).
- Note: the visible effect is on TS/PVR remux rips, which aren't in the local test
  set — the fix is unit-tested and is a strict no-op for the dominant MP4/MKV path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)