### PR TITLE
feat(player): enable Dolby Vision passthrough per platform

### DIFF
--- a/client/android/app/src/main/java/media/fliks/app/HdrPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/HdrPlugin.java
@@ -13,7 +13,7 @@ import com.getcapacitor.annotation.CapacitorPlugin;
  * Capacitor plugin to detect HDR display capabilities on Android.
  *
  * Usage from JS:
- *   const { supported } = await Hdr.isSupported();
+ *   const { supported, dolbyVision } = await Hdr.isSupported();
  */
 @CapacitorPlugin(name = "Hdr")
 public class HdrPlugin extends Plugin {
@@ -21,6 +21,7 @@ public class HdrPlugin extends Plugin {
     @PluginMethod()
     public void isSupported(PluginCall call) {
         boolean supported = false;
+        boolean dolbyVision = false;
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             Display display = getActivity().getWindowManager().getDefaultDisplay();
@@ -28,11 +29,20 @@ public class HdrPlugin extends Plugin {
             if (hdrCaps != null) {
                 int[] types = hdrCaps.getSupportedHdrTypes();
                 supported = types != null && types.length > 0;
+                if (types != null) {
+                    for (int t : types) {
+                        if (t == Display.HdrCapabilities.HDR_TYPE_DOLBY_VISION) {
+                            dolbyVision = true;
+                            break;
+                        }
+                    }
+                }
             }
         }
 
         JSObject result = new JSObject();
         result.put("supported", supported);
+        result.put("dolbyVision", dolbyVision);
         call.resolve(result);
     }
 }

--- a/client/ios/App/App/HdrPlugin.swift
+++ b/client/ios/App/App/HdrPlugin.swift
@@ -12,6 +12,9 @@ public class HdrPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc func isSupported(_ call: CAPPluginCall) {
         let supported = AVPlayer.eligibleForHDRPlayback
-        call.resolve(["supported": supported])
+        // iOS has no public per-codec Dolby Vision probe; DV playback tracks HDR
+        // eligibility on AVPlayer (HDR-eligible iPhone/iPad/Apple TV models decode
+        // DV P5/P8.1), so the HDR signal doubles as the DV one.
+        call.resolve(["supported": supported, "dolbyVision": supported])
     }
 }

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -67,6 +67,7 @@
     "error_network": "Erreur réseau pendant la lecture.",
     "error_decode": "Erreur de décodage de la vidéo.",
     "error_unsupported": "Format vidéo non pris en charge.",
+    "dolby_vision_decode_failed": "La lecture Dolby Vision a échoué sur cet appareil. Choisissez une autre qualité pour la convertir.",
     "error_details": "Détails techniques",
     "copy_diagnostics": "Copier les infos",
     "copied": "Copié",

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -8,7 +8,7 @@ import { SystemInfoService } from './system-info.service';
 import { getDeviceName } from '../utils/device-info';
 
 interface HdrPlugin {
-  isSupported(): Promise<{ supported: boolean }>;
+  isSupported(): Promise<{ supported: boolean; dolbyVision?: boolean }>;
 }
 const Hdr = registerPlugin<HdrPlugin>('Hdr');
 
@@ -86,6 +86,12 @@ export interface DeviceProfile {
    *  Falls back to maxAudioChannels per codec on the backend. */
   audioChannelsByCodec?: Record<string, number>;
   supportsHdr: boolean;
+  /** Client can present single-layer Dolby Vision (P5 / 8.x) directly, so the
+   *  backend DirectPlays the original container untouched instead of tonemapping
+   *  P5 to SDR. iOS/Android report it from the native probe (DV HW decoder / DV
+   *  panel type); webOS OLEDs assume it when the panel is HDR. Web/Shaka and
+   *  Tizen stay false. Absent = false on the backend. */
+  supportsDolbyVision?: boolean;
   /** Client device category — selects the backend bitrate ladder.
    *  Capacitor native (iOS/Android app) → 'mobile'; web (incl. Cast sender) → 'desktop'. */
   deviceType: 'mobile' | 'desktop';
@@ -155,6 +161,7 @@ export class BrowserDeviceProfileService {
   private readonly systemInfo = inject(SystemInfoService);
   private cachedProfile: DeviceProfile | null = null;
   private nativeHdr: boolean | null = null;
+  private nativeDolbyVision: boolean | null = null;
   private nativeAudio: {
     codecs: string[];
     maxChannels: number;
@@ -167,8 +174,12 @@ export class BrowserDeviceProfileService {
     // later sync use)
     if (Capacitor.isNativePlatform()) {
       Hdr.isSupported()
-        .then((r) => { this.nativeHdr = r.supported; })
-        .catch(() => { this.nativeHdr = false; });
+        .then((r) => {
+          this.nativeHdr = r.supported;
+          this.nativeDolbyVision = r.dolbyVision ?? false;
+          this.cachedProfile = null;
+        })
+        .catch(() => { this.nativeHdr = false; this.nativeDolbyVision = false; });
       AudioCaps.getSupported()
         .then((r) => { this.nativeAudio = r; this.cachedProfile = null; })
         .catch(() => { this.nativeAudio = null; });
@@ -209,6 +220,10 @@ export class BrowserDeviceProfileService {
       ...this.cachedProfile,
       systemName,
       supportsHdr: forceDisableHdr ? false : this.cachedProfile.supportsHdr,
+      // Forcing HDR off (user wants SDR) also drops DV passthrough — DV is HDR.
+      supportsDolbyVision: forceDisableHdr
+        ? false
+        : this.cachedProfile.supportsDolbyVision,
       useTs: useTsOverride,
     };
   }
@@ -466,6 +481,22 @@ export class BrowserDeviceProfileService {
       supportsHdr = hdrDisplay && has10bitCodec;
     }
 
+    // Dolby Vision passthrough capability. iOS/Android report it from the native
+    // probe (DV HW decoder / DV panel type). webOS OLEDs are assumed DV-capable
+    // when the panel is HDR (no per-model probe; optimistic). Web/Shaka has no DV
+    // (browser MSE never decodes dvh1), and Tizen is HLS-only with DV signaling
+    // not yet wired, so both stay false.
+    // DV is a superset of HDR, so it never outlives supportsHdr (keeps the
+    // forceDisableHdr override consistent, and a non-HDR panel can't present DV).
+    let supportsDolbyVision: boolean;
+    if (Capacitor.isNativePlatform()) {
+      supportsDolbyVision = supportsHdr && (this.nativeDolbyVision ?? false);
+    } else if (tvPlatform === 'webos') {
+      supportsDolbyVision = supportsHdr;
+    } else {
+      supportsDolbyVision = false;
+    }
+
     const useTs = readUseTsOverride();
     if (useTs) console.warn('[DeviceProfile] useTs override active');
 
@@ -480,6 +511,7 @@ export class BrowserDeviceProfileService {
       maxAudioChannels,
       audioChannelsByCodec: this.nativeAudio?.channelsByCodec,
       supportsHdr,
+      supportsDolbyVision,
       deviceType: Capacitor.isNativePlatform() ? 'mobile' : 'desktop',
       deviceName: getDeviceName(),
       useTs,

--- a/client/src/app/core/services/playback-engine/playback-error.spec.ts
+++ b/client/src/app/core/services/playback-engine/playback-error.spec.ts
@@ -25,6 +25,18 @@ describe('playback-error', () => {
       expect(userMessageKeyFor({ source: 'shaka', category: 3, code: 3017 })).toBe('player.playback_error');
       expect(userMessageKeyFor({ source: 'session' })).toBe('player.playback_error');
     });
+
+    it('surfaces an explicit Dolby Vision message on a DV decode failure', () => {
+      expect(userMessageKeyFor({ source: 'media', code: 3, dolbyVision: true })).toBe('player.dolby_vision_decode_failed');
+      expect(userMessageKeyFor({ source: 'shaka', category: 3, code: 3016, dolbyVision: true })).toBe('player.dolby_vision_decode_failed');
+      expect(userMessageKeyFor({ source: 'engine', dolbyVision: true })).toBe('player.dolby_vision_decode_failed');
+    });
+
+    it('does not blame Dolby Vision for a network/abort blip', () => {
+      expect(userMessageKeyFor({ source: 'media', code: 2, dolbyVision: true })).toBe('player.error_network');
+      expect(userMessageKeyFor({ source: 'media', code: 1, dolbyVision: true })).toBe('player.error_aborted');
+      expect(userMessageKeyFor({ source: 'shaka', category: 1, code: 1002, dolbyVision: true })).toBe('player.error_network');
+    });
   });
 
   describe('isUndecodableError', () => {

--- a/client/src/app/core/services/playback-engine/playback-error.ts
+++ b/client/src/app/core/services/playback-engine/playback-error.ts
@@ -76,7 +76,14 @@ export function userMessageKeyFor(err: {
   source: PlaybackError['source'];
   code?: number;
   category?: number;
+  dolbyVision?: boolean;
 }): string {
+  // A fatal failure while presenting Dolby Vision untouched is almost always the
+  // DV bitstream the device couldn't decode — show an explicit, actionable line.
+  // Network / abort blips keep their own message.
+  if (err.dolbyVision && !isNetworkOrAbort(err)) {
+    return 'player.dolby_vision_decode_failed';
+  }
   if (err.source === 'media') {
     switch (err.code) {
       case 1:
@@ -95,6 +102,19 @@ export function userMessageKeyFor(err: {
     if (err.code === 4032) return 'player.error_unsupported';
   }
   return 'player.playback_error';
+}
+
+/** Transient transport failures (network / user abort) — distinct from a
+ *  decode/format failure, so a Dolby Vision title doesn't blame DV for a
+ *  dropped connection. */
+export function isNetworkOrAbort(err: {
+  source: PlaybackError['source'];
+  code?: number;
+  category?: number;
+}): boolean {
+  if (err.source === 'media') return err.code === 1 || err.code === 2;
+  if (err.source === 'shaka') return err.category === 1;
+  return false;
 }
 
 /** A stream-level decode/format failure that a fresh session cannot fix —

--- a/client/src/app/core/services/player-state.service.ts
+++ b/client/src/app/core/services/player-state.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject, signal } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import type { PlaybackEngine } from './playback-engine/playback-engine';
 import {
+  isNetworkOrAbort,
   isUndecodableError,
   userMessageKeyFor,
   type PlaybackError,
@@ -59,9 +60,19 @@ export class PlayerStateService {
    *  "Playback error" overlay. Owned by PlayerComponent's recovery flow. */
   private recovering = false;
 
+  /** Live check for whether the current media is Dolby Vision served untouched
+   *  (DirectPlay/DirectStream). Read at error time — not cached — so a mid-session
+   *  play-method change (e.g. a quality switch to a tonemapped transcode) is
+   *  always reflected. Registered once by PlayerComponent. */
+  private dolbyVisionProbe: (() => boolean) | null = null;
+
   setRecovering(value: boolean): void {
     this.recovering = value;
     if (value) this.error.set(null);
+  }
+
+  setDolbyVisionProbe(probe: (() => boolean) | null): void {
+    this.dolbyVisionProbe = probe;
   }
 
   /** Set the error card from a translated one-liner plus optional
@@ -128,14 +139,21 @@ export class PlayerStateService {
         return;
       }
       const source = e.source ?? 'engine';
-      // Prefer the engine's explicit i18n key (Tizen/webOS surface platform
-      // strings); otherwise map the source/code/category to a category
-      // message. The raw fields are kept for the diagnostics block.
-      const userMessage = e.errorKey
-        ? this.translate.instant(e.errorKey)
-        : this.translate.instant(
-            userMessageKeyFor({ source, code: e.code, category: e.category }),
-          );
+      // A DV passthrough that fails to decode wins over everything else (even a
+      // platform errorKey): tell the user Dolby Vision failed on this device.
+      // Otherwise prefer the engine's explicit i18n key (Tizen/webOS surface
+      // platform strings), else map source/code/category to a category message.
+      // The raw fields are kept for the diagnostics block regardless.
+      const dvFailure =
+        (this.dolbyVisionProbe?.() ?? false) &&
+        !isNetworkOrAbort({ source, code: e.code, category: e.category });
+      const userMessage = dvFailure
+        ? this.translate.instant('player.dolby_vision_decode_failed')
+        : e.errorKey
+          ? this.translate.instant(e.errorKey)
+          : this.translate.instant(
+              userMessageKeyFor({ source, code: e.code, category: e.category }),
+            );
       this.setError(userMessage, {
         source,
         code: e.code,

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -248,6 +248,15 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
    *  `ngAfterViewInit` but that happens after the first effect pass. */
   private readonly _stateReset = (this.state.reset(), null);
 
+  /** Register the live DV-passthrough probe once. Read at error time, so it
+   *  reflects the current play method even after a mid-session quality switch.
+   *  `reset()` (called again on episode reload) must not clear it, hence a
+   *  one-shot registration here rather than a per-load sync. */
+  private readonly _dvProbe = (
+    this.state.setDolbyVisionProbe(() => this.isDolbyVisionPassthrough()),
+    null
+  );
+
   private readonly videoEl = viewChild<ElementRef<HTMLVideoElement>>('videoElement');
   private readonly containerEl = viewChild<ElementRef<HTMLDivElement>>('playerContainer');
   private readonly controls = viewChild(PlayerControlsComponent);
@@ -1280,11 +1289,14 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       // message and keep the raw fields for the diagnostics block.
       const isShaka = e?.category != null;
       this.state.setError(
-        isShaka
-          ? this.translate.instant(
-              userMessageKeyFor({ source: 'shaka', code: e?.code, category: e?.category }),
-            )
-          : this.translate.instant('player.playback_error'),
+        this.translate.instant(
+          userMessageKeyFor({
+            source: isShaka ? 'shaka' : 'engine',
+            code: e?.code,
+            category: e?.category,
+            dolbyVision: this.isDolbyVisionPassthrough(),
+          }),
+        ),
         {
           source: isShaka ? 'shaka' : 'engine',
           code: e?.code,
@@ -2057,11 +2069,14 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       // `message` field only — the card body never shows an untranslated string.
       const isShaka = e?.category != null;
       this.state.setError(
-        isShaka
-          ? this.translate.instant(
-              userMessageKeyFor({ source: 'shaka', code: e?.code, category: e?.category }),
-            )
-          : this.translate.instant('player.playback_error'),
+        this.translate.instant(
+          userMessageKeyFor({
+            source: isShaka ? 'shaka' : 'engine',
+            code: e?.code,
+            category: e?.category,
+            dolbyVision: this.isDolbyVisionPassthrough(),
+          }),
+        ),
         {
           source: isShaka ? 'shaka' : 'engine',
           code: e?.code,
@@ -2490,6 +2505,19 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     } catch {
       // Clipboard blocked (insecure context / denied permission) — no-op.
     }
+  }
+
+  /** True when the current media is Dolby Vision AND we're serving it untouched
+   *  (DirectPlay / DirectStream): a decode failure is then a DV-capability
+   *  failure, surfaced with an explicit message. A tonemapped transcode is not
+   *  DV, so it stays on the generic error path. Read live at error time (via the
+   *  probe registered on PlayerStateService) so it tracks quality switches. */
+  private isDolbyVisionPassthrough(): boolean {
+    const method = this.playbackInfo?.playMethod;
+    if (method !== 'DirectPlay' && method !== 'DirectStream') return false;
+    const v = this.media?.files?.find((f) => f.id === this.mediaFileId)
+      ?.streamInfo?.video?.[0];
+    return (v?.dvProfile ?? 0) > 0;
   }
 
   /** Ticked once a second from the stats interval. Detects a frozen playhead


### PR DESCRIPTION
## What

Turns on the Dolby Vision passthrough that #660 wired: clients now **declare** DV support, and the player shows an **explicit** message when a DV stream fails to decode. Per the ask, DV is enabled optimistically per platform (untested on-device) with an explicit failure path.

## Client DV capability (`supportsDolbyVision`)

| Platform | Signal | Rationale |
|---|---|---|
| **Android** | `Display.HdrCapabilities.HDR_TYPE_DOLBY_VISION` in the panel's supported HDR types | Real per-panel signal |
| **iOS** | `AVPlayer.eligibleForHDRPlayback` | No public per-codec DV probe; HDR-eligible Apple devices decode DV P5/8.1 — optimistic proxy |
| **webOS** | `= supportsHdr` | LG OLEDs do DV; no per-model probe — optimistic |
| **web / Shaka, Tizen, Cast** | `false` | Browser MSE has no DV; Tizen is HLS-only with DV signaling not yet wired; Cast profile omits it |

DV is gated under `supportsHdr` (DV ⊆ HDR), so `forceDisableHdr` drops it too. The native probe rides the existing `Hdr.isSupported()` plugin (now returns `{ supported, dolbyVision }`).

## Explicit failure

When a DV passthrough (DirectPlay/DirectStream of a `dvProfile > 0` source) fails to decode, the error card shows `player.dolby_vision_decode_failed` ("La lecture Dolby Vision a échoué sur cet appareil. Choisissez une autre qualité pour la convertir.") instead of a generic decode error — and it wins over a platform `errorKey`. Network/abort blips keep their own message. DV-ness is read **live** at error time via a probe on `PlayerStateService`, so a mid-session quality switch to a tonemapped transcode never mislabels the failure as DV. The diagnostics block still carries the raw code/variant.

## Verification

- `tsc --noEmit -p tsconfig.app.json` clean.
- `playback-error.spec.ts` — 11 tests incl. new DV cases (DV decode → DV key; network/abort → keeps its own).
- Adversarial review (4 dimensions) run before commit: it caught a real staleness bug (the flag going stale on a quality-switch reload) — fixed by switching from a cached boolean synced at each reload to the live probe. Native Android/iOS API correctness and enable-safety (web/Tizen/Cast stay false, no false-positive DV DirectPlay) verified.

## Accepted risks / follow-ups

- **webOS is optimistic**: an HDR10-only LG set (NanoCell/LCD) would claim DV and could render P5 as wrong colors *without* a decode error (so no explicit message). LG OLEDs — the common DV case — are fine. A real webOS panel-DV probe is a follow-up.
- **iOS proxy**: an HDR10-only external display could report DV-eligible; a P5 there falls to the explicit error.
- **Remux (DirectStream) DV** still lacks `EXT-X-SUPPLEMENTAL-CODECS` signaling (deferred with #368 step 5); DirectPlay (raw file) is the clean path.
- Native probes are **not compilable/testable here** — on-device validation pending.

Refs: #368
