### PR TITLE
feat(tmdb-preview): add show-more toggle on the mobile synopsis

### DIFF
--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -286,18 +286,18 @@
               <div class="col-span-2 sm:col-span-1 sm:col-start-2">
                 @if (ep.overview) {
                   <p
-                    #epOverview
-                    [attr.data-ep-id]="ep.id"
+                    [appClampToggle]="ep.overview"
+                    #syn="clampToggle"
                     class="text-sm sm:text-base text-base-content/70"
-                    [class.line-clamp-3]="!expandedOverviews().has(ep.id)"
+                    [class.line-clamp-3]="!syn.expanded()"
                   >{{ ep.overview }}</p>
-                  @if (clampedOverviews().has(ep.id) || expandedOverviews().has(ep.id)) {
+                  @if (syn.showToggle()) {
                     <button
                       type="button"
                       class="link link-primary no-underline hover:underline text-sm mt-0.5 cursor-pointer"
-                      (click)="toggleEpisodeOverview(ep.id)"
+                      (click)="syn.toggle()"
                     >
-                      {{ (expandedOverviews().has(ep.id) ? 'common.show_less' : 'common.show_more') | translate }}
+                      {{ (syn.expanded() ? 'common.show_less' : 'common.show_more') | translate }}
                     </button>
                   }
                 } @else {

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -1,14 +1,11 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  ElementRef,
   computed,
-  effect,
   inject,
   input,
   output,
   signal,
-  viewChildren,
 } from '@angular/core';
 import { UpperCasePipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
@@ -34,6 +31,7 @@ import { MediaCardComponent } from '../../../../shared/components/media-card/med
 import { DropdownMenuComponent } from '../../../../shared/components/dropdown-menu';
 import { DropdownOptionComponent } from '../../../../shared/components/dropdown-option/dropdown-option';
 import { TvRowDirective } from '../../../../shared/directives/tv-row.directive';
+import { ClampToggleDirective } from '../../../../shared/directives/clamp-toggle.directive';
 import {
   Episode,
   Media,
@@ -69,7 +67,7 @@ function readEpisodeViewFromStorage(): EpisodeView {
 
 @Component({
   selector: 'app-media-detail-seasons',
-  imports: [TranslateModule, UpperCasePipe, RouterLink, LocaleDatePipe, HorizontalScrollerComponent, MediaCardComponent, DropdownMenuComponent, DropdownOptionComponent, TvRowDirective, LucideCheck, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideHeart, LucideLayoutGrid, LucideList, LucideListChecks, LucideListPlus, LucidePackage, LucideUserPlus, LucideX],
+  imports: [TranslateModule, UpperCasePipe, RouterLink, LocaleDatePipe, HorizontalScrollerComponent, MediaCardComponent, DropdownMenuComponent, DropdownOptionComponent, TvRowDirective, ClampToggleDirective, LucideCheck, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideHeart, LucideLayoutGrid, LucideList, LucideListChecks, LucideListPlus, LucidePackage, LucideUserPlus, LucideX],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-seasons.component.html',
 })
@@ -149,42 +147,6 @@ export class MediaDetailSeasonsComponent {
   /** TVDB reports a bare year, which date formatting would widen into a day. */
   seasonAirDateIsYearOnly(season: Season): boolean {
     return /^\d{4}$/.test(season.airDate ?? '');
-  }
-
-  // ── Episode synopsis clamp ──
-
-  private readonly overviewRefs =
-    viewChildren<ElementRef<HTMLParagraphElement>>('epOverview');
-  readonly expandedOverviews = signal<ReadonlySet<number>>(new Set());
-  /** Episodes whose synopsis actually overflows three lines. */
-  readonly clampedOverviews = signal<ReadonlySet<number>>(new Set());
-
-  /**
-   * CSS can't report that a clamp took effect, so measure it. Reads the episode
-   * list but not the expanded set: an expanded paragraph stops overflowing, and
-   * re-measuring on toggle would drop the button that collapses it again.
-   */
-  private readonly clampEffect = effect(() => {
-    this.filteredEpisodes();
-    this.showEpisodeList();
-    requestAnimationFrame(() => {
-      const clamped = new Set<number>();
-      for (const ref of this.overviewRefs()) {
-        const el = ref.nativeElement;
-        const id = Number(el.dataset['epId']);
-        if (!Number.isFinite(id)) continue;
-        if (el.scrollHeight > el.clientHeight + 1) clamped.add(id);
-      }
-      this.clampedOverviews.set(clamped);
-    });
-  });
-
-  toggleEpisodeOverview(id: number) {
-    this.expandedOverviews.update((set) => {
-      const next = new Set(set);
-      if (!next.delete(id)) next.add(id);
-      return next;
-    });
   }
 
   seasonWatchedCount(season: Season): number {

--- a/client/src/app/features/person-detail/person-detail.html
+++ b/client/src/app/features/person-detail/person-detail.html
@@ -40,11 +40,11 @@
           </p>
         }
         @if (d.person.biography) {
-          <p #bioText class="text-sm leading-relaxed" [class.line-clamp-4]="!bioExpanded()">{{ d.person.biography }}</p>
-          @if (bioClamped() || bioExpanded()) {
+          <p [appClampToggle]="d.person.biography" #bio="clampToggle" class="text-sm leading-relaxed" [class.line-clamp-4]="!bio.expanded()">{{ d.person.biography }}</p>
+          @if (bio.showToggle()) {
             <div class="flex justify-end">
-              <button class="btn btn-xs btn-ghost mt-1" (click)="toggleBio()">
-                {{ bioExpanded() ? ('common.show_less' | translate) : ('common.show_more' | translate) }}
+              <button class="btn btn-xs btn-ghost mt-1" (click)="bio.toggle()">
+                {{ bio.expanded() ? ('common.show_less' | translate) : ('common.show_more' | translate) }}
               </button>
             </div>
           }

--- a/client/src/app/features/person-detail/person-detail.ts
+++ b/client/src/app/features/person-detail/person-detail.ts
@@ -4,9 +4,6 @@ import {
   signal,
   inject,
   OnInit,
-  ViewChild,
-  ElementRef,
-  AfterViewInit,
 } from '@angular/core';
 import { ActivatedRoute, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
@@ -17,45 +14,25 @@ import {
 import { NavbarService } from '../../core/services/navbar.service';
 import { LucideChevronLeft } from '@lucide/angular';
 import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
+import { ClampToggleDirective } from '../../shared/directives/clamp-toggle.directive';
 
 @Component({
   selector: 'app-person-detail',
-  imports: [TranslateModule, RouterLink, RouterLinkActive, RouterOutlet, ResolveUrlPipe, LucideChevronLeft],
+  imports: [TranslateModule, RouterLink, RouterLinkActive, RouterOutlet, ResolveUrlPipe, ClampToggleDirective, LucideChevronLeft],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './person-detail.html',
 })
-export class PersonDetailComponent implements OnInit, AfterViewInit {
+export class PersonDetailComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
   private readonly personsApi = inject(PersonsApiService);
   private readonly navbar = inject(NavbarService);
 
-  @ViewChild('bioText') bioTextRef?: ElementRef<HTMLParagraphElement>;
-
   readonly detail = signal<PersonDetail | null>(null);
   readonly loading = signal(true);
-  readonly bioClamped = signal(false);
-  readonly bioExpanded = signal(false);
 
   ngOnInit() {
     const id = Number(this.route.snapshot.paramMap.get('id'));
     this.load(id);
-  }
-
-  ngAfterViewInit() {
-    this.checkBioClamped();
-  }
-
-  private checkBioClamped() {
-    requestAnimationFrame(() => {
-      const el = this.bioTextRef?.nativeElement;
-      if (el) {
-        this.bioClamped.set(el.scrollHeight > el.clientHeight);
-      }
-    });
-  }
-
-  toggleBio() {
-    this.bioExpanded.update((v) => !v);
   }
 
   goBack() {
@@ -69,7 +46,6 @@ export class PersonDetailComponent implements OnInit, AfterViewInit {
       this.detail.set(detail);
     } finally {
       this.loading.set(false);
-      this.checkBioClamped();
     }
   }
 }

--- a/client/src/app/features/tmdb-preview/tmdb-preview.html
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.html
@@ -69,7 +69,14 @@
       }
 
       @if (m.overview) {
-        <p class="mt-3 text-sm text-base-content/80 leading-relaxed line-clamp-4">{{ m.overview }}</p>
+        <p [appClampToggle]="m.overview" #syn="clampToggle"
+           class="mt-3 text-sm text-base-content/80 leading-relaxed"
+           [class.line-clamp-4]="!syn.expanded()">{{ m.overview }}</p>
+        @if (syn.showToggle()) {
+          <button type="button" class="link link-primary no-underline hover:underline text-sm mt-1" (click)="syn.toggle()">
+            {{ (syn.expanded() ? 'common.show_less' : 'common.show_more') | translate }}
+          </button>
+        }
       }
 
       <!-- Metadata grid -->

--- a/client/src/app/features/tmdb-preview/tmdb-preview.ts
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.ts
@@ -34,10 +34,11 @@ import { MobileFanartHeroComponent } from '../../shared/components/mobile-fanart
 import { HorizontalScrollerComponent } from '../../shared/components/horizontal-scroller';
 import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
 import { LocaleDatePipe } from '../../core/pipes/locale-date.pipe';
+import { ClampToggleDirective } from '../../shared/directives/clamp-toggle.directive';
 
 @Component({
   selector: 'app-tmdb-preview',
-  imports: [FormsModule, CurrencyPipe, DecimalPipe, TranslateModule, ResolveUrlPipe, LocaleDatePipe, RequestModalComponent, ImportModalComponent, MobileFanartHeroComponent, HorizontalScrollerComponent, LucideFilm, LucideUser, LucidePlay, LucidePlus],
+  imports: [FormsModule, CurrencyPipe, DecimalPipe, TranslateModule, ResolveUrlPipe, LocaleDatePipe, RequestModalComponent, ImportModalComponent, MobileFanartHeroComponent, HorizontalScrollerComponent, ClampToggleDirective, LucideFilm, LucideUser, LucidePlay, LucidePlus],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './tmdb-preview.html',
 })

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -169,12 +169,12 @@
 
     <!-- Overview -->
     @if (overview()) {
-      <p #overviewText
+      <p [appClampToggle]="overview()" #syn="clampToggle"
          class="mt-4 text-base-content/80 leading-relaxed"
-         [class.line-clamp-4]="!overviewExpanded()">{{ overview() }}</p>
-      @if (overviewClamped() || overviewExpanded()) {
-        <button type="button" class="link link-primary no-underline hover:underline text-sm mt-1" (click)="toggleOverview()">
-          {{ (overviewExpanded() ? 'common.show_less' : 'common.show_more') | translate }}
+         [class.line-clamp-4]="!syn.expanded()">{{ overview() }}</p>
+      @if (syn.showToggle()) {
+        <button type="button" class="link link-primary no-underline hover:underline text-sm mt-1" (click)="syn.toggle()">
+          {{ (syn.expanded() ? 'common.show_less' : 'common.show_more') | translate }}
         </button>
       }
     }
@@ -387,12 +387,12 @@
 
       <!-- Overview -->
       @if (overview()) {
-        <p #overviewText
+        <p [appClampToggle]="overview()" #synDesktop="clampToggle"
            class="mt-4 text-base-content/90 leading-relaxed whitespace-pre-line"
-           [class.line-clamp-4]="!overviewExpanded()">{{ overview() }}</p>
-        @if (overviewClamped() || overviewExpanded()) {
-          <button type="button" class="link link-primary no-underline hover:underline text-sm mt-1" (click)="toggleOverview()">
-            {{ (overviewExpanded() ? 'common.show_less' : 'common.show_more') | translate }}
+           [class.line-clamp-4]="!synDesktop.expanded()">{{ overview() }}</p>
+        @if (synDesktop.showToggle()) {
+          <button type="button" class="link link-primary no-underline hover:underline text-sm mt-1" (click)="synDesktop.toggle()">
+            {{ (synDesktop.expanded() ? 'common.show_less' : 'common.show_more') | translate }}
           </button>
         }
       }

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -1,14 +1,12 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  ElementRef,
   computed,
   effect,
   inject,
   input,
   output,
   signal,
-  viewChildren,
 } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { Router, RouterLink } from '@angular/router';
@@ -54,6 +52,7 @@ import { DropdownMenuComponent } from '../dropdown-menu';
 import { DropdownOptionComponent } from '../dropdown-option/dropdown-option';
 import { ProgressBadgeComponent } from '../progress-badge/progress-badge.component';
 import { ImgFadeInDirective } from '../../directives/img-fade-in.directive';
+import { ClampToggleDirective } from '../../directives/clamp-toggle.directive';
 import { TvRowDirective } from '../../directives/tv-row.directive';
 import { TvSelectDirective } from '../../directives/tv-select.directive';
 import { NgTemplateOutlet } from '@angular/common';
@@ -104,6 +103,7 @@ interface AudioTrack {
     DropdownMenuComponent, DropdownOptionComponent,
     ProgressBadgeComponent,
     ImgFadeInDirective,
+    ClampToggleDirective,
     TvRowDirective,
     TvSelectDirective,
     NgTemplateOutlet,
@@ -276,31 +276,6 @@ export class MediaInfoHeaderComponent {
   readonly selectedSubtitle = computed(
     () => this.subtitles().find((s) => s.id === this.selectedSubtitleId()) ?? null,
   );
-
-  // Overview clamp / expand. The mobile and desktop layouts each render an
-  // `#overviewText` paragraph (both live in the DOM; CSS hides one), so we
-  // measure whichever is actually on screen.
-  private readonly overviewTextRefs = viewChildren<ElementRef<HTMLParagraphElement>>('overviewText');
-  readonly overviewClamped = signal(false);
-  readonly overviewExpanded = signal(false);
-
-  private readonly overviewClampEffect = effect(() => {
-    // Re-measure whenever the overview text changes.
-    this.overview();
-    this.overviewExpanded.set(false);
-    requestAnimationFrame(() => {
-      const refs = this.overviewTextRefs();
-      const el =
-        refs.map((r) => r.nativeElement).find((n) => n.offsetParent !== null) ??
-        refs[0]?.nativeElement;
-      if (el) this.overviewClamped.set(el.scrollHeight > el.clientHeight + 1);
-      else this.overviewClamped.set(false);
-    });
-  });
-
-  toggleOverview() {
-    this.overviewExpanded.update(v => !v);
-  }
 
   // ── Load playback state + watched when media/episode changes ──
 

--- a/client/src/app/shared/directives/clamp-toggle.directive.ts
+++ b/client/src/app/shared/directives/clamp-toggle.directive.ts
@@ -1,0 +1,54 @@
+import { Directive, ElementRef, OnDestroy, computed, effect, inject, input, signal } from '@angular/core';
+
+/**
+ * Drives a show-more / show-less toggle for a `line-clamp-*` paragraph. CSS
+ * can't report that a clamp took effect, so the overflow is measured — and
+ * re-measured on every resize, since a paragraph hidden by a responsive
+ * `md:hidden` wrapper measures as zero-height until its layout is visible.
+ *
+ * Usage:
+ *   <p appClampToggle #syn="clampToggle" [class.line-clamp-4]="!syn.expanded()">{{ text }}</p>
+ *   @if (syn.showToggle()) { <button (click)="syn.toggle()">…</button> }
+ *
+ * Bind the text (`[appClampToggle]="text"`) when it can change in place, so
+ * the paragraph collapses and re-measures instead of keeping a stale verdict.
+ */
+@Directive({
+  selector: '[appClampToggle]',
+  standalone: true,
+  exportAs: 'clampToggle',
+})
+export class ClampToggleDirective implements OnDestroy {
+  readonly text = input<unknown>(undefined, { alias: 'appClampToggle' });
+
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly observer = new ResizeObserver(() => this.measure());
+
+  readonly clamped = signal(false);
+  readonly expanded = signal(false);
+  /** Expanded text no longer overflows, but it still needs its collapse button. */
+  readonly showToggle = computed(() => this.clamped() || this.expanded());
+
+  constructor() {
+    this.observer.observe(this.host.nativeElement);
+    effect((onCleanup) => {
+      this.text();
+      this.expanded.set(false);
+      const frame = requestAnimationFrame(() => this.measure());
+      onCleanup(() => cancelAnimationFrame(frame));
+    });
+  }
+
+  toggle() {
+    this.expanded.update((v) => !v);
+  }
+
+  ngOnDestroy() {
+    this.observer.disconnect();
+  }
+
+  private measure() {
+    const el = this.host.nativeElement;
+    this.clamped.set(el.scrollHeight > el.clientHeight + 1);
+  }
+}


### PR DESCRIPTION
## What

The add-media preview (`/add/movie/:provider/:id`) clamped its mobile synopsis to four lines with no way to read the rest. It now gets a **Voir plus / Voir moins** toggle, shown only when the text actually overflows.

## How

The clamp verdict moves into a shared `appClampToggle` directive (`client/src/app/shared/directives/clamp-toggle.directive.ts`), replacing four hand-rolled copies:

- `media-info-header` (mobile + desktop layouts)
- `person-detail` (biography)
- `media-detail-seasons` (per-episode synopsis — the two `Set`s of expanded/clamped ids are gone)
- `tmdb-preview` (new)

```html
<p [appClampToggle]="text" #syn="clampToggle" [class.line-clamp-4]="!syn.expanded()">{{ text }}</p>
@if (syn.showToggle()) { <button (click)="syn.toggle()">…</button> }
```

The `line-clamp-N` class stays at the call site: the values differ (3 vs 4) and Tailwind needs the literal to emit the rule.

## Why a ResizeObserver

Every previous copy measured once, in a `requestAnimationFrame` after load. The first attempt on this page reproduced the bug it was meant to fix: the mobile paragraph sits under a `md:hidden` wrapper, so when the page loads at desktop width it measures `scrollHeight === 0`, records "not clamped", and narrowing the window afterwards never re-measures — clamped text, no button. Observing the element instead re-measures on every size change, including `display:none` → visible, orientation changes, and the expand/collapse round trip.

Net: -116 / +37 in the call sites for a 50-line directive.

## Test

`ng build` clean. Verified on `/add/movie/tmdb/1280738` at mobile width.