### PR TITLE
feat(events): add a domain event bus alongside the SSE one

### DIFF
--- a/backend/src/common/library-ingest/library-ingest.service.spec.ts
+++ b/backend/src/common/library-ingest/library-ingest.service.spec.ts
@@ -61,6 +61,7 @@ function buildHarness() {
   wired.subtitleScheduler = subtitleScheduler;
   wired.ffprobe = ffprobe;
   wired.logger = logger;
+  wired.events = { emitDomain: jest.fn() };
 
   return {
     service,

--- a/backend/src/common/library-ingest/library-ingest.service.ts
+++ b/backend/src/common/library-ingest/library-ingest.service.ts
@@ -14,6 +14,7 @@ import { SubtitleSchedulerService } from '../../modules/scheduler/subtitle-sched
 import { MediaService } from '../../modules/media/media.service';
 import { FileTransferService, TransferMethod } from '../services/file-transfer.service';
 import { FfprobeService } from '../../modules/subtitles/ffprobe.service';
+import { EventsService } from '../../modules/scheduler/events.service';
 import { qualityFromResolution } from '../release-parsing';
 
 export interface IngestRequest {
@@ -72,6 +73,7 @@ export class LibraryIngestService {
     @Inject(forwardRef(() => SubtitleSchedulerService))
     private readonly subtitleScheduler: SubtitleSchedulerService,
     private readonly ffprobe: FfprobeService,
+    private readonly events: EventsService,
   ) {}
 
   async ingest(req: IngestRequest): Promise<IngestResult> {
@@ -111,8 +113,11 @@ export class LibraryIngestService {
       ? this.naming.extractReleaseGroup(req.releaseName)
       : undefined;
 
-    const imported: (IngestResult['imported'][number] & { destPath: string })[] =
-      [];
+    const imported: (IngestResult['imported'][number] & {
+      destPath: string;
+      seasonNumber?: number;
+      episodeNumber?: number;
+    })[] = [];
 
     for (const file of files) {
       const ext = path.extname(file.path);
@@ -318,6 +323,23 @@ export class LibraryIngestService {
         seasonId,
         sourcePath: file.path,
         destPath,
+        seasonNumber,
+        episodeNumber,
+      });
+    }
+
+    if (imported.length > 0) {
+      const single = imported.length === 1 ? imported[0] : undefined;
+      this.events.emitDomain({
+        type: 'media.files.imported',
+        mediaId: media.id,
+        ...(single?.seasonNumber != null
+          ? { seasonNumber: single.seasonNumber }
+          : {}),
+        ...(single?.episodeNumber != null
+          ? { episodeNumber: single.episodeNumber }
+          : {}),
+        source: req.releaseName ? 'download' : 'disk',
       });
     }
 

--- a/backend/src/modules/download-clients/download-clients.service.ts
+++ b/backend/src/modules/download-clients/download-clients.service.ts
@@ -23,6 +23,7 @@ import { TestDownloadClientDto } from './dto/test-download-client.dto';
 import { TorrentHistoryMatcher } from '../media/torrent-history-matcher.service';
 import { BlocklistService } from '../blocklist/blocklist.service';
 import { SchedulerService } from '../scheduler/scheduler.service';
+import { EventsService } from '../scheduler/events.service';
 
 export interface QueueEntry extends QbittorrentTorrent {
   clientId: number;
@@ -130,6 +131,7 @@ export class DownloadClientsService {
     private readonly blocklist: BlocklistService,
     @Inject(forwardRef(() => SchedulerService))
     private readonly scheduler: SchedulerService,
+    private readonly events: EventsService,
   ) {}
 
   async testConnection(
@@ -239,6 +241,11 @@ export class DownloadClientsService {
     // (monitored + profiled + missing); the blocklist row excludes this release.
     if (entry?.mediaId) {
       void this.scheduler.searchMissingForMedia([entry.mediaId]);
+      this.events.emitDomain({
+        type: 'media.acquisition.requested',
+        mediaIds: [entry.mediaId],
+        reason: 'download-blocklisted',
+      });
     }
   }
 

--- a/backend/src/modules/media/media-service/media-import.season-scope.spec.ts
+++ b/backend/src/modules/media/media-service/media-import.season-scope.spec.ts
@@ -54,6 +54,7 @@ describe('MediaImportService — season monitoring scope on import', () => {
         persistMediaMetadataInBackground: jest.fn(),
       } as any,
       { onMediaImported: jest.fn().mockResolvedValue(undefined) } as any,
+      { emitDomain: jest.fn() } as any,
     );
     jest.spyOn(svc as any, 'resolveImportTarget').mockResolvedValue({
       libraryId: 7,

--- a/backend/src/modules/media/media-service/media-import.service.ts
+++ b/backend/src/modules/media/media-service/media-import.service.ts
@@ -31,6 +31,7 @@ import { User } from '../../users/entities/user.entity';
 import { Library } from '../../libraries/entities/library.entity';
 import { LibrariesService } from '../../libraries/libraries.service';
 import { NamingService } from '../../scheduler/naming.service';
+import { EventsService } from '../../scheduler/events.service';
 import { buildMediaFieldsFromTmdb } from './tmdb-mapping.util';
 import { MediaMetadataService } from './media-metadata.service';
 
@@ -57,6 +58,7 @@ export class MediaImportService {
     private readonly metadata: MediaMetadataService,
     @Inject(forwardRef(() => RequestLifecycleService))
     private readonly requestLifecycle: RequestLifecycleService,
+    private readonly events: EventsService,
   ) {}
 
   async importFromTmdb(
@@ -271,6 +273,14 @@ export class MediaImportService {
     await this.metadata.updateSearchVector(saved.id);
     const reloaded = await this.mediaRepo.findOne({ where: { id: saved.id } });
     if (!reloaded) throw new Error(`Media #${saved.id} not found after save`);
+    this.events.emitDomain({
+      type: 'media.imported',
+      mediaId: saved.id,
+      tmdbId: dto.tmdbId ?? null,
+      mediaType: dto.type,
+      libraryId: null,
+      addedByUserId: null,
+    });
     return reloaded;
   }
 
@@ -357,6 +367,14 @@ export class MediaImportService {
     this.metadata.downloadMediaImagesInBackground(saved.id, details);
     await this.metadata.updateSearchVector(saved.id);
     await this.requestLifecycle.onMediaImported(saved, addedByUserId ?? null);
+    this.events.emitDomain({
+      type: 'media.imported',
+      mediaId: saved.id,
+      tmdbId: details.tmdbId ?? null,
+      mediaType: MediaType.MOVIE,
+      libraryId: libraryId ?? null,
+      addedByUserId: addedByUserId ?? null,
+    });
     const reloaded = await this.mediaRepo.findOne({ where: { id: saved.id } });
     if (!reloaded) throw new Error(`Media #${saved.id} not found after save`);
     // Cast/crew + per-person enrichment is detail-page data the badge,
@@ -429,6 +447,14 @@ export class MediaImportService {
 
     await this.metadata.updateSearchVector(saved.id);
     await this.requestLifecycle.onMediaImported(saved, addedByUserId ?? null);
+    this.events.emitDomain({
+      type: 'media.imported',
+      mediaId: saved.id,
+      tmdbId: details.tmdbId ?? null,
+      mediaType: MediaType.SERIES,
+      libraryId: libraryId ?? null,
+      addedByUserId: addedByUserId ?? null,
+    });
     const reloaded = await this.mediaRepo.findOne({ where: { id: saved.id } });
     if (!reloaded) throw new Error(`Media #${saved.id} not found after save`);
     // See persistImportedMovie: cast/crew enrichment is deferred. Season and

--- a/backend/src/modules/media/media-service/media-metadata.service.ts
+++ b/backend/src/modules/media/media-service/media-metadata.service.ts
@@ -27,6 +27,7 @@ import { MetadataLanguageOverride } from '../../metadata-providers/metadata-sett
 import { MediaType } from '../../../common/enums';
 import { ImageService } from '../../images/image.service';
 import { SchedulerService } from '../../scheduler/scheduler.service';
+import { EventsService } from '../../scheduler/events.service';
 import { mapWithConcurrency } from '../../../common/utils/concurrency';
 import { buildMediaFieldsFromTmdb } from './tmdb-mapping.util';
 
@@ -53,6 +54,7 @@ export class MediaMetadataService {
     private readonly imageService: ImageService,
     @Inject(forwardRef(() => SchedulerService))
     private readonly scheduler: SchedulerService,
+    private readonly events: EventsService,
   ) {}
 
   /** Metadata language/region override for a media's library, or undefined when
@@ -115,6 +117,11 @@ export class MediaMetadataService {
       // for the next scheduler tick. Mirrors the post-approval kick.
       if (insertedCount > 0) {
         void this.scheduler.searchMissingForMedia([media.id]);
+        this.events.emitDomain({
+          type: 'media.acquisition.requested',
+          mediaIds: [media.id],
+          reason: 'metadata-refresh',
+        });
       }
     }
 

--- a/backend/src/modules/media/media-service/media-mutation.service.spec.ts
+++ b/backend/src/modules/media/media-service/media-mutation.service.spec.ts
@@ -84,6 +84,7 @@ describe('MediaMutationService monitoring cascade', () => {
       query as never,
       metadata as never,
       requestLifecycle as never,
+      { emitDomain: jest.fn() } as never,
     );
   });
 
@@ -184,6 +185,7 @@ describe('MediaMutationService remove disk cleanup', () => {
       query as never,
       {} as never,
       requestLifecycle as never,
+      { emitDomain: jest.fn() } as never,
     );
   });
 

--- a/backend/src/modules/media/media-service/media-mutation.service.ts
+++ b/backend/src/modules/media/media-service/media-mutation.service.ts
@@ -22,6 +22,7 @@ import { QualityProfile } from '../../profiles/entities/quality-profile.entity';
 import { LanguageProfile } from '../../profiles/entities/language-profile.entity';
 import { Library } from '../../libraries/entities/library.entity';
 import { MediaServersService } from '../../media-servers/media-servers.service';
+import { EventsService } from '../../scheduler/events.service';
 import { RequestLifecycleService } from '../../requests/request-lifecycle.service';
 import { MediaQueryService } from './media-query.service';
 import { MediaMetadataService } from './media-metadata.service';
@@ -47,6 +48,7 @@ export class MediaMutationService {
     private readonly metadata: MediaMetadataService,
     @Inject(forwardRef(() => RequestLifecycleService))
     private readonly requestLifecycle: RequestLifecycleService,
+    private readonly events: EventsService,
   ) {}
 
   async update(id: number, dto: UpdateMediaDto): Promise<Media> {
@@ -59,6 +61,11 @@ export class MediaMutationService {
     const saved = await this.mediaRepo.save(media);
     if (dto.monitored !== undefined) {
       await this.cascadeMonitoredToChildren([saved.id], dto.monitored);
+      this.events.emitDomain({
+        type: 'media.monitored.changed',
+        mediaId: saved.id,
+        monitored: dto.monitored,
+      });
     }
     await this.metadata.updateSearchVector(saved.id);
     await this.requestLifecycle.onMediaMonitorChange(saved, wasMonitored);
@@ -205,9 +212,17 @@ export class MediaMutationService {
     const media = await this.query.findOne(id);
     const title = media.title;
     const mediaPath = media.path;
+    const tmdbId = media.tmdbId;
+    const mediaType = media.type;
     const diskPath = this.resolveSafeMediaDir(media);
     await this.requestLifecycle.onMediaRemoved(media);
     await this.mediaRepo.remove(media);
+    this.events.emitDomain({
+      type: 'media.removed',
+      mediaId: id,
+      tmdbId: tmdbId ?? null,
+      mediaType,
+    });
     void this.mediaServers.dispatch('media.deleted', {
       title,
       path: mediaPath,
@@ -278,6 +293,12 @@ export class MediaMutationService {
         wasMonitored,
         saved.monitored,
       );
+      this.events.emitDomain({
+        type: 'media.season.monitored.changed',
+        mediaId: season.media.id,
+        seasonNumber: saved.seasonNumber,
+        monitored: saved.monitored,
+      });
     }
     return saved;
   }

--- a/backend/src/modules/media/media.controller.ts
+++ b/backend/src/modules/media/media.controller.ts
@@ -451,6 +451,14 @@ export class MediaController {
           subtitleRemovedMissing: result.subtitleRemovedMissing,
           subtitleRemovedDuplicates: result.subtitleRemovedDuplicates,
         });
+        if (media.libraryId != null) {
+          this.eventsService.emitDomain({
+            type: 'library.scan.completed',
+            libraryId: media.libraryId,
+            added: result.added,
+            updated: result.updated,
+          });
+        }
       },
       (err) => {
         const message = (err as Error).message;

--- a/backend/src/modules/requests/request-lifecycle.service.ts
+++ b/backend/src/modules/requests/request-lifecycle.service.ts
@@ -169,6 +169,11 @@ export class RequestLifecycleService
     // failures (missing indexer, etc.) are logged inside the scheduler.
     if (touched.length && (await this.autoGrabOnApproval())) {
       void this.scheduler.searchMissingForMedia([media.id]);
+      this.events.emitDomain({
+        type: 'media.acquisition.requested',
+        mediaIds: [media.id],
+        reason: 'media-imported',
+      });
     }
   }
 

--- a/backend/src/modules/requests/requests.service.spec.ts
+++ b/backend/src/modules/requests/requests.service.spec.ts
@@ -77,6 +77,7 @@ describe('RequestsService delete requests', () => {
       {} as never,
       {} as never,
       libraries as never,
+      { emitDomain: jest.fn() } as never,
     );
   });
 

--- a/backend/src/modules/requests/requests.service.ts
+++ b/backend/src/modules/requests/requests.service.ts
@@ -29,6 +29,7 @@ import { MediaService } from '../media/media.service';
 import { Media } from '../media/entities/media.entity';
 import { ProfilesService } from '../profiles/profiles.service';
 import { SchedulerService } from '../scheduler/scheduler.service';
+import { EventsService } from '../scheduler/events.service';
 import { CaslAbilityFactory } from '../auth/casl/casl-ability.factory';
 import { Action } from '../auth/casl/actions.enum';
 import { ImageService } from '../images/image.service';
@@ -68,6 +69,7 @@ export class RequestsService {
     private readonly imageService: ImageService,
     private readonly tmdb: TmdbProvider,
     private readonly libraries: LibrariesService,
+    private readonly events: EventsService,
   ) {}
 
   private readonly logger = new Logger(RequestsService.name);
@@ -289,6 +291,27 @@ export class RequestsService {
     const row = this.requestRepo.create(partial);
     const saved = await this.requestRepo.save(row);
     this.projectEmbeddedUsers(saved);
+
+    this.events.emitDomain({
+      type: 'request.created',
+      requestId: saved.id,
+      mediaType: dto.mediaType,
+      tmdbId: dto.tmdbId,
+      userId: user.id,
+      kind: RequestKind.ADD,
+      seasons: dto.seasons ?? null,
+    });
+    if (autoApprove) {
+      this.events.emitDomain({
+        type: 'request.approved',
+        requestId: saved.id,
+        mediaId: media?.id ?? null,
+        mediaType: dto.mediaType,
+        tmdbId: dto.tmdbId,
+        seasons: dto.seasons ?? null,
+        approvedByUserId: user.id,
+      });
+    }
 
     const event = autoApprove ? 'request.approved' : 'request.created';
     void this.notifications.dispatch(event, {
@@ -784,8 +807,22 @@ export class RequestsService {
         await this.requestRepo.save(linked);
       }
       void this.scheduler.searchMissingForMedia([media.id]);
+      this.events.emitDomain({
+        type: 'media.acquisition.requested',
+        mediaIds: [media.id],
+        reason: 'request-approved',
+      });
     }
 
+    this.events.emitDomain({
+      type: 'request.approved',
+      requestId: row.id,
+      mediaId: media?.id ?? null,
+      mediaType: row.mediaType,
+      tmdbId: row.tmdbId,
+      seasons: row.seasons ?? null,
+      approvedByUserId: admin.id,
+    });
     void this.notifications.dispatch('request.approved', { title: row.title });
 
     return this.findResolvedRow(id);

--- a/backend/src/modules/scheduler/completion.service.spec.ts
+++ b/backend/src/modules/scheduler/completion.service.spec.ts
@@ -419,7 +419,7 @@ describe('CompletionService.processOne', () => {
     // background task never touches episodeRepo/seasonRepo a second time.
     const settings = { get: jest.fn().mockResolvedValue('false') };
     const sseAudience = { recipientsForMedia: jest.fn().mockResolvedValue([]) };
-    const events = { emit: jest.fn(), emitToUsers: jest.fn() };
+    const events = { emit: jest.fn(), emitToUsers: jest.fn(), emitDomain: jest.fn() };
     const ffprobe = {
       detectMediaFileInfo: jest
         .fn()
@@ -486,6 +486,7 @@ describe('CompletionService.processOne', () => {
     ingestWired.subtitleScheduler = subtitleScheduler;
     ingestWired.ffprobe = ffprobe;
     ingestWired.logger = log;
+    ingestWired.events = events;
 
     const run = (
       historyRow: DownloadHistory,

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -1112,6 +1112,11 @@ export class CompletionService implements OnModuleInit {
       );
       // Fire-and-forget: a slow indexer search shouldn't hold up this cron tick.
       void this.scheduler.searchMissingForMedia(Array.from(mediaToResearch));
+      this.events.emitDomain({
+        type: 'media.acquisition.requested',
+        mediaIds: Array.from(mediaToResearch),
+        reason: 'stalled-cleanup',
+      });
     }
   }
 

--- a/backend/src/modules/scheduler/events.service.ts
+++ b/backend/src/modules/scheduler/events.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { Subject, Observable, Subscription } from 'rxjs';
 import { randomUUID } from 'crypto';
 
@@ -186,6 +186,29 @@ export type SseEvent =
       mediaTitle: string;
     };
 
+// ---------------------------------------------------------------------------
+// Domain events — backend-to-backend, distinct from the SSE bus above.
+// ---------------------------------------------------------------------------
+
+/**
+ * Backend-to-backend events. Distinct from `SseEvent`, which is what browsers
+ * receive: a domain event describes something that happened in the domain, and
+ * its subscribers are other backend modules — eventually out-of-process plugins.
+ * In-process fan-out, at-most-once, no persistence, no replay, no retry. A
+ * subscriber that throws is caught and logged; it never reaches the emitter.
+ */
+export type DomainEvent =
+  | { type: 'media.imported'; mediaId: number; tmdbId: number | null; mediaType: string; libraryId: number | null; addedByUserId: number | null }
+  | { type: 'media.monitored.changed'; mediaId: number; monitored: boolean }
+  | { type: 'media.season.monitored.changed'; mediaId: number; seasonNumber: number; monitored: boolean }
+  | { type: 'media.removed'; mediaId: number; tmdbId: number | null; mediaType: string }
+  | { type: 'media.files.imported'; mediaId: number; seasonNumber?: number; episodeNumber?: number; source: 'download' | 'disk' }
+  | { type: 'media.acquisition.requested'; mediaIds: number[]; reason: string }
+  | { type: 'request.created'; requestId: number; mediaType: string; tmdbId: number; userId: number | null; kind: string; seasons: number[] | null }
+  | { type: 'request.approved'; requestId: number; mediaId: number | null; mediaType: string; tmdbId: number; seasons: number[] | null; approvedByUserId: number | null }
+  | { type: 'library.scan.completed'; libraryId: number; added: number; updated: number }
+  | { type: 'settings.changed'; key: string };
+
 /**
  * Wraps an `SseEvent` with its delivery audience.
  *   - `audience: null` + `connectionIds: null` → every SSE connection.
@@ -202,7 +225,9 @@ interface SseEnvelope {
 
 @Injectable()
 export class EventsService {
+  private readonly log = new Logger(EventsService.name);
   private readonly subject = new Subject<SseEnvelope>();
+  private readonly domainSubject = new Subject<DomainEvent>();
   private readonly connections = new Map<string, { userId: number }>();
 
   /** Broadcast to every connected client. */
@@ -272,5 +297,24 @@ export class EventsService {
   /** Backend-internal listener — used by services that react to other modules' events. */
   subscribe(handler: (event: SseEvent) => void): Subscription {
     return this.subject.subscribe((env) => handler(env.event));
+  }
+
+  /** Publish a domain event. Never throws: subscriber errors are swallowed by `onDomain`. */
+  emitDomain(event: DomainEvent): void {
+    this.domainSubject.next(event);
+  }
+
+  /** Subscribe to domain events. A throwing handler is logged, never propagated. */
+  onDomain(handler: (event: DomainEvent) => void): Subscription {
+    return this.domainSubject.subscribe((event) => {
+      try {
+        handler(event);
+      } catch (err) {
+        this.log.error(
+          `Domain event handler threw on "${event.type}": ${(err as Error).message}`,
+          err instanceof Error ? err.stack : undefined,
+        );
+      }
+    });
   }
 }

--- a/backend/src/modules/settings/settings.service.ts
+++ b/backend/src/modules/settings/settings.service.ts
@@ -2,12 +2,14 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { AppSetting } from './entities/app-setting.entity';
+import { EventsService } from '../scheduler/events.service';
 
 @Injectable()
 export class SettingsService {
   constructor(
     @InjectRepository(AppSetting)
     private readonly repo: Repository<AppSetting>,
+    private readonly events: EventsService,
   ) {}
 
   private readonly changeListeners: Array<(key: string) => void> = [];
@@ -24,6 +26,7 @@ export class SettingsService {
         /* listener errors must not break writes */
       }
     }
+    this.events.emitDomain({ type: 'settings.changed', key });
   }
 
   async getAll(): Promise<Record<string, string | null>> {


### PR DESCRIPTION
PR 2.1 of the plugin-system plan.

A second RxJS `Subject` in `events.service.ts` — not a new module, not a new dependency — carrying the plan's ten-event catalog: media imported/removed/monitored, season monitored, files imported, acquisition requested, request created/approved, library scan completed, settings changed. `onDomain` wraps the handler in try/catch and logs, so a throwing subscriber never reaches the emitter and never kills the subscription.

**Emitters only.** Nothing subscribes, nothing is removed, no call is reordered — the inversion is 2.2 and phase 4. `media.acquisition.requested` landed on five sites rather than the three the plan named: two more `searchMissingForMedia` callers exist today.

Deliberately not taken: the agent's first pass made four of the new `EventsService` injections optional so hand-rolled test harnesses would keep compiling. A missing provider should fail at boot, not silently drop every event, so they are required and the four harnesses pass a mock instead.

Verified: `tsc` 0, suite 82/773/29 green with the `it(` count unchanged in every touched spec, backend boots with no resolution errors.