### PR TITLE
feat(plugins): validate plugin archives before anything touches disk

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "1.15.2",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "1.15.2",
+      "version": "2.0.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@capacitor/app": "^8.1.0",
@@ -33,8 +33,10 @@
         "pg": "^8.20.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "semver": "^7.8.5",
         "sharp": "^0.35.3",
-        "typeorm": "^0.3.28"
+        "typeorm": "^0.3.28",
+        "yauzl": "^3.4.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -51,6 +53,7 @@
         "@types/passport-jwt": "^4.0.1",
         "@types/pg": "^8.20.0",
         "@types/supertest": "^6.0.2",
+        "@types/yauzl": "^3.4.0",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.2.2",
@@ -3514,6 +3517,16 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.2",
@@ -9281,6 +9294,12 @@
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
     "node_modules/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
@@ -11875,6 +11894,18 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
       "engines": {
         "node": ">=12"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -49,8 +49,10 @@
     "pg": "^8.20.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "semver": "^7.8.5",
     "sharp": "^0.35.3",
-    "typeorm": "^0.3.28"
+    "typeorm": "^0.3.28",
+    "yauzl": "^3.4.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -67,6 +69,7 @@
     "@types/passport-jwt": "^4.0.1",
     "@types/pg": "^8.20.0",
     "@types/supertest": "^6.0.2",
+    "@types/yauzl": "^3.4.0",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.2",

--- a/backend/src/modules/plugins/archive/ed25519-test-keys.ts
+++ b/backend/src/modules/plugins/archive/ed25519-test-keys.ts
@@ -1,0 +1,19 @@
+import { generateKeyPairSync, sign as ed25519Sign, KeyObject } from 'crypto';
+
+export interface TestKeypair {
+  privateKey: KeyObject;
+  /** Raw 32-byte public key — the format {@link resolveTrust} stores keys in. */
+  rawPublicKey: Buffer;
+}
+
+/** A fresh Ed25519 keypair for signature-path specs. Never used outside tests. */
+export function generateTestKeypair(): TestKeypair {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const spki = publicKey.export({ type: 'spki', format: 'der' }) as Buffer;
+  return { privateKey, rawPublicKey: spki.subarray(spki.length - 32) };
+}
+
+/** Base64 text — exactly what a `plugin.json.sig` entry's file content holds. */
+export function signManifestBase64(privateKey: KeyObject, manifestBytes: Buffer): string {
+  return ed25519Sign(null, manifestBytes, privateKey).toString('base64');
+}

--- a/backend/src/modules/plugins/archive/extract.spec.ts
+++ b/backend/src/modules/plugins/archive/extract.spec.ts
@@ -1,0 +1,137 @@
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { extractToStaging, writeGuardedFile } from './extract';
+import { buildZip } from './zip-builder';
+import { minimalDataManifest, minimalProcessManifest } from './test-manifests';
+import { pngLogo, sha256Hex, svgLogo } from './test-fixtures';
+
+describe('extractToStaging() — happy path', () => {
+  it('extracts a process archive and hashes match manifest.files', async () => {
+    const pluginJs = Buffer.from('module.exports = {};', 'utf8');
+    const logo = pngLogo();
+    const files = { 'plugin.js': sha256Hex(pluginJs), 'logo.png': sha256Hex(logo) };
+    const manifest = minimalProcessManifest(files);
+    const buffer = buildZip([
+      { name: 'plugin.json', content: Buffer.from(JSON.stringify(manifest)) },
+      { name: 'plugin.js', content: pluginJs },
+      { name: 'logo.png', content: logo },
+    ]);
+
+    const result = await extractToStaging(buffer, manifest);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    try {
+      expect(statSync(result.dir).mode & 0o777).toBe(0o700);
+      const byName = new Map(result.files.map((f) => [f.name, f]));
+      expect(byName.get('plugin.js')?.sha256).toBe(files['plugin.js']);
+      expect(byName.get('logo.png')?.sha256).toBe(files['logo.png']);
+      expect(readFileSync(byName.get('plugin.js')!.path)).toEqual(pluginJs);
+      expect(statSync(byName.get('plugin.js')!.path).mode & 0o777).toBe(0o600);
+    } finally {
+      rmSync(result.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('extracts a data archive without a files{} map (nothing to hash-check)', async () => {
+    const manifest = minimalDataManifest();
+    const logo = svgLogo();
+    const buffer = buildZip([
+      { name: 'plugin.json', content: Buffer.from(JSON.stringify(manifest)) },
+      { name: 'logo.svg', content: logo },
+    ]);
+
+    const result = await extractToStaging(buffer, manifest);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    rmSync(result.dir, { recursive: true, force: true });
+  });
+});
+
+describe('extractToStaging() — guards', () => {
+  it('PLUGIN_HASH_MISMATCH: extracted content does not match the declared hash', async () => {
+    const pluginJs = Buffer.from('module.exports = {};');
+    const logo = pngLogo();
+    // Declare a hash that matches nothing actually in the archive.
+    const manifest = minimalProcessManifest({ 'plugin.js': 'f'.repeat(64), 'logo.png': sha256Hex(logo) });
+    const buffer = buildZip([
+      { name: 'plugin.json', content: Buffer.from(JSON.stringify(manifest)) },
+      { name: 'plugin.js', content: pluginJs },
+      { name: 'logo.png', content: logo },
+    ]);
+
+    const result = await extractToStaging(buffer, manifest);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('PLUGIN_HASH_MISMATCH');
+  });
+
+  it('PLUGIN_BAD_LOGO: an SVG carrying a <script> element', async () => {
+    const manifest = minimalDataManifest();
+    const evilSvg = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>');
+    const buffer = buildZip([
+      { name: 'plugin.json', content: Buffer.from(JSON.stringify(manifest)) },
+      { name: 'logo.svg', content: evilSvg },
+    ]);
+
+    const result = await extractToStaging(buffer, manifest);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('PLUGIN_BAD_LOGO');
+  });
+
+  it('PLUGIN_BAD_LOGO: a logo.png with the wrong magic bytes', async () => {
+    const manifest = minimalDataManifest({ logo: 'logo.png' });
+    const buffer = buildZip([
+      { name: 'plugin.json', content: Buffer.from(JSON.stringify(manifest)) },
+      { name: 'logo.png', content: Buffer.from('this is not a png') },
+    ]);
+
+    const result = await extractToStaging(buffer, manifest);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('PLUGIN_BAD_LOGO');
+  });
+
+  it('purges the staging directory on refusal — no partial installs', async () => {
+    const pluginJs = Buffer.from('module.exports = {};');
+    const manifest = minimalProcessManifest({ 'plugin.js': 'f'.repeat(64) });
+    const buffer = buildZip([
+      { name: 'plugin.json', content: Buffer.from(JSON.stringify(manifest)) },
+      { name: 'plugin.js', content: pluginJs },
+    ]);
+
+    const before = stagingDirCount();
+    const result = await extractToStaging(buffer, manifest);
+    expect(result.ok).toBe(false);
+    expect(stagingDirCount()).toBe(before);
+  });
+});
+
+describe('writeGuardedFile() — symlink escape at the write target', () => {
+  it('refuses to follow a symlink already at the target path', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fliks-plugin-test-'));
+    const outsideFile = join(dir, 'outside.txt');
+    writeFileSync(outsideFile, 'untouched');
+    const target = join(dir, 'plugin.js');
+    symlinkSync(outsideFile, target);
+
+    try {
+      let code: string | undefined;
+      try {
+        writeGuardedFile(target, Buffer.from('payload'));
+      } catch (err) {
+        code = (err as NodeJS.ErrnoException).code;
+      }
+      expect(code).toBe('EEXIST');
+      expect(readFileSync(outsideFile, 'utf8')).toBe('untouched');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+/** Counts `fliks-plugin-*` mkdtemp directories left behind in the OS temp dir, as a leak check. */
+function stagingDirCount(): number {
+  return readdirSync(tmpdir()).filter((n) => n.startsWith('fliks-plugin-')).length;
+}

--- a/backend/src/modules/plugins/archive/extract.ts
+++ b/backend/src/modules/plugins/archive/extract.ts
@@ -1,0 +1,131 @@
+import { createHash, timingSafeEqual } from 'crypto';
+import { closeSync, mkdtempSync, openSync, rmSync, writeSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import * as yauzl from 'yauzl';
+import type { PluginManifest } from '../../../common/plugin-contract';
+import { PluginRefusal, refuse } from './refusal-codes';
+
+export interface ExtractedFile {
+  name: string;
+  path: string;
+  sha256: string;
+  size: number;
+}
+
+export interface ExtractSuccess {
+  ok: true;
+  dir: string;
+  files: ExtractedFile[];
+}
+
+export type ExtractResult = ExtractSuccess | PluginRefusal;
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/** Internal signal that a guard refused mid-extraction — carries the staging dir cleanup with it. */
+class ExtractionRefused extends Error {
+  constructor(public readonly refusal: PluginRefusal) {
+    super(refusal.code);
+  }
+}
+
+/**
+ * V8: fresh `mkdtemp` (mode 0o700 by POSIX definition), each entry written
+ * `wx`/0o600 so an existing symlink at the target path is refused rather
+ * than followed, then hashed against `manifest.files` for a `process`
+ * archive. Independent of {@link inspect} — re-reads the raw bytes rather
+ * than trusting anything cached from an earlier call. Any failure purges
+ * the staging directory: partial installs are not a state this pipeline has.
+ */
+export async function extractToStaging(buffer: Buffer, manifest: PluginManifest): Promise<ExtractResult> {
+  const zipfile = await yauzl.fromBufferPromise(buffer, {
+    lazyEntries: true,
+    decodeStrings: true,
+    strictFileNames: true,
+    validateEntrySizes: true,
+  });
+
+  const dir = mkdtempSync(join(tmpdir(), 'fliks-plugin-'));
+  const declaredHashes = manifest.kind === 'process' ? manifest.files : {};
+  const files: ExtractedFile[] = [];
+
+  try {
+    for await (const entry of zipfile.eachEntry()) {
+      const name = entry.fileName;
+      const content = await readEntry(zipfile, entry);
+
+      if (name === 'logo.svg' || name === 'logo.png') {
+        const badLogo = sniffLogo(name, content);
+        if (badLogo) throw new ExtractionRefused(badLogo);
+      }
+
+      const actualHash = createHash('sha256').update(content).digest('hex');
+      const expectedHash = declaredHashes[name];
+      if (expectedHash && !hexEqual(actualHash, expectedHash)) {
+        throw new ExtractionRefused(refuse('PLUGIN_HASH_MISMATCH', `${name}: expected ${expectedHash}, got ${actualHash}`));
+      }
+
+      const path = join(dir, name);
+      writeGuardedFile(path, content);
+      files.push({ name, path, sha256: actualHash, size: content.length });
+    }
+  } catch (err) {
+    rmSync(dir, { recursive: true, force: true });
+    if (err instanceof ExtractionRefused) return err.refusal;
+    throw err;
+  }
+
+  return { ok: true, dir, files };
+}
+
+/** `O_EXCL` (`wx`) fails on an existing path — including a pre-planted symlink — rather than following it. */
+export function writeGuardedFile(path: string, content: Buffer): void {
+  const fd = openSync(path, 'wx', 0o600);
+  try {
+    writeSync(fd, content);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function readEntry(zipfile: yauzl.ZipFile, entry: yauzl.Entry): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    zipfile.openReadStream(entry, (err, stream) => {
+      if (err) return reject(err);
+      const chunks: Buffer[] = [];
+      stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+      stream.on('end', () => resolve(Buffer.concat(chunks)));
+      stream.on('error', reject);
+    });
+  });
+}
+
+function hexEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}
+
+/** PNG by magic bytes; SVG must parse as XML rooted at `<svg>` with no script content. */
+function sniffLogo(name: string, content: Buffer): PluginRefusal | null {
+  if (name === 'logo.png') {
+    if (!content.subarray(0, PNG_MAGIC.length).equals(PNG_MAGIC)) {
+      return refuse('PLUGIN_BAD_LOGO', 'logo.png does not start with the PNG magic bytes');
+    }
+    return null;
+  }
+  const text = content.toString('utf8');
+  if (!/<svg[\s>]/i.test(text)) {
+    return refuse('PLUGIN_BAD_LOGO', 'logo.svg has no <svg> root element');
+  }
+  if (/<script[\s>]/i.test(text)) {
+    return refuse('PLUGIN_BAD_LOGO', 'logo.svg contains a <script> element');
+  }
+  if (/\son[a-z]+\s*=/i.test(text)) {
+    return refuse('PLUGIN_BAD_LOGO', 'logo.svg contains an event-handler attribute');
+  }
+  if (/javascript:/i.test(text)) {
+    return refuse('PLUGIN_BAD_LOGO', 'logo.svg contains a javascript: URI');
+  }
+  return null;
+}

--- a/backend/src/modules/plugins/archive/index.ts
+++ b/backend/src/modules/plugins/archive/index.ts
@@ -1,0 +1,7 @@
+/** Archive validator: guards, signature verification and staging extraction. No DI, no controller — see plans/plugin-system.plan.md PR 3.3. */
+export * from './refusal-codes';
+export * from './limits';
+export * from './trust-store';
+export * from './manifest-parser';
+export * from './zip-inspector';
+export * from './extract';

--- a/backend/src/modules/plugins/archive/limits.ts
+++ b/backend/src/modules/plugins/archive/limits.ts
@@ -1,0 +1,36 @@
+/**
+ * The closed entry-name set (`plans/plugin-system.plan.md`, "The ZIP — a
+ * closed literal file list"). Matched by `===` only — never normalised,
+ * never case-folded — so path traversal has no class of name to exploit.
+ */
+export const LEGAL_ENTRY_NAMES = [
+  'plugin.json',
+  'plugin.json.sig',
+  'plugin.js',
+  'logo.svg',
+  'logo.png',
+] as const;
+export type LegalEntryName = (typeof LEGAL_ENTRY_NAMES)[number];
+
+/** `process`-only entries; illegal inside a `data` archive. */
+export const PROCESS_ONLY_ENTRY_NAMES: ReadonlySet<string> = new Set(['plugin.js']);
+
+export const MAX_ARCHIVE_ENTRIES = 4;
+export const MAX_ARCHIVE_COMPRESSED_BYTES = 8 * 1024 * 1024;
+export const MAX_TOTAL_UNCOMPRESSED_BYTES = 24 * 1024 * 1024;
+export const MAX_ENTRY_RATIO = 100;
+export const MAX_MANIFEST_BYTES = 256 * 1024;
+export const MAX_SIGNATURE_BYTES = 256;
+export const MAX_PLUGIN_JS_BYTES = 8 * 1024 * 1024;
+export const MAX_LOGO_BYTES = 64 * 1024;
+
+/** Raw byte length of an Ed25519 signature — fixed regardless of message size. */
+export const ED25519_SIGNATURE_LENGTH = 64;
+
+/** Per-entry uncompressed-size cap, keyed by the closed name set above. */
+export function maxUncompressedBytesFor(name: string): number {
+  if (name === 'plugin.json') return MAX_MANIFEST_BYTES;
+  if (name === 'plugin.json.sig') return MAX_SIGNATURE_BYTES;
+  if (name === 'plugin.js') return MAX_PLUGIN_JS_BYTES;
+  return MAX_LOGO_BYTES; // logo.svg | logo.png
+}

--- a/backend/src/modules/plugins/archive/manifest-parser.ts
+++ b/backend/src/modules/plugins/archive/manifest-parser.ts
@@ -1,0 +1,145 @@
+import type {
+  DataPluginManifest,
+  PluginManifest,
+  PluginRoute,
+  ProcessPluginManifest,
+} from '../../../common/plugin-contract';
+import { PluginScope } from '../../../common/plugin-contract';
+
+const BASE_KEYS = new Set([
+  'id',
+  'pluginApi',
+  'name',
+  'version',
+  'fliks',
+  'author',
+  'description',
+  'license',
+  'logo',
+  'homepage',
+  'provides',
+  'ui',
+  'events',
+  'i18n',
+  'kind',
+]);
+
+const PROCESS_KEYS = new Set([
+  ...BASE_KEYS,
+  'runtime',
+  'memoryMb',
+  'files',
+  'database',
+  'routes',
+  'legacyPaths',
+  'scopes',
+  'ingestRoots',
+  'jobs',
+  'permissions',
+  'checklist',
+]);
+
+const PLUGIN_SCOPES: ReadonlySet<string> = new Set<PluginScope>([
+  'media:read',
+  'acquisition:candidates',
+  'releases:score',
+  'blocklist:write',
+  'requests:progress',
+  'ingest:write',
+  'events:emit',
+  'config:rw',
+]);
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function hasRequiredBaseFields(json: Record<string, unknown>): boolean {
+  return (
+    typeof json.id === 'string' &&
+    json.id.length > 0 &&
+    typeof json.pluginApi === 'number' &&
+    typeof json.name === 'string' &&
+    json.name.length > 0 &&
+    typeof json.version === 'string' &&
+    json.version.length > 0 &&
+    typeof json.fliks === 'string' &&
+    json.fliks.length > 0 &&
+    typeof json.author === 'string' &&
+    typeof json.description === 'string' &&
+    typeof json.license === 'string' &&
+    typeof json.logo === 'string' &&
+    (json.homepage === undefined || typeof json.homepage === 'string')
+  );
+}
+
+function isStringRecord(v: unknown): v is Record<string, string> {
+  return isRecord(v) && Object.values(v).every((x) => typeof x === 'string');
+}
+
+function isRouteArray(v: unknown): v is PluginRoute[] {
+  return (
+    Array.isArray(v) &&
+    v.every(
+      (r) =>
+        isRecord(r) &&
+        typeof r.method === 'string' &&
+        typeof r.path === 'string' &&
+        typeof r.policy === 'string' &&
+        (r.objectGuard === undefined || typeof r.objectGuard === 'string'),
+    )
+  );
+}
+
+function hasRequiredProcessFields(json: Record<string, unknown>): boolean {
+  return (
+    json.runtime === 'node' &&
+    typeof json.memoryMb === 'number' &&
+    isStringRecord(json.files) &&
+    isRecord(json.database) &&
+    typeof json.database.schema === 'boolean' &&
+    Array.isArray(json.database.coreRefs) &&
+    json.database.coreRefs.every((r) => typeof r === 'string') &&
+    isRouteArray(json.routes) &&
+    Array.isArray(json.scopes) &&
+    json.scopes.length > 0 &&
+    json.scopes.every((s) => typeof s === 'string' && PLUGIN_SCOPES.has(s)) &&
+    Array.isArray(json.ingestRoots) &&
+    json.ingestRoots.every((r) => typeof r === 'string')
+  );
+}
+
+/**
+ * Structural validation only — required fields, types, unknown-key
+ * rejection (mirrors `forbidNonWhitelisted` at `main.ts:76-80`) and the
+ * `data`/`process` field split. Deep validation of nested shapes (route
+ * `policy`/`objectGuard` against a live registry, `ui.contributions[]`
+ * slot legality) needs modules this PR doesn't build; deferred to 3.5/6.1.
+ */
+export function parseManifest(bytes: Buffer): PluginManifest | null {
+  let json: unknown;
+  try {
+    json = JSON.parse(bytes.toString('utf8'));
+  } catch {
+    return null;
+  }
+  if (!isRecord(json)) return null;
+  if (!hasRequiredBaseFields(json)) return null;
+
+  if (json.kind === 'data') {
+    for (const key of Object.keys(json)) {
+      if (!BASE_KEYS.has(key)) return null;
+    }
+    return json as unknown as DataPluginManifest;
+  }
+
+  if (json.kind === 'process') {
+    for (const key of Object.keys(json)) {
+      if (!PROCESS_KEYS.has(key)) return null;
+    }
+    if (!hasRequiredProcessFields(json)) return null;
+    return json as unknown as ProcessPluginManifest;
+  }
+
+  return null;
+}

--- a/backend/src/modules/plugins/archive/refusal-codes.ts
+++ b/backend/src/modules/plugins/archive/refusal-codes.ts
@@ -1,0 +1,45 @@
+/**
+ * One code per archive guard (see `plans/plugin-system.plan.md`, "Guards,
+ * ordered"). The code is the contract: a caller branches on it, never on
+ * `detail`, which is log/debug text only.
+ */
+export type PluginRefusalCode =
+  | 'PLUGIN_BAD_MAGIC'
+  | 'PLUGIN_TOO_MANY_ENTRIES'
+  | 'PLUGIN_UNEXPECTED_ENTRY'
+  | 'PLUGIN_PATH_SEPARATOR'
+  | 'PLUGIN_ABSOLUTE_PATH'
+  | 'PLUGIN_CONTROL_CHAR'
+  | 'PLUGIN_NOT_NFC'
+  | 'PLUGIN_DUPLICATE_ENTRY'
+  | 'PLUGIN_DIRECTORY_ENTRY'
+  | 'PLUGIN_SYMLINK'
+  | 'PLUGIN_ZIP64'
+  | 'PLUGIN_DATA_DESCRIPTOR'
+  | 'PLUGIN_TRAILING_DATA'
+  | 'PLUGIN_ARCHIVE_COMMENT'
+  | 'PLUGIN_ENCRYPTED'
+  | 'PLUGIN_COMPRESSION_METHOD'
+  | 'PLUGIN_TOO_LARGE'
+  | 'PLUGIN_RATIO'
+  | 'PLUGIN_MANIFEST_TOO_LARGE'
+  | 'PLUGIN_BAD_SIGNATURE'
+  | 'PLUGIN_UNSIGNED'
+  | 'PLUGIN_HASH_MISMATCH'
+  | 'PLUGIN_FILE_SET_MISMATCH'
+  | 'PLUGIN_TIER_VIOLATION'
+  | 'PLUGIN_BAD_MANIFEST'
+  | 'PLUGIN_BAD_LOGO'
+  /** yauzl refused the archive and no more specific guard claimed it. Never
+   *  report a specific cause we did not actually establish. */
+  | 'PLUGIN_MALFORMED_ARCHIVE';
+
+export interface PluginRefusal {
+  ok: false;
+  code: PluginRefusalCode;
+  detail: string;
+}
+
+export function refuse(code: PluginRefusalCode, detail: string): PluginRefusal {
+  return { ok: false, code, detail };
+}

--- a/backend/src/modules/plugins/archive/test-fixtures.ts
+++ b/backend/src/modules/plugins/archive/test-fixtures.ts
@@ -1,0 +1,15 @@
+import { createHash } from 'crypto';
+
+/** A minimal, valid SVG — no script, no event handler, parses as `<svg>` rooted XML. */
+export function svgLogo(): Buffer {
+  return Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"></svg>', 'utf8');
+}
+
+/** PNG magic bytes followed by a few arbitrary bytes — enough for the magic-byte sniff, not a decodable image. */
+export function pngLogo(): Buffer {
+  return Buffer.concat([Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]), Buffer.from([0, 0, 0, 0])]);
+}
+
+export function sha256Hex(content: Buffer): string {
+  return createHash('sha256').update(content).digest('hex');
+}

--- a/backend/src/modules/plugins/archive/test-manifests.ts
+++ b/backend/src/modules/plugins/archive/test-manifests.ts
@@ -1,0 +1,45 @@
+import type { DataPluginManifest, ProcessPluginManifest } from '../../../common/plugin-contract';
+
+/** Minimal, structurally-valid `data` manifest — spread `overrides` to break one field at a time. */
+export function minimalDataManifest(overrides: Partial<DataPluginManifest> = {}): DataPluginManifest {
+  return {
+    id: 'fliks.test-plugin',
+    pluginApi: 0,
+    name: 'Test plugin',
+    version: '1.0.0',
+    fliks: '>=2.1.0 <3.0.0',
+    author: 'Fliks',
+    description: 'A spec fixture.',
+    license: 'MIT',
+    logo: 'logo.svg',
+    kind: 'data',
+    ...overrides,
+  };
+}
+
+/** Minimal, structurally-valid `process` manifest — `files` must match the archive's actual entries+hashes. */
+export function minimalProcessManifest(
+  files: Record<string, string>,
+  overrides: Partial<ProcessPluginManifest> = {},
+): ProcessPluginManifest {
+  return {
+    id: 'fliks.test-process-plugin',
+    pluginApi: 0,
+    name: 'Test process plugin',
+    version: '1.0.0',
+    fliks: '>=2.1.0 <3.0.0',
+    author: 'Fliks',
+    description: 'A spec fixture.',
+    license: 'MIT',
+    logo: 'logo.png',
+    kind: 'process',
+    runtime: 'node',
+    memoryMb: 256,
+    files,
+    database: { schema: true, coreRefs: [] },
+    routes: [],
+    scopes: ['media:read'],
+    ingestRoots: [],
+    ...overrides,
+  };
+}

--- a/backend/src/modules/plugins/archive/trust-store.spec.ts
+++ b/backend/src/modules/plugins/archive/trust-store.spec.ts
@@ -1,0 +1,55 @@
+import { resolveTrust } from './trust-store';
+import { generateTestKeypair, signManifestBase64 } from './ed25519-test-keys';
+
+describe('resolveTrust()', () => {
+  const data = Buffer.from(JSON.stringify({ id: 'fliks.test', version: '1.0.0' }));
+
+  it('is unsigned when no signature is present', () => {
+    expect(resolveTrust(data, null).trust).toBe('unsigned');
+  });
+
+  it('an empty trust store resolves a validly-signed archive to unverified, not official, and does not throw', () => {
+    const { privateKey } = generateTestKeypair();
+    const signature = Buffer.from(signManifestBase64(privateKey, data), 'base64');
+    expect(() => resolveTrust(data, signature)).not.toThrow();
+    const result = resolveTrust(data, signature);
+    expect(result.trust).toBe('unverified');
+    expect(result.signedByKeyId).toBeUndefined();
+  });
+
+  it('resolves to official when the signer is a compiled-in official key', () => {
+    const { privateKey, rawPublicKey } = generateTestKeypair();
+    const signature = Buffer.from(signManifestBase64(privateKey, data), 'base64');
+    const officialKeys = new Map([['release-2026', rawPublicKey]]);
+    const result = resolveTrust(data, signature, officialKeys);
+    expect(result.trust).toBe('official');
+    expect(result.signedByKeyId).toBe('release-2026');
+  });
+
+  it('resolves to verified-<keyId> for a third-party key that is not official', () => {
+    const { privateKey, rawPublicKey } = generateTestKeypair();
+    const signature = Buffer.from(signManifestBase64(privateKey, data), 'base64');
+    const thirdPartyKeys = new Map([['admin-added-key', rawPublicKey]]);
+    const result = resolveTrust(data, signature, new Map(), thirdPartyKeys);
+    expect(result.trust).toBe('verified-admin-added-key');
+    expect(result.signedByKeyId).toBe('admin-added-key');
+  });
+
+  it('prefers an official match over an incidental third-party match', () => {
+    const { privateKey, rawPublicKey } = generateTestKeypair();
+    const signature = Buffer.from(signManifestBase64(privateKey, data), 'base64');
+    const officialKeys = new Map([['release-2026', rawPublicKey]]);
+    const thirdPartyKeys = new Map([['admin-added-key', rawPublicKey]]);
+    const result = resolveTrust(data, signature, officialKeys, thirdPartyKeys);
+    expect(result.trust).toBe('official');
+  });
+
+  it('a tampered signature against a known key falls through to unverified, never official', () => {
+    const { privateKey, rawPublicKey } = generateTestKeypair();
+    const signature = Buffer.from(signManifestBase64(privateKey, data), 'base64');
+    signature[0] ^= 0xff; // flip a bit — the signature no longer verifies
+    const officialKeys = new Map([['release-2026', rawPublicKey]]);
+    const result = resolveTrust(data, signature, officialKeys);
+    expect(result.trust).toBe('unverified');
+  });
+});

--- a/backend/src/modules/plugins/archive/trust-store.ts
+++ b/backend/src/modules/plugins/archive/trust-store.ts
@@ -1,0 +1,63 @@
+import { createPublicKey, verify as verifyDetached } from 'crypto';
+
+/**
+ * Official release keys, raw 32-byte Ed25519 public keys keyed by key id.
+ * Empty until Phase 8.1 (`fliks-plugin-catalog`) mints the first signing
+ * key: populate with `OFFICIAL_KEYS.set('<keyId>', Buffer.from('<base64>', 'base64'))`.
+ * An empty store must never resolve a signature to `official` — see {@link resolveTrust}.
+ */
+export const OFFICIAL_KEYS: ReadonlyMap<string, Buffer> = new Map();
+
+export type TrustOutcome = 'official' | `verified-${string}` | 'unverified' | 'unsigned';
+
+export interface SignatureVerification {
+  trust: TrustOutcome;
+  signedByKeyId?: string;
+}
+
+const ED25519_SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex');
+
+/** Wrap a raw 32-byte Ed25519 public key in the DER/SPKI envelope `crypto.createPublicKey` requires. */
+function rawEd25519ToSpki(raw: Buffer): Buffer {
+  return Buffer.concat([ED25519_SPKI_PREFIX, raw]);
+}
+
+function verifyWithRawKey(data: Buffer, signature: Buffer, rawPublicKey: Buffer): boolean {
+  if (rawPublicKey.length !== 32) return false;
+  try {
+    const keyObject = createPublicKey({
+      key: rawEd25519ToSpki(rawPublicKey),
+      format: 'der',
+      type: 'spki',
+    });
+    return verifyDetached(null, data, keyObject, signature);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Classify a signature by trying every known key — official first, then
+ * caller-supplied third-party keys — never the reverse: an official key
+ * always wins the `official` badge over an incidental third-party match.
+ * No signature at all is `unsigned`. A signature nothing recognises is
+ * `unverified` — including the case where both stores are empty, which
+ * must never crash and must never read as `official`.
+ */
+export function resolveTrust(
+  data: Buffer,
+  signature: Buffer | null,
+  officialKeys: ReadonlyMap<string, Buffer> = OFFICIAL_KEYS,
+  thirdPartyKeys: ReadonlyMap<string, Buffer> = new Map(),
+): SignatureVerification {
+  if (!signature) return { trust: 'unsigned' };
+  for (const [keyId, rawKey] of officialKeys) {
+    if (verifyWithRawKey(data, signature, rawKey)) return { trust: 'official', signedByKeyId: keyId };
+  }
+  for (const [keyId, rawKey] of thirdPartyKeys) {
+    if (verifyWithRawKey(data, signature, rawKey)) {
+      return { trust: `verified-${keyId}`, signedByKeyId: keyId };
+    }
+  }
+  return { trust: 'unverified' };
+}

--- a/backend/src/modules/plugins/archive/zip-builder.ts
+++ b/backend/src/modules/plugins/archive/zip-builder.ts
@@ -1,0 +1,149 @@
+import { deflateRawSync } from 'zlib';
+
+/**
+ * Byte-level ZIP assembler for the guard spec suite. Several guards
+ * (ZIP64, a data descriptor bit, duplicate central-directory records, a
+ * lying declared size) cannot be produced by any real zip writer — this
+ * builder writes the local header, file data, central directory and EOCD
+ * by hand so a spec can corrupt exactly one field and leave the rest valid.
+ */
+export interface ZipEntrySpec {
+  name: string;
+  content: Buffer;
+  /** 0 = store, 8 = deflate. Default 0. */
+  compressionMethod?: number;
+  /** Default 0x0800 (UTF-8 flag) — set explicit bits to test the data-descriptor/encryption bits. */
+  generalPurposeBitFlag?: number;
+  /** Default 0 (no attributes). Set `(unixMode << 16) | dosBits` to test symlink/directory detection. */
+  externalFileAttributes?: number;
+  extraFields?: { id: number; data: Buffer }[];
+  /** Lies about the size fields in both the local header and the central directory. */
+  declaredUncompressedSize?: number;
+  declaredCompressedSize?: number;
+}
+
+export interface ZipBuildOptions {
+  /** Archive-level comment in the EOCD record. Default none. */
+  archiveComment?: string;
+  /** Indices into `entries` whose central-directory record is written a second time. */
+  duplicateCentralDirectoryRecords?: number[];
+  /** Raw bytes appended after the EOCD record — a second archive, or plain garbage. */
+  trailingBytes?: Buffer;
+  /** Override the EOCD's declared total-entries field independent of the actual record count. */
+  declaredEntryCount?: number;
+}
+
+interface BuiltEntry {
+  spec: ZipEntrySpec;
+  offset: number;
+  compressedData: Buffer;
+  nameBuf: Buffer;
+  extraBuf: Buffer;
+}
+
+function encodeExtraFields(fields: { id: number; data: Buffer }[]): Buffer {
+  return Buffer.concat(
+    fields.map(({ id, data }) => {
+      const header = Buffer.alloc(4);
+      header.writeUInt16LE(id, 0);
+      header.writeUInt16LE(data.length, 2);
+      return Buffer.concat([header, data]);
+    }),
+  );
+}
+
+function buildLocalHeader(e: BuiltEntry): Buffer {
+  const { spec, nameBuf, extraBuf, compressedData } = e;
+  const compressionMethod = spec.compressionMethod ?? 0;
+  const uncompressedSize = spec.declaredUncompressedSize ?? spec.content.length;
+  const compressedSize = spec.declaredCompressedSize ?? compressedData.length;
+  const header = Buffer.alloc(30);
+  header.writeUInt32LE(0x04034b50, 0);
+  header.writeUInt16LE(20, 4); // version needed
+  header.writeUInt16LE(spec.generalPurposeBitFlag ?? 0x0800, 6);
+  header.writeUInt16LE(compressionMethod, 8);
+  header.writeUInt16LE(0, 10); // mod time
+  header.writeUInt16LE(0x21, 12); // mod date — an arbitrary valid DOS date
+  header.writeUInt32LE(0, 14); // crc32 — not checked on the read path used here
+  header.writeUInt32LE(compressedSize >>> 0, 18);
+  header.writeUInt32LE(uncompressedSize >>> 0, 22);
+  header.writeUInt16LE(nameBuf.length, 26);
+  header.writeUInt16LE(extraBuf.length, 28);
+  return Buffer.concat([header, nameBuf, extraBuf]);
+}
+
+function buildCentralDirectoryRecord(e: BuiltEntry): Buffer {
+  const { spec, nameBuf, extraBuf, compressedData, offset } = e;
+  const compressionMethod = spec.compressionMethod ?? 0;
+  const uncompressedSize = spec.declaredUncompressedSize ?? spec.content.length;
+  const compressedSize = spec.declaredCompressedSize ?? compressedData.length;
+  const header = Buffer.alloc(46);
+  header.writeUInt32LE(0x02014b50, 0);
+  header.writeUInt16LE((3 << 8) | 20, 4); // version made by — Unix, spec 2.0
+  header.writeUInt16LE(20, 6); // version needed
+  header.writeUInt16LE(spec.generalPurposeBitFlag ?? 0x0800, 8);
+  header.writeUInt16LE(compressionMethod, 10);
+  header.writeUInt16LE(0, 12); // mod time
+  header.writeUInt16LE(0x21, 14); // mod date
+  header.writeUInt32LE(0, 16); // crc32
+  header.writeUInt32LE(compressedSize >>> 0, 20);
+  header.writeUInt32LE(uncompressedSize >>> 0, 24);
+  header.writeUInt16LE(nameBuf.length, 28);
+  header.writeUInt16LE(extraBuf.length, 30);
+  header.writeUInt16LE(0, 32); // file comment length
+  header.writeUInt16LE(0, 34); // disk number start
+  header.writeUInt16LE(0, 36); // internal file attributes
+  header.writeUInt32LE((spec.externalFileAttributes ?? 0) >>> 0, 38);
+  header.writeUInt32LE(offset >>> 0, 42);
+  return Buffer.concat([header, nameBuf, extraBuf]);
+}
+
+/** Assemble a complete ZIP buffer from entry specs, byte by byte. */
+export function buildZip(entries: ZipEntrySpec[], options: ZipBuildOptions = {}): Buffer {
+  const built: BuiltEntry[] = [];
+  const localParts: Buffer[] = [];
+  let cursor = 0;
+
+  for (const spec of entries) {
+    const compressionMethod = spec.compressionMethod ?? 0;
+    const compressedData = compressionMethod === 8 ? deflateRawSync(spec.content) : spec.content;
+    const e: BuiltEntry = {
+      spec,
+      offset: cursor,
+      compressedData,
+      nameBuf: Buffer.from(spec.name, 'utf8'),
+      extraBuf: encodeExtraFields(spec.extraFields ?? []),
+    };
+    const local = buildLocalHeader(e);
+    localParts.push(local, compressedData);
+    cursor += local.length + compressedData.length;
+    built.push(e);
+  }
+
+  const centralParts: Buffer[] = built.map(buildCentralDirectoryRecord);
+  for (const idx of options.duplicateCentralDirectoryRecords ?? []) {
+    centralParts.push(buildCentralDirectoryRecord(built[idx]));
+  }
+  const centralDirectory = Buffer.concat(centralParts);
+  const centralDirectoryOffset = cursor;
+
+  const commentBuf = Buffer.from(options.archiveComment ?? '', 'utf8');
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4); // disk number
+  eocd.writeUInt16LE(0, 6); // disk where CD starts
+  const entryCount = options.declaredEntryCount ?? centralParts.length;
+  eocd.writeUInt16LE(entryCount, 8);
+  eocd.writeUInt16LE(entryCount, 10);
+  eocd.writeUInt32LE(centralDirectory.length >>> 0, 12);
+  eocd.writeUInt32LE(centralDirectoryOffset >>> 0, 16);
+  eocd.writeUInt16LE(commentBuf.length, 20);
+
+  return Buffer.concat([
+    ...localParts,
+    centralDirectory,
+    eocd,
+    commentBuf,
+    options.trailingBytes ?? Buffer.alloc(0),
+  ]);
+}

--- a/backend/src/modules/plugins/archive/zip-inspector.spec.ts
+++ b/backend/src/modules/plugins/archive/zip-inspector.spec.ts
@@ -1,0 +1,345 @@
+import { deflateRawSync } from 'zlib';
+import { inspect } from './zip-inspector';
+import { buildZip, ZipEntrySpec } from './zip-builder';
+import { generateTestKeypair, signManifestBase64 } from './ed25519-test-keys';
+import { minimalDataManifest, minimalProcessManifest } from './test-manifests';
+import { pngLogo, sha256Hex, svgLogo } from './test-fixtures';
+import { PluginRefusalCode } from './refusal-codes';
+
+/** Sign a manifest object and return its raw bytes + a `plugin.json.sig` entry spec. */
+function signedManifestEntries(manifest: unknown): { manifestBytes: Buffer; entries: ZipEntrySpec[] } {
+  const manifestBytes = Buffer.from(JSON.stringify(manifest), 'utf8');
+  const { privateKey } = generateTestKeypair();
+  const sig = signManifestBase64(privateKey, manifestBytes);
+  return {
+    manifestBytes,
+    entries: [
+      { name: 'plugin.json', content: manifestBytes },
+      { name: 'plugin.json.sig', content: Buffer.from(sig, 'utf8') },
+    ],
+  };
+}
+
+async function expectRefusal(buffer: Buffer, code: PluginRefusalCode) {
+  const result = await inspect(buffer);
+  expect(result.ok).toBe(false);
+  if (!result.ok) expect(result.code).toBe(code);
+}
+
+describe('inspect() — happy path', () => {
+  it('accepts a well-formed signed data archive', async () => {
+    const manifest = minimalDataManifest();
+    const { entries } = signedManifestEntries(manifest);
+    const buffer = buildZip([...entries, { name: 'logo.svg', content: svgLogo() }]);
+
+    const result = await inspect(buffer);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.kind).toBe('data');
+    expect(result.id).toBe(manifest.id);
+    expect(result.signature).toBe('unverified'); // signer is not in any trust store
+    expect(result.entryNames.sort()).toEqual(['logo.svg', 'plugin.json', 'plugin.json.sig']);
+  });
+
+  it('resolves to `official` when the signer is a compiled-in official key', async () => {
+    const manifest = minimalDataManifest();
+    const manifestBytes = Buffer.from(JSON.stringify(manifest), 'utf8');
+    const { privateKey, rawPublicKey } = generateTestKeypair();
+    const sig = signManifestBase64(privateKey, manifestBytes);
+    const officialKeys = new Map([['release-2026', rawPublicKey]]);
+    const buffer = buildZip([
+      { name: 'plugin.json', content: manifestBytes },
+      { name: 'plugin.json.sig', content: Buffer.from(sig, 'utf8') },
+      { name: 'logo.svg', content: svgLogo() },
+    ]);
+
+    const result = await inspect(buffer, { officialKeys });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.signature).toBe('official');
+    expect(result.signedByKeyId).toBe('release-2026');
+  });
+
+  it('accepts a well-formed signed process archive and reports its capabilities', async () => {
+    const pluginJs = Buffer.from('module.exports = {};', 'utf8');
+    const logo = pngLogo();
+    const files = { 'plugin.js': sha256Hex(pluginJs), 'logo.png': sha256Hex(logo) };
+    const manifest = minimalProcessManifest(files, {
+      jobs: [{ name: 'sync', cron: '0 * * * *', triggerable: true, labelKey: 'jobs.sync' }],
+    });
+    const { entries } = signedManifestEntries(manifest);
+    const buffer = buildZip([
+      ...entries,
+      { name: 'plugin.js', content: pluginJs },
+      { name: 'logo.png', content: logo },
+    ]);
+
+    const result = await inspect(buffer);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.kind).toBe('process');
+    expect(result.capabilities).toContain('scope:media:read');
+    expect(result.capabilities).toContain('job:sync');
+  });
+});
+
+describe('inspect() — guards', () => {
+  it('PLUGIN_BAD_MAGIC: prepended data / not a zip at all', async () => {
+    await expectRefusal(Buffer.from('not a zip file at all'), 'PLUGIN_BAD_MAGIC');
+  });
+
+  it('PLUGIN_TOO_LARGE: whole archive over the 8 MiB compressed cap', async () => {
+    const buffer = Buffer.alloc(8 * 1024 * 1024 + 1);
+    buffer.set([0x50, 0x4b, 0x03, 0x04], 0);
+    await expectRefusal(buffer, 'PLUGIN_TOO_LARGE');
+  });
+
+  it('PLUGIN_TRAILING_DATA: garbage appended after the EOCD record', async () => {
+    const { entries } = signedManifestEntries(minimalDataManifest());
+    const buffer = buildZip([...entries, { name: 'logo.svg', content: svgLogo() }], {
+      trailingBytes: Buffer.from('x'),
+    });
+    await expectRefusal(buffer, 'PLUGIN_TRAILING_DATA');
+  });
+
+  it('PLUGIN_TRAILING_DATA: two central directories (a second archive concatenated on)', async () => {
+    const { entries } = signedManifestEntries(minimalDataManifest());
+    const one = buildZip([...entries, { name: 'logo.svg', content: svgLogo() }]);
+    const buffer = Buffer.concat([one, one]);
+    await expectRefusal(buffer, 'PLUGIN_TRAILING_DATA');
+  });
+
+  it('PLUGIN_ARCHIVE_COMMENT: nonzero archive comment', async () => {
+    const { entries } = signedManifestEntries(minimalDataManifest());
+    const buffer = buildZip([...entries, { name: 'logo.svg', content: svgLogo() }], {
+      archiveComment: 'hello',
+    });
+    await expectRefusal(buffer, 'PLUGIN_ARCHIVE_COMMENT');
+  });
+
+  it('PLUGIN_TOO_MANY_ENTRIES: more than 4 entries, read from the EOCD', async () => {
+    const buffer = buildZip(
+      ['a', 'b', 'c', 'd', 'e'].map((n) => ({ name: n, content: Buffer.from(n) })),
+    );
+    await expectRefusal(buffer, 'PLUGIN_TOO_MANY_ENTRIES');
+  });
+
+  it('PLUGIN_CONTROL_CHAR: NUL byte in an entry name', async () => {
+    const name = 'logo.svg' + String.fromCharCode(0) + '.js';
+    const buffer = buildZip([{ name, content: svgLogo() }]);
+    await expectRefusal(buffer, 'PLUGIN_CONTROL_CHAR');
+  });
+
+  it('PLUGIN_NOT_NFC: a decomposed-form entry name', async () => {
+    const name = 'logo' + '́' + '.svg'; // combining acute accent, never precomposed
+    const buffer = buildZip([{ name, content: svgLogo() }]);
+    await expectRefusal(buffer, 'PLUGIN_NOT_NFC');
+  });
+
+  it('PLUGIN_PATH_SEPARATOR: a nested path yauzl itself accepts as legal', async () => {
+    const buffer = buildZip([{ name: 'sub/plugin.json', content: Buffer.from('{}') }]);
+    await expectRefusal(buffer, 'PLUGIN_PATH_SEPARATOR');
+  });
+
+  it('PLUGIN_PATH_SEPARATOR: a backslash separator (strictFileNames makes yauzl error)', async () => {
+    const buffer = buildZip([{ name: 'sub\\plugin.json', content: Buffer.from('{}') }]);
+    await expectRefusal(buffer, 'PLUGIN_PATH_SEPARATOR');
+  });
+
+  it('PLUGIN_ABSOLUTE_PATH: a rooted path', async () => {
+    const buffer = buildZip([{ name: '/etc/passwd', content: Buffer.from('x') }]);
+    await expectRefusal(buffer, 'PLUGIN_ABSOLUTE_PATH');
+  });
+
+  it('PLUGIN_ABSOLUTE_PATH: a drive-letter path', async () => {
+    const buffer = buildZip([{ name: 'C:evil.txt', content: Buffer.from('x') }]);
+    await expectRefusal(buffer, 'PLUGIN_ABSOLUTE_PATH');
+  });
+
+  it('PLUGIN_DUPLICATE_ENTRY: the exact same name twice in the central directory', async () => {
+    const buffer = buildZip([{ name: 'plugin.json', content: Buffer.from('{}') }], {
+      duplicateCentralDirectoryRecords: [0],
+    });
+    await expectRefusal(buffer, 'PLUGIN_DUPLICATE_ENTRY');
+  });
+
+  it('PLUGIN_DUPLICATE_ENTRY: two names differing only by case', async () => {
+    const buffer = buildZip([
+      { name: 'logo.svg', content: svgLogo() },
+      { name: 'Logo.svg', content: svgLogo() },
+    ]);
+    await expectRefusal(buffer, 'PLUGIN_DUPLICATE_ENTRY');
+  });
+
+  it('PLUGIN_DUPLICATE_ENTRY: a second logo slot (svg + png together)', async () => {
+    const buffer = buildZip([
+      { name: 'logo.svg', content: svgLogo() },
+      { name: 'logo.png', content: pngLogo() },
+    ]);
+    await expectRefusal(buffer, 'PLUGIN_DUPLICATE_ENTRY');
+  });
+
+  it('PLUGIN_DIRECTORY_ENTRY: the DOS directory attribute bit on a plain-named entry', async () => {
+    const buffer = buildZip([
+      { name: 'logo.svg', content: svgLogo(), externalFileAttributes: 0x10 },
+    ]);
+    await expectRefusal(buffer, 'PLUGIN_DIRECTORY_ENTRY');
+  });
+
+  it('accepts permission bits with no file-type nibble, as python zipfile writes', async () => {
+    // 0o600 << 16 and nothing else: an empty type nibble is not the same as a
+    // type declared to be something other than a regular file. Caught against
+    // an archive written by python's zipfile, which every entry looks like.
+    const permsOnly = (0o600 << 16) >>> 0;
+    const { entries } = signedManifestEntries(minimalDataManifest());
+    const buffer = buildZip(
+      [...entries, { name: 'logo.svg', content: svgLogo() }].map((e) => ({
+        ...e,
+        externalFileAttributes: permsOnly,
+      })),
+    );
+
+    const result = await inspect(buffer);
+    expect(result.ok).toBe(true);
+  });
+
+  it('PLUGIN_SYMLINK: a Unix symlink mode in externalFileAttributes', async () => {
+    const symlinkMode = 0xa1ff; // S_IFLNK | 0777
+    const buffer = buildZip([
+      { name: 'logo.png', content: pngLogo(), externalFileAttributes: (symlinkMode << 16) >>> 0 },
+    ]);
+    await expectRefusal(buffer, 'PLUGIN_SYMLINK');
+  });
+
+  it('PLUGIN_UNEXPECTED_ENTRY: a name outside the closed literal set', async () => {
+    const buffer = buildZip([{ name: 'README.md', content: Buffer.from('hi') }]);
+    await expectRefusal(buffer, 'PLUGIN_UNEXPECTED_ENTRY');
+  });
+
+  it('PLUGIN_ZIP64: a ZIP64 extended-information extra field', async () => {
+    const buffer = buildZip([
+      { name: 'logo.svg', content: svgLogo(), extraFields: [{ id: 0x0001, data: Buffer.alloc(0) }] },
+    ]);
+    await expectRefusal(buffer, 'PLUGIN_ZIP64');
+  });
+
+  it('PLUGIN_DATA_DESCRIPTOR: general-purpose bit 3 set', async () => {
+    const buffer = buildZip([
+      { name: 'logo.svg', content: svgLogo(), generalPurposeBitFlag: 0x0800 | 0x0008 },
+    ]);
+    await expectRefusal(buffer, 'PLUGIN_DATA_DESCRIPTOR');
+  });
+
+  it('PLUGIN_ENCRYPTED: general-purpose bit 0 set', async () => {
+    // compressionMethod: 8 sidesteps yauzl's own store-mode size-consistency
+    // check (which the encryption bit would otherwise fail before we get a look).
+    const buffer = buildZip([
+      {
+        name: 'logo.svg',
+        content: svgLogo(),
+        compressionMethod: 8,
+        generalPurposeBitFlag: 0x0800 | 0x0001,
+      },
+    ]);
+    await expectRefusal(buffer, 'PLUGIN_ENCRYPTED');
+  });
+
+  it('PLUGIN_COMPRESSION_METHOD: a method other than store or deflate', async () => {
+    const buffer = buildZip([{ name: 'logo.svg', content: svgLogo(), compressionMethod: 99 }]);
+    await expectRefusal(buffer, 'PLUGIN_COMPRESSION_METHOD');
+  });
+
+  it('PLUGIN_MANIFEST_TOO_LARGE: plugin.json over the 256 KiB cap', async () => {
+    const content = Buffer.alloc(300 * 1024, 0x7b);
+    const buffer = buildZip([{ name: 'plugin.json', content, compressionMethod: 8 }]);
+    await expectRefusal(buffer, 'PLUGIN_MANIFEST_TOO_LARGE');
+  });
+
+  it('PLUGIN_TOO_LARGE: logo over its 64 KiB cap', async () => {
+    const content = Buffer.alloc(70 * 1024, 0x41);
+    const buffer = buildZip([{ name: 'logo.png', content, compressionMethod: 8 }]);
+    await expectRefusal(buffer, 'PLUGIN_TOO_LARGE');
+  });
+
+  it('PLUGIN_RATIO: a highly-compressible entry over the 100:1 cap', async () => {
+    const content = Buffer.alloc(20000, 0);
+    const buffer = buildZip([{ name: 'logo.svg', content, compressionMethod: 8 }]);
+    await expectRefusal(buffer, 'PLUGIN_RATIO');
+  });
+
+  it('PLUGIN_TOO_LARGE: a lying central directory understates plugin.json size (validateEntrySizes)', async () => {
+    const realContent = Buffer.alloc(5000, 0x41);
+    const buffer = buildZip([
+      {
+        name: 'plugin.json',
+        content: realContent,
+        compressionMethod: 8,
+        declaredUncompressedSize: 100, // the lie: real inflate produces 5000 bytes
+      },
+    ]);
+    await expectRefusal(buffer, 'PLUGIN_TOO_LARGE');
+  });
+
+  it('PLUGIN_BAD_MANIFEST: plugin.json is not valid JSON', async () => {
+    const buffer = buildZip([{ name: 'plugin.json', content: Buffer.from('{not json') }]);
+    await expectRefusal(buffer, 'PLUGIN_BAD_MANIFEST');
+  });
+
+  it('PLUGIN_BAD_MANIFEST: missing a required field', async () => {
+    const manifest = minimalDataManifest();
+    delete (manifest as unknown as Record<string, unknown>).name;
+    const buffer = buildZip([{ name: 'plugin.json', content: Buffer.from(JSON.stringify(manifest)) }]);
+    await expectRefusal(buffer, 'PLUGIN_BAD_MANIFEST');
+  });
+
+  it('PLUGIN_BAD_MANIFEST: an unknown top-level key', async () => {
+    const manifest = { ...minimalDataManifest(), evil: true };
+    const buffer = buildZip([{ name: 'plugin.json', content: Buffer.from(JSON.stringify(manifest)) }]);
+    await expectRefusal(buffer, 'PLUGIN_BAD_MANIFEST');
+  });
+
+  it('PLUGIN_BAD_SIGNATURE: a signature that does not decode to 64 bytes', async () => {
+    const manifestBytes = Buffer.from(JSON.stringify(minimalDataManifest()), 'utf8');
+    const buffer = buildZip([
+      { name: 'plugin.json', content: manifestBytes },
+      { name: 'plugin.json.sig', content: Buffer.from(Buffer.from('too short').toString('base64')) },
+    ]);
+    await expectRefusal(buffer, 'PLUGIN_BAD_SIGNATURE');
+  });
+
+  it('PLUGIN_UNSIGNED: a process-tier archive with no plugin.json.sig entry', async () => {
+    const pluginJs = Buffer.from('module.exports = {};');
+    const logo = pngLogo();
+    const manifest = minimalProcessManifest({ 'plugin.js': sha256Hex(pluginJs), 'logo.png': sha256Hex(logo) });
+    const buffer = buildZip([
+      { name: 'plugin.json', content: Buffer.from(JSON.stringify(manifest)) },
+      { name: 'plugin.js', content: pluginJs },
+      { name: 'logo.png', content: logo },
+    ]);
+    await expectRefusal(buffer, 'PLUGIN_UNSIGNED');
+  });
+
+  it('PLUGIN_TIER_VIOLATION: a data-tier archive carrying plugin.js', async () => {
+    const { entries } = signedManifestEntries(minimalDataManifest());
+    const buffer = buildZip([...entries, { name: 'plugin.js', content: Buffer.from('x') }]);
+    await expectRefusal(buffer, 'PLUGIN_TIER_VIOLATION');
+  });
+
+  it('PLUGIN_TIER_VIOLATION: a process-tier archive missing plugin.js', async () => {
+    const logo = pngLogo();
+    const manifest = minimalProcessManifest({ 'logo.png': sha256Hex(logo) });
+    const { entries } = signedManifestEntries(manifest);
+    const buffer = buildZip([...entries, { name: 'logo.png', content: logo }]);
+    await expectRefusal(buffer, 'PLUGIN_TIER_VIOLATION');
+  });
+
+  it('PLUGIN_FILE_SET_MISMATCH: manifest.files omits an archive entry', async () => {
+    const pluginJs = Buffer.from('module.exports = {};');
+    const logo = pngLogo();
+    // files{} is missing the logo.png hash entirely.
+    const manifest = minimalProcessManifest({ 'plugin.js': sha256Hex(pluginJs) });
+    const { entries } = signedManifestEntries(manifest);
+    const buffer = buildZip([...entries, { name: 'plugin.js', content: pluginJs }, { name: 'logo.png', content: logo }]);
+    await expectRefusal(buffer, 'PLUGIN_FILE_SET_MISMATCH');
+  });
+});

--- a/backend/src/modules/plugins/archive/zip-inspector.ts
+++ b/backend/src/modules/plugins/archive/zip-inspector.ts
@@ -1,0 +1,312 @@
+import { createHash } from 'crypto';
+import * as yauzl from 'yauzl';
+import type { PluginKind, PluginManifest } from '../../../common/plugin-contract';
+import { parseManifest } from './manifest-parser';
+import { PluginRefusal, PluginRefusalCode, refuse } from './refusal-codes';
+import { resolveTrust, OFFICIAL_KEYS, TrustOutcome } from './trust-store';
+import {
+  ED25519_SIGNATURE_LENGTH,
+  LEGAL_ENTRY_NAMES,
+  MAX_ARCHIVE_COMPRESSED_BYTES,
+  MAX_ARCHIVE_ENTRIES,
+  MAX_ENTRY_RATIO,
+  MAX_TOTAL_UNCOMPRESSED_BYTES,
+  PROCESS_ONLY_ENTRY_NAMES,
+  maxUncompressedBytesFor,
+} from './limits';
+
+const ZIP_MAGIC = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+const EOCD_SIGNATURE = Buffer.from([0x50, 0x4b, 0x05, 0x06]);
+const ZIP64_EXTRA_FIELD_ID = 0x0001;
+const DATA_DESCRIPTOR_BIT = 0x0008;
+const DIRECTORY_ATTRIBUTE_BIT = 0x10;
+const UNIX_FILE_TYPE_MASK = 0xf000;
+const UNIX_REGULAR_FILE = 0x8000;
+const MAX_CONTROL_CODE = 0x1f;
+const DEL_CODE = 0x7f;
+const ABSOLUTE_PATH_PATTERN = /^\/|^[A-Za-z]:/;
+
+/** NUL and other control characters — yauzl does not check for these. */
+function hasControlChar(name: string): boolean {
+  for (let i = 0; i < name.length; i++) {
+    const code = name.charCodeAt(i);
+    if (code <= MAX_CONTROL_CODE || code === DEL_CODE) return true;
+  }
+  return false;
+}
+
+export interface InspectOptions {
+  /** Test-only override of the compiled-in official key set. Defaults to {@link OFFICIAL_KEYS}. */
+  officialKeys?: ReadonlyMap<string, Buffer>;
+  /** Admin-registered third-party keys (empty until Phase 7's key registry ships). */
+  thirdPartyKeys?: ReadonlyMap<string, Buffer>;
+  /** `FLIKS_UNSIGNED_PLUGINS` ids — the only way a `process` plugin may ship unsigned. */
+  unsignedProcessAllowlist?: readonly string[];
+}
+
+export interface InspectSuccess {
+  ok: true;
+  id: string;
+  version: string;
+  kind: PluginKind;
+  manifest: PluginManifest;
+  sha256: string;
+  signature: TrustOutcome;
+  signedByKeyId?: string;
+  capabilities: string[];
+  entryNames: string[];
+}
+
+export type InspectResult = InspectSuccess | PluginRefusal;
+
+interface WalkedEntry {
+  name: string;
+  compressedSize: number;
+  uncompressedSize: number;
+}
+
+/**
+ * V1-V7 of the install pipeline (`plans/plugin-system.plan.md`, "Guards,
+ * ordered"). Nothing touches disk. The signature is verified before the
+ * manifest's business rules are even read - refusal order in this
+ * function mirrors the plan's table, not convenience.
+ */
+export async function inspect(buffer: Buffer, options: InspectOptions = {}): Promise<InspectResult> {
+  // V1/V2 - bytes already in RAM; magic + whole-archive size cap, nothing parsed yet.
+  if (buffer.length < 4 || !buffer.subarray(0, 4).equals(ZIP_MAGIC)) {
+    return refuse('PLUGIN_BAD_MAGIC', 'archive does not start with the ZIP local-file-header signature');
+  }
+  if (buffer.length > MAX_ARCHIVE_COMPRESSED_BYTES) {
+    return refuse('PLUGIN_TOO_LARGE', `archive is ${buffer.length} bytes, cap is ${MAX_ARCHIVE_COMPRESSED_BYTES}`);
+  }
+  const ambiguity = checkEocdAmbiguity(buffer);
+  if (ambiguity) return ambiguity;
+  const sha256 = createHash('sha256').update(buffer).digest('hex');
+
+  // V3 - open via the central directory; entry count comes from the EOCD before any entry is read.
+  let zipfile: yauzl.ZipFile;
+  try {
+    zipfile = await yauzl.fromBufferPromise(buffer, {
+      lazyEntries: true,
+      decodeStrings: true,
+      strictFileNames: true,
+      validateEntrySizes: true,
+    });
+  } catch (err) {
+    return refuse(classifyYauzlError(err) ?? 'PLUGIN_MALFORMED_ARCHIVE', String(err));
+  }
+  if (zipfile.comment.length > 0) {
+    return refuse('PLUGIN_ARCHIVE_COMMENT', 'archive carries a nonzero comment');
+  }
+  if (zipfile.entryCount > MAX_ARCHIVE_ENTRIES) {
+    return refuse('PLUGIN_TOO_MANY_ENTRIES', `${zipfile.entryCount} entries, cap is ${MAX_ARCHIVE_ENTRIES}`);
+  }
+
+  // V4 - walk the central directory. One failure refuses the whole archive.
+  const seenExact = new Set<string>();
+  const seenLower = new Set<string>();
+  let sawLogo = false;
+  let totalUncompressed = 0;
+  const walked: WalkedEntry[] = [];
+  const entryBuffers = new Map<string, () => Promise<Buffer>>();
+
+  try {
+    for await (const entry of zipfile.eachEntry()) {
+      const name = entry.fileName;
+
+      if (hasControlChar(name)) {
+        return refuse('PLUGIN_CONTROL_CHAR', `control character in entry name ${JSON.stringify(name)}`);
+      }
+      if (name !== name.normalize('NFC')) {
+        return refuse('PLUGIN_NOT_NFC', `entry name ${JSON.stringify(name)} is not NFC-normalised`);
+      }
+      if (name.includes('/')) {
+        return refuse('PLUGIN_PATH_SEPARATOR', `entry name ${JSON.stringify(name)} contains a path separator`);
+      }
+      if (ABSOLUTE_PATH_PATTERN.test(name)) {
+        return refuse('PLUGIN_ABSOLUTE_PATH', `entry name ${JSON.stringify(name)} is an absolute path`);
+      }
+      if ((entry.externalFileAttributes & DIRECTORY_ATTRIBUTE_BIT) !== 0) {
+        return refuse('PLUGIN_DIRECTORY_ENTRY', `entry ${JSON.stringify(name)} is flagged as a directory`);
+      }
+      // Judge the type only when the writer declared one: python's zipfile and
+      // every DOS-era tool emit permission bits with an empty type nibble, and
+      // reading that as "not a regular file" refuses well-formed archives.
+      const fileType =
+        (entry.externalFileAttributes >>> 16) & UNIX_FILE_TYPE_MASK;
+      if (fileType !== 0 && fileType !== UNIX_REGULAR_FILE) {
+        return refuse('PLUGIN_SYMLINK', `entry ${JSON.stringify(name)} is not a regular file (type 0${fileType.toString(8)})`);
+      }
+      if (seenExact.has(name) || seenLower.has(name.toLowerCase())) {
+        return refuse('PLUGIN_DUPLICATE_ENTRY', `duplicate entry ${JSON.stringify(name)}`);
+      }
+      seenExact.add(name);
+      seenLower.add(name.toLowerCase());
+
+      if (!(LEGAL_ENTRY_NAMES as readonly string[]).includes(name)) {
+        return refuse('PLUGIN_UNEXPECTED_ENTRY', `${JSON.stringify(name)} is not one of the legal entry names`);
+      }
+      if (name === 'logo.svg' || name === 'logo.png') {
+        if (sawLogo) return refuse('PLUGIN_DUPLICATE_ENTRY', 'archive carries more than one logo entry');
+        sawLogo = true;
+      }
+      if (entry.extraFields.some((f) => f.id === ZIP64_EXTRA_FIELD_ID)) {
+        return refuse('PLUGIN_ZIP64', `entry ${JSON.stringify(name)} carries a ZIP64 extra field`);
+      }
+      if ((entry.generalPurposeBitFlag & DATA_DESCRIPTOR_BIT) !== 0) {
+        return refuse('PLUGIN_DATA_DESCRIPTOR', `entry ${JSON.stringify(name)} uses a data descriptor`);
+      }
+      if (entry.isEncrypted()) {
+        return refuse('PLUGIN_ENCRYPTED', `entry ${JSON.stringify(name)} is encrypted`);
+      }
+      if (entry.compressionMethod !== 0 && entry.compressionMethod !== 8) {
+        return refuse('PLUGIN_COMPRESSION_METHOD', `entry ${JSON.stringify(name)} uses compression method ${entry.compressionMethod}`);
+      }
+      const cap = maxUncompressedBytesFor(name);
+      if (entry.uncompressedSize > cap) {
+        const code: PluginRefusalCode = name === 'plugin.json' ? 'PLUGIN_MANIFEST_TOO_LARGE' : 'PLUGIN_TOO_LARGE';
+        return refuse(code, `entry ${JSON.stringify(name)} declares ${entry.uncompressedSize} bytes, cap is ${cap}`);
+      }
+      if (entry.compressedSize > 0) {
+        const ratio = entry.uncompressedSize / entry.compressedSize;
+        if (ratio > MAX_ENTRY_RATIO) {
+          return refuse('PLUGIN_RATIO', `entry ${JSON.stringify(name)} has a ${ratio.toFixed(1)}:1 compression ratio`);
+        }
+      } else if (entry.uncompressedSize > 0) {
+        return refuse('PLUGIN_RATIO', `entry ${JSON.stringify(name)} declares content from zero compressed bytes`);
+      }
+
+      totalUncompressed += entry.uncompressedSize;
+      walked.push({ name, compressedSize: entry.compressedSize, uncompressedSize: entry.uncompressedSize });
+      entryBuffers.set(name, () => readEntry(zipfile, entry));
+    }
+  } catch (err) {
+    // Refuse rather than throw: an unclassified malformation is still the
+    // archive's fault, and the caller's contract is a code.
+    return refuse(classifyYauzlError(err) ?? 'PLUGIN_MALFORMED_ARCHIVE', String(err));
+  }
+
+  if (totalUncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES) {
+    return refuse('PLUGIN_TOO_LARGE', `archive declares ${totalUncompressed} uncompressed bytes, cap is ${MAX_TOTAL_UNCOMPRESSED_BYTES}`);
+  }
+
+  // V5 - inflate plugin.json (+ its signature) into memory. Nothing else is read yet.
+  const manifestReader = entryBuffers.get('plugin.json');
+  if (!manifestReader) {
+    return refuse('PLUGIN_BAD_MANIFEST', 'archive has no plugin.json entry');
+  }
+  let manifestBytes: Buffer;
+  let sigBytes: Buffer | null = null;
+  try {
+    manifestBytes = await manifestReader();
+    const sigReader = entryBuffers.get('plugin.json.sig');
+    if (sigReader) {
+      const sigText = (await sigReader()).toString('utf8').trim();
+      sigBytes = Buffer.from(sigText, 'base64');
+    }
+  } catch (err) {
+    // A lying central-directory entry surfaces here as a stream error - the
+    // one guard `validateEntrySizes` implements that we cannot from outside.
+    return refuse('PLUGIN_TOO_LARGE', `entry content did not match its declared size: ${String(err)}`);
+  }
+
+  // V6 - verify Ed25519 before a single business rule from the manifest is trusted.
+  if (sigBytes && sigBytes.length !== ED25519_SIGNATURE_LENGTH) {
+    return refuse('PLUGIN_BAD_SIGNATURE', `signature is ${sigBytes.length} bytes, expected ${ED25519_SIGNATURE_LENGTH}`);
+  }
+  const officialKeys = options.officialKeys ?? OFFICIAL_KEYS;
+  const trust = resolveTrust(manifestBytes, sigBytes, officialKeys, options.thirdPartyKeys ?? new Map());
+
+  // V7 - only now is the manifest content itself read.
+  const manifest = parseManifest(manifestBytes);
+  if (!manifest) {
+    return refuse('PLUGIN_BAD_MANIFEST', 'plugin.json failed structural validation');
+  }
+  const hasPluginJs = entryBuffers.has('plugin.js');
+  if (manifest.kind === 'data' && hasPluginJs) {
+    return refuse('PLUGIN_TIER_VIOLATION', 'a data-tier archive may not carry plugin.js');
+  }
+  if (manifest.kind === 'process' && !hasPluginJs) {
+    return refuse('PLUGIN_TIER_VIOLATION', 'a process-tier archive must carry plugin.js');
+  }
+  if (manifest.kind === 'process') {
+    if (trust.trust === 'unsigned' && !(options.unsignedProcessAllowlist ?? []).includes(manifest.id)) {
+      return refuse('PLUGIN_UNSIGNED', 'process-tier plugins must be signed unless allowlisted');
+    }
+    const codeNames = new Set(
+      walked.map((w) => w.name).filter((n) => PROCESS_ONLY_ENTRY_NAMES.has(n) || n.startsWith('logo.')),
+    );
+    const declared = new Set(Object.keys(manifest.files));
+    const mismatch = [...codeNames].some((n) => !declared.has(n)) || [...declared].some((n) => !codeNames.has(n));
+    if (mismatch) {
+      return refuse('PLUGIN_FILE_SET_MISMATCH', 'archive entries and manifest.files disagree');
+    }
+  }
+
+  return {
+    ok: true,
+    id: manifest.id,
+    version: manifest.version,
+    kind: manifest.kind,
+    manifest,
+    sha256,
+    signature: trust.trust,
+    signedByKeyId: trust.signedByKeyId,
+    capabilities: deriveCapabilities(manifest),
+    entryNames: walked.map((w) => w.name),
+  };
+}
+
+function readEntry(zipfile: yauzl.ZipFile, entry: yauzl.Entry): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    zipfile.openReadStream(entry, (err, stream) => {
+      if (err) return reject(err);
+      const chunks: Buffer[] = [];
+      stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+      stream.on('end', () => resolve(Buffer.concat(chunks)));
+      stream.on('error', reject);
+    });
+  });
+}
+
+/**
+ * Two central directories / trailing data: the raw signature bytes must
+ * occur exactly once in the buffer. A second occurrence - an appended
+ * archive, or a decoy planted earlier - means a different tool reading
+ * the same bytes (a registry reviewer's `unzip -l`) can disagree with
+ * what this code is about to parse.
+ */
+function checkEocdAmbiguity(buffer: Buffer): PluginRefusal | null {
+  const first = buffer.indexOf(EOCD_SIGNATURE);
+  const last = buffer.lastIndexOf(EOCD_SIGNATURE);
+  if (first !== -1 && first !== last) {
+    return refuse('PLUGIN_TRAILING_DATA', 'archive contains more than one end-of-central-directory signature');
+  }
+  return null;
+}
+
+/** Map yauzl's own thrown/emitted errors - generic `Error` objects - onto our typed codes. */
+function classifyYauzlError(err: unknown): PluginRefusalCode | null {
+  const message = err instanceof Error ? err.message : String(err);
+  if (/invalid characters in fileName/.test(message)) return 'PLUGIN_PATH_SEPARATOR';
+  if (/absolute path/.test(message)) return 'PLUGIN_ABSOLUTE_PATH';
+  if (/invalid relative path/.test(message)) return 'PLUGIN_PATH_SEPARATOR';
+  if (/strong encryption/.test(message)) return 'PLUGIN_ENCRYPTED';
+  if (/Invalid comment length/.test(message)) return 'PLUGIN_TRAILING_DATA';
+  if (/compressed\/uncompressed size mismatch/.test(message)) return 'PLUGIN_TOO_LARGE';
+  if (/unsupported compression method/.test(message)) return 'PLUGIN_COMPRESSION_METHOD';
+  return null;
+}
+
+/** Lightweight capability summary for the (future) consent sheet - not the sheet itself. */
+function deriveCapabilities(manifest: PluginManifest): string[] {
+  const caps: string[] = [];
+  for (const c of manifest.ui?.contributions ?? []) caps.push(`ui:${c.slot}`);
+  for (const p of manifest.ui?.configPages ?? []) caps.push(`config:${p.id}`);
+  if (manifest.events?.length) caps.push('webhook');
+  if (manifest.kind === 'process') {
+    for (const s of manifest.scopes) caps.push(`scope:${s}`);
+    for (const j of manifest.jobs ?? []) caps.push(`job:${j.name}`);
+  }
+  return caps;
+}


### PR DESCRIPTION
PR 3.3. The plan's deliverable for this one is explicitly *the spec file* — one fixture per guard, each asserting a specific refusal code — so that is what this is built around. **51 tests, +50 on the baseline.**

**Scope.** The validator, the guards, signature verification, and staging extraction, as plain functions. No controller, no entity, no migration, nothing registered in `app.module.ts` — there is nowhere to install a plugin *to* yet, and wiring endpoints into a void is not this PR's job. V9 (fsync + atomic rename into place) waits for a destination.

**Why the order matters.** Signature is verified before a single byte reaches disk. The archive never supplies a filesystem path: four literal filenames, matched by `===` against a compiled-in set, written to `join(stagingDir, thatSameLiteral)`. Traversal is not mitigated, it is structurally impossible.

**`yauzl` is the one bought dependency.** It reads the central directory before inflating, so the bomb budget is known in advance instead of discovered post-mortem, and `validateEntrySizes` errors mid-stream on a central directory that lies — the one guard that cannot be implemented from outside the library. `semver` is promoted from transitive to declared.

**The fixtures are assembled byte by byte**, because no normal zip writer produces a ZIP64 sentinel, general-purpose bit 3, duplicate central-directory entries, a symlink mode, a second central directory, or a central directory that understates a size.

## One bug found, and how

The spec builds its fixtures with its own builder, so it can only catch what that builder can express. I ran the validator against archives written by **python's `zipfile`** instead — a genuinely different implementation, which is the same class of mismatch the plan worries about when it notes the registry pipeline uses a second ZIP implementation.

Every well-formed archive was refused as `PLUGIN_SYMLINK`.

The guard was the plan's own formula, `mode && (mode & 0xF000) !== 0x8000`. But `mode` being nonzero means *some permission bits are set*, not *a file type was declared*. Python writes `0o600 << 16` with an empty type nibble, as do DOS-era writers — so the check read "no type declared" as "declared to be something other than a regular file" and refused. Real plugin authors would have hit this on their first upload.

Fixed to judge the type only when one is actually declared, with a regression test built from permission-bits-only attributes. After the fix, the python-written archive inspects clean (`kind=data`, and `official` when its signer is supplied as an official key) while the traversal and directory variants are still refused.

**Also changed from the agent's first pass:** an unclassified yauzl error was reported as `PLUGIN_BAD_MAGIC`, which claims a cause that was never established — a caller branching on that code would be misled. It now has its own `PLUGIN_MALFORMED_ARCHIVE`, and the sibling path that *threw* on an unclassified error refuses with it too, so the caller's contract is always a code.

**Trust store ships empty**, with a comment pointing at 8.1 as the populator. An empty store makes a validly-signed archive `unverified` — never `official`, never a crash. Worth knowing before the consent UI lands, so it is not mistaken for a bug.

Verified: `tsc` 0, suite 85/824/29 green.