### PR TITLE
fix(streaming): cut audio renditions on the fps-aware segment grid

### DIFF
--- a/backend/src/modules/streaming/transcoding/audio-only-args.spec.ts
+++ b/backend/src/modules/streaming/transcoding/audio-only-args.spec.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@nestjs/common';
 import { buildAudioOnlyFfmpegArgs } from './ffmpeg-args';
-import { segmentIndexToSeconds } from './constants';
+import { realSegmentSeconds, segmentIndexToSeconds } from './constants';
 
 describe('buildAudioOnlyFfmpegArgs', () => {
   const log = new Logger('test');
@@ -40,6 +40,33 @@ describe('buildAudioOnlyFfmpegArgs', () => {
     // Must match the video path's fps-aware seek, not the integer-grid value.
     expect(seek).toBe(String(segmentIndexToSeconds(5, fps)));
     expect(seek).not.toBe(String(segmentIndexToSeconds(5)));
+  });
+
+  it('cuts on the fps-aware grid so audio renditions stay aligned with the video IDRs', () => {
+    const fps = 24000 / 1001; // 23.976
+    const args = buildAudioOnlyFfmpegArgs(
+      {
+        inputPath: '/in.mkv',
+        outputDir: '/out',
+        audioStreamIndex: 0,
+        trustedStreamInfo: true,
+        sourceFps: fps,
+      },
+      log,
+    );
+    const hlsTime = args[args.indexOf('-hls_time') + 1];
+    // Must match the video IDR / EXTINF grid (3.003s), not the integer 3.0s
+    // setting — otherwise the audio tfdt drifts a whole segment mid-film.
+    expect(hlsTime).toBe(String(realSegmentSeconds(fps)));
+    expect(hlsTime).not.toBe('3');
+  });
+
+  it('cuts on the integer grid when fps is unknown (no regression)', () => {
+    const args = buildAudioOnlyFfmpegArgs(
+      { inputPath: '/in.mkv', outputDir: '/out', audioStreamIndex: 0 },
+      log,
+    );
+    expect(args[args.indexOf('-hls_time') + 1]).toBe('3');
   });
 
   it('emits no -ss for a fresh start', () => {

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -706,8 +706,13 @@ export function buildFfmpegArgs(
       ...(useTs ? [] : ['-movflags', '+cmaf']),
       '-f',
       'hls',
+      // Cut on the fps-aware grid (== the forced-IDR cadence and the playlist
+      // EXTINF), not the integer setting. On fractional-fps sources the audio
+      // renditions would otherwise be cut on the 3.0s grid while video IDRs land
+      // on 3.003s; the per-segment drift accumulates until the tfdt anchor snaps
+      // audio a whole segment late mid-film (sudden A/V desync).
       '-hls_time',
-      String(SEGMENT_DURATION),
+      String(realSeg),
       '-hls_list_size',
       '0',
       '-start_number',
@@ -808,7 +813,10 @@ export function buildAudioOnlyFfmpegArgs(
   } = opts;
   const segType = useTs ? 'mpegts' : 'fmp4';
   const segExt = useTs ? 'ts' : 'm4s';
-  const SEGMENT_DURATION = getSegmentDuration();
+  // fps-aware segment length so audio renditions cut on the same grid as the
+  // video IDRs / playlist EXTINF (see buildFfmpegArgs). Equals the integer
+  // setting for integer / unknown fps.
+  const realSeg = realSegmentSeconds(sourceFps);
 
   const args = ['-hide_banner', '-loglevel', 'warning'];
   if (trustedStreamInfo) {
@@ -846,7 +854,7 @@ export function buildAudioOnlyFfmpegArgs(
     '-f',
     'hls',
     '-hls_time',
-    String(SEGMENT_DURATION),
+    String(realSeg),
     '-hls_list_size',
     '0',
     '-start_number',


### PR DESCRIPTION
Closes #631.

## Problem

Audio-only HLS renditions were cut with `-hls_time` set to the **integer** segment setting (3.0s), while the video IDR cadence (`-force_key_frames`), the playlist EXTINF, and the fMP4 `tfdt` anchor all use the **fps-aware** real segment length (`realSegmentSeconds`, e.g. 3.003s for a 24000/1001 source).

On fractional-fps sources each audio segment drifts ~3ms against the video grid. The packaging-layer `tfdt` anchor (`timeline.ts` `rewriteSegmentTfdt`) has no video fragment for an audio-only rendition, so it *snaps* the run start to the nearest grid point. Once the accumulated drift exceeds half a segment (~25 min at 3s segments, ~50 min at the 6s admin setting) the snap flips a whole segment: a segment-long hole in the audio SourceBuffer, then audio playing 3–6s behind video for the rest of the film — a sudden mid-film A/V desync. This matches the open desync reports.

## Fix

Pass the fps-aware duration to `-hls_time` in the two builders that emit audio-only renditions (`buildFfmpegArgs` var_stream_map path + `buildAudioOnlyFfmpegArgs`), so audio is cut on the **same grid** as the video IDRs.

- **No-op for integer / unknown fps** (`realSegmentSeconds === setting`): all 16 golden-arg snapshots are unchanged.
- The remux path (`-copyts`, timeline-rewrite skipped) and the muxed single-stream path (audio cut at the video IDR anyway) are intentionally left untouched.

## Verification

- Added two unit tests: audio renditions cut on the 3.003s grid for 23.976fps; still 3.0s when fps is unknown (regression guard).
- `jest` on the transcoding arg specs: 28 passed, 16 snapshots unchanged.

Devices affected: Chrome/Firefox/Edge (Shaka), Android (ExoPlayer), Chromecast, Safari macOS, desktop app.

_Filed from the 2026-07-09 streaming-reliability audit._