### PR TITLE
feat(layout): add a My profile entry under Search in the sidebar

### DIFF
--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -293,6 +293,7 @@
   },
   "nav": {
     "home": "Accueil",
+    "my_profile": "Mon profil",
     "statistics": "Statistiques",
     "dashboard": "Tableau de bord",
     "import_disk": "Import disque",

--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -338,6 +338,14 @@
             {{ 'search.title' | translate }}
           </a>
         </li>
+        @if (!tv.isTv() && auth.user()?.id) {
+          <li>
+            <a [routerLink]="['/profile', auth.user()!.id]" routerLinkActive="active">
+              <svg lucideUserRound class="h-5 w-5"></svg>
+              {{ 'nav.my_profile' | translate }}
+            </a>
+          </li>
+        }
 
         <li class="menu-title text-xs uppercase tracking-wider mt-3">{{ 'nav.section_library' | translate }}</li>
         @for (lib of displayLibraries(); track lib.id) {

--- a/client/src/app/shared/layout/layout.ts
+++ b/client/src/app/shared/layout/layout.ts
@@ -60,6 +60,7 @@ import {
   LucidePin,
   LucideRocket,
   LucideListVideo,
+  LucideUserRound,
 } from '@lucide/angular';
 
 
@@ -69,7 +70,7 @@ import {
     RouterOutlet, RouterLink, RouterLinkActive, TranslateModule,
     LucideMenu, LucideChevronLeft, LucideHome, LucideSearch,
     LucideClipboardList, LucideDownload, LucideCalendar, LucideCast,
-    LucideHistory, LucideEllipsisVertical, LucidePin, LucideRocket, LucideListVideo,
+    LucideHistory, LucideEllipsisVertical, LucidePin, LucideRocket, LucideListVideo, LucideUserRound,
     CastOverlayComponent,
     CardActionsPanelComponent,
     AddToPlaylistModalComponent,


### PR DESCRIPTION
Adds a **Mon profil** link in the desktop left sidebar, right under Search, deep-linking to the current user's profile (`/profile/:id`). Hidden on TV (like the rest of the social surface) and only shown once a user is loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)