### PR TITLE
fix(media-card): scope the actions dropdown to the spatial-nav modal layer

### DIFF
--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
@@ -6,6 +6,7 @@
   ></div>
   <div
     #menu
+    data-tv-modal
     class="card-actions-menu fixed z-[101] bg-base-200 rounded-box shadow-xl overflow-hidden"
     animate.leave="card-actions-leaving"
     [style.top.px]="position()?.top"
@@ -30,7 +31,7 @@
       </div>
     }
     <ul role="menu" class="menu p-2 gap-0.5 w-full">
-      @for (a of actions(); track a; let i = $index) {
+      @for (a of actions(); track a) {
         <li [class.disabled]="a.disabled">
           <button
             type="button"
@@ -39,7 +40,6 @@
             [disabled]="a.disabled"
             class="flex items-center gap-3"
             [class.text-error]="a.tone === 'danger'"
-            [class.menu-active]="i === activeIndex()"
             (click)="trigger(a)"
           >
             @switch (a.icon) {

--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.ts
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.ts
@@ -81,8 +81,6 @@ export class CardActionsPanelComponent {
 
   /** Computed style for the anchored dropdown — re-read on each open. */
   readonly position = signal<{ top: number; left: number; width: number } | null>(null);
-  /** Index of the currently highlighted action (for keyboard nav). */
-  readonly activeIndex = signal(0);
 
   readonly actions = computed(() => this.service.actions() ?? []);
   readonly title = this.service.title;
@@ -113,7 +111,6 @@ export class CardActionsPanelComponent {
     // Recompute position and reset highlight when the panel opens.
     effect(() => {
       if (!this.service.open()) return;
-      this.activeIndex.set(0);
       if (this.useDropdown()) {
         queueMicrotask(() => {
           this.computePosition();
@@ -139,36 +136,18 @@ export class CardActionsPanelComponent {
     queueMicrotask(() => action.run());
   }
 
-  /**
-   * Keyboard handler for the anchored dropdown — Up/Down move highlight,
-   * Escape closes. Bound on TV and desktop alike (the bottom sheet on touch
-   * surfaces uses tap-to-dismiss instead).
-   */
+  // Arrow nav is owned by the global spatial-nav service, scoped to this panel
+  // via `data-tv-modal` (keeps arrows inside the menu instead of leaking to the
+  // grid behind and scrolling the page); only Escape is handled locally.
   onMenuKey(e: KeyboardEvent) {
-    if (!this.useDropdown()) return;
-    const list = this.actions();
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      e.stopPropagation();
-      const next = (this.activeIndex() + 1) % list.length;
-      this.activeIndex.set(next);
-      this.focusActionAt(next);
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      e.stopPropagation();
-      const prev = (this.activeIndex() - 1 + list.length) % list.length;
-      this.activeIndex.set(prev);
-      this.focusActionAt(prev);
-    } else if (e.key === 'Escape') {
-      e.preventDefault();
-      e.stopPropagation();
-      this.onClose();
+    if (!this.useDropdown() || e.key !== 'Escape') return;
+    e.preventDefault();
+    e.stopPropagation();
+    const anchor = this.service.anchor();
+    this.onClose();
+    if (anchor?.isConnected) {
+      queueMicrotask(() => anchor.focus({ preventScroll: true }));
     }
-  }
-
-  private focusActionAt(i: number) {
-    const buttons = this.menu()?.nativeElement.querySelectorAll<HTMLButtonElement>('button[data-action]');
-    buttons?.[i]?.focus();
   }
 
   private computePosition() {


### PR DESCRIPTION
## Bug
Keyboard/D-pad navigation in the media-card **⋮ actions dropdown** couldn't exit cleanly — at the last item it started scrolling the whole page.

## Cause
The global `TvSpatialNavService` listens on `window` in the **capture phase**, so it runs before the panel's local (bubble-phase) keydown handler. The desktop menu wasn't a spatial-nav modal (`data-tv-modal`), so `findNeighbor` treated the grid cards behind it as candidates and `performMove` page-scrolled at the edge (`if (!openModals().length) window.scrollBy(...)`). The local handler couldn't stop the capture-phase nav.

## Fix
- Add `data-tv-modal` to the desktop menu → the global nav scopes arrows to it (`collectFocusables(menu)`), so focus stays inside and the edge no longer page-scrolls. Same mechanism as `app-popover-menu` / bottom sheets.
- Remove the redundant local arrow handling + `activeIndex`/`menu-active` (the scoped global nav owns arrow movement; the `:focus-visible` ring shows the highlight).
- Escape still closes and returns focus to the card.

Verified working on desktop (focus stays in the menu; Escape returns to the card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)