### PR TITLE
feat(home): format coming-soon dates in the active language

### DIFF
--- a/client/src/app/core/pipes/locale-date.pipe.ts
+++ b/client/src/app/core/pipes/locale-date.pipe.ts
@@ -1,0 +1,30 @@
+import { Pipe, PipeTransform, inject } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+
+/**
+ * Formats a date in the currently-selected language's convention (fr →
+ * DD/MM/YYYY, en → M/D/YYYY, …). Impure so it re-renders on a live language
+ * switch — Angular's DatePipe can't, since `LOCALE_ID` is fixed at bootstrap.
+ * Date-only strings (`YYYY-MM-DD`) format in UTC to avoid an off-by-one day.
+ */
+@Pipe({ name: 'localeDate', standalone: true, pure: false })
+export class LocaleDatePipe implements PipeTransform {
+  private readonly translate = inject(TranslateService);
+
+  transform(
+    value: string | Date | null | undefined,
+    options: Intl.DateTimeFormatOptions = {},
+  ): string {
+    if (!value) return '';
+    const date = typeof value === 'string' ? new Date(value) : value;
+    if (Number.isNaN(date.getTime())) return '';
+    const lang =
+      this.translate.currentLang || this.translate.defaultLang || undefined;
+    const dateOnly =
+      typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value);
+    return date.toLocaleDateString(lang, {
+      ...(dateOnly ? { timeZone: 'UTC' } : {}),
+      ...options,
+    });
+  }
+}

--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -154,7 +154,7 @@
                 [attr.data-home-focus]="'soon:' + entry.id"
                 [imageUrl]="entry.posterUrl"
                 [title]="entry.title"
-                [subtitle]="entry.date"
+                [subtitle]="entry.date | localeDate"
                 [link]="['/' + (entry.type === 'series' ? 'series' : 'movies'), '' + entry.mediaId]"
                 [playlistMediaId]="entry.mediaId"
               />

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -2,6 +2,7 @@ import { Component, ChangeDetectionStrategy, inject, signal, computed, effect, O
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Subscription, filter } from 'rxjs';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
+import { LocaleDatePipe } from '../../core/pipes/locale-date.pipe';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { MediaService, Media, CalendarEntry } from '../../core/services/api/media.service';
 import { StreamingApiService, ContinueWatchingItem, RecommendationItem } from '../../core/services/api/streaming-api.service';
@@ -77,6 +78,7 @@ import { RequestDeclineModalComponent } from '../requests/request-decline-modal/
   selector: 'app-home',
   imports: [
     RouterLink, TranslateModule, DefaultFocusDirective,
+    LocaleDatePipe,
     MediaCardComponent,
     MosaicCardComponent,
     HorizontalScrollerComponent,


### PR DESCRIPTION
## What
The **"Coming soon"** row showed raw ISO dates (`2026-07-17`). They now follow the selected language's convention (fr → `17/07/2026`, en → `7/17/2026`, …).

## How
New reusable **`localeDate`** pipe (`core/pipes/locale-date.pipe.ts`):
- Formats via `toLocaleDateString(translate.currentLang, …)` — the **active** language.
- **Impure**, so it re-renders on a live language switch. Angular's `DatePipe` can't, because `LOCALE_ID` is fixed at bootstrap.
- Date-only strings (`YYYY-MM-DD`) format in UTC to avoid an off-by-one day.
- Accepts optional `Intl.DateTimeFormatOptions` for other formats.

Applied to the coming-soon card subtitle.

## Follow-up (not in this PR)
Other date spots still hardcode `'fr-FR'` (always French regardless of language): `calendar` month header, `media-detail` episode air date, `watch-history` row date. A few admin screens use Angular's `| date` (bootstrap locale, not reactive to live switch): tmdb-preview, subtitles, backups, update-settings. The same pipe can replace all of these — happy to sweep them next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)