### PR TITLE
fix(home): expose recommend/add-to-playlist on the likes row cards

### DIFF
--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -94,6 +94,8 @@
                 [title]="item.title"
                 [subtitle]="item.label ?? undefined"
                 [link]="likeLink(item)"
+                [playlistMediaId]="item.mediaId"
+                [playlistEpisodeId]="item.episodeId"
               />
             }
           </app-horizontal-scroller>


### PR DESCRIPTION
The home "Coups de cœur" row rendered its cards from lean like items without a `playlistMediaId`, so — unlike every other content row (continue-watching, recommendations, recently-added, coming-soon, per-library) — its cards offered neither **Recommander** nor **Ajouter à une playlist**. Pass the media (and episode) id through so both actions appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)