### PR TITLE
fix(update): add desktop-only update settings page and updater file log

### DIFF
--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -165,8 +165,18 @@
       "cast": "Chromecast",
       "display": "Affichage",
       "storage": "Stockage",
-      "home": "Accueil"
+      "home": "Accueil",
+      "update": "Mise à jour"
     }
+  },
+  "update_settings": {
+    "title": "Mise à jour",
+    "current_version": "Version actuelle",
+    "unknown_version": "Inconnue",
+    "check": "Vérifier les mises à jour",
+    "up_to_date": "Votre application est à jour.",
+    "check_failed": "Échec de la vérification des mises à jour.",
+    "store_managed": "Les mises à jour de cette application sont gérées par votre store."
   },
   "display_settings": {
     "title": "Affichage",

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import { adminGuard } from './core/guards/admin.guard';
 import { serverConfigGuard } from './core/guards/server-config.guard';
 import { passwordChangeGuard } from './core/guards/password-change.guard';
 import { noTvGuard } from './core/guards/no-tv.guard';
+import { desktopGuard } from './core/guards/desktop.guard';
 
 export const routes: Routes = [
   {
@@ -286,6 +287,14 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./features/app-settings/display-settings/display-settings').then(
             (m) => m.DisplaySettingsPageComponent,
+          ),
+      },
+      {
+        path: 'update',
+        canActivate: [desktopGuard],
+        loadComponent: () =>
+          import('./features/app-settings/update-settings/update-settings').then(
+            (m) => m.UpdateSettingsPageComponent,
           ),
       },
     ],

--- a/client/src/app/core/guards/desktop.guard.ts
+++ b/client/src/app/core/guards/desktop.guard.ts
@@ -1,0 +1,15 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { DeviceService } from '../services/device.service';
+
+/**
+ * Restricts a route to the native desktop client (Electron). The in-app
+ * self-update flow only exists there — web updates through the server, mobile
+ * and TV through their store — so non-desktop hits redirect to the settings home.
+ */
+export const desktopGuard: CanActivateFn = () => {
+  const device = inject(DeviceService);
+  const router = inject(Router);
+  if (device.isDesktopNative()) return true;
+  return router.createUrlTree(['/app-settings/home']);
+};

--- a/client/src/app/features/app-settings/app-settings-shell.html
+++ b/client/src/app/features/app-settings/app-settings-shell.html
@@ -14,5 +14,8 @@
     @if (!tv.isTv()) {
       <li><a routerLink="/app-settings/storage" routerLinkActive="active"><svg lucideHardDrive class="h-4 w-4"></svg>{{ 'app_settings.nav.storage' | translate }}</a></li>
     }
+    @if (device.isDesktopNative()) {
+      <li><a routerLink="/app-settings/update" routerLinkActive="active"><svg lucideDownload class="h-4 w-4"></svg>{{ 'app_settings.nav.update' | translate }}</a></li>
+    }
   </ng-container>
 </app-settings-drawer>

--- a/client/src/app/features/app-settings/app-settings-shell.ts
+++ b/client/src/app/features/app-settings/app-settings-shell.ts
@@ -2,19 +2,21 @@ import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { SettingsDrawerComponent } from '../../shared/components/settings-drawer/settings-drawer';
-import { LucideSettings, LucidePlay, LucideCaptions, LucideCast, LucideHardDrive, LucideMonitor, LucideHouse } from '@lucide/angular';
+import { LucideSettings, LucidePlay, LucideCaptions, LucideCast, LucideHardDrive, LucideMonitor, LucideHouse, LucideDownload } from '@lucide/angular';
 import { TvService } from '../../core/services/tv.service';
+import { DeviceService } from '../../core/services/device.service';
 
 @Component({
   selector: 'app-app-settings-shell',
   imports: [
     RouterLink, RouterLinkActive, TranslateModule,
     SettingsDrawerComponent,
-    LucideSettings, LucidePlay, LucideCaptions, LucideCast, LucideHardDrive, LucideMonitor, LucideHouse,
+    LucideSettings, LucidePlay, LucideCaptions, LucideCast, LucideHardDrive, LucideMonitor, LucideHouse, LucideDownload,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './app-settings-shell.html',
 })
 export class AppSettingsShellComponent {
   readonly tv = inject(TvService);
+  readonly device = inject(DeviceService);
 }

--- a/client/src/app/features/app-settings/update-settings/update-settings.html
+++ b/client/src/app/features/app-settings/update-settings/update-settings.html
@@ -1,0 +1,98 @@
+<h1 class="text-2xl font-bold mb-4">{{ 'update_settings.title' | translate }}</h1>
+<div class="card bg-base-100 border border-base-200">
+  <div class="card-body gap-5">
+    <div class="flex items-center justify-between gap-4 flex-wrap">
+      <div>
+        <p class="text-sm opacity-70">{{ 'update_settings.current_version' | translate }}</p>
+        <p class="text-lg font-semibold">
+          {{ update.currentVersion() || ('update_settings.unknown_version' | translate) }}
+        </p>
+      </div>
+
+      @if (canCheck()) {
+        <button class="btn btn-sm" [disabled]="checking() || downloading()" (click)="check()">
+          @if (checking()) {
+            <span class="loading loading-spinner loading-xs"></span>
+          }
+          {{ 'update_settings.check' | translate }}
+        </button>
+      }
+    </div>
+
+    @if (!canCheck()) {
+      <div class="alert bg-base-200">
+        <span class="text-sm">{{ 'update_settings.store_managed' | translate }}</span>
+      </div>
+    } @else if (upToDate()) {
+      <div class="flex items-center gap-2 text-success">
+        <svg lucideCircleCheck class="h-5 w-5"></svg>
+        <span>{{ 'update_settings.up_to_date' | translate }}</span>
+      </div>
+    } @else if (hasError()) {
+      <div class="flex items-start gap-2 text-error">
+        <svg lucideCircleAlert class="h-5 w-5 shrink-0"></svg>
+        <div>
+          <p>{{ 'update_settings.check_failed' | translate }}</p>
+          @if (update.errorMessage(); as err) {
+            <p class="text-xs opacity-70 mt-0.5 break-words">{{ err }}</p>
+          }
+        </div>
+      </div>
+    }
+
+    @if (update.info(); as info) {
+      @if (!upToDate()) {
+        <div class="rounded-box bg-base-200 p-4">
+          <div class="flex items-center gap-2 mb-1">
+            <svg lucideRocket class="h-5 w-5 text-primary"></svg>
+            <h2 class="font-bold">{{ 'update.title' | translate }}</h2>
+          </div>
+          <p class="text-sm opacity-70 mb-3">
+            @if (update.currentVersion(); as current) {
+              {{ 'update.version_transition' | translate: { current: current, next: info.version } }}
+            } @else {
+              {{ 'update.version_available' | translate: { version: info.version } }}
+            }
+            @if (info.releaseDate) {
+              · {{ info.releaseDate | date: 'mediumDate' }}
+            }
+          </p>
+
+          <div class="rounded-box bg-base-100 p-3 max-h-72 overflow-y-auto mb-4">
+            @if (info.releaseNotes) {
+              <div class="changelog-md text-sm break-words" [innerHTML]="info.releaseNotes | markdown"></div>
+            } @else {
+              <p class="text-sm opacity-60">{{ 'update.no_notes' | translate }}</p>
+            }
+          </div>
+
+          @if (downloading()) {
+            <progress class="progress progress-primary w-full" [value]="update.progress()" max="100"></progress>
+            <p class="text-xs opacity-70 mt-1 text-center">
+              {{ 'update.downloading' | translate: { percent: update.progress() } }}
+            </p>
+          } @else {
+            <div class="flex justify-end">
+              @if (installing()) {
+                <button class="btn btn-primary" disabled>
+                  <span class="loading loading-spinner loading-sm"></span>
+                  {{ 'update.installing' | translate }}
+                </button>
+              } @else if (canInstallInApp()) {
+                <button class="btn btn-primary" (click)="action()">
+                  <svg lucideDownload class="h-4 w-4"></svg>
+                  {{ 'update.install' | translate }}
+                </button>
+              } @else {
+                <button class="btn btn-primary" (click)="action()">
+                  <svg lucideExternalLink class="h-4 w-4"></svg>
+                  {{ 'update.open_release' | translate }}
+                </button>
+              }
+            </div>
+          }
+        </div>
+      }
+    }
+  </div>
+</div>

--- a/client/src/app/features/app-settings/update-settings/update-settings.ts
+++ b/client/src/app/features/app-settings/update-settings/update-settings.ts
@@ -1,0 +1,85 @@
+import { ChangeDetectionStrategy, Component, OnInit, computed, inject } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
+import {
+  LucideCircleAlert,
+  LucideCircleCheck,
+  LucideDownload,
+  LucideExternalLink,
+  LucideRocket,
+} from '@lucide/angular';
+import { AppUpdateService } from '../../../core/services/app-update.service';
+import { MarkdownPipe } from '../../../shared/pipes/markdown.pipe';
+
+/** Full-page counterpart to the topbar update button: shows the running
+ *  version, lets the user re-check on demand, and surfaces the check result —
+ *  including the "up to date" and error states the topbar button hides. Reads
+ *  everything from {@link AppUpdateService}, so the action adapts to the
+ *  platform (in-app install on desktop, external release link on web/.deb). */
+@Component({
+  selector: 'app-update-settings',
+  imports: [
+    DatePipe,
+    TranslateModule,
+    MarkdownPipe,
+    LucideCircleAlert,
+    LucideCircleCheck,
+    LucideDownload,
+    LucideExternalLink,
+    LucideRocket,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './update-settings.html',
+  styles: [
+    `
+      /* ::ng-deep — the changelog HTML is injected via [innerHTML], so it
+         carries no encapsulation attribute and plain component styles miss it. */
+      :host ::ng-deep .changelog-md { line-height: 1.55; }
+      :host ::ng-deep .changelog-md > :first-child { margin-top: 0; }
+      :host ::ng-deep .changelog-md h1,
+      :host ::ng-deep .changelog-md h2 { font-size: 1.1rem; font-weight: 700; margin: 1rem 0 0.45rem; }
+      :host ::ng-deep .changelog-md h3 { font-size: 0.95rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em; opacity: 0.75; margin: 0.9rem 0 0.35rem; }
+      :host ::ng-deep .changelog-md ul,
+      :host ::ng-deep .changelog-md ol { list-style: disc; padding-left: 1.4rem; margin: 0.4rem 0; }
+      :host ::ng-deep .changelog-md ol { list-style: decimal; }
+      :host ::ng-deep .changelog-md li { margin: 0.3rem 0; padding-left: 0.15rem; }
+      :host ::ng-deep .changelog-md li::marker { color: var(--color-primary); }
+      :host ::ng-deep .changelog-md p { margin: 0.5rem 0; }
+      :host ::ng-deep .changelog-md a { color: var(--color-primary); text-decoration: underline; }
+      :host ::ng-deep .changelog-md code { font-family: monospace; font-size: 0.85em; background: rgba(127, 127, 127, 0.18); padding: 0.05rem 0.3rem; border-radius: 0.25rem; }
+      :host ::ng-deep .changelog-md hr { margin: 0.75rem 0; border: 0; border-top: 1px solid rgba(127, 127, 127, 0.3); }
+    `,
+  ],
+})
+export class UpdateSettingsPageComponent implements OnInit {
+  readonly update = inject(AppUpdateService);
+
+  /** A manual re-check only makes sense for the desktop self-updater and the
+   *  admin server-version check; store-managed native apps have no in-app path. */
+  readonly canCheck = computed(() => this.update.mode() !== 'none');
+  readonly checking = computed(() => this.update.state() === 'checking');
+  readonly upToDate = computed(() => this.update.state() === 'not-available');
+  readonly downloading = computed(() => this.update.state() === 'downloading');
+  readonly installing = computed(() => this.update.state() === 'downloaded');
+  readonly hasError = computed(() => this.update.state() === 'error');
+
+  /** Desktop builds that can self-install show "Install"; everything else
+   *  (server mode, .deb, dev) shows an external "open release" link. */
+  readonly canInstallInApp = computed(
+    () => this.update.mode() === 'desktop' && this.update.canInstall(),
+  );
+
+  ngOnInit(): void {
+    // Re-check when the page opens so the state reflects now, not the last
+    // background poll. No-op in store-managed (`none`) mode.
+    if (this.canCheck()) void this.update.check();
+  }
+
+  check(): void {
+    void this.update.check();
+  }
+
+  action(): void {
+    void this.update.install();
+  }
+}

--- a/desktop/src/main/updater.ts
+++ b/desktop/src/main/updater.ts
@@ -1,4 +1,6 @@
 import { app, BrowserWindow, ipcMain, shell } from 'electron';
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
 import electronUpdater from 'electron-updater';
 import {
   UPDATE_IPC,
@@ -23,6 +25,36 @@ const PERIODIC_CHECK_MS = 6 * 60 * 60 * 1000;
 function updateCheckDisabled(): boolean {
   const v = (process.env.FLIKS_DISABLE_UPDATE_CHECK ?? '').trim().toLowerCase();
   return v === '1' || v === 'true' || v === 'yes';
+}
+
+/** File logger for electron-updater. A packaged GUI app has no console, so the
+ *  updater's own diagnostics (feed URL, resolved version, failure cause) would
+ *  otherwise vanish — and a failed check is silent in the UI. Writes to the
+ *  app's logs dir (e.g. %APPDATA%/Fliks/logs/updater.log on Windows). */
+function fileUpdaterLogger(): {
+  info: (m?: unknown) => void;
+  warn: (m?: unknown) => void;
+  error: (m?: unknown) => void;
+  debug: (m?: unknown) => void;
+} {
+  const write = (level: string, m?: unknown): void => {
+    try {
+      const dir = app.getPath('logs');
+      mkdirSync(dir, { recursive: true });
+      appendFileSync(
+        join(dir, 'updater.log'),
+        `${new Date().toISOString()} [${level}] ${typeof m === 'string' ? m : JSON.stringify(m)}\n`,
+      );
+    } catch {
+      // Logging must never break the updater.
+    }
+  };
+  return {
+    info: (m) => write('info', m),
+    warn: (m) => write('warn', m),
+    error: (m) => write('error', m),
+    debug: (m) => write('debug', m),
+  };
 }
 
 function canSelfInstall(): boolean {
@@ -76,6 +108,7 @@ export function setupUpdater(): void {
   }
 
   if (installable) {
+    autoUpdater.logger = fileUpdaterLogger();
     autoUpdater.autoDownload = false;
     autoUpdater.autoInstallOnAppQuit = true;
     // Avoid lzma-native (not bundled); full-file downloads are fine here.


### PR DESCRIPTION
## Why

On the desktop app the **only** update signal is the topbar button, and it stays hidden whenever a check errors (`available` is true only in the `available`/`downloaded` states). So a failed check — no network, proxy, GitHub rate-limit, TLS — looks identical to "up to date": no icon, no message, nothing to retry from, and (on a packaged GUI app with no console) no trace on disk. This is what made a real "no update showing" hard to diagnose even though the v1.15.0 release was perfectly published.

## What

**New "Mise à jour" page under the app settings panel — desktop only.**
- Nav entry gated on `DeviceService.isDesktopNative()`; the route is protected by a new `desktopGuard` (deep-links from web/mobile/TV redirect to the settings home).
- Shows the running version, a manual **"Vérifier les mises à jour"** button, and the check result — the **up-to-date**, **available** (version + changelog + install/open) and **error** states the topbar button hides. Reuses `AppUpdateService` and the changelog markdown rendering, so the platform action is unchanged (in-app install on desktop, external release link otherwise).

**Desktop main process: electron-updater file logger.**
- `autoUpdater.logger` now writes to the app's logs dir (`updater.log`, e.g. `%APPDATA%/Fliks/logs/` on Windows) so a silent check failure is diagnosable instead of vanishing. No new dependency (small `fs`-based logger).

## Verification

- `ng build --configuration development` — clean (templates compile).
- `tsc --noEmit` on `desktop/` — clean.
- Launched the Linux Electron client: boots cleanly, identifies as `[device] desktop` → the update nav/page are exposed on desktop and gated off elsewhere.

## Note

`latest.yml` is the **correct** Windows electron-updater channel file (mac → `latest-mac.yml`, linux → `latest-linux.yml`); there is no `latest-windows.yml`. The v1.15.0 release already ships all three plus the installer — nothing to change there.