### PR TITLE
fix(i18n): rename the auto language option to System

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -189,7 +189,7 @@
     "home_background": "Hintergrundbild auf der Startseite",
     "home_background_hint": "Zeigt ein Poster im Vollbild hinter den Bereichen der Startseite an.",
     "language": "App-Sprache",
-    "language_auto": "Automatisch (Browsersprache)",
+    "language_auto": "System",
     "language_hint": "Sprache der Oberfläche. Standardmäßig die deines Browsers oder Systems."
   },
   "storage_settings": {

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -189,7 +189,7 @@
     "home_background": "Background image on home",
     "home_background_hint": "Shows a full-screen poster behind the home sections.",
     "language": "Application language",
-    "language_auto": "Automatic (browser language)",
+    "language_auto": "System",
     "language_hint": "Interface language. Defaults to your browser or system language."
   },
   "storage_settings": {

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -189,7 +189,7 @@
     "home_background": "Imagen de fondo en el inicio",
     "home_background_hint": "Muestra un póster a pantalla completa detrás de las secciones del inicio.",
     "language": "Idioma de la aplicación",
-    "language_auto": "Automático (idioma del navegador)",
+    "language_auto": "Sistema",
     "language_hint": "Idioma de la interfaz. Por defecto, el de tu navegador o sistema."
   },
   "storage_settings": {

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -189,7 +189,7 @@
     "home_background": "Image de fond sur l'accueil",
     "home_background_hint": "Affiche une affiche en plein écran derrière les sections de l'accueil.",
     "language": "Langue de l'application",
-    "language_auto": "Automatique (langue du navigateur)",
+    "language_auto": "Système",
     "language_hint": "Langue de l'interface. Par défaut, celle de votre navigateur ou de votre système."
   },
   "storage_settings": {

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -189,7 +189,7 @@
     "home_background": "Immagine di sfondo nella home",
     "home_background_hint": "Mostra un poster a schermo intero dietro le sezioni della home.",
     "language": "Lingua dell'app",
-    "language_auto": "Automatico (lingua del browser)",
+    "language_auto": "Sistema",
     "language_hint": "Lingua dell'interfaccia. Per impostazione predefinita, quella del browser o del sistema."
   },
   "storage_settings": {

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -189,7 +189,7 @@
     "home_background": "Imagem de fundo no início",
     "home_background_hint": "Mostra um poster em ecrã inteiro atrás das secções do início.",
     "language": "Idioma da aplicação",
-    "language_auto": "Automático (idioma do navegador)",
+    "language_auto": "Sistema",
     "language_hint": "Idioma da interface. Por predefinição, o do seu navegador ou sistema."
   },
   "storage_settings": {


### PR DESCRIPTION
Renames the Display language "auto" option from "Automatique (langue du navigateur)" to **System** (localized: Système / System / Sistema) across all six locale files. It follows the browser/OS language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)