### PR TITLE
feat(user-menu): show the user's avatar as the header menu trigger

### DIFF
--- a/client/src/app/shared/components/user-menu.ts
+++ b/client/src/app/shared/components/user-menu.ts
@@ -40,7 +40,7 @@ import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
         @if (auth.user(); as user) {
           <div class="avatar avatar-placeholder">
             <div
-              class="w-7 h-7 md:w-8 md:h-8 rounded-full border-2 border-white/40 text-white text-xs font-semibold"
+              class="w-7 h-7 md:w-9 md:h-9 rounded-full border border-primary/40 text-white text-xs font-semibold"
               [style.background-color]="'hsl(' + avatar(user.username).hue + ' 55% 45%)'"
             >
               @if (user.avatar) {
@@ -62,7 +62,7 @@ import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
           >
             <div class="avatar avatar-placeholder shrink-0">
               <div
-                class="w-10 h-10 rounded-full text-white text-sm font-semibold"
+                class="w-8 h-8 rounded-full text-white text-sm font-semibold"
                 [style.background-color]="'hsl(' + avatar(user.username).hue + ' 55% 45%)'"
               >
                 @if (user.avatar) {

--- a/client/src/app/shared/components/user-menu.ts
+++ b/client/src/app/shared/components/user-menu.ts
@@ -37,7 +37,22 @@ import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
         class="btn btn-ghost btn-circle"
         [attr.aria-label]="'nav.user_menu' | translate"
       >
-        <svg lucideUser class="h-5 w-5 md:h-6 md:w-6"></svg>
+        @if (auth.user(); as user) {
+          <div class="avatar avatar-placeholder">
+            <div
+              class="w-8 h-8 md:w-9 md:h-9 rounded-full text-white text-xs font-semibold"
+              [style.background-color]="'hsl(' + avatar(user.username).hue + ' 55% 45%)'"
+            >
+              @if (user.avatar) {
+                <img [src]="user.avatar | resolveUrl" [alt]="user.username" />
+              } @else {
+                <span>{{ avatar(user.username).initials }}</span>
+              }
+            </div>
+          </div>
+        } @else {
+          <svg lucideUser class="h-5 w-5 md:h-6 md:w-6"></svg>
+        }
       </button>
       @if (auth.user(); as user) {
         <div class="border-b border-white/10 pb-1 mb-1">

--- a/client/src/app/shared/components/user-menu.ts
+++ b/client/src/app/shared/components/user-menu.ts
@@ -40,7 +40,7 @@ import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
         @if (auth.user(); as user) {
           <div class="avatar avatar-placeholder">
             <div
-              class="w-8 h-8 md:w-9 md:h-9 rounded-full text-white text-xs font-semibold"
+              class="w-7 h-7 md:w-8 md:h-8 rounded-full border-2 border-white/40 text-white text-xs font-semibold"
               [style.background-color]="'hsl(' + avatar(user.username).hue + ' 55% 45%)'"
             >
               @if (user.avatar) {


### PR DESCRIPTION
The header user-menu dropdown trigger showed a generic user icon. It now shows the user's **avatar** (their image, or initials fallback — same rendering as the dropdown header), falling back to the icon when no user is loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)