### PR TITLE
fix(media): stop non-Latin alt titles from bypassing title match

### DIFF
--- a/backend/src/modules/media/release-rejection.helper.spec.ts
+++ b/backend/src/modules/media/release-rejection.helper.spec.ts
@@ -104,6 +104,37 @@ describe('releaseMatchesMedia', () => {
       ),
     ).toBe(true);
   });
+
+  // A movie routinely carries TMDB alternative titles in other scripts. Those
+  // tokenize to nothing, and must not turn the matcher into a wildcard that
+  // claims every same-year release — otherwise RSS/SearchMissing grab an
+  // unrelated film that merely shares the year.
+  const withNonLatinAlt = {
+    title: 'Original Movie Title',
+    originalTitle: 'Original Movie Title',
+    year: 1985,
+    alternativeTitles: ['作品タイトル', 'Original Movie Title'],
+  };
+
+  it('rejects an unrelated same-year release despite a non-Latin alternative title', () => {
+    expect(
+      releaseMatchesMedia(
+        'Unrelated.Other.Film.1985.1080p.BluRay.x264-GROUP',
+        withNonLatinAlt,
+        { requireYearInTitle: true },
+      ),
+    ).toBe(false);
+  });
+
+  it('still accepts the real title when a non-Latin alternative title is stored', () => {
+    expect(
+      releaseMatchesMedia(
+        'Original.Movie.Title.1985.1080p.BluRay.x264-GROUP',
+        withNonLatinAlt,
+        { requireYearInTitle: true },
+      ),
+    ).toBe(true);
+  });
 });
 
 describe('resolveSearchTitles + titleMatchesExpectation', () => {
@@ -170,6 +201,26 @@ describe('resolveSearchTitles + titleMatchesExpectation', () => {
         'Titre.localise.de.l.editeur.S01E04.AD.HDTV.x264-GROUP',
         expectedTitles,
       ),
+    ).toBe(true);
+  });
+
+  it('skips a non-Latin candidate instead of matching everything', () => {
+    expect(
+      titleMatchesExpectation('Unrelated.Other.Film.1985.1080p.x264-GROUP', [
+        'Original Movie Title',
+        '作品タイトル',
+      ]),
+    ).toBe(false);
+  });
+
+  it('stays permissive when every candidate is non-Latin', () => {
+    // A work stored only under a non-Latin name yields no comparable tokens;
+    // acceptance falls back to permissive so it remains grabbable.
+    expect(
+      titleMatchesExpectation('Anything.1985.1080p.x264-GROUP', [
+        '作品タイトル',
+        '作品',
+      ]),
     ).toBe(true);
   });
 });

--- a/backend/src/modules/media/release-rejection.helper.ts
+++ b/backend/src/modules/media/release-rejection.helper.ts
@@ -331,6 +331,12 @@ function significantTokens(tokens: string[]): string[] {
  * international name still passes when both the localized and original forms
  * are in the candidate list (TMDB's `alternative_titles` / TVDB's `aliases`).
  *
+ * A candidate the tokenizer strips to nothing — an alternative title written
+ * in a non-Latin script, say — carries no comparable tokens, so it is skipped:
+ * it can neither vouch for a match nor veto one. Acceptance falls back to
+ * permissive only when *every* expected title is like that (a work with no
+ * Latin-script name at all), leaving the caller's year guard as the safeguard.
+ *
  * Used as a backend safety net for indexers that ignore `q=` and return any
  * S01 / category-2000 release regardless of what we asked for.
  */
@@ -343,14 +349,16 @@ export function titleMatchesExpectation(
   );
   if (!candidates.length) return true; // nothing meaningful to match
   const releaseTokens = new Set(titleReadings(releaseTitle).flat());
+  let comparable = false;
   for (const cand of candidates) {
     for (const reading of titleReadings(cand)) {
       const tokens = significantTokens(reading);
-      if (!tokens.length) return true; // pathological — treat as match
+      if (!tokens.length) continue; // no comparable tokens (e.g. a non-Latin title)
+      comparable = true;
       if (tokens.every((t) => releaseTokens.has(t))) return true;
     }
   }
-  return false;
+  return !comparable;
 }
 
 export function computeRejections(opts: {


### PR DESCRIPTION
## Problem

Auto-grab picked a torrent for a **completely different movie**: searching/monitoring *The Breakfast Club* (1985), it grabbed an unrelated 1985 film (an anime posted on a French tracker). A manual search for the same movie returns only correct-movie releases — so the divergence is in how auto-grab decides a release belongs to a movie, not in scoring.

## Root cause

`titleMatchesExpectation` (in `release-rejection.helper.ts`) is the single title safety net used by manual search (`computeRejections` → `TITLE_MISMATCH`), SearchMissing and RSS (`releaseMatchesMedia`). It tokenizes each expected title — canonical + original + **every** TMDB alternative title — keeping only `[a-z0-9]` tokens, and passes a release when all of some candidate's significant tokens appear in the release name.

An alternative title written in a **non-Latin script** (Japanese/Cyrillic/etc. — a famous film has several on TMDB) tokenizes to nothing. The old escape hatch treated a candidate with no tokens as a wildcard:

```ts
if (!tokens.length) return true; // pathological — treat as match
```

So any movie carrying such an alternative title matched **every** release; the only remaining barrier was `releaseTitle.includes(year)`. Both films being 1985, the RSS bulk-pull (no query) attributed the unrelated release to the monitored movie and grabbed it.

## Fix

Skip non-comparable candidates instead of wildcarding on them — a title with no comparable tokens can neither vouch for nor veto a match. Acceptance falls back to permissive only when **no** expected title yields comparable tokens at all (a work with no Latin-script name), so those stay grabbable while the gate is restored for everyone else.

Because the matcher is the shared chokepoint for all three paths, this aligns auto-grab selection with the manual search **without duplicating logic**.

## Tests

Added regression cases to `release-rejection.helper.spec.ts`:
- rejects an unrelated same-year release despite a non-Latin alternative title (fails on the old code)
- still accepts the real title when a non-Latin alternative title is stored
- skips a non-Latin candidate instead of matching everything
- stays permissive when every candidate is non-Latin

All 16 tests in the suite pass.

## Residual (out of scope)

The subset-OR match still allows a very short/degenerate Latin alt title to match loosely, and there is no `tmdbId`/`imdbId` verification of returned releases. Neither caused this incident; tightening them risks false-negatives on legitimate localized releases and is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)