### PR TITLE
fix(streaming): offset subtitle cues by the source start PTS on TS rips

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.spec.ts
+++ b/backend/src/modules/streaming/streaming.controller.spec.ts
@@ -1,5 +1,23 @@
-import { StreamingController } from './streaming.controller';
+import { StreamingController, withTimestampMap } from './streaming.controller';
 import type { LiveSession } from './live-session.service';
+
+describe('withTimestampMap', () => {
+  const mapLine = (vtt: string): string | undefined =>
+    vtt.split('\n').find((l) => l.startsWith('X-TIMESTAMP-MAP'));
+
+  it('emits MPEGTS:0 (no-op) for a zero start time', () => {
+    expect(mapLine(withTimestampMap('WEBVTT\n\n'))).toBe(
+      'X-TIMESTAMP-MAP=MPEGTS:0,LOCAL:00:00:00.000',
+    );
+  });
+
+  it('offsets cues by the source start PTS on the 90kHz clock', () => {
+    // 1.4s × 90000 → the cue at LOCAL 0 maps to the first frame, not 1.4s early.
+    expect(mapLine(withTimestampMap('WEBVTT\n\n', 1.4))).toBe(
+      'X-TIMESTAMP-MAP=MPEGTS:126000,LOCAL:00:00:00.000',
+    );
+  });
+});
 
 /**
  * Focused unit tests for the sid-scoped stop handler. The controller is

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -78,10 +78,18 @@ const VALID_QUALITIES = new Set([
  * time treat VTT time as relative to playback start, which drifts after
  * any seek that doesn't land on an exact keyframe (-noaccurate_seek).
  */
-const VTT_TIMESTAMP_MAP = 'X-TIMESTAMP-MAP=MPEGTS:0,LOCAL:00:00:00.000';
-function withTimestampMap(vtt: string | Buffer): string {
+export function withTimestampMap(
+  vtt: string | Buffer,
+  startSeconds = 0,
+): string {
   const text = typeof vtt === 'string' ? vtt : vtt.toString('utf-8');
-  return text.replace(/^(WEBVTT[^\n]*)\n/, `$1\n${VTT_TIMESTAMP_MAP}\n`);
+  // `-copyts` keeps the first video frame at the source start PTS, so 0-based
+  // cue times (sidecar SRT/ASS and embedded extracts alike) must be offset by
+  // it on the 90kHz MPEGTS clock — else cues lead the video by `startSeconds`
+  // on TS/PVR rips. `startSeconds` 0 → MPEGTS:0, the no-op for MP4/MKV.
+  const mpegts = Math.round(Math.max(0, startSeconds) * 90000);
+  const map = `X-TIMESTAMP-MAP=MPEGTS:${mpegts},LOCAL:00:00:00.000`;
+  return text.replace(/^(WEBVTT[^\n]*)\n/, `$1\n${map}\n`);
 }
 
 /** Default segment duration — overridden by admin streaming settings. */
@@ -1127,6 +1135,12 @@ export class StreamingController {
     @CurrentUser() user: User | undefined,
     @Res() res: Response,
   ) {
+    // ffmpeg extracts these cues without `-copyts`, so they come out 0-based —
+    // same as sidecar subs — and need the source start-PTS offset to line up
+    // with the video on TS/PVR rips. resolveFile also re-checks library access.
+    const resolved = await this.streamingService.resolveFile(mediaFileId, user);
+    const startTimeSeconds =
+      resolved.mediaFile.streamInfo?.video?.[0]?.startTimeSeconds ?? 0;
     const stream = await this.subtitleStreamService.extractEmbeddedSubtitle(
       mediaFileId,
       streamIndex,
@@ -1141,7 +1155,7 @@ export class StreamingController {
     const vtt = Buffer.concat(chunks);
     res.setHeader('Content-Type', 'text/vtt; charset=utf-8');
     res.setHeader('Access-Control-Allow-Origin', '*');
-    res.send(withTimestampMap(vtt));
+    res.send(withTimestampMap(vtt, startTimeSeconds));
   }
 
   /** Serve an external subtitle as WebVTT. */
@@ -1151,13 +1165,11 @@ export class StreamingController {
     @CurrentUser() user: User | undefined,
     @Res() res: Response,
   ) {
-    const vtt = await this.subtitleStreamService.getSubtitleAsVtt(
-      subtitleId,
-      user,
-    );
+    const { vtt, startTimeSeconds } =
+      await this.subtitleStreamService.getSubtitleAsVtt(subtitleId, user);
     res.setHeader('Content-Type', 'text/vtt; charset=utf-8');
     res.setHeader('Access-Control-Allow-Origin', '*');
-    res.send(withTimestampMap(vtt));
+    res.send(withTimestampMap(vtt, startTimeSeconds));
   }
 
   // HLS subtitle media playlists (single WebVTT segment) — referenced by the

--- a/backend/src/modules/streaming/subtitle-stream.service.ts
+++ b/backend/src/modules/streaming/subtitle-stream.service.ts
@@ -86,10 +86,13 @@ export class SubtitleStreamService {
   /**
    * Get an external subtitle file converted to WebVTT.
    */
-  async getSubtitleAsVtt(subtitleId: number, user?: User): Promise<string> {
+  async getSubtitleAsVtt(
+    subtitleId: number,
+    user?: User,
+  ): Promise<{ vtt: string; startTimeSeconds: number }> {
     const sub = await this.subtitleFileRepo.findOne({
       where: { id: subtitleId },
-      relations: ['media', 'media.library'],
+      relations: ['media', 'media.library', 'mediaFile'],
     });
     // Library ACL on the subtitle's OWN media, so a foreign subtitle id can't
     // be read regardless of the mediaFileId in the request path (IDOR).
@@ -125,13 +128,17 @@ export class SubtitleStreamService {
 
     const content = await fs.readFile(realSubPath, 'utf-8');
     const ext = path.extname(realSubPath).toLowerCase();
-
-    if (ext === '.vtt') return content;
-    if (ext === '.srt') return this.srtToVtt(content);
-    if (ext === '.ass' || ext === '.ssa') return this.assToVtt(content);
-
-    // Fallback: try SRT conversion
-    return this.srtToVtt(content);
+    // Sidecar cues are authored 0-based; the player aligns them via the
+    // X-TIMESTAMP-MAP offset, which the caller derives from this start PTS.
+    const startTimeSeconds =
+      sub.mediaFile?.streamInfo?.video?.[0]?.startTimeSeconds ?? 0;
+    const vtt =
+      ext === '.vtt'
+        ? content
+        : ext === '.ass' || ext === '.ssa'
+          ? this.assToVtt(content)
+          : this.srtToVtt(content); // .srt + unknown fallback
+    return { vtt, startTimeSeconds };
   }
 
   /**

--- a/backend/src/modules/subtitles/ffprobe.service.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.ts
@@ -44,6 +44,10 @@ export interface VideoStreamInfo {
   displayAspectRatio?: string;
   pixelFormat?: string;
   frameRate?: string;
+  /** Container start PTS of the video stream (seconds). Non-zero on TS / PVR
+   *  rips; the `-copyts` transcode keeps the first frame at this time, so
+   *  0-based sidecar/embedded subtitle cues must be shifted by it. */
+  startTimeSeconds?: number;
   bitRate?: number;
   bitDepth?: number;
   colorSpace?: string;
@@ -110,6 +114,7 @@ interface FfprobeStream {
   display_aspect_ratio?: string;
   pix_fmt?: string;
   r_frame_rate?: string;
+  start_time?: string;
   bit_rate?: string;
   bits_per_raw_sample?: string;
   color_space?: string;
@@ -350,6 +355,7 @@ export class FfprobeService {
           displayAspectRatio: s.display_aspect_ratio,
           pixelFormat: s.pix_fmt,
           frameRate: this.parseFrameRate(s.r_frame_rate),
+          startTimeSeconds: s.start_time ? Number(s.start_time) : undefined,
           bitRate: s.bit_rate ? Number(s.bit_rate) : undefined,
           bitDepth: s.bits_per_raw_sample
             ? Number(s.bits_per_raw_sample)


### PR DESCRIPTION
Last item from the streaming bug-hunt. On sources with a non-zero container
start PTS (TS / PVR captures, ≈1.4s), subtitles led the video by that offset on
timestamp-trusting native players (AVPlayer, ExoPlayer, AVPlay, webOS); Shaka
self-corrects.

## Mechanism (validated locally with ffmpeg, no device)
- `ffprobe` a TS rip → video `start_time = 1.4s`.
- The `-copyts` transcode keeps the first frame there → seg-0 first PTS = 1.416s.
- Both sidecar SRT/ASS **and** embedded extracts come out **0-based** (the embedded
  extraction runs without `-copyts`) — confirmed: a cue authored at content-2.0s
  extracts to `00:02.000`.
- Served with `X-TIMESTAMP-MAP=MPEGTS:0`, a content-0 cue maps to media-0 while the
  video frame is at media-1.4s → the cue leads by the start offset.

This refutes the earlier "embedded subs are already aligned" assumption — **both**
routes needed the shift.

## Fix
- Surface the video start PTS (`startTimeSeconds`, from ffprobe `start_time`) on the
  stream info.
- `withTimestampMap(vtt, startSeconds)` emits `MPEGTS:round(startSeconds × 90000)`,
  applied on both the embedded and external subtitle routes.

**No-op for MP4/MKV** (`start_time` 0 → `MPEGTS:0`, unchanged). The field populates on
the next rescan; until then the offset is 0 (today's behaviour). No DB migration
(the value rides the existing `streamInfo` jsonb).

## Validation
- `tsc` clean; streaming + subtitles suites green (240 tests), incl. new
  `withTimestampMap` 90kHz cases.
- Mechanism reproduced end-to-end locally on a synthetic `start_time=1.4s` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)