### PR TITLE
feat(subtitles): strip HI cues properly and drop the tag afterwards

### DIFF
--- a/backend/src/modules/subtitles/subtitle-cleaner.spec.ts
+++ b/backend/src/modules/subtitles/subtitle-cleaner.spec.ts
@@ -1,0 +1,105 @@
+import { cleanSubtitle } from './subtitle-cleaner';
+
+const clean = (srt: string): string =>
+  cleanSubtitle(Buffer.from(srt, 'utf-8'), {
+    removeAds: false,
+    removeHiTags: true,
+  }).toString('utf-8');
+
+const cue = (n: number, text: string): string =>
+  `${n}\n00:00:0${n},000 --> 00:00:0${n},900\n${text}`;
+
+describe('cleanSubtitle — HI removal', () => {
+  it('drops cues that are only a sound description', () => {
+    const out = clean([cue(1, '[door slams]'), cue(2, 'Hello.')].join('\n\n'));
+    expect(out).not.toContain('door slams');
+    expect(out).toContain('Hello.');
+    expect(out).toContain('1\n00:00:02,000'); // renumbered
+  });
+
+  it('removes a span that wraps across two lines', () => {
+    const out = clean(cue(1, '[distant\nthunder rumbling]\nRun!'));
+    expect(out).not.toContain('thunder');
+    expect(out).toContain('Run!');
+  });
+
+  it('handles CJK full-width parentheses and markers', () => {
+    const out = clean(
+      [
+        cue(1, '（咲太）おはよう'),
+        cue(2, '（学生たちの笑い声）'),
+        cue(3, '♬～'),
+        cue(4, '📱 もしもし ➡'),
+      ].join('\n\n'),
+    );
+    expect(out).toContain('おはよう');
+    expect(out).not.toContain('咲太');
+    expect(out).not.toContain('笑い声');
+    expect(out).not.toContain('♬');
+    expect(out).not.toContain('➡');
+    expect(out).toContain('もしもし');
+  });
+
+  it('keeps short parentheticals that carry no words', () => {
+    expect(clean(cue(1, 'Really(?)'))).toContain('Really(?)');
+  });
+
+  it('strips uppercase speaker labels but keeps the dialogue', () => {
+    const out = clean(cue(1, '- MAN: Get down!\n- WOMAN: Now!'));
+    expect(out).toContain('- Get down!');
+    expect(out).toContain('- Now!');
+    expect(out).not.toContain('MAN');
+  });
+
+  it('only strips a caps label when the colon ends it', () => {
+    expect(clean(cue(1, 'Meet me at 10:30 AM'))).toContain('10:30 AM');
+  });
+
+  it('strips a mixed-case label only when it recurs', () => {
+    const recurring = clean(
+      [cue(1, 'Rose: Hi there.'), cue(2, 'Rose: Again.')].join('\n\n'),
+    );
+    expect(recurring).toContain('Hi there.');
+    expect(recurring).not.toContain('Rose:');
+
+    expect(clean(cue(1, "Look: it's fine."))).toContain("Look: it's fine.");
+  });
+
+  it('drops bare uppercase sound cues', () => {
+    const out = clean([cue(1, 'DOOR CREAKING'), cue(2, 'Hi.')].join('\n\n'));
+    expect(out).not.toContain('CREAKING');
+    expect(out).toContain('Hi.');
+  });
+
+  it('keeps uppercase lines when the whole subtitle is uppercase', () => {
+    const out = clean(
+      [
+        cue(1, 'DOOR CREAKING'),
+        cue(2, 'WHAT ARE YOU DOING'),
+        cue(3, 'I AM LEAVING NOW'),
+      ].join('\n\n'),
+    );
+    expect(out).toContain('CREAKING');
+  });
+
+  it('keeps style tags but drops the ones it empties', () => {
+    const out = clean(
+      [
+        cue(1, '<font color="#00ff00">Hello</font>'),
+        cue(2, '<i>[sighs]</i>'),
+      ].join('\n\n'),
+    );
+    expect(out).toContain('<font color="#00ff00">Hello</font>');
+    expect(out).not.toContain('sighs');
+    expect(out).not.toContain('<i>');
+  });
+
+  it('leaves the subtitle untouched when the option is off', () => {
+    const srt = cue(1, '[door slams]\nMAN: Hello');
+    const out = cleanSubtitle(Buffer.from(srt, 'utf-8'), {
+      removeAds: false,
+    }).toString('utf-8');
+    expect(out).toContain('[door slams]');
+    expect(out).toContain('MAN: Hello');
+  });
+});

--- a/backend/src/modules/subtitles/subtitle-cleaner.ts
+++ b/backend/src/modules/subtitles/subtitle-cleaner.ts
@@ -19,16 +19,36 @@ const AD_PATTERNS: RegExp[] = [
   /captions\s+(by|copyright|paid)/i,
 ];
 
-/** HI tag patterns: [music playing], (sighs), ♪, etc. */
-const HI_TAG_PATTERNS: RegExp[] = [
-  /\[.*?\]/g,
-  /\(.*?\)/g,
-  /♪[^♪]*♪/g,
-  /♪/g,
-  /♫/g,
-  /🎵/g,
-  /🎶/g,
+/**
+ * Bracketed sound descriptions, half-width and CJK full-width.
+ * Matched across line breaks: an HI span often wraps mid-cue.
+ */
+const HI_SPANS: RegExp[] = [
+  /\[[\s\S]{1,300}?\]/g,
+  /\([\s\S]{1,300}?\)/g,
+  /（[\s\S]{1,300}?）/g,
+  /［[\s\S]{1,300}?］/g,
 ];
+
+/** Music, phone and line-continuation markers, incl. CJK subtitle conventions. */
+const HI_SYMBOLS = /[♪-♯¶\u{1F3B5}\u{1F3B6}\u{1F4F1}☎☏➡⇒]/gu;
+
+/** A line left with nothing but dashes, dots or CJK wave marks is noise. */
+const JUNK_LINE = /^[～〜~.…\-–—•\s]*$/;
+
+/** Speaker label at line start: `MAN:`, `- Rose:`. Colon must end the label. */
+const LABEL_LINE = /^([ \t]*)((?:[-–—][ \t]*)?)([^\n:]{1,30}):(?=[ \t]|$)/gm;
+
+/** A label that reads like a name: capitalised, at most three words. */
+const NAME_LABEL = /^\p{Lu}[\p{L}'’.\-]*(?: \p{Lu}[\p{L}'’.\-]*){0,2}$/u;
+
+/**
+ * Sound cues written as a bare uppercase line, with no brackets to key on.
+ * ponytail: English cue vocabulary — other languages fall back to the bracket
+ * and label rules, which are language-agnostic.
+ */
+const HI_CAPS_CUE =
+  /\b(LAUGH|CHUCKL|GIGGL|APPLAU|CLAP|CHEER|MUSIC|SONG|SINGING|PLAYING|THEME|SIGH|GASP|GRUNT|GROAN|MOAN|PANT|SCREAM|SHOUT|YELL|WHISPER|MUMBL|MUTTER|SOB|SNIFF|COUGH|SNORE|KNOCK|DOOR|BELL|PHONE|RING|BEEP|BUZZ|SIREN|ALARM|GUNSHOT|GUNFIRE|EXPLOSION|CRASH|BANG|THUD|CLANG|FOOTSTEP|ENGINE|TIRES|HORN|WIND|RAIN|THUNDER|BIRD|DOG|BARK|CLICK|CLATTER|RUSTL|SQUEAK|CREAK|SPLASH|STATIC|INDISTINCT|INAUDIBLE|CHATTER|SPEAKING|CONTINUES|NARRATOR|ANNOUNCER|VOICE|OVER|ON TV|ON RADIO)/;
 
 export interface CleanerOptions {
   /** Remove lines matching ad patterns (default: true) */
@@ -37,6 +57,86 @@ export interface CleanerOptions {
   removeHiTags?: boolean;
   /** Custom regex patterns to remove lines (user-configured) */
   customExclusions?: string[];
+}
+
+/** Keep `(?)` and `(12)`: a span is HI only if it holds real words. */
+function isSoundSpan(span: string): boolean {
+  const inner = span.slice(1, -1).trim();
+  return inner.length >= 2 && /[\p{L}\p{N}]/u.test(inner);
+}
+
+function stripSpansAndSymbols(text: string): string {
+  let out = text;
+  for (const re of HI_SPANS) {
+    out = out.replace(re, (m) => (isSoundSpan(m) ? '' : m));
+  }
+  return out.replace(HI_SYMBOLS, '');
+}
+
+function isCapsLabel(label: string): boolean {
+  const upper = label.replace(/[^\p{Lu}]/gu, '');
+  return upper.length >= 2 && !/\p{Ll}/u.test(label);
+}
+
+/**
+ * Mixed-case labels are only safe to strip when they recur: a real speaker name
+ * comes back, whereas `Look: it's fine` is a one-off line of dialogue.
+ */
+function recurringNameLabels(cues: string[]): Set<string> {
+  const counts = new Map<string, number>();
+  for (const cue of cues) {
+    for (const m of cue.matchAll(LABEL_LINE)) {
+      const label = m[3].trim();
+      if (!NAME_LABEL.test(label)) continue;
+      counts.set(label, (counts.get(label) ?? 0) + 1);
+    }
+  }
+  return new Set(
+    [...counts].filter(([, n]) => n >= 2).map(([label]) => label),
+  );
+}
+
+function stripLabels(text: string, recurring: Set<string>): string {
+  return text.replace(LABEL_LINE, (match, indent, dash, label: string) => {
+    const trimmed = label.trim();
+    if (isCapsLabel(trimmed) || recurring.has(trimmed)) return indent + dash;
+    return match;
+  });
+}
+
+/** Share of text lines that are fully uppercase — a whole sub can be shouted. */
+function uppercaseRatio(cues: string[]): number {
+  let total = 0;
+  let caps = 0;
+  for (const cue of cues) {
+    for (const line of cue.split('\n')) {
+      if (!/\p{L}/u.test(line)) continue;
+      total++;
+      if (!/\p{Ll}/u.test(line)) caps++;
+    }
+  }
+  return total ? caps / total : 0;
+}
+
+function isCapsSoundLine(line: string): boolean {
+  const letters = line.replace(/[^\p{L}]/gu, '');
+  if (letters.length < 4 || /\p{Ll}/u.test(line) || /[!?]/.test(line))
+    return false;
+  return HI_CAPS_CUE.test(line);
+}
+
+function tidy(text: string, shrunk: boolean): string {
+  const lines = text
+    .replace(/<(\w+)[^>]*>\s*<\/\1>/g, '')
+    .split('\n')
+    .map((l) => l.replace(/[ \t]{2,}/g, ' ').trim())
+    .filter((l) => l.length > 0 && !JUNK_LINE.test(l));
+
+  // A leading dialogue dash is meaningless once the other speaker's line is gone
+  if (shrunk && lines.length === 1) {
+    lines[0] = lines[0].replace(/^[-–—][ \t]*/, '');
+  }
+  return lines.filter((l) => l.length > 0).join('\n');
 }
 
 /**
@@ -66,12 +166,12 @@ export function cleanSubtitle(
 
   // Split into SRT blocks (separated by blank lines)
   const blocks = content.split(/\r?\n\r?\n/);
-  const cleaned: string[] = [];
+  const kept: { header: string[]; text: string; raw?: true }[] = [];
 
   for (const block of blocks) {
     const lines = block.split(/\r?\n/);
     if (lines.length < 2) {
-      cleaned.push(block);
+      if (block.trim()) kept.push({ header: [], text: block, raw: true });
       continue;
     }
 
@@ -89,34 +189,41 @@ export function cleanSubtitle(
 
     if (isAd) continue; // Skip this entire subtitle block
 
-    // Clean HI tags from text lines if requested
-    if (removeHiTags) {
-      const cleanedLines = textLines
-        .map((line) => {
-          let cleaned = line;
-          for (const pattern of HI_TAG_PATTERNS) {
-            cleaned = cleaned.replace(pattern, '');
-          }
-          return cleaned.trim();
-        })
-        .filter((line) => line.length > 0);
+    kept.push({ header: lines.slice(0, 2), text: textLines.join('\n') });
+  }
 
-      if (cleanedLines.length === 0) continue; // All text was HI tags
-      cleaned.push([...lines.slice(0, 2), ...cleanedLines].join('\n'));
-    } else {
-      cleaned.push(block);
+  if (removeHiTags) {
+    // Spans first: uppercase ratio and recurring labels both read cleaner text,
+    // otherwise a single mixed-case sound description skews the whole file.
+    const stripped = kept.map((b) =>
+      b.raw ? b.text : stripSpansAndSymbols(b.text),
+    );
+    const recurring = recurringNameLabels(stripped);
+    const dropCapsLines = uppercaseRatio(stripped) < 0.7;
+
+    for (let i = 0; i < kept.length; i++) {
+      if (kept[i].raw) continue;
+      let text = stripLabels(stripped[i], recurring);
+      if (dropCapsLines) {
+        text = text
+          .split('\n')
+          .filter((l) => !isCapsSoundLine(l))
+          .join('\n');
+      }
+      kept[i].text = tidy(text, text.length !== kept[i].text.length);
     }
   }
 
-  // Renumber blocks
+  // Renumber, dropping blocks whose text is now empty
   let index = 1;
-  const result = cleaned.map((block) => {
-    const lines = block.split(/\r?\n/);
-    if (lines.length >= 2 && /^\d+$/.test(lines[0].trim())) {
-      lines[0] = String(index++);
-    }
-    return lines.join('\n');
-  });
+  const result = kept
+    .filter((b) => b.text.trim().length > 0)
+    .map((b) => {
+      if (b.raw) return b.text;
+      const header = [...b.header];
+      if (/^\d+$/.test(header[0].trim())) header[0] = String(index++);
+      return [...header, b.text].join('\n');
+    });
 
   return Buffer.from(result.join('\n\n') + '\n', 'utf-8');
 }

--- a/backend/src/modules/subtitles/subtitle-ocr.service.ts
+++ b/backend/src/modules/subtitles/subtitle-ocr.service.ts
@@ -169,19 +169,22 @@ export class SubtitleOcrService {
         this.releaseOcrSlot();
       }
 
+      const removeHiTags =
+        (await this.settings.get('subtitle_remove_hi_tags')) === 'true';
       const cleaned = cleanSubtitle(Buffer.from(srt, 'utf-8'), {
         removeAds: true,
-        removeHiTags:
-          (await this.settings.get('subtitle_remove_hi_tags')) === 'true',
+        removeHiTags,
         customExclusions: ((await this.settings.get('subtitle_custom_exclusions')) ?? '')
           .split('\n')
           .filter((l) => l.trim()),
       });
 
       const parsed = path.parse(videoPath);
+      // The HI cues are stripped, so the output no longer warrants the tag
+      const hearingImpaired = source.hearingImpaired && !removeHiTags;
       const langSuffix = source.forced
         ? `${source.language}.forced`
-        : source.hearingImpaired
+        : hearingImpaired
           ? `${source.language}.hi`
           : source.language;
       let outPath = path.join(parsed.dir, `${parsed.name}.${langSuffix}.ocr.srt`);
@@ -200,6 +203,7 @@ export class SubtitleOcrService {
 
       await this.repo.update(placeholderId, {
         relativePath,
+        hearingImpaired,
         status: SubtitleStatus.DOWNLOADED,
       });
       this.log.log(

--- a/backend/src/modules/subtitles/subtitle-translation.service.ts
+++ b/backend/src/modules/subtitles/subtitle-translation.service.ts
@@ -237,10 +237,11 @@ export class SubtitleTranslationService {
         timing: c.timing,
         text: translated[i] ?? c.text,
       }));
+      const removeHiTags =
+        (await this.settings.get('subtitle_remove_hi_tags')) === 'true';
       const cleaned = cleanSubtitle(Buffer.from(serializeSrt(outCues), 'utf-8'), {
         removeAds: true,
-        removeHiTags:
-          (await this.settings.get('subtitle_remove_hi_tags')) === 'true',
+        removeHiTags,
         customExclusions: (
           (await this.settings.get('subtitle_custom_exclusions')) ?? ''
         )
@@ -249,9 +250,11 @@ export class SubtitleTranslationService {
       });
 
       const parsed = path.parse(videoPath);
+      // The HI cues are stripped, so the output no longer warrants the tag
+      const hearingImpaired = source.hearingImpaired && !removeHiTags;
       const langSuffix = source.forced
         ? `${target}.forced`
-        : source.hearingImpaired
+        : hearingImpaired
           ? `${target}.hi`
           : target;
       let outPath = path.join(parsed.dir, `${parsed.name}.${langSuffix}.srt`);
@@ -272,6 +275,7 @@ export class SubtitleTranslationService {
 
       await this.repo.update(placeholderId, {
         relativePath,
+        hearingImpaired,
         status: SubtitleStatus.DOWNLOADED,
       });
       this.log.log(

--- a/backend/src/modules/subtitles/subtitles.service.ts
+++ b/backend/src/modules/subtitles/subtitles.service.ts
@@ -260,10 +260,20 @@ export class SubtitlesService {
       );
     }
 
+    const removeHiTags =
+      (await this.settingsService.get('subtitle_remove_hi_tags')) === 'true';
+    const customExclusions = (
+      (await this.settingsService.get('subtitle_custom_exclusions')) ?? ''
+    )
+      .split('\n')
+      .filter((l) => l.trim());
+
     const lang = normalizeLanguageCode(searchResult.language);
+    // The HI cues are stripped below, so the file no longer warrants the tag
+    const hearingImpaired = searchResult.hearingImpaired && !removeHiTags;
     const langSuffix = searchResult.forced
       ? `${lang}.forced`
-      : searchResult.hearingImpaired
+      : hearingImpaired
         ? `${lang}.hi`
         : lang;
 
@@ -289,13 +299,6 @@ export class SubtitlesService {
     }
 
     // Clean subtitle content (remove ads, optionally HI tags)
-    const removeHiTags =
-      (await this.settingsService.get('subtitle_remove_hi_tags')) === 'true';
-    const customExclusions = (
-      (await this.settingsService.get('subtitle_custom_exclusions')) ?? ''
-    )
-      .split('\n')
-      .filter((l) => l.trim());
     buffer = cleanSubtitle(buffer, {
       removeAds: true,
       removeHiTags,
@@ -333,7 +336,7 @@ export class SubtitlesService {
       episode: episodeId ? { id: episodeId } : null,
       language: lang,
       forced: searchResult.forced,
-      hearingImpaired: searchResult.hearingImpaired,
+      hearingImpaired,
       providerType: provider.type,
       providerFileId: searchResult.providerFileId,
       relativePath,
@@ -519,6 +522,8 @@ export class SubtitlesService {
     language: string;
     forced: boolean;
     hearingImpaired: boolean;
+    /** Index of the HI token in the dot-separated name, for renaming */
+    hiPart: number | null;
   } | null {
     const ext = path.extname(filename).toLowerCase();
     if (!SubtitlesService.SUBTITLE_EXTS.has(ext)) return null;
@@ -529,6 +534,7 @@ export class SubtitlesService {
     let language = 'und';
     let forced = false;
     let hearingImpaired = false;
+    let hiPart: number | null = null;
 
     // Parse right-to-left (skip the leftmost parts = video name)
     for (let i = parts.length - 1; i >= 1; i--) {
@@ -541,6 +547,7 @@ export class SubtitlesService {
           language = 'hi';
         } else {
           hearingImpaired = true;
+          hiPart = i;
         }
       } else if (SubtitlesService.SKIP_FLAGS.has(token)) {
         // ignore 'default'
@@ -552,7 +559,20 @@ export class SubtitlesService {
       }
     }
 
-    return { language, forced, hearingImpaired };
+    return { language, forced, hearingImpaired, hiPart };
+  }
+
+  /**
+   * Drop the `.hi`/`.cc`/`.sdh` token from a subtitle filename.
+   * Without it a library rescan re-derives the flag from the name.
+   */
+  private stripHiFromFilename(filename: string): string | null {
+    const parsed = this.parseSubtitleFilename(filename);
+    if (!parsed || parsed.hiPart === null) return null;
+    const ext = path.extname(filename);
+    const parts = filename.slice(0, -ext.length).split('.');
+    parts.splice(parsed.hiPart, 1);
+    return parts.join('.') + ext;
   }
 
   /** Known ISO 639-1 codes from APP_LANGUAGES. */
@@ -870,6 +890,9 @@ export class SubtitlesService {
     }
 
     await fs.writeFile(abs, content, 'utf-8');
+    if (action === 'removeHiTags' && sub.hearingImpaired) {
+      await this.dropHiTag(sub, abs);
+    }
     sub.locked = true;
     await this.repo.save(sub);
     // Log a sample of the first timestamp to verify the change
@@ -878,5 +901,42 @@ export class SubtitlesService {
       `PostProcess #${subtitleId}: ${action} done (${sizeBefore} → ${content.length} chars, first timestamp: ${sampleMatch?.[0] ?? 'none'})`,
     );
     return sub;
+  }
+
+  /** Rename the file and clear the flag once the HI cues are gone. */
+  private async dropHiTag(sub: SubtitleFile, abs: string): Promise<void> {
+    const newName = this.stripHiFromFilename(path.basename(abs));
+    if (!newName) {
+      sub.hearingImpaired = false;
+      return;
+    }
+
+    const target = path.join(path.dirname(abs), newName);
+    // rename() overwrites silently, so refuse when a sibling already holds the name
+    const taken = await fs.access(target).then(
+      () => true,
+      () => false,
+    );
+    if (taken) {
+      this.logger.warn(
+        `Kept the HI tag on sub #${sub.id}: "${newName}" already exists`,
+      );
+      return;
+    }
+    try {
+      await fs.rename(abs, target);
+    } catch (err) {
+      this.logger.warn(
+        `Could not drop the HI tag on sub #${sub.id}: ${(err as Error).message}`,
+      );
+      return;
+    }
+
+    sub.hearingImpaired = false;
+    if (sub.relativePath) {
+      sub.relativePath = path
+        .join(path.dirname(sub.relativePath), newName)
+        .replace(/\\/g, '/');
+    }
   }
 }


### PR DESCRIPTION
## Why

The HI cleaner (`subtitle-cleaner.ts`) matched only ASCII `[...]`, `(...)` and a few music symbols, line by line. That left behind speaker labels, bare uppercase sound cues, and every CJK convention. It also never touched the `.hi` tag: a subtitle whose HI cues had just been stripped still carried `.hi` in its filename and `hearingImpaired = true` in the database.

The known failure modes of the equivalent upstream feature were used as the checklist:

| Upstream issue | Problem | Handled by |
|---|---|---|
| [bazarr#2987](https://github.com/morpheus65535/bazarr/issues/2987) | `（咲太）`, `➡`, `♬～`, `📱`, `☎` untouched in JP subtitles | full-width bracket pairs + CJK marker set |
| [bazarr#1933](https://github.com/morpheus65535/bazarr/issues/1933) | uppercase detection runs *before* HI removal, so the uppercase rule is skipped | two-pass: ratio computed on stripped text |
| [bazarr#2846](https://github.com/morpheus65535/bazarr/issues/2846) | HI removal eats `<font color>` | tags never matched; only emptied pairs dropped |
| Sub-Zero #542 | caps label before a colon removed too eagerly | colon must be followed by whitespace or EOL |
| — | `Look: it's fine.` mangled by the mixed-case label rule | mixed-case labels stripped only when recurring |

## What changed

**Cleaning** runs in two passes. Spans and symbols go first; the uppercase ratio and the recurring-label set are then computed on the already-stripped text. Coverage:

- `[...]` `(...)` `（...）` `［...］`, matched across line breaks, guarded by "at least two characters, one of them a letter or digit" so `Really(?)` survives
- music, phone and continuation markers `♪-♯ ¶ 🎵 🎶 📱 ☎ ☏ ➡ ⇒`, plus lines left holding only `～ 〜 - …`
- all-caps speaker labels, keeping the dialogue and the leading dialogue dash
- mixed-case speaker labels, only when the same label appears at least twice in the file
- bare uppercase sound cues, disabled when more than 70% of the file is uppercase
- orphan dialogue dash removed when a single line is left

**Tag removal** on all four paths that clean: download, OCR, translation, and the manual `removeHiTags` post-processing action.

The manual path renames the file rather than only clearing the column. `parseSubtitleFilename` re-derives `hearingImpaired` from the filename during a library scan, so clearing the column alone would be undone on the next rescan. The parser now reports which token carried the flag, which keeps the `hi` = Hindi ambiguity intact. A name collision keeps the tag and logs, rather than clobbering the sibling — `rename()` overwrites silently.

## Tests

`subtitle-cleaner.spec.ts`, 11 cases, one per rule above plus the option-off path. Full subtitles suite: 44 passing.

## Not in scope

- No batch "apply to a whole series" action; the post-processing action stays per subtitle.
- The uppercase sound-cue keyword list is English, marked with a `ponytail:` comment. The bracket and label rules are language-agnostic and carry the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)