### PR TITLE
chore(windows): name the server installer like the other release assets

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -135,7 +135,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Fliks-Server-${{ steps.version.outputs.version }}-win-x64
-          path: windows/build/Fliks-Setup-*.exe
+          path: windows/build/Fliks-Server-*-x64.exe
           if-no-files-found: error
 
       - name: Attach to GitHub Release
@@ -146,5 +146,5 @@ jobs:
         # contents: write — attaching a file never needed it.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ github.ref_name }}" windows/build/Fliks-Setup-*.exe --clobber
+        run: gh release upload "${{ github.ref_name }}" windows/build/Fliks-Server-*-x64.exe --clobber
         working-directory: ${{ github.workspace }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@
 - **Don't run `git push` against `main` directly**; it always fails. If you mistakenly committed straight to local `main`, move the commit onto a branch (`git checkout -b <branch>` while on the commit, then `git reset --hard origin/main` on `main`) before pushing.
 - **Squash-merge to escape a bad-message branch**: when an existing branch's history has commits that fail commitlint (the lint runs on every commit in the PR), prefer `gh pr merge --squash` with a clean conventional title over rewriting + force-pushing. Force-push to a published branch is destructive and needs explicit user approval.
 - **Local hooks**: see `.husky/` if present. Don't bypass them.
+- **Write pull requests in English** — title and body — like commit messages and code comments, whatever language the conversation uses.
 
 ## Commit conventions
 

--- a/windows/Installer/fliks.nsi
+++ b/windows/Installer/fliks.nsi
@@ -16,7 +16,7 @@
   !error "BUNDLE_DIR is required"
 !endif
 !ifndef OUT_FILE
-  !define OUT_FILE "Fliks-Setup-${VERSION}.exe"
+  !define OUT_FILE "Fliks-Server-${VERSION}-x64.exe"
 !endif
 
 !define APPNAME "Fliks"

--- a/windows/README.md
+++ b/windows/README.md
@@ -41,7 +41,7 @@ $env:TMDB_API_KEY = "..."   # optional; baked into the tray
 $env:TVDB_API_KEY = "..."
 .\Scripts\build-app.ps1
 
-# 3. Package the installer → .\build\Fliks-Setup-<version>.exe
+# 3. Package the installer → .\build\Fliks-Server-<version>-x64.exe
 .\Scripts\make-installer.ps1 -Version 1.0.0
 ```
 

--- a/windows/Scripts/make-installer.ps1
+++ b/windows/Scripts/make-installer.ps1
@@ -28,7 +28,7 @@ $winDir = Split-Path -Parent $PSScriptRoot
 $build  = Join-Path $winDir 'build'
 $bundle = Join-Path $build 'Bundle'
 $nsi    = Join-Path $winDir 'Installer\fliks.nsi'
-$outFile = Join-Path $build "Fliks-Setup-$Version.exe"
+$outFile = Join-Path $build "Fliks-Server-$Version-x64.exe"
 
 # VIProductVersion needs a strict numeric X.X.X.X — derive it from the display
 # version (e.g. "1.2.3" -> "1.2.3.0", "dev-abc123" -> "0.0.0.0").


### PR DESCRIPTION
On the release page, `Fliks-Setup-2.0.0.exe` sat next to `Fliks-Server-2.0.0-arm64.dmg` and `Fliks-Client-2.0.0-x64.exe`. Nothing in the name said which product it was, nor which architecture.

It becomes `Fliks-Server-<version>-x64.exe` — product, version, architecture, like every other asset.

Renamed in the four places that carried the old name: the NSIS `OUT_FILE`, the `make-installer.ps1` output path, the workflow (artifact path and release upload glob) and `windows/README.md`.

The asset already attached to v2.0.0 was renamed by hand so that release is consistent too; the binary is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)