### PR TITLE
feat(plugins): add the three plugin tables and the data-tier validator

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -29,6 +29,7 @@ import { ImportsModule } from './modules/imports/imports.module';
 import { FilesystemModule } from './modules/filesystem/filesystem.module';
 import { SetupChecklistModule } from './modules/setup-checklist/setup-checklist.module';
 import { CountsModule } from './modules/counts/counts.module';
+import { PluginsModule } from './modules/plugins/plugins.module';
 import { CommonModule } from './common/common.module';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
@@ -105,6 +106,7 @@ import { join } from 'path';
     FilesystemModule,
     SetupChecklistModule,
     CountsModule,
+    PluginsModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/migrations/1782800000000-create-plugin-tables.ts
+++ b/backend/src/migrations/1782800000000-create-plugin-tables.ts
@@ -1,0 +1,68 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/** The three plugin tables (`plans/plugin-system.plan.md`, "Where plugin storage lives").
+ *  All three are new and empty on upgrade. */
+export class CreatePluginTables1782800000000 implements MigrationInterface {
+  name = 'CreatePluginTables1782800000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "plugin_packages_origin_enum" AS ENUM ('catalog', 'manual')
+    `);
+    await queryRunner.query(`
+      CREATE TYPE "plugin_packages_status_enum" AS ENUM ('active', 'failed')
+    `);
+    await queryRunner.query(`
+      CREATE TABLE "plugin_packages" (
+        "id" SERIAL PRIMARY KEY,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "pluginId" varchar NOT NULL,
+        "version" varchar NOT NULL,
+        "archive" bytea NOT NULL,
+        "origin" "plugin_packages_origin_enum" NOT NULL,
+        "signature" varchar NOT NULL,
+        "verifiedByKeyId" varchar,
+        "manifest" jsonb NOT NULL,
+        "status" "plugin_packages_status_enum" NOT NULL DEFAULT 'active',
+        CONSTRAINT "UQ_plugin_packages_pluginId" UNIQUE ("pluginId")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "plugin_sources" (
+        "id" SERIAL PRIMARY KEY,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "url" varchar NOT NULL,
+        "enabled" boolean NOT NULL DEFAULT true,
+        "publicKey" bytea,
+        "lastRefreshedAt" timestamptz,
+        "lastRefreshError" text,
+        "cachedCatalog" jsonb
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "plugin_registrations" (
+        "id" SERIAL PRIMARY KEY,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "pluginId" varchar NOT NULL,
+        "ingestRoots" text[] NOT NULL DEFAULT '{}',
+        "scopes" text[] NOT NULL DEFAULT '{}',
+        "enabled" boolean NOT NULL DEFAULT true,
+        "manifest" jsonb NOT NULL,
+        CONSTRAINT "UQ_plugin_registrations_pluginId" UNIQUE ("pluginId")
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "plugin_registrations"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "plugin_sources"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "plugin_packages"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "plugin_packages_status_enum"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "plugin_packages_origin_enum"`);
+  }
+}

--- a/backend/src/modules/plugins/archive/manifest-parser.ts
+++ b/backend/src/modules/plugins/archive/manifest-parser.ts
@@ -6,7 +6,8 @@ import type {
 } from '../../../common/plugin-contract';
 import { PluginScope } from '../../../common/plugin-contract';
 
-const BASE_KEYS = new Set([
+/** Legal top-level keys on a `data` manifest; reused by the data-tier validator. */
+export const BASE_KEYS = new Set([
   'id',
   'pluginApi',
   'name',

--- a/backend/src/modules/plugins/archive/refusal-codes.ts
+++ b/backend/src/modules/plugins/archive/refusal-codes.ts
@@ -30,6 +30,17 @@ export type PluginRefusalCode =
   | 'PLUGIN_TIER_VIOLATION'
   | 'PLUGIN_BAD_MANIFEST'
   | 'PLUGIN_BAD_LOGO'
+  /** `data`-tier manifest field bans (see `PluginManifestBase` deltas) — each
+   *  names the process-only field it caught, so a refusal is attributable. */
+  | 'PLUGIN_DATA_HAS_FILES'
+  | 'PLUGIN_DATA_HAS_ROUTES'
+  | 'PLUGIN_DATA_HAS_DATABASE'
+  | 'PLUGIN_DATA_HAS_JOBS'
+  | 'PLUGIN_DATA_HAS_INGEST_ROOTS'
+  | 'PLUGIN_DATA_HAS_MEMORY_MB'
+  | 'PLUGIN_DATA_HAS_RUNTIME'
+  | 'PLUGIN_DATA_HAS_PERMISSIONS'
+  | 'PLUGIN_DATA_HAS_CHECKLIST'
   /** yauzl refused the archive and no more specific guard claimed it. Never
    *  report a specific cause we did not actually establish. */
   | 'PLUGIN_MALFORMED_ARCHIVE';

--- a/backend/src/modules/plugins/data-tier-manifest.validator.spec.ts
+++ b/backend/src/modules/plugins/data-tier-manifest.validator.spec.ts
@@ -1,0 +1,68 @@
+import { validateDataTierManifest } from './data-tier-manifest.validator';
+import { minimalDataManifest, minimalProcessManifest } from './archive/test-manifests';
+import { PluginRefusalCode } from './archive/refusal-codes';
+
+function expectRefusal(manifest: unknown, code: PluginRefusalCode) {
+  const result = validateDataTierManifest(manifest as Parameters<typeof validateDataTierManifest>[0]);
+  expect(result.ok).toBe(false);
+  if (!result.ok) expect(result.code).toBe(code);
+}
+
+describe('validateDataTierManifest()', () => {
+  it('accepts a minimal data manifest', () => {
+    expect(validateDataTierManifest(minimalDataManifest()).ok).toBe(true);
+  });
+
+  it('accepts a data manifest using provides.* and events[].webhook', () => {
+    const manifest = minimalDataManifest({
+      provides: { indexers: [{ id: 'x' }] },
+      events: [{ webhook: 'https://example.invalid/hook' }],
+    });
+    expect(validateDataTierManifest(manifest).ok).toBe(true);
+  });
+
+  it('is a no-op for a process manifest', () => {
+    const manifest = minimalProcessManifest({ 'plugin.js': 'f'.repeat(64) });
+    expect(validateDataTierManifest(manifest).ok).toBe(true);
+  });
+
+  it('PLUGIN_DATA_HAS_FILES: refuses a data manifest carrying a files map (incl. plugin.js)', () => {
+    expectRefusal({ ...minimalDataManifest(), files: { 'plugin.js': 'f'.repeat(64) } }, 'PLUGIN_DATA_HAS_FILES');
+  });
+
+  it('PLUGIN_DATA_HAS_ROUTES: refuses a data manifest declaring routes', () => {
+    expectRefusal({ ...minimalDataManifest(), routes: [] }, 'PLUGIN_DATA_HAS_ROUTES');
+  });
+
+  it('PLUGIN_DATA_HAS_DATABASE: refuses a data manifest declaring a database schema', () => {
+    expectRefusal({ ...minimalDataManifest(), database: { schema: true, coreRefs: [] } }, 'PLUGIN_DATA_HAS_DATABASE');
+  });
+
+  it('PLUGIN_DATA_HAS_JOBS: refuses a data manifest declaring jobs', () => {
+    expectRefusal({ ...minimalDataManifest(), jobs: [] }, 'PLUGIN_DATA_HAS_JOBS');
+  });
+
+  it('PLUGIN_DATA_HAS_INGEST_ROOTS: refuses a data manifest declaring ingestRoots', () => {
+    expectRefusal({ ...minimalDataManifest(), ingestRoots: [] }, 'PLUGIN_DATA_HAS_INGEST_ROOTS');
+  });
+
+  it('PLUGIN_DATA_HAS_MEMORY_MB: refuses a data manifest declaring memoryMb', () => {
+    expectRefusal({ ...minimalDataManifest(), memoryMb: 256 }, 'PLUGIN_DATA_HAS_MEMORY_MB');
+  });
+
+  it('PLUGIN_DATA_HAS_RUNTIME: refuses a data manifest declaring runtime', () => {
+    expectRefusal({ ...minimalDataManifest(), runtime: 'node' }, 'PLUGIN_DATA_HAS_RUNTIME');
+  });
+
+  it('PLUGIN_DATA_HAS_PERMISSIONS: refuses a data manifest declaring permissions', () => {
+    expectRefusal({ ...minimalDataManifest(), permissions: [] }, 'PLUGIN_DATA_HAS_PERMISSIONS');
+  });
+
+  it('PLUGIN_DATA_HAS_CHECKLIST: refuses a data manifest declaring a checklist', () => {
+    expectRefusal({ ...minimalDataManifest(), checklist: [] }, 'PLUGIN_DATA_HAS_CHECKLIST');
+  });
+
+  it('PLUGIN_BAD_MANIFEST: refuses an unknown top-level key not covered by a specific rule', () => {
+    expectRefusal({ ...minimalDataManifest(), legacyPaths: {} }, 'PLUGIN_BAD_MANIFEST');
+  });
+});

--- a/backend/src/modules/plugins/data-tier-manifest.validator.ts
+++ b/backend/src/modules/plugins/data-tier-manifest.validator.ts
@@ -1,0 +1,35 @@
+import type { PluginManifest } from '../../common/plugin-contract';
+import { refuse, type PluginRefusal, type PluginRefusalCode, BASE_KEYS } from './archive';
+
+export interface DataTierValidationSuccess {
+  ok: true;
+}
+export type DataTierValidationResult = DataTierValidationSuccess | PluginRefusal;
+
+/** Process-only keys, each refused on `data` with its own code so the exact violation is nameable. */
+const PROCESS_ONLY_KEY_CODES: [string, PluginRefusalCode][] = [
+  ['files', 'PLUGIN_DATA_HAS_FILES'],
+  ['routes', 'PLUGIN_DATA_HAS_ROUTES'],
+  ['database', 'PLUGIN_DATA_HAS_DATABASE'],
+  ['jobs', 'PLUGIN_DATA_HAS_JOBS'],
+  ['ingestRoots', 'PLUGIN_DATA_HAS_INGEST_ROOTS'],
+  ['memoryMb', 'PLUGIN_DATA_HAS_MEMORY_MB'],
+  ['runtime', 'PLUGIN_DATA_HAS_RUNTIME'],
+  ['permissions', 'PLUGIN_DATA_HAS_PERMISSIONS'],
+  ['checklist', 'PLUGIN_DATA_HAS_CHECKLIST'],
+];
+
+/** Runtime re-check of the `data` tier's field ban for a manifest that arrived as JSON.
+ *  A no-op on `process`. */
+export function validateDataTierManifest(manifest: PluginManifest): DataTierValidationResult {
+  if (manifest.kind !== 'data') return { ok: true };
+
+  const raw = manifest as unknown as Record<string, unknown>;
+  for (const [key, code] of PROCESS_ONLY_KEY_CODES) {
+    if (key in raw) return refuse(code, `a data-tier manifest may not declare "${key}"`);
+  }
+  for (const key of Object.keys(raw)) {
+    if (!BASE_KEYS.has(key)) return refuse('PLUGIN_BAD_MANIFEST', `unknown top-level key "${key}"`);
+  }
+  return { ok: true };
+}

--- a/backend/src/modules/plugins/entities/plugin-package.entity.ts
+++ b/backend/src/modules/plugins/entities/plugin-package.entity.ts
@@ -1,0 +1,41 @@
+import { Entity, Column } from 'typeorm';
+import { BaseEntity } from '../../../common/entities/base.entity';
+import type { PluginManifest } from '../../../common/plugin-contract';
+import type { TrustOutcome } from '../archive/trust-store';
+
+export const PLUGIN_PACKAGE_ORIGINS = ['catalog', 'manual'] as const;
+export type PluginPackageOrigin = (typeof PLUGIN_PACKAGE_ORIGINS)[number];
+
+export const PLUGIN_PACKAGE_STATUSES = ['active', 'failed'] as const;
+export type PluginPackageStatus = (typeof PLUGIN_PACKAGE_STATUSES)[number];
+
+/** The installed artifact — one row per plugin id, replaced in place on upgrade. */
+@Entity('plugin_packages')
+export class PluginPackage extends BaseEntity {
+  /** Immutable business key; unique so a reinstall upserts rather than duplicates. */
+  @Column({ unique: true })
+  pluginId: string;
+
+  @Column()
+  version: string;
+
+  /** The ZIP bytes, so an install survives an image rebuild and a volume wipe. */
+  @Column({ type: 'bytea' })
+  archive: Buffer;
+
+  @Column({ type: 'enum', enum: PLUGIN_PACKAGE_ORIGINS })
+  origin: PluginPackageOrigin;
+
+  @Column({ type: 'varchar' })
+  signature: TrustOutcome;
+
+  @Column({ type: 'varchar', nullable: true })
+  verifiedByKeyId: string | null;
+
+  @Column({ type: 'jsonb' })
+  manifest: PluginManifest;
+
+  /** `failed` on a P4 activation failure; the row (and archive) stand regardless. */
+  @Column({ type: 'enum', enum: PLUGIN_PACKAGE_STATUSES, default: 'active' })
+  status: PluginPackageStatus;
+}

--- a/backend/src/modules/plugins/entities/plugin-registration.entity.ts
+++ b/backend/src/modules/plugins/entities/plugin-registration.entity.ts
@@ -1,0 +1,25 @@
+import { Entity, Column } from 'typeorm';
+import { BaseEntity } from '../../../common/entities/base.entity';
+import type { PluginManifest, PluginScope } from '../../../common/plugin-contract';
+
+/** Per-install runtime grants — one row per installed plugin. */
+@Entity('plugin_registrations')
+export class PluginRegistration extends BaseEntity {
+  @Column({ unique: true })
+  pluginId: string;
+
+  /** Allowlist `library.ingest` paths are checked against; admin-editable after install. */
+  @Column({ type: 'text', array: true, default: () => "'{}'" })
+  ingestRoots: string[];
+
+  /** Scopes consented to at install, a subset of the manifest's declared `scopes`. */
+  @Column({ type: 'text', array: true, default: () => "'{}'" })
+  scopes: PluginScope[];
+
+  @Column({ default: true })
+  enabled: boolean;
+
+  /** Cached for `GET /api/plugins/ui`; refreshed at hello, manual refresh, and the plugin's own notify. */
+  @Column({ type: 'jsonb' })
+  manifest: PluginManifest;
+}

--- a/backend/src/modules/plugins/entities/plugin-source.entity.ts
+++ b/backend/src/modules/plugins/entities/plugin-source.entity.ts
@@ -1,0 +1,26 @@
+import { Entity, Column } from 'typeorm';
+import { BaseEntity } from '../../../common/entities/base.entity';
+
+/** A configured catalog source (an admin-added URL); the official one is just the seeded first row. */
+@Entity('plugin_sources')
+export class PluginSource extends BaseEntity {
+  @Column()
+  url: string;
+
+  @Column({ default: true })
+  enabled: boolean;
+
+  /** Verifies this source's signed `catalog.json`; null defers to the compiled-in official key. */
+  @Column({ type: 'bytea', nullable: true })
+  publicKey: Buffer | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  lastRefreshedAt: Date | null;
+
+  @Column({ type: 'text', nullable: true })
+  lastRefreshError: string | null;
+
+  /** Opaque — the signed `catalog.json` shape isn't defined until the catalog-client phase. */
+  @Column({ type: 'jsonb', nullable: true })
+  cachedCatalog: Record<string, unknown> | null;
+}

--- a/backend/src/modules/plugins/plugins.module.ts
+++ b/backend/src/modules/plugins/plugins.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PluginPackage } from './entities/plugin-package.entity';
+import { PluginSource } from './entities/plugin-source.entity';
+import { PluginRegistration } from './entities/plugin-registration.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([PluginPackage, PluginSource, PluginRegistration])],
+  exports: [TypeOrmModule],
+})
+export class PluginsModule {}


### PR DESCRIPTION
PR 6.1, opening phase 6 — and picking up the persistence #897 deliberately deferred.

**Where an installed plugin lives** is decided by one constraint in the plan: it must survive an image rebuild, a `docker volume rm` and a uid change. So the ZIP bytes live in `plugin_packages.archive`, and the extracted files are re-materialised from there into a runtime dir owned by whatever uid is running. Uninstall is a `DELETE`.

`plugin_sources` is a catalog and its cached index; `plugin_registrations` holds what was consented at install — including `ingestRoots`, the allowlist every `library.ingest` path is later checked against.

**Every column traces to a line in the plan**, listed in the commit. Columns nobody has asked for are migrations to undo later, so the load-time states the supervisor will eventually persist (`quarantined`, `tampered`, `incompatible`) are deliberately absent — `status` is `active | failed` and grows when something writes the rest.

**The validator** is the runtime half of what the contract types already make a compile error. A manifest that arrives as JSON can still claim `routes`, `database`, `jobs` or `ingestRoots` on a tier that executes nothing, so each gets its own refusal code rather than a generic "bad manifest".

## Verification

The migration was checked the way the plan itself specifies for phase 4 — **run it, then ask `migration:generate` whether anything is left to do.** Zero plugin-related statements, so the entities and the migration produce the same schema. It caught a genuine disagreement on the first pass: the migration used `timestamptz` for the timestamps, following a neighbour's precedent, but `BaseEntity`'s bare `@CreateDateColumn()` synchronizes to plain `timestamp`.

Also: up → revert → up against a throwaway Postgres, inspecting the schema at each step; and the dev stack, which runs `synchronize: true`, booted and created all three tables from the entity definitions alone.

`tsc` 0, suite **86/837/29** (+13, the new validator tests).

## Two things worth knowing

**That same drift check surfaced a pre-existing one, filed as #898.** Nine tables disagree between a migrated database and a synchronized one, and `migration:generate` currently wants to `DROP`/`ADD` 18 `createdAt`/`updatedAt` columns — committing its output today would destroy those timestamps in production. It also blocks the plan's phase-4 acceptance test, which assumes a clean generate.

**Local dev stacks need a dependency refresh after #897.** The container's `node_modules` is baked into the image rather than bind-mounted, so `yauzl` is missing until you rebuild or `npm install` inside it — the symptom is implicit-any errors in `zip-inspector.ts`. CI and the published image are unaffected; they install from the lockfile.