### PR TITLE
fix(modals): fix clipped close ring and phantom keyboard focus stop

### DIFF
--- a/client/src/app/features/activity/queue/queue.html
+++ b/client/src/app/features/activity/queue/queue.html
@@ -202,13 +202,14 @@
 <!-- Link torrent to media modal -->
 <dialog #linkModal class="modal">
   <div class="modal-box max-w-lg">
-    <form method="dialog">
-      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
-    </form>
-    <h3 class="text-lg font-bold mb-1">{{ 'activity.link_media' | translate }}</h3>
-    @if (linkItem(); as li) {
-      <p class="text-sm text-base-content/60 mb-4 truncate" [title]="li.name">{{ li.name }}</p>
-    }
+    <app-modal-header>
+      <div class="min-w-0">
+        <h3 class="text-lg font-bold">{{ 'activity.link_media' | translate }}</h3>
+        @if (linkItem(); as li) {
+          <p class="text-sm text-base-content/60 truncate" [title]="li.name">{{ li.name }}</p>
+        }
+      </div>
+    </app-modal-header>
 
     <div class="flex gap-2 mb-4">
       <input
@@ -283,7 +284,7 @@
       </button>
     </div>
   </div>
-  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>
 
 <!-- Search a replacement release for a queue item -->

--- a/client/src/app/features/activity/queue/queue.ts
+++ b/client/src/app/features/activity/queue/queue.ts
@@ -41,6 +41,7 @@ import { DropdownMenuComponent } from '../../../shared/components/dropdown-menu'
 import { PaginationComponent } from '../../../shared/components/pagination/pagination';
 import { ReleasesModalComponent } from '../../media-detail/components/releases-modal/releases-modal.component';
 import { ProgressBarComponent } from '../../../shared/components/progress-bar/progress-bar.component';
+import { ModalHeaderComponent } from '../../../shared/components/modal-header';
 import {
   ProgressVariant,
   formatBytes as fmtBytes,
@@ -50,7 +51,7 @@ import {
 
 @Component({
   selector: 'app-activity-queue',
-  imports: [TranslateModule, DecimalPipe, NgClass, RouterLink, FormsModule, ResolveUrlPipe, DropdownMenuComponent, PaginationComponent, ReleasesModalComponent, ProgressBarComponent, LucideRotateCcw, LucideLink2, LucideEllipsisVertical, LucideTriangleAlert, LucideDownload, LucideSearch, LucideTrash2, LucideBan],
+  imports: [TranslateModule, DecimalPipe, NgClass, RouterLink, FormsModule, ResolveUrlPipe, DropdownMenuComponent, PaginationComponent, ReleasesModalComponent, ProgressBarComponent, ModalHeaderComponent, LucideRotateCcw, LucideLink2, LucideEllipsisVertical, LucideTriangleAlert, LucideDownload, LucideSearch, LucideTrash2, LucideBan],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './queue.html',
 })

--- a/client/src/app/features/media-detail/components/media-detail-episode-releases-modal/media-detail-episode-releases-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-episode-releases-modal/media-detail-episode-releases-modal.component.html
@@ -49,5 +49,5 @@
       </form>
     </div>
   </div>
-  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>

--- a/client/src/app/features/media-detail/components/media-detail-library-modal/media-detail-library-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-library-modal/media-detail-library-modal.component.html
@@ -1,9 +1,6 @@
 <dialog #dialog class="modal">
   <div class="modal-box max-w-md">
-    <form method="dialog">
-      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
-    </form>
-    <h3 class="text-lg font-bold mb-4">{{ 'media_detail.library_section' | translate }}</h3>
+    <app-modal-header [title]="'media_detail.library_section' | translate" />
     <form class="flex flex-col gap-4" (ngSubmit)="save.emit()">
       <label class="form-control w-full">
         <span class="label-text">{{ 'media_detail.library_label' | translate }}</span>
@@ -57,5 +54,5 @@
       </div>
     </form>
   </div>
-  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>

--- a/client/src/app/features/media-detail/components/media-detail-library-modal/media-detail-library-modal.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-library-modal/media-detail-library-modal.component.ts
@@ -11,10 +11,11 @@ import { TranslateModule } from '@ngx-translate/core';
 import { LibrarySummary } from '../../../../core/services/api/libraries-api.service';
 import { METADATA_PROVIDER_OPTIONS_OVERRIDE } from '../../../../core/constants/metadata-providers';
 import { TvSelectDirective } from '../../../../shared/directives/tv-select.directive';
+import { ModalHeaderComponent } from '../../../../shared/components/modal-header';
 
 @Component({
   selector: 'app-media-detail-library-modal',
-  imports: [TranslateModule, FormsModule, TvSelectDirective],
+  imports: [TranslateModule, FormsModule, TvSelectDirective, ModalHeaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-library-modal.component.html',
 })

--- a/client/src/app/features/media-detail/components/media-detail-profiles-modal/media-detail-profiles-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-profiles-modal/media-detail-profiles-modal.component.html
@@ -1,9 +1,6 @@
 <dialog #dialog class="modal">
   <div class="modal-box max-w-md">
-    <form method="dialog">
-      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
-    </form>
-    <h3 class="text-lg font-bold mb-4">{{ 'media_detail.profiles_section' | translate }}</h3>
+    <app-modal-header [title]="'media_detail.profiles_section' | translate" />
     @if (profilesOptionsLoading()) {
       <div class="flex justify-center py-8">
         <span class="loading loading-spinner loading-lg"></span>
@@ -60,5 +57,5 @@
       </form>
     }
   </div>
-  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>

--- a/client/src/app/features/media-detail/components/media-detail-profiles-modal/media-detail-profiles-modal.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-profiles-modal/media-detail-profiles-modal.component.ts
@@ -9,10 +9,11 @@ import {
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { TvSelectDirective } from '../../../../shared/directives/tv-select.directive';
+import { ModalHeaderComponent } from '../../../../shared/components/modal-header';
 
 @Component({
   selector: 'app-media-detail-profiles-modal',
-  imports: [TranslateModule, FormsModule, TvSelectDirective],
+  imports: [TranslateModule, FormsModule, TvSelectDirective, ModalHeaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-profiles-modal.component.html',
 })

--- a/client/src/app/features/media-detail/components/media-detail-season-releases-modal/media-detail-season-releases-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-season-releases-modal/media-detail-season-releases-modal.component.html
@@ -33,5 +33,5 @@
       </form>
     </div>
   </div>
-  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>

--- a/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.html
@@ -67,5 +67,5 @@
       <form method="dialog"><button class="btn btn-ghost">{{ 'common.close' | translate }}</button></form>
     </div>
   </div>
-  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>

--- a/client/src/app/features/media-detail/components/media-detail-upgrade-releases-modal/media-detail-upgrade-releases-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-upgrade-releases-modal/media-detail-upgrade-releases-modal.component.html
@@ -32,5 +32,5 @@
       </form>
     </div>
   </div>
-  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>

--- a/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.html
+++ b/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.html
@@ -53,5 +53,5 @@
       </form>
     </div>
   </div>
-  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>

--- a/client/src/app/features/playlists/playlist-detail/playlist-detail.html
+++ b/client/src/app/features/playlists/playlist-detail/playlist-detail.html
@@ -320,15 +320,7 @@
 
 <dialog #renameDialog class="modal">
   <div class="modal-box max-w-md">
-    <form method="dialog">
-      <button
-        class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
-        [attr.aria-label]="'common.close' | translate"
-      >
-        ✕
-      </button>
-    </form>
-    <h3 class="text-lg font-bold mb-4">{{ 'playlists.rename' | translate }}</h3>
+    <app-modal-header [title]="'playlists.rename' | translate" />
     <form class="flex flex-col gap-4" (ngSubmit)="confirmRename()">
       <input
         type="text"
@@ -355,20 +347,12 @@
       </div>
     </form>
   </div>
-  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>
 
 <dialog #settingsDialog class="modal">
   <div class="modal-box max-w-md">
-    <form method="dialog">
-      <button
-        class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
-        [attr.aria-label]="'common.close' | translate"
-      >
-        ✕
-      </button>
-    </form>
-    <h3 class="text-lg font-bold mb-4">{{ 'playlists.settings' | translate }}</h3>
+    <app-modal-header [title]="'playlists.settings' | translate" />
     <div class="flex flex-col gap-4">
       <div class="form-control">
         <label class="label pb-1">
@@ -422,16 +406,17 @@
       </button>
     </div>
   </div>
-  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>
 
 <dialog #membersDialog class="modal">
   <div class="modal-box max-w-md">
-    <form method="dialog">
-      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" [attr.aria-label]="'common.close' | translate">✕</button>
-    </form>
-    <h3 class="text-lg font-bold mb-1">{{ 'playlists.members' | translate }}</h3>
-    <p class="text-sm text-base-content/60 mb-4">{{ 'playlists.members_hint' | translate }}</p>
+    <app-modal-header>
+      <div>
+        <h3 class="text-lg font-bold">{{ 'playlists.members' | translate }}</h3>
+        <p class="text-sm text-base-content/60">{{ 'playlists.members_hint' | translate }}</p>
+      </div>
+    </app-modal-header>
 
     <!-- Current members -->
     <ul class="flex flex-col gap-1 mb-4">
@@ -483,5 +468,5 @@
       </ul>
     }
   </div>
-  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>

--- a/client/src/app/features/playlists/playlist-detail/playlist-detail.ts
+++ b/client/src/app/features/playlists/playlist-detail/playlist-detail.ts
@@ -40,6 +40,7 @@ import {
 } from '@lucide/angular';
 import { ToggleFieldComponent } from '../../../shared/components/forms/toggle-field/toggle-field';
 import { DropdownMenuComponent } from '../../../shared/components/dropdown-menu';
+import { ModalHeaderComponent } from '../../../shared/components/modal-header';
 import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 import { StreamingApiService } from '../../../core/services/api/streaming-api.service';
 import { BackgroundService } from '../../../core/services/background.service';
@@ -102,6 +103,7 @@ type PlaylistGroupedEntry =
     LucideBookmarkCheck,
     ToggleFieldComponent,
     DropdownMenuComponent,
+    ModalHeaderComponent,
     ResolveUrlPipe,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/client/src/app/features/playlists/playlists.html
+++ b/client/src/app/features/playlists/playlists.html
@@ -35,15 +35,7 @@
 
 <dialog #createDialog class="modal">
   <div class="modal-box max-w-md">
-    <form method="dialog">
-      <button
-        class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
-        [attr.aria-label]="'common.close' | translate"
-      >
-        ✕
-      </button>
-    </form>
-    <h3 class="text-lg font-bold mb-4">{{ 'playlists.create' | translate }}</h3>
+    <app-modal-header [title]="'playlists.create' | translate" />
     <form class="flex flex-col gap-4" (ngSubmit)="create()">
       <input
         type="text"
@@ -71,5 +63,5 @@
       </div>
     </form>
   </div>
-  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>

--- a/client/src/app/features/playlists/playlists.ts
+++ b/client/src/app/features/playlists/playlists.ts
@@ -14,6 +14,7 @@ import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { LucidePlus } from '@lucide/angular';
 import { MosaicCardComponent } from '../../shared/components/mosaic-card/mosaic-card';
+import { ModalHeaderComponent } from '../../shared/components/modal-header';
 import {
   Playlist,
   PlaylistsApiService,
@@ -23,7 +24,13 @@ import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
 
 @Component({
   selector: 'app-playlists',
-  imports: [MosaicCardComponent, TranslateModule, FormsModule, LucidePlus],
+  imports: [
+    MosaicCardComponent,
+    TranslateModule,
+    FormsModule,
+    LucidePlus,
+    ModalHeaderComponent,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './playlists.html',
 })

--- a/client/src/app/features/search/search.html
+++ b/client/src/app/features/search/search.html
@@ -259,10 +259,10 @@
 <!-- Mobile filter sheet — top-level so it opens during discovery and search alike -->
 <dialog #filterSheet class="modal">
   <div class="modal-box">
-    <form method="dialog"><button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" [attr.aria-label]="'common.close' | translate">✕</button></form>
+    <app-modal-header />
     <ng-container *ngTemplateOutlet="filterPanel" />
   </div>
-  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>
 
 <!-- Discover filter panel — projected into the desktop sidebar and the mobile sheet -->

--- a/client/src/app/features/search/search.ts
+++ b/client/src/app/features/search/search.ts
@@ -38,13 +38,14 @@ import { MediaCardComponent, CardBadge } from '../../shared/components/media-car
 import { HorizontalScrollerComponent } from '../../shared/components/horizontal-scroller';
 import { DropdownMenuComponent } from '../../shared/components/dropdown-menu';
 import { NgTemplateOutlet } from '@angular/common';
+import { ModalHeaderComponent } from '../../shared/components/modal-header';
 import { LucideSearch, LucideX, LucideSettings } from '@lucide/angular';
 import { Capacitor } from '@capacitor/core';
 import { Keyboard } from '@capacitor/keyboard';
 
 @Component({
   selector: 'app-search',
-  imports: [FormsModule, TranslateModule, RouterLink, NgTemplateOutlet, MediaCardComponent, HorizontalScrollerComponent, DropdownMenuComponent, LucideSearch, LucideX, LucideSettings, ResolveUrlPipe],
+  imports: [FormsModule, TranslateModule, RouterLink, NgTemplateOutlet, MediaCardComponent, HorizontalScrollerComponent, DropdownMenuComponent, LucideSearch, LucideX, LucideSettings, ResolveUrlPipe, ModalHeaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './search.html',
 })

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-modal/orphan-scan-modal.html
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-modal/orphan-scan-modal.html
@@ -1,17 +1,19 @@
 <dialog #dialog class="modal">
   <div class="modal-box max-w-3xl flex flex-col max-h-[85vh] overflow-hidden">
-    <button type="button" class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
-      (click)="close()" [attr.aria-label]="'common.close' | translate">✕</button>
-
     <!-- Header (fixed) -->
     <div class="shrink-0">
-      <h2 class="text-lg font-bold">{{ 'settings.libraries.scan_title' | translate }}</h2>
+      <app-modal-header>
+        <div>
+          <h2 class="text-lg font-bold">{{ 'settings.libraries.scan_title' | translate }}</h2>
+          @if (!scanning() && !scanError()) {
+            <p class="text-sm text-base-content/60 mt-1">
+              {{ 'settings.libraries.scan_orphan_count' | translate: { count: orphanCount() } }}
+            </p>
+          }
+        </div>
+      </app-modal-header>
 
       @if (!scanning() && !scanError()) {
-        <p class="text-sm text-base-content/60 mt-1">
-          {{ 'settings.libraries.scan_orphan_count' | translate: { count: orphanCount() } }}
-        </p>
-
         @if (hasLinkable()) {
           <div class="flex items-center justify-between gap-3 mt-4">
             <label class="label cursor-pointer justify-start gap-3 max-w-max">

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-modal/orphan-scan-modal.ts
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-modal/orphan-scan-modal.ts
@@ -22,6 +22,7 @@ import {
   ImportsApiService,
   OrphanGroup,
 } from '../../../../../core/services/api/imports-api.service';
+import { ModalHeaderComponent } from '../../../../../shared/components/modal-header';
 
 interface GroupVM {
   group: OrphanGroup;
@@ -47,6 +48,7 @@ interface GroupVM {
     ResolveUrlPipe,
     LucideChevronsDownUp,
     LucideChevronsUpDown,
+    ModalHeaderComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './orphan-scan-modal.html',

--- a/client/src/app/features/tmdb-preview/tmdb-preview.html
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.html
@@ -316,7 +316,7 @@
       }
     </div>
   </div>
-  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>
 
 <app-request-modal

--- a/client/src/app/shared/components/add-to-playlist-modal/add-to-playlist-modal.component.html
+++ b/client/src/app/shared/components/add-to-playlist-modal/add-to-playlist-modal.component.html
@@ -1,16 +1,6 @@
 <dialog #dialog class="modal">
   <div class="modal-box max-w-md">
-    <form method="dialog">
-      <button
-        class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
-        [attr.aria-label]="'common.close' | translate"
-      >
-        ✕
-      </button>
-    </form>
-    <h3 class="text-lg font-bold mb-4">
-      {{ 'playlists.add_to_playlist_title' | translate }}
-    </h3>
+    <app-modal-header [title]="'playlists.add_to_playlist_title' | translate" />
 
     @if (loading()) {
       <div class="flex justify-center py-8">
@@ -73,5 +63,5 @@
       </div>
     }
   </div>
-  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>

--- a/client/src/app/shared/components/add-to-playlist-modal/add-to-playlist-modal.component.ts
+++ b/client/src/app/shared/components/add-to-playlist-modal/add-to-playlist-modal.component.ts
@@ -17,6 +17,7 @@ import {
 } from '../../../core/services/api/playlists-api.service';
 import { ToastService } from '../../../core/services/toast.service';
 import { AutoDownloadService } from '../../../core/services/auto-download.service';
+import { ModalHeaderComponent } from '../modal-header';
 
 /**
  * Small dialog to add a media to an existing playlist or create a new one on
@@ -26,7 +27,13 @@ import { AutoDownloadService } from '../../../core/services/auto-download.servic
  */
 @Component({
   selector: 'app-add-to-playlist-modal',
-  imports: [FormsModule, TranslateModule, LucideListPlus, LucidePlus],
+  imports: [
+    FormsModule,
+    TranslateModule,
+    LucideListPlus,
+    LucidePlus,
+    ModalHeaderComponent,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './add-to-playlist-modal.component.html',
 })

--- a/client/src/app/shared/components/app-update-modal/app-update-modal.html
+++ b/client/src/app/shared/components/app-update-modal/app-update-modal.html
@@ -1,13 +1,11 @@
 <dialog #dialog class="modal">
   <div class="modal-box max-w-lg">
-    <form method="dialog">
-      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
-    </form>
-
-    <div class="flex items-center gap-2 mb-1">
-      <svg lucideRocket class="h-5 w-5 text-primary"></svg>
-      <h3 class="text-lg font-bold">{{ 'update.title' | translate }}</h3>
-    </div>
+    <app-modal-header>
+      <div class="flex items-center gap-2">
+        <svg lucideRocket class="h-5 w-5 text-primary"></svg>
+        <h3 class="text-lg font-bold">{{ 'update.title' | translate }}</h3>
+      </div>
+    </app-modal-header>
 
     @if (update.info(); as info) {
       <p class="text-sm opacity-70 mb-3">

--- a/client/src/app/shared/components/app-update-modal/app-update-modal.ts
+++ b/client/src/app/shared/components/app-update-modal/app-update-modal.ts
@@ -11,13 +11,14 @@ import { TranslateModule } from '@ngx-translate/core';
 import { LucideDownload, LucideExternalLink, LucideRocket } from '@lucide/angular';
 import { AppUpdateService } from '../../../core/services/app-update.service';
 import { MarkdownPipe } from '../../pipes/markdown.pipe';
+import { ModalHeaderComponent } from '../modal-header';
 
 /** Changelog + install dialog for the topbar update button. Reads everything
  *  from AppUpdateService; the action adapts to the platform (in-app install on
  *  desktop, external release link on web/.deb). */
 @Component({
   selector: 'app-update-modal',
-  imports: [DatePipe, TranslateModule, MarkdownPipe, LucideDownload, LucideExternalLink, LucideRocket],
+  imports: [DatePipe, TranslateModule, MarkdownPipe, LucideDownload, LucideExternalLink, LucideRocket, ModalHeaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './app-update-modal.html',
   styles: [

--- a/client/src/app/shared/components/download-detail-modal/download-detail-modal.html
+++ b/client/src/app/shared/components/download-detail-modal/download-detail-modal.html
@@ -1,9 +1,6 @@
 <dialog #dialog class="modal">
   <div class="modal-box max-w-lg">
-    <form method="dialog">
-      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
-    </form>
-    <h3 class="text-lg font-bold mb-4">{{ 'media_detail.download_detail_title' | translate }}</h3>
+    <app-modal-header [title]="'media_detail.download_detail_title' | translate" />
 
     @if (progress(); as p) {
       <div class="flex flex-col gap-1.5">
@@ -58,5 +55,5 @@
       </button>
     </div>
   </div>
-  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>

--- a/client/src/app/shared/components/download-detail-modal/download-detail-modal.ts
+++ b/client/src/app/shared/components/download-detail-modal/download-detail-modal.ts
@@ -12,6 +12,7 @@ import {
   MediaDownloadProgress,
 } from '../../../core/services/download-progress.service';
 import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
+import { ModalHeaderComponent } from '../modal-header';
 import {
   qbStateVariant,
   qbStateLabelKey,
@@ -51,7 +52,7 @@ interface SeasonRow {
 @Component({
   selector: 'app-download-detail-modal',
   standalone: true,
-  imports: [TranslateModule, ProgressBarComponent],
+  imports: [TranslateModule, ProgressBarComponent, ModalHeaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './download-detail-modal.html',
 })

--- a/client/src/app/shared/components/media-info-extra/media-info-extra.html
+++ b/client/src/app/shared/components/media-info-extra/media-info-extra.html
@@ -99,5 +99,5 @@
       }
     </div>
   </div>
-  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>

--- a/client/src/app/shared/components/modal-header.html
+++ b/client/src/app/shared/components/modal-header.html
@@ -1,0 +1,15 @@
+<div class="flex items-start justify-between gap-4 mb-4">
+  @if (title()) {
+    <h3 class="text-lg font-bold">{{ title() }}</h3>
+  } @else {
+    <ng-content />
+  }
+  <form method="dialog">
+    <button
+      class="btn btn-sm btn-circle btn-ghost shrink-0"
+      [attr.aria-label]="'common.close' | translate"
+    >
+      ✕
+    </button>
+  </form>
+</div>

--- a/client/src/app/shared/components/modal-header.ts
+++ b/client/src/app/shared/components/modal-header.ts
@@ -1,0 +1,18 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+
+/**
+ * Standard dialog header: title on the left, close button on the right, laid
+ * out in a flex row so the button's focus ring isn't clipped by the modal-box
+ * corner. The button submits the enclosing native <dialog>, so no handler is
+ * needed. Pass a plain `title`, or project a custom title area (icon, subtitle).
+ */
+@Component({
+  selector: 'app-modal-header',
+  imports: [TranslateModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './modal-header.html',
+})
+export class ModalHeaderComponent {
+  readonly title = input('');
+}

--- a/client/src/app/shared/components/recommend-modal/recommend-modal.component.html
+++ b/client/src/app/shared/components/recommend-modal/recommend-modal.component.html
@@ -1,14 +1,6 @@
 <dialog #dialog class="modal">
   <div class="modal-box max-w-md">
-    <form method="dialog">
-      <button
-        class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
-        [attr.aria-label]="'common.close' | translate"
-      >
-        ✕
-      </button>
-    </form>
-    <h3 class="text-lg font-bold mb-4">{{ 'recommend.title' | translate }}</h3>
+    <app-modal-header [title]="'recommend.title' | translate" />
 
     <textarea
       class="textarea textarea-bordered w-full"
@@ -52,5 +44,5 @@
       <p class="text-sm text-base-content/50 mt-3">{{ 'recommend.no_recipients' | translate }}</p>
     }
   </div>
-  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>

--- a/client/src/app/shared/components/recommend-modal/recommend-modal.component.ts
+++ b/client/src/app/shared/components/recommend-modal/recommend-modal.component.ts
@@ -14,6 +14,7 @@ import {
   SocialUser,
 } from '../../../core/services/api/social-api.service';
 import { RecommendTarget } from '../../../core/services/recommend.service';
+import { ModalHeaderComponent } from '../modal-header';
 import { ToastService } from '../../../core/services/toast.service';
 
 /**
@@ -25,7 +26,7 @@ import { ToastService } from '../../../core/services/toast.service';
  */
 @Component({
   selector: 'app-recommend-modal',
-  imports: [FormsModule, TranslateModule, LucideSend],
+  imports: [FormsModule, TranslateModule, LucideSend, ModalHeaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './recommend-modal.component.html',
 })

--- a/client/src/app/shared/components/tracking-status-modal/tracking-status-modal.html
+++ b/client/src/app/shared/components/tracking-status-modal/tracking-status-modal.html
@@ -1,9 +1,6 @@
 <dialog #dialog class="modal">
   <div class="modal-box max-w-lg">
-    <form method="dialog">
-      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
-    </form>
-    <h3 class="text-lg font-bold mb-3">{{ 'tracking.title' | translate }}</h3>
+    <app-modal-header [title]="'tracking.title' | translate" />
 
     @if (loading()) {
       <div class="flex justify-center py-10">
@@ -58,7 +55,7 @@
       </button>
     </div>
   </div>
-  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>
 
 <ng-template #line let-s>

--- a/client/src/app/shared/components/tracking-status-modal/tracking-status-modal.ts
+++ b/client/src/app/shared/components/tracking-status-modal/tracking-status-modal.ts
@@ -20,6 +20,7 @@ import {
   TrackingEpisode,
   TrackingStatus,
 } from '../../../core/services/api/media.service';
+import { ModalHeaderComponent } from '../modal-header';
 
 export type TrackingScope =
   | { kind: 'movie' }
@@ -33,6 +34,7 @@ export type TrackingScope =
   imports: [
     NgTemplateOutlet,
     TranslateModule,
+    ModalHeaderComponent,
     LucideArrowRight,
     LucideCheck,
     LucideCircleAlert,


### PR DESCRIPTION
## Two focus bugs across most dialogs

**1. Clipped close-button ring** — the close button was pinned to the modal-box corner (`absolute right-2 top-2`), so its focus ring was clipped by the box edge (visible on the *Add to a list* modal, same issue seen earlier on the subtitles modal).

**2. Phantom keyboard-focus stop** — the full-screen `modal-backdrop` `<button>close</button>` had no `tabindex`, so it sat in the focus order as an *invisible* stop. Arrow/Tab from a control landed there (no visible focus) before wrapping back into the dialog.

## Fix

- New reusable **`app-modal-header`**: title on the left, close button on the right in a flex row so the ring is never clipped. It owns the close button (`form method="dialog"`, native close) and adds the previously-missing `common.close` aria-label everywhere. The titled dialogs are migrated onto it.
- **`tabindex="-1"`** on every `modal-backdrop` close button (19 of them) so it no longer traps keyboard focus — matching the pattern the subtitles modal already used. The backdrop still closes on click and Escape.

## Notes
- The two full-bleed **trailer** dialogs (`media-info-extra`, `tmdb-preview`) keep their floating close button — a header row would break the edge-to-edge video — but still get the backdrop `tabindex` fix.

## Verification
- Angular production build: clean.
- `grep`: 0 remaining corner-pinned close buttons (except the 2 trailers) and 0 backdrop buttons missing `tabindex="-1"`.
- `FOCUSABLE_SELECTOR` excludes `[tabindex="-1"]`, so the backdrop button is now skipped by both spatial-nav and Tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)