### PR TITLE
perf(streaming): hw-decode the OpenCL tone-map path (#729 proposal 1)

### DIFF
--- a/backend/src/modules/streaming/transcoding/codec/opencl-tonemap-probe.ts
+++ b/backend/src/modules/streaming/transcoding/codec/opencl-tonemap-probe.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { promisify } from 'util';
 import { openclTonemapInitArgs } from '../hw-device';
+import type { HwAccelType } from '../types';
 
 const execFileAsync = promisify(execFile);
 
@@ -23,7 +24,10 @@ export function isOpenclTonemapEnabled(): boolean {
   return probedOnce && enabled;
 }
 
-export async function runOpenclTonemapProbe(log: Logger): Promise<void> {
+export async function runOpenclTonemapProbe(
+  log: Logger,
+  hwAccel: HwAccelType,
+): Promise<void> {
   const t0 = Date.now();
   let failure = '';
   const hdrSample = path.join(
@@ -54,17 +58,25 @@ export async function runOpenclTonemapProbe(log: Logger): Promise<void> {
       { timeout: 15_000 },
     );
 
-    // The exact chain a session uses: CPU frame → OpenCL → tonemap → CPU.
-    // `opencl=ocl` auto-picks the first usable device (the NVIDIA GPU on an
-    // NVENC host; a bare Intel platform with no device is skipped).
+    // Mirror the session graph so a pass implies the real graph inits: HW
+    // decode (NVDEC / d3d11va) coexisting with the OpenCL filter device. cuda
+    // surfaces are downloaded before the OpenCL hwupload; d3d11va auto-downloads.
+    const decodeArgs =
+      hwAccel === 'nvenc'
+        ? ['-hwaccel', 'cuda', '-hwaccel_output_format', 'cuda']
+        : hwAccel === 'amf'
+          ? ['-hwaccel', 'd3d11va']
+          : [];
+    const download = hwAccel === 'nvenc' ? 'hwdownload,format=p010le,' : '';
     await execFileAsync(
       'ffmpeg',
       [
         '-hide_banner', '-loglevel', 'error',
+        ...decodeArgs,
         ...openclTonemapInitArgs(),
         '-i', hdrSample,
         '-vf',
-        'format=p010le,hwupload,tonemap_opencl=t=bt709:m=bt709:p=bt709:tonemap=hable:desat=0:format=nv12,hwdownload,format=nv12',
+        `${download}format=p010le,hwupload,tonemap_opencl=t=bt709:m=bt709:p=bt709:tonemap=hable:desat=0:format=nv12,hwdownload,format=nv12`,
         '-frames:v', '1',
         '-f', 'null', '-',
       ],

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -476,14 +476,13 @@ export function buildFfmpegArgs(
   // When the OpenCL tone-map probe passed, route it through tonemap_opencl
   // (GPU) instead of the CPU zscale chain — decisive on 4K where the CPU
   // tone-map can't sustain real-time, and it offloads the (often weak) APU CPU.
-  // Decode is forced to CPU so the frame reaches OpenCL via a plain hwupload
-  // (no CUDA/D3D11 ↔ OpenCL interop, which is unreliable); the tone-map, the
-  // expensive step, is what moves to the GPU.
   const openclTonemap =
     !!tonemap &&
     (effectiveHwAccel === 'nvenc' || effectiveHwAccel === 'amf') &&
     isOpenclTonemapEnabled();
-  const decodeHwAccel: HwAccelType = openclTonemap ? 'none' : effectiveHwAccel;
+  // GPU decode whenever available, including the tone-map path — the frame
+  // reaches OpenCL via hwdownload→hwupload (a copy, no CUDA/D3D11↔OpenCL interop).
+  const decodeHwAccel: HwAccelType = effectiveHwAccel;
 
   // Early sessions live ~1s before Shaka jumps to the main session — visual
   // quality on those warm-up frames is throwaway, so bias every knob towards
@@ -595,12 +594,18 @@ export function buildFfmpegArgs(
   // its device from the upstream `hwmap=derive_device=opencl` frame
   // context, and the round-trip back to qsv uses an explicit
   // `derive_device=qsv` on the closing hwmap.
-  if (tonemap && !useVaapiTonemap && decoder.outputSurface === 'vaapi') {
+  // `!openclTonemap`: that path inits `ocl` below — skip here to avoid a
+  // duplicate `-init_hw_device` alias when a vaapi decoder feeds an AMF/NVENC encode.
+  if (
+    tonemap &&
+    !useVaapiTonemap &&
+    decoder.outputSurface === 'vaapi' &&
+    !openclTonemap
+  ) {
     args.push('-init_hw_device', 'opencl=ocl:0.0');
   }
-  // NVENC/AMF OpenCL tone-map: init the OpenCL device and make it the default
-  // filter device so the chain's `hwupload` lands on it. Decode is CPU here
-  // (see openclTonemap above), so there's no competing hwaccel device.
+  // NVENC/AMF OpenCL tone-map: OpenCL as the default filter device so `hwupload`
+  // lands on it, coexisting with the HW decode device (validated by the probe).
   if (openclTonemap) {
     args.push(...openclTonemapInitArgs());
   }

--- a/backend/src/modules/streaming/transcoding/hw-decode-tonemap.spec.ts
+++ b/backend/src/modules/streaming/transcoding/hw-decode-tonemap.spec.ts
@@ -1,0 +1,85 @@
+import { Logger } from '@nestjs/common';
+
+jest.mock('./codec/opencl-tonemap-probe', () => ({
+  isOpenclTonemapEnabled: jest.fn(() => true),
+}));
+
+import { buildFfmpegArgs } from './ffmpeg-args';
+import type { BuildFfmpegArgsOptions } from './ffmpeg-args';
+import type { CodecVariant } from './codec/types';
+
+const silentLog = {
+  debug: () => {},
+  log: () => {},
+  warn: () => {},
+  error: () => {},
+} as unknown as Logger;
+
+const H264_SDR: CodecVariant = { codec: 'h264', bitDepth: 8, hdr: null };
+
+const opts = (over: Partial<BuildFfmpegArgsOptions>): BuildFfmpegArgsOptions =>
+  ({
+    inputPath: '/media/in.mkv',
+    outputDir: '/cache/out',
+    hwAccel: 'none',
+    profile: {
+      name: '2160p',
+      maxWidth: 3840,
+      maxHeight: 2160,
+      videoBitrate: '15M',
+      audioBitrate: '192k',
+    },
+    videoVariant: H264_SDR,
+    // 10-bit HEVC HDR source tone-mapped to 8-bit SDR — the openclTonemap case.
+    sourceVideoCodec: 'hevc',
+    sourceBitDepth: 10,
+    sourceWidth: 3840,
+    sourceHeight: 2160,
+    sourceFps: 24,
+    trustedStreamInfo: true,
+    tonemap: true,
+    ...over,
+  }) as BuildFfmpegArgsOptions;
+
+const vfOf = (args: string[]): string => args[args.indexOf('-vf') + 1];
+
+// #729 Proposal 1: the OpenCL tone-map path decodes on the GPU (was forced to
+// CPU). The boot probe is mocked enabled so buildFfmpegArgs takes that branch.
+describe('buildFfmpegArgs — HW decode on the OpenCL tone-map path (#729)', () => {
+  const platformDescriptor = Object.getOwnPropertyDescriptor(
+    process,
+    'platform',
+  )!;
+  afterEach(() =>
+    Object.defineProperty(process, 'platform', platformDescriptor),
+  );
+
+  it('NVENC: NVDEC-decodes (not CPU) and hwdownloads into tonemap_opencl', () => {
+    const args = buildFfmpegArgs(opts({ hwAccel: 'nvenc' }), silentLog);
+    const cli = args.join(' ');
+    // GPU decode — before Proposal 1 this path forced software decode.
+    expect(cli).toContain('-hwaccel cuda -hwaccel_output_format cuda');
+    // OpenCL filter device, inited exactly once (no duplicate `ocl` alias).
+    expect(cli).toContain('-init_hw_device opencl=ocl -filter_hw_device ocl');
+    expect(args.filter((a) => a === 'opencl=ocl')).toHaveLength(1);
+    // cuda surface pulled to system memory, tone-mapped on OpenCL, back to CPU.
+    const vf = vfOf(args);
+    expect(vf.startsWith('hwdownload,format=p010le,')).toBe(true);
+    expect(vf).toContain('tonemap_opencl=');
+    expect(vf).toContain('hwdownload,format=nv12');
+  });
+
+  it('AMF: d3d11va-decodes (not CPU) feeding tonemap_opencl', () => {
+    // AMF encoders are win32-gated.
+    Object.defineProperty(process, 'platform', {
+      value: 'win32',
+      configurable: true,
+    });
+    const args = buildFfmpegArgs(opts({ hwAccel: 'amf' }), silentLog);
+    const cli = args.join(' ');
+    expect(cli).toContain('-hwaccel d3d11va');
+    expect(cli).toContain('-init_hw_device opencl=ocl -filter_hw_device ocl');
+    expect(args.filter((a) => a === 'opencl=ocl')).toHaveLength(1);
+    expect(vfOf(args)).toContain('tonemap_opencl=');
+  });
+});

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -147,7 +147,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     // as CUDA/NVENC and AMD's driver, unlike the GLX/Vulkan chain which fails
     // headless).
     if (this.detectedHwAccel === 'nvenc' || this.detectedHwAccel === 'amf') {
-      void runOpenclTonemapProbe(this.log);
+      void runOpenclTonemapProbe(this.log, this.detectedHwAccel);
     }
     // Zero-copy AMD GPU scale for the AMF encode (scale_d3d11, needs FFmpeg
     // ≥ 8.1 and a GPU that accepts its output texture). Probed so an unavailable


### PR DESCRIPTION
Implements #729 Proposal 1: HW-decode the OpenCL HDR→SDR tone-map path.

The tone-map path forced CPU decode (`decodeHwAccel='none'`), software-decoding 4K sources even on HW-encode hosts. Now decode on the GPU whenever available (NVDEC / d3d11va); the frame reaches OpenCL via `hwdownload`→`hwupload` (a copy, not the unreliable CUDA/D3D11↔OpenCL interop). Win = GPU decode speed + CPU offload on 4K HDR tone-map (not zero-copy — the frame still round-trips CPU for tonemap_opencl).

**Guards** (from the #729 adversarial audit):
- `opencl-tonemap-probe` now runs the same `-hwaccel cuda` / `d3d11va` + `-filter_hw_device ocl` graph the session uses, so `enabled=true` implies the runtime graph inits (it previously probed CPU decode only → fail-open).
- Skip the vaapi opencl init when `openclTonemap` also inits `ocl`, avoiding a duplicate `-init_hw_device` alias when a vaapi decoder feeds an AMF/NVENC encode.

⚠️ **Needs on-hardware validation on NVIDIA + AMD before merge** — the device coexistence (CUDA/d3d11va + OpenCL in one process) can't be verified in CI. Test: play a 4K HDR film that tone-maps, from start AND a mid-file seek, on NVIDIA (HEVC source) and AMD.

Refs: #729, #720