### PR TITLE
fix(player): webOS subtitle margin and remote control wake

### DIFF
--- a/client/src/app/features/player/player.html
+++ b/client/src/app/features/player/player.html
@@ -7,6 +7,8 @@
   [class.native-player]="!!nativeEngine"
   [class.hidden]="castService.isConnected()"
   (mousemove)="device.isTouch() || device.isDpad() ? null : showControls()"
+  (wheel)="wakeControlsFromPointer()"
+  (click)="wakeControlsFromPointer()"
 >
   <!-- Backdrop until video renders its first frame. Rendered for both
        web (Shaka) and native (ExoPlayer) — on native the WebView is

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -497,7 +497,11 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       bump kicks in. Browser playback uses CSS instead — see styles below. */
   private readonly subtitleControlsMarginEffect = effect(() => {
     this.controlsVisible();
-    if (this.isNativeEngine() && this.engine) {
+    // webOS drives the same DOM subtitle overlay as the native engines but
+    // reports isNativeEngine=false (it keeps the Shaka UX), so it needs an
+    // explicit branch — otherwise the margin stays pinned at its load-time
+    // value (controls visible → offset) and never settles flush on hide.
+    if ((this.isNativeEngine() || this.isWebOs) && this.engine) {
       this.applyNativeSubtitleStyle();
     }
   });
@@ -1560,6 +1564,15 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   showControls() {
     this.controlsVisible.set(true);
     this.resetHideTimer();
+  }
+
+  /** The webOS Magic Remote's scroll wheel and center-button press arrive as
+   *  `wheel` / `click` events at the pointer, not `keydown`, so the D-pad wake
+   *  path in `onKeyDown` never sees them — and `mousemove` is intentionally
+   *  muted on dpad input to avoid pointer-drift waking the bar. Wake the
+   *  controls for those discrete, intentional pointer gestures. */
+  wakeControlsFromPointer() {
+    if (this.device.isDpad() && !this.controlsVisible()) this.showControls();
   }
 
   /** Move focus to the seekbar after the controls bar has rendered/become
@@ -2738,7 +2751,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
   /**
    * Apply user's subtitle style settings to native engine. When the player
-   * controls are visible, bumps the bottom margin by 5% so cues don't sit
+   * controls are visible, bumps the bottom margin by 10vh so cues don't sit
    * under the controls bar — the WebKit `::cue` shift used in browser mode
    * doesn't apply on ExoPlayer/AVPlayer.
    */


### PR DESCRIPTION
Two webOS-only player fixes, both rooted in the LG engine reporting `isNativeEngine=false` (it keeps the Shaka UX while driving a native `<video>` + DOM subtitle overlay). Both were confirmed on-device on an LG webOS TV.

## Subtitle bottom margin never settles flush on webOS

The controls-toggle re-application effect (`subtitleControlsMarginEffect`) was gated on `isNativeEngine()`. webOS reports `false`, so the subtitle margin was applied only once — at load, while the controls bar is still visible, which adds the +10vh clearance bump. It never recomputed when the bar hid, so a **"subtitle position 0%"** setting still sat ~10vh off the bottom edge instead of flush.

**Fix:** include webOS in the effect guard so the margin recomputes on controls show/hide, exactly as it already does on Tizen. During normal viewing (controls hidden) position 0% is now flush; with controls up it lifts to clear the bar.

## Magic Remote wheel / center click don't wake the controls

On the LG Magic Remote in pointer mode, the scroll wheel emits `wheel` events and the center-button press emits a `click`/`mouseup` at the pointer — **not** `keydown`. The D-pad wake path in `onKeyDown` never saw them, and `mousemove` is intentionally muted on dpad input (pointer drift would otherwise wake the bar constantly).

**Fix:** add `(wheel)` / `(click)` handlers on the player container wired to a new `wakeControlsFromPointer()` that wakes the bar for those discrete, intentional pointer gestures. Guarded by `isDpad() && !controlsVisible()` so desktop is untouched and clicks on visible control buttons still activate normally.

Also corrects a stale doc comment (the controls-visible bump is 10vh, not 5%).

## Test plan (on LG webOS TV)
- Subtitles, position 0%, let controls hide → cues sit flush at the bottom; raising controls lifts them; 5/10/15/20% step proportionally.
- In-player, controls hidden → scroll wheel wakes the bar; center-button press wakes the bar; D-pad + OK still wake; clicking a visible control still acts on it.
