### PR TITLE
refactor(streaming): drop unused Dolby Vision supplementalTag

### DIFF
--- a/backend/src/modules/streaming/transcoding/codec/dolby-vision.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/dolby-vision.spec.ts
@@ -5,20 +5,17 @@ describe('deriveDvInfo', () => {
     const info = deriveDvInfo({ dvProfile: 5, dvBlSignalCompatId: 0 });
     expect(info.singleLayer).toBe(true);
     expect(isDvProfile5(info)).toBe(true);
-    expect(info.supplementalTag).toBeNull();
   });
 
-  it('classifies P8.1 as single-layer with the db1p brand', () => {
+  it('classifies P8.1 (HDR10 base) as single-layer', () => {
     const info = deriveDvInfo({ dvProfile: 8, dvBlSignalCompatId: 1 });
     expect(info.singleLayer).toBe(true);
     expect(isDvProfile5(info)).toBe(false);
-    expect(info.supplementalTag).toBe('db1p');
   });
 
-  it('classifies P8.4 with the db4h brand', () => {
+  it('classifies P8.4 (HLG base) as single-layer', () => {
     const info = deriveDvInfo({ dvProfile: 8, dvBlSignalCompatId: 4 });
     expect(info.singleLayer).toBe(true);
-    expect(info.supplementalTag).toBe('db4h');
   });
 
   it('treats a dual-layer profile (enhancement layer present) as not single-layer', () => {
@@ -45,6 +42,5 @@ describe('deriveDvInfo', () => {
     expect(info.profile).toBeUndefined();
     expect(info.singleLayer).toBe(false);
     expect(isDvProfile5(info)).toBe(false);
-    expect(info.supplementalTag).toBeNull();
   });
 });

--- a/backend/src/modules/streaming/transcoding/codec/dolby-vision.ts
+++ b/backend/src/modules/streaming/transcoding/codec/dolby-vision.ts
@@ -6,9 +6,6 @@ export interface DvInfo {
   profile?: number;
   compatId?: number;
   singleLayer: boolean;
-  /** EXT-X-SUPPLEMENTAL-CODECS brand for the base-layer compatibility:
-   *  db1p = 8.1 (HDR10 base), db4h = 8.4 (HLG base). */
-  supplementalTag: 'db1p' | 'db4h' | null;
 }
 
 export interface DvStream {
@@ -22,9 +19,7 @@ export function deriveDvInfo(v?: DvStream): DvInfo {
   const compatId = v?.dvBlSignalCompatId;
   const singleLayer =
     (profile === 5 || profile === 8) && v?.dvElPresent !== true;
-  const supplementalTag =
-    compatId === 1 ? 'db1p' : compatId === 4 ? 'db4h' : null;
-  return { profile, compatId, singleLayer, supplementalTag };
+  return { profile, compatId, singleLayer };
 }
 
 /** Profile 5: single-layer IPT-PQ-C2 with no HDR10 base. A non-DV client that


### PR DESCRIPTION
Removes the dead `supplementalTag` (db1p/db4h) from `deriveDvInfo`. It was added for an `EXT-X-SUPPLEMENTAL-CODECS` manifest line that's proven infeasible (ffmpeg 6.1/7.1 drop the DV config box on fMP4 `-c:v copy`), and it never had a production consumer. The raw `compatId` stays. Surfaced by the #464 HDR-epic audit.

Verified: tsc clean; dolby-vision + dovi-play-method specs green (12 tests).

Refs: #464