### PR TITLE
feat(media-detail): punctuate the stream info labels

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -770,9 +770,9 @@
     "no_local_credits": "Keine lokalen Credits für diese Person"
   },
   "media_info": {
-    "video": "Video",
-    "audio": "Audio",
-    "subtitles": "Untertitel",
+    "video": "Video:",
+    "audio": "Audio:",
+    "subtitles": "Untertitel:",
     "directors": "Regisseure",
     "watched": "Gesehen",
     "ends_at": "Endet um {{time}}",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -775,9 +775,9 @@
     "no_local_credits": "No local credits for this person"
   },
   "media_info": {
-    "video": "Video",
-    "audio": "Audio",
-    "subtitles": "Subtitles",
+    "video": "Video:",
+    "audio": "Audio:",
+    "subtitles": "Subtitles:",
     "directors": "Directors",
     "watched": "Watched",
     "ends_at": "Ends at {{time}}",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -770,9 +770,9 @@
     "no_local_credits": "No hay créditos locales para esta persona"
   },
   "media_info": {
-    "video": "Vídeo",
-    "audio": "Audio",
-    "subtitles": "Subtítulos",
+    "video": "Vídeo:",
+    "audio": "Audio:",
+    "subtitles": "Subtítulos:",
     "directors": "Directores",
     "watched": "Visto",
     "ends_at": "Termina a las {{time}}",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -775,9 +775,9 @@
     "no_local_credits": "Aucun crédit local pour cette personne"
   },
   "media_info": {
-    "video": "Vidéo",
-    "audio": "Audio",
-    "subtitles": "Sous-titres",
+    "video": "Vidéo :",
+    "audio": "Audio :",
+    "subtitles": "Sous-titres :",
     "directors": "Réalisateurs",
     "watched": "Lu",
     "ends_at": "Se termine à {{time}}",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -770,9 +770,9 @@
     "no_local_credits": "Nessun credito locale per questa persona"
   },
   "media_info": {
-    "video": "Video",
-    "audio": "Audio",
-    "subtitles": "Sottotitoli",
+    "video": "Video:",
+    "audio": "Audio:",
+    "subtitles": "Sottotitoli:",
     "directors": "Registi",
     "watched": "Visto",
     "ends_at": "Termina alle {{time}}",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -770,9 +770,9 @@
     "no_local_credits": "Nenhum crédito local para esta pessoa"
   },
   "media_info": {
-    "video": "Vídeo",
-    "audio": "Áudio",
-    "subtitles": "Legendas",
+    "video": "Vídeo:",
+    "audio": "Áudio:",
+    "subtitles": "Legendas:",
     "directors": "Realizadores",
     "watched": "Visto",
     "ends_at": "Termina às {{time}}",


### PR DESCRIPTION
## Before / after

`Vidéo 1080p H.264` → `Vidéo : 1080p H.264`, same for Audio and Subtitles above the stream
selectors on the media detail header.

## Where the colon lives

In the translations, not the template. The spacing around a colon is a typographic rule that
differs by language, so a hardcoded `:` in the markup would be wrong in French and a
hardcoded `&nbsp;:` wrong everywhere else:

| locale | value |
|---|---|
| fr | `Vidéo :` (U+00A0 before the colon) |
| en | `Video:` |
| pt | `Vídeo:` |
| de | `Video:` |
| it | `Video:` |
| es | `Vídeo:` |

The French space is a real non-breaking space (U+00A0, verified in the written file, not a
plain space) — which is also what keeps the colon from wrapping onto its own line away from
the word. The other five need nothing: the colon is glued to the word, so no break point
exists there.

No CSS `whitespace-nowrap` was added; it would be redundant against the U+00A0 and would also
stop the label itself from wrapping, which is not wanted.

## Scope

`media_info.video`, `media_info.audio` and `media_info.subtitles` are referenced only by this
block (`media-info-header.html:423`, `:436`, `:464`), so no other screen inherits the
punctuation. Template untouched — the diff is 3 strings × 6 locales.

Client suite 39 passed, production build clean.
