### PR TITLE
fix(player): don't let the stall watchdog kill a legit post-seek respawn

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -293,6 +293,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   private lastProgressPos = 0;
   private lastProgressAt = 0;
   private readonly stallTimeoutMs = 15_000;
+  // A backward seek can trigger a 10-30s backend respawn (awaitSeekUnlock's
+  // ceiling) with a frozen-but-healthy playhead; widen the window right after.
+  private lastSeekAt = 0;
+  private readonly seekStallGraceMs = 32_000;
 
   // ── Template-facing signal aliases (delegate to services) ──
   readonly loading = this.state.loading;
@@ -1701,6 +1705,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       // until `awaitSeekUnlock` lets the engine resume driving it.
       this.state.seekLocked.set(true);
       this.state.currentTime.set(t);
+      this.lastSeekAt = Date.now();
       void this.awaitSeekUnlock(t);
     }
     // Suppress auto-skip for 2s after a manual seek so the user can step back
@@ -2532,7 +2537,11 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       }
       return;
     }
-    if (Date.now() - this.lastProgressAt >= this.stallTimeoutMs) {
+    const timeout =
+      Date.now() - this.lastSeekAt < this.seekStallGraceMs
+        ? this.seekStallGraceMs
+        : this.stallTimeoutMs;
+    if (Date.now() - this.lastProgressAt >= timeout) {
       this.resetStallWatchdog();
       void this.recoverFromLostSession();
     }


### PR DESCRIPTION
Closes #634.

## Problem
`checkStall` already bails during initial load (`loading()`) and quality switches (`reloadingStream`), but not during a **backward-seek respawn**: a seek outside the cached range triggers a backend ffmpeg respawn that can take 10-30s (`awaitSeekUnlock`'s convergence ceiling is 30s) with a frozen-but-healthy playhead. The 15s watchdog fired inside that window, killed the encode seconds before it delivered, and the fresh encode needed the same wait → 3 strikes → terminal error card on a stream that would have played.

## Fix
Stamp `lastSeekAt` on each seek and use a 32s stall grace for a bounded window after it, reverting to the fast 15s recovery for mid-playback wedges. It's **time-based, not lock-based** — the deferred design gated on `seekLocked`, which stays stuck `true` after a rejected native/Tizen seek and would disable the watchdog for the whole session; a timestamp self-clears.

## Verification
- `tsc` green. Logic: no recent seek → 15s (unchanged); within 32s of a seek → 32s grace covers the respawn; a genuine wedge right after a seek recovers at 32s instead of 15s (rare, acceptable).

_Filed from the 2026-07-09 streaming-reliability audit._