### PR TITLE
feat(plugins): fetch and cache signed plugin catalogs

### DIFF
--- a/backend/src/modules/plugins/catalog/catalog.spec.ts
+++ b/backend/src/modules/plugins/catalog/catalog.spec.ts
@@ -1,0 +1,112 @@
+import { parseCatalogDocument, filterCatalog, type CatalogDocument, type CatalogVersionEntry } from './catalog';
+import { PLUGIN_API_VERSION } from '../../../common/plugin-contract';
+
+/** A `fliks` range every test can rely on matching this repo's own `package.json` version
+ *  (same convention as `plugin-registry.service.spec.ts`'s `COMPATIBLE_RANGE`). */
+const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
+
+function version(overrides: Partial<CatalogVersionEntry> = {}): CatalogVersionEntry {
+  return { version: '1.0.0', pluginApi: PLUGIN_API_VERSION, fliks: COMPATIBLE_RANGE, ...overrides };
+}
+
+function document(overrides: Partial<CatalogDocument['plugins'][number]> = {}): CatalogDocument {
+  return {
+    plugins: [
+      {
+        id: 'fliks.test-plugin',
+        name: 'Test plugin',
+        description: 'A fixture.',
+        author: 'Fliks',
+        kind: 'data',
+        versions: [version()],
+        ...overrides,
+      },
+    ],
+  };
+}
+
+describe('parseCatalogDocument()', () => {
+  it('parses a structurally valid document', () => {
+    const bytes = Buffer.from(JSON.stringify(document()), 'utf8');
+    expect(parseCatalogDocument(bytes)).toEqual(document());
+  });
+
+  it('returns null for bytes that are not JSON at all', () => {
+    expect(parseCatalogDocument(Buffer.from('not json{{{', 'utf8'))).toBeNull();
+  });
+
+  it('returns null when a version entry is missing a required field', () => {
+    const doc = document({ versions: [{ version: '1.0.0', fliks: COMPATIBLE_RANGE } as CatalogVersionEntry] });
+    expect(parseCatalogDocument(Buffer.from(JSON.stringify(doc), 'utf8'))).toBeNull();
+  });
+
+  it('returns null when a plugin entry has no versions at all', () => {
+    const doc = document({ versions: [] });
+    expect(parseCatalogDocument(Buffer.from(JSON.stringify(doc), 'utf8'))).toBeNull();
+  });
+
+  it('returns null when a version declares an invalid semver range', () => {
+    const doc = document({ versions: [version({ fliks: 'not-a-range' })] });
+    expect(parseCatalogDocument(Buffer.from(JSON.stringify(doc), 'utf8'))).toBeNull();
+  });
+});
+
+describe('filterCatalog()', () => {
+  it('lists a version whose pluginApi matches and whose fliks range is satisfied', () => {
+    const doc = document({ versions: [version()] });
+    const result = filterCatalog(doc, PLUGIN_API_VERSION, '2.0.1');
+    expect(result.plugins[0].installable).toEqual([version()]);
+    expect(result.plugins[0].hidden).toBeNull();
+  });
+
+  it('hides a version whose pluginApi does not match exactly, and counts it', () => {
+    const mismatched = version({ pluginApi: PLUGIN_API_VERSION + 1, fliks: COMPATIBLE_RANGE });
+    const doc = document({ versions: [mismatched] });
+    const result = filterCatalog(doc, PLUGIN_API_VERSION, '2.0.1');
+    expect(result.plugins[0].installable).toEqual([]);
+    // No version number reveals it: the mismatch is the plugin API, not the range.
+    expect(result.plugins[0].hidden).toEqual({ count: 1, minFliksVersion: null });
+  });
+
+  it('hides a version whose fliks range excludes the running core version, and counts it', () => {
+    const tooNew = version({ fliks: '>=5.0.0 <6.0.0' });
+    const doc = document({ versions: [tooNew] });
+    const result = filterCatalog(doc, PLUGIN_API_VERSION, '2.0.1');
+    expect(result.plugins[0].installable).toEqual([]);
+    expect(result.plugins[0].hidden).toEqual({ count: 1, minFliksVersion: '5.0.0' });
+  });
+
+  it('reports the minimum core version across every hidden version’s floor, not the first one', () => {
+    const needsFive = version({ version: '2.0.0', fliks: '>=5.0.0 <6.0.0' });
+    const needsFour = version({ version: '3.0.0', fliks: '>=4.0.0 <5.0.0' });
+    const doc = document({ versions: [needsFive, needsFour] });
+    const result = filterCatalog(doc, PLUGIN_API_VERSION, '2.0.1');
+    expect(result.plugins[0].hidden).toEqual({ count: 2, minFliksVersion: '4.0.0' });
+  });
+
+  it('offers no upgrade when every hidden version sits below the running core version', () => {
+    // The range's upper bound is already behind us: upgrading moves further away.
+    const tooOld = version({ fliks: '>=1.0.0 <2.0.0' });
+    const doc = document({ versions: [tooOld] });
+    const result = filterCatalog(doc, PLUGIN_API_VERSION, '2.0.1');
+    expect(result.plugins[0].hidden).toEqual({ count: 1, minFliksVersion: null });
+  });
+
+  it('keeps a plugin in the result with an empty installable list when every version is hidden', () => {
+    const doc = document({ versions: [version({ fliks: '>=5.0.0 <6.0.0' })] });
+    const result = filterCatalog(doc, PLUGIN_API_VERSION, '2.0.1');
+    expect(result.plugins).toHaveLength(1);
+    expect(result.plugins[0].id).toBe('fliks.test-plugin');
+    expect(result.plugins[0].installable).toEqual([]);
+    expect(result.plugins[0].hidden?.count).toBe(1);
+  });
+
+  it('separates installable and hidden versions of the same plugin', () => {
+    const ok = version({ version: '1.0.0' });
+    const tooNew = version({ version: '2.0.0', fliks: '>=5.0.0 <6.0.0' });
+    const doc = document({ versions: [ok, tooNew] });
+    const result = filterCatalog(doc, PLUGIN_API_VERSION, '2.0.1');
+    expect(result.plugins[0].installable).toEqual([ok]);
+    expect(result.plugins[0].hidden).toEqual({ count: 1, minFliksVersion: '5.0.0' });
+  });
+});

--- a/backend/src/modules/plugins/catalog/catalog.ts
+++ b/backend/src/modules/plugins/catalog/catalog.ts
@@ -1,0 +1,151 @@
+import * as semver from 'semver';
+import type { PluginKind } from '../../../common/plugin-contract';
+
+/**
+ * One published version's compatibility declaration — the same two axes as a plugin
+ * manifest (`pluginApi` exact, `fliks` a lower-bounded range), see
+ * `plans/plugin-system.plan.md`, "The four skew cases". Everything else about a
+ * version (download location, hashes) is install-pipeline (PR 7.2) concern and
+ * opaque here, so it passes through the index signature untouched.
+ */
+export interface CatalogVersionEntry {
+  version: string;
+  pluginApi: number;
+  fliks: string;
+  [key: string]: unknown;
+}
+
+export interface CatalogPluginEntry {
+  id: string;
+  name: string;
+  description: string;
+  author: string;
+  kind: PluginKind;
+  versions: CatalogVersionEntry[];
+}
+
+export interface CatalogDocument {
+  plugins: CatalogPluginEntry[];
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function isVersionEntry(v: unknown): v is CatalogVersionEntry {
+  return (
+    isRecord(v) &&
+    typeof v.version === 'string' &&
+    v.version.length > 0 &&
+    typeof v.pluginApi === 'number' &&
+    typeof v.fliks === 'string' &&
+    semver.validRange(v.fliks) !== null
+  );
+}
+
+function isPluginEntry(v: unknown): v is CatalogPluginEntry {
+  return (
+    isRecord(v) &&
+    typeof v.id === 'string' &&
+    v.id.length > 0 &&
+    typeof v.name === 'string' &&
+    typeof v.description === 'string' &&
+    typeof v.author === 'string' &&
+    (v.kind === 'data' || v.kind === 'process') &&
+    Array.isArray(v.versions) &&
+    v.versions.length > 0 &&
+    v.versions.every(isVersionEntry)
+  );
+}
+
+/**
+ * Structural validation only, same posture as `archive/manifest-parser.ts`'s
+ * `parseManifest`: a signature proves who wrote the bytes, not that the JSON
+ * inside them is well-formed, so this still has to fail closed on garbage.
+ */
+export function parseCatalogDocument(bytes: Buffer): CatalogDocument | null {
+  let json: unknown;
+  try {
+    json = JSON.parse(bytes.toString('utf8'));
+  } catch {
+    return null;
+  }
+  if (!isRecord(json) || !Array.isArray(json.plugins) || !json.plugins.every(isPluginEntry)) {
+    return null;
+  }
+  return json as unknown as CatalogDocument;
+}
+
+export interface HiddenVersionsSummary {
+  count: number;
+  /** The lowest Fliks version that would reveal at least one hidden version, or null
+   *  when upgrading reveals nothing. Only versions excluded by their `fliks` range with
+   *  a floor above the running version qualify: a version hidden by a `pluginApi`
+   *  mismatch, or by a range whose upper bound is already behind us, is not something a
+   *  version number in this document can promise to fix, and offering one would tell the
+   *  user to upgrade to a release they are already past. */
+  minFliksVersion: string | null;
+}
+
+export interface FilteredCatalogEntry {
+  id: string;
+  name: string;
+  description: string;
+  author: string;
+  kind: PluginKind;
+  /** Only versions installable on this core build. A caller iterating this list can
+   *  never accidentally offer an incompatible version — there is no boolean to miss. */
+  installable: CatalogVersionEntry[];
+  /** Null when nothing is hidden. A plugin with an empty `installable` list still
+   *  appears in the result, carrying this instead — never a bare empty page. */
+  hidden: HiddenVersionsSummary | null;
+}
+
+export interface FilteredCatalog {
+  plugins: FilteredCatalogEntry[];
+}
+
+function isInstallable(v: CatalogVersionEntry, pluginApiVersion: number, fliksVersion: string): boolean {
+  return v.pluginApi === pluginApiVersion && semver.satisfies(fliksVersion, v.fliks);
+}
+
+function summarizeHidden(
+  hidden: CatalogVersionEntry[],
+  fliksVersion: string,
+): HiddenVersionsSummary | null {
+  if (hidden.length === 0) return null;
+  const reachable = hidden
+    .filter((v) => !semver.satisfies(fliksVersion, v.fliks))
+    .map((v) => semver.minVersion(v.fliks))
+    .filter((v): v is semver.SemVer => v !== null && semver.gt(v, fliksVersion));
+  const lowest = reachable.length
+    ? reachable.reduce((min, v) => (semver.lt(v, min) ? v : min))
+    : null;
+  return { count: hidden.length, minFliksVersion: lowest?.version ?? null };
+}
+
+/**
+ * `pluginApi` exact equality and `semver.satisfies` against the running core version
+ * — the same two checks `PluginRegistryService.register` runs at load, applied here
+ * one layer earlier so the admin never sees a version they cannot install.
+ */
+export function filterCatalog(document: CatalogDocument, pluginApiVersion: number, fliksVersion: string): FilteredCatalog {
+  return {
+    plugins: document.plugins.map((entry) => {
+      const installable: CatalogVersionEntry[] = [];
+      const hidden: CatalogVersionEntry[] = [];
+      for (const version of entry.versions) {
+        (isInstallable(version, pluginApiVersion, fliksVersion) ? installable : hidden).push(version);
+      }
+      return {
+        id: entry.id,
+        name: entry.name,
+        description: entry.description,
+        author: entry.author,
+        kind: entry.kind,
+        installable,
+        hidden: summarizeHidden(hidden, fliksVersion),
+      };
+    }),
+  };
+}

--- a/backend/src/modules/plugins/entities/plugin-source.entity.ts
+++ b/backend/src/modules/plugins/entities/plugin-source.entity.ts
@@ -4,6 +4,7 @@ import { BaseEntity } from '../../../common/entities/base.entity';
 /** A configured catalog source (an admin-added URL); the official one is just the seeded first row. */
 @Entity('plugin_sources')
 export class PluginSource extends BaseEntity {
+  /** The `catalog.json` URL itself — not a directory. The signature is fetched from `${url}.sig`. */
   @Column()
   url: string;
 

--- a/backend/src/modules/plugins/plugin-catalog-client.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-catalog-client.service.spec.ts
@@ -1,0 +1,245 @@
+import axios, { AxiosRequestConfig } from 'axios';
+import { PluginCatalogClientService } from './plugin-catalog-client.service';
+import { PluginSource } from './entities/plugin-source.entity';
+import { generateTestKeypair, signManifestBase64 } from './archive/ed25519-test-keys';
+import { OFFICIAL_KEYS } from './archive/trust-store';
+import type { CatalogDocument } from './catalog/catalog';
+import { PLUGIN_API_VERSION } from '../../common/plugin-contract';
+
+const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
+
+function fakeSource(overrides: Partial<PluginSource> = {}): PluginSource {
+  return {
+    id: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    url: 'https://catalog.example.com/catalog.json',
+    enabled: true,
+    publicKey: null,
+    lastRefreshedAt: null,
+    lastRefreshError: null,
+    cachedCatalog: null,
+    ...overrides,
+  } as PluginSource;
+}
+
+function catalogWith(versionOverrides: Record<string, unknown> = {}): CatalogDocument {
+  return {
+    plugins: [
+      {
+        id: 'fliks.test-plugin',
+        name: 'Test plugin',
+        description: 'A fixture.',
+        author: 'Fliks',
+        kind: 'data',
+        versions: [{ version: '1.0.0', pluginApi: PLUGIN_API_VERSION, fliks: COMPATIBLE_RANGE, ...versionOverrides }],
+      },
+    ],
+  } as CatalogDocument;
+}
+
+function repoStub() {
+  const save = jest.fn(async (s: PluginSource) => s);
+  return { save } as unknown as { save: jest.Mock };
+}
+
+/** Routes a GET by URL suffix — `catalog.json` and `catalog.json.sig` never collide since
+ *  `endsWith` is exact. A value that is an `Error` rejects instead of resolving. */
+function adapterFor(responses: Record<string, Buffer | Error>) {
+  return (config: AxiosRequestConfig) => {
+    const url = String(config.url);
+    const entry = Object.entries(responses).find(([suffix]) => url.endsWith(suffix));
+    if (!entry) return Promise.reject(new Error(`unexpected request to ${url}`));
+    const [, value] = entry;
+    if (value instanceof Error) return Promise.reject(value);
+    return Promise.resolve({ data: value, status: 200, statusText: 'OK', headers: {}, config }) as never;
+  };
+}
+
+describe('PluginCatalogClientService', () => {
+  const originalAdapter = axios.defaults.adapter;
+
+  afterEach(() => {
+    axios.defaults.adapter = originalAdapter;
+  });
+
+  it('fetches, verifies against the source key, filters and caches a compatible catalog', async () => {
+    const { privateKey, rawPublicKey } = generateTestKeypair();
+    const doc = catalogWith();
+    const bytes = Buffer.from(JSON.stringify(doc), 'utf8');
+    const sig = Buffer.from(signManifestBase64(privateKey, bytes), 'utf8');
+    axios.defaults.adapter = adapterFor({ 'catalog.json.sig': sig, 'catalog.json': bytes });
+
+    const repo = repoStub();
+    const service = new PluginCatalogClientService(repo as never);
+    const source = fakeSource({ publicKey: rawPublicKey });
+
+    const result = await service.refreshSource(source);
+
+    expect(result).toEqual({ ok: true });
+    expect(source.lastRefreshError).toBeNull();
+    expect(source.lastRefreshedAt).toBeInstanceOf(Date);
+    expect(source.cachedCatalog).toEqual({
+      plugins: [
+        expect.objectContaining({
+          id: 'fliks.test-plugin',
+          installable: [{ version: '1.0.0', pluginApi: PLUGIN_API_VERSION, fliks: COMPATIBLE_RANGE }],
+          hidden: null,
+        }),
+      ],
+    });
+    expect(repo.save).toHaveBeenCalledWith(source);
+  });
+
+  it('refuses a catalog whose signature does not verify, and keeps the previous cache', async () => {
+    const { privateKey, rawPublicKey } = generateTestKeypair();
+    const bytes = Buffer.from(JSON.stringify(catalogWith()), 'utf8');
+    const tamperedSig = Buffer.from(signManifestBase64(privateKey, bytes), 'utf8');
+    tamperedSig[10] ^= 0xff; // corrupt the signature bytes themselves
+    axios.defaults.adapter = adapterFor({ 'catalog.json.sig': tamperedSig, 'catalog.json': bytes });
+
+    const repo = repoStub();
+    const service = new PluginCatalogClientService(repo as never);
+    const previousCatalog = { plugins: [{ id: 'old' }] };
+    const source = fakeSource({
+      publicKey: rawPublicKey,
+      cachedCatalog: previousCatalog,
+      lastRefreshedAt: new Date('2026-01-01T00:00:00Z'),
+    });
+
+    const result = await service.refreshSource(source);
+
+    expect(result).toEqual({ ok: false, reason: 'bad-signature', detail: expect.any(String) });
+    expect(source.cachedCatalog).toBe(previousCatalog);
+    expect(source.lastRefreshedAt).toEqual(new Date('2026-01-01T00:00:00Z'));
+    expect(source.lastRefreshError).toEqual(expect.any(String));
+  });
+
+  it('refuses a catalog signed by a key that is not the source’s configured key', async () => {
+    const sourceKeypair = generateTestKeypair();
+    const attackerKeypair = generateTestKeypair();
+    const bytes = Buffer.from(JSON.stringify(catalogWith()), 'utf8');
+    const sig = Buffer.from(signManifestBase64(attackerKeypair.privateKey, bytes), 'utf8');
+    axios.defaults.adapter = adapterFor({ 'catalog.json.sig': sig, 'catalog.json': bytes });
+
+    const repo = repoStub();
+    const service = new PluginCatalogClientService(repo as never);
+    const source = fakeSource({ publicKey: sourceKeypair.rawPublicKey });
+
+    const result = await service.refreshSource(source);
+
+    expect(result).toEqual({ ok: false, reason: 'bad-signature', detail: expect.any(String) });
+    expect(source.cachedCatalog).toBeNull();
+  });
+
+  it('falls back to the compiled-in official keys when the source has none configured', async () => {
+    const { privateKey, rawPublicKey } = generateTestKeypair();
+    const bytes = Buffer.from(JSON.stringify(catalogWith()), 'utf8');
+    const sig = Buffer.from(signManifestBase64(privateKey, bytes), 'utf8');
+    axios.defaults.adapter = adapterFor({ 'catalog.json.sig': sig, 'catalog.json': bytes });
+
+    const mutableOfficialKeys = OFFICIAL_KEYS as unknown as Map<string, Buffer>;
+    mutableOfficialKeys.set('test-official', rawPublicKey);
+    try {
+      const repo = repoStub();
+      const service = new PluginCatalogClientService(repo as never);
+      const source = fakeSource({ publicKey: null });
+
+      const result = await service.refreshSource(source);
+
+      expect(result).toEqual({ ok: true });
+    } finally {
+      mutableOfficialKeys.delete('test-official');
+    }
+  });
+
+  it('hides an incompatible pluginApi version and reports the hidden count and minimum core version', async () => {
+    const { privateKey, rawPublicKey } = generateTestKeypair();
+    const doc = catalogWith({ pluginApi: PLUGIN_API_VERSION + 1, fliks: '>=5.0.0 <6.0.0' });
+    const bytes = Buffer.from(JSON.stringify(doc), 'utf8');
+    const sig = Buffer.from(signManifestBase64(privateKey, bytes), 'utf8');
+    axios.defaults.adapter = adapterFor({ 'catalog.json.sig': sig, 'catalog.json': bytes });
+
+    const repo = repoStub();
+    const service = new PluginCatalogClientService(repo as never);
+    const source = fakeSource({ publicKey: rawPublicKey });
+
+    await service.refreshSource(source);
+
+    const catalog = source.cachedCatalog as { plugins: { installable: unknown[]; hidden: { count: number; minFliksVersion: string } }[] };
+    expect(catalog.plugins[0].installable).toEqual([]);
+    expect(catalog.plugins[0].hidden).toEqual({ count: 1, minFliksVersion: '5.0.0' });
+  });
+
+  it('keeps the previous cachedCatalog and records the error on a network failure', async () => {
+    axios.defaults.adapter = adapterFor({
+      'catalog.json.sig': new Error('ECONNRESET'),
+      'catalog.json': new Error('ECONNRESET'),
+    });
+
+    const repo = repoStub();
+    const service = new PluginCatalogClientService(repo as never);
+    const previousCatalog = { plugins: [{ id: 'old' }] };
+    const previousRefreshedAt = new Date('2026-01-01T00:00:00Z');
+    const source = fakeSource({
+      publicKey: generateTestKeypair().rawPublicKey,
+      cachedCatalog: previousCatalog,
+      lastRefreshedAt: previousRefreshedAt,
+    });
+
+    const result = await service.refreshSource(source);
+
+    expect(result).toEqual({ ok: false, reason: 'network-error', detail: expect.any(String) });
+    expect(source.cachedCatalog).toBe(previousCatalog);
+    expect(source.lastRefreshedAt).toBe(previousRefreshedAt);
+    expect(source.lastRefreshError).toEqual(expect.any(String));
+  });
+
+  it('refuses malformed JSON after a valid signature as a catalog error, without throwing', async () => {
+    const { privateKey, rawPublicKey } = generateTestKeypair();
+    const bytes = Buffer.from('not valid json{{{', 'utf8');
+    const sig = Buffer.from(signManifestBase64(privateKey, bytes), 'utf8');
+    axios.defaults.adapter = adapterFor({ 'catalog.json.sig': sig, 'catalog.json': bytes });
+
+    const repo = repoStub();
+    const service = new PluginCatalogClientService(repo as never);
+    const source = fakeSource({ publicKey: rawPublicKey });
+
+    await expect(service.refreshSource(source)).resolves.toEqual({
+      ok: false,
+      reason: 'malformed-catalog',
+      detail: expect.any(String),
+    });
+  });
+
+  it('refuses a non-https source url before making any request', async () => {
+    let requested = false;
+    axios.defaults.adapter = (config: AxiosRequestConfig) => {
+      requested = true;
+      return Promise.reject(new Error(`unexpected request to ${String(config.url)}`)) as never;
+    };
+
+    const repo = repoStub();
+    const service = new PluginCatalogClientService(repo as never);
+    const source = fakeSource({ url: 'http://insecure.example.com/catalog.json' });
+
+    const result = await service.refreshSource(source);
+
+    expect(result).toEqual({ ok: false, reason: 'insecure-url', detail: expect.any(String) });
+    expect(requested).toBe(false);
+  });
+
+  describe('refreshAll (daily cron)', () => {
+    it('refreshes every enabled source and never queries a disabled one', async () => {
+      const enabledSource = fakeSource({ id: 1, enabled: true });
+      const find = jest.fn().mockResolvedValue([enabledSource]);
+      const service = new PluginCatalogClientService({ find } as never);
+      jest.spyOn(service, 'refreshSource').mockResolvedValue({ ok: true });
+
+      await service.refreshAll();
+
+      expect(find).toHaveBeenCalledWith({ where: { enabled: true } });
+      expect(service.refreshSource).toHaveBeenCalledWith(enabledSource);
+    });
+  });
+});

--- a/backend/src/modules/plugins/plugin-catalog-client.service.ts
+++ b/backend/src/modules/plugins/plugin-catalog-client.service.ts
@@ -1,0 +1,126 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import axios from 'axios';
+import { PluginSource } from './entities/plugin-source.entity';
+import { OFFICIAL_KEYS, resolveTrust, MAX_SIGNATURE_BYTES } from './archive';
+import { PLUGIN_API_VERSION } from '../../common/plugin-contract';
+import { CURRENT_FLIKS_VERSION } from './plugin-registry.service';
+import { parseCatalogDocument, filterCatalog, type FilteredCatalog } from './catalog/catalog';
+
+const CATALOG_REQUEST_TIMEOUT_MS = 10_000;
+/** A catalog is a small JSON index of plugin metadata, nowhere near the 8 MiB
+ *  archive cap (`archive/limits.ts`) — generous versus today's few-KB catalogs. */
+const CATALOG_MAX_RESPONSE_BYTES = 1024 * 1024;
+
+export type CatalogRefreshFailureReason = 'insecure-url' | 'network-error' | 'bad-signature' | 'malformed-catalog';
+
+export type CatalogRefreshResult = { ok: true } | { ok: false; reason: CatalogRefreshFailureReason; detail: string };
+
+/**
+ * Fetches, verifies and caches one source's `catalog.json`. Deliberately does not
+ * reuse `internal-address.ts`: that guard blocks a plugin-authored webhook URL
+ * (untrusted input) from reaching the LAN, but a source URL is typed in by the
+ * admin themselves, who may legitimately run a self-hosted catalog on their own
+ * network — refusing private ranges here would break a supported setup. The two
+ * checks share a shape but not a trust boundary, so they stay separate on purpose.
+ */
+@Injectable()
+export class PluginCatalogClientService {
+  private readonly logger = new Logger(PluginCatalogClientService.name);
+
+  constructor(
+    @InjectRepository(PluginSource)
+    private readonly sourceRepo: Repository<PluginSource>,
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_4AM)
+  async refreshAll(): Promise<void> {
+    const sources = await this.sourceRepo.find({ where: { enabled: true } });
+    for (const source of sources) {
+      await this.refreshSource(source);
+    }
+  }
+
+  /**
+   * Verifies the exact bytes fetched before any JSON parsing happens — a signature
+   * proves who wrote the bytes, and that check has to run before anything trusts
+   * their content. A transient failure at any step keeps the source's previous
+   * `cachedCatalog` untouched; only a successful refresh replaces it.
+   */
+  async refreshSource(source: PluginSource): Promise<CatalogRefreshResult> {
+    // "catalog: the signed JSON document served at a source's URL" (plan, "Naming, and
+    // why not repository") — `source.url` IS the catalog.json URL, not a base to join
+    // against. The detached signature is the sibling file the archive convention
+    // already uses: the same name plus `.sig`.
+    let catalogUrl: URL;
+    try {
+      catalogUrl = new URL(source.url);
+    } catch {
+      return this.fail(source, 'insecure-url', `source url "${source.url}" is not a valid URL`);
+    }
+    if (catalogUrl.protocol !== 'https:') {
+      return this.fail(source, 'insecure-url', `source url "${source.url}" must be https`);
+    }
+    const sigUrl = `${source.url}.sig`;
+
+    let catalogBytes: Buffer;
+    let sigBytes: Buffer;
+    try {
+      [catalogBytes, sigBytes] = await Promise.all([
+        this.fetchBytes(catalogUrl.toString(), CATALOG_MAX_RESPONSE_BYTES),
+        this.fetchBytes(sigUrl, MAX_SIGNATURE_BYTES),
+      ]);
+    } catch (err) {
+      return this.fail(source, 'network-error', (err as Error).message);
+    }
+
+    const officialKeys = source.publicKey ? new Map([['source', source.publicKey]]) : OFFICIAL_KEYS;
+    const signature = this.parseSignature(sigBytes);
+    const trust = resolveTrust(catalogBytes, signature, officialKeys, new Map());
+    if (trust.trust === 'unsigned' || trust.trust === 'unverified') {
+      return this.fail(source, 'bad-signature', `catalog signature did not verify (${trust.trust})`);
+    }
+
+    const document = parseCatalogDocument(catalogBytes);
+    if (!document) {
+      return this.fail(source, 'malformed-catalog', 'catalog signature verified but the document did not parse');
+    }
+
+    const filtered: FilteredCatalog = filterCatalog(document, PLUGIN_API_VERSION, CURRENT_FLIKS_VERSION);
+    source.cachedCatalog = filtered as unknown as Record<string, unknown>;
+    source.lastRefreshedAt = new Date();
+    source.lastRefreshError = null;
+    await this.sourceRepo.save(source);
+    return { ok: true };
+  }
+
+  private async fail(
+    source: PluginSource,
+    reason: CatalogRefreshFailureReason,
+    detail: string,
+  ): Promise<CatalogRefreshResult> {
+    this.logger.warn(`catalog refresh failed for source #${source.id} (${reason}): ${detail}`);
+    source.lastRefreshError = detail;
+    await this.sourceRepo.save(source);
+    return { ok: false, reason, detail };
+  }
+
+  /** Same format as `plugin.json.sig` in an archive: base64 text, one file. */
+  private parseSignature(sigBytes: Buffer): Buffer | null {
+    const text = sigBytes.toString('utf8').trim();
+    return text ? Buffer.from(text, 'base64') : null;
+  }
+
+  private async fetchBytes(url: string, maxBytes: number): Promise<Buffer> {
+    const res = await axios.get<ArrayBuffer>(url, {
+      responseType: 'arraybuffer',
+      timeout: CATALOG_REQUEST_TIMEOUT_MS,
+      maxRedirects: 0,
+      maxContentLength: maxBytes,
+      headers: { 'User-Agent': 'Fliks-Plugin-Catalog-Client/1.0' },
+    });
+    return Buffer.from(res.data);
+  }
+}

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -36,8 +36,9 @@ type AssertSameStringUnion<A extends string, B extends string> = [A] extends [B]
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const _webhookCatalogMatchesDomainEvents: AssertSameStringUnion<PluginWebhookEventName, DomainEvent['type']> = true;
 
-/** Same pattern as `UpdateCheckService`/`SystemController` — no shared version util exists yet. */
-const CURRENT_FLIKS_VERSION: string = (() => {
+/** Same pattern as `UpdateCheckService`/`SystemController` — no shared version util exists yet.
+ *  Exported so the catalog client checks compatibility against this exact value, never a second read. */
+export const CURRENT_FLIKS_VERSION: string = (() => {
   try {
     const pkg = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8')) as { version?: string };
     return pkg.version ?? '0.0.0';

--- a/backend/src/modules/plugins/plugin-sources.controller.spec.ts
+++ b/backend/src/modules/plugins/plugin-sources.controller.spec.ts
@@ -1,0 +1,59 @@
+import { NotFoundException } from '@nestjs/common';
+import { PluginSourcesController } from './plugin-sources.controller';
+import { PluginSource } from './entities/plugin-source.entity';
+
+function fakeSource(overrides: Partial<PluginSource> = {}): PluginSource {
+  return {
+    id: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    url: 'https://catalog.example.com/',
+    enabled: true,
+    publicKey: null,
+    lastRefreshedAt: null,
+    lastRefreshError: null,
+    cachedCatalog: null,
+    ...overrides,
+  } as PluginSource;
+}
+
+describe('PluginSourcesController', () => {
+  it('returns the cached catalog fields for a known source', async () => {
+    const source = fakeSource({ cachedCatalog: { plugins: [] }, lastRefreshError: 'boom' });
+    const repo = { findOne: jest.fn().mockResolvedValue(source) };
+    const controller = new PluginSourcesController(repo as never, {} as never);
+
+    await expect(controller.getCatalog(1)).resolves.toEqual({
+      cachedCatalog: { plugins: [] },
+      lastRefreshedAt: null,
+      lastRefreshError: 'boom',
+    });
+    expect(repo.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
+  });
+
+  it('404s reading the catalog of an unknown source', async () => {
+    const repo = { findOne: jest.fn().mockResolvedValue(null) };
+    const controller = new PluginSourcesController(repo as never, {} as never);
+
+    await expect(controller.getCatalog(99)).rejects.toThrow(NotFoundException);
+  });
+
+  it('delegates a manual refresh to the catalog client for a known source', async () => {
+    const source = fakeSource();
+    const repo = { findOne: jest.fn().mockResolvedValue(source) };
+    const catalogClient = { refreshSource: jest.fn().mockResolvedValue({ ok: true }) };
+    const controller = new PluginSourcesController(repo as never, catalogClient as never);
+
+    await expect(controller.refresh(1)).resolves.toEqual({ ok: true });
+    expect(catalogClient.refreshSource).toHaveBeenCalledWith(source);
+  });
+
+  it('404s a manual refresh of an unknown source without touching the catalog client', async () => {
+    const repo = { findOne: jest.fn().mockResolvedValue(null) };
+    const catalogClient = { refreshSource: jest.fn() };
+    const controller = new PluginSourcesController(repo as never, catalogClient as never);
+
+    await expect(controller.refresh(99)).rejects.toThrow(NotFoundException);
+    expect(catalogClient.refreshSource).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/plugins/plugin-sources.controller.ts
+++ b/backend/src/modules/plugins/plugin-sources.controller.ts
@@ -1,0 +1,48 @@
+import { Controller, Get, Post, Param, ParseIntPipe, NotFoundException, UseGuards } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PluginSource } from './entities/plugin-source.entity';
+import { PluginCatalogClientService, type CatalogRefreshResult } from './plugin-catalog-client.service';
+import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
+import { PoliciesGuard } from '../auth/casl/policies.guard';
+import { CheckPolicies } from '../auth/casl/check-policies.decorator';
+import { Action } from '../auth/casl/actions.enum';
+
+/** Manual refresh and cached-catalog read for one `plugin_sources` row. Admin-only. */
+@Controller('plugins/sources')
+@UseGuards(JwtOrApiKeyGuard, PoliciesGuard)
+export class PluginSourcesController {
+  constructor(
+    @InjectRepository(PluginSource)
+    private readonly sourceRepo: Repository<PluginSource>,
+    private readonly catalogClient: PluginCatalogClientService,
+  ) {}
+
+  @Get(':id/catalog')
+  @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
+  async getCatalog(@Param('id', ParseIntPipe) id: number): Promise<{
+    cachedCatalog: Record<string, unknown> | null;
+    lastRefreshedAt: Date | null;
+    lastRefreshError: string | null;
+  }> {
+    const source = await this.findOrThrow(id);
+    return {
+      cachedCatalog: source.cachedCatalog,
+      lastRefreshedAt: source.lastRefreshedAt,
+      lastRefreshError: source.lastRefreshError,
+    };
+  }
+
+  @Post(':id/refresh')
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
+  async refresh(@Param('id', ParseIntPipe) id: number): Promise<CatalogRefreshResult> {
+    const source = await this.findOrThrow(id);
+    return this.catalogClient.refreshSource(source);
+  }
+
+  private async findOrThrow(id: number): Promise<PluginSource> {
+    const source = await this.sourceRepo.findOne({ where: { id } });
+    if (!source) throw new NotFoundException(`Plugin source #${id} not found`);
+    return source;
+  }
+}

--- a/backend/src/modules/plugins/plugins.module.ts
+++ b/backend/src/modules/plugins/plugins.module.ts
@@ -5,15 +5,17 @@ import { PluginSource } from './entities/plugin-source.entity';
 import { PluginRegistration } from './entities/plugin-registration.entity';
 import { PluginRegistryService } from './plugin-registry.service';
 import { PluginWebhookDispatcherService } from './plugin-webhook-dispatcher.service';
+import { PluginCatalogClientService } from './plugin-catalog-client.service';
 import { PluginLogoController } from './plugin-logo.controller';
 import { PluginIndexerDescriptorsController } from './plugin-indexer-descriptors.controller';
+import { PluginSourcesController } from './plugin-sources.controller';
 import { AuthModule } from '../auth/auth.module';
 import { EventsModule } from '../scheduler/events.module';
 
 @Module({
   imports: [TypeOrmModule.forFeature([PluginPackage, PluginSource, PluginRegistration]), AuthModule, EventsModule],
-  controllers: [PluginLogoController, PluginIndexerDescriptorsController],
-  providers: [PluginRegistryService, PluginWebhookDispatcherService],
+  controllers: [PluginLogoController, PluginIndexerDescriptorsController, PluginSourcesController],
+  providers: [PluginRegistryService, PluginWebhookDispatcherService, PluginCatalogClientService],
   exports: [TypeOrmModule, PluginRegistryService],
 })
 export class PluginsModule {}


### PR DESCRIPTION
PR 7.1, opening phase 7. A **source** is a URL an admin adds; a **catalog** is the signed JSON document served at it. This fetches, verifies, filters and caches them.

- **Verify before parse.** Ed25519 over the exact bytes fetched, against the source's own key or the compiled-in official ones — never a re-serialised object, and never parse-then-verify.
- **A failed refresh never blanks a working catalog.** Only `lastRefreshError` is written; the cache and its timestamp are untouched, asserted by identity (`toBe`) rather than equality so a rebuilt-but-equal object could not pass.
- **Compatibility** uses the same two checks the loader uses — exact `pluginApi`, semver range for the core version — and hidden versions are *summarised*, not dropped. A plugin whose every version is hidden still appears, because the plan explicitly rules out a bare empty page.
- `https` only, `maxRedirects: 0`, a read cap and a timeout, matching the outbound rules already used for webhooks.

**The internal-address guard from #903 is deliberately not applied here**, and the reasoning is written into the code rather than left implicit: that guard stops a *plugin author* from pointing core at the LAN, whereas a source URL is typed by the admin, who may legitimately host a catalog on their own network. Same shape, different trust boundary — refusing private ranges there would break a supported setup.

## The hidden-versions line promised an upgrade it could not deliver

The summary computed its minimum core version from *every* hidden version. Two cases make that wrong, and one had a test enshrining it:

- a version hidden by a **`pluginApi` mismatch** may satisfy its own `fliks` floor perfectly — the committed test asserted `minFliksVersion: '1.0.0'` for a user already running `2.0.1`, so the UI would have said *"1 version hidden — need Fliks ≥ 1.0.0"* to someone well past it;
- a version whose range is **already behind us** (`>=1.0.0 <2.0.0`, running 2.0.1) is revealed by downgrading, not upgrading.

Only versions an upgrade genuinely reveals are counted toward the floor now, and when none qualify the answer is `null` rather than a number that misleads. That changed one existing assertion — deliberately, because the behaviour it pinned was wrong — and added a case for the already-behind-us range.

Verified: `tsc` 0, suite **931** (+25), and against the running stack: anonymous `401`, admin with an unknown source `404` on both routes.

**Note:** `OFFICIAL_KEYS` is still empty until 8.1, so today only a source with its own pinned key can verify — expected, not an oversight.