### PR TITLE
refactor(imports): extract LibraryIngestService behind disk import

### DIFF
--- a/backend/src/common/library-ingest/library-ingest.module.ts
+++ b/backend/src/common/library-ingest/library-ingest.module.ts
@@ -1,0 +1,19 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Media } from '../../modules/media/entities/media.entity';
+import { MediaFile } from '../../modules/media/entities/media-file.entity';
+import { Episode } from '../../modules/media/entities/episode.entity';
+import { LibraryIngestService } from './library-ingest.service';
+import { FliksSchedulerModule } from '../../modules/scheduler/scheduler.module';
+import { MediaModule } from '../../modules/media/media.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Media, MediaFile, Episode]),
+    forwardRef(() => FliksSchedulerModule),
+    forwardRef(() => MediaModule),
+  ],
+  providers: [LibraryIngestService],
+  exports: [LibraryIngestService],
+})
+export class LibraryIngestModule {}

--- a/backend/src/common/library-ingest/library-ingest.service.ts
+++ b/backend/src/common/library-ingest/library-ingest.service.ts
@@ -1,0 +1,226 @@
+import { Injectable, Logger, Inject, forwardRef } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as fs from 'fs';
+import * as path from 'path';
+import { Media } from '../../modules/media/entities/media.entity';
+import { MediaFile } from '../../modules/media/entities/media-file.entity';
+import { Episode } from '../../modules/media/entities/episode.entity';
+import { MediaType } from '../enums';
+import { relativePathUnderMediaRoot } from '../utils/media-path.util';
+import { NamingService } from '../../modules/scheduler/naming.service';
+import { SubtitleSchedulerService } from '../../modules/scheduler/subtitle-scheduler.service';
+import { MediaService } from '../../modules/media/media.service';
+import { FileTransferService, TransferMethod } from '../services/file-transfer.service';
+
+export interface IngestRequest {
+  /** Media the file(s) belong to. Must already be anchored to a library
+   *  (`library` + `folderName` persisted) — resolving/pinning that is the
+   *  caller's job, since each caller picks its own library differently. */
+  mediaId: number;
+  files: { path: string }[];
+  transfer: TransferMethod;
+  /** Quality used for naming and the initial `MediaFile.quality` column. */
+  fallbackQuality?: string;
+  /** For logs / companion-transfer log tags. */
+  sourceLabel: string;
+  /** Pre-resolved episode for a series file; the caller already matched it. */
+  episodeId?: number;
+  /** Bypass collision detection and overwrite in place. */
+  force?: boolean;
+  /** Append " (n)" instead of silently skipping when the computed name collides. */
+  uniquifyOnCollision?: boolean;
+}
+
+export interface IngestResult {
+  imported: MediaFile[];
+  seasonNumber?: number;
+  episodeNumber?: number;
+}
+
+/**
+ * Destination-path + filesystem-write + `MediaFile` persistence core shared
+ * by every path that lands a file in a library. Extracted from disk import;
+ * the media passed in must already be pinned to its library/folderName.
+ */
+@Injectable()
+export class LibraryIngestService {
+  private readonly logger = new Logger(LibraryIngestService.name);
+
+  constructor(
+    @InjectRepository(Media)
+    private readonly mediaRepo: Repository<Media>,
+    @InjectRepository(MediaFile)
+    private readonly fileRepo: Repository<MediaFile>,
+    @InjectRepository(Episode)
+    private readonly episodeRepo: Repository<Episode>,
+    private readonly naming: NamingService,
+    private readonly fileTransfer: FileTransferService,
+    @Inject(forwardRef(() => MediaService))
+    private readonly mediaService: MediaService,
+    @Inject(forwardRef(() => SubtitleSchedulerService))
+    private readonly subtitleScheduler: SubtitleSchedulerService,
+  ) {}
+
+  async ingest(req: IngestRequest): Promise<IngestResult> {
+    const media = await this.mediaRepo.findOne({
+      where: { id: req.mediaId },
+      relations: ['library'],
+    });
+    if (!media) {
+      throw new Error(`Media #${req.mediaId} not found`);
+    }
+
+    const formats = await this.naming.getFormats();
+    const companionExts = await this.fileTransfer.getCompanionExts();
+
+    let seasonNumber: number | undefined;
+    let episodeNumber: number | undefined;
+    let episodeTitle: string | undefined;
+    let airDate: string | undefined;
+    if (req.episodeId) {
+      const ep = await this.episodeRepo.findOne({
+        where: { id: req.episodeId },
+        relations: ['season'],
+      });
+      if (ep) {
+        episodeNumber = ep.episodeNumber;
+        seasonNumber = ep.season?.seasonNumber ?? 1;
+        episodeTitle = ep.title ?? undefined;
+        airDate = ep.airDate ?? undefined;
+      }
+    }
+
+    const imported: MediaFile[] = [];
+
+    for (const file of req.files) {
+      const ext = path.extname(file.path);
+      const sourceBase = path.basename(file.path, ext);
+      let newBaseName: string;
+      let destDir: string;
+
+      if (media.type === MediaType.MOVIE) {
+        newBaseName = this.naming.applyMovieFormat(formats.movie, {
+          title: media.title,
+          originalTitle: media.originalTitle,
+          year: media.year,
+          quality: req.fallbackQuality ?? '',
+          tmdbId: media.tmdbId,
+        });
+        destDir = media.path!;
+      } else {
+        newBaseName = this.naming.applySeriesFormat(formats.series, {
+          seriesTitle: media.title,
+          season: seasonNumber ?? 1,
+          episode: episodeNumber ?? 1,
+          episodeTitle,
+          quality: req.fallbackQuality ?? '',
+          airDate,
+        });
+        const seasonFolder = this.naming.applySeasonFolderFormat(
+          formats.seasonFolder,
+          { season: seasonNumber ?? 1 },
+        );
+        destDir = path.join(media.path!, seasonFolder);
+      }
+
+      let destPath = path.join(destDir, newBaseName + ext);
+
+      // `relativePath` is stored relative to the MEDIA root (library.path +
+      // folderName) — matches how the grab/rescan paths store it.
+      let relativePath = relativePathUnderMediaRoot(media.path!, destPath);
+      if (!relativePath) {
+        this.logger.error(
+          `Ingest[${req.sourceLabel}]: computed dest outside media folder — root=${media.path!} dest=${destPath}`,
+        );
+        throw new Error('destination en dehors du dossier du média');
+      }
+
+      const collides = async (rel: string, abs: string) =>
+        fs.existsSync(abs) ||
+        !!(await this.fileRepo.findOne({
+          where: { media: { id: media.id }, relativePath: rel },
+        }));
+
+      if ((await collides(relativePath, destPath)) && !req.force) {
+        if (!req.uniquifyOnCollision) {
+          // Re-running the same import is a safe no-op.
+          continue;
+        }
+        // A different file maps to a name already taken by this media (e.g.
+        // a second copy of the same quality). Append " (n)" instead of
+        // silently skipping it.
+        let n = 2;
+        let base: string;
+        let rel: string | null;
+        do {
+          base = `${newBaseName} (${n})`;
+          destPath = path.join(destDir, base + ext);
+          rel = relativePathUnderMediaRoot(media.path!, destPath);
+          n++;
+        } while (rel && (await collides(rel, destPath)) && n < 100);
+        if (!rel) continue;
+        newBaseName = base;
+        relativePath = rel;
+      }
+
+      let sourceSize = 0;
+      try {
+        sourceSize = fs.statSync(file.path).size;
+      } catch {
+        // Caller already verified the source exists; best-effort fallback only.
+      }
+
+      await this.fileTransfer.transferFile(file.path, destPath, req.transfer);
+      await this.fileTransfer.transferCompanions({
+        srcDir: path.dirname(file.path),
+        destDir,
+        sourceBaseName: sourceBase,
+        newBaseName,
+        method: req.transfer,
+        allowedExts: companionExts,
+        logTag: `library-ingest:${req.sourceLabel}`,
+      });
+
+      const finalSize = (() => {
+        try {
+          return fs.statSync(destPath).size;
+        } catch {
+          return sourceSize;
+        }
+      })();
+
+      const saved = await this.fileRepo.save(
+        this.fileRepo.create({
+          media,
+          episode:
+            req.episodeId != null ? ({ id: req.episodeId } as Episode) : null,
+          relativePath,
+          size: finalSize,
+          quality: req.fallbackQuality ?? '',
+        }),
+      );
+
+      await this.mediaService.enrichMediaFileFromDisk(saved.id);
+      try {
+        await this.subtitleScheduler.onMediaFileImported(
+          media.id,
+          saved.id,
+          req.episodeId ?? undefined,
+        );
+      } catch (e) {
+        this.logger.warn(
+          `Ingest[${req.sourceLabel}]: post-import subtitle pipeline failed — ${(e as Error).message}`,
+        );
+      }
+
+      if (req.episodeId) {
+        await this.episodeRepo.update(req.episodeId, { hasFile: true });
+      }
+
+      imported.push(saved);
+    }
+
+    return { imported, seasonNumber, episodeNumber };
+  }
+}

--- a/backend/src/modules/imports/disk-import.service.ts
+++ b/backend/src/modules/imports/disk-import.service.ts
@@ -33,10 +33,8 @@ import { MediaMetadataService } from '../media/media-service/media-metadata.serv
 import { NamingService } from '../scheduler/naming.service';
 import { SubtitleSchedulerService } from '../scheduler/subtitle-scheduler.service';
 import { LibrariesService } from '../libraries/libraries.service';
-import {
-  FileTransferService,
-  TransferMethod,
-} from '../../common/services/file-transfer.service';
+import { TransferMethod } from '../../common/services/file-transfer.service';
+import { LibraryIngestService } from '../../common/library-ingest/library-ingest.service';
 
 const VIDEO_EXTS = new Set([
   '.mkv',
@@ -85,10 +83,10 @@ export class DiskImportService {
     private readonly subtitleScheduler: SubtitleSchedulerService,
     private readonly naming: NamingService,
     private readonly libraries: LibrariesService,
-    private readonly fileTransfer: FileTransferService,
     @Inject(forwardRef(() => MediaMetadataService))
     private readonly metadata: MediaMetadataService,
     private readonly nfo: NfoMetadataService,
+    private readonly libraryIngest: LibraryIngestService,
   ) {}
 
   /**
@@ -454,7 +452,6 @@ export class DiskImportService {
     const errors: string[] = [];
 
     const formats = await this.naming.getFormats();
-    const companionExts = await this.fileTransfer.getCompanionExts();
 
     for (const entry of imports) {
       try {
@@ -468,9 +465,8 @@ export class DiskImportService {
         }
 
         // Verify the source still exists before we touch the DB.
-        let sourceStat: fs.Stats;
         try {
-          sourceStat = fs.statSync(entry.filePath);
+          fs.statSync(entry.filePath);
         } catch {
           errors.push(
             `${path.basename(entry.filePath)}: fichier source introuvable`,
@@ -518,151 +514,19 @@ export class DiskImportService {
           media.folderName = folderName;
         }
 
-        // Build destination filename + folder via the naming service.
-        const ext = path.extname(entry.filePath);
-        const sourceBase = path.basename(entry.filePath, ext);
-        let newBaseName: string;
-        let destDir: string;
-
-        if (media.type === MediaType.MOVIE) {
-          newBaseName = this.naming.applyMovieFormat(formats.movie, {
-            title: media.title,
-            originalTitle: media.originalTitle,
-            year: media.year,
-            quality: entry.quality,
-            tmdbId: media.tmdbId,
-          });
-          destDir = media.path!;
-        } else {
-          // Series: pull season + episode metadata from the matched Episode
-          // (the scan phase already created/linked it) so renaming stays
-          // consistent with the DB rather than re-parsing the filename.
-          let seasonNumber = 1;
-          let episodeNumber = 1;
-          let episodeTitle: string | undefined;
-          let airDate: string | undefined;
-          if (entry.episodeId) {
-            const ep = await this.episodeRepo.findOne({
-              where: { id: entry.episodeId },
-              relations: ['season'],
-            });
-            if (ep) {
-              episodeNumber = ep.episodeNumber;
-              seasonNumber = ep.season?.seasonNumber ?? 1;
-              episodeTitle = ep.title ?? undefined;
-              airDate = ep.airDate ?? undefined;
-            }
-          }
-          newBaseName = this.naming.applySeriesFormat(formats.series, {
-            seriesTitle: media.title,
-            season: seasonNumber,
-            episode: episodeNumber,
-            episodeTitle,
-            quality: entry.quality,
-            airDate,
-          });
-          const seasonFolder = this.naming.applySeasonFolderFormat(
-            formats.seasonFolder,
-            { season: seasonNumber },
-          );
-          destDir = path.join(media.path!, seasonFolder);
-        }
-
-        let destPath = path.join(destDir, newBaseName + ext);
-
-        // `relativePath` is stored relative to the MEDIA root (library.path +
-        // folderName), matching how the grab/rescan paths store it and how
-        // `enrichMediaFileFromDisk` resolves it. Computing it against the
-        // library root instead double-counts the media folder and leaves the
-        // file unresolvable on disk.
-        let relativePath = relativePathUnderMediaRoot(media.path!, destPath);
-        if (!relativePath) {
-          this.logger.error(
-            `Disk import: computed dest outside media folder — root=${media.path!} dest=${destPath}`,
-          );
-          errors.push(
-            `${path.basename(entry.filePath)}: destination en dehors du dossier du média`,
-          );
-          continue;
-        }
-        const collides = async (rel: string, abs: string) =>
-          fs.existsSync(abs) ||
-          !!(await this.fileRepo.findOne({
-            where: { media: { id: media.id }, relativePath: rel },
-          }));
-        if ((await collides(relativePath, destPath)) && !entry.force) {
-          if (!opts.uniquifyOnCollision) {
-            // Re-running the same import is a safe no-op.
-            continue;
-          }
-          // A different orphan file maps to a name already taken by this media
-          // (e.g. a second copy of the same quality). Append " (n)" so it is
-          // linked as an additional file instead of being silently skipped.
-          let n = 2;
-          let base: string;
-          let rel: string | null;
-          do {
-            base = `${newBaseName} (${n})`;
-            destPath = path.join(destDir, base + ext);
-            rel = relativePathUnderMediaRoot(media.path!, destPath);
-            n++;
-          } while (rel && (await collides(rel, destPath)) && n < 100);
-          if (!rel) continue;
-          newBaseName = base;
-          relativePath = rel;
-        }
-
-        // Filesystem write. mkdir + copy/move handled by FileTransferService.
-        await this.fileTransfer.transferFile(entry.filePath, destPath, method);
-        await this.fileTransfer.transferCompanions({
-          srcDir: path.dirname(entry.filePath),
-          destDir,
-          sourceBaseName: sourceBase,
-          newBaseName,
-          method,
-          allowedExts: companionExts,
-          logTag: `disk-import:${media.title}`,
+        // Destination path, filesystem write, MediaFile row and post-import
+        // enrichment all live in the shared ingest service.
+        const result = await this.libraryIngest.ingest({
+          mediaId: media.id,
+          files: [{ path: entry.filePath }],
+          transfer: method,
+          fallbackQuality: entry.quality,
+          sourceLabel: media.title,
+          episodeId: entry.episodeId,
+          force: entry.force,
+          uniquifyOnCollision: opts.uniquifyOnCollision,
         });
-
-        const finalSize = (() => {
-          try {
-            return fs.statSync(destPath).size;
-          } catch {
-            return sourceStat.size;
-          }
-        })();
-
-        const saved = await this.fileRepo.save(
-          this.fileRepo.create({
-            media,
-            episode:
-              entry.episodeId != null
-                ? ({ id: entry.episodeId } as Episode)
-                : null,
-            relativePath,
-            size: finalSize,
-            quality: entry.quality,
-          }),
-        );
-
-        await this.mediaService.enrichMediaFileFromDisk(saved.id);
-        try {
-          await this.subtitleScheduler.onMediaFileImported(
-            media.id,
-            saved.id,
-            entry.episodeId ?? undefined,
-          );
-        } catch (e) {
-          this.logger.warn(
-            `Disk import: post-import subtitle pipeline failed — ${(e as Error).message}`,
-          );
-        }
-
-        if (entry.episodeId) {
-          await this.episodeRepo.update(entry.episodeId, { hasFile: true });
-        }
-
-        imported++;
+        imported += result.imported.length;
       } catch (e) {
         errors.push(
           `${path.basename(entry.filePath)}: ${(e as Error).message}`,

--- a/backend/src/modules/imports/imports.module.ts
+++ b/backend/src/modules/imports/imports.module.ts
@@ -22,6 +22,7 @@ import { SettingsModule } from '../settings/settings.module';
 import { LibrariesModule } from '../libraries/libraries.module';
 import { MediaModule } from '../media/media.module';
 import { FliksSchedulerModule } from '../scheduler/scheduler.module';
+import { LibraryIngestModule } from '../../common/library-ingest/library-ingest.module';
 
 @Module({
   imports: [
@@ -42,6 +43,7 @@ import { FliksSchedulerModule } from '../scheduler/scheduler.module';
     LibrariesModule,
     forwardRef(() => MediaModule),
     forwardRef(() => FliksSchedulerModule),
+    LibraryIngestModule,
   ],
   controllers: [ImportsController],
   providers: [


### PR DESCRIPTION
Phase 1 of the plugin-system plan (PR 1.3). **No behaviour change** — full suite identical before and after.

## What this is

Landing a file in the library is implemented twice: `imports/disk-import.service.ts` for files the user already has, `scheduler/completion.service.ts` for a finished torrent. Both compute a destination through `NamingService`, transfer, write `MediaFile` rows and handle companions.

The shared service is extracted here and **only disk import is repointed**. `completion.service.ts` is byte-identical — it converges in the next pull request, against an extraction already exercised by the simpler caller.

## The real output: the two implementations have drifted apart in 16 ways

This is what the reconciliation PR has to decide, so it is worth reading. Several are defects rather than asymmetries.

**Likely bugs:**

1. **Disk import can silently downgrade quality to 480p.** It names the file from the pre-parsed `entry.quality`, then `enrichMediaFileFromDisk` → `probeAndResolve` overwrites the DB column afterwards — and that path has **no keep-prior-value fallback**, so a failed probe buckets to 480p (`resolution.util.ts:29-30`). The torrent path guards against exactly this with `: history.quality` (`completion.service.ts:819-830`). The on-disk filename also never reflects the correction, since naming already happened.
2. **Duplicate `MediaFile` rows on a forced re-import.** With `entry.force`, the DB-collision branch is skipped but `fileRepo.create()` still inserts, so one `relativePath` can end up with two rows.
3. **A failed enrichment marks the whole entry as an error** even though the file was already transferred and the row already saved, so the user sees a failure for a successful import. The torrent path runs the same work fire-and-forget after completion, where a failure cannot affect the outcome.
4. **The torrent path has no pre-write collision guard at all** — `transferFile` always overwrites. Disk import checks first and either skips or suffixes.

**Asymmetries to decide, not obviously wrong:** quality source (trusted vs. re-probed from pixels); library pin policy (disk import reassigns, torrent only pins when unset); file size (re-stat the destination vs. trust the clients reported size); `streamInfo` populated at creation only on torrent; re-import self-heals on torrent but is skipped on disk import; episode resolution (pre-matched vs. re-parsed with a silent `1/1` default).

**Torrent-only, by nature:** SSE `import.complete`/`queue.updated`, notifications and external-media-server dispatch, marker detection, sprite generation, the post-import script hook, and all `DownloadHistory` bookkeeping.

## Contract

```ts
export interface IngestRequest {
  mediaId: number;
  files: { path: string }[];
  transfer: copy | move;
  fallbackQuality?: string;
  sourceLabel: string;
  episodeId?: number;            // added
  force?: boolean;               // added
  uniquifyOnCollision?: boolean; // added
}
```

The three additions are not speculation — disk import needs each. `episodeId` because this caller resolves the episode upstream and re-deriving it from the filename would contradict what it already matched. `force` and `uniquifyOnCollision` because its collision handling is load-bearing and has no torrent equivalent.

Deliberately **not** in the contract: library resolution and the pin-or-reassign policy. That is difference #2 above and belongs to the reconciliation. `ingest()` assumes the media is already anchored; the caller keeps that step unchanged.

`files` is a single-element array today — each entry carries its own media and episode — but the shape is kept for the convergence, where several files legitimately share one `mediaId`.

## Verification

- `tsc --noEmit` exits 0.
- Full suite **80 suites / 766 tests / 29 snapshots — identical before and after.** That includes the 100 `NamingService` tests and the 8 pinning the torrent ingestion tail, both landed earlier this phase precisely to cover this move.
- `git diff --stat` on `completion.service.ts`: empty.
- Backend restarted in the local Docker stack: boots clean, liveness 200, no resolution errors.

## Noted

One French user-facing error string moved verbatim into `common/`. It pre-exists on `main` in `disk-import.service.ts`; rewriting it would have changed API output and broken the no-behaviour-change property this PR rests on. It should become a translation key, the same way the plan already schedules for the connection-test strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)