### PR TITLE
fix(navbar): keep back arrow visible after a hard refresh

### DIFF
--- a/client/src/app/core/services/navbar.service.ts
+++ b/client/src/app/core/services/navbar.service.ts
@@ -102,7 +102,15 @@ export class NavbarService {
           this.history.push(lastUrl);
         }
         lastUrl = e.urlAfterRedirects;
-        this.canGoBack.set(this.history.length > 0 && this.router.url !== '/');
+        // Our own stack is empty right after a hard refresh (in-memory state
+        // doesn't survive reload), but the real browser session history does
+        // — fall back to it so the arrow doesn't vanish. Skipped on native:
+        // Capacitor's WebView doesn't reliably track window.history either
+        // (see goBack()'s comment).
+        const hasRealHistory = !this.isNative && window.history.length > 1;
+        this.canGoBack.set(
+          (this.history.length > 0 || hasRealHistory) && this.router.url !== '/',
+        );
       }
     });
   }
@@ -158,6 +166,18 @@ export class NavbarService {
         // it as `true`, but later programmatic navs from that page see `false`.
         setTimeout(() => this.lastWasBack.set(false), 0);
       });
+      return;
+    }
+    if (!this.isNative && window.history.length > 1) {
+      this.isPoppingBack = true;
+      this.lastWasBack.set(true);
+      const sub = this.router.events.subscribe((e) => {
+        if (e instanceof NavigationEnd) {
+          sub.unsubscribe();
+          setTimeout(() => this.lastWasBack.set(false), 0);
+        }
+      });
+      window.history.back();
       return;
     }
     if (fallback?.length) {


### PR DESCRIPTION
## Summary
- `NavbarService.canGoBack` was tracked in an in-memory stack that resets on every app reboot, so refreshing a movie/series/episode detail page always cleared it even though the browser's real session history was still intact — the back arrow would vanish until another in-app navigation happened.
- Fall back to `window.history.length > 1` on web when the in-memory stack is empty, for both the `canGoBack` visibility check and `goBack()`'s actual navigation. Skipped on Capacitor (`isNative`), since its WebView doesn't track `window.history` reliably — same reasoning already used for `goBack()`'s existing in-memory path.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.app.json` passes
- [ ] Manually verify: open a movie/series/episode detail page in a browser, hit F5, confirm the back arrow is still shown and works