### PR TITLE
refactor(media-detail): move delete-file action into the file info panel

### DIFF
--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -63,7 +63,6 @@
           [releasesLoading]="epReleasesLoading()"
           [grabBusy]="epGrabBusy()"
           (selectedFileIdChange)="selectedFileId.set($event)"
-          (deleteFile)="deleteFile($event.fileId, $event.deleteOnDisk)"
           (openDownload)="openDownloadModal()"
           (refreshMetadata)="refreshMetadata()"
           (toggleMonitored)="toggleMonitored()"
@@ -131,7 +130,13 @@
 
         @if (episodeActiveFile(); as sf) {
           <div class="divider my-6"></div>
-          <app-media-file-info [file]="sf" [mediaPath]="m.path ?? null" />
+          <app-media-file-info
+            [file]="sf"
+            [mediaPath]="m.path ?? null"
+            [canDelete]="canDelete()"
+            [fileId]="episodeActiveFileId()"
+            (deleteFile)="deleteFile($event.fileId, $event.deleteOnDisk)"
+          />
         }
       </div>
 
@@ -176,7 +181,6 @@
           [monitoredLoading]="monitoredLoading()"
           [deleteLoading]="deleteLoading()"
           (selectedFileIdChange)="selectedFileId.set($event)"
-          (deleteFile)="deleteFile($event.fileId, $event.deleteOnDisk)"
           (openDownload)="openDownloadModal()"
           (openProfiles)="openProfilesModal()"
           (openLibrary)="openLibraryModal()"
@@ -220,7 +224,13 @@
 
         @if (activeFile(); as af) {
           <div class="divider my-6"></div>
-          <app-media-file-info [file]="af" [mediaPath]="m.path ?? null" />
+          <app-media-file-info
+            [file]="af"
+            [mediaPath]="m.path ?? null"
+            [canDelete]="canDelete()"
+            [fileId]="activeFileId()"
+            (deleteFile)="deleteFile($event.fileId, $event.deleteOnDisk)"
+          />
         }
 
         @if (m.type === 'series' && m.seasons?.length) {

--- a/client/src/app/shared/components/media-file-info.html
+++ b/client/src/app/shared/components/media-file-info.html
@@ -96,5 +96,18 @@
         </div>
       </div>
     }
+
+    @if (canDelete() && fileId() != null) {
+      <div class="pt-2">
+        <button
+          type="button"
+          class="btn btn-sm btn-outline btn-error"
+          (click)="onDeleteFileClick()"
+        >
+          <svg lucideTrash2 class="h-4 w-4"></svg>
+          {{ 'media_detail.delete_file' | translate }}
+        </button>
+      </div>
+    }
   </div>
 }

--- a/client/src/app/shared/components/media-file-info.ts
+++ b/client/src/app/shared/components/media-file-info.ts
@@ -4,14 +4,16 @@ import {
   computed,
   inject,
   input,
+  output,
 } from '@angular/core';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { LucideVideo, LucideVolume2 } from '@lucide/angular';
+import { LucideVideo, LucideVolume2, LucideTrash2 } from '@lucide/angular';
 import {
   MediaFileInfo,
   VideoStreamInfo,
   AudioStreamInfo,
 } from '../../core/services/api/media.service';
+import { ConfirmationService } from '../../core/services/confirmation.service';
 
 type FileInput = {
   relativePath: string;
@@ -22,17 +24,37 @@ type FileInput = {
 
 @Component({
   selector: 'app-media-file-info',
-  imports: [TranslateModule, LucideVideo, LucideVolume2],
+  imports: [TranslateModule, LucideVideo, LucideVolume2, LucideTrash2],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-file-info.html',
 })
 export class MediaFileInfoComponent {
   private readonly translate = inject(TranslateService);
+  private readonly confirmation = inject(ConfirmationService);
   readonly file = input.required<FileInput | null>();
   /** Absolute folder path of the parent media (library.path + folderName).
    *  Concatenated with `file.relativePath` so the panel exposes the
    *  full disk path instead of a basename-like fragment. */
   readonly mediaPath = input<string | null>(null);
+
+  /** Viewer holds the delete permission: exposes the delete-file action at the
+   *  bottom of the panel. */
+  readonly canDelete = input(false);
+  /** Id of the file this panel describes, required to delete it. */
+  readonly fileId = input<number | null>(null);
+  readonly deleteFile = output<{ fileId: number; deleteOnDisk: boolean }>();
+
+  async onDeleteFileClick() {
+    const id = this.fileId();
+    if (id == null) return;
+    const confirmed = await this.confirmation.confirm({
+      title: this.translate.instant('common.confirm'),
+      message: this.translate.instant('media_detail.confirm_delete_file_disk'),
+      variant: 'danger',
+    });
+    if (!confirmed) return;
+    this.deleteFile.emit({ fileId: id, deleteOnDisk: true });
+  }
 
   readonly videoStream = computed(() => this.file()?.streamInfo?.video[0] ?? null);
   readonly audioStreams = computed(() => this.file()?.streamInfo?.audio ?? []);

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -508,12 +508,6 @@
       <span class="flex-1">{{ (monitored() ? 'media_detail.unmonitor' : 'media_detail.monitor') | translate }}</span>
     </button>
   }
-  @if (canDelete() && selectedFileId() && (mediaType() !== 'series' || episodeId())) {
-    <button type="button" class="dropdown-item text-error" (click)="onDeleteFileClick()">
-      <svg lucideTrash2 class="h-5 w-5 shrink-0"></svg>
-      <span class="flex-1">{{ 'media_detail.delete_file' | translate }}</span>
-    </button>
-  }
   @if (canDelete()) {
     <button type="button" [disabled]="deleteLoading()" class="dropdown-item text-error" (click)="deleteMedia.emit()">
       @if (deleteLoading()) { <span class="loading loading-spinner loading-sm"></span> }

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -37,7 +37,6 @@ import {
 } from '@lucide/angular';
 import { PlayableMediaService } from '../../../core/services/playable-media.service';
 import { StreamingApiService } from '../../../core/services/api/streaming-api.service';
-import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { PlayerSettingsService } from '../../../core/services/player-settings.service';
 import { TrackManagerService } from '../../../core/services/track-manager.service';
 import { NavbarService } from '../../../core/services/navbar.service';
@@ -112,7 +111,6 @@ interface AudioTrack {
   templateUrl: './media-info-header.html',
 })
 export class MediaInfoHeaderComponent {
-  private readonly confirmation = inject(ConfirmationService);
   private readonly translate = inject(TranslateService);
   private readonly playerSettings = inject(PlayerSettingsService);
   private readonly trackManager = inject(TrackManagerService);
@@ -200,7 +198,6 @@ export class MediaInfoHeaderComponent {
 
   // ── Outputs (delegated to parent) ──
   readonly selectedFileIdChange = output<number>();
-  readonly deleteFile = output<{ fileId: number; deleteOnDisk: boolean }>();
   readonly openDownload = output<void>();
   readonly openProfiles = output<void>();
   readonly openLibrary = output<void>();
@@ -515,15 +512,4 @@ export class MediaInfoHeaderComponent {
   }
 
 
-  async onDeleteFileClick() {
-    const fileId = this.selectedFileId();
-    if (!fileId) return;
-    const confirmed = await this.confirmation.confirm({
-      title: this.translate.instant('common.confirm'),
-      message: this.translate.instant('media_detail.confirm_delete_file_disk'),
-      variant: 'danger',
-    });
-    if (!confirmed) return;
-    this.deleteFile.emit({ fileId, deleteOnDisk: true });
-  }
 }


### PR DESCRIPTION
## What

For users who hold the delete permission, the **"Supprimer le fichier"** action moves from the media-detail header's `…` dropdown to the **bottom of the "Informations du fichier" panel** it acts on. **"Supprimer de la bibliothèque"** stays in the dropdown.

## Why

The destructive per-file deletion now sits directly with the file it targets (the file-info panel already shows that file's path/streams), which reads more clearly than burying it in the actions menu.

## Changes

- `MediaFileInfoComponent` gains `canDelete` + `fileId` inputs and a `deleteFile` output, and renders a delete button at the bottom of the panel (confirmation dialog reused). Wired at both usages in `media-detail` (movie / show-episode) to the existing `deleteFile` handler.
- Removed the delete-file entry (and its now-unused handler/output/import) from `media-info-header`.

Permission gate unchanged (`media.delete`); confirmation dialog unchanged. Client `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)