### PR TITLE
feat(tmdb-preview): show a type badge and a season browser for series

### DIFF
--- a/backend/src/modules/metadata-providers/interfaces/metadata-provider.interface.ts
+++ b/backend/src/modules/metadata-providers/interfaces/metadata-provider.interface.ts
@@ -29,6 +29,8 @@ export interface MetadataDetails extends MetadataSearchResult {
    *  has no additional artwork. */
   additionalFanartUrls: string[];
   runtime: number | null;
+  seasonCount: number | null;
+  episodeCount: number | null;
   releaseDate: string | null;
   inCinemas: string | null;
   digitalRelease: string | null;

--- a/backend/src/modules/metadata-providers/providers/tmdb-api.types.ts
+++ b/backend/src/modules/metadata-providers/providers/tmdb-api.types.ts
@@ -153,6 +153,8 @@ export interface TmdbTvDetailsResponse {
   genres?: TmdbNamed[];
   external_ids?: { imdb_id?: string | null };
   episode_run_time?: number[];
+  number_of_seasons?: number;
+  number_of_episodes?: number;
   status?: string;
   original_language?: string;
   origin_country?: string[];

--- a/backend/src/modules/metadata-providers/providers/tmdb.provider.ts
+++ b/backend/src/modules/metadata-providers/providers/tmdb.provider.ts
@@ -245,6 +245,8 @@ export class TmdbProvider implements IMetadataProvider {
     return {
       tmdbId: data.id,
       tvdbId: null,
+      seasonCount: null,
+      episodeCount: null,
       imdbId: data.external_ids?.imdb_id ?? data.imdb_id ?? null,
       provider: 'tmdb',
       title: data.title,
@@ -356,6 +358,8 @@ export class TmdbProvider implements IMetadataProvider {
       genres: data.genres?.map((g: TmdbNamed) => g.name) ?? [],
       mediaType: 'series',
       runtime: data.episode_run_time?.[0] ?? null,
+      seasonCount: data.number_of_seasons ?? null,
+      episodeCount: data.number_of_episodes ?? null,
       releaseDate: data.first_air_date ?? null,
       inCinemas: null,
       digitalRelease: null,

--- a/backend/src/modules/metadata-providers/providers/tvdb.provider.ts
+++ b/backend/src/modules/metadata-providers/providers/tvdb.provider.ts
@@ -155,6 +155,8 @@ export class TvdbProvider implements IMetadataProvider {
     const imdbId = this.extractRemoteId(m.remoteIds, 'IMDB');
 
     return {
+      seasonCount: null,
+      episodeCount: null,
       tmdbId: parseInt(
         this.extractRemoteId(m.remoteIds, 'TheMovieDB.com') ?? '0',
         10,
@@ -232,6 +234,8 @@ export class TvdbProvider implements IMetadataProvider {
     const imdbId = this.extractRemoteId(s.remoteIds, 'IMDB');
 
     return {
+      seasonCount: (s.seasons ?? []).filter((x: { number?: number }) => x.number !== 0).length || null,
+      episodeCount: null,
       tmdbId: parseInt(
         this.extractRemoteId(s.remoteIds, 'TheMovieDB.com') ?? '0',
         10,

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -649,6 +649,7 @@
     "clear": "Löschen"
   },
   "discover": {
+    "seasons_failed": "Staffeln konnten nicht geladen werden",
     "title": "Zur Bibliothek hinzufügen",
     "subtitle": "Suche in The Movie Database (TMDB) — wie in Radarr / Sonarr.",
     "tab_movies": "Filme",
@@ -805,6 +806,8 @@
     "details": "Details"
   },
   "media_detail": {
+    "season_count_one": "{{count}} Staffel",
+    "season_count_other": "{{count}} Staffeln",
     "part_of": "Teil von {{name}}",
     "similar": "Ähnliche Filme",
     "cast": "Besetzung",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -654,6 +654,7 @@
     "clear": "Clear"
   },
   "discover": {
+    "seasons_failed": "Could not load the seasons",
     "title": "Add to library",
     "subtitle": "Search on The Movie Database (TMDB) — like in Radarr / Sonarr.",
     "tab_movies": "Movies",
@@ -810,6 +811,8 @@
     "details": "Details"
   },
   "media_detail": {
+    "season_count_one": "{{count}} season",
+    "season_count_other": "{{count}} seasons",
     "part_of": "Part of {{name}}",
     "similar": "Similar movies",
     "cast": "Cast",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -649,6 +649,7 @@
     "clear": "Borrar"
   },
   "discover": {
+    "seasons_failed": "No se pudieron cargar las temporadas",
     "title": "Añadir a la biblioteca",
     "subtitle": "Búsqueda en The Movie Database (TMDB) — como en Radarr / Sonarr.",
     "tab_movies": "Películas",
@@ -805,6 +806,8 @@
     "details": "Detalles"
   },
   "media_detail": {
+    "season_count_one": "{{count}} temporada",
+    "season_count_other": "{{count}} temporadas",
     "part_of": "Parte de {{name}}",
     "similar": "Películas similares",
     "cast": "Reparto",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -654,6 +654,7 @@
     "clear": "Effacer"
   },
   "discover": {
+    "seasons_failed": "Impossible de charger les saisons",
     "title": "Ajouter à la bibliothèque",
     "subtitle": "Recherche sur The Movie Database (TMDB) — comme dans Radarr / Sonarr.",
     "tab_movies": "Films",
@@ -810,6 +811,8 @@
     "details": "Détails"
   },
   "media_detail": {
+    "season_count_one": "{{count}} saison",
+    "season_count_other": "{{count}} saisons",
     "part_of": "Inclus dans {{name}}",
     "similar": "Films similaires",
     "cast": "Casting",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -649,6 +649,7 @@
     "clear": "Cancella"
   },
   "discover": {
+    "seasons_failed": "Impossibile caricare le stagioni",
     "title": "Aggiungi alla libreria",
     "subtitle": "Ricerca su The Movie Database (TMDB) — come in Radarr / Sonarr.",
     "tab_movies": "Film",
@@ -805,6 +806,8 @@
     "details": "Dettagli"
   },
   "media_detail": {
+    "season_count_one": "{{count}} stagione",
+    "season_count_other": "{{count}} stagioni",
     "part_of": "Fa parte di {{name}}",
     "similar": "Film simili",
     "cast": "Cast",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -649,6 +649,7 @@
     "clear": "Limpar"
   },
   "discover": {
+    "seasons_failed": "Não foi possível carregar as temporadas",
     "title": "Adicionar à biblioteca",
     "subtitle": "Pesquisa no The Movie Database (TMDB) — como no Radarr / Sonarr.",
     "tab_movies": "Filmes",
@@ -805,6 +806,8 @@
     "details": "Detalhes"
   },
   "media_detail": {
+    "season_count_one": "{{count}} temporada",
+    "season_count_other": "{{count}} temporadas",
     "part_of": "Parte de {{name}}",
     "similar": "Filmes semelhantes",
     "cast": "Elenco",

--- a/client/src/app/core/services/api/metadata.service.ts
+++ b/client/src/app/core/services/api/metadata.service.ts
@@ -49,6 +49,8 @@ export interface MetadataDetails extends MetadataSearchResult {
   /** Transparent PNG "clearlogo" title treatment when the provider has one. */
   logoUrl: string | null;
   runtime: number | null;
+  seasonCount: number | null;
+  episodeCount: number | null;
   releaseDate: string | null;
   inCinemas: string | null;
   digitalRelease: string | null;
@@ -70,9 +72,22 @@ export interface MetadataDetails extends MetadataSearchResult {
   tmdbCollectionName: string | null;
 }
 
-export interface SeasonStub {
+export interface MetadataEpisode {
+  episodeNumber: number;
+  title: string;
+  overview: string | null;
+  airDate: string | null;
+  runtime: number | null;
+  stillUrl: string | null;
+}
+
+export interface MetadataSeason {
   seasonNumber: number;
   episodeCount: number;
+  overview: string | null;
+  airDate: string | null;
+  posterUrl: string | null;
+  episodes: MetadataEpisode[];
 }
 
 /** A TMDB genre (id + localized name). */
@@ -158,7 +173,15 @@ export class MetadataService {
 
   getTvSeasons(tmdbId: number) {
     return firstValueFrom(
-      this.http.get<SeasonStub[]>(`/api/metadata/tv/${tmdbId}/seasons`),
+      this.http.get<MetadataSeason[]>(`/api/metadata/tv/${tmdbId}/seasons`),
+    );
+  }
+
+  getSeasons(provider: string, externalId: string) {
+    return firstValueFrom(
+      this.http.get<MetadataSeason[]>(
+        `/api/metadata/${provider}/tv/${externalId}/seasons`,
+      ),
     );
   }
 

--- a/client/src/app/features/tmdb-preview/components/preview-seasons/preview-seasons.component.html
+++ b/client/src/app/features/tmdb-preview/components/preview-seasons/preview-seasons.component.html
@@ -1,0 +1,103 @@
+@if (loading()) {
+  <div class="flex justify-center py-8">
+    <span class="loading loading-spinner"></span>
+  </div>
+} @else if (failed()) {
+  <p class="text-sm text-warning py-2">{{ 'discover.seasons_failed' | translate }}</p>
+} @else if (seasons().length) {
+  <div appTvRow class="flex flex-wrap items-center gap-2 mb-4">
+    @for (s of seasons(); track s.seasonNumber) {
+      <button
+        type="button"
+        class="btn btn-sm"
+        [class.btn-primary]="s.seasonNumber === activeSeasonNumber()"
+        [class.btn-ghost]="s.seasonNumber !== activeSeasonNumber()"
+        (click)="selectSeason(s.seasonNumber)"
+      >
+        {{ 'media_detail.season' | translate }} {{ s.seasonNumber }}
+        <span class="opacity-60 tabular-nums">{{ s.episodeCount }}</span>
+      </button>
+    }
+  </div>
+
+  @if (activeSeason(); as season) {
+    @if (season.airDate || season.overview) {
+      <div class="mb-4 text-sm text-base-content/70 space-y-1">
+        @if (season.airDate) {
+          <p class="tabular-nums">{{ season.airDate | localeDate:{ dateStyle: 'long' } }}</p>
+        }
+        @if (season.overview) {
+          <p
+            [appClampToggle]="season.overview"
+            #syn="clampToggle"
+            [class.line-clamp-3]="!syn.expanded()"
+          >{{ season.overview }}</p>
+          @if (syn.showToggle()) {
+            <button
+              type="button"
+              class="link link-primary no-underline hover:underline text-sm"
+              (click)="syn.toggle()"
+            >
+              {{ (syn.expanded() ? 'common.show_less' : 'common.show_more') | translate }}
+            </button>
+          }
+        }
+      </div>
+    }
+
+    <ul class="divide-y divide-base-content/10 border-t border-base-content/10">
+      @for (ep of season.episodes; track ep.episodeNumber) {
+        <li appTvRow class="grid grid-cols-[auto_1fr] gap-x-3 sm:gap-x-4 gap-y-1.5 py-3">
+          <div class="w-28 sm:w-48 lg:w-56 shrink-0 sm:row-span-2">
+            <div class="aspect-video rounded-lg overflow-hidden bg-base-300/40">
+              @if (ep.stillUrl) {
+                <img
+                  appImgFadeIn
+                  [src]="ep.stillUrl"
+                  [alt]="ep.title"
+                  class="w-full h-full object-cover"
+                  loading="lazy"
+                  decoding="async"
+                />
+              }
+            </div>
+          </div>
+
+          <div class="min-w-0 flex flex-col gap-0.5 sm:gap-1">
+            <p class="text-base sm:text-lg font-medium">
+              <span class="text-base-content/50 tabular-nums mr-1.5">{{ ep.episodeNumber }}</span>
+              {{ ep.title }}
+            </p>
+            <span class="text-sm text-base-content/50 tabular-nums">
+              @if (ep.airDate) { {{ ep.airDate | localeDate:{ dateStyle: 'medium' } }} }
+              @if (ep.airDate && ep.runtime) { · }
+              @if (ep.runtime) { {{ ep.runtime }}min }
+            </span>
+          </div>
+
+          <div class="col-span-2 sm:col-span-1 sm:col-start-2">
+            @if (ep.overview) {
+              <p
+                [appClampToggle]="ep.overview"
+                #epSyn="clampToggle"
+                class="text-sm sm:text-base text-base-content/70"
+                [class.line-clamp-3]="!epSyn.expanded()"
+              >{{ ep.overview }}</p>
+              @if (epSyn.showToggle()) {
+                <button
+                  type="button"
+                  class="link link-primary no-underline hover:underline text-sm mt-0.5"
+                  (click)="epSyn.toggle()"
+                >
+                  {{ (epSyn.expanded() ? 'common.show_less' : 'common.show_more') | translate }}
+                </button>
+              }
+            } @else {
+              <p class="text-sm sm:text-base text-base-content/35 italic">{{ 'media_detail.ep_no_overview' | translate }}</p>
+            }
+          </div>
+        </li>
+      }
+    </ul>
+  }
+}

--- a/client/src/app/features/tmdb-preview/components/preview-seasons/preview-seasons.component.ts
+++ b/client/src/app/features/tmdb-preview/components/preview-seasons/preview-seasons.component.ts
@@ -1,0 +1,75 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import {
+  MetadataSeason,
+  MetadataService,
+} from '../../../../core/services/api/metadata.service';
+import { LocaleDatePipe } from '../../../../core/pipes/locale-date.pipe';
+import { ImgFadeInDirective } from '../../../../shared/directives/img-fade-in.directive';
+import { ClampToggleDirective } from '../../../../shared/directives/clamp-toggle.directive';
+import { TvRowDirective } from '../../../../shared/directives/tv-row.directive';
+
+@Component({
+  selector: 'app-preview-seasons',
+  imports: [
+    TranslateModule,
+    LocaleDatePipe,
+    ImgFadeInDirective,
+    ClampToggleDirective,
+    TvRowDirective,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './preview-seasons.component.html',
+  host: { class: 'block' },
+})
+export class PreviewSeasonsComponent {
+  private readonly metadata = inject(MetadataService);
+
+  readonly provider = input.required<string>();
+  readonly externalId = input.required<string>();
+
+  readonly seasons = signal<MetadataSeason[]>([]);
+  readonly loading = signal(false);
+  readonly failed = signal(false);
+  readonly activeSeasonNumber = signal<number | null>(null);
+
+  readonly activeSeason = computed(
+    () =>
+      this.seasons().find((s) => s.seasonNumber === this.activeSeasonNumber()) ??
+      null,
+  );
+
+  /**
+   * One provider call per season upstream, so it waits for the section to be
+   * opened rather than firing on every series preview.
+   */
+  private readonly loadEffect = effect(() => {
+    const id = this.externalId();
+    const provider = this.provider();
+    if (!id) return;
+    this.seasons.set([]);
+    this.activeSeasonNumber.set(null);
+    this.failed.set(false);
+    this.loading.set(true);
+    this.metadata
+      .getSeasons(provider, id)
+      .then((seasons) => {
+        this.seasons.set(seasons);
+        this.activeSeasonNumber.set(seasons[0]?.seasonNumber ?? null);
+      })
+      .catch(() => this.failed.set(true))
+      .finally(() => this.loading.set(false));
+  });
+
+  selectSeason(seasonNumber: number) {
+    this.activeSeasonNumber.set(seasonNumber);
+  }
+}

--- a/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.ts
+++ b/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { MetadataService, SeasonStub } from '../../../../core/services/api/metadata.service';
+import { MetadataService, MetadataSeason } from '../../../../core/services/api/metadata.service';
 import { RequestsService } from '../../../../core/services/api/requests.service';
 import { LibrarySummary } from '../../../../core/services/api/libraries-api.service';
 import { ToastService } from '../../../../core/services/toast.service';
@@ -48,7 +48,7 @@ export class RequestModalComponent {
   readonly libraryId = signal<number | null>(null);
   readonly requesting = signal(false);
 
-  readonly seasons = signal<SeasonStub[]>([]);
+  readonly seasons = signal<MetadataSeason[]>([]);
   readonly selectedSeasons = signal<Set<number>>(new Set());
   readonly seasonsLoading = signal(false);
   /** Season numbers already covered by an active request — passed in by

--- a/client/src/app/features/tmdb-preview/tmdb-preview.html
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.html
@@ -29,7 +29,9 @@
         }
         @if (m.year) { <span>{{ m.year }}</span> }
         @if (m.runtime) { <span>{{ m.runtime }}min</span> }
+        @if (seasonsLabel()) { <span>{{ seasonsLabel() }}</span> }
         @if (m.status && m.status !== 'unknown') { <span>{{ statusKey() | translate }}</span> }
+        <span class="badge badge-outline badge-sm">{{ typeLabelKey() | translate }}</span>
       </div>
 
       @if (m.genres.length) {
@@ -159,7 +161,9 @@
           }
           @if (m.year) { <span>{{ m.year }}</span> }
           @if (m.runtime) { <span>{{ m.runtime }}min</span> }
+          @if (seasonsLabel()) { <span>{{ seasonsLabel() }}</span> }
           @if (m.status && m.status !== 'unknown') { <span>{{ statusKey() | translate }}</span> }
+          <span class="badge badge-outline">{{ typeLabelKey() | translate }}</span>
         </div>
 
         @if (m.genres.length) {
@@ -278,6 +282,17 @@
       </div>
     </div>
   </div>
+
+  @if (type() === 'series') {
+    <section class="px-1 md:px-0 mt-8">
+      <app-collapsible-section
+        [heading]="'media_detail.seasons_section' | translate"
+        persistKey="previewSeasons"
+      >
+        <app-preview-seasons [provider]="provider()" [externalId]="externalId()" />
+      </app-collapsible-section>
+    </section>
+  }
 
   <!-- Cast (shared mobile + desktop) -->
   @if (topCast().length) {

--- a/client/src/app/features/tmdb-preview/tmdb-preview.ts
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.ts
@@ -36,10 +36,12 @@ import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
 import { LocaleDatePipe } from '../../core/pipes/locale-date.pipe';
 import { localizeLanguage } from '../../core/utils/language.utils';
 import { ClampToggleDirective } from '../../shared/directives/clamp-toggle.directive';
+import { CollapsibleSectionComponent } from '../../shared/components/collapsible-section/collapsible-section';
+import { PreviewSeasonsComponent } from './components/preview-seasons/preview-seasons.component';
 
 @Component({
   selector: 'app-tmdb-preview',
-  imports: [FormsModule, CurrencyPipe, DecimalPipe, TranslateModule, ResolveUrlPipe, LocaleDatePipe, RequestModalComponent, ImportModalComponent, MobileFanartHeroComponent, HorizontalScrollerComponent, ClampToggleDirective, LucideFilm, LucideUser, LucidePlay, LucidePlus],
+  imports: [FormsModule, CurrencyPipe, DecimalPipe, TranslateModule, ResolveUrlPipe, LocaleDatePipe, RequestModalComponent, ImportModalComponent, MobileFanartHeroComponent, HorizontalScrollerComponent, ClampToggleDirective, CollapsibleSectionComponent, PreviewSeasonsComponent, LucideFilm, LucideUser, LucidePlay, LucidePlus],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './tmdb-preview.html',
 })
@@ -134,6 +136,24 @@ export class TmdbPreviewComponent implements OnInit, OnDestroy {
   readonly directorsLabel = computed(() =>
     this.directors().map((d) => d.name).join(', '),
   );
+
+  readonly typeLabelKey = computed(() =>
+    this.type() === 'series' ? 'requests.type_series' : 'requests.type_movie',
+  );
+
+  readonly seasonsLabel = computed(() => {
+    const m = this.media();
+    if (this.type() !== 'series' || !m?.seasonCount) return '';
+    const plural = (key: string, count: number) =>
+      this.translate.instant(
+        `media_detail.${key}_${count <= 1 ? 'one' : 'other'}`,
+        { count },
+      );
+    const seasons = plural('season_count', m.seasonCount);
+    return m.episodeCount
+      ? `${seasons} · ${plural('episode_count', m.episodeCount)}`
+      : seasons;
+  });
 
   readonly originalLanguageLabel = computed(() =>
     localizeLanguage(this.media()?.originalLanguage, this.translate),


### PR DESCRIPTION
## What

The add page (`/add/tv/…`) rendered a series exactly like a film — nothing said which one you were looking at, and nothing said what the show contains.

- **Type badge** — `Film` / `Série` in the metadata line of both layouts, reusing the existing `requests.type_*` labels.
- **Counts** — `8 saisons · 73 épisodes` beside the runtime, for series.
- **Season browser** — a foldable "Saisons & épisodes" section before the cast, shaped like the library's series page: season picker with per-season episode counts, the season's air date and synopsis, then one row per episode with its still, number, title, air date, runtime and synopsis.

## How

`GET /api/metadata/:provider/tv/:id/seasons` already returned every field the view needs — the client's `SeasonStub` type only declared two of the six, so it becomes `MetadataSeason` / `MetadataEpisode`.

The counts are new: `seasonCount` / `episodeCount` on the provider DTO, read from `number_of_seasons` / `number_of_episodes` in the detail response TMDB already returns, so no extra upstream call. Null for movies and for TVDB, which counts its non-specials seasons instead.

The new `app-preview-seasons` reuses `app-collapsible-section`, `appClampToggle` and `appImgFadeIn`, and each episode row carries `[appTvRow]` so arrow keys step between episodes rather than through the three targets inside one row — the bug fixed page-wide in #835, avoided here from the start.

## Caveat

That endpoint makes one upstream TMDB call **per season** (9 for Game of Thrones). The section is open by default with a spinner, since browsing seasons is the point of the page. Trivially switched to load-on-expand if it reads slow.

## Test

Verified against the live API on tmdb/1399: 8 seasons, 73 episodes, and full per-episode detail (title, air date, runtime, still, synopsis). Backend `tsc` clean, client build clean, 89 tests passing.