### PR TITLE
feat(playlists): add backend playlists module (crud, items, roles)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -13,6 +13,7 @@ import { FliksSchedulerModule } from './modules/scheduler/scheduler.module';
 import { EventsModule } from './modules/scheduler/events.module';
 import { CleanupProfilesModule } from './modules/cleanup-profiles/cleanup-profiles.module';
 import { LibrariesModule } from './modules/libraries/libraries.module';
+import { PlaylistsModule } from './modules/playlists/playlists.module';
 import { BlocklistModule } from './modules/blocklist/blocklist.module';
 import { NotificationsModule } from './modules/notifications/notifications.module';
 import { SettingsModule } from './modules/settings/settings.module';
@@ -87,6 +88,7 @@ import { join } from 'path';
     FliksSchedulerModule,
     CleanupProfilesModule,
     LibrariesModule,
+    PlaylistsModule,
     BlocklistModule,
     NotificationsModule,
     SettingsModule,

--- a/backend/src/common/enums/index.ts
+++ b/backend/src/common/enums/index.ts
@@ -6,3 +6,4 @@ export * from './media-server-type.enum';
 export * from './minimum-availability.enum';
 export * from './subtitle-provider-type.enum';
 export * from './subtitle-status.enum';
+export * from './playlist-share-role.enum';

--- a/backend/src/common/enums/playlist-share-role.enum.ts
+++ b/backend/src/common/enums/playlist-share-role.enum.ts
@@ -1,0 +1,5 @@
+export enum PlaylistShareRole {
+  VIEWER = 'viewer',
+  EDITOR = 'editor',
+  ADMINISTRATOR = 'administrator',
+}

--- a/backend/src/migrations/1781200000000-create-playlists.ts
+++ b/backend/src/migrations/1781200000000-create-playlists.ts
@@ -1,0 +1,96 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreatePlaylists1781200000000 implements MigrationInterface {
+  name = 'CreatePlaylists1781200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "public"."playlist_shares_role_enum"
+        AS ENUM('viewer', 'editor', 'administrator')
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "playlists" (
+        "id" SERIAL PRIMARY KEY,
+        "createdAt" timestamptz NOT NULL DEFAULT now(),
+        "updatedAt" timestamptz NOT NULL DEFAULT now(),
+        "name" varchar(255) NOT NULL,
+        "ownerId" int NOT NULL,
+        "autoRemoveWatched" boolean NOT NULL DEFAULT false,
+        "autoDownload" boolean NOT NULL DEFAULT false,
+        "coverImageUrl" varchar(512),
+        CONSTRAINT "FK_playlists_owner"
+          FOREIGN KEY ("ownerId") REFERENCES "users"("id") ON DELETE CASCADE
+      )
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_playlists_ownerId" ON "playlists" ("ownerId")
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "playlist_items" (
+        "id" SERIAL PRIMARY KEY,
+        "createdAt" timestamptz NOT NULL DEFAULT now(),
+        "updatedAt" timestamptz NOT NULL DEFAULT now(),
+        "playlistId" int NOT NULL,
+        "mediaId" int NOT NULL,
+        "position" int NOT NULL,
+        "addedById" int,
+        CONSTRAINT "FK_playlist_items_playlist"
+          FOREIGN KEY ("playlistId") REFERENCES "playlists"("id") ON DELETE CASCADE,
+        CONSTRAINT "FK_playlist_items_media"
+          FOREIGN KEY ("mediaId") REFERENCES "media"("id") ON DELETE CASCADE,
+        CONSTRAINT "FK_playlist_items_addedBy"
+          FOREIGN KEY ("addedById") REFERENCES "users"("id") ON DELETE SET NULL,
+        CONSTRAINT "UQ_playlist_items_playlist_media"
+          UNIQUE ("playlistId", "mediaId")
+      )
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_playlist_items_playlist_position"
+        ON "playlist_items" ("playlistId", "position")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_playlist_items_mediaId"
+        ON "playlist_items" ("mediaId")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_playlist_items_addedById"
+        ON "playlist_items" ("addedById")
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "playlist_shares" (
+        "id" SERIAL PRIMARY KEY,
+        "createdAt" timestamptz NOT NULL DEFAULT now(),
+        "updatedAt" timestamptz NOT NULL DEFAULT now(),
+        "playlistId" int NOT NULL,
+        "userId" int NOT NULL,
+        "role" "public"."playlist_shares_role_enum" NOT NULL DEFAULT 'viewer',
+        CONSTRAINT "FK_playlist_shares_playlist"
+          FOREIGN KEY ("playlistId") REFERENCES "playlists"("id") ON DELETE CASCADE,
+        CONSTRAINT "FK_playlist_shares_user"
+          FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE,
+        CONSTRAINT "UQ_playlist_shares_playlist_user"
+          UNIQUE ("playlistId", "userId")
+      )
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_playlist_shares_playlistId"
+        ON "playlist_shares" ("playlistId")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_playlist_shares_userId"
+        ON "playlist_shares" ("userId")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "playlist_shares"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "playlist_items"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "playlists"`);
+    await queryRunner.query(
+      `DROP TYPE IF EXISTS "public"."playlist_shares_role_enum"`,
+    );
+  }
+}

--- a/backend/src/modules/auth/casl/casl-ability.factory.ts
+++ b/backend/src/modules/auth/casl/casl-ability.factory.ts
@@ -15,6 +15,7 @@ import { LanguageProfile } from '../../profiles/entities/language-profile.entity
 import { SubtitleProvider } from '../../subtitles/entities/subtitle-provider.entity';
 import { SubtitleFile } from '../../subtitles/entities/subtitle-file.entity';
 import { Library } from '../../libraries/entities/library.entity';
+import { Playlist } from '../../playlists/entities/playlist.entity';
 import { Action } from './actions.enum';
 
 type Subjects =
@@ -29,6 +30,7 @@ type Subjects =
       | typeof SubtitleProvider
       | typeof SubtitleFile
       | typeof Library
+      | typeof Playlist
     >
   | 'Settings'
   | 'all';
@@ -51,6 +53,14 @@ export class CaslAbilityFactory {
     // Every authenticated user can read/update themselves
     can(Action.Read, User, { id: user.id } as any);
     can(Action.Update, User, { id: user.id } as any);
+
+    // Every authenticated user may use playlists. This only opens the feature;
+    // the per-playlist owner/administrator/editor/viewer rules are enforced in
+    // PlaylistsService (CASL sees the class, never the instance).
+    can(Action.Read, Playlist);
+    can(Action.Create, Playlist);
+    can(Action.Update, Playlist);
+    can(Action.Delete, Playlist);
 
     // --- media ---
     if (perms.has('media.read')) {

--- a/backend/src/modules/playlists/dto/add-playlist-item.dto.ts
+++ b/backend/src/modules/playlists/dto/add-playlist-item.dto.ts
@@ -1,0 +1,6 @@
+import { IsInt } from 'class-validator';
+
+export class AddPlaylistItemDto {
+  @IsInt()
+  mediaId: number;
+}

--- a/backend/src/modules/playlists/dto/create-playlist.dto.ts
+++ b/backend/src/modules/playlists/dto/create-playlist.dto.ts
@@ -1,0 +1,15 @@
+import { IsBoolean, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class CreatePlaylistDto {
+  @IsString()
+  @MaxLength(255)
+  name: string;
+
+  @IsOptional()
+  @IsBoolean()
+  autoRemoveWatched?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  autoDownload?: boolean;
+}

--- a/backend/src/modules/playlists/dto/reorder-playlist-items.dto.ts
+++ b/backend/src/modules/playlists/dto/reorder-playlist-items.dto.ts
@@ -1,0 +1,9 @@
+import { IsArray, IsInt } from 'class-validator';
+
+export class ReorderPlaylistItemsDto {
+  /** Playlist item ids in the desired order (each item's position becomes its
+   *  index in this array). */
+  @IsArray()
+  @IsInt({ each: true })
+  itemIds: number[];
+}

--- a/backend/src/modules/playlists/dto/update-playlist.dto.ts
+++ b/backend/src/modules/playlists/dto/update-playlist.dto.ts
@@ -1,0 +1,16 @@
+import { IsBoolean, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdatePlaylistDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  name?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  autoRemoveWatched?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  autoDownload?: boolean;
+}

--- a/backend/src/modules/playlists/entities/playlist-item.entity.ts
+++ b/backend/src/modules/playlists/entities/playlist-item.entity.ts
@@ -1,0 +1,52 @@
+import {
+  Entity,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  RelationId,
+  Unique,
+} from 'typeorm';
+import { BaseEntity } from '../../../common/entities/base.entity';
+import { Playlist } from './playlist.entity';
+import { Media } from '../../media/entities/media.entity';
+import { User } from '../../users/entities/user.entity';
+
+/**
+ * One media entry in a playlist. A plain junction (not @ManyToMany) because it
+ * carries `position` and the "who added it" attribution. `@Unique` keeps a
+ * given media from appearing twice in the same playlist.
+ */
+@Entity('playlist_items')
+@Unique(['playlist', 'media'])
+export class PlaylistItem extends BaseEntity {
+  @ManyToOne(() => Playlist, (playlist) => playlist.items, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'playlistId' })
+  playlist: Playlist;
+
+  @RelationId((i: PlaylistItem) => i.playlist)
+  playlistId: number;
+
+  @ManyToOne(() => Media, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'mediaId' })
+  media: Media;
+
+  @RelationId((i: PlaylistItem) => i.media)
+  mediaId: number;
+
+  /** Ascending order within the playlist; the first four feed the cover. */
+  @Column({ type: 'int' })
+  position: number;
+
+  /**
+   * Who added the item (attribution on shared playlists). SET NULL rather than
+   * CASCADE so removing the adder keeps the item in the owner's playlist.
+   */
+  @ManyToOne(() => User, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'addedById' })
+  addedBy: User | null;
+
+  @RelationId((i: PlaylistItem) => i.addedBy)
+  addedById: number | null;
+}

--- a/backend/src/modules/playlists/entities/playlist-share.entity.ts
+++ b/backend/src/modules/playlists/entities/playlist-share.entity.ts
@@ -1,0 +1,42 @@
+import {
+  Entity,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  RelationId,
+  Unique,
+} from 'typeorm';
+import { BaseEntity } from '../../../common/entities/base.entity';
+import { Playlist } from './playlist.entity';
+import { User } from '../../users/entities/user.entity';
+import { PlaylistShareRole } from '../../../common/enums';
+
+/**
+ * Grants a non-owner user a role on a playlist. The owner is never represented
+ * here (it lives on {@link Playlist}.owner), which is what makes the
+ * "owner can never be removed" rule structural.
+ */
+@Entity('playlist_shares')
+@Unique(['playlist', 'user'])
+export class PlaylistShare extends BaseEntity {
+  @ManyToOne(() => Playlist, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'playlistId' })
+  playlist: Playlist;
+
+  @RelationId((s: PlaylistShare) => s.playlist)
+  playlistId: number;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @RelationId((s: PlaylistShare) => s.user)
+  userId: number;
+
+  @Column({
+    type: 'enum',
+    enum: PlaylistShareRole,
+    default: PlaylistShareRole.VIEWER,
+  })
+  role: PlaylistShareRole;
+}

--- a/backend/src/modules/playlists/entities/playlist.entity.ts
+++ b/backend/src/modules/playlists/entities/playlist.entity.ts
@@ -1,0 +1,47 @@
+import {
+  Entity,
+  Column,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+  RelationId,
+} from 'typeorm';
+import { BaseEntity } from '../../../common/entities/base.entity';
+import { User } from '../../users/entities/user.entity';
+import { PlaylistItem } from './playlist-item.entity';
+
+/**
+ * A user-owned, named collection of media. The owner is a column here (not a
+ * share row) so it is structurally impossible to remove or demote the owner.
+ * Access for other users is granted per-user through {@link PlaylistShare}.
+ */
+@Entity('playlists')
+export class Playlist extends BaseEntity {
+  @Column({ type: 'varchar', length: 255 })
+  name: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'ownerId' })
+  owner: User;
+
+  @RelationId((p: Playlist) => p.owner)
+  ownerId: number;
+
+  /** Drop an item from the playlist once its watcher has finished it. */
+  @Column({ default: false })
+  autoRemoveWatched: boolean;
+
+  /** Keep the playlist's media downloaded on native iOS/Android clients. */
+  @Column({ default: false })
+  autoDownload: boolean;
+
+  /**
+   * User-picked cover. While null the client renders a 2×2 mosaic from the
+   * first four items' posters. Reserved for a later "choose cover" feature.
+   */
+  @Column({ type: 'varchar', length: 512, nullable: true, default: null })
+  coverImageUrl: string | null;
+
+  @OneToMany(() => PlaylistItem, (item) => item.playlist, { cascade: true })
+  items: PlaylistItem[];
+}

--- a/backend/src/modules/playlists/playlists.controller.ts
+++ b/backend/src/modules/playlists/playlists.controller.ts
@@ -1,0 +1,106 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Put,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import { PlaylistsService } from './playlists.service';
+import { CreatePlaylistDto } from './dto/create-playlist.dto';
+import { UpdatePlaylistDto } from './dto/update-playlist.dto';
+import { AddPlaylistItemDto } from './dto/add-playlist-item.dto';
+import { ReorderPlaylistItemsDto } from './dto/reorder-playlist-items.dto';
+import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
+import { PoliciesGuard } from '../auth/casl/policies.guard';
+import { CheckPolicies } from '../auth/casl/check-policies.decorator';
+import { Action } from '../auth/casl/actions.enum';
+import { User } from '../users/entities/user.entity';
+import { Playlist } from './entities/playlist.entity';
+
+/**
+ * The class-level policies only gate "may use playlists at all" (granted to
+ * every authenticated user). The real per-playlist role enforcement
+ * (owner/administrator/editor/viewer) lives in {@link PlaylistsService}.
+ */
+@Controller('playlists')
+@UseGuards(JwtOrApiKeyGuard, PoliciesGuard)
+export class PlaylistsController {
+  constructor(private readonly service: PlaylistsService) {}
+
+  @Get()
+  @CheckPolicies((ability) => ability.can(Action.Read, Playlist))
+  findMine(@Req() req: Request) {
+    return this.service.findAccessibleForUser(req.user as User);
+  }
+
+  @Post()
+  @CheckPolicies((ability) => ability.can(Action.Create, Playlist))
+  create(@Req() req: Request, @Body() dto: CreatePlaylistDto) {
+    return this.service.create(req.user as User, dto);
+  }
+
+  @Get(':id')
+  @CheckPolicies((ability) => ability.can(Action.Read, Playlist))
+  findOne(@Req() req: Request, @Param('id', ParseIntPipe) id: number) {
+    return this.service.findOneForUser(req.user as User, id);
+  }
+
+  @Patch(':id')
+  @CheckPolicies((ability) => ability.can(Action.Update, Playlist))
+  update(
+    @Req() req: Request,
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdatePlaylistDto,
+  ) {
+    return this.service.update(req.user as User, id, dto);
+  }
+
+  @Delete(':id')
+  @CheckPolicies((ability) => ability.can(Action.Delete, Playlist))
+  remove(@Req() req: Request, @Param('id', ParseIntPipe) id: number) {
+    return this.service.remove(req.user as User, id);
+  }
+
+  @Get(':id/items')
+  @CheckPolicies((ability) => ability.can(Action.Read, Playlist))
+  getItems(@Req() req: Request, @Param('id', ParseIntPipe) id: number) {
+    return this.service.getItems(req.user as User, id);
+  }
+
+  @Post(':id/items')
+  @CheckPolicies((ability) => ability.can(Action.Update, Playlist))
+  addItem(
+    @Req() req: Request,
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: AddPlaylistItemDto,
+  ) {
+    return this.service.addItem(req.user as User, id, dto);
+  }
+
+  @Put(':id/items/order')
+  @CheckPolicies((ability) => ability.can(Action.Update, Playlist))
+  reorder(
+    @Req() req: Request,
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: ReorderPlaylistItemsDto,
+  ) {
+    return this.service.reorder(req.user as User, id, dto);
+  }
+
+  @Delete(':id/items/:itemId')
+  @CheckPolicies((ability) => ability.can(Action.Update, Playlist))
+  removeItem(
+    @Req() req: Request,
+    @Param('id', ParseIntPipe) id: number,
+    @Param('itemId', ParseIntPipe) itemId: number,
+  ) {
+    return this.service.removeItem(req.user as User, id, itemId);
+  }
+}

--- a/backend/src/modules/playlists/playlists.module.ts
+++ b/backend/src/modules/playlists/playlists.module.ts
@@ -1,0 +1,22 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Playlist } from './entities/playlist.entity';
+import { PlaylistItem } from './entities/playlist-item.entity';
+import { PlaylistShare } from './entities/playlist-share.entity';
+import { Media } from '../media/entities/media.entity';
+import { PlaylistsService } from './playlists.service';
+import { PlaylistsController } from './playlists.controller';
+import { AuthModule } from '../auth/auth.module';
+import { LibrariesModule } from '../libraries/libraries.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Playlist, PlaylistItem, PlaylistShare, Media]),
+    forwardRef(() => AuthModule),
+    LibrariesModule,
+  ],
+  controllers: [PlaylistsController],
+  providers: [PlaylistsService],
+  exports: [PlaylistsService, TypeOrmModule],
+})
+export class PlaylistsModule {}

--- a/backend/src/modules/playlists/playlists.service.ts
+++ b/backend/src/modules/playlists/playlists.service.ts
@@ -1,0 +1,370 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, In, Repository } from 'typeorm';
+import { Playlist } from './entities/playlist.entity';
+import { PlaylistItem } from './entities/playlist-item.entity';
+import { PlaylistShare } from './entities/playlist-share.entity';
+import { Media } from '../media/entities/media.entity';
+import { User } from '../users/entities/user.entity';
+import { LibrariesService } from '../libraries/libraries.service';
+import { PlaylistShareRole } from '../../common/enums';
+import { CreatePlaylistDto } from './dto/create-playlist.dto';
+import { UpdatePlaylistDto } from './dto/update-playlist.dto';
+import { AddPlaylistItemDto } from './dto/add-playlist-item.dto';
+import { ReorderPlaylistItemsDto } from './dto/reorder-playlist-items.dto';
+
+/** Owner has every capability; the enum ranks the three shared roles. */
+export type PlaylistRole = 'owner' | PlaylistShareRole;
+
+const ROLE_RANK: Record<PlaylistShareRole, number> = {
+  [PlaylistShareRole.VIEWER]: 1,
+  [PlaylistShareRole.EDITOR]: 2,
+  [PlaylistShareRole.ADMINISTRATOR]: 3,
+};
+
+export interface PlaylistView {
+  id: number;
+  name: string;
+  ownerId: number;
+  role: PlaylistRole;
+  autoRemoveWatched: boolean;
+  autoDownload: boolean;
+  coverImageUrl: string | null;
+  itemCount: number;
+  posters: string[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface PlaylistItemView {
+  itemId: number;
+  position: number;
+  addedById: number | null;
+  media: Media;
+}
+
+@Injectable()
+export class PlaylistsService {
+  constructor(
+    @InjectRepository(Playlist)
+    private readonly repo: Repository<Playlist>,
+    @InjectRepository(PlaylistItem)
+    private readonly itemRepo: Repository<PlaylistItem>,
+    @InjectRepository(PlaylistShare)
+    private readonly shareRepo: Repository<PlaylistShare>,
+    @InjectRepository(Media)
+    private readonly mediaRepo: Repository<Media>,
+    private readonly libraries: LibrariesService,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // Access control
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Resolve the caller's role on a playlist and reject if it is below `min`.
+   * The owner short-circuits with full rights. Non-members get a 404 so the
+   * playlist's existence isn't leaked; members below `min` get a 403.
+   */
+  private async assertRole(
+    user: User,
+    playlistId: number,
+    min: PlaylistShareRole,
+  ): Promise<{ playlist: Playlist; role: PlaylistRole }> {
+    const playlist = await this.repo.findOne({ where: { id: playlistId } });
+    if (!playlist) {
+      throw new NotFoundException(`Playlist #${playlistId} not found`);
+    }
+    if (playlist.ownerId === user.id) return { playlist, role: 'owner' };
+
+    const share = await this.shareRepo.findOne({
+      where: { playlist: { id: playlistId }, user: { id: user.id } },
+    });
+    if (!share) throw new NotFoundException(`Playlist #${playlistId} not found`);
+    if (ROLE_RANK[share.role] < ROLE_RANK[min]) {
+      throw new ForbiddenException('Insufficient playlist role');
+    }
+    return { playlist, role: share.role };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Read
+  // ---------------------------------------------------------------------------
+
+  /** Playlists the caller owns or has been shared, with per-viewer cover/count. */
+  async findAccessibleForUser(user: User): Promise<PlaylistView[]> {
+    const owned = await this.repo.find({ where: { owner: { id: user.id } } });
+    const shares = await this.shareRepo.find({
+      where: { user: { id: user.id } },
+      relations: ['playlist'],
+    });
+
+    const byId = new Map<number, { playlist: Playlist; role: PlaylistRole }>();
+    for (const p of owned) byId.set(p.id, { playlist: p, role: 'owner' });
+    for (const s of shares) {
+      if (s.playlist && !byId.has(s.playlist.id)) {
+        byId.set(s.playlist.id, { playlist: s.playlist, role: s.role });
+      }
+    }
+
+    const entries = [...byId.values()];
+    if (!entries.length) return [];
+
+    const accessible = await this.libraries.getAccessibleLibraryIds(user);
+    const stats = await this.postersAndCounts(
+      entries.map((e) => e.playlist.id),
+      accessible,
+    );
+    return entries
+      .map((e) => this.toView(e.playlist, e.role, stats.get(e.playlist.id)))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  async findOneForUser(user: User, playlistId: number): Promise<PlaylistView> {
+    const { playlist, role } = await this.assertRole(
+      user,
+      playlistId,
+      PlaylistShareRole.VIEWER,
+    );
+    const accessible = await this.libraries.getAccessibleLibraryIds(user);
+    const stats = (await this.postersAndCounts([playlistId], accessible)).get(
+      playlistId,
+    );
+    return this.toView(playlist, role, stats);
+  }
+
+  /**
+   * Ordered media in the playlist, filtered to what the caller may see: media
+   * in a library the caller lacks access to are omitted (shared members
+   * included). Enforced with the *caller's* accessible library ids.
+   */
+  async getItems(user: User, playlistId: number): Promise<PlaylistItemView[]> {
+    await this.assertRole(user, playlistId, PlaylistShareRole.VIEWER);
+    const items = await this.itemRepo.find({
+      where: { playlist: { id: playlistId } },
+      order: { position: 'ASC' },
+    });
+    if (!items.length) return [];
+
+    const accessible = await this.libraries.getAccessibleLibraryIds(user);
+    const media = await this.mediaRepo.find({
+      where: {
+        id: In(items.map((i) => i.mediaId)),
+        library: { id: In(accessible.length ? accessible : [-1]) },
+      },
+      relations: ['library'],
+    });
+    const byId = new Map(media.map((m) => [m.id, m]));
+    return items
+      .filter((i) => byId.has(i.mediaId))
+      .map((i) => ({
+        itemId: i.id,
+        position: i.position,
+        addedById: i.addedById,
+        media: byId.get(i.mediaId) as Media,
+      }));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Write — playlist
+  // ---------------------------------------------------------------------------
+
+  async create(user: User, dto: CreatePlaylistDto): Promise<PlaylistView> {
+    const playlist = await this.repo.save(
+      this.repo.create({
+        name: dto.name.trim(),
+        owner: { id: user.id } as User,
+        autoRemoveWatched: dto.autoRemoveWatched ?? false,
+        autoDownload: dto.autoDownload ?? false,
+      }),
+    );
+    return this.findOneForUser(user, playlist.id);
+  }
+
+  async update(
+    user: User,
+    playlistId: number,
+    dto: UpdatePlaylistDto,
+  ): Promise<PlaylistView> {
+    await this.assertRole(user, playlistId, PlaylistShareRole.ADMINISTRATOR);
+    const patch: Partial<Playlist> = {};
+    if (dto.name !== undefined) patch.name = dto.name.trim();
+    if (dto.autoRemoveWatched !== undefined) {
+      patch.autoRemoveWatched = dto.autoRemoveWatched;
+    }
+    if (dto.autoDownload !== undefined) patch.autoDownload = dto.autoDownload;
+    if (Object.keys(patch).length) await this.repo.update(playlistId, patch);
+    return this.findOneForUser(user, playlistId);
+  }
+
+  async remove(user: User, playlistId: number): Promise<void> {
+    const { playlist } = await this.assertRole(
+      user,
+      playlistId,
+      PlaylistShareRole.VIEWER,
+    );
+    if (playlist.ownerId !== user.id) {
+      throw new ForbiddenException('Only the owner can delete a playlist');
+    }
+    await this.repo.remove(playlist);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Write — items
+  // ---------------------------------------------------------------------------
+
+  async addItem(
+    user: User,
+    playlistId: number,
+    dto: AddPlaylistItemDto,
+  ): Promise<PlaylistItem> {
+    await this.assertRole(user, playlistId, PlaylistShareRole.EDITOR);
+
+    // Only media the caller can see may be added.
+    const accessible = await this.libraries.getAccessibleLibraryIds(user);
+    const media = await this.mediaRepo.findOne({
+      where: {
+        id: dto.mediaId,
+        library: { id: In(accessible.length ? accessible : [-1]) },
+      },
+    });
+    if (!media) throw new NotFoundException(`Media #${dto.mediaId} not found`);
+
+    const existing = await this.itemRepo.findOne({
+      where: { playlist: { id: playlistId }, media: { id: dto.mediaId } },
+    });
+    if (existing) throw new BadRequestException('Media already in playlist');
+
+    const max = await this.itemRepo
+      .createQueryBuilder('i')
+      .select('MAX(i.position)', 'max')
+      .where('i."playlistId" = :pid', { pid: playlistId })
+      .getRawOne<{ max: number | null }>();
+    const position = max?.max != null ? Number(max.max) + 1 : 0;
+
+    try {
+      return await this.itemRepo.save(
+        this.itemRepo.create({
+          playlist: { id: playlistId } as Playlist,
+          media: { id: dto.mediaId } as Media,
+          addedBy: { id: user.id } as User,
+          position,
+        }),
+      );
+    } catch (err) {
+      // Unique(playlist, media): a concurrent add raced past the pre-check —
+      // surface the same clean 400 rather than a raw DB error.
+      if ((err as { code?: string }).code === '23505') {
+        throw new BadRequestException('Media already in playlist');
+      }
+      throw err;
+    }
+  }
+
+  async removeItem(
+    user: User,
+    playlistId: number,
+    itemId: number,
+  ): Promise<void> {
+    await this.assertRole(user, playlistId, PlaylistShareRole.EDITOR);
+    const res = await this.itemRepo.delete({
+      id: itemId,
+      playlist: { id: playlistId },
+    });
+    if (!res.affected) {
+      throw new NotFoundException(`Playlist item #${itemId} not found`);
+    }
+  }
+
+  async reorder(
+    user: User,
+    playlistId: number,
+    dto: ReorderPlaylistItemsDto,
+  ): Promise<void> {
+    await this.assertRole(user, playlistId, PlaylistShareRole.EDITOR);
+    const items = await this.itemRepo.find({
+      where: { playlist: { id: playlistId } },
+    });
+    const ids = new Set(items.map((i) => i.id));
+    const unique = new Set(dto.itemIds);
+    if (
+      unique.size !== dto.itemIds.length ||
+      dto.itemIds.length !== items.length ||
+      dto.itemIds.some((id) => !ids.has(id))
+    ) {
+      throw new BadRequestException(
+        'itemIds must list every item in the playlist exactly once',
+      );
+    }
+    await this.dataSource.transaction(async (m) => {
+      for (let idx = 0; idx < dto.itemIds.length; idx++) {
+        await m.update(PlaylistItem, { id: dto.itemIds[idx] }, { position: idx });
+      }
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internals
+  // ---------------------------------------------------------------------------
+
+  private toView(
+    playlist: Playlist,
+    role: PlaylistRole,
+    stats: { count: number; posters: string[] } | undefined,
+  ): PlaylistView {
+    return {
+      id: playlist.id,
+      name: playlist.name,
+      ownerId: playlist.ownerId,
+      role,
+      autoRemoveWatched: playlist.autoRemoveWatched,
+      autoDownload: playlist.autoDownload,
+      coverImageUrl: playlist.coverImageUrl,
+      itemCount: stats?.count ?? 0,
+      posters: stats?.posters ?? [],
+      createdAt: playlist.createdAt,
+      updatedAt: playlist.updatedAt,
+    };
+  }
+
+  /**
+   * Per-playlist item count + first four posters, scoped to the libraries the
+   * viewer may access — so a shared member never sees a poster (or a count)
+   * for media outside their library access. Ordered by playlist position.
+   */
+  private async postersAndCounts(
+    playlistIds: number[],
+    accessibleLibraryIds: number[],
+  ): Promise<Map<number, { count: number; posters: string[] }>> {
+    const map = new Map<number, { count: number; posters: string[] }>();
+    if (!playlistIds.length || !accessibleLibraryIds.length) return map;
+    const rows: { playlistId: number; count: number; posters: string[] }[] =
+      await this.dataSource.query(
+        `
+        SELECT pi."playlistId" AS "playlistId",
+               COUNT(*)::int    AS count,
+               COALESCE(
+                 (ARRAY_AGG(m."posterUrl" ORDER BY pi."position")
+                  FILTER (WHERE m."posterUrl" IS NOT NULL))[1:4],
+                 ARRAY[]::text[]
+               ) AS posters
+        FROM playlist_items pi
+        JOIN media m ON m.id = pi."mediaId"
+        WHERE pi."playlistId" = ANY($1)
+          AND m."libraryId" = ANY($2)
+        GROUP BY pi."playlistId"
+        `,
+        [playlistIds, accessibleLibraryIds],
+      );
+    for (const r of rows) {
+      map.set(r.playlistId, { count: r.count, posters: r.posters ?? [] });
+    }
+    return map;
+  }
+}


### PR DESCRIPTION
## What

First backend slice (PR 1 of 6) of the user **playlists** ("listes de lecture") feature: a self-contained `playlists` module with CRUD, item management, and per-playlist role model. Ships owner-only playlists, verifiable via the API.

### Data model (`backend/src/modules/playlists/`)
- `Playlist` — `name`, `owner` (FK), `autoRemoveWatched`, `autoDownload`, nullable `coverImageUrl` (reserved for a future custom cover), `items`.
- `PlaylistItem` — junction with `position` + `addedBy` (SET NULL so removing the adder keeps the item), `@Unique(playlist, media)`.
- `PlaylistShare` — `(playlist, user, role)` with `PlaylistShareRole` enum `viewer | editor | administrator`, `@Unique(playlist, user)`.
- Migration `1781200000000-create-playlists.ts` (enum type + 3 tables + cascade FKs + indexes).

### Permissions
- **Owner is a column on the playlist**, never a share row → the "owner can never be removed/demoted" rule is structural, no runtime guard needed.
- Per-playlist roles enforced in `PlaylistsService.assertRole` (CASL only gates the class — every authenticated user may use the feature). Non-members get 404 (existence not leaked); members below the required role get 403.
- Capability ranks: viewer < editor < administrator; owner short-circuits.

### Library ACL on visibility
Every media read — the item list, the cover posters, and the item count — is scoped to the **requesting** user's `accessibleLibraryIds` (`LibrariesService.getAccessibleLibraryIds`), **never the owner's**. A shared member therefore never sees media (poster, item, or count) from a library they lack access to; cover/count are computed per-viewer. An editor can only add media they themselves can see.

### API
`GET /playlists`, `POST /playlists`, `GET/PATCH/DELETE /playlists/:id`, `GET/POST /playlists/:id/items`, `PUT /playlists/:id/items/order`, `DELETE /playlists/:id/items/:itemId`.

## Deferred to later slices
Sharing endpoints + share UI (PR 3), auto-remove-after-watched hook (PR 4), native auto-download (PR 5), and the whole frontend (PR 2). Custom cover upload stays deferred (only the `coverImageUrl` column is reserved).

## Verification
- Backend `tsc --noEmit`: clean.
- Adversarial multi-agent review of the diff (DI/boot, service logic, entity↔migration parity, routes, ACL leak-paths): 0 confirmed issues; one minor TOCTOU on concurrent duplicate-add was fixed (unique-violation now returns a clean 400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
