### PR TITLE
fix(ci): attach release assets without updating the release

### DIFF
--- a/.github/workflows/macos-server-dmg.yml
+++ b/.github/workflows/macos-server-dmg.yml
@@ -154,6 +154,11 @@ jobs:
       # ── Attach DMG to GitHub Release (tag pushes only) ──
       - name: Attach to GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v3
-        with:
-          files: macos/build/Fliks-*.dmg
+        # `gh release upload` only POSTs the asset. The action we used before
+        # PATCHes the release first to sync its fields, and that call is
+        # refused ("Resource not accessible by integration") even with
+        # contents: write — attaching a file never needed it.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.ref_name }}" macos/build/Fliks-*.dmg --clobber
+        working-directory: ${{ github.workspace }}

--- a/.github/workflows/play-store-publish.yml
+++ b/.github/workflows/play-store-publish.yml
@@ -134,11 +134,14 @@ jobs:
 
       - name: Attach signed APK to the GitHub release
         if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.apk_tag != ''
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ steps.apk.outputs.tag }}
-          files: ${{ steps.apk.outputs.path }}
-          fail_on_unmatched_files: true
+        # `gh release upload` only POSTs the asset. The action we used before
+        # PATCHes the release first to sync its fields, and that call is
+        # refused ("Resource not accessible by integration") even with
+        # contents: write — attaching a file never needed it.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ steps.apk.outputs.tag }}" "${{ steps.apk.outputs.path }}" --clobber
+        working-directory: ${{ github.workspace }}
 
       - name: Extract latest release notes from CHANGELOG.md
         if: github.event.inputs.apk_tag == ''

--- a/.github/workflows/tizen-publish.yml
+++ b/.github/workflows/tizen-publish.yml
@@ -53,7 +53,11 @@ jobs:
 
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v3
-        with:
-          files: ${{ steps.art.outputs.path }}
-          fail_on_unmatched_files: true
+        # `gh release upload` only POSTs the asset. The action we used before
+        # PATCHes the release first to sync its fields, and that call is
+        # refused ("Resource not accessible by integration") even with
+        # contents: write — attaching a file never needed it.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.ref_name }}" "${{ steps.art.outputs.path }}" --clobber
+        working-directory: ${{ github.workspace }}

--- a/.github/workflows/webos-publish.yml
+++ b/.github/workflows/webos-publish.yml
@@ -51,7 +51,11 @@ jobs:
 
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v3
-        with:
-          files: ${{ steps.art.outputs.path }}
-          fail_on_unmatched_files: true
+        # `gh release upload` only POSTs the asset. The action we used before
+        # PATCHes the release first to sync its fields, and that call is
+        # refused ("Resource not accessible by integration") even with
+        # contents: write — attaching a file never needed it.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.ref_name }}" "${{ steps.art.outputs.path }}" --clobber
+        working-directory: ${{ github.workspace }}

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -140,6 +140,11 @@ jobs:
 
       - name: Attach to GitHub Release
         if: env.IS_TAG == 'true'
-        uses: softprops/action-gh-release@v3
-        with:
-          files: windows/build/Fliks-Setup-*.exe
+        # `gh release upload` only POSTs the asset. The action we used before
+        # PATCHes the release first to sync its fields, and that call is
+        # refused ("Resource not accessible by integration") even with
+        # contents: write — attaching a file never needed it.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.ref_name }}" windows/build/Fliks-Setup-*.exe --clobber
+        working-directory: ${{ github.workspace }}


### PR DESCRIPTION
On the `v2.0.0` tag, three of the six release jobs died in the same place:

```
Found release v2.0.0 (with id=363832115)
⚠️ Unexpected error fetching GitHub release for tag refs/tags/v2.0.0:
   HttpError: Resource not accessible by integration - .../releases#update-a-release
```

`play-store-publish`, `windows-installer` and `macos-server-dmg` failed; `tizen-publish`, `webos-publish` and `desktop-release` went through.

## Diagnosis

Not a matter of declared permissions: all six jobs get the same token, `Contents: write / Metadata: read` (checked in the "GITHUB_TOKEN Permissions" group of each log). Not release immutability either — the API reports `immutable: false` — and not a transient glitch: re-running `windows-installer` reproduces the error exactly.

What is refused is precisely `PATCH /releases/:id`. **Asset uploads** go through: `desktop-release` pushed six of them between 16:18 and 16:21, after `play-store` failed at 16:20:47.

`softprops/action-gh-release` always updates the release before attaching files, and offers no way to skip that call. Attaching a binary never needed it.

## Fix

The five attach steps move to `gh release upload <tag> <file> --clobber`, which only posts the asset. `--clobber` replaces a file of the same name, which keeps re-runs idempotent.

All six workflows now make the single call they need, and the repository drops its dependency on that action.

## After merging

The three failed jobs need re-running for 2.0.0. Android is the urgent one: the failure sat **before** the publish step, so the version never reached the Play Store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)