### PR TITLE
style(cards): limit the enlarged card text to md and up

### DIFF
--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -151,18 +151,18 @@
   <div class="pt-1.5">
     @if (_link()) {
       <a [routerLink]="_link()" [state]="_navState()" [replaceUrl]="replaceUrl()" class="hover:underline" [attr.tabindex]="innerTabindex" (pointerdown)="onAnchorPointerdown()" (keydown.enter)="onAnchorPointerdown()">
-        <h3 class="text-base font-medium line-clamp-1 leading-snug">{{ _title() }}</h3>
+        <h3 class="text-sm md:text-base font-medium line-clamp-1 leading-snug">{{ _title() }}</h3>
       </a>
     } @else {
-      <h3 class="text-base font-medium line-clamp-1 leading-snug">{{ _title() }}</h3>
+      <h3 class="text-sm md:text-base font-medium line-clamp-1 leading-snug">{{ _title() }}</h3>
     }
     @if (_subtitle()) {
       @if (subtitleLink()) {
         <a [routerLink]="subtitleLink()" class="hover:underline" [attr.tabindex]="innerTabindex">
-          <p class="text-sm text-base-content/50 line-clamp-1">{{ _subtitle() }}</p>
+          <p class="text-xs md:text-sm text-base-content/50 line-clamp-1">{{ _subtitle() }}</p>
         </a>
       } @else {
-        <p class="text-sm text-base-content/50 line-clamp-1">{{ _subtitle() }}</p>
+        <p class="text-xs md:text-sm text-base-content/50 line-clamp-1">{{ _subtitle() }}</p>
       }
     }
   </div>

--- a/client/src/app/shared/components/mosaic-card/mosaic-card.ts
+++ b/client/src/app/shared/components/mosaic-card/mosaic-card.ts
@@ -35,9 +35,9 @@ import { ImgFadeInDirective } from '../../directives/img-fade-in.directive';
         }
         <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none"></div>
       </div>
-      <div class="text-base min-w-0 w-full">
+      <div class="text-sm md:text-base min-w-0 w-full">
         <div class="font-medium truncate hover:underline">{{ label() }}</div>
-        <div class="text-sm text-base-content/50">{{ subtitle() }}</div>
+        <div class="text-xs md:text-sm text-base-content/50">{{ subtitle() }}</div>
       </div>
     </button>
   `,


### PR DESCRIPTION
Follow-up to #693: the bigger title/subtitle now only applies at `md` and up. Mobile keeps the original sizes.

- Title: `text-sm md:text-base`
- Subtitle: `text-xs md:text-sm`

Applied to both media-card and mosaic-card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)