### PR TITLE
feat(docker): adopt jellyfin-ffmpeg on Linux with AV1 vaapi-decode fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,14 +31,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && cargo install subtile-ocr --version 0.2.6 --root /opt/subtile-ocr \
   && rm -rf /var/lib/apt/lists/* "$HOME/.cargo/registry" "$HOME/.rustup"
 
-# --- Stage 2c: Build libplacebo with Dolby Vision (libdovi) ---
-# The apt libplacebo isn't built with libdovi, so ffmpeg's `apply_dolbyvision`
-# is a silent no-op there and a DV Profile 5 source renders wrong. Rebuild the
-# SAME libplacebo version (identical soname → drop-in for the apt ffmpeg) with
-# libdovi so P5 can be RPU-tonemapped. Pin LIBPLACEBO_TAG to the runtime's apt
-# libplacebo version (check `apt-cache policy libplacebo338`) so the ABI matches.
+# --- Stage 2c: Build libplacebo with Dolby Vision (libdovi), ABI-matched to
+#     jellyfin-ffmpeg ---
+# jellyfin-ffmpeg bundles libplacebo but WITHOUT libdovi (their build has no
+# -Dlibdovi), so `apply_dolbyvision` is a no-op and DV Profile 5 renders wrong
+# (#636). Rebuild libplacebo at the SAME commit jellyfin uses — identical soname
+# (.so.360), a drop-in for the bundled ffmpeg — with libdovi enabled, and overlay
+# it in the runtime stage. Keep LIBPLACEBO_COMMIT in sync with jellyfin-ffmpeg's
+# builder/scripts.d/50-libplacebo.sh (SCRIPT_COMMIT) for the pinned version.
 FROM ubuntu:24.04 AS libplacebo-dovi-build
-ARG LIBPLACEBO_TAG=v6.338.2
+ARG LIBPLACEBO_COMMIT=cee9b076f2c63104ccfd497fa79c39a867293ec4
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl git build-essential pkg-config libssl-dev \
     meson ninja-build libshaderc-dev libvulkan-dev liblcms2-dev python3-mako python3-jinja2 \
@@ -48,13 +50,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && git clone --depth 1 https://github.com/quietvoid/dovi_tool /tmp/dovi_tool \
   && cd /tmp/dovi_tool/dolby_vision \
   && cargo cinstall --release --prefix=/opt/dvlibs --libdir=/opt/dvlibs/lib \
-  && git clone --depth 1 --branch "$LIBPLACEBO_TAG" \
-       https://code.videolan.org/videolan/libplacebo.git /tmp/libplacebo \
+  && git clone https://code.videolan.org/videolan/libplacebo.git /tmp/libplacebo \
   && cd /tmp/libplacebo \
+  && git checkout "$LIBPLACEBO_COMMIT" \
+  && git submodule update --init --recursive \
   && PKG_CONFIG_PATH=/opt/dvlibs/lib/pkgconfig meson setup build \
-       -Dlibdovi=enabled -Dvulkan=enabled -Dshaderc=enabled -Dglslang=disabled \
-       -Dopengl=disabled -Dd3d11=disabled \
-       -Ddemos=false -Dtests=false --buildtype=release --prefix=/opt/plbo --libdir=lib \
+       -Dlibdovi=enabled -Dvulkan=enabled -Dvk-proc-addr=enabled -Dshaderc=enabled \
+       -Dglslang=disabled -Dopengl=disabled -Dd3d11=disabled \
+       -Ddemos=false -Dtests=false -Dbench=false -Dfuzz=false \
+       --default-library=shared --buildtype=release --prefix=/opt/plbo --libdir=lib \
   && ninja -C build && ninja -C build install \
   && rm -rf /var/lib/apt/lists/* "$HOME/.cargo/registry" "$HOME/.rustup" \
        /tmp/dovi_tool /tmp/libplacebo
@@ -66,6 +70,9 @@ FROM ubuntu:24.04
 # arm64, ...). Used below to skip x86-only packages on arm64 builds.
 ARG TARGETARCH
 
+# jellyfin-ffmpeg release to bundle. Same build as the Windows server (unified).
+ARG JELLYFIN_FFMPEG_VERSION=8.1.2-1
+
 # Install Node.js 24
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
   && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
@@ -73,10 +80,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
   && apt-get purge -y curl gnupg \
   && rm -rf /var/lib/apt/lists/*
 
-# Install runtime dependencies + FFmpeg. Intel GPU stack and the alass
-# binary are amd64-only — on arm64 (Apple Silicon Docker, ARM NAS, Pi)
-# the image falls back to CPU transcoding (libx264) and subtitle sync
-# via ffsubsync alone. ffmpeg apt package is arch-aware on both.
+# Install runtime dependencies + FFmpeg (jellyfin-ffmpeg — self-contained
+# VAAPI/QSV stack). jellyfin-ffmpeg bundles libva, iHD and oneVPL/libmfx, so the
+# apt ffmpeg and Intel VA drivers are gone. It does NOT bundle intel-opencl-icd
+# (tonemap_opencl), the Vulkan driver, lcms2 (libplacebo deps) or libdovi
+# (overlaid below) — those stay, amd64-only. The jellyfin-ffmpeg deb is per-arch;
+# on arm64 there's no Intel HW so the image is CPU-only (libx264) + ffsubsync.
 RUN apt-get update && apt-get install -y --no-install-recommends \
   bash \
   postgresql-client \
@@ -84,7 +93,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python3 \
   python3-pip \
   python3-venv \
-  ffmpeg \
   libchromaprint-tools \
   mkvtoolnix \
   tesseract-ocr \
@@ -96,15 +104,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libc6-dev \
   && if [ "$TARGETARCH" = "amd64" ]; then \
        apt-get install -y --no-install-recommends \
-         intel-media-va-driver-non-free \
          intel-opencl-icd \
-         libmfx-gen1.2 \
-         libvpl2 \
          libvulkan1 \
          libshaderc1 \
-         mesa-vulkan-drivers \
-         vainfo; \
+         liblcms2-2 \
+         mesa-vulkan-drivers; \
      fi \
+  && wget -q -O /tmp/jellyfin-ffmpeg.deb "https://github.com/jellyfin/jellyfin-ffmpeg/releases/download/v${JELLYFIN_FFMPEG_VERSION}/jellyfin-ffmpeg8_${JELLYFIN_FFMPEG_VERSION}-noble_${TARGETARCH}.deb" \
+  && apt-get install -y --no-install-recommends /tmp/jellyfin-ffmpeg.deb \
+  && ln -sf /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/ffmpeg \
+  && ln -sf /usr/lib/jellyfin-ffmpeg/ffprobe /usr/local/bin/ffprobe \
+  && rm -f /tmp/jellyfin-ffmpeg.deb \
   && python3 -m pip install --no-cache-dir --break-system-packages ffsubsync pgsrip \
   && if [ "$TARGETARCH" = "amd64" ]; then \
        wget -q -O /usr/local/bin/alass https://github.com/kaegi/alass/releases/download/v2.0.0/alass-linux64 \
@@ -117,15 +127,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # VobSub OCR binary (links against the tesseract/leptonica installed above).
 COPY --from=vobsub-ocr-build /opt/subtile-ocr/bin/subtile-ocr /usr/local/bin/subtile-ocr
 
-# libdovi + the libdovi-enabled libplacebo, dropped in over the apt libplacebo
-# so the apt ffmpeg can RPU-tonemap DV Profile 5. amd64 only — it's paired with
-# the Intel Vulkan stack above; arm64 keeps the stock libplacebo (the DV probe
-# fails closed there and P5 falls back to the standard transcode).
+# Overlay the libdovi-enabled libplacebo (built at jellyfin's commit) over the
+# bundled one, which ships without libdovi — restores DV Profile 5 (#636).
+# libplacebo → jellyfin's lib dir (loaded via ffmpeg's rpath); libdovi → the
+# system path + ldconfig (libplacebo resolves it transitively there). amd64 only —
+# arm64 keeps the bundled libplacebo (no HW transcode; P5 falls back to standard).
 COPY --from=libplacebo-dovi-build /opt/dvlibs/lib/ /tmp/dvlibs/
 COPY --from=libplacebo-dovi-build /opt/plbo/lib/ /tmp/dvlibs/
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
-      cp -a /tmp/dvlibs/libdovi.so* /usr/lib/x86_64-linux-gnu/ \
-      && cp -a /tmp/dvlibs/libplacebo.so* /usr/lib/x86_64-linux-gnu/ \
+      cp -a /tmp/dvlibs/libplacebo.so* /usr/lib/jellyfin-ffmpeg/lib/ \
+      && cp -a /tmp/dvlibs/libdovi.so* /usr/lib/x86_64-linux-gnu/ \
       && ldconfig; \
     fi \
   && rm -rf /tmp/dvlibs

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,12 @@
-# --- Build libplacebo with Dolby Vision (libdovi) ---
-# The apt libplacebo isn't built with libdovi, so ffmpeg's apply_dolbyvision is
-# a no-op and DV Profile 5 renders wrong. Rebuild the same libplacebo version
-# (identical soname → drop-in for the apt ffmpeg) with libdovi. Keep
-# LIBPLACEBO_TAG in sync with the runtime's apt libplacebo (apt-cache policy
-# libplacebo338) and with the production Dockerfile.
+# --- Build libplacebo with Dolby Vision (libdovi), ABI-matched to jellyfin-ffmpeg ---
+# jellyfin-ffmpeg bundles libplacebo but WITHOUT libdovi (their build has no
+# -Dlibdovi), so `apply_dolbyvision` is a no-op and DV Profile 5 renders wrong
+# (#636). Rebuild libplacebo at the SAME commit jellyfin uses — identical soname
+# (.so.360), so it's a drop-in for the bundled ffmpeg — with libdovi enabled, and
+# overlay it below. Keep LIBPLACEBO_COMMIT in sync with jellyfin-ffmpeg's
+# builder/scripts.d/50-libplacebo.sh (SCRIPT_COMMIT) for the pinned version.
 FROM ubuntu:24.04 AS libplacebo-dovi-build
-ARG LIBPLACEBO_TAG=v6.338.2
+ARG LIBPLACEBO_COMMIT=cee9b076f2c63104ccfd497fa79c39a867293ec4
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl git build-essential pkg-config libssl-dev \
     meson ninja-build libshaderc-dev libvulkan-dev liblcms2-dev python3-mako python3-jinja2 \
@@ -15,18 +16,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && git clone --depth 1 https://github.com/quietvoid/dovi_tool /tmp/dovi_tool \
   && cd /tmp/dovi_tool/dolby_vision \
   && cargo cinstall --release --prefix=/opt/dvlibs --libdir=/opt/dvlibs/lib \
-  && git clone --depth 1 --branch "$LIBPLACEBO_TAG" \
-       https://code.videolan.org/videolan/libplacebo.git /tmp/libplacebo \
+  && git clone https://code.videolan.org/videolan/libplacebo.git /tmp/libplacebo \
   && cd /tmp/libplacebo \
+  && git checkout "$LIBPLACEBO_COMMIT" \
+  && git submodule update --init --recursive \
   && PKG_CONFIG_PATH=/opt/dvlibs/lib/pkgconfig meson setup build \
-       -Dlibdovi=enabled -Dvulkan=enabled -Dshaderc=enabled -Dglslang=disabled \
-       -Dopengl=disabled -Dd3d11=disabled \
-       -Ddemos=false -Dtests=false --buildtype=release --prefix=/opt/plbo --libdir=lib \
+       -Dlibdovi=enabled -Dvulkan=enabled -Dvk-proc-addr=enabled -Dshaderc=enabled \
+       -Dglslang=disabled -Dopengl=disabled -Dd3d11=disabled \
+       -Ddemos=false -Dtests=false -Dbench=false -Dfuzz=false \
+       --default-library=shared --buildtype=release --prefix=/opt/plbo --libdir=lib \
   && ninja -C build && ninja -C build install \
   && rm -rf /var/lib/apt/lists/* "$HOME/.cargo/registry" "$HOME/.rustup" \
        /tmp/dovi_tool /tmp/libplacebo
 
 FROM ubuntu:24.04
+
+# jellyfin-ffmpeg release to bundle. Same build as the Windows server (unified).
+ARG JELLYFIN_FFMPEG_VERSION=8.1.2-1
 
 # Install Node.js 24
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
@@ -35,7 +41,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
   && apt-get purge -y curl gnupg \
   && rm -rf /var/lib/apt/lists/*
 
-# Install runtime dependencies + Intel GPU drivers + FFmpeg
+# Install runtime dependencies + FFmpeg (jellyfin-ffmpeg). jellyfin-ffmpeg bundles
+# the VAAPI/QSV stack (libva, iHD, oneVPL/libmfx), so the apt ffmpeg and Intel VA
+# drivers are gone. It does NOT bundle: intel-opencl-icd (the Intel OpenCL compute
+# runtime for tonemap_opencl) or the Vulkan driver (libplacebo's DV path needs it)
+# — kept here — nor libdovi (overlaid below).
 RUN apt-get update && apt-get install -y --no-install-recommends \
   bash \
   postgresql-client \
@@ -43,18 +53,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python3 \
   python3-pip \
   python3-venv \
-  ffmpeg \
   libchromaprint-tools \
   tesseract-ocr \
   tesseract-ocr-all \
-  intel-media-va-driver-non-free \
   intel-opencl-icd \
-  libmfx-gen1.2 \
-  libvpl2 \
   libvulkan1 \
   libshaderc1 \
+  liblcms2-2 \
   mesa-vulkan-drivers \
-  vainfo \
   wget \
   ca-certificates \
   gcc \
@@ -63,16 +69,25 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && python3 -m pip install --no-cache-dir --break-system-packages ffsubsync pgsrip \
   && wget -q -O /usr/local/bin/alass https://github.com/kaegi/alass/releases/download/v2.0.0/alass-linux64 \
   && chmod +x /usr/local/bin/alass \
+  && wget -q -O /tmp/jellyfin-ffmpeg.deb "https://github.com/jellyfin/jellyfin-ffmpeg/releases/download/v${JELLYFIN_FFMPEG_VERSION}/jellyfin-ffmpeg8_${JELLYFIN_FFMPEG_VERSION}-noble_amd64.deb" \
+  && apt-get install -y --no-install-recommends /tmp/jellyfin-ffmpeg.deb \
+  && ln -sf /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/ffmpeg \
+  && ln -sf /usr/lib/jellyfin-ffmpeg/ffprobe /usr/local/bin/ffprobe \
+  && rm -f /tmp/jellyfin-ffmpeg.deb \
   && apt-get purge -y wget gcc python3-dev libc6-dev \
   && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/*
 
-# libdovi + the libdovi-enabled libplacebo, dropped in over the apt libplacebo
-# so ffmpeg can RPU-tonemap DV Profile 5 (the DV probe stays disabled otherwise).
+# Overlay the libdovi-enabled libplacebo (built at jellyfin's commit) over the
+# bundled one, which ships without libdovi — restores DV Profile 5 (#636).
+# libplacebo goes into jellyfin's lib dir (loaded via ffmpeg's rpath); libdovi
+# goes into the system path + ldconfig (libplacebo resolves it transitively there,
+# not via ffmpeg's rpath). libplacebo's other deps (vulkan, shaderc, lcms2) are
+# the apt packages above.
 COPY --from=libplacebo-dovi-build /opt/dvlibs/lib/ /tmp/dvlibs/
 COPY --from=libplacebo-dovi-build /opt/plbo/lib/ /tmp/dvlibs/
-RUN cp -a /tmp/dvlibs/libdovi.so* /usr/lib/x86_64-linux-gnu/ \
-  && cp -a /tmp/dvlibs/libplacebo.so* /usr/lib/x86_64-linux-gnu/ \
+RUN cp -a /tmp/dvlibs/libplacebo.so* /usr/lib/jellyfin-ffmpeg/lib/ \
+  && cp -a /tmp/dvlibs/libdovi.so* /usr/lib/x86_64-linux-gnu/ \
   && ldconfig \
   && rm -rf /tmp/dvlibs
 

--- a/backend/src/modules/streaming/transcoding/codec/decoders/qsv.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/decoders/qsv.spec.ts
@@ -1,4 +1,9 @@
-import { h264QsvNativeDecoder, h264QsvD3d11Decoder } from './qsv';
+import {
+  h264QsvNativeDecoder,
+  hevcQsvNativeDecoder,
+  av1QsvNativeDecoder,
+  h264QsvD3d11Decoder,
+} from './qsv';
 import { findQsvNativeDecoder } from './index';
 
 describe('QSV encode-path decoders', () => {
@@ -30,5 +35,15 @@ describe('QSV encode-path decoders', () => {
     // supports() reads the real process.platform (linux under CI).
     expect(h264QsvNativeDecoder.supports()).toBe(process.platform !== 'win32');
     expect(h264QsvD3d11Decoder.supports()).toBe(process.platform === 'win32');
+  });
+
+  it('force-disables av1 qsv-native decode (broken on ffmpeg 8.x) but keeps h264/hevc', () => {
+    // AV1_QSV_DECODE_BROKEN: av1_qsv decode regresses on jellyfin-ffmpeg 8.x
+    // (oneVPL dynamic frame pool -17), so AV1 falls back to VAAPI decode. The
+    // boot decoder-probe honours supports() and disables it accordingly.
+    expect(av1QsvNativeDecoder.supports()).toBe(false);
+    // Only AV1 is disabled — h264/hevc qsv-native decode stays available.
+    expect(hevcQsvNativeDecoder.supports()).toBe(process.platform !== 'win32');
+    expect(h264QsvNativeDecoder.supports()).toBe(process.platform !== 'win32');
   });
 });

--- a/backend/src/modules/streaming/transcoding/codec/decoders/qsv.ts
+++ b/backend/src/modules/streaming/transcoding/codec/decoders/qsv.ts
@@ -113,7 +113,22 @@ export const av1QsvDecoder = qsvDecoder('av1', 10);
 
 export const h264QsvNativeDecoder = qsvNativeDecoder('h264', 8);
 export const hevcQsvNativeDecoder = qsvNativeDecoder('hevc', 10);
-export const av1QsvNativeDecoder = qsvNativeDecoder('av1', 10);
+/** AV1 QSV-native decode is force-disabled on the bundled jellyfin-ffmpeg 8.x:
+ *  `av1_qsv` hits the oneVPL 2.9+ dynamic frame pool, whose surface allocation
+ *  returns -17 on a real AV1 DPB (regression vs 7.1.x — verified on Iris Xe; a
+ *  synthetic clip decodes fine so the boot probe can't catch it). AV1 therefore
+ *  falls back to VAAPI *decode* only — the QSV *encoder* is unaffected and still
+ *  runs (VAAPI decode → scale_vaapi → hwmap qsv → hevc/h264_qsv). Windows decodes
+ *  AV1 on D3D11VA (av1QsvD3d11Decoder), so this only affects Linux.
+ *
+ *  Removal: flip to `false` once the shipped ffmpeg/oneVPL no longer regresses
+ *  av1_qsv (e.g. a fixed 8.x point release, or reverting to a 7.1.x build). */
+const AV1_QSV_DECODE_BROKEN = true;
+
+export const av1QsvNativeDecoder: DecoderDescriptor = {
+  ...qsvNativeDecoder('av1', 10),
+  supports: () => !AV1_QSV_DECODE_BROKEN && process.platform !== 'win32',
+};
 
 export const h264QsvD3d11Decoder = qsvD3d11Decoder('h264', 8);
 export const hevcQsvD3d11Decoder = qsvD3d11Decoder('hevc', 10);


### PR DESCRIPTION
Adopts **jellyfin-ffmpeg 8.1.2** on the Linux/Docker images, unifying the ffmpeg with the Windows server (#737). Replaces the apt `ffmpeg` + Intel VA/media stack + the custom apt-matched libplacebo build.

## Why

jellyfin-ffmpeg is self-contained (bundles libva, iHD, oneVPL/libmfx) and is the maintained HW-transcode ffmpeg. Same build on Linux and Windows.

## QSV vs VAAPI (context)

On Intel/Linux QSV is a thin layer over VAAPI — **same hardware**. Benchmarked 4K→1080p HEVC on Raptor Lake: VAAPI-full ~4.0x, QSV-full ~3.6x. No throughput win; QSV's edge is encode rate-control quality. So h264/hevc use full QSV; AV1 uses the fallback below.

## Two jellyfin-ffmpeg 8.x quirks handled

### 1. `av1_qsv` decode is broken on FFmpeg 8.x → VAAPI-decode fallback

A real 4K/10-bit/HDR AV1 fails at the QSV surface handoff with `-17` ("frames decoded, 0 decode errors" then `[vf#0:0] File exists`). **Bisected**: works on jellyfin-ffmpeg 6.0 / 7.0 / **7.1.4**, breaks on **8.1.1+**. Root cause is the FFmpeg 8.x **dynamic frame pool** (`qsvdec.c` sets `initial_pool_size = 0` for oneVPL ≥ 2.9); the dynamic surface alloc returns `-17` on a real AV1 DPB. `-extra_hw_frames` doesn't help (ignored in the dynamic branch). The boot decoder-probe is a **false positive** (a synthetic clip decodes fine).

Fix: `AV1_QSV_DECODE_BROKEN` in `codec/decoders/qsv.ts` force-disables `av1_qsv` native decode. AV1 falls back to **VAAPI decode** while the **QSV encoder is kept** (VAAPI decode → `scale_vaapi` → `hwmap qsv` → `hevc/h264_qsv`). h264/hevc qsv-native decode is unaffected. One-line flag flip to re-enable when upstream fixes it. (Windows already avoids this via D3D11 AV1 decode, #735.)

### 2. jellyfin-ffmpeg lacks libdovi → DV Profile 5 overlay

jellyfin-ffmpeg builds libplacebo **without libdovi** (verified in their build recipe), so `apply_dolbyvision` is a no-op and DV P5 renders wrong (#636). We rebuild libplacebo at **jellyfin's exact commit** (identical soname `.360` → ABI-compatible drop-in; jellyfin applies no libplacebo patches) with `-Dlibdovi=enabled`, overlay it over the bundled one, and put `libdovi.so.3` on the system ldconfig path. `liblcms2-2` added (libplacebo runtime dep).

Windows bundles the same libdovi-less jellyfin-ffmpeg → same DV P5 gap, tracked in **#738**.

## Dockerfiles

Both `Dockerfile` (prod, multi-arch — amd64 gets the GPU stack + DV overlay, arm64 stays CPU-only) and `backend/Dockerfile` (dev). Detection needs no change (the 8.x dynamic-pool `hwupload,format=qsv` probe passes).

## Validation (on Raptor Lake Iris Xe, deb-installed image, no LD_LIBRARY_PATH)

Built the full dev image and ran on the real GPU: ffmpeg loads; libplacebo resolves libvulkan/liblcms2/libdovi; `apply_dolbyvision` runs (libdovi linked); QSV detection probe OK; **AV1 fallback** (VAAPI decode → tonemap_opencl → hwmap qsv → hevc_qsv) OK; **HEVC full-QSV** OK. 433 streaming specs + typecheck green.

Refs: #720, #737, #738, #636