### PR TITLE
fix(windows): add extra_hw_frames to the AMD full-GPU d3d11 decode

### DIFF
--- a/backend/src/modules/streaming/transcoding/codec/decoders/d3d11va.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/decoders/d3d11va.spec.ts
@@ -1,0 +1,17 @@
+import { h264D3d11vaDecoder, h264D3d11vaNativeDecoder } from './d3d11va';
+
+describe('D3D11VA (AMF) decoders', () => {
+  it('the full-GPU decoder keeps frames on d3d11 and enlarges the pool', () => {
+    const joined = h264D3d11vaNativeDecoder.buildInputArgs().join(' ');
+    expect(h264D3d11vaNativeDecoder.outputSurface).toBe('d3d11');
+    expect(joined).toContain('-hwaccel_output_format d3d11');
+    expect(joined).toContain('-extra_hw_frames 32');
+  });
+
+  it('the CPU-output decoder downloads immediately and stays lean', () => {
+    const joined = h264D3d11vaDecoder.buildInputArgs().join(' ');
+    expect(h264D3d11vaDecoder.outputSurface).toBe('cpu');
+    expect(joined).not.toContain('-hwaccel_output_format');
+    expect(joined).not.toContain('-extra_hw_frames');
+  });
+});

--- a/backend/src/modules/streaming/transcoding/codec/decoders/d3d11va.ts
+++ b/backend/src/modules/streaming/transcoding/codec/decoders/d3d11va.ts
@@ -45,6 +45,8 @@ function d3d11NativeDecoder(
       'd3d11va',
       '-hwaccel_output_format',
       'd3d11',
+      '-extra_hw_frames',
+      '32',
       '-noautorotate',
     ],
   };

--- a/backend/src/modules/streaming/transcoding/codec/scale-d3d11-probe.ts
+++ b/backend/src/modules/streaming/transcoding/codec/scale-d3d11-probe.ts
@@ -47,6 +47,7 @@ export async function runScaleD3d11Probe(log: Logger): Promise<void> {
       [
         '-hide_banner', '-loglevel', 'error',
         '-hwaccel', 'd3d11va', '-hwaccel_output_format', 'd3d11',
+        '-extra_hw_frames', '32',
         '-i', sample,
         '-vf', 'scale_d3d11=width=1280:height=720:format=nv12',
         '-c:v', 'hevc_amf', '-frames:v', '2', '-f', 'null', '-',


### PR DESCRIPTION
Found while reviewing the AMD path after the QSV D3D11 decode fix (#735) — both decode via D3D11VA.

## Latent bug

The full-GPU AMF path (`d3d11 decode → scale_d3d11 → AMF encode`) keeps the decoded texture on the D3D11 device through scale + encode, but `d3d11NativeDecoder` set **no `-extra_hw_frames`**. That is the exact frame-retention that just needed it on the QSV D3D11 path: on a 2160p source the default pool exhausts (`Static surface pool size exceeded` → dropped frames + non-monotonic DTS).

The `scale_d3d11` boot probe wouldn`t catch it — it used a tiny 1080p / 2-frame clip on the default pool (false positive on a small input, same pattern as the earlier QSV probes).

## Fix

`-extra_hw_frames 32` on the full-GPU decoder **and** the probe (so the probe exercises the real allocation). The CPU-output AMF decoder (the validated baseline) is untouched — it downloads each frame immediately and holds no d3d11 pool.

## Not vendor-uniform

AMD already decodes via D3D11VA (this is a pool-size fix, not a decode-path change). NVIDIA stays on CUDA/NVDEC. Only the D3D11 decoders (Intel-QSV #735, AMD here) need the pool headroom.

## ⚠️ Unvalidated on AMD hardware

The tested AMD APU falls back to CPU scale (its `scale_d3d11` probe fails), so this full-GPU path is **dormant** there. It only engages on an AMD GPU where `scale_d3d11` works (RDNA-class) — no such hardware on hand to confirm. Low risk (only enlarges a pool; changes nothing on paths that already work).

New `d3d11va.spec.ts`. 327+ transcoding specs + typecheck green.

Refs: #720