### PR TITLE
feat(subtitles): subtitle UX improvements (Plan B)

### DIFF
--- a/backend/src/migrations/1782400000000-add-subtitle-translation-provider-name.ts
+++ b/backend/src/migrations/1782400000000-add-subtitle-translation-provider-name.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Snapshots the translation provider's display name onto a translated subtitle
+ * so the source column can show the admin-given label (e.g. "Gemini Flash")
+ * even after the provider is renamed or removed. Existing rows stay null and
+ * fall back to the engine label.
+ */
+export class AddSubtitleTranslationProviderName1782400000000
+  implements MigrationInterface
+{
+  name = 'AddSubtitleTranslationProviderName1782400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "subtitle_files" ADD COLUMN "translationProviderName" varchar`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "subtitle_files" DROP COLUMN IF EXISTS "translationProviderName"`,
+    );
+  }
+}

--- a/backend/src/modules/profiles/dto/create-language-profile.dto.ts
+++ b/backend/src/modules/profiles/dto/create-language-profile.dto.ts
@@ -4,8 +4,12 @@ import {
   IsArray,
   ValidateNested,
   IsOptional,
+  IsIn,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import type { HearingImpairedMode } from '../entities/language-profile.entity';
+
+const HI_MODES: HearingImpairedMode[] = ['prefer', 'avoid', 'require', 'forbid'];
 
 export class AudioLanguageItemDto {
   @IsString()
@@ -27,6 +31,10 @@ export class SubtitleLanguageItemDto {
 
   @IsBoolean()
   hi: boolean;
+
+  @IsIn(HI_MODES)
+  @IsOptional()
+  hearingImpaired?: HearingImpairedMode;
 }
 
 export class CreateLanguageProfileDto {

--- a/backend/src/modules/subtitles/entities/subtitle-file.entity.ts
+++ b/backend/src/modules/subtitles/entities/subtitle-file.entity.ts
@@ -119,4 +119,9 @@ export class SubtitleFile extends BaseEntity {
 
   @Column({ type: 'varchar', nullable: true })
   translationModel: string | null;
+
+  /** The provider's admin-given name at translation time — shown as the source
+   *  label. Snapshotted so it survives a later rename or removal. */
+  @Column({ type: 'varchar', nullable: true })
+  translationProviderName: string | null;
 }

--- a/backend/src/modules/subtitles/subtitle-translation.service.ts
+++ b/backend/src/modules/subtitles/subtitle-translation.service.ts
@@ -125,6 +125,7 @@ export class SubtitleTranslationService {
       codec: 'subrip',
       score: source.score,
       translationProvider: { id: provider.id },
+      translationProviderName: provider.name,
       translationEngine: provider.engine,
       translationModel: this.translationFactory.resolveModel(
         provider.engine,

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1290,6 +1290,7 @@
     "save": "Save",
     "delete": "Delete",
     "edit": "Edit",
+    "download": "Download",
     "refresh": "Refresh",
     "active": "Active",
     "disabled": "Disabled",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -70,6 +70,7 @@
       "ocr": "OCR"
     },
     "playback_error": "Playback failed.",
+    "subtitle_load_failed": "Couldn't load that subtitle track.",
     "error_aborted": "Playback interrupted.",
     "error_network": "Network error during playback.",
     "error_decode": "Video decoding error.",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1005,6 +1005,7 @@
     "col_sub_title": "Title",
     "search": "Search",
     "no_subtitle_results": "No results found.",
+    "subtitle_downloads": "{{count}} downloads",
     "confirm_delete_subtitle": "Delete this subtitle?",
     "rejection": {
       "QUALITY_NOT_ALLOWED": "Quality outside profile",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2135,6 +2135,7 @@
       "translation_libretranslate_url_hint": "Point to your LibreTranslate container, e.g. http://libretranslate:5000.",
       "translation_api_key_optional": "API key (optional)",
       "translation_new": "Add provider",
+      "translation_concurrency": "Max parallel",
       "translation_empty": "No translation provider configured yet.",
       "translation_col_engine": "Engine",
       "translation_default": "Default",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -65,6 +65,10 @@
     "low_bandwidth": "low bandwidth",
     "audio_track_n": "Track {{index}}",
     "subtitle_track_n": "Subtitle {{index}}",
+    "subtitle_source": {
+      "translated": "Translated",
+      "ocr": "OCR"
+    },
     "playback_error": "Playback failed.",
     "error_aborted": "Playback interrupted.",
     "error_network": "Network error during playback.",
@@ -1620,6 +1624,13 @@
       "title": "Language profiles",
       "subtitle": "Define the accepted audio languages and the subtitles to download automatically.",
       "new": "New profile",
+      "hi_label": "Hearing-impaired",
+      "hi_mode": {
+        "prefer": "Prefer",
+        "avoid": "Avoid",
+        "require": "Require",
+        "forbid": "Forbid"
+      },
       "col_name": "Name",
       "col_audio_count": "Audio languages",
       "col_subtitle_count": "Subtitle languages",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1005,6 +1005,7 @@
     "col_sub_title": "Titre",
     "search": "Rechercher",
     "no_subtitle_results": "Aucun résultat trouvé.",
+    "subtitle_downloads": "{{count}} téléchargements",
     "confirm_delete_subtitle": "Supprimer ce sous-titre ?",
     "rejection": {
       "QUALITY_NOT_ALLOWED": "Qualité hors profil",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -65,6 +65,10 @@
     "low_bandwidth": "faible consommation",
     "audio_track_n": "Piste {{index}}",
     "subtitle_track_n": "Sous-titre {{index}}",
+    "subtitle_source": {
+      "translated": "Traduit",
+      "ocr": "OCR"
+    },
     "playback_error": "La lecture a échoué.",
     "error_aborted": "Lecture interrompue.",
     "error_network": "Erreur réseau pendant la lecture.",
@@ -1620,6 +1624,13 @@
       "title": "Profils de langue",
       "subtitle": "Définissez les langues audio acceptées et les sous-titres à télécharger automatiquement.",
       "new": "Nouveau profil",
+      "hi_label": "Malentendants",
+      "hi_mode": {
+        "prefer": "Préférer",
+        "avoid": "Éviter",
+        "require": "Exiger",
+        "forbid": "Interdire"
+      },
       "col_name": "Nom",
       "col_audio_count": "Langues audio",
       "col_subtitle_count": "Langues sous-titres",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -70,6 +70,7 @@
       "ocr": "OCR"
     },
     "playback_error": "La lecture a échoué.",
+    "subtitle_load_failed": "Impossible de charger cette piste de sous-titres.",
     "error_aborted": "Lecture interrompue.",
     "error_network": "Erreur réseau pendant la lecture.",
     "error_decode": "Erreur de décodage de la vidéo.",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1290,6 +1290,7 @@
     "save": "Enregistrer",
     "delete": "Supprimer",
     "edit": "Modifier",
+    "download": "Télécharger",
     "refresh": "Actualiser",
     "active": "Actif",
     "disabled": "Désactivé",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2135,6 +2135,7 @@
       "translation_libretranslate_url_hint": "Pointez vers votre conteneur LibreTranslate, ex. http://libretranslate:5000.",
       "translation_api_key_optional": "Clé API (optionnelle)",
       "translation_new": "Ajouter un fournisseur",
+      "translation_concurrency": "Parallélisme max",
       "translation_empty": "Aucun fournisseur de traduction configuré pour le moment.",
       "translation_col_engine": "Moteur",
       "translation_default": "Par défaut",

--- a/client/src/app/core/interceptors/cache.interceptor.ts
+++ b/client/src/app/core/interceptors/cache.interceptor.ts
@@ -41,11 +41,14 @@ const EXCLUDED_PREFIXES = [
   '/api/playback/media/',
 ];
 
-// Release search endpoints are always live (hit external indexers) — never cache.
+// Live query endpoints (external indexers / providers) — never cache. A stale
+// hit here returns an old (often empty) result and only revalidates in the
+// background, so the caller never sees the real response.
 const EXCLUDED_PATTERNS = [
   /\/api\/media\/\d+\/(releases|upgrade-releases)/,
   /\/api\/media\/\d+\/seasons\/\d+\/releases/,
   /\/api\/media\/\d+\/episodes\/\d+\/releases/,
+  /\/api\/media\/\d+\/subtitles\/search/,
 ];
 
 const DETAIL_PATTERN = /^\/api\/media\/\d+$/;

--- a/client/src/app/core/services/api/profiles.service.ts
+++ b/client/src/app/core/services/api/profiles.service.ts
@@ -37,11 +37,14 @@ export interface AudioLanguageItem {
   name: string;
 }
 
+export type HearingImpairedMode = 'prefer' | 'avoid' | 'require' | 'forbid';
+
 export interface SubtitleLanguageItem {
   isoCode: string;
   name: string;
   forced: boolean;
   hi: boolean;
+  hearingImpaired?: HearingImpairedMode;
 }
 
 export interface LanguageProfile {

--- a/client/src/app/core/services/api/subtitles-api.service.ts
+++ b/client/src/app/core/services/api/subtitles-api.service.ts
@@ -21,6 +21,11 @@ export interface SubtitleFileRow {
   syncOffset?: number;
   streamIndex?: number | null;
   codec?: string | null;
+  /** For TRANSLATED subs: the provider name/engine/model that produced them. */
+  translationProviderName?: string | null;
+  translationEngine?: string | null;
+  translationModel?: string | null;
+  translationProviderId?: number | null;
 }
 
 export interface SubtitleSearchResult {

--- a/client/src/app/core/services/track-manager.service.ts
+++ b/client/src/app/core/services/track-manager.service.ts
@@ -24,6 +24,8 @@ export interface SubtitleOption {
   subtitleDbId?: number;
   /** True if this is a forced subtitle track */
   forced?: boolean;
+  /** Origin: `translated`, `ocr`, `embedded`, or a download provider name. */
+  providerType?: string | null;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -166,6 +168,7 @@ export class TrackManagerService {
         burnIn: t.kind === 'embedded' && t.isImage && !rendersImageNatively,
         subtitleDbId: t.subtitleId,
         forced: t.forced,
+        providerType: t.providerType,
       }));
       const seen = new Set(tracks.map((t) => t.key));
 

--- a/client/src/app/core/services/track-manager.service.ts
+++ b/client/src/app/core/services/track-manager.service.ts
@@ -265,8 +265,15 @@ export class TrackManagerService {
       return;
     }
 
+    // Prefer a real (downloaded / embedded) track over a machine-generated one
+    // (translated / OCR) for the same language, so auto-select doesn't silently
+    // land on a machine translation when a native sub exists.
+    const isMachine = (s: SubtitleOption) =>
+      s.providerType === 'translated' || s.providerType === 'ocr';
     const findMatch = () =>
-      subs.find((s) => s.language === prefLang && !s.forced)
+      subs.find((s) => s.language === prefLang && !s.forced && !isMachine(s))
+      ?? subs.find((s) => s.language === prefLang && !s.forced)
+      ?? subs.find((s) => s.language === prefLang && !isMachine(s))
       ?? subs.find((s) => s.language === prefLang);
 
     if (settings.subtitleMode === 'always') {

--- a/client/src/app/core/utils/player.utils.ts
+++ b/client/src/app/core/utils/player.utils.ts
@@ -170,6 +170,7 @@ export function formatSubtitleLabel(
     forced?: boolean | null;
     hearingImpaired?: boolean | null;
     relativePath?: string | null;
+    providerType?: string | null;
   },
   translate: TranslateService,
   trackIndex?: number,
@@ -183,5 +184,20 @@ export function formatSubtitleLabel(
   if (sub.hearingImpaired) parts.push('HI');
   if (sub.forced) parts.push('Forced');
   parts.push(shortSubtitleCodec(sub.codec, !!sub.relativePath));
+  const origin = subtitleOriginLabel(sub.providerType, translate);
+  if (origin) parts.push(origin);
   return `${head} (${parts.join(') (')})`;
+}
+
+/** Short origin hint for machine-translated / OCR'd subtitles. Embedded and
+ *  downloaded subs get none — their codec already conveys the essentials. */
+export function subtitleOriginLabel(
+  providerType: string | null | undefined,
+  translate: TranslateService,
+): string | null {
+  if (providerType === 'translated')
+    return translate.instant('player.subtitle_source.translated');
+  if (providerType === 'ocr')
+    return translate.instant('player.subtitle_source.ocr');
+  return null;
 }

--- a/client/src/app/core/utils/subtitle-tracks.ts
+++ b/client/src/app/core/utils/subtitle-tracks.ts
@@ -10,6 +10,7 @@ export interface SubtitleRowLike {
   hearingImpaired?: boolean | null;
   relativePath?: string | null;
   streamIndex?: number | null;
+  providerType?: string | null;
 }
 
 export interface SubtitleTrack {
@@ -23,6 +24,9 @@ export interface SubtitleTrack {
   relativePath: string | null;
   streamIndex: number | null;
   kind: 'external' | 'embedded';
+  /** Origin of the sub — `translated`, `ocr`, `embedded`, or a download
+   *  provider name. Surfaced as an origin hint in the track label. */
+  providerType: string | null;
   /** Bitmap track (PGS/VOBSUB…) that can't be served as text — burn-in only. */
   isImage: boolean;
 }
@@ -70,6 +74,7 @@ export function buildSubtitleTracks(
       relativePath: sub.relativePath ?? null,
       streamIndex: sub.streamIndex ?? null,
       kind,
+      providerType: sub.providerType ?? null,
       isImage,
     });
   }

--- a/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.html
@@ -35,7 +35,19 @@
             @for (r of subSearchResults(); track r.providerFileId) {
               <tr>
                 <td class="text-sm max-w-[20rem] truncate" [title]="r.title">{{ r.title }}</td>
-                <td class="text-center tabular-nums">{{ r.score }}</td>
+                <td>
+                  <div class="flex items-center gap-2 justify-center">
+                    <progress
+                      class="progress w-14 h-1.5"
+                      [class.progress-success]="r.score >= 80"
+                      [class.progress-warning]="r.score >= 40 && r.score < 80"
+                      [class.progress-error]="r.score < 40"
+                      [value]="r.score"
+                      max="100"
+                    ></progress>
+                    <span class="tabular-nums text-xs w-7 text-right">{{ r.score }}</span>
+                  </div>
+                </td>
                 <td class="text-center text-xs">
                   @if (r.forced) {
                     <span class="badge badge-xs badge-outline mr-1">F</span>
@@ -44,7 +56,12 @@
                     <span class="badge badge-xs badge-outline">HI</span>
                   }
                 </td>
-                <td class="text-sm">{{ r.providerName }}</td>
+                <td class="text-sm">
+                  {{ r.providerName }}
+                  @if (r.downloadCount) {
+                    <span class="block text-xs text-base-content/50">{{ 'media_detail.subtitle_downloads' | translate: { count: r.downloadCount } }}</span>
+                  }
+                </td>
                 <td>
                   <button
                     type="button"

--- a/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.html
@@ -1,5 +1,5 @@
 <dialog #dialog class="modal">
-  <div class="modal-box max-w-3xl max-h-[85vh] flex flex-col">
+  <div class="modal-box max-w-5xl max-h-[85vh] flex flex-col">
     <h3 class="text-lg font-bold mb-4">{{ 'media_detail.search_subtitles' | translate }}</h3>
     <div class="flex gap-2 mb-4">
       <select
@@ -28,7 +28,7 @@
               <th class="text-center">{{ 'media_detail.col_sub_score' | translate }}</th>
               <th class="text-center">{{ 'media_detail.col_sub_flags' | translate }}</th>
               <th>{{ 'media_detail.col_sub_provider' | translate }}</th>
-              <th class="w-20"></th>
+              <th class="w-32"></th>
             </tr>
           </thead>
           <tbody>
@@ -65,11 +65,11 @@
                 <td>
                   <button
                     type="button"
-                    class="btn btn-primary btn-xs"
+                    class="btn btn-primary btn-sm"
                     (click)="download.emit(r)"
                     [disabled]="subtitleActionBusy()"
                   >
-                    DL
+                    {{ 'common.download' | translate }}
                   </button>
                 </td>
               </tr>

--- a/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.html
@@ -45,7 +45,7 @@
                       [value]="r.score"
                       max="100"
                     ></progress>
-                    <span class="tabular-nums">{{ r.score }}</span>
+                    <span class="tabular-nums">{{ r.score }}%</span>
                     @if (r.forced) {
                       <span class="badge badge-xs badge-outline">F</span>
                     }
@@ -64,7 +64,7 @@
                       [value]="r.score"
                       max="100"
                     ></progress>
-                    <span class="tabular-nums text-xs w-7 text-right">{{ r.score }}</span>
+                    <span class="tabular-nums text-xs w-9 text-right">{{ r.score }}%</span>
                   </div>
                 </td>
                 <td class="text-center text-xs hidden sm:table-cell">

--- a/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.html
@@ -25,8 +25,8 @@
           <thead>
             <tr>
               <th>{{ 'media_detail.col_sub_title' | translate }}</th>
-              <th class="text-center">{{ 'media_detail.col_sub_score' | translate }}</th>
-              <th class="text-center">{{ 'media_detail.col_sub_flags' | translate }}</th>
+              <th class="text-center hidden sm:table-cell">{{ 'media_detail.col_sub_score' | translate }}</th>
+              <th class="text-center hidden sm:table-cell">{{ 'media_detail.col_sub_flags' | translate }}</th>
               <th>{{ 'media_detail.col_sub_provider' | translate }}</th>
               <th class="w-32"></th>
             </tr>
@@ -34,8 +34,27 @@
           <tbody>
             @for (r of subSearchResults(); track r.providerFileId) {
               <tr>
-                <td class="text-sm max-w-[20rem] truncate" [title]="r.title">{{ r.title }}</td>
-                <td>
+                <td class="text-sm">
+                  <div class="max-w-[13rem] sm:max-w-[20rem] truncate" [title]="r.title">{{ r.title }}</div>
+                  <div class="sm:hidden mt-1 flex items-center gap-2 text-xs">
+                    <progress
+                      class="progress w-14 h-1.5"
+                      [class.progress-success]="r.score >= 80"
+                      [class.progress-warning]="r.score >= 40 && r.score < 80"
+                      [class.progress-error]="r.score < 40"
+                      [value]="r.score"
+                      max="100"
+                    ></progress>
+                    <span class="tabular-nums">{{ r.score }}</span>
+                    @if (r.forced) {
+                      <span class="badge badge-xs badge-outline">F</span>
+                    }
+                    @if (r.hearingImpaired) {
+                      <span class="badge badge-xs badge-outline">HI</span>
+                    }
+                  </div>
+                </td>
+                <td class="hidden sm:table-cell">
                   <div class="flex items-center gap-2 justify-center">
                     <progress
                       class="progress w-14 h-1.5"
@@ -48,7 +67,7 @@
                     <span class="tabular-nums text-xs w-7 text-right">{{ r.score }}</span>
                   </div>
                 </td>
-                <td class="text-center text-xs">
+                <td class="text-center text-xs hidden sm:table-cell">
                   @if (r.forced) {
                     <span class="badge badge-xs badge-outline mr-1">F</span>
                   }
@@ -59,7 +78,7 @@
                 <td class="text-sm">
                   {{ r.providerName }}
                   @if (r.downloadCount) {
-                    <span class="block text-xs text-base-content/50">{{ 'media_detail.subtitle_downloads' | translate: { count: r.downloadCount } }}</span>
+                    <span class="block text-xs text-base-content/50 whitespace-nowrap">{{ 'media_detail.subtitle_downloads' | translate: { count: r.downloadCount } }}</span>
                   }
                 </td>
                 <td>

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -3395,7 +3395,12 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       });
       try { this.engine.setTextVisibility(true); } catch {}
     } catch (e) {
+      // Surface the failure instead of silently moving the checkmark to a track
+      // that never loaded — leave the prior selection and the picker in place so
+      // the user can pick another.
       console.error('[Player] Failed to load subtitle:', e);
+      this.toast.error(this.translate.instant('player.subtitle_load_failed'));
+      return;
     }
 
     this.activeSubtitleId.set(sub.id);

--- a/client/src/app/features/settings/language-profiles/language-profiles.html
+++ b/client/src/app/features/settings/language-profiles/language-profiles.html
@@ -119,13 +119,16 @@
                       Forced
                     </label>
                     <label class="flex items-center gap-1 text-xs">
-                      <input
-                        type="checkbox"
-                        class="checkbox checkbox-xs"
-                        [checked]="isSubHi(l.isoCode)"
-                        (change)="toggleSubHi(l.isoCode, $event)"
-                      />
-                      HI
+                      <span>{{ 'settings.language_profiles.hi_label' | translate }}</span>
+                      <select
+                        class="select select-bordered select-xs"
+                        [ngModel]="subHiMode(l.isoCode)"
+                        (ngModelChange)="setSubHiMode(l.isoCode, $event)"
+                      >
+                        @for (m of hiModes; track m) {
+                          <option [value]="m">{{ 'settings.language_profiles.hi_mode.' + m | translate }}</option>
+                        }
+                      </select>
                     </label>
                   }
                 </div>

--- a/client/src/app/features/settings/language-profiles/language-profiles.ts
+++ b/client/src/app/features/settings/language-profiles/language-profiles.ts
@@ -16,6 +16,7 @@ import {
   LanguageProfile,
   AudioLanguageItem,
   SubtitleLanguageItem,
+  HearingImpairedMode,
 } from '../../../core/services/api/profiles.service';
 
 interface LangDef {
@@ -23,6 +24,14 @@ interface LangDef {
   name: string;
   isoCode: string;
 }
+
+interface SubEntry {
+  forced: boolean;
+  hi: boolean;
+  hearingImpaired: HearingImpairedMode;
+}
+
+const HI_MODES: HearingImpairedMode[] = ['prefer', 'avoid', 'require', 'forbid'];
 
 @Component({
   selector: 'app-language-profiles',
@@ -47,9 +56,10 @@ export class LanguageProfilesComponent implements OnInit {
 
   readonly editingId = signal<number | null>(null);
 
+  readonly hiModes = HI_MODES;
   readonly formName = signal('');
   readonly audioIsoCodes = signal<Set<string>>(new Set());
-  readonly subtitleEntries = signal<Map<string, { forced: boolean; hi: boolean }>>(new Map());
+  readonly subtitleEntries = signal<Map<string, SubEntry>>(new Map());
 
   ngOnInit() {
     this.reloadAll();
@@ -92,9 +102,13 @@ export class LanguageProfilesComponent implements OnInit {
     this.editingId.set(p.id);
     this.formName.set(p.name);
     this.audioIsoCodes.set(new Set(p.audioLanguages.map((l) => l.isoCode)));
-    const subs = new Map<string, { forced: boolean; hi: boolean }>();
+    const subs = new Map<string, SubEntry>();
     for (const s of p.subtitleLanguages) {
-      subs.set(s.isoCode, { forced: s.forced, hi: s.hi });
+      subs.set(s.isoCode, {
+        forced: s.forced,
+        hi: s.hi,
+        hearingImpaired: s.hearingImpaired ?? (s.hi ? 'prefer' : 'avoid'),
+      });
     }
     this.subtitleEntries.set(subs);
     this.editorDialog()?.nativeElement.showModal();
@@ -123,7 +137,7 @@ export class LanguageProfilesComponent implements OnInit {
   toggleSubtitle(isoCode: string, ev: Event) {
     const checked = (ev.target as HTMLInputElement).checked;
     const next = new Map(this.subtitleEntries());
-    if (checked) next.set(isoCode, { forced: false, hi: false });
+    if (checked) next.set(isoCode, { forced: false, hi: false, hearingImpaired: 'avoid' });
     else next.delete(isoCode);
     this.subtitleEntries.set(next);
   }
@@ -132,8 +146,8 @@ export class LanguageProfilesComponent implements OnInit {
     return this.subtitleEntries().get(isoCode)?.forced ?? false;
   }
 
-  isSubHi(isoCode: string): boolean {
-    return this.subtitleEntries().get(isoCode)?.hi ?? false;
+  subHiMode(isoCode: string): HearingImpairedMode {
+    return this.subtitleEntries().get(isoCode)?.hearingImpaired ?? 'avoid';
   }
 
   toggleSubForced(isoCode: string, ev: Event) {
@@ -146,12 +160,17 @@ export class LanguageProfilesComponent implements OnInit {
     }
   }
 
-  toggleSubHi(isoCode: string, ev: Event) {
-    const checked = (ev.target as HTMLInputElement).checked;
+  /** Set the HI preference; keep the legacy `hi` boolean in sync so the scorer's
+   *  fallback and any remaining `hi` readers stay correct. */
+  setSubHiMode(isoCode: string, mode: HearingImpairedMode) {
     const next = new Map(this.subtitleEntries());
     const entry = next.get(isoCode);
     if (entry) {
-      next.set(isoCode, { ...entry, hi: checked });
+      next.set(isoCode, {
+        ...entry,
+        hearingImpaired: mode,
+        hi: mode === 'prefer' || mode === 'require',
+      });
       this.subtitleEntries.set(next);
     }
   }
@@ -166,7 +185,14 @@ export class LanguageProfilesComponent implements OnInit {
     const subtitleLanguages: SubtitleLanguageItem[] = [];
     for (const [iso, opts] of this.subtitleEntries()) {
       const def = defs.find((d) => d.isoCode === iso);
-      if (def) subtitleLanguages.push({ isoCode: def.isoCode, name: def.name, forced: opts.forced, hi: opts.hi });
+      if (def)
+        subtitleLanguages.push({
+          isoCode: def.isoCode,
+          name: def.name,
+          forced: opts.forced,
+          hi: opts.hi,
+          hearingImpaired: opts.hearingImpaired,
+        });
     }
     return { name: this.formName().trim(), audioLanguages, subtitleLanguages };
   }

--- a/client/src/app/features/settings/subtitle-providers/subtitle-providers.html
+++ b/client/src/app/features/settings/subtitle-providers/subtitle-providers.html
@@ -22,16 +22,30 @@
         </button>
       </div>
 
-      <label class="label cursor-pointer justify-start gap-3 w-fit">
-        <input
-          type="checkbox"
-          class="toggle toggle-primary"
-          [disabled]="savingTranslationEnabled()"
-          [ngModel]="translationEnabled()"
-          (ngModelChange)="saveTranslationEnabled($event)"
-        />
-        <span class="label-text">{{ 'settings.subtitle_providers.translation_enabled' | translate }}</span>
-      </label>
+      <div class="flex flex-wrap items-end gap-6">
+        <label class="label cursor-pointer justify-start gap-3 w-fit">
+          <input
+            type="checkbox"
+            class="toggle toggle-primary"
+            [disabled]="savingTranslationEnabled()"
+            [ngModel]="translationEnabled()"
+            (ngModelChange)="saveTranslationEnabled($event)"
+          />
+          <span class="label-text">{{ 'settings.subtitle_providers.translation_enabled' | translate }}</span>
+        </label>
+
+        <label class="form-control w-32">
+          <span class="label-text">{{ 'settings.subtitle_providers.translation_concurrency' | translate }}</span>
+          <input
+            type="number"
+            min="1"
+            class="input input-bordered input-sm w-full"
+            [disabled]="savingConcurrency()"
+            [ngModel]="translationMaxConcurrency()"
+            (ngModelChange)="saveTranslationConcurrency($event)"
+          />
+        </label>
+      </div>
 
       @if (translationLoading()) {
         <div class="flex justify-center py-6"><span class="loading loading-spinner"></span></div>

--- a/client/src/app/features/settings/subtitle-providers/subtitle-providers.html
+++ b/client/src/app/features/settings/subtitle-providers/subtitle-providers.html
@@ -149,7 +149,7 @@
           {{ 'settings.subtitle_providers.editor_edit_title' | translate }}
         }
       </h2>
-      <div class="py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0">
+      <div class="p-2 -m-2 mt-2 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0">
         <label class="form-control w-full">
           <span class="label-text">{{ 'settings.subtitle_providers.field_name' | translate }}</span>
           <input type="text" class="input input-bordered input-sm w-full"
@@ -296,7 +296,7 @@
         }
       </h2>
 
-      <div class="flex flex-col gap-3 py-3 overflow-y-auto">
+      <div class="flex flex-col gap-3 p-2 -m-2 mt-1 overflow-y-auto">
         <label class="form-control w-full">
           <span class="label-text">{{ 'settings.subtitle_providers.col_name' | translate }}</span>
           <input type="text" class="input input-bordered input-sm w-full"

--- a/client/src/app/features/settings/subtitle-providers/subtitle-providers.ts
+++ b/client/src/app/features/settings/subtitle-providers/subtitle-providers.ts
@@ -100,6 +100,8 @@ export class SubtitleProvidersSettingsComponent implements OnInit {
   readonly translationEngines = TRANSLATION_ENGINES;
   readonly translationEnabled = signal(false);
   readonly savingTranslationEnabled = signal(false);
+  readonly translationMaxConcurrency = signal(1);
+  readonly savingConcurrency = signal(false);
   readonly translationRows = signal<TranslationProviderRow[]>([]);
   readonly translationLoading = signal(true);
 
@@ -126,8 +128,24 @@ export class SubtitleProvidersSettingsComponent implements OnInit {
     try {
       const all = await this.settingsApi.getAll();
       this.translationEnabled.set(all['subtitle_translation_enabled'] === 'true');
+      this.translationMaxConcurrency.set(
+        Math.max(1, Math.floor(Number(all['subtitle_translation_max_concurrency'] ?? '1')) || 1),
+      );
     } catch {
       // handled by global error interceptor
+    }
+  }
+
+  async saveTranslationConcurrency(value: number) {
+    const n = Math.max(1, Math.floor(Number(value) || 1));
+    this.translationMaxConcurrency.set(n);
+    this.savingConcurrency.set(true);
+    try {
+      await this.settingsApi.setBulk({
+        subtitle_translation_max_concurrency: String(n),
+      });
+    } finally {
+      this.savingConcurrency.set(false);
     }
   }
 

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -499,25 +499,27 @@
       <h3 class="text-lg font-bold">{{ 'media_detail.ocr_language_title' | translate }}</h3>
       <p class="py-2 text-sm text-base-content/70">{{ 'media_detail.ocr_language_hint' | translate }}</p>
     }
-    <select class="select select-bordered w-full" [ngModel]="ocrLang()" (ngModelChange)="ocrLang.set($event)">
-      @for (code of langDialogCodes(); track code) {
-        <option [value]="code">{{ code | localizeLanguage }}</option>
+    <div class="mt-2 space-y-4">
+      <select class="select select-bordered w-full" [ngModel]="ocrLang()" (ngModelChange)="ocrLang.set($event)">
+        @for (code of langDialogCodes(); track code) {
+          <option [value]="code">{{ code | localizeLanguage }}</option>
+        }
+      </select>
+      @if (langDialogMode() === 'translate' && translationProviders().length > 1) {
+        <label class="form-control w-full">
+          <span class="label-text mb-1">{{ 'media_detail.translate_provider' | translate }}</span>
+          <select
+            class="select select-bordered w-full"
+            [ngModel]="selectedTranslationProviderId()"
+            (ngModelChange)="selectedTranslationProviderId.set($event)"
+          >
+            @for (p of translationProviders(); track p.id) {
+              <option [ngValue]="p.id">{{ p.name }}</option>
+            }
+          </select>
+        </label>
       }
-    </select>
-    @if (langDialogMode() === 'translate' && translationProviders().length > 1) {
-      <label class="form-control w-full mt-3">
-        <span class="label-text">{{ 'media_detail.translate_provider' | translate }}</span>
-        <select
-          class="select select-bordered w-full"
-          [ngModel]="selectedTranslationProviderId()"
-          (ngModelChange)="selectedTranslationProviderId.set($event)"
-        >
-          @for (p of translationProviders(); track p.id) {
-            <option [ngValue]="p.id">{{ p.name }}</option>
-          }
-        </select>
-      </label>
-    }
+    </div>
     <div class="modal-action">
       <button type="button" class="btn" (click)="closeOcrLangModal()">{{ 'common.cancel' | translate }}</button>
       <button type="button" class="btn btn-primary" (click)="confirmLanguage()">

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -84,6 +84,8 @@
                     <td class="text-sm">
                       @if (sub.providerType === 'embedded') {
                         <span class="badge badge-sm badge-neutral">embedded</span>
+                      } @else if (sub.providerType === 'translated') {
+                        <span [title]="sub.translationModel ?? ''">{{ translationServiceLabel(sub) }}</span>
                       } @else {
                         {{ sub.providerType }}
                       }

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -680,6 +680,23 @@ export class SubtitlesModalComponent {
     this.ocrLangDialog()?.nativeElement.showModal();
   }
 
+  /** Display label for a translated sub's provider column: the admin-given
+   *  provider name (snapshotted at translation time), falling back to the engine
+   *  and then a generic "translated" for rows created before provenance existed. */
+  translationServiceLabel(sub: SubtitleFileRow): string {
+    if (sub.translationProviderName) return sub.translationProviderName;
+    switch (sub.translationEngine) {
+      case 'gemini':
+        return 'Gemini';
+      case 'openai':
+        return 'OpenAI';
+      case 'libretranslate':
+        return 'LibreTranslate';
+      default:
+        return this.translate.instant('player.subtitle_source.translated');
+    }
+  }
+
   /** Translate a text subtitle: pick the target language and provider first. */
   async translateSubtitle(sub: SubtitleFileRow) {
     let providers: AvailableTranslationProvider[] = [];

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -14,11 +14,12 @@
   --radius-box: 0.5rem;
 }
 
-/* Form fields defer to the global primary box-shadow focus ring below. Drop
-   daisyUI's own focus outline (it draws a second, tighter ring inside the
-   box-shadow one) and its border-on-focus so the field shows a single ring. */
+/* Thinner focus outline on form fields. Suppress daisyUI's border on focus —
+   the focus ring (outline) is the only visual cue we want, the extra white
+   border doubled up with the ring looks noisy. */
 .select:focus, .input:focus, .textarea:focus {
-  outline: none;
+  outline-width: 1px;
+  outline-offset: 0px;
   border-color: transparent;
 }
 


### PR DESCRIPTION
Implements **Plan B** (`plans/subtitle-ux-improvements.plan.md`) — accumulating in one PR. **WIP**; several items touch the player across web/desktop/TV/mobile and need on-device validation before merge.

## Done so far
- **#4 origin hint** — a subtitle's origin (translated / OCR) is threaded through the track builder + `SubtitleOption` and appended as a localized token to the track label, so a machine-translated or OCR'd track is distinguishable from a downloaded one.
- **#11 hearing-impaired mode** — the language-profile editor exposes the full 4-way `HearingImpairedMode` (prefer / avoid / require / forbid) as a select instead of an on/off checkbox. Backend fix: the create DTO now whitelists `hearingImpaired` (it was silently stripped by class-validator); the UI backfills from the legacy `hi` flag and keeps `hi` in sync.
- Translate dialog: spaced out the language / provider fields (Plan A follow-up).

## Remaining (to come on this branch)
Quick wins: #9 track ordering, #5 selection feedback, #7 in-player appearance entry, #8 search-result clarity, #12 settings IA.
Flagship (need device testing): #0 player↔SSE spine, #1 in-player actions, #2 offset control, #3 no-subs empty state + search, #6 job feedback, #10 auto-select origin-awareness, #13 a11y.

## Verify
Backend `tsc` clean; client `ng build` green. Not device-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)