### PR TITLE
fix(streaming): drop the duplicate -ss in audio-only resume

### DIFF
--- a/backend/src/modules/streaming/transcoding/audio-only-args.spec.ts
+++ b/backend/src/modules/streaming/transcoding/audio-only-args.spec.ts
@@ -1,0 +1,38 @@
+import { Logger } from '@nestjs/common';
+import { buildAudioOnlyFfmpegArgs } from './ffmpeg-args';
+
+describe('buildAudioOnlyFfmpegArgs', () => {
+  const log = new Logger('test');
+
+  it('applies a single input-side -ss on resume (no double seek)', () => {
+    const args = buildAudioOnlyFfmpegArgs(
+      '/in.mkv',
+      '/out',
+      0,
+      '192k',
+      5, // startSegment
+      true,
+      log,
+      false,
+    );
+    // Exactly one -ss: a second (output-side, after -copyts) would re-discard
+    // the resume offset and start the audio at 2×T.
+    expect(args.filter((a) => a === '-ss')).toHaveLength(1);
+    // It precedes -i (demuxer seek), so -copyts threads the source PTS cleanly.
+    expect(args.indexOf('-ss')).toBeLessThan(args.indexOf('-i'));
+  });
+
+  it('emits no -ss for a fresh start', () => {
+    const args = buildAudioOnlyFfmpegArgs(
+      '/in.mkv',
+      '/out',
+      0,
+      '192k',
+      0,
+      true,
+      log,
+      false,
+    );
+    expect(args).not.toContain('-ss');
+  });
+});

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -820,10 +820,6 @@ export function buildAudioOnlyFfmpegArgs(
   // anchored to the same timeline as the main video output.
   args.push('-copyts', '-muxdelay', '0', '-muxpreload', '0');
 
-  if (startSegment > 0) {
-    args.push('-ss', String(seekSeconds));
-  }
-
   args.push('-map', audioMapSpec(audioStreams, audioStreamIndex));
   args.push('-vn');
   args.push('-c:a', 'aac', '-b:a', audioBitrate, '-ac', '2');


### PR DESCRIPTION
Found while auditing `buildAudioOnlyFfmpegArgs` for the options-object refactor.

On a resume (`startSegment > 0`) the function pushed `-ss <T>` **twice**: once
before `-i` (the demuxer/input seek) and again after `-copyts` (an output seek)
— two byte-identical copy-pasted blocks. With `-copyts`, the second seek
re-discards the resume offset, so an audio-only rendition resumed at **2×T** and
ran ahead of the video. Only the fallback (non `var_stream_map`) audio-only path
hits this builder, so it doesn't affect the common fMP4 multi-audio path.

Keep the input-side `-ss`, drop the duplicated output-side one.

## Validation
- New `audio-only-args.spec.ts`: asserts exactly one `-ss` on resume and that it
  precedes `-i` (so `-copyts` threads the source PTS), and none on fresh start.
- `tsc` clean; streaming suite green (231 tests). Note: the visible effect is a
  resume on the audio-only fallback path — not in the local test set — but the
  arg-level fix is unit-tested and the change is a strict removal of a duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)