### PR TITLE
fix(streaming): never remux Dolby Vision Profile 5 (drops DV signaling)

### DIFF
--- a/backend/src/modules/streaming/dovi-play-method.spec.ts
+++ b/backend/src/modules/streaming/dovi-play-method.spec.ts
@@ -32,6 +32,22 @@ const dvHevcClient: DeviceProfileDto = {
   supportsDolbyVision: true,
 } as never;
 
+// DV-capable client that can NOT raw-play MKV (iOS AVPlayer: mp4/mov only), so a
+// DV-in-MKV source can't DirectPlay and would otherwise fall to a remux copy.
+const dvMp4OnlyClient: DeviceProfileDto = {
+  containers: ['mp4'],
+  directPlayProfiles: [
+    { containers: ['mp4'], videoCodecs: ['hevc'], audioCodecs: ['aac'] },
+  ],
+  codecConditions: [
+    { codec: 'hevc', profiles: ['main', 'main 10'], maxBitDepth: 10, maxWidth: 3840, maxHeight: 2160, maxLevel: 180 },
+  ],
+  supportsHdr: true,
+  supportsDirectPlay: true,
+  supportsDolbyVision: true,
+  maxAudioChannels: 6,
+} as never;
+
 const resolved = (
   dvProfile?: number,
   dvBlSignalCompatId?: number,
@@ -121,5 +137,14 @@ describe('StreamBuilderService — Dolby Vision play-method', () => {
     const out = svc().evaluate(r, dvHevcClient, 'tok');
     expect(out.response.playMethod).toBe('DirectPlay');
     expect(out.response.videoCopyStream).toBe(true);
+  });
+
+  it('transcodes (not remuxes) P5 for a DV client that cannot raw-play the container', () => {
+    // iOS-style: MKV source can't DirectPlay, and the fMP4 remux would drop the
+    // DV config box → green/purple. P5 must tonemap instead of copy.
+    const r = svc().evaluate(resolved(5, 0), dvMp4OnlyClient, 'tok');
+    expect(r.response.playMethod).toBe('Transcode');
+    expect(r.response.videoCopyStream).toBeFalsy();
+    expect(r.response.tonemapping).toBe(true);
   });
 });

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -426,7 +426,11 @@ export class StreamBuilderService {
     // Cannot remux if tone mapping or burn-in is needed (video must be re-encoded).
     // A lower explicit rung / ABR-on-auto wants a re-encoded ladder, not a
     // source-resolution remux copy, so `forceLadder` skips this path too.
-    const canCopyVideo = sourceCopyable && !forceLadder;
+    // Dolby Vision Profile 5 is never remuxed: the fMP4 muxer drops the DV
+    // configuration box on `-c:v copy`, so a copied P5 (whose base layer isn't
+    // valid HDR10) would render green/purple. P5 rides raw DirectPlay (whole
+    // original file, DV intact) or a tonemap transcode instead — never remux.
+    const canCopyVideo = sourceCopyable && !forceLadder && !dvP5;
     if (canCopyVideo) {
       // Some audio codecs the device profile claims to support are
       // only playable in their NATIVE container (e.g. MP3 via


### PR DESCRIPTION
## What

Fixes a green/purple regression for Dolby Vision Profile 5 on the remux path, and settles (with proof) that DV-over-HLS isn't achievable with the current ffmpeg.

## The bug

The DV DirectPlay gate (#660) made single-layer DV source-copyable for a DV-capable client. That was correct for **raw DirectPlay** (the whole original file is served byte-for-byte, DV intact) — but it also let a P5 that *couldn't* raw-DirectPlay (e.g. iOS AVPlayer + DV-in-MKV: MKV isn't a raw-playable container) fall through to the **fMP4 remux copy** path. And the remux can't carry DV.

## Empirical finding (why remux breaks DV)

I verified against the Fliks ffmpeg (6.1.1) — and ffmpeg 7.1 — with a real DV P8.1 sample (dovi_tool RPU → mkvmerge):

- MKV input carries the `DOVI configuration record` (ffprobe confirms).
- MKV → **MKV** copy: DOVI **preserved**.
- MKV → **fMP4** copy: DOVI **dropped** — no `dvcC`/`dvvC` box — across every combination tested (no tag, `-tag:v hvc1`, `-tag:v hev1`, `-tag:v dvh1`, fragmented, plain, HLS-fmp4 segment muxer, `-strict unofficial`). `-tag:v dvh1` renames the sample entry to `dvh1` **without** the required config box → invalid DV.

So a remuxed P5 loses its DV signaling; since P5's base layer isn't valid HDR10, it renders green/purple. (P8.x survives as its HDR10/HLG base, which is fine.)

## Fix

`canCopyVideo = sourceCopyable && !forceLadder && !dvP5` — Profile 5 is never remuxed. It rides **raw DirectPlay** (whole file, DV intact) when the container is raw-playable, or a **tonemap transcode** (correct SDR via #636) otherwise. Never an fMP4 copy.

## Net DV behaviour (clean + definitive)

| Case | Result |
|---|---|
| P5 / P8.x, raw-playable container, DV client | raw DirectPlay — DV preserved |
| P5, non-raw container (iOS + MKV) | tonemap transcode — correct SDR, no green/purple |
| P8.x, non-raw container | remux → HDR10/HLG base (graceful) |
| non-DV client | tonemap transcode (#636) |
| P7 dual-layer | HDR10 base |

## Why "DV over HLS" (EXT-X-SUPPLEMENTAL-CODECS) is not implemented

It would require the fMP4 segments to carry the DV config box, which ffmpeg's MP4 muxer cannot write on copy (proven above). Advertising `dvh1`/`SUPPLEMENTAL-CODECS` over DV-blind segments would hard-reject on strict decoders. The only route would be swapping the live muxer (e.g. GPAC) — disproportionate + destabilising for a niche case. Raw DirectPlay is the DV path; the fallbacks above are correct and watchable.

## Verified

`tsc` clean; `jest src/modules/streaming` 260 tests / 34 suites / 29 snapshots green (added the iOS-MKV P5 → Transcode regression test).

Refs: #368
