### PR TITLE
feat(media-detail): add collection and similar-movies sections to the movie page

### DIFF
--- a/backend/src/modules/media/media-service/media-related.scoring.spec.ts
+++ b/backend/src/modules/media/media-service/media-related.scoring.spec.ts
@@ -1,0 +1,62 @@
+import { scoreSimilarity } from './media-related.service';
+import { Media } from '../entities/media.entity';
+
+type Candidate = Pick<Media, 'genres' | 'year' | 'metadata'>;
+
+const movie = (
+  genres: string[],
+  year: number,
+  keywords: string[] = [],
+): Candidate =>
+  ({ genres, year, metadata: { keywords } }) as unknown as Candidate;
+
+const source = movie(['Action', 'Thriller'], 2010, ['heist', 'dream']);
+
+describe('similarity scoring', () => {
+  it('ranks two shared keywords above an identical genre pair', () => {
+    const keywordMatch = movie(['Drama'], 2010, ['heist', 'dream']);
+    const genreMatch = movie(['Action', 'Thriller'], 2010);
+    expect(scoreSimilarity(source, keywordMatch, false)).toBeGreaterThan(
+      scoreSimilarity(source, genreMatch, false),
+    );
+  });
+
+  it('keeps a single keyword below an identical genre pair', () => {
+    expect(scoreSimilarity(source, movie(['Drama'], 2010, ['heist']), false)).toBeLessThan(
+      scoreSimilarity(source, movie(['Action', 'Thriller'], 2010), false),
+    );
+  });
+
+  it('normalizes genre overlap by the candidate breadth', () => {
+    const tight = movie(['Action', 'Thriller'], 2010);
+    const catchAll = movie(
+      ['Action', 'Thriller', 'Drama', 'Comedy', 'Horror', 'Western'],
+      2010,
+    );
+    expect(scoreSimilarity(source, tight, false)).toBeGreaterThan(
+      scoreSimilarity(source, catchAll, false),
+    );
+  });
+
+  it('caps the keyword contribution so a tag dump cannot dominate', () => {
+    const many = movie([], 2010, ['heist', 'dream', 'a', 'b', 'c', 'd']);
+    const two = movie([], 2010, ['heist', 'dream']);
+    expect(scoreSimilarity(source, many, false)).toBeCloseTo(
+      scoreSimilarity(source, two, false),
+    );
+  });
+
+  it('scores nothing for a title sharing no signal', () => {
+    expect(scoreSimilarity(source, movie(['Documentary'], 1950), false)).toBe(0);
+  });
+
+  it('rewards the same director and closer release years', () => {
+    const other = movie(['Drama'], 2010);
+    expect(scoreSimilarity(source, other, true)).toBeGreaterThan(
+      scoreSimilarity(source, other, false),
+    );
+    expect(scoreSimilarity(source, movie(['Action'], 2011), false)).toBeGreaterThan(
+      scoreSimilarity(source, movie(['Action'], 1985), false),
+    );
+  });
+});

--- a/backend/src/modules/media/media-service/media-related.service.ts
+++ b/backend/src/modules/media/media-service/media-related.service.ts
@@ -1,0 +1,233 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Brackets, Repository } from 'typeorm';
+import { Media } from '../entities/media.entity';
+import { MediaCrew } from '../entities/media-crew.entity';
+import { MediaType } from '../../../common/enums';
+
+export interface RelatedMediaItem {
+  id: number;
+  title: string;
+  year: number;
+  posterUrl: string | null;
+  rating: number | null;
+  genres: string[];
+  /** False when nothing is on disk yet, so the card can flag it as missing. */
+  hasFile: boolean;
+}
+
+export interface MediaCollection {
+  id: number;
+  name: string;
+  /** Every other title of the collection held in the same library, oldest first. */
+  items: RelatedMediaItem[];
+}
+
+/** Keywords are the sharpest signal TMDB gives: two of them beat any genre pair. */
+const W_KEYWORD = 1.6;
+const KEYWORD_CAP = 4.8;
+const W_GENRE = 2.5;
+const W_DIRECTOR = 2;
+const W_YEAR = 0.5;
+/** Two decades apart contributes nothing. */
+const YEAR_SPAN = 20;
+/** Below this a title only shares one broad genre — noise, not a suggestion. */
+const MIN_SCORE = 1;
+
+/** Exported for the spec: the ranking is the whole feature. */
+export function scoreSimilarity(
+  source: Pick<Media, 'genres' | 'year' | 'metadata'>,
+  candidate: Pick<Media, 'genres' | 'year' | 'metadata'>,
+  sameDirector: boolean,
+): number {
+  let score = 0;
+
+  const keywordHits = sharedCount(
+    source.metadata?.keywords ?? [],
+    candidate.metadata?.keywords ?? [],
+  );
+  score += Math.min(keywordHits * W_KEYWORD, KEYWORD_CAP);
+
+  score += cosineOverlap(source.genres ?? [], candidate.genres ?? []) * W_GENRE;
+
+  if (sameDirector) score += W_DIRECTOR;
+
+  if (source.year && candidate.year) {
+    const gap = Math.abs(source.year - candidate.year);
+    score += Math.max(0, 1 - gap / YEAR_SPAN) * W_YEAR;
+  }
+
+  return score;
+}
+
+function toItem(media: Media): RelatedMediaItem {
+  return {
+    id: media.id,
+    title: media.title,
+    year: media.year,
+    posterUrl: media.posterUrl ?? null,
+    rating: media.rating ?? null,
+    genres: media.genres ?? [],
+    hasFile: ((media as Media & { fileCount?: number }).fileCount ?? 0) > 0,
+  };
+}
+
+function sharedCount(a: string[], b: string[]): number {
+  if (!a.length || !b.length) return 0;
+  const set = new Set(a.map((v) => v.toLowerCase()));
+  return b.filter((v) => set.has(v.toLowerCase())).length;
+}
+
+/**
+ * Overlap normalized by both list lengths, so a title tagged with eight
+ * genres doesn't outrank a tighter match just by casting a wider net.
+ */
+function cosineOverlap(a: string[], b: string[]): number {
+  const shared = sharedCount(a, b);
+  return shared ? shared / Math.sqrt(a.length * b.length) : 0;
+}
+
+/**
+ * Related-titles queries for the movie page, both restricted to what the
+ * library actually holds: the collection the movie belongs to, and a
+ * "more like this" list.
+ *
+ * Similarity scores candidates on the signals the local metadata carries —
+ * keywords, genres, director, release year — rather than asking the provider
+ * for its own similar list, which mostly returns titles nobody here owns.
+ * Collection members are excluded: they have their own section, and a saga
+ * listed twice on one page reads as a bug.
+ *
+ * The SQL pre-filter keeps candidates to those sharing at least one signal,
+ * so a large library isn't hydrated in full on every movie page.
+ */
+@Injectable()
+export class MediaRelatedService {
+  constructor(
+    @InjectRepository(Media)
+    private readonly mediaRepo: Repository<Media>,
+    @InjectRepository(MediaCrew)
+    private readonly crewRepo: Repository<MediaCrew>,
+  ) {}
+
+  async findSimilar(mediaId: number, limit = 12): Promise<RelatedMediaItem[]> {
+    const source = await this.mediaRepo.findOne({
+      where: { id: mediaId },
+      relations: ['metadata'],
+    });
+    if (!source) throw new NotFoundException(`Media #${mediaId} not found`);
+    if (source.type !== MediaType.MOVIE || !source.libraryId) return [];
+
+    const genres = source.genres ?? [];
+    const keywords = source.metadata?.keywords ?? [];
+    const directors = await this.directorPersonIds(mediaId);
+    const sameDirectorIds = directors.length
+      ? await this.mediaIdsByDirector(directors, mediaId)
+      : [];
+
+    if (!genres.length && !keywords.length && !sameDirectorIds.length) return [];
+
+    const candidatesQb = this.mediaRepo
+      .createQueryBuilder('m')
+      .leftJoin('m.metadata', 'meta')
+      .addSelect(['meta.id', 'meta.keywords'])
+      .loadRelationCountAndMap('m.fileCount', 'm.files')
+      .where('m.libraryId = :libraryId', { libraryId: source.libraryId })
+      .andWhere('m.type = :type', { type: MediaType.MOVIE })
+      .andWhere('m.id != :mediaId', { mediaId })
+      .andWhere(
+        new Brackets((w) => {
+          // `1 = 0` keeps the brackets valid whichever signals are missing.
+          w.where('1 = 0');
+          if (genres.length) {
+            w.orWhere('jsonb_exists_any(m.genres, ARRAY[:...genres])', {
+              genres,
+            });
+          }
+          if (keywords.length) {
+            w.orWhere('jsonb_exists_any(meta.keywords, ARRAY[:...keywords])', {
+              keywords,
+            });
+          }
+          if (sameDirectorIds.length) {
+            w.orWhere('m.id IN (:...sameDirectorIds)', { sameDirectorIds });
+          }
+        }),
+      );
+
+    if (source.tmdbCollectionId != null) {
+      candidatesQb.andWhere(
+        '(m.tmdbCollectionId IS NULL OR m.tmdbCollectionId != :sourceCollectionId)',
+        { sourceCollectionId: source.tmdbCollectionId },
+      );
+    }
+
+    const candidates = await candidatesQb.getMany();
+    const directorMatches = new Set(sameDirectorIds);
+
+    return candidates
+      .map((media) => ({
+        media,
+        score: scoreSimilarity(source, media, directorMatches.has(media.id)),
+      }))
+      .filter((c) => c.score >= MIN_SCORE)
+      .sort(
+        (a, b) =>
+          b.score - a.score || (b.media.rating ?? 0) - (a.media.rating ?? 0),
+      )
+      .slice(0, limit)
+      .map(({ media }) => toItem(media));
+  }
+
+  /**
+   * The rest of the movie's TMDB collection, as held in the same library.
+   * Null when the movie belongs to no collection or owns it alone — the
+   * page has nothing to show either way.
+   */
+  async findCollection(mediaId: number): Promise<MediaCollection | null> {
+    const source = await this.mediaRepo.findOne({ where: { id: mediaId } });
+    if (!source) throw new NotFoundException(`Media #${mediaId} not found`);
+    if (source.tmdbCollectionId == null || !source.libraryId) return null;
+
+    const items = await this.mediaRepo
+      .createQueryBuilder('m')
+      .loadRelationCountAndMap('m.fileCount', 'm.files')
+      .where('m.libraryId = :libraryId', { libraryId: source.libraryId })
+      .andWhere('m.tmdbCollectionId = :collectionId', {
+        collectionId: source.tmdbCollectionId,
+      })
+      .andWhere('m.id != :mediaId', { mediaId })
+      .orderBy('m.releaseDate', 'ASC', 'NULLS LAST')
+      .addOrderBy('m.year', 'ASC', 'NULLS LAST')
+      .getMany();
+
+    if (!items.length) return null;
+    return {
+      id: source.tmdbCollectionId,
+      name: source.tmdbCollectionName ?? '',
+      items: items.map(toItem),
+    };
+  }
+
+  private async directorPersonIds(mediaId: number): Promise<number[]> {
+    const crew = await this.crewRepo.find({
+      where: { media: { id: mediaId }, job: 'Director' },
+      relations: ['person'],
+    });
+    return crew.map((c) => c.person.id);
+  }
+
+  private async mediaIdsByDirector(
+    personIds: number[],
+    excludeMediaId: number,
+  ): Promise<number[]> {
+    const rows = await this.crewRepo
+      .createQueryBuilder('crew')
+      .select('crew."mediaId"', 'mediaId')
+      .where('crew."personId" IN (:...personIds)', { personIds })
+      .andWhere('crew.job = :job', { job: 'Director' })
+      .andWhere('crew."mediaId" != :excludeMediaId', { excludeMediaId })
+      .getRawMany<{ mediaId: number }>();
+    return [...new Set(rows.map((r) => r.mediaId))];
+  }
+}

--- a/backend/src/modules/media/media.controller.ts
+++ b/backend/src/modules/media/media.controller.ts
@@ -800,6 +800,31 @@ export class MediaController {
     return this.mediaService.findOne(id);
   }
 
+  @Get(':id/similar')
+  @CheckPolicies((ability) => ability.can(Action.Read, Media))
+  async getSimilar(
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentUser() user: User,
+    @Query('limit') limit?: string,
+  ) {
+    await this.assertMediaAccessible(id, user);
+    const parsed = Number(limit);
+    return this.mediaService.findSimilar(
+      id,
+      Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, 30) : undefined,
+    );
+  }
+
+  @Get(':id/collection')
+  @CheckPolicies((ability) => ability.can(Action.Read, Media))
+  async getCollection(
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentUser() user: User,
+  ) {
+    await this.assertMediaAccessible(id, user);
+    return this.mediaService.findCollection(id);
+  }
+
   @Get(':id/cast')
   @CheckPolicies((ability) => ability.can(Action.Read, Media))
   async getCast(

--- a/backend/src/modules/media/media.module.ts
+++ b/backend/src/modules/media/media.module.ts
@@ -29,6 +29,7 @@ import { NamingService } from '../scheduler/naming.service';
 import { MediaImportService } from './media-service/media-import.service';
 import { MediaMetadataService } from './media-service/media-metadata.service';
 import { MediaQueryService } from './media-service/media-query.service';
+import { MediaRelatedService } from './media-service/media-related.service';
 import { MediaMutationService } from './media-service/media-mutation.service';
 import { MediaRescanService } from './media-service/media-rescan.service';
 import { Library } from '../libraries/entities/library.entity';
@@ -72,6 +73,7 @@ import { StreamingModule } from '../streaming/streaming.module';
     MediaImportService,
     MediaMetadataService,
     MediaQueryService,
+    MediaRelatedService,
     MediaMutationService,
     MediaRescanService,
     MovieDownloadService,

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -19,6 +19,7 @@ import { MediaType } from '../../common/enums';
 import { MediaImportService } from './media-service/media-import.service';
 import { MediaMetadataService } from './media-service/media-metadata.service';
 import { MediaQueryService } from './media-service/media-query.service';
+import { MediaRelatedService } from './media-service/media-related.service';
 import { MediaMutationService } from './media-service/media-mutation.service';
 import { MediaRescanService } from './media-service/media-rescan.service';
 
@@ -36,6 +37,7 @@ export class MediaService {
     private readonly imports: MediaImportService,
     private readonly metadata: MediaMetadataService,
     private readonly query: MediaQueryService,
+    private readonly related: MediaRelatedService,
     private readonly mutation: MediaMutationService,
     private readonly rescan: MediaRescanService,
   ) {}
@@ -108,6 +110,14 @@ export class MediaService {
 
   findOne(id: number) {
     return this.query.findOne(id);
+  }
+
+  findSimilar(id: number, limit?: number) {
+    return this.related.findSimilar(id, limit);
+  }
+
+  findCollection(id: number) {
+    return this.related.findCollection(id);
   }
 
   getTrackingStatus(id: number) {

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -805,6 +805,8 @@
     "details": "Details"
   },
   "media_detail": {
+    "part_of": "Teil von {{name}}",
+    "similar": "Ähnliche Filme",
     "cast": "Besetzung",
     "crew": "Technisches Team",
     "episodes": "Folgen",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -810,6 +810,8 @@
     "details": "Details"
   },
   "media_detail": {
+    "part_of": "Part of {{name}}",
+    "similar": "Similar movies",
     "cast": "Cast",
     "crew": "Crew",
     "episodes": "Episodes",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -805,6 +805,8 @@
     "details": "Detalles"
   },
   "media_detail": {
+    "part_of": "Parte de {{name}}",
+    "similar": "Películas similares",
     "cast": "Reparto",
     "crew": "Equipo técnico",
     "episodes": "Episodios",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -810,6 +810,8 @@
     "details": "Détails"
   },
   "media_detail": {
+    "part_of": "Inclus dans {{name}}",
+    "similar": "Films similaires",
     "cast": "Casting",
     "crew": "Équipe technique",
     "episodes": "Épisodes",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -805,6 +805,8 @@
     "details": "Dettagli"
   },
   "media_detail": {
+    "part_of": "Fa parte di {{name}}",
+    "similar": "Film simili",
     "cast": "Cast",
     "crew": "Troupe tecnica",
     "episodes": "Episodi",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -805,6 +805,8 @@
     "details": "Detalhes"
   },
   "media_detail": {
+    "part_of": "Parte de {{name}}",
+    "similar": "Filmes semelhantes",
     "cast": "Elenco",
     "crew": "Equipa técnica",
     "episodes": "Episódios",

--- a/client/src/app/core/services/api/media.service.ts
+++ b/client/src/app/core/services/api/media.service.ts
@@ -171,6 +171,24 @@ export interface MediaCastEntry {
   person: { id: number; name: string; avatarUrl: string | null };
 }
 
+/** Movie from the same library, related to the one being viewed. */
+export interface RelatedMedia {
+  id: number;
+  title: string;
+  year: number;
+  posterUrl: string | null;
+  rating: number | null;
+  genres: string[];
+  hasFile: boolean;
+}
+
+/** TMDB collection the viewed movie belongs to, minus the movie itself. */
+export interface MediaCollection {
+  id: number;
+  name: string;
+  items: RelatedMedia[];
+}
+
 export interface MediaCrewEntry {
   id: number;
   job: string;
@@ -390,6 +408,18 @@ export class MediaService {
 
   getCast(id: number) {
     return firstValueFrom(this.http.get<MediaCastEntry[]>(`/api/media/${id}/cast`));
+  }
+
+  getSimilar(id: number) {
+    return firstValueFrom(
+      this.http.get<RelatedMedia[]>(`/api/media/${id}/similar`),
+    );
+  }
+
+  getCollection(id: number) {
+    return firstValueFrom(
+      this.http.get<MediaCollection | null>(`/api/media/${id}/collection`),
+    );
   }
 
   getCrew(id: number) {

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -214,6 +214,80 @@
           <app-media-info-extra [media]="m" [directors]="directors()" />
         }
 
+        @if (m.type === 'movie' && collection(); as coll) {
+          <div class="divider my-6"></div>
+          <app-collapsible-section
+            [heading]="'media_detail.part_of' | translate:{ name: coll.name }"
+            persistKey="collection"
+          >
+            @if (coll.items.length > 1) {
+              <app-horizontal-scroller>
+                @for (c of coll.items; track c.id) {
+                  <app-media-card
+                    class="shrink-0 w-28 sm:w-32 lg:w-40"
+                    [aspect]="'portrait'"
+                    [imageUrl]="c.posterUrl"
+                    [title]="c.title"
+                    [subtitle]="c.year ? ('' + c.year) : ''"
+                    [rating]="c.rating ?? 0"
+                    [status]="c.hasFile ? null : 'missing'"
+                    [link]="['/movies', '' + c.id]"
+                  />
+                }
+              </app-horizontal-scroller>
+            } @else if (coll.items[0]; as only) {
+              <!-- A lone sibling doesn't earn a rail: one row, poster beside title. -->
+              <a
+                [routerLink]="['/movies', '' + only.id]"
+                class="flex items-center gap-4 p-3 rounded-box bg-base-200/40 hover:bg-base-200 transition-colors max-w-md"
+              >
+                @if (only.posterUrl) {
+                  <img
+                    appImgFadeIn
+                    [src]="only.posterUrl | resolveUrl:'thumb'"
+                    [alt]="only.title"
+                    class="w-16 rounded-md shrink-0"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                }
+                <div class="min-w-0">
+                  <p class="font-semibold truncate">{{ only.title }}</p>
+                  @if (only.year) {
+                    <p class="text-sm text-base-content/60">{{ only.year }}</p>
+                  }
+                  @if (!only.hasFile) {
+                    <span class="badge badge-sm badge-warning mt-1">{{ 'media_card.missing_files' | translate }}</span>
+                  }
+                </div>
+              </a>
+            }
+          </app-collapsible-section>
+        }
+
+        @if (m.type === 'movie' && similar().length) {
+          <div class="divider my-6"></div>
+          <app-collapsible-section
+            [heading]="'media_detail.similar' | translate"
+            persistKey="similar"
+          >
+            <app-horizontal-scroller>
+              @for (s of similar(); track s.id) {
+                <app-media-card
+                  class="shrink-0 w-28 sm:w-32 lg:w-40"
+                  [aspect]="'portrait'"
+                  [imageUrl]="s.posterUrl"
+                  [title]="s.title"
+                  [subtitle]="s.year ? ('' + s.year) : ''"
+                  [rating]="s.rating ?? 0"
+                  [status]="s.hasFile ? null : 'missing'"
+                  [link]="['/movies', '' + s.id]"
+                />
+              }
+            </app-horizontal-scroller>
+          </app-collapsible-section>
+        }
+
         @if (m.type === 'movie' && cast().length) {
           <div class="divider my-6"></div>
           <ng-container *ngTemplateOutlet="castCrewBlock" />

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -22,6 +22,8 @@ import {
   MovieRelease,
   MediaCastEntry,
   MediaCrewEntry,
+  RelatedMedia,
+  MediaCollection,
 } from '../../core/services/api/media.service';
 import { AuthService } from '../../core/services/auth.service';
 import { ProfilesService, LanguageProfile } from '../../core/services/api/profiles.service';
@@ -186,6 +188,23 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
    */
   private readonly routeParams = toSignal(this.route.paramMap);
 
+  private loadedId: number | null = null;
+
+  /**
+   * Angular reuses this component between two `movies/:id` URLs — the similar
+   * -movies rail links to one — so the load is driven by the route param
+   * instead of ngOnInit, which would only ever run for the first title.
+   */
+  private readonly routeMediaEffect = effect(() => {
+    const params = this.routeParams();
+    if (!params) return;
+    const id = Number(params.get('id'));
+    if (id === this.loadedId) return;
+    const arriving = this.loadedId === null;
+    this.loadedId = id;
+    void this.loadMedia(id, arriving);
+  });
+
   /**
    * Keep the episode-focus state in sync with the URL whenever either the
    * loaded media or the route params change.
@@ -251,6 +270,8 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   readonly media = signal<Media | null>(null);
   readonly cast = signal<MediaCastEntry[]>([]);
   readonly crew = signal<MediaCrewEntry[]>([]);
+  readonly similar = signal<RelatedMedia[]>([]);
+  readonly collection = signal<MediaCollection | null>(null);
   readonly resumeInfo = signal<MediaResumeInfo | null>(null);
   readonly watchedEpisodeIds = signal<Set<number>>(new Set());
   readonly episodeProgress = signal<Record<number, number>>({});
@@ -742,19 +763,65 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     this.backgroundService.clear();
   }
 
-  async ngOnInit() {
+  ngOnInit() {
     // Enter hero page immediately (transparent navbar) — title will be set after media loads
     this.navbarService.enterHeroPage('');
+    this.expectedKind.set(this.route.snapshot.data['kind'] as MediaType);
+    // Load profiles in parallel with media — neither blocks the other
+    void this.loadProfiles();
+  }
+
+  private async loadProfiles() {
+    // Admins edit profiles inline; regular requesters need the same
+    // options surfaced to fill the request modal. Either permission
+    // is enough to justify the round-trip.
+    if (
+      !this.auth.hasPermission('media.edit') &&
+      !this.auth.hasPermission('requests.create')
+    ) return;
+    this.profilesOptionsLoading.set(true);
+    try {
+      const [q, l, libs] = await Promise.all([
+        this.profilesApi.getQualityProfiles(),
+        this.profilesApi.getLanguageProfiles(),
+        this.librariesApi.listMine(),
+      ]);
+      this.qualityProfileOptions.set(q.map((p) => ({ id: p.id, name: p.name })));
+      this.languageProfiles.set(l);
+      this.languageProfileOptions.set(l.map((p) => ({ id: p.id, name: p.name })));
+      this.libraries.set(libs);
+    } catch {
+      // Profiles will just be empty — the page still works
+    } finally {
+      this.profilesOptionsLoading.set(false);
+    }
+  }
+
+  /**
+   * `arriving` is false when the page swaps titles under itself (a related
+   * -movies card): the router already puts us back at the top, and pushing
+   * the scroll to wherever this title was last read would fight that.
+   */
+  private async loadMedia(id: number, arriving: boolean) {
     const kind = this.route.snapshot.data['kind'] as MediaType;
-    this.expectedKind.set(kind);
     this.scrollMemory.activate(this.scrollKey());
-    const idParam = this.route.snapshot.paramMap.get('id');
-    const id = idParam ? Number(idParam) : NaN;
     if (!Number.isFinite(id) || id < 1) {
       this.loading.set(false);
       this.notFound.set(true);
       return;
     }
+
+    // Nothing here survives a switch to another title.
+    this.notFound.set(false);
+    this.cast.set([]);
+    this.crew.set([]);
+    this.similar.set([]);
+    this.collection.set(null);
+    this.resumeInfo.set(null);
+    this.watchedEpisodeIds.set(new Set());
+    this.episodeProgress.set({});
+    this.selectedFileId.set(null);
+    this.activeSeasonId.set(null);
 
     // Card → detail handoff: when the user clicks a media card, we ship the
     // already-loaded Media via router state so the detail page can render
@@ -765,36 +832,10 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     if (passed && passed.id === id && passed.type === kind) {
       this.media.set(passed);
       this.loading.set(false);
+    } else if (this.media()?.id !== id) {
+      this.media.set(null);
+      this.loading.set(true);
     }
-
-    const loadProfiles = async () => {
-      // Admins edit profiles inline; regular requesters need the same
-      // options surfaced to fill the request modal. Either permission
-      // is enough to justify the round-trip.
-      if (
-        !this.auth.hasPermission('media.edit') &&
-        !this.auth.hasPermission('requests.create')
-      ) return;
-      this.profilesOptionsLoading.set(true);
-      try {
-        const [q, l, libs] = await Promise.all([
-          this.profilesApi.getQualityProfiles(),
-          this.profilesApi.getLanguageProfiles(),
-          this.librariesApi.listMine(),
-        ]);
-        this.qualityProfileOptions.set(q.map((p) => ({ id: p.id, name: p.name })));
-        this.languageProfiles.set(l);
-        this.languageProfileOptions.set(l.map((p) => ({ id: p.id, name: p.name })));
-        this.libraries.set(libs);
-      } catch {
-        // Profiles will just be empty — the page still works
-      } finally {
-        this.profilesOptionsLoading.set(false);
-      }
-    };
-
-    // Load profiles in parallel with media — neither blocks the other
-    void loadProfiles();
 
     try {
       const m = await this.mediaService.getOne(id);
@@ -814,7 +855,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       // offset put back by hand. Sticky, not a single shot: cast, crew and the
       // hero artwork land after this point, so a one-off scrollTo gets clamped
       // by a document that hasn't reached its full height yet.
-      this.scrollMemory.restoreSticky(this.scrollKey());
+      if (arriving) this.scrollMemory.restoreSticky(this.scrollKey());
       this.draftQualityProfileId.set(m.qualityProfile?.id ?? null);
       this.draftLanguageProfileId.set(m.languageProfile?.id ?? null);
       this.selectedLibraryId.set(m.libraryId ?? null);
@@ -835,6 +876,10 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       // Load cast/crew async — doesn't block page render
       this.mediaService.getCast(m.id).then((c) => this.cast.set(c)).catch(() => {});
       this.mediaService.getCrew(m.id).then((c) => this.crew.set(c)).catch(() => {});
+      if (m.type === 'movie') {
+        this.mediaService.getSimilar(m.id).then((s) => this.similar.set(s)).catch(() => {});
+        this.mediaService.getCollection(m.id).then((c) => this.collection.set(c)).catch(() => {});
+      }
       // Active requests (only for users who would ever see the Demander
       // button — admins skip the round-trip).
       if (this.canRequest()) {

--- a/client/src/app/shared/components/horizontal-scroller.ts
+++ b/client/src/app/shared/components/horizontal-scroller.ts
@@ -52,6 +52,15 @@ export class HorizontalScrollerComponent implements AfterViewInit, OnDestroy {
   protected onFocusIn(event: FocusEvent): void {
     const from = event.relatedTarget as Node | null;
     if (from && this.host.nativeElement.contains(from)) return;
+    // Clicking a card focuses it too, and pulling the page under the cursor
+    // mid-click is never wanted. Chromium 76 (Tizen) throws on the selector —
+    // those builds are D-pad only, where every focus deserves the snap.
+    try {
+      const target = event.target as HTMLElement | null;
+      if (target && !target.matches(':focus-visible')) return;
+    } catch {
+      // No :focus-visible support — fall through and snap.
+    }
     queueMicrotask(() => this.snapToRowTop());
   }
 


### PR DESCRIPTION
## What

Two new sections on a movie page, both between **Details** and **Cast**, both foldable and persisted like the others:

- **Part of \<collection\>** — the rest of the movie's TMDB collection held in the same library, oldest first.
- **Similar movies** — scored suggestions from the same library.

## Similar: scoring

`GET /api/media/:id/similar` walks the same library and scores on what the local metadata carries:

| Signal | Weight |
|---|---|
| Shared TMDB keywords | 1.6 each, capped at 4.8 |
| Shared genres (cosine, normalized by both genre counts) | ×2.5 |
| Same director | 2 |
| Release-year proximity (nothing left at 20 years apart) | ×0.5 |

Keywords outweigh genres because they are far more specific — two shared keywords beat an identical genre pair, one does not. Candidates are pre-filtered in SQL (`jsonb_exists_any` on genres and keywords, plus the director's other films) so a large library isn't hydrated on every page view, and anything under 1 point is dropped. Titles in the movie's own collection are excluded — the collection section covers them.

`GET /api/media/:id/collection` returns `null` when the movie has no collection or is the only member the library holds, so the section disappears rather than rendering empty.

## Collection: layout

Several siblings get the usual scroller. A single sibling doesn't earn a rail, so it renders as one row — poster beside title, year and missing-files badge. Movies with no file on disk carry the missing marker in both layouts.

## Two behaviours these rows exposed

Both are older bugs that nothing could reach until a card on the movie page linked to another movie:

1. **The page didn't reload.** Everything was loaded in `ngOnInit`, which runs once; Angular serves two `movies/:id` URLs with the same component instance, so the URL changed and the content didn't. The load now runs off the route param, and per-title state (cast, crew, related rows, resume, watched episodes, selected file) resets on each switch. `ngOnInit` keeps only the one-shot setup.

2. **Clicking a card scrolled the page down.** `app-horizontal-scroller`'s `focusin` handler aligns the row to the top of the viewport for D-pad and keyboard navigation. A mouse click focuses the card too, so the page smooth-scrolled down and the animation carried over into the next page. It now ignores focus that isn't `:focus-visible`; Chromium 76 (Tizen) throws on the selector and falls through, which is right there — no pointer, every focus is a D-pad focus. Applies to every row in the app.

Related: `restoreSticky` now only runs when arriving from another page. Swapping titles in place would otherwise jump to wherever that title was last read, fighting the router's scroll-to-top.

## Test

Backend `tsc` clean, 6 new unit tests on the scoring (`media-related.scoring.spec.ts`). Client build clean, 85 tests passing. Both endpoints exercised against a real library: a 7-entry collection (scroller), a 1-entry collection (single row), a movie with no collection (empty), and a similar list with no collection duplicates.