### PR TITLE
feat(plugins): deliver domain events to plugin-declared webhooks

### DIFF
--- a/backend/src/common/plugin-contract/manifest.ts
+++ b/backend/src/common/plugin-contract/manifest.ts
@@ -3,6 +3,42 @@ import type { UiContribution, ConfigPage } from './ui-contribution';
 import type { PluginScope } from './principal';
 
 /**
+ * Domain event names a `data` plugin's webhook may subscribe to. Mirrors
+ * `DomainEvent['type']` in `modules/scheduler/events.service.ts` verbatim: this
+ * island may not import from the rest of the backend (see the module doc below),
+ * so the catalog is restated here and `PluginRegistryService` asserts the two
+ * stay in sync.
+ */
+export const PLUGIN_WEBHOOK_EVENT_NAMES = [
+  'media.imported',
+  'media.monitored.changed',
+  'media.season.monitored.changed',
+  'media.removed',
+  'media.files.imported',
+  'media.acquisition.requested',
+  'acquisition.grabbed',
+  'request.created',
+  'request.approved',
+  'library.scan.completed',
+  'settings.changed',
+] as const;
+
+export type PluginWebhookEventName = (typeof PLUGIN_WEBHOOK_EVENT_NAMES)[number];
+
+/**
+ * One `events[]` entry: POST the event to `webhook` when `event` fires. Both
+ * fields are optional at the type level — a manifest is untrusted JSON, so
+ * `PluginRegistryService` validates every entry before believing it (same
+ * posture as `provides.indexers`).
+ */
+export interface PluginWebhookDeclaration {
+  event: PluginWebhookEventName;
+  /** An absolute https URL. Validated again at registration and at every
+   *  dispatch: a manifest is untrusted JSON and DNS can move under it. */
+  webhook: string;
+}
+
+/**
  * `data` ships JSON descriptors and executes nothing; `process` ships one
  * bundled JS file that core spawns as a child process. The baseline's
  * third tier, `bundled`, is deleted: in-repo code is just core now.
@@ -50,7 +86,7 @@ interface PluginManifestBase {
     configPages?: ConfigPage[];
   };
   /** `data`-tier outbound notifications only. */
-  events?: { webhook?: string }[];
+  events?: PluginWebhookDeclaration[];
   i18n?: Record<string, Record<string, string>>;
 }
 

--- a/backend/src/modules/plugins/data-tier-manifest.validator.spec.ts
+++ b/backend/src/modules/plugins/data-tier-manifest.validator.spec.ts
@@ -26,7 +26,9 @@ describe('validateDataTierManifest()', () => {
           },
         ],
       },
-      events: [{ webhook: 'https://example.invalid/hook' }],
+      events: [
+        { event: 'media.imported', webhook: 'https://example.invalid/hook' },
+      ],
     });
     expect(validateDataTierManifest(manifest).ok).toBe(true);
   });

--- a/backend/src/modules/plugins/internal-address.spec.ts
+++ b/backend/src/modules/plugins/internal-address.spec.ts
@@ -1,0 +1,39 @@
+import { isInternalAddress } from './internal-address';
+
+/**
+ * A plugin-supplied webhook URL is the only outbound reach a `data` plugin has,
+ * so this table is the tier's security boundary. Both spellings of the
+ * IPv4-mapped form are here on purpose: a check that recognises only the
+ * compressed one is bypassed by writing the other.
+ */
+describe('isInternalAddress', () => {
+  const cases: [string, boolean][] = [
+  ['127.0.0.1', true], ['10.1.2.3', true], ['169.254.169.254', true],
+  ['172.16.0.1', true], ['172.31.255.255', true], ['192.168.1.1', true],
+  ['0.0.0.0', true], ['::1', true], ['::', true], ['fe80::1', true],
+  ['fc00::1', true], ['fd12:3456::1', true], ['::ffff:127.0.0.1', true],
+  ['8.8.8.8', false], ['1.1.1.1', false], ['2606:4700::1111', false],
+  ['172.32.0.1', false], ['172.15.0.1', false], ['192.169.1.1', false],
+  // adversarial forms
+  ['::ffff:10.0.0.1', true],
+  ['::FFFF:169.254.169.254', true],
+  ['0:0:0:0:0:ffff:127.0.0.1', true],
+  ['64:ff9b::127.0.0.1', true],
+  ['fe80:0000:0000:0000:0000:0000:0000:0001', true],
+  ['100.64.0.1', true],
+  ['198.18.0.1', true],
+  ['192.0.0.1', true],
+  ['255.255.255.255', true],
+  ['224.0.0.1', true],
+];
+
+  it.each(cases)('%s -> blocked=%s', (ip, blocked) => {
+    expect(isInternalAddress(ip)).toBe(blocked);
+  });
+
+  it('refuses anything that is not a literal IP', () => {
+    for (const bogus of ['', 'example.com', '127.0.0.1.evil.com', '0x7f000001']) {
+      expect(isInternalAddress(bogus)).toBe(true);
+    }
+  });
+});

--- a/backend/src/modules/plugins/internal-address.ts
+++ b/backend/src/modules/plugins/internal-address.ts
@@ -1,0 +1,96 @@
+import * as net from 'net';
+
+/** IPv4 space a plugin-supplied webhook may never target, as CIDRs. Beyond the
+ *  obvious private ranges: CGNAT is real internal space on many hosts, and the
+ *  reserved/benchmark/multicast blocks have no business receiving a webhook. */
+const BLOCKED_V4: ReadonlyArray<readonly [string, number]> = [
+  ['0.0.0.0', 8], // "this network"
+  ['10.0.0.0', 8], // RFC1918
+  ['100.64.0.0', 10], // RFC6598 CGNAT
+  ['127.0.0.0', 8], // loopback
+  ['169.254.0.0', 16], // link-local, incl. cloud metadata
+  ['172.16.0.0', 12], // RFC1918
+  ['192.0.0.0', 24], // IETF protocol assignments
+  ['192.0.2.0', 24], // TEST-NET-1
+  ['192.168.0.0', 16], // RFC1918
+  ['198.18.0.0', 15], // RFC2544 benchmarking
+  ['198.51.100.0', 24], // TEST-NET-2
+  ['203.0.113.0', 24], // TEST-NET-3
+  ['224.0.0.0', 4], // multicast
+  ['240.0.0.0', 4], // reserved, incl. 255.255.255.255
+];
+
+function v4ToInt(ip: string): number {
+  return ip.split('.').reduce((n, octet) => n * 256 + Number(octet), 0) >>> 0;
+}
+
+function inV4Cidr(ip: string, base: string, bits: number): boolean {
+  const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+  return ((v4ToInt(ip) & mask) >>> 0) === ((v4ToInt(base) & mask) >>> 0);
+}
+
+/** Expand any legal IPv6 text to its eight 16-bit groups. */
+function expandV6(ip: string): number[] | null {
+  const [head, tail] = ip.split('::');
+  const parse = (s: string) =>
+    s ? s.split(':').filter(Boolean).map((g) => parseInt(g, 16)) : [];
+  // A trailing dotted quad (mapped or NAT64) occupies the last two groups.
+  const embedded = /(\d+\.\d+\.\d+\.\d+)$/.exec(ip)?.[1];
+  const strip = (s: string) => (embedded ? s.replace(/(:)?[\d.]+$/, '') : s);
+  const groups = embedded
+    ? (() => {
+        const n = v4ToInt(embedded);
+        return [(n >>> 16) & 0xffff, n & 0xffff];
+      })()
+    : [];
+  const left = parse(strip(head ?? ''));
+  const right = tail === undefined ? [] : parse(strip(tail));
+  const known = left.length + right.length + groups.length;
+  if (tail === undefined) {
+    return known === 8 ? [...left, ...groups] : null;
+  }
+  if (known > 8) return null;
+  return [...left, ...new Array(8 - known).fill(0), ...right, ...groups];
+}
+
+/**
+ * True if `ip` is an address a plugin-supplied webhook may not target:
+ * loopback, link-local, private, CGNAT, reserved or multicast.
+ *
+ * Works on the numeric value, not the text shape — `::ffff:127.0.0.1` and
+ * `0:0:0:0:0:ffff:127.0.0.1` are the same address, and a check that only
+ * recognises the compressed spelling is bypassed by writing the other one.
+ * Anything that is not a literal IP is refused rather than guessed at.
+ */
+export function isInternalAddress(ip: string): boolean {
+  const version = net.isIP(ip);
+  if (version === 0) return true;
+
+  if (version === 4) {
+    return BLOCKED_V4.some(([base, bits]) => inV4Cidr(ip, base, bits));
+  }
+
+  const groups = expandV6(ip);
+  if (!groups) return true;
+
+  // IPv4-mapped (::ffff:0:0/96) and NAT64 (64:ff9b::/96) both carry a real
+  // IPv4 destination in the last two groups; judge it as IPv4.
+  const isMapped =
+    groups.slice(0, 5).every((g) => g === 0) && groups[5] === 0xffff;
+  const isNat64 =
+    groups[0] === 0x64 &&
+    groups[1] === 0xff9b &&
+    groups.slice(2, 6).every((g) => g === 0);
+  if (isMapped || isNat64) {
+    const n = (groups[6] << 16) + groups[7];
+    const v4 = [24, 16, 8, 0].map((s) => (n >>> s) & 0xff).join('.');
+    return BLOCKED_V4.some(([base, bits]) => inV4Cidr(v4, base, bits));
+  }
+
+  if (groups.every((g) => g === 0)) return true; // ::
+  if (groups.slice(0, 7).every((g) => g === 0) && groups[7] === 1) return true; // ::1
+  if ((groups[0] & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
+  if ((groups[0] & 0xfe00) === 0xfc00) return true; // fc00::/7 unique-local
+  if ((groups[0] & 0xff00) === 0xff00) return true; // ff00::/8 multicast
+  return false;
+}

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -3,18 +3,38 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as net from 'net';
 import * as semver from 'semver';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { arePluginsDisabled, FLIKS_PLUGINS_DISABLED_ENV } from '../../common/constants/plugin-flags';
 import {
   PLUGIN_API_VERSION,
+  PLUGIN_WEBHOOK_EVENT_NAMES,
   buildIndexerImplementationId,
   INDEXER_ID_SEPARATOR,
   type PluginKind,
   type PluginManifest,
   type IndexerDescriptor,
+  type PluginWebhookEventName,
 } from '../../common/plugin-contract';
 import { OFFICIAL_KEYS, resolveTrust, readArchiveEntries, type TrustOutcome } from './archive';
+import { isInternalAddress } from './internal-address';
+import type { DomainEvent } from '../scheduler/events.service';
+
+const WEBHOOK_EVENT_NAMES: ReadonlySet<string> = new Set(PLUGIN_WEBHOOK_EVENT_NAMES);
+
+/**
+ * Fails to typecheck if the contract's webhook catalog and `DomainEvent`'s ever
+ * drift apart. `plugin-contract/` cannot import `DomainEvent` (island rule), so
+ * this file — which may import both — is where the two are asserted to agree.
+ */
+type AssertSameStringUnion<A extends string, B extends string> = [A] extends [B]
+  ? [B] extends [A]
+    ? unknown
+    : never
+  : never;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const _webhookCatalogMatchesDomainEvents: AssertSameStringUnion<PluginWebhookEventName, DomainEvent['type']> = true;
 
 /** Same pattern as `UpdateCheckService`/`SystemController` — no shared version util exists yet. */
 const CURRENT_FLIKS_VERSION: string = (() => {
@@ -57,7 +77,11 @@ export type PluginRegistrationFailureReason =
   | 'incompatible-fliks'
   | 'unsupported-indexer-driver'
   | 'invalid-indexer-key'
-  | 'invalid-indexer-endpoint';
+  | 'invalid-indexer-endpoint'
+  | 'invalid-webhook-event'
+  | 'invalid-webhook-url'
+  | 'insecure-webhook-scheme'
+  | 'internal-webhook-host';
 
 export interface PluginRegistrationSuccess {
   ok: true;
@@ -85,6 +109,9 @@ export class PluginRegistryService implements OnModuleInit {
   private readonly registry = new Map<string, RegisteredPlugin>();
   /** Keyed by the namespaced id (`buildIndexerImplementationId`), rebuilt per plugin on every `register()`. */
   private readonly indexerDescriptors = new Map<string, { pluginId: string; descriptor: IndexerDescriptor }>();
+  /** Keyed by plugin id; entries are already validated (URL, scheme, event name) — the
+   *  dispatcher trusts this without re-checking any of that. */
+  private readonly webhookDeclarations = new Map<string, { event: PluginWebhookEventName; webhook: string }[]>();
 
   constructor(
     @InjectRepository(PluginPackage)
@@ -145,6 +172,13 @@ export class PluginRegistryService implements OnModuleInit {
     const descriptorCheck = this.validateIndexerDescriptors(manifest.provides?.indexers ?? []);
     if (!descriptorCheck.ok) return this.fail(pkg.pluginId, descriptorCheck.reason, descriptorCheck.detail);
 
+    // `events` is a `PluginManifestBase` field so it's structurally legal on `process` too, but
+    // the `unsupported-tier` bail above already refuses every process manifest before reaching
+    // here — so in practice this only ever runs for `data`, which is the only tier the webhook
+    // dispatcher fans out to.
+    const webhookCheck = this.validateWebhookDeclarations(manifest.events ?? []);
+    if (!webhookCheck.ok) return this.fail(pkg.pluginId, webhookCheck.reason, webhookCheck.detail);
+
     this.registry.set(pkg.pluginId, {
       pluginId: pkg.pluginId,
       version: pkg.version,
@@ -155,12 +189,14 @@ export class PluginRegistryService implements OnModuleInit {
       archive: pkg.archive,
     });
     this.replaceIndexerDescriptors(pkg.pluginId, descriptorCheck.descriptors);
+    this.replaceWebhookDeclarations(pkg.pluginId, webhookCheck.declarations);
     return { ok: true, pluginId: pkg.pluginId };
   }
 
   unregister(pluginId: string): void {
     this.registry.delete(pluginId);
     this.replaceIndexerDescriptors(pluginId, []);
+    this.replaceWebhookDeclarations(pluginId, []);
   }
 
   list(): RegisteredPlugin[] {
@@ -183,6 +219,23 @@ export class PluginRegistryService implements OnModuleInit {
       pluginId,
       ...descriptor,
     }));
+  }
+
+  /** Every registered webhook subscribed to `eventType` — the dispatcher's fan-out list. */
+  listWebhooksForEvent(eventType: string): { pluginId: string; webhook: string }[] {
+    const out: { pluginId: string; webhook: string }[] = [];
+    for (const [pluginId, declarations] of this.webhookDeclarations) {
+      for (const d of declarations) {
+        if (d.event === eventType) out.push({ pluginId, webhook: d.webhook });
+      }
+    }
+    return out;
+  }
+
+  /** Drops this plugin's previous webhooks (if any) and installs `declarations` in their place. */
+  private replaceWebhookDeclarations(pluginId: string, declarations: { event: PluginWebhookEventName; webhook: string }[]): void {
+    if (declarations.length === 0) this.webhookDeclarations.delete(pluginId);
+    else this.webhookDeclarations.set(pluginId, declarations);
   }
 
   /** Drops this plugin's previous descriptors (if any) and installs `descriptors` in their place. */
@@ -245,6 +298,45 @@ export class PluginRegistryService implements OnModuleInit {
       descriptors.push({ key, name, driverApi, endpoint, settings });
     }
     return { ok: true, descriptors };
+  }
+
+  /**
+   * `manifest.events` is untrusted JSON like `provides.indexers`, so each entry
+   * is read defensively. `event` must be a name from the webhook catalog; `webhook`
+   * must be an `https://` URL whose host, when it's an IP literal, isn't internal.
+   * A bare hostname is accepted here — DNS isn't resolved at install time, and
+   * resolving it wouldn't help anyway (it can repoint after the check); the
+   * dispatcher re-resolves and re-checks on every delivery instead.
+   */
+  private validateWebhookDeclarations(
+    raw: unknown[],
+  ):
+    | { ok: true; declarations: { event: PluginWebhookEventName; webhook: string }[] }
+    | { ok: false; reason: PluginRegistrationFailureReason; detail: string } {
+    const declarations: { event: PluginWebhookEventName; webhook: string }[] = [];
+    for (const entry of raw) {
+      const d = entry as { event?: unknown; webhook?: unknown } | null | undefined;
+      const event = typeof d?.event === 'string' ? d.event : '';
+      const webhook = typeof d?.webhook === 'string' ? d.webhook : '';
+
+      if (!WEBHOOK_EVENT_NAMES.has(event)) {
+        return { ok: false, reason: 'invalid-webhook-event', detail: `event "${event}" is not a recognised domain event` };
+      }
+      let url: URL;
+      try {
+        url = new URL(webhook);
+      } catch {
+        return { ok: false, reason: 'invalid-webhook-url', detail: `webhook "${webhook}" is not a valid URL` };
+      }
+      if (url.protocol !== 'https:') {
+        return { ok: false, reason: 'insecure-webhook-scheme', detail: `webhook "${webhook}" must use https, got "${url.protocol}"` };
+      }
+      if (net.isIP(url.hostname) !== 0 && isInternalAddress(url.hostname)) {
+        return { ok: false, reason: 'internal-webhook-host', detail: `webhook host "${url.hostname}" is an internal address` };
+      }
+      declarations.push({ event: event as PluginWebhookEventName, webhook });
+    }
+    return { ok: true, declarations };
   }
 
   private fail(pluginId: string, reason: PluginRegistrationFailureReason, detail: string): PluginRegistrationFailure {

--- a/backend/src/modules/plugins/plugin-registry.service.webhooks.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.webhooks.spec.ts
@@ -1,0 +1,151 @@
+import { PluginRegistryService } from './plugin-registry.service';
+import { PluginPackage } from './entities/plugin-package.entity';
+import { minimalDataManifest, minimalProcessManifest } from './archive/test-manifests';
+import type { PluginManifest, PluginWebhookDeclaration } from '../../common/plugin-contract';
+
+/** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
+const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
+
+function makePackage(manifest: PluginManifest, overrides: Partial<PluginPackage> = {}): PluginPackage {
+  return {
+    id: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    pluginId: manifest.id,
+    version: manifest.version,
+    // Webhook validation never re-verifies the archive (verifiedByKeyId is null), so its bytes don't matter.
+    archive: Buffer.alloc(0),
+    origin: 'manual',
+    signature: 'unsigned',
+    verifiedByKeyId: null,
+    manifest,
+    status: 'active',
+    ...overrides,
+  } as PluginPackage;
+}
+
+function repoMock(): { find: jest.Mock } {
+  return { find: jest.fn().mockResolvedValue([]) };
+}
+
+function webhookDeclaration(overrides: Partial<PluginWebhookDeclaration> = {}): PluginWebhookDeclaration {
+  return { event: 'media.imported', webhook: 'https://hooks.example.com/fliks', ...overrides };
+}
+
+describe('PluginRegistryService — webhooks', () => {
+  it('refuses a plain-http webhook URL', async () => {
+    const manifest = minimalDataManifest({
+      fliks: COMPATIBLE_RANGE,
+      events: [webhookDeclaration({ webhook: 'http://hooks.example.com/fliks' })],
+    });
+    const service = new PluginRegistryService(repoMock() as never);
+
+    const result = await service.register(makePackage(manifest));
+
+    expect(result).toEqual({
+      ok: false,
+      pluginId: manifest.id,
+      reason: 'insecure-webhook-scheme',
+      detail: expect.any(String),
+    });
+  });
+
+  it.each([
+    ['loopback', 'https://127.0.0.1/hook'],
+    ['RFC1918', 'https://10.0.0.5/hook'],
+    ['link-local', 'https://169.254.169.254/hook'],
+  ])('refuses an IP-literal %s webhook host', async (_label, webhook) => {
+    const manifest = minimalDataManifest({
+      fliks: COMPATIBLE_RANGE,
+      events: [webhookDeclaration({ webhook })],
+    });
+    const service = new PluginRegistryService(repoMock() as never);
+
+    const result = await service.register(makePackage(manifest));
+
+    expect(result).toEqual({
+      ok: false,
+      pluginId: manifest.id,
+      reason: 'internal-webhook-host',
+      detail: expect.stringContaining(new URL(webhook).hostname),
+    });
+  });
+
+  it('refuses a malformed webhook URL', async () => {
+    const manifest = minimalDataManifest({
+      fliks: COMPATIBLE_RANGE,
+      events: [webhookDeclaration({ webhook: 'not-a-url' })],
+    });
+    const service = new PluginRegistryService(repoMock() as never);
+
+    const result = await service.register(makePackage(manifest));
+
+    expect(result).toEqual({
+      ok: false,
+      pluginId: manifest.id,
+      reason: 'invalid-webhook-url',
+      detail: expect.stringContaining('not-a-url'),
+    });
+  });
+
+  it('refuses an event name outside the domain-event catalog', async () => {
+    const manifest = minimalDataManifest({
+      fliks: COMPATIBLE_RANGE,
+      events: [{ event: 'media.deleted-forever', webhook: 'https://hooks.example.com/fliks' } as unknown as PluginWebhookDeclaration],
+    });
+    const service = new PluginRegistryService(repoMock() as never);
+
+    const result = await service.register(makePackage(manifest));
+
+    expect(result).toEqual({
+      ok: false,
+      pluginId: manifest.id,
+      reason: 'invalid-webhook-event',
+      detail: expect.stringContaining('media.deleted-forever'),
+    });
+  });
+
+  it('registers a valid https webhook on a public host and exposes it to the dispatcher', async () => {
+    const manifest = minimalDataManifest({
+      fliks: COMPATIBLE_RANGE,
+      events: [webhookDeclaration()],
+    });
+    const service = new PluginRegistryService(repoMock() as never);
+
+    const result = await service.register(makePackage(manifest));
+
+    expect(result).toEqual({ ok: true, pluginId: manifest.id });
+    expect(service.listWebhooksForEvent('media.imported')).toEqual([
+      { pluginId: manifest.id, webhook: 'https://hooks.example.com/fliks' },
+    ]);
+  });
+
+  it('drops a plugin webhooks on unregister', async () => {
+    const manifest = minimalDataManifest({ fliks: COMPATIBLE_RANGE, events: [webhookDeclaration()] });
+    const service = new PluginRegistryService(repoMock() as never);
+    await service.register(makePackage(manifest));
+    expect(service.listWebhooksForEvent('media.imported')).toHaveLength(1);
+
+    service.unregister(manifest.id);
+
+    expect(service.listWebhooksForEvent('media.imported')).toEqual([]);
+  });
+
+  it('refuses a process-tier manifest declaring a webhook (process is not a supported tier yet)', async () => {
+    const manifest = minimalProcessManifest(
+      { 'plugin.js': 'a'.repeat(64), 'logo.png': 'b'.repeat(64) },
+      { fliks: COMPATIBLE_RANGE, events: [webhookDeclaration()] },
+    );
+    const service = new PluginRegistryService(repoMock() as never);
+
+    const result = await service.register(makePackage(manifest));
+
+    expect(result).toEqual({
+      ok: false,
+      pluginId: manifest.id,
+      reason: 'unsupported-tier',
+      detail: expect.any(String),
+    });
+    expect(service.listWebhooksForEvent('media.imported')).toEqual([]);
+  });
+});

--- a/backend/src/modules/plugins/plugin-webhook-dispatcher.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-webhook-dispatcher.service.spec.ts
@@ -1,0 +1,127 @@
+import axios, { AxiosRequestConfig } from 'axios';
+import * as dns from 'dns';
+import { PluginWebhookDispatcherService } from './plugin-webhook-dispatcher.service';
+import { EventsService } from '../scheduler/events.service';
+import { PluginRegistryService } from './plugin-registry.service';
+
+jest.mock('dns', () => ({ promises: { lookup: jest.fn() } }));
+
+function registryStub(map: Record<string, { pluginId: string; webhook: string }[]>): PluginRegistryService {
+  return { listWebhooksForEvent: jest.fn((eventType: string) => map[eventType] ?? []) } as unknown as PluginRegistryService;
+}
+
+const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+describe('PluginWebhookDispatcherService', () => {
+  const originalAdapter = axios.defaults.adapter;
+  let requests: { url: string; data: unknown }[];
+  const lookupMock = jest.mocked(dns.promises.lookup);
+
+  beforeEach(() => {
+    requests = [];
+    lookupMock.mockReset();
+    lookupMock.mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never);
+    axios.defaults.adapter = (config: AxiosRequestConfig) => {
+      requests.push({ url: String(config.url), data: config.data ? JSON.parse(String(config.data)) : undefined });
+      return Promise.resolve({ data: {}, status: 200, statusText: 'OK', headers: {}, config }) as never;
+    };
+  });
+
+  afterEach(() => {
+    axios.defaults.adapter = originalAdapter;
+  });
+
+  it('delivers a fired event to the plugin subscribed to it', async () => {
+    const registry = registryStub({
+      'media.imported': [{ pluginId: 'fliks.plugin-a', webhook: 'https://hooks.example/a' }],
+    });
+    const events = new EventsService();
+    new PluginWebhookDispatcherService(events, registry).onModuleInit();
+
+    events.emitDomain({ type: 'media.imported', mediaId: 1, tmdbId: null, mediaType: 'movie', libraryId: null, addedByUserId: null });
+    await flush();
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].url).toBe('https://hooks.example/a');
+  });
+
+  it('does not deliver to a plugin subscribed to a different event', async () => {
+    const registry = registryStub({}); // nothing subscribed to media.removed
+    const events = new EventsService();
+    new PluginWebhookDispatcherService(events, registry).onModuleInit();
+
+    events.emitDomain({ type: 'media.removed', mediaId: 1, tmdbId: null, mediaType: 'movie' });
+    await flush();
+
+    expect(requests).toHaveLength(0);
+  });
+
+  it('delivers to two plugins subscribed to the same event', async () => {
+    const registry = registryStub({
+      'settings.changed': [
+        { pluginId: 'fliks.plugin-a', webhook: 'https://hooks.example/a' },
+        { pluginId: 'fliks.plugin-b', webhook: 'https://hooks.example/b' },
+      ],
+    });
+    const events = new EventsService();
+    new PluginWebhookDispatcherService(events, registry).onModuleInit();
+
+    events.emitDomain({ type: 'settings.changed', key: 'library_path' });
+    await flush();
+
+    expect(requests.map((r) => r.url).sort()).toEqual(['https://hooks.example/a', 'https://hooks.example/b']);
+  });
+
+  it('does not call out when the host resolves to a private address at dispatch time (DNS rebinding)', async () => {
+    lookupMock.mockResolvedValue([{ address: '10.0.0.5', family: 4 }] as never);
+    const registry = registryStub({
+      'settings.changed': [{ pluginId: 'fliks.rebinder', webhook: 'https://rebinder.example/hook' }],
+    });
+    const events = new EventsService();
+    new PluginWebhookDispatcherService(events, registry).onModuleInit();
+
+    events.emitDomain({ type: 'settings.changed', key: 'x' });
+    await flush();
+
+    expect(requests).toHaveLength(0);
+  });
+
+  it('logs and swallows a rejecting webhook, and still delivers to a second plugin for the same event', async () => {
+    const registry = registryStub({
+      'settings.changed': [
+        { pluginId: 'fliks.failing', webhook: 'https://failing.example/hook' },
+        { pluginId: 'fliks.ok', webhook: 'https://ok.example/hook' },
+      ],
+    });
+    axios.defaults.adapter = (config: AxiosRequestConfig) => {
+      if (String(config.url).includes('failing')) return Promise.reject(new Error('timeout')) as never;
+      requests.push({ url: String(config.url), data: config.data ? JSON.parse(String(config.data)) : undefined });
+      return Promise.resolve({ data: {}, status: 200, statusText: 'OK', headers: {}, config }) as never;
+    };
+    const events = new EventsService();
+    new PluginWebhookDispatcherService(events, registry).onModuleInit();
+
+    // emitDomain is synchronous and void — the caller (and the emitter's own contract) is never affected.
+    expect(() => events.emitDomain({ type: 'settings.changed', key: 'x' })).not.toThrow();
+    await flush();
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].url).toBe('https://ok.example/hook');
+  });
+
+  it('POSTs exactly the event and the plugin id — nothing else', async () => {
+    const registry = registryStub({
+      'media.removed': [{ pluginId: 'fliks.plugin-a', webhook: 'https://hooks.example/a' }],
+    });
+    const events = new EventsService();
+    new PluginWebhookDispatcherService(events, registry).onModuleInit();
+
+    events.emitDomain({ type: 'media.removed', mediaId: 42, tmdbId: 99, mediaType: 'movie' });
+    await flush();
+
+    expect(requests[0].data).toEqual({
+      event: { type: 'media.removed', mediaId: 42, tmdbId: 99, mediaType: 'movie' },
+      pluginId: 'fliks.plugin-a',
+    });
+  });
+});

--- a/backend/src/modules/plugins/plugin-webhook-dispatcher.service.ts
+++ b/backend/src/modules/plugins/plugin-webhook-dispatcher.service.ts
@@ -1,0 +1,84 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { Subscription } from 'rxjs';
+import axios from 'axios';
+import * as dns from 'dns';
+import { EventsService, type DomainEvent } from '../scheduler/events.service';
+import { PluginRegistryService } from './plugin-registry.service';
+import { isInternalAddress } from './internal-address';
+
+const WEBHOOK_TIMEOUT_MS = 5_000;
+/** Core never reads the body — cap it so a hostile endpoint can't hold the connection streaming data. */
+const WEBHOOK_MAX_RESPONSE_BYTES = 64 * 1024;
+
+/**
+ * Fans a domain event out to every `data` plugin webhook subscribed to it.
+ * Mirrors `EventsService.onDomain`'s at-most-once/no-retry contract: a slow or
+ * failing webhook is logged and never reaches the emitter.
+ */
+@Injectable()
+export class PluginWebhookDispatcherService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(PluginWebhookDispatcherService.name);
+  private readonly subscription = new Subscription();
+
+  constructor(
+    private readonly events: EventsService,
+    private readonly registry: PluginRegistryService,
+  ) {}
+
+  onModuleInit(): void {
+    this.subscription.add(this.events.onDomain((event) => this.dispatch(event)));
+  }
+
+  onModuleDestroy(): void {
+    this.subscription.unsubscribe();
+  }
+
+  private async dispatch(event: DomainEvent): Promise<void> {
+    const targets = this.registry.listWebhooksForEvent(event.type);
+    await Promise.allSettled(targets.map((t) => this.deliver(t.pluginId, t.webhook, event)));
+  }
+
+  /**
+   * Re-resolves and re-checks the host on every delivery, not only at registration — a
+   * name that validated at install can repoint later (DNS rebinding). This narrows but
+   * does not eliminate the attack: the HTTP client below re-resolves the same name to
+   * actually connect, leaving a window between this check and its connect().
+   */
+  private async deliver(pluginId: string, webhook: string, event: DomainEvent): Promise<void> {
+    let hostname: string;
+    try {
+      hostname = new URL(webhook).hostname;
+    } catch {
+      this.logger.warn(`plugin "${pluginId}" webhook skipped — "${webhook}" no longer parses as a URL`);
+      return;
+    }
+
+    let addresses: string[];
+    try {
+      addresses = (await dns.promises.lookup(hostname, { all: true })).map((a) => a.address);
+    } catch (err) {
+      this.logger.warn(`plugin "${pluginId}" webhook skipped — DNS lookup failed for "${hostname}": ${(err as Error).message}`);
+      return;
+    }
+    const internal = addresses.find(isInternalAddress);
+    if (internal) {
+      this.logger.warn(`plugin "${pluginId}" webhook skipped — "${hostname}" resolves to internal address ${internal}`);
+      return;
+    }
+
+    try {
+      await axios.post(
+        webhook,
+        { event, pluginId },
+        {
+          timeout: WEBHOOK_TIMEOUT_MS,
+          maxRedirects: 0,
+          maxContentLength: WEBHOOK_MAX_RESPONSE_BYTES,
+          headers: { 'User-Agent': 'Fliks-Plugin-Webhook/1.0', 'Content-Type': 'application/json' },
+        },
+      );
+    } catch (err) {
+      this.logger.warn(`plugin "${pluginId}" webhook delivery failed: ${(err as Error).message}`);
+    }
+  }
+}

--- a/backend/src/modules/plugins/plugins.module.ts
+++ b/backend/src/modules/plugins/plugins.module.ts
@@ -4,14 +4,16 @@ import { PluginPackage } from './entities/plugin-package.entity';
 import { PluginSource } from './entities/plugin-source.entity';
 import { PluginRegistration } from './entities/plugin-registration.entity';
 import { PluginRegistryService } from './plugin-registry.service';
+import { PluginWebhookDispatcherService } from './plugin-webhook-dispatcher.service';
 import { PluginLogoController } from './plugin-logo.controller';
 import { PluginIndexerDescriptorsController } from './plugin-indexer-descriptors.controller';
 import { AuthModule } from '../auth/auth.module';
+import { EventsModule } from '../scheduler/events.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([PluginPackage, PluginSource, PluginRegistration]), AuthModule],
+  imports: [TypeOrmModule.forFeature([PluginPackage, PluginSource, PluginRegistration]), AuthModule, EventsModule],
   controllers: [PluginLogoController, PluginIndexerDescriptorsController],
-  providers: [PluginRegistryService],
+  providers: [PluginRegistryService, PluginWebhookDispatcherService],
   exports: [TypeOrmModule, PluginRegistryService],
 })
 export class PluginsModule {}


### PR DESCRIPTION
The second half of the plan's 6.3. A `data` plugin declares `events[].webhook`; core POSTs the domain event there.

**Why this is mostly a security PR.** A `data` plugin executes no code. Its *only* capability is making core issue an outbound request to a URL its author chose — an SSRF primitive with the event payload as the exfiltration channel. The tier's promise to the user ("this plugin contains no program code, it cannot run anything on your server") is hollow unless that is guarded.

So the URL is checked **twice**:

- **at registration** — https only, and no internal address;
- **at every dispatch** — the hostname is resolved again and refused if *any* answer is internal, because a name that was public at install can point at the metadata service later. Redirects are refused for the same reason: a validated host handing off to an unvalidated one defeats the check.

## The guard was bypassable, and I found it by probing rather than reading

The first implementation matched address *shapes* with regexes. I ran it against a table of adversarial literals and 7 of 29 came back wrong — one of them a genuine bypass:

`0:0:0:0:0:ffff:127.0.0.1` is the uncompressed IPv4-mapped form of loopback. The check only recognised `::ffff:127.0.0.1`, so writing the other spelling walked straight through — and registration validates literals taken *from the manifest*, so a plugin author controls that string exactly.

It now judges the numeric value, not the text. Also newly blocked: CGNAT (`100.64.0.0/10`, real internal space on many hosts), the reserved/benchmark/documentation blocks, multicast, the broadcast address, and NAT64-embedded IPv4. All 29 probe cases are now a spec (`internal-address.spec.ts`, 30 tests) so the guard cannot silently regress.

**Residual, stated plainly:** resolve-then-connect leaves a DNS rebinding window between our lookup and axios's own; closing it fully needs a connect-time IP pin via a custom agent. A public host that itself relays to an internal target is not detectable by any IP check.

## The rest

Delivery matches the domain bus's existing guarantees — at most once, no retry, one plugin's failure never reaching the emitter or its siblings, all pinned by tests. The body is exactly the event plus the plugin id, asserted on the serialised payload so a future field cannot leak in unnoticed.

The contract's event-name union is tied to `DomainEvent` by an assignability assertion, so adding an event on one side without the other stops compiling — better than a comment asking people to remember.

**Changed from the agent's pass:** `event` and `webhook` were optional on the declaration type because a frozen fixture constructed one without `event`. That is a fixture dictating the contract — the same thing I corrected in #901. Both are required now, the fixture is a valid declaration, and its assertion and the file's `it(` count are untouched at 13.

Verified: `tsc` 0, suite **906 tests** (+45), backend boots clean.