### PR TITLE
fix(subtitles): skip upgrades for languages outside the language profile

### DIFF
--- a/backend/src/modules/scheduler/subtitle-scheduler.service.ts
+++ b/backend/src/modules/scheduler/subtitle-scheduler.service.ts
@@ -325,6 +325,12 @@ export class SubtitleSchedulerService {
     );
 
     for (const sub of lowScoreSubs) {
+      // The profile is the contract: a language it doesn't ask for is never
+      // searched, downloaded, nor allowed to replace a file on disk.
+      const langItem = sub.media?.languageProfile?.subtitleLanguages?.find(
+        (l) => l.isoCode === sub.language,
+      );
+      if (!langItem) continue;
       if (sub.mediaFile?.id != null && missingByFileId.get(sub.mediaFile.id)) {
         this.log.debug?.(
           `SubtitleUpgrade: skipping sub #${sub.id} ("${sub.media?.title}", ${sub.language}) — file still has missing required languages, deferring to next missing-search pass`,
@@ -336,9 +342,6 @@ export class SubtitleSchedulerService {
         const videoReleaseName = fileRel
           ? path.basename(fileRel, path.extname(fileRel))
           : undefined;
-        const langItem = sub.media?.languageProfile?.subtitleLanguages?.find(
-          (l) => l.isoCode === sub.language,
-        );
         const results = await this.subtitlesService.searchSubtitles({
           imdbId: sub.media?.imdbId ?? undefined,
           tmdbId: sub.media?.tmdbId,
@@ -350,9 +353,7 @@ export class SubtitleSchedulerService {
           videoReleaseName,
           moviehash: sub.mediaFile?.osdbHash ?? undefined,
           moviebytesize: sub.mediaFile?.osdbBytesize ?? undefined,
-          hearingImpairedMode: langItem
-            ? resolveHearingImpairedMode(langItem)
-            : 'avoid',
+          hearingImpairedMode: resolveHearingImpairedMode(langItem),
         });
 
         // Invariant: a hash-matched sub is the perfect time sync — refuse

--- a/backend/src/modules/scheduler/utils/arr-import.util.ts
+++ b/backend/src/modules/scheduler/utils/arr-import.util.ts
@@ -201,6 +201,10 @@ export async function subtitlePathsBesideEpisode(
   return out;
 }
 
+/** Imported sidecars are files the user already owns — scored like disk
+ *  sidecars and embedded tracks so the upgrade pass never replaces them. */
+const IMPORTED_SUBTITLE_SCORE = 100;
+
 export interface UpsertImportedSubtitleParams {
   mediaId: number;
   mediaFileId: number;
@@ -267,6 +271,7 @@ export async function upsertImportedSubtitleFile(
         tags,
         relativePath: relativePath ?? existing.relativePath,
         status: SubtitleStatus.DOWNLOADED,
+        score: IMPORTED_SUBTITLE_SCORE,
         ...(wasEmbedded ? { streamIndex: null, codec: null } : {}),
       });
       return 1;
@@ -285,6 +290,7 @@ export async function upsertImportedSubtitleFile(
       hearingImpaired,
       providerType,
       status: SubtitleStatus.DOWNLOADED,
+      score: IMPORTED_SUBTITLE_SCORE,
       relativePath,
       tags,
     }),


### PR DESCRIPTION
## Problem

Production kept downloading subtitles in languages no language profile asks for (`da`, `vi`, `ar`, `es` on libraries configured for `fr`/`en` only).

The missing-search pass is fine — it iterates `profile.subtitleLanguages`. The **upgrade** pass is the culprit: it selects every `subtitle_files` row below `subtitle_upgrade_threshold` and re-searches on that row's own `language`, with no profile check. Worse, `upgradeSubtitle` deletes the original file once the replacement is persisted, so an out-of-profile sidecar was replaced by a provider download.

Entry point: rows inserted without an explicit `score`. `SubtitleFile.score` defaults to `0`, and the Radarr/Sonarr import path (`arr-import.util.ts`) never set it — unlike disk sidecars, embedded tracks and OCR results, which are all stored at `100` and therefore never eligible. So imported sidecars in any language became upgrade candidates.

## Fix

Two commits, one per half of the cause:

1. **`fix(subtitles)`** — resolve the profile's `SubtitleLanguageItem` at the top of the upgrade loop and `continue` when there is none. The lookup already existed further down (it fed the hearing-impaired mode), so this only moves it up and makes it authoritative — the `'avoid'` fallback disappears since the item is now always present. Both automatic passes are bound to the profile by construction after this. Manual downloads from the subtitles modal are unaffected: the user picks the language explicitly there.

2. **`fix(imports)`** — store arr-imported subtitles at `100` like every other on-disk sidecar, so the upgrade pass can't replace and unlink a file the user already owns. The update branch sets it too, so rows inserted before this heal on the next arr sync rather than needing a migration.

## Verification

Typecheck passes (`tsc --noEmit`). No spec exists for this scheduler and the guard is three lines inside an existing loop, so no test was added.

Existing out-of-profile files already on disk are left alone — a rescan does not remove them; they need deleting from the UI.