### PR TITLE
fix(desktop): round the player window bottom corners on macOS and windows

### DIFF
--- a/desktop/native/player_mac/addon.mm
+++ b/desktop/native/player_mac/addon.mm
@@ -810,6 +810,57 @@ Napi::Value Resize(const Napi::CallbackInfo& info) {
   return info.Env().Undefined();
 }
 
+// Path for `r` with only the two corners on one Y-edge rounded. bottomIsMinY
+// selects which edge is "bottom" in the layer's geometry (a non-flipped AppKit
+// view has its bottom at minY; a flipped Chromium view at maxY).
+static CGPathRef CreateBottomRoundedPath(CGRect r, CGFloat radius, BOOL bottomIsMinY) {
+  CGFloat x0 = CGRectGetMinX(r), x1 = CGRectGetMaxX(r);
+  CGFloat y0 = CGRectGetMinY(r), y1 = CGRectGetMaxY(r);
+  CGFloat rad = MIN(radius, MIN(r.size.width, r.size.height) / 2.0);
+  CGMutablePathRef p = CGPathCreateMutable();
+  CGFloat sq = bottomIsMinY ? y1 : y0;  // square edge
+  CGFloat rd = bottomIsMinY ? y0 : y1;  // rounded edge
+  CGFloat dir = bottomIsMinY ? 1.0 : -1.0;
+  CGPathMoveToPoint(p, NULL, x0, sq);
+  CGPathAddLineToPoint(p, NULL, x1, sq);
+  CGPathAddLineToPoint(p, NULL, x1, rd + rad * dir);
+  CGPathAddArcToPoint(p, NULL, x1, rd, x1 - rad, rd, rad);
+  CGPathAddLineToPoint(p, NULL, x0 + rad, rd);
+  CGPathAddArcToPoint(p, NULL, x0, rd, x0, rd + rad * dir, rad);
+  CGPathCloseSubpath(p);
+  return p;
+}
+
+// setBottomCornerRadius(wid, radius) — clip any window's content view to a
+// square-top / rounded-bottom shape via a CAShapeLayer mask (works for the web
+// content AND the CAOpenGLLayer, which ignores an ancestor's cornerRadius). The
+// caller re-invokes on resize with the new bounds. N-API runs on the AppKit
+// main thread, so layer mutation here is safe.
+Napi::Value SetBottomCornerRadius(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 2) return env.Undefined();
+  std::string widStr = info[0].ToString().Utf8Value();
+  double radius = info[1].As<Napi::Number>().DoubleValue();
+  uintptr_t ptr = static_cast<uintptr_t>(strtoull(widStr.c_str(), nullptr, 10));
+  NSView* view = (__bridge NSView*)reinterpret_cast<void*>(ptr);
+  if (!view) return env.Undefined();
+  view.wantsLayer = YES;
+  CALayer* layer = view.layer;
+  if (!layer) return env.Undefined();
+  CGPathRef path = CreateBottomRoundedPath(view.bounds, radius, !view.isFlipped);
+  CAShapeLayer* mask = [layer.mask isKindOfClass:[CAShapeLayer class]]
+                           ? (CAShapeLayer*)layer.mask
+                           : [CAShapeLayer layer];
+  [CATransaction begin];
+  [CATransaction setDisableActions:YES];  // no implicit animation on resize
+  mask.frame = view.bounds;
+  mask.path = path;
+  layer.mask = mask;
+  [CATransaction commit];
+  CGPathRelease(path);
+  return env.Undefined();
+}
+
 Napi::Value Stop(const Napi::CallbackInfo& info) {
   // run.store(false) MUST stay first: a still-queued ApplyLayerColorConfig block
   // (posted from the event thread) is only safe because it early-returns on
@@ -870,6 +921,7 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("getProperty", Napi::Function::New(env, GetProperty));
   exports.Set("setProperty", Napi::Function::New(env, SetProperty));
   exports.Set("resize", Napi::Function::New(env, Resize));
+  exports.Set("setBottomCornerRadius", Napi::Function::New(env, SetBottomCornerRadius));
   exports.Set("stop", Napi::Function::New(env, Stop));
   return exports;
 }

--- a/desktop/src/main/mpv/mac-mpv-player.ts
+++ b/desktop/src/main/mpv/mac-mpv-player.ts
@@ -36,8 +36,34 @@ type MacAddon = {
   getProperty(name: string): string | null;
   setProperty(name: string, value: string): void;
   resize(): void;
+  setBottomCornerRadius(wid: string, radius: number): void;
   stop(): void;
 };
+
+/** Resolve + require the native addon (singleton across the process). The .node
+ *  addon and the dlopen'd libmpv are asarUnpack'd, so in a packaged app they
+ *  live under app.asar.unpacked. */
+let macAddon: MacAddon | null = null;
+function loadMacAddon(): MacAddon {
+  if (macAddon) return macAddon;
+  const base = app.isPackaged
+    ? app.getAppPath().replace(/app\.asar$/, 'app.asar.unpacked')
+    : app.getAppPath();
+  if (!process.env.FLIKS_MPV_PATH) {
+    process.env.FLIKS_MPV_PATH = path.join(base, 'native', 'vendor', 'libmpv.dylib');
+  }
+  macAddon = createRequire(__filename)(
+    path.join(base, 'native', 'build', 'Release', 'fliks_player_mac.node'),
+  ) as MacAddon;
+  return macAddon;
+}
+
+/** Clip a window's content view to a square-top / rounded-bottom shape. Call on
+ *  create and on every resize with the window's current bounds. */
+export function roundWindowBottomCorners(win: BrowserWindow, radius: number): void {
+  const wid = win.getNativeWindowHandle().readBigUInt64LE(0).toString();
+  loadMacAddon().setBottomCornerRadius(wid, radius);
+}
 
 export class MacMpvPlayer extends TypedEmitter<PlayerBackendEvents> implements PlayerBackend {
   private readonly addon: MacAddon;
@@ -57,19 +83,7 @@ export class MacMpvPlayer extends TypedEmitter<PlayerBackendEvents> implements P
     // macOS getNativeWindowHandle() yields a pointer-sized (64-bit) NSView*; the
     // addon parses it back from a decimal string (a JS number can't hold it).
     this.wid = videoWin.getNativeWindowHandle().readBigUInt64LE(0).toString();
-
-    // The .node addon and the dlopen'd libmpv are asarUnpack'd, so in a packaged
-    // app they live under app.asar.unpacked. Mirror index.ts's Linux resolution.
-    const base = app.isPackaged
-      ? app.getAppPath().replace(/app\.asar$/, 'app.asar.unpacked')
-      : app.getAppPath();
-    if (!process.env.FLIKS_MPV_PATH) {
-      process.env.FLIKS_MPV_PATH = path.join(base, 'native', 'vendor', 'libmpv.dylib');
-    }
-    const req = createRequire(__filename);
-    this.addon = req(
-      path.join(base, 'native', 'build', 'Release', 'fliks_player_mac.node'),
-    ) as MacAddon;
+    this.addon = loadMacAddon();
   }
 
   async start(): Promise<this> {

--- a/desktop/src/main/window/player-session.ts
+++ b/desktop/src/main/window/player-session.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow } from 'electron';
 import path from 'node:path';
 import fs from 'node:fs';
 import { MpvPlayer } from '../mpv/mpv-player';
-import { MacMpvPlayer } from '../mpv/mac-mpv-player';
+import { MacMpvPlayer, roundWindowBottomCorners } from '../mpv/mac-mpv-player';
 import type { PlayerBackend } from '../mpv/player-backend';
 import { createEmbedBackend } from './backends';
 import { setPlaybackKeepAwake, keepAwakeForState } from '../power';
@@ -27,6 +27,27 @@ export interface PlayerSessionOptions {
   rendererUrl: string;
   preloadPath: string;
   iconPath?: string;
+}
+
+/** Window corner radius matching each OS's native window rounding, so the
+ *  overlays' clipped bottom aligns with frameWin's rounded bottom: macOS ~10pt,
+ *  Windows 11 DWM ~8px. */
+const OVERLAY_CORNER_RADIUS = 10;
+const WIN_OVERLAY_CORNER_RADIUS = 8;
+
+/** Windows: a square-top / rounded-bottom window region as a horizontal-slice
+ *  staircase (setShape/SetWindowRgn has no anti-aliasing, so the curve is
+ *  stepped — imperceptible at this radius). Coordinates are the window's own. */
+function roundedBottomShape(width: number, height: number): Electron.Rectangle[] {
+  const r = Math.max(0, Math.min(WIN_OVERLAY_CORNER_RADIUS, Math.floor(Math.min(width, height) / 2)));
+  if (r === 0) return [];
+  const rects: Electron.Rectangle[] = [{ x: 0, y: 0, width, height: height - r }];
+  for (let i = 0; i < r; i++) {
+    const o = i + 0.5; // sample mid-row for a smoother step
+    const inset = Math.round(r - Math.sqrt(r * r - o * o));
+    rects.push({ x: inset, y: height - r + i, width: width - 2 * inset, height: 1 });
+  }
+  return rects;
 }
 
 /**
@@ -73,6 +94,7 @@ export class PlayerSession {
       transparent: true,
       backgroundColor: '#00000000',
       hasShadow: false,
+      roundedCorners: false,
       resizable: false,
       skipTaskbar: true,
       // Owned by frameWin: stays above it (over its content area) and hides /
@@ -90,6 +112,7 @@ export class PlayerSession {
       transparent: true,
       backgroundColor: '#00000000',
       hasShadow: false,
+      roundedCorners: false,
       // Electron warns that resizing a transparent window can break its
       // transparency on some platforms; the overlay is re-fitted via setBounds
       // in sync(), so keep the user from resizing it directly.
@@ -142,6 +165,18 @@ export class PlayerSession {
       const u = { ...b };
       if (process.platform === 'win32' && this.frameWin.isFullScreen()) u.height -= 1;
       this.uiWin.setBounds(u);
+      // frameWin rounds its bottom natively (macOS) / via DWM (Win11); clip the
+      // square overlays to match so the video + UI don't overhang it. Re-applied
+      // here so the shape tracks every resize. Skip in fullscreen (edge-to-edge).
+      const fs = this.frameWin.isFullScreen();
+      if (process.platform === 'darwin') {
+        const r = fs ? 0 : OVERLAY_CORNER_RADIUS;
+        roundWindowBottomCorners(this.videoWin, r);
+        roundWindowBottomCorners(this.uiWin, r);
+      } else if (process.platform === 'win32') {
+        this.videoWin.setShape(fs ? [] : roundedBottomShape(b.width, b.height));
+        this.uiWin.setShape(fs ? [] : roundedBottomShape(u.width, u.height));
+      }
     };
     // All these window events take a `() => void` listener; cast to one literal
     // so the overload resolves (a union of event names matches none).

--- a/desktop/src/main/window/player-session.ts
+++ b/desktop/src/main/window/player-session.ts
@@ -207,6 +207,10 @@ export class PlayerSession {
     });
     this.frameWin.on('closed', () => this.destroy());
 
+    // Shape + position the overlays BEFORE awaiting the (slow) Angular load, so
+    // the corners are rounded from the first painted frame instead of showing
+    // square for the ~0.5s the app takes to load.
+    sync();
     await this.uiWin.loadURL(rendererUrl);
     sync();
 


### PR DESCRIPTION
## Problem

The desktop player stacks three windows: a framed opaque `frameWin` + two frameless **transparent** overlays (`videoWin` = mpv, `uiWin` = Angular) pinned over its content area. `frameWin` rounds its corners natively (macOS) / via DWM (Win11), but the square overlays sat on top and **overhung** that rounding — showing a black/desktop artifact at the corners. Letting the overlays round themselves (all four corners) instead put a **notch** under the title bar.

## Fix

Keep the overlays' window frame **square** and clip only their **bottom** corners so they line up with `frameWin`'s rounded bottom, leaving the top square (no notch, title bar + traffic lights untouched):

- **macOS** — a `CAShapeLayer` mask with a square-top / rounded-bottom `CGPath` on each overlay's content-view layer (new `setBottomCornerRadius` in the `player_mac` addon). This reliably clips the `CAOpenGLLayer` (which ignores an ancestor's `cornerRadius`) and is flip-safe. Radius 10pt to match the OS.
- **Windows** — `BrowserWindow.setShape()` with a square-top / rounded-bottom region staircase (radius 8px to match DWM). No new dependency. `frameWin` keeps DWM's native 4-corner rounding.
- Re-applied on every resize; dropped in fullscreen (edge-to-edge).

## Test

- macOS: **validated** — bottom corners rounded, top square, no notch, video corners clipped, follows resize.
- Windows: needs testing on a Win11 machine (I can't run it here). `setShape` region edges are aliased (no AA) — acceptable at 8px; if the UI edge looks rough we can move `uiWin` to a CSS `border-radius` instead.