### PR TITLE
style(layout): widen topbar action gap further on desktop

### DIFF
--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -128,7 +128,7 @@
         }
       </div>
       <!-- Cast + user (right) -->
-      <div class="flex items-center gap-1.5 md:gap-2">
+      <div class="flex items-center gap-1.5 md:gap-4">
         @if (appUpdate.available()) {
           <button class="btn btn-ghost btn-circle" (click)="openUpdateModal()"
                   [attr.aria-label]="'update.title' | translate">


### PR DESCRIPTION
Bump the desktop spacing between the topbar action buttons (update / cast / user menu) from `md:gap-2` to `md:gap-4` for more breathing room around the avatar trigger.