### PR TITLE
fix(blocklist): enforce source-title uniqueness, drop raw SQL on requests

### DIFF
--- a/backend/src/migrations/1782600000000-add-blocklist-source-title-unique-index.ts
+++ b/backend/src/migrations/1782600000000-add-blocklist-source-title-unique-index.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+// Pre-existing duplicates must be collapsed first, or the unique index cannot be created.
+export class AddBlocklistSourceTitleUniqueIndex1782600000000
+  implements MigrationInterface
+{
+  name = 'AddBlocklistSourceTitleUniqueIndex1782600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DELETE FROM "blocklist" b
+      USING "blocklist" b2
+      WHERE LOWER(b."sourceTitle") = LOWER(b2."sourceTitle")
+        AND b.id > b2.id
+    `);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX IF NOT EXISTS "UQ_blocklist_sourceTitle_lower" ON "blocklist" (LOWER("sourceTitle"))`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "UQ_blocklist_sourceTitle_lower"`,
+    );
+  }
+}

--- a/backend/src/modules/blocklist/entities/blocklist-entry.entity.ts
+++ b/backend/src/modules/blocklist/entities/blocklist-entry.entity.ts
@@ -1,10 +1,18 @@
-import { Entity, Column, ManyToOne, JoinColumn, RelationId } from 'typeorm';
+import {
+  Entity,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  RelationId,
+  Index,
+} from 'typeorm';
 import { BaseEntity } from '../../../common/entities/base.entity';
 import { Indexer } from '../../indexers/entities/indexer.entity';
 import { Media } from '../../media/entities/media.entity';
 import { User } from '../../users/entities/user.entity';
 
 @Entity('blocklist')
+@Index('UQ_blocklist_sourceTitle_lower', { synchronize: false })
 export class BlocklistEntry extends BaseEntity {
   @Column()
   sourceTitle: string;

--- a/backend/src/modules/scheduler/scheduler.module.ts
+++ b/backend/src/modules/scheduler/scheduler.module.ts
@@ -2,6 +2,7 @@ import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ScheduleModule } from '@nestjs/schedule';
 import { Command } from './entities/command.entity';
+import { FliksRequest } from '../requests/entities/request.entity';
 import { Media } from '../media/entities/media.entity';
 import { MediaFile } from '../media/entities/media-file.entity';
 import { DownloadHistory } from '../media/entities/download-history.entity';
@@ -44,6 +45,7 @@ import { Library } from '../libraries/entities/library.entity';
     ScheduleModule.forRoot(),
     TypeOrmModule.forFeature([
       Command,
+      FliksRequest,
       Media,
       MediaFile,
       DownloadHistory,

--- a/backend/src/modules/scheduler/system.controller.spec.ts
+++ b/backend/src/modules/scheduler/system.controller.spec.ts
@@ -107,6 +107,7 @@ describe('SystemController.activeStreams recency filter', () => {
       playbackService as never,
       mediaFileRepo as never,
       {} as never, // episodeRepo
+      {} as never, // requestRepo
       {} as never, // updateCheck
     );
 
@@ -202,6 +203,7 @@ describe('SystemController.sendPlayerCommand', () => {
       {} as never,
       {} as never,
       {} as never,
+      {} as never,
     );
 
     return {
@@ -265,6 +267,7 @@ describe('SystemController.restart', () => {
 
   function makeController() {
     return new SystemController(
+      {} as never,
       {} as never,
       {} as never,
       {} as never,

--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -51,6 +51,8 @@ import { StreamLifetime } from '../streaming/lifetime-constants';
 import { PlaybackService } from '../streaming/playback.service';
 import { MediaFile } from '../media/entities/media-file.entity';
 import { Episode } from '../media/entities/episode.entity';
+import { FliksRequest } from '../requests/entities/request.entity';
+import { RequestStatus } from '../../common/enums';
 import { bucketResolutionLabel } from '../../common/utils/resolution.util';
 
 const APP_VERSION: string = (() => {
@@ -212,6 +214,8 @@ export class SystemController {
     private readonly mediaFileRepo: Repository<MediaFile>,
     @InjectRepository(Episode)
     private readonly episodeRepo: Repository<Episode>,
+    @InjectRepository(FliksRequest)
+    private readonly requestRepo: Repository<FliksRequest>,
     private readonly updateCheck: UpdateCheckService,
   ) {}
 
@@ -280,7 +284,7 @@ export class SystemController {
   @Get('stats')
   @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
   async stats(): Promise<StatsReport> {
-    const [[moviesRow], [seriesRow], [pendingRow], libraries] =
+    const [[moviesRow], [seriesRow], pendingRequests, libraries] =
       await Promise.all([
         this.dataSource.query(
           `SELECT COUNT(*)::int AS count FROM media WHERE type = 'movie'`,
@@ -288,9 +292,7 @@ export class SystemController {
         this.dataSource.query(
           `SELECT COUNT(*)::int AS count FROM media WHERE type = 'series'`,
         ),
-        this.dataSource.query(
-          `SELECT COUNT(*)::int AS count FROM requests WHERE status = 'pending'`,
-        ),
+        this.requestRepo.count({ where: { status: RequestStatus.PENDING } }),
         this.libraryRepo.find({ order: { name: 'ASC' } }),
       ]);
 
@@ -318,7 +320,7 @@ export class SystemController {
     return {
       movies: moviesRow.count,
       series: seriesRow.count,
-      pendingRequests: pendingRow.count,
+      pendingRequests,
       diskSpace,
     };
   }


### PR DESCRIPTION
First PR of the plugin-system Phase 0 prerequisites (`plans/plugin-system.plan.md`, PR 0.4). Both changes stand on their own and ship value with or without the plugin work.

## Blocklist duplicates

Three call sites wrap `BlocklistService.createFromHistory` in a `try/catch` that treats a constraint violation as "already blocklisted" and continues:

- `backend/src/modules/download-clients/download-clients.service.ts:199`
- `backend/src/modules/scheduler/completion.service.ts:456`
- `backend/src/modules/scheduler/completion.service.ts:674`

There was no constraint to violate, so none of them could ever fire. Every failed import, stall cleanup and manual block appended another row for a release that was already blocked.

The new unique index is on `LOWER("sourceTitle")`, which is exactly the comparison `BlocklistService.isBlocked` performs — no media filter, so the blocklist is global by title. Second effect: that lookup runs once per candidate release on the auto-grab path and was a sequential scan with a per-row function call; it is now an index seek.

The migration collapses pre-existing case-insensitive duplicates first, keeping the lowest id (the original block), because the index cannot be created otherwise. This is the only row-level change.

## Raw SQL on a core table

`system.controller.ts` counted pending requests with an unqualified `SELECT ... FROM requests`. It was the last raw reference to a core table outside the entity layer. Now a repository `count()`, so the table name lives only in the entity.

## Verification

- `npx tsc --noEmit` exits 0. Note `backend/dist/` is root-owned in this environment, so the incremental buildinfo write fails with EACCES and masks the real exit code; verified with `--tsBuildInfoFile` pointed at a writable path.
- Full migration chain (44 existing + this one) applied to a **fresh** Postgres 17: exit 0. The dev database is `synchronize`-built and cannot accept the chain, which is what the migrations README warns about.
- `down()` then `up()` round trip: index dropped, 4 rows seeded with 3 case-insensitive duplicates, re-run collapsed them to 2 rows keeping id 1, index recreated.
- Constraint verified live: inserting `REL.2024.1080P` next to `Rel.2024.1080p` now raises `duplicate key value violates unique constraint`, so the three guards above finally do what they claim.
- Backend restarted in the local Docker stack and boots clean.

## Not included

`semver` was going to be promoted to a declared dependency here. It is not used anywhere in the tree yet — it only becomes necessary when manifest compatibility ranges land. Adding it now would be a dependency with no consumer, so it moves to the PR that uses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)