### PR TITLE
fix(dropdown-menu): cap desktop menu height and scroll overflow

### DIFF
--- a/client/src/app/shared/components/dropdown-menu.ts
+++ b/client/src/app/shared/components/dropdown-menu.ts
@@ -60,7 +60,7 @@ type Placement = 'bottom-end' | 'bottom-start' | 'top-end' | 'top-start';
         </div>
         <div
           tabindex="0"
-          class="dropdown-content bg-base-200 rounded-box shadow-xl min-w-60 p-1 z-[101] overflow-hidden whitespace-nowrap"
+          class="dropdown-content bg-base-200 rounded-box shadow-xl min-w-60 max-h-[70vh] p-1 z-[101] overflow-y-auto overflow-x-hidden whitespace-nowrap"
         >
           <ng-container *ngTemplateOutlet="itemsTpl"></ng-container>
         </div>


### PR DESCRIPTION
## What

The shared desktop dropdown (`app-dropdown-menu`, ~20 call sites — media-detail
audio/subtitle/more menus, Chromecast overlay, etc.) rendered its content with
`overflow-hidden` and no height cap. A long list (many audio or subtitle tracks,
the full more-menu) could extend past the viewport with its tail unreachable.

Cap the desktop `.dropdown-content` at `max-h-[70vh]` and scroll vertically
(`overflow-y-auto`); horizontal stays clipped (`overflow-x-hidden`) to preserve
the rounded corners and the `whitespace-nowrap` layout.

## Notes

- Desktop branch only — the mobile/TV branch (bottom sheet) already scrolls
  (`max-h-[70vh] overflow-y-auto`), and the in-player control menus already cap
  their own height.
- Short menus are visually unchanged: `overflow-y-auto` only shows a scrollbar
  when content exceeds the cap.

## Test

Pure Tailwind class change. Needs a quick on-device glance at a long
audio/subtitle track list on desktop.
