### PR TITLE
fix(recommendations): resolve card image URLs through the pipe

### DIFF
--- a/client/src/app/shared/components/received-recommendations-card/received-recommendations-card.html
+++ b/client/src/app/shared/components/received-recommendations-card/received-recommendations-card.html
@@ -15,7 +15,7 @@
                 <a [routerLink]="mediaLink(item)" class="shrink-0 rounded-md">
                   <div class="w-24 aspect-video rounded-md bg-base-300 overflow-hidden">
                     @if (item.stillUrl ?? item.fanartUrl ?? item.posterUrl; as img) {
-                      <img [src]="img" [alt]="item.title" class="w-full h-full object-cover" loading="lazy" />
+                      <img [src]="img | resolveUrl:'thumb'" [alt]="item.title" class="w-full h-full object-cover" loading="lazy" />
                     }
                   </div>
                 </a>

--- a/client/src/app/shared/components/received-recommendations-card/received-recommendations-card.ts
+++ b/client/src/app/shared/components/received-recommendations-card/received-recommendations-card.ts
@@ -23,6 +23,7 @@ import { SseService } from '../../../core/services/sse.service';
 import { TvService } from '../../../core/services/tv.service';
 import { DropdownMenuComponent } from '../dropdown-menu';
 import { TvRowDirective } from '../../directives/tv-row.directive';
+import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 import { AddToPlaylistService } from '../../../core/services/add-to-playlist.service';
 import { LikesApiService } from '../../../core/services/api/likes-api.service';
 
@@ -40,6 +41,7 @@ import { LikesApiService } from '../../../core/services/api/likes-api.service';
     TranslateModule,
     DropdownMenuComponent,
     TvRowDirective,
+    ResolveUrlPipe,
     LucideX,
     LucideEllipsisVertical,
     LucideHeart,


### PR DESCRIPTION
## Bug
Poster/still thumbnails in the member **"Recommended by X"** card were broken in the native **Android** app.

## Cause
The card bound `<img [src]="img">` to the raw relative `/api/images/...` path. The web build resolves relative URLs against the page origin, but the Capacitor Android WebView has no such base, so the images 404'd. Every other card resolves image URLs through `ResolveUrlPipe`.

## Fix
Pipe the source through `resolveUrl:'thumb'` (same as `media-card`): resolves against the configured server base and requests the pre-generated thumbnail variant for the small w-24 image.

Frontend-only — verify on an Android device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)