### PR TITLE
feat(media-detail): make the cast, file info and season sections collapsible

### DIFF
--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -311,8 +311,8 @@
       <!-- Same top rule and inset as the list, so toggling views doesn't shift
            the block; the padding stands in for a list row's own. Only where the
            toggle exists: the "more from season" row has nothing to switch to. -->
-      <div [class]="canSwitchEpisodeView() ? 'border-t border-base-content/10 py-3' : ''">
-      <app-horizontal-scroller [title]="sectionTitle() ?? ''">
+      <ng-template #episodeRow>
+        <app-horizontal-scroller>
         @for (ep of filteredEpisodes(); track ep.id) {
           <app-media-card [aspect]="'landscape'"
             [id]="'episode-' + ep.id"
@@ -333,7 +333,17 @@
             (watchedToggled)="toggleEpisodeWatched.emit({ episode: ep, watched: $event })"
           />
         }
-      </app-horizontal-scroller>
+        </app-horizontal-scroller>
+      </ng-template>
+
+      <div [class]="canSwitchEpisodeView() ? 'border-t border-base-content/10 py-3' : ''">
+        @if (sectionTitle(); as heading) {
+          <app-collapsible-section [heading]="heading" persistKey="moreFromSeason">
+            <ng-container *ngTemplateOutlet="episodeRow" />
+          </app-collapsible-section>
+        } @else {
+          <ng-container *ngTemplateOutlet="episodeRow" />
+        }
       </div>
     }
 

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -7,7 +7,7 @@ import {
   output,
   signal,
 } from '@angular/core';
-import { UpperCasePipe } from '@angular/common';
+import { NgTemplateOutlet, UpperCasePipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
@@ -32,6 +32,7 @@ import { DropdownMenuComponent } from '../../../../shared/components/dropdown-me
 import { DropdownOptionComponent } from '../../../../shared/components/dropdown-option/dropdown-option';
 import { TvRowDirective } from '../../../../shared/directives/tv-row.directive';
 import { ClampToggleDirective } from '../../../../shared/directives/clamp-toggle.directive';
+import { CollapsibleSectionComponent } from '../../../../shared/components/collapsible-section/collapsible-section';
 import {
   Episode,
   Media,
@@ -67,7 +68,7 @@ function readEpisodeViewFromStorage(): EpisodeView {
 
 @Component({
   selector: 'app-media-detail-seasons',
-  imports: [TranslateModule, UpperCasePipe, RouterLink, LocaleDatePipe, HorizontalScrollerComponent, MediaCardComponent, DropdownMenuComponent, DropdownOptionComponent, TvRowDirective, ClampToggleDirective, LucideCheck, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideHeart, LucideLayoutGrid, LucideList, LucideListChecks, LucideListPlus, LucidePackage, LucideUserPlus, LucideX],
+  imports: [TranslateModule, UpperCasePipe, NgTemplateOutlet, RouterLink, LocaleDatePipe, HorizontalScrollerComponent, CollapsibleSectionComponent, MediaCardComponent, DropdownMenuComponent, DropdownOptionComponent, TvRowDirective, ClampToggleDirective, LucideCheck, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideHeart, LucideLayoutGrid, LucideList, LucideListChecks, LucideListPlus, LucidePackage, LucideUserPlus, LucideX],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-seasons.component.html',
 })

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -96,7 +96,11 @@
 
         @if (otherSeasons().length) {
           <div class="divider my-6"></div>
-          <app-horizontal-scroller [title]="'media_detail.other_seasons_of' | translate:{ title: m.title }">
+          <app-collapsible-section
+            [heading]="'media_detail.other_seasons_of' | translate:{ title: m.title }"
+            persistKey="otherSeasons"
+          >
+          <app-horizontal-scroller>
             @for (other of otherSeasons(); track other.id) {
               <app-media-card
                 class="shrink-0 w-28 sm:w-32 lg:w-40"
@@ -112,6 +116,7 @@
               />
             }
           </app-horizontal-scroller>
+          </app-collapsible-section>
         }
 
         @if (cast().length) {
@@ -357,7 +362,8 @@
 <ng-template #castCrewBlock>
   @if (cast().length) {
     <div class="cv-auto" style="contain-intrinsic-size: auto 12rem">
-    <app-horizontal-scroller [title]="'media_detail.cast' | translate">
+    <app-collapsible-section [heading]="'media_detail.cast' | translate" persistKey="cast">
+    <app-horizontal-scroller>
       @for (c of cast(); track c.id) {
         <a [routerLink]="['/persons', c.person.id]" data-no-focus-ring class="shrink-0 w-20 sm:w-24 flex flex-col items-center gap-1.5 group">
           <div class="avatar">
@@ -378,6 +384,7 @@
         </a>
       }
     </app-horizontal-scroller>
+    </app-collapsible-section>
     </div>
   }
 </ng-template>

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -55,6 +55,7 @@ import { AddToPlaylistService } from '../../core/services/add-to-playlist.servic
 import { RecommendService } from '../../core/services/recommend.service';
 import { LikesApiService, LikeState } from '../../core/services/api/likes-api.service';
 import { HorizontalScrollerComponent } from '../../shared/components/horizontal-scroller';
+import { CollapsibleSectionComponent } from '../../shared/components/collapsible-section/collapsible-section';
 import { MediaCardComponent } from '../../shared/components/media-card/media-card';
 import { DownloadQualityModalComponent } from '../../shared/components/download-quality-modal/download-quality-modal';
 import { DownloadManagerService } from '../../core/services/download-manager.service';
@@ -105,6 +106,7 @@ function readEpisodesHasFileOnlyFromStorage(): boolean {
     MediaDetailLibraryModalComponent,
     RequestModalComponent,
     HorizontalScrollerComponent,
+    CollapsibleSectionComponent,
     MediaCardComponent,
     DownloadQualityModalComponent,
     DownloadDetailModalComponent,

--- a/client/src/app/shared/components/collapsible-section/collapsible-section.html
+++ b/client/src/app/shared/components/collapsible-section/collapsible-section.html
@@ -1,0 +1,29 @@
+<button
+  type="button"
+  class="flex items-center gap-2 cursor-pointer text-lg font-bold"
+  [attr.aria-expanded]="open()"
+  (click)="toggle()"
+>
+  {{ heading() }}
+  <svg
+    lucideChevronDown
+    class="h-4 w-4 opacity-60 transition-transform duration-200"
+    [class.rotate-180]="open()"
+    aria-hidden="true"
+  ></svg>
+</button>
+
+<!-- 0fr → 1fr is the one grid-row trick that animates to the content's own
+     height; browsers that can't interpolate it just snap open. -->
+<div
+  class="grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none"
+  [style.grid-template-rows]="open() ? '1fr' : '0fr'"
+>
+  <!-- Collapsed content still occupies the DOM, so keep it out of tab and
+       spatial-navigation reach. -->
+  <div class="overflow-hidden" [attr.inert]="open() ? null : ''">
+    <div class="mt-3">
+      <ng-content />
+    </div>
+  </div>
+</div>

--- a/client/src/app/shared/components/collapsible-section/collapsible-section.spec.ts
+++ b/client/src/app/shared/components/collapsible-section/collapsible-section.spec.ts
@@ -1,0 +1,24 @@
+import { readSectionOpen, writeSectionOpen } from './collapsible-section';
+
+describe('collapsible section persistence', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('falls back to the default until something is stored', () => {
+    expect(readSectionOpen('cast', true)).toBe(true);
+    expect(readSectionOpen('cast', false)).toBe(false);
+  });
+
+  it('reads back both states, default be damned', () => {
+    writeSectionOpen('cast', false);
+    expect(readSectionOpen('cast', true)).toBe(false);
+    writeSectionOpen('cast', true);
+    expect(readSectionOpen('cast', false)).toBe(true);
+  });
+
+  it('keeps sections independent and skips storage without a key', () => {
+    writeSectionOpen('cast', false);
+    expect(readSectionOpen('fileInfo', true)).toBe(true);
+    writeSectionOpen('', false);
+    expect(readSectionOpen('', true)).toBe(true);
+  });
+});

--- a/client/src/app/shared/components/collapsible-section/collapsible-section.ts
+++ b/client/src/app/shared/components/collapsible-section/collapsible-section.ts
@@ -1,0 +1,55 @@
+import { ChangeDetectionStrategy, Component, OnInit, input, signal } from '@angular/core';
+import { LucideChevronDown } from '@lucide/angular';
+
+const LS_PREFIX = 'fliks.section.';
+
+export function readSectionOpen(key: string, fallback: boolean): boolean {
+  if (!key || typeof localStorage === 'undefined') return fallback;
+  try {
+    const stored = localStorage.getItem(LS_PREFIX + key);
+    return stored === null ? fallback : stored === '1';
+  } catch {
+    return fallback;
+  }
+}
+
+export function writeSectionOpen(key: string, open: boolean): void {
+  if (!key || typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(LS_PREFIX + key, open ? '1' : '0');
+  } catch {
+    // Private browsing / quota: the fold still works, it just won't stick.
+  }
+}
+
+/**
+ * Section with a fold/unfold header that animates to the content's height.
+ * Pass a `persistKey` to remember the open state across pages and reloads.
+ *
+ * Usage: <app-collapsible-section [heading]="'file_info.title' | translate" persistKey="fileInfo">
+ */
+@Component({
+  selector: 'app-collapsible-section',
+  imports: [LucideChevronDown],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './collapsible-section.html',
+  host: { class: 'block' },
+})
+export class CollapsibleSectionComponent implements OnInit {
+  readonly heading = input.required<string>();
+  /** localStorage suffix. Empty means the section reopens at its default. */
+  readonly persistKey = input('');
+  readonly defaultOpen = input(true);
+
+  protected readonly open = signal(false);
+
+  ngOnInit() {
+    this.open.set(readSectionOpen(this.persistKey(), this.defaultOpen()));
+  }
+
+  protected toggle() {
+    const open = !this.open();
+    this.open.set(open);
+    writeSectionOpen(this.persistKey(), open);
+  }
+}

--- a/client/src/app/shared/components/media-file-info.html
+++ b/client/src/app/shared/components/media-file-info.html
@@ -1,6 +1,6 @@
 @if (file(); as f) {
+  <app-collapsible-section [heading]="'file_info.title' | translate" persistKey="fileInfo">
   <div class="space-y-4">
-    <h2 class="text-lg font-bold">{{ 'file_info.title' | translate }}</h2>
 
     <!-- File info from DB (always available) -->
     <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-x-6 gap-y-1 text-sm">
@@ -110,4 +110,5 @@
       </div>
     }
   </div>
+  </app-collapsible-section>
 }

--- a/client/src/app/shared/components/media-file-info.ts
+++ b/client/src/app/shared/components/media-file-info.ts
@@ -14,6 +14,7 @@ import {
   AudioStreamInfo,
 } from '../../core/services/api/media.service';
 import { ConfirmationService } from '../../core/services/confirmation.service';
+import { CollapsibleSectionComponent } from './collapsible-section/collapsible-section';
 
 type FileInput = {
   relativePath: string;
@@ -24,7 +25,7 @@ type FileInput = {
 
 @Component({
   selector: 'app-media-file-info',
-  imports: [TranslateModule, LucideVideo, LucideVolume2, LucideTrash2],
+  imports: [TranslateModule, CollapsibleSectionComponent, LucideVideo, LucideVolume2, LucideTrash2],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-file-info.html',
 })

--- a/client/src/app/shared/components/media-info-extra/media-info-extra.html
+++ b/client/src/app/shared/components/media-info-extra/media-info-extra.html
@@ -6,19 +6,12 @@
       <p class="italic text-base-content/70 text-lg">{{ tagline() }}</p>
     }
 
-    <details class="group">
-      <summary
-        class="flex items-center gap-2 cursor-pointer text-lg font-bold list-none [&::-webkit-details-marker]:hidden"
-      >
-        {{ 'media_info.details' | translate }}
-        <svg
-          lucideChevronDown
-          class="h-4 w-4 opacity-60 transition-transform group-open:rotate-180"
-          aria-hidden="true"
-        ></svg>
-      </summary>
-
-      <dl class="grid grid-cols-2 gap-x-6 gap-y-3 mt-3">
+    <app-collapsible-section
+      [heading]="'media_info.details' | translate"
+      persistKey="details"
+      [defaultOpen]="false"
+    >
+      <dl class="grid grid-cols-2 gap-x-6 gap-y-3">
         @if (originalTitle()) {
           <div>
             <dt class="text-base-content/50 text-sm">{{ 'discover.preview_original_title' | translate }}</dt>
@@ -68,7 +61,7 @@
           </div>
         }
       </dl>
-    </details>
+    </app-collapsible-section>
 
     @if (trailerKey()) {
       <button type="button" class="btn btn-outline gap-2 mt-2" (click)="openTrailer()">

--- a/client/src/app/shared/components/media-info-extra/media-info-extra.ts
+++ b/client/src/app/shared/components/media-info-extra/media-info-extra.ts
@@ -11,10 +11,11 @@ import {
 import { CurrencyPipe } from '@angular/common';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { LucideChevronDown, LucidePlay } from '@lucide/angular';
+import { LucidePlay } from '@lucide/angular';
 import { Media } from '../../../core/services/api/media.service';
 import { localizeLanguage } from '../../../core/utils/language.utils';
 import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
+import { CollapsibleSectionComponent } from '../collapsible-section/collapsible-section';
 
 /**
  * "Extra info" panel rendered on the media-detail page above the cast,
@@ -25,7 +26,7 @@ import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
  */
 @Component({
   selector: 'app-media-info-extra',
-  imports: [LocaleDatePipe, CurrencyPipe, TranslateModule, LucideChevronDown, LucidePlay],
+  imports: [LocaleDatePipe, CurrencyPipe, TranslateModule, CollapsibleSectionComponent, LucidePlay],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-info-extra.html',
 })


### PR DESCRIPTION
## What

Only the **Details** panel could be folded, and it reopened closed on every navigation. Five sections now fold, and remember their state across pages and reloads:

| Section | `persistKey` | Default |
|---|---|---|
| Details | `details` | closed |
| Cast | `cast` | open |
| File information | `fileInfo` | open |
| More from season *N* | `moreFromSeason` | open |
| Other seasons of … | `otherSeasons` | open |

State lives in `localStorage` under `fliks.section.<key>`; a missing entry falls back to the section's default, and a write failure (private browsing, quota) just means the fold doesn't stick.

## How

New shared `app-collapsible-section` (`client/src/app/shared/components/collapsible-section/`):

```html
<app-collapsible-section [heading]="'file_info.title' | translate" persistKey="fileInfo">
  …content…
</app-collapsible-section>
```

Inputs: `heading` (already translated), `persistKey` (omit to skip persistence), `defaultOpen`.

### Why not `<details>`

The details panel used a native `<details>`, which can't animate: the closed content isn't rendered, so there's no height to transition from. The component uses a `grid-template-rows: 0fr → 1fr` transition instead — it animates to the content's own height with no measurement — behind a `<button aria-expanded>`. Browsers that can't interpolate grid rows (Tizen's Chromium 76) snap open, and `motion-reduce` opts out of the transition.

That leaves the collapsed content in the DOM, so the wrapper is `inert` while closed — otherwise Tab and the TV spatial navigation would reach cards nobody can see.

### Seasons row

The episode rail moved into an `<ng-template #episodeRow>` so the untitled main grid view and the titled "more from season" row share it; only the titled one gets a fold.

## Test

`ng build` clean, `ng test` 85 passing including 3 new ones covering the storage round-trip (default fallback, both states, key isolation).