### PR TITLE
fix(streaming): don't copy non-fMP4 audio codecs on the transcode path

### DIFF
--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -537,8 +537,15 @@ export class StreamBuilderService {
     const srcChannels = source.audioChannels ?? 2;
     const srcCodec = (source.audioCodec ?? '').toLowerCase();
     const srcCap = audioChannelCap(profile, srcCodec);
+    // Copy the source audio only when it can live in an fMP4 segment. Without
+    // this gate a profile that claims mp3/alac would copy an MP3/ALAC track
+    // into muxed fMP4 whose CODECS string can't be declared, so MSE rejects the
+    // init segment (Shaka 3014/3015) — a black player instead of playback.
+    // Mirrors the DirectStream path's guard.
     const srcCompatible =
-      directPlayResult.audioSupported && srcChannels <= srcCap;
+      directPlayResult.audioSupported &&
+      srcChannels <= srcCap &&
+      FMP4_COMPATIBLE_AUDIO.has(srcCodec);
     const surroundCodec = profileAudioCodecs.includes('eac3')
       ? 'eac3'
       : profileAudioCodecs.includes('ac3')


### PR DESCRIPTION
Closes #640.

## Problem

On the full-transcode path, the audio-copy decision was `directPlayResult.audioSupported && srcChannels <= srcCap` — with **no fMP4-container check**, unlike the DirectStream path which gates on `FMP4_COMPATIBLE_AUDIO` (stream-builder.service.ts:419-421). A codec like **MP3/ALAC** can't be declared in an fMP4 `CODECS` string, so:

- A profile that claims `mp3` (Firefox probes `mp4a.6B/69` positively; webOS claims it unconditionally) or `alac` (Safari) made ffmpeg `-c:a copy` mux MP3/ALAC into fMP4 segments.
- `audioCodecString('mp3'|'alac')` is null → the variant `CODECS` declared video only while the segment carried a muxed audio track → MSE rejects the init segment (Shaka **3014/3015**): black player / error card, or at best video with no audio.

## Fix

Add `&& FMP4_COMPATIBLE_AUDIO.has(srcCodec)` to the transcode-path `srcCompatible` copy condition, mirroring the remux path. Non-fMP4-safe codecs now transcode to AAC/E-AC-3 instead of being copied.

## Verification

- `tsc --noEmit` clean.
- Copy still happens for the fMP4-safe set (`aac/ac3/eac3/opus/flac`) — no change for the common case; only mp3/alac (and any other non-listed codec) now transcode instead of producing a broken segment.

_Filed from the 2026-07-09 streaming-reliability audit._