### PR TITLE
fix(media-detail): localize season episode air dates

### DIFF
--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -183,7 +183,7 @@
             [imageUrl]="ep.stillUrl ?? m.posterUrl"
             [imageBlurred]="!ep.stillUrl && !!m.posterUrl"
             [title]="ep.title ?? ('media_detail.ep_no_title' | translate)"
-            [subtitle]="ep.airDate ?? '—'"
+            [subtitle]="(ep.airDate | localeDate) || '—'"
             [topLeftBadge]="episodeBadgeLabel(ep)"
             [status]="watchedEpisodeIds().has(ep.id) ? 'watched' : (!ep.hasFile ? 'missing' : null)"
             [progressPercent]="episodeProgress()[ep.id]"

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -45,11 +45,12 @@ import { PlayableMediaService } from '../../../../core/services/playable-media.s
 import { AddToPlaylistService } from '../../../../core/services/add-to-playlist.service';
 import { TvService } from '../../../../core/services/tv.service';
 import { AuthService } from '../../../../core/services/auth.service';
+import { LocaleDatePipe } from '../../../../core/pipes/locale-date.pipe';
 
 
 @Component({
   selector: 'app-media-detail-seasons',
-  imports: [TranslateModule, FormsModule, UpperCasePipe, HorizontalScrollerComponent, MediaCardComponent, DropdownMenuComponent, TvSelectDirective, TvRowDirective, LucideCheck, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideHeart, LucideListChecks, LucideListPlus, LucidePackage, LucideUserPlus, LucideX],
+  imports: [TranslateModule, FormsModule, UpperCasePipe, LocaleDatePipe, HorizontalScrollerComponent, MediaCardComponent, DropdownMenuComponent, TvSelectDirective, TvRowDirective, LucideCheck, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideHeart, LucideListChecks, LucideListPlus, LucidePackage, LucideUserPlus, LucideX],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-seasons.component.html',
 })


### PR DESCRIPTION
## What

The episode cards in the season detail row rendered their air date as raw ISO (`2026-07-17`) instead of the active language's convention.

## Why

This is the same class of bug already fixed on the home coming-soon row in #725. That MR introduced the impure `localeDate` pipe (formats in the selected language, re-renders on a live language switch, and formats date-only `YYYY-MM-DD` strings in UTC to avoid an off-by-one day). The season episode card used the same `app-media-card` `subtitle` input but still passed `ep.airDate` raw.

## How

- `media-detail-seasons.component.html`: `[subtitle]="(ep.airDate | localeDate) || '—'"` — mirrors the home usage on the same input. Uses `||` rather than `??` because the pipe yields an empty string (not `null`) for a missing date, so the `—` fallback still fires.
- `media-detail-seasons.component.ts`: import `LocaleDatePipe` and add it to the standalone `imports`.

The episode detail page was already correct (it formats via `episodeDateLabel` using the active language); this was the last raw-ISO date left in the media-detail templates.

## Verify

Client build (`ng build --configuration development`) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)