### PR TITLE
fix(player): localise the forced and hearing-impaired subtitle tags

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -65,6 +65,8 @@
     "low_bandwidth": "geringer Verbrauch",
     "audio_track_n": "Spur {{index}}",
     "subtitle_track_n": "Untertitel {{index}}",
+    "subtitle_forced": "Erzwungen",
+    "subtitle_hearing_impaired": "Hörgeschädigt",
     "playback_error": "Wiedergabe fehlgeschlagen.",
     "error_aborted": "Wiedergabe abgebrochen.",
     "error_network": "Netzwerkfehler während der Wiedergabe.",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -65,6 +65,8 @@
     "low_bandwidth": "low bandwidth",
     "audio_track_n": "Track {{index}}",
     "subtitle_track_n": "Subtitle {{index}}",
+    "subtitle_forced": "Forced",
+    "subtitle_hearing_impaired": "Hearing-impaired",
     "subtitle_source": {
       "translated": "Translated",
       "ocr": "OCR"

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -65,6 +65,8 @@
     "low_bandwidth": "bajo consumo",
     "audio_track_n": "Pista {{index}}",
     "subtitle_track_n": "Subtítulo {{index}}",
+    "subtitle_forced": "Forzado",
+    "subtitle_hearing_impaired": "Sordos",
     "playback_error": "La reproducción ha fallado.",
     "error_aborted": "Reproducción interrumpida.",
     "error_network": "Error de red durante la reproducción.",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -65,6 +65,8 @@
     "low_bandwidth": "faible consommation",
     "audio_track_n": "Piste {{index}}",
     "subtitle_track_n": "Sous-titre {{index}}",
+    "subtitle_forced": "Forcé",
+    "subtitle_hearing_impaired": "Malentendants",
     "subtitle_source": {
       "translated": "Traduit",
       "ocr": "OCR"

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -65,6 +65,8 @@
     "low_bandwidth": "basso consumo",
     "audio_track_n": "Traccia {{index}}",
     "subtitle_track_n": "Sottotitolo {{index}}",
+    "subtitle_forced": "Forzato",
+    "subtitle_hearing_impaired": "Non udenti",
     "playback_error": "La riproduzione è fallita.",
     "error_aborted": "Riproduzione interrotta.",
     "error_network": "Errore di rete durante la riproduzione.",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -65,6 +65,8 @@
     "low_bandwidth": "baixo consumo",
     "audio_track_n": "Faixa {{index}}",
     "subtitle_track_n": "Legenda {{index}}",
+    "subtitle_forced": "Forçado",
+    "subtitle_hearing_impaired": "Surdos",
     "playback_error": "A reprodução falhou.",
     "error_aborted": "Reprodução interrompida.",
     "error_network": "Erro de rede durante a reprodução.",

--- a/client/src/app/core/utils/player.utils.ts
+++ b/client/src/app/core/utils/player.utils.ts
@@ -202,8 +202,8 @@ export function formatAudioParts(
  * Render a subtitle as a dropdown label. Mirrors {@link formatAudioLabel} so
  * the player and media-detail subtitle menus stay consistent.
  *
- * Format: `"<lang> (HI) (Forced) (CODEC)"` with the parenthesised parts
- * omitted when the corresponding flag is absent.
+ * Format: `"<lang> (hearing-impaired) (forced) (CODEC)"`, every parenthesised
+ * part localised and omitted when the corresponding flag is absent.
  */
 export function formatSubtitleLabel(
   sub: {
@@ -223,8 +223,8 @@ export function formatSubtitleLabel(
       ? translate.instant('player.subtitle_track_n', { index: trackIndex })
       : localizeLanguage(sub.language, translate);
   const parts: string[] = [];
-  if (sub.hearingImpaired) parts.push('HI');
-  if (sub.forced) parts.push('Forced');
+  if (sub.hearingImpaired) parts.push(translate.instant('player.subtitle_hearing_impaired'));
+  if (sub.forced) parts.push(translate.instant('player.subtitle_forced'));
   const codec = shortSubtitleCodec(sub.codec, sub.relativePath);
   if (codec) parts.push(codec);
   const origin = subtitleOriginLabel(sub.providerType, translate);
@@ -234,7 +234,8 @@ export function formatSubtitleLabel(
 
 /**
  * Two-part subtitle label for the player menu: the language on top and the
- * details ("SRT • Forced • Translated") as a subline, joined with " • ".
+ * details ("SRT • forced • translated") as a subline, joined with " • ".
+ * Every flag label is localised.
  */
 export function formatSubtitleParts(
   sub: {
@@ -256,8 +257,8 @@ export function formatSubtitleParts(
   const parts: string[] = [];
   const codec = shortSubtitleCodec(sub.codec, sub.relativePath);
   if (codec) parts.push(codec);
-  if (sub.forced) parts.push('Forced');
-  if (sub.hearingImpaired) parts.push('HI');
+  if (sub.forced) parts.push(translate.instant('player.subtitle_forced'));
+  if (sub.hearingImpaired) parts.push(translate.instant('player.subtitle_hearing_impaired'));
   const origin = subtitleOriginLabel(sub.providerType, translate);
   if (origin) parts.push(origin);
   return { head, sub: parts.join(' • ') };


### PR DESCRIPTION
## What

The subtitle selection dropdowns (player, media detail, Chromecast overlay) showed
the flag tags **Forced** and **HI** in English regardless of UI language, sitting
right next to an already-localised language name.

All three surfaces build their labels through `formatSubtitleLabel` /
`formatSubtitleParts` in `player.utils.ts`, which pushed the raw `'Forced'` /
`'HI'` strings. Both now go through two new keys:

- `player.subtitle_forced`
- `player.subtitle_hearing_impaired`

added to every locale (en/fr/es/de/it/pt). The French wording reuses
**"Malentendants"**, the term the language-profile screen already uses.

Example (French): `Français (Malentendants) (Forcé) (SRT)` and subline
`SRT • Forcé • Malentendants`.

## Scope

Only the subtitle **dropdown labels**. The standalone `HI` badge chips in the
subtitle-search modal, the subtitle-management modal and the activity list are
intentionally left as-is (compact badge pattern, different context).

## Test

Type-safe swap of literals for `translate.instant(...)` calls (both functions
already receive the `TranslateService`). JSON validated for all six locales. Needs
a quick on-device glance at a forced/HI subtitle in a non-English UI.
