### PR TITLE
fix(library-ingest): stop duplicating rows and mislabelling successful imports

### DIFF
--- a/backend/src/common/library-ingest/library-ingest.service.spec.ts
+++ b/backend/src/common/library-ingest/library-ingest.service.spec.ts
@@ -1,0 +1,179 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { DataSource } from 'typeorm';
+import { LibraryIngestService, IngestRequest } from './library-ingest.service';
+import { NamingService } from '../../modules/scheduler/naming.service';
+import { Media } from '../../modules/media/entities/media.entity';
+import { MediaFile } from '../../modules/media/entities/media-file.entity';
+import { MediaType } from '../enums';
+
+/**
+ * `ingest` is the only public method and only touches the collaborators wired
+ * below, so we exercise it on a bare prototype instance rather than standing
+ * up the 8-dependency constructor — same approach as CompletionService specs.
+ */
+function buildHarness() {
+  const service = Object.create(
+    LibraryIngestService.prototype,
+  ) as LibraryIngestService;
+
+  const mediaRepo = { findOne: jest.fn() };
+  const fileRepo = {
+    findOne: jest.fn().mockResolvedValue(null),
+    create: jest.fn((x: unknown) => x),
+    save: jest.fn(async (x: unknown) => x),
+  };
+  const episodeRepo = {
+    findOne: jest.fn().mockResolvedValue(null),
+    update: jest.fn().mockResolvedValue(undefined),
+  };
+  const fileTransfer = {
+    transferFile: jest.fn().mockResolvedValue(undefined),
+    transferCompanions: jest.fn().mockResolvedValue(undefined),
+    getCompanionExts: jest.fn().mockResolvedValue(new Set<string>()),
+  };
+  const mediaService = {
+    enrichMediaFileFromDisk: jest.fn().mockResolvedValue(undefined),
+  };
+  const subtitleScheduler = {
+    onMediaFileImported: jest.fn().mockResolvedValue(undefined),
+  };
+  const logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+  // Real NamingService — a stubbed `query` returning no rows means
+  // `getFormats()` resolves the built-in defaults, no DB needed.
+  const naming = new NamingService({
+    query: jest.fn().mockResolvedValue([]),
+  } as unknown as DataSource);
+
+  const wired = service as unknown as Record<string, unknown>;
+  wired.mediaRepo = mediaRepo;
+  wired.fileRepo = fileRepo;
+  wired.episodeRepo = episodeRepo;
+  wired.naming = naming;
+  wired.fileTransfer = fileTransfer;
+  wired.mediaService = mediaService;
+  wired.subtitleScheduler = subtitleScheduler;
+  wired.logger = logger;
+
+  return {
+    service,
+    mediaRepo,
+    fileRepo,
+    episodeRepo,
+    fileTransfer,
+    mediaService,
+    subtitleScheduler,
+    logger,
+  };
+}
+
+function buildMovie(over: Partial<Media> & { path: string }): Media {
+  return {
+    id: 1,
+    title: 'Lonely Harbor',
+    originalTitle: undefined,
+    year: 2021,
+    type: MediaType.MOVIE,
+    tmdbId: undefined,
+    library: { id: 10 },
+    folderName: 'Lonely Harbor (2021)',
+    ...over,
+  } as unknown as Media;
+}
+
+describe('LibraryIngestService.ingest', () => {
+  let srcDir: string;
+
+  beforeEach(() => {
+    srcDir = fs.mkdtempSync(path.join(os.tmpdir(), 'library-ingest-src-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(srcDir, { recursive: true, force: true });
+  });
+
+  it('updates the existing row in place on a forced re-import instead of inserting a second one', async () => {
+    const h = buildHarness();
+    const srcFile = path.join(srcDir, 'Lonely.Harbor.2021.mkv');
+    fs.writeFileSync(srcFile, 'x'.repeat(4096));
+
+    const media = buildMovie({ id: 7, path: '/library/movies/Lonely Harbor (2021)' });
+    h.mediaRepo.findOne.mockResolvedValue(media);
+
+    const existingRow = {
+      id: 501,
+      media: { id: 7 },
+      relativePath: 'Lonely Harbor (2021) WEBDL-1080p.mkv',
+      size: 999,
+      quality: 'HDTV-720p',
+      episode: null,
+    } as unknown as MediaFile;
+    h.fileRepo.findOne.mockResolvedValue(existingRow);
+
+    const req: IngestRequest = {
+      mediaId: 7,
+      files: [{ path: srcFile }],
+      transfer: 'copy',
+      fallbackQuality: 'WEBDL-1080p',
+      sourceLabel: 'Lonely Harbor',
+      force: true,
+    };
+
+    const result = await h.service.ingest(req);
+
+    expect(h.fileRepo.create).not.toHaveBeenCalled();
+    expect(h.fileRepo.save).toHaveBeenCalledTimes(1);
+    expect(h.fileRepo.save).toHaveBeenCalledWith(existingRow);
+    expect(result.imported).toHaveLength(1);
+    expect(result.imported[0]).toEqual({
+      id: 501,
+      media: { id: 7 },
+      relativePath: 'Lonely Harbor (2021) WEBDL-1080p.mkv',
+      size: 4096,
+      quality: 'WEBDL-1080p',
+      episode: null,
+    });
+  });
+
+  it('reports success and still returns the imported file when enrichment throws', async () => {
+    const h = buildHarness();
+    const srcFile = path.join(srcDir, 'Coral.Drift.2022.mkv');
+    fs.writeFileSync(srcFile, 'y'.repeat(2048));
+
+    const media = buildMovie({
+      id: 8,
+      title: 'Coral Drift',
+      year: 2022,
+      path: '/library/movies/Coral Drift (2022)',
+    });
+    h.mediaRepo.findOne.mockResolvedValue(media);
+    h.fileRepo.findOne.mockResolvedValue(null);
+    h.mediaService.enrichMediaFileFromDisk.mockRejectedValue(
+      new Error('ffprobe crashed'),
+    );
+
+    const req: IngestRequest = {
+      mediaId: 8,
+      files: [{ path: srcFile }],
+      transfer: 'copy',
+      fallbackQuality: 'WEBDL-720p',
+      sourceLabel: 'Coral Drift',
+    };
+
+    const result = await h.service.ingest(req);
+
+    expect(result.imported).toHaveLength(1);
+    expect(result.imported[0]).toEqual({
+      media,
+      episode: null,
+      relativePath: 'Coral Drift (2022) WEBDL-720p.mkv',
+      size: 2048,
+      quality: 'WEBDL-720p',
+    });
+    expect(h.mediaService.enrichMediaFileFromDisk).toHaveBeenCalledTimes(1);
+    expect(h.logger.warn).toHaveBeenCalledWith(
+      'Ingest[Coral Drift]: post-import enrichment failed — ffprobe crashed',
+    );
+  });
+});

--- a/backend/src/common/library-ingest/library-ingest.service.ts
+++ b/backend/src/common/library-ingest/library-ingest.service.ts
@@ -190,18 +190,42 @@ export class LibraryIngestService {
         }
       })();
 
-      const saved = await this.fileRepo.save(
-        this.fileRepo.create({
-          media,
-          episode:
-            req.episodeId != null ? ({ id: req.episodeId } as Episode) : null,
-          relativePath,
-          size: finalSize,
-          quality: req.fallbackQuality ?? '',
-        }),
-      );
+      // `force` skips the collision check above, so a re-import over an
+      // already-tracked path must update that row instead of inserting a dupe.
+      const existingFile = await this.fileRepo.findOne({
+        where: { media: { id: media.id }, relativePath },
+      });
+      const saved = existingFile
+        ? await this.fileRepo.save(
+            Object.assign(existingFile, {
+              episode:
+                req.episodeId != null
+                  ? ({ id: req.episodeId } as Episode)
+                  : null,
+              size: finalSize,
+              quality: req.fallbackQuality ?? '',
+            }),
+          )
+        : await this.fileRepo.save(
+            this.fileRepo.create({
+              media,
+              episode:
+                req.episodeId != null
+                  ? ({ id: req.episodeId } as Episode)
+                  : null,
+              relativePath,
+              size: finalSize,
+              quality: req.fallbackQuality ?? '',
+            }),
+          );
 
-      await this.mediaService.enrichMediaFileFromDisk(saved.id);
+      try {
+        await this.mediaService.enrichMediaFileFromDisk(saved.id);
+      } catch (e) {
+        this.logger.warn(
+          `Ingest[${req.sourceLabel}]: post-import enrichment failed — ${(e as Error).message}`,
+        );
+      }
       try {
         await this.subtitleScheduler.onMediaFileImported(
           media.id,


### PR DESCRIPTION
Two of the three defects still open from the divergence comparison in #879. Both were carried over **verbatim** when `LibraryIngestService` was extracted, deliberately, so that the extraction stayed provably behaviour-preserving. Fixing them now that it has landed.

## A — a forced re-import left two rows for one file

`IngestRequest.force` skips the collision check, and the code then unconditionally called `fileRepo.create()`. Re-importing over a path already tracked in the database inserted a **second** `MediaFile` for the same `relativePath`.

It now updates the existing row instead, which is what the torrent path has always done (`completion.service.ts:944-956`).

The lookup added here is a no-op outside the forced path — by the time execution reaches it, the collision check above has already either skipped the file or renamed it, so `findOne` returns null and the insert branch runs exactly as before. One extra query per ingest, for correctness.

## B — a successful import was reported as a failure

`enrichMediaFileFromDisk` was awaited un-guarded inside the per-entry `try`. A throw there was caught by the outer handler, which marked the **whole entry** as an error and skipped the success counter — even though the file had already been transferred and the `MediaFile` row already saved.

The user was told the import failed when it had succeeded, and the file was sitting correctly in the library.

Enrichment is a post-success enhancement, so its failure is now logged and cannot change the reported outcome. This matches how the torrent path treats the same work (`completion.service.ts:1076-1097`, after the row is committed). It stays awaited — the caller has no ordering dependency, so a plain guard was enough and a fire-and-forget change was unnecessary.

## Scope

Only these two. The other divergences that comparison found — quality sourcing, the library pin-or-reassign policy, and the missing pre-write collision guard on the torrent side — are left alone deliberately. The collision guard is the next change.

## Verification

`tsc --noEmit` exits 0. Backend restarted in the local Docker stack, boots clean, liveness 200.

New spec for the service, which had none. 2 tests, exact values:

- a forced re-import over an existing row updates it and does not insert a second
- enrichment throwing still reports success and still returns the imported file

Suite **81 → 82 suites, 771 → 773 tests**, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)