### PR TITLE
fix(player): hold the buffering spinner until playback resumes

### DIFF
--- a/client/src/app/core/services/player-state.service.ts
+++ b/client/src/app/core/services/player-state.service.ts
@@ -101,7 +101,14 @@ export class PlayerStateService {
 
     engine.on('stateChanged', (e) => {
       this.paused.set(e.state === 'paused' || e.state === 'idle');
-      this.buffering.set(e.state === 'buffering' || (this.recovering && e.state === 'error'));
+      const buffering = e.state === 'buffering' || (this.recovering && e.state === 'error');
+      // Anchor the playhead reference as buffering begins so the timeUpdate clear
+      // below fires on real forward progress, not the position jump a seek into
+      // the stall produces — otherwise the spinner clears before playback resumes.
+      if (buffering && !this.buffering()) {
+        this.lastBufferingPos = this.engine?.currentTime ?? this.lastBufferingPos;
+      }
+      this.buffering.set(buffering);
       // Only a generic fallback: the `error` event (below) fires alongside
       // this and already set the detailed PlaybackError, so don't clobber it.
       if (e.state === 'error' && !this.recovering && !this.error()) {


### PR DESCRIPTION
## What

When seeking, the loading spinner cleared too early — it disappeared while the stream was still buffering, leaving a visible gap before the picture actually came back.

## Root cause

A seek jumps the playhead to the target position while the new segment is still buffering. `PlayerStateService`'s `timeUpdate` spinner-clear treats a moving playhead (`position !== lastBufferingPos`) as "frames are flowing". But `lastBufferingPos` still held the **pre-seek** position, so the seek jump itself read as forward progress and cleared the spinner immediately — well before playback resumed.

## Fix

Anchor `lastBufferingPos` to the current playhead **as buffering begins**, so the existing clear only fires on real forward motion (genuine resume), not on the position jump a seek produces.

```ts
const buffering = e.state === 'buffering' || (this.recovering && e.state === 'error');
if (buffering && !this.buffering()) {
  this.lastBufferingPos = this.engine?.currentTime ?? this.lastBufferingPos;
}
this.buffering.set(buffering);
```

Single, engine-agnostic change in the shared state service — no per-engine logic. Verified on **web (Shaka)** and the **desktop (mpv) client**; both drive the same shared `timeUpdate` path.

## Verify

- Client build (`ng build`) green.
- Desktop installers built green on all three OSes (Actions run 29776997930) and validated on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)