### PR TITLE
feat(plugins): load installed plugins into a registry at boot

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -52,6 +52,7 @@
         "@types/node": "^22.10.7",
         "@types/passport-jwt": "^4.0.1",
         "@types/pg": "^8.20.0",
+        "@types/semver": "^7.8.0",
         "@types/supertest": "^6.0.2",
         "@types/yauzl": "^3.4.0",
         "eslint": "^9.18.0",
@@ -3440,6 +3441,13 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/backend/package.json
+++ b/backend/package.json
@@ -68,6 +68,7 @@
     "@types/node": "^22.10.7",
     "@types/passport-jwt": "^4.0.1",
     "@types/pg": "^8.20.0",
+    "@types/semver": "^7.8.0",
     "@types/supertest": "^6.0.2",
     "@types/yauzl": "^3.4.0",
     "eslint": "^9.18.0",

--- a/backend/src/modules/plugins/archive/extract.ts
+++ b/backend/src/modules/plugins/archive/extract.ts
@@ -107,7 +107,7 @@ function hexEqual(a: string, b: string): boolean {
 }
 
 /** PNG by magic bytes; SVG must parse as XML rooted at `<svg>` with no script content. */
-function sniffLogo(name: string, content: Buffer): PluginRefusal | null {
+export function sniffLogo(name: string, content: Buffer): PluginRefusal | null {
   if (name === 'logo.png') {
     if (!content.subarray(0, PNG_MAGIC.length).equals(PNG_MAGIC)) {
       return refuse('PLUGIN_BAD_LOGO', 'logo.png does not start with the PNG magic bytes');
@@ -128,4 +128,41 @@ function sniffLogo(name: string, content: Buffer): PluginRefusal | null {
     return refuse('PLUGIN_BAD_LOGO', 'logo.svg contains a javascript: URI');
   }
   return null;
+}
+
+/** Read a subset of named entries out of an already-in-memory archive, ignoring the rest. */
+export async function readArchiveEntries(archive: Buffer, wanted: ReadonlySet<string>): Promise<Map<string, Buffer>> {
+  const zipfile = await yauzl.fromBufferPromise(archive, {
+    lazyEntries: true,
+    decodeStrings: true,
+    strictFileNames: true,
+    validateEntrySizes: true,
+  });
+  const found = new Map<string, Buffer>();
+  for await (const entry of zipfile.eachEntry()) {
+    if (!wanted.has(entry.fileName)) continue;
+    found.set(entry.fileName, await readEntry(zipfile, entry));
+    if (found.size === wanted.size) break;
+  }
+  return found;
+}
+
+export interface VerifiedLogo {
+  contentType: 'image/png' | 'image/svg+xml';
+  content: Buffer;
+}
+
+/**
+ * Serve-time logo read: classifies by magic bytes / XML shape, never by the
+ * entry's own name, and re-runs {@link sniffLogo}'s safety checks rather
+ * than trusting the install-time pass.
+ */
+export async function readVerifiedLogo(archive: Buffer): Promise<VerifiedLogo | null> {
+  const entries = await readArchiveEntries(archive, new Set(['logo.png', 'logo.svg']));
+  const content = entries.get('logo.png') ?? entries.get('logo.svg');
+  if (!content) return null;
+  if (content.subarray(0, PNG_MAGIC.length).equals(PNG_MAGIC)) {
+    return sniffLogo('logo.png', content) ? null : { contentType: 'image/png', content };
+  }
+  return sniffLogo('logo.svg', content) ? null : { contentType: 'image/svg+xml', content };
 }

--- a/backend/src/modules/plugins/plugin-logo.controller.spec.ts
+++ b/backend/src/modules/plugins/plugin-logo.controller.spec.ts
@@ -1,0 +1,65 @@
+import { NotFoundException } from '@nestjs/common';
+import type { Response } from 'express';
+import { PluginLogoController } from './plugin-logo.controller';
+import { buildZip } from './archive/zip-builder';
+import { pngLogo, svgLogo } from './archive/test-fixtures';
+import type { RegisteredPlugin } from './plugin-registry.service';
+
+function fakeResponse(): jest.Mocked<Pick<Response, 'set' | 'send'>> {
+  return { set: jest.fn(), send: jest.fn() } as never;
+}
+
+function registryReturning(plugin: Pick<RegisteredPlugin, 'archive'> | undefined) {
+  return { get: jest.fn().mockReturnValue(plugin) };
+}
+
+describe('PluginLogoController', () => {
+  it('serves a PNG logo with the sniffed content type and the security headers', async () => {
+    const logo = pngLogo();
+    const archive = buildZip([{ name: 'logo.png', content: logo }]);
+    const controller = new PluginLogoController(registryReturning({ archive }) as never);
+    const res = fakeResponse();
+
+    await controller.logo('fliks.test-plugin', res as never);
+
+    expect(res.set).toHaveBeenCalledWith({
+      'Content-Type': 'image/png',
+      'X-Content-Type-Options': 'nosniff',
+      'Content-Security-Policy': 'sandbox',
+    });
+    expect(res.send).toHaveBeenCalledWith(logo);
+  });
+
+  it('serves a clean SVG logo as image/svg+xml', async () => {
+    const archive = buildZip([{ name: 'logo.svg', content: svgLogo() }]);
+    const controller = new PluginLogoController(registryReturning({ archive }) as never);
+    const res = fakeResponse();
+
+    await controller.logo('fliks.test-plugin', res as never);
+
+    expect(res.set).toHaveBeenCalledWith(
+      expect.objectContaining({ 'Content-Type': 'image/svg+xml' }),
+    );
+  });
+
+  it('refuses an SVG entry carrying a <script> element instead of serving it', async () => {
+    const malicious = Buffer.from(
+      '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>',
+      'utf8',
+    );
+    const archive = buildZip([{ name: 'logo.svg', content: malicious }]);
+    const controller = new PluginLogoController(registryReturning({ archive }) as never);
+
+    await expect(controller.logo('fliks.test-plugin', fakeResponse() as never)).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('404s for an unregistered plugin id without reading any archive', async () => {
+    const registry = registryReturning(undefined);
+    const controller = new PluginLogoController(registry as never);
+
+    await expect(controller.logo('unknown', fakeResponse() as never)).rejects.toThrow(NotFoundException);
+    expect(registry.get).toHaveBeenCalledWith('unknown');
+  });
+});

--- a/backend/src/modules/plugins/plugin-logo.controller.ts
+++ b/backend/src/modules/plugins/plugin-logo.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get, NotFoundException, Param, Res, UseGuards } from '@nestjs/common';
+import type { Response } from 'express';
+import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
+import { PoliciesGuard } from '../auth/casl/policies.guard';
+import { CheckPolicies } from '../auth/casl/check-policies.decorator';
+import { Action } from '../auth/casl/actions.enum';
+import { PluginRegistryService } from './plugin-registry.service';
+import { readVerifiedLogo } from './archive';
+
+/** Admin-UI-only image; unknown/unregistered ids 404 rather than probing the archive. */
+@Controller('plugins')
+@UseGuards(JwtOrApiKeyGuard, PoliciesGuard)
+export class PluginLogoController {
+  constructor(private readonly registry: PluginRegistryService) {}
+
+  @Get(':pluginId/logo')
+  @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
+  async logo(@Param('pluginId') pluginId: string, @Res() res: Response): Promise<void> {
+    const plugin = this.registry.get(pluginId);
+    if (!plugin) throw new NotFoundException();
+
+    const logo = await readVerifiedLogo(plugin.archive);
+    if (!logo) throw new NotFoundException();
+
+    res.set({
+      'Content-Type': logo.contentType,
+      'X-Content-Type-Options': 'nosniff',
+      'Content-Security-Policy': 'sandbox',
+    });
+    res.send(logo.content);
+  }
+}

--- a/backend/src/modules/plugins/plugin-registry.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.spec.ts
@@ -1,0 +1,182 @@
+import { PluginRegistryService } from './plugin-registry.service';
+import { PluginPackage } from './entities/plugin-package.entity';
+import { buildZip, ZipEntrySpec } from './archive/zip-builder';
+import { generateTestKeypair, signManifestBase64 } from './archive/ed25519-test-keys';
+import { minimalDataManifest, minimalProcessManifest } from './archive/test-manifests';
+import { svgLogo, pngLogo } from './archive/test-fixtures';
+import { OFFICIAL_KEYS } from './archive/trust-store';
+import { FLIKS_PLUGINS_DISABLED_ENV } from '../../common/constants/plugin-flags';
+import type { PluginManifest } from '../../common/plugin-contract';
+
+/** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
+const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
+
+function archiveFor(manifest: PluginManifest, extraEntries: ZipEntrySpec[] = []): Buffer {
+  const entries: ZipEntrySpec[] = [
+    { name: 'plugin.json', content: Buffer.from(JSON.stringify(manifest), 'utf8') },
+    ...extraEntries,
+  ];
+  if (!entries.some((e) => e.name.startsWith('logo.'))) {
+    entries.push({ name: manifest.kind === 'process' ? 'logo.png' : 'logo.svg', content: manifest.kind === 'process' ? pngLogo() : svgLogo() });
+  }
+  return buildZip(entries);
+}
+
+function makePackage(manifest: PluginManifest, overrides: Partial<PluginPackage> = {}): PluginPackage {
+  return {
+    id: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    pluginId: manifest.id,
+    version: manifest.version,
+    archive: archiveFor(manifest),
+    origin: 'manual',
+    signature: 'unsigned',
+    verifiedByKeyId: null,
+    manifest,
+    status: 'active',
+    ...overrides,
+  } as PluginPackage;
+}
+
+function repoMock(rows: PluginPackage[] = []) {
+  return { find: jest.fn().mockResolvedValue(rows) };
+}
+
+describe('PluginRegistryService — boot load', () => {
+  const originalEnv = process.env[FLIKS_PLUGINS_DISABLED_ENV];
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env[FLIKS_PLUGINS_DISABLED_ENV];
+    else process.env[FLIKS_PLUGINS_DISABLED_ENV] = originalEnv;
+  });
+
+  it('L0: FLIKS_PLUGINS_DISABLED=1 registers nothing and never queries the repository', async () => {
+    process.env[FLIKS_PLUGINS_DISABLED_ENV] = '1';
+    const repo = repoMock([makePackage(minimalDataManifest({ fliks: COMPATIBLE_RANGE }))]);
+    const service = new PluginRegistryService(repo as never);
+
+    await service.onModuleInit();
+
+    expect(repo.find).not.toHaveBeenCalled();
+    expect(service.list()).toEqual([]);
+  });
+
+  it('boot continues past a failing package and still registers a later valid one', async () => {
+    const bad = minimalDataManifest({ id: 'fliks.bad-plugin', fliks: '>=99.0.0' });
+    const good = minimalDataManifest({ id: 'fliks.good-plugin', fliks: COMPATIBLE_RANGE });
+    const repo = repoMock([makePackage(bad), makePackage(good)]);
+    const service = new PluginRegistryService(repo as never);
+
+    await service.onModuleInit();
+
+    expect(service.get(bad.id)).toBeUndefined();
+    expect(service.get(good.id)).toBeDefined();
+    expect(service.list()).toHaveLength(1);
+  });
+});
+
+describe('PluginRegistryService.register()', () => {
+  afterEach(() => {
+    (OFFICIAL_KEYS as Map<string, Buffer>).clear();
+  });
+
+  it('registers a valid data-tier package and is idempotent', async () => {
+    const manifest = minimalDataManifest({ fliks: COMPATIBLE_RANGE });
+    const pkg = makePackage(manifest);
+    const service = new PluginRegistryService(repoMock() as never);
+
+    const first = await service.register(pkg);
+    const second = await service.register(pkg);
+
+    expect(first).toEqual({ ok: true, pluginId: manifest.id });
+    expect(second).toEqual({ ok: true, pluginId: manifest.id });
+    expect(service.list()).toHaveLength(1);
+    expect(service.get(manifest.id)?.manifest).toEqual(manifest);
+  });
+
+  it('L2: does not register when verifiedByKeyId is no longer in the trust store', async () => {
+    const { privateKey } = generateTestKeypair();
+    const manifest = minimalDataManifest({ fliks: COMPATIBLE_RANGE });
+    const manifestBytes = Buffer.from(JSON.stringify(manifest), 'utf8');
+    const sig = signManifestBase64(privateKey, manifestBytes);
+    const archive = archiveFor(manifest, [{ name: 'plugin.json.sig', content: Buffer.from(sig, 'utf8') }]);
+    const pkg = makePackage(manifest, { archive, signature: 'official', verifiedByKeyId: 'revoked-key' });
+    const service = new PluginRegistryService(repoMock() as never);
+
+    const result = await service.register(pkg);
+
+    expect(result).toEqual({
+      ok: false,
+      pluginId: manifest.id,
+      reason: 'untrusted',
+      detail: expect.stringContaining('revoked-key'),
+    });
+    expect(service.get(manifest.id)).toBeUndefined();
+  });
+
+  it('L2: registers when verifiedByKeyId is still present and the signature still verifies', async () => {
+    const { privateKey, rawPublicKey } = generateTestKeypair();
+    (OFFICIAL_KEYS as Map<string, Buffer>).set('release-2026', rawPublicKey);
+    const manifest = minimalDataManifest({ fliks: COMPATIBLE_RANGE });
+    const manifestBytes = Buffer.from(JSON.stringify(manifest), 'utf8');
+    const sig = signManifestBase64(privateKey, manifestBytes);
+    const archive = archiveFor(manifest, [{ name: 'plugin.json.sig', content: Buffer.from(sig, 'utf8') }]);
+    const pkg = makePackage(manifest, { archive, signature: 'official', verifiedByKeyId: 'release-2026' });
+    const service = new PluginRegistryService(repoMock() as never);
+
+    const result = await service.register(pkg);
+
+    expect(result).toEqual({ ok: true, pluginId: manifest.id });
+  });
+
+  it('L4: does not register when pluginApi differs from PLUGIN_API_VERSION, with its own reason', async () => {
+    const manifest = minimalDataManifest({ fliks: COMPATIBLE_RANGE, pluginApi: 99 });
+    const pkg = makePackage(manifest);
+    const service = new PluginRegistryService(repoMock() as never);
+
+    const result = await service.register(pkg);
+
+    expect(result).toEqual({
+      ok: false,
+      pluginId: manifest.id,
+      reason: 'incompatible-api',
+      detail: expect.any(String),
+    });
+  });
+
+  it('L4: does not register when the fliks range excludes the running version, with its own reason', async () => {
+    const manifest = minimalDataManifest({ fliks: '>=99.0.0' });
+    const pkg = makePackage(manifest);
+    const service = new PluginRegistryService(repoMock() as never);
+
+    const result = await service.register(pkg);
+
+    expect(result).toEqual({
+      ok: false,
+      pluginId: manifest.id,
+      reason: 'incompatible-fliks',
+      detail: expect.any(String),
+    });
+  });
+
+  it('refuses a process-tier package as not supported yet', async () => {
+    const pluginJs = Buffer.from('module.exports = {};', 'utf8');
+    const manifest = minimalProcessManifest(
+      { 'plugin.js': 'a'.repeat(64), 'logo.png': 'b'.repeat(64) },
+      { fliks: COMPATIBLE_RANGE },
+    );
+    const archive = archiveFor(manifest, [{ name: 'plugin.js', content: pluginJs }]);
+    const pkg = makePackage(manifest, { archive });
+    const service = new PluginRegistryService(repoMock() as never);
+
+    const result = await service.register(pkg);
+
+    expect(result).toEqual({
+      ok: false,
+      pluginId: manifest.id,
+      reason: 'unsupported-tier',
+      detail: expect.any(String),
+    });
+  });
+});

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -1,0 +1,181 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as semver from 'semver';
+import { PluginPackage } from './entities/plugin-package.entity';
+import { arePluginsDisabled, FLIKS_PLUGINS_DISABLED_ENV } from '../../common/constants/plugin-flags';
+import { PLUGIN_API_VERSION, type PluginKind, type PluginManifest } from '../../common/plugin-contract';
+import { OFFICIAL_KEYS, resolveTrust, readArchiveEntries, type TrustOutcome } from './archive';
+
+/** Same pattern as `UpdateCheckService`/`SystemController` — no shared version util exists yet. */
+const CURRENT_FLIKS_VERSION: string = (() => {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8')) as { version?: string };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+})();
+
+export interface RegisteredPlugin {
+  pluginId: string;
+  version: string;
+  kind: PluginKind;
+  manifest: PluginManifest;
+  signature: TrustOutcome;
+  verifiedByKeyId: string | null;
+  /** Same buffer as the `plugin_packages` row — the logo route re-extracts from
+   *  this on each request rather than the registry caching decoded image bytes. */
+  archive: Buffer;
+}
+
+export type PluginRegistrationFailureReason =
+  | 'unsupported-tier'
+  | 'untrusted'
+  | 'incompatible-api'
+  | 'incompatible-fliks';
+
+export interface PluginRegistrationSuccess {
+  ok: true;
+  pluginId: string;
+}
+export interface PluginRegistrationFailure {
+  ok: false;
+  pluginId: string;
+  reason: PluginRegistrationFailureReason;
+  detail: string;
+}
+export type PluginRegistrationResult = PluginRegistrationSuccess | PluginRegistrationFailure;
+
+/**
+ * In-memory installed-plugin set — the only thing the rest of core asks about
+ * plugins. Populated at boot (L0-L4 of `plans/plugin-system.plan.md`'s load
+ * table) and by `register()`, the hot-reload entry point a future installer
+ * calls for a `data` plugin (P4a). L1/L3 — `state.json` and re-hashing
+ * `plugin.js` from the fd that will be loaded — belong to the process-tier
+ * supervisor, which does not exist yet.
+ */
+@Injectable()
+export class PluginRegistryService implements OnModuleInit {
+  private readonly logger = new Logger(PluginRegistryService.name);
+  private readonly registry = new Map<string, RegisteredPlugin>();
+
+  constructor(
+    @InjectRepository(PluginPackage)
+    private readonly packageRepo: Repository<PluginPackage>,
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    // L0 — read before any plugin row is touched.
+    if (arePluginsDisabled()) {
+      this.logger.warn(`${FLIKS_PLUGINS_DISABLED_ENV}=1 — no plugin will be loaded`);
+      return;
+    }
+
+    const packages = await this.packageRepo.find();
+    for (const pkg of packages) {
+      try {
+        const result = await this.register(pkg);
+        if (!result.ok) {
+          this.logger.warn(`plugin "${result.pluginId}" not loaded (${result.reason}): ${result.detail}`);
+        }
+      } catch (err) {
+        // One bad row must never take the app down at boot.
+        this.logger.warn(`plugin "${pkg.pluginId}" failed to load: ${(err as Error).message}`);
+      }
+    }
+  }
+
+  /** Hot-reload entry point (install pipeline P4a). Same checks as boot load; idempotent on plugin id. */
+  async register(pkg: PluginPackage): Promise<PluginRegistrationResult> {
+    const manifest = pkg.manifest;
+
+    if (manifest.kind === 'process') {
+      return this.fail(pkg.pluginId, 'unsupported-tier', 'process-tier plugins are not supported yet (no supervisor)');
+    }
+
+    // L1 (state.json quarantine) slots in here, ahead of the signature re-check — supervisor-owned.
+    // L2
+    const trust = await this.reverifyTrust(pkg);
+    if (!trust.ok) return this.fail(pkg.pluginId, 'untrusted', trust.detail);
+
+    // L3 (re-hash plugin.js from the loaded fd) slots in here, process-tier only — supervisor-owned.
+    // L4
+    if (manifest.pluginApi !== PLUGIN_API_VERSION) {
+      return this.fail(
+        pkg.pluginId,
+        'incompatible-api',
+        `manifest declares pluginApi ${manifest.pluginApi}, running ${PLUGIN_API_VERSION}`,
+      );
+    }
+    if (!semver.satisfies(CURRENT_FLIKS_VERSION, manifest.fliks)) {
+      return this.fail(
+        pkg.pluginId,
+        'incompatible-fliks',
+        `manifest requires fliks "${manifest.fliks}", running ${CURRENT_FLIKS_VERSION}`,
+      );
+    }
+
+    this.registry.set(pkg.pluginId, {
+      pluginId: pkg.pluginId,
+      version: pkg.version,
+      kind: manifest.kind,
+      manifest,
+      signature: pkg.signature,
+      verifiedByKeyId: pkg.verifiedByKeyId,
+      archive: pkg.archive,
+    });
+    return { ok: true, pluginId: pkg.pluginId };
+  }
+
+  unregister(pluginId: string): void {
+    this.registry.delete(pluginId);
+  }
+
+  list(): RegisteredPlugin[] {
+    return [...this.registry.values()];
+  }
+
+  get(pluginId: string): RegisteredPlugin | undefined {
+    return this.registry.get(pluginId);
+  }
+
+  private fail(pluginId: string, reason: PluginRegistrationFailureReason, detail: string): PluginRegistrationFailure {
+    return { ok: false, pluginId, reason, detail };
+  }
+
+  /**
+   * Re-verify against `verifiedByKeyId` specifically — never "any trusted key" — so a
+   * revoked/removed key fails the plugin rather than silently falling back to another.
+   * A package that was never signed against a known key at install (unsigned/unverified)
+   * has nothing to re-check here and passes through.
+   */
+  private async reverifyTrust(pkg: PluginPackage): Promise<{ ok: true } | { ok: false; detail: string }> {
+    if (!pkg.verifiedByKeyId) return { ok: true };
+
+    const key = OFFICIAL_KEYS.get(pkg.verifiedByKeyId);
+    if (!key) {
+      return { ok: false, detail: `key "${pkg.verifiedByKeyId}" is no longer in the trust store` };
+    }
+
+    try {
+      const entries = await readArchiveEntries(pkg.archive, new Set(['plugin.json', 'plugin.json.sig']));
+      const manifestBytes = entries.get('plugin.json');
+      const sigText = entries.get('plugin.json.sig')?.toString('utf8').trim();
+      if (!manifestBytes || !sigText) {
+        return { ok: false, detail: 'archive is missing plugin.json or its signature' };
+      }
+      const signature = Buffer.from(sigText, 'base64');
+      // Scope the check to exactly this one key by passing it as the sole candidate.
+      const result = resolveTrust(manifestBytes, signature, new Map([[pkg.verifiedByKeyId, key]]), new Map());
+      if (result.trust !== 'official') {
+        return { ok: false, detail: `signature no longer verifies against key "${pkg.verifiedByKeyId}"` };
+      }
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, detail: `archive unreadable: ${(err as Error).message}` };
+    }
+  }
+}

--- a/backend/src/modules/plugins/plugins.module.ts
+++ b/backend/src/modules/plugins/plugins.module.ts
@@ -3,9 +3,14 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { PluginSource } from './entities/plugin-source.entity';
 import { PluginRegistration } from './entities/plugin-registration.entity';
+import { PluginRegistryService } from './plugin-registry.service';
+import { PluginLogoController } from './plugin-logo.controller';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([PluginPackage, PluginSource, PluginRegistration])],
-  exports: [TypeOrmModule],
+  imports: [TypeOrmModule.forFeature([PluginPackage, PluginSource, PluginRegistration]), AuthModule],
+  controllers: [PluginLogoController],
+  providers: [PluginRegistryService],
+  exports: [TypeOrmModule, PluginRegistryService],
 })
 export class PluginsModule {}


### PR DESCRIPTION
PR 6.2. The registry, its boot load, hot reload for the `data` tier, and the logo route. **No supervisor, no child process, no installer endpoint** — nothing spawns anything here, and there is still no route that installs a plugin.

**The load sequence**, as far as it goes without a supervisor:

- `FLIKS_PLUGINS_DISABLED` is read *before any row is touched* — a test asserts the repository was never queried, because "disabled" that still hits the database is not disabled.
- Each package's signature is re-verified **against `verifiedByKeyId` specifically**, not against the set of trusted keys. A withdrawn key has to stop its plugins loading, and verifying against "any trusted key" silently defeats exactly that.
- `pluginApi` exact-equality and `semver.satisfies` on the Fliks range, each with its own refusal reason.
- A failing package is recorded and skipped — **boot continues**, pinned by a test where one bad package and one good one are loaded together and only the good one lands.

L1 (`state.json` quarantine) and L3 (re-hashing `plugin.js` from the fd that will load it) belong to the supervisor; their slots are marked in place.

**The logo route** decides `Content-Type` from magic bytes, never the entry's filename, and re-uses the archive validator's own SVG check instead of a second copy — an SVG carrying `<script>` is refused rather than served. `nosniff` + `Content-Security-Policy: sandbox`, since this is same-origin SVG in a product with no CSP. Bytes come out of the stored archive per request and are not cached: an admin-only route decoding a ≤64 KiB entry does not justify memory that grows per installed plugin.

**Process-tier packages are refused** with a reason saying so. Registering something nothing can run would be worse than declining.

## Verified

`tsc` 0, suite **88/849/29** (+12).

Authorization checked against the running stack rather than through mocked guards, because that is where an undecorated route would show up as authorized-by-nobody:

| request | result |
|---|---|
| anonymous | **401** |
| regular user (role 2) | **403** |
| owner, unknown plugin id | **404** — a miss, not a probe |

**Changed from the agent's pass:** it hit `semver` having no bundled types and, reading my "no new dependency" constraint literally, hand-wrote a three-line ambient module declaring only `satisfies`. That constraint meant runtime dependencies; a types package is the right answer and a partial hand-written shim silently diverges from the library it describes. Replaced with `@types/semver` in devDependencies.

Note for local stacks: the backend container needs `@types/semver` (and `yauzl` from #897) installed inside it, or its watcher fails to typecheck — its `node_modules` is baked into the image rather than bind-mounted.