### PR TITLE
ci(desktop): vendor newest x86_64 mpv, not releases/latest

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -173,14 +173,23 @@ jobs:
       - name: Vendor mpv (Windows)
         if: runner.os == 'Windows'
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           dest=desktop/native/vendor
           mkdir -p "$dest"
-          url=$(curl -fsSL https://api.github.com/repos/zhongfly/mpv-winbuild/releases/latest \
-            | grep -oE 'https://[^"]+' \
-            | grep -E 'mpv-x86_64-[0-9][^"]*\.7z$' | head -1)
-          test -n "$url" || { echo "::error::no mpv x86_64 .7z asset found"; exit 1; }
+          # zhongfly/mpv-winbuild sometimes cuts an arch-specific (e.g.
+          # aarch64-only) release, which `releases/latest` then points at,
+          # leaving no x86_64 asset. Scan the recent releases and take the
+          # newest x86_64 build instead. The `|| true` keeps `set -e` from
+          # firing on a grep-no-match / head SIGPIPE; the explicit guard below
+          # reports the failure clearly. The API call is authenticated to avoid
+          # the unauthenticated shared-runner-IP rate limit.
+          url=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/zhongfly/mpv-winbuild/releases?per_page=20" \
+            | grep -oE 'https://[^"]+mpv-x86_64-[0-9][^"]*\.7z' | head -1) || true
+          test -n "$url" || { echo "::error::no mpv-x86_64 .7z asset in the last 20 releases"; exit 1; }
           echo "Downloading mpv: $url"
           curl -fsSL -o "$RUNNER_TEMP/mpv.7z" "$url"
           7z x -y -o"$dest" "$RUNNER_TEMP/mpv.7z" >/dev/null


### PR DESCRIPTION
## Problem

The `Desktop release` Windows job fails at the **Vendor mpv (Windows)** step (run [28857642554](https://github.com/fliks-app/fliks/actions/runs/28857642554) — Linux ✅ / macOS ✅ / Windows ❌).

The step pinned to `zhongfly/mpv-winbuild` **`releases/latest`** and assumed it always carries an `mpv-x86_64-*.7z` asset. Upstream periodically cuts an **arch-specific (aarch64-only)** release — the current `latest` (`2026-07-06-4c220ffd95`) has **no x86_64 asset at all**. So the `mpv-x86_64-[0-9]…\.7z` regex matched nothing, `url` was empty, and the pipeline exited 1 under `set -euo pipefail` *before* the guard (≈0.4 s, no `Downloading mpv:` line, no custom error). Not a compile failure — an upstream-shape regression.

Verified locally: every recent release except `…4c220ffd95` ships x86_64; the old pipeline returns empty, the new one returns `mpv-x86_64-20260706-git-c8c7d91a8e.7z`.

## Fix

- Query `releases?per_page=20` and take the **newest release that actually has an x86_64 build**, instead of trusting `latest`.
- **Authenticate** the API call (`GITHUB_TOKEN`) to avoid the unauthenticated shared-runner-IP rate limit now that we list releases.
- Make the URL capture **`set -e`-safe** (`|| true` + explicit `test -n` guard) so a genuine no-match reports a clear error rather than a bare `exit 1`.

macOS/Linux are unaffected — Linux uses the committed vendored `libmpv.so.2` and macOS builds from Homebrew `mpv`; only Windows pulls from zhongfly.

## Verification

- Replacement pipeline reproduced locally against the live API → resolves a valid x86_64 `.7z` URL.
- A `workflow_dispatch` run of `Desktop release` on this branch confirms the Windows job before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
