### PR TITLE
refactor(requests): invert both seams between requests and acquisition

### DIFF
--- a/backend/src/modules/download-clients/download-clients.service.ts
+++ b/backend/src/modules/download-clients/download-clients.service.ts
@@ -22,7 +22,6 @@ import { UpdateDownloadClientDto } from './dto/update-download-client.dto';
 import { TestDownloadClientDto } from './dto/test-download-client.dto';
 import { TorrentHistoryMatcher } from '../media/torrent-history-matcher.service';
 import { BlocklistService } from '../blocklist/blocklist.service';
-import { SchedulerService } from '../scheduler/scheduler.service';
 import { EventsService } from '../scheduler/events.service';
 
 export interface QueueEntry extends QbittorrentTorrent {
@@ -129,8 +128,6 @@ export class DownloadClientsService {
     private readonly qbittorrent: QbittorrentService,
     private readonly historyMatcher: TorrentHistoryMatcher,
     private readonly blocklist: BlocklistService,
-    @Inject(forwardRef(() => SchedulerService))
-    private readonly scheduler: SchedulerService,
     private readonly events: EventsService,
   ) {}
 
@@ -240,7 +237,6 @@ export class DownloadClientsService {
     // Fire-and-forget: the scheduler decides whether anything is grabbed
     // (monitored + profiled + missing); the blocklist row excludes this release.
     if (entry?.mediaId) {
-      void this.scheduler.searchMissingForMedia([entry.mediaId]);
       this.events.emitDomain({
         type: 'media.acquisition.requested',
         mediaIds: [entry.mediaId],

--- a/backend/src/modules/media/auto-grab-pipeline.service.ts
+++ b/backend/src/modules/media/auto-grab-pipeline.service.ts
@@ -1,8 +1,8 @@
-import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Media } from './entities/media.entity';
-import { RequestLifecycleService } from '../requests/request-lifecycle.service';
+import { EventsService } from '../scheduler/events.service';
 import { DownloadHistory } from './entities/download-history.entity';
 import { buildGrabHistoryRow } from './grab-history.util';
 import { Indexer } from '../indexers/entities/indexer.entity';
@@ -73,8 +73,7 @@ export class AutoGrabPipelineService {
     private readonly qbittorrent: QbittorrentService,
     private readonly naming: NamingService,
     private readonly qualityDefs: QualityDefinitionsService,
-    @Inject(forwardRef(() => RequestLifecycleService))
-    private readonly requestLifecycle: RequestLifecycleService,
+    private readonly events: EventsService,
   ) {}
 
   /**
@@ -374,15 +373,11 @@ export class AutoGrabPipelineService {
       this.log.log(
         `AutoGrab[${args.mediaType}]: grabbed "${args.pick.title}" for "${args.label}"`,
       );
-      // Flip linked APPROVED requests to PROCESSING. Failures don't
-      // abort the grab — best effort.
-      void this.requestLifecycle
-        .onReleaseGrabbed(args.media.id, args.seasonNumber)
-        .catch((err) =>
-          this.log.warn(
-            `request-lifecycle: failed to flip requests to PROCESSING for media#${args.media.id}: ${(err as Error).message}`,
-          ),
-        );
+      this.events.emitDomain({
+        type: 'acquisition.grabbed',
+        mediaId: args.media.id,
+        seasonNumber: args.seasonNumber,
+      });
       return true;
     } catch (e) {
       this.log.warn(

--- a/backend/src/modules/media/episode-download.service.ts
+++ b/backend/src/modules/media/episode-download.service.ts
@@ -3,13 +3,11 @@ import {
   BadRequestException,
   NotFoundException,
   Logger,
-  Inject,
-  forwardRef,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Media } from './entities/media.entity';
-import { RequestLifecycleService } from '../requests/request-lifecycle.service';
+import { EventsService } from '../scheduler/events.service';
 import { Season } from './entities/season.entity';
 import { Episode } from './entities/episode.entity';
 import { DownloadHistory } from './entities/download-history.entity';
@@ -109,8 +107,7 @@ export class EpisodeDownloadService {
     private readonly notifications: NotificationsService,
     private readonly qualityDefs: QualityDefinitionsService,
     private readonly profiles: ProfilesService,
-    @Inject(forwardRef(() => RequestLifecycleService))
-    private readonly requestLifecycle: RequestLifecycleService,
+    private readonly events: EventsService,
   ) {}
 
   private allowedQualityIds(
@@ -380,13 +377,11 @@ export class EpisodeDownloadService {
       sourceTitle,
     });
 
-    void this.requestLifecycle
-      .onReleaseGrabbed(mediaId, season.seasonNumber)
-      .catch((err) =>
-        this.log.warn(
-          `request-lifecycle: failed to flip requests to PROCESSING for media#${mediaId}: ${(err as Error).message}`,
-        ),
-      );
+    this.events.emitDomain({
+      type: 'acquisition.grabbed',
+      mediaId,
+      seasonNumber: season.seasonNumber,
+    });
 
     return saved;
   }
@@ -669,13 +664,11 @@ export class EpisodeDownloadService {
         quality: parsed.quality.name,
         sourceTitle,
       });
-      void this.requestLifecycle
-        .onReleaseGrabbed(mediaId, season.seasonNumber)
-        .catch((err) =>
-          this.log.warn(
-            `request-lifecycle: failed to flip requests to PROCESSING for media#${mediaId}: ${(err as Error).message}`,
-          ),
-        );
+      this.events.emitDomain({
+        type: 'acquisition.grabbed',
+        mediaId,
+        seasonNumber: season.seasonNumber,
+      });
       return { grabbed: 1, errors: [] };
     }
 
@@ -773,13 +766,11 @@ export class EpisodeDownloadService {
         quality: bestPack.qualityName,
         sourceTitle: bestPack.title,
       });
-      void this.requestLifecycle
-        .onReleaseGrabbed(mediaId, season.seasonNumber)
-        .catch((err) =>
-          this.log.warn(
-            `request-lifecycle: failed to flip requests to PROCESSING for media#${mediaId}: ${(err as Error).message}`,
-          ),
-        );
+      this.events.emitDomain({
+        type: 'acquisition.grabbed',
+        mediaId,
+        seasonNumber: season.seasonNumber,
+      });
       return { grabbed: 1, errors: [] };
     }
 
@@ -901,13 +892,11 @@ export class EpisodeDownloadService {
     }
 
     if (grabbed > 0) {
-      void this.requestLifecycle
-        .onReleaseGrabbed(mediaId, season.seasonNumber)
-        .catch((err) =>
-          this.log.warn(
-            `request-lifecycle: failed to flip requests to PROCESSING for media#${mediaId}: ${(err as Error).message}`,
-          ),
-        );
+      this.events.emitDomain({
+        type: 'acquisition.grabbed',
+        mediaId,
+        seasonNumber: season.seasonNumber,
+      });
     }
 
     return { grabbed, errors };

--- a/backend/src/modules/media/media-service/media-metadata.service.ts
+++ b/backend/src/modules/media/media-service/media-metadata.service.ts
@@ -26,7 +26,6 @@ import {
 import { MetadataLanguageOverride } from '../../metadata-providers/metadata-settings-cache.service';
 import { MediaType } from '../../../common/enums';
 import { ImageService } from '../../images/image.service';
-import { SchedulerService } from '../../scheduler/scheduler.service';
 import { EventsService } from '../../scheduler/events.service';
 import { mapWithConcurrency } from '../../../common/utils/concurrency';
 import { buildMediaFieldsFromTmdb } from './tmdb-mapping.util';
@@ -52,8 +51,6 @@ export class MediaMetadataService {
     private readonly tmdb: TmdbProvider,
     private readonly providerRegistry: MetadataProviderRegistry,
     private readonly imageService: ImageService,
-    @Inject(forwardRef(() => SchedulerService))
-    private readonly scheduler: SchedulerService,
     private readonly events: EventsService,
   ) {}
 
@@ -116,7 +113,6 @@ export class MediaMetadataService {
       // drop): kick the auto-grab pipeline now instead of waiting up to 6 h
       // for the next scheduler tick. Mirrors the post-approval kick.
       if (insertedCount > 0) {
-        void this.scheduler.searchMissingForMedia([media.id]);
         this.events.emitDomain({
           type: 'media.acquisition.requested',
           mediaIds: [media.id],

--- a/backend/src/modules/media/movie-download.service.ts
+++ b/backend/src/modules/media/movie-download.service.ts
@@ -3,13 +3,11 @@ import {
   BadRequestException,
   NotFoundException,
   Logger,
-  Inject,
-  forwardRef,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Media } from './entities/media.entity';
-import { RequestLifecycleService } from '../requests/request-lifecycle.service';
+import { EventsService } from '../scheduler/events.service';
 import { DownloadHistory } from './entities/download-history.entity';
 import { buildGrabHistoryRow } from './grab-history.util';
 import { Indexer } from '../indexers/entities/indexer.entity';
@@ -101,8 +99,7 @@ export class MovieDownloadService {
     private readonly notifications: NotificationsService,
     private readonly qualityDefs: QualityDefinitionsService,
     private readonly profiles: ProfilesService,
-    @Inject(forwardRef(() => RequestLifecycleService))
-    private readonly requestLifecycle: RequestLifecycleService,
+    private readonly events: EventsService,
   ) {}
 
   private allowedQualityIds(
@@ -351,15 +348,7 @@ export class MovieDownloadService {
       sourceTitle,
     });
 
-    // Flip any APPROVED request for this movie to PROCESSING (the auto-grab
-    // pipeline does this for its grabs; manual grabs route through here).
-    void this.requestLifecycle
-      .onReleaseGrabbed(mediaId)
-      .catch((err) =>
-        this.log.warn(
-          `request-lifecycle: failed to flip requests to PROCESSING for media#${mediaId}: ${(err as Error).message}`,
-        ),
-      );
+    this.events.emitDomain({ type: 'acquisition.grabbed', mediaId });
 
     return saved;
   }

--- a/backend/src/modules/requests/request-lifecycle.service.spec.ts
+++ b/backend/src/modules/requests/request-lifecycle.service.spec.ts
@@ -18,7 +18,6 @@ describe('RequestLifecycleService onMediaRemoved (kind-aware)', () => {
       { subscribe: jest.fn() } as never,
       {} as never,
       {} as never,
-      {} as never,
     );
   });
 

--- a/backend/src/modules/requests/request-lifecycle.service.ts
+++ b/backend/src/modules/requests/request-lifecycle.service.ts
@@ -16,7 +16,6 @@ import { MediaService } from '../media/media.service';
 import { onDiskEpisodeNumbers } from '../media/episode-coverage.util';
 import { ProfilesService } from '../profiles/profiles.service';
 import { EventsService } from '../scheduler/events.service';
-import { SchedulerService } from '../scheduler/scheduler.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { SettingsService } from '../settings/settings.service';
 import { User } from '../users/entities/user.entity';
@@ -37,9 +36,10 @@ import {
  *  - `onMediaImported`     — admin clicked Add or an approval imported
  *                            the row. Link & auto-approve compatible
  *                            open requests.
- *  - `onReleaseGrabbed`    — auto-grab pipeline pushed a release to
- *                            the download client. Flip APPROVED →
- *                            PROCESSING.
+ *  - `markInProgress`      — driven by the `acquisition.grabbed` domain
+ *                            event (auto-grab / manual grab pushed a
+ *                            release to the download client). Flip
+ *                            APPROVED → PROCESSING.
  *  - `onImportComplete`    — files landed on disk (via `EventsService`
  *                            subscription). Promote PROCESSING /
  *                            APPROVED → AVAILABLE for covered scopes.
@@ -64,8 +64,6 @@ export class RequestLifecycleService
     private readonly mediaService: MediaService,
     private readonly profiles: ProfilesService,
     private readonly events: EventsService,
-    @Inject(forwardRef(() => SchedulerService))
-    private readonly scheduler: SchedulerService,
     private readonly notifications: NotificationsService,
     private readonly settings: SettingsService,
   ) {}
@@ -95,6 +93,19 @@ export class RequestLifecycleService
         this.onImportComplete(event.mediaId).catch((err) => {
           this.log.warn(
             `onImportComplete failed for media#${event.mediaId}: ${(err as Error).message}`,
+          );
+        });
+      }),
+    );
+
+    // Auto-grab pipeline / manual grab pushed a release to the download
+    // client — flip matching APPROVED requests to PROCESSING.
+    this.subscriptions.add(
+      this.events.onDomain((event) => {
+        if (event.type !== 'acquisition.grabbed') return;
+        this.markInProgress(event.mediaId, event.seasonNumber).catch((err) => {
+          this.log.warn(
+            `markInProgress failed for media#${event.mediaId}: ${(err as Error).message}`,
           );
         });
       }),
@@ -168,7 +179,6 @@ export class RequestLifecycleService
     // wait up to 6 h for the next scheduled tick. Fire-and-forget;
     // failures (missing indexer, etc.) are logged inside the scheduler.
     if (touched.length && (await this.autoGrabOnApproval())) {
-      void this.scheduler.searchMissingForMedia([media.id]);
       this.events.emitDomain({
         type: 'media.acquisition.requested',
         mediaIds: [media.id],
@@ -182,12 +192,12 @@ export class RequestLifecycleService
   // ---------------------------------------------------------------------------
 
   /**
-   * Auto-grab pipeline sent a release to the download client. Flip
-   * matching `APPROVED` requests to `PROCESSING`. Per-season requests
-   * honour the season scope: only flip when the grabbed season is in
-   * the `seasons` array. Movies / whole-series flip on any grab.
+   * Driven by the `acquisition.grabbed` domain event. Flip matching
+   * `APPROVED` requests to `PROCESSING`. Per-season requests honour the
+   * season scope: only flip when the grabbed season is in the `seasons`
+   * array. Movies / whole-series flip on any grab.
    */
-  async onReleaseGrabbed(
+  async markInProgress(
     mediaId: number,
     seasonNumber?: number,
   ): Promise<void> {

--- a/backend/src/modules/requests/requests.module.ts
+++ b/backend/src/modules/requests/requests.module.ts
@@ -9,7 +9,6 @@ import { SettingsModule } from '../settings/settings.module';
 import { MediaModule } from '../media/media.module';
 import { LibrariesModule } from '../libraries/libraries.module';
 import { ProfilesModule } from '../profiles/profiles.module';
-import { FliksSchedulerModule } from '../scheduler/scheduler.module';
 import { ImageModule } from '../images/image.module';
 import { MetadataProvidersModule } from '../metadata-providers/metadata-providers.module';
 import { RequestsService } from './requests.service';
@@ -29,10 +28,6 @@ import { AutoApprovalRulesController } from './auto-approval-rules.controller';
     forwardRef(() => MediaModule),
     LibrariesModule,
     ProfilesModule,
-    // forwardRef because FliksSchedulerModule itself imports MediaModule,
-    // which already imports RequestsModule via forwardRef — defensive to
-    // avoid the cycle resolver throwing on a clean cold boot.
-    forwardRef(() => FliksSchedulerModule),
     // Local request-card art stored at creation (ImageService) from the
     // provider's TMDB URLs (TmdbProvider).
     ImageModule,

--- a/backend/src/modules/requests/requests.service.ts
+++ b/backend/src/modules/requests/requests.service.ts
@@ -28,7 +28,7 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { MediaService } from '../media/media.service';
 import { Media } from '../media/entities/media.entity';
 import { ProfilesService } from '../profiles/profiles.service';
-import { SchedulerService } from '../scheduler/scheduler.service';
+import { SettingsService } from '../settings/settings.service';
 import { EventsService } from '../scheduler/events.service';
 import { CaslAbilityFactory } from '../auth/casl/casl-ability.factory';
 import { Action } from '../auth/casl/actions.enum';
@@ -64,7 +64,7 @@ export class RequestsService {
     private readonly notifications: NotificationsService,
     private readonly mediaService: MediaService,
     private readonly profilesService: ProfilesService,
-    private readonly scheduler: SchedulerService,
+    private readonly settings: SettingsService,
     private readonly caslAbilityFactory: CaslAbilityFactory,
     private readonly imageService: ImageService,
     private readonly tmdb: TmdbProvider,
@@ -73,6 +73,11 @@ export class RequestsService {
   ) {}
 
   private readonly logger = new Logger(RequestsService.name);
+
+  /** Admin-toggleable from the General settings page; an unset key reads as enabled. */
+  private async autoGrabOnApproval(): Promise<boolean> {
+    return (await this.settings.get('requests_auto_grab_on_approval')) !== 'false';
+  }
 
   /** Aligné sur PoliciesGuard / CaslAbilityFactory (manage:all → Manage sur tout). */
   private canManageRequests(user: User): boolean {
@@ -806,12 +811,13 @@ export class RequestsService {
         linked.media = media;
         await this.requestRepo.save(linked);
       }
-      void this.scheduler.searchMissingForMedia([media.id]);
-      this.events.emitDomain({
-        type: 'media.acquisition.requested',
-        mediaIds: [media.id],
-        reason: 'request-approved',
-      });
+      if (await this.autoGrabOnApproval()) {
+        this.events.emitDomain({
+          type: 'media.acquisition.requested',
+          mediaIds: [media.id],
+          reason: 'request-approved',
+        });
+      }
     }
 
     this.events.emitDomain({

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -47,7 +47,6 @@ import { TorrentAutoMatcher } from '../media/torrent-auto-matcher.service';
 import { buildGrabHistoryRow } from '../media/grab-history.util';
 import { parseReleaseQuality } from '../../common/release-parsing';
 import { MarkersService } from '../markers/markers.service';
-import { SchedulerService } from './scheduler.service';
 import { LibraryIngestService } from '../../common/library-ingest/library-ingest.service';
 import { VIDEO_EXTS } from '../../common/constants/video-extensions';
 
@@ -112,8 +111,6 @@ export class CompletionService implements OnModuleInit {
     private readonly autoMatcher: TorrentAutoMatcher,
     private readonly markers: MarkersService,
     private readonly sseAudience: SseAudienceService,
-    @Inject(forwardRef(() => SchedulerService))
-    private readonly scheduler: SchedulerService,
     @Inject(forwardRef(() => LibraryIngestService))
     private readonly libraryIngest: LibraryIngestService,
   ) {}
@@ -1110,8 +1107,6 @@ export class CompletionService implements OnModuleInit {
       this.log.log(
         `StalledCleanup: running SearchMissing for ${mediaToResearch.size} media(s)`,
       );
-      // Fire-and-forget: a slow indexer search shouldn't hold up this cron tick.
-      void this.scheduler.searchMissingForMedia(Array.from(mediaToResearch));
       this.events.emitDomain({
         type: 'media.acquisition.requested',
         mediaIds: Array.from(mediaToResearch),

--- a/backend/src/modules/scheduler/events.service.ts
+++ b/backend/src/modules/scheduler/events.service.ts
@@ -204,6 +204,8 @@ export type DomainEvent =
   | { type: 'media.removed'; mediaId: number; tmdbId: number | null; mediaType: string }
   | { type: 'media.files.imported'; mediaId: number; seasonNumber?: number; episodeNumber?: number; source: 'download' | 'disk' }
   | { type: 'media.acquisition.requested'; mediaIds: number[]; reason: string }
+  // Release sent to the download client — flips matching approved requests to PROCESSING.
+  | { type: 'acquisition.grabbed'; mediaId: number; seasonNumber?: number }
   | { type: 'request.created'; requestId: number; mediaType: string; tmdbId: number; userId: number | null; kind: string; seasons: number[] | null }
   | { type: 'request.approved'; requestId: number; mediaId: number | null; mediaType: string; tmdbId: number; seasons: number[] | null; approvedByUserId: number | null }
   | { type: 'library.scan.completed'; libraryId: number; added: number; updated: number }

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -154,6 +154,13 @@ export class SchedulerService implements OnModuleInit {
         `Marked ${stale.affected} stale command(s) as failed on startup`,
       );
     }
+
+    // Single subscriber for every acquisition-side trigger — see the five
+    // `media.acquisition.requested` emitters across media/download-clients/requests.
+    this.eventsService.onDomain((event) => {
+      if (event.type !== 'media.acquisition.requested') return;
+      void this.searchMissingForMedia(event.mediaIds);
+    });
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
PR 2.2 of the plugin-system plan — the first PR with domain-event *subscribers*.

**Outbound (requests → acquisition).** Two direct `searchMissingForMedia` calls lived in the requests module. Both are gone; the scheduler subscribes to `media.acquisition.requested` instead. All five emitters of that event dropped their direct call in the same move, so every path reaches the search exactly once.

**The user-visible fix rides here.** The admin approval path called the scheduler with no gate, while the import path checked `requests_auto_grab_on_approval` first. Approving a request therefore started a grab even with the setting off. The gate now sits on both emitters.

**Inbound (acquisition → requests).** The six sites that flipped approved requests to `PROCESSING` now emit `acquisition.grabbed`; `RequestLifecycleService` subscribes and keeps the work (`onReleaseGrabbed` → `markInProgress`, the plan's name). All six were already `void`ed, so the semantics are unchanged — only the direction is.

**Cycles removed:** `forwardRef(() => FliksSchedulerModule)` from `requests.module.ts` plus three now-dead `forwardRef(() => SchedulerService)` injections in media-metadata, download-clients and completion that the inversion orphaned.

**Left alone on purpose:** `media-mutation.service.ts` still calls `RequestLifecycleService` for the monitor/remove hooks. Those are *awaited*, and converting them to fire-and-forget events would change ordering the API response depends on.

Verified: `tsc` 0, suite 82/773/29 green with no `it(` count change, backend boots with no resolution errors.

Not covered by a test: the approve-path gate. The existing spec only exercises delete-kind approvals and the add-kind path needs a large harness — filed as a follow-up issue rather than smuggled in here.