### PR TITLE
fix(subtitles): mute toasts for auto-triggered background events

### DIFF
--- a/backend/src/modules/scheduler/events.service.ts
+++ b/backend/src/modules/scheduler/events.service.ts
@@ -15,6 +15,8 @@ export type SseEvent =
       subtitleId: number;
       language: string;
       mediaId?: number;
+      /** Unattended scheduler run — client skips the confirmation toast */
+      automatic?: boolean;
     }
   | {
       type: 'subtitle.downloaded';
@@ -25,6 +27,8 @@ export type SseEvent =
       /** Set for translation results so a client can target the finished row
        *  (e.g. add just that track) instead of a blind refetch. */
       subtitleId?: number;
+      /** Unattended scheduler run — client skips the confirmation toast */
+      automatic?: boolean;
     }
   | {
       type: 'subtitle.failed';
@@ -35,6 +39,8 @@ export type SseEvent =
       /** Set to 'rate_limit' when a translation failed on a Gemini quota/rate
        *  limit, so the client can show a specific message. */
       reason?: string;
+      /** Unattended scheduler run — client skips the confirmation toast */
+      automatic?: boolean;
     }
   | {
       // Machine-translation progress for a PROCESSING subtitle row. `progress`

--- a/backend/src/modules/scheduler/subtitle-scheduler.service.ts
+++ b/backend/src/modules/scheduler/subtitle-scheduler.service.ts
@@ -184,7 +184,7 @@ export class SubtitleSchedulerService {
           await this.subtitleSync.reencodeToUtf8(sub.id);
         }
         if (opts.autoSyncEnabled) {
-          await this.subtitleSync.syncSubtitle(sub.id);
+          await this.subtitleSync.syncSubtitle(sub.id, { automatic: true });
         }
 
         void this.notifications.dispatch('subtitle.downloaded', {
@@ -255,7 +255,7 @@ export class SubtitleSchedulerService {
     if (!imageSub) return false;
 
     try {
-      await this.subtitleOcr.ocrSubtitle(imageSub.id, isoCode);
+      await this.subtitleOcr.ocrSubtitle(imageSub.id, isoCode, { automatic: true });
       return true;
     } catch (err) {
       this.log.warn(`SubtitleOcr: OCR-first failed for ${isoCode}: ${err}`);
@@ -375,7 +375,7 @@ export class SubtitleSchedulerService {
           await this.subtitleSync.reencodeToUtf8(upgraded.id);
         }
         if (opts.autoSyncEnabled) {
-          await this.subtitleSync.syncSubtitle(upgraded.id);
+          await this.subtitleSync.syncSubtitle(upgraded.id, { automatic: true });
         }
 
         void this.notifications.dispatch('subtitle.upgraded', {

--- a/backend/src/modules/subtitles/subtitle-ocr.service.ts
+++ b/backend/src/modules/subtitles/subtitle-ocr.service.ts
@@ -77,6 +77,7 @@ export class SubtitleOcrService {
   async ocrSubtitle(
     subtitleId: number,
     language?: string,
+    options: { automatic?: boolean } = {},
   ): Promise<SubtitleFile> {
     const source = await this.repo.findOne({
       where: { id: subtitleId },
@@ -122,7 +123,7 @@ export class SubtitleOcrService {
       sourceStreamIndex: source.streamIndex,
     } as any);
 
-    void this.runOcr(placeholder.id, source).catch((err) => {
+    void this.runOcr(placeholder.id, source, options.automatic).catch((err) => {
       this.log.error(`OCR run crashed for sub #${subtitleId}: ${err}`);
     });
     return placeholder;
@@ -148,7 +149,11 @@ export class SubtitleOcrService {
     this.ocrWaiters.shift()?.();
   }
 
-  private async runOcr(placeholderId: number, source: SubtitleFile): Promise<void> {
+  private async runOcr(
+    placeholderId: number,
+    source: SubtitleFile,
+    automatic?: boolean,
+  ): Promise<void> {
     const media = await this.mediaRepo.findOne({
       where: { id: source.mediaId },
     });
@@ -215,6 +220,7 @@ export class SubtitleOcrService {
         title: media.title,
         language: source.language,
         provider: 'ocr',
+        automatic,
       });
 
       if ((await this.settings.get('subtitle_ocr_delete_source')) === 'true') {
@@ -231,6 +237,7 @@ export class SubtitleOcrService {
         title: media?.title ?? '',
         language: source.language,
         error: String(err),
+        automatic,
       });
       // Leave nothing behind: drop the PROCESSING placeholder so a failed run
       // never lingers in the subtitle list (temp artefacts are already removed

--- a/backend/src/modules/subtitles/subtitle-sync.service.ts
+++ b/backend/src/modules/subtitles/subtitle-sync.service.ts
@@ -32,6 +32,8 @@ export interface SyncOptions {
   noFixFramerate?: boolean;
   /** Use golden-section search algorithm (ffsubsync --gss) */
   goldenSectionSearch?: boolean;
+  /** Set by the scheduler for unattended runs — tells the client to skip the toast */
+  automatic?: boolean;
 }
 
 export interface SyncQueueItem {
@@ -268,6 +270,7 @@ export class SubtitleSyncService {
                 subtitleId: saved.id,
                 language: saved.language,
                 mediaId: saved.mediaId,
+                automatic: options.automatic,
               });
             }
             return saved;
@@ -305,6 +308,7 @@ export class SubtitleSyncService {
         subtitleId: saved.id,
         language: saved.language,
         mediaId: saved.mediaId,
+        automatic: options.automatic,
       });
       // Notify media servers (Emby/Plex) to refresh
       const media = await this.mediaRepo.findOne({

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -123,8 +123,6 @@
     "subtitle_synced": "Untertitel erfolgreich synchronisiert.",
     "subtitle_downloaded": "Untertitel heruntergeladen: {{title}} [{{lang}}]",
     "subtitle_failed": "OCR-Extraktion fehlgeschlagen ({{lang}})",
-    "import_complete": "Import abgeschlossen: {{title}}",
-    "stalled_removed": "Blockierter Torrent entfernt: {{title}}",
     "rescan_started": "Scan läuft: {{title}}",
     "rescan_completed": "Scan abgeschlossen: {{title}} — {{added}} hinzugefügt, {{removed}} entfernt, {{updated}} aktualisiert",
     "rescan_subtitles_cleaned": "{{missing}} Untertiteleintrag/-einträge ohne Datei entfernt, {{duplicates}} Duplikat(e) zusammengeführt",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -128,8 +128,6 @@
     "subtitle_synced": "Subtitle synced successfully.",
     "subtitle_downloaded": "Subtitle downloaded: {{title}} [{{lang}}]",
     "subtitle_failed": "OCR extraction failed ({{lang}})",
-    "import_complete": "Import complete: {{title}}",
-    "stalled_removed": "Stalled torrent removed: {{title}}",
     "rescan_started": "Scan in progress: {{title}}",
     "rescan_completed": "Scan complete: {{title}} — {{added}} added, {{removed}} removed, {{updated}} updated",
     "rescan_subtitles_cleaned": "{{missing}} subtitle entry(ies) without file removed, {{duplicates}} duplicate(s) merged",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -123,8 +123,6 @@
     "subtitle_synced": "Subtítulo sincronizado correctamente.",
     "subtitle_downloaded": "Subtítulo descargado: {{title}} [{{lang}}]",
     "subtitle_failed": "Error en la extracción OCR ({{lang}})",
-    "import_complete": "Importación completada: {{title}}",
-    "stalled_removed": "Torrent bloqueado eliminado: {{title}}",
     "rescan_started": "Escaneo en curso: {{title}}",
     "rescan_completed": "Escaneo completado: {{title}} — {{added}} añadido(s), {{removed}} eliminado(s), {{updated}} actualizado(s)",
     "rescan_subtitles_cleaned": "{{missing}} entrada(s) de subtítulo sin archivo eliminada(s), {{duplicates}} duplicado(s) fusionado(s)",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -128,8 +128,6 @@
     "subtitle_synced": "Sous-titre synchronisé avec succès.",
     "subtitle_downloaded": "Sous-titre téléchargé : {{title}} [{{lang}}]",
     "subtitle_failed": "Échec de l'extraction OCR ({{lang}})",
-    "import_complete": "Import terminé : {{title}}",
-    "stalled_removed": "Torrent bloqué supprimé : {{title}}",
     "rescan_started": "Scan en cours : {{title}}",
     "rescan_completed": "Scan terminé : {{title}} — {{added}} ajouté(s), {{removed}} supprimé(s), {{updated}} mis à jour",
     "rescan_subtitles_cleaned": "{{missing}} entrée(s) sous-titre sans fichier supprimée(s), {{duplicates}} doublon(s) fusionné(s)",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -123,8 +123,6 @@
     "subtitle_synced": "Sottotitolo sincronizzato con successo.",
     "subtitle_downloaded": "Sottotitolo scaricato: {{title}} [{{lang}}]",
     "subtitle_failed": "Estrazione OCR fallita ({{lang}})",
-    "import_complete": "Importazione completata: {{title}}",
-    "stalled_removed": "Torrent bloccato rimosso: {{title}}",
     "rescan_started": "Scansione in corso: {{title}}",
     "rescan_completed": "Scansione completata: {{title}} — {{added}} aggiunto/i, {{removed}} rimosso/i, {{updated}} aggiornato/i",
     "rescan_subtitles_cleaned": "{{missing}} voce/i sottotitolo senza file rimossa/e, {{duplicates}} duplicato/i unito/i",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -123,8 +123,6 @@
     "subtitle_synced": "Legenda sincronizada com sucesso.",
     "subtitle_downloaded": "Legenda transferida: {{title}} [{{lang}}]",
     "subtitle_failed": "Falha na extração OCR ({{lang}})",
-    "import_complete": "Importação concluída: {{title}}",
-    "stalled_removed": "Torrent bloqueado removido: {{title}}",
     "rescan_started": "Análise em curso: {{title}}",
     "rescan_completed": "Análise concluída: {{title}} — {{added}} adicionado(s), {{removed}} removido(s), {{updated}} atualizado(s)",
     "rescan_subtitles_cleaned": "{{missing}} entrada(s) de legenda sem ficheiro removida(s), {{duplicates}} duplicado(s) fundido(s)",

--- a/client/src/app/core/services/sse.service.ts
+++ b/client/src/app/core/services/sse.service.ts
@@ -176,14 +176,11 @@ export class SseService implements OnDestroy {
           event['seasonNumber'] as number | undefined,
           event['episodeNumber'] as number | undefined,
         );
-        this.toast.success(
-          this.translate.instant('sse.import_complete', { title: event['title'] ?? '' }),
-        );
+        // Import always finishes unattended (torrent completion is polled by
+        // a scheduler) — no toast, just retire the live progress above.
         break;
       case 'stalled.removed':
-        this.toast.info(
-          this.translate.instant('sse.stalled_removed', { title: event['title'] ?? '' }),
-        );
+        // Unattended cleanup of a stalled torrent — no toast.
         break;
       case 'social.followed':
         this.toast.info(

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -612,26 +612,31 @@ export class SubtitlesModalComponent {
     if (event === this.lastSseEvent) return;
     this.lastSseEvent = event;
 
+    const automatic = event['automatic'] === true;
     if (event.type === 'subtitle.synced') {
-      this.toast.success(this.translate.instant('sse.subtitle_synced'));
+      if (!automatic) this.toast.success(this.translate.instant('sse.subtitle_synced'));
       void this.loadSubtitles(mediaId);
     } else if (event.type === 'subtitle.downloaded') {
-      this.toast.success(
-        this.translate.instant('sse.subtitle_downloaded', {
-          title: event['title'] ?? '',
-          lang: event['language'] ?? '',
-        }),
-      );
+      if (!automatic) {
+        this.toast.success(
+          this.translate.instant('sse.subtitle_downloaded', {
+            title: event['title'] ?? '',
+            lang: event['language'] ?? '',
+          }),
+        );
+      }
       void this.loadSubtitles(mediaId);
     } else if (event.type === 'subtitle.failed') {
-      this.toast.error(
-        this.translate.instant(
-          event['reason'] === 'rate_limit'
-            ? 'media_detail.translation_rate_limited'
-            : 'sse.subtitle_failed',
-          { lang: event['language'] ?? '' },
-        ),
-      );
+      if (!automatic) {
+        this.toast.error(
+          this.translate.instant(
+            event['reason'] === 'rate_limit'
+              ? 'media_detail.translation_rate_limited'
+              : 'sse.subtitle_failed',
+            { lang: event['language'] ?? '' },
+          ),
+        );
+      }
       void this.loadSubtitles(mediaId);
     }
   });


### PR DESCRIPTION
## Summary
- Subtitle sync/OCR completion events fire from both a manual click and the 6h scheduler pass, but always showed the same toast — annoying when it's the unattended scheduler run.
- Tag scheduler-triggered `subtitle.synced` / `subtitle.downloaded` / `subtitle.failed` SSE events with an `automatic` flag; the client skips the toast for those while still silently refreshing the subtitle list. Manual actions keep their toast since it's their only completion feedback.
- `import.complete` and `stalled.removed` are always scheduler-driven with no manual counterpart, so their toasts are removed outright, along with the now-dead `sse.import_complete` / `sse.stalled_removed` translation keys (all 6 locales).

## Test plan
- [x] `tsc --noEmit` clean on both `backend` and `client`
- [ ] Manually trigger a subtitle sync from the UI and confirm the success toast still appears
- [ ] Let the subtitle scheduler run (or trigger it) and confirm no toast appears, but the subtitle list still refreshes