### PR TITLE
feat(player): keyboard/TV-friendly skip cue and default focus

### DIFF
--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -198,7 +198,7 @@
           <svg lucideRotateCcw class="h-6 w-6"></svg>
         </button>
         <!-- lucide:play / lucide:pause -->
-        <button #playPauseBtn type="button" class="btn btn-ghost btn-md btn-circle text-white" [attr.aria-label]="(paused() ? 'player.play' : 'player.pause') | translate" [attr.aria-pressed]="!paused()" (click)="togglePlay.emit()">
+        <button #playPauseBtn data-default-focus type="button" class="btn btn-ghost btn-md btn-circle text-white" [attr.aria-label]="(paused() ? 'player.play' : 'player.pause') | translate" [attr.aria-pressed]="!paused()" (click)="togglePlay.emit()">
           @if (paused()) {
             <svg xmlns="http://www.w3.org/2000/svg" class="h-7 w-7" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M5 5a2 2 0 0 1 3.008-1.728l11.997 6.998a2 2 0 0 1 .003 3.458l-12 7A2 2 0 0 1 5 19z"/></svg>
           } @else {
@@ -266,26 +266,46 @@
 <!-- ===== Skip intro floating button ===== -->
 @if (showSkipIntro()) {
   <button
+    #skipIntroBtn
     type="button"
-    class="btn btn-primary absolute right-6 z-50 shadow-lg gap-2"
-    style="right: max(1.5rem, env(safe-area-inset-right)); bottom: max(8rem, calc(8rem + env(safe-area-inset-bottom)));"
+    class="btn btn-primary absolute right-6 z-50 shadow-lg overflow-hidden rounded-lg player-floating-cue"
+    style="right: max(1.5rem, env(safe-area-inset-right)); bottom: max(var(--cue-bottom, 8rem), calc(var(--cue-bottom, 8rem) + env(safe-area-inset-bottom)));"
     (click)="skipIntro.emit()"
+    (focus)="cueFocused.set(true)"
+    (blur)="cueFocused.set(false)"
   >
-    <svg lucideSkipForward class="h-4 w-4"></svg>
-    {{ 'player.skip_intro' | translate }}
+    <span
+      class="player-cue-progress pointer-events-none absolute inset-y-0 right-0 bg-base-100/40"
+      [style.animation-duration.ms]="cueDurationMs()"
+      [style.animation-play-state]="(visible() || cueFocused()) ? 'paused' : 'running'"
+    ></span>
+    <span class="relative flex items-center gap-2">
+      <svg lucideSkipForward class="h-4 w-4"></svg>
+      {{ 'player.skip_intro' | translate }} ({{ skipIntroCountdown() }})
+    </span>
   </button>
 }
 
 <!-- ===== Next episode floating button (during outro) ===== -->
 @if (showNextEpisode()) {
   <button
+    #nextEpisodeBtn
     type="button"
-    class="btn btn-primary absolute right-6 z-50 shadow-lg gap-2"
-    style="right: max(1.5rem, env(safe-area-inset-right)); bottom: max(8rem, calc(8rem + env(safe-area-inset-bottom)));"
+    class="btn btn-primary absolute right-6 z-50 shadow-lg overflow-hidden rounded-lg player-floating-cue"
+    style="right: max(1.5rem, env(safe-area-inset-right)); bottom: max(var(--cue-bottom, 8rem), calc(var(--cue-bottom, 8rem) + env(safe-area-inset-bottom)));"
     (click)="skipToNextEpisode.emit()"
+    (focus)="cueFocused.set(true)"
+    (blur)="cueFocused.set(false)"
   >
-    <svg lucideSkipForward class="h-4 w-4"></svg>
-    {{ 'player.next_episode' | translate }}
+    <span
+      class="player-cue-progress pointer-events-none absolute inset-y-0 right-0 bg-base-100/40"
+      [style.animation-duration.ms]="cueDurationMs()"
+      [style.animation-play-state]="(visible() || cueFocused()) ? 'paused' : 'running'"
+    ></span>
+    <span class="relative flex items-center gap-2">
+      <svg lucideSkipForward class="h-4 w-4"></svg>
+      {{ 'player.next_episode' | translate }}
+    </span>
   </button>
 }
 

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -115,15 +115,11 @@ export class PlayerControlsComponent {
       const visible = this.visible();
       const wasVisible = this.lastVisible;
       this.lastVisible = visible;
-      // Focus play/pause when the bar appears under keyboard / D-pad — on TV
-      // (always) and on the browser in keyboard modality — so the next
-      // Enter/Space toggles playback. Skipped for pointer (mouse-revealed
+      // Focus play/pause when the bar appears under keyboard / D-pad so the
+      // next Enter/Space toggles playback. Skipped for pointer (mouse-revealed
       // controls shouldn't steal focus). An arrow-seek re-focuses the seekbar
       // afterwards (player.focusSeekbar), which wins the deferred race.
-      const keyboardModality =
-        typeof document !== 'undefined' &&
-        document.body.classList.contains('keyboard-modality');
-      if (visible && !wasVisible && (this.isTv() || keyboardModality)) {
+      if (visible && !wasVisible && this.autoFocusModality()) {
         this.closeDropdown();
         this.playPauseBtn()?.nativeElement.focus({ preventScroll: true });
       }
@@ -136,6 +132,38 @@ export class PlayerControlsComponent {
       this.lastPanelOpen = open;
       this.panelOpenChange.emit(open);
     });
+    // Skip-intro cue countdown — mirrors the progress sweep numerically.
+    // Reset to the full window each time the cue (re)appears.
+    effect(() => {
+      if (this.showSkipIntro()) {
+        this.skipIntroCountdown.set(Math.ceil(this.cueDurationMs() / 1000));
+      }
+    });
+    // Tick down to 1, but hold while the cue is "engaged" — the controls bar is
+    // up or the cue itself is focused. The parent freezes the retract timer on
+    // the same conditions, so the number stays in lockstep. The cleanup stops
+    // the tick on pause and on retract alike.
+    effect((onCleanup) => {
+      if (!this.showSkipIntro() || this.visible() || this.cueFocused()) return;
+      const id = setInterval(
+        () => this.skipIntroCountdown.update((n) => (n > 1 ? n - 1 : 1)),
+        1000,
+      );
+      onCleanup(() => clearInterval(id));
+    });
+    // A cue removed while focused can swallow its blur, leaving the flag stuck;
+    // clear it whenever no cue is shown so the next one isn't born frozen.
+    effect(() => {
+      if (!this.showSkipIntro() && !this.showNextEpisode()) {
+        this.cueFocused.set(false);
+      }
+    });
+    // Focus a floating cue the instant it mounts so a TV / keyboard user can
+    // act on it without first hunting for it with the D-pad. Each effect is
+    // driven by its cue's view-query signal, which holds the element while the
+    // cue's @if is live and is undefined otherwise.
+    effect(() => this.autoFocusCue(this.skipIntroBtn()));
+    effect(() => this.autoFocusCue(this.nextEpisodeBtn()));
   }
   private lastPanelOpen = false;
   private lastVisible = true;
@@ -209,6 +237,16 @@ export class PlayerControlsComponent {
   readonly statsVisible = input(false);
   readonly showSkipIntro = input(false);
   readonly showNextEpisode = input(false);
+  /** How long a floating cue stays up, in ms — drives the in-button progress
+   *  sweep so it finishes exactly as the parent retracts the cue. */
+  readonly cueDurationMs = input(6000);
+  /** Seconds left before the skip-intro cue retracts, shown in the button as a
+   *  live countdown next to its progress sweep. */
+  readonly skipIntroCountdown = signal(0);
+  /** True while a floating cue holds focus. The player reads it to freeze the
+   *  retract timer, and the sweep / countdown freeze on it here — a cue the
+   *  user has navigated to (keyboard / D-pad) must not vanish from under them. */
+  readonly cueFocused = signal(false);
   readonly togglePlay = output<void>();
   readonly skipIntro = output<void>();
   readonly skipToNextEpisode = output<void>();
@@ -272,6 +310,30 @@ export class PlayerControlsComponent {
   /** Desktop/TV play-pause button — focused on TV every time the controls
    *  bar reappears, so the next D-pad center triggers play/pause. */
   private readonly playPauseBtn = viewChild<ElementRef<HTMLButtonElement>>('playPauseBtn');
+  /** Floating skip-intro / next-episode cues — focused the instant they mount
+   *  (see the constructor effects) so TV / keyboard users can act on them. */
+  private readonly skipIntroBtn = viewChild<ElementRef<HTMLButtonElement>>('skipIntroBtn');
+  private readonly nextEpisodeBtn = viewChild<ElementRef<HTMLButtonElement>>('nextEpisodeBtn');
+
+  /** True under keyboard / D-pad input — the only modality where stealing focus
+   *  is wanted (mouse and touch users are left alone, matching the CSS ring
+   *  gate). TV is always keyboard-like; the browser flags it on `body`. */
+  private autoFocusModality(): boolean {
+    return (
+      this.isTv() ||
+      (typeof document !== 'undefined' &&
+        document.body.classList.contains('keyboard-modality'))
+    );
+  }
+
+  /** Pull focus onto a floating cue the moment it appears — but only for TV
+   *  and keyboard navigation, where there's no pointer to reach it. A
+   *  mouse-revealed cue shouldn't steal focus. */
+  private autoFocusCue(btn: ElementRef<HTMLButtonElement> | undefined): void {
+    if (btn && this.autoFocusModality()) {
+      btn.nativeElement.focus({ preventScroll: true });
+    }
+  }
   readonly hostEl: ElementRef<HTMLElement> = inject(ElementRef);
   private readonly injector = inject(Injector);
   private dropdownTrigger: HTMLElement | null = null;

--- a/client/src/app/features/player/player.html
+++ b/client/src/app/features/player/player.html
@@ -1,6 +1,7 @@
 <!-- Local player (hidden when casting — Cast overlay is global in the layout) -->
 <div
   #playerContainer
+  appDefaultFocus="[data-default-focus]"
   class="player-container"
   [class.hide-cursor]="!controlsVisible()"
   [class.native-player]="!!nativeEngine"
@@ -139,8 +140,9 @@
     [spriteUrl]="spriteUrl()"
     [spriteMetadata]="spriteMetadata()"
     [chapters]="chapters()"
-    [showSkipIntro]="inIntroRange()"
-    [showNextEpisode]="showNextEpisodeButton()"
+    [showSkipIntro]="skipIntroVisible()"
+    [showNextEpisode]="nextEpisodeVisible()"
+    [cueDurationMs]="cueRevealMs"
     (skipIntro)="skipIntro()"
     (skipToNextEpisode)="goToNextEpisode()"
     (nextEpisode)="goToNextEpisode()"

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -5,6 +5,7 @@ import {
   ElementRef,
   OnDestroy,
   ViewEncapsulation,
+  WritableSignal,
   computed,
   effect,
   inject,
@@ -73,9 +74,61 @@ const Pip = registerPlugin<PipPlugin>('Pip');
 import { LucideCircleAlert, LucideInfo, LucideX } from '@lucide/angular';
 import { PlayerControlsComponent } from './controls/player-controls';
 import { PlayerStatsOverlayComponent, PlayerStats } from './overlay/player-stats-overlay';
+import { DefaultFocusDirective } from '../../shared/directives/default-focus.directive';
+
+/**
+ * A one-shot timer that can be paused and resumed without losing the time it
+ * has left. Backs the floating cues' auto-retract: the countdown freezes while
+ * the controls bar is up (the user is plainly engaged) and resumes the instant
+ * it hides, so a cue never vanishes out from under an interacting viewer.
+ */
+class PausableTimeout {
+  private handle: ReturnType<typeof setTimeout> | null = null;
+  private remainingMs = 0;
+  private resumedAt = 0;
+
+  constructor(private readonly onElapsed: () => void) {}
+
+  /** (Re)start from a full duration, discarding any prior run. */
+  start(durationMs: number): void {
+    this.cancel();
+    this.remainingMs = durationMs;
+    this.run();
+  }
+
+  /** Freeze the countdown, banking the time left. No-op unless running. */
+  pause(): void {
+    if (this.handle === null) return;
+    clearTimeout(this.handle);
+    this.handle = null;
+    this.remainingMs -= Date.now() - this.resumedAt;
+  }
+
+  /** Resume a paused countdown from where it stopped. No-op unless paused. */
+  resume(): void {
+    if (this.handle !== null || this.remainingMs <= 0) return;
+    this.run();
+  }
+
+  /** Stop and forget — the cue is gone for good. */
+  cancel(): void {
+    if (this.handle !== null) clearTimeout(this.handle);
+    this.handle = null;
+    this.remainingMs = 0;
+  }
+
+  private run(): void {
+    this.resumedAt = Date.now();
+    this.handle = setTimeout(() => {
+      this.handle = null;
+      this.remainingMs = 0;
+      this.onElapsed();
+    }, this.remainingMs);
+  }
+}
 
 @Component({
-  imports: [TranslateModule, LucideCircleAlert, LucideInfo, LucideX, PlayerControlsComponent, PlayerStatsOverlayComponent],
+  imports: [TranslateModule, LucideCircleAlert, LucideInfo, LucideX, PlayerControlsComponent, PlayerStatsOverlayComponent, DefaultFocusDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './player.html',
   encapsulation: ViewEncapsulation.None,
@@ -225,6 +278,8 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
   private saveInterval: ReturnType<typeof setInterval> | null = null;
   private controlsTimeout: ReturnType<typeof setTimeout> | null = null;
+  private readonly skipIntroCue = new PausableTimeout(() => this.skipIntroVisible.set(false));
+  private readonly nextEpisodeCue = new PausableTimeout(() => this.nextEpisodeVisible.set(false));
   private seekDragging = false;
   private statsInterval: ReturnType<typeof setInterval> | null = null;
   private subtitleStyleEl: HTMLStyleElement | null = null;
@@ -1302,6 +1357,8 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     this.spriteAbort?.abort();
     if (this.saveInterval) clearInterval(this.saveInterval);
     if (this.controlsTimeout) clearTimeout(this.controlsTimeout);
+    this.skipIntroCue.cancel();
+    this.nextEpisodeCue.cancel();
     if (this.statsInterval) clearInterval(this.statsInterval);
     if (this.recoverRetryTimer) clearTimeout(this.recoverRetryTimer);
     if (this.adminMessageTimer) clearTimeout(this.adminMessageTimer);
@@ -1517,7 +1574,13 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // them deliberately.
     if (typeof document !== 'undefined') {
       const active = document.activeElement as HTMLElement | null;
-      if (active && active.closest('app-player-controls')) {
+      // A floating cue outlives the bar's auto-hide — it stays on screen and
+      // operable — so keep its focus; only blur controls that are hiding.
+      if (
+        active &&
+        active.closest('app-player-controls') &&
+        !active.closest('.player-floating-cue')
+      ) {
         active.blur();
       }
     }
@@ -1683,6 +1746,66 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     return t >= m.startSeconds && t < m.endSeconds - 1;
   });
 
+  // ── Timed reveal of the floating intro / next-episode cues ──
+  // A cue surfaces for a short window when the playhead enters its marker
+  // range, then retracts on its own; a progress sweep inside the button counts
+  // that window down. Revealing once per range entry (latched via the *Armed
+  // flags) stops the cue re-popping every frame while the playhead sits inside
+  // the range — the latch only re-arms once the playhead has left and re-entered.
+
+  /** Lifetime of a floating cue, in ms — also the duration of its progress
+   *  sweep, forwarded to the controls so the timer and the animation stay in
+   *  lockstep. */
+  readonly cueRevealMs = 6000;
+  readonly skipIntroVisible = signal(false);
+  readonly nextEpisodeVisible = signal(false);
+  private skipIntroCueArmed = false;
+  private nextEpisodeCueArmed = false;
+
+  /** Show a cue and arm its retract, replacing any pending one. The retract
+   *  starts frozen if the controls bar is already up — the cue waits for the
+   *  viewer's attention to leave before counting itself down. */
+  private revealCue(visible: WritableSignal<boolean>, cue: PausableTimeout): void {
+    visible.set(true);
+    cue.start(this.cueRevealMs);
+    if (untracked(this.controlsVisible)) cue.pause();
+  }
+
+  /** Hide a cue and cancel its pending retract. */
+  private hideCue(visible: WritableSignal<boolean>, cue: PausableTimeout): void {
+    cue.cancel();
+    visible.set(false);
+  }
+
+  /** Freeze both cues' retract timers while the cue is engaged — the controls
+   *  bar is up, or the cue itself holds focus (a keyboard / D-pad user has
+   *  navigated to it) — and resume them once it isn't. The sweep and countdown
+   *  in the controls component freeze on the same conditions, so all three
+   *  representations of the window stay in lockstep. */
+  private readonly cueTimerPauseEffect = effect(() => {
+    const engaged =
+      this.controlsVisible() || (this.controls()?.cueFocused() ?? false);
+    if (engaged) {
+      this.skipIntroCue.pause();
+      this.nextEpisodeCue.pause();
+    } else {
+      this.skipIntroCue.resume();
+      this.nextEpisodeCue.resume();
+    }
+  });
+
+  /** Reveal the skip-intro cue once each time the playhead enters the intro. */
+  private readonly skipIntroCueEffect = effect(() => {
+    if (this.inIntroRange()) {
+      if (this.skipIntroCueArmed) return;
+      this.skipIntroCueArmed = true;
+      this.revealCue(this.skipIntroVisible, this.skipIntroCue);
+    } else if (this.skipIntroCueArmed) {
+      this.skipIntroCueArmed = false;
+      this.hideCue(this.skipIntroVisible, this.skipIntroCue);
+    }
+  });
+
   /** Player-controls click handler — seek to the end of the intro. */
   skipIntro(): void {
     const m = this.introMarker();
@@ -1753,10 +1876,23 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     return this.currentTime() >= m.startSeconds;
   });
 
-  /** Drives visibility of the floating "Épisode suivant" button. */
+  /** True when the playhead is in the outro and a next episode exists —
+   *  gates the timed reveal of the floating "Épisode suivant" cue. */
   readonly showNextEpisodeButton = computed(
     () => this.inOutroRange() && this.nextEpisodeContext() !== null,
   );
+
+  /** Reveal the next-episode cue once each time the playhead enters the outro. */
+  private readonly nextEpisodeCueEffect = effect(() => {
+    if (this.showNextEpisodeButton()) {
+      if (this.nextEpisodeCueArmed) return;
+      this.nextEpisodeCueArmed = true;
+      this.revealCue(this.nextEpisodeVisible, this.nextEpisodeCue);
+    } else if (this.nextEpisodeCueArmed) {
+      this.nextEpisodeCueArmed = false;
+      this.hideCue(this.nextEpisodeVisible, this.nextEpisodeCue);
+    }
+  });
 
   /** Navigate to the next episode identified by {@link nextEpisodeContext}.
    *  Marks the current episode as watched (position := duration) before
@@ -2626,6 +2762,14 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // keep clear of the lib.dom `keyCode` deprecation.
     const legacyKeyCode = (e as { keyCode: number }).keyCode;
     const isBackKey = legacyKeyCode === 10009 || e.key === 'XF86Back' || e.key === 'GoBack' || e.key === 'Escape';
+
+    // A floating cue (skip-intro / next-episode) stays visible and actionable
+    // even while the controls bar is hidden. So — unlike a hidden bar control —
+    // a focused cue must receive its activation key directly rather than have
+    // the press swallowed to merely wake the bar. The guards below honour this.
+    const activeEl = document.activeElement as HTMLElement | null;
+    const cueFocused = !!activeEl?.closest('.player-floating-cue');
+
     // Controls hidden + Left/Right: wake the bar, seek, and land focus on the
     // seekbar so the next presses scrub it — on every device (keyboard + TV
     // remote), matching the seekbar-focused scrub when the bar is already up.
@@ -2643,8 +2787,9 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
     // TV only: any other key while the bar is hidden just WAKES it — never
     // activates the invisible focused button (e.g. OK would hit the back arrow
-    // and quit). The back key bubbles to app.ts so the user can still exit.
-    if (!isBackKey && !this.controlsVisible() && this.device.isTv()) {
+    // and quit). A focused cue is exempt: it's visible, so OK should act on it.
+    // The back key bubbles to app.ts so the user can still exit.
+    if (!isBackKey && !cueFocused && !this.controlsVisible() && this.device.isTv()) {
       this.showControls();
       e.preventDefault();
       e.stopPropagation();
@@ -2654,8 +2799,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // ArrowLeft/Right are claimed by the seekbar when it owns focus, and used
     // for D-pad navigation between controls otherwise. Skip them here unless
     // no control has focus (in which case keep the legacy "background" seek).
-    const active = document.activeElement as HTMLElement | null;
-    const arrowSeekAllowed = !active || active === document.body;
+    const arrowSeekAllowed = !activeEl || activeEl === document.body;
 
     switch (e.key) {
       case ' ':
@@ -2667,10 +2811,11 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         // it always toggles playback.
         if (
           e.key === ' ' &&
-          this.controlsVisible() &&
-          active &&
-          active !== document.body &&
-          active.closest('app-player-controls')
+          (cueFocused ||
+            (this.controlsVisible() &&
+              activeEl &&
+              activeEl !== document.body &&
+              activeEl.closest('app-player-controls')))
         ) {
           return; // fall through to native activation
         }
@@ -2735,8 +2880,9 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // which (with no controls shown) goes straight to `onBack()`.
     // Without this guard, the trailing `showControls()` fired first,
     // `onPlayerBackEvent` then saw controls visible and only hid them
-    // — so Return-on-TV looked stuck.
-    if (!isBackKey) this.showControls();
+    // — so Return-on-TV looked stuck. A focused cue is likewise left
+    // alone: acting on it shouldn't drag the whole bar onto the screen.
+    if (!isBackKey && !cueFocused) this.showControls();
   };
 
   // ── Event handlers ──

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -232,6 +232,44 @@ body.native.hero-page {
   }
 }
 
+/* Floating player cues (skip-intro / next-episode) carry an in-button
+   countdown: a dimmed overlay anchored to the right edge that retracts from
+   full width to nothing, "filling" the button as its on-screen window elapses.
+   The duration is bound inline so it tracks the parent's retract timer. */
+@keyframes player-cue-sweep {
+  from {
+    width: 100%;
+  }
+  to {
+    width: 0%;
+  }
+}
+
+.player-cue-progress {
+  animation-name: player-cue-sweep;
+  animation-timing-function: linear;
+  animation-fill-mode: both;
+}
+
+/* Reduced-motion: skip the sweep, leaving the button at full brightness; the
+   parent timer still retracts the cue on schedule. */
+@media (prefers-reduced-motion: reduce) {
+  .player-cue-progress {
+    animation: none;
+    width: 0;
+  }
+}
+
+/* Mobile landscape: the viewport is short, so the cue's portrait 8rem offset
+   strands it high on screen (most visible once the controls bar auto-hides).
+   Short + wide identifies a phone in landscape; drop the cue nearer the
+   bottom edge there. --cue-bottom feeds the button's inline bottom offset. */
+@media (orientation: landscape) and (max-height: 600px) {
+  .player-floating-cue {
+    --cue-bottom: 4.5rem;
+  }
+}
+
 /* ============================================================================
    Android TV / 10-foot UI overrides — body.tv toggled by TvService
    ============================================================================ */
@@ -345,6 +383,15 @@ body:not(.keyboard-modality):not(.tv) app-mosaic-card button:focus-visible .mosa
     0 0 0 4px var(--color-primary, #7a3ff2);
   z-index: 1;
   position: relative;
+}
+/* The floating player cues position themselves absolutely via inline right /
+   bottom offsets. The generic ring above forces `position: relative` (and a low
+   z-index), which would re-anchor those offsets to the cue's in-flow origin and
+   fling it off-screen — re-assert its own placement so the ring decorates it in
+   situ. Same specificity as the rule above, so source order settles it. */
+.player-floating-cue:focus-visible {
+  position: absolute;
+  z-index: 50;
 }
 /* Opt-out for focusables that paint their own focus affordance (e.g.
    round avatar with a ring-primary on the inner div). The default


### PR DESCRIPTION
## What

Make the floating **skip-intro** / **next-episode** cues fully operable by
keyboard and TV D-pad, and stop them disappearing while the viewer is engaged.

## Changes

- **Countdown** — the skip-intro button shows the seconds left next to its
  label, mirroring the progress sweep numerically.
- **Mobile landscape** — the cue drops closer to the bottom edge on short, wide
  viewports (a `--cue-bottom` var swapped by an `orientation: landscape` +
  `max-height` media query); the portrait `8rem` offset stranded it high.
- **Keyboard / TV** — a cue is auto-focused the instant it appears (TV /
  keyboard modality only, never pointer). OK / Enter acts on the cue directly
  instead of being swallowed to merely wake the controls bar, and a focused cue
  keeps its focus when the bar auto-hides.
- **Pause while engaged** — the cue's retract timer, progress sweep and
  countdown all freeze while the controls bar is up or the cue holds focus, via
  a small `PausableTimeout`. A cue the user is looking at no longer times out
  from under them.
- **Focus ring fix** — the generic `:focus-visible` ring forced
  `position: relative` on the absolutely-positioned cue, flinging it (ring
  included) off-screen; a targeted rule re-asserts its placement.
- **Default focus** — the player's keyboard / D-pad default focus now lands on
  play/pause (`appDefaultFocus`) instead of the back arrow.

## Files

`player-controls.{ts,html}`, `player.{ts,html}`, `styles.css`.

## Verification

`ng build` compiles clean (only the pre-existing `shaka-player` non-ESM
warning). The keyboard/TV behaviour still merits a final check on a real device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
