### PR TITLE
fix(requests): monitor only the requested seasons on a scoped import

### DIFF
--- a/backend/src/modules/media/media-service/media-import.season-scope.spec.ts
+++ b/backend/src/modules/media/media-service/media-import.season-scope.spec.ts
@@ -1,0 +1,97 @@
+import { MediaImportService } from './media-import.service';
+import { MediaType } from '../../../common/enums';
+
+/**
+ * A season-scoped request must monitor only the seasons it asked for on a fresh
+ * import; the rest import unmonitored so the auto-grab leaves them alone.
+ */
+describe('MediaImportService — season monitoring scope on import', () => {
+  function makeService() {
+    const created: { seasonNumber: number; monitored: boolean }[] = [];
+    const seasonRepo = {
+      create: jest.fn((s: any) => {
+        created.push(s);
+        return s;
+      }),
+      save: jest.fn(async (s: any) => ({ id: s.seasonNumber + 100, ...s })),
+    };
+    const mediaRepo = {
+      findOne: jest
+        .fn()
+        .mockResolvedValueOnce(null) // existing-title check
+        .mockResolvedValue({ id: 1 }), // reload after save
+      create: jest.fn((m: any) => m),
+      save: jest.fn(async (m: any) => ({ id: 1, ...m })),
+    };
+    const svc = new MediaImportService(
+      mediaRepo as any,
+      seasonRepo as any,
+      {} as any,
+      {} as any,
+      { query: jest.fn().mockResolvedValue([]) } as any,
+      {
+        getTvShowDetails: jest
+          .fn()
+          .mockResolvedValue({ title: 'X', tmdbId: 42 }),
+        getTvShowSeasons: jest
+          .fn()
+          .mockResolvedValue(
+            [0, 1, 2, 3, 4, 5, 6].map((n) => ({ seasonNumber: n })),
+          ),
+      } as any,
+      {} as any,
+      { get: jest.fn().mockReturnValue('tmdb-key') } as any,
+      {
+        resolveQualityProfileIdForImport: jest.fn().mockResolvedValue(null),
+        resolveLanguageProfileIdForImport: jest.fn().mockResolvedValue(null),
+      } as any,
+      {} as any,
+      { applySeriesFolderFormat: jest.fn().mockReturnValue('folder') } as any,
+      {
+        downloadMediaImagesInBackground: jest.fn(),
+        applySeasonDetails: jest.fn().mockResolvedValue(undefined),
+        updateSearchVector: jest.fn().mockResolvedValue(undefined),
+        persistMediaMetadataInBackground: jest.fn(),
+      } as any,
+      { onMediaImported: jest.fn().mockResolvedValue(undefined) } as any,
+    );
+    jest
+      .spyOn(svc as any, 'resolveImportTarget')
+      .mockResolvedValue({ libraryId: 7 });
+    return { svc, created };
+  }
+
+  const dto = { type: MediaType.SERIES, tmdbId: 42 } as any;
+
+  const monitoredNumbers = (
+    created: { seasonNumber: number; monitored: boolean }[],
+  ) =>
+    created
+      .filter((s) => s.monitored)
+      .map((s) => s.seasonNumber)
+      .sort((a, b) => a - b);
+
+  it('monitors only the requested seasons, leaving the rest unmonitored', async () => {
+    const { svc, created } = makeService();
+    await svc.importFromTmdb(dto, null, [1, 2, 3, 4]);
+    expect(monitoredNumbers(created)).toEqual([1, 2, 3, 4]);
+    expect(
+      created
+        .filter((s) => !s.monitored)
+        .map((s) => s.seasonNumber)
+        .sort((a, b) => a - b),
+    ).toEqual([0, 5, 6]);
+  });
+
+  it('monitors every season when the scope is null (whole series / admin add)', async () => {
+    const { svc, created } = makeService();
+    await svc.importFromTmdb(dto, null, null);
+    expect(created.every((s) => s.monitored)).toBe(true);
+  });
+
+  it('monitors every season when the scope is an empty array', async () => {
+    const { svc, created } = makeService();
+    await svc.importFromTmdb(dto, null, []);
+    expect(created.every((s) => s.monitored)).toBe(true);
+  });
+});

--- a/backend/src/modules/media/media-service/media-import.service.ts
+++ b/backend/src/modules/media/media-service/media-import.service.ts
@@ -61,6 +61,7 @@ export class MediaImportService {
   async importFromTmdb(
     dto: ImportTmdbDto,
     addedByUserId: number | null = null,
+    monitoredSeasons: number[] | null = null,
   ): Promise<Media> {
     const key = this.config.get<string>('TMDB_API_KEY', '');
     if (!key?.trim()) {
@@ -138,6 +139,7 @@ export class MediaImportService {
       folderName,
       libraryId,
       addedByUserId,
+      monitoredSeasons,
     );
   }
 
@@ -363,6 +365,7 @@ export class MediaImportService {
     folderName?: string,
     libraryId?: number,
     addedByUserId?: number | null,
+    monitoredSeasons?: number[] | null,
   ): Promise<Media> {
     const row = this.mediaRepo.create({
       ...buildMediaFieldsFromTmdb(details, MediaType.SERIES),
@@ -382,12 +385,18 @@ export class MediaImportService {
     this.logLibraryAdded('series', saved, `seasons=${seasons.length}`);
     this.metadata.downloadMediaImagesInBackground(saved.id, details);
 
+    // A season-scoped request only monitors the seasons it asked for; the rest
+    // import unmonitored so the auto-grab leaves them alone. An empty/absent
+    // scope (whole-series request or admin add) monitors every season.
+    const inScope = (n: number) =>
+      !monitoredSeasons?.length || monitoredSeasons.includes(n);
+
     for (const sd of seasons) {
       const sSaved = await this.seasonRepo.save(
         this.seasonRepo.create({
           media: saved,
           seasonNumber: sd.seasonNumber,
-          monitored: true,
+          monitored: inScope(sd.seasonNumber),
         }),
       );
       // Reuse the same per-season routine the metadata refresh uses so import

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -42,8 +42,12 @@ export class MediaService {
 
   // -- Imports ----------------------------------------------------------------
 
-  importFromTmdb(dto: ImportTmdbDto, addedByUserId: number | null = null) {
-    return this.imports.importFromTmdb(dto, addedByUserId);
+  importFromTmdb(
+    dto: ImportTmdbDto,
+    addedByUserId: number | null = null,
+    monitoredSeasons: number[] | null = null,
+  ) {
+    return this.imports.importFromTmdb(dto, addedByUserId, monitoredSeasons);
   }
 
   /**

--- a/backend/src/modules/requests/requests.service.ts
+++ b/backend/src/modules/requests/requests.service.ts
@@ -771,6 +771,7 @@ export class RequestsService {
           libraryId: spec.libraryId ?? undefined,
         },
         addedByUserId,
+        spec.seasons,
       );
     } catch (err: any) {
       if (err?.status !== 409) throw err;


### PR DESCRIPTION
## Problem

Requesting only some seasons of a series (e.g. seasons 1–4) and approving it monitored **every** season, not just the requested ones — so the auto-grab pipeline fetched seasons the user never asked for.

## Root cause

On approval, `ensureMediaForApprovedRequest` calls `importFromTmdb` **without** the request's season scope. A fresh series import (`persistImportedSeries`) then creates every season with `monitored: true`. The only season-scoping step, `applyMonitoredForRequestScope`, is deliberately one-directional (`false → true` only, to never overwrite an admin's manual choices) — so it can promote the requested seasons but never demote the rest. No code path ever set a season to `monitored: false`, so the non-requested seasons stayed monitored.

## Fix

Thread the requested season list from approval → `importFromTmdb` → `persistImportedSeries`, where out-of-scope seasons are now created `monitored: false`.

- A **null/empty** scope (whole-series request, or an admin "Add to library" with no request) keeps every season monitored — unchanged.
- The **existing-media reuse / 409** path is untouched: an admin's manual monitoring choices on a series already in the library are never overwritten.

## Tests

New `media-import.season-scope.spec.ts`:
- scoped request `[1,2,3,4]` → only those monitored, the rest (incl. specials) unmonitored;
- `null` scope → all monitored;
- `[]` scope → all monitored.

Full `requests` + `media` suites pass; `tsc --noEmit` clean.