### PR TITLE
feat(metadata): make the TMDB client resilient to upstream outages

### DIFF
--- a/backend/src/modules/metadata-providers/http-circuit-breaker.spec.ts
+++ b/backend/src/modules/metadata-providers/http-circuit-breaker.spec.ts
@@ -1,0 +1,77 @@
+import axios, { AxiosInstance } from 'axios';
+import { installCircuitBreaker, CircuitOpenError } from './http-circuit-breaker';
+
+/** A failure with no HTTP response — a timeout/DNS/reset, which the breaker
+ *  treats as transient. */
+const transientError = () =>
+  Object.assign(new Error('timeout'), { code: 'ECONNABORTED' });
+
+/** A real HTTP answer — must NOT trip the breaker. */
+const httpError = (status: number) =>
+  Object.assign(new Error(`HTTP ${status}`), { response: { status } });
+
+const okResponse = (config: unknown) => ({
+  data: { ok: true },
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config,
+});
+
+describe('installCircuitBreaker', () => {
+  let client: AxiosInstance;
+  let calls: number;
+  let behavior: (config: unknown) => Promise<unknown>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+    calls = 0;
+    behavior = () => Promise.reject(transientError());
+    client = axios.create();
+    // Stub the network so the interceptors are exercised in isolation.
+    client.defaults.adapter = (config) => {
+      calls += 1;
+      return behavior(config) as never;
+    };
+    installCircuitBreaker(client, {
+      name: 'test',
+      failureThreshold: 3,
+      cooldownMs: 30_000,
+    });
+  });
+
+  afterEach(() => jest.useRealTimers());
+
+  it('opens after the threshold, then fails fast without hitting the network', async () => {
+    for (let i = 0; i < 3; i++) {
+      await expect(client.get('/x')).rejects.toBeDefined();
+    }
+    expect(calls).toBe(3);
+
+    // Circuit open: rejects with CircuitOpenError and never reaches the adapter.
+    await expect(client.get('/x')).rejects.toBeInstanceOf(CircuitOpenError);
+    expect(calls).toBe(3);
+  });
+
+  it('probes after the cooldown and closes on the first success', async () => {
+    for (let i = 0; i < 3; i++) await expect(client.get('/x')).rejects.toBeDefined();
+    expect(calls).toBe(3);
+
+    jest.setSystemTime(31_000); // past the cooldown
+    behavior = (config) => Promise.resolve(okResponse(config));
+
+    await expect(client.get('/x')).resolves.toMatchObject({ data: { ok: true } });
+    expect(calls).toBe(4); // the probe reached the adapter
+
+    // Closed again — subsequent calls pass straight through.
+    await expect(client.get('/x')).resolves.toMatchObject({ data: { ok: true } });
+    expect(calls).toBe(5);
+  });
+
+  it('ignores 4xx answers — a real response must not trip the breaker', async () => {
+    behavior = () => Promise.reject(httpError(404));
+    for (let i = 0; i < 5; i++) await expect(client.get('/x')).rejects.toBeDefined();
+    expect(calls).toBe(5); // every call reached the adapter; breaker stayed closed
+  });
+});

--- a/backend/src/modules/metadata-providers/http-circuit-breaker.ts
+++ b/backend/src/modules/metadata-providers/http-circuit-breaker.ts
@@ -1,0 +1,69 @@
+import { AxiosError, AxiosInstance } from 'axios';
+import { Logger } from '@nestjs/common';
+
+/** Thrown by the breaker while the circuit is open, so callers fail instantly
+ *  instead of waiting out the socket timeout. */
+export class CircuitOpenError extends Error {
+  readonly isCircuitOpen = true;
+  constructor(name: string) {
+    super(`${name} circuit open — upstream temporarily unreachable`);
+    this.name = 'CircuitOpenError';
+  }
+}
+
+/** A missing HTTP response (timeout, DNS, refused, reset) or an upstream that is
+ *  itself failing (rate-limit / 5xx) is transient; a 4xx is a real answer. */
+function isTransient(error: AxiosError): boolean {
+  if (!error.response) return true;
+  const status = error.response.status;
+  return status === 429 || status >= 500;
+}
+
+/**
+ * Fail-fast circuit breaker for an outbound axios client, installed as
+ * interceptors so every request is covered without touching call sites.
+ *
+ * After `failureThreshold` consecutive transient failures the circuit opens for
+ * `cooldownMs`: requests then reject immediately with {@link CircuitOpenError}
+ * rather than each hanging on the socket timeout. This is what turns an upstream
+ * outage from an app-wide stall — and a background refresh loop that reprobes a
+ * dead host on every item — into a cheap, immediate failure. The first request
+ * after the cooldown probes the upstream; any success closes the circuit.
+ */
+export function installCircuitBreaker(
+  client: AxiosInstance,
+  opts: { name: string; failureThreshold: number; cooldownMs: number },
+): void {
+  const logger = new Logger(`CircuitBreaker:${opts.name}`);
+  let failures = 0;
+  let openUntil = 0;
+
+  client.interceptors.request.use((config) => {
+    if (Date.now() < openUntil) throw new CircuitOpenError(opts.name);
+    return config;
+  });
+
+  client.interceptors.response.use(
+    (response) => {
+      if (failures > 0) {
+        failures = 0;
+        logger.log('upstream recovered — circuit closed');
+      }
+      return response;
+    },
+    (error: AxiosError) => {
+      if (isTransient(error)) {
+        failures += 1;
+        if (failures >= opts.failureThreshold && Date.now() >= openUntil) {
+          openUntil = Date.now() + opts.cooldownMs;
+          logger.warn(
+            `${failures} consecutive failures — circuit open for ${Math.round(
+              opts.cooldownMs / 1000,
+            )}s`,
+          );
+        }
+      }
+      throw error;
+    },
+  );
+}

--- a/backend/src/modules/metadata-providers/providers/tmdb.provider.ts
+++ b/backend/src/modules/metadata-providers/providers/tmdb.provider.ts
@@ -28,6 +28,7 @@ import {
   MetadataSettingsCache,
   MetadataLanguageOverride,
 } from '../metadata-settings-cache.service';
+import { installCircuitBreaker } from '../http-circuit-breaker';
 
 const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p';
 
@@ -147,6 +148,36 @@ export class TmdbProvider implements IMetadataProvider {
       params: { api_key: this.config.get<string>('TMDB_API_KEY', '') },
       timeout: 10000,
     });
+    // A TMDB/CloudFront outage otherwise makes every call hang for the full
+    // timeout; fail fast once it's clearly down and stop reprobing it per item.
+    installCircuitBreaker(this.client, {
+      name: 'tmdb',
+      failureThreshold: 3,
+      cooldownMs: 30_000,
+    });
+  }
+
+  /** Last successful payload per global list key, served when a live fetch
+   *  fails so a TMDB outage empties nothing that was ever loaded. */
+  private readonly listFallback = new Map<string, unknown>();
+
+  /** Fetch a global (non-user-specific) TMDB list, falling back to the last
+   *  good copy on failure. Cold misses propagate — there is nothing to serve. */
+  private async withStaleFallback<T>(
+    key: string,
+    fetch: () => Promise<T>,
+  ): Promise<T> {
+    try {
+      const value = await fetch();
+      this.listFallback.set(key, value);
+      return value;
+    } catch (err) {
+      if (this.listFallback.has(key)) {
+        this.logger.warn(`TMDB ${key} unavailable — serving last cached copy`);
+        return this.listFallback.get(key) as T;
+      }
+      throw err;
+    }
   }
 
   async searchMovie(
@@ -479,74 +510,103 @@ export class TmdbProvider implements IMetadataProvider {
     window: 'day' | 'week' = 'week',
   ): Promise<MetadataSearchResult[]> {
     const lang = await this.metaLang.resolve();
-    const { data } = await this.client.get<TmdbPaginated<TmdbMovieListItem>>(
-      `/trending/movie/${window}`,
-      { params: { language: lang.tmdbLocale } },
+    return this.withStaleFallback(
+      `trending:movie:${window}:${lang.tmdbLocale}`,
+      async () => {
+        const { data } = await this.client.get<
+          TmdbPaginated<TmdbMovieListItem>
+        >(`/trending/movie/${window}`, {
+          params: { language: lang.tmdbLocale },
+        });
+        return data.results.map((r) => this.mapMovieResult(r));
+      },
     );
-    return data.results.map((r) => this.mapMovieResult(r));
   }
 
   async getPopularMovies(): Promise<MetadataSearchResult[]> {
     const lang = await this.metaLang.resolve();
-    const { data } = await this.client.get<TmdbPaginated<TmdbMovieListItem>>(
-      '/movie/popular',
-      { params: { language: lang.tmdbLocale } },
+    return this.withStaleFallback(
+      `popular:movie:${lang.tmdbLocale}`,
+      async () => {
+        const { data } = await this.client.get<
+          TmdbPaginated<TmdbMovieListItem>
+        >('/movie/popular', { params: { language: lang.tmdbLocale } });
+        return data.results.map((r) => this.mapMovieResult(r));
+      },
     );
-    return data.results.map((r) => this.mapMovieResult(r));
   }
 
   async getUpcomingMovies(): Promise<MetadataSearchResult[]> {
     const lang = await this.metaLang.resolve();
-    const { data } = await this.client.get<TmdbPaginated<TmdbMovieListItem>>(
-      '/movie/upcoming',
-      { params: { language: lang.tmdbLocale, region: lang.region } },
+    return this.withStaleFallback(
+      `upcoming:movie:${lang.tmdbLocale}:${lang.region}`,
+      async () => {
+        const { data } = await this.client.get<
+          TmdbPaginated<TmdbMovieListItem>
+        >('/movie/upcoming', {
+          params: { language: lang.tmdbLocale, region: lang.region },
+        });
+        return data.results.map((r) => this.mapMovieResult(r));
+      },
     );
-    return data.results.map((r) => this.mapMovieResult(r));
   }
 
   async getTrendingTvShows(
     window: 'day' | 'week' = 'week',
   ): Promise<MetadataSearchResult[]> {
     const lang = await this.metaLang.resolve();
-    const { data } = await this.client.get<TmdbPaginated<TmdbTvListItem>>(
-      `/trending/tv/${window}`,
-      { params: { language: lang.tmdbLocale } },
+    return this.withStaleFallback(
+      `trending:tv:${window}:${lang.tmdbLocale}`,
+      async () => {
+        const { data } = await this.client.get<TmdbPaginated<TmdbTvListItem>>(
+          `/trending/tv/${window}`,
+          { params: { language: lang.tmdbLocale } },
+        );
+        return data.results.map((r) => this.mapTvResult(r));
+      },
     );
-    return data.results.map((r) => this.mapTvResult(r));
   }
 
   async getPopularTvShows(): Promise<MetadataSearchResult[]> {
     const lang = await this.metaLang.resolve();
-    const { data } = await this.client.get<TmdbPaginated<TmdbTvListItem>>(
-      '/tv/popular',
-      { params: { language: lang.tmdbLocale } },
-    );
-    return data.results.map((r) => this.mapTvResult(r));
+    return this.withStaleFallback(`popular:tv:${lang.tmdbLocale}`, async () => {
+      const { data } = await this.client.get<TmdbPaginated<TmdbTvListItem>>(
+        '/tv/popular',
+        { params: { language: lang.tmdbLocale } },
+      );
+      return data.results.map((r) => this.mapTvResult(r));
+    });
   }
 
   async getUpcomingTvShows(): Promise<MetadataSearchResult[]> {
     const lang = await this.metaLang.resolve();
-    const { data } = await this.client.get<TmdbPaginated<TmdbTvListItem>>(
-      '/tv/on_the_air',
-      { params: { language: lang.tmdbLocale } },
-    );
-    return data.results.map((r) => this.mapTvResult(r));
+    return this.withStaleFallback(`upcoming:tv:${lang.tmdbLocale}`, async () => {
+      const { data } = await this.client.get<TmdbPaginated<TmdbTvListItem>>(
+        '/tv/on_the_air',
+        { params: { language: lang.tmdbLocale } },
+      );
+      return data.results.map((r) => this.mapTvResult(r));
+    });
   }
 
   async getMovieGenres(): Promise<{ id: number; name: string }[]> {
     const lang = await this.metaLang.resolve();
-    const { data } = await this.client.get<{
-      genres: { id: number; name: string }[];
-    }>('/genre/movie/list', { params: { language: lang.tmdbLocale } });
-    return data.genres;
+    return this.withStaleFallback(`genres:movie:${lang.tmdbLocale}`, async () => {
+      const { data } = await this.client.get<{
+        genres: { id: number; name: string }[];
+      }>('/genre/movie/list', { params: { language: lang.tmdbLocale } });
+      return data.genres;
+    });
   }
 
   async getTvGenres(): Promise<{ id: number; name: string }[]> {
     const lang = await this.metaLang.resolve();
-    const { data } = await this.client.get<{
-      genres: { id: number; name: string }[];
-    }>('/genre/tv/list', { params: { language: lang.tmdbLocale } });
-    return data.genres;
+    return this.withStaleFallback(`genres:tv:${lang.tmdbLocale}`, async () => {
+      const { data } = await this.client.get<{
+        genres: { id: number; name: string }[];
+      }>('/genre/tv/list', { params: { language: lang.tmdbLocale } });
+      return data.genres;
+    });
   }
 
   async discoverMovies(opts: DiscoverOptions): Promise<MetadataSearchResult[]> {

--- a/client/src/app/core/interceptors/error.interceptor.ts
+++ b/client/src/app/core/interceptors/error.interceptor.ts
@@ -15,7 +15,12 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
       // 401 — the auth guard handles unauth state by redirecting to the user
       // picker; toasting the 401 just adds noise on top of that flow.
       const showToast = (err.status >= 400 && err.status < 500 && err.status !== 408 && err.status !== 401) || err.status === 500;
-      if (!showToast || req.url.includes('/i18n/')) {
+      // Discover/search/browse GETs degrade in place (stale cache or empty
+      // rows), so an upstream 500 there must not spray toasts — one discover
+      // open fires several parallel metadata calls at once.
+      const softMetadataGet =
+        req.method === 'GET' && req.url.includes('/api/metadata') && err.status === 500;
+      if (!showToast || softMetadataGet || req.url.includes('/i18n/')) {
         return throwError(() => err);
       }
       const message = extractMessage(err, translate);


### PR DESCRIPTION
## Why

Diagnosed from real backend logs: TMDB (behind CloudFront) intermittently accepts the TLS connection but returns no HTTP response, so **every** provider call hung the full 10s timeout. Effects: discover/genre endpoints 500'd, one discover open fired several identical error toasts, and the metadata-refresh cron reprobed the dead host on every item forever. Verified independently that the request itself is correct (the exact URL returns 16 genres from another network) — this is upstream/network, so the fix is resilience.

## What (reliability-first, no behaviour change while TMDB is up)

1. **Circuit breaker** on the shared TMDB axios client (`http-circuit-breaker.ts`), installed as interceptors so every call is covered with no call-site changes. After 3 consecutive *transient* failures (timeout/DNS/reset/5xx/429 — a 4xx is a real answer and is ignored) it opens for 30s and rejects instantly with `CircuitOpenError` instead of hanging; the first call after the cooldown probes and closes on success. **Unit-tested** (`http-circuit-breaker.spec.ts`, 3 cases: opens+fails-fast, probes+closes, ignores 4xx).
2. **Stale-if-error fallback** for the global list endpoints (genres / trending / popular / upcoming) in `TmdbProvider`: the last good payload is kept per `(endpoint, locale[, window/region])` and served when a live fetch fails, so an outage empties nothing that was ever loaded. Cold misses propagate (nothing to serve). Bounded key space; no TTL by design — always fetch live first, fall back only on error.
3. **Frontend** (`error.interceptor.ts`): suppress the `500` toast for `GET /api/metadata` browse calls, which already fail soft (stale cache / empty state). Kills the multi-toast storm from a cold discover open (also covers the background SWR-revalidation 500).

## Scope (intentionally tight — no over-engineering)
Left as possible follow-ups, not needed for core reliability: proxying discover/search posters through `/api/images` (dead-CDN `<img>` placeholders), persisting an import snapshot on the request row (offline approvals), and applying the breaker to TVDB. Library metadata + images are already persisted/local, so the core product was never affected by the outage.

## Verification
- Backend `tsc --noEmit`: clean. Circuit-breaker unit tests: 3/3 pass.
- Angular build: clean.
- Live: during a real TMDB down-window the genre endpoint served its cached copy (HTTP 200) instead of 500; search (live) works when TMDB is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)