### PR TITLE
fix(desktop): stop auto-skip on playback error, rework the mpv backend

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -165,8 +165,16 @@ class PausableTimeout {
     .player-container.native-player > .player-video {
       display: none !important;
     }
+    /* Hide the cursor with a transparent image, not cursor:none: on macOS the
+       latter maps to NSCursor hide, whose hide/unhide stack only rebalances when
+       the pointer crosses the window edge, so the OS cursor stays hidden when the
+       controls re-show. An image cursor is applied via NSCursor set, so reverting
+       to the default is balanced. */
     .player-container.hide-cursor {
-      cursor: none;
+      cursor:
+        url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=')
+          0 0,
+        none;
     }
     .player-video {
       position: absolute;
@@ -1776,11 +1784,17 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // tap, so reading it can issue two same-direction commands. On the web
     // <video> the getter is exact (paused flips synchronously); the native
     // engine mirrors its bridge state, which the coalesce window covers.
+    // Reflect the target in the UI immediately instead of waiting for the
+    // engine's `stateChanged` round-trip (on the desktop mpv backend that loop
+    // — IPC → mpv property-observe → IPC back — can lag ~1s). The engine event
+    // reasserts the real state, and a rejected command reverts to it.
     if (this.engine.paused) {
-      this.engine.play().catch(() => {});
+      this.state.paused.set(false);
+      this.engine.play().catch(() => this.state.paused.set(this.engine?.paused ?? true));
       this.resetHideTimer();
     } else {
-      this.engine.pause().catch(() => {});
+      this.state.paused.set(true);
+      this.engine.pause().catch(() => this.state.paused.set(this.engine?.paused ?? true));
     }
   }
 

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -2113,9 +2113,12 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
   /** Auto-advance when a stream reaches its natural end and the context allows
    *  it. {@link PlayerStateService.ended} latches on the engine 'ended' event
-   *  and is cleared by the reload's state reset, so this fires once per item. */
+   *  and is cleared by the reload's state reset, so this fires once per item.
+   *  Never advances while an error card is up: a mid-stream failure must not be
+   *  mistaken for a natural end and skip the item. */
   private readonly autoAdvanceEffect = effect(() => {
     if (!this.state.ended()) return;
+    if (this.state.error()) return;
     if (!this.autoplayEnabled()) return;
     if (!this.upNext()) return;
     void this.advance();

--- a/desktop/native/compositor/addon.cc
+++ b/desktop/native/compositor/addon.cc
@@ -497,26 +497,9 @@ Napi::Value Start(const Napi::CallbackInfo& info) {
     M::set_option_string(g_state.mpv, "load-unsafe-playlists", "yes");
     // The app drives subtitle selection; don't let mpv auto-pick a track.
     M::set_option_string(g_state.mpv, "sid", "no");
-    // The backend produces transcode segments on demand: it answers 404 (seg-0/
-    // init on a resume, before the early companion writes them) or 503 (the
-    // resume segment while ffmpeg is still encoding it), and a late multi-audio
-    // rendition transcode can fail the open at the TRANSPORT layer (reset /
-    // refused / TLS) rather than with a 4xx/5xx status. mpv's ffmpeg HLS demuxer
-    // aborts on the first error; make its child segment/init opens reconnect on
-    // BOTH network errors and 4xx/5xx with backoff so a transient miss doesn't
-    // kill the load or skip the resume segment. The `4xx,5xx` value carries a
-    // comma, so it uses mpv's `%len%` escaping (7 = strlen("4xx,5xx")) to
-    // survive the key-value-list parser.
-    M::set_option_string(g_state.mpv, "demuxer-lavf-o",
-        "reconnect=1,reconnect_streamed=1,reconnect_on_network_error=1,reconnect_on_http_error=%7%4xx,5xx,reconnect_delay_max=5");
-    // Buffer like the web engine: ~30s forward (cache-secs binds the TIME cap),
-    // ~60s back; the byte cap is a generous ceiling so time binds first.
-    M::set_option_string(g_state.mpv, "cache", "yes");
-    M::set_option_string(g_state.mpv, "cache-secs", "30");
-    M::set_option_string(g_state.mpv, "demuxer-readahead-secs", "30");
-    M::set_option_string(g_state.mpv, "demuxer-max-bytes", "256MiB");
-    M::set_option_string(g_state.mpv, "demuxer-max-back-bytes", "96MiB");
-    M::set_option_string(g_state.mpv, "cache-pause-wait", "1");
+    // Streaming/buffering/reconnect tuning is applied from TS after start
+    // (MPV_STREAM_OPTIONS in src/shared/mpv-stream-options.ts) — one source of
+    // truth shared with the Windows subprocess + macOS backends.
     if (M::initialize(g_state.mpv) < 0) fprintf(stderr, "[compositor] mpv_initialize failed\n");
     M::observe_property(g_state.mpv, 1, "time-pos", MPV_FORMAT_DOUBLE);
     M::observe_property(g_state.mpv, 2, "duration", MPV_FORMAT_DOUBLE);

--- a/desktop/native/player_mac/addon.mm
+++ b/desktop/native/player_mac/addon.mm
@@ -521,18 +521,9 @@ Napi::Value Start(const Napi::CallbackInfo& info) {
   // target-colorspace-hint is deliberately NOT set — it is inert on the render
   // API (it needs vo=gpu-next plus a Wayland/D3D11/winvk swapchain, none of which
   // exist for a host-owned CAOpenGLLayer FBO).
-  // Same on-demand-transcode reconnect policy as the Linux addon (see addon.cc):
-  // retry seg-0/init 404s, in-progress 503s and transport-level open failures.
-  M::set_option_string(g_state.mpv, "demuxer-lavf-o",
-      "reconnect=1,reconnect_streamed=1,reconnect_on_network_error=1,reconnect_on_http_error=%7%4xx,5xx,reconnect_delay_max=5");
-  // Buffer like the web engine: ~30s forward (cache-secs binds the TIME cap),
-  // ~60s back; the byte cap is a generous ceiling so time binds first.
-  M::set_option_string(g_state.mpv, "cache", "yes");
-  M::set_option_string(g_state.mpv, "cache-secs", "30");
-  M::set_option_string(g_state.mpv, "demuxer-readahead-secs", "30");
-  M::set_option_string(g_state.mpv, "demuxer-max-bytes", "256MiB");
-  M::set_option_string(g_state.mpv, "demuxer-max-back-bytes", "96MiB");
-  M::set_option_string(g_state.mpv, "cache-pause-wait", "1");
+  // Streaming/buffering/reconnect tuning is applied from TS after start
+  // (MPV_STREAM_OPTIONS in src/shared/mpv-stream-options.ts) — one source of
+  // truth shared with the Linux + Windows backends.
   if (M::initialize(g_state.mpv) < 0) fprintf(stderr, "[player-mac] mpv_initialize failed\n");
   M::observe_property(g_state.mpv, 1, "time-pos", MPV_FORMAT_DOUBLE);
   M::observe_property(g_state.mpv, 2, "duration", MPV_FORMAT_DOUBLE);

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -11,6 +11,8 @@ import { registerDownloadIpc } from './download';
 import { setPlaybackKeepAwake, keepAwakeForState } from './power';
 import { IPC, type DesktopEvent, type DesktopSubtitleStyle } from '../shared/contract';
 import { mpvSubtitleProps } from './mpv/subtitle-style';
+import { parseTracks } from './mpv/tracks';
+import { MPV_STREAM_OPTIONS } from '../shared/mpv-stream-options';
 
 // Name the app before `ready` so Linux derives the WM class (and thus the
 // GNOME/Ubuntu top-bar + dock identity) from "Fliks" rather than "Electron".
@@ -148,33 +150,6 @@ function computeDeviceName(): string {
     /* fall through to hostname */
   }
   return os.hostname().replace(/\.local$/, '');
-}
-
-function parseTracks(json: string | null): {
-  audioTracks: unknown[];
-  subtitleTracks: unknown[];
-} {
-  let list: any[] = [];
-  try {
-    list = JSON.parse(json ?? '[]') ?? [];
-  } catch {
-    /* not ready */
-  }
-  const audioTracks: unknown[] = [];
-  const subtitleTracks: unknown[] = [];
-  for (const t of list) {
-    if (t.type === 'audio')
-      audioTracks.push({ id: String(t.id), language: t.lang ?? '', label: t.title ?? '', selected: !!t.selected });
-    else if (t.type === 'sub')
-      subtitleTracks.push({
-        id: String(t.id),
-        language: t.lang ?? '',
-        label: t.title ?? '',
-        forced: !!t.forced,
-        selected: !!t.selected,
-      });
-  }
-  return { audioTracks, subtitleTracks };
 }
 
 const KEYMAP: Record<string, string> = {
@@ -338,6 +313,10 @@ app.whenReady().then(async () => {
   uiWin.webContents.on('console-message', (_e, _l, m) => console.log('[renderer]', m));
 
   addon.start({ width: WIDTH, height: HEIGHT, title: 'Fliks', icon: compositorIcon() });
+  // Apply the shared streaming/reconnect tuning (all runtime-mutable, set before
+  // the first load) so buffering + resume behaviour matches the other backends
+  // from one source of truth.
+  for (const [name, value] of MPV_STREAM_OPTIONS) addon.setProperty(name, value);
 
   // Periodic position emit. The addon's `time-pos` observe doesn't push while
   // playback advances, so poll mpv on a timer and forward a `timeUpdate` — this
@@ -396,7 +375,7 @@ app.whenReady().then(async () => {
         send({ type: 'stateChanged', payload: { state: raw.state } });
         break;
       case 'tracksChanged':
-        send({ type: 'tracksChanged', payload: parseTracks(addon.getProperty('track-list')) as any });
+        send({ type: 'tracksChanged', payload: parseTracks(addon.getProperty('track-list')) });
         break;
       case 'firstFrame':
         // mpv autoplays on load (addon forces pause=no) but may not emit a

--- a/desktop/src/main/mpv/mac-mpv-player.ts
+++ b/desktop/src/main/mpv/mac-mpv-player.ts
@@ -7,19 +7,21 @@
 // a near-copy of the Linux IPC handlers + event reshaping in `main/index.ts`.
 
 import { app, BrowserWindow } from 'electron';
-import { EventEmitter } from 'node:events';
 import path from 'node:path';
 import { createRequire } from 'node:module';
-import type { PlayerBackend } from './player-backend';
+import type { PlayerBackend, PlayerBackendEvents } from './player-backend';
 import type {
   DesktopAudioTrack,
   DesktopLoadOptions,
+  DesktopPlayerState,
   DesktopPositionInfo,
   DesktopSubtitleStyle,
   DesktopSubtitleTrack,
 } from '../../shared/contract';
+import { MPV_STREAM_OPTIONS } from '../../shared/mpv-stream-options';
 import { mpvSubtitleProps } from './subtitle-style';
 import { parseTracks } from './tracks';
+import { TypedEmitter } from './typed-emitter';
 
 // Cadence of the periodic position emit while playing. As on Linux, the addon's
 // `time-pos` observe doesn't push while playback advances, so the seekbar + the
@@ -43,7 +45,7 @@ const num = (v: string | null): number => {
   return Number.isFinite(n) ? n : 0;
 };
 
-export class MacMpvPlayer extends EventEmitter implements PlayerBackend {
+export class MacMpvPlayer extends TypedEmitter<PlayerBackendEvents> implements PlayerBackend {
   private readonly addon: MacAddon;
   private readonly wid: string;
   private sawFirstFrame = false;
@@ -73,12 +75,22 @@ export class MacMpvPlayer extends EventEmitter implements PlayerBackend {
     // Register the event callback BEFORE start so no early event is missed.
     this.addon.onEvent((json) => this.onAddonEvent(json));
     this.addon.start({ wid: this.wid });
+    // Apply the shared streaming/reconnect tuning (all runtime-mutable, set
+    // before the first load) so buffering + resume behaviour matches the other
+    // backends from one source of truth.
+    for (const [name, value] of MPV_STREAM_OPTIONS) this.addon.setProperty(name, value);
     return this;
   }
 
   // ── addon events → PlayerBackend events (mirrors index.ts addon.onEvent) ────
   private onAddonEvent(json: string): void {
-    let raw: { type?: string; state?: string; position?: number; duration?: number; message?: string };
+    let raw: {
+      type?: string;
+      state?: DesktopPlayerState;
+      position?: number;
+      duration?: number;
+      message?: string;
+    };
     try {
       raw = JSON.parse(json);
     } catch {
@@ -92,13 +104,16 @@ export class MacMpvPlayer extends EventEmitter implements PlayerBackend {
           buffered: num(this.addon.getProperty('demuxer-cache-time')),
         } satisfies DesktopPositionInfo);
         break;
-      case 'stateChanged':
+      case 'stateChanged': {
+        const state = raw.state;
+        if (!state) break;
         // Only an actively-playing session drives the poll; pausing / ending /
         // buffering / idle stops it so a torn-down player can't keep emitting.
-        if (raw.state === 'playing') this.startPositionTimer();
+        if (state === 'playing') this.startPositionTimer();
         else this.stopPositionTimer();
-        this.emit('stateChanged', { state: raw.state });
+        this.emit('stateChanged', { state });
         break;
+      }
       case 'tracksChanged':
         this.emit('tracksChanged', parseTracks(this.addon.getProperty('track-list')));
         break;

--- a/desktop/src/main/mpv/mpv-player.ts
+++ b/desktop/src/main/mpv/mpv-player.ts
@@ -6,7 +6,6 @@
 
 import { spawn, type ChildProcess } from 'node:child_process';
 import net from 'node:net';
-import { EventEmitter } from 'node:events';
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -17,25 +16,51 @@ import type {
   DesktopSubtitleStyle,
   DesktopSubtitleTrack,
 } from '../../shared/contract';
+import { MPV_STREAM_OPTIONS } from '../../shared/mpv-stream-options';
 import { mpvSubtitleProps } from './subtitle-style';
-import { isImageBasedSubtitleCodec } from './tracks';
+import { mapTrackList, type MpvTrack } from './tracks';
+import { TypedEmitter } from './typed-emitter';
+import type { PlayerBackend, PlayerBackendEvents } from './player-backend';
 
 const CONNECT_RETRY_MS = 30;
 const CONNECT_TIMEOUT_MS = 5000;
+/** Cap on a single IPC command's round-trip. A live-but-wedged mpv would else
+ *  hang an awaiting load/seek forever (only a socket/process death rejects). */
+const COMMAND_TIMEOUT_MS = 30_000;
+/** How long `load()` waits for the first frame before sequencing post-open work. */
+const FIRST_FRAME_TIMEOUT_MS = 10_000;
+/** Grace for mpv to reply to `quit` before the socket/process are torn down. */
+const QUIT_GRACE_MS = 500;
+/** Ring size for buffered error/fatal log lines attached to an error event. */
+const MAX_ERROR_LOG_LINES = 12;
+/** Playhead-to-duration gap (s) above which an `eof-reached` is read as a
+ *  mid-stream failure (ffmpeg surfaces a dead HLS segment as EOF, not an error)
+ *  rather than a genuine end, and routed to `error` instead of `ended`. */
+const PREMATURE_EOF_GAP_S = 10;
 
-interface MpvTrack {
-  id: number;
-  type: string;
-  codec?: string;
-  lang?: string;
-  title?: string;
-  selected?: boolean;
-  forced?: boolean;
+/** Monotonic per-process counter for the IPC socket/pipe name, so two players
+ *  created within the same millisecond can't collide on the path. */
+let instanceSeq = 0;
+
+/** A message line from mpv's JSON IPC — either a command reply (`request_id`) or
+ *  an event (`event`). Every field is optional; only the discriminant is read. */
+interface MpvIpcMessage {
+  request_id?: number;
+  error?: string;
+  data?: unknown;
+  event?: string;
+  name?: string;
+  reason?: string;
+  file_error?: string;
+  level?: string;
+  prefix?: string;
+  text?: string;
 }
 
 interface Pending {
   resolve: (value: unknown) => void;
   reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
 }
 
 export interface MpvPlayerOptions {
@@ -46,7 +71,7 @@ export interface MpvPlayerOptions {
   env?: NodeJS.ProcessEnv;
 }
 
-export class MpvPlayer extends EventEmitter {
+export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements PlayerBackend {
   private readonly mpvPath: string;
   private readonly baseArgs: string[];
   private readonly env: NodeJS.ProcessEnv;
@@ -59,12 +84,18 @@ export class MpvPlayer extends EventEmitter {
   private buf = '';
   private sawFirstFrame = false;
   /** One-shot per load: `--keep-open=yes` makes mpv pause on the last frame and
-   *  set `eof-reached` instead of firing an `end-file`(eof) event, so the
-   *  natural end is detected from that property. Guards against mpv re-sending
-   *  the property-change so `ended` (which drives auto-advance) emits once. */
+   *  set `eof-reached` instead of firing an `end-file`(eof) event, so the stream
+   *  end is detected from that property. Guards against mpv re-sending the
+   *  property-change so the end-vs-failure decision runs once. */
   private sawEof = false;
   private duration = 0;
   private cacheEnd = 0;
+  /** Last `time-pos` seen; compared against `duration` when `eof-reached` fires
+   *  to tell a genuine end from a mid-stream failure. */
+  private lastPosition = 0;
+  /** Set before an intentional shutdown (destroy / failed start) so the process
+   *  `exit` handler can tell a clean quit from an unexpected crash. */
+  private shuttingDown = false;
   /** Demuxer format forced for the current media (`hls` for manifests, else
    *  empty). Dropped around a sidecar `sub-add` so the VTT isn't demuxed as HLS. */
   private forcedDemuxFormat = '';
@@ -85,7 +116,7 @@ export class MpvPlayer extends EventEmitter {
     // mpv's --input-ipc-server is a unix socket on POSIX but a NAMED PIPE on
     // Windows; Node's net only accepts the \\.\pipe\ namespace there (a /tmp
     // path is rejected), so build the path per-platform.
-    const stamp = `fliks-mpv-${process.pid}-${this.reqId}-${Math.floor(performance.now())}`;
+    const stamp = `fliks-mpv-${process.pid}-${instanceSeq++}-${Math.floor(performance.now())}`;
     this.sockPath =
       process.platform === 'win32'
         ? `\\\\.\\pipe\\${stamp}`
@@ -107,43 +138,46 @@ export class MpvPlayer extends EventEmitter {
       // mpv's playlist safety check otherwise refuses them on the fallback path.
       '--load-unsafe-playlists=yes',
       '--ytdl=no',
-      // Buffer like the web (Shaka) engine (~30s fwd / ~60s back / resume 1s).
-      // cache-secs is the binding forward TIME cap — with --cache=yes it else
-      // defaults to ~unlimited and overrides readahead-secs; bytes are a ceiling.
-      '--cache=yes',
-      '--cache-secs=30',
-      '--demuxer-readahead-secs=30',
-      '--demuxer-max-bytes=256MiB',
-      '--demuxer-max-back-bytes=96MiB',
-      '--cache-pause-wait=1',
-      // A slow transcode (HDR tonemap re-encode) isn't ready when mpv opens
-      // seg-0/init for a stream, so it aborts unless told to reconnect. A
-      // separate multi-audio rendition's transcode spins up late and the open
-      // can fail at the TRANSPORT layer (reset / refused / TLS) rather than with
-      // a 4xx/5xx status, so reconnect_on_network_error is needed alongside
-      // reconnect_on_http_error. The `4xx,5xx` value carries a comma, so it uses
-      // mpv's `%len%` escaping (7 = strlen("4xx,5xx")) to survive the key-value-
-      // list parser. Mirrors native/compositor/addon.cc.
-      '--demuxer-lavf-o=reconnect=1,reconnect_streamed=1,reconnect_on_network_error=1,reconnect_on_http_error=%7%4xx,5xx,reconnect_delay_max=5',
+      // Buffering / reconnect tuning shared with the libmpv addons (see module).
+      ...MPV_STREAM_OPTIONS.map(([name, value]) => `--${name}=${value}`),
       `--input-ipc-server=${this.sockPath}`,
     ];
     console.log('[mpv] spawn:', this.mpvPath, args.join(' '));
     this.proc = spawn(this.mpvPath, args, { stdio: ['ignore', 'pipe', 'pipe'], env: this.env });
-    this.proc.on('exit', (code) => {
-      this.emit('stateChanged', { state: 'idle' });
-      this.emit('exit', { code });
+    this.proc.on('exit', (code, signal) => {
+      this.emit('exit', { code, signal });
       this.rejectAllPending('mpv process exited');
+      if (this.shuttingDown) {
+        this.emit('stateChanged', { state: 'idle' });
+      } else {
+        // Under --idle/--keep-open the process is persistent, so an exit we
+        // didn't ask for is a crash (segfault / OOM-kill). Surface it as an
+        // error with the buffered cause, not a benign idle.
+        this.emit('error', {
+          code: code ?? -1,
+          message: `mpv exited unexpectedly (code ${code ?? 'null'}${signal ? `, signal ${signal}` : ''})`,
+          detail: this.errorLog.join(' | ') || undefined,
+        });
+      }
     });
     this.proc.stderr?.on('data', (d: Buffer) => this.emit('log', d.toString()));
 
-    await this.connect();
-    await this.setupObservers();
-    // Surface mpv's own log over IPC (ffmpeg HTTP/TLS/decode failures) —
-    // `--no-terminal` suppresses stderr, so this is how we see why a load
-    // failed. Defaults to warn; FLIKS_MPV_LOGLEVEL=v exposes ffmpeg's per-open
-    // 'Will reconnect' / HTTP-status lines for diagnosing segment failures.
-    const logLevel = process.env.FLIKS_MPV_LOGLEVEL || 'warn';
-    await this.command(['request_log_messages', logLevel]).catch(() => {});
+    try {
+      await this.connect();
+      await this.setupObservers();
+      // Surface mpv's own log over IPC (ffmpeg HTTP/TLS/decode failures) —
+      // `--no-terminal` suppresses stderr, so this is how we see why a load
+      // failed. Defaults to verbose (matches the libmpv addons + docs), exposing
+      // ffmpeg's per-open 'Will reconnect' / HTTP-status lines for diagnosing
+      // segment failures; FLIKS_MPV_LOGLEVEL overrides it.
+      const logLevel = process.env.FLIKS_MPV_LOGLEVEL || 'v';
+      await this.command(['request_log_messages', logLevel]).catch(() => {});
+    } catch (e) {
+      // A failed connect/observe leaves the child alive; tear it down so it
+      // can't orphan an embedded window.
+      this.teardown();
+      throw e;
+    }
     return this;
   }
 
@@ -172,10 +206,17 @@ export class MpvPlayer extends EventEmitter {
     return new Promise((resolve, reject) => {
       const sock = net.createConnection(this.sockPath);
       sock.once('connect', () => {
+        // Drop the connect-phase rejecter so the live socket carries only the
+        // permanent error handler installed below.
+        sock.removeListener('error', reject);
         this.sock = sock;
         sock.on('data', (chunk: Buffer) => this.onData(chunk));
         sock.on('error', (e) => {
-          this.emit('error', { code: -1, message: String(e) });
+          this.emit('error', {
+            code: -1,
+            message: String(e),
+            detail: this.errorLog.join(' | ') || undefined,
+          });
           this.rejectAllPending(`mpv socket error: ${e}`);
         });
         sock.on('close', () => {
@@ -195,7 +236,7 @@ export class MpvPlayer extends EventEmitter {
       const line = this.buf.slice(0, nl).trim();
       this.buf = this.buf.slice(nl + 1);
       if (!line) continue;
-      let msg: any;
+      let msg: MpvIpcMessage;
       try {
         msg = JSON.parse(line);
       } catch {
@@ -204,6 +245,7 @@ export class MpvPlayer extends EventEmitter {
       if (msg.request_id != null && this.pending.has(msg.request_id)) {
         const p = this.pending.get(msg.request_id)!;
         this.pending.delete(msg.request_id);
+        clearTimeout(p.timer);
         if (msg.error && msg.error !== 'success') p.reject(new Error(msg.error));
         else p.resolve(msg.data);
       } else if (msg.event) {
@@ -212,16 +254,16 @@ export class MpvPlayer extends EventEmitter {
     }
   }
 
-  private onEvent(msg: any): void {
+  private onEvent(msg: MpvIpcMessage): void {
     switch (msg.event) {
       case 'property-change':
-        this.onProperty(msg.name, msg.data);
+        this.onProperty(msg.name ?? '', msg.data);
         break;
       case 'log-message': {
         const line = `${msg.prefix ? `${msg.prefix}: ` : ''}${msg.text ?? ''}`.trim();
         if (msg.level === 'error' || msg.level === 'fatal') {
           this.errorLog.push(line);
-          if (this.errorLog.length > 12) this.errorLog.shift();
+          if (this.errorLog.length > MAX_ERROR_LOG_LINES) this.errorLog.shift();
         }
         this.emit('log', `[${msg.level}] ${line}`);
         break;
@@ -246,30 +288,52 @@ export class MpvPlayer extends EventEmitter {
     }
   }
 
-  private onProperty(name: string, data: any): void {
+  private onProperty(name: string, data: unknown): void {
     switch (name) {
       case 'time-pos':
+        this.lastPosition = typeof data === 'number' ? data : 0;
         this.emit('timeUpdate', {
-          position: data ?? 0,
+          position: this.lastPosition,
           duration: this.duration,
           buffered: this.cacheEnd,
         } satisfies DesktopPositionInfo);
         break;
       case 'duration':
-        this.duration = data ?? 0;
+        this.duration = typeof data === 'number' ? data : 0;
         break;
       case 'demuxer-cache-time':
         // mpv reports null for this between HLS segments; keep the last value
         // instead of zeroing it, otherwise the seekbar's buffered zone (drawn
         // `@if (bufferedEnd())`) collapses to 0 and flickers on every gap.
-        if (data != null) this.cacheEnd = data;
+        if (typeof data === 'number') this.cacheEnd = data;
         break;
       case 'eof-reached':
-        // With `--keep-open=yes` this is how a natural end surfaces (no
-        // `end-file`(eof)); map it to the `ended` state that drives auto-advance.
+        // mpv sets `eof-reached` at a genuine end (surfaced here since
+        // `--keep-open=yes` suppresses `end-file`(eof)) but ALSO when playback
+        // can't continue: ffmpeg's HLS demuxer reports a segment that failed
+        // past its reconnect budget as EOF, not an error. Discriminate by the
+        // playhead — a real end sits at the duration; a premature stop is short
+        // by more than a segment (or, with an unknown duration, coincides with
+        // buffered errors) — and route the premature case to `error` (with the
+        // buffered cause) so it recovers or shows why, not silently advances.
+        // mpv clears the flag on a backward seek, so reset the one-shot then.
         if (data === true && !this.sawEof) {
           this.sawEof = true;
-          this.emit('stateChanged', { state: 'ended' });
+          const premature =
+            this.duration > 0
+              ? this.duration - this.lastPosition > PREMATURE_EOF_GAP_S
+              : this.errorLog.length > 0;
+          if (premature) {
+            this.emit('error', {
+              code: -1,
+              message: 'playback stopped before end of stream',
+              detail: this.errorLog.join(' | ') || undefined,
+            });
+          } else {
+            this.emit('stateChanged', { state: 'ended' });
+          }
+        } else if (data === false) {
+          this.sawEof = false;
         }
         break;
       case 'pause':
@@ -279,7 +343,7 @@ export class MpvPlayer extends EventEmitter {
         if (data) this.emit('stateChanged', { state: 'buffering' });
         break;
       case 'track-list':
-        this.emit('tracksChanged', this.mapTracks(data ?? []));
+        this.emit('tracksChanged', mapTrackList((data as MpvTrack[]) ?? []));
         break;
       default:
         break;
@@ -302,15 +366,21 @@ export class MpvPlayer extends EventEmitter {
 
   // ── Command transport ──────────────────────────────────────────────────
 
-  private command(command: unknown[]): Promise<any> {
-    return new Promise((resolve, reject) => {
+  private command<T = unknown>(command: unknown[]): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
       if (!this.sock) return reject(new Error('mpv socket not connected'));
       const request_id = ++this.reqId;
-      this.pending.set(request_id, { resolve, reject });
+      const timer = setTimeout(() => {
+        if (this.pending.delete(request_id)) {
+          reject(new Error(`mpv command timed out: ${JSON.stringify(command)}`));
+        }
+      }, COMMAND_TIMEOUT_MS);
+      this.pending.set(request_id, { resolve: resolve as (value: unknown) => void, reject, timer });
       try {
         this.sock.write(JSON.stringify({ command, request_id }) + '\n');
       } catch (e) {
         this.pending.delete(request_id);
+        clearTimeout(timer);
         reject(e instanceof Error ? e : new Error(String(e)));
       }
     });
@@ -319,12 +389,15 @@ export class MpvPlayer extends EventEmitter {
   /** Fail every in-flight command so a socket/process death can't wedge an
    *  awaiting load/seek invoke forever. */
   private rejectAllPending(message: string): void {
-    for (const p of this.pending.values()) p.reject(new Error(message));
+    for (const p of this.pending.values()) {
+      clearTimeout(p.timer);
+      p.reject(new Error(message));
+    }
     this.pending.clear();
   }
 
-  private get(prop: string): Promise<any> {
-    return this.command(['get_property', prop]);
+  private get<T = unknown>(prop: string): Promise<T> {
+    return this.command<T>(['get_property', prop]);
   }
 
   private set(prop: string, value: unknown): Promise<void> {
@@ -338,6 +411,7 @@ export class MpvPlayer extends EventEmitter {
     this.sawEof = false;
     this.duration = 0;
     this.cacheEnd = 0;
+    this.lastPosition = 0;
     this.errorLog = [];
     const gen = ++this.loadGen;
     // Reset the reused player first so the new open's probe can't read atop the
@@ -382,8 +456,12 @@ export class MpvPlayer extends EventEmitter {
       await this.command(['set', 'demuxer-lavf-format', '']).catch(() => {});
     }
     for (const s of opts.subtitles ?? []) {
-      await this.command(['sub-add', s.url, 'auto', s.label ?? '', s.language ?? '']);
       if (gen !== this.loadGen) return;
+      // Best-effort: this runs after the video is playing, so an unreachable
+      // sidecar subtitle must not reject the load.
+      await this.command(['sub-add', s.url, 'auto', s.label ?? '', s.language ?? '']).catch((e) =>
+        this.emit('log', `[warn] sub-add failed ${s.url}: ${e}`),
+      );
     }
   }
 
@@ -398,7 +476,7 @@ export class MpvPlayer extends EventEmitter {
         this.off('error', done);
         resolve();
       };
-      const timer = setTimeout(done, 10_000);
+      const timer = setTimeout(done, FIRST_FRAME_TIMEOUT_MS);
       this.once('firstFrame', done);
       this.once('error', done);
     });
@@ -424,6 +502,7 @@ export class MpvPlayer extends EventEmitter {
     this.sawEof = false;
     this.duration = 0;
     this.cacheEnd = 0;
+    this.lastPosition = 0;
     return this.command(['stop']).then(() => undefined);
   }
 
@@ -440,41 +519,14 @@ export class MpvPlayer extends EventEmitter {
   }
 
   async getPosition(): Promise<DesktopPositionInfo> {
-    return {
-      position: (await this.get('time-pos').catch(() => 0)) ?? 0,
-      duration: (await this.get('duration').catch(() => 0)) ?? 0,
-      buffered: (await this.get('demuxer-cache-time').catch(() => 0)) ?? 0,
-    };
-  }
-
-  private mapTracks(list: MpvTrack[]): {
-    audioTracks: DesktopAudioTrack[];
-    subtitleTracks: DesktopSubtitleTrack[];
-  } {
-    const audioTracks: DesktopAudioTrack[] = [];
-    const subtitleTracks: DesktopSubtitleTrack[] = [];
-    for (const t of list) {
-      if (t.type === 'audio')
-        audioTracks.push({
-          id: String(t.id),
-          language: t.lang ?? '',
-          label: t.title ?? '',
-          selected: !!t.selected,
-        });
-      else if (t.type === 'sub' && !isImageBasedSubtitleCodec(t.codec))
-        subtitleTracks.push({
-          id: String(t.id),
-          language: t.lang ?? '',
-          label: t.title ?? '',
-          forced: !!t.forced,
-          selected: !!t.selected,
-        });
-    }
-    return { audioTracks, subtitleTracks };
+    // The observed properties are the single source of truth (buffered keeps its
+    // last non-null value across HLS gaps); re-reading them live would race that
+    // and report buffered:0 mid-gap.
+    return { position: this.lastPosition, duration: this.duration, buffered: this.cacheEnd };
   }
 
   async getAudioTracks(): Promise<DesktopAudioTrack[]> {
-    return this.mapTracks((await this.get('track-list')) ?? []).audioTracks;
+    return mapTrackList((await this.get<MpvTrack[]>('track-list')) ?? []).audioTracks;
   }
 
   selectAudioTrack(id: string): Promise<void> {
@@ -482,7 +534,7 @@ export class MpvPlayer extends EventEmitter {
   }
 
   async getSubtitleTracks(): Promise<DesktopSubtitleTrack[]> {
-    return this.mapTracks((await this.get('track-list')) ?? []).subtitleTracks;
+    return mapTrackList((await this.get<MpvTrack[]>('track-list')) ?? []).subtitleTracks;
   }
 
   selectSubtitleTrack(id: string | null): Promise<void> {
@@ -501,23 +553,32 @@ export class MpvPlayer extends EventEmitter {
     for (const [name, value] of mpvSubtitleProps(s)) await this.set(name, value);
   }
 
-  async destroy(): Promise<void> {
-    this.loadGen++;
-    try {
-      // mpv may close the socket on quit without replying — cap the wait.
-      await Promise.race([
-        this.command(['quit']),
-        new Promise<void>((resolve) => setTimeout(resolve, 500)),
-      ]);
-    } catch {
-      /* socket may already be gone */
-    }
+  /** Tear down the socket + process + IPC path. Idempotent; also marks the exit
+   *  as intentional so the `exit` handler reports idle, not a crash. */
+  private teardown(): void {
+    this.shuttingDown = true;
     this.sock?.destroy();
+    this.sock = null;
     this.proc?.kill('SIGTERM');
     try {
       if (fs.existsSync(this.sockPath)) fs.unlinkSync(this.sockPath);
     } catch {
-      /* best effort */
+      /* best effort; a Windows named pipe is never a filesystem entry */
     }
+  }
+
+  async destroy(): Promise<void> {
+    this.loadGen++;
+    this.shuttingDown = true;
+    try {
+      // mpv may close the socket on quit without replying — cap the wait.
+      await Promise.race([
+        this.command(['quit']),
+        new Promise<void>((resolve) => setTimeout(resolve, QUIT_GRACE_MS)),
+      ]);
+    } catch {
+      /* socket may already be gone */
+    }
+    this.teardown();
   }
 }

--- a/desktop/src/main/mpv/player-backend.ts
+++ b/desktop/src/main/mpv/player-backend.ts
@@ -1,11 +1,29 @@
-import type { EventEmitter } from 'node:events';
 import type {
   DesktopAudioTrack,
   DesktopLoadOptions,
+  DesktopPlayerState,
   DesktopPositionInfo,
   DesktopSubtitleStyle,
   DesktopSubtitleTrack,
 } from '../../shared/contract';
+import type { TypedEmitter } from './typed-emitter';
+
+/** Events every backend emits; `PlayerSession.forwardEvents` subscribes to each
+ *  and reshapes it onto the `DesktopEvent` IPC channel. A `type` (not an
+ *  interface) so it satisfies {@link TypedEmitter}'s event-map constraint. */
+export type PlayerBackendEvents = {
+  /** A raw mpv log line (already level-prefixed). */
+  log: [message: string];
+  /** The player process/engine terminated. */
+  exit: [info: { code: number | null; signal: NodeJS.Signals | null }];
+  stateChanged: [payload: { state: DesktopPlayerState }];
+  timeUpdate: [payload: DesktopPositionInfo];
+  tracksChanged: [
+    payload: { audioTracks: DesktopAudioTrack[]; subtitleTracks: DesktopSubtitleTrack[] },
+  ];
+  firstFrame: [];
+  error: [payload: { code: number; message: string; detail?: string }];
+};
 
 /**
  * The control surface a platform player must expose to `PlayerSession` /
@@ -13,11 +31,10 @@ import type {
  * Windows) and the in-process libmpv player (`MacMpvPlayer`, macOS) implement
  * it, so the session and the renderer IPC stay OS-agnostic.
  *
- * It extends `EventEmitter` because `PlayerSession.forwardEvents` subscribes to
- * `log`, `exit`, `stateChanged`, `timeUpdate`, `tracksChanged`, `firstFrame` and
- * `error`. `MpvPlayer` already satisfies this unchanged.
+ * It is a {@link TypedEmitter} of {@link PlayerBackendEvents}, so subscribers get
+ * a compile-time-checked event name and payload with no defensive casting.
  */
-export interface PlayerBackend extends EventEmitter {
+export interface PlayerBackend extends TypedEmitter<PlayerBackendEvents> {
   start(): Promise<unknown>;
   load(opts: DesktopLoadOptions): Promise<void>;
   play(): Promise<void>;

--- a/desktop/src/main/mpv/tracks.ts
+++ b/desktop/src/main/mpv/tracks.ts
@@ -1,6 +1,9 @@
 import type { DesktopAudioTrack, DesktopSubtitleTrack } from '../../shared/contract';
 
-interface MpvTrack {
+/** A single entry of mpv's `track-list`. Shared by every backend: the Windows
+ *  subprocess reads it as parsed JSON-IPC data, the libmpv addons via a property
+ *  string. */
+export interface MpvTrack {
   id: number;
   type: string;
   codec?: string;
@@ -25,20 +28,13 @@ export function isImageBasedSubtitleCodec(codec: string | undefined): boolean {
   return IMAGE_BASED_SUBTITLE_CODECS.has(codec ?? '');
 }
 
-/** Parse mpv's `track-list` JSON (as returned by get_property_string) into the
- *  desktop contract's audio/subtitle shapes. Shared by every libmpv backend
- *  that reads tracks via a property string (the Linux compositor and the macOS
- *  in-process player). Tolerates a null/partial value (returns empty lists). */
-export function parseTracks(json: string | null): {
+/** Map an mpv `track-list` array into the desktop contract's audio/subtitle
+ *  shapes. Image-based subtitle codecs are dropped (never selectable tracks).
+ *  The single source of truth for track mapping across all three backends. */
+export function mapTrackList(list: MpvTrack[]): {
   audioTracks: DesktopAudioTrack[];
   subtitleTracks: DesktopSubtitleTrack[];
 } {
-  let list: MpvTrack[] = [];
-  try {
-    list = JSON.parse(json ?? '[]') ?? [];
-  } catch {
-    /* not ready */
-  }
   const audioTracks: DesktopAudioTrack[] = [];
   const subtitleTracks: DesktopSubtitleTrack[] = [];
   for (const t of list) {
@@ -59,4 +55,20 @@ export function parseTracks(json: string | null): {
       });
   }
   return { audioTracks, subtitleTracks };
+}
+
+/** Parse mpv's `track-list` JSON (as returned by get_property_string) and map
+ *  it. Used by the libmpv addons (Linux compositor, macOS in-process) that read
+ *  tracks via a property string. Tolerates a null/partial value (empty lists). */
+export function parseTracks(json: string | null): {
+  audioTracks: DesktopAudioTrack[];
+  subtitleTracks: DesktopSubtitleTrack[];
+} {
+  let list: MpvTrack[] = [];
+  try {
+    list = JSON.parse(json ?? '[]') ?? [];
+  } catch {
+    /* not ready */
+  }
+  return mapTrackList(list);
 }

--- a/desktop/src/main/mpv/typed-emitter.ts
+++ b/desktop/src/main/mpv/typed-emitter.ts
@@ -1,0 +1,25 @@
+import { EventEmitter } from 'node:events';
+
+/** Event map: event name → the tuple of arguments its listeners receive. */
+export type EventArgsMap = Record<string, unknown[]>;
+
+/**
+ * A minimal typed wrapper over Node's `EventEmitter`. `on`/`once`/`off`/`emit`
+ * are constrained to a per-class event map, so both the event name and its
+ * payload are checked at compile time (no string-literal drift, no untyped
+ * payloads on the consumer side).
+ */
+export class TypedEmitter<T extends EventArgsMap> extends EventEmitter {
+  on<K extends keyof T & string>(event: K, listener: (...args: T[K]) => void): this {
+    return super.on(event, listener as (...args: unknown[]) => void);
+  }
+  once<K extends keyof T & string>(event: K, listener: (...args: T[K]) => void): this {
+    return super.once(event, listener as (...args: unknown[]) => void);
+  }
+  off<K extends keyof T & string>(event: K, listener: (...args: T[K]) => void): this {
+    return super.off(event, listener as (...args: unknown[]) => void);
+  }
+  emit<K extends keyof T & string>(event: K, ...args: T[K]): boolean {
+    return super.emit(event, ...args);
+  }
+}

--- a/desktop/src/main/window/player-session.ts
+++ b/desktop/src/main/window/player-session.ts
@@ -23,6 +23,14 @@ function resolveBundledMpv(): string | undefined {
   return fs.existsSync(bundled) ? bundled : undefined;
 }
 
+// A `transparent` window drops macOS out of the WindowServer's opaque fast path
+// and alpha-composites the whole UI every frame, so the app feels sluggish
+// app-wide (not just the player). The UI overlay defaults to OPAQUE (fast); set
+// FLIKS_OPAQUE_UI=0 to restore the transparent overlay that lets the mpv video
+// show through during playback. An opaque overlay hides the video behind it.
+const OPAQUE_UI =
+  process.env.FLIKS_OPAQUE_UI !== '0' && process.env.FLIKS_OPAQUE_UI !== 'false';
+
 export interface PlayerSessionOptions {
   rendererUrl: string;
   preloadPath: string;
@@ -87,8 +95,8 @@ export class PlayerSession {
     this.uiWin = new BrowserWindow({
       ...this.frameWin.getContentBounds(),
       frame: false,
-      transparent: true,
-      backgroundColor: '#00000000',
+      transparent: !OPAQUE_UI,
+      backgroundColor: OPAQUE_UI ? '#000000' : '#00000000',
       hasShadow: false,
       // Electron warns that resizing a transparent window can break its
       // transparency on some platforms; the overlay is re-fitted via setBounds

--- a/desktop/src/main/window/player-session.ts
+++ b/desktop/src/main/window/player-session.ts
@@ -200,9 +200,8 @@ export class PlayerSession {
     mpv.on('log', (s: string) => process.stderr.write(`[${Date.now()}][mpv] ${s}`));
     mpv.on('exit', (e) => console.error('[mpv] process exit', JSON.stringify(e)));
     mpv.on('stateChanged', (p) => {
-      const state = (p as { state?: string }).state;
-      console.log('[player] state:', state);
-      setPlaybackKeepAwake(keepAwakeForState(state));
+      console.log('[player] state:', p.state);
+      setPlaybackKeepAwake(keepAwakeForState(p.state));
       this.emit({ type: 'stateChanged', payload: p });
     });
     mpv.on('timeUpdate', (p) => this.emit({ type: 'timeUpdate', payload: p }));

--- a/desktop/src/main/window/player-session.ts
+++ b/desktop/src/main/window/player-session.ts
@@ -23,14 +23,6 @@ function resolveBundledMpv(): string | undefined {
   return fs.existsSync(bundled) ? bundled : undefined;
 }
 
-// A `transparent` window drops macOS out of the WindowServer's opaque fast path
-// and alpha-composites the whole UI every frame, so the app feels sluggish
-// app-wide (not just the player). The UI overlay defaults to OPAQUE (fast); set
-// FLIKS_OPAQUE_UI=0 to restore the transparent overlay that lets the mpv video
-// show through during playback. An opaque overlay hides the video behind it.
-const OPAQUE_UI =
-  process.env.FLIKS_OPAQUE_UI !== '0' && process.env.FLIKS_OPAQUE_UI !== 'false';
-
 export interface PlayerSessionOptions {
   rendererUrl: string;
   preloadPath: string;
@@ -95,8 +87,8 @@ export class PlayerSession {
     this.uiWin = new BrowserWindow({
       ...this.frameWin.getContentBounds(),
       frame: false,
-      transparent: !OPAQUE_UI,
-      backgroundColor: OPAQUE_UI ? '#000000' : '#00000000',
+      transparent: true,
+      backgroundColor: '#00000000',
       hasShadow: false,
       // Electron warns that resizing a transparent window can break its
       // transparency on some platforms; the overlay is re-fitted via setBounds

--- a/desktop/src/shared/mpv-stream-options.ts
+++ b/desktop/src/shared/mpv-stream-options.ts
@@ -1,0 +1,32 @@
+// Streaming / buffering / reconnect mpv options shared by every backend so the
+// buffering + resume behaviour can't drift per platform. Single source of truth:
+//   • Windows subprocess (mpv-player.ts) maps each to a `--name=value` CLI arg.
+//   • Linux compositor (index.ts) + macOS in-process player (mac-mpv-player.ts)
+//     apply each via the addon's `setProperty` right after start (all seven are
+//     runtime-mutable and set before the first load, so this matches the addons'
+//     former pre-init set_option_string exactly).
+//
+// Rationale for the tuning:
+//   • Buffer like the web (Shaka) engine: ~30s forward (cache-secs is the binding
+//     forward TIME cap — with cache=yes it otherwise defaults to ~unlimited and
+//     overrides readahead-secs; the byte caps are a ceiling), ~96s back.
+//   • Reconnect on failure: a slow transcode (HDR tonemap re-encode) isn't ready
+//     when mpv opens seg-0/init, and a separate multi-audio rendition's transcode
+//     can fail at the TRANSPORT layer (reset / refused / TLS) rather than with a
+//     4xx/5xx status — so reconnect_on_network_error is needed alongside
+//     reconnect_on_http_error. The `4xx,5xx` value carries a comma, so it uses
+//     mpv's `%len%` escaping (7 = strlen("4xx,5xx")) to survive the key-value-list
+//     parser.
+
+export const MPV_STREAM_OPTIONS: readonly (readonly [name: string, value: string])[] = [
+  ['cache', 'yes'],
+  ['cache-secs', '30'],
+  ['demuxer-readahead-secs', '30'],
+  ['demuxer-max-bytes', '256MiB'],
+  ['demuxer-max-back-bytes', '96MiB'],
+  ['cache-pause-wait', '1'],
+  [
+    'demuxer-lavf-o',
+    'reconnect=1,reconnect_streamed=1,reconnect_on_network_error=1,reconnect_on_http_error=%7%4xx,5xx,reconnect_delay_max=5',
+  ],
+];


### PR DESCRIPTION
## Playback error → no more auto-skip (the prod bug)

On the Windows desktop client, a mid-stream failure was skipping to the next episode and hiding the cause. mpv runs with `--keep-open=yes`, so ffmpeg surfaces a dead HLS segment (reconnect budget exhausted) as `eof-reached`, indistinguishable from a real end — and that was mapped straight to `ended`.

- Discriminate a premature EOF by the playhead and route it to `error` (with the buffered log detail) so the player recovers or shows why, instead of advancing.
- Gate the client auto-advance effect on `!error()` as a cross-engine safety net.

## mpv backend rework (quality-audit follow-up)

- De-duplicate mpv track mapping into `tracks.ts` (three copies existed; the Linux copy had dropped the image-based-subtitle filter, so PGS/VOBSUB showed as selectable subtitle tracks — a real latent bug, now fixed).
- Single source of truth for the streaming/reconnect options (`mpv-stream-options.ts`), applied to every backend instead of three drifting literal copies.
- Surface an unexpected mpv exit as an error, not a silent idle.
- Best-effort in-load `sub-add` so an unreachable sidecar can't fail a playing load; guard the loop against a stale load generation.
- Tear the child down on a failed start so it can't orphan an embedded window.
- Per-command timeout so a wedged mpv can't hang a load/seek forever.
- Typed event emitter + IPC messages, named magic literals, cached `getPosition()` triplet.

## macOS responsiveness

- Optimistic pause state on toggle (the mpv round-trip lagged the button ~1s).
- Restore the cursor after the controls hide (transparent image cursor instead of `cursor: none`, which stuck via NSCursor hide on macOS).

A separate app-wide macOS sluggishness was probed with an opaque-UI experiment that was added and reverted here — that lag is not transparent-window compositing and is tracked separately.

## Validation

Desktop `tsc` green, Linux compositor addon rebuilt, CI green on all three OSes. On-device Windows/macOS validation still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)