### PR TITLE
style(layout): widen topbar action gap on desktop

### DIFF
--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -128,7 +128,7 @@
         }
       </div>
       <!-- Cast + user (right) -->
-      <div class="flex items-center gap-1.5">
+      <div class="flex items-center gap-1.5 md:gap-2">
         @if (appUpdate.available()) {
           <button class="btn btn-ghost btn-circle" (click)="openUpdateModal()"
                   [attr.aria-label]="'update.title' | translate">


### PR DESCRIPTION
Widen the spacing between the topbar action buttons (update / cast / user menu) from md and up so the avatar trigger has a bit more breathing room next to the cast button on desktop.