### PR TITLE
feat(subtitles): show the episode on the subtitle history rows

### DIFF
--- a/backend/src/modules/subtitles/subtitle-activity.controller.ts
+++ b/backend/src/modules/subtitles/subtitle-activity.controller.ts
@@ -24,6 +24,20 @@ import { PoliciesGuard } from '../auth/casl/policies.guard';
 import { CheckPolicies } from '../auth/casl/check-policies.decorator';
 import { Action } from '../auth/casl/actions.enum';
 
+/**
+ * Season / episode scope of a subtitle row. `SubtitleFile.episode` is only set
+ * when the caller passed an episode id, so the media file's own link — the one
+ * the import establishes — is the fallback.
+ */
+export function episodeScope(sf: SubtitleFile) {
+  const episode = sf.episode ?? sf.mediaFile?.episode ?? null;
+  return {
+    seasonNumber: episode?.season?.seasonNumber ?? null,
+    episodeNumber: episode?.episodeNumber ?? null,
+    episodeTitle: episode?.title ?? null,
+  };
+}
+
 @Controller('subtitles')
 @UseGuards(JwtOrApiKeyGuard, PoliciesGuard)
 export class SubtitleActivityController {
@@ -55,6 +69,11 @@ export class SubtitleActivityController {
     const qb = this.subtitleFileRepo
       .createQueryBuilder('sf')
       .leftJoinAndSelect('sf.media', 'media')
+      .leftJoinAndSelect('sf.episode', 'episode')
+      .leftJoinAndSelect('episode.season', 'season')
+      .leftJoinAndSelect('sf.mediaFile', 'mediaFile')
+      .leftJoinAndSelect('mediaFile.episode', 'fileEpisode')
+      .leftJoinAndSelect('fileEpisode.season', 'fileSeason')
       .orderBy('sf.createdAt', 'DESC');
 
     if (excludeEmbedded === 'true') {
@@ -78,6 +97,7 @@ export class SubtitleActivityController {
         mediaId: sf.mediaId,
         mediaTitle: sf.media?.title ?? '?',
         mediaType: sf.media?.type ?? null,
+        ...episodeScope(sf),
         language: sf.language,
         providerType: sf.providerType,
         score: sf.score,
@@ -119,7 +139,14 @@ export class SubtitleActivityController {
         .getRawMany(),
       this.subtitleFileRepo.find({
         where: notEmbedded,
-        relations: ['media'],
+        relations: [
+          'media',
+          'episode',
+          'episode.season',
+          'mediaFile',
+          'mediaFile.episode',
+          'mediaFile.episode.season',
+        ],
         order: { createdAt: 'DESC' },
         take: 10,
       }),
@@ -136,6 +163,7 @@ export class SubtitleActivityController {
       recent: recent.map((sf) => ({
         id: sf.id,
         mediaTitle: sf.media?.title ?? '?',
+        ...episodeScope(sf),
         language: sf.language,
         providerType: sf.providerType,
         score: sf.score,

--- a/backend/src/modules/subtitles/subtitle-activity.episode-scope.spec.ts
+++ b/backend/src/modules/subtitles/subtitle-activity.episode-scope.spec.ts
@@ -1,0 +1,45 @@
+import { episodeScope } from './subtitle-activity.controller';
+import { SubtitleFile } from './entities/subtitle-file.entity';
+
+const episode = (episodeNumber: number, seasonNumber: number, title: string) =>
+  ({ episodeNumber, title, season: { seasonNumber } }) as never;
+
+const subtitleFile = (over: Partial<SubtitleFile>): SubtitleFile =>
+  ({ episode: null, ...over }) as SubtitleFile;
+
+describe('episodeScope', () => {
+  it('reads the subtitle row own episode link', () => {
+    expect(
+      episodeScope(subtitleFile({ episode: episode(3, 1, 'Pilot') })),
+    ).toEqual({ seasonNumber: 1, episodeNumber: 3, episodeTitle: 'Pilot' });
+  });
+
+  it('falls back to the media file link when the row carries none', () => {
+    expect(
+      episodeScope(
+        subtitleFile({
+          mediaFile: { episode: episode(7, 2, 'Later') } as never,
+        }),
+      ),
+    ).toEqual({ seasonNumber: 2, episodeNumber: 7, episodeTitle: 'Later' });
+  });
+
+  it('prefers the row own link over the media file one', () => {
+    expect(
+      episodeScope(
+        subtitleFile({
+          episode: episode(3, 1, 'Pilot'),
+          mediaFile: { episode: episode(7, 2, 'Later') } as never,
+        }),
+      ).episodeNumber,
+    ).toBe(3);
+  });
+
+  it('yields nulls for a movie subtitle', () => {
+    expect(episodeScope(subtitleFile({ mediaFile: {} as never }))).toEqual({
+      seasonNumber: null,
+      episodeNumber: null,
+      episodeTitle: null,
+    });
+  });
+});

--- a/client/src/app/core/services/api/subtitles-api.service.ts
+++ b/client/src/app/core/services/api/subtitles-api.service.ts
@@ -200,6 +200,9 @@ export interface SubtitleHistoryEntry {
   mediaId: number;
   mediaTitle: string;
   mediaType: MediaType | null;
+  seasonNumber: number | null;
+  episodeNumber: number | null;
+  episodeTitle: string | null;
   language: string;
   providerType: string;
   score: number;
@@ -224,6 +227,9 @@ export interface SubtitleStats {
   recent: {
     id: number;
     mediaTitle: string;
+    seasonNumber: number | null;
+    episodeNumber: number | null;
+    episodeTitle: string | null;
     language: string;
     providerType: string;
     score: number;

--- a/client/src/app/features/activity/subtitles/subtitles.html
+++ b/client/src/app/features/activity/subtitles/subtitles.html
@@ -49,11 +49,16 @@
         @for (entry of subHistory(); track entry.id) {
           <tr>
             <td class="text-sm whitespace-nowrap">{{ entry.createdAt | localeDate:{ dateStyle: 'short', timeStyle: 'short' } }}</td>
-            <td class="font-medium max-w-[14rem] truncate" [title]="entry.mediaTitle">
+            <td class="font-medium max-w-[14rem]" [title]="entry.mediaTitle">
               <a
                 [routerLink]="['/' + (entry.mediaType === 'series' ? 'series' : 'movies'), entry.mediaId]"
-                class="link link-hover"
+                class="link link-hover block truncate"
               >{{ entry.mediaTitle }}</a>
+              @if (episodeLabel(entry)) {
+                <p class="text-xs font-normal text-base-content/60 truncate" [title]="episodeLabel(entry)">
+                  {{ episodeLabel(entry) }}
+                </p>
+              }
             </td>
             <td class="text-sm font-mono">{{ entry.language }}</td>
             <td class="text-sm">{{ entry.providerType }}</td>

--- a/client/src/app/features/activity/subtitles/subtitles.ts
+++ b/client/src/app/features/activity/subtitles/subtitles.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../core/services/api/subtitles-api.service';
 import { PaginationComponent } from '../../../shared/components/pagination/pagination';
 import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
+import { episodeLabel } from '../../../shared/utils/episode-label';
 
 @Component({
   selector: 'app-activity-subtitles',
@@ -25,6 +26,8 @@ import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
 export class ActivitySubtitlesComponent implements OnInit {
   private readonly subtitlesApi = inject(SubtitlesApiService);
   private readonly translate = inject(TranslateService);
+
+  readonly episodeLabel = episodeLabel;
 
   readonly subHistory = signal<SubtitleHistoryEntry[]>([]);
   readonly subHistoryTotal = signal(0);

--- a/client/src/app/features/dashboard/dashboard.html
+++ b/client/src/app/features/dashboard/dashboard.html
@@ -145,7 +145,14 @@
               <tbody>
                 @for (r of sub.recent; track r.id) {
                   <tr>
-                    <td class="font-medium max-w-[12rem] truncate">{{ r.mediaTitle }}</td>
+                    <td class="font-medium max-w-[12rem]" [title]="r.mediaTitle">
+                      <span class="block truncate">{{ r.mediaTitle }}</span>
+                      @if (episodeLabel(r)) {
+                        <span class="block text-xs font-normal text-base-content/60 truncate" [title]="episodeLabel(r)">
+                          {{ episodeLabel(r) }}
+                        </span>
+                      }
+                    </td>
                     <td class="font-mono text-sm">{{ r.language }}</td>
                     <td class="text-sm">{{ r.providerType }}</td>
                     <td class="text-center tabular-nums">{{ r.score }}</td>

--- a/client/src/app/features/dashboard/dashboard.ts
+++ b/client/src/app/features/dashboard/dashboard.ts
@@ -11,6 +11,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { firstValueFrom } from 'rxjs';
 import { SubtitlesApiService, SubtitleStats } from '../../core/services/api/subtitles-api.service';
 import { LocaleDatePipe } from '../../core/pipes/locale-date.pipe';
+import { episodeLabel } from '../../shared/utils/episode-label';
 
 interface DiskSpaceEntry {
   path: string;
@@ -35,6 +36,8 @@ interface StatsReport {
 export class DashboardComponent implements OnInit {
   private readonly http = inject(HttpClient);
   private readonly subtitlesApi = inject(SubtitlesApiService);
+
+  readonly episodeLabel = episodeLabel;
 
   readonly stats = signal<StatsReport | null>(null);
   readonly subStats = signal<SubtitleStats | null>(null);

--- a/client/src/app/shared/utils/episode-label.ts
+++ b/client/src/app/shared/utils/episode-label.ts
@@ -1,0 +1,14 @@
+/** `S01E03 — Title` for a row that targets one episode, `''` for a movie or a
+ *  whole-season row. Season falls back to 0 so a linked episode never renders
+ *  a bare `SE03`. */
+export function episodeLabel(row: {
+  seasonNumber: number | null;
+  episodeNumber: number | null;
+  episodeTitle: string | null;
+}): string {
+  if (row.episodeNumber == null) return '';
+  const season = String(row.seasonNumber ?? 0).padStart(2, '0');
+  const episode = String(row.episodeNumber).padStart(2, '0');
+  const code = `S${season}E${episode}`;
+  return row.episodeTitle ? `${code} — ${row.episodeTitle}` : code;
+}


### PR DESCRIPTION
## Why

On both subtitle recaps — the dashboard "recently downloaded" table and the Activities
subtitle tab — a series row showed only the series title. Several subtitles pulled for
different episodes of one show were indistinguishable from each other.

## Changes

`GET /subtitles/history` and `GET /subtitles/stats` now return `seasonNumber`,
`episodeNumber` and `episodeTitle`. Both screens render them as a muted `S01E03 — Title`
line under the media title, matching how the Activities download queue already labels an
episode. Movies and whole-season rows render nothing extra.

The formatting lives in one shared helper rather than being inlined twice — the pattern was
already open-coded in three other components, so this is the first shared version, not a new
abstraction layer.

## The part that would have silently done nothing

`SubtitleFile.episode` is nullable and only set when the caller passes an episode id: the
scheduler does (`file.episodeId`), the manual download endpoint takes it as an optional DTO
field. Reading only that column would have left the label missing on an unknown share of
existing rows.

The scope therefore falls back to the media file's own episode link, which the import
establishes and which is the authoritative one — a subtitle belongs to a file, and the file
belongs to an episode. The row's own column is preferred when present.

## Tests

Four cases on the scope resolution: row link, fallback to the file link, row link winning
over the file link, and a movie yielding nulls. 624 backend tests green, backend and client
typecheck clean, production client build clean.

Not covered: the two templates. They are markup with no branching beyond "is there an
episode", which the helper decides and which is tested.
