### PR TITLE
feat(player): two-line subtitle labels (language + details subline)

### DIFF
--- a/client/src/app/core/services/track-manager.service.ts
+++ b/client/src/app/core/services/track-manager.service.ts
@@ -5,7 +5,7 @@ import { SubtitlesApiService } from './api/subtitles-api.service';
 import { StreamingApiService } from './api/streaming-api.service';
 import { AppSettingsService } from './app-settings.service';
 import { BrowserDeviceProfileService } from './browser-device-profile.service';
-import { formatSubtitleLabel } from '../utils/player.utils';
+import { formatSubtitleLabel, formatSubtitleParts } from '../utils/player.utils';
 import { isImageBasedSubtitleCodec } from '../utils/subtitle-codecs';
 import { buildSubtitleTracks } from '../utils/subtitle-tracks';
 import type { PlaybackEngine, AudioTrack } from './playback-engine/playback-engine';
@@ -26,6 +26,9 @@ export interface SubtitleOption {
   forced?: boolean;
   /** Origin: `translated`, `ocr`, `embedded`, or a download provider name. */
   providerType?: string | null;
+  /** Player-menu two-line label: language head + details subline ("SRT • …"). */
+  menuHead?: string;
+  menuSub?: string;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -154,9 +157,13 @@ export class TrackManagerService {
         !!this.deviceProfile.getProfile().supportsImageSubtitles;
       const subs = await this.subtitlesApi.getForMedia(mediaId);
       const tracks = buildSubtitleTracks(subs, mediaFileId, { hideBurnIn });
-      const options: SubtitleOption[] = tracks.map((t) => ({
+      const options: SubtitleOption[] = tracks.map((t) => {
+        const parts = formatSubtitleParts(t, this.translate);
+        return {
         id: t.key,
         label: formatSubtitleLabel(t, this.translate),
+        menuHead: parts.head,
+        menuSub: parts.sub,
         url:
           t.kind === 'external'
             ? streamingApi.getSubtitleUrl(mediaFileId, t.subtitleId)
@@ -169,7 +176,8 @@ export class TrackManagerService {
         subtitleDbId: t.subtitleId,
         forced: t.forced,
         providerType: t.providerType,
-      }));
+        };
+      });
       const seen = new Set(tracks.map((t) => t.key));
 
       // Also check streamInfo for embedded subs not yet in DB
@@ -181,9 +189,12 @@ export class TrackManagerService {
           if (seen.has(key)) continue;
           seen.add(key);
           if (isImageBasedSubtitleCodec(emb.codec)) continue; // Bitmap from streamInfo only (no DB ID for burn-in)
+          const embParts = formatSubtitleParts(emb, this.translate);
           options.push({
             id: key,
             label: formatSubtitleLabel(emb, this.translate),
+            menuHead: embParts.head,
+            menuSub: embParts.sub,
             url: streamingApi.getEmbeddedSubtitleUrl(mediaFileId, emb.streamIndex),
             language: emb.language,
             burnIn: false,

--- a/client/src/app/core/utils/player.utils.ts
+++ b/client/src/app/core/utils/player.utils.ts
@@ -189,6 +189,35 @@ export function formatSubtitleLabel(
   return `${head} (${parts.join(') (')})`;
 }
 
+/**
+ * Two-part subtitle label for the player menu: the language on top and the
+ * details ("SRT • Forced • Translated") as a subline, joined with " • ".
+ */
+export function formatSubtitleParts(
+  sub: {
+    language?: string;
+    codec?: string | null;
+    forced?: boolean | null;
+    hearingImpaired?: boolean | null;
+    relativePath?: string | null;
+    providerType?: string | null;
+  },
+  translate: TranslateService,
+  trackIndex?: number,
+): { head: string; sub: string } {
+  const norm = normalizeLangCode(sub.language);
+  const head =
+    trackIndex != null && (norm === 'und' || norm === 'xx')
+      ? translate.instant('player.subtitle_track_n', { index: trackIndex })
+      : localizeLanguage(sub.language, translate);
+  const parts: string[] = [shortSubtitleCodec(sub.codec, !!sub.relativePath)];
+  if (sub.forced) parts.push('Forced');
+  if (sub.hearingImpaired) parts.push('HI');
+  const origin = subtitleOriginLabel(sub.providerType, translate);
+  if (origin) parts.push(origin);
+  return { head, sub: parts.join(' • ') };
+}
+
 /** Short origin hint for machine-translated / OCR'd subtitles. Embedded and
  *  downloaded subs get none — their codec already conveys the essentials. */
 export function subtitleOriginLabel(

--- a/client/src/app/core/utils/player.utils.ts
+++ b/client/src/app/core/utils/player.utils.ts
@@ -156,6 +156,22 @@ export function formatAudioLabel(
   return tail ? `${head} (${tail})` : head;
 }
 
+/** Two-part audio label for the menu: language head + details ("EAC3 • 5.1"). */
+export function formatAudioParts(
+  audio: { language?: string; title?: string; codec?: string; channels?: number },
+  translate: TranslateService,
+  trackIndex?: number,
+): { head: string; sub: string } {
+  const norm = normalizeLangCode(audio.language);
+  const head =
+    trackIndex != null && (norm === 'und' || norm === 'xx')
+      ? translate.instant('player.audio_track_n', { index: trackIndex })
+      : localizeLanguage(audio.language, translate);
+  const codec = (audio.codec ?? '').toUpperCase().replace('TRUEHD', 'TrueHD');
+  const channels = audioChannelsLabel(audio.channels);
+  return { head, sub: [codec, channels].filter(Boolean).join(' • ') };
+}
+
 /**
  * Render a subtitle as a dropdown label. Mirrors {@link formatAudioLabel} so
  * the player and media-detail subtitle menus stay consistent.

--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -533,7 +533,7 @@
       <svg lucideCaptions class="h-5 w-5 text-white/50 shrink-0"></svg>
       <span class="flex-1 text-left">
         <span class="block">{{ sub.menuHead || sub.label }}@if (sub.isImage) { <span class="text-warning/70 text-[10px] ml-1">{{ 'player.burned' | translate }}</span> }</span>
-        @if (sub.menuSub) { <span class="block text-sm text-white/60">{{ sub.menuSub }}</span> }
+        @if (sub.menuSub) { <span class="block text-xs text-white/60">{{ sub.menuSub }}</span> }
       </span>
       @if (activeSubtitleId() === sub.id) { <svg lucideCheck class="h-5 w-5 text-white shrink-0"></svg> }
     </button>

--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -531,7 +531,10 @@
       (click)="selectSubtitle.emit(sub.id); closeSheet()"
     >
       <svg lucideCaptions class="h-5 w-5 text-white/50 shrink-0"></svg>
-      <span class="flex-1 text-left">{{ sub.label }}@if (sub.isImage) { <span class="text-warning/70 text-[10px] ml-1">{{ 'player.burned' | translate }}</span> }</span>
+      <span class="flex-1 text-left">
+        <span class="block">{{ sub.menuHead || sub.label }}@if (sub.isImage) { <span class="text-warning/70 text-[10px] ml-1">{{ 'player.burned' | translate }}</span> }</span>
+        @if (sub.menuSub) { <span class="block text-sm text-white/60">{{ sub.menuSub }}</span> }
+      </span>
       @if (activeSubtitleId() === sub.id) { <svg lucideCheck class="h-5 w-5 text-white shrink-0"></svg> }
     </button>
   }

--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -550,7 +550,10 @@
       (click)="selectAudioTrack.emit(track.id); closeSheet()"
     >
       <svg lucideHeadphones class="h-5 w-5 text-white/50 shrink-0"></svg>
-      <span class="flex-1 text-left">{{ track.label }}</span>
+      <span class="flex-1 text-left">
+        <span class="block">{{ track.menuHead || track.label }}</span>
+        @if (track.menuSub) { <span class="block text-xs text-white/60">{{ track.menuSub }}</span> }
+      </span>
       @if (activeAudioTrackId() === track.id) { <svg lucideCheck class="h-5 w-5 text-white shrink-0"></svg> }
     </button>
   }

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -243,7 +243,7 @@ export class PlayerControlsComponent {
   readonly availableQualities = input<{ id: string; label: string; lowBandwidth?: boolean }[]>([]);
   readonly activeSubtitleId = input<string | null>(null);
   readonly activeQualityId = input('auto');
-  readonly availableAudioTracks = input<{ id: string; label: string }[]>([]);
+  readonly availableAudioTracks = input<{ id: string; label: string; menuHead?: string; menuSub?: string }[]>([]);
   readonly activeAudioTrackId = input<string | null>(null);
   readonly pipAvailable = input(true);
   readonly castAvailable = input(false);

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -239,7 +239,7 @@ export class PlayerControlsComponent {
   readonly isDesktop = input(false);
   readonly subtitlePickerOpen = input(false);
   readonly qualityPickerOpen = input(false);
-  readonly availableSubtitles = input<{ id: string; label: string; burnIn?: boolean; isImage?: boolean }[]>([]);
+  readonly availableSubtitles = input<{ id: string; label: string; menuHead?: string; menuSub?: string; burnIn?: boolean; isImage?: boolean }[]>([]);
   readonly availableQualities = input<{ id: string; label: string; lowBandwidth?: boolean }[]>([]);
   readonly activeSubtitleId = input<string | null>(null);
   readonly activeQualityId = input('auto');

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -40,7 +40,7 @@ import { ToastService } from '../../core/services/toast.service';
 import { NavbarService } from '../../core/services/navbar.service';
 import { PlaybackQueueService, QueueItem } from '../../core/services/playback-queue.service';
 import { resolvePlayableFile } from '../../shared/utils/media-play.util';
-import { audioChannelsLabel, formatAudioLabel, parseAudioIndex, SpriteMetadata, widthForProfile } from '../../core/utils/player.utils';
+import { audioChannelsLabel, formatAudioLabel, formatAudioParts, parseAudioIndex, SpriteMetadata, widthForProfile } from '../../core/utils/player.utils';
 import { formatErrorDiagnostics, userMessageKeyFor } from '../../core/services/playback-engine/playback-error';
 import {
   PlayerSettingsService, normalizeLang,
@@ -417,7 +417,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   readonly spriteMetadata = signal<SpriteMetadata | null>(null);
   readonly activeSubtitleId = signal<string | null>(null);
   readonly activeAudioTrackId = signal<string | null>(null);
-  readonly availableAudioTracks = signal<{ id: string; label: string; language: string }[]>([]);
+  readonly availableAudioTracks = signal<{ id: string; label: string; language: string; menuHead?: string; menuSub?: string }[]>([]);
   readonly availableSubtitles = signal<SubtitleOption[]>([]);
 
   /** Audio tracks from streamInfo for the Cast remote */
@@ -1644,6 +1644,8 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       const tracks = e.tracks.map((t: any, i: number) => ({
         id: t.id,
         label: audioList[i] ? formatAudioLabel(audioList[i], this.translate, i + 1) : t.label,
+        menuHead: audioList[i] ? formatAudioParts(audioList[i], this.translate, i + 1).head : t.label,
+        menuSub: audioList[i] ? formatAudioParts(audioList[i], this.translate, i + 1).sub : '',
         language: normalizeLang(t.language),
         selected: !!t.selected,
       }));
@@ -3218,6 +3220,8 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
           const tracks = audioList.map((a: any, i: number) => ({
             id: `si-${i}`,
             label: formatAudioLabel(a, this.translate, i + 1),
+            menuHead: formatAudioParts(a, this.translate, i + 1).head,
+            menuSub: formatAudioParts(a, this.translate, i + 1).sub,
             language: normalizeLang(a.language),
           }));
           this.availableAudioTracks.set(tracks);
@@ -3244,6 +3248,8 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       const tracks = engineTracks.map((t, i) => ({
         id: t.id,
         label: audioList[i] ? formatAudioLabel(audioList[i], this.translate, i + 1) : t.label,
+        menuHead: audioList[i] ? formatAudioParts(audioList[i], this.translate, i + 1).head : t.label,
+        menuSub: audioList[i] ? formatAudioParts(audioList[i], this.translate, i + 1).sub : '',
         language: normalizeLang(t.language),
       }));
 

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -451,12 +451,20 @@
           @if (subtitles().length === 1) {
             <span>{{ subtitles()[0].label }}</span>
           } @else {
-            <select class="select select-bordered select-sm w-fit" appTvSelect [ngModel]="selectedSubtitleId()" (ngModelChange)="onSubtitleChange($event)">
-              <option [ngValue]="null">{{ 'player.off' | translate }}</option>
+            <app-dropdown-menu placement="bottom-end">
+              <button trigger type="button" class="select select-bordered select-sm w-fit text-left">
+                {{ selectedSubtitle()?.label ?? ('player.off' | translate) }}
+              </button>
+              <button type="button" class="dropdown-item" (click)="onSubtitleChange(null)">
+                {{ 'player.off' | translate }}
+              </button>
               @for (s of subtitles(); track s.id) {
-                <option [ngValue]="s.id">{{ s.label }}</option>
+                <button type="button" class="dropdown-item !items-start flex-col gap-0" (click)="onSubtitleChange(s.id)">
+                  <span>{{ s.head || s.label }}</span>
+                  @if (s.sub) { <span class="text-xs opacity-60">{{ s.sub }}</span> }
+                </button>
               }
-            </select>
+            </app-dropdown-menu>
           }
         </div>
       }

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -422,7 +422,7 @@
       <div class="flex items-center gap-2">
         <span class="text-base-content/50">{{ 'media_info.video' | translate }}</span>
         @if (multipleFiles()) {
-          <select class="select select-bordered select-sm w-fit" appTvSelect [ngModel]="selectedFileId()" (ngModelChange)="selectedFileIdChange.emit($event)">
+          <select class="select select-bordered select-sm w-fit pe-9" appTvSelect [ngModel]="selectedFileId()" (ngModelChange)="selectedFileIdChange.emit($event)">
             @for (f of files(); track f.id) {
               <option [ngValue]="f.id">{{ fileLabel(f) }}</option>
             }
@@ -437,11 +437,25 @@
           @if (audioTracks().length === 1) {
             <span>{{ audioTracks()[0].label }}</span>
           } @else {
-            <select class="select select-bordered select-sm w-fit" appTvSelect [ngModel]="selectedAudioIndex()" (ngModelChange)="onAudioChange($event)">
+            <app-dropdown-menu placement="bottom-end">
+              <button trigger type="button" class="select select-bordered select-sm w-fit text-left pe-9">
+                {{ selectedAudio()?.head || selectedAudio()?.label }}
+              </button>
               @for (t of audioTracks(); track t.index) {
-                <option [ngValue]="t.index">{{ t.label }}</option>
+                <button
+                  type="button"
+                  class="dropdown-item"
+                  [class.text-primary]="t.index === selectedAudioIndex()"
+                  (click)="onAudioChange(t.index)"
+                >
+                  <span class="flex-1 flex flex-col items-start gap-0 leading-tight text-left">
+                    <span>{{ t.head || t.label }}</span>
+                    @if (t.sub) { <span class="text-xs opacity-60">{{ t.sub }}</span> }
+                  </span>
+                  @if (t.index === selectedAudioIndex()) { <span class="h-2 w-2 rounded-full bg-primary shrink-0"></span> }
+                </button>
               }
-            </select>
+            </app-dropdown-menu>
           }
         </div>
       }
@@ -452,16 +466,30 @@
             <span>{{ subtitles()[0].label }}</span>
           } @else {
             <app-dropdown-menu placement="bottom-end">
-              <button trigger type="button" class="select select-bordered select-sm w-fit text-left">
-                {{ selectedSubtitle()?.label ?? ('player.off' | translate) }}
+              <button trigger type="button" class="select select-bordered select-sm w-fit text-left pe-9">
+                {{ selectedSubtitle()?.head || selectedSubtitle()?.label || ('player.off' | translate) }}
               </button>
-              <button type="button" class="dropdown-item" (click)="onSubtitleChange(null)">
-                {{ 'player.off' | translate }}
+              <button
+                type="button"
+                class="dropdown-item"
+                [class.text-primary]="!selectedSubtitleId()"
+                (click)="onSubtitleChange(null)"
+              >
+                <span class="flex-1 text-left">{{ 'player.off' | translate }}</span>
+                @if (!selectedSubtitleId()) { <span class="h-2 w-2 rounded-full bg-primary shrink-0"></span> }
               </button>
               @for (s of subtitles(); track s.id) {
-                <button type="button" class="dropdown-item !items-start flex-col gap-0" (click)="onSubtitleChange(s.id)">
-                  <span>{{ s.head || s.label }}</span>
-                  @if (s.sub) { <span class="text-xs opacity-60">{{ s.sub }}</span> }
+                <button
+                  type="button"
+                  class="dropdown-item"
+                  [class.text-primary]="s.id === selectedSubtitleId()"
+                  (click)="onSubtitleChange(s.id)"
+                >
+                  <span class="flex-1 flex flex-col items-start gap-0 leading-tight text-left">
+                    <span>{{ s.head || s.label }}</span>
+                    @if (s.sub) { <span class="text-xs opacity-60">{{ s.sub }}</span> }
+                  </span>
+                  @if (s.id === selectedSubtitleId()) { <span class="h-2 w-2 rounded-full bg-primary shrink-0"></span> }
                 </button>
               }
             </app-dropdown-menu>

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -67,6 +67,8 @@ export interface MediaInfoHeaderFile {
 export interface MediaInfoHeaderSubtitle {
   id: string;
   label: string;
+  head?: string;
+  sub?: string;
   language: string;
   forced?: boolean;
   /** Bitmap (PGS/VOBSUB) track. */
@@ -242,6 +244,9 @@ export class MediaInfoHeaderComponent {
   readonly durationSeconds = signal<number | null>(null);
   readonly selectedAudioIndex = signal<number | null>(null);
   readonly selectedSubtitleId = signal<string | null>(null);
+  readonly selectedSubtitle = computed(
+    () => this.subtitles().find((s) => s.id === this.selectedSubtitleId()) ?? null,
+  );
 
   // Overview clamp / expand. The mobile and desktop layouts each render an
   // `#overviewText` paragraph (both live in the DOM; CSS hides one), so we

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -47,6 +47,7 @@ import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 import {
   bucketResolutionLabel,
   formatAudioLabel,
+  formatAudioParts,
   resolutionFromQualityName,
 } from '../../../core/utils/player.utils';
 import { DropdownMenuComponent } from '../dropdown-menu';
@@ -89,6 +90,8 @@ export interface MediaInfoHeaderBadge {
 interface AudioTrack {
   index: number;
   label: string;
+  head?: string;
+  sub?: string;
   language: string;
 }
 
@@ -316,12 +319,20 @@ export class MediaInfoHeaderComponent {
     const file = this.selectedFile();
     const audio = file?.streamInfo?.audio as any[] | undefined;
     if (!audio?.length) return [];
-    return audio.map((a: any, i: number) => ({
-      index: i,
-      label: formatAudioLabel(a, this.translate, i + 1),
-      language: a.language ?? 'und',
-    }));
+    return audio.map((a: any, i: number) => {
+      const parts = formatAudioParts(a, this.translate, i + 1);
+      return {
+        index: i,
+        label: formatAudioLabel(a, this.translate, i + 1),
+        head: parts.head,
+        sub: parts.sub,
+        language: a.language ?? 'und',
+      };
+    });
   });
+  readonly selectedAudio = computed(
+    () => this.audioTracks().find((t) => t.index === this.selectedAudioIndex()) ?? null,
+  );
 
   private readonly resolveDefaultsEffect = effect(() => {
     const file = this.selectedFile();

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -409,6 +409,8 @@ export class SubtitlesModalComponent {
       return {
         id,
         label: parts.sub ? `${parts.head} — ${parts.sub}` : parts.head,
+        head: parts.head,
+        sub: parts.sub,
         language: s.language,
         forced: s.forced,
         image: isImageBasedSubtitleCodec(s.codec),

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -33,7 +33,7 @@ import {
   LucideZap,
 } from '@lucide/angular';
 import { LocalizeLanguagePipe } from '../../../core/pipes/localize-language.pipe';
-import { formatSubtitleLabel } from '../../../core/utils/player.utils';
+import { formatSubtitleLabel, formatSubtitleParts } from '../../../core/utils/player.utils';
 import { localizeLanguage } from '../../../core/utils/language.utils';
 import {
   isImageBasedSubtitleCodec,
@@ -405,9 +405,10 @@ export class SubtitlesModalComponent {
     );
     return subs.map((s) => {
       const id = s.streamIndex != null ? `emb-${s.streamIndex}` : `ext-${s.id}`;
+      const parts = formatSubtitleParts(s, this.translate);
       return {
         id,
-        label: formatSubtitleLabel(s, this.translate),
+        label: parts.sub ? `${parts.head} — ${parts.sub}` : parts.head,
         language: s.language,
         forced: s.forced,
         image: isImageBasedSubtitleCodec(s.codec),


### PR DESCRIPTION
Subtitle track labels stop trailing every attribute in parentheses.

- **Player track menu** (desktop + mobile): language on top, details as a muted `text-xs` subline in the form "SRT • Translated" (codec • flags • origin).
- **Media-detail header selector**: same parts, but it's a native `<select>` so the details stay on one line — "language — SRT • Translated".

`formatSubtitleParts()` centralizes the head/sub split; `formatSubtitleLabel()` (flat, used by cast/native) is unchanged.

Client `ng build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)