### PR TITLE
fix(streaming): report macOS scale_vt tone-map as hardware, not CPU

### DIFF
--- a/backend/src/modules/streaming/dto/playback-info.dto.ts
+++ b/backend/src/modules/streaming/dto/playback-info.dto.ts
@@ -109,10 +109,11 @@ export interface PlaybackInfoResponse {
 
   /** Tone-map mechanism the session actually runs. `'vaapi'` / `'opencl'`
    *  / `'qsv'` for QSV/VAAPI encoders (after `auto` resolution + boot
-   *  probe); `'cpu'` for the CPU zscale chain used by NVENC / libx26x /
-   *  VideoToolbox fallback. `null` when no tone-mapping pass runs. Stats
-   *  overlays show this value, not the (encoder-agnostic) admin pick. */
-  tonemapAlgo?: 'vaapi' | 'opencl' | 'qsv' | 'cpu' | null;
+   *  probe); `'videotoolbox'` for the macOS `scale_vt` Metal path; `'cpu'`
+   *  for the CPU zscale chain (NVENC / libx26x / VideoToolbox with a
+   *  burn-in or crop). `null` when no tone-mapping pass runs. Stats overlays
+   *  show this value, not the (encoder-agnostic) admin pick. */
+  tonemapAlgo?: 'vaapi' | 'opencl' | 'qsv' | 'videotoolbox' | 'cpu' | null;
 
   /** Tone-map curve (`hable` / `mobius` / `reinhard`), set only when
    *  `tonemapAlgo === 'cpu'`. Surfaced so the overlay names the exact

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -766,12 +766,17 @@ export class StreamingController {
     const openclTonemap =
       (response.hwAccel === 'nvenc' || response.hwAccel === 'amf') &&
       isOpenclTonemapEnabled();
+    // mirrors ffmpeg-args useVtMetalPath (scale_vt HW tone-map)
+    const vtMetalTonemap =
+      response.hwAccel === 'videotoolbox' && !hasCrop && !burnInSubtitleId;
     const tonemapAlgo = response.tonemapping
       ? hwTonemap
         ? resolveTonemapPath(ss.tonemapAlgo, { hasCrop })
         : openclTonemap
           ? 'opencl'
-          : 'cpu'
+          : vtMetalTonemap
+            ? 'videotoolbox'
+            : 'cpu'
       : null;
     // The curve is a `tonemap`/`tonemap_opencl` operator, so it only applies to
     // the opencl and CPU paths — the vpp_qsv / tonemap_vaapi LUTs ignore it.

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -32,7 +32,7 @@ export interface PlaybackInfoResponse {
    *  (`'vaapi'` / `'opencl'` / `'qsv'`) on QSV/VAAPI encoders, or
    *  `'cpu'` for the CPU chain (NVENC / libx26x / VideoToolbox
    *  fallback). Null when no tone-mapping pass runs on this session. */
-  tonemapAlgo?: 'vaapi' | 'opencl' | 'qsv' | 'cpu' | null;
+  tonemapAlgo?: 'vaapi' | 'opencl' | 'qsv' | 'videotoolbox' | 'cpu' | null;
   /** Tone-map curve, set for the `opencl` and `cpu` paths (the LUTs ignore it). */
   tonemapCurve?: 'hable' | 'mobius' | 'reinhard';
   /** Cibles par rung (transcodage). */

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -791,6 +791,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       vaapi: 'VAAPI',
       opencl: 'OpenCL',
       qsv: 'vpp_qsv',
+      videotoolbox: 'VideoToolbox',
       cpu: 'CPU',
     };
     // The opencl and CPU paths run a tunable curve (tonemap_opencl / tonemap),


### PR DESCRIPTION
The nerd-stats overlay showed **CPU (hable)** for macOS HDR playback even though the transcode ran `scale_vt` on the Apple Media Engine (VideoToolbox/Metal). The stats reporter only recognised qsv/vaapi/nvenc/amf as hardware and fell through to `cpu`+`hable` for VideoToolbox.

Detect the Metal fast path (mirrors `ffmpeg-args` `useVtMetalPath`: VideoToolbox encoder, tonemapping on, no burn-in, no crop) and report a new `videotoolbox` algo. Burn-in / crop still correctly report `cpu` (that path genuinely runs the CPU tonemap chain). Adds the `VideoToolbox` label to the overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)