### PR TITLE
chore(appletv): share the iOS bundle id so both platforms use one app record

### DIFF
--- a/.github/workflows/tvos-publish.yml
+++ b/.github/workflows/tvos-publish.yml
@@ -17,8 +17,9 @@
 #   - IOS_DEV_CERT_P12_BASE64 / IOS_DEV_CERT_PASSWORD
 #   - APPLE_TEAM_ID
 #
-# One-shot setup outside this repo: an App Store Connect app record for the
-# tvOS platform on bundle id `media.fliks.tv`.
+# One-shot setup outside this repo: add the tvOS platform to the existing
+# `media.fliks.app` record in App Store Connect — same bundle id as the iOS
+# client, which is what keeps both under one app listing.
 name: Publish tvOS to App Store Connect
 
 on:

--- a/appletv/project.yml
+++ b/appletv/project.yml
@@ -39,7 +39,9 @@ targets:
         ITSAppUsesNonExemptEncryption: false
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: media.fliks.tv
+        # Same id as the iOS client on purpose: App Store Connect only
+        # groups iOS and tvOS under one app record when the ids match.
+        PRODUCT_BUNDLE_IDENTIFIER: media.fliks.app
         ASSETCATALOG_COMPILER_APPICON_NAME: "App Icon & Top Shelf Image"
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: 85ZC7Y8WQ2

--- a/appletv/scripts/remote-build.sh
+++ b/appletv/scripts/remote-build.sh
@@ -11,7 +11,7 @@ cd "$HERE"
 
 PROJECT="FliksTV.xcodeproj"
 SCHEME="FliksTV"
-BUNDLE_ID="${BUNDLE_ID:-media.fliks.tv}"
+BUNDLE_ID="${BUNDLE_ID:-media.fliks.app}"
 APP_NAME="${APP_NAME:-Fliks}"
 DERIVED=".build"
 SIM_NAME="${SIM_NAME:-Apple TV 4K (3rd generation)}"


### PR DESCRIPTION
Moves the tvOS app from `media.fliks.tv` to `media.fliks.app`, the id the iOS and Android clients already use.

App Store Connect only keeps iOS and tvOS under **one app record** when the bundle id is identical. With `media.fliks.tv` we would have had a separate listing: its own page, its own screenshots, its own submissions, and nothing linking the two apps for the viewer.

Three files touched: `appletv/project.yml`, the `BUNDLE_ID` default in `scripts/remote-build.sh`, and the prerequisite noted at the top of `tvos-publish.yml`.

Verified in the simulator: build, install and launch under `media.fliks.app`, entitlement `85ZC7Y8WQ2.media.fliks.app`.

Worth knowing: the container and the keychain scope both follow the bundle id, so installed dev builds start from scratch (server URL and sessions to re-enter) and the old app stays on device until it is deleted by hand.

On the Apple side, the tvOS platform still has to be added to the existing `media.fliks.app` record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)