### PR TITLE
feat(windows): adopt jellyfin-ffmpeg for zero-copy OpenCL HDR tonemap

### DIFF
--- a/backend/src/modules/streaming/dto/playback-info.dto.ts
+++ b/backend/src/modules/streaming/dto/playback-info.dto.ts
@@ -114,10 +114,10 @@ export interface PlaybackInfoResponse {
    *  overlays show this value, not the (encoder-agnostic) admin pick. */
   tonemapAlgo?: 'vaapi' | 'opencl' | 'qsv' | 'cpu' | null;
 
-  /** CPU tone-map curve (`hable` / `mobius`), set only when
+  /** Tone-map curve (`hable` / `mobius` / `reinhard`), set only when
    *  `tonemapAlgo === 'cpu'`. Surfaced so the overlay names the exact
    *  curve in use. */
-  tonemapCurve?: 'hable' | 'mobius';
+  tonemapCurve?: 'hable' | 'mobius' | 'reinhard';
 
   /**
    * Bitrate targets per quality rung (FFmpeg profiles).

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -724,8 +724,8 @@ export class StreamingController {
     // pick. QSV/VAAPI encoders run the HW tonemap (vaapi/opencl/qsv after
     // `auto` resolution + boot probe); NVENC runs `tonemap_opencl` on the GPU
     // when the OpenCL probe passed, else the CPU zscale chain; libx26x /
-    // VideoToolbox fallback always CPU. Report the real path (+ curve only for
-    // the CPU chain) so the overlay shows what's running.
+    // VideoToolbox fallback always CPU. Report the real path (+ curve for the
+    // opencl/CPU chains, which honour it) so the overlay shows what's running.
     const hasCrop = resolved.mediaFile.streamInfo?.video?.[0]?.crop != null;
     const hwTonemap =
       response.hwAccel === 'qsv' || response.hwAccel === 'vaapi';
@@ -739,8 +739,10 @@ export class StreamingController {
           ? 'opencl'
           : 'cpu'
       : null;
+    // The curve is a `tonemap`/`tonemap_opencl` operator, so it only applies to
+    // the opencl and CPU paths — the vpp_qsv / tonemap_vaapi LUTs ignore it.
     const tonemapCurve =
-      response.tonemapping && !hwTonemap && !openclTonemap
+      tonemapAlgo === 'opencl' || tonemapAlgo === 'cpu'
         ? resolveTonemapCurve()
         : undefined;
 

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.spec.ts
@@ -56,10 +56,11 @@ describe('qsvScaleFilter8bit', () => {
         input({ inputSurface: 'd3d11', tonemap: true, tonemapPath: 'opencl' }),
       ),
     ).toBe(
-      'hwmap=derive_device=opencl:mode=read,' +
+      'hwmap=derive_device=qsv,' +
+        'vpp_qsv=w=1920:h=804:format=p010le,' +
+        'hwmap=derive_device=opencl,' +
         'tonemap_opencl=tonemap=hable:t=bt709:m=bt709:p=bt709:format=nv12,' +
-        'hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv,' +
-        'vpp_qsv=w=1920:h=804:format=nv12',
+        'hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv',
     );
   });
 

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.spec.ts
@@ -50,16 +50,16 @@ describe('qsvScaleFilter8bit', () => {
     ).toBe('hwmap=derive_device=qsv,vpp_qsv=tonemap=1:w=1920:h=804:format=nv12');
   });
 
-  it('tone-maps a Windows d3d11 surface via a CPU-bounce OpenCL chain', () => {
+  it('tone-maps a Windows d3d11 surface zero-copy through OpenCL', () => {
     expect(
       qsvScaleFilter8bit(
         input({ inputSurface: 'd3d11', tonemap: true, tonemapPath: 'opencl' }),
       ),
     ).toBe(
-      'hwmap=derive_device=qsv,vpp_qsv=w=1920:h=804:format=p010le,' +
-        'hwdownload,format=p010le,hwupload,' +
+      'hwmap=derive_device=opencl:mode=read,' +
         'tonemap_opencl=tonemap=hable:t=bt709:m=bt709:p=bt709:format=nv12,' +
-        'hwdownload,format=nv12',
+        'hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv,' +
+        'vpp_qsv=w=1920:h=804:format=nv12',
     );
   });
 

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.spec.ts
@@ -72,10 +72,36 @@ describe('qsvScaleFilter8bit', () => {
     ).toBe(
       'vpp_qsv=w=1920:h=804:format=p010le,' +
         'hwmap=derive_device=opencl:mode=read,' +
-        'tonemap_opencl=format=nv12:p=bt709:t=bt709:m=bt709:tonemap=reinhard:desat=0,' +
+        'tonemap_opencl=format=nv12:p=bt709:t=bt709:m=bt709:tonemap=hable:desat=0,' +
         'hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,' +
         'format=qsv',
     );
+  });
+
+  it('honours TRANSCODE_TONEMAP_CURVE on the d3d11 OpenCL chain', () => {
+    expect(
+      qsvScaleFilter8bit(
+        input({
+          inputSurface: 'd3d11',
+          tonemap: true,
+          tonemapPath: 'opencl',
+          tonemapCurve: 'mobius',
+        }),
+      ),
+    ).toContain('tonemap_opencl=tonemap=mobius:');
+  });
+
+  it('honours TRANSCODE_TONEMAP_CURVE on the Linux OpenCL chain', () => {
+    expect(
+      qsvScaleFilter8bit(
+        input({
+          inputSurface: 'qsv',
+          tonemap: true,
+          tonemapPath: 'opencl',
+          tonemapCurve: 'reinhard',
+        }),
+      ),
+    ).toContain(':tonemap=reinhard:desat=0');
   });
 });
 

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.spec.ts
@@ -49,6 +49,33 @@ describe('qsvScaleFilter8bit', () => {
       ),
     ).toBe('hwmap=derive_device=qsv,vpp_qsv=tonemap=1:w=1920:h=804:format=nv12');
   });
+
+  it('tone-maps a Windows d3d11 surface via a CPU-bounce OpenCL chain', () => {
+    expect(
+      qsvScaleFilter8bit(
+        input({ inputSurface: 'd3d11', tonemap: true, tonemapPath: 'opencl' }),
+      ),
+    ).toBe(
+      'hwmap=derive_device=qsv,vpp_qsv=w=1920:h=804:format=p010le,' +
+        'hwdownload,format=p010le,hwupload,' +
+        'tonemap_opencl=tonemap=hable:t=bt709:m=bt709:p=bt709:format=nv12,' +
+        'hwdownload,format=nv12',
+    );
+  });
+
+  it('keeps the zero-copy QSV↔OpenCL chain for a Linux qsv surface', () => {
+    expect(
+      qsvScaleFilter8bit(
+        input({ inputSurface: 'qsv', tonemap: true, tonemapPath: 'opencl' }),
+      ),
+    ).toBe(
+      'vpp_qsv=w=1920:h=804:format=p010le,' +
+        'hwmap=derive_device=opencl:mode=read,' +
+        'tonemap_opencl=format=nv12:p=bt709:t=bt709:m=bt709:tonemap=reinhard:desat=0,' +
+        'hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,' +
+        'format=qsv',
+    );
+  });
 });
 
 describe('qsvScaleFilter10bit', () => {

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
@@ -43,8 +43,20 @@ export function qsvScaleFilter8bit(input: EncoderInput): string {
       ? `cw=${cropArgs.w}:ch=${cropArgs.h}:cx=${cropArgs.x}:cy=${cropArgs.y}:`
       : '';
     if (tonemap && tonemapPath === 'opencl') {
+      if (input.inputSurface === 'd3d11') {
+        // Windows: no zero-copy QSV↔OpenCL bridge (D3D11↔OpenCL is NV12-only,
+        // can't carry the 10-bit HDR surface). Scale on the QSV VPP (p010),
+        // bounce through CPU into OpenCL for the tone-map, hand nv12 back to
+        // the encoder (which auto-uploads to the QSV device).
+        return (
+          `hwmap=derive_device=qsv,vpp_qsv=${cropOpts}w=${w}:h=${targetH}:format=p010le,` +
+          `hwdownload,format=p010le,hwupload,` +
+          `tonemap_opencl=tonemap=hable:t=bt709:m=bt709:p=bt709:format=nv12,` +
+          `hwdownload,format=nv12`
+        );
+      }
       return (
-        `${qsvMap}vpp_qsv=${cropOpts}w=${w}:h=${targetH}:format=p010le,` +
+        `vpp_qsv=${cropOpts}w=${w}:h=${targetH}:format=p010le,` +
         `hwmap=derive_device=opencl:mode=read,` +
         `tonemap_opencl=format=nv12:p=bt709:t=bt709:m=bt709:tonemap=reinhard:desat=0,` +
         `hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,` +

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
@@ -16,6 +16,7 @@ import type { EncoderInput } from '../../types';
 export function qsvScaleFilter8bit(input: EncoderInput): string {
   const { target, filters, hasCrop, tonemap, tonemapPath } = input;
   const w = target.width;
+  const curve = input.tonemapCurve ?? 'hable';
   if (input.inputSurface === 'qsv' || input.inputSurface === 'd3d11') {
     // Windows decodes on D3D11VA and hands the frame here as a `d3d11`
     // surface; map it onto the QSV device before `vpp_qsv`. A Linux qsv-native
@@ -53,14 +54,14 @@ export function qsvScaleFilter8bit(input: EncoderInput): string {
           `hwmap=derive_device=qsv,` +
           `vpp_qsv=${cropOpts}w=${w}:h=${targetH}:format=p010le,` +
           `hwmap=derive_device=opencl,` +
-          `tonemap_opencl=tonemap=hable:t=bt709:m=bt709:p=bt709:format=nv12,` +
+          `tonemap_opencl=tonemap=${curve}:t=bt709:m=bt709:p=bt709:format=nv12,` +
           `hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`
         );
       }
       return (
         `vpp_qsv=${cropOpts}w=${w}:h=${targetH}:format=p010le,` +
         `hwmap=derive_device=opencl:mode=read,` +
-        `tonemap_opencl=format=nv12:p=bt709:t=bt709:m=bt709:tonemap=reinhard:desat=0,` +
+        `tonemap_opencl=format=nv12:p=bt709:t=bt709:m=bt709:tonemap=${curve}:desat=0,` +
         `hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,` +
         `format=qsv`
       );

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
@@ -44,15 +44,16 @@ export function qsvScaleFilter8bit(input: EncoderInput): string {
       : '';
     if (tonemap && tonemapPath === 'opencl') {
       if (input.inputSurface === 'd3d11') {
-        // Windows: no zero-copy QSV↔OpenCL bridge (D3D11↔OpenCL is NV12-only,
-        // can't carry the 10-bit HDR surface). Scale on the QSV VPP (p010),
-        // bounce through CPU into OpenCL for the tone-map, hand nv12 back to
-        // the encoder (which auto-uploads to the QSV device).
+        // Windows zero-copy (jellyfin-ffmpeg P010 D3D11↔OpenCL): map the HDR
+        // surface straight into OpenCL, tone-map, map back onto the QSV device,
+        // then scale + crop on vpp_qsv. No CPU round-trip. Mapping goes via
+        // D3D11 (not QSV→OpenCL, which needs a Linux-only extension), so the
+        // OpenCL step precedes vpp_qsv and the scale happens after.
         return (
-          `hwmap=derive_device=qsv,vpp_qsv=${cropOpts}w=${w}:h=${targetH}:format=p010le,` +
-          `hwdownload,format=p010le,hwupload,` +
+          `hwmap=derive_device=opencl:mode=read,` +
           `tonemap_opencl=tonemap=hable:t=bt709:m=bt709:p=bt709:format=nv12,` +
-          `hwdownload,format=nv12`
+          `hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv,` +
+          `vpp_qsv=${cropOpts}w=${w}:h=${targetH}:format=nv12`
         );
       }
       return (

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.ts
@@ -44,16 +44,17 @@ export function qsvScaleFilter8bit(input: EncoderInput): string {
       : '';
     if (tonemap && tonemapPath === 'opencl') {
       if (input.inputSurface === 'd3d11') {
-        // Windows zero-copy (jellyfin-ffmpeg P010 D3D11↔OpenCL): map the HDR
-        // surface straight into OpenCL, tone-map, map back onto the QSV device,
-        // then scale + crop on vpp_qsv. No CPU round-trip. Mapping goes via
-        // D3D11 (not QSV→OpenCL, which needs a Linux-only extension), so the
-        // OpenCL step precedes vpp_qsv and the scale happens after.
+        // Windows zero-copy (jellyfin-ffmpeg P010 D3D11↔OpenCL): crop + scale on
+        // vpp_qsv (p010, HDR kept) so the tone-map runs at output resolution,
+        // map onto OpenCL, tone-map, map back onto the QSV device. No CPU
+        // round-trip. vpp_qsv can't ingest a reverse-mapped OpenCL surface, so
+        // the scale precedes the OpenCL step.
         return (
-          `hwmap=derive_device=opencl:mode=read,` +
+          `hwmap=derive_device=qsv,` +
+          `vpp_qsv=${cropOpts}w=${w}:h=${targetH}:format=p010le,` +
+          `hwmap=derive_device=opencl,` +
           `tonemap_opencl=tonemap=hable:t=bt709:m=bt709:p=bt709:format=nv12,` +
-          `hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv,` +
-          `vpp_qsv=${cropOpts}w=${w}:h=${targetH}:format=nv12`
+          `hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv`
         );
       }
       return (

--- a/backend/src/modules/streaming/transcoding/codec/qsv-opencl-probe.ts
+++ b/backend/src/modules/streaming/transcoding/codec/qsv-opencl-probe.ts
@@ -7,16 +7,14 @@ import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);
 
-/** Result of the Windows QSV↔OpenCL tone-map probe. The Windows QSV encode
- *  path decodes on D3D11VA and can't zero-copy-map its 10-bit surface into
- *  OpenCL (the D3D11↔OpenCL bridge is NV12-only), so the higher-quality
- *  `tonemap_opencl` runs through a CPU bounce: `vpp_qsv` scales on the QSV
- *  device, the frame is downloaded, OpenCL tone-maps it, and it's handed back
- *  to the QSV encoder. This probe runs that exact chain once at boot so
- *  `tonemapAlgo='auto'` (and the encode-pipeline gate) only pick OpenCL when it
- *  actually works — otherwise it falls back to the fixed-function vpp_qsv LUT.
+/** Result of the Windows QSV OpenCL tone-map probe. With jellyfin-ffmpeg (P010
+ *  D3D11↔OpenCL sharing) the HDR surface maps straight D3D11→OpenCL, tone-maps,
+ *  and maps back to QSV — zero-copy, no CPU round-trip. This probe runs that
+ *  exact chain once at boot (needs the ffmpeg P010 patch AND a P010-capable
+ *  Intel OpenCL ICD) so `tonemapAlgo='auto'` and the encode-pipeline gate only
+ *  pick OpenCL when it actually works — else they fall back to the vpp_qsv LUT.
  *
- *  Linux QSV derives from VAAPI and uses the zero-copy QSV↔OpenCL bridge
+ *  Linux QSV derives from VAAPI and uses the QSV↔OpenCL bridge
  *  (`tonemap-opencl-probe.ts`), so this probe is win32-only. */
 let probedOnce = false;
 let enabled = false;
@@ -71,7 +69,8 @@ export async function runQsvOpenclTonemapProbe(log: Logger): Promise<void> {
     );
 
     // The exact Windows chain a session runs: d3d11va decode → map to QSV →
-    // vpp_qsv scale (p010) → CPU bounce → tonemap_opencl (nv12) → h264_qsv.
+    // Zero-copy: d3d11 decode → map D3D11→OpenCL → tonemap → map back to QSV →
+    // vpp_qsv scale → h264_qsv. Same chain the encoder emits.
     await execFileAsync(
       'ffmpeg',
       [
@@ -83,7 +82,7 @@ export async function runQsvOpenclTonemapProbe(log: Logger): Promise<void> {
         '-init_hw_device',
         'qsv=qs@dx',
         '-init_hw_device',
-        'opencl=ocl',
+        'opencl=ocl@dx',
         '-filter_hw_device',
         'ocl',
         '-hwaccel',
@@ -95,10 +94,10 @@ export async function runQsvOpenclTonemapProbe(log: Logger): Promise<void> {
         '-i',
         hdrSample,
         '-vf',
-        'hwmap=derive_device=qsv,vpp_qsv=w=320:h=176:format=p010le,' +
-          'hwdownload,format=p010le,hwupload,' +
+        'hwmap=derive_device=opencl:mode=read,' +
           'tonemap_opencl=tonemap=hable:t=bt709:m=bt709:p=bt709:format=nv12,' +
-          'hwdownload,format=nv12',
+          'hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv,' +
+          'vpp_qsv=w=320:h=176:format=nv12',
         '-c:v',
         'h264_qsv',
         '-preset',

--- a/backend/src/modules/streaming/transcoding/codec/qsv-opencl-probe.ts
+++ b/backend/src/modules/streaming/transcoding/codec/qsv-opencl-probe.ts
@@ -68,9 +68,9 @@ export async function runQsvOpenclTonemapProbe(log: Logger): Promise<void> {
       { timeout: 15_000 },
     );
 
-    // The exact Windows chain a session runs: d3d11va decode → map to QSV →
-    // Zero-copy: d3d11 decode → map D3D11→OpenCL → tonemap → map back to QSV →
-    // vpp_qsv scale → h264_qsv. Same chain the encoder emits.
+    // The exact Windows chain a session runs: d3d11 decode → map to QSV →
+    // vpp_qsv scale (p010) → map to OpenCL → tonemap → map back to QSV →
+    // h264_qsv. Same chain the encoder emits.
     await execFileAsync(
       'ffmpeg',
       [
@@ -94,10 +94,11 @@ export async function runQsvOpenclTonemapProbe(log: Logger): Promise<void> {
         '-i',
         hdrSample,
         '-vf',
-        'hwmap=derive_device=opencl:mode=read,' +
+        'hwmap=derive_device=qsv,' +
+          'vpp_qsv=w=320:h=176:format=p010le,' +
+          'hwmap=derive_device=opencl,' +
           'tonemap_opencl=tonemap=hable:t=bt709:m=bt709:p=bt709:format=nv12,' +
-          'hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv,' +
-          'vpp_qsv=w=320:h=176:format=nv12',
+          'hwmap=derive_device=qsv:mode=write:reverse=1:extra_hw_frames=16,format=qsv',
         '-c:v',
         'h264_qsv',
         '-preset',

--- a/backend/src/modules/streaming/transcoding/codec/qsv-opencl-probe.ts
+++ b/backend/src/modules/streaming/transcoding/codec/qsv-opencl-probe.ts
@@ -1,0 +1,124 @@
+import { Logger } from '@nestjs/common';
+import { execFile } from 'child_process';
+import { unlink } from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+/** Result of the Windows QSV↔OpenCL tone-map probe. The Windows QSV encode
+ *  path decodes on D3D11VA and can't zero-copy-map its 10-bit surface into
+ *  OpenCL (the D3D11↔OpenCL bridge is NV12-only), so the higher-quality
+ *  `tonemap_opencl` runs through a CPU bounce: `vpp_qsv` scales on the QSV
+ *  device, the frame is downloaded, OpenCL tone-maps it, and it's handed back
+ *  to the QSV encoder. This probe runs that exact chain once at boot so
+ *  `tonemapAlgo='auto'` (and the encode-pipeline gate) only pick OpenCL when it
+ *  actually works — otherwise it falls back to the fixed-function vpp_qsv LUT.
+ *
+ *  Linux QSV derives from VAAPI and uses the zero-copy QSV↔OpenCL bridge
+ *  (`tonemap-opencl-probe.ts`), so this probe is win32-only. */
+let probedOnce = false;
+let enabled = false;
+
+export function isQsvOpenclTonemapEnabled(): boolean {
+  return probedOnce && enabled;
+}
+
+export async function runQsvOpenclTonemapProbe(log: Logger): Promise<void> {
+  const t0 = Date.now();
+  const hdrSample = path.join(
+    os.tmpdir(),
+    `fliks-qsv-opencl-probe-${process.pid}.hevc`,
+  );
+  try {
+    // Synthesise a tiny HEVC Main10 PQ HDR bitstream (same shape as the other
+    // tone-map probes — black frames are fine, we test the graph plumbing).
+    await execFileAsync(
+      'ffmpeg',
+      [
+        '-hide_banner',
+        '-loglevel',
+        'error',
+        '-y',
+        '-f',
+        'lavfi',
+        '-i',
+        'nullsrc=size=320x180:rate=30,format=yuv420p10le',
+        '-frames:v',
+        '8',
+        '-c:v',
+        'libx265',
+        '-color_primaries',
+        'bt2020',
+        '-color_trc',
+        'smpte2084',
+        '-colorspace',
+        'bt2020nc',
+        '-x265-params',
+        [
+          'hdr-opt=1',
+          'repeat-headers=1',
+          'colorprim=bt2020',
+          'transfer=smpte2084',
+          'colormatrix=bt2020nc',
+          'master-display=G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(10000000,1)',
+          'max-cll=1000,400',
+        ].join(':'),
+        hdrSample,
+      ],
+      { timeout: 15_000 },
+    );
+
+    // The exact Windows chain a session runs: d3d11va decode → map to QSV →
+    // vpp_qsv scale (p010) → CPU bounce → tonemap_opencl (nv12) → h264_qsv.
+    await execFileAsync(
+      'ffmpeg',
+      [
+        '-hide_banner',
+        '-loglevel',
+        'error',
+        '-init_hw_device',
+        'd3d11va=dx',
+        '-init_hw_device',
+        'qsv=qs@dx',
+        '-init_hw_device',
+        'opencl=ocl',
+        '-filter_hw_device',
+        'ocl',
+        '-hwaccel',
+        'd3d11va',
+        '-hwaccel_output_format',
+        'd3d11',
+        '-hwaccel_device',
+        'dx',
+        '-i',
+        hdrSample,
+        '-vf',
+        'hwmap=derive_device=qsv,vpp_qsv=w=320:h=176:format=p010le,' +
+          'hwdownload,format=p010le,hwupload,' +
+          'tonemap_opencl=tonemap=hable:t=bt709:m=bt709:p=bt709:format=nv12,' +
+          'hwdownload,format=nv12',
+        '-c:v',
+        'h264_qsv',
+        '-preset',
+        'veryfast',
+        '-frames:v',
+        '1',
+        '-f',
+        'null',
+        '-',
+      ],
+      { timeout: 15_000 },
+    );
+    enabled = true;
+  } catch {
+    enabled = false;
+  } finally {
+    await unlink(hdrSample).catch(() => {});
+    probedOnce = true;
+    log.log(
+      `[qsv-opencl-probe] ${enabled ? 'enabled' : 'disabled'} (${Date.now() - t0}ms)`,
+    );
+  }
+}

--- a/backend/src/modules/streaming/transcoding/codec/types.ts
+++ b/backend/src/modules/streaming/transcoding/codec/types.ts
@@ -19,6 +19,13 @@ export type BitDepth = 8 | 10;
  *  passthrough is deferred to #368. */
 export type HdrFormat = 'HDR10' | 'HLG';
 
+/** HDR→SDR tone-map curve, shared by the CPU and GPU (tonemap_opencl) paths.
+ *  `hable` is a filmic curve with a gentle highlight rolloff (retains specular
+ *  detail on high-nit HDR10); `mobius` is punchier with a harder highlight knee;
+ *  `reinhard` is the simplest global operator. Selected via
+ *  `TRANSCODE_TONEMAP_CURVE`, default `hable`. */
+export type TonemapCurve = 'hable' | 'mobius' | 'reinhard';
+
 /** Source HDR10 static metadata (SMPTE ST 2086 mastering display + CTA-861.3
  *  content light level), probed from the source and propagated into the encoder
  *  so the display tonemaps against the real peak luminance instead of a generic
@@ -109,6 +116,9 @@ export interface EncoderInput {
    *  `hwdownload→CPU crop→hwupload→scale_vaapi→opencl` chain. Only
    *  meaningful when `tonemap` is true. */
   tonemapPath: 'vaapi' | 'opencl' | 'qsv';
+  /** Tone-map curve for the qsv-native OpenCL path (`tonemap_opencl`).
+   *  Resolved from `TRANSCODE_TONEMAP_CURVE`; absent → `hable`. */
+  tonemapCurve?: TonemapCurve;
   hasBurnIn: boolean;
   hasCrop: boolean;
   /** Surface format on the decoder's output side. Encoders use it to

--- a/backend/src/modules/streaming/transcoding/encode-pipeline.ts
+++ b/backend/src/modules/streaming/transcoding/encode-pipeline.ts
@@ -8,6 +8,7 @@ import {
   isTonemapOpenclEnabled,
   isTonemapOpenclEnabledWithCrop,
 } from './codec/tonemap-opencl-probe';
+import { isQsvOpenclTonemapEnabled } from './codec/qsv-opencl-probe';
 import { isScaleD3d11Enabled } from './codec/scale-d3d11-probe';
 import { resolveTonemapPath } from './tonemap-path';
 import { normaliseSourceCodec } from './codec/normalise';
@@ -98,9 +99,11 @@ export function resolveEncodePipeline(
     { hasCrop: ctx.crop },
     platform,
   );
-  const tonemapOpenclOk = ctx.crop
-    ? isTonemapOpenclEnabledWithCrop()
-    : isTonemapOpenclEnabled();
+  const tonemapOpenclOk = noVaapi
+    ? isQsvOpenclTonemapEnabled()
+    : ctx.crop
+      ? isTonemapOpenclEnabledWithCrop()
+      : isTonemapOpenclEnabled();
   // Keep the whole pipeline on QSV (no hwdownload→crop→hwupload round-trip):
   // crop-only always; tonemap via vpp_qsv LUT or via opencl when probed;
   // tonemap via vaapi is NOT qsv-native compatible.

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -610,17 +610,23 @@ export function buildFfmpegArgs(
     args.push(...openclTonemapInitArgs());
   }
   // Windows QSV OpenCL tone-map: the D3D11VA/QSV decode stays, but the
-  // tone-map bounces through OpenCL (no zero-copy D3D11↔OpenCL for HDR). Add
-  // the OpenCL device as the default filter device (overriding the decoder's
-  // `-filter_hw_device qs`) so the chain's `hwupload` lands on it; the QSV
-  // encoder auto-uploads the returned CPU frames via the `qsv=qs@dx` device.
+  // tone-map bounces through OpenCL (no zero-copy D3D11↔OpenCL for HDR). OpenCL
+  // has to be the default filter device for the chain's `hwupload` — and ffmpeg
+  // allows only one, so repoint the decoder's `-filter_hw_device qs` to `ocl`
+  // and add the OpenCL device just before it (vpp_qsv still uses its hwmap'd
+  // qsv frames' device; the encoder auto-uploads the returned CPU frames via
+  // `qsv=qs@dx`).
   const qsvOpenclTonemap =
     !!tonemap &&
     tonemapPath === 'opencl' &&
     effectiveHwAccel === 'qsv' &&
     decoder.outputSurface === 'd3d11';
   if (qsvOpenclTonemap) {
-    args.push(...openclTonemapInitArgs());
+    const fhd = args.lastIndexOf('-filter_hw_device');
+    if (fhd !== -1) {
+      args[fhd + 1] = 'ocl';
+      args.splice(fhd, 0, '-init_hw_device', 'opencl=ocl');
+    }
   }
   if (useDoviTonemap) {
     args.push('-init_hw_device', 'vulkan=vk:0', '-filter_hw_device', 'vk');

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -653,6 +653,7 @@ export function buildFfmpegArgs(
     args.push('-ss', String(seekSeconds));
   }
 
+  const tonemapCurve = resolveTonemapCurve();
   const encoderInput: EncoderInput = {
     variant,
     target: {
@@ -680,12 +681,13 @@ export function buildFfmpegArgs(
       useVaapiTonemap,
       sourceBitDepth,
       dovi: useDoviTonemap,
-      tonemapCurve: resolveTonemapCurve(),
+      tonemapCurve,
       scaleWidth: w,
       openclTonemap,
     }),
     tonemap,
     tonemapPath,
+    tonemapCurve,
     hasBurnIn: !!burnIn?.filter,
     hasCrop: !!crop,
     hdrMetadata: sourceHdrMetadata,

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -609,13 +609,11 @@ export function buildFfmpegArgs(
   if (openclTonemap) {
     args.push(...openclTonemapInitArgs());
   }
-  // Windows QSV OpenCL tone-map: the D3D11VA/QSV decode stays, but the
-  // tone-map bounces through OpenCL (no zero-copy D3D11↔OpenCL for HDR). OpenCL
-  // has to be the default filter device for the chain's `hwupload` — and ffmpeg
-  // allows only one, so repoint the decoder's `-filter_hw_device qs` to `ocl`
-  // and add the OpenCL device just before it (vpp_qsv still uses its hwmap'd
-  // qsv frames' device; the encoder auto-uploads the returned CPU frames via
-  // `qsv=qs@dx`).
+  // Windows QSV OpenCL tone-map (zero-copy): the frame maps D3D11→OpenCL and
+  // back to QSV, so OpenCL must be the default filter device AND derived from
+  // the same D3D11 device (`opencl=ocl@dx`) to share surfaces. ffmpeg accepts
+  // only one filter device, so repoint the decoder's `-filter_hw_device qs` to
+  // `ocl` and add the derived OpenCL device just before it.
   const qsvOpenclTonemap =
     !!tonemap &&
     tonemapPath === 'opencl' &&
@@ -625,7 +623,7 @@ export function buildFfmpegArgs(
     const fhd = args.lastIndexOf('-filter_hw_device');
     if (fhd !== -1) {
       args[fhd + 1] = 'ocl';
-      args.splice(fhd, 0, '-init_hw_device', 'opencl=ocl');
+      args.splice(fhd, 0, '-init_hw_device', 'opencl=ocl@dx');
     }
   }
   if (useDoviTonemap) {

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -609,6 +609,19 @@ export function buildFfmpegArgs(
   if (openclTonemap) {
     args.push(...openclTonemapInitArgs());
   }
+  // Windows QSV OpenCL tone-map: the D3D11VA/QSV decode stays, but the
+  // tone-map bounces through OpenCL (no zero-copy D3D11↔OpenCL for HDR). Add
+  // the OpenCL device as the default filter device (overriding the decoder's
+  // `-filter_hw_device qs`) so the chain's `hwupload` lands on it; the QSV
+  // encoder auto-uploads the returned CPU frames via the `qsv=qs@dx` device.
+  const qsvOpenclTonemap =
+    !!tonemap &&
+    tonemapPath === 'opencl' &&
+    effectiveHwAccel === 'qsv' &&
+    decoder.outputSurface === 'd3d11';
+  if (qsvOpenclTonemap) {
+    args.push(...openclTonemapInitArgs());
+  }
   if (useDoviTonemap) {
     args.push('-init_hw_device', 'vulkan=vk:0', '-filter_hw_device', 'vk');
   }

--- a/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.ts
@@ -1,15 +1,11 @@
 import type { BurnInSubtitle } from './types';
-import type { EncoderInput } from './codec/types';
+import type { EncoderInput, TonemapCurve } from './codec/types';
 
-/** CPU HDR→SDR tone-map curve. `hable` is a filmic curve with a gentle
- *  highlight rolloff (retains specular detail on high-nit HDR10); `mobius`
- *  is punchier with a harder highlight knee. */
-export type TonemapCurve = 'hable' | 'mobius';
-
-/** Resolve the CPU tone-map curve from the optional `TRANSCODE_TONEMAP_CURVE`
- *  env var, defaulting to `hable`. */
+/** Resolve the tone-map curve from the optional `TRANSCODE_TONEMAP_CURVE`
+ *  env var, defaulting to `hable`. Shared by the CPU and GPU tone-map paths. */
 export function resolveTonemapCurve(): TonemapCurve {
-  return process.env.TRANSCODE_TONEMAP_CURVE === 'mobius' ? 'mobius' : 'hable';
+  const v = process.env.TRANSCODE_TONEMAP_CURVE;
+  return v === 'mobius' || v === 'reinhard' ? v : 'hable';
 }
 
 export interface VideoFilterContext {
@@ -68,6 +64,7 @@ export function buildVideoFilters(
     scaleWidth,
     openclTonemap,
   } = ctx;
+  const curve = tonemapCurve ?? 'hable';
   const cropStr = crop
     ? `crop=${crop.width}:${crop.height}:${crop.x}:${crop.y}`
     : '';
@@ -75,7 +72,7 @@ export function buildVideoFilters(
   const burnInFilter = burnIn?.filter ? `,${burnIn.filter}` : '';
   const tonemapOpencl =
     tonemap && !useVaapiTonemap && !burnIn?.filter
-      ? ',hwmap=derive_device=opencl:mode=read,tonemap_opencl=format=nv12:p=bt709:t=bt709:m=bt709:tonemap=reinhard:desat=0'
+      ? `,hwmap=derive_device=opencl:mode=read,tonemap_opencl=format=nv12:p=bt709:t=bt709:m=bt709:tonemap=${curve}:desat=0`
       : '';
   const tonemapVaapi =
     useVaapiTonemap && !burnIn?.filter
@@ -97,7 +94,6 @@ export function buildVideoFilters(
   // upload the CPU frame to OpenCL, tonemap_opencl (linearises + BT.2020→709
   // + curve internally), download back. tonemap_opencl has no bt2390 in
   // ffmpeg 6.1, so it uses the same hable/mobius curve as the CPU chain.
-  const curve = tonemapCurve ?? 'hable';
   const tonemapCpu = tonemap
     ? dovi
       ? `hwupload,libplacebo=apply_dolbyvision=1:tonemapping=bt.2390:colorspace=bt709:color_primaries=bt709:color_trc=bt709:format=nv12,hwdownload,format=nv12,`

--- a/backend/src/modules/streaming/transcoding/ffmpeg-stderr.spec.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-stderr.spec.ts
@@ -26,6 +26,17 @@ describe('stripBenignFfmpegStderr', () => {
     );
   });
 
+  it('drops the benign QSV→OpenCL mapping warning (unused zero-copy path)', () => {
+    const raw = [
+      '[OpenCL @ 0x1] The cl_intel_va_api_media_sharing extension is required for QSV to OpenCL mapping.',
+      '[OpenCL @ 0x1] QSV to OpenCL mapping not usable.',
+      '[vost#0:0/h264_qsv @ 0x2] frame= 100',
+    ].join('\n');
+    expect(stripBenignFfmpegStderr(raw)).toBe(
+      '[vost#0:0/h264_qsv @ 0x2] frame= 100',
+    );
+  });
+
   it('leaves a codec-param warning for a non-subtitle stream untouched', () => {
     const raw =
       '[in#0/matroska,webm @ 0x1] Could not find codec parameters for stream 0 (Video: hevc): unspecified size';

--- a/backend/src/modules/streaming/transcoding/ffmpeg-stderr.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-stderr.ts
@@ -9,10 +9,16 @@
  *   - ffmpeg's paired `Consider increasing the value for the 'analyzeduration'`
  *     hint isn't actionable: the low probe budget is a deliberate first-segment
  *     latency choice, not an oversight.
+ *   - The OpenCL device enumeration reports `QSV to OpenCL mapping not usable`
+ *     (needs the Linux-only `cl_intel_va_api_media_sharing` extension) on the
+ *     Windows QSV OpenCL path. That zero-copy map is unused — the tone-map
+ *     bounces through the CPU (`hwupload`) — so it's informational only.
  */
 const BENIGN_STDERR_PATTERNS: RegExp[] = [
   /Could not find codec parameters for stream \d+ \(Subtitle:/,
   /Consider increasing the value for the 'analyzeduration'/,
+  /QSV to OpenCL mapping not usable/,
+  /cl_intel_va_api_media_sharing extension is required/,
 ];
 
 /** Strip {@link BENIGN_STDERR_PATTERNS} from a captured ffmpeg stderr blob so

--- a/backend/src/modules/streaming/transcoding/tonemap-path.spec.ts
+++ b/backend/src/modules/streaming/transcoding/tonemap-path.spec.ts
@@ -5,6 +5,9 @@ jest.mock('./codec/tonemap-opencl-probe', () => ({
 jest.mock('./codec/vpp-qsv-probe', () => ({
   isVppQsvTonemapEnabled: jest.fn(() => false),
 }));
+jest.mock('./codec/qsv-opencl-probe', () => ({
+  isQsvOpenclTonemapEnabled: jest.fn(() => false),
+}));
 
 import { resolveTonemapPath } from './tonemap-path';
 import {
@@ -12,16 +15,25 @@ import {
   isTonemapOpenclEnabledWithCrop,
 } from './codec/tonemap-opencl-probe';
 import { isVppQsvTonemapEnabled } from './codec/vpp-qsv-probe';
+import { isQsvOpenclTonemapEnabled } from './codec/qsv-opencl-probe';
 
 const openclNoCrop = isTonemapOpenclEnabled as jest.Mock;
 const openclCrop = isTonemapOpenclEnabledWithCrop as jest.Mock;
 const vppQsv = isVppQsvTonemapEnabled as jest.Mock;
+const qsvOpencl = isQsvOpenclTonemapEnabled as jest.Mock;
 
 describe('resolveTonemapPath', () => {
+  const origEnv = process.env.TRANSCODE_TONEMAP_ALGO;
   beforeEach(() => {
     openclNoCrop.mockReturnValue(false);
     openclCrop.mockReturnValue(false);
     vppQsv.mockReturnValue(false);
+    qsvOpencl.mockReturnValue(false);
+    delete process.env.TRANSCODE_TONEMAP_ALGO;
+  });
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.TRANSCODE_TONEMAP_ALGO;
+    else process.env.TRANSCODE_TONEMAP_ALGO = origEnv;
   });
 
   it('passes explicit picks through unchanged, on any platform', () => {
@@ -34,55 +46,85 @@ describe('resolveTonemapPath', () => {
     );
   });
 
-  it('auto → opencl when the opencl probe passed', () => {
+  it('auto → opencl on Linux when the opencl probe passed', () => {
     openclNoCrop.mockReturnValue(true);
     expect(resolveTonemapPath('auto', { hasCrop: false }, 'linux')).toBe(
       'opencl',
     );
   });
 
-  it('auto consults the crop-variant opencl probe when cropping', () => {
+  it('auto consults the crop-variant opencl probe when cropping (Linux)', () => {
     openclCrop.mockReturnValue(true);
     openclNoCrop.mockReturnValue(false);
     expect(resolveTonemapPath('auto', { hasCrop: true }, 'linux')).toBe(
       'opencl',
     );
-    // The no-crop result must not leak into the cropped decision.
     openclCrop.mockReturnValue(false);
     openclNoCrop.mockReturnValue(true);
     expect(resolveTonemapPath('auto', { hasCrop: true }, 'linux')).toBe('vaapi');
   });
 
-  it('auto → vaapi on Linux when opencl is unavailable (VAAPI is a valid QSV path there)', () => {
+  it('auto → vaapi on Linux when opencl is unavailable', () => {
     expect(resolveTonemapPath('auto', { hasCrop: false }, 'linux')).toBe(
       'vaapi',
     );
   });
 
-  it('auto → qsv on Windows when opencl is unavailable but the vpp_qsv LUT probe passed', () => {
+  it('auto → opencl on Windows when the QSV OpenCL probe passed', () => {
+    qsvOpencl.mockReturnValue(true);
+    expect(resolveTonemapPath('auto', { hasCrop: false }, 'win32')).toBe(
+      'opencl',
+    );
+  });
+
+  it('auto → qsv (LUT) on Windows when OpenCL is unavailable but the vpp_qsv probe passed', () => {
     vppQsv.mockReturnValue(true);
     expect(resolveTonemapPath('auto', { hasCrop: false }, 'win32')).toBe('qsv');
   });
 
-  it('auto → vaapi on Windows when neither opencl nor the vpp_qsv LUT is available', () => {
-    vppQsv.mockReturnValue(false);
-    expect(resolveTonemapPath('auto', { hasCrop: false }, 'win32')).toBe(
-      'vaapi',
-    );
-  });
-
-  it('does not divert to the qsv LUT on Linux even when its probe passed', () => {
-    vppQsv.mockReturnValue(true);
-    expect(resolveTonemapPath('auto', { hasCrop: false }, 'linux')).toBe(
-      'vaapi',
-    );
-  });
-
-  it('prefers opencl over the qsv LUT on Windows when both are available', () => {
-    openclNoCrop.mockReturnValue(true);
+  it('prefers OpenCL over the qsv LUT on Windows when both probes passed', () => {
+    qsvOpencl.mockReturnValue(true);
     vppQsv.mockReturnValue(true);
     expect(resolveTonemapPath('auto', { hasCrop: false }, 'win32')).toBe(
       'opencl',
     );
+  });
+
+  it('ignores the Linux VAAPI opencl probe on Windows (uses the QSV OpenCL one)', () => {
+    openclNoCrop.mockReturnValue(true); // VAAPI probe — irrelevant on win32
+    vppQsv.mockReturnValue(true);
+    expect(resolveTonemapPath('auto', { hasCrop: false }, 'win32')).toBe('qsv');
+  });
+
+  describe('TRANSCODE_TONEMAP_ALGO override', () => {
+    it('forces the algo over the probe-driven auto, on any platform', () => {
+      openclNoCrop.mockReturnValue(true); // auto would pick opencl on Linux
+      process.env.TRANSCODE_TONEMAP_ALGO = 'qsv';
+      expect(resolveTonemapPath('auto', { hasCrop: false }, 'linux')).toBe(
+        'qsv',
+      );
+    });
+
+    it('overrides an explicit setting too', () => {
+      process.env.TRANSCODE_TONEMAP_ALGO = 'opencl';
+      expect(resolveTonemapPath('vaapi', { hasCrop: false }, 'win32')).toBe(
+        'opencl',
+      );
+    });
+
+    it('is case-insensitive and trims whitespace', () => {
+      process.env.TRANSCODE_TONEMAP_ALGO = '  OpenCL  ';
+      expect(resolveTonemapPath('auto', { hasCrop: false }, 'linux')).toBe(
+        'opencl',
+      );
+    });
+
+    it('ignores an invalid value (falls back to the normal resolution)', () => {
+      process.env.TRANSCODE_TONEMAP_ALGO = 'nonsense';
+      vppQsv.mockReturnValue(true);
+      expect(resolveTonemapPath('auto', { hasCrop: false }, 'win32')).toBe(
+        'qsv',
+      );
+    });
   });
 });

--- a/backend/src/modules/streaming/transcoding/tonemap-path.ts
+++ b/backend/src/modules/streaming/transcoding/tonemap-path.ts
@@ -3,8 +3,19 @@ import {
   isTonemapOpenclEnabledWithCrop,
 } from './codec/tonemap-opencl-probe';
 import { isVppQsvTonemapEnabled } from './codec/vpp-qsv-probe';
+import { isQsvOpenclTonemapEnabled } from './codec/qsv-opencl-probe';
 import { hostHasVaapi } from './hw-device';
 import type { TonemapAlgo } from './types';
+
+/** `TRANSCODE_TONEMAP_ALGO` override (auto/qsv/vaapi/opencl), applied on every
+ *  platform before the `auto` resolution — pins the HDR→SDR tone-map without
+ *  the admin UI (see docker-compose). Invalid/unset → null (no override). */
+export function tonemapAlgoOverride(): TonemapAlgo | null {
+  const v = process.env.TRANSCODE_TONEMAP_ALGO?.trim().toLowerCase();
+  return v === 'auto' || v === 'qsv' || v === 'vaapi' || v === 'opencl'
+    ? (v as TonemapAlgo)
+    : null;
+}
 
 /** Concrete filter chain the session-time graph will actually use,
  *  derived from the admin `TonemapAlgo` setting + boot probe results.
@@ -31,10 +42,16 @@ export function resolveTonemapPath(
   opts: { hasCrop: boolean } = { hasCrop: false },
   platform: NodeJS.Platform = process.platform,
 ): ResolvedTonemapPath {
-  if (algo === 'auto') {
-    const openclOk = opts.hasCrop
-      ? isTonemapOpenclEnabledWithCrop()
-      : isTonemapOpenclEnabled();
+  const effective = tonemapAlgoOverride() ?? algo;
+  if (effective === 'auto') {
+    // Windows QSV OpenCL is the CPU-bounce path (its own probe); elsewhere it's
+    // the VAAPI-derived bridge.
+    const openclOk =
+      platform === 'win32'
+        ? isQsvOpenclTonemapEnabled()
+        : opts.hasCrop
+          ? isTonemapOpenclEnabledWithCrop()
+          : isTonemapOpenclEnabled();
     if (openclOk) return 'opencl';
     // No VAAPI device (Windows): 'vaapi' isn't a QSV path, so prefer the
     // vpp_qsv fixed-function LUT when its probe passed rather than force a
@@ -42,5 +59,5 @@ export function resolveTonemapPath(
     if (!hostHasVaapi(platform) && isVppQsvTonemapEnabled()) return 'qsv';
     return 'vaapi';
   }
-  return algo;
+  return effective;
 }

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -45,6 +45,7 @@ import {
   runTonemapOpenclProbe,
 } from './codec/tonemap-opencl-probe';
 import { runOpenclTonemapProbe } from './codec/opencl-tonemap-probe';
+import { runQsvOpenclTonemapProbe } from './codec/qsv-opencl-probe';
 import { runLibplaceboDvProbe } from './codec/libplacebo-dv-probe';
 import { runScaleD3d11Probe } from './codec/scale-d3d11-probe';
 import {
@@ -132,14 +133,19 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     // probe times out at 15s on hosts without the qsv encoder).
     if (this.detectedHwAccel === 'qsv') {
       void runVppQsvTonemapProbe(this.log);
+      // Windows QSV OpenCL tone-map (CPU-bounce). The VAAPI-based
+      // tonemap-opencl probe below can't run here (no VAAPI on Windows).
+      if (process.platform === 'win32') {
+        void runQsvOpenclTonemapProbe(this.log);
+      }
     }
     // tonemap_opencl probe runs on every Linux Intel host (QSV or VAAPI):
     // both paths can route through the opencl tonemap chain at session
     // time, but the QSV↔OpenCL bridge is fragile and we need to know
     // upfront whether `tonemapAlgo='auto'` can safely default to opencl.
     if (
-      this.detectedHwAccel === 'qsv' ||
-      this.detectedHwAccel === 'vaapi'
+      (this.detectedHwAccel === 'qsv' || this.detectedHwAccel === 'vaapi') &&
+      process.platform !== 'win32'
     ) {
       void runTonemapOpenclProbe(this.log);
     }

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -94,7 +94,7 @@
     "stats_stream": "Stream",
     "stats_dropped_frames": "Verworfene Bilder:",
     "stats_crop": "Zuschnitt:",
-    "stats_tonemapping": "Tone-Mapping",
+    "stats_tonemapping": "Tone-Mapping:",
     "stats_reasons": "Gründe:",
     "stats_sample_rate": "Abtastrate",
     "transcode_reason": {

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -94,7 +94,7 @@
     "stats_stream": "Stream",
     "stats_dropped_frames": "Dropped frames:",
     "stats_crop": "Crop:",
-    "stats_tonemapping": "Tone mapping",
+    "stats_tonemapping": "Tone mapping:",
     "stats_reasons": "Reasons:",
     "stats_sample_rate": "Sample rate",
     "transcode_reason": {

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -94,7 +94,7 @@
     "stats_stream": "Flujo",
     "stats_dropped_frames": "Imágenes perdidas:",
     "stats_crop": "Recorte:",
-    "stats_tonemapping": "Mapeo tonal",
+    "stats_tonemapping": "Mapeo tonal:",
     "stats_reasons": "Motivos:",
     "stats_sample_rate": "Frecuencia de muestreo",
     "transcode_reason": {

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -94,7 +94,7 @@
     "stats_stream": "Flux",
     "stats_dropped_frames": "Images perdues :",
     "stats_crop": "Recadrage :",
-    "stats_tonemapping": "Mappage tonal",
+    "stats_tonemapping": "Mappage tonal :",
     "stats_reasons": "Raisons :",
     "stats_sample_rate": "Fréquence d'échantillonnage",
     "transcode_reason": {

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -94,7 +94,7 @@
     "stats_stream": "Flusso",
     "stats_dropped_frames": "Fotogrammi persi:",
     "stats_crop": "Ritaglio:",
-    "stats_tonemapping": "Mappatura tonale",
+    "stats_tonemapping": "Mappatura tonale:",
     "stats_reasons": "Motivi:",
     "stats_sample_rate": "Frequenza di campionamento",
     "transcode_reason": {

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -94,7 +94,7 @@
     "stats_stream": "Fluxo",
     "stats_dropped_frames": "Imagens perdidas:",
     "stats_crop": "Recorte:",
-    "stats_tonemapping": "Mapeamento tonal",
+    "stats_tonemapping": "Mapeamento tonal:",
     "stats_reasons": "Motivos:",
     "stats_sample_rate": "Frequência de amostragem",
     "transcode_reason": {

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -33,8 +33,8 @@ export interface PlaybackInfoResponse {
    *  `'cpu'` for the CPU chain (NVENC / libx26x / VideoToolbox
    *  fallback). Null when no tone-mapping pass runs on this session. */
   tonemapAlgo?: 'vaapi' | 'opencl' | 'qsv' | 'cpu' | null;
-  /** CPU tone-map curve, set only when `tonemapAlgo === 'cpu'`. */
-  tonemapCurve?: 'hable' | 'mobius';
+  /** Tone-map curve, set for the `opencl` and `cpu` paths (the LUTs ignore it). */
+  tonemapCurve?: 'hable' | 'mobius' | 'reinhard';
   /** Cibles par rung (transcodage). */
   transcodeBitrateByQuality?: Record<
     string,

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -760,17 +760,19 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // setting says `auto`/`opencl`. Source of truth is `pi.tonemapAlgo`
     // set by the backend in playback-info.
     const tonemapLabel: Record<string, string> = {
-      vaapi: 'tonemap_vaapi',
-      opencl: 'tonemap_opencl',
-      qsv: 'vpp_qsv tonemap',
+      vaapi: 'VAAPI',
+      opencl: 'OpenCL',
+      qsv: 'vpp_qsv',
       cpu: 'CPU',
     };
-    const tonemapAlgoLabel =
-      pi?.tonemapAlgo === 'cpu' && pi?.tonemapCurve
-        ? `CPU (${pi.tonemapCurve})`
-        : pi?.tonemapAlgo
-          ? (tonemapLabel[pi.tonemapAlgo] ?? pi.tonemapAlgo)
-          : '';
+    // The opencl and CPU paths run a tunable curve (tonemap_opencl / tonemap),
+    // surfaced in parentheses; the vpp_qsv / VAAPI LUTs carry no curve.
+    const curve = pi?.tonemapCurve
+      ? ` (${pi.tonemapCurve.charAt(0).toUpperCase()}${pi.tonemapCurve.slice(1)})`
+      : '';
+    const tonemapAlgoLabel = pi?.tonemapAlgo
+      ? `${tonemapLabel[pi.tonemapAlgo] ?? pi.tonemapAlgo}${curve}`
+      : '';
     const tonemapping =
       pi?.tonemapping && tonemapAlgoLabel
         ? tonemapAlgoLabel

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -91,6 +91,15 @@ services:
       #
       # How often the cache garbage collector runs. Default 300000 (5 min).
       # TRANSCODE_CACHE_GC_INTERVAL_MS: 300000
+      #
+      # HDR->SDR tone-mapping method for hardware transcodes (Intel/AMD).
+      # 'auto' (default) picks per-GPU from the boot probes: OpenCL when
+      # available (best quality — a proper tone curve), else the fixed-function
+      # LUT (faster and lighter, but can look darker/flatter). OpenCL costs more
+      # (on Intel it bounces through the CPU): fine at 1080p, ~single-stream at
+      # 4K. Force one to override the probe-driven default:
+      #   auto | opencl | vaapi | qsv
+      # TRANSCODE_TONEMAP_ALGO: auto
     volumes:
       # ---- Media library ------------------------------------------------
       # Map your existing media tree here. Match the path Fliks tells the

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -63,7 +63,7 @@ services:
       # the fixed-function LUT (also fast, but can look darker/flatter).
       # Values: auto | opencl | vaapi | qsv
       # TRANSCODE_TONEMAP_ALGO: auto
-      # CPU/OpenCL tonemap curve. Default hable. Values: hable | mobius
+      # HDR->SDR tonemap curve (CPU + OpenCL). Default hable. Values: hable | mobius | reinhard
       # TRANSCODE_TONEMAP_CURVE: hable
       # DRI render node for VAAPI / Linux QSV. Default /dev/dri/renderD128.
       # FLIKS_VAAPI_RENDER_NODE: /dev/dri/renderD128

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,13 +1,8 @@
 # Example Docker Compose for self-hosting Fliks.
-#
-# Copy this file to `docker-compose.yml`, edit the volume paths and the
-# DB password, then `docker compose up -d`. The web UI lives at
-# http://<host>:4848.
-#
-# Image is pulled from GitHub Container Registry — no auth required for
-# public images. To pin a specific version replace `:latest` with `:1.2.3`
-# (see https://github.com/fliks-app/fliks/pkgs/container/fliks for the
-# full tag list).
+# Copy to `docker-compose.yml`, edit the volume paths + DB password, then
+# `docker compose up -d`. Web UI: http://<host>:4848.
+# Pin a version by replacing `:latest` with `:1.2.3` (tags:
+# https://github.com/fliks-app/fliks/pkgs/container/fliks).
 
 services:
   postgres:
@@ -15,10 +10,7 @@ services:
     restart: unless-stopped
     environment:
       POSTGRES_USER: fliks
-      # Change me before exposing the stack to anything other than
-      # localhost. The DB is reached over the internal compose network
-      # only, but a default password in published Compose files is a
-      # well-known footgun.
+      # Change before exposing the stack beyond localhost.
       POSTGRES_PASSWORD: changeme
       POSTGRES_DB: fliks
     volumes:
@@ -35,19 +27,12 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    # Publish the web UI / API on host port 4848. The container runs on the
-    # default compose bridge network and reaches Postgres by its service name.
-    #
-    # Note: on a bridge network, LAN Chromecast / DLNA discovery (mDNS) does
-    # not reach the container. If you rely on Cast-device auto-discovery from
-    # this server, either run a host-network sidecar for discovery or switch
-    # this service to `network_mode: host` (then drop the `ports:` block and
-    # set DB_HOST to 127.0.0.1 with Postgres also reachable on the host).
+    # On a bridge network, LAN Chromecast/DLNA discovery (mDNS) can't reach the
+    # container. For Cast auto-discovery use `network_mode: host` (then drop
+    # `ports:` and set DB_HOST to 127.0.0.1).
     ports:
       - '4848:4848'
     environment:
-      # Default port. Override (and the published port above) if 4848 is
-      # already used on the host.
       PORT: 4848
       DB_HOST: postgres
       DB_PORT: 5432
@@ -55,98 +40,56 @@ services:
       DB_PASSWORD: changeme
       DB_NAME: fliks
       NODE_ENV: production
-      # Set to disable the GitHub update check: no outbound api.github.com
-      # request, and /api/system/update always reports "up to date". Default:
-      # enabled (a single cached read request, no token, no data sent).
+      # Disable the GitHub update check (no outbound request). Default: enabled.
       # FLIKS_DISABLE_UPDATE_CHECK: '1'
-      # ---- Streaming session tuning (optional) -----------------------
-      # All values below have safe defaults baked in. Override only if
-      # you know what you're doing.
-      #
-      # How long a "live viewer" entry survives without any heartbeat
-      # from the client. The client beats every 10 s, so 30 s tolerates
-      # three missed beats (background tab, network blip). Default 30000.
+
+      # ---- Streaming tuning (optional, safe defaults) ----
+      # Live-viewer TTL without a heartbeat (client beats every 10s). Default 30000.
       # STREAM_LIVE_SESSION_TTL_MS: 30000
-      #
-      # Grace window after the last live viewer for a given
-      # (user, file, profileHash) disappears, before the matching
-      # ffmpeg encoder is killed. Cache stays so a reconnect within the
-      # next few hours reattaches without retranscoding. Default 60000.
+      # Grace before the encoder is killed after the last viewer leaves. Default 60000.
       # STREAM_JOB_GRACE_MS: 60000
-      #
-      # Idle timeout for transcode sessions that were never paired with
-      # a live session (legacy URL fetches, admin scrubbing). Mirrors
-      # the pre-heartbeat behaviour. Default 1800000 (30 min).
+      # Idle timeout for sessions never paired with a live viewer. Default 1800000.
       # STREAM_JOB_FALLBACK_TIMEOUT_MS: 1800000
-      #
-      # How long transcoded segments stay on disk after their last
-      # access. Default 14400000 (4 h). Set lower to free disk faster,
-      # higher to cover users who pause for a long time and come back.
+      # Segment retention on disk after last access. Default 14400000 (4 h).
       # TRANSCODE_CACHE_TTL_MS: 14400000
-      #
-      # Hard cap on the total size of the transcode cache. Above this,
-      # LRU eviction kicks in even if entries are still within TTL.
-      # Default 21474836480 (20 GB).
+      # Transcode cache size cap (LRU eviction above it). Default 21474836480 (20 GB).
       # TRANSCODE_CACHE_MAX_BYTES: 21474836480
-      #
-      # How often the cache garbage collector runs. Default 300000 (5 min).
+      # Cache GC interval. Default 300000 (5 min).
       # TRANSCODE_CACHE_GC_INTERVAL_MS: 300000
-      #
-      # HDR->SDR tone-mapping method for hardware transcodes (Intel/AMD).
-      # 'auto' (default) picks per-GPU from the boot probes: OpenCL when
-      # available (best quality — a proper tone curve), else the fixed-function
-      # LUT (faster and lighter, but can look darker/flatter). OpenCL costs more
-      # (on Intel it bounces through the CPU): fine at 1080p, ~single-stream at
-      # 4K. Force one to override the probe-driven default:
-      #   auto | opencl | vaapi | qsv
+
+      # ---- HW transcode / HDR (optional) ----
+      # HDR->SDR tonemap method. auto (default) uses OpenCL when the GPU probe
+      # passes (best quality), else the fixed-function LUT (faster, can look
+      # darker). OpenCL costs more (CPU bounce on Intel): fine <=1080p,
+      # ~single-stream at 4K. Values: auto | opencl | vaapi | qsv
       # TRANSCODE_TONEMAP_ALGO: auto
+      # CPU/OpenCL tonemap curve. Default hable. Values: hable | mobius
+      # TRANSCODE_TONEMAP_CURVE: hable
+      # DRI render node for VAAPI / Linux QSV. Default /dev/dri/renderD128.
+      # FLIKS_VAAPI_RENDER_NODE: /dev/dri/renderD128
+      # Pin the OpenCL platform.device on multi-GPU hosts. Default: auto-pick.
+      # FLIKS_OPENCL_DEVICE: '0.0'
     volumes:
-      # ---- Media library ------------------------------------------------
-      # Map your existing media tree here. Match the path Fliks tells the
-      # user to use when adding a library in the UI.
-      #
-      # Add as many of these as you need — every mount you expose here
-      # can be picked as a separate library root in Fliks (Settings →
-      # Libraries → Add). Example with a second drive:
-      #   - /path/to/your/movies:/medias/movies
-      #   - /path/to/your/series:/medias/series
+      # Media library: use this container path when adding a library in the UI.
+      # Add more mounts for more roots (e.g. /medias/movies, /medias/series).
       - /path/to/your/media:/medias
-
-      # ---- Download folder ---------------------------------------------
-      # Where freshly-downloaded files land before Fliks imports them
-      # into the library above. Mount the SAME path here and on whichever
-      # download client you use so the two services share the working
-      # directory.
+      # Download folder: mount the SAME path here and on your download client.
       - /path/to/download/folder:/downloads
-
-      # ---- App-managed storage -----------------------------------------
-      # Server-side secrets auto-generated on first boot (JWT signing
-      # key, future encryption keys). Must be persisted across container
-      # restarts — losing this file invalidates every JWT and forces all
-      # users to log back in. Permissions inside are 0700 / 0600.
+      # Server secrets (JWT key) — persist across restarts or all users re-login.
       - fliks_conf:/app/conf
-      # Cached TMDB / fanart images, sprite sheets for player seek preview.
+      # Cached images + seek-preview sprites.
       - fliks_images:/app/images
-      # Optional: persistent transcoding cache (HLS segments, etc.)
-      # If omitted, a tmpfs is used per-container restart.
+      # Transcode cache (HLS segments). Omit to use a per-restart tmpfs.
       - fliks_transcode:/app/transcode
 
-  # Optional GPU-accelerated transcoding via Intel QSV / VAAPI. Uncomment
-  # the `devices` block above (under the fliks service) and pick the
-  # right /dev/dri device for your host. NVIDIA NVENC needs a different
-  # setup (runtime: nvidia + nvidia-container-toolkit on the host) and
-  # is not covered by this example.
-  #
-  # services:
+  # GPU transcode (Intel QSV / VAAPI): add a `devices` block to the fliks
+  # service with your /dev/dri node. NVENC needs runtime: nvidia +
+  # nvidia-container-toolkit (not covered here).
   #   fliks:
   #     devices:
   #       - /dev/dri:/dev/dri
-  #
-  # ARM hosts (Apple Silicon Docker Desktop, Pi 5, ARM NAS): the image
-  # is published for linux/arm64 too — Docker pulls the right variant
-  # automatically. No HW transcode there (the Intel GPU stack ships only
-  # in the amd64 image, and Metal/VideoToolbox aren't reachable from a
-  # Linux container), so streams fall back to libx264 CPU encoding.
+  # ARM (Apple Silicon, Pi 5, ARM NAS): linux/arm64 is auto-pulled, but there's
+  # no HW transcode (Intel stack is amd64-only) -> CPU libx264 fallback.
 
 volumes:
   fliks_pgdata:

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -59,9 +59,9 @@ services:
 
       # ---- HW transcode / HDR (optional) ----
       # HDR->SDR tonemap method. auto (default) uses OpenCL when the GPU probe
-      # passes (best quality), else the fixed-function LUT (faster, can look
-      # darker). OpenCL costs more (CPU bounce on Intel): fine <=1080p,
-      # ~single-stream at 4K. Values: auto | opencl | vaapi | qsv
+      # passes (best quality — a proper tone curve, zero-copy on the GPU), else
+      # the fixed-function LUT (also fast, but can look darker/flatter).
+      # Values: auto | opencl | vaapi | qsv
       # TRANSCODE_TONEMAP_ALGO: auto
       # CPU/OpenCL tonemap curve. Default hable. Values: hable | mobius
       # TRANSCODE_TONEMAP_CURVE: hable

--- a/windows/README.md
+++ b/windows/README.md
@@ -16,7 +16,7 @@ mechanisms.
 | Tray UI | SwiftUI `MenuBarExtra` | C#/.NET 8 WinForms `NotifyIcon` |
 | Code discovery | symlink dist/node_modules into a writable cwd | run `node <dist>\main.js` by absolute path, cwd = writable data dir (Node resolves `node_modules` from the script path — no symlinks) |
 | PostgreSQL | Homebrew bottle + dylib relocation | EDB binaries zip (self-contained, no relocation) |
-| FFmpeg | Homebrew + dylib relocation | BtbN gpl static build (one exe: QSV + AMF + NVENC + OpenCL) |
+| FFmpeg | Homebrew + dylib relocation | jellyfin-ffmpeg gpl build (QSV + AMF + NVENC + OpenCL, incl. zero-copy D3D11↔OpenCL P010 for HDR tone-map) |
 | Autostart | `SMAppService` | `HKCU\…\Run` registry value |
 | Package | DMG | NSIS per-user installer |
 

--- a/windows/Scripts/fetch-vendored.ps1
+++ b/windows/Scripts/fetch-vendored.ps1
@@ -21,14 +21,13 @@ $NodeVersion = '24.2.0'
 # EDB "binaries" zip (no installer) — verify the build suffix at
 # https://www.enterprisedb.com/download-postgresql-binaries
 $PgVersion = '18.0-1'
-# n8.1 stable release branch (NOT master). 8.1 carries the native scale_d3d11
-# filter (zero-copy AMD scale, dormant until a GPU accepts it). 8.1's scale_cuda
-# has a green-frame bug on non-scaling format conversion (p010→nv12 with no
-# resize); we sidestep it in the encoder filter graph (scale_cuda keeps the
-# native format, the encoder owns the output bit depth) so this pin is safe.
-# Note: 8.x links a newer NVENC API — NVENC needs an NVIDIA driver >= 570; older
-# drivers fall back to CPU. One binary covers QSV + AMF + NVENC + OpenCL.
-$FfmpegUrl = 'https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n8.1-latest-win64-gpl-8.1.zip'
+# jellyfin-ffmpeg (GPL) — same FFmpeg 8.1 base as BtbN plus HW-interop patches.
+# The one that matters on Windows: zero-copy D3D11<->OpenCL P010, so HDR->SDR
+# tone-maps on OpenCL (proper tone curve) with no CPU round-trip — ~8x @4K vs
+# ~1.2x for the stock CPU bounce. Also ships a P010-capable Intel OpenCL ICD.
+# One binary covers QSV + AMF + NVENC + OpenCL; NVENC still needs an NVIDIA
+# driver >= 570 (8.x NVENC API). Pin the exact tag (their `latest` moves).
+$FfmpegUrl = 'https://github.com/jellyfin/jellyfin-ffmpeg/releases/download/v8.1.2-1/jellyfin-ffmpeg_8.1.2-1_portable_win64-clang-gpl.zip'
 
 function Get-Archive([string]$url, [string]$dest) {
     $tmp = Join-Path ([IO.Path]::GetTempPath()) ([Guid]::NewGuid())
@@ -90,18 +89,21 @@ if (Test-Path $mp) {
     Write-Warning 'MSVCP140.dll not bundled; postgres/node may crash on hosts with an old VC++ runtime'
 }
 
-# ── FFmpeg (BtbN gpl static) ──
+# ── FFmpeg (jellyfin-ffmpeg gpl) ──
 if (Test-Path (Join-Path $vendored 'ffmpeg\bin\ffmpeg.exe')) {
     Write-Host '    [skip] FFmpeg already present'
 } else {
     $tmp = Join-Path ([IO.Path]::GetTempPath()) ([Guid]::NewGuid())
     Get-Archive $FfmpegUrl $tmp
-    $ffBin = Get-ChildItem -Path $tmp -Directory | Select-Object -First 1 | ForEach-Object { Join-Path $_.FullName 'bin' }
-    New-Item -ItemType Directory -Force -Path (Join-Path $vendored 'ffmpeg\bin') | Out-Null
-    Copy-Item (Join-Path $ffBin 'ffmpeg.exe') (Join-Path $vendored 'ffmpeg\bin\ffmpeg.exe')
-    Copy-Item (Join-Path $ffBin 'ffprobe.exe') (Join-Path $vendored 'ffmpeg\bin\ffprobe.exe')
+    # Copy the whole binary dir (ffmpeg/ffprobe + bundled runtime/ICD DLLs),
+    # located by finding ffmpeg.exe wherever this archive nests it.
+    $ffExe = Get-ChildItem -Path $tmp -Recurse -Filter ffmpeg.exe | Select-Object -First 1
+    if (-not $ffExe) { throw "ffmpeg.exe not found in $FfmpegUrl" }
+    $dst = Join-Path $vendored 'ffmpeg\bin'
+    New-Item -ItemType Directory -Force -Path $dst | Out-Null
+    Copy-Item (Join-Path $ffExe.Directory.FullName '*') $dst -Recurse -Force
     Remove-Item -Recurse -Force $tmp
-    Write-Host '    [done] FFmpeg (gpl)'
+    Write-Host '    [done] FFmpeg (jellyfin-ffmpeg gpl)'
 }
 
 Write-Host ''


### PR DESCRIPTION
Gives Windows QSV a **proper, fast** HDR→SDR tone-map by adopting **jellyfin-ffmpeg**, plus an env override to pick the method.

## Why

The `vpp_qsv` fixed-function LUT under-exposes (known Intel limit); its only knob — procamp brightness — washes out contrast (confirmed on-box). `tonemap_opencl` gives a real curve, but on the stock BtbN build the D3D11↔OpenCL bridge is **NV12-only** (can't carry the 10-bit HDR surface) and QSV→OpenCL needs a Linux-only extension — so OpenCL could only run through a slow CPU bounce (~1.2x @4K).

**jellyfin-ffmpeg 8.1.2** (same FFmpeg 8.1 base as BtbN + HW-interop patches, incl. **P010 D3D11↔OpenCL sharing** and a P010-capable Intel OpenCL ICD) unlocks the **zero-copy** path.

## Chain & perf (Iris Xe, on-box)

`d3d11va decode → hwmap QSV → vpp_qsv crop/scale (p010) → hwmap OpenCL → tonemap_opencl(hable) → hwmap back to QSV → h264/hevc_qsv` — no CPU round-trip. The tone-map runs at **output** resolution (scale first), which also beats tone-mapping the full 4K source.

| Output | LUT | OpenCL CPU-bounce (BtbN) | **OpenCL zero-copy (jellyfin)** |
|---|---|---|---|
| 4K | ~4x | ~1.2x | **~8x** |

OpenCL now wins on **quality AND throughput** — multi-user 4K HDR is fine. Scale sits on the up-front `vpp_qsv` (the same forward `d3d11→qsv→vpp_qsv` stage the LUT path uses): `vpp_qsv` cannot ingest a surface produced by a *reverse* hwmap out of OpenCL, so the scale must precede the OpenCL step, not follow it.

## Changes

- **Vendoring** (`fetch-vendored.ps1`): BtbN → `jellyfin-ffmpeg_8.1.2-1_portable_win64-clang-gpl.zip`; copy the whole binary dir (bundled DLLs/ICD). CI cache key already hashes this script, so it auto-refetches.
- **qsv-filters**: d3d11 OpenCL branch = the zero-copy chain above.
- **ffmpeg-args**: OpenCL derived from the same D3D11 device (`opencl=ocl@dx`), single filter device.
- **qsv-opencl-probe**: runs the exact zero-copy chain at boot (fail-closed → LUT). Validated on-box (8x @4K).
- **`TRANSCODE_TONEMAP_ALGO`** env (`auto|qsv|vaapi|opencl`) overrides the method on any platform; documented in `docker-compose.example.yml`. Admin UI later.
- `auto` on Windows: OpenCL if the probe passes, else the vpp_qsv LUT.

## Validation

- **Intel QSV** (Iris Xe): OpenCL zero-copy tone-map + LUT fallback validated on-box — clean 4K HDR playback, excellent throughput, no CPU fallback.
- **NVENC / AMF**: the ffmpeg swap touches all Windows vendors; both were left un-re-tested by explicit choice (jellyfin-ffmpeg shares the 8.1.2 base and is a mainstream NVENC/AMF build → low risk).
- Linux/Docker unchanged (own ffmpeg + VAAPI bridge).

## Tests

`tonemap-path.spec` (routing + `TRANSCODE_TONEMAP_ALGO`), `qsv-filters.spec` (zero-copy d3d11 chain vs Linux chain), `ffmpeg-stderr.spec` (benign-warning filter). 340 transcoding specs + typecheck green.

Refs: #720