### PR TITLE
feat(playlists): support movie + episode items with season/series bulk add

### DIFF
--- a/backend/src/migrations/1781200000000-create-playlists.ts
+++ b/backend/src/migrations/1781200000000-create-playlists.ts
@@ -34,16 +34,17 @@ export class CreatePlaylists1781200000000 implements MigrationInterface {
         "updatedAt" timestamptz NOT NULL DEFAULT now(),
         "playlistId" int NOT NULL,
         "mediaId" int NOT NULL,
+        "episodeId" int,
         "position" int NOT NULL,
         "addedById" int,
         CONSTRAINT "FK_playlist_items_playlist"
           FOREIGN KEY ("playlistId") REFERENCES "playlists"("id") ON DELETE CASCADE,
         CONSTRAINT "FK_playlist_items_media"
           FOREIGN KEY ("mediaId") REFERENCES "media"("id") ON DELETE CASCADE,
+        CONSTRAINT "FK_playlist_items_episode"
+          FOREIGN KEY ("episodeId") REFERENCES "episodes"("id") ON DELETE CASCADE,
         CONSTRAINT "FK_playlist_items_addedBy"
-          FOREIGN KEY ("addedById") REFERENCES "users"("id") ON DELETE SET NULL,
-        CONSTRAINT "UQ_playlist_items_playlist_media"
-          UNIQUE ("playlistId", "mediaId")
+          FOREIGN KEY ("addedById") REFERENCES "users"("id") ON DELETE SET NULL
       )
     `);
     await queryRunner.query(`
@@ -55,8 +56,26 @@ export class CreatePlaylists1781200000000 implements MigrationInterface {
         ON "playlist_items" ("mediaId")
     `);
     await queryRunner.query(`
+      CREATE INDEX "IDX_playlist_items_episodeId"
+        ON "playlist_items" ("episodeId")
+    `);
+    await queryRunner.query(`
       CREATE INDEX "IDX_playlist_items_addedById"
         ON "playlist_items" ("addedById")
+    `);
+    // A movie appears at most once per playlist; an episode at most once per
+    // playlist. Two partial indexes because a plain UNIQUE(playlistId, mediaId,
+    // episodeId) would let duplicate movies through (Postgres treats NULLs as
+    // distinct by default).
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "UQ_playlist_items_movie"
+        ON "playlist_items" ("playlistId", "mediaId")
+        WHERE "episodeId" IS NULL
+    `);
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "UQ_playlist_items_episode"
+        ON "playlist_items" ("playlistId", "episodeId")
+        WHERE "episodeId" IS NOT NULL
     `);
 
     await queryRunner.query(`

--- a/backend/src/modules/playlists/dto/add-playlist-item.dto.ts
+++ b/backend/src/modules/playlists/dto/add-playlist-item.dto.ts
@@ -1,6 +1,21 @@
-import { IsInt } from 'class-validator';
+import { IsInt, IsOptional } from 'class-validator';
 
+/**
+ * Exactly one axis is used, which selects the scope:
+ *   - `episodeId` → add that single episode
+ *   - `seasonId`  → add every episode of that season
+ *   - `mediaId`   → add the movie, or (for a series) all its episodes
+ */
 export class AddPlaylistItemDto {
+  @IsOptional()
   @IsInt()
-  mediaId: number;
+  mediaId?: number;
+
+  @IsOptional()
+  @IsInt()
+  episodeId?: number;
+
+  @IsOptional()
+  @IsInt()
+  seasonId?: number;
 }

--- a/backend/src/modules/playlists/entities/playlist-item.entity.ts
+++ b/backend/src/modules/playlists/entities/playlist-item.entity.ts
@@ -1,23 +1,36 @@
 import {
   Entity,
   Column,
+  Index,
   ManyToOne,
   JoinColumn,
   RelationId,
-  Unique,
 } from 'typeorm';
 import { BaseEntity } from '../../../common/entities/base.entity';
 import { Playlist } from './playlist.entity';
 import { Media } from '../../media/entities/media.entity';
+import { Episode } from '../../media/entities/episode.entity';
 import { User } from '../../users/entities/user.entity';
 
 /**
- * One media entry in a playlist. A plain junction (not @ManyToMany) because it
- * carries `position` and the "who added it" attribution. `@Unique` keeps a
- * given media from appearing twice in the same playlist.
+ * One entry in a playlist: a movie (`episode` null, `media` is the movie) or a
+ * single episode (`media` is the parent series, `episode` set). A plain
+ * junction (not @ManyToMany) because it carries `position` and the "who added
+ * it" attribution. Uniqueness is enforced by partial unique indexes in the
+ * migration — one row per (playlist, movie) and one per (playlist, episode).
  */
 @Entity('playlist_items')
-@Unique(['playlist', 'media'])
+// Partial unique indexes (also created by the migration) so a movie appears at
+// most once and an episode at most once per playlist. Declared here too so dev
+// `synchronize` matches prod — a plain @Unique can't express the NULL split.
+@Index('UQ_playlist_items_movie', ['playlist', 'media'], {
+  unique: true,
+  where: '"episodeId" IS NULL',
+})
+@Index('UQ_playlist_items_episode', ['playlist', 'episode'], {
+  unique: true,
+  where: '"episodeId" IS NOT NULL',
+})
 export class PlaylistItem extends BaseEntity {
   @ManyToOne(() => Playlist, (playlist) => playlist.items, {
     onDelete: 'CASCADE',
@@ -28,12 +41,21 @@ export class PlaylistItem extends BaseEntity {
   @RelationId((i: PlaylistItem) => i.playlist)
   playlistId: number;
 
+  /** The movie, or the parent series when this item is an episode. */
   @ManyToOne(() => Media, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'mediaId' })
   media: Media;
 
   @RelationId((i: PlaylistItem) => i.media)
   mediaId: number;
+
+  /** Set when the item is a single episode; null for a movie item. */
+  @ManyToOne(() => Episode, { nullable: true, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'episodeId' })
+  episode: Episode | null;
+
+  @RelationId((i: PlaylistItem) => i.episode)
+  episodeId: number | null;
 
   /** Ascending order within the playlist; the first four feed the cover. */
   @Column({ type: 'int' })

--- a/backend/src/modules/playlists/playlists.module.ts
+++ b/backend/src/modules/playlists/playlists.module.ts
@@ -4,6 +4,7 @@ import { Playlist } from './entities/playlist.entity';
 import { PlaylistItem } from './entities/playlist-item.entity';
 import { PlaylistShare } from './entities/playlist-share.entity';
 import { Media } from '../media/entities/media.entity';
+import { Episode } from '../media/entities/episode.entity';
 import { PlaylistsService } from './playlists.service';
 import { PlaylistsController } from './playlists.controller';
 import { AuthModule } from '../auth/auth.module';
@@ -11,7 +12,7 @@ import { LibrariesModule } from '../libraries/libraries.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Playlist, PlaylistItem, PlaylistShare, Media]),
+    TypeOrmModule.forFeature([Playlist, PlaylistItem, PlaylistShare, Media, Episode]),
     forwardRef(() => AuthModule),
     LibrariesModule,
   ],

--- a/backend/src/modules/playlists/playlists.service.ts
+++ b/backend/src/modules/playlists/playlists.service.ts
@@ -10,9 +10,10 @@ import { Playlist } from './entities/playlist.entity';
 import { PlaylistItem } from './entities/playlist-item.entity';
 import { PlaylistShare } from './entities/playlist-share.entity';
 import { Media } from '../media/entities/media.entity';
+import { Episode } from '../media/entities/episode.entity';
 import { User } from '../users/entities/user.entity';
 import { LibrariesService } from '../libraries/libraries.service';
-import { PlaylistShareRole } from '../../common/enums';
+import { MediaType, PlaylistShareRole } from '../../common/enums';
 import { CreatePlaylistDto } from './dto/create-playlist.dto';
 import { UpdatePlaylistDto } from './dto/update-playlist.dto';
 import { AddPlaylistItemDto } from './dto/add-playlist-item.dto';
@@ -45,7 +46,10 @@ export interface PlaylistItemView {
   itemId: number;
   position: number;
   addedById: number | null;
+  /** The movie, or the parent series when this item is an episode. */
   media: Media;
+  /** Set when the item is a single episode; null for a movie item. */
+  episode: Episode | null;
 }
 
 @Injectable()
@@ -59,6 +63,8 @@ export class PlaylistsService {
     private readonly shareRepo: Repository<PlaylistShare>,
     @InjectRepository(Media)
     private readonly mediaRepo: Repository<Media>,
+    @InjectRepository(Episode)
+    private readonly episodeRepo: Repository<Episode>,
     private readonly libraries: LibrariesService,
     private readonly dataSource: DataSource,
   ) {}
@@ -161,6 +167,20 @@ export class PlaylistsService {
       relations: ['library'],
     });
     const byId = new Map(media.map((m) => [m.id, m]));
+
+    // The client has no standalone episode fetch, so inline the episode fields
+    // (season/episode numbers, title, still) needed to render episode items.
+    const epIds = items
+      .map((i) => i.episodeId)
+      .filter((id): id is number => id != null);
+    const episodes = epIds.length
+      ? await this.episodeRepo.find({
+          where: { id: In(epIds) },
+          relations: ['season'],
+        })
+      : [];
+    const epById = new Map(episodes.map((e) => [e.id, e]));
+
     return items
       .filter((i) => byId.has(i.mediaId))
       .map((i) => ({
@@ -168,6 +188,7 @@ export class PlaylistsService {
         position: i.position,
         addedById: i.addedById,
         media: byId.get(i.mediaId) as Media,
+        episode: i.episodeId != null ? (epById.get(i.episodeId) ?? null) : null,
       }));
   }
 
@@ -219,52 +240,174 @@ export class PlaylistsService {
   // Write — items
   // ---------------------------------------------------------------------------
 
+  /**
+   * Add to a playlist. The body picks the scope: a movie (`mediaId` → a movie),
+   * a single episode (`episodeId`), a whole season (`seasonId`) or a whole
+   * series (`mediaId` → a series). Season/series expand server-side to one row
+   * per episode in a single transaction, skipping items already present, and
+   * only touching media the caller can access. Returns how many rows were added.
+   */
   async addItem(
     user: User,
     playlistId: number,
     dto: AddPlaylistItemDto,
-  ): Promise<PlaylistItem> {
+  ): Promise<{ added: number }> {
     await this.assertRole(user, playlistId, PlaylistShareRole.EDITOR);
-
-    // Only media the caller can see may be added.
     const accessible = await this.libraries.getAccessibleLibraryIds(user);
-    const media = await this.mediaRepo.findOne({
-      where: {
-        id: dto.mediaId,
-        library: { id: In(accessible.length ? accessible : [-1]) },
-      },
-    });
-    if (!media) throw new NotFoundException(`Media #${dto.mediaId} not found`);
+    const accessibleIds = accessible.length ? accessible : [-1];
 
-    const existing = await this.itemRepo.findOne({
-      where: { playlist: { id: playlistId }, media: { id: dto.mediaId } },
-    });
-    if (existing) throw new BadRequestException('errors.media_already_in_playlist');
+    const { targets, bulk } = await this.resolveAddTargets(dto, accessibleIds);
+    if (!targets.length) return { added: 0 };
 
-    const max = await this.itemRepo
-      .createQueryBuilder('i')
-      .select('MAX(i.position)', 'max')
-      .where('i."playlistId" = :pid', { pid: playlistId })
-      .getRawOne<{ max: number | null }>();
-    const position = max?.max != null ? Number(max.max) + 1 : 0;
+    const runInsert = (): Promise<{ added: number }> =>
+      this.dataSource.transaction(async (m) => {
+        const itemRepo = m.getRepository(PlaylistItem);
+        const existing = await itemRepo.find({
+          where: { playlist: { id: playlistId } },
+        });
+        const movieIds = new Set(
+          existing.filter((e) => e.episodeId == null).map((e) => e.mediaId),
+        );
+        const epIds = new Set(
+          existing.filter((e) => e.episodeId != null).map((e) => e.episodeId),
+        );
+        const fresh = targets.filter((t) =>
+          t.episodeId != null ? !epIds.has(t.episodeId) : !movieIds.has(t.mediaId),
+        );
+        if (!fresh.length) {
+          // A single explicit add of an item already present is the "duplicate"
+          // case the UI surfaces; a bulk add just reports nothing new.
+          if (!bulk) {
+            throw new BadRequestException('errors.media_already_in_playlist');
+          }
+          return { added: 0 };
+        }
+
+        const maxRow = await itemRepo
+          .createQueryBuilder('i')
+          .select('MAX(i.position)', 'max')
+          .where('i."playlistId" = :pid', { pid: playlistId })
+          .getRawOne<{ max: number | null }>();
+        let position = maxRow?.max != null ? Number(maxRow.max) + 1 : 0;
+
+        const rows = fresh.map((t) =>
+          itemRepo.create({
+            playlist: { id: playlistId } as Playlist,
+            media: { id: t.mediaId } as Media,
+            episode: t.episodeId != null ? ({ id: t.episodeId } as Episode) : null,
+            addedBy: { id: user.id } as User,
+            position: position++,
+          }),
+        );
+        await itemRepo.save(rows);
+        return { added: rows.length };
+      });
 
     try {
-      return await this.itemRepo.save(
-        this.itemRepo.create({
-          playlist: { id: playlistId } as Playlist,
-          media: { id: dto.mediaId } as Media,
-          addedBy: { id: user.id } as User,
-          position,
-        }),
-      );
+      return await runInsert();
     } catch (err) {
-      // Unique(playlist, media): a concurrent add raced past the pre-check —
-      // surface the same clean 400 rather than a raw DB error.
-      if ((err as { code?: string }).code === '23505') {
+      if (err instanceof BadRequestException) throw err;
+      if ((err as { code?: string }).code !== '23505') throw err;
+      // Partial unique index violation — a concurrent add raced past the
+      // skip-existing check. A single add is the "duplicate" case the UI
+      // surfaces; a bulk add retries once so skip-existing now sees the
+      // concurrently-inserted rows (and no-ops cleanly if it races again).
+      if (!bulk) {
         throw new BadRequestException('errors.media_already_in_playlist');
       }
-      throw err;
+      try {
+        return await runInsert();
+      } catch (retry) {
+        if (retry instanceof BadRequestException) throw retry;
+        if ((retry as { code?: string }).code === '23505') return { added: 0 };
+        throw retry;
+      }
     }
+  }
+
+  /**
+   * Turn an add request into the concrete rows to insert, validating the
+   * caller's library access. `bulk` = a season/series expansion (skip
+   * already-present episodes) vs a single movie/episode add.
+   */
+  private async resolveAddTargets(
+    dto: AddPlaylistItemDto,
+    accessibleIds: number[],
+  ): Promise<{
+    targets: { mediaId: number; episodeId: number | null }[];
+    bulk: boolean;
+  }> {
+    // Single episode
+    if (dto.episodeId != null) {
+      const ep = await this.episodeRepo.findOne({
+        where: { id: dto.episodeId },
+        relations: ['season'],
+      });
+      if (!ep?.season) {
+        throw new NotFoundException(`Episode #${dto.episodeId} not found`);
+      }
+      await this.assertAccessibleSeries(ep.season.mediaId, accessibleIds);
+      return {
+        targets: [{ mediaId: ep.season.mediaId, episodeId: dto.episodeId }],
+        bulk: false,
+      };
+    }
+
+    // Whole season
+    if (dto.seasonId != null) {
+      const eps = await this.episodeRepo.find({
+        where: { season: { id: dto.seasonId } },
+        relations: ['season'],
+        order: { episodeNumber: 'ASC' },
+      });
+      if (!eps.length) return { targets: [], bulk: true };
+      const seriesId = eps[0].season.mediaId;
+      await this.assertAccessibleSeries(seriesId, accessibleIds);
+      return {
+        targets: eps.map((e) => ({ mediaId: seriesId, episodeId: e.id })),
+        bulk: true,
+      };
+    }
+
+    // Movie or whole series (by media id)
+    if (dto.mediaId != null) {
+      const media = await this.mediaRepo.findOne({
+        where: { id: dto.mediaId, library: { id: In(accessibleIds) } },
+      });
+      if (!media) throw new NotFoundException(`Media #${dto.mediaId} not found`);
+      if (media.type === MediaType.SERIES) {
+        const eps = await this.episodeRepo.find({
+          where: { season: { media: { id: dto.mediaId } } },
+          relations: ['season'],
+        });
+        eps.sort(
+          (a, b) =>
+            a.season.seasonNumber - b.season.seasonNumber ||
+            a.episodeNumber - b.episodeNumber,
+        );
+        return {
+          targets: eps.map((e) => ({ mediaId: media.id, episodeId: e.id })),
+          bulk: true,
+        };
+      }
+      return { targets: [{ mediaId: dto.mediaId, episodeId: null }], bulk: false };
+    }
+
+    throw new BadRequestException('errors.playlist_add_target_required');
+  }
+
+  private async assertAccessibleSeries(
+    seriesId: number,
+    accessibleIds: number[],
+  ): Promise<void> {
+    const series = await this.mediaRepo.findOne({
+      where: {
+        id: seriesId,
+        type: MediaType.SERIES,
+        library: { id: In(accessibleIds) },
+      },
+    });
+    if (!series) throw new NotFoundException(`Series #${seriesId} not found`);
   }
 
   async removeItem(

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1966,6 +1966,7 @@
     "404": "Ressource introuvable",
     "409": "Conflit — la ressource existe déjà",
     "media_already_in_playlist": "Ce média est déjà dans la liste",
+    "playlist_add_target_required": "Aucun média, épisode ou saison indiqué",
     "422": "Données invalides",
     "429": "Trop de requêtes — réessayez plus tard",
     "500": "Erreur interne du serveur",


### PR DESCRIPTION
## What

Backend groundwork so a playlist can hold **movies and individual episodes** (reverses the earlier media-level-only model), with server-side "add whole season / whole series". Frontend (episode add buttons + the two view modes) lands in a follow-up PR.

### Data model
- `playlist_item` gains a **nullable `episodeId` FK** (`ON DELETE CASCADE`). A row is a *movie* (`mediaId`=movie, `episodeId` null) or a *single episode* (`mediaId`=parent series, `episodeId` set).
- The old `UNIQUE(playlistId, mediaId)` **blocked two episodes of one series** (both carry `mediaId=seriesId`). Replaced by **two partial unique indexes** — `(playlistId, mediaId) WHERE episodeId IS NULL` and `(playlistId, episodeId) WHERE episodeId IS NOT NULL` — avoiding the Postgres `NULLS DISTINCT` duplicate-movie trap.
- Declared in **both** the migration and as entity `@Index` (partial, same names) so dev `synchronize` matches prod. The create-playlists migration was **edited in place** (approved — never deployed to prod) rather than adding an ALTER.

### Backend
- `AddPlaylistItemDto` = `mediaId? | episodeId? | seasonId?`; the service infers scope: `episodeId` → one episode, `seasonId` → all its episodes, `mediaId` → a movie or (for a series) all its episodes.
- Season/series **expand server-side** to one row per episode in a **single transaction**, skipping items already present, ACL-checked against the series' library, ordered by (season, episode). Returns `{ added }`. Single duplicate → translated 400; a bulk concurrent race retries once then no-ops.
- `getItems` / `PlaylistItemView` inline episode fields (season/episode numbers, title, still) — the client has no standalone episode fetch.

## Verification
- Backend `tsc --noEmit`: clean.
- Adversarial multi-agent review (migration/entity dev-prod parity, addItem scope+ACL, getItems/integration): 0 confirmed issues; a minor bulk-race 500 was fixed (retry-once + graceful no-op).

## Follow-up (next PR)
Frontend: three add affordances (episode / whole season / whole series), the two playlist-detail view modes (grouped-by-series ⇄ flat, per-user toggle), episode card rendering, cover-poster de-dup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
