### PR TITLE
fix(player): probe webOS Dolby Vision instead of assuming it from HDR

### DIFF
--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -481,21 +481,18 @@ export class BrowserDeviceProfileService {
       supportsHdr = hdrDisplay && has10bitCodec;
     }
 
-    // Dolby Vision passthrough capability. iOS/Android report it from the native
-    // probe (DV HW decoder / DV panel type). webOS OLEDs are assumed DV-capable
-    // when the panel is HDR (no per-model probe; optimistic). Web/Shaka has no DV
-    // (browser MSE never decodes dvh1), and Tizen is HLS-only with DV signaling
-    // not yet wired, so both stay false.
-    // DV is a superset of HDR, so it never outlives supportsHdr (keeps the
-    // forceDisableHdr override consistent, and a non-HDR panel can't present DV).
-    let supportsDolbyVision: boolean;
-    if (Capacitor.isNativePlatform()) {
-      supportsDolbyVision = supportsHdr && (this.nativeDolbyVision ?? false);
-    } else if (tvPlatform === 'webos') {
-      supportsDolbyVision = supportsHdr;
-    } else {
-      supportsDolbyVision = false;
-    }
+    // Dolby Vision passthrough capability, gated under supportsHdr (DV ⊆ HDR, so
+    // it never outlives HDR and the forceDisableHdr override stays consistent).
+    // iOS/Android report it from the native probe (DV HW decoder / DV panel
+    // type). Non-native targets (webOS `<video>`, desktop/web browsers) probe the
+    // DV codec strings directly: LG webOS pipelines answer canPlayType for
+    // dvh1/dvhe on DV panels, while browsers and HDR10-only TVs return empty and
+    // correctly stay false (no green/purple from a copied P5).
+    const supportsDolbyVision =
+      supportsHdr &&
+      (Capacitor.isNativePlatform()
+        ? this.nativeDolbyVision ?? false
+        : this.probeDolbyVision(video, hasMSE));
 
     const useTs = readUseTsOverride();
     if (useTs) console.warn('[DeviceProfile] useTs override active');
@@ -564,6 +561,18 @@ export class BrowserDeviceProfileService {
     const full = codec ? `${mime}; codecs="${codec}"` : mime;
     if (hasMSE) return MediaSource.isTypeSupported(full);
     return !!video.canPlayType(full);
+  }
+
+  /** Probe single-layer Dolby Vision decode (profiles 5 and 8, dvh1/dvhe tags).
+   *  Returns true only if the pipeline actually claims a DV codec — so DV panels
+   *  report true and HDR10-only displays / browsers report false. */
+  private probeDolbyVision(video: HTMLVideoElement, hasMSE: boolean): boolean {
+    return (
+      this.testCodec(video, hasMSE, 'video/mp4', 'dvh1.05.06') ||
+      this.testCodec(video, hasMSE, 'video/mp4', 'dvh1.08.06') ||
+      this.testCodec(video, hasMSE, 'video/mp4', 'dvhe.05.06') ||
+      this.testCodec(video, hasMSE, 'video/mp4', 'dvhe.08.06')
+    );
   }
 
   /** Turn the native plugin's per-codec decode ceiling into a codec-condition


### PR DESCRIPTION
## What

Replaces the optimistic webOS Dolby Vision assumption (from #661) with a real DV codec probe.

Before: `webOS → supportsDolbyVision = supportsHdr`. An HDR10-only LG set (NanoCell / LCD) has an HDR panel but no DV decoder, so it claimed DV and the backend would DirectPlay a copied Profile 5 → **green/purple with no decode error** (so the explicit DV error never fired — a silent failure).

After: non-native targets (webOS `<video>`, browsers) probe the DV codec strings `dvh1.05.06` / `dvh1.08.06` / `dvhe.05.06` / `dvhe.08.06` via `canPlayType`/`MediaSource.isTypeSupported`. LG webOS pipelines answer for DV panels; HDR10-only sets and desktop browsers return empty and correctly stay `false`. Native iOS/Android keep their Capacitor plugin probe (a WebView `canPlayType` doesn't reflect the native decoder). Still gated under `supportsHdr` (DV ⊆ HDR).

Net: a false-positive that could show wrong colours silently becomes a safe fallback (HDR10 / transcode) when DV isn't actually supported.

## Verified

`tsc --noEmit -p tsconfig.app.json` clean.

## Note on the other remaining #368 item (HLS-remux DV signaling)

I looked at adding `EXT-X-SUPPLEMENTAL-CODECS` (dvh1.PP.LL) to the HLS master, but it does not apply cleanly here: the master ladder **re-encodes** every rung (the `-c:v copy` passthrough rung was deliberately dropped for ExoPlayer ABR reliability — see `master-playlist.ts`), so the segments don't carry the DV RPU. Advertising `dvh1` over transcoded segments would be a manifest lie that makes DV clients fail. The clean DV path is raw DirectPlay (shipped in #660/#661); clients that can't raw-DirectPlay DV (e.g. iOS + DV-in-MKV) correctly fall back to a transcode (tonemapped via #636). True DV-over-HLS would require re-introducing an advertised copy rung — a separate, device-validated change, left on #368.

Refs: #368
