### PR TITLE
feat(indexers): log every torrent search, its indexers and its result count

### DIFF
--- a/backend/src/modules/indexers/torznab.service.ts
+++ b/backend/src/modules/indexers/torznab.service.ts
@@ -54,6 +54,24 @@ function buildTorznabQuery(opts: {
   return parts.join('&');
 }
 
+/** Log-friendly summary of a Torznab query. Never includes the API key. */
+function describeTorznabQuery(url: string): string {
+  let params: URLSearchParams;
+  try {
+    params = new URL(url).searchParams;
+  } catch {
+    return 'search';
+  }
+  const parts = [params.get('t') ?? 'search'];
+  const q = params.get('q');
+  if (q) parts.push(`q="${q}"`);
+  for (const key of ['season', 'ep', 'cat', 'tvdbid', 'imdbid', 'tmdbid']) {
+    const value = params.get(key);
+    if (value) parts.push(`${key}=${value}`);
+  }
+  return parts.join(' ');
+}
+
 function extractInnerXml(block: string, tag: string): string | null {
   const re = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, 'i');
   const m = block.match(re);
@@ -177,8 +195,10 @@ export class TorznabService {
         ready.push(ix);
       }
     }
+    // Info, not debug: a cooldown is the usual reason a search silently
+    // returns nothing, and the caller only logs the indexers it kept.
     if (skipped.length) {
-      this.log.debug?.(
+      this.log.log(
         `skipping ${skipped.length} indexer(s) in cooldown: ${skipped.join(', ')}`,
       );
     }
@@ -254,12 +274,45 @@ export class TorznabService {
     indexer.capsSearchFallback = false;
   }
 
+  /**
+   * Whether this indexer can serve a search, and the endpoint to hit.
+   * Null means skipped — the reason is logged here so every search path
+   * reports it the same way.
+   */
+  private resolveSearchTarget(
+    indexer: Indexer,
+  ): { baseUrl: string; apiKey: string } | null {
+    if (!indexer.enabled) {
+      this.log.debug(`[${indexer.name}] skipped — indexer disabled`);
+      return null;
+    }
+    if (!indexer.enableSearch) {
+      this.log.debug(`[${indexer.name}] skipped — search disabled`);
+      return null;
+    }
+    const impl = (indexer.implementation || '').toLowerCase();
+    if (!impl.includes('torznab')) {
+      this.log.debug(
+        `[${indexer.name}] skipped — implementation "${indexer.implementation}" is not Torznab`,
+      );
+      return null;
+    }
+    const settings = indexer.settings as { baseUrl?: string; apiKey?: string };
+    const baseUrl = String(settings.baseUrl || '').replace(/\/$/, '');
+    if (!baseUrl) {
+      this.log.warn(`Indexer "${indexer.name}" has no baseUrl`);
+      return null;
+    }
+    return { baseUrl, apiKey: String(settings.apiKey || '') };
+  }
+
   /** Execute a Torznab search URL. Returns results and the Torznab error message if any. */
   private async execSearch(
     url: string,
     queryType: string,
     indexer: Indexer,
   ): Promise<{ results: TorznabRelease[]; torznabError: string | null }> {
+    const query = describeTorznabQuery(url);
     const start = Date.now();
     try {
       const res = await this.throttle.run(indexer, () =>
@@ -283,6 +336,7 @@ export class TorznabService {
             errorMessage: msg,
           }),
         );
+        this.log.warn(`[${indexer.name}] ${query} → ${msg}`);
         return { results: [], torznabError: msg };
       }
       const results = parseTorznabItems(body, indexer);
@@ -294,6 +348,9 @@ export class TorznabService {
           resultCount: results.length,
           errorMessage: null,
         }),
+      );
+      this.log.log(
+        `[${indexer.name}] ${query} → ${results.length} result(s) in ${Date.now() - start}ms`,
       );
       return { results, torznabError: null };
     } catch (e) {
@@ -309,6 +366,7 @@ export class TorznabService {
           errorMessage: msg,
         }),
       );
+      this.log.warn(`[${indexer.name}] ${query} failed: ${msg}`);
       return { results: [], torznabError: msg };
     }
   }
@@ -433,14 +491,9 @@ export class TorznabService {
     season: number,
     externalIds?: { tvdbId?: number | null; imdbId?: string | null },
   ): Promise<TorznabRelease[]> {
-    if (!indexer.enabled || !indexer.enableSearch) return [];
-    const impl = (indexer.implementation || '').toLowerCase();
-    if (!impl.includes('torznab')) return [];
-
-    const settings = indexer.settings as { baseUrl?: string; apiKey?: string };
-    const baseUrl = String(settings.baseUrl || '').replace(/\/$/, '');
-    const apiKey = String(settings.apiKey || '');
-    if (!baseUrl) return [];
+    const target = this.resolveSearchTarget(indexer);
+    if (!target) return [];
+    const { baseUrl, apiKey } = target;
 
     const useTvSearch = indexer.capsTvSearch && !indexer.capsSearchFallback;
     // See comment in searchSeries: text-mode search needs the season tag
@@ -487,14 +540,9 @@ export class TorznabService {
     episode: number,
     externalIds?: { tvdbId?: number | null; imdbId?: string | null },
   ): Promise<TorznabRelease[]> {
-    if (!indexer.enabled || !indexer.enableSearch) return [];
-    const impl = (indexer.implementation || '').toLowerCase();
-    if (!impl.includes('torznab')) return [];
-
-    const settings = indexer.settings as { baseUrl?: string; apiKey?: string };
-    const baseUrl = String(settings.baseUrl || '').replace(/\/$/, '');
-    const apiKey = String(settings.apiKey || '');
-    if (!baseUrl) return [];
+    const target = this.resolveSearchTarget(indexer);
+    if (!target) return [];
+    const { baseUrl, apiKey } = target;
 
     const useTvSearch = indexer.capsTvSearch && !indexer.capsSearchFallback;
     // When using t=search (indexer can't tvsearch, or admin pinned the
@@ -545,29 +593,9 @@ export class TorznabService {
     query: string,
     externalIds?: { imdbId?: string | null; tmdbId?: number | null },
   ): Promise<TorznabRelease[]> {
-    if (!indexer.enabled) {
-      this.log.debug(`[${indexer.name}] skipped — indexer disabled`);
-      return [];
-    }
-    if (!indexer.enableSearch) {
-      this.log.debug(`[${indexer.name}] skipped — search disabled`);
-      return [];
-    }
-    const impl = (indexer.implementation || '').toLowerCase();
-    if (!impl.includes('torznab')) {
-      this.log.debug(
-        `[${indexer.name}] skipped — implementation "${indexer.implementation}" is not Torznab`,
-      );
-      return [];
-    }
-
-    const settings = indexer.settings as { baseUrl?: string; apiKey?: string };
-    const baseUrl = String(settings.baseUrl || '').replace(/\/$/, '');
-    const apiKey = String(settings.apiKey || '');
-    if (!baseUrl) {
-      this.log.warn(`Indexer "${indexer.name}" has no baseUrl`);
-      return [];
-    }
+    const target = this.resolveSearchTarget(indexer);
+    if (!target) return [];
+    const { baseUrl, apiKey } = target;
 
     const useMovieSearch =
       indexer.capsMovieSearch &&
@@ -588,12 +616,7 @@ export class TorznabService {
       'search',
       indexer,
     );
-    if (!torznabError) {
-      this.log.log(
-        `[${indexer.name}] search "${query}" → ${results.length} result(s)`,
-      );
-      return results;
-    }
+    if (!torznabError) return results;
 
     if (useMovieSearch) {
       this.log.warn(

--- a/backend/src/modules/media/episode-download.service.ts
+++ b/backend/src/modules/media/episode-download.service.ts
@@ -174,6 +174,16 @@ export class EpisodeDownloadService {
       resolveSearchTitles(media, customQuery);
     const externalIds = { tvdbId: media.tvdbId, imdbId: media.imdbId };
     const ready = this.torznab.filterReadyIndexers(indexers);
+    const label = `"${media.title}" S${String(season.seasonNumber).padStart(2, '0')}E${String(episode.episodeNumber).padStart(2, '0')}`;
+    if (!ready.length) {
+      this.log.warn(
+        `[searchEpisodeReleases] ${label} — no indexer ready (${indexers.length} enabled)`,
+      );
+      return [];
+    }
+    this.log.log(
+      `[searchEpisodeReleases] ${label} — query="${queryTitle}", indexers=[${ready.map((i) => i.name).join(', ')}]`,
+    );
     const batches = await Promise.all(
       ready.map((ix) =>
         this.torznab.searchSeries(
@@ -194,7 +204,8 @@ export class EpisodeDownloadService {
     //     or oddly-named release — let scoring decide), OR
     //   - the season matches AND (episode matches OR it's a season pack
     //     that contains the target episode).
-    const flat = batches.flat().filter((r) => {
+    const raw = batches.flat();
+    const flat = raw.filter((r) => {
       const p = parseSeasonEpisode(r.title);
       if (p.season === null) return true;
       if (p.season !== season.seasonNumber) return false;
@@ -202,6 +213,9 @@ export class EpisodeDownloadService {
       if (p.episode === null) return true;
       return p.episode === episode.episodeNumber;
     });
+    this.log.log(
+      `[searchEpisodeReleases] ${label} — ${raw.length} raw result(s) across ${ready.length} indexer(s), ${flat.length} for this episode`,
+    );
 
     // Season packs need their size scored against the WHOLE season's
     // runtime (sum of episode runtimes), not a single episode — else
@@ -236,6 +250,12 @@ export class EpisodeDownloadService {
     // comment in MovieDownloadService.searchMovieReleases.
     const maxRank = maxAllowedRank(allowed);
     const withinProfile = rowsWithKind.filter((x) => x.row.rank <= maxRank);
+    const accepted = withinProfile.filter(
+      (x) => x.row.rejections.length === 0,
+    ).length;
+    this.log.log(
+      `[searchEpisodeReleases] ${label} — ${withinProfile.length} within profile (rank ≤ ${maxRank}), ${accepted} accepted, ${withinProfile.length - accepted} rejected`,
+    );
 
     // User is asking for ONE episode. Season packs still match, but
     // they download a whole season for a single episode — they should
@@ -497,6 +517,16 @@ export class EpisodeDownloadService {
       resolveSearchTitles(media, customQuery);
     const externalIds = { tvdbId: media.tvdbId, imdbId: media.imdbId };
     const ready = this.torznab.filterReadyIndexers(indexers);
+    const label = `"${media.title}" S${String(season.seasonNumber).padStart(2, '0')}`;
+    if (!ready.length) {
+      this.log.warn(
+        `[searchSeasonReleases] ${label} — no indexer ready (${indexers.length} enabled)`,
+      );
+      return [];
+    }
+    this.log.log(
+      `[searchSeasonReleases] ${label} — query="${searchTitle}", indexers=[${ready.map((i) => i.name).join(', ')}]`,
+    );
     const batches = await Promise.all(
       ready.map((ix) =>
         this.torznab.searchSeasonPack(
@@ -512,11 +542,15 @@ export class EpisodeDownloadService {
     // ignore `season=` and return any release whose title contains
     // the show name. Keep only releases that parse to the requested
     // season (single episodes or full packs alike).
-    const flat = batches.flat().filter((r) => {
+    const raw = batches.flat();
+    const flat = raw.filter((r) => {
       const p = parseSeasonEpisode(r.title);
       if (p.season === null) return true;
       return p.season === season.seasonNumber;
     });
+    this.log.log(
+      `[searchSeasonReleases] ${label} — ${raw.length} raw result(s) across ${ready.length} indexer(s), ${flat.length} for this season`,
+    );
 
     const defaultEpisodeRuntime = media.runtime ?? 45;
     const rowsWithKind = await Promise.all(
@@ -545,6 +579,10 @@ export class EpisodeDownloadService {
     const packs = rowsWithKind
       .filter((x) => x.isPack && x.row.rank <= maxRank)
       .map((x) => x.row);
+    const accepted = packs.filter((r) => r.rejections.length === 0).length;
+    this.log.log(
+      `[searchSeasonReleases] ${label} — ${packs.length} pack(s) within profile (rank ≤ ${maxRank}), ${accepted} accepted, ${packs.length - accepted} rejected`,
+    );
     return sortReleasesByRelevance(packs);
   }
 


### PR DESCRIPTION
## Why

Opening the season packs list, or any episode release search, produced no backend output. Only `searchMovieReleases` logged anything, so an empty result set gave nothing to distinguish an indexer sitting in cooldown from a query that genuinely matched nothing.

## What changed

**Per-indexer line, once.** It now lives in `execSearch`, the single point every Torznab query passes through, so season packs, episodes, movies and the `t=search` fallbacks are all covered by one statement instead of three that had drifted apart. The movie path's own duplicate line is gone.

```
[Indexer] tvsearch q="Some Show" season=2 cat=5000 tvdbid=12345 → 43 result(s) in 812ms
[Indexer] search q="Some Show S02" cat=5000 → Torznab error: invalid apikey
```

The summary is rebuilt from the request URL with the API key left out.

**Uniform skip reasons.** The three search methods opened with an identical eligibility prelude — enabled, search enabled, Torznab implementation, base URL present — but only the movie one logged why it bailed. That moved into `resolveSearchTarget`, so a skipped indexer reports the same reason whichever search asked for it, and the triplication is gone.

**Fan-out lines** on both series paths, matching the shape `searchMovieReleases` already used:

```
[searchSeasonReleases] "Some Show" S02 — query="Some Show", indexers=[A, B, C]
[searchSeasonReleases] "Some Show" S02 — 128 raw result(s) across 3 indexer(s), 96 for this season
[searchSeasonReleases] "Some Show" S02 — 14 pack(s) within profile (rank ≤ 8), 9 accepted, 5 rejected
```

An empty ready set is now a warning naming how many indexers were enabled, instead of a silent empty list.

**Cooldown skips move from debug to info.** A cooldown is the usual reason a search returns nothing, and the caller only lists the indexers it kept — at debug level that line is invisible in exactly the situation someone is trying to diagnose.

## Tests

No new cases: this is logging plus the extraction of an unchanged prelude. Backend indexers and media suites pass (55), `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)