### PR TITLE
fix(player): apply fill screen on every native renderer

### DIFF
--- a/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
@@ -662,6 +662,24 @@ public class NativePlayerPlugin extends Plugin {
         }
     }
 
+    // ── Display ──
+
+    @PluginMethod()
+    public void setFillScreen(PluginCall call) {
+        boolean fill = call.getBoolean("fill", false);
+        mainHandler.post(() -> {
+            // ZOOM crops the overflowing axis while keeping the aspect ratio
+            // (what object-fit: cover does on the browser path); FILL would
+            // stretch. The wrapper clips the overflow — clipChildren default.
+            if (aspectFrame != null) {
+                aspectFrame.setResizeMode(fill
+                        ? AspectRatioFrameLayout.RESIZE_MODE_ZOOM
+                        : AspectRatioFrameLayout.RESIZE_MODE_FIT);
+            }
+            call.resolve();
+        });
+    }
+
     // ── Brightness ──
 
     @PluginMethod()

--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -36,6 +36,7 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "getSubtitleTracks", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "selectSubtitleTrack", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setSubtitleStyle", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setFillScreen", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setBrightness", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setMaxResolution", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getPosition", returnType: CAPPluginReturnPromise),
@@ -597,6 +598,19 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     // MARK: - Brightness
+
+    // MARK: - Display
+
+    /// Crop-to-fill vs letterbox. `resizeAspectFill` is the AVPlayerLayer
+    /// equivalent of `object-fit: cover` — the layer clips the overflow itself.
+    @objc func setFillScreen(_ call: CAPPluginCall) {
+        let fill = call.getBool("fill") ?? false
+
+        DispatchQueue.main.async { [weak self] in
+            self?.playerLayer?.videoGravity = fill ? .resizeAspectFill : .resizeAspect
+            call.resolve()
+        }
+    }
 
     @objc func setBrightness(_ call: CAPPluginCall) {
         let brightness = call.getFloat("brightness") ?? -1

--- a/client/src/app/core/plugins/desktop-player.bridge.ts
+++ b/client/src/app/core/plugins/desktop-player.bridge.ts
@@ -88,6 +88,8 @@ export interface FliksDesktopApi {
    *  reuses an already-loaded track for the same URL instead of duplicating. */
   subAdd(url: string, label: string, language: string): Promise<void>;
   setSubtitleStyle(style: DesktopSubtitleStyle): Promise<void>;
+  /** Crop the video to fill the window (mpv `panscan`) instead of letterboxing. */
+  setFillScreen(fill: boolean): Promise<void>;
   resize(rect: DesktopRect): Promise<void>;
   setFullscreen(enabled: boolean): Promise<void>;
   destroy(): Promise<void>;

--- a/client/src/app/core/plugins/native-player.plugin.ts
+++ b/client/src/app/core/plugins/native-player.plugin.ts
@@ -101,6 +101,13 @@ export interface NativePlayerPlugin {
     bottomMarginPercent: number;
   }): Promise<void>;
 
+  // ── Display ──
+
+  /** Crop the video to fill the surface (`true`) or letterbox it (`false`).
+   *  The engines render outside the <video> element, so the CSS object-fit
+   *  binding the browser path uses can't reach them. */
+  setFillScreen(options: { fill: boolean }): Promise<void>;
+
   // ── Brightness ──
 
   /** Set screen brightness. -1 = restore system default, 1.0 = max. */

--- a/client/src/app/core/services/playback-engine/desktop-engine.ts
+++ b/client/src/app/core/services/playback-engine/desktop-engine.ts
@@ -67,6 +67,7 @@ export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEng
     edgeType: string;
     bottomMarginPercent: number;
   } | null = null;
+  private _fillScreen = false;
 
   // ── Lifecycle ──
 
@@ -110,6 +111,9 @@ export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEng
     });
     if (this._subtitleStyle) {
       await this.bridge.setSubtitleStyle(this._subtitleStyle);
+    }
+    if (this._fillScreen) {
+      await this.bridge.setFillScreen(true).catch(() => {});
     }
     // Fresh media → fresh track ids; let the desired selection re-apply once
     // mpv reports the new track list (tracksChanged).
@@ -290,6 +294,12 @@ export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEng
     if (this._initialized) {
       this.bridge.setSubtitleStyle(this._subtitleStyle).catch(() => {});
     }
+  }
+
+  /** Match NativeEngine.setFillScreen: crop-to-fill instead of letterbox. */
+  setFillScreen(fill: boolean): void {
+    this._fillScreen = fill;
+    this.bridge.setFillScreen(fill).catch(() => {});
   }
 
   // ── Stats ──

--- a/client/src/app/core/services/playback-engine/native-engine.ts
+++ b/client/src/app/core/services/playback-engine/native-engine.ts
@@ -123,6 +123,9 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
     if (this._subtitleStyle) {
       await NativePlayer.setSubtitleStyle(this._subtitleStyle);
     }
+    if (this._fillScreen) {
+      await NativePlayer.setFillScreen({ fill: true }).catch(() => {});
+    }
 
     // A new MediaItem resurfaces fresh text tracks: drop the stale resolved
     // id and let the desired selection (kept across a silent reload —
@@ -159,6 +162,15 @@ export class NativeEngine extends AbstractPlaybackEngine implements PlaybackEngi
     if (this._initialized) {
       NativePlayer.setSubtitleStyle(this._subtitleStyle).catch(() => {});
     }
+  }
+
+  private _fillScreen = false;
+
+  /** Crop the video to fill the surface instead of letterboxing it. Re-applied
+   *  after load() so a surface rebuilt by an error retry keeps the mode. */
+  setFillScreen(fill: boolean): void {
+    this._fillScreen = fill;
+    NativePlayer.setFillScreen({ fill }).catch(() => {});
   }
 
   private _preloadedSubtitles: { url: string; language: string; label: string }[] = [];

--- a/client/src/app/core/services/playback-engine/tizen-engine.ts
+++ b/client/src/app/core/services/playback-engine/tizen-engine.ts
@@ -157,8 +157,21 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
     if (!this.avObject) return;
     try {
       webapis.avplay.setDisplayRect(0, 0, 1920, 1080);
-      webapis.avplay.setDisplayMethod('PLAYER_DISPLAY_MODE_LETTER_BOX');
+      // CROPPED_FULL keeps the aspect ratio and crops the overflowing axis (the
+      // object-fit: cover equivalent); FULL_SCREEN would stretch the picture.
+      webapis.avplay.setDisplayMethod(this._fillScreen
+        ? 'PLAYER_DISPLAY_MODE_CROPPED_FULL'
+        : 'PLAYER_DISPLAY_MODE_LETTER_BOX');
     } catch { /* invalid in NONE — re-applied post-prepare */ }
+  }
+
+  private _fillScreen = false;
+
+  /** Crop the video to fill the screen instead of letterboxing it. Stored so
+   *  the post-prepare / orientation re-applies keep the mode. */
+  setFillScreen(fill: boolean): void {
+    this._fillScreen = fill;
+    this.applyDisplayRect();
   }
 
   // ── Loading ─────────────────────────────────────────────────────────

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -587,6 +587,17 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     }
   });
 
+  /** Mirror the fill-screen toggle onto engines that paint outside the <video>
+      element (ExoPlayer / AVPlayer) — the object-fit binding in the template
+      only reaches the browser path. Duck-typed like the subtitle style. */
+  private readonly fillScreenEffect = effect(() => {
+    const fill = this.fillScreen();
+    const engine = this.engine as NativeEngine | null;
+    if (engine && typeof engine.setFillScreen === 'function') {
+      engine.setFillScreen(fill);
+    }
+  });
+
   /** Push appearance to the active renderer whenever the settings change, so the
       in-player subtitle appearance panel lands on the cue without a reload.
       Untracked: the appliers also read controlsVisible(), whose margin bump the

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -468,6 +468,9 @@ app.whenReady().then(async () => {
   ipcMain.handle(IPC.subAdd, (_e, url: string, label: string, language: string) =>
     addon.command(['sub-add', url, 'cached', label ?? '', language ?? '']),
   );
+  ipcMain.handle(IPC.setFillScreen, (_e, fill: boolean) =>
+    addon.setProperty('panscan', fill ? '1.0' : '0.0'),
+  );
   ipcMain.handle(IPC.setFullscreen, (_e, enabled: boolean) => addon.setFullscreen(enabled));
   ipcMain.handle(IPC.setSubtitleStyle, (_e, s: DesktopSubtitleStyle) => {
     if (!s) return;

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -39,6 +39,7 @@ export function registerPlayerIpc(session: PlayerSession): void {
   ipcMain.handle(IPC.setSubtitleStyle, (_e, style: DesktopSubtitleStyle) =>
     session.player.setSubtitleStyle(style),
   );
+  ipcMain.handle(IPC.setFillScreen, (_e, fill: boolean) => session.player.setFillScreen(fill));
   ipcMain.handle(IPC.setFullscreen, (_e, enabled: boolean) => session.setFullscreen(enabled));
   ipcMain.handle(IPC.resize, (_e, rect: DesktopRect) => session.resize(rect));
   ipcMain.handle(IPC.destroy, () => session.destroy());

--- a/desktop/src/main/mpv/mac-mpv-player.ts
+++ b/desktop/src/main/mpv/mac-mpv-player.ts
@@ -262,6 +262,10 @@ export class MacMpvPlayer extends TypedEmitter<PlayerBackendEvents> implements P
     for (const [name, value] of mpvSubtitleProps(style)) this.addon.setProperty(name, value);
   }
 
+  async setFillScreen(fill: boolean): Promise<void> {
+    this.addon.setProperty('panscan', fill ? '1.0' : '0.0');
+  }
+
   async destroy(): Promise<void> {
     this.firstFrameResolve?.(); // don't leave a pending load() hanging on teardown
     this.addon.stop();

--- a/desktop/src/main/mpv/mpv-player.ts
+++ b/desktop/src/main/mpv/mpv-player.ts
@@ -608,6 +608,10 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
     for (const [name, value] of mpvSubtitleProps(s)) await this.set(name, value);
   }
 
+  async setFillScreen(fill: boolean): Promise<void> {
+    await this.set('panscan', fill ? '1.0' : '0.0');
+  }
+
   /** Tear down the socket + process + IPC path. Idempotent; also marks the exit
    *  as intentional so the `exit` handler reports idle, not a crash. */
   private teardown(): void {

--- a/desktop/src/main/mpv/player-backend.ts
+++ b/desktop/src/main/mpv/player-backend.ts
@@ -51,5 +51,9 @@ export interface PlayerBackend extends TypedEmitter<PlayerBackendEvents> {
   selectSubtitleTrack(id: string | null): Promise<void>;
   subAdd(url: string, label: string, language: string): Promise<void>;
   setSubtitleStyle(style: DesktopSubtitleStyle): Promise<void>;
+  /** Crop the video to fill the window instead of letterboxing it. Implemented
+   *  with mpv `panscan` (0 = letterbox, 1 = crop the overflowing axis fully),
+   *  which keeps the aspect ratio — unlike `keepaspect=no`, which stretches. */
+  setFillScreen(fill: boolean): Promise<void>;
   destroy(): Promise<void>;
 }

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -38,6 +38,7 @@ const api: FliksDesktopApi = {
     ipcRenderer.invoke(IPC.subAdd, url, label, language),
   setSubtitleStyle: (style: DesktopSubtitleStyle) =>
     ipcRenderer.invoke(IPC.setSubtitleStyle, style),
+  setFillScreen: (fill: boolean) => ipcRenderer.invoke(IPC.setFillScreen, fill),
   resize: (rect: DesktopRect) => ipcRenderer.invoke(IPC.resize, rect),
   destroy: () => ipcRenderer.invoke(IPC.destroy),
   getSystemInfo: () => ipcRenderer.invoke(IPC.getSystemInfo),

--- a/desktop/src/shared/contract.ts
+++ b/desktop/src/shared/contract.ts
@@ -101,6 +101,7 @@ export const IPC = {
   selectSubtitleTrack: 'player:selectSubtitleTrack',
   subAdd: 'player:subAdd',
   setSubtitleStyle: 'player:setSubtitleStyle',
+  setFillScreen: 'player:setFillScreen',
   resize: 'player:resize',
   destroy: 'player:destroy',
   /** Host OS identity (name + version), resolved natively. */
@@ -236,6 +237,8 @@ export interface FliksDesktopApi {
    *  reuses an already-loaded track for the same URL instead of duplicating. */
   subAdd(url: string, label: string, language: string): Promise<void>;
   setSubtitleStyle(style: DesktopSubtitleStyle): Promise<void>;
+  /** Crop the video to fill the window (mpv `panscan`) instead of letterboxing. */
+  setFillScreen(fill: boolean): Promise<void>;
   resize(rect: DesktopRect): Promise<void>;
   destroy(): Promise<void>;
   /** Native host OS identity (e.g. { systemName: "macOS 26" }). */


### PR DESCRIPTION
## Problem

The fill-screen toggle only bound `object-fit` on the `<video>` element. Every engine that paints on its own surface never shows that element: ExoPlayer and AVPlayer composite behind the WebView, AVPlay owns a hardware plane, and mpv renders into the desktop window. The menu item was a no-op everywhere except the browser and webOS.

## Change

Each renderer now gets the mode that crops while preserving the aspect ratio (the `object-fit: cover` equivalent):

| Renderer | Mode |
| --- | --- |
| ExoPlayer (Android) | `RESIZE_MODE_ZOOM` |
| AVPlayerLayer (iOS) | `resizeAspectFill` |
| AVPlay (Tizen) | `PLAYER_DISPLAY_MODE_CROPPED_FULL` |
| mpv (desktop, all three backends) | `panscan` |

Their stretch counterparts (`RESIZE_MODE_FILL`, `FULL_SCREEN`, `keepaspect=no`) would distort the picture instead.

`NativeEngine` and `DesktopEngine` re-apply the value after `load()`, and the Tizen engine folds it into `applyDisplayRect`, so a surface rebuilt by an error retry or an orientation change doesn't silently fall back to letterbox while the menu still shows the toggle as on.

## Testing

Not yet validated on device — needs a check on Android, iOS, Tizen and desktop.
