### PR TITLE
fix(releases): match titles when groups drop the possessive apostrophe

### DIFF
--- a/backend/src/modules/media/release-rejection.helper.spec.ts
+++ b/backend/src/modules/media/release-rejection.helper.spec.ts
@@ -132,4 +132,44 @@ describe('resolveSearchTitles + titleMatchesExpectation', () => {
       ),
     ).toBe(false);
   });
+
+  // Release groups drop the English possessive apostrophe and glue the
+  // letters ("Owner's" → "Owners"), so the stored original title must still
+  // match a release spelled without it — and vice-versa for the French
+  // elision, which splits on the apostrophe ("l'éditeur" → "l editeur").
+  const possessiveShow = {
+    title: "Titre localisé de l'éditeur",
+    originalTitle: "Owner's Original Title",
+    alternativeTitles: null,
+  };
+
+  it('matches a release that drops the possessive apostrophe', () => {
+    const { expectedTitles } = resolveSearchTitles(possessiveShow);
+    expect(
+      titleMatchesExpectation(
+        'Owners.Original.Title.S01E04.1080p.HDTV.x264-GROUP',
+        expectedTitles,
+      ),
+    ).toBe(true);
+  });
+
+  it('matches an English-titled release even when its audio is localized', () => {
+    const { expectedTitles } = resolveSearchTitles(possessiveShow);
+    expect(
+      titleMatchesExpectation(
+        'Owners.Original.Title.S01E04.MULTI.VF.1080p.HDTV-GROUP',
+        expectedTitles,
+      ),
+    ).toBe(true);
+  });
+
+  it('still matches the localized title with an elided article', () => {
+    const { expectedTitles } = resolveSearchTitles(possessiveShow);
+    expect(
+      titleMatchesExpectation(
+        'Titre.localise.de.l.editeur.S01E04.AD.HDTV.x264-GROUP',
+        expectedTitles,
+      ),
+    ).toBe(true);
+  });
 });

--- a/backend/src/modules/media/release-rejection.helper.ts
+++ b/backend/src/modules/media/release-rejection.helper.ts
@@ -280,39 +280,56 @@ const TITLE_STOPWORDS = new Set([
   'for',
 ]);
 
-/** Normalize a title for matching: lowercase, strip accents, replace any
- *  non-alphanumeric with a space, collapse whitespace. */
-function normalizeForMatch(s: string): string {
+/** Strip accents and lowercase, leaving punctuation for the tokenizer. */
+function foldCase(s: string): string {
   return s
     .normalize('NFD')
     .replace(/[̀-ͯ]/g, '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, ' ')
-    .trim();
+    .toLowerCase();
 }
 
-/** Significant tokens of a title — tokens that must appear in the release
- *  title for it to be considered a match. Excludes stopwords and very short
- *  tokens (1 char). Falls back to the full normalized title when filtering
- *  leaves nothing (e.g. titles made entirely of stopwords). */
-function significantTokens(title: string): string[] {
-  const normalized = normalizeForMatch(title);
-  if (!normalized) return [];
-  const tokens = normalized
+/** Split a case-folded string into alphanumeric tokens. */
+function tokenize(s: string): string[] {
+  return s
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
     .split(' ')
-    .filter((t) => t.length > 1 && !TITLE_STOPWORDS.has(t));
-  return tokens.length ? tokens : normalized.split(' ').filter(Boolean);
+    .filter(Boolean);
+}
+
+/**
+ * Two tokenizations of a title that differ only in how the apostrophe reads.
+ * Release groups are inconsistent: an English possessive loses the apostrophe
+ * and glues the letters (`X's` → `Xs`), while a French elision splits on it
+ * (`d'eau` → `d eau`). Emitting both readings — apostrophe removed, then
+ * apostrophe as a separator — lets one expected title match either spelling.
+ */
+function titleReadings(title: string): string[][] {
+  const folded = foldCase(title);
+  return [
+    tokenize(folded.replace(/['‘’ʼ]/g, '')),
+    tokenize(folded),
+  ];
+}
+
+/** Significant tokens of one reading — drops stopwords and 1-char tokens, but
+ *  falls back to the raw tokens when that filter empties the list (e.g. a
+ *  title made entirely of stopwords). */
+function significantTokens(tokens: string[]): string[] {
+  const filtered = tokens.filter(
+    (t) => t.length > 1 && !TITLE_STOPWORDS.has(t),
+  );
+  return filtered.length ? filtered : tokens;
 }
 
 /**
  * Return true when a release title plausibly matches *any* of the expected
- * titles. Every significant token of one expected variant must appear as
- * a whole-word substring in the normalized release title.
+ * titles. A candidate matches when, under either apostrophe reading, all of
+ * its significant tokens appear as whole tokens in the release title.
  *
- * Multiple expected titles is the normal case: an "Au service de la France"
- * release indexed under its international name "A Very Secret Service"
- * still passes when both forms are in the candidate list (TMDB's
- * `alternative_titles` / TVDB's `aliases`).
+ * Multiple expected titles is the normal case: a release indexed under its
+ * international name still passes when both the localized and original forms
+ * are in the candidate list (TMDB's `alternative_titles` / TVDB's `aliases`).
  *
  * Used as a backend safety net for indexers that ignore `q=` and return any
  * S01 / category-2000 release regardless of what we asked for.
@@ -325,11 +342,13 @@ export function titleMatchesExpectation(
     (s): s is string => !!s && s.trim().length > 0,
   );
   if (!candidates.length) return true; // nothing meaningful to match
-  const releaseTokens = new Set(normalizeForMatch(releaseTitle).split(' '));
+  const releaseTokens = new Set(titleReadings(releaseTitle).flat());
   for (const cand of candidates) {
-    const tokens = significantTokens(cand);
-    if (!tokens.length) return true; // pathological — treat as match
-    if (tokens.every((t) => releaseTokens.has(t))) return true;
+    for (const reading of titleReadings(cand)) {
+      const tokens = significantTokens(reading);
+      if (!tokens.length) return true; // pathological — treat as match
+      if (tokens.every((t) => releaseTokens.has(t))) return true;
+    }
   }
   return false;
 }


### PR DESCRIPTION
## Problem

In the episode-releases dialog, releases named after the **original** title were flagged `TITLE_MISMATCH` (warning + greyed out), while releases using the **localized** title passed — even though both clearly refer to the same episode.

Root cause is the possessive apostrophe. TMDB stores the original title with its apostrophe (e.g. `X's Show`). `titleMatchesExpectation` normalised the apostrophe to a space, so `X's` tokenised to `x` + `s`; the one-char `s` was dropped as a stopword, leaving the expected token `x`. Release groups instead **drop** the apostrophe and glue the letters (`X's` → `Xs`), producing the token `xs`. `x ≠ xs`, so the original-title candidate never matched and only the localized title did — rejecting every release indexed under the original (English) name, including French-audio releases that keep the English title.

## Fix

The apostrophe can't simply be stripped: the French elision does the opposite — groups split on it (`d'eau` written `d.eau` → `d eau`). So matching now tokenises each expected title under **both apostrophe readings** (apostrophe removed *and* apostrophe as a separator) and accepts a release when either reading's significant tokens are all present. This covers the English possessive and the French elision with no regression on plain titles.

## Tests

- 3 regression tests added (possessive dropped, English title with localized audio, localized title with an elided article).
- `release-rejection.helper.spec.ts`: 12/12 pass.
- Full `media` module suite: 35/35 pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)