### PR TITLE
feat(subtitles): multiple selectable translation providers

### DIFF
--- a/backend/src/common/enums/index.ts
+++ b/backend/src/common/enums/index.ts
@@ -7,6 +7,7 @@ export * from './media-server-type.enum';
 export * from './minimum-availability.enum';
 export * from './subtitle-provider-type.enum';
 export * from './subtitle-status.enum';
+export * from './translation-engine.enum';
 export * from './playlist-share-role.enum';
 export * from './playlist-visibility.enum';
 export * from './profile-visibility.enum';

--- a/backend/src/common/enums/translation-engine.enum.ts
+++ b/backend/src/common/enums/translation-engine.enum.ts
@@ -1,0 +1,11 @@
+/** Machine-translation engines a translation provider can run on. */
+export const TRANSLATION_ENGINES = [
+  'gemini',
+  'openai',
+  'libretranslate',
+] as const;
+
+export type TranslationEngine = (typeof TRANSLATION_ENGINES)[number];
+
+/** Model used when a Gemini provider leaves the model unset. */
+export const DEFAULT_TRANSLATION_MODEL = 'gemini-2.0-flash';

--- a/backend/src/migrations/1782300000000-create-translation-providers.ts
+++ b/backend/src/migrations/1782300000000-create-translation-providers.ts
@@ -1,0 +1,55 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds the `translation_providers` table (admin-configured machine-translation
+ * providers, several selectable at translate time) and provenance columns on
+ * `subtitle_files` recording which provider/engine/model produced a translated
+ * subtitle. Existing `translated` rows keep the columns null (generic origin).
+ */
+export class CreateTranslationProviders1782300000000
+  implements MigrationInterface
+{
+  name = 'CreateTranslationProviders1782300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "translation_providers_engine_enum"
+        AS ENUM ('gemini', 'openai', 'libretranslate')
+    `);
+    await queryRunner.query(`
+      CREATE TABLE "translation_providers" (
+        "id" SERIAL PRIMARY KEY,
+        "createdAt" timestamptz NOT NULL DEFAULT now(),
+        "updatedAt" timestamptz NOT NULL DEFAULT now(),
+        "name" varchar NOT NULL,
+        "engine" "translation_providers_engine_enum" NOT NULL,
+        "enabled" boolean NOT NULL DEFAULT true,
+        "isDefault" boolean NOT NULL DEFAULT false,
+        "settings" jsonb NOT NULL DEFAULT '{}'
+      )
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "subtitle_files"
+        ADD COLUMN "translationProviderId" int,
+        ADD COLUMN "translationEngine" varchar,
+        ADD COLUMN "translationModel" varchar,
+        ADD CONSTRAINT "FK_subtitle_files_translation_provider"
+          FOREIGN KEY ("translationProviderId")
+          REFERENCES "translation_providers"("id") ON DELETE SET NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "subtitle_files"
+        DROP CONSTRAINT IF EXISTS "FK_subtitle_files_translation_provider",
+        DROP COLUMN IF EXISTS "translationProviderId",
+        DROP COLUMN IF EXISTS "translationEngine",
+        DROP COLUMN IF EXISTS "translationModel"
+    `);
+    await queryRunner.query(`DROP TABLE IF EXISTS "translation_providers"`);
+    await queryRunner.query(
+      `DROP TYPE IF EXISTS "translation_providers_engine_enum"`,
+    );
+  }
+}

--- a/backend/src/modules/auth/casl/casl-ability.factory.ts
+++ b/backend/src/modules/auth/casl/casl-ability.factory.ts
@@ -14,6 +14,7 @@ import { QualityProfile } from '../../profiles/entities/quality-profile.entity';
 import { LanguageProfile } from '../../profiles/entities/language-profile.entity';
 import { SubtitleProvider } from '../../subtitles/entities/subtitle-provider.entity';
 import { SubtitleFile } from '../../subtitles/entities/subtitle-file.entity';
+import { TranslationProvider } from '../../subtitles/entities/translation-provider.entity';
 import { Library } from '../../libraries/entities/library.entity';
 import { Playlist } from '../../playlists/entities/playlist.entity';
 import { Action } from './actions.enum';
@@ -29,6 +30,7 @@ type Subjects =
       | typeof LanguageProfile
       | typeof SubtitleProvider
       | typeof SubtitleFile
+      | typeof TranslationProvider
       | typeof Library
       | typeof Playlist
     >
@@ -115,6 +117,7 @@ export class CaslAbilityFactory {
       can(Action.Manage, QualityProfile);
       can(Action.Manage, LanguageProfile);
       can(Action.Manage, SubtitleProvider);
+      can(Action.Manage, TranslationProvider);
       can(Action.Manage, Library);
     }
 

--- a/backend/src/modules/media/media.controller.ts
+++ b/backend/src/modules/media/media.controller.ts
@@ -625,12 +625,13 @@ export class MediaController {
     @Param('id', ParseIntPipe) id: number,
     @Param('subtitleId', ParseIntPipe) subtitleId: number,
     @CurrentUser() user: User,
-    @Body() body: { targetLanguage: string },
+    @Body() body: { targetLanguage: string; providerId?: number },
   ) {
     await this.assertMediaAccessible(id, user);
     return this.subtitleTranslation.translateSubtitle(
       subtitleId,
       body.targetLanguage,
+      body.providerId,
     );
   }
 

--- a/backend/src/modules/scheduler/events.service.ts
+++ b/backend/src/modules/scheduler/events.service.ts
@@ -22,6 +22,9 @@ export type SseEvent =
       title: string;
       language: string;
       provider: string;
+      /** Set for translation results so a client can target the finished row
+       *  (e.g. add just that track) instead of a blind refetch. */
+      subtitleId?: number;
     }
   | {
       type: 'subtitle.failed';

--- a/backend/src/modules/subtitles/dto/create-translation-provider.dto.ts
+++ b/backend/src/modules/subtitles/dto/create-translation-provider.dto.ts
@@ -1,0 +1,23 @@
+import { IsBoolean, IsIn, IsObject, IsOptional, IsString } from 'class-validator';
+import { TRANSLATION_ENGINES } from '../../../common/enums';
+import type { TranslationEngine } from '../../../common/enums';
+
+export class CreateTranslationProviderDto {
+  @IsString()
+  name: string;
+
+  @IsIn(TRANSLATION_ENGINES as unknown as string[])
+  engine: TranslationEngine;
+
+  @IsObject()
+  @IsOptional()
+  settings?: Record<string, unknown>;
+
+  @IsBoolean()
+  @IsOptional()
+  enabled?: boolean;
+
+  @IsBoolean()
+  @IsOptional()
+  isDefault?: boolean;
+}

--- a/backend/src/modules/subtitles/dto/test-translation-provider.dto.ts
+++ b/backend/src/modules/subtitles/dto/test-translation-provider.dto.ts
@@ -1,0 +1,12 @@
+import { IsIn, IsObject, IsOptional } from 'class-validator';
+import { TRANSLATION_ENGINES } from '../../../common/enums';
+import type { TranslationEngine } from '../../../common/enums';
+
+export class TestTranslationProviderDto {
+  @IsIn(TRANSLATION_ENGINES as unknown as string[])
+  engine: TranslationEngine;
+
+  @IsObject()
+  @IsOptional()
+  settings?: Record<string, unknown>;
+}

--- a/backend/src/modules/subtitles/dto/update-translation-provider.dto.ts
+++ b/backend/src/modules/subtitles/dto/update-translation-provider.dto.ts
@@ -1,0 +1,25 @@
+import { IsBoolean, IsIn, IsObject, IsOptional, IsString } from 'class-validator';
+import { TRANSLATION_ENGINES } from '../../../common/enums';
+import type { TranslationEngine } from '../../../common/enums';
+
+export class UpdateTranslationProviderDto {
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @IsIn(TRANSLATION_ENGINES as unknown as string[])
+  @IsOptional()
+  engine?: TranslationEngine;
+
+  @IsObject()
+  @IsOptional()
+  settings?: Record<string, unknown>;
+
+  @IsBoolean()
+  @IsOptional()
+  enabled?: boolean;
+
+  @IsBoolean()
+  @IsOptional()
+  isDefault?: boolean;
+}

--- a/backend/src/modules/subtitles/entities/subtitle-file.entity.ts
+++ b/backend/src/modules/subtitles/entities/subtitle-file.entity.ts
@@ -4,6 +4,7 @@ import { SubtitleProviderType, SubtitleStatus } from '../../../common/enums';
 import { Media } from '../../media/entities/media.entity';
 import { MediaFile } from '../../media/entities/media-file.entity';
 import { Episode } from '../../media/entities/episode.entity';
+import { TranslationProvider } from './translation-provider.entity';
 import { normalizeLanguageCode } from '../../../common/constants/app-languages';
 
 @Entity('subtitle_files')
@@ -102,4 +103,20 @@ export class SubtitleFile extends BaseEntity {
 
   @Column('simple-json', { default: '[]' })
   tags: string[];
+
+  /** For TRANSLATED subs: the provider that produced this file. Nulled if the
+   *  provider is later removed; the engine/model snapshot below preserves the
+   *  provenance regardless. */
+  @ManyToOne(() => TranslationProvider, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'translationProviderId' })
+  translationProvider: TranslationProvider | null;
+
+  @RelationId((sf: SubtitleFile) => sf.translationProvider)
+  translationProviderId: number | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  translationEngine: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  translationModel: string | null;
 }

--- a/backend/src/modules/subtitles/entities/translation-provider.entity.ts
+++ b/backend/src/modules/subtitles/entities/translation-provider.entity.ts
@@ -1,0 +1,29 @@
+import { Entity, Column } from 'typeorm';
+import { BaseEntity } from '../../../common/entities/base.entity';
+import { TRANSLATION_ENGINES } from '../../../common/enums';
+import type { TranslationEngine } from '../../../common/enums';
+
+/**
+ * An admin-configured machine-translation provider. Several can coexist (e.g. a
+ * Gemini key, an OpenAI-compatible endpoint, a self-hosted LibreTranslate); the
+ * user picks one at translate time. `settings` holds the engine-specific config
+ * opaquely (gemini `{apiKey, model}`, openai `{baseUrl, apiKey, model}`,
+ * libretranslate `{url, apiKey}`), mirroring {@link SubtitleProvider}.
+ */
+@Entity('translation_providers')
+export class TranslationProvider extends BaseEntity {
+  @Column()
+  name: string;
+
+  @Column({ type: 'enum', enum: [...TRANSLATION_ENGINES] })
+  engine: TranslationEngine;
+
+  @Column({ default: true })
+  enabled: boolean;
+
+  @Column({ default: false })
+  isDefault: boolean;
+
+  @Column({ type: 'jsonb', default: {} })
+  settings: Record<string, unknown>;
+}

--- a/backend/src/modules/subtitles/providers/translation-provider.factory.ts
+++ b/backend/src/modules/subtitles/providers/translation-provider.factory.ts
@@ -1,0 +1,109 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  DEFAULT_TRANSLATION_MODEL,
+  TranslationEngine,
+} from '../../../common/enums';
+import { TranslationRequest } from '../translation-core';
+import { GeminiConfig, translateWithGemini } from '../gemini-translator';
+import { OpenAiConfig, translateWithOpenAi } from '../openai-translator';
+import {
+  LibreTranslateConfig,
+  translateWithLibreTranslate,
+} from '../libretranslate-translator';
+
+type ProgressCb = (done: number, total: number) => void;
+
+/**
+ * Resolves a translation provider's opaque `settings` into the typed per-engine
+ * config and dispatches the actual translation. Mirrors
+ * {@link SubtitleProviderFactory} for the download providers — one place that
+ * knows how each engine is configured and invoked, so the service stays
+ * engine-agnostic.
+ */
+@Injectable()
+export class TranslationProviderFactory {
+  private str(settings: Record<string, unknown>, key: string): string {
+    const v = settings?.[key];
+    return typeof v === 'string' ? v.trim() : '';
+  }
+
+  private geminiConfig(settings: Record<string, unknown>): GeminiConfig {
+    return {
+      apiKey: this.str(settings, 'apiKey'),
+      model: this.str(settings, 'model') || DEFAULT_TRANSLATION_MODEL,
+    };
+  }
+
+  private openAiConfig(settings: Record<string, unknown>): OpenAiConfig {
+    return {
+      baseUrl: this.str(settings, 'baseUrl'),
+      apiKey: this.str(settings, 'apiKey'),
+      model: this.str(settings, 'model'),
+    };
+  }
+
+  private libreConfig(settings: Record<string, unknown>): LibreTranslateConfig {
+    return {
+      url: this.str(settings, 'url'),
+      apiKey: this.str(settings, 'apiKey'),
+    };
+  }
+
+  /**
+   * Assert a provider is usable before work starts. The requirements are
+   * deliberately asymmetric: Gemini needs an API key (model has a default);
+   * an OpenAI-compatible endpoint needs a base URL and model but not a key
+   * (local Ollama is keyless); LibreTranslate needs only a URL (self-hosted
+   * instances are usually keyless).
+   */
+  validateConfig(
+    engine: TranslationEngine,
+    settings: Record<string, unknown>,
+  ): void {
+    if (engine === 'gemini' && !this.geminiConfig(settings).apiKey) {
+      throw new BadRequestException('Gemini API key is not set');
+    }
+    if (engine === 'openai') {
+      const c = this.openAiConfig(settings);
+      if (!c.baseUrl || !c.model) {
+        throw new BadRequestException(
+          'An OpenAI-compatible base URL and model are required',
+        );
+      }
+    }
+    if (engine === 'libretranslate' && !this.libreConfig(settings).url) {
+      throw new BadRequestException('The LibreTranslate URL is not set');
+    }
+  }
+
+  /** The model string that will actually be used (for provenance snapshots). */
+  resolveModel(
+    engine: TranslationEngine,
+    settings: Record<string, unknown>,
+  ): string | null {
+    if (engine === 'gemini') return this.geminiConfig(settings).model;
+    if (engine === 'openai') return this.openAiConfig(settings).model;
+    return null;
+  }
+
+  async translate(
+    engine: TranslationEngine,
+    texts: string[],
+    req: TranslationRequest,
+    settings: Record<string, unknown>,
+    onProgress?: ProgressCb,
+  ): Promise<string[]> {
+    if (engine === 'openai') {
+      return translateWithOpenAi(texts, req, this.openAiConfig(settings), onProgress);
+    }
+    if (engine === 'libretranslate') {
+      return translateWithLibreTranslate(
+        texts,
+        req,
+        this.libreConfig(settings),
+        onProgress,
+      );
+    }
+    return translateWithGemini(texts, req, this.geminiConfig(settings), onProgress);
+  }
+}

--- a/backend/src/modules/subtitles/subtitle-translation-settings-cache.service.ts
+++ b/backend/src/modules/subtitles/subtitle-translation-settings-cache.service.ts
@@ -1,7 +1,9 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import { SettingsService } from '../settings/settings.service';
+import { DEFAULT_TRANSLATION_MODEL, TranslationEngine } from '../../common/enums';
 
-export type TranslationEngine = 'gemini' | 'openai' | 'libretranslate';
+export { DEFAULT_TRANSLATION_MODEL };
+export type { TranslationEngine };
 
 /** Resolved subtitle-translation configuration read from the key/value store. */
 export interface ResolvedTranslationSettings {
@@ -12,8 +14,6 @@ export interface ResolvedTranslationSettings {
   openai: { baseUrl: string; apiKey: string; model: string };
   libretranslate: { url: string; apiKey: string };
 }
-
-export const DEFAULT_TRANSLATION_MODEL = 'gemini-2.0-flash';
 
 function parseEngine(raw: string | null): TranslationEngine {
   return raw === 'openai' || raw === 'libretranslate' ? raw : 'gemini';

--- a/backend/src/modules/subtitles/subtitle-translation.service.ts
+++ b/backend/src/modules/subtitles/subtitle-translation.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   Injectable,
   Logger,
   NotFoundException,
@@ -14,17 +15,14 @@ import { SubtitleFile } from './entities/subtitle-file.entity';
 import { Media } from '../media/entities/media.entity';
 import { SettingsService } from '../settings/settings.service';
 import { EventsService } from '../scheduler/events.service';
-import {
-  ResolvedTranslationSettings,
-  SubtitleTranslationSettingsCache,
-} from './subtitle-translation-settings-cache.service';
+import { SubtitleTranslationSettingsCache } from './subtitle-translation-settings-cache.service';
 import {
   TranslationRateLimitError,
   type TranslationRequest,
 } from './translation-core';
-import { translateWithGemini } from './gemini-translator';
-import { translateWithOpenAi } from './openai-translator';
-import { translateWithLibreTranslate } from './libretranslate-translator';
+import { TranslationProviderService } from './translation-provider.service';
+import { TranslationProviderFactory } from './providers/translation-provider.factory';
+import { TranslationProvider } from './entities/translation-provider.entity';
 import { parseSrt, serializeSrt } from './srt.util';
 import { cleanSubtitle } from './subtitle-cleaner';
 import { relativePathUnderMediaRoot } from '../../common/utils/media-path.util';
@@ -64,6 +62,8 @@ export class SubtitleTranslationService {
     private readonly settings: SettingsService,
     private readonly events: EventsService,
     private readonly translationSettings: SubtitleTranslationSettingsCache,
+    private readonly translationProviders: TranslationProviderService,
+    private readonly translationFactory: TranslationProviderFactory,
   ) {
     fs.mkdir(this.tmpDir, { recursive: true }).catch(() => {});
   }
@@ -76,12 +76,14 @@ export class SubtitleTranslationService {
   async translateSubtitle(
     subtitleId: number,
     targetLanguage: string,
+    providerId?: number,
   ): Promise<SubtitleFile> {
-    const config = await this.translationSettings.get();
-    if (!config.enabled) {
+    const settings = await this.translationSettings.get();
+    if (!settings.enabled) {
       throw new BadRequestException('Subtitle translation is disabled');
     }
-    this.assertEngineConfigured(config);
+    const provider = await this.resolveProvider(providerId);
+    this.translationFactory.validateConfig(provider.engine, provider.settings);
 
     const source = await this.repo.findOne({
       where: { id: subtitleId },
@@ -122,29 +124,45 @@ export class SubtitleTranslationService {
       status: SubtitleStatus.PROCESSING,
       codec: 'subrip',
       score: source.score,
+      translationProvider: { id: provider.id },
+      translationEngine: provider.engine,
+      translationModel: this.translationFactory.resolveModel(
+        provider.engine,
+        provider.settings,
+      ),
     } as any);
 
-    void this.runTranslation(placeholder.id, source, target, config).catch((err) => {
+    void this.runTranslation(
+      placeholder.id,
+      source,
+      target,
+      provider,
+      settings.maxConcurrency,
+    ).catch((err) => {
       this.log.error(`Translate run crashed for sub #${subtitleId}: ${err}`);
     });
     return placeholder;
   }
 
-  private assertEngineConfigured(config: ResolvedTranslationSettings): void {
-    if (config.engine === 'gemini' && !config.gemini.apiKey) {
-      throw new BadRequestException('Gemini API key is not set');
+  /** Resolve the provider to translate with: the requested one (must exist and
+   *  be enabled) or the configured default. */
+  private async resolveProvider(
+    providerId?: number,
+  ): Promise<TranslationProvider> {
+    if (providerId != null) {
+      const provider = await this.translationProviders.findOne(providerId);
+      if (!provider.enabled) {
+        throw new ConflictException(
+          'The selected translation provider is disabled',
+        );
+      }
+      return provider;
     }
-    if (
-      config.engine === 'openai' &&
-      (!config.openai.baseUrl || !config.openai.model)
-    ) {
-      throw new BadRequestException(
-        'An OpenAI-compatible base URL and model are required',
-      );
+    const fallback = await this.translationProviders.findDefault();
+    if (!fallback) {
+      throw new BadRequestException('No translation provider is configured');
     }
-    if (config.engine === 'libretranslate' && !config.libretranslate.url) {
-      throw new BadRequestException('The LibreTranslate URL is not set');
-    }
+    return fallback;
   }
 
   private async acquireSlot(limit: number): Promise<void> {
@@ -163,7 +181,8 @@ export class SubtitleTranslationService {
     placeholderId: number,
     source: SubtitleFile,
     target: string,
-    config: ResolvedTranslationSettings,
+    provider: TranslationProvider,
+    maxConcurrency: number,
   ): Promise<void> {
     const media = await this.mediaRepo.findOne({ where: { id: source.mediaId } });
     const base = path.join(
@@ -199,21 +218,16 @@ export class SubtitleTranslationService {
       };
       const texts = cues.map((c) => c.text);
 
-      await this.acquireSlot(config.maxConcurrency);
+      await this.acquireSlot(maxConcurrency);
       let translated: string[];
       try {
-        if (config.engine === 'openai') {
-          translated = await translateWithOpenAi(texts, req, config.openai, onProgress);
-        } else if (config.engine === 'libretranslate') {
-          translated = await translateWithLibreTranslate(
-            texts,
-            req,
-            config.libretranslate,
-            onProgress,
-          );
-        } else {
-          translated = await translateWithGemini(texts, req, config.gemini, onProgress);
-        }
+        translated = await this.translationFactory.translate(
+          provider.engine,
+          texts,
+          req,
+          provider.settings,
+          onProgress,
+        );
       } finally {
         this.releaseSlot();
       }
@@ -267,7 +281,8 @@ export class SubtitleTranslationService {
         mediaId: source.mediaId,
         title: media.title,
         language: target,
-        provider: config.engine,
+        provider: provider.name,
+        subtitleId: placeholderId,
       });
     } catch (err) {
       this.log.warn(

--- a/backend/src/modules/subtitles/subtitles.module.ts
+++ b/backend/src/modules/subtitles/subtitles.module.ts
@@ -4,6 +4,7 @@ import { SubtitleProvider } from './entities/subtitle-provider.entity';
 import { SubtitleProviderStat } from './entities/subtitle-provider-stat.entity';
 import { SubtitleFile } from './entities/subtitle-file.entity';
 import { SubtitleBlacklist } from './entities/subtitle-blacklist.entity';
+import { TranslationProvider } from './entities/translation-provider.entity';
 import { Media } from '../media/entities/media.entity';
 import { MediaFile } from '../media/entities/media-file.entity';
 import { AuthModule } from '../auth/auth.module';
@@ -19,7 +20,10 @@ import { EmbeddedSubtitleService } from './embedded-subtitle.service';
 import { SubtitleOcrService } from './subtitle-ocr.service';
 import { SubtitleTranslationService } from './subtitle-translation.service';
 import { SubtitleTranslationSettingsCache } from './subtitle-translation-settings-cache.service';
+import { TranslationProviderService } from './translation-provider.service';
+import { TranslationProviderFactory } from './providers/translation-provider.factory';
 import { SubtitlesController } from './subtitles.controller';
+import { TranslationProvidersController } from './translation-providers.controller';
 import { SubtitleActivityController } from './subtitle-activity.controller';
 
 @Module({
@@ -29,6 +33,7 @@ import { SubtitleActivityController } from './subtitle-activity.controller';
       SubtitleProviderStat,
       SubtitleFile,
       SubtitleBlacklist,
+      TranslationProvider,
       Media,
       MediaFile,
     ]),
@@ -37,7 +42,11 @@ import { SubtitleActivityController } from './subtitle-activity.controller';
     NotificationsModule,
     MediaServersModule,
   ],
-  controllers: [SubtitlesController, SubtitleActivityController],
+  controllers: [
+    SubtitlesController,
+    TranslationProvidersController,
+    SubtitleActivityController,
+  ],
   providers: [
     SubtitlesService,
     SubtitleProviderService,
@@ -48,6 +57,8 @@ import { SubtitleActivityController } from './subtitle-activity.controller';
     SubtitleOcrService,
     SubtitleTranslationService,
     SubtitleTranslationSettingsCache,
+    TranslationProviderService,
+    TranslationProviderFactory,
   ],
   exports: [
     SubtitlesService,
@@ -57,6 +68,7 @@ import { SubtitleActivityController } from './subtitle-activity.controller';
     FfprobeService,
     SubtitleOcrService,
     SubtitleTranslationService,
+    TranslationProviderService,
   ],
 })
 export class SubtitlesModule {}

--- a/backend/src/modules/subtitles/translation-provider.service.ts
+++ b/backend/src/modules/subtitles/translation-provider.service.ts
@@ -1,0 +1,199 @@
+import { Injectable, Logger, NotFoundException, OnModuleInit } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TranslationProvider } from './entities/translation-provider.entity';
+import { CreateTranslationProviderDto } from './dto/create-translation-provider.dto';
+import { UpdateTranslationProviderDto } from './dto/update-translation-provider.dto';
+import { TranslationProviderFactory } from './providers/translation-provider.factory';
+import { SubtitleTranslationSettingsCache } from './subtitle-translation-settings-cache.service';
+import { TranslationEngine } from '../../common/enums';
+
+/** Trigger-facing projection of an enabled provider — never carries `settings`
+ *  (API keys), so it is safe to hand to a non-admin at translate time. */
+export interface AvailableTranslationProvider {
+  id: number;
+  name: string;
+  engine: TranslationEngine;
+  isDefault: boolean;
+}
+
+@Injectable()
+export class TranslationProviderService implements OnModuleInit {
+  private readonly log = new Logger(TranslationProviderService.name);
+
+  constructor(
+    @InjectRepository(TranslationProvider)
+    private readonly repo: Repository<TranslationProvider>,
+    private readonly factory: TranslationProviderFactory,
+    private readonly legacySettings: SubtitleTranslationSettingsCache,
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    await this.seedFromLegacyConfig();
+  }
+
+  async create(dto: CreateTranslationProviderDto): Promise<TranslationProvider> {
+    const provider = this.repo.create({
+      name: dto.name,
+      engine: dto.engine,
+      settings: dto.settings ?? {},
+      enabled: dto.enabled ?? true,
+      isDefault: dto.isDefault ?? false,
+    });
+    const saved = await this.repo.save(provider);
+    if (saved.isDefault) await this.clearOtherDefaults(saved.id);
+    return this.findOne(saved.id);
+  }
+
+  findAll(): Promise<TranslationProvider[]> {
+    return this.repo.find({ order: { isDefault: 'DESC', name: 'ASC' } });
+  }
+
+  async findOne(id: number): Promise<TranslationProvider> {
+    const provider = await this.repo.findOne({ where: { id } });
+    if (!provider)
+      throw new NotFoundException(`TranslationProvider #${id} not found`);
+    return provider;
+  }
+
+  findEnabled(): Promise<TranslationProvider[]> {
+    return this.repo.find({
+      where: { enabled: true },
+      order: { isDefault: 'DESC', id: 'ASC' },
+    });
+  }
+
+  /** The provider used when a translate call omits `providerId`: the enabled
+   *  default, else the first enabled provider, else null. */
+  async findDefault(): Promise<TranslationProvider | null> {
+    const enabled = await this.findEnabled();
+    return enabled.find((p) => p.isDefault) ?? enabled[0] ?? null;
+  }
+
+  async listAvailable(): Promise<AvailableTranslationProvider[]> {
+    const enabled = await this.findEnabled();
+    return enabled.map((p) => ({
+      id: p.id,
+      name: p.name,
+      engine: p.engine,
+      isDefault: p.isDefault,
+    }));
+  }
+
+  async update(
+    id: number,
+    dto: UpdateTranslationProviderDto,
+  ): Promise<TranslationProvider> {
+    const provider = await this.findOne(id);
+    if (dto.name !== undefined) provider.name = dto.name;
+    if (dto.engine !== undefined) provider.engine = dto.engine;
+    if (dto.settings !== undefined) provider.settings = dto.settings;
+    if (dto.enabled !== undefined) provider.enabled = dto.enabled;
+    if (dto.isDefault !== undefined) provider.isDefault = dto.isDefault;
+    const saved = await this.repo.save(provider);
+    if (dto.isDefault === true) await this.clearOtherDefaults(saved.id);
+    return this.findOne(saved.id);
+  }
+
+  async remove(id: number): Promise<void> {
+    const provider = await this.findOne(id);
+    const wasDefault = provider.isDefault;
+    await this.repo.remove(provider);
+    if (wasDefault) await this.promoteNextDefault();
+  }
+
+  async testProvider(id: number): Promise<{ ok: boolean; error?: string }> {
+    const provider = await this.findOne(id);
+    return this.testConnection(provider.engine, provider.settings);
+  }
+
+  /** One short live round-trip through the engine so the admin can confirm the
+   *  config works. Uses the normal retry path (a transient 429 shouldn't read
+   *  as broken) but a 2-line payload to keep it cheap and avoid a single-line
+   *  count-mismatch split. */
+  async testConnection(
+    engine: TranslationEngine,
+    settings: Record<string, unknown>,
+  ): Promise<{ ok: boolean; error?: string }> {
+    try {
+      this.factory.validateConfig(engine, settings);
+      const out = await this.factory.translate(
+        engine,
+        ['Hello.', 'Good morning.'],
+        { sourceLanguage: 'en', targetLanguage: 'fr', context: {} },
+        settings,
+      );
+      if (!out?.length) return { ok: false, error: 'Empty translation response' };
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  private async clearOtherDefaults(keepId: number): Promise<void> {
+    await this.repo
+      .createQueryBuilder()
+      .update(TranslationProvider)
+      .set({ isDefault: false })
+      .where('id != :keepId', { keepId })
+      .andWhere('"isDefault" = true')
+      .execute();
+  }
+
+  private async promoteNextDefault(): Promise<void> {
+    const next = await this.repo.findOne({
+      where: { enabled: true },
+      order: { id: 'ASC' },
+    });
+    if (next && !next.isDefault) {
+      next.isDefault = true;
+      await this.repo.save(next);
+    }
+  }
+
+  /** On first boot with no providers, migrate the single legacy
+   *  `subtitle_translation_*` engine config into one enabled default provider so
+   *  installs that were already translating keep working with zero admin action.
+   *  Idempotent and table-safe (no-op once any provider exists). */
+  private async seedFromLegacyConfig(): Promise<void> {
+    try {
+      if ((await this.repo.count()) > 0) return;
+      const legacy = await this.legacySettings.get();
+      const settings = this.legacyEngineSettings(legacy);
+      try {
+        this.factory.validateConfig(legacy.engine, settings);
+      } catch {
+        return; // legacy config isn't usable — nothing worth seeding
+      }
+      await this.repo.save(
+        this.repo.create({
+          name: this.engineLabel(legacy.engine),
+          engine: legacy.engine,
+          settings,
+          enabled: true,
+          isDefault: true,
+        }),
+      );
+      this.log.log(
+        `Seeded a "${legacy.engine}" translation provider from legacy settings`,
+      );
+    } catch (err) {
+      // Table may not exist yet under some startup orderings; a later boot seeds.
+      this.log.warn(`Translation-provider seed skipped: ${err}`);
+    }
+  }
+
+  private legacyEngineSettings(
+    legacy: Awaited<ReturnType<SubtitleTranslationSettingsCache['get']>>,
+  ): Record<string, unknown> {
+    if (legacy.engine === 'openai') return { ...legacy.openai };
+    if (legacy.engine === 'libretranslate') return { ...legacy.libretranslate };
+    return { ...legacy.gemini };
+  }
+
+  private engineLabel(engine: TranslationEngine): string {
+    if (engine === 'openai') return 'OpenAI-compatible';
+    if (engine === 'libretranslate') return 'LibreTranslate';
+    return 'Gemini';
+  }
+}

--- a/backend/src/modules/subtitles/translation-providers.controller.ts
+++ b/backend/src/modules/subtitles/translation-providers.controller.ts
@@ -1,0 +1,81 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
+import { TranslationProviderService } from './translation-provider.service';
+import { CreateTranslationProviderDto } from './dto/create-translation-provider.dto';
+import { UpdateTranslationProviderDto } from './dto/update-translation-provider.dto';
+import { TestTranslationProviderDto } from './dto/test-translation-provider.dto';
+import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
+import { PoliciesGuard } from '../auth/casl/policies.guard';
+import { CheckPolicies } from '../auth/casl/check-policies.decorator';
+import { Action } from '../auth/casl/actions.enum';
+import { TranslationProvider } from './entities/translation-provider.entity';
+import { SubtitleFile } from './entities/subtitle-file.entity';
+
+@Controller('subtitles/translation-providers')
+@UseGuards(JwtOrApiKeyGuard, PoliciesGuard)
+export class TranslationProvidersController {
+  constructor(private readonly service: TranslationProviderService) {}
+
+  /** Enabled providers without secrets — the list a user picks from when
+   *  triggering a translation. Guarded by the *translate* capability so a user
+   *  who can list can also submit (no 403-after-pick). */
+  @Get('available')
+  @CheckPolicies((ability) => ability.can(Action.Create, SubtitleFile))
+  listAvailable() {
+    return this.service.listAvailable();
+  }
+
+  @Post('test-connection')
+  @CheckPolicies((ability) => ability.can(Action.Read, TranslationProvider))
+  testConnection(@Body() dto: TestTranslationProviderDto) {
+    return this.service.testConnection(dto.engine, dto.settings ?? {});
+  }
+
+  @Post()
+  @CheckPolicies((ability) => ability.can(Action.Create, TranslationProvider))
+  create(@Body() dto: CreateTranslationProviderDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  @CheckPolicies((ability) => ability.can(Action.Read, TranslationProvider))
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  @CheckPolicies((ability) => ability.can(Action.Read, TranslationProvider))
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.service.findOne(id);
+  }
+
+  @Put(':id')
+  @CheckPolicies((ability) => ability.can(Action.Update, TranslationProvider))
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateTranslationProviderDto,
+  ) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  @CheckPolicies((ability) => ability.can(Action.Delete, TranslationProvider))
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.service.remove(id);
+  }
+
+  @Post(':id/test')
+  @CheckPolicies((ability) => ability.can(Action.Read, TranslationProvider))
+  testProvider(@Param('id', ParseIntPipe) id: number) {
+    return this.service.testProvider(id);
+  }
+}

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1283,6 +1283,7 @@
     "no": "No",
     "save": "Save",
     "delete": "Delete",
+    "edit": "Edit",
     "refresh": "Refresh",
     "active": "Active",
     "disabled": "Disabled",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -952,6 +952,8 @@
     "translate_processing": "Translating",
     "translation_in_progress": "Translating subtitles: {{langs}}",
     "translate_target_language": "Target language",
+    "translate_provider": "Translation provider",
+    "translate_no_providers": "No translation provider is configured. Ask an admin to add one in settings.",
     "translate_hint": "Create a new subtitle by translating this one. The translation runs in the background and keeps the original timing.",
     "translation_started": "Translation started — the subtitle will appear once ready.",
     "translation_rate_limited": "Gemini quota or rate limit reached — try again later, or check your API plan.",
@@ -2117,7 +2119,14 @@
       "translation_openai_model": "Model",
       "translation_libretranslate_url": "Server URL",
       "translation_libretranslate_url_hint": "Point to your LibreTranslate container, e.g. http://libretranslate:5000.",
-      "translation_api_key_optional": "API key (optional)"
+      "translation_api_key_optional": "API key (optional)",
+      "translation_new": "Add provider",
+      "translation_empty": "No translation provider configured yet.",
+      "translation_col_engine": "Engine",
+      "translation_default": "Default",
+      "translation_editor_create": "New translation provider",
+      "translation_editor_edit": "Edit translation provider",
+      "translation_set_default": "Use as default"
     },
     "schedulers": {
       "title": "Scheduled tasks",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1283,6 +1283,7 @@
     "no": "Non",
     "save": "Enregistrer",
     "delete": "Supprimer",
+    "edit": "Modifier",
     "refresh": "Actualiser",
     "active": "Actif",
     "disabled": "Désactivé",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -952,6 +952,8 @@
     "translate_processing": "Traduction",
     "translation_in_progress": "Traduction des sous-titres en cours : {{langs}}",
     "translate_target_language": "Langue cible",
+    "translate_provider": "Fournisseur de traduction",
+    "translate_no_providers": "Aucun fournisseur de traduction n'est configuré. Demandez à un administrateur d'en ajouter un dans les réglages.",
     "translate_hint": "Créer un nouveau sous-titre en traduisant celui-ci. La traduction s'exécute en arrière-plan et conserve le minutage d'origine.",
     "translation_started": "Traduction lancée — le sous-titre apparaîtra une fois prêt.",
     "translation_rate_limited": "Quota ou limite Gemini atteint — réessayez plus tard, ou vérifiez votre offre API.",
@@ -2117,7 +2119,14 @@
       "translation_openai_model": "Modèle",
       "translation_libretranslate_url": "URL du serveur",
       "translation_libretranslate_url_hint": "Pointez vers votre conteneur LibreTranslate, ex. http://libretranslate:5000.",
-      "translation_api_key_optional": "Clé API (optionnelle)"
+      "translation_api_key_optional": "Clé API (optionnelle)",
+      "translation_new": "Ajouter un fournisseur",
+      "translation_empty": "Aucun fournisseur de traduction configuré pour le moment.",
+      "translation_col_engine": "Moteur",
+      "translation_default": "Par défaut",
+      "translation_editor_create": "Nouveau fournisseur de traduction",
+      "translation_editor_edit": "Modifier le fournisseur de traduction",
+      "translation_set_default": "Utiliser par défaut"
     },
     "schedulers": {
       "title": "Tâches planifiées",

--- a/client/src/app/core/services/api/subtitles-api.service.ts
+++ b/client/src/app/core/services/api/subtitles-api.service.ts
@@ -82,11 +82,16 @@ export class SubtitlesApiService {
     );
   }
 
-  translate(mediaId: number, subtitleId: number, targetLanguage: string) {
+  translate(
+    mediaId: number,
+    subtitleId: number,
+    targetLanguage: string,
+    providerId?: number,
+  ) {
     return firstValueFrom(
       this.http.post<SubtitleFileRow | null>(
         `/api/media/${mediaId}/subtitles/${subtitleId}/translate`,
-        { targetLanguage },
+        { targetLanguage, ...(providerId != null ? { providerId } : {}) },
       ),
     );
   }

--- a/client/src/app/core/services/api/translation-providers-api.service.ts
+++ b/client/src/app/core/services/api/translation-providers-api.service.ts
@@ -1,0 +1,86 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+
+export type TranslationEngine = 'gemini' | 'openai' | 'libretranslate';
+
+export interface TranslationProviderRow {
+  id: number;
+  name: string;
+  engine: TranslationEngine;
+  enabled: boolean;
+  isDefault: boolean;
+  settings: Record<string, unknown>;
+}
+
+export interface CreateTranslationProviderBody {
+  name: string;
+  engine: TranslationEngine;
+  settings?: Record<string, unknown>;
+  enabled?: boolean;
+  isDefault?: boolean;
+}
+
+export interface TestTranslationProviderBody {
+  engine: TranslationEngine;
+  settings?: Record<string, unknown>;
+}
+
+/** Secret-free projection handed to a user when they trigger a translation. */
+export interface AvailableTranslationProvider {
+  id: number;
+  name: string;
+  engine: TranslationEngine;
+  isDefault: boolean;
+}
+
+export interface TranslationTestResult {
+  ok: boolean;
+  error?: string;
+}
+
+const BASE = '/api/subtitles/translation-providers';
+
+@Injectable({ providedIn: 'root' })
+export class TranslationProvidersApiService {
+  private readonly http = inject(HttpClient);
+
+  list() {
+    return firstValueFrom(this.http.get<TranslationProviderRow[]>(BASE));
+  }
+
+  get(id: number) {
+    return firstValueFrom(this.http.get<TranslationProviderRow>(`${BASE}/${id}`));
+  }
+
+  create(body: CreateTranslationProviderBody) {
+    return firstValueFrom(this.http.post<TranslationProviderRow>(BASE, body));
+  }
+
+  update(id: number, body: Partial<CreateTranslationProviderBody>) {
+    return firstValueFrom(this.http.put<TranslationProviderRow>(`${BASE}/${id}`, body));
+  }
+
+  remove(id: number) {
+    return firstValueFrom(this.http.delete<void>(`${BASE}/${id}`));
+  }
+
+  testConnection(body: TestTranslationProviderBody) {
+    return firstValueFrom(
+      this.http.post<TranslationTestResult>(`${BASE}/test-connection`, body),
+    );
+  }
+
+  testProvider(id: number) {
+    return firstValueFrom(
+      this.http.post<TranslationTestResult>(`${BASE}/${id}/test`, {}),
+    );
+  }
+
+  /** Enabled providers (no secrets) for the translate picker. */
+  getAvailable() {
+    return firstValueFrom(
+      this.http.get<AvailableTranslationProvider[]>(`${BASE}/available`),
+    );
+  }
+}

--- a/client/src/app/core/services/subtitle-actions.service.ts
+++ b/client/src/app/core/services/subtitle-actions.service.ts
@@ -83,11 +83,11 @@ export class SubtitleActionsService {
   async translateSubtitle(
     mediaId: number, subtitleId: number,
     subtitles: WritableSignal<SubtitleFileRow[]>, busy: WritableSignal<boolean>,
-    targetLanguage: string,
+    targetLanguage: string, providerId?: number,
   ) {
     busy.set(true);
     try {
-      await this.subtitlesApi.translate(mediaId, subtitleId, targetLanguage);
+      await this.subtitlesApi.translate(mediaId, subtitleId, targetLanguage, providerId);
       subtitles.set(await this.subtitlesApi.getForMedia(mediaId));
     } finally {
       busy.set(false);

--- a/client/src/app/features/settings/subtitle-providers/subtitle-providers.html
+++ b/client/src/app/features/settings/subtitle-providers/subtitle-providers.html
@@ -12,118 +12,75 @@
   <!-- AI subtitle translation -->
   <div class="card bg-base-100 border border-base-200">
     <div class="card-body gap-4">
-      <div>
-        <h2 class="card-title text-lg">{{ 'settings.subtitle_providers.translation_title' | translate }}</h2>
-        <p class="text-sm text-base-content/60">{{ 'settings.subtitle_providers.translation_hint' | translate }}</p>
+      <div class="flex items-start justify-between gap-4">
+        <div>
+          <h2 class="card-title text-lg">{{ 'settings.subtitle_providers.translation_title' | translate }}</h2>
+          <p class="text-sm text-base-content/60">{{ 'settings.subtitle_providers.translation_hint' | translate }}</p>
+        </div>
+        <button type="button" class="btn btn-primary btn-sm shrink-0" (click)="openCreateTranslation()">
+          {{ 'settings.subtitle_providers.translation_new' | translate }}
+        </button>
       </div>
+
       <label class="label cursor-pointer justify-start gap-3 w-fit">
         <input
           type="checkbox"
           class="toggle toggle-primary"
+          [disabled]="savingTranslationEnabled()"
           [ngModel]="translationEnabled()"
-          (ngModelChange)="translationEnabled.set($event)"
+          (ngModelChange)="saveTranslationEnabled($event)"
         />
         <span class="label-text">{{ 'settings.subtitle_providers.translation_enabled' | translate }}</span>
       </label>
 
-      <label class="form-control w-full max-w-md">
-        <span class="label-text">{{ 'settings.subtitle_providers.translation_engine' | translate }}</span>
-        <select
-          class="select select-bordered select-sm w-full"
-          [ngModel]="translationEngine()"
-          (ngModelChange)="translationEngine.set($event)"
-        >
-          <option value="gemini">{{ 'settings.subtitle_providers.translation_engine_gemini' | translate }}</option>
-          <option value="openai">{{ 'settings.subtitle_providers.translation_engine_openai' | translate }}</option>
-          <option value="libretranslate">{{ 'settings.subtitle_providers.translation_engine_libretranslate' | translate }}</option>
-        </select>
-      </label>
-
-      @if (translationEngine() === 'gemini') {
-        <label class="form-control w-full max-w-md">
-          <span class="label-text">{{ 'settings.subtitle_providers.translation_api_key' | translate }}</span>
-          <input
-            type="text"
-            class="input input-bordered input-sm w-full font-mono"
-            [ngModel]="geminiApiKey()"
-            (ngModelChange)="geminiApiKey.set($event)"
-          />
-        </label>
-        <label class="form-control w-full max-w-md">
-          <span class="label-text">{{ 'settings.subtitle_providers.translation_model' | translate }}</span>
-          <select
-            class="select select-bordered select-sm w-full font-mono"
-            [ngModel]="geminiModel()"
-            (ngModelChange)="geminiModel.set($event)"
-          >
-            @if (!geminiModels.includes(geminiModel())) {
-              <option [value]="geminiModel()">{{ geminiModel() }}</option>
-            }
-            @for (m of geminiModels; track m) {
-              <option [value]="m">{{ m }}</option>
-            }
-          </select>
-        </label>
-      } @else if (translationEngine() === 'openai') {
-        <label class="form-control w-full max-w-md">
-          <span class="label-text">{{ 'settings.subtitle_providers.translation_openai_base_url' | translate }}</span>
-          <input
-            type="text"
-            class="input input-bordered input-sm w-full font-mono"
-            placeholder="https://api.groq.com/openai/v1"
-            [ngModel]="openaiBaseUrl()"
-            (ngModelChange)="openaiBaseUrl.set($event)"
-          />
-          <span class="text-xs text-base-content/50 mt-1">{{ 'settings.subtitle_providers.translation_openai_base_url_hint' | translate }}</span>
-        </label>
-        <label class="form-control w-full max-w-md">
-          <span class="label-text">{{ 'settings.subtitle_providers.translation_api_key_optional' | translate }}</span>
-          <input
-            type="text"
-            class="input input-bordered input-sm w-full font-mono"
-            [ngModel]="openaiApiKey()"
-            (ngModelChange)="openaiApiKey.set($event)"
-          />
-        </label>
-        <label class="form-control w-full max-w-md">
-          <span class="label-text">{{ 'settings.subtitle_providers.translation_openai_model' | translate }}</span>
-          <input
-            type="text"
-            class="input input-bordered input-sm w-full font-mono"
-            placeholder="llama-3.3-70b-versatile"
-            [ngModel]="openaiModel()"
-            (ngModelChange)="openaiModel.set($event)"
-          />
-        </label>
+      @if (translationLoading()) {
+        <div class="flex justify-center py-6"><span class="loading loading-spinner"></span></div>
+      } @else if (translationRows().length === 0) {
+        <p class="text-sm text-base-content/50 py-4">{{ 'settings.subtitle_providers.translation_empty' | translate }}</p>
       } @else {
-        <label class="form-control w-full max-w-md">
-          <span class="label-text">{{ 'settings.subtitle_providers.translation_libretranslate_url' | translate }}</span>
-          <input
-            type="text"
-            class="input input-bordered input-sm w-full font-mono"
-            placeholder="http://libretranslate:5000"
-            [ngModel]="libreUrl()"
-            (ngModelChange)="libreUrl.set($event)"
-          />
-          <span class="text-xs text-base-content/50 mt-1">{{ 'settings.subtitle_providers.translation_libretranslate_url_hint' | translate }}</span>
-        </label>
-        <label class="form-control w-full max-w-md">
-          <span class="label-text">{{ 'settings.subtitle_providers.translation_api_key_optional' | translate }}</span>
-          <input
-            type="text"
-            class="input input-bordered input-sm w-full font-mono"
-            [ngModel]="libreApiKey()"
-            (ngModelChange)="libreApiKey.set($event)"
-          />
-        </label>
+        <div class="overflow-x-auto rounded-lg border border-base-200">
+          <table class="table table-sm">
+            <thead>
+              <tr>
+                <th>{{ 'settings.subtitle_providers.col_name' | translate }}</th>
+                <th>{{ 'settings.subtitle_providers.translation_col_engine' | translate }}</th>
+                <th class="text-center">{{ 'settings.subtitle_providers.col_status' | translate }}</th>
+                <th class="text-end w-32">{{ 'settings.subtitle_providers.actions' | translate }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (row of translationRows(); track row.id) {
+                <tr>
+                  <td class="font-medium">
+                    {{ row.name }}
+                    @if (row.isDefault) {
+                      <span class="badge badge-primary badge-sm ms-2">{{ 'settings.subtitle_providers.translation_default' | translate }}</span>
+                    }
+                  </td>
+                  <td class="text-sm">{{ translationEngineLabel(row.engine) }}</td>
+                  <td class="text-center">
+                    @if (row.enabled) {
+                      <span class="badge badge-success badge-sm">ON</span>
+                    } @else {
+                      <span class="badge badge-ghost badge-sm">OFF</span>
+                    }
+                  </td>
+                  <td class="text-end">
+                    <div class="flex justify-end gap-1">
+                      <button type="button" class="btn btn-ghost btn-xs" (click)="openEditTranslation(row)">
+                        {{ 'common.edit' | translate }}
+                      </button>
+                      <button type="button" class="btn btn-ghost btn-xs text-error" (click)="deleteTranslationProvider(row)">
+                        {{ 'common.delete' | translate }}
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
       }
-
-      <div>
-        <button type="button" class="btn btn-primary" (click)="saveTranslation()" [disabled]="savingTranslation()">
-          @if (savingTranslation()) { <span class="loading loading-spinner loading-sm"></span> }
-          {{ 'common.save' | translate }}
-        </button>
-      </div>
     </div>
   </div>
 
@@ -326,5 +283,125 @@
     </div>
     <form method="dialog" class="modal-backdrop">
       <button type="button" (click)="closeStats()">close</button>
+    </form>
+  </dialog>
+
+  <dialog #translationEditorDialog class="modal">
+    <div class="modal-box max-w-xl max-h-[90vh] flex flex-col">
+      <h2 class="text-lg font-bold shrink-0">
+        @if (trEditingId() === null) {
+          {{ 'settings.subtitle_providers.translation_editor_create' | translate }}
+        } @else {
+          {{ 'settings.subtitle_providers.translation_editor_edit' | translate }}
+        }
+      </h2>
+
+      <div class="flex flex-col gap-3 py-3 overflow-y-auto">
+        <label class="form-control w-full">
+          <span class="label-text">{{ 'settings.subtitle_providers.col_name' | translate }}</span>
+          <input type="text" class="input input-bordered input-sm w-full"
+            [ngModel]="trFormName()" (ngModelChange)="trFormName.set($event)" />
+        </label>
+
+        <label class="form-control w-full">
+          <span class="label-text">{{ 'settings.subtitle_providers.translation_engine' | translate }}</span>
+          <select class="select select-bordered select-sm w-full"
+            [ngModel]="trFormEngine()" (ngModelChange)="onTranslationEngineChange($event)">
+            @for (e of translationEngines; track e.value) {
+              <option [value]="e.value">{{ e.label }}</option>
+            }
+          </select>
+        </label>
+
+        @if (trFormEngine() === 'gemini') {
+          <label class="form-control w-full">
+            <span class="label-text">{{ 'settings.subtitle_providers.translation_api_key' | translate }}</span>
+            <input type="text" class="input input-bordered input-sm w-full font-mono"
+              [ngModel]="trFormApiKey()" (ngModelChange)="trFormApiKey.set($event)" />
+          </label>
+          <label class="form-control w-full">
+            <span class="label-text">{{ 'settings.subtitle_providers.translation_model' | translate }}</span>
+            <select class="select select-bordered select-sm w-full font-mono"
+              [ngModel]="trFormModel()" (ngModelChange)="trFormModel.set($event)">
+              @if (!geminiModels.includes(trFormModel())) {
+                <option [value]="trFormModel()">{{ trFormModel() }}</option>
+              }
+              @for (m of geminiModels; track m) {
+                <option [value]="m">{{ m }}</option>
+              }
+            </select>
+          </label>
+        } @else if (trFormEngine() === 'openai') {
+          <label class="form-control w-full">
+            <span class="label-text">{{ 'settings.subtitle_providers.translation_openai_base_url' | translate }}</span>
+            <input type="text" class="input input-bordered input-sm w-full font-mono"
+              placeholder="https://api.groq.com/openai/v1"
+              [ngModel]="trFormBaseUrl()" (ngModelChange)="trFormBaseUrl.set($event)" />
+            <span class="text-xs text-base-content/50 mt-1">{{ 'settings.subtitle_providers.translation_openai_base_url_hint' | translate }}</span>
+          </label>
+          <label class="form-control w-full">
+            <span class="label-text">{{ 'settings.subtitle_providers.translation_api_key_optional' | translate }}</span>
+            <input type="text" class="input input-bordered input-sm w-full font-mono"
+              [ngModel]="trFormApiKey()" (ngModelChange)="trFormApiKey.set($event)" />
+          </label>
+          <label class="form-control w-full">
+            <span class="label-text">{{ 'settings.subtitle_providers.translation_openai_model' | translate }}</span>
+            <input type="text" class="input input-bordered input-sm w-full font-mono"
+              placeholder="llama-3.3-70b-versatile"
+              [ngModel]="trFormModel()" (ngModelChange)="trFormModel.set($event)" />
+          </label>
+        } @else {
+          <label class="form-control w-full">
+            <span class="label-text">{{ 'settings.subtitle_providers.translation_libretranslate_url' | translate }}</span>
+            <input type="text" class="input input-bordered input-sm w-full font-mono"
+              placeholder="http://libretranslate:5000"
+              [ngModel]="trFormUrl()" (ngModelChange)="trFormUrl.set($event)" />
+            <span class="text-xs text-base-content/50 mt-1">{{ 'settings.subtitle_providers.translation_libretranslate_url_hint' | translate }}</span>
+          </label>
+          <label class="form-control w-full">
+            <span class="label-text">{{ 'settings.subtitle_providers.translation_api_key_optional' | translate }}</span>
+            <input type="text" class="input input-bordered input-sm w-full font-mono"
+              [ngModel]="trFormApiKey()" (ngModelChange)="trFormApiKey.set($event)" />
+          </label>
+        }
+
+        <div class="flex gap-6">
+          <label class="flex items-center gap-2">
+            <input type="checkbox" class="checkbox checkbox-sm"
+              [ngModel]="trFormEnabled()" (ngModelChange)="trFormEnabled.set($event)" />
+            <span class="label-text">{{ 'settings.subtitle_providers.field_enabled' | translate }}</span>
+          </label>
+          <label class="flex items-center gap-2">
+            <input type="checkbox" class="checkbox checkbox-sm"
+              [ngModel]="trFormDefault()" (ngModelChange)="trFormDefault.set($event)" />
+            <span class="label-text">{{ 'settings.subtitle_providers.translation_set_default' | translate }}</span>
+          </label>
+        </div>
+
+        <div class="flex items-center gap-2">
+          <button type="button" class="btn btn-outline btn-sm" (click)="testTranslation()" [disabled]="trTestLoading()">
+            @if (trTestLoading()) { <span class="loading loading-spinner loading-xs"></span> }
+            {{ 'settings.subtitle_providers.test' | translate }}
+          </button>
+          @if (trTestResult(); as r) {
+            <span class="text-sm" [class.text-success]="r.ok" [class.text-error]="!r.ok">{{ r.message }}</span>
+          }
+        </div>
+      </div>
+
+      <div class="modal-action shrink-0">
+        <button type="button" class="btn btn-ghost" (click)="closeTranslationEditor()" [disabled]="trSaving()">
+          {{ 'settings.subtitle_providers.cancel' | translate }}
+        </button>
+        <button type="button" class="btn btn-primary" (click)="saveTranslationProvider()" [disabled]="trSaving()">
+          @if (trSaving()) { <span class="loading loading-spinner loading-sm"></span> }
+          {{ 'settings.subtitle_providers.save' | translate }}
+        </button>
+      </div>
+    </div>
+    <form method="dialog" class="modal-backdrop">
+      <button type="button" (click)="closeTranslationEditor()" [attr.aria-label]="'common.close' | translate">
+        {{ 'common.close' | translate }}
+      </button>
     </form>
   </dialog>

--- a/client/src/app/features/settings/subtitle-providers/subtitle-providers.ts
+++ b/client/src/app/features/settings/subtitle-providers/subtitle-providers.ts
@@ -17,6 +17,11 @@ import {
   SubtitleProviderRow,
   ProviderRateLimit,
 } from '../../../core/services/api/subtitle-providers-api.service';
+import {
+  TranslationProvidersApiService,
+  TranslationProviderRow,
+  TranslationEngine,
+} from '../../../core/services/api/translation-providers-api.service';
 
 const DEFAULT_TRANSLATION_MODEL = 'gemini-2.0-flash';
 
@@ -27,6 +32,12 @@ const GEMINI_MODELS = [
   'gemini-2.0-flash-lite',
   'gemini-1.5-flash',
   'gemini-1.5-pro',
+];
+
+const TRANSLATION_ENGINES: { value: TranslationEngine; label: string }[] = [
+  { value: 'gemini', label: 'Gemini' },
+  { value: 'openai', label: 'OpenAI-compatible' },
+  { value: 'libretranslate', label: 'LibreTranslate' },
 ];
 
 const PROVIDER_TYPES = [
@@ -46,6 +57,7 @@ const PROVIDER_TYPES = [
 })
 export class SubtitleProvidersSettingsComponent implements OnInit {
   private readonly api = inject(SubtitleProvidersApiService);
+  private readonly translationApi = inject(TranslationProvidersApiService);
   private readonly settingsApi = inject(SettingsApiService);
   private readonly translate = inject(TranslateService);
   private readonly confirmation = inject(ConfirmationService);
@@ -53,6 +65,7 @@ export class SubtitleProvidersSettingsComponent implements OnInit {
 
   private readonly editorDialog = viewChild<ElementRef<HTMLDialogElement>>('editorDialog');
   private readonly statsDialog = viewChild<ElementRef<HTMLDialogElement>>('statsDialog');
+  private readonly translationEditorDialog = viewChild<ElementRef<HTMLDialogElement>>('translationEditorDialog');
 
   readonly providerTypes = PROVIDER_TYPES;
   readonly rows = signal<SubtitleProviderRow[]>([]);
@@ -81,68 +94,198 @@ export class SubtitleProvidersSettingsComponent implements OnInit {
   readonly statsData = signal<{ date: string; queries: number; avgResponseMs: number; totalResults: number; errors: number }[]>([]);
   readonly statsProviderName = signal('');
 
-  // Machine-translation settings — stored in the app key/value store.
+  // Machine-translation — a list of admin-configured providers plus the global
+  // on/off master switch (still an app key/value setting).
   readonly geminiModels = GEMINI_MODELS;
+  readonly translationEngines = TRANSLATION_ENGINES;
   readonly translationEnabled = signal(false);
-  readonly translationEngine = signal<'gemini' | 'openai' | 'libretranslate'>('gemini');
-  readonly geminiApiKey = signal('');
-  readonly geminiModel = signal(DEFAULT_TRANSLATION_MODEL);
-  readonly openaiBaseUrl = signal('');
-  readonly openaiApiKey = signal('');
-  readonly openaiModel = signal('');
-  readonly libreUrl = signal('');
-  readonly libreApiKey = signal('');
-  readonly savingTranslation = signal(false);
+  readonly savingTranslationEnabled = signal(false);
+  readonly translationRows = signal<TranslationProviderRow[]>([]);
+  readonly translationLoading = signal(true);
+
+  readonly trEditingId = signal<number | null>(null);
+  readonly trSaving = signal(false);
+  readonly trFormName = signal('');
+  readonly trFormEngine = signal<TranslationEngine>('gemini');
+  readonly trFormEnabled = signal(true);
+  readonly trFormDefault = signal(false);
+  readonly trFormApiKey = signal('');
+  readonly trFormModel = signal(DEFAULT_TRANSLATION_MODEL);
+  readonly trFormBaseUrl = signal('');
+  readonly trFormUrl = signal('');
+  readonly trTestLoading = signal(false);
+  readonly trTestResult = signal<{ ok: boolean; message: string } | null>(null);
 
   ngOnInit() {
     this.reloadAll();
     void this.loadTranslationSettings();
+    void this.reloadTranslationProviders();
   }
 
   private async loadTranslationSettings() {
     try {
       const all = await this.settingsApi.getAll();
       this.translationEnabled.set(all['subtitle_translation_enabled'] === 'true');
-      const engine = all['subtitle_translation_engine'];
-      this.translationEngine.set(
-        engine === 'openai' || engine === 'libretranslate' ? engine : 'gemini',
-      );
-      this.geminiApiKey.set(all['subtitle_translation_gemini_api_key'] ?? '');
-      this.geminiModel.set(
-        all['subtitle_translation_gemini_model'] || DEFAULT_TRANSLATION_MODEL,
-      );
-      this.openaiBaseUrl.set(all['subtitle_translation_openai_base_url'] ?? '');
-      this.openaiApiKey.set(all['subtitle_translation_openai_api_key'] ?? '');
-      this.openaiModel.set(all['subtitle_translation_openai_model'] ?? '');
-      this.libreUrl.set(all['subtitle_translation_libretranslate_url'] ?? '');
-      this.libreApiKey.set(all['subtitle_translation_libretranslate_api_key'] ?? '');
     } catch {
       // handled by global error interceptor
     }
   }
 
-  async saveTranslation() {
-    this.savingTranslation.set(true);
+  async reloadTranslationProviders() {
+    this.translationLoading.set(true);
     try {
-      await this.settingsApi.setBulk({
-        subtitle_translation_enabled: String(this.translationEnabled()),
-        subtitle_translation_engine: this.translationEngine(),
-        subtitle_translation_gemini_api_key: this.geminiApiKey().trim(),
-        subtitle_translation_gemini_model:
-          this.geminiModel().trim() || DEFAULT_TRANSLATION_MODEL,
-        subtitle_translation_openai_base_url: this.openaiBaseUrl().trim(),
-        subtitle_translation_openai_api_key: this.openaiApiKey().trim(),
-        subtitle_translation_openai_model: this.openaiModel().trim(),
-        subtitle_translation_libretranslate_url: this.libreUrl().trim(),
-        subtitle_translation_libretranslate_api_key: this.libreApiKey().trim(),
-      });
-      this.toast.success(
-        this.translate.instant('settings.subtitle_providers.translation_saved'),
-      );
+      this.translationRows.set(await this.translationApi.list());
     } catch {
       // handled by global error interceptor
     } finally {
-      this.savingTranslation.set(false);
+      this.translationLoading.set(false);
+    }
+  }
+
+  async saveTranslationEnabled(enabled: boolean) {
+    this.translationEnabled.set(enabled);
+    this.savingTranslationEnabled.set(true);
+    try {
+      await this.settingsApi.setBulk({
+        subtitle_translation_enabled: String(enabled),
+      });
+    } catch {
+      this.translationEnabled.set(!enabled);
+    } finally {
+      this.savingTranslationEnabled.set(false);
+    }
+  }
+
+  translationEngineLabel(engine: string): string {
+    return TRANSLATION_ENGINES.find((e) => e.value === engine)?.label ?? engine;
+  }
+
+  openCreateTranslation() {
+    this.trEditingId.set(null);
+    this.trFormName.set(this.translationEngineLabel('gemini'));
+    this.trFormEngine.set('gemini');
+    this.trFormEnabled.set(true);
+    this.trFormDefault.set(this.translationRows().length === 0);
+    this.trFormApiKey.set('');
+    this.trFormModel.set(DEFAULT_TRANSLATION_MODEL);
+    this.trFormBaseUrl.set('');
+    this.trFormUrl.set('');
+    this.trTestResult.set(null);
+    this.translationEditorDialog()?.nativeElement.showModal();
+  }
+
+  openEditTranslation(row: TranslationProviderRow) {
+    this.trEditingId.set(row.id);
+    this.trFormName.set(row.name);
+    this.trFormEngine.set(row.engine);
+    this.trFormEnabled.set(row.enabled);
+    this.trFormDefault.set(row.isDefault);
+    const s = row.settings ?? {};
+    this.trFormApiKey.set(String(s['apiKey'] ?? ''));
+    this.trFormModel.set(String(s['model'] ?? '') || DEFAULT_TRANSLATION_MODEL);
+    this.trFormBaseUrl.set(String(s['baseUrl'] ?? ''));
+    this.trFormUrl.set(String(s['url'] ?? ''));
+    this.trTestResult.set(null);
+    this.translationEditorDialog()?.nativeElement.showModal();
+  }
+
+  onTranslationEngineChange(engine: TranslationEngine) {
+    this.trFormEngine.set(engine);
+    if (this.trEditingId() === null) {
+      this.trFormName.set(this.translationEngineLabel(engine));
+    }
+  }
+
+  closeTranslationEditor() {
+    this.translationEditorDialog()?.nativeElement.close();
+  }
+
+  private buildTranslationSettings(): Record<string, unknown> {
+    const engine = this.trFormEngine();
+    if (engine === 'openai') {
+      return {
+        baseUrl: this.trFormBaseUrl().trim(),
+        apiKey: this.trFormApiKey().trim(),
+        model: this.trFormModel().trim(),
+      };
+    }
+    if (engine === 'libretranslate') {
+      return { url: this.trFormUrl().trim(), apiKey: this.trFormApiKey().trim() };
+    }
+    return {
+      apiKey: this.trFormApiKey().trim(),
+      model: this.trFormModel().trim() || DEFAULT_TRANSLATION_MODEL,
+    };
+  }
+
+  async testTranslation() {
+    this.trTestResult.set(null);
+    this.trTestLoading.set(true);
+    try {
+      const res = await this.translationApi.testConnection({
+        engine: this.trFormEngine(),
+        settings: this.buildTranslationSettings(),
+      });
+      this.trTestResult.set({
+        ok: res.ok,
+        message: res.ok
+          ? this.translate.instant('settings.subtitle_providers.test_success')
+          : res.error ||
+            this.translate.instant('settings.subtitle_providers.test_failed'),
+      });
+    } catch {
+      this.trTestResult.set({
+        ok: false,
+        message: this.translate.instant('settings.subtitle_providers.test_network_error'),
+      });
+    } finally {
+      this.trTestLoading.set(false);
+    }
+  }
+
+  async saveTranslationProvider() {
+    const name = this.trFormName().trim();
+    if (!name) return;
+    const body = {
+      name,
+      engine: this.trFormEngine(),
+      enabled: this.trFormEnabled(),
+      isDefault: this.trFormDefault(),
+      settings: this.buildTranslationSettings(),
+    };
+    this.trSaving.set(true);
+    const id = this.trEditingId();
+    try {
+      await (id == null
+        ? this.translationApi.create(body)
+        : this.translationApi.update(id, body));
+      this.closeTranslationEditor();
+      await this.reloadTranslationProviders();
+    } catch {
+      // handled by global error interceptor
+    } finally {
+      this.trSaving.set(false);
+    }
+  }
+
+  async deleteTranslationProvider(row: TranslationProviderRow) {
+    const msg = this.translate.instant(
+      'settings.subtitle_providers.confirm_delete',
+      { name: row.name },
+    );
+    if (
+      !(await this.confirmation.confirm({
+        title: this.translate.instant('common.confirm'),
+        message: msg,
+        variant: 'danger',
+      }))
+    )
+      return;
+    try {
+      await this.translationApi.remove(row.id);
+      await this.reloadTranslationProviders();
+    } catch {
+      // handled by global error interceptor
     }
   }
 

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -504,6 +504,20 @@
         <option [value]="code">{{ code | localizeLanguage }}</option>
       }
     </select>
+    @if (langDialogMode() === 'translate' && translationProviders().length > 1) {
+      <label class="form-control w-full mt-3">
+        <span class="label-text">{{ 'media_detail.translate_provider' | translate }}</span>
+        <select
+          class="select select-bordered w-full"
+          [ngModel]="selectedTranslationProviderId()"
+          (ngModelChange)="selectedTranslationProviderId.set($event)"
+        >
+          @for (p of translationProviders(); track p.id) {
+            <option [ngValue]="p.id">{{ p.name }}</option>
+          }
+        </select>
+      </label>
+    }
     <div class="modal-action">
       <button type="button" class="btn" (click)="closeOcrLangModal()">{{ 'common.cancel' | translate }}</button>
       <button type="button" class="btn btn-primary" (click)="confirmLanguage()">

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -50,6 +50,10 @@ import {
   SyncOptions,
 } from '../../../core/services/api/subtitles-api.service';
 import { SubtitleActionsService } from '../../../core/services/subtitle-actions.service';
+import {
+  TranslationProvidersApiService,
+  AvailableTranslationProvider,
+} from '../../../core/services/api/translation-providers-api.service';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import {
   LanguageProfile,
@@ -110,6 +114,7 @@ interface SubtitleRow {
 export class SubtitlesModalComponent {
   private readonly subtitlesApi = inject(SubtitlesApiService);
   private readonly subActions = inject(SubtitleActionsService);
+  private readonly translationProvidersApi = inject(TranslationProvidersApiService);
   private readonly confirmation = inject(ConfirmationService);
   private readonly translate = inject(TranslateService);
   private readonly toast = inject(ToastService);
@@ -276,6 +281,10 @@ export class SubtitlesModalComponent {
   ];
   private readonly ocrTargetId = signal<number | null>(null);
   readonly ocrLang = signal('en');
+  /** Enabled translation providers, loaded when the translate dialog opens; the
+   *  user picks one (default preselected). */
+  readonly translationProviders = signal<AvailableTranslationProvider[]>([]);
+  readonly selectedTranslationProviderId = signal<number | null>(null);
   /** The language dialog drives OCR (pick before converting), relabel (reassign
    *  an existing subtitle's language) and translate (pick the target language). */
   readonly langDialogMode = signal<'ocr' | 'relabel' | 'translate'>('ocr');
@@ -671,8 +680,24 @@ export class SubtitlesModalComponent {
     this.ocrLangDialog()?.nativeElement.showModal();
   }
 
-  /** Translate a text subtitle: always pick the target language first. */
-  translateSubtitle(sub: SubtitleFileRow) {
+  /** Translate a text subtitle: pick the target language and provider first. */
+  async translateSubtitle(sub: SubtitleFileRow) {
+    let providers: AvailableTranslationProvider[] = [];
+    try {
+      providers = await this.translationProvidersApi.getAvailable();
+    } catch {
+      return; // global interceptor surfaced the error
+    }
+    if (providers.length === 0) {
+      this.toast.error(
+        this.translate.instant('media_detail.translate_no_providers'),
+      );
+      return;
+    }
+    this.translationProviders.set(providers);
+    this.selectedTranslationProviderId.set(
+      (providers.find((p) => p.isDefault) ?? providers[0]).id,
+    );
     const src = (sub.language ?? '').toLowerCase();
     this.langDialogMode.set('translate');
     this.ocrTargetId.set(sub.id);
@@ -698,7 +723,11 @@ export class SubtitlesModalComponent {
     if (mode === 'ocr') {
       void this.triggerOcr(id, this.ocrLang());
     } else if (mode === 'translate') {
-      void this.triggerTranslate(id, this.ocrLang());
+      void this.triggerTranslate(
+        id,
+        this.ocrLang(),
+        this.selectedTranslationProviderId() ?? undefined,
+      );
     } else {
       void this.subActions
         .setLanguage(this.mediaId(), id, this.subtitles, this.subtitleActionBusy, this.ocrLang());
@@ -720,13 +749,18 @@ export class SubtitlesModalComponent {
     this.toast.info(this.translate.instant('media_detail.ocr_started'));
   }
 
-  private async triggerTranslate(subtitleId: number, targetLanguage: string) {
+  private async triggerTranslate(
+    subtitleId: number,
+    targetLanguage: string,
+    providerId?: number,
+  ) {
     await this.subActions.translateSubtitle(
       this.mediaId(),
       subtitleId,
       this.subtitles,
       this.subtitleActionBusy,
       targetLanguage,
+      providerId,
     );
     this.toast.info(this.translate.instant('media_detail.translation_started'));
   }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -14,12 +14,11 @@
   --radius-box: 0.5rem;
 }
 
-/* Thinner focus outline on form fields. Suppress daisyUI's border on focus —
-   the focus ring (outline) is the only visual cue we want, the extra white
-   border doubled up with the ring looks noisy. */
+/* Form fields defer to the global primary box-shadow focus ring below. Drop
+   daisyUI's own focus outline (it draws a second, tighter ring inside the
+   box-shadow one) and its border-on-focus so the field shows a single ring. */
 .select:focus, .input:focus, .textarea:focus {
-  outline-width: 1px;
-  outline-offset: 0px;
+  outline: none;
   border-color: transparent;
 }
 


### PR DESCRIPTION
Implements **Plan A** (`plans/subtitle-multi-provider-translation.plan.md`) — management-first scope.

## What
Turns the single global translation engine into a list of admin-configured **translation providers**, and lets a user pick which one to use when they translate a subtitle.

## Backend
- New `translation_providers` table + `TranslationProvider` entity, mirroring the download-provider (`SubtitleProvider`) pattern: `TranslationProviderFactory` (engine dispatch + asymmetric `validateConfig`), `TranslationProviderService` (CRUD, `findDefault`, transactional `isDefault` exclusivity, live `testConnection`), `TranslationProvidersController` (`/api/subtitles/translation-providers`).
- **Authorization**: CRUD is admin-only (`Manage TranslationProvider`, registered in CASL); the secret-free `GET /available` list and the translate call are gated by the existing `Create SubtitleFile` capability — a user who can list can also submit (no 403-after-pick). API keys stay server-side (returned only to admins on CRUD, matching the download-provider precedent; excluded from `/available`).
- `POST /media/:id/subtitles/:subtitleId/translate` accepts an optional `providerId`; omitted → the configured default. Produced `SubtitleFile` rows persist `translationProviderId` + `translationEngine`/`translationModel` provenance snapshots.
- **Back-compat**: the global `subtitle_translation_enabled` master switch is unchanged; the legacy `subtitle_translation_*` engine config seeds one enabled **default** provider on first boot so installs that were translating keep working with zero admin action. Existing `translated` subtitles keep the new columns null.
- SSE `subtitle.downloaded` now carries the finished `subtitleId` (additive).

## Frontend
- New `TranslationProvidersApiService`.
- Settings → Subtitle providers: the single-engine translation form becomes a **provider list** (add/edit/remove/test/enable/default) with engine-conditional fields; the global on/off toggle is kept.
- The subtitle-management translate dialog gains a **provider picker** (default preselected, shown when >1 provider); "no providers configured" surfaces a toast pointing to settings.
- i18n: en + fr added; other locales fall back to en (`fallbackLang`).

## Scope / deferred
- Management surface only. The in-player "Translate…" entry is Phase 2 (it needs a player SSE subscription; overlaps Plan B #0/#4 and should be built once).
- No unit tests added (the subtitles module has no service-spec pattern to mirror yet) — flagged as a follow-up.

## Verify
- Backend `tsc` typecheck clean; client `ng build` green.
- Not yet exercised against a live backend/DB — needs a smoke test (create a provider, translate a subtitle, confirm provenance + default resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)