### PR TITLE
fix(imports): derive imported file quality from real resolution

### DIFF
--- a/backend/src/common/release-parsing/index.ts
+++ b/backend/src/common/release-parsing/index.ts
@@ -8,5 +8,6 @@
 export * from './attributes.parser';
 export * from './language.parser';
 export * from './quality.parser';
+export * from './quality-from-resolution';
 export * from './season-episode.parser';
 export * from './title.extractor';

--- a/backend/src/common/release-parsing/quality-from-resolution.spec.ts
+++ b/backend/src/common/release-parsing/quality-from-resolution.spec.ts
@@ -1,0 +1,28 @@
+import { qualityFromResolution } from './quality-from-resolution';
+
+describe('qualityFromResolution', () => {
+  it('buckets by real pixels, ignoring a mislabeled release resolution', () => {
+    // Release name claims 2160p, but the file is a 1080p scope master (1920×804).
+    expect(
+      qualityFromResolution('The.Fall.Guy.2024.2160p.WEB-DL.x265', 1920, 804),
+    ).toBe('WEBDL-1080p');
+  });
+
+  it('keeps 2160p when the pixels really are 2160p', () => {
+    expect(
+      qualityFromResolution('Movie.2024.2160p.WEB-DL', 3840, 2160),
+    ).toBe('WEBDL-2160p');
+  });
+
+  it('takes the source tag from the text (remux)', () => {
+    expect(qualityFromResolution('Movie.2024.1080p.Remux', 1920, 1080)).toBe(
+      'Remux-1080p',
+    );
+  });
+
+  it('defaults the source to hdtv when no tag is present', () => {
+    expect(qualityFromResolution('Movie 2024 1080', 1920, 1080)).toBe(
+      'HDTV-1080p',
+    );
+  });
+});

--- a/backend/src/common/release-parsing/quality-from-resolution.ts
+++ b/backend/src/common/release-parsing/quality-from-resolution.ts
@@ -1,0 +1,36 @@
+import { APP_QUALITIES } from '../constants/app-qualities';
+import { bucketResolutionHeight } from '../utils/resolution.util';
+
+/**
+ * Resolve a quality name from the ACTUAL video dimensions plus the source tag
+ * (bluray / web / remux …) sniffed from `sourceText` (a release name or
+ * filename). Unlike parseReleaseQuality, which trusts the release name's
+ * resolution claim, this buckets by real pixels — so a release mislabeled
+ * "2160p" that is really 1920×804 resolves to a 1080p quality.
+ */
+export function qualityFromResolution(
+  sourceText: string,
+  actualWidth?: number,
+  actualHeight?: number,
+): string {
+  // Clamp to APP_QUALITIES' supported resolutions (480 / 720 / 1080 / 2160).
+  // Tiny sub-480 sources fall back to 480 (no 144/240/360 entries exist).
+  const bucket = bucketResolutionHeight(actualWidth, actualHeight);
+  const resolution = bucket >= 2160 ? 2160 : bucket <= 480 ? 480 : bucket;
+
+  const t = sourceText.replace(/\./g, ' ').toLowerCase();
+  let source = 'hdtv';
+  if (/\bremux\b/.test(t)) source = 'remux';
+  else if (/\b(bluray|blu-?ray|bdrip|brrip)\b/.test(t)) source = 'bluray';
+  else if (/\bweb-?dl\b/.test(t)) source = 'web';
+  else if (/\bweb-?rip\b/.test(t)) source = 'web';
+  else if (/\b(dvd|dvdrip)\b/.test(t)) source = 'dvd';
+
+  const match = APP_QUALITIES.find(
+    (q) => q.resolution === resolution && q.source === source,
+  );
+  if (match) return match.name;
+
+  const fallback = APP_QUALITIES.find((q) => q.resolution === resolution);
+  return fallback?.name ?? `HDTV-${resolution}p`;
+}

--- a/backend/src/modules/media/media-service/media-rescan.service.ts
+++ b/backend/src/modules/media/media-service/media-rescan.service.ts
@@ -13,8 +13,10 @@ import { MediaFile } from '../entities/media-file.entity';
 import { Season } from '../entities/season.entity';
 import { Episode } from '../entities/episode.entity';
 import { MediaType } from '../../../common/enums';
-import { APP_QUALITIES } from '../../../common/constants/app-qualities';
-import { parseReleaseQuality } from '../../../common/release-parsing';
+import {
+  parseReleaseQuality,
+  qualityFromResolution,
+} from '../../../common/release-parsing';
 import { AnalyzeMediaDto } from '../dto/analyze-media.dto';
 import { computeMovieHash } from '../../subtitles/moviehash';
 import { NamingService } from '../../scheduler/naming.service';
@@ -30,7 +32,6 @@ import { MediaServersService } from '../../media-servers/media-servers.service';
 import { MediaMetadataService } from './media-metadata.service';
 import { clearMediaCache } from '../../../common/utils/media-cache.util';
 import { relativePathUnderMediaRoot } from '../../../common/utils/media-path.util';
-import { bucketResolutionHeight } from '../../../common/utils/resolution.util';
 
 type ProbeResult = Awaited<ReturnType<FfprobeService['detectMediaFileInfo']>>;
 
@@ -909,10 +910,10 @@ export class MediaRescanService {
         );
       }
     }
-    const quality = this.resolveQuality(
+    const quality = qualityFromResolution(
       filename,
-      streamInfo?.video?.[0]?.height,
       streamInfo?.video?.[0]?.width,
+      streamInfo?.video?.[0]?.height,
     );
     return { streamInfo, quality };
   }
@@ -956,36 +957,4 @@ export class MediaRescanService {
     return files;
   }
 
-  /**
-   * Determine quality from ffprobe resolution (source of truth) + filename source tag.
-   */
-  private resolveQuality(
-    filename: string,
-    actualHeight?: number,
-    actualWidth?: number,
-  ): string {
-    // Bucket by dimensions, clamped to APP_QUALITIES' supported resolutions
-    // (480 / 720 / 1080 / 2160). Tiny sub-480 sources fall back to 480 here
-    // because we don't ship 144/240/360 entries in APP_QUALITIES.
-    const bucket = bucketResolutionHeight(actualWidth, actualHeight);
-    const resolution = bucket >= 2160 ? 2160 : bucket <= 480 ? 480 : bucket;
-
-    // Determine source from filename (bluray, web, remux, etc.)
-    const t = filename.replace(/\./g, ' ').toLowerCase();
-    let source = 'hdtv';
-    if (/\bremux\b/.test(t)) source = 'remux';
-    else if (/\b(bluray|blu-?ray|bdrip|brrip)\b/.test(t)) source = 'bluray';
-    else if (/\bweb-?dl\b/.test(t)) source = 'web';
-    else if (/\bweb-?rip\b/.test(t)) source = 'web';
-    else if (/\b(dvd|dvdrip)\b/.test(t)) source = 'dvd';
-
-    const match = APP_QUALITIES.find(
-      (q) => q.resolution === resolution && q.source === source,
-    );
-    if (match) return match.name;
-
-    // Fallback: any quality with correct resolution
-    const fallback = APP_QUALITIES.find((q) => q.resolution === resolution);
-    return fallback?.name ?? `HDTV-${resolution}p`;
-  }
 }

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -40,7 +40,10 @@ import { Library } from '../libraries/entities/library.entity';
 import { TorrentHistoryMatcher } from '../media/torrent-history-matcher.service';
 import { TorrentAutoMatcher } from '../media/torrent-auto-matcher.service';
 import { buildGrabHistoryRow } from '../media/grab-history.util';
-import { parseReleaseQuality } from '../../common/release-parsing';
+import {
+  parseReleaseQuality,
+  qualityFromResolution,
+} from '../../common/release-parsing';
 import { MarkersService } from '../markers/markers.service';
 import { FileTransferService } from '../../common/services/file-transfer.service';
 import { MediaService } from '../media/media.service';
@@ -694,6 +697,24 @@ export class CompletionService {
       const ext = path.extname(videoFile.filePath);
       const filename = path.basename(videoFile.filePath, ext);
 
+      // Derive quality from the real pixels, not the (sometimes mislabeled)
+      // release name: a torrent tagged "2160p" that is actually 1920×804 must
+      // be named + tracked as 1080p (drives the filename, the badge, and the
+      // upgrade cutoff). The source tag still comes from the release name. Falls
+      // back to the grabbed quality when probing yields no dimensions.
+      const streamInfo = await this.ffprobe.detectMediaFileInfo(
+        videoFile.filePath,
+      );
+      const srcVideo = streamInfo?.video?.[0];
+      const fileQuality =
+        srcVideo?.width && srcVideo?.height
+          ? qualityFromResolution(
+              history.sourceTitle,
+              srcVideo.width,
+              srcVideo.height,
+            )
+          : history.quality;
+
       let newFilename: string;
       let destDir: string;
       let episodeId: number | undefined;
@@ -704,7 +725,7 @@ export class CompletionService {
           title: media.title,
           originalTitle: media.originalTitle,
           year: media.year,
-          quality: history.quality,
+          quality: fileQuality,
           releaseGroup,
           tmdbId: media.tmdbId,
         });
@@ -756,7 +777,7 @@ export class CompletionService {
           season: epNums?.season ?? 1,
           episode: epNums?.episode ?? 1,
           episodeTitle: epTitle,
-          quality: history.quality,
+          quality: fileQuality,
           releaseGroup,
           airDate,
         });
@@ -805,8 +826,6 @@ export class CompletionService {
         );
         continue;
       }
-      const streamInfo = await this.ffprobe.detectMediaFileInfo(destPath);
-
       // Avoid duplicate: update existing record if same path already tracked
       const existingFile = await this.mediaFileRepo.findOne({
         where: { media: { id: media.id }, relativePath },
@@ -817,7 +836,7 @@ export class CompletionService {
               episode:
                 episodeId != null ? ({ id: episodeId } as Episode) : null,
               size: videoFile.size,
-              quality: history.quality,
+              quality: fileQuality,
               streamInfo,
             }),
           )
@@ -828,7 +847,7 @@ export class CompletionService {
                 episodeId != null ? ({ id: episodeId } as Episode) : null,
               relativePath,
               size: videoFile.size,
-              quality: history.quality,
+              quality: fileQuality,
               streamInfo,
             }),
           );


### PR DESCRIPTION
## Problem

A torrent mislabeled **2160p** but actually **1920×804 (1080p scope)** was
imported as `The Fall Guy (2024) 2160p.mkv` with `quality = "2160p"`. The
completion path ran ffprobe but **discarded the resolution** and took quality
from the release name, so the filename, the file-info badge and the upgrade
**cutoff** all reported 2160p — wrongly marking the cutoff as met and blocking a
legitimate upgrade to a real higher-res source. (The media-detail header already
showed the correct 1080p, since it buckets the actual dimensions.)

## Fix

- New shared helper **`qualityFromResolution(sourceText, width, height)`**
  (`common/release-parsing/`): buckets by real pixels, source tag from the text.
  This is the resolution-bucketing logic that already lived privately in the
  rescan service, extracted so both import paths agree (dedup — the rescan
  service now uses it too, private method removed).
- **`completion.service.ts`**: probe the **source before naming** and derive
  quality from the actual pixels (source tag from `history.sourceTitle`), feeding
  both the destination **filename** and **`MediaFile.quality`**. Falls back to
  the grabbed release quality when probing yields no dimensions. The duplicate
  post-move probe is dropped (one probe now).

The cutoff and the file-info badge read `MediaFile.quality`, so they correct
automatically.

## Scope

- **New imports**: filename + quality + cutoff correct from the start.
- **Existing files**: a rescan re-derives `MediaFile.quality` (badge + cutoff fix
  to 1080p). The on-disk filename is not renamed in place (risky w.r.t.
  hardlinks / seeding) — it corrects on re-import.

## Verification

- Backend type-check passes.
- New unit spec (4 cases) — incl. the bug case
  `qualityFromResolution('…2160p.WEB-DL', 1920, 804)` → `WEBDL-1080p`, and a real
  `3840×2160` → `WEBDL-2160p`.
