### PR TITLE
refactor(streaming): master-playlist options object + real audio BANDWIDTH/CHANNELS

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -1054,36 +1054,37 @@ export class StreamingController {
       useExtXMedia && live?.audioTrackPlans?.length
         ? live.audioTrackPlans[0].outputCodec
         : (live?.audioPlan?.codec ?? 'aac');
-    const playlist = this.transcodingService.generateMasterPlaylist(
+    const playlist = this.transcodingService.generateMasterPlaylist({
       mediaFileId,
-      w,
-      h,
+      sourceWidth: w,
+      sourceHeight: h,
       tokenParam,
       includeRemux,
-      sourceBitrate || undefined,
+      sourceBitrate: sourceBitrate || undefined,
       // Pass the array when we want EXT-X-MEDIA renditions, OR when the
       // source has zero audio streams — the empty array signals
       // `noAudio` to the master-playlist builder so CODECS drops the
       // audio entry (otherwise Shaka / ExoPlayer reject the variant).
       // `undefined` keeps the muxed single-audio layout for everyone else.
-      useExtXMedia || audioStreams.length === 0 ? audioStreams : undefined,
+      audioStreams:
+        useExtXMedia || audioStreams.length === 0 ? audioStreams : undefined,
       onlyQuality,
-      pickedIdx ?? 0,
+      defaultAudioIndex: pickedIdx ?? 0,
       deviceType,
-      masterAudioCodec,
+      outputAudioCodec: masterAudioCodec,
       hdrPassThrough,
       // Only the SDR ladder branch consumes this — the HDR branch
       // already drives its codec strings from `hdrPassThrough`.
-      sdrVariant && sdrVariant.hdr == null ? sdrVariant : undefined,
+      sdrVariant: sdrVariant && sdrVariant.hdr == null ? sdrVariant : undefined,
       sourceFrameRate,
       subtitleRenditions,
-      resolveSourceVideoBitrateBps(
+      sourceVideoBitrateBps: resolveSourceVideoBitrateBps(
         v?.bitRate,
         si?.formatBitRate,
         (si?.audio ?? []).reduce((sum, a) => sum + (a?.bitRate ?? 0), 0),
       ),
-      (v?.codec ?? '').toLowerCase() || undefined,
-    );
+      sourceVideoCodec: (v?.codec ?? '').toLowerCase() || undefined,
+    });
 
     res.setHeader('Content-Type', 'application/vnd.apple.mpegurl');
     res.setHeader('Access-Control-Allow-Origin', '*');

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -1068,6 +1068,10 @@ export class StreamingController {
       // `undefined` keeps the muxed single-audio layout for everyone else.
       audioStreams:
         useExtXMedia || audioStreams.length === 0 ? audioStreams : undefined,
+      // Real per-track output channels (copy keeps source, transcode downmixes)
+      // so the rendition CHANNELS hint matches the bytes; aligned with the
+      // source audio order the session produces renditions in.
+      audioOutputChannels: live?.audioTrackPlans?.map((p) => p.outputChannels),
       onlyQuality,
       defaultAudioIndex: pickedIdx ?? 0,
       deviceType,

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -1076,6 +1076,12 @@ export class StreamingController {
       defaultAudioIndex: pickedIdx ?? 0,
       deviceType,
       outputAudioCodec: masterAudioCodec,
+      // Real output audio bitrate so the BANDWIDTH sum reflects the 640k
+      // AC-3/E-AC-3 path, not the profile nominal; copy renditions fall back.
+      audioOutputBitrateBps:
+        live?.audioPlan?.mode === 'transcode'
+          ? live.audioPlan.bitrateBps
+          : undefined,
       hdrPassThrough,
       // Only the SDR ladder branch consumes this — the HDR branch
       // already drives its codec strings from `hdrPassThrough`.

--- a/backend/src/modules/streaming/transcoding/hls-variant-ladder.ts
+++ b/backend/src/modules/streaming/transcoding/hls-variant-ladder.ts
@@ -55,11 +55,12 @@ export function buildUniqueAudioNames(
 }
 
 /** Emit one `EXT-X-MEDIA:TYPE=AUDIO` rendition per source audio stream, sharing
- *  the `audio` group. CHANNELS reports the rendition's real output layout (AAC
- *  downmixes to 2 via `-ac 2`; copy / AC-3 / E-AC-3 keep the source layout) —
+ *  the `audio` group. CHANNELS reports the rendition's real output layout —
  *  Tizen AVPlay needs the hint to pre-allocate the decoder before fetching the
  *  rendition, else the single-audio fMP4 path never follows the rendition link
- *  (issue #148). */
+ *  (issue #148). `outputChannels[i]` is the resolved per-track output count
+ *  (copy keeps the source, transcode downmixes); falls back to a codec-derived
+ *  guess when the plan isn't threaded. */
 export function emitAudioRenditions(
   lines: string[],
   audioStreams: AudioStreamMeta[],
@@ -67,6 +68,7 @@ export function emitAudioRenditions(
   outputAudioCodec: string,
   mediaFileId: number,
   tokenParam: string,
+  outputChannels?: (number | undefined)[],
 ): void {
   const pickedIdx =
     defaultAudioIndex >= 0 && defaultAudioIndex < audioStreams.length
@@ -77,8 +79,10 @@ export function emitAudioRenditions(
     const a = audioStreams[i];
     const lang = a.language || 'und';
     const isDefault = i === pickedIdx ? 'YES' : 'NO';
+    const channels =
+      outputChannels?.[i] ?? audioRenditionChannels(outputAudioCodec, a.channels);
     lines.push(
-      `#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="${names[i]}",LANGUAGE="${lang}",DEFAULT=${isDefault},AUTOSELECT=${isDefault},CHANNELS="${audioRenditionChannels(outputAudioCodec, a.channels)}",URI="/api/stream/${mediaFileId}/audio/${i}/index.m3u8${tokenParam}"`,
+      `#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="${names[i]}",LANGUAGE="${lang}",DEFAULT=${isDefault},AUTOSELECT=${isDefault},CHANNELS="${channels}",URI="/api/stream/${mediaFileId}/audio/${i}/index.m3u8${tokenParam}"`,
     );
   }
 }

--- a/backend/src/modules/streaming/transcoding/hls-variant-ladder.ts
+++ b/backend/src/modules/streaming/transcoding/hls-variant-ladder.ts
@@ -94,6 +94,10 @@ export interface VariantLadderOptions {
   /** VIDEO-RANGE attribute value; omitted (SDR) leaves the attribute off. */
   range?: 'PQ' | 'HLG';
   audioAttr: string;
+  /** Real output audio bitrate (bps) for the BANDWIDTH/AVERAGE-BANDWIDTH sum.
+   *  Falls back to the per-rung profile nominal when absent — which undercounts
+   *  AC-3/E-AC-3 (encoded at a fixed 640k, far above the nominal). */
+  audioBitrateBps?: number;
   subsAttr: string;
   frameRateAttr: string;
   codecsTail: string;
@@ -121,6 +125,7 @@ export function emitVariantLadder(
     variant,
     range,
     audioAttr,
+    audioBitrateBps,
     subsAttr,
     frameRateAttr,
     codecsTail,
@@ -147,7 +152,8 @@ export function emitVariantLadder(
       sourceVideoBitrateBps,
       sourceVideoCodec,
     });
-    const avg = cappedVideo + parseBitrateToBps(p.audioBitrate);
+    const avg =
+      cappedVideo + (audioBitrateBps ?? parseBitrateToBps(p.audioBitrate));
     // BANDWIDTH ~1.5x nominal: with -maxrate == -b:v the encoder is near-CBR but
     // VBV bursts push segments ~30% above nominal; the margin gives AVPlayer ABR
     // stable hysteresis.

--- a/backend/src/modules/streaming/transcoding/index.ts
+++ b/backend/src/modules/streaming/transcoding/index.ts
@@ -32,6 +32,7 @@ export type { SessionVariant } from './variant';
 export {
   generateMasterPlaylist,
   getAvailableProfiles,
+  type MasterPlaylistOptions,
 } from './master-playlist';
 export { TranscodingService } from './transcoding.service';
 export { TranscodeCacheService } from './transcode-cache.service';

--- a/backend/src/modules/streaming/transcoding/master-playlist.golden.spec.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.golden.spec.ts
@@ -48,26 +48,21 @@ function master(opts: MasterOpts = {}): string {
     sourceFrameRate = 24,
     sourceVideoCodec = 'hevc',
   } = opts;
-  return generateMasterPlaylist(
-    7, // mediaFileId
-    width,
-    height,
-    '', // tokenParam
-    false, // includeRemux
-    undefined, // sourceBitrate
+  return generateMasterPlaylist({
+    mediaFileId: 7,
+    sourceWidth: width,
+    sourceHeight: height,
+    tokenParam: '',
     audioStreams,
-    undefined, // onlyQuality
-    0, // defaultAudioIndex
     deviceType,
     outputAudioCodec,
-    hdrVariant ? { hdrFormat, hdrVariant } : undefined,
-    !!hdrVariant, // canEmitHdrLadder
+    hdrPassThrough: hdrVariant ? { hdrFormat, hdrVariant } : undefined,
+    canEmitHdrLadder: !!hdrVariant,
     sdrVariant,
     sourceFrameRate,
-    undefined, // subtitleRenditions
-    SRC_BITRATE,
+    sourceVideoBitrateBps: SRC_BITRATE,
     sourceVideoCodec,
-  );
+  });
 }
 
 describe('generateMasterPlaylist — golden manifests (characterization)', () => {

--- a/backend/src/modules/streaming/transcoding/master-playlist.spec.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.spec.ts
@@ -11,23 +11,15 @@ function hdrMaster(
   opts: { hdrFormat?: 'HDR10' | 'HLG'; canEmitHdrLadder?: boolean } = {},
 ): string {
   const { hdrFormat = 'HDR10', canEmitHdrLadder = true } = opts;
-  return generateMasterPlaylist(
-    1, // mediaFileId
-    3840, // sourceWidth
-    2160, // sourceHeight
-    '', // tokenParam
-    false, // includeRemux
-    undefined, // sourceBitrate
-    undefined, // audioStreams
-    undefined, // onlyQuality
-    0, // defaultAudioIndex
-    'desktop', // deviceType
-    'aac', // outputAudioCodec
-    { hdrFormat, hdrVariant }, // hdrPassThrough
+  return generateMasterPlaylist({
+    mediaFileId: 1,
+    sourceWidth: 3840,
+    sourceHeight: 2160,
+    tokenParam: '',
+    hdrPassThrough: { hdrFormat, hdrVariant },
     canEmitHdrLadder,
-    undefined, // sdrVariant
-    24, // sourceFrameRate
-  );
+    sourceFrameRate: 24,
+  });
 }
 
 const streamInfLines = (m: string): string[] =>

--- a/backend/src/modules/streaming/transcoding/master-playlist.spec.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.spec.ts
@@ -94,3 +94,23 @@ describe('generateMasterPlaylist — audio rendition CHANNELS', () => {
     expect(mediaLines(m)[0]).toContain('CHANNELS="6"');
   });
 });
+
+describe('generateMasterPlaylist — audio bitrate in BANDWIDTH', () => {
+  const maxAvgBandwidth = (m: string): number =>
+    Math.max(
+      ...[...m.matchAll(/AVERAGE-BANDWIDTH=(\d+)/g)].map((x) => Number(x[1])),
+    );
+
+  it('folds the real output audio bitrate into AVERAGE-BANDWIDTH', () => {
+    const base = {
+      mediaFileId: 1,
+      sourceWidth: 1920,
+      sourceHeight: 1080,
+      tokenParam: '',
+    };
+    const hi = generateMasterPlaylist({ ...base, audioOutputBitrateBps: 640_000 });
+    const lo = generateMasterPlaylist({ ...base, audioOutputBitrateBps: 100_000 });
+    // Same video rungs; only the audio component differs by the exact delta.
+    expect(maxAvgBandwidth(hi) - maxAvgBandwidth(lo)).toBe(540_000);
+  });
+});

--- a/backend/src/modules/streaming/transcoding/master-playlist.spec.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.spec.ts
@@ -61,3 +61,36 @@ describe('generateMasterPlaylist — HDR ladder is variant-driven (#464)', () =>
     expect(lines).toHaveLength(0);
   });
 });
+
+describe('generateMasterPlaylist — audio rendition CHANNELS', () => {
+  const mediaLines = (m: string): string[] =>
+    m.split('\n').filter((l) => l.startsWith('#EXT-X-MEDIA:TYPE=AUDIO'));
+
+  it('declares the resolved output channels, not the source layout', () => {
+    // 7.1 (8ch) source: track 0 transcoded to E-AC-3 ships 6, track 1 copied keeps 8.
+    const m = generateMasterPlaylist({
+      mediaFileId: 1,
+      sourceWidth: 1920,
+      sourceHeight: 1080,
+      tokenParam: '',
+      outputAudioCodec: 'eac3',
+      audioStreams: [{ channels: 8 }, { channels: 8 }],
+      audioOutputChannels: [6, 8],
+    });
+    const media = mediaLines(m);
+    expect(media[0]).toContain('CHANNELS="6"');
+    expect(media[1]).toContain('CHANNELS="8"');
+  });
+
+  it('falls back to the codec-derived count when output channels are absent', () => {
+    const m = generateMasterPlaylist({
+      mediaFileId: 1,
+      sourceWidth: 1920,
+      sourceHeight: 1080,
+      tokenParam: '',
+      outputAudioCodec: 'eac3',
+      audioStreams: [{ channels: 6 }],
+    });
+    expect(mediaLines(m)[0]).toContain('CHANNELS="6"');
+  });
+});

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -91,6 +91,10 @@ export interface MasterPlaylistOptions {
   includeRemux?: boolean;
   sourceBitrate?: number;
   audioStreams?: AudioStreamMeta[];
+  /** Resolved per-track output channel count (aligned with `audioStreams`):
+   *  source count when copied, downmix target when transcoded. Drives the
+   *  rendition CHANNELS attribute; codec-derived fallback when absent. */
+  audioOutputChannels?: (number | undefined)[];
   onlyQuality?: string;
   defaultAudioIndex?: number;
   deviceType?: DeviceType;
@@ -130,6 +134,7 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
     includeRemux = false,
     sourceBitrate,
     audioStreams,
+    audioOutputChannels,
     onlyQuality,
     defaultAudioIndex = 0,
     deviceType = 'desktop',
@@ -266,6 +271,7 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
       outputAudioCodec,
       mediaFileId,
       tokenParam,
+      audioOutputChannels,
     );
   }
 

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -83,79 +83,65 @@ export function getAvailableProfiles(
   );
 }
 
-/**
- * Generate the HLS master playlist listing available qualities.
- */
-export function generateMasterPlaylist(
-  mediaFileId: number,
-  sourceWidth: number,
-  sourceHeight: number,
-  tokenParam: string,
-  includeRemux = false,
-  sourceBitrate?: number,
-  audioStreams?: AudioStreamMeta[],
-  onlyQuality?: string,
-  defaultAudioIndex = 0,
-  deviceType: DeviceType = 'desktop',
-  /** Output audio codec actually emitted by ffmpeg. The CODECS attribute
-   *  must match or the receiver rejects the segment at MSE chunk-demuxer
-   *  append. Recognised values: `'aac'` (AAC-LC), `'ac3'` (Dolby Digital),
-   *  `'eac3'` (Dolby Digital Plus). Defaults to AAC for legacy callers. */
-  outputAudioCodec: string = 'aac',
-  /** When set, the master emits an HDR ladder instead of the SDR transcode
-   *  ladder. `hdrVariant` is the codec the encoder pipeline resolved for this
-   *  HDR source on the host (HEVC Main10 on QSV/VAAPI/NVENC/VideoToolbox,
-   *  native AV1 HDR on NVENC Ada / libsvtav1); every rung's CODECS string is
-   *  derived from it (`hvc1.2.4.*` for HEVC, `av01.*.10` for AV1). iOS
-   *  AVPlayer / ExoPlayer use the `VIDEO-RANGE` attribute + the codec string
-   *  to dispatch to the HDR rendering path. */
+export interface MasterPlaylistOptions {
+  mediaFileId: number;
+  sourceWidth: number;
+  sourceHeight: number;
+  tokenParam: string;
+  includeRemux?: boolean;
+  sourceBitrate?: number;
+  audioStreams?: AudioStreamMeta[];
+  onlyQuality?: string;
+  defaultAudioIndex?: number;
+  deviceType?: DeviceType;
+  /** Output audio codec ffmpeg emits; the CODECS attribute must match it or the
+   *  receiver rejects the segment on MSE append. `aac` | `ac3` | `eac3`. */
+  outputAudioCodec?: string;
+  /** When set, emit an HDR ladder (gated by `canEmitHdrLadder`); `hdrVariant`
+   *  drives every rung's CODECS + VIDEO-RANGE. */
   hdrPassThrough?: {
     hdrFormat: 'HDR10' | 'HLG';
     hdrVariant: CodecVariant;
     videoBitRateBps?: number;
     audioBitRateBps?: number;
-  },
-  /** True when the registry has a probed-OK encoder for `hdrPassThrough.
-   *  hdrVariant` on this host (the resolved codec + HDR format, with CPU
-   *  fallback). When false the HDR ladder is skipped so the master never
-   *  advertises HDR rungs whose segments the host can't actually produce —
-   *  a `hvc1.*`/`av01.*` CODECS claim with no matching encoder trips a
-   *  Media3 fallback-options crash on ExoPlayer / an MSE append reject. */
-  canEmitHdrLadder = false,
-  /** SDR-ladder output codec, picked by the codec selector. When the
-   *  selector promoted HEVC (source codec match, or efficiency
-   *  ranking on HEVC-capable clients), every SDR rung emits a
-   *  `hvc1.*` CODECS string instead of `avc1.*` so MSE doesn't reject
-   *  the appended segments. Absent for legacy callers that haven't
-   *  threaded the variant through — falls back to H.264 codec strings. */
-  sdrVariant?: CodecVariant,
-  /** Source frame rate in fps (e.g. 23.976, 24, 29.97). Emitted as the
-   *  HLS `FRAME-RATE` attribute on every `#EXT-X-STREAM-INF` and fed
-   *  into the codec-string level computation. REQUIRED on HDR variants:
-   *  Apple's HLS parser rejects PQ/HLG rungs missing `FRAME-RATE` with
-   *  `HDR alternate is missing FRAME-RATE` (CoreMedia -12642), and when
-   *  every HDR variant is filtered out AVPlayer surfaces the empty
-   *  playable set as `NSURLErrorUnsupportedURL -1002`. Defaults to 24
-   *  so legacy callers without source info still produce a valid
-   *  manifest. */
-  sourceFrameRate = 24,
-  /** Text subtitle tracks to advertise as an HLS `SUBTITLES` rendition
-   *  group. When non-empty, a `#EXT-X-MEDIA:TYPE=SUBTITLES` line is emitted
-   *  per track and every `#EXT-X-STREAM-INF` gains `SUBTITLES="subs"`, so a
-   *  native HLS player (AVPlayer, ExoPlayer, AVPlay, webOS) renders cues
-   *  inside its own pipeline — visible in PiP / AirPlay / lock-screen.
-   *  Empty / undefined keeps the manifest subtitle-free (web + older
-   *  clients keep fetching sidecar VTT). The renditions are decoupled from
-   *  the video transcode: each URI points at a tiny media playlist wrapping
-   *  the WebVTT the subtitle service already extracts, so the HEVC
-   *  `var_stream_map` is untouched (no decoder-buffer regression). */
-  subtitleRenditions?: SubtitleRenditionMeta[],
-  /** Probed (or estimated) source video bitrate + codec. Each transcode
-   *  rung's declared BANDWIDTH is capped to the source (no upward inflation),
-   *  matching the encode cap in `buildFfmpegArgs`. Omitted → no cap. */
-  sourceVideoBitrateBps?: number,
-  sourceVideoCodec?: string,
-): string {
+  };
+  /** Host has a probed-OK encoder for `hdrPassThrough.hdrVariant`; false skips
+   *  the HDR ladder so the master never advertises rungs it can't produce. */
+  canEmitHdrLadder?: boolean;
+  /** SDR-ladder output codec from the selector (HEVC promotion → `hvc1.*`). */
+  sdrVariant?: CodecVariant;
+  /** Source fps for the `FRAME-RATE` attribute — required on HDR rungs (Apple
+   *  rejects PQ/HLG rungs without it). */
+  sourceFrameRate?: number;
+  /** Text subtitle tracks to advertise as a `SUBTITLES` rendition group. */
+  subtitleRenditions?: SubtitleRenditionMeta[];
+  /** Source video bitrate + codec; caps each rung's declared BANDWIDTH. */
+  sourceVideoBitrateBps?: number;
+  sourceVideoCodec?: string;
+}
+
+/** Generate the HLS master playlist listing available qualities. */
+export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
+  const {
+    mediaFileId,
+    sourceWidth,
+    sourceHeight,
+    tokenParam,
+    includeRemux = false,
+    sourceBitrate,
+    audioStreams,
+    onlyQuality,
+    defaultAudioIndex = 0,
+    deviceType = 'desktop',
+    outputAudioCodec = 'aac',
+    hdrPassThrough,
+    canEmitHdrLadder = false,
+    sdrVariant,
+    sourceFrameRate = 24,
+    subtitleRenditions,
+    sourceVideoBitrateBps,
+    sourceVideoCodec,
+  } = opts;
   // The "multi-audio" flag is really an "EXT-X-MEDIA layout" toggle —
   // the caller decided whether to split audio into renditions. Single-
   // audio sources can opt-in (Tizen fMP4 needs it; see issue #148), so

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -101,6 +101,9 @@ export interface MasterPlaylistOptions {
   /** Output audio codec ffmpeg emits; the CODECS attribute must match it or the
    *  receiver rejects the segment on MSE append. `aac` | `ac3` | `eac3`. */
   outputAudioCodec?: string;
+  /** Real output audio bitrate (bps) for each rung's BANDWIDTH; profile nominal
+   *  fallback when absent (undercounts the fixed-640k AC-3/E-AC-3 path). */
+  audioOutputBitrateBps?: number;
   /** When set, emit an HDR ladder (gated by `canEmitHdrLadder`); `hdrVariant`
    *  drives every rung's CODECS + VIDEO-RANGE. */
   hdrPassThrough?: {
@@ -139,6 +142,7 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
     defaultAudioIndex = 0,
     deviceType = 'desktop',
     outputAudioCodec = 'aac',
+    audioOutputBitrateBps,
     hdrPassThrough,
     canEmitHdrLadder = false,
     sdrVariant,
@@ -247,6 +251,7 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
         variant: hdrVariant,
         range,
         audioAttr: hdrAudioAttr,
+        audioBitrateBps: hdrPassThrough.audioBitRateBps ?? audioOutputBitrateBps,
         subsAttr,
         frameRateAttr,
         codecsTail,
@@ -305,6 +310,7 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
     profiles,
     variant: sdrVariant ?? SDR_H264_VARIANT,
     audioAttr,
+    audioBitrateBps: audioOutputBitrateBps,
     subsAttr,
     frameRateAttr,
     codecsTail,

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -45,6 +45,7 @@ import {
 import {
   generateMasterPlaylist,
   getAvailableProfiles,
+  type MasterPlaylistOptions,
 } from './master-playlist';
 import {
   fileExists,
@@ -406,63 +407,20 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     return getAvailableProfiles(sourceWidth, sourceHeight, deviceType);
   }
 
-  /** Generate the HLS master playlist listing available qualities. */
+  /** Generate the HLS master playlist listing available qualities. The HDR
+   *  ladder is gated here on the registry having a probed-OK encoder for the
+   *  resolved variant (codec + HDR format, with CPU fallback) so the manifest
+   *  never advertises HDR rungs the host can't actually emit. */
   generateMasterPlaylist(
-    mediaFileId: number,
-    sourceWidth: number,
-    sourceHeight: number,
-    tokenParam: string,
-    includeRemux = false,
-    sourceBitrate?: number,
-    audioStreams?: { language?: string; title?: string }[],
-    onlyQuality?: string,
-    defaultAudioIndex = 0,
-    deviceType: DeviceType = 'desktop',
-    outputAudioCodec: string = 'aac',
-    hdrPassThrough?: {
-      hdrFormat: 'HDR10' | 'HLG';
-      hdrVariant: import('./codec/types').CodecVariant;
-      videoBitRateBps?: number;
-      audioBitRateBps?: number;
-    },
-    sdrVariant?: import('./codec/types').CodecVariant,
-    sourceFrameRate?: number,
-    subtitleRenditions?: import('./types').SubtitleRenditionMeta[],
-    sourceVideoBitrateBps?: number,
-    sourceVideoCodec?: string,
+    opts: Omit<MasterPlaylistOptions, 'canEmitHdrLadder'>,
   ): string {
-    // Gate the HDR ladder on the registry having a probed-OK encoder for the
-    // variant the selector actually resolved — the chosen codec (HEVC or AV1)
-    // AND the source's HDR format (HDR10 or HLG), with automatic CPU fallback.
-    // The manifest then advertises only HDR rungs the host can emit; a `hvc1.*`
-    // / `av01.*` CODECS claim with no matching encoder would otherwise reject
-    // on MSE append (or crash Media3 on ExoPlayer).
-    const canEmitHdrLadder = hdrPassThrough
+    const canEmitHdrLadder = opts.hdrPassThrough
       ? !!encoderRegistry.resolve(
-          hdrPassThrough.hdrVariant,
+          opts.hdrPassThrough.hdrVariant,
           this.detectedHwAccel,
         )
       : false;
-    return generateMasterPlaylist(
-      mediaFileId,
-      sourceWidth,
-      sourceHeight,
-      tokenParam,
-      includeRemux,
-      sourceBitrate,
-      audioStreams,
-      onlyQuality,
-      defaultAudioIndex,
-      deviceType,
-      outputAudioCodec,
-      hdrPassThrough,
-      canEmitHdrLadder,
-      sdrVariant,
-      sourceFrameRate,
-      subtitleRenditions,
-      sourceVideoBitrateBps,
-      sourceVideoCodec,
-    );
+    return generateMasterPlaylist({ ...opts, canEmitHdrLadder });
   }
 
   /**


### PR DESCRIPTION
Finishes the streaming bug-hunt's two audio-attribute fixes, on a clean base.

## 1. Refactor: `generateMasterPlaylist` takes an options object
The function (and its service wrapper) had grown to ~18 positional parameters —
every call site was a column of bare values + comments, with no clean seam to
thread per-rendition data. Both now take a `MasterPlaylistOptions` object.
**Behaviour-preserving** — the golden master-playlist snapshots are unchanged.

## 2. Real per-track output CHANNELS on audio renditions
`EXT-X-MEDIA:...,CHANNELS` was re-derived from source layout + output codec, so a
7.1 source advertised `CHANNELS="8"` while a transcoded E-AC-3 rendition ships
5.1 (and a copied one keeps 8). Thread the resolved per-track output channel
count (`audioTrackPlans[i].outputChannels`) into the rendition line; codec-derived
fallback when no plan is present. (Tizen AVPlay pre-allocates its decoder from
this hint — issue #148.)

## 3. Real output audio bitrate in BANDWIDTH
Each rung's BANDWIDTH summed the profile-nominal audio bitrate, undercounting the
AC-3/E-AC-3 path (fixed 640k vs 48–192k nominal) — worst on low rungs, biasing
ABR toward cheap variants. Thread the session audio plan's `bitrateBps` into the
ladder; profile-nominal fallback for copy/unknown. No-op for AAC.

## Notes
- Both #2/#3 use the per-track audio plans, aligned by index with the source audio
  order the session produces renditions in (same order `outputCodec` is already
  read from). Both fall back to today's behaviour when the plan is absent, so
  they're no-ops for the common AAC/MP4 path.
- `tsc` clean; streaming suite green (213 tests, incl. new CHANNELS + BANDWIDTH cases);
  golden snapshots unchanged by the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)