### PR TITLE
fix(profile): set the browser tab title to the profile name

### DIFF
--- a/client/src/app/features/profile/profile.ts
+++ b/client/src/app/features/profile/profile.ts
@@ -88,8 +88,15 @@ export class ProfileComponent {
       const id = this.userId();
       if (Number.isFinite(id) && id > 0) void this.ctx.load(id);
     });
+    effect(() => {
+      const name = this.profile()?.username;
+      if (name) this.navbar.setPageTitle(name);
+    });
     this.navbar.showBackButton.set(true);
-    this.destroyRef.onDestroy(() => this.navbar.showBackButton.set(false));
+    this.destroyRef.onDestroy(() => {
+      this.navbar.showBackButton.set(false);
+      this.navbar.clearPageTitle();
+    });
   }
 
   async follow(): Promise<void> {


### PR DESCRIPTION
The profile page never set a page title, so the browser tab kept whatever the previous page left behind. Set it to the profile's username once the aggregate loads (via NavbarService, like the library page), and clear it on destroy so it doesn't leak into the next route.