### PR TITLE
fix(player): translate reload/init error card, never show raw text

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1274,7 +1274,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
           ? this.translate.instant(
               userMessageKeyFor({ source: 'shaka', code: e?.code, category: e?.category }),
             )
-          : msg,
+          : this.translate.instant('player.playback_error'),
         {
           source: isShaka ? 'shaka' : 'engine',
           code: e?.code,
@@ -2032,12 +2032,24 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       if (!this.isNativeEngine()) this.engine.play().catch(() => {});
       this.resetHideTimer();
     } catch (e: any) {
-      this.state.setError(e?.message ?? String(e), {
-        source: 'engine',
-        code: e?.code,
-        category: e?.category,
-        data: e?.data,
-      });
+      // Map to a translated line (Shaka-shaped errors keep their category
+      // message) and keep the raw engine/exception text in the diagnostics
+      // `message` field only — the card body never shows an untranslated string.
+      const isShaka = e?.category != null;
+      this.state.setError(
+        isShaka
+          ? this.translate.instant(
+              userMessageKeyFor({ source: 'shaka', code: e?.code, category: e?.category }),
+            )
+          : this.translate.instant('player.playback_error'),
+        {
+          source: isShaka ? 'shaka' : 'engine',
+          code: e?.code,
+          category: e?.category,
+          data: e?.data,
+          message: e?.message ?? String(e),
+        },
+      );
     } finally {
       this.reloadingStream = false;
       this.state.loading.set(false);


### PR DESCRIPTION
## What

Two `catch` blocks in the player passed a raw, untranslated string as the error-card body via `setError(e?.message ?? String(e), …)`:

- the `reloadForEpisode` catch
- the `ngAfterViewInit` init fallback (non-Shaka `else` branch)

When the caught value was a reason-less rejection (`undefined`), `String(undefined) === "undefined"` was rendered verbatim as the card message; any other engine/exception text bypassed i18n.

## Fix

Route both through `translate.instant(userMessageKeyFor(…))` — the same mapping the engine `error`-event path already uses — falling back to `player.playback_error`, and keep the raw text only in the diagnostics `message` field so it stays copyable in the details block.

The engine `error`-event path, the recovery-exhaustion terminals, and the offline path were already translated; this closes the two remaining raw-string surfaces so the card body can never show an untranslated value.

## Context

Reported on an old iPad web client: the error card showed the title with a literal `undefined` body after ~10 min on Auto. This PR fixes the **display** (no more raw/untranslated text). The **underlying** ~10-min failure trigger — most likely an ABR climb into an undecodable rung or a `SourceBuffer` quota on the memory-tight old iPad — is a separate reliability issue still pending an on-device Web Inspector capture of the actual Shaka/MediaError code; the now-copyable diagnostics block is what will pin it.

## Verification

- AOT build clean (`ng build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
