### PR TITLE
fix(cast): preserve pause state across an auto-recovery reload

### DIFF
--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -430,7 +430,7 @@ export class CastPlayerService {
    * audio/burn-in context wouldn't be picked up by an existing session
    * (transcoding.service only auto-replaces on quality change).
    */
-  async reloadCastStream(positionOverride?: number) {
+  async reloadCastStream(positionOverride?: number, autoplay = true) {
     const mfId = this.mediaFileId();
     if (!mfId) return;
 
@@ -455,7 +455,7 @@ export class CastPlayerService {
       this.authService.getCastInfo(),
     ]);
 
-    await this.dispatchLoad(mfId, pi, currentPos, transcodeQuality, castInfo);
+    await this.dispatchLoad(mfId, pi, currentPos, transcodeQuality, castInfo, autoplay);
   }
 
   /**
@@ -468,6 +468,7 @@ export class CastPlayerService {
     currentPos: number,
     transcodeQuality: string | undefined,
     castInfo: { token: string; streamBaseUrl: string },
+    autoplay: boolean,
   ) {
     const castMode: 'direct' | 'remux' | 'transcode' =
       pi.playMethod === 'DirectPlay' ? 'direct' :
@@ -549,6 +550,7 @@ export class CastPlayerService {
       activeSubtitleTrackId,
       mediaId: this.mediaId(),
       episodeId: this.episodeId(),
+      autoplay,
     });
   }
 
@@ -622,7 +624,11 @@ export class CastPlayerService {
       // Backend lost the session (its keep-alive lapsed, a restart, …).
       // The receiver can't self-heal a session_expired, so re-issue
       // playback-info and reload the stream with a fresh sid.
-      if (response?.sessionLost) await this.reloadCastStream(pos);
+      // Preserve the receiver's pause state across an auto-recovery reload — a
+      // paused cast whose session was reaped (missed heartbeats) must not be
+      // force-resumed by the reload's default autoplay.
+      if (response?.sessionLost)
+        await this.reloadCastStream(pos, !this.cast.isPaused());
     } catch { /* ignore */ }
   }
 
@@ -776,6 +782,6 @@ export class CastPlayerService {
       activeAudioStreamIndex: audioIndex,
     });
 
-    await this.dispatchLoad(opts.mediaFileId, pi, startTime, activeQualityId, castInfo);
+    await this.dispatchLoad(opts.mediaFileId, pi, startTime, activeQualityId, castInfo, true);
   }
 }

--- a/client/src/app/core/services/cast.service.ts
+++ b/client/src/app/core/services/cast.service.ts
@@ -43,6 +43,10 @@ export interface CastMediaInfo {
   subtitle?: string;
   posterUrl?: string;
   currentTime?: number;
+  /** When false, the receiver loads the media paused; defaults to autoplay.
+   *  Recovery reloads pass the receiver's current pause state so a paused cast
+   *  isn't force-resumed. */
+  autoplay?: boolean;
   subtitles?: { url: string; language: string; label: string }[];
   activeSubtitleTrackId?: number;
   /**
@@ -406,7 +410,7 @@ export class CastService implements OnDestroy {
 
     const request = new chrome.cast.media.LoadRequest(mediaInfo);
     request.currentTime = info.currentTime ?? 0;
-    request.autoplay = true;
+    request.autoplay = info.autoplay ?? true;
     if (info.activeSubtitleTrackId) {
       request.activeTrackIds = [info.activeSubtitleTrackId];
     }
@@ -414,7 +418,7 @@ export class CastService implements OnDestroy {
     try {
       await this.session.loadMedia(request);
       this.mediaTitle.set(info.title);
-      this.isPaused.set(false);
+      this.isPaused.set(info.autoplay === false);
       if (info.activeSubtitleTrackId) {
         setTimeout(() => this.setActiveSubtitle(info.activeSubtitleTrackId!), 1500);
       }


### PR DESCRIPTION
Closes #633.

## Problem

While a cast is **paused** there's no segment traffic keeping the backend `LiveSession` alive, so the only keep-alive is the sender's 10s heartbeat. If it lags past the 30s session TTL — a background tab throttled to 1 timer/min, a closed laptop lid, or a backend restart — the next heartbeat returns `sessionLost` and the client auto-reloads via `reloadCastStream`. That reload's `LoadRequest` **hard-coded `autoplay = true`**, so a deliberately paused TV spontaneously resumed playing.

## Fix

Thread an `autoplay` flag through `dispatchLoad` → `cast.loadMedia` → the `LoadRequest`, and on the heartbeat `sessionLost` recovery pass the receiver's current pause state (`!this.cast.isPaused()`). Initial casts (`quickStart`) and user-initiated reloads keep `autoplay = true`, so only the automatic keep-alive recovery of a *paused* session changes behaviour.

**Scope note** (from adversarial review): the auditor's patch also changed the `recoverFromCastError` (fatal-error) path to read `isPaused()`, but that signal is unreliable right after the receiver's `ERROR → IDLE` teardown (it can collapse to its `?? true` fallback). That site is intentionally **left at the default `autoplay = true`** here — the fixed vector is the heartbeat-`sessionLost` auto-reload, which reads the signal on a healthy tick.

## Verification

- `tsc --noEmit` clean.
- Web sender only (the LoadRequest path); native cast unaffected.

_Filed from the 2026-07-09 streaming-reliability audit._