### PR TITLE
fix(tmdb-preview): translate the original language and match the desktop date format

### DIFF
--- a/client/src/app/features/tmdb-preview/tmdb-preview.html
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.html
@@ -90,25 +90,25 @@
         @if (m.originalLanguage) {
           <div>
             <span class="text-base-content/50 block">{{ 'discover.preview_original_language' | translate }}</span>
-            <span class="font-medium">{{ m.originalLanguage }}</span>
+            <span class="font-medium">{{ originalLanguageLabel() }}</span>
           </div>
         }
         @if (m.releaseDate) {
           <div>
             <span class="text-base-content/50 block">{{ 'discover.preview_release_date' | translate }}</span>
-            <span class="font-medium">{{ m.releaseDate | localeDate }}</span>
+            <span class="font-medium">{{ m.releaseDate | localeDate:{ dateStyle: 'long' } }}</span>
           </div>
         }
         @if (m.inCinemas) {
           <div>
             <span class="text-base-content/50 block">{{ 'discover.preview_in_cinemas' | translate }}</span>
-            <span class="font-medium">{{ m.inCinemas | localeDate }}</span>
+            <span class="font-medium">{{ m.inCinemas | localeDate:{ dateStyle: 'long' } }}</span>
           </div>
         }
         @if (m.digitalRelease) {
           <div>
             <span class="text-base-content/50 block">{{ 'discover.preview_digital' | translate }}</span>
-            <span class="font-medium">{{ m.digitalRelease | localeDate }}</span>
+            <span class="font-medium">{{ m.digitalRelease | localeDate:{ dateStyle: 'long' } }}</span>
           </div>
         }
         @if (m.productionCountries.length) {
@@ -213,7 +213,7 @@
           @if (m.originalLanguage) {
             <div>
               <span class="text-base-content/50 block">{{ 'discover.preview_original_language' | translate }}</span>
-              <span class="font-medium">{{ m.originalLanguage }}</span>
+              <span class="font-medium">{{ originalLanguageLabel() }}</span>
             </div>
           }
           @if (m.releaseDate) {

--- a/client/src/app/features/tmdb-preview/tmdb-preview.ts
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.ts
@@ -34,6 +34,7 @@ import { MobileFanartHeroComponent } from '../../shared/components/mobile-fanart
 import { HorizontalScrollerComponent } from '../../shared/components/horizontal-scroller';
 import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
 import { LocaleDatePipe } from '../../core/pipes/locale-date.pipe';
+import { localizeLanguage } from '../../core/utils/language.utils';
 import { ClampToggleDirective } from '../../shared/directives/clamp-toggle.directive';
 
 @Component({
@@ -132,6 +133,10 @@ export class TmdbPreviewComponent implements OnInit, OnDestroy {
   });
   readonly directorsLabel = computed(() =>
     this.directors().map((d) => d.name).join(', '),
+  );
+
+  readonly originalLanguageLabel = computed(() =>
+    localizeLanguage(this.media()?.originalLanguage, this.translate),
   );
 
   /** i18n key for the provider status (lowercased, spaces → underscores). */


### PR DESCRIPTION
## What

On `/add/movie/…`, the mobile layout showed the raw provider language code (`en`) where the library's media page shows `Anglais`, and its three dates rendered as `29/07/2026` while the desktop block beside them rendered `29 juillet 2026`.

Both were layout-local omissions, not platform differences — a phone gets the `md:hidden` block, a wide window the other one.

## How

- `originalLanguageLabel` runs the code through the same `localizeLanguage()` the media page uses; an untranslated code still falls back to the raw value.
- The three mobile dates pass `{ dateStyle: 'long' }`, like the four desktop ones. The pipe's numeric default is left alone — it suits the tables (blocklist, user requests) that rely on it.

## Test

Client build clean.