### PR TITLE
feat(search): auto-apply filters, library browse without external search, consistent cards

### DIFF
--- a/client/src/app/core/services/search-state.service.ts
+++ b/client/src/app/core/services/search-state.service.ts
@@ -54,6 +54,17 @@ export class SearchStateService {
   /** True once a discover query has been applied (rows → results grid). */
   readonly discoverActive = signal(false);
 
+  /** Any narrowing filter is set (genre / rating / year). Sort alone doesn't
+   *  count — it only reorders an already-filtered or queried set. Drives the
+   *  auto-apply and the single Clear button. */
+  readonly filtersEngaged = computed(
+    () =>
+      this.discoverSelectedGenres().size > 0 ||
+      this.discoverVoteMin() > 0 ||
+      this.discoverYearMin() != null ||
+      this.discoverYearMax() != null,
+  );
+
   /** Names of the selected discover genres (panel selects TMDB ids; results
    *  carry genre names). Used to post-filter external results by name. */
   readonly selectedGenreNames = computed(() => {

--- a/client/src/app/features/search/search.html
+++ b/client/src/app/features/search/search.html
@@ -82,22 +82,19 @@
       <p class="text-base-content/50 text-center py-12">{{ (state.hasQuery() ? 'social.no_people_results' : 'search.discover_people_hint') | translate }}</p>
     }
   } @else if (!state.hasQuery()) {
-    @if (state.externalEnabled()) {
-      <!-- Discover: filter sidebar (desktop) + rows / results grid -->
-      <div class="flex gap-6">
-        <aside class="hidden lg:block w-60 shrink-0">
-          <ng-container *ngTemplateOutlet="filterPanel" />
-        </aside>
-        <div class="flex-1 min-w-0">
-          <button type="button" class="lg:hidden btn btn-sm btn-outline gap-2 mb-4" (click)="openFilterSheet()">
-            <svg lucideSettings class="h-4 w-4"></svg>{{ 'search.filters' | translate }}
-          </button>
+    <!-- Discover / library browse: filter sidebar (desktop) + content -->
+    <div class="flex gap-6">
+      <aside class="hidden lg:block w-60 shrink-0">
+        <ng-container *ngTemplateOutlet="filterPanel" />
+      </aside>
+      <div class="flex-1 min-w-0">
+        <button type="button" class="lg:hidden btn btn-sm btn-outline gap-2 mb-4" (click)="openFilterSheet()">
+          <svg lucideSettings class="h-4 w-4"></svg>{{ 'search.filters' | translate }}
+        </button>
 
-          @if (state.discoverActive()) {
-            <div class="flex items-center gap-3 mb-3">
-              <h2 class="text-lg font-bold">{{ 'search.discover_results' | translate }}</h2>
-              <button type="button" class="btn btn-ghost btn-xs" (click)="clearDiscover()">{{ 'search.clear' | translate }}</button>
-            </div>
+        @if (state.discoverActive()) {
+          <!-- Filters applied → results grid (TMDB discover, or the local library when external search is off) -->
+          @if (state.externalEnabled()) {
             @if (state.discoverLoading()) {
               <div class="flex justify-center py-12"><span class="loading loading-spinner loading-lg"></span></div>
             } @else if (state.discoverResults().length) {
@@ -110,6 +107,27 @@
               <p class="text-base-content/50 text-center py-12">{{ 'search.no_results' | translate }}</p>
             }
           } @else {
+            @if (state.localLoading()) {
+              <div class="flex justify-center py-12"><span class="loading loading-spinner loading-lg"></span></div>
+            } @else if (state.localResults().length) {
+              <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 gap-3 sm:gap-4">
+                @for (media of state.localResults(); track media.id) {
+                  <app-media-card
+                    [media]="media"
+                    [status]="media.watched ? 'watched' : null"
+                    [progressPercent]="media.watched ? 0 : (media.progressPercent ?? 0)"
+                    [interactiveWatched]="canMarkMediaWatched(media)"
+                    (watchedToggled)="toggleMediaWatched(media, $event)"
+                  />
+                }
+              </div>
+            } @else {
+              <p class="text-base-content/50 text-center py-12">{{ 'search.no_results' | translate }}</p>
+            }
+          }
+        } @else {
+          <!-- No filters → discovery rows -->
+          @if (state.externalEnabled()) {
             @if (state.discoveryLoading() && !state.discoveryTrending().length && !state.discoveryPopular().length && !state.discoverySuggestions().length) {
               <div class="flex justify-center py-12"><span class="loading loading-spinner loading-lg"></span></div>
             }
@@ -140,21 +158,20 @@
                 </app-horizontal-scroller>
               }
             </div>
+          } @else {
+            @if (state.discoveryRecommendations().length) {
+              <app-horizontal-scroller [title]="'search.discover_suggestions' | translate" class="block">
+                @for (rec of state.discoveryRecommendations(); track rec.media.id) {
+                  <app-media-card class="shrink-0 w-28 sm:w-32 lg:w-40" [imageUrl]="rec.media.posterUrl" [title]="rec.media.title" [subtitle]="'' + (rec.media.year ?? '')" [link]="recLink(rec)" [status]="rec.media.available ? null : 'missing'" [playable]="rec.media.available" />
+                }
+              </app-horizontal-scroller>
+            } @else {
+              <p class="text-base-content/50 text-center py-12">{{ 'search.hint_local' | translate }}</p>
+            }
           }
-        </div>
+        }
       </div>
-    } @else {
-      <!-- External search off: local suggestions only -->
-      @if (state.discoveryRecommendations().length) {
-        <app-horizontal-scroller [title]="'search.discover_suggestions' | translate" class="block">
-          @for (rec of state.discoveryRecommendations(); track rec.media.id) {
-            <app-media-card class="shrink-0 w-28 sm:w-32 lg:w-40" [imageUrl]="rec.media.posterUrl" [title]="rec.media.title" [subtitle]="'' + (rec.media.year ?? '')" [link]="recLink(rec)" [status]="rec.media.available ? null : 'missing'" [playable]="rec.media.available" />
-          }
-        </app-horizontal-scroller>
-      } @else {
-        <p class="text-base-content/50 text-center py-12">{{ 'search.hint_local' | translate }}</p>
-      }
-    }
+    </div>
   } @else {
     <!-- Text-search results: filter sidebar (desktop) + results column -->
     <div class="flex gap-6">
@@ -316,12 +333,9 @@
       </div>
     </div>
 
-    @if (!state.hasQuery()) {
-      <div class="flex gap-2 pt-1">
-        <button type="button" class="btn btn-primary btn-sm flex-1" (click)="applyDiscover()">{{ 'search.apply' | translate }}</button>
-        @if (state.discoverActive() || state.discoverSelectedGenres().size) {
-          <button type="button" class="btn btn-ghost btn-sm" (click)="clearDiscover()">{{ 'search.clear' | translate }}</button>
-        }
+    @if (state.filtersEngaged()) {
+      <div class="pt-1">
+        <button type="button" class="btn btn-ghost btn-sm w-full" (click)="clearDiscover()">{{ 'search.clear' | translate }}</button>
       </div>
     }
   </div>

--- a/client/src/app/features/search/search.html
+++ b/client/src/app/features/search/search.html
@@ -110,7 +110,7 @@
             @if (state.localLoading()) {
               <div class="flex justify-center py-12"><span class="loading loading-spinner loading-lg"></span></div>
             } @else if (state.localResults().length) {
-              <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 gap-3 sm:gap-4">
+              <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 3xl:grid-cols-8 gap-3 sm:gap-4">
                 @for (media of state.localResults(); track media.id) {
                   <app-media-card
                     [media]="media"
@@ -191,7 +191,7 @@
         } @else if (state.localResults().length > 0 || state.ownedExternalResults().length > 0) {
           <div>
             <h2 class="text-lg font-semibold mb-3">{{ 'search.section_library' | translate }}</h2>
-            <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 gap-3 sm:gap-4">
+            <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 3xl:grid-cols-8 gap-3 sm:gap-4">
               @for (media of state.localResults(); track media.id) {
                 <app-media-card
                   [media]="media"
@@ -224,7 +224,7 @@
         } @else if (state.filteredExternalResults().length > 0) {
           <div>
             <h2 class="text-lg font-semibold mb-3">{{ 'search.section_discover' | translate }}</h2>
-            <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 gap-3 sm:gap-4">
+            <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 3xl:grid-cols-8 gap-3 sm:gap-4">
               @for (row of state.filteredExternalResults(); track row.tmdbId) {
                 <app-media-card
                   [imageUrl]="row.posterUrl"

--- a/client/src/app/features/search/search.html
+++ b/client/src/app/features/search/search.html
@@ -17,7 +17,7 @@
         (blur)="onInputBlur()"
       />
       @if (state.hasQuery()) {
-        <button type="button" class="btn btn-ghost btn-circle btn-sm absolute right-1 top-1/2 -translate-y-1/2" (click)="clearQuery()">
+        <button type="button" class="btn btn-ghost btn-circle btn-sm absolute right-1 top-1/2 -translate-y-1/2 z-10" (click)="clearQuery()">
           <svg lucideX class="h-4 w-4"></svg>
         </button>
       }

--- a/client/src/app/features/search/search.html
+++ b/client/src/app/features/search/search.html
@@ -7,6 +7,7 @@
         #searchInput
         type="text"
         enterkeyhint="search"
+        data-tv-skip-spatial
         class="input input-bordered w-full pl-10 pr-10"
         [placeholder]="'search.placeholder' | translate"
         [ngModel]="state.query()"

--- a/client/src/app/features/search/search.ts
+++ b/client/src/app/features/search/search.ts
@@ -128,11 +128,9 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
     untracked(() => void this.ensureDiscoverGenres());
   });
 
-  /** Live-apply the discover panel filters to the local (backend) search while a
-   *  text query is active. Debounced; the run is untracked so its writes can't
-   *  feed back. Only the local search re-runs — external results re-filter
-   *  reactively via the state computeds (no TMDB refetch). Skips when the query
-   *  already reflects these filters (e.g. a content-type switch ran directly). */
+  /** Auto-apply the discover panel filters (debounced) — no explicit apply
+   *  button. The run is untracked so its writes can't feed back into the effect.
+   *  See applyFiltersNow for what each state does. */
   private readonly liveFilterEffect = effect(() => {
     this.state.discoverSelectedGenres();
     this.state.discoverSort();
@@ -140,14 +138,37 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
     this.state.discoverYearMin();
     this.state.discoverYearMax();
     untracked(() => {
-      if (!this.state.hasQuery()) return;
-      const q = this.state.query().trim();
-      const ct = this.state.contentType();
-      if (this.filterSig(q, ct) === this.lastLocalSig) return;
+      if (this.state.tab() !== 'videos') return;
       if (this.filterDebounce) clearTimeout(this.filterDebounce);
-      this.filterDebounce = setTimeout(() => void this.runLocalSearch(q, ct), 300);
+      this.filterDebounce = setTimeout(() => void this.applyFiltersNow(), 300);
     });
   });
+
+  /** Apply the current filters to the right source:
+   *  - text query  → the local library query (external post-filters reactively);
+   *  - no query + filters + external on  → TMDB /discover;
+   *  - no query + filters + external off → filtered local library browse;
+   *  - no query + no filters → back to the discovery rows. */
+  private async applyFiltersNow(): Promise<void> {
+    if (this.state.tab() !== 'videos') return;
+    const ct = this.state.contentType();
+    if (this.state.hasQuery()) {
+      const q = this.state.query().trim();
+      if (this.filterSig(q, ct) !== this.lastLocalSig) await this.runLocalSearch(q, ct);
+      return;
+    }
+    if (!this.state.filtersEngaged()) {
+      this.state.discoverActive.set(false);
+      this.state.discoverResults.set([]);
+      return;
+    }
+    if (this.state.externalEnabled()) {
+      await this.applyDiscover();
+    } else {
+      this.state.discoverActive.set(true);
+      await this.runLocalSearch('', ct);
+    }
+  }
 
   readonly requestedTmdbIds = signal<Map<number, FliksRequestStatus>>(new Map());
 
@@ -258,6 +279,8 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
       this.state.externalResults.set([]);
       this.state.localLoading.set(false);
       this.state.externalLoading.set(false);
+      // An engaged filter keeps browsing (discover / local) with no text query.
+      void this.applyFiltersNow();
     }
   }
 
@@ -285,15 +308,19 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
 
   toggleExternal() {
     this.state.externalEnabled.update(v => !v);
-    if (this.state.externalEnabled()) {
-      // Re-run search to fetch external results
-      if (this.state.query().trim()) {
+    const on = this.state.externalEnabled();
+    if (!on) {
+      this.state.externalResults.set([]);
+      this.state.externalLoading.set(false);
+    }
+    if (this.state.query().trim()) {
+      if (on) {
         if (this.searchTimer) clearTimeout(this.searchTimer);
         this.runSearch();
       }
     } else {
-      this.state.externalResults.set([]);
-      this.state.externalLoading.set(false);
+      // Discover mode: switch the filter source (TMDB /discover ↔ local browse).
+      void this.applyFiltersNow();
     }
   }
 

--- a/client/src/app/features/search/search.ts
+++ b/client/src/app/features/search/search.ts
@@ -322,6 +322,7 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
       }
     } else {
       // Discover mode: switch the filter source (TMDB /discover ↔ local browse).
+      if (this.filterDebounce) clearTimeout(this.filterDebounce);
       void this.applyFiltersNow();
     }
   }
@@ -619,10 +620,6 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
 
   openFilterSheet() {
     this.filterSheet()?.nativeElement.showModal();
-  }
-
-  closeFilterSheet() {
-    this.filterSheet()?.nativeElement.close();
   }
 
   /** Series toggle via the bulk endpoint; movies need a local file. */

--- a/client/src/app/features/search/search.ts
+++ b/client/src/app/features/search/search.ts
@@ -125,6 +125,7 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly discoverGenreEffect = effect(() => {
     this.state.tab();
     this.state.contentType();
+    this.state.externalEnabled();
     untracked(() => void this.ensureDiscoverGenres());
   });
 
@@ -280,6 +281,7 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
       this.state.localLoading.set(false);
       this.state.externalLoading.set(false);
       // An engaged filter keeps browsing (discover / local) with no text query.
+      if (this.filterDebounce) clearTimeout(this.filterDebounce);
       void this.applyFiltersNow();
     }
   }
@@ -327,6 +329,10 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
   clearQuery() {
     this.state.clear();
     this.searchInput()?.nativeElement.focus();
+    // Clearing the query isn't tracked by liveFilterEffect, so re-apply any
+    // engaged filter (browse) instead of dropping to unfiltered discovery rows.
+    if (this.filterDebounce) clearTimeout(this.filterDebounce);
+    void this.applyFiltersNow();
   }
 
   avatar(name: string) {
@@ -366,7 +372,8 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
       if (!external) {
         this.state.discoveryTrending.set([]);
         this.state.discoveryPopular.set([]);
-        this.state.discoverGenres.set([]);
+        // Keep discoverGenres — the filter panel's genre chips + name mapping
+        // are needed for the local-library browse when external search is off.
         this.state.discoverySuggestions.set([]);
         return;
       }
@@ -520,9 +527,11 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   /** Run the TMDB /discover query from the current panel filters and switch
-   *  the content area to the results grid. */
+   *  the content area to the results grid. Stale responses (a later filter
+   *  change superseded this one) are dropped. */
   async applyDiscover() {
     const ct = this.state.contentType();
+    const sig = (this.lastDiscoverSig = this.filterSig('', ct));
     const opts: DiscoverFilters = {
       genreIds: [...this.state.discoverSelectedGenres()],
       sort: this.state.discoverSort(),
@@ -532,32 +541,35 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
     };
     this.state.discoverActive.set(true);
     this.state.discoverLoading.set(true);
-    this.closeFilterSheet();
+    const fresh = () => this.lastDiscoverSig === sig;
     try {
       const rows =
         ct === 'series'
           ? await this.metadata.discoverTv(opts)
           : await this.metadata.discoverMovies(opts);
-      this.state.discoverResults.set(rows);
-      this.loadRequestedIds();
+      if (fresh()) {
+        this.state.discoverResults.set(rows);
+        this.loadRequestedIds();
+      }
     } catch {
-      this.state.discoverResults.set([]);
+      if (fresh()) this.state.discoverResults.set([]);
     } finally {
-      this.state.discoverLoading.set(false);
+      if (fresh()) this.state.discoverLoading.set(false);
     }
   }
+  private lastDiscoverSig = '';
 
   clearDiscover() {
     this.state.resetDiscover();
   }
 
-  /** Preload the discover grid on a genre id (resolved by the caller — a
-   *  profile taste chip — so it's language-proof). */
-  private async applyGenreFilter(genreId: number): Promise<void> {
+  /** Preload the discover panel on a genre id (resolved by the caller — a
+   *  profile taste chip — so it's language-proof). The filter auto-applies via
+   *  liveFilterEffect, routed to the right source by the external toggle. */
+  private applyGenreFilter(genreId: number): void {
     this.state.tab.set('videos');
     this.state.query.set('');
     this.state.discoverSelectedGenres.set(new Set([genreId]));
-    await this.applyDiscover();
   }
 
   /** Map the panel sort to the local sortBy/sortOrder, or null for the default
@@ -672,7 +684,10 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
    *  (q + genres + year + rating + sort). Re-run standalone on a filter change. */
   private async runLocalSearch(q: string, ct: 'all' | 'movie' | 'series') {
     const sig = (this.lastLocalSig = this.filterSig(q, ct));
-    void this.ensureDiscoverGenres();
+    // Selected genres are mapped to names via the loaded genre list; wait for it
+    // when a genre is selected so the filter isn't silently dropped.
+    if (this.state.discoverSelectedGenres().size) await this.ensureDiscoverGenres();
+    else void this.ensureDiscoverGenres();
     const type: MediaType | undefined = ct === 'all' ? undefined : ct;
     const sort = this.mapPanelSort();
     const localParams: SearchParams = { q, limit: 20, sortBy: sort?.sortBy ?? 'title' };


### PR DESCRIPTION
## What

Refines the search filter panel:
- **Auto-apply**: the "Rechercher" apply button is gone — filters apply automatically (debounced) in every state. A single **Clear** button lives in the panel.
- **Works without external search**: with no text query, an engaged filter (genre / year / rating) browses TMDB `/discover` when external search is on, and the **local library** (backend-filtered) when it's off. No filter → the discovery rows, as before.
- **Consistent card size**: all result grids now share the discovery column counts, so cards no longer shrink when you start typing.
- **Caret stays put**: the search input owns left/right arrows (caret movement) instead of the arrow escaping to spatial nav and jumping focus to the clear (X) button mid-typing; up/down still leave the field.

## Adversarial review

Built and hardened across two adversarial review rounds (14 findings total surfaced, all confirmed ones fixed):
- **[high]** genre filter silently dropped with external search off (genre list was cleared / not name-resolved) → keep the list loaded, track the toggle, await it before mapping selected genres.
- stale `/discover` responses dropped (fresh guard); the X-clear path re-applies filters; the profile taste-chip deep link routes through the auto-apply path; direct query/toggle changes clear the filter debounce (no duplicate fetch); removed dead code.

## Known limitation (pre-existing, low)

In the **"All"** tab, a TV-only genre (a genre absent from the movie taxonomy, e.g. Reality) doesn't map, so it filters nothing there — the same movie-centric taxonomy limitation the discover panel already had. Use the Movies / Series tabs for precise genre filtering.

## Testing

Client `tsc` clean; all four result grids verified identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)