### PR TITLE
feat(dashboard): link the media title in the recent-subtitles table

### DIFF
--- a/backend/src/modules/subtitles/subtitle-activity.controller.ts
+++ b/backend/src/modules/subtitles/subtitle-activity.controller.ts
@@ -165,6 +165,7 @@ export class SubtitleActivityController {
         id: sf.id,
         mediaId: sf.mediaId,
         mediaTitle: sf.media?.title ?? '?',
+        mediaType: sf.media?.type ?? null,
         ...episodeScope(sf),
         language: sf.language,
         providerType: sf.providerType,

--- a/client/src/app/core/services/api/subtitles-api.service.ts
+++ b/client/src/app/core/services/api/subtitles-api.service.ts
@@ -245,6 +245,7 @@ export interface SubtitleStats {
     id: number;
     mediaId: number;
     mediaTitle: string;
+    mediaType: 'movie' | 'series' | null;
     episodeId: number | null;
     seasonNumber: number | null;
     episodeNumber: number | null;

--- a/client/src/app/features/dashboard/dashboard.html
+++ b/client/src/app/features/dashboard/dashboard.html
@@ -146,7 +146,10 @@
                 @for (r of sub.recent; track r.id) {
                   <tr>
                     <td class="font-medium max-w-[12rem]" [title]="r.mediaTitle">
-                      <span class="block truncate">{{ r.mediaTitle }}</span>
+                      <a
+                        [routerLink]="['/', r.mediaType === 'series' ? 'series' : 'movies', r.mediaId]"
+                        class="link link-hover block truncate"
+                      >{{ r.mediaTitle }}</a>
                       @if (episodeLabel(r)) {
                         <span class="block text-xs font-normal text-base-content/60 truncate" [title]="episodeLabel(r)">
                           @if (r.episodeId != null) {


### PR DESCRIPTION
## What

In admin statistics → subtitles → recent, the episode line under the title was already a link while the film / series title above it was plain text. It links now, to `/movies/:id` or `/series/:id`.

## How

`GET /api/subtitles/stats` didn't carry the media type, which the row needs to pick the route — the activity endpoint in the same controller already exposed it, so this is one field added to the `recent` mapper (the `media` relation was already loaded).

## Test

Backend `tsc` clean, client build clean.