### PR TITLE
fix(scheduler): run the seeded-torrent cleanup on a cron

### DIFF
--- a/backend/src/modules/scheduler/completion.service.spec.ts
+++ b/backend/src/modules/scheduler/completion.service.spec.ts
@@ -171,3 +171,71 @@ describe('CompletionService.reconcileOrphanHistory', () => {
     expect(noop.emit).not.toHaveBeenCalled();
   });
 });
+
+describe('CompletionService.cleanSeededTorrents', () => {
+  const DAY_SEC = 86400;
+  const nowSec = Math.floor(Date.now() / 1000);
+
+  /** Same bare-prototype approach as above, wiring only the collaborators
+   *  `cleanSeededTorrents` reads. */
+  function run(
+    seeded: Partial<QbittorrentTorrent>,
+    settings: Record<string, unknown>,
+  ) {
+    const deleteTorrent = jest.fn().mockResolvedValue(undefined);
+    const service = Object.create(CompletionService.prototype) as CompletionService;
+    const qb = {
+      where: () => qb,
+      andWhere: () => qb,
+      // Uppercase hash on purpose: rows written from an indexer-supplied hash
+      // must still resolve against qBit's lowercase one.
+      getMany: async () => [
+        history({
+          id: 3,
+          status: 'completed',
+          torrentHash: 'H1',
+          indexerId: 5,
+        }),
+      ],
+    };
+    const wired = service as unknown as Record<string, unknown>;
+    wired.clientRepo = { find: async () => [{ id: 1 }] };
+    wired.qbittorrent = {
+      supports: () => true,
+      getTorrents: async () => [
+        { hash: 'h1', name: 'pack', ratio: 0, completion_on: nowSec, ...seeded },
+      ],
+      deleteTorrent,
+    };
+    wired.historyRepo = { createQueryBuilder: () => qb };
+    wired.indexerRepo = { find: async () => [{ id: 5, settings }] };
+    wired.log = { log: jest.fn(), error: jest.fn() };
+    wired.events = { emit: jest.fn() };
+    return { deleteTorrent, done: service.cleanSeededTorrents() };
+  }
+
+  it('removes a torrent past its retention even when the ratio target is unmet', async () => {
+    const { deleteTorrent, done } = run(
+      { ratio: 0.1, completion_on: nowSec - 26 * DAY_SEC },
+      { seedRatio: 1, maxRetentionDays: 2 },
+    );
+    await done;
+    // Third arg = delete the payload files, not just the torrent entry.
+    expect(deleteTorrent).toHaveBeenCalledWith({ id: 1 }, 'h1', true);
+  });
+
+  it('keeps a torrent that meets neither retention nor ratio', async () => {
+    const { deleteTorrent, done } = run(
+      { ratio: 0.1, completion_on: nowSec - DAY_SEC },
+      { seedRatio: 1, maxRetentionDays: 2 },
+    );
+    await done;
+    expect(deleteTorrent).not.toHaveBeenCalled();
+  });
+
+  it('still removes on the ratio target when no retention is configured', async () => {
+    const { deleteTorrent, done } = run({ ratio: 1.5 }, { seedRatio: 1 });
+    await done;
+    expect(deleteTorrent).toHaveBeenCalledWith({ id: 1 }, 'h1', true);
+  });
+});

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -1337,18 +1337,8 @@ export class CompletionService {
   // Seed ratio cleanup — remove torrents that have met their seed ratio target
   // ---------------------------------------------------------------------------
 
+  @Cron(CronExpression.EVERY_5_MINUTES)
   async cleanSeededTorrents(): Promise<void> {
-    // Only care about completed imports that still have a torrent hash
-    const completed = await this.historyRepo.find({
-      where: { status: 'completed' },
-    });
-    const withHash = completed.filter((h) => h.torrentHash);
-    if (!withHash.length) return;
-
-    // Load all indexers into a map for quick lookup
-    const indexers = await this.indexerRepo.find();
-    const indexerMap = new Map(indexers.map((ix) => [ix.id, ix]));
-
     // Fetch torrents from all enabled qBittorrent clients
     const clients = await this.clientRepo.find({ where: { enabled: true } });
     const qbitClients = clients.filter((c) => this.qbittorrent.supports(c));
@@ -1371,6 +1361,22 @@ export class CompletionService {
     const torrentMap = new Map(
       allTorrents.map((e) => [e.torrent.hash.toLowerCase(), e]),
     );
+
+    // Scoped to the hashes the client still holds: history grows forever while
+    // the client's contents don't, and a row whose torrent is already gone has
+    // nothing left to clean up.
+    const withHash = await this.historyRepo
+      .createQueryBuilder('h')
+      .where('h.status = :status', { status: 'completed' })
+      .andWhere('LOWER(h."torrentHash") IN (:...hashes)', {
+        hashes: [...torrentMap.keys()],
+      })
+      .getMany();
+    if (!withHash.length) return;
+
+    const indexers = await this.indexerRepo.find();
+    const indexerMap = new Map(indexers.map((ix) => [ix.id, ix]));
+
     const nowSec = Math.floor(Date.now() / 1000);
     let deleted = 0;
 

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -121,7 +121,7 @@ export class SchedulerService implements OnModuleInit {
     },
     {
       name: 'CleanSeeded',
-      cron: CronExpression.EVERY_MINUTE,
+      cron: CronExpression.EVERY_5_MINUTES,
       triggerable: true,
     },
     {


### PR DESCRIPTION
## Symptom

An indexer configured with `Retention max = 2 days` still held a torrent completed on
2 July, imported, at 100% — 26 days past its window.

## Root cause

`cleanSeededTorrents` had no `@Cron`. The task registry (`scheduler.service.ts:123`)
declared `CleanSeeded` at `EVERY_MINUTE`, and `getSchedulers` parses that string to show a
next-run time in the Schedulers page, so the UI reported a job that nothing invoked. The
only live crons were:

```
scheduler.service.ts   SearchMissing, RefreshMetadata, RssSync
completion.service.ts  processCompleted (ImportCompleted), cleanStalledTorrents (CleanStalled)
```

`cleanSeededTorrents` ran only on a manual trigger, so per-indexer max-retention and
seed-ratio limits never applied on their own.

The rest of the chain was already correct and was verified before changing anything: the
"Imported" badge maps from history status `completed` (`download-clients.service.ts:434`) so
the row passes the filter, `maxRetentionDays` does persist (the indexer DTOs pass
`settings` through as `Record<string, unknown>`), the `ageDays >= maxRetentionDays`
comparison is sound, and `deleteTorrent(..., true)` already removes the payload files.

## Changes

- `@Cron(EVERY_5_MINUTES)` on `cleanSeededTorrents`, matching `CleanStalled`. Retention is
  expressed in days and ratios move slowly, so a shorter interval only adds load. The
  registry string is updated to match so the Schedulers page stays truthful.
- The history lookup is scoped to the hashes the client currently holds rather than loading
  every `completed` row: that table grows without bound while the client's contents do not,
  and a row whose torrent is already gone has nothing to clean. Compared case-insensitively
  so rows carrying an indexer-supplied hash still resolve against qBit's lowercase one.

## Heads-up for the deploy

This activates a job that deletes torrents **and their files**. `seedRatio` defaults to
`1` when unset, so within 5 minutes of the deploy any completed torrent already at ratio
≥ 1.0 becomes eligible. That is the documented meaning of the field, but it has been
dormant until now, so the first run may remove a large batch at once. Worth a look at
current ratios before shipping.

## Tests

Three cases on the retention/ratio decision — the logic that had never run: retention
exceeded with the ratio target unmet, neither threshold met, and ratio-only with no
retention configured. 35 tests green across `src/modules/scheduler` and
`src/modules/indexers`; typecheck clean.

## Not addressed

`ImportCompleted`, `CleanStalled` and now `CleanSeeded` fire via bare `@Cron` in
`CompletionService` rather than through `runCommand`, so their scheduled runs are not
recorded in `commands` and the Schedulers page shows a last-run only after a manual
trigger. Pre-existing, and a fix means restructuring around the
SchedulerService/CompletionService dependency direction.
