### PR TITLE
feat(plugins): install, update and uninstall a data plugin

### DIFF
--- a/backend/src/common/constants/paths.ts
+++ b/backend/src/common/constants/paths.ts
@@ -31,3 +31,22 @@ export function getImagesDir(): string {
   );
   return cachedImagesDir;
 }
+
+let cachedPluginsRuntimeDir: string | null = null;
+
+/**
+ * Base directory for staged and installed plugin files. `FLIKS_RUNTIME_DIR`
+ * overrides; falls back to a temp dir (wiped on restart) — durable state
+ * lives in `plugin_packages.archive`, not here. Resolved and probed once.
+ */
+export function getPluginsRuntimeDir(): string {
+  if (cachedPluginsRuntimeDir) return cachedPluginsRuntimeDir;
+  const override = process.env.FLIKS_RUNTIME_DIR?.trim();
+  const preferred = override ? path.join(override, 'fliks-plugins') : path.join(os.tmpdir(), 'fliks-plugins');
+  cachedPluginsRuntimeDir = resolveWritableDir(
+    [preferred, path.join(os.tmpdir(), 'fliks-plugins')],
+    'Cannot write to the plugins runtime directory — installed plugin files ' +
+      'will not survive a restart. Set FLIKS_RUNTIME_DIR to a writable path.',
+  );
+  return cachedPluginsRuntimeDir;
+}

--- a/backend/src/migrations/1782900000000-add-plugin-package-status-reason.ts
+++ b/backend/src/migrations/1782900000000-add-plugin-package-status-reason.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/** Carries why `register()` refused a package, so a `failed` row is attributable (PR 7.2). */
+export class AddPluginPackageStatusReason1782900000000 implements MigrationInterface {
+  name = 'AddPluginPackageStatusReason1782900000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "plugin_packages" ADD COLUMN "statusReason" text`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "plugin_packages" DROP COLUMN "statusReason"`);
+  }
+}

--- a/backend/src/modules/plugins/dto/confirm-import.dto.ts
+++ b/backend/src/modules/plugins/dto/confirm-import.dto.ts
@@ -1,0 +1,11 @@
+import { Matches } from 'class-validator';
+
+export class ConfirmImportDto {
+  /** `sha256(zip).slice(0, 32)` — the id `inspect` returned. */
+  @Matches(/^[0-9a-f]{32}$/)
+  stagingId: string;
+
+  /** The full `sha256` the client saw in the `inspect` response. */
+  @Matches(/^[0-9a-f]{64}$/)
+  sha256: string;
+}

--- a/backend/src/modules/plugins/dto/install-from-catalog.dto.ts
+++ b/backend/src/modules/plugins/dto/install-from-catalog.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class InstallFromCatalogDto {
+  @IsString()
+  @IsNotEmpty()
+  pluginId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  version: string;
+}

--- a/backend/src/modules/plugins/entities/plugin-package.entity.ts
+++ b/backend/src/modules/plugins/entities/plugin-package.entity.ts
@@ -38,4 +38,8 @@ export class PluginPackage extends BaseEntity {
   /** `failed` on a P4 activation failure; the row (and archive) stand regardless. */
   @Column({ type: 'enum', enum: PLUGIN_PACKAGE_STATUSES, default: 'active' })
   status: PluginPackageStatus;
+
+  /** `PluginRegistrationFailure.reason: detail` when `status` is `failed`; null otherwise. */
+  @Column({ type: 'text', nullable: true })
+  statusReason: string | null;
 }

--- a/backend/src/modules/plugins/plugin-import.controller.spec.ts
+++ b/backend/src/modules/plugins/plugin-import.controller.spec.ts
@@ -1,0 +1,31 @@
+import { BadRequestException } from '@nestjs/common';
+import { PluginImportController } from './plugin-import.controller';
+
+describe('PluginImportController', () => {
+  it('inspects the uploaded file and delegates to the install service', async () => {
+    const installService = { inspectUpload: jest.fn().mockResolvedValue({ installable: true }) };
+    const controller = new PluginImportController(installService as never);
+    const file = { buffer: Buffer.from('archive bytes') } as Express.Multer.File;
+
+    await expect(controller.inspect(file)).resolves.toEqual({ installable: true });
+    expect(installService.inspectUpload).toHaveBeenCalledWith(file.buffer);
+  });
+
+  it('rejects when no file is uploaded, without touching the install service', async () => {
+    const installService = { inspectUpload: jest.fn() };
+    const controller = new PluginImportController(installService as never);
+
+    await expect(controller.inspect(undefined as never)).rejects.toThrow(BadRequestException);
+    expect(installService.inspectUpload).not.toHaveBeenCalled();
+  });
+
+  it('confirms an import by delegating to the install service', async () => {
+    const result = { pluginId: 'fliks.test', version: '1.0.0', status: 'active' as const };
+    const installService = { confirmImport: jest.fn().mockResolvedValue(result) };
+    const controller = new PluginImportController(installService as never);
+    const dto = { stagingId: 'a'.repeat(32), sha256: 'b'.repeat(64) };
+
+    await expect(controller.confirm(dto)).resolves.toEqual(result);
+    expect(installService.confirmImport).toHaveBeenCalledWith(dto);
+  });
+});

--- a/backend/src/modules/plugins/plugin-import.controller.ts
+++ b/backend/src/modules/plugins/plugin-import.controller.ts
@@ -1,0 +1,34 @@
+import { BadRequestException, Body, Controller, Post, UploadedFile, UseGuards, UseInterceptors } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
+import { PoliciesGuard } from '../auth/casl/policies.guard';
+import { CheckPolicies } from '../auth/casl/check-policies.decorator';
+import { Action } from '../auth/casl/actions.enum';
+import { PluginInstallService, PluginInspectReport, PluginInstallResult } from './plugin-install.service';
+import { ConfirmImportDto } from './dto/confirm-import.dto';
+import { MAX_ARCHIVE_COMPRESSED_BYTES } from './archive';
+
+/** Manual-upload half of the install pipeline (`plans/plugin-system.plan.md`, "Manual upload"). */
+@Controller('plugins/import')
+@UseGuards(JwtOrApiKeyGuard, PoliciesGuard)
+export class PluginImportController {
+  constructor(private readonly installService: PluginInstallService) {}
+
+  @Post('inspect')
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
+  @UseInterceptors(
+    FileInterceptor('file', {
+      limits: { fileSize: MAX_ARCHIVE_COMPRESSED_BYTES, files: 1, fields: 0, parts: 2 },
+    }),
+  )
+  async inspect(@UploadedFile() file: Express.Multer.File): Promise<PluginInspectReport> {
+    if (!file) throw new BadRequestException('No file uploaded');
+    return this.installService.inspectUpload(file.buffer);
+  }
+
+  @Post('confirm')
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
+  async confirm(@Body() dto: ConfirmImportDto): Promise<PluginInstallResult> {
+    return this.installService.confirmImport(dto);
+  }
+}

--- a/backend/src/modules/plugins/plugin-install.exception.ts
+++ b/backend/src/modules/plugins/plugin-install.exception.ts
@@ -1,0 +1,16 @@
+import { HttpException } from '@nestjs/common';
+
+/**
+ * Every install-pipeline refusal that isn't an archive-guard code, with a
+ * stable `{ code, message }` body (same shape as `SessionExpiredException`)
+ * so a caller branches on `code`, never on the HTTP status alone.
+ */
+export class PluginInstallException extends HttpException {
+  constructor(
+    status: number,
+    public readonly code: string,
+    detail: string,
+  ) {
+    super({ code, message: detail }, status);
+  }
+}

--- a/backend/src/modules/plugins/plugin-install.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-install.service.spec.ts
@@ -1,0 +1,328 @@
+import axios, { AxiosRequestConfig } from 'axios';
+import { createHash } from 'crypto';
+import { existsSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { PluginInstallService, installedPluginDir } from './plugin-install.service';
+import { PluginInstallException } from './plugin-install.exception';
+import { PluginStagingService } from './plugin-staging.service';
+import { PluginRegistryService } from './plugin-registry.service';
+import { PluginPackage } from './entities/plugin-package.entity';
+import { PluginSource } from './entities/plugin-source.entity';
+import { buildZip, ZipEntrySpec } from './archive/zip-builder';
+import { generateTestKeypair, signManifestBase64 } from './archive/ed25519-test-keys';
+import { minimalDataManifest } from './archive/test-manifests';
+import { svgLogo } from './archive/test-fixtures';
+import { getPluginsRuntimeDir } from '../../common/constants/paths';
+import { PLUGIN_API_VERSION } from '../../common/plugin-contract';
+import type { DataPluginManifest } from '../../common/plugin-contract';
+
+/** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
+const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
+
+function signedDataArchive(overrides: Partial<DataPluginManifest> = {}): { buffer: Buffer; manifest: DataPluginManifest } {
+  const manifest = minimalDataManifest({ fliks: COMPATIBLE_RANGE, ...overrides });
+  const manifestBytes = Buffer.from(JSON.stringify(manifest), 'utf8');
+  const { privateKey } = generateTestKeypair();
+  const sig = signManifestBase64(privateKey, manifestBytes);
+  const buffer = buildZip([
+    { name: 'plugin.json', content: manifestBytes },
+    { name: 'plugin.json.sig', content: Buffer.from(sig, 'utf8') },
+    { name: 'logo.svg', content: svgLogo() },
+  ]);
+  return { buffer, manifest };
+}
+
+function tamperedZip(): Buffer {
+  // A well-formed archive that `inspect()` refuses on its own — a control
+  // character in an entry name — standing in for a directory modified
+  // out from under `confirm` by something other than this API.
+  const entries: ZipEntrySpec[] = [{ name: 'logo.svg' + String.fromCharCode(0) + '.js', content: svgLogo() }];
+  return buildZip(entries);
+}
+
+function stagedArchivePath(stagingId: string): string {
+  return join(getPluginsRuntimeDir(), 'import-staging', stagingId, 'archive.zip');
+}
+
+function fakePackageRepo() {
+  const rows = new Map<string, PluginPackage>();
+  let nextId = 1;
+  return {
+    rows,
+    findOne: jest.fn(async ({ where: { pluginId } }: { where: { pluginId: string } }) => rows.get(pluginId) ?? null),
+    create: jest.fn(
+      (partial: Partial<PluginPackage>) =>
+        ({ id: nextId++, createdAt: new Date(), updatedAt: new Date(), statusReason: null, ...partial }) as PluginPackage,
+    ),
+    save: jest.fn(async (row: PluginPackage) => {
+      rows.set(row.pluginId, row);
+      return row;
+    }),
+    remove: jest.fn(async (row: PluginPackage) => {
+      rows.delete(row.pluginId);
+      return row;
+    }),
+  };
+}
+
+function fakeSource(cachedCatalog: Record<string, unknown> | null): PluginSource {
+  return {
+    id: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    url: 'https://catalog.example.com/catalog.json',
+    enabled: true,
+    publicKey: null,
+    lastRefreshedAt: null,
+    lastRefreshError: null,
+    cachedCatalog,
+  } as PluginSource;
+}
+
+/** Routes a GET by URL suffix, mirroring `plugin-catalog-client.service.spec.ts`'s adapter. */
+function adapterFor(responses: Record<string, Buffer | Error>) {
+  return (config: AxiosRequestConfig) => {
+    const url = String(config.url);
+    const entry = Object.entries(responses).find(([suffix]) => url.endsWith(suffix));
+    if (!entry) return Promise.reject(new Error(`unexpected request to ${url}`));
+    const [, value] = entry;
+    if (value instanceof Error) return Promise.reject(value);
+    return Promise.resolve({ data: value, status: 200, statusText: 'OK', headers: {}, config }) as never;
+  };
+}
+
+async function expectInstallError(promise: Promise<unknown>, status: number, code: string): Promise<void> {
+  const err = await promise.then(
+    () => {
+      throw new Error('expected the promise to reject');
+    },
+    (e: unknown) => e,
+  );
+  expect(err).toBeInstanceOf(PluginInstallException);
+  expect((err as PluginInstallException).getStatus()).toBe(status);
+  expect((err as PluginInstallException).code).toBe(code);
+}
+
+describe('PluginInstallService', () => {
+  let repo: ReturnType<typeof fakePackageRepo>;
+  let registry: PluginRegistryService;
+  let staging: PluginStagingService;
+  let service: PluginInstallService;
+  const originalAdapter = axios.defaults.adapter;
+
+  function stagingRoot(): string {
+    return join(getPluginsRuntimeDir(), 'import-staging');
+  }
+
+  beforeEach(() => {
+    rmSync(stagingRoot(), { recursive: true, force: true });
+    rmSync(join(getPluginsRuntimeDir(), 'installed'), { recursive: true, force: true });
+    repo = fakePackageRepo();
+    registry = new PluginRegistryService(repo as never);
+    staging = new PluginStagingService();
+    service = new PluginInstallService(repo as never, registry, staging);
+  });
+
+  afterEach(() => {
+    axios.defaults.adapter = originalAdapter;
+  });
+
+  describe('inspectUpload', () => {
+    it('reports a valid signed data archive as installable, with its id/version/trust, and stages it', async () => {
+      const { buffer, manifest } = signedDataArchive({ id: 'fliks.inspect-happy' });
+
+      const report = await service.inspectUpload(buffer);
+
+      expect(report).toEqual(
+        expect.objectContaining({
+          installable: true,
+          id: manifest.id,
+          version: manifest.version,
+          kind: 'data',
+          signature: 'unverified',
+          compatible: true,
+          stagingId: expect.any(String),
+          sha256: expect.any(String),
+        }),
+      );
+      expect(existsSync(stagedArchivePath(report.stagingId!))).toBe(true);
+    });
+
+    it('refuses a malformed archive with its specific refusal code and stages nothing', async () => {
+      const stageSpy = jest.spyOn(staging, 'stage');
+
+      const report = await service.inspectUpload(Buffer.from('not a zip at all'));
+
+      expect(report).toEqual({ installable: false, refusalCode: 'PLUGIN_BAD_MAGIC', detail: expect.any(String) });
+      expect(stageSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('confirmImport', () => {
+    it('refuses with a distinct conflict code when the claimed hash no longer matches the staged bytes', async () => {
+      const { buffer } = signedDataArchive({ id: 'fliks.confirm-stale' });
+      const { stagingId } = await service.inspectUpload(buffer);
+
+      await expectInstallError(
+        service.confirmImport({ stagingId: stagingId!, sha256: '0'.repeat(64) }),
+        409,
+        'PLUGIN_STAGING_STALE',
+      );
+    });
+
+    it('refuses an unknown staging id', async () => {
+      await expectInstallError(
+        service.confirmImport({ stagingId: 'f'.repeat(32), sha256: '0'.repeat(64) }),
+        404,
+        'PLUGIN_STAGING_NOT_FOUND',
+      );
+    });
+
+    it('re-runs the guards against a fresh read: a directory modified after inspect is caught even when the claimed hash matches the tampered bytes', async () => {
+      const { buffer } = signedDataArchive({ id: 'fliks.confirm-tamper' });
+      const { stagingId } = await service.inspectUpload(buffer);
+
+      const tampered = tamperedZip();
+      writeFileSync(stagedArchivePath(stagingId!), tampered);
+      const tamperedSha256 = createHash('sha256').update(tampered).digest('hex');
+
+      // The claimed hash matches exactly what is now on disk — only a second guard
+      // pass over the fresh bytes, not the hash check, can catch this.
+      await expectInstallError(
+        service.confirmImport({ stagingId: stagingId!, sha256: tamperedSha256 }),
+        422,
+        'PLUGIN_CONTROL_CHAR',
+      );
+    });
+
+    it('promotes on success: a plugin_packages row exists and the registry has the plugin', async () => {
+      const { buffer, manifest } = signedDataArchive({ id: 'fliks.confirm-promote' });
+      const { stagingId, sha256 } = await service.inspectUpload(buffer);
+
+      const result = await service.confirmImport({ stagingId: stagingId!, sha256: sha256! });
+
+      expect(result).toEqual({ pluginId: manifest.id, version: manifest.version, status: 'active' });
+      expect(repo.rows.get(manifest.id)).toEqual(expect.objectContaining({ status: 'active', pluginId: manifest.id }));
+      expect(registry.get(manifest.id)).toBeDefined();
+      expect(existsSync(installedPluginDir(manifest.id, manifest.version))).toBe(true);
+    });
+
+    it('discards the staging directory after a successful confirm', async () => {
+      const { buffer } = signedDataArchive({ id: 'fliks.confirm-discard' });
+      const { stagingId, sha256 } = await service.inspectUpload(buffer);
+
+      await service.confirmImport({ stagingId: stagingId!, sha256: sha256! });
+
+      expect(existsSync(join(stagingRoot(), stagingId!))).toBe(false);
+    });
+
+    it('leaves a failed activation standing: the row is present with its reason, and nothing is registered', async () => {
+      const { buffer, manifest } = signedDataArchive({ id: 'fliks.confirm-incompatible', fliks: '>=99.0.0' });
+      const { stagingId, sha256 } = await service.inspectUpload(buffer);
+
+      const result = await service.confirmImport({ stagingId: stagingId!, sha256: sha256! });
+
+      expect(result).toEqual({
+        pluginId: manifest.id,
+        version: manifest.version,
+        status: 'failed',
+        reason: 'incompatible-fliks',
+        detail: expect.any(String),
+      });
+      const row = repo.rows.get(manifest.id);
+      expect(row?.status).toBe('failed');
+      expect(row?.statusReason).toContain('incompatible-fliks');
+      expect(registry.get(manifest.id)).toBeUndefined();
+    });
+
+    it('re-uploading the same archive reuses its staging directory rather than creating a second', async () => {
+      const { buffer } = signedDataArchive({ id: 'fliks.reupload' });
+
+      const first = await service.inspectUpload(buffer);
+      const second = await service.inspectUpload(buffer);
+
+      expect(second.stagingId).toBe(first.stagingId);
+    });
+  });
+
+  describe('installFromCatalog', () => {
+    it('refuses before any guard runs when the fetched archive disagrees with the signed catalog checksum', async () => {
+      const { buffer } = signedDataArchive({ id: 'fliks.catalog-mismatch' });
+      axios.defaults.adapter = adapterFor({ 'plugin.zip': buffer });
+      const source = fakeSource({
+        plugins: [
+          {
+            id: 'fliks.catalog-mismatch',
+            installable: [
+              {
+                version: '1.0.0',
+                pluginApi: PLUGIN_API_VERSION,
+                fliks: COMPATIBLE_RANGE,
+                zipUrl: 'https://cdn.example.com/plugin.zip',
+                sha256: '0'.repeat(64),
+              },
+            ],
+          },
+        ],
+      });
+
+      await expectInstallError(
+        service.installFromCatalog(source, 'fliks.catalog-mismatch', '1.0.0'),
+        422,
+        'PLUGIN_CHECKSUM_MISMATCH',
+      );
+    });
+
+    it('installs a version whose checksum matches the signed catalog entry', async () => {
+      const { buffer, manifest } = signedDataArchive({ id: 'fliks.catalog-happy', version: '2.0.0' });
+      const sha256 = createHash('sha256').update(buffer).digest('hex');
+      axios.defaults.adapter = adapterFor({ 'plugin.zip': buffer });
+      const source = fakeSource({
+        plugins: [
+          {
+            id: manifest.id,
+            installable: [
+              { version: manifest.version, pluginApi: PLUGIN_API_VERSION, fliks: COMPATIBLE_RANGE, zipUrl: 'https://cdn.example.com/plugin.zip', sha256 },
+            ],
+          },
+        ],
+      });
+
+      const result = await service.installFromCatalog(source, manifest.id, manifest.version);
+
+      expect(result).toEqual({ pluginId: manifest.id, version: manifest.version, status: 'active' });
+      expect(registry.get(manifest.id)).toBeDefined();
+    });
+
+    it('refuses an id/version that is not on the source catalog', async () => {
+      const source = fakeSource({ plugins: [] });
+
+      await expectInstallError(
+        service.installFromCatalog(source, 'fliks.unknown', '1.0.0'),
+        404,
+        'PLUGIN_CATALOG_VERSION_NOT_FOUND',
+      );
+    });
+  });
+
+  describe('uninstall', () => {
+    it('removes the row, the registry entry and the directory; calling it twice is not an error', async () => {
+      const { buffer, manifest } = signedDataArchive({ id: 'fliks.uninstall-me' });
+      const { stagingId, sha256 } = await service.inspectUpload(buffer);
+      await service.confirmImport({ stagingId: stagingId!, sha256: sha256! });
+      expect(registry.get(manifest.id)).toBeDefined();
+
+      await service.uninstall(manifest.id);
+
+      expect(repo.rows.has(manifest.id)).toBe(false);
+      expect(registry.get(manifest.id)).toBeUndefined();
+      expect(existsSync(installedPluginDir(manifest.id, manifest.version))).toBe(false);
+
+      await expect(service.uninstall(manifest.id)).resolves.toBeUndefined();
+    });
+
+    it('is safe for a plugin whose row and files never existed', async () => {
+      await expect(service.uninstall('fliks.never-installed')).resolves.toBeUndefined();
+    });
+  });
+});

--- a/backend/src/modules/plugins/plugin-install.service.ts
+++ b/backend/src/modules/plugins/plugin-install.service.ts
@@ -1,0 +1,290 @@
+import { Injectable, Logger, HttpStatus } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import axios from 'axios';
+import { createHash } from 'crypto';
+import { closeSync, cpSync, existsSync, fsyncSync, mkdirSync, openSync, renameSync, rmSync } from 'fs';
+import { dirname, join } from 'path';
+import * as semver from 'semver';
+import { PluginPackage, PluginPackageOrigin } from './entities/plugin-package.entity';
+import { PluginSource } from './entities/plugin-source.entity';
+import { PluginRegistryService, CURRENT_FLIKS_VERSION } from './plugin-registry.service';
+import { PluginStagingService } from './plugin-staging.service';
+import { PluginInstallException } from './plugin-install.exception';
+import { getPluginsRuntimeDir } from '../../common/constants/paths';
+import { inspect, InspectSuccess, extractToStaging, MAX_ARCHIVE_COMPRESSED_BYTES, type PluginRefusalCode } from './archive';
+import type { TrustOutcome } from './archive/trust-store';
+import type { CatalogVersionEntry, FilteredCatalog, FilteredCatalogEntry } from './catalog/catalog';
+import { PLUGIN_API_VERSION, type PluginKind, type PluginManifest } from '../../common/plugin-contract';
+import type { ConfirmImportDto } from './dto/confirm-import.dto';
+
+const ARCHIVE_FETCH_TIMEOUT_MS = 30_000;
+
+export interface PluginInspectReport {
+  installable: boolean;
+  refusalCode?: PluginRefusalCode;
+  detail?: string;
+  stagingId?: string;
+  sha256?: string;
+  id?: string;
+  version?: string;
+  kind?: PluginKind;
+  signature?: TrustOutcome;
+  signedByKeyId?: string;
+  capabilities?: string[];
+  /** `pluginApi` exact match + `fliks` range — informational, never blocks staging. */
+  compatible?: boolean;
+}
+
+export interface PluginInstallResult {
+  pluginId: string;
+  version: string;
+  status: 'active' | 'failed';
+  reason?: string;
+  detail?: string;
+}
+
+/** `${runtime dir}/installed/<id>@<version>/` — exported for uninstall's own recomputation and for tests. */
+export function installedPluginDir(pluginId: string, version: string): string {
+  return join(getPluginsRuntimeDir(), 'installed', `${pluginId}@${version}`);
+}
+
+function fsyncPath(path: string): void {
+  const fd = openSync(path, 'r');
+  try {
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/** Same-filesystem rename when possible; copy+remove is the only option across devices. */
+function promoteDir(srcDir: string, destDir: string): void {
+  mkdirSync(dirname(destDir), { recursive: true });
+  rmSync(destDir, { recursive: true, force: true });
+  try {
+    renameSync(srcDir, destDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EXDEV') throw err;
+    cpSync(srcDir, destDir, { recursive: true });
+    rmSync(srcDir, { recursive: true, force: true });
+  }
+}
+
+/** Same two checks `PluginRegistryService.register()` runs at L4 — reported here as information only, never a staging gate. */
+function isCompatible(manifest: PluginManifest): boolean {
+  return manifest.pluginApi === PLUGIN_API_VERSION && semver.satisfies(CURRENT_FLIKS_VERSION, manifest.fliks);
+}
+
+/** `zipUrl`/`sha256` are install-pipeline-owned fields on a catalog version entry — see `catalog/catalog.ts`'s doc comment. */
+function catalogArchiveInfo(entry: CatalogVersionEntry): { zipUrl: string; sha256: string } | null {
+  const { zipUrl, sha256 } = entry as { zipUrl?: unknown; sha256?: unknown };
+  if (typeof zipUrl !== 'string' || typeof sha256 !== 'string') return null;
+  return { zipUrl, sha256 };
+}
+
+function findInstallableVersion(
+  cachedCatalog: Record<string, unknown> | null,
+  pluginId: string,
+  version: string,
+): CatalogVersionEntry | null {
+  const catalog = cachedCatalog as unknown as FilteredCatalog | null;
+  const entry = catalog?.plugins?.find((p: FilteredCatalogEntry) => p.id === pluginId);
+  const versionEntry = entry?.installable.find((v) => v.version === version);
+  return versionEntry ?? null;
+}
+
+/**
+ * Orchestrates the install/update/uninstall pipeline for the `data` tier
+ * (`plans/plugin-system.plan.md`, "Install pipeline, end to end"). `process`
+ * archives flow through the same guards and the same promotion — only
+ * `PluginRegistryService.register()` tells them apart, refusing to activate
+ * one for lack of a supervisor. That refusal does not roll back the install.
+ */
+@Injectable()
+export class PluginInstallService {
+  private readonly logger = new Logger(PluginInstallService.name);
+
+  constructor(
+    @InjectRepository(PluginPackage)
+    private readonly packageRepo: Repository<PluginPackage>,
+    private readonly registry: PluginRegistryService,
+    private readonly staging: PluginStagingService,
+  ) {}
+
+  /** V1-V7 in memory, then stages the raw bytes. Nothing is activated. */
+  async inspectUpload(buffer: Buffer): Promise<PluginInspectReport> {
+    const result = await inspect(buffer);
+    if (!result.ok) return { installable: false, refusalCode: result.code, detail: result.detail };
+
+    const { stagingId } = this.staging.stage(buffer);
+    return this.buildReport(result, stagingId);
+  }
+
+  /**
+   * Re-runs V1-V7 against a fresh read of the staged bytes — never the
+   * buffer inspect() already validated — because a writable directory is
+   * not proof of what a second HTTP call will find in it.
+   */
+  async confirmImport(dto: ConfirmImportDto): Promise<PluginInstallResult> {
+    const buffer = this.staging.read(dto.stagingId);
+    const actualSha256 = createHash('sha256').update(buffer).digest('hex');
+    if (actualSha256 !== dto.sha256) {
+      throw new PluginInstallException(
+        HttpStatus.CONFLICT,
+        'PLUGIN_STAGING_STALE',
+        'the staged bytes no longer match the hash the client saw',
+      );
+    }
+
+    const result = await inspect(buffer);
+    if (!result.ok) {
+      throw new PluginInstallException(HttpStatus.UNPROCESSABLE_ENTITY, result.code, result.detail);
+    }
+
+    try {
+      return await this.promote(buffer, result, 'manual');
+    } finally {
+      this.staging.discard(dto.stagingId);
+    }
+  }
+
+  /** A1 (fetch) + A2 (checksum vs the signed catalog document, before any guard runs), then the same pipeline. */
+  async installFromCatalog(source: PluginSource, pluginId: string, version: string): Promise<PluginInstallResult> {
+    const entry = findInstallableVersion(source.cachedCatalog, pluginId, version);
+    const info = entry && catalogArchiveInfo(entry);
+    if (!info) {
+      throw new PluginInstallException(
+        HttpStatus.NOT_FOUND,
+        'PLUGIN_CATALOG_VERSION_NOT_FOUND',
+        `"${pluginId}@${version}" is not an installable version on source #${source.id}`,
+      );
+    }
+
+    const buffer = await this.fetchArchive(info.zipUrl);
+
+    const actualSha256 = createHash('sha256').update(buffer).digest('hex');
+    if (actualSha256 !== info.sha256) {
+      throw new PluginInstallException(
+        HttpStatus.UNPROCESSABLE_ENTITY,
+        'PLUGIN_CHECKSUM_MISMATCH',
+        'the downloaded archive does not match the signed catalog checksum',
+      );
+    }
+
+    const result = await inspect(buffer);
+    if (!result.ok) {
+      throw new PluginInstallException(HttpStatus.UNPROCESSABLE_ENTITY, result.code, result.detail);
+    }
+
+    return this.promote(buffer, result, 'catalog');
+  }
+
+  /** Safe to call for a plugin whose row, registry entry or directory is already gone. */
+  async uninstall(pluginId: string): Promise<void> {
+    this.registry.unregister(pluginId);
+    const pkg = await this.packageRepo.findOne({ where: { pluginId } });
+    if (!pkg) return;
+    await this.packageRepo.remove(pkg);
+    rmSync(installedPluginDir(pkg.pluginId, pkg.version), { recursive: true, force: true });
+  }
+
+  private buildReport(result: InspectSuccess, stagingId: string): PluginInspectReport {
+    return {
+      installable: true,
+      stagingId,
+      sha256: result.sha256,
+      id: result.id,
+      version: result.version,
+      kind: result.kind,
+      signature: result.signature,
+      signedByKeyId: result.signedByKeyId,
+      capabilities: result.capabilities,
+      compatible: isCompatible(result.manifest),
+    };
+  }
+
+  /** P2 (fsync + rename) -> P3 (upsert the row) -> P4a (register). A P4a refusal leaves the row `failed`, install stands. */
+  private async promote(buffer: Buffer, result: InspectSuccess, origin: PluginPackageOrigin): Promise<PluginInstallResult> {
+    const { manifest } = result;
+    const extracted = await extractToStaging(buffer, manifest);
+    if (!extracted.ok) {
+      throw new PluginInstallException(HttpStatus.UNPROCESSABLE_ENTITY, extracted.code, extracted.detail);
+    }
+
+    const existing = await this.packageRepo.findOne({ where: { pluginId: manifest.id } });
+    const targetDir = installedPluginDir(manifest.id, manifest.version);
+    const previousDir =
+      existing && existing.version !== manifest.version ? installedPluginDir(existing.pluginId, existing.version) : null;
+
+    try {
+      for (const file of extracted.files) fsyncPath(file.path);
+      fsyncPath(extracted.dir);
+      promoteDir(extracted.dir, targetDir);
+    } catch (err) {
+      rmSync(extracted.dir, { recursive: true, force: true });
+      throw new PluginInstallException(HttpStatus.INTERNAL_SERVER_ERROR, 'PLUGIN_PROMOTE_FAILED', (err as Error).message);
+    }
+
+    let saved: PluginPackage;
+    try {
+      const row = existing ?? this.packageRepo.create({ pluginId: manifest.id });
+      row.version = manifest.version;
+      row.archive = buffer;
+      row.origin = origin;
+      row.signature = result.signature;
+      row.verifiedByKeyId = result.signedByKeyId ?? null;
+      row.manifest = manifest;
+      row.status = 'active';
+      row.statusReason = null;
+      saved = await this.packageRepo.save(row);
+    } catch (err) {
+      rmSync(targetDir, { recursive: true, force: true });
+      throw new PluginInstallException(HttpStatus.INTERNAL_SERVER_ERROR, 'PLUGIN_INSTALL_FAILED', (err as Error).message);
+    }
+
+    if (previousDir && existsSync(previousDir)) rmSync(previousDir, { recursive: true, force: true });
+
+    const registration = await this.registry.register(saved);
+    if (!registration.ok) {
+      saved.status = 'failed';
+      saved.statusReason = `${registration.reason}: ${registration.detail}`;
+      await this.packageRepo.save(saved);
+      this.logger.warn(`plugin "${saved.pluginId}" installed but not activated (${registration.reason}): ${registration.detail}`);
+      return { pluginId: saved.pluginId, version: saved.version, status: 'failed', reason: registration.reason, detail: registration.detail };
+    }
+
+    return { pluginId: saved.pluginId, version: saved.version, status: 'active' };
+  }
+
+  private async fetchArchive(zipUrl: string): Promise<Buffer> {
+    let url: URL;
+    try {
+      url = new URL(zipUrl);
+    } catch {
+      throw new PluginInstallException(HttpStatus.BAD_GATEWAY, 'PLUGIN_FETCH_FAILED', `invalid archive URL "${zipUrl}"`);
+    }
+    if (url.protocol !== 'https:') {
+      throw new PluginInstallException(HttpStatus.BAD_GATEWAY, 'PLUGIN_FETCH_FAILED', 'archive URL must be https');
+    }
+
+    try {
+      const res = await axios.get<ArrayBuffer>(url.toString(), {
+        responseType: 'arraybuffer',
+        timeout: ARCHIVE_FETCH_TIMEOUT_MS,
+        maxRedirects: 0,
+        maxContentLength: MAX_ARCHIVE_COMPRESSED_BYTES,
+        headers: { 'User-Agent': 'Fliks-Plugin-Installer/1.0' },
+      });
+      return Buffer.from(res.data);
+    } catch (err) {
+      if (axios.isAxiosError(err) && err.code === 'ECONNABORTED') {
+        throw new PluginInstallException(HttpStatus.GATEWAY_TIMEOUT, 'PLUGIN_FETCH_TIMEOUT', 'archive download timed out');
+      }
+      if (axios.isAxiosError(err) && /maxContentLength/i.test(err.message)) {
+        throw new PluginInstallException(HttpStatus.PAYLOAD_TOO_LARGE, 'PLUGIN_FETCH_TOO_LARGE', err.message);
+      }
+      throw new PluginInstallException(HttpStatus.BAD_GATEWAY, 'PLUGIN_FETCH_FAILED', (err as Error).message);
+    }
+  }
+}

--- a/backend/src/modules/plugins/plugin-sources.controller.spec.ts
+++ b/backend/src/modules/plugins/plugin-sources.controller.spec.ts
@@ -21,7 +21,7 @@ describe('PluginSourcesController', () => {
   it('returns the cached catalog fields for a known source', async () => {
     const source = fakeSource({ cachedCatalog: { plugins: [] }, lastRefreshError: 'boom' });
     const repo = { findOne: jest.fn().mockResolvedValue(source) };
-    const controller = new PluginSourcesController(repo as never, {} as never);
+    const controller = new PluginSourcesController(repo as never, {} as never, {} as never);
 
     await expect(controller.getCatalog(1)).resolves.toEqual({
       cachedCatalog: { plugins: [] },
@@ -33,7 +33,7 @@ describe('PluginSourcesController', () => {
 
   it('404s reading the catalog of an unknown source', async () => {
     const repo = { findOne: jest.fn().mockResolvedValue(null) };
-    const controller = new PluginSourcesController(repo as never, {} as never);
+    const controller = new PluginSourcesController(repo as never, {} as never, {} as never);
 
     await expect(controller.getCatalog(99)).rejects.toThrow(NotFoundException);
   });
@@ -42,7 +42,7 @@ describe('PluginSourcesController', () => {
     const source = fakeSource();
     const repo = { findOne: jest.fn().mockResolvedValue(source) };
     const catalogClient = { refreshSource: jest.fn().mockResolvedValue({ ok: true }) };
-    const controller = new PluginSourcesController(repo as never, catalogClient as never);
+    const controller = new PluginSourcesController(repo as never, catalogClient as never, {} as never);
 
     await expect(controller.refresh(1)).resolves.toEqual({ ok: true });
     expect(catalogClient.refreshSource).toHaveBeenCalledWith(source);
@@ -51,9 +51,32 @@ describe('PluginSourcesController', () => {
   it('404s a manual refresh of an unknown source without touching the catalog client', async () => {
     const repo = { findOne: jest.fn().mockResolvedValue(null) };
     const catalogClient = { refreshSource: jest.fn() };
-    const controller = new PluginSourcesController(repo as never, catalogClient as never);
+    const controller = new PluginSourcesController(repo as never, catalogClient as never, {} as never);
 
     await expect(controller.refresh(99)).rejects.toThrow(NotFoundException);
     expect(catalogClient.refreshSource).not.toHaveBeenCalled();
+  });
+
+  it('delegates a catalog install to the install service for a known source', async () => {
+    const source = fakeSource();
+    const repo = { findOne: jest.fn().mockResolvedValue(source) };
+    const installService = { installFromCatalog: jest.fn().mockResolvedValue({ pluginId: 'fliks.test', version: '1.0.0', status: 'active' }) };
+    const controller = new PluginSourcesController(repo as never, {} as never, installService as never);
+
+    await expect(controller.install(1, { pluginId: 'fliks.test', version: '1.0.0' })).resolves.toEqual({
+      pluginId: 'fliks.test',
+      version: '1.0.0',
+      status: 'active',
+    });
+    expect(installService.installFromCatalog).toHaveBeenCalledWith(source, 'fliks.test', '1.0.0');
+  });
+
+  it('404s a catalog install of an unknown source without touching the install service', async () => {
+    const repo = { findOne: jest.fn().mockResolvedValue(null) };
+    const installService = { installFromCatalog: jest.fn() };
+    const controller = new PluginSourcesController(repo as never, {} as never, installService as never);
+
+    await expect(controller.install(99, { pluginId: 'fliks.test', version: '1.0.0' })).rejects.toThrow(NotFoundException);
+    expect(installService.installFromCatalog).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/plugins/plugin-sources.controller.ts
+++ b/backend/src/modules/plugins/plugin-sources.controller.ts
@@ -1,14 +1,16 @@
-import { Controller, Get, Post, Param, ParseIntPipe, NotFoundException, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, Param, ParseIntPipe, NotFoundException, UseGuards } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { PluginSource } from './entities/plugin-source.entity';
 import { PluginCatalogClientService, type CatalogRefreshResult } from './plugin-catalog-client.service';
+import { PluginInstallService, type PluginInstallResult } from './plugin-install.service';
+import { InstallFromCatalogDto } from './dto/install-from-catalog.dto';
 import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
 import { PoliciesGuard } from '../auth/casl/policies.guard';
 import { CheckPolicies } from '../auth/casl/check-policies.decorator';
 import { Action } from '../auth/casl/actions.enum';
 
-/** Manual refresh and cached-catalog read for one `plugin_sources` row. Admin-only. */
+/** Manual refresh, cached-catalog read and install-from-catalog for one `plugin_sources` row. Admin-only. */
 @Controller('plugins/sources')
 @UseGuards(JwtOrApiKeyGuard, PoliciesGuard)
 export class PluginSourcesController {
@@ -16,6 +18,7 @@ export class PluginSourcesController {
     @InjectRepository(PluginSource)
     private readonly sourceRepo: Repository<PluginSource>,
     private readonly catalogClient: PluginCatalogClientService,
+    private readonly installService: PluginInstallService,
   ) {}
 
   @Get(':id/catalog')
@@ -38,6 +41,13 @@ export class PluginSourcesController {
   async refresh(@Param('id', ParseIntPipe) id: number): Promise<CatalogRefreshResult> {
     const source = await this.findOrThrow(id);
     return this.catalogClient.refreshSource(source);
+  }
+
+  @Post(':id/install')
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
+  async install(@Param('id', ParseIntPipe) id: number, @Body() dto: InstallFromCatalogDto): Promise<PluginInstallResult> {
+    const source = await this.findOrThrow(id);
+    return this.installService.installFromCatalog(source, dto.pluginId, dto.version);
   }
 
   private async findOrThrow(id: number): Promise<PluginSource> {

--- a/backend/src/modules/plugins/plugin-staging.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-staging.service.spec.ts
@@ -1,0 +1,82 @@
+import { existsSync, readdirSync, rmSync, utimesSync } from 'fs';
+import { join } from 'path';
+import { PluginStagingService, MAX_CONCURRENT_STAGED_IMPORTS } from './plugin-staging.service';
+import { PluginInstallException } from './plugin-install.exception';
+import { getPluginsRuntimeDir } from '../../common/constants/paths';
+
+function stagingRoot(): string {
+  return join(getPluginsRuntimeDir(), 'import-staging');
+}
+
+describe('PluginStagingService', () => {
+  let service: PluginStagingService;
+
+  beforeEach(() => {
+    rmSync(stagingRoot(), { recursive: true, force: true });
+    service = new PluginStagingService();
+  });
+
+  afterAll(() => {
+    rmSync(stagingRoot(), { recursive: true, force: true });
+  });
+
+  it('stages a buffer under a directory named after its sha256, and reads it back unchanged', () => {
+    const buffer = Buffer.from('one archive');
+    const { stagingId, sha256 } = service.stage(buffer);
+
+    expect(stagingId).toBe(sha256.slice(0, 32));
+    expect(service.read(stagingId)).toEqual(buffer);
+  });
+
+  it('re-staging identical bytes reuses the existing directory rather than creating a second', () => {
+    const buffer = Buffer.from('same content every time');
+    const first = service.stage(buffer);
+    const second = service.stage(buffer);
+
+    expect(second.stagingId).toBe(first.stagingId);
+    expect(readdirSync(stagingRoot())).toEqual([first.stagingId]);
+  });
+
+  it('reading an unknown staging id refuses with PLUGIN_STAGING_NOT_FOUND', () => {
+    expect(() => service.read('0'.repeat(32))).toThrow(PluginInstallException);
+    try {
+      service.read('0'.repeat(32));
+    } catch (err) {
+      expect((err as PluginInstallException).getStatus()).toBe(404);
+      expect((err as PluginInstallException).code).toBe('PLUGIN_STAGING_NOT_FOUND');
+    }
+  });
+
+  it('refuses a new staging directory once the concurrent cap is reached', () => {
+    for (let i = 0; i < MAX_CONCURRENT_STAGED_IMPORTS; i++) {
+      service.stage(Buffer.from(`distinct archive ${i}`));
+    }
+
+    expect(() => service.stage(Buffer.from('one too many'))).toThrow(PluginInstallException);
+    try {
+      service.stage(Buffer.from('one too many'));
+    } catch (err) {
+      expect((err as PluginInstallException).getStatus()).toBe(429);
+      expect((err as PluginInstallException).code).toBe('PLUGIN_STAGING_LIMIT');
+    }
+  });
+
+  it('discard removes a staged directory', () => {
+    const { stagingId } = service.stage(Buffer.from('to be discarded'));
+    service.discard(stagingId);
+    expect(existsSync(join(stagingRoot(), stagingId))).toBe(false);
+  });
+
+  it('sweep removes only entries older than the retention window', () => {
+    const fresh = service.stage(Buffer.from('fresh'));
+    const stale = service.stage(Buffer.from('stale'));
+    const staleDir = join(stagingRoot(), stale.stagingId);
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    utimesSync(staleDir, twoHoursAgo, twoHoursAgo);
+
+    service.sweep();
+
+    expect(existsSync(join(stagingRoot(), fresh.stagingId))).toBe(true);
+    expect(existsSync(staleDir)).toBe(false);
+  });
+});

--- a/backend/src/modules/plugins/plugin-staging.service.ts
+++ b/backend/src/modules/plugins/plugin-staging.service.ts
@@ -1,0 +1,86 @@
+import { Injectable, HttpStatus } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { createHash } from 'crypto';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { getPluginsRuntimeDir } from '../../common/constants/paths';
+import { PluginInstallException } from './plugin-install.exception';
+
+/** `plans/plugin-system.plan.md`, "Staging disk-fill" guard. */
+export const MAX_CONCURRENT_STAGED_IMPORTS = 5;
+const STAGING_MAX_AGE_MS = 60 * 60 * 1000;
+const ARCHIVE_FILENAME = 'archive.zip';
+
+/**
+ * Holds a manually-uploaded archive on disk between `inspect` and `confirm`,
+ * so `confirm` never has to trust an in-memory buffer that a second HTTP
+ * call away might no longer match a writable directory's actual bytes.
+ * Directory name = `sha256(zip).slice(0, 32)`, so re-staging identical bytes
+ * is a no-op rather than a second directory.
+ */
+@Injectable()
+export class PluginStagingService {
+  private root(): string {
+    return join(getPluginsRuntimeDir(), 'import-staging');
+  }
+
+  private dirFor(stagingId: string): string {
+    return join(this.root(), stagingId);
+  }
+
+  /** Idempotent on content: identical bytes reuse the existing directory and never count twice against the cap. */
+  stage(buffer: Buffer): { stagingId: string; sha256: string } {
+    const sha256 = createHash('sha256').update(buffer).digest('hex');
+    const stagingId = sha256.slice(0, 32);
+    const archivePath = join(this.dirFor(stagingId), ARCHIVE_FILENAME);
+    if (existsSync(archivePath)) return { stagingId, sha256 };
+
+    if (this.listStagingIds().length >= MAX_CONCURRENT_STAGED_IMPORTS) {
+      throw new PluginInstallException(
+        HttpStatus.TOO_MANY_REQUESTS,
+        'PLUGIN_STAGING_LIMIT',
+        `at most ${MAX_CONCURRENT_STAGED_IMPORTS} staged installs may exist at once — confirm or wait for one to be swept`,
+      );
+    }
+
+    mkdirSync(this.dirFor(stagingId), { recursive: true, mode: 0o700 });
+    writeFileSync(archivePath, buffer, { mode: 0o600 });
+    return { stagingId, sha256 };
+  }
+
+  /** Fresh read off disk — the whole point of the second guard pass at confirm. */
+  read(stagingId: string): Buffer {
+    const archivePath = join(this.dirFor(stagingId), ARCHIVE_FILENAME);
+    if (!existsSync(archivePath)) {
+      throw new PluginInstallException(HttpStatus.NOT_FOUND, 'PLUGIN_STAGING_NOT_FOUND', `no staged upload "${stagingId}"`);
+    }
+    return readFileSync(archivePath);
+  }
+
+  discard(stagingId: string): void {
+    rmSync(this.dirFor(stagingId), { recursive: true, force: true });
+  }
+
+  private listStagingIds(): string[] {
+    try {
+      return readdirSync(this.root());
+    } catch {
+      return [];
+    }
+  }
+
+  /** Same `@nestjs/schedule` mechanism `PluginCatalogClientService` already declares its cron on. */
+  @Cron(CronExpression.EVERY_HOUR)
+  sweep(): void {
+    const root = this.root();
+    const cutoff = Date.now() - STAGING_MAX_AGE_MS;
+    for (const id of this.listStagingIds()) {
+      const dir = join(root, id);
+      try {
+        if (statSync(dir).mtimeMs < cutoff) rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // removed between the listing and the stat — nothing to sweep
+      }
+    }
+  }
+}

--- a/backend/src/modules/plugins/plugins.controller.spec.ts
+++ b/backend/src/modules/plugins/plugins.controller.spec.ts
@@ -1,0 +1,11 @@
+import { PluginsController } from './plugins.controller';
+
+describe('PluginsController', () => {
+  it('delegates uninstall to the install service', async () => {
+    const installService = { uninstall: jest.fn().mockResolvedValue(undefined) };
+    const controller = new PluginsController(installService as never);
+
+    await expect(controller.uninstall('fliks.test-plugin')).resolves.toBeUndefined();
+    expect(installService.uninstall).toHaveBeenCalledWith('fliks.test-plugin');
+  });
+});

--- a/backend/src/modules/plugins/plugins.controller.ts
+++ b/backend/src/modules/plugins/plugins.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Delete, HttpCode, HttpStatus, Param, UseGuards } from '@nestjs/common';
+import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
+import { PoliciesGuard } from '../auth/casl/policies.guard';
+import { CheckPolicies } from '../auth/casl/check-policies.decorator';
+import { Action } from '../auth/casl/actions.enum';
+import { PluginInstallService } from './plugin-install.service';
+
+@Controller('plugins')
+@UseGuards(JwtOrApiKeyGuard, PoliciesGuard)
+export class PluginsController {
+  constructor(private readonly installService: PluginInstallService) {}
+
+  /** Row + registry entry + extracted directory. Safe on a plugin whose files or row are already gone. */
+  @Delete(':pluginId')
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async uninstall(@Param('pluginId') pluginId: string): Promise<void> {
+    await this.installService.uninstall(pluginId);
+  }
+}

--- a/backend/src/modules/plugins/plugins.module.ts
+++ b/backend/src/modules/plugins/plugins.module.ts
@@ -6,16 +6,32 @@ import { PluginRegistration } from './entities/plugin-registration.entity';
 import { PluginRegistryService } from './plugin-registry.service';
 import { PluginWebhookDispatcherService } from './plugin-webhook-dispatcher.service';
 import { PluginCatalogClientService } from './plugin-catalog-client.service';
+import { PluginStagingService } from './plugin-staging.service';
+import { PluginInstallService } from './plugin-install.service';
 import { PluginLogoController } from './plugin-logo.controller';
 import { PluginIndexerDescriptorsController } from './plugin-indexer-descriptors.controller';
 import { PluginSourcesController } from './plugin-sources.controller';
+import { PluginImportController } from './plugin-import.controller';
+import { PluginsController } from './plugins.controller';
 import { AuthModule } from '../auth/auth.module';
 import { EventsModule } from '../scheduler/events.module';
 
 @Module({
   imports: [TypeOrmModule.forFeature([PluginPackage, PluginSource, PluginRegistration]), AuthModule, EventsModule],
-  controllers: [PluginLogoController, PluginIndexerDescriptorsController, PluginSourcesController],
-  providers: [PluginRegistryService, PluginWebhookDispatcherService, PluginCatalogClientService],
+  controllers: [
+    PluginLogoController,
+    PluginIndexerDescriptorsController,
+    PluginSourcesController,
+    PluginImportController,
+    PluginsController,
+  ],
+  providers: [
+    PluginRegistryService,
+    PluginWebhookDispatcherService,
+    PluginCatalogClientService,
+    PluginStagingService,
+    PluginInstallService,
+  ],
   exports: [TypeOrmModule, PluginRegistryService],
 })
 export class PluginsModule {}


### PR DESCRIPTION
PR 7.2. The guard suite from #897 has had nothing to guard until now; this is the pipeline around it.

**Two steps, because consent needs something to consent to.** `inspect` validates and stages without activating anything. `confirm` **re-reads the bytes from disk and runs every guard again** — a writable directory between two HTTP calls is not something to trust.

The test for that is the one worth reading: it stages a valid archive, overwrites the staged file with a *different but well-formed* one, **and recomputes the hash so the hash comparison passes**. What refuses it is the guard re-run, not the checksum. Without that test the second pass could be quietly reduced to a hash check and nobody would notice.

**Promotion** fsyncs the files and the directory before renaming into place, so a crash mid-install cannot leave a half-written plugin that loads. A plugin that installs but fails to register keeps its row and records why — the install stands, per the plan, and the reason is a column rather than a log line, which needed a small migration.

**Uninstall** removes the row, the registry entry and the extracted files; safe twice, and safe on something that never registered.

## Verified end to end against the running stack

Not just unit tests — a real archive built by **python's `zipfile`** (an implementation the suite doesn't use), pushed through the actual HTTP API:

| step | result |
|---|---|
| `POST import/inspect` | `201`, `installable: true`, `signature: unverified` (correct — empty trust store) |
| `confirm` with a wrong sha256 | `409` |
| `confirm` with the right one | `201 {status: active}` |
| `plugin_packages` | one row, 628 archive bytes, `origin: manual` |
| on disk | `plugin.json`, `.sig`, `logo.svg` under the runtime dir |
| **`GET /plugins/:id/logo`** | **`200 image/svg+xml`** |
| `DELETE`, then again | `204`, `204` |
| after uninstall | logo `404`, zero rows, zero directories |

That logo line is the interesting one: the route from #900 served a plugin installed seconds earlier **with no restart** — the hot-reload path working for real, not in a mock.

Authorization checked live too: anonymous `401`, regular user `403`.

Migration verified up → down → up on a throwaway database, then `migration:generate` confirmed zero drift between the entities and the migration chain — the check that caught a real bug in #899.

`tsc` 0, suite **957** (+26).

## Out of scope, deliberately

- **Rollback.** It needs a decision about retaining prior versions that this PR has no basis to make. The old directory is removed on update rather than kept in a shape that would have to be redesigned.
- **P1 database provisioning** — that is 3.4, and there is no supervisor yet.
- A `process` archive flows through the identical pipeline and lands as `status: failed` via the registry's existing tier refusal. Nothing pretends to spawn it.