### PR TITLE
fix(nav): back button after opening the keyboard from the search dock

### DIFF
--- a/client/src/app/shared/layout/layout.ts
+++ b/client/src/app/shared/layout/layout.ts
@@ -332,10 +332,17 @@ export class LayoutComponent implements OnInit, OnDestroy {
    *  no-ops on a same-URL navigation, so the click handler signals the
    *  search page via {@link SearchStateService.requestFocus}. */
   onSearchNavClick(): void {
-    this.resetNavHistory();
     if (this.router.url.split('?')[0] === '/search') {
+      // Already on search: re-focus the input (re-open the keyboard). No
+      // navigation happens, so we must NOT resetNavHistory() here — its
+      // isPoppingBack flag would linger with nothing to consume it and then
+      // swallow the history push of the next navigation (tapping a result),
+      // leaving that page with no back arrow / dead back gesture.
       this.searchState.requestFocus();
+      return;
     }
+    // Navigating to search fresh — a top-level dock entry, so clear the stack.
+    this.resetNavHistory();
   }
 
   toggleBottomMenu() {


### PR DESCRIPTION
Follow-up to #684. That fixed the case where the keyboard was opened by tapping the input; opening it via the **search dock (loupe)** while already on `/search` still broke the back button.

`onSearchNavClick()` called `resetNavHistory()` unconditionally, which sets `isPoppingBack`. A same-route re-tap doesn't navigate, so nothing consumes the flag — it then swallows the history push of the next navigation (tapping a result), leaving the detail page with no back arrow and a dead back gesture.

Fix: only `resetNavHistory()` when the dock click actually navigates to search; a same-route re-tap just re-focuses the input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)