### PR TITLE
feat(subtitles): link the episode label to the episode page

### DIFF
--- a/backend/src/modules/subtitles/subtitle-activity.controller.ts
+++ b/backend/src/modules/subtitles/subtitle-activity.controller.ts
@@ -32,6 +32,7 @@ import { Action } from '../auth/casl/actions.enum';
 export function episodeScope(sf: SubtitleFile) {
   const episode = sf.episode ?? sf.mediaFile?.episode ?? null;
   return {
+    episodeId: episode?.id ?? null,
     seasonNumber: episode?.season?.seasonNumber ?? null,
     episodeNumber: episode?.episodeNumber ?? null,
     episodeTitle: episode?.title ?? null,
@@ -162,6 +163,7 @@ export class SubtitleActivityController {
       ),
       recent: recent.map((sf) => ({
         id: sf.id,
+        mediaId: sf.mediaId,
         mediaTitle: sf.media?.title ?? '?',
         ...episodeScope(sf),
         language: sf.language,

--- a/backend/src/modules/subtitles/subtitle-activity.episode-scope.spec.ts
+++ b/backend/src/modules/subtitles/subtitle-activity.episode-scope.spec.ts
@@ -1,8 +1,12 @@
 import { episodeScope } from './subtitle-activity.controller';
 import { SubtitleFile } from './entities/subtitle-file.entity';
 
-const episode = (episodeNumber: number, seasonNumber: number, title: string) =>
-  ({ episodeNumber, title, season: { seasonNumber } }) as never;
+const episode = (
+  episodeNumber: number,
+  seasonNumber: number,
+  title: string,
+  id = episodeNumber * 100,
+) => ({ id, episodeNumber, title, season: { seasonNumber } }) as never;
 
 const subtitleFile = (over: Partial<SubtitleFile>): SubtitleFile =>
   ({ episode: null, ...over }) as SubtitleFile;
@@ -11,7 +15,12 @@ describe('episodeScope', () => {
   it('reads the subtitle row own episode link', () => {
     expect(
       episodeScope(subtitleFile({ episode: episode(3, 1, 'Pilot') })),
-    ).toEqual({ seasonNumber: 1, episodeNumber: 3, episodeTitle: 'Pilot' });
+    ).toEqual({
+      episodeId: 300,
+      seasonNumber: 1,
+      episodeNumber: 3,
+      episodeTitle: 'Pilot',
+    });
   });
 
   it('falls back to the media file link when the row carries none', () => {
@@ -21,7 +30,12 @@ describe('episodeScope', () => {
           mediaFile: { episode: episode(7, 2, 'Later') } as never,
         }),
       ),
-    ).toEqual({ seasonNumber: 2, episodeNumber: 7, episodeTitle: 'Later' });
+    ).toEqual({
+      episodeId: 700,
+      seasonNumber: 2,
+      episodeNumber: 7,
+      episodeTitle: 'Later',
+    });
   });
 
   it('prefers the row own link over the media file one', () => {
@@ -37,6 +51,7 @@ describe('episodeScope', () => {
 
   it('yields nulls for a movie subtitle', () => {
     expect(episodeScope(subtitleFile({ mediaFile: {} as never }))).toEqual({
+      episodeId: null,
       seasonNumber: null,
       episodeNumber: null,
       episodeTitle: null,

--- a/client/src/app/core/services/api/subtitles-api.service.ts
+++ b/client/src/app/core/services/api/subtitles-api.service.ts
@@ -200,6 +200,7 @@ export interface SubtitleHistoryEntry {
   mediaId: number;
   mediaTitle: string;
   mediaType: MediaType | null;
+  episodeId: number | null;
   seasonNumber: number | null;
   episodeNumber: number | null;
   episodeTitle: string | null;
@@ -226,7 +227,9 @@ export interface SubtitleStats {
   byProvider: Record<string, number>;
   recent: {
     id: number;
+    mediaId: number;
     mediaTitle: string;
+    episodeId: number | null;
     seasonNumber: number | null;
     episodeNumber: number | null;
     episodeTitle: string | null;

--- a/client/src/app/features/activity/subtitles/subtitles.html
+++ b/client/src/app/features/activity/subtitles/subtitles.html
@@ -56,7 +56,14 @@
               >{{ entry.mediaTitle }}</a>
               @if (episodeLabel(entry)) {
                 <p class="text-xs font-normal text-base-content/60 truncate" [title]="episodeLabel(entry)">
-                  {{ episodeLabel(entry) }}
+                  @if (entry.episodeId != null) {
+                    <a
+                      [routerLink]="['/series', entry.mediaId, 'episode', entry.episodeId]"
+                      class="link link-hover"
+                    >{{ episodeLabel(entry) }}</a>
+                  } @else {
+                    {{ episodeLabel(entry) }}
+                  }
                 </p>
               }
             </td>

--- a/client/src/app/features/dashboard/dashboard.html
+++ b/client/src/app/features/dashboard/dashboard.html
@@ -149,7 +149,14 @@
                       <span class="block truncate">{{ r.mediaTitle }}</span>
                       @if (episodeLabel(r)) {
                         <span class="block text-xs font-normal text-base-content/60 truncate" [title]="episodeLabel(r)">
-                          {{ episodeLabel(r) }}
+                          @if (r.episodeId != null) {
+                            <a
+                              [routerLink]="['/series', r.mediaId, 'episode', r.episodeId]"
+                              class="link link-hover"
+                            >{{ episodeLabel(r) }}</a>
+                          } @else {
+                            {{ episodeLabel(r) }}
+                          }
                         </span>
                       }
                     </td>


### PR DESCRIPTION
Follow-up to #806, where the episode label was inert text.

## Changes

The label now routes to `/series/:id/episode/:episodeId` (`app.routes.ts:221`) — the same
episode route the Activities download queue already links to, so both activity views behave
alike.

That needed two ids the payloads did not carry: the resolved episode id (taken from whichever
link `episodeScope` settled on, row or media file, so the fallback path links correctly too)
and, on the dashboard recap, the media id — that endpoint only ever returned the media
*title*.

Rows with no resolved episode keep rendering plain text, so movies and whole-season rows are
untouched. The media title on the dashboard stays unlinked; making it a link was not asked
for, and the media id is now available if you want it later.

## Tests

The scope spec asserts the episode id on all four paths (row link, media-file fallback, row
winning over file, movie yielding nulls). 624 backend tests green, backend and client
typecheck clean, production client build clean.
