### PR TITLE
refactor(ui): build the card actions menu on app-popover-menu

### DIFF
--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
@@ -1,111 +1,44 @@
-@if (service.open() && useDropdown()) {
-  <!-- TV / desktop: anchored dropdown — DaisyUI menu styling -->
-  <div
-    class="fixed inset-0 z-[100]"
-    (click)="onClose()"
-  ></div>
-  <div
-    #menu
-    data-tv-modal
-    class="card-actions-menu fixed z-[101] bg-base-200 rounded-box shadow-xl overflow-hidden"
-    animate.leave="card-actions-leaving"
-    [style.top.px]="position()?.top"
-    [style.left.px]="position()?.left"
-    [style.width.px]="position()?.width"
-    (keydown)="onMenuKey($event)"
-  >
-    @if (title()) {
-      <div class="flex items-start gap-3 px-4 py-3 border-b border-base-content/10">
-        @if (imageUrl(); as img) {
-          <img [src]="img | resolveUrl" alt="" loading="lazy"
-            class="shrink-0 rounded object-cover bg-base-300"
-            [style.width.px]="imageAspect() === 'landscape' ? 80 : 60"
-            [style.aspect-ratio]="imageAspect() === 'landscape' ? '16 / 9' : '2 / 3'" />
+<app-popover-menu
+  [open]="service.open()"
+  [anchor]="service.anchor()"
+  [placement]="placement()"
+  [width]="width()"
+  (closed)="onClose()"
+>
+  @if (title()) {
+    <div class="flex items-start gap-3 px-2 pb-3 mb-1 border-b border-base-content/10">
+      @if (imageUrl(); as img) {
+        <img [src]="img | resolveUrl" alt="" loading="lazy"
+          class="shrink-0 rounded object-cover bg-base-300"
+          [style.width.px]="imageAspect() === 'landscape' ? 80 : 60"
+          [style.aspect-ratio]="imageAspect() === 'landscape' ? '16 / 9' : '2 / 3'" />
+      }
+      <div class="min-w-0">
+        <div class="text-sm font-semibold line-clamp-2">{{ title() }}</div>
+        @if (subtitle()) {
+          <div class="text-xs text-base-content/60 line-clamp-2">{{ subtitle() }}</div>
         }
-        <div class="min-w-0">
-          <div class="text-sm font-semibold line-clamp-2">{{ title() }}</div>
-          @if (subtitle()) {
-            <div class="text-xs text-base-content/60 line-clamp-2">{{ subtitle() }}</div>
-          }
-        </div>
       </div>
-    }
-    <ul role="menu" class="menu p-2 gap-0.5 w-full">
-      @for (a of actions(); track a) {
-        <li [class.disabled]="a.disabled">
-          <button
-            type="button"
-            role="menuitem"
-            data-action
-            [disabled]="a.disabled"
-            class="flex items-center gap-3"
-            [class.text-error]="a.tone === 'danger'"
-            (click)="trigger(a)"
-          >
-            @switch (a.icon) {
-              @case ('play') { <svg lucidePlay class="h-4 w-4 shrink-0 opacity-70"></svg> }
-              @case ('external-link') { <svg lucideExternalLink class="h-4 w-4 shrink-0 opacity-70"></svg> }
-              @case ('eye') { <svg lucideEye class="h-4 w-4 shrink-0 opacity-70"></svg> }
-              @case ('eye-off') { <svg lucideEyeOff class="h-4 w-4 shrink-0 opacity-70"></svg> }
-              @case ('trash-2') { <svg lucideTrash2 class="h-4 w-4 shrink-0 opacity-70"></svg> }
-              @case ('list-plus') { <svg lucideListPlus class="h-4 w-4 shrink-0 opacity-70"></svg> }
-              @case ('user-plus') { <svg lucideUserPlus class="h-4 w-4 shrink-0 opacity-70"></svg> }
-            }
-            <span class="flex-1 truncate text-left">{{ a.labelKey ? (a.labelKey | translate) : a.label }}</span>
-          </button>
-        </li>
-      }
-    </ul>
-  </div>
-}
-@if (!useDropdown()) {
-  <!-- Mobile / TV: bottom sheet. Kept mounted (driven by [open], not gated
-       behind @if(service.open())) so service.close() plays the sheet's
-       slide-down exit. The sheet gates <ng-content> behind its own
-       @if(visible()), so the projected list is only instantiated while the
-       sheet is on screen. The list survives the slide-out because close()
-       keeps actions() populated until clear() runs once closed; actions()
-       falls back to [] so the @for/@if below stay null-safe. -->
-  <app-bottom-sheet [open]="service.open()" (closed)="onClose()">
-    <div #sheet data-tv-modal class="px-2 pb-2">
-      @if (title()) {
-        <div class="flex items-start gap-3 px-4 py-3 mb-1 border-b border-white/10">
-          @if (imageUrl(); as img) {
-            <img [src]="img | resolveUrl" alt="" loading="lazy"
-              class="shrink-0 rounded object-cover bg-white/10"
-              [style.width.px]="imageAspect() === 'landscape' ? 92 : 70"
-              [style.aspect-ratio]="imageAspect() === 'landscape' ? '16 / 9' : '2 / 3'" />
-          }
-          <div class="min-w-0">
-            <div class="text-white text-base font-semibold line-clamp-2">{{ title() }}</div>
-            @if (subtitle()) {
-              <div class="text-white/60 text-sm line-clamp-2">{{ subtitle() }}</div>
-            }
-          </div>
-        </div>
-      }
-      @for (a of actions(); track a) {
-        <button
-          type="button"
-          [disabled]="a.disabled"
-          class="w-full flex items-center gap-3 px-4 py-3.5 text-left text-base rounded-lg active:bg-white/10"
-          [class.text-white]="a.tone !== 'danger'"
-          [class.text-error]="a.tone === 'danger'"
-          [class.opacity-40]="a.disabled"
-          (click)="trigger(a)"
-        >
-          @switch (a.icon) {
-            @case ('play') { <svg lucidePlay class="h-5 w-5 shrink-0 opacity-80"></svg> }
-            @case ('external-link') { <svg lucideExternalLink class="h-5 w-5 shrink-0 opacity-80"></svg> }
-            @case ('eye') { <svg lucideEye class="h-5 w-5 shrink-0 opacity-80"></svg> }
-            @case ('eye-off') { <svg lucideEyeOff class="h-5 w-5 shrink-0 opacity-80"></svg> }
-            @case ('trash-2') { <svg lucideTrash2 class="h-5 w-5 shrink-0 opacity-80"></svg> }
-            @case ('list-plus') { <svg lucideListPlus class="h-5 w-5 shrink-0 opacity-80"></svg> }
-            @case ('user-plus') { <svg lucideUserPlus class="h-5 w-5 shrink-0 opacity-80"></svg> }
-          }
-          <span class="flex-1">{{ a.labelKey ? (a.labelKey | translate) : a.label }}</span>
-        </button>
-      }
     </div>
-  </app-bottom-sheet>
-}
+  }
+  @for (a of actions(); track a) {
+    <button
+      type="button"
+      class="dropdown-item"
+      [class.text-error]="a.tone === 'danger'"
+      [disabled]="a.disabled"
+      (click)="trigger(a)"
+    >
+      @switch (a.icon) {
+        @case ('play') { <svg lucidePlay class="h-4 w-4 shrink-0 opacity-70"></svg> }
+        @case ('external-link') { <svg lucideExternalLink class="h-4 w-4 shrink-0 opacity-70"></svg> }
+        @case ('eye') { <svg lucideEye class="h-4 w-4 shrink-0 opacity-70"></svg> }
+        @case ('eye-off') { <svg lucideEyeOff class="h-4 w-4 shrink-0 opacity-70"></svg> }
+        @case ('trash-2') { <svg lucideTrash2 class="h-4 w-4 shrink-0 opacity-70"></svg> }
+        @case ('list-plus') { <svg lucideListPlus class="h-4 w-4 shrink-0 opacity-70"></svg> }
+        @case ('user-plus') { <svg lucideUserPlus class="h-4 w-4 shrink-0 opacity-70"></svg> }
+      }
+      <span class="flex-1 truncate text-left">{{ a.labelKey ? (a.labelKey | translate) : a.label }}</span>
+    </button>
+  }
+</app-popover-menu>

--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.ts
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.ts
@@ -2,11 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
-  effect,
-  ElementRef,
   inject,
-  signal,
-  viewChild,
 } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import {
@@ -19,29 +15,21 @@ import {
   LucideUserPlus,
 } from '@lucide/angular';
 import { CardAction, CardActionsService } from '../../../core/services/card-actions.service';
-import { TvService } from '../../../core/services/tv.service';
-import { DeviceService } from '../../../core/services/device.service';
-import { BottomSheetComponent } from '../bottom-sheet';
+import { PopoverMenuComponent } from '../popover-menu';
 import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 
 /**
- * Singleton panel mounted once at the layout level. Picks its presentation
- * from the active platform:
- *
- *   • TV → absolutely-positioned dropdown anchored to the focused card,
- *     navigated with the D-pad.
- *   • Mobile native → bottom sheet (reuses BottomSheetComponent for swipe-down
- *     dismiss + safe-area handling).
- *
- * The component reads its content from `CardActionsService` and never holds
- * action state itself, so the same instance serves every card on the page.
+ * Singleton actions menu for cards, mounted once at the layout level. It reads
+ * its content from `CardActionsService` and delegates all chrome — anchored
+ * dropdown on desktop, bottom sheet on touch/TV, positioning, focus, spatial-nav
+ * scoping and dismiss — to `app-popover-menu`.
  */
 @Component({
   selector: 'app-card-actions-panel',
   standalone: true,
   imports: [
     TranslateModule,
-    BottomSheetComponent,
+    PopoverMenuComponent,
     ResolveUrlPipe,
     LucidePlay,
     LucideExternalLink,
@@ -53,77 +41,27 @@ import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './card-actions-panel.html',
-  styles: [`
-    .card-actions-menu {
-      transform-origin: top center;
-      animation: card-actions-pop 140ms cubic-bezier(0.2, 0, 0.13, 1.5);
-    }
-    @keyframes card-actions-pop {
-      from { opacity: 0; transform: scale(0.94) translateY(-4px); }
-      to   { opacity: 1; transform: scale(1) translateY(0); }
-    }
-    .card-actions-leaving {
-      animation: card-actions-pop-out 120ms ease forwards;
-    }
-    @keyframes card-actions-pop-out {
-      from { opacity: 1; transform: scale(1) translateY(0); }
-      to   { opacity: 0; transform: scale(0.94) translateY(-4px); }
-    }
-  `],
 })
 export class CardActionsPanelComponent {
   readonly service = inject(CardActionsService);
-  readonly tv = inject(TvService);
-  private readonly device = inject(DeviceService);
-
-  readonly menu = viewChild<ElementRef<HTMLElement>>('menu');
-  readonly sheet = viewChild<ElementRef<HTMLElement>>('sheet');
-
-  /** Computed style for the anchored dropdown — re-read on each open. */
-  readonly position = signal<{ top: number; left: number; width: number } | null>(null);
 
   readonly actions = computed(() => this.service.actions() ?? []);
   readonly title = this.service.title;
   readonly imageUrl = this.service.imageUrl;
   readonly imageAspect = this.service.imageAspect;
   readonly subtitle = this.service.subtitle;
-  readonly isTv = this.tv.isTv;
-  /**
-   * Anchored dropdown only on desktop with a mouse. TV and touch surfaces
-   * (mobile, tablet) get the bottom-sheet — bigger targets, predictable
-   * positioning, and no fragile dropdown anchoring with the body.tv scale
-   * transform.
-   */
-  readonly useDropdown = computed(() => !this.isTv() && !this.device.isTouch());
 
-  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
-
-  constructor() {
-    // body.tv applies a scale transform that re-anchors any fixed-position
-    // descendant (the bottom sheet) to body's box rather than the viewport.
-    // Move the panel host to <html> so its fixed positioning falls back to
-    // the viewport while the rest of the page keeps its overscan transform.
-    if (this.tv.isTv() && typeof document !== 'undefined') {
-      queueMicrotask(() => {
-        document.documentElement.appendChild(this.host.nativeElement);
-      });
-    }
-    // Recompute position and reset highlight when the panel opens.
-    effect(() => {
-      if (!this.service.open()) return;
-      if (this.useDropdown()) {
-        queueMicrotask(() => {
-          this.computePosition();
-          this.menu()?.nativeElement.querySelector<HTMLButtonElement>('button')?.focus();
-        });
-      } else if (this.isTv()) {
-        // Focus first action so the user can press Enter immediately.
-        queueMicrotask(() => {
-          this.sheet()?.nativeElement.querySelector<HTMLButtonElement>('button:not([disabled])')?.focus();
-        });
-      }
-    });
-  }
+  /** `button` aligns the menu's right edge under the ⋯ trigger; `card` centres
+   *  it under the card figure. */
+  readonly placement = computed(() =>
+    this.service.placement() === 'button' ? 'bottom-end' : 'bottom-center',
+  );
+  /** Compact under the ⋯ button; about the card's width under a figure. */
+  readonly width = computed(() => {
+    const anchor = this.service.anchor();
+    if (this.service.placement() === 'button' || !anchor) return 220;
+    return Math.min(280, Math.max(220, anchor.getBoundingClientRect().width));
+  });
 
   onClose() {
     this.service.close();
@@ -132,55 +70,7 @@ export class CardActionsPanelComponent {
   trigger(action: CardAction) {
     if (action.disabled) return;
     this.service.close();
-    // Defer the action so the panel close transition lands first.
+    // Defer so the close transition lands before the action navigates/mutates.
     queueMicrotask(() => action.run());
-  }
-
-  // Arrow nav is owned by the global spatial-nav service, scoped to this panel
-  // via `data-tv-modal` (keeps arrows inside the menu instead of leaking to the
-  // grid behind and scrolling the page); only Escape is handled locally.
-  onMenuKey(e: KeyboardEvent) {
-    if (!this.useDropdown() || e.key !== 'Escape') return;
-    e.preventDefault();
-    e.stopPropagation();
-    const anchor = this.service.anchor();
-    this.onClose();
-    if (anchor?.isConnected) {
-      queueMicrotask(() => anchor.focus({ preventScroll: true }));
-    }
-  }
-
-  private computePosition() {
-    const anchor = this.service.anchor();
-    if (!anchor) return;
-    const r = anchor.getBoundingClientRect();
-    const placement = this.service.placement();
-    const margin = placement === 'button' ? 4 : 12;
-    // Estimate the panel's height from action count instead of a fixed 320px:
-    // a single-action menu is ~120px tall, the old constant overestimated by
-    // a factor 3 and forced the panel to render above the anchor even when
-    // there was plenty of room below — landing well above the actual card.
-    const itemCount = this.actions()?.length ?? 0;
-    const titleHeight = this.title() ? 28 : 0;
-    const estimatedHeight =
-      Math.min(360, 24 + titleHeight + Math.max(itemCount, 1) * 44);
-    const fitsBelow = r.bottom + margin + estimatedHeight < window.innerHeight;
-    const top = fitsBelow
-      ? r.bottom + margin
-      : Math.max(8, r.top - estimatedHeight - margin);
-    let width: number;
-    let left: number;
-    if (placement === 'button') {
-      // Compact dropdown anchored to the button's right edge — overlays the
-      // card body below the ⋯ trigger.
-      width = 220;
-      left = r.right - width;
-    } else {
-      // Default: centered under the card figure.
-      width = Math.min(280, Math.max(220, r.width));
-      left = r.left + (r.width - width) / 2;
-    }
-    left = Math.max(8, Math.min(left, window.innerWidth - width - 8));
-    this.position.set({ top, left, width });
   }
 }

--- a/client/src/app/shared/components/popover-menu.ts
+++ b/client/src/app/shared/components/popover-menu.ts
@@ -86,11 +86,20 @@ export class PopoverMenuComponent {
   readonly open = input(false);
   /** Element the dropdown should anchor to on desktop. */
   readonly anchor = input<HTMLElement | null>(null);
-  /** Where the dropdown opens relative to the anchor. `right-start` / `left-start`
-   *  are side flyouts (used for submenus) that open beside the anchor. */
+  /** Where the dropdown opens relative to the anchor. `*-center` centers it
+   *  under the anchor; `right-start` / `left-start` are side flyouts (used for
+   *  submenus) that open beside the anchor. */
   readonly placement = input<
-    'bottom-end' | 'bottom-start' | 'top-end' | 'top-start' | 'right-start' | 'left-start'
+    | 'bottom-end'
+    | 'bottom-start'
+    | 'bottom-center'
+    | 'top-end'
+    | 'top-start'
+    | 'right-start'
+    | 'left-start'
   >('bottom-end');
+  /** Dropdown width in px (the sheet ignores it). */
+  readonly width = input(240);
   /** Marks this menu as a flyout submenu: spatial nav traps up/down inside it
    *  and lets left/right return to the opener in the parent menu. */
   readonly submenu = input(false);
@@ -216,7 +225,7 @@ export class PopoverMenuComponent {
   readonly position = computed(() => {
     this.viewportTick(); // dependency: forces recompute on scroll / resize
     const GUTTER = 8;
-    const WIDTH = 240;
+    const WIDTH = this.width();
     const MIN_HEIGHT = 120;
     const a = this.anchor();
     if (!a)
@@ -269,8 +278,12 @@ export class PopoverMenuComponent {
       : spaceBelow < MIN_HEIGHT && spaceAbove > spaceBelow;
     const maxHeight = Math.max(MIN_HEIGHT, openTop ? spaceAbove : spaceBelow);
 
-    // Horizontal: anchor to the requested edge, then clamp into the viewport.
-    const rawLeft = onEnd ? r.right - WIDTH : r.left;
+    // Horizontal: anchor to the requested edge (or centre), then clamp.
+    const rawLeft = placement.endsWith('center')
+      ? r.left + (r.width - WIDTH) / 2
+      : onEnd
+        ? r.right - WIDTH
+        : r.left;
     const left = Math.min(
       Math.max(GUTTER, rawLeft),
       Math.max(GUTTER, viewportW - WIDTH - GUTTER),


### PR DESCRIPTION
## Why
`card-actions-panel` re-implemented the entire anchored-menu chrome — JS positioning, host reparenting, the bottom-sheet branch, `data-tv-modal` scoping, focus-on-open, key handling — that **`app-popover-menu`** already provides (and that `select-picker` + `subtitles-modal` already reuse). Duplication of the trickiest, most subtle code.

## What
- **`app-popover-menu`** (backward-compatible extension): a `width` input (default `240`, so `select-picker`/`subtitles-modal` are unchanged) and a `bottom-center` placement.
- **`card-actions-panel`** rewritten to delegate all chrome to `<app-popover-menu>`. It now only reads content from `CardActionsService` and projects a header + `.dropdown-item` action list. Placement/width map the service's `button` (right-aligned, 220) / `card` (centred, ≈ card width) modes.

**~160 lines deleted.** Keyboard nav, animation and spatial-nav scoping are now identical to the app's other dropdowns.

## Risk / verification
`card-actions-panel` is on every media card. Build is clean, but the positioning + item styling changed (items now use the shared `.dropdown-item`; sheet items are a touch more compact). **Verify on the three surfaces**: desktop ⋯ dropdown, mobile long-press sheet, TV menu-key dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)