### PR TITLE
fix(scheduler): skip cooldown indexers in auto-grab search fan-outs

### DIFF
--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -413,20 +413,38 @@ export class SchedulerService implements OnModuleInit {
     );
   }
 
+  /**
+   * Drop indexers in failure / Retry-After cooldown before an auto-grab
+   * fan-out, mirroring the interactive search paths. A cooled-down indexer
+   * left in the list makes the throttle sleep its queued call out for the
+   * full backoff (up to 6h); since the fan-out awaits every indexer, one
+   * broken host stalls the whole `Promise.allSettled` and the grab step
+   * never runs. Returns [] when every indexer is cooling.
+   */
+  private readyIndexersOrNone(indexers: Indexer[], context: string): Indexer[] {
+    const ready = this.torznab.filterReadyIndexers(indexers);
+    if (!ready.length) {
+      this.log.warn(
+        `${context}: every indexer is in cooldown — skipping this run`,
+      );
+    }
+    return ready;
+  }
+
   private async doSearchMissing(mediaIds?: number[]): Promise<void> {
     if (mediaIds?.length) {
       this.log.log(
         `SearchMissing: targeted restart for media IDs [${mediaIds.join(', ')}]`,
       );
     }
-    const indexers = await this.indexerRepo.find({
+    const enabledIndexers = await this.indexerRepo.find({
       where: { enabled: true },
       order: { priority: 'ASC' },
     });
     const clients = await this.clientRepo.find({ where: { enabled: true } });
     const qbitClient = clients.find((c) => this.qbittorrent.supports(c));
 
-    if (!indexers.length) {
+    if (!enabledIndexers.length) {
       throw new Error('No enabled indexers configured');
     }
     if (!qbitClient) {
@@ -439,6 +457,9 @@ export class SchedulerService implements OnModuleInit {
     if (!connCheck.ok) {
       throw new Error(`Download client unreachable — ${connCheck.message}`);
     }
+
+    const indexers = this.readyIndexersOrNone(enabledIndexers, 'SearchMissing');
+    if (!indexers.length) return;
 
     await this.searchMissingMovies(indexers, qbitClient, mediaIds);
     await this.searchMissingEpisodes(indexers, qbitClient, mediaIds);
@@ -977,11 +998,14 @@ export class SchedulerService implements OnModuleInit {
   }
 
   private async doRssSync(): Promise<void> {
-    const indexers = await this.indexerRepo.find({
+    const enabledIndexers = await this.indexerRepo.find({
       where: { enabled: true, enableRss: true },
       order: { priority: 'ASC' },
     });
 
+    if (!enabledIndexers.length) return;
+
+    const indexers = this.readyIndexersOrNone(enabledIndexers, 'RssSync');
     if (!indexers.length) return;
 
     // Full candidates (with profiles + files) so RSS reuses the exact same


### PR DESCRIPTION
## Problem

Approving a request (or any SearchMissing / RssSync tick) could produce **no download at all** — no grab, no `AutoGrabPipelineService` log line, nothing added to qBittorrent — while the interactive download modal still listed plenty of clean, grabbable releases for the same title.

## Root cause

The auto-grab search fan-outs in `SchedulerService` queried **every enabled indexer**, including ones currently serving a failure / `Retry-After` **cooldown**:

- `doSearchMissing` → `searchMissingMovies` / `searchMissingEpisodes` (movie, episode and season-pack fan-outs)
- `doRssSync`

`IndexerThrottle.runOne` sleeps a cooled-down indexer's queued call out for the **full backoff (up to 6h)** (`nextAllowedAt`). Because each fan-out does `Promise.allSettled(indexers.map(...))`, a single broken host (e.g. an indexer deep in backoff — observed with ~4.4h remaining) **stalls the entire search**, so `tryAutoGrab` is never reached.

The interactive search paths (`MovieDownloadService`, `EpisodeDownloadService`) never hit this because they already call `torznab.filterReadyIndexers(...)` before fanning out — which is why the modal returned candidates instantly while the auto-grab silently hung.

## Fix

Filter to ready indexers before both auto-grab fan-outs, via a shared `readyIndexersOrNone` helper that mirrors the manual search paths, and skip the run when every indexer is cooling. A broken indexer can no longer stall auto-grab.

## Verification

- `tsc --noEmit` clean
- `jest src/modules/scheduler` — 25/25 passing