### PR TITLE
fix(player-stats): render 0 dropped frames instead of NaN

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -906,7 +906,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       crop: cropLine,
       tonemapping,
       videoTranscodeReasons,
-      droppedFrames: engineStats?.droppedFrames ?? 0,
+      // Engine stats can read NaN before a quality switch settles; show 0.
+      droppedFrames: Number.isFinite(engineStats?.droppedFrames)
+        ? engineStats!.droppedFrames
+        : 0,
       audioLabel,
       audioStreamBitrate,
       audioDetailLine,


### PR DESCRIPTION
## Problem

In the player stats overlay, switching quality could briefly show **`Images perdues: NaN`** (dropped frames).

The overlay renders the dropped-frame count as a raw number. The engine stats (Shaka, webOS) report `NaN` for a short window right after a quality switch — before the video-playback-quality counters are re-measured. The existing `engineStats?.droppedFrames ?? 0` fallback only catches `null`/`undefined`, so `NaN` leaked straight through.

## Fix

Guard the value with `Number.isFinite` at the single point where the overlay stats are assembled (`player.ts`), so it renders `0` until a real count arrives. This covers every engine at once (Shaka/webOS NaN, plus the engines that already return a literal 0).

This is the only raw number rendered in the overlay — the bitrate lines already go through `validBps`, which excludes `NaN`.

## Verification

- `tsc --noEmit` on the client: clean.