### PR TITLE
fix(streaming): fall back to avg_frame_rate when r_frame_rate is unusable

### DIFF
--- a/backend/src/modules/subtitles/ffprobe.service.spec.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.spec.ts
@@ -1,0 +1,32 @@
+import { FfprobeService } from './ffprobe.service';
+
+describe('FfprobeService.parseFrameRate', () => {
+  const svc = new FfprobeService();
+  const parse = (r?: string, avg?: string): string | undefined =>
+    (svc as unknown as {
+      parseFrameRate(r?: string, avg?: string): string | undefined;
+    }).parseFrameRate(r, avg);
+
+  it('normalises a rational to a trimmed decimal', () => {
+    expect(parse('24000/1001')).toBe('23.976');
+    expect(parse('25/1')).toBe('25');
+    expect(parse('30000/1001')).toBe('29.97');
+  });
+
+  it('falls back to avg_frame_rate when r_frame_rate is unusable', () => {
+    // VFR / some remuxed sources report r_frame_rate 0/0 — without the fallback
+    // frameRate is dropped and the segment grid collapses to the integer rate,
+    // drifting audio off the video IDR cadence on a fractional-fps source.
+    expect(parse('0/0', '24000/1001')).toBe('23.976');
+    expect(parse(undefined, '25/1')).toBe('25');
+  });
+
+  it('returns undefined only when neither rate is usable', () => {
+    expect(parse('0/0', '0/0')).toBeUndefined();
+    expect(parse(undefined, undefined)).toBeUndefined();
+  });
+
+  it('passes a non-rational string through unchanged', () => {
+    expect(parse('23.976')).toBe('23.976');
+  });
+});

--- a/backend/src/modules/subtitles/ffprobe.service.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.ts
@@ -125,6 +125,7 @@ interface FfprobeStream {
   display_aspect_ratio?: string;
   pix_fmt?: string;
   r_frame_rate?: string;
+  avg_frame_rate?: string;
   start_time?: string;
   bit_rate?: string;
   bits_per_raw_sample?: string;
@@ -379,7 +380,7 @@ export class FfprobeService {
             height: s.height,
             displayAspectRatio: s.display_aspect_ratio,
             pixelFormat: s.pix_fmt,
-            frameRate: this.parseFrameRate(s.r_frame_rate),
+            frameRate: this.parseFrameRate(s.r_frame_rate, s.avg_frame_rate),
             startTimeSeconds: s.start_time ? Number(s.start_time) : undefined,
             bitRate: s.bit_rate ? Number(s.bit_rate) : undefined,
             bitDepth: s.bits_per_raw_sample
@@ -525,16 +526,27 @@ export class FfprobeService {
     }
   }
 
-  private parseFrameRate(rate?: string): string | undefined {
-    if (!rate || rate === '0/0') return undefined;
-    const parts = rate.split('/');
-    const num = Number(parts[0]);
-    const den = Number(parts[1]);
-    if (!den || !num) return rate;
-    const fps = num / den;
-    return fps > 0
-      ? fps.toFixed(3).replace(/0+$/, '').replace(/\.$/, '')
-      : undefined;
+  /**
+   * Normalise a ffprobe frame-rate to a decimal fps string (e.g. `23.976`).
+   * Prefers `r_frame_rate` and falls back to `avg_frame_rate` when the former
+   * is unusable (`0/0`, which VFR/some remuxed sources report): the transcode
+   * and playlist grids derive the segment length from this fps, so a missing
+   * value would drop them onto the integer grid and drift the audio off the
+   * video IDR cadence on a fractional-fps source.
+   */
+  private parseFrameRate(rate?: string, avgRate?: string): string | undefined {
+    const normalise = (r?: string): string | undefined => {
+      if (!r || r === '0/0') return undefined;
+      const parts = r.split('/');
+      const num = Number(parts[0]);
+      const den = Number(parts[1]);
+      if (!den || !num) return r;
+      const fps = num / den;
+      return fps > 0
+        ? fps.toFixed(3).replace(/0+$/, '').replace(/\.$/, '')
+        : undefined;
+    };
+    return normalise(rate) ?? normalise(avgRate);
   }
 
   /**


### PR DESCRIPTION
## Problem
The transcode and playlist grids derive the real segment length from the source fps (`round(segmentDuration × fps)` frames = `gop / fps` seconds). When a source reports `r_frame_rate` `0/0` — VFR and some remuxed containers do — `parseFrameRate` returned `undefined`, so `frameRate` was dropped from `streamInfo` and both grids collapsed to the **integer** rate.

On a fractional-fps source the encoder still emits its native-rate GOPs (144 frames = 6.006 s) while the serve grid assumes 6.000 s; the ~3 ms/segment divergence accumulates until the audio-only tfdt anchor snaps a whole segment late (~25 min in) — a sudden A/V desync (the #749 signature).

## Fix
Prefer `r_frame_rate` (unchanged for the 99% case) and fall back to `avg_frame_rate` only when the former is `0/0`, so a real video stream never loses its fps. Fixed at the probe (import/rescan) — the encode and serve grids keep sharing one exact value, with **no re-probe on the playback hot path and no fps guessing** (both of which were rejected as band-aids).

The pre-existing 3-decimal rounding is intentionally kept: `24000/1001` → `23.976` is a ~6 µs/segment error (~1.5 ms over 25 min), far below one audio frame — not worth precision churn.

## Testing
New `ffprobe.service.spec.ts` covers the rational normalisation, the `0/0` → `avg_frame_rate` fallback, the both-unusable → `undefined` case, and non-rational passthrough. 470 subtitles + streaming tests green, tsc clean.

Closes #749