### PR TITLE
refactor(streaming): drop the no-op CCwGTV resolution-cap quirk

### DIFF
--- a/backend/src/modules/streaming/transcoding/codec/fallback.ts
+++ b/backend/src/modules/streaming/transcoding/codec/fallback.ts
@@ -49,14 +49,6 @@ const CCWGTV_HD_NO_4K_HEVC_HDR: ClientQuirk = {
     'Chromecast with Google TV (HD) silently fails HEVC Main10 above 1080p',
 };
 
-const CCWGTV_HD_NO_4K: ClientQuirk = {
-  id: 'ccwgtv-hd-no-4k-rungs',
-  matches: (ctx) =>
-    /chromecast.+google.+tv/i.test(ctx.userAgent) && !/4k/i.test(ctx.userAgent),
-  filter: (variants) => variants,
-  reason: 'Chromecast with Google TV (HD) caps decode at 1080p',
-};
-
 const OLDER_CHROMECAST_NO_AV1: ClientQuirk = {
   id: 'older-chromecast-no-av1',
   matches: (ctx) => {
@@ -84,7 +76,6 @@ const APPLE_TV_PRE_A17_NO_AV1: ClientQuirk = {
 
 const REGISTRY: readonly ClientQuirk[] = [
   CCWGTV_HD_NO_4K_HEVC_HDR,
-  CCWGTV_HD_NO_4K,
   OLDER_CHROMECAST_NO_AV1,
   APPLE_TV_PRE_A17_NO_AV1,
 ];


### PR DESCRIPTION
§7 of the #464 HDR epic. `CCWGTV_HD_NO_4K` was a no-op (`filter: variants => variants`). A resolution cap can't be a codec-variant filter — it lives in the device profile's `codecConditions` (maxWidth/maxHeight), already fed by the native decoder probe. The genuine CCwGTV HEVC-HDR-above-1080p failure stays covered by `CCWGTV_HD_NO_4K_HEVC_HDR`.

(Also considered a MediaTek/Dimensity HDR-throttle quirk from the audit but deliberately skipped it: WebView UA doesn't expose the SoC, and per-codec decoder resolution limits are already reported by the native VideoCapabilities probe — a UA quirk would be a redundant, fragile band-aid.)

Verified: tsc clean; no spec referenced the removed quirk.

Refs: #464