### PR TITLE
fix(media-detail): allow liking a title without a local file

### DIFF
--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -120,18 +120,20 @@
           <svg lucideCheck class="h-5 w-5"></svg>
           {{ 'media_info.watched' | translate }}
         </button>
-        @if (mediaType() === 'movie' || episodeId()) {
-          <button type="button" class="flex flex-col items-center gap-1 text-sm cursor-pointer" [class.text-error]="liked()" (click)="likeToggled.emit()">
-            <svg lucideHeart class="h-5 w-5" [attr.fill]="liked() ? 'currentColor' : 'none'"></svg>
-            {{ 'likes.like' | translate }}
-          </button>
-        }
         @if ((mediaType() === 'movie' || episodeId()) && !tv.isTv()) {
           <button class="flex flex-col items-center gap-1 text-sm" (click)="openDownload.emit()">
             <svg lucideDownload class="h-5 w-5"></svg>
             {{ 'downloads.download' | translate }}
           </button>
         }
+      }
+      <!-- Like is a taste signal, not a playback action — available with or
+           without a local file (parity with recommendations + add-to-playlist). -->
+      @if (mediaType() === 'movie' || episodeId()) {
+        <button type="button" class="flex flex-col items-center gap-1 text-sm cursor-pointer" [class.text-error]="liked()" (click)="likeToggled.emit()">
+          <svg lucideHeart class="h-5 w-5" [attr.fill]="liked() ? 'currentColor' : 'none'"></svg>
+          {{ 'likes.like' | translate }}
+        </button>
       }
       <button type="button" class="flex flex-col items-center gap-1 text-sm cursor-pointer" (click)="addToPlaylist.emit()">
         <svg lucideListPlus class="h-5 w-5"></svg>
@@ -295,15 +297,19 @@
             </button>
           }
           @if (mediaType() === 'movie' || episodeId()) {
-            <button type="button" class="btn btn-ghost btn btn-circle" [class.text-error]="liked()" [attr.aria-label]="'likes.like' | translate" (click)="likeToggled.emit()">
-              <svg lucideHeart class="h-4 w-4" [attr.fill]="liked() ? 'currentColor' : 'none'"></svg>
-            </button>
             <button type="button" class="btn btn-ghost btn btn-circle" (click)="openDownload.emit()">
               <svg lucideDownload class="h-4 w-4"></svg>
             </button>
           }
         }
         <ng-container *ngTemplateOutlet="downloadBadge"></ng-container>
+        <!-- Like is a taste signal, not a playback action — available with or
+             without a local file (parity with recommendations + add-to-playlist). -->
+        @if (mediaType() === 'movie' || episodeId()) {
+          <button type="button" class="btn btn-ghost btn btn-circle" [class.text-error]="liked()" [attr.aria-label]="'likes.like' | translate" (click)="likeToggled.emit()">
+            <svg lucideHeart class="h-4 w-4" [attr.fill]="liked() ? 'currentColor' : 'none'"></svg>
+          </button>
+        }
         <button type="button" class="btn btn-ghost btn btn-circle" [attr.aria-label]="'playlists.add_to_playlist' | translate" (click)="addToPlaylist.emit()">
           <svg lucideListPlus class="h-4 w-4"></svg>
         </button>


### PR DESCRIPTION
## Bug

A library title can be recommended even without its file downloaded, and you can **like** it from the recommendation card. But on the **media-detail page** the like button was gated away when there was no local file — inconsistent.

## Cause

The like button lived inside the `@if (selectedFileId())` playback block (alongside *watched* and *download*) on both the mobile and desktop action rows, so no file → no button. Yet `add-to-playlist` (also a non-playback action) already sits outside that block, and `toggleLike()` never depended on a file.

## Fix

Move the like button out of the playback block (keeping only its `movie || episode` condition), next to add-to-playlist, on both layouts. *Watched* and *download* stay file-gated (they genuinely need the file). Liking a not-yet-downloaded title now works from the detail page, matching the recommendation card.

## Verification
- Angular build: clean.
- `toggleLike()` / like-state are keyed by media/episode id, independent of file presence — confirmed no file dependency in the action itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)