### PR TITLE
fix(player): skip reload when re-selecting the active quality rung

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -3242,6 +3242,13 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   async onSelectQualityById(id: string) {
     const option = this.availableQualities().find(q => q.id === id);
     if (!option) return;
+    // Re-selecting the active rung is a no-op: selectQuality() short-circuits
+    // internally, but reloadStream() would still kill + re-mint the session
+    // (ffmpeg stop, playback-info, full engine.load) for zero change.
+    if (id === this.activeQualityId()) {
+      this.resetHideTimer();
+      return;
+    }
     const mode = this.playbackMode();
     // Picking a rung below source — or any rung while already on the HLS
     // ladder — re-negotiates playback: reloadStream() re-requests playback-info


### PR DESCRIPTION
Fixes the LOW audit finding #641.

## Problem
Tapping the **already-selected** rung in the quality menu ran the full reload path — `reloadStream()` → `stopSessions()` (kills ffmpeg) → `getPlaybackInfo()` → `engine.load()` — for **zero change**: seconds of spinner mid-film and a black flash on native engines. `selectQuality()` already short-circuits on the same id, but the reload fired regardless (no same-id guard in `onSelectQualityById`).

## Fix
Early-return in `onSelectQualityById` when the picked id equals `activeQualityId()`.

## Scope note
The audit's broader suggestion (use `selectVariantTrack` instead of reload for genuine rung changes) does **not** apply: the backend's `applyQualityPin` collapses a pinned rung to a single-variant master (deliberately, to stop native ExoPlayer/AVPlayer ABR-thrashing ffmpeg), so a real 720p↔1080p switch must re-negotiate playback-info — the reload there is by design and is left unchanged. Only the no-op re-click is fixed.

## Verified
`tsc --noEmit -p tsconfig.app.json` clean.

Refs: #641