### PR TITLE
fix(nav): stray popstate no longer kills the back button after keyboard close

### DIFF
--- a/client/src/app/core/services/navbar.service.ts
+++ b/client/src/app/core/services/navbar.service.ts
@@ -69,8 +69,15 @@ export class NavbarService {
       // from — e.g. media-detail → player → browser-back → "Retour" would
       // otherwise reopen the player).
       if (e instanceof NavigationStart && e.navigationTrigger === 'popstate') {
-        this.isPoppingBack = true;
+        // Only treat a popstate as a back-pop when it lands on the URL at the
+        // top of our own stack. A stray popstate that doesn't (e.g. Android
+        // dismissing the soft keyboard pops an IME history entry) must NOT set
+        // isPoppingBack — otherwise it swallows the push for the *next* real
+        // navigation, leaving that page with no back arrow and a dead back
+        // gesture (reproduced by tapping a card from search with the keyboard
+        // still open).
         if (this.history[this.history.length - 1] === e.url) {
+          this.isPoppingBack = true;
           this.history.pop();
         }
       }


### PR DESCRIPTION
## Symptom (Android)
From `/search` with the soft keyboard open, tapping a media card navigates to the detail page but leaves it with **no header back arrow** and a **dead back gesture**. Works fine when the keyboard is closed.

## Root cause
`NavbarService` set `isPoppingBack = true` on *any* `popstate` `NavigationStart`. Dismissing the Android soft keyboard (by tapping the card) pops the WebView's IME history entry → a stray `popstate` fires → the flag is set → the next real navigation (search→detail) sees it and **skips pushing `/search`** onto the back stack. So `canGoBack()` is false → no arrow (`layout.html`) and nothing for `handleBackButton()` to do (`app.ts`).

## Fix
Only set `isPoppingBack` when the `popstate` lands on the URL at the top of our own back stack (a genuine back). A stray IME popstate is ignored and no longer poisons the following navigation. Genuine browser/gesture back still matches the top and behaves as before.

Confirmed on Android by the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)