### PR TITLE
fix(desktop): keep the forced HLS demuxer off sidecar subtitle loads

### DIFF
--- a/desktop/src/main/mpv/mpv-player.ts
+++ b/desktop/src/main/mpv/mpv-player.ts
@@ -60,6 +60,9 @@ export class MpvPlayer extends EventEmitter {
   private sawFirstFrame = false;
   private duration = 0;
   private cacheEnd = 0;
+  /** Demuxer format forced for the current media (`hls` for manifests, else
+   *  empty). Dropped around a sidecar `sub-add` so the VTT isn't demuxed as HLS. */
+  private forcedDemuxFormat = '';
   /** Bumped by load/stop/destroy; a load with a stale id skips its remaining
    *  IPC writes, so a stop can't be overtaken by a trailing loadfile. */
   private loadGen = 0;
@@ -326,7 +329,8 @@ export class MpvPlayer extends EventEmitter {
     // Force the HLS demuxer for manifests so mpv parses the playlist directly,
     // skipping the generic probe whose backward seek the linear HTTP stream
     // can't satisfy.
-    if (/\.m3u8(\?|$)/.test(opts.url)) fileOpts.push('demuxer-lavf-format=hls');
+    this.forcedDemuxFormat = /\.m3u8(\?|$)/.test(opts.url) ? 'hls' : '';
+    if (this.forcedDemuxFormat) fileOpts.push(`demuxer-lavf-format=${this.forcedDemuxFormat}`);
     const cmd: unknown[] = ['loadfile', opts.url, 'replace', 0];
     if (fileOpts.length) cmd.push(fileOpts.join(','));
     await this.command(cmd);
@@ -431,7 +435,20 @@ export class MpvPlayer extends EventEmitter {
    *  re-selecting the same subtitle never stacks; mpv parses the VTT once and
    *  seeks within it natively, unlike a re-read HLS rendition. */
   async subAdd(url: string, label: string, language: string): Promise<void> {
-    await this.command(['sub-add', url, 'cached', label ?? '', language ?? '']);
+    // A manifest load forces demuxer-lavf-format=hls; while it's in effect mpv
+    // applies it to this sidecar VTT too and fails to open it ("Found 'hls'
+    // (forced)" → avformat_open_input() failed). Drop the forced format for the
+    // sub-add so the VTT is probed normally, then restore it.
+    if (this.forcedDemuxFormat) {
+      await this.command(['set', 'demuxer-lavf-format', '']).catch(() => {});
+    }
+    try {
+      await this.command(['sub-add', url, 'cached', label ?? '', language ?? '']);
+    } finally {
+      if (this.forcedDemuxFormat) {
+        await this.command(['set', 'demuxer-lavf-format', this.forcedDemuxFormat]).catch(() => {});
+      }
+    }
   }
 
   async setSubtitleStyle(s: DesktopSubtitleStyle): Promise<void> {

--- a/desktop/src/main/mpv/mpv-player.ts
+++ b/desktop/src/main/mpv/mpv-player.ts
@@ -340,10 +340,37 @@ export class MpvPlayer extends EventEmitter {
     // the mobile native player (playWhenReady) and never calls play() itself.
     await this.set('pause', false);
     if (gen !== this.loadGen) return;
+    if (this.forcedDemuxFormat) {
+      // The manifest is force-demuxed as hls (file-local). Once it has actually
+      // opened, drop the forced format globally so a later sidecar sub-add isn't
+      // demuxed as hls (which fails to open). Clearing it before the manifest
+      // opens would race its own probe and break the load, so wait for the first
+      // frame first.
+      await this.waitFirstFrame(gen);
+      if (gen !== this.loadGen) return;
+      await this.command(['set', 'demuxer-lavf-format', '']).catch(() => {});
+    }
     for (const s of opts.subtitles ?? []) {
       await this.command(['sub-add', s.url, 'auto', s.label ?? '', s.language ?? '']);
       if (gen !== this.loadGen) return;
     }
+  }
+
+  /** Resolve once mpv has opened the media (first frame), or on error/timeout.
+   *  Lets load() sequence post-open work after the manifest demuxer is up. */
+  private waitFirstFrame(gen: number): Promise<void> {
+    if (this.sawFirstFrame || gen !== this.loadGen) return Promise.resolve();
+    return new Promise((resolve) => {
+      const done = (): void => {
+        clearTimeout(timer);
+        this.off('firstFrame', done);
+        this.off('error', done);
+        resolve();
+      };
+      const timer = setTimeout(done, 10_000);
+      this.once('firstFrame', done);
+      this.once('error', done);
+    });
   }
 
   play(): Promise<void> {
@@ -435,20 +462,7 @@ export class MpvPlayer extends EventEmitter {
    *  re-selecting the same subtitle never stacks; mpv parses the VTT once and
    *  seeks within it natively, unlike a re-read HLS rendition. */
   async subAdd(url: string, label: string, language: string): Promise<void> {
-    // A manifest load forces demuxer-lavf-format=hls; while it's in effect mpv
-    // applies it to this sidecar VTT too and fails to open it ("Found 'hls'
-    // (forced)" → avformat_open_input() failed). Drop the forced format for the
-    // sub-add so the VTT is probed normally, then restore it.
-    if (this.forcedDemuxFormat) {
-      await this.command(['set', 'demuxer-lavf-format', '']).catch(() => {});
-    }
-    try {
-      await this.command(['sub-add', url, 'cached', label ?? '', language ?? '']);
-    } finally {
-      if (this.forcedDemuxFormat) {
-        await this.command(['set', 'demuxer-lavf-format', this.forcedDemuxFormat]).catch(() => {});
-      }
-    }
+    await this.command(['sub-add', url, 'cached', label ?? '', language ?? '']);
   }
 
   async setSubtitleStyle(s: DesktopSubtitleStyle): Promise<void> {


### PR DESCRIPTION
## Problem

On the Windows desktop client, subtitles never displayed for a **transcode** playback (DirectPlay and web were fine). The mpv log showed the sidecar VTT being demuxed as HLS and failing:

```
curl: Opening .../subtitles/<id>  Mime-type: 'text/vtt'
lavf: Found 'hls' at score=100 (forced)
[error] lavf: avformat_open_input() failed
[error] cplayer: Can not open external file .../subtitles/<id>
Error occurred in handler for 'player:subAdd'
```

The Windows backend forces `demuxer-lavf-format=hls` for a `.m3u8` media load (so the HLS demuxer is used directly instead of the generic probe, whose backward seek the linear HTTP stream can't satisfy). That forced format stays in effect for the whole playback, and mpv applies it to a `sub-add` too — so the VTT is (wrongly) demuxed as HLS and fails to open, leaving the transcode with no selectable subtitles.

Windows-only (only that backend forces the format); transcode-only (`.m3u8`). DirectPlay plays the raw file so mpv reads embedded subs natively; the web/Shaka path has no mpv.

## Fix

Force `hls` only as the manifest's file-local load option, wait for its first frame (so the demuxer is actually open), then drop the forced format globally. Subsequent sidecar sub-adds — including the re-add after a seek/resume reload, which runs only after `load()` resolves — probe the VTT normally. DirectPlay (no forced format) is untouched.

A first attempt cleared the format around the `sub-add` itself, which raced a concurrent manifest re-open on seek (`unrecognized file format`); clearing only after the manifest has opened avoids that.

## Testing

Validated on the Windows desktop client: transcode subtitles load and stay in sync after resume and after a seek; the manifest no longer fails to open on seek. Installer build green on all three OSes.