### PR TITLE
fix(player): back button needs two presses after the first play

### DIFF
--- a/client/src/app/shared/layout/layout.ts
+++ b/client/src/app/shared/layout/layout.ts
@@ -29,6 +29,7 @@ import { TvService } from '../../core/services/tv.service';
 import { DeviceService } from '../../core/services/device.service';
 import { CastPlayerService } from '../../core/services/cast-player.service';
 import { DownloadManagerService } from '../../core/services/download-manager.service';
+import { NavigationHistoryService } from '../../core/services/navigation-history.service';
 import { NetworkService } from '../../core/services/network.service';
 import { CastOverlayComponent } from '../cast-overlay/cast-overlay';
 import { CardActionsPanelComponent } from '../components/card-actions-panel/card-actions-panel';
@@ -93,6 +94,13 @@ export class LayoutComponent implements OnInit, OnDestroy {
   private readonly serverCache = inject(ServerCacheService);
   private readonly sse = inject(SseService);
   private readonly downloadManager = inject(DownloadManagerService);
+  // Instantiate eagerly from the shell so it records the page the user was on
+  // BEFORE the first player open. It is `providedIn: 'root'` but otherwise only
+  // injected by the player, which is created too late (during the → /watch nav)
+  // to observe the launching page — leaving the player's onBack without a
+  // previousUrl on the first play and forcing a replaceUrl that strands a
+  // history entry (back button then needs two presses to leave the detail page).
+  private readonly navHistory = inject(NavigationHistoryService);
   private readonly addToPlaylistSvc = inject(AddToPlaylistService);
   private readonly addToPlaylistModal = viewChild(AddToPlaylistModalComponent);
   // Bridge the global "add to playlist" requests (from cards / the media-detail


### PR DESCRIPTION
## Symptom
Refresh a detail page (e.g. `/series/675/episode/202`) → **Lire** → back (closes player, returns to detail) → the next topbar-back press does nothing; a second press is needed to reach home.

## Root cause
`NavigationHistoryService` is `providedIn: 'root'` but injected **only by the player**, so it is created lazily *during* the detail→`/watch` navigation and never records the launching page. On the first play of a session (or right after a refresh) the player's `onBack()` reads `previousUrl === null` and falls back to a `replaceUrl` jump to the detail page — which strands the detail entry that was pushed onto `NavbarService`'s in-app back-stack when the player opened. The first back press pops that stale entry (same URL → no visible change); only the second reaches home. Later plays work because the singleton is warm.

## Fix
Instantiate `NavigationHistoryService` eagerly from the layout shell so `previousUrl` is accurate from app start. `onBack()` then takes the `history.back()` branch it already uses on subsequent plays, clearing both the browser and in-app histories in one step.

Confirmed working locally by the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)