### PR TITLE
feat(media-detail): move the episode count under the season in its picker

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -783,6 +783,8 @@
     "cast": "Besetzung",
     "crew": "Technisches Team",
     "episodes": "Folgen",
+    "episode_count_one": "{{count}} Episode",
+    "episode_count_other": "{{count}} Episoden",
     "back": "Zurück zur Liste",
     "request_media": "Anfragen",
     "request_season": "Diese Staffel anfragen",

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -896,6 +896,7 @@
     "mark_series_unwatched": "Serie als nicht gesehen markieren",
     "seasons_section": "Staffeln & Folgen",
     "season": "Staffel",
+    "season_number": "Staffel {{number}}",
     "more_from_season": "Mehr aus Staffel {{season}}",
     "other_seasons_of": "Andere Staffeln von {{title}}",
     "col_ep": "F.",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -901,6 +901,7 @@
     "mark_series_unwatched": "Mark series as unwatched",
     "seasons_section": "Seasons & episodes",
     "season": "Season",
+    "season_number": "Season {{number}}",
     "more_from_season": "More from season {{season}}",
     "other_seasons_of": "Other seasons of {{title}}",
     "col_ep": "Ep.",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -788,6 +788,8 @@
     "cast": "Cast",
     "crew": "Crew",
     "episodes": "Episodes",
+    "episode_count_one": "{{count}} episode",
+    "episode_count_other": "{{count}} episodes",
     "back": "Back to list",
     "request_media": "Request",
     "request_season": "Request this season",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -896,6 +896,7 @@
     "mark_series_unwatched": "Marcar la serie como no vista",
     "seasons_section": "Temporadas y episodios",
     "season": "Temporada",
+    "season_number": "Temporada {{number}}",
     "more_from_season": "Más de la temporada {{season}}",
     "other_seasons_of": "Otras temporadas de {{title}}",
     "col_ep": "Ep.",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -783,6 +783,8 @@
     "cast": "Reparto",
     "crew": "Equipo técnico",
     "episodes": "Episodios",
+    "episode_count_one": "{{count}} episodio",
+    "episode_count_other": "{{count}} episodios",
     "back": "Volver a la lista",
     "request_media": "Solicitar",
     "request_season": "Solicitar esta temporada",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -901,6 +901,7 @@
     "mark_series_unwatched": "Marquer la série comme non vue",
     "seasons_section": "Saisons & épisodes",
     "season": "Saison",
+    "season_number": "Saison {{number}}",
     "more_from_season": "Plus de saison {{season}}",
     "other_seasons_of": "Autres saisons de {{title}}",
     "col_ep": "Ep.",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -788,6 +788,8 @@
     "cast": "Casting",
     "crew": "Équipe technique",
     "episodes": "Épisodes",
+    "episode_count_one": "{{count}} épisode",
+    "episode_count_other": "{{count}} épisodes",
     "back": "Retour à la liste",
     "request_media": "Demander",
     "request_season": "Demander cette saison",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -896,6 +896,7 @@
     "mark_series_unwatched": "Segna la serie come non vista",
     "seasons_section": "Stagioni ed episodi",
     "season": "Stagione",
+    "season_number": "Stagione {{number}}",
     "more_from_season": "Altro dalla stagione {{season}}",
     "other_seasons_of": "Altre stagioni di {{title}}",
     "col_ep": "Ep.",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -783,6 +783,8 @@
     "cast": "Cast",
     "crew": "Troupe tecnica",
     "episodes": "Episodi",
+    "episode_count_one": "{{count}} episodio",
+    "episode_count_other": "{{count}} episodi",
     "back": "Torna all'elenco",
     "request_media": "Richiedi",
     "request_season": "Richiedi questa stagione",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -783,6 +783,8 @@
     "cast": "Elenco",
     "crew": "Equipa técnica",
     "episodes": "Episódios",
+    "episode_count_one": "{{count}} episódio",
+    "episode_count_other": "{{count}} episódios",
     "back": "Voltar à lista",
     "request_media": "Pedir",
     "request_season": "Pedir esta temporada",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -896,6 +896,7 @@
     "mark_series_unwatched": "Marcar a série como não vista",
     "seasons_section": "Temporadas e episódios",
     "season": "Temporada",
+    "season_number": "Temporada {{number}}",
     "more_from_season": "Mais da temporada {{season}}",
     "other_seasons_of": "Outras temporadas de {{title}}",
     "col_ep": "Ep.",

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -143,23 +143,19 @@
     </app-dropdown-menu>
     <app-dropdown-menu placement="bottom-start">
       <button trigger type="button" class="select select-bordered w-fit shrink-0 text-left cursor-pointer transition-colors hover:bg-base-content/10">
-        {{ 'media_detail.season' | translate }} {{ selSeason?.seasonNumber }}
+        @if (selSeason) {
+          {{ 'media_detail.season_number' | translate:{ number: selSeason.seasonNumber } }}
+        } @else {
+          {{ 'media_detail.season' | translate }}
+        }
       </button>
       @for (season of displaySeasons(); track season.id) {
-        <button
-          type="button"
-          class="dropdown-item"
-          [class.text-primary]="season.id === activeSeasonId()"
+        <app-dropdown-option
+          [head]="'media_detail.season_number' | translate:{ number: season.seasonNumber }"
+          [sub]="(tabEpisodeCount(season) <= 1 ? 'media_detail.episode_count_one' : 'media_detail.episode_count_other') | translate:{ count: tabEpisodeCount(season) }"
+          [selected]="season.id === activeSeasonId()"
           (click)="selectSeason.emit(season.id)"
-        >
-          <span class="flex-1 flex flex-col items-start gap-0 leading-tight text-left">
-            <span>{{ 'media_detail.season' | translate }} {{ season.seasonNumber }}</span>
-            <span class="text-xs md:text-sm opacity-60">
-              {{ (tabEpisodeCount(season) <= 1 ? 'media_detail.episode_count_one' : 'media_detail.episode_count_other') | translate:{ count: tabEpisodeCount(season) } }}
-            </span>
-          </span>
-          @if (season.id === activeSeasonId()) { <span class="h-2 w-2 rounded-full bg-primary shrink-0"></span> }
-        </button>
+        />
       }
     </app-dropdown-menu>
     @if (selSeason && isSeasonTabVisible(selSeason) && !episodesHasFileOnly()) {

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -154,7 +154,7 @@
         >
           <span class="flex-1 flex flex-col items-start gap-0 leading-tight text-left">
             <span>{{ 'media_detail.season' | translate }} {{ season.seasonNumber }}</span>
-            <span class="text-xs opacity-60">
+            <span class="text-xs md:text-sm opacity-60">
               {{ (tabEpisodeCount(season) <= 1 ? 'media_detail.episode_count_one' : 'media_detail.episode_count_other') | translate:{ count: tabEpisodeCount(season) } }}
             </span>
           </span>

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -141,18 +141,27 @@
         }
       }
     </app-dropdown-menu>
-    <select
-      appTvSelect
-      class="select select-bordered w-fit shrink-0"
-      [ngModel]="activeSeasonId()"
-      (ngModelChange)="selectSeason.emit($event)"
-    >
+    <app-dropdown-menu placement="bottom-start">
+      <button trigger type="button" class="select select-bordered w-fit shrink-0 text-left cursor-pointer transition-colors hover:bg-base-content/10">
+        {{ 'media_detail.season' | translate }} {{ selSeason?.seasonNumber }}
+      </button>
       @for (season of displaySeasons(); track season.id) {
-        <option [ngValue]="season.id">
-          {{ 'media_detail.season' | translate }} {{ season.seasonNumber }} ({{ tabEpisodeCount(season) }})
-        </option>
+        <button
+          type="button"
+          class="dropdown-item"
+          [class.text-primary]="season.id === activeSeasonId()"
+          (click)="selectSeason.emit(season.id)"
+        >
+          <span class="flex-1 flex flex-col items-start gap-0 leading-tight text-left">
+            <span>{{ 'media_detail.season' | translate }} {{ season.seasonNumber }}</span>
+            <span class="text-xs opacity-60">
+              {{ (tabEpisodeCount(season) <= 1 ? 'media_detail.episode_count_one' : 'media_detail.episode_count_other') | translate:{ count: tabEpisodeCount(season) } }}
+            </span>
+          </span>
+          @if (season.id === activeSeasonId()) { <span class="h-2 w-2 rounded-full bg-primary shrink-0"></span> }
+        </button>
       }
-    </select>
+    </app-dropdown-menu>
     @if (selSeason && isSeasonTabVisible(selSeason) && !episodesHasFileOnly()) {
       @if (!selSeason.monitored) {
         <span class="badge badge-ghost shrink-0">{{ 'media_detail.unmonitored' | translate }}</span>

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -25,6 +25,7 @@ import {
 import { HorizontalScrollerComponent } from '../../../../shared/components/horizontal-scroller';
 import { MediaCardComponent } from '../../../../shared/components/media-card/media-card';
 import { DropdownMenuComponent } from '../../../../shared/components/dropdown-menu';
+import { DropdownOptionComponent } from '../../../../shared/components/dropdown-option/dropdown-option';
 import { TvRowDirective } from '../../../../shared/directives/tv-row.directive';
 import {
   Episode,
@@ -48,7 +49,7 @@ import { LocaleDatePipe } from '../../../../core/pipes/locale-date.pipe';
 
 @Component({
   selector: 'app-media-detail-seasons',
-  imports: [TranslateModule, UpperCasePipe, LocaleDatePipe, HorizontalScrollerComponent, MediaCardComponent, DropdownMenuComponent, TvRowDirective, LucideCheck, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideHeart, LucideListChecks, LucideListPlus, LucidePackage, LucideUserPlus, LucideX],
+  imports: [TranslateModule, UpperCasePipe, LocaleDatePipe, HorizontalScrollerComponent, MediaCardComponent, DropdownMenuComponent, DropdownOptionComponent, TvRowDirective, LucideCheck, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideHeart, LucideListChecks, LucideListPlus, LucidePackage, LucideUserPlus, LucideX],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-seasons.component.html',
 })

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -7,7 +7,6 @@ import {
   output,
 } from '@angular/core';
 import { UpperCasePipe } from '@angular/common';
-import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import {
   LucideCheck,
@@ -26,7 +25,6 @@ import {
 import { HorizontalScrollerComponent } from '../../../../shared/components/horizontal-scroller';
 import { MediaCardComponent } from '../../../../shared/components/media-card/media-card';
 import { DropdownMenuComponent } from '../../../../shared/components/dropdown-menu';
-import { TvSelectDirective } from '../../../../shared/directives/tv-select.directive';
 import { TvRowDirective } from '../../../../shared/directives/tv-row.directive';
 import {
   Episode,
@@ -50,7 +48,7 @@ import { LocaleDatePipe } from '../../../../core/pipes/locale-date.pipe';
 
 @Component({
   selector: 'app-media-detail-seasons',
-  imports: [TranslateModule, FormsModule, UpperCasePipe, LocaleDatePipe, HorizontalScrollerComponent, MediaCardComponent, DropdownMenuComponent, TvSelectDirective, TvRowDirective, LucideCheck, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideHeart, LucideListChecks, LucideListPlus, LucidePackage, LucideUserPlus, LucideX],
+  imports: [TranslateModule, UpperCasePipe, LocaleDatePipe, HorizontalScrollerComponent, MediaCardComponent, DropdownMenuComponent, TvRowDirective, LucideCheck, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideHeart, LucideListChecks, LucideListPlus, LucidePackage, LucideUserPlus, LucideX],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-seasons.component.html',
 })

--- a/client/src/app/shared/components/dropdown-option/dropdown-option.html
+++ b/client/src/app/shared/components/dropdown-option/dropdown-option.html
@@ -1,0 +1,11 @@
+<button type="button" class="dropdown-item" [class.text-primary]="selected()">
+  <span class="flex-1 flex flex-col items-start gap-0 leading-tight text-left">
+    <span>{{ head() }}</span>
+    @if (sub()) {
+      <span class="text-xs md:text-sm opacity-60">{{ sub() }}</span>
+    }
+  </span>
+  @if (selected()) {
+    <span class="h-2 w-2 rounded-full bg-primary shrink-0"></span>
+  }
+</button>

--- a/client/src/app/shared/components/dropdown-option/dropdown-option.ts
+++ b/client/src/app/shared/components/dropdown-option/dropdown-option.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+/**
+ * One option of an `app-dropdown-menu`: a head line, an optional detail line,
+ * and the selected marker. Shared by the audio, subtitle and season pickers,
+ * which render the same shape.
+ *
+ * Both labels arrive already translated — the component holds no user-facing
+ * string of its own. The host is `display: contents` so `.dropdown-item`'s
+ * `w-full` keeps resolving against the menu, not against a wrapper.
+ *
+ * Selection is reported by binding `(click)` on the element: the inner button's
+ * event bubbles through, which is also how the menu closes itself.
+ */
+@Component({
+  selector: 'app-dropdown-option',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './dropdown-option.html',
+  host: { class: 'contents' },
+})
+export class DropdownOptionComponent {
+  readonly head = input.required<string>();
+  readonly sub = input<string | null | undefined>(null);
+  readonly selected = input(false);
+}

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -450,7 +450,7 @@
                 >
                   <span class="flex-1 flex flex-col items-start gap-0 leading-tight text-left">
                     <span>{{ t.head || t.label }}</span>
-                    @if (t.sub) { <span class="text-xs opacity-60">{{ t.sub }}</span> }
+                    @if (t.sub) { <span class="text-xs md:text-sm opacity-60">{{ t.sub }}</span> }
                   </span>
                   @if (t.index === selectedAudioIndex()) { <span class="h-2 w-2 rounded-full bg-primary shrink-0"></span> }
                 </button>
@@ -487,7 +487,7 @@
                 >
                   <span class="flex-1 flex flex-col items-start gap-0 leading-tight text-left">
                     <span>{{ s.head || s.label }}</span>
-                    @if (s.sub) { <span class="text-xs opacity-60">{{ s.sub }}</span> }
+                    @if (s.sub) { <span class="text-xs md:text-sm opacity-60">{{ s.sub }}</span> }
                   </span>
                   @if (s.id === selectedSubtitleId()) { <span class="h-2 w-2 rounded-full bg-primary shrink-0"></span> }
                 </button>

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -442,18 +442,12 @@
                 {{ selectedAudio()?.head || selectedAudio()?.label }}
               </button>
               @for (t of audioTracks(); track t.index) {
-                <button
-                  type="button"
-                  class="dropdown-item"
-                  [class.text-primary]="t.index === selectedAudioIndex()"
+                <app-dropdown-option
+                  [head]="t.head || t.label"
+                  [sub]="t.sub"
+                  [selected]="t.index === selectedAudioIndex()"
                   (click)="onAudioChange(t.index)"
-                >
-                  <span class="flex-1 flex flex-col items-start gap-0 leading-tight text-left">
-                    <span>{{ t.head || t.label }}</span>
-                    @if (t.sub) { <span class="text-xs md:text-sm opacity-60">{{ t.sub }}</span> }
-                  </span>
-                  @if (t.index === selectedAudioIndex()) { <span class="h-2 w-2 rounded-full bg-primary shrink-0"></span> }
-                </button>
+                />
               }
             </app-dropdown-menu>
           }
@@ -469,28 +463,18 @@
               <button trigger type="button" class="select select-bordered select-sm w-fit text-left cursor-pointer transition-colors hover:bg-base-content/10">
                 {{ selectedSubtitle()?.head || selectedSubtitle()?.label || ('player.off' | translate) }}
               </button>
-              <button
-                type="button"
-                class="dropdown-item"
-                [class.text-primary]="!selectedSubtitleId()"
+              <app-dropdown-option
+                [head]="'player.off' | translate"
+                [selected]="!selectedSubtitleId()"
                 (click)="onSubtitleChange(null)"
-              >
-                <span class="flex-1 text-left">{{ 'player.off' | translate }}</span>
-                @if (!selectedSubtitleId()) { <span class="h-2 w-2 rounded-full bg-primary shrink-0"></span> }
-              </button>
+              />
               @for (s of subtitles(); track s.id) {
-                <button
-                  type="button"
-                  class="dropdown-item"
-                  [class.text-primary]="s.id === selectedSubtitleId()"
+                <app-dropdown-option
+                  [head]="s.head || s.label"
+                  [sub]="s.sub"
+                  [selected]="s.id === selectedSubtitleId()"
                   (click)="onSubtitleChange(s.id)"
-                >
-                  <span class="flex-1 flex flex-col items-start gap-0 leading-tight text-left">
-                    <span>{{ s.head || s.label }}</span>
-                    @if (s.sub) { <span class="text-xs md:text-sm opacity-60">{{ s.sub }}</span> }
-                  </span>
-                  @if (s.id === selectedSubtitleId()) { <span class="h-2 w-2 rounded-full bg-primary shrink-0"></span> }
-                </button>
+                />
               }
             </app-dropdown-menu>
           }

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -51,6 +51,7 @@ import {
   resolutionFromQualityName,
 } from '../../../core/utils/player.utils';
 import { DropdownMenuComponent } from '../dropdown-menu';
+import { DropdownOptionComponent } from '../dropdown-option/dropdown-option';
 import { ProgressBadgeComponent } from '../progress-badge/progress-badge.component';
 import { ImgFadeInDirective } from '../../directives/img-fade-in.directive';
 import { TvRowDirective } from '../../directives/tv-row.directive';
@@ -100,7 +101,7 @@ interface AudioTrack {
   imports: [
     MobileFanartHeroComponent,
     ResolveUrlPipe,
-    DropdownMenuComponent,
+    DropdownMenuComponent, DropdownOptionComponent,
     ProgressBadgeComponent,
     ImgFadeInDirective,
     TvRowDirective,


### PR DESCRIPTION
## Before / after

```
Season 1 (12)          →   Season 1
                            12 episodes
```

The season picker was a native `<select>`; it now uses `app-dropdown-menu`, the same component
the audio and subtitle pickers of that header already use, with the count as the second line
of each entry. The three pickers in that row now behave identically.

The trigger shows the season alone, matching how the subtitle trigger shows only its head
line. The count still comes from `tabEpisodeCount`, so it keeps following the
"episodes on disk only" filter rather than becoming a static total.

## Commits

1. **The season picker** — dropdown instead of native select, count on a second line.
2. **`md:text-sm` on the option detail lines** — audio, subtitle and season together; at
   `text-xs` on every viewport they read cramped next to the head line on a desktop menu.
3. **`app-dropdown-option` extracted** — see below.

## The shared option component

Commit 2 had to edit the same class in three files, which is what made the copied markup worth
removing — not the line count, since the extraction nets four lines. The value is one place to
change that visual.

Deliberately narrow: `.dropdown-item` is used ~80 times across the app in unrelated shapes
(toggle rows, icon rows, plain buttons). Only the two-line-with-selected-marker shape repeats,
and only that shape moved. Inputs are `head`, `sub`, `selected`; selection is reported by
binding `(click)` on the element.

Checked rather than assumed, since the extraction adds a DOM level:

- the host is `display: contents` (already used inside `dropdown-menu`), so `.dropdown-item`'s
  `w-full` keeps resolving against the menu instead of a shrink-to-fit wrapper;
- the menu closes via `target.closest('a, button')`, which the inner button satisfies through
  bubbling;
- TV navigation collects targets with `FOCUSABLE_SELECTOR` scoped to `[data-tv-modal]` /
  `.dropdown-content`, matching `button` at any depth — nesting is irrelevant to it.

The subtitle "off" entry joins the component too; the detail line being optional makes it a
single-line option, visually what it was.

## i18n

- `media_detail.episode_count_one` / `_other`, chosen in the template — the convention already
  set by `common.item_count_one` / `_other`.
- `media_detail.season_number` (`Season {{number}}`) replaces concatenating the translation
  with the number in the template, so a locale can order the two itself. The six supported
  locales all happen to put the word first, but the template no longer decides that.
- The component itself holds no string: both labels arrive translated from the caller.

## Also

The output contract is unchanged: `selectSeason` is still `output<number>()` receiving the
season id, previously through `[ngValue]` + `ngModel`, now emitted directly.

`FormsModule` and `TvSelectDirective` were removed from the seasons component — that select
was the last `ngModel` and `appTvSelect` in its template.

## Tests

Client suite 39 passed, typecheck clean, production build clean with no new warnings (the two
that remain, `NG8102` and `NG8113`, both point at `SearchComponent` and predate this branch).

No spec added: what changed is markup, a plural ternary and a component with three inputs and
no logic.

Worth a look on a TV before you trust it: the picker's keyboard path moves from a native select
to the dropdown. I verified the selector and close-check mechanics by reading them, not on a
device.