### PR TITLE
fix(boot): survive an operator-imposed container uid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,13 +130,16 @@ ARG TVDB_API_KEY=""
 ENV TMDB_API_KEY=${TMDB_API_KEY}
 ENV TVDB_API_KEY=${TVDB_API_KEY}
 
-# Persistent conf dir for auto-generated server-side secrets (JWT
-# signing key, future encryption keys, etc.). Mount this as a Docker
-# volume so the secret survives container restarts and image
-# rebuilds. Permissions stay 0700; the secret files inside are 0600.
-RUN mkdir -p /app/conf && chmod 700 /app/conf
-VOLUME /app/conf
+# Persistent dirs, group=root + g=u: writable by root, by an arbitrary uid
+# with gid 0, or via `--user <uid> --group-add 0` — no USER directive needed.
+RUN mkdir -p /app/conf /app/images /app/transcode \
+ && chgrp -R 0 /app/conf /app/images /app/transcode \
+ && chmod -R g=u /app/conf /app/images /app/transcode
+VOLUME /app/conf /app/images /app/transcode
 
 EXPOSE 4848
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:'+(process.env.PORT||4848)+'/api/system/liveness',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
 
 CMD ["node", "dist/main"]

--- a/backend/src/common/constants/paths.ts
+++ b/backend/src/common/constants/paths.ts
@@ -1,5 +1,6 @@
 import * as os from 'os';
 import * as path from 'path';
+import { resolveWritableDir } from './writable-dir';
 
 /** Base directory for transient transcode/thumbnail data.
  *  `FLIKS_TRANSCODE_DIR` overrides; Windows falls back to `%TEMP%`, other
@@ -11,3 +12,22 @@ export const TRANSCODE_DIR =
     : process.platform === 'win32'
       ? path.join(os.tmpdir(), 'fliks-transcode')
       : '/tmp/transcode';
+
+let cachedImagesDir: string | null = null;
+
+/**
+ * Posters, fanart and seek-preview sprites. `FLIKS_IMAGES_DIR` overrides;
+ * falls back to a temp dir (wiped on restart) if `/app/images` isn't
+ * writable at the container's uid. Resolved and probed once, on first call.
+ */
+export function getImagesDir(): string {
+  if (cachedImagesDir) return cachedImagesDir;
+  const override = process.env.FLIKS_IMAGES_DIR?.trim();
+  cachedImagesDir = resolveWritableDir(
+    [override || path.join(process.cwd(), 'images'), path.join(os.tmpdir(), 'fliks-images')],
+    'Cannot write to the images directory — posters, fanart and seek-preview ' +
+      'sprites will not survive a restart. Set FLIKS_IMAGES_DIR, or mount ' +
+      '/app/images writable for this container user.',
+  );
+  return cachedImagesDir;
+}

--- a/backend/src/common/constants/writable-dir.spec.ts
+++ b/backend/src/common/constants/writable-dir.spec.ts
@@ -1,0 +1,43 @@
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Logger } from '@nestjs/common';
+import { resolveWritableDir } from './writable-dir';
+
+describe('resolveWritableDir', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(path.join(os.tmpdir(), 'writable-dir-test-'));
+  });
+
+  afterEach(() => {
+    chmodSync(tmpRoot, 0o700);
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('returns the first writable candidate without warning', () => {
+    const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    const dir = path.join(tmpRoot, 'ok');
+
+    const result = resolveWritableDir([dir, path.join(tmpRoot, 'unused')], 'warning');
+
+    expect(result).toBe(dir);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('falls back to the next candidate and warns when the first is unwritable', () => {
+    const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    const blocked = path.join(tmpRoot, 'blocked');
+    mkdirSync(blocked, { mode: 0o500 });
+    const fallback = path.join(tmpRoot, 'fallback');
+
+    const result = resolveWritableDir([blocked, fallback], 'fallback warning');
+
+    expect(result).toBe(fallback);
+    expect(existsSync(fallback)).toBe(true);
+    expect(warn).toHaveBeenCalledWith('fallback warning');
+    warn.mockRestore();
+  });
+});

--- a/backend/src/common/constants/writable-dir.ts
+++ b/backend/src/common/constants/writable-dir.ts
@@ -1,0 +1,34 @@
+import { closeSync, mkdirSync, openSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { Logger } from '@nestjs/common';
+
+const logger = new Logger('WritableDir');
+
+/**
+ * First candidate directory that accepts a real write. Probes by opening
+ * `.probe` for writing and deleting it — `fs.access` is not enough, it
+ * reports writable under some ACL/overlay-mount setups that then reject
+ * the actual write. Falls back to the last candidate (best effort, logging
+ * `warning`) if none of them are writable.
+ */
+export function resolveWritableDir(
+  candidates: string[],
+  warning: string,
+  mode?: number,
+): string {
+  for (let i = 0; i < candidates.length; i++) {
+    const dir = candidates[i];
+    try {
+      mkdirSync(dir, { recursive: true, mode });
+      const probe = join(dir, '.probe');
+      closeSync(openSync(probe, 'w'));
+      unlinkSync(probe);
+      if (i > 0) logger.warn(warning);
+      return dir;
+    } catch {
+      // try the next candidate
+    }
+  }
+  logger.warn(warning);
+  return candidates[candidates.length - 1];
+}

--- a/backend/src/common/utils/jwt-secret.ts
+++ b/backend/src/common/utils/jwt-secret.ts
@@ -1,6 +1,11 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { randomBytes } from 'crypto';
 import { join } from 'path';
+import * as os from 'os';
+import { Logger } from '@nestjs/common';
+import { resolveWritableDir } from '../constants/writable-dir';
+
+const logger = new Logger('JwtSecret');
 
 /**
  * Resolve the JWT signing secret without forcing the operator to set
@@ -18,7 +23,10 @@ import { join } from 'path';
  * The conf directory defaults to `/app/conf` (mountable as a Docker
  * volume so the secret survives container restarts and image
  * rebuilds). Override with `FLIKS_CONF_DIR` for local dev where
- * `/app/conf` is not writable.
+ * `/app/conf` is not writable. If neither is writable (e.g. the volume
+ * is root-owned and the container runs as a pinned uid), falls back to
+ * a temp dir so boot still succeeds — the secret then won't survive a
+ * restart.
  *
  * Sync I/O is intentional: this runs once at module init, before the
  * HTTP server starts accepting requests. Async would force the
@@ -27,8 +35,20 @@ import { join } from 'path';
  * Result is cached for the process lifetime — every JWT sign /
  * verify reads from memory, never the disk.
  */
-const CONF_DIR = process.env.FLIKS_CONF_DIR || '/app/conf';
-const JWT_SECRET_FILE = join(CONF_DIR, '.jwt-secret');
+let cachedConfDir: string | null = null;
+function confDir(): string {
+  if (cachedConfDir) return cachedConfDir;
+  const override = process.env.FLIKS_CONF_DIR?.trim();
+  cachedConfDir = resolveWritableDir(
+    [override || '/app/conf', join(os.tmpdir(), 'fliks-conf')],
+    'Cannot write to the JWT conf directory — JWT_SECRET will be ' +
+      'regenerated on every restart and every session invalidated. Set ' +
+      'JWT_SECRET directly, or make FLIKS_CONF_DIR (default /app/conf) ' +
+      'writable for this container user.',
+    0o700,
+  );
+  return cachedConfDir;
+}
 
 let cached: string | null = null;
 
@@ -40,14 +60,28 @@ export function getJwtSecret(): string {
     return cached;
   }
 
-  if (existsSync(JWT_SECRET_FILE)) {
-    cached = readFileSync(JWT_SECRET_FILE, 'utf8').trim();
+  const dir = confDir();
+  const file = join(dir, '.jwt-secret');
+
+  try {
+    if (existsSync(file)) {
+      cached = readFileSync(file, 'utf8').trim();
+      return cached;
+    }
+
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    const secret = randomBytes(32).toString('hex');
+    writeFileSync(file, secret, { mode: 0o600 });
+    cached = secret;
+    return secret;
+  } catch (err) {
+    // resolveWritableDir already probed `dir` — this only fires on a race
+    // or a read failure on an existing file it can no longer access.
+    logger.warn(
+      `Cannot persist JWT secret in ${dir} (${(err as Error).message}) — ` +
+        'using an in-memory secret for this process only.',
+    );
+    cached = randomBytes(32).toString('hex');
     return cached;
   }
-
-  mkdirSync(CONF_DIR, { recursive: true, mode: 0o700 });
-  const secret = randomBytes(32).toString('hex');
-  writeFileSync(JWT_SECRET_FILE, secret, { mode: 0o600 });
-  cached = secret;
-  return secret;
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -2,7 +2,7 @@
 process.env.UV_THREADPOOL_SIZE = '16';
 
 import { NestFactory, Reflector } from '@nestjs/core';
-import { ClassSerializerInterceptor, ValidationPipe } from '@nestjs/common';
+import { ClassSerializerInterceptor, Logger, ValidationPipe } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import { AppModule } from './app.module';
 import { LogBufferService } from './modules/scheduler/log-buffer.service';
@@ -93,4 +93,20 @@ async function bootstrap() {
   const port = Number(process.env.PORT) || 4848;
   await app.listen(port);
 }
-bootstrap();
+
+const bootstrapLogger = new Logger('Bootstrap');
+
+// `restart: unless-stopped` retries forever on a silent crash — log and exit visibly instead.
+process.on('unhandledRejection', (reason) => {
+  bootstrapLogger.error('Unhandled rejection', reason as Error);
+  process.exit(1);
+});
+process.on('uncaughtException', (err) => {
+  bootstrapLogger.error('Uncaught exception', err.stack);
+  process.exit(1);
+});
+
+bootstrap().catch((err) => {
+  bootstrapLogger.error('Failed to start', err instanceof Error ? err.stack : err);
+  process.exit(1);
+});

--- a/backend/src/modules/images/image.service.ts
+++ b/backend/src/modules/images/image.service.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 import * as fs from 'fs';
 import * as path from 'path';
 import sharp from 'sharp';
+import { getImagesDir } from '../../common/constants/paths';
 
 export type ImageType =
   | 'media'
@@ -75,7 +76,7 @@ function sizeTokenWidth(token: string): number | null {
 @Injectable()
 export class ImageService {
   private readonly logger = new Logger(ImageService.name);
-  private readonly baseDir = path.join(process.cwd(), 'images');
+  private readonly baseDir = getImagesDir();
 
   /**
    * Download an image from a remote URL and store it locally, generating the

--- a/backend/src/modules/scheduler/liveness.controller.spec.ts
+++ b/backend/src/modules/scheduler/liveness.controller.spec.ts
@@ -1,0 +1,8 @@
+import { LivenessController } from './liveness.controller';
+
+describe('LivenessController', () => {
+  it('carries no guard metadata and returns ok', () => {
+    expect(Reflect.getMetadata('__guards__', LivenessController)).toBeUndefined();
+    expect(new LivenessController().liveness()).toEqual({ ok: true });
+  });
+});

--- a/backend/src/modules/scheduler/liveness.controller.ts
+++ b/backend/src/modules/scheduler/liveness.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get } from '@nestjs/common';
+
+/** Unauthenticated by design — the only route a container HEALTHCHECK can
+ *  call before any credentials exist. No `@UseGuards`, no dependencies. */
+@Controller('system')
+export class LivenessController {
+  @Get('liveness')
+  liveness(): { ok: true } {
+    return { ok: true };
+  }
+}

--- a/backend/src/modules/scheduler/scheduler.module.ts
+++ b/backend/src/modules/scheduler/scheduler.module.ts
@@ -19,6 +19,7 @@ import { LogBufferService } from './log-buffer.service';
 import { UpdateCheckService } from './update-check.service';
 import { CommandsController } from './commands.controller';
 import { SystemController } from './system.controller';
+import { LivenessController } from './liveness.controller';
 import { IndexersModule } from '../indexers/indexers.module';
 import { DownloadClientsModule } from '../download-clients/download-clients.module';
 import { MetadataProvidersModule } from '../metadata-providers/metadata-providers.module';
@@ -77,7 +78,7 @@ import { Library } from '../libraries/entities/library.entity';
     ProfilesModule,
     MarkersModule,
   ],
-  controllers: [CommandsController, SystemController],
+  controllers: [CommandsController, SystemController, LivenessController],
   providers: [
     SchedulerService,
     CompletionService,

--- a/backend/src/modules/streaming/thumbnail.service.ts
+++ b/backend/src/modules/streaming/thumbnail.service.ts
@@ -6,6 +6,7 @@ import { promisify } from 'util';
 import { existsSync } from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
+import { getImagesDir } from '../../common/constants/paths';
 import { EventsService } from '../scheduler/events.service';
 import { Command } from '../scheduler/entities/command.entity';
 import {
@@ -34,8 +35,8 @@ export interface SpriteMetadata {
   count: number;
 }
 
-const BASE_DIR = path.join(process.cwd(), 'images', 'thumbnails');
-const FRAMES_TMP_DIR = path.join(process.cwd(), 'images', 'thumbnails-tmp');
+const baseDir = () => path.join(getImagesDir(), 'thumbnails');
+const framesTmpDir = () => path.join(getImagesDir(), 'thumbnails-tmp');
 
 /** Concurrent ffmpeg `-ss` seeks per sprite. HW decode saturates much
  *  earlier than the CPU pool — the GPU's decoder-session count caps useful
@@ -159,7 +160,7 @@ export class ThumbnailService {
     skipTracking = false,
     crop?: CropArea,
   ): Promise<SpriteMetadata | null> {
-    const dir = path.join(BASE_DIR, String(mediaFileId));
+    const dir = path.join(baseDir(), String(mediaFileId));
     const metaPath = path.join(dir, 'sprite.json');
 
     if (!force && existsSync(metaPath)) {
@@ -193,11 +194,11 @@ export class ThumbnailService {
   }
 
   getSpritePath(mediaFileId: number): string {
-    return path.join(BASE_DIR, String(mediaFileId), 'sprite.jpg');
+    return path.join(baseDir(), String(mediaFileId), 'sprite.jpg');
   }
 
   getMetadataPath(mediaFileId: number): string {
-    return path.join(BASE_DIR, String(mediaFileId), 'sprite.json');
+    return path.join(baseDir(), String(mediaFileId), 'sprite.json');
   }
 
   /**
@@ -207,7 +208,7 @@ export class ThumbnailService {
    * import/rescan (scheduler) or via the manual regenerate button.
    */
   async readExistingMeta(mediaFileId: number): Promise<SpriteMetadata | null> {
-    const metaPath = path.join(BASE_DIR, String(mediaFileId), 'sprite.json');
+    const metaPath = path.join(baseDir(), String(mediaFileId), 'sprite.json');
     if (!existsSync(metaPath)) return null;
     try {
       return JSON.parse(await fsp.readFile(metaPath, 'utf-8'));
@@ -253,7 +254,7 @@ export class ThumbnailService {
     skipTracking = false,
     crop?: CropArea,
   ): Promise<SpriteMetadata | null> {
-    const dir = path.join(BASE_DIR, String(mediaFileId));
+    const dir = path.join(baseDir(), String(mediaFileId));
     const spritePath = path.join(dir, 'sprite.jpg');
     const metaPath = path.join(dir, 'sprite.json');
     const interval = this.pickInterval(durationSeconds);
@@ -304,7 +305,7 @@ export class ThumbnailService {
       });
     }
 
-    const framesDir = path.join(FRAMES_TMP_DIR, String(mediaFileId));
+    const framesDir = path.join(framesTmpDir(), String(mediaFileId));
     await fsp.mkdir(dir, { recursive: true });
     await fsp.mkdir(framesDir, { recursive: true });
 
@@ -442,7 +443,7 @@ export class ThumbnailService {
       });
       // Cleanup tmp frames (fire-and-forget).
       fsp
-        .rm(path.join(FRAMES_TMP_DIR, String(mediaFileId)), {
+        .rm(path.join(framesTmpDir(), String(mediaFileId)), {
           recursive: true,
           force: true,
         })

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -25,6 +25,12 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    # Uncomment if your platform pins the container user (TrueNAS catalog uid
+    # 568, unraid 99:100, Kubernetes runAsNonRoot, OpenShift arbitrary uid).
+    # Any uid works as long as gid 0 is in the group list — the image's
+    # /app/conf, /app/images and /app/transcode are group-writable by root.
+    # user: '568:568'
+    # group_add: ['0']
     # mDNS doesn't cross a bridge network, so Chromecast auto-discovery needs
     # `network_mode: host` — then drop `ports:` and set DB_HOST to 127.0.0.1.
     ports:


### PR DESCRIPTION
Phase 0 prerequisite (PR 0.6) of the plugin-system plan, but it stands entirely on its own: **it is what currently blocks shipping in the TrueNAS catalog.**

## The bug

Fliks cannot boot when the operator pins the container user. That is not an edge case — it is the normal configuration on every target platform: TrueNAS catalog apps run as **568**, unraid as 99:100, Kubernetes with `runAsNonRoot`, OpenShift with an arbitrary uid and gid 0. `plans/truenas-catalog.plan.md` never mentions uid, and its validation step "install with default values, confirm the container is healthy" fails at step one.

Three directories, one shape — created root-owned at image build, written unconditionally at runtime:

| Path | How it breaks |
|---|---|
| `/app/conf` | `Dockerfile` did `mkdir -p /app/conf && chmod 700` at build time, so root:root 0700, and `VOLUME` seeds the named volume with that ownership. `jwt-secret.ts` then writes `.jwt-secret` with no try/catch and no fallback → EACCES. |
| `/app/images` | Mounted by `docker-compose.example.yml` but **never created in the image**, so Docker seeds it root:root 0755. Every poster and seek sprite write fails → a library with no artwork and no error. |
| `/app/transcode` | Same, though see the note below — it is currently unused. |

And the failure looped invisibly: `bootstrap()` had no `.catch()`, no `unhandledRejection` or `uncaughtException` handler, `LogBufferService` installs only *after* `NestFactory.create()` resolves, and the shipped compose uses `restart: unless-stopped`. The only escapes were setting `JWT_SECRET` or `FLIKS_CONF_DIR`, neither documented as required.

## The fix

**Directory resolution** copies the shape `common/constants/paths.ts` already used for `TRANSCODE_DIR`: try the configured path, fall back to one under the OS temp dir. The probe opens a file for writing rather than calling `access`, which lies under some mount and ACL setups. Falling back logs the consequence and the fixes; it never throws, which matters because `jwt-secret.ts` runs inside `NestFactory.create()`.

**Image directories** are created group-root and group-writable (`chgrp -R 0` + `chmod -R g=u` → 0775 root:0). **No `USER` directive** — it would turn every existing installs root-owned volumes into EACCES on the next `docker compose pull`, with no in-image migration possible, and every target platform overrides it anyway. Loosening 0700 → 0775 on `/app/conf` changes nothing: its only occupant is a 0600 file owned by the running uid, and group 0 is root.

**`HEALTHCHECK`** needed an unauthenticated route. `system/health` is `@CheckPolicies(can(Read,'Settings'))`, so probing it would mark every container permanently unhealthy. This codebase has no global guard and no `@Public()` decorator — auth is opt-in per controller — and `SystemController` carries class-level guards a sibling method cannot escape, so liveness is a separate zero-dependency controller sharing the `system` prefix.

**Beyond the brief:** `thumbnail.service.ts` had the identical `path.join(process.cwd(), 'images')` assumption. Routed through the same resolver so sprites cannot land somewhere other than posters after a fallback.

## Verification

`tsc --noEmit` exits 0. Two new spec files, 3 tests, passing.

**Fallback, under the real TrueNAS uid inside the running container:**

```
root-owned 0700 dir, resolver given [that dir, /tmp/fliks-conf-fallback]
  as root      → RESOLVED: /rootonly-conf              (no warning)
  as uid 568   → WARN [WritableDir] … → RESOLVED: /tmp/fliks-conf-fallback
                 drwxr-xr-x 2 568 568  /tmp/fliks-conf-fallback
```

The fallback directory is created and owned by 568. No throw.

**Permission pattern**, built as a synthetic image containing only the changed `RUN` lines, writing to all three directories:

| invocation | result |
|---|---|
| `--user 568:568 --group-add 0` (TrueNAS) | ok ok ok |
| `--user 1000670000:0` (OpenShift) | ok ok ok |
| `--user 99:100 --group-add 0` (unraid) | ok ok ok |
| root (default) | ok ok ok |
| `--user 568:568`, no group 0 — negative control | DENIED DENIED DENIED |

The negative control matters: it proves the directories are not accidentally world-writable, and that group-0 membership is genuinely the operators part of the contract.

**Liveness**, unauthenticated with no headers: `GET /api/system/liveness` → `200 {"ok":true}`. `GET /api/system/health` still → `401`. Backend restarted in the local Docker stack, boots clean.

The root Dockerfile was not built in full — it compiles Rust and jellyfin-ffmpeg — hence the synthetic image for the lines that changed.

## Note on `/app/transcode`

`TRANSCODE_DIR` is `/tmp/transcode` on non-Windows, and `/tmp` is world-writable in the base image, so nothing writes to `/app/transcode` today unless an operator sets `FLIKS_TRANSCODE_DIR`. The compose volume is currently dead weight. Kept and made writable rather than removed, because that env override is the supported way to persist the segment cache across restarts and it now works at any uid.

The uid section for `plans/truenas-catalog.plan.md` was written but `plans/` is gitignored, so only the `docker-compose.example.yml` half of the documentation lands here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)