### PR TITLE
refactor(imports): move file selection and episode resolution into ingest

### DIFF
--- a/backend/src/common/constants/video-extensions.ts
+++ b/backend/src/common/constants/video-extensions.ts
@@ -1,0 +1,11 @@
+/** Container extensions Fliks treats as a playable video file. Lowercase, dot-prefixed. */
+export const VIDEO_EXTS: ReadonlySet<string> = new Set([
+  '.mkv',
+  '.mp4',
+  '.avi',
+  '.mov',
+  '.ts',
+  '.m2ts',
+  '.wmv',
+  '.flv',
+]);

--- a/backend/src/common/library-ingest/library-ingest.module.ts
+++ b/backend/src/common/library-ingest/library-ingest.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Media } from '../../modules/media/entities/media.entity';
 import { MediaFile } from '../../modules/media/entities/media-file.entity';
 import { Episode } from '../../modules/media/entities/episode.entity';
+import { Season } from '../../modules/media/entities/season.entity';
 import { LibraryIngestService } from './library-ingest.service';
 import { FliksSchedulerModule } from '../../modules/scheduler/scheduler.module';
 import { MediaModule } from '../../modules/media/media.module';
@@ -10,7 +11,7 @@ import { SubtitlesModule } from '../../modules/subtitles/subtitles.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Media, MediaFile, Episode]),
+    TypeOrmModule.forFeature([Media, MediaFile, Episode, Season]),
     forwardRef(() => FliksSchedulerModule),
     forwardRef(() => MediaModule),
     SubtitlesModule,

--- a/backend/src/common/library-ingest/library-ingest.service.spec.ts
+++ b/backend/src/common/library-ingest/library-ingest.service.spec.ts
@@ -28,6 +28,7 @@ function buildHarness() {
     findOne: jest.fn().mockResolvedValue(null),
     update: jest.fn().mockResolvedValue(undefined),
   };
+  const seasonRepo = { findOne: jest.fn().mockResolvedValue(null) };
   const fileTransfer = {
     transferFile: jest.fn().mockResolvedValue(undefined),
     transferCompanions: jest.fn().mockResolvedValue(undefined),
@@ -53,6 +54,7 @@ function buildHarness() {
   wired.mediaRepo = mediaRepo;
   wired.fileRepo = fileRepo;
   wired.episodeRepo = episodeRepo;
+  wired.seasonRepo = seasonRepo;
   wired.naming = naming;
   wired.fileTransfer = fileTransfer;
   wired.mediaService = mediaService;
@@ -65,6 +67,7 @@ function buildHarness() {
     mediaRepo,
     fileRepo,
     episodeRepo,
+    seasonRepo,
     fileTransfer,
     mediaService,
     subtitleScheduler,

--- a/backend/src/common/library-ingest/library-ingest.service.ts
+++ b/backend/src/common/library-ingest/library-ingest.service.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import { Media } from '../../modules/media/entities/media.entity';
 import { MediaFile } from '../../modules/media/entities/media-file.entity';
 import { Episode } from '../../modules/media/entities/episode.entity';
+import { Season } from '../../modules/media/entities/season.entity';
 import { MediaType } from '../enums';
 import { relativePathUnderMediaRoot } from '../utils/media-path.util';
 import { NamingService } from '../../modules/scheduler/naming.service';
@@ -38,7 +39,12 @@ export interface IngestRequest {
 export interface IngestResult {
   /** `sourcePath` echoes the request entry, so a caller can map a landed file
    *  back to what it knows about it — a skipped file leaves no entry. */
-  imported: { file: MediaFile; episodeId?: number; sourcePath: string }[];
+  imported: {
+    file: MediaFile;
+    episodeId?: number;
+    seasonId?: number;
+    sourcePath: string;
+  }[];
 }
 
 /**
@@ -57,6 +63,8 @@ export class LibraryIngestService {
     private readonly fileRepo: Repository<MediaFile>,
     @InjectRepository(Episode)
     private readonly episodeRepo: Repository<Episode>,
+    @InjectRepository(Season)
+    private readonly seasonRepo: Repository<Season>,
     private readonly naming: NamingService,
     private readonly fileTransfer: FileTransferService,
     @Inject(forwardRef(() => MediaService))
@@ -81,6 +89,21 @@ export class LibraryIngestService {
         `Media #${req.mediaId} is not anchored to a library folder`,
       );
     }
+    if (!req.files.length) return { imported: [] };
+
+    // A series release carrying several video files is a season pack: every file
+    // is its own episode. Anything else keeps only the largest file (samples,
+    // proofs and extras ride along in the same folder). A single-file request is
+    // unaffected either way.
+    const isSeasonPack = media.type === MediaType.SERIES && req.files.length > 1;
+    const files = isSeasonPack
+      ? req.files
+      : [req.files.reduce((a, b) => ((a.size ?? 0) > (b.size ?? 0) ? a : b))];
+    if (isSeasonPack) {
+      this.logger.log(
+        `Ingest[${req.sourceLabel}]: season pack — ${files.length} episode(s) to import`,
+      );
+    }
 
     const formats = await this.naming.getFormats();
     const companionExts = await this.fileTransfer.getCompanionExts();
@@ -91,21 +114,64 @@ export class LibraryIngestService {
     const imported: (IngestResult['imported'][number] & { destPath: string })[] =
       [];
 
-    for (const file of req.files) {
+    for (const file of files) {
+      const ext = path.extname(file.path);
+      const sourceBase = path.basename(file.path, ext);
+
+      let episodeId = file.episodeId;
+      let seasonId: number | undefined;
       let seasonNumber: number | undefined;
       let episodeNumber: number | undefined;
       let episodeTitle: string | undefined;
       let airDate: string | undefined;
-      if (file.episodeId) {
-        const ep = await this.episodeRepo.findOne({
-          where: { id: file.episodeId },
-          relations: ['season'],
-        });
-        if (ep) {
-          episodeNumber = ep.episodeNumber;
-          seasonNumber = ep.season?.seasonNumber ?? 1;
-          episodeTitle = ep.title ?? undefined;
-          airDate = ep.airDate ?? undefined;
+
+      if (media.type !== MediaType.MOVIE) {
+        const epNums =
+          this.naming.parseEpisodeNumbers(sourceBase) ??
+          (req.releaseName ? this.naming.parseEpisodeNumbers(req.releaseName) : null);
+        seasonNumber = epNums?.season;
+        episodeNumber = epNums?.episode;
+
+        if (episodeId != null) {
+          // Caller already matched the episode: its row is authoritative.
+          const ep = await this.episodeRepo.findOne({
+            where: { id: episodeId },
+            relations: ['season'],
+          });
+          if (ep) {
+            episodeNumber = ep.episodeNumber;
+            seasonNumber = ep.season?.seasonNumber ?? 1;
+            seasonId = ep.season?.id;
+            episodeTitle = ep.title ?? undefined;
+            airDate = ep.airDate ?? undefined;
+          }
+        } else if (epNums) {
+          const season = await this.seasonRepo.findOne({
+            where: { media: { id: media.id }, seasonNumber: epNums.season },
+          });
+          if (season) {
+            seasonId = season.id;
+            const episode = await this.episodeRepo.findOne({
+              where: { season: { id: season.id }, episodeNumber: epNums.episode },
+            });
+            if (episode) {
+              episodeId = episode.id;
+              episodeTitle = episode.title ?? undefined;
+              airDate = episode.airDate ?? undefined;
+              if (
+                epNums.episodeEnd != null &&
+                episode.endEpisodeNumber !== epNums.episodeEnd
+              ) {
+                episode.endEpisodeNumber = epNums.episodeEnd;
+                await this.episodeRepo.save(episode);
+              }
+            }
+          }
+        }
+        if (isSeasonPack) {
+          this.logger.log(
+            `Ingest[${req.sourceLabel}]: "${sourceBase}" → ${epNums ? `S${String(epNums.season).padStart(2, '0')}E${String(epNums.episode).padStart(2, '0')}` : 'no episode parsed'}`,
+          );
         }
       }
 
@@ -125,8 +191,6 @@ export class LibraryIngestService {
             )
           : (req.fallbackQuality ?? '');
 
-      const ext = path.extname(file.path);
-      const sourceBase = path.basename(file.path, ext);
       let newBaseName: string;
       let destDir: string;
 
@@ -227,7 +291,7 @@ export class LibraryIngestService {
       })();
 
       const payload = {
-        episode: file.episodeId != null ? ({ id: file.episodeId } as Episode) : null,
+        episode: episodeId != null ? ({ id: episodeId } as Episode) : null,
         size: finalSize,
         quality,
         ...(streamInfo ? { streamInfo } : {}),
@@ -244,13 +308,14 @@ export class LibraryIngestService {
             this.fileRepo.create({ media, relativePath, ...payload }),
           );
 
-      if (file.episodeId != null) {
-        await this.episodeRepo.update(file.episodeId, { hasFile: true });
+      if (episodeId != null) {
+        await this.episodeRepo.update(episodeId, { hasFile: true });
       }
 
       imported.push({
         file: saved,
-        episodeId: file.episodeId,
+        episodeId,
+        seasonId,
         sourcePath: file.path,
         destPath,
       });
@@ -283,9 +348,10 @@ export class LibraryIngestService {
     })();
 
     return {
-      imported: imported.map(({ file, episodeId, sourcePath }) => ({
+      imported: imported.map(({ file, episodeId, seasonId, sourcePath }) => ({
         file,
         episodeId,
+        seasonId,
         sourcePath,
       })),
     };

--- a/backend/src/modules/imports/disk-import.service.ts
+++ b/backend/src/modules/imports/disk-import.service.ts
@@ -36,17 +36,7 @@ import { LibrariesService } from '../libraries/libraries.service';
 import { TransferMethod } from '../../common/services/file-transfer.service';
 import { LibraryIngestService } from '../../common/library-ingest/library-ingest.service';
 import { MediaServersService } from '../media-servers/media-servers.service';
-
-const VIDEO_EXTS = new Set([
-  '.mkv',
-  '.mp4',
-  '.avi',
-  '.mov',
-  '.ts',
-  '.m2ts',
-  '.wmv',
-  '.flv',
-]);
+import { VIDEO_EXTS } from '../../common/constants/video-extensions';
 
 export interface ScanCandidate {
   filePath: string;

--- a/backend/src/modules/media/media-service/media-rescan.service.ts
+++ b/backend/src/modules/media/media-service/media-rescan.service.ts
@@ -32,23 +32,13 @@ import { MediaServersService } from '../../media-servers/media-servers.service';
 import { MediaMetadataService } from './media-metadata.service';
 import { clearMediaCache } from '../../../common/utils/media-cache.util';
 import { relativePathUnderMediaRoot } from '../../../common/utils/media-path.util';
+import { VIDEO_EXTS } from '../../../common/constants/video-extensions';
 
 type ProbeResult = Awaited<ReturnType<FfprobeService['detectMediaFileInfo']>>;
 
 @Injectable()
 export class MediaRescanService {
   private readonly log = new Logger(MediaRescanService.name);
-
-  private static readonly VIDEO_EXTS = new Set([
-    '.mkv',
-    '.mp4',
-    '.avi',
-    '.mov',
-    '.ts',
-    '.m2ts',
-    '.wmv',
-    '.flv',
-  ]);
 
   constructor(
     @InjectRepository(Media)
@@ -954,11 +944,7 @@ export class MediaRescanService {
         files.push(
           ...this.collectVideoFilesRecursive(fullPath, depth + 1, mediaId),
         );
-      } else if (
-        MediaRescanService.VIDEO_EXTS.has(
-          path.extname(entry.name).toLowerCase(),
-        )
-      ) {
+      } else if (VIDEO_EXTS.has(path.extname(entry.name).toLowerCase())) {
         files.push(fullPath);
       }
     }

--- a/backend/src/modules/scheduler/completion.service.spec.ts
+++ b/backend/src/modules/scheduler/completion.service.spec.ts
@@ -479,6 +479,7 @@ describe('CompletionService.processOne', () => {
     ingestWired.mediaRepo = mediaRepo;
     ingestWired.fileRepo = mediaFileRepo;
     ingestWired.episodeRepo = episodeRepo;
+    ingestWired.seasonRepo = seasonRepo;
     ingestWired.naming = naming;
     ingestWired.fileTransfer = fileTransfer;
     ingestWired.mediaService = mediaService;
@@ -533,11 +534,11 @@ describe('CompletionService.processOne', () => {
   }
 
   /** Wires the two-episode season-pack fixture shared by the "own episode per
-   *  file" and "history reconciliation" tests below. `episodeRepo.findOne` is
-   *  hit with two different query shapes now: `processOne`'s own pre-pass
-   *  looks up `{ season, episodeNumber }`, while `LibraryIngestService`
-   *  (sharing the same mock) re-fetches by `{ id }` for naming. Both must
-   *  resolve to the same two episodes. */
+   *  file" and "history reconciliation" tests below. `LibraryIngestService`
+   *  hits `episodeRepo.findOne` with two different query shapes depending on
+   *  whether the file arrives with a caller-resolved `episodeId` (`{ id }`)
+   *  or needs parsing from the filename (`{ season, episodeNumber }`). Both
+   *  must resolve to the same two episodes. */
   function wireSeasonPack(h: ReturnType<typeof buildProcessOneHarness>) {
     const episodesById: Record<number, Record<string, unknown>> = {
       601: {

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -49,6 +49,7 @@ import { parseReleaseQuality } from '../../common/release-parsing';
 import { MarkersService } from '../markers/markers.service';
 import { SchedulerService } from './scheduler.service';
 import { LibraryIngestService } from '../../common/library-ingest/library-ingest.service';
+import { VIDEO_EXTS } from '../../common/constants/video-extensions';
 
 /**
  * How long a `grabbed` or `importing` history row may stay without a
@@ -600,17 +601,6 @@ export class CompletionService implements OnModuleInit {
     seriesFolderFormat: string,
     libraries: Library[],
   ): Promise<void> {
-    const VIDEO_EXTS = [
-      '.mkv',
-      '.mp4',
-      '.avi',
-      '.mov',
-      '.ts',
-      '.m2ts',
-      '.wmv',
-      '.flv',
-    ];
-
     // Use qBittorrent API to get actual files of this torrent
     const videoFiles: { filePath: string; size: number }[] = [];
 
@@ -621,7 +611,7 @@ export class CompletionService implements OnModuleInit {
       );
       for (const f of torrentFiles) {
         const ext = path.extname(f.name).toLowerCase();
-        if (VIDEO_EXTS.includes(ext) && f.progress >= 1) {
+        if (VIDEO_EXTS.has(ext) && f.progress >= 1) {
           const filePath = path.join(torrent.save_path, f.name);
           videoFiles.push({ filePath, size: f.size });
         }
@@ -762,110 +752,20 @@ export class CompletionService implements OnModuleInit {
     media.folderName = folderName;
     if (resolvedLib) media.library = resolvedLib;
 
-    // For movies or single episode: import the largest file
-    // For series with multiple files: import each file as a separate episode
-    const isSeasonPack =
-      media.type === MediaType.SERIES && videoFiles.length > 1;
-    const filesToImport = isSeasonPack
-      ? videoFiles
-      : [videoFiles.reduce((a, b) => (a.size > b.size ? a : b))];
-
-    if (isSeasonPack) {
-      this.log.log(
-        `Import[${history.sourceTitle}]: season pack detected — ${filesToImport.length} episodes to import`,
-      );
-    }
-
-    // Resolve each file's episode (season packs carry one per file) before
-    // handing the batch to the shared ingest pipeline, which owns naming,
-    // the filesystem write and MediaFile persistence.
-    const resolved: {
-      path: string;
-      episodeId?: number;
-      size: number;
-      seasonId?: number;
-    }[] = [];
-    for (let idx = 0; idx < filesToImport.length; idx++) {
-      const videoFile = filesToImport[idx];
-      const filename = path.basename(
-        videoFile.filePath,
-        path.extname(videoFile.filePath),
-      );
-
-      let episodeId: number | undefined;
-      let seasonId: number | undefined;
-
-      if (media.type !== MediaType.MOVIE) {
-        // For season packs: parse from individual filename; for single ep: try filename then release name
-        const epNums =
-          this.naming.parseEpisodeNumbers(filename) ??
-          this.naming.parseEpisodeNumbers(history.sourceTitle);
-
-        if (isSeasonPack) {
-          this.log.log(
-            `Import[${history.sourceTitle}]: [${idx + 1}/${filesToImport.length}] "${filename}" → ${epNums ? `S${String(epNums.season).padStart(2, '0')}E${String(epNums.episode).padStart(2, '0')}` : 'no episode parsed'}`,
-          );
-        }
-
-        if (epNums) {
-          const season = await this.seasonRepo.findOne({
-            where: { media: { id: media.id }, seasonNumber: epNums.season },
-          });
-          if (season) {
-            seasonId = season.id;
-            const episode = await this.episodeRepo.findOne({
-              where: {
-                season: { id: season.id },
-                episodeNumber: epNums.episode,
-              },
-            });
-            if (episode) {
-              episodeId = episode.id;
-              if (
-                epNums.episodeEnd != null &&
-                episode.endEpisodeNumber !== epNums.episodeEnd
-              ) {
-                episode.endEpisodeNumber = epNums.episodeEnd;
-                await this.episodeRepo.save(episode);
-              }
-            }
-          }
-        }
-      }
-
-      resolved.push({
-        path: videoFile.filePath,
-        episodeId,
-        size: videoFile.size,
-        seasonId,
-      });
-    }
-
-    // Keyed by source path, not by episode: a season pack whose season row
-    // exists but whose episode row doesn't still pins the season on the
-    // history row below.
-    const seasonByPath = new Map(resolved.map((r) => [r.path, r.seasonId]));
-
     const result = await this.libraryIngest.ingest({
       mediaId: media.id,
-      files: resolved.map((r) => ({
-        path: r.path,
-        episodeId: r.episodeId,
-        size: r.size,
-      })),
+      files: videoFiles.map((f) => ({ path: f.filePath, size: f.size })),
       transfer: 'copy',
       fallbackQuality: history.quality,
       releaseName: history.sourceTitle,
       sourceLabel: history.sourceTitle,
       force: true,
     });
-    const importedFiles = result.imported.map(
-      ({ file, episodeId, sourcePath }) => ({
-        savedFile: file,
-        episodeId,
-        seasonId: seasonByPath.get(sourcePath),
-      }),
-    );
+    const importedFiles = result.imported.map(({ file, episodeId, seasonId }) => ({
+      savedFile: file,
+      episodeId,
+      seasonId,
+    }));
 
     if (!importedFiles.length) {
       const statusMessage = `Import failed: no file could be placed under the library root for "${torrent.name}"`;

--- a/backend/src/modules/scheduler/naming.service.ts
+++ b/backend/src/modules/scheduler/naming.service.ts
@@ -2,17 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import * as fs from 'fs';
 import * as path from 'path';
-
-const VIDEO_EXTS = new Set([
-  '.mkv',
-  '.mp4',
-  '.avi',
-  '.mov',
-  '.ts',
-  '.m2ts',
-  '.wmv',
-  '.flv',
-]);
+import { VIDEO_EXTS } from '../../common/constants/video-extensions';
 
 export interface NamingFormats {
   movie: string;


### PR DESCRIPTION
Phase 1 of the plugin-system plan (PR 1.5). #882 moved the ingest *tail* into
`LibraryIngestService`; this moves the *head*, so the service now owns everything downstream of
"here is a set of files that belong to this media".

## What moves, and why each piece

**File selection** — `processOne` decided which of a release's video files to actually import:
a series release with several of them is a season pack (every file is its own episode),
anything else keeps the largest (samples, proofs and extras ride along in the same folder).
That is a media-type-driven ingestion policy, not a torrent one. It is also a **no-op for a
single-file request**, which is all disk import ever sends, so it applies unconditionally with
no flag and no change for that caller.

**Episode resolution** — this one is not a dedup, it is a boundary correction. Resolving a
file's season and episode means reading core's `seasons` and `episodes` tables; leaving it in
`completion.service.ts` would have put it on the plugin's side of the phase-10 cut, where the
plugin has only its own Postgres schema. The service honours a caller-pinned `episodeId` first
(disk import matched it upstream, its row stays authoritative) and otherwise parses the
filename, falling back to the release name — then looks the season and episode rows up,
patches `endEpisodeNumber`, and returns `seasonId` alongside `episodeId` so the torrent
caller's history reconciliation is unchanged.

**The extension filter** — deduped, not moved. `VIDEO_EXTS` was declared four times with
byte-identical contents (`disk-import`, `media-rescan`, `naming`, `completion`); it is now one
constant in `common/constants/`. The *use* of it in `processOne`, and the `progress >= 1`
check next to it, stay with the torrent caller: both read download-client data, and they are
what decides whether a release gets blocklisted as a dud. That is an acquisition decision, so
it belongs next to the blocklist call it feeds — a deliberate deviation from the plan line,
which listed both as moving.

## It also repairs a regression from #882

Before #882, the torrent path named a series file from the numbers **parsed out of the
filename**, whether or not the episode row existed in the DB. #882 made naming read the
numbers off the episode row instead, defaulting to `1/1` when the caller passed no
`episodeId` — so a release whose episode Fliks has no row for (an auto-matched orphan torrent,
an episode the metadata provider has not listed yet) was written as `S01E01`, and since the
torrent path passes `force: true`, **over the top of the real S01E01**. Rare, but it is data
loss, and I missed it when reviewing that PR.

The parse restored here fixes it: naming uses the parsed numbers again, and the episode row
only supplies the title, the air date and the link. Disk import gains the same parse, which
also closes the "silent 1/1 default" noted as divergence 10 in #879.

## Verification

- `tsc --noEmit` exits 0.
- Full suite **82 suites / 773 tests / 29 snapshots, green — identical to `main`**, with the
  `it(` count per touched spec unchanged (24 and 2). Harness wiring only; no assertion touched.
- **The plan's acceptance criterion, run for real in the local Docker stack:** the same three
  files landed twice — once as a torrent season pack through the cron, once through
  `POST /api/imports/disk/confirm` — produce **byte-identical `relativePath` sets**.
- The torrent run also pins the two filters that stayed behind: the stand-in qBittorrent served
  5 files, and the import took 3 — a `.txt` dropped by extension, a half-downloaded `.mkv`
  (`progress: 0.4`) dropped by the progress check.
- And it pins the regression fix: the pack's third file is `S01E09`, an episode with **no row
  in the database**. It landed as `Verify Show - S01E09 - WEBDL-1080p.mkv` — the parsed number,
  no title — where `main` would have written it as `S01E01 - Wake` on top of the real first
  episode. Both callers produce that same name, which is why the two sets match.
- Backend boots clean on the new DI graph (`Season` repository added to `LibraryIngestModule`):
  liveness 200, no resolution errors.

## What is left in `processOne`

The qBittorrent file fetch and its two filters, the no-video failure branch (blocklist, drop
the dud torrent, `import.failed`), the media lookup, library/folderName resolution and pinning,
and the whole tail: `DownloadHistory` bookkeeping, SSE, notifications, media-server dispatch,
marker detection, sprites, the post-import script. Phase 2.3 takes the event routing next.
