### PR TITLE
fix(media): stop a failed probe from downgrading a file to 480p

### DIFF
--- a/backend/src/modules/media/media-service/media-rescan.service.spec.ts
+++ b/backend/src/modules/media/media-service/media-rescan.service.spec.ts
@@ -1,0 +1,196 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { MediaRescanService } from './media-rescan.service';
+import { MediaType } from '../../../common/enums';
+
+/**
+ * Wires every collaborator `enrichMediaFileFromDisk` / `rescanFiles` touch
+ * onto a bare prototype instance — same approach as the other media-service
+ * specs, avoiding the 12-dependency constructor.
+ */
+function buildHarness() {
+  const service = Object.create(MediaRescanService.prototype) as MediaRescanService;
+
+  const mediaFileRepo = {
+    findOne: jest.fn(),
+    save: jest.fn(async (x: unknown) => x),
+    find: jest.fn().mockResolvedValue([]),
+    remove: jest.fn().mockResolvedValue(undefined),
+    count: jest.fn().mockResolvedValue(0),
+    create: jest.fn((x: unknown) => x),
+  };
+  const mediaRepo = { findOne: jest.fn() };
+  const episodeRepo = { update: jest.fn().mockResolvedValue(undefined) };
+  const seasonRepo = {};
+  const naming = { parseEpisodeNumbers: jest.fn() };
+  const ffprobe = {
+    detectMediaFileInfo: jest.fn(),
+    detectCrop: jest.fn().mockResolvedValue(null),
+  };
+  const subtitles = {
+    reconcileSubtitleFilesAfterRescan: jest
+      .fn()
+      .mockResolvedValue({ removedMissing: 0, removedDuplicates: 0 }),
+    discoverExternalSubtitles: jest.fn().mockResolvedValue(0),
+  };
+  const embeddedSubtitle = { detectAndStore: jest.fn().mockResolvedValue(undefined) };
+  const subtitleStream = {
+    clearMediaFileSubtitleCache: jest.fn().mockResolvedValue(undefined),
+    warmupCache: jest.fn().mockResolvedValue(undefined),
+  };
+  const thumbnailService = {};
+  const mediaServers = { dispatch: jest.fn() };
+  const metadata = { refreshSeriesEpisodes: jest.fn().mockResolvedValue(undefined) };
+  const log = { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+
+  const wired = service as unknown as Record<string, unknown>;
+  wired.mediaRepo = mediaRepo;
+  wired.seasonRepo = seasonRepo;
+  wired.episodeRepo = episodeRepo;
+  wired.mediaFileRepo = mediaFileRepo;
+  wired.naming = naming;
+  wired.ffprobe = ffprobe;
+  wired.subtitles = subtitles;
+  wired.embeddedSubtitle = embeddedSubtitle;
+  wired.subtitleStream = subtitleStream;
+  wired.thumbnailService = thumbnailService;
+  wired.mediaServers = mediaServers;
+  wired.metadata = metadata;
+  wired.log = log;
+
+  return {
+    service,
+    mediaRepo,
+    mediaFileRepo,
+    episodeRepo,
+    ffprobe,
+    subtitles,
+    embeddedSubtitle,
+    subtitleStream,
+    mediaServers,
+    metadata,
+    log,
+  };
+}
+
+describe('MediaRescanService.enrichMediaFileFromDisk — quality from probe results', () => {
+  let mediaDir: string;
+
+  beforeEach(() => {
+    mediaDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rescan-enrich-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(mediaDir, { recursive: true, force: true });
+  });
+
+  function dbFileIn(mediaDirPath: string, filename: string, quality: string) {
+    const absPath = path.join(mediaDirPath, filename);
+    fs.writeFileSync(absPath, 'video-bytes');
+    return {
+      id: 5,
+      relativePath: filename,
+      size: 1,
+      quality,
+      streamInfo: null,
+      media: { path: mediaDirPath, title: 'Ember Horizon' },
+    };
+  }
+
+  it('derives quality from real dimensions and overwrites the stale value', async () => {
+    const h = buildHarness();
+    const dbFile = dbFileIn(mediaDir, 'Ember.Horizon.2022.1080p.WEB-DL-RELGRP.mkv', 'HDTV-720p');
+    h.mediaFileRepo.findOne.mockResolvedValue(dbFile);
+    h.ffprobe.detectMediaFileInfo.mockResolvedValue({
+      video: [{ width: 1920, height: 1080 }],
+      audio: [],
+      subtitles: [],
+    });
+
+    await h.service.enrichMediaFileFromDisk(5);
+
+    expect(dbFile.quality).toBe('WEBDL-1080p');
+  });
+
+  it('keeps the existing quality when the probe reports no video stream', async () => {
+    const h = buildHarness();
+    const dbFile = dbFileIn(mediaDir, 'Ember.Horizon.2022.1080p.WEB-DL-RELGRP.mkv', 'WEBDL-1080p');
+    h.mediaFileRepo.findOne.mockResolvedValue(dbFile);
+    h.ffprobe.detectMediaFileInfo.mockResolvedValue({ video: [], audio: [], subtitles: [] });
+
+    await h.service.enrichMediaFileFromDisk(5);
+
+    expect(dbFile.quality).toBe('WEBDL-1080p');
+  });
+
+  it('keeps the existing quality and skips saving when ffprobe throws', async () => {
+    const h = buildHarness();
+    const dbFile = dbFileIn(mediaDir, 'Ember.Horizon.2022.1080p.WEB-DL-RELGRP.mkv', 'WEBDL-1080p');
+    h.mediaFileRepo.findOne.mockResolvedValue(dbFile);
+    h.ffprobe.detectMediaFileInfo.mockRejectedValue(new Error('ffprobe crashed'));
+
+    await h.service.enrichMediaFileFromDisk(5);
+
+    expect(dbFile.quality).toBe('WEBDL-1080p');
+    expect(h.mediaFileRepo.save).not.toHaveBeenCalled();
+  });
+});
+
+describe('MediaRescanService.rescanFiles — quality from probe results', () => {
+  let mediaDir: string;
+
+  beforeEach(() => {
+    mediaDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rescan-files-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(mediaDir, { recursive: true, force: true });
+  });
+
+  function movieMedia(over: Record<string, unknown>) {
+    return {
+      id: 8,
+      title: 'Ember Horizon',
+      type: MediaType.MOVIE,
+      files: [],
+      get path() {
+        return mediaDir;
+      },
+      ...over,
+    };
+  }
+
+  it('keeps an existing file quality unchanged when the refresh probe finds no video stream', async () => {
+    const h = buildHarness();
+    const filename = 'Ember.Horizon.2022.1080p.WEB-DL-RELGRP.mkv';
+    fs.writeFileSync(path.join(mediaDir, filename), 'video-bytes');
+    const dbFile = {
+      id: 9,
+      relativePath: filename,
+      size: 999,
+      quality: 'WEBDL-1080p',
+      streamInfo: null,
+    };
+    h.mediaRepo.findOne.mockResolvedValue(movieMedia({ files: [dbFile] }));
+    h.ffprobe.detectMediaFileInfo.mockResolvedValue({ video: [], audio: [], subtitles: [] });
+
+    await h.service.rescanFiles(8, { skipWarmup: true });
+
+    expect(dbFile.quality).toBe('WEBDL-1080p');
+  });
+
+  it('assigns the filename-derived 480p fallback to a brand-new file when the probe finds no video stream', async () => {
+    const h = buildHarness();
+    const filename = 'Ember.Horizon.2022.1080p.WEB-DL-RELGRP.mkv';
+    fs.writeFileSync(path.join(mediaDir, filename), 'video-bytes');
+    h.mediaRepo.findOne.mockResolvedValue(movieMedia({ files: [] }));
+    h.ffprobe.detectMediaFileInfo.mockResolvedValue({ video: [], audio: [], subtitles: [] });
+
+    await h.service.rescanFiles(8, { skipWarmup: true });
+
+    expect(h.mediaFileRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({ relativePath: filename, quality: 'WEBDL-480p' }),
+    );
+  });
+});

--- a/backend/src/modules/media/media-service/media-rescan.service.ts
+++ b/backend/src/modules/media/media-service/media-rescan.service.ts
@@ -114,7 +114,9 @@ export class MediaRescanService {
 
     dbFile.size = diskSize;
     dbFile.streamInfo = streamInfo.streamInfo;
-    dbFile.quality = streamInfo.quality;
+    // No usable video dimensions: keep the file's existing quality rather than
+    // downgrading it to the filename-only 480p fallback.
+    if (streamInfo.quality !== null) dbFile.quality = streamInfo.quality;
     const saved = await this.mediaFileRepo.save(dbFile);
     this.log.log(
       `enrichMediaFileFromDisk: enriched media file #${mediaFileId} "${normPath}"`,
@@ -606,7 +608,9 @@ export class MediaRescanService {
         }
       }
       dbFile.streamInfo = streamInfo;
-      dbFile.quality = probed.quality;
+      // No usable video dimensions: keep the existing quality instead of
+      // downgrading it to the filename-only 480p fallback.
+      if (probed.quality !== null) dbFile.quality = probed.quality;
       try {
         await this.mediaFileRepo.save(dbFile);
         updated++;
@@ -686,6 +690,9 @@ export class MediaRescanService {
         contextLabel: `Rescan[media #${mediaId}] new file "${relativePath}"`,
       });
       if (!probed) continue;
+      // Brand-new row has no prior quality to protect — fall back to the
+      // filename-derived guess (source text at the 480p default bucket).
+      const quality = probed.quality ?? qualityFromResolution(filename);
       try {
         const savedFile = await this.mediaFileRepo.save(
           this.mediaFileRepo.create({
@@ -693,7 +700,7 @@ export class MediaRescanService {
             episode: episodeId != null ? ({ id: episodeId } as Episode) : null,
             relativePath,
             size,
-            quality: probed.quality,
+            quality,
             streamInfo: probed.streamInfo,
           }),
         );
@@ -875,13 +882,14 @@ export class MediaRescanService {
    * ffprobe + optional cropdetect + filename/resolution quality. Used by
    * every import path (rescan refresh, rescan new file, disk-import enrich)
    * so the probe pipeline lives in one place.
-   * Returns null on ffprobe error so callers can `continue`.
+   * Returns null on ffprobe error so callers can `continue`; `quality` is
+   * null when there are no usable video dimensions, letting callers decide.
    */
   private async probeAndResolve(
     absPath: string,
     filename: string,
     opts: { detectCrop: boolean; contextLabel: string },
-  ): Promise<{ streamInfo: ProbeResult; quality: string } | null> {
+  ): Promise<{ streamInfo: ProbeResult; quality: string | null } | null> {
     let streamInfo: ProbeResult;
     try {
       streamInfo = await this.ffprobe.detectMediaFileInfo(absPath);
@@ -910,11 +918,11 @@ export class MediaRescanService {
         );
       }
     }
-    const quality = qualityFromResolution(
-      filename,
-      streamInfo?.video?.[0]?.width,
-      streamInfo?.video?.[0]?.height,
-    );
+    const v = streamInfo?.video?.[0];
+    const quality =
+      v?.width && v?.height
+        ? qualityFromResolution(filename, v.width, v.height)
+        : null;
     return { streamInfo, quality };
   }
 


### PR DESCRIPTION
Found while documenting the divergence between the two ingestion paths in #879. First of the four defects that comparison surfaced; it ships on its own and is worth landing regardless of the plugin work.

## The bug

`MediaRescanService.probeAndResolve` guarded the case where ffprobe **throws** — return `null`, callers keep the prior value. It did not guard the case where ffprobe **returns without a video stream**. That path still reached:

```ts
qualityFromResolution(filename, streamInfo?.video?.[0]?.width, streamInfo?.video?.[0]?.height)
```

with both dimensions `undefined`. `bucketResolutionHeight` answers **480** for missing input, deliberately. The *source* is still parsed from the filename text. So a file named `Nova.Skyline.2023.1080p.WEB-DL.mkv` whose probe came back empty was stored as **`WEBDL-480p`**, overwriting a correct release-parsed quality with no error and no log.

## Why it is worse than it looks

**The guarded branch is the one that never fires.** `FfprobeService.detectMediaFileInfo` (`subtitles/ffprobe.service.ts:332`) wraps its entire body in one `try` and its `catch` returns `{ video: [], audio: [], subtitles: [], error: message }`. It never rejects.

So every real failure mode — ffprobe binary missing, unsupported container, malformed output, timeout, OOM-killed subprocess — arrives as "probe succeeded, no video stream", which is precisely the **unguarded** path. This was not a corrupt-file edge case; **any** probe failure silently downgraded the file.

And it is not only the badge. `bucketResolutionHeight` is shared with `profileFitsSource`, so the wrong bucket skews transcode-ladder decisions too.

The torrent import path already guards correctly (`completion.service.ts:819-830`, `dimensions ? derived : history.quality`). This brings the rescan path in line.

## The fix

`probeAndResolve` now returns `quality: string | null`, null meaning "not determinable from pixels". The three call sites are **not** treated alike, because they are not equivalent:

| Call site | Behaviour |
|---|---|
| `:109` `enrichMediaFileFromDisk` | keeps the stored quality when null — this is the one the disk-import path reaches |
| `:609` rescan refresh of an existing file | keeps the stored quality when null |
| `:692` rescan of a brand-new file | **unchanged** — no prior value to protect, so it still derives from the filename at the 480 bucket, just routed explicitly instead of implicitly |

`bucketResolutionHeight` and `qualityFromResolution` are **untouched**. Their 480 default is correct for the transcode ladder that shares them; the caller is the right place to fix this.

## Verification

`tsc --noEmit` exits 0. Backend restarted in the local Docker stack, boots clean, liveness 200.

New spec `media-rescan.service.spec.ts` — the service had none. 5 tests, exact asserted values:

1. real dimensions → derived quality overwrites a stale one (`WEBDL-1080p`)
2. no video stream via `enrichMediaFileFromDisk` → stored quality **unchanged**
3. ffprobe throws → unchanged, `mediaFileRepo.save` never called (pins the already-working early return)
4. no video stream on rescan refresh → **unchanged**
5. no video stream on a brand-new file → `WEBDL-480p`, i.e. the old behaviour deliberately preserved where there is nothing better

Suite **80 → 81 suites, 766 → 771 tests**, all green.

## Remaining from the #879 comparison

Three defects still open, each worth its own change: duplicate `MediaFile` rows on a forced re-import; a failed enrichment reporting a successful import as an error; the torrent path having no pre-write collision guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)