### PR TITLE
fix(cast): coalesce rapid seek bursts into one settled dispatch

### DIFF
--- a/client/src/app/core/services/cast.service.ts
+++ b/client/src/app/core/services/cast.service.ts
@@ -387,6 +387,10 @@ export class CastService implements OnDestroy {
   }
 
   async loadMedia(info: CastMediaInfo) {
+    // Drop any armed/settling seek from a prior stream so a trailing dispatch
+    // can't fire onto the freshly loaded session (quality change, recovery,
+    // sessionLost reload) at a stale target.
+    this.clearSeekCoalescing();
     // Forwarded to the receiver. Fields here MUST stay JSON-serialisable
     // and free of secrets — `customData` is logged in plain text by the
     // CAF debug overlay.
@@ -531,14 +535,24 @@ export class CastService implements OnDestroy {
   }
 
   seek(time: number) {
+    const dur = this.duration();
+    const target = dur > 0 ? Math.max(0, Math.min(time, dur)) : Math.max(0, time);
+    // Whether a prior seek is still in flight — captured BEFORE the window is
+    // refreshed below (mirrorReceiverTime zeroes it once the receiver arrives).
+    const settling = this.seekSettleUntil > Date.now();
     // Pin the bar at the target and mark the seek in-flight BEFORE dispatching,
     // so a burst reads the pinned target (accumulating ±10 taps correctly) and
     // stale receiver echoes can't bounce it back (see mirrorReceiverTime).
-    this.pendingSeekTarget = time;
-    this.currentTime.set(time);
+    this.pendingSeekTarget = target;
+    this.currentTime.set(target);
     this.seekSettleUntil = Date.now() + CAST_SEEK_SETTLE_MS;
-    // Leading edge: dispatch immediately when idle so a single seek stays snappy.
-    if (this.seekCoalesceTimer == null) this.dispatchSeek(time);
+    // Leading edge only while idle: a lone tap dispatches immediately and stays
+    // snappy. Once a seek is in flight, every further tap folds into the single
+    // trailing dispatch instead of firing its own raw seek, so the receiver runs
+    // ONE buffer-flush cycle for the final target. Raw back-to-back seeks
+    // interrupt the receiver's independent audio and video refills mid-append,
+    // leaving the two buffers settled at different targets (A/V desync).
+    if (!settling) this.dispatchSeek(target);
     // Trailing edge: (re)arm; once the burst stops, send the final settled target
     // (skipped when it equals the leading dispatch, i.e. a lone seek).
     if (this.seekCoalesceTimer != null) clearTimeout(this.seekCoalesceTimer);


### PR DESCRIPTION
## What

Repeated ±10s skip taps on a **multi-audio** Chromecast stream (~300 ms apart) each
found the coalesce timer idle and fired their own raw, fire-and-forget SEEK — the
prior sender coalescing (`ff579015`) only engages for sub-220 ms scrubbing, and the
220 ms window is shorter than the discrete-tap cadence. On the receiver, a multi-audio
stream keeps audio and video in **separate SourceBuffers**; a storm of raw seeks
interrupts their independent refills mid-append and leaves the two buffers settled at
**different targets** → a constant A/V offset the moment the seek lands.

## Change (sender-only, `cast.service.ts`)

- Dispatch the **leading edge only when no seek is in flight**; once one is settling,
  fold every further tap into the single **trailing** dispatch. A burst collapses from
  N raw seeks to 2 well-separated ones (leading + final target), so the receiver runs
  one flush cycle per burst and both buffers converge on the final target. Lone taps
  stay snappy.
- Clamp the target to `[0, duration]` (the ±10 buttons could send negative / past-end
  near clip boundaries; local `onSeek` already clamps).
- Drop any armed seek at the top of `loadMedia()` so a trailing dispatch can't fire
  onto a freshly reloaded session (quality change / recovery / `sessionLost`).

The full generation-token + convergence-poll rewrite was left out on purpose:
trailing-only removes the seek overlap at the source, and the extra async machinery
would add regression risk that can't be validated without a device.

## Status

Typecheck green. **Not yet validated on a physical Chromecast** — the test checklist and
fallback proposals (receiver `shakaConfig`/`autoResumeDuration` hardening, `MessageType.SEEK`
interceptor) live in the tracking issue, which stays open until device validation.

Refs #789
