### PR TITLE
fix(auth): stop leaking settings and provider credentials to requesters

### DIFF
--- a/backend/src/modules/auth/casl/casl-ability.factory.ts
+++ b/backend/src/modules/auth/casl/casl-ability.factory.ts
@@ -78,9 +78,8 @@ export class CaslAbilityFactory {
     if (perms.has('media.delete')) can(Action.Delete, Media);
     if (perms.has('media.grab')) can(Action.Grab, Media);
 
-    // --- read-only access to root folders & queue for users who can add/request media ---
+    // --- read-only queue access for users who can add/request media ---
     if (perms.has('media.create') || perms.has('requests.create')) {
-      can(Action.Read, 'Settings');
       can(Action.Read, DownloadClient);
     }
 

--- a/backend/src/modules/download-clients/download-clients.controller.ts
+++ b/backend/src/modules/download-clients/download-clients.controller.ts
@@ -10,7 +10,7 @@ import {
   UseGuards,
   ParseIntPipe,
 } from '@nestjs/common';
-import { DownloadClientsService } from './download-clients.service';
+import { DownloadClientsService, redactPassword } from './download-clients.service';
 import { CreateDownloadClientDto } from './dto/create-download-client.dto';
 import { UpdateDownloadClientDto } from './dto/update-download-client.dto';
 import { TestDownloadClientDto } from './dto/test-download-client.dto';
@@ -96,8 +96,8 @@ export class DownloadClientsController {
 
   @Get(':id')
   @CheckPolicies((ability) => ability.can(Action.Read, DownloadClient))
-  findOne(@Param('id', ParseIntPipe) id: number) {
-    return this.service.findOne(id);
+  async findOne(@Param('id', ParseIntPipe) id: number) {
+    return redactPassword(await this.service.findOne(id));
   }
 
   @Put(':id')

--- a/backend/src/modules/download-clients/download-clients.service.ts
+++ b/backend/src/modules/download-clients/download-clients.service.ts
@@ -75,6 +75,15 @@ export interface QueueQuery {
 const QUEUE_PAGE_SIZE_DEFAULT = 20;
 const QUEUE_PAGE_SIZE_MAX = 100;
 
+/** Strips the stored credential so it never reaches an HTTP response. */
+export function redactPassword(dc: DownloadClient): DownloadClient {
+  const { password: _password, ...settings } = (dc.settings ?? {}) as Record<
+    string,
+    unknown
+  >;
+  return { ...dc, settings };
+}
+
 const QB_STATE_MAP: Record<string, string> = {
   error: 'Error',
   missingFiles: 'Missing files',
@@ -131,11 +140,13 @@ export class DownloadClientsService {
       enabled: dto.enabled ?? true,
       priority: dto.priority ?? 1,
     });
-    return this.repo.save(row);
+    const saved = await this.repo.save(row);
+    return redactPassword(saved);
   }
 
-  findAll(): Promise<DownloadClient[]> {
-    return this.repo.find({ order: { priority: 'ASC', id: 'ASC' } });
+  async findAll(): Promise<DownloadClient[]> {
+    const rows = await this.repo.find({ order: { priority: 'ASC', id: 'ASC' } });
+    return rows.map(redactPassword);
   }
 
   async findOne(id: number): Promise<DownloadClient> {
@@ -152,10 +163,18 @@ export class DownloadClientsService {
     if (dto.name !== undefined) dc.name = dto.name;
     if (dto.implementation !== undefined)
       dc.implementation = dto.implementation;
-    if (dto.settings !== undefined) dc.settings = dto.settings;
+    if (dto.settings !== undefined) {
+      // Blank/absent password keeps the stored one instead of wiping it —
+      // the client never sends the real value back on read.
+      const incoming = dto.settings as Record<string, unknown>;
+      const existingPassword = (dc.settings as Record<string, unknown>)
+        ?.password;
+      dc.settings = { ...incoming, password: incoming.password || existingPassword };
+    }
     if (dto.enabled !== undefined) dc.enabled = dto.enabled;
     if (dto.priority !== undefined) dc.priority = dto.priority;
-    return this.repo.save(dc);
+    const saved = await this.repo.save(dc);
+    return redactPassword(saved);
   }
 
   async remove(id: number): Promise<void> {

--- a/backend/src/modules/indexers/indexers.controller.ts
+++ b/backend/src/modules/indexers/indexers.controller.ts
@@ -11,7 +11,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { IndexersService } from './indexers.service';
+import { IndexersService, redactApiKey } from './indexers.service';
 import { CreateIndexerDto } from './dto/create-indexer.dto';
 import { UpdateIndexerDto } from './dto/update-indexer.dto';
 import { TestIndexerConnectionDto } from './dto/test-indexer-connection.dto';
@@ -64,8 +64,8 @@ export class IndexersController {
 
   @Get(':id')
   @CheckPolicies((ability) => ability.can(Action.Read, Indexer))
-  findOne(@Param('id', ParseIntPipe) id: number) {
-    return this.indexersService.findOne(id);
+  async findOne(@Param('id', ParseIntPipe) id: number) {
+    return redactApiKey(await this.indexersService.findOne(id));
   }
 
   @Put(':id')

--- a/backend/src/modules/indexers/indexers.service.ts
+++ b/backend/src/modules/indexers/indexers.service.ts
@@ -8,6 +8,15 @@ import { TorznabService } from './torznab.service';
 import { IndexerThrottle } from './indexer-throttle.service';
 import { TestIndexerConnectionDto } from './dto/test-indexer-connection.dto';
 
+/** Strips the stored API key so it never reaches an HTTP response. */
+export function redactApiKey(ix: Indexer): Indexer {
+  const { apiKey: _apiKey, ...settings } = (ix.settings ?? {}) as Record<
+    string,
+    unknown
+  >;
+  return { ...ix, settings };
+}
+
 /** An indexer plus its live throttle state, as the settings page needs it. */
 export type IndexerWithCooldown = Indexer & {
   cooldown: {
@@ -63,7 +72,7 @@ export class IndexersService {
 
     const saved = await this.indexerRepo.save(row);
     void this.torznab.refreshCaps(saved);
-    return saved;
+    return redactApiKey(saved);
   }
 
   async findAll(): Promise<IndexerWithCooldown[]> {
@@ -72,7 +81,7 @@ export class IndexersService {
     });
     return rows.map((ix) => {
       const cd = this.throttle.getCooldown(ix.id);
-      return Object.assign(ix, {
+      return Object.assign(redactApiKey(ix), {
         cooldown: cd
           ? {
               reason: cd.reason,
@@ -114,12 +123,18 @@ export class IndexersService {
     if (dto.priority !== undefined) ix.priority = dto.priority;
     if (dto.requestDelay !== undefined) ix.requestDelay = dto.requestDelay;
     if (dto.enabled !== undefined) ix.enabled = dto.enabled;
-    if (dto.settings !== undefined)
-      ix.settings = this.sanitizeSettings(dto.settings);
+    if (dto.settings !== undefined) {
+      // Blank/absent apiKey keeps the stored one instead of wiping it —
+      // the client never sends the real value back on read.
+      const incoming = this.sanitizeSettings(dto.settings);
+      const existingApiKey = (ix.settings as Record<string, unknown>)
+        ?.apiKey;
+      ix.settings = { ...incoming, apiKey: incoming.apiKey || existingApiKey };
+    }
 
     const saved = await this.indexerRepo.save(ix);
     void this.torznab.refreshCaps(saved);
-    return saved;
+    return redactApiKey(saved);
   }
 
   async remove(id: number): Promise<void> {

--- a/backend/src/modules/settings/settings.controller.ts
+++ b/backend/src/modules/settings/settings.controller.ts
@@ -22,15 +22,15 @@ class SetBulkDto {
 export class SettingsController {
   constructor(private readonly service: SettingsService) {}
 
-  /** Get all settings (admin reads; values may contain API keys — admin only) */
+  /** Get all settings (values may contain API keys — admin only) */
   @Get()
-  @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
   getAll() {
     return this.service.getAll();
   }
 
   @Get(':key')
-  @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
   getOne(@Param('key') key: string) {
     return this.service.get(key).then((value) => ({ key, value }));
   }

--- a/client/src/app/core/services/app-settings.service.ts
+++ b/client/src/app/core/services/app-settings.service.ts
@@ -1,33 +1,13 @@
-import { Injectable, computed, inject, signal } from '@angular/core';
-import { SettingsApiService } from './api/settings-api.service';
+import { Injectable, computed, inject } from '@angular/core';
 import { PlayerSettingsService } from './player-settings.service';
 
 /**
- * Lazily-cached read access to server-side application settings for surfaces
- * that need a flag but don't own the settings page. Loads `/api/settings` once
- * and exposes signals; call `refresh()` after a save to re-read.
+ * Read access to the client-local player preferences that surfaces needing a
+ * subtitle-display flag depend on, without owning the settings page.
  */
 @Injectable({ providedIn: 'root' })
 export class AppSettingsService {
-  private readonly api = inject(SettingsApiService);
   private readonly playerSettings = inject(PlayerSettingsService);
-  private readonly all = signal<Record<string, string | null> | null>(null);
-  private loadPromise: Promise<Record<string, string | null>> | null = null;
-
-  /** Load the settings once (no-op once cached). Safe to call repeatedly. */
-  async ensureLoaded(): Promise<void> {
-    if (this.all()) return;
-    if (!this.loadPromise) {
-      this.loadPromise = this.api.getAll().catch(() => ({}) as Record<string, string | null>);
-    }
-    this.all.set(await this.loadPromise);
-  }
-
-  /** Re-read from the server (e.g. after the settings page saves). */
-  async refresh(): Promise<void> {
-    this.loadPromise = this.api.getAll().catch(() => ({}) as Record<string, string | null>);
-    this.all.set(await this.loadPromise);
-  }
 
   /**
    * Hide image-based (PGS/VOBSUB) subtitles from the pickers and native player.

--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -747,7 +747,6 @@ export class CastPlayerService {
     );
 
     // Build subtitle list from the parallel fetch (shared with the player).
-    await this.appSettings.ensureLoaded();
     const subtitleInfos: SubtitleInfo[] = buildSubtitleTracks(
       subsResult,
       opts.mediaFileId,

--- a/client/src/app/core/services/track-manager.service.ts
+++ b/client/src/app/core/services/track-manager.service.ts
@@ -149,7 +149,6 @@ export class TrackManagerService {
     if (!mediaId) return [];
 
     try {
-      await this.appSettings.ensureLoaded();
       const hideBurnIn = this.appSettings.hideBurnInSubtitles();
       // Devices whose player renders bitmap subs itself (ExoPlayer, mpv) show
       // them natively; others burn them into the video server-side.

--- a/client/src/app/features/settings/indexers/indexers.html
+++ b/client/src/app/features/settings/indexers/indexers.html
@@ -153,6 +153,7 @@
             class="input input-bordered input-sm w-full"
             [ngModel]="formTorznabKey()"
             (ngModelChange)="formTorznabKey.set($event)"
+            [placeholder]="editingId() !== null ? '••••••••' : ''"
           />
         </label>
 

--- a/client/src/app/features/settings/indexers/indexers.ts
+++ b/client/src/app/features/settings/indexers/indexers.ts
@@ -199,7 +199,7 @@ export class IndexersSettingsComponent implements OnInit {
     this.formEnableSearch.set(ix.enableSearch);
     const s = ix.settings ?? {};
     this.formTorznabBase.set(String(s['baseUrl'] ?? ''));
-    this.formTorznabKey.set(String(s['apiKey'] ?? ''));
+    this.formTorznabKey.set('');
     this.formMinSeeders.set(Number(s['minSeeders'] ?? 0));
     this.formSeedRatio.set(Number(s['seedRatio'] ?? 1));
     this.formMaxRetentionDays.set(s['maxRetentionDays'] != null ? Number(s['maxRetentionDays']) : null);
@@ -257,7 +257,7 @@ export class IndexersSettingsComponent implements OnInit {
       enableSearch: this.formEnableSearch(),
       settings: {
         baseUrl: base.replace(/\/$/, ''),
-        apiKey: this.formTorznabKey().trim(),
+        apiKey: this.formTorznabKey().trim() || undefined,
         minSeeders: this.formMinSeeders(),
         seedRatio: this.formSeedRatio(),
         maxRetentionDays: this.formMaxRetentionDays() || undefined,

--- a/client/src/app/features/settings/subtitles/subtitles-settings.ts
+++ b/client/src/app/features/settings/subtitles/subtitles-settings.ts
@@ -8,7 +8,6 @@ import {
 import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { SettingsApiService } from '../../../core/services/api/settings-api.service';
-import { AppSettingsService } from '../../../core/services/app-settings.service';
 import { ToastService } from '../../../core/services/toast.service';
 
 @Component({
@@ -19,7 +18,6 @@ import { ToastService } from '../../../core/services/toast.service';
 })
 export class SubtitlesSettingsComponent implements OnInit {
   private readonly api = inject(SettingsApiService);
-  private readonly appSettings = inject(AppSettingsService);
   private readonly translate = inject(TranslateService);
   private readonly toast = inject(ToastService);
 
@@ -75,7 +73,6 @@ export class SubtitlesSettingsComponent implements OnInit {
         subtitle_ocr_delete_source: this.deleteBurnInSource(),
         subtitle_custom_exclusions: this.customExclusions(),
       });
-      await this.appSettings.refresh();
       this.toast.success(this.translate.instant('settings.subtitles.saved'));
     } catch {
       // handled by global interceptor

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -137,11 +137,6 @@ export class SubtitlesModalComponent {
   private readonly streamingApi = inject(StreamingApiService);
   private readonly device = inject(DeviceService);
 
-  constructor() {
-    // Header subtitle chips honour the hide-burn-in app setting; load it once.
-    void this.appSettings.ensureLoaded();
-  }
-
   // ── Inputs ──
   readonly mediaId = input.required<number>();
   readonly episodeId = input<number | undefined>(undefined);


### PR DESCRIPTION
Phase 0 prerequisite of the plugin-system plan (PR 0.2), but both halves are live security bugs today and stand on their own.

> Note: the branch carries a single commit whose message covers only the first half. Squashing with the title above, per the repo guidance on not force-pushing a published branch.

## 1. Any account that can file a request could read every setting

`backend/src/modules/auth/casl/casl-ability.factory.ts:81-85` granted `Read 'Settings'` to anyone holding `media.create` **or** `requests.create`. On this install the default `User` role is `["media.read","requests.create","subtitles.manage"]`, so that is every ordinary account.

`GET /settings` returns all rows, and its own docstring says *"values may contain API keys — admin only"*. The policy said otherwise.

The grant justified itself with root folders, which migrated to `Library.isDefaultForMovies/Series` long ago. Removed; `GET /settings` and `GET /settings/:key` now require `Manage 'Settings'`.

**No new endpoint was needed.** Tracing every caller showed no non-admin page reads a settings key. The one non-admin caller, `core/services/app-settings.service.ts`, fetched the whole map on every playback and never read from it — `hideBurnInSubtitles` and `showSubtitleFormat` come from the client-local `PlayerSettingsService`. Deleting that call was required, not cosmetic: `error.interceptor.ts` toasts on 4xx, so otherwise every viewer opening the subtitle picker or casting would get a Forbidden toast.

## 2. The same accounts could read the torrent-client password

`Read DownloadClient` is granted by the same block, and `GET /download-clients` returned `settings.password` verbatim. `Indexer.settings.apiKey` had the same shape on its own endpoint.

`Read DownloadClient` is genuinely needed — `/activity` and the progress bars on home, media-detail and the request badge all consume `GET /download-clients/queue` — so the grant stays and the payload is fixed instead. Neither entity carries an `@Exclude` and the global `ClassSerializerInterceptor` cannot see inside a jsonb column, so both services strip the secret explicitly.

Withholding it on read surfaced a second bug: the edit form then submits a blank field, and the previous blind assignment wrote that blank over the stored secret. Both services now keep the existing value when the incoming one is blank and overwrite only on an explicit new value. `findOne` still returns the real credential — `update`, `remove`, `removeTorrent` and `blockTorrent` need it to reach the client — and the controller redacts at the boundary.

## Verification

Backend and client `tsc --noEmit` both exit 0. Backend restarted in the local Docker stack, boots clean. Live, against a token for a real `User`-role account (`requests.create`) and one for the owner:

| check | result |
|---|---|
| `GET /settings` as `requests.create` | **403** (was 200 with every API key) |
| `GET /settings` as owner | 200 |
| `GET /download-clients` as owner | 200, no `password` key in the payload |
| `GET /indexers` as owner | 200, no `apiKey` key in the payload |
| `GET /download-clients/queue` as `requests.create` | 200, still works |

Credential handling proven with a canary rather than the empty dev value:

| step | stored value |
|---|---|
| seed | `s3cr3t-canary` |
| `GET /download-clients` | 0 occurrences of the canary |
| `PUT` with no password field | `s3cr3t-canary` — preserved |
| `PUT` with `password: "rotated-value"` | `rotated-value` — overwritten |

Dev database restored to its original state afterwards.

## Noted, not fixed

`client/src/app/features/settings/indexers/indexers.html` hardcodes "Torznab base URL" and "API key" in English instead of using the translate pipe. Pre-existing and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)