### PR TITLE
feat(media-detail): show season artwork in the picker and season info above the episodes

### DIFF
--- a/backend/src/migrations/1782500000000-add-season-overview-airdate.ts
+++ b/backend/src/migrations/1782500000000-add-season-overview-airdate.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Per-season synopsis and air date. Both are already fetched into
+ * `SeasonDetails` but were never persisted. `airDate` is a varchar, not a date:
+ * TVDB reports a bare year for a season, which a date column would reject or
+ * silently widen into a fabricated 1 January.
+ */
+export class AddSeasonOverviewAirDate1782500000000
+  implements MigrationInterface
+{
+  name = 'AddSeasonOverviewAirDate1782500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "seasons" ADD COLUMN IF NOT EXISTS "overview" text`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "seasons" ADD COLUMN IF NOT EXISTS "airDate" character varying(10)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "seasons" DROP COLUMN IF EXISTS "airDate"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "seasons" DROP COLUMN IF EXISTS "overview"`,
+    );
+  }
+}

--- a/backend/src/modules/media/entities/season.entity.ts
+++ b/backend/src/modules/media/entities/season.entity.ts
@@ -40,6 +40,14 @@ export class Season extends BaseEntity {
   @Column({ type: 'text', nullable: true })
   posterUrl: string | null;
 
+  /** Season synopsis. Null on providers that don't carry one (TVDB). */
+  @Column({ type: 'text', nullable: true })
+  overview: string | null;
+
+  /** First air date. Varchar, not date: TVDB reports a bare year here. */
+  @Column({ type: 'varchar', length: 10, nullable: true })
+  airDate: string | null;
+
   @OneToMany(() => Episode, (episode) => episode.season, { cascade: true })
   episodes: Episode[];
 }

--- a/backend/src/modules/media/media-service/media-metadata.service.ts
+++ b/backend/src/modules/media/media-service/media-metadata.service.ts
@@ -300,6 +300,18 @@ export class MediaMetadataService {
       (dbSeason.episodes ?? []).map((e) => [e.episodeNumber, e]),
     );
 
+    const seasonUpdates: Partial<Season> = {};
+    if (sd.overview && sd.overview !== dbSeason.overview) {
+      seasonUpdates.overview = sd.overview;
+    }
+    if (sd.airDate && sd.airDate.slice(0, 10) !== dbSeason.airDate) {
+      seasonUpdates.airDate = sd.airDate.slice(0, 10);
+    }
+    if (Object.keys(seasonUpdates).length) {
+      await this.seasonRepo.update(dbSeason.id, seasonUpdates);
+      Object.assign(dbSeason, seasonUpdates);
+    }
+
     // 1. Partition into INSERTs and UPDATEs in a single pass.
     type UpdateJob = {
       id: number;

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -809,6 +809,7 @@
     "episodes": "Folgen",
     "episode_count_one": "{{count}} Episode",
     "episode_count_other": "{{count}} Episoden",
+    "season_watched_count": "{{count}} gesehen",
     "back": "Zurück zur Liste",
     "request_media": "Anfragen",
     "request_season": "Diese Staffel anfragen",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -814,6 +814,7 @@
     "episodes": "Episodes",
     "episode_count_one": "{{count}} episode",
     "episode_count_other": "{{count}} episodes",
+    "season_watched_count": "{{count}} watched",
     "back": "Back to list",
     "request_media": "Request",
     "request_season": "Request this season",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -809,6 +809,7 @@
     "episodes": "Episodios",
     "episode_count_one": "{{count}} episodio",
     "episode_count_other": "{{count}} episodios",
+    "season_watched_count": "{{count}} vistos",
     "back": "Volver a la lista",
     "request_media": "Solicitar",
     "request_season": "Solicitar esta temporada",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -814,6 +814,7 @@
     "episodes": "Épisodes",
     "episode_count_one": "{{count}} épisode",
     "episode_count_other": "{{count}} épisodes",
+    "season_watched_count": "{{count}} vus",
     "back": "Retour à la liste",
     "request_media": "Demander",
     "request_season": "Demander cette saison",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -809,6 +809,7 @@
     "episodes": "Episodi",
     "episode_count_one": "{{count}} episodio",
     "episode_count_other": "{{count}} episodi",
+    "season_watched_count": "{{count}} visti",
     "back": "Torna all'elenco",
     "request_media": "Richiedi",
     "request_season": "Richiedi questa stagione",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -809,6 +809,7 @@
     "episodes": "Episódios",
     "episode_count_one": "{{count}} episódio",
     "episode_count_other": "{{count}} episódios",
+    "season_watched_count": "{{count}} vistos",
     "back": "Voltar à lista",
     "request_media": "Pedir",
     "request_season": "Pedir esta temporada",

--- a/client/src/app/core/services/api/media.service.ts
+++ b/client/src/app/core/services/api/media.service.ts
@@ -72,6 +72,10 @@ export interface Season {
   preferredProvider?: 'tmdb' | 'tvdb' | null;
   /** Season-specific poster (TMDB/TVDB); null → fall back to series poster. */
   posterUrl: string | null;
+  /** Season synopsis; null on providers that don't carry one (TVDB). */
+  overview?: string | null;
+  /** First air date. May be a bare year: that's what TVDB reports. */
+  airDate?: string | null;
   episodes: Episode[];
 }
 

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -151,6 +151,7 @@
       </button>
       @for (season of displaySeasons(); track season.id) {
         <app-dropdown-option
+          [imageUrl]="season.posterUrl ?? m.posterUrl"
           [head]="'media_detail.season_number' | translate:{ number: season.seasonNumber }"
           [sub]="(tabEpisodeCount(season) <= 1 ? 'media_detail.episode_count_one' : 'media_detail.episode_count_other') | translate:{ count: tabEpisodeCount(season) }"
           [selected]="season.id === activeSeasonId()"
@@ -176,6 +177,32 @@
   }
 
   @if (selSeason && isSeasonTabVisible(selSeason)) {
+    @if (showSeasonInfo()) {
+      <div class="space-y-2">
+        <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-base-content/60">
+          @if (selSeason.airDate) {
+            <span>
+              @if (seasonAirDateIsYearOnly(selSeason)) {
+                {{ selSeason.airDate }}
+              } @else {
+                {{ selSeason.airDate | localeDate:{ dateStyle: 'long' } }}
+              }
+            </span>
+            <span aria-hidden="true">·</span>
+          }
+          <span>
+            {{ (tabEpisodeCount(selSeason) <= 1 ? 'media_detail.episode_count_one' : 'media_detail.episode_count_other') | translate:{ count: tabEpisodeCount(selSeason) } }}
+          </span>
+          @if (seasonWatchedCount(selSeason) > 0) {
+            <span aria-hidden="true">·</span>
+            <span>{{ 'media_detail.season_watched_count' | translate:{ count: seasonWatchedCount(selSeason) } }}</span>
+          }
+        </div>
+        @if (selSeason.overview) {
+          <p class="text-sm text-base-content/80 line-clamp-4">{{ selSeason.overview }}</p>
+        }
+      </div>
+    }
     @if (filteredEpisodes().length === 0 && episodesHasFileOnly() && selSeason.episodes.length > 0) {
       <p class="text-sm text-base-content/50 py-8 text-center">
         {{ 'media_detail.episodes_filter_empty' | translate }}

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -125,6 +125,28 @@ export class MediaDetailSeasonsComponent {
     return filterSeasonEpisodesOnDisk(season, this.episodesHasFileOnly()).length;
   }
 
+  /**
+   * Season header. Skipped on the episode page, where the series synopsis is
+   * already above and a season one would just repeat the context. Needs a
+   * synopsis or an air date to be worth a row: the episode count alone is
+   * already on the picker.
+   */
+  readonly showSeasonInfo = computed(() => {
+    if (this.hideControls()) return false;
+    const s = this.selectedSeason();
+    return !!s && (!!s.overview || !!s.airDate);
+  });
+
+  /** TVDB reports a bare year, which date formatting would widen into a day. */
+  seasonAirDateIsYearOnly(season: Season): boolean {
+    return /^\d{4}$/.test(season.airDate ?? '');
+  }
+
+  seasonWatchedCount(season: Season): number {
+    const watched = this.watchedEpisodeIds();
+    return (season.episodes ?? []).filter((ep) => watched.has(ep.id)).length;
+  }
+
   /** True when at least one episode of the season isn't on disk — the
    *  prerequisite for surfacing a Demander entry. Uses coverage so a season
    *  fully covered by multi-episode files isn't flagged as missing. */

--- a/client/src/app/shared/components/dropdown-option/dropdown-option.html
+++ b/client/src/app/shared/components/dropdown-option/dropdown-option.html
@@ -1,4 +1,13 @@
 <button type="button" class="dropdown-item" [class.text-primary]="selected()">
+  @if (imageUrl()) {
+    <img
+      [src]="imageUrl()! | resolveUrl:'thumb'"
+      class="w-8 h-12 shrink-0 rounded object-cover bg-base-content/10"
+      alt=""
+      loading="lazy"
+      decoding="async"
+    />
+  }
   <span class="flex-1 flex flex-col items-start gap-0 leading-tight text-left">
     <span>{{ head() }}</span>
     @if (sub()) {

--- a/client/src/app/shared/components/dropdown-option/dropdown-option.ts
+++ b/client/src/app/shared/components/dropdown-option/dropdown-option.ts
@@ -1,9 +1,11 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 
 /**
- * One option of an `app-dropdown-menu`: a head line, an optional detail line,
- * and the selected marker. Shared by the audio, subtitle and season pickers,
- * which render the same shape.
+ * One option of an `app-dropdown-menu`: an optional thumbnail, a head line, an
+ * optional detail line, and the selected marker. Shared by the audio, subtitle
+ * and season pickers; only the season picker carries artwork, so the thumbnail
+ * reserves no space when `imageUrl` is absent.
  *
  * Both labels arrive already translated — the component holds no user-facing
  * string of its own. The host is `display: contents` so `.dropdown-item`'s
@@ -14,6 +16,7 @@ import { ChangeDetectionStrategy, Component, input } from '@angular/core';
  */
 @Component({
   selector: 'app-dropdown-option',
+  imports: [ResolveUrlPipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './dropdown-option.html',
   host: { class: 'contents' },
@@ -22,4 +25,6 @@ export class DropdownOptionComponent {
   readonly head = input.required<string>();
   readonly sub = input<string | null | undefined>(null);
   readonly selected = input(false);
+  /** Portrait artwork shown at the left of the row. Omit for a text-only option. */
+  readonly imageUrl = input<string | null | undefined>(null);
 }


### PR DESCRIPTION
## Why

The season picker listed a number and an episode count — the least identifiable thing about a season. And nothing on the page carried the season's own synopsis or air date, even though both were already being fetched.

## Season artwork in the picker

The thumbnail went into the shared `app-dropdown-option`, which already backs the audio and subtitle pickers; the season picker only differs by having artwork to show. `imageUrl` is opt-in and the `@if` reserves no space when it's absent, so the text-only pickers render unchanged. The image goes through `| resolveUrl:'thumb'` like `app-media-card`, and falls back to the series poster the same way the "Other seasons" scroller already did — a provider with no per-season artwork leaves no hole.

No backend work: `Season.posterUrl` already existed, both providers populate it, `ImageService` stores it locally under the `season` scope, and the client `Season` type already carried it.

## Season info above the episodes scroller

`SeasonDetails` has carried `overview` and `airDate` since the providers were written (`tmdb.provider.ts:442`), but `applySeasonDetails` only ever persisted the poster and dropped both. So this half needed a migration.

- `seasons.overview text`, `seasons.airDate varchar(10)`.
- `airDate` is a **varchar, not a date**: TVDB reports a bare year for a season (`tvdb.provider.ts:366`), which a date column would reject or silently widen into a fabricated 1 January. The header prints a year-only value untouched and only date-formats a full one.
- No DTO work — seasons are returned as full entities through the `seasons` relation, so the columns surface on their own.

The header shows air date · episode count · watched count, then the synopsis clamped to four lines. It needs a synopsis **or** an air date to render at all: an episode count on its own would just repeat the picker. TVDB never returns a season synopsis and many TMDB seasons have an empty one, so it degrades to the meta line alone rather than falling back to the series synopsis, which already sits at the top of the page and would read as season-specific.

It is skipped on the episode page, where this component is reused for "more from this season" and the surrounding context already establishes the season.

## Backfill

Existing series have neither field until their next metadata refresh, and the header simply doesn't appear until then. No mass refresh is triggered from here — that would hit TMDB for the whole library, which should be a deliberate action.

## Checks

`tsc` clean, client build clean, backend media suite 48 passing, client suite 82 passing. No new tests: the only non-trivial branch is the year-only date guard, which is a one-line regex feeding a template branch.

## Not in scope

I left the season poster out of the info header itself — you asked for it in the picker, and a second copy of the same artwork on the same screen is a layout call that's yours to make. Say the word and it's a four-line addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)