### PR TITLE
fix(macos): use vendored jellyfin-ffmpeg + HW tone-map for cropped HDR

### DIFF
--- a/.github/workflows/macos-server-dmg.yml
+++ b/.github/workflows/macos-server-dmg.yml
@@ -54,8 +54,9 @@ jobs:
             backend/package-lock.json
 
       # ── Homebrew dependencies ──
+      # ffmpeg is not installed here — fetch-vendored.sh downloads jellyfin-ffmpeg.
       - name: Install Homebrew dependencies
-        run: brew install postgresql@18 ffmpeg xcodegen create-dmg
+        run: brew install postgresql@18 xcodegen create-dmg
 
       # ── Fetch vendored Node.js 24 (arm64) ──
       - name: Fetch vendored binaries

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -24,8 +24,8 @@ archives and the upstream projects linked here.
 | PostgreSQL client | PostgreSQL License | https://www.postgresql.org |
 
 The macOS server app bundles **jellyfin-ffmpeg** (GPL-2.0-or-later,
-https://github.com/jellyfin/jellyfin-ffmpeg — FFmpeg with VideoToolbox +
-libplacebo) in place of the FFmpeg row above, plus PostgreSQL and Node.js.
+https://github.com/jellyfin/jellyfin-ffmpeg — FFmpeg with VideoToolbox + OpenCL)
+in place of the FFmpeg row above, plus PostgreSQL and Node.js.
 
 Node/npm package dependencies declare their own licenses in their respective
 `package.json` and `node_modules`; this file covers the non-npm programs

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -23,6 +23,10 @@ archives and the upstream projects linked here.
 | Node.js runtime | MIT-style | https://github.com/nodejs/node |
 | PostgreSQL client | PostgreSQL License | https://www.postgresql.org |
 
+The macOS server app bundles **jellyfin-ffmpeg** (GPL-2.0-or-later,
+https://github.com/jellyfin/jellyfin-ffmpeg — FFmpeg with VideoToolbox +
+libplacebo) in place of the FFmpeg row above, plus PostgreSQL and Node.js.
+
 Node/npm package dependencies declare their own licenses in their respective
 `package.json` and `node_modules`; this file covers the non-npm programs
 embedded in the runtime image.

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -766,9 +766,10 @@ export class StreamingController {
     const openclTonemap =
       (response.hwAccel === 'nvenc' || response.hwAccel === 'amf') &&
       isOpenclTonemapEnabled();
-    // mirrors ffmpeg-args useVtMetalPath (scale_vt HW tone-map)
+    // VideoToolbox HW tone-map: scale_vt (no crop) or tonemap_videotoolbox
+    // (crop); burn-in still falls back to the CPU chain.
     const vtMetalTonemap =
-      response.hwAccel === 'videotoolbox' && !hasCrop && !burnInSubtitleId;
+      response.hwAccel === 'videotoolbox' && !burnInSubtitleId;
     const tonemapAlgo = response.tonemapping
       ? hwTonemap
         ? resolveTonemapPath(ss.tonemapAlgo, { hasCrop })

--- a/backend/src/modules/streaming/transcoding/codec/encoders/h264-videotoolbox.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/h264-videotoolbox.ts
@@ -37,16 +37,16 @@ export const h264Videotoolbox: EncoderDescriptor = {
       '-force_key_frames',
       input.forceKeyframesExpr,
     ];
-    // Full-Metal HDR pipeline — see the matching comment in
-    // `hevc-videotoolbox.ts`. Active when the orchestrator already
-    // configured the decoder to emit videotoolbox_vld IOSurfaces.
+    // VideoToolbox surface path — see the matching comment in
+    // `hevc-videotoolbox.ts`. No crop → scale_vt; crop → tonemap_videotoolbox
+    // then hwdownload for the CPU crop.
     if (inputSurface === 'videotoolbox') {
-      return [
-        ...common,
-        '-vf',
-        `scale_vt=w=${w}:h=-2:color_matrix=bt709:color_primaries=bt709:color_transfer=bt709`,
-        ...trailing,
-      ];
+      const vf = input.hasCrop
+        ? `tonemap_videotoolbox=tonemap=${input.tonemapCurve ?? 'hable'}:t=bt709:m=bt709:p=bt709:range=tv,` +
+          `hwdownload,format=p010le,${filters.cpuCropPrefix}` +
+          `scale=${w}:${scaleEvenHeight(w)}:flags=lanczos,format=yuv420p`
+        : `scale_vt=w=${w}:h=-2:color_matrix=bt709:color_primaries=bt709:color_transfer=bt709`;
+      return [...common, '-vf', vf, ...trailing];
     }
     return [
       ...common,

--- a/backend/src/modules/streaming/transcoding/codec/encoders/hevc-videotoolbox.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/hevc-videotoolbox.ts
@@ -39,19 +39,18 @@ export const hevcVideotoolbox: EncoderDescriptor = {
       '-tag:v',
       'hvc1',
     ];
-    // Full-Metal HDR pipeline: the orchestrator has set the decoder to
-    // emit videotoolbox_vld surfaces (`-hwaccel_output_format`), so
-    // `scale_vt` accepts the input directly and the entire chain runs
-    // on the Apple Media Engine — no CPU bounce. Only viable when no
-    // CPU-only filter (burn-in, crop) is required; the orchestrator
-    // checks those before flipping `inputSurface` to `'videotoolbox'`.
+    // VideoToolbox surface path (orchestrator set -hwaccel_output_format).
+    // No crop: scale_vt tone-maps + scales entirely on the Media Engine.
+    // Crop: no VT crop filter exists, so tone-map on the surface via
+    // tonemap_videotoolbox, then hwdownload for the cheap CPU crop + scale.
+    // Burn-in still takes the CPU fallback below.
     if (inputSurface === 'videotoolbox') {
-      return [
-        ...common,
-        '-vf',
-        `scale_vt=w=${w}:h=-2:color_matrix=bt709:color_primaries=bt709:color_transfer=bt709`,
-        ...trailing,
-      ];
+      const vf = input.hasCrop
+        ? `tonemap_videotoolbox=tonemap=${input.tonemapCurve ?? 'hable'}:t=bt709:m=bt709:p=bt709:range=tv,` +
+          `hwdownload,format=p010le,${filters.cpuCropPrefix}` +
+          `scale=${w}:${scaleEvenHeight(w)}:flags=lanczos,format=yuv420p`
+        : `scale_vt=w=${w}:h=-2:color_matrix=bt709:color_primaries=bt709:color_transfer=bt709`;
+      return [...common, '-vf', vf, ...trailing];
     }
     // CPU tonemap fallback — works on every macOS host even when the
     // Metal fast path is inapplicable (burn-in, crop, or a future

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -570,6 +570,7 @@ function resolveDecodeStage(opts: {
   decodeArgs: string[];
   decoder: ReturnType<typeof decoderRegistry.resolve>;
   useVtMetalPath: boolean;
+  useVtHwTonemap: boolean;
 } {
   const {
     sourceVideoCodec,
@@ -628,13 +629,17 @@ function resolveDecodeStage(opts: {
   // input args here when the Metal fast path is eligible. The encoder
   // branches on `inputSurface === 'videotoolbox'` to pick the scale_vt
   // filter; falls back to the CPU tonemap chain otherwise.
-  const useVtMetalPath =
+  const vtSurfaceEligible =
     decoder.hwAccel === 'videotoolbox' &&
     (encoderId === 'h264_videotoolbox' || encoderId === 'hevc_videotoolbox') &&
     tonemap &&
-    !hasBurnInFilter &&
-    !hasCrop;
-  if (useVtMetalPath) {
+    !hasBurnInFilter;
+  // No crop: scale_vt keeps the SDR result on a VT surface. Crop: no VT crop
+  // filter exists, so the encoder tone-maps on the surface (tonemap_videotoolbox)
+  // then hwdownloads for the cheap CPU crop. Both need videotoolbox_vld input.
+  const useVtMetalPath = vtSurfaceEligible && !hasCrop;
+  const useVtHwTonemap = vtSurfaceEligible && hasCrop;
+  if (useVtMetalPath || useVtHwTonemap) {
     args.push('-hwaccel_output_format', 'videotoolbox_vld');
   }
 
@@ -694,7 +699,7 @@ function resolveDecodeStage(opts: {
     args.push(...openclTonemapInitArgs());
   }
 
-  return { decodeArgs: args, decoder, useVtMetalPath };
+  return { decodeArgs: args, decoder, useVtMetalPath, useVtHwTonemap };
 }
 
 /**
@@ -978,7 +983,8 @@ export function buildFfmpegArgs(
   // needs to land for encode (qsv-native + vpp_qsv, vaapi + scale_vaapi, CPU +
   // hwdownload). `useVaapiTonemap` / `tonemapPath` / `qsvNativeAvailable` come
   // from resolveEncodePipeline above.
-  const { decodeArgs, decoder, useVtMetalPath } = resolveDecodeStage({
+  const { decodeArgs, decoder, useVtMetalPath, useVtHwTonemap } =
+    resolveDecodeStage({
     sourceVideoCodec,
     qsvNativeAvailable,
     amfFullGpuAvailable,
@@ -1077,7 +1083,8 @@ export function buildFfmpegArgs(
     // decoder (via `-hwaccel_output_format videotoolbox_vld`) to emit
     // IOSurfaces in this particular session. The encoder branches on
     // this to pick scale_vt vs the CPU tonemap chain.
-    inputSurface: useVtMetalPath ? 'videotoolbox' : decoder.outputSurface,
+    inputSurface:
+      useVtMetalPath || useVtHwTonemap ? 'videotoolbox' : decoder.outputSurface,
   };
   args.push(...encoder.buildArgs(encoderInput));
 

--- a/macos/Scripts/build-app.sh
+++ b/macos/Scripts/build-app.sh
@@ -3,8 +3,8 @@
 # Build a self-contained Fliks Server.app bundle with all dependencies.
 #
 # Prerequisites:
-#   1. brew install xcodegen postgresql@18 ffmpeg
-#   2. ./Scripts/fetch-vendored.sh  (for Node.js 24 arm64)
+#   1. brew install xcodegen postgresql@18
+#   2. ./Scripts/fetch-vendored.sh  (Node.js 24 + jellyfin-ffmpeg, arm64)
 #   3. Xcode 16+ with command line tools
 #
 # Usage: ./build-app.sh [--skip-web] [--skip-xcode]
@@ -36,20 +36,21 @@ if [ ! -x "$VENDORED/node/bin/node" ]; then
     exit 1
 fi
 
-for tool in ffmpeg psql; do
-    if ! command -v $tool &>/dev/null; then
-        echo "Error: $tool not found. Run: brew install postgresql@18 ffmpeg"
-        exit 1
-    fi
-done
+if ! command -v psql &>/dev/null; then
+    echo "Error: psql not found. Run: brew install postgresql@18"
+    exit 1
+fi
+if [ ! -x "$VENDORED/ffmpeg/bin/ffmpeg" ]; then
+    echo "Error: Vendored ffmpeg not found. Run ./Scripts/fetch-vendored.sh first."
+    exit 1
+fi
 
 PG_PREFIX="$(brew --prefix postgresql@18)"
-FF_PREFIX="$(brew --prefix ffmpeg)"
 
 echo "==> Build configuration"
 echo "    Node.js:    $VENDORED/node/bin/node ($($VENDORED/node/bin/node --version))"
 echo "    PostgreSQL: $PG_PREFIX ($($PG_PREFIX/bin/postgres --version | awk '{print $NF}'))"
-echo "    FFmpeg:     $FF_PREFIX ($(ffmpeg -version 2>&1 | head -1 | awk '{print $3}'))"
+echo "    FFmpeg:     $VENDORED/ffmpeg/bin/ffmpeg ($("$VENDORED/ffmpeg/bin/ffmpeg" -version 2>&1 | head -1 | awk '{print $3}'))"
 echo ""
 
 # ── Build web apps ──
@@ -156,14 +157,10 @@ if [ -d "$RESOURCES/postgres/lib/postgresql" ]; then
     bash "$SCRIPTS_DIR/bundle-dylibs.sh" "$RESOURCES/postgres/lib/postgresql" "$RESOURCES/postgres/lib"
 fi
 
-# ── FFmpeg (from Homebrew installed, needs dylib bundling) ──
-echo "    [ffmpeg] Copying FFmpeg..."
-mkdir -p "$RESOURCES/ffmpeg/bin" "$RESOURCES/ffmpeg/lib"
-cp "$FF_PREFIX/bin/ffmpeg" "$RESOURCES/ffmpeg/bin/"
-[ -f "$FF_PREFIX/bin/ffprobe" ] && cp "$FF_PREFIX/bin/ffprobe" "$RESOURCES/ffmpeg/bin/"
-
-# Bundle Homebrew dylib dependencies for ffmpeg.
-bash "$SCRIPTS_DIR/bundle-dylibs.sh" "$RESOURCES/ffmpeg/bin" "$RESOURCES/ffmpeg/lib"
+# ── FFmpeg (vendored jellyfin-ffmpeg, statically linked — no dylib fixup) ──
+echo "    [ffmpeg] Copying jellyfin-ffmpeg..."
+mkdir -p "$RESOURCES/ffmpeg/bin"
+cp -R "$VENDORED/ffmpeg/bin/"* "$RESOURCES/ffmpeg/bin/"
 
 # ── Backend ──
 echo "    [backend] Copying NestJS backend..."
@@ -238,6 +235,16 @@ if [ -n "$stray" ]; then
     exit 1
 fi
 echo "    [verify] no bundled binary references /opt/homebrew"
+
+# 3. ffmpeg must have zscale (libzimg) + the VideoToolbox tone-map — the HDR
+#    paths (crop / burn-in / DV) depend on them.
+for filt in zscale tonemap_videotoolbox; do
+    if ! "$RESOURCES/ffmpeg/bin/ffmpeg" -hide_banner -filters 2>/dev/null | grep -qw "$filt"; then
+        echo "Error: bundled ffmpeg is missing the '$filt' filter (expected jellyfin-ffmpeg)."
+        exit 1
+    fi
+done
+echo "    [verify] ffmpeg has zscale + tonemap_videotoolbox"
 
 echo ""
 echo "==> Build complete: $APP_BUNDLE"

--- a/macos/Scripts/fetch-vendored.sh
+++ b/macos/Scripts/fetch-vendored.sh
@@ -17,11 +17,9 @@ mkdir -p "$VENDORED"
 NODE_VERSION="24.2.0"
 PG_VERSION="18"
 ARCH="arm64"
-# jellyfin-ffmpeg (GPL) — same FFmpeg 8.1 base and version as the Linux/Windows
-# servers (unified). Replaces the Homebrew bottle so macOS gets the same
-# libplacebo + HW tonemap filters (tonemap_opencl/videotoolbox with the DV RPU
-# `apply_dovi` path), so Dolby Vision Profile 5 tone-maps correctly instead of
-# rendering green/purple through the stock tonemap. Pin the exact tag.
+# jellyfin-ffmpeg (GPL) — FFmpeg 8.1 base shared with the Linux/Windows servers.
+# The macarm64 build ships VideoToolbox + OpenCL: zscale, tonemap_videotoolbox,
+# and tonemap_opencl (+ apply_dovi for DV P5). No libplacebo/Vulkan on macOS.
 FFMPEG_VERSION="8.1.2-1"
 
 echo "==> Fetching vendored binaries to $VENDORED"


### PR DESCRIPTION
## Two changes

### 1. Actually bundle the vendored jellyfin-ffmpeg (fixes the crop crash)
`fetch-vendored.sh` already downloads **jellyfin-ffmpeg macarm64** into `Vendored/ffmpeg` (from #762), but `build-app.sh` still copied the **Homebrew ffmpeg bottle** — which has no libzimg, so cropped/burn-in HDR crashed on the missing `zscale` filter, and #763's DV-P5 `tonemap_opencl`/`apply_dovi` path had nothing to run on. #762 shipped incomplete (only touched fetch-vendored). Point build-app.sh at the vendored static binary (no dylib bundling) and assert `zscale` + `tonemap_videotoolbox` at build time.

(Corrected the stale "libplacebo" note — the macarm64 build has VideoToolbox + OpenCL + libzimg, **not** libplacebo/Vulkan.)

### 2. Hardware HDR tone-map for cropped playback
VideoToolbox has no crop filter, so a cropped HDR transcode fell back to the full **CPU `zscale`+tonemap** chain. Now route it through **`tonemap_videotoolbox`** on the decoded surface, then `hwdownload` for the cheap CPU crop+scale. The per-pixel tone math runs on the Media Engine:

| chain | speed |
|---|---|
| **tonemap_videotoolbox + CPU crop** | **3.54×** |
| CPU zscale chain | 1.43× |

Burn-in still takes the CPU chain (no VT overlay path wired). Stats overlay now reports `videotoolbox` for cropped HDR (the #766 reporter drops its `!hasCrop` guard).

## Validation
- ✅ jellyfin-ffmpeg macarm64 verified: static, `zscale`+`tonemap_videotoolbox`, 0 external deps.
- ✅ HW crop+tonemap chain proven manually (3.54× vs 1.43×) on the real 2160p HDR file.
- ✅ backend builds; deployed locally for testing.
- ⏳ CI DMG build to confirm the vendored-ffmpeg bundle + `zscale` assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)