### PR TITLE
fix(media): exclude owned movies from coming-soon

### DIFF
--- a/backend/src/modules/media/media-service/media-query.service.ts
+++ b/backend/src/modules/media/media-service/media-query.service.ts
@@ -844,6 +844,7 @@ export class MediaQueryService {
     if (!dto.type || dto.type === MediaType.MOVIE) {
       const moviesQb = this.mediaRepo
         .createQueryBuilder('m')
+        .leftJoinAndSelect('m.files', 'files')
         .where('m.type = :type', { type: MediaType.MOVIE })
         .andWhere(
           new Brackets((qb) => {
@@ -881,6 +882,7 @@ export class MediaQueryService {
       ];
 
       for (const m of movies) {
+        const hasFile = (m.files ?? []).length > 0;
         let hasSpecificDate = false;
         for (const { field, event } of eventFields) {
           const d = toDateStr(m[field]);
@@ -896,6 +898,7 @@ export class MediaQueryService {
               posterUrl: m.posterUrl,
               status: m.status,
               year: m.year,
+              hasFile,
             });
           }
         }
@@ -912,6 +915,7 @@ export class MediaQueryService {
             posterUrl: m.posterUrl,
             status: m.status,
             year: m.year,
+            hasFile,
           });
         }
       }


### PR DESCRIPTION
## Problem

The home **"Coming soon"** section lists movies the user already owns (has a
file for) instead of only upcoming/undownloaded content.

## Root cause

`getCalendar` (`media-query.service.ts`) builds movie entries **without** a
`hasFile` flag — only the episode branch sets it. So every movie entry reported
`hasFile: undefined`. The client filters the section with `!e.hasFile`, and
`!undefined` is truthy, so any movie with a calendar date in range showed up,
downloaded or not.

## Fix

In the movie branch:

- `leftJoinAndSelect('m.files', 'files')` to load the files relation;
- compute `hasFile = (m.files ?? []).length > 0` (the same test used for movie
  file presence elsewhere in this service);
- set it on both the specific-event and the generic `release` entries.

No client change: the existing `!hasFile` filter now excludes owned movies. The
episode branch is untouched.

## Verification

Backend type-check passes. Behaviour to confirm against real data: a released
movie with a file no longer appears under "Coming soon".
