### PR TITLE
feat(desktop): keep the screen awake during playback

### DIFF
--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -7,6 +7,7 @@ import { createRequire } from 'node:module';
 import { registerAppSchemePrivileged, registerAppProtocol, APP_URL } from './protocol';
 import { installCorsBypass } from './cors';
 import { setupUpdater } from './updater';
+import { setPlaybackKeepAwake, keepAwakeForState } from './power';
 import { IPC, type DesktopEvent, type DesktopSubtitleStyle } from '../shared/contract';
 import { mpvSubtitleProps } from './mpv/subtitle-style';
 
@@ -386,6 +387,7 @@ app.whenReady().then(async () => {
         // player can't keep emitting (and leaking the interval).
         if (raw.state === 'playing') startPositionTimer();
         else stopPositionTimer();
+        setPlaybackKeepAwake(keepAwakeForState(raw.state));
         send({ type: 'stateChanged', payload: { state: raw.state } });
         break;
       case 'tracksChanged':
@@ -396,10 +398,12 @@ app.whenReady().then(async () => {
         // pause-property change, so the playing stateChanged can be missing on
         // a fresh load — arm the timer on the first frame as well.
         startPositionTimer();
+        setPlaybackKeepAwake(true);
         send({ type: 'firstFrame' });
         break;
       case 'error':
         stopPositionTimer();
+        setPlaybackKeepAwake(false);
         send({ type: 'error', payload: { code: -1, message: raw.message ?? 'error' } });
         break;
     }

--- a/desktop/src/main/power.ts
+++ b/desktop/src/main/power.ts
@@ -1,0 +1,24 @@
+import { powerSaveBlocker } from 'electron';
+
+// mpv renders outside the web contents (vo=libmpv / --wid), so Chromium's media
+// wake-lock never engages and the OS dims/sleeps mid-playback — the main process
+// must inhibit sleep itself. One blocker for the app's single player session.
+let blockerId: number | null = null;
+
+/** Hold a `prevent-display-sleep` blocker while playing, release it otherwise. */
+export function setPlaybackKeepAwake(active: boolean): void {
+  const held = blockerId !== null && powerSaveBlocker.isStarted(blockerId);
+  if (active === held) return;
+  if (active) {
+    blockerId = powerSaveBlocker.start('prevent-display-sleep');
+  } else {
+    if (blockerId !== null) powerSaveBlocker.stop(blockerId);
+    blockerId = null;
+  }
+}
+
+/** True while playing or buffering — both mean an active session that must not
+ *  let the screen sleep; paused / idle / ended / error release it. */
+export function keepAwakeForState(state: string | undefined): boolean {
+  return state === 'playing' || state === 'buffering';
+}

--- a/desktop/src/main/window/player-session.ts
+++ b/desktop/src/main/window/player-session.ts
@@ -5,6 +5,7 @@ import { MpvPlayer } from '../mpv/mpv-player';
 import { MacMpvPlayer } from '../mpv/mac-mpv-player';
 import type { PlayerBackend } from '../mpv/player-backend';
 import { createEmbedBackend } from './backends';
+import { setPlaybackKeepAwake, keepAwakeForState } from '../power';
 import { IPC, type DesktopEvent, type DesktopRect } from '../../shared/contract';
 
 /**
@@ -185,7 +186,9 @@ export class PlayerSession {
     mpv.on('log', (s: string) => process.stderr.write(`[mpv] ${s}`));
     mpv.on('exit', (e) => console.error('[mpv] process exit', JSON.stringify(e)));
     mpv.on('stateChanged', (p) => {
-      console.log('[player] state:', (p as { state?: string }).state);
+      const state = (p as { state?: string }).state;
+      console.log('[player] state:', state);
+      setPlaybackKeepAwake(keepAwakeForState(state));
       this.emit({ type: 'stateChanged', payload: p });
     });
     mpv.on('timeUpdate', (p) => this.emit({ type: 'timeUpdate', payload: p }));
@@ -195,10 +198,12 @@ export class PlayerSession {
     });
     mpv.on('firstFrame', () => {
       console.log('[player] firstFrame');
+      setPlaybackKeepAwake(true);
       this.emit({ type: 'firstFrame' });
     });
     mpv.on('error', (p) => {
       console.log('[player] error:', JSON.stringify(p));
+      setPlaybackKeepAwake(false);
       this.emit({ type: 'error', payload: p });
     });
   }
@@ -226,6 +231,7 @@ export class PlayerSession {
   }
 
   async destroy(): Promise<void> {
+    setPlaybackKeepAwake(false);
     await this.mpv?.destroy();
     this.mpv = null;
     if (this.uiWin && !this.uiWin.isDestroyed()) this.uiWin.destroy();


### PR DESCRIPTION
## Problem

On the native desktop app the display dims / the machine sleeps **during
playback** (reported on macOS; the same gap exists on Windows and Linux).

## Root cause

mpv renders outside the web contents (`vo=libmpv` on macOS/Linux, `--wid` embed
on Windows), so Chromium never sees a `<video>` playing and its media wake-lock
never engages. mpv's own screensaver inhibition doesn't apply through the
libmpv render API either. Nothing inhibits sleep → the OS dims/sleeps mid-film.

## Fix

The main process now holds an Electron `powerSaveBlocker`
(`prevent-display-sleep`) while **playing or buffering**, and releases it on
**pause / idle / ended / error** and on teardown.

- New `src/main/power.ts` centralises the blocker lifecycle (idempotent
  start/stop) and the active-state predicate.
- Wired on both backend event pipelines: the Linux compositor (`index.ts`) and
  the Windows/macOS `PlayerSession`.

Covers all three platforms uniformly. On Windows the subprocess mpv may already
inhibit via `--stop-screensaver`; the blocker doubles it harmlessly and
guarantees consistent behaviour.

## Verification

- Desktop type-check + esbuild bundle pass.
- Runtime sleep behaviour to confirm on-device (macOS/Windows).
