### PR TITLE
style(history): match the page title size to other pages

### DIFF
--- a/client/src/app/features/watch-history/watch-history.html
+++ b/client/src/app/features/watch-history/watch-history.html
@@ -1,5 +1,5 @@
 <div class="flex min-w-0 max-w-full flex-col gap-3">
-  <h1 class="sr-only lg:not-sr-only text-xl font-bold">{{ 'history.title' | translate }}</h1>
+  <h1 class="sr-only lg:not-sr-only text-2xl font-bold">{{ 'history.title' | translate }}</h1>
 
   @if (loading()) {
     <div class="flex justify-center py-12">


### PR DESCRIPTION
The watch-history page title used `text-xl` while other pages use `text-2xl`, making it smaller on desktop. Aligned to `text-2xl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)