### PR TITLE
chore(streaming): quiet benign subtitle-probe warnings in transcode logs

### DIFF
--- a/backend/src/modules/streaming/transcoding/ffmpeg-stderr.spec.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-stderr.spec.ts
@@ -1,0 +1,39 @@
+import { stripBenignFfmpegStderr } from './ffmpeg-stderr';
+
+describe('stripBenignFfmpegStderr', () => {
+  it('drops PGS/VOBSUB subtitle codec-parameter warnings and their hint', () => {
+    const raw = [
+      "[in#0/matroska,webm @ 0x1] Could not find codec parameters for stream 5 (Subtitle: hdmv_pgs_subtitle (pgssub)): unspecified size",
+      "Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options",
+      "[in#0/matroska,webm @ 0x1] Could not find codec parameters for stream 6 (Subtitle: dvd_subtitle): unspecified size",
+      "Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options",
+    ].join('\n');
+    expect(stripBenignFfmpegStderr(raw)).toBe('');
+  });
+
+  it('keeps the real error while dropping the surrounding subtitle noise', () => {
+    const raw = [
+      '[in#0/matroska,webm @ 0x1] Could not find codec parameters for stream 5 (Subtitle: hdmv_pgs_subtitle (pgssub)): unspecified size',
+      "Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options",
+      '[vf#0:0 @ 0x2] Task finished with error code: -17 (File exists)',
+      '[vost#0:0/h264_qsv @ 0x3] Could not open encoder before EOF',
+    ].join('\n');
+    expect(stripBenignFfmpegStderr(raw)).toBe(
+      [
+        '[vf#0:0 @ 0x2] Task finished with error code: -17 (File exists)',
+        '[vost#0:0/h264_qsv @ 0x3] Could not open encoder before EOF',
+      ].join('\n'),
+    );
+  });
+
+  it('leaves a codec-param warning for a non-subtitle stream untouched', () => {
+    const raw =
+      '[in#0/matroska,webm @ 0x1] Could not find codec parameters for stream 0 (Video: hevc): unspecified size';
+    expect(stripBenignFfmpegStderr(raw)).toBe(raw);
+  });
+
+  it('is a no-op on clean stderr', () => {
+    const raw = 'frame= 100 fps=30 q=28.0 size=1024KiB';
+    expect(stripBenignFfmpegStderr(raw)).toBe(raw);
+  });
+});

--- a/backend/src/modules/streaming/transcoding/ffmpeg-stderr.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-stderr.ts
@@ -1,0 +1,25 @@
+/** Benign ffmpeg stderr lines dropped before a transcode's stderr tail is
+ *  logged. They clutter diagnostics — and make a real failure harder to read —
+ *  without signalling a fault:
+ *
+ *   - Image-subtitle streams (PGS / VOBSUB) we never map report
+ *     `Could not find codec parameters for stream N (Subtitle: …): unspecified
+ *     size` under the fast-start `-analyzeduration 0` probe. The streams aren't
+ *     in the output map, so the transcode is unaffected.
+ *   - ffmpeg's paired `Consider increasing the value for the 'analyzeduration'`
+ *     hint isn't actionable: the low probe budget is a deliberate first-segment
+ *     latency choice, not an oversight.
+ */
+const BENIGN_STDERR_PATTERNS: RegExp[] = [
+  /Could not find codec parameters for stream \d+ \(Subtitle:/,
+  /Consider increasing the value for the 'analyzeduration'/,
+];
+
+/** Strip {@link BENIGN_STDERR_PATTERNS} from a captured ffmpeg stderr blob so
+ *  the logged tail carries only actionable output. Pure string transform. */
+export function stripBenignFfmpegStderr(stderr: string): string {
+  return stderr
+    .split('\n')
+    .filter((line) => !BENIGN_STDERR_PATTERNS.some((re) => re.test(line)))
+    .join('\n');
+}

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -30,6 +30,7 @@ import {
   type BuildFfmpegArgsOptions,
 } from './ffmpeg-args';
 import { varStreamMapLayout } from './audio-layout';
+import { stripBenignFfmpegStderr } from './ffmpeg-stderr';
 import { detectHwAccel } from './hw-detect';
 import { ALL_DESCRIPTORS, encoderRegistry } from './codec/encoders';
 import { runEncoderProbes } from './codec/encoder-probe';
@@ -689,7 +690,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         return this.sessions.get(key) ?? session;
       }
       this.log.warn(
-        `Transcode [${key}]: HW accel (${this.detectedHwAccel}) crashed (exit=${session.process.exitCode}), falling back to CPU\n${(session.stderr ?? '').slice(-1000)}`,
+        `Transcode [${key}]: HW accel (${this.detectedHwAccel}) crashed (exit=${session.process.exitCode}), falling back to CPU\n${stripBenignFfmpegStderr(session.stderr ?? '').slice(-1000)}`,
       );
       this.sessions.delete(key);
       await this.killAndClean(session.process, sessionDir);
@@ -931,7 +932,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         // seek that "does nothing" is traceable in prod.
         const running = session.process.exitCode === null;
         this.log.warn(
-          `[${session.id}] segment ${name} not produced within ${timeoutMs}ms — ffmpeg ${running ? 'still running' : `exited ${session.process.exitCode}`}${session.stderr ? `\nlast stderr:\n${session.stderr.slice(-1500)}` : ''}`,
+          `[${session.id}] segment ${name} not produced within ${timeoutMs}ms — ffmpeg ${running ? 'still running' : `exited ${session.process.exitCode}`}${session.stderr ? `\nlast stderr:\n${stripBenignFfmpegStderr(session.stderr).slice(-1500)}` : ''}`,
         );
         finish(null);
       }, timeoutMs);
@@ -1065,7 +1066,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         // `code !== 0` also catches a null code (process killed by a signal we
         // didn't issue); our own kills set `intentionallyKilled` and skip this.
         this.log.error(
-          `FFmpeg [${id}] exited code=${code}${firstSegProduced ? '' : ` before producing ${firstSegName}`}:\n${stderr.slice(-2000)}`,
+          `FFmpeg [${id}] exited code=${code}${firstSegProduced ? '' : ` before producing ${firstSegName}`}:\n${stripBenignFfmpegStderr(stderr).slice(-2000)}`,
         );
       }
     });


### PR DESCRIPTION
Image-subtitle streams (PGS/VOBSUB) we never map report `Could not find codec parameters for stream N (Subtitle: …): unspecified size` under the fast-start `-analyzeduration 0` probe, plus ffmpeg's non-actionable `Consider increasing analyzeduration/probesize` hint. Not in the output map → transcode unaffected, but they flood every transcode log and, on a real HW crash, bury the actual error in the stderr tail (they made the recent `vpp_qsv -17` look subtitle-related when it was not).

Strip those two benign patterns from the stderr tail before logging, at the three sites that surface it (HW-crash → CPU fallback, segment-not-produced timeout, non-zero exit). `-analyzeduration 0` (first-segment latency) is untouched.

New `ffmpeg-stderr.ts` helper + spec (4 cases: drops the subtitle noise, keeps the real error, leaves non-subtitle codec-param warnings, no-op on clean stderr). Typecheck green.

Refs: #720