### PR TITLE
feat(home): add a recently-modified playlists zone

### DIFF
--- a/backend/src/modules/playlists/playlists.service.ts
+++ b/backend/src/modules/playlists/playlists.service.ts
@@ -352,6 +352,8 @@ export class PlaylistsService {
           }),
         );
         await itemRepo.save(rows);
+        // Reflect item changes in updatedAt (it otherwise only moves on rename).
+        await m.update(Playlist, playlistId, { updatedAt: () => 'now()' });
         return { added: rows.length };
       });
 
@@ -475,6 +477,8 @@ export class PlaylistsService {
     if (!res.affected) {
       throw new NotFoundException(`Playlist item #${itemId} not found`);
     }
+    // Reflect item changes in updatedAt (it otherwise only moves on rename).
+    await this.repo.update(playlistId, { updatedAt: () => 'now()' });
   }
 
   /** Remove every item of one media from the playlist — for a series this is
@@ -489,6 +493,10 @@ export class PlaylistsService {
       playlist: { id: playlistId },
       media: { id: mediaId },
     });
+    if (res.affected) {
+      // Reflect item changes in updatedAt (it otherwise only moves on rename).
+      await this.repo.update(playlistId, { updatedAt: () => 'now()' });
+    }
     return { removed: res.affected ?? 0 };
   }
 
@@ -552,6 +560,8 @@ export class PlaylistsService {
       for (let idx = 0; idx < dto.itemIds.length; idx++) {
         await m.update(PlaylistItem, { id: dto.itemIds[idx] }, { position: idx });
       }
+      // Reflect item changes in updatedAt (it otherwise only moves on rename).
+      await m.update(Playlist, playlistId, { updatedAt: () => 'now()' });
     });
   }
 

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -255,6 +255,7 @@
     "coming_soon": "Bientôt disponible",
     "recent_media": "Récemment ajoutés",
     "recommendations": "Recommandations",
+    "playlists": "Playlists récentes",
     "recent_media_in": "Récemment ajouté – {{library}}",
     "requests_recent": "Demandes récentes",
     "cw_remove_title": "Retirer",
@@ -567,7 +568,6 @@
     "bulk_monitored": "Surveillance",
     "view_suggestions": "Suggestions",
     "view_genres": "Genres",
-    "element_count": "{{count}} éléments",
     "order_asc": "Tri croissant",
     "order_desc": "Tri décroissant",
     "filter_button": "Filtres",
@@ -1086,6 +1086,8 @@
     "recap": "Résumé"
   },
   "common": {
+    "item_count_one": "{{count}} élément",
+    "item_count_other": "{{count}} éléments",
     "search": "Rechercher…",
     "confirm": "Confirmer",
     "cancel": "Annuler",
@@ -1125,7 +1127,6 @@
     "empty": "Aucune liste de lecture",
     "no_items": "Cette liste est vide",
     "new_placeholder": "Nom de la liste",
-    "item_count": "{{count}} élément(s)",
     "rename": "Renommer",
     "settings": "Paramètres",
     "saved": "Modifications enregistrées",
@@ -2072,6 +2073,7 @@
       "continue_watching": "Reprendre la lecture",
       "recommendations": "Recommandations",
       "recently_added": "Récemment ajouté",
+      "playlists": "Playlists récentes",
       "coming_soon": "Bientôt disponible",
       "requests_recent": "Demandes récentes"
     },

--- a/client/src/app/core/services/api/playlists-api.service.ts
+++ b/client/src/app/core/services/api/playlists-api.service.ts
@@ -16,6 +16,8 @@ export interface Playlist {
   itemCount: number;
   /** First up-to-4 poster URLs for the card mosaic (per-viewer). */
   posters: string[];
+  /** ISO timestamp of the last edit (rename, flag or item change). */
+  updatedAt: string;
 }
 
 export interface PlaylistEpisode {

--- a/client/src/app/core/services/home-settings.service.ts
+++ b/client/src/app/core/services/home-settings.service.ts
@@ -7,6 +7,7 @@ export type HomeSectionKey =
   | 'continue-watching'
   | 'recommendations'
   | 'recently-added'
+  | 'playlists'
   | 'coming-soon'
   | 'requests-recent'
   | `library-recent:${number}`;
@@ -16,6 +17,7 @@ export type HomeSectionType =
   | 'continue-watching'
   | 'recommendations'
   | 'recently-added'
+  | 'playlists'
   | 'coming-soon'
   | 'requests-recent'
   | 'library-recent';
@@ -50,6 +52,7 @@ const BUILTIN_ORDER: HomeSectionKey[] = [
   'continue-watching',
   'recommendations',
   'recently-added',
+  'playlists',
   'coming-soon',
 ];
 

--- a/client/src/app/features/app-settings/home-settings/home-settings.ts
+++ b/client/src/app/features/app-settings/home-settings/home-settings.ts
@@ -91,6 +91,7 @@ export class HomeSettingsPageComponent implements OnInit {
     'continue-watching': 'home_settings.section.continue_watching',
     recommendations: 'home_settings.section.recommendations',
     'recently-added': 'home_settings.section.recently_added',
+    playlists: 'home_settings.section.playlists',
     'coming-soon': 'home_settings.section.coming_soon',
     'requests-recent': 'home_settings.section.requests_recent',
   };

--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -99,6 +99,25 @@
         }
       }
 
+      <!-- Recently modified playlists -->
+      @case ('playlists') {
+        @if (playlists().length) {
+          <app-horizontal-scroller [title]="'home.playlists' | translate">
+            @for (p of playlists(); track p.id) {
+              <div class="shrink-0 w-28 sm:w-32 lg:w-40">
+                <app-mosaic-card
+                  [attr.data-home-focus]="'playlist:' + p.id"
+                  [posters]="p.posters"
+                  [label]="p.name"
+                  [subtitle]="(p.itemCount <= 1 ? 'common.item_count_one' : 'common.item_count_other') | translate: { count: p.itemCount }"
+                  (clicked)="openPlaylist(p.id)"
+                />
+              </div>
+            }
+          </app-horizontal-scroller>
+        }
+      }
+
       <!-- Coming Soon -->
       @case ('coming-soon') {
         @if (comingSoon().length) {

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -6,6 +6,7 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { MediaService, Media, CalendarEntry } from '../../core/services/api/media.service';
 import { StreamingApiService, ContinueWatchingItem, RecommendationItem } from '../../core/services/api/streaming-api.service';
 import { LibrariesApiService, LibrarySummary } from '../../core/services/api/libraries-api.service';
+import { PlaylistsApiService, Playlist } from '../../core/services/api/playlists-api.service';
 import { RequestsService, FliksRequestRow } from '../../core/services/api/requests.service';
 import { SseService } from '../../core/services/sse.service';
 import {
@@ -27,6 +28,7 @@ import { LibraryPrefsService } from '../../core/services/library-prefs.service';
 import { TvService } from '../../core/services/tv.service';
 import { CardAction } from '../../core/services/card-actions.service';
 import { MediaCardComponent } from '../../shared/components/media-card/media-card';
+import { MosaicCardComponent } from '../../shared/components/mosaic-card/mosaic-card';
 import { HorizontalScrollerComponent } from '../../shared/components/horizontal-scroller';
 import { LucideIconComponent } from '../../shared/components/lucide-icon';
 import { SetupChecklistComponent } from '../../shared/components/setup-checklist/setup-checklist';
@@ -73,6 +75,7 @@ import { RequestDeclineModalComponent } from '../requests/request-decline-modal/
   imports: [
     RouterLink, TranslateModule, DefaultFocusDirective,
     MediaCardComponent,
+    MosaicCardComponent,
     HorizontalScrollerComponent,
     LucideIconComponent,
     SetupChecklistComponent,
@@ -91,6 +94,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly router = inject(Router);
   private readonly playableMedia = inject(PlayableMediaService);
   private readonly librariesApi = inject(LibrariesApiService);
+  private readonly playlistsApi = inject(PlaylistsApiService);
   private readonly requestsService = inject(RequestsService);
   private readonly sse = inject(SseService);
   private readonly downloadProgress = inject(DownloadProgressService);
@@ -131,6 +135,8 @@ export class HomeComponent implements OnInit, OnDestroy {
   readonly recentMedia = signal<Media[]>([]);
   readonly comingSoon = signal<CalendarEntry[]>([]);
   readonly recommendations = signal<RecommendationItem[]>([]);
+  /** Accessible playlists ordered by last modification, for the "playlists" zone. */
+  readonly playlists = signal<Playlist[]>([]);
   /** Recently-added items per library, keyed by library id (opt-in zones). */
   readonly libraryRecent = signal<Map<number, Media[]>>(new Map());
   /** Latest requests (scoped to rights by the backend) for the optional
@@ -253,6 +259,10 @@ export class HomeComponent implements OnInit, OnDestroy {
     return c;
   }
 
+  openPlaylist(id: number): void {
+    void this.router.navigate(['/playlists', id]);
+  }
+
   async ngOnInit() {
     this.scrollMemory.activate(HomeComponent.SCROLL_KEY);
     // Profile names for the request cards are resolved client-side (same as
@@ -336,14 +346,21 @@ export class HomeComponent implements OnInit, OnDestroy {
   private async loadAllSections(opts: { force?: boolean } = {}): Promise<void> {
     const force = !!opts.force;
     try {
-      const [libs, cw, recs] = await Promise.all([
+      const [libs, cw, recs, pls] = await Promise.all([
         this.librariesApi.listMine({ force }).catch(() => null),
         this.streamingApi.getContinueWatching(undefined, { force }).catch(() => null),
         this.streamingApi.getRecommendations({ force }).catch(() => null),
+        this.playlistsApi.list({ force }).catch(() => null),
       ]);
       if (libs) this.libraries.set(libs);
       if (cw) this.continueWatching.set(cw);
       if (recs) this.recommendations.set(recs);
+      if (pls)
+        this.playlists.set(
+          [...pls]
+            .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+            .slice(0, 20),
+        );
     } catch { /* ignore */ }
     await this.loadFilteredSections({ force });
   }

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -67,7 +67,7 @@
       [class.pr-4]="sortBy() === 'title' && sortOrder() === 'ASC'"
     >
       <span class="text-sm text-base-content/70 mr-1">
-        {{ 'library.element_count' | translate:{ count: list.total() } }}
+        {{ (list.total() <= 1 ? 'common.item_count_one' : 'common.item_count_other') | translate:{ count: list.total() } }}
       </span>
 
       @if (selectedGenre()) {
@@ -467,7 +467,7 @@
   } @else if (viewMode() === 'genres') {
     <div class="flex items-center gap-3">
       <span class="text-sm text-base-content/70">
-        {{ 'library.element_count' | translate:{ count: genresList().length } }}
+        {{ (genresList().length <= 1 ? 'common.item_count_one' : 'common.item_count_other') | translate:{ count: genresList().length } }}
       </span>
     </div>
     @if (genresLoading() && !genresList().length) {
@@ -488,7 +488,7 @@
           <app-mosaic-card
             [posters]="g.posters"
             [label]="g.genre"
-            [count]="g.count"
+            [subtitle]="(g.count <= 1 ? 'common.item_count_one' : 'common.item_count_other') | translate: { count: g.count }"
             (clicked)="pickGenre(g.genre)"
           />
         }
@@ -511,7 +511,7 @@
           <app-mosaic-card
             [posters]="c.posters"
             [label]="c.name"
-            [count]="c.count"
+            [subtitle]="(c.count <= 1 ? 'common.item_count_one' : 'common.item_count_other') | translate: { count: c.count }"
             (clicked)="pickCollection(c.id)"
           />
         }

--- a/client/src/app/features/playlists/playlist-detail/playlist-detail.html
+++ b/client/src/app/features/playlists/playlist-detail/playlist-detail.html
@@ -24,7 +24,7 @@
       <div class="min-w-0 flex-1">
         <h1 class="text-2xl font-bold truncate">{{ pl.name }}</h1>
         <p class="text-sm text-base-content/60 mt-1">
-          {{ 'playlists.item_count' | translate: { count: items().length } }}
+          {{ (items().length <= 1 ? 'common.item_count_one' : 'common.item_count_other') | translate: { count: items().length } }}
         </p>
       </div>
       <div class="flex items-center gap-2 shrink-0">

--- a/client/src/app/features/playlists/playlists.html
+++ b/client/src/app/features/playlists/playlists.html
@@ -25,7 +25,7 @@
         <app-mosaic-card
           [posters]="p.posters"
           [label]="p.name"
-          [count]="p.itemCount"
+          [subtitle]="(p.itemCount <= 1 ? 'common.item_count_one' : 'common.item_count_other') | translate: { count: p.itemCount }"
           (clicked)="openPlaylist(p.id)"
         />
       }

--- a/client/src/app/shared/components/mosaic-card/mosaic-card.ts
+++ b/client/src/app/shared/components/mosaic-card/mosaic-card.ts
@@ -16,10 +16,10 @@ import { ImgFadeInDirective } from '../../directives/img-fade-in.directive';
     <button
       type="button"
       data-no-focus-ring
-      class="group flex flex-col items-stretch gap-2 text-left focus:outline-none min-w-0 w-full"
+      class="group flex flex-col items-stretch gap-2 text-left focus:outline-none min-w-0 w-full cursor-pointer"
       (click)="clicked.emit()"
     >
-      <div class="mosaic-art aspect-square rounded-xl overflow-hidden bg-base-300 ring-1 ring-base-300 transition-shadow group-hover:ring-primary">
+      <div class="mosaic-art relative aspect-square rounded-xl overflow-hidden bg-base-300 shadow-md group-hover:shadow-xl transition-shadow">
         @if (posters().length >= 4) {
           <div class="grid grid-cols-2 grid-rows-2 w-full h-full">
             @for (p of posters().slice(0, 4); track p) {
@@ -33,10 +33,11 @@ import { ImgFadeInDirective } from '../../directives/img-fade-in.directive';
             <svg lucideFolder class="w-12 h-12" [strokeWidth]="1.5"></svg>
           </div>
         }
+        <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none"></div>
       </div>
       <div class="text-sm min-w-0 w-full">
-        <div class="font-medium truncate group-hover:text-primary transition-colors">{{ label() }}</div>
-        <div class="text-xs text-base-content/50">{{ count() }}</div>
+        <div class="font-medium truncate hover:underline">{{ label() }}</div>
+        <div class="text-xs text-base-content/50">{{ subtitle() }}</div>
       </div>
     </button>
   `,
@@ -44,6 +45,7 @@ import { ImgFadeInDirective } from '../../directives/img-fade-in.directive';
 export class MosaicCardComponent {
   readonly posters = input.required<string[]>();
   readonly label = input.required<string>();
-  readonly count = input.required<number>();
+  /** Pre-formatted subtitle line under the label (e.g. "5 éléments"). */
+  readonly subtitle = input.required<string>();
   readonly clicked = output<void>();
 }


### PR DESCRIPTION
## What

Adds a new home zone that lists the user's accessible playlists ordered by **last modification**, rendered as mosaic tiles that link to each playlist. Like the other zones it is toggleable and reorderable from `/app-settings/home` and default-visible.

## How

- **Backend** (`playlists.service.ts`): so *modified* reflects content changes and not just renames, the four item mutators (`addItem`, `removeItem`, `removeItemsByMedia`, `reorder`) now touch the parent `updatedAt`. No schema change / migration — `PlaylistView` already carries `updatedAt`.
- **Frontend**:
  - New `playlists` section type in the home registry (`home-settings.service.ts`), its label in the settings page, and the `@case` in `home.html`.
  - `home.ts` fetches `GET /api/playlists` in the existing two-pass SWR load, sorts by `updatedAt` desc and keeps the top 20.
  - `updatedAt` exposed on the `Playlist` client interface (already returned by the backend).
  - Tiles use the shared `app-mosaic-card`; `data-home-focus` keeps them reachable via TV/remote spatial navigation.

## Mosaic polish (shared component, applies to playlists + library genres/collections)

- Element-count labels now use shared `common.item_count_one` / `common.item_count_other` keys for correct French singular/plural (`0 élément`, `1 élément`, `2 éléments`) — replacing the `élément(s)` / always-plural forms. Applied to every mosaic subtitle and the three count headers; the now-unused keys were removed.
- `app-mosaic-card` hover now matches `app-media-card`: shadow lift, darkening veil, pointer cursor, and a title underline on hover — no border or accent colour. The `count` input became a caller-provided `subtitle` string.

## Verification

Backend type-check (`tsc`) and frontend `ng build` both pass clean. Not exercised in a running app; the zone only appears when the user has playlists.