### PR TITLE
fix(player): re-mint the stream token on recovery and quality-switch reload

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -2359,6 +2359,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       prewarmQuality,
       pos > 0 ? Math.floor(pos) : undefined,
     );
+    // Refresh the near-expiry stream token before rebuilding the play URL:
+    // it's baked into every segment URL and can't be swapped once the engine
+    // loads, so a token that lapsed mid-film would 401 every segment.
+    await this.authService.ensureStreamToken();
     const { url, mimeType } = this.buildPlayUrl({
       sid: this.playbackInfo.sessionId,
     });
@@ -3295,6 +3299,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     this.qualityManager.buildQualityOptions(pi);
 
     const mode = this.playbackMode();
+    // Refresh the near-expiry stream token before rebuilding the play URL:
+    // it's baked into every segment URL and can't be swapped once the engine
+    // loads, so a token that lapsed mid-film would 401 every segment.
+    await this.authService.ensureStreamToken();
     const { url, mimeType } = this.buildPlayUrl({ startTime: currentPos });
     await this.engine.load(url, currentPos, mimeType);
 


### PR DESCRIPTION
Closes #629.

## Problem

The stream token is baked into every segment URL at `engine.load()` time and can't be swapped mid-stream. `ensureStreamToken()` reuses the cached 12h token while it has >30 min of life left, so a token minted earlier in a session can lapse mid-film. Both reload paths — the lost-session recovery (`refreshSidAndReload`) and the user-initiated quality/audio switch (`doReloadStream`) — rebuilt the play URL **without re-minting**, so every segment 401'd and recovery looped straight to a terminal error card, unrecoverable without an app restart (native/TV hit hardest, since there the token is the sole auth carrier on segment requests).

## Fix

`await this.authService.ensureStreamToken()` before rebuilding the play URL in both paths. It's idempotent, single-flight and never throws (matches the 3 existing call sites), and the fresh token reaches the rebuilt URLs via the `streamToken()` signal.

## Verification

- `tsc --noEmit` on the client: clean.
- `ensureStreamToken()` re-mints once the cached token has <30 min left (negative at expiry), so the mid-film-expiry case now gets a fresh token; the happy path (token still fresh) is an idempotent no-op.

Affects Tizen, webOS, Android, iOS on long films.

_Filed from the 2026-07-09 streaming-reliability audit._