### PR TITLE
fix(search): stop the genre hand-off from locking the discover panel

### DIFF
--- a/client/src/app/features/search/search.ts
+++ b/client/src/app/features/search/search.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectionStrategy,
   signal,
   effect,
+  untracked,
   inject,
   Injector,
   OnDestroy,
@@ -111,7 +112,15 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly genreFilterEffect = effect(() => {
     const req = this.state.genreFilterRequest();
     if (!req) return;
-    void this.applyGenreFilter(req.genreId);
+    // Consume once, untracked: applying reads the discover-filter signals
+    // (selected genres, sort, rating…) synchronously, and without untracked
+    // those reads would become dependencies of this effect — so changing a
+    // genre or switching tab afterwards would re-fire it and snap the
+    // selection back. Clearing the request keeps it a one-shot hand-off.
+    untracked(() => {
+      void this.applyGenreFilter(req.genreId);
+      this.state.genreFilterRequest.set(null);
+    });
   });
 
   readonly requestedTmdbIds = signal<Map<number, FliksRequestStatus>>(new Map());

--- a/client/src/app/features/search/search.ts
+++ b/client/src/app/features/search/search.ts
@@ -112,11 +112,7 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly genreFilterEffect = effect(() => {
     const req = this.state.genreFilterRequest();
     if (!req) return;
-    // Consume once, untracked: applying reads the discover-filter signals
-    // (selected genres, sort, rating…) synchronously, and without untracked
-    // those reads would become dependencies of this effect — so changing a
-    // genre or switching tab afterwards would re-fire it and snap the
-    // selection back. Clearing the request keeps it a one-shot hand-off.
+    // One-shot: untracked so the applied filter reads don't become deps.
     untracked(() => {
       void this.applyGenreFilter(req.genreId);
       this.state.genreFilterRequest.set(null);


### PR DESCRIPTION
## Bug
Clicking a genre chip on a profile lands on Search with that genre applied (correct), but afterwards you **can't change the genre** (it snaps back and the page reloads) and **can't switch to the Utilisateur tab**.

## Cause
The genre hand-off applies the filter inside an `effect()` that reads `genreFilterRequest`. It calls `applyGenreFilter → applyDiscover()`, and `applyDiscover()` reads the discover-filter signals (`discoverSelectedGenres`, `contentType`, `discoverSort`, `discoverVoteMin`, …) **synchronously** — so those reads became dependencies of the effect. Any later change to a genre/filter re-fired the effect and reset the selection to the profile genre.

## Fix
Consume the request inside `untracked()` (so the applied reads don't become dependencies) and clear it afterwards so it's a one-shot hand-off. The effect now depends only on `genreFilterRequest`.

Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)