### PR TITLE
feat(media-detail): surface series status and genres, fold the rest of the details

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -801,7 +801,8 @@
     "watched": "Gesehen",
     "ends_at": "Endet um {{time}}",
     "remaining": "verbleibend",
-    "genres": "Genres"
+    "genres": "Genres",
+    "details": "Details"
   },
   "media_detail": {
     "cast": "Besetzung",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -806,7 +806,8 @@
     "watched": "Watched",
     "ends_at": "Ends at {{time}}",
     "remaining": "remaining",
-    "genres": "Genres"
+    "genres": "Genres",
+    "details": "Details"
   },
   "media_detail": {
     "cast": "Cast",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -801,7 +801,8 @@
     "watched": "Visto",
     "ends_at": "Termina a las {{time}}",
     "remaining": "restantes",
-    "genres": "Géneros"
+    "genres": "Géneros",
+    "details": "Detalles"
   },
   "media_detail": {
     "cast": "Reparto",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -806,7 +806,8 @@
     "watched": "Lu",
     "ends_at": "Se termine à {{time}}",
     "remaining": "restantes",
-    "genres": "Genres"
+    "genres": "Genres",
+    "details": "Détails"
   },
   "media_detail": {
     "cast": "Casting",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -801,7 +801,8 @@
     "watched": "Visto",
     "ends_at": "Termina alle {{time}}",
     "remaining": "rimanenti",
-    "genres": "Generi"
+    "genres": "Generi",
+    "details": "Dettagli"
   },
   "media_detail": {
     "cast": "Cast",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -801,7 +801,8 @@
     "watched": "Visto",
     "ends_at": "Termina às {{time}}",
     "remaining": "restantes",
-    "genres": "Géneros"
+    "genres": "Géneros",
+    "details": "Detalhes"
   },
   "media_detail": {
     "cast": "Elenco",

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -235,6 +235,10 @@
           />
         }
 
+        @if (m.type === 'series') {
+          <app-media-info-extra [media]="m" [directors]="directors()" />
+        }
+
         @if (m.type === 'series' && m.seasons?.length) {
           <app-media-detail-seasons
             [media]="m"
@@ -266,10 +270,6 @@
             (toggleSeasonLike)="toggleSeasonLike($event)"
             (recommendSeason)="recommendSeason($event)"
           />
-        }
-
-        @if (m.type === 'series') {
-          <app-media-info-extra [media]="m" [directors]="directors()" />
         }
 
         @if (m.type === 'series' && cast().length) {

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -235,10 +235,6 @@
           />
         }
 
-        @if (m.type === 'series') {
-          <app-media-info-extra [media]="m" [directors]="directors()" />
-        }
-
         @if (m.type === 'series' && m.seasons?.length) {
           <app-media-detail-seasons
             [media]="m"
@@ -270,6 +266,10 @@
             (toggleSeasonLike)="toggleSeasonLike($event)"
             (recommendSeason)="recommendSeason($event)"
           />
+        }
+
+        @if (m.type === 'series') {
+          <app-media-info-extra [media]="m" [directors]="directors()" />
         }
 
         @if (m.type === 'series' && cast().length) {

--- a/client/src/app/shared/components/media-info-extra/media-info-extra.html
+++ b/client/src/app/shared/components/media-info-extra/media-info-extra.html
@@ -6,72 +6,86 @@
       <p class="italic text-base-content/70 text-lg">{{ tagline() }}</p>
     }
 
-    <dl class="grid grid-cols-2 gap-x-6 gap-y-3">
-      @if (originalTitle()) {
-        <div>
-          <dt class="text-base-content/50 text-sm">{{ 'discover.preview_original_title' | translate }}</dt>
-          <dd class="font-medium text-base">{{ originalTitle() }}</dd>
-        </div>
-      }
-      @if (media().status) {
-        <div>
-          <dt class="text-base-content/50 text-sm">{{ 'discover.preview_status' | translate }}</dt>
-          <dd class="font-medium text-base">{{ statusLabel() }}</dd>
-        </div>
-      }
-      @if (media().releaseDate) {
-        <div>
-          <dt class="text-base-content/50 text-sm">{{ 'discover.preview_release_date' | translate }}</dt>
-          <dd class="font-medium text-base">{{ media().releaseDate | localeDate:{ dateStyle: 'long' } }}</dd>
-        </div>
-      }
-      @if (originalLanguage() && originalLanguage() !== 'und') {
-        <div>
-          <dt class="text-base-content/50 text-sm">{{ 'discover.preview_original_language' | translate }}</dt>
-          <dd class="font-medium text-base">{{ originalLanguage() }}</dd>
-        </div>
-      }
-      @if (productionCountries()) {
-        <div>
-          <dt class="text-base-content/50 text-sm">{{ 'discover.preview_countries' | translate }}</dt>
-          <dd class="font-medium text-base">{{ productionCountries() }}</dd>
-        </div>
-      }
-      @if (productionCompanies()) {
-        <div>
-          <dt class="text-base-content/50 text-sm">{{ 'discover.preview_studios' | translate }}</dt>
-          <dd class="font-medium text-base">{{ productionCompanies() }}</dd>
-        </div>
-      }
-      @if (directorsLabel()) {
-        <div>
-          <dt class="text-base-content/50 text-sm">{{ 'media_info.directors' | translate }}</dt>
-          <dd class="font-medium text-base">{{ directorsLabel() }}</dd>
-        </div>
-      }
-      @if (genres().length) {
-        <div>
-          <dt class="text-base-content/50 text-sm">{{ 'media_info.genres' | translate }}</dt>
-          <dd class="font-medium text-base flex flex-wrap gap-x-1">
-            @for (genre of genres(); track genre; let last = $last) {
-              <span><button type="button" class="hover:underline rounded text-left" (click)="navigateToGenre(genre)">{{ genre }}</button>@if (!last){,}</span>
-            }
-          </dd>
-        </div>
-      }
-      @if (budget()) {
-        <div>
-          <dt class="text-base-content/50 text-sm">{{ 'discover.preview_budget' | translate }}</dt>
-          <dd class="font-medium text-base">{{ budget() | currency:'USD':'symbol':'1.0-0' }}</dd>
-        </div>
-      }
-      @if (revenue()) {
-        <div>
-          <dt class="text-base-content/50 text-sm">{{ 'discover.preview_revenue' | translate }}</dt>
-          <dd class="font-medium text-base">{{ revenue() | currency:'USD':'symbol':'1.0-0' }}</dd>
-        </div>
-      }
-    </dl>
+    <!-- Status and genres stay out of the fold: the status changes how the
+         episode list reads, and a genre is navigation, not a reference fact. -->
+    @if (media().status || genres().length) {
+      <div class="flex flex-wrap items-center gap-2">
+        @if (media().status) {
+          <span class="badge badge-outline">{{ statusLabel() }}</span>
+        }
+        @for (genre of genres(); track genre) {
+          <button
+            type="button"
+            class="badge badge-outline badge-primary hover:bg-primary/15"
+            (click)="navigateToGenre(genre)"
+          >{{ genre }}</button>
+        }
+      </div>
+    }
+
+    <details class="group">
+      <summary
+        class="flex items-center gap-2 cursor-pointer font-semibold list-none [&::-webkit-details-marker]:hidden"
+      >
+        {{ 'media_info.details' | translate }}
+        <svg
+          lucideChevronDown
+          class="h-4 w-4 opacity-60 transition-transform group-open:rotate-180"
+          aria-hidden="true"
+        ></svg>
+      </summary>
+
+      <dl class="grid grid-cols-2 gap-x-6 gap-y-3 mt-3">
+        @if (originalTitle()) {
+          <div>
+            <dt class="text-base-content/50 text-sm">{{ 'discover.preview_original_title' | translate }}</dt>
+            <dd class="font-medium text-base">{{ originalTitle() }}</dd>
+          </div>
+        }
+        @if (media().releaseDate) {
+          <div>
+            <dt class="text-base-content/50 text-sm">{{ 'discover.preview_release_date' | translate }}</dt>
+            <dd class="font-medium text-base">{{ media().releaseDate | localeDate:{ dateStyle: 'long' } }}</dd>
+          </div>
+        }
+        @if (originalLanguage() && originalLanguage() !== 'und') {
+          <div>
+            <dt class="text-base-content/50 text-sm">{{ 'discover.preview_original_language' | translate }}</dt>
+            <dd class="font-medium text-base">{{ originalLanguage() }}</dd>
+          </div>
+        }
+        @if (productionCountries()) {
+          <div>
+            <dt class="text-base-content/50 text-sm">{{ 'discover.preview_countries' | translate }}</dt>
+            <dd class="font-medium text-base">{{ productionCountries() }}</dd>
+          </div>
+        }
+        @if (productionCompanies()) {
+          <div>
+            <dt class="text-base-content/50 text-sm">{{ 'discover.preview_studios' | translate }}</dt>
+            <dd class="font-medium text-base">{{ productionCompanies() }}</dd>
+          </div>
+        }
+        @if (directorsLabel()) {
+          <div>
+            <dt class="text-base-content/50 text-sm">{{ 'media_info.directors' | translate }}</dt>
+            <dd class="font-medium text-base">{{ directorsLabel() }}</dd>
+          </div>
+        }
+        @if (budget()) {
+          <div>
+            <dt class="text-base-content/50 text-sm">{{ 'discover.preview_budget' | translate }}</dt>
+            <dd class="font-medium text-base">{{ budget() | currency:'USD':'symbol':'1.0-0' }}</dd>
+          </div>
+        }
+        @if (revenue()) {
+          <div>
+            <dt class="text-base-content/50 text-sm">{{ 'discover.preview_revenue' | translate }}</dt>
+            <dd class="font-medium text-base">{{ revenue() | currency:'USD':'symbol':'1.0-0' }}</dd>
+          </div>
+        }
+      </dl>
+    </details>
 
     @if (trailerKey()) {
       <button type="button" class="btn btn-outline gap-2 mt-2" (click)="openTrailer()">

--- a/client/src/app/shared/components/media-info-extra/media-info-extra.html
+++ b/client/src/app/shared/components/media-info-extra/media-info-extra.html
@@ -6,23 +6,6 @@
       <p class="italic text-base-content/70 text-lg">{{ tagline() }}</p>
     }
 
-    <!-- Status and genres stay out of the fold: the status changes how the
-         episode list reads, and a genre is navigation, not a reference fact. -->
-    @if (media().status || genres().length) {
-      <div class="flex flex-wrap items-center gap-2">
-        @if (media().status) {
-          <span class="badge badge-outline">{{ statusLabel() }}</span>
-        }
-        @for (genre of genres(); track genre) {
-          <button
-            type="button"
-            class="badge badge-outline badge-primary hover:bg-primary/15"
-            (click)="navigateToGenre(genre)"
-          >{{ genre }}</button>
-        }
-      </div>
-    }
-
     <details class="group">
       <summary
         class="flex items-center gap-2 cursor-pointer font-semibold list-none [&::-webkit-details-marker]:hidden"

--- a/client/src/app/shared/components/media-info-extra/media-info-extra.ts
+++ b/client/src/app/shared/components/media-info-extra/media-info-extra.ts
@@ -9,7 +9,6 @@ import {
   viewChild,
 } from '@angular/core';
 import { CurrencyPipe } from '@angular/common';
-import { Router } from '@angular/router';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { LucideChevronDown, LucidePlay } from '@lucide/angular';
@@ -32,7 +31,6 @@ import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
 })
 export class MediaInfoExtraComponent {
   private readonly translate = inject(TranslateService);
-  private readonly router = inject(Router);
   private readonly sanitizer = inject(DomSanitizer);
   private readonly trailerDialog =
     viewChild<ElementRef<HTMLDialogElement>>('trailerDialog');
@@ -85,14 +83,6 @@ export class MediaInfoExtraComponent {
 
   /** Translated status label (`media_detail.info_status_<value>`), or the
    *  raw enum value if no translation exists. */
-  readonly statusLabel = computed(() => {
-    const s = this.media().status;
-    if (!s) return '';
-    const key = `media_detail.info_status_${s}`;
-    const t = this.translate.instant(key);
-    return typeof t === 'string' && t !== key ? t : s;
-  });
-
   /** Original title as returned by the provider; shown whenever present. */
   readonly originalTitle = computed(() => this.media().originalTitle ?? '');
 
@@ -114,14 +104,6 @@ export class MediaInfoExtraComponent {
 
   readonly revenue = computed(() => this.media().metadata?.revenue ?? null);
 
-  readonly genres = computed(() => this.media().genres ?? []);
-
-  navigateToGenre(genre: string) {
-    const libraryName = this.media().library?.name;
-    if (!libraryName) return;
-    void this.router.navigate(['/libraries', libraryName], { queryParams: { genre } });
-  }
-
   /** True when at least one row has content — keeps the parent template
    *  from rendering an empty wrapper / divider. */
   readonly hasAnyContent = computed(() => {
@@ -129,7 +111,6 @@ export class MediaInfoExtraComponent {
     return !!(
       this.tmdbScore() != null ||
       this.originalTitle() ||
-      m.status ||
       m.releaseDate ||
       this.originalLanguage() !== 'und' ||
       this.productionCountries() ||
@@ -137,7 +118,6 @@ export class MediaInfoExtraComponent {
       this.tagline() ||
       this.budget() ||
       this.revenue() ||
-      this.genres().length > 0 ||
       this.directorsLabel() ||
       this.trailerKey()
     );

--- a/client/src/app/shared/components/media-info-extra/media-info-extra.ts
+++ b/client/src/app/shared/components/media-info-extra/media-info-extra.ts
@@ -12,7 +12,7 @@ import { CurrencyPipe } from '@angular/common';
 import { Router } from '@angular/router';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { LucidePlay } from '@lucide/angular';
+import { LucideChevronDown, LucidePlay } from '@lucide/angular';
 import { Media } from '../../../core/services/api/media.service';
 import { localizeLanguage } from '../../../core/utils/language.utils';
 import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
@@ -26,7 +26,7 @@ import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
  */
 @Component({
   selector: 'app-media-info-extra',
-  imports: [LocaleDatePipe, CurrencyPipe, TranslateModule, LucidePlay],
+  imports: [LocaleDatePipe, CurrencyPipe, TranslateModule, LucideChevronDown, LucidePlay],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-info-extra.html',
 })

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -31,6 +31,23 @@
       }
     </div>
 
+    <!-- Status and genres: the status frames how the episode list reads, and a
+         genre is navigation. Both stay out of the folded details panel. -->
+    @if (statusLabel() || genres().length) {
+      <div class="flex flex-wrap items-center gap-2 mt-2">
+        @if (statusLabel()) {
+          <span class="badge badge-outline">{{ statusLabel() }}</span>
+        }
+        @for (genre of genres(); track genre) {
+          <button
+            type="button"
+            class="badge badge-outline badge-primary hover:bg-primary/15"
+            (click)="navigateToGenre(genre)"
+          >{{ genre }}</button>
+        }
+      </div>
+    }
+
     <ng-container *ngTemplateOutlet="streamInfoBlock"></ng-container>
 
     <!-- Tags (library badge moved up; genres moved to media-info-extra). -->
@@ -242,6 +259,23 @@
           <span class="badge badge-primary badge-outline">{{ libraryName() }}</span>
         }
       </div>
+
+      <!-- Status and genres: the status frames how the episode list reads, and a
+           genre is navigation. Both stay out of the folded details panel. -->
+      @if (statusLabel() || genres().length) {
+        <div class="flex flex-wrap items-center gap-2 mt-2">
+          @if (statusLabel()) {
+            <span class="badge badge-outline">{{ statusLabel() }}</span>
+          }
+          @for (genre of genres(); track genre) {
+            <button
+              type="button"
+              class="badge badge-outline badge-primary hover:bg-primary/15"
+              (click)="navigateToGenre(genre)"
+            >{{ genre }}</button>
+          }
+        </div>
+      }
 
       <ng-container *ngTemplateOutlet="streamInfoBlock"></ng-container>
 

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -11,7 +11,7 @@ import {
   viewChildren,
 } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
-import { RouterLink } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { FormsModule } from '@angular/forms';
 import {
@@ -118,6 +118,7 @@ interface AudioTrack {
 })
 export class MediaInfoHeaderComponent {
   private readonly translate = inject(TranslateService);
+  private readonly router = inject(Router);
   private readonly playerSettings = inject(PlayerSettingsService);
   private readonly trackManager = inject(TrackManagerService);
   readonly navbar = inject(NavbarService);
@@ -142,6 +143,15 @@ export class MediaInfoHeaderComponent {
   readonly resumeEpisodeId = input<number | undefined>(undefined);
   readonly resumeMediaFileId = input<number | undefined>(undefined);
   readonly status = input<string | null>(null);
+
+  /** Translated release status, falling back to the raw provider value. */
+  readonly statusLabel = computed(() => {
+    const value = this.status();
+    if (!value) return '';
+    const key = `media_detail.info_status_${value}`;
+    const t = this.translate.instant(key);
+    return typeof t === 'string' && t !== key ? t : value;
+  });
   readonly monitored = input(true);
   readonly libraryName = input<string | null>(null);
   readonly qualityProfileName = input<string | null>(null);
@@ -531,5 +541,12 @@ export class MediaInfoHeaderComponent {
     return `${(bytes / 1_073_741_824).toFixed(2)} GB`;
   }
 
+
+
+  navigateToGenre(genre: string) {
+    const library = this.libraryName();
+    if (!library) return;
+    void this.router.navigate(['/libraries', library], { queryParams: { genre } });
+  }
 
 }


### PR DESCRIPTION
Correction 5, option D from the placement review.

## Why

On a series page the details block sat under the whole season and episode block, so the two facts that inform the episode list arrived after it:

- **Status** decides how the list reads. A series marked *Ended* with no season 4 is complete; one marked *Continuing* is waiting.
- **Genres** are clickable navigation, not a reference fact — nobody scrolls past the episodes to browse.

## What changed

**Status and genres move into the hero**, as chips under the metadata row, in both the mobile and desktop header layouts. They fill inputs `media-info-header` already declared and `media-detail` already bound, but which the template never rendered — dead since genres were moved out of the header at some point. `statusLabel` and `navigateToGenre` move here with them, so nothing is duplicated: the details panel loses both, plus the `Router` it only needed for genres.

Genres also leave the `<dl>`, where a row of buttons never had the right shape — a definition list whose single value is seven links is the wrong element.

**Everything else goes behind a native `<details>` / `<summary>`**: original title, release date, original language, countries, studios, directors, budget, revenue. No script, correct keyboard and screen-reader behaviour for free, and the movie page gets the same benefit. Tagline and trailer button stay outside the fold — one is flavour, the other is an action.

**The panel stays below the seasons.** It is reference material; it doesn't need to precede the episode list once the two facts that do have moved up.

## Why not the alternatives

- **Everything into the hero**: the metadata row would carry seven values of different kinds and lose the labels. "Atelier Nord" without its `dt` means nothing, and it didn't cover the movie case on the same shared component.
- **Fold only, in place**: keeps the reading order wrong. Status and genres would sit below the episodes *and* behind a click — the two facts you want first become the most expensive to reach.

## Checks

Client build clean, client suite 82 passing. `media-detail.html` is byte-identical to `main` — the placement change is entirely inside the two shared components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)