### PR TITLE
fix(home): key continue-watching rows by media, not the null-join id

### DIFF
--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -37,9 +37,9 @@
       @case ('continue-watching') {
         @if (continueWatching().length) {
           <app-horizontal-scroller [title]="'home.continue_watching' | translate">
-            @for (item of continueWatching(); track item.id) {
+            @for (item of continueWatching(); track item.mediaId + '-' + (item.episodeId ?? '')) {
               <app-media-card [aspect]="'landscape'"
-                [attr.data-home-focus]="'cw:' + item.id"
+                [attr.data-home-focus]="'cw:' + item.mediaId + '-' + (item.episodeId ?? '')"
                 [imageUrl]="item.stillUrl ?? item.fanartUrl ?? item.posterUrl"
                 [title]="item.mediaTitle"
                 [subtitle]="item.episodeLabel ?? undefined"

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -453,7 +453,7 @@
            in-progress in this library so we don't render an empty row. -->
       @if (suggestionsContinue().length) {
         <app-horizontal-scroller [title]="'home.continue_watching' | translate">
-          @for (item of suggestionsContinue(); track item.id) {
+          @for (item of suggestionsContinue(); track item.mediaId + '-' + (item.episodeId ?? '')) {
             <app-media-card
               [aspect]="'landscape'"
               [imageUrl]="item.fanartUrl ?? item.posterUrl"


### PR DESCRIPTION
## What

The home + library **Continue watching** rows tracked their `@for` by `item.id`. That id arrives from the backend as `COALESCE(next-episode playback_state id, 0)`, so every *"finished an episode, next one not yet started"* series row carries `id = 0`. With three such series in the list, Angular logs **NG0955 (duplicated keys)** — `key "0" at index 2/3/7`.

## Why it matters (not just a warning)

- **TV / spatial-nav focus:** the same value feeds `data-home-focus="cw:{id}"`, so three cards get identical `cw:0` — focus restore lands on the wrong card.
- **Element-state churn:** the row re-fetches/re-sorts (two-pass SWR, `import.complete` SSE, watched-toggle). Duplicate keys make Angular's keyed diff reuse/reorder the colliding views, so transient per-card state can jump to the wrong card.

## Fix

Track by the `mediaId + '-' + episodeId` composite — unique per row (movies: unique `mediaId` + null `episodeId`; each series appears once with its next `episodeId`) and consistent with the likes row directly above it. The focus id is keyed the same way. Applied to both the home row and the library "continue" suggestions row.

Found while auditing the macOS desktop player (the warning showed up in the Electron renderer log); unrelated to the player itself.