### PR TITLE
fix(streaming): size the encode to the crop, not the uncropped frame

### DIFF
--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.golden.spec.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.golden.spec.ts
@@ -1476,3 +1476,27 @@ describe('buildRemuxArgs / buildAudioOnlyFfmpegArgs — golden (characterization
     `);
   });
 });
+
+describe('buildFfmpegArgs — pillarbox crop output sizing', () => {
+  it('scales a pillarbox crop at the cropped width, not the uncropped source width', () => {
+    const args = buildFfmpegArgs(
+      opts({
+        hwAccel: 'qsv',
+        videoVariant: HEVC_SDR,
+        profile: profile(PROFILE_4K),
+        // 4:3 content pillarboxed inside a 3840x2160 container.
+        crop: { width: 2880, height: 2160, x: 480, y: 0 },
+        sourceWidth: 3840,
+        sourceHeight: 2160,
+      }),
+      silentLog,
+    );
+    const vf = args[args.indexOf('-vf') + 1];
+    // The encoder must scale the crop at its own 2880 width so the bitstream
+    // RESOLUTION and codec level match what the master playlist declares for
+    // this rung — not scale back up to the uncropped 3840 width (which
+    // over-declares the level and trips strict MSE decoders).
+    expect(vf).toContain('crop=2880:2160:480:0');
+    expect(vf).not.toContain('3840');
+  });
+});

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -351,9 +351,17 @@ export function buildFfmpegArgs(
   // playlist already advertises for this rung — display aspect stays stable
   // across the session even if the player re-parses the manifest. Resolved here
   // (ahead of the bitrate) so the HEVC Main-tier clamp below can use it.
+  // When an auto-crop trims the source frame the encoder scales the CROPPED
+  // picture, so the output size must follow the crop dimensions — otherwise a
+  // horizontal (pillarbox) crop scales back up to the uncropped width and the
+  // bitstream's RESOLUTION and codec level overshoot what the master playlist
+  // declares for this rung (the master already sizes from the crop). A
+  // letterbox crop keeps the source width, so its output width is unchanged.
+  const framedWidth = crop ? crop.width : sourceWidth;
+  const framedHeight = crop ? crop.height : sourceHeight;
   const outDims =
-    sourceWidth > 0 && sourceHeight > 0
-      ? profileResolution(profile, sourceWidth, sourceHeight)
+    framedWidth > 0 && framedHeight > 0
+      ? profileResolution(profile, framedWidth, framedHeight)
       : { width: profile.maxWidth, height: profile.maxHeight };
   const w = outDims.width;
   const h = outDims.height;


### PR DESCRIPTION
Closes #630.

## Problem

The master playlist derives each rung's `RESOLUTION` and CODECS **level** from the crop dimensions, while `buildFfmpegArgs` computed its output size (`outDims` → scale width + HEVC main-tier clamp) from the **uncropped** `sourceWidth`/`sourceHeight`. For a horizontal (pillarbox) crop the two diverge: a 4:3 title cropped to 2880×2160 inside a 3840×2160 container was cropped and then scaled **back up to 3840** wide → the bitstream's resolution and level overshoot the `avc1.*`/`hvc1.*` string and `RESOLUTION` the master declares. Strict-MSE clients (Safari) throw `MEDIA_ERR_DECODE`, iOS AVPlayer reinitialises the decoder, Cast Shaka rejects the variant (4032) — plus a silent ~1.8× upscale at the same rung bitrate.

## Fix

Compute the output size from the **crop** frame when a crop is active (`framedWidth`/`framedHeight`). Letterbox crops keep the source width, so their output is unchanged; only pillarbox crops converge onto the crop-based dims the master already advertises.

## Verification

- All 16 existing golden snapshots (incl. the letterbox `CROP_4K` case) are **unchanged** — the change is byte-identical for every non-pillarbox path.
- Added a pillarbox test: the 2880-wide crop now scales at `w=2880`; confirmed it fails on `main` (scales to `w=3840`) and passes with the fix.
- `tsc --noEmit` clean.

_Filed from the 2026-07-09 streaming-reliability audit._