### PR TITLE
fix(appletv): keep requests intact across an http to https redirect

### DIFF
--- a/appletv/Sources/Core/API/APIClient.swift
+++ b/appletv/Sources/Core/API/APIClient.swift
@@ -54,6 +54,34 @@ extension JSONEncoder {
     }()
 }
 
+/// Carries a request across a server-side redirect. Left alone, URLSession
+/// turns a 301/302 POST into a bodyless GET and drops `Authorization` when the
+/// scheme changes — which is precisely what a server entered as `http://` but
+/// redirecting to `https://` does to every write.
+private final class RedirectKeeper: NSObject, URLSessionTaskDelegate {
+    func urlSession(_ session: URLSession, task: URLSessionTask,
+                    willPerformHTTPRedirection response: HTTPURLResponse,
+                    newRequest request: URLRequest) async -> URLRequest? {
+        guard let original = task.originalRequest,
+              let from = original.url, let to = request.url,
+              // Credentials follow the redirect only within the same host.
+              from.host == to.host else { return request }
+
+        if from.scheme == "http", to.scheme == "https" {
+            await ServerStore.shared.upgradeToHTTPS(redirectedTo: to)
+        }
+
+        var rebuilt = request
+        rebuilt.httpMethod = original.httpMethod
+        rebuilt.httpBody = original.httpBody
+        for (key, value) in original.allHTTPHeaderFields ?? [:]
+        where rebuilt.value(forHTTPHeaderField: key) == nil {
+            rebuilt.setValue(value, forHTTPHeaderField: key)
+        }
+        return rebuilt
+    }
+}
+
 /// Generic async REST client. Base URL comes from `ServerStore`, the Bearer
 /// token from `TokenStore` — every `/api/*` request except `/auth/refresh`
 /// carries `Authorization: Bearer <access>` (mirrors the native branch of
@@ -68,10 +96,13 @@ final class APIClient {
     var refreshTokens: (() async throws -> Void)?
 
     private let session: URLSession
+    private let redirects: RedirectKeeper
     private var refreshTask: Task<Void, Error>?
 
-    init(session: URLSession = .shared) {
-        self.session = session
+    init(session: URLSession? = nil) {
+        let keeper = RedirectKeeper()
+        redirects = keeper
+        self.session = session ?? URLSession(configuration: .default, delegate: keeper, delegateQueue: nil)
     }
 
     func get<T: Decodable>(_ path: String, query: [String: String] = [:], headers: [String: String] = [:]) async throws -> T {

--- a/appletv/Sources/Core/Server/ServerStore.swift
+++ b/appletv/Sources/Core/Server/ServerStore.swift
@@ -49,6 +49,26 @@ struct KnownServer: Codable, Identifiable, Hashable {
         url = ""
     }
 
+    /// A server typed as `http://` that answers with a redirect to `https://`
+    /// is stored by its https address: later requests skip the hop instead of
+    /// making every write survive it, and image URLs stop being downgraded.
+    ///
+    /// Port comes from the redirect target, not from what was typed — a server
+    /// reached on `:8096` usually answers TLS on 443.
+    @MainActor
+    func upgradeToHTTPS(redirectedTo target: URL) {
+        guard var comps = URLComponents(string: url), comps.scheme == "http",
+              target.scheme == "https", comps.host == target.host else { return }
+        let previous = url
+        comps.scheme = "https"
+        comps.port = target.port
+        guard let upgraded = comps.string else { return }
+        let known = knownServers.first { $0.url == previous }
+        save(upgraded)
+        forgetKnownServer(previous)
+        touchKnownServer(upgraded, name: known?.name, username: known?.lastUsername)
+    }
+
     /// Append to the known list, or bump `lastUsedAt` if already present.
     func touchKnownServer(_ serverUrl: String, name: String? = nil, username: String? = nil) {
         let cleaned = Self.trimTrailingSlashes(serverUrl)


### PR DESCRIPTION
Entering `http://` for a server that answers over `https` (with a redirect) broke every write request.

## Cause

URLSession follows the redirect on its own, but a 301/302 **turns a POST into a GET**, drops the body, and drops the `Authorization` header when the scheme changes. Login, pairing, playback progress, watched toggles: all of them reached the server as anonymous GETs.

Reproduced against a local redirector, before and after:

```
without delegate: {"method": "GET",  "auth": null,         "body": ""}
with delegate:    {"method": "POST", "auth": "Bearer tok", "body": "{\"username\":\"x\"}"}
```

Then verified **inside the app**, pointed at that redirector — the login POST arrives intact:

```
RECV GET  /api/auth/users-public auth=None body=''
RECV POST /api/auth/login        auth=None body='{"username":"","password":"pass"}'
```

## Fix

`RedirectKeeper`, the delegate of `APIClient`'s session, rebuilds the redirected request with the original method, body and headers — only **when the host is the same**, so credentials never follow a redirect elsewhere, which is URLSession's own default.

On top of that, the stored address is upgraded to `https` on the first redirect, so later requests skip the hop — including image loads, which go through another session and wouldn't have benefited from the delegate. The port comes from the redirect target rather than from what was typed: a server reached on `:8096` usually answers TLS on 443.

| typed address | redirect target | address kept |
|---|---|---|
| `http://fliks.example.com` | `https://fliks.example.com/…` | `https://fliks.example.com` |
| `http://fliks.example.com:8096` | `https://fliks.example.com/…` | `https://fliks.example.com` |
| `http://fliks.example.com:8096` | `https://fliks.example.com:8443/…` | `https://fliks.example.com:8443` |
| `http://example.com/fliks` | `https://example.com/fliks/…` | `https://example.com/fliks` |
| `http://fliks.example.com` | `https://other.example.com/…` | unchanged |

The matching entry in the recent-servers list is migrated at the same time, name and last username preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)