### PR TITLE
feat(ui): animate desktop dropdown and card-action menus on close

### DIFF
--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
@@ -7,6 +7,7 @@
   <div
     #menu
     class="card-actions-menu fixed z-[101] bg-base-200 rounded-box shadow-xl overflow-hidden"
+    animate.leave="card-actions-leaving"
     [style.top.px]="position()?.top"
     [style.left.px]="position()?.left"
     [style.width.px]="position()?.width"

--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.ts
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.ts
@@ -62,6 +62,13 @@ import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
       from { opacity: 0; transform: scale(0.94) translateY(-4px); }
       to   { opacity: 1; transform: scale(1) translateY(0); }
     }
+    .card-actions-leaving {
+      animation: card-actions-pop-out 120ms ease forwards;
+    }
+    @keyframes card-actions-pop-out {
+      from { opacity: 1; transform: scale(1) translateY(0); }
+      to   { opacity: 0; transform: scale(0.94) translateY(-4px); }
+    }
   `],
 })
 export class CardActionsPanelComponent {

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -573,7 +573,33 @@ body.tv .to-base-100\/50 {
 /* Dropdowns are click-driven (`.dropdown-open` toggled by
    `appDropdownToggle`). Neutralise DaisyUI's `:focus-within` fallback so
    tabbing onto a trigger never auto-opens the menu — Tab/D-pad focus alone
-   should be a focus move, not an open. */
+   should be a focus move, not an open. `display` is part of the transition
+   (`allow-discrete`) so the panel animates on close before it's hidden;
+   `@starting-style` gives the matching open animation. Unsupported engines
+   (old TV Chromium) ignore both and just toggle instantly. */
+.dropdown > .dropdown-content {
+  opacity: 0;
+  transform: scale(0.96);
+  transform-origin: top;
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease,
+    display 0.15s allow-discrete;
+}
+.dropdown.dropdown-end > .dropdown-content {
+  transform-origin: top right;
+}
+.dropdown.dropdown-top > .dropdown-content {
+  transform-origin: bottom;
+}
+.dropdown.dropdown-open > .dropdown-content {
+  opacity: 1;
+  transform: scale(1);
+  @starting-style {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+}
 .dropdown:not(.dropdown-open) > .dropdown-content {
   display: none !important;
 }


### PR DESCRIPTION
Adds a small fade + scale close (and open) animation to desktop menus.

- **Dropdowns** (`app-dropdown-menu` — user menu, season menu, etc.): the panel is class-toggled (`.dropdown-open`), so it's done in CSS via `transition-behavior: allow-discrete` (close) + `@starting-style` (open). No change to the shared directive / spatial-nav / focus.
- **Media-card actions menu** (`card-actions-panel`, desktop): this panel is `@if`-rendered, so it uses Angular 21's `animate.leave` to play a symmetric exit — reusing the component's existing `card-actions-pop` keyframe style.

Unsupported engines (old TV Chromium) just toggle instantly; both panels only render on desktop anyway (touch/TV use the bottom sheet). Build clean.