### PR TITLE
fix(device-profile): gate Android Direct Play by the decoder's max resolution

### DIFF
--- a/client/android/app/src/main/java/media/fliks/app/VideoCapabilitiesPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/VideoCapabilitiesPlugin.java
@@ -10,7 +10,9 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -29,6 +31,10 @@ public class VideoCapabilitiesPlugin extends Plugin {
     @PluginMethod()
     public void getSupported(PluginCall call) {
         Set<String> codecs = new HashSet<>();
+        // codec key -> the most capable decoder's [maxWidth, maxHeight]. Gates
+        // Direct Play so a device whose HEVC/AV1 decoder tops out at 1080p
+        // doesn't advertise unbounded support and black-screen on a 4K source.
+        Map<String, int[]> maxRes = new HashMap<>();
         boolean hevcMain10 = false;
         boolean av1Main10 = false;
         try {
@@ -43,6 +49,17 @@ public class VideoCapabilitiesPlugin extends Plugin {
                         MediaCodecInfo.CodecCapabilities caps = info.getCapabilitiesForType(type);
                         if ("hevc".equals(key) && supportsMain10(caps, true)) hevcMain10 = true;
                         if ("av1".equals(key) && supportsMain10(caps, false)) av1Main10 = true;
+                        MediaCodecInfo.VideoCapabilities vc = caps.getVideoCapabilities();
+                        if (vc != null) {
+                            int w = vc.getSupportedWidths().getUpper();
+                            int h = vc.getSupportedHeights().getUpper();
+                            int[] cur = maxRes.get(key);
+                            // Keep the single most capable decoder (by area) so we
+                            // never report a width/height pair no one decoder does.
+                            if (cur == null || (long) w * h > (long) cur[0] * cur[1]) {
+                                maxRes.put(key, new int[] { w, h });
+                            }
+                        }
                     } catch (Throwable ignored) { /* per-codec best-effort */ }
                 }
             }
@@ -60,11 +77,22 @@ public class VideoCapabilitiesPlugin extends Plugin {
         containers.put("webm");
         containers.put("mkv");
 
+        // Per-codec max decodable resolution, so the backend refuses Direct
+        // Play of a source above the device's real decode ceiling.
+        JSObject resolutions = new JSObject();
+        for (Map.Entry<String, int[]> e : maxRes.entrySet()) {
+            JSObject wh = new JSObject();
+            wh.put("width", e.getValue()[0]);
+            wh.put("height", e.getValue()[1]);
+            resolutions.put(e.getKey(), wh);
+        }
+
         JSObject result = new JSObject();
         result.put("videoCodecs", arr);
         result.put("hevcMain10", hevcMain10);
         result.put("av1Main10", av1Main10);
         result.put("containers", containers);
+        result.put("resolutions", resolutions);
         call.resolve(result);
     }
 

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -29,6 +29,10 @@ interface NativeVideoCaps {
   hevcMain10: boolean;
   av1Main10: boolean;
   containers: string[];
+  /** Per-codec max decodable resolution (codec key → {width, height}) from the
+   *  device's MediaCodec VideoCapabilities. Absent on platforms whose plugin
+   *  doesn't report it, leaving the codec unconstrained as before. */
+  resolutions?: Record<string, { width: number; height: number }>;
 }
 interface VideoCapabilitiesPlugin {
   getSupported(): Promise<NativeVideoCaps>;
@@ -324,6 +328,7 @@ export class BrowserDeviceProfileService {
             codec: 'h264',
             profiles: ['baseline', 'constrained baseline', 'main', 'high'],
             maxBitDepth: 8,
+            ...this.nativeResCondition(nv, 'h264'),
           });
         } else if (c === 'hevc') {
           videoCodecs.push('hevc', 'h265', 'hvc1', 'hev1');
@@ -331,6 +336,7 @@ export class BrowserDeviceProfileService {
             codec: 'hevc',
             profiles: nv.hevcMain10 ? ['main', 'main 10'] : ['main'],
             maxBitDepth: nv.hevcMain10 ? 10 : 8,
+            ...this.nativeResCondition(nv, 'hevc'),
           });
         } else if (c === 'av1') {
           videoCodecs.push('av1');
@@ -338,6 +344,7 @@ export class BrowserDeviceProfileService {
             codec: 'av1',
             profiles: nv.av1Main10 ? ['main', 'high'] : ['main'],
             maxBitDepth: nv.av1Main10 ? 10 : 8,
+            ...this.nativeResCondition(nv, 'av1'),
           });
         } else {
           videoCodecs.push(c); // vp9 / vp8 — no fine-grained conditions
@@ -525,6 +532,19 @@ export class BrowserDeviceProfileService {
     const full = codec ? `${mime}; codecs="${codec}"` : mime;
     if (hasMSE) return MediaSource.isTypeSupported(full);
     return !!video.canPlayType(full);
+  }
+
+  /** Turn the native plugin's per-codec decode ceiling into a codec-condition
+   *  fragment. Empty when the plugin didn't report a resolution for this codec,
+   *  leaving it unconstrained (the backend then Direct Plays any resolution). */
+  private nativeResCondition(
+    nv: NativeVideoCaps,
+    key: string,
+  ): { maxWidth?: number; maxHeight?: number } {
+    const r = nv.resolutions?.[key];
+    return r && r.width > 0 && r.height > 0
+      ? { maxWidth: r.width, maxHeight: r.height }
+      : {};
   }
 
   /** Probe max H.264 level by testing progressively higher levels */


### PR DESCRIPTION
Closes #626.

## Problem

`VideoCapabilitiesPlugin` (Android native) advertised every MediaCodec decoder with **no resolution ceiling**. A device whose HEVC/AV1/H.264 decoder tops out at 1080p still claimed unbounded support, so a 4K source Direct Played onto a decoder that can't handle it → **black screen / decode failure** on Android phones and Android TV.

## Fix

Client-only — the backend already has the enforcement:

1. **Native** (`VideoCapabilitiesPlugin.java`): for each decoder, read `CodecCapabilities.getVideoCapabilities()` and track the most capable decoder's max width×height per codec (by area, so we never report a width/height pair no single decoder does). Report it as a new optional `resolutions` map.
2. **Device profile** (`browser-device-profile.service.ts`): set `maxWidth`/`maxHeight` on the h264/hevc/av1 codec conditions from that map.
3. **Backend**: no change — `tryDirectPlay` already enforces `cond.maxWidth`/`maxHeight` (stream-builder.service.ts:1007-1018), so a source above the ceiling now fails Direct Play and falls back to transcode.

The `resolutions` field is optional: platforms whose plugin doesn't report it (iOS) leave the codec unconstrained, exactly as today. `h264`/`hevc`/`av1` are gated; `vp9`/`vp8` keep today's behaviour (no condition).

## Verification

- `tsc --noEmit` on the client: clean.
- The Java can't be compiled/exercised in this environment (JDK17 + Android SDK) — **@Clément will validate on-device**: confirm a 4K HEVC/AV1 source on a 1080p-only device now transcodes (was black), and that a genuinely 4K-capable device still Direct Plays 4K.

### Possible follow-up
Prefer hardware decoders' limits over software ones (a SW fallback decoder can advertise a very large size); out of scope for the black-screen fix since any advertised size is at least nominally decodable, but worth a look if a device routes 4K to a stuttering SW path.

_Filed from the 2026-07-09 streaming-reliability audit._