### PR TITLE
feat(streaming): tonemap Dolby Vision Profile 5 correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 FROM ubuntu:24.04 AS libplacebo-dovi-build
 ARG LIBPLACEBO_TAG=v6.338.2
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates curl git build-essential pkg-config \
-    meson ninja-build glslang-dev libvulkan-dev liblcms2-dev python3-mako \
+    ca-certificates curl git build-essential pkg-config libssl-dev \
+    meson ninja-build libshaderc-dev libvulkan-dev liblcms2-dev python3-mako python3-jinja2 \
   && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal \
   && . "$HOME/.cargo/env" \
   && cargo install cargo-c \
@@ -52,7 +52,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
        https://code.videolan.org/videolan/libplacebo.git /tmp/libplacebo \
   && cd /tmp/libplacebo \
   && PKG_CONFIG_PATH=/opt/dvlibs/lib/pkgconfig meson setup build \
-       -Dlibdovi=enabled -Dvulkan=enabled -Dglslang=enabled \
+       -Dlibdovi=enabled -Dvulkan=enabled -Dshaderc=enabled -Dglslang=disabled \
+       -Dopengl=disabled -Dd3d11=disabled \
        -Ddemos=false -Dtests=false --buildtype=release --prefix=/opt/plbo --libdir=lib \
   && ninja -C build && ninja -C build install \
   && rm -rf /var/lib/apt/lists/* "$HOME/.cargo/registry" "$HOME/.rustup" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,33 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && cargo install subtile-ocr --version 0.2.6 --root /opt/subtile-ocr \
   && rm -rf /var/lib/apt/lists/* "$HOME/.cargo/registry" "$HOME/.rustup"
 
+# --- Stage 2c: Build libplacebo with Dolby Vision (libdovi) ---
+# The apt libplacebo isn't built with libdovi, so ffmpeg's `apply_dolbyvision`
+# is a silent no-op there and a DV Profile 5 source renders wrong. Rebuild the
+# SAME libplacebo version (identical soname → drop-in for the apt ffmpeg) with
+# libdovi so P5 can be RPU-tonemapped. Pin LIBPLACEBO_TAG to the runtime's apt
+# libplacebo version (check `apt-cache policy libplacebo338`) so the ABI matches.
+FROM ubuntu:24.04 AS libplacebo-dovi-build
+ARG LIBPLACEBO_TAG=v6.338.2
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl git build-essential pkg-config \
+    meson ninja-build glslang-dev libvulkan-dev liblcms2-dev python3-mako \
+  && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal \
+  && . "$HOME/.cargo/env" \
+  && cargo install cargo-c \
+  && git clone --depth 1 https://github.com/quietvoid/dovi_tool /tmp/dovi_tool \
+  && cd /tmp/dovi_tool/dolby_vision \
+  && cargo cinstall --release --prefix=/opt/dvlibs --libdir=/opt/dvlibs/lib \
+  && git clone --depth 1 --branch "$LIBPLACEBO_TAG" \
+       https://code.videolan.org/videolan/libplacebo.git /tmp/libplacebo \
+  && cd /tmp/libplacebo \
+  && PKG_CONFIG_PATH=/opt/dvlibs/lib/pkgconfig meson setup build \
+       -Dlibdovi=enabled -Dvulkan=enabled -Dglslang=enabled \
+       -Ddemos=false -Dtests=false --buildtype=release --prefix=/opt/plbo --libdir=lib \
+  && ninja -C build && ninja -C build install \
+  && rm -rf /var/lib/apt/lists/* "$HOME/.cargo/registry" "$HOME/.rustup" \
+       /tmp/dovi_tool /tmp/libplacebo
+
 # --- Stage 3: Production runtime ---
 FROM ubuntu:24.04
 
@@ -72,6 +99,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
          intel-opencl-icd \
          libmfx-gen1.2 \
          libvpl2 \
+         libvulkan1 \
+         mesa-vulkan-drivers \
          vainfo; \
      fi \
   && python3 -m pip install --no-cache-dir --break-system-packages ffsubsync pgsrip \
@@ -85,6 +114,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # VobSub OCR binary (links against the tesseract/leptonica installed above).
 COPY --from=vobsub-ocr-build /opt/subtile-ocr/bin/subtile-ocr /usr/local/bin/subtile-ocr
+
+# libdovi + the libdovi-enabled libplacebo, dropped in over the apt libplacebo
+# so the apt ffmpeg can RPU-tonemap DV Profile 5. amd64 only — it's paired with
+# the Intel Vulkan stack above; arm64 keeps the stock libplacebo (the DV probe
+# fails closed there and P5 falls back to the standard transcode).
+COPY --from=libplacebo-dovi-build /opt/dvlibs/lib/ /tmp/dvlibs/
+COPY --from=libplacebo-dovi-build /opt/plbo/lib/ /tmp/dvlibs/
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+      cp -a /tmp/dvlibs/libdovi.so* /usr/lib/x86_64-linux-gnu/ \
+      && cp -a /tmp/dvlibs/libplacebo.so* /usr/lib/x86_64-linux-gnu/ \
+      && ldconfig; \
+    fi \
+  && rm -rf /tmp/dvlibs
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
          libmfx-gen1.2 \
          libvpl2 \
          libvulkan1 \
+         libshaderc1 \
          mesa-vulkan-drivers \
          vainfo; \
      fi \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,3 +1,30 @@
+# --- Build libplacebo with Dolby Vision (libdovi) ---
+# The apt libplacebo isn't built with libdovi, so ffmpeg's apply_dolbyvision is
+# a no-op and DV Profile 5 renders wrong. Rebuild the same libplacebo version
+# (identical soname → drop-in for the apt ffmpeg) with libdovi. Keep
+# LIBPLACEBO_TAG in sync with the runtime's apt libplacebo (apt-cache policy
+# libplacebo338) and with the production Dockerfile.
+FROM ubuntu:24.04 AS libplacebo-dovi-build
+ARG LIBPLACEBO_TAG=v6.338.2
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl git build-essential pkg-config \
+    meson ninja-build glslang-dev libvulkan-dev liblcms2-dev python3-mako \
+  && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal \
+  && . "$HOME/.cargo/env" \
+  && cargo install cargo-c \
+  && git clone --depth 1 https://github.com/quietvoid/dovi_tool /tmp/dovi_tool \
+  && cd /tmp/dovi_tool/dolby_vision \
+  && cargo cinstall --release --prefix=/opt/dvlibs --libdir=/opt/dvlibs/lib \
+  && git clone --depth 1 --branch "$LIBPLACEBO_TAG" \
+       https://code.videolan.org/videolan/libplacebo.git /tmp/libplacebo \
+  && cd /tmp/libplacebo \
+  && PKG_CONFIG_PATH=/opt/dvlibs/lib/pkgconfig meson setup build \
+       -Dlibdovi=enabled -Dvulkan=enabled -Dglslang=enabled \
+       -Ddemos=false -Dtests=false --buildtype=release --prefix=/opt/plbo --libdir=lib \
+  && ninja -C build && ninja -C build install \
+  && rm -rf /var/lib/apt/lists/* "$HOME/.cargo/registry" "$HOME/.rustup" \
+       /tmp/dovi_tool /tmp/libplacebo
+
 FROM ubuntu:24.04
 
 # Install Node.js 24
@@ -23,6 +50,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   intel-opencl-icd \
   libmfx-gen1.2 \
   libvpl2 \
+  libvulkan1 \
+  mesa-vulkan-drivers \
   vainfo \
   wget \
   ca-certificates \
@@ -35,6 +64,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && apt-get purge -y wget gcc python3-dev libc6-dev \
   && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/*
+
+# libdovi + the libdovi-enabled libplacebo, dropped in over the apt libplacebo
+# so ffmpeg can RPU-tonemap DV Profile 5 (the DV probe stays disabled otherwise).
+COPY --from=libplacebo-dovi-build /opt/dvlibs/lib/ /tmp/dvlibs/
+COPY --from=libplacebo-dovi-build /opt/plbo/lib/ /tmp/dvlibs/
+RUN cp -a /tmp/dvlibs/libdovi.so* /usr/lib/x86_64-linux-gnu/ \
+  && cp -a /tmp/dvlibs/libplacebo.so* /usr/lib/x86_64-linux-gnu/ \
+  && ldconfig \
+  && rm -rf /tmp/dvlibs
 
 WORKDIR /app
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libmfx-gen1.2 \
   libvpl2 \
   libvulkan1 \
+  libshaderc1 \
   mesa-vulkan-drivers \
   vainfo \
   wget \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,8 +7,8 @@
 FROM ubuntu:24.04 AS libplacebo-dovi-build
 ARG LIBPLACEBO_TAG=v6.338.2
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates curl git build-essential pkg-config \
-    meson ninja-build glslang-dev libvulkan-dev liblcms2-dev python3-mako \
+    ca-certificates curl git build-essential pkg-config libssl-dev \
+    meson ninja-build libshaderc-dev libvulkan-dev liblcms2-dev python3-mako python3-jinja2 \
   && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal \
   && . "$HOME/.cargo/env" \
   && cargo install cargo-c \
@@ -19,7 +19,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
        https://code.videolan.org/videolan/libplacebo.git /tmp/libplacebo \
   && cd /tmp/libplacebo \
   && PKG_CONFIG_PATH=/opt/dvlibs/lib/pkgconfig meson setup build \
-       -Dlibdovi=enabled -Dvulkan=enabled -Dglslang=enabled \
+       -Dlibdovi=enabled -Dvulkan=enabled -Dshaderc=enabled -Dglslang=disabled \
+       -Dopengl=disabled -Dd3d11=disabled \
        -Ddemos=false -Dtests=false --buildtype=release --prefix=/opt/plbo --libdir=lib \
   && ninja -C build && ninja -C build install \
   && rm -rf /var/lib/apt/lists/* "$HOME/.cargo/registry" "$HOME/.rustup" \

--- a/backend/src/modules/streaming/dovi-play-method.spec.ts
+++ b/backend/src/modules/streaming/dovi-play-method.spec.ts
@@ -1,0 +1,95 @@
+import { StreamBuilderService } from './stream-builder.service';
+import type { DeviceProfileDto } from './dto/device-profile.dto';
+
+const svc = () =>
+  new StreamBuilderService(
+    { getDetectedHwAccel: () => 'none' } as never,
+    { getAutoCropEnabled: () => false, getTonemapAlgo: () => 'auto' } as never,
+  );
+
+const hdrHevcClient: DeviceProfileDto = {
+  containers: ['mkv'],
+  directPlayProfiles: [
+    { containers: ['mkv'], videoCodecs: ['hevc'], audioCodecs: ['aac'] },
+  ],
+  codecConditions: [
+    {
+      codec: 'hevc',
+      profiles: ['main', 'main 10'],
+      maxBitDepth: 10,
+      maxWidth: 3840,
+      maxHeight: 2160,
+      maxLevel: 180,
+    },
+  ],
+  supportsHdr: true,
+  supportsDirectPlay: true,
+  maxAudioChannels: 6,
+} as never;
+
+const resolved = (dvProfile?: number, dvBlSignalCompatId?: number) =>
+  ({
+    ext: '.mkv',
+    contentType: 'video/x-matroska',
+    absolutePath: '/m/in.mkv',
+    relativePath: 'in.mkv',
+    size: 1,
+    media: { title: 'X', type: 'movie' },
+    mediaFile: {
+      id: 1,
+      streamInfo: {
+        video: [
+          {
+            codec: 'hevc',
+            width: 1920,
+            height: 1080,
+            bitDepth: 10,
+            profile: 'Main 10',
+            level: 120,
+            bitRate: 8_000_000,
+            frameRate: '24',
+            hdrFormat: 'HDR10',
+            colorTransfer: 'smpte2084',
+            colorPrimaries: 'bt2020',
+            dvProfile,
+            dvBlSignalCompatId,
+          },
+        ],
+        audio: [{ codec: 'aac', channels: 2, bitRate: 128_000 }],
+        durationSeconds: 100,
+      },
+    },
+  }) as never;
+
+describe('StreamBuilderService — Dolby Vision play-method', () => {
+  it('forces P5 to a tonemapping transcode with an SDR output variant', () => {
+    const r = svc().evaluate(resolved(5, 0), hdrHevcClient, 'tok');
+    expect(r.response.playMethod).toBe('Transcode');
+    expect(r.videoVariant?.hdr).toBeNull();
+    expect(r.response.tonemapping).toBe(true);
+    expect(
+      r.response.transcodeReasons.some((x) => /Dolby Vision/.test(x.message)),
+    ).toBe(true);
+  });
+
+  it('forces P5 even with no HDR VUI (RPU-only metadata)', () => {
+    // Strip the HDR color tags so isSourceHdr would be false — dvP5 must still
+    // force the transcode on its own.
+    const r: any = resolved(5, 0);
+    r.mediaFile.streamInfo.video[0].hdrFormat = undefined;
+    r.mediaFile.streamInfo.video[0].colorTransfer = undefined;
+    r.mediaFile.streamInfo.video[0].colorPrimaries = undefined;
+    const out = svc().evaluate(r, hdrHevcClient, 'tok');
+    expect(out.response.playMethod).toBe('Transcode');
+    expect(out.videoVariant?.hdr).toBeNull();
+    expect(out.response.tonemapping).toBe(true);
+  });
+
+  it('leaves DV 8.1 (HDR10-compatible base) on its HDR path', () => {
+    const r = svc().evaluate(resolved(8, 1), hdrHevcClient, 'tok');
+    expect(
+      r.response.transcodeReasons.some((x) => /Dolby Vision/.test(x.message)),
+    ).toBe(false);
+    expect(r.response.tonemapping).toBe(false);
+  });
+});

--- a/backend/src/modules/streaming/services/session-context-builder.service.ts
+++ b/backend/src/modules/streaming/services/session-context-builder.service.ts
@@ -91,6 +91,8 @@ export class SessionContextBuilder {
       ),
       isSourceHdr: !!si?.video?.[0]?.hdrFormat,
       hdrMetadata: si?.video?.[0]?.hdrMetadata,
+      sourceDvProfile: si?.video?.[0]?.dvProfile,
+      sourceDvBlSignalCompatId: si?.video?.[0]?.dvBlSignalCompatId,
       // Variant chosen by stream-builder's codec selector at playback-info time,
       // threaded through every session spawn so ffmpeg-args resolves the
       // matching encoder descriptor. Undefined only for legacy callers that

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -160,6 +160,12 @@ export class StreamBuilderService {
 
     // HDR detection
     const isSourceHdr = !!source.hdrFormat;
+    // Dolby Vision Profile 5 (single-layer IPT-PQ-C2, no HDR10 base): decodes
+    // green/purple wherever copied, and its metadata often lives only in the RPU
+    // (no HDR VUI), so it drives transcode+tonemap independently of isSourceHdr.
+    const dvP5 =
+      v?.dvProfile === 5 &&
+      (v?.dvBlSignalCompatId === 0 || v?.dvBlSignalCompatId == null);
     const clientSupportsHdr = profile.supportsHdr === true;
     // Codec selector: picks the variant the encoder pipeline will produce
     // when the playback path lands on transcode. The result is threaded by
@@ -178,7 +184,7 @@ export class StreamBuilderService {
       {
         width: source.width ?? 0,
         height: source.height ?? 0,
-        hdr: (source.hdrFormat as CodecVariant['hdr']) ?? null,
+        hdr: dvP5 ? null : ((source.hdrFormat as CodecVariant['hdr']) ?? null),
         codec: normaliseSourceCodec(source.videoCodec) ?? undefined,
       },
       profile,
@@ -199,7 +205,7 @@ export class StreamBuilderService {
     // re-encode then runs the tonemap filter; copy paths (DirectPlay / remux)
     // never tone-map. AVPlayer rejects with -12927 if an H.264 re-encode
     // keeps the HDR VUI, hence the filter.
-    const transcodeTonemaps = isSourceHdr && !useHdrLadder;
+    const transcodeTonemaps = (isSourceHdr || dvP5) && !useHdrLadder;
     // useHdrLadder and selectedVariant are returned to the controller
     // via EvaluateResult; the controller threads them onto the live
     // session rather than the service writing side-effects.
@@ -237,6 +243,7 @@ export class StreamBuilderService {
     // the source codec on purpose: AV1, VP9 and HEVC 10-bit HDR all qualify.
     const clientCanPresentHdr =
       isSourceHdr &&
+      !dvP5 &&
       clientSupportsHdr &&
       directPlayResult.videoSupported &&
       directPlayResult.videoConditionsMet;
@@ -245,13 +252,13 @@ export class StreamBuilderService {
     // tone-map only when the re-encode is actually SDR — when the HDR ladder
     // preserves it the real blocker is whatever tryDirectPlay already
     // recorded (resolution, level, …).
-    if (isSourceHdr && !clientCanPresentHdr) {
+    if ((isSourceHdr || dvP5) && !clientCanPresentHdr) {
       if (directPlayResult.canDirectPlay)
         directPlayResult.canDirectPlay = false;
       if (transcodeTonemaps) {
         reasons.push({
           flag: 'VideoHdrNotSupported',
-          message: `HDR → SDR (tone mapping ${source.hdrFormat})`,
+          message: `HDR → SDR (tone mapping ${dvP5 ? 'Dolby Vision P5' : source.hdrFormat})`,
         });
       }
     }
@@ -326,6 +333,7 @@ export class StreamBuilderService {
       directPlayResult.videoSupported &&
       directPlayResult.videoConditionsMet &&
       (!isSourceHdr || clientCanPresentHdr) &&
+      !dvP5 &&
       !needsBurnIn &&
       !needsCrop;
 

--- a/backend/src/modules/streaming/transcoding/codec/libplacebo-dv-probe.ts
+++ b/backend/src/modules/streaming/transcoding/codec/libplacebo-dv-probe.ts
@@ -22,6 +22,23 @@ export function isLibplaceboDvEnabled(): boolean {
   return probedOnce && enabled;
 }
 
+/** True when the libplacebo ffmpeg loads is actually linked against libdovi.
+ *  The stock Ubuntu apt libplacebo is NOT, and there `apply_dolbyvision` is a
+ *  silent no-op — so without this check the probe would falsely enable and ship
+ *  an uncorrected P5. `ldd` prints the full transitive closure, so libdovi
+ *  appears iff libplacebo pulled it in. */
+async function libdoviLinked(): Promise<boolean> {
+  try {
+    await execFileAsync('sh', [
+      '-c',
+      'ldd "$(command -v ffmpeg)" 2>/dev/null | grep -qi libdovi',
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function runLibplaceboDvProbe(log: Logger): Promise<void> {
   const t0 = Date.now();
   const sample = path.join(
@@ -29,6 +46,9 @@ export async function runLibplaceboDvProbe(log: Logger): Promise<void> {
     `fliks-libplacebo-dv-probe-${process.pid}.hevc`,
   );
   try {
+    if (!(await libdoviLinked())) {
+      throw new Error('libplacebo is not linked against libdovi');
+    }
     await execFileAsync(
       'ffmpeg',
       [

--- a/backend/src/modules/streaming/transcoding/codec/libplacebo-dv-probe.ts
+++ b/backend/src/modules/streaming/transcoding/codec/libplacebo-dv-probe.ts
@@ -1,0 +1,74 @@
+import { Logger } from '@nestjs/common';
+import { execFile } from 'child_process';
+import { unlink } from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+/** Whether the Vulkan/libplacebo Dolby Vision tonemap path works on this host:
+ *  a Vulkan device inits, the libplacebo filter loads and accepts
+ *  `apply_dolbyvision`, and the hwupload → filter → hwdownload round-trip runs.
+ *  Fail-closed (`probedOnce && enabled`) so a P5 source before/without the probe
+ *  takes the standard-tonemap fallback rather than emitting a broken vulkan init.
+ *  The probe validates plumbing on a synthetic PQ sample; it does NOT prove a
+ *  real DV RPU survives decode → hwupload → libplacebo (only a real P5 file can).
+ */
+let probedOnce = false;
+let enabled = false;
+
+export function isLibplaceboDvEnabled(): boolean {
+  return probedOnce && enabled;
+}
+
+export async function runLibplaceboDvProbe(log: Logger): Promise<void> {
+  const t0 = Date.now();
+  const sample = path.join(
+    os.tmpdir(),
+    `fliks-libplacebo-dv-probe-${process.pid}.hevc`,
+  );
+  try {
+    await execFileAsync(
+      'ffmpeg',
+      [
+        '-hide_banner', '-loglevel', 'error', '-y',
+        '-f', 'lavfi',
+        '-i', 'nullsrc=size=320x180:rate=30,format=yuv420p10le',
+        '-frames:v', '4',
+        '-c:v', 'libx265',
+        '-color_primaries', 'bt2020',
+        '-color_trc', 'smpte2084',
+        '-colorspace', 'bt2020nc',
+        '-x265-params',
+        'repeat-headers=1:colorprim=bt2020:transfer=smpte2084:colormatrix=bt2020nc',
+        sample,
+      ],
+      { timeout: 15_000 },
+    );
+    // Same init string ffmpeg-args emits, so the probe predicts the real chain.
+    await execFileAsync(
+      'ffmpeg',
+      [
+        '-hide_banner', '-loglevel', 'error',
+        '-init_hw_device', 'vulkan=vk:0',
+        '-filter_hw_device', 'vk',
+        '-i', sample,
+        '-vf',
+        'hwupload,libplacebo=apply_dolbyvision=1:tonemapping=bt.2390:colorspace=bt709:color_primaries=bt709:color_trc=bt709:format=nv12,hwdownload,format=nv12',
+        '-c:v', 'libx264', '-preset', 'veryfast',
+        '-frames:v', '1', '-f', 'null', '-',
+      ],
+      { timeout: 20_000 },
+    );
+    enabled = true;
+  } catch {
+    enabled = false;
+  } finally {
+    await unlink(sample).catch(() => {});
+    probedOnce = true;
+    log.log(
+      `[libplacebo-dv-probe] ${enabled ? 'enabled' : 'disabled'} (${Date.now() - t0}ms)`,
+    );
+  }
+}

--- a/backend/src/modules/streaming/transcoding/codec/libplacebo-dv-probe.ts
+++ b/backend/src/modules/streaming/transcoding/codec/libplacebo-dv-probe.ts
@@ -41,6 +41,7 @@ async function libdoviLinked(): Promise<boolean> {
 
 export async function runLibplaceboDvProbe(log: Logger): Promise<void> {
   const t0 = Date.now();
+  let reason = '';
   const sample = path.join(
     os.tmpdir(),
     `fliks-libplacebo-dv-probe-${process.pid}.hevc`,
@@ -82,13 +83,14 @@ export async function runLibplaceboDvProbe(log: Logger): Promise<void> {
       { timeout: 20_000 },
     );
     enabled = true;
-  } catch {
+  } catch (e) {
     enabled = false;
+    reason = e instanceof Error ? e.message : String(e);
   } finally {
     await unlink(sample).catch(() => {});
     probedOnce = true;
     log.log(
-      `[libplacebo-dv-probe] ${enabled ? 'enabled' : 'disabled'} (${Date.now() - t0}ms)`,
+      `[libplacebo-dv-probe] ${enabled ? 'enabled' : `disabled (${reason})`} (${Date.now() - t0}ms)`,
     );
   }
 }

--- a/backend/src/modules/streaming/transcoding/dovi-args.spec.ts
+++ b/backend/src/modules/streaming/transcoding/dovi-args.spec.ts
@@ -1,0 +1,69 @@
+jest.mock('./codec/libplacebo-dv-probe', () => ({
+  isLibplaceboDvEnabled: () => true,
+  runLibplaceboDvProbe: async () => {},
+}));
+
+import { Logger } from '@nestjs/common';
+import { buildFfmpegArgs } from './ffmpeg-args';
+import type { BuildFfmpegArgsOptions } from './ffmpeg-args';
+import type { CodecVariant } from './codec/types';
+
+const silentLog = {
+  debug: () => {},
+  log: () => {},
+  warn: () => {},
+  error: () => {},
+} as unknown as Logger;
+
+const H264_SDR: CodecVariant = { codec: 'h264', bitDepth: 8, hdr: null };
+
+const opts = (over: Partial<BuildFfmpegArgsOptions>): BuildFfmpegArgsOptions =>
+  ({
+    inputPath: '/media/in.mkv',
+    outputDir: '/cache/out',
+    hwAccel: 'qsv',
+    profile: {
+      name: '1080p',
+      maxWidth: 1920,
+      maxHeight: 1080,
+      videoBitrate: '8M',
+      audioBitrate: '192k',
+    },
+    videoVariant: H264_SDR,
+    sourceWidth: 1920,
+    sourceHeight: 1080,
+    sourceFps: 24,
+    trustedStreamInfo: true,
+    tonemap: true,
+    sourceBitDepth: 10,
+    ...over,
+  }) as BuildFfmpegArgsOptions;
+
+describe('buildFfmpegArgs — Dolby Vision Profile 5', () => {
+  it('routes P5 through the vulkan/libplacebo tonemap on CPU encode', () => {
+    const args = buildFfmpegArgs(
+      opts({ sourceDvProfile: 5, sourceDvBlSignalCompatId: 0 }),
+      silentLog,
+    );
+    const vk = args.indexOf('vulkan=vk:0');
+    expect(vk).toBeGreaterThan(-1);
+    expect(vk).toBeLessThan(args.indexOf('-i'));
+    expect(args).toContain('-filter_hw_device');
+    const vf = args[args.indexOf('-vf') + 1];
+    expect(vf).toContain('libplacebo=apply_dolbyvision=1');
+    expect(vf).not.toContain('tonemap=mobius');
+    // useDoviTonemap forces CPU encode even on a qsv host.
+    expect(args).toContain('libx264');
+    expect(args).not.toContain('h264_qsv');
+  });
+
+  it('leaves DV 8.1 (compat id 1) on the standard path — no libplacebo', () => {
+    const args = buildFfmpegArgs(
+      opts({ sourceDvProfile: 8, sourceDvBlSignalCompatId: 1 }),
+      silentLog,
+    );
+    expect(args).not.toContain('vulkan=vk:0');
+    const vf = args[args.indexOf('-vf') + 1];
+    expect(vf).not.toContain('libplacebo');
+  });
+});

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -32,6 +32,7 @@ import { hevcMainTierCapBps } from './codec/codec-strings';
 import { varStreamMapLayout } from './audio-layout';
 import { resolveEncodePipeline } from './encode-pipeline';
 import { buildVideoFilters } from './ffmpeg-filter-graph';
+import { isLibplaceboDvEnabled } from './codec/libplacebo-dv-probe';
 import { buildImageBurnInFilterComplex } from './subtitle-overlay-filter';
 
 /**
@@ -94,6 +95,10 @@ export interface BuildFfmpegArgsOptions {
    *  display tonemaps to the real peak luminance; the encoders fall back to a
    *  generic 1000-nit reference when absent. */
   sourceHdrMetadata?: HdrStaticMetadata;
+  /** Dolby Vision profile + base-layer compat id — gate the P5 libplacebo
+   *  tonemap (#636). */
+  sourceDvProfile?: number;
+  sourceDvBlSignalCompatId?: number;
   /** Audio output decision — see {@link SessionContext.audioPlan}. When
    *  omitted, ffmpeg-args falls back to AAC stereo at the profile bitrate
    *  (safe default that plays everywhere). */
@@ -239,6 +244,8 @@ export function buildFfmpegArgs(
     sourceWidth = 0,
     sourceHeight = 0,
     sourceHdrMetadata,
+    sourceDvProfile,
+    sourceDvBlSignalCompatId,
     tonemapAlgo = 'auto',
   } = opts;
 
@@ -409,6 +416,13 @@ export function buildFfmpegArgs(
   }
   const variant: CodecVariant = videoVariant;
   const isHdrOutput = variant.hdr !== null;
+  // Dolby Vision P5 tonemaps through the RPU-aware libplacebo (Vulkan) chain,
+  // on CPU decode/encode, only when the boot probe confirmed it works (#636).
+  const useDoviTonemap =
+    !!tonemap &&
+    sourceDvProfile === 5 &&
+    (sourceDvBlSignalCompatId === 0 || sourceDvBlSignalCompatId == null) &&
+    isLibplaceboDvEnabled();
 
   // Image-based subtitle burn-in (PGS/VOBSUB) is composited via -filter_complex
   // below, reusing the encoder's video chain so the accelerated scale/tonemap
@@ -427,7 +441,7 @@ export function buildFfmpegArgs(
     qsvNativeAvailable,
     useVaapiTonemap,
   } = resolveEncodePipeline(variant, {
-    hwAccel,
+    hwAccel: useDoviTonemap ? 'none' : hwAccel,
     crop: !!crop,
     burnIn: !!burnIn?.filter,
     tonemap: !!tonemap,
@@ -540,6 +554,9 @@ export function buildFfmpegArgs(
   if (tonemap && !useVaapiTonemap && decoder.outputSurface === 'vaapi') {
     args.push('-init_hw_device', 'opencl=ocl:0.0');
   }
+  if (useDoviTonemap) {
+    args.push('-init_hw_device', 'vulkan=vk:0', '-filter_hw_device', 'vk');
+  }
 
   args.push('-i', inputPath);
 
@@ -590,6 +607,7 @@ export function buildFfmpegArgs(
       tonemap,
       useVaapiTonemap,
       sourceBitDepth,
+      dovi: useDoviTonemap,
     }),
     tonemap,
     tonemapPath,

--- a/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.spec.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.spec.ts
@@ -66,4 +66,18 @@ describe('buildVideoFilters', () => {
     expect(f.burnInFilter).toBe(',subtitles=/tmp/x.ass');
     expect(f.tonemapCpu).toContain('tonemap=mobius');
   });
+
+  it('dovi swaps only the CPU tone-map slot for the libplacebo chain', () => {
+    const plain = buildVideoFilters({ ...base, tonemap: true });
+    const dv = buildVideoFilters({ ...base, tonemap: true, dovi: true });
+    expect(dv.tonemapCpu).toContain('libplacebo=apply_dolbyvision=1');
+    expect(dv.tonemapCpu).not.toContain('tonemap=mobius');
+    // Every other slot is identical to the non-dovi tone-map.
+    for (const k of [
+      'cropStr', 'cpuCropPrefix', 'hwCropPrefix',
+      'burnInFilter', 'tonemapVaapi', 'tonemapOpencl',
+    ] as const) {
+      expect(dv[k]).toBe(plain[k]);
+    }
+  });
 });

--- a/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.ts
@@ -11,6 +11,9 @@ export interface VideoFilterContext {
   /** Source bit depth — picks the crop round-trip pixel format (10-bit → p010le
    *  so the HDR colour space survives the hwdownload → crop → hwupload trip). */
   sourceBitDepth: number;
+  /** Dolby Vision P5: tonemap via the RPU-aware libplacebo (Vulkan) chain
+   *  instead of the standard tonemap that misreads IPT-C2 (#636). */
+  dovi?: boolean;
 }
 
 /**
@@ -30,7 +33,7 @@ export interface VideoFilterContext {
 export function buildVideoFilters(
   ctx: VideoFilterContext,
 ): EncoderInput['filters'] {
-  const { crop, burnIn, tonemap, useVaapiTonemap, sourceBitDepth } = ctx;
+  const { crop, burnIn, tonemap, useVaapiTonemap, sourceBitDepth, dovi } = ctx;
   const cropStr = crop
     ? `crop=${crop.width}:${crop.height}:${crop.x}:${crop.y}`
     : '';
@@ -48,7 +51,9 @@ export function buildVideoFilters(
   // yuv420p; the `tonemap` filter handles PQ/HLG linearisation internally (no
   // zscale/libzimg dependency).
   const tonemapCpu = tonemap
-    ? `format=gbrpf32le,tonemap=mobius:desat=0,format=yuv420p,`
+    ? dovi
+      ? `hwupload,libplacebo=apply_dolbyvision=1:tonemapping=bt.2390:colorspace=bt709:color_primaries=bt709:color_trc=bt709:format=nv12,hwdownload,format=nv12,`
+      : `format=gbrpf32le,tonemap=mobius:desat=0,format=yuv420p,`
     : '';
   // HW-crop round-trip: hwdownload → crop → hwupload. The explicit `format=`
   // matches the source bit depth (p010le for 10-bit) so crop runs in the

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -43,6 +43,7 @@ import {
   isTonemapOpenclEnabled,
   runTonemapOpenclProbe,
 } from './codec/tonemap-opencl-probe';
+import { runLibplaceboDvProbe } from './codec/libplacebo-dv-probe';
 import {
   generateMasterPlaylist,
   getAvailableProfiles,
@@ -138,6 +139,11 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       this.detectedHwAccel === 'vaapi'
     ) {
       void runTonemapOpenclProbe(this.log);
+    }
+    // Vulkan/libplacebo Dolby Vision P5 tonemap. Vendor-agnostic, so probe on
+    // any non-macOS host; a GPU-less server fails device init fast (fail-closed).
+    if (this.detectedHwAccel !== 'videotoolbox') {
+      void runLibplaceboDvProbe(this.log);
     }
 
     // Tight cleanup cadence — paired with the live-session 30 s TTL +
@@ -1589,10 +1595,12 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       videoVariant: ctx?.videoVariant,
       sourceVideoCodec: ctx?.sourceVideoCodec,
       sourceVideoBitrateBps: ctx?.sourceVideoBitrateBps,
-      sourceBitDepth: ctx?.isSourceHdr ? 10 : 8,
+      sourceBitDepth: ctx?.isSourceHdr || ctx?.sourceDvProfile === 5 ? 10 : 8,
       sourceWidth: ctx?.sourceWidth,
       sourceHeight: ctx?.sourceHeight,
       sourceHdrMetadata: ctx?.hdrMetadata,
+      sourceDvProfile: ctx?.sourceDvProfile,
+      sourceDvBlSignalCompatId: ctx?.sourceDvBlSignalCompatId,
     };
   }
 

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -226,6 +226,10 @@ export interface SessionContext {
    *  encoder signals the source's real mastering display / content light
    *  instead of a generic 1000-nit reference. */
   hdrMetadata?: import('./codec/types').HdrStaticMetadata;
+  /** Dolby Vision profile + base-layer compat id, threaded from streamInfo so
+   *  ffmpeg-args can gate the P5 libplacebo tonemap (#636). */
+  sourceDvProfile?: number;
+  sourceDvBlSignalCompatId?: number;
 }
 
 export interface TranscodeSession {


### PR DESCRIPTION
Closes #636. Advances #368 (part 3, the P5 fallback). **Hold for on-device validation with a real DV P5 file** — the boot probe validates the Vulkan/libplacebo plumbing but cannot prove the DV RPU survives decode→libplacebo end-to-end; only a real IPT-PQ-C2 asset can.

## Problem
DV Profile 5 is single-layer IPT-PQ-C2, no HDR10-compatible base layer. ffprobe captured `dvProfile`/`dvBlSignalCompatId` but nothing consulted them, so a P5 file was DirectPlayed/remuxed (raw IPT-C2 to the client decoder) or run through the standard opencl/vaapi/qsv tonemap — both misread the colour → green/purple. DV 8.1 (PQ base) / 8.4 (HLG base) already degrade correctly and are untouched.

## Fix — contained, two halves
Treat "P5-ness" as a **source** property, never a `CodecVariant.hdr` value (so the encoder registry, master playlist and every golden stay untouched).

1. **Play-method** (`stream-builder.evaluate`): `dvP5 = dvProfile===5 && (compatId===0||null)` folded *independently* into the gates — forces the source out of DirectPlay/remux into a tonemapping transcode with an **SDR output variant**, even when the HEVC VUI carries no HDR tags (P5 metadata often lives only in the RPU → `isSourceHdr` false).
2. **Filter** (`ffmpeg-args` + `ffmpeg-filter-graph`): thread the DV numbers via `SessionContext`; `useDoviTonemap = tonemap && dvProfile===5 && (compatId 0/null) && isLibplaceboDvEnabled()`. When true → CPU encode + `-init_hw_device vulkan=vk:0 -filter_hw_device vk` + the `tonemapCpu` slot becomes the **RPU-aware libplacebo** chain. A fail-closed boot probe gates it.

## Containment
Every non-P5 source (SDR/HDR10/HLG/DV8.1) keeps its exact resolved pipeline + ffmpeg args — **all 16 existing golden snapshots unchanged**. A bug in the DV path can only reach P5, which was already broken. Probe-off (no Vulkan / macOS / pre-probe): P5 still transcodes (decodable, non-passthrough) rather than shipping the raw bitstream — same-or-better than today, no crash.

## Verification
- Design mapped + adversarially stress-tested (sound-with-fixes, all applied); diff adversarially reviewed → SAFE-TO-MERGE (7 attack surfaces incl. containment, P8.1, probe-off, vulkan chain, threading).
- `tsc` clean; **251 streaming tests pass, 16+29 snapshots unchanged**. New tests: P5 play-method (incl. RPU-only, no-HDR-VUI), P8.1 unchanged, P5 args (vulkan+libplacebo+CPU encode), `dovi` swaps only the tonemap slot.
- **@Clément to validate:** on the target host, `docker compose logs backend | grep libplacebo-dv-probe` should show `enabled`; then play a real **DV Profile 5** file → correct SDR colour (not green/purple); and confirm a real **HDR10**, **HLG**, and **DV 8.1** file are unchanged.

### Out of scope (#368 follow-up)
DV DirectPlay passthrough (`dvh1` + `EXT-X-SUPPLEMENTAL-CODECS`) and per-platform client DV capability flags — needs client capability work not testable here.

_Filed from the 2026-07-09 streaming-reliability audit._