### PR TITLE
fix(streaming): keep Windows QSV HDR tonemap on the vpp_qsv LUT

### DIFF
--- a/backend/src/modules/streaming/transcoding/encode-pipeline.spec.ts
+++ b/backend/src/modules/streaming/transcoding/encode-pipeline.spec.ts
@@ -2,12 +2,21 @@ import { resolveEncodePipeline } from './encode-pipeline';
 import type { EncodePipelineContext } from './encode-pipeline';
 import type { CodecVariant } from './codec/types';
 import { isScaleD3d11Enabled } from './codec/scale-d3d11-probe';
+import { isVppQsvTonemapEnabled } from './codec/vpp-qsv-probe';
 
 jest.mock('./codec/scale-d3d11-probe', () => ({
   isScaleD3d11Enabled: jest.fn(() => false),
 }));
+jest.mock('./codec/vpp-qsv-probe', () => ({
+  isVppQsvTonemapEnabled: jest.fn(() => false),
+}));
 
 const mockScaleD3d11 = isScaleD3d11Enabled as jest.Mock;
+const mockVppQsvTonemap = isVppQsvTonemapEnabled as jest.Mock;
+
+beforeEach(() => {
+  mockVppQsvTonemap.mockReturnValue(false);
+});
 
 const SDR_H264: CodecVariant = { codec: 'h264', bitDepth: 8, hdr: null };
 
@@ -47,6 +56,19 @@ describe('resolveEncodePipeline — Windows QSV routing', () => {
     expect(r.qsvNativeAvailable).toBe(false);
     expect(r.requestedHwAccel).toBe('none');
     expect(r.effectiveHwAccel).toBe('none');
+  });
+
+  it('keeps a Windows auto HDR tonemap on QSV via the vpp_qsv LUT (no CPU drop)', () => {
+    mockVppQsvTonemap.mockReturnValue(true);
+    const r = resolveEncodePipeline(
+      SDR_H264,
+      ctx({ tonemap: true, tonemapAlgo: 'auto', sourceVideoCodec: 'hevc' }),
+      'win32',
+    );
+    expect(r.tonemapPath).toBe('qsv');
+    expect(r.qsvNativeAvailable).toBe(true);
+    expect(r.requestedHwAccel).toBe('qsv');
+    expect(r.effectiveHwAccel).toBe('qsv');
   });
 });
 

--- a/backend/src/modules/streaming/transcoding/encode-pipeline.ts
+++ b/backend/src/modules/streaming/transcoding/encode-pipeline.ts
@@ -84,9 +84,11 @@ export function resolveEncodePipeline(
   // `auto` picks opencl when the boot probe enabled it, vaapi otherwise; the
   // explicit overrides bypass the probe. Drives both the qsv-native gate and
   // the useVaapiTonemap flag so the two stay in sync.
-  const tonemapPath = resolveTonemapPath(ctx.tonemapAlgo, {
-    hasCrop: ctx.crop,
-  });
+  const tonemapPath = resolveTonemapPath(
+    ctx.tonemapAlgo,
+    { hasCrop: ctx.crop },
+    platform,
+  );
   const tonemapOpenclOk = ctx.crop
     ? isTonemapOpenclEnabledWithCrop()
     : isTonemapOpenclEnabled();

--- a/backend/src/modules/streaming/transcoding/encode-pipeline.ts
+++ b/backend/src/modules/streaming/transcoding/encode-pipeline.ts
@@ -1,4 +1,5 @@
 import { requestedHwAccelFor } from './hw-detect';
+import { hostHasVaapi } from './hw-device';
 import { encoderRegistry } from './codec/encoders';
 import { isDecoderEnabled } from './codec/decoder-probe';
 import { isVppQsvTonemapEnabled } from './codec/vpp-qsv-probe';
@@ -60,7 +61,7 @@ export function resolveEncodePipeline(
   ctx: EncodePipelineContext,
   platform: NodeJS.Platform = process.platform,
 ): ResolvedEncodePipeline {
-  const isWindows = platform === 'win32';
+  const noVaapi = !hostHasVaapi(platform);
   const normalisedSourceCodec = normaliseSourceCodec(ctx.sourceVideoCodec);
   const hasUsableQsvNativeDecoder =
     ctx.hwAccel === 'qsv' &&
@@ -95,11 +96,11 @@ export function resolveEncodePipeline(
   // Keep the whole pipeline on QSV (no hwdownload→crop→hwupload round-trip):
   // crop-only always; tonemap via vpp_qsv LUT or via opencl when probed;
   // tonemap via vaapi is NOT qsv-native compatible.
-  // Windows QSV has no VAAPI chain, so the qsv-native pipeline is the only
-  // QSV path — used for every session (not just crop/tonemap as on Linux).
+  // Without VAAPI (Windows) the qsv-native pipeline is the only QSV path, so
+  // it's used for every session (not just crop/tonemap as on Linux).
   const qsvNativeAvailable =
     hasUsableQsvNativeDecoder &&
-    (isWindows ||
+    (noVaapi ||
       ctx.crop ||
       tonemapPath === 'qsv' ||
       tonemapPath === 'opencl') &&
@@ -115,9 +116,10 @@ export function resolveEncodePipeline(
     { burnIn: ctx.burnIn, crop: ctx.crop, qsvCanCrop },
     platform,
   );
-  // On Windows, QSV without a viable native pipeline (e.g. HDR tonemap with
-  // no vpp_qsv/opencl) has no fallback chain — drop to CPU encode.
-  if (isWindows && ctx.hwAccel === 'qsv' && !qsvNativeAvailable) {
+  // Without a VAAPI fallback (Windows), QSV without a viable native pipeline
+  // (e.g. HDR tonemap with no vpp_qsv/opencl) has no fallback chain — drop to
+  // CPU encode.
+  if (noVaapi && ctx.hwAccel === 'qsv' && !qsvNativeAvailable) {
     requestedHwAccel = 'none';
   }
   const encoder = encoderRegistry.resolve(variant, requestedHwAccel);

--- a/backend/src/modules/streaming/transcoding/hw-detect.ts
+++ b/backend/src/modules/streaming/transcoding/hw-detect.ts
@@ -2,7 +2,7 @@ import { Logger } from '@nestjs/common';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import type { HwAccelType } from './types';
-import { qsvDeviceInitArgs, vaapiDeviceInitArgs } from './hw-device';
+import { hostHasVaapi, qsvDeviceInitArgs, vaapiDeviceInitArgs } from './hw-device';
 
 const execFileAsync = promisify(execFile);
 
@@ -153,7 +153,7 @@ export function requestedHwAccelFor(
     detected === 'qsv' &&
     needs.crop &&
     !needs.qsvCanCrop &&
-    platform !== 'win32'
+    hostHasVaapi(platform)
   )
     return 'vaapi';
   return detected;

--- a/backend/src/modules/streaming/transcoding/hw-device.spec.ts
+++ b/backend/src/modules/streaming/transcoding/hw-device.spec.ts
@@ -1,4 +1,5 @@
 import {
+  hostHasVaapi,
   openclTonemapInitArgs,
   qsvDeviceInitArgs,
   vaapiDeviceInitArgs,
@@ -64,6 +65,15 @@ describe('hw-device', () => {
         '-init_hw_device',
         'qsv=qs@va',
       ]);
+    });
+  });
+
+  describe('hostHasVaapi', () => {
+    it('is true on Linux (QSV is VAAPI-backed)', () => {
+      expect(hostHasVaapi('linux')).toBe(true);
+    });
+    it('is false on Windows (QSV runs natively on D3D11)', () => {
+      expect(hostHasVaapi('win32')).toBe(false);
     });
   });
 

--- a/backend/src/modules/streaming/transcoding/hw-device.ts
+++ b/backend/src/modules/streaming/transcoding/hw-device.ts
@@ -31,6 +31,17 @@ export function qsvDeviceInitArgs(
   ];
 }
 
+/** Whether QSV is backed by a VAAPI device on this host: true on Linux
+ *  (`qsv=qs@va`), false on Windows (native D3D11). The QSV→VAAPI crop
+ *  fallback and the VAAPI/`tonemap_vaapi` tone-map paths need a VAAPI device,
+ *  so when this is false they must stay QSV-native (`vpp_qsv`) or drop to CPU —
+ *  there is no VAAPI to route through. (macOS has no QSV, so it never asks.) */
+export function hostHasVaapi(
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return platform !== 'win32';
+}
+
 /** OpenCL device + filter selector for the NVENC/CPU standalone tonemap
  *  chain (`hwupload,tonemap_opencl,hwdownload`). Defaults to `ocl` (auto-pick
  *  the first usable platform — the NVIDIA GPU on an NVENC host). Set

--- a/backend/src/modules/streaming/transcoding/tonemap-path.spec.ts
+++ b/backend/src/modules/streaming/transcoding/tonemap-path.spec.ts
@@ -1,0 +1,88 @@
+jest.mock('./codec/tonemap-opencl-probe', () => ({
+  isTonemapOpenclEnabled: jest.fn(() => false),
+  isTonemapOpenclEnabledWithCrop: jest.fn(() => false),
+}));
+jest.mock('./codec/vpp-qsv-probe', () => ({
+  isVppQsvTonemapEnabled: jest.fn(() => false),
+}));
+
+import { resolveTonemapPath } from './tonemap-path';
+import {
+  isTonemapOpenclEnabled,
+  isTonemapOpenclEnabledWithCrop,
+} from './codec/tonemap-opencl-probe';
+import { isVppQsvTonemapEnabled } from './codec/vpp-qsv-probe';
+
+const openclNoCrop = isTonemapOpenclEnabled as jest.Mock;
+const openclCrop = isTonemapOpenclEnabledWithCrop as jest.Mock;
+const vppQsv = isVppQsvTonemapEnabled as jest.Mock;
+
+describe('resolveTonemapPath', () => {
+  beforeEach(() => {
+    openclNoCrop.mockReturnValue(false);
+    openclCrop.mockReturnValue(false);
+    vppQsv.mockReturnValue(false);
+  });
+
+  it('passes explicit picks through unchanged, on any platform', () => {
+    expect(resolveTonemapPath('qsv', { hasCrop: false }, 'win32')).toBe('qsv');
+    expect(resolveTonemapPath('vaapi', { hasCrop: false }, 'linux')).toBe(
+      'vaapi',
+    );
+    expect(resolveTonemapPath('opencl', { hasCrop: false }, 'win32')).toBe(
+      'opencl',
+    );
+  });
+
+  it('auto → opencl when the opencl probe passed', () => {
+    openclNoCrop.mockReturnValue(true);
+    expect(resolveTonemapPath('auto', { hasCrop: false }, 'linux')).toBe(
+      'opencl',
+    );
+  });
+
+  it('auto consults the crop-variant opencl probe when cropping', () => {
+    openclCrop.mockReturnValue(true);
+    openclNoCrop.mockReturnValue(false);
+    expect(resolveTonemapPath('auto', { hasCrop: true }, 'linux')).toBe(
+      'opencl',
+    );
+    // The no-crop result must not leak into the cropped decision.
+    openclCrop.mockReturnValue(false);
+    openclNoCrop.mockReturnValue(true);
+    expect(resolveTonemapPath('auto', { hasCrop: true }, 'linux')).toBe('vaapi');
+  });
+
+  it('auto → vaapi on Linux when opencl is unavailable (VAAPI is a valid QSV path there)', () => {
+    expect(resolveTonemapPath('auto', { hasCrop: false }, 'linux')).toBe(
+      'vaapi',
+    );
+  });
+
+  it('auto → qsv on Windows when opencl is unavailable but the vpp_qsv LUT probe passed', () => {
+    vppQsv.mockReturnValue(true);
+    expect(resolveTonemapPath('auto', { hasCrop: false }, 'win32')).toBe('qsv');
+  });
+
+  it('auto → vaapi on Windows when neither opencl nor the vpp_qsv LUT is available', () => {
+    vppQsv.mockReturnValue(false);
+    expect(resolveTonemapPath('auto', { hasCrop: false }, 'win32')).toBe(
+      'vaapi',
+    );
+  });
+
+  it('does not divert to the qsv LUT on Linux even when its probe passed', () => {
+    vppQsv.mockReturnValue(true);
+    expect(resolveTonemapPath('auto', { hasCrop: false }, 'linux')).toBe(
+      'vaapi',
+    );
+  });
+
+  it('prefers opencl over the qsv LUT on Windows when both are available', () => {
+    openclNoCrop.mockReturnValue(true);
+    vppQsv.mockReturnValue(true);
+    expect(resolveTonemapPath('auto', { hasCrop: false }, 'win32')).toBe(
+      'opencl',
+    );
+  });
+});

--- a/backend/src/modules/streaming/transcoding/tonemap-path.ts
+++ b/backend/src/modules/streaming/transcoding/tonemap-path.ts
@@ -2,6 +2,7 @@ import {
   isTonemapOpenclEnabled,
   isTonemapOpenclEnabledWithCrop,
 } from './codec/tonemap-opencl-probe';
+import { isVppQsvTonemapEnabled } from './codec/vpp-qsv-probe';
 import type { TonemapAlgo } from './types';
 
 /** Concrete filter chain the session-time graph will actually use,
@@ -10,10 +11,12 @@ import type { TonemapAlgo } from './types';
  *  - `'auto'` resolves to `'opencl'` when the matching boot probe
  *    enabled it (separate probes run with and without a crop prefix
  *    because some Intel iHD builds accept the basic opencl chain but
- *    fail the cropped variant), else `'vaapi'` — that fallback
- *    covers macOS, containers without an OpenCL stack, and Intel
- *    hosts whose iHD driver fails the bridge with the
- *    `QSV to OpenCL mapping not usable` / exit=218 pattern.
+ *    fail the cropped variant). Otherwise it falls back to `'qsv'` on
+ *    Windows (the vpp_qsv fixed-function LUT) when that probe passed,
+ *    and to `'vaapi'` elsewhere. The Windows split matters because
+ *    Windows has no VAAPI device: `'vaapi'` there is not a QSV path at
+ *    all, so it would force the session onto a CPU encode. On Linux
+ *    QSV is VAAPI-backed, so `'vaapi'` stays a valid on-GPU tone-map.
  *  - Explicit picks (`'vaapi'` / `'qsv'` / `'opencl'`) bypass the
  *    probe and trust the admin to know their hardware.
  *
@@ -25,12 +28,15 @@ export type ResolvedTonemapPath = 'vaapi' | 'opencl' | 'qsv';
 export function resolveTonemapPath(
   algo: TonemapAlgo,
   opts: { hasCrop: boolean } = { hasCrop: false },
+  platform: NodeJS.Platform = process.platform,
 ): ResolvedTonemapPath {
   if (algo === 'auto') {
     const openclOk = opts.hasCrop
       ? isTonemapOpenclEnabledWithCrop()
       : isTonemapOpenclEnabled();
-    return openclOk ? 'opencl' : 'vaapi';
+    if (openclOk) return 'opencl';
+    if (platform === 'win32' && isVppQsvTonemapEnabled()) return 'qsv';
+    return 'vaapi';
   }
   return algo;
 }

--- a/backend/src/modules/streaming/transcoding/tonemap-path.ts
+++ b/backend/src/modules/streaming/transcoding/tonemap-path.ts
@@ -3,6 +3,7 @@ import {
   isTonemapOpenclEnabledWithCrop,
 } from './codec/tonemap-opencl-probe';
 import { isVppQsvTonemapEnabled } from './codec/vpp-qsv-probe';
+import { hostHasVaapi } from './hw-device';
 import type { TonemapAlgo } from './types';
 
 /** Concrete filter chain the session-time graph will actually use,
@@ -35,7 +36,10 @@ export function resolveTonemapPath(
       ? isTonemapOpenclEnabledWithCrop()
       : isTonemapOpenclEnabled();
     if (openclOk) return 'opencl';
-    if (platform === 'win32' && isVppQsvTonemapEnabled()) return 'qsv';
+    // No VAAPI device (Windows): 'vaapi' isn't a QSV path, so prefer the
+    // vpp_qsv fixed-function LUT when its probe passed rather than force a
+    // CPU encode.
+    if (!hostHasVaapi(platform) && isVppQsvTonemapEnabled()) return 'qsv';
     return 'vaapi';
   }
   return algo;


### PR DESCRIPTION
## Problem

On Windows, an HDR→SDR session with the default `tonemapAlgo='auto'` silently dropped to a **CPU `libx265`** encode instead of the QSV GPU encoder. On 4K HDR that cannot sustain real-time.

Root cause: `resolveTonemapPath('auto')` resolves to `'opencl'` or `'vaapi'`, never `'qsv'`. The OpenCL tone-map probe is VAAPI-based and always fails on Windows, so `'auto'` → `'vaapi'`. But Windows has no VAAPI device, so `'vaapi'` isn't a QSV-native path — `resolveEncodePipeline` then forces `requestedHwAccel='none'` → CPU.

## Fix

When OpenCL is unavailable **and there is no VAAPI device**, fall back to `'qsv'` — the `vpp_qsv` fixed-function HDR→SDR LUT — when its boot probe passed. HDR→SDR then stays on the QSV encoder.

- **Linux unchanged**: QSV there is VAAPI-backed, so `'vaapi'` stays a valid on-GPU tone-map (`tonemap_vaapi` → `hwmap qsv`) and is still preferred.
- The "no VAAPI on Windows" fact is now named `hostHasVaapi(platform)` (hw-device.ts) and shared by the three sites that branched on it (the QSV→VAAPI crop fallback, the CPU-drop guard + qsv-native gate, and this tone-map fallback), replacing raw `platform === 'win32'` checks.

## Why not native QSV↔OpenCL (reinhard)?

Measured on Iris Xe (`plans/qsv-opencl-native-windows.plan.md`): infeasible on the bundled FFmpeg. QSV→OpenCL needs `cl_intel_va_api_media_sharing` (VAAPI/Linux-only); D3D11→OpenCL exists but is NV12-only, so it can't carry the 10-bit P010 HDR surface. The vpp_qsv LUT is the on-GPU HDR option on Windows. (An OpenCL CPU-bounce is a possible quality upgrade later if the LUT visibly under-exposes.)

## Tests

New `tonemap-path.spec.ts` (auto resolution across platforms), a `hostHasVaapi` case in `hw-device.spec.ts`, and an `encode-pipeline.spec.ts` case asserting a Windows auto HDR session stays on QSV. 406 streaming specs + typecheck green.

## Testing note

Exercising this on the box needs **#732** too (the QSV encoder-probe fix); otherwise the QSV encoders stay disabled and there is nothing to route HDR to.

Refs: #720
