### PR TITLE
fix(subtitles): surface OCR timeouts explicitly, fix stuck-processing crash

### DIFF
--- a/backend/src/modules/subtitles/subtitle-ocr.service.ts
+++ b/backend/src/modules/subtitles/subtitle-ocr.service.ts
@@ -29,6 +29,28 @@ const execFileAsync = promisify(execFile);
 // a dense 2h+ track can take past 10 minutes, so this needs real headroom.
 const OCR_TOOL_TIMEOUT_MS = 1_800_000;
 
+/** execFile's `timeout` option kills the child but throws the same generic
+ *  "Command failed" message as a real crash — call this out explicitly so
+ *  the OCR failure log says what actually happened. */
+async function execFileOrTimeout(
+  command: string,
+  args: string[],
+  options: { timeout: number; maxBuffer?: number },
+) {
+  const start = Date.now();
+  try {
+    return await execFileAsync(command, args, options);
+  } catch (err: any) {
+    if (err?.killed) {
+      const elapsed = Math.round((Date.now() - start) / 1000);
+      throw new Error(
+        `${command} timed out after ${elapsed}s (limit ${Math.round(options.timeout / 1000)}s)`,
+      );
+    }
+    throw err;
+  }
+}
+
 /** ISO 639-1 → tesseract (ISO 639-2/T) traineddata names, for subtile-ocr's
  *  `-l`. All packs ship via `tesseract-ocr-all`. Falls back to `eng`.
  *  (pgsrip derives its own language from the staged .sup filename.) */
@@ -157,10 +179,11 @@ export class SubtitleOcrService {
     source: SubtitleFile,
     automatic?: boolean,
   ): Promise<void> {
-    const media = await this.mediaRepo.findOne({
-      where: { id: source.mediaId },
-    });
+    // Fetched inside the try: a query failure here must still land the sub
+    // in FAILED (not leave the PROCESSING placeholder stuck forever).
+    let media: Media | null = null;
     try {
+      media = await this.mediaRepo.findOne({ where: { id: source.mediaId } });
       if (!media?.path) throw new Error('media root folder not set');
       const videoPath = path.join(media.path, source.mediaFile.relativePath);
       const limit = await this.ocrConcurrencyLimit();
@@ -269,10 +292,10 @@ export class SubtitleOcrService {
     try {
       if (codec === 'hdmv_pgs_subtitle') {
         const sup = `${base}.${ietf}.sup`;
-        await execFileAsync('ffmpeg', [
+        await execFileOrTimeout('ffmpeg', [
           '-y', '-i', videoPath, '-map', `0:${streamIndex}`, '-c:s', 'copy', sup,
         ], { timeout: 120_000 });
-        const { stdout, stderr } = await execFileAsync(
+        const { stdout, stderr } = await execFileOrTimeout(
           'pgsrip',
           ['--language', ietf, sup],
           { timeout: OCR_TOOL_TIMEOUT_MS, maxBuffer: 1 << 24 },
@@ -297,7 +320,7 @@ export class SubtitleOcrService {
           throw new Error('VobSub OCR requires a Matroska (.mkv) source');
         }
         try {
-          await execFileAsync('mkvextract', [
+          await execFileOrTimeout('mkvextract', [
             'tracks', videoPath, `${streamIndex}:${base}.idx`,
           ], { timeout: 120_000 });
         } catch (err) {
@@ -306,7 +329,7 @@ export class SubtitleOcrService {
           if (!(await this.exists(`${base}.sub`))) throw err;
         }
         // subtile-ocr reads the .idx (+ paired .sub) and writes "<base>.srt".
-        await execFileAsync('subtile-ocr', [
+        await execFileOrTimeout('subtile-ocr', [
           '-l', tess, '-o', `${base}.srt`, `${base}.idx`,
         ], { timeout: OCR_TOOL_TIMEOUT_MS, maxBuffer: 1 << 24 });
         return await fs.readFile(`${base}.srt`, 'utf-8');


### PR DESCRIPTION
## Summary
Stacked on #867 (raises the OCR timeout) — this is the follow-up requested after that fix: make future OCR failures easier to diagnose, and check for silent-failure gaps.

- `execFile`'s `timeout` option kills the child but throws the same generic `Command failed` message as a real crash — a timed-out run and an actual pgsrip/subtile-ocr error were indistinguishable in the logs. Verified with Node directly: a timeout sets `err.killed = true` (distinct from a `maxBuffer` overflow, which sets its own `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` code) — wrapped the 4 OCR subprocess calls to detect this and say `"pgsrip timed out after 617s (limit 1800s)"` instead.
- Found one real silent-crash path while auditing: `runOcr`'s media lookup ran *before* the `try` block, so a DB query failure there skipped the `catch` entirely — no `subtitle.failed` event, no placeholder cleanup. The subtitle would sit in `PROCESSING` forever with nothing but a generic "OCR run crashed" log line. Moved the lookup inside the `try` so every failure path is handled uniformly.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Kill an in-flight OCR run past its timeout and confirm the log names the timeout explicitly
- [ ] Simulate a DB blip during the media lookup and confirm the sub lands in FAILED, not stuck in PROCESSING