### PR TITLE
fix(tv): exit on the first return-key press from the entry screen

### DIFF
--- a/client/src/app/core/services/card-actions.service.ts
+++ b/client/src/app/core/services/card-actions.service.ts
@@ -152,7 +152,16 @@ export class CardActionsService {
       this.show();
       return;
     }
-    if (this.open() && (e.key === 'Escape' || e.key === 'Backspace' || e.key === 'GoBack')) {
+    // Tizen's Return key (10009 / XF86Back) must close this popup rather than
+    // reach the app-shell back handler, which would navigate away or exit.
+    if (
+      this.open() &&
+      (e.key === 'Escape' ||
+        e.key === 'Backspace' ||
+        e.key === 'GoBack' ||
+        e.key === 'XF86Back' ||
+        e.keyCode === 10009)
+    ) {
       e.preventDefault();
       e.stopPropagation();
       this.close();

--- a/client/src/app/core/services/navbar.service.spec.ts
+++ b/client/src/app/core/services/navbar.service.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed } from '@angular/core/testing';
+import { Component, inject as ngInject } from '@angular/core';
+import { provideRouter, Router, UrlTree } from '@angular/router';
+import { NavbarService } from './navbar.service';
+
+@Component({ template: '' })
+class PageStub {}
+
+describe('NavbarService', () => {
+  /** Entry screens are reached through a guard redirect (Tizen boots into
+   *  /setup). A back entry recorded there makes the first hardware-back press
+   *  a no-op redirect instead of leaving the app — Samsung rejects that. */
+  it('has no back entry on an entry screen reached through a guard redirect', async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          { path: 'setup', component: PageStub },
+          {
+            path: '',
+            component: PageStub,
+            canActivate: [() => ngInject(Router).createUrlTree(['/setup']) as UrlTree],
+          },
+        ]),
+      ],
+    });
+
+    // Construction order matches the real app: injected by App's DI, before the
+    // router runs its initial navigation.
+    const navbar = TestBed.inject(NavbarService);
+    await TestBed.inject(Router).navigateByUrl('/');
+
+    expect(navbar.canGoBack()).toBe(false);
+  });
+
+  it('records a back entry once a real in-app navigation happens', async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          { path: '', component: PageStub },
+          { path: 'library', component: PageStub },
+        ]),
+      ],
+    });
+
+    const navbar = TestBed.inject(NavbarService);
+    const router = TestBed.inject(Router);
+    await router.navigateByUrl('/');
+    await router.navigateByUrl('/library');
+
+    expect(navbar.canGoBack()).toBe(true);
+  });
+});

--- a/client/src/app/core/services/navbar.service.ts
+++ b/client/src/app/core/services/navbar.service.ts
@@ -61,7 +61,10 @@ export class NavbarService {
       this.isLargeScreen.set(mq.matches);
       mq.addEventListener('change', (e) => this.isLargeScreen.set(e.matches));
     }
-    let lastUrl = this.router.url;
+    // Empty, not `router.url`: this service is constructed before the router's
+    // initial navigation, so seeding it would push a phantom '/' entry and make
+    // the first hardware-back press on the entry screen a no-op redirect.
+    let lastUrl = '';
     this.router.events.subscribe((e) => {
       // Browser back/forward: mirror the pop on our internal stack so the
       // next in-app back button doesn't re-push the URL we just left (which


### PR DESCRIPTION
TV Seller Office rejected V2.0.0 for the whole model range (Tizen 7 → 10) on a
single CRITICAL item: the [Return key policy](https://developer.samsung.com/smarttv/develop/guides/fundamentals/terminating-applications.html).
The handler was there and shipped in the submitted widget — the behaviour was
wrong.

## The entry screen never exited on the first press

`NavbarService` is constructed from `App`s DI, which runs *before* the routers
initial navigation. It seeded its internal back stack with the pre-navigation
`/`, so the first `NavigationEnd` — the one landing on the redirect target —
pushed a phantom entry and `canGoBack()` was already true on the very first
screen.

On a standalone bundle with no server configured, `serverConfigGuard` sends
every route to `/setup`, and that is the only screen a reviewer without a Fliks
server can reach. There, the first Return press took the in-app back branch,
navigated to `/`, the guard redirected straight back to `/setup` — same screen,
nothing visibly happened, no exit. Only a second press left the app.

Reproduced in `navbar.service.spec.ts`: entry route reached through a guard
redirect reported `canGoBack() === true`.

## The TV card-actions overlay swallowed nothing on Tizen

`CardActionsService` closed on `Escape` / `Backspace` / `GoBack` (the webOS
code) but not on `10009` / `XF86Back`, so on Tizen the Return key fell through
to the app-shell handler and navigated away — or quit the app — with the popup
still open. The same policy requires the popup to close first.

## Validation

Sideloaded on the test TV (QE85Q80BATXXC, Tizen upgrade install, settings kept):
Return exits on the first press from the entry screen, and closes the card
actions overlay instead of navigating.

Next step after merge: rebuild the signed store widget from the Tizen workflow
and re-submit V2.0.0 to Seller Office.