### PR TITLE
fix(events): catch rejected promises from domain event handlers

### DIFF
--- a/backend/src/modules/download-clients/download-clients.module.ts
+++ b/backend/src/modules/download-clients/download-clients.module.ts
@@ -1,4 +1,4 @@
-import { forwardRef, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { DownloadClient } from './entities/download-client.entity';
 import { DownloadHistory } from '../media/entities/download-history.entity';
@@ -10,7 +10,6 @@ import { DownloadClientsController } from './download-clients.controller';
 import { AuthModule } from '../auth/auth.module';
 import { TorrentHistoryMatcher } from '../media/torrent-history-matcher.service';
 import { BlocklistModule } from '../blocklist/blocklist.module';
-import { FliksSchedulerModule } from '../scheduler/scheduler.module';
 
 @Module({
   imports: [
@@ -22,9 +21,6 @@ import { FliksSchedulerModule } from '../scheduler/scheduler.module';
     ]),
     AuthModule,
     BlocklistModule,
-    // forwardRef: FliksSchedulerModule already imports this module for
-    // QbittorrentService/TorrentHistoryMatcher.
-    forwardRef(() => FliksSchedulerModule),
   ],
   controllers: [DownloadClientsController],
   providers: [

--- a/backend/src/modules/download-clients/download-clients.service.ts
+++ b/backend/src/modules/download-clients/download-clients.service.ts
@@ -1,9 +1,4 @@
-import {
-  forwardRef,
-  Inject,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { DownloadClient } from './entities/download-client.entity';

--- a/backend/src/modules/media/media-service/media-metadata.service.ts
+++ b/backend/src/modules/media/media-service/media-metadata.service.ts
@@ -1,11 +1,4 @@
-import {
-  Injectable,
-  Logger,
-  NotFoundException,
-  BadRequestException,
-  Inject,
-  forwardRef,
-} from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
 import { Media } from '../entities/media.entity';

--- a/backend/src/modules/scheduler/events.service.ts
+++ b/backend/src/modules/scheduler/events.service.ts
@@ -306,16 +306,22 @@ export class EventsService {
     this.domainSubject.next(event);
   }
 
-  /** Subscribe to domain events. A throwing handler is logged, never propagated. */
-  onDomain(handler: (event: DomainEvent) => void): Subscription {
+  /** Subscribe to domain events. A handler that throws — or returns a rejected
+   *  promise — is logged, never propagated: one bad subscriber must not reach
+   *  the emitter, and an async one must not become an unhandled rejection. */
+  onDomain(
+    handler: (event: DomainEvent) => void | Promise<void>,
+  ): Subscription {
+    const fail = (event: DomainEvent, err: unknown) =>
+      this.log.error(
+        `Domain event handler threw on "${event.type}": ${(err as Error).message}`,
+        err instanceof Error ? err.stack : undefined,
+      );
     return this.domainSubject.subscribe((event) => {
       try {
-        handler(event);
+        void Promise.resolve(handler(event)).catch((err) => fail(event, err));
       } catch (err) {
-        this.log.error(
-          `Domain event handler threw on "${event.type}": ${(err as Error).message}`,
-          err instanceof Error ? err.stack : undefined,
-        );
+        fail(event, err);
       }
     });
   }

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -3,11 +3,13 @@ import {
   Inject,
   Injectable,
   Logger,
+  OnModuleDestroy,
   OnModuleInit,
 } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { existsSync } from 'fs';
 import { In } from 'typeorm';
+import { Subscription } from 'rxjs';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CronExpressionParser } from 'cron-parser';
@@ -58,7 +60,8 @@ import { parseSeasonEpisode, matchesSeasonPack } from '../../common/release-pars
 const yieldLoop = () => new Promise<void>((r) => setTimeout(r, 50));
 
 @Injectable()
-export class SchedulerService implements OnModuleInit {
+export class SchedulerService implements OnModuleInit, OnModuleDestroy {
+  private readonly subscriptions = new Subscription();
   private readonly log = new Logger(SchedulerService.name);
 
   constructor(
@@ -157,10 +160,16 @@ export class SchedulerService implements OnModuleInit {
 
     // Single subscriber for every acquisition-side trigger — see the five
     // `media.acquisition.requested` emitters across media/download-clients/requests.
-    this.eventsService.onDomain((event) => {
-      if (event.type !== 'media.acquisition.requested') return;
-      void this.searchMissingForMedia(event.mediaIds);
-    });
+    this.subscriptions.add(
+      this.eventsService.onDomain((event) => {
+        if (event.type !== 'media.acquisition.requested') return;
+        void this.searchMissingForMedia(event.mediaIds);
+      }),
+    );
+  }
+
+  onModuleDestroy(): void {
+    this.subscriptions.unsubscribe();
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-ups from the phase-2 audit. Four of its seven findings; the other three are filed as issues.

**The one that matters.** `onDomain` wrapped the handler in try/catch and its doc comment promised a throwing subscriber "never reaches the emitter". An `async` handler never throws synchronously — anything it fails on becomes a rejection on the returned promise, which nothing awaited. So the guarantee held only for synchronous handlers, while the signature `(e) => void` happily accepts an async arrow and the comment invites one. The first async subscriber someone wrote would have turned its own error into an unhandled rejection. The type now admits `Promise<void>` and both paths are caught. Today's two handlers are synchronous and were never at risk — but this bus is documented as the seam plugin authors will subscribe on.

**Three cleanups.** `SchedulerService` keeps its subscription in a `Subscription` and unsubscribes in `onModuleDestroy`, matching `RequestLifecycleService` — previously it leaked one per module init. `download-clients.module.ts` drops a `forwardRef(() => FliksSchedulerModule)` whose own comment justified it by a dependency the seam inversion removed, and two services drop `forwardRef`/`Inject` imports with no remaining call.

Verified: `tsc` 0, suite 82/773/29, backend boots with the module import gone — the check that matters for a removed `forwardRef`, since a wrong one shows up only at DI resolution.