### PR TITLE
fix(i18n): add missing media-status labels on the add page

### DIFF
--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -685,7 +685,11 @@
     "status_canceled": "Annulé",
     "status_returning_series": "En cours",
     "status_ended": "Terminé",
-    "status_pilot": "Pilote"
+    "status_pilot": "Pilote",
+    "status_continuing": "En cours",
+    "status_tba": "À venir",
+    "status_announced": "Annoncé",
+    "status_deleted": "Supprimé"
   },
   "library": {
     "empty": "Aucun média dans cette bibliothèque",


### PR DESCRIPTION
## What

The add/preview page derives the status badge label from the media status (`discover.status_<value>`). Statuses without a matching key rendered the **raw key** (e.g. `discover.status_continuing`, as reported).

Adds the missing `MediaStatus` values to `client/public/i18n/fr.json`:
- `status_continuing` → « En cours »
- `status_tba` → « À venir »
- `status_announced` → « Annoncé »
- `status_deleted` → « Supprimé »

(`released` / `ended` already existed.)

fr.json validated as JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)