### PR TITLE
fix(player): cap Auto-ABR rungs to the player element size

### DIFF
--- a/client/src/app/core/services/quality-manager.service.ts
+++ b/client/src/app/core/services/quality-manager.service.ts
@@ -203,6 +203,9 @@ export class QualityManagerService {
             switchInterval: 5,              // Re-evaluate every 5s (default: 8)
             bandwidthUpgradeTarget: 0.7,    // Upgrade at 70% headroom (default: 0.85 = more conservative)
             bandwidthDowngradeTarget: 0.95, // Downgrade only when nearly saturated
+            // Don't fetch a rung larger than the player element (DPR-aware):
+            // a 4K rung on a 1080p view only wastes bandwidth and stalls slow links.
+            restrictToElementSize: true,
             advanced: {
               // Require 5 MB of observed data before ABR makes decisions.
               // FFmpeg transcode startup makes the first segment arrive 10-30s


### PR DESCRIPTION
Partial mitigation of #635 (kept open for the bandwidth-tuning core).

## What
Enable Shaka `abr.restrictToElementSize` so Auto mode never selects a variant larger than the video element needs. On a sub-4K view (windowed desktop, 1080p laptop, iPad) it stops picking the 4K rung — pure wasted bandwidth that makes slow links stall. DPR-aware, so a retina panel still gets the resolution it can actually display; a genuine 4K fullscreen display is unaffected.

## What this deliberately does NOT touch
The three tuned ABR knobs (`defaultBandwidthEstimate: 100Mbps`, `minTotalBytes: 5MB`, `slowHalfLife: 30s`) are load-bearing — they counter the transcode cold-start (first 4K/HDR segment arrives 10-30s late) where Shaka's defaults would misread the slow first segment as network saturation and downswitch before playback starts. On a live-transcode stream the client's *measured* throughput tracks the ffmpeg production rate, not the real link, so "warmup-slow" and "network-slow" are indistinguishable client-side. Retuning them safely needs real slow-**and**-fast-network A/B measurement, so it's left for a dedicated pass rather than guessed at here.

## Verification
- `tsc` green. `restrictToElementSize` is a documented Shaka 5.0.9 AbrConfiguration field; native/Tizen/webOS engines (own ABR) ignore the Shaka-only abr config.

_Filed from the 2026-07-09 streaming-reliability audit._