### PR TITLE
feat(player): rework volume control and add chromecast volume

### DIFF
--- a/client/android/app/src/main/java/media/fliks/app/CastPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/CastPlugin.java
@@ -164,10 +164,12 @@ public class CastPlugin extends Plugin {
         );
     }
 
-    private void notifyJSTime(double time, double duration, boolean paused, boolean buffering) {
+    private void notifyJSTime(double time, double duration, boolean paused, boolean buffering,
+                             double volume, boolean muted) {
         String js = "window.dispatchEvent(new CustomEvent('castMediaUpdate', { detail: { "
             + "currentTime: " + time + ", duration: " + duration + ", isPaused: " + paused
-            + ", buffering: " + buffering + " } }));";
+            + ", buffering: " + buffering + ", volume: " + volume + ", muted: " + muted
+            + " } }));";
         getBridge().getWebView().post(() ->
             getBridge().getWebView().evaluateJavascript(js, null)
         );
@@ -484,6 +486,37 @@ public class CastPlugin extends Plugin {
     }
 
     @PluginMethod()
+    public void setVolume(PluginCall call) {
+        runOnMainThread(() -> {
+            double level = call.getDouble("level", 1.0);
+            level = Math.max(0.0, Math.min(1.0, level));
+            if (castSession != null && castSession.isConnected()) {
+                try {
+                    castSession.setVolume(level);
+                } catch (Exception e) {
+                    Log.w(TAG, "setVolume failed", e);
+                }
+            }
+            call.resolve();
+        });
+    }
+
+    @PluginMethod()
+    public void setMuted(PluginCall call) {
+        runOnMainThread(() -> {
+            boolean muted = call.getBoolean("muted", false);
+            if (castSession != null && castSession.isConnected()) {
+                try {
+                    castSession.setMute(muted);
+                } catch (Exception e) {
+                    Log.w(TAG, "setMute failed", e);
+                }
+            }
+            call.resolve();
+        });
+    }
+
+    @PluginMethod()
     public void disconnect(PluginCall call) {
         runOnMainThread(() -> {
             if (sessionManager != null) {
@@ -645,7 +678,12 @@ public class CastPlugin extends Plugin {
                         boolean buffering = state == MediaStatus.PLAYER_STATE_BUFFERING
                             || state == MediaStatus.PLAYER_STATE_LOADING;
                         if (time > 0) lastGoodPosition = time;
-                        notifyJSTime(time, duration, paused, buffering);
+                        // Device (receiver) volume isn't part of MediaStatus — read it
+                        // off the session each tick so external changes (TV remote, cast
+                        // dialog) mirror back into the sender slider within a poll.
+                        double volume = castSession.getVolume();
+                        boolean muted = castSession.isMute();
+                        notifyJSTime(time, duration, paused, buffering, volume, muted);
                     }
                     pollHandler.postDelayed(this, 1000);
                 } catch (Exception e) {

--- a/client/ios/App/App/CastPlugin.swift
+++ b/client/ios/App/App/CastPlugin.swift
@@ -18,6 +18,8 @@ public class CastPlugin: CAPPlugin, CAPBridgedPlugin, GCKSessionManagerListener,
         CAPPluginMethod(name: "stop", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "disconnect", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setActiveSubtitle", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setVolume", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setMuted", returnType: CAPPluginReturnPromise),
     ]
 
     private var sessionManager: GCKSessionManager?
@@ -240,6 +242,22 @@ public class CastPlugin: CAPPlugin, CAPBridgedPlugin, GCKSessionManagerListener,
         }
     }
 
+    @objc func setVolume(_ call: CAPPluginCall) {
+        DispatchQueue.main.async { [weak self] in
+            let level = Float(call.getDouble("level") ?? 1.0)
+            self?.currentSession?.setDeviceVolume(max(0, min(1, level)))
+            call.resolve()
+        }
+    }
+
+    @objc func setMuted(_ call: CAPPluginCall) {
+        DispatchQueue.main.async { [weak self] in
+            let muted = call.getBool("muted") ?? false
+            self?.currentSession?.setDeviceMuted(muted)
+            call.resolve()
+        }
+    }
+
     @objc func setActiveSubtitle(_ call: CAPPluginCall) {
         DispatchQueue.main.async { [weak self] in
             let trackId = call.getInt("trackId") ?? 0
@@ -333,8 +351,12 @@ public class CastPlugin: CAPPlugin, CAPBridgedPlugin, GCKSessionManagerListener,
         let time = client.approximateStreamPosition()
         let duration = status.mediaInformation?.streamDuration ?? 0
         let paused = status.playerState == .paused
+        // Device (receiver) volume lives on the session, not media status —
+        // read it each tick so external changes mirror back into the slider.
+        let volume = currentSession?.currentDeviceVolume ?? 1
+        let muted = currentSession?.currentDeviceMuted ?? false
 
-        emitMediaUpdate(time: time, duration: duration, paused: paused)
+        emitMediaUpdate(time: time, duration: duration, paused: paused, volume: volume, muted: muted)
     }
 
     // MARK: - Helpers
@@ -357,8 +379,8 @@ public class CastPlugin: CAPPlugin, CAPBridgedPlugin, GCKSessionManagerListener,
         }
     }
 
-    private func emitMediaUpdate(time: TimeInterval, duration: TimeInterval, paused: Bool) {
-        let js = "window.dispatchEvent(new CustomEvent('castMediaUpdate', { detail: { currentTime: \(time), duration: \(duration), isPaused: \(paused) } }));"
+    private func emitMediaUpdate(time: TimeInterval, duration: TimeInterval, paused: Bool, volume: Float, muted: Bool) {
+        let js = "window.dispatchEvent(new CustomEvent('castMediaUpdate', { detail: { currentTime: \(time), duration: \(duration), isPaused: \(paused), volume: \(volume), muted: \(muted) } }));"
         DispatchQueue.main.async { [weak self] in
             self?.bridge?.webView?.evaluateJavaScript(js)
         }

--- a/client/src/app/core/services/cast.service.ts
+++ b/client/src/app/core/services/cast.service.ts
@@ -88,6 +88,10 @@ interface NativeCastPlugin {
   disconnect(): Promise<void>;
   setActiveSubtitle(opts: { trackId: number }): Promise<void>;
   setActiveAudioLanguage(opts: { language: string; name: string }): Promise<{ success: boolean }>;
+  /** Set the Cast device output level (0..1) / mute. Drives the receiver
+   *  volume, not the phone's — the OS volume keys already do the latter. */
+  setVolume(opts: { level: number }): Promise<void>;
+  setMuted(opts: { muted: boolean }): Promise<void>;
 }
 
 const NativeCast = registerPlugin<NativeCastPlugin>('NativeCast');
@@ -115,6 +119,10 @@ export class CastService implements OnDestroy {
   readonly currentTime = signal(0);
   readonly duration = signal(0);
   readonly isPaused = signal(true);
+  /** Receiver (Cast device) output level 0..1 and mute flag, mirrored from the
+   *  RemotePlayer (web) / native plugin poll. Drives the cast volume slider. */
+  readonly volume = signal(1);
+  readonly muted = signal(false);
   /** Receiver is loading/buffering (not yet playing) — drives the
    *  indeterminate seekbar sweep in the cast overlay. */
   readonly buffering = signal(false);
@@ -192,6 +200,10 @@ export class CastService implements OnDestroy {
         this.duration.set(e.detail?.duration ?? 0);
         this.isPaused.set(e.detail?.isPaused ?? true);
         this.buffering.set(e.detail?.buffering ?? false);
+        // Volume fields are optional — older native builds omit them; skip
+        // the mirror rather than snapping the slider to a default.
+        if (e.detail?.volume != null) this.volume.set(e.detail.volume);
+        if (e.detail?.muted != null) this.muted.set(e.detail.muted);
       }) as EventListener);
 
       // The plugin maps the receiver's IDLE/ERROR state to this event —
@@ -261,6 +273,14 @@ export class CastService implements OnDestroy {
               chrome.cast.media.PlayerState.BUFFERING,
           ),
       );
+      this.remotePlayerController.addEventListener(
+        cast.framework.RemotePlayerEventType.VOLUME_LEVEL_CHANGED,
+        () => this.volume.set(this.remotePlayer.volumeLevel ?? 1),
+      );
+      this.remotePlayerController.addEventListener(
+        cast.framework.RemotePlayerEventType.IS_MUTED_CHANGED,
+        () => this.muted.set(this.remotePlayer.isMuted ?? false),
+      );
       this.isAvailable.set(true);
     } catch {
       this.isAvailable.set(false);
@@ -275,6 +295,10 @@ export class CastService implements OnDestroy {
     this.session = connected
       ? cast.framework.CastContext.getInstance().getCurrentSession()
       : null;
+    if (connected && this.remotePlayer) {
+      this.volume.set(this.remotePlayer.volumeLevel ?? 1);
+      this.muted.set(this.remotePlayer.isMuted ?? false);
+    }
     if (this.session) {
       this.attachReceiverMessageListener(this.session);
     } else {
@@ -470,6 +494,40 @@ export class CastService implements OnDestroy {
     if (!this.remotePlayerController) return;
     this.isPaused.set(!this.isPaused());
     this.remotePlayerController.playOrPause();
+  }
+
+  /** Set the receiver output level (0..1). Dragging the slider up lifts a mute,
+   *  mirroring the local player. Signals are set optimistically so the slider
+   *  is responsive; the receiver echo (web event / native poll) confirms. */
+  setVolume(level: number) {
+    const v = Math.min(1, Math.max(0, level));
+    this.volume.set(v);
+    if (v > 0 && this.muted()) this.setMuted(false);
+    if (this.isNative) { NativeCast.setVolume({ level: v }).catch(() => {}); return; }
+    if (!this.remotePlayer || !this.remotePlayerController) return;
+    this.remotePlayer.volumeLevel = v;
+    this.remotePlayerController.setVolumeLevel();
+  }
+
+  setMuted(muted: boolean) {
+    this.muted.set(muted);
+    if (this.isNative) { NativeCast.setMuted({ muted }).catch(() => {}); return; }
+    if (!this.remotePlayer || !this.remotePlayerController) return;
+    // muteOrUnmute() toggles receiver-side, so only fire it when the receiver's
+    // current state differs from the target — avoids a double-toggle no-op.
+    if ((this.remotePlayer.isMuted ?? false) !== muted) {
+      this.remotePlayerController.muteOrUnmute();
+    }
+  }
+
+  toggleMute() {
+    // Toggle audible/silent (mirrors the local player): when already silent —
+    // muted or level at 0 — restore sound and bump a zero level to full so the
+    // button never sticks on mute.
+    const silent = this.muted() || this.volume() === 0;
+    if (!silent) { this.setMuted(true); return; }
+    this.setMuted(false);
+    if (this.volume() === 0) this.setVolume(1);
   }
 
   seek(time: number) {

--- a/client/src/app/core/services/playback-engine/desktop-engine.ts
+++ b/client/src/app/core/services/playback-engine/desktop-engine.ts
@@ -162,6 +162,7 @@ export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEng
   set volume(v: number) {
     this._volume = v;
     this.bridge.setVolume(Math.round(v * 100)).catch(() => {});
+    this.emit('volumechange', { volume: this._volume, muted: this._muted });
   }
   get muted(): boolean {
     return this._muted;
@@ -169,6 +170,7 @@ export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEng
   set muted(m: boolean) {
     this._muted = m;
     this.bridge.setMuted(m).catch(() => {});
+    this.emit('volumechange', { volume: this._volume, muted: this._muted });
   }
 
   // ── Audio tracks ──

--- a/client/src/app/core/services/playback-engine/native-engine.ts
+++ b/client/src/app/core/services/playback-engine/native-engine.ts
@@ -222,9 +222,15 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
   // ShakaEngine, but they don't reach the native player — the host OS
   // is the source of truth for output level.
   get volume(): number { return this._volume; }
-  set volume(v: number) { this._volume = v; }
+  set volume(v: number) {
+    this._volume = v;
+    this.emit('volumechange', { volume: this._volume, muted: this._muted });
+  }
   get muted(): boolean { return this._muted; }
-  set muted(m: boolean) { this._muted = m; }
+  set muted(m: boolean) {
+    this._muted = m;
+    this.emit('volumechange', { volume: this._volume, muted: this._muted });
+  }
 
   // ── Audio tracks ──
 

--- a/client/src/app/core/services/playback-engine/playback-engine.ts
+++ b/client/src/app/core/services/playback-engine/playback-engine.ts
@@ -63,6 +63,12 @@ export type EngineEventMap = {
     variant?: string;
   };
   audioTracksChanged: { tracks: AudioTrack[] };
+  /** Output level or mute state changed on the engine. Every engine emits this
+   *  as the single source of truth for the UI volume slider — the video-element
+   *  engines (Shaka/webOS) bridge the DOM `volumechange`, the rest emit it from
+   *  their volume/muted setters. `volume` is the raw level (0..1), independent
+   *  of `muted`, so a mute never loses the retained level. */
+  volumechange: { volume: number; muted: boolean };
   ended: void;
   /** Fires when the first video frame is presented to the screen.
    *  Distinct from `stateChanged: 'playing'` which fires on play() (the

--- a/client/src/app/core/services/playback-engine/shaka-engine.ts
+++ b/client/src/app/core/services/playback-engine/shaka-engine.ts
@@ -451,6 +451,11 @@ export class ShakaEngine extends AbstractPlaybackEngine implements PlaybackEngin
       this.emit('ended', undefined as any);
     });
 
+    // Output level / mute — the single mirror back to the UI slider.
+    this.addVideoListener('volumechange', () => {
+      this.emit('volumechange', { volume: video.volume, muted: video.muted });
+    });
+
     // Video element errors
     this.addVideoListener('error', () => {
       const e = video.error;

--- a/client/src/app/core/services/playback-engine/tizen-engine.ts
+++ b/client/src/app/core/services/playback-engine/tizen-engine.ts
@@ -457,11 +457,13 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
   set volume(v: number) {
     this._volume = v;
     /* AVPlay uses system volume; no per-stream knob. */
+    this.emit('volumechange', { volume: this._volume, muted: this._muted });
   }
   get muted(): boolean { return this._muted; }
   set muted(m: boolean) {
     this._muted = m;
     /* No web-level mute API on AVPlay; rely on TV remote / system. */
+    this.emit('volumechange', { volume: this._volume, muted: this._muted });
   }
 
   // ── Audio tracks ────────────────────────────────────────────────────

--- a/client/src/app/core/services/playback-engine/webos-engine.ts
+++ b/client/src/app/core/services/playback-engine/webos-engine.ts
@@ -143,6 +143,9 @@ export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngin
       this.emit('stateChanged', { state: 'ended' });
       this.emit('ended', undefined);
     });
+    add('volumechange', () => {
+      this.emit('volumechange', { volume: v.volume, muted: v.muted });
+    });
     add('error', () => {
       if (this.loadingPhase) return; // recovered via the load() fallback
       const err = v.error;

--- a/client/src/app/core/services/player-state.service.ts
+++ b/client/src/app/core/services/player-state.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, inject, signal } from '@angular/core';
+import { Injectable, effect, inject, signal } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import type { PlaybackEngine } from './playback-engine/playback-engine';
 import {
@@ -7,6 +7,9 @@ import {
   userMessageKeyFor,
   type PlaybackError,
 } from './playback-engine/playback-error';
+
+/** localStorage key for the persisted output level (a bare 0..1 number). */
+const VOLUME_KEY = 'player.volume';
 
 /**
  * Shared playback state signals that any UI component can read.
@@ -27,7 +30,13 @@ export class PlayerStateService {
   readonly paused = signal(true);
   readonly currentTime = signal(0);
   readonly duration = signal(0);
-  readonly volume = signal(1);
+  /** Raw output level (0..1), independent of {@link muted}. Mirrors the engine
+   *  and is restored from localStorage on startup. Kept even while muted so
+   *  unmuting recovers the exact level. */
+  readonly volume = signal(this.loadVolume());
+  /** Mute flag, mirrored from the engine. Intentionally NOT persisted — a new
+   *  session starts unmuted so the player never opens on an unexplained silence. */
+  readonly muted = signal(false);
   readonly playbackRate = signal(1);
   readonly buffering = signal(false);
   readonly bufferedEnd = signal(0);
@@ -70,6 +79,28 @@ export class PlayerStateService {
    *  always reflected. Registered once by PlayerComponent. */
   private dolbyVisionProbe: (() => boolean) | null = null;
 
+  constructor() {
+    // Persist the level (not the mute flag) whenever it changes, so it carries
+    // across reloads and navigations.
+    effect(() => {
+      const v = this.volume();
+      try {
+        localStorage.setItem(VOLUME_KEY, String(v));
+      } catch { /* storage unavailable (private mode) — volume stays session-only */ }
+    });
+  }
+
+  private loadVolume(): number {
+    try {
+      const raw = localStorage.getItem(VOLUME_KEY);
+      if (raw != null) {
+        const v = parseFloat(raw);
+        if (isFinite(v)) return Math.min(1, Math.max(0, v));
+      }
+    } catch { /* ignore */ }
+    return 1;
+  }
+
   setRecovering(value: boolean): void {
     this.recovering = value;
     if (value) this.error.set(null);
@@ -98,6 +129,18 @@ export class PlayerStateService {
   /** Bind a playback engine's events to our signals. Call this when the engine changes. */
   bindEngine(engine: PlaybackEngine): void {
     this.engine = engine;
+
+    engine.on('volumechange', (e) => {
+      this.volume.set(e.volume);
+      this.muted.set(e.muted);
+    });
+
+    // Push the current level/mute onto the freshly-created engine so a new
+    // <video> (or mpv instance) plays at the value the slider already shows,
+    // instead of its own default — otherwise a re-created engine desyncs the
+    // audio from the UI until the user next touches the slider.
+    engine.volume = this.volume();
+    engine.muted = this.muted();
 
     engine.on('stateChanged', (e) => {
       this.paused.set(e.state === 'paused' || e.state === 'idle');

--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -37,11 +37,11 @@
         [min]="0"
         [max]="1"
         [step]="0.05"
-        [value]="volume()"
+        [value]="displayVolume()"
         (input)="onVolumeChange($event)"
       />
       <button type="button" class="btn btn-ghost btn-md btn-circle text-white" [attr.aria-label]="'player.volume' | translate" (click)="toggleMute.emit()">
-        @if (volume() === 0) {
+        @if (muted() || volume() === 0) {
           <!-- lucide:volume-x -->
           <svg lucideVolumeX class="h-6 w-6"></svg>
         } @else {

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -209,6 +209,10 @@ export class PlayerControlsComponent {
   readonly duration = input(0);
   readonly bufferedEnd = input(0);
   readonly volume = input(1);
+  readonly muted = input(false);
+  /** Effective slider position: drops to 0 while muted, so the thumb reflects
+   *  what's actually audible; the retained level returns on unmute. */
+  readonly displayVolume = computed(() => (this.muted() ? 0 : this.volume()));
   readonly playbackRate = input(1);
   readonly mediaTitle = input('');
   /** Clearlogo shown in place of the title text in the top-left overlay. */

--- a/client/src/app/features/player/player.html
+++ b/client/src/app/features/player/player.html
@@ -116,6 +116,7 @@
     [duration]="duration()"
     [bufferedEnd]="bufferedEnd()"
     [volume]="volume()"
+    [muted]="muted()"
     [playbackRate]="playbackRate()"
     [mediaTitle]="mediaTitle()"
     [logoUrl]="mediaLogoUrl()"

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -334,6 +334,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   readonly currentTime = this.state.currentTime;
   readonly duration = this.state.duration;
   readonly volume = this.state.volume;
+  readonly muted = this.state.muted;
   readonly buffering = this.state.buffering;
   readonly bufferedEnd = this.state.bufferedEnd;
   readonly playbackMode = this.state.playbackMode;
@@ -1486,7 +1487,6 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     const video = this.videoEl()?.nativeElement;
     if (video) {
       video.removeEventListener('seeked', this.onSeeked);
-      video.removeEventListener('volumechange', this.onVideoVolumeChange);
     }
     this.spriteAbort?.abort();
     if (this.saveInterval) clearInterval(this.saveInterval);
@@ -1528,8 +1528,6 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       this.state.videoStarted.set(true);
     });
     this.wireSessionExpiredRecovery(engine);
-    // Volume sync for template
-    video.addEventListener('volumechange', this.onVideoVolumeChange);
   }
 
   private async createWebOsEngine(): Promise<void> {
@@ -1547,7 +1545,6 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       this.state.videoStarted.set(true);
     });
     this.wireSessionExpiredRecovery(engine);
-    video.addEventListener('volumechange', this.onVideoVolumeChange);
   }
 
   private async createTizenEngine(): Promise<void> {
@@ -2526,13 +2523,25 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
   onVolumeChange(vol: number) {
     if (!this.engine) return;
+    // Dragging the slider sets the level and lifts a mute — the state signals
+    // update via the engine's `volumechange` event, keeping the display in
+    // lockstep with the real output on every engine.
     this.engine.volume = vol;
-    this.engine.muted = vol === 0;
+    if (vol > 0 && this.engine.muted) this.engine.muted = false;
   }
 
   onToggleMute() {
     if (!this.engine) return;
-    this.engine.muted = !this.engine.muted;
+    // Toggle audible/silent, not the raw mute flag: when already silent —
+    // either muted or the level dragged to 0 — a click restores sound, bumping
+    // a zero level back to full so the button never appears stuck on mute.
+    const silent = this.engine.muted || this.engine.volume === 0;
+    if (silent) {
+      this.engine.muted = false;
+      if (this.engine.volume === 0) this.engine.volume = 1;
+    } else {
+      this.engine.muted = true;
+    }
   }
 
   onToggleFullscreen() {
@@ -3488,10 +3497,6 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   private onSeeked = () => {
     this.resetStallWatchdog();
     this.savePosition();
-  };
-  private onVideoVolumeChange = () => {
-    const v = this.videoEl()?.nativeElement;
-    if (v) this.state.volume.set(v.muted ? 0 : v.volume);
   };
   private spriteAbort?: AbortController;
 

--- a/client/src/app/features/player/remote/cast-remote.html
+++ b/client/src/app/features/player/remote/cast-remote.html
@@ -128,6 +128,27 @@
       </button>
     </div>
 
+    <!-- Volume -->
+    <div class="flex items-center justify-center gap-2 mt-3 landscape:mt-1">
+      <button type="button" class="btn btn-ghost btn-sm btn-circle text-white" [attr.aria-label]="'player.volume' | translate" (click)="cast.toggleMute()">
+        @if (cast.muted() || cast.volume() === 0) {
+          <svg lucideVolumeX class="h-5 w-5"></svg>
+        } @else {
+          <svg lucideVolume2 class="h-5 w-5"></svg>
+        }
+      </button>
+      <input
+        type="range"
+        class="range range-xs w-40 max-w-[50vw]"
+        [attr.aria-label]="'player.volume' | translate"
+        [min]="0"
+        [max]="1"
+        [step]="0.05"
+        [value]="cast.muted() ? 0 : cast.volume()"
+        (input)="cast.setVolume(+$any($event.target).value)"
+      />
+    </div>
+
     <!-- Stop Cast -->
     <div class="flex justify-center mt-3 landscape:mt-1">
       <button class="btn btn-ghost btn-sm text-white/50 gap-2" (click)="disconnect.emit()">

--- a/client/src/app/features/player/remote/cast-remote.ts
+++ b/client/src/app/features/player/remote/cast-remote.ts
@@ -22,6 +22,8 @@ import {
   LucideRotateCw,
   LucideSettings,
   LucideSquare,
+  LucideVolume2,
+  LucideVolumeX,
 } from '@lucide/angular';
 
 export interface CastSubtitleOption {
@@ -49,7 +51,7 @@ export interface CastQualityOption {
   imports: [
     LucideCaptions, LucideCast, LucideCheck, LucideChevronLeft,
     LucideHeadphones, LucidePause, LucidePlay, LucideRotateCcw, LucideRotateCw,
-    LucideSettings, LucideSquare,
+    LucideSettings, LucideSquare, LucideVolume2, LucideVolumeX,
     TranslateModule,
     DropdownMenuComponent,
   ],

--- a/client/src/app/shared/cast-overlay/cast-overlay.html
+++ b/client/src/app/shared/cast-overlay/cast-overlay.html
@@ -73,6 +73,27 @@
             </button>
           </div>
 
+          <!-- Volume -->
+          <div class="flex items-center justify-center gap-2">
+            <button class="btn btn-ghost btn-sm btn-circle" [attr.aria-label]="'player.volume' | translate" (click)="cast.toggleMute()">
+              @if (cast.muted() || cast.volume() === 0) {
+                <svg lucideVolumeX class="h-5 w-5"></svg>
+              } @else {
+                <svg lucideVolume2 class="h-5 w-5"></svg>
+              }
+            </button>
+            <input
+              type="range"
+              class="range range-xs flex-1 max-w-56"
+              [attr.aria-label]="'player.volume' | translate"
+              [min]="0"
+              [max]="1"
+              [step]="0.05"
+              [value]="cast.muted() ? 0 : cast.volume()"
+              (input)="cast.setVolume(+$any($event.target).value)"
+            />
+          </div>
+
           <!-- Pickers -->
           <div class="flex items-center justify-center gap-3 lg:gap-2 flex-wrap">
             @if (cp.availableSubtitles().length) {

--- a/client/src/app/shared/cast-overlay/cast-overlay.ts
+++ b/client/src/app/shared/cast-overlay/cast-overlay.ts
@@ -4,6 +4,7 @@ import { CastService } from '../../core/services/cast.service';
 import { CastPlayerService } from '../../core/services/cast-player.service';
 import { SeekbarComponent } from '../components/seekbar/seekbar';
 import { DropdownMenuComponent } from '../components/dropdown-menu';
+import { TranslateModule } from '@ngx-translate/core';
 import {
   LucideCaptions,
   LucideCast,
@@ -15,6 +16,8 @@ import {
   LucideRotateCw,
   LucideSettings,
   LucideSquare,
+  LucideVolume2,
+  LucideVolumeX,
   LucideX,
 } from '@lucide/angular';
 
@@ -23,9 +26,10 @@ import {
   imports: [
     LucideCaptions, LucideCast, LucideCheck,
     LucideHeadphones, LucidePause, LucidePlay, LucideRotateCcw, LucideRotateCw,
-    LucideSettings, LucideSquare, LucideX,
+    LucideSettings, LucideSquare, LucideVolume2, LucideVolumeX, LucideX,
     SeekbarComponent,
     DropdownMenuComponent,
+    TranslateModule,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './cast-overlay.html',


### PR DESCRIPTION
## Why

The displayed volume could drift from the real output. `state.volume` was mirrored back only through a DOM `volumechange` listener wired in **2 of the 5 engine factories** (Shaka/webOS), so:

- **Desktop/mpv**: the slider was shown but stuck at its default — never resynced with mpv.
- **Shaka**: on every engine (re)creation the new `<video>` starts at 1 while the carried-over signal held the old value → **audio at 100% while the slider showed 30%** (player re-open, quality/recovery reload, cast resume).
- Mute was conflated with `volume === 0` (no distinct flag), there was no persistence, and Chromecast had **no volume control at all**.

## What changed

**Local player**
- New unified `volumechange: { volume, muted }` engine event emitted by **every** engine (Shaka/webOS bridge the DOM event inside the engine; desktop/native/tizen emit from their setters). Removes the fragile per-factory listener.
- `PlayerStateService` keeps separate `volume` and `muted` signals, subscribes to the event, and **re-applies the current level/mute onto each freshly-bound engine** so a new `<video>`/mpv instance can't desync. The level is persisted to `localStorage`; mute resets each session.
- Slider drops to 0 when muted; icon reflects `muted || volume === 0`.
- The mute button toggles audible/silent and **restores a zero level back to full** instead of appearing stuck on mute.

**Chromecast (new)** — controls the receiver/device volume, not the phone:
- `CastService`: `volume`/`muted` signals + `setVolume`/`setMuted`/`toggleMute`. Web via `RemotePlayerController.setVolumeLevel()` / `muteOrUnmute()` + `VOLUME_LEVEL_CHANGED` / `IS_MUTED_CHANGED` listeners. Native via new `NativeCast.setVolume`/`setMuted` (Android `CastSession`, iOS `GCKCastSession`) with volume/mute added to the 1 Hz media poll.
- Volume slider + mute button added to the cast remote and the mini overlay.

## Testing

`ng build` passes. Needs on-device validation: desktop/mpv slider, native Cast volume (Android/iOS require a native build), and that Shaka re-open/quality/recovery no longer desyncs the level.
