### PR TITLE
fix(subtitles): rename to .srt after converting an ASS sidecar

### DIFF
--- a/backend/src/modules/subtitles/subtitle-post-processor.spec.ts
+++ b/backend/src/modules/subtitles/subtitle-post-processor.spec.ts
@@ -1,0 +1,27 @@
+import { assToSrt } from './subtitle-post-processor';
+
+// The `.ass` → `.srt` rename in applyPostProcessing keys on assToSrt returning
+// something different from its input, so the no-op paths have to stay exact.
+describe('assToSrt', () => {
+  it('converts dialogue lines and timings', () => {
+    const ass = [
+      '[Events]',
+      'Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text',
+      'Dialogue: 0,0:01:23.45,0:01:26.78,Default,,0,0,0,,First line\\NSecond line',
+    ].join('\n');
+
+    expect(assToSrt(ass)).toBe(
+      '1\n00:01:23,450 --> 00:01:26,780\nFirst line\nSecond line\n',
+    );
+  });
+
+  it('returns SRT input unchanged', () => {
+    const srt = '1\n00:00:01,000 --> 00:00:02,000\nHello\n';
+    expect(assToSrt(srt)).toBe(srt);
+  });
+
+  it('returns the original when no dialogue line is usable', () => {
+    const ass = '[Events]\nDialogue: 0,0:01:23.45,0:01:26.78,Default,,0,0,0,,';
+    expect(assToSrt(ass)).toBe(ass);
+  });
+});

--- a/backend/src/modules/subtitles/subtitle-post-processor.ts
+++ b/backend/src/modules/subtitles/subtitle-post-processor.ts
@@ -218,7 +218,8 @@ export function assToSrt(content: string): string {
     index++;
   }
 
-  return srtBlocks.join('\n\n') + '\n';
+  // No usable dialogue: keep the original rather than blank the file
+  return srtBlocks.length ? srtBlocks.join('\n\n') + '\n' : content;
 }
 
 function assTimeToSrt(assTime: string): string {

--- a/backend/src/modules/subtitles/subtitles.service.ts
+++ b/backend/src/modules/subtitles/subtitles.service.ts
@@ -839,6 +839,7 @@ export class SubtitlesService {
 
     let content = await fs.readFile(abs, 'utf-8');
     const sizeBefore = content.length;
+    let convertedToSrt = false;
 
     switch (action) {
       case 'removeHiTags': {
@@ -880,9 +881,14 @@ export class SubtitlesService {
           Number(params?.toFps ?? 25),
         );
         break;
-      case 'convertToSrt':
-        content = postProcess.assToSrt(content);
+      case 'convertToSrt': {
+        const converted = postProcess.assToSrt(content);
+        // assToSrt is a no-op on anything without Dialogue: lines — don't
+        // relabel a file whose content never changed
+        convertedToSrt = converted !== content;
+        content = converted;
         break;
+      }
       default:
         throw new BadRequestException(
           `Unknown post-processing action: ${action}`,
@@ -892,6 +898,14 @@ export class SubtitlesService {
     await fs.writeFile(abs, content, 'utf-8');
     if (action === 'removeHiTags' && sub.hearingImpaired) {
       await this.dropHiTag(sub, abs);
+    }
+    if (convertedToSrt) {
+      const renamed = await this.renameSubtitleFile(
+        sub,
+        abs,
+        `${path.parse(abs).name}.srt`,
+      );
+      if (renamed) sub.codec = 'subrip';
     }
     sub.locked = true;
     await this.repo.save(sub);
@@ -910,8 +924,24 @@ export class SubtitlesService {
       sub.hearingImpaired = false;
       return;
     }
+    if (await this.renameSubtitleFile(sub, abs, newName)) {
+      sub.hearingImpaired = false;
+    }
+  }
 
+  /**
+   * Rename a sidecar and keep relativePath in sync. Returns the new absolute
+   * path, or null when the rename was refused — the caller then leaves the
+   * matching metadata alone so the row keeps describing the file on disk.
+   */
+  private async renameSubtitleFile(
+    sub: SubtitleFile,
+    abs: string,
+    newName: string,
+  ): Promise<string | null> {
     const target = path.join(path.dirname(abs), newName);
+    if (target === abs) return abs;
+
     // rename() overwrites silently, so refuse when a sibling already holds the name
     const taken = await fs.access(target).then(
       () => true,
@@ -919,24 +949,24 @@ export class SubtitlesService {
     );
     if (taken) {
       this.logger.warn(
-        `Kept the HI tag on sub #${sub.id}: "${newName}" already exists`,
+        `Sub #${sub.id}: kept "${path.basename(abs)}", "${newName}" already exists`,
       );
-      return;
+      return null;
     }
     try {
       await fs.rename(abs, target);
     } catch (err) {
       this.logger.warn(
-        `Could not drop the HI tag on sub #${sub.id}: ${(err as Error).message}`,
+        `Sub #${sub.id}: rename to "${newName}" failed: ${(err as Error).message}`,
       );
-      return;
+      return null;
     }
 
-    sub.hearingImpaired = false;
     if (sub.relativePath) {
       sub.relativePath = path
         .join(path.dirname(sub.relativePath), newName)
         .replace(/\\/g, '/');
     }
+    return target;
   }
 }


### PR DESCRIPTION
## Why

The `convertToSrt` correction rewrote the file in place. An `.ass` sidecar therefore ended up holding SRT content under its original extension: `movie.en.ass` with SRT inside. Both players and `parseSubtitleFilename` during a library rescan read the extension, so the file stayed mislabelled.

A second problem sat underneath: `assToSrt` returned `'\n'` when it found `Dialogue:` lines but none of them yielded usable text, which blanked the sidecar.

## What changed

- `assToSrt` returns its input untouched when no cue could be produced, instead of emitting an empty document.
- `applyPostProcessing` renames to `.srt` and updates `relativePath` once the conversion actually produced cues, and sets `codec` to `subrip`. A conversion that was a no-op leaves the extension alone — the rename keys on the content having changed.
- The rename itself is now shared with the HI-tag removal from #819. Both need `relativePath` kept in sync, and both must refuse to overwrite a sibling that already holds the target name, since `rename()` overwrites silently.

## Tests

`subtitle-post-processor.spec.ts`, 3 cases on `assToSrt`: a real conversion, SRT input returned unchanged, and ASS with no usable dialogue returned unchanged. The last two are what the rename depends on. Full subtitles suite: 47 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)