### PR TITLE
ci(appletv): archive unsigned and let the export sign for the App Store

### DIFF
--- a/.github/workflows/tvos-publish.yml
+++ b/.github/workflows/tvos-publish.yml
@@ -102,10 +102,11 @@ jobs:
             $(security list-keychains -d user | sed -e 's/^[[:space:]]*//' -e 's/"//g')
         working-directory: ${{ github.workspace }}
 
-      # Signed with the distribution identity from the start. Left to its
-      # default, Xcode archives with `Apple Development` and asks Apple for a
-      # tvOS development profile, which needs a registered tvOS device — the
-      # team has none, and an App Store profile needs none either way.
+      # Archived unsigned on purpose. With automatic signing, `xcodebuild
+      # archive` asks Apple for a *development* profile, which can only be
+      # issued to a team with a registered tvOS device — there is none, and a
+      # simulator can't be registered. The export below re-signs the bundle for
+      # the App Store, and that profile type needs no device.
       - name: Archive tvOS app
         env:
           KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
@@ -123,7 +124,7 @@ jobs:
             -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_$KEY_ID.p8 \
             CURRENT_PROJECT_VERSION=${{ steps.bnum.outputs.value }} \
             DEVELOPMENT_TEAM=${{ secrets.APPLE_TEAM_ID }} \
-            CODE_SIGN_IDENTITY="Apple Distribution" \
+            CODE_SIGNING_ALLOWED=NO \
             clean archive
 
       - name: Export signed IPA


### PR DESCRIPTION
Unblocks tvOS publishing with no registered device at all.

## The blocker

With automatic signing, `xcodebuild archive` asks for a **development** profile — which is also what the iOS pipeline does, as its `v1.15.2` run shows:

```
Signing Identity:     "Apple Development: Clément Delestre (226BST8S87)"
Provisioning Profile: "iOS Team Provisioning Profile: media.fliks.app"
```

Apple only issues that profile to a team with a registered device. The account has iPhones, no Apple TV — and a simulator can't be registered. Hence the first failure (`your team has no devices from which to generate a provisioning profile`), then, after forcing the distribution identity, the conflict `automatically signed for development, but a conflicting code signing identity Apple Distribution has been manually specified`.

## The way out

The archive is produced **unsigned** (`CODE_SIGNING_ALLOWED=NO`) and `-exportArchive` signs the bundle for the App Store. That profile type depends on no device, so cloud signing creates it on its own.

Verified end to end by a manual run on this branch ([run 30754965061](https://github.com/fliks-app/fliks/actions/runs/30754965061)):

```
UPLOAD SUCCEEDED with no errors
Delivery UUID: d5db4099-d52d-4dbb-b076-afccc5125c4c
Transferred 12635549 bytes in 0.847 seconds
No errors uploading archive at 'build/export/FliksTV.ipa'.
```

The build already reached App Store Connect; it shows up in TestFlight once Apple finishes processing.

Replaces the `CODE_SIGN_IDENTITY="Apple Distribution"` from #844, which moved the problem instead of solving it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)