### PR TITLE
ci(appletv): publish signed tvOS builds to App Store Connect on release tags

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -39,7 +39,8 @@
         "client/android/app/build.gradle",
         "client/src/environments/environment.ts",
         "cast-receiver/index.html",
-        "client/ios/App/App.xcodeproj/project.pbxproj"
+        "client/ios/App/App.xcodeproj/project.pbxproj",
+        "appletv/project.yml"
       ]
     }
   }

--- a/.github/workflows/tvos-publish.yml
+++ b/.github/workflows/tvos-publish.yml
@@ -1,0 +1,149 @@
+# Builds a signed IPA of the Fliks tvOS app and uploads it to App Store
+# Connect on every release tag (`v*` produced by release-please) plus on
+# manual `workflow_dispatch`. The build lands in TestFlight after Apple's
+# processing (~10-30 min); promotion to the public App Store still requires
+# clicking "Submit for Review" from App Store Connect.
+#
+# Marketing version comes from `appletv/project.yml`, which release-please
+# bumps along with the other clients, so the tag and the uploaded build always
+# agree. Build number comes from `git rev-list --count HEAD`, shared with the
+# iOS workflow — Apple rejects a build number it has already seen, and a
+# commit count only ever grows.
+#
+# Uses the same secrets as the iOS workflow (an Apple Distribution certificate
+# covers every platform of the team):
+#   - APPSTORE_API_KEY_ID / APPSTORE_API_ISSUER_ID / APPSTORE_API_KEY_P8_BASE64
+#   - IOS_DIST_CERT_P12_BASE64 / IOS_DIST_CERT_PASSWORD
+#   - IOS_DEV_CERT_P12_BASE64 / IOS_DEV_CERT_PASSWORD
+#   - APPLE_TEAM_ID
+#
+# One-shot setup outside this repo: an App Store Connect app record for the
+# tvOS platform on bundle id `media.fliks.tv`.
+name: Publish tvOS to App Store Connect
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    runs-on: macos-15
+    defaults:
+      run:
+        working-directory: appletv
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history → `git rev-list --count HEAD` gives a real commit
+          # count for the build number.
+          fetch-depth: 0
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      # The .xcodeproj isn't versioned — XcodeGen rebuilds it from project.yml.
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate the Xcode project
+        run: xcodegen generate --spec project.yml
+
+      - name: Compute build number from commit count
+        id: bnum
+        run: echo "value=$(git rev-list --count HEAD)" >> "$GITHUB_OUTPUT"
+        working-directory: ${{ github.workspace }}
+
+      # Xcode discovers the key at this exact path, so the decode is all the
+      # staging it needs.
+      - name: Stage App Store Connect API key
+        env:
+          KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+          KEY_P8: ${{ secrets.APPSTORE_API_KEY_P8_BASE64 }}
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo "$KEY_P8" | base64 -d \
+            > ~/.appstoreconnect/private_keys/AuthKey_$KEY_ID.p8
+          chmod 600 ~/.appstoreconnect/private_keys/AuthKey_$KEY_ID.p8
+
+      # Import the team's certificates into a throwaway keychain so Xcode
+      # reuses them: on a blank runner keychain, `-allowProvisioningUpdates`
+      # mints a fresh certificate every run and climbs toward Apple's cap. The
+      # keychain is ADDED to the search list (login kept) so cloud-managed
+      # profiles still resolve.
+      - name: Import signing certificates
+        env:
+          DIST_P12_BASE64: ${{ secrets.IOS_DIST_CERT_P12_BASE64 }}
+          DIST_PASSWORD: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
+          DEV_P12_BASE64: ${{ secrets.IOS_DEV_CERT_P12_BASE64 }}
+          DEV_PASSWORD: ${{ secrets.IOS_DEV_CERT_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+          KEYCHAIN_PWD="$(openssl rand -base64 24)"
+          security create-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN_PATH"
+          import_p12() {
+            local path="$RUNNER_TEMP/cert.p12"
+            echo "$1" | base64 -d > "$path"
+            security import "$path" -P "$2" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+            rm -f "$path"
+          }
+          import_p12 "$DIST_P12_BASE64" "$DIST_PASSWORD"
+          import_p12 "$DEV_P12_BASE64" "$DEV_PASSWORD"
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PWD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" \
+            $(security list-keychains -d user | sed -e 's/^[[:space:]]*//' -e 's/"//g')
+        working-directory: ${{ github.workspace }}
+
+      - name: Archive tvOS app
+        env:
+          KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+          ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+        run: |
+          xcodebuild \
+            -project FliksTV.xcodeproj \
+            -scheme FliksTV \
+            -configuration Release \
+            -destination 'generic/platform=tvOS' \
+            -archivePath build/FliksTV.xcarchive \
+            -allowProvisioningUpdates \
+            -authenticationKeyID "$KEY_ID" \
+            -authenticationKeyIssuerID "$ISSUER_ID" \
+            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_$KEY_ID.p8 \
+            CURRENT_PROJECT_VERSION=${{ steps.bnum.outputs.value }} \
+            DEVELOPMENT_TEAM=${{ secrets.APPLE_TEAM_ID }} \
+            clean archive
+
+      - name: Export signed IPA
+        env:
+          KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+          ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+        run: |
+          xcodebuild \
+            -exportArchive \
+            -archivePath build/FliksTV.xcarchive \
+            -exportOptionsPlist ExportOptions.plist \
+            -exportPath build/export \
+            -allowProvisioningUpdates \
+            -authenticationKeyID "$KEY_ID" \
+            -authenticationKeyIssuerID "$ISSUER_ID" \
+            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_$KEY_ID.p8
+
+      # `altool --upload-app` is the only ASC upload path that takes an API key
+      # on the command line; `notarytool` notarises, it doesn't publish.
+      - name: Upload IPA to App Store Connect
+        env:
+          KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+          ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+        run: |
+          xcrun altool --upload-app \
+            --type tvos \
+            --file "$(ls build/export/*.ipa | head -1)" \
+            --apiKey "$KEY_ID" \
+            --apiIssuer "$ISSUER_ID"

--- a/appletv/.gitignore
+++ b/appletv/.gitignore
@@ -10,3 +10,5 @@ last-shot.png
 
 # macOS
 .DS_Store
+FliksTV-Info.plist
+build/

--- a/appletv/ExportOptions.plist
+++ b/appletv/ExportOptions.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Same shape as the iOS client's ExportOptions: App Store distribution,
+	     automatic signing, and the App Store Connect API key passed to
+	     `xcodebuild -authenticationKey…` so the runner pulls the profile it
+	     needs instead of carrying a .mobileprovision in repo secrets. -->
+	<key>method</key>
+	<string>app-store-connect</string>
+	<key>teamID</key>
+	<string>85ZC7Y8WQ2</string>
+	<key>signingStyle</key>
+	<string>automatic</string>
+	<key>uploadSymbols</key>
+	<true/>
+	<key>stripSwiftSymbols</key>
+	<true/>
+</dict>
+</plist>

--- a/appletv/Sources/Features/Player/PlayerView.swift
+++ b/appletv/Sources/Features/Player/PlayerView.swift
@@ -411,8 +411,7 @@ private struct SkipCueStyle: ButtonStyle {
         player.appliesMediaSelectionCriteriaAutomatically = mode != "off"
 
         Task {
-            _ = try? await item.asset.load(.availableMediaCharacteristicsWithMediaSelectionOptions)
-            guard let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: .legible) else { return }
+            guard let group = try? await item.asset.loadMediaSelectionGroup(for: .legible) else { return }
             if mode == "off" {
                 item.select(nil, in: group)
                 return
@@ -435,7 +434,7 @@ private struct SkipCueStyle: ButtonStyle {
     /// Language of the audio actually playing — the selected option when the
     /// stream carries several, else the only track's own tag.
     private func audioLanguage(of item: AVPlayerItem) async -> String? {
-        if let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: .audible),
+        if let group = try? await item.asset.loadMediaSelectionGroup(for: .audible),
            let selected = item.currentMediaSelection.selectedMediaOption(in: group),
            let tag = selected.extendedLanguageTag {
             return Self.languageCode(tag)

--- a/appletv/project.yml
+++ b/appletv/project.yml
@@ -8,7 +8,9 @@ options:
 settings:
   base:
     SWIFT_VERSION: "5.0"
-    MARKETING_VERSION: "0.1.0"
+    MARKETING_VERSION: "1.15.2" # x-release-please-version
+    # CI overrides this with the repo's commit count: Apple rejects a build
+    # number it has already seen for the app.
     CURRENT_PROJECT_VERSION: "1"
 
 targets:
@@ -17,12 +19,28 @@ targets:
     platform: tvOS
     sources:
       - Sources
+    # A written plist rather than GENERATE_INFOPLIST_FILE: App Transport
+    # Security takes a dictionary, which the INFOPLIST_KEY_* settings can't
+    # express.
+    info:
+      path: FliksTV-Info.plist
+      properties:
+        CFBundleDisplayName: Fliks
+        # XcodeGen would otherwise hardcode 1.0 / 1 and ignore the settings
+        # above, so a CI build number would never reach the bundle.
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
+        # Self-hosted servers are routinely plain http on a LAN — same
+        # exception the iOS client ships with.
+        NSAppTransportSecurity:
+          NSAllowsArbitraryLoads: true
+        # No encryption beyond HTTPS: declared here so every upload skips the
+        # export-compliance prompt.
+        ITSAppUsesNonExemptEncryption: false
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: media.fliks.tv
-        INFOPLIST_KEY_CFBundleDisplayName: Fliks
         ASSETCATALOG_COMPILER_APPICON_NAME: "App Icon & Top Shelf Image"
-        GENERATE_INFOPLIST_FILE: "YES"
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: 85ZC7Y8WQ2
 
@@ -33,3 +51,5 @@ schemes:
         FliksTV: all
     run:
       config: Debug
+    archive:
+      config: Release


### PR DESCRIPTION
Gets the tvOS app ready to reach App Store Connect signed, mirroring the existing iOS pipeline.

## Workflow

`.github/workflows/tvos-publish.yml` — runs on `v*` tags (the ones release-please produces) and on `workflow_dispatch`. XcodeGen regenerates the `.xcodeproj` (it isn't versioned), then a Release archive for `generic/platform=tvOS`, export through `ExportOptions.plist`, and `xcrun altool --upload-app --type tvos`.

No new secrets: the App Store Connect API key and the team certificates are the ones the iOS workflow already uses — an Apple Distribution certificate covers every platform of the team. Certificates are imported into a throwaway keychain for the same reason as on iOS: on a blank runner keychain, `-allowProvisioningUpdates` mints a fresh one every run and climbs toward Apple's cap.

The build number comes from `git rev-list --count HEAD`, like iOS: shared, monotonic, and Apple rejects a number it has already seen.

## Version

`appletv/project.yml` carried a hardcoded `MARKETING_VERSION: 0.1.0`. It now tracks the monorepo version behind an `x-release-please-version` marker, and the file joins release-please's `extra-files` — so the tag and the uploaded build carry the same number.

Verified locally: Release archive with `CURRENT_PROJECT_VERSION=4242` → `CFBundleShortVersionString = 1.15.2`, `CFBundleVersion = 4242`.

## Info.plist

Switched from a generated plist to a written one (via XcodeGen's `info:`): App Transport Security takes a dictionary, which the `INFOPLIST_KEY_*` settings can't express.

- `NSAllowsArbitraryLoads` — a self-hosted server is routinely plain http on a LAN; the iOS client ships the same exception.
- `ITSAppUsesNonExemptEncryption = false` — skips the export-compliance prompt on every upload.
- `CFBundleShortVersionString` / `CFBundleVersion` reference the build settings, otherwise XcodeGen freezes 1.0 / 1 and the CI override never reaches the bundle.

Checked on the archive: icon (`CFBundleIcons`), Top Shelf, ATS and version all present.

## Also

The last two warnings from the Release archive (`mediaSelectionGroup(forMediaCharacteristic:)`, deprecated since tvOS 16) move to `loadMediaSelectionGroup(for:)`.

## Outside this repo

An App Store Connect record for the tvOS platform on bundle id `media.fliks.tv` — without it the upload fails at delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)