### PR TITLE
fix(windows): decode QSV sessions on D3D11VA and map into QSV

### DIFF
--- a/backend/src/modules/streaming/transcoding/codec/decoders/index.ts
+++ b/backend/src/modules/streaming/transcoding/codec/decoders/index.ts
@@ -9,6 +9,9 @@ import {
   h264QsvNativeDecoder,
   hevcQsvNativeDecoder,
   av1QsvNativeDecoder,
+  h264QsvD3d11Decoder,
+  hevcQsvD3d11Decoder,
+  av1QsvD3d11Decoder,
 } from './qsv';
 import { h264VaapiDecoder, hevcVaapiDecoder, av1VaapiDecoder } from './vaapi';
 import { h264CudaDecoder, hevcCudaDecoder, av1CudaDecoder } from './nvenc';
@@ -112,23 +115,30 @@ export const ALL_DECODERS: readonly DecoderDescriptor[] = [
   h264QsvNativeDecoder,
   hevcQsvNativeDecoder,
   av1QsvNativeDecoder,
+  h264QsvD3d11Decoder,
+  hevcQsvD3d11Decoder,
+  av1QsvD3d11Decoder,
   h264D3d11vaNativeDecoder,
   hevcD3d11vaNativeDecoder,
   av1D3d11vaNativeDecoder,
 ];
 
-/** Lookup a qsv-native decoder by source codec — exposed for the
- *  vpp_qsv crop path that bypasses the registry resolver. */
+/** Lookup the QSV encode-path decoder for `codec` — exposed for the vpp_qsv
+ *  crop / scale path that bypasses the registry resolver. Windows decodes on
+ *  D3D11VA and maps into QSV ({@link h264QsvD3d11Decoder}); every other
+ *  platform decodes qsv-native (derived from VAAPI). */
 export function findQsvNativeDecoder(
   codec: 'h264' | 'hevc' | 'av1',
+  platform: NodeJS.Platform = process.platform,
 ): DecoderDescriptor | null {
+  const win = platform === 'win32';
   switch (codec) {
     case 'h264':
-      return h264QsvNativeDecoder;
+      return win ? h264QsvD3d11Decoder : h264QsvNativeDecoder;
     case 'hevc':
-      return hevcQsvNativeDecoder;
+      return win ? hevcQsvD3d11Decoder : hevcQsvNativeDecoder;
     case 'av1':
-      return av1QsvNativeDecoder;
+      return win ? av1QsvD3d11Decoder : av1QsvNativeDecoder;
   }
 }
 

--- a/backend/src/modules/streaming/transcoding/codec/decoders/qsv.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/decoders/qsv.spec.ts
@@ -1,0 +1,34 @@
+import { h264QsvNativeDecoder, h264QsvD3d11Decoder } from './qsv';
+import { findQsvNativeDecoder } from './index';
+
+describe('QSV encode-path decoders', () => {
+  it('findQsvNativeDecoder picks the D3D11VA→QSV decoder on Windows', () => {
+    const d = findQsvNativeDecoder('av1', 'win32');
+    expect(d?.id).toBe('av1_qsv_d3d11_decode');
+    expect(d?.outputSurface).toBe('d3d11');
+    expect(d?.hwAccel).toBe('qsv');
+  });
+
+  it('findQsvNativeDecoder picks the qsv-native decoder off Windows', () => {
+    const d = findQsvNativeDecoder('av1', 'linux');
+    expect(d?.id).toBe('av1_qsv_native_decode');
+    expect(d?.outputSurface).toBe('qsv');
+  });
+
+  it('the Windows decoder decodes on D3D11VA and derives QSV from the same device', () => {
+    const args = h264QsvD3d11Decoder.buildInputArgs();
+    const joined = args.join(' ');
+    expect(args).toContain('d3d11va=dx');
+    expect(args).toContain('qsv=qs@dx');
+    expect(joined).toContain('-hwaccel d3d11va');
+    expect(joined).toContain('-hwaccel_output_format d3d11');
+    // Never the native -hwaccel qsv decode (its AV1 path is broken on Windows).
+    expect(joined).not.toContain('-hwaccel qsv');
+  });
+
+  it('the qsv-native decoder is off-Windows-only, the d3d11 one Windows-only', () => {
+    // supports() reads the real process.platform (linux under CI).
+    expect(h264QsvNativeDecoder.supports()).toBe(process.platform !== 'win32');
+    expect(h264QsvD3d11Decoder.supports()).toBe(process.platform === 'win32');
+  });
+});

--- a/backend/src/modules/streaming/transcoding/codec/decoders/qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/decoders/qsv.ts
@@ -1,6 +1,6 @@
 import type { DecoderDescriptor } from './types';
 import type { VideoCodec } from '../types';
-import { qsvDeviceInitArgs } from '../../hw-device';
+import { qsvDeviceInitArgs, qsvViaD3d11DeviceInitArgs } from '../../hw-device';
 
 /** Build a QSV decoder descriptor for `codec`. Decode actually happens
  *  on the VAAPI driver (Linux Intel) — libavcodec wires the qsv encoder
@@ -39,10 +39,10 @@ function qsvDecoder(codec: VideoCodec, maxBitDepth: 8 | 10): DecoderDescriptor {
   };
 }
 
-/** QSV-native decoder variant — same iGPU but emits QSV surfaces
- *  directly. Selected by `vpp_qsv` crop / scale paths that consume
- *  QSV surfaces; the default qsv decoder above stays VAAPI-output for
- *  compatibility with the scale_vaapi-based encoder chains. */
+/** QSV-native decoder variant (Linux) — decodes on the iGPU (derived from
+ *  VAAPI) and emits `qsv` surfaces the `vpp_qsv` encoder chain consumes
+ *  directly, no hwmap. Selected by the vpp_qsv crop / scale paths. Windows
+ *  uses {@link qsvD3d11Decoder} instead (see there for why). */
 function qsvNativeDecoder(
   codec: VideoCodec,
   maxBitDepth: 8 | 10,
@@ -53,7 +53,7 @@ function qsvNativeDecoder(
     sourceCodec: codec,
     maxBitDepth,
     outputSurface: 'qsv',
-    supports: () => true,
+    supports: () => process.platform !== 'win32',
     buildInputArgs: () => [
       ...qsvDeviceInitArgs(),
       '-filter_hw_device',
@@ -71,6 +71,42 @@ function qsvNativeDecoder(
   };
 }
 
+/** Windows QSV decoder — decodes on **D3D11VA** and derives QSV from the same
+ *  D3D11 device (`qsv=qs@dx`). The frame lands as a `d3d11` surface; the QSV
+ *  encoder filter maps it onto the QSV device (`hwmap=derive_device=qsv`)
+ *  before `vpp_qsv`. Distinct from the native `-hwaccel qsv` decode
+ *  ({@link qsvNativeDecoder}), which is avoided on Windows because its AV1 path
+ *  fails on Intel/oneVPL for real streams (the tiny boot probe passes, a real
+ *  2160p AV1 exits `-17`) while D3D11VA decode is solid. Pairs with the QSV
+ *  encoders (`hwAccel: 'qsv'`). Windows-only. */
+function qsvD3d11Decoder(
+  codec: VideoCodec,
+  maxBitDepth: 8 | 10,
+): DecoderDescriptor {
+  return {
+    id: `${codec}_qsv_d3d11_decode`,
+    hwAccel: 'qsv',
+    sourceCodec: codec,
+    maxBitDepth,
+    outputSurface: 'd3d11',
+    supports: () => process.platform === 'win32',
+    buildInputArgs: () => [
+      ...qsvViaD3d11DeviceInitArgs(),
+      '-filter_hw_device',
+      'qs',
+      '-hwaccel',
+      'd3d11va',
+      '-hwaccel_output_format',
+      'd3d11',
+      '-hwaccel_device',
+      'dx',
+      '-extra_hw_frames',
+      '32',
+      '-noautorotate',
+    ],
+  };
+}
+
 export const h264QsvDecoder = qsvDecoder('h264', 8);
 export const hevcQsvDecoder = qsvDecoder('hevc', 10);
 export const av1QsvDecoder = qsvDecoder('av1', 10);
@@ -78,3 +114,7 @@ export const av1QsvDecoder = qsvDecoder('av1', 10);
 export const h264QsvNativeDecoder = qsvNativeDecoder('h264', 8);
 export const hevcQsvNativeDecoder = qsvNativeDecoder('hevc', 10);
 export const av1QsvNativeDecoder = qsvNativeDecoder('av1', 10);
+
+export const h264QsvD3d11Decoder = qsvD3d11Decoder('h264', 8);
+export const hevcQsvD3d11Decoder = qsvD3d11Decoder('hevc', 10);
+export const av1QsvD3d11Decoder = qsvD3d11Decoder('av1', 10);

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.spec.ts
@@ -1,0 +1,66 @@
+import { qsvScaleFilter8bit, qsvScaleFilter10bit } from './qsv-filters';
+import type { EncoderInput } from '../../types';
+
+/** Minimal EncoderInput for the QSV vpp filter builders — only the fields they
+ *  read (target / filters / tonemap / inputSurface). */
+function input(over: Partial<EncoderInput>): EncoderInput {
+  return {
+    target: {
+      width: 1920,
+      height: 804,
+      videoBitrateBps: 0,
+      gopSize: 0,
+      frameRate: 24,
+    },
+    filters: {
+      cropStr: '',
+      cpuCropPrefix: '',
+      hwCropPrefix: '',
+      burnInFilter: '',
+      tonemapVaapi: '',
+      tonemapOpencl: '',
+      tonemapCpu: '',
+    },
+    tonemap: false,
+    tonemapPath: 'qsv',
+    hasCrop: false,
+    inputSurface: 'qsv',
+    ...over,
+  } as unknown as EncoderInput;
+}
+
+describe('qsvScaleFilter8bit', () => {
+  it('emits vpp_qsv directly for a qsv-native (Linux) input surface', () => {
+    expect(qsvScaleFilter8bit(input({ inputSurface: 'qsv' }))).toBe(
+      'vpp_qsv=w=1920:h=804:format=nv12',
+    );
+  });
+
+  it('maps the d3d11 (Windows) surface onto QSV before vpp_qsv', () => {
+    expect(qsvScaleFilter8bit(input({ inputSurface: 'd3d11' }))).toBe(
+      'hwmap=derive_device=qsv,vpp_qsv=w=1920:h=804:format=nv12',
+    );
+  });
+
+  it('keeps the vpp_qsv LUT tonemap on the mapped d3d11 path', () => {
+    expect(
+      qsvScaleFilter8bit(
+        input({ inputSurface: 'd3d11', tonemap: true, tonemapPath: 'qsv' }),
+      ),
+    ).toBe('hwmap=derive_device=qsv,vpp_qsv=tonemap=1:w=1920:h=804:format=nv12');
+  });
+});
+
+describe('qsvScaleFilter10bit', () => {
+  it('emits vpp_qsv p010le directly for a qsv-native input surface', () => {
+    expect(qsvScaleFilter10bit(input({ inputSurface: 'qsv' }))).toBe(
+      'vpp_qsv=w=1920:h=804:format=p010le',
+    );
+  });
+
+  it('maps the d3d11 surface onto QSV before vpp_qsv (p010le)', () => {
+    expect(qsvScaleFilter10bit(input({ inputSurface: 'd3d11' }))).toBe(
+      'hwmap=derive_device=qsv,vpp_qsv=w=1920:h=804:format=p010le',
+    );
+  });
+});

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
@@ -16,7 +16,12 @@ import type { EncoderInput } from '../../types';
 export function qsvScaleFilter8bit(input: EncoderInput): string {
   const { target, filters, hasCrop, tonemap, tonemapPath } = input;
   const w = target.width;
-  if (input.inputSurface === 'qsv') {
+  if (input.inputSurface === 'qsv' || input.inputSurface === 'd3d11') {
+    // Windows decodes on D3D11VA and hands the frame here as a `d3d11`
+    // surface; map it onto the QSV device before `vpp_qsv`. A Linux qsv-native
+    // input is already a QSV surface, so the prefix is empty.
+    const qsvMap =
+      input.inputSurface === 'd3d11' ? 'hwmap=derive_device=qsv,' : '';
     // `vpp_qsv` does crop + scale + format on the QSV device in one
     // pass — no CPU bounce, no hwmap. Tonemap is wired three ways:
     //  - `tonemap=qsv`: enable vpp_qsv's fixed-function HDR LUT
@@ -39,7 +44,7 @@ export function qsvScaleFilter8bit(input: EncoderInput): string {
       : '';
     if (tonemap && tonemapPath === 'opencl') {
       return (
-        `vpp_qsv=${cropOpts}w=${w}:h=${targetH}:format=p010le,` +
+        `${qsvMap}vpp_qsv=${cropOpts}w=${w}:h=${targetH}:format=p010le,` +
         `hwmap=derive_device=opencl:mode=read,` +
         `tonemap_opencl=format=nv12:p=bt709:t=bt709:m=bt709:tonemap=reinhard:desat=0,` +
         `hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,` +
@@ -47,7 +52,7 @@ export function qsvScaleFilter8bit(input: EncoderInput): string {
       );
     }
     const tonemapOpt = tonemap ? 'tonemap=1:' : '';
-    return `vpp_qsv=${tonemapOpt}${cropOpts}w=${w}:h=${targetH}:format=nv12`;
+    return `${qsvMap}vpp_qsv=${tonemapOpt}${cropOpts}w=${w}:h=${targetH}:format=nv12`;
   }
   // hwCropPrefix = 'hwdownload,format=nv12,crop=…,hwupload=vaapi,' when
   // a crop is needed and we're on the vaapi-input path. Prepending it
@@ -74,7 +79,11 @@ export function qsvScaleFilter8bit(input: EncoderInput): string {
 export function qsvScaleFilter10bit(input: EncoderInput): string {
   const { target, filters, hasCrop } = input;
   const w = target.width;
-  if (input.inputSurface === 'qsv') {
+  if (input.inputSurface === 'qsv' || input.inputSurface === 'd3d11') {
+    // See qsvScaleFilter8bit: Windows d3d11 input maps onto the QSV device
+    // first; Linux qsv-native input is already a QSV surface.
+    const qsvMap =
+      input.inputSurface === 'd3d11' ? 'hwmap=derive_device=qsv,' : '';
     const cropArgs =
       hasCrop && filters.cropStr ? parseCropStr(filters.cropStr) : null;
     const targetH = cropArgs
@@ -83,7 +92,7 @@ export function qsvScaleFilter10bit(input: EncoderInput): string {
     const cropOpts = cropArgs
       ? `cw=${cropArgs.w}:ch=${cropArgs.h}:cx=${cropArgs.x}:cy=${cropArgs.y}:`
       : '';
-    return `vpp_qsv=${cropOpts}w=${w}:h=${targetH}:format=p010le`;
+    return `${qsvMap}vpp_qsv=${cropOpts}w=${w}:h=${targetH}:format=p010le`;
   }
   return `${filters.hwCropPrefix}scale_vaapi=w=${w}:h=-2:format=p010le:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv`;
 }

--- a/backend/src/modules/streaming/transcoding/encode-pipeline.ts
+++ b/backend/src/modules/streaming/transcoding/encode-pipeline.ts
@@ -2,6 +2,7 @@ import { requestedHwAccelFor } from './hw-detect';
 import { hostHasVaapi } from './hw-device';
 import { encoderRegistry } from './codec/encoders';
 import { isDecoderEnabled } from './codec/decoder-probe';
+import { findQsvNativeDecoder } from './codec/decoders';
 import { isVppQsvTonemapEnabled } from './codec/vpp-qsv-probe';
 import {
   isTonemapOpenclEnabled,
@@ -63,11 +64,18 @@ export function resolveEncodePipeline(
 ): ResolvedEncodePipeline {
   const noVaapi = !hostHasVaapi(platform);
   const normalisedSourceCodec = normaliseSourceCodec(ctx.sourceVideoCodec);
+  // The QSV encode-path decoder is platform-specific (qsv-native on Linux,
+  // d3d11va→qsv on Windows); resolve it by platform rather than a hard-coded id
+  // so the gate can't drift from the descriptor the segment builder picks.
+  const qsvNativeDecoder =
+    normalisedSourceCodec != null
+      ? findQsvNativeDecoder(normalisedSourceCodec, platform)
+      : null;
   const hasUsableQsvNativeDecoder =
     ctx.hwAccel === 'qsv' &&
     !ctx.burnIn &&
-    normalisedSourceCodec != null &&
-    isDecoderEnabled(`${normalisedSourceCodec}_qsv_native_decode`);
+    qsvNativeDecoder != null &&
+    isDecoderEnabled(qsvNativeDecoder.id);
   // Full-GPU AMF: d3d11 decode → scale_d3d11 → AMF encode, zero-copy. Scoped to
   // the clean SDR case (crop needs an off-GPU pass, HDR→SDR uses the CPU/OpenCL
   // tonemap chain). Gated on the d3d11-native decode probe AND the scale_d3d11

--- a/backend/src/modules/streaming/transcoding/hw-device.ts
+++ b/backend/src/modules/streaming/transcoding/hw-device.ts
@@ -3,6 +3,7 @@
 
 export const VAAPI_DEVICE_ALIAS = 'va';
 export const QSV_DEVICE_ALIAS = 'qs';
+export const D3D11VA_DEVICE_ALIAS = 'dx';
 
 /** DRI render node for the VAAPI/Linux-QSV device. Override with
  *  `FLIKS_VAAPI_RENDER_NODE`; ignored on Windows (MFX/D3D11, no node). */
@@ -28,6 +29,21 @@ export function qsvDeviceInitArgs(
     ...vaapiDeviceInitArgs(),
     '-init_hw_device',
     `qsv=${QSV_DEVICE_ALIAS}@${VAAPI_DEVICE_ALIAS}`,
+  ];
+}
+
+/** Windows QSV device derived from an explicit D3D11VA device (`dx`):
+ *  `-init_hw_device d3d11va=dx -init_hw_device qsv=qs@dx`. Paired with a
+ *  `d3d11va` decode + `hwmap=derive_device=qsv` so the decoded texture and the
+ *  `vpp_qsv`/encoder share one D3D11 device. Preferred over the native
+ *  `-hwaccel qsv` decode on Windows, whose AV1 decoder fails on real streams.
+ *  Windows-only. */
+export function qsvViaD3d11DeviceInitArgs(): string[] {
+  return [
+    '-init_hw_device',
+    `d3d11va=${D3D11VA_DEVICE_ALIAS}`,
+    '-init_hw_device',
+    `qsv=${QSV_DEVICE_ALIAS}@${D3D11VA_DEVICE_ALIAS}`,
   ];
 }
 


### PR DESCRIPTION
On Windows every QSV transcode of a real 2160p **AV1** source crashed with `exit -17` at filter init and fell back to CPU (`libx264`), unusable on 4K.

## Root cause

The native `-hwaccel qsv` **AV1 decoder** fails on this Intel/oneVPL stack for real streams. Isolated on-hardware (Iris Xe, Furiosa 2160p AV1 HDR10):

| Test | Result |
|---|---|
| `-hwaccel qsv` decode only | ❌ `-17` |
| CPU decode → hwupload → vpp_qsv → h264_qsv | ✅ |
| **d3d11va decode → hwmap qsv → vpp_qsv → h264_qsv** | ✅ |

The boot decoder probe used a tiny synthetic clip the native decoder accepts → **false positive** (`*_qsv_native_decode` reported enabled, real 4K exits `-17`). The subtitle-probe warnings in the crash logs were an unrelated red herring (fixed separately in #734).

## Fix

Windows decodes on **D3D11VA** and derives QSV from the *same* D3D11 device (`-init_hw_device d3d11va=dx -init_hw_device qsv=qs@dx`); the decoded texture is mapped onto the QSV device (`hwmap=derive_device=qsv`) before `vpp_qsv`. Full HW, no CPU bounce. D3D11VA decode is solid for h264/hevc/av1 on Windows.

- **Separate decoder descriptor** `*_qsv_d3d11_decode` (Windows-only, `hwAccel: qsv`, `outputSurface: d3d11`) rather than a platform branch inside the qsv-native one. `findQsvNativeDecoder(codec, platform)` picks it on Windows / qsv-native elsewhere; the encode-pipeline gate resolves the decoder id **through that helper** so it cant drift from the descriptor the segment builder picks.
- The QSV encoder filter (`qsvScaleFilter8bit`/`10bit`) prepends `hwmap=derive_device=qsv` **only** for a `d3d11` input surface. Linux qsv-native input (a QSV surface) is unchanged.
- **Linux untouched**: qsv-native decode (derived from VAAPI, emits QSV surfaces directly) stays as-is, gated by `supports()`.

Why not the same for AMD/NVIDIA: AMD already decodes via D3D11VA; NVIDIA keeps CUDA/NVDEC (mature, native — mapping d3d11→cuda would add a non-standard hop with no gain).

## Tests

New `decoders/qsv.spec.ts` (platform picks the right decoder; Windows decoder uses d3d11va + `qsv=qs@dx`, never `-hwaccel qsv`) and `qsv-filters.spec.ts` (d3d11 surface gets the `hwmap` prefix, qsv surface does not; 8-bit + 10-bit). 327 transcoding specs + typecheck green.

## Pre-merge validation

Confirmed on hardware: d3d11va→qsv **scale** (`EXIT 0`). Final check before merge = the same chain **with `tonemap=1`** (the real HDR path) on the box.

Refs: #720