### PR TITLE
fix(player): keep playback alive when a subtitle track fails

### DIFF
--- a/client/src/app/core/services/playback-engine/shaka-engine.ts
+++ b/client/src/app/core/services/playback-engine/shaka-engine.ts
@@ -69,6 +69,9 @@ export class ShakaEngine extends AbstractPlaybackEngine implements PlaybackEngin
         bufferingGoal: 30,
         rebufferingGoal: 1,
         bufferBehind: 60,
+        // A selected subtitle track whose segments 404 or fail to parse is
+        // dropped instead of aborting video and audio playback.
+        ignoreTextStreamFailures: true,
       },
     } as any);
 


### PR DESCRIPTION
Closes #628.

## Problem

The Shaka `streaming` config sets only `bufferingGoal`/`rebufferingGoal`/`bufferBehind`, leaving `ignoreTextStreamFailures` at its default `false`. When a selected subtitle track's segments 404 or fail to parse, Shaka escalates it to a `CRITICAL` error that aborts **video and audio** — a broken subtitle kills the whole film instead of just dropping captions.

## Fix

Set `streaming.ignoreTextStreamFailures: true` so a failing text stream is dropped and playback continues.

## Verification

- One-line, well-documented Shaka flag; the block is already cast `as any` and the property exists in the shipped shaka-player typings, so it compiles.
- Only changes behaviour when a text stream fails (previously fatal → now non-fatal); happy path unchanged.

Affects Chrome/Firefox/Edge, Safari macOS, and mobile web (the Shaka engine).

_Filed from the 2026-07-09 streaming-reliability audit._