### PR TITLE
fix(player): keep subtitles off on desktop when disabled in controls

### DIFF
--- a/client/src/app/core/services/playback-engine/desktop-engine.ts
+++ b/client/src/app/core/services/playback-engine/desktop-engine.ts
@@ -226,7 +226,13 @@ export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEng
   }
 
   private resolveSubtitle(): void {
-    if (!this._desiredSubtitle) return;
+    if (!this._desiredSubtitle) {
+      // No subtitle wanted → assert off. mpv auto-selects one otherwise; the
+      // app is the sole source of truth for subtitle selection.
+      this._activeTrackId = null;
+      this.bridge.selectSubtitleTrack(null).catch(() => {});
+      return;
+    }
     const { language, forced, embIndex } = this._desiredSubtitle;
     const want = normalizeLangCode(language);
     const tracks = this._nativeSubtitleTracks;

--- a/desktop/native/compositor/addon.cc
+++ b/desktop/native/compositor/addon.cc
@@ -495,6 +495,8 @@ Napi::Value Start(const Napi::CallbackInfo& info) {
     M::set_option_string(g_state.mpv, "ytdl", "no");
     M::set_option_string(g_state.mpv, "terminal", "no");
     M::set_option_string(g_state.mpv, "load-unsafe-playlists", "yes");
+    // The app drives subtitle selection; don't let mpv auto-pick a track.
+    M::set_option_string(g_state.mpv, "sid", "no");
     // The backend produces transcode segments on demand: it answers 404 (seg-0/
     // init on a resume, before the early companion writes them) or 503 (the
     // resume segment while ffmpeg is still encoding it), and a late multi-audio

--- a/desktop/native/player_mac/addon.mm
+++ b/desktop/native/player_mac/addon.mm
@@ -369,6 +369,8 @@ Napi::Value Start(const Napi::CallbackInfo& info) {
   M::set_option_string(g_state.mpv, "ytdl", "no");
   M::set_option_string(g_state.mpv, "terminal", "no");
   M::set_option_string(g_state.mpv, "load-unsafe-playlists", "yes");
+  // The app drives subtitle selection; don't let mpv auto-pick a track.
+  M::set_option_string(g_state.mpv, "sid", "no");
   // Let mpv adapt its output to the layer's (HDR-capable) colorspace instead of
   // hard-tonemapping to SDR — best-effort HDR passthrough.
   M::set_option_string(g_state.mpv, "target-colorspace-hint", "yes");

--- a/desktop/src/main/mpv/mpv-player.ts
+++ b/desktop/src/main/mpv/mpv-player.ts
@@ -85,6 +85,8 @@ export class MpvPlayer extends EventEmitter {
       '--no-config',
       '--no-terminal',
       '--keep-open=yes',
+      // The app drives subtitle selection; don't let mpv auto-pick a track.
+      '--sid=no',
       // The Fliks HLS references tokenised same-host segment/rendition URLs;
       // mpv's playlist safety check otherwise refuses them on the fallback path.
       '--load-unsafe-playlists=yes',


### PR DESCRIPTION
## Problem

On the native desktop app (Windows/macOS, and Linux), a subtitle is sometimes
rendered when opening the player even though the controls report subtitles as
**disabled**. Intermittent — it depends on the media (an embedded subtitle
track) or on leftover state from a previous playback.

## Root cause

The desktop player embeds **mpv**, whose default subtitle selection is
`sid=auto`: it auto-selects and renders an embedded track flagged default/forced
or matching the locale. None of the three mpv backends disabled this.

The Angular control plane only ever *enables* subtitles explicitly. On the
"off" path — subtitle mode off, remembered selection `off`, or no language match
— `autoSelectSubtitle` / `resolveSubtitle` returned **without** disabling,
relying on the player defaulting to no subtitle. That holds for
Shaka / ExoPlayer / AVPlayer but **not for mpv**, and is compounded by the mpv
main-process player being a persistent singleton that retains a prior session's
subtitle across loads.

## Fix

- **`desktop-engine.ts`** (shared by all platforms): `resolveSubtitle()` now
  asserts `selectSubtitleTrack(null)` whenever no subtitle is desired instead of
  returning early. It runs on every `tracksChanged`, so it also cancels a late
  auto-selection mpv makes when it discovers subs mid-stream, and clears the
  persistent singleton's leftover.
- **`--sid=no` / `sid=no` at mpv init** in all three backends
  (`mpv-player.ts` Windows, `addon.cc` Linux, `addon.mm` macOS) — defense in
  depth so mpv never auto-picks, avoiding even a brief flash on load.

## Verification

- Client + desktop type-checks pass.
- The two C++ lines mirror adjacent `set_option_string` calls; the macOS addon
  is not locally compilable (no mac).
- Behaviour to confirm on-device: open a media with an embedded subtitle track
  with subtitles set to "off" → no subtitle should appear.
