### PR TITLE
fix(toast): add top gap, show above modals, pin close button right

### DIFF
--- a/client/src/app/shared/components/toast-container.html
+++ b/client/src/app/shared/components/toast-container.html
@@ -1,37 +1,35 @@
-<div class="toast toast-top toast-end z-[9999]" aria-live="polite" style="top: env(safe-area-inset-top); right: env(safe-area-inset-right)">
+<div #popover popover="manual" class="toast toast-top toast-end z-[9999]" aria-live="polite">
   @for (toast of toastService.toasts(); track toast.id) {
     <div
-      class="alert shadow-lg max-w-sm animate-slide-in"
+      class="alert shadow-lg w-full animate-slide-in"
       [class.alert-success]="toast.type === 'success'"
       [class.alert-error]="toast.type === 'error'"
       [class.alert-warning]="toast.type === 'warning'"
       [class.alert-info]="toast.type === 'info'"
       role="alert"
     >
-      <div class="flex items-start gap-2 w-full">
-        @switch (toast.type) {
-          @case ('success') {
-            <svg lucideCircleCheck class="h-5 w-5 shrink-0"></svg>
-          }
-          @case ('error') {
-            <svg lucideCircleX class="h-5 w-5 shrink-0"></svg>
-          }
-          @case ('warning') {
-            <svg lucideTriangleAlert class="h-5 w-5 shrink-0"></svg>
-          }
-          @case ('info') {
-            <svg lucideInfo class="h-5 w-5 shrink-0"></svg>
-          }
+      @switch (toast.type) {
+        @case ('success') {
+          <svg lucideCircleCheck class="h-5 w-5 shrink-0"></svg>
         }
-        <span class="text-sm flex-1">{{ toast.message }}</span>
-        <button
-          class="btn btn-ghost btn-xs btn-square"
-          (click)="toastService.dismiss(toast.id)"
-          [attr.aria-label]="'common.close_notification' | translate"
-        >
-          <svg lucideX class="h-4 w-4"></svg>
-        </button>
-      </div>
+        @case ('error') {
+          <svg lucideCircleX class="h-5 w-5 shrink-0"></svg>
+        }
+        @case ('warning') {
+          <svg lucideTriangleAlert class="h-5 w-5 shrink-0"></svg>
+        }
+        @case ('info') {
+          <svg lucideInfo class="h-5 w-5 shrink-0"></svg>
+        }
+      }
+      <span class="text-sm flex-1">{{ toast.message }}</span>
+      <button
+        class="btn btn-ghost btn-xs btn-square shrink-0"
+        (click)="toastService.dismiss(toast.id)"
+        [attr.aria-label]="'common.close_notification' | translate"
+      >
+        <svg lucideX class="h-4 w-4"></svg>
+      </button>
     </div>
   }
 </div>

--- a/client/src/app/shared/components/toast-container.ts
+++ b/client/src/app/shared/components/toast-container.ts
@@ -1,4 +1,11 @@
-import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import {
+  Component,
+  ChangeDetectionStrategy,
+  ElementRef,
+  effect,
+  inject,
+  viewChild,
+} from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { ToastService } from '../../core/services/toast.service';
 import {
@@ -14,7 +21,53 @@ import {
   imports: [TranslateModule, LucideCircleCheck, LucideCircleX, LucideTriangleAlert, LucideInfo, LucideX],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './toast-container.html',
+  styles: [
+    `
+      /* env(safe-area-inset-*) is 0 on desktop; add a base gap from the edge.
+         A stable width keeps the close button pinned right on short messages. */
+      .toast {
+        inset: auto;
+        top: calc(env(safe-area-inset-top, 0px) + 1rem);
+        right: calc(env(safe-area-inset-right, 0px) + 1rem);
+        width: min(100vw - 2rem, 24rem);
+      }
+      /* DaisyUI's .alert is a content-sized grid; force a flex row so the text
+         (flex-1) pushes the close button to the right edge. */
+      .alert {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+      /* Strip the popover UA chrome — keep a transparent positioning wrapper. */
+      .toast[popover] {
+        margin: 0;
+        padding: 0;
+        border: 0;
+        background: transparent;
+        overflow: visible;
+      }
+    `,
+  ],
 })
 export class ToastContainerComponent {
   readonly toastService = inject(ToastService);
+  private readonly popover = viewChild<ElementRef<HTMLElement>>('popover');
+
+  constructor() {
+    // Top-layer via the Popover API so toasts sit above showModal() <dialog>s,
+    // which no z-index can beat; re-promote on each change. Absent API (older TV
+    // webviews) falls back to the z-index div.
+    effect(() => {
+      const hasToasts = this.toastService.toasts().length > 0;
+      const el = this.popover()?.nativeElement;
+      if (!el || typeof el.showPopover !== 'function') return;
+      const open = el.matches(':popover-open');
+      if (hasToasts) {
+        if (open) el.hidePopover();
+        el.showPopover();
+      } else if (open) {
+        el.hidePopover();
+      }
+    });
+  }
 }


### PR DESCRIPTION
## Problem

Three issues with the notification toasts, mainly on desktop:

1. Not enough space above the stack (toasts hug the top edge).
2. Toasts sometimes render **behind** modals.
3. The close button isn't pinned to the right on short messages.

## Fixes

- **Top gap** — the offsets used `env(safe-area-inset-*)` alone, which is `0` on
  desktop. Add a `1rem` base gap on top of the safe-area inset.
- **Above modals** — the app's modals are native `<dialog>`s opened with
  `showModal()`, which live in the browser **top layer**, above every z-index.
  The stack is now promoted into the top layer via the **Popover API**
  (feature-detected; falls back to the plain z-index div on older TV webviews),
  re-promoted on each change so it stays above a dialog opened since.
- **Close button pinned right** — DaisyUI's `.alert` is a content-sized grid, so
  on short messages the button sat right after the text. Force a flex row
  (scoped style, reliably overrides the layered DaisyUI grid) and give the stack
  a stable responsive width, so the `flex-1` message pushes the button to the
  edge. It also centers the icon/button vertically on multi-line toasts.

## Verification

Client type-check passes. Visual behaviour confirmed by the reporter.
