### PR TITLE
feat(home): reorderable member-recommendations zone with keyboard nav

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2286,6 +2286,7 @@
       "libraries": "Bibliotheken",
       "continue_watching": "Wiedergabe fortsetzen",
       "recommendations": "Empfehlungen",
+      "received_recommendations": "Empfehlungen von Mitgliedern",
       "likes": "Meine Favoriten",
       "recently_added": "Kürzlich hinzugefügt",
       "playlists": "Neueste Playlists",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2286,6 +2286,7 @@
       "libraries": "Libraries",
       "continue_watching": "Continue watching",
       "recommendations": "Recommendations",
+      "received_recommendations": "Member recommendations",
       "likes": "My favorites",
       "recently_added": "Recently added",
       "playlists": "Recent playlists",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2286,6 +2286,7 @@
       "libraries": "Bibliotecas",
       "continue_watching": "Reanudar la reproducción",
       "recommendations": "Recomendaciones",
+      "received_recommendations": "Recomendaciones de miembros",
       "likes": "Mis favoritos",
       "recently_added": "Añadido recientemente",
       "playlists": "Listas recientes",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2286,6 +2286,7 @@
       "libraries": "Bibliothèques",
       "continue_watching": "Reprendre la lecture",
       "recommendations": "Recommandations",
+      "received_recommendations": "Recommandations des membres",
       "likes": "Mes coups de cœur",
       "recently_added": "Récemment ajouté",
       "playlists": "Playlists récentes",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2286,6 +2286,7 @@
       "libraries": "Librerie",
       "continue_watching": "Riprendi la riproduzione",
       "recommendations": "Consigli",
+      "received_recommendations": "Consigli dei membri",
       "likes": "I miei preferiti",
       "recently_added": "Aggiunto di recente",
       "playlists": "Playlist recenti",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2286,6 +2286,7 @@
       "libraries": "Bibliotecas",
       "continue_watching": "Retomar a reprodução",
       "recommendations": "Recomendações",
+      "received_recommendations": "Recomendações de membros",
       "likes": "Os meus favoritos",
       "recently_added": "Adicionado recentemente",
       "playlists": "Playlists recentes",

--- a/client/src/app/core/services/home-settings.service.ts
+++ b/client/src/app/core/services/home-settings.service.ts
@@ -3,6 +3,7 @@ import { Injectable, signal } from '@angular/core';
 /** Stable identity of a home zone. Built-ins are fixed; per-library
  *  "recently added" zones are keyed by their library id. */
 export type HomeSectionKey =
+  | 'received-recommendations'
   | 'libraries'
   | 'continue-watching'
   | 'recommendations'
@@ -14,6 +15,7 @@ export type HomeSectionKey =
   | `library-recent:${number}`;
 
 export type HomeSectionType =
+  | 'received-recommendations'
   | 'libraries'
   | 'continue-watching'
   | 'recommendations'
@@ -50,6 +52,7 @@ const STORAGE_KEY = 'home.settings';
 const LIBRARY_RECENT_PREFIX = 'library-recent:';
 
 const BUILTIN_ORDER: HomeSectionKey[] = [
+  'received-recommendations',
   'libraries',
   'continue-watching',
   'recommendations',
@@ -143,6 +146,12 @@ export class HomeSettingsService {
         merged.push(pref);
         seen.add(pref.key);
       }
+    }
+    // Saved layouts predating this zone get it on top, not appended at the
+    // bottom (new users already get it first via DEFAULTS).
+    if (!seen.has('received-recommendations')) {
+      merged.unshift({ key: 'received-recommendations', visible: true });
+      seen.add('received-recommendations');
     }
     for (const key of BUILTIN_ORDER) {
       if (!seen.has(key)) {

--- a/client/src/app/features/app-settings/home-settings/home-settings.ts
+++ b/client/src/app/features/app-settings/home-settings/home-settings.ts
@@ -87,6 +87,7 @@ export class HomeSettingsPageComponent implements OnInit {
   readonly librarySaving = signal(false);
 
   private readonly BUILTIN_LABELS: Record<string, string> = {
+    'received-recommendations': 'home_settings.section.received_recommendations',
     libraries: 'home_settings.section.libraries',
     'continue-watching': 'home_settings.section.continue_watching',
     recommendations: 'home_settings.section.recommendations',

--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -2,13 +2,17 @@
   <app-setup-checklist [padding]="true" />
 }
 <app-follow-requests-card [padding]="true" />
-<app-received-recommendations-card [padding]="true" />
 
 
 <div appTvSection appDefaultFocus="a[data-home-focus^='library:']" focusKey="home" focusIdAttr="data-home-focus" class="flex flex-col gap-8">
 
   @for (section of visibleSections(); track section.key) {
     @switch (section.type) {
+
+      <!-- Member recommendations -->
+      @case ('received-recommendations') {
+        <app-received-recommendations-card />
+      }
 
       <!-- Libraries -->
       @case ('libraries') {

--- a/client/src/app/shared/components/received-recommendations-card/received-recommendations-card.html
+++ b/client/src/app/shared/components/received-recommendations-card/received-recommendations-card.html
@@ -1,73 +1,71 @@
 @if (!tv.isTv() && items().length > 0) {
-  <div [class.pb-4]="padding()">
-    <section class="card bg-base-200/60 backdrop-blur-sm shadow-sm">
-      <div class="card-body p-4 sm:p-5 gap-4">
-        @for (group of grouped(); track group.senderId) {
-          <div class="flex flex-col gap-2">
-            <a
-              [routerLink]="['/profile', group.senderId]"
-              class="w-fit text-lg font-semibold hover:underline"
-            >
-              {{ 'recommend.recommended_by' | translate: { username: group.senderName } }}
-            </a>
-            <ul class="flex flex-col divide-y divide-base-300/50">
-              @for (item of group.items; track item.id) {
-                <li class="flex items-center gap-4 py-3 first:pt-0 last:pb-0">
-                  <a [routerLink]="mediaLink(item)" class="shrink-0">
-                    <div class="w-24 aspect-video rounded-md bg-base-300 overflow-hidden">
-                      @if (item.stillUrl ?? item.fanartUrl ?? item.posterUrl; as img) {
-                        <img [src]="img" [alt]="item.title" class="w-full h-full object-cover" loading="lazy" />
-                      }
-                    </div>
-                  </a>
-                  <div class="flex-1 min-w-0 space-y-0.5">
-                    <a [routerLink]="mediaLink(item)" class="block">
-                      <p class="text-base font-semibold truncate hover:underline">{{ item.title }}</p>
-                      @if (item.label) {
-                        <p class="text-sm text-base-content/70 truncate">{{ item.label }}</p>
-                      }
-                    </a>
-                    @if (item.message) {
-                      <p class="text-sm text-base-content/80 italic truncate">« {{ item.message }} »</p>
+  <section class="card bg-base-200/60 backdrop-blur-sm shadow-sm">
+    <div class="card-body p-4 sm:p-5 gap-4">
+      @for (group of grouped(); track group.senderId) {
+        <div class="flex flex-col gap-2">
+          <a
+            [routerLink]="['/profile', group.senderId]"
+            class="w-fit text-lg font-semibold hover:underline"
+          >
+            {{ 'recommend.recommended_by' | translate: { username: group.senderName } }}
+          </a>
+          <ul class="flex flex-col divide-y divide-base-300/50">
+            @for (item of group.items; track item.id) {
+              <li class="flex items-center gap-4 py-3 first:pt-0 last:pb-0">
+                <a [routerLink]="mediaLink(item)" class="shrink-0">
+                  <div class="w-24 aspect-video rounded-md bg-base-300 overflow-hidden">
+                    @if (item.stillUrl ?? item.fanartUrl ?? item.posterUrl; as img) {
+                      <img [src]="img" [alt]="item.title" class="w-full h-full object-cover" loading="lazy" />
                     }
                   </div>
-                  <div class="flex items-center gap-1 shrink-0">
-                    <app-dropdown-menu placement="bottom-end">
-                      <button
-                        trigger
-                        type="button"
-                        class="btn btn-ghost btn-sm btn-square"
-                        [attr.aria-label]="'media_card.actions' | translate"
-                      >
-                        <svg lucideEllipsisVertical class="h-5 w-5"></svg>
-                      </button>
-                      <button type="button" class="dropdown-item" (click)="toggleLike(item); $event.stopPropagation()">
-                        <svg lucideHeart class="h-4 w-4 text-error" [attr.fill]="item.liked ? 'currentColor' : 'none'"></svg>
-                        <span class="flex-1">{{ (item.liked ? 'likes.unlike' : 'likes.like') | translate }}</span>
-                      </button>
-                      <button type="button" class="dropdown-item" (click)="addToPlaylist(item)">
-                        <svg lucideListPlus class="h-4 w-4"></svg>
-                        <span class="flex-1">{{ 'playlists.add_to_playlist_title' | translate }}</span>
-                      </button>
-                    </app-dropdown-menu>
-                    <span class="tooltip tooltip-left" [attr.data-tip]="'recommend.dismiss' | translate">
-                      <button
-                        type="button"
-                        class="btn btn-ghost btn-sm btn-square"
-                        [disabled]="busyId() === item.id"
-                        (click)="dismiss(item)"
-                        [attr.aria-label]="'recommend.dismiss' | translate"
-                      >
-                        <svg lucideX class="h-5 w-5"></svg>
-                      </button>
-                    </span>
-                  </div>
-                </li>
-              }
-            </ul>
-          </div>
-        }
-      </div>
-    </section>
-  </div>
+                </a>
+                <div class="flex-1 min-w-0 space-y-0.5">
+                  <a [routerLink]="mediaLink(item)" class="block">
+                    <p class="text-base font-semibold truncate hover:underline">{{ item.title }}</p>
+                    @if (item.label) {
+                      <p class="text-sm text-base-content/70 truncate">{{ item.label }}</p>
+                    }
+                  </a>
+                  @if (item.message) {
+                    <p class="text-sm text-base-content/80 italic truncate">« {{ item.message }} »</p>
+                  }
+                </div>
+                <div class="flex items-center gap-1 shrink-0">
+                  <app-dropdown-menu placement="bottom-end">
+                    <button
+                      trigger
+                      type="button"
+                      class="btn btn-ghost btn-sm btn-square"
+                      [attr.aria-label]="'media_card.actions' | translate"
+                    >
+                      <svg lucideEllipsisVertical class="h-5 w-5"></svg>
+                    </button>
+                    <button type="button" class="dropdown-item" (click)="toggleLike(item); $event.stopPropagation()">
+                      <svg lucideHeart class="h-4 w-4 text-error" [attr.fill]="item.liked ? 'currentColor' : 'none'"></svg>
+                      <span class="flex-1">{{ (item.liked ? 'likes.unlike' : 'likes.like') | translate }}</span>
+                    </button>
+                    <button type="button" class="dropdown-item" (click)="addToPlaylist(item)">
+                      <svg lucideListPlus class="h-4 w-4"></svg>
+                      <span class="flex-1">{{ 'playlists.add_to_playlist_title' | translate }}</span>
+                    </button>
+                  </app-dropdown-menu>
+                  <span class="tooltip tooltip-left" [attr.data-tip]="'recommend.dismiss' | translate">
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-sm btn-square"
+                      [disabled]="busyId() === item.id"
+                      (click)="dismiss(item)"
+                      [attr.aria-label]="'recommend.dismiss' | translate"
+                    >
+                      <svg lucideX class="h-5 w-5"></svg>
+                    </button>
+                  </span>
+                </div>
+              </li>
+            }
+          </ul>
+        </div>
+      }
+    </div>
+  </section>
 }

--- a/client/src/app/shared/components/received-recommendations-card/received-recommendations-card.html
+++ b/client/src/app/shared/components/received-recommendations-card/received-recommendations-card.html
@@ -5,14 +5,14 @@
         <div class="flex flex-col gap-2">
           <a
             [routerLink]="['/profile', group.senderId]"
-            class="w-fit text-lg font-semibold hover:underline"
+            class="w-fit rounded text-lg font-semibold hover:underline"
           >
             {{ 'recommend.recommended_by' | translate: { username: group.senderName } }}
           </a>
           <ul class="flex flex-col divide-y divide-base-300/50">
             @for (item of group.items; track item.id) {
-              <li class="flex items-center gap-4 py-3 first:pt-0 last:pb-0">
-                <a [routerLink]="mediaLink(item)" class="shrink-0">
+              <li appTvRow class="flex items-center gap-4 py-3 first:pt-0 last:pb-0">
+                <a [routerLink]="mediaLink(item)" class="shrink-0 rounded-md">
                   <div class="w-24 aspect-video rounded-md bg-base-300 overflow-hidden">
                     @if (item.stillUrl ?? item.fanartUrl ?? item.posterUrl; as img) {
                       <img [src]="img" [alt]="item.title" class="w-full h-full object-cover" loading="lazy" />
@@ -20,7 +20,7 @@
                   </div>
                 </a>
                 <div class="flex-1 min-w-0 space-y-0.5">
-                  <a [routerLink]="mediaLink(item)" class="block">
+                  <a [routerLink]="mediaLink(item)" class="block rounded">
                     <p class="text-base font-semibold truncate hover:underline">{{ item.title }}</p>
                     @if (item.label) {
                       <p class="text-sm text-base-content/70 truncate">{{ item.label }}</p>

--- a/client/src/app/shared/components/received-recommendations-card/received-recommendations-card.ts
+++ b/client/src/app/shared/components/received-recommendations-card/received-recommendations-card.ts
@@ -22,6 +22,7 @@ import {
 import { SseService } from '../../../core/services/sse.service';
 import { TvService } from '../../../core/services/tv.service';
 import { DropdownMenuComponent } from '../dropdown-menu';
+import { TvRowDirective } from '../../directives/tv-row.directive';
 import { AddToPlaylistService } from '../../../core/services/add-to-playlist.service';
 import { LikesApiService } from '../../../core/services/api/likes-api.service';
 
@@ -38,6 +39,7 @@ import { LikesApiService } from '../../../core/services/api/likes-api.service';
     RouterLink,
     TranslateModule,
     DropdownMenuComponent,
+    TvRowDirective,
     LucideX,
     LucideEllipsisVertical,
     LucideHeart,

--- a/client/src/app/shared/components/received-recommendations-card/received-recommendations-card.ts
+++ b/client/src/app/shared/components/received-recommendations-card/received-recommendations-card.ts
@@ -5,7 +5,6 @@ import {
   computed,
   effect,
   inject,
-  input,
   signal,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
@@ -46,6 +45,7 @@ import { LikesApiService } from '../../../core/services/api/likes-api.service';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './received-recommendations-card.html',
+  host: { class: 'contents' },
 })
 export class ReceivedRecommendationsCardComponent implements OnInit {
   private readonly api = inject(SocialApiService);
@@ -53,9 +53,6 @@ export class ReceivedRecommendationsCardComponent implements OnInit {
   private readonly addToPlaylistService = inject(AddToPlaylistService);
   private readonly likesApi = inject(LikesApiService);
   readonly tv = inject(TvService);
-
-  /** Adds bottom padding when stacked above the home sections. */
-  readonly padding = input(false);
 
   readonly items = signal<ReceivedRecommendation[]>([]);
   readonly busyId = signal<number | null>(null);


### PR DESCRIPTION
## What

Two improvements to the member **"Recommended by X"** card:

### 1. Reorderable home zone
The card was hard-pinned above the home sections, outside the personalizable layout. It's now a first-class **home zone** — reorderable and hideable, defaulting to the top.

- **`home-settings.service.ts`**: new `received-recommendations` section key/type, first in `BUILTIN_ORDER` (new users get it on top). `resolve()` front-inserts it into saved layouts that predate the zone, so it stays on top for current users instead of being appended at the bottom — matching its previous always-top placement.
- **`home.html`**: rendered as a `@case` in the sections `@switch` instead of a fixed widget.
- **card host** set to `display: contents` so an empty card (no recs / TV) leaves no `gap-8` hole; removed the now-unused `padding` input.
- **Settings** reorder page lists the zone via a new label (6 locales), distinct from the algorithmic "Recommendations" zone.

### 2. Keyboard navigation + rounded focus
- Each recommendation row is now an **`appTvRow`**, so keyboard/D-pad users step left/right within a row (poster → title → actions) and up/down between rows — the same tree-aware nav used across the app.
- **Rounded focus ring** on the sender/poster/title links: the global `:focus-visible` ring is a `box-shadow` that follows `border-radius`, which those link elements lacked (they painted a rectangle); added `rounded`/`rounded-md`.

## Verification
- Angular build: clean. i18n parity preserved (one new key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)