### PR TITLE
feat(playlists): auto-remove watched items from auto-remove playlists

### DIFF
--- a/backend/src/modules/playlists/playlists.service.ts
+++ b/backend/src/modules/playlists/playlists.service.ts
@@ -492,6 +492,42 @@ export class PlaylistsService {
     return { removed: res.affected ?? 0 };
   }
 
+  /**
+   * Auto-remove hook for finished playback: drop the matching row(s) from every
+   * playlist the user *owns* that has `autoRemoveWatched` on. Scoped to owned
+   * playlists so one member finishing an item never mutates a shared list for
+   * the others. Called from the playback path when a `PlaybackState` transitions
+   * to completed; the caller isolates failures so a playlist write can't break
+   * recording the watch.
+   *
+   * `episodeIds` picks the target: `null` matches the movie row (episode NULL);
+   * a list matches those episode rows (a single toggle passes one id, a
+   * season/series mark-watched passes many). An empty list is a no-op.
+   */
+  async removeWatchedFromAutoPlaylists(
+    userId: number,
+    mediaId: number,
+    episodeIds: number[] | null,
+  ): Promise<void> {
+    if (episodeIds != null && !episodeIds.length) return;
+    const playlists = await this.repo.find({
+      where: { owner: { id: userId }, autoRemoveWatched: true },
+    });
+    if (!playlists.length) return;
+
+    const qb = this.itemRepo
+      .createQueryBuilder()
+      .delete()
+      .from(PlaylistItem)
+      .where('"playlistId" IN (:...playlistIds)', {
+        playlistIds: playlists.map((p) => p.id),
+      })
+      .andWhere('"mediaId" = :mediaId', { mediaId });
+    if (episodeIds == null) qb.andWhere('"episodeId" IS NULL');
+    else qb.andWhere('"episodeId" IN (:...episodeIds)', { episodeIds });
+    await qb.execute();
+  }
+
   async reorder(
     user: User,
     playlistId: number,

--- a/backend/src/modules/streaming/playback.service.ts
+++ b/backend/src/modules/streaming/playback.service.ts
@@ -11,6 +11,7 @@ import { MediaFile } from '../media/entities/media-file.entity';
 import { Episode } from '../media/entities/episode.entity';
 import { User } from '../users/entities/user.entity';
 import { PlaybackState } from './entities/playback-state.entity';
+import { PlaylistsService } from '../playlists/playlists.service';
 
 export interface WatchHistoryItem {
   id: number;
@@ -88,7 +89,33 @@ export class PlaybackService implements OnModuleInit {
     private readonly mediaFileRepo: Repository<MediaFile>,
     @InjectRepository(Episode)
     private readonly episodeRepo: Repository<Episode>,
+    private readonly playlists: PlaylistsService,
   ) {}
+
+  /**
+   * Fire the playlist auto-remove hook for an item the user just finished,
+   * isolating any failure: a playlist write must never break recording a
+   * watch. `episodeIds` is `null` for a movie, or the finished episode ids.
+   */
+  private async autoRemoveFromPlaylists(
+    userId: number,
+    mediaId: number,
+    episodeIds: number[] | null,
+  ): Promise<void> {
+    try {
+      await this.playlists.removeWatchedFromAutoPlaylists(
+        userId,
+        mediaId,
+        episodeIds,
+      );
+    } catch (err) {
+      this.log.warn(
+        `Playlist auto-remove failed for media #${mediaId}: ${
+          (err as Error).message
+        }`,
+      );
+    }
+  }
 
   async onModuleInit() {
     await this.deduplicateAndCreateIndexes();
@@ -273,6 +300,7 @@ export class PlaybackService implements OnModuleInit {
       throw new BadRequestException('mediaId and mediaFileId are required');
     }
     let state = await this.findState(userId, mediaId, body.episodeId);
+    const wasCompleted = state?.completed ?? false;
 
     const dur = body.durationSeconds ?? 0;
     const pos = body.positionSeconds ?? 0;
@@ -308,7 +336,15 @@ export class PlaybackService implements OnModuleInit {
     }
 
     try {
-      return await this.repo.save(state);
+      const saved = await this.repo.save(state);
+      if (completed && !wasCompleted) {
+        await this.autoRemoveFromPlaylists(
+          userId,
+          mediaId,
+          body.episodeId != null ? [body.episodeId] : null,
+        );
+      }
+      return saved;
     } catch (err) {
       if ((err as { code?: string })?.code === PG_FK_VIOLATION) return null;
       throw err;
@@ -627,6 +663,13 @@ export class PlaybackService implements OnModuleInit {
         `,
         [userId, mediaId],
       );
+      const completedStates = await this.repo.find({
+        where: { user: { id: userId }, media: { id: mediaId }, completed: true },
+      });
+      const episodeIds = completedStates
+        .map((s) => s.episodeId)
+        .filter((id): id is number => id != null);
+      await this.autoRemoveFromPlaylists(userId, mediaId, episodeIds);
     } else {
       await this.repo.query(
         `
@@ -706,6 +749,11 @@ export class PlaybackService implements OnModuleInit {
         .filter((r): r is NonNullable<typeof r> => r !== null);
       if (rows.length) {
         await this.repo.save(rows as Partial<PlaybackState>[]);
+        await this.autoRemoveFromPlaylists(
+          userId,
+          mediaId,
+          rows.map((r) => r.episode.id),
+        );
       }
     } else {
       await this.repo.update(
@@ -778,7 +826,15 @@ export class PlaybackService implements OnModuleInit {
       }
     }
 
-    return this.repo.save(state);
+    const saved = await this.repo.save(state);
+    if (willBeCompleted) {
+      await this.autoRemoveFromPlaylists(
+        userId,
+        mediaId,
+        episodeId != null ? [episodeId] : null,
+      );
+    }
+    return saved;
   }
 
   async hideFromContinueWatching(

--- a/backend/src/modules/streaming/streaming.module.ts
+++ b/backend/src/modules/streaming/streaming.module.ts
@@ -29,6 +29,7 @@ import { AuthModule } from '../auth/auth.module';
 import { SettingsModule } from '../settings/settings.module';
 import { LibrariesModule } from '../libraries/libraries.module';
 import { MarkersModule } from '../markers/markers.module';
+import { PlaylistsModule } from '../playlists/playlists.module';
 
 @Module({
   imports: [
@@ -46,6 +47,7 @@ import { MarkersModule } from '../markers/markers.module';
     SettingsModule,
     LibrariesModule,
     MarkersModule,
+    PlaylistsModule,
   ],
   controllers: [StreamingController, PlaybackController],
   providers: [

--- a/client/src/app/features/playlists/playlist-detail/playlist-detail.ts
+++ b/client/src/app/features/playlists/playlist-detail/playlist-detail.ts
@@ -256,10 +256,19 @@ export class PlaylistDetailComponent {
         undefined,
         item.episode?.id ?? undefined,
       );
-      this.patchItem(item.itemId, {
-        watched: state.completed,
-        progressPercent: state.completed ? 100 : 0,
-      });
+      // On an auto-remove playlist the server drops the row once it is watched
+      // (owner-scoped), so mirror that by removing it from the list instead of
+      // just flagging it.
+      if (state.completed && this.playlist()?.autoRemoveWatched && this.isOwner()) {
+        this.items.update((list) =>
+          list.filter((i) => i.itemId !== item.itemId),
+        );
+      } else {
+        this.patchItem(item.itemId, {
+          watched: state.completed,
+          progressPercent: state.completed ? 100 : 0,
+        });
+      }
     } catch {
       // Revert on failure (global interceptor surfaces the error).
       this.patchItem(item.itemId, {


### PR DESCRIPTION
## What

Wires up the `autoRemoveWatched` playlist setting, which until now was stored but never acted on.

When a user's `PlaybackState` transitions to **completed**, the matching item is dropped from every playlist that user **owns** and that has `autoRemoveWatched` on. The four completion paths are all covered:

- **progress beacon** (`updateState`) — only on the false→true transition, so it fires once per item, not on every heartbeat past 90%;
- **manual mark-watched** (`toggleWatched`);
- **season bulk mark** (`toggleSeasonWatched`) — removes the episodes actually marked;
- **series bulk mark** (`toggleSeriesWatched`) — removes the series' now-completed episodes.

## Design notes

- **Keyed on `(mediaId, episodeId)`** — a single watched episode clears without touching its siblings; a movie clears on the `episodeId IS NULL` row.
- **Owner-scoped** — auto-remove only touches playlists the watching user owns, so one member finishing an item never mutates a shared list for the others. (Shared-member semantics are intentionally out of scope for V1.)
- **Isolated from the playback write** — the hook runs through a helper that logs and swallows failures, so a playlist write can never break recording a watch.
- **Module wiring** — `StreamingModule` now imports `PlaylistsModule` (already exports `PlaylistsService`); no dependency cycle (the playlists graph doesn't reach streaming).
- **Frontend** — on the detail page, marking an item watched on an owned auto-remove playlist drops it from the list to mirror the server instead of just flagging it.

## Verification

- Backend `tsc --noEmit`: clean.
- Frontend production build: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)