### PR TITLE
fix(activity): translate the blocked-from-queue status message

### DIFF
--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -929,6 +929,7 @@
     "fstatus_imported": "Importé",
     "fstatus_import_failed": "Échec de l'import",
     "msg_no_video_file": "Aucun fichier vidéo valide dans ce téléchargement",
+    "msg_blocked_from_queue": "Bloqué depuis la file d'activité",
     "stall_strikes_tooltip": "Nettoyage : {{current}} sur {{required}} vérifications sans progression",
     "search_another": "Chercher un autre torrent",
     "search_no_target": "Impossible de déterminer la cible de recherche pour cet élément.",

--- a/client/src/app/features/activity/queue/queue.ts
+++ b/client/src/app/features/activity/queue/queue.ts
@@ -520,6 +520,9 @@ export class ActivityQueueComponent implements OnInit, OnDestroy {
     if (msg.includes('no valid video file')) {
       return this.translate.instant('activity.msg_no_video_file');
     }
+    if (msg === 'Blocked from the activity queue') {
+      return this.translate.instant('activity.msg_blocked_from_queue');
+    }
     return msg;
   }
 }


### PR DESCRIPTION
## Problem

In the activity queue, a torrent retired via **Search another** shows the status message **`Blocked from the activity queue`** in raw English, while every other label is localized. The backend emits that string by design (backend is English-only), and `statusMessageLabel` (queue.ts) only mapped the `no valid video file` case — everything else fell through to `return msg` untranslated.

## Fix

- `queue.ts` → `statusMessageLabel` maps `'Blocked from the activity queue'` to the i18n key `activity.msg_blocked_from_queue`.
- `fr.json` → `"msg_blocked_from_queue": "Bloqué depuis la file d'activité"`.

The row now shows **« Bloqué depuis la file d'activité »**.

## Verification

- AOT build clean (`ng build`); `fr.json` validated as JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)