### PR TITLE
fix(player-stats): show source resolution in the video header

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -684,21 +684,19 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       : '';
 
     // --- Video label ---
-    // Use profile name from active variant URL (e.g. "360p") instead of raw resolution
+    // The header describes the SOURCE file (resolution + HDR + codec), matching
+    // the panel's `source → output` convention: the "→ Transcodage" line below
+    // carries the output codec/HW and the downscale target. Source dimensions
+    // keep the header stable across pinned-quality and ABR variant switches.
     const active = this.getActiveVariant();
     const urlMatch = active?.originalVideoId?.match(/\/(\d+p)\//);
-    // For a pinned quality (anything but `auto`), trust the selected rung's
-    // label — the native engine's reported variant doesn't always refresh
-    // after a switch on mobile, leaving the resolution line stale. `auto`
-    // still reads the ABR-chosen variant.
     const selectedQualityOpt = this.qualityManager
       .availableQualities()
       .find((q) => q.id === _quality);
-    const resLabel =
-      _quality !== 'auto' && selectedQualityOpt?.label
-        ? selectedQualityOpt.label
-        : (urlMatch?.[1] ??
-          this.qualityManager.resolutionLabel(playingWidth, playingHeight));
+    const resLabel = this.qualityManager.resolutionLabel(
+      src?.width,
+      src?.height,
+    );
     const hdrTag = src?.hdrFormat ? ` ${src.hdrFormat}` : '';
     const codecName = (src?.videoCodec ?? '?').toUpperCase();
     const videoLabel = `${resLabel}${hdrTag} ${codecName}`;


### PR DESCRIPTION
## Problem

In the player **stats overlay** ("statistics for nerds"), the video header line (e.g. `4K HDR10 AV1`) mixed two sources of truth:

- **resolution** came from the selected quality rung / current variant (**output**)
- **HDR** and **codec** came from the source

So the header was misleading whenever a lower rung was pinned or ABR downscaled: a `4K HDR10 AV1` source tone-mapped to SDR could show up as `1080p HDR10 AV1`, claiming HDR10/AV1 at a resolution that isn't the source's — and it's actually SDR after tone-mapping.

## Fix

Derive the header resolution from the **source dimensions** (`pi.source.width/height`) so the header describes the source file consistently: `resolution + HDR + codec`. This matches the panel's existing `source → output` convention — the container line (`MKV → HLS`) and the audio line (`OPUS 7.1 → OPUS 2.0`) already read this way.

Everything about the **output** stays where it belongs:
- output codec / hardware, downscale target (`→ WxH`) and tone-mapping remain on the `→ Transcodage …` lines
- the **current stream bitrate** (`Flux X Mbps`) line is unchanged — it's useful to see the delivered bitrate

As a side benefit, reading source dimensions removes the pinned-rung special-case that existed only to keep the header stable against stale mobile variant reports.

## Verification

- `tsc --noEmit` on the client: clean.
- Display-only derivation change; worth a quick on-device visual confirmation of the overlay (pin a lower quality on a 4K HDR source and check the header still reads the source).