### PR TITLE
feat(plugins): add the plugin contract as types only

### DIFF
--- a/backend/src/common/constants/plugin-flags.ts
+++ b/backend/src/common/constants/plugin-flags.ts
@@ -1,0 +1,11 @@
+/**
+ * Crash-loop rescue lever (Decision 23 of the plugin-system plan): set
+ * before any plugin file I/O runs, so a bad plugin can be locked out
+ * without a live HTTP server to click a restart button through.
+ */
+export const FLIKS_PLUGINS_DISABLED_ENV = 'FLIKS_PLUGINS_DISABLED';
+
+/** True when `FLIKS_PLUGINS_DISABLED=1` is set in the server environment. */
+export function arePluginsDisabled(): boolean {
+  return process.env[FLIKS_PLUGINS_DISABLED_ENV] === '1';
+}

--- a/backend/src/common/plugin-contract/host-methods.ts
+++ b/backend/src/common/plugin-contract/host-methods.ts
@@ -1,0 +1,246 @@
+/**
+ * The 17 methods a `process` plugin calls on core, grouped A-E as the
+ * plan groups them. Every payload/return shape is restated structurally
+ * here rather than imported, even where it mirrors an entity — this
+ * directory has no dependency on `backend/src` outside itself.
+ */
+
+export type MediaKind = 'movie' | 'series';
+
+/**
+ * Everything a plugin needs to decide whether, and how, to acquire one
+ * piece of media. `want: null` means unprofiled — the plugin must not act.
+ */
+export interface AcquisitionTarget {
+  mediaId: number;
+  kind: MediaKind;
+  title: string;
+  originalTitle: string | null;
+  alternativeTitles: string[];
+  year: number | null;
+  runtimeMinutes: number | null;
+  imdbId: string | null;
+  tmdbId: number | null;
+  tvdbId: number | null;
+  libraryId: number;
+  want: {
+    decision: 'missing' | 'upgrade';
+    allowedQualityIds: number[];
+    allowedLanguageIds: number[];
+    minRankExclusive: number;
+    maxRankInclusive: number;
+    minResolution: number;
+    resolutionUpgradeOnly: boolean;
+  } | null;
+  expectedTitles: string[];
+  searchTitle: string;
+  season?: { id: number; number: number; episodeCount: number };
+  episode?: { id: number; number: number; endNumber: number | null; airDate: string | null };
+}
+
+/** The verdict on one candidate release, already sorted by relevance. */
+export interface ScoredRelease {
+  id: string;
+  qualityId: number;
+  rank: number;
+  allowed: boolean;
+  customFormatScore: number;
+  blocklisted: boolean;
+  languageId: number | null;
+  languageAllowed: boolean;
+  isFullSeason: boolean;
+  sizeDeviation: number;
+  videoCodec: string | null;
+  rejections: { code: string; detail?: string }[];
+}
+
+/** Domain facts a plugin publishes; core decides the SSE audience for each. */
+export type AcquisitionEvent =
+  | {
+      type: 'acquisition.grabbed';
+      mediaId: number;
+      seasonNumber?: number;
+      episodeNumber?: number;
+      sourceTitle: string;
+      quality: string;
+    }
+  | {
+      type: 'acquisition.progress';
+      mediaId: number;
+      ref: string;
+      progress: number;
+      etaSeconds: number | null;
+      state: string;
+    }
+  | { type: 'acquisition.imported'; mediaId: number; seasonNumber?: number; episodeNumber?: number }
+  | { type: 'acquisition.failed'; mediaId: number; reason: string }
+  | { type: 'acquisition.queue.changed' };
+
+/**
+ * The full core-side surface, keyed by dotted method name. A `process`
+ * plugin's socket client implements calls against this shape; core's
+ * `FliksHostImpl` is declared to satisfy it.
+ */
+export interface PluginHostApi {
+  // Group A — read (6)
+
+  /** Replaces 8 mediaRepo.findOne + 6 profiles.resolveAllowedForMedia* + 4 getSizeLimitsMap calls. */
+  'media.acquisitionContext': (p: {
+    mediaId: number;
+    seasonId?: number;
+    episodeId?: number;
+  }) => Promise<AcquisitionTarget | null>;
+
+  /** Replaces the scheduler's four candidate-enumeration call sites. Cursor-paged, limit <= 500. */
+  'acquisition.candidates': (p: {
+    kind?: MediaKind;
+    mediaIds?: number[];
+    availableOn: string;
+    limit: number;
+    cursor?: string;
+  }) => Promise<{ items: AcquisitionTarget[]; cursor: string | null }>;
+
+  /** Replaces the RSS full-library load — the endpoint that makes RssSync viable. */
+  'releases.match': (p: {
+    titles: { id: string; title: string; publishDate: string }[];
+    minAgeMinutes?: number;
+  }) => Promise<
+    {
+      id: string;
+      mediaId: number | null;
+      seasonNumber?: number;
+      episodeNumber?: number;
+      isFullSeason: boolean;
+      decision: 'grab' | 'skip';
+      skipReason?: 'on-disk' | 'not-monitored' | 'unmatched' | 'too-fresh' | 'not-available' | 'unprofiled';
+    }[]
+  >;
+
+  /** The hot path: rejection rules, custom formats, blocklist and quality/profile scoring, all in one call. */
+  'releases.score': (p: {
+    mediaId: number;
+    seasonNumber?: number;
+    episodeNumber?: number;
+    releases: {
+      id: string;
+      title: string;
+      size: number;
+      seeders: number;
+      leechers: number;
+      publishDate: string;
+      freeleech?: boolean;
+      downloadVolumeFactor?: number;
+      sourceRef: string;
+      minSeeders?: number;
+      unknownLanguageIsoCode?: string;
+    }[];
+  }) => Promise<ScoredRelease[]>;
+
+  /** Queue page labels. Bounded: <= 100 ids (QUEUE_PAGE_SIZE_MAX). */
+  'media.resolve': (p: {
+    mediaIds?: number[];
+    seasonIds?: number[];
+    episodeIds?: number[];
+  }) => Promise<
+    Record<
+      string,
+      {
+        title: string;
+        kind: MediaKind;
+        libraryId: number;
+        seasonNumber?: number;
+        episodeNumber?: number;
+        episodeTitle?: string;
+        stalledCleanupProfile: { key: string; samples: number; intervalMinutes: number; autoRestart: boolean } | null;
+      }
+    >
+  >;
+
+  /** Orphan reconcile. The FK makes this a belt, not the braces. */
+  'media.exists': (p: { mediaIds: number[] }) => Promise<number[]>;
+
+  // Group B — write acquisition state (3)
+
+  'blocklist.add': (p: {
+    idempotencyKey: string;
+    sourceTitle: string;
+    quality?: string;
+    mediaId?: number;
+    indexerName?: string;
+    downloadUrl?: string;
+    note: string;
+  }) => Promise<{ id: number }>;
+
+  'blocklist.check': (p: { titles: string[] }) => Promise<{ blocked: string[] }>;
+
+  'requests.markInProgress': (p: {
+    idempotencyKey: string;
+    mediaId: number;
+    seasonNumber?: number;
+  }) => Promise<void>;
+
+  // Group C — ingest (1)
+
+  /**
+   * The one method that writes to disk. Core, not the plugin, resolves the
+   * destination and enforces the ingest-root allowlist and idempotency.
+   */
+  'library.ingest': (p: {
+    idempotencyKey: string;
+    mediaId: number;
+    paths: string[];
+    transfer: 'copy' | 'move';
+    fallbackQuality?: string;
+    sourceLabel: string;
+  }) => Promise<{
+    imported: { mediaFileId: number; relativePath: string; quality: string }[];
+    seasonNumber?: number;
+    episodeNumber?: number;
+  }>;
+
+  // Group D — events and outbound (5)
+  // (Section header in the plan says "(4)"; the 17-method total only
+  // reconciles with the 5 methods listed below, D1-D5.)
+
+  /** Batched. Core resolves the SSE audience via SseAudienceService.recipientsForMedia. */
+  'events.publish': (p: AcquisitionEvent[]) => Promise<void>;
+
+  /** Closed vocabulary, not a free string. Today: 'grab.started'. */
+  'notifications.dispatch': (p: {
+    event: 'grab.started';
+    payload: Record<string, unknown>;
+  }) => Promise<void>;
+
+  /** The sidebar badge, pushed not polled. */
+  'counts.set': (p: { key: string; value: number }) => Promise<void>;
+
+  /** Plugin-namespaced SSE. Core force-prefixes the type to `plugin.<id>.<type>`. */
+  'events.emitOwn': (p: {
+    type: string;
+    payload: unknown;
+    audience: 'all' | { mediaId: number };
+  }) => Promise<void>;
+
+  /**
+   * Live acquisition progress. Plugin pushes; core emits the reserved
+   * `download.progress` SSE type. Coalesced server-side to <= 1/media/second.
+   */
+  'progress.set': (p: {
+    mediaId: number;
+    seasonNumber?: number;
+    episodeNumber?: number;
+    ref: string;
+    progress: number;
+    bytesPerSecond?: number;
+    etaSeconds?: number;
+    state: 'queued' | 'active' | 'stalled' | 'paused' | 'importing';
+  }) => Promise<void>;
+
+  // Group E — config (2)
+
+  /** `plugin.<id>.*` keys only. */
+  'config.get': (p: { keys?: string[] }) => Promise<Record<string, string>>;
+
+  /** Prefix applied server-side. Never `PUT /settings/:key`. */
+  'config.set': (p: { key: string; value: string | null }) => Promise<void>;
+}

--- a/backend/src/common/plugin-contract/index.ts
+++ b/backend/src/common/plugin-contract/index.ts
@@ -1,0 +1,8 @@
+/** Public surface of the plugin contract. Types and constants only — no runtime wiring. */
+
+export * from './protocol';
+export * from './principal';
+export * from './host-methods';
+export * from './plugin-methods';
+export * from './ui-contribution';
+export * from './manifest';

--- a/backend/src/common/plugin-contract/manifest.ts
+++ b/backend/src/common/plugin-contract/manifest.ts
@@ -1,0 +1,87 @@
+import type { UiContribution, ConfigPage } from './ui-contribution';
+import type { PluginScope } from './principal';
+
+/**
+ * `data` ships JSON descriptors and executes nothing; `process` ships one
+ * bundled JS file that core spawns as a child process. The baseline's
+ * third tier, `bundled`, is deleted: in-repo code is just core now.
+ */
+export type PluginKind = 'data' | 'process';
+
+/** `schedulers[]` renamed: core owns the cron and calls `job` on the trigger. */
+export interface PluginJob {
+  name: string;
+  cron: string;
+  triggerable: boolean;
+  labelKey: string;
+}
+
+/** One proxied HTTP route a `process` plugin owns. Both fields are install-time validations. */
+export interface PluginRoute {
+  method: string;
+  path: string;
+  policy: string;
+  objectGuard?: string;
+}
+
+/**
+ * Fields unchanged between tiers. `provides`, `events` and `i18n` carry
+ * shapes owned by a pre-existing baseline schema not reproduced here
+ * (e.g. `IndexerDescriptor`); kept structurally opaque rather than guessed.
+ */
+interface PluginManifestBase {
+  id: string;
+  pluginApi: number;
+  name: string;
+  version: string;
+  /** Semver range with a mandatory upper bound, e.g. ">=2.1.0 <3.0.0". */
+  fliks: string;
+  author: string;
+  description: string;
+  license: string;
+  logo: string;
+  homepage?: string;
+  provides?: Record<string, unknown>;
+  ui?: {
+    contributions?: UiContribution[];
+    configPages?: ConfigPage[];
+  };
+  /** `data`-tier outbound notifications only. */
+  events?: { webhook?: string }[];
+  i18n?: Record<string, Record<string, string>>;
+}
+
+/** A `data` manifest: no code, so none of the `process`-only keys are legal on it. */
+export interface DataPluginManifest extends PluginManifestBase {
+  kind: 'data';
+}
+
+/** A `process` manifest: owns a schema, routes, jobs and an ingest allowlist. */
+export interface ProcessPluginManifest extends PluginManifestBase {
+  kind: 'process';
+  /** The only legal value; not omittable. */
+  runtime: 'node';
+  /** `--max-old-space-size`; core caps at 1024. */
+  memoryMb: number;
+  /** sha256 of every archive entry but the manifest and its signature. */
+  files: Record<string, string>;
+  database: { schema: boolean; coreRefs: string[] };
+  routes: PluginRoute[];
+  /** URL aliases core keeps for one major version. */
+  legacyPaths?: Record<string, string>;
+  scopes: PluginScope[];
+  /** Allowlist for `library.ingest` paths. */
+  ingestRoots: string[];
+  jobs?: PluginJob[];
+  /** Legal on `process`, refused on `data`; item shape is the pre-existing baseline's. */
+  permissions?: string[];
+  /** Legal on `process`, refused on `data`; item shape is the pre-existing baseline's. */
+  checklist?: string[];
+}
+
+/**
+ * The manifest, discriminated on `kind`. A `data` object literal carrying
+ * `routes` (or any other `process`-only key) fails to typecheck: narrowing
+ * on `kind: 'data'` selects `DataPluginManifest`, which has no such property.
+ */
+export type PluginManifest = DataPluginManifest | ProcessPluginManifest;

--- a/backend/src/common/plugin-contract/plugin-methods.ts
+++ b/backend/src/common/plugin-contract/plugin-methods.ts
@@ -1,0 +1,39 @@
+import type { PluginManifest } from './manifest';
+import type { Note } from './protocol';
+import type { Principal } from './principal';
+
+/**
+ * Closed vocabulary of core SSE event names a plugin can subscribe to via
+ * `event`. Restated as `string`: the actual closed set lives in core's
+ * EventsService, outside this directory's import boundary.
+ */
+export type CoreEventName = string;
+
+/** The 7 methods core calls on a running `process` plugin. */
+export interface PluginApi {
+  hello: (p: {
+    pluginApi: number;
+    coreVersion: string;
+    config: Record<string, string>;
+  }) => Promise<{ manifest: PluginManifest }>;
+
+  health: () => Promise<{ ok: boolean; detail?: string }>;
+
+  job: (p: { name: string; jobId: string; args?: unknown }) => Promise<{ ok: true }>;
+
+  http: (p: {
+    method: string;
+    path: string;
+    query: Record<string, string>;
+    body: unknown;
+    principal: Principal;
+  }) => Promise<{ status: number; headers: Record<string, string>; body: unknown }>;
+
+  /** Fire-and-forget: no reply. */
+  event: (p: Note<{ name: CoreEventName; payload: unknown }>) => void;
+
+  /** Fire-and-forget: no reply. */
+  config: (p: Note<{ changed: string[] }>) => void;
+
+  shutdown: () => Promise<{ ok: true }>;
+}

--- a/backend/src/common/plugin-contract/principal.ts
+++ b/backend/src/common/plugin-contract/principal.ts
@@ -1,0 +1,26 @@
+/**
+ * Auth model for the plugin socket. There is no JWT and no `User` row on
+ * this side of the boundary — only these two principals.
+ */
+
+/**
+ * Who the plugin is acting as for one `http` callback. `delegated` is a
+ * proxied authenticated request, re-checked by core against that exact
+ * user on every callback; `system` is a background job, limited to the
+ * scopes consented at install.
+ */
+export type Principal = { kind: 'delegated'; userId: number } | { kind: 'system' };
+
+/**
+ * The eight scopes a `process` manifest can request, one per method
+ * group, consented once at install.
+ */
+export type PluginScope =
+  | 'media:read'
+  | 'acquisition:candidates'
+  | 'releases:score'
+  | 'blocklist:write'
+  | 'requests:progress'
+  | 'ingest:write'
+  | 'events:emit'
+  | 'config:rw';

--- a/backend/src/common/plugin-contract/protocol.ts
+++ b/backend/src/common/plugin-contract/protocol.ts
@@ -1,0 +1,35 @@
+/**
+ * Wire protocol for the two unix sockets between core and a `process`
+ * plugin: newline-delimited JSON, one object per line.
+ *
+ * This directory is a standalone island: it imports nothing from
+ * `backend/src` outside itself (no NestJS, no TypeORM, no entity class),
+ * because the plugin repo compiles this same source as its contract.
+ */
+
+/** A request frame. `i` pairs it with its `Res`; `m` is the dotted method name. */
+export interface Req {
+  i: number;
+  m: string;
+  p?: unknown;
+}
+
+/** The reply to a `Req` with the same `i`. Exactly one of `r`/`e` is present. */
+export interface Res {
+  i: number;
+  r?: unknown;
+  e?: { c: string; m: string };
+}
+
+/** A fire-and-forget frame: no `i`, no reply is ever sent for it. */
+export type Note<P = unknown> = { m: string; p?: P };
+
+/** Per-frame size ceiling. An oversize frame is a protocol violation and SIGKILLs the plugin. */
+export const MAX_FRAME_BYTES = 4 * 1024 * 1024;
+
+/**
+ * Checked for exact equality at catalog, install and `hello` — never a
+ * range. Within one value the method set is additive-only; any removal
+ * or semantic change bumps it.
+ */
+export const PLUGIN_API_VERSION = 0;

--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -1,0 +1,69 @@
+/**
+ * UI-facing contribution types carried by the manifest's `ui.*` block.
+ * `client/src/app/core/plugin-ui/contribution.types.ts` mirrors this file
+ * verbatim (types only); the CI drift gate diffs the two.
+ */
+
+/** The six slots a contribution can render into. */
+export type SlotId =
+  | 'nav.main'
+  | 'nav.acquisition'
+  | 'settings.page'
+  | 'media.actions'
+  | 'media.season.actions'
+  | 'card.actions';
+
+/**
+ * Closed `when` vocabulary, evaluated with `.every()`. A leading "!"
+ * negates any entry; an unknown predicate evaluates false (fail closed).
+ */
+export type WhenPredicate =
+  | 'isAdmin'
+  | `hasPermission:${string}`
+  | 'mediaType:movie'
+  | 'mediaType:series'
+  | 'hasFiles'
+  | 'isMonitored'
+  | 'hasQualityProfile'
+  | 'isEpisode'
+  | 'isTv'
+  | 'isTouch';
+
+/** One `ui.contributions[]` entry — a nav item, action or menu row. */
+export interface UiContribution {
+  id: string;
+  slot: SlotId;
+  weight: number;
+  labelKey: string;
+  icon?: string;
+  tone?: 'default' | 'danger';
+  badge?: string;
+  confirmKey?: string;
+  when?: WhenPredicate[];
+  action: { kind: 'route'; path: string } | { kind: 'action'; actionId: string };
+}
+
+/** The seven field kinds `<app-schema-form>` renders, over four form components. */
+export type FieldType = 'text' | 'email' | 'password' | 'url' | 'number' | 'toggle' | 'select';
+
+/** One input of a plugin's settings form. */
+export interface FieldDef {
+  key: string;
+  type: FieldType;
+  labelKey: string;
+  hint?: string;
+  placeholder?: string;
+  required?: boolean;
+  /** Stripped from every read response; only written back when non-empty. */
+  secret?: boolean;
+  default?: string | number | boolean;
+  options?: { value: string; labelKey: string }[];
+}
+
+/** One `ui.configPages[]` entry — a form-backed settings page under `plugin.<id>.`. */
+export interface ConfigPage {
+  id: string;
+  labelKey: string;
+  icon?: string;
+  fields: FieldDef[];
+}

--- a/client/src/app/core/plugin-ui/contribution.types.ts
+++ b/client/src/app/core/plugin-ui/contribution.types.ts
@@ -1,0 +1,72 @@
+/**
+ * Mirror of `backend/src/common/plugin-contract/ui-contribution.ts`, types
+ * only. The backend copy is the source of truth; a CI job diffs the two.
+ *
+ * NOTE: `client/src/app/core/plugins/` already exists and is the native
+ * host bridge folder (desktop-player.bridge.ts, native-player.plugin.ts,
+ * …). Plugin-UI code does not belong there — this is a separate folder.
+ */
+
+/** The six slots a contribution can render into. */
+export type SlotId =
+  | 'nav.main'
+  | 'nav.acquisition'
+  | 'settings.page'
+  | 'media.actions'
+  | 'media.season.actions'
+  | 'card.actions';
+
+/**
+ * Closed `when` vocabulary, evaluated with `.every()`. A leading "!"
+ * negates any entry; an unknown predicate evaluates false (fail closed).
+ */
+export type WhenPredicate =
+  | 'isAdmin'
+  | `hasPermission:${string}`
+  | 'mediaType:movie'
+  | 'mediaType:series'
+  | 'hasFiles'
+  | 'isMonitored'
+  | 'hasQualityProfile'
+  | 'isEpisode'
+  | 'isTv'
+  | 'isTouch';
+
+/** One `ui.contributions[]` entry — a nav item, action or menu row. */
+export interface UiContribution {
+  id: string;
+  slot: SlotId;
+  weight: number;
+  labelKey: string;
+  icon?: string;
+  tone?: 'default' | 'danger';
+  badge?: string;
+  confirmKey?: string;
+  when?: WhenPredicate[];
+  action: { kind: 'route'; path: string } | { kind: 'action'; actionId: string };
+}
+
+/** The seven field kinds `<app-schema-form>` renders, over four form components. */
+export type FieldType = 'text' | 'email' | 'password' | 'url' | 'number' | 'toggle' | 'select';
+
+/** One input of a plugin's settings form. */
+export interface FieldDef {
+  key: string;
+  type: FieldType;
+  labelKey: string;
+  hint?: string;
+  placeholder?: string;
+  required?: boolean;
+  /** Stripped from every read response; only written back when non-empty. */
+  secret?: boolean;
+  default?: string | number | boolean;
+  options?: { value: string; labelKey: string }[];
+}
+
+/** One `ui.configPages[]` entry — a form-backed settings page under `plugin.<id>.`. */
+export interface ConfigPage {
+  id: string;
+  labelKey: string;
+  icon?: string;
+  fields: FieldDef[];
+}


### PR DESCRIPTION
PR 3.1, opening phase 3. **Types and constants only** — no supervisor, no installer, no route, no DI wiring, and nothing imports any of it yet.

- **17 core-side methods** (plugin → core, groups A–E), **7 plugin-side** (core → plugin), **8 scopes**, the newline-delimited JSON frame types, and `PLUGIN_API_VERSION`, compared for exact equality at catalog, install and `hello`.
- **The manifest is a discriminated union on `kind`.** A `data` manifest carrying `routes`, `database` or `ingestRoots` fails to compile rather than being refused at install — the tier boundary the plan describes in prose, expressed where the compiler holds it.
- **The directory imports nothing from the rest of the backend** — no NestJS, no TypeORM, no entity, not even a `common/` enum. Verified: zero non-relative imports. It has to compile standalone in the plugin repo, which has none of those.

**The CI drift gate is missing from this PR and needs a human to add it.** My token has no `workflow` scope, so the push was rejected. The workflow is written and locally verified — it compiles both the backend contract and the client mirror with `tsc --emitDeclarationOnly --removeComments` and diffs the declarations, passing on identical copies and failing when one union member is added to either side. Filed with its full content as a follow-up issue.

Three things worth flagging rather than burying:

1. The plan's Group D header says *(4)* but lists five methods. Five is right — 6+3+1+5+2 = 17, the total the same section states. Header typo.
2. `FieldDef` / `ConfigPage` are called "unchanged from the baseline", a document outside this repo, and their shape appears nowhere in the plan. Reconstructed from what the plan does state — seven field types over the four existing form components, plus `secret`. This is the one place the transcription had nothing to transcribe; worth a look from someone holding the baseline.
3. `permissions[]`, `checklist[]`, `provides`, `events[].webhook` and `i18n` are likewise named but never shaped. Kept as opaque placeholders so nothing is silently dropped, to be typed when a real plugin needs them.

Verified: backend `tsc` 0, client `tsc` 0, suite 82/773/29 untouched. Note the client's `tsconfig.json` is a false green here — `files: []` plus project references means it checks zero files without `-b`; `tsconfig.app.json` is the real target and is what was run.