### PR TITLE
fix(compose): point the segment cache at the volume mounted for it

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -42,6 +42,9 @@ services:
       DB_USERNAME: fliks
       DB_PASSWORD: changeme
       DB_NAME: fliks
+      # Without this the segment cache lands in /tmp, which is tmpfs on many
+      # hosts — and its LRU cap defaults to 20 GB.
+      FLIKS_TRANSCODE_DIR: /app/transcode
       # TZ: Europe/Paris
 
       # ---- Access (optional) ----
@@ -85,7 +88,8 @@ services:
       - fliks_conf:/app/conf
       # Posters, fanart, seek-preview sprites.
       - fliks_images:/app/images
-      # HLS segment cache. Omit for a per-restart tmpfs.
+      # HLS segment cache, paired with FLIKS_TRANSCODE_DIR above. Drop both to
+      # leave it in /tmp.
       - fliks_transcode:/app/transcode
 
   # ---- Intel QSV / VAAPI ---- add to the fliks service:


### PR DESCRIPTION
Follow-up to #874, which surfaced this while auditing the mounted directories.

## The dead wiring

`docker-compose.example.yml` mounts `fliks_transcode:/app/transcode` and labels it *"HLS segment cache"*. Nothing ever wrote there. `TRANSCODE_DIR` (`backend/src/common/constants/paths.ts`) resolves to `/tmp/transcode` unless `FLIKS_TRANSCODE_DIR` is set, and that variable appears in no compose file. The volume was inert and the comment was false.

## Why wire it rather than delete it

The persistence is real, not aspirational: `TranscodeCacheService.onModuleInit` calls `rebuildIndex()`, so on-disk segments are re-discovered after a restart and reused on a cache hit rather than re-encoded.

And the default is actively bad. `/tmp` is tmpfs on plenty of hosts, while the same compose file documents `TRANSCODE_CACHE_MAX_BYTES: 21474836480` — a 20 GB LRU cap. Shipping an example that aims a 20 GB cache at RAM is worse than an unused volume.

So the fix is the one line that was missing, plus a volume comment that now describes what actually happens.

## Not touched

`docker-compose.prod.yml` is stale in several ways — pinned to `ghcr.io/clementdelestre/fliks:v1.0.0`, mapping `3000:3000` against an app that listens on 4848, and mounting neither `/app/conf` nor `/app/images`. It is **gitignored** (`.gitignore:69`), so it is a local operator file rather than repo content, and out of scope here.

## Verification

Config-only change, no code path altered. `docker compose -f docker-compose.example.yml config` parses. The dev stack (`docker-compose.yml`) deliberately keeps the `/tmp/transcode` default and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)