### PR TITLE
feat(home): add a customize-home shortcut card

### DIFF
--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -258,7 +258,9 @@
     "recent_media_in": "Récemment ajouté – {{library}}",
     "requests_recent": "Demandes récentes",
     "cw_remove_title": "Retirer",
-    "cw_remove_message": "Retirer « {{title}} » de la liste ?"
+    "cw_remove_message": "Retirer « {{title}} » de la liste ?",
+    "customize": "Personnaliser l'accueil",
+    "customize_hint": "Ajoutez, retirez et réorganisez les zones de l'accueil"
   },
   "playback_settings": {
     "title": "Paramètres de lecture",

--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -161,6 +161,17 @@
     }
   }
 
+  <!-- Mobile: compact box (icon beside text); tablet/desktop: stacked box -->
+  <a routerLink="/app-settings/home"
+     data-home-focus="customize"
+     class="flex items-center gap-3 sm:block w-full sm:max-w-md rounded-2xl bg-base-content/5 hover:bg-base-content/10 focus-visible:bg-base-content/10 p-4 sm:p-6 transition-colors">
+    <app-lucide-icon name="layout-grid" class="h-6 w-6 sm:h-7 sm:w-7 shrink-0 text-base-content/70" />
+    <div class="min-w-0">
+      <h2 class="sm:mt-4 text-base sm:text-lg font-semibold">{{ 'home.customize' | translate }}</h2>
+      <p class="mt-0.5 sm:mt-1 text-xs sm:text-sm text-base-content/60">{{ 'home.customize_hint' | translate }}</p>
+    </div>
+  </a>
+
 </div>
 
 <app-request-decline-modal

--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -178,7 +178,7 @@
          navigate via the drawer/sidebar; phones use the dock as the primary
          nav surface so they need the spacer to avoid content under the bar. -->
     @if (isNative && device.isPhone()) {
-      <div class="h-20"></div>
+      <div class="h-24"></div>
     }
     <!-- Native bottom navigation bar — phones only.
          Tablets and TV use the drawer/sidebar instead. -->


### PR DESCRIPTION
## What

Adds a boxed shortcut at the bottom of the home page that links to `/app-settings/home`, giving users a direct entry point to the home-customization screen (the page where they reorder/toggle home sections).

## Design

- **Phones (< sm):** compact box — icon beside title + description, reduced padding, so it stays lightweight and doesn't eat vertical space.
- **Tablet / desktop (≥ sm):** the box switches to a stacked card (icon on top, larger padding), capped at `max-w-md`, left-aligned to match the home rows.
- Inspired by the Android TV "customize channels" card; wording reuses the existing "zones de l'accueil" vocabulary from the home-settings page.
- Icon via the shared `<app-lucide-icon>` (`layout-grid`); text via ngx-translate (`home.customize`, `home.customize_hint`).
- `data-home-focus` set so the card is reachable via TV/remote spatial navigation.

## Also

Bumps the native bottom-dock spacer (`h-20` → `h-24`) so page content clears the dock on phones.

## Verification

`ng build` passes clean.