### PR TITLE
feat(player): show the output codec and HDR format in transcode stats

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -728,7 +728,12 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       videoPlaybackMode = this.translate.instant('player.stats_direct_playback');
     } else {
       const hwLabel: Record<string, string> = { qsv: 'QSV', vaapi: 'VAAPI', nvenc: 'NVENC', videotoolbox: 'Apple VT', none: 'CPU' };
-      videoPlaybackMode = this.translate.instant('player.stats_transcoding', { hw: hwLabel[hw] ?? hw.toUpperCase() });
+      const parts = [hwLabel[hw] ?? hw.toUpperCase()];
+      if (pi?.outputVideoCodec) parts.push(pi.outputVideoCodec.toUpperCase());
+      // HDR survives the transcode only when the source is HDR and we're not
+      // tonemapping to SDR — surface the format (HDR10 / HLG) that's emitted.
+      if (src?.hdrFormat && !pi?.tonemapping) parts.push(src.hdrFormat);
+      videoPlaybackMode = this.translate.instant('player.stats_transcoding', { hw: parts.join(' ') });
     }
     if (playingHeight && src?.height && playingHeight < src.height) {
       videoPlaybackMode += ` \u2192 ${playingWidth}x${playingHeight}`;


### PR DESCRIPTION
§8 of the #464 HDR epic. The stats overlay showed only the hwAccel (`Transcodage (QSV)`); now it appends the output codec and, when HDR is preserved through the transcode (source HDR + not tonemapping), the HDR format — e.g. `Transcodage (QSV HEVC HDR10)`. Display-only, from fields already in the playback-info response (`outputVideoCodec`, `tonemapping`, `source.hdrFormat`).

Verified: client tsc clean.

Refs: #464