### PR TITLE
fix(player): gate sidecar sub preload on NativeEngine not isNative

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1042,16 +1042,16 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
           this.applyNativeSubtitleStyle();
 
-          // Direct play plays the raw container, so external/OCR sidecar subs
-          // must be injected — transcode/remux carry them as HLS renditions.
-          if (this.isNative) {
+          // Capacitor native players preload sidecar subs into the MediaItem for
+          // direct play; HLS modes and the desktop mpv engine handle subs themselves.
+          if (this.engine instanceof NativeEngine) {
             const ext =
               mode === 'direct'
                 ? (await subsPromise)
                     .filter((s) => !s.burnIn && !!s.url && s.id.startsWith('ext-'))
                     .map((s) => ({ url: s.url, language: s.language, label: s.label }))
                 : [];
-            (this.engine as NativeEngine).setPreloadedSubtitles(ext);
+            this.engine.setPreloadedSubtitles(ext);
           }
 
           const token =


### PR DESCRIPTION
The desktop mpv engine reports `isNative=true` but is not a `NativeEngine` instance, so `setPreloadedSubtitles` was being called on an engine that doesn't implement it — breaking playback on the Linux desktop client.

Gating the preload on `this.engine instanceof NativeEngine` restricts it to the Capacitor native players, which is where sidecar subs actually need to be injected. HLS modes and the desktop mpv engine handle subtitles themselves.