### PR TITLE
fix(player): don't let lost-session recovery race a user reload

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -2551,6 +2551,16 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   private async recoverFromLostSession(): Promise<void> {
     if (this.destroyed) return;
     if (this.recoveringFromLostSession) return;
+    // A user reload (quality / audio switch, episode swap) re-mints the session
+    // and reloads the engine itself; a 410 or a heartbeat sessionLost inside
+    // that window is expected, and recovering here would race a second
+    // getPlaybackInfo + engine.load onto the same engine. Clear any recovery
+    // veil we were holding across a backoff — the in-flight reload now owns the
+    // session — so it isn't leaked true after the reload settles.
+    if (this.reloadingStream) {
+      this.state.setRecovering(false);
+      return;
+    }
     if (this.recoverRetryTimer) return; // a backoff retry is already queued
     if (this.recoverAttempts >= this.maxRecoverAttempts) {
       // Exhausted recovery — surface a terminal error card instead of


### PR DESCRIPTION
Closes #632.

## Problem

`recoverFromLostSession()` guarded on `recoveringFromLostSession`, a queued backoff, the attempt cap, cast and engine — but **not** `reloadingStream`, whereas `checkStall()` already bails on both. The two other recovery triggers — the Shaka `sessionExpired` event and the heartbeat `sessionLost` branch — could therefore fire during a user-initiated reload (quality/audio switch, episode swap):

1. `doReloadStream` stops the old session; the in-flight segment 410s → `sessionExpired`, and the 10s heartbeat PUTs the now-dead sid → `sessionLost`.
2. Recovery starts concurrently: two `getPlaybackInfo` mint two LiveSessions, two `engine.load` interleave (the interrupted one rejects with Shaka 7000, feeding the recovery backoff → another reload 2s later), and `this.playbackInfo` settles on whichever resolved last — so heartbeats can keep an orphaned session warm while the actually-playing session idles out and dies mid-film.

## Fix

Add `if (this.reloadingStream) return;` to `recoverFromLostSession`'s entry guards, matching `checkStall`'s existing dual-flag guard. Both reload paths always reset `reloadingStream` in `finally`, so recovery is never permanently suppressed; if the reload itself fails, a fresh 410 / `sessionLost` / stall re-triggers recovery.

**Mitigation for the backoff edge** (found by adversarial review): the failure branch holds the recovering veil across a 2s backoff. If the queued retry fires while a reload now owns `reloadingStream`, bailing without clearing would leak `state.recovering = true` (masking a later fatal error as an endless spinner). So the guard also calls `setRecovering(false)` — the in-flight reload owns the session and drives its own loading/error state.

## Verification

- `tsc --noEmit` clean.
- No `player.spec.ts` harness exists; correctness rests on parity with the existing `checkStall` guard plus the veil-clear mitigation.

_Filed from the 2026-07-09 streaming-reliability audit._