### PR TITLE
fix(macos): bundle ffmpeg with libzimg for the HDR tonemap chain

### DIFF
--- a/.github/workflows/macos-server-dmg.yml
+++ b/.github/workflows/macos-server-dmg.yml
@@ -54,16 +54,32 @@ jobs:
             backend/package-lock.json
 
       # ── Homebrew dependencies ──
-      # ffmpeg comes from the homebrew-ffmpeg tap built --with-zimg: the stock
-      # brew ffmpeg has no libzimg, so it lacks the `zscale` filter the HDR→SDR
-      # CPU tonemap chain needs (crop / burn-in paths). VideoToolbox is on by
-      # default there. --with-zimg forces a source build, so this step is slow.
       - name: Install Homebrew dependencies
+        run: brew install postgresql@18 xcodegen create-dmg
+
+      # ── ffmpeg from homebrew-ffmpeg --with-zimg (cached) ──
+      # Stock brew ffmpeg has no libzimg → no `zscale`, which the HDR→SDR CPU
+      # tonemap chain (crop / burn-in paths) needs. --with-zimg is a ~30-min
+      # source build, so cache the compiled keg. Bump the key suffix to rebuild.
+      - name: Cache ffmpeg keg
+        uses: actions/cache@v4
+        with:
+          path: ~/ffmpeg-keg
+          key: ffmpeg-zimg-${{ runner.arch }}-v1
+      - name: Install ffmpeg (--with-zimg)
         run: |
-          brew install postgresql@18 xcodegen create-dmg
-          brew uninstall --ignore-dependencies --force ffmpeg 2>/dev/null || true
           brew tap homebrew-ffmpeg/ffmpeg
-          brew install homebrew-ffmpeg/ffmpeg/ffmpeg --with-zimg
+          brew uninstall --ignore-dependencies --force ffmpeg 2>/dev/null || true
+          # Runtime deps as prebuilt bottles (fast); zimg is the --with-zimg extra.
+          brew install zimg $(brew deps homebrew-ffmpeg/ffmpeg/ffmpeg)
+          if [ -d ~/ffmpeg-keg/ffmpeg ]; then
+            cp -R ~/ffmpeg-keg/ffmpeg "$(brew --cellar)/"
+            brew link --overwrite --force ffmpeg
+          else
+            brew install --build-from-source homebrew-ffmpeg/ffmpeg/ffmpeg --with-zimg
+            mkdir -p ~/ffmpeg-keg && cp -R "$(brew --cellar)/ffmpeg" ~/ffmpeg-keg/
+          fi
+          ffmpeg -hide_banner -filters | grep -qw zscale
 
       # ── Fetch vendored Node.js 24 (arm64) ──
       - name: Fetch vendored binaries

--- a/.github/workflows/macos-server-dmg.yml
+++ b/.github/workflows/macos-server-dmg.yml
@@ -54,8 +54,16 @@ jobs:
             backend/package-lock.json
 
       # ── Homebrew dependencies ──
+      # ffmpeg comes from the homebrew-ffmpeg tap built --with-zimg: the stock
+      # brew ffmpeg has no libzimg, so it lacks the `zscale` filter the HDR→SDR
+      # CPU tonemap chain needs (crop / burn-in paths). VideoToolbox is on by
+      # default there. --with-zimg forces a source build, so this step is slow.
       - name: Install Homebrew dependencies
-        run: brew install postgresql@18 ffmpeg xcodegen create-dmg
+        run: |
+          brew install postgresql@18 xcodegen create-dmg
+          brew uninstall --ignore-dependencies --force ffmpeg 2>/dev/null || true
+          brew tap homebrew-ffmpeg/ffmpeg
+          brew install homebrew-ffmpeg/ffmpeg/ffmpeg --with-zimg
 
       # ── Fetch vendored Node.js 24 (arm64) ──
       - name: Fetch vendored binaries

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -23,6 +23,12 @@ archives and the upstream projects linked here.
 | Node.js runtime | MIT-style | https://github.com/nodejs/node |
 | PostgreSQL client | PostgreSQL License | https://www.postgresql.org |
 
+The macOS server app bundles FFmpeg, PostgreSQL and Node.js from the table above
+rather than the Docker archive. Its FFmpeg is a `homebrew-ffmpeg` build
+`--with-zimg`, which adds **libzimg / z.lib** (WTFPL, https://github.com/sekrit-twc/zimg)
+for the `zscale` filter; the FFmpeg umbrella license is unchanged
+(GPL-2.0-or-later).
+
 Node/npm package dependencies declare their own licenses in their respective
 `package.json` and `node_modules`; this file covers the non-npm programs
 embedded in the runtime image.

--- a/macos/Scripts/build-app.sh
+++ b/macos/Scripts/build-app.sh
@@ -3,7 +3,8 @@
 # Build a self-contained Fliks Server.app bundle with all dependencies.
 #
 # Prerequisites:
-#   1. brew install xcodegen postgresql@18 ffmpeg
+#   1. brew install xcodegen postgresql@18
+#      brew tap homebrew-ffmpeg/ffmpeg && brew install homebrew-ffmpeg/ffmpeg/ffmpeg --with-zimg
 #   2. ./Scripts/fetch-vendored.sh  (for Node.js 24 arm64)
 #   3. Xcode 16+ with command line tools
 #
@@ -38,13 +39,13 @@ fi
 
 for tool in ffmpeg psql; do
     if ! command -v $tool &>/dev/null; then
-        echo "Error: $tool not found. Run: brew install postgresql@18 ffmpeg"
+        echo "Error: $tool not found. See the prerequisites at the top of this script."
         exit 1
     fi
 done
 
 PG_PREFIX="$(brew --prefix postgresql@18)"
-FF_PREFIX="$(brew --prefix ffmpeg)"
+FF_PREFIX="$(brew --prefix homebrew-ffmpeg/ffmpeg/ffmpeg 2>/dev/null || brew --prefix ffmpeg)"
 
 echo "==> Build configuration"
 echo "    Node.js:    $VENDORED/node/bin/node ($($VENDORED/node/bin/node --version))"
@@ -238,6 +239,14 @@ if [ -n "$stray" ]; then
     exit 1
 fi
 echo "    [verify] no bundled binary references /opt/homebrew"
+
+# 3. ffmpeg must have zscale (libzimg) — the HDR→SDR CPU tonemap chain used by
+#    the crop / burn-in paths is built on it.
+if ! "$RESOURCES/ffmpeg/bin/ffmpeg" -hide_banner -filters 2>/dev/null | grep -qw zscale; then
+    echo "Error: bundled ffmpeg lacks the zscale filter (build it --with-zimg)."
+    exit 1
+fi
+echo "    [verify] ffmpeg has zscale (libzimg)"
 
 echo ""
 echo "==> Build complete: $APP_BUNDLE"


### PR DESCRIPTION
## Why

macOS HDR playback **crashes** whenever it can't use the `scale_vt` Metal fast path — i.e. with **auto-crop** (letterbox removal) or **burned-in subtitles**. Those force the CPU tonemap chain, which is built on the `zscale` filter:

```
crop=…,zscale=…t=linear,…,tonemap=hable,zscale=t=bt709…
[AVFilterGraph] No such filter: 'zscale'  →  ffmpeg exit=8  →  every fallback dies
```

The bundled **Homebrew ffmpeg** ships with only `--enable-videotoolbox` — **no libzimg**, so no `zscale`. (`scale_vt` can't crop, so crop/burn-in can't stay on the HW path.) This is the *"we're supposed to be on jellyfin-ffmpeg"* gap — jellyfin-ffmpeg has zimg, but [has no macOS build](https://github.com/jellyfin/jellyfin-ffmpeg/issues/339), and macOS doesn't need its Linux/Windows HW patches anyway (VideoToolbox is upstream).

## Change

- Source ffmpeg from the **`homebrew-ffmpeg` tap `--with-zimg`** (`--enable-libzimg` → `zscale`; VideoToolbox stays on by default). Builds from source, so the CI `brew install` step is slower.
- `build-app.sh` now **asserts the bundled ffmpeg has `zscale`** — fails the build otherwise (same guard style as the node/homebrew checks).
- The existing `bundle-dylibs.sh` pass relocates `libzimg` into the bundle automatically; the `/opt/homebrew` assertion covers it.
- **Third-party notices** updated: macOS ffmpeg now bundles **libzimg / z.lib** (WTFPL).

Non-crop / non-burn-in HDR is unaffected (still the `scale_vt` hardware path).

## Validation
- ⏳ Needs a CI build to confirm the `--with-zimg` source build + the new `zscale` assertion pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)