### PR TITLE
fix(desktop): stop the auto-quality ffmpeg restart storm on the Windows player

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -15,6 +15,9 @@
 #      desktop/web so electron-builder ships it at resources/web.
 #   + a vendored self-contained libmpv into desktop/native/vendor per OS.
 #
+# Release checklist: the Windows mpv pin (MPV_WINBUILD_TAG below) needs a
+# periodic bump — it does not move on its own, unlike the old newest-asset scrape.
+#
 # The native compositor addon (SDL2 + GLES/EGL) is LINUX-ONLY by design — it is
 # the OSR self-compositor needed under Mutter/X11. macOS and Windows embed mpv
 # natively instead (--wid into a child NSView/HWND, see desktop/src/main/window/
@@ -166,30 +169,28 @@ jobs:
             || { echo "::error::libmpv exports av_* — not self-contained, will clash with Electron's libffmpeg"; exit 1; }
           echo "vendored libmpv OK: $(du -h "$f" | cut -f1)"
 
-      # Windows embeds mpv via --wid by spawning a vendored mpv.exe. Download a
-      # static x64 build (zhongfly/mpv-winbuild — maintained) into native/vendor,
-      # which electron-builder ships via the native/vendor/** glob. UNTESTED on
-      # real Windows hardware — playback verification needs a Windows box.
+      # Windows embeds mpv via --wid by spawning a vendored mpv.exe, downloaded
+      # from a pinned zhongfly/mpv-winbuild release (MPV_WINBUILD_TAG below) so
+      # the Windows media/TLS stack only changes when that pin is bumped, not on
+      # every build. Bumping is a one-line edit; confirm the target release has
+      # an x86_64 asset first — some are aarch64-only.
       - name: Vendor mpv (Windows)
         if: runner.os == 'Windows'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MPV_WINBUILD_TAG: "2026-07-27-48e6c35c0e"
         run: |
           set -euo pipefail
           dest=desktop/native/vendor
           mkdir -p "$dest"
-          # zhongfly/mpv-winbuild sometimes cuts an arch-specific (e.g.
-          # aarch64-only) release, which `releases/latest` then points at,
-          # leaving no x86_64 asset. Scan the recent releases and take the
-          # newest x86_64 build instead. The `|| true` keeps `set -e` from
-          # firing on a grep-no-match / head SIGPIPE; the explicit guard below
-          # reports the failure clearly. The API call is authenticated to avoid
-          # the unauthenticated shared-runner-IP rate limit.
+          # The `|| true` keeps `set -e` from firing on a grep-no-match / head
+          # SIGPIPE; the explicit guard below reports the failure clearly. The
+          # API call is authenticated to avoid the unauthenticated shared-runner-IP rate limit.
           url=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" \
-            "https://api.github.com/repos/zhongfly/mpv-winbuild/releases?per_page=20" \
+            "https://api.github.com/repos/zhongfly/mpv-winbuild/releases/tags/$MPV_WINBUILD_TAG" \
             | grep -oE 'https://[^"]+mpv-x86_64-[0-9][^"]*\.7z' | head -1) || true
-          test -n "$url" || { echo "::error::no mpv-x86_64 .7z asset in the last 20 releases"; exit 1; }
+          test -n "$url" || { echo "::error::no mpv-x86_64 .7z asset on release $MPV_WINBUILD_TAG"; exit 1; }
           echo "Downloading mpv: $url"
           curl -fsSL -o "$RUNNER_TEMP/mpv.7z" "$url"
           7z x -y -o"$dest" "$RUNNER_TEMP/mpv.7z" >/dev/null

--- a/backend/src/modules/scheduler/system.controller.spec.ts
+++ b/backend/src/modules/scheduler/system.controller.spec.ts
@@ -54,6 +54,7 @@ describe('SystemController.activeStreams recency filter', () => {
       hdrLadder: false,
       supportsHlsSubtitles: false,
       probesSegZero: true,
+      supportsAbr: true,
       videoVariant: null,
       tonemapping: false,
       transcodeReasons: [],

--- a/backend/src/modules/streaming/dto/device-profile.dto.ts
+++ b/backend/src/modules/streaming/dto/device-profile.dto.ts
@@ -201,4 +201,17 @@ export class DeviceProfileDto {
   @IsBoolean()
   @IsOptional()
   useTsOnSingleAudio?: boolean;
+
+  /**
+   * Client can switch HLS variants at runtime (real ABR). `false` means the
+   * client picks one variant when it opens the master and never switches
+   * again (e.g. embedded mpv), so the backend must hand it a single-variant
+   * master instead of the full ladder — otherwise its HLS demuxer touches
+   * every variant playlist at open and each touch (a different `quality`)
+   * kills + respawns ffmpeg for the last one touched. Unset is treated as
+   * `true` for backward compatibility.
+   */
+  @IsBoolean()
+  @IsOptional()
+  supportsAbr?: boolean;
 }

--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -93,6 +93,10 @@ export interface LiveSession {
    *  the resume segment and never request seg-0 — false skips the companion.
    *  Sourced from the device profile. */
   probesSegZero: boolean;
+  /** Client can switch HLS variants at runtime (real ABR). `false` (e.g.
+   *  embedded mpv) collapses the master to a single variant instead of the
+   *  full ladder. Sourced from the device profile. */
+  supportsAbr: boolean;
   videoVariant: CodecVariant | null;
   tonemapping: boolean;
   transcodeReasons: TranscodeReason[];
@@ -147,6 +151,7 @@ export interface CreateLiveSessionInput {
   hdrLadder?: boolean;
   supportsHlsSubtitles?: boolean;
   probesSegZero?: boolean;
+  supportsAbr?: boolean;
   videoVariant?: CodecVariant | null;
   tonemapping?: boolean;
   transcodeReasons?: TranscodeReason[];
@@ -261,6 +266,9 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
       // keep the companion (a wasted seg-0 probe is harmless; a missing one
       // makes a seg-0-probing engine restart from scratch).
       probesSegZero: input.probesSegZero ?? true,
+      // Default true: an older client that doesn't send the field keeps
+      // today's full-ladder behaviour, same as a fresh capability flag.
+      supportsAbr: input.supportsAbr ?? true,
       videoVariant: input.videoVariant ?? null,
       tonemapping: input.tonemapping ?? false,
       transcodeReasons: input.transcodeReasons ?? [],

--- a/backend/src/modules/streaming/streaming.controller.spec.ts
+++ b/backend/src/modules/streaming/streaming.controller.spec.ts
@@ -144,6 +144,7 @@ describe('StreamingController.stopLiveSession', () => {
       hdrLadder: false,
       supportsHlsSubtitles: false,
       probesSegZero: true,
+      supportsAbr: true,
       videoVariant: null,
       tonemapping: false,
       transcodeReasons: [],

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -883,6 +883,7 @@ export class StreamingController {
       hdrLadder: useHdrLadder,
       supportsHlsSubtitles: !!deviceProfile.supportsHlsSubtitles,
       probesSegZero: deviceProfile.probesSegZero,
+      supportsAbr: deviceProfile.supportsAbr,
       videoVariant,
       tonemapping: response.tonemapping,
       transcodeReasons: response.transcodeReasons,
@@ -1083,6 +1084,10 @@ export class StreamingController {
       deviceParam === 'mobile' || deviceParam === 'desktop'
         ? deviceParam
         : (live?.deviceType ?? 'desktop');
+    // Client-side ABR capability, frozen on the session at playback-info. No
+    // live session (legacy URL / stale sid) defaults to true — the existing
+    // full-ladder behaviour.
+    const supportsAbr = live?.supportsAbr ?? true;
     // Persist the master.m3u8 decisions back on the session so segment
     // requests stay coherent (especially for the URL-override device
     // and the audio layout that callers downstream gate on).
@@ -1144,6 +1149,7 @@ export class StreamingController {
       onlyQuality,
       defaultAudioIndex: pickedIdx ?? 0,
       deviceType,
+      supportsAbr,
       outputAudioCodec: masterAudioCodec,
       // Real output audio bitrate so the BANDWIDTH sum reflects the 640k
       // AC-3/E-AC-3 path, not the profile nominal; copy renditions fall back.

--- a/backend/src/modules/streaming/transcoding/master-playlist.spec.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.spec.ts
@@ -95,6 +95,38 @@ describe('generateMasterPlaylist — audio rendition CHANNELS', () => {
   });
 });
 
+describe('generateMasterPlaylist — supportsAbr collapses the ladder', () => {
+  const base = {
+    mediaFileId: 1,
+    sourceWidth: 1920,
+    sourceHeight: 1080,
+    tokenParam: '',
+  };
+
+  it('no onlyQuality + supportsAbr:false collapses to the single top-fitting rung', () => {
+    const m = generateMasterPlaylist({ ...base, supportsAbr: false });
+    expect(streamInfLines(m)).toHaveLength(1);
+    expect(m).toContain('/1080p/');
+  });
+
+  it('no onlyQuality + supportsAbr:true (or unset) keeps the full ladder unchanged', () => {
+    const withFlag = generateMasterPlaylist({ ...base, supportsAbr: true });
+    const withoutFlag = generateMasterPlaylist(base);
+    expect(streamInfLines(withFlag).length).toBeGreaterThan(1);
+    expect(withFlag).toEqual(withoutFlag);
+  });
+
+  it('an explicit onlyQuality still wins over supportsAbr:false', () => {
+    const m = generateMasterPlaylist({
+      ...base,
+      supportsAbr: false,
+      onlyQuality: '720p',
+    });
+    expect(streamInfLines(m)).toHaveLength(1);
+    expect(m).toContain('/720p/');
+  });
+});
+
 describe('generateMasterPlaylist — audio bitrate in BANDWIDTH', () => {
   const maxAvgBandwidth = (m: string): number =>
     Math.max(

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -27,25 +27,38 @@ function formatFrameRate(fps: number): string {
   return Number.isInteger(fps) ? String(fps) : fps.toFixed(3);
 }
 
-/** Apply the `onlyQuality` URL pin to a ladder. Used identically by
- *  the SDR and HDR branches: when the player has a saved quality
- *  preference (or an explicit dropdown pick), the master playlist
- *  emits a single-variant ladder so ExoPlayer's HLS source can't
- *  pre-load other variants — each unfocused variant playlist or
- *  init.mp4 fetch triggers a ffmpeg kill+respawn on the backend
- *  when the requested quality doesn't match the active session.
+/** The single profile a collapsed ladder falls back to: the highest rung
+ *  that fits the source resolution (no upscale), delegated to
+ *  {@link profileFitsSource} (bucket on both axes) so anamorphic or scope
+ *  crops (e.g. 1918×872) keep their 1080p top rung. */
+function topFittingProfile(
+  ladder: TranscodeProfile[],
+  sourceWidth: number,
+  sourceHeight: number,
+): TranscodeProfile {
+  return (
+    ladder.find((p) => profileFitsSource(p, sourceWidth, sourceHeight)) ??
+    ladder[0]
+  );
+}
+
+/** Collapse the ladder to a single variant when the client can't be trusted
+ *  to stay on one rung: an explicit `onlyQuality` URL pin (saved preference
+ *  / dropdown pick), or — with no pin — a device profile that declared
+ *  `supportsAbr: false` (the client picks one HLS variant when it opens the
+ *  master and never switches again, e.g. embedded mpv). A full ladder
+ *  handed to either makes the player's HLS demuxer touch every variant
+ *  playlist/init segment at open; each touch carries a different `quality`,
+ *  and since there's no per-rung session key, each fetch kills + respawns
+ *  ffmpeg for the last-touched rung — a self-sustaining restart storm. Used
+ *  identically by the SDR and HDR branches.
  *
- *  - `remux` / `original` collapse to the single top profile that fits
- *    the source resolution (no upscale), in both the SDR and HDR
- *    ladders — one variant so AVPlayer / ExoPlayer have no other rung
- *    to ABR-switch to and stay locked at the source quality. Fitting is
- *    delegated to {@link profileFitsSource} (bucket on both axes) so
- *    anamorphic or scope crops (e.g. 1918×872) keep their 1080p top
- *    rung — a strict `maxWidth <= sourceWidth` check sat one or two
- *    pixels short and dropped the user back to 720p.
+ *  - `remux` / `original`, or no pin with `supportsAbr: false`, collapse to
+ *    {@link topFittingProfile} in both the SDR and HDR ladders.
  *  - When `hdrSuffix` is true, an input `1080p` is matched against
  *    `1080p-hdr` (HDR ladder rungs carry the suffix); already
  *    `*-hdr` inputs pass through unchanged.
+ *  - An explicit `onlyQuality` always wins over `supportsAbr`.
  *  - Falls back to the full ladder when the pin doesn't match any
  *    rung (legacy URLs / typos). */
 function applyQualityPin(
@@ -54,13 +67,15 @@ function applyQualityPin(
   sourceWidth: number,
   sourceHeight: number,
   hdrSuffix = false,
+  supportsAbr = true,
 ): TranscodeProfile[] {
-  if (!onlyQuality) return ladder;
+  if (!onlyQuality) {
+    return supportsAbr
+      ? ladder
+      : [topFittingProfile(ladder, sourceWidth, sourceHeight)];
+  }
   if (onlyQuality === 'remux' || onlyQuality === 'original') {
-    const top =
-      ladder.find((p) => profileFitsSource(p, sourceWidth, sourceHeight)) ??
-      ladder[0];
-    return [top];
+    return [topFittingProfile(ladder, sourceWidth, sourceHeight)];
   }
   const wanted =
     hdrSuffix && !onlyQuality.endsWith('-hdr')
@@ -125,6 +140,11 @@ export interface MasterPlaylistOptions {
   /** Source video bitrate + codec; caps each rung's declared BANDWIDTH. */
   sourceVideoBitrateBps?: number;
   sourceVideoCodec?: string;
+  /** Client can switch HLS variants at runtime (real ABR). `false` collapses
+   *  the ladder to {@link topFittingProfile} when there's no explicit
+   *  `onlyQuality` pin — see {@link applyQualityPin}. Missing/undefined
+   *  defaults to `true` (existing full-ladder behaviour). */
+  supportsAbr?: boolean;
 }
 
 /** Generate the HLS master playlist listing available qualities. */
@@ -150,6 +170,7 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
     subtitleRenditions,
     sourceVideoBitrateBps,
     sourceVideoCodec,
+    supportsAbr = true,
   } = opts;
   // The "multi-audio" flag is really an "EXT-X-MEDIA layout" toggle —
   // the caller decided whether to split audio into renditions. Single-
@@ -245,6 +266,7 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
         sourceWidth,
         sourceHeight,
         /* hdrSuffix */ true,
+        supportsAbr,
       );
       emitVariantLadder(lines, {
         profiles: hdrLadder,
@@ -304,7 +326,14 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
   // master exposes a single variant — AVPlayer / ExoPlayer have no
   // other rung to ABR-switch to and playback stays locked at the
   // chosen quality.
-  profiles = applyQualityPin(profiles, onlyQuality, sourceWidth, sourceHeight);
+  profiles = applyQualityPin(
+    profiles,
+    onlyQuality,
+    sourceWidth,
+    sourceHeight,
+    /* hdrSuffix */ false,
+    supportsAbr,
+  );
 
   emitVariantLadder(lines, {
     profiles,

--- a/client/src/app/core/plugins/desktop-player.bridge.ts
+++ b/client/src/app/core/plugins/desktop-player.bridge.ts
@@ -23,7 +23,6 @@ export interface DesktopLoadOptions {
   url: string;
   startTime?: number;
   headers?: Record<string, string>;
-  subtitles?: { url: string; language: string; label: string; forced?: boolean }[];
   /** Preferred audio language (mpv `alang`) so the player keeps the chosen
    *  language across seeks/reloads instead of reverting to the manifest default. */
   audioLanguage?: string;

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -148,6 +148,12 @@ export interface DeviceProfile {
    *  False for Tizen AVPlay (HLS-only): the backend then never returns
    *  DirectPlay and falls back to DirectStream (remux to HLS). Unset = true. */
   supportsDirectPlay?: boolean;
+
+  /** Client can switch HLS variants at runtime (real ABR). `false` (e.g.
+   *  embedded mpv, which picks one variant when it opens the master and
+   *  never switches again) tells the backend to collapse the master to a
+   *  single variant instead of the full ladder. Unset = true. */
+  supportsAbr?: boolean;
 }
 
 /** True when `localStorage['fliks.useTs']` is set to a truthy value.
@@ -275,8 +281,8 @@ export class BrowserDeviceProfileService {
     // Q-series TVs.
     const isTv = this.device.isTv();
     const tvPlatform = this.device.tvPlatform();
-    // The four engine-behavioural flags below come from one declarative
-    // row keyed on the engine kind (platform + native split). Adding a
+    // The engine-behavioural flags below come from one declarative row
+    // keyed on the engine kind (platform + native split). Adding a
     // platform is a single row in `engine-traits.ts`.
     const traits =
       ENGINE_TRAITS[
@@ -548,6 +554,10 @@ export class BrowserDeviceProfileService {
       // falls back to DirectStream (remux to HLS, codec-copy). Every other
       // engine (Shaka, ExoPlayer/AVPlayer, webOS <video>) plays raw files.
       supportsDirectPlay: traits.supportsDirectPlay,
+      // `false` only for the desktop mpv engine (see engine-traits.ts): the
+      // backend then collapses the master to a single variant instead of
+      // handing a no-ABR client the full ladder.
+      supportsAbr: traits.supportsAbr,
     };
   }
 

--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -173,9 +173,10 @@ export class CastPlayerService {
       // back later without re-doing the plumbing.
       useTs: false,
       // The Cast receiver runs Shaka, which fetches seg-0 on a load-then-seek,
-      // so keep the backend's seg-0 early-start companion for resumes. The CAST
-      // row sets only `probesSegZero`, leaving useTsOnSingleAudio /
-      // supportsHlsSubtitles / supportsDirectPlay undefined on the wire.
+      // so keep the backend's seg-0 early-start companion for resumes, and it
+      // has real ABR (Shaka), so supportsAbr rides through as true. The CAST
+      // row leaves useTsOnSingleAudio / supportsHlsSubtitles /
+      // supportsDirectPlay undefined on the wire.
       ...ENGINE_TRAITS[EngineKind.CAST],
     };
   }

--- a/client/src/app/core/services/engine-traits.spec.ts
+++ b/client/src/app/core/services/engine-traits.spec.ts
@@ -10,6 +10,7 @@ const EXPECTED: Record<EngineKind, EngineTraits> = {
     supportsImageSubtitles: false,
     probesSegZero: true,
     supportsDirectPlay: true,
+    supportsAbr: true,
   },
   [EngineKind.NATIVE]: {
     useTsOnSingleAudio: false,
@@ -17,6 +18,7 @@ const EXPECTED: Record<EngineKind, EngineTraits> = {
     supportsImageSubtitles: true,
     probesSegZero: false,
     supportsDirectPlay: true,
+    supportsAbr: true,
   },
   [EngineKind.DESKTOP]: {
     useTsOnSingleAudio: false,
@@ -24,6 +26,7 @@ const EXPECTED: Record<EngineKind, EngineTraits> = {
     supportsImageSubtitles: true,
     probesSegZero: true,
     supportsDirectPlay: true,
+    supportsAbr: false,
   },
   [EngineKind.ANDROID_TV]: {
     useTsOnSingleAudio: false,
@@ -31,6 +34,7 @@ const EXPECTED: Record<EngineKind, EngineTraits> = {
     supportsImageSubtitles: true,
     probesSegZero: false,
     supportsDirectPlay: true,
+    supportsAbr: true,
   },
   [EngineKind.TIZEN]: {
     useTsOnSingleAudio: true,
@@ -38,6 +42,7 @@ const EXPECTED: Record<EngineKind, EngineTraits> = {
     supportsImageSubtitles: false,
     probesSegZero: false,
     supportsDirectPlay: false,
+    supportsAbr: true,
   },
   [EngineKind.WEBOS]: {
     useTsOnSingleAudio: false,
@@ -45,9 +50,11 @@ const EXPECTED: Record<EngineKind, EngineTraits> = {
     supportsImageSubtitles: false,
     probesSegZero: false,
     supportsDirectPlay: true,
+    supportsAbr: true,
   },
   [EngineKind.CAST]: {
     probesSegZero: true,
+    supportsAbr: true,
   },
 };
 

--- a/client/src/app/core/services/engine-traits.ts
+++ b/client/src/app/core/services/engine-traits.ts
@@ -45,16 +45,22 @@ export interface EngineTraits {
   probesSegZero?: boolean;
   /** Engine can play a raw progressive file as DirectPlay. */
   supportsDirectPlay?: boolean;
+  /** Engine has its own client-side ABR (bitrate-adaptive variant switching
+   *  mid-playback). Client-only — never sent to the backend, so it's a plain
+   *  required boolean rather than the wire-optional pattern above. */
+  supportsAbr: boolean;
 }
 
 /**
- * Single source of truth for the four engine traits, one row per `EngineKind`.
+ * Single source of truth for the four wire engine traits plus `supportsAbr`,
+ * one row per `EngineKind`.
  *
- * The CAST row sets only `probesSegZero` so the other three serialise as
- * `undefined` (absent from the payload), matching the hand-rolled Cast
- * profile. The TV-platform rows are always reached with `isNative === true`:
- * the only UA markers that set a non-null `tvPlatform` also match the
- * `isNative` regex, so no `isNative === false` TV row is reachable today.
+ * The CAST row sets `supportsAbr` (a local-only decision, never on the wire)
+ * plus `probesSegZero`, leaving the other three `undefined` (absent from the
+ * payload), matching the hand-rolled Cast profile. The TV-platform rows are
+ * always reached with `isNative === true`: the only UA markers that set a
+ * non-null `tvPlatform` also match the `isNative` regex, so no
+ * `isNative === false` TV row is reachable today.
  */
 export const ENGINE_TRAITS: Record<EngineKind, EngineTraits> = {
   [EngineKind.WEB]: {
@@ -63,6 +69,7 @@ export const ENGINE_TRAITS: Record<EngineKind, EngineTraits> = {
     supportsImageSubtitles: false,
     probesSegZero: true,
     supportsDirectPlay: true,
+    supportsAbr: true,
   },
   [EngineKind.NATIVE]: {
     useTsOnSingleAudio: false,
@@ -70,6 +77,7 @@ export const ENGINE_TRAITS: Record<EngineKind, EngineTraits> = {
     supportsImageSubtitles: true,
     probesSegZero: false,
     supportsDirectPlay: true,
+    supportsAbr: true,
   },
   // Embedded mpv: renders behind the UI like NATIVE, but its ffmpeg HLS
   // demuxer fetches seg-0 on load then seeks (like Shaka), so it needs the
@@ -81,12 +89,18 @@ export const ENGINE_TRAITS: Record<EngineKind, EngineTraits> = {
   // VTT, and mpv's ffmpeg HLS demuxer re-reads that segment on every seek
   // without clearing the prior cue set, so cues accumulate/stack. `sub-add`
   // parses the VTT once and seeks within it natively (like the browser).
+  //
+  // `supportsAbr: false` — mpv picks one HLS variant when it opens the master
+  // playlist (`--hls-bitrate=max`) and never re-evaluates it mid-playback, so
+  // the backend must be told a single rung via `startQuality` instead of the
+  // full ladder.
   [EngineKind.DESKTOP]: {
     useTsOnSingleAudio: false,
     supportsHlsSubtitles: false,
     supportsImageSubtitles: true,
     probesSegZero: true,
     supportsDirectPlay: true,
+    supportsAbr: false,
   },
   [EngineKind.ANDROID_TV]: {
     useTsOnSingleAudio: false,
@@ -94,6 +108,7 @@ export const ENGINE_TRAITS: Record<EngineKind, EngineTraits> = {
     supportsImageSubtitles: true,
     probesSegZero: false,
     supportsDirectPlay: true,
+    supportsAbr: true,
   },
   [EngineKind.TIZEN]: {
     useTsOnSingleAudio: true,
@@ -101,6 +116,7 @@ export const ENGINE_TRAITS: Record<EngineKind, EngineTraits> = {
     supportsImageSubtitles: false,
     probesSegZero: false,
     supportsDirectPlay: false,
+    supportsAbr: true,
   },
   [EngineKind.WEBOS]: {
     useTsOnSingleAudio: false,
@@ -108,9 +124,11 @@ export const ENGINE_TRAITS: Record<EngineKind, EngineTraits> = {
     supportsImageSubtitles: false,
     probesSegZero: false,
     supportsDirectPlay: true,
+    supportsAbr: true,
   },
   [EngineKind.CAST]: {
     probesSegZero: true,
+    supportsAbr: true,
   },
 };
 

--- a/client/src/app/core/services/playback-engine/desktop-engine.ts
+++ b/client/src/app/core/services/playback-engine/desktop-engine.ts
@@ -383,10 +383,15 @@ export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEng
         // mpv's generic message ("loading failed") plus the concrete cause it
         // logged (TLS verify, HTTP status, unsupported codec) so the error card
         // shows why, not just that.
-        this.emit('error', {
-          code,
-          message: detail ? `${message} — ${detail}` : message,
-        });
+        const composed = detail ? `${message} — ${detail}` : message;
+        // code 2 (MEDIA_ERR_NETWORK) is mpv's own TLS/libcurl transport
+        // classification; source:'media' routes it through the shared
+        // network/abort classifier instead of a decode-path label such as
+        // Dolby Vision.
+        this.emit(
+          'error',
+          code === 2 ? { code, message: composed, source: 'media' } : { code, message: composed },
+        );
         break;
       }
       default:

--- a/client/src/app/core/services/playback-engine/desktop-engine.ts
+++ b/client/src/app/core/services/playback-engine/desktop-engine.ts
@@ -299,19 +299,22 @@ export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEng
   }
 
   // ── Quality ──
-  // mpv handles ABR over the HLS master internally; the backend ladder already
-  // bounds the rungs, so variant pinning is a no-op here (kept for the
+  // mpv selects one HLS variant when it opens the master playlist and never
+  // switches mid-playback — there is no in-engine ABR to drive. The rung is
+  // pinned server-side via `startQuality` before load (player.ts
+  // resolveStartQuality), so variant pinning here is a no-op (kept for the
   // PlaybackEngine contract).
   getVariantTracks(): any[] {
     return [];
   }
   selectVariantTrack(_track: any, _clearBuffer?: boolean): void {
-    /* mpv-driven ABR */
+    /* no-op: mpv already opened its single pinned variant */
   }
   configure(config: any): void {
-    // ABR is mpv-driven; the only knob we honour is the preferred audio language,
-    // threaded to mpv as `alang` on the next load so it auto-selects the right
-    // rendition on every reconfig (mirrors the Shaka engine's preferredAudioLanguage).
+    // No ABR knob to honour (see above); the only one is the preferred audio
+    // language, threaded to mpv as `alang` on the next load so it auto-selects
+    // the right rendition on every reconfig (mirrors the Shaka engine's
+    // preferredAudioLanguage).
     if (config && typeof config.preferredAudioLanguage === 'string') {
       this._preferredAudioLanguage = config.preferredAudioLanguage || undefined;
     }

--- a/client/src/app/core/services/playback-engine/playback-error.ts
+++ b/client/src/app/core/services/playback-engine/playback-error.ts
@@ -1,3 +1,5 @@
+import { HttpErrorResponse } from '@angular/common/http';
+
 /**
  * Structured playback error surfaced on the player's error card.
  *
@@ -70,6 +72,21 @@ const MEDIA_ERROR_NAMES: Record<number, string> = {
   4: 'MEDIA_ERR_SRC_NOT_SUPPORTED',
 };
 
+/** Classify a caught init/reload error into the `{source, code}` pair the
+ *  error card keys off. An `HttpErrorResponse` (a failed playback-info /
+ *  session request) reports its transport status; an object carrying a
+ *  Shaka `category` is a Shaka error; anything else is an engine (mpv /
+ *  native) failure. One place for the guess, so an HTTP transport fault is
+ *  never mislabelled as an engine failure. */
+export function classifyPlaybackError(
+  e: unknown,
+): { source: PlaybackError['source']; code?: number } {
+  if (e instanceof HttpErrorResponse) return { source: 'session', code: e.status };
+  const obj = e as { category?: number; code?: number } | null | undefined;
+  if (obj?.category != null) return { source: 'shaka', code: obj.code };
+  return { source: 'engine', code: obj?.code };
+}
+
 /** i18n key for the human line, mapped from the error class. Falls back to
  *  the generic `player.playback_error`. */
 export function userMessageKeyFor(err: {
@@ -101,6 +118,9 @@ export function userMessageKeyFor(err: {
     if (err.code === 3016) return 'player.error_decode';
     if (err.code === 4032) return 'player.error_unsupported';
   }
+  // A playback-info/session request that failed transport-side (status 0 —
+  // no response reached the browser) reads the same as a media network error.
+  if (err.source === 'session' && err.code === 0) return 'player.error_network';
   return 'player.playback_error';
 }
 
@@ -114,6 +134,8 @@ export function isNetworkOrAbort(err: {
 }): boolean {
   if (err.source === 'media') return err.code === 1 || err.code === 2;
   if (err.source === 'shaka') return err.category === 1;
+  // A session request that never got a response (status 0) is the same class.
+  if (err.source === 'session') return err.code === 0;
   return false;
 }
 

--- a/client/src/app/core/services/quality-manager.service.spec.ts
+++ b/client/src/app/core/services/quality-manager.service.spec.ts
@@ -1,0 +1,23 @@
+import { highestRungId, type QualityOption } from './quality-manager.service';
+
+const opt = (id: string, height: number): QualityOption => ({ id, label: id, height });
+
+describe('highestRungId', () => {
+  it('picks the max-height rung, excluding auto', () => {
+    const opts = [opt('auto', 0), opt('480p', 480), opt('1080p', 1080), opt('2160p', 2160)];
+    expect(highestRungId(opts)).toBe('2160p');
+  });
+
+  it('is order-independent', () => {
+    const opts = [opt('1080p', 1080), opt('2160p', 2160), opt('auto', 0), opt('480p', 480)];
+    expect(highestRungId(opts)).toBe('2160p');
+  });
+
+  it('returns undefined for an empty list', () => {
+    expect(highestRungId([])).toBeUndefined();
+  });
+
+  it('returns undefined when only auto is present', () => {
+    expect(highestRungId([opt('auto', 0)])).toBeUndefined();
+  });
+});

--- a/client/src/app/core/services/quality-manager.service.ts
+++ b/client/src/app/core/services/quality-manager.service.ts
@@ -51,6 +51,16 @@ export function findBestVariantForHeight(tracks: any[], targetHeight: number): a
   return tracks.reduce((a: any, b: any) => ((a.height ?? 0) <= (b.height ?? 0) ? a : b));
 }
 
+/**
+ * Id of the highest-resolution rung in a quality list, excluding 'auto'.
+ * Undefined for an empty (or auto-only) list.
+ */
+export function highestRungId(options: QualityOption[]): string | undefined {
+  const rungs = options.filter((q) => q.id !== 'auto');
+  if (!rungs.length) return undefined;
+  return rungs.reduce((a, b) => (b.height > a.height ? b : a)).id;
+}
+
 @Injectable({ providedIn: 'root' })
 export class QualityManagerService {
   private readonly translate = inject(TranslateService);
@@ -108,6 +118,15 @@ export class QualityManagerService {
       visible = all.filter((q) => !q.lowBandwidth);
     }
     this.availableQualities.set(visible);
+  }
+
+  /** Id of the highest rung currently offered (excluding 'auto') — pins a
+   *  no-ABR engine (desktop mpv) to a single variant in 'auto' instead of
+   *  handing it the full backend ladder. The list is already device- and
+   *  source-aware (and eco-filtered by {@link buildQualityOptions}), so no
+   *  extra filtering here. */
+  topRungId(): string | undefined {
+    return highestRungId(this.availableQualities());
   }
 
   /** Default quality id for the current visible list: `auto` when present,

--- a/client/src/app/features/player/player.html
+++ b/client/src/app/features/player/player.html
@@ -66,15 +66,18 @@
             </summary>
             <pre class="mt-2 max-h-60 overflow-auto whitespace-pre-wrap break-words rounded bg-black/40 p-2 text-[11px] leading-snug text-white/70">{{ errorDiagnostics() }}</pre>
           </details>
-          <div class="mt-4 flex items-center justify-center gap-2">
+        }
+        <div class="mt-4 flex items-center justify-center gap-2">
+          @if (!videoStarted()) {
+            <button class="btn btn-ghost btn-sm" (click)="onRetry()">{{ 'common.retry' | translate }}</button>
+          }
+          @if (err.code != null || err.data?.length || err.variant || err.message) {
             <button class="btn btn-ghost btn-sm" (click)="copyErrorDiagnostics()">
               {{ (errorCopied() ? 'player.copied' : 'player.copy_diagnostics') | translate }}
             </button>
-            <button class="btn btn-ghost btn-sm" (click)="onBack()">{{ 'player.back' | translate }}</button>
-          </div>
-        } @else {
-          <button class="btn btn-ghost btn-sm mt-4" (click)="onBack()">{{ 'player.back' | translate }}</button>
-        }
+          }
+          <button class="btn btn-ghost btn-sm" (click)="onBack()">{{ 'player.back' | translate }}</button>
+        </div>
       </div>
     </div>
   }

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1006,8 +1006,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       // (instead of waiting for master.m3u8), overlapping encoder init with
       // the ~100–300ms gap before the player fetches the playlist.
       const deviceProfile = this.deviceProfileService.getProfile();
-      const savedQualityId = this.activeQualityId();
-      const prewarmQuality = savedQualityId !== 'auto' ? savedQualityId : undefined;
+      const prewarmQuality = this.resolveStartQuality();
       const prewarmStartAt = resumeTime;
       const playbackInfoPromise = this.isOfflinePlayback
         ? null
@@ -2304,9 +2303,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       // Re-negotiate the stream for the new file (DirectPlay vs the ladder).
       await this.authService.ensureStreamToken();
       const deviceProfile = this.deviceProfileService.getProfile();
-      const activeQuality = this.activeQualityId();
-      const requestedQuality =
-        activeQuality && activeQuality !== 'auto' ? activeQuality : undefined;
+      const requestedQuality = this.resolveStartQuality();
       this.playbackInfo = await this.streamingApi.getPlaybackInfo(
         this.mediaFileId,
         deviceProfile,
@@ -2714,6 +2711,20 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   }
 
   /**
+   * Resolve the `startQuality` wire value: the explicit rung id, or — only
+   * in 'auto' — the top rung when the active engine has no client-side ABR,
+   * so a no-ABR engine (desktop mpv) still gets pinned to a single variant
+   * instead of the full backend ladder. Single source for every
+   * playback-info / stream-url call site.
+   */
+  private resolveStartQuality(): string | undefined {
+    const active = this.activeQualityId();
+    if (active !== 'auto') return active;
+    const supportsAbr = this.deviceProfileService.getProfile().supportsAbr ?? true;
+    return supportsAbr ? undefined : this.qualityManager.topRungId();
+  }
+
+  /**
    * Compose the engine's stream URL for the current `playbackMode`.
    * Returns `{ url, mimeType }` — direct play needs the explicit
    * `video/mp4` content type for native + Tizen engines, HLS lets the
@@ -2734,8 +2745,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         mimeType: 'video/mp4',
       };
     } else {
-      const savedQualityId = this.activeQualityId();
-      const startQuality = savedQualityId !== 'auto' ? savedQualityId : undefined;
+      const startQuality = this.resolveStartQuality();
       built = {
         url: this.streamingApi.getHlsUrl(
           this.mediaFileId,
@@ -2763,70 +2773,74 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     opts: { preservePause: boolean; unmute: boolean },
   ): Promise<void> {
     if (!this.engine || !this.mediaFileId) return;
-    // Drop the prior sid before minting a new one, and await it: a stall
-    // recovery still has a live prior session, and the backend would otherwise
-    // treat the re-mint as a concurrent sibling and split it onto a cold job.
-    const prevSid = this.playbackInfo?.sessionId;
-    if (prevSid) {
-      await this.streamingApi
-        .stopSessions(this.mediaFileId, prevSid)
-        .catch(() => {});
-    }
-    if (opts.unmute) this.engine.muted = false;
-    const wasPaused = opts.preservePause ? this.paused() : false;
-    const deviceProfile = this.deviceProfileService.getProfile();
-    // Pass the active rung as startQuality so the backend prewarms ffmpeg at
-    // the resume position — main session at -ss pos plus the bounded early
-    // session that absorbs Shaka's seg-0 VOD probe. Mirrors the initial load.
-    const activeQuality = this.activeQualityId();
-    const prewarmQuality = activeQuality !== 'auto' ? activeQuality : undefined;
-    this.playbackInfo = await this.streamingApi.getPlaybackInfo(
-      this.mediaFileId,
-      deviceProfile,
-      this.activeBurnInId ?? undefined,
-      this.activeAudioStreamIndex ?? undefined,
-      prewarmQuality,
-      pos > 0 ? Math.floor(pos) : undefined,
-    );
-    // Refresh the near-expiry stream token before rebuilding the play URL:
-    // it's baked into every segment URL and can't be swapped once the engine
-    // loads, so a token that lapsed mid-film would 401 every segment.
-    await this.authService.ensureStreamToken();
-    const { url, mimeType } = this.buildPlayUrl({
-      sid: this.playbackInfo.sessionId,
-    });
-    await this.engine.load(url, pos > 0 ? pos : undefined, mimeType);
-    this.qualityManager.applyQualityPreferenceAfterLoad(
-      this.engine,
-      this.playbackMode(),
-    );
-    // Shaka/webOS and the desktop mpv engine drop sidecar text tracks on a fresh
-    // load(), so a recovery reload silently loses the user's subtitle. Re-add +
-    // re-select the active soft subtitle. The Capacitor native players restore
-    // their own pick inside load(); burn-in is re-baked server-side via the
-    // activeBurnInId passed to playback-info above.
-    if (!this.isNativeEngine() || this.isDesktopNative) {
-      const activeId = this.activeSubtitleId();
-      const sub = activeId
-        ? this.availableSubtitles().find((s) => s.id === activeId)
-        : null;
-      if (sub && !sub.burnIn && sub.url) {
-        try {
-          const track = await this.engine.addTextTrack(
-            sub.url,
-            sub.language,
-            sub.label,
-            sub.forced,
-            this.subtitleOrdinal(sub),
-          );
-          this.engine.selectTextTrack(track);
-          this.engine.setTextVisibility(true);
-        } catch (e) {
-          console.error('[Player] re-apply subtitle after reload failed:', e);
+    this.state.buffering.set(true);
+    try {
+      // Drop the prior sid before minting a new one, and await it: a stall
+      // recovery still has a live prior session, and the backend would otherwise
+      // treat the re-mint as a concurrent sibling and split it onto a cold job.
+      const prevSid = this.playbackInfo?.sessionId;
+      if (prevSid) {
+        await this.streamingApi
+          .stopSessions(this.mediaFileId, prevSid)
+          .catch(() => {});
+      }
+      if (opts.unmute) this.engine.muted = false;
+      const wasPaused = opts.preservePause ? this.paused() : false;
+      const deviceProfile = this.deviceProfileService.getProfile();
+      // Pass the active rung as startQuality so the backend prewarms ffmpeg at
+      // the resume position — main session at -ss pos plus the bounded early
+      // session that absorbs Shaka's seg-0 VOD probe. Mirrors the initial load.
+      const prewarmQuality = this.resolveStartQuality();
+      this.playbackInfo = await this.streamingApi.getPlaybackInfo(
+        this.mediaFileId,
+        deviceProfile,
+        this.activeBurnInId ?? undefined,
+        this.activeAudioStreamIndex ?? undefined,
+        prewarmQuality,
+        pos > 0 ? Math.floor(pos) : undefined,
+      );
+      // Refresh the near-expiry stream token before rebuilding the play URL:
+      // it's baked into every segment URL and can't be swapped once the engine
+      // loads, so a token that lapsed mid-film would 401 every segment.
+      await this.authService.ensureStreamToken();
+      const { url, mimeType } = this.buildPlayUrl({
+        sid: this.playbackInfo.sessionId,
+      });
+      await this.engine.load(url, pos > 0 ? pos : undefined, mimeType);
+      this.qualityManager.applyQualityPreferenceAfterLoad(
+        this.engine,
+        this.playbackMode(),
+      );
+      // Shaka/webOS and the desktop mpv engine drop sidecar text tracks on a fresh
+      // load(), so a recovery reload silently loses the user's subtitle. Re-add +
+      // re-select the active soft subtitle. The Capacitor native players restore
+      // their own pick inside load(); burn-in is re-baked server-side via the
+      // activeBurnInId passed to playback-info above.
+      if (!this.isNativeEngine() || this.isDesktopNative) {
+        const activeId = this.activeSubtitleId();
+        const sub = activeId
+          ? this.availableSubtitles().find((s) => s.id === activeId)
+          : null;
+        if (sub && !sub.burnIn && sub.url) {
+          try {
+            const track = await this.engine.addTextTrack(
+              sub.url,
+              sub.language,
+              sub.label,
+              sub.forced,
+              this.subtitleOrdinal(sub),
+            );
+            this.engine.selectTextTrack(track);
+            this.engine.setTextVisibility(true);
+          } catch (e) {
+            console.error('[Player] re-apply subtitle after reload failed:', e);
+          }
         }
       }
+      this.restorePlayState(wasPaused);
+    } finally {
+      this.state.buffering.set(false);
     }
-    this.restorePlayState(wasPaused);
   }
 
   /**
@@ -3835,73 +3849,82 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
   private async doReloadStream() {
     if (!this.engine) return;
-    const currentPos = this.engine.currentTime;
-    // Capture the user's play/pause intent before tearing the stream down — a
-    // quality / audio / subtitle switch must not resume a paused player.
-    const wasPaused = this.paused();
+    this.state.buffering.set(true);
+    try {
+      // A locked seekbar holds a target the engine hasn't converged on yet, so
+      // anchor the reload there rather than at the engine's pre-seek position —
+      // otherwise a switch made mid-seek restarts the stream where the user
+      // just left, and the bar keeps showing the target it will never reach.
+      const currentPos = this.state.seekLocked()
+        ? this.currentTime()
+        : this.engine.currentTime;
+      // Capture the user's play/pause intent before tearing the stream down — a
+      // quality / audio / subtitle switch must not resume a paused player.
+      const wasPaused = this.paused();
 
-    // Remember active subtitle so we can restore it after reload
-    const activeSub = this.activeSubtitleId()
-      ? this.availableSubtitles().find(s => s.id === this.activeSubtitleId())
-      : null;
+      // Remember active subtitle so we can restore it after reload
+      const activeSub = this.activeSubtitleId()
+        ? this.availableSubtitles().find(s => s.id === this.activeSubtitleId())
+        : null;
 
-    // Native: stop the player before reload to avoid freeze
-    if (this.isNativeEngine()) {
-      await NativePlayer.stop().catch(() => {});
-    }
+      // Native: stop the player before reload to avoid freeze
+      if (this.isNativeEngine()) {
+        await NativePlayer.stop().catch(() => {});
+      }
 
-    // Stop only this device's session — multi-device viewers on the
-    // same file with a different profile should stay alive.
-    await this.streamingApi
-      .stopSessions(this.mediaFileId, this.playbackInfo?.sessionId)
-      .catch(() => {});
+      // Stop only this device's session — multi-device viewers on the
+      // same file with a different profile should stay alive.
+      await this.streamingApi
+        .stopSessions(this.mediaFileId, this.playbackInfo?.sessionId)
+        .catch(() => {});
 
-    const deviceProfile = this.deviceProfileService.getProfile();
-    // Pass the requested rung so the backend re-decides DirectPlay vs the
-    // transcode ladder: a rung below source forces the ladder, 'auto' lets the
-    // server apply its autoQualityMode.
-    const activeQuality = this.activeQualityId();
-    const requestedQuality =
-      activeQuality && activeQuality !== 'auto' ? activeQuality : undefined;
-    this.playbackInfo = await this.streamingApi.getPlaybackInfo(
-      this.mediaFileId,
-      deviceProfile,
-      this.activeBurnInId ?? undefined,
-      this.activeAudioStreamIndex,
-      requestedQuality,
-    );
-    const pi = this.playbackInfo;
-    this.introMarker.set(pi.markers?.intro ?? null);
+      const deviceProfile = this.deviceProfileService.getProfile();
+      // Pass the requested rung so the backend re-decides DirectPlay vs the
+      // transcode ladder: a rung below source forces the ladder, 'auto' lets the
+      // server apply its autoQualityMode.
+      const requestedQuality = this.resolveStartQuality();
+      this.playbackInfo = await this.streamingApi.getPlaybackInfo(
+        this.mediaFileId,
+        deviceProfile,
+        this.activeBurnInId ?? undefined,
+        this.activeAudioStreamIndex,
+        requestedQuality,
+      );
+      const pi = this.playbackInfo;
+      this.introMarker.set(pi.markers?.intro ?? null);
 
-    if (pi.playMethod === 'DirectPlay') {
-      this.state.playbackMode.set('direct');
-    } else if (pi.playMethod === 'DirectStream') {
-      this.state.playbackMode.set('remux');
-    } else {
-      this.state.playbackMode.set('transcode');
-    }
-    this.state.hwAccel.set(pi.hwAccel);
-    this.qualityManager.buildQualityOptions(pi);
+      if (pi.playMethod === 'DirectPlay') {
+        this.state.playbackMode.set('direct');
+      } else if (pi.playMethod === 'DirectStream') {
+        this.state.playbackMode.set('remux');
+      } else {
+        this.state.playbackMode.set('transcode');
+      }
+      this.state.hwAccel.set(pi.hwAccel);
+      this.qualityManager.buildQualityOptions(pi);
 
-    const mode = this.playbackMode();
-    // Refresh the near-expiry stream token before rebuilding the play URL:
-    // it's baked into every segment URL and can't be swapped once the engine
-    // loads, so a token that lapsed mid-film would 401 every segment.
-    await this.authService.ensureStreamToken();
-    const { url, mimeType } = this.buildPlayUrl({ startTime: currentPos });
-    await this.engine.load(url, currentPos, mimeType);
-    this.reloadReachedPlayback = true;
+      const mode = this.playbackMode();
+      // Refresh the near-expiry stream token before rebuilding the play URL:
+      // it's baked into every segment URL and can't be swapped once the engine
+      // loads, so a token that lapsed mid-film would 401 every segment.
+      await this.authService.ensureStreamToken();
+      const { url, mimeType } = this.buildPlayUrl({ startTime: currentPos });
+      await this.engine.load(url, currentPos, mimeType);
+      this.reloadReachedPlayback = true;
 
-    this.qualityManager.applyQualityPreferenceAfterLoad(this.engine, mode);
-    this.restorePlayState(wasPaused);
+      this.qualityManager.applyQualityPreferenceAfterLoad(this.engine, mode);
+      this.restorePlayState(wasPaused);
 
-    // Restore active subtitle (non burn-in) after Shaka reload
-    if (activeSub && !activeSub.burnIn && activeSub.url) {
-      try {
-        const track = await this.engine.addTextTrack(activeSub.url, activeSub.language, activeSub.label, activeSub.forced);
-        this.engine.selectTextTrack(track);
-        this.engine.setTextVisibility(true);
-      } catch {}
+      // Restore active subtitle (non burn-in) after Shaka reload
+      if (activeSub && !activeSub.burnIn && activeSub.url) {
+        try {
+          const track = await this.engine.addTextTrack(activeSub.url, activeSub.language, activeSub.label, activeSub.forced);
+          this.engine.selectTextTrack(track);
+          this.engine.setTextVisibility(true);
+        } catch {}
+      }
+    } finally {
+      this.state.buffering.set(false);
     }
   }
 

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -41,7 +41,7 @@ import { NavbarService } from '../../core/services/navbar.service';
 import { PlaybackQueueService, QueueItem } from '../../core/services/playback-queue.service';
 import { resolvePlayableFile } from '../../shared/utils/media-play.util';
 import { audioChannelsLabel, formatAudioLabel, formatAudioParts, parseAudioIndex, SpriteMetadata, widthForProfile } from '../../core/utils/player.utils';
-import { formatErrorDiagnostics, userMessageKeyFor } from '../../core/services/playback-engine/playback-error';
+import { classifyPlaybackError, formatErrorDiagnostics, userMessageKeyFor } from '../../core/services/playback-engine/playback-error';
 import { environment } from '../../../environments/environment';
 import {
   PlayerSettingsService, normalizeLang,
@@ -1411,27 +1411,26 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     } catch (e: any) {
       console.error('[Player] Init error:', e?.code, e?.category, e?.data, e);
       const msg = e?.message ?? String(e);
-      // Shaka-shaped init errors carry code/category — map to a category
-      // message and keep the raw fields for the diagnostics block.
-      const isShaka = e?.category != null;
-      this.state.setError(
-        this.translate.instant(
-          userMessageKeyFor({
-            source: isShaka ? 'shaka' : 'engine',
-            code: e?.code,
-            category: e?.category,
-            dolbyVision: this.isDolbyVisionPassthrough(),
-          }),
-        ),
-        {
-          source: isShaka ? 'shaka' : 'engine',
-          code: e?.code,
+      // Classify the caught error (HttpErrorResponse = a failed playback-info
+      // request, an object with a Shaka category, or an engine failure) so a
+      // transport fault is never mislabelled as an mpv/engine error.
+      const { source, code } = classifyPlaybackError(e);
+      const userMessage = this.translate.instant(
+        userMessageKeyFor({
+          source,
+          code,
           category: e?.category,
-          severity: e?.severity,
-          data: e?.data,
-          message: msg,
-        },
+          dolbyVision: this.isDolbyVisionPassthrough(),
+        }),
       );
+      this.state.setError(userMessage, {
+        source,
+        code,
+        category: e?.category,
+        severity: e?.severity,
+        data: e?.data,
+        message: msg,
+      });
       // TV / Tizen engine path: the AVPlay <object> + the hidden <video>
       // both stay parked on top of the error overlay if the engine dies
       // during load(). Force the player UI back into a visible-DOM state
@@ -1454,7 +1453,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       // by the always-mounted <app-toast-container>, so it survives even
       // when the player-container itself isn't laying out correctly.
       try {
-        this.toast.error(msg.slice(0, 240));
+        this.toast.error(userMessage);
       } catch {
         /* toast service may not be ready during early init — ignore */
       }
@@ -2254,6 +2253,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       // Surface the loading backdrop (set to the new episode's still below)
       // over the outgoing frame and rewind the playhead UI to the start.
       this.state.reset();
+      // Drop the outgoing episode's negotiated info so a failure before the
+      // new getPlaybackInfo resolves reports no playMethod/hwAccel rather
+      // than the previous episode's stale values.
+      this.playbackInfo = null;
 
       // Native engines must be stopped before a fresh load to avoid a freeze;
       // release the outgoing file's session (other devices on it stay alive).
@@ -2356,21 +2359,22 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       this.controlsVisible.set(true);
     } catch (e: any) {
       // Map to a translated line (Shaka-shaped errors keep their category
-      // message) and keep the raw engine/exception text in the diagnostics
-      // `message` field only — the card body never shows an untranslated string.
-      const isShaka = e?.category != null;
+      // message, a failed playback-info request its transport status) and
+      // keep the raw engine/exception text in the diagnostics `message`
+      // field only — the card body never shows an untranslated string.
+      const { source, code } = classifyPlaybackError(e);
       this.state.setError(
         this.translate.instant(
           userMessageKeyFor({
-            source: isShaka ? 'shaka' : 'engine',
-            code: e?.code,
+            source,
+            code,
             category: e?.category,
             dolbyVision: this.isDolbyVisionPassthrough(),
           }),
         ),
         {
-          source: isShaka ? 'shaka' : 'engine',
-          code: e?.code,
+          source,
+          code,
           category: e?.category,
           data: e?.data,
           message: e?.message ?? String(e),
@@ -2895,10 +2899,14 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   errorDiagnostics(): string {
     const err = this.state.error();
     if (!err) return '';
+    // playbackMode/hwAccel are only meaningful once a negotiation has
+    // actually resolved — otherwise they still hold the previous title's
+    // values (state.reset() doesn't clear them) and would misreport a
+    // pre-negotiation failure as a negotiated DirectPlay.
     const dump = formatErrorDiagnostics(err, {
       currentTime: this.state.currentTime(),
-      mode: this.state.playbackMode(),
-      hwAccel: this.state.hwAccel(),
+      mode: this.playbackInfo ? this.state.playbackMode() : undefined,
+      hwAccel: this.playbackInfo ? this.state.hwAccel() : undefined,
       engine: this.engineLabel(),
       url: this.lastStreamUrl,
       title: this.diagnosticsTitle(),
@@ -3052,9 +3060,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       // still veiled) or a stale overlay with no way out.
       this.state.setRecovering(false);
       if (!this.state.error()) {
-        this.state.setError(this.translate.instant('player.playback_error'), {
-          source: 'session',
-        });
+        this.state.setError(
+          this.translate.instant(userMessageKeyFor({ source: 'session' })),
+          { source: 'session' },
+        );
       }
       return;
     }
@@ -3089,12 +3098,14 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       // then immediately re-fails keeps counting toward the cap.
       this.recoverConfirmPending = true;
       this.recoverConfirmAt = Date.now();
-    } catch {
+    } catch (e) {
       if (this.recoverAttempts >= this.maxRecoverAttempts) {
         this.state.setRecovering(false);
-        this.state.setError(this.translate.instant('player.playback_error'), {
-          source: 'session',
-        });
+        const { source, code } = classifyPlaybackError(e);
+        this.state.setError(
+          this.translate.instant(userMessageKeyFor({ source, code })),
+          { source, code, message: (e as any)?.message ?? String(e) },
+        );
       } else {
         // Hold the recovering veil up across the backoff so the user sees a
         // reconnect, not a flash of the fatal overlay between attempts.
@@ -3121,12 +3132,14 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         preservePause: false,
         unmute: true,
       });
-    } catch {
+    } catch (e) {
       // No retry path after a Cast disconnect — surface a terminal error
       // instead of leaving the local player silently dead.
-      this.state.setError(this.translate.instant('player.playback_error'), {
-        source: 'session',
-      });
+      const { source, code } = classifyPlaybackError(e);
+      this.state.setError(
+        this.translate.instant(userMessageKeyFor({ source, code })),
+        { source, code, message: (e as any)?.message ?? String(e) },
+      );
     }
   }
 
@@ -3209,6 +3222,16 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       return;
     }
     void this.router.navigateByUrl(target, { replaceUrl: true });
+  }
+
+  /** Retry a cold-open failure (playback never started). */
+  onRetry() {
+    // ponytail: route bounce instead of extracting initPlayback(); extract it if the flicker shows.
+    this.state.error.set(null);
+    const target = this.router.url;
+    void this.router
+      .navigateByUrl('/', { skipLocationChange: true })
+      .then(() => this.router.navigateByUrl(target, { replaceUrl: true }));
   }
 
   onOpenMedia() {
@@ -3784,26 +3807,25 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     try {
       await this.doReloadStream();
     } catch (e) {
-      // Only the mobile ExoPlayer/AVPlayer engine is torn down before
-      // re-negotiating (NativePlayer.stop()), so a transient failure there
-      // (playback-info / engine.load) leaves a dead surface with the stall
-      // watchdog quiesced — surface a terminal card so the user has a way out.
-      // Every other engine keeps its previous source playing from buffer and
-      // self-heals via the 410 -> sessionExpired recovery (Shaka/webOS, and the
-      // desktop-mpv / Tizen surfaces, whose Capacitor stop is a no-op), and a
-      // throw after load() means video is already playing — none should card.
+      // Mobile Capacitor tears its surface down before re-negotiating, and
+      // desktop mpv's negotiation failure otherwise never reaches the user —
+      // both need a terminal card. Tizen/Shaka/webOS keep their previous
+      // source playing from buffer and self-heal via the 410 -> sessionExpired
+      // recovery, and a throw after load() means video is already playing —
+      // none of those three should card.
       console.error('[Player] reloadStream failed:', e);
       if (
         this.isNativeEngine() &&
-        !this.isDesktopNative &&
         !this.isTizenEngine() &&
         !this.reloadReachedPlayback &&
         !this.destroyed &&
         !this.state.error()
       ) {
-        this.state.setError(this.translate.instant('player.playback_error'), {
-          source: 'session',
-        });
+        const { source, code } = classifyPlaybackError(e);
+        this.state.setError(
+          this.translate.instant(userMessageKeyFor({ source, code })),
+          { source, code, message: (e as any)?.message ?? String(e) },
+        );
       }
       throw e;
     } finally {

--- a/desktop/src/main/cors.ts
+++ b/desktop/src/main/cors.ts
@@ -1,5 +1,6 @@
 import { session } from 'electron';
 import { APP_SCHEME } from './protocol';
+import { appendLog, redactQuery } from './log-file';
 
 const APP_ORIGIN = `${APP_SCHEME}://app`;
 
@@ -13,7 +14,8 @@ const APP_ORIGIN = `${APP_SCHEME}://app`;
  * No backend change required.
  */
 export function installCorsBypass(): void {
-  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+  const { webRequest } = session.defaultSession;
+  webRequest.onHeadersReceived((details, callback) => {
     const headers = details.responseHeaders ?? {};
     // Drop any existing (case-variant) CORS headers before setting ours.
     for (const key of Object.keys(headers)) {
@@ -25,5 +27,20 @@ export function installCorsBypass(): void {
     headers['Access-Control-Allow-Origin'] = [APP_ORIGIN];
     headers['Access-Control-Allow-Credentials'] = ['true'];
     callback({ responseHeaders: headers });
+  });
+
+  // A renderer network failure only ever surfaces as a bare `status 0` — this
+  // is the one place the underlying ERR_* (reset / TLS / network-changed) is
+  // available at all.
+  webRequest.onErrorOccurred((details) => {
+    appendLog(`[net] ${details.method} ${redactQuery(details.url)} ${details.error}`);
+  });
+
+  // Ranks the CORS-preflight hypothesis for a failed /api/ call: an OPTIONS
+  // that never resolves, or resolves without the right headers, precedes it.
+  webRequest.onCompleted((details) => {
+    if (details.method === 'OPTIONS' && details.url.includes('/api/')) {
+      appendLog(`[net] OPTIONS ${redactQuery(details.url)} -> ${details.statusCode}`);
+    }
   });
 }

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -6,6 +6,7 @@ import { execFileSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { registerAppSchemePrivileged, registerAppProtocol, APP_URL } from './protocol';
 import { installCorsBypass } from './cors';
+import { appendLog, redactQuery } from './log-file';
 import { setupUpdater } from './updater';
 import { registerDownloadIpc } from './download';
 import { setPlaybackKeepAwake, keepAwakeForState } from './power';
@@ -36,7 +37,10 @@ process.on('unhandledRejection', (e) => console.error('[main:unhandledRejection]
 // trust — Chromium would otherwise refuse the HTTPS connection. Accept cert
 // errors: the app only ever loads its own fliks:// UI and talks to the server
 // the user explicitly configured (same trust model as the mobile apps).
-app.on('certificate-error', (event, _wc, _url, _error, _cert, callback) => {
+app.on('certificate-error', (event, _wc, url, error, _cert, callback) => {
+  // Logged before the accept: if this fires for the media host, a "TLS
+  // failure" report has nothing to do with mpv's own verification at all.
+  appendLog(`[tls] ${redactQuery(url)} ${error}`);
   event.preventDefault();
   callback(true);
 });

--- a/desktop/src/main/log-file.ts
+++ b/desktop/src/main/log-file.ts
@@ -1,0 +1,39 @@
+import { app } from 'electron';
+import { appendFileSync, mkdirSync, statSync, truncateSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Above this, the file is truncated once at startup (no rotation). */
+const MAX_LOG_BYTES = 5 * 1024 * 1024;
+
+let truncated = false;
+
+function logPath(): string {
+  const dir = app.getPath('logs');
+  mkdirSync(dir, { recursive: true });
+  return join(dir, 'desktop.log');
+}
+
+/** Append one timestamped line to the desktop log file — the only retrievable
+ *  diagnostic on a packaged build (no console). */
+export function appendLog(line: string): void {
+  try {
+    const p = logPath();
+    if (!truncated) {
+      truncated = true;
+      try {
+        if (statSync(p).size > MAX_LOG_BYTES) truncateSync(p, 0);
+      } catch {
+        /* no existing file yet */
+      }
+    }
+    appendFileSync(p, `${new Date().toISOString()} ${line}\n`);
+  } catch {
+    // Logging must never break the caller.
+  }
+}
+
+/** Strips a URL's query string (tokens live there) before it's logged. */
+export function redactQuery(url: string): string {
+  const i = url.indexOf('?');
+  return i === -1 ? url : `${url.slice(0, i)}?<redacted>`;
+}

--- a/desktop/src/main/mpv/mpv-player.ts
+++ b/desktop/src/main/mpv/mpv-player.ts
@@ -83,6 +83,12 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
   private readonly pending = new Map<number, Pending>();
   private buf = '';
   private sawFirstFrame = false;
+  /** `playback-restart` seen for the current load — one of the two signals
+   *  {@link maybeEmitFirstFrame} waits on before emitting `firstFrame`. */
+  private sawPlaybackRestart = false;
+  /** mpv's `vo-configured` property last reported true for the current load —
+   *  the other signal {@link maybeEmitFirstFrame} waits on. */
+  private sawVoConfigured = false;
   /** One-shot per load: `--keep-open=yes` makes mpv pause on the last frame and
    *  set `eof-reached` instead of firing an `end-file`(eof) event, so the stream
    *  end is detected from that property. Guards against mpv re-sending the
@@ -285,10 +291,8 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
         // or belongs to the segment/seek that just succeeded.
         this.errorLog = [];
         this.sawTransportError = false;
-        if (!this.sawFirstFrame) {
-          this.sawFirstFrame = true;
-          this.emit('firstFrame');
-        }
+        this.sawPlaybackRestart = true;
+        this.maybeEmitFirstFrame();
         break;
       case 'end-file':
         if (msg.reason === 'eof') this.emit('stateChanged', { state: 'ended' });
@@ -303,12 +307,19 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
   private onProperty(name: string, data: unknown): void {
     switch (name) {
       case 'time-pos':
-        this.lastPosition = typeof data === 'number' ? data : 0;
+        // mpv sends null when idle/stopped — that means "no position", not
+        // "position zero", so leave lastPosition and the UI seekbar untouched.
+        if (typeof data !== 'number') break;
+        this.lastPosition = data;
         this.emit('timeUpdate', {
           position: this.lastPosition,
           duration: this.duration,
           buffered: this.cacheEnd,
         } satisfies DesktopPositionInfo);
+        break;
+      case 'vo-configured':
+        this.sawVoConfigured = !!data;
+        this.maybeEmitFirstFrame();
         break;
       case 'duration':
         this.duration = typeof data === 'number' ? data : 0;
@@ -358,6 +369,16 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
     }
   }
 
+  /** Emits `firstFrame` once for the current load, once mpv has both resumed
+   *  playback and configured a video output — either alone can fire before a
+   *  frame is actually on screen (e.g. an HLS variant reopen resumes playback
+   *  before the new VO configures). */
+  private maybeEmitFirstFrame(): void {
+    if (this.sawFirstFrame || !this.sawPlaybackRestart || !this.sawVoConfigured) return;
+    this.sawFirstFrame = true;
+    this.emit('firstFrame');
+  }
+
   /** Builds the shared `error` event payload from the buffered mpv log —
    *  the single place the three error-emitting sites read `errorLog` and
    *  `sawTransportError`, so the transport classification can't drift between
@@ -381,6 +402,7 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
       'paused-for-cache',
       'eof-reached',
       'track-list',
+      'vo-configured',
     ]) {
       await this.command(['observe_property', ++this.observeId, prop]);
     }
@@ -430,6 +452,8 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
 
   async load(opts: DesktopLoadOptions): Promise<void> {
     this.sawFirstFrame = false;
+    this.sawPlaybackRestart = false;
+    this.sawVoConfigured = false;
     this.sawEof = false;
     this.duration = 0;
     this.cacheEnd = 0;
@@ -508,8 +532,17 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
     return this.set('pause', true);
   }
 
-  seek(position: number): Promise<void> {
-    return this.command(['seek', position, 'absolute']).then(() => undefined);
+  async seek(position: number): Promise<void> {
+    // A load/stop that starts while this seek's IPC round-trip is in flight
+    // bumps loadGen — drop the stale seek instead of surfacing its failure
+    // (or racing the new load) once the round-trip settles.
+    const gen = this.loadGen;
+    try {
+      await this.command(['seek', position, 'absolute']);
+    } catch (e) {
+      if (gen !== this.loadGen) return;
+      throw e;
+    }
   }
 
   stop(): Promise<void> {
@@ -517,6 +550,8 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
     // Reset baselines so the persistent player can't replay a stale first-frame
     // / position into the next session after a back-navigation.
     this.sawFirstFrame = false;
+    this.sawPlaybackRestart = false;
+    this.sawVoConfigured = false;
     this.sawEof = false;
     this.duration = 0;
     this.cacheEnd = 0;

--- a/desktop/src/main/mpv/mpv-player.ts
+++ b/desktop/src/main/mpv/mpv-player.ts
@@ -102,11 +102,20 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
   /** Bumped by load/stop/destroy; a load with a stale id skips its remaining
    *  IPC writes, so a stop can't be overtaken by a trailing loadfile. */
   private loadGen = 0;
-  /** error/fatal mpv log lines seen since the current load began. mpv's
-   *  `end-file` error carries only the generic `MPV_ERROR_*` string ("loading
-   *  failed"); the real cause (TLS verify, HTTP status, unsupported codec) is in
-   *  these log lines, so we buffer them and attach them to the error event. */
+  /** error/fatal mpv log lines seen since the current playback attempt began.
+   *  Cleared on `load()`, on `stop()`, and on every successful `playback-restart`
+   *  so a resolved failure (a recovered 404, a failed sidecar sub-add) can't be
+   *  attached to a later, unrelated error. mpv's `end-file` error carries only
+   *  the generic `MPV_ERROR_*` string ("loading failed"); the real cause (TLS
+   *  verify, HTTP status, unsupported codec) is in these log lines, so we
+   *  buffer them and attach them to the error event. */
   private errorLog: string[] = [];
+  /** Set when a buffered error/fatal log line is mpv's own libcurl/TLS failure
+   *  signature — log prefix exactly `curl`/`tls`, or a "Failed to open"
+   *  message. Reset alongside `errorLog`. Deliberately strict: a bare `stream`
+   *  prefix or any other line must not set this, or a genuine decode failure
+   *  (e.g. Dolby Vision) would misreport as a transport fault. */
+  private sawTransportError = false;
 
   constructor(opts: MpvPlayerOptions) {
     super();
@@ -143,7 +152,7 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
       `--input-ipc-server=${this.sockPath}`,
     ];
     console.log('[mpv] spawn:', this.mpvPath, args.join(' '));
-    this.proc = spawn(this.mpvPath, args, { stdio: ['ignore', 'pipe', 'pipe'], env: this.env });
+    this.proc = spawn(this.mpvPath, args, { stdio: ['ignore', 'ignore', 'pipe'], env: this.env });
     this.proc.on('exit', (code, signal) => {
       this.emit('exit', { code, signal });
       this.rejectAllPending('mpv process exited');
@@ -212,11 +221,7 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
         this.sock = sock;
         sock.on('data', (chunk: Buffer) => this.onData(chunk));
         sock.on('error', (e) => {
-          this.emit('error', {
-            code: -1,
-            message: String(e),
-            detail: this.errorLog.join(' | ') || undefined,
-          });
+          this.emit('error', this.errorPayload(String(e)));
           this.rejectAllPending(`mpv socket error: ${e}`);
         });
         sock.on('close', () => {
@@ -264,11 +269,22 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
         if (msg.level === 'error' || msg.level === 'fatal') {
           this.errorLog.push(line);
           if (this.errorLog.length > MAX_ERROR_LOG_LINES) this.errorLog.shift();
+          if (
+            msg.prefix === 'curl' ||
+            msg.prefix === 'tls' ||
+            (msg.text ?? '').includes('Failed to open')
+          ) {
+            this.sawTransportError = true;
+          }
         }
         this.emit('log', `[${msg.level}] ${line}`);
         break;
       }
       case 'playback-restart':
+        // A frame is playing again: whatever errorLog held was either resolved
+        // or belongs to the segment/seek that just succeeded.
+        this.errorLog = [];
+        this.sawTransportError = false;
         if (!this.sawFirstFrame) {
           this.sawFirstFrame = true;
           this.emit('firstFrame');
@@ -277,11 +293,7 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
       case 'end-file':
         if (msg.reason === 'eof') this.emit('stateChanged', { state: 'ended' });
         else if (msg.reason === 'error')
-          this.emit('error', {
-            code: -1,
-            message: msg.file_error ?? 'end-file error',
-            detail: this.errorLog.join(' | ') || undefined,
-          });
+          this.emit('error', this.errorPayload(msg.file_error ?? 'end-file error'));
         break;
       default:
         break;
@@ -324,11 +336,7 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
               ? this.duration - this.lastPosition > PREMATURE_EOF_GAP_S
               : this.errorLog.length > 0;
           if (premature) {
-            this.emit('error', {
-              code: -1,
-              message: 'playback stopped before end of stream',
-              detail: this.errorLog.join(' | ') || undefined,
-            });
+            this.emit('error', this.errorPayload('playback stopped before end of stream'));
           } else {
             this.emit('stateChanged', { state: 'ended' });
           }
@@ -348,6 +356,20 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
       default:
         break;
     }
+  }
+
+  /** Builds the shared `error` event payload from the buffered mpv log —
+   *  the single place the three error-emitting sites read `errorLog` and
+   *  `sawTransportError`, so the transport classification can't drift between
+   *  them. `code` follows MediaError semantics: 2 (MEDIA_ERR_NETWORK) when
+   *  this attempt's buffered log matched mpv's own TLS/libcurl signature,
+   *  else -1 (no MediaError equivalent — decode/format/unknown). */
+  private errorPayload(message: string): { code: number; message: string; detail?: string } {
+    return {
+      code: this.sawTransportError ? 2 : -1,
+      message,
+      detail: this.errorLog.join(' | ') || undefined,
+    };
   }
 
   private async setupObservers(): Promise<void> {
@@ -413,6 +435,7 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
     this.cacheEnd = 0;
     this.lastPosition = 0;
     this.errorLog = [];
+    this.sawTransportError = false;
     const gen = ++this.loadGen;
     // Reset the reused player first so the new open's probe can't read atop the
     // previous file's buffered stream.
@@ -458,14 +481,6 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
       if (gen !== this.loadGen) return;
       await this.command(['set', 'demuxer-lavf-format', '']).catch(() => {});
     }
-    for (const s of opts.subtitles ?? []) {
-      if (gen !== this.loadGen) return;
-      // Best-effort: this runs after the video is playing, so an unreachable
-      // sidecar subtitle must not reject the load.
-      await this.command(['sub-add', s.url, 'auto', s.label ?? '', s.language ?? '']).catch((e) =>
-        this.emit('log', `[warn] sub-add failed ${s.url}: ${e}`),
-      );
-    }
   }
 
   /** Resolve once mpv has opened the media (first frame), or on error/timeout.
@@ -506,6 +521,8 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
     this.duration = 0;
     this.cacheEnd = 0;
     this.lastPosition = 0;
+    this.errorLog = [];
+    this.sawTransportError = false;
     return this.command(['stop']).then(() => undefined);
   }
 

--- a/desktop/src/main/window/player-session.ts
+++ b/desktop/src/main/window/player-session.ts
@@ -6,6 +6,7 @@ import { MacMpvPlayer, roundWindowBottomCorners } from '../mpv/mac-mpv-player';
 import type { PlayerBackend } from '../mpv/player-backend';
 import { createEmbedBackend } from './backends';
 import { setPlaybackKeepAwake, keepAwakeForState } from '../power';
+import { appendLog } from '../log-file';
 import { IPC, type DesktopEvent, type DesktopRect } from '../../shared/contract';
 
 /**
@@ -236,7 +237,12 @@ export class PlayerSession {
   }
 
   private forwardEvents(mpv: PlayerBackend): void {
-    mpv.on('log', (s: string) => process.stderr.write(`[${Date.now()}][mpv] ${s}`));
+    mpv.on('log', (s: string) => {
+      process.stderr.write(`[${Date.now()}][mpv] ${s}`);
+      // Only the failure levels reach the file: mpv's default `v` level logs
+      // every segment URL, and this write is synchronous on the main thread.
+      if (/^\[(error|fatal|warn)\]/.test(s)) appendLog(`[mpv] ${s.trimEnd()}`);
+    });
     mpv.on('exit', (e) => console.error('[mpv] process exit', JSON.stringify(e)));
     mpv.on('stateChanged', (p) => {
       console.log('[player] state:', p.state);

--- a/desktop/src/shared/contract.ts
+++ b/desktop/src/shared/contract.ts
@@ -22,7 +22,6 @@ export interface DesktopLoadOptions {
   url: string;
   startTime?: number;
   headers?: Record<string, string>;
-  subtitles?: { url: string; language: string; label: string; forced?: boolean }[];
   /** Preferred audio language (mpv `alang`). Applied as a file-local loadfile
    *  option so mpv auto-selects the matching audio rendition on the initial load
    *  AND on every mid-file reconfig — without a client round-trip. Neutralises
@@ -74,7 +73,15 @@ export type DesktopEvent =
       payload: { audioTracks: DesktopAudioTrack[]; subtitleTracks: DesktopSubtitleTrack[] };
     }
   | { type: 'firstFrame' }
-  | { type: 'error'; payload: { code: number; message: string; detail?: string } };
+  | {
+      type: 'error';
+      /** `code` follows MediaError semantics where applicable: 2
+       *  (MEDIA_ERR_NETWORK) marks a transport-level failure (mpv's own
+       *  TLS/libcurl signature — see `MpvPlayer.errorPayload`), so the client
+       *  classifies it as network/abort instead of blaming the decode path
+       *  (e.g. Dolby Vision). Any other value carries no MediaError meaning. */
+      payload: { code: number; message: string; detail?: string };
+    };
 
 /** renderer → main invoke channels. */
 export const IPC = {


### PR DESCRIPTION
## What

Four fixes on the Windows desktop player, found while chasing a black screen with no spinner on a 4K HDR10 title played with quality set to `auto`.

### The ffmpeg restart storm (`f904f20`)

The desktop client has no client-side ABR. mpv's `--hls-bitrate` picks an HLS variant when the master playlist is opened and never switches again ([mpv#15158](https://github.com/mpv-player/mpv/issues/15158)), while ffmpeg's HLS demuxer touches *every* variant playlist at open. With quality on `auto` the client sent no `startQuality`, so the master carried the full ladder (6 HDR rungs / 10 SDR) and each of those probe fetches arrived with a different `quality`. The transcode session key carries no rung, so every one of them killed and respawned ffmpeg for the previously touched rung — which then 404s its next segment, gets retried by mpv's `reconnect_on_http_error=4xx,5xx` (no attempt cap), and respawns again. Self-sustaining. On a 4K HDR10 title, where the first segment already takes tens of seconds, no rung ever produced one.

Clients now declare `supportsAbr` in the device profile. It is frozen on the live session at playback-info and collapses the master to a single variant when `false`; unset stays `true`, so existing clients keep the full ladder. The mechanism reuses the existing `applyQualityPin` collapse rather than adding a second path.

### Why it was silent instead of loud

Two independent gaps:

- `firstFrame` was emitted on mpv's `playback-restart`, which means the playback loop resumed — not that a frame reached the screen. That flipped `videoStarted`, removing the backdrop, the spinner *and* the controls over a black window. It now also waits for `vo-configured`, with the existing 10s timeout kept as an escape hatch.
- Neither reload path raised any veil, unlike the audio switch right beside them. Both now bracket the reload with `buffering` in a `try/finally`.

### The timeline desync

mpv reports `time-pos` as `null` while stopped, which was coerced to `0` and forwarded to the seekbar. That made the bar drop to 00:00, made a reload anchored on the engine position restart the film from the beginning, and made far-seek detection fire on almost any seek near a reload. A `null` `time-pos` is now ignored, and a reload issued while the seekbar is locked anchors on the user's target instead of the pre-seek position.

### Already on the branch

`f92f360c` classifies failed session requests instead of blaming the engine, `e6fb17c4` distinguishes mpv transport failures from decode failures, `d6d327ac` pins the vendored Windows mpv build.

## Deliberately not addressed

All pre-existing, none introduced here:

- **No ABR on desktop.** mpv has none natively and cannot switch variants mid-playback, so a real ABR would mean a stream reload per switch. Decided against.
- **The unbounded recovery loop.** `checkStall` re-zeroes `recoverAttempts` on any playhead movement, so the 3-attempt cap never bites. This fix removes the trigger, not the broken guard.
- **`reconnect_on_http_error=4xx,5xx` with no attempt cap** turns a 401 or 410 into an infinite retry rather than a fast error.
- **`supportsHdr` is derived from `matchMedia('(dynamic-range: high)')`** while Windows can only SDR-tonemap, so the client asks for the most expensive encode and then discards the HDR. This is the remaining suspect for slow 4K HDR startup.

## Verification

- `tsc --noEmit` clean on client and backend, exit code checked explicitly.
- Desktop main/preload bundle builds.
- 447 backend streaming tests pass, including 10 in `master-playlist.spec.ts` with new cases: no pin + no ABR emits exactly one `EXT-X-STREAM-INF`; no pin + ABR leaves the ladder byte-identical; an explicit `startQuality` still wins over the flag.
- New `quality-manager.service.spec.ts` covers top-rung resolution.
- CI green on both the Docker image and the desktop installers (Linux/macOS/Windows).

⚠️ **Not yet validated on a Windows device.** Deploying this requires a transcode cache purge — the ladder emitted in the master changes.
