### PR TITLE
fix(streaming): stop spurious mid-stream transcode respawns that desync A/V

### DIFF
--- a/backend/src/modules/streaming/transcoding/audio-only-args.spec.ts
+++ b/backend/src/modules/streaming/transcoding/audio-only-args.spec.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@nestjs/common';
 import { buildAudioOnlyFfmpegArgs } from './ffmpeg-args';
+import { segmentIndexToSeconds } from './constants';
 
 describe('buildAudioOnlyFfmpegArgs', () => {
   const log = new Logger('test');
@@ -20,6 +21,25 @@ describe('buildAudioOnlyFfmpegArgs', () => {
     expect(args.filter((a) => a === '-ss')).toHaveLength(1);
     // It precedes -i (demuxer seek), so -copyts threads the source PTS cleanly.
     expect(args.indexOf('-ss')).toBeLessThan(args.indexOf('-i'));
+  });
+
+  it('seeks on the fps-aware grid so audio stays aligned with video on fractional fps', () => {
+    const fps = 24000 / 1001; // 23.976
+    const args = buildAudioOnlyFfmpegArgs(
+      {
+        inputPath: '/in.mkv',
+        outputDir: '/out',
+        audioStreamIndex: 0,
+        startSegment: 5,
+        trustedStreamInfo: true,
+        sourceFps: fps,
+      },
+      log,
+    );
+    const seek = args[args.indexOf('-ss') + 1];
+    // Must match the video path's fps-aware seek, not the integer-grid value.
+    expect(seek).toBe(String(segmentIndexToSeconds(5, fps)));
+    expect(seek).not.toBe(String(segmentIndexToSeconds(5)));
   });
 
   it('emits no -ss for a fresh start', () => {

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -783,6 +783,8 @@ export interface BuildAudioOnlyArgsOptions {
    *  (relative) to its absolute ffprobe index so `-map 0:<abs>` skips
    *  FFmpeg's audio enumeration. */
   audioStreams?: AudioStreamMeta[];
+  /** Source fps, so the resume seek lands on the same fps-aware grid as video. */
+  sourceFps?: number;
 }
 
 /**
@@ -802,6 +804,7 @@ export function buildAudioOnlyFfmpegArgs(
     trustedStreamInfo = false,
     useTs = false,
     audioStreams,
+    sourceFps,
   } = opts;
   const segType = useTs ? 'mpegts' : 'fmp4';
   const segExt = useTs ? 'ts' : 'm4s';
@@ -821,7 +824,7 @@ export function buildAudioOnlyFfmpegArgs(
   }
 
   const seekSeconds =
-    startSegment > 0 ? segmentIndexToSeconds(startSegment) : 0;
+    startSegment > 0 ? segmentIndexToSeconds(startSegment, sourceFps) : 0;
 
   if (startSegment > 0) {
     args.push('-ss', String(seekSeconds));

--- a/backend/src/modules/streaming/transcoding/segment-utils.ts
+++ b/backend/src/modules/streaming/transcoding/segment-utils.ts
@@ -31,6 +31,31 @@ export async function segmentNearby(
 }
 
 /**
+ * True when a produced segment exists within `lookback` positions at or below
+ * `from` — i.e. the encoder frontier is at most `lookback` segments behind the
+ * request. Distinguishes a client buffering just ahead of a live encode (wait)
+ * from a genuine seek far past the frontier (restart).
+ */
+export async function segmentWithinReach(
+  cachePath: string,
+  from: number,
+  lookback: number,
+): Promise<boolean> {
+  const exts = ['.m4s', '.ts'];
+  const dirs = [cachePath, path.join(cachePath, '0')];
+  const lowest = Math.max(0, from - lookback);
+  for (let seg = from; seg >= lowest; seg--) {
+    const num = String(seg).padStart(4, '0');
+    for (const dir of dirs) {
+      for (const ext of exts) {
+        if (await fileExists(path.join(dir, `seg-${num}${ext}`))) return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
  * Delete cached segments numbered `>= fromSegment` across the flat layout and
  * any var_stream_map numeric subdirs (`0/`, `1/`, …). Called when a run
  * (re)starts at a new seek point: each run's segments carry a tfdt that is

--- a/backend/src/modules/streaming/transcoding/segment-within-reach.spec.ts
+++ b/backend/src/modules/streaming/transcoding/segment-within-reach.spec.ts
@@ -1,0 +1,60 @@
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { segmentWithinReach } from './segment-utils';
+
+const ROOT = '/tmp/fliks-within-reach-test';
+
+function seg(n: number): string {
+  return `seg-${String(n).padStart(4, '0')}.m4s`;
+}
+
+async function writeSegs(dir: string, from: number, to: number): Promise<void> {
+  await fsp.mkdir(dir, { recursive: true });
+  for (let n = from; n <= to; n++) {
+    await fsp.writeFile(path.join(dir, seg(n)), 'x');
+  }
+}
+
+describe('segmentWithinReach', () => {
+  beforeEach(async () => {
+    await fsp.rm(ROOT, { recursive: true, force: true });
+  });
+  afterEach(async () => {
+    await fsp.rm(ROOT, { recursive: true, force: true });
+  });
+
+  it('is true when the encoder frontier sits within lookback behind the request', async () => {
+    const dir = path.join(ROOT, 'near');
+    // Frontier at segment 200, mid-stream; client asks for 205 (buffer-ahead).
+    await writeSegs(dir, 0, 200);
+    expect(await segmentWithinReach(dir, 205, 15)).toBe(true);
+  });
+
+  it('is false when the request is further than lookback past the frontier', async () => {
+    const dir = path.join(ROOT, 'far');
+    // Frontier at 200; a real seek to 250 is 50 segments ahead.
+    await writeSegs(dir, 0, 200);
+    expect(await segmentWithinReach(dir, 250, 15)).toBe(false);
+  });
+
+  it('does not let the start segment widen the grace window (mid-stream lag is not a seek)', async () => {
+    const dir = path.join(ROOT, 'midstream');
+    // The frontier (180), not startSegment (0), bounds the grace: a request 2
+    // ahead of a deep frontier must wait, exactly as it would near segment 0.
+    await writeSegs(dir, 0, 180);
+    expect(await segmentWithinReach(dir, 182, 15)).toBe(true);
+    expect(await segmentWithinReach(dir, 200, 15)).toBe(false);
+  });
+
+  it('checks the var_stream_map 0/ subdir as well as the flat layout', async () => {
+    const dir = path.join(ROOT, 'vsm');
+    await writeSegs(path.join(dir, '0'), 0, 100);
+    expect(await segmentWithinReach(dir, 103, 15)).toBe(true);
+  });
+
+  it('is false on an empty cache (nothing produced yet)', async () => {
+    const dir = path.join(ROOT, 'empty');
+    await fsp.mkdir(dir, { recursive: true });
+    expect(await segmentWithinReach(dir, 5, 15)).toBe(false);
+  });
+});

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -53,6 +53,7 @@ import {
   firstMissingSegment,
   purgeSegmentsFrom,
   segmentNearby,
+  segmentWithinReach,
 } from './segment-utils';
 import { sessionKey } from './session-key';
 import {
@@ -333,11 +334,15 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     existing.lastAccess = Date.now();
 
     if (!(await segmentNearby(existing.cachePath, requestedSegment))) {
-      if (requestedSegment >= (existing.startSegment ?? 0)) {
-        const gap = requestedSegment - (existing.startSegment ?? 0);
-        if (gap <= SEEK_WAIT_THRESHOLD) {
-          return existing;
-        }
+      // Within reach of the encoder frontier: buffer-ahead, wait. Beyond it: seek.
+      if (
+        await segmentWithinReach(
+          existing.cachePath,
+          requestedSegment,
+          SEEK_WAIT_THRESHOLD,
+        )
+      ) {
+        return existing;
       }
       this.log.log(
         `Seek: restarting [${key}] from segment ${requestedSegment} (not cached)`,
@@ -1311,6 +1316,16 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         existing.lastAccess = Date.now();
 
         if (!(await segmentNearby(existing.cachePath, requestedSegment))) {
+          // Same wait/restart call as video, so the two sessions stay in step.
+          if (
+            await segmentWithinReach(
+              existing.cachePath,
+              requestedSegment,
+              SEEK_WAIT_THRESHOLD,
+            )
+          ) {
+            return existing;
+          }
           this.log.log(
             `Seek: restarting audio session [${key}] from segment ${requestedSegment} (not cached)`,
           );
@@ -1351,6 +1366,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         trustedStreamInfo: ctx?.trustedStreamInfo ?? false,
         useTs: ctx?.useTs ?? false,
         audioStreams: ctx?.audioStreams,
+        sourceFps: ctx?.sourceFps,
       },
       this.log,
     );


### PR DESCRIPTION
## Symptom

Watching a film via HLS transcode, around the middle, the audio and video suddenly went out of sync — an abrupt jump, not a gradual drift. No seek was performed. Quitting the player and resuming the transcode cleared it.

## Root cause

In `resolveExistingSession` (`transcoding.service.ts`), when the requested segment isn't yet on disk, the "wait for the encoder vs. restart as a seek" decision measured the gap as `requestedSegment - startSegment`. So the `SEEK_WAIT_THRESHOLD` (15) grace only held for the **first 15 segments of a run**. Deep in the film, `requestedSegment - startSegment` is in the hundreds, so any transient where the client buffered 2+ segments ahead of the encoder frontier (HW hiccup, I/O stall, GC pause) made `segmentNearby` false and the gap exceed the threshold — a plain forward playback was misread as a seek and the session was **killed and restarted mid-film**.

Worse, the audio session (`doGetOrCreateAudioSession`) had **no wait grace at all** and restarted on every such transient, while video waited. The two ffmpeg processes then restarted at different moments and timeline anchors → the sudden A/V desync. A separate fractional-fps offset compounded it: the audio-only seek used `segmentIndexToSeconds(startSegment)` **without** `sourceFps`, while video passed it.

This logic dates to `6993311d` (2026-05-03) — it is **not** a regression from the recent ffmpeg-args refactors.

## Fix

- Add `segmentWithinReach(cachePath, from, lookback)` — anchors the wait grace on the **encoder frontier** (a produced segment within `lookback` at or below the request), not on the run start. Bounded to `lookback + 1` existence checks.
- Use it in both the video and audio resolve paths, so the two sessions always make the **same** wait/restart call.
- Pass `sourceFps` to `buildAudioOnlyFfmpegArgs` so the audio resume seek lands on the same fps-aware grid as video.

## Structural note

The deeper fragility — audio and video as two independent ffmpeg sessions with parallel restart state machines that must stay in lockstep — remains. This PR makes the two paths symmetric; the durable follow-up would be to mux audio with video in a single session (var_stream_map already does this in some configs) and drop the separate audio session.

## Tests

- New `segment-within-reach.spec.ts` covers frontier-within-reach, far-seek, mid-stream-lag-is-not-a-seek, var_stream_map subdir, and empty cache.
- `audio-only-args.spec.ts` asserts the resume seek uses the fps-aware grid.
- Full streaming suite (golden args, master playlist, lifecycle, cache) passes; `tsc --noEmit` clean.