### PR TITLE
fix(media-detail): keep a card rail scrolling inside a collapsible section

### DIFF
--- a/client/src/app/shared/components/collapsible-section/collapsible-section.html
+++ b/client/src/app/shared/components/collapsible-section/collapsible-section.html
@@ -17,7 +17,10 @@
   class="grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none"
   [style.grid-template-rows]="open() ? '1fr' : '0fr'"
 >
-  <div [class.overflow-hidden]="clipped()" [attr.inert]="open() ? null : ''">
+  <!-- min-w-0: a grid item only shrinks below its content when its overflow is
+       clipped, and the clip goes away once open — without it a card rail widens
+       the page instead of scrolling inside its own box. -->
+  <div class="min-w-0" [class.overflow-hidden]="clipped()" [attr.inert]="open() ? null : ''">
     <div class="mt-3">
       <ng-content />
     </div>


### PR DESCRIPTION
## Symptom

"Films similaires", "Inclus dans" and the other rails inside a foldable section stopped scrolling: the row ran off the screen and dragged a horizontal scrollbar onto the whole page, instead of staying in its box behind the custom arrows.

## Cause

Mine, from #835. Removing the section's clip once it finishes opening — so the focus ring stops being cut — also removed what kept the rail narrow: a grid item's `min-width: auto` resolves to its content width, and the exception that turns it into `0` only applies while the item's overflow is clipped. While the clip was permanent the rail was constrained and scrolled internally; without it, it grew.

## Fix

`min-w-0` on that item, which is the explicit form of what the clip was doing implicitly. Both states keep their intent: clipped while folding, ring free to bleed once open, rail always bounded.

## Test

Client build clean.