### PR TITLE
chore(streaming): log ffmpeg timestamp anomalies during playback

### DIFF
--- a/backend/src/modules/streaming/transcoding/ffmpeg-stderr.spec.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-stderr.spec.ts
@@ -1,4 +1,7 @@
-import { stripBenignFfmpegStderr } from './ffmpeg-stderr';
+import {
+  matchTimingWarnings,
+  stripBenignFfmpegStderr,
+} from './ffmpeg-stderr';
 
 describe('stripBenignFfmpegStderr', () => {
   it('drops PGS/VOBSUB subtitle codec-parameter warnings and their hint', () => {
@@ -46,5 +49,45 @@ describe('stripBenignFfmpegStderr', () => {
   it('is a no-op on clean stderr', () => {
     const raw = 'frame= 100 fps=30 q=28.0 size=1024KiB';
     expect(stripBenignFfmpegStderr(raw)).toBe(raw);
+  });
+});
+
+describe('matchTimingWarnings', () => {
+  it('flags a non-monotonic DTS line (both ffmpeg spellings)', () => {
+    for (const spelling of ['Non-monotonic DTS', 'Non-monotonous DTS']) {
+      const raw = `[hls @ 0x1] ${spelling} in output stream 0:1; previous: 100, current: 90; changing to 100.`;
+      expect(matchTimingWarnings(raw)).toEqual([
+        { label: 'non-monotonic-dts', line: raw.trim() },
+      ]);
+    }
+  });
+
+  it('flags the invalid-increasing-dts and past-duration and backward-in-time lines', () => {
+    expect(
+      matchTimingWarnings(
+        'Application provided invalid, non monotonically increasing dts to muxer in stream 1',
+      )[0].label,
+    ).toBe('invalid-increasing-dts');
+    expect(
+      matchTimingWarnings('[vost#0:0] Past duration 0.812 too large')[0].label,
+    ).toBe('past-duration-too-large');
+    expect(
+      matchTimingWarnings('[aost#0:1] Queue input is backward in time')[0]
+        .label,
+    ).toBe('backward-in-time');
+  });
+
+  it('returns each anomaly kind at most once even across repeated lines', () => {
+    const raw = [
+      '[hls @ 0x1] Non-monotonic DTS; previous: 1, current: 0; changing to 1.',
+      '[hls @ 0x1] Non-monotonic DTS; previous: 2, current: 1; changing to 2.',
+    ].join('\n');
+    expect(matchTimingWarnings(raw)).toHaveLength(1);
+  });
+
+  it('is empty on clean progress output', () => {
+    expect(matchTimingWarnings('frame= 100 fps=30 q=28.0 size=1024KiB')).toEqual(
+      [],
+    );
   });
 });

--- a/backend/src/modules/streaming/transcoding/ffmpeg-stderr.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-stderr.ts
@@ -29,3 +29,42 @@ export function stripBenignFfmpegStderr(stderr: string): string {
     .filter((line) => !BENIGN_STDERR_PATTERNS.some((re) => re.test(line)))
     .join('\n');
 }
+
+/** ffmpeg stderr lines that signal a timestamp anomaly rather than a crash.
+ *  They appear on an exit-0 process during normal playback — where nothing
+ *  logs the stderr tail — so an A/V-desync incident leaves no trace. Each maps
+ *  to a stable label so the caller can surface the first occurrence per session
+ *  once, instead of on every chunk. */
+const TIMING_STDERR_PATTERNS: { label: string; re: RegExp }[] = [
+  { label: 'non-monotonic-dts', re: /Non-monoton(?:ic|ous) DTS/i },
+  {
+    label: 'invalid-increasing-dts',
+    re: /non[- ]monotonically increasing dts/i,
+  },
+  { label: 'past-duration-too-large', re: /Past duration [\d.]+ too large/i },
+  { label: 'backward-in-time', re: /is backward in time/i },
+];
+
+/** Scan an ffmpeg stderr fragment for timestamp-anomaly lines. Returns at most
+ *  one `{ label, line }` per distinct anomaly kind found, so a caller keeping a
+ *  seen-set logs each kind once per session. Pure — the throttling state lives
+ *  with the caller. */
+export function matchTimingWarnings(
+  text: string,
+): { label: string; line: string }[] {
+  const out: { label: string; line: string }[] = [];
+  const seen = new Set<string>();
+  for (const line of text.split('\n')) {
+    for (const { label, re } of TIMING_STDERR_PATTERNS) {
+      if (!seen.has(label) && re.test(line)) {
+        seen.add(label);
+        out.push({ label, line: line.trim() });
+      }
+    }
+  }
+  return out;
+}
+
+/** Number of distinct timing-anomaly kinds — the caller can stop scanning once
+ *  it has surfaced them all. */
+export const TIMING_WARNING_KINDS = TIMING_STDERR_PATTERNS.length;

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -30,7 +30,11 @@ import {
   type BuildFfmpegArgsOptions,
 } from './ffmpeg-args';
 import { varStreamMapLayout } from './audio-layout';
-import { stripBenignFfmpegStderr } from './ffmpeg-stderr';
+import {
+  matchTimingWarnings,
+  stripBenignFfmpegStderr,
+  TIMING_WARNING_KINDS,
+} from './ffmpeg-stderr';
 import { detectHwAccel } from './hw-detect';
 import { ALL_DESCRIPTORS, encoderRegistry } from './codec/encoders';
 import { runEncoderProbes } from './codec/encoder-probe';
@@ -1017,6 +1021,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     });
 
     let stderr = '';
+    const warnedTimingLabels = new Set<string>();
     let resolved = false;
     const segDir = segSubDir ? path.join(sessionDir, segSubDir) : sessionDir;
     const firstSeg = path.join(
@@ -1050,6 +1055,19 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
 
     proc.stderr.on('data', (chunk: Buffer) => {
       stderr += chunk.toString();
+      // Timestamp-anomaly lines print during normal exit-0 playback, where the
+      // stderr tail is never logged — surface the first of each kind so an A/V
+      // desync in the wild is diagnosable. Re-scan a bounded tail (a line can
+      // split across chunks) and stop once every kind has been seen.
+      if (warnedTimingLabels.size < TIMING_WARNING_KINDS) {
+        for (const { label, line } of matchTimingWarnings(stderr.slice(-4000))) {
+          if (warnedTimingLabels.has(label)) continue;
+          warnedTimingLabels.add(label);
+          this.log.warn(
+            `FFmpeg [${id}] timestamp anomaly (${label}) — possible A/V desync: ${line}`,
+          );
+        }
+      }
       checkReady();
     });
 


### PR DESCRIPTION
## Why

From the #740 A/V-desync audit: ffmpeg stderr is only ever logged on a crash, segment timeout, or HW→CPU fallback. The lines that actually signal an A/V-desync source — `Non-monotonic DTS`, `non monotonically increasing dts`, `Past duration … too large`, `is backward in time` — print on an otherwise healthy **exit-0** process during normal playback, so a desync in the wild currently leaves **no trace** to diagnose. This is the instrument the deferred runtime-verification session needs.

## What

- `matchTimingWarnings()` in `ffmpeg-stderr.ts`: a pure scanner returning at most one `{ label, line }` per anomaly kind.
- The session's stderr handler surfaces the **first occurrence of each kind per session** at warn level (bounded 4 KB tail re-scan so a line split across chunks is still caught; seen-set throttle stops once all kinds are seen).

Diagnostic only — no playback behaviour changes, no new stderr suppression.

## Testing

- `ffmpeg-stderr`: 9 passed (4 new cases). Full `transcoding/` suite: 347 passed. `tsc` clean.

Refs: #740

🤖 Generated with [Claude Code](https://claude.com/claude-code)