### PR TITLE
refactor(scheduler): route acquisition fan-out through one publisher

### DIFF
--- a/backend/src/migrations/1782700000000-drop-blocklist-indexer-fk.ts
+++ b/backend/src/migrations/1782700000000-drop-blocklist-indexer-fk.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+// `indexers` becomes a plugin-owned table; core may no longer hold a
+// cross-schema FK into it. The column and its data stay — indexerName is
+// what the UI renders.
+export class DropBlocklistIndexerFk1782700000000
+  implements MigrationInterface
+{
+  name = 'DropBlocklistIndexerFk1782700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "blocklist" DROP CONSTRAINT IF EXISTS "FK_c0ad3d19ab0e2d7edb3b6468a7b"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "blocklist" SET "indexerId" = NULL WHERE "indexerId" IS NOT NULL AND "indexerId" NOT IN (SELECT "id" FROM "indexers")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "blocklist" ADD CONSTRAINT "FK_c0ad3d19ab0e2d7edb3b6468a7b" FOREIGN KEY ("indexerId") REFERENCES "indexers"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/backend/src/modules/blocklist/blocklist.service.ts
+++ b/backend/src/modules/blocklist/blocklist.service.ts
@@ -27,7 +27,7 @@ export class BlocklistService {
     const row = this.repo.create({
       ...rest,
       indexerName,
-      indexer: indexerId ? ({ id: indexerId } as Indexer) : null,
+      indexerId: indexerId ?? null,
       media: mediaId ? ({ id: mediaId } as Media) : null,
       user: userId ? ({ id: userId } as User) : null,
     });

--- a/backend/src/modules/blocklist/entities/blocklist-entry.entity.ts
+++ b/backend/src/modules/blocklist/entities/blocklist-entry.entity.ts
@@ -7,7 +7,6 @@ import {
   Index,
 } from 'typeorm';
 import { BaseEntity } from '../../../common/entities/base.entity';
-import { Indexer } from '../../indexers/entities/indexer.entity';
 import { Media } from '../../media/entities/media.entity';
 import { User } from '../../users/entities/user.entity';
 
@@ -17,12 +16,10 @@ export class BlocklistEntry extends BaseEntity {
   @Column()
   sourceTitle: string;
 
-  @ManyToOne(() => Indexer, { nullable: true, onDelete: 'SET NULL' })
-  @JoinColumn({ name: 'indexerId' })
-  indexer: Indexer | null;
-
-  @RelationId((b: BlocklistEntry) => b.indexer)
-  indexerId: number;
+  /** Not a relation: `indexers` becomes a plugin-owned table, and core may not
+   *  hold a foreign key into it. `indexerName` is what the UI renders. */
+  @Column({ type: 'int', nullable: true })
+  indexerId: number | null;
 
   @Column({ nullable: true })
   indexerName: string;

--- a/backend/src/modules/scheduler/acquisition-events.service.ts
+++ b/backend/src/modules/scheduler/acquisition-events.service.ts
@@ -1,0 +1,79 @@
+import { Injectable } from '@nestjs/common';
+import { EventsService } from './events.service';
+import { SseAudienceService } from './sse-audience.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { MediaServersService } from '../media-servers/media-servers.service';
+
+export type AcquisitionEvent =
+  | {
+      type: 'acquisition.imported';
+      mediaId: number;
+      title: string;
+      seasonNumber?: number;
+      episodeNumber?: number;
+      quality: string;
+      sourceTitle: string;
+      mediaPath: string | null;
+    }
+  | { type: 'acquisition.failed'; mediaId: number; title: string; reason: string }
+  | { type: 'acquisition.queue.changed' };
+
+/**
+ * Fan-out for acquisition-side events: resolves the SSE audience, emits the
+ * client event, and dispatches to notifications / external media servers.
+ * The single seam a download plugin will publish through — it cannot resolve
+ * an audience or reach a media server itself.
+ */
+@Injectable()
+export class AcquisitionEventsService {
+  constructor(
+    private readonly events: EventsService,
+    private readonly sseAudience: SseAudienceService,
+    private readonly notifications: NotificationsService,
+    private readonly mediaServers: MediaServersService,
+  ) {}
+
+  async publish(event: AcquisitionEvent): Promise<void> {
+    switch (event.type) {
+      case 'acquisition.imported': {
+        void this.notifications.dispatch('download.complete', {
+          title: event.title,
+          quality: event.quality,
+          sourceTitle: event.sourceTitle,
+        });
+        const recipients = await this.sseAudience.recipientsForMedia(
+          event.mediaId,
+        );
+        this.events.emitToUsers(recipients, {
+          type: 'import.complete',
+          mediaId: event.mediaId,
+          title: event.title,
+          seasonNumber: event.seasonNumber,
+          episodeNumber: event.episodeNumber,
+        });
+        this.events.emit({ type: 'queue.updated' });
+        void this.mediaServers.dispatch('download.complete', {
+          title: event.title,
+          path: event.mediaPath,
+        });
+        return;
+      }
+      case 'acquisition.failed': {
+        const recipients = await this.sseAudience.recipientsForMedia(
+          event.mediaId,
+        );
+        this.events.emitToUsers(recipients, {
+          type: 'import.failed',
+          mediaId: event.mediaId,
+          title: event.title,
+          error: event.reason,
+        });
+        this.events.emit({ type: 'queue.updated' });
+        return;
+      }
+      case 'acquisition.queue.changed':
+        this.events.emit({ type: 'queue.updated' });
+        return;
+    }
+  }
+}

--- a/backend/src/modules/scheduler/completion.service.spec.ts
+++ b/backend/src/modules/scheduler/completion.service.spec.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { DataSource } from 'typeorm';
 import { CompletionService } from './completion.service';
+import { AcquisitionEventsService } from './acquisition-events.service';
 import { NamingService } from './naming.service';
 import { DownloadHistory } from '../media/entities/download-history.entity';
 import { Media } from '../media/entities/media.entity';
@@ -42,11 +43,19 @@ function buildService(matchByHash: Set<string>) {
     historyMatcher: unknown;
     log: unknown;
     events: unknown;
+    acquisitionEvents: unknown;
   };
   wired.historyRepo = { update };
   wired.historyMatcher = matcher;
   wired.log = { warn: jest.fn(), log: jest.fn() };
   wired.events = { emit };
+  // `acquisitionEvents.publish` routes 'acquisition.queue.changed' straight
+  // through `events.emit` — wire it onto the same mock the tests assert on.
+  const acquisitionEvents = Object.create(
+    AcquisitionEventsService.prototype,
+  ) as AcquisitionEventsService;
+  (acquisitionEvents as unknown as { events: unknown }).events = { emit };
+  wired.acquisitionEvents = acquisitionEvents;
   return { service, update, emit };
 }
 
@@ -302,7 +311,13 @@ describe('CompletionService.cleanSeededTorrents', () => {
     wired.historyRepo = { createQueryBuilder: () => qb };
     wired.indexerRepo = { find: async () => [{ id: 5, settings }] };
     wired.log = { log: jest.fn(), error: jest.fn() };
-    wired.events = { emit: jest.fn() };
+    const emit = jest.fn();
+    wired.events = { emit };
+    const acquisitionEvents = Object.create(
+      AcquisitionEventsService.prototype,
+    ) as AcquisitionEventsService;
+    (acquisitionEvents as unknown as { events: unknown }).events = { emit };
+    wired.acquisitionEvents = acquisitionEvents;
     return { deleteTorrent, done: service.cleanSeededTorrents() };
   }
 
@@ -456,6 +471,21 @@ describe('CompletionService.processOne', () => {
       query: jest.fn().mockResolvedValue([]),
     } as unknown as DataSource);
 
+    // `AcquisitionEventsService` now owns the sseAudience/events/notifications/
+    // mediaServers fan-out `processOne` used to do inline — wire a bare
+    // instance over the same mocks, same approach as `libraryIngest` below.
+    const acquisitionEvents = Object.create(
+      AcquisitionEventsService.prototype,
+    ) as AcquisitionEventsService;
+    const acquisitionEventsWired = acquisitionEvents as unknown as Record<
+      string,
+      unknown
+    >;
+    acquisitionEventsWired.events = events;
+    acquisitionEventsWired.sseAudience = sseAudience;
+    acquisitionEventsWired.notifications = notifications;
+    acquisitionEventsWired.mediaServers = mediaServers;
+
     const wired = service as unknown as Record<string, unknown>;
     wired.mediaRepo = mediaRepo;
     wired.historyRepo = historyRepo;
@@ -466,8 +496,7 @@ describe('CompletionService.processOne', () => {
     wired.settings = settings;
     wired.sseAudience = sseAudience;
     wired.events = events;
-    wired.notifications = notifications;
-    wired.mediaServers = mediaServers;
+    wired.acquisitionEvents = acquisitionEvents;
     wired.markers = markers;
     wired.thumbnailService = thumbnailService;
     wired.dataSource = dataSource;

--- a/backend/src/modules/scheduler/completion.service.ts
+++ b/backend/src/modules/scheduler/completion.service.ts
@@ -19,13 +19,12 @@ import {
   QbittorrentTorrent,
 } from '../download-clients/qbittorrent.service';
 import { Indexer } from '../indexers/entities/indexer.entity';
-import { NotificationsService } from '../notifications/notifications.service';
 import { NamingService } from './naming.service';
 import { BlocklistService } from '../blocklist/blocklist.service';
 import { EventsService } from './events.service';
 import { SseAudienceService } from './sse-audience.service';
+import { AcquisitionEventsService } from './acquisition-events.service';
 import { SettingsService } from '../settings/settings.service';
-import { MediaServersService } from '../media-servers/media-servers.service';
 import {
   ThumbnailService,
   buildSpriteLabel,
@@ -100,17 +99,16 @@ export class CompletionService implements OnModuleInit {
     @InjectRepository(Library)
     private readonly libraryRepo: Repository<Library>,
     private readonly qbittorrent: QbittorrentService,
-    private readonly notifications: NotificationsService,
     private readonly naming: NamingService,
     private readonly blocklist: BlocklistService,
     private readonly settings: SettingsService,
-    private readonly mediaServers: MediaServersService,
     private readonly events: EventsService,
     private readonly thumbnailService: ThumbnailService,
     private readonly historyMatcher: TorrentHistoryMatcher,
     private readonly autoMatcher: TorrentAutoMatcher,
     private readonly markers: MarkersService,
     private readonly sseAudience: SseAudienceService,
+    private readonly acquisitionEvents: AcquisitionEventsService,
     @Inject(forwardRef(() => LibraryIngestService))
     private readonly libraryIngest: LibraryIngestService,
   ) {}
@@ -416,16 +414,12 @@ export class CompletionService implements OnModuleInit {
           statusMessage: (e as Error).message,
         });
 
-        const failRecipients = await this.sseAudience.recipientsForMedia(
-          history.mediaId,
-        );
-        this.events.emitToUsers(failRecipients, {
-          type: 'import.failed',
+        await this.acquisitionEvents.publish({
+          type: 'acquisition.failed',
           mediaId: history.mediaId,
           title: history.sourceTitle,
-          error: (e as Error).message,
+          reason: (e as Error).message,
         });
-        this.events.emit({ type: 'queue.updated' });
 
         // Auto-blocklist the failed release so it won't be grabbed again
         try {
@@ -585,7 +579,7 @@ export class CompletionService implements OnModuleInit {
       );
     }
 
-    if (changed) this.events.emit({ type: 'queue.updated' });
+    if (changed) await this.acquisitionEvents.publish({ type: 'acquisition.queue.changed' });
   }
 
   private async processOne(
@@ -655,16 +649,12 @@ export class CompletionService implements OnModuleInit {
         }
       }
 
-      const failRecipients = await this.sseAudience.recipientsForMedia(
-        history.mediaId,
-      );
-      this.events.emitToUsers(failRecipients, {
-        type: 'import.failed',
+      await this.acquisitionEvents.publish({
+        type: 'acquisition.failed',
         mediaId: history.mediaId,
         title: history.sourceTitle,
-        error: statusMessage,
+        reason: statusMessage,
       });
-      this.events.emit({ type: 'queue.updated' });
       return;
     }
 
@@ -683,7 +673,7 @@ export class CompletionService implements OnModuleInit {
         status: 'failed',
         statusMessage,
       });
-      this.events.emit({ type: 'queue.updated' });
+      await this.acquisitionEvents.publish({ type: 'acquisition.queue.changed' });
       return;
     }
     this.log.log(
@@ -703,7 +693,7 @@ export class CompletionService implements OnModuleInit {
           status: 'failed',
           statusMessage,
         });
-        this.events.emit({ type: 'queue.updated' });
+        await this.acquisitionEvents.publish({ type: 'acquisition.queue.changed' });
         return;
       }
       resolvedLib = fallback;
@@ -771,7 +761,7 @@ export class CompletionService implements OnModuleInit {
         status: 'failed',
         statusMessage,
       });
-      this.events.emit({ type: 'queue.updated' });
+      await this.acquisitionEvents.publish({ type: 'acquisition.queue.changed' });
       return;
     }
 
@@ -815,14 +805,6 @@ export class CompletionService implements OnModuleInit {
       `Import[${history.sourceTitle}]: completed successfully (${importedFiles.length} file(s))`,
     );
 
-    void this.notifications.dispatch('download.complete', {
-      title: media.title,
-      quality: history.quality,
-      sourceTitle: history.sourceTitle,
-    });
-    const importRecipients = await this.sseAudience.recipientsForMedia(
-      media.id,
-    );
     // Single-season series imports carry the season so the client retires only
     // that season's live progress (other in-flight seasons keep advancing).
     let importedSeasonNumber: number | undefined;
@@ -846,18 +828,15 @@ export class CompletionService implements OnModuleInit {
       });
       importedEpisodeNumber = e?.episodeNumber;
     }
-    this.events.emitToUsers(importRecipients, {
-      type: 'import.complete',
+    await this.acquisitionEvents.publish({
+      type: 'acquisition.imported',
       mediaId: media.id,
       title: media.title,
       seasonNumber: importedSeasonNumber,
       episodeNumber: importedEpisodeNumber,
-    });
-    this.events.emit({ type: 'queue.updated' });
-
-    void this.mediaServers.dispatch('download.complete', {
-      title: media.title,
-      path: media.path,
+      quality: history.quality,
+      sourceTitle: history.sourceTitle,
+      mediaPath: media.path,
     });
 
     // Series only: kick off intro / outro marker detection for every
@@ -1262,7 +1241,7 @@ export class CompletionService implements OnModuleInit {
     }
 
     if (deleted > 0) {
-      this.events.emit({ type: 'queue.updated' });
+      await this.acquisitionEvents.publish({ type: 'acquisition.queue.changed' });
     }
   }
 }

--- a/backend/src/modules/scheduler/scheduler.module.ts
+++ b/backend/src/modules/scheduler/scheduler.module.ts
@@ -13,6 +13,7 @@ import { DownloadClient } from '../download-clients/entities/download-client.ent
 import { QualityProfile } from '../profiles/entities/quality-profile.entity';
 import { SchedulerService } from './scheduler.service';
 import { CompletionService } from './completion.service';
+import { AcquisitionEventsService } from './acquisition-events.service';
 import { NamingService } from './naming.service';
 import { BackupService } from './backup.service';
 import { LogBufferService } from './log-buffer.service';
@@ -84,6 +85,7 @@ import { LibraryIngestModule } from '../../common/library-ingest/library-ingest.
   providers: [
     SchedulerService,
     CompletionService,
+    AcquisitionEventsService,
     NamingService,
     BackupService,
     LogBufferService,
@@ -93,6 +95,7 @@ import { LibraryIngestModule } from '../../common/library-ingest/library-ingest.
   exports: [
     SchedulerService,
     CompletionService,
+    AcquisitionEventsService,
     NamingService,
     LogBufferService,
     SubtitleSchedulerService,


### PR DESCRIPTION
PR 2.3, closing phase 2.

**The publisher.** `completion.service.ts` repeated the same four-step fan-out at a dozen sites. `AcquisitionEventsService.publish` now owns it, with three event shapes — `acquisition.imported`, `acquisition.failed`, `acquisition.queue.changed`. Only the variants the converted sites actually use; the plan's `grabbed` and `progress` arrive when the grab services and the progress push route through it.

Every emitted SSE payload is field-for-field identical to what it replaced — the frontend consumes those shapes. `NotificationsService` and `MediaServersService` left `CompletionService` entirely with the move.

**Left alone on purpose:** `emitDownloadProgress`. It resolves recipients through a per-tick cache; routing it per event would issue one query per torrent per minute instead of one per media. Also the stalled-cleanup fan-out, which emits `stalled.removed` rather than `import.failed` and is not an acquisition event.

**The migration** drops `FK_c0ad3d19ab0e2d7edb3b6468a7b` (`blocklist.indexerId` → `indexers.id`), keeping the column and every row. `indexers` becomes plugin-owned in phase 10, and a cross-schema foreign key is silently stripped by a schema drop while leaving the column populated — better to not have it than to have one that lies. The entity's `@ManyToOne` becomes a plain column so no future `migration:generate` tries to put it back.

**Verified**, beyond `tsc` 0 and the suite at 82/773/29 with no `it(` count change:
- migration run **up → down → up** against a throwaway Postgres seeded with both a valid row and one whose indexer no longer exists; `down()` nulls the orphan before re-adding the constraint, and the valid row keeps its id;
- a real torrent import through the local stack against a stand-in qBittorrent: history `completed`, file landed, and — after subscribing the configured media server to `download.complete`, since an unsubscribed target would have made the leg's silence meaningless — `[EmbyProvider] Emby library refresh triggered`, proving the dispatch leg still fires through the new publisher.