### PR TITLE
fix(windows): correct the QSV detection and encoder probes on D3D11

### DIFF
--- a/backend/src/modules/streaming/transcoding/codec/encoder-probe.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoder-probe.ts
@@ -155,12 +155,14 @@ async function probeOne(d: EncoderDescriptor, _log: Logger): Promise<boolean> {
   //    'internal encoding error 24' at 320x180 specifically (probe
   //    false-negative we hit). nv12 / p010le sidestep the small-frame
   //    layout quirk.
-  //  - QSV: same `vaapi=va` + `qsv=qs@va` chain as `decoders/qsv.ts`
-  //    runtime decode, then `hwupload=extra_hw_frames=64,format=qsv`.
-  //    Earlier versions fed lavfi CPU input directly relying on
-  //    ffmpeg's auto-conversion; that produced false-positive PASSes
-  //    on hosts where the auto-converter is missing in the build,
-  //    only to crash at first real session.
+  //  - QSV: the platform device chain from `hw-device.ts` (native
+  //    `qsv=qs` on Windows, `vaapi=va` + `qsv=qs@va` on Linux), then
+  //    `hwupload,format=qsv`. Feeding qsv surfaces (not raw lavfi CPU
+  //    input relying on ffmpeg's auto-converter) keeps the probe honest
+  //    on builds without that converter. No `extra_hw_frames`: a padded
+  //    upload pool becomes a larger D3D11 array texture that the Intel
+  //    D3D11 stack rejects with E_INVALIDARG, so the plain upload is
+  //    both representative and the allocation that actually succeeds.
   //  - CPU (`'none'`): plain lavfi input — no device.
   const surfaceFmt = d.variant.bitDepth === 10 ? 'p010le' : 'nv12';
   const lavfi = `nullsrc=size=320x180:rate=30,format=${pixFmt}`;
@@ -189,10 +191,7 @@ async function probeOne(d: EncoderDescriptor, _log: Logger): Promise<boolean> {
         '-i',
         lavfi,
       ];
-      filterArgs = [
-        '-vf',
-        `format=${surfaceFmt},hwupload=extra_hw_frames=64,format=qsv`,
-      ];
+      filterArgs = ['-vf', `format=${surfaceFmt},hwupload,format=qsv`];
       break;
     default:
       inputArgs = ['-f', 'lavfi', '-i', lavfi];

--- a/backend/src/modules/streaming/transcoding/hw-detect.spec.ts
+++ b/backend/src/modules/streaming/transcoding/hw-detect.spec.ts
@@ -24,6 +24,12 @@ function probedEncoders(): string[] {
   });
 }
 
+/** The `-vf` filter string of the first probe invocation. */
+function firstProbeFilter(): string {
+  const args = mockExecFile.mock.calls[0][1] as string[];
+  return args[args.indexOf('-vf') + 1];
+}
+
 describe('detectHwAccel', () => {
   beforeEach(() => mockExecFile.mockReset());
 
@@ -71,6 +77,18 @@ describe('detectHwAccel', () => {
     const qsvCall = mockExecFile.mock.calls[0][1] as string[];
     expect(qsvCall).toContain('vaapi=va:/dev/dri/renderD128');
     expect(qsvCall).toContain('qsv=qs@va');
+  });
+
+  it('drives vpp_qsv in the Windows QSV probe so it matches the real path', async () => {
+    programProbes(() => false);
+    await detectHwAccel(log, 'win32');
+    expect(firstProbeFilter()).toContain('vpp_qsv');
+  });
+
+  it('keeps the plain upload probe for Linux QSV (no vpp_qsv)', async () => {
+    programProbes(() => false);
+    await detectHwAccel(log, 'linux');
+    expect(firstProbeFilter()).not.toContain('vpp_qsv');
   });
 });
 

--- a/backend/src/modules/streaming/transcoding/hw-detect.ts
+++ b/backend/src/modules/streaming/transcoding/hw-detect.ts
@@ -14,8 +14,21 @@ const BLACK_INPUT = ['-f', 'lavfi', '-i', 'color=black:s=320x240:d=0.1'];
 const ONE_FRAME_NULL = ['-frames:v', '1', '-f', 'null', '-'];
 
 /** QSV one-frame probe. On Windows QSV initialises natively (`qsv=qs`); on
- *  Linux it derives from VAAPI (see {@link qsvDeviceInitArgs}). */
+ *  Linux it derives from VAAPI (see {@link qsvDeviceInitArgs}).
+ *
+ *  Windows transcodes run qsv-native decode + `vpp_qsv` scaling on the QSV
+ *  device, so the probe drives `vpp_qsv`: its output pool is a D3D11
+ *  `RENDER_TARGET` array texture — a strictly stronger allocation than a
+ *  plain `hwupload` (`BIND_DECODER`) pool, and one an outdated Intel driver
+ *  can reject on its own. Exercising the full filter path keeps detection
+ *  honest: QSV is green-lit only when the real transcode can run. Linux QSV
+ *  derives from VAAPI and scales via `scale_vaapi`→`hwmap`, so it keeps the
+ *  plain upload probe. */
 function qsvTest(platform: NodeJS.Platform): HwTest {
+  const filter =
+    platform === 'win32'
+      ? 'format=nv12,hwupload,vpp_qsv=w=160:h=120:format=nv12'
+      : 'hwupload,format=qsv';
   return {
     type: 'qsv',
     args: [
@@ -27,7 +40,7 @@ function qsvTest(platform: NodeJS.Platform): HwTest {
       'qs',
       ...BLACK_INPUT,
       '-vf',
-      'hwupload,format=qsv',
+      filter,
       '-c:v',
       'h264_qsv',
       ...ONE_FRAME_NULL,

--- a/backend/src/modules/streaming/transcoding/hw-detect.ts
+++ b/backend/src/modules/streaming/transcoding/hw-detect.ts
@@ -27,7 +27,7 @@ function qsvTest(platform: NodeJS.Platform): HwTest {
       'qs',
       ...BLACK_INPUT,
       '-vf',
-      'hwupload=extra_hw_frames=64,format=qsv',
+      'hwupload,format=qsv',
       '-c:v',
       'h264_qsv',
       ...ONE_FRAME_NULL,

--- a/windows/Scripts/fetch-vendored.ps1
+++ b/windows/Scripts/fetch-vendored.ps1
@@ -67,6 +67,29 @@ if (Test-Path (Join-Path $vendored 'pgsql\bin\postgres.exe')) {
     Write-Host "    [done] PostgreSQL $PgVersion"
 }
 
+# ── VC++ 2015-2022 runtime, app-local next to the exes that link it ──
+# The PG18 EDB and Node binaries are built with a recent VS toolset; on a host
+# whose system MSVCP140.dll is older they crash (0xC0000005 ACCESS_VIOLATION —
+# seen at initdb). Windows searches the exe's own directory before System32, so
+# bundling the runtime beside each exe makes it load the correct version.
+$vcDlls = @(
+    'MSVCP140.dll', 'MSVCP140_1.dll', 'MSVCP140_2.dll', 'MSVCP140_atomic_wait.dll',
+    'VCRUNTIME140.dll', 'VCRUNTIME140_1.dll', 'CONCRT140.dll'
+)
+foreach ($dir in @((Join-Path $vendored 'pgsql\bin'), (Join-Path $vendored 'node'))) {
+    foreach ($dll in $vcDlls) {
+        $src = Join-Path $env:SystemRoot "System32\$dll"
+        $dst = Join-Path $dir $dll
+        if ((Test-Path $src) -and -not (Test-Path $dst)) { Copy-Item $src $dst -Force }
+    }
+}
+$mp = Join-Path $vendored 'pgsql\bin\MSVCP140.dll'
+if (Test-Path $mp) {
+    Write-Host "    [done] VC++ runtime bundled ($((Get-Item $mp).VersionInfo.FileVersion))"
+} else {
+    Write-Warning 'MSVCP140.dll not bundled; postgres/node may crash on hosts with an old VC++ runtime'
+}
+
 # ── FFmpeg (BtbN gpl static) ──
 if (Test-Path (Join-Path $vendored 'ffmpeg\bin\ffmpeg.exe')) {
     Write-Host '    [skip] FFmpeg already present'


### PR DESCRIPTION
On Windows the QSV capability probes disagreed with the real transcode path, so QSV was mis-detected. Two probes were wrong; both are D3D11 frame-pool allocation issues surfacing as `Could not create the texture (0x80070057 E_INVALIDARG)`.

## 1. Detection probe was a false positive

The real Windows QSV path is *qsv-native decode + `vpp_qsv` scaling* on the QSV device. `vpp_qsv`'s **output** frame pool is a D3D11 `RENDER_TARGET` **array texture** (`hwcontext_qsv.c` maps `MFX_MEMTYPE_FROM_VPPOUT` → `D3D11_BIND_RENDER_TARGET`, allocated as one array texture). The detection probe only exercised a plain `hwupload` pool (`D3D11_BIND_DECODER`, a strictly weaker allocation), so it passed while the real `vpp_qsv` output pool failed.

**Fix:** drive `vpp_qsv` in the Windows detection probe. Outdated driver → probe fails → CPU fallback; current driver → QSV as intended. Linux keeps the plain upload probe (it scales via `scale_vaapi`→`hwmap`, not `vpp_qsv`).

## 2. Encoder probe was a false negative

The per-encoder QSV probe uploaded through `hwupload=extra_hw_frames=64,format=qsv`. The padded pool becomes a larger D3D11 array texture the Intel stack rejects with `E_INVALIDARG` — so `h264_qsv`/`hevc_qsv`/`av1_qsv` were all blacklisted *even when detection and QSV decode succeeded*. `cab6c11a` had already removed `extra_hw_frames` from the detection probe for this exact reason; the encoder probe still carried it.

**Fix:** drop `extra_hw_frames` — a plain `hwupload,format=qsv` pool encodes fine and stays representative of the runtime path.

## Verified on hardware (Intel Iris Xe, Tiger Lake)

- Old driver `31.0.101.1999` (2022): every `vpp_qsv`/`scale_qsv` output pool fails; detection now correctly rejects QSV → CPU. (Also confirmed device wiring is irrelevant — explicit `d3d11va` derive fails identically; bind flags come from the MFX frame type. QSV mandates a fixed pool, so there is no single-texture path to sidestep the array — support is driver-gated.)
- Current driver: `vpp_qsv` detection passes, QSV native decode enabled, and `hwupload,format=qsv → h264_qsv` encodes (`EXIT=0`), while the old `extra_hw_frames=64` form still fails. So both probes now match the real path.

## Tests

`hw-detect.spec.ts`: added coverage that the Windows probe drives `vpp_qsv` and Linux does not. All streaming specs + typecheck green.

Refs: #720