### PR TITLE
fix(tv-select): add pointer/hover affordance and ignore right-click

### DIFF
--- a/client/src/app/shared/directives/tv-select.directive.ts
+++ b/client/src/app/shared/directives/tv-select.directive.ts
@@ -20,6 +20,7 @@ import { SelectPickerService } from '../../core/services/select-picker.service';
 @Directive({
   selector: 'select[appTvSelect]',
   standalone: true,
+  host: { class: 'cursor-pointer transition-colors hover:bg-base-content/10' },
 })
 export class TvSelectDirective {
   private readonly host = inject<ElementRef<HTMLSelectElement>>(ElementRef);
@@ -32,6 +33,9 @@ export class TvSelectDirective {
   @HostListener('keydown.enter', ['$event'])
   @HostListener('keydown.space', ['$event'])
   protected onOpen(e: Event) {
+    // Only the primary (left) button opens the picker — a right/middle click
+    // falls through to the browser's default handling instead of hijacking it.
+    if (e instanceof MouseEvent && e.button !== 0) return;
     e.preventDefault();
     e.stopPropagation();
     this.picker.show(this.host.nativeElement, this.appTvSelect());

--- a/client/src/app/shared/directives/tv-select.directive.ts
+++ b/client/src/app/shared/directives/tv-select.directive.ts
@@ -19,7 +19,6 @@ import { SelectPickerService } from '../../core/services/select-picker.service';
  */
 @Directive({
   selector: 'select[appTvSelect]',
-  standalone: true,
   host: { class: 'cursor-pointer transition-colors hover:bg-base-content/10' },
 })
 export class TvSelectDirective {


### PR DESCRIPTION
## What

The native `<select>`s routed through the custom picker (`appTvSelect`) — audio / video / subtitle track pickers in the media-detail header, plus the library and media-detail modals — read as plain text and mishandled the mouse:

- no pointer cursor (looked non-interactive)
- no hover feedback
- the open gesture is bound to `mousedown` for **every** button, so a **right or middle click opened the picker** instead of falling through to the browser's default.

## Fix

All three are properties of the directive itself (the select behaves like a picker trigger), so they live on `TvSelectDirective` — one source of truth, consistent across every `appTvSelect` select rather than styling a single call site:

- host classes `cursor-pointer transition-colors hover:bg-base-content/10` — pointer cursor + a theme-robust hover tint (the `base-content` overlay lightens on dark themes and darkens on light ones, matching the app's existing convention).
- gate the open handler on the primary button (`e.button !== 0` → return), so right/middle clicks are handled natively.

## Scope

Applies to all 6 `appTvSelect` usages (media-info header ×3, library, and 2 media-detail modals) — deliberately, so the control behaves the same everywhere.

## Verification

- `tsc --noEmit` on the client: clean.
- Frontend-only; visible in the running dev client.