### PR TITLE
fix(appletv): archive with the distribution identity to reach App Store Connect

### DIFF
--- a/.github/workflows/tvos-publish.yml
+++ b/.github/workflows/tvos-publish.yml
@@ -102,6 +102,10 @@ jobs:
             $(security list-keychains -d user | sed -e 's/^[[:space:]]*//' -e 's/"//g')
         working-directory: ${{ github.workspace }}
 
+      # Signed with the distribution identity from the start. Left to its
+      # default, Xcode archives with `Apple Development` and asks Apple for a
+      # tvOS development profile, which needs a registered tvOS device — the
+      # team has none, and an App Store profile needs none either way.
       - name: Archive tvOS app
         env:
           KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
@@ -119,6 +123,7 @@ jobs:
             -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_$KEY_ID.p8 \
             CURRENT_PROJECT_VERSION=${{ steps.bnum.outputs.value }} \
             DEVELOPMENT_TEAM=${{ secrets.APPLE_TEAM_ID }} \
+            CODE_SIGN_IDENTITY="Apple Distribution" \
             clean archive
 
       - name: Export signed IPA


### PR DESCRIPTION
The first dispatched run of `tvos-publish` failed at the archive step:

```
error: Communication with Apple failed: Your team has no devices from which to generate a
provisioning profile.
error: No profiles for 'media.fliks.app' were found: Xcode couldn't find any tvOS App
Development provisioning profiles matching 'media.fliks.app'.
```

With no explicit signing identity, Xcode archives with `Apple Development` and asks Apple for a tvOS **development** profile. Such a profile is only issued once the team has at least one registered tvOS device, which is not the case. An App Store profile requires none.

The archive therefore names the distribution identity outright (`CODE_SIGN_IDENTITY="Apple Distribution"`). Export and upload were already set up for the App Store and don't change.

Considered and rejected: registering the Apple TV in the developer portal. It would unblock CI too, but tying an App Store release to a test device sitting in the account is fragile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)