### PR TITLE
fix(auth): deny handlers that declare no policy in PoliciesGuard

### DIFF
--- a/backend/src/modules/auth/casl/check-policies.decorator.ts
+++ b/backend/src/modules/auth/casl/check-policies.decorator.ts
@@ -11,3 +11,7 @@ export type PolicyHandler = IPolicyHandler | PolicyHandlerCallback;
 export const CHECK_POLICIES_KEY = 'check_policies';
 export const CheckPolicies = (...handlers: PolicyHandler[]) =>
   SetMetadata(CHECK_POLICIES_KEY, handlers);
+
+/** For handlers scoped to the caller's own record, where CASL has no object to test.
+ *  `PoliciesGuard` denies handlers that declare nothing, so the intent must be explicit. */
+export const AnyAuthenticatedUser: PolicyHandlerCallback = () => true;

--- a/backend/src/modules/auth/casl/policies.guard.ts
+++ b/backend/src/modules/auth/casl/policies.guard.ts
@@ -13,14 +13,17 @@ export class PoliciesGuard implements CanActivate {
   ) {}
 
   canActivate(context: ExecutionContext): boolean {
+    // Handler wins over class so a controller-wide default can be tightened per route.
     const policyHandlers =
-      this.reflector.get<PolicyHandler[]>(
-        CHECK_POLICIES_KEY,
+      this.reflector.getAllAndOverride<PolicyHandler[]>(CHECK_POLICIES_KEY, [
         context.getHandler(),
-      ) ?? [];
+        context.getClass(),
+      ]) ?? [];
 
+    // Fail closed: a handler under this guard that declares no policy is denied,
+    // so forgetting `@CheckPolicies` cannot silently expose it to every account.
     if (policyHandlers.length === 0) {
-      return true;
+      return false;
     }
 
     const { user } = context

--- a/backend/src/modules/users/users.controller.ts
+++ b/backend/src/modules/users/users.controller.ts
@@ -18,7 +18,10 @@ import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
 import { PoliciesGuard } from '../auth/casl/policies.guard';
-import { CheckPolicies } from '../auth/casl/check-policies.decorator';
+import {
+  CheckPolicies,
+  AnyAuthenticatedUser,
+} from '../auth/casl/check-policies.decorator';
 import { Action } from '../auth/casl/actions.enum';
 import { User } from './entities/user.entity';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
@@ -45,9 +48,10 @@ export class UsersController {
     return this.usersService.create(dto);
   }
 
-  /** Self: upload a new avatar (cropped square JPEG). No policy handler → the
-   *  class JWT guard is enough; the target is always the caller. */
+  /** Self: upload a new avatar (cropped square JPEG). The target is always the
+   *  caller, so there is no object for CASL to test. */
   @Post('me/avatar')
+  @CheckPolicies(AnyAuthenticatedUser)
   @UseInterceptors(
     FileInterceptor('file', { limits: { fileSize: 5 * 1024 * 1024 } }),
   )
@@ -60,6 +64,7 @@ export class UsersController {
 
   /** Self: remove the current avatar. */
   @Delete('me/avatar')
+  @CheckPolicies(AnyAuthenticatedUser)
   clearAvatar(@CurrentUser() user: User) {
     return this.usersService.clearAvatar(user.id);
   }


### PR DESCRIPTION
Phase 0 prerequisite (PR 0.7), and direct follow-up to #871 — that leak existed because a permissive default made a missing decorator invisible.

## The change

`PoliciesGuard.canActivate` returned `true` when a handler carried no `@CheckPolicies` metadata. 27 controllers sit behind this guard. Any route added to one of them without the decorator was reachable by every authenticated account, silently and with no signal in review.

It now denies instead. Two smaller fixes come with it:

- Metadata is read handler-then-class (`getAllAndOverride`). Previously only the handler was read, so a controller-wide `@CheckPolicies` would have been ignored while looking correct. Nothing uses class-level today; this makes it work rather than leaving the trap armed.
- `AnyAuthenticatedUser` is exported for handlers that act on the callers own record, where CASL has no object to test. Explicit intent instead of an inherited default.

## Audit before changing anything

Paired every `@Get/@Post/@Put/@Patch/@Delete` to its decorators across all 27 controllers. Exactly two handlers had no policy:

- `users.controller.ts` `POST me/avatar`
- `users.controller.ts` `DELETE me/avatar`

Both are scoped to `@CurrentUser()` — deliberate, and the docstring said so (*"No policy handler → the class JWT guard is enough; the target is always the caller"*). Both now declare `AnyAuthenticatedUser`. Re-running the audit after the change reports **0 handlers denied that were not denied before**.

## Verification

`tsc --noEmit` exits 0. Backend restarted in the local Docker stack, boots clean. Live, with a token for the owner and one for a real `User`-role account:

| endpoint | owner | `User` role |
|---|---|---|
| `/api/users` | 200 | 403 (unchanged) |
| `/api/media` | 200 | 200 |
| `/api/libraries` | 200 | — |
| `/api/settings` | 200 | 403 (from #871) |
| `/api/indexers` | 200 | — |
| `/api/download-clients` | 200 | — |
| `/api/requests` | 200 | 200 |
| `/api/roles` | 200 | — |
| `/api/profiles/quality` | 200 | — |
| `/api/counts` | 200 | 200 |
| `/api/playlists` | 200 | 200 |
| `/api/blocklist` | 200 | — |
| `/api/download-clients/queue` | — | 200 |

The two annotated handlers, as a normal user: `DELETE users/me/avatar` → 200, `POST users/me/avatar` without a file → 400 from validation. Neither 403, so the guard passes them. The test account had no avatar, so nothing was destroyed.

## Not included

The plan pairs this with the `error.interceptor.ts` 5xx fix. Skipping it here: omitting gateway errors is deliberate (the comment says so) and the application-level `503` it needs to surface has no producer yet. It moves to the PR that introduces one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)