### PR TITLE
feat(media-detail): add an episode list view with synopsis and runtime

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -811,6 +811,8 @@
     "episode_count_other": "{{count}} Episoden",
     "season_watched_count": "{{count}} gesehen",
     "season_resume": "E{{episode}} fortsetzen",
+    "episode_view_grid": "Kartenansicht",
+    "episode_view_list": "Listenansicht",
     "back": "Zurück zur Liste",
     "request_media": "Anfragen",
     "request_season": "Diese Staffel anfragen",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -816,6 +816,8 @@
     "episode_count_other": "{{count}} episodes",
     "season_watched_count": "{{count}} watched",
     "season_resume": "Resume E{{episode}}",
+    "episode_view_grid": "Card view",
+    "episode_view_list": "List view",
     "back": "Back to list",
     "request_media": "Request",
     "request_season": "Request this season",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -811,6 +811,8 @@
     "episode_count_other": "{{count}} episodios",
     "season_watched_count": "{{count}} vistos",
     "season_resume": "Reanudar E{{episode}}",
+    "episode_view_grid": "Vista de tarjetas",
+    "episode_view_list": "Vista de lista",
     "back": "Volver a la lista",
     "request_media": "Solicitar",
     "request_season": "Solicitar esta temporada",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -816,6 +816,8 @@
     "episode_count_other": "{{count}} épisodes",
     "season_watched_count": "{{count}} vus",
     "season_resume": "Reprendre E{{episode}}",
+    "episode_view_grid": "Vue cartes",
+    "episode_view_list": "Vue liste",
     "back": "Retour à la liste",
     "request_media": "Demander",
     "request_season": "Demander cette saison",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -811,6 +811,8 @@
     "episode_count_other": "{{count}} episodi",
     "season_watched_count": "{{count}} visti",
     "season_resume": "Riprendi E{{episode}}",
+    "episode_view_grid": "Vista a schede",
+    "episode_view_list": "Vista a elenco",
     "back": "Torna all'elenco",
     "request_media": "Richiedi",
     "request_season": "Richiedi questa stagione",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -811,6 +811,8 @@
     "episode_count_other": "{{count}} episódios",
     "season_watched_count": "{{count}} vistos",
     "season_resume": "Retomar E{{episode}}",
+    "episode_view_grid": "Vista de cartões",
+    "episode_view_list": "Vista de lista",
     "back": "Voltar à lista",
     "request_media": "Pedir",
     "request_season": "Pedir esta temporada",

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -256,11 +256,7 @@
       <ul class="divide-y divide-base-200 border-y border-base-200">
         @for (ep of filteredEpisodes(); track ep.id) {
           <li class="flex gap-4 py-3" [class.opacity-50]="!ep.monitored">
-            <a
-              [routerLink]="episodeRoute(ep)"
-              [replaceUrl]="hideControls()"
-              class="relative block w-40 sm:w-56 shrink-0 aspect-video rounded-lg overflow-hidden bg-base-200"
-            >
+            <div class="relative w-40 sm:w-56 shrink-0 aspect-video rounded-lg overflow-hidden bg-base-200">
               @if (ep.stillUrl) {
                 <img
                   [src]="ep.stillUrl | resolveUrl:'thumb'"
@@ -274,9 +270,10 @@
                   <svg lucideFilm class="h-8 w-8" [strokeWidth]="1.5" aria-hidden="true"></svg>
                 </span>
               }
+
               <!-- Same overlay language as app-media-card: red cross for a
                    missing file, then the episode number. -->
-              <div class="absolute top-2 left-2 z-10 flex items-center gap-1">
+              <div class="absolute top-2 left-2 z-20 flex items-center gap-1 pointer-events-none">
                 @if (!ep.hasFile) {
                   <svg
                     lucideCircleX
@@ -288,11 +285,33 @@
                 <span class="badge badge-neutral font-mono">{{ episodeBadgeLabel(ep) }}</span>
               </div>
               @if (episodeProgress()[ep.id]) {
-                <span class="absolute bottom-0 inset-x-0 h-1 bg-base-300/60">
+                <span class="absolute bottom-0 inset-x-0 h-1 z-20 bg-base-300/60 pointer-events-none">
                   <span class="block h-full bg-primary" [style.width.%]="episodeProgress()[ep.id]"></span>
                 </span>
               }
-            </a>
+
+              <!-- Cover plays when there is a file, mirroring the card's hover
+                   overlay; otherwise it opens the episode so it can be grabbed. -->
+              @if (ep.hasFile) {
+                <button
+                  type="button"
+                  class="absolute inset-0 z-10 flex items-center justify-center bg-black/40 opacity-0 hover:opacity-100 focus-visible:opacity-100 transition-opacity cursor-pointer"
+                  [attr.aria-label]="'media_card.play' | translate"
+                  (click)="playEpisode(ep)"
+                >
+                  <span class="w-12 h-12 rounded-full bg-black/50 flex items-center justify-center text-white">
+                    <svg lucidePlay class="h-6 w-6" [strokeWidth]="2"></svg>
+                  </span>
+                </button>
+              } @else {
+                <a
+                  [routerLink]="episodeRoute(ep)"
+                  [replaceUrl]="hideControls()"
+                  class="absolute inset-0 z-10"
+                  [attr.aria-label]="ep.title ?? ('media_detail.ep_no_title' | translate)"
+                ></a>
+              }
+            </div>
 
             <div class="min-w-0 flex-1 flex flex-col gap-1">
               <div class="flex flex-wrap items-baseline gap-x-2">
@@ -314,15 +333,6 @@
 
             <div class="flex items-start gap-1 shrink-0">
               @if (ep.hasFile) {
-                <button
-                  type="button"
-                  class="btn btn-ghost btn-sm btn-circle"
-                  [attr.aria-label]="'media_card.play' | translate"
-                  [attr.title]="'media_card.play' | translate"
-                  (click)="playEpisode(ep)"
-                >
-                  <svg lucidePlay class="h-4 w-4"></svg>
-                </button>
                 <button
                   type="button"
                   class="btn btn-ghost btn-sm btn-circle"

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -30,7 +30,7 @@
         </button>
       </div>
     }
-    <app-dropdown-menu placement="bottom-start" [class]="canSwitchEpisodeView() ? 'order-last' : 'order-last ms-auto'">
+    <app-dropdown-menu placement="bottom-end" [class]="canSwitchEpisodeView() ? 'order-last' : 'order-last ms-auto'">
       <button trigger type="button" class="btn btn-ghost btn-circle shrink-0">
         <svg lucideEllipsisVertical class="h-5 w-5"></svg>
       </button>
@@ -259,7 +259,7 @@
             <a
               [routerLink]="episodeRoute(ep)"
               [replaceUrl]="hideControls()"
-              class="relative block w-32 sm:w-40 shrink-0 aspect-video rounded-lg overflow-hidden bg-base-200"
+              class="relative block w-40 sm:w-56 shrink-0 aspect-video rounded-lg overflow-hidden bg-base-200"
             >
               @if (ep.stillUrl) {
                 <img
@@ -271,7 +271,7 @@
                 />
               } @else {
                 <span class="flex items-center justify-center w-full h-full text-base-content/20">
-                  <svg lucideFilm class="h-6 w-6" [strokeWidth]="1.5" aria-hidden="true"></svg>
+                  <svg lucideFilm class="h-8 w-8" [strokeWidth]="1.5" aria-hidden="true"></svg>
                 </span>
               }
               <!-- Same overlay language as app-media-card: red cross for a

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -4,7 +4,33 @@
 <section class="space-y-4">
   @if (!hideControls()) {
   <div appTvRow class="flex items-center gap-2 flex-wrap">
-    <app-dropdown-menu placement="bottom-start" class="order-last ms-auto">
+    @if (canSwitchEpisodeView()) {
+      <div class="order-last join ms-auto" role="group">
+        <button
+          type="button"
+          class="btn btn-sm join-item"
+          [class.btn-active]="episodeView() === 'grid'"
+          [attr.aria-pressed]="episodeView() === 'grid'"
+          [attr.aria-label]="'media_detail.episode_view_grid' | translate"
+          [attr.title]="'media_detail.episode_view_grid' | translate"
+          (click)="setEpisodeView('grid')"
+        >
+          <svg lucideLayoutGrid class="h-4 w-4"></svg>
+        </button>
+        <button
+          type="button"
+          class="btn btn-sm join-item"
+          [class.btn-active]="episodeView() === 'list'"
+          [attr.aria-pressed]="episodeView() === 'list'"
+          [attr.aria-label]="'media_detail.episode_view_list' | translate"
+          [attr.title]="'media_detail.episode_view_list' | translate"
+          (click)="setEpisodeView('list')"
+        >
+          <svg lucideList class="h-4 w-4"></svg>
+        </button>
+      </div>
+    }
+    <app-dropdown-menu placement="bottom-start" [class]="canSwitchEpisodeView() ? 'order-last' : 'order-last ms-auto'">
       <button trigger type="button" class="btn btn-ghost btn-circle shrink-0">
         <svg lucideEllipsisVertical class="h-5 w-5"></svg>
       </button>
@@ -226,6 +252,85 @@
       <p class="text-sm text-base-content/50 py-8 text-center">
         {{ 'media_detail.episodes_filter_empty' | translate }}
       </p>
+    } @else if (filteredEpisodes().length > 0 && showEpisodeList()) {
+      <ul class="divide-y divide-base-200 border-y border-base-200">
+        @for (ep of filteredEpisodes(); track ep.id) {
+          <li class="flex gap-4 py-3" [class.opacity-50]="!ep.monitored">
+            <a
+              [routerLink]="episodeRoute(ep)"
+              [replaceUrl]="hideControls()"
+              class="relative block w-32 sm:w-40 shrink-0 aspect-video rounded-lg overflow-hidden bg-base-200"
+            >
+              @if (ep.stillUrl) {
+                <img
+                  [src]="ep.stillUrl | resolveUrl:'thumb'"
+                  class="w-full h-full object-cover"
+                  alt=""
+                  loading="lazy"
+                  decoding="async"
+                />
+              } @else {
+                <span class="flex items-center justify-center w-full h-full text-base-content/20">
+                  <svg lucideFilm class="h-6 w-6" [strokeWidth]="1.5" aria-hidden="true"></svg>
+                </span>
+              }
+              <span
+                class="absolute top-1 start-1 rounded bg-base-300/85 px-1.5 text-sm tabular-nums"
+              >{{ episodeBadgeLabel(ep) }}</span>
+              @if (episodeProgress()[ep.id]) {
+                <span class="absolute bottom-0 inset-x-0 h-1 bg-base-300/60">
+                  <span class="block h-full bg-primary" [style.width.%]="episodeProgress()[ep.id]"></span>
+                </span>
+              }
+            </a>
+
+            <div class="min-w-0 flex-1 flex flex-col gap-1">
+              <div class="flex flex-wrap items-baseline gap-x-2">
+                <a
+                  [routerLink]="episodeRoute(ep)"
+                  [replaceUrl]="hideControls()"
+                  class="text-lg font-medium hover:underline"
+                >{{ ep.title ?? ('media_detail.ep_no_title' | translate) }}</a>
+                <span class="text-sm text-base-content/50 tabular-nums">
+                  {{ episodeCardSubtitle((ep.airDate | localeDate), ep.runtime) }}
+                </span>
+              </div>
+              @if (ep.overview) {
+                <p class="text-base text-base-content/70 line-clamp-2">{{ ep.overview }}</p>
+              } @else {
+                <p class="text-base text-base-content/35 italic">{{ 'media_detail.ep_no_overview' | translate }}</p>
+              }
+            </div>
+
+            <div class="flex items-start gap-1 shrink-0">
+              @if (ep.hasFile) {
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-sm btn-circle"
+                  [attr.aria-label]="'media_card.play' | translate"
+                  [attr.title]="'media_card.play' | translate"
+                  (click)="playEpisode(ep)"
+                >
+                  <svg lucidePlay class="h-4 w-4"></svg>
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-sm btn-circle"
+                  [class.text-success]="watchedEpisodeIds().has(ep.id)"
+                  [attr.aria-pressed]="watchedEpisodeIds().has(ep.id)"
+                  [attr.aria-label]="(watchedEpisodeIds().has(ep.id) ? 'media_card.mark_unwatched' : 'media_card.mark_watched') | translate"
+                  [attr.title]="(watchedEpisodeIds().has(ep.id) ? 'media_card.mark_unwatched' : 'media_card.mark_watched') | translate"
+                  (click)="toggleEpisodeWatched.emit({ episode: ep, watched: !watchedEpisodeIds().has(ep.id) })"
+                >
+                  <svg lucideCheck class="h-4 w-4"></svg>
+                </button>
+              } @else {
+                <span class="badge badge-ghost badge-sm">{{ 'media_card.missing_files' | translate }}</span>
+              }
+            </div>
+          </li>
+        }
+      </ul>
     } @else if (filteredEpisodes().length > 0) {
       <app-horizontal-scroller [title]="sectionTitle() ?? ''">
         @for (ep of filteredEpisodes(); track ep.id) {
@@ -233,7 +338,7 @@
             [id]="'episode-' + ep.id"
             [imageUrl]="ep.stillUrl ?? null"
             [title]="ep.title ?? ('media_detail.ep_no_title' | translate)"
-            [subtitle]="(ep.airDate | localeDate) || '—'"
+            [subtitle]="episodeCardSubtitle((ep.airDate | localeDate), ep.runtime)"
             [topLeftBadge]="episodeBadgeLabel(ep)"
             [status]="watchedEpisodeIds().has(ep.id) ? 'watched' : (!ep.hasFile ? 'missing' : null)"
             [progressPercent]="episodeProgress()[ep.id]"

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -274,9 +274,19 @@
                   <svg lucideFilm class="h-6 w-6" [strokeWidth]="1.5" aria-hidden="true"></svg>
                 </span>
               }
-              <span
-                class="absolute top-1 start-1 rounded bg-base-300/85 px-1.5 text-sm tabular-nums"
-              >{{ episodeBadgeLabel(ep) }}</span>
+              <!-- Same overlay language as app-media-card: red cross for a
+                   missing file, then the episode number. -->
+              <div class="absolute top-2 left-2 z-10 flex items-center gap-1">
+                @if (!ep.hasFile) {
+                  <svg
+                    lucideCircleX
+                    class="h-5 w-5 text-error drop-shadow"
+                    [attr.aria-label]="'media_card.missing_files' | translate"
+                    [attr.title]="'media_card.missing_files' | translate"
+                  ></svg>
+                }
+                <span class="badge badge-neutral font-mono">{{ episodeBadgeLabel(ep) }}</span>
+              </div>
               @if (episodeProgress()[ep.id]) {
                 <span class="absolute bottom-0 inset-x-0 h-1 bg-base-300/60">
                   <span class="block h-full bg-primary" [style.width.%]="episodeProgress()[ep.id]"></span>
@@ -324,8 +334,6 @@
                 >
                   <svg lucideCheck class="h-4 w-4"></svg>
                 </button>
-              } @else {
-                <span class="badge badge-ghost badge-sm">{{ 'media_card.missing_files' | translate }}</span>
               }
             </div>
           </li>

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -12,6 +12,7 @@ import { RouterLink } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
   LucideCheck,
+  LucideCircleX,
   LucideClipboardList,
   LucideDownload,
   LucideEllipsisVertical,
@@ -69,7 +70,7 @@ function readEpisodeViewFromStorage(): EpisodeView {
 
 @Component({
   selector: 'app-media-detail-seasons',
-  imports: [TranslateModule, UpperCasePipe, RouterLink, LocaleDatePipe, ResolveUrlPipe, HorizontalScrollerComponent, MediaCardComponent, DropdownMenuComponent, DropdownOptionComponent, TvRowDirective, LucideCheck, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideFilm, LucideHeart, LucideLayoutGrid, LucideList, LucideListChecks, LucideListPlus, LucidePackage, LucidePlay, LucideUserPlus, LucideX],
+  imports: [TranslateModule, UpperCasePipe, RouterLink, LocaleDatePipe, ResolveUrlPipe, HorizontalScrollerComponent, MediaCardComponent, DropdownMenuComponent, DropdownOptionComponent, TvRowDirective, LucideCheck, LucideCircleX, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideFilm, LucideHeart, LucideLayoutGrid, LucideList, LucideListChecks, LucideListPlus, LucidePackage, LucidePlay, LucideUserPlus, LucideX],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-seasons.component.html',
 })

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -5,9 +5,11 @@ import {
   inject,
   input,
   output,
+  signal,
 } from '@angular/core';
 import { UpperCasePipe } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { RouterLink } from '@angular/router';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
   LucideCheck,
   LucideClipboardList,
@@ -15,7 +17,10 @@ import {
   LucideEllipsisVertical,
   LucideEye,
   LucideEyeOff,
+  LucideFilm,
   LucideHeart,
+  LucideLayoutGrid,
+  LucideList,
   LucideListChecks,
   LucideListPlus,
   LucidePackage,
@@ -46,17 +51,32 @@ import { AddToPlaylistService } from '../../../../core/services/add-to-playlist.
 import { TvService } from '../../../../core/services/tv.service';
 import { AuthService } from '../../../../core/services/auth.service';
 import { LocaleDatePipe } from '../../../../core/pipes/locale-date.pipe';
+import { ResolveUrlPipe } from '../../../../core/pipes/resolve-url.pipe';
+
+const LS_EPISODE_VIEW = 'fliks.mediaDetail.episodeView';
+
+type EpisodeView = 'grid' | 'list';
+
+function readEpisodeViewFromStorage(): EpisodeView {
+  if (typeof localStorage === 'undefined') return 'grid';
+  try {
+    return localStorage.getItem(LS_EPISODE_VIEW) === 'list' ? 'list' : 'grid';
+  } catch {
+    return 'grid';
+  }
+}
 
 
 @Component({
   selector: 'app-media-detail-seasons',
-  imports: [TranslateModule, UpperCasePipe, LocaleDatePipe, HorizontalScrollerComponent, MediaCardComponent, DropdownMenuComponent, DropdownOptionComponent, TvRowDirective, LucideCheck, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideHeart, LucideListChecks, LucideListPlus, LucidePackage, LucidePlay, LucideUserPlus, LucideX],
+  imports: [TranslateModule, UpperCasePipe, RouterLink, LocaleDatePipe, ResolveUrlPipe, HorizontalScrollerComponent, MediaCardComponent, DropdownMenuComponent, DropdownOptionComponent, TvRowDirective, LucideCheck, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideFilm, LucideHeart, LucideLayoutGrid, LucideList, LucideListChecks, LucideListPlus, LucidePackage, LucidePlay, LucideUserPlus, LucideX],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-seasons.component.html',
 })
 export class MediaDetailSeasonsComponent {
   private readonly playableMedia = inject(PlayableMediaService);
   private readonly addToPlaylist = inject(AddToPlaylistService);
+  private readonly translate = inject(TranslateService);
   readonly tv = inject(TvService);
   readonly auth = inject(AuthService);
   readonly media = input.required<Media>();
@@ -134,6 +154,38 @@ export class MediaDetailSeasonsComponent {
   seasonWatchedCount(season: Season): number {
     const watched = this.watchedEpisodeIds();
     return (season.episodes ?? []).filter((ep) => watched.has(ep.id)).length;
+  }
+
+  /**
+   * Card row or detail list. Kept local: nothing outside this component reacts
+   * to it, unlike the on-disk filter the parent owns. Cards only on a TV, where
+   * a vertical list has no idiom and the d-pad row does.
+   */
+  readonly episodeView = signal<EpisodeView>(readEpisodeViewFromStorage());
+  readonly canSwitchEpisodeView = computed(
+    () => !this.hideControls() && !this.tv.isTv(),
+  );
+  readonly showEpisodeList = computed(
+    () => this.canSwitchEpisodeView() && this.episodeView() === 'list',
+  );
+
+  setEpisodeView(view: EpisodeView) {
+    this.episodeView.set(view);
+    try {
+      localStorage.setItem(LS_EPISODE_VIEW, view);
+    } catch {
+      /* private mode / quota */
+    }
+  }
+
+  /**
+   * `05/08/2026 · 34 min`. Takes the date already formatted so the impure
+   * locale pipe stays in the template and keeps re-running on a language switch.
+   */
+  episodeCardSubtitle(formattedDate: string, runtime?: number | null): string {
+    const parts = [formattedDate || '—'];
+    if (runtime) parts.push(`${runtime} ${this.translate.instant('common.min')}`);
+    return parts.join(' · ');
   }
 
   seasonProgressPercent(season: Season): number {


### PR DESCRIPTION
Correction 3 from the layout review. Correction 5 (series details placement) is still open — it needs a call on *move up* vs *collapse*.

## Why

The card row physically can't carry an episode synopsis, so the one thing a viewer actually reads before picking an episode was the only thing the page didn't show. That's why every reference client offers both shapes rather than picking one.

Both fields were already on the client `Episode` type and simply unused — no backend work.

## What changed

**A list view**, toggled from the season header: thumbnail, episode badge, title, air date · runtime, synopsis clamped to two lines, then play and watched buttons. An episode with no synopsis says so rather than collapsing the row, and one with no file shows the missing badge in place of the actions.

It reuses the card's own `media_card.play` / `mark_watched` / `mark_unwatched` / `missing_files` labels rather than minting parallel strings for the same actions, and carries over what the card encoded: watched state, in-progress bar, the unmonitored dim, and multi-episode badges via `episodeBadgeLabel`.

**Runtime on the card too** — `episodeCardSubtitle` builds `05/08/2026 · 34 min`. It takes the date pre-formatted so the impure `localeDate` pipe stays in the template and keeps re-rendering on a live language switch.

**Persistence** follows the on-disk filter's localStorage pattern, but the signal stays local to this component. Nothing outside reacts to it, unlike that filter, which the parent owns because it also drives season selection.

**Where the toggle doesn't appear**: on a TV, where a vertical list has no d-pad idiom and the card row does; and on the episode page's "more from this season" block, which is a row by intent.

## Sizing

No `text-xs` anywhere in the touched markup, per your note — title `text-lg`, synopsis `text-base`, meta `text-sm`.

One I left alone: `app-dropdown-option`'s sub line is still `text-xs md:text-sm`. It's pre-existing and shared with the audio and subtitle pickers, so bumping it changes those two menus as well. Now that the row carries a 32×48 poster it does read small — say the word and I'll raise it in all three.

## Checks

Client build clean, client suite 82 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)