### PR TITLE
feat(indexers): surface indexer cooldowns and let admins lift them

### DIFF
--- a/backend/src/modules/indexers/indexer-throttle.service.spec.ts
+++ b/backend/src/modules/indexers/indexer-throttle.service.spec.ts
@@ -66,3 +66,75 @@ describe('IndexerThrottle cooldown gate', () => {
     expect(t.cooldownRemainingMs(1)).toBe(0);
   });
 });
+
+describe('IndexerThrottle cooldown reporting', () => {
+  it('reports the failure reason and count', () => {
+    const t = new IndexerThrottle();
+    t.notifyFailure(indexer(), 'ECONNREFUSED');
+    expect(t.getCooldown(1)).toMatchObject({
+      reason: 'failures',
+      failureCount: 1,
+      detail: 'ECONNREFUSED',
+    });
+  });
+
+  it('reports the rate-limit reason with the header value', () => {
+    const t = new IndexerThrottle();
+    t.setRetryAfter(indexer(), '120');
+    expect(t.getCooldown(1)).toMatchObject({
+      reason: 'rate-limit',
+      detail: '120',
+    });
+  });
+
+  it('reports nothing once the window has elapsed', () => {
+    jest.useFakeTimers();
+    try {
+      const t = new IndexerThrottle();
+      t.notifyFailure(indexer());
+      jest.advanceTimersByTime(30_001);
+      expect(t.getCooldown(1)).toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('IndexerThrottle cooldown reset', () => {
+  it('lifts the window and restarts the failure ladder', () => {
+    const t = new IndexerThrottle();
+    t.notifyFailure(indexer());
+    expect(t.clearCooldown(1)).toBe(true);
+    expect(t.cooldownRemainingMs(1)).toBe(0);
+    // Ladder restarted: the next failure is the 30s step again, not 2min.
+    t.notifyFailure(indexer());
+    expect(t.cooldownRemainingMs(1)).toBeLessThanOrEqual(30_000);
+  });
+
+  it('lets a request run immediately after a reset', async () => {
+    const t = new IndexerThrottle();
+    t.setRetryAfter(indexer(), '3600');
+    t.clearCooldown(1);
+    // The queue gate was pushed to the same instant as the skip gate; if the
+    // reset left it set, this call would sleep an hour instead of running.
+    const ran = await Promise.race([
+      t.run(indexer(), async () => 'ok'),
+      new Promise((r) => setTimeout(() => r('timeout'), 200)),
+    ]);
+    expect(ran).toBe('ok');
+  });
+
+  it('reports false when there was nothing to lift', () => {
+    const t = new IndexerThrottle();
+    expect(t.clearCooldown(1)).toBe(false);
+  });
+
+  it('counts only the indexers actually in cooldown', () => {
+    const t = new IndexerThrottle();
+    t.notifyFailure(indexer({ id: 1 }));
+    t.notifyFailure(indexer({ id: 2, name: 'other' }));
+    t.clearCooldown(2);
+    expect(t.clearAllCooldowns()).toBe(1);
+    expect(t.cooldownRemainingMs(1)).toBe(0);
+  });
+});

--- a/backend/src/modules/indexers/indexer-throttle.service.ts
+++ b/backend/src/modules/indexers/indexer-throttle.service.ts
@@ -21,6 +21,16 @@ import { Indexer } from './entities/indexer.entity';
  *      15min → 1h → 6h, at most one step per elapsed window. Resets on
  *      success.
  */
+/** Why an indexer is being skipped, and until when. */
+export interface IndexerCooldown {
+  until: number;
+  reason: 'rate-limit' | 'failures';
+  /** Consecutive failures that produced the window (failure backoff only). */
+  failureCount?: number;
+  /** Last error text or Retry-After value, when the caller had one. */
+  detail?: string;
+}
+
 @Injectable()
 export class IndexerThrottle {
   private readonly log = new Logger(IndexerThrottle.name);
@@ -37,7 +47,7 @@ export class IndexerThrottle {
    *  only by failure backoff and Retry-After, never by routine request
    *  spacing. Lets searches skip a backing-off indexer instead of queueing
    *  behind its full cooldown. */
-  private cooldownUntil = new Map<number, number>();
+  private cooldownUntil = new Map<number, IndexerCooldown>();
 
   /** Queue `fn` against `indexer`. Returns whatever `fn` resolves to.
    *  Rejections propagate untouched (so callers can pattern-match on
@@ -77,7 +87,10 @@ export class IndexerThrottle {
   setRetryAfter(indexer: Indexer, headerValue: string | undefined): void {
     const ms = parseRetryAfter(headerValue);
     if (ms <= 0) return;
-    this.bumpCooldown(indexer.id, Date.now() + ms);
+    this.bumpCooldown(indexer.id, Date.now() + ms, {
+      reason: 'rate-limit',
+      detail: headerValue?.trim(),
+    });
     this.log.warn(
       `[${indexer.name}] Retry-After honoured — next request in ${Math.round(ms / 1000)}s`,
     );
@@ -88,13 +101,17 @@ export class IndexerThrottle {
    *  arriving inside an open cooldown belong to the outage that opened it, so
    *  the ladder tracks how long an indexer has been broken rather than how
    *  many requests hit it. */
-  notifyFailure(indexer: Indexer): void {
+  notifyFailure(indexer: Indexer, detail?: string): void {
     if (this.cooldownRemainingMs(indexer.id) > 0) return;
     const n = (this.failureCount.get(indexer.id) ?? 0) + 1;
     this.failureCount.set(indexer.id, n);
     const cooldownMs = backoffFor(n);
     if (cooldownMs <= 0) return;
-    this.bumpCooldown(indexer.id, Date.now() + cooldownMs);
+    this.bumpCooldown(indexer.id, Date.now() + cooldownMs, {
+      reason: 'failures',
+      failureCount: n,
+      detail,
+    });
     this.log.warn(
       `[${indexer.name}] consecutive failure #${n} — cooldown ${Math.round(cooldownMs / 1000)}s`,
     );
@@ -110,19 +127,55 @@ export class IndexerThrottle {
    *  ready). Routine request-delay spacing is deliberately excluded so a
    *  healthy indexer queried seconds ago still reads as ready. */
   cooldownRemainingMs(indexerId: number): number {
-    const until = this.cooldownUntil.get(indexerId) ?? 0;
+    const until = this.cooldownUntil.get(indexerId)?.until ?? 0;
     return Math.max(0, until - Date.now());
+  }
+
+  /** The live cooldown for an indexer, or null when it's ready. */
+  getCooldown(indexerId: number): IndexerCooldown | null {
+    const entry = this.cooldownUntil.get(indexerId);
+    if (!entry || entry.until <= Date.now()) return null;
+    return entry;
+  }
+
+  /**
+   * Lift a penalty window. Clears the queue gate too: `bumpCooldown` pushed
+   * both, so leaving `nextAllowedAt` set would make the next request sleep the
+   * window we just claimed to have cancelled. Returns false when there was
+   * nothing to lift.
+   */
+  clearCooldown(indexerId: number): boolean {
+    const had = this.cooldownRemainingMs(indexerId) > 0;
+    this.cooldownUntil.delete(indexerId);
+    this.failureCount.delete(indexerId);
+    this.nextAllowedAt.delete(indexerId);
+    return had;
+  }
+
+  /** Lift every penalty window. Returns how many indexers were in cooldown. */
+  clearAllCooldowns(): number {
+    let cleared = 0;
+    for (const id of [...this.cooldownUntil.keys()]) {
+      if (this.clearCooldown(id)) cleared++;
+    }
+    return cleared;
   }
 
   /** Push a backpressure window onto an indexer: bumps both the queue's
    *  earliest-start gate (so a request that does get queued still waits) and
    *  the skip gate (so searches can drop it from the fan-out). Monotonic —
    *  only ever extends the window, never shortens it. */
-  private bumpCooldown(indexerId: number, until: number): void {
+  private bumpCooldown(
+    indexerId: number,
+    until: number,
+    info: Omit<IndexerCooldown, 'until'>,
+  ): void {
     const curNext = this.nextAllowedAt.get(indexerId) ?? 0;
     if (until > curNext) this.nextAllowedAt.set(indexerId, until);
-    const curCooldown = this.cooldownUntil.get(indexerId) ?? 0;
-    if (until > curCooldown) this.cooldownUntil.set(indexerId, until);
+    const curCooldown = this.cooldownUntil.get(indexerId)?.until ?? 0;
+    if (until > curCooldown) {
+      this.cooldownUntil.set(indexerId, { until, ...info });
+    }
   }
 }
 

--- a/backend/src/modules/indexers/indexers.controller.ts
+++ b/backend/src/modules/indexers/indexers.controller.ts
@@ -49,6 +49,19 @@ export class IndexersController {
     return this.indexersService.findAll();
   }
 
+  /** Declared before `:id` routes — `cooldowns` would otherwise hit ParseIntPipe. */
+  @Delete('cooldowns')
+  @CheckPolicies((ability) => ability.can(Action.Update, Indexer))
+  clearAllCooldowns() {
+    return this.indexersService.clearAllCooldowns();
+  }
+
+  @Delete(':id/cooldown')
+  @CheckPolicies((ability) => ability.can(Action.Update, Indexer))
+  clearCooldown(@Param('id', ParseIntPipe) id: number) {
+    return this.indexersService.clearCooldown(id);
+  }
+
   @Get(':id')
   @CheckPolicies((ability) => ability.can(Action.Read, Indexer))
   findOne(@Param('id', ParseIntPipe) id: number) {

--- a/backend/src/modules/indexers/indexers.service.ts
+++ b/backend/src/modules/indexers/indexers.service.ts
@@ -5,7 +5,19 @@ import { Indexer } from './entities/indexer.entity';
 import { CreateIndexerDto } from './dto/create-indexer.dto';
 import { UpdateIndexerDto } from './dto/update-indexer.dto';
 import { TorznabService } from './torznab.service';
+import { IndexerThrottle } from './indexer-throttle.service';
 import { TestIndexerConnectionDto } from './dto/test-indexer-connection.dto';
+
+/** An indexer plus its live throttle state, as the settings page needs it. */
+export type IndexerWithCooldown = Indexer & {
+  cooldown: {
+    reason: 'rate-limit' | 'failures';
+    remainingMs: number;
+    until: string;
+    failureCount?: number;
+    detail?: string;
+  } | null;
+};
 
 @Injectable()
 export class IndexersService {
@@ -13,6 +25,7 @@ export class IndexersService {
     @InjectRepository(Indexer)
     private readonly indexerRepo: Repository<Indexer>,
     private readonly torznab: TorznabService,
+    private readonly throttle: IndexerThrottle,
   ) {}
 
   async testConnection(
@@ -53,10 +66,35 @@ export class IndexersService {
     return saved;
   }
 
-  findAll(): Promise<Indexer[]> {
-    return this.indexerRepo.find({
+  async findAll(): Promise<IndexerWithCooldown[]> {
+    const rows = await this.indexerRepo.find({
       order: { priority: 'ASC', id: 'ASC' },
     });
+    return rows.map((ix) => {
+      const cd = this.throttle.getCooldown(ix.id);
+      return Object.assign(ix, {
+        cooldown: cd
+          ? {
+              reason: cd.reason,
+              remainingMs: Math.max(0, cd.until - Date.now()),
+              until: new Date(cd.until).toISOString(),
+              failureCount: cd.failureCount,
+              detail: cd.detail,
+            }
+          : null,
+      });
+    });
+  }
+
+  /** Lift the throttle window on one indexer. */
+  async clearCooldown(id: number): Promise<{ cleared: boolean }> {
+    await this.findOne(id);
+    return { cleared: this.throttle.clearCooldown(id) };
+  }
+
+  /** Lift every throttle window. */
+  clearAllCooldowns(): { cleared: number } {
+    return { cleared: this.throttle.clearAllCooldowns() };
   }
 
   async findOne(id: number): Promise<Indexer> {

--- a/backend/src/modules/indexers/torznab.service.ts
+++ b/backend/src/modules/indexers/torznab.service.ts
@@ -258,7 +258,7 @@ export class TorznabService {
       );
     } catch (e) {
       this.maybeHandleRateLimit(indexer, e);
-      this.throttle.notifyFailure(indexer);
+      this.throttle.notifyFailure(indexer, (e as Error).message);
       this.log.warn(
         `[${indexer.name}] caps fetch failed: ${(e as Error).message}`,
       );
@@ -355,7 +355,7 @@ export class TorznabService {
       return { results, torznabError: null };
     } catch (e) {
       this.maybeHandleRateLimit(indexer, e);
-      this.throttle.notifyFailure(indexer);
+      this.throttle.notifyFailure(indexer, (e as Error).message);
       const msg = (e as Error).message;
       void this.statRepo.save(
         this.statRepo.create({
@@ -467,7 +467,7 @@ export class TorznabService {
       return results;
     } catch (e) {
       this.maybeHandleRateLimit(indexer, e);
-      this.throttle.notifyFailure(indexer);
+      this.throttle.notifyFailure(indexer, (e as Error).message);
       void this.statRepo.save(
         this.statRepo.create({
           indexer,

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1569,6 +1569,7 @@
       "col_name": "Name",
       "col_priority": "Priorität",
       "col_enabled": "Aktiv",
+      "col_status": "Status",
       "actions": "Aktionen",
       "edit": "Bearbeiten",
       "delete": "Löschen",

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1604,7 +1604,19 @@
       "stats_queries": "Anfragen",
       "stats_avg_time": "Durchschn. Zeit",
       "stats_results": "Ergebnisse",
-      "stats_errors": "Fehler"
+      "stats_errors": "Fehler",
+      "cooldown_reset_all": "Alle Cooldowns zurücksetzen ({{count}})",
+      "cooldown_reset": "Cooldown zurücksetzen",
+      "cooldown_badge_title": "Im Cooldown — für Details klicken",
+      "cooldown_title": "{{name}} ist im Cooldown",
+      "cooldown_reason_rate_limit": "Der Indexer hat um Verlangsamung gebeten (Ratenbegrenzung). Anfragen sind bis zum Ablauf des angegebenen Zeitraums ausgesetzt.",
+      "cooldown_reason_failures": "Der Indexer ist {{count}}-mal hintereinander fehlgeschlagen. Jeder weitere Fehler verlängert die Pause, von 30 Sekunden bis zu 6 Stunden.",
+      "cooldown_remaining": "Restzeit",
+      "cooldown_expires_at": "Läuft ab um",
+      "cooldown_detail": "Letzter Fehler",
+      "cooldown_reset_hint": "Das Zurücksetzen löscht die Pause und den Fehlerzähler. Ist der Indexer weiterhin nicht erreichbar, öffnet die nächste Suche ein neues Fenster.",
+      "cooldown_reset_done": "Cooldown für {{name}} aufgehoben",
+      "cooldown_reset_all_done": "{{count}} Cooldown(s) aufgehoben"
     },
     "quality_profiles": {
       "title": "Qualitätsprofile",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1579,6 +1579,7 @@
       "col_name": "Name",
       "col_priority": "Priority",
       "col_enabled": "Active",
+      "col_status": "Status",
       "actions": "Actions",
       "edit": "Edit",
       "delete": "Delete",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1614,7 +1614,19 @@
       "stats_queries": "Queries",
       "stats_avg_time": "Avg. time",
       "stats_results": "Results",
-      "stats_errors": "Errors"
+      "stats_errors": "Errors",
+      "cooldown_reset_all": "Reset all cooldowns ({{count}})",
+      "cooldown_reset": "Reset cooldown",
+      "cooldown_badge_title": "In cooldown — click for details",
+      "cooldown_title": "{{name}} is in cooldown",
+      "cooldown_reason_rate_limit": "The indexer asked us to slow down (rate limit). Requests are paused until the window it gave us has elapsed.",
+      "cooldown_reason_failures": "The indexer failed {{count}} time(s) in a row. Each further failure widens the pause, from 30 seconds up to 6 hours.",
+      "cooldown_remaining": "Remaining",
+      "cooldown_expires_at": "Expires at",
+      "cooldown_detail": "Last error",
+      "cooldown_reset_hint": "Resetting clears the pause and the failure counter. If the indexer is still unreachable, the next search will open a new window.",
+      "cooldown_reset_done": "Cooldown lifted on {{name}}",
+      "cooldown_reset_all_done": "{{count}} cooldown(s) lifted"
     },
     "quality_profiles": {
       "title": "Quality profiles",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1604,7 +1604,19 @@
       "stats_queries": "Peticiones",
       "stats_avg_time": "Tiempo medio",
       "stats_results": "Resultados",
-      "stats_errors": "Errores"
+      "stats_errors": "Errores",
+      "cooldown_reset_all": "Restablecer todos los cooldowns ({{count}})",
+      "cooldown_reset": "Restablecer el cooldown",
+      "cooldown_badge_title": "En cooldown — haz clic para ver los detalles",
+      "cooldown_title": "{{name}} está en cooldown",
+      "cooldown_reason_rate_limit": "El indexador pidió reducir el ritmo (límite de peticiones). Las consultas están en pausa hasta que termine el plazo indicado.",
+      "cooldown_reason_failures": "El indexador falló {{count}} vez/veces seguidas. Cada nuevo fallo alarga la pausa, de 30 segundos hasta 6 horas.",
+      "cooldown_remaining": "Tiempo restante",
+      "cooldown_expires_at": "Expira a las",
+      "cooldown_detail": "Último error",
+      "cooldown_reset_hint": "Restablecer borra la pausa y el contador de fallos. Si el indexador sigue inaccesible, la próxima búsqueda abrirá un plazo nuevo.",
+      "cooldown_reset_done": "Cooldown retirado en {{name}}",
+      "cooldown_reset_all_done": "{{count}} cooldown(s) retirado(s)"
     },
     "quality_profiles": {
       "title": "Perfiles de calidad",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1569,6 +1569,7 @@
       "col_name": "Nombre",
       "col_priority": "Prioridad",
       "col_enabled": "Activo",
+      "col_status": "Estado",
       "actions": "Acciones",
       "edit": "Modificar",
       "delete": "Eliminar",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1614,7 +1614,19 @@
       "stats_queries": "Requêtes",
       "stats_avg_time": "Temps moy.",
       "stats_results": "Résultats",
-      "stats_errors": "Erreurs"
+      "stats_errors": "Erreurs",
+      "cooldown_reset_all": "Réinitialiser tous les cooldowns ({{count}})",
+      "cooldown_reset": "Réinitialiser le cooldown",
+      "cooldown_badge_title": "En cooldown — cliquez pour les détails",
+      "cooldown_title": "{{name}} est en cooldown",
+      "cooldown_reason_rate_limit": "L'indexeur a demandé de ralentir (limite de débit). Les requêtes sont suspendues jusqu'à la fin du délai qu'il a indiqué.",
+      "cooldown_reason_failures": "L'indexeur a échoué {{count}} fois de suite. Chaque nouvel échec allonge la pause, de 30 secondes jusqu'à 6 heures.",
+      "cooldown_remaining": "Temps restant",
+      "cooldown_expires_at": "Expire à",
+      "cooldown_detail": "Dernière erreur",
+      "cooldown_reset_hint": "La réinitialisation efface la pause et le compteur d'échecs. Si l'indexeur reste injoignable, la prochaine recherche ouvrira un nouveau délai.",
+      "cooldown_reset_done": "Cooldown levé sur {{name}}",
+      "cooldown_reset_all_done": "{{count}} cooldown(s) levé(s)"
     },
     "quality_profiles": {
       "title": "Profils de qualité",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1579,6 +1579,7 @@
       "col_name": "Nom",
       "col_priority": "Priorité",
       "col_enabled": "Actif",
+      "col_status": "État",
       "actions": "Actions",
       "edit": "Modifier",
       "delete": "Supprimer",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1569,6 +1569,7 @@
       "col_name": "Nome",
       "col_priority": "Priorità",
       "col_enabled": "Attivo",
+      "col_status": "Stato",
       "actions": "Azioni",
       "edit": "Modifica",
       "delete": "Elimina",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1604,7 +1604,19 @@
       "stats_queries": "Richieste",
       "stats_avg_time": "Tempo med.",
       "stats_results": "Risultati",
-      "stats_errors": "Errori"
+      "stats_errors": "Errori",
+      "cooldown_reset_all": "Reimposta tutti i cooldown ({{count}})",
+      "cooldown_reset": "Reimposta il cooldown",
+      "cooldown_badge_title": "In cooldown — clicca per i dettagli",
+      "cooldown_title": "{{name}} è in cooldown",
+      "cooldown_reason_rate_limit": "L'indexer ha chiesto di rallentare (limite di richieste). Le richieste sono sospese fino allo scadere della finestra indicata.",
+      "cooldown_reason_failures": "L'indexer ha fallito {{count}} volta/volte di seguito. Ogni ulteriore errore allunga la pausa, da 30 secondi fino a 6 ore.",
+      "cooldown_remaining": "Tempo rimanente",
+      "cooldown_expires_at": "Scade alle",
+      "cooldown_detail": "Ultimo errore",
+      "cooldown_reset_hint": "La reimpostazione azzera la pausa e il contatore degli errori. Se l'indexer resta irraggiungibile, la prossima ricerca aprirà una nuova finestra.",
+      "cooldown_reset_done": "Cooldown rimosso su {{name}}",
+      "cooldown_reset_all_done": "{{count}} cooldown rimossi"
     },
     "quality_profiles": {
       "title": "Profili di qualità",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1569,6 +1569,7 @@
       "col_name": "Nome",
       "col_priority": "Prioridade",
       "col_enabled": "Ativo",
+      "col_status": "Estado",
       "actions": "Ações",
       "edit": "Editar",
       "delete": "Eliminar",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1604,7 +1604,19 @@
       "stats_queries": "Pedidos",
       "stats_avg_time": "Tempo méd.",
       "stats_results": "Resultados",
-      "stats_errors": "Erros"
+      "stats_errors": "Erros",
+      "cooldown_reset_all": "Reiniciar todos os cooldowns ({{count}})",
+      "cooldown_reset": "Reiniciar o cooldown",
+      "cooldown_badge_title": "Em cooldown — clique para ver os detalhes",
+      "cooldown_title": "{{name}} está em cooldown",
+      "cooldown_reason_rate_limit": "O indexador pediu para abrandar (limite de pedidos). Os pedidos estão suspensos até terminar o prazo indicado.",
+      "cooldown_reason_failures": "O indexador falhou {{count}} vez/vezes seguidas. Cada nova falha alarga a pausa, de 30 segundos até 6 horas.",
+      "cooldown_remaining": "Tempo restante",
+      "cooldown_expires_at": "Expira às",
+      "cooldown_detail": "Último erro",
+      "cooldown_reset_hint": "Reiniciar limpa a pausa e o contador de falhas. Se o indexador continuar inacessível, a próxima pesquisa abrirá um novo prazo.",
+      "cooldown_reset_done": "Cooldown levantado em {{name}}",
+      "cooldown_reset_all_done": "{{count}} cooldown(s) levantado(s)"
     },
     "quality_profiles": {
       "title": "Perfis de qualidade",

--- a/client/src/app/core/services/api/indexers-api.service.ts
+++ b/client/src/app/core/services/api/indexers-api.service.ts
@@ -2,6 +2,16 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 
+/** Live throttle state: why the indexer is being skipped, and until when. */
+export interface IndexerCooldown {
+  reason: 'rate-limit' | 'failures';
+  remainingMs: number;
+  /** ISO timestamp — the client recomputes the countdown from it. */
+  until: string;
+  failureCount?: number;
+  detail?: string;
+}
+
 export interface IndexerRow {
   id: number;
   name: string;
@@ -12,6 +22,8 @@ export interface IndexerRow {
   priority: number;
   requestDelay: number;
   enabled: boolean;
+  /** Only the list endpoint reports it; create/update responses carry none. */
+  cooldown?: IndexerCooldown | null;
 }
 
 export interface CreateIndexerBody {
@@ -65,6 +77,20 @@ export class IndexersApiService {
         '/api/indexers/test-connection',
         body,
       ),
+    );
+  }
+
+  /** Lift the throttle window on one indexer. */
+  clearCooldown(id: number) {
+    return firstValueFrom(
+      this.http.delete<{ cleared: boolean }>(`/api/indexers/${id}/cooldown`),
+    );
+  }
+
+  /** Lift every throttle window. */
+  clearAllCooldowns() {
+    return firstValueFrom(
+      this.http.delete<{ cleared: number }>('/api/indexers/cooldowns'),
     );
   }
 

--- a/client/src/app/features/settings/indexers/indexers.html
+++ b/client/src/app/features/settings/indexers/indexers.html
@@ -44,34 +44,35 @@
             <th>{{ 'settings.indexers.col_name' | translate }}</th>
             <th>{{ 'settings.indexers.col_priority' | translate }}</th>
             <th>{{ 'settings.indexers.col_enabled' | translate }}</th>
+            <th>{{ 'settings.indexers.col_status' | translate }}</th>
             <th class="text-end w-40">{{ 'settings.indexers.actions' | translate }}</th>
           </tr>
         </thead>
         <tbody>
           @for (ix of rows(); track ix.id) {
             <tr>
-              <td class="font-medium">
-                <div class="flex flex-wrap items-center gap-2">
-                  <span>{{ ix.name }}</span>
-                  @if (isCooledDown(ix)) {
-                    <button
-                      type="button"
-                      class="badge badge-warning badge-sm gap-1"
-                      (click)="openCooldown(ix)"
-                      [attr.title]="'settings.indexers.cooldown_badge_title' | translate"
-                    >
-                      <svg lucideSnowflake class="h-3 w-3" aria-hidden="true"></svg>
-                      {{ cooldownRemaining(ix) }}
-                    </button>
-                  }
-                </div>
-              </td>
+              <td class="font-medium">{{ ix.name }}</td>
               <td class="tabular-nums">{{ ix.priority }}</td>
               <td>
                 @if (ix.enabled) {
                   <span class="badge badge-success badge-sm">{{ 'common.yes' | translate }}</span>
                 } @else {
                   <span class="badge badge-ghost badge-sm">{{ 'common.no' | translate }}</span>
+                }
+              </td>
+              <td>
+                @if (isCooledDown(ix)) {
+                  <button
+                    type="button"
+                    class="badge badge-warning badge-sm gap-1 tabular-nums"
+                    (click)="openCooldown(ix)"
+                    [attr.title]="'settings.indexers.cooldown_badge_title' | translate"
+                  >
+                    <svg lucideSnowflake class="h-3 w-3" aria-hidden="true"></svg>
+                    {{ cooldownRemaining(ix) }}
+                  </button>
+                } @else {
+                  <span class="text-base-content/30">—</span>
                 }
               </td>
               <td class="text-end">

--- a/client/src/app/features/settings/indexers/indexers.html
+++ b/client/src/app/features/settings/indexers/indexers.html
@@ -6,9 +6,24 @@
         {{ 'settings.indexers.subtitle' | translate }}
       </p>
     </div>
-    <button type="button" class="btn btn-primary self-start sm:self-auto" (click)="openCreate()">
-      {{ 'settings.indexers.new' | translate }}
-    </button>
+    <div class="flex flex-wrap items-center gap-2 self-start sm:self-auto">
+      @if (hasCooldowns()) {
+        <button
+          type="button"
+          class="btn btn-ghost"
+          [disabled]="resettingCooldown()"
+          (click)="resetAllCooldowns()"
+        >
+          @if (resettingCooldown()) {
+            <span class="loading loading-spinner loading-xs"></span>
+          }
+          {{ 'settings.indexers.cooldown_reset_all' | translate: { count: cooledDown().length } }}
+        </button>
+      }
+      <button type="button" class="btn btn-primary" (click)="openCreate()">
+        {{ 'settings.indexers.new' | translate }}
+      </button>
+    </div>
   </div>
 
   @if (loading()) {
@@ -35,7 +50,22 @@
         <tbody>
           @for (ix of rows(); track ix.id) {
             <tr>
-              <td class="font-medium">{{ ix.name }}</td>
+              <td class="font-medium">
+                <div class="flex flex-wrap items-center gap-2">
+                  <span>{{ ix.name }}</span>
+                  @if (isCooledDown(ix)) {
+                    <button
+                      type="button"
+                      class="badge badge-warning badge-sm gap-1"
+                      (click)="openCooldown(ix)"
+                      [attr.title]="'settings.indexers.cooldown_badge_title' | translate"
+                    >
+                      <svg lucideSnowflake class="h-3 w-3" aria-hidden="true"></svg>
+                      {{ cooldownRemaining(ix) }}
+                    </button>
+                  }
+                </div>
+              </td>
               <td class="tabular-nums">{{ ix.priority }}</td>
               <td>
                 @if (ix.enabled) {
@@ -45,6 +75,16 @@
                 }
               </td>
               <td class="text-end">
+                @if (isCooledDown(ix)) {
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-xs text-warning"
+                    [disabled]="resettingCooldown()"
+                    (click)="resetCooldown(ix)"
+                  >
+                    {{ 'settings.indexers.cooldown_reset' | translate }}
+                  </button>
+                }
                 <button type="button" class="btn btn-ghost btn-xs" (click)="openStats(ix)">
                   {{ 'settings.indexers.stats' | translate }}
                 </button>
@@ -306,5 +346,59 @@
     </div>
     <form method="dialog" class="modal-backdrop">
       <button type="button" (click)="closeStats()">close</button>
+    </form>
+  </dialog>
+
+  <dialog #cooldownDialog class="modal">
+    <div class="modal-box max-w-md">
+      @if (cooldownRow(); as ix) {
+        <h2 class="text-lg font-bold flex items-center gap-2">
+          <svg lucideSnowflake class="h-5 w-5 text-warning" aria-hidden="true"></svg>
+          {{ 'settings.indexers.cooldown_title' | translate: { name: ix.name } }}
+        </h2>
+
+        <p class="mt-3 text-sm text-base-content/70">
+          @if (ix.cooldown?.reason === 'rate-limit') {
+            {{ 'settings.indexers.cooldown_reason_rate_limit' | translate }}
+          } @else {
+            {{ 'settings.indexers.cooldown_reason_failures' | translate: { count: ix.cooldown?.failureCount ?? 1 } }}
+          }
+        </p>
+
+        <dl class="mt-4 grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+          <dt class="text-base-content/60">{{ 'settings.indexers.cooldown_remaining' | translate }}</dt>
+          <dd class="tabular-nums font-medium">{{ cooldownRemaining(ix) }}</dd>
+          <dt class="text-base-content/60">{{ 'settings.indexers.cooldown_expires_at' | translate }}</dt>
+          <dd class="tabular-nums font-medium">{{ cooldownExpiresAt(ix) }}</dd>
+          @if (ix.cooldown?.detail) {
+            <dt class="text-base-content/60">{{ 'settings.indexers.cooldown_detail' | translate }}</dt>
+            <dd class="font-mono text-xs break-all">{{ ix.cooldown?.detail }}</dd>
+          }
+        </dl>
+
+        <p class="mt-4 text-xs text-base-content/50">
+          {{ 'settings.indexers.cooldown_reset_hint' | translate }}
+        </p>
+
+        <div class="modal-action">
+          <button type="button" class="btn btn-ghost" (click)="closeCooldown()">
+            {{ 'common.close' | translate }}
+          </button>
+          <button
+            type="button"
+            class="btn btn-warning"
+            [disabled]="resettingCooldown()"
+            (click)="resetCooldown(ix)"
+          >
+            @if (resettingCooldown()) {
+              <span class="loading loading-spinner loading-xs"></span>
+            }
+            {{ 'settings.indexers.cooldown_reset' | translate }}
+          </button>
+        </div>
+      }
+    </div>
+    <form method="dialog" class="modal-backdrop">
+      <button type="button" (click)="closeCooldown()">close</button>
     </form>
   </dialog>

--- a/client/src/app/features/settings/indexers/indexers.ts
+++ b/client/src/app/features/settings/indexers/indexers.ts
@@ -1,14 +1,16 @@
 import {
   Component,
   ChangeDetectionStrategy,
+  DestroyRef,
   ElementRef,
+  computed,
   signal,
   inject,
   OnInit,
   viewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { LucideX } from '@lucide/angular';
+import { LucideSnowflake, LucideX } from '@lucide/angular';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import {
@@ -16,10 +18,11 @@ import {
   IndexerRow,
 } from '../../../core/services/api/indexers-api.service';
 import { ProfilesService } from '../../../core/services/api/profiles.service';
+import { ToastService } from '../../../core/services/toast.service';
 
 @Component({
   selector: 'app-indexers-settings',
-  imports: [FormsModule, LucideX, TranslateModule],
+  imports: [FormsModule, LucideSnowflake, LucideX, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './indexers.html',
 })
@@ -28,6 +31,7 @@ export class IndexersSettingsComponent implements OnInit {
   private readonly profilesApi = inject(ProfilesService);
   private readonly translate = inject(TranslateService);
   private readonly confirmation = inject(ConfirmationService);
+  private readonly toast = inject(ToastService);
   private readonly editorDialog = viewChild<ElementRef<HTMLDialogElement>>('editorDialog');
   private readonly statsDialog = viewChild<ElementRef<HTMLDialogElement>>('statsDialog');
 
@@ -56,6 +60,95 @@ export class IndexersSettingsComponent implements OnInit {
   readonly statsData = signal<{ date: string; queries: number; avgResponseMs: number; totalResults: number; errors: number }[]>([]);
   readonly statsIndexerName = signal('');
   readonly languages = signal<{ id: number; name: string; isoCode: string }[]>([]);
+
+  // ── Cooldowns ──
+  private readonly cooldownDialog =
+    viewChild<ElementRef<HTMLDialogElement>>('cooldownDialog');
+  /** Ticks so countdowns tick down and expired windows drop without a refetch. */
+  private readonly now = signal(Date.now());
+  readonly cooldownRow = signal<IndexerRow | null>(null);
+  readonly resettingCooldown = signal(false);
+
+  /** Rows whose window is still open, recomputed against the local clock. */
+  readonly cooledDown = computed(() => {
+    const now = this.now();
+    return this.rows().filter(
+      (ix) => ix.cooldown && Date.parse(ix.cooldown.until) > now,
+    );
+  });
+  readonly hasCooldowns = computed(() => this.cooledDown().length > 0);
+
+  constructor() {
+    const timer = setInterval(() => this.now.set(Date.now()), 5_000);
+    inject(DestroyRef).onDestroy(() => clearInterval(timer));
+  }
+
+  isCooledDown(ix: IndexerRow): boolean {
+    return !!ix.cooldown && Date.parse(ix.cooldown.until) > this.now();
+  }
+
+  /** Remaining window as `1 h 05 min`, `4 min 12 s`, `38 s`. */
+  cooldownRemaining(ix: IndexerRow): string {
+    if (!ix.cooldown) return '';
+    const total = Math.max(
+      0,
+      Math.round((Date.parse(ix.cooldown.until) - this.now()) / 1000),
+    );
+    const h = Math.floor(total / 3600);
+    const m = Math.floor((total % 3600) / 60);
+    const s = total % 60;
+    if (h) return `${h} h ${String(m).padStart(2, '0')} min`;
+    if (m) return `${m} min ${String(s).padStart(2, '0')} s`;
+    return `${s} s`;
+  }
+
+  cooldownExpiresAt(ix: IndexerRow): string {
+    return ix.cooldown ? new Date(ix.cooldown.until).toLocaleTimeString() : '';
+  }
+
+  openCooldown(ix: IndexerRow) {
+    this.cooldownRow.set(ix);
+    this.cooldownDialog()?.nativeElement.showModal();
+  }
+
+  closeCooldown() {
+    this.cooldownDialog()?.nativeElement.close();
+  }
+
+  async resetCooldown(ix: IndexerRow) {
+    this.resettingCooldown.set(true);
+    try {
+      await this.api.clearCooldown(ix.id);
+      this.closeCooldown();
+      await this.reloadAll();
+      this.toast.success(
+        this.translate.instant('settings.indexers.cooldown_reset_done', {
+          name: ix.name,
+        }),
+      );
+    } catch {
+      // handled by global error interceptor
+    } finally {
+      this.resettingCooldown.set(false);
+    }
+  }
+
+  async resetAllCooldowns() {
+    this.resettingCooldown.set(true);
+    try {
+      const { cleared } = await this.api.clearAllCooldowns();
+      await this.reloadAll();
+      this.toast.success(
+        this.translate.instant('settings.indexers.cooldown_reset_all_done', {
+          count: cleared,
+        }),
+      );
+    } catch {
+      // handled by global error interceptor
+    } finally {
+      this.resettingCooldown.set(false);
+    }
+  }
 
   ngOnInit() {
     this.reloadAll();


### PR DESCRIPTION
## Why

An indexer sitting in throttle cooldown was invisible on `/admin/settings/indexers`. Searches quietly dropped it from the fan-out with nothing to show that it happened, why, or for how long — and no way to retry before the window closed. At the fifth consecutive failure that window is six hours.

## What changed

**The throttle now records why.** It only kept an expiry timestamp, so `cooldownUntil` became a `Map<number, IndexerCooldown>` holding the reason, the consecutive-failure count and the last error text. The two causes read very differently to an admin: a `Retry-After` window is the indexer asking us to slow down, a backoff window is the indexer being broken. The failing search already had the error message in hand, so `notifyFailure` takes it as an optional detail.

**Lifting a window clears both gates.** `bumpCooldown` pushes the skip gate (`cooldownUntil`, what searches consult) *and* the queue gate (`nextAllowedAt`, what serialised requests sleep on). Clearing only the skip gate produces a reset that looks like it worked and doesn't: the search picks the indexer back up, then the request sleeps the rest of the original window inside the queue. `clearCooldown` clears both, plus the failure counter — otherwise the next failure resumes the ladder mid-way instead of restarting at 30 seconds.

**API**

- `GET /api/indexers` — each row carries `cooldown: { reason, remainingMs, until, failureCount?, detail? } | null`. Folded into the existing list response rather than a second endpoint, since the page already fetches it.
- `DELETE /api/indexers/:id/cooldown`
- `DELETE /api/indexers/cooldowns` — declared before the `:id` routes, otherwise `cooldowns` hits `ParseIntPipe` and 400s.

Both resets are behind `Action.Update, Indexer`.

**UI**

- A dedicated Status column holding a warning badge with the remaining time; clicking it opens the detail modal. It is its own column rather than part of Actif because that one reports configuration the admin set while a cooldown is runtime health, and the two are independent — an enabled indexer in cooldown would render as "Oui" beside "2 min" in one cell. Keeping it out of the name cell also keeps it aligned, so the list can be scanned for what is stuck.
- Per-row "Reset cooldown", shown only while a window is open.
- A header button to lift them all, shown only when at least one is open, labelled with the count.
- The modal explains the reason in prose, and lists remaining time, expiry clock time and the last error when there is one.

Countdowns are recomputed from the `until` timestamp against a 5s local tick, so a window that closes on its own stops showing without a refetch or a poll.

## Tests

`indexer-throttle.service.spec.ts` grows from 7 to 14 cases: reason and failure count reported, rate-limit reason with the header value, nothing reported once elapsed, ladder restarts after a reset, a request runs immediately after a reset (the queue-gate case above, guarded with a race against a 200ms timeout), false when there was nothing to lift, and the all-reset count covering only indexers actually in cooldown.

Backend indexers + media suites pass (62), `tsc` clean, client build clean.

## Not in scope

Cooldowns live in memory, so a backend restart clears them all — no change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)