### PR TITLE
fix(desktop): player robustness (teardown, seek, buffering, IPC)

### DIFF
--- a/client/src/app/core/services/playback-engine/desktop-engine.ts
+++ b/client/src/app/core/services/playback-engine/desktop-engine.ts
@@ -94,6 +94,7 @@ export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEng
     _mimeType?: string,
     headers?: Record<string, string>,
   ): Promise<void> {
+    if (this.dead) return;
     this.resetFirstFrame();
     await this.bridge.load({ url, startTime, headers });
     if (this._subtitleStyle) {
@@ -115,6 +116,7 @@ export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEng
   // ── Playback ──
 
   async play(): Promise<void> {
+    if (this.dead) return;
     await this.bridge.play();
     this._paused = false;
   }
@@ -125,6 +127,7 @@ export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEng
   }
 
   async seek(position: number): Promise<void> {
+    if (this.dead) return;
     await this.bridge.seek(position);
     this._currentTime = position;
   }

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1221,6 +1221,12 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
           const { url: nativeUrl, mimeType: nativeMimeType } = this.buildPlayUrl({
             startTime,
           });
+          // Left the view during setup: stop the engine, don't start playback.
+          if (this.destroyed) {
+            await this.engine?.destroy().catch(() => {});
+            this.engine = null;
+            return;
+          }
           await this.engine!.load(nativeUrl, startTime, nativeMimeType, headers);
         } else {
           await this.createShakaEngine();

--- a/desktop/native/compositor/addon.cc
+++ b/desktop/native/compositor/addon.cc
@@ -508,7 +508,15 @@ Napi::Value Start(const Napi::CallbackInfo& info) {
     // comma, so it uses mpv's `%len%` escaping (7 = strlen("4xx,5xx")) to
     // survive the key-value-list parser.
     M::set_option_string(g_state.mpv, "demuxer-lavf-o",
-        "reconnect=1,reconnect_streamed=1,reconnect_on_network_error=1,reconnect_on_http_error=%7%4xx,5xx,reconnect_delay_max=60");
+        "reconnect=1,reconnect_streamed=1,reconnect_on_network_error=1,reconnect_on_http_error=%7%4xx,5xx,reconnect_delay_max=5");
+    // Buffer like the web engine: ~30s forward (cache-secs binds the TIME cap),
+    // ~60s back; the byte cap is a generous ceiling so time binds first.
+    M::set_option_string(g_state.mpv, "cache", "yes");
+    M::set_option_string(g_state.mpv, "cache-secs", "30");
+    M::set_option_string(g_state.mpv, "demuxer-readahead-secs", "30");
+    M::set_option_string(g_state.mpv, "demuxer-max-bytes", "256MiB");
+    M::set_option_string(g_state.mpv, "demuxer-max-back-bytes", "96MiB");
+    M::set_option_string(g_state.mpv, "cache-pause-wait", "1");
     if (M::initialize(g_state.mpv) < 0) fprintf(stderr, "[compositor] mpv_initialize failed\n");
     M::observe_property(g_state.mpv, 1, "time-pos", MPV_FORMAT_DOUBLE);
     M::observe_property(g_state.mpv, 2, "duration", MPV_FORMAT_DOUBLE);

--- a/desktop/native/player_mac/addon.mm
+++ b/desktop/native/player_mac/addon.mm
@@ -524,7 +524,15 @@ Napi::Value Start(const Napi::CallbackInfo& info) {
   // Same on-demand-transcode reconnect policy as the Linux addon (see addon.cc):
   // retry seg-0/init 404s, in-progress 503s and transport-level open failures.
   M::set_option_string(g_state.mpv, "demuxer-lavf-o",
-      "reconnect=1,reconnect_streamed=1,reconnect_on_network_error=1,reconnect_on_http_error=%7%4xx,5xx,reconnect_delay_max=60");
+      "reconnect=1,reconnect_streamed=1,reconnect_on_network_error=1,reconnect_on_http_error=%7%4xx,5xx,reconnect_delay_max=5");
+  // Buffer like the web engine: ~30s forward (cache-secs binds the TIME cap),
+  // ~60s back; the byte cap is a generous ceiling so time binds first.
+  M::set_option_string(g_state.mpv, "cache", "yes");
+  M::set_option_string(g_state.mpv, "cache-secs", "30");
+  M::set_option_string(g_state.mpv, "demuxer-readahead-secs", "30");
+  M::set_option_string(g_state.mpv, "demuxer-max-bytes", "256MiB");
+  M::set_option_string(g_state.mpv, "demuxer-max-back-bytes", "96MiB");
+  M::set_option_string(g_state.mpv, "cache-pause-wait", "1");
   if (M::initialize(g_state.mpv) < 0) fprintf(stderr, "[player-mac] mpv_initialize failed\n");
   M::observe_property(g_state.mpv, 1, "time-pos", MPV_FORMAT_DOUBLE);
   M::observe_property(g_state.mpv, 2, "duration", MPV_FORMAT_DOUBLE);

--- a/desktop/src/main/mpv/mpv-player.ts
+++ b/desktop/src/main/mpv/mpv-player.ts
@@ -292,11 +292,16 @@ export class MpvPlayer extends EventEmitter {
       if (gen !== this.loadGen) return;
     }
     // mpv >= 0.38 loadfile signature is <url> <flags> <index> <options>; the
-    // bundled mpv is recent, so pass index 0 then the options. Append the start
-    // option only when set — an empty options string is otherwise parsed as the
-    // index and mpv rejects it ("invalid parameter").
+    // bundled mpv is recent, so pass index 0 then the options. Omit the options
+    // string when empty — mpv otherwise parses it as the index and rejects it.
+    const fileOpts: string[] = [];
+    if (opts.startTime && opts.startTime > 0) fileOpts.push(`start=${opts.startTime}`);
+    // Force the HLS demuxer for manifests so mpv parses the playlist directly,
+    // skipping the generic probe whose backward seek the linear HTTP stream
+    // can't satisfy.
+    if (/\.m3u8(\?|$)/.test(opts.url)) fileOpts.push('demuxer-lavf-format=hls');
     const cmd: unknown[] = ['loadfile', opts.url, 'replace', 0];
-    if (opts.startTime && opts.startTime > 0) cmd.push(`start=${opts.startTime}`);
+    if (fileOpts.length) cmd.push(fileOpts.join(','));
     await this.command(cmd);
     if (gen !== this.loadGen) return;
     // The persistent mpv keeps its pause state across loads; force playback so a

--- a/desktop/src/main/mpv/mpv-player.ts
+++ b/desktop/src/main/mpv/mpv-player.ts
@@ -94,6 +94,13 @@ export class MpvPlayer extends EventEmitter {
       // mpv's playlist safety check otherwise refuses them on the fallback path.
       '--load-unsafe-playlists=yes',
       '--ytdl=no',
+      // Align buffering with the web (Shaka) engine: ~30s ahead, ~60s behind,
+      // resume after 1s (byte caps approximate mpv's byte-bounded cache).
+      '--cache=yes',
+      '--demuxer-readahead-secs=30',
+      '--demuxer-max-bytes=48MiB',
+      '--demuxer-max-back-bytes=96MiB',
+      '--cache-pause-wait=1',
       // A slow transcode (HDR tonemap re-encode) isn't ready when mpv opens
       // seg-0/init for a stream, so it aborts unless told to reconnect. A
       // separate multi-audio rendition's transcode spins up late and the open

--- a/desktop/src/main/mpv/mpv-player.ts
+++ b/desktop/src/main/mpv/mpv-player.ts
@@ -274,7 +274,13 @@ export class MpvPlayer extends EventEmitter {
 
   async load(opts: DesktopLoadOptions): Promise<void> {
     this.sawFirstFrame = false;
+    this.duration = 0;
+    this.cacheEnd = 0;
     const gen = ++this.loadGen;
+    // Reset the reused player first so the new open's probe can't read atop the
+    // previous file's buffered stream.
+    await this.command(['stop']).catch(() => {});
+    if (gen !== this.loadGen) return;
     // Auth/other headers → the http-header-fields LIST property, set BEFORE
     // loadfile. Don't cram them into the comma-separated loadfile options
     // string — header values contain ',' and ':' that would break that parse.

--- a/desktop/src/main/mpv/mpv-player.ts
+++ b/desktop/src/main/mpv/mpv-player.ts
@@ -94,11 +94,13 @@ export class MpvPlayer extends EventEmitter {
       // mpv's playlist safety check otherwise refuses them on the fallback path.
       '--load-unsafe-playlists=yes',
       '--ytdl=no',
-      // Align buffering with the web (Shaka) engine: ~30s ahead, ~60s behind,
-      // resume after 1s (byte caps approximate mpv's byte-bounded cache).
+      // Buffer like the web (Shaka) engine (~30s fwd / ~60s back / resume 1s).
+      // cache-secs is the binding forward TIME cap — with --cache=yes it else
+      // defaults to ~unlimited and overrides readahead-secs; bytes are a ceiling.
       '--cache=yes',
+      '--cache-secs=30',
       '--demuxer-readahead-secs=30',
-      '--demuxer-max-bytes=48MiB',
+      '--demuxer-max-bytes=256MiB',
       '--demuxer-max-back-bytes=96MiB',
       '--cache-pause-wait=1',
       // A slow transcode (HDR tonemap re-encode) isn't ready when mpv opens
@@ -109,7 +111,7 @@ export class MpvPlayer extends EventEmitter {
       // reconnect_on_http_error. The `4xx,5xx` value carries a comma, so it uses
       // mpv's `%len%` escaping (7 = strlen("4xx,5xx")) to survive the key-value-
       // list parser. Mirrors native/compositor/addon.cc.
-      '--demuxer-lavf-o=reconnect=1,reconnect_streamed=1,reconnect_on_network_error=1,reconnect_on_http_error=%7%4xx,5xx,reconnect_delay_max=60',
+      '--demuxer-lavf-o=reconnect=1,reconnect_streamed=1,reconnect_on_network_error=1,reconnect_on_http_error=%7%4xx,5xx,reconnect_delay_max=5',
       `--input-ipc-server=${this.sockPath}`,
     ];
     console.log('[mpv] spawn:', this.mpvPath, args.join(' '));
@@ -117,6 +119,7 @@ export class MpvPlayer extends EventEmitter {
     this.proc.on('exit', (code) => {
       this.emit('stateChanged', { state: 'idle' });
       this.emit('exit', { code });
+      this.rejectAllPending('mpv process exited');
     });
     this.proc.stderr?.on('data', (d: Buffer) => this.emit('log', d.toString()));
 
@@ -158,7 +161,14 @@ export class MpvPlayer extends EventEmitter {
       sock.once('connect', () => {
         this.sock = sock;
         sock.on('data', (chunk: Buffer) => this.onData(chunk));
-        sock.on('error', (e) => this.emit('error', { code: -1, message: String(e) }));
+        sock.on('error', (e) => {
+          this.emit('error', { code: -1, message: String(e) });
+          this.rejectAllPending(`mpv socket error: ${e}`);
+        });
+        sock.on('close', () => {
+          this.sock = null;
+          this.rejectAllPending('mpv socket closed');
+        });
         resolve();
       });
       sock.once('error', reject);
@@ -265,8 +275,20 @@ export class MpvPlayer extends EventEmitter {
       if (!this.sock) return reject(new Error('mpv socket not connected'));
       const request_id = ++this.reqId;
       this.pending.set(request_id, { resolve, reject });
-      this.sock.write(JSON.stringify({ command, request_id }) + '\n');
+      try {
+        this.sock.write(JSON.stringify({ command, request_id }) + '\n');
+      } catch (e) {
+        this.pending.delete(request_id);
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
     });
+  }
+
+  /** Fail every in-flight command so a socket/process death can't wedge an
+   *  awaiting load/seek invoke forever. */
+  private rejectAllPending(message: string): void {
+    for (const p of this.pending.values()) p.reject(new Error(message));
+    this.pending.clear();
   }
 
   private get(prop: string): Promise<any> {
@@ -288,16 +310,14 @@ export class MpvPlayer extends EventEmitter {
     // previous file's buffered stream.
     await this.command(['stop']).catch(() => {});
     if (gen !== this.loadGen) return;
-    // Auth/other headers → the http-header-fields LIST property, set BEFORE
-    // loadfile. Don't cram them into the comma-separated loadfile options
-    // string — header values contain ',' and ':' that would break that parse.
-    if (opts.headers && Object.keys(opts.headers).length) {
-      await this.set(
-        'http-header-fields',
-        Object.entries(opts.headers).map(([k, v]) => `${k}: ${v}`),
-      );
-      if (gen !== this.loadGen) return;
-    }
+    // Always set http-header-fields (empty list when absent) so this reused
+    // singleton can't inherit a prior load's auth header over the fresh ?token=.
+    // A LIST property, not the loadfile options string (values carry ','/':' ).
+    await this.set(
+      'http-header-fields',
+      opts.headers ? Object.entries(opts.headers).map(([k, v]) => `${k}: ${v}`) : [],
+    );
+    if (gen !== this.loadGen) return;
     // mpv >= 0.38 loadfile signature is <url> <flags> <index> <options>; the
     // bundled mpv is recent, so pass index 0 then the options. Omit the options
     // string when empty — mpv otherwise parses it as the index and rejects it.

--- a/desktop/src/main/mpv/mpv-player.ts
+++ b/desktop/src/main/mpv/mpv-player.ts
@@ -60,6 +60,9 @@ export class MpvPlayer extends EventEmitter {
   private sawFirstFrame = false;
   private duration = 0;
   private cacheEnd = 0;
+  /** Bumped by load/stop/destroy; a load with a stale id skips its remaining
+   *  IPC writes, so a stop can't be overtaken by a trailing loadfile. */
+  private loadGen = 0;
 
   constructor(opts: MpvPlayerOptions) {
     super();
@@ -271,6 +274,7 @@ export class MpvPlayer extends EventEmitter {
 
   async load(opts: DesktopLoadOptions): Promise<void> {
     this.sawFirstFrame = false;
+    const gen = ++this.loadGen;
     // Auth/other headers → the http-header-fields LIST property, set BEFORE
     // loadfile. Don't cram them into the comma-separated loadfile options
     // string — header values contain ',' and ':' that would break that parse.
@@ -279,6 +283,7 @@ export class MpvPlayer extends EventEmitter {
         'http-header-fields',
         Object.entries(opts.headers).map(([k, v]) => `${k}: ${v}`),
       );
+      if (gen !== this.loadGen) return;
     }
     // mpv >= 0.38 loadfile signature is <url> <flags> <index> <options>; the
     // bundled mpv is recent, so pass index 0 then the options. Append the start
@@ -287,12 +292,15 @@ export class MpvPlayer extends EventEmitter {
     const cmd: unknown[] = ['loadfile', opts.url, 'replace', 0];
     if (opts.startTime && opts.startTime > 0) cmd.push(`start=${opts.startTime}`);
     await this.command(cmd);
+    if (gen !== this.loadGen) return;
     // The persistent mpv keeps its pause state across loads; force playback so a
     // freshly opened file always autoplays. The JS side treats this engine like
     // the mobile native player (playWhenReady) and never calls play() itself.
     await this.set('pause', false);
+    if (gen !== this.loadGen) return;
     for (const s of opts.subtitles ?? []) {
       await this.command(['sub-add', s.url, 'auto', s.label ?? '', s.language ?? '']);
+      if (gen !== this.loadGen) return;
     }
   }
 
@@ -309,6 +317,7 @@ export class MpvPlayer extends EventEmitter {
   }
 
   stop(): Promise<void> {
+    this.loadGen++;
     // Reset baselines so the persistent player can't replay a stale first-frame
     // / position into the next session after a back-navigation.
     this.sawFirstFrame = false;
@@ -392,8 +401,13 @@ export class MpvPlayer extends EventEmitter {
   }
 
   async destroy(): Promise<void> {
+    this.loadGen++;
     try {
-      await this.command(['quit']);
+      // mpv may close the socket on quit without replying — cap the wait.
+      await Promise.race([
+        this.command(['quit']),
+        new Promise<void>((resolve) => setTimeout(resolve, 500)),
+      ]);
     } catch {
       /* socket may already be gone */
     }

--- a/desktop/src/main/window/player-session.ts
+++ b/desktop/src/main/window/player-session.ts
@@ -197,7 +197,7 @@ export class PlayerSession {
   }
 
   private forwardEvents(mpv: PlayerBackend): void {
-    mpv.on('log', (s: string) => process.stderr.write(`[mpv] ${s}`));
+    mpv.on('log', (s: string) => process.stderr.write(`[${Date.now()}][mpv] ${s}`));
     mpv.on('exit', (e) => console.error('[mpv] process exit', JSON.stringify(e)));
     mpv.on('stateChanged', (p) => {
       const state = (p as { state?: string }).state;

--- a/desktop/src/main/window/player-session.ts
+++ b/desktop/src/main/window/player-session.ts
@@ -56,12 +56,12 @@ export class PlayerSession {
       height: 800,
       minWidth: 800,
       minHeight: 500,
-      backgroundColor: '#1d232a', // Fliks brand; only seen if videoWin lags
+      backgroundColor: '#000000', // black so a seek-time video gap reads as loading, not a brand flash
       title: 'Fliks',
       ...(iconPath ? { icon: iconPath } : {}),
     });
     await this.frameWin.loadURL(
-      'data:text/html,<body style="margin:0;background:%231d232a"></body>',
+      'data:text/html,<body style="margin:0;background:%23000000"></body>',
     );
 
     this.videoWin = new BrowserWindow({

--- a/desktop/src/main/window/player-session.ts
+++ b/desktop/src/main/window/player-session.ts
@@ -56,12 +56,12 @@ export class PlayerSession {
       height: 800,
       minWidth: 800,
       minHeight: 500,
-      backgroundColor: '#000000', // black so a seek-time video gap reads as loading, not a brand flash
+      backgroundColor: '#1d232a', // brand at startup; set black on first frame so a video gap reads as loading
       title: 'Fliks',
       ...(iconPath ? { icon: iconPath } : {}),
     });
     await this.frameWin.loadURL(
-      'data:text/html,<body style="margin:0;background:%23000000"></body>',
+      'data:text/html,<body style="margin:0;background:transparent"></body>',
     );
 
     this.videoWin = new BrowserWindow({
@@ -213,6 +213,9 @@ export class PlayerSession {
     mpv.on('firstFrame', () => {
       console.log('[player] firstFrame');
       setPlaybackKeepAwake(true);
+      // Now that playback owns the window, paint the frame black: a video gap
+      // (decoder re-init on a seek) then reads as loading, not a brand flash.
+      if (!this.frameWin.isDestroyed()) this.frameWin.setBackgroundColor('#000000');
       this.emit({ type: 'firstFrame' });
     });
     mpv.on('error', (p) => {


### PR DESCRIPTION
Desktop (Electron/mpv) player robustness batch — validated on Windows across the session.

## Included
- **Audio survives close (teardown race)** — Angular `destroyed` guard in `ngAfterViewInit` + `loadGen` token in `MpvPlayer` + `dead` guard in `DesktopEngine`, so a back-navigation during load can't spawn an orphan engine or let a stale load autoplay.
- **`unrecognized file format` at open** — force `demuxer-lavf-format=hls` per-load for `.m3u8` URLs, so mpv parses the manifest directly instead of the generic probe that rewinds a non-seekable HTTP stream. **On-device confirmed.**
- **Reset mpv before each load** — clean `stop` before `loadfile` so the reused singleton doesn't probe atop the previous file's buffered stream.
- **Time-bound buffering** — `--cache-secs=30` (the binding forward time cap; `--cache=yes` otherwise makes `readahead-secs` inert and over-buffers), `--demuxer-max-bytes=256MiB` as a ceiling. Mirrored in the Linux/macOS addons.
- **Reconnect** — `reconnect_delay_max` 60→5 so a stuck segment fails fast (60s outlived the client's 32s stall watchdog). All three backends.
- **Header leak** — always set `http-header-fields` (empty when absent) so a reused singleton can't leak a prior `Authorization` over the refreshed `?token=`.
- **Socket robustness** — reject all in-flight commands on socket error/close + process exit, guard `sock.write`, so a dead mpv can't wedge an awaiting invoke.
- **Player window** — brand background at startup, black on first frame (a seek-time video gap reads as loading, not a brand flash); black player gap is consistent across Win/mac (PlayerSession) and Linux (compositor already clears black).
- Timestamped `[mpv]` log lines (seek-latency diagnosis).

## Verification
- `tsc --noEmit` + esbuild bundle: clean. Linux compositor addon recompiles (node-gyp). macOS addon change is an exact mirror of the Linux one.
- The far-seek slow/reload issue (multi-audio EXT-X-MEDIA cursor asymmetry) is tracked separately — its structural fix (muxed desktop rendition) lands in a follow-up branch.