### PR TITLE
fix(streaming): snap segment length to the true GOP length

### DIFF
--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -25,6 +25,7 @@ import {
   type RungBitrateContext,
 } from './transcoding/quality-ladder';
 import { resolveEncodePipeline } from './transcoding/encode-pipeline';
+import { parseSourceFps } from './transcoding/constants';
 import { ActiveStreamTracker } from './active-stream-tracker.service';
 import {
   bucketResolutionHeight,
@@ -652,7 +653,7 @@ export class StreamBuilderService {
       outputCodec,
       sourceWidth: source.width ?? 0,
       sourceHeight: source.height ?? 0,
-      sourceFrameRate: parseFloat(source.frameRate ?? '') || 24,
+      sourceFrameRate: parseSourceFps(source.frameRate) ?? 24,
       sourceVideoBitrateBps: source.videoBitRate,
       sourceVideoCodec: source.videoCodec,
     };

--- a/backend/src/modules/streaming/transcoding/constants.spec.ts
+++ b/backend/src/modules/streaming/transcoding/constants.spec.ts
@@ -10,10 +10,20 @@ describe('parseSourceFps', () => {
     expect(parseSourceFps('24')).toBe(24);
   });
 
-  it('returns undefined for missing / empty / zero', () => {
+  it('parses rational frame rates (ffprobe r_frame_rate)', () => {
+    // parseFloat('24000/1001') would yield 24000 and blow up the GOP/seg grid.
+    expect(parseSourceFps('24000/1001')).toBeCloseTo(24000 / 1001, 6);
+    expect(parseSourceFps('30000/1001')).toBeCloseTo(30000 / 1001, 6);
+    expect(parseSourceFps('30/1')).toBe(30);
+  });
+
+  it('returns undefined for missing / empty / zero / degenerate rationals', () => {
     expect(parseSourceFps(undefined)).toBeUndefined();
     expect(parseSourceFps('')).toBeUndefined();
     expect(parseSourceFps('0')).toBeUndefined();
+    expect(parseSourceFps('0/0')).toBeUndefined();
+    expect(parseSourceFps('24000/0')).toBeUndefined();
+    expect(parseSourceFps('0/1001')).toBeUndefined();
   });
 });
 
@@ -29,14 +39,23 @@ describe('realSegmentSeconds', () => {
     expect(realSegmentSeconds(6, undefined)).toBe(6);
   });
 
-  it('returns gop/fps for fractional fps', () => {
-    // round(3 × 23.976) = 72 frames → 72 / 23.976 ≈ 3.003s
-    expect(realSegmentSeconds(3, 23.976)).toBeCloseTo(72 / 23.976, 6);
+  it('returns the true whole-ms GOP length for fractional fps', () => {
+    // round(3 × 23.976) = 72 frames. The stored fps is rounded to 3 decimals,
+    // so raw 72 / 23.976 = 3.0030030… overshoots the true GOP; snapping to the
+    // ms restores 72·1001/24000 = 3.003 exactly. As -hls_time the raw value
+    // makes the muxer merge two GOPs into the run's first segment.
+    expect(realSegmentSeconds(3, 23.976)).toBe(3.003);
+    expect(realSegmentSeconds(3, 23.976)).toBeLessThanOrEqual((72 * 1001) / 24000);
+    // 6s setting → 144 frames → 6.006s.
+    expect(realSegmentSeconds(6, 23.976)).toBe(6.006);
+    // 29.97 (30000/1001): 90 frames → 3.003s.
+    expect(realSegmentSeconds(3, 29.97)).toBe(3.003);
   });
 
-  it('keeps secondsToSegmentIndex on the same fractional grid', () => {
-    // seg-N starts at N × 3.003; t just under the 2nd boundary is still seg 1.
-    expect(secondsToSegmentIndex(72 / 23.976, 3, 23.976)).toBe(1);
-    expect(secondsToSegmentIndex((72 / 23.976) * 2 - 0.001, 3, 23.976)).toBe(1);
+  it('keeps secondsToSegmentIndex on the same grid', () => {
+    const seg = realSegmentSeconds(3, 23.976); // 3.003
+    // seg-N starts at N × seg; t just under the 2nd boundary is still seg 1.
+    expect(secondsToSegmentIndex(seg, 3, 23.976)).toBe(1);
+    expect(secondsToSegmentIndex(seg * 2 - 0.001, 3, 23.976)).toBe(1);
   });
 });

--- a/backend/src/modules/streaming/transcoding/constants.ts
+++ b/backend/src/modules/streaming/transcoding/constants.ts
@@ -35,24 +35,44 @@ export const EARLY_PROBE_SEGMENTS = 2;
  *  session against the segments already cut on its old grid. */
 export const DEFAULT_SEGMENT_DURATION = 3;
 
-/** Real length of one transcoded segment = a pinned GOP of
- *  `round(segmentDuration · fps)` frames = `gop / fps` seconds. Equals
- *  `segmentDuration` for integer / unknown fps; differs only for fractional
- *  rates (24000/1001 → 3.003s at a 3s setting). */
+/** Real length of one transcoded segment: a pinned GOP of
+ *  `round(segmentDuration · fps)` frames (`gop / fps` seconds), snapped to the
+ *  millisecond. Equals `segmentDuration` for integer / unknown fps; a
+ *  fractional rate yields the true whole-ms GOP length (24000/1001 → 3.003s).
+ *
+ *  The ms snap is load-bearing. `fps` arrives rounded to 3 decimals
+ *  (`parseFrameRate` stores 24000/1001 as "23.976"), so raw `gop / fps` sits a
+ *  sub-ms sliver ABOVE the true GOP (72/23.976 = 3.0030030… vs the true
+ *  72·1001/24000 = 3.003). This value is `-hls_time`: FFmpeg's HLS muxer cuts
+ *  on the first keyframe once the threshold has elapsed, so a threshold above
+ *  one GOP skips the per-segment forced IDR and packs two GOPs into the run's
+ *  first segment. Snapping to the ms the real frame rate lands on keeps
+ *  `-hls_time` at/below one GOP, so the muxer cuts on every IDR. */
 export function realSegmentSeconds(
   segmentDuration: number,
   fps?: number,
 ): number {
   if (!fps || fps <= 0) return segmentDuration;
-  return Math.max(1, Math.round(segmentDuration * fps)) / fps;
+  const gopSeconds = Math.max(1, Math.round(segmentDuration * fps)) / fps;
+  return Math.round(gopSeconds * 1000) / 1000;
 }
 
-/** Parse a ffprobe `frameRate` string to fps, or `undefined` when unknown.
- *  Single rule for the transcode/playlist callers that feed
- *  {@link realSegmentSeconds} — a divergent parse would declare a different
- *  segment length for one surface and reintroduce fractional-fps A/V drift. */
+/** Parse a ffprobe `frameRate` to fps, or `undefined` when unknown. Accepts a
+ *  decimal ("23.976") or a rational ("24000/1001"): ffprobe reports
+ *  `r_frame_rate` as a rational, and a bare `parseFloat("24000/1001")` yields
+ *  24000, which would blow up the GOP and segment grid. Single rule for the
+ *  transcode/playlist callers that feed {@link realSegmentSeconds} — a divergent
+ *  parse would declare a different segment length for one surface and
+ *  reintroduce fractional-fps A/V drift. */
 export function parseSourceFps(frameRate: string | undefined): number | undefined {
-  return parseFloat(frameRate ?? '') || undefined;
+  if (!frameRate) return undefined;
+  const slash = frameRate.indexOf('/');
+  if (slash !== -1) {
+    const num = Number(frameRate.slice(0, slash));
+    const den = Number(frameRate.slice(slash + 1));
+    return num > 0 && den > 0 ? num / den : undefined;
+  }
+  return parseFloat(frameRate) || undefined;
 }
 
 /** Presentation time (seconds) → containing FFmpeg segment number, on the


### PR DESCRIPTION
## Problem
On fractional-fps (NTSC 23.976 / 29.97) transcodes, the first video segment of
every ffmpeg run — initial playback *and* every seek landing — shipped at double
length (144 frames / ~6s instead of 72 / 3.003s), while the playlist EXTINF and
the separate audio session stayed single-GOP. Players that trust tfdt desync A/V;
players that trust EXTINF desync subtitles. Integer-fps content was unaffected.

## Root cause
`realSegmentSeconds` computed `gopSize / fps`, but `fps` is stored rounded to 3
decimals (`parseFrameRate` keeps `24000/1001` as `"23.976"`), so
`72 / 23.976 = 3.0030030…` overshoots the true `72·1001/24000 = 3.003` GOP length.
That value becomes ffmpeg's `-hls_time`; a threshold a hair above one GOP makes
the HLS muxer skip the per-segment forced IDR and merge two GOPs into the first
segment.

## Fix
- Snap the segment length to the millisecond → the true whole-ms GOP length, so
  `-hls_time` stays at/below one GOP and the muxer cuts on every IDR. One
  single-source-of-truth change; EXTINF / tfdt / seek grid all get more accurate.
- Harden `parseSourceFps` to also parse a rational frame rate (`"24000/1001"`) and
  route `stream-builder` through it, so a rational string can't collapse the
  GOP/segment grid via a bare `parseFloat`.

## Validation
- Reproduced against production (2160p SDR 23.976): every cold seek landed a
  144-frame first segment containing two IDRs (encoder correct, muxer miss).
- Local ffmpeg repro (libx264 and libx265): `3.0030030` → 144 frames, `3.003` →
  72; integer-fps → 72.
- Decimal path unchanged (existing library unaffected); rational and decimal both
  converge on `realSeg = 3.003`.
- Backend specs green (constants, audio-only, controller).

## Deploy note
Purge the transcode cache for affected titles after deploy — double segments
already on disk keep being served (the grid isn't part of the profile hash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
