### PR TITLE
fix(streaming): pin forced IDR on av1_amf explicitly

### DIFF
--- a/backend/src/modules/streaming/transcoding/codec/encoders/amf.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/amf.spec.ts
@@ -124,18 +124,12 @@ describe('AMF encoders', () => {
   });
 
   describe('closed-GOP flags', () => {
-    it('forces IDR + drops B-frames on h264/hevc', () => {
-      for (const enc of [h264Amf, hevcAmf, hevcAmfHdr10]) {
-        const args = enc.buildArgs(makeInput({ tonemap: enc !== h264Amf }));
+    it('forces IDR + drops B-frames on every AMF encoder', () => {
+      for (const enc of [h264Amf, hevcAmf, hevcAmfHdr10, av1Amf, av1AmfHdr10]) {
+        const args = enc.buildArgs(makeInput({ tonemap: enc === hevcAmfHdr10 }));
         expect(flag(args, '-forced_idr')).toBe('1');
         expect(flag(args, '-bf')).toBe('0');
       }
-    });
-
-    it('omits -forced_idr on av1_amf (unsupported option)', () => {
-      const args = av1Amf.buildArgs(makeInput({}));
-      expect(args).not.toContain('-forced_idr');
-      expect(flag(args, '-bf')).toBe('0');
     });
   });
 

--- a/backend/src/modules/streaming/transcoding/codec/encoders/av1-amf.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/av1-amf.ts
@@ -2,7 +2,7 @@ import type { EncoderDescriptor, EncoderInput, EncoderTarget } from '../types';
 import { av1CodecString } from '../codec-strings';
 import { hdrColorArgs, hlgFromHdr10 } from './helpers/hdr-variants';
 import { amfScaleFilter8bit, amfScaleFilter10bit } from './helpers/amf-filters';
-import { AV1_AMF_GOP_ARGS } from './helpers/amf-gop';
+import { AMF_GOP_ARGS } from './helpers/amf-gop';
 
 /** AMD AMF AV1 encoder — RDNA3 (RX 7000) and later. Older GPUs lack the
  *  AV1 encode unit; the runtime fallback catches the spawn error and drops
@@ -32,7 +32,7 @@ export const av1Amf: EncoderDescriptor = {
       bitrate,
       '-vf',
       amfScaleFilter8bit(input),
-      ...AV1_AMF_GOP_ARGS,
+      ...AMF_GOP_ARGS,
       '-g',
       String(target.gopSize),
       '-force_key_frames',
@@ -72,7 +72,7 @@ export const av1AmfHdr10: EncoderDescriptor = {
       bitrate,
       '-vf',
       amfScaleFilter10bit(input),
-      ...AV1_AMF_GOP_ARGS,
+      ...AMF_GOP_ARGS,
       '-g',
       String(target.gopSize),
       '-force_key_frames',

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/amf-gop.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/amf-gop.ts
@@ -1,10 +1,5 @@
-/** Closed-GOP flags for the AMF encoders — the generic HLS fix (each
- *  segment must start on a self-decodable IDR). `-forced_idr 1` makes every
- *  `force_key_frames` tick a real IDR; `-bf 0` drops B-frame reordering so
- *  the muxer cuts cleanly on the boundary. */
+/** Closed-GOP flags for the AMF encoders: `-forced_idr 1` makes every
+ *  `force_key_frames` tick a real IDR (av1_amf would emit an intra-only frame,
+ *  which keeps its references and is no random-access point), `-bf 0` drops
+ *  B-frame reordering so the muxer cuts on the boundary. */
 export const AMF_GOP_ARGS: readonly string[] = ['-forced_idr', '1', '-bf', '0'];
-
-/** AV1 AMF variant — `av1_amf` has no `-forced_idr` option (passing an
- *  unknown option aborts the encoder and drops it to the CPU fallback), so
- *  only `-bf 0` is applied. */
-export const AV1_AMF_GOP_ARGS: readonly string[] = ['-bf', '0'];


### PR DESCRIPTION
Follow-up to the #761 investigation (that issue itself is a no-op — see the comment there).

## Problem

`AV1_AMF_GOP_ARGS` omitted `-forced_idr 1`, documented as "av1_amf has no `-forced_idr` option". That was true on FFmpeg 7.1; it is not true on the 8.1 base we vendor:

- `libavcodec/amfenc_av1.c` declares `{ "forced_idr", …, { .i64 = 0 }, 0, 1, VE }`.
- `libavcodec/amfenc.c`, `case AV_CODEC_ID_AV1` on `AV_PICTURE_TYPE_I`:
  - flag set → `AV1_FORCE_FRAME_TYPE_KEY` + `AV1_FORCE_INSERT_SEQUENCE_HEADER`
  - flag unset → `AV1_FORCE_FRAME_TYPE_INTRA_ONLY`

An AV1 intra-only frame keeps its reference buffers and carries no sequence header, so it is not the random-access point `-hls_flags independent_segments` advertises to the player.

## Severity: latent, not live

`jellyfin-ffmpeg` (vendored by `windows/Scripts/fetch-vendored.ps1`, v8.1.2-1) patches the `forced_idr` default to `1` for all three AMF encoders in `0005-add-amf-fixes-from-upstream-and-custom-tunings.patch`. The shipped Windows binary therefore already forces real key frames, and this PR changes no observable behaviour there. What it changes is the dependency: the argv now states the requirement instead of inheriting it from a downstream patch that a build change could drop.

## Change

- `-forced_idr 1` on `av1_amf`, via the shared `AMF_GOP_ARGS` — the AV1-specific constant is deleted, so `h264_amf`, `hevc_amf` and `av1_amf` now share one closed-GOP arg list.
- The golden argv test covers all five AMF descriptors instead of asserting the omission on AV1.

## Testing

`npx jest src/modules/streaming/transcoding/codec/encoders` — 108 passed. Typecheck clean.

Not validated on hardware: AV1 AMF requires an RDNA3+ AMD GPU, which no test rig has. A `ffmpeg -h encoder=av1_amf | grep forced_idr` on the Windows host confirms the option in one line.
