### PR TITLE
feat(streaming): tone-map Dolby Vision P5 via tonemap_opencl apply_dovi

### DIFF
--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -567,6 +567,7 @@ function resolveDecodeStage(opts: {
   openclTonemap: boolean;
   tonemapPath: string;
   useDoviTonemap: boolean;
+  useDoviOpenclTonemap: boolean;
 }): {
   decodeArgs: string[];
   decoder: ReturnType<typeof decoderRegistry.resolve>;
@@ -587,6 +588,7 @@ function resolveDecodeStage(opts: {
     openclTonemap,
     tonemapPath,
     useDoviTonemap,
+    useDoviOpenclTonemap,
   } = opts;
   const args: string[] = [];
 
@@ -691,6 +693,11 @@ function resolveDecodeStage(opts: {
   }
   if (useDoviTonemap) {
     args.push('-init_hw_device', 'vulkan=vk:0', '-filter_hw_device', 'vk');
+  }
+  // OpenCL device for the DV RPU tone-map (`tonemap_opencl=apply_dovi`) when
+  // libplacebo can't (no libdovi). The CPU-decoded frame hwuploads onto it.
+  if (useDoviOpenclTonemap) {
+    args.push(...openclTonemapInitArgs());
   }
 
   return { decodeArgs: args, decoder, useVtMetalPath };
@@ -915,6 +922,17 @@ export function buildFfmpegArgs(
     sourceDvProfile === 5 &&
     (sourceDvBlSignalCompatId === 0 || sourceDvBlSignalCompatId == null) &&
     isLibplaceboDvEnabled();
+  // DV Profile 5 without a libdovi-enabled libplacebo (the Windows / macOS
+  // builds, or Linux without the overlay): apply the RPU in the OpenCL tone-map
+  // filter (`tonemap_opencl=apply_dovi=1`) instead. The RPU is exposed as frame
+  // side-data by the software HEVC decoder, so — like the libplacebo path — this
+  // forces CPU decode, then hwupload → tonemap_opencl → hwdownload.
+  const useDoviOpenclTonemap =
+    !!tonemap &&
+    sourceDvProfile === 5 &&
+    (sourceDvBlSignalCompatId === 0 || sourceDvBlSignalCompatId == null) &&
+    !useDoviTonemap &&
+    isOpenclTonemapEnabled();
 
   // Image-based subtitle burn-in (PGS/VOBSUB) is composited via -filter_complex
   // below, reusing the encoder's video chain so the accelerated scale/tonemap
@@ -934,7 +952,7 @@ export function buildFfmpegArgs(
     useVaapiTonemap,
     amfFullGpuAvailable,
   } = resolveEncodePipeline(variant, {
-    hwAccel: useDoviTonemap ? 'none' : hwAccel,
+    hwAccel: useDoviTonemap || useDoviOpenclTonemap ? 'none' : hwAccel,
     crop: !!crop,
     burnIn: !!burnIn?.filter,
     tonemap: !!tonemap,
@@ -990,6 +1008,7 @@ export function buildFfmpegArgs(
     openclTonemap,
     tonemapPath,
     useDoviTonemap,
+    useDoviOpenclTonemap,
   });
   args.push(...decodeArgs);
 
@@ -1058,6 +1077,7 @@ export function buildFfmpegArgs(
       useVaapiTonemap,
       sourceBitDepth,
       dovi: useDoviTonemap,
+      doviOpencl: useDoviOpenclTonemap,
       tonemapCurve,
       scaleWidth: w,
       openclTonemap,

--- a/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.ts
@@ -21,6 +21,8 @@ export interface VideoFilterContext {
   /** Dolby Vision P5: tonemap via the RPU-aware libplacebo (Vulkan) chain
    *  instead of the standard tonemap that misreads IPT-C2 (#636). */
   dovi?: boolean;
+  /** DV Profile 5 tone-map via `tonemap_opencl=apply_dovi` (no libdovi path). */
+  doviOpencl?: boolean;
   /** CPU HDR→SDR tone-map curve (`hable` default, `mobius` optional). */
   tonemapCurve?: TonemapCurve;
   /** Route the HDR→SDR tone-map through `tonemap_opencl` (GPU) instead of the
@@ -60,6 +62,7 @@ export function buildVideoFilters(
     useVaapiTonemap,
     sourceBitDepth,
     dovi,
+    doviOpencl,
     tonemapCurve,
     scaleWidth,
     openclTonemap,
@@ -97,9 +100,13 @@ export function buildVideoFilters(
   const tonemapCpu = tonemap
     ? dovi
       ? `hwupload,libplacebo=apply_dolbyvision=1:tonemapping=bt.2390:colorspace=bt709:color_primaries=bt709:color_trc=bt709:format=nv12,hwdownload,format=nv12,`
-      : openclTonemap
-        ? `format=p010le,hwupload,tonemap_opencl=t=bt709:m=bt709:p=bt709:tonemap=${curve}:desat=0:format=nv12,hwdownload,format=nv12,`
-        : `zscale=w=${scaleWidth}:h=-2:t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=${curve}:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p,`
+      : doviOpencl
+        ? // DV P5 RPU applied in the OpenCL tone-map (no libdovi). The RPU rides
+          // as side-data on the CPU-decoded frame through hwupload.
+          `format=p010le,hwupload,tonemap_opencl=apply_dovi=1:t=bt709:m=bt709:p=bt709:tonemap=${curve}:desat=0:format=nv12,hwdownload,format=nv12,`
+        : openclTonemap
+          ? `format=p010le,hwupload,tonemap_opencl=t=bt709:m=bt709:p=bt709:tonemap=${curve}:desat=0:format=nv12,hwdownload,format=nv12,`
+          : `zscale=w=${scaleWidth}:h=-2:t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=${curve}:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p,`
     : '';
   // HW-crop round-trip: hwdownload → crop → hwupload. The explicit `format=`
   // matches the source bit depth (p010le for 10-bit) so crop runs in the

--- a/macos/Scripts/fetch-vendored.sh
+++ b/macos/Scripts/fetch-vendored.sh
@@ -17,6 +17,12 @@ mkdir -p "$VENDORED"
 NODE_VERSION="24.2.0"
 PG_VERSION="18"
 ARCH="arm64"
+# jellyfin-ffmpeg (GPL) — same FFmpeg 8.1 base and version as the Linux/Windows
+# servers (unified). Replaces the Homebrew bottle so macOS gets the same
+# libplacebo + HW tonemap filters (tonemap_opencl/videotoolbox with the DV RPU
+# `apply_dovi` path), so Dolby Vision Profile 5 tone-maps correctly instead of
+# rendering green/purple through the stock tonemap. Pin the exact tag.
+FFMPEG_VERSION="8.1.2-1"
 
 echo "==> Fetching vendored binaries to $VENDORED"
 
@@ -77,49 +83,35 @@ else
 fi
 
 # ─────────────────────────────────────────────────────────────
-# FFmpeg — with VideoToolbox support
+# FFmpeg — jellyfin-ffmpeg (VideoToolbox + libplacebo + DV tonemap)
 # ─────────────────────────────────────────────────────────────
 if [ -x "$VENDORED/ffmpeg/bin/ffmpeg" ]; then
     echo "    [skip] FFmpeg already present"
 else
-    echo "    [fetch] FFmpeg via Homebrew..."
+    echo "    [fetch] FFmpeg (jellyfin-ffmpeg ${FFMPEG_VERSION}, ${ARCH})..."
     TMP_FF="$(mktemp -d)"
 
-    brew fetch ffmpeg 2>/dev/null
+    # portable_macarm64 / portable_mac64 tarball ships self-contained ffmpeg +
+    # ffprobe binaries (no external dylib closure).
+    FF_SLUG="$([ "$ARCH" = "arm64" ] && echo macarm64 || echo mac64)"
+    FF_URL="https://github.com/jellyfin/jellyfin-ffmpeg/releases/download/v${FFMPEG_VERSION}/jellyfin-ffmpeg_${FFMPEG_VERSION}_portable_${FF_SLUG}-gpl.tar.xz"
+    echo "    [fetch] ${FF_URL}"
+    curl -fsSL "$FF_URL" -o "$TMP_FF/ffmpeg.tar.xz"
+    tar xJf "$TMP_FF/ffmpeg.tar.xz" -C "$TMP_FF"
 
-    BOTTLE_PATH="$(find "$(brew --cache)" -name "ffmpeg--*.tar.gz" -type f 2>/dev/null | sort -t- -k3 -rV | head -1)"
-    if [ -z "$BOTTLE_PATH" ] || [ ! -f "$BOTTLE_PATH" ]; then
-        BOTTLE_PATH="$(brew --cache ffmpeg)"
-    fi
-    mkdir -p "$VENDORED/ffmpeg/bin"
-    tar xzf "$BOTTLE_PATH" -C "$TMP_FF"
-
-    FF_BIN="$(find "$TMP_FF" -name "ffmpeg" -type f | head -1)"
+    FF_BIN="$(find "$TMP_FF" -name ffmpeg -type f | head -1)"
     if [ -z "$FF_BIN" ]; then
-        echo "    [error] Could not locate ffmpeg binary in bottle"
+        echo "    [error] ffmpeg not found in $FF_URL"
         rm -rf "$TMP_FF"
         exit 1
     fi
-
-    cp "$FF_BIN" "$VENDORED/ffmpeg/bin/ffmpeg"
-    chmod +x "$VENDORED/ffmpeg/bin/ffmpeg"
-
-    # Also grab ffprobe if present.
-    FF_PROBE="$(find "$TMP_FF" -name "ffprobe" -type f | head -1)"
-    if [ -n "$FF_PROBE" ]; then
-        cp "$FF_PROBE" "$VENDORED/ffmpeg/bin/ffprobe"
-        chmod +x "$VENDORED/ffmpeg/bin/ffprobe"
-    fi
-
-    # Copy shared libraries that ffmpeg needs.
-    FF_LIB_DIR="$(dirname "$FF_BIN")/../lib"
-    if [ -d "$FF_LIB_DIR" ]; then
-        mkdir -p "$VENDORED/ffmpeg/lib"
-        cp -R "$FF_LIB_DIR/"* "$VENDORED/ffmpeg/lib/" 2>/dev/null || true
-    fi
+    # Copy the whole binary dir (ffmpeg/ffprobe + any bundled dylibs).
+    mkdir -p "$VENDORED/ffmpeg/bin"
+    cp -R "$(dirname "$FF_BIN")/"* "$VENDORED/ffmpeg/bin/"
+    chmod +x "$VENDORED/ffmpeg/bin/ffmpeg" "$VENDORED/ffmpeg/bin/ffprobe" 2>/dev/null || true
 
     rm -rf "$TMP_FF"
-    echo "    [done] FFmpeg"
+    echo "    [done] FFmpeg (jellyfin-ffmpeg gpl)"
 fi
 
 echo ""


### PR DESCRIPTION
## Problem
DV Profile 5 (IPT-PQ-C2, no HDR10 base) only tone-mapped correctly through the **libplacebo `apply_dolbyvision`** path, which needs a **libdovi**-enabled libplacebo — present on the Linux Docker build (custom Stage 2c overlay) but **not** on the Windows or macOS builds, where P5 fell through to the plain tone-map → **green/purple** (#738, #659).

## Fix — the buildless, standard approach
The bundled ffmpeg's `tonemap_opencl` filter already applies the DV RPU (`apply_dovi`, verified present on jellyfin-ffmpeg 8.1.2). Add a parallel `useDoviOpenclTonemap` path that, when the libdovi/libplacebo path is unavailable and the OpenCL tone-map probe passed, tone-maps P5 through `format=p010le,hwupload,tonemap_opencl=apply_dovi=1:…,hwdownload`. Like the libplacebo path it forces software decode (so the RPU rides as frame side-data through the upload) and inits an OpenCL filter device.

This is how upstream servers on the same ffmpeg handle P5 — no custom build, no libdovi.

## Safety
Additive and gated: the new path engages **only** for P5 + tonemap when libplacebo is unavailable **and** the OpenCL probe passed. The Linux libplacebo path and every non-DV pipeline are byte-for-byte unchanged — **golden spec unaffected**, 441 streaming tests green, tsc clean.

## Validation
Verified the **exact generated filtergraph** on a real DV source on the server's OpenCL: `tonemap_opencl=apply_dovi=1` produces **correct SDR colour, no green/purple** (natural skin tones). Blind on P5 end-to-end — the test library has no genuine P5 file (P5 is niche), so this was validated on a P8 DV source (same RPU-in-side-data mechanism). Worst case is contained to P5 sources, which already render wrong on Windows/macOS today.

Pairs with #762 (macOS → jellyfin-ffmpeg, so it has the capable filter). Once confirmed on a real P5, the Linux libplacebo+libdovi overlay (Dockerfile Stage 2c) can likely be dropped for a simpler pipeline.

Refs #738, #659