### PR TITLE
feat(profile): route taste chips to search and polish the profile UI

### DIFF
--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -216,7 +216,7 @@
     "profile_private": "Ce profil est privé. Suivez cet utilisateur pour voir son contenu.",
     "profile_empty": "L'utilisateur a choisi de ne pas afficher de données sur son profil.",
     "section_playlists": "Playlists publiques",
-    "section_tastes": "Genres préférés de {{username}}",
+    "section_tastes": "Genres préférés",
     "section_recommendations": "Recommandations",
     "section_recently_watched": "Vu récemment",
     "section_likes": "Coups de cœur",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -247,6 +247,7 @@
     "avatar_edit_title": "Recadrer la photo",
     "avatar_zoom": "Zoom",
     "avatar_remove": "Retirer la photo",
+    "avatar_remove_confirm": "Voulez-vous vraiment retirer votre photo de profil ?",
     "avatar_invalid": "Le fichier sélectionné n'est pas une image",
     "avatar_updated": "Photo de profil mise à jour",
     "avatar_removed": "Photo de profil retirée",

--- a/client/src/app/core/services/search-state.service.ts
+++ b/client/src/app/core/services/search-state.service.ts
@@ -74,16 +74,17 @@ export class SearchStateService {
     this.focusRequestId.update((n) => n + 1);
   }
 
-  /** A genre a caller (e.g. a profile taste chip) asked to preload into the
-   *  discover panel. Carries a monotonic counter so repeat requests refire the
-   *  search page's effect even when the route is reused. */
-  readonly genreFilterRequest = signal<{ genre: string; n: number } | null>(
+  /** A TMDB genre id a caller (e.g. a profile taste chip) asked to preload into
+   *  the discover panel. An id (not a name) keeps it language-proof. Carries a
+   *  monotonic counter so repeat requests refire the search page's effect even
+   *  when the route is reused. */
+  readonly genreFilterRequest = signal<{ genreId: number; n: number } | null>(
     null,
   );
   private genreFilterCounter = 0;
 
-  requestGenreFilter(genre: string): void {
-    this.genreFilterRequest.set({ genre, n: ++this.genreFilterCounter });
+  requestGenreFilter(genreId: number): void {
+    this.genreFilterRequest.set({ genreId, n: ++this.genreFilterCounter });
   }
 
   /** External results for the "add to library" section: only titles NOT already

--- a/client/src/app/core/services/search-state.service.ts
+++ b/client/src/app/core/services/search-state.service.ts
@@ -74,6 +74,18 @@ export class SearchStateService {
     this.focusRequestId.update((n) => n + 1);
   }
 
+  /** A genre a caller (e.g. a profile taste chip) asked to preload into the
+   *  discover panel. Carries a monotonic counter so repeat requests refire the
+   *  search page's effect even when the route is reused. */
+  readonly genreFilterRequest = signal<{ genre: string; n: number } | null>(
+    null,
+  );
+  private genreFilterCounter = 0;
+
+  requestGenreFilter(genre: string): void {
+    this.genreFilterRequest.set({ genre, n: ++this.genreFilterCounter });
+  }
+
   /** External results for the "add to library" section: only titles NOT already
    *  in the library (owned ones move to {@link ownedExternalResults}). */
   readonly filteredExternalResults = computed(() => {

--- a/client/src/app/core/utils/tmdb-genres.ts
+++ b/client/src/app/core/utils/tmdb-genres.ts
@@ -1,0 +1,79 @@
+/**
+ * Resolve a genre *name* to its TMDB genre id, language-independently.
+ *
+ * Taste-profile chips carry genre names captured on the media at add time,
+ * which may be English ("Drama") on older items or French ("Drame") on newer
+ * ones (TMDB is queried in fr-FR today). The discover panel filters by genre
+ * id, and TMDB ids are stable across languages — so we map the name to an id
+ * through a normalized EN/FR alias table rather than matching display strings.
+ *
+ * Ids target the movie catalogue (the discover grid's default); TV-only genres
+ * map to their closest movie equivalent so a chip always yields a usable
+ * filter. A caller can pass a live genre list (e.g. the fr-FR list fetched from
+ * TMDB) as a fallback for names the static table doesn't cover.
+ */
+
+/** Lowercase, strip accents, drop separators — so "Science-Fiction",
+ *  "Science Fiction" and "science fiction" all collapse to one key. */
+function normalizeGenre(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '');
+}
+
+/** Normalized EN + FR genre name → TMDB id. */
+const GENRE_ALIASES: Record<string, number> = {
+  // Movie genres (EN / fr-FR)
+  action: 28,
+  adventure: 12,
+  aventure: 12,
+  animation: 16,
+  comedy: 35,
+  comedie: 35,
+  crime: 80,
+  documentary: 99,
+  documentaire: 99,
+  drama: 18,
+  drame: 18,
+  family: 10751,
+  familial: 10751,
+  fantasy: 14,
+  fantastique: 14,
+  history: 36,
+  histoire: 36,
+  horror: 27,
+  horreur: 27,
+  music: 10402,
+  musique: 10402,
+  mystery: 9648,
+  mystere: 9648,
+  romance: 10749,
+  sciencefiction: 878,
+  thriller: 53,
+  tvmovie: 10770,
+  telefilm: 10770,
+  war: 10752,
+  guerre: 10752,
+  western: 37,
+  // TV-only genres → closest movie equivalent so the chip still filters
+  actionadventure: 28,
+  actionaventure: 28,
+  scififantasy: 878,
+  sciencefictionfantastique: 878,
+  warpolitics: 10752,
+  guerrepolitique: 10752,
+  kids: 10751,
+  enfants: 10751,
+};
+
+export function resolveTmdbGenreId(
+  name: string,
+  fallbackList: { id: number; name: string }[] = [],
+): number | null {
+  const key = normalizeGenre(name);
+  if (GENRE_ALIASES[key] != null) return GENRE_ALIASES[key];
+  const match = fallbackList.find((g) => normalizeGenre(g.name) === key);
+  return match?.id ?? null;
+}

--- a/client/src/app/features/profile/profile-overview.html
+++ b/client/src/app/features/profile/profile-overview.html
@@ -12,16 +12,16 @@
       </div>
     }
     <!-- Tastes -->
-    @if (p.shown.tastes && p.topGenres.length) {
+    @if (p.shown.tastes && displayGenres().length) {
       <section class="mb-8">
         <h2 class="text-lg font-semibold mb-3">{{ 'social.section_tastes' | translate: { username: p.username } }}</h2>
         <div class="flex flex-wrap gap-2">
-          @for (g of p.topGenres; track g.genre) {
+          @for (g of displayGenres(); track g.id) {
             <button
               type="button"
               class="badge badge-lg badge-outline cursor-pointer hover:badge-primary"
-              (click)="openGenre(g.genre)"
-            >{{ g.genre }}</button>
+              (click)="openGenre(g.id)"
+            >{{ g.name }}</button>
           }
         </div>
       </section>

--- a/client/src/app/features/profile/profile-overview.html
+++ b/client/src/app/features/profile/profile-overview.html
@@ -14,7 +14,7 @@
     <!-- Tastes -->
     @if (p.shown.tastes && displayGenres().length) {
       <section class="mb-8">
-        <h2 class="text-lg font-semibold mb-3">{{ 'social.section_tastes' | translate: { username: p.username } }}</h2>
+        <h2 class="text-lg font-semibold mb-3">{{ 'social.section_tastes' | translate }}</h2>
         <div class="flex flex-wrap gap-2">
           @for (g of displayGenres(); track g.id) {
             <button

--- a/client/src/app/features/profile/profile-overview.html
+++ b/client/src/app/features/profile/profile-overview.html
@@ -17,15 +17,11 @@
         <h2 class="text-lg font-semibold mb-3">{{ 'social.section_tastes' | translate: { username: p.username } }}</h2>
         <div class="flex flex-wrap gap-2">
           @for (g of p.topGenres; track g.genre) {
-            @if (firstLibraryName()) {
-              <a
-                class="badge badge-lg badge-outline cursor-pointer hover:badge-primary"
-                [routerLink]="['/libraries', firstLibraryName()]"
-                [queryParams]="{ view: 'all', genre: g.genre }"
-              >{{ g.genre }}</a>
-            } @else {
-              <span class="badge badge-lg badge-outline">{{ g.genre }}</span>
-            }
+            <button
+              type="button"
+              class="badge badge-lg badge-outline cursor-pointer hover:badge-primary"
+              (click)="openGenre(g.genre)"
+            >{{ g.genre }}</button>
           }
         </div>
       </section>

--- a/client/src/app/features/profile/profile-overview.ts
+++ b/client/src/app/features/profile/profile-overview.ts
@@ -2,15 +2,14 @@ import {
   ChangeDetectionStrategy,
   Component,
   inject,
-  signal,
 } from '@angular/core';
-import { Router, RouterLink } from '@angular/router';
+import { Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { MosaicCardComponent } from '../../shared/components/mosaic-card/mosaic-card';
 import { MediaCardComponent } from '../../shared/components/media-card/media-card';
 import { HorizontalScrollerComponent } from '../../shared/components/horizontal-scroller';
 import { PublicProfile } from '../../core/services/api/social-api.service';
-import { LibrariesApiService } from '../../core/services/api/libraries-api.service';
+import { SearchStateService } from '../../core/services/search-state.service';
 import { ProfileContextService } from './profile-context.service';
 
 /** The profile "overview" tab: tastes, playlists, recommendations, recently
@@ -19,7 +18,6 @@ import { ProfileContextService } from './profile-context.service';
 @Component({
   selector: 'app-profile-overview',
   imports: [
-    RouterLink,
     TranslateModule,
     MosaicCardComponent,
     MediaCardComponent,
@@ -30,26 +28,16 @@ import { ProfileContextService } from './profile-context.service';
 })
 export class ProfileOverviewComponent {
   private readonly router = inject(Router);
-  private readonly librariesApi = inject(LibrariesApiService);
+  private readonly searchState = inject(SearchStateService);
   protected readonly ctx = inject(ProfileContextService);
 
   readonly profile = this.ctx.profile;
 
-  /** Name of the first library the viewer can access — genre chips link here,
-   *  filtered by the genre. Empty when the viewer has no library access. */
-  readonly firstLibraryName = signal('');
-
-  constructor() {
-    void this.loadLibraries();
-  }
-
-  private async loadLibraries(): Promise<void> {
-    try {
-      const libs = await this.librariesApi.list();
-      this.firstLibraryName.set(libs[0]?.name ?? '');
-    } catch {
-      /* interceptor surfaces errors */
-    }
+  /** Open the general search page with the discover panel preloaded on a
+   *  genre (not a library-scoped view). */
+  openGenre(genre: string): void {
+    this.searchState.requestGenreFilter(genre);
+    void this.router.navigate(['/search']);
   }
 
   mediaLink(mediaType: string, mediaId: number): string[] {

--- a/client/src/app/features/profile/profile-overview.ts
+++ b/client/src/app/features/profile/profile-overview.ts
@@ -1,7 +1,9 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   inject,
+  signal,
 } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
@@ -9,7 +11,9 @@ import { MosaicCardComponent } from '../../shared/components/mosaic-card/mosaic-
 import { MediaCardComponent } from '../../shared/components/media-card/media-card';
 import { HorizontalScrollerComponent } from '../../shared/components/horizontal-scroller';
 import { PublicProfile } from '../../core/services/api/social-api.service';
+import { MetadataService, TmdbGenre } from '../../core/services/api/metadata.service';
 import { SearchStateService } from '../../core/services/search-state.service';
+import { resolveTmdbGenreId } from '../../core/utils/tmdb-genres';
 import { ProfileContextService } from './profile-context.service';
 
 /** The profile "overview" tab: tastes, playlists, recommendations, recently
@@ -28,15 +32,52 @@ import { ProfileContextService } from './profile-context.service';
 })
 export class ProfileOverviewComponent {
   private readonly router = inject(Router);
+  private readonly metadata = inject(MetadataService);
   private readonly searchState = inject(SearchStateService);
   protected readonly ctx = inject(ProfileContextService);
 
   readonly profile = this.ctx.profile;
 
-  /** Open the general search page with the discover panel preloaded on a
-   *  genre (not a library-scoped view). */
-  openGenre(genre: string): void {
-    this.searchState.requestGenreFilter(genre);
+  /** TMDB genre lists in the server language (movie first so shared genres
+   *  resolve to a movie id, which the discover grid can filter on). */
+  private readonly genreList = signal<TmdbGenre[]>([]);
+
+  /** Taste chips resolved to a TMDB id + the server-language name, deduped.
+   *  Stored genre names can be a mix of languages on older items; resolving to
+   *  an id lets us relabel them consistently and filter reliably. */
+  readonly displayGenres = computed<{ id: number; name: string }[]>(() => {
+    const list = this.genreList();
+    const out: { id: number; name: string }[] = [];
+    const seen = new Set<number>();
+    for (const g of this.profile()?.topGenres ?? []) {
+      const id = resolveTmdbGenreId(g.genre, list);
+      if (id == null || seen.has(id)) continue;
+      seen.add(id);
+      out.push({ id, name: list.find((x) => x.id === id)?.name ?? g.genre });
+    }
+    return out;
+  });
+
+  constructor() {
+    void this.loadGenres();
+  }
+
+  private async loadGenres(): Promise<void> {
+    try {
+      const [movie, tv] = await Promise.all([
+        this.metadata.getMovieGenres().catch(() => [] as TmdbGenre[]),
+        this.metadata.getTvGenres().catch(() => [] as TmdbGenre[]),
+      ]);
+      this.genreList.set([...movie, ...tv]);
+    } catch {
+      /* chips fall back to the static alias resolver */
+    }
+  }
+
+  /** Open the general search page with the discover panel preloaded on a genre
+   *  id (language-proof), not a library-scoped view. */
+  openGenre(id: number): void {
+    this.searchState.requestGenreFilter(id);
     void this.router.navigate(['/search']);
   }
 

--- a/client/src/app/features/profile/profile-recommendations.html
+++ b/client/src/app/features/profile/profile-recommendations.html
@@ -12,7 +12,7 @@
     <section class="mb-8">
       <h2 class="text-lg font-semibold mb-3">{{ 'recommend.profile_received' | translate }}</h2>
       <div class="overflow-x-auto">
-        <table class="table table-sm">
+        <table class="table text-base">
           <thead>
             <tr>
               <th>{{ 'recommend.col_content' | translate }}</th>
@@ -27,13 +27,13 @@
                   <a [routerLink]="contentLink(item)" class="flex items-center gap-3 min-w-0">
                     <div class="w-14 aspect-video rounded bg-base-300 overflow-hidden shrink-0">
                       @if (item.stillUrl ?? item.fanartUrl ?? item.posterUrl; as img) {
-                        <img [src]="img" [alt]="item.title" class="w-full h-full object-cover" loading="lazy" />
+                        <img [src]="img | resolveUrl:'thumb'" [alt]="item.title" class="w-full h-full object-cover" loading="lazy" />
                       }
                     </div>
                     <div class="min-w-0">
                       <div class="font-medium truncate hover:underline">{{ item.title }}</div>
                       @if (item.label) {
-                        <div class="text-xs text-base-content/60 truncate">{{ item.label }}</div>
+                        <div class="text-sm text-base-content/60 truncate">{{ item.label }}</div>
                       }
                     </div>
                   </a>
@@ -57,7 +57,7 @@
     <section class="mb-8">
       <h2 class="text-lg font-semibold mb-3">{{ 'recommend.profile_sent' | translate }}</h2>
       <div class="overflow-x-auto">
-        <table class="table table-sm">
+        <table class="table text-base">
           <thead>
             <tr>
               <th>{{ 'recommend.col_content' | translate }}</th>
@@ -72,13 +72,13 @@
                   <a [routerLink]="contentLink(item)" class="flex items-center gap-3 min-w-0">
                     <div class="w-14 aspect-video rounded bg-base-300 overflow-hidden shrink-0">
                       @if (item.stillUrl ?? item.fanartUrl ?? item.posterUrl; as img) {
-                        <img [src]="img" [alt]="item.title" class="w-full h-full object-cover" loading="lazy" />
+                        <img [src]="img | resolveUrl:'thumb'" [alt]="item.title" class="w-full h-full object-cover" loading="lazy" />
                       }
                     </div>
                     <div class="min-w-0">
                       <div class="font-medium truncate hover:underline">{{ item.title }}</div>
                       @if (item.label) {
-                        <div class="text-xs text-base-content/60 truncate">{{ item.label }}</div>
+                        <div class="text-sm text-base-content/60 truncate">{{ item.label }}</div>
                       }
                     </div>
                   </a>

--- a/client/src/app/features/profile/profile-recommendations.ts
+++ b/client/src/app/features/profile/profile-recommendations.ts
@@ -12,6 +12,7 @@ import {
   SentRecommendation,
   SocialApiService,
 } from '../../core/services/api/social-api.service';
+import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
 import { ProfileContextService } from './profile-context.service';
 
 /** The profile "recommendations" tab, own-profile only: content other members
@@ -19,7 +20,7 @@ import { ProfileContextService } from './profile-context.service';
  *  Rendered as compact tables so the recipient/sender is always visible. */
 @Component({
   selector: 'app-profile-recommendations',
-  imports: [TranslateModule, RouterLink],
+  imports: [TranslateModule, RouterLink, ResolveUrlPipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './profile-recommendations.html',
 })

--- a/client/src/app/features/profile/profile.html
+++ b/client/src/app/features/profile/profile.html
@@ -55,7 +55,7 @@
         @if (p.isSelf && p.avatar) {
           <button
             type="button"
-            class="text-xs text-base-content/50 hover:text-error mt-1"
+            class="text-sm text-base-content/50 hover:text-error mt-1"
             (click)="removeAvatar()"
           >
             {{ 'social.avatar_remove' | translate }}

--- a/client/src/app/features/profile/profile.ts
+++ b/client/src/app/features/profile/profile.ts
@@ -28,6 +28,7 @@ import { SocialApiService } from '../../core/services/api/social-api.service';
 import { UsersApiService } from '../../core/services/api/users-api.service';
 import { AuthService } from '../../core/services/auth.service';
 import { ToastService } from '../../core/services/toast.service';
+import { ConfirmationService } from '../../core/services/confirmation.service';
 import { NavbarService } from '../../core/services/navbar.service';
 import { initialsAvatar } from '../../core/utils/initials-avatar';
 import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
@@ -67,6 +68,7 @@ export class ProfileComponent {
   private readonly auth = inject(AuthService);
   private readonly toast = inject(ToastService);
   private readonly translate = inject(TranslateService);
+  private readonly confirmation = inject(ConfirmationService);
   private readonly navbar = inject(NavbarService);
   private readonly destroyRef = inject(DestroyRef);
   protected readonly ctx = inject(ProfileContextService);
@@ -163,6 +165,13 @@ export class ProfileComponent {
   }
 
   async removeAvatar(): Promise<void> {
+    const confirmed = await this.confirmation.confirm({
+      title: this.translate.instant('social.avatar_remove'),
+      message: this.translate.instant('social.avatar_remove_confirm'),
+      confirmLabel: this.translate.instant('social.avatar_remove'),
+      variant: 'danger',
+    });
+    if (!confirmed) return;
     try {
       const res = await this.usersApi.deleteAvatar();
       this.ctx.patch({ avatar: res.avatar });

--- a/client/src/app/features/search/search.ts
+++ b/client/src/app/features/search/search.ts
@@ -111,7 +111,7 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly genreFilterEffect = effect(() => {
     const req = this.state.genreFilterRequest();
     if (!req) return;
-    void this.applyGenreFilter(req.genre);
+    void this.applyGenreFilter(req.genreId);
   });
 
   readonly requestedTmdbIds = signal<Map<number, FliksRequestStatus>>(new Map());
@@ -485,26 +485,13 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
     this.state.resetDiscover();
   }
 
-  /** Resolve a genre name to a TMDB id and run the discover grid for it. Taste
-   *  chips mix movies + series, so match against the movie genre list (the
-   *  discover grid defaults to the movie catalogue). */
-  private async applyGenreFilter(name: string): Promise<void> {
+  /** Preload the discover grid on a genre id (resolved by the caller — a
+   *  profile taste chip — so it's language-proof). */
+  private async applyGenreFilter(genreId: number): Promise<void> {
     this.state.tab.set('videos');
     this.state.query.set('');
-    try {
-      const genres = this.state.discoverGenres().length
-        ? this.state.discoverGenres()
-        : await this.metadata.getMovieGenres();
-      this.state.discoverGenres.set(genres);
-      const match = genres.find(
-        (g) => g.name.toLowerCase() === name.toLowerCase(),
-      );
-      if (!match) return;
-      this.state.discoverSelectedGenres.set(new Set([match.id]));
-      await this.applyDiscover();
-    } catch {
-      /* global error toast */
-    }
+    this.state.discoverSelectedGenres.set(new Set([genreId]));
+    await this.applyDiscover();
   }
 
   openFilterSheet() {

--- a/client/src/app/features/search/search.ts
+++ b/client/src/app/features/search/search.ts
@@ -105,6 +105,15 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
     }, 0);
   });
 
+  /** Preload the discover panel with a genre asked for from elsewhere (e.g. a
+   *  profile taste chip). Lives on the instance so it fires across route reuse,
+   *  where ngOnInit wouldn't re-run. */
+  private readonly genreFilterEffect = effect(() => {
+    const req = this.state.genreFilterRequest();
+    if (!req) return;
+    void this.applyGenreFilter(req.genre);
+  });
+
   readonly requestedTmdbIds = signal<Map<number, FliksRequestStatus>>(new Map());
 
   private static readonly SCROLL_KEY = 'search';
@@ -474,6 +483,28 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
 
   clearDiscover() {
     this.state.resetDiscover();
+  }
+
+  /** Resolve a genre name to a TMDB id and run the discover grid for it. Taste
+   *  chips mix movies + series, so match against the movie genre list (the
+   *  discover grid defaults to the movie catalogue). */
+  private async applyGenreFilter(name: string): Promise<void> {
+    this.state.tab.set('videos');
+    this.state.query.set('');
+    try {
+      const genres = this.state.discoverGenres().length
+        ? this.state.discoverGenres()
+        : await this.metadata.getMovieGenres();
+      this.state.discoverGenres.set(genres);
+      const match = genres.find(
+        (g) => g.name.toLowerCase() === name.toLowerCase(),
+      );
+      if (!match) return;
+      this.state.discoverSelectedGenres.set(new Set([match.id]));
+      await this.applyDiscover();
+    } catch {
+      /* global error toast */
+    }
   }
 
   openFilterSheet() {


### PR DESCRIPTION
Bundle of profile-page tweaks:

- **Avatar removal confirm** — "Retirer la photo" now asks for confirmation (danger variant) before deleting.
- **Taste genre chips → search** — clicking a genre on a profile opens the **general Search** page with the Discover panel preloaded on that genre (not a library-scoped view). Hand-off via a `SearchStateService` request counter so it fires reliably even when the cached `/search` route is reattached.
  - **Language-proof**: stored genre names can be a mix of languages on older items ("Drama" vs the fr-FR "Drame"), so chips are resolved to a language-independent **TMDB genre id** (EN/FR alias table + the live server-language list as fallback), **relabelled in the server language**, deduped by id, and the **id** — not a name — is handed to the discover filter.
- **Bigger recommendation text** — the recommendations-tab tables drop `table-sm`/`text-xs` for the default table size + `text-sm` sublabels.
- **Android broken thumbnails** — recommendation table thumbnails now go through `| resolveUrl:'thumb'` so relative `/api/images/...` paths resolve against the server in the WebView.

🤖 Generated with [Claude Code](https://claude.com/claude-code)