### PR TITLE
feat(player): enrich the playback error dialog and fix desktop autoplay

### DIFF
--- a/client/src/app/core/plugins/desktop-player.bridge.ts
+++ b/client/src/app/core/plugins/desktop-player.bridge.ts
@@ -65,7 +65,7 @@ export type DesktopEvent =
       payload: { audioTracks: DesktopAudioTrack[]; subtitleTracks: DesktopSubtitleTrack[] };
     }
   | { type: 'firstFrame' }
-  | { type: 'error'; payload: { code: number; message: string } };
+  | { type: 'error'; payload: { code: number; message: string; detail?: string } };
 
 export interface FliksDesktopApi {
   runtime: 'electron';

--- a/client/src/app/core/services/playback-engine/desktop-engine.ts
+++ b/client/src/app/core/services/playback-engine/desktop-engine.ts
@@ -358,7 +358,14 @@ export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEng
         // session-expired recovery before surfacing a fatal error.
         if (this.maybeEmitSessionExpired()) return;
         this._state = 'error';
-        this.emit('error', event.payload);
+        const { code, message, detail } = event.payload;
+        // mpv's generic message ("loading failed") plus the concrete cause it
+        // logged (TLS verify, HTTP status, unsupported codec) so the error card
+        // shows why, not just that.
+        this.emit('error', {
+          code,
+          message: detail ? `${message} — ${detail}` : message,
+        });
         break;
       }
       default:

--- a/client/src/app/core/services/playback-engine/playback-error.spec.ts
+++ b/client/src/app/core/services/playback-engine/playback-error.spec.ts
@@ -96,5 +96,22 @@ describe('playback-error', () => {
       const err: PlaybackError = { userMessage: 'x', source: 'media', code: 3 };
       expect(formatErrorDiagnostics(err, {})).toContain('code: 3 (MEDIA_ERR_DECODE)');
     });
+
+    it('renders the engine, endpoint, title, device and app version', () => {
+      const err: PlaybackError = { userMessage: 'x', source: 'engine', code: -1, message: 'loading failed' };
+      const out = formatErrorDiagnostics(err, {
+        engine: 'desktop-mpv',
+        url: '/api/stream/3?token=abc&sid=xyz',
+        title: 'Some Series — S1:E2 - An Episode',
+        device: 'desktop/electron · UA',
+        appVersion: '1.15.2',
+      });
+      expect(out).toContain('engine: desktop-mpv');
+      expect(out).toContain('url: /api/stream/3?token=abc&sid=xyz');
+      expect(out).toContain('title: Some Series — S1:E2 - An Episode');
+      expect(out).toContain('device: desktop/electron · UA');
+      expect(out).toContain('appVersion: 1.15.2');
+      expect(out).toContain('message: loading failed');
+    });
   });
 });

--- a/client/src/app/core/services/playback-engine/playback-error.ts
+++ b/client/src/app/core/services/playback-engine/playback-error.ts
@@ -143,7 +143,16 @@ export function errorSignature(err: PlaybackError): string {
  *  report, not translated UI copy. */
 export function formatErrorDiagnostics(
   err: PlaybackError,
-  ctx: { currentTime?: number; mode?: string; hwAccel?: string },
+  ctx: {
+    currentTime?: number;
+    mode?: string;
+    hwAccel?: string;
+    engine?: string;
+    url?: string;
+    title?: string;
+    device?: string;
+    appVersion?: string;
+  },
 ): string {
   const codeName =
     err.source === 'media'
@@ -152,7 +161,11 @@ export function formatErrorDiagnostics(
   const catName =
     err.category != null ? SHAKA_CATEGORY_NAMES[err.category] : undefined;
   const lines: string[] = [];
+  if (ctx.title) lines.push(`title: ${ctx.title}`);
+  if (ctx.device) lines.push(`device: ${ctx.device}`);
+  if (ctx.appVersion) lines.push(`appVersion: ${ctx.appVersion}`);
   lines.push(`source: ${err.source}`);
+  if (ctx.engine) lines.push(`engine: ${ctx.engine}`);
   if (err.code != null) lines.push(`code: ${err.code}${codeName ? ` (${codeName})` : ''}`);
   if (err.category != null) lines.push(`category: ${err.category}${catName ? ` (${catName})` : ''}`);
   if (err.severity != null) lines.push(`severity: ${err.severity}${err.severity === 2 ? ' (CRITICAL)' : err.severity === 1 ? ' (RECOVERABLE)' : ''}`);
@@ -160,6 +173,7 @@ export function formatErrorDiagnostics(
   if (ctx.mode) lines.push(`playMethod: ${ctx.mode}`);
   if (ctx.hwAccel) lines.push(`hwAccel: ${ctx.hwAccel}`);
   if (ctx.currentTime != null) lines.push(`position: ${ctx.currentTime.toFixed(1)}s`);
+  if (ctx.url) lines.push(`url: ${ctx.url}`);
   if (err.message) lines.push(`message: ${err.message}`);
   if (err.data && err.data.length) {
     let dump: string;

--- a/client/src/app/features/player/player.html
+++ b/client/src/app/features/player/player.html
@@ -59,12 +59,12 @@
         <svg lucideCircleAlert class="h-12 w-12 mx-auto mb-4 text-error"></svg>
         <p class="text-lg font-medium">{{ 'player.error' | translate }}</p>
         <p class="text-sm text-white/60 mt-1">{{ err.userMessage }}</p>
-        @if (err.code != null || err.data?.length || err.variant) {
+        @if (err.code != null || err.data?.length || err.variant || err.message) {
           <details class="mt-3 text-left">
             <summary class="cursor-pointer select-none text-xs text-white/50">
               {{ 'player.error_details' | translate }}
             </summary>
-            <pre class="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-all rounded bg-black/40 p-2 text-[11px] leading-snug text-white/70">{{ errorDiagnostics() }}</pre>
+            <pre class="mt-2 max-h-60 overflow-auto whitespace-pre-wrap break-words rounded bg-black/40 p-2 text-[11px] leading-snug text-white/70">{{ errorDiagnostics() }}</pre>
           </details>
           <div class="mt-4 flex items-center justify-center gap-2">
             <button class="btn btn-ghost btn-sm" (click)="copyErrorDiagnostics()">

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -42,6 +42,7 @@ import { PlaybackQueueService, QueueItem } from '../../core/services/playback-qu
 import { resolvePlayableFile } from '../../shared/utils/media-play.util';
 import { audioChannelsLabel, formatAudioLabel, formatAudioParts, parseAudioIndex, SpriteMetadata, widthForProfile } from '../../core/utils/player.utils';
 import { formatErrorDiagnostics, userMessageKeyFor } from '../../core/services/playback-engine/playback-error';
+import { environment } from '../../../environments/environment';
 import {
   PlayerSettingsService, normalizeLang,
   SUBTITLE_SIZE_MAP, SUBTITLE_COLOR_MAP, SUBTITLE_SHADOW_MAP, SUBTITLE_BG_MAP,
@@ -600,6 +601,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   });
   private playbackInfo: PlaybackInfoResponse | null = null;
 
+  /** Last URL handed to the engine's load(), surfaced (token-redacted) in the
+   *  error diagnostics so a failed open shows which endpoint/format was tried. */
+  private lastStreamUrl = '';
+
   /** Live-session id to bind the next stream request to. While casting
    *  the receiver's session id wins (its segments come from a separate
    *  ffmpeg job under the cast device profile); otherwise the local
@@ -1062,6 +1067,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       if (this.isOfflinePlayback) {
         this.state.playbackMode.set('direct');
         this.qualityManager.availableQualities.set([]);
+        this.lastStreamUrl = offlineCheck ?? '';
 
         if (this.isDesktopNative) {
           // Desktop: the original container lives on disk; mpv plays it back
@@ -2672,22 +2678,26 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   } = {}): { url: string; mimeType?: string } {
     const mode = this.playbackMode();
     const sid = opts.sid ?? this.playbackInfo?.sessionId;
+    let built: { url: string; mimeType?: string };
     if (mode === 'direct') {
-      return {
+      built = {
         url: this.streamingApi.getStreamUrl(this.mediaFileId, sid),
         mimeType: 'video/mp4',
       };
+    } else {
+      const savedQualityId = this.activeQualityId();
+      const startQuality = savedQualityId !== 'auto' ? savedQualityId : undefined;
+      built = {
+        url: this.streamingApi.getHlsUrl(
+          this.mediaFileId,
+          startQuality,
+          opts.startTime,
+          sid,
+        ),
+      };
     }
-    const savedQualityId = this.activeQualityId();
-    const startQuality = savedQualityId !== 'auto' ? savedQualityId : undefined;
-    return {
-      url: this.streamingApi.getHlsUrl(
-        this.mediaFileId,
-        startQuality,
-        opts.startTime,
-        sid,
-      ),
-    };
+    this.lastStreamUrl = built.url;
+    return built;
   }
 
   /**
@@ -2840,11 +2850,52 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   errorDiagnostics(): string {
     const err = this.state.error();
     if (!err) return '';
-    return formatErrorDiagnostics(err, {
+    const dump = formatErrorDiagnostics(err, {
       currentTime: this.state.currentTime(),
       mode: this.state.playbackMode(),
       hwAccel: this.state.hwAccel(),
+      engine: this.engineLabel(),
+      url: this.lastStreamUrl,
+      title: this.diagnosticsTitle(),
+      device: this.diagnosticsDevice(),
+      appVersion: environment.version,
     });
+    return this.redactSecrets(dump);
+  }
+
+  /** Concrete playback engine behind the current session — `source: engine`
+   *  alone can't tell desktop mpv from mobile native from a TV player. */
+  private engineLabel(): string {
+    if (this.isDesktopNative) return 'desktop-mpv';
+    if (this.isTizenEngine()) return 'tizen-avplay';
+    if (this.isWebOs) return 'webos';
+    if (this.isNativeEngine()) return 'native';
+    return 'shaka';
+  }
+
+  /** `Film` or `Series — S1:E2 - Episode` for the diagnostics header. */
+  private diagnosticsTitle(): string {
+    const title = this.mediaTitle();
+    const episode = this.episodeTitle();
+    return episode ? `${title} — ${episode}` : title;
+  }
+
+  /** Form factor + shell/platform + user agent, so a pasted report says which
+   *  build and OS hit the error. */
+  private diagnosticsDevice(): string {
+    const platform = this.device.desktopPlatform() ?? this.device.tvPlatform();
+    const label = platform
+      ? `${this.device.formFactor()}/${platform}`
+      : this.device.formFactor();
+    return `${label} · ${navigator.userAgent}`;
+  }
+
+  /** Strip auth secrets before the diagnostics block is shown or copied: the
+   *  stream URL carries a `?token=<JWT>` and requests use a Bearer header. */
+  private redactSecrets(dump: string): string {
+    return dump
+      .replace(/([?&]token=)[^&\s]+/gi, '$1<redacted>')
+      .replace(/(Bearer\s+)[\w.-]+/gi, '$1<redacted>');
   }
 
   async copyErrorDiagnostics(): Promise<void> {

--- a/desktop/src/main/mpv/mpv-player.ts
+++ b/desktop/src/main/mpv/mpv-player.ts
@@ -58,6 +58,11 @@ export class MpvPlayer extends EventEmitter {
   private readonly pending = new Map<number, Pending>();
   private buf = '';
   private sawFirstFrame = false;
+  /** One-shot per load: `--keep-open=yes` makes mpv pause on the last frame and
+   *  set `eof-reached` instead of firing an `end-file`(eof) event, so the
+   *  natural end is detected from that property. Guards against mpv re-sending
+   *  the property-change so `ended` (which drives auto-advance) emits once. */
+  private sawEof = false;
   private duration = 0;
   private cacheEnd = 0;
   /** Demuxer format forced for the current media (`hls` for manifests, else
@@ -66,6 +71,11 @@ export class MpvPlayer extends EventEmitter {
   /** Bumped by load/stop/destroy; a load with a stale id skips its remaining
    *  IPC writes, so a stop can't be overtaken by a trailing loadfile. */
   private loadGen = 0;
+  /** error/fatal mpv log lines seen since the current load began. mpv's
+   *  `end-file` error carries only the generic `MPV_ERROR_*` string ("loading
+   *  failed"); the real cause (TLS verify, HTTP status, unsupported codec) is in
+   *  these log lines, so we buffer them and attach them to the error event. */
+  private errorLog: string[] = [];
 
   constructor(opts: MpvPlayerOptions) {
     super();
@@ -207,9 +217,15 @@ export class MpvPlayer extends EventEmitter {
       case 'property-change':
         this.onProperty(msg.name, msg.data);
         break;
-      case 'log-message':
-        this.emit('log', `[${msg.level}] ${msg.prefix}: ${msg.text}`);
+      case 'log-message': {
+        const line = `${msg.prefix ? `${msg.prefix}: ` : ''}${msg.text ?? ''}`.trim();
+        if (msg.level === 'error' || msg.level === 'fatal') {
+          this.errorLog.push(line);
+          if (this.errorLog.length > 12) this.errorLog.shift();
+        }
+        this.emit('log', `[${msg.level}] ${line}`);
         break;
+      }
       case 'playback-restart':
         if (!this.sawFirstFrame) {
           this.sawFirstFrame = true;
@@ -219,7 +235,11 @@ export class MpvPlayer extends EventEmitter {
       case 'end-file':
         if (msg.reason === 'eof') this.emit('stateChanged', { state: 'ended' });
         else if (msg.reason === 'error')
-          this.emit('error', { code: -1, message: msg.file_error ?? 'end-file error' });
+          this.emit('error', {
+            code: -1,
+            message: msg.file_error ?? 'end-file error',
+            detail: this.errorLog.join(' | ') || undefined,
+          });
         break;
       default:
         break;
@@ -244,6 +264,14 @@ export class MpvPlayer extends EventEmitter {
         // `@if (bufferedEnd())`) collapses to 0 and flickers on every gap.
         if (data != null) this.cacheEnd = data;
         break;
+      case 'eof-reached':
+        // With `--keep-open=yes` this is how a natural end surfaces (no
+        // `end-file`(eof)); map it to the `ended` state that drives auto-advance.
+        if (data === true && !this.sawEof) {
+          this.sawEof = true;
+          this.emit('stateChanged', { state: 'ended' });
+        }
+        break;
       case 'pause':
         this.emit('stateChanged', { state: data ? 'paused' : 'playing' });
         break;
@@ -265,6 +293,7 @@ export class MpvPlayer extends EventEmitter {
       'demuxer-cache-time',
       'pause',
       'paused-for-cache',
+      'eof-reached',
       'track-list',
     ]) {
       await this.command(['observe_property', ++this.observeId, prop]);
@@ -306,8 +335,10 @@ export class MpvPlayer extends EventEmitter {
 
   async load(opts: DesktopLoadOptions): Promise<void> {
     this.sawFirstFrame = false;
+    this.sawEof = false;
     this.duration = 0;
     this.cacheEnd = 0;
+    this.errorLog = [];
     const gen = ++this.loadGen;
     // Reset the reused player first so the new open's probe can't read atop the
     // previous file's buffered stream.
@@ -390,6 +421,7 @@ export class MpvPlayer extends EventEmitter {
     // Reset baselines so the persistent player can't replay a stale first-frame
     // / position into the next session after a back-navigation.
     this.sawFirstFrame = false;
+    this.sawEof = false;
     this.duration = 0;
     this.cacheEnd = 0;
     return this.command(['stop']).then(() => undefined);

--- a/desktop/src/shared/contract.ts
+++ b/desktop/src/shared/contract.ts
@@ -67,7 +67,7 @@ export type DesktopEvent =
       payload: { audioTracks: DesktopAudioTrack[]; subtitleTracks: DesktopSubtitleTrack[] };
     }
   | { type: 'firstFrame' }
-  | { type: 'error'; payload: { code: number; message: string } };
+  | { type: 'error'; payload: { code: number; message: string; detail?: string } };
 
 /** renderer → main invoke channels. */
 export const IPC = {


### PR DESCRIPTION
## Context

Reported on the Windows desktop client, but the dialog work is engine-agnostic:

1. **Playback error dialog was uninformative** — on desktop mpv it showed only the generic `loading failed` with no way to tell *why* it failed or on which build. A real case: a **TLS certificate verification failure** on the direct-play open surfaced as a bare `loading failed`.
2. **Auto-advance to the next episode did not work on desktop** (works on web).

## Changes

### Error dialog — richer, complete, copyable (all platforms)
`formatErrorDiagnostics()` and the error card template are shared by every engine (Shaka/web, Capacitor native, Tizen, webOS, desktop mpv), so this applies everywhere:
- Adds **media title** (`Film` or `Series — S1:E2 - …`), **device** (form factor + shell/platform + UA), **app version**, **engine** (desktop-mpv / native / tizen-avplay / webos / shaka) and the **stream URL** to the diagnostics dump.
- **Redacts** the `?token=` JWT and any `Bearer` header before the block is shown or copied.
- The details block stays collapsed by default but is fully visible (scrollable) and copyable once expanded; the copy button always copies the full dump.

### Surface the real failure cause (desktop mpv)
- The Windows mpv backend now buffers mpv's `error`/`fatal` log lines for the current load and attaches them to the error event as `detail`; the client folds it into the message. `loading failed` now reads e.g. `loading failed — curl: TLS certificate verification failed. | stream: Failed to open …`.
- Other engines already carry their underlying cause in `message`/`data` (Shaka `data[]`, Tizen `AVPlay … failed: …`, webOS media error, native ExoPlayer/AVPlayer), so no per-engine change was needed.

### Desktop autoplay-next fix (Windows)
- `--keep-open=yes` makes mpv pause on the last frame and set the `eof-reached` property **instead of** firing an `end-file`(eof) event, so `stateChanged: ended` never fired → the client's `ended` signal never latched → auto-advance never ran.
- Detect the natural end from the `eof-reached` property and emit `ended` (guarded once per load; reset on load/stop). The Linux/macOS addons already end via mpv defaults; web via the DOM `ended` event.

## Verification
- `desktop` typecheck ✓, `client` typecheck ✓
- `client` dev build ✓ (template compiles)
- `playback-error` unit spec ✓ (12/12, incl. new coverage for engine/url/title/device/appVersion)
- On-device (Windows) validation of the autoplay fix and the surfaced error detail still pending.

## Follow-up (separate decision)
The **root cause** of `loading failed` is mpv's bundled network stack failing TLS verification on `https://…` for the direct-play open (curl backend / CA bundle). HLS/transcode opens via ffmpeg and is unaffected. Fixing it (ship a CA bundle / use the system store / route direct play through ffmpeg / disable verify) is a security trade-off left out of this MR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)