### PR TITLE
fix(spatial-nav): unify the focus rules and annotate the rows that skipped them

### DIFF
--- a/client/src/app/core/services/default-focus.service.ts
+++ b/client/src/app/core/services/default-focus.service.ts
@@ -2,7 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { DeviceService } from './device.service';
 import { FocusMemoryService } from './focus-memory.service';
 import { NavbarService } from './navbar.service';
-import { FOCUSABLE_SELECTOR } from './focusable.constants';
+import { FOCUSABLE_SELECTOR, isFocusCandidate } from './focusable.constants';
 
 /** How long to wait for an async-loaded target to render before giving up and
  *  focusing whatever's there (so a slow/empty list doesn't sit unfocused). */
@@ -162,15 +162,11 @@ export class DefaultFocusService {
    *  descendant. Null when nothing visible is focusable. */
   private firstVisibleFocusable(el: HTMLElement | null): HTMLElement | null {
     if (!el) return null;
-    if (el.matches(FOCUSABLE_SELECTOR) && this.isVisible(el)) return el;
+    if (el.matches(FOCUSABLE_SELECTOR) && isFocusCandidate(el)) return el;
     for (const c of Array.from(el.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))) {
-      if (this.isVisible(c)) return c;
+      if (isFocusCandidate(c)) return c;
     }
     return null;
   }
 
-  /** Rendered (not display:none on itself or an ancestor). */
-  private isVisible(el: HTMLElement): boolean {
-    return el.offsetParent !== null;
-  }
 }

--- a/client/src/app/core/services/focusable.constants.ts
+++ b/client/src/app/core/services/focusable.constants.ts
@@ -9,3 +9,49 @@
  */
 export const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]), [data-tv-focusable]';
+
+/** Tab-cycle targets inside a trapped overlay (bottom sheet, dropdown menu). */
+export const TABBABLE_SELECTOR =
+  'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * A horizontally scrolling rail. Arrow keys stay inside one while stepping,
+ * and its off-screen cards remain valid targets.
+ */
+export const SCROLLER_SELECTOR = '[data-scroller], .flex.overflow-x-auto';
+
+/** Laid out and painted: not detached, zero-sized, hidden or display:none. */
+export function isRendered(el: HTMLElement, style?: CSSStyleDeclaration): boolean {
+  if (el.offsetParent === null && el.tagName !== 'BODY') return false;
+  const r = el.getBoundingClientRect();
+  if (r.width === 0 || r.height === 0) return false;
+  const s = style ?? getComputedStyle(el);
+  return s.visibility !== 'hidden' && s.display !== 'none';
+}
+
+/**
+ * Whether focus may land on `el`. Every skip rule lives here so the passes
+ * that hunt for a target — tree step, document scan, default focus — can't
+ * drift apart; a new rule (`inert` was the last one) is added once.
+ *
+ * Pass `style` when the caller already resolved it, to save a second
+ * `getComputedStyle` per element on a whole-document scan.
+ */
+export function isFocusCandidate(
+  el: HTMLElement,
+  style?: CSSStyleDeclaration,
+): boolean {
+  return !isFocusOptedOut(el) && isRendered(el, style);
+}
+
+/** The opt-out half of {@link isFocusCandidate}, split out to stay testable. */
+export function isFocusOptedOut(el: HTMLElement): boolean {
+  if (el.hasAttribute('disabled')) return true;
+  if (el.getAttribute('aria-hidden') === 'true') return true;
+  // `a[href]` matches regardless of tabindex, so a media-card's inner links
+  // (tabindex=-1 on TV) would otherwise show up as separate targets.
+  if (el.getAttribute('tabindex') === '-1') return true;
+  // A collapsed section keeps its content laid out, just inert: it measures
+  // as visible but refuses focus, which dead-ends the move.
+  return !!el.closest('[inert]');
+}

--- a/client/src/app/core/services/focusable.spec.ts
+++ b/client/src/app/core/services/focusable.spec.ts
@@ -1,0 +1,35 @@
+import { FOCUSABLE_SELECTOR, isFocusOptedOut } from './focusable.constants';
+
+function html(markup: string): HTMLElement {
+  const host = document.createElement('div');
+  host.innerHTML = markup;
+  return host.firstElementChild as HTMLElement;
+}
+
+describe('focus opt-outs', () => {
+  it('takes a plain focusable', () => {
+    const el = html('<button>ok</button>');
+    expect(el.matches(FOCUSABLE_SELECTOR)).toBe(true);
+    expect(isFocusOptedOut(el)).toBe(false);
+  });
+
+  it('rejects disabled, aria-hidden and tabindex=-1', () => {
+    expect(isFocusOptedOut(html('<button disabled>x</button>'))).toBe(true);
+    expect(isFocusOptedOut(html('<button aria-hidden="true">x</button>'))).toBe(true);
+    expect(isFocusOptedOut(html('<a href="/x" tabindex="-1">x</a>'))).toBe(true);
+  });
+
+  it('rejects anything under an inert subtree, however deep', () => {
+    const section = html('<div inert><div><a href="/x">x</a></div></div>');
+    const link = section.querySelector('a') as HTMLElement;
+    expect(isFocusOptedOut(link)).toBe(true);
+    expect(isFocusOptedOut(section)).toBe(true);
+  });
+
+  it('takes the same element once its section is no longer inert', () => {
+    const section = html('<div inert><a href="/x">x</a></div>');
+    const link = section.querySelector('a') as HTMLElement;
+    section.removeAttribute('inert');
+    expect(isFocusOptedOut(link)).toBe(false);
+  });
+});

--- a/client/src/app/core/services/tv-spatial-nav.service.ts
+++ b/client/src/app/core/services/tv-spatial-nav.service.ts
@@ -1,7 +1,12 @@
 import { Injectable, inject, DestroyRef } from '@angular/core';
 import { TvService } from './tv.service';
 import { DefaultFocusService } from './default-focus.service';
-import { FOCUSABLE_SELECTOR } from './focusable.constants';
+import {
+  FOCUSABLE_SELECTOR,
+  SCROLLER_SELECTOR,
+  isFocusCandidate,
+  isRendered,
+} from './focusable.constants';
 
 /**
  * Spatial navigation for D-pad input on Android TV — and keyboard
@@ -118,7 +123,7 @@ export class TvSpatialNavService {
         childList: true,
         subtree: true,
         attributes: true,
-        attributeFilter: ['class', 'style', 'disabled', 'hidden', 'aria-hidden', 'tabindex'],
+        attributeFilter: ['class', 'style', 'disabled', 'hidden', 'aria-hidden', 'tabindex', 'inert'],
       });
       this.destroyRef.onDestroy(() => this.focusObserver?.disconnect());
     }
@@ -207,8 +212,10 @@ export class TvSpatialNavService {
   private focusFirstIfNoFocus() {
     if (typeof document === 'undefined') return;
     if (document.activeElement && document.activeElement !== document.body) return;
-    const all = this.getFocusables();
-    all[0]?.focus({ preventScroll: true });
+    // Same choice as the cold-load branch of findNeighbor: the page's declared
+    // default beats the first document focusable, which is the topbar.
+    const target = this.defaultFocus.currentTarget() ?? this.getFocusables()[0];
+    target?.focus({ preventScroll: true });
   }
 
   private onKey(e: KeyboardEvent) {
@@ -358,16 +365,11 @@ export class TvSpatialNavService {
     while (Math.abs(this.wheelAcc) >= STEP) {
       const dir = this.wheelAcc > 0 ? 'down' : 'up';
       this.wheelAcc -= dir === 'down' ? STEP : -STEP;
-      this.navigateVertical(dir);
+      // Same paced dispatcher as the D-pad, so a fast spin can't fire smooth
+      // scrolls faster than they settle. crossZones: a wheel is a scroll
+      // gesture, not a discrete press, so it may leave the current zone.
+      this.dispatchMove(dir, true);
     }
-  }
-
-  /** Magic-Remote wheel vertical step. Routes through the same paced dispatcher
-   *  as the D-pad so a fast spin can't fire smooth scrolls faster than they
-   *  settle. crossZones=true: a wheel is a scroll gesture, not a discrete press,
-   *  so it may scroll out of a zone (unlike a held D-pad key). */
-  private navigateVertical(dir: 'up' | 'down') {
-    this.dispatchMove(dir, true);
   }
 
   /** Currently-open overlays that scope spatial navigation. Bottom sheets
@@ -448,7 +450,7 @@ export class TvSpatialNavService {
     // so the user can step out of the row toward a same-band element
     // outside it (typically: the layout sidebar on the left).
     const activeScroller = horizontal
-      ? active.closest<HTMLElement>('.flex.overflow-x-auto, [data-scroller]')
+      ? active.closest<HTMLElement>(SCROLLER_SELECTOR)
       : null;
 
     // Three-pass selection:
@@ -595,7 +597,7 @@ export class TvSpatialNavService {
     let bestScore = Infinity;
     for (const c of this.containers.values()) {
       if (c === from || c.parent !== null) continue;
-      if (!isVisibleElement(c.el)) continue;
+      if (!isRendered(c.el)) continue;
       const r = c.el.getBoundingClientRect();
       const cx = r.left + r.width / 2;
       const cy = r.top + r.height / 2;
@@ -634,12 +636,12 @@ export class TvSpatialNavService {
   private digDown(el: HTMLElement, preferFirst = false): HTMLElement | null {
     const c = this.containers.get(el);
     if (!c) return el; // it's a leaf focusable
-    if (!preferFirst && c.activeChild && c.el.contains(c.activeChild) && isVisibleFocusable(c.activeChild)) {
+    if (!preferFirst && c.activeChild && c.el.contains(c.activeChild) && isFocusCandidate(c.activeChild)) {
       return c.activeChild;
     }
     if (!preferFirst) {
       const auto = c.el.querySelector<HTMLElement>('[autofocus]');
-      if (auto && isVisibleFocusable(auto)) return auto;
+      if (auto && isFocusCandidate(auto)) return auto;
     }
     const children = this.getNavigableChildren(c);
     for (const child of children) {
@@ -662,11 +664,11 @@ export class TvSpatialNavService {
       // A registered sub-container: it is itself a navigable child; do not
       // descend (the recursion stops, its own children belong to its tree).
       if (el !== container.el && this.containers.has(el)) {
-        if (isVisibleElement(el)) out.push(el);
+        if (isRendered(el)) out.push(el);
         return;
       }
       // A focusable leaf at this level — treat as navigable, do not descend.
-      if (matchesFocusable(el) && isVisibleFocusable(el)) {
+      if (matchesFocusable(el) && isFocusCandidate(el)) {
         out.push(el);
         return;
       }
@@ -686,21 +688,6 @@ function matchesFocusable(el: HTMLElement): boolean {
   return el.matches?.(FOCUSABLE_SELECTOR) ?? false;
 }
 
-function isVisibleElement(el: HTMLElement): boolean {
-  if (el.offsetParent === null && el.tagName !== 'BODY') return false;
-  const r = el.getBoundingClientRect();
-  if (r.width === 0 && r.height === 0) return false;
-  const style = getComputedStyle(el);
-  return style.visibility !== 'hidden' && style.display !== 'none';
-}
-
-function isVisibleFocusable(el: HTMLElement): boolean {
-  if (el.hasAttribute('disabled')) return false;
-  if (el.getAttribute('aria-hidden') === 'true') return false;
-  if (el.getAttribute('tabindex') === '-1') return false;
-  return isVisibleElement(el);
-}
-
 const ARROW_TO_DIR: Record<string, 'left' | 'right' | 'up' | 'down' | undefined> = {
   ArrowLeft: 'left',
   ArrowRight: 'right',
@@ -718,19 +705,10 @@ const KEYCODE_TO_DIR: Record<number, 'left' | 'right' | 'up' | 'down' | undefine
 function collectFocusables(root: ParentNode = document): HTMLElement[] {
   const nodes = Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
   const visible = nodes.filter((el) => {
-    if (el.hasAttribute('disabled')) return false;
-    if (el.getAttribute('aria-hidden') === 'true') return false;
-    // tabindex=-1 means "skip spatial nav". The FOCUSABLE_SELECTOR matches
-    // anchors via `a[href]` independently of tabindex, so without this filter
-    // a media-card's inner title/subtitle links (which we set tabindex=-1 on
-    // TV) would still be picked up by the D-pad as separate focus targets.
-    if (el.getAttribute('tabindex') === '-1') return false;
-    // offsetParent is null when the element (or any ancestor) has display:none,
-    // visibility:hidden, or is detached — covers the cases where a parent hides
-    // a focusable child via class toggling without the child itself being hidden.
-    if (el.offsetParent === null && el.tagName !== 'BODY') return false;
+    const style = getComputedStyle(el);
+    if (!isFocusCandidate(el, style)) return false;
+    if (style.pointerEvents === 'none') return false;
     const r = el.getBoundingClientRect();
-    if (r.width === 0 || r.height === 0) return false;
     // Reject focusables only when they're positioned entirely off-document —
     // not just scrolled out of view. DaisyUI's drawer-toggle checkbox lives
     // at left: -100% and would otherwise pollute spatial nav (Left key would
@@ -741,17 +719,11 @@ function collectFocusables(root: ParentNode = document): HTMLElement[] {
     // for scrolled-off content, and a horizontal-scroller's internal
     // scrollLeft reaches its hidden siblings, so allow either case.
     if (r.right <= 0 || r.bottom <= 0) {
-      const inScroller = el.closest('.flex.overflow-x-auto, [data-scroller]');
+      const inScroller = el.closest(SCROLLER_SELECTOR);
       const docRight = r.right + window.scrollX;
       const docBottom = r.bottom + window.scrollY;
       if (!inScroller && (docRight <= 0 || docBottom <= 0)) return false;
     }
-    const style = getComputedStyle(el);
-    if (style.visibility === 'hidden' || style.display === 'none') return false;
-    // pointerEvents:none folded in here (the scoring loop used to call
-    // getComputedStyle a second time per element for this) — reuses the style
-    // object already resolved above, so it's free, and the result is cached.
-    if (style.pointerEvents === 'none') return false;
     return true;
   });
   // Keep only the outermost focusables: if an element has an ancestor that is

--- a/client/src/app/core/utils/focus-snap.util.ts
+++ b/client/src/app/core/utils/focus-snap.util.ts
@@ -1,0 +1,45 @@
+/**
+ * Pull a card row to the top of the viewport when focus enters it from
+ * outside — the spatial-nav default `focus()` scrolls instantly and drops the
+ * user mid-row. Shared by `app-horizontal-scroller` and `[appTvRowSnap]`, the
+ * two row flavours, so a fix lands on both.
+ */
+export function snapRowOnFocus(
+  event: FocusEvent,
+  host: HTMLElement,
+  topOffset: number,
+): void {
+  const from = event.relatedTarget as Node | null;
+  if (from && host.contains(from)) return;
+  // Clicking a card focuses it too, and pulling the page under the cursor
+  // mid-click is never wanted. Chromium 76 (Tizen) throws on the selector —
+  // those builds are D-pad only, where every focus deserves the snap.
+  try {
+    const target = event.target as HTMLElement | null;
+    if (target && !target.matches(':focus-visible')) return;
+  } catch {
+    // No :focus-visible support — fall through and snap.
+  }
+  queueMicrotask(() => snapToTop(host, topOffset));
+}
+
+function snapToTop(host: HTMLElement, topOffset: number): void {
+  if (typeof window === 'undefined') return;
+  const scrollEl = document.scrollingElement ?? document.documentElement;
+  const rect = host.getBoundingClientRect();
+  const currentTop = scrollEl.scrollTop ?? 0;
+  // Already fully visible: the user is walking between visible rows.
+  if (rect.top >= topOffset && rect.bottom <= window.innerHeight) return;
+  const targetTop = Math.max(0, currentTop + rect.top - topOffset);
+  if (Math.abs(targetTop - currentTop) < 4) return;
+  try {
+    window.scrollTo({ top: targetTop, left: 0, behavior: 'smooth' });
+  } catch {
+    window.scrollTo(0, targetTop);
+  }
+}
+
+/** Row top gap: TV clears the floating top-right dock, pointer UIs just breathe. */
+export function rowTopOffset(isTv: boolean): number {
+  return isTv ? 96 : 24;
+}

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -242,7 +242,7 @@
           <!-- Two columns, and only the synopsis's span changes with the
                breakpoint: full width under the image on a phone, beside it from
                sm. A grid keeps that to one copy of the text. -->
-          <li class="grid grid-cols-[auto_1fr] gap-x-3 sm:gap-x-4 gap-y-1.5 py-3">
+          <li appTvRow class="grid grid-cols-[auto_1fr] gap-x-3 sm:gap-x-4 gap-y-1.5 py-3">
               <!-- The tile is app-media-card with its caption dropped: the episode
                    badge, missing cross, progress, hover play and watched toggle all
                    come from the one implementation instead of a lookalike. -->

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -221,22 +221,8 @@
             persistKey="collection"
           >
             @if (coll.items.length > 1) {
-              <app-horizontal-scroller>
-                @for (c of coll.items; track c.id) {
-                  <app-media-card
-                    class="shrink-0 w-28 sm:w-32 lg:w-40"
-                    [aspect]="'portrait'"
-                    [imageUrl]="c.posterUrl"
-                    [title]="c.title"
-                    [subtitle]="c.year ? ('' + c.year) : ''"
-                    [rating]="c.rating ?? 0"
-                    [status]="c.hasFile ? null : 'missing'"
-                    [link]="['/movies', '' + c.id]"
-                  />
-                }
-              </app-horizontal-scroller>
+              <ng-container *ngTemplateOutlet="movieRow; context: { $implicit: coll.items }" />
             } @else if (coll.items[0]; as only) {
-              <!-- A lone sibling doesn't earn a rail: one row, poster beside title. -->
               <a
                 [routerLink]="['/movies', '' + only.id]"
                 class="flex items-center gap-4 p-3 rounded-box bg-base-200/40 hover:bg-base-200 transition-colors max-w-md"
@@ -271,20 +257,7 @@
             [heading]="'media_detail.similar' | translate"
             persistKey="similar"
           >
-            <app-horizontal-scroller>
-              @for (s of similar(); track s.id) {
-                <app-media-card
-                  class="shrink-0 w-28 sm:w-32 lg:w-40"
-                  [aspect]="'portrait'"
-                  [imageUrl]="s.posterUrl"
-                  [title]="s.title"
-                  [subtitle]="s.year ? ('' + s.year) : ''"
-                  [rating]="s.rating ?? 0"
-                  [status]="s.hasFile ? null : 'missing'"
-                  [link]="['/movies', '' + s.id]"
-                />
-              }
-            </app-horizontal-scroller>
+            <ng-container *ngTemplateOutlet="movieRow; context: { $implicit: similar() }" />
           </app-collapsible-section>
         }
 
@@ -433,9 +406,26 @@
   }
 </div>
 
+<ng-template #movieRow let-items>
+  <app-horizontal-scroller>
+    @for (item of items; track item.id) {
+      <app-media-card
+        class="shrink-0 w-28 sm:w-32 lg:w-40"
+        [aspect]="'portrait'"
+        [imageUrl]="item.posterUrl"
+        [title]="item.title"
+        [subtitle]="item.year ? ('' + item.year) : ''"
+        [rating]="item.rating ?? 0"
+        [status]="item.hasFile ? null : 'missing'"
+        [link]="['/movies', '' + item.id]"
+      />
+    }
+  </app-horizontal-scroller>
+</ng-template>
+
 <ng-template #castCrewBlock>
   @if (cast().length) {
-    <div class="cv-auto" style="contain-intrinsic-size: auto 12rem">
+    <div class="cv-auto py-5 -my-5 px-4 -mx-4" style="contain-intrinsic-size: auto 12rem">
     <app-collapsible-section [heading]="'media_detail.cast' | translate" persistKey="cast">
     <app-horizontal-scroller>
       @for (c of cast(); track c.id) {

--- a/client/src/app/shared/components/bottom-sheet.ts
+++ b/client/src/app/shared/components/bottom-sheet.ts
@@ -13,6 +13,7 @@ import {
 } from '@angular/core';
 import { DismissableStackService } from '../../core/services/dismissable-stack.service';
 import { TvService } from '../../core/services/tv.service';
+import { TABBABLE_SELECTOR } from '../../core/services/focusable.constants';
 
 @Component({
   selector: 'app-bottom-sheet',
@@ -92,8 +93,6 @@ export class BottomSheetComponent {
   private focusTrapActive = false;
   /** Element focused when the sheet opened — restored on close. */
   private prevFocused: HTMLElement | null = null;
-  private static readonly FOCUSABLE_SELECTOR =
-    'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
   /**
    * TV-only focus trap. The WebView's spatial navigation moves focus to the
@@ -109,7 +108,7 @@ export class BottomSheetComponent {
     if (!sheetEl) return;
     const target = e.target as HTMLElement | null;
     if (!target || sheetEl.contains(target)) return;
-    const first = sheetEl.querySelector<HTMLElement>(BottomSheetComponent.FOCUSABLE_SELECTOR);
+    const first = sheetEl.querySelector<HTMLElement>(TABBABLE_SELECTOR);
     first?.focus({ preventScroll: true });
   };
 
@@ -169,7 +168,7 @@ export class BottomSheetComponent {
               if (!this.open()) return;
               const sheetEl = this.sheet()?.nativeElement;
               const first = sheetEl?.querySelector<HTMLElement>(
-                BottomSheetComponent.FOCUSABLE_SELECTOR,
+                TABBABLE_SELECTOR,
               );
               first?.focus({ preventScroll: true });
             });

--- a/client/src/app/shared/components/collapsible-section/collapsible-section.html
+++ b/client/src/app/shared/components/collapsible-section/collapsible-section.html
@@ -13,15 +13,11 @@
   ></svg>
 </button>
 
-<!-- 0fr → 1fr is the one grid-row trick that animates to the content's own
-     height; browsers that can't interpolate it just snap open. -->
 <div
   class="grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none"
   [style.grid-template-rows]="open() ? '1fr' : '0fr'"
 >
-  <!-- Collapsed content still occupies the DOM, so keep it out of tab and
-       spatial-navigation reach. -->
-  <div class="overflow-hidden" [attr.inert]="open() ? null : ''">
+  <div [class.overflow-hidden]="clipped()" [attr.inert]="open() ? null : ''">
     <div class="mt-3">
       <ng-content />
     </div>

--- a/client/src/app/shared/components/collapsible-section/collapsible-section.ts
+++ b/client/src/app/shared/components/collapsible-section/collapsible-section.ts
@@ -1,7 +1,16 @@
-import { ChangeDetectionStrategy, Component, OnInit, input, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnDestroy,
+  OnInit,
+  input,
+  signal,
+} from '@angular/core';
 import { LucideChevronDown } from '@lucide/angular';
 
 const LS_PREFIX = 'fliks.section.';
+/** Slightly past the fold transition below, so the clip outlives the motion. */
+const UNCLIP_DELAY_MS = 250;
 
 export function readSectionOpen(key: string, fallback: boolean): boolean {
   if (!key || typeof localStorage === 'undefined') return fallback;
@@ -35,21 +44,38 @@ export function writeSectionOpen(key: string, open: boolean): void {
   templateUrl: './collapsible-section.html',
   host: { class: 'block' },
 })
-export class CollapsibleSectionComponent implements OnInit {
+export class CollapsibleSectionComponent implements OnInit, OnDestroy {
   readonly heading = input.required<string>();
   /** localStorage suffix. Empty means the section reopens at its default. */
   readonly persistKey = input('');
   readonly defaultOpen = input(true);
 
   protected readonly open = signal(false);
+  /** Clipped only while folding: open, a card rail must bleed out its focus ring. */
+  protected readonly clipped = signal(true);
+  private unclipTimer: ReturnType<typeof setTimeout> | null = null;
 
   ngOnInit() {
-    this.open.set(readSectionOpen(this.persistKey(), this.defaultOpen()));
+    const open = readSectionOpen(this.persistKey(), this.defaultOpen());
+    this.open.set(open);
+    this.clipped.set(!open);
   }
 
   protected toggle() {
     const open = !this.open();
     this.open.set(open);
     writeSectionOpen(this.persistKey(), open);
+
+    if (this.unclipTimer) clearTimeout(this.unclipTimer);
+    if (!open) {
+      this.clipped.set(true);
+      return;
+    }
+    // Timer, not `transitionend`: Tizen snaps open without firing it.
+    this.unclipTimer = setTimeout(() => this.clipped.set(false), UNCLIP_DELAY_MS);
+  }
+
+  ngOnDestroy() {
+    if (this.unclipTimer) clearTimeout(this.unclipTimer);
   }
 }

--- a/client/src/app/shared/components/horizontal-scroller.html
+++ b/client/src/app/shared/components/horizontal-scroller.html
@@ -33,6 +33,7 @@
     #scroller
     appTvRow
     data-tv-zone
+    data-scroller
     class="flex gap-2 lg:gap-4 overflow-x-auto scrollbar-none [scroll-behavior:smooth] py-5 -my-5 px-4 -mx-4 scroll-px-16"
     (scroll)="updateArrows()"
   >

--- a/client/src/app/shared/components/horizontal-scroller.ts
+++ b/client/src/app/shared/components/horizontal-scroller.ts
@@ -16,6 +16,7 @@ import { LucideChevronLeft, LucideChevronRight } from '@lucide/angular';
 import { TvRowDirective } from '../directives/tv-row.directive';
 import { TvService } from '../../core/services/tv.service';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
+import { rowTopOffset, snapRowOnFocus } from '../../core/utils/focus-snap.util';
 
 @Component({
   selector: 'app-horizontal-scroller',
@@ -42,51 +43,9 @@ export class HorizontalScrollerComponent implements AfterViewInit, OnDestroy {
   private readonly scrollerEl = viewChild<ElementRef<HTMLElement>>('scroller');
   private resizeObserver?: ResizeObserver;
 
-  /** Smooth-scroll the page so this row's top sits at the viewport top
-   *  when focus arrives from outside (e.g. the row above/below). The
-   *  spatial-nav default `focus()` triggers an `instant` scrollIntoView
-   *  that drops the user mid-row — this hostlistener replaces it with
-   *  a smooth, row-aligned animation. Skips when focus moves between
-   *  cards inside the same rail. */
   @HostListener('focusin', ['$event'])
   protected onFocusIn(event: FocusEvent): void {
-    const from = event.relatedTarget as Node | null;
-    if (from && this.host.nativeElement.contains(from)) return;
-    // Clicking a card focuses it too, and pulling the page under the cursor
-    // mid-click is never wanted. Chromium 76 (Tizen) throws on the selector —
-    // those builds are D-pad only, where every focus deserves the snap.
-    try {
-      const target = event.target as HTMLElement | null;
-      if (target && !target.matches(':focus-visible')) return;
-    } catch {
-      // No :focus-visible support — fall through and snap.
-    }
-    queueMicrotask(() => this.snapToRowTop());
-  }
-
-  private snapToRowTop(): void {
-    if (typeof window === 'undefined') return;
-    const scrollEl = document.scrollingElement ?? document.documentElement;
-    const rect = this.host.nativeElement.getBoundingClientRect();
-    const currentTop = scrollEl.scrollTop ?? 0;
-    // Leave a gap above the row title so the focused row doesn't sit
-    // flush against the viewport edge. On TV the cast/user dock floats
-    // top-right (~48 px tall at top:24); bump the offset so the focused
-    // row clears the dock with its own breathing room.
-    const TOP_OFFSET = this.tv.isTv() ? 96 : 24;
-    // Skip when the row is already fully visible in the viewport: the
-    // user is just walking between visible rows, no scroll is warranted.
-    // Only snap when the row is partially / fully off-screen, in which
-    // case we need to bring it back into view.
-    const viewportH = window.innerHeight;
-    if (rect.top >= TOP_OFFSET && rect.bottom <= viewportH) return;
-    const targetTop = Math.max(0, currentTop + rect.top - TOP_OFFSET);
-    if (Math.abs(targetTop - currentTop) < 4) return;
-    try {
-      window.scrollTo({ top: targetTop, left: 0, behavior: 'smooth' });
-    } catch {
-      window.scrollTo(0, targetTop);
-    }
+    snapRowOnFocus(event, this.host.nativeElement, rowTopOffset(this.tv.isTv()));
   }
 
   ngAfterViewInit() {

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -32,9 +32,9 @@
 
     <!-- Genres are navigation, so they stay out of the folded details panel. -->
     @if (genres().length) {
-      <div class="flex flex-wrap items-center gap-x-1 mt-1 pt-1 font-medium text-base-content/80">
+      <div appTvRow class="flex flex-wrap items-center gap-x-1 mt-1 pt-1 font-medium text-base-content/80">
         @for (genre of genres(); track genre; let last = $last) {
-          <span><button type="button" class="cursor-pointer hover:underline rounded" (click)="navigateToGenre(genre)">{{ genre }}</button>@if (!last){,}</span>
+          <span><button type="button" class="cursor-pointer hover:underline" (click)="navigateToGenre(genre)">{{ genre }}</button>@if (!last){,}</span>
         }
       </div>
     }
@@ -252,9 +252,9 @@
 
       <!-- Genres are navigation, so they stay out of the folded details panel. -->
       @if (genres().length) {
-        <div class="flex flex-wrap items-center gap-x-1 mt-1 pt-1 font-medium text-base-content/80">
+        <div appTvRow class="flex flex-wrap items-center gap-x-1 mt-1 pt-1 font-medium text-base-content/80">
           @for (genre of genres(); track genre; let last = $last) {
-            <span><button type="button" class="cursor-pointer hover:underline rounded" (click)="navigateToGenre(genre)">{{ genre }}</button>@if (!last){,}</span>
+            <span><button type="button" class="cursor-pointer hover:underline" (click)="navigateToGenre(genre)">{{ genre }}</button>@if (!last){,}</span>
           }
         </div>
       }
@@ -434,7 +434,7 @@
      when iterating on the layout. -->
 <ng-template #streamInfoBlock>
   @if (selectedFileId() && (mediaType() !== 'series' || episodeId())) {
-    <div class="flex flex-wrap items-center gap-x-4 gap-y-1.5 mt-5">
+    <div appTvRow class="flex flex-wrap items-center gap-x-4 gap-y-1.5 mt-5">
       <div class="flex items-center gap-2">
         <span class="text-base-content/50">{{ 'media_info.video' | translate }}</span>
         @if (multipleFiles()) {

--- a/client/src/app/shared/directives/dropdown-toggle.directive.ts
+++ b/client/src/app/shared/directives/dropdown-toggle.directive.ts
@@ -1,5 +1,6 @@
 import { Directive, ElementRef, inject, OnDestroy } from '@angular/core';
 import { DismissableStackService } from '../../core/services/dismissable-stack.service';
+import { TABBABLE_SELECTOR } from '../../core/services/focusable.constants';
 
 /**
  * Click-driven `.dropdown-open` toggle for any DaisyUI dropdown trigger.
@@ -16,8 +17,6 @@ import { DismissableStackService } from '../../core/services/dismissable-stack.s
  *     <div class="dropdown-content">…</div>
  *   </div>
  */
-const MENU_FOCUSABLE_SELECTOR =
-  'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 @Directive({
   selector: '[appDropdownToggle]',
@@ -80,7 +79,7 @@ export class DropdownToggleDirective implements OnDestroy {
     // and keyboard users can act without an extra Tab. Standard ARIA
     // menu pattern.
     queueMicrotask(() => {
-      const first = content?.querySelector<HTMLElement>(MENU_FOCUSABLE_SELECTOR);
+      const first = content?.querySelector<HTMLElement>(TABBABLE_SELECTOR);
       first?.focus({ preventScroll: true });
     });
     const close = () => {
@@ -108,7 +107,7 @@ export class DropdownToggleDirective implements OnDestroy {
     this.tabKeyHandler = (e: KeyboardEvent) => {
       if (e.key !== 'Tab' || !content) return;
       const items = Array.from(
-        content.querySelectorAll<HTMLElement>(MENU_FOCUSABLE_SELECTOR),
+        content.querySelectorAll<HTMLElement>(TABBABLE_SELECTOR),
       );
       if (!items.length) return;
       const first = items[0];

--- a/client/src/app/shared/directives/tv-row.directive.ts
+++ b/client/src/app/shared/directives/tv-row.directive.ts
@@ -1,6 +1,7 @@
 import { Directive, ElementRef, HostListener, inject, OnDestroy, OnInit, input } from '@angular/core';
 import { TvSpatialNavService } from '../../core/services/tv-spatial-nav.service';
 import { TvService } from '../../core/services/tv.service';
+import { rowTopOffset, snapRowOnFocus } from '../../core/utils/focus-snap.util';
 
 /**
  * Horizontal-orientation container in the spatial-nav tree. `←/→` step
@@ -47,27 +48,6 @@ export class TvRowDirective implements OnInit, OnDestroy {
   @HostListener('focusin', ['$event'])
   protected onFocusIn(event: FocusEvent): void {
     if (!this.appTvRowSnap()) return;
-    const from = event.relatedTarget as Node | null;
-    if (from && this.host.nativeElement.contains(from)) return;
-    queueMicrotask(() => this.snapToRowTop());
-  }
-
-  private snapToRowTop(): void {
-    if (typeof window === 'undefined') return;
-    const scrollEl = document.scrollingElement ?? document.documentElement;
-    const rect = this.host.nativeElement.getBoundingClientRect();
-    const currentTop = scrollEl.scrollTop ?? 0;
-    const TOP_OFFSET = this.tv.isTv() ? 96 : 24;
-    // Skip when the row is already fully visible: the user is just walking
-    // between visible rows, no scroll needed.
-    const viewportH = window.innerHeight;
-    if (rect.top >= TOP_OFFSET && rect.bottom <= viewportH) return;
-    const targetTop = Math.max(0, currentTop + rect.top - TOP_OFFSET);
-    if (Math.abs(targetTop - currentTop) < 4) return;
-    try {
-      window.scrollTo({ top: targetTop, left: 0, behavior: 'smooth' });
-    } catch {
-      window.scrollTo(0, targetTop);
-    }
+    snapRowOnFocus(event, this.host.nativeElement, rowTopOffset(this.tv.isTv()));
   }
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -392,6 +392,16 @@ body:not(.keyboard-modality):not(.tv) app-mosaic-card button:focus-visible .mosa
   z-index: 1;
   position: relative;
 }
+/* Default radius for the ring above, so a bare focusable (a section heading,
+   a plain link) doesn't get a rectangle around it and no component has to
+   remember its own. On an element with no background or border a radius paints
+   nothing, so this is invisible until focus. In `base`, so a `rounded-*`
+   utility or a daisyUI component radius still wins. */
+@layer base {
+  :is(a, button, select, input, [role="button"], [tabindex]) {
+    @apply rounded-lg;
+  }
+}
 /* The floating player cues position themselves absolutely via inline right /
    bottom offsets. The generic ring above forces `position: relative` (and a low
    z-index), which would re-anchor those offsets to the cue's in-flow origin and


### PR DESCRIPTION
## Symptoms fixed

- **Arrow keys walked sideways.** On the genre line, the video/audio/subtitle pickers and the episode list view, ↓ moved to the next item on the same line instead of the next row. Each holds several focusables with no row container, so the page's vertical `[appTvSection]` counted them as its own children and stepped through them one at a time. They carry `[appTvRow]` now: ←/→ inside, ↑/↓ between.
- **A collapsed section was a dead end.** Its content stays laid out — clipped, and `inert`. It measures as visible, so the D-pad handed focus to something that refuses it and the move died there. `inert` is now an opt-out rule.
- **The focus ring got clipped**, on the left of a rail inside a fold and on top of the cast row. Two different clippers: the fold's `overflow-hidden`, and `content-visibility: auto`, which paints under containment. The fold's clip now only lives as long as the animation; the cast wrapper pads for the ring.

## The duplication behind them

Adding the `inert` rule took three edits, which is the actual bug:

| Was | Now |
|---|---|
| Focusability decided in `collectFocusables`, `isVisibleFocusable` and `DefaultFocusService.isVisible` | one `isFocusCandidate()` / `isRendered()` in `focusable.constants.ts` |
| `snapToRowTop` implemented twice, verbatim (`horizontal-scroller`, `[appTvRowSnap]`) | one `snapRowOnFocus()` in `core/utils/focus-snap.util.ts` |
| Trap selector copy-pasted in `bottom-sheet` and `dropdown-toggle` | `TABBABLE_SELECTOR` |
| `.flex.overflow-x-auto, [data-scroller]` hardcoded twice | `SCROLLER_SELECTOR`, and the rail now carries `data-scroller` instead of being matched by its Tailwind classes |
| Cold-load focus: `all[0]` on TV boot, the page's declared default elsewhere | both use the declared default |

Two divergences surfaced while merging them:

- The tree step rejected zero-size elements with `&&` (width **and** height), the document scan with `||`. A collapsed row — zero height, full width — still passed the tree. Unified on `||`.
- Only the scroller's snap had yesterday's "don't follow a mouse click" guard; `[appTvRowSnap]` rows (the top-right dock) kept dragging the page on click. Shared now.

## Focus ring radius

`@layer base` default in `styles.css` instead of a `rounded-*` on each component (removed from the section heading and both genre buttons). Tailwind declares its layer order up front, so every `rounded-*` utility and daisyUI component radius still wins — verified in the built stylesheet. Applied outside `:focus-visible` too: a radius paints nothing on an element with no background, so it stays invisible until the ring appears.

## Not touched

- Five other `<li>` rows with 2+ focusables and no `[appTvRow]` (`profile-connections`, `setup-checklist`, `follow-requests-card`, `pending-requests`, `privacy`) — same shape, but I haven't seen them on screen and on some the current order may be what you want.
- The overlay focus trap covers no `input`/`select`/`textarea`, so Tab can escape a sheet holding a field. Widening it changes every overlay and deserves its own test.

## Test

4 new tests on the opt-out rules, including a deep `inert` subtree (jsdom has no layout, so the rendered half isn't unit-testable — it's split out for exactly that reason). 89 passing, build clean.