### PR TITLE
fix(player): keep the previous episode out of the back stack

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -2052,9 +2052,9 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     const canReloadInPlace =
       !!this.engine && !this.isOfflinePlayback && !this.castService.isConnected();
     if (canReloadInPlace) {
-      // Keep the URL in step (refresh / back stay correct). replaceUrl drops
-      // the old episode's /watch entry; the route reuses the component, so no
-      // remount fires and reloadForEpisode does the actual swap.
+      // replaceUrl + markAsBackNavigation keep both histories clear of the old
+      // episode so Back never reopens the player. Route reuse → no remount.
+      this.navbar.markAsBackNavigation();
       void this.router.navigate(['/watch', next.mediaFileId], {
         queryParams: { mediaId, episodeId: next.episodeId },
         replaceUrl: true,


### PR DESCRIPTION
## Problem

After switching episodes in place (#587), pressing **Back** could reopen the
player on the previous episode — the player must never be reachable by Back.

## Cause

`NavbarService` pushes the URL it's leaving onto its in-app back stack on every
`NavigationEnd` where the **path** changes. The `/watch/:mediaFileId` route
changes its path segment between episodes, so the in-place switch was stacking
the old episode's `/watch` entry.

## Fix

Call `markAsBackNavigation()` before the switch navigation — exactly as
`onBack()` already does. Combined with the existing `replaceUrl` (which keeps a
single `/watch` entry in browser history), the player is no longer reachable by
Back from either the browser or the in-app history.

## Verification

`ng build` compiles clean (only the pre-existing `shaka-player` non-ESM warning).
Behaviour still warrants a device check on the Back paths (hardware/browser back
and the in-app back arrow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
