### PR TITLE
feat(downloads): implement ios offline downloads

### DIFF
--- a/client/ios/App/App.xcodeproj/project.pbxproj
+++ b/client/ios/App/App.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		F1000001AAAA000000000006 /* CastPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1000001AAAA000000000016 /* CastPlugin.swift */; };
 		F1000001AAAA000000000007 /* AudioCapabilitiesPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1000001AAAA000000000017 /* AudioCapabilitiesPlugin.swift */; };
 		F1000001AAAA000000000008 /* SubtitleOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1000001AAAA000000000018 /* SubtitleOverlayView.swift */; };
+		F1000001AAAA000000000009 /* DownloadPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1000001AAAA000000000019 /* DownloadPlugin.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -45,6 +46,7 @@
 		F1000001AAAA000000000016 /* CastPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CastPlugin.swift; sourceTree = "<group>"; };
 		F1000001AAAA000000000017 /* AudioCapabilitiesPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCapabilitiesPlugin.swift; sourceTree = "<group>"; };
 		F1000001AAAA000000000018 /* SubtitleOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtitleOverlayView.swift; sourceTree = "<group>"; };
+		F1000001AAAA000000000019 /* DownloadPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadPlugin.swift; sourceTree = "<group>"; };
 		FC68EB0AF532CFC21C3344DD /* Pods-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-App/Pods-App.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -99,6 +101,7 @@
 				F1000001AAAA000000000016 /* CastPlugin.swift */,
 				F1000001AAAA000000000017 /* AudioCapabilitiesPlugin.swift */,
 				F1000001AAAA000000000018 /* SubtitleOverlayView.swift */,
+				F1000001AAAA000000000019 /* DownloadPlugin.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -256,6 +259,7 @@
 				F1000001AAAA000000000006 /* CastPlugin.swift in Sources */,
 				F1000001AAAA000000000007 /* AudioCapabilitiesPlugin.swift in Sources */,
 				F1000001AAAA000000000008 /* SubtitleOverlayView.swift in Sources */,
+				F1000001AAAA000000000009 /* DownloadPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/client/ios/App/App/AppDelegate.swift
+++ b/client/ios/App/App/AppDelegate.swift
@@ -2,9 +2,10 @@ import UIKit
 import Capacitor
 import AVFoundation
 import GoogleCast
+import UserNotifications
 
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
 
     var window: UIWindow?
 
@@ -20,6 +21,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         } catch {
             print("Audio session configuration failed: \(error)")
         }
+
+        // Present download completion banners even while the app is foregrounded
+        // (default iOS behaviour suppresses them when the app is active).
+        UNUserNotificationCenter.current().delegate = self
 
         // Initialize Google Cast SDK early (required for device discovery)
         let castOptions = GCKCastOptions(discoveryCriteria:
@@ -61,6 +66,31 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+    // iOS relaunches the app in the background when our background download
+    // session has events to deliver. Stash the completion handler so the
+    // DownloadPlugin's session delegate can call it once all events are flushed
+    // (urlSessionDidFinishEvents). Not calling it makes the OS throttle us.
+    func application(
+        _ application: UIApplication,
+        handleEventsForBackgroundURLSession identifier: String,
+        completionHandler: @escaping () -> Void
+    ) {
+        if identifier == BackgroundDownloadCompletion.sessionIdentifier {
+            BackgroundDownloadCompletion.handler = completionHandler
+        } else {
+            completionHandler()
+        }
+    }
+
+    // Show download banners as alerts while the app is in the foreground.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound])
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {

--- a/client/ios/App/App/DownloadPlugin.swift
+++ b/client/ios/App/App/DownloadPlugin.swift
@@ -1,83 +1,195 @@
 import Capacitor
 import AVFoundation
+import UserNotifications
+
+/// Holds the completion handler iOS hands us when it relaunches the app in the
+/// background to finish delivering events for our background `URLSession`.
+///
+/// `AppDelegate.application(_:handleEventsForBackgroundURLSession:)` stores it
+/// here; the session's `urlSessionDidFinishEvents(forBackgroundURLSession:)`
+/// delegate callback invokes and clears it once all queued events have been
+/// dispatched. Failing to call it makes the OS consider the app misbehaving and
+/// throttles future background transfers. Keyed by the session identifier so a
+/// stray handler for another session can't be consumed by ours.
+enum BackgroundDownloadCompletion {
+    static let sessionIdentifier = "media.fliks.app.download"
+    static var handler: (() -> Void)?
+}
 
 /**
- * Capacitor plugin for offline HLS downloads on iOS.
- * Uses AVAssetDownloadURLSession to download HLS content as .movpkg
- * bundles that AVPlayer can play natively offline.
+ * Capacitor plugin for offline HLS downloads on iOS — the AVFoundation
+ * counterpart of the Android `DownloadNotificationPlugin` (ExoPlayer).
+ *
+ * Downloads run through a single background `AVAssetDownloadURLSession`, so the
+ * OS keeps them alive while the app is suspended, the screen is locked, or the
+ * app is terminated — no foreground service or idle-timer juggling is needed
+ * (that is the iOS-idiomatic equivalent of Android's foreground download
+ * service that also blocks device sleep). Each finished download is a local
+ * `.movpkg` bundle that `AVURLAsset` plays natively offline.
+ *
+ * Contract shared with the WebView / Android (see download-notification.service.ts):
+ *   methods  startDownload / removeDownload / getDownloads / isDownloaded
+ *            / getOfflineUrl / pauseDownloads / resumeDownloads
+ *   events   downloadProgress | downloadComplete | downloadFailed | downloadRemoved
+ *            each carrying { id, progress, state }
  */
 @objc(DownloadNotification)
-class DownloadPlugin: CAPPlugin, CAPBridgedPlugin, AVAssetDownloadDelegate {
-    let identifier = "DownloadNotification"
-    let jsName = "DownloadNotification"
-    let pluginMethods: [CAPPluginMethod] = [
+public class DownloadPlugin: CAPPlugin, CAPBridgedPlugin, AVAssetDownloadDelegate {
+    public let identifier = "DownloadNotification"
+    public let jsName = "DownloadNotification"
+    public let pluginMethods: [CAPPluginMethod] = [
         CAPPluginMethod(name: "startDownload", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "removeDownload", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getDownloads", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "isDownloaded", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getOfflineUrl", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "pauseDownloads", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "resumeDownloads", returnType: CAPPluginReturnPromise),
     ]
 
-    private var downloadSession: AVAssetDownloadURLSession!
-    /// Maps taskDescription (our download ID) → active download task
-    private var activeTasks: [String: AVAggregateAssetDownloadTask] = [:]
-    /// Maps taskDescription → local .movpkg URL (set on completion)
-    private var downloadedAssets: [String: URL] = [:]
+    /// UserDefaults key under which the id → relative-path map is persisted.
+    private static let assetsDefaultsKey = "fliks_offline_assets"
 
-    override func load() {
-        // Restore persisted asset locations
-        if let saved = UserDefaults.standard.dictionary(forKey: "fliks_offline_assets") as? [String: String] {
-            for (id, path) in saved {
-                downloadedAssets[id] = URL(fileURLWithPath: path)
-            }
+    private var downloadSession: AVAssetDownloadURLSession!
+    /// taskDescription (our download id) → active aggregate download task.
+    private var activeTasks: [String: AVAggregateAssetDownloadTask] = [:]
+    /// id → last progress percentage (0–100) seen from the delegate. HLS byte
+    /// counts are unreliable for aggregate tasks, so progress is derived from
+    /// loaded time-ranges and cached here for `getDownloads`.
+    private var progressById: [String: Float] = [:]
+    /// id → completed asset location, kept RELATIVE to the home directory. The
+    /// sandbox container path changes across app launches and updates, so an
+    /// absolute path saved today is dangling tomorrow — Apple's documented
+    /// rule for downloaded HLS assets is to persist the relative path and
+    /// rebuild it against `NSHomeDirectory()` at use time.
+    private var relativePathById: [String: String] = [:]
+    /// id → notification strings supplied by the WebView (already localized via
+    /// ngx-translate so no user-facing text is hardcoded in native).
+    private var notifById: [String: (title: String, complete: String, failed: String)] = [:]
+
+    override public func load() {
+        // Restore the persisted id → relative-path map so completed downloads
+        // survive an app restart.
+        if let saved = UserDefaults.standard.dictionary(forKey: Self.assetsDefaultsKey) as? [String: String] {
+            relativePathById = saved
+            for id in saved.keys { progressById[id] = 100 }
         }
 
-        // Background session survives app suspension
-        let config = URLSessionConfiguration.background(withIdentifier: "com.fliks.download")
+        // A background session survives app suspension AND termination. It must
+        // be recreated with the SAME identifier on every launch so the OS can
+        // hand back any transfers that were still running — otherwise the
+        // in-flight tasks are orphaned. `.main` delegate queue keeps our
+        // WebView event dispatch on the main thread.
+        let config = URLSessionConfiguration.background(
+            withIdentifier: BackgroundDownloadCompletion.sessionIdentifier
+        )
+        config.isDiscretionary = false          // start now, don't wait for wifi/charging
+        config.sessionSendsLaunchEvents = true  // relaunch us to finish delivering events
         downloadSession = AVAssetDownloadURLSession(
             configuration: config,
             assetDownloadDelegate: self,
             delegateQueue: .main
         )
+
+        // Re-adopt transfers that were still running when the app was last
+        // killed so `getDownloads` reports them and progress keeps flowing.
+        downloadSession.getAllTasks { [weak self] tasks in
+            guard let self = self else { return }
+            for task in tasks {
+                guard let aggTask = task as? AVAggregateAssetDownloadTask,
+                      let id = aggTask.taskDescription else { continue }
+                self.activeTasks[id] = aggTask
+            }
+        }
+
+        // Ask for notification permission up front so the completion banner can
+        // actually appear. Silently degrades to no banner if the user declines.
+        UNUserNotificationCenter.current().requestAuthorization(
+            options: [.alert, .sound]
+        ) { _, _ in }
     }
 
     // MARK: - Plugin Methods
 
     @objc func startDownload(_ call: CAPPluginCall) {
         guard let id = call.getString("id"),
-              let hlsUrlStr = call.getString("hlsUrl") else {
-            call.reject("id and hlsUrl are required")
+              let hlsUrlStr = call.getString("hlsUrl"),
+              let url = URL(string: hlsUrlStr) else {
+            call.reject("id and a valid hlsUrl are required")
             return
         }
 
-        // Add auth token to the URL (AVAssetDownloadTask doesn't support custom headers)
-        var urlStr = hlsUrlStr
+        // Authenticate segment + child-playlist fetches with the same bearer
+        // token Android sends. The download URL already carries `?token=` for
+        // the master request, but relative segment URIs derived from it may
+        // not, so the header is the reliable channel. `AVURLAssetHTTPHeaderFieldsKey`
+        // is applied to the asset's requests by the download task.
+        var assetOptions: [String: Any] = [:]
         if let token = call.getString("token"), !token.isEmpty {
-            let sep = urlStr.contains("?") ? "&" : "?"
-            urlStr += "\(sep)token=\(token)"
+            assetOptions["AVURLAssetHTTPHeaderFieldsKey"] = ["Authorization": "Bearer \(token)"]
         }
 
-        guard let url = URL(string: urlStr) else {
-            call.reject("Invalid URL")
-            return
+        // Capture the (already localized) notification copy for this download.
+        if let title = call.getString("notifTitle"),
+           let complete = call.getString("notifComplete"),
+           let failed = call.getString("notifFailed") {
+            notifById[id] = (title, complete, failed)
         }
 
-        let asset = AVURLAsset(url: url)
-        guard let task = downloadSession.aggregateAssetDownloadTask(
-            with: asset,
-            mediaSelections: [asset.preferredMediaSelection],
-            assetTitle: id,
-            assetArtworkData: nil,
-            options: [AVAssetDownloadTaskMinimumRequiredMediaBitrateKey: 0]
-        ) else {
-            call.reject("Failed to create download task")
-            return
+        let asset = AVURLAsset(url: url, options: assetOptions.isEmpty ? nil : assetOptions)
+
+        // Load the media-selection groups first, then queue the download with
+        // EVERY audio + subtitle rendition (not just the default preferred
+        // selection). Without this only the default audio is fetched and the
+        // .movpkg has no subtitles offline. The renditions land in the same
+        // legible / audible selection groups NativePlayerPlugin reads online,
+        // so offline subtitles/audio work with no extra wiring.
+        // No `AVAssetDownloadTaskMinimumRequiredMediaBitrateKey`: the manifest
+        // is already scoped to the chosen quality (startQuality in the URL), so
+        // AVFoundation takes the highest variant it exposes.
+        let key = "availableMediaCharacteristicsWithMediaSelectionOptions"
+        asset.loadValuesAsynchronously(forKeys: [key]) { [weak self] in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                let selections = self.allMediaSelections(for: asset)
+                guard let task = self.downloadSession.aggregateAssetDownloadTask(
+                    with: asset,
+                    mediaSelections: selections,
+                    assetTitle: id,
+                    assetArtworkData: nil,
+                    options: nil
+                ) else {
+                    NSLog("[Download] failed to create task id=\(id)")
+                    self.notifyListeners("downloadFailed", data: ["id": id, "progress": 0, "state": "failed"])
+                    return
+                }
+                task.taskDescription = id
+                self.activeTasks[id] = task
+                self.progressById[id] = 0
+                task.resume()
+            }
         }
 
-        task.taskDescription = id
-        activeTasks[id] = task
-        task.resume()
-
+        // Surface the queued state immediately so the UI leaves "transcoding".
+        notifyListeners("downloadProgress", data: ["id": id, "progress": 0, "state": "downloading"])
         call.resolve()
+    }
+
+    /// Every audio + subtitle media selection for the asset, each derived from
+    /// the preferred selection with one option chosen in its group, so the
+    /// aggregate download bakes all renditions into the .movpkg for offline use.
+    private func allMediaSelections(for asset: AVURLAsset) -> [AVMediaSelection] {
+        var selections: [AVMediaSelection] = []
+        let base = asset.preferredMediaSelection
+        for characteristic in [AVMediaCharacteristic.audible, .legible] {
+            guard let group = asset.mediaSelectionGroup(forMediaCharacteristic: characteristic) else { continue }
+            for option in group.options {
+                guard let mutable = base.mutableCopy() as? AVMutableMediaSelection else { continue }
+                mutable.select(option, in: group)
+                selections.append(mutable)
+            }
+        }
+        return selections.isEmpty ? [base] : selections
     }
 
     @objc func removeDownload(_ call: CAPPluginCall) {
@@ -86,41 +198,44 @@ class DownloadPlugin: CAPPlugin, CAPBridgedPlugin, AVAssetDownloadDelegate {
             return
         }
 
-        // Cancel active task if running
+        // Cancel the transfer if it is still running.
         activeTasks[id]?.cancel()
         activeTasks.removeValue(forKey: id)
+        progressById.removeValue(forKey: id)
+        notifById.removeValue(forKey: id)
 
-        // Delete downloaded asset
-        if let url = downloadedAssets[id] {
+        // Delete the on-disk bundle (resolved from the stored relative path).
+        if let url = resolvedAssetURL(id: id) {
             try? FileManager.default.removeItem(at: url)
-            downloadedAssets.removeValue(forKey: id)
-            persistAssetLocations()
         }
+        relativePathById.removeValue(forKey: id)
+        persistAssetLocations()
 
+        // Drop any lingering completion banner for this download.
+        let notifId = "download-\(id)"
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [notifId])
+        UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [notifId])
+
+        // Mirror Android's event so the WebView reconciles its list.
+        notifyListeners("downloadRemoved", data: ["id": id, "progress": 0, "state": "removed"])
         call.resolve()
     }
 
     @objc func getDownloads(_ call: CAPPluginCall) {
         var arr: [[String: Any]] = []
 
-        // Active downloads
-        for (id, task) in activeTasks {
+        // In-flight downloads with their last-known progress.
+        for (id, _) in activeTasks {
             arr.append([
                 "id": id,
-                "progress": task.countOfBytesReceived > 0 && task.countOfBytesExpectedToReceive > 0
-                    ? Float(task.countOfBytesReceived) / Float(task.countOfBytesExpectedToReceive) * 100
-                    : 0,
+                "progress": Int(progressById[id] ?? 0),
                 "state": "downloading",
             ])
         }
-
-        // Completed downloads
-        for (id, _) in downloadedAssets where activeTasks[id] == nil {
-            arr.append([
-                "id": id,
-                "progress": 100,
-                "state": "completed",
-            ])
+        // Completed downloads that still exist on disk.
+        for (id, _) in relativePathById where activeTasks[id] == nil {
+            guard resolvedAssetURL(id: id) != nil else { continue }
+            arr.append(["id": id, "progress": 100, "state": "completed"])
         }
 
         if let data = try? JSONSerialization.data(withJSONObject: arr),
@@ -136,26 +251,48 @@ class DownloadPlugin: CAPPlugin, CAPBridgedPlugin, AVAssetDownloadDelegate {
             call.resolve(["downloaded": false])
             return
         }
-        let exists = downloadedAssets[id] != nil
-            && FileManager.default.fileExists(atPath: downloadedAssets[id]!.path)
-        call.resolve(["downloaded": exists])
+        call.resolve(["downloaded": resolvedAssetURL(id: id) != nil])
+    }
+
+    /// Return the local `file://` URL for a completed offline asset so the
+    /// player can load it directly. Resolved fresh from the relative path on
+    /// every call, which is why it survives container-path changes.
+    @objc func getOfflineUrl(_ call: CAPPluginCall) {
+        guard let id = call.getString("id"),
+              let url = resolvedAssetURL(id: id) else {
+            call.resolve(["url": NSNull()])
+            return
+        }
+        call.resolve(["url": url.absoluteString])
+    }
+
+    @objc func pauseDownloads(_ call: CAPPluginCall) {
+        for task in activeTasks.values { task.suspend() }
+        call.resolve()
+    }
+
+    @objc func resumeDownloads(_ call: CAPPluginCall) {
+        for task in activeTasks.values { task.resume() }
+        call.resolve()
     }
 
     // MARK: - AVAssetDownloadDelegate
 
-    /// Called when all media selections for a task have been downloaded
-    func urlSession(
+    /// The bundle's final location, delivered before completion. Store it
+    /// RELATIVE to the home directory (see `relativePathById`).
+    public func urlSession(
         _ session: URLSession,
         aggregateAssetDownloadTask: AVAggregateAssetDownloadTask,
         willDownloadTo location: URL
     ) {
         guard let id = aggregateAssetDownloadTask.taskDescription else { return }
-        downloadedAssets[id] = location
+        relativePathById[id] = location.relativePath
         persistAssetLocations()
     }
 
-    /// Progress callback
-    func urlSession(
+    /// Progress callback — driven by loaded time-ranges, the reliable measure
+    /// for HLS aggregate downloads.
+    public func urlSession(
         _ session: URLSession,
         aggregateAssetDownloadTask: AVAggregateAssetDownloadTask,
         didLoad timeRange: CMTimeRange,
@@ -170,49 +307,87 @@ class DownloadPlugin: CAPPlugin, CAPBridgedPlugin, AVAssetDownloadDelegate {
         }
         let expected = CMTimeGetSeconds(timeRangeExpectedToLoad.duration)
         let progress = expected > 0 ? Float(loadedDuration / expected) * 100 : 0
+        progressById[id] = progress
 
         notifyListeners("downloadProgress", data: [
             "id": id,
-            "progress": progress,
+            "progress": Int(progress),
             "state": "downloading",
         ])
     }
 
-    /// Task completion (success or failure)
-    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+    /// Task completion (success or failure).
+    public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         guard let id = task.taskDescription else { return }
         activeTasks.removeValue(forKey: id)
 
         if let error = error as NSError?, error.code != NSURLErrorCancelled {
-            notifyListeners("downloadFailed", data: [
-                "id": id,
-                "progress": 0,
-                "state": "failed",
-            ])
+            progressById.removeValue(forKey: id)
+            // A failed download leaves no usable bundle — drop its dangling
+            // location so getDownloads / isDownloaded don't report it as ready.
+            relativePathById.removeValue(forKey: id)
+            persistAssetLocations()
+            NSLog("[Download] task \(id) failed: [\(error.domain) \(error.code)] \(error.localizedDescription)")
+            notifyListeners("downloadFailed", data: ["id": id, "progress": 0, "state": "failed"])
+            postNotification(id: id, success: false)
         } else if error == nil {
+            progressById[id] = 100
             notifyListeners("downloadComplete", data: [
                 "id": id,
                 "progress": 100,
                 "state": "completed",
+                "localUrl": resolvedAssetURL(id: id)?.absoluteString ?? "",
             ])
+            postNotification(id: id, success: true)
         }
+        // NSURLErrorCancelled == user-initiated removeDownload; stay silent.
+    }
+
+    /// All queued background events for the session have been delivered — tell
+    /// the OS we're done so it can suspend us again (and doesn't throttle us).
+    public func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+        DispatchQueue.main.async {
+            BackgroundDownloadCompletion.handler?()
+            BackgroundDownloadCompletion.handler = nil
+        }
+    }
+
+    // MARK: - Notifications
+
+    /// Post the (pre-localized) completion or failure banner for a download.
+    private func postNotification(id: String, success: Bool) {
+        guard let copy = notifById[id] else { return }
+        let content = UNMutableNotificationContent()
+        content.title = copy.title
+        content.body = success ? copy.complete : copy.failed
+        content.sound = .default
+        let request = UNNotificationRequest(
+            identifier: "download-\(id)",
+            content: content,
+            trigger: nil // deliver immediately
+        )
+        UNUserNotificationCenter.current().add(request) { _ in }
+        notifById.removeValue(forKey: id)
     }
 
     // MARK: - Persistence
 
-    /// Save .movpkg locations to UserDefaults so they survive app restart
     private func persistAssetLocations() {
-        var dict: [String: String] = [:]
-        for (id, url) in downloadedAssets {
-            dict[id] = url.path
-        }
-        UserDefaults.standard.set(dict, forKey: "fliks_offline_assets")
+        UserDefaults.standard.set(relativePathById, forKey: Self.assetsDefaultsKey)
     }
 
-    /// Get the local file:// URL for an offline asset (used for playback)
+    /// Rebuild the absolute asset URL from the stored relative path and confirm
+    /// the bundle still exists on disk. Returns nil if unknown or deleted.
+    private func resolvedAssetURL(id: String) -> URL? {
+        guard let relativePath = relativePathById[id] else { return nil }
+        let baseURL = URL(fileURLWithPath: NSHomeDirectory())
+        let url = baseURL.appendingPathComponent(relativePath)
+        return FileManager.default.fileExists(atPath: url.path) ? url : nil
+    }
+
+    /// Local `file://` URL for an offline asset (used by NativePlayerPlugin for
+    /// offline playback). Exposed for parity with the Android accessor.
     func getAssetUrl(id: String) -> URL? {
-        guard let url = downloadedAssets[id],
-              FileManager.default.fileExists(atPath: url.path) else { return nil }
-        return url
+        return resolvedAssetURL(id: id)
     }
 }

--- a/client/ios/App/App/FlksViewController.swift
+++ b/client/ios/App/App/FlksViewController.swift
@@ -19,6 +19,7 @@ class FlksViewController: CAPBridgeViewController {
         bridge?.registerPluginInstance(ImmersivePlugin())
         bridge?.registerPluginInstance(PipPlugin())
         bridge?.registerPluginInstance(CastPlugin())
+        bridge?.registerPluginInstance(DownloadPlugin())
     }
 
     func updateStatusBar(hidden: Bool) {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "1.12.3",
+  "version": "1.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "1.12.3",
+      "version": "1.14.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@angular/cdk": "^21.2.4",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1118,7 +1118,9 @@
     "failed": "Échec",
     "offline": "Hors ligne",
     "confirm_delete": "Supprimer ce téléchargement ? Le fichier sera supprimé de cet appareil.",
-    "retry": "Réessayer"
+    "retry": "Réessayer",
+    "notif_complete": "Téléchargement terminé",
+    "notif_failed": "Échec du téléchargement"
   },
   "setup_checklist": {
     "title": "Configuration",

--- a/client/src/app/core/services/download-cache.service.ts
+++ b/client/src/app/core/services/download-cache.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, signal } from '@angular/core';
+import { Injectable, signal, untracked } from '@angular/core';
 
 /** Client-side download task tracked in localStorage. */
 export interface DownloadTask {
@@ -49,7 +49,9 @@ export class DownloadCacheService {
   }
 
   private persistLocalIds() {
-    localStorage.setItem(LOCAL_IDS_KEY, JSON.stringify([...this.localTaskIds()]));
+    // untracked: markLocal/removeLocal run inside effects that also write
+    // localTaskIds — a tracked read here would create a mutual-invalidation loop.
+    localStorage.setItem(LOCAL_IDS_KEY, JSON.stringify([...untracked(() => this.localTaskIds())]));
   }
 
   markLocal(taskId: number) {

--- a/client/src/app/core/services/download-manager.service.ts
+++ b/client/src/app/core/services/download-manager.service.ts
@@ -9,6 +9,8 @@ import { DownloadCacheService, DownloadTask } from './download-cache.service';
 import { DownloadNotificationService } from './download-notification.service';
 import { AuthService } from './auth.service';
 import { BrowserDeviceProfileService } from './browser-device-profile.service';
+import { TranslateService } from '@ngx-translate/core';
+import { formatSubtitleLabel } from '../utils/player.utils';
 
 export interface DownloadEvent {
   type: 'progress' | 'ready' | 'failed' | 'complete';
@@ -41,6 +43,7 @@ export class DownloadManagerService {
   private readonly notif = inject(DownloadNotificationService);
   private readonly auth = inject(AuthService);
   private readonly deviceProfile = inject(BrowserDeviceProfileService);
+  private readonly translate = inject(TranslateService);
 
   private readonly titles = new Map<number, { title: string; episode?: string }>();
   private activeCount = 0;
@@ -150,7 +153,15 @@ export class DownloadManagerService {
     if (this.isNative) {
       const token =
         this.auth.streamToken() ?? this.auth.accessToken ?? '';
-      this.notif.startDownload(String(taskId), hlsUrl, token);
+      // Pre-translated banner copy for the iOS completion/failure notification
+      // (ngx-translate is the single source of user-facing strings; the native
+      // side never hardcodes text). Ignored on Android.
+      const notifTitle = episode ? `${title} · ${episode}` : title;
+      this.notif.startDownload(String(taskId), hlsUrl, token, {
+        notifTitle,
+        notifComplete: this.translate.instant('downloads.notif_complete'),
+        notifFailed: this.translate.instant('downloads.notif_failed'),
+      });
     } else {
       void this.handleWebDownload(task, hlsUrl);
     }
@@ -240,11 +251,16 @@ export class DownloadManagerService {
             : null;
         if (!url) continue;
         const key = `sub-${task.mediaFileId}-${sub.id}`;
-        await this.storage.downloadSmallFile(url, key);
+        // Only record the subtitle if its VTT was actually written — a dangling
+        // entry makes offline playback attach a subtitle track that renders nothing.
+        const stored = await this.storage.downloadSmallFile(url, key);
+        if (!stored) continue;
         offlineSubs.push({
           key,
           language: sub.language,
-          label: `${sub.language}${sub.hearingImpaired ? ' (HI)' : ''}${sub.forced ? ' (Forced)' : ''}${sub.streamIndex != null ? ' [embedded]' : ''}`,
+          // Same normalized label as online playback (localized language name +
+          // HI/Forced/codec) instead of the raw language code.
+          label: formatSubtitleLabel(sub, this.translate),
           forced: sub.forced,
         });
       }

--- a/client/src/app/core/services/download-notification.service.ts
+++ b/client/src/app/core/services/download-notification.service.ts
@@ -9,11 +9,22 @@ export interface NativeDownloadEvent {
   seq: number;
 }
 
+/** Pre-translated notification copy shown by the native download daemon (iOS). */
+export interface DownloadNotifStrings {
+  notifTitle: string;
+  notifComplete: string;
+  notifFailed: string;
+}
+
 interface DownloadNotificationPlugin {
-  startDownload(opts: { id: string; hlsUrl: string; token: string }): Promise<void>;
+  startDownload(
+    opts: { id: string; hlsUrl: string; token: string } & Partial<DownloadNotifStrings>,
+  ): Promise<void>;
   removeDownload(opts: { id: string }): Promise<void>;
   getDownloads(): Promise<{ downloads: string }>;
   isDownloaded(opts: { id: string }): Promise<{ downloaded: boolean }>;
+  /** iOS: local `file://` URL of the downloaded .movpkg, or null. Unused on Android. */
+  getOfflineUrl(opts: { id: string }): Promise<{ url: string | null }>;
   pauseDownloads(): Promise<void>;
   resumeDownloads(): Promise<void>;
   addListener(event: string, cb: (data: any) => void): Promise<any>;
@@ -53,10 +64,30 @@ export class DownloadNotificationService {
     }
   }
 
-  /** Start an HLS download via the native platform's download manager. */
-  startDownload(id: string, hlsUrl: string, token: string): void {
+  /**
+   * Start an HLS download via the native platform's download manager.
+   * `notif` carries pre-translated banner copy for iOS completion/failure
+   * notifications (ignored on Android, which builds its own foreground-service
+   * notification).
+   */
+  startDownload(id: string, hlsUrl: string, token: string, notif?: DownloadNotifStrings): void {
     if (!this.isNative || !DownloadNotification) return;
-    DownloadNotification.startDownload({ id, hlsUrl, token }).catch(() => {});
+    DownloadNotification.startDownload({ id, hlsUrl, token, ...(notif ?? {}) }).catch(() => {});
+  }
+
+  /**
+   * iOS: resolve the local `file://` URL of a completed download for offline
+   * playback. Returns null on Android (offline playback there replays the
+   * remote HLS URL through ExoPlayer's CacheDataSource) or when not found.
+   */
+  async getOfflineUrl(id: string): Promise<string | null> {
+    if (!DownloadNotification || !DownloadNotification.getOfflineUrl) return null;
+    try {
+      const result = await DownloadNotification.getOfflineUrl({ id });
+      return result.url ?? null;
+    } catch {
+      return null;
+    }
   }
 
   /** Remove a download (cancel + delete cached data). */

--- a/client/src/app/core/services/offline-storage.service.ts
+++ b/client/src/app/core/services/offline-storage.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { Capacitor } from '@capacitor/core';
 import { AuthService } from './auth.service';
+import { DownloadNotificationService } from './download-notification.service';
 
 const CACHE_NAME = 'offline-media';
 
@@ -28,13 +29,12 @@ async function getShaka() {
 @Injectable({ providedIn: 'root' })
 export class OfflineStorageService {
   private readonly isNative = Capacitor.isNativePlatform();
+  private readonly platform = Capacitor.getPlatform();
   private readonly auth = inject(AuthService);
+  private readonly notif = inject(DownloadNotificationService);
 
   async getLocalUrl(key: string): Promise<string | null> {
     if (this.isNative) {
-      // ExoPlayer stores content in SimpleCache, not filesystem.
-      // Return the stored HLS URL — native player uses CacheDataSource to
-      // read from cache. The URL is stored in the DownloadTask.
       return this.getNativeOfflineUrl(key);
     }
     // Web: check Shaka offline URI (stored in localStorage)
@@ -43,14 +43,28 @@ export class OfflineStorageService {
     return offlineUri ?? null;
   }
 
-  /** Look up the stored HLS URL for a native download from localStorage. */
-  private getNativeOfflineUrl(key: string): string | null {
+  /**
+   * Resolve the playable offline source for a native download.
+   *
+   * The two native platforms store offline HLS very differently:
+   *   - iOS (AVAssetDownloadTask) writes a local `.movpkg` bundle; the player
+   *     loads that file directly. Its path is resolved fresh from the native
+   *     plugin so it survives sandbox container-path changes across app updates.
+   *   - Android (ExoPlayer) keeps segments in SimpleCache and replays the
+   *     original remote HLS URL through a CacheDataSource, so we hand back the
+   *     `hlsUrl` stored on the DownloadTask.
+   */
+  private async getNativeOfflineUrl(key: string): Promise<string | null> {
     try {
       const mfid = Number(key.replace('download-', ''));
       const raw = localStorage.getItem('fliks.downloads.cache');
       const tasks: any[] = raw ? JSON.parse(raw) : [];
       const task = tasks.find((t: any) => t.mediaFileId === mfid && t.status === 'ready');
-      return task?.hlsUrl ?? null;
+      if (!task) return null;
+      if (this.platform === 'ios') {
+        return await this.notif.getOfflineUrl(String(task.id));
+      }
+      return task.hlsUrl ?? null;
     } catch {
       return null;
     }
@@ -186,26 +200,41 @@ export class OfflineStorageService {
     await this.shakaRemove(mfid);
   }
 
-  /** Download a small text file (VTT subtitle) and store locally. */
-  async downloadSmallFile(url: string, key: string): Promise<void> {
-    const response = await fetch(url, {
-      headers: { Authorization: `Bearer ${this.auth.accessToken}` },
-    });
-    if (!response.ok) return;
-    const text = await response.text();
-
-    if (this.isNative) {
-      const { Filesystem, Directory } = await getFs();
-      await this.ensureDir();
-      await Filesystem.writeFile({
-        path: `fliks-downloads/${key}`,
-        data: text,
-        directory: Directory.Data,
-        encoding: 'utf8' as any,
+  /**
+   * Download a small text file (VTT subtitle) and store locally.
+   * Returns true only when the file was actually fetched and written — callers
+   * must not record a subtitle entry for a file that failed, otherwise offline
+   * playback points the native player at a non-existent file and renders nothing.
+   */
+  async downloadSmallFile(url: string, key: string): Promise<boolean> {
+    try {
+      // Downloads can finish hours after the 1h access token was minted, so
+      // authenticate with the long-lived stream token (same token baked into
+      // the subtitle URL's ?token=), falling back to the access token.
+      const token = this.auth.streamToken() ?? this.auth.accessToken ?? '';
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
       });
-    } else {
-      const cache = await caches.open(CACHE_NAME);
-      await cache.put(key, new Response(text, { headers: { 'Content-Type': 'text/vtt' } }));
+      if (!response.ok) return false;
+      const text = await response.text();
+      if (!text) return false;
+
+      if (this.isNative) {
+        const { Filesystem, Directory } = await getFs();
+        await this.ensureDir();
+        await Filesystem.writeFile({
+          path: `fliks-downloads/${key}`,
+          data: text,
+          directory: Directory.Data,
+          encoding: 'utf8' as any,
+        });
+      } else {
+        const cache = await caches.open(CACHE_NAME);
+        await cache.put(key, new Response(text, { headers: { 'Content-Type': 'text/vtt' } }));
+      }
+      return true;
+    } catch {
+      return false;
     }
   }
 
@@ -242,6 +271,10 @@ export class OfflineStorageService {
     if (!this.isNative) return this.getSmallFileUrl(key);
     try {
       const { Filesystem, Directory } = await getFs();
+      // Confirm the file exists — getUri only builds a path, it never checks.
+      // Returning a URI for a missing file makes the native player attach a
+      // dead subtitle track that renders nothing.
+      await Filesystem.stat({ path: `fliks-downloads/${key}`, directory: Directory.Data });
       const result = await Filesystem.getUri({
         path: `fliks-downloads/${key}`,
         directory: Directory.Data,
@@ -254,8 +287,8 @@ export class OfflineStorageService {
 
   async has(key: string): Promise<boolean> {
     if (this.isNative) {
-      // ExoPlayer stores in SimpleCache, not filesystem — check localStorage.
-      return this.getNativeOfflineUrl(key) !== null;
+      // Native offline content — resolve via the platform-specific path.
+      return (await this.getNativeOfflineUrl(key)) !== null;
     }
     // Web: check Shaka offline URI
     const mfid = key.replace('download-', '');

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -771,6 +771,13 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
         return;
       }
       this.media.set(m);
+      // Paint from the cache-served media immediately; the uncacheable
+      // playback-state calls below must not gate first paint.
+      this.loading.set(false);
+      this.draftQualityProfileId.set(m.qualityProfile?.id ?? null);
+      this.draftLanguageProfileId.set(m.languageProfile?.id ?? null);
+      this.selectedLibraryId.set(m.libraryId ?? null);
+      this.selectedProvider.set(m.preferredProvider ?? null);
       queueMicrotask(() => {
         void this.mediaService
           .getOne(id, { force: true })
@@ -800,88 +807,87 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       ) {
         void this.downloadProgress.seed();
       }
-      // Load resume + watched episodes + per-episode progress for series
-      const [resumeInfo, watchedIds, progress] = await Promise.all([
-        this.streamingApi.getMediaResumeInfo(m.id).catch(() => null),
-        m.type === 'series'
-          ? this.streamingApi.getWatchedEpisodeIds(m.id).catch(() => [] as number[])
-          : Promise.resolve([] as number[]),
-        m.type === 'series'
-          ? this.streamingApi
-              .getEpisodeProgress(m.id)
-              .catch(() => ({}) as Record<number, number>)
-          : Promise.resolve({} as Record<number, number>),
-      ]);
-      this.resumeInfo.set(resumeInfo);
-      const watchedSet = new Set(watchedIds);
-      this.watchedEpisodeIds.set(watchedSet);
-      this.episodeProgress.set(progress);
+      // Resume/watched/progress hit uncacheable /api/playback/media/* — load
+      // them off the render path so a slow server never holds the spinner.
+      void (async () => {
+        const [resumeInfo, watchedIds, progress] = await Promise.all([
+          this.streamingApi.getMediaResumeInfo(m.id).catch(() => null),
+          m.type === 'series'
+            ? this.streamingApi.getWatchedEpisodeIds(m.id).catch(() => [] as number[])
+            : Promise.resolve([] as number[]),
+          m.type === 'series'
+            ? this.streamingApi
+                .getEpisodeProgress(m.id)
+                .catch(() => ({}) as Record<number, number>)
+            : Promise.resolve({} as Record<number, number>),
+        ]);
+        this.resumeInfo.set(resumeInfo);
+        const watchedSet = new Set(watchedIds);
+        this.watchedEpisodeIds.set(watchedSet);
+        this.episodeProgress.set(progress);
 
-      // Pre-select the last-played file if available
-      if (resumeInfo?.mediaFileId) {
-        const files = m.files ?? [];
-        if (files.some((f) => f.id === resumeInfo.mediaFileId)) {
-          this.selectedFileId.set(resumeInfo.mediaFileId);
-        }
-      }
-
-      // Series: preselect the season the user is currently watching.
-      //   1. Latest in-progress episode (resumeInfo).
-      //   2. Season of the first unwatched-with-file episode — handles the
-      //      between-episodes case (last ep completed, next not started yet)
-      //      where resumeInfo is null.
-      let resumeHandled = false;
-      if (m.type === 'series' && m.seasons?.length) {
-        let targetSeasonId: number | null = null;
-        if (resumeInfo?.episodeId) {
-          targetSeasonId =
-            m.seasons.find((s) =>
-              s.episodes?.some((e) => e.id === resumeInfo.episodeId),
-            )?.id ?? null;
-        }
-        if (targetSeasonId == null) {
-          targetSeasonId =
-            m.seasons.find((s) =>
-              s.episodes?.some(
-                (e) => e.hasFile && !watchedSet.has(e.id),
-              ),
-            )?.id ?? null;
-        }
-        if (targetSeasonId != null) {
-          this.activeSeasonId.set(targetSeasonId);
-          this.persistActiveSeason(targetSeasonId);
-          resumeHandled = true;
-        }
-      }
-
-      if (m.type === 'series' && m.seasons?.length) {
-        if (!resumeHandled) this.syncActiveSeasonForSeriesFilter();
-        // Scroll to first unwatched episode in active season
-        const seasonId = this.activeSeasonId();
-        const activeSeason = m.seasons.find((s) => s.id === seasonId);
-        if (activeSeason?.episodes?.length) {
-          const firstUnwatched = activeSeason.episodes.find((e) => e.hasFile && !watchedSet.has(e.id));
-          if (firstUnwatched) {
-            requestAnimationFrame(() => {
-              const el = document.getElementById(`episode-${firstUnwatched.id}`);
-              if (!el) return;
-              const scroller = el.parentElement;
-              if (scroller && scroller.scrollWidth > scroller.clientWidth) {
-                const elRect = el.getBoundingClientRect();
-                const scrollerRect = scroller.getBoundingClientRect();
-                const offset = elRect.left - scrollerRect.left + scroller.scrollLeft - scroller.clientWidth / 2 + el.offsetWidth / 2;
-                scroller.scrollTo({ left: offset, behavior: 'smooth' });
-              }
-            });
+        // Pre-select the last-played file if available
+        if (resumeInfo?.mediaFileId) {
+          const files = m.files ?? [];
+          if (files.some((f) => f.id === resumeInfo.mediaFileId)) {
+            this.selectedFileId.set(resumeInfo.mediaFileId);
           }
         }
-      } else {
-        this.activeSeasonId.set(null);
-      }
-      this.draftQualityProfileId.set(m.qualityProfile?.id ?? null);
-      this.draftLanguageProfileId.set(m.languageProfile?.id ?? null);
-      this.selectedLibraryId.set(m.libraryId ?? null);
-      this.selectedProvider.set(m.preferredProvider ?? null);
+
+        // Series: preselect the season the user is currently watching.
+        //   1. Latest in-progress episode (resumeInfo).
+        //   2. Season of the first unwatched-with-file episode — handles the
+        //      between-episodes case (last ep completed, next not started yet)
+        //      where resumeInfo is null.
+        let resumeHandled = false;
+        if (m.type === 'series' && m.seasons?.length) {
+          let targetSeasonId: number | null = null;
+          if (resumeInfo?.episodeId) {
+            targetSeasonId =
+              m.seasons.find((s) =>
+                s.episodes?.some((e) => e.id === resumeInfo.episodeId),
+              )?.id ?? null;
+          }
+          if (targetSeasonId == null) {
+            targetSeasonId =
+              m.seasons.find((s) =>
+                s.episodes?.some(
+                  (e) => e.hasFile && !watchedSet.has(e.id),
+                ),
+              )?.id ?? null;
+          }
+          if (targetSeasonId != null) {
+            this.activeSeasonId.set(targetSeasonId);
+            this.persistActiveSeason(targetSeasonId);
+            resumeHandled = true;
+          }
+        }
+
+        if (m.type === 'series' && m.seasons?.length) {
+          if (!resumeHandled) this.syncActiveSeasonForSeriesFilter();
+          // Scroll to first unwatched episode in active season
+          const seasonId = this.activeSeasonId();
+          const activeSeason = m.seasons.find((s) => s.id === seasonId);
+          if (activeSeason?.episodes?.length) {
+            const firstUnwatched = activeSeason.episodes.find((e) => e.hasFile && !watchedSet.has(e.id));
+            if (firstUnwatched) {
+              requestAnimationFrame(() => {
+                const el = document.getElementById(`episode-${firstUnwatched.id}`);
+                if (!el) return;
+                const scroller = el.parentElement;
+                if (scroller && scroller.scrollWidth > scroller.clientWidth) {
+                  const elRect = el.getBoundingClientRect();
+                  const scrollerRect = scroller.getBoundingClientRect();
+                  const offset = elRect.left - scrollerRect.left + scroller.scrollLeft - scroller.clientWidth / 2 + el.offsetWidth / 2;
+                  scroller.scrollTo({ left: offset, behavior: 'smooth' });
+                }
+              });
+            }
+          }
+        } else {
+          this.activeSeasonId.set(null);
+        }
+      })();
     } catch {
       this.notFound.set(true);
     } finally {

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -2663,7 +2663,16 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     if (!this.mediaId) {
       target = '/';
     } else {
-      const kind = this.media?.type === 'series' ? 'series' : 'movies';
+      // Offline playback never loads `this.media`; fall back to the type stored
+      // on the download task so a downloaded series routes to /series, not
+      // /movies (a wrong-kind URL redirects and breaks the topbar back button).
+      const offlineType = this.isOfflinePlayback
+        ? this.dlCache
+            .load()
+            .find((t) => t.mediaFileId === this.mediaFileId && t.status === 'ready')
+            ?.media?.type
+        : undefined;
+      const kind = (this.media?.type ?? offlineType) === 'series' ? 'series' : 'movies';
       if (this.episodeId && kind === 'series') {
         // A finished episode returns to the NEXT episode's detail page so the
         // user lands ready to continue; an episode left mid-watch returns to


### PR DESCRIPTION
## Why

The iOS `DownloadPlugin` existed on disk but was **never registered** with the Capacitor bridge (missing from `FlksViewController.capacitorDidLoad()` and from the Xcode target), so offline downloads never worked on iOS. This wires it up and completes the `AVAssetDownloadURLSession` implementation to match Android, then fixes the issues surfaced while validating the full download → offline-playback → back flow on a device.

## iOS download implementation

- Register `DownloadPlugin` in `FlksViewController` and add it to the Xcode target (`project.pbxproj`).
- Background `AVAssetDownloadURLSession` recreated with the same identifier on launch + in-flight task re-adoption via `getAllTasks` (survives suspend/lock/terminate — the iOS-idiomatic equivalent of Android's foreground service).
- Persist the `.movpkg` location **relative** to the home directory — the sandbox container path changes across launches/updates, so an absolute path dangles (Apple's documented gotcha).
- Download **every** audio + subtitle media selection so offline playback exposes them through the same `legible`/`audible` groups as online playback (no sidecar needed on iOS).
- `Authorization: Bearer` header for segment/child-playlist fetches.
- Completion/failure local notifications + background `URLSession` completion handler in `AppDelegate`.
- `getOfflineUrl` resolves the local asset URL for the player.

## Fixes found end-to-end

- **Downloads page froze** after a download completed (until app restart, both platforms): `markLocal`/`persistLocalIds` did a *tracked* read of `localTaskIds` inside effects that also write it (a fresh `Set` each time) → mutual-invalidation storm. Read it `untracked`.
- **media-detail slow** returning from offline playback: it gated first paint on uncacheable `/api/playback/media/*` calls. Paint from the cache-served media object; load resume/watched/progress off the render path.
- **Topbar back button dead** after offline playback of a series episode: `onBack` defaulted to `kind=movies` (`this.media` is null offline), routing to `/movies/:id` which redirects and leaves a dead history entry. Derive the type from the download task.
- Normalize offline subtitle labels via `formatSubtitleLabel` (was showing raw language codes).
- Only record offline subtitles whose VTT actually downloaded, authenticated with the long-lived stream token.

## Testing

Built + run on a physical iPhone (background HLS download doesn't work on the simulator): download a movie and a series episode → progress + completion notification → appears in Downloads → play in airplane mode with subtitles/audio tracks → delete → back navigation. The `untracked` fix also benefits Android (shared code).
