### PR TITLE
fix(streaming): correct NVENC transcode and HDR->SDR tonemap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* "$HOME/.cargo/registry" "$HOME/.rustup" \
        /tmp/dovi_tool /tmp/libplacebo
 
+# --- Newer Vulkan loader ---
+# Ubuntu 24.04 ships libvulkan1 1.3.275, which can't negotiate with the
+# current NVIDIA ICD (Vulkan 1.4): `vk_icdGetInstanceProcAddr` returns a NULL
+# vkCreateInstance, so Vulkan silently falls back to llvmpipe (software) and
+# libplacebo tonemapping crawls at ~0.03x. Build a 1.4 loader to drop in over
+# the apt one so `-init_hw_device vulkan` reaches the real GPU.
+FROM ubuntu:24.04 AS vulkan-loader-build
+ARG VULKAN_LOADER_TAG=vulkan-sdk-1.4.313.0
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates git cmake ninja-build build-essential python3 \
+  && git clone --depth 1 --branch "$VULKAN_LOADER_TAG" \
+       https://github.com/KhronosGroup/Vulkan-Loader.git /tmp/vkloader-src \
+  && cmake -S /tmp/vkloader-src -B /tmp/vkloader-build -G Ninja \
+       -DUPDATE_DEPS=ON -DBUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release \
+       -DCMAKE_INSTALL_PREFIX=/opt/vkloader \
+  && cmake --build /tmp/vkloader-build --target install \
+  && rm -rf /var/lib/apt/lists/* /tmp/vkloader-src /tmp/vkloader-build
+
 # --- Stage 3: Production runtime ---
 FROM ubuntu:24.04
 
@@ -129,6 +147,19 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
       && ldconfig; \
     fi \
   && rm -rf /tmp/dvlibs
+
+# Replace the apt Vulkan loader (1.3.275, too old for the NVIDIA 1.4 ICD) with
+# the 1.4 build, and drop the llvmpipe software ICD so `-init_hw_device vulkan`
+# selects the real GPU (NVIDIA/Intel) instead of the CPU renderer.
+COPY --from=vulkan-loader-build /opt/vkloader/lib/ /tmp/vkloader/
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+      real="$(ls /tmp/vkloader/libvulkan.so.1.* | head -1)" \
+      && cp -a "$real" /usr/lib/x86_64-linux-gnu/ \
+      && ln -sf "$(basename "$real")" /usr/lib/x86_64-linux-gnu/libvulkan.so.1 \
+      && rm -f /usr/share/vulkan/icd.d/lvp_icd.json \
+      && ldconfig; \
+    fi \
+  && rm -rf /tmp/vkloader
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,11 +68,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 FROM ubuntu:24.04 AS vulkan-loader-build
 ARG VULKAN_LOADER_TAG=vulkan-sdk-1.4.313.0
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates git cmake ninja-build build-essential python3 \
+      ca-certificates git cmake ninja-build build-essential python3 pkg-config \
   && git clone --depth 1 --branch "$VULKAN_LOADER_TAG" \
        https://github.com/KhronosGroup/Vulkan-Loader.git /tmp/vkloader-src \
   && cmake -S /tmp/vkloader-src -B /tmp/vkloader-build -G Ninja \
        -DUPDATE_DEPS=ON -DBUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release \
+       -DBUILD_WSI_XCB_SUPPORT=OFF -DBUILD_WSI_XLIB_SUPPORT=OFF \
+       -DBUILD_WSI_WAYLAND_SUPPORT=OFF -DBUILD_WSI_DIRECTFB_SUPPORT=OFF \
        -DCMAKE_INSTALL_PREFIX=/opt/vkloader \
   && cmake --build /tmp/vkloader-build --target install \
   && rm -rf /var/lib/apt/lists/* /tmp/vkloader-src /tmp/vkloader-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,24 +59,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* "$HOME/.cargo/registry" "$HOME/.rustup" \
        /tmp/dovi_tool /tmp/libplacebo
 
-# --- Newer Vulkan loader ---
-# Ubuntu 24.04 ships libvulkan1 1.3.275, which can't negotiate with the
-# current NVIDIA ICD (Vulkan 1.4): `vk_icdGetInstanceProcAddr` returns a NULL
-# vkCreateInstance, so Vulkan silently falls back to llvmpipe (software) and
-# libplacebo tonemapping crawls at ~0.03x. Build a 1.4 loader to drop in over
-# the apt one so `-init_hw_device vulkan` reaches the real GPU.
-FROM ubuntu:24.04 AS vulkan-loader-build
-ARG VULKAN_LOADER_TAG=vulkan-sdk-1.4.313.0
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates git cmake ninja-build build-essential python3 \
-  && git clone --depth 1 --branch "$VULKAN_LOADER_TAG" \
-       https://github.com/KhronosGroup/Vulkan-Loader.git /tmp/vkloader-src \
-  && cmake -S /tmp/vkloader-src -B /tmp/vkloader-build -G Ninja \
-       -DUPDATE_DEPS=ON -DBUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release \
-       -DCMAKE_INSTALL_PREFIX=/opt/vkloader \
-  && cmake --build /tmp/vkloader-build --target install \
-  && rm -rf /var/lib/apt/lists/* /tmp/vkloader-src /tmp/vkloader-build
-
 # --- Stage 3: Production runtime ---
 FROM ubuntu:24.04
 
@@ -147,19 +129,6 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
       && ldconfig; \
     fi \
   && rm -rf /tmp/dvlibs
-
-# Replace the apt Vulkan loader (1.3.275, too old for the NVIDIA 1.4 ICD) with
-# the 1.4 build, and drop the llvmpipe software ICD so `-init_hw_device vulkan`
-# selects the real GPU (NVIDIA/Intel) instead of the CPU renderer.
-COPY --from=vulkan-loader-build /opt/vkloader/lib/ /tmp/vkloader/
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-      real="$(ls /tmp/vkloader/libvulkan.so.1.* | head -1)" \
-      && cp -a "$real" /usr/lib/x86_64-linux-gnu/ \
-      && ln -sf "$(basename "$real")" /usr/lib/x86_64-linux-gnu/libvulkan.so.1 \
-      && rm -f /usr/share/vulkan/icd.d/lvp_icd.json \
-      && ldconfig; \
-    fi \
-  && rm -rf /tmp/vkloader
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -134,12 +134,12 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
 # on NVENC hosts. The container toolkit mounts libnvidia-opencl.so with the
 # `compute` capability (same path as CUDA/NVENC, no Vulkan/GLX needed) but
 # doesn't create the ICD entry — without it the OpenCL loader reports no
-# NVIDIA platform. Harmless on non-NVIDIA hosts: the loader just skips an ICD
-# whose library is absent.
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-      mkdir -p /etc/OpenCL/vendors \
-      && echo 'libnvidia-opencl.so.1' > /etc/OpenCL/vendors/nvidia.icd; \
-    fi
+# NVIDIA platform. Arch-agnostic: the entry is just the soname, resolved
+# per-arch by the loader, and harmless on non-NVIDIA hosts (the loader skips
+# an ICD whose library is absent), so it runs for amd64 and arm64 alike (the
+# latter covers NVIDIA-on-ARM hosts like Jetson / Grace).
+RUN mkdir -p /etc/OpenCL/vendors \
+  && echo 'libnvidia-opencl.so.1' > /etc/OpenCL/vendors/nvidia.icd
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -130,6 +130,17 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     fi \
   && rm -rf /tmp/dvlibs
 
+# Register the NVIDIA OpenCL ICD so tonemap_opencl can run HDR→SDR on the GPU
+# on NVENC hosts. The container toolkit mounts libnvidia-opencl.so with the
+# `compute` capability (same path as CUDA/NVENC, no Vulkan/GLX needed) but
+# doesn't create the ICD entry — without it the OpenCL loader reports no
+# NVIDIA platform. Harmless on non-NVIDIA hosts: the loader just skips an ICD
+# whose library is absent.
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+      mkdir -p /etc/OpenCL/vendors \
+      && echo 'libnvidia-opencl.so.1' > /etc/OpenCL/vendors/nvidia.icd; \
+    fi
+
 WORKDIR /app
 
 # Copy backend production dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,13 +68,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 FROM ubuntu:24.04 AS vulkan-loader-build
 ARG VULKAN_LOADER_TAG=vulkan-sdk-1.4.313.0
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates git cmake ninja-build build-essential python3 pkg-config \
+      ca-certificates git cmake ninja-build build-essential python3 \
   && git clone --depth 1 --branch "$VULKAN_LOADER_TAG" \
        https://github.com/KhronosGroup/Vulkan-Loader.git /tmp/vkloader-src \
   && cmake -S /tmp/vkloader-src -B /tmp/vkloader-build -G Ninja \
        -DUPDATE_DEPS=ON -DBUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release \
-       -DBUILD_WSI_XCB_SUPPORT=OFF -DBUILD_WSI_XLIB_SUPPORT=OFF \
-       -DBUILD_WSI_WAYLAND_SUPPORT=OFF -DBUILD_WSI_DIRECTFB_SUPPORT=OFF \
        -DCMAKE_INSTALL_PREFIX=/opt/vkloader \
   && cmake --build /tmp/vkloader-build --target install \
   && rm -rf /var/lib/apt/lists/* /tmp/vkloader-src /tmp/vkloader-build

--- a/backend/src/common/utils/resolution.util.spec.ts
+++ b/backend/src/common/utils/resolution.util.spec.ts
@@ -1,0 +1,25 @@
+import { resolutionFitsCap } from './resolution.util';
+
+describe('resolutionFitsCap', () => {
+  it('passes when the frame fits the cap', () => {
+    expect(resolutionFitsCap(1920, 1080, 2048, 2048)).toBe(true);
+  });
+
+  it('rejects a frame whose long edge exceeds the cap', () => {
+    expect(resolutionFitsCap(3840, 2076, 2048, 2048)).toBe(false);
+  });
+
+  it('is orientation-agnostic — a rotated cap still fits a landscape frame', () => {
+    // 4K decoder advertising its maxima rotated (2160×3840) vs a 3840×2160 frame.
+    expect(resolutionFitsCap(3840, 2160, 2160, 3840)).toBe(true);
+  });
+
+  it('is orientation-agnostic — a portrait frame is rejected on the long edge', () => {
+    expect(resolutionFitsCap(2076, 3840, 2048, 2048)).toBe(false);
+  });
+
+  it('treats an undefined/zero cap axis as no limit', () => {
+    expect(resolutionFitsCap(3840, 2160, undefined, undefined)).toBe(true);
+    expect(resolutionFitsCap(3840, 2160, 0, 0)).toBe(true);
+  });
+});

--- a/backend/src/common/utils/resolution.util.ts
+++ b/backend/src/common/utils/resolution.util.ts
@@ -40,6 +40,30 @@ export function bucketResolutionHeight(
 }
 
 /**
+ * Whether a (width × height) frame fits within a decoder's max resolution,
+ * compared in either orientation — a device reports its per-codec maxima per
+ * axis and can return them rotated (a 4K decoder advertising 2048×2048 vs
+ * 2160×3840), so the source's long edge is checked against the cap's long edge
+ * and likewise for the short edges. An undefined/zero cap axis means "no limit
+ * declared" and passes. Shared by the direct-play codec gate (source vs cap)
+ * and the output-codec selector (target vs cap).
+ */
+export function resolutionFitsCap(
+  width?: number | null,
+  height?: number | null,
+  maxWidth?: number | null,
+  maxHeight?: number | null,
+): boolean {
+  const long = Math.max(width ?? 0, height ?? 0);
+  const short = Math.min(width ?? 0, height ?? 0);
+  const capLong = Math.max(maxWidth ?? 0, maxHeight ?? 0);
+  const capShort = Math.min(maxWidth ?? 0, maxHeight ?? 0);
+  if (capLong && long > capLong) return false;
+  if (capShort && short > capShort) return false;
+  return true;
+}
+
+/**
  * Display label for a (width × height) pair — `"4K"` for 2160 buckets,
  * `"<bucket>p"` for everything else, `null` when both inputs are
  * zero/missing. Mirrors the client's `bucketResolutionLabel` so badge

--- a/backend/src/modules/streaming/dto/playback-info.dto.ts
+++ b/backend/src/modules/streaming/dto/playback-info.dto.ts
@@ -107,13 +107,17 @@ export interface PlaybackInfoResponse {
   /** Whether HDR→SDR tone mapping is being applied */
   tonemapping: boolean;
 
-  /** Actual tone-mapping filter the session will use, after admin
-   *  setting + boot-probe resolution. `null` when no tone-mapping
-   *  pass runs. Distinct from the admin `streaming_tonemap_algo`
-   *  setting because `'auto'` resolves to `'opencl'` when the boot
-   *  probe enabled it and `'vaapi'` otherwise — stats overlays show
-   *  this value, not the (potentially-stale) admin pick. */
-  tonemapAlgo?: 'vaapi' | 'opencl' | 'qsv' | null;
+  /** Tone-map mechanism the session actually runs. `'vaapi'` / `'opencl'`
+   *  / `'qsv'` for QSV/VAAPI encoders (after `auto` resolution + boot
+   *  probe); `'cpu'` for the CPU zscale chain used by NVENC / libx26x /
+   *  VideoToolbox fallback. `null` when no tone-mapping pass runs. Stats
+   *  overlays show this value, not the (encoder-agnostic) admin pick. */
+  tonemapAlgo?: 'vaapi' | 'opencl' | 'qsv' | 'cpu' | null;
+
+  /** CPU tone-map curve (`hable` / `mobius`), set only when
+   *  `tonemapAlgo === 'cpu'`. Surfaced so the overlay names the exact
+   *  curve in use. */
+  tonemapCurve?: 'hable' | 'mobius';
 
   /**
    * Bitrate targets per quality rung (FFmpeg profiles).

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -26,7 +26,10 @@ import {
 } from './transcoding/quality-ladder';
 import { resolveEncodePipeline } from './transcoding/encode-pipeline';
 import { ActiveStreamTracker } from './active-stream-tracker.service';
-import { bucketResolutionHeight } from '../../common/utils/resolution.util';
+import {
+  bucketResolutionHeight,
+  resolutionFitsCap,
+} from '../../common/utils/resolution.util';
 import { normaliseSourceCodec } from './transcoding/codec/normalise';
 import { deriveDvInfo, isDvProfile5 } from './transcoding/codec/dolby-vision';
 import { pickPrimaryVariant } from './transcoding/codec/selector';
@@ -1021,13 +1024,14 @@ export class StreamBuilderService {
             message: `${source.videoBitDepth} bit > max ${cond.maxBitDepth} bit`,
           });
         }
-        // Match source long/short edges against the decoder's max rectangle in
-        // either orientation — Android can report the per-axis maxima rotated.
-        const srcLong = Math.max(source.width ?? 0, source.height ?? 0);
-        const srcShort = Math.min(source.width ?? 0, source.height ?? 0);
-        const capLong = Math.max(cond.maxWidth ?? 0, cond.maxHeight ?? 0);
-        const capShort = Math.min(cond.maxWidth ?? 0, cond.maxHeight ?? 0);
-        if ((capLong && srcLong > capLong) || (capShort && srcShort > capShort)) {
+        if (
+          !resolutionFitsCap(
+            source.width,
+            source.height,
+            cond.maxWidth,
+            cond.maxHeight,
+          )
+        ) {
           videoConditionsMet = false;
           reasons.push({
             flag: 'VideoResolutionNotSupported',

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -14,7 +14,6 @@ import {
   TranscodingService,
   getHdrLadderForDevice,
   getLadderForDevice,
-  cappedTranscodeVideoBitrateBps,
   isEcoProfile,
   parseBitrateToBps,
   profileFitsSource,
@@ -367,32 +366,20 @@ export class StreamBuilderService {
       }
     }
 
-    // Surface a quality-reduction reason only when the chosen explicit rung is
-    // an ACTUAL downscale or bitrate cut vs the source — not merely because a
-    // fixed rung was picked. A rung at the source resolution whose source-
-    // capped bitrate matches the source changes nothing worth flagging.
+    // An explicit rung only reaches this branch via `explicitDownscale` — a
+    // lower resolution or an eco (same-resolution, reduced-bitrate) tier the
+    // user deliberately picked, both of which re-encode the video. Surface the
+    // choice so the overlay never shows a transcode with an empty video reason.
+    // (A per-bitrate re-check used to gate this and silently dropped the reason
+    // for eco rungs whose source-capped bitrate wasn't provably below an
+    // unknown or already-low source bitrate.)
     if (forceLadder && !autoOnLadder) {
       const rung = qualityLadder.find((p) => p.name === requestedQuality);
       if (rung) {
-        const reducesResolution =
-          bucketResolutionHeight(rung.maxWidth, rung.maxHeight) <
-          bucketResolutionHeight(source.width, source.height);
-        const rungVideoBps = cappedTranscodeVideoBitrateBps(
-          parseBitrateToBps(rung.videoBitrate),
-          source.videoBitRate,
-          source.videoCodec,
-          selectedVariant.codec,
-        );
-        const reducesBitrate =
-          source.videoBitRate != null &&
-          source.videoBitRate > 0 &&
-          rungVideoBps < source.videoBitRate * 0.95;
-        if (reducesResolution || reducesBitrate) {
-          reasons.push({
-            flag: 'VideoQualityReduced',
-            message: `Reduced-quality rung selected (${requestedQuality})`,
-          });
-        }
+        reasons.push({
+          flag: 'VideoQualityReduced',
+          message: `Reduced-quality rung selected (${requestedQuality})`,
+        });
       }
     }
 

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -619,7 +619,7 @@ export class StreamBuilderService {
       transcodeReasons: reasons,
       videoCopyStream: false,
       audioCopyStream: canCopyAudio,
-      outputVideoCodec: 'h264',
+      outputVideoCodec: selectedVariant.codec,
       outputAudioCodec,
       audioPlan: canCopyAudio
         ? { mode: 'copy', codec: srcCodec }
@@ -1021,18 +1021,17 @@ export class StreamBuilderService {
             message: `${source.videoBitDepth} bit > max ${cond.maxBitDepth} bit`,
           });
         }
-        if (cond.maxWidth && source.width && source.width > cond.maxWidth) {
+        // Match source long/short edges against the decoder's max rectangle in
+        // either orientation — Android can report the per-axis maxima rotated.
+        const srcLong = Math.max(source.width ?? 0, source.height ?? 0);
+        const srcShort = Math.min(source.width ?? 0, source.height ?? 0);
+        const capLong = Math.max(cond.maxWidth ?? 0, cond.maxHeight ?? 0);
+        const capShort = Math.min(cond.maxWidth ?? 0, cond.maxHeight ?? 0);
+        if ((capLong && srcLong > capLong) || (capShort && srcShort > capShort)) {
           videoConditionsMet = false;
           reasons.push({
             flag: 'VideoResolutionNotSupported',
-            message: `Width ${source.width} > max ${cond.maxWidth}`,
-          });
-        }
-        if (cond.maxHeight && source.height && source.height > cond.maxHeight) {
-          videoConditionsMet = false;
-          reasons.push({
-            flag: 'VideoResolutionNotSupported',
-            message: `Height ${source.height} > max ${cond.maxHeight}`,
+            message: `Resolution ${source.width}x${source.height} > max ${cond.maxWidth ?? '?'}x${cond.maxHeight ?? '?'}`,
           });
         }
       }

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -54,6 +54,7 @@ import { SessionRouter } from './services/session-router.service';
 import { SessionContextBuilder } from './services/session-context-builder.service';
 import { pickAudioLayout } from './transcoding/audio-layout';
 import { resolveTonemapPath } from './transcoding/tonemap-path';
+import { resolveTonemapCurve } from './transcoding/ffmpeg-filter-graph';
 import { ThumbnailService } from './thumbnail.service';
 import { StreamBuilderService } from './stream-builder.service';
 import { ActiveStreamTracker } from './active-stream-tracker.service';
@@ -718,13 +719,22 @@ export class StreamingController {
       ? resolved.mediaFile.streamInfo.chapters
       : undefined;
 
-    // Surface the actually-used tonemap filter (after `auto` resolution
-    // + boot probe). Stats overlay reads this so it can show what's
-    // running, not what was originally requested.
+    // Surface the tonemap mechanism the session actually runs, not the admin
+    // pick. QSV/VAAPI encoders run the HW tonemap (vaapi/opencl/qsv after
+    // `auto` resolution + boot probe); every other encoder (NVENC, libx26x,
+    // VideoToolbox CPU fallback) tone-maps on the CPU zscale chain — report
+    // `cpu` plus the curve so the overlay shows what's running (the admin
+    // `tonemapAlgo` HW path is inert on those encoders).
     const hasCrop = resolved.mediaFile.streamInfo?.video?.[0]?.crop != null;
+    const hwTonemap =
+      response.hwAccel === 'qsv' || response.hwAccel === 'vaapi';
     const tonemapAlgo = response.tonemapping
-      ? resolveTonemapPath(ss.tonemapAlgo, { hasCrop })
+      ? hwTonemap
+        ? resolveTonemapPath(ss.tonemapAlgo, { hasCrop })
+        : 'cpu'
       : null;
+    const tonemapCurve =
+      response.tonemapping && !hwTonemap ? resolveTonemapCurve() : undefined;
 
     // Compute the profile hash from the inputs we just derived — no
     // tracker round-trip needed. The hash drives the cache directory
@@ -868,6 +878,7 @@ export class StreamingController {
       ...response,
       playUrl: playUrlWithSid,
       tonemapAlgo,
+      tonemapCurve,
       durationSeconds: duration,
       markers,
       chapters,

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -55,6 +55,7 @@ import { SessionContextBuilder } from './services/session-context-builder.servic
 import { pickAudioLayout } from './transcoding/audio-layout';
 import { resolveTonemapPath } from './transcoding/tonemap-path';
 import { resolveTonemapCurve } from './transcoding/ffmpeg-filter-graph';
+import { isOpenclTonemapEnabled } from './transcoding/codec/opencl-tonemap-probe';
 import { ThumbnailService } from './thumbnail.service';
 import { StreamBuilderService } from './stream-builder.service';
 import { ActiveStreamTracker } from './active-stream-tracker.service';
@@ -721,20 +722,26 @@ export class StreamingController {
 
     // Surface the tonemap mechanism the session actually runs, not the admin
     // pick. QSV/VAAPI encoders run the HW tonemap (vaapi/opencl/qsv after
-    // `auto` resolution + boot probe); every other encoder (NVENC, libx26x,
-    // VideoToolbox CPU fallback) tone-maps on the CPU zscale chain — report
-    // `cpu` plus the curve so the overlay shows what's running (the admin
-    // `tonemapAlgo` HW path is inert on those encoders).
+    // `auto` resolution + boot probe); NVENC runs `tonemap_opencl` on the GPU
+    // when the OpenCL probe passed, else the CPU zscale chain; libx26x /
+    // VideoToolbox fallback always CPU. Report the real path (+ curve only for
+    // the CPU chain) so the overlay shows what's running.
     const hasCrop = resolved.mediaFile.streamInfo?.video?.[0]?.crop != null;
     const hwTonemap =
       response.hwAccel === 'qsv' || response.hwAccel === 'vaapi';
+    const nvencOpencl =
+      response.hwAccel === 'nvenc' && isOpenclTonemapEnabled();
     const tonemapAlgo = response.tonemapping
       ? hwTonemap
         ? resolveTonemapPath(ss.tonemapAlgo, { hasCrop })
-        : 'cpu'
+        : nvencOpencl
+          ? 'opencl'
+          : 'cpu'
       : null;
     const tonemapCurve =
-      response.tonemapping && !hwTonemap ? resolveTonemapCurve() : undefined;
+      response.tonemapping && !hwTonemap && !nvencOpencl
+        ? resolveTonemapCurve()
+        : undefined;
 
     // Compute the profile hash from the inputs we just derived — no
     // tracker round-trip needed. The hash drives the cache directory

--- a/backend/src/modules/streaming/transcoding/codec/encoders/av1-nvenc.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/av1-nvenc.ts
@@ -6,6 +6,7 @@ import {
   nvencScaleFilter10bit,
   nvencScaleFilter8bit,
 } from './helpers/nvenc-filters';
+import { AV1_NVENC_GOP_ARGS } from './helpers/nvenc-gop';
 
 /** NVIDIA NVENC AV1 encoder — Ada Lovelace (RTX 4000 series) and later.
  *  Pascal, Turing and Ampere don't ship the AV1 encode unit, so
@@ -34,6 +35,7 @@ export const av1Nvenc: EncoderDescriptor = {
       bitrate,
       '-vf',
       nvencScaleFilter8bit(input),
+      ...AV1_NVENC_GOP_ARGS,
       '-g',
       String(target.gopSize),
       '-keyint_min',
@@ -72,6 +74,7 @@ export const av1NvencHdr10: EncoderDescriptor = {
       bitrate,
       '-vf',
       nvencScaleFilter10bit(input),
+      ...AV1_NVENC_GOP_ARGS,
       '-g',
       String(target.gopSize),
       '-keyint_min',
@@ -113,6 +116,7 @@ export const av1NvencHlg: EncoderDescriptor = {
       bitrate,
       '-vf',
       nvencScaleFilter10bit(input),
+      ...AV1_NVENC_GOP_ARGS,
       '-g',
       String(target.gopSize),
       '-keyint_min',

--- a/backend/src/modules/streaming/transcoding/codec/encoders/av1-nvenc.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/av1-nvenc.ts
@@ -2,7 +2,10 @@ import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { av1CodecString } from '../codec-strings';
 import { hdrColorArgs } from './helpers/hdr-variants';
 import { masterDisplayString, maxCllString } from './helpers/hdr-metadata';
-import { scaleEvenHeight } from './helpers/scale-filter';
+import {
+  nvencScaleFilter10bit,
+  nvencScaleFilter8bit,
+} from './helpers/nvenc-filters';
 
 /** NVIDIA NVENC AV1 encoder — Ada Lovelace (RTX 4000 series) and later.
  *  Pascal, Turing and Ampere don't ship the AV1 encode unit, so
@@ -18,10 +21,9 @@ export const av1Nvenc: EncoderDescriptor = {
   supportsHdrMetadata: () => false,
   codecString: (target: EncoderTarget) => av1CodecString(target, 8),
   buildArgs(input: EncoderInput): string[] {
-    const { target, nvencPreset, filters, tonemap, hasCrop } = input;
-    const w = target.width;
+    const { target, nvencPreset } = input;
     const bitrate = `${target.videoBitrateBps}`;
-    const common = [
+    return [
       '-c:v',
       'av1_nvenc',
       '-preset',
@@ -30,32 +32,14 @@ export const av1Nvenc: EncoderDescriptor = {
       bitrate,
       '-maxrate',
       bitrate,
-    ];
-    const trailing = [
+      '-vf',
+      nvencScaleFilter8bit(input),
       '-g',
       String(target.gopSize),
       '-keyint_min',
       String(target.gopSize),
       '-force_key_frames',
       input.forceKeyframesExpr,
-    ];
-
-    if (tonemap) {
-      return [
-        ...common,
-        '-vf',
-        `hwdownload,format=p010le,${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleEvenHeight(w)}`,
-        ...trailing,
-      ];
-    }
-    const nvCropFilter = hasCrop
-      ? `hwdownload,format=nv12,${filters.cropStr},hwupload_cuda,`
-      : '';
-    return [
-      ...common,
-      '-vf',
-      `${nvCropFilter}scale_cuda=w=${w}:h=-2:format=nv12`,
-      ...trailing,
     ];
   },
 };
@@ -73,12 +57,8 @@ export const av1NvencHdr10: EncoderDescriptor = {
   supportsHdrMetadata: () => true,
   codecString: (target: EncoderTarget) => av1CodecString(target, 10),
   buildArgs(input: EncoderInput): string[] {
-    const { target, nvencPreset, filters, hasCrop } = input;
-    const w = target.width;
+    const { target, nvencPreset } = input;
     const bitrate = `${target.videoBitrateBps}`;
-    const nvCropFilter = hasCrop
-      ? `hwdownload,format=p010le,${filters.cropStr},hwupload_cuda,`
-      : '';
     return [
       '-c:v',
       'av1_nvenc',
@@ -91,7 +71,7 @@ export const av1NvencHdr10: EncoderDescriptor = {
       '-maxrate',
       bitrate,
       '-vf',
-      `${nvCropFilter}scale_cuda=w=${w}:h=-2:format=p010le`,
+      nvencScaleFilter10bit(input),
       '-g',
       String(target.gopSize),
       '-keyint_min',
@@ -118,12 +98,8 @@ export const av1NvencHlg: EncoderDescriptor = {
   supportsHdrMetadata: () => true,
   codecString: (target: EncoderTarget) => av1CodecString(target, 10),
   buildArgs(input: EncoderInput): string[] {
-    const { target, nvencPreset, filters, hasCrop } = input;
-    const w = target.width;
+    const { target, nvencPreset } = input;
     const bitrate = `${target.videoBitrateBps}`;
-    const nvCropFilter = hasCrop
-      ? `hwdownload,format=p010le,${filters.cropStr},hwupload_cuda,`
-      : '';
     return [
       '-c:v',
       'av1_nvenc',
@@ -136,7 +112,7 @@ export const av1NvencHlg: EncoderDescriptor = {
       '-maxrate',
       bitrate,
       '-vf',
-      `${nvCropFilter}scale_cuda=w=${w}:h=-2:format=p010le`,
+      nvencScaleFilter10bit(input),
       '-g',
       String(target.gopSize),
       '-keyint_min',

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-nvenc.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-nvenc.ts
@@ -1,6 +1,7 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { h264CodecString } from '../codec-strings';
 import { nvencScaleFilter8bit } from './helpers/nvenc-filters';
+import { NVENC_GOP_ARGS } from './helpers/nvenc-gop';
 
 /** NVIDIA NVENC H.264 encoder — Kepler and later. Tonemap path round-trips
  *  via CPU (hwdownload + scale + tonemap chain) because the CUDA filter
@@ -26,6 +27,7 @@ export const h264Nvenc: EncoderDescriptor = {
       bitrate,
       '-vf',
       nvencScaleFilter8bit(input),
+      ...NVENC_GOP_ARGS,
       '-g',
       String(target.gopSize),
       '-keyint_min',

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-nvenc.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-nvenc.ts
@@ -1,6 +1,6 @@
 import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { h264CodecString } from '../codec-strings';
-import { scaleEvenHeight } from './helpers/scale-filter';
+import { nvencScaleFilter8bit } from './helpers/nvenc-filters';
 
 /** NVIDIA NVENC H.264 encoder — Kepler and later. Tonemap path round-trips
  *  via CPU (hwdownload + scale + tonemap chain) because the CUDA filter
@@ -13,10 +13,9 @@ export const h264Nvenc: EncoderDescriptor = {
   supportsHdrMetadata: () => false,
   codecString: (target: EncoderTarget) => h264CodecString(target),
   buildArgs(input: EncoderInput): string[] {
-    const { target, nvencPreset, filters, tonemap, hasCrop } = input;
-    const w = target.width;
+    const { target, nvencPreset } = input;
     const bitrate = `${target.videoBitrateBps}`;
-    const common = [
+    return [
       '-c:v',
       'h264_nvenc',
       '-preset',
@@ -25,33 +24,14 @@ export const h264Nvenc: EncoderDescriptor = {
       bitrate,
       '-maxrate',
       bitrate,
-    ];
-    const trailing = [
+      '-vf',
+      nvencScaleFilter8bit(input),
       '-g',
       String(target.gopSize),
       '-keyint_min',
       String(target.gopSize),
       '-force_key_frames',
       input.forceKeyframesExpr,
-    ];
-
-    if (tonemap) {
-      // Download to CPU, tonemap on CPU, encode on NVENC.
-      return [
-        ...common,
-        '-vf',
-        `hwdownload,format=p010le,${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleEvenHeight(w)}`,
-        ...trailing,
-      ];
-    }
-    const nvCropFilter = hasCrop
-      ? `hwdownload,format=nv12,${filters.cropStr},hwupload_cuda,`
-      : '';
-    return [
-      ...common,
-      '-vf',
-      `${nvCropFilter}scale_cuda=w=${w}:h=-2:format=nv12`,
-      ...trailing,
     ];
   },
 };

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/nvenc-filters.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/nvenc-filters.ts
@@ -1,0 +1,63 @@
+import type { EncoderInput } from '../../types';
+import { scaleEvenHeight } from './scale-filter';
+
+/** Build the `-vf` value for an 8-bit NVENC SDR encode (h264_nvenc /
+ *  hevc_nvenc / av1_nvenc). NVENC encode and NVDEC decode are probed
+ *  independently, so the encoder must handle whatever surface the decoder
+ *  produced:
+ *
+ *  - `'cuda'` — NVDEC handed off GPU frames: the SDR crop+scale stays on
+ *    the device with `scale_cuda` (crop bounces to CPU and back only when a
+ *    manual crop is active). The HDR→SDR tonemap round-trips through CPU
+ *    (mainline ffmpeg has no `tonemap_cuda`), so `hwdownload` pulls the
+ *    frames down before the CPU tonemap chain.
+ *  - `'cpu'` — software decode (NVDEC disabled or unable to decode this
+ *    codec/bit depth): every filter runs on CPU and NVENC uploads the
+ *    finished frames itself.
+ *  - any other HW surface (`'vaapi'` from a decode-only VAAPI stack bridged
+ *    in on an NVENC host, etc.): the frames live on another device that
+ *    `scale_cuda` can't touch, so `hwdownload` pulls them to system memory
+ *    and the CPU chain takes over — NVENC re-uploads on encode.
+ *
+ *  Only `scale_cuda` / `hwupload_cuda` require a CUDA surface; running them
+ *  on non-CUDA frames aborts the graph with `Function not implemented`.
+ */
+export function nvencScaleFilter8bit(input: EncoderInput): string {
+  const { target, filters, tonemap, hasCrop, inputSurface } = input;
+  const w = target.width;
+  if (tonemap) {
+    // tonemapCpu already emits `format=yuv420p`; only the download prefix
+    // differs. Tonemap implies a 10-bit HDR source, so download as p010le.
+    const download =
+      inputSurface === 'cpu' ? '' : 'hwdownload,format=p010le,';
+    return `${download}${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleEvenHeight(w)}`;
+  }
+  if (inputSurface === 'cuda') {
+    const nvCropFilter = hasCrop
+      ? `hwdownload,format=nv12,${filters.cropStr},hwupload_cuda,`
+      : '';
+    return `${nvCropFilter}scale_cuda=w=${w}:h=-2:format=nv12`;
+  }
+  const download = inputSurface === 'cpu' ? '' : 'hwdownload,format=nv12,';
+  return `${download}${filters.cpuCropPrefix}scale=${w}:${scaleEvenHeight(w)}:flags=lanczos,format=yuv420p`;
+}
+
+/** Build the `-vf` value for a 10-bit NVENC HDR encode (hevc_nvenc
+ *  main10, av1_nvenc hdr10 / hlg). Same surface split as the 8-bit path,
+ *  but the pixels stay `p010le` end-to-end — there is no tonemap branch
+ *  because a 10-bit HDR encoder is preserving HDR (tonemapping it would
+ *  defeat the bitstream's HDR signaling; tonemap-to-SDR sources are routed
+ *  to the 8-bit SDR rung by the registry).
+ */
+export function nvencScaleFilter10bit(input: EncoderInput): string {
+  const { target, filters, hasCrop, inputSurface } = input;
+  const w = target.width;
+  if (inputSurface === 'cuda') {
+    const nvCropFilter = hasCrop
+      ? `hwdownload,format=p010le,${filters.cropStr},hwupload_cuda,`
+      : '';
+    return `${nvCropFilter}scale_cuda=w=${w}:h=-2:format=p010le`;
+  }
+  const download = inputSurface === 'cpu' ? '' : 'hwdownload,format=p010le,';
+  return `${download}${filters.cpuCropPrefix}scale=${w}:${scaleEvenHeight(w)}:flags=lanczos,format=p010le`;
+}

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/nvenc-gop.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/nvenc-gop.ts
@@ -1,0 +1,28 @@
+/** Closed-GOP, deterministic-IDR flags for the NVENC descriptors. Mirrors
+ *  the qsv-extra recipe (see ffmpeg-args.ts): without `-forced-idr`, NVENC
+ *  emits some `force_key_frames` ticks as plain (non-IDR) I-frames, so the
+ *  HLS segment boundary isn't a clean random-access point and the segment
+ *  can't be decoded on its own — the visible failure is heavy macroblock
+ *  corruption from the first segment. `-bf 0` drops B-frame reordering
+ *  across the segment edge so the muxer cuts cleanly on each IDR;
+ *  `-no-scenecut` keeps adaptive I-frames off the forced grid.
+ */
+export const NVENC_GOP_ARGS: readonly string[] = [
+  '-forced-idr',
+  '1',
+  '-no-scenecut',
+  '1',
+  '-bf',
+  '0',
+];
+
+/** AV1 NVENC variant of {@link NVENC_GOP_ARGS}. `av1_nvenc` shares
+ *  `-forced-idr` and `-bf` but has no `-no-scenecut` option, so it is
+ *  omitted here (passing an unknown option would abort av1_nvenc and drop
+ *  it to the libsvtav1 fallback). */
+export const AV1_NVENC_GOP_ARGS: readonly string[] = [
+  '-forced-idr',
+  '1',
+  '-bf',
+  '0',
+];

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-nvenc.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-nvenc.ts
@@ -6,6 +6,7 @@ import {
   nvencScaleFilter10bit,
   nvencScaleFilter8bit,
 } from './helpers/nvenc-filters';
+import { NVENC_GOP_ARGS } from './helpers/nvenc-gop';
 
 /** NVIDIA NVENC HEVC SDR encoder — Maxwell 2nd gen (GM20x) and later.
  *  Tonemap path round-trips via CPU because mainline FFmpeg still has no
@@ -33,6 +34,7 @@ export const hevcNvenc: EncoderDescriptor = {
       bitrate,
       '-vf',
       nvencScaleFilter8bit(input),
+      ...NVENC_GOP_ARGS,
       '-g',
       String(target.gopSize),
       '-keyint_min',
@@ -75,6 +77,7 @@ export const hevcNvencHdr10: EncoderDescriptor = {
       bitrate,
       '-vf',
       nvencScaleFilter10bit(input),
+      ...NVENC_GOP_ARGS,
       '-g',
       String(target.gopSize),
       '-keyint_min',

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-nvenc.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-nvenc.ts
@@ -2,7 +2,10 @@ import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { hevcMain10CodecString, hevcMainCodecString } from '../codec-strings';
 import { hdrColorArgs, hlgFromHdr10 } from './helpers/hdr-variants';
 import { masterDisplayString, maxCllString } from './helpers/hdr-metadata';
-import { scaleEvenHeight } from './helpers/scale-filter';
+import {
+  nvencScaleFilter10bit,
+  nvencScaleFilter8bit,
+} from './helpers/nvenc-filters';
 
 /** NVIDIA NVENC HEVC SDR encoder — Maxwell 2nd gen (GM20x) and later.
  *  Tonemap path round-trips via CPU because mainline FFmpeg still has no
@@ -15,10 +18,9 @@ export const hevcNvenc: EncoderDescriptor = {
   supportsHdrMetadata: () => false,
   codecString: (target: EncoderTarget) => hevcMainCodecString(target),
   buildArgs(input: EncoderInput): string[] {
-    const { target, nvencPreset, filters, tonemap, hasCrop } = input;
-    const w = target.width;
+    const { target, nvencPreset } = input;
     const bitrate = `${target.videoBitrateBps}`;
-    const common = [
+    return [
       '-c:v',
       'hevc_nvenc',
       '-preset',
@@ -29,8 +31,8 @@ export const hevcNvenc: EncoderDescriptor = {
       bitrate,
       '-maxrate',
       bitrate,
-    ];
-    const trailing = [
+      '-vf',
+      nvencScaleFilter8bit(input),
       '-g',
       String(target.gopSize),
       '-keyint_min',
@@ -39,24 +41,6 @@ export const hevcNvenc: EncoderDescriptor = {
       input.forceKeyframesExpr,
       '-tag:v',
       'hvc1',
-    ];
-
-    if (tonemap) {
-      return [
-        ...common,
-        '-vf',
-        `hwdownload,format=p010le,${filters.cpuCropPrefix}${filters.tonemapCpu}scale=${w}:${scaleEvenHeight(w)}`,
-        ...trailing,
-      ];
-    }
-    const nvCropFilter = hasCrop
-      ? `hwdownload,format=nv12,${filters.cropStr},hwupload_cuda,`
-      : '';
-    return [
-      ...common,
-      '-vf',
-      `${nvCropFilter}scale_cuda=w=${w}:h=-2:format=nv12`,
-      ...trailing,
     ];
   },
 };
@@ -74,12 +58,8 @@ export const hevcNvencHdr10: EncoderDescriptor = {
   supportsHdrMetadata: () => true,
   codecString: (target: EncoderTarget) => hevcMain10CodecString(target),
   buildArgs(input: EncoderInput): string[] {
-    const { target, nvencPreset, filters, hasCrop } = input;
-    const w = target.width;
+    const { target, nvencPreset } = input;
     const bitrate = `${target.videoBitrateBps}`;
-    const nvCropFilter = hasCrop
-      ? `hwdownload,format=p010le,${filters.cropStr},hwupload_cuda,`
-      : '';
     return [
       '-c:v',
       'hevc_nvenc',
@@ -94,7 +74,7 @@ export const hevcNvencHdr10: EncoderDescriptor = {
       '-maxrate',
       bitrate,
       '-vf',
-      `${nvCropFilter}scale_cuda=w=${w}:h=-2:format=p010le`,
+      nvencScaleFilter10bit(input),
       '-g',
       String(target.gopSize),
       '-keyint_min',

--- a/backend/src/modules/streaming/transcoding/codec/encoders/nvenc.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/nvenc.spec.ts
@@ -63,6 +63,11 @@ function vfOf(args: string[]): string {
   return args[i + 1];
 }
 
+function hasFlag(args: string[], flag: string, value: string): boolean {
+  const i = args.indexOf(flag);
+  return i !== -1 && args[i + 1] === value;
+}
+
 const SDR_ENCODERS: [string, EncoderDescriptor][] = [
   ['hevc_nvenc', hevcNvenc],
   ['h264_nvenc', h264Nvenc],
@@ -162,6 +167,29 @@ describe('NVENC encoders — surface-aware filter graph', () => {
       expect(vf).toBe(
         'hwdownload,format=p010le,scale=1920:ceil(ih*1920/iw/2)*2:flags=lanczos,format=p010le',
       );
+    });
+  });
+
+  // Closed-GOP, deterministic-IDR flags: every NVENC descriptor must force
+  // its keyframes to IDR and drop B-frame reordering, or HLS segments aren't
+  // independently decodable (macroblock corruption — mirrors the qsvExtra
+  // recipe). Independent of the input surface.
+  describe.each(ALL_ENCODERS)('%s (GOP flags)', (id, enc) => {
+    it('forces IDR keyframes and disables B-frames', () => {
+      const args = enc.buildArgs(makeInput({ inputSurface: 'cuda', sourceBitDepth: 10 }));
+      expect(hasFlag(args, '-forced-idr', '1')).toBe(true);
+      expect(hasFlag(args, '-bf', '0')).toBe(true);
+    });
+
+    it('gates -no-scenecut on codec support (h264/hevc yes, av1 no)', () => {
+      const args = enc.buildArgs(makeInput({ inputSurface: 'cuda', sourceBitDepth: 10 }));
+      if (id.startsWith('av1')) {
+        // av1_nvenc has no -no-scenecut option; passing it would abort the
+        // encoder and drop it to the libsvtav1 fallback.
+        expect(args).not.toContain('-no-scenecut');
+      } else {
+        expect(hasFlag(args, '-no-scenecut', '1')).toBe(true);
+      }
     });
   });
 

--- a/backend/src/modules/streaming/transcoding/codec/encoders/nvenc.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/nvenc.spec.ts
@@ -88,7 +88,9 @@ describe('NVENC encoders — surface-aware filter graph', () => {
     it('cuda decode + tonemap: hwdownload pulls GPU frames to CPU', () => {
       const vf = vfOf(enc.buildArgs(makeInput({ inputSurface: 'cuda', tonemap: true })));
       expect(vf).toContain('hwdownload,format=p010le,');
-      expect(vf).toContain('tonemap=mobius');
+      // CPU tonemap must linearise + convert gamut, not just tone-curve.
+      expect(vf).toContain('zscale=t=linear');
+      expect(vf).toContain('tonemap=tonemap=hable');
       expect(vf).toContain('scale=1920:');
     });
 
@@ -96,8 +98,8 @@ describe('NVENC encoders — surface-aware filter graph', () => {
       const vf = vfOf(enc.buildArgs(makeInput({ inputSurface: 'cpu', tonemap: true })));
       expect(vf).not.toContain('hwdownload');
       expect(vf).not.toContain('scale_cuda');
-      expect(vf.startsWith('format=gbrpf32le,')).toBe(true);
-      expect(vf).toContain('tonemap=mobius');
+      expect(vf.startsWith('zscale=t=linear:npl=100,')).toBe(true);
+      expect(vf).toContain('tonemap=tonemap=hable');
       expect(vf).toContain('scale=1920:');
     });
 
@@ -105,7 +107,7 @@ describe('NVENC encoders — surface-aware filter graph', () => {
       const vf = vfOf(enc.buildArgs(makeInput({ inputSurface: 'vaapi', tonemap: true })));
       expect(vf.startsWith('hwdownload,format=p010le,')).toBe(true);
       expect(vf).not.toContain('scale_cuda');
-      expect(vf).toContain('tonemap=mobius');
+      expect(vf).toContain('tonemap=tonemap=hable');
     });
 
     it('cuda decode, no tonemap: scale_cuda stays on the GPU as nv12', () => {

--- a/backend/src/modules/streaming/transcoding/codec/encoders/nvenc.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/nvenc.spec.ts
@@ -48,6 +48,7 @@ function makeInput(cfg: {
       tonemap,
       useVaapiTonemap: false,
       sourceBitDepth: cfg.sourceBitDepth ?? (tonemap ? 10 : 8),
+      scaleWidth: 1920,
     }),
     tonemap,
     tonemapPath: 'opencl',
@@ -88,19 +89,18 @@ describe('NVENC encoders — surface-aware filter graph', () => {
     it('cuda decode + tonemap: hwdownload pulls GPU frames to CPU', () => {
       const vf = vfOf(enc.buildArgs(makeInput({ inputSurface: 'cuda', tonemap: true })));
       expect(vf).toContain('hwdownload,format=p010le,');
-      // CPU tonemap must linearise + convert gamut, not just tone-curve.
-      expect(vf).toContain('zscale=t=linear');
+      // CPU tonemap must downscale in linear light + convert gamut.
+      expect(vf).toContain('zscale=w=1920:h=-2:t=linear');
       expect(vf).toContain('tonemap=tonemap=hable');
-      expect(vf).toContain('scale=1920:');
     });
 
-    it('cpu decode + tonemap: no hwdownload, CPU tonemap chain only', () => {
+    it('cpu decode + tonemap: no hwdownload, downscale-then-tonemap on CPU', () => {
       const vf = vfOf(enc.buildArgs(makeInput({ inputSurface: 'cpu', tonemap: true })));
       expect(vf).not.toContain('hwdownload');
       expect(vf).not.toContain('scale_cuda');
-      expect(vf.startsWith('zscale=t=linear:npl=100,')).toBe(true);
+      // Downscale to the output width in linear light before the tone curve.
+      expect(vf.startsWith('zscale=w=1920:h=-2:t=linear:npl=100,')).toBe(true);
       expect(vf).toContain('tonemap=tonemap=hable');
-      expect(vf).toContain('scale=1920:');
     });
 
     it('vaapi decode + tonemap: hwdownload bridge before the CPU chain', () => {

--- a/backend/src/modules/streaming/transcoding/codec/encoders/nvenc.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/nvenc.spec.ts
@@ -1,0 +1,185 @@
+import { hevcNvenc, hevcNvencHdr10, hevcNvencHlg } from './hevc-nvenc';
+import { h264Nvenc } from './h264-nvenc';
+import { av1Nvenc, av1NvencHdr10, av1NvencHlg } from './av1-nvenc';
+import { buildVideoFilters } from '../../ffmpeg-filter-graph';
+import type { EncoderDescriptor, EncoderInput } from '../types';
+import type { SurfaceFormat } from '../decoders/types';
+
+/**
+ * The NVENC descriptors must emit a filter graph valid for the surface the
+ * decoder actually produced. NVENC encode and NVDEC decode are probed
+ * independently, so an NVENC encoder can be paired with:
+ *  - `cuda`  — NVDEC frames on the GPU (the happy path),
+ *  - `cpu`   — software decode when NVDEC is disabled or can't decode the
+ *              source codec/bit depth,
+ *  - `vaapi` — a decode-only VAAPI stack bridged in on an NVENC host.
+ * `scale_cuda` / `hwdownload` / `hwupload_cuda` require CUDA surfaces; run
+ * on anything else they abort the graph with `Function not implemented`.
+ */
+
+const CROP = { width: 3840, height: 1632, x: 0, y: 264 };
+
+function makeInput(cfg: {
+  inputSurface: SurfaceFormat;
+  tonemap?: boolean;
+  crop?: boolean;
+  sourceBitDepth?: number;
+}): EncoderInput {
+  const tonemap = cfg.tonemap ?? false;
+  const crop = cfg.crop ? CROP : undefined;
+  return {
+    variant: { codec: 'hevc', bitDepth: 8, hdr: null },
+    target: {
+      width: 1920,
+      height: 1080,
+      videoBitrateBps: 8_000_000,
+      gopSize: 72,
+      frameRate: 24,
+    },
+    preset: 'fast',
+    nvencPreset: 'p4',
+    seekSeconds: 0,
+    early: false,
+    forceKeyframesExpr: 'expr:gte(t,0)',
+    qsv: { extra: [], rcInitOccupancy: 0, bufsize: 0 },
+    libx264BufsizeMb: '16M',
+    filters: buildVideoFilters({
+      crop,
+      tonemap,
+      useVaapiTonemap: false,
+      sourceBitDepth: cfg.sourceBitDepth ?? (tonemap ? 10 : 8),
+    }),
+    tonemap,
+    tonemapPath: 'opencl',
+    hasBurnIn: false,
+    hasCrop: !!crop,
+    inputSurface: cfg.inputSurface,
+  };
+}
+
+function vfOf(args: string[]): string {
+  const i = args.indexOf('-vf');
+  if (i === -1) throw new Error('no -vf in args');
+  return args[i + 1];
+}
+
+const SDR_ENCODERS: [string, EncoderDescriptor][] = [
+  ['hevc_nvenc', hevcNvenc],
+  ['h264_nvenc', h264Nvenc],
+  ['av1_nvenc', av1Nvenc],
+];
+
+const HDR_ENCODERS: [string, EncoderDescriptor][] = [
+  ['hevc_nvenc_main10', hevcNvencHdr10],
+  ['hevc_nvenc_hlg', hevcNvencHlg],
+  ['av1_nvenc_hdr10', av1NvencHdr10],
+  ['av1_nvenc_hlg', av1NvencHlg],
+];
+
+const ALL_ENCODERS = [...SDR_ENCODERS, ...HDR_ENCODERS];
+
+describe('NVENC encoders — surface-aware filter graph', () => {
+  describe.each(SDR_ENCODERS)('%s (SDR)', (_id, enc) => {
+    it('cuda decode + tonemap: hwdownload pulls GPU frames to CPU', () => {
+      const vf = vfOf(enc.buildArgs(makeInput({ inputSurface: 'cuda', tonemap: true })));
+      expect(vf).toContain('hwdownload,format=p010le,');
+      expect(vf).toContain('tonemap=mobius');
+      expect(vf).toContain('scale=1920:');
+    });
+
+    it('cpu decode + tonemap: no hwdownload, CPU tonemap chain only', () => {
+      const vf = vfOf(enc.buildArgs(makeInput({ inputSurface: 'cpu', tonemap: true })));
+      expect(vf).not.toContain('hwdownload');
+      expect(vf).not.toContain('scale_cuda');
+      expect(vf.startsWith('format=gbrpf32le,')).toBe(true);
+      expect(vf).toContain('tonemap=mobius');
+      expect(vf).toContain('scale=1920:');
+    });
+
+    it('vaapi decode + tonemap: hwdownload bridge before the CPU chain', () => {
+      const vf = vfOf(enc.buildArgs(makeInput({ inputSurface: 'vaapi', tonemap: true })));
+      expect(vf.startsWith('hwdownload,format=p010le,')).toBe(true);
+      expect(vf).not.toContain('scale_cuda');
+      expect(vf).toContain('tonemap=mobius');
+    });
+
+    it('cuda decode, no tonemap: scale_cuda stays on the GPU as nv12', () => {
+      const vf = vfOf(enc.buildArgs(makeInput({ inputSurface: 'cuda' })));
+      expect(vf).toBe('scale_cuda=w=1920:h=-2:format=nv12');
+    });
+
+    it('cpu decode, no tonemap: software scale, no GPU filters', () => {
+      const vf = vfOf(enc.buildArgs(makeInput({ inputSurface: 'cpu' })));
+      expect(vf).toBe(
+        'scale=1920:ceil(ih*1920/iw/2)*2:flags=lanczos,format=yuv420p',
+      );
+    });
+
+    it('vaapi decode, no tonemap: hwdownload then CPU scale, no scale_cuda', () => {
+      const vf = vfOf(enc.buildArgs(makeInput({ inputSurface: 'vaapi' })));
+      expect(vf).toBe(
+        'hwdownload,format=nv12,scale=1920:ceil(ih*1920/iw/2)*2:flags=lanczos,format=yuv420p',
+      );
+    });
+
+    it('cuda decode + crop: crop round-trips through hwupload_cuda', () => {
+      const vf = vfOf(enc.buildArgs(makeInput({ inputSurface: 'cuda', crop: true })));
+      expect(vf).toBe(
+        'hwdownload,format=nv12,crop=3840:1632:0:264,hwupload_cuda,scale_cuda=w=1920:h=-2:format=nv12',
+      );
+    });
+
+    it('cpu decode + crop: plain CPU crop, no hwupload_cuda', () => {
+      const vf = vfOf(enc.buildArgs(makeInput({ inputSurface: 'cpu', crop: true })));
+      expect(vf).toBe(
+        'crop=3840:1632:0:264,scale=1920:ceil(ih*1920/iw/2)*2:flags=lanczos,format=yuv420p',
+      );
+    });
+  });
+
+  describe.each(HDR_ENCODERS)('%s (HDR)', (_id, enc) => {
+    it('cuda decode: scale_cuda keeps pixels p010le on the GPU', () => {
+      const vf = vfOf(enc.buildArgs(makeInput({ inputSurface: 'cuda', sourceBitDepth: 10 })));
+      expect(vf).toBe('scale_cuda=w=1920:h=-2:format=p010le');
+    });
+
+    it('cuda decode + crop: p010le round-trip preserves 10-bit through crop', () => {
+      const vf = vfOf(
+        enc.buildArgs(makeInput({ inputSurface: 'cuda', crop: true, sourceBitDepth: 10 })),
+      );
+      expect(vf).toBe(
+        'hwdownload,format=p010le,crop=3840:1632:0:264,hwupload_cuda,scale_cuda=w=1920:h=-2:format=p010le',
+      );
+    });
+
+    it('cpu decode: software scale to p010le, no scale_cuda', () => {
+      const vf = vfOf(enc.buildArgs(makeInput({ inputSurface: 'cpu', sourceBitDepth: 10 })));
+      expect(vf).toBe('scale=1920:ceil(ih*1920/iw/2)*2:flags=lanczos,format=p010le');
+    });
+
+    it('vaapi decode: hwdownload bridge to a CPU p010le scale', () => {
+      const vf = vfOf(enc.buildArgs(makeInput({ inputSurface: 'vaapi', sourceBitDepth: 10 })));
+      expect(vf).toBe(
+        'hwdownload,format=p010le,scale=1920:ceil(ih*1920/iw/2)*2:flags=lanczos,format=p010le',
+      );
+    });
+  });
+
+  // Load-bearing invariant: only CUDA surfaces may drive `scale_cuda` /
+  // `hwupload_cuda`. On any other surface those GPU-only filters must be
+  // absent, and CPU-decoded input must carry no `hwdownload` at all.
+  it.each(ALL_ENCODERS)('%s never runs CUDA filters on non-cuda input', (_id, enc) => {
+    for (const tonemap of [false, true]) {
+      for (const crop of [false, true]) {
+        for (const surface of ['cpu', 'vaapi'] as SurfaceFormat[]) {
+          const vf = vfOf(
+            enc.buildArgs(makeInput({ inputSurface: surface, tonemap, crop, sourceBitDepth: 10 })),
+          );
+          expect(vf).not.toContain('scale_cuda');
+          expect(vf).not.toContain('hwupload_cuda');
+          if (surface === 'cpu') expect(vf).not.toContain('hwdownload');
+        }
+      }
+    }
+  });
+});

--- a/backend/src/modules/streaming/transcoding/codec/opencl-tonemap-probe.ts
+++ b/backend/src/modules/streaming/transcoding/codec/opencl-tonemap-probe.ts
@@ -1,0 +1,77 @@
+import { Logger } from '@nestjs/common';
+import { execFile } from 'child_process';
+import { unlink } from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+/** Standalone `tonemap_opencl` capability, i.e. the OpenCL HDR→SDR path an
+ *  NVENC/CPU encoder can use: `format=p010le,hwupload,tonemap_opencl,…,
+ *  hwdownload`. This is DISTINCT from the QSV probe in `tonemap-opencl-probe`,
+ *  which tests the QSV↔OpenCL surface bridge (`hwmap`) and is meaningless on a
+ *  pure-NVENC host. On NVIDIA, OpenCL rides the same compute stack as
+ *  CUDA/NVENC (`libnvidia-opencl.so`) — no Vulkan/GLX — so it is the only way
+ *  to keep the HDR→SDR tone-map on the GPU there (mainline ffmpeg has no
+ *  `tonemap_cuda`). Fail-closed until the boot probe confirms it. */
+let probedOnce = false;
+let enabled = false;
+
+export function isOpenclTonemapEnabled(): boolean {
+  return probedOnce && enabled;
+}
+
+export async function runOpenclTonemapProbe(log: Logger): Promise<void> {
+  const t0 = Date.now();
+  const hdrSample = path.join(
+    os.tmpdir(),
+    `fliks-opencl-tonemap-probe-${process.pid}.hevc`,
+  );
+  try {
+    // Synthesise a tiny HEVC Main10 PQ/BT.2020 clip — black frames are fine,
+    // we're only checking that the OpenCL tone-map filter graph plumbs.
+    await execFileAsync(
+      'ffmpeg',
+      [
+        '-hide_banner', '-loglevel', 'error', '-y',
+        '-f', 'lavfi',
+        '-i', 'nullsrc=size=320x180:rate=30,format=yuv420p10le',
+        '-frames:v', '4',
+        '-c:v', 'libx265',
+        '-color_primaries', 'bt2020',
+        '-color_trc', 'smpte2084',
+        '-colorspace', 'bt2020nc',
+        hdrSample,
+      ],
+      { timeout: 15_000 },
+    );
+
+    // The exact chain a session uses: CPU frame → OpenCL → tonemap → CPU.
+    // `opencl=ocl` auto-picks the first usable device (the NVIDIA GPU on an
+    // NVENC host; a bare Intel platform with no device is skipped).
+    await execFileAsync(
+      'ffmpeg',
+      [
+        '-hide_banner', '-loglevel', 'error',
+        '-init_hw_device', 'opencl=ocl',
+        '-filter_hw_device', 'ocl',
+        '-i', hdrSample,
+        '-vf',
+        'format=p010le,hwupload,tonemap_opencl=t=bt709:m=bt709:p=bt709:tonemap=hable:desat=0:format=nv12,hwdownload,format=nv12',
+        '-frames:v', '1',
+        '-f', 'null', '-',
+      ],
+      { timeout: 20_000 },
+    );
+    enabled = true;
+  } catch {
+    enabled = false;
+  } finally {
+    await unlink(hdrSample).catch(() => {});
+    probedOnce = true;
+    log.log(
+      `[opencl-tonemap-probe] enabled=${enabled} (${Date.now() - t0}ms)`,
+    );
+  }
+}

--- a/backend/src/modules/streaming/transcoding/codec/selector.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/selector.spec.ts
@@ -1,0 +1,78 @@
+import { pickPrimaryVariant } from './selector';
+import type { DeviceProfileDto } from '../../dto/device-profile.dto';
+
+/** A native-style profile that lists AV1, HEVC and H.264 but caps the AV1
+ *  decoder at 2048x2048 (no 4K AV1 HW path) while allowing 4K HEVC. */
+function nativeProfile(): DeviceProfileDto {
+  return {
+    deviceType: 'mobile',
+    supportsHdr: true,
+    directPlayProfiles: [
+      {
+        containers: ['mp4', 'mkv'],
+        videoCodecs: ['av1', 'hevc', 'hvc1', 'h264', 'avc1'],
+        audioCodecs: ['aac', 'ac3', 'eac3'],
+      },
+    ],
+    codecConditions: [
+      { codec: 'av1', maxBitDepth: 10, maxWidth: 2048, maxHeight: 2048 },
+      { codec: 'hevc', maxBitDepth: 10, maxWidth: 3840, maxHeight: 2160 },
+      { codec: 'h264', maxBitDepth: 8, maxWidth: 3840, maxHeight: 2160 },
+    ],
+  } as unknown as DeviceProfileDto;
+}
+
+describe('pickPrimaryVariant — client decode-resolution gate', () => {
+  it('falls back to HEVC for a 4K AV1 source when the AV1 decoder caps at 2048', () => {
+    const v = pickPrimaryVariant(
+      { width: 3840, height: 2076, hdr: 'HDR10', codec: 'av1' },
+      nativeProfile(),
+      'none',
+      '',
+    );
+    expect(v.codec).toBe('hevc');
+    expect(v.hdr).toBe('HDR10');
+  });
+
+  it('un-trips for a rotated (portrait) 4K frame — long/short edges compared', () => {
+    const v = pickPrimaryVariant(
+      { width: 2076, height: 3840, hdr: 'HDR10', codec: 'av1' },
+      nativeProfile(),
+      'none',
+      '',
+    );
+    expect(v.codec).toBe('hevc');
+  });
+
+  it('keeps AV1 for a 1080p source that fits the AV1 decoder cap', () => {
+    const v = pickPrimaryVariant(
+      { width: 1920, height: 1080, hdr: null, codec: 'av1' },
+      nativeProfile(),
+      'none',
+      '',
+    );
+    expect(v.codec).toBe('av1');
+  });
+
+  it('does not gate codecs whose profile declares no resolution cap', () => {
+    const profile = {
+      deviceType: 'desktop',
+      supportsHdr: false,
+      directPlayProfiles: [
+        {
+          containers: ['mp4'],
+          videoCodecs: ['av1', 'hevc', 'h264'],
+          audioCodecs: ['aac'],
+        },
+      ],
+      codecConditions: [{ codec: 'av1', maxBitDepth: 10 }],
+    } as unknown as DeviceProfileDto;
+    const v = pickPrimaryVariant(
+      { width: 3840, height: 2160, hdr: null, codec: 'av1' },
+      profile,
+      'none',
+      '',
+    );
+    expect(v.codec).toBe('av1');
+  });
+});

--- a/backend/src/modules/streaming/transcoding/codec/selector.ts
+++ b/backend/src/modules/streaming/transcoding/codec/selector.ts
@@ -70,6 +70,8 @@ export function pickVariants(
     for (const codec of codecOrder) {
       if (codec === 'h264') continue;
       if (!clientSupports(clientCodecs, codec)) continue;
+      if (!clientDecodesResolution(profile, codec, source.width, source.height))
+        continue;
       const variant: CodecVariant = { codec, bitDepth: 10, hdr: source.hdr };
       if (resolveHwEncoder(variant, hwAccel)) {
         candidates.push(variant);
@@ -80,6 +82,8 @@ export function pickVariants(
       for (const codec of codecOrder) {
         if (codec === 'h264') continue;
         if (!clientSupports(clientCodecs, codec)) continue;
+        if (!clientDecodesResolution(profile, codec, source.width, source.height))
+          continue;
         const variant: CodecVariant = { codec, bitDepth: 10, hdr: source.hdr };
         if (encoderRegistry.resolve(variant, hwAccel)) {
           candidates.push(variant);
@@ -99,6 +103,8 @@ export function pickVariants(
   const beforeSdr = candidates.length;
   for (const codec of codecOrder) {
     if (!clientSupports(clientCodecs, codec)) continue;
+    if (!clientDecodesResolution(profile, codec, source.width, source.height))
+      continue;
     const variant: CodecVariant = { codec, bitDepth: 8, hdr: null };
     if (resolveHwEncoder(variant, hwAccel)) {
       candidates.push(variant);
@@ -107,6 +113,8 @@ export function pickVariants(
   if (candidates.length === beforeSdr) {
     for (const codec of codecOrder) {
       if (!clientSupports(clientCodecs, codec)) continue;
+      if (!clientDecodesResolution(profile, codec, source.width, source.height))
+        continue;
       const variant: CodecVariant = { codec, bitDepth: 8, hdr: null };
       if (encoderRegistry.resolve(variant, hwAccel)) {
         candidates.push(variant);
@@ -160,4 +168,27 @@ function clientSupports(set: Set<string>, codec: VideoCodec): boolean {
     case 'av1':
       return set.has('av1') || set.has('av01');
   }
+}
+
+/** Whether the client can DECODE `codec` at the resolution we intend to emit.
+ *  A native client reports its HW decoder's per-codec max width/height; since
+ *  one codec drives every rung of the master, a codec whose ceiling can't fit
+ *  the top rung is unusable — a 4K source on a device that decodes AV1 only up
+ *  to 2048 must fall back to HEVC. Compared in either orientation (the maxima
+ *  can be reported rotated). Codecs with no declared ceiling always pass. */
+function clientDecodesResolution(
+  profile: DeviceProfileDto,
+  codec: VideoCodec,
+  width: number,
+  height: number,
+): boolean {
+  const cond = profile.codecConditions?.find((c) => c.codec === codec);
+  if (!cond) return true;
+  const long = Math.max(width, height);
+  const short = Math.min(width, height);
+  const capLong = Math.max(cond.maxWidth ?? 0, cond.maxHeight ?? 0);
+  const capShort = Math.min(cond.maxWidth ?? 0, cond.maxHeight ?? 0);
+  if (capLong && long > capLong) return false;
+  if (capShort && short > capShort) return false;
+  return true;
 }

--- a/backend/src/modules/streaming/transcoding/codec/selector.ts
+++ b/backend/src/modules/streaming/transcoding/codec/selector.ts
@@ -3,6 +3,7 @@ import type { DeviceProfileDto } from '../../dto/device-profile.dto';
 import type { HwAccelType } from '../types';
 import { encoderRegistry } from './encoders';
 import { applyQuirks, type QuirkContext } from './fallback';
+import { resolutionFitsCap } from '../../../../common/utils/resolution.util';
 
 /**
  * Resolve an encoder for `variant` whose `hwAccel` matches the detected
@@ -174,8 +175,7 @@ function clientSupports(set: Set<string>, codec: VideoCodec): boolean {
  *  A native client reports its HW decoder's per-codec max width/height; since
  *  one codec drives every rung of the master, a codec whose ceiling can't fit
  *  the top rung is unusable — a 4K source on a device that decodes AV1 only up
- *  to 2048 must fall back to HEVC. Compared in either orientation (the maxima
- *  can be reported rotated). Codecs with no declared ceiling always pass. */
+ *  to 2048 must fall back to HEVC. Codecs with no declared ceiling always pass. */
 function clientDecodesResolution(
   profile: DeviceProfileDto,
   codec: VideoCodec,
@@ -184,11 +184,5 @@ function clientDecodesResolution(
 ): boolean {
   const cond = profile.codecConditions?.find((c) => c.codec === codec);
   if (!cond) return true;
-  const long = Math.max(width, height);
-  const short = Math.min(width, height);
-  const capLong = Math.max(cond.maxWidth ?? 0, cond.maxHeight ?? 0);
-  const capShort = Math.min(cond.maxWidth ?? 0, cond.maxHeight ?? 0);
-  if (capLong && long > capLong) return false;
-  if (capShort && short > capShort) return false;
-  return true;
+  return resolutionFitsCap(width, height, cond.maxWidth, cond.maxHeight);
 }

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.golden.spec.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.golden.spec.ts
@@ -282,7 +282,7 @@ describe('buildFfmpegArgs — CPU golden argv (characterization)', () => {
        "-bufsize",
        "16M",
        "-vf",
-       "format=gbrpf32le,tonemap=mobius:desat=0,format=yuv420p,scale=1920:ceil(ih*1920/iw/2)*2:flags=lanczos,format=yuv420p",
+       "zscale=t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=hable:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p,scale=1920:ceil(ih*1920/iw/2)*2:flags=lanczos,format=yuv420p",
        "-force_key_frames",
        "expr:gte(t,0+n_forced*3)",
        "-sc_threshold:v:0",

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.golden.spec.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.golden.spec.ts
@@ -282,7 +282,7 @@ describe('buildFfmpegArgs — CPU golden argv (characterization)', () => {
        "-bufsize",
        "16M",
        "-vf",
-       "zscale=t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=hable:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p,scale=1920:ceil(ih*1920/iw/2)*2:flags=lanczos,format=yuv420p",
+       "zscale=w=1920:h=-2:t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=hable:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p,scale=1920:ceil(ih*1920/iw/2)*2:flags=lanczos,format=yuv420p",
        "-force_key_frames",
        "expr:gte(t,0+n_forced*3)",
        "-sc_threshold:v:0",

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.golden.spec.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.golden.spec.ts
@@ -1500,3 +1500,31 @@ describe('buildFfmpegArgs — pillarbox crop output sizing', () => {
     expect(vf).not.toContain('3840');
   });
 });
+
+describe('buildFfmpegArgs — NVENC early/steady-state SPS consistency', () => {
+  const presetOf = (args: string[]): string | null => {
+    const i = args.indexOf('-preset');
+    return i === -1 ? null : args[i + 1];
+  };
+
+  // The controller can serve init.mp4 from the early warm-up session and
+  // segments from the steady-state session. NVENC bakes preset-dependent
+  // knobs into the SPS, so the two sessions must build an identical video
+  // argv or the hvc1 init/segment parameter sets diverge → macroblock
+  // corruption. (Mirrors the pinned-preset invariant for libx264.)
+  it('builds an identical NVENC video argv for early and steady-state', () => {
+    const main = buildFfmpegArgs(
+      opts({ hwAccel: 'nvenc', videoVariant: HEVC_SDR }),
+      silentLog,
+    );
+    const early = buildFfmpegArgs(
+      opts({ hwAccel: 'nvenc', videoVariant: HEVC_SDR, early: true }),
+      silentLog,
+    );
+    expect(presetOf(main)).toBe('p4');
+    expect(presetOf(early)).toBe('p4');
+    // -t (early duration cap) is injected by the session layer, not here, so
+    // the argv this builder emits must be byte-identical across the two.
+    expect(early).toEqual(main);
+  });
+});

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -618,6 +618,7 @@ export function buildFfmpegArgs(
       sourceBitDepth,
       dovi: useDoviTonemap,
       tonemapCurve: resolveTonemapCurve(),
+      scaleWidth: w,
     }),
     tonemap,
     tonemapPath,

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -464,7 +464,16 @@ export function buildFfmpegArgs(
   // Baseline and produces an SPS that doesn't match the High SPS in the
   // main session's init.mp4 — player concatenates the two and corrupts.
   const earlyPreset = early ? 'veryfast' : encoderPreset;
-  const earlyNvencPreset = early ? 'p1' : 'p4';
+  // NVENC preset is held identical across the early and steady-state
+  // sessions, for the same reason the libx264 preset is pinned above: NVENC
+  // bakes preset-dependent knobs (num_ref_frames, level, VUI) into the SPS,
+  // and the controller can serve init.mp4 from one session while serving
+  // segments from the other. A p1/p4 split shipped an init (p1) whose SPS
+  // didn't match the p4-encoded slices — fatal under hvc1 (parameter sets
+  // live only in the init), producing macroblock corruption from seg-0.
+  // NVENC encodes 1080p at >10x realtime even at p4, so pinning the warm-up
+  // session to p4 costs no meaningful first-segment latency.
+  const nvencPreset = 'p4';
   // QSV rate-control: tight VBV (bufsize = bitrate × 1) so the BRC has a
   // short horizon and can't defer big I-frames. Early uses 0.5× / 1× so
   // the encoder doesn't hold back frames waiting for the buffer to fill.
@@ -591,7 +600,7 @@ export function buildFfmpegArgs(
       frameRate: fps,
     },
     preset: earlyPreset,
-    nvencPreset: earlyNvencPreset,
+    nvencPreset,
     seekSeconds,
     early,
     forceKeyframesExpr,

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -32,6 +32,7 @@ import { hevcMainTierCapBps } from './codec/codec-strings';
 import { varStreamMapLayout } from './audio-layout';
 import { resolveEncodePipeline } from './encode-pipeline';
 import { buildVideoFilters, resolveTonemapCurve } from './ffmpeg-filter-graph';
+import { isOpenclTonemapEnabled } from './codec/opencl-tonemap-probe';
 import { isLibplaceboDvEnabled } from './codec/libplacebo-dv-probe';
 import { buildImageBurnInFilterComplex } from './subtitle-overlay-filter';
 
@@ -456,6 +457,16 @@ export function buildFfmpegArgs(
     );
   }
 
+  // NVENC has no tonemap_cuda, so its HDR→SDR tone-map runs off-encoder.
+  // When the OpenCL tone-map probe passed, route it through tonemap_opencl
+  // (GPU) instead of the CPU zscale chain — decisive on 4K where the CPU
+  // tone-map can't sustain real-time. Decode is forced to CPU so the frame
+  // reaches OpenCL via a plain hwupload (no CUDA↔OpenCL interop, which is
+  // unreliable); the tone-map, the expensive step, is what moves to the GPU.
+  const nvencOpencl =
+    !!tonemap && effectiveHwAccel === 'nvenc' && isOpenclTonemapEnabled();
+  const decodeHwAccel: HwAccelType = nvencOpencl ? 'none' : effectiveHwAccel;
+
   // Early sessions live ~1s before Shaka jumps to the main session — visual
   // quality on those warm-up frames is throwaway, so bias every knob towards
   // ramp-up speed. `veryfast` everywhere keeps the H.264 profile consistent
@@ -519,7 +530,7 @@ export function buildFfmpegArgs(
             codec: normalisedSourceCodec ?? 'h264',
             bitDepth: sourceBitDepth,
           },
-          effectiveHwAccel,
+          decodeHwAccel,
         );
   args.push(...decoder.buildInputArgs());
 
@@ -562,6 +573,12 @@ export function buildFfmpegArgs(
   // `derive_device=qsv` on the closing hwmap.
   if (tonemap && !useVaapiTonemap && decoder.outputSurface === 'vaapi') {
     args.push('-init_hw_device', 'opencl=ocl:0.0');
+  }
+  // NVENC OpenCL tone-map: init the OpenCL device and make it the default
+  // filter device so the chain's `hwupload` lands on it. Decode is CPU here
+  // (see nvencOpencl above), so there's no competing hwaccel device.
+  if (nvencOpencl) {
+    args.push('-init_hw_device', 'opencl=ocl', '-filter_hw_device', 'ocl');
   }
   if (useDoviTonemap) {
     args.push('-init_hw_device', 'vulkan=vk:0', '-filter_hw_device', 'vk');
@@ -619,6 +636,7 @@ export function buildFfmpegArgs(
       dovi: useDoviTonemap,
       tonemapCurve: resolveTonemapCurve(),
       scaleWidth: w,
+      openclTonemap: nvencOpencl,
     }),
     tonemap,
     tonemapPath,

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -31,7 +31,7 @@ import { normaliseSourceCodec } from './codec/normalise';
 import { hevcMainTierCapBps } from './codec/codec-strings';
 import { varStreamMapLayout } from './audio-layout';
 import { resolveEncodePipeline } from './encode-pipeline';
-import { buildVideoFilters } from './ffmpeg-filter-graph';
+import { buildVideoFilters, resolveTonemapCurve } from './ffmpeg-filter-graph';
 import { isLibplaceboDvEnabled } from './codec/libplacebo-dv-probe';
 import { buildImageBurnInFilterComplex } from './subtitle-overlay-filter';
 
@@ -617,6 +617,7 @@ export function buildFfmpegArgs(
       useVaapiTonemap,
       sourceBitDepth,
       dovi: useDoviTonemap,
+      tonemapCurve: resolveTonemapCurve(),
     }),
     tonemap,
     tonemapPath,

--- a/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.spec.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.spec.ts
@@ -60,6 +60,15 @@ describe('buildVideoFilters', () => {
     );
   });
 
+  it('routes the tone-map through tonemap_opencl (GPU) when openclTonemap', () => {
+    const f = buildVideoFilters({ ...base, tonemap: true, openclTonemap: true });
+    expect(f.tonemapCpu).toBe(
+      'format=p010le,hwupload,tonemap_opencl=t=bt709:m=bt709:p=bt709:tonemap=hable:desat=0:format=nv12,hwdownload,format=nv12,',
+    );
+    // No CPU zscale tone-map when the GPU path is used.
+    expect(f.tonemapCpu).not.toContain('zscale');
+  });
+
   it('honours the tonemapCurve override', () => {
     const hable = buildVideoFilters({ ...base, tonemap: true });
     const mobius = buildVideoFilters({ ...base, tonemap: true, tonemapCurve: 'mobius' });

--- a/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.spec.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.spec.ts
@@ -46,7 +46,23 @@ describe('buildVideoFilters', () => {
     const f = buildVideoFilters({ ...base, tonemap: true });
     expect(f.tonemapOpencl).toContain('tonemap_opencl=');
     expect(f.tonemapVaapi).toBe('');
-    expect(f.tonemapCpu).toContain('tonemap=mobius');
+    expect(f.tonemapCpu).toContain('tonemap=hable');
+  });
+
+  it('CPU tone-map linearises then converts BT.2020 → BT.709 (not a bare tonemap)', () => {
+    const f = buildVideoFilters({ ...base, tonemap: true });
+    // vf_tonemap needs linear light; the chain must linearise first and
+    // convert primaries + output transfer, or the picture washes out grey.
+    expect(f.tonemapCpu).toBe(
+      'zscale=t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=hable:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p,',
+    );
+  });
+
+  it('honours the tonemapCurve override', () => {
+    const hable = buildVideoFilters({ ...base, tonemap: true });
+    const mobius = buildVideoFilters({ ...base, tonemap: true, tonemapCurve: 'mobius' });
+    expect(hable.tonemapCpu).toContain('tonemap=tonemap=hable:');
+    expect(mobius.tonemapCpu).toContain('tonemap=tonemap=mobius:');
   });
 
   it('vaapi tone-map when useVaapiTonemap', () => {
@@ -64,14 +80,14 @@ describe('buildVideoFilters', () => {
     expect(f.tonemapOpencl).toBe('');
     expect(f.tonemapVaapi).toBe('');
     expect(f.burnInFilter).toBe(',subtitles=/tmp/x.ass');
-    expect(f.tonemapCpu).toContain('tonemap=mobius');
+    expect(f.tonemapCpu).toContain('tonemap=hable');
   });
 
   it('dovi swaps only the CPU tone-map slot for the libplacebo chain', () => {
     const plain = buildVideoFilters({ ...base, tonemap: true });
     const dv = buildVideoFilters({ ...base, tonemap: true, dovi: true });
     expect(dv.tonemapCpu).toContain('libplacebo=apply_dolbyvision=1');
-    expect(dv.tonemapCpu).not.toContain('tonemap=mobius');
+    expect(dv.tonemapCpu).not.toContain('tonemap=tonemap=hable');
     // Every other slot is identical to the non-dovi tone-map.
     for (const k of [
       'cropStr', 'cpuCropPrefix', 'hwCropPrefix',

--- a/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.spec.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.spec.ts
@@ -6,6 +6,7 @@ const base = {
   tonemap: false,
   useVaapiTonemap: false,
   sourceBitDepth: 8,
+  scaleWidth: 1920,
 };
 
 describe('buildVideoFilters', () => {
@@ -49,12 +50,13 @@ describe('buildVideoFilters', () => {
     expect(f.tonemapCpu).toContain('tonemap=hable');
   });
 
-  it('CPU tone-map linearises then converts BT.2020 → BT.709 (not a bare tonemap)', () => {
-    const f = buildVideoFilters({ ...base, tonemap: true });
-    // vf_tonemap needs linear light; the chain must linearise first and
-    // convert primaries + output transfer, or the picture washes out grey.
+  it('CPU tone-map downscales in linear light, then converts BT.2020 → BT.709', () => {
+    const f = buildVideoFilters({ ...base, tonemap: true, scaleWidth: 1280 });
+    // Downscale to the output width in linear light first, so the CPU tone
+    // curve + gamut conversion run at output res, not the source's; vf_tonemap
+    // needs linear light and the chain must convert primaries + transfer.
     expect(f.tonemapCpu).toBe(
-      'zscale=t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=hable:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p,',
+      'zscale=w=1280:h=-2:t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=hable:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p,',
     );
   });
 

--- a/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.ts
@@ -27,6 +27,12 @@ export interface VideoFilterContext {
   dovi?: boolean;
   /** CPU HDR→SDR tone-map curve (`hable` default, `mobius` optional). */
   tonemapCurve?: TonemapCurve;
+  /** Target output width. The CPU tone-map downscales to it in linear light
+   *  before tone-mapping, so the (CPU-bound) tone curve + gamut conversion run
+   *  at the output resolution instead of the source's — decisive on a 4K
+   *  source with no HW decode (e.g. AV1 on a pre-Ampere NVIDIA GPU), where
+   *  tone-mapping at 2160p drops below real-time. */
+  scaleWidth: number;
 }
 
 /**
@@ -46,8 +52,16 @@ export interface VideoFilterContext {
 export function buildVideoFilters(
   ctx: VideoFilterContext,
 ): EncoderInput['filters'] {
-  const { crop, burnIn, tonemap, useVaapiTonemap, sourceBitDepth, dovi, tonemapCurve } =
-    ctx;
+  const {
+    crop,
+    burnIn,
+    tonemap,
+    useVaapiTonemap,
+    sourceBitDepth,
+    dovi,
+    tonemapCurve,
+    scaleWidth,
+  } = ctx;
   const cropStr = crop
     ? `crop=${crop.width}:${crop.height}:${crop.x}:${crop.y}`
     : '';
@@ -61,19 +75,23 @@ export function buildVideoFilters(
     useVaapiTonemap && !burnIn?.filter
       ? ',tonemap_vaapi=format=nv12:t=bt709:p=bt709:m=bt709'
       : '';
-  // CPU tonemap chain: HDR (PQ/HLG BT.2020) → SDR (BT.709). zscale linearises
-  // the source transfer to linear light first — vf_tonemap operates on linear
-  // light only and does NOT linearise itself, so feeding it PQ/HLG code values
-  // collapses the picture to a washed-out grey and skips the gamut conversion.
-  // Then the BT.2020 → BT.709 primaries map runs in linear light, `tonemap`
-  // applies the tone curve, and the closing zscale re-encodes to BT.709
-  // transfer + matrix + limited range. Input colorimetry is read from the
-  // frame tags, so PQ (smpte2084) and HLG (arib-std-b67) are both handled.
+  // CPU tonemap chain: HDR (PQ/HLG BT.2020) → SDR (BT.709). The opening zscale
+  // linearises the source transfer AND downscales to the output width in one
+  // pass: vf_tonemap operates on linear light only and does NOT linearise
+  // itself (feeding it PQ/HLG code values collapses the picture to a washed-out
+  // grey), and resampling belongs in linear light. Doing the downscale here
+  // also means the CPU-bound tone curve + gamut conversion run at the output
+  // resolution, not the source's — the difference between real-time and a stall
+  // on a 4K source with no HW decode. Then the BT.2020 → BT.709 primaries map
+  // runs in linear light, `tonemap` applies the curve, and the closing zscale
+  // re-encodes to BT.709 transfer + matrix + limited range. Input colorimetry
+  // is read from the frame tags, so PQ (smpte2084) and HLG (arib-std-b67) both
+  // work. `h=-2` keeps the (post-crop) aspect at an even height.
   const curve = tonemapCurve ?? 'hable';
   const tonemapCpu = tonemap
     ? dovi
       ? `hwupload,libplacebo=apply_dolbyvision=1:tonemapping=bt.2390:colorspace=bt709:color_primaries=bt709:color_trc=bt709:format=nv12,hwdownload,format=nv12,`
-      : `zscale=t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=${curve}:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p,`
+      : `zscale=w=${scaleWidth}:h=-2:t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=${curve}:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p,`
     : '';
   // HW-crop round-trip: hwdownload → crop → hwupload. The explicit `format=`
   // matches the source bit depth (p010le for 10-bit) so crop runs in the

--- a/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.ts
@@ -27,6 +27,11 @@ export interface VideoFilterContext {
   dovi?: boolean;
   /** CPU HDR→SDR tone-map curve (`hable` default, `mobius` optional). */
   tonemapCurve?: TonemapCurve;
+  /** Route the HDR→SDR tone-map through `tonemap_opencl` (GPU) instead of the
+   *  CPU zscale chain. Set for NVENC sessions when the OpenCL tone-map probe
+   *  passed — on NVIDIA this keeps the tone-map on the GPU (there is no
+   *  tonemap_cuda), turning a 4K source's ~0.5x CPU tone-map into >1x. */
+  openclTonemap?: boolean;
   /** Target output width. The CPU tone-map downscales to it in linear light
    *  before tone-mapping, so the (CPU-bound) tone curve + gamut conversion run
    *  at the output resolution instead of the source's — decisive on a 4K
@@ -61,6 +66,7 @@ export function buildVideoFilters(
     dovi,
     tonemapCurve,
     scaleWidth,
+    openclTonemap,
   } = ctx;
   const cropStr = crop
     ? `crop=${crop.width}:${crop.height}:${crop.x}:${crop.y}`
@@ -87,11 +93,17 @@ export function buildVideoFilters(
   // re-encodes to BT.709 transfer + matrix + limited range. Input colorimetry
   // is read from the frame tags, so PQ (smpte2084) and HLG (arib-std-b67) both
   // work. `h=-2` keeps the (post-crop) aspect at an even height.
+  // `openclTonemap` (NVENC + OpenCL GPU) keeps the tone-map on the GPU:
+  // upload the CPU frame to OpenCL, tonemap_opencl (linearises + BT.2020→709
+  // + curve internally), download back. tonemap_opencl has no bt2390 in
+  // ffmpeg 6.1, so it uses the same hable/mobius curve as the CPU chain.
   const curve = tonemapCurve ?? 'hable';
   const tonemapCpu = tonemap
     ? dovi
       ? `hwupload,libplacebo=apply_dolbyvision=1:tonemapping=bt.2390:colorspace=bt709:color_primaries=bt709:color_trc=bt709:format=nv12,hwdownload,format=nv12,`
-      : `zscale=w=${scaleWidth}:h=-2:t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=${curve}:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p,`
+      : openclTonemap
+        ? `format=p010le,hwupload,tonemap_opencl=t=bt709:m=bt709:p=bt709:tonemap=${curve}:desat=0:format=nv12,hwdownload,format=nv12,`
+        : `zscale=w=${scaleWidth}:h=-2:t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=${curve}:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p,`
     : '';
   // HW-crop round-trip: hwdownload → crop → hwupload. The explicit `format=`
   // matches the source bit depth (p010le for 10-bit) so crop runs in the

--- a/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.ts
@@ -1,6 +1,17 @@
 import type { BurnInSubtitle } from './types';
 import type { EncoderInput } from './codec/types';
 
+/** CPU HDR→SDR tone-map curve. `hable` is a filmic curve with a gentle
+ *  highlight rolloff (retains specular detail on high-nit HDR10); `mobius`
+ *  is punchier with a harder highlight knee. */
+export type TonemapCurve = 'hable' | 'mobius';
+
+/** Resolve the CPU tone-map curve from the optional `TRANSCODE_TONEMAP_CURVE`
+ *  env var, defaulting to `hable`. */
+export function resolveTonemapCurve(): TonemapCurve {
+  return process.env.TRANSCODE_TONEMAP_CURVE === 'mobius' ? 'mobius' : 'hable';
+}
+
 export interface VideoFilterContext {
   crop?: { width: number; height: number; x: number; y: number };
   burnIn?: BurnInSubtitle;
@@ -14,6 +25,8 @@ export interface VideoFilterContext {
   /** Dolby Vision P5: tonemap via the RPU-aware libplacebo (Vulkan) chain
    *  instead of the standard tonemap that misreads IPT-C2 (#636). */
   dovi?: boolean;
+  /** CPU HDR→SDR tone-map curve (`hable` default, `mobius` optional). */
+  tonemapCurve?: TonemapCurve;
 }
 
 /**
@@ -33,7 +46,8 @@ export interface VideoFilterContext {
 export function buildVideoFilters(
   ctx: VideoFilterContext,
 ): EncoderInput['filters'] {
-  const { crop, burnIn, tonemap, useVaapiTonemap, sourceBitDepth, dovi } = ctx;
+  const { crop, burnIn, tonemap, useVaapiTonemap, sourceBitDepth, dovi, tonemapCurve } =
+    ctx;
   const cropStr = crop
     ? `crop=${crop.width}:${crop.height}:${crop.x}:${crop.y}`
     : '';
@@ -47,13 +61,19 @@ export function buildVideoFilters(
     useVaapiTonemap && !burnIn?.filter
       ? ',tonemap_vaapi=format=nv12:t=bt709:p=bt709:m=bt709'
       : '';
-  // CPU tonemap chain: HDR (PQ/HLG BT.2020) → SDR (BT.709). Float → tonemap →
-  // yuv420p; the `tonemap` filter handles PQ/HLG linearisation internally (no
-  // zscale/libzimg dependency).
+  // CPU tonemap chain: HDR (PQ/HLG BT.2020) → SDR (BT.709). zscale linearises
+  // the source transfer to linear light first — vf_tonemap operates on linear
+  // light only and does NOT linearise itself, so feeding it PQ/HLG code values
+  // collapses the picture to a washed-out grey and skips the gamut conversion.
+  // Then the BT.2020 → BT.709 primaries map runs in linear light, `tonemap`
+  // applies the tone curve, and the closing zscale re-encodes to BT.709
+  // transfer + matrix + limited range. Input colorimetry is read from the
+  // frame tags, so PQ (smpte2084) and HLG (arib-std-b67) are both handled.
+  const curve = tonemapCurve ?? 'hable';
   const tonemapCpu = tonemap
     ? dovi
       ? `hwupload,libplacebo=apply_dolbyvision=1:tonemapping=bt.2390:colorspace=bt709:color_primaries=bt709:color_trc=bt709:format=nv12,hwdownload,format=nv12,`
-      : `format=gbrpf32le,tonemap=mobius:desat=0,format=yuv420p,`
+      : `zscale=t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=${curve}:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p,`
     : '';
   // HW-crop round-trip: hwdownload → crop → hwupload. The explicit `format=`
   // matches the source bit depth (p010le for 10-bit) so crop runs in the

--- a/backend/src/modules/streaming/transcoding/profiles.ts
+++ b/backend/src/modules/streaming/transcoding/profiles.ts
@@ -24,10 +24,13 @@ const CODEC_BITRATE_FACTOR: Record<string, number> = {
 
 /**
  * Source video bitrate in bps: the probed per-stream value, or an estimate
- * from the container bitrate minus audio when the stream omits it (common in
- * MKV, where ffprobe leaves the per-stream bitrate unset). Returns undefined
- * when neither is known. Shared by the stream-builder decision and the session
- * context so the encode cap and the overlay agree on the source bitrate.
+ * from the container bitrate when the stream omits it (common in MKV, where
+ * ffprobe leaves the per-stream bitrate unset). Audio is subtracted when its
+ * bitrate is known; when the container omits that too, the overall container
+ * bitrate stands as the video estimate — a hair generous but a far better cap
+ * than the ladder nominal. Returns undefined when no container bitrate is
+ * known. Shared by the stream-builder decision and the session context so the
+ * encode cap and the overlay agree on the source bitrate.
  */
 export function resolveSourceVideoBitrateBps(
   videoStreamBitrateBps: number | null | undefined,
@@ -37,12 +40,8 @@ export function resolveSourceVideoBitrateBps(
   if (videoStreamBitrateBps != null && videoStreamBitrateBps > 0) {
     return videoStreamBitrateBps;
   }
-  if (
-    formatBitrateBps != null &&
-    formatBitrateBps > 0 &&
-    audioSumBitrateBps > 0
-  ) {
-    const est = formatBitrateBps - audioSumBitrateBps;
+  if (formatBitrateBps != null && formatBitrateBps > 0) {
+    const est = formatBitrateBps - Math.max(0, audioSumBitrateBps);
     if (est > 10_000) return est;
   }
   return undefined;

--- a/backend/src/modules/streaming/transcoding/transcode-bitrate-cap.spec.ts
+++ b/backend/src/modules/streaming/transcoding/transcode-bitrate-cap.spec.ts
@@ -17,6 +17,12 @@ describe('resolveSourceVideoBitrateBps', () => {
     );
   });
 
+  it('falls back to the container bitrate when audio bitrate is also absent', () => {
+    // MKV with no per-stream video *or* audio bitrate: the container total is
+    // the video estimate, so the cap tracks the source instead of the rung.
+    expect(resolveSourceVideoBitrateBps(null, 12_500_000, 0)).toBe(12_500_000);
+  });
+
   it('returns undefined when neither source is usable', () => {
     expect(resolveSourceVideoBitrateBps(null, null, 0)).toBeUndefined();
     expect(resolveSourceVideoBitrateBps(0, 0, 0)).toBeUndefined();

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -43,6 +43,7 @@ import {
   isTonemapOpenclEnabled,
   runTonemapOpenclProbe,
 } from './codec/tonemap-opencl-probe';
+import { runOpenclTonemapProbe } from './codec/opencl-tonemap-probe';
 import { runLibplaceboDvProbe } from './codec/libplacebo-dv-probe';
 import {
   generateMasterPlaylist,
@@ -139,6 +140,12 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       this.detectedHwAccel === 'vaapi'
     ) {
       void runTonemapOpenclProbe(this.log);
+    }
+    // Standalone OpenCL tone-map — the GPU HDR→SDR path for NVENC (no
+    // tonemap_cuda in mainline ffmpeg; OpenCL rides the same compute stack
+    // as CUDA/NVENC, unlike the GLX/Vulkan chain which fails headless).
+    if (this.detectedHwAccel === 'nvenc') {
+      void runOpenclTonemapProbe(this.log);
     }
     // Vulkan/libplacebo Dolby Vision P5 tonemap. Vendor-agnostic, so probe on
     // any non-macOS host; a GPU-less server fails device init fast (fail-closed).

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -103,7 +103,7 @@
       "VideoProfileNotSupported": "Profil vidéo non supporté",
       "VideoLevelNotSupported": "Niveau vidéo trop élevé",
       "VideoBitDepthNotSupported": "10-bit non supporté",
-      "VideoResolutionNotSupported": "Résolution trop élevée",
+      "VideoResolutionNotSupported": "{{codec}} non décodable à cette résolution",
       "VideoCrop": "Suppression des bandes noires",
       "VideoQualityReduced": "Bitrate réduit (qualité choisie)",
       "VideoAbr": "Bitrate adaptatif (ABR)",

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -28,10 +28,13 @@ export interface PlaybackInfoResponse {
   outputContainer: string;
   hwAccel: string;
   tonemapping: boolean;
-  /** Resolved tone-mapping filter the backend will actually use
-   *  (`'auto'` resolves to opencl or vaapi depending on the boot
-   *  probe). Null when no tone-mapping pass runs on this session. */
-  tonemapAlgo?: 'vaapi' | 'opencl' | 'qsv' | null;
+  /** Tone-map mechanism the backend actually runs: a HW path
+   *  (`'vaapi'` / `'opencl'` / `'qsv'`) on QSV/VAAPI encoders, or
+   *  `'cpu'` for the CPU chain (NVENC / libx26x / VideoToolbox
+   *  fallback). Null when no tone-mapping pass runs on this session. */
+  tonemapAlgo?: 'vaapi' | 'opencl' | 'qsv' | 'cpu' | null;
+  /** CPU tone-map curve, set only when `tonemapAlgo === 'cpu'`. */
+  tonemapCurve?: 'hable' | 'mobius';
   /** Cibles par rung (transcodage). */
   transcodeBitrateByQuality?: Record<
     string,

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -835,9 +835,9 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       );
 
     let audioStreamBitrate = '';
-    if (selectedRateEntry) {
+    if (selectedRateEntry && validBps(selectedRateEntry.audioBitrateBps)) {
       audioStreamBitrate = formatBitrateBps(selectedRateEntry.audioBitrateBps);
-    } else if (validBps(sourceA) && pi?.playMethod === 'DirectStream') {
+    } else if (validBps(sourceA)) {
       audioStreamBitrate = formatBitrateBps(sourceA);
     } else {
       const trackAbw = activeVariant?.audioBandwidth;

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -792,7 +792,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // transcodes, not just raw codes. Unknown flags fall back to the raw token.
     const reasonLabel = (flag: string) => {
       const key = `player.transcode_reason.${flag}`;
-      const label = this.translate.instant(key);
+      const label = this.translate.instant(key, { codec: codecName });
       return label === key ? flag : label;
     };
     const videoTranscodeReasons = effectiveVideoCopy

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -763,10 +763,17 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       vaapi: 'tonemap_vaapi',
       opencl: 'tonemap_opencl',
       qsv: 'vpp_qsv tonemap',
+      cpu: 'CPU',
     };
+    const tonemapAlgoLabel =
+      pi?.tonemapAlgo === 'cpu' && pi?.tonemapCurve
+        ? `CPU (${pi.tonemapCurve})`
+        : pi?.tonemapAlgo
+          ? (tonemapLabel[pi.tonemapAlgo] ?? pi.tonemapAlgo)
+          : '';
     const tonemapping =
-      pi?.tonemapping && pi?.tonemapAlgo
-        ? (tonemapLabel[pi.tonemapAlgo] ?? pi.tonemapAlgo)
+      pi?.tonemapping && tonemapAlgoLabel
+        ? tonemapAlgoLabel
         : pi?.tonemapping
           ? 'enabled'
           : '';


### PR DESCRIPTION
NVIDIA (NVENC) enablement + HDR tonemap fixes found during the first on-hardware NVIDIA test. Four independent bugs, each isolated with on-box `ffmpeg` reproductions (single-file transcodes + PNG snapshots) before the fix. Single branch.

## 1. Crash on software-decode fallback — `build the filter graph for the decoder's actual surface`
NVENC encode and NVDEC decode are probed independently; when CUDA decode fails, decode falls back to CPU while the encoder stays `hevc_nvenc`, yet the descriptors hard-coded a GPU-only `-vf` (`hwdownload`/`scale_cuda`/`hwupload_cuda`) → `Function not implemented`, exit 218. Fixed with a surface-aware `nvenc-filters.ts` (mirrors `qsv-filters.ts`): `cuda`→GPU (byte-identical), `cpu`→pure-CPU, other HW→`hwdownload` bridge.

## 2. Missing closed-GOP flags — `force IDR keyframes so HLS segments decode independently`
NVENC passed only `-g/-keyint_min/-force_key_frames`; with `-forced-idr` off, some forced keyframes are non-IDR. Added the qsvExtra recipe: h264/hevc `-forced-idr 1 -no-scenecut 1 -bf 0`, av1 `-forced-idr 1 -bf 0`.

## 3. Root cause of the macroblock corruption — `pin the warm-up preset so early/main SPS match`
The early warm-up session encoded `-preset p1`, the steady-state session `-preset p4`. NVENC bakes preset-dependent knobs (num_ref_frames, level, VUI) into the SPS, and the controller serves `init_0.mp4` from the early session but segments from the steady-state one — under `-tag:v hvc1` the parameter sets live only in the init, so p1's SPS was applied to p4 slices → corruption. Same failure class libx264 already guards against by pinning its preset; NVENC was never pinned (QSV/VAAPI are SPS-immune to preset). Fix: pin NVENC to `p4` for both sessions. Isolation proved the bitstream itself was clean (single-file + single-encoder HLS both decode perfectly).

## 4. Washed-out HDR->SDR tonemap — `linearise and gamut-convert the CPU HDR->SDR chain`
The CPU tone-map (the only path NVENC can use) was `format=gbrpf32le,tonemap=mobius,format=yuv420p`, producing a grey/washed image. `vf_tonemap` needs **linear light** and does not linearise itself, so PQ/HLG code values were tone-mapped as if linear (a full ramp capped at Y=159 vs 239); the chain also never did BT.2020→BT.709 gamut conversion (pixels relabelled bt709 without conversion → desaturated). The HW paths and the DV libplacebo path already do this right — why Intel looked fine and NVIDIA didn't. Replaced with a zscale chain: linearise the tagged transfer (PQ + HLG) → convert primaries in linear light → tone curve → re-encode to BT.709 tv-range. On-box: saturation tripled, highlights restored. Curve is `hable` by default, `mobius` via `TRANSCODE_TONEMAP_CURVE`. (libplacebo BT.2390 was trialled but showed horizontal banding on the test driver, so it is not used for the general HDR path.)


## 5. Overlay mislabelled the tonemap mechanism — `report the real tonemap mechanism and curve`
The stats overlay showed the admin `tonemapAlgo` HW path (e.g. `tonemap_vaapi`) for every tonemapping session, even on NVENC where that path is inert and the tone-map runs on the CPU zscale chain. Now derived from the effective encoder: QSV/VAAPI keep the resolved HW path; NVENC/libx26x/VT-fallback report `CPU (hable|mobius)`.

## 6. Missing transcode reason for eco/lower rungs — `surface a transcode reason for eco/lower rungs`
Picking an eco rung (e.g. "1080p eco") forces the ladder via `explicitDownscale` (lower resolution OR eco tier), but the reason block re-derived the reduction per-bitrate and dropped `VideoQualityReduced` when the cut wasn't provable against a known/higher source bitrate — so the overlay showed a transcode with no video reason. Reaching `forceLadder && !autoOnLadder` already means a deliberate reduction, so the reason is now always surfaced there.

## Tests
- `codec/encoders/nvenc.spec.ts`: cuda path byte-identical; no CUDA-only filter on non-cuda input; `-forced-idr 1 -bf 0` on all, `-no-scenecut 1` on h264/hevc only; tonemap chain linearises + gamut-converts.
- `ffmpeg-args.golden.spec.ts`: early vs steady-state NVENC argv byte-identical; CPU tonemap golden updated to the zscale chain.
- `ffmpeg-filter-graph.spec.ts`: tonemap chain shape + `TRANSCODE_TONEMAP_CURVE` override.
- Full transcoding suite: **234 tests / 25 suites** green.
- `tsc --noEmit` clean.

## Validating on a NVIDIA box
`docker pull ghcr.io/fliks-app/fliks:nvenc-test` (amd64; force re-pull, tag is rewritten each build). Clear `/tmp/transcode/cache` before re-testing so old segments aren't replayed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 7. 4K CPU tonemap stall/loop — `downscale before the CPU tonemap`
Playing a 2160p AV1 HDR file on a GTX 1070 looped (`seg not produced within 60s`). The GPU has no AV1 decoder (pre-Ampere), so AV1 decodes on CPU — but that's fine (3.7× realtime, dav1d). The real bottleneck was the CPU HDR→SDR tonemap running at the **source** 4K resolution (0.47× realtime → stall). Fix: fold the downscale into the opening zscale (`zscale=w=<out>:h=-2:t=linear`) so resample happens in linear light and the tone curve + gamut conversion run at the output resolution (0.47×→1.1×). Benefits every downscaled CPU-tonemap rung; Intel is unaffected (QSV/VAAPI already tonemap on the GPU after scaling to output width).

## 8. GPU HDR tonemap via OpenCL — `tone-map HDR on the GPU via OpenCL`
NVENC has no `tonemap_cuda`, so HDR→SDR tone-mapping ran on the CPU and couldn't sustain real-time on 4K (stall/loop). The libplacebo/Vulkan GPU path is unusable in the container (`libnvidia-glcore` needs Xorg/old-glibc symbols absent headless), but **OpenCL rides the same compute stack as CUDA/NVENC** (`libnvidia-opencl.so`, no Vulkan/GLX) and works headless. Register the NVIDIA OpenCL ICD in the image + route the NVENC tone-map through `tonemap_opencl` when a boot probe confirms it (CPU decode + `hwupload`; zscale CPU fallback otherwise). Measured on a GTX 1070: 2160p tone-map **1.81× real-time** (vs 0.47× CPU), clean output, no stall. Overlay reports `opencl`.
