### PR TITLE
fix(player): back out of an episode to the page it was opened from

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -3246,12 +3246,21 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       const kind = (this.media?.type ?? offlineType) === 'series' ? 'series' : 'movies';
       if (this.episodeId && kind === 'series') {
         // A finished episode returns to the NEXT episode's detail page so the
-        // user lands ready to continue; an episode left mid-watch returns to
-        // its own page (to resume).
+        // user lands ready to continue. Otherwise the origin wins: opening an
+        // episode straight from the series page and backing out should land
+        // back there, not on a page the user never visited. Only a player
+        // opened from somewhere else (the episode's own page, a deep link, a
+        // continue-watching row) falls back to the episode page.
         const next = this.nextEpisodeContext();
-        const epId =
-          this.episodeFinished() && next ? next.episodeId : this.episodeId;
-        target = `/series/${this.mediaId}/episode/${epId}`;
+        const seriesPath = `/series/${this.mediaId}`;
+        const cameFromSeries =
+          this.navHistory.previousUrl?.split('?')[0] === seriesPath;
+        target =
+          this.episodeFinished() && next
+            ? `${seriesPath}/episode/${next.episodeId}`
+            : cameFromSeries
+              ? seriesPath
+              : `${seriesPath}/episode/${this.episodeId}`;
       } else {
         target = `/${kind}/${this.mediaId}`;
       }


### PR DESCRIPTION
## Why

Closing the player always routed to the episode's own detail page, regardless of which page had opened it (`player.ts`, the close handler). Starting an episode from the series page and backing out therefore landed on a page the user had never visited, with the series page sitting one step further back.

It wasn't accidental — the existing comment reads *"an episode left mid-watch returns to its own page (to resume)"*. That's a reasonable destination when the player was opened from the episode page. It just ignored where the user actually came from.

## What changed

The origin wins when there is one. A previous URL of `/series/:id` becomes the target, which lets the handler's existing branch take over:

```ts
if (prev && prev.split('?')[0] === target) { history.back(); return; }
```

So the exit becomes a real `history.back()` popping `/watch`, instead of a `replaceUrl` onto a third page. Two things fall out of that: the browser stack stays honest, and the series page keeps its scroll offset — it's restored by the back navigation rather than rebuilt from scratch.

Unchanged:

- **A finished episode** still routes forward to the next episode's page. That isn't a return, it's the hand-off to the next watch.
- **A player opened from the episode page**, a deep link, or a continue-watching row still lands on the episode page — there's no better origin to go back to.
- Playlist playback still returns to the playlist.

## Checks

Client build clean, client suite 82 passing. Worth a click-through on a device: series → episode → back, and episode page → play → back, which must still land on the episode page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)