### PR TITLE
fix(streaming): run the HW-crash CPU fallback for non-blocking spawns too

### DIFF
--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -454,7 +454,29 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         ctx,
       ),
     );
-    if (skipVerify) return session;
+    if (skipVerify) {
+      // Return without blocking the caller on seg-0, but still run the
+      // HW-crash → CPU fallback in the BACKGROUND. A HW encoder that crashes on
+      // the first frame otherwise leaves a 0-byte init.mp4 + a dead session in
+      // the map, and no other path re-spawns it on CPU — every later init/seg
+      // request then serves the 0-byte stub as a retryable 503 forever, so the
+      // title never plays. The fallback swaps a healthy CPU session into the map
+      // under the same key; subsequent requests pick it up.
+      void this.verifyHwAccelOrFallback(
+        session,
+        key,
+        mediaFileId,
+        quality,
+        absolutePath,
+        session.cachePath,
+        requestedSegment,
+        ctx,
+      ).catch(() => {
+        /* background safety net — a failure here just leaves the existing
+           transient-503 behaviour, never worse */
+      });
+      return session;
+    }
     return this.verifyHwAccelOrFallback(
       session,
       key,
@@ -657,6 +679,12 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         ctx,
       );
       this.applyContext(cpuSession, ctx);
+      // Carry the crashed session's identity forward so live-session cleanup
+      // can reap this fallback on the normal grace window; without it an
+      // abandoned fallback (viewer left before any segment request) would run
+      // to EOF unattended before fallbackIdleCleanup reaps it.
+      cpuSession.baseProfileHash = session.baseProfileHash;
+      cpuSession.variant = session.variant;
       this.sessions.set(key, cpuSession);
       return cpuSession;
     });


### PR DESCRIPTION
Closes #637.

## Problem

The prewarm transcode spawn (`streaming.controller.ts` prewarm) and the audio-route video spawn both passed `skipVerify=true`, which made `getOrCreateSession` **skip `verifyHwAccelOrFallback` entirely**. On a HW-transcode host, if the encoder crashes on the first frame of a title it leaves a **0-byte `init.mp4` + a dead session** in the map. `ffmpeg` writes the init at muxer open and only fills the moov with the first fragment, so the stub persists. Every later init/segment request then takes the fast path, serves the 0-byte stub, and returns a retryable **503 forever** — nothing re-spawns the session on CPU, so the title is permanently unplayable (pressing play again just recreates the stub).

## Fix

Make `skipVerify` mean **"don't *await* verify"** rather than **"never verify"**: fire `verifyHwAccelOrFallback` in the **background** (`void … .catch(…)`) for those spawns.

- The prewarm is fire-and-forget (both call sites use `void`), and the audio route already returned the same (possibly-dead) session for the current request — so **latency is unchanged**.
- On healthy HW (`crashed === false`) and CPU-only hosts (`detectedHwAccel === 'none'`) the background verify is a **no-op**.
- On the crash path, verify cleans the stub and swaps a healthy **CPU** session into the map under the same key; subsequent requests pick it up. It carries the crashed session's `baseProfileHash`/`variant` so an *abandoned* fallback is reaped on the normal grace window rather than running to EOF.

## Review

Adversarial regression review — verdict **SAFE-TO-MERGE**. Checked: no double-ffmpeg/orphan (the `sessions.get(key) !== session` identity guard + shared `withLock` serialize spawns), no deadlock (verify fires after the creation lock is released and awaits `session.ready` before re-acquiring it), stale-reference on the audio route is identical to prior behaviour (transient self-healing 503), and no new unhandled rejection/leak. The `baseProfileHash` carry-forward addresses the one nit the review raised.

## Verification

- `tsc --noEmit` clean.
- The crash path itself needs a HW host whose encoder crashes on frame 1 (can't be reproduced here); the healthy path is a verified no-op.

_Filed from the 2026-07-09 streaming-reliability audit._