### PR TITLE
fix(subtitles): tag track format from extension, hide if unknown

### DIFF
--- a/client/src/app/core/utils/player.utils.ts
+++ b/client/src/app/core/utils/player.utils.ts
@@ -105,18 +105,44 @@ export function parseAudioIndex(trackId: string): number {
   return parseInt(trackId.replace(/^(si-|shaka-|audio-)/, ''), 10);
 }
 
-/** Map a raw FFmpeg/ffprobe subtitle codec name to a short, user-friendly
- *  tag (PGS, SRT, ASS, VTT). Falls back to "SRT" for external files
- *  (typical) and "EMB" for embedded streams without a codec hint. */
-function shortSubtitleCodec(codec: string | null | undefined, hasFile: boolean): string {
-  const c = (codec ?? '').toLowerCase();
-  if (c === 'hdmv_pgs_subtitle' || c === 'dvd_subtitle' || c === 'dvb_subtitle') return 'PGS';
-  if (c === 'subrip') return 'SRT';
-  if (c === 'ass' || c === 'ssa') return 'ASS';
-  if (c === 'webvtt') return 'VTT';
-  if (c === 'mov_text') return 'TX3G';
+/** Canonical codec name for a subtitle sidecar, inferred from its file
+ *  extension. External subs (downloaded, disk-scanned) carry no ffprobe
+ *  codec, so the extension is the authoritative format hint. */
+function subtitleCodecFromPath(relativePath: string): string {
+  const ext = relativePath.slice(relativePath.lastIndexOf('.') + 1).toLowerCase();
+  switch (ext) {
+    case 'srt': return 'subrip';
+    case 'vtt': return 'webvtt';
+    case 'ass': return 'ass';
+    case 'ssa': return 'ssa';
+    case 'sup': return 'hdmv_pgs_subtitle';
+    case 'sub': return 'dvd_subtitle';
+    case 'smi':
+    case 'sami': return 'sami';
+    default: return '';
+  }
+}
+
+/** Map a subtitle codec (an ffprobe name, or one inferred from the sidecar
+ *  extension) to a short user-facing tag (SRT, ASS, VTT, PGS, …). Returns
+ *  an empty string when the format can't be determined, so the caller shows
+ *  no tag rather than a misleading default. */
+function shortSubtitleCodec(codec: string | null | undefined, relativePath: string | null | undefined): string {
+  let c = (codec ?? '').toLowerCase();
+  if (!c && relativePath) c = subtitleCodecFromPath(relativePath);
+  switch (c) {
+    case 'hdmv_pgs_subtitle':
+    case 'dvd_subtitle':
+    case 'dvb_subtitle': return 'PGS';
+    case 'subrip': return 'SRT';
+    case 'ass':
+    case 'ssa': return 'ASS';
+    case 'webvtt': return 'VTT';
+    case 'sami': return 'SAMI';
+    case 'mov_text': return 'TX3G';
+  }
   if (c) return c.toUpperCase();
-  return hasFile ? 'SRT' : 'EMB';
+  return '';
 }
 
 /** Channel count to a recognizable layout label (5.1, 7.1, 2.0, …). */
@@ -199,10 +225,11 @@ export function formatSubtitleLabel(
   const parts: string[] = [];
   if (sub.hearingImpaired) parts.push('HI');
   if (sub.forced) parts.push('Forced');
-  parts.push(shortSubtitleCodec(sub.codec, !!sub.relativePath));
+  const codec = shortSubtitleCodec(sub.codec, sub.relativePath);
+  if (codec) parts.push(codec);
   const origin = subtitleOriginLabel(sub.providerType, translate);
   if (origin) parts.push(origin);
-  return `${head} (${parts.join(') (')})`;
+  return parts.length ? `${head} (${parts.join(') (')})` : head;
 }
 
 /**
@@ -226,7 +253,9 @@ export function formatSubtitleParts(
     trackIndex != null && (norm === 'und' || norm === 'xx')
       ? translate.instant('player.subtitle_track_n', { index: trackIndex })
       : localizeLanguage(sub.language, translate);
-  const parts: string[] = [shortSubtitleCodec(sub.codec, !!sub.relativePath)];
+  const parts: string[] = [];
+  const codec = shortSubtitleCodec(sub.codec, sub.relativePath);
+  if (codec) parts.push(codec);
   if (sub.forced) parts.push('Forced');
   if (sub.hearingImpaired) parts.push('HI');
   const origin = subtitleOriginLabel(sub.providerType, translate);


### PR DESCRIPTION
## Problem

The subtitle selector always displayed **SRT**, regardless of the actual file format.

External subtitles (downloaded, disk-scanned) are persisted without an ffprobe `codec`, so the label helper fell back to a blanket `'SRT'` for any sidecar (`shortSubtitleCodec` returned `hasFile ? 'SRT' : 'EMB'`). A `.ass`, `.vtt` or `.sup` file dropped in a media folder was therefore shown as "SRT".

## Fix

`client/src/app/core/utils/player.utils.ts`:

- Derive the format tag from the **sidecar file extension** when no `codec` is present — the extension is authoritative for an external file (`.srt→SRT`, `.vtt→VTT`, `.ass/.ssa→ASS`, `.sup/.sub→PGS`, `.smi/.sami→SAMI`).
- When the format still can't be determined (unknown extension, or an embedded stream with no codec hint), render **no tag** instead of a misleading default.
- Both label builders (`formatSubtitleLabel`, `formatSubtitleParts`) filter the empty tag so there's no orphan `•` separator or empty `()`.

The tag is computed at render time from the `relativePath` the API already returns, so **existing rows are corrected instantly — no migration or rescan**. Backend serving/coverage logic is untouched.

Embedded tracks keep their real ffprobe codec. Downloaded and translated/OCR subs stay "SRT" (they really are SubRip output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)