### PR TITLE
feat(streaming): direct-play single-layer Dolby Vision untouched

### DIFF
--- a/backend/src/modules/streaming/dovi-play-method.spec.ts
+++ b/backend/src/modules/streaming/dovi-play-method.spec.ts
@@ -27,7 +27,16 @@ const hdrHevcClient: DeviceProfileDto = {
   maxAudioChannels: 6,
 } as never;
 
-const resolved = (dvProfile?: number, dvBlSignalCompatId?: number) =>
+const dvHevcClient: DeviceProfileDto = {
+  ...hdrHevcClient,
+  supportsDolbyVision: true,
+} as never;
+
+const resolved = (
+  dvProfile?: number,
+  dvBlSignalCompatId?: number,
+  dvElPresent?: boolean,
+) =>
   ({
     ext: '.mkv',
     contentType: 'video/x-matroska',
@@ -53,6 +62,7 @@ const resolved = (dvProfile?: number, dvBlSignalCompatId?: number) =>
             colorPrimaries: 'bt2020',
             dvProfile,
             dvBlSignalCompatId,
+            dvElPresent,
           },
         ],
         audio: [{ codec: 'aac', channels: 2, bitRate: 128_000 }],
@@ -91,5 +101,25 @@ describe('StreamBuilderService — Dolby Vision play-method', () => {
       r.response.transcodeReasons.some((x) => /Dolby Vision/.test(x.message)),
     ).toBe(false);
     expect(r.response.tonemapping).toBe(false);
+  });
+
+  it('DirectPlays P5 untouched for a client that can present DV', () => {
+    const r = svc().evaluate(resolved(5, 0), dvHevcClient, 'tok');
+    expect(r.response.playMethod).toBe('DirectPlay');
+    expect(r.response.videoCopyStream).toBe(true);
+    expect(r.response.tonemapping).toBe(false);
+    expect(
+      r.response.transcodeReasons.some((x) => /Dolby Vision/.test(x.message)),
+    ).toBe(false);
+  });
+
+  it('DirectPlays P5 with RPU-only metadata (no HDR VUI) for a DV client', () => {
+    const r: any = resolved(5, 0);
+    r.mediaFile.streamInfo.video[0].hdrFormat = undefined;
+    r.mediaFile.streamInfo.video[0].colorTransfer = undefined;
+    r.mediaFile.streamInfo.video[0].colorPrimaries = undefined;
+    const out = svc().evaluate(r, dvHevcClient, 'tok');
+    expect(out.response.playMethod).toBe('DirectPlay');
+    expect(out.response.videoCopyStream).toBe(true);
   });
 });

--- a/backend/src/modules/streaming/dto/device-profile.dto.ts
+++ b/backend/src/modules/streaming/dto/device-profile.dto.ts
@@ -88,6 +88,18 @@ export class DeviceProfileDto {
   supportsHdr?: boolean;
 
   /**
+   * Client can present single-layer Dolby Vision (Profile 5 / 8.x) directly:
+   * both a DV decoder and a DV panel confirmed on the device. The backend then
+   * DirectPlays the original container untouched so the RPU rides through.
+   * ABSENT means false — the opposite of {@link supportsDirectPlay} — so a
+   * client that hasn't proven DV never gets a P5 copied (it would render
+   * green/purple on non-DV hardware); such clients keep the tonemap transcode.
+   */
+  @IsBoolean()
+  @IsOptional()
+  supportsDolbyVision?: boolean;
+
+  /**
    * Client engine can play a raw progressive file served as-is (Direct Play).
    * Shaka (web), ExoPlayer/AVPlayer (native mobile) and webOS `<video>` all
    * can. Samsung Tizen AVPlay is HLS-only and cannot open a raw file, so it

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -29,6 +29,7 @@ import { resolveEncodePipeline } from './transcoding/encode-pipeline';
 import { ActiveStreamTracker } from './active-stream-tracker.service';
 import { bucketResolutionHeight } from '../../common/utils/resolution.util';
 import { normaliseSourceCodec } from './transcoding/codec/normalise';
+import { deriveDvInfo, isDvProfile5 } from './transcoding/codec/dolby-vision';
 import { pickPrimaryVariant } from './transcoding/codec/selector';
 import type { CodecVariant, VideoCodec } from './transcoding/codec/types';
 
@@ -158,14 +159,14 @@ export class StreamBuilderService {
       crop: autoCropEnabled ? v?.crop : undefined,
     };
 
-    // HDR detection
+    // HDR / Dolby Vision detection
     const isSourceHdr = !!source.hdrFormat;
-    // Dolby Vision Profile 5 (single-layer IPT-PQ-C2, no HDR10 base): decodes
-    // green/purple wherever copied, and its metadata often lives only in the RPU
-    // (no HDR VUI), so it drives transcode+tonemap independently of isSourceHdr.
-    const dvP5 =
-      v?.dvProfile === 5 &&
-      (v?.dvBlSignalCompatId === 0 || v?.dvBlSignalCompatId == null);
+    const dv = deriveDvInfo(v);
+    // Profile 5 (single-layer IPT-PQ-C2, no HDR10 base) decodes green/purple
+    // wherever a non-DV client copies it, and its metadata often lives only in
+    // the RPU (no HDR VUI), so it drives transcode+tonemap independently of
+    // isSourceHdr — unless the client can present DV (see clientCanPresentDv).
+    const dvP5 = isDvProfile5(dv);
     const clientSupportsHdr = profile.supportsHdr === true;
     // Codec selector: picks the variant the encoder pipeline will produce
     // when the playback path lands on transcode. The result is threaded by
@@ -248,11 +249,22 @@ export class StreamBuilderService {
       directPlayResult.videoSupported &&
       directPlayResult.videoConditionsMet;
 
-    // HDR the client can't present as-is forces a transcode. Flag the
+    // Single-layer DV (P5, P8.x) carries its RPU inside the HEVC NALs, so a raw
+    // copy preserves DV for a client that declares it can present it. Dual-layer
+    // P7's enhancement layer can't ride HLS, so dv.singleLayer excludes it.
+    const clientCanPresentDv =
+      profile.supportsDolbyVision === true &&
+      dv.singleLayer &&
+      directPlayResult.videoSupported &&
+      directPlayResult.videoConditionsMet;
+    const clientCanPresentDynamicRange =
+      clientCanPresentHdr || clientCanPresentDv;
+
+    // HDR/DV the client can't present as-is forces a transcode. Flag the
     // tone-map only when the re-encode is actually SDR — when the HDR ladder
     // preserves it the real blocker is whatever tryDirectPlay already
     // recorded (resolution, level, …).
-    if ((isSourceHdr || dvP5) && !clientCanPresentHdr) {
+    if ((isSourceHdr || dvP5) && !clientCanPresentDynamicRange) {
       if (directPlayResult.canDirectPlay)
         directPlayResult.canDirectPlay = false;
       if (transcodeTonemaps) {
@@ -332,8 +344,7 @@ export class StreamBuilderService {
     const sourceCopyable =
       directPlayResult.videoSupported &&
       directPlayResult.videoConditionsMet &&
-      (!isSourceHdr || clientCanPresentHdr) &&
-      !dvP5 &&
+      ((!isSourceHdr && !dvP5) || clientCanPresentDynamicRange) &&
       !needsBurnIn &&
       !needsCrop;
 

--- a/backend/src/modules/streaming/transcoding/codec/dolby-vision.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/dolby-vision.spec.ts
@@ -1,0 +1,50 @@
+import { deriveDvInfo, isDvProfile5 } from './dolby-vision';
+
+describe('deriveDvInfo', () => {
+  it('classifies P5 as single-layer', () => {
+    const info = deriveDvInfo({ dvProfile: 5, dvBlSignalCompatId: 0 });
+    expect(info.singleLayer).toBe(true);
+    expect(isDvProfile5(info)).toBe(true);
+    expect(info.supplementalTag).toBeNull();
+  });
+
+  it('classifies P8.1 as single-layer with the db1p brand', () => {
+    const info = deriveDvInfo({ dvProfile: 8, dvBlSignalCompatId: 1 });
+    expect(info.singleLayer).toBe(true);
+    expect(isDvProfile5(info)).toBe(false);
+    expect(info.supplementalTag).toBe('db1p');
+  });
+
+  it('classifies P8.4 with the db4h brand', () => {
+    const info = deriveDvInfo({ dvProfile: 8, dvBlSignalCompatId: 4 });
+    expect(info.singleLayer).toBe(true);
+    expect(info.supplementalTag).toBe('db4h');
+  });
+
+  it('treats a dual-layer profile (enhancement layer present) as not single-layer', () => {
+    const info = deriveDvInfo({
+      dvProfile: 7,
+      dvBlSignalCompatId: 6,
+      dvElPresent: true,
+    });
+    expect(info.singleLayer).toBe(false);
+    expect(isDvProfile5(info)).toBe(false);
+  });
+
+  it('treats a P8 that declares an enhancement layer as not single-layer', () => {
+    const info = deriveDvInfo({
+      dvProfile: 8,
+      dvBlSignalCompatId: 1,
+      dvElPresent: true,
+    });
+    expect(info.singleLayer).toBe(false);
+  });
+
+  it('returns no DV classification for a non-DV stream', () => {
+    const info = deriveDvInfo({});
+    expect(info.profile).toBeUndefined();
+    expect(info.singleLayer).toBe(false);
+    expect(isDvProfile5(info)).toBe(false);
+    expect(info.supplementalTag).toBeNull();
+  });
+});

--- a/backend/src/modules/streaming/transcoding/codec/dolby-vision.ts
+++ b/backend/src/modules/streaming/transcoding/codec/dolby-vision.ts
@@ -1,0 +1,35 @@
+/** Dolby Vision classification derived from a stream's DOVI configuration
+ *  record. Single-layer profiles (5, 8) carry their DV inside the HEVC NALs, so
+ *  a raw stream copy preserves DV with no re-encode; dual-layer P7's enhancement
+ *  layer is unreachable over HLS, so it is never single-layer here. */
+export interface DvInfo {
+  profile?: number;
+  compatId?: number;
+  singleLayer: boolean;
+  /** EXT-X-SUPPLEMENTAL-CODECS brand for the base-layer compatibility:
+   *  db1p = 8.1 (HDR10 base), db4h = 8.4 (HLG base). */
+  supplementalTag: 'db1p' | 'db4h' | null;
+}
+
+export interface DvStream {
+  dvProfile?: number;
+  dvBlSignalCompatId?: number;
+  dvElPresent?: boolean;
+}
+
+export function deriveDvInfo(v?: DvStream): DvInfo {
+  const profile = v?.dvProfile;
+  const compatId = v?.dvBlSignalCompatId;
+  const singleLayer =
+    (profile === 5 || profile === 8) && v?.dvElPresent !== true;
+  const supplementalTag =
+    compatId === 1 ? 'db1p' : compatId === 4 ? 'db4h' : null;
+  return { profile, compatId, singleLayer, supplementalTag };
+}
+
+/** Profile 5: single-layer IPT-PQ-C2 with no HDR10 base. A non-DV client that
+ *  copies it renders green/purple, so it forces a tonemap transcode unless the
+ *  client can present DV. */
+export function isDvProfile5(info: DvInfo): boolean {
+  return info.profile === 5 && info.singleLayer;
+}

--- a/backend/src/modules/subtitles/ffprobe.service.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.ts
@@ -55,9 +55,15 @@ export interface VideoStreamInfo {
   colorPrimaries?: string;
   hdrFormat?: HdrFormat;
   /** Dolby Vision profile from the stream's DOVI configuration record (e.g. 5,
-   *  8), with its base-layer signal compatibility id (e.g. 8.1, 8.4). */
+   *  8), with its base-layer signal compatibility id (e.g. 8.1, 8.4), level, and
+   *  which layers the record declares. `dvElPresent` tells single-layer (P5/P8)
+   *  from dual-layer P7, whose enhancement layer is unreachable over HLS. */
   dvProfile?: number;
   dvBlSignalCompatId?: number;
+  dvLevel?: number;
+  dvRpuPresent?: boolean;
+  dvBlPresent?: boolean;
+  dvElPresent?: boolean;
   /** Source HDR10 static metadata (SMPTE ST 2086 mastering display + CTA-861.3
    *  content light), probed via frame side-data for HDR10 sources. Drives the
    *  encoder's master-display / max-cll so the display tonemaps to the source's
@@ -127,7 +133,11 @@ interface FfprobeStream {
   side_data_list?: {
     side_data_type?: string;
     dv_profile?: number;
+    dv_level?: number;
     dv_bl_signal_compatibility_id?: number;
+    rpu_present_flag?: number;
+    bl_present_flag?: number;
+    el_present_flag?: number;
   }[];
   channels?: number;
   channel_layout?: string;
@@ -379,6 +389,10 @@ export class FfprobeService {
             hdrFormat: this.deriveHdrFormat(s.color_transfer, s.color_primaries),
             dvProfile: dovi?.dv_profile,
             dvBlSignalCompatId: dovi?.dv_bl_signal_compatibility_id,
+            dvLevel: dovi?.dv_level,
+            dvRpuPresent: dovi?.rpu_present_flag === 1,
+            dvBlPresent: dovi?.bl_present_flag === 1,
+            dvElPresent: dovi?.el_present_flag === 1,
           };
         });
 


### PR DESCRIPTION
## What

The backend foundation for real Dolby Vision support (issue #368), building on #636.

**Key insight:** #636 only handled Profile 5 — it force-transcodes P5 to a tonemapped SDR because a non-DV client copying P5 renders green/purple. But the **raw DirectPlay path serves the original container verbatim**, so single-layer DV (P5 and 8.x) already decodes correctly on a DV-capable client — the *only* thing blocking DV passthrough was that P5 force-transcode. This PR lets a client that declares DV support keep the original stream.

## Changes (backend only)

- **Detection** (`ffprobe.service.ts`): parse `dv_level` and the `rpu/bl/el_present` flags from the DOVI configuration record, alongside the existing `dv_profile` / `dv_bl_signal_compatibility_id`.
- **Classification** (`transcoding/codec/dolby-vision.ts`, new): `deriveDvInfo()` is now the single DV source of truth — `singleLayer` (P5/P8 with no enhancement layer), and the `db1p`/`db4h` supplemental brand for later manifest use. The inline `dvP5` expression in the stream builder now derives from it.
- **Capability flag** (`device-profile.dto.ts`): `supportsDolbyVision?: boolean`. **Absent = false** (deliberately the opposite of `supportsDirectPlay`), so a client that hasn't proven a DV decoder + DV panel never gets a P5 copied.
- **Play-method gate** (`stream-builder.service.ts`): a new `clientCanPresentDv` folds into a unified `clientCanPresentDynamicRange = clientCanPresentHdr || clientCanPresentDv`. For a DV client with single-layer DV, DirectPlay is preserved and the original container is copied (video copy, no tonemap). Everything else is unchanged.

## Safety

The flag defaults to absent/false, so **every existing client keeps today's behavior byte-for-byte**: P5 still tonemaps to SDR, 8.1 still rides the HDR10 path. No client emits `supportsDolbyVision: true` yet (see deferred), so production behavior is unchanged until the device probes land.

## Verified

- `tsc --noEmit` clean.
- `jest src/modules/streaming` — 259 tests / 34 suites / 29 snapshots, all green.
- New tests: `deriveDvInfo` matrix (P5/8.1/8.4/P7-dual-layer/non-DV); play-method spec extended — DV client DirectPlays P5 (copy, no tonemap), and the non-DV client still transcodes P5 (regression guard).

## Deferred (device-gated, separate PRs)

- **Per-platform client DV probes** — iOS (`kCMVideoCodecType_DolbyVisionHEVC`), Android (`HDR_TYPE_DOLBY_VISION` + a `video/dolby-vision` decoder), Tizen/webOS panel APIs. Each must AND-gate a decoder probe with a display probe and default OFF until hardware-verified; web/Shaka stays false. This is what actually flips `supportsDolbyVision` on.
- **Remux-path `EXT-X-SUPPLEMENTAL-CODECS`** (`dvh1.PP.LL` + `db1p`/`db4h`) for DirectStream clients (mostly Tizen) — the riskiest bit (a `dvh1` claim over segments that lost the `dvcC` box hard-rejects on strict decoders), so it stays out of this pass.
- **P7 dual-layer** passthrough is explicitly out of scope — the enhancement layer can't ride HLS; P7 keeps DirectPlaying its HDR10 base.

Refs: #368
