### PR TITLE
fix(player): guard Tizen AVPlay teardown by singleton ownership

### DIFF
--- a/client/src/app/core/services/playback-engine/tizen-engine.ts
+++ b/client/src/app/core/services/playback-engine/tizen-engine.ts
@@ -143,6 +143,16 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
     this.clearHandlers();
   }
 
+  /** Stop the shared AVPlay surface and drop the transparent-page class,
+   *  but only while this engine still owns the singleton. A stale load()
+   *  settling after a newer engine took over must not stop the newer
+   *  engine's playback. Mirrors the ownership guard in destroy(). */
+  private stopIfOwner(): void {
+    if (TizenEngine.activeEngine !== this) return;
+    try { webapis.avplay.stop(); } catch { /* ok */ }
+    document.documentElement.classList.remove('native-player-active');
+  }
+
   private applyDisplayRect() {
     if (!this.avObject) return;
     try {
@@ -199,8 +209,7 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
       const timer = setTimeout(() => {
         if (settled) return;
         settled = true;
-        try { webapis.avplay.stop(); } catch { /* ok */ }
-        document.documentElement.classList.remove('native-player-active');
+        this.stopIfOwner();
         const msg = 'AVPlay prepareAsync timeout (30s)';
         this.emit('error', { code: -1, message: msg, errorKey: 'player.playback_error' });
         reject(new Error(msg));
@@ -232,16 +241,14 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
             resolve();
           }),
           (err) => done(() => {
-            try { webapis.avplay.stop(); } catch { /* ok */ }
-            document.documentElement.classList.remove('native-player-active');
+            this.stopIfOwner();
             this.emit('error', { code: -1, message: 'AVPlay prepare failed: ' + String(err), errorKey: 'player.playback_error' });
             reject(new Error('AVPlay prepare failed: ' + String(err)));
           }),
         );
       } catch (e) {
         done(() => {
-          try { webapis.avplay.stop(); } catch { /* ok */ }
-          document.documentElement.classList.remove('native-player-active');
+          this.stopIfOwner();
           const msg = 'AVPlay prepareAsync threw: ' + (e instanceof Error ? e.message : String(e));
           this.emit('error', { code: -1, message: msg, errorKey: 'player.playback_error' });
           reject(new Error(msg));


### PR DESCRIPTION
Closes #625.

## Problem

AVPlay is a process-wide singleton and `prepareAsync` can stay pending up to 30s. The three `load()` failure paths — the 30s timeout, the `prepareAsync` error callback, and the synchronous `catch` — each unconditionally called `avplay.stop()` and stripped `html.native-player-active`. If a stale engine's load settles **after** it was destroyed and a newer engine took over the singleton, that late failure stops the newer engine's playback and hides its surface: a black screen on the TV.

## Fix

Route those three paths through a new `stopIfOwner()` helper that no-ops unless this engine still owns the singleton (`TizenEngine.activeEngine === this`) — the exact ownership check already used in `destroy()`. The stop-before-open at the top of `load()` is intentional (replacing the current media) and is left untouched.

## Verification

- `tsc --noEmit` on the client: clean.
- Behaviour-identical on every single-engine path (`activeEngine === this` holds during a normal own-load failure, so it still cleans up); the guard only blocks a *stale* instance. Cannot be exercised on-device here — Tizen requires the physical TV — but the change can only make teardown *more* conservative, never less.

_Filed from the 2026-07-09 streaming-reliability audit._