### PR TITLE
fix(streaming): survive a direct-play read error instead of crashing

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -2061,7 +2061,19 @@ export class StreamingController {
       res.setHeader('Content-Type', contentType);
       res.setHeader('Content-Length', fileSize);
       res.setHeader('Accept-Ranges', 'bytes');
-      fs.createReadStream(absolutePath).pipe(res);
+      // pipe() does not forward source errors, so a read failure (EIO/ESTALE
+      // on a network mount, a file swapped mid-stream) would emit an
+      // unhandled 'error' and crash the process, killing every active
+      // playback. Close this one response instead.
+      const fullStream = fs.createReadStream(absolutePath);
+      fullStream.on('error', (err) => {
+        this.log.error(
+          `direct-play read error (mediaFileId=${mediaFileId}): ${err}`,
+        );
+        if (!res.headersSent) res.status(500).end();
+        else res.destroy();
+      });
+      fullStream.pipe(res);
       return;
     }
 
@@ -2082,6 +2094,14 @@ export class StreamingController {
     res.setHeader('Accept-Ranges', 'bytes');
     res.setHeader('Content-Length', chunkSize);
 
-    fs.createReadStream(absolutePath, { start, end }).pipe(res);
+    const rangeStream = fs.createReadStream(absolutePath, { start, end });
+    rangeStream.on('error', (err) => {
+      this.log.error(
+        `direct-play read error (mediaFileId=${mediaFileId}): ${err}`,
+      );
+      if (!res.headersSent) res.status(500).end();
+      else res.destroy();
+    });
+    rangeStream.pipe(res);
   }
 }


### PR DESCRIPTION
Closes #627.

## Problem

The direct-play `stream()` handler piped `fs.createReadStream(...)` into the Express response with **no `error` listener** on either path (full-file at ~L2064, Range at ~L2085). `Readable.pipe()` does not forward source errors, so a read failure — `EIO`/`ESTALE` on an NFS/SMB library mount, or a file swapped by the download-upgrade pipeline mid-stream — emits an unhandled `'error'` event that Node escalates to an `uncaughtException`. There is no global `uncaughtException` handler, so the **whole backend process exits, killing every active playback and transcode at once**.

## Fix

Attach an `error` listener to both read streams: log it, then send `500` if headers haven't been flushed yet, otherwise `res.destroy()`. A single client's read error now fails only that one request.

## Verification

- `tsc --noEmit` on the backend: clean.
- Behavioural: minimal, standard Node stream-error hardening; the happy path is byte-identical (listener only fires on a source read error, which previously crashed the process).

_Filed from the 2026-07-09 streaming-reliability audit._