### PR TITLE
fix(scheduler): rank history rows per torrent and recover stranded imports

### DIFF
--- a/backend/src/modules/download-clients/qbittorrent.service.ts
+++ b/backend/src/modules/download-clients/qbittorrent.service.ts
@@ -440,6 +440,10 @@ export class QbittorrentService {
     client: DownloadClient,
     torrentUrl: string,
     mediaType?: 'movie' | 'series',
+    /** Throw when the client already holds this hash instead of recording a
+     *  grab against a torrent we did not add. Off for user-driven grabs, where
+     *  re-adding a release on purpose is legitimate. */
+    rejectIfAlreadyPresent = false,
   ): Promise<string> {
     torrentUrl = this.sanitizeUrl(torrentUrl);
     const s = client.settings;
@@ -602,6 +606,18 @@ export class QbittorrentService {
           `qBittorrent: could not recover hash for newly-added torrent — Activities row will rely on name match until next tick`,
         );
       }
+    }
+
+    // qBittorrent deduplicates by hash: the add above created nothing when the
+    // torrent was already there, so refusing after the fact costs nothing.
+    if (
+      rejectIfAlreadyPresent &&
+      infoHash &&
+      beforeHashes.has(infoHash.toLowerCase())
+    ) {
+      throw new BadRequestException(
+        `Torrent ${infoHash} is already in the download client`,
+      );
     }
 
     return infoHash ?? '';

--- a/backend/src/modules/media/auto-grab-pipeline.service.ts
+++ b/backend/src/modules/media/auto-grab-pipeline.service.ts
@@ -354,6 +354,7 @@ export class AutoGrabPipelineService {
         args.qbitClient,
         args.pick.downloadUrl,
         args.mediaType,
+        true,
       );
       await this.historyRepo.save(
         this.historyRepo.create(

--- a/backend/src/modules/media/torrent-history-matcher.service.ts
+++ b/backend/src/modules/media/torrent-history-matcher.service.ts
@@ -17,6 +17,37 @@ export interface HistoryMatch {
   matchedBy: MatchedBy;
 }
 
+const LIVE_STATUSES = new Set(['grabbed', 'importing']);
+
+/**
+ * Several rows legitimately describe one torrent: re-grabbing a release already
+ * in the client adds a row but no torrent, since qBittorrent deduplicates by
+ * hash. Ranking them is therefore mandatory — without it the winner is whatever
+ * order the database happened to return, and callers disagree on which row
+ * speaks for the torrent.
+ */
+function authorityRank(h: DownloadHistory): number {
+  return (h.mediaId ? 2 : 0) + (LIVE_STATUSES.has(h.status) ? 1 : 0);
+}
+
+/** Whether `candidate` speaks for the torrent over `current`: a media link
+ *  first, then a live status over a terminal one, then the most recent row. */
+export function outranksForTorrent(
+  candidate: DownloadHistory,
+  current: DownloadHistory,
+): boolean {
+  const delta = authorityRank(candidate) - authorityRank(current);
+  return delta > 0 || (delta === 0 && candidate.id > current.id);
+}
+
+function pickAuthoritative(rows: DownloadHistory[]): DownloadHistory | null {
+  let best: DownloadHistory | null = null;
+  for (const h of rows) {
+    if (!best || outranksForTorrent(h, best)) best = h;
+  }
+  return best;
+}
+
 /**
  * Single source of truth for the "which DownloadHistory does this qBittorrent
  * torrent belong to" lookup. Three call sites used to inline three slightly
@@ -29,9 +60,13 @@ export interface HistoryMatch {
  *
  * Rules, in order:
  *  1. `history.torrentHash === torrent.hash` — definitive.
- *  2. Exactly one history with normalised `sourceTitle === torrent.name`.
+ *  2. Histories whose normalised `sourceTitle` equals the normalised
+ *     `torrent.name` — the same release.
  *  3. Exactly one history whose normalised `sourceTitle` is a prefix of the
  *     normalised `torrent.name` (or vice-versa). Multiple candidates abort.
+ *
+ * (1) and (2) can each yield several rows, which {@link outranksForTorrent}
+ * ranks. (3) cannot: distinct releases overlap by prefix, so it still aborts.
  *
  * Both name comparisons use {@link normaliseTorrentName}, which decodes HTML
  * entities, collapses whitespace and strips noise tokens — qBittorrent
@@ -59,25 +94,23 @@ export class TorrentHistoryMatcher {
     const name = normaliseTorrentName(torrent.name);
 
     if (hash) {
-      const byHash = histories.find(
-        (h) => h.torrentHash && h.torrentHash.toLowerCase() === hash,
+      const byHash = pickAuthoritative(
+        histories.filter(
+          (h) => h.torrentHash && h.torrentHash.toLowerCase() === hash,
+        ),
       );
       if (byHash) return { history: byHash, matchedBy: 'hash' };
     }
 
-    const exact = histories.filter(
-      (h) => normaliseTorrentName(h.sourceTitle ?? '') === name,
+    // Rows sharing a normalised sourceTitle describe the same release, so rank
+    // them like a shared hash. Prefix overlap below stays a refusal: distinct
+    // releases can overlap there, and picking one would cross-match them.
+    const byName = pickAuthoritative(
+      histories.filter(
+        (h) => normaliseTorrentName(h.sourceTitle ?? '') === name,
+      ),
     );
-    if (exact.length === 1) {
-      return { history: exact[0], matchedBy: 'exact-name' };
-    }
-    if (exact.length > 1) {
-      // Ambiguous exact match — refuse rather than guess.
-      this.log.warn(
-        `TorrentHistoryMatcher: ${exact.length} histories share normalised sourceTitle="${name}" — refusing to cross-match`,
-      );
-      return null;
-    }
+    if (byName) return { history: byName, matchedBy: 'exact-name' };
 
     const prefix = histories.filter((h) => {
       if (!h.sourceTitle) return false;

--- a/backend/src/modules/media/torrent-history-matcher.spec.ts
+++ b/backend/src/modules/media/torrent-history-matcher.spec.ts
@@ -1,4 +1,95 @@
-import { normaliseTorrentName } from './torrent-history-matcher.service';
+import {
+  TorrentHistoryMatcher,
+  normaliseTorrentName,
+} from './torrent-history-matcher.service';
+import { DownloadHistory } from './entities/download-history.entity';
+
+const row = (over: Partial<DownloadHistory>): DownloadHistory =>
+  ({
+    id: 1,
+    status: 'grabbed',
+    sourceTitle: 'Show.S01.1080p-GROUP',
+    torrentHash: 'h1',
+    ...over,
+  }) as DownloadHistory;
+
+/** `findMatch` reads no collaborator, so a bare prototype is enough. */
+const matcher = () =>
+  Object.create(TorrentHistoryMatcher.prototype) as TorrentHistoryMatcher;
+
+describe('TorrentHistoryMatcher.findMatch priority', () => {
+  const torrent = { hash: 'h1', name: 'Show.S01.1080p-GROUP' };
+
+  it('prefers the live row over an already-completed one on a shared hash', () => {
+    const rows = [
+      row({ id: 10, status: 'completed', mediaId: 42 }),
+      row({ id: 11, status: 'grabbed', mediaId: 42 }),
+      row({ id: 12, status: 'completed', mediaId: 42 }),
+    ];
+    expect(matcher().findMatch(torrent, rows)?.history.id).toBe(11);
+  });
+
+  it('prefers a media-linked row over a media-less one', () => {
+    const rows = [
+      row({ id: 20, status: 'grabbed', mediaId: 42 }),
+      row({ id: 21, status: 'grabbed' }),
+    ];
+    expect(matcher().findMatch(torrent, rows)?.history.id).toBe(20);
+  });
+
+  it('falls back to the most recent row when rank ties', () => {
+    const rows = [
+      row({ id: 30, status: 'completed', mediaId: 42 }),
+      row({ id: 31, status: 'completed', mediaId: 42 }),
+    ];
+    expect(matcher().findMatch(torrent, rows)?.history.id).toBe(31);
+  });
+
+  it('ranks rows sharing a title instead of refusing to choose', () => {
+    const rows = [
+      row({
+        id: 40,
+        status: 'completed',
+        mediaId: 42,
+        torrentHash: null as unknown as string,
+      }),
+      row({
+        id: 41,
+        status: 'grabbed',
+        mediaId: 42,
+        torrentHash: null as unknown as string,
+      }),
+    ];
+    const match = matcher().findMatch(
+      { hash: 'h9', name: 'Show_S01_1080p-GROUP' },
+      rows,
+    );
+    expect(match?.matchedBy).toBe('exact-name');
+    expect(match?.history.id).toBe(41);
+  });
+
+  it('still refuses an ambiguous prefix overlap', () => {
+    const rows = [
+      row({
+        id: 50,
+        sourceTitle: 'Show.S01',
+        torrentHash: null as unknown as string,
+      }),
+      row({
+        id: 51,
+        sourceTitle: 'Show.S01.1080p',
+        torrentHash: null as unknown as string,
+      }),
+    ];
+    const log = { warn: jest.fn() };
+    const m = matcher();
+    (m as unknown as { log: unknown }).log = log;
+    expect(
+      m.findMatch({ hash: 'h9', name: 'Show.S01.1080p-GROUP' }, rows),
+    ).toBeNull();
+    expect(log.warn).toHaveBeenCalled();
+  });
+});
 
 describe('normaliseTorrentName', () => {
   it('decodes HTML entities qBittorrent renders on display', () => {
@@ -11,7 +102,7 @@ describe('normaliseTorrentName', () => {
   });
 
   it('decodes numeric and hex character references', () => {
-    expect(normaliseTorrentName("Mum&#39;s.S01.WEB-DL")).toBe(
+    expect(normaliseTorrentName('Mum&#39;s.S01.WEB-DL')).toBe(
       "mum's s01 web-dl",
     );
     expect(normaliseTorrentName('A&#x26;B.S01')).toBe('a&b s01');

--- a/backend/src/modules/scheduler/completion.service.spec.ts
+++ b/backend/src/modules/scheduler/completion.service.spec.ts
@@ -159,6 +159,25 @@ describe('CompletionService.reconcileOrphanHistory', () => {
     expect(update).not.toHaveBeenCalled();
   });
 
+  it('re-arms an importing row whose torrent went back to downloading', async () => {
+    const row = history({ id: 21, status: 'importing', updatedAt: new Date() });
+    const live = { ...torrent('h1'), progress: 0.1 } as QbittorrentTorrent;
+    const { update, done } = run([live], [], [row]);
+    await done;
+    expect(update).toHaveBeenCalledWith([21], {
+      status: 'grabbed',
+      statusMessage: null,
+    });
+  });
+
+  it('leaves an importing row alone while its torrent is complete', async () => {
+    const row = history({ id: 21, status: 'importing', updatedAt: new Date() });
+    const done0 = { ...torrent('h1'), progress: 1 } as QbittorrentTorrent;
+    const { update, done } = run([done0], [], [row]);
+    await done;
+    expect(update).not.toHaveBeenCalled();
+  });
+
   it('emits queue.updated on a change, and stays silent when nothing moved', async () => {
     const gone = history({ id: 7, status: 'grabbed', updatedAt: HOUR_AGO });
     const flip = run([], [gone]);

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -1,4 +1,10 @@
-import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
+import {
+  forwardRef,
+  Inject,
+  Injectable,
+  Logger,
+  OnModuleInit,
+} from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, In, LessThan, Repository } from 'typeorm';
@@ -40,6 +46,7 @@ import { Library } from '../libraries/entities/library.entity';
 import {
   TorrentHistoryMatcher,
   normaliseTorrentName,
+  outranksForTorrent,
 } from '../media/torrent-history-matcher.service';
 import { TorrentAutoMatcher } from '../media/torrent-auto-matcher.service';
 import { buildGrabHistoryRow } from '../media/grab-history.util';
@@ -72,7 +79,7 @@ const ORPHAN_GRACE_MS = 5 * 60_000;
 const ORPHAN_STATUS_MESSAGE = 'Torrent no longer present in download client';
 
 @Injectable()
-export class CompletionService {
+export class CompletionService implements OnModuleInit {
   private readonly log = new Logger(CompletionService.name);
 
   /** Torrent hashes the auto-matcher could not resolve on the previous tick.
@@ -122,6 +129,24 @@ export class CompletionService {
   ) {}
 
   /**
+   * `importing` is written before the copy starts, so a process that dies
+   * mid-import leaves the row claiming an import that no longer exists — and
+   * the import loop skips `importing` rows to avoid re-entering a copy still in
+   * flight. Nothing is in flight right after boot, so re-arm them all.
+   */
+  async onModuleInit(): Promise<void> {
+    const stranded = await this.historyRepo.update(
+      { status: 'importing' },
+      { status: 'grabbed' },
+    );
+    if (stranded.affected) {
+      this.log.warn(
+        `Import: re-armed ${stranded.affected} row(s) left importing by a previous run`,
+      );
+    }
+  }
+
+  /**
    * Whether series imports trigger automatic intro / outro marker
    * detection. Default on — most users want skip-intro working right
    * after a series finishes downloading.
@@ -130,7 +155,9 @@ export class CompletionService {
    * (an unset key reads as enabled) to preserve behaviour on existing installs.
    */
   private async autoDetectMarkersOnImport(): Promise<boolean> {
-    return (await this.settings.get('markers_auto_detect_on_import')) !== 'false';
+    return (
+      (await this.settings.get('markers_auto_detect_on_import')) !== 'false'
+    );
   }
 
   /**
@@ -168,8 +195,7 @@ export class CompletionService {
       if (!h.torrentHash) continue;
       const key = h.torrentHash.toLowerCase();
       const kept = rowByHash.get(key);
-      // Several rows can carry one hash; the linked one is authoritative.
-      if (!kept || (!kept.mediaId && h.mediaId)) rowByHash.set(key, h);
+      if (!kept || outranksForTorrent(h, kept)) rowByHash.set(key, h);
     }
 
     const linkedTitles = new Set(
@@ -229,8 +255,7 @@ export class CompletionService {
       }
 
       const quality = parseReleaseQuality(torrent.name).quality.name;
-      const seasonId =
-        match.season?.id ?? match.episode?.season?.id ?? null;
+      const seasonId = match.season?.id ?? match.episode?.season?.id ?? null;
       const episodeId = match.episode?.id ?? null;
 
       let row: DownloadHistory;
@@ -241,8 +266,7 @@ export class CompletionService {
         // are left intact — this is restoration, not a new grab.
         existingRow.media = match.media;
         existingRow.episode = match.episode ?? null;
-        existingRow.season =
-          match.season ?? match.episode?.season ?? null;
+        existingRow.season = match.season ?? match.episode?.season ?? null;
         existingRow.quality = quality;
         row = await this.historyRepo.save(existingRow);
         rebound++;
@@ -305,7 +329,11 @@ export class CompletionService {
         const { ok, torrents } = await this.qbittorrent.getTorrentsResult(c);
         return {
           ok,
-          torrents: torrents.map((t) => ({ ...t, _clientId: c.id, _client: c })),
+          torrents: torrents.map((t) => ({
+            ...t,
+            _clientId: c.id,
+            _client: c,
+          })),
         };
       }),
     );
@@ -438,25 +466,6 @@ export class CompletionService {
   }
 
   /**
-   * Reconcile grabbed/importing/failed rows against the live torrent list.
-   * Caller must pass a complete list (every client responded), since every
-   * direction keys off a torrent's presence:
-   *
-   *  - A `grabbed` or `importing` row whose torrent has been gone for at least
-   *    {@link ORPHAN_GRACE_MS} flips to `failed` — this is what reconciles a
-   *    torrent the user removed from the client by hand. The grace is measured
-   *    off `updatedAt`, which every status / hash heal write bumps, so a row
-   *    whose torrent just arrived has a fresh timestamp and won't be flipped.
-   *  - A `failed` row carrying the {@link ORPHAN_STATUS_MESSAGE} stamp whose
-   *    torrent is matched again returns to `grabbed`, so the activity queue
-   *    never shows "no longer present" beside a torrent the client still
-   *    reports. A torrent that failed for any other reason keeps its status.
-   *
-   * The media link is preserved in every direction. A `queue.updated` event is
-   * emitted on any change so the sidebar badge refreshes live rather than
-   * staying stale until the next navigation.
-   */
-  /**
    * Push a `download.progress` SSE for every in-flight torrent to that media's
    * request audience. Reuses the same hash-first matcher as the queue endpoint;
    * resolves the season/episode scope so a series renders per-season progress.
@@ -498,6 +507,27 @@ export class CompletionService {
     }
   }
 
+  /**
+   * Reconcile grabbed/importing/failed rows against the live torrent list.
+   * Caller must pass a complete list (every client responded), since every
+   * direction keys off a torrent's presence:
+   *
+   *  - A `grabbed` or `importing` row whose torrent has been gone for at least
+   *    {@link ORPHAN_GRACE_MS} flips to `failed` — this is what reconciles a
+   *    torrent the user removed from the client by hand. The grace is measured
+   *    off `updatedAt`, which every status / hash heal write bumps, so a row
+   *    whose torrent just arrived has a fresh timestamp and won't be flipped.
+   *  - A `failed` row carrying the {@link ORPHAN_STATUS_MESSAGE} stamp whose
+   *    torrent is matched again returns to `grabbed`, so the activity queue
+   *    never shows "no longer present" beside a torrent the client still
+   *    reports. A torrent that failed for any other reason keeps its status.
+   *  - An `importing` row whose torrent is no longer complete returns to
+   *    `grabbed`: no import can be in flight for it.
+   *
+   * The media link is preserved in every direction. A `queue.updated` event is
+   * emitted on any change so the sidebar badge refreshes live rather than
+   * staying stale until the next navigation.
+   */
   private async reconcileOrphanHistory(
     allTorrents: ReadonlyArray<QbittorrentTorrent>,
     grabbed: DownloadHistory[],
@@ -507,13 +537,34 @@ export class CompletionService {
     // Match torrents against both sets so a live torrent keeps either kind of
     // row off the orphan list.
     const candidates = [...grabbed, ...importing];
-    const matchedHistoryIds = new Set<number>();
+    const torrentByHistoryId = new Map<number, QbittorrentTorrent>();
     for (const t of allTorrents) {
       const m = this.historyMatcher.findMatch(t, candidates);
-      if (m) matchedHistoryIds.add(m.history.id);
+      if (m) torrentByHistoryId.set(m.history.id, t);
     }
+    const matchedHistoryIds = new Set(torrentByHistoryId.keys());
 
     let changed = false;
+
+    // An import only ever starts on a complete torrent, so an `importing` row
+    // whose torrent is no longer complete cannot have one in flight: the
+    // process died mid-copy, or the payload vanished and the client restarted
+    // the download. Re-arm it — `importing` is otherwise a dead end, excluded
+    // from the import candidates and only ever reclaimed by the orphan sweep.
+    const restarted = importing.filter((h) => {
+      const t = torrentByHistoryId.get(h.id);
+      return t != null && t.progress < 1;
+    });
+    if (restarted.length) {
+      await this.historyRepo.update(
+        restarted.map((h) => h.id),
+        { status: 'grabbed', statusMessage: null as unknown as string },
+      );
+      changed = true;
+      this.log.warn(
+        `Import: ${restarted.length} importing entries whose torrent is no longer complete — re-armed as grabbed`,
+      );
+    }
 
     const revived = grabbed.filter(
       (h) =>
@@ -659,9 +710,13 @@ export class CompletionService {
       relations: ['library'],
     });
     if (!media) {
-      this.log.warn(
-        `Import[${history.sourceTitle}]: media id=${history.mediaId} not found in DB`,
-      );
+      const statusMessage = `Import failed: media id=${history.mediaId} not found`;
+      this.log.warn(`Import[${history.sourceTitle}]: ${statusMessage}`);
+      await this.historyRepo.update(history.id, {
+        status: 'failed',
+        statusMessage,
+      });
+      this.events.emit({ type: 'queue.updated' });
       return;
     }
     this.log.log(
@@ -677,9 +732,13 @@ export class CompletionService {
     if (!rootPath) {
       const fallback = libraries.find((l) => !!l.path);
       if (!fallback) {
-        this.log.warn(
-          `Import[${history.sourceTitle}]: no library path configured, skipping`,
-        );
+        const statusMessage = 'Import failed: no library path configured';
+        this.log.warn(`Import[${history.sourceTitle}]: ${statusMessage}`);
+        await this.historyRepo.update(history.id, {
+          status: 'failed',
+          statusMessage,
+        });
+        this.events.emit({ type: 'queue.updated' });
         return;
       }
       resolvedLib = fallback;
@@ -910,6 +969,17 @@ export class CompletionService {
       }
 
       importedFiles.push({ savedFile, episodeId, seasonId, destPath });
+    }
+
+    if (!importedFiles.length) {
+      const statusMessage = `Import failed: no file could be placed under the library root for "${torrent.name}"`;
+      this.log.error(`Import[${history.sourceTitle}]: ${statusMessage}`);
+      await this.historyRepo.update(history.id, {
+        status: 'failed',
+        statusMessage,
+      });
+      this.events.emit({ type: 'queue.updated' });
+      return;
     }
 
     // Reconcile the history row with what was actually imported. Its


### PR DESCRIPTION
Full review of the history / import path — grab → add to client → history row → phases 1-3 →
import → cleanups. Six defects, three of which silently lose work. Confirmed against
production data: three rows carried hash `7070f26f…` for one torrent, one of them stuck in
`importing`.

## 1. Nothing ranked the rows describing one torrent

`torrent-history-matcher.service.ts` resolved by hash with `histories.find(...)`, and no
caller ordered its query — the winner was whatever Postgres returned first. Multiple rows per
torrent is not a corrupt state: re-grabbing a release the client already holds records a row
but adds no torrent, because qBittorrent deduplicates by hash. A ranking rule was therefore
missing, not merely nice to have. Four call sites were affected, not one:

- the Activities queue showed a torrent at 9.9% as **Imported**;
- `reconcileOrphanHistory` registered one row per torrent and stamped every sibling
  "no longer present" while the torrent was right there — and those rows could never come
  back, since revival requires being matched;
- `cleanStalledTorrents` blocklisted and failed an arbitrary row;
- the import loop drove an arbitrary one, so two `grabbed` rows on one torrent imported on
  consecutive ticks, re-copying the whole payload the second time.

Rank: media link first, then a live status over a terminal one, then the most recent row.
Rows sharing a normalised `sourceTitle` are ranked the same way instead of returning `null`
with a per-tick `refusing to cross-match` warning. Prefix overlap still aborts — distinct
releases overlap there, and picking one would cross-match them.

## 2. `importing` was a dead end — this is the one that loses episodes

The status is written before the copy starts, the import loop deliberately skips `importing`
rows so a copy still in flight is never re-entered, and only the orphan sweep reclaimed them,
exclusively when the torrent disappeared. A process that died mid-copy, or a payload deleted
under the client so it went back to downloading, left a row that would never be imported
again — not even once the download completed. Three ways out:

- the sweep re-arms an `importing` row whose torrent is no longer complete: an import only
  ever starts on a complete torrent, so none can be in flight for it;
- boot re-arms whatever is left, since nothing is in flight then (same shape as
  `SchedulerService.onModuleInit`, which already does this for stale commands);
- the two early returns in `processOne` — media not found, no library path — record a final
  status instead of abandoning the row mid-flight.

## 3. `completed` was written even when nothing was imported

The final status write ran unconditionally, while every file can be skipped for resolving
outside the library root. History claimed an import that produced no file, the media stayed
empty, and the next missing-media search re-grabbed the release — creating the duplicate rows
of #1. It now fails with the reason.

## 4. Duplicate rows caused full re-copies

Falls out of #1: with ranking, one row owns the torrent and the sibling is no longer picked on
the following tick.

## 5. The generator: no presence check before adding

`addTorrentUrl` never checked whether the client already held the hash. qBittorrent answers
200 and creates nothing, the info hash is unchanged, and a history row is recorded against a
torrent we did not add — which is exactly how the three production rows appeared. It already
snapshots every hash before the add for its hash-recovery path, so the check is free.

Unattended grabs (`auto-grab-pipeline`) now refuse; the existing `catch` turns that into a
skipped grab and the scheduler moves on. User-driven grabs are unchanged, since re-adding a
release on purpose is legitimate there.

## 6. Hygiene

The `reconcileOrphanHistory` doc block had drifted above `emitDownloadProgress`, which has its
own; the real function had none. Moved back.

## Tests

620 green, typecheck clean. New coverage on the two rules that had none: the ranking (live
over completed, linked over unlinked, recency as tiebreak, title-shared rows ranked rather
than refused, prefix overlap still refused) and the `importing` recovery (torrent back to
downloading → re-armed; torrent still complete → untouched).

Not unit-tested: the `processOne` early returns and the presence check, both of which sit
behind roughly a dozen collaborators or live HTTP. Worth an integration pass, not worth
mock scaffolding at that depth.

## Note for the reviewer

Four hunks in `completion.service.ts` are Prettier reflow of pre-existing lines, not logic
(`markers_auto_detect_on_import`, `seasonId`, `existingRow.season`, the `torrents.map`
spread). The repo has 143 files Prettier would rewrite, so no formatting pass was run beyond
the files this change already touches.

## Left open, deliberately

The rows the `1779500000000` migration stamped are still in the database. They are inert
under the ranking rule, and collapsing them would now feed them to the seeded-cleanup cron
activated in #803, where a ghost row's empty indexer settings resolve to the default
`seedRatio` of 1 — turning a cosmetic cleanup into file deletions.

A unique index on `LOWER("torrentHash")` remains off the table while the 9
`buildGrabHistoryRow` insertion sites handle no constraint violation and a re-grab
legitimately reuses the hash.
