### PR TITLE
feat(social): recommend media popular among people you follow

### DIFF
--- a/backend/src/modules/social/social.controller.ts
+++ b/backend/src/modules/social/social.controller.ts
@@ -33,6 +33,19 @@ export class SocialController {
     return this.service.searchConnectable(me, q ?? '');
   }
 
+  @Get('recommendations')
+  followingRecommendations(
+    @CurrentUser() me: User,
+    @Query('libraryId') libraryId?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.service.followingRecommendations(
+      me,
+      libraryId ? +libraryId : undefined,
+      limit ? Math.min(+limit, 50) : 20,
+    );
+  }
+
   @Get('requests')
   requests(@CurrentUser() me: User) {
     return this.service.listRequests(me);

--- a/backend/src/modules/social/social.module.ts
+++ b/backend/src/modules/social/social.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserFollow } from './entities/user-follow.entity';
 import { User } from '../users/entities/user.entity';
+import { PlaybackState } from '../streaming/entities/playback-state.entity';
+import { Media } from '../media/entities/media.entity';
 import { SocialService } from './social.service';
 import { SocialController } from './social.controller';
 import { PlaylistsModule } from '../playlists/playlists.module';
@@ -12,7 +14,7 @@ import { AuthModule } from '../auth/auth.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([UserFollow, User]),
+    TypeOrmModule.forFeature([UserFollow, User, PlaybackState, Media]),
     PlaylistsModule,
     StreamingModule,
     LibrariesModule,

--- a/backend/src/modules/social/social.service.ts
+++ b/backend/src/modules/social/social.service.ts
@@ -7,6 +7,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { UserFollow } from './entities/user-follow.entity';
 import { User } from '../users/entities/user.entity';
+import { PlaybackState } from '../streaming/entities/playback-state.entity';
+import { Media } from '../media/entities/media.entity';
 import { PlaylistsService, PlaylistView } from '../playlists/playlists.service';
 import {
   RecommendationItem,
@@ -53,6 +55,10 @@ export class SocialService {
     private readonly followRepo: Repository<UserFollow>,
     @InjectRepository(User)
     private readonly userRepo: Repository<User>,
+    @InjectRepository(PlaybackState)
+    private readonly playbackRepo: Repository<PlaybackState>,
+    @InjectRepository(Media)
+    private readonly mediaRepo: Repository<Media>,
     private readonly playlists: PlaylistsService,
     private readonly recommendations: RecommendationService,
     private readonly playback: PlaybackService,
@@ -343,5 +349,68 @@ export class SocialService {
       recommendations: recommendations.map((r) => ({ ...r, becauseTitle: '' })),
       recentlyWatched: history.data,
     };
+  }
+
+  /** Media popular among the members the caller follows (accepted), scoped to
+   *  the caller's library ACL (and the active library when given), excluding
+   *  what the caller has already played. Shaped as RecommendationItem[] so the
+   *  library Suggestions row can render it like the other recommendation rows. */
+  async followingRecommendations(
+    me: User,
+    libraryId?: number,
+    limit = 20,
+  ): Promise<RecommendationItem[]> {
+    const followingIds = (
+      await this.followRepo.find({
+        where: { follower: { id: me.id }, status: FollowStatus.ACCEPTED },
+      })
+    ).map((f) => f.followingId);
+    if (!followingIds.length) return [];
+    const accessible = await this.libraries.getAccessibleLibraryIds(me);
+    if (!accessible.length) return [];
+    const libs =
+      libraryId && accessible.includes(libraryId) ? [libraryId] : accessible;
+
+    const rows: { mediaId: number }[] = await this.playbackRepo.query(
+      `
+      SELECT ps."mediaId" AS "mediaId", COUNT(DISTINCT ps."userId")::int AS cnt
+      FROM playback_states ps
+      JOIN media m ON m.id = ps."mediaId"
+      WHERE ps."userId" = ANY($1)
+        AND ps.completed = true
+        AND m."libraryId" = ANY($2)
+        AND NOT EXISTS (
+          SELECT 1 FROM playback_states mine
+          WHERE mine."userId" = $3 AND mine."mediaId" = ps."mediaId"
+        )
+      GROUP BY ps."mediaId"
+      ORDER BY cnt DESC, ps."mediaId" DESC
+      LIMIT $4
+      `,
+      [followingIds, libs, me.id, limit],
+    );
+    if (!rows.length) return [];
+    const media = await this.mediaRepo.find({
+      where: { id: In(rows.map((r) => r.mediaId)) },
+    });
+    const byId = new Map(media.map((m) => [m.id, m]));
+    return rows
+      .map((r) => byId.get(r.mediaId))
+      .filter((m): m is Media => !!m)
+      .map((m) => ({
+        media: {
+          id: m.id,
+          title: m.title,
+          type: m.type,
+          year: m.year,
+          posterUrl: m.posterUrl,
+          fanartUrl: m.fanartUrl,
+          additionalFanartUrls: m.additionalFanartUrls ?? [],
+          genres: m.genres ?? [],
+          available: true,
+        },
+        becauseTitle: '',
+        score: 0,
+      }));
   }
 }

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -630,6 +630,7 @@
     "coming_soon": "Bientôt disponible",
     "suggestions_empty": "Pas encore de suggestions",
     "suggestions_empty_hint": "Regardez quelques films / séries pour alimenter les recommandations basées sur votre historique.",
+    "suggestions_following": "Populaire chez vos abonnements",
     "genres_empty": "Aucun genre dans cette bibliothèque",
     "clear_genre": "Effacer le filtre genre",
     "view_collections": "Collections",

--- a/client/src/app/core/services/api/social-api.service.ts
+++ b/client/src/app/core/services/api/social-api.service.ts
@@ -52,6 +52,17 @@ export class SocialApiService {
     );
   }
 
+  /** Media popular among the members the caller follows, for a library's
+   *  Suggestions view. */
+  followingRecommendations(libraryId: number, opts: { force?: boolean } = {}) {
+    return firstValueFrom(
+      this.http.get<RecommendationItem[]>('/api/social/recommendations', {
+        params: { libraryId: String(libraryId) },
+        ...this.headers(opts.force),
+      }),
+    );
+  }
+
   /** Members the caller may add as playlist collaborators (public or followed). */
   searchConnectable(q: string) {
     return firstValueFrom(

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -442,6 +442,21 @@
         </app-horizontal-scroller>
       }
 
+      <!-- Popular among the members the user follows. -->
+      @if (suggestionsFromFollowing().length) {
+        <app-horizontal-scroller [title]="'library.suggestions_following' | translate">
+          @for (rec of suggestionsFromFollowing(); track rec.media.id) {
+            <app-media-card
+              class="shrink-0 w-28 sm:w-32 lg:w-40"
+              [imageUrl]="rec.media.posterUrl"
+              [title]="rec.media.title"
+              [subtitle]="rec.media.year ? '' + rec.media.year : undefined"
+              [link]="['/' + (rec.media.type === 'series' ? 'series' : 'movies'), '' + rec.media.id]"
+            />
+          }
+        </app-horizontal-scroller>
+      }
+
       <!-- Recommendations grid — same column rhythm as the main `all`
            grid so the suggestions feel like a continuation of the same
            page rather than a separate component. -->
@@ -457,7 +472,7 @@
             />
           }
         </div>
-      } @else if (!suggestionsContinue().length) {
+      } @else if (!suggestionsContinue().length && !suggestionsFromFollowing().length) {
         <div class="text-center py-24 text-base-content/50">
           <p class="text-lg">{{ 'library.suggestions_empty' | translate }}</p>
           <p class="text-sm mt-2">{{ 'library.suggestions_empty_hint' | translate }}</p>

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -15,6 +15,7 @@ import { Subscription, filter } from 'rxjs';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { MediaService, Media, GenreSummary, CollectionSummary } from '../../core/services/api/media.service';
+import { SocialApiService } from '../../core/services/api/social-api.service';
 import { StreamingApiService } from '../../core/services/api/streaming-api.service';
 import { ProfilesService, QualityProfile } from '../../core/services/api/profiles.service';
 import { LibrariesApiService, LibrarySummary } from '../../core/services/api/libraries-api.service';
@@ -82,6 +83,7 @@ const NATURAL_ORDER_BY_SORT: Record<string, SortOrder> = {
 export class LibraryComponent implements OnInit, OnDestroy {
   private readonly mediaService = inject(MediaService);
   private readonly streamingApi = inject(StreamingApiService);
+  private readonly socialApi = inject(SocialApiService);
   private readonly profilesService = inject(ProfilesService);
   private readonly librariesApi = inject(LibrariesApiService);
   private readonly route = inject(ActivatedRoute);
@@ -126,6 +128,8 @@ export class LibraryComponent implements OnInit, OnDestroy {
   readonly suggestionsContinue = signal<ContinueWatchingItem[]>([]);
   /** History-based recommendations, scoped to the active library. */
   readonly suggestionsRecommendations = signal<RecommendationItem[]>([]);
+  /** Popular among the members the user follows. */
+  readonly suggestionsFromFollowing = signal<RecommendationItem[]>([]);
   readonly suggestionsLoading = signal(false);
 
   // ── Genres view ─────────────────────────────────────────────────────
@@ -480,14 +484,16 @@ export class LibraryComponent implements OnInit, OnDestroy {
     if (!lib) return;
     this.suggestionsLoading.set(true);
     try {
-      const [cw, recs] = await Promise.all([
+      const [cw, recs, following] = await Promise.all([
         this.streamingApi.getContinueWatching(lib.id).catch(() => null),
         this.streamingApi
           .getRecommendations({ libraryId: lib.id, limit: 30 })
           .catch(() => null),
+        this.socialApi.followingRecommendations(lib.id).catch(() => null),
       ]);
       if (cw) this.suggestionsContinue.set(cw);
       if (recs) this.suggestionsRecommendations.set(recs);
+      if (following) this.suggestionsFromFollowing.set(following);
     } finally {
       this.suggestionsLoading.set(false);
     }


### PR DESCRIPTION
## What & why

V4 (final planned phase) of the social layer. Adds a **"Populaire chez vos abonnements"** row to the library **Suggestions** view — media most-watched by the members you follow.

## Backend
- `GET /social/recommendations?libraryId=&limit=` — media most-completed by the caller's **accepted** followings, excluding what the caller has already played, **scoped to the caller's library ACL** and (when given) the active library. Returned as `RecommendationItem[]` so the client reuses the existing card rendering. No migration (reuses `playback_states` + `user_follows`).

## Frontend
- `library.ts` `loadSuggestions()` fetches it alongside continue-watching + recommendations; a new `suggestionsFromFollowing` signal renders as a horizontal scroller of `MediaCard`s, above the recommendations grid. The Suggestions empty-state accounts for it.

ACL note: results are filtered by the **viewer's** accessible libraries, so nothing outside the viewer's access is surfaced. Backend typecheck + client build clean.

This completes the planned V1–V4 social roadmap (discovery + follow, profiles, collaborative & saved playlists, friends-based recommendations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)