### PR TITLE
refactor(imports): route the torrent import through LibraryIngestService

### DIFF
--- a/backend/src/common/library-ingest/library-ingest.module.ts
+++ b/backend/src/common/library-ingest/library-ingest.module.ts
@@ -6,12 +6,14 @@ import { Episode } from '../../modules/media/entities/episode.entity';
 import { LibraryIngestService } from './library-ingest.service';
 import { FliksSchedulerModule } from '../../modules/scheduler/scheduler.module';
 import { MediaModule } from '../../modules/media/media.module';
+import { SubtitlesModule } from '../../modules/subtitles/subtitles.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Media, MediaFile, Episode]),
     forwardRef(() => FliksSchedulerModule),
     forwardRef(() => MediaModule),
+    SubtitlesModule,
   ],
   providers: [LibraryIngestService],
   exports: [LibraryIngestService],

--- a/backend/src/common/library-ingest/library-ingest.service.spec.ts
+++ b/backend/src/common/library-ingest/library-ingest.service.spec.ts
@@ -34,7 +34,7 @@ function buildHarness() {
     getCompanionExts: jest.fn().mockResolvedValue(new Set<string>()),
   };
   const mediaService = {
-    enrichMediaFileFromDisk: jest.fn().mockResolvedValue(undefined),
+    finalizeImportedFile: jest.fn().mockResolvedValue(undefined),
   };
   const subtitleScheduler = {
     onMediaFileImported: jest.fn().mockResolvedValue(undefined),
@@ -45,6 +45,9 @@ function buildHarness() {
   const naming = new NamingService({
     query: jest.fn().mockResolvedValue([]),
   } as unknown as DataSource);
+  // Null probe result: both tests fall back to `fallbackQuality` and no
+  // `streamInfo` is written.
+  const ffprobe = { detectMediaFileInfo: jest.fn().mockResolvedValue(null) };
 
   const wired = service as unknown as Record<string, unknown>;
   wired.mediaRepo = mediaRepo;
@@ -54,6 +57,7 @@ function buildHarness() {
   wired.fileTransfer = fileTransfer;
   wired.mediaService = mediaService;
   wired.subtitleScheduler = subtitleScheduler;
+  wired.ffprobe = ffprobe;
   wired.logger = logger;
 
   return {
@@ -64,6 +68,7 @@ function buildHarness() {
     fileTransfer,
     mediaService,
     subtitleScheduler,
+    ffprobe,
     logger,
   };
 }
@@ -126,7 +131,7 @@ describe('LibraryIngestService.ingest', () => {
     expect(h.fileRepo.save).toHaveBeenCalledTimes(1);
     expect(h.fileRepo.save).toHaveBeenCalledWith(existingRow);
     expect(result.imported).toHaveLength(1);
-    expect(result.imported[0]).toEqual({
+    expect(result.imported[0].file).toEqual({
       id: 501,
       media: { id: 7 },
       relativePath: 'Lonely Harbor (2021) WEBDL-1080p.mkv',
@@ -149,7 +154,7 @@ describe('LibraryIngestService.ingest', () => {
     });
     h.mediaRepo.findOne.mockResolvedValue(media);
     h.fileRepo.findOne.mockResolvedValue(null);
-    h.mediaService.enrichMediaFileFromDisk.mockRejectedValue(
+    h.mediaService.finalizeImportedFile.mockRejectedValue(
       new Error('ffprobe crashed'),
     );
 
@@ -162,16 +167,18 @@ describe('LibraryIngestService.ingest', () => {
     };
 
     const result = await h.service.ingest(req);
+    // Post-import work is fire-and-forget — let it settle before asserting.
+    await new Promise((r) => setImmediate(r));
 
     expect(result.imported).toHaveLength(1);
-    expect(result.imported[0]).toEqual({
+    expect(result.imported[0].file).toEqual({
       media,
       episode: null,
       relativePath: 'Coral Drift (2022) WEBDL-720p.mkv',
       size: 2048,
       quality: 'WEBDL-720p',
     });
-    expect(h.mediaService.enrichMediaFileFromDisk).toHaveBeenCalledTimes(1);
+    expect(h.mediaService.finalizeImportedFile).toHaveBeenCalledTimes(1);
     expect(h.logger.warn).toHaveBeenCalledWith(
       'Ingest[Coral Drift]: post-import enrichment failed — ffprobe crashed',
     );

--- a/backend/src/common/library-ingest/library-ingest.service.ts
+++ b/backend/src/common/library-ingest/library-ingest.service.ts
@@ -12,20 +12,23 @@ import { NamingService } from '../../modules/scheduler/naming.service';
 import { SubtitleSchedulerService } from '../../modules/scheduler/subtitle-scheduler.service';
 import { MediaService } from '../../modules/media/media.service';
 import { FileTransferService, TransferMethod } from '../services/file-transfer.service';
+import { FfprobeService } from '../../modules/subtitles/ffprobe.service';
+import { qualityFromResolution } from '../release-parsing';
 
 export interface IngestRequest {
   /** Media the file(s) belong to. Must already be anchored to a library
    *  (`library` + `folderName` persisted) — resolving/pinning that is the
    *  caller's job, since each caller picks its own library differently. */
   mediaId: number;
-  files: { path: string }[];
+  /** `episodeId`: pre-resolved by the caller. `size`: last-resort size when
+   *  the destination cannot be stat'ed. */
+  files: { path: string; episodeId?: number; size?: number }[];
   transfer: TransferMethod;
-  /** Quality used for naming and the initial `MediaFile.quality` column. */
+  /** Quality used when the probe yields no usable dimensions. */
   fallbackQuality?: string;
-  /** For logs / companion-transfer log tags. */
+  /** Release title — source tag of the derived quality and release group. */
+  releaseName?: string;
   sourceLabel: string;
-  /** Pre-resolved episode for a series file; the caller already matched it. */
-  episodeId?: number;
   /** Bypass collision detection and overwrite in place. */
   force?: boolean;
   /** Append " (n)" instead of silently skipping when the computed name collides. */
@@ -33,9 +36,9 @@ export interface IngestRequest {
 }
 
 export interface IngestResult {
-  imported: MediaFile[];
-  seasonNumber?: number;
-  episodeNumber?: number;
+  /** `sourcePath` echoes the request entry, so a caller can map a landed file
+   *  back to what it knows about it — a skipped file leaves no entry. */
+  imported: { file: MediaFile; episodeId?: number; sourcePath: string }[];
 }
 
 /**
@@ -60,6 +63,7 @@ export class LibraryIngestService {
     private readonly mediaService: MediaService,
     @Inject(forwardRef(() => SubtitleSchedulerService))
     private readonly subtitleScheduler: SubtitleSchedulerService,
+    private readonly ffprobe: FfprobeService,
   ) {}
 
   async ingest(req: IngestRequest): Promise<IngestResult> {
@@ -70,30 +74,57 @@ export class LibraryIngestService {
     if (!media) {
       throw new Error(`Media #${req.mediaId} not found`);
     }
+    // `media.path` is a getter over library.path + folderName; both are the
+    // caller's to set, and a null here would surface as a path.join TypeError.
+    if (!media.path) {
+      throw new Error(
+        `Media #${req.mediaId} is not anchored to a library folder`,
+      );
+    }
 
     const formats = await this.naming.getFormats();
     const companionExts = await this.fileTransfer.getCompanionExts();
+    const releaseGroup = req.releaseName
+      ? this.naming.extractReleaseGroup(req.releaseName)
+      : undefined;
 
-    let seasonNumber: number | undefined;
-    let episodeNumber: number | undefined;
-    let episodeTitle: string | undefined;
-    let airDate: string | undefined;
-    if (req.episodeId) {
-      const ep = await this.episodeRepo.findOne({
-        where: { id: req.episodeId },
-        relations: ['season'],
-      });
-      if (ep) {
-        episodeNumber = ep.episodeNumber;
-        seasonNumber = ep.season?.seasonNumber ?? 1;
-        episodeTitle = ep.title ?? undefined;
-        airDate = ep.airDate ?? undefined;
-      }
-    }
-
-    const imported: MediaFile[] = [];
+    const imported: (IngestResult['imported'][number] & { destPath: string })[] =
+      [];
 
     for (const file of req.files) {
+      let seasonNumber: number | undefined;
+      let episodeNumber: number | undefined;
+      let episodeTitle: string | undefined;
+      let airDate: string | undefined;
+      if (file.episodeId) {
+        const ep = await this.episodeRepo.findOne({
+          where: { id: file.episodeId },
+          relations: ['season'],
+        });
+        if (ep) {
+          episodeNumber = ep.episodeNumber;
+          seasonNumber = ep.season?.seasonNumber ?? 1;
+          episodeTitle = ep.title ?? undefined;
+          airDate = ep.airDate ?? undefined;
+        }
+      }
+
+      // Derive quality from the real pixels, not the (sometimes mislabeled)
+      // release name: a torrent tagged "2160p" that is actually 1920×804 must
+      // be named + tracked as 1080p. The source tag still comes from the
+      // release name. Falls back to the caller's quality when probing yields
+      // no dimensions.
+      const streamInfo = await this.ffprobe.detectMediaFileInfo(file.path);
+      const srcVideo = streamInfo?.video?.[0];
+      const quality =
+        srcVideo?.width && srcVideo?.height
+          ? qualityFromResolution(
+              req.releaseName ?? path.basename(file.path),
+              srcVideo.width,
+              srcVideo.height,
+            )
+          : (req.fallbackQuality ?? '');
+
       const ext = path.extname(file.path);
       const sourceBase = path.basename(file.path, ext);
       let newBaseName: string;
@@ -104,7 +135,8 @@ export class LibraryIngestService {
           title: media.title,
           originalTitle: media.originalTitle,
           year: media.year,
-          quality: req.fallbackQuality ?? '',
+          quality,
+          releaseGroup,
           tmdbId: media.tmdbId,
         });
         destDir = media.path!;
@@ -114,7 +146,8 @@ export class LibraryIngestService {
           season: seasonNumber ?? 1,
           episode: episodeNumber ?? 1,
           episodeTitle,
-          quality: req.fallbackQuality ?? '',
+          quality,
+          releaseGroup,
           airDate,
         });
         const seasonFolder = this.naming.applySeasonFolderFormat(
@@ -133,7 +166,7 @@ export class LibraryIngestService {
         this.logger.error(
           `Ingest[${req.sourceLabel}]: computed dest outside media folder — root=${media.path!} dest=${destPath}`,
         );
-        throw new Error('destination en dehors du dossier du média');
+        continue;
       }
 
       const collides = async (rel: string, abs: string) =>
@@ -171,6 +204,9 @@ export class LibraryIngestService {
         // Caller already verified the source exists; best-effort fallback only.
       }
 
+      this.logger.log(
+        `Ingest[${req.sourceLabel}]: ${req.transfer} "${path.basename(file.path)}" → "${destPath}"`,
+      );
       await this.fileTransfer.transferFile(file.path, destPath, req.transfer);
       await this.fileTransfer.transferCompanions({
         srcDir: path.dirname(file.path),
@@ -186,9 +222,16 @@ export class LibraryIngestService {
         try {
           return fs.statSync(destPath).size;
         } catch {
-          return sourceSize;
+          return file.size ?? sourceSize;
         }
       })();
+
+      const payload = {
+        episode: file.episodeId != null ? ({ id: file.episodeId } as Episode) : null,
+        size: finalSize,
+        quality,
+        ...(streamInfo ? { streamInfo } : {}),
+      };
 
       // `force` skips the collision check above, so a re-import over an
       // already-tracked path must update that row instead of inserting a dupe.
@@ -196,55 +239,55 @@ export class LibraryIngestService {
         where: { media: { id: media.id }, relativePath },
       });
       const saved = existingFile
-        ? await this.fileRepo.save(
-            Object.assign(existingFile, {
-              episode:
-                req.episodeId != null
-                  ? ({ id: req.episodeId } as Episode)
-                  : null,
-              size: finalSize,
-              quality: req.fallbackQuality ?? '',
-            }),
-          )
+        ? await this.fileRepo.save(Object.assign(existingFile, payload))
         : await this.fileRepo.save(
-            this.fileRepo.create({
-              media,
-              episode:
-                req.episodeId != null
-                  ? ({ id: req.episodeId } as Episode)
-                  : null,
-              relativePath,
-              size: finalSize,
-              quality: req.fallbackQuality ?? '',
-            }),
+            this.fileRepo.create({ media, relativePath, ...payload }),
           );
 
-      try {
-        await this.mediaService.enrichMediaFileFromDisk(saved.id);
-      } catch (e) {
-        this.logger.warn(
-          `Ingest[${req.sourceLabel}]: post-import enrichment failed — ${(e as Error).message}`,
-        );
-      }
-      try {
-        await this.subtitleScheduler.onMediaFileImported(
-          media.id,
-          saved.id,
-          req.episodeId ?? undefined,
-        );
-      } catch (e) {
-        this.logger.warn(
-          `Ingest[${req.sourceLabel}]: post-import subtitle pipeline failed — ${(e as Error).message}`,
-        );
+      if (file.episodeId != null) {
+        await this.episodeRepo.update(file.episodeId, { hasFile: true });
       }
 
-      if (req.episodeId) {
-        await this.episodeRepo.update(req.episodeId, { hasFile: true });
-      }
-
-      imported.push(saved);
+      imported.push({
+        file: saved,
+        episodeId: file.episodeId,
+        sourcePath: file.path,
+        destPath,
+      });
     }
 
-    return { imported, seasonNumber, episodeNumber };
+    // Per-file post-import work: cropdetect + embedded-subtitle cache warmup
+    // via finalizeImportedFile, then the external-subtitle search. Sequential
+    // to avoid hammering ffmpeg and the subtitle provider rate limits.
+    void (async () => {
+      for (const { file, episodeId, destPath } of imported) {
+        try {
+          await this.mediaService.finalizeImportedFile(file, destPath, media);
+        } catch (e) {
+          this.logger.warn(
+            `Ingest[${req.sourceLabel}]: post-import enrichment failed — ${(e as Error).message}`,
+          );
+        }
+        try {
+          await this.subtitleScheduler.onMediaFileImported(
+            media.id,
+            file.id,
+            episodeId,
+          );
+        } catch (e) {
+          this.logger.warn(
+            `Ingest[${req.sourceLabel}]: post-import subtitle pipeline failed — ${(e as Error).message}`,
+          );
+        }
+      }
+    })();
+
+    return {
+      imported: imported.map(({ file, episodeId, sourcePath }) => ({
+        file,
+        episodeId,
+        sourcePath,
+      })),
+    };
   }
 }

--- a/backend/src/modules/imports/disk-import.service.ts
+++ b/backend/src/modules/imports/disk-import.service.ts
@@ -35,6 +35,7 @@ import { SubtitleSchedulerService } from '../scheduler/subtitle-scheduler.servic
 import { LibrariesService } from '../libraries/libraries.service';
 import { TransferMethod } from '../../common/services/file-transfer.service';
 import { LibraryIngestService } from '../../common/library-ingest/library-ingest.service';
+import { MediaServersService } from '../media-servers/media-servers.service';
 
 const VIDEO_EXTS = new Set([
   '.mkv',
@@ -87,6 +88,7 @@ export class DiskImportService {
     private readonly metadata: MediaMetadataService,
     private readonly nfo: NfoMetadataService,
     private readonly libraryIngest: LibraryIngestService,
+    private readonly mediaServers: MediaServersService,
   ) {}
 
   /**
@@ -518,15 +520,20 @@ export class DiskImportService {
         // enrichment all live in the shared ingest service.
         const result = await this.libraryIngest.ingest({
           mediaId: media.id,
-          files: [{ path: entry.filePath }],
+          files: [{ path: entry.filePath, episodeId: entry.episodeId }],
           transfer: method,
           fallbackQuality: entry.quality,
           sourceLabel: media.title,
-          episodeId: entry.episodeId,
           force: entry.force,
           uniquifyOnCollision: opts.uniquifyOnCollision,
         });
         imported += result.imported.length;
+        if (result.imported.length) {
+          void this.mediaServers.dispatch('library.rescan', {
+            title: media.title,
+            path: media.path,
+          });
+        }
       } catch (e) {
         errors.push(
           `${path.basename(entry.filePath)}: ${(e as Error).message}`,

--- a/backend/src/modules/imports/imports.module.ts
+++ b/backend/src/modules/imports/imports.module.ts
@@ -23,6 +23,7 @@ import { LibrariesModule } from '../libraries/libraries.module';
 import { MediaModule } from '../media/media.module';
 import { FliksSchedulerModule } from '../scheduler/scheduler.module';
 import { LibraryIngestModule } from '../../common/library-ingest/library-ingest.module';
+import { MediaServersModule } from '../media-servers/media-servers.module';
 
 @Module({
   imports: [
@@ -44,6 +45,7 @@ import { LibraryIngestModule } from '../../common/library-ingest/library-ingest.
     forwardRef(() => MediaModule),
     forwardRef(() => FliksSchedulerModule),
     LibraryIngestModule,
+    MediaServersModule,
   ],
   controllers: [ImportsController],
   providers: [

--- a/backend/src/modules/scheduler/completion.service.spec.ts
+++ b/backend/src/modules/scheduler/completion.service.spec.ts
@@ -10,6 +10,7 @@ import { Library } from '../libraries/entities/library.entity';
 import { QbittorrentTorrent } from '../download-clients/qbittorrent.service';
 import { TorrentHistoryMatcher } from '../media/torrent-history-matcher.service';
 import { FileTransferService } from '../../common/services/file-transfer.service';
+import { LibraryIngestService } from '../../common/library-ingest/library-ingest.service';
 import { MediaType } from '../../common/enums';
 
 /** The exact stamp the orphan sweep writes — pinned here so the test guards
@@ -358,7 +359,9 @@ describe('CompletionService.processOne', () => {
   }
 
   function buildMedia(over: Record<string, unknown>): Media {
-    return {
+    // A real instance (not a cast object literal) so `media.path` — the
+    // getter LibraryIngestService reads to derive the destination — works.
+    return Object.assign(new Media(), {
       id: 1,
       title: 'placeholder title',
       originalTitle: undefined,
@@ -369,7 +372,7 @@ describe('CompletionService.processOne', () => {
       library: null,
       libraryId: null,
       ...over,
-    } as unknown as Media;
+    });
   }
 
   /**
@@ -378,9 +381,18 @@ describe('CompletionService.processOne', () => {
    * same approach as the other describe blocks in this file. `naming` is the
    * real service (pure/sync for the methods used here) so destination
    * strings are pinned against real formatting logic, not a stand-in.
+   *
+   * The destination-path/write/persistence work now lives in
+   * `LibraryIngestService` (also a bare prototype instance here), so most
+   * collaborators below are wired onto IT rather than onto `service`
+   * directly — `processOne` only keeps the media/history/episode
+   * bookkeeping around the single `libraryIngest.ingest()` call.
    */
   function buildProcessOneHarness() {
     const service = Object.create(CompletionService.prototype) as CompletionService;
+    const libraryIngest = Object.create(
+      LibraryIngestService.prototype,
+    ) as LibraryIngestService;
 
     const mediaRepo = {
       findOne: jest.fn(),
@@ -437,11 +449,15 @@ describe('CompletionService.processOne', () => {
       error: jest.fn(),
       debug: jest.fn(),
     };
-    const naming = new NamingService({} as unknown as DataSource);
+    // Stubbed `query` (unlike the other describe blocks' bare `{}`): ingest
+    // now calls `naming.getFormats()` itself, which round-trips through
+    // `dataSource.query` before falling back to the same defaults as FORMATS.
+    const naming = new NamingService({
+      query: jest.fn().mockResolvedValue([]),
+    } as unknown as DataSource);
 
     const wired = service as unknown as Record<string, unknown>;
     wired.mediaRepo = mediaRepo;
-    wired.mediaFileRepo = mediaFileRepo;
     wired.historyRepo = historyRepo;
     wired.seasonRepo = seasonRepo;
     wired.episodeRepo = episodeRepo;
@@ -450,17 +466,25 @@ describe('CompletionService.processOne', () => {
     wired.settings = settings;
     wired.sseAudience = sseAudience;
     wired.events = events;
-    wired.ffprobe = ffprobe;
-    wired.fileTransfer = fileTransfer;
     wired.notifications = notifications;
     wired.mediaServers = mediaServers;
-    wired.mediaService = mediaService;
-    wired.subtitleScheduler = subtitleScheduler;
     wired.markers = markers;
     wired.thumbnailService = thumbnailService;
     wired.dataSource = dataSource;
     wired.log = log;
     wired.naming = naming;
+    wired.libraryIngest = libraryIngest;
+
+    const ingestWired = libraryIngest as unknown as Record<string, unknown>;
+    ingestWired.mediaRepo = mediaRepo;
+    ingestWired.fileRepo = mediaFileRepo;
+    ingestWired.episodeRepo = episodeRepo;
+    ingestWired.naming = naming;
+    ingestWired.fileTransfer = fileTransfer;
+    ingestWired.mediaService = mediaService;
+    ingestWired.subtitleScheduler = subtitleScheduler;
+    ingestWired.ffprobe = ffprobe;
+    ingestWired.logger = log;
 
     const run = (
       historyRow: DownloadHistory,
@@ -476,17 +500,15 @@ describe('CompletionService.processOne', () => {
       ).processOne(
         historyRow,
         torrentRow,
-        FORMATS.movie,
         FORMATS.movieFolder,
-        FORMATS.series,
         FORMATS.seriesFolder,
-        FORMATS.seasonFolder,
         libraries,
       );
     };
 
     return {
       service,
+      libraryIngest,
       run,
       mediaRepo,
       mediaFileRepo,
@@ -511,27 +533,37 @@ describe('CompletionService.processOne', () => {
   }
 
   /** Wires the two-episode season-pack fixture shared by the "own episode per
-   *  file" and "history reconciliation" tests below. */
+   *  file" and "history reconciliation" tests below. `episodeRepo.findOne` is
+   *  hit with two different query shapes now: `processOne`'s own pre-pass
+   *  looks up `{ season, episodeNumber }`, while `LibraryIngestService`
+   *  (sharing the same mock) re-fetches by `{ id }` for naming. Both must
+   *  resolve to the same two episodes. */
   function wireSeasonPack(h: ReturnType<typeof buildProcessOneHarness>) {
+    const episodesById: Record<number, Record<string, unknown>> = {
+      601: {
+        id: 601,
+        episodeNumber: 1,
+        title: 'Wake',
+        airDate: '2019-01-01',
+        endEpisodeNumber: null,
+        season: { seasonNumber: 1 },
+      },
+      602: {
+        id: 602,
+        episodeNumber: 2,
+        title: 'Drift',
+        airDate: '2019-01-08',
+        endEpisodeNumber: null,
+        season: { seasonNumber: 1 },
+      },
+    };
+    const idByEpisodeNumber: Record<number, number> = { 1: 601, 2: 602 };
     h.episodeRepo.findOne.mockImplementation(
-      async (opts: { where?: { episodeNumber?: number } }) => {
-        if (opts.where?.episodeNumber === 1) {
-          return {
-            id: 601,
-            episodeNumber: 1,
-            title: 'Wake',
-            airDate: '2019-01-01',
-            endEpisodeNumber: null,
-          };
-        }
-        if (opts.where?.episodeNumber === 2) {
-          return {
-            id: 602,
-            episodeNumber: 2,
-            title: 'Drift',
-            airDate: '2019-01-08',
-            endEpisodeNumber: null,
-          };
+      async (opts: { where?: { id?: number; episodeNumber?: number } }) => {
+        if (opts.where?.id != null) return episodesById[opts.where.id] ?? null;
+        if (opts.where?.episodeNumber != null) {
+          const id = idByEpisodeNumber[opts.where.episodeNumber];
+          return id != null ? episodesById[id] : null;
         }
         return null;
       },
@@ -793,8 +825,9 @@ describe('CompletionService.processOne', () => {
 
       const h = buildProcessOneHarness();
       // Real FileTransferService for this one test — the allow-list filtering
-      // it does is exactly what's being pinned, a mock would hide it.
-      (h.service as unknown as { fileTransfer: unknown }).fileTransfer =
+      // it does is exactly what's being pinned, a mock would hide it. Lives
+      // on the ingest instance now: that's what actually calls it.
+      (h.libraryIngest as unknown as { fileTransfer: unknown }).fileTransfer =
         new FileTransferService(
           { query: jest.fn().mockResolvedValue([]) } as unknown as DataSource,
         );

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -10,7 +10,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, In, LessThan, Repository } from 'typeorm';
 import * as path from 'path';
 import { Media } from '../media/entities/media.entity';
-import { MediaFile } from '../media/entities/media-file.entity';
 import { DownloadHistory } from '../media/entities/download-history.entity';
 import { Season } from '../media/entities/season.entity';
 import { Episode } from '../media/entities/episode.entity';
@@ -26,15 +25,12 @@ import { BlocklistService } from '../blocklist/blocklist.service';
 import { EventsService } from './events.service';
 import { SseAudienceService } from './sse-audience.service';
 import { SettingsService } from '../settings/settings.service';
-import { SubtitleSchedulerService } from './subtitle-scheduler.service';
 import { MediaServersService } from '../media-servers/media-servers.service';
-import { FfprobeService } from '../subtitles/ffprobe.service';
 import {
   ThumbnailService,
   buildSpriteLabel,
 } from '../streaming/thumbnail.service';
 import { MediaType } from '../../common/enums';
-import { relativePathUnderMediaRoot } from '../../common/utils/media-path.util';
 import { StalledCheck } from './entities/stalled-check.entity';
 import {
   countStalledStrikes,
@@ -49,14 +45,10 @@ import {
 } from '../media/torrent-history-matcher.service';
 import { TorrentAutoMatcher } from '../media/torrent-auto-matcher.service';
 import { buildGrabHistoryRow } from '../media/grab-history.util';
-import {
-  parseReleaseQuality,
-  qualityFromResolution,
-} from '../../common/release-parsing';
+import { parseReleaseQuality } from '../../common/release-parsing';
 import { MarkersService } from '../markers/markers.service';
-import { FileTransferService } from '../../common/services/file-transfer.service';
-import { MediaService } from '../media/media.service';
 import { SchedulerService } from './scheduler.service';
+import { LibraryIngestService } from '../../common/library-ingest/library-ingest.service';
 
 /**
  * How long a `grabbed` or `importing` history row may stay without a
@@ -91,8 +83,6 @@ export class CompletionService implements OnModuleInit {
     private readonly dataSource: DataSource,
     @InjectRepository(Media)
     private readonly mediaRepo: Repository<Media>,
-    @InjectRepository(MediaFile)
-    private readonly mediaFileRepo: Repository<MediaFile>,
     @InjectRepository(DownloadHistory)
     private readonly historyRepo: Repository<DownloadHistory>,
     @InjectRepository(Season)
@@ -114,20 +104,17 @@ export class CompletionService implements OnModuleInit {
     private readonly naming: NamingService,
     private readonly blocklist: BlocklistService,
     private readonly settings: SettingsService,
-    private readonly subtitleScheduler: SubtitleSchedulerService,
     private readonly mediaServers: MediaServersService,
     private readonly events: EventsService,
-    private readonly ffprobe: FfprobeService,
     private readonly thumbnailService: ThumbnailService,
     private readonly historyMatcher: TorrentHistoryMatcher,
     private readonly autoMatcher: TorrentAutoMatcher,
-    private readonly fileTransfer: FileTransferService,
     private readonly markers: MarkersService,
     private readonly sseAudience: SseAudienceService,
-    @Inject(forwardRef(() => MediaService))
-    private readonly mediaService: MediaService,
     @Inject(forwardRef(() => SchedulerService))
     private readonly scheduler: SchedulerService,
+    @Inject(forwardRef(() => LibraryIngestService))
+    private readonly libraryIngest: LibraryIngestService,
   ) {}
 
   /**
@@ -391,11 +378,8 @@ export class CompletionService implements OnModuleInit {
     if (!completedTorrents.length) return;
 
     const formats = await this.naming.getFormats();
-    const movieFormat = formats.movie;
     const movieFolderFormat = formats.movieFolder;
-    const seriesFormat = formats.series;
     const seriesFolderFormat = formats.seriesFolder;
-    const seasonFolderFormat = formats.seasonFolder;
     const libraries = await this.libraryRepo.find({ order: { path: 'ASC' } });
 
     let imported = 0;
@@ -420,11 +404,8 @@ export class CompletionService implements OnModuleInit {
         await this.processOne(
           history,
           torrent,
-          movieFormat,
           movieFolderFormat,
-          seriesFormat,
           seriesFolderFormat,
-          seasonFolderFormat,
           libraries,
         );
         imported++;
@@ -615,11 +596,8 @@ export class CompletionService implements OnModuleInit {
       _clientId?: number;
       _client?: import('../download-clients/entities/download-client.entity').DownloadClient;
     },
-    movieFormat: string,
     movieFolderFormat: string,
-    seriesFormat: string,
     seriesFolderFormat: string,
-    seasonFolderFormat: string,
     libraries: Library[],
   ): Promise<void> {
     const VIDEO_EXTS = [
@@ -725,8 +703,6 @@ export class CompletionService implements OnModuleInit {
       `Import[${history.sourceTitle}]: media="${media.title}" (${media.type}, id=${media.id})`,
     );
 
-    const releaseGroup = this.naming.extractReleaseGroup(history.sourceTitle);
-
     // Destination root folder (just the root, without folderName — folderName
     // is appended separately when building destDir).
     let rootPath = media.library?.path ?? '';
@@ -780,10 +756,11 @@ export class CompletionService implements OnModuleInit {
       );
     }
 
-    // libraryRoot = rootPath + folderName (= media.path) — relativePath is
-    // stored relative to this because resolveFile joins media.path + relativePath.
-    const libraryRoot = path.normalize(path.join(rootPath, folderName));
-    const companionExts = await this.fileTransfer.getCompanionExts();
+    // Keep the in-memory media in sync with what was just persisted — the
+    // ingest service re-reads media.path (library.path + folderName) to
+    // derive the destination.
+    media.folderName = folderName;
+    if (resolvedLib) media.library = resolvedLib;
 
     // For movies or single episode: import the largest file
     // For series with multiple files: import each file as a separate episode
@@ -799,52 +776,26 @@ export class CompletionService implements OnModuleInit {
       );
     }
 
-    const importedFiles: {
-      savedFile: MediaFile;
+    // Resolve each file's episode (season packs carry one per file) before
+    // handing the batch to the shared ingest pipeline, which owns naming,
+    // the filesystem write and MediaFile persistence.
+    const resolved: {
+      path: string;
       episodeId?: number;
+      size: number;
       seasonId?: number;
-      destPath: string;
     }[] = [];
-
     for (let idx = 0; idx < filesToImport.length; idx++) {
       const videoFile = filesToImport[idx];
-      const ext = path.extname(videoFile.filePath);
-      const filename = path.basename(videoFile.filePath, ext);
-
-      // Derive quality from the real pixels, not the (sometimes mislabeled)
-      // release name: a torrent tagged "2160p" that is actually 1920×804 must
-      // be named + tracked as 1080p (drives the filename, the badge, and the
-      // upgrade cutoff). The source tag still comes from the release name. Falls
-      // back to the grabbed quality when probing yields no dimensions.
-      const streamInfo = await this.ffprobe.detectMediaFileInfo(
+      const filename = path.basename(
         videoFile.filePath,
+        path.extname(videoFile.filePath),
       );
-      const srcVideo = streamInfo?.video?.[0];
-      const fileQuality =
-        srcVideo?.width && srcVideo?.height
-          ? qualityFromResolution(
-              history.sourceTitle,
-              srcVideo.width,
-              srcVideo.height,
-            )
-          : history.quality;
 
-      let newFilename: string;
-      let destDir: string;
       let episodeId: number | undefined;
       let seasonId: number | undefined;
 
-      if (media.type === MediaType.MOVIE) {
-        newFilename = this.naming.applyMovieFormat(movieFormat, {
-          title: media.title,
-          originalTitle: media.originalTitle,
-          year: media.year,
-          quality: fileQuality,
-          releaseGroup,
-          tmdbId: media.tmdbId,
-        });
-        destDir = path.join(rootPath, folderName);
-      } else {
+      if (media.type !== MediaType.MOVIE) {
         // For season packs: parse from individual filename; for single ep: try filename then release name
         const epNums =
           this.naming.parseEpisodeNumbers(filename) ??
@@ -855,9 +806,6 @@ export class CompletionService implements OnModuleInit {
             `Import[${history.sourceTitle}]: [${idx + 1}/${filesToImport.length}] "${filename}" → ${epNums ? `S${String(epNums.season).padStart(2, '0')}E${String(epNums.episode).padStart(2, '0')}` : 'no episode parsed'}`,
           );
         }
-
-        let epTitle: string | undefined;
-        let airDate: string | undefined;
 
         if (epNums) {
           const season = await this.seasonRepo.findOne({
@@ -872,8 +820,6 @@ export class CompletionService implements OnModuleInit {
               },
             });
             if (episode) {
-              epTitle = episode.title ?? undefined;
-              airDate = episode.airDate ?? undefined;
               episodeId = episode.id;
               if (
                 epNums.episodeEnd != null &&
@@ -885,93 +831,41 @@ export class CompletionService implements OnModuleInit {
             }
           }
         }
-
-        newFilename = this.naming.applySeriesFormat(seriesFormat, {
-          seriesTitle: media.title,
-          season: epNums?.season ?? 1,
-          episode: epNums?.episode ?? 1,
-          episodeTitle: epTitle,
-          quality: fileQuality,
-          releaseGroup,
-          airDate,
-        });
-
-        const seasonFolder = this.naming.applySeasonFolderFormat(
-          seasonFolderFormat,
-          { season: epNums?.season ?? 1 },
-        );
-        destDir = path.join(rootPath, folderName, seasonFolder);
       }
 
-      const destPath = path.join(destDir, newFilename + ext);
-
-      this.log.log(
-        `Import[${history.sourceTitle}]: copying "${path.basename(videoFile.filePath)}" → "${destPath}"`,
-      );
-      await this.fileTransfer.transferFile(
-        videoFile.filePath,
-        destPath,
-        'copy',
-      );
-
-      // Copy companion files for this video — torrent client keeps seeding
-      // from the source, so we never move.
-      const sourceBaseName = path.basename(
-        videoFile.filePath,
-        path.extname(videoFile.filePath),
-      );
-      await this.fileTransfer.transferCompanions({
-        srcDir: path.dirname(videoFile.filePath),
-        destDir,
-        sourceBaseName,
-        newBaseName: newFilename,
-        method: 'copy',
-        allowedExts: companionExts,
-        logTag: `Import[${history.sourceTitle}]`,
+      resolved.push({
+        path: videoFile.filePath,
+        episodeId,
+        size: videoFile.size,
+        seasonId,
       });
-
-      const relativePath = relativePathUnderMediaRoot(
-        path.resolve(libraryRoot),
-        path.resolve(destPath),
-      );
-      if (!relativePath) {
-        this.log.error(
-          `Import[${history.sourceTitle}]: dest outside library root — resolvedRoot=${path.resolve(libraryRoot)} resolvedDest=${path.resolve(destPath)} libraryRoot=${libraryRoot} dest=${destPath}`,
-        );
-        continue;
-      }
-      // Avoid duplicate: update existing record if same path already tracked
-      const existingFile = await this.mediaFileRepo.findOne({
-        where: { media: { id: media.id }, relativePath },
-      });
-      const savedFile = existingFile
-        ? await this.mediaFileRepo.save(
-            Object.assign(existingFile, {
-              episode:
-                episodeId != null ? ({ id: episodeId } as Episode) : null,
-              size: videoFile.size,
-              quality: fileQuality,
-              streamInfo,
-            }),
-          )
-        : await this.mediaFileRepo.save(
-            this.mediaFileRepo.create({
-              media,
-              episode:
-                episodeId != null ? ({ id: episodeId } as Episode) : null,
-              relativePath,
-              size: videoFile.size,
-              quality: fileQuality,
-              streamInfo,
-            }),
-          );
-
-      if (episodeId != null) {
-        await this.episodeRepo.update(episodeId, { hasFile: true });
-      }
-
-      importedFiles.push({ savedFile, episodeId, seasonId, destPath });
     }
+
+    // Keyed by source path, not by episode: a season pack whose season row
+    // exists but whose episode row doesn't still pins the season on the
+    // history row below.
+    const seasonByPath = new Map(resolved.map((r) => [r.path, r.seasonId]));
+
+    const result = await this.libraryIngest.ingest({
+      mediaId: media.id,
+      files: resolved.map((r) => ({
+        path: r.path,
+        episodeId: r.episodeId,
+        size: r.size,
+      })),
+      transfer: 'copy',
+      fallbackQuality: history.quality,
+      releaseName: history.sourceTitle,
+      sourceLabel: history.sourceTitle,
+      force: true,
+    });
+    const importedFiles = result.imported.map(
+      ({ file, episodeId, sourcePath }) => ({
+        savedFile: file,
+        episodeId,
+        seasonId: seasonByPath.get(sourcePath),
+      }),
+    );
 
     if (!importedFiles.length) {
       const statusMessage = `Import failed: no file could be placed under the library root for "${torrent.name}"`;
@@ -1068,33 +962,6 @@ export class CompletionService implements OnModuleInit {
       title: media.title,
       path: media.path,
     });
-
-    // Per-file post-import work: cropdetect + embedded-subtitle cache warmup
-    // via finalizeImportedFile (shared with disk import / rescan), then the
-    // external-subtitle search. Sequential to avoid hammering ffmpeg and the
-    // subtitle provider rate limits.
-    void (async () => {
-      for (const { savedFile, episodeId: epId, destPath } of importedFiles) {
-        try {
-          await this.mediaService.finalizeImportedFile(
-            savedFile,
-            destPath,
-            media,
-          );
-        } catch (e) {
-          this.log.warn(`Post-import enrichment failed: ${e}`);
-        }
-        try {
-          await this.subtitleScheduler.onMediaFileImported(
-            media.id,
-            savedFile.id,
-            epId,
-          );
-        } catch (e) {
-          this.log.warn(`Post-import subtitle search failed: ${e}`);
-        }
-      }
-    })();
 
     // Series only: kick off intro / outro marker detection for every
     // season whose episodes just landed. Detection runs at season

--- a/backend/src/modules/scheduler/scheduler.module.ts
+++ b/backend/src/modules/scheduler/scheduler.module.ts
@@ -40,6 +40,7 @@ import { LibrariesModule } from '../libraries/libraries.module';
 import { ProfilesModule } from '../profiles/profiles.module';
 import { MarkersModule } from '../markers/markers.module';
 import { Library } from '../libraries/entities/library.entity';
+import { LibraryIngestModule } from '../../common/library-ingest/library-ingest.module';
 
 @Module({
   imports: [
@@ -77,6 +78,7 @@ import { Library } from '../libraries/entities/library.entity';
     LibrariesModule,
     ProfilesModule,
     MarkersModule,
+    forwardRef(() => LibraryIngestModule),
   ],
   controllers: [CommandsController, SystemController, LivenessController],
   providers: [


### PR DESCRIPTION
Phase 1 of the plugin-system plan (PR 1.4). #879 extracted `LibraryIngestService` and repointed
only disk import; this repoints the torrent path and deletes the second implementation.

## What moves

`processOne` kept its own copy of quality derivation, destination naming, the filesystem write,
companion transfer, `relativePath` computation, the `MediaFile` upsert, the `hasFile` flag and
the post-import enrichment chain. All of it is now the shared service's, called once per torrent
with the whole file list.

`processOne` keeps what is genuinely torrent-specific: video-file selection, the no-video failure
branch, library/folderName resolution and pinning, episode/season resolution, `DownloadHistory`
bookkeeping, SSE, notifications, media-server dispatch, marker detection, sprite generation and
the post-import script hook.

Five constructor dependencies died with the duplicate — `mediaFileRepo`, `ffprobe`,
`fileTransfer`, `subtitleScheduler`, `mediaService` — and with the last one goes a
`forwardRef(() => MediaService)` cycle.

## The 16 divergences of #879, and what each resolves to

**The four flagged as likely bugs**

1. *Disk import silently downgrades quality to 480p.* Fixed in #880; now structurally impossible —
   one probe, before naming, with the caller's declared quality as the fallback.
2. *Duplicate `MediaFile` rows on a forced re-import.* Fixed in #881.
3. *A failed enrichment marks a successful import as an error.* Fixed in #881, and now off the
   critical path for both callers.
4. *No pre-write collision guard on the torrent path.* Not a defect: the filename carries
   `{Quality Full}`, so an upgrade writes a different name, and the only reachable collision is
   same media / same episode / same quality — where overwriting is the intended self-heal. The
   torrent path passes `force: true`, which preserves exactly that.

**The two asymmetries that actually needed a decision**

5. **Quality source — pixels win, for both callers.** The declared value (`entry.quality` from a
   filename parse, `history.quality` from the release name) is a guess about a file nobody has
   opened; the probe is the only ground truth, and it has to run before naming or the filename
   and the DB column disagree. So `ingest()` probes the source once, derives the quality from the
   real dimensions plus the source tag sniffed from `releaseName ?? basename(file)`, and falls
   back to the caller's value only when the probe yields no dimensions. Disk import's quality is
   display-only in the UI, never user-edited, so nothing is being overridden. Verified live: a
   file declared `Bluray-2160p` that is really 1280×720 lands as `Bluray-720p`.
6. **Library policy — stays with the caller, out of the contract.** The two callers answer
   different questions: disk import has an explicit `targetLibraryId` the user picked, so it may
   reassign; the torrent has no target, so the media's own anchor is the answer and it only pins
   when empty. Nothing is shared but the precondition, which the service now asserts instead of
   crashing on a `path.join(null)`.

**The four remaining asymmetries**

7. *File size.* The destination stat wins — it describes the file that actually landed. The
   caller's number (qBittorrent's reported size) survives as a last-resort fallback for a
   destination that cannot be stat'ed.
8. *`streamInfo` at creation.* Now always written, for both: the probe is already in hand, so the
   row is complete the moment it exists instead of a background pass later.
9. *Re-import self-heal.* Preserved on both sides by `force`: the torrent always forces
   (overwrite is the self-heal), disk import forces only when the user asks.
10. *Episode resolution.* Caller-side, per-file `episodeId`. The torrent path needs the season id
    for its history row anyway and disk import has already matched the episode upstream; a
    service-side re-parse would silently default to S01E01.

**Six torrent-only by nature, unchanged and still in `completion.service.ts`**

11-16. SSE `import.complete` / `queue.updated`, notification dispatch, external media-server
dispatch, marker detection, sprite generation, and the post-import script plus all
`DownloadHistory` bookkeeping.

## One consequence worth naming

The shared post-import chain calls `finalizeImportedFile` (cropdetect, OSDB hash, embedded-subtitle
cache warmup) rather than `enrichMediaFileFromDisk`, and fire-and-forget for both callers.
`enrichMediaFileFromDisk` re-probes and re-derives the quality from the *destination* filename
(`media-rescan.service.ts:924`), which is strictly worse than what ingest just computed from the
release name — a naming format without `{Quality Full}` would flip `WEBDL-1080p` to `HDTV-1080p`.
So disk import loses its second probe, and the `library.rescan` media-server dispatch that used to
ride along inside it is now issued by the disk-import caller itself, once per imported entry.
Notification policy stays caller-owned, like library resolution.

Not done here: the plan's `media.files.imported` line. Disk import emits nothing today and
`import.complete` carries download-queue semantics (season/episode numbers used to retire progress
leaves), so there is no shared event to emit yet. The domain-event catalog in 2.1 is where it belongs.

## Verification

- `tsc --noEmit` exits 0.
- Full suite **82 suites / 773 tests / 29 snapshots, green — identical to `main`.** The `it(`
  count per touched spec is unchanged (24 and 2): the two characterisation nets landed for this
  move were adapted at the harness level only, every assertion kept byte-identical. The
  `processOne` harness now composes a real `LibraryIngestService` over the same mocks, so those 8
  tests still pin the same destinations, sizes and qualities across the new seam.
- **The real torrent path, end to end in the local Docker stack**, against a stand-in qBittorrent
  WebAPI: a grabbed history row + a completed torrent whose release name claims 2160p but whose
  video is really 1920×804. `processCompleted` imported it on its own cron tick and produced
  `Verify Sample (2024) WEBDL-1080p.mkv` under a folder it computed and pinned itself, the
  allow-listed `.srt` companion renamed alongside it, the `.txt` skipped, a `media_files` row with
  `quality=WEBDL-1080p`, `size` equal to the real destination bytes and `streamInfo` carrying
  1920×804, the history row `completed`, the source left in place (copy, not move), and cropdetect
  plus the embedded-subtitle probe running afterwards off the critical path.
- **The disk-import path through `POST /api/imports/disk/confirm`** on the same service: declared
  `Bluray-2160p`, real 1280×720, landed as `Bluray-720p`.
- Backend boots clean on the new DI graph (the `LibraryIngestModule` ⇄ scheduler forwardRef and
  `SubtitlesModule` for the probe): liveness 200, no resolution errors.

## Out of scope, but now settled by tracing

The open question from #879 — whether the superseded file is cleaned up after a quality upgrade —
is **no**. An upgrade writes a different filename, so `existingFile` never matches, a second
`MediaFile` row is inserted and both copies persist. Only two paths ever delete a file row: the
manual `DELETE /media/:id/files/:fileId` and the rescan sweep, which removes rows whose file is
*missing from disk* (`media-rescan.service.ts:479`) — neither is reachable from an import. Nothing
records that a grab was an upgrade; `classifyForSearch`'s `mode: 'upgrade'` is transient. Worse,
`media.files` is loaded with no ordering and every client call site takes `files[0]`, so after an
upgrade playback can be pointed at the older copy. That is a defect, not a refactor, and wants its
own pull request.
