### PR TITLE
refactor(media-detail): drop the season progress bar and resume button

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -811,7 +811,6 @@
     "episode_count_one": "{{count}} Episode",
     "episode_count_other": "{{count}} Episoden",
     "season_watched_count": "{{count}} gesehen",
-    "season_resume": "E{{episode}} fortsetzen",
     "episode_view_grid": "Kartenansicht",
     "episode_view_list": "Listenansicht",
     "back": "Zurück zur Liste",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -816,7 +816,6 @@
     "episode_count_one": "{{count}} episode",
     "episode_count_other": "{{count}} episodes",
     "season_watched_count": "{{count}} watched",
-    "season_resume": "Resume E{{episode}}",
     "episode_view_grid": "Card view",
     "episode_view_list": "List view",
     "back": "Back to list",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -811,7 +811,6 @@
     "episode_count_one": "{{count}} episodio",
     "episode_count_other": "{{count}} episodios",
     "season_watched_count": "{{count}} vistos",
-    "season_resume": "Reanudar E{{episode}}",
     "episode_view_grid": "Vista de tarjetas",
     "episode_view_list": "Vista de lista",
     "back": "Volver a la lista",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -816,7 +816,6 @@
     "episode_count_one": "{{count}} épisode",
     "episode_count_other": "{{count}} épisodes",
     "season_watched_count": "{{count}} vus",
-    "season_resume": "Reprendre E{{episode}}",
     "episode_view_grid": "Vue cartes",
     "episode_view_list": "Vue liste",
     "back": "Retour à la liste",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -811,7 +811,6 @@
     "episode_count_one": "{{count}} episodio",
     "episode_count_other": "{{count}} episodi",
     "season_watched_count": "{{count}} visti",
-    "season_resume": "Riprendi E{{episode}}",
     "episode_view_grid": "Vista a schede",
     "episode_view_list": "Vista a elenco",
     "back": "Torna all'elenco",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -811,7 +811,6 @@
     "episode_count_one": "{{count}} episódio",
     "episode_count_other": "{{count}} episódios",
     "season_watched_count": "{{count}} vistos",
-    "season_resume": "Retomar E{{episode}}",
     "episode_view_grid": "Vista de cartões",
     "episode_view_list": "Vista de lista",
     "back": "Voltar à lista",

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -227,22 +227,6 @@
           }
         </div>
 
-        @if (seasonWatchedCount(selSeason) > 0) {
-          <div class="flex items-center gap-3">
-            <progress
-              class="progress progress-primary h-1 w-full max-w-xs"
-              [value]="seasonProgressPercent(selSeason)"
-              max="100"
-            ></progress>
-            @if (seasonResumeEpisode(selSeason); as next) {
-              <button type="button" class="btn btn-primary btn-xs shrink-0" (click)="playEpisode(next)">
-                <svg lucidePlay class="h-3 w-3 shrink-0" aria-hidden="true"></svg>
-                {{ 'media_detail.season_resume' | translate:{ episode: next.episodeNumber } }}
-              </button>
-            }
-          </div>
-        }
-
         @if (selSeason.overview) {
           <p class="text-sm text-base-content/80 line-clamp-4">{{ selSeason.overview }}</p>
         }

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -189,27 +189,6 @@ export class MediaDetailSeasonsComponent {
     return parts.join(' · ');
   }
 
-  seasonProgressPercent(season: Season): number {
-    const total = this.tabEpisodeCount(season);
-    if (!total) return 0;
-    return Math.min(100, Math.round((this.seasonWatchedCount(season) / total) * 100));
-  }
-
-  /**
-   * Next episode to play in this season. Only offered once the season has been
-   * started: on an untouched season the header's own resume button already
-   * covers it, and the first card is one click away either way.
-   */
-  seasonResumeEpisode(season: Season | null): Episode | null {
-    if (!season || this.seasonWatchedCount(season) === 0) return null;
-    const watched = this.watchedEpisodeIds();
-    return (
-      (season.episodes ?? [])
-        .filter((ep) => ep.hasFile && !watched.has(ep.id))
-        .sort((a, b) => a.episodeNumber - b.episodeNumber)[0] ?? null
-    );
-  }
-
   /** True when at least one episode of the season isn't on disk — the
    *  prerequisite for surfacing a Demander entry. Uses coverage so a season
    *  fully covered by multi-episode files isn't flagged as missing. */


### PR DESCRIPTION
Reverts correction 4 from #825, on the strength of seeing it on the real page.

Neither element earns its space:

- The **progress bar** restates the watched count that already sits in the meta line one row above it.
- The **season resume button** sat between the page header's own resume and the episode covers, which are directly playable since #826. It did nothing either of those couldn't.

`seasonWatchedCount` stays — the meta line still reads `5 août 2026 · 10 épisodes · 3 vus`. `seasonProgressPercent` and `seasonResumeEpisode` are gone, along with the `season_resume` key in all six locales. `LucidePlay` stays imported: the list view's cover overlay still uses it.

Net −43 lines, no additions.

## Checks

Client build clean, client suite 82 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)