### PR TITLE
fix(streaming): keep sprite extraction off the GPU during live transcodes

### DIFF
--- a/backend/src/modules/streaming/thumbnail-extractors/index.ts
+++ b/backend/src/modules/streaming/thumbnail-extractors/index.ts
@@ -51,9 +51,15 @@ const BACKENDS: ExtractorBackend[] = (() => {
   return [new SwExtractor()];
 })();
 
-/** Pick the highest-priority backend that can handle the given crop. */
-export function pickExtractor(crop?: CropArea): ExtractorBackend {
+/** Pick the highest-priority backend that can handle the given crop.
+ *  `forceSoftware` skips every HW backend and returns the CPU extractor —
+ *  used to keep sprite decodes off the GPU while a live transcode owns it. */
+export function pickExtractor(
+  crop?: CropArea,
+  forceSoftware = false,
+): ExtractorBackend {
   for (const b of BACKENDS) {
+    if (forceSoftware && b.name !== 'sw') continue;
     if (b.supports(crop)) return b;
   }
   // Unreachable — SwExtractor.supports() always returns true.

--- a/backend/src/modules/streaming/thumbnail.service.ts
+++ b/backend/src/modules/streaming/thumbnail.service.ts
@@ -14,6 +14,7 @@ import {
   pickExtractor,
   type CropArea,
 } from './thumbnail-extractors';
+import { TranscodingService } from './transcoding';
 
 const execFileAsync = promisify(execFile);
 
@@ -95,9 +96,21 @@ export class ThumbnailService {
     private readonly eventsService: EventsService,
     @InjectRepository(Command)
     private readonly commandRepo: Repository<Command>,
+    private readonly transcoding: TranscodingService,
   ) {
     this.log.log(
       `Thumbnail extraction backends: ${describeBackends()} (SEEK_CONCURRENCY=${SEEK_CONCURRENCY}, SPRITE_CONCURRENCY=${SPRITE_CONCURRENCY})`,
+    );
+  }
+
+  /** Pick the frame extractor, forcing the CPU path while a live transcode is
+   *  using the GPU. HW sprite decodes share the same render node as the
+   *  transcode's decode/VPP pipeline with no GPU budget between them, so an
+   *  unguarded sprite burst starves (or, on QSV, kills) the live session. */
+  private chooseExtractor(crop?: CropArea) {
+    return pickExtractor(
+      crop,
+      HWACCEL_AVAILABLE && this.transcoding.hasActiveTranscode(),
     );
   }
 
@@ -266,7 +279,7 @@ export class ThumbnailService {
 
     // Ask the factory which backend will run, so the log line matches
     // exactly what ffmpeg sees per frame.
-    const decode = pickExtractor(crop).describe();
+    const decode = this.chooseExtractor(crop).describe();
     this.log.log(
       `Sprite START for "${label}" (file #${mediaFileId}): ${count} thumbs @ ${interval}s interval, workers=${SEEK_CONCURRENCY}, decode=${decode}, otherSprites=${otherRunning}, queued=${this.queue.length}, srcSize=${srcSizeMb ?? '?'}MB, crop=${
         crop ? `${crop.width}x${crop.height}+${crop.x},${crop.y}` : 'none'
@@ -597,7 +610,7 @@ export class ThumbnailService {
     crop?: CropArea,
   ): Promise<void> {
     return new Promise((resolve, reject) => {
-      const args = pickExtractor(crop).buildArgs({
+      const args = this.chooseExtractor(crop).buildArgs({
         inputPath,
         seekSeconds,
         outputPath,

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -231,6 +231,16 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     return this.detectedHwAccel;
   }
 
+  /** True while any transcode ffmpeg is still running. ThumbnailService reads it
+   *  to keep HW sprite extraction off the GPU while a live transcode needs the
+   *  decode/VPP pipeline (ionice/nice only de-prioritise CPU, not the GPU). */
+  hasActiveTranscode(): boolean {
+    for (const session of this.sessions.values()) {
+      if (session.process.exitCode === null) return true;
+    }
+    return false;
+  }
+
   /** List of tone-mapping algorithms the current host can run.
    *  `'auto'` is always available — it maps to the platform's native
    *  HW path (`scale_vt` on macOS / VideoToolbox, tonemap_opencl or


### PR DESCRIPTION
Fixes the MEDIUM audit finding #639: sprite/trickplay HW extraction shares the GPU with live transcodes with no coordination.

## Problem
`ThumbnailService` and `TranscodingService` are independent consumers of the same render node. A sprite job spawns up to `SEEK_CONCURRENCY×SPRITE_CONCURRENCY` = 8 concurrent `ffmpeg -hwaccel` decodes as background work (post-download, rescan, scheduled batches) with **no awareness** of a live transcode. When they hit the GPU alongside a transcode, the transcode loses real-time headroom (rebuffering / infinite spinner) and, on QSV, can exhaust the frame pool and **die mid-session** (the seg-0 CPU-fallback check has already passed, so it's never recovered). `ionice`/`nice` only de-prioritise CPU/IO — they have no effect on the GPU command queue.

## Fix
- `TranscodingService.hasActiveTranscode()` — true while any transcode ffmpeg is running.
- `ThumbnailService.chooseExtractor()` — while a transcode is active on a HW host, forces the CPU/SW frame extractor (`pickExtractor(crop, forceSoftware)`), so sprite decodes never share the GPU with a live session. Sprite CPU work stays de-prioritised via the existing ionice/nice wrapper.

No shared-semaphore rework needed: sprite generation is best-effort background work, so yielding the GPU to the live session (and running sprites on CPU meanwhile) is the correct trade-off. Only `extractFrameAt` (the HW decode) is gated; the CPU-only tiling step is untouched.

## Verified
`tsc` clean; `jest src/modules/streaming` 260 tests / 34 suites / 29 snapshots green. (No DI cycle: TranscodingService doesn't depend on ThumbnailService.)

Refs: #639