### PR TITLE
fix(streaming): skip the tfdt anchor for remux on the cached fast path

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -1805,6 +1805,10 @@ export class StreamingController {
           segmentContentType(segment),
           {
             segDuration: realSegmentSeconds(existing.sourceFps),
+            // Remux carries its own keyframe-cut timeline; the grid tfdt anchor
+            // shifts each remux segment by its IDR-vs-grid offset and must be
+            // skipped, exactly as the slow-path serve below does (#349).
+            skipTimelineRewrite: quality === 'remux',
           },
         );
         return;
@@ -1978,10 +1982,10 @@ export class StreamingController {
       sendTransientUnavailable(res);
       return;
     }
-    // Remux segments skip the tfdt anchor — they already carry an absolute
-    // -copyts timeline (see SegmentPackagingService / #349). The early-probe
-    // paths above never run for remux (gated on quality !== 'remux'), so this
-    // main serve is the only remux-reachable tfdt path.
+    // Remux segments skip the tfdt anchor — they already carry a keyframe-cut
+    // -copyts timeline (see SegmentPackagingService / #349). The on-disk fast
+    // path above serves remux too, so it passes the same flag; only the
+    // early-probe paths never run for remux (gated on quality !== 'remux').
     await this.segmentPackaging.serve(
       res,
       segPath,


### PR DESCRIPTION
## Problem

Part of the #740 A/V-desync audit. The serve-time `tfdt` anchor rewrites each segment so `seg-N` decodes at `N·segDuration`. That is correct for grid-aligned transcode output but wrong for **remux**, whose segments are keyframe-cut and already carry a `-copyts` timeline — so the slow path deliberately skips it (`skipTimelineRewrite: quality === 'remux'`, #349).

The **on-disk fast path** (`streaming.controller.ts`, the `existing.quality === quality` branch) did **not** pass that flag. Since a segment's first serve goes through the slow path (skipped) but every subsequent re-serve from cache went through the fast path (anchored), the same remux segment was handed out with two different timelines depending on cache state → keyframe-vs-grid shift → seconds of A/V desync against the on-grid audio renditions, on both web (Shaka) and desktop (libmpv).

The slow-path comment even claimed it was "the only remux-reachable tfdt path" — false; the fast path is reachable for remux (its `segName` logic already branches on `quality !== 'remux'`).

## Fix

Pass `skipTimelineRewrite: quality === 'remux'` on the fast-path serve too, and correct the comment. Remux serving is now deterministic and consistent with the slow path.

**Transcode is unaffected** — the flag is `false` for every non-remux rung, so the common path is byte-identical.

## Scope note

This fixes the fast/slow **inconsistency** for cold/forward remux playback. The deeper remux-**after-seek** issue (a remux respawn writes `tfdt=0`; both paths then serve `tfdt=0` against an absolute playlist) is a separate, higher-risk item tracked for the runtime-validation branch, not addressed here.

## Testing

- `streaming.controller` suite: 11 passed. `tsc`: clean.
- Not yet validated on a live remux (DirectStream) playback — behavioural change is confined to remux and aligns it to the already-shipped slow-path contract.

Refs: #740

🤖 Generated with [Claude Code](https://claude.com/claude-code)