### PR TITLE
fix(player): number the subtitle tracks a file left untagged

### DIFF
--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -752,9 +752,9 @@ export class CastPlayerService {
       subsResult,
       opts.mediaFileId,
       { hideBurnIn: this.appSettings.hideBurnInSubtitles() },
-    ).map((t) => ({
+    ).map((t, i) => ({
       id: t.key,
-      label: formatSubtitleLabel(t, this.translate, undefined, {
+      label: formatSubtitleLabel(t, this.translate, i + 1, {
         showFormat: this.appSettings.showSubtitleFormat(),
       }),
       language: t.language,

--- a/client/src/app/core/services/download-manager.service.ts
+++ b/client/src/app/core/services/download-manager.service.ts
@@ -375,7 +375,7 @@ export class DownloadManagerService {
           language: sub.language,
           // Same normalized label as online playback (localized language name +
           // HI/Forced) instead of the raw language code.
-          label: formatSubtitleLabel(sub, this.translate, undefined, {
+          label: formatSubtitleLabel(sub, this.translate, offlineSubs.length + 1, {
             showFormat: this.appSettings.showSubtitleFormat(),
           }),
           forced: sub.forced,

--- a/client/src/app/core/services/track-manager.service.ts
+++ b/client/src/app/core/services/track-manager.service.ts
@@ -158,11 +158,11 @@ export class TrackManagerService {
       const labelOpts = { showFormat: this.appSettings.showSubtitleFormat() };
       const subs = await this.subtitlesApi.getForMedia(mediaId);
       const tracks = buildSubtitleTracks(subs, mediaFileId, { hideBurnIn });
-      const options: SubtitleOption[] = tracks.map((t) => {
-        const parts = formatSubtitleParts(t, this.translate, undefined, labelOpts);
+      const options: SubtitleOption[] = tracks.map((t, i) => {
+        const parts = formatSubtitleParts(t, this.translate, i + 1, labelOpts);
         return {
         id: t.key,
-        label: formatSubtitleLabel(t, this.translate, undefined, labelOpts),
+        label: formatSubtitleLabel(t, this.translate, i + 1, labelOpts),
         menuHead: parts.head,
         menuSub: parts.sub,
         url:
@@ -190,10 +190,13 @@ export class TrackManagerService {
           if (seen.has(key)) continue;
           seen.add(key);
           if (isImageBasedSubtitleCodec(emb.codec)) continue; // Bitmap from streamInfo only (no DB ID for burn-in)
-          const embParts = formatSubtitleParts(emb, this.translate, undefined, labelOpts);
+          // Numbering continues the list, so a track keeps the position the
+          // menu shows it at.
+          const trackNumber = options.length + 1;
+          const embParts = formatSubtitleParts(emb, this.translate, trackNumber, labelOpts);
           options.push({
             id: key,
-            label: formatSubtitleLabel(emb, this.translate, undefined, labelOpts),
+            label: formatSubtitleLabel(emb, this.translate, trackNumber, labelOpts),
             menuHead: embParts.head,
             menuSub: embParts.sub,
             url: streamingApi.getEmbeddedSubtitleUrl(mediaFileId, emb.streamIndex),

--- a/client/src/app/core/utils/subtitle-label-format.spec.ts
+++ b/client/src/app/core/utils/subtitle-label-format.spec.ts
@@ -31,6 +31,26 @@ describe('subtitle label file format', () => {
     );
   });
 
+  it('numbers a track the file left untagged', () => {
+    const untagged = { codec: 'subrip' };
+    expect(formatSubtitleLabel(untagged, translate, 3)).toContain(
+      'player.subtitle_track_n',
+    );
+    expect(formatSubtitleParts(untagged, translate, 3).head).toContain(
+      'player.subtitle_track_n',
+    );
+  });
+
+  it('keeps the language name when the track has one', () => {
+    expect(formatSubtitleParts(srt, translate, 3).head).not.toContain(
+      'player.subtitle_track_n',
+    );
+  });
+
+  it('falls back to the bare code when no number is supplied', () => {
+    expect(formatSubtitleParts({ codec: 'subrip' }, translate).head).toBe('und');
+  });
+
   it('derives the format from the file extension when the codec is absent', () => {
     const byPath = { language: 'eng', relativePath: 'Show.S01E01.en.vtt' };
     expect(

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -404,9 +404,9 @@ export class SubtitlesModalComponent {
         !(hideBurnIn && isImageBasedSubtitleCodec(s.codec)),
     );
     const labelOpts = { showFormat: this.appSettings.showSubtitleFormat() };
-    return subs.map((s) => {
+    return subs.map((s, i) => {
       const id = s.streamIndex != null ? `emb-${s.streamIndex}` : `ext-${s.id}`;
-      const parts = formatSubtitleParts(s, this.translate, undefined, labelOpts);
+      const parts = formatSubtitleParts(s, this.translate, i + 1, labelOpts);
       return {
         id,
         label: parts.sub ? `${parts.head} — ${parts.sub}` : parts.head,


### PR DESCRIPTION
## The dead fallback

`formatSubtitleLabel` / `formatSubtitleParts` already contain this:

```ts
const head = trackIndex != null && (norm === 'und' || norm === 'xx')
  ? translate.instant('player.subtitle_track_n', { index: trackIndex })
  : localizeLanguage(sub.language, translate);
```

`player.subtitle_track_n` is translated in all six locales. But every caller passed
`undefined` for `trackIndex`, so the branch was unreachable and an untagged track rendered as
a bare `und`. Audio never had the problem — it passes `i + 1`, which is why the same menu
shows `1 (EAC3 - 5.1)` for audio and `und` for subtitles.

Found on a real file: a Rick and Morty HDTV remux whose **every** stream (video, audio, four
`subrip` tracks) carries no language tag, producing four indistinguishable `und` rows. The
tracks are in fact English, English SDH (the `hearing_impaired` disposition is read correctly
and does show), Latin-American Spanish and Brazilian Portuguese — identified by extracting the
text, which is not something the client can do.

## Numbering choice

Position in the menu, like audio. A track named by its language still occupies a number, so
the unnamed ones read `Subtitle 3`, `Subtitle 4` after `English` and `French`. The alternative
— numbering only the unnamed ones from 1 — would collide conceptually with the named entries
and require duplicating the `und` test at every call site, which the formatter already owns.

In `track-manager` the streamInfo pass continues from `options.length + 1`, so the DB-backed
and streamInfo-backed tracks form one sequence rather than two overlapping ones.

## Scope

All four pickers: player (`track-manager`), media detail (`subtitles-modal`), cast
(`cast-player`) and offline downloads (`download-manager`).

## Tests

Three cases added on the fallback, which had none: an untagged track numbered, a track with a
language keeping its name, and no number supplied still yielding the bare code (so the
previous behaviour stays pinned for callers that pass nothing). 42 client tests green,
typecheck clean, production build clean.

## What this does not fix

The label still says `Subtitle 3`, not `Spanish`. Recovering the real language means detecting
it from the subtitle text at scan time, in the backend — a separate job, and the only way,
since the container holds nothing to read.
