### PR TITLE
fix(desktop): restore caption buttons after exit-fullscreen on windows

### DIFF
--- a/desktop/src/main/window/player-session.ts
+++ b/desktop/src/main/window/player-session.ts
@@ -152,10 +152,24 @@ export class PlayerSession {
       'unmaximize',
       'restore',
       'enter-full-screen',
-      'leave-full-screen',
     ] as const) {
       this.frameWin.on(ev as 'resize', sync);
     }
+    // On Windows, 'leave-full-screen' fires BEFORE the windowed frame is
+    // restored (Electron applies the size after notifying), so a synchronous
+    // getContentBounds() still returns the full-display rect. sync() would then
+    // pin the transparent video/UI overlays over the title bar, covering the
+    // native caption buttons, with no later event guaranteed to correct it.
+    // Re-fit once the restore has committed. macOS reports settled bounds at the
+    // event already, so it needs only the synchronous pass; the deferred ones
+    // are idempotent no-ops (sync() guards isDestroyed()).
+    this.frameWin.on('leave-full-screen', () => {
+      sync();
+      if (process.platform === 'win32') {
+        setTimeout(sync, 0);
+        setTimeout(sync, 150);
+      }
+    });
     this.frameWin.on('closed', () => this.destroy());
 
     await this.uiWin.loadURL(rendererUrl);


### PR DESCRIPTION
## Problem

On the **Windows** desktop client, after entering fullscreen and exiting it, the native Windows caption buttons (close / minimize / maximize) do not reappear.

## Root cause

The Windows/macOS client uses a three-window model (`desktop/src/main/window/player-session.ts`): `frameWin` carries the native chrome, and the frameless transparent `videoWin`/`uiWin` (always z-ordered above it) are pinned to `frameWin.getContentBounds()` by `sync()` on every geometry event.

On Windows, Electron's `NativeWindowViews::SetFullScreen` emits **`leave-full-screen` before** it applies the windowed-frame restore (it sets the size *after* notifying). So the synchronous `sync()` reads the still-fullscreen `getContentBounds()` (top ≈ 0, full-display height) and pins the transparent overlays over the title-bar band — occluding the caption buttons that live in `frameWin`'s non-client area behind them. No later event re-runs `sync()` with the settled bounds, so it stays until a manual move/resize. (With `isFullScreen()` already flipped to false, the win32 #27286 1px shave is also skipped, so `uiWin` can even turn opaque over the whole strip.)

Windows-only: Linux uses the separate single-window SDL compositor (no `frameWin`); macOS emits `leave-full-screen` only after the exit-space transition settles, so bounds are already correct there.

## Fix

Split `leave-full-screen` out of the shared listener loop and add a **win32-gated deferred re-fit**, so the overlays are re-pinned once the restore commits:

```ts
this.frameWin.on('leave-full-screen', () => {
  sync();
  if (process.platform === 'win32') {
    setTimeout(sync, 0);    // runs after setFullScreen(false) returns → restored bounds
    setTimeout(sync, 150);  // backstop for a slow/loaded machine
  }
});
```

Safe: win32-gated (macOS keeps its synchronous `sync()`, Linux untouched), idempotent, teardown-safe (`sync()` guards `isDestroyed()`), and the `enter-full-screen` 1px anti-#27286 shave is unchanged.

## Verification

- Root cause is code-verified against Electron's documented Windows notify-before-apply fullscreen ordering; the main bundle builds clean (`npm run build`).
- **Pending on-device confirmation** (no Windows box here). Decisive check on a Windows build: after exit-fullscreen, click where the caption buttons sit or nudge the window 1px — if the buttons return, occlusion is confirmed and this fix resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
