### PR TITLE
feat(social): opt-out of sharing + default member roster in search

### DIFF
--- a/backend/src/migrations/1781800000000-add-share-disabled.ts
+++ b/backend/src/migrations/1781800000000-add-share-disabled.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddShareDisabled1781800000000 implements MigrationInterface {
+  name = 'AddShareDisabled1781800000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "shareDisabled" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" DROP COLUMN IF EXISTS "shareDisabled"`,
+    );
+  }
+}

--- a/backend/src/modules/playlists/playlists.service.ts
+++ b/backend/src/modules/playlists/playlists.service.ts
@@ -249,6 +249,9 @@ export class PlaylistsService {
 
   /** Bookmark another member's readable playlist into the caller's list. */
   async savePlaylist(user: User, playlistId: number): Promise<void> {
+    if (user.shareDisabled) {
+      throw new BadRequestException('Sharing features are disabled');
+    }
     const { playlist } = await this.assertRole(
       user,
       playlistId,
@@ -398,7 +401,13 @@ export class PlaylistsService {
     }
     if (dto.autoDownload !== undefined) patch.autoDownload = dto.autoDownload;
     if (dto.autoPlay !== undefined) patch.autoPlay = dto.autoPlay;
-    if (dto.visibility !== undefined) patch.visibility = dto.visibility;
+    if (dto.visibility !== undefined) {
+      // A member who opted out of sharing can't expose a playlist publicly.
+      if (user.shareDisabled && dto.visibility !== PlaylistVisibility.PRIVATE) {
+        throw new BadRequestException('Sharing features are disabled');
+      }
+      patch.visibility = dto.visibility;
+    }
     if (Object.keys(patch).length) await this.repo.update(playlistId, patch);
     return this.findOneForUser(user, playlistId);
   }
@@ -469,6 +478,9 @@ export class PlaylistsService {
       playlistId,
       PlaylistShareRole.ADMINISTRATOR,
     );
+    if (user.shareDisabled) {
+      throw new BadRequestException('Sharing features are disabled');
+    }
     if (dto.userId === user.id) {
       throw new BadRequestException('Cannot change your own role');
     }
@@ -479,16 +491,18 @@ export class PlaylistsService {
       where: { id: dto.userId, enabled: true },
     });
     if (!target) throw new NotFoundException(`User #${dto.userId} not found`);
-    // Only public members, or members the caller follows, may be added.
+    // Only public members, or members the caller follows, may be added — and
+    // never a member who opted out of sharing.
     const connectable =
-      target.profileVisibility === ProfileVisibility.PUBLIC ||
-      (await this.followRepo.exist({
+      !target.shareDisabled &&
+      (target.profileVisibility === ProfileVisibility.PUBLIC ||
+        (await this.followRepo.exist({
         where: {
           follower: { id: user.id },
           following: { id: dto.userId },
           status: FollowStatus.ACCEPTED,
         },
-      }));
+      })));
     if (!connectable) {
       throw new ForbiddenException(
         'You can only add public members or members you follow',

--- a/backend/src/modules/social/social.service.ts
+++ b/backend/src/modules/social/social.service.ts
@@ -160,7 +160,13 @@ export class SocialService {
     if (me.id === targetId) {
       throw new BadRequestException('Cannot follow yourself');
     }
+    if (me.shareDisabled) {
+      throw new BadRequestException('Sharing features are disabled');
+    }
     const target = await this.requireUser(targetId);
+    // A member who opted out of sharing is undiscoverable — 404, not 403, so
+    // their existence can't be probed.
+    if (target.shareDisabled) throw new NotFoundException(`User #${targetId} not found`);
     const existing = await this.followRepo.findOne({
       where: { follower: { id: me.id }, following: { id: targetId } },
     });
@@ -236,16 +242,17 @@ export class SocialService {
   // ── discovery ──
 
   async search(me: User, query: string): Promise<SocialUser[]> {
+    // Opted-out members don't use discovery at all.
+    if (me.shareDisabled) return [];
     const q = query?.trim();
-    if (!q) return [];
-    const users = await this.userRepo
+    // No query → a default roster of discoverable members (not just matches).
+    const qb = this.userRepo
       .createQueryBuilder('u')
       .where('u.enabled = true')
-      .andWhere('u.id != :meId', { meId: me.id })
-      .andWhere('u.username ILIKE :q', { q: `%${q}%` })
-      .orderBy('u.username', 'ASC')
-      .take(30)
-      .getMany();
+      .andWhere('u.shareDisabled = false')
+      .andWhere('u.id != :meId', { meId: me.id });
+    if (q) qb.andWhere('u.username ILIKE :q', { q: `%${q}%` });
+    const users = await qb.orderBy('u.username', 'ASC').take(30).getMany();
     return this.decorate(me, users);
   }
 
@@ -253,6 +260,7 @@ export class SocialService {
    *  members the caller already follows (accepted). An empty query returns the
    *  default suggestions (so the picker can propose on focus). */
   async searchConnectable(me: User, query: string): Promise<SocialUser[]> {
+    if (me.shareDisabled) return [];
     const q = query?.trim();
     const followingIds = (
       await this.followRepo.find({
@@ -262,6 +270,7 @@ export class SocialService {
     const qb = this.userRepo
       .createQueryBuilder('u')
       .where('u.enabled = true')
+      .andWhere('u.shareDisabled = false')
       .andWhere('u.id != :meId', { meId: me.id })
       .andWhere('(u.profileVisibility = :pub OR u.id IN (:...ids))', {
         pub: ProfileVisibility.PUBLIC,
@@ -305,6 +314,11 @@ export class SocialService {
   async getProfile(me: User, targetId: number): Promise<PublicProfile> {
     const target = await this.requireUser(targetId);
     const isSelf = me.id === targetId;
+    // An opted-out member is invisible to everyone but themselves, and an
+    // opted-out viewer can't browse others' profiles. 404 either way (no probe).
+    if (!isSelf && (target.shareDisabled || me.shareDisabled)) {
+      throw new NotFoundException(`User #${targetId} not found`);
+    }
     const [followerCount, followingCount, outgoing] = await Promise.all([
       this.followRepo.count({
         where: { following: { id: targetId }, status: FollowStatus.ACCEPTED },
@@ -474,8 +488,9 @@ export class SocialService {
    *  (accepted) — the same reach as the playlist-collaborator picker. */
   private async assertConnectable(me: User, target: User): Promise<void> {
     const ok =
-      target.profileVisibility === ProfileVisibility.PUBLIC ||
-      (await this.isAcceptedFollower(me.id, target.id));
+      !target.shareDisabled &&
+      (target.profileVisibility === ProfileVisibility.PUBLIC ||
+        (await this.isAcceptedFollower(me.id, target.id)));
     // 404 (not 403) so a hidden recipient can't be probed for existence.
     if (!ok) throw new NotFoundException(`User #${target.id} not found`);
   }
@@ -483,6 +498,9 @@ export class SocialService {
   async recommend(me: User, dto: RecommendContentDto): Promise<void> {
     if (me.id === dto.recipientId) {
       throw new BadRequestException('Cannot recommend to yourself');
+    }
+    if (me.shareDisabled) {
+      throw new BadRequestException('Sharing features are disabled');
     }
     const recipient = await this.requireUser(dto.recipientId);
     await this.assertConnectable(me, recipient);

--- a/backend/src/modules/users/dto/update-user.dto.ts
+++ b/backend/src/modules/users/dto/update-user.dto.ts
@@ -102,4 +102,10 @@ export class UpdateUserDto {
   @IsBoolean()
   @IsOptional()
   shareLikes?: boolean;
+
+  /** Self-editable: opt out of the whole social layer (undiscoverable + can't
+   *  use sharing features). Enabling it drops the user's social ties. */
+  @IsBoolean()
+  @IsOptional()
+  shareDisabled?: boolean;
 }

--- a/backend/src/modules/users/entities/user.entity.ts
+++ b/backend/src/modules/users/entities/user.entity.ts
@@ -113,6 +113,13 @@ export class User extends BaseEntity {
   @Column({ default: false })
   shareLikes: boolean;
 
+  /** Opt out of the whole social layer: the user becomes undiscoverable (search,
+   *  connectable, profile) and can't use any sharing feature. Enabling it drops
+   *  their social ties (follows, saved playlists, collaborations, recommendations)
+   *  — see UsersService. */
+  @Column({ default: false })
+  shareDisabled: boolean;
+
   /** Computed permissions from the linked role (isAdmin overrides with all). */
   get permissions(): string[] {
     if (this.isAdmin) {

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -243,7 +243,16 @@ export class UsersService implements OnModuleInit {
       target.shareWatchHistory = dto.shareWatchHistory;
     if (dto.shareLikes !== undefined) target.shareLikes = dto.shareLikes;
 
+    // Opting out of the social layer: run the teardown once, on the
+    // false → true transition (after the row is saved so the flag is set).
+    const leavingSocial =
+      dto.shareDisabled === true && target.shareDisabled !== true;
+    if (dto.shareDisabled !== undefined)
+      target.shareDisabled = dto.shareDisabled;
+
     await this.userRepo.save(target);
+
+    if (leavingSocial) await this.leaveSocial(targetId);
 
     // Library access replace (manager-only). Done after the user row save so
     // FK is valid even for newly-promoted users.
@@ -267,6 +276,40 @@ export class UsersService implements OnModuleInit {
     }
 
     return this.findOne(targetId);
+  }
+
+  /**
+   * Tear down a user's social ties when they opt out of the sharing layer.
+   * Raw SQL keyed on the (stable) table/column names so UsersService stays
+   * decoupled from the social/playlist modules. Every table FK-cascades on
+   * user delete, so these are the same rows that would vanish if the account
+   * were removed — here we drop them while keeping the account.
+   */
+  private async leaveSocial(userId: number): Promise<void> {
+    const m = this.userRepo.manager;
+    // Leave the follow graph in both directions.
+    await m.query(
+      'DELETE FROM user_follows WHERE "followerId" = $1 OR "followingId" = $1',
+      [userId],
+    );
+    // Drop playlists they saved from other members.
+    await m.query('DELETE FROM playlist_saves WHERE "userId" = $1', [userId]);
+    // Remove them as a collaborator elsewhere, and unshare their own playlists.
+    await m.query('DELETE FROM playlist_shares WHERE "userId" = $1', [userId]);
+    await m.query(
+      'DELETE FROM playlist_shares WHERE "playlistId" IN (SELECT id FROM playlists WHERE "ownerId" = $1)',
+      [userId],
+    );
+    // Make their own playlists private again.
+    await m.query(
+      `UPDATE playlists SET visibility = 'private' WHERE "ownerId" = $1 AND visibility <> 'private'`,
+      [userId],
+    );
+    // Drop content recommendations they sent or received.
+    await m.query(
+      'DELETE FROM content_recommendations WHERE "senderId" = $1 OR "recipientId" = $1',
+      [userId],
+    );
   }
 
   async remove(id: number): Promise<void> {

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -237,6 +237,8 @@
     "privacy_share_likes_hint": "Affiche les films, saisons et épisodes que vous aimez sur votre profil.",
     "privacy_share_disabled": "Ne pas utiliser les fonctions de partage",
     "privacy_share_disabled_hint": "Vous devenez introuvable par les autres utilisateurs et ne pouvez plus suivre, recommander, collaborer ou enregistrer des playlists. Activer cette option supprime vos abonnements, playlists enregistrées, collaborations et recommandations.",
+    "privacy_share_disabled_confirm": "En désactivant les fonctions de partage, vous devenez introuvable et vos abonnements, playlists enregistrées, collaborations et recommandations seront définitivement supprimés. Continuer ?",
+    "privacy_share_disabled_confirm_action": "Désactiver le partage",
     "privacy_saved": "Préférences de confidentialité enregistrées",
     "requests_title": "Demandes de suivi",
     "accept": "Accepter",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -235,6 +235,8 @@
     "privacy_share_watch_history_hint": "Affiche les derniers contenus que vous avez regardés sur votre profil.",
     "privacy_share_likes": "Partager mes coups de cœur",
     "privacy_share_likes_hint": "Affiche les films, saisons et épisodes que vous aimez sur votre profil.",
+    "privacy_share_disabled": "Ne pas utiliser les fonctions de partage",
+    "privacy_share_disabled_hint": "Vous devenez introuvable par les autres utilisateurs et ne pouvez plus suivre, recommander, collaborer ou enregistrer des playlists. Activer cette option supprime vos abonnements, playlists enregistrées, collaborations et recommandations.",
     "privacy_saved": "Préférences de confidentialité enregistrées",
     "requests_title": "Demandes de suivi",
     "accept": "Accepter",

--- a/client/src/app/core/services/api/users-api.service.ts
+++ b/client/src/app/core/services/api/users-api.service.ts
@@ -47,6 +47,8 @@ export interface UpdateUserBody {
   shareWatchHistory?: boolean;
   /** Self-editable: expose liked content on the public profile. */
   shareLikes?: boolean;
+  /** Self-editable: opt out of the whole social/sharing layer. */
+  shareDisabled?: boolean;
 }
 
 /** Aggregated stats payload for the admin user-detail Statistics tab. */

--- a/client/src/app/core/services/auth.service.ts
+++ b/client/src/app/core/services/auth.service.ts
@@ -31,6 +31,8 @@ export interface User {
   shareWatchHistory: boolean;
   /** Expose liked content on the public profile. */
   shareLikes: boolean;
+  /** Opt out of the whole social layer (undiscoverable + can't use sharing). */
+  shareDisabled: boolean;
 }
 
 /** Public = instant follow + shared content; private = follow on approval. */
@@ -131,6 +133,10 @@ export class AuthService {
 
   readonly user = this._user.asReadonly();
   readonly isAuthenticated = computed(() => !!this._user());
+  /** True when the user opted out of the social/sharing layer — social UI
+   *  surfaces (follow, recommend, playlist collaborators/save, people search)
+   *  are hidden and the backend rejects the actions. */
+  readonly sharingDisabled = computed(() => !!this._user()?.shareDisabled);
 
   /** Check if the current user has a specific permission. */
   hasPermission(perm: string): boolean {

--- a/client/src/app/features/account/privacy.html
+++ b/client/src/app/features/account/privacy.html
@@ -3,6 +3,16 @@
   <p class="text-sm text-base-content/60 mb-6">{{ 'social.privacy_intro' | translate }}</p>
 
   <div class="flex flex-col gap-4">
+    <!-- Master opt-out: hides the rest of the sharing options when on. -->
+    <app-toggle-field
+      [value]="shareDisabled()"
+      (valueChange)="onShareDisabledChange($event)"
+      [label]="'social.privacy_share_disabled' | translate"
+      [hint]="'social.privacy_share_disabled_hint' | translate"
+    />
+
+    @if (!shareDisabled()) {
+    <div class="divider my-0"></div>
     <app-toggle-field
       [value]="publicProfile()"
       (valueChange)="onPublicProfileChange($event)"
@@ -36,10 +46,11 @@
       [label]="'social.privacy_share_likes' | translate"
       [hint]="'social.privacy_share_likes_hint' | translate"
     />
+    }
   </div>
 
   <!-- Follow requests -->
-  @if (requests().length) {
+  @if (!shareDisabled() && requests().length) {
     <div class="mt-8">
       <h2 class="text-lg font-semibold mb-3">{{ 'social.requests_title' | translate }}</h2>
       <ul class="flex flex-col gap-2">

--- a/client/src/app/features/account/privacy.ts
+++ b/client/src/app/features/account/privacy.ts
@@ -11,6 +11,7 @@ import { ToggleFieldComponent } from '../../shared/components/forms/toggle-field
 import { UsersApiService } from '../../core/services/api/users-api.service';
 import { AuthService, ProfileVisibility } from '../../core/services/auth.service';
 import { ToastService } from '../../core/services/toast.service';
+import { ConfirmationService } from '../../core/services/confirmation.service';
 import { SocialApiService, SocialUser } from '../../core/services/api/social-api.service';
 
 /** The self-editable social privacy fields — shape shared by the API body and
@@ -36,6 +37,7 @@ export class AccountPrivacyComponent implements OnInit {
   private readonly auth = inject(AuthService);
   private readonly toast = inject(ToastService);
   private readonly translate = inject(TranslateService);
+  private readonly confirmation = inject(ConfirmationService);
 
   readonly publicProfile = signal(false);
   readonly shareTastes = signal(false);
@@ -98,10 +100,23 @@ export class AccountPrivacyComponent implements OnInit {
   }
 
   async onShareDisabledChange(value: boolean): Promise<void> {
+    // Enabling tears down the user's social ties server-side (follows, saved
+    // playlists, collaborations, recommendations) — confirm before applying.
+    if (value) {
+      const confirmed = await this.confirmation.confirm({
+        title: this.translate.instant('social.privacy_share_disabled'),
+        message: this.translate.instant('social.privacy_share_disabled_confirm'),
+        confirmLabel: this.translate.instant('social.privacy_share_disabled_confirm_action'),
+        variant: 'danger',
+      });
+      if (!confirmed) {
+        // Snap the toggle back to its bound state — nothing was persisted.
+        this.shareDisabled.set(false);
+        return;
+      }
+    }
     this.shareDisabled.set(value);
     await this.persist({ shareDisabled: value });
-    // Enabling tears down the user's social ties server-side (follows, saved
-    // playlists, collaborations…); drop the now-empty follow-requests list.
     if (value) this.requests.set([]);
   }
 

--- a/client/src/app/features/account/privacy.ts
+++ b/client/src/app/features/account/privacy.ts
@@ -21,6 +21,7 @@ interface SocialPrefs {
   shareRecommendations?: boolean;
   shareWatchHistory?: boolean;
   shareLikes?: boolean;
+  shareDisabled?: boolean;
 }
 
 @Component({
@@ -41,6 +42,7 @@ export class AccountPrivacyComponent implements OnInit {
   readonly shareRecommendations = signal(false);
   readonly shareWatchHistory = signal(false);
   readonly shareLikes = signal(false);
+  readonly shareDisabled = signal(false);
 
   readonly requests = signal<SocialUser[]>([]);
 
@@ -59,6 +61,7 @@ export class AccountPrivacyComponent implements OnInit {
     this.shareRecommendations.set(u.shareRecommendations);
     this.shareWatchHistory.set(u.shareWatchHistory);
     this.shareLikes.set(u.shareLikes);
+    this.shareDisabled.set(u.shareDisabled);
   }
 
   private async loadRequests(): Promise<void> {
@@ -92,6 +95,14 @@ export class AccountPrivacyComponent implements OnInit {
   async onShareLikesChange(value: boolean): Promise<void> {
     this.shareLikes.set(value);
     await this.persist({ shareLikes: value });
+  }
+
+  async onShareDisabledChange(value: boolean): Promise<void> {
+    this.shareDisabled.set(value);
+    await this.persist({ shareDisabled: value });
+    // Enabling tears down the user's social ties server-side (follows, saved
+    // playlists, collaborations…); drop the now-empty follow-requests list.
+    if (value) this.requests.set([]);
   }
 
   private async persist(patch: SocialPrefs): Promise<void> {

--- a/client/src/app/features/account/privacy.ts
+++ b/client/src/app/features/account/privacy.ts
@@ -100,6 +100,9 @@ export class AccountPrivacyComponent implements OnInit {
   }
 
   async onShareDisabledChange(value: boolean): Promise<void> {
+    // Reflect the toggle immediately so the bound value tracks the switch —
+    // this is what lets the false reset below register as a real change.
+    this.shareDisabled.set(value);
     // Enabling tears down the user's social ties server-side (follows, saved
     // playlists, collaborations, recommendations) — confirm before applying.
     if (value) {
@@ -110,14 +113,12 @@ export class AccountPrivacyComponent implements OnInit {
         variant: 'danger',
       });
       if (!confirmed) {
-        // Snap the toggle back to its bound state — nothing was persisted.
         this.shareDisabled.set(false);
         return;
       }
+      this.requests.set([]);
     }
-    this.shareDisabled.set(value);
     await this.persist({ shareDisabled: value });
-    if (value) this.requests.set([]);
   }
 
   private async persist(patch: SocialPrefs): Promise<void> {

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -51,7 +51,7 @@
             (isSeasonLiked(selSeason.id) ? 'likes.unlike_season' : 'likes.like_season') | translate
           }}</span>
         </button>
-        @if (!tv.isTv()) {
+        @if (!tv.isTv() && !auth.sharingDisabled()) {
           <button
             type="button"
             class="dropdown-item text-white"

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -44,6 +44,7 @@ import {
 import { PlayableMediaService } from '../../../../core/services/playable-media.service';
 import { AddToPlaylistService } from '../../../../core/services/add-to-playlist.service';
 import { TvService } from '../../../../core/services/tv.service';
+import { AuthService } from '../../../../core/services/auth.service';
 
 
 @Component({
@@ -56,6 +57,7 @@ export class MediaDetailSeasonsComponent {
   private readonly playableMedia = inject(PlayableMediaService);
   private readonly addToPlaylist = inject(AddToPlaylistService);
   readonly tv = inject(TvService);
+  readonly auth = inject(AuthService);
   readonly media = input.required<Media>();
   readonly selectedSeason = input<Season | null>(null);
   readonly activeSeasonId = input.required<number | null>();

--- a/client/src/app/features/playlists/playlist-detail/playlist-detail.html
+++ b/client/src/app/features/playlists/playlist-detail/playlist-detail.html
@@ -34,7 +34,7 @@
             {{ 'player.play' | translate }}
           </button>
         }
-        @if (!isOwner()) {
+        @if (!isOwner() && !sharingDisabled()) {
           <button type="button" class="btn btn-sm gap-2" [class.btn-ghost]="!pl.saved" [class.btn-outline]="pl.saved" [disabled]="savingBookmark()" (click)="toggleSave()">
             @if (pl.saved) {
               <svg lucideBookmarkCheck class="h-4 w-4"></svg>
@@ -48,10 +48,12 @@
         <!-- md+ : inline buttons -->
         <div class="hidden md:flex items-center gap-2">
           @if (canManage()) {
-            <button type="button" class="btn btn-ghost btn-sm gap-2" (click)="openMembers()">
-              <svg lucideUsers class="h-4 w-4"></svg>
-              {{ 'playlists.members' | translate }}
-            </button>
+            @if (!sharingDisabled()) {
+              <button type="button" class="btn btn-ghost btn-sm gap-2" (click)="openMembers()">
+                <svg lucideUsers class="h-4 w-4"></svg>
+                {{ 'playlists.members' | translate }}
+              </button>
+            }
             <button type="button" class="btn btn-ghost btn-sm gap-2" (click)="openSettings()">
               <svg lucideSettings class="h-4 w-4"></svg>
               {{ 'playlists.settings' | translate }}
@@ -76,10 +78,12 @@
               <svg lucideEllipsisVertical class="h-5 w-5"></svg>
             </div>
             @if (canManage()) {
-              <button type="button" class="dropdown-item text-white" (click)="openMembers()">
-                <svg lucideUsers class="h-4 w-4"></svg>
-                {{ 'playlists.members' | translate }}
-              </button>
+              @if (!sharingDisabled()) {
+                <button type="button" class="dropdown-item text-white" (click)="openMembers()">
+                  <svg lucideUsers class="h-4 w-4"></svg>
+                  {{ 'playlists.members' | translate }}
+                </button>
+              }
               <button type="button" class="dropdown-item text-white" (click)="openSettings()">
                 <svg lucideSettings class="h-4 w-4"></svg>
                 {{ 'playlists.settings' | translate }}

--- a/client/src/app/features/playlists/playlist-detail/playlist-detail.ts
+++ b/client/src/app/features/playlists/playlist-detail/playlist-detail.ts
@@ -126,6 +126,8 @@ export class PlaylistDetailComponent {
 
   /** The signed-in user's id — a member can't edit their own role. */
   readonly myUserId = computed(() => this.auth.user()?.id ?? 0);
+  /** Opted out of sharing → hide save + collaborator controls. */
+  readonly sharingDisabled = this.auth.sharingDisabled;
 
   private readonly routeParams = toSignal(this.route.paramMap);
   readonly playlistId = computed(() => Number(this.routeParams()?.get('id')));

--- a/client/src/app/features/search/search.html
+++ b/client/src/app/features/search/search.html
@@ -39,7 +39,7 @@
     <button type="button" role="tab" class="tab" [class.tab-active]="state.tab() === 'videos'" (click)="setTab('videos')">
       {{ 'search.tab_videos' | translate }}
     </button>
-    @if (!tv.isTv()) {
+    @if (!tv.isTv() && !sharingDisabled()) {
       <button type="button" role="tab" class="tab" [class.tab-active]="state.tab() === 'people'" (click)="setTab('people')">
         {{ 'social.search_tab_people' | translate }}
       </button>
@@ -56,10 +56,33 @@
     </div>
   }
 
-  @if (!state.hasQuery()) {
-    @if (state.tab() === 'people') {
-      <p class="text-base-content/50 text-center py-12">{{ 'search.discover_people_hint' | translate }}</p>
-    } @else if (state.externalEnabled()) {
+  @if (state.tab() === 'people') {
+    <!-- People: default roster (no query) or filtered results -->
+    @if (state.peopleLoading() && !state.peopleResults().length) {
+      <div class="flex justify-center py-8"><span class="loading loading-spinner loading-lg"></span></div>
+    } @else if (state.peopleResults().length > 0) {
+      <div class="flex flex-col gap-1 max-w-xl">
+        @for (u of state.peopleResults(); track u.id) {
+          <button type="button" class="flex items-center gap-3 p-2 rounded-lg hover:bg-base-200 text-left cursor-pointer" (click)="openProfile(u.id)">
+            <div class="avatar avatar-placeholder shrink-0">
+              <div class="w-10 h-10 rounded-full text-white text-sm font-semibold" [style.background-color]="'hsl(' + avatar(u.username).hue + ' 55% 45%)'">
+                @if (u.avatar) { <img [src]="u.avatar" [alt]="u.username" /> } @else { <span>{{ avatar(u.username).initials }}</span> }
+              </div>
+            </div>
+            <span class="flex-1 min-w-0 truncate font-medium">{{ u.username }}</span>
+            @if (u.isFollowing) {
+              <span class="badge badge-sm badge-ghost">{{ 'social.following' | translate }}</span>
+            } @else if (u.followsYou) {
+              <span class="badge badge-sm badge-ghost">{{ 'social.follows_you' | translate }}</span>
+            }
+          </button>
+        }
+      </div>
+    } @else {
+      <p class="text-base-content/50 text-center py-12">{{ (state.hasQuery() ? 'social.no_people_results' : 'search.discover_people_hint') | translate }}</p>
+    }
+  } @else if (!state.hasQuery()) {
+    @if (state.externalEnabled()) {
       <!-- Discover: filter sidebar (desktop) + rows / results grid -->
       <div class="flex gap-6">
         <aside class="hidden lg:block w-60 shrink-0">
@@ -140,39 +163,6 @@
       } @else {
         <p class="text-base-content/50 text-center py-12">{{ 'search.hint_local' | translate }}</p>
       }
-    }
-  } @else if (state.tab() === 'people') {
-    <!-- People results -->
-    @if (state.peopleLoading()) {
-      <div class="flex justify-center py-8">
-        <span class="loading loading-spinner loading-lg"></span>
-      </div>
-    } @else if (state.peopleResults().length > 0) {
-      <div class="flex flex-col gap-1 max-w-xl">
-        @for (u of state.peopleResults(); track u.id) {
-          <button type="button" class="flex items-center gap-3 p-2 rounded-lg hover:bg-base-200 text-left cursor-pointer" (click)="openProfile(u.id)">
-            <div class="avatar avatar-placeholder shrink-0">
-              <div class="w-10 h-10 rounded-full text-white text-sm font-semibold" [style.background-color]="'hsl(' + avatar(u.username).hue + ' 55% 45%)'">
-                @if (u.avatar) {
-                  <img [src]="u.avatar" [alt]="u.username" />
-                } @else {
-                  <span>{{ avatar(u.username).initials }}</span>
-                }
-              </div>
-            </div>
-            <span class="flex-1 min-w-0 truncate font-medium">{{ u.username }}</span>
-            @if (u.isFollowing) {
-              <span class="badge badge-sm badge-ghost">{{ 'social.following' | translate }}</span>
-            } @else if (u.followsYou) {
-              <span class="badge badge-sm badge-ghost">{{ 'social.follows_you' | translate }}</span>
-            }
-          </button>
-        }
-      </div>
-    } @else {
-      <div class="text-center py-8">
-        <p class="text-base-content/50">{{ 'social.no_people_results' | translate }}</p>
-      </div>
     }
   } @else {
     <!-- Local library results -->

--- a/client/src/app/features/search/search.ts
+++ b/client/src/app/features/search/search.ts
@@ -52,6 +52,8 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
   private readonly auth = inject(AuthService);
+  /** Opted out of the social layer → the people tab is hidden. */
+  protected readonly sharingDisabled = this.auth.sharingDisabled;
   private readonly requestsApi = inject(RequestsService);
   private readonly scrollMemory = inject(ScrollMemoryService);
   private readonly reuseStrategy = inject(CachingReuseStrategy);
@@ -199,7 +201,8 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
   onQueryInput(value: string) {
     this.state.query.set(value);
     if (this.searchTimer) clearTimeout(this.searchTimer);
-    if (value.trim()) {
+    // People keeps searching on an empty query (→ default roster); videos clear.
+    if (value.trim() || this.state.tab() === 'people') {
       this.searchTimer = setTimeout(() => this.runSearch(), 350);
     } else {
       this.state.localResults.set([]);
@@ -212,7 +215,9 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
   setTab(t: 'videos' | 'people') {
     if (t === this.state.tab()) return;
     this.state.tab.set(t);
-    if (this.state.query().trim()) {
+    // Load the default member roster when switching to people (even with no
+    // query); videos only searches when a query is present.
+    if (t === 'people' || this.state.query().trim()) {
       if (this.searchTimer) clearTimeout(this.searchTimer);
       this.runSearch();
     }
@@ -506,9 +511,9 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private async runSearch() {
     const q = this.state.query().trim();
-    if (!q) return;
 
-    // People search is a distinct surface — no local/external media lookups.
+    // People is a distinct surface — no local/external media lookups. Runs even
+    // with an empty query: the backend then returns the default member roster.
     if (this.state.tab() === 'people') {
       this.state.peopleLoading.set(true);
       try {
@@ -525,6 +530,8 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
       }
       return;
     }
+
+    if (!q) return;
 
     const ct = this.state.contentType();
     const type: MediaType | undefined = ct === 'all' ? undefined : ct;

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -12,6 +12,7 @@ import { CardAction, CardActionsService } from '../../../core/services/card-acti
 import { AddToPlaylistService } from '../../../core/services/add-to-playlist.service';
 import { RecommendService } from '../../../core/services/recommend.service';
 import { TvService } from '../../../core/services/tv.service';
+import { AuthService } from '../../../core/services/auth.service';
 import { DeviceService } from '../../../core/services/device.service';
 import { PlayableMediaService } from '../../../core/services/playable-media.service';
 import { NavbarService } from '../../../core/services/navbar.service';
@@ -44,6 +45,7 @@ export class MediaCardComponent {
   private readonly cardActionsService = inject(CardActionsService);
   private readonly addToPlaylist = inject(AddToPlaylistService);
   private readonly recommend = inject(RecommendService);
+  private readonly auth = inject(AuthService);
   private readonly playableMedia = inject(PlayableMediaService);
   private readonly navbar = inject(NavbarService);
   protected readonly device = inject(DeviceService);
@@ -393,7 +395,7 @@ export class MediaCardComponent {
       // Recommend to a member sits next to "add to playlist". Needs the parent
       // mediaId (the API keys recommendations to the title), and is hidden on TV
       // like the rest of the social surface.
-      if (mediaId != null && !this.tv.isTv()) {
+      if (mediaId != null && !this.tv.isTv() && !this.auth.sharingDisabled()) {
         actions.push({
           labelKey: 'recommend.menu_item',
           icon: 'user-plus',

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -426,7 +426,7 @@
 
 <!-- Items projected into both mobile + desktop dropdown-menus. -->
 <ng-template #moreMenuItems>
-  @if (!tv.isTv()) {
+  @if (!tv.isTv() && !auth.sharingDisabled()) {
     <button type="button" class="dropdown-item text-white" (click)="recommend.emit()">
       <svg lucideUserPlus class="h-5 w-5 shrink-0 opacity-80"></svg>
       <span class="flex-1">{{ 'recommend.menu_item' | translate }}</span>

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -42,6 +42,7 @@ import { PlayerSettingsService } from '../../../core/services/player-settings.se
 import { TrackManagerService } from '../../../core/services/track-manager.service';
 import { NavbarService } from '../../../core/services/navbar.service';
 import { TvService } from '../../../core/services/tv.service';
+import { AuthService } from '../../../core/services/auth.service';
 import { MobileFanartHeroComponent } from '../mobile-fanart-hero';
 import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 import {
@@ -117,6 +118,7 @@ export class MediaInfoHeaderComponent {
   private readonly trackManager = inject(TrackManagerService);
   readonly navbar = inject(NavbarService);
   readonly tv = inject(TvService);
+  readonly auth = inject(AuthService);
   private readonly playable = inject(PlayableMediaService);
   private readonly streamingApi = inject(StreamingApiService);
 


### PR DESCRIPTION
## Summary
Two things:

### 1. "Ne pas utiliser les fonctions de partage" (social opt-out)
A new master toggle at the top of **Confidentialité**. When enabled, the member:
- **Becomes undiscoverable** — excluded from `/social/search` + `/social/connectable`, and their profile/follow return **404** to everyone but themselves.
- **Can't use any sharing feature** — follow, recommend, playlist collaborators (`addMember`), save a playlist, or expose a playlist publicly are all rejected server-side; the corresponding UI (people search tab, recommend actions, playlist save/members) is hidden.
- On enabling, their **social ties are torn down** (`UsersService.leaveSocial`): follows both directions, saved playlists, collaborations (theirs + collaborators on their own playlists), content recommendations sent/received, and their own playlists revert to `private`.

The other privacy toggles are hidden while the opt-out is on (they're moot).

### 2. Default member roster in search
The **Utilisateurs** search tab now shows a default list of discoverable members before any query is typed (backend `search` returns the roster on an empty query), instead of a bare hint.

## Backend
- `users.shareDisabled` column + migration `1781800000000`, self-editable DTO field, applied in `UsersService.update` which runs `leaveSocial` on the false→true transition.
- Guards in `SocialService` (search/connectable/getProfile/follow/recommend) and `PlaylistsService` (savePlaylist/addMember/update-visibility).

Verified: backend `tsc` + frontend build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)