### PR TITLE
fix(player): show an error card when a switch kills the mobile player

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -3233,6 +3233,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
    *  a second quick switch) must not run two getPlaybackInfo + load cycles at
    *  once — that races the engine and leaks a session. */
   private reloadingStream = false;
+  /** Set once doReloadStream reaches a successful engine.load(). Lets the
+   *  reloadStream catch tell a dead surface (failure before load) from a live
+   *  one (a later throw over already-playing video). */
+  private reloadReachedPlayback = false;
 
   /** Reload the stream (e.g. when toggling burn-in subtitles or switching
    *  audio). User-initiated, so re-arm the native recovery guard and serialise
@@ -3240,9 +3244,33 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   private async reloadStream() {
     if (!this.engine || this.reloadingStream) return;
     this.reloadingStream = true;
+    this.reloadReachedPlayback = false;
     this.engine.resetRecoveryGuard();
     try {
       await this.doReloadStream();
+    } catch (e) {
+      // Only the mobile ExoPlayer/AVPlayer engine is torn down before
+      // re-negotiating (NativePlayer.stop()), so a transient failure there
+      // (playback-info / engine.load) leaves a dead surface with the stall
+      // watchdog quiesced — surface a terminal card so the user has a way out.
+      // Every other engine keeps its previous source playing from buffer and
+      // self-heals via the 410 -> sessionExpired recovery (Shaka/webOS, and the
+      // desktop-mpv / Tizen surfaces, whose Capacitor stop is a no-op), and a
+      // throw after load() means video is already playing — none should card.
+      console.error('[Player] reloadStream failed:', e);
+      if (
+        this.isNativeEngine() &&
+        !this.isDesktopNative &&
+        !this.isTizenEngine() &&
+        !this.reloadReachedPlayback &&
+        !this.destroyed &&
+        !this.state.error()
+      ) {
+        this.state.setError(this.translate.instant('player.playback_error'), {
+          source: 'session',
+        });
+      }
+      throw e;
     } finally {
       this.reloadingStream = false;
     }
@@ -3305,6 +3333,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     await this.authService.ensureStreamToken();
     const { url, mimeType } = this.buildPlayUrl({ startTime: currentPos });
     await this.engine.load(url, currentPos, mimeType);
+    this.reloadReachedPlayback = true;
 
     this.qualityManager.applyQualityPreferenceAfterLoad(this.engine, mode);
     this.restorePlayState(wasPaused);


### PR DESCRIPTION
Closes #623.

## Problem

A quality/audio/subtitle switch runs `doReloadStream()`, which on the **mobile** ExoPlayer/AVPlayer engine calls `NativePlayer.stop()` and releases the backend session **before** re-negotiating (`getPlaybackInfo` + `engine.load`). A transient network failure there threw uncaught, leaving a dead black surface with the stall watchdog quiesced (state `paused`) and **no error card** — the user had no way out but to leave the player.

## Fix

Catch the failure in `reloadStream()` and surface the existing translated terminal card — but only when the surface was genuinely torn down and won't self-heal:

- **Gated to the mobile native engine** (`isNativeEngine() && !isDesktopNative && !isTizenEngine()`). Every other engine keeps its previous source playing from buffer and self-heals via the `410 → sessionExpired → recoverFromLostSession` path (Shaka/webOS, and the desktop-mpv / Tizen surfaces whose Capacitor `stop()` is a no-op), so carding them would flash a terminal overlay over still-playing video.
- A `reloadReachedPlayback` flag suppresses the card when the throw lands **after** a successful `engine.load()` (the new stream is already playing).
- The catch **rethrows**, so every caller's control flow is identical to `main` (where the throw already propagated through the try/finally).

Net effect: the card is **purely additive** for the one dead-mobile-surface case; behaviour on every other engine is byte-for-byte `main`.

## Review

Two adversarial review passes: the first rejected an unconditional card (regressed web/Shaka self-heal); this version was then caught over-broad on desktop-mpv/Tizen and narrowed to the mobile engine only. `tsc --noEmit` clean. Runtime behaviour on the mobile native path can't be exercised here (needs the app + an induced mid-switch network blip).

_Filed from the 2026-07-09 streaming-reliability audit._