### PR TITLE
feat(plugins): let a data plugin declare a Torznab tracker

### DIFF
--- a/backend/src/common/plugin-contract/index.ts
+++ b/backend/src/common/plugin-contract/index.ts
@@ -5,4 +5,5 @@ export * from './principal';
 export * from './host-methods';
 export * from './plugin-methods';
 export * from './ui-contribution';
+export * from './indexer-descriptor';
 export * from './manifest';

--- a/backend/src/common/plugin-contract/indexer-descriptor.spec.ts
+++ b/backend/src/common/plugin-contract/indexer-descriptor.spec.ts
@@ -1,0 +1,19 @@
+import { buildIndexerImplementationId, parseIndexerImplementationId } from './indexer-descriptor';
+
+describe('indexer implementation namespacing', () => {
+  it('round-trips a plugin id that itself contains the separator', () => {
+    const id = buildIndexerImplementationId('fliks.test-plugin', 'mytracker');
+
+    expect(id).toBe('fliks.test-plugin.mytracker');
+    expect(parseIndexerImplementationId(id)).toEqual({ pluginId: 'fliks.test-plugin', key: 'mytracker' });
+  });
+
+  it('returns null for the legacy plain "torznab" value', () => {
+    expect(parseIndexerImplementationId('torznab')).toBeNull();
+  });
+
+  it('returns null when there is nothing on one side of the separator', () => {
+    expect(parseIndexerImplementationId('.mytracker')).toBeNull();
+    expect(parseIndexerImplementationId('fliks.test-plugin.')).toBeNull();
+  });
+});

--- a/backend/src/common/plugin-contract/indexer-descriptor.ts
+++ b/backend/src/common/plugin-contract/indexer-descriptor.ts
@@ -1,0 +1,42 @@
+import type { FieldDef } from './ui-contribution';
+
+/**
+ * One `provides.indexers[]` entry: a named tracker over a core driver
+ * (`driverApi`) at a known `endpoint`, with the settings a user must
+ * supply. Not part of the `ui-contribution.ts` drift gate — that job only
+ * compiles `ui-contribution.ts` against its client mirror, and this type
+ * has no client mirror yet.
+ */
+export interface IndexerDescriptor {
+  /** Unique within the plugin; must not contain `INDEXER_ID_SEPARATOR`. */
+  key: string;
+  name: string;
+  /** Core driver this descriptor runs over, e.g. "torznab". */
+  driverApi: string;
+  /** Absolute http(s) base URL — the only user input left is credentials. */
+  endpoint: string;
+  /** Rendered by the same `<app-schema-form>` as any other plugin credential. */
+  settings: FieldDef[];
+}
+
+/** Joins a plugin id and a descriptor key for storage in `Indexer.implementation`. */
+export const INDEXER_ID_SEPARATOR = '.';
+
+/** Namespaces a descriptor key by plugin id, so two plugins can't collide
+ *  and an orphaned indexer row is traceable to the plugin that defined it. */
+export function buildIndexerImplementationId(pluginId: string, key: string): string {
+  return `${pluginId}${INDEXER_ID_SEPARATOR}${key}`;
+}
+
+/**
+ * Inverse of `buildIndexerImplementationId`. Plugin ids are commonly
+ * reverse-domain (`fliks.test-plugin`) and may themselves contain the
+ * separator, so the split is taken from the right — the key must not.
+ * Returns null when `implementation` isn't a namespaced descriptor id
+ * (e.g. the legacy plain `"torznab"` value).
+ */
+export function parseIndexerImplementationId(implementation: string): { pluginId: string; key: string } | null {
+  const i = implementation.lastIndexOf(INDEXER_ID_SEPARATOR);
+  if (i <= 0 || i === implementation.length - 1) return null;
+  return { pluginId: implementation.slice(0, i), key: implementation.slice(i + 1) };
+}

--- a/backend/src/common/plugin-contract/manifest.ts
+++ b/backend/src/common/plugin-contract/manifest.ts
@@ -1,3 +1,4 @@
+import type { IndexerDescriptor } from './indexer-descriptor';
 import type { UiContribution, ConfigPage } from './ui-contribution';
 import type { PluginScope } from './principal';
 
@@ -25,9 +26,11 @@ export interface PluginRoute {
 }
 
 /**
- * Fields unchanged between tiers. `provides`, `events` and `i18n` carry
- * shapes owned by a pre-existing baseline schema not reproduced here
- * (e.g. `IndexerDescriptor`); kept structurally opaque rather than guessed.
+ * Fields unchanged between tiers. `events` and `i18n` carry shapes owned by
+ * a pre-existing baseline schema not reproduced here; kept structurally
+ * opaque rather than guessed. `provides.indexers` is typed, but the type is
+ * a statement of intent only: a manifest is untrusted JSON, so
+ * `PluginRegistryService` validates every entry before believing it.
  */
 interface PluginManifestBase {
   id: string;
@@ -41,7 +44,7 @@ interface PluginManifestBase {
   license: string;
   logo: string;
   homepage?: string;
-  provides?: Record<string, unknown>;
+  provides?: { indexers?: IndexerDescriptor[] };
   ui?: {
     contributions?: UiContribution[];
     configPages?: ConfigPage[];

--- a/backend/src/modules/indexers/indexers.module.ts
+++ b/backend/src/modules/indexers/indexers.module.ts
@@ -7,9 +7,10 @@ import { IndexerThrottle } from './indexer-throttle.service';
 import { IndexersService } from './indexers.service';
 import { IndexersController } from './indexers.controller';
 import { AuthModule } from '../auth/auth.module';
+import { PluginsModule } from '../plugins/plugins.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Indexer, IndexerStat]), AuthModule],
+  imports: [TypeOrmModule.forFeature([Indexer, IndexerStat]), AuthModule, PluginsModule],
   controllers: [IndexersController],
   providers: [TorznabService, IndexerThrottle, IndexersService],
   exports: [TypeOrmModule, TorznabService],

--- a/backend/src/modules/indexers/torznab.service.spec.ts
+++ b/backend/src/modules/indexers/torznab.service.spec.ts
@@ -1,0 +1,100 @@
+import axios from 'axios';
+import { TorznabService } from './torznab.service';
+import { IndexerThrottle } from './indexer-throttle.service';
+import { Indexer } from './entities/indexer.entity';
+import { PluginRegistryService } from '../plugins/plugin-registry.service';
+import { buildIndexerImplementationId, type IndexerDescriptor } from '../../common/plugin-contract';
+
+const indexer = (over: Partial<Indexer> = {}): Indexer =>
+  ({
+    id: 1,
+    name: 'test',
+    implementation: 'torznab',
+    settings: {},
+    enableRss: true,
+    enableSearch: true,
+    priority: 25,
+    requestDelay: 0,
+    enabled: true,
+    capsMovieSearch: false,
+    capsTvSearch: false,
+    capsSearchFallback: false,
+    ...over,
+  }) as Indexer;
+
+/** No `<item>`/`<error>` — a valid, empty Torznab response. */
+const emptyTorznabBody = '<?xml version="1.0"?><rss><channel></channel></rss>';
+
+function makeService(getIndexerDescriptor: jest.Mock = jest.fn().mockReturnValue(undefined)): TorznabService {
+  const statRepo = { create: jest.fn((x: unknown) => x), save: jest.fn().mockResolvedValue(undefined) };
+  const indexerRepo = { update: jest.fn().mockResolvedValue(undefined) };
+  const registry = { getIndexerDescriptor } as unknown as PluginRegistryService;
+  return new TorznabService(statRepo as never, indexerRepo as never, new IndexerThrottle(), registry);
+}
+
+describe('TorznabService — search target resolution', () => {
+  const originalAdapter = axios.defaults.adapter;
+  let requestedUrls: string[];
+
+  beforeEach(() => {
+    requestedUrls = [];
+    // Stub the network at the adapter level (same approach as http-circuit-breaker.spec.ts)
+    // so the real axios request/response pipeline still runs.
+    axios.defaults.adapter = (config) => {
+      requestedUrls.push(String(config.url));
+      return Promise.resolve({ data: emptyTorznabBody, status: 200, statusText: 'OK', headers: {}, config }) as never;
+    };
+  });
+
+  afterEach(() => {
+    axios.defaults.adapter = originalAdapter;
+  });
+
+  it('resolves a plain torznab indexer from its own settings.baseUrl, unchanged', async () => {
+    const service = makeService();
+    const ix = indexer({
+      implementation: 'torznab',
+      settings: { baseUrl: 'https://legacy.tld/api', apiKey: 'legacy-key' },
+    });
+
+    const results = await service.searchMovie(ix, 'Some Movie');
+
+    expect(results).toEqual([]);
+    expect(requestedUrls).toHaveLength(1);
+    expect(requestedUrls[0].startsWith('https://legacy.tld/api?')).toBe(true);
+    expect(requestedUrls[0]).toContain('apikey=legacy-key');
+  });
+
+  it('resolves an indexer naming a registered descriptor to the descriptor endpoint, with the user apiKey', async () => {
+    const descriptor: IndexerDescriptor = {
+      key: 'mytracker',
+      name: 'My Tracker',
+      driverApi: 'torznab',
+      endpoint: 'https://tracker.example/api',
+      settings: [],
+    };
+    const implementation = buildIndexerImplementationId('fliks.test-plugin', 'mytracker');
+    const getIndexerDescriptor = jest.fn((id: string) => (id === implementation ? descriptor : undefined));
+    const service = makeService(getIndexerDescriptor);
+    const ix = indexer({ implementation, settings: { apiKey: 'user-key' } });
+
+    const results = await service.searchMovie(ix, 'Some Movie');
+
+    expect(results).toEqual([]);
+    expect(getIndexerDescriptor).toHaveBeenCalledWith(implementation);
+    expect(requestedUrls).toHaveLength(1);
+    expect(requestedUrls[0].startsWith('https://tracker.example/api?')).toBe(true);
+    expect(requestedUrls[0]).toContain('apikey=user-key');
+  });
+
+  it('skips an indexer naming an unregistered descriptor, never falling through to raw torznab', async () => {
+    const implementation = buildIndexerImplementationId('fliks.uninstalled-plugin', 'sometracker');
+    const service = makeService();
+    const ix = indexer({ implementation, settings: { apiKey: 'user-key' } });
+
+    const results = await service.searchMovie(ix, 'Some Movie');
+
+    expect(results).toEqual([]);
+    expect(requestedUrls).toHaveLength(0);
+  });
+});

--- a/backend/src/modules/indexers/torznab.service.ts
+++ b/backend/src/modules/indexers/torznab.service.ts
@@ -7,6 +7,8 @@ import { IndexerStat } from './entities/indexer-stat.entity';
 import { IndexerThrottle } from './indexer-throttle.service';
 import { decodeHtmlEntities } from '../../common/utils/decode-html-entities';
 import { ReleaseCandidate } from '../../common/release-scoring';
+import { parseIndexerImplementationId } from '../../common/plugin-contract';
+import { PluginRegistryService } from '../plugins/plugin-registry.service';
 
 const decodeXmlEntities = decodeHtmlEntities;
 
@@ -164,6 +166,7 @@ export class TorznabService {
     @InjectRepository(Indexer)
     private readonly indexerRepo: Repository<Indexer>,
     private readonly throttle: IndexerThrottle,
+    private readonly pluginRegistry: PluginRegistryService,
   ) {}
 
   /** Drop indexers currently serving a failure / Retry-After cooldown from a
@@ -266,6 +269,12 @@ export class TorznabService {
    * Whether this indexer can serve a search, and the endpoint to hit.
    * Null means skipped — the reason is logged here so every search path
    * reports it the same way.
+   *
+   * `implementation` is either the legacy plain `"torznab"` value (baseUrl
+   * comes from the indexer's own settings) or a plugin-namespaced descriptor
+   * id (baseUrl comes from the registered descriptor). A namespaced id whose
+   * plugin isn't registered is skipped outright — it never falls through to
+   * the plain-Torznab path with an empty baseUrl.
    */
   private resolveSearchTarget(
     indexer: Indexer,
@@ -278,14 +287,24 @@ export class TorznabService {
       this.log.debug(`[${indexer.name}] skipped — search disabled`);
       return null;
     }
-    const impl = (indexer.implementation || '').toLowerCase();
-    if (!impl.includes('torznab')) {
-      this.log.debug(
-        `[${indexer.name}] skipped — implementation "${indexer.implementation}" is not Torznab`,
-      );
+    const settings = indexer.settings as { baseUrl?: string; apiKey?: string };
+    const implementation = indexer.implementation || '';
+
+    if (parseIndexerImplementationId(implementation)) {
+      const descriptor = this.pluginRegistry.getIndexerDescriptor(implementation);
+      if (!descriptor) {
+        this.log.warn(
+          `[${indexer.name}] skipped — descriptor "${implementation}" is not registered (plugin missing or refused at boot)`,
+        );
+        return null;
+      }
+      return { baseUrl: descriptor.endpoint.replace(/\/$/, ''), apiKey: String(settings.apiKey || '') };
+    }
+
+    if (!implementation.toLowerCase().includes('torznab')) {
+      this.log.debug(`[${indexer.name}] skipped — implementation "${indexer.implementation}" is not Torznab`);
       return null;
     }
-    const settings = indexer.settings as { baseUrl?: string; apiKey?: string };
     const baseUrl = String(settings.baseUrl || '').replace(/\/$/, '');
     if (!baseUrl) {
       this.log.warn(`Indexer "${indexer.name}" has no baseUrl`);

--- a/backend/src/modules/plugins/data-tier-manifest.validator.spec.ts
+++ b/backend/src/modules/plugins/data-tier-manifest.validator.spec.ts
@@ -15,7 +15,17 @@ describe('validateDataTierManifest()', () => {
 
   it('accepts a data manifest using provides.* and events[].webhook', () => {
     const manifest = minimalDataManifest({
-      provides: { indexers: [{ id: 'x' }] },
+      provides: {
+        indexers: [
+          {
+            key: 'example',
+            name: 'Example Tracker',
+            driverApi: 'torznab',
+            endpoint: 'https://tracker.invalid/api',
+            settings: [],
+          },
+        ],
+      },
       events: [{ webhook: 'https://example.invalid/hook' }],
     });
     expect(validateDataTierManifest(manifest).ok).toBe(true);

--- a/backend/src/modules/plugins/plugin-indexer-descriptors.controller.ts
+++ b/backend/src/modules/plugins/plugin-indexer-descriptors.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
+import { PoliciesGuard } from '../auth/casl/policies.guard';
+import { CheckPolicies } from '../auth/casl/check-policies.decorator';
+import { Action } from '../auth/casl/actions.enum';
+import { PluginRegistryService } from './plugin-registry.service';
+
+/** Read-only catalog of indexer descriptors from registered plugins, for the "add indexer" admin UI. */
+@Controller('plugins')
+@UseGuards(JwtOrApiKeyGuard, PoliciesGuard)
+export class PluginIndexerDescriptorsController {
+  constructor(private readonly registry: PluginRegistryService) {}
+
+  @Get('indexer-descriptors')
+  @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
+  list() {
+    return this.registry.listIndexerDescriptors();
+  }
+}

--- a/backend/src/modules/plugins/plugin-registry.service.indexer-descriptors.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.indexer-descriptors.spec.ts
@@ -1,0 +1,144 @@
+import { PluginRegistryService } from './plugin-registry.service';
+import { PluginPackage } from './entities/plugin-package.entity';
+import { minimalDataManifest } from './archive/test-manifests';
+import { buildIndexerImplementationId, type IndexerDescriptor, type PluginManifest } from '../../common/plugin-contract';
+
+/** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
+const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
+
+function makePackage(manifest: PluginManifest, overrides: Partial<PluginPackage> = {}): PluginPackage {
+  return {
+    id: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    pluginId: manifest.id,
+    version: manifest.version,
+    // Descriptor validation never re-verifies the archive (verifiedByKeyId is null), so its bytes don't matter.
+    archive: Buffer.alloc(0),
+    origin: 'manual',
+    signature: 'unsigned',
+    verifiedByKeyId: null,
+    manifest,
+    status: 'active',
+    ...overrides,
+  } as PluginPackage;
+}
+
+function repoMock(): { find: jest.Mock } {
+  return { find: jest.fn().mockResolvedValue([]) };
+}
+
+function indexerDescriptor(overrides: Partial<IndexerDescriptor> = {}): IndexerDescriptor {
+  return {
+    key: 'mytracker',
+    name: 'My Tracker',
+    driverApi: 'torznab',
+    endpoint: 'https://tracker.example/api',
+    settings: [],
+    ...overrides,
+  };
+}
+
+describe('PluginRegistryService — indexer descriptors', () => {
+  it('refuses a descriptor with an unsupported driverApi, naming the missing driver', async () => {
+    const manifest = minimalDataManifest({
+      fliks: COMPATIBLE_RANGE,
+      provides: { indexers: [indexerDescriptor({ driverApi: 'newznab' })] },
+    });
+    const service = new PluginRegistryService(repoMock() as never);
+
+    const result = await service.register(makePackage(manifest));
+
+    expect(result).toEqual({
+      ok: false,
+      pluginId: manifest.id,
+      reason: 'unsupported-indexer-driver',
+      detail: expect.stringContaining('newznab'),
+    });
+    expect(service.getIndexerDescriptor(buildIndexerImplementationId(manifest.id, 'mytracker'))).toBeUndefined();
+  });
+
+  it('refuses a duplicate key within the same plugin', async () => {
+    const manifest = minimalDataManifest({
+      fliks: COMPATIBLE_RANGE,
+      provides: { indexers: [indexerDescriptor({ key: 'dup' }), indexerDescriptor({ key: 'dup' })] },
+    });
+    const service = new PluginRegistryService(repoMock() as never);
+
+    const result = await service.register(makePackage(manifest));
+
+    expect(result).toEqual({
+      ok: false,
+      pluginId: manifest.id,
+      reason: 'invalid-indexer-key',
+      detail: expect.stringContaining('dup'),
+    });
+  });
+
+  it('refuses a key containing the namespace separator', async () => {
+    const manifest = minimalDataManifest({
+      fliks: COMPATIBLE_RANGE,
+      provides: { indexers: [indexerDescriptor({ key: 'my.tracker' })] },
+    });
+    const service = new PluginRegistryService(repoMock() as never);
+
+    const result = await service.register(makePackage(manifest));
+
+    expect(result).toEqual({
+      ok: false,
+      pluginId: manifest.id,
+      reason: 'invalid-indexer-key',
+      detail: expect.any(String),
+    });
+  });
+
+  it('refuses a malformed endpoint', async () => {
+    const manifest = minimalDataManifest({
+      fliks: COMPATIBLE_RANGE,
+      provides: { indexers: [indexerDescriptor({ endpoint: 'not-a-url' })] },
+    });
+    const service = new PluginRegistryService(repoMock() as never);
+
+    const result = await service.register(makePackage(manifest));
+
+    expect(result).toEqual({
+      ok: false,
+      pluginId: manifest.id,
+      reason: 'invalid-indexer-endpoint',
+      detail: expect.stringContaining('not-a-url'),
+    });
+  });
+
+  it('registers a valid descriptor and exposes it under its namespaced id', async () => {
+    const manifest = minimalDataManifest({
+      fliks: COMPATIBLE_RANGE,
+      provides: { indexers: [indexerDescriptor()] },
+    });
+    const service = new PluginRegistryService(repoMock() as never);
+
+    const result = await service.register(makePackage(manifest));
+
+    const implementationId = buildIndexerImplementationId(manifest.id, 'mytracker');
+    expect(result).toEqual({ ok: true, pluginId: manifest.id });
+    expect(service.getIndexerDescriptor(implementationId)).toEqual(indexerDescriptor());
+    expect(service.listIndexerDescriptors()).toEqual([
+      { implementationId, pluginId: manifest.id, ...indexerDescriptor() },
+    ]);
+  });
+
+  it('drops a plugin descriptors on unregister', async () => {
+    const manifest = minimalDataManifest({
+      fliks: COMPATIBLE_RANGE,
+      provides: { indexers: [indexerDescriptor()] },
+    });
+    const service = new PluginRegistryService(repoMock() as never);
+    await service.register(makePackage(manifest));
+    const implementationId = buildIndexerImplementationId(manifest.id, 'mytracker');
+    expect(service.getIndexerDescriptor(implementationId)).toBeDefined();
+
+    service.unregister(manifest.id);
+
+    expect(service.getIndexerDescriptor(implementationId)).toBeUndefined();
+    expect(service.listIndexerDescriptors()).toEqual([]);
+  });
+});

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -6,7 +6,14 @@ import * as path from 'path';
 import * as semver from 'semver';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { arePluginsDisabled, FLIKS_PLUGINS_DISABLED_ENV } from '../../common/constants/plugin-flags';
-import { PLUGIN_API_VERSION, type PluginKind, type PluginManifest } from '../../common/plugin-contract';
+import {
+  PLUGIN_API_VERSION,
+  buildIndexerImplementationId,
+  INDEXER_ID_SEPARATOR,
+  type PluginKind,
+  type PluginManifest,
+  type IndexerDescriptor,
+} from '../../common/plugin-contract';
 import { OFFICIAL_KEYS, resolveTrust, readArchiveEntries, type TrustOutcome } from './archive';
 
 /** Same pattern as `UpdateCheckService`/`SystemController` — no shared version util exists yet. */
@@ -18,6 +25,18 @@ const CURRENT_FLIKS_VERSION: string = (() => {
     return '0.0.0';
   }
 })();
+
+/** The only `driverApi` core knows how to run a search through today. */
+const SUPPORTED_INDEXER_DRIVER_APIS: ReadonlySet<string> = new Set(['torznab']);
+
+function isAbsoluteHttpUrl(value: string): boolean {
+  try {
+    const u = new URL(value);
+    return u.protocol === 'http:' || u.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
 
 export interface RegisteredPlugin {
   pluginId: string;
@@ -35,7 +54,10 @@ export type PluginRegistrationFailureReason =
   | 'unsupported-tier'
   | 'untrusted'
   | 'incompatible-api'
-  | 'incompatible-fliks';
+  | 'incompatible-fliks'
+  | 'unsupported-indexer-driver'
+  | 'invalid-indexer-key'
+  | 'invalid-indexer-endpoint';
 
 export interface PluginRegistrationSuccess {
   ok: true;
@@ -61,6 +83,8 @@ export type PluginRegistrationResult = PluginRegistrationSuccess | PluginRegistr
 export class PluginRegistryService implements OnModuleInit {
   private readonly logger = new Logger(PluginRegistryService.name);
   private readonly registry = new Map<string, RegisteredPlugin>();
+  /** Keyed by the namespaced id (`buildIndexerImplementationId`), rebuilt per plugin on every `register()`. */
+  private readonly indexerDescriptors = new Map<string, { pluginId: string; descriptor: IndexerDescriptor }>();
 
   constructor(
     @InjectRepository(PluginPackage)
@@ -118,6 +142,9 @@ export class PluginRegistryService implements OnModuleInit {
       );
     }
 
+    const descriptorCheck = this.validateIndexerDescriptors(manifest.provides?.indexers ?? []);
+    if (!descriptorCheck.ok) return this.fail(pkg.pluginId, descriptorCheck.reason, descriptorCheck.detail);
+
     this.registry.set(pkg.pluginId, {
       pluginId: pkg.pluginId,
       version: pkg.version,
@@ -127,11 +154,13 @@ export class PluginRegistryService implements OnModuleInit {
       verifiedByKeyId: pkg.verifiedByKeyId,
       archive: pkg.archive,
     });
+    this.replaceIndexerDescriptors(pkg.pluginId, descriptorCheck.descriptors);
     return { ok: true, pluginId: pkg.pluginId };
   }
 
   unregister(pluginId: string): void {
     this.registry.delete(pluginId);
+    this.replaceIndexerDescriptors(pluginId, []);
   }
 
   list(): RegisteredPlugin[] {
@@ -140,6 +169,82 @@ export class PluginRegistryService implements OnModuleInit {
 
   get(pluginId: string): RegisteredPlugin | undefined {
     return this.registry.get(pluginId);
+  }
+
+  /** The descriptor behind a namespaced `Indexer.implementation`, if that plugin is currently registered. */
+  getIndexerDescriptor(implementationId: string): IndexerDescriptor | undefined {
+    return this.indexerDescriptors.get(implementationId)?.descriptor;
+  }
+
+  /** Every indexer descriptor currently on offer, for the discovery route. */
+  listIndexerDescriptors(): ({ implementationId: string; pluginId: string } & IndexerDescriptor)[] {
+    return [...this.indexerDescriptors.entries()].map(([implementationId, { pluginId, descriptor }]) => ({
+      implementationId,
+      pluginId,
+      ...descriptor,
+    }));
+  }
+
+  /** Drops this plugin's previous descriptors (if any) and installs `descriptors` in their place. */
+  private replaceIndexerDescriptors(pluginId: string, descriptors: IndexerDescriptor[]): void {
+    for (const [id, entry] of this.indexerDescriptors) {
+      if (entry.pluginId === pluginId) this.indexerDescriptors.delete(id);
+    }
+    for (const descriptor of descriptors) {
+      this.indexerDescriptors.set(buildIndexerImplementationId(pluginId, descriptor.key), { pluginId, descriptor });
+    }
+  }
+
+  /**
+   * `manifest.provides.indexers` is untrusted JSON (`unknown[]` at the type
+   * level — see `manifest.ts`), so each entry is read defensively rather
+   * than trusted as an `IndexerDescriptor`. Each violation gets its own
+   * reason so a refusal is attributable, mirroring
+   * `validateDataTierManifest`'s one-code-per-key style.
+   */
+  private validateIndexerDescriptors(
+    raw: unknown[],
+  ):
+    | { ok: true; descriptors: IndexerDescriptor[] }
+    | { ok: false; reason: PluginRegistrationFailureReason; detail: string } {
+    const descriptors: IndexerDescriptor[] = [];
+    const seenKeys = new Set<string>();
+    for (const entry of raw) {
+      const d = (entry ?? {}) as Partial<IndexerDescriptor>;
+      const key = typeof d.key === 'string' ? d.key : '';
+      const driverApi = typeof d.driverApi === 'string' ? d.driverApi : '';
+      const endpoint = typeof d.endpoint === 'string' ? d.endpoint : '';
+      const name = typeof d.name === 'string' ? d.name : '';
+      const settings = Array.isArray(d.settings) ? d.settings : [];
+
+      if (!SUPPORTED_INDEXER_DRIVER_APIS.has(driverApi)) {
+        return {
+          ok: false,
+          reason: 'unsupported-indexer-driver',
+          detail: `descriptor "${key}" needs driverApi "${driverApi}", which core does not support (supported: ${[...SUPPORTED_INDEXER_DRIVER_APIS].join(', ')})`,
+        };
+      }
+      if (!key || key.includes(INDEXER_ID_SEPARATOR)) {
+        return {
+          ok: false,
+          reason: 'invalid-indexer-key',
+          detail: `indexer key "${key}" is empty or contains "${INDEXER_ID_SEPARATOR}"`,
+        };
+      }
+      if (seenKeys.has(key)) {
+        return { ok: false, reason: 'invalid-indexer-key', detail: `duplicate indexer key "${key}"` };
+      }
+      seenKeys.add(key);
+      if (!isAbsoluteHttpUrl(endpoint)) {
+        return {
+          ok: false,
+          reason: 'invalid-indexer-endpoint',
+          detail: `descriptor "${key}" has an invalid endpoint "${endpoint}"`,
+        };
+      }
+      descriptors.push({ key, name, driverApi, endpoint, settings });
+    }
+    return { ok: true, descriptors };
   }
 
   private fail(pluginId: string, reason: PluginRegistrationFailureReason, detail: string): PluginRegistrationFailure {

--- a/backend/src/modules/plugins/plugins.module.ts
+++ b/backend/src/modules/plugins/plugins.module.ts
@@ -5,11 +5,12 @@ import { PluginSource } from './entities/plugin-source.entity';
 import { PluginRegistration } from './entities/plugin-registration.entity';
 import { PluginRegistryService } from './plugin-registry.service';
 import { PluginLogoController } from './plugin-logo.controller';
+import { PluginIndexerDescriptorsController } from './plugin-indexer-descriptors.controller';
 import { AuthModule } from '../auth/auth.module';
 
 @Module({
   imports: [TypeOrmModule.forFeature([PluginPackage, PluginSource, PluginRegistration]), AuthModule],
-  controllers: [PluginLogoController],
+  controllers: [PluginLogoController, PluginIndexerDescriptorsController],
   providers: [PluginRegistryService],
   exports: [TypeOrmModule, PluginRegistryService],
 })


### PR DESCRIPTION
PR 6.3, first half. The `data` tier's argument is that a second Torznab-compatible tracker needs no process, no signature ceremony and no restart — just a descriptor over the parser core already has.

A plugin declares the tracker's name, its driver, the endpoint an admin would otherwise hunt down and type, and the credential fields the user fills. Those fields **reuse the existing `FieldDef` vocabulary** rather than inventing a second one — a tracker's api key is entered by the same machinery as any other plugin credential, including `secret`.

**Namespacing.** The value stored in `Indexer.implementation` is `<pluginId>.<key>`, so two plugins cannot collide and a row orphaned by an uninstall still names its definer. Plugin ids are reverse-domain and contain dots themselves, so the split is from the right and a key may not contain the separator — enforced at registration, not assumed.

**Refusals happen at registration, not at search time.** Core has no newznab parser; the word appears in exactly one comment in `torznab.service.ts`, so the plan's "rss-torznab/rss-newznab parsers" is aspirational for that half. A `newznab` descriptor is therefore refused with a reason naming the missing driver, rather than accepted and then silently dead when someone searches. Duplicate keys and non-absolute endpoints likewise.

**The regression that matters** is the plain-`torznab` path every current install uses. It is untouched, and a test pins its exact outgoing URL through an axios adapter stub rather than asserting pass/fail. An indexer naming an *unregistered* descriptor is skipped with a log line — never falling through to "raw Torznab with an empty base URL".

**Changed from the agent's pass:** it typed `provides.indexers` as `unknown[]` because a frozen spec fixture (`[{ id: 'x' }]`) would not compile against the real type. That is a fixture dictating the contract. The field is now `IndexerDescriptor[]` and the fixture is a valid descriptor — its assertion is untouched and the file's `it(` count is unchanged at 13.

Verified: `tsc` 0, suite **91/861** (+12), and the discovery route answers `200 []` against the running stack with an empty registry.

## Two gaps, deliberately left and filed

1. **This is inert end to end until the create path accepts a descriptor id.** `CreateIndexerDto.implementation` is still `@IsIn(['torznab'])`, so an admin cannot yet add a plugin-backed indexer — only discovery and search-side resolution exist.
2. **RSS sync and caps refresh** read `settings.baseUrl` directly and do not go through descriptor resolution, so a descriptor-backed indexer would degrade silently (no RSS, caps stuck false) rather than crash.

Both are the same missing piece — making descriptor-backed indexers actually creatable and complete — and both are unreachable today precisely because of (1). Filed together rather than half-done here.

The **webhook dispatcher**, the other half of the plan's 6.3 line, is independent and gets its own PR.