### PR TITLE
refactor(media-detail): drop intro detection from the header dropdown

### DIFF
--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -179,7 +179,6 @@
           (loadReleases)="loadReleases()"
           (grabBest)="grabBest()"
           (openAnalyze)="openAnalyzeModal()"
-          (detectIntros)="detectIntros(m.id)"
           (seriesWatchedToggled)="onSeriesWatchedToggled($event)"
           (editSubtitles)="openSubtitles()"
           (requestMedia)="openRequestForMedia()"

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -1241,17 +1241,6 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     }
   }
 
-  async detectIntros(mediaId: number) {
-    try {
-      await this.markersApi.detectSeries(mediaId);
-      this.toast.success(
-        this.translate.instant('markers.detection_started'),
-      );
-    } catch {
-      this.toast.error(this.translate.instant('common.error'));
-    }
-  }
-
   private async reloadAfterRescan(mediaId: number) {
     try {
       const updated = await this.mediaService.getOne(mediaId);

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -475,12 +475,6 @@
       <svg lucideScanLine class="h-5 w-5 shrink-0 opacity-80"></svg>
       <span class="flex-1">{{ 'media_detail.analyze' | translate }}</span>
     </button>
-    @if (mediaType() === 'series') {
-      <button type="button" class="dropdown-item text-white" (click)="detectIntros.emit()">
-        <svg lucideSkipForward class="h-5 w-5 shrink-0 opacity-80"></svg>
-        <span class="flex-1">{{ 'markers.detect_intros' | translate }}</span>
-      </button>
-    }
     <button type="button" [disabled]="monitoredLoading()" class="dropdown-item text-white" (click)="toggleMonitored.emit()">
       @if (monitored()) { <svg lucideEyeOff class="h-5 w-5 shrink-0 opacity-80"></svg> }
       @else { <svg lucideEye class="h-5 w-5 shrink-0 opacity-80"></svg> }

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -30,7 +30,6 @@ import {
   LucideScanLine,
   LucideSearch,
   LucideSettings,
-  LucideSkipForward,
   LucideTrash2,
 } from '@lucide/angular';
 import { PlayableMediaService } from '../../../core/services/playable-media.service';
@@ -103,7 +102,7 @@ interface AudioTrack {
     LucideCaptions, LucideCheck, LucideClipboardList, LucideDownload,
     LucideEllipsisVertical, LucideEye, LucideEyeOff,
     LucideFilm, LucideFolder, LucideListChecks, LucidePlay, LucideRotateCcw, LucideScanLine,
-    LucideSearch, LucideSettings, LucideSkipForward, LucideTrash2,
+    LucideSearch, LucideSettings, LucideTrash2,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-info-header.html',
@@ -198,7 +197,6 @@ export class MediaInfoHeaderComponent {
   readonly loadReleases = output<void>();
   readonly grabBest = output<void>();
   readonly openAnalyze = output<void>();
-  readonly detectIntros = output<void>();
   readonly editSubtitles = output<void>();
   /** Open the tracking-status modal scoped to this header's context
    *  (whole series / the movie / the current episode). */


### PR DESCRIPTION
## What

Remove the **detect intros** button from the media-detail header dropdown. The
same action already lives in the **Analyze** modal (the *markers* checkbox),
which calls the same `markersApi.detectSeries`. Keeping both was a redundant
entry point.

## Changes

- `media-info-header.html` — drop the dropdown button.
- `media-info-header.ts` — drop the now-unused `detectIntros` output and the
  orphaned `LucideSkipForward` icon import.
- `media-detail.html` — drop the `(detectIntros)` binding.
- `media-detail.ts` — drop the orphaned `detectIntros()` handler.

`markersApi` is still used by `runAnalyze()`, so nothing else changes.

## Verification

`ng build` compiles clean (only the pre-existing `shaka-player` non-ESM warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
