### PR TITLE
fix(update): hide topbar update check on native apps

### DIFF
--- a/client/src/app/core/services/app-update.service.ts
+++ b/client/src/app/core/services/app-update.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, computed, effect, inject, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { Capacitor } from '@capacitor/core';
 import { firstValueFrom } from 'rxjs';
 import { DeviceService } from './device.service';
 import { AuthService } from './auth.service';
@@ -49,6 +50,9 @@ export class AppUpdateService {
 
   readonly mode = computed<UpdateMode>(() => {
     if (this.device.isDesktopNative() && this.desktop) return 'desktop';
+    // Native apps (iOS/Android/TV) update through their store — no in-app
+    // update path, so the topbar update check doesn't apply there.
+    if (Capacitor.isNativePlatform()) return 'none';
     if (this.auth.canAccessSettings()) return 'server';
     return 'none';
   });


### PR DESCRIPTION
Native apps (iOS/Android/TV) update through the App Store / Play Store, so the topbar server-version update check doesn't apply there — it only showed a misleading "update available" button to admins on the mobile app. Gate `AppUpdateService.mode` to `none` on Capacitor native platforms. Web (admin server-version check) and desktop (Electron self-update) are unchanged.