### PR TITLE
style(ui): animate popover and select panels on open and close

### DIFF
--- a/client/src/app/shared/components/forms/searchable-select/searchable-select.html
+++ b/client/src/app/shared/components/forms/searchable-select/searchable-select.html
@@ -17,7 +17,8 @@
 
 @if (open()) {
   <div
-    class="absolute left-0 right-0 mt-1 z-40 bg-base-100 border border-base-300 rounded-lg shadow-lg overflow-hidden"
+    animate.leave="popover-pop-leaving"
+    class="popover-pop-in absolute left-0 right-0 mt-1 z-40 bg-base-100 border border-base-300 rounded-lg shadow-lg overflow-hidden"
   >
     <div class="p-2 border-b border-base-200">
       <input

--- a/client/src/app/shared/components/popover-menu.ts
+++ b/client/src/app/shared/components/popover-menu.ts
@@ -57,7 +57,8 @@ import { DismissableStackService } from '../../core/services/dismissable-stack.s
         data-tv-modal
         [attr.data-tv-submenu]="submenu() ? '' : null"
         (focusout)="onSubmenuFocusOut($event)"
-        class="fixed z-[101] bg-base-200 rounded-box shadow-xl overflow-y-auto p-2 [scroll-padding:0.5rem] [scroll-behavior:smooth]"
+        animate.leave="popover-pop-leaving"
+        class="popover-pop-in fixed z-[101] bg-base-200 rounded-box shadow-xl overflow-y-auto p-2 [scroll-padding:0.5rem] [scroll-behavior:smooth]"
         [style.top.px]="position().top"
         [style.bottom.px]="position().bottom"
         [style.left.px]="position().left"

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -604,6 +604,30 @@ body.tv .to-base-100\/50 {
   display: none !important;
 }
 
+/* Open/close animation for the anchored popover / searchable-select panels.
+   They live under an Angular `@if`, so the base class animates the entry on
+   insert and `animate.leave="popover-pop-leaving"` holds the node in the DOM
+   for the exit before removal (same approach as card-actions-panel). */
+.popover-pop-in {
+  transform-origin: top;
+  animation: popover-pop 0.15s ease;
+}
+@keyframes popover-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+}
+.popover-pop-leaving {
+  animation: popover-pop-out 0.12s ease forwards;
+}
+@keyframes popover-pop-out {
+  to {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+}
+
 /* Shared item style for app-dropdown-menu (desktop dropdown + mobile/TV
    bottom sheet). Caller adds a colour utility (`text-white`, `text-error`,
    …) and an icon — everything else (padding, hover, focus, layout) lives


### PR DESCRIPTION
## Why

The user-menu dropdown (`app-dropdown-menu`) has a smooth open+close animation, but `app-popover-menu` (desktop) and `searchable-select` popped in/out instantly — inconsistent.

**Root cause:** the dropdown keeps its panel mounted and toggles `.dropdown-open` (so CSS `allow-discrete` + `@starting-style` animate both directions). The popover and searchable-select add/remove their panel via Angular `@if`, so the node is gone before a close transition can run.

## Fix

Keep the `@if` (content stays lazy — no always-mounted panel, no timers) and use Angular 21's native **`animate.leave`** to defer DOM removal until the exit animation finishes, paired with a base-class keyframe for the entry. Same approach already used by `card-actions-panel`.

- New shared classes in `styles.css`: `.popover-pop-in` (entry keyframe) + `.popover-pop-leaving` (exit keyframe, applied via `animate.leave`).
- Applied to `app-popover-menu`'s desktop panel (which also fixes **select-picker**, the styled `<select>` replacement, since it renders through the popover) and to `searchable-select`'s panel.

## Scope
- `select-field` uses a native `<select>` (OS-rendered) — untouched.
- Mobile/TV bottom-sheet variants already animate — untouched.

## Verification
- Angular build: clean (`animate.leave` recognised, already in use in card-actions-panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)