### PR TITLE
feat(search): keep filters functional while typing a query

### DIFF
--- a/backend/src/modules/media/dto/search-media.dto.ts
+++ b/backend/src/modules/media/dto/search-media.dto.ts
@@ -4,6 +4,7 @@ import {
   IsEnum,
   IsNumber,
   IsBoolean,
+  IsArray,
 } from 'class-validator';
 import { Type, Transform } from 'class-transformer';
 import { MediaType, MediaStatus } from '../../../common/enums';
@@ -34,6 +35,43 @@ export class SearchMediaDto {
   @IsString()
   @IsOptional()
   genre?: string;
+
+  /**
+   * Multi-genre filter matched by name. Accepts a comma-joined string (as sent
+   * by the search panel) or an array; all listed genres must be present
+   * (AND semantics).
+   */
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (Array.isArray(value)) {
+      return value.map((v: string) => String(v).trim()).filter(Boolean);
+    }
+    if (typeof value === 'string') {
+      return value
+        .split(',')
+        .map((v) => v.trim())
+        .filter(Boolean);
+    }
+    return value;
+  })
+  genres?: string[];
+
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  yearMin?: number;
+
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  yearMax?: number;
+
+  @IsNumber()
+  @IsOptional()
+  @Type(() => Number)
+  voteMin?: number;
 
   @IsNumber()
   @IsOptional()

--- a/backend/src/modules/media/media-service/media-query.applyfilters.spec.ts
+++ b/backend/src/modules/media/media-service/media-query.applyfilters.spec.ts
@@ -1,0 +1,121 @@
+import { MediaQueryService } from './media-query.service';
+import { SearchMediaDto } from '../dto/search-media.dto';
+
+/**
+ * Build a chainable query-builder stub that records every `andWhere` call so a
+ * test can assert which clauses `applyFilters` emitted. Terminal methods are
+ * present but unused here.
+ */
+function fakeQueryBuilder() {
+  const andWhereCalls: [string, unknown?][] = [];
+  const builder: any = {
+    andWhereCalls,
+    where: () => builder,
+    andWhere: (clause: string, params?: unknown) => {
+      andWhereCalls.push([clause, params]);
+      return builder;
+    },
+    orderBy: () => builder,
+    skip: () => builder,
+    take: () => builder,
+    getManyAndCount: () => Promise.resolve([[], 0]),
+  };
+  return builder;
+}
+
+function makeService(): MediaQueryService {
+  return new MediaQueryService(
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+  );
+}
+
+/** Collect the SQL fragments passed to `andWhere` for easy substring matching. */
+function clauses(builder: { andWhereCalls: [string, unknown?][] }): string[] {
+  return builder.andWhereCalls.map(([clause]) => clause);
+}
+
+describe('MediaQueryService.applyFilters', () => {
+  let service: MediaQueryService;
+
+  beforeEach(() => {
+    service = makeService();
+  });
+
+  it('emits genres @>, year range, and rating clauses for a populated dto', () => {
+    const qb = fakeQueryBuilder();
+    const dto: SearchMediaDto = {
+      genres: ['Action', 'Drama'],
+      yearMin: 2000,
+      yearMax: 2010,
+      voteMin: 7,
+    };
+
+    (service as any).applyFilters(qb, dto);
+
+    const emitted = clauses(qb);
+    expect(emitted).toContain('media.genres @> :genres');
+    expect(emitted).toContain('media.year >= :yearMin');
+    expect(emitted).toContain('media.year <= :yearMax');
+    expect(emitted).toContain('media.rating >= :voteMin');
+
+    // Genres are matched by name via a JSON-encoded contains payload.
+    const genresCall = qb.andWhereCalls.find(
+      ([clause]: [string, unknown?]) => clause === 'media.genres @> :genres',
+    );
+    expect(genresCall?.[1]).toEqual({
+      genres: JSON.stringify(['Action', 'Drama']),
+    });
+    const yearMinCall = qb.andWhereCalls.find(
+      ([clause]: [string, unknown?]) => clause === 'media.year >= :yearMin',
+    );
+    expect(yearMinCall?.[1]).toEqual({ yearMin: 2000 });
+    const yearMaxCall = qb.andWhereCalls.find(
+      ([clause]: [string, unknown?]) => clause === 'media.year <= :yearMax',
+    );
+    expect(yearMaxCall?.[1]).toEqual({ yearMax: 2010 });
+    const voteCall = qb.andWhereCalls.find(
+      ([clause]: [string, unknown?]) => clause === 'media.rating >= :voteMin',
+    );
+    expect(voteCall?.[1]).toEqual({ voteMin: 7 });
+  });
+
+  it('emits none of the new clauses for an empty dto', () => {
+    const qb = fakeQueryBuilder();
+
+    (service as any).applyFilters(qb, {} as SearchMediaDto);
+
+    const emitted = clauses(qb);
+    expect(emitted).not.toContain('media.genres @> :genres');
+    expect(emitted).not.toContain('media.year >= :yearMin');
+    expect(emitted).not.toContain('media.year <= :yearMax');
+    expect(emitted).not.toContain('media.rating >= :voteMin');
+  });
+
+  it('skips the genres clause when the array is empty', () => {
+    const qb = fakeQueryBuilder();
+
+    (service as any).applyFilters(qb, { genres: [] } as SearchMediaDto);
+
+    expect(clauses(qb)).not.toContain('media.genres @> :genres');
+  });
+
+  it('keeps the single-genre and exact-year branches for other callers', () => {
+    const qb = fakeQueryBuilder();
+
+    (service as any).applyFilters(qb, {
+      genre: 'Comedy',
+      year: 1999,
+    } as SearchMediaDto);
+
+    const emitted = clauses(qb);
+    expect(emitted).toContain('media.genres @> :genre');
+    expect(emitted).toContain('media.year = :year');
+    expect(emitted).not.toContain('media.genres @> :genres');
+    expect(emitted).not.toContain('media.year >= :yearMin');
+  });
+});

--- a/backend/src/modules/media/media-service/media-query.service.ts
+++ b/backend/src/modules/media/media-service/media-query.service.ts
@@ -1018,9 +1018,23 @@ export class MediaQueryService {
     if (query.year) {
       qb.andWhere('media.year = :year', { year: query.year });
     }
+    if (query.yearMin !== undefined) {
+      qb.andWhere('media.year >= :yearMin', { yearMin: query.yearMin });
+    }
+    if (query.yearMax !== undefined) {
+      qb.andWhere('media.year <= :yearMax', { yearMax: query.yearMax });
+    }
+    if (query.voteMin !== undefined) {
+      qb.andWhere('media.rating >= :voteMin', { voteMin: query.voteMin });
+    }
     if (query.genre) {
       qb.andWhere('media.genres @> :genre', {
         genre: JSON.stringify([query.genre]),
+      });
+    }
+    if (query.genres && query.genres.length > 0) {
+      qb.andWhere('media.genres @> :genres', {
+        genres: JSON.stringify(query.genres),
       });
     }
     if (query.collectionId) {

--- a/backend/src/modules/metadata-providers/interfaces/metadata-provider.interface.ts
+++ b/backend/src/modules/metadata-providers/interfaces/metadata-provider.interface.ts
@@ -10,6 +10,8 @@ export interface MetadataSearchResult {
   posterUrl: string | null;
   rating: number;
   genres: string[];
+  /** TMDB genre ids — search-list results carry ids, not names. */
+  genreIds?: number[];
   mediaType: 'movie' | 'series';
 }
 

--- a/backend/src/modules/metadata-providers/providers/tmdb-api.types.ts
+++ b/backend/src/modules/metadata-providers/providers/tmdb-api.types.ts
@@ -71,6 +71,7 @@ export interface TmdbMovieListItem {
   release_date?: string;
   poster_path?: string | null;
   vote_average?: number;
+  genre_ids?: number[];
 }
 
 export interface TmdbTvListItem {
@@ -81,6 +82,7 @@ export interface TmdbTvListItem {
   first_air_date?: string;
   poster_path?: string | null;
   vote_average?: number;
+  genre_ids?: number[];
 }
 
 export interface TmdbPaginated<T> {

--- a/backend/src/modules/metadata-providers/providers/tmdb.provider.ts
+++ b/backend/src/modules/metadata-providers/providers/tmdb.provider.ts
@@ -637,6 +637,7 @@ export class TmdbProvider implements IMetadataProvider {
         : null,
       rating: r.vote_average ?? 0,
       genres: [],
+      genreIds: r.genre_ids ?? [],
       mediaType: 'movie',
     };
   }
@@ -654,6 +655,7 @@ export class TmdbProvider implements IMetadataProvider {
         : null,
       rating: r.vote_average ?? 0,
       genres: [],
+      genreIds: r.genre_ids ?? [],
       mediaType: 'series',
     };
   }

--- a/client/src/app/core/services/api/media.service.ts
+++ b/client/src/app/core/services/api/media.service.ts
@@ -218,6 +218,12 @@ export interface SearchParams {
   monitored?: boolean;
   year?: number;
   genre?: string;
+  /** Multi-genre filter matched by name; all must be present (AND). */
+  genres?: string[];
+  yearMin?: number;
+  yearMax?: number;
+  /** Minimum rating (compared against media.rating). */
+  voteMin?: number;
   collectionId?: number;
   sortBy?: string;
   sortOrder?: 'ASC' | 'DESC';
@@ -325,9 +331,12 @@ export class MediaService {
   getAll(params: SearchParams = {}, opts: { force?: boolean } = {}) {
     let httpParams = new HttpParams();
     for (const [key, value] of Object.entries(params)) {
-      if (value !== undefined && value !== null && value !== '') {
-        httpParams = httpParams.set(key, String(value));
+      if (value === undefined || value === null || value === '') continue;
+      if (Array.isArray(value)) {
+        if (value.length) httpParams = httpParams.set(key, value.join(','));
+        continue;
       }
+      httpParams = httpParams.set(key, String(value));
     }
     const headers = opts.force ? { [CACHE_BYPASS_HEADER]: '1' } : undefined;
     return firstValueFrom(

--- a/client/src/app/core/services/api/metadata.service.ts
+++ b/client/src/app/core/services/api/metadata.service.ts
@@ -16,6 +16,7 @@ export interface MetadataSearchResult {
   posterUrl: string | null;
   rating: number;
   genres: string[];
+  genreIds?: number[];
   mediaType: MediaType;
   existingMediaId: number | null;
   existingMediaType: MediaType | null;

--- a/client/src/app/core/services/search-state.service.ts
+++ b/client/src/app/core/services/search-state.service.ts
@@ -54,6 +54,15 @@ export class SearchStateService {
   /** True once a discover query has been applied (rows → results grid). */
   readonly discoverActive = signal(false);
 
+  /** Names of the selected discover genres (panel selects TMDB ids; results
+   *  carry genre names). Used to post-filter external results by name. */
+  readonly selectedGenreNames = computed(() => {
+    const selected = this.discoverSelectedGenres();
+    return this.discoverGenres()
+      .filter((g) => selected.has(g.id))
+      .map((g) => g.name);
+  });
+
   /** Reset the discover panel filters + results. */
   resetDiscover(): void {
     this.discoverSelectedGenres.set(new Set());
@@ -88,12 +97,14 @@ export class SearchStateService {
   }
 
   /** External results for the "add to library" section: only titles NOT already
-   *  in the library (owned ones move to {@link ownedExternalResults}). */
+   *  in the library (owned ones move to {@link ownedExternalResults}). Narrowed
+   *  by the discover panel filters (genre/year/rating) while a query is active. */
   readonly filteredExternalResults = computed(() => {
     const localTmdbIds = new Set(this.localResults().map(m => m.tmdbId));
-    return this.externalResults().filter(
+    const rows = this.externalResults().filter(
       (r) => r.existingMediaId == null && !localTmdbIds.has(r.tmdbId),
     );
+    return this.applyPanelFilters(rows);
   });
 
   /** Library titles the provider matched by other metadata (franchise, keywords,
@@ -102,10 +113,46 @@ export class SearchStateService {
    *  library section so owned matches show at the top. Deduped against local. */
   readonly ownedExternalResults = computed(() => {
     const localTmdbIds = new Set(this.localResults().map(m => m.tmdbId));
-    return this.externalResults().filter(
+    const rows = this.externalResults().filter(
       (r) => r.existingMediaId != null && !localTmdbIds.has(r.tmdbId),
     );
+    return this.applyPanelFilters(rows);
   });
+
+  /** Narrow external rows by the discover panel filters, then sort only when the
+   *  user picked a rating/recency sort (the default keeps provider relevance).
+   *  Genre matches by TMDB id (search results carry ids, not names) with a name
+   *  fallback for providers that return names. No-op when no filter is engaged. */
+  private applyPanelFilters(
+    rows: MetadataSearchResult[],
+  ): MetadataSearchResult[] {
+    const ids = [...this.discoverSelectedGenres()];
+    const names = this.selectedGenreNames();
+    const voteMin = this.discoverVoteMin();
+    const yearMin = this.discoverYearMin();
+    const yearMax = this.discoverYearMax();
+
+    const filtered = rows.filter((row) => {
+      if (ids.length) {
+        const byId = !!row.genreIds && ids.every((id) => row.genreIds!.includes(id));
+        const byName = names.length > 0 && names.every((n) => row.genres.includes(n));
+        if (!byId && !byName) return false;
+      }
+      if (row.rating < voteMin) return false;
+      if (yearMin != null && (row.year == null || row.year < yearMin)) return false;
+      if (yearMax != null && (row.year == null || row.year > yearMax)) return false;
+      return true;
+    });
+
+    const sort = this.discoverSort();
+    if (sort === 'primary_release_date.desc') {
+      return [...filtered].sort((a, b) => (b.year ?? 0) - (a.year ?? 0));
+    }
+    if (sort === 'vote_average.desc') {
+      return [...filtered].sort((a, b) => b.rating - a.rating);
+    }
+    return filtered;
+  }
 
   clear() {
     this.query.set('');

--- a/client/src/app/features/search/search.html
+++ b/client/src/app/features/search/search.html
@@ -143,15 +143,6 @@
           }
         </div>
       </div>
-
-      <!-- Mobile filter sheet -->
-      <dialog #filterSheet class="modal">
-        <div class="modal-box">
-          <form method="dialog"><button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" [attr.aria-label]="'common.close' | translate">✕</button></form>
-          <ng-container *ngTemplateOutlet="filterPanel" />
-        </div>
-        <form method="dialog" class="modal-backdrop"><button>close</button></form>
-      </dialog>
     } @else {
       <!-- External search off: local suggestions only -->
       @if (state.discoveryRecommendations().length) {
@@ -165,75 +156,96 @@
       }
     }
   } @else {
-    <!-- Local library results -->
-    @if (state.localLoading()) {
-      <div class="flex justify-center py-8">
-        <span class="loading loading-spinner loading-lg"></span>
-      </div>
-    } @else if (state.localResults().length > 0 || state.ownedExternalResults().length > 0) {
-      <div>
-        <h2 class="text-lg font-semibold mb-3">{{ 'search.section_library' | translate }}</h2>
-        <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 gap-3 sm:gap-4">
-          @for (media of state.localResults(); track media.id) {
-            <app-media-card
-              [media]="media"
-              [status]="media.watched ? 'watched' : null"
-              [progressPercent]="media.watched ? 0 : (media.progressPercent ?? 0)"
-              [interactiveWatched]="canMarkMediaWatched(media)"
-              (watchedToggled)="toggleMediaWatched(media, $event)"
-            />
-          }
-          <!-- Owned titles the local title search missed but the provider
-               matched via other metadata (franchise, keywords…). -->
-          @for (row of state.ownedExternalResults(); track row.mediaType + ':' + row.tmdbId) {
-            <app-media-card
-              [imageUrl]="row.posterUrl"
-              [title]="row.title"
-              [subtitle]="'' + (row.year ?? '')"
-              [rating]="row.rating"
-              (clicked)="onExternalCardClick(row)"
-            />
-          }
-        </div>
-      </div>
-    }
+    <!-- Text-search results: filter sidebar (desktop) + results column -->
+    <div class="flex gap-6">
+      <aside class="hidden lg:block w-60 shrink-0">
+        <ng-container *ngTemplateOutlet="filterPanel" />
+      </aside>
+      <div class="flex-1 min-w-0 flex flex-col gap-4">
+        <button type="button" class="lg:hidden btn btn-sm btn-outline gap-2 self-start" (click)="openFilterSheet()">
+          <svg lucideSettings class="h-4 w-4"></svg>{{ 'search.filters' | translate }}
+        </button>
 
-    <!-- External provider results -->
-    @if (state.externalLoading()) {
-      <div class="flex justify-center py-8">
-        <span class="loading loading-spinner loading-lg"></span>
-      </div>
-    } @else if (state.filteredExternalResults().length > 0) {
-      <div>
-        <h2 class="text-lg font-semibold mb-3">{{ 'search.section_discover' | translate }}</h2>
-        <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 gap-3 sm:gap-4">
-          @for (row of state.filteredExternalResults(); track row.tmdbId) {
-            <app-media-card
-              [imageUrl]="row.posterUrl"
-              [title]="row.title"
-              [subtitle]="'' + (row.year ?? '')"
-              [rating]="row.rating"
-              [badge]="cardStatus(row)"
-              (clicked)="onExternalCardClick(row)"
-            />
-          }
-        </div>
-      </div>
-    }
+        <!-- Local library results -->
+        @if (state.localLoading()) {
+          <div class="flex justify-center py-8">
+            <span class="loading loading-spinner loading-lg"></span>
+          </div>
+        } @else if (state.localResults().length > 0 || state.ownedExternalResults().length > 0) {
+          <div>
+            <h2 class="text-lg font-semibold mb-3">{{ 'search.section_library' | translate }}</h2>
+            <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 gap-3 sm:gap-4">
+              @for (media of state.localResults(); track media.id) {
+                <app-media-card
+                  [media]="media"
+                  [status]="media.watched ? 'watched' : null"
+                  [progressPercent]="media.watched ? 0 : (media.progressPercent ?? 0)"
+                  [interactiveWatched]="canMarkMediaWatched(media)"
+                  (watchedToggled)="toggleMediaWatched(media, $event)"
+                />
+              }
+              <!-- Owned titles the local title search missed but the provider
+                   matched via other metadata (franchise, keywords…). -->
+              @for (row of state.ownedExternalResults(); track row.mediaType + ':' + row.tmdbId) {
+                <app-media-card
+                  [imageUrl]="row.posterUrl"
+                  [title]="row.title"
+                  [subtitle]="'' + (row.year ?? '')"
+                  [rating]="row.rating"
+                  (clicked)="onExternalCardClick(row)"
+                />
+              }
+            </div>
+          </div>
+        }
 
-    <!-- No results at all -->
-    @if (!state.localLoading() && !state.externalLoading() && state.localResults().length === 0 && state.filteredExternalResults().length === 0 && state.ownedExternalResults().length === 0) {
-      <div class="text-center py-8">
-        <p class="text-base-content/50">{{ 'search.no_results' | translate }}</p>
-        @if (!state.externalEnabled()) {
-          <button class="btn btn-primary btn-sm mt-4" (click)="toggleExternal()">
-            {{ 'search.enable_external' | translate }}
-          </button>
+        <!-- External provider results -->
+        @if (state.externalLoading()) {
+          <div class="flex justify-center py-8">
+            <span class="loading loading-spinner loading-lg"></span>
+          </div>
+        } @else if (state.filteredExternalResults().length > 0) {
+          <div>
+            <h2 class="text-lg font-semibold mb-3">{{ 'search.section_discover' | translate }}</h2>
+            <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 gap-3 sm:gap-4">
+              @for (row of state.filteredExternalResults(); track row.tmdbId) {
+                <app-media-card
+                  [imageUrl]="row.posterUrl"
+                  [title]="row.title"
+                  [subtitle]="'' + (row.year ?? '')"
+                  [rating]="row.rating"
+                  [badge]="cardStatus(row)"
+                  (clicked)="onExternalCardClick(row)"
+                />
+              }
+            </div>
+          </div>
+        }
+
+        <!-- No results at all -->
+        @if (!state.localLoading() && !state.externalLoading() && state.localResults().length === 0 && state.filteredExternalResults().length === 0 && state.ownedExternalResults().length === 0) {
+          <div class="text-center py-8">
+            <p class="text-base-content/50">{{ 'search.no_results' | translate }}</p>
+            @if (!state.externalEnabled()) {
+              <button class="btn btn-primary btn-sm mt-4" (click)="toggleExternal()">
+                {{ 'search.enable_external' | translate }}
+              </button>
+            }
+          </div>
         }
       </div>
-    }
+    </div>
   }
 </div>
+
+<!-- Mobile filter sheet — top-level so it opens during discovery and search alike -->
+<dialog #filterSheet class="modal">
+  <div class="modal-box">
+    <form method="dialog"><button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" [attr.aria-label]="'common.close' | translate">✕</button></form>
+    <ng-container *ngTemplateOutlet="filterPanel" />
+  </div>
+  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+</dialog>
 
 <!-- Discover filter panel — projected into the desktop sidebar and the mobile sheet -->
 <ng-template #filterPanel>
@@ -304,11 +316,13 @@
       </div>
     </div>
 
-    <div class="flex gap-2 pt-1">
-      <button type="button" class="btn btn-primary btn-sm flex-1" (click)="applyDiscover()">{{ 'search.apply' | translate }}</button>
-      @if (state.discoverActive() || state.discoverSelectedGenres().size) {
-        <button type="button" class="btn btn-ghost btn-sm" (click)="clearDiscover()">{{ 'search.clear' | translate }}</button>
-      }
-    </div>
+    @if (!state.hasQuery()) {
+      <div class="flex gap-2 pt-1">
+        <button type="button" class="btn btn-primary btn-sm flex-1" (click)="applyDiscover()">{{ 'search.apply' | translate }}</button>
+        @if (state.discoverActive() || state.discoverSelectedGenres().size) {
+          <button type="button" class="btn btn-ghost btn-sm" (click)="clearDiscover()">{{ 'search.clear' | translate }}</button>
+        }
+      </div>
+    }
   </div>
 </ng-template>

--- a/client/src/app/features/search/search.ts
+++ b/client/src/app/features/search/search.ts
@@ -16,7 +16,7 @@ import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
-import { MediaService, Media } from '../../core/services/api/media.service';
+import { MediaService, Media, SearchParams } from '../../core/services/api/media.service';
 import { StreamingApiService, RecommendationItem } from '../../core/services/api/streaming-api.service';
 import {
   MetadataService,
@@ -119,10 +119,43 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
     });
   });
 
+  /** Keep the discover genre list populated for the active content type so the
+   *  filter panel's genre chips render during a text search too. Movie genres
+   *  cover the "all" and "movie" tabs; series uses the TV list. */
+  private readonly discoverGenreEffect = effect(() => {
+    this.state.tab();
+    this.state.contentType();
+    untracked(() => void this.ensureDiscoverGenres());
+  });
+
+  /** Live-apply the discover panel filters to the local (backend) search while a
+   *  text query is active. Debounced; the run is untracked so its writes can't
+   *  feed back. Only the local search re-runs — external results re-filter
+   *  reactively via the state computeds (no TMDB refetch). Skips when the query
+   *  already reflects these filters (e.g. a content-type switch ran directly). */
+  private readonly liveFilterEffect = effect(() => {
+    this.state.discoverSelectedGenres();
+    this.state.discoverSort();
+    this.state.discoverVoteMin();
+    this.state.discoverYearMin();
+    this.state.discoverYearMax();
+    untracked(() => {
+      if (!this.state.hasQuery()) return;
+      const q = this.state.query().trim();
+      const ct = this.state.contentType();
+      if (this.filterSig(q, ct) === this.lastLocalSig) return;
+      if (this.filterDebounce) clearTimeout(this.filterDebounce);
+      this.filterDebounce = setTimeout(() => void this.runLocalSearch(q, ct), 300);
+    });
+  });
+
   readonly requestedTmdbIds = signal<Map<number, FliksRequestStatus>>(new Map());
 
   private static readonly SCROLL_KEY = 'search';
   private searchTimer: ReturnType<typeof setTimeout> | null = null;
+  private filterDebounce: ReturnType<typeof setTimeout> | null = null;
+  /** Movie/series bucket the discover genre list was last loaded for. */
+  private lastGenreType = '';
   private attachedSub?: Subscription;
   private detachedSub?: Subscription;
 
@@ -155,6 +188,7 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngOnDestroy() {
     if (this.searchTimer) clearTimeout(this.searchTimer);
+    if (this.filterDebounce) clearTimeout(this.filterDebounce);
     this.scrollMemory.deactivate();
     this.attachedSub?.unsubscribe();
     this.detachedSub?.unsubscribe();
@@ -499,6 +533,51 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
     await this.applyDiscover();
   }
 
+  /** Map the panel sort to the local sortBy/sortOrder, or null for the default
+   *  (keeps the title relevance order — the panel default has no local column). */
+  private mapPanelSort(): { sortBy: string; sortOrder: 'ASC' | 'DESC' } | null {
+    const s = this.state.discoverSort();
+    if (s === 'primary_release_date.desc') return { sortBy: 'year', sortOrder: 'DESC' };
+    if (s === 'vote_average.desc') return { sortBy: 'rating', sortOrder: 'DESC' };
+    return null;
+  }
+
+  /** Signature of the inputs that shape the local library query, so a re-run
+   *  can be skipped when nothing changed and a stale revalidation ignored. */
+  private filterSig(q: string, ct: string): string {
+    return JSON.stringify({
+      q,
+      ct,
+      g: [...this.state.discoverSelectedGenres()].sort((a, b) => a - b),
+      ymin: this.state.discoverYearMin(),
+      ymax: this.state.discoverYearMax(),
+      vmin: this.state.discoverVoteMin(),
+      sort: this.state.discoverSort(),
+    });
+  }
+  private lastLocalSig = '';
+
+  /** Load the discover genre list for the active content type when missing, so
+   *  the filter panel's genre chips render during a text search. Fails soft. */
+  private async ensureDiscoverGenres(): Promise<void> {
+    if (this.state.tab() !== 'videos') return;
+    const type = this.state.contentType() === 'series' ? 'series' : 'movie';
+    if (type === this.lastGenreType && this.state.discoverGenres().length) return;
+    this.lastGenreType = type;
+    const stale = () =>
+      this.state.tab() !== 'videos' ||
+      (this.state.contentType() === 'series' ? 'series' : 'movie') !== type;
+    try {
+      const genres =
+        type === 'series'
+          ? await this.metadata.getTvGenres()
+          : await this.metadata.getMovieGenres();
+      if (!stale()) this.state.discoverGenres.set(genres);
+    } catch {
+      if (!stale()) this.state.discoverGenres.set([]);
+    }
+  }
+
   openFilterSheet() {
     this.filterSheet()?.nativeElement.showModal();
   }
@@ -558,35 +637,52 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
     if (!q) return;
 
     const ct = this.state.contentType();
-    const type: MediaType | undefined = ct === 'all' ? undefined : ct;
+    await this.runLocalSearch(q, ct);
+    if (this.state.externalEnabled()) await this.runExternalSearch(q, ct);
+  }
 
-    // Search local library first
+  /** Local library query with the discover panel filters pushed to the backend
+   *  (q + genres + year + rating + sort). Re-run standalone on a filter change. */
+  private async runLocalSearch(q: string, ct: 'all' | 'movie' | 'series') {
+    const sig = (this.lastLocalSig = this.filterSig(q, ct));
+    void this.ensureDiscoverGenres();
+    const type: MediaType | undefined = ct === 'all' ? undefined : ct;
+    const sort = this.mapPanelSort();
+    const localParams: SearchParams = { q, limit: 20, sortBy: sort?.sortBy ?? 'title' };
+    if (sort) localParams.sortOrder = sort.sortOrder;
+    if (type) localParams.type = type;
+    const genres = this.state.selectedGenreNames();
+    if (genres.length) localParams.genres = genres;
+    const yearMin = this.state.discoverYearMin();
+    if (yearMin != null) localParams.yearMin = yearMin;
+    const yearMax = this.state.discoverYearMax();
+    if (yearMax != null) localParams.yearMax = yearMax;
+    const voteMin = this.state.discoverVoteMin();
+    if (voteMin) localParams.voteMin = voteMin;
+
+    const fresh = () => this.filterSig(this.state.query().trim(), this.state.contentType()) === sig;
     this.state.localLoading.set(true);
-    const localParams = { q, type, limit: 20, sortBy: 'title' } as const;
     try {
       const res = await this.mediaService.getAll(localParams);
-      this.state.localResults.set(res.data);
+      if (fresh()) this.state.localResults.set(res.data);
     } catch {
-      this.state.localResults.set([]);
+      if (fresh()) this.state.localResults.set([]);
     } finally {
       this.state.localLoading.set(false);
     }
     queueMicrotask(() => {
-      // Revalidate: cached result paints instantly, then catch up to fresh
-      // matches (a media imported since the last identical query lands here).
-      if (this.state.query().trim() !== q || this.state.contentType() !== ct) return;
+      if (!fresh()) return;
       void this.mediaService
         .getAll(localParams, { force: true })
-        .then((fresh) => {
-          if (this.state.query().trim() === q && this.state.contentType() === ct) {
-            this.state.localResults.set(fresh.data);
-          }
-        })
-        .catch(() => { /* keep cached results */ });
+        .then((data) => { if (fresh()) this.state.localResults.set(data.data); })
+        .catch(() => {});
     });
+  }
 
-    // Then search external providers (if enabled)
-    if (!this.state.externalEnabled()) return;
+  /** External provider (TMDB) title search. Not re-run on filter changes — the
+   *  state computeds re-filter the fetched rows client-side. */
+  private async runExternalSearch(q: string, ct: 'all' | 'movie' | 'series') {
+    const fresh = () => this.state.query().trim() === q && this.state.contentType() === ct;
     this.state.externalLoading.set(true);
     try {
       let rows: MetadataSearchResult[];
@@ -601,10 +697,12 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
         ]);
         rows = [...movies, ...tv].sort((a, b) => b.rating - a.rating);
       }
-      this.state.externalResults.set(rows);
-      this.loadRequestedIds();
+      if (fresh()) {
+        this.state.externalResults.set(rows);
+        this.loadRequestedIds();
+      }
     } catch {
-      this.state.externalResults.set([]);
+      if (fresh()) this.state.externalResults.set([]);
     } finally {
       this.state.externalLoading.set(false);
     }


### PR DESCRIPTION
## What

On the search page (videos tab), the discover **filter panel now stays visible and functional while a text query is active** — previously it vanished the moment you typed. Genre / year range / rating / sort narrow the results live.

## How

Text search and the filter panel rely on two different TMDB endpoints (`/search` = text, no filters; `/discover` = filters, no text), so they can't be one call. Split by source:
- **Local library**: the filters are pushed to the backend query. `SearchMediaDto` + the query builder gained multi-genre (JSONB contains-all), `yearMin`/`yearMax`, and `voteMin` (rating) — additive, existing callers unaffected.
- **External (TMDB)**: post-filtered client-side (each row already carries year + rating; genre is matched by the newly-exposed `genreIds`, since `/search` returns genre ids but no names). A filter change re-runs **only** the local query (debounced + deduped) and re-filters the external rows reactively — no TMDB refetch.

Default sort keeps provider/relevance order; only an explicit rating/recency sort reorders.

## Adversarial review

Built via a multi-agent workflow, then an adversarial review pass (6 findings). All were fixed before this PR:
- **[high]** genre filter wiped all external results (TMDB `/search` returns `genres: []`) → now matches by `genreIds` exposed on search results.
- **[med]** default sort silently reordered external by rating → sort only applies when the user picks rating/recency.
- **[med]** live-filter effect refetched TMDB on every change → effect now re-runs only the local query.
- **[low]** content-type switch double-searched → deduped via a filter signature.
- **[low]** force-revalidation could overwrite filtered results → guard now includes the filters.

## Known limitation

In the **"All"** tab, genre chips use the movie taxonomy, so a genre selection filters movies precisely but not series (TV uses a distinct genre taxonomy) — same movie-centric behavior as the existing discover panel. Use the Movies / Series tabs for precise genre filtering.

## Testing

Backend `tsc` + new `media-query.applyfilters` spec (4 tests) green; client `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)