### PR TITLE
feat(streams): show client build version for non-web devices

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -37,6 +37,7 @@
           "path": "macos/Fliks/Info.plist"
         },
         "client/android/app/build.gradle",
+        "client/src/environments/environment.ts",
         "cast-receiver/index.html",
         "client/ios/App/App.xcodeproj/project.pbxproj"
       ]

--- a/backend/src/modules/scheduler/system.controller.spec.ts
+++ b/backend/src/modules/scheduler/system.controller.spec.ts
@@ -37,6 +37,7 @@ describe('SystemController.activeStreams recency filter', () => {
       kind: 'directplay',
       deviceLabel: null,
       systemName: null,
+      appVersion: null,
       sseConnectionId: null,
       startedAt: new Date(overrides.lastBeat),
       position: 0,

--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -81,6 +81,9 @@ export interface ActiveStreamDto {
   /** Real host OS name+version ("macOS 26") from the client; overrides the
    *  frozen-UA OS in the device label. */
   systemName: string | null;
+  /** Fliks client build version ("1.15.2"); only non-web clients (native app /
+   *  TV / desktop) report it, so it's null for browser sessions. */
+  appVersion: string | null;
   startedAt: string;
   lastActivity: string;
   // Progress
@@ -406,6 +409,7 @@ export class SystemController {
       lastActivity: string;
       deviceLabel: string | null;
       systemName: string | null;
+      appVersion: string | null;
       transcodeSession: TranscodeSession | undefined;
       audioPlan: LiveSessionSnapshot['audioPlan'];
       position: number;
@@ -456,6 +460,7 @@ export class SystemController {
               )
             : null),
         systemName: session.systemName,
+        appVersion: session.appVersion,
         transcodeSession: ts,
         audioPlan: session.audioPlan,
         // The LiveSession keeps the playhead fresh on every heartbeat — read
@@ -525,6 +530,7 @@ export class SystemController {
         hwAccel: s.hwAccelVal,
         device: s.deviceLabel,
         systemName: s.systemName,
+        appVersion: s.appVersion,
         startedAt: s.startedAt,
         lastActivity: s.lastActivity,
         positionSeconds,

--- a/backend/src/modules/streaming/dto/device-profile.dto.ts
+++ b/backend/src/modules/streaming/dto/device-profile.dto.ts
@@ -162,6 +162,15 @@ export class DeviceProfileDto {
   @MaxLength(60)
   systemName?: string;
 
+  /** Fliks client build version ("1.15.2"), sent only by non-web clients
+   *  (native app / TV / desktop). Web omits it — its bundle is always the
+   *  server's current build, so a version there is redundant. Shown next to
+   *  the device label on the admin streams dashboard. Cosmetic only. */
+  @IsString()
+  @IsOptional()
+  @MaxLength(40)
+  appVersion?: string;
+
   /**
    * Force MPEG-TS segments for every transcode session of this device.
    * Hard override, used as an emergency switch (admin / debug). The

--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -55,6 +55,10 @@ export interface LiveSession {
   /** Real host OS name+version ("macOS 26") from the client DeviceProfile;
    *  preferred over the UA-derived label in the admin streams dashboard. */
   systemName: string | null;
+  /** Fliks client build version ("1.15.2") from the DeviceProfile; only
+   *  non-web clients (native app / TV / desktop) send it. Shown next to the
+   *  device label on the admin streams dashboard. */
+  appVersion: string | null;
   /** SSE connection that owns this playback — admin remote-control is routed
    *  here so a second device on the same (user, file) is left untouched. */
   sseConnectionId: string | null;
@@ -126,6 +130,7 @@ export interface CreateLiveSessionInput {
   kind: SessionKind;
   deviceLabel?: string | null;
   systemName?: string | null;
+  appVersion?: string | null;
   sseConnectionId?: string | null;
   position?: number;
   useTs?: boolean;
@@ -234,6 +239,7 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
       kind: input.kind,
       deviceLabel: input.deviceLabel ?? null,
       systemName: input.systemName ?? null,
+      appVersion: input.appVersion ?? null,
       sseConnectionId: input.sseConnectionId ?? null,
       startedAt: now,
       lastBeat: now,

--- a/backend/src/modules/streaming/streaming.controller.spec.ts
+++ b/backend/src/modules/streaming/streaming.controller.spec.ts
@@ -126,6 +126,7 @@ describe('StreamingController.stopLiveSession', () => {
       kind: 'directplay',
       deviceLabel: null,
       systemName: null,
+      appVersion: null,
       sseConnectionId: null,
       startedAt: Date.now(),
       lastBeat: Date.now(),

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -805,6 +805,7 @@ export class StreamingController {
       kind,
       deviceLabel,
       systemName: deviceProfile.systemName ?? null,
+      appVersion: deviceProfile.appVersion ?? null,
       sseConnectionId,
       position: resumePosition,
       useTs: effectiveUseTs,

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1020,6 +1020,7 @@
     "device_google_tv": "Google TV",
     "device_samsung_tv": "TV Samsung",
     "device_lg_tv": "TV LG",
+    "device_client_version": "v{{version}}",
     "commands_title": "Déclencher une tâche",
     "cmd_rss_sync": "Synchronisation RSS",
     "cmd_search_missing": "Rechercher les manquants",

--- a/client/src/app/core/services/api/streams-api.service.ts
+++ b/client/src/app/core/services/api/streams-api.service.ts
@@ -21,6 +21,10 @@ export interface ActiveStream {
   /** Real host OS name+version ("macOS 26") sent by the client; overrides the
    *  UA-derived OS (which the browser freezes) in the device label. */
   systemName: string | null;
+  /** Fliks client build version ("1.15.2"); only non-web clients (native app /
+   *  TV / desktop) report it, so it's null for browser sessions. Shown next to
+   *  the device label. */
+  appVersion: string | null;
   startedAt: string;
   lastActivity: string;
   positionSeconds: number;

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -6,6 +6,7 @@ import { ServerConfigService } from './server-config.service';
 import { ENGINE_TRAITS, engineKindFor } from './engine-traits';
 import { SystemInfoService } from './system-info.service';
 import { getDeviceName } from '../utils/device-info';
+import { environment } from '../../../environments/environment';
 
 interface HdrPlugin {
   isSupported(): Promise<{ supported: boolean; dolbyVision?: boolean }>;
@@ -101,6 +102,10 @@ export interface DeviceProfile {
   /** Real host OS name+version ("macOS 26", "iOS 18.5") resolved natively; the
    *  admin label prefers this over the UA-derived OS (which the UA freezes). */
   systemName?: string;
+  /** Fliks client build version ("1.15.2"). Sent only by non-web clients
+   *  (native app / TV / desktop): a browser always runs the server's current
+   *  build, so a version there is redundant. Shown on the admin dashboard. */
+  appVersion?: string;
   /** Hard force MPEG-TS HLS for every transcode session of this client.
    *  Defaults to `false`; the only switch in shipping configs is the
    *  narrower `useTsOnSingleAudio` below. Opt-in via
@@ -497,6 +502,12 @@ export class BrowserDeviceProfileService {
     const useTs = readUseTsOverride();
     if (useTs) console.warn('[DeviceProfile] useTs override active');
 
+    // A plain browser always runs the server's current build, so its version is
+    // redundant on the admin dashboard — only the installed clients (native app,
+    // Smart TV, desktop shell) report a build version worth surfacing.
+    const isWeb =
+      !Capacitor.isNativePlatform() && !isTv && !this.device.isDesktopNative();
+
     return {
       directPlayProfiles: [{
         containers,
@@ -511,6 +522,7 @@ export class BrowserDeviceProfileService {
       supportsDolbyVision,
       deviceType: Capacitor.isNativePlatform() ? 'mobile' : 'desktop',
       deviceName: getDeviceName(),
+      appVersion: isWeb ? undefined : environment.version,
       useTs,
       // Tizen opts into MPEG-TS on single-audio sources (AVPlay's HLS-fMP4
       // rendition-probe stall, issue #148). Multi-audio sources stay on

--- a/client/src/app/features/system/streams/streams.html
+++ b/client/src/app/features/system/streams/streams.html
@@ -125,7 +125,9 @@
         <div class="text-center text-xs text-base-content/60 py-1.5">
           {{ s.username ?? '—' }}
           @if (formatDevice(s.device, s.systemName); as deviceLabel) {
-            <div class="text-base-content/40">{{ deviceLabel }}</div>
+            <div class="text-base-content/40">
+              {{ deviceLabel }}@if (s.appVersion) {<span class="opacity-70"> · {{ 'system.device_client_version' | translate:{ version: s.appVersion } }}</span>}
+            </div>
           }
         </div>
 

--- a/client/src/environments/environment.ts
+++ b/client/src/environments/environment.ts
@@ -1,5 +1,9 @@
 export const environment = {
   production: false,
+  /** Fliks client build version, kept in sync with client/package.json by
+   *  release-please. Reported to the backend (non-web clients only) so the
+   *  admin streams dashboard can show which app build a viewer is running. */
+  version: '1.15.2', // x-release-please-version
   /** Base URL pour ApiHandlerService (chemins versionnés sous /api). */
   apiUrl: '/api',
   /**


### PR DESCRIPTION
## What

In **Admin → Video activity**, each active stream shows the viewer's device (e.g. *"Application Windows 11"*). Non-web clients now also show the **client build version** next to that label, so it reads *"Application Windows 11 · v1.15.2"*.

Web browsers show no version — their bundle is always the server's current build, so a version there is redundant. Only installed clients (native app, Smart TV, desktop shell) report one.

## How

- **Version source**: baked from `client/package.json` into `environment.version`, kept in sync by release-please via the `x-release-please-version` annotation (same mechanism as `build.gradle`). `environment.ts` was added to the release-please `extra-files`.
- **Plumbing**: the new `appVersion` field rides the exact same path as `systemName`, end to end — `DeviceProfileDto` → `LiveSession` → `ActiveStreamDto` → client `ActiveStream` → template.
- **Non-web detection** (client): `!Capacitor.isNativePlatform() && !isTv && !isDesktopNative()` — the version is only sent by non-web clients.
- A `system.device_client_version` i18n key (`"v{{version}}"`) carries the label so no user-facing string is hardcoded.

## Verification

- Backend typecheck (`tsc --noEmit`): pass
- Client build (`ng build`): pass
- `system.controller` + `streaming.controller` specs: 16/16 pass