### PR TITLE
refactor(streaming): thread frozen segment duration, drop mutable global

### DIFF
--- a/backend/src/modules/streaming/active-stream-tracker.service.ts
+++ b/backend/src/modules/streaming/active-stream-tracker.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import type { TonemapAlgo } from './transcoding';
+import { DEFAULT_SEGMENT_DURATION } from './transcoding/constants';
 
 /**
  * Cross-cutting bookkeeping for streaming. Per-playback session state lives on
@@ -46,6 +47,18 @@ export class ActiveStreamTracker {
   }
   getQsvOptions(): { lowPower: boolean } {
     return { lowPower: this.qsvLowPowerCache };
+  }
+
+  /** HLS segment duration in seconds (admin-configurable, global). Read once
+   *  per session when the context is built and frozen onto the session, so a
+   *  later change never re-grids a session mid-playback against segments
+   *  already cut on its old grid. */
+  private segmentDurationCache = DEFAULT_SEGMENT_DURATION;
+  setSegmentDuration(seconds: number) {
+    this.segmentDurationCache = seconds;
+  }
+  getSegmentDuration(): number {
+    return this.segmentDurationCache;
   }
 
   /** HDR → SDR tone-mapping algorithm (admin-configurable, global). */

--- a/backend/src/modules/streaming/services/session-context-builder.service.spec.ts
+++ b/backend/src/modules/streaming/services/session-context-builder.service.spec.ts
@@ -26,6 +26,7 @@ describe('SessionContextBuilder.build', () => {
     getQsvOptions: jest.Mock;
     getTonemapAlgo: jest.Mock;
     getAutoCropEnabled: jest.Mock;
+    getSegmentDuration: jest.Mock;
   };
   let builder: SessionContextBuilder;
 
@@ -35,6 +36,7 @@ describe('SessionContextBuilder.build', () => {
       getQsvOptions: jest.fn().mockReturnValue({ lowPower: false }),
       getTonemapAlgo: jest.fn().mockReturnValue('auto'),
       getAutoCropEnabled: jest.fn().mockReturnValue(true),
+      getSegmentDuration: jest.fn().mockReturnValue(3),
     };
     builder = new SessionContextBuilder(tracker as never, sessionRouter as never);
   });
@@ -52,6 +54,11 @@ describe('SessionContextBuilder.build', () => {
     expect(ctx.sourceVideoCodec).toBe('hevc');
     expect(ctx.sourceFps).toBe(24);
     expect(ctx.userId).toBe(7);
+  });
+
+  it('snapshots the admin segment duration onto the context', () => {
+    tracker.getSegmentDuration.mockReturnValue(6);
+    expect(builder.build(req, resolved(1), 1).segmentDuration).toBe(6);
   });
 
   it('gates the crop on the auto-crop toggle', () => {

--- a/backend/src/modules/streaming/services/session-context-builder.service.ts
+++ b/backend/src/modules/streaming/services/session-context-builder.service.ts
@@ -72,6 +72,10 @@ export class SessionContextBuilder {
       // accurate GOP so IDR frames fall on the same boundary regardless of
       // source fps. Falls back to 24 when unknown.
       sourceFps: parseSourceFps(si?.video?.[0]?.frameRate),
+      // Admin segment-duration setting, snapshotted here and frozen onto the
+      // session at spawn so the serve/seek grid never shifts under a live
+      // session if the admin later changes it.
+      segmentDuration: this.activeStreamTracker.getSegmentDuration(),
       // ffprobe ran at import/rescan and the result is cached in streamInfo —
       // tell FFmpeg to skip its own redundant avformat_find_stream_info scan.
       trustedStreamInfo: !!si?.video?.[0]?.codec,

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -37,8 +37,8 @@ import {
   type BurnInSubtitle,
 } from './transcoding';
 import {
+  DEFAULT_SEGMENT_DURATION,
   EARLY_PROBE_SEGMENTS,
-  getSegmentDuration,
   parseSourceFps,
   realSegmentSeconds,
   secondsToSegmentIndex,
@@ -203,8 +203,8 @@ function statSizeOrNull(filePath: string): number | null {
 export function buildVodPlaylist(
   duration: number,
   segmentUrl: (index: string) => string,
-  initUrl?: string,
-  segDuration: number = getSegmentDuration(),
+  initUrl: string | undefined,
+  segDuration: number,
 ): string {
   // Subtract small epsilon before ceil to avoid phantom last segment when
   // ffprobe duration has floating-point imprecision (e.g. 120.001 → ceil
@@ -342,7 +342,11 @@ export class StreamingController {
   private resumeFloor(
     live: { position: number } | null | undefined,
     existing:
-      | { startSegment?: number | null; sourceFps?: number }
+      | {
+          startSegment?: number | null;
+          sourceFps?: number;
+          segmentDuration?: number;
+        }
       | null
       | undefined,
     boundaries?: number[],
@@ -350,9 +354,22 @@ export class StreamingController {
     const posIndex = live
       ? boundaries
         ? boundarySecondsToIndex(boundaries, live.position)
-        : secondsToSegmentIndex(live.position, existing?.sourceFps)
+        : secondsToSegmentIndex(
+            live.position,
+            this.segDur(existing ?? undefined),
+            existing?.sourceFps,
+          )
       : 0;
     return Math.max(existing?.startSegment ?? 0, posIndex);
+  }
+
+  /** Segment duration for a request: the session's frozen grid when serving an
+   *  existing session, else the current admin setting (which a spawn will
+   *  freeze, so playlist and session agree). Never reads a mutable global. */
+  private segDur(session?: { segmentDuration?: number }): number {
+    return (
+      session?.segmentDuration ?? this.activeStreamTracker.getSegmentDuration()
+    );
   }
 
   /** Keyframe-aligned cumulative segment boundaries for the remux/copy path,
@@ -361,9 +378,10 @@ export class StreamingController {
    *  fetched before segments, so segment-time lookups hit the warm cache. */
   private async remuxBoundaries(
     absolutePath: string,
+    segDur: number,
     durationHint = 0,
   ): Promise<number[] | null> {
-    const grid = await getRemuxSegmentGrid(absolutePath, durationHint);
+    const grid = await getRemuxSegmentGrid(absolutePath, durationHint, segDur);
     return grid ? grid.boundaries : null;
   }
 
@@ -447,7 +465,11 @@ export class StreamingController {
           : startQuality;
       const startSegment = Math.max(
         0,
-        secondsToSegmentIndex(effectiveStartAt, ctx.sourceFps),
+        secondsToSegmentIndex(
+          effectiveStartAt,
+          this.segDur(ctx),
+          ctx.sourceFps,
+        ),
       );
 
       // The seg-0 early-start companion runs in parallel with main and serves
@@ -636,7 +658,7 @@ export class StreamingController {
 
     // File-scoped + global tracker state (kept in the tracker because
     // these don't vary per playback session).
-    this.transcodingService.setSegmentDuration(ss.segmentDuration);
+    this.activeStreamTracker.setSegmentDuration(ss.segmentDuration);
     this.activeStreamTracker.setQsvOptions({ lowPower: ss.qsvLowPower });
     this.activeStreamTracker.setTonemapAlgo(ss.tonemapAlgo);
     this.activeStreamTracker.setAutoCropEnabled(ss.autoCropEnabled);
@@ -1307,7 +1329,7 @@ export class StreamingController {
         audioIndex,
         resolved.absolutePath,
         0,
-        { userId: user?.id },
+        { userId: user?.id, segmentDuration: this.segDur() },
       );
     }
 
@@ -1321,7 +1343,9 @@ export class StreamingController {
       resolved.mediaFile.streamInfo?.video?.[0]?.frameRate,
     );
     const audioSegDuration =
-      useExtXMedia && !useTs ? realSegmentSeconds(sourceFps) : getSegmentDuration();
+      useExtXMedia && !useTs
+        ? realSegmentSeconds(this.segDur(), sourceFps)
+        : this.segDur();
     const playlist = buildVodPlaylist(
       duration,
       (seg) => `${basePath}/seg-${seg}.${segExt}${tokenParam}`,
@@ -1532,7 +1556,10 @@ export class StreamingController {
       segPath,
       segmentContentType(segment),
       {
-        segDuration: realSegmentSeconds(videoSession.sourceFps),
+        segDuration: realSegmentSeconds(
+          this.segDur(videoSession),
+          videoSession.sourceFps,
+        ),
       },
     );
   }
@@ -1586,11 +1613,12 @@ export class StreamingController {
           // (and seek) via the real keyframe boundaries, not the uniform grid.
           const boundaries = await this.remuxBoundaries(
             resolved.absolutePath,
+            this.segDur(ctx),
             duration,
           );
           const startSegment = boundaries
             ? boundarySecondsToIndex(boundaries, startAtSec)
-            : secondsToSegmentIndex(startAtSec);
+            : secondsToSegmentIndex(startAtSec, this.segDur(ctx));
           void this.transcodingService.getOrCreateRemuxSession(
             mediaFileId,
             resolved.absolutePath,
@@ -1604,7 +1632,7 @@ export class StreamingController {
             mediaFileId,
             quality,
             resolved.absolutePath,
-            secondsToSegmentIndex(startAtSec, ctx.sourceFps),
+            secondsToSegmentIndex(startAtSec, this.segDur(ctx), ctx.sourceFps),
             ctx,
           );
         }
@@ -1645,7 +1673,7 @@ export class StreamingController {
     let remuxDurations: number[] | null = null;
     if (quality === 'remux' && !useTs) {
       remuxDurations =
-        (await getRemuxSegmentGrid(resolved.absolutePath, duration))
+        (await getRemuxSegmentGrid(resolved.absolutePath, duration, this.segDur()))
           ?.durations ?? null;
     }
     // Transcoded fMP4 segments span one GOP each — declare their real length
@@ -1661,7 +1689,7 @@ export class StreamingController {
           duration,
           segmentUrl,
           initRef,
-          transcodeFmp4 ? realSegmentSeconds(sourceFps) : getSegmentDuration(),
+          transcodeFmp4 ? realSegmentSeconds(this.segDur(), sourceFps) : this.segDur(),
         );
 
     res.setHeader('Content-Type', 'application/vnd.apple.mpegurl');
@@ -1768,7 +1796,7 @@ export class StreamingController {
           res,
           initPath,
           segmentContentType(segment),
-          { segDuration: realSegmentSeconds(src.sourceFps) },
+          { segDuration: realSegmentSeconds(this.segDur(src), src.sourceFps) },
         );
         return;
       }
@@ -1804,7 +1832,10 @@ export class StreamingController {
           segPath,
           segmentContentType(segment),
           {
-            segDuration: realSegmentSeconds(existing.sourceFps),
+            segDuration: realSegmentSeconds(
+              this.segDur(existing),
+              existing.sourceFps,
+            ),
             // Remux carries its own keyframe-cut timeline; the grid tfdt anchor
             // shifts each remux segment by its IDR-vs-grid offset and must be
             // skipped, exactly as the slow-path serve below does (#349).
@@ -1901,7 +1932,10 @@ export class StreamingController {
             segPath,
             segmentContentType(segment),
             {
-              segDuration: realSegmentSeconds(earlySession.sourceFps),
+              segDuration: realSegmentSeconds(
+                this.segDur(earlySession),
+                earlySession.sourceFps,
+              ),
             },
           );
           return;
@@ -1921,7 +1955,10 @@ export class StreamingController {
     // aligned. Non-remux keeps the uniform grid (force_key_frames makes it true).
     const remuxBounds =
       quality === 'remux'
-        ? ((await this.remuxBoundaries(resolved.absolutePath)) ?? undefined)
+        ? ((await this.remuxBoundaries(
+            resolved.absolutePath,
+            this.segDur(ctx),
+          )) ?? undefined)
         : undefined;
     const anchorSeg = this.anchorSegment(
       live,
@@ -1991,7 +2028,7 @@ export class StreamingController {
       segPath,
       segmentContentType(segment),
       {
-        segDuration: realSegmentSeconds(session.sourceFps),
+        segDuration: realSegmentSeconds(this.segDur(session), session.sourceFps),
         skipTimelineRewrite: quality === 'remux',
       },
     );

--- a/backend/src/modules/streaming/transcoding/audio-only-args.spec.ts
+++ b/backend/src/modules/streaming/transcoding/audio-only-args.spec.ts
@@ -38,8 +38,8 @@ describe('buildAudioOnlyFfmpegArgs', () => {
     );
     const seek = args[args.indexOf('-ss') + 1];
     // Must match the video path's fps-aware seek, not the integer-grid value.
-    expect(seek).toBe(String(segmentIndexToSeconds(5, fps)));
-    expect(seek).not.toBe(String(segmentIndexToSeconds(5)));
+    expect(seek).toBe(String(segmentIndexToSeconds(5, 3, fps)));
+    expect(seek).not.toBe(String(segmentIndexToSeconds(5, 3)));
   });
 
   it('cuts on the fps-aware grid so audio renditions stay aligned with the video IDRs', () => {
@@ -57,7 +57,7 @@ describe('buildAudioOnlyFfmpegArgs', () => {
     const hlsTime = args[args.indexOf('-hls_time') + 1];
     // Must match the video IDR / EXTINF grid (3.003s), not the integer 3.0s
     // setting — otherwise the audio tfdt drifts a whole segment mid-film.
-    expect(hlsTime).toBe(String(realSegmentSeconds(fps)));
+    expect(hlsTime).toBe(String(realSegmentSeconds(3, fps)));
     expect(hlsTime).not.toBe('3');
   });
 

--- a/backend/src/modules/streaming/transcoding/constants.spec.ts
+++ b/backend/src/modules/streaming/transcoding/constants.spec.ts
@@ -2,7 +2,6 @@ import {
   parseSourceFps,
   realSegmentSeconds,
   secondsToSegmentIndex,
-  setSegmentDuration,
 } from './constants';
 
 describe('parseSourceFps', () => {
@@ -19,22 +18,25 @@ describe('parseSourceFps', () => {
 });
 
 describe('realSegmentSeconds', () => {
-  beforeEach(() => setSegmentDuration(3));
-
   it('equals the nominal duration for integer / unknown fps', () => {
-    expect(realSegmentSeconds(24)).toBe(3);
-    expect(realSegmentSeconds(30)).toBe(3);
-    expect(realSegmentSeconds(undefined)).toBe(3);
+    expect(realSegmentSeconds(3, 24)).toBe(3);
+    expect(realSegmentSeconds(3, 30)).toBe(3);
+    expect(realSegmentSeconds(3, undefined)).toBe(3);
+  });
+
+  it('honours a non-default segment duration', () => {
+    expect(realSegmentSeconds(6, 24)).toBe(6);
+    expect(realSegmentSeconds(6, undefined)).toBe(6);
   });
 
   it('returns gop/fps for fractional fps', () => {
     // round(3 × 23.976) = 72 frames → 72 / 23.976 ≈ 3.003s
-    expect(realSegmentSeconds(23.976)).toBeCloseTo(72 / 23.976, 6);
+    expect(realSegmentSeconds(3, 23.976)).toBeCloseTo(72 / 23.976, 6);
   });
 
   it('keeps secondsToSegmentIndex on the same fractional grid', () => {
     // seg-N starts at N × 3.003; t just under the 2nd boundary is still seg 1.
-    expect(secondsToSegmentIndex(72 / 23.976, 23.976)).toBe(1);
-    expect(secondsToSegmentIndex((72 / 23.976) * 2 - 0.001, 23.976)).toBe(1);
+    expect(secondsToSegmentIndex(72 / 23.976, 3, 23.976)).toBe(1);
+    expect(secondsToSegmentIndex((72 / 23.976) * 2 - 0.001, 3, 23.976)).toBe(1);
   });
 });

--- a/backend/src/modules/streaming/transcoding/constants.ts
+++ b/backend/src/modules/streaming/transcoding/constants.ts
@@ -27,24 +27,22 @@ export const SEEK_WAIT_THRESHOLD = 15;
  *  session that never wrote that segment. Independent of segment duration. */
 export const EARLY_PROBE_SEGMENTS = 2;
 
-/** Mutable runtime state for HLS segment duration. Updated from admin
- *  streaming settings via `setSegmentDuration()`. Read by FFmpeg arg
- *  builders and the session manager. */
-let segmentDuration = 3;
-
-export function getSegmentDuration(): number {
-  return segmentDuration;
-}
-
-export function setSegmentDuration(seg: number): void {
-  segmentDuration = seg;
-}
+/** Default HLS segment duration (seconds) when the admin setting is
+ *  unavailable. The live value is an admin streaming setting held by
+ *  `ActiveStreamTracker`, frozen onto each session at spawn (`sourceFps`'s
+ *  sibling), and threaded explicitly into the grid helpers below — never a
+ *  module-mutable global, so a mid-playback setting change can't re-grid a
+ *  session against the segments already cut on its old grid. */
+export const DEFAULT_SEGMENT_DURATION = 3;
 
 /** Real length of one transcoded segment = a pinned GOP of
  *  `round(segmentDuration · fps)` frames = `gop / fps` seconds. Equals
  *  `segmentDuration` for integer / unknown fps; differs only for fractional
  *  rates (24000/1001 → 3.003s at a 3s setting). */
-export function realSegmentSeconds(fps?: number): number {
+export function realSegmentSeconds(
+  segmentDuration: number,
+  fps?: number,
+): number {
   if (!fps || fps <= 0) return segmentDuration;
   return Math.max(1, Math.round(segmentDuration * fps)) / fps;
 }
@@ -59,13 +57,21 @@ export function parseSourceFps(frameRate: string | undefined): number | undefine
 
 /** Presentation time (seconds) → containing FFmpeg segment number, on the
  *  `fps`-aware real-duration grid. */
-export function secondsToSegmentIndex(seconds: number, fps?: number): number {
+export function secondsToSegmentIndex(
+  seconds: number,
+  segmentDuration: number,
+  fps?: number,
+): number {
   if (seconds <= 0) return 0;
-  return Math.floor(seconds / realSegmentSeconds(fps));
+  return Math.floor(seconds / realSegmentSeconds(segmentDuration, fps));
 }
 
 /** Inverse of `secondsToSegmentIndex` — start time of an FFmpeg segment. */
-export function segmentIndexToSeconds(segment: number, fps?: number): number {
+export function segmentIndexToSeconds(
+  segment: number,
+  segmentDuration: number,
+  fps?: number,
+): number {
   if (segment <= 0) return 0;
-  return segment * realSegmentSeconds(fps);
+  return segment * realSegmentSeconds(segmentDuration, fps);
 }

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@nestjs/common';
 import * as path from 'path';
 import {
-  getSegmentDuration,
+  DEFAULT_SEGMENT_DURATION,
   realSegmentSeconds,
   segmentIndexToSeconds,
 } from './constants';
@@ -140,6 +140,10 @@ export interface BuildFfmpegArgsOptions {
    *  which preserves the historical vaapi-when-available preference. */
   tonemapAlgo?: TonemapAlgo;
   sourceFps?: number;
+  /** HLS segment duration (seconds) this session cuts on. Sets the GOP length
+   *  and the forced-IDR / seek grid. Defaults to {@link DEFAULT_SEGMENT_DURATION}
+   *  when omitted. */
+  segmentDuration?: number;
   trustedStreamInfo?: boolean;
   /** Short-lived parallel session producing only seg-0/seg-1 during a
    *  mid-file resume. Trades visual quality on the discarded warm-up frames
@@ -249,6 +253,7 @@ export function buildFfmpegArgs(
     encoderPreset = 'faster',
     qsvOptions = { lowPower: false },
     sourceFps,
+    segmentDuration = DEFAULT_SEGMENT_DURATION,
     trustedStreamInfo = false,
     early = false,
     useTs = false,
@@ -270,8 +275,6 @@ export function buildFfmpegArgs(
   // we ship, so `useTs` defaults to false everywhere.
   const segType = useTs ? 'mpegts' : 'fmp4';
   const segExt = useTs ? 'ts' : 'm4s';
-
-  const SEGMENT_DURATION = getSegmentDuration();
 
   // Audio output args derived from the stream-builder decision. No
   // re-derivation here — we just emit what we were told. Safe fallback to
@@ -298,21 +301,26 @@ export function buildFfmpegArgs(
   // GOP = segment_duration × fps so each segment starts exactly on an IDR.
   // Fallback to 24 fps when source fps is unknown (safe for most content).
   const fps = sourceFps && sourceFps > 0 ? sourceFps : 24;
-  const gopSize = Math.max(1, Math.round(SEGMENT_DURATION * fps));
+  const gopSize = Math.max(1, Math.round(segmentDuration * fps));
   // Real segment length on the wire (gop/fps). The seek grid, the force-IDR
   // cadence, the playlist EXTINF and the fMP4 tfdt all anchor on this so they
-  // agree on fractional-fps sources. Equals SEGMENT_DURATION for integer fps.
-  const realSeg = realSegmentSeconds(sourceFps);
+  // agree on fractional-fps sources. Equals segmentDuration for integer fps.
+  const realSeg = realSegmentSeconds(segmentDuration, sourceFps);
 
-  // Resume point for mid-file seek (`startSegment > 0`). Seek to T,
-  // then `-copyts` (set after `-i` below) threads source PTS through
-  // to the muxer so the first segment lands at tfdt = T × timescale.
+  // Resume point for mid-file seek (`startSegment > 0`). The HLS-fMP4 muxer
+  // restarts each run's fragment timeline at tfdt 0; the serve-time anchor
+  // (SegmentPackagingService) rebases every served segment back onto the single
+  // absolute presentation grid, so a resumed run splices seamlessly.
   const seekSeconds =
-    startSegment > 0 ? segmentIndexToSeconds(startSegment, sourceFps) : 0;
+    startSegment > 0
+      ? segmentIndexToSeconds(startSegment, segmentDuration, sourceFps)
+      : 0;
 
   // Force an IDR every `realSeg` seconds so the HLS muxer cuts on the same grid
-  // the playlist declares. `-copyts` keeps the encoder's `t` in source time, so
-  // the expression anchors at `seekSeconds` and IDRs survive a seek-resume.
+  // the playlist declares. ffmpeg evaluates the expression's `t` relative to the
+  // first frame of THIS run, not source time — so on a seek-resume the first
+  // forced tick only lands after `seekSeconds` of output. The GOP (`-g gopSize`,
+  // set by every encoder descriptor) keeps cuts on the grid through that window.
   const forceKeyframesExpr = `expr:gte(t,${seekSeconds}+n_forced*${realSeg})`;
   // Closed-GOP, deterministic IDR placement on h264_qsv:
   //  - `-forced_idr 1` : every `force_key_frames` tick lands as a real
@@ -860,7 +868,7 @@ export function buildFfmpegArgs(
       '-f',
       'hls',
       '-hls_time',
-      String(SEGMENT_DURATION),
+      String(segmentDuration),
       '-hls_list_size',
       '0',
       '-start_number',
@@ -893,6 +901,9 @@ export interface BuildAudioOnlyArgsOptions {
   audioStreams?: AudioStreamMeta[];
   /** Source fps, so the resume seek lands on the same fps-aware grid as video. */
   sourceFps?: number;
+  /** Segment duration (seconds) — same grid the paired video session uses.
+   *  Defaults to {@link DEFAULT_SEGMENT_DURATION}. */
+  segmentDuration?: number;
 }
 
 /**
@@ -913,13 +924,14 @@ export function buildAudioOnlyFfmpegArgs(
     useTs = false,
     audioStreams,
     sourceFps,
+    segmentDuration = DEFAULT_SEGMENT_DURATION,
   } = opts;
   const segType = useTs ? 'mpegts' : 'fmp4';
   const segExt = useTs ? 'ts' : 'm4s';
   // fps-aware segment length so audio renditions cut on the same grid as the
   // video IDRs / playlist EXTINF (see buildFfmpegArgs). Equals the integer
   // setting for integer / unknown fps.
-  const realSeg = realSegmentSeconds(sourceFps);
+  const realSeg = realSegmentSeconds(segmentDuration, sourceFps);
 
   const args = ['-hide_banner', '-loglevel', 'warning'];
   if (trustedStreamInfo) {
@@ -935,7 +947,9 @@ export function buildAudioOnlyFfmpegArgs(
   }
 
   const seekSeconds =
-    startSegment > 0 ? segmentIndexToSeconds(startSegment, sourceFps) : 0;
+    startSegment > 0
+      ? segmentIndexToSeconds(startSegment, segmentDuration, sourceFps)
+      : 0;
 
   if (startSegment > 0) {
     args.push('-ss', String(seekSeconds));
@@ -1002,6 +1016,9 @@ export interface BuildRemuxArgsOptions {
    *  the real start of `startSegment` — not the uniform-grid `index * segDur`,
    *  which lands on the wrong content and desyncs the post-seek playlist. */
   segmentBoundaries?: number[];
+  /** Nominal segment duration (seconds) for `-hls_time` and the uniform-grid
+   *  seek fallback. Defaults to {@link DEFAULT_SEGMENT_DURATION}. */
+  segmentDuration?: number;
 }
 
 export function buildRemuxArgs(
@@ -1020,8 +1037,8 @@ export function buildRemuxArgs(
     sourceVideoCodec,
     audioStreams,
     segmentBoundaries,
+    segmentDuration = DEFAULT_SEGMENT_DURATION,
   } = opts;
-  const SEGMENT_DURATION = getSegmentDuration();
 
   const args = ['-hide_banner', '-loglevel', 'warning'];
   if (trustedStreamInfo) {
@@ -1037,7 +1054,7 @@ export function buildRemuxArgs(
   const remuxSeekSeconds =
     startSegment > 0
       ? (segmentBoundaries?.[startSegment] ??
-        segmentIndexToSeconds(startSegment))
+        segmentIndexToSeconds(startSegment, segmentDuration))
       : 0;
   if (startSegment > 0) {
     args.push('-ss', String(remuxSeekSeconds));
@@ -1116,7 +1133,7 @@ export function buildRemuxArgs(
     '-f',
     'hls',
     '-hls_time',
-    String(SEGMENT_DURATION),
+    String(segmentDuration),
     '-hls_list_size',
     '0',
     '-start_number',

--- a/backend/src/modules/streaming/transcoding/segment-boundaries.ts
+++ b/backend/src/modules/streaming/transcoding/segment-boundaries.ts
@@ -2,7 +2,6 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { Logger } from '@nestjs/common';
 import { statSync } from 'fs';
-import { getSegmentDuration } from './constants';
 
 const execFileAsync = promisify(execFile);
 const log = new Logger('SegmentBoundaries');
@@ -77,7 +76,7 @@ export async function extractKeyframeTimes(filePath: string): Promise<number[]> 
 export function computeSegmentDurations(
   keyframeTimes: number[],
   totalDuration: number,
-  segDur: number = getSegmentDuration(),
+  segDur: number,
 ): number[] {
   if (keyframeTimes.length === 0 || segDur <= 0) return [];
   // A keyframe past the container-reported duration extends the timeline so the
@@ -141,7 +140,7 @@ export function secondsToSegmentIndex(
 export async function getRemuxSegmentGrid(
   filePath: string,
   totalDuration: number,
-  segDur: number = getSegmentDuration(),
+  segDur: number,
 ): Promise<SegmentGrid | null> {
   let mtimeMs = 0;
   try {

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -9,13 +9,12 @@ import { existsSync, watch, FSWatcher } from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import {
+  DEFAULT_SEGMENT_DURATION,
   EARLY_PROBE_SEGMENTS,
   JOB_GRACE_MS,
   SEEK_WAIT_THRESHOLD,
   SESSION_TIMEOUT_MS,
-  getSegmentDuration,
   segmentIndexToSeconds,
-  setSegmentDuration as applySegmentDuration,
 } from './constants';
 import { LiveSessionRegistry } from '../live-session.service';
 import {
@@ -289,15 +288,6 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     return out;
   }
 
-  /** Update segment duration from admin streaming settings. */
-  setSegmentDuration(segDuration: number) {
-    applySegmentDuration(segDuration);
-  }
-
-  getSegmentDuration(): number {
-    return getSegmentDuration();
-  }
-
   getActiveSessions(): TranscodeSession[] {
     return Array.from(this.sessions.values());
   }
@@ -308,7 +298,10 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
    *  profile variants of the same `(file, user)` coexist as siblings. */
   computeProfileHashForCtx(ctx: SessionContext | undefined): string {
     const base = computeProfileHash(
-      buildPlaybackProfileFromContext(ctx, getSegmentDuration() * 1000),
+      buildPlaybackProfileFromContext(
+        ctx,
+        (ctx?.segmentDuration ?? DEFAULT_SEGMENT_DURATION) * 1000,
+      ),
     );
     // Instance suffix forks a concurrent playback onto its own job (#638);
     // absent for the sole playback, so the hash is unchanged there.
@@ -442,7 +435,10 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         if (maxSeg >= 0) break;
       }
       if (maxSeg < 0) return 0;
-      const transcodedUpTo = segmentIndexToSeconds(maxSeg + 1);
+      const transcodedUpTo = segmentIndexToSeconds(
+        maxSeg + 1,
+        session.segmentDuration ?? DEFAULT_SEGMENT_DURATION,
+      );
       return Math.min(100, (transcodedUpTo / durationSeconds) * 100);
     } catch {
       return 0;
@@ -745,7 +741,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
    *
    * Bounded by an input-side `-t` of EARLY_PROBE_SEGMENTS segments (+1s) so
    * ffmpeg exits shortly after flushing seg-0 .. seg-(EARLY_PROBE_SEGMENTS-1),
-   * each a full `getSegmentDuration()` long (there is no `hls_init_time`, so
+   * each a full segment long (there is no `hls_init_time`, so
    * seg-0 is not shortened). Same encoder profile + audio layout as the main
    * session so segments and
    * init.mp4 are decode-compatible (Shaka can mix-and-match across the two
@@ -829,7 +825,10 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       // ffmpeg exits cleanly. Derived from the configured segment duration —
       // a hardcoded 4s only covered two segments at the 3s default and left
       // seg-1 unwritten at 4s/6s grids. Insert as an INPUT option (before -i).
-      const earlyReadSec = EARLY_PROBE_SEGMENTS * getSegmentDuration() + 1;
+      const earlyReadSec =
+        EARLY_PROBE_SEGMENTS *
+          (ctx?.segmentDuration ?? DEFAULT_SEGMENT_DURATION) +
+        1;
       const inputIdx = args.indexOf('-i');
       if (inputIdx >= 0) args.splice(inputIdx, 0, '-t', String(earlyReadSec));
 
@@ -1335,6 +1334,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         sourceVideoCodec: ctx?.sourceVideoCodec,
         audioStreams: ctx?.audioStreams,
         segmentBoundaries,
+        segmentDuration: ctx?.segmentDuration ?? DEFAULT_SEGMENT_DURATION,
       },
       this.log,
     );
@@ -1454,6 +1454,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
         useTs: ctx?.useTs ?? false,
         audioStreams: ctx?.audioStreams,
         sourceFps: ctx?.sourceFps,
+        segmentDuration: ctx?.segmentDuration ?? DEFAULT_SEGMENT_DURATION,
       },
       this.log,
     );
@@ -1640,6 +1641,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       qsvOptions: ctx?.qsvOptions,
       tonemapAlgo: ctx?.tonemapAlgo,
       sourceFps: ctx?.sourceFps,
+      segmentDuration: ctx?.segmentDuration ?? DEFAULT_SEGMENT_DURATION,
       trustedStreamInfo: ctx?.trustedStreamInfo,
       useTs: ctx?.useTs ?? false,
       videoVariant: ctx?.videoVariant,
@@ -1676,6 +1678,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       ? 'var-stream-map'
       : 'inline';
     session.sourceFps = ctx.sourceFps;
+    session.segmentDuration = ctx.segmentDuration ?? DEFAULT_SEGMENT_DURATION;
     if (!session.startedAt) session.startedAt = new Date();
   }
 

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -126,8 +126,12 @@ export interface SessionContext {
    *  let the codec selector keep its built-in preference order). Forwarded
    *  to `ffmpeg-args` to override the default `useVaapiTonemap` decision. */
   tonemapAlgo?: TonemapAlgo;
-  /** Source framerate (fps). Used to compute GOP = SEGMENT_DURATION * fps. */
+  /** Source framerate (fps). Used to compute GOP = segmentDuration * fps. */
   sourceFps?: number;
+  /** HLS segment duration (seconds) this session cuts on — read from the admin
+   *  setting when the context is built and frozen onto the session, so the
+   *  serve/seek grid stays fixed for the session's lifetime. */
+  segmentDuration?: number;
   /**
    * True when the backend already has a trusted `streamInfo` for this file
    * (populated by ffprobe at import / rescan). If set, FFmpeg can use an
@@ -270,6 +274,11 @@ export interface TranscodeSession {
   /** Source frame rate this session encodes at. Lets the segment-serve path
    *  resolve the real segment-duration grid without re-probing streamInfo. */
   sourceFps?: number;
+  /** Segment duration (seconds) this session was spawned with, frozen from the
+   *  admin setting at spawn. The serve/seek grid reads this — never the live
+   *  admin value — so an admin change mid-playback can't shift the timeline of
+   *  segments already on disk. */
+  segmentDuration?: number;
   /** Marks the session as killed intentionally (seek restart, quality
    *  change, etc.) so the close handler doesn't log a spurious "exited
    *  WITHOUT producing first segment" warning. */


### PR DESCRIPTION
## Why (from the #740 A/V-desync audit)

The HLS segment duration was a **module-mutable `let`** in `transcoding/constants.ts`, written on every `playback-info` of any user and read by the ffmpeg arg builders, the serve-time `tfdt` anchor, the seek grid, and the playlist EXTINF. A session recorded its `sourceFps` but **not** the segment duration it was spawned with.

So an admin changing the segment-duration setting while anyone is playing **re-grids every in-flight session**: the running ffmpeg keeps cutting the old grid while the serve path computes the new one, snapping the timeline by up to a full segment → sudden audio-vs-video desync on **all** clients (audit candidate B-F5/C-F2). It's a rare trigger but a real latent corruption, and the mutable global is a long-term footgun.

## What

- **Move the setting to its proper home**: `ActiveStreamTracker.get/setSegmentDuration()`, alongside the other admin streaming settings (qsv, tonemap, auto-crop). The `constants.ts` global is gone.
- **Snapshot → freeze**: `SessionContextBuilder` reads the admin value onto `ctx.segmentDuration`; the session freezes it at spawn next to `sourceFps` (`applyContext`).
- **Explicit grid helpers**: `realSegmentSeconds` / `secondsToSegmentIndex` / `segmentIndexToSeconds` now take a **required** `segmentDuration` argument — the compiler proves every one of the ~40 call sites was migrated.
- **Read rule**: the **serve/seek** path reads the session's **frozen** value (`this.segDur(session)`), while **spawn/plan** uses the current admin value the new session will freeze — so playlist and session always agree, and no module holds mutable timeline state.
- Corrected the `ffmpeg-args` comments that claimed `-copyts` keeps the encoder clock in source time — empirically the HLS-fMP4 muxer rebases each run's `tfdt` to 0 and the serve-time anchor restores the absolute timeline (verified against the production jellyfin-ffmpeg 8.1.2 during the audit).

## Behaviour-preserving

At the default 3s setting the **ffmpeg golden argv and the profile hash are byte-identical** — this is a pure data-flow refactor, not a behaviour change on the common path. The only behavioural difference is the bug it removes: a mid-playback setting change no longer corrupts live sessions.

## Testing

- Full `src/modules/streaming` suite: **439 passed** (added a context-builder assertion + segment-duration unit cases). Golden snapshots unchanged. `tsc` clean.
- **Not yet validated at runtime.** See the PR discussion for the manual test plan (change the segment-duration setting mid-playback and confirm in-flight sessions keep their grid) — this is the risky branch; do **not** merge before that check.

Refs: #740

🤖 Generated with [Claude Code](https://claude.com/claude-code)