### PR TITLE
feat(desktop): offline downloads played back via mpv

### DIFF
--- a/client/src/app/core/plugins/desktop-bridge.d.ts
+++ b/client/src/app/core/plugins/desktop-bridge.d.ts
@@ -1,4 +1,5 @@
 import type { FliksDesktopApi } from './desktop-player.bridge';
+import type { FliksDownloaderApi } from './desktop-downloader.bridge';
 
 // Ambient `Window.fliksDesktop` augmentation. Kept in a `.d.ts` (matched by
 // every tsconfig's `src/**/*.d.ts` include) so the global type is visible to
@@ -8,5 +9,7 @@ declare global {
   interface Window {
     /** Injected by the Electron desktop preload; absent in browser / native. */
     fliksDesktop?: FliksDesktopApi;
+    /** Offline-download bridge; injected by the Electron desktop preload. */
+    fliksDownloader?: FliksDownloaderApi;
   }
 }

--- a/client/src/app/core/plugins/desktop-downloader.bridge.ts
+++ b/client/src/app/core/plugins/desktop-downloader.bridge.ts
@@ -1,0 +1,48 @@
+// Bridge to the Electron desktop shell's offline-download service, exposed on
+// `window.fliksDownloader` by the desktop preload. Types mirror
+// desktop/src/shared/contract.ts — the two live in separate build workspaces,
+// so the shape is intentionally duplicated here.
+
+export interface DesktopDownloadRequest {
+  id: string;
+  url: string;
+  filename?: string;
+  quality?: string;
+}
+
+export interface DesktopDownloadItem {
+  id: string;
+  filename: string;
+  path: string;
+  size: number;
+  received: number;
+  complete: boolean;
+}
+
+export type DesktopDownloadStatus =
+  | { id: string; state: 'progress'; received: number; total: number }
+  | { id: string; state: 'done'; item: DesktopDownloadItem }
+  | { id: string; state: 'error'; message: string };
+
+export interface FliksDownloaderApi {
+  start(req: DesktopDownloadRequest): Promise<void>;
+  cancel(id: string): Promise<void>;
+  remove(id: string): Promise<void>;
+  list(): Promise<DesktopDownloadItem[]>;
+  getLocalUrl(id: string): Promise<string | null>;
+  saveFile(key: string, url: string): Promise<boolean>;
+  fileUrl(key: string): Promise<string | null>;
+  deleteFile(key: string): Promise<void>;
+  onStatus(handler: (status: DesktopDownloadStatus) => void): () => void;
+}
+
+declare global {
+  interface Window {
+    fliksDownloader?: FliksDownloaderApi;
+  }
+}
+
+/** The desktop downloader bridge, or null when not running in the Electron shell. */
+export function desktopDownloaderOrNull(): FliksDownloaderApi | null {
+  return typeof window !== 'undefined' ? (window.fliksDownloader ?? null) : null;
+}

--- a/client/src/app/core/services/auto-download.service.ts
+++ b/client/src/app/core/services/auto-download.service.ts
@@ -2,6 +2,7 @@ import { Injectable, effect, inject } from '@angular/core';
 import { Capacitor } from '@capacitor/core';
 import { AuthService } from './auth.service';
 import { TvService } from './tv.service';
+import { desktopDownloaderOrNull } from '../plugins/desktop-downloader.bridge';
 import { AppResumeService } from './app-resume.service';
 import { DownloadManagerService } from './download-manager.service';
 import { DownloadCacheService, DownloadTask } from './download-cache.service';
@@ -25,15 +26,17 @@ interface AutoTarget {
 
 /**
  * Syncs offline downloads with the user's autoDownload playlists (native mobile
- * only — never on TV or web). Downloads not-yet-watched items that aren't on
- * device and removes auto-managed downloads once watched; manual downloads are
- * never touched.
+ * and the Electron desktop — never on TV or web). Downloads not-yet-watched
+ * items that aren't on device and removes auto-managed downloads once watched;
+ * manual downloads are never touched.
  */
 @Injectable({ providedIn: 'root' })
 export class AutoDownloadService {
-  /** True only on native mobile (iOS/Android). Also gates the settings toggle. */
+  /** True on native mobile (iOS/Android) and the Electron desktop, where an
+   *  offline backend exists. Also gates the settings toggle. */
   readonly enabled =
-    Capacitor.isNativePlatform() && !inject(TvService).isTv();
+    (Capacitor.isNativePlatform() || !!desktopDownloaderOrNull()) &&
+    !inject(TvService).isTv();
   private readonly auth = inject(AuthService);
   private readonly appResume = inject(AppResumeService);
   private readonly downloads = inject(DownloadManagerService);

--- a/client/src/app/core/services/download-manager.service.ts
+++ b/client/src/app/core/services/download-manager.service.ts
@@ -168,6 +168,17 @@ export class DownloadManagerService {
       media: { id: meta?.mediaId ?? 0, title, posterUrl: meta?.posterUrl ?? null, type: meta?.type ?? '' },
     };
 
+    // Desktop keeps a single offline copy per file (the disk key + status
+    // events are keyed by mediaFileId), so a new download replaces any prior
+    // one for the same file instead of colliding with it.
+    if (this.isDesktop) {
+      for (const prev of this.cache
+        .load()
+        .filter((t) => t.mediaFileId === mediaFileId)) {
+        await this.deleteDownload(prev);
+      }
+    }
+
     // Hydrate a fresh long-lived stream JWT before we bake the URL +
     // header into the native download daemon — downloads can run for
     // hours so we can't rely on the 1h access token.

--- a/client/src/app/core/services/download-manager.service.ts
+++ b/client/src/app/core/services/download-manager.service.ts
@@ -11,6 +11,10 @@ import { AuthService } from './auth.service';
 import { BrowserDeviceProfileService } from './browser-device-profile.service';
 import { TranslateService } from '@ngx-translate/core';
 import { formatSubtitleLabel } from '../utils/player.utils';
+import {
+  desktopDownloaderOrNull,
+  type DesktopDownloadStatus,
+} from '../plugins/desktop-downloader.bridge';
 
 export interface DownloadEvent {
   type: 'progress' | 'ready' | 'failed' | 'complete';
@@ -35,6 +39,11 @@ export interface DownloadEvent {
 @Injectable({ providedIn: 'root' })
 export class DownloadManagerService {
   private readonly isNative = Capacitor.isNativePlatform();
+  /** Electron desktop backend: download the original file to disk, play via mpv. */
+  private readonly downloader = desktopDownloaderOrNull();
+  private get isDesktop(): boolean {
+    return !!this.downloader;
+  }
   private readonly streamingApi = inject(StreamingApiService);
   private readonly subtitlesApi = inject(SubtitlesApiService);
   private readonly mediaService = inject(MediaService);
@@ -103,6 +112,29 @@ export class DownloadManagerService {
     window.addEventListener('online', () => {
       if (this.recovered) void this.recover();
     });
+    this.downloader?.onStatus((s) => this.onDesktopStatus(s));
+  }
+
+  /** Map a desktop (Electron) download status event onto the cache task keyed
+   *  by mediaFileId. Progress drives the badge; done pre-fetches subtitles. */
+  private onDesktopStatus(s: DesktopDownloadStatus): void {
+    const mfid = Number(s.id);
+    const task = this.cache
+      .load()
+      .find((t) => t.mediaFileId === mfid && t.status !== 'ready' && t.status !== 'failed');
+    if (!task) return;
+    if (s.state === 'progress') {
+      const pct = s.total > 0 ? Math.round((s.received / s.total) * 100) : 0;
+      this.cache.updateProgress(task.id, pct);
+      this.emitEvent('progress', task.id, pct, 'downloading');
+    } else if (s.state === 'done') {
+      this.updateTaskStatus(task.id, 'ready', 100);
+      this.emitEvent('complete', task.id, 100);
+      void this.preDownloadSubtitles(task.id);
+    } else {
+      this.updateTaskStatus(task.id, 'failed', 0);
+      this.emitEvent('failed', task.id, 0);
+    }
   }
 
   // ===== PUBLIC API =====
@@ -141,6 +173,23 @@ export class DownloadManagerService {
     // hours so we can't rely on the 1h access token.
     await this.auth.ensureStreamToken();
 
+    // Desktop (Electron), original: fetch the untouched container straight to
+    // disk and play it offline via mpv (full codec coverage). No HLS session —
+    // the raw ?download=1 route streams the file with Range support.
+    if (this.isDesktop && quality === 'original') {
+      const url = this.streamingApi.getOriginalDownloadUrl(mediaFileId);
+      task.hlsUrl = url;
+      this.titles.set(taskId, { title, episode });
+      this.persistTask(task);
+      void this.downloader!.start({
+        id: String(mediaFileId),
+        url,
+        filename: episode ? `${title} - ${episode}` : title,
+      });
+      this.emitEvent('progress', taskId, 0, 'downloading');
+      return task;
+    }
+
     // Establish a live session the way playback does: the HLS segment routes
     // resolve the codec variant off the session via ?sid= and reject (410)
     // any segment request that can't resolve one. Thread the returned sid
@@ -165,7 +214,17 @@ export class DownloadManagerService {
     this.titles.set(taskId, { title, episode });
     this.persistTask(task);
 
-    if (this.isNative) {
+    if (this.isDesktop) {
+      // Desktop, transcoded rung: mirror the HLS bundle to disk and play it
+      // offline via mpv (the local master.m3u8) — like the native offline flow.
+      void this.downloader!.start({
+        id: String(mediaFileId),
+        url: hlsUrl,
+        quality,
+        filename: episode ? `${title} - ${episode}` : title,
+      });
+      this.emitEvent('progress', taskId, 0, 'downloading');
+    } else if (this.isNative) {
       const token =
         this.auth.streamToken() ?? this.auth.accessToken ?? '';
       // Pre-translated banner copy for the iOS completion/failure notification
@@ -369,6 +428,17 @@ export class DownloadManagerService {
     }
 
     for (const t of tasks) {
+      if (this.isDesktop) {
+        // Reconcile against the on-disk manifest: a file that survived is ready;
+        // an interrupted download (no file) is failed so the user can retry.
+        const hasLocal = await this.storage.has(`download-${t.mediaFileId}`);
+        if (hasLocal) {
+          if (t.status !== 'ready') this.updateTaskStatus(t.id, 'ready', 100);
+        } else if (onStartup && t.status !== 'ready') {
+          this.updateTaskStatus(t.id, 'failed', 0);
+        }
+        continue;
+      }
       if (t.status === 'ready') {
         // Native: trust localStorage — ExoPlayer's SimpleCache persists across
         // restarts and querying DownloadIndex has timing issues.

--- a/client/src/app/core/services/offline-storage.service.ts
+++ b/client/src/app/core/services/offline-storage.service.ts
@@ -3,6 +3,7 @@ import { Capacitor } from '@capacitor/core';
 import { AuthService } from './auth.service';
 import { DownloadNotificationService } from './download-notification.service';
 import { DownloadCacheService } from './download-cache.service';
+import { desktopDownloaderOrNull } from '../plugins/desktop-downloader.bridge';
 
 const CACHE_NAME = 'offline-media';
 
@@ -35,6 +36,15 @@ export class OfflineStorageService {
   private readonly auth = inject(AuthService);
   private readonly notif = inject(DownloadNotificationService);
   private readonly cache = inject(DownloadCacheService);
+  /** Electron desktop offline backend: files on disk, played back via mpv. */
+  private readonly downloader = desktopDownloaderOrNull();
+  private get isDesktop(): boolean {
+    return !!this.downloader;
+  }
+
+  private mfidFromKey(key: string): string {
+    return key.replace('download-', '');
+  }
 
   /** Per (server, user) key for the Shaka offline URI map. */
   private shakaKey(): string {
@@ -42,6 +52,9 @@ export class OfflineStorageService {
   }
 
   async getLocalUrl(key: string): Promise<string | null> {
+    if (this.isDesktop) {
+      return this.downloader!.getLocalUrl(this.mfidFromKey(key));
+    }
     if (this.isNative) {
       return this.getNativeOfflineUrl(key);
     }
@@ -202,6 +215,7 @@ export class OfflineStorageService {
   }
 
   async delete(key: string): Promise<void> {
+    if (this.isDesktop) return this.downloader!.remove(this.mfidFromKey(key));
     if (this.isNative) return this.deleteNative(key);
     // Web: remove Shaka offline content
     const mfid = Number(key.replace('download-', ''));
@@ -215,6 +229,7 @@ export class OfflineStorageService {
    * playback points the native player at a non-existent file and renders nothing.
    */
   async downloadSmallFile(url: string, key: string): Promise<boolean> {
+    if (this.isDesktop) return this.downloader!.saveFile(key, url);
     try {
       // Downloads can finish hours after the 1h access token was minted, so
       // authenticate with the long-lived stream token (same token baked into
@@ -248,6 +263,7 @@ export class OfflineStorageService {
 
   /** Remove a stored VTT subtitle (counterpart to {@link downloadSmallFile}). */
   async deleteSmallFile(key: string): Promise<void> {
+    if (this.isDesktop) return this.downloader!.deleteFile(key);
     try {
       if (this.isNative) {
         const { Filesystem, Directory } = await getFs();
@@ -264,6 +280,7 @@ export class OfflineStorageService {
 
   /** Get small file content as text (for VTT). */
   async getSmallFileUrl(key: string): Promise<string | null> {
+    if (this.isDesktop) return this.downloader!.fileUrl(key);
     if (this.isNative) {
       try {
         const { Filesystem, Directory } = await getFs();
@@ -290,8 +307,9 @@ export class OfflineStorageService {
     }
   }
 
-  /** Get native file URI for a small file (for ExoPlayer — not a blob URL). */
+  /** Get native file URI for a small file (for ExoPlayer / mpv — not a blob URL). */
   async getSmallFileNativeUri(key: string): Promise<string | null> {
+    if (this.isDesktop) return this.downloader!.fileUrl(key);
     if (!this.isNative) return this.getSmallFileUrl(key);
     try {
       const { Filesystem, Directory } = await getFs();
@@ -310,6 +328,7 @@ export class OfflineStorageService {
   }
 
   async has(key: string): Promise<boolean> {
+    if (this.isDesktop) return (await this.downloader!.getLocalUrl(this.mfidFromKey(key))) !== null;
     if (this.isNative) {
       // Native offline content — resolve via the platform-specific path.
       return (await this.getNativeOfflineUrl(key)) !== null;

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1063,7 +1063,13 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         this.state.playbackMode.set('direct');
         this.qualityManager.availableQualities.set([]);
 
-        if (this.isNative) {
+        if (this.isDesktopNative) {
+          // Desktop: the original container lives on disk; mpv plays it back
+          // offline (file://) with full codec coverage + embedded tracks.
+          await this.createDesktopEngine();
+          await this.engine!.load(offlineCheck!, startTime);
+          await this.loadOfflineSubtitles();
+        } else if (this.isNative) {
           // Android: ExoPlayer with CacheDataSource (offline HLS from cache)
           await this.createNativeEngine();
           (this.engine as NativeEngine).setOffline(true);

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1629,9 +1629,18 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     engine.on('audioTracksChanged', (e) => {
       // Cross-reference engine tracks with streamInfo.audio so the dropdown
       // label matches what the media-detail header shows. Engine emits tracks
-      // in streamInfo order.
-      const file = this.media?.files?.find((f: any) => f.id === this.mediaFileId);
-      const audioList = (file?.streamInfo as any)?.audio ?? [];
+      // in streamInfo order. Offline there's no media loaded, so fall back to
+      // the audio metadata captured on the download task at download time.
+      let audioList: { language?: string }[];
+      if (this.isOfflinePlayback) {
+        const task = this.dlCache
+          .load()
+          .find((t) => t.mediaFileId === this.mediaFileId && t.status === 'ready');
+        audioList = task?.audioStreams ?? [];
+      } else {
+        const file = this.media?.files?.find((f: any) => f.id === this.mediaFileId);
+        audioList = (file?.streamInfo as any)?.audio ?? [];
+      }
       const tracks = e.tracks.map((t: any, i: number) => ({
         id: t.id,
         label: audioList[i] ? formatAudioLabel(audioList[i], this.translate, i + 1) : t.label,

--- a/client/src/app/shared/components/download-quality-modal/download-quality-modal.ts
+++ b/client/src/app/shared/components/download-quality-modal/download-quality-modal.ts
@@ -87,8 +87,8 @@ export class DownloadQualityModalComponent {
   /** Original-file download is a browser save-to-disk — hidden on native,
    *  which uses the ExoPlayer/AVAsset offline pipeline instead. */
   readonly isNative = Capacitor.isNativePlatform();
-  /** Desktop (Electron) downloads the original file to disk via the shell, so
-   *  the transcoded quality rungs don't apply — only the original is offered. */
+  /** Desktop (Electron) offers the same quality rungs; the original-file option
+   *  routes through the shell's download-to-disk path rather than a browser save. */
   readonly isDesktop = !!desktopDownloaderOrNull();
 
   @ViewChild('dialog') dialogRef!: ElementRef<HTMLDialogElement>;

--- a/client/src/app/shared/components/download-quality-modal/download-quality-modal.ts
+++ b/client/src/app/shared/components/download-quality-modal/download-quality-modal.ts
@@ -15,6 +15,7 @@ import {
   DownloadQuality,
 } from '../../../core/services/api/streaming-api.service';
 import { AuthService } from '../../../core/services/auth.service';
+import { desktopDownloaderOrNull } from '../../../core/plugins/desktop-downloader.bridge';
 import { LucideDownload, LucideX } from '@lucide/angular';
 
 @Component({
@@ -86,6 +87,9 @@ export class DownloadQualityModalComponent {
   /** Original-file download is a browser save-to-disk — hidden on native,
    *  which uses the ExoPlayer/AVAsset offline pipeline instead. */
   readonly isNative = Capacitor.isNativePlatform();
+  /** Desktop (Electron) downloads the original file to disk via the shell, so
+   *  the transcoded quality rungs don't apply — only the original is offered. */
+  readonly isDesktop = !!desktopDownloaderOrNull();
 
   @ViewChild('dialog') dialogRef!: ElementRef<HTMLDialogElement>;
 
@@ -121,6 +125,12 @@ export class DownloadQualityModalComponent {
    *  Mint a long-lived stream token first: the file can be several GB and a
    *  1h access token would expire on a resumed range request mid-download. */
   async downloadOriginal() {
+    // Desktop: route the original through the Electron download-to-disk path
+    // (the browser <a> save doesn't reliably attach in the Electron shell).
+    if (this.isDesktop) {
+      this.selectQuality('original');
+      return;
+    }
     await this.auth.ensureStreamToken();
     const url = this.streamingApi.getOriginalDownloadUrl(this.mediaFileId);
     const a = document.createElement('a');

--- a/desktop/src/main/download.ts
+++ b/desktop/src/main/download.ts
@@ -1,0 +1,295 @@
+import { app, BrowserWindow, ipcMain, net } from 'electron';
+import { createWriteStream, existsSync, promises as fsp } from 'node:fs';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { pathToFileURL } from 'node:url';
+import {
+  DOWNLOAD_IPC,
+  type DesktopDownloadItem,
+  type DesktopDownloadRequest,
+  type DesktopDownloadStatus,
+} from '../shared/contract';
+import { mirrorHls } from './hls-mirror';
+
+// Offline downloads for the desktop client: fetch a media file to disk under
+// userData and hand mpv a local file:// URL on playback. Sidecar subtitle files
+// are fetched the same way (mpv can only sub-add a real path, not a blob URL).
+// The download URL already carries the ?token= stream JWT, and net.request goes
+// out on the default session (self-signed certs accepted app-wide).
+
+const PROGRESS_MIN_INTERVAL_MS = 400;
+
+type Manifest = Record<string, DesktopDownloadItem>;
+
+function baseDir(): string {
+  return path.join(app.getPath('userData'), 'downloads');
+}
+function filesDir(): string {
+  return path.join(baseDir(), 'files');
+}
+function manifestPath(): string {
+  return path.join(baseDir(), 'manifest.json');
+}
+/** Collapse anything that isn't a safe filename char so ids/keys with slashes
+ *  or query junk can't escape the downloads dir. */
+function safe(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+let manifest: Manifest | null = null;
+const active = new Map<string, Electron.ClientRequest>();
+const hlsActive = new Map<string, { cancelled: boolean }>();
+
+async function loadManifest(): Promise<Manifest> {
+  if (manifest) return manifest;
+  try {
+    manifest = JSON.parse(await fsp.readFile(manifestPath(), 'utf8')) as Manifest;
+  } catch {
+    manifest = {};
+  }
+  return manifest;
+}
+async function saveManifest(): Promise<void> {
+  await fsp.mkdir(baseDir(), { recursive: true });
+  await fsp.writeFile(manifestPath(), JSON.stringify(manifest ?? {}));
+}
+
+function broadcast(status: DesktopDownloadStatus): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) win.webContents.send(DOWNLOAD_IPC.status, status);
+  }
+}
+
+/** Extension for the on-disk file, from Content-Disposition then Content-Type. */
+function resolveExt(headers: Record<string, string | string[]>): string {
+  const cd = headers['content-disposition'];
+  const disp = Array.isArray(cd) ? cd[0] : cd;
+  if (disp) {
+    const m = /filename\*?=(?:UTF-8'')?"?([^";]+)"?/i.exec(disp);
+    const ext = m ? path.extname(decodeURIComponent(m[1].trim())) : '';
+    if (ext) return ext;
+  }
+  const ct = headers['content-type'];
+  const type = (Array.isArray(ct) ? ct[0] : ct)?.split(';')[0].trim();
+  const map: Record<string, string> = {
+    'video/x-matroska': '.mkv',
+    'video/mp4': '.mp4',
+    'video/quicktime': '.mov',
+    'video/x-msvideo': '.avi',
+    'video/mp2t': '.ts',
+    'video/webm': '.webm',
+  };
+  return (type && map[type]) || '.bin';
+}
+
+function cleanup(tmpPath: string): void {
+  fsp.rm(tmpPath, { force: true }).catch(() => {});
+}
+
+async function start(req: DesktopDownloadRequest): Promise<void> {
+  const m = await loadManifest();
+  const done = m[req.id];
+  if (done?.complete && existsSync(done.path)) {
+    broadcast({ id: req.id, state: 'done', item: done });
+    return;
+  }
+  if (active.has(req.id) || hlsActive.has(req.id)) return; // already downloading
+
+  await fsp.mkdir(baseDir(), { recursive: true });
+
+  // A .m3u8 source is a transcoded stream — mirror the HLS bundle to disk.
+  if (/\.m3u8(\?|$)/i.test(req.url)) {
+    await startHls(req);
+    return;
+  }
+
+  const tmpPath = path.join(baseDir(), `${safe(req.id)}.part`);
+  const request = net.request({ url: req.url, method: 'GET' });
+  active.set(req.id, request);
+
+  request.on('response', (res) => {
+    // Electron's net IncomingMessage is a Readable at runtime; its types omit
+    // the stream methods, so read status/headers off `res` and stream via `body`.
+    const body = res as unknown as Readable;
+    if ((res.statusCode ?? 0) >= 400) {
+      active.delete(req.id);
+      broadcast({ id: req.id, state: 'error', message: `HTTP ${res.statusCode}` });
+      body.resume();
+      return;
+    }
+    const headers = res.headers as Record<string, string | string[]>;
+    const total = Number((Array.isArray(headers['content-length']) ? headers['content-length'][0] : headers['content-length']) ?? 0);
+    const ext = resolveExt(headers);
+    const finalPath = path.join(baseDir(), `${safe(req.id)}${ext}`);
+    const out = createWriteStream(tmpPath);
+    let received = 0;
+    let lastEmit = 0;
+
+    const fail = (message: string): void => {
+      active.delete(req.id);
+      out.destroy();
+      cleanup(tmpPath);
+      broadcast({ id: req.id, state: 'error', message });
+    };
+    out.on('error', (e) => fail(e.message));
+
+    body.on('data', (chunk: Buffer) => {
+      received += chunk.length;
+      if (!out.write(chunk)) body.pause();
+      const now = Date.now();
+      if (now - lastEmit >= PROGRESS_MIN_INTERVAL_MS) {
+        lastEmit = now;
+        broadcast({ id: req.id, state: 'progress', received, total });
+      }
+    });
+    out.on('drain', () => body.resume());
+    body.on('error', (e: Error) => fail(e.message));
+    body.on('end', () => {
+      out.end(async () => {
+        try {
+          await fsp.rename(tmpPath, finalPath);
+          const item: DesktopDownloadItem = {
+            id: req.id,
+            filename: req.filename ?? path.basename(finalPath),
+            path: finalPath,
+            size: received,
+            received,
+            complete: true,
+          };
+          (await loadManifest())[req.id] = item;
+          await saveManifest();
+          active.delete(req.id);
+          broadcast({ id: req.id, state: 'done', item });
+        } catch (e) {
+          fail((e as Error).message);
+        }
+      });
+    });
+  });
+  request.on('error', (e) => {
+    active.delete(req.id);
+    cleanup(tmpPath);
+    broadcast({ id: req.id, state: 'error', message: e.message });
+  });
+  request.end();
+}
+
+/** Mirror a transcoded HLS stream to a per-id directory; the manifest points at
+ *  the local master.m3u8 so playback loads it via mpv (file://). */
+async function startHls(req: DesktopDownloadRequest): Promise<void> {
+  const destDir = path.join(baseDir(), safe(req.id));
+  await fsp.rm(destDir, { recursive: true, force: true }).catch(() => {});
+  const control = { cancelled: false };
+  hlsActive.set(req.id, control);
+  let lastEmit = 0;
+  try {
+    const masterPath = await mirrorHls({
+      masterUrl: req.url,
+      quality: req.quality,
+      destDir,
+      cancelled: () => control.cancelled,
+      onProgress: (received, total) => {
+        const now = Date.now();
+        if (now - lastEmit >= PROGRESS_MIN_INTERVAL_MS || received === total) {
+          lastEmit = now;
+          broadcast({ id: req.id, state: 'progress', received, total });
+        }
+      },
+    });
+    const item: DesktopDownloadItem = {
+      id: req.id,
+      filename: req.filename ?? req.id,
+      path: masterPath,
+      size: 0,
+      received: 0,
+      complete: true,
+    };
+    (await loadManifest())[req.id] = item;
+    await saveManifest();
+    broadcast({ id: req.id, state: 'done', item });
+  } catch (e) {
+    await fsp.rm(destDir, { recursive: true, force: true }).catch(() => {});
+    if (!control.cancelled) {
+      broadcast({ id: req.id, state: 'error', message: (e as Error).message });
+    }
+  } finally {
+    hlsActive.delete(req.id);
+  }
+}
+
+async function cancel(id: string): Promise<void> {
+  const hls = hlsActive.get(id);
+  if (hls) hls.cancelled = true;
+  const request = active.get(id);
+  if (request) {
+    active.delete(id);
+    request.abort();
+  }
+  cleanup(path.join(baseDir(), `${safe(id)}.part`));
+}
+
+async function remove(id: string): Promise<void> {
+  await cancel(id);
+  const m = await loadManifest();
+  const item = m[id];
+  if (item) {
+    await fsp.rm(item.path, { force: true }).catch(() => {});
+    delete m[id];
+    await saveManifest();
+  }
+  // An HLS download lives in a per-id directory alongside the manifest entry.
+  await fsp.rm(path.join(baseDir(), safe(id)), { recursive: true, force: true }).catch(() => {});
+}
+
+async function getLocalUrl(id: string): Promise<string | null> {
+  const item = (await loadManifest())[id];
+  if (item?.complete && existsSync(item.path)) {
+    return pathToFileURL(item.path).toString();
+  }
+  return null;
+}
+
+/** Fetch a small sidecar file (VTT) to disk under `key`. */
+async function saveFile(key: string, url: string): Promise<boolean> {
+  await fsp.mkdir(filesDir(), { recursive: true });
+  const dest = path.join(filesDir(), safe(key));
+  return new Promise<boolean>((resolve) => {
+    const request = net.request({ url, method: 'GET' });
+    request.on('response', (res) => {
+      const body = res as unknown as Readable;
+      if ((res.statusCode ?? 0) >= 400) {
+        body.resume();
+        resolve(false);
+        return;
+      }
+      const out = createWriteStream(dest);
+      out.on('error', () => resolve(false));
+      body.on('error', () => resolve(false));
+      body.pipe(out);
+      out.on('finish', () => resolve(true));
+    });
+    request.on('error', () => resolve(false));
+    request.end();
+  });
+}
+
+async function fileUrl(key: string): Promise<string | null> {
+  const p = path.join(filesDir(), safe(key));
+  return existsSync(p) ? pathToFileURL(p).toString() : null;
+}
+
+async function deleteFile(key: string): Promise<void> {
+  await fsp.rm(path.join(filesDir(), safe(key)), { force: true }).catch(() => {});
+}
+
+/** Wire the renderer→main download channels. Registered once on app ready. */
+export function registerDownloadIpc(): void {
+  ipcMain.handle(DOWNLOAD_IPC.start, (_e, req: DesktopDownloadRequest) => start(req));
+  ipcMain.handle(DOWNLOAD_IPC.cancel, (_e, id: string) => cancel(id));
+  ipcMain.handle(DOWNLOAD_IPC.remove, (_e, id: string) => remove(id));
+  ipcMain.handle(DOWNLOAD_IPC.list, async () => Object.values(await loadManifest()));
+  ipcMain.handle(DOWNLOAD_IPC.getLocalUrl, (_e, id: string) => getLocalUrl(id));
+  ipcMain.handle(DOWNLOAD_IPC.saveFile, (_e, key: string, url: string) => saveFile(key, url));
+  ipcMain.handle(DOWNLOAD_IPC.fileUrl, (_e, key: string) => fileUrl(key));
+  ipcMain.handle(DOWNLOAD_IPC.deleteFile, (_e, key: string) => deleteFile(key));
+}

--- a/desktop/src/main/download.ts
+++ b/desktop/src/main/download.ts
@@ -30,15 +30,18 @@ function filesDir(): string {
 function manifestPath(): string {
   return path.join(baseDir(), 'manifest.json');
 }
-/** Collapse anything that isn't a safe filename char so ids/keys with slashes
- *  or query junk can't escape the downloads dir. */
+/** Collapse anything that isn't a safe filename char to a single flat segment,
+ *  so an id/key can never resolve outside the downloads dir. `.` is excluded
+ *  from the allowed set too — otherwise `.`/`..` would pass through and
+ *  `path.join(baseDir(), '..')` would escape to userData. */
 function safe(name: string): string {
-  return name.replace(/[^a-zA-Z0-9._-]/g, '_');
+  return name.replace(/[^a-zA-Z0-9_-]/g, '_') || '_';
 }
 
 let manifest: Manifest | null = null;
-const active = new Map<string, Electron.ClientRequest>();
-const hlsActive = new Map<string, { cancelled: boolean }>();
+/** id → abort: tears down the in-flight single-file request + its write stream. */
+const active = new Map<string, () => void>();
+const hlsActive = new Map<string, { cancelled: boolean; abort?: () => void }>();
 
 async function loadManifest(): Promise<Manifest> {
   if (manifest) return manifest;
@@ -51,7 +54,10 @@ async function loadManifest(): Promise<Manifest> {
 }
 async function saveManifest(): Promise<void> {
   await fsp.mkdir(baseDir(), { recursive: true });
-  await fsp.writeFile(manifestPath(), JSON.stringify(manifest ?? {}));
+  // Write-then-rename so a concurrent finish can't observe a truncated file.
+  const tmp = `${manifestPath()}.tmp`;
+  await fsp.writeFile(tmp, JSON.stringify(manifest ?? {}));
+  await fsp.rename(tmp, manifestPath());
 }
 
 function broadcast(status: DesktopDownloadStatus): void {
@@ -105,7 +111,18 @@ async function start(req: DesktopDownloadRequest): Promise<void> {
 
   const tmpPath = path.join(baseDir(), `${safe(req.id)}.part`);
   const request = net.request({ url: req.url, method: 'GET' });
-  active.set(req.id, request);
+  let out: ReturnType<typeof createWriteStream> | null = null;
+  // Cancel = abort the request AND destroy the write stream (aborting the net
+  // request doesn't necessarily surface as a body 'error'), then drop the .part.
+  active.set(req.id, () => {
+    try {
+      request.abort();
+    } catch {
+      /* already ended */
+    }
+    out?.destroy();
+    cleanup(tmpPath);
+  });
 
   request.on('response', (res) => {
     // Electron's net IncomingMessage is a Readable at runtime; its types omit
@@ -121,31 +138,32 @@ async function start(req: DesktopDownloadRequest): Promise<void> {
     const total = Number((Array.isArray(headers['content-length']) ? headers['content-length'][0] : headers['content-length']) ?? 0);
     const ext = resolveExt(headers);
     const finalPath = path.join(baseDir(), `${safe(req.id)}${ext}`);
-    const out = createWriteStream(tmpPath);
+    const w = createWriteStream(tmpPath);
+    out = w;
     let received = 0;
     let lastEmit = 0;
 
     const fail = (message: string): void => {
       active.delete(req.id);
-      out.destroy();
+      w.destroy();
       cleanup(tmpPath);
       broadcast({ id: req.id, state: 'error', message });
     };
-    out.on('error', (e) => fail(e.message));
+    w.on('error', (e) => fail(e.message));
 
     body.on('data', (chunk: Buffer) => {
       received += chunk.length;
-      if (!out.write(chunk)) body.pause();
+      if (!w.write(chunk)) body.pause();
       const now = Date.now();
       if (now - lastEmit >= PROGRESS_MIN_INTERVAL_MS) {
         lastEmit = now;
         broadcast({ id: req.id, state: 'progress', received, total });
       }
     });
-    out.on('drain', () => body.resume());
+    w.on('drain', () => body.resume());
     body.on('error', (e: Error) => fail(e.message));
     body.on('end', () => {
-      out.end(async () => {
+      w.end(async () => {
         try {
           await fsp.rename(tmpPath, finalPath);
           const item: DesktopDownloadItem = {
@@ -179,7 +197,7 @@ async function start(req: DesktopDownloadRequest): Promise<void> {
 async function startHls(req: DesktopDownloadRequest): Promise<void> {
   const destDir = path.join(baseDir(), safe(req.id));
   await fsp.rm(destDir, { recursive: true, force: true }).catch(() => {});
-  const control = { cancelled: false };
+  const control: { cancelled: boolean; abort?: () => void } = { cancelled: false };
   hlsActive.set(req.id, control);
   let lastEmit = 0;
   try {
@@ -188,6 +206,9 @@ async function startHls(req: DesktopDownloadRequest): Promise<void> {
       quality: req.quality,
       destDir,
       cancelled: () => control.cancelled,
+      onRequest: (abort) => {
+        control.abort = abort;
+      },
       onProgress: (received, total) => {
         const now = Date.now();
         if (now - lastEmit >= PROGRESS_MIN_INTERVAL_MS || received === total) {
@@ -219,12 +240,17 @@ async function startHls(req: DesktopDownloadRequest): Promise<void> {
 
 async function cancel(id: string): Promise<void> {
   const hls = hlsActive.get(id);
-  if (hls) hls.cancelled = true;
-  const request = active.get(id);
-  if (request) {
-    active.delete(id);
-    request.abort();
+  if (hls) {
+    hls.cancelled = true;
+    try {
+      hls.abort?.();
+    } catch {
+      /* request already ended */
+    }
   }
+  const abort = active.get(id);
+  active.delete(id);
+  abort?.();
   cleanup(path.join(baseDir(), `${safe(id)}.part`));
 }
 
@@ -264,7 +290,11 @@ async function saveFile(key: string, url: string): Promise<boolean> {
       }
       const out = createWriteStream(dest);
       out.on('error', () => resolve(false));
-      body.on('error', () => resolve(false));
+      // pipe() doesn't close the dest when the SOURCE errors — destroy it here.
+      body.on('error', () => {
+        out.destroy();
+        resolve(false);
+      });
       body.pipe(out);
       out.on('finish', () => resolve(true));
     });

--- a/desktop/src/main/hls-mirror.ts
+++ b/desktop/src/main/hls-mirror.ts
@@ -1,0 +1,185 @@
+import { net } from 'electron';
+import { createWriteStream, promises as fsp } from 'node:fs';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+
+// Mirror a transcoded HLS stream to disk so mpv can play it back offline, the
+// desktop equivalent of iOS's .movpkg / Android's ExoPlayer cache. Fetches the
+// master, the chosen ladder rung, every audio + subtitle rendition and all of
+// their segments, rewriting each playlist to reference the local files. The
+// segments are pulled in playlist order so the backend's on-demand transcode
+// advances linearly (no seek/respawn). Returns the local master.m3u8 path.
+
+function readableOf(res: Electron.IncomingMessage): Readable {
+  return res as unknown as Readable;
+}
+
+function fetchText(url: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const req = net.request({ url });
+    req.on('response', (res) => {
+      const body = readableOf(res);
+      if ((res.statusCode ?? 0) >= 400) {
+        body.resume();
+        reject(new Error(`HTTP ${res.statusCode}`));
+        return;
+      }
+      const chunks: Buffer[] = [];
+      body.on('data', (c: Buffer) => chunks.push(c));
+      body.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+      body.on('error', reject);
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+function fetchToFile(url: string, dest: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = net.request({ url });
+    req.on('response', (res) => {
+      const body = readableOf(res);
+      if ((res.statusCode ?? 0) >= 400) {
+        body.resume();
+        reject(new Error(`HTTP ${res.statusCode}`));
+        return;
+      }
+      const out = createWriteStream(dest);
+      out.on('error', reject);
+      body.on('error', reject);
+      body.pipe(out);
+      out.on('finish', () => resolve());
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+/** Last path component of a URI, query stripped (e.g. `seg-0001.m4s`). */
+function basename(uri: string): string {
+  return uri.split('?')[0].split('/').pop() || 'seg';
+}
+
+interface MirrorOpts {
+  masterUrl: string;
+  quality: string | undefined;
+  destDir: string;
+  onProgress: (received: number, total: number) => void;
+  cancelled: () => boolean;
+}
+
+export async function mirrorHls(opts: MirrorOpts): Promise<string> {
+  const { masterUrl, quality, destDir, onProgress, cancelled } = opts;
+  const origin = new URL(masterUrl).origin;
+  const token = new URL(masterUrl).searchParams.get('token') ?? '';
+
+  // Absolutise a playlist-relative URI and carry the stream token forward.
+  const resolveFrom = (base: string, uri: string): string => {
+    const abs = /^https?:/i.test(uri)
+      ? uri
+      : uri.startsWith('/')
+        ? origin + uri
+        : new URL(uri, base).toString();
+    if (!token) return abs;
+    const u = new URL(abs);
+    if (!u.searchParams.has('token')) u.searchParams.set('token', token);
+    return u.toString();
+  };
+
+  await fsp.mkdir(destDir, { recursive: true });
+  const masterText = await fetchText(masterUrl);
+  const mlines = masterText.split(/\r?\n/);
+
+  // Pick one variant: the rung whose URI matches the requested quality, else
+  // the first listed. Every audio / subtitle rendition is kept.
+  const variants: string[] = [];
+  for (let i = 0; i < mlines.length; i++) {
+    if (mlines[i].startsWith('#EXT-X-STREAM-INF')) variants.push((mlines[i + 1] ?? '').trim());
+  }
+  const chosenUri =
+    variants.find((u) => quality && u.includes(`/${quality}/`)) ?? variants[0];
+  if (!chosenUri) throw new Error('no variant in master playlist');
+
+  const children: { url: string; dir: string }[] = [
+    { url: resolveFrom(masterUrl, chosenUri), dir: 'video' },
+  ];
+  const masterOut: string[] = [];
+  let audioN = 0;
+  let subN = 0;
+  for (let i = 0; i < mlines.length; i++) {
+    const line = mlines[i];
+    if (line.startsWith('#EXT-X-STREAM-INF')) {
+      const uri = (mlines[i + 1] ?? '').trim();
+      i++;
+      if (uri === chosenUri) {
+        masterOut.push(line, 'video/index.m3u8');
+      }
+      continue; // drop non-chosen rungs
+    }
+    if (line.startsWith('#EXT-X-MEDIA:')) {
+      const uriM = /URI="([^"]+)"/.exec(line);
+      const isAudio = /TYPE=AUDIO/.test(line);
+      const isSubs = /TYPE=SUBTITLES/.test(line);
+      if (uriM && (isAudio || isSubs)) {
+        const dir = isAudio ? `audio${audioN++}` : `subs${subN++}`;
+        children.push({ url: resolveFrom(masterUrl, uriM[1]), dir });
+        masterOut.push(line.replace(/URI="[^"]+"/, `URI="${dir}/index.m3u8"`));
+      } else {
+        masterOut.push(line);
+      }
+      continue;
+    }
+    masterOut.push(line);
+  }
+
+  // Fetch every child playlist first (cheap) so the total segment count — hence
+  // the progress denominator — is known before pulling segments.
+  const parsed = [];
+  for (const c of children) {
+    const text = await fetchText(c.url);
+    const init = /#EXT-X-MAP:URI="([^"]+)"/.exec(text)?.[1];
+    const segs = text
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith('#'));
+    parsed.push({ child: c, text, init, segs });
+  }
+  const total = parsed.reduce((n, p) => n + p.segs.length + (p.init ? 1 : 0), 0);
+  let received = 0;
+
+  for (const p of parsed) {
+    if (cancelled()) throw new Error('cancelled');
+    const cdir = path.join(destDir, p.child.dir);
+    await fsp.mkdir(cdir, { recursive: true });
+
+    let initName: string | undefined;
+    if (p.init) {
+      initName = basename(p.init);
+      await fetchToFile(resolveFrom(p.child.url, p.init), path.join(cdir, initName));
+      onProgress(++received, total);
+    }
+    for (const seg of p.segs) {
+      if (cancelled()) throw new Error('cancelled');
+      await fetchToFile(resolveFrom(p.child.url, seg), path.join(cdir, basename(seg)));
+      onProgress(++received, total);
+    }
+
+    // Rewrite the playlist so init + segments point at the local basenames.
+    const rewritten = p.text
+      .split(/\r?\n/)
+      .map((l) => {
+        const t = l.trim();
+        if (t.startsWith('#EXT-X-MAP:URI=') && initName) {
+          return l.replace(/URI="[^"]+"/, `URI="${initName}"`);
+        }
+        if (t && !t.startsWith('#')) return basename(t);
+        return l;
+      })
+      .join('\n');
+    await fsp.writeFile(path.join(cdir, 'index.m3u8'), rewritten);
+  }
+
+  const masterPath = path.join(destDir, 'master.m3u8');
+  await fsp.writeFile(masterPath, masterOut.join('\n'));
+  return masterPath;
+}

--- a/desktop/src/main/hls-mirror.ts
+++ b/desktop/src/main/hls-mirror.ts
@@ -14,9 +14,10 @@ function readableOf(res: Electron.IncomingMessage): Readable {
   return res as unknown as Readable;
 }
 
-function fetchText(url: string): Promise<string> {
+function fetchText(url: string, onRequest?: (abort: () => void) => void): Promise<string> {
   return new Promise((resolve, reject) => {
     const req = net.request({ url });
+    onRequest?.(() => req.abort());
     req.on('response', (res) => {
       const body = readableOf(res);
       if ((res.statusCode ?? 0) >= 400) {
@@ -34,9 +35,14 @@ function fetchText(url: string): Promise<string> {
   });
 }
 
-function fetchToFile(url: string, dest: string): Promise<void> {
+function fetchToFile(
+  url: string,
+  dest: string,
+  onRequest?: (abort: () => void) => void,
+): Promise<void> {
   return new Promise((resolve, reject) => {
     const req = net.request({ url });
+    onRequest?.(() => req.abort());
     req.on('response', (res) => {
       const body = readableOf(res);
       if ((res.statusCode ?? 0) >= 400) {
@@ -46,7 +52,11 @@ function fetchToFile(url: string, dest: string): Promise<void> {
       }
       const out = createWriteStream(dest);
       out.on('error', reject);
-      body.on('error', reject);
+      // pipe() doesn't close the dest when the SOURCE errors — destroy it here.
+      body.on('error', (e) => {
+        out.destroy();
+        reject(e);
+      });
       body.pipe(out);
       out.on('finish', () => resolve());
     });
@@ -66,10 +76,12 @@ interface MirrorOpts {
   destDir: string;
   onProgress: (received: number, total: number) => void;
   cancelled: () => boolean;
+  /** Receives an abort handle for each in-flight fetch so a cancel is immediate. */
+  onRequest?: (abort: () => void) => void;
 }
 
 export async function mirrorHls(opts: MirrorOpts): Promise<string> {
-  const { masterUrl, quality, destDir, onProgress, cancelled } = opts;
+  const { masterUrl, quality, destDir, onProgress, cancelled, onRequest } = opts;
   const origin = new URL(masterUrl).origin;
   const token = new URL(masterUrl).searchParams.get('token') ?? '';
 
@@ -87,7 +99,7 @@ export async function mirrorHls(opts: MirrorOpts): Promise<string> {
   };
 
   await fsp.mkdir(destDir, { recursive: true });
-  const masterText = await fetchText(masterUrl);
+  const masterText = await fetchText(masterUrl, onRequest);
   const mlines = masterText.split(/\r?\n/);
 
   // Pick one variant: the rung whose URI matches the requested quality, else
@@ -136,7 +148,7 @@ export async function mirrorHls(opts: MirrorOpts): Promise<string> {
   // the progress denominator — is known before pulling segments.
   const parsed = [];
   for (const c of children) {
-    const text = await fetchText(c.url);
+    const text = await fetchText(c.url, onRequest);
     const init = /#EXT-X-MAP:URI="([^"]+)"/.exec(text)?.[1];
     const segs = text
       .split(/\r?\n/)
@@ -155,12 +167,12 @@ export async function mirrorHls(opts: MirrorOpts): Promise<string> {
     let initName: string | undefined;
     if (p.init) {
       initName = basename(p.init);
-      await fetchToFile(resolveFrom(p.child.url, p.init), path.join(cdir, initName));
+      await fetchToFile(resolveFrom(p.child.url, p.init), path.join(cdir, initName), onRequest);
       onProgress(++received, total);
     }
     for (const seg of p.segs) {
       if (cancelled()) throw new Error('cancelled');
-      await fetchToFile(resolveFrom(p.child.url, seg), path.join(cdir, basename(seg)));
+      await fetchToFile(resolveFrom(p.child.url, seg), path.join(cdir, basename(seg)), onRequest);
       onProgress(++received, total);
     }
 

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -7,6 +7,7 @@ import { createRequire } from 'node:module';
 import { registerAppSchemePrivileged, registerAppProtocol, APP_URL } from './protocol';
 import { installCorsBypass } from './cors';
 import { setupUpdater } from './updater';
+import { registerDownloadIpc } from './download';
 import { setPlaybackKeepAwake, keepAwakeForState } from './power';
 import { IPC, type DesktopEvent, type DesktopSubtitleStyle } from '../shared/contract';
 import { mpvSubtitleProps } from './mpv/subtitle-style';
@@ -274,6 +275,10 @@ app.whenReady().then(async () => {
   // detect-only on .deb/dev). Registered on every platform path so the renderer
   // can always query capability + listen for status.
   setupUpdater();
+
+  // Offline downloads (renderer→main fetch-to-disk). Registered on every
+  // platform path so the desktop download UI works regardless of playback backend.
+  registerDownloadIpc();
 
   const dir = webDir();
   const haveApp = fs.existsSync(path.join(dir, 'index.html'));

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -2,12 +2,16 @@ import { contextBridge, ipcRenderer } from 'electron';
 import {
   IPC,
   UPDATE_IPC,
+  DOWNLOAD_IPC,
+  type DesktopDownloadRequest,
+  type DesktopDownloadStatus,
   type DesktopEvent,
   type DesktopLoadOptions,
   type DesktopRect,
   type DesktopSubtitleStyle,
   type DesktopUpdateStatus,
   type FliksDesktopApi,
+  type FliksDownloaderApi,
   type FliksUpdaterApi,
 } from '../shared/contract';
 
@@ -61,3 +65,23 @@ const updater: FliksUpdaterApi = {
 };
 
 contextBridge.exposeInMainWorld('fliksUpdater', updater);
+
+// Exposes offline downloads on `window.fliksDownloader`, consumed by the Angular
+// DownloadManager/OfflineStorage services on the desktop path.
+const downloader: FliksDownloaderApi = {
+  start: (req: DesktopDownloadRequest) => ipcRenderer.invoke(DOWNLOAD_IPC.start, req),
+  cancel: (id: string) => ipcRenderer.invoke(DOWNLOAD_IPC.cancel, id),
+  remove: (id: string) => ipcRenderer.invoke(DOWNLOAD_IPC.remove, id),
+  list: () => ipcRenderer.invoke(DOWNLOAD_IPC.list),
+  getLocalUrl: (id: string) => ipcRenderer.invoke(DOWNLOAD_IPC.getLocalUrl, id),
+  saveFile: (key: string, url: string) => ipcRenderer.invoke(DOWNLOAD_IPC.saveFile, key, url),
+  fileUrl: (key: string) => ipcRenderer.invoke(DOWNLOAD_IPC.fileUrl, key),
+  deleteFile: (key: string) => ipcRenderer.invoke(DOWNLOAD_IPC.deleteFile, key),
+  onStatus: (handler: (status: DesktopDownloadStatus) => void) => {
+    const listener = (_e: unknown, status: DesktopDownloadStatus) => handler(status);
+    ipcRenderer.on(DOWNLOAD_IPC.status, listener);
+    return () => ipcRenderer.removeListener(DOWNLOAD_IPC.status, listener);
+  },
+};
+
+contextBridge.exposeInMainWorld('fliksDownloader', downloader);

--- a/desktop/src/shared/contract.ts
+++ b/desktop/src/shared/contract.ts
@@ -129,6 +129,67 @@ export const UPDATE_IPC = {
   status: 'update:status',
 } as const;
 
+// ── Downloads (offline) ──
+// App-level, independent of the per-session player surface — modelled on the
+// updater. Media is fetched to disk and played back offline via mpv (file://).
+
+export interface DesktopDownloadRequest {
+  /** Stable id; the client uses the mediaFileId. */
+  id: string;
+  /** Source URL, including the ?token= stream JWT. A `.m3u8` URL is mirrored to
+   *  disk as a local HLS bundle; anything else is fetched as a single file. */
+  url: string;
+  /** Preferred display filename; the on-disk extension is taken from the response. */
+  filename?: string;
+  /** For an HLS download, the ladder rung to mirror (variant selection). */
+  quality?: string;
+}
+
+export interface DesktopDownloadItem {
+  id: string;
+  filename: string;
+  /** Absolute local path of the downloaded file. */
+  path: string;
+  /** Total bytes (0 until the response headers arrive). */
+  size: number;
+  received: number;
+  complete: boolean;
+}
+
+export type DesktopDownloadStatus =
+  | { id: string; state: 'progress'; received: number; total: number }
+  | { id: string; state: 'done'; item: DesktopDownloadItem }
+  | { id: string; state: 'error'; message: string };
+
+export const DOWNLOAD_IPC = {
+  start: 'download:start',
+  cancel: 'download:cancel',
+  remove: 'download:remove',
+  list: 'download:list',
+  getLocalUrl: 'download:getLocalUrl',
+  saveFile: 'download:saveFile',
+  fileUrl: 'download:fileUrl',
+  deleteFile: 'download:deleteFile',
+  /** main → renderer (discriminated by DesktopDownloadStatus.state). */
+  status: 'download:status',
+} as const;
+
+/** Exposed on `window.fliksDownloader` by the preload bridge. */
+export interface FliksDownloaderApi {
+  start(req: DesktopDownloadRequest): Promise<void>;
+  cancel(id: string): Promise<void>;
+  remove(id: string): Promise<void>;
+  list(): Promise<DesktopDownloadItem[]>;
+  /** file:// URL of a completed download, or null. */
+  getLocalUrl(id: string): Promise<string | null>;
+  /** Fetch a small sidecar file (e.g. a VTT subtitle) to disk under `key`. */
+  saveFile(key: string, url: string): Promise<boolean>;
+  /** file:// URL of a saved sidecar file, or null. */
+  fileUrl(key: string): Promise<string | null>;
+  deleteFile(key: string): Promise<void>;
+  onStatus(handler: (status: DesktopDownloadStatus) => void): () => void;
+}
+
 /** Exposed on `window.fliksUpdater` by the preload bridge. */
 export interface FliksUpdaterApi {
   getCapability(): Promise<DesktopUpdateCapability>;


### PR DESCRIPTION
## Summary

Adds a real offline-download path to the Electron desktop client, mirroring the native mobile model (iOS `.movpkg` / Android ExoPlayer cache) but playing back through mpv so every codec the desktop targets (HEVC/AV1, multi-audio, embedded subs) works offline.

Previously the desktop shell exposed no download/filesystem surface, and the offline playback branch routed to the mobile Capacitor ExoPlayer/AVPlayer plugin (absent in Electron) while storage went through Shaka/Chromium (can't decode the codecs the desktop uses mpv for). The two conflicting "native" definitions — `Capacitor.isNativePlatform()` (false on Electron) and `ServerConfig.isNative` (true) — disagreed precisely for the desktop.

## What it does

- **Electron shell**: a download service on `window.fliksDownloader` (new IPC surface) that fetches to `userData/downloads` over the app session (self-signed certs + `?token=` already handled). An **original** download is the untouched container as a single file; a chosen **quality** mirrors the transcoded HLS bundle to disk (variant + audio/subtitle renditions + segments, playlists rewritten to local paths), so mpv plays the local `master.m3u8` offline.
- **Client**: `OfflineStorage` + `DownloadManager` gain a desktop backend keyed off the bridge; the player offline branch routes desktop to `DesktopEngine` + `file://` (fixes the hard break); the quality modal offers rungs + original.
- **Auto-download for playlists** is enabled on the desktop (its offline backend now exists) — the per-playlist toggle and watched-item cleanup.
- One offline copy per file (replaces on re-download); offline audio-track labels fall back to the metadata captured at download time.

No backend change — reuses the existing raw `?download=1` and HLS routes.

## Hardening (from review)

Path-traversal guard on download ids, file-descriptor leak fixes on stream errors, cancel closes the write stream + aborts in-flight HLS fetches, atomic manifest writes.

## Testing

- Desktop installer build green on all three OSes.
- Client + desktop `tsc --noEmit` green.
- On-device validation of manual + auto downloads and offline playback pending.