### PR TITLE
style(select): match dropdown-trigger hover and widen chevron spacing

### DIFF
--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -422,7 +422,7 @@
       <div class="flex items-center gap-2">
         <span class="text-base-content/50">{{ 'media_info.video' | translate }}</span>
         @if (multipleFiles()) {
-          <select class="select select-bordered select-sm w-fit pe-9" appTvSelect [ngModel]="selectedFileId()" (ngModelChange)="selectedFileIdChange.emit($event)">
+          <select class="select select-bordered select-sm w-fit" appTvSelect [ngModel]="selectedFileId()" (ngModelChange)="selectedFileIdChange.emit($event)">
             @for (f of files(); track f.id) {
               <option [ngValue]="f.id">{{ fileLabel(f) }}</option>
             }
@@ -438,7 +438,7 @@
             <span>{{ audioTracks()[0].label }}</span>
           } @else {
             <app-dropdown-menu placement="bottom-end">
-              <button trigger type="button" class="select select-bordered select-sm w-fit text-left pe-9">
+              <button trigger type="button" class="select select-bordered select-sm w-fit text-left cursor-pointer transition-colors hover:bg-base-content/10">
                 {{ selectedAudio()?.head || selectedAudio()?.label }}
               </button>
               @for (t of audioTracks(); track t.index) {
@@ -466,7 +466,7 @@
             <span>{{ subtitles()[0].label }}</span>
           } @else {
             <app-dropdown-menu placement="bottom-end">
-              <button trigger type="button" class="select select-bordered select-sm w-fit text-left pe-9">
+              <button trigger type="button" class="select select-bordered select-sm w-fit text-left cursor-pointer transition-colors hover:bg-base-content/10">
                 {{ selectedSubtitle()?.head || selectedSubtitle()?.label || ('player.off' | translate) }}
               </button>
               <button

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -23,6 +23,14 @@
   border-color: transparent;
 }
 
+/* daisyUI draws the dropdown chevron ~16px from the trailing edge but only
+   reserves 1.75rem of end padding, so the value text crowds the arrow. Give
+   every select a touch more trailing room (logical property keeps it RTL-safe).
+   The chevron position is size-independent, so one value fits every modifier. */
+.select {
+  padding-inline-end: 2.25rem;
+}
+
 /* daisyUI ships `.tab` flat by default, which makes the global focus ring
    (a box-shadow that traces border-radius) render as a square notched
    into the otherwise rounded UI. Give every tab the same radius as the


### PR DESCRIPTION
## What

Two small select/dropdown styling tweaks on top of each other.

**1. Dropdown-trigger hover (media info header).** The Audio and Subtitle pickers
are `<button>`s styled as `.select`, so they lacked the pointer cursor and hover
tint a native `<select>` shows. They now get `cursor-pointer` and a
`base-content/10` lighten on hover, matching the Video select beside them (and the
same lighten idiom the open dropdown items already use).

**2. Chevron spacing, now global.** daisyUI reserves only `1.75rem` of trailing
padding while the chevron sits ~16px from the edge, so the value text crowds the
arrow on every select in the app — the admin selects had the same problem. The
local `pe-9` patch on the three media-info-header controls is replaced by a single
global `.select { padding-inline-end: 2.25rem }` rule.

## Why global

- The chevron position is size-independent (`select-sm/md/lg` only change height and
  font), so one value fits every modifier.
- Uses the `padding-inline-end` logical property, so it stays RTL-safe.
- Rule is unlayered, so it overrides daisyUI's own value — the same mechanism the
  existing `.select:focus` rule in `styles.css` relies on.

## Test

Visual only, no logic touched. Verified no other select carries a `pe-*` patch and
all selects are direct `<select class="select">` / `button.select` (no wrapper
pattern to reconcile). Needs a quick on-device look across admin selects.
