### PR TITLE
fix(indexers): escalate the failure backoff once per elapsed window

### DIFF
--- a/backend/src/modules/indexers/indexer-throttle.service.spec.ts
+++ b/backend/src/modules/indexers/indexer-throttle.service.spec.ts
@@ -18,13 +18,29 @@ describe('IndexerThrottle cooldown gate', () => {
     expect(t.cooldownRemainingMs(1)).toBeLessThanOrEqual(30_000);
   });
 
-  it('extends the window on consecutive failures', () => {
+  it('escalates once the open window has elapsed', () => {
+    jest.useFakeTimers();
+    try {
+      const t = new IndexerThrottle();
+      t.notifyFailure(indexer());
+      jest.advanceTimersByTime(30_000);
+      t.notifyFailure(indexer());
+      // Second failure after the 30s window escalates to 2min.
+      expect(t.cooldownRemainingMs(1)).toBeGreaterThan(30_000);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not escalate on failures inside the open window', () => {
     const t = new IndexerThrottle();
     t.notifyFailure(indexer());
     const afterOne = t.cooldownRemainingMs(1);
+    // A network-wide outage fails every queued request; escalating on each
+    // would burn the whole ladder to the 6h cap within seconds.
     t.notifyFailure(indexer());
-    // Second failure escalates 30s -> 2min.
-    expect(t.cooldownRemainingMs(1)).toBeGreaterThan(afterOne);
+    t.notifyFailure(indexer());
+    expect(t.cooldownRemainingMs(1)).toBeLessThanOrEqual(afterOne);
   });
 
   it('clears the cooldown on confirmed success', () => {

--- a/backend/src/modules/indexers/indexer-throttle.service.ts
+++ b/backend/src/modules/indexers/indexer-throttle.service.ts
@@ -18,7 +18,8 @@ import { Indexer } from './entities/indexer.entity';
  *      subsequent calls block until the window elapses; this overrides
  *      `requestDelay` upward, never downward.
  *   4. Progressive cooldown on consecutive failures — 30s → 2min →
- *      15min → 1h → 6h. Resets on success.
+ *      15min → 1h → 6h, at most one step per elapsed window. Resets on
+ *      success.
  */
 @Injectable()
 export class IndexerThrottle {
@@ -82,9 +83,13 @@ export class IndexerThrottle {
     );
   }
 
-  /** Caller signals a transport-level failure (network error, 5xx,
-   *  429 even after Retry-After). Drives progressive cooldown. */
+  /** Caller signals a transport-level failure (network error, 5xx, 429 even
+   *  after Retry-After). Escalates one step per elapsed window: failures
+   *  arriving inside an open cooldown belong to the outage that opened it, so
+   *  the ladder tracks how long an indexer has been broken rather than how
+   *  many requests hit it. */
   notifyFailure(indexer: Indexer): void {
+    if (this.cooldownRemainingMs(indexer.id) > 0) return;
     const n = (this.failureCount.get(indexer.id) ?? 0) + 1;
     this.failureCount.set(indexer.id, n);
     const cooldownMs = backoffFor(n);

--- a/backend/src/modules/indexers/torznab.service.ts
+++ b/backend/src/modules/indexers/torznab.service.ts
@@ -178,7 +178,7 @@ export class TorznabService {
       }
     }
     if (skipped.length) {
-      this.log.warn(
+      this.log.debug?.(
         `skipping ${skipped.length} indexer(s) in cooldown: ${skipped.join(', ')}`,
       );
     }

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -72,6 +72,11 @@ const ORPHAN_STATUS_MESSAGE = 'Torrent no longer present in download client';
 export class CompletionService {
   private readonly log = new Logger(CompletionService.name);
 
+  /** Torrent hashes the auto-matcher could not resolve on the previous tick.
+   *  Rebuilt wholesale each run, so it stays bounded by the client's current
+   *  torrent count and drops a hash as soon as the torrent leaves the client. */
+  private unidentifiedHashes = new Set<string>();
+
   constructor(
     private readonly dataSource: DataSource,
     @InjectRepository(Media)
@@ -177,9 +182,10 @@ export class CompletionService {
       this.log.debug?.(
         `Auto-match: ${allTorrents.length} qBit torrents, all already linked — nothing to do`,
       );
+      this.unidentifiedHashes = new Set();
       return;
     }
-    this.log.log(
+    this.log.debug?.(
       `Auto-match: scanning ${candidates.length}/${allTorrents.length} torrent(s) without a media link`,
     );
 
@@ -187,6 +193,7 @@ export class CompletionService {
     let rebound = 0;
     let skippedByNameFallback = 0;
     let unidentified = 0;
+    const stillUnidentified = new Set<string>();
     for (const torrent of candidates) {
       const existingRow = rowByHash.get(torrent.hash!.toLowerCase());
 
@@ -210,9 +217,11 @@ export class CompletionService {
       }
       if (!match) {
         unidentified++;
-        this.log.log(
-          `Auto-match: "${torrent.name}" — no media in library matches the parsed title (ambiguous or unknown)`,
-        );
+        const hash = torrent.hash!.toLowerCase();
+        stillUnidentified.add(hash);
+        const message = `Auto-match: "${torrent.name}" — no media in library matches the parsed title (ambiguous or unknown)`;
+        if (this.unidentifiedHashes.has(hash)) this.log.debug?.(message);
+        else this.log.log(message);
         continue;
       }
 
@@ -265,9 +274,10 @@ export class CompletionService {
         `Auto-match: ${verb} torrent "${torrent.name}" → ${match.media.title}${epLabel} (history #${row.id})`,
       );
     }
-    this.log.log(
-      `Auto-match: done — ${bound} created, ${rebound} healed, ${skippedByNameFallback} matched by name (will heal hash), ${unidentified} unidentified`,
-    );
+    this.unidentifiedHashes = stillUnidentified;
+    const summary = `Auto-match: done — ${bound} created, ${rebound} healed, ${skippedByNameFallback} matched by name (will heal hash), ${unidentified} unidentified`;
+    if (bound || rebound) this.log.log(summary);
+    else this.log.debug?.(summary);
   }
 
   @Cron(CronExpression.EVERY_MINUTE)


### PR DESCRIPTION
## Context

A VPN drop in production took every indexer offline at once (since fixed). The logs showed
all 11 indexers stuck in cooldown with ~1h50 remaining, plus a per-minute auto-match loop
re-reporting the same unmatchable torrent.

## What was actually broken

`IndexerThrottle.notifyFailure` counted *consecutive failures* with no time dimension, so
escalation measured how many requests happened to hit an indexer, not how long it had been
broken. A network-wide failure fails every indexer and every queued request at once, which
walked the whole `30s → 2min → 15min → 1h → 6h` ladder to the cap in seconds. The result:
a short blip cost up to 6h of skipped indexers, long after connectivity came back.

A failure arriving while a cooldown is still open now returns early — it belongs to the
outage that opened the window. The ladder advances at most one step per elapsed window, so
the backoff tracks sustained breakage. Side effect: the per-indexer warn drops from one per
request to one per window, which removes most of the log volume at its source.

## Log noise

- `filterReadyIndexers` warned the full skip list on every search fan-out, restating a state
  the throttle already logs with host and duration → `debug`.
- The auto-match cron re-logged the same unresolvable torrent every minute (3 lines/tick)
  because nothing was carried between runs. Unresolved hashes are now remembered, so each
  torrent is reported once at `log` level and repeats only at `debug`; scan and summary lines
  drop to `debug` when nothing was created or healed. The set is replaced wholesale each run,
  so it stays bounded by the client's current torrent count.

## Tests

`indexer-throttle.service.spec.ts` covers the new contract: escalation after the window has
elapsed (fake timers), and no escalation for failures inside an open window. 32 tests green
across `src/modules/indexers` and `src/modules/scheduler`; typecheck clean.

## Not addressed

`refreshCaps` does not filter cooldowns, so an indexer test triggered from the UI during an
outage sleeps out the full backoff inside `throttle.run`. Correct behaviour, but the request
can hang; worth a separate look.
