### PR TITLE
fix(scheduler): resolve auto-match against the linked history row

### DIFF
--- a/backend/src/modules/scheduler/completion.service.spec.ts
+++ b/backend/src/modules/scheduler/completion.service.spec.ts
@@ -172,6 +172,69 @@ describe('CompletionService.reconcileOrphanHistory', () => {
   });
 });
 
+describe('CompletionService.autoMatchOrphanTorrents', () => {
+  function run(rows: DownloadHistory[], name: string, hash: string) {
+    const tryMatch = jest.fn().mockResolvedValue(null);
+    const service = Object.create(CompletionService.prototype) as CompletionService;
+    const wired = service as unknown as Record<string, unknown>;
+    wired.historyRepo = { find: async () => rows, save: jest.fn(), create: jest.fn() };
+    wired.autoMatcher = { tryMatch };
+    wired.unidentifiedHashes = new Set<string>();
+    wired.log = { log: jest.fn(), warn: jest.fn(), debug: jest.fn() };
+    return {
+      tryMatch,
+      done: (
+        service as unknown as {
+          autoMatchOrphanTorrents: (t: unknown[]) => Promise<void>;
+        }
+      ).autoMatchOrphanTorrents([{ hash, name, _clientId: 1, _client: {} }]),
+    };
+  }
+
+  it('trusts the linked row when a ghost row shares its hash', async () => {
+    const { tryMatch, done } = run(
+      [
+        history({ id: 1, status: 'grabbed', torrentHash: 'h1' }),
+        history({ id: 2, status: 'completed', torrentHash: 'h1', mediaId: 42 }),
+        // Ghost last on purpose: insertion order must not decide the verdict.
+        history({ id: 3, status: 'grabbed', torrentHash: 'h1' }),
+      ],
+      'Some.Release.1080p',
+      'h1',
+    );
+    await done;
+    expect(tryMatch).not.toHaveBeenCalled();
+  });
+
+  it('skips a torrent whose title is already bound to a media', async () => {
+    const { tryMatch, done } = run(
+      [
+        history({
+          id: 5,
+          status: 'completed',
+          torrentHash: null as unknown as string,
+          sourceTitle: 'Some_Release_1080p',
+          mediaId: 42,
+        }),
+      ],
+      'Some.Release.1080p',
+      'h9',
+    );
+    await done;
+    expect(tryMatch).not.toHaveBeenCalled();
+  });
+
+  it('still tries to identify a torrent nothing accounts for', async () => {
+    const { tryMatch, done } = run(
+      [history({ id: 5, status: 'completed', torrentHash: 'other', mediaId: 42 })],
+      'Unknown.Release.1080p',
+      'h9',
+    );
+    await done;
+    expect(tryMatch).toHaveBeenCalledWith('Unknown.Release.1080p');
+  });
+});
+
 describe('CompletionService.cleanSeededTorrents', () => {
   const DAY_SEC = 86400;
   const nowSec = Math.floor(Date.now() / 1000);

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -37,7 +37,10 @@ import {
 } from './utils/stalled-progress.util';
 import { CleanupProfile } from '../cleanup-profiles/entities/cleanup-profile.entity';
 import { Library } from '../libraries/entities/library.entity';
-import { TorrentHistoryMatcher } from '../media/torrent-history-matcher.service';
+import {
+  TorrentHistoryMatcher,
+  normaliseTorrentName,
+} from '../media/torrent-history-matcher.service';
 import { TorrentAutoMatcher } from '../media/torrent-auto-matcher.service';
 import { buildGrabHistoryRow } from '../media/grab-history.util';
 import {
@@ -161,15 +164,19 @@ export class CompletionService {
       relations: ['media'],
     });
     const rowByHash = new Map<string, DownloadHistory>();
-    const activeHistory = allHistory.filter(
-      (h) =>
-        h.status === 'grabbed' ||
-        h.status === 'failed' ||
-        h.status === 'warning',
-    );
     for (const h of allHistory) {
-      if (h.torrentHash) rowByHash.set(h.torrentHash.toLowerCase(), h);
+      if (!h.torrentHash) continue;
+      const key = h.torrentHash.toLowerCase();
+      const kept = rowByHash.get(key);
+      // Several rows can carry one hash; the linked one is authoritative.
+      if (!kept || (!kept.mediaId && h.mediaId)) rowByHash.set(key, h);
     }
+
+    const linkedTitles = new Set(
+      allHistory
+        .filter((h) => h.mediaId && h.sourceTitle)
+        .map((h) => normaliseTorrentName(h.sourceTitle)),
+    );
 
     const candidates = allTorrents.filter((t) => {
       if (!t.hash) return false;
@@ -197,11 +204,7 @@ export class CompletionService {
     for (const torrent of candidates) {
       const existingRow = rowByHash.get(torrent.hash!.toLowerCase());
 
-      // Belt-and-braces: name-fallback against currently-active rows.
-      // Only skip if that match actually has a media reference — a
-      // \`mediaId IS NULL\` ghost row would otherwise prevent the heal.
-      const fallback = this.historyMatcher.findMatch(torrent, activeHistory);
-      if (fallback?.history.mediaId) {
+      if (linkedTitles.has(normaliseTorrentName(torrent.name))) {
         skippedByNameFallback++;
         continue;
       }


### PR DESCRIPTION
## Symptom

`Auto-match: "…[LEAK].mp4" — no media in library matches the parsed title` repeating every
tick, for a torrent the Activities page shows as **Imported and linked to a media** (the
title renders as a `routerLink` in `queue.html:71` only when `item.mediaId` is set, and no
"Link media" button is offered).

## Root cause

Both code paths key on the torrent hash, and they disagree on which row wins when more than
one carries it:

- the queue resolves through `findMatch` → `histories.find(...)` → **first** row wins;
- the auto-match built its index with `rowByHash.set(...)` → **last** row wins.

So the queue could hold the linked row while the auto-match held a media-less one, hit
`if (!existing.mediaId) return true`, and treated an imported torrent as an orphan on every
run. Which row won depended on Postgres' return order.

Rows sharing a hash are not purely pathological — a re-grab after a failed import produces
one legitimately. Migration `1779500000000` collapsed duplicates grouped by
`(mediaId, LOWER(sourceTitle))` but scoped itself to `"mediaId" IS NOT NULL`, so the
media-less ones were left in place.

## Changes

- The hash index prefers the row carrying a media link, whatever the insertion order. That
  is the row that is authoritative for the torrent.
- The name fallback searched only `grabbed|failed|warning`, so a `completed` row could never
  cause a skip: an imported torrent not found by hash could be handed a **second** history
  row by the auto-match — the very mechanism that accumulates duplicates. Widening
  `findMatch`'s input was not viable, since it deliberately refuses to choose beyond one
  candidate and would return `null` plus a `refusing to cross-match` warn on every tick for
  shared titles. A set of the titles already bound to a media answers the only question this
  call site asks, and collapses duplicates rather than tripping over them.

Net effect is a smaller function: the `activeHistory` filter and the matcher call are gone.

## Tests

Three cases, the first two of which fail on the previous code: a ghost row sharing the hash
(deliberately ordered last, so insertion order cannot carry the test), an imported torrent
whose row has no hash but whose title is bound, and a genuinely unknown torrent that must
still reach `tryMatch` so the skip cannot silently swallow real work. 81 tests green across
`src/modules/scheduler`, `src/modules/indexers` and `src/modules/media`; typecheck clean.

## Deliberately not done

**A migration collapsing the media-less rows.** It does not prevent recurrence — `healHash`
re-stamps a hash onto any row it matches by name — and following the precedent of
`1779500000000` (stamp the redundant rows `completed`) would now feed them to the
seeded-cleanup cron that #803 just activated, where a ghost row's empty indexer settings
resolve to the default `seedRatio` of 1. That turns a cosmetic cleanup into file deletions.
The deterministic code path above is the durable fix; the leftover rows are inert.

**A unique index on `LOWER("torrentHash")`.** Tempting, but a re-grab of the same release
legitimately reuses the hash, and none of the 9 `buildGrabHistoryRow` insertion sites handle
a constraint violation. It would convert a silent duplicate into a request-time error. It
only becomes an option once those paths are idempotent.
