### PR TITLE
fix(media-detail): allow liking a series at the series level

### DIFF
--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -127,9 +127,9 @@
           </button>
         }
       }
-      <!-- Like is a taste signal, not a playback action — available with or
-           without a local file (parity with recommendations + add-to-playlist). -->
-      @if (mediaType() === 'movie' || episodeId()) {
+      <!-- Like is a taste signal, not a playback action — available on movies,
+           series and episodes, with or without a local file. -->
+      @if (mediaType() === 'movie' || mediaType() === 'series' || episodeId()) {
         <button type="button" class="flex flex-col items-center gap-1 text-sm cursor-pointer" [class.text-error]="liked()" (click)="likeToggled.emit()">
           <svg lucideHeart class="h-5 w-5" [attr.fill]="liked() ? 'currentColor' : 'none'"></svg>
           {{ 'likes.like' | translate }}
@@ -303,9 +303,9 @@
           }
         }
         <ng-container *ngTemplateOutlet="downloadBadge"></ng-container>
-        <!-- Like is a taste signal, not a playback action — available with or
-             without a local file (parity with recommendations + add-to-playlist). -->
-        @if (mediaType() === 'movie' || episodeId()) {
+        <!-- Like is a taste signal, not a playback action — available on movies,
+             series and episodes, with or without a local file. -->
+        @if (mediaType() === 'movie' || mediaType() === 'series' || episodeId()) {
           <button type="button" class="btn btn-ghost btn btn-circle" [class.text-error]="liked()" [attr.aria-label]="'likes.like' | translate" (click)="likeToggled.emit()">
             <svg lucideHeart class="h-4 w-4" [attr.fill]="liked() ? 'currentColor' : 'none'"></svg>
           </button>


### PR DESCRIPTION
## Bug

You can like a movie or a focused episode from the media-detail header, and a **series** can be liked from a recommendation — but on the series **overview** page (no episode focused) there was no like button.

## Cause

The header like button was gated `mediaType() === 'movie' || episodeId()`, which excludes a series in normal mode (`mediaType() === 'series'`, no `episodeId`). Yet `focusedLiked()` already returns the series-level state (`likeState().media`) and `toggleLike()` already targets `{ mediaId }` in that view — only the button's visibility condition was missing the series case.

## Fix

Widen the condition to `movie || series || episodeId` on both the mobile and desktop action rows. Series-level likes (`{ mediaId }`, `UQ_likes_movie`) are already supported end-to-end (backend + recommendation flow). Season and episode likes stay independent scopes.

## Verification
- Angular build: clean.
- `toggleLike()` targets `{ mediaId }` and `focusedLiked()` reads `likeState().media` when no episode is focused — series-level wiring confirmed already present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)