### PR TITLE
feat(media-detail): group the season block and stop repeating the poster in the episode row

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -810,6 +810,7 @@
     "episode_count_one": "{{count}} Episode",
     "episode_count_other": "{{count}} Episoden",
     "season_watched_count": "{{count}} gesehen",
+    "season_resume": "E{{episode}} fortsetzen",
     "back": "Zurück zur Liste",
     "request_media": "Anfragen",
     "request_season": "Diese Staffel anfragen",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -815,6 +815,7 @@
     "episode_count_one": "{{count}} episode",
     "episode_count_other": "{{count}} episodes",
     "season_watched_count": "{{count}} watched",
+    "season_resume": "Resume E{{episode}}",
     "back": "Back to list",
     "request_media": "Request",
     "request_season": "Request this season",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -810,6 +810,7 @@
     "episode_count_one": "{{count}} episodio",
     "episode_count_other": "{{count}} episodios",
     "season_watched_count": "{{count}} vistos",
+    "season_resume": "Reanudar E{{episode}}",
     "back": "Volver a la lista",
     "request_media": "Solicitar",
     "request_season": "Solicitar esta temporada",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -815,6 +815,7 @@
     "episode_count_one": "{{count}} épisode",
     "episode_count_other": "{{count}} épisodes",
     "season_watched_count": "{{count}} vus",
+    "season_resume": "Reprendre E{{episode}}",
     "back": "Retour à la liste",
     "request_media": "Demander",
     "request_season": "Demander cette saison",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -810,6 +810,7 @@
     "episode_count_one": "{{count}} episodio",
     "episode_count_other": "{{count}} episodi",
     "season_watched_count": "{{count}} visti",
+    "season_resume": "Riprendi E{{episode}}",
     "back": "Torna all'elenco",
     "request_media": "Richiedi",
     "request_season": "Richiedi questa stagione",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -810,6 +810,7 @@
     "episode_count_one": "{{count}} episódio",
     "episode_count_other": "{{count}} episódios",
     "season_watched_count": "{{count}} vistos",
+    "season_resume": "Retomar E{{episode}}",
     "back": "Voltar à lista",
     "request_media": "Pedir",
     "request_season": "Pedir esta temporada",

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -4,7 +4,7 @@
 <section class="space-y-4">
   @if (!hideControls()) {
   <div appTvRow class="flex items-center gap-2 flex-wrap">
-    <app-dropdown-menu placement="bottom-start">
+    <app-dropdown-menu placement="bottom-start" class="order-last ms-auto">
       <button trigger type="button" class="btn btn-ghost btn-circle shrink-0">
         <svg lucideEllipsisVertical class="h-5 w-5"></svg>
       </button>
@@ -142,7 +142,7 @@
       }
     </app-dropdown-menu>
     <app-dropdown-menu placement="bottom-start">
-      <button trigger type="button" class="select select-bordered w-fit shrink-0 text-left cursor-pointer transition-colors hover:bg-base-content/10">
+      <button trigger type="button" class="select select-bordered w-fit shrink-0 text-left text-lg font-bold cursor-pointer transition-colors hover:bg-base-content/10">
         @if (selSeason) {
           {{ 'media_detail.season_number' | translate:{ number: selSeason.seasonNumber } }}
         } @else {
@@ -177,8 +177,10 @@
   }
 
   @if (selSeason && isSeasonTabVisible(selSeason)) {
-    @if (showSeasonInfo()) {
-      <div class="space-y-2">
+    <!-- Pulled up out of the section's space-y-4 so it groups with the season
+         picker above rather than reading as a caption of the episode row. -->
+    @if (!hideControls()) {
+      <div class="space-y-2 -mt-2">
         <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-base-content/60">
           @if (selSeason.airDate) {
             <span>
@@ -198,6 +200,23 @@
             <span>{{ 'media_detail.season_watched_count' | translate:{ count: seasonWatchedCount(selSeason) } }}</span>
           }
         </div>
+
+        @if (seasonWatchedCount(selSeason) > 0) {
+          <div class="flex items-center gap-3">
+            <progress
+              class="progress progress-primary h-1 w-full max-w-xs"
+              [value]="seasonProgressPercent(selSeason)"
+              max="100"
+            ></progress>
+            @if (seasonResumeEpisode(selSeason); as next) {
+              <button type="button" class="btn btn-primary btn-xs shrink-0" (click)="playEpisode(next)">
+                <svg lucidePlay class="h-3 w-3 shrink-0" aria-hidden="true"></svg>
+                {{ 'media_detail.season_resume' | translate:{ episode: next.episodeNumber } }}
+              </button>
+            }
+          </div>
+        }
+
         @if (selSeason.overview) {
           <p class="text-sm text-base-content/80 line-clamp-4">{{ selSeason.overview }}</p>
         }
@@ -208,12 +227,11 @@
         {{ 'media_detail.episodes_filter_empty' | translate }}
       </p>
     } @else if (filteredEpisodes().length > 0) {
-      <app-horizontal-scroller [title]="sectionTitle() ?? ('media_detail.episodes' | translate)">
+      <app-horizontal-scroller [title]="sectionTitle() ?? ''">
         @for (ep of filteredEpisodes(); track ep.id) {
           <app-media-card [aspect]="'landscape'"
             [id]="'episode-' + ep.id"
-            [imageUrl]="ep.stillUrl ?? m.posterUrl"
-            [imageBlurred]="!ep.stillUrl && !!m.posterUrl"
+            [imageUrl]="ep.stillUrl ?? null"
             [title]="ep.title ?? ('media_detail.ep_no_title' | translate)"
             [subtitle]="(ep.airDate | localeDate) || '—'"
             [topLeftBadge]="episodeBadgeLabel(ep)"

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -19,6 +19,7 @@ import {
   LucideListChecks,
   LucideListPlus,
   LucidePackage,
+  LucidePlay,
   LucideUserPlus,
   LucideX,
 } from '@lucide/angular';
@@ -49,7 +50,7 @@ import { LocaleDatePipe } from '../../../../core/pipes/locale-date.pipe';
 
 @Component({
   selector: 'app-media-detail-seasons',
-  imports: [TranslateModule, UpperCasePipe, LocaleDatePipe, HorizontalScrollerComponent, MediaCardComponent, DropdownMenuComponent, DropdownOptionComponent, TvRowDirective, LucideCheck, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideHeart, LucideListChecks, LucideListPlus, LucidePackage, LucideUserPlus, LucideX],
+  imports: [TranslateModule, UpperCasePipe, LocaleDatePipe, HorizontalScrollerComponent, MediaCardComponent, DropdownMenuComponent, DropdownOptionComponent, TvRowDirective, LucideCheck, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideHeart, LucideListChecks, LucideListPlus, LucidePackage, LucidePlay, LucideUserPlus, LucideX],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-seasons.component.html',
 })
@@ -125,18 +126,6 @@ export class MediaDetailSeasonsComponent {
     return filterSeasonEpisodesOnDisk(season, this.episodesHasFileOnly()).length;
   }
 
-  /**
-   * Season header. Skipped on the episode page, where the series synopsis is
-   * already above and a season one would just repeat the context. Needs a
-   * synopsis or an air date to be worth a row: the episode count alone is
-   * already on the picker.
-   */
-  readonly showSeasonInfo = computed(() => {
-    if (this.hideControls()) return false;
-    const s = this.selectedSeason();
-    return !!s && (!!s.overview || !!s.airDate);
-  });
-
   /** TVDB reports a bare year, which date formatting would widen into a day. */
   seasonAirDateIsYearOnly(season: Season): boolean {
     return /^\d{4}$/.test(season.airDate ?? '');
@@ -145,6 +134,27 @@ export class MediaDetailSeasonsComponent {
   seasonWatchedCount(season: Season): number {
     const watched = this.watchedEpisodeIds();
     return (season.episodes ?? []).filter((ep) => watched.has(ep.id)).length;
+  }
+
+  seasonProgressPercent(season: Season): number {
+    const total = this.tabEpisodeCount(season);
+    if (!total) return 0;
+    return Math.min(100, Math.round((this.seasonWatchedCount(season) / total) * 100));
+  }
+
+  /**
+   * Next episode to play in this season. Only offered once the season has been
+   * started: on an untouched season the header's own resume button already
+   * covers it, and the first card is one click away either way.
+   */
+  seasonResumeEpisode(season: Season | null): Episode | null {
+    if (!season || this.seasonWatchedCount(season) === 0) return null;
+    const watched = this.watchedEpisodeIds();
+    return (
+      (season.episodes ?? [])
+        .filter((ep) => ep.hasFile && !watched.has(ep.id))
+        .sort((a, b) => a.episodeNumber - b.episodeNumber)[0] ?? null
+    );
   }
 
   /** True when at least one episode of the season isn't on disk — the

--- a/client/src/app/shared/components/horizontal-scroller.html
+++ b/client/src/app/shared/components/horizontal-scroller.html
@@ -1,7 +1,11 @@
-<div class="mb-3 flex items-center gap-3">
-  <h2 class="text-lg font-bold">{{ title() }}</h2>
-  <ng-content select="[scrollerActions]" />
-</div>
+<!-- Dropped entirely without a title: a caller that titles the row itself
+     would otherwise get an empty heading holding vertical space. -->
+@if (title()) {
+  <div class="mb-3 flex items-center gap-3">
+    <h2 class="text-lg font-bold">{{ title() }}</h2>
+    <ng-content select="[scrollerActions]" />
+  </div>
+}
 
 <!-- Scroll affordances overlay the row's edges and fade in on hover; the
      scroller itself owns the smooth scroll. Vertical / horizontal padding


### PR DESCRIPTION
Corrections 1, 2 and 4 from the layout review. Correction 3 (episode duration + list view with synopsis) and 5 (series details placement) are not in here.

## 1 — The season block became a real section header

The meta line floated between the picker and the "Épisodes" heading, attached to neither, reading as a stray caption.

- The season number is now the section heading (the picker trigger carries `text-lg font-bold`), with the meta, progress and synopsis grouped under it.
- The kebab moves to the end of the row, so the heading leads it.
- The episode row loses its own "Épisodes" title — it never said anything the row below didn't already show.
- `app-horizontal-scroller` now drops its header block entirely when it has no title. Previously an empty title still rendered an empty `<h2>` plus its `mb-3`, so a caller that titles the row itself inherited a phantom line. The only caller projecting `[scrollerActions]` also passes a title, so nothing loses its actions.

The header block sits outside the section's `space-y-4` with a `-mt-2`, since the picker row and the info block live in different conditionals — the picker shows even when the season tab is filtered out, the info block doesn't — so they can't share a wrapper without changing when each appears.

## 2 — The repeated poster is gone

An episode with no still fell back to `m.posterUrl` with `imageBlurred`. On an unaired season nothing has a still, so that's the same picture six times across the row — the actual image overload on that screen.

The fallback is **deleted** rather than replaced: `app-media-card` already renders a neutral film-icon placeholder when it has no image. A blurred poster reads as content, an empty tile reads as "nothing yet", which is what an unaired episode is. That also drops the only `imageBlurred` usage in the app.

## 4 — Progress bar and season resume

The watched count keeps its text form and gains a bar beside it. The resume button only appears on a season that already has a watched episode: on an untouched season the page header's own resume covers the same intent, and showing both would put two near-identical buttons on screen. It reuses the component's existing `playEpisode`, so no new wiring.

## Checks

Client build clean, client suite 82 passing. No new tests — this is layout plus two guard conditions on data the component already had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)