### PR TITLE
fix(docker): swap pgsrip's opencv-python for the headless build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && ln -sf /usr/lib/jellyfin-ffmpeg/ffprobe /usr/local/bin/ffprobe \
   && rm -f /tmp/jellyfin-ffmpeg.deb \
   && python3 -m pip install --no-cache-dir --break-system-packages ffsubsync pgsrip \
+  # pgsrip pulls opencv-python (GUI build, needs libGL.so.1, missing here) —
+  # remove it first so its files don't collide with the headless build below.
   && python3 -m pip uninstall -y --break-system-packages opencv-python \
   && python3 -m pip install --no-cache-dir --break-system-packages opencv-python-headless \
   && if [ "$TARGETARCH" = "amd64" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && ln -sf /usr/lib/jellyfin-ffmpeg/ffprobe /usr/local/bin/ffprobe \
   && rm -f /tmp/jellyfin-ffmpeg.deb \
   && python3 -m pip install --no-cache-dir --break-system-packages ffsubsync pgsrip \
+  && python3 -m pip uninstall -y --break-system-packages opencv-python \
+  && python3 -m pip install --no-cache-dir --break-system-packages opencv-python-headless \
   && if [ "$TARGETARCH" = "amd64" ]; then \
        wget -q -O /usr/local/bin/alass https://github.com/kaegi/alass/releases/download/v2.0.0/alass-linux64 \
        && chmod +x /usr/local/bin/alass; \


### PR DESCRIPTION
## Summary
- PGS OCR crashed in prod: `ImportError: libGL.so.1: cannot open shared object file` — pgsrip pulls `opencv-python` (GUI build) as a dependency, which needs `libGL.so.1` at import time. The headless runtime image doesn't ship it.
- Swap it for `opencv-python-headless` (uninstall then reinstall, since the two ship the same `cv2` module under different package names — installing one on top of the other without removing the first leaves stale/conflicting files in `site-packages`). No new system libraries needed.

## Test plan
- [x] Built a minimal Ubuntu 24.04 image with the same pip sequence and confirmed `python3 -c "import cv2"` and `pgsrip --help` both work without the GL error
- [ ] Trigger a PGS/VobSub OCR on a real media file against the built prod image and confirm it completes