### PR TITLE
feat(plugins): add the plugins admin page and its install consent sheet

### DIFF
--- a/backend/src/modules/plugins/plugin-install.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-install.service.spec.ts
@@ -62,6 +62,7 @@ function fakePackageRepo() {
       rows.delete(row.pluginId);
       return row;
     }),
+    find: jest.fn(async () => [...rows.values()]),
   };
 }
 
@@ -137,6 +138,7 @@ describe('PluginInstallService', () => {
         expect.objectContaining({
           installable: true,
           id: manifest.id,
+          name: manifest.name,
           version: manifest.version,
           kind: 'data',
           signature: 'unverified',
@@ -323,6 +325,39 @@ describe('PluginInstallService', () => {
 
     it('is safe for a plugin whose row and files never existed', async () => {
       await expect(service.uninstall('fliks.never-installed')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('listInstalled', () => {
+    it('lists every row regardless of status, with the failed one carrying its reason', async () => {
+      const { buffer: activeBuf, manifest: activeManifest } = signedDataArchive({ id: 'fliks.list-active' });
+      const activeStage = await service.inspectUpload(activeBuf);
+      await service.confirmImport({ stagingId: activeStage.stagingId!, sha256: activeStage.sha256! });
+
+      const { buffer: failedBuf, manifest: failedManifest } = signedDataArchive({
+        id: 'fliks.list-failed',
+        fliks: '>=99.0.0',
+      });
+      const failedStage = await service.inspectUpload(failedBuf);
+      await service.confirmImport({ stagingId: failedStage.stagingId!, sha256: failedStage.sha256! });
+
+      const list = await service.listInstalled();
+
+      expect(list).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            pluginId: activeManifest.id,
+            name: activeManifest.name,
+            status: 'active',
+            statusReason: null,
+          }),
+          expect.objectContaining({
+            pluginId: failedManifest.id,
+            status: 'failed',
+            statusReason: expect.stringContaining('incompatible-fliks'),
+          }),
+        ]),
+      );
     });
   });
 });

--- a/backend/src/modules/plugins/plugin-install.service.ts
+++ b/backend/src/modules/plugins/plugin-install.service.ts
@@ -6,7 +6,7 @@ import { createHash } from 'crypto';
 import { closeSync, cpSync, existsSync, fsyncSync, mkdirSync, openSync, renameSync, rmSync } from 'fs';
 import { dirname, join } from 'path';
 import * as semver from 'semver';
-import { PluginPackage, PluginPackageOrigin } from './entities/plugin-package.entity';
+import { PluginPackage, PluginPackageOrigin, PluginPackageStatus } from './entities/plugin-package.entity';
 import { PluginSource } from './entities/plugin-source.entity';
 import { PluginRegistryService, CURRENT_FLIKS_VERSION } from './plugin-registry.service';
 import { PluginStagingService } from './plugin-staging.service';
@@ -27,6 +27,8 @@ export interface PluginInspectReport {
   stagingId?: string;
   sha256?: string;
   id?: string;
+  /** The manifest's human-readable `name` — the consent sheet's copy ("{{name}} runs code…") reads this, never `id`. */
+  name?: string;
   version?: string;
   kind?: PluginKind;
   signature?: TrustOutcome;
@@ -42,6 +44,19 @@ export interface PluginInstallResult {
   status: 'active' | 'failed';
   reason?: string;
   detail?: string;
+}
+
+/** One row of the admin plugin list — sourced from `plugin_packages`, not the in-memory registry, so a `failed` row still shows up. */
+export interface PluginSummary {
+  pluginId: string;
+  name: string;
+  version: string;
+  kind: PluginKind;
+  origin: PluginPackageOrigin;
+  status: PluginPackageStatus;
+  statusReason: string | null;
+  signature: TrustOutcome;
+  verifiedByKeyId: string | null;
 }
 
 /** `${runtime dir}/installed/<id>@<version>/` — exported for uninstall's own recomputation and for tests. */
@@ -180,6 +195,22 @@ export class PluginInstallService {
     return this.promote(buffer, result, 'catalog');
   }
 
+  /** Every installed row, active or failed — the admin list reads the table directly for this reason. */
+  async listInstalled(): Promise<PluginSummary[]> {
+    const packages = await this.packageRepo.find();
+    return packages.map((pkg) => ({
+      pluginId: pkg.pluginId,
+      name: pkg.manifest.name,
+      version: pkg.version,
+      kind: pkg.manifest.kind,
+      origin: pkg.origin,
+      status: pkg.status,
+      statusReason: pkg.statusReason,
+      signature: pkg.signature,
+      verifiedByKeyId: pkg.verifiedByKeyId,
+    }));
+  }
+
   /** Safe to call for a plugin whose row, registry entry or directory is already gone. */
   async uninstall(pluginId: string): Promise<void> {
     this.registry.unregister(pluginId);
@@ -195,6 +226,7 @@ export class PluginInstallService {
       stagingId,
       sha256: result.sha256,
       id: result.id,
+      name: result.manifest.name,
       version: result.version,
       kind: result.kind,
       signature: result.signature,

--- a/backend/src/modules/plugins/plugins.controller.spec.ts
+++ b/backend/src/modules/plugins/plugins.controller.spec.ts
@@ -8,4 +8,13 @@ describe('PluginsController', () => {
     await expect(controller.uninstall('fliks.test-plugin')).resolves.toBeUndefined();
     expect(installService.uninstall).toHaveBeenCalledWith('fliks.test-plugin');
   });
+
+  it('delegates list to the install service', async () => {
+    const rows = [{ pluginId: 'fliks.test-plugin', status: 'active' }];
+    const installService = { listInstalled: jest.fn().mockResolvedValue(rows) };
+    const controller = new PluginsController(installService as never);
+
+    await expect(controller.list()).resolves.toBe(rows);
+    expect(installService.listInstalled).toHaveBeenCalled();
+  });
 });

--- a/backend/src/modules/plugins/plugins.controller.ts
+++ b/backend/src/modules/plugins/plugins.controller.ts
@@ -1,14 +1,20 @@
-import { Controller, Delete, HttpCode, HttpStatus, Param, UseGuards } from '@nestjs/common';
+import { Controller, Delete, Get, HttpCode, HttpStatus, Param, UseGuards } from '@nestjs/common';
 import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
 import { PoliciesGuard } from '../auth/casl/policies.guard';
 import { CheckPolicies } from '../auth/casl/check-policies.decorator';
 import { Action } from '../auth/casl/actions.enum';
-import { PluginInstallService } from './plugin-install.service';
+import { PluginInstallService, PluginSummary } from './plugin-install.service';
 
 @Controller('plugins')
 @UseGuards(JwtOrApiKeyGuard, PoliciesGuard)
 export class PluginsController {
   constructor(private readonly installService: PluginInstallService) {}
+
+  @Get()
+  @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
+  async list(): Promise<PluginSummary[]> {
+    return this.installService.listInstalled();
+  }
 
   /** Row + registry entry + extracted directory. Safe on a plugin whose files or row are already gone. */
   @Delete(':pluginId')

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1494,7 +1494,8 @@
       "subtitle_providers": "Untertitel-Anbieter",
       "subtitles": "Untertitel",
       "schedulers": "Geplante Aufgaben",
-      "streaming": "Streaming"
+      "streaming": "Streaming",
+      "plugins": "Plugins"
     },
     "streaming": {
       "title": "Streaming",
@@ -2252,6 +2253,64 @@
       "search_one": "Diesen Untertitel suchen",
       "search_one_ok": "Untertitel {{lang}} für „{{title}}“ heruntergeladen",
       "search_one_none": "Kein Untertitel {{lang}} mit ausreichendem Score gefunden"
+    },
+    "plugins": {
+      "title": "Plugins",
+      "subtitle": "Install plugins to add indexers, jobs and interface pages to Fliks.",
+      "upload": "Install plugin…",
+      "load_error": "Unable to load the plugin list.",
+      "empty": "No plugin installed.",
+      "col_plugin": "Plugin",
+      "col_version": "Version",
+      "col_tier": "Tier",
+      "col_trust": "Trust",
+      "col_status": "Status",
+      "tier_data": "Data",
+      "tier_process": "Process",
+      "status_active": "Active",
+      "status_failed": "Failed",
+      "uninstall": "Uninstall",
+      "confirm_uninstall": "Uninstall \"{{name}}\"? Its files are removed immediately.",
+      "uninstalled": "Plugin uninstalled.",
+      "uninstall_error": "Unable to uninstall the plugin.",
+      "inspect_error": "Unable to read this archive.",
+      "installed": "Plugin installed.",
+      "install_failed_but_kept": "\"{{id}}\" was installed but could not start: {{reason}}",
+      "trust": {
+        "official": "Official",
+        "verified": "Verified — {{key}}",
+        "unverified": "Unverified",
+        "manual": "Imported manually"
+      },
+      "consent": {
+        "refused_title": "This plugin cannot be installed",
+        "title": "Install {{name}}?",
+        "identity": "{{id}} · v{{version}}",
+        "data_tier": "This plugin contains no program code. It cannot run anything on your server.",
+        "process_tier_title": "{{name}} runs code on your server.",
+        "process_tier_body": "It runs in its own process with restricted file access — it cannot read your server's secrets. It can reach your network, and it can add files to your media library. A signature confirms who published it. It does not confirm that the code is safe.",
+        "capabilities_title": "This plugin can",
+        "capability": {
+          "ui": "Add a \"{{value}}\" interface element",
+          "config": "Add a \"{{value}}\" settings page",
+          "scope": "Access: {{value}}",
+          "job": "Run a scheduled job: {{value}}",
+          "webhook": "Subscribe to server events"
+        },
+        "unverified_ack": "I understand this plugin's publisher is not verified, and I want to install it anyway.",
+        "confirm": "Install",
+        "refusal": {
+          "malformed": "This archive is not a valid Fliks plugin package.",
+          "too_large": "This archive is too large, or its contents don't match what it declares.",
+          "data_tier_field": "This plugin claims to be data-only, but its manifest declares program code. It was refused.",
+          "bad_signature": "This archive's signature is malformed.",
+          "unsigned_process": "This plugin runs code but is not signed. Signed process plugins are required.",
+          "hash_mismatch": "This archive changed after it was inspected. Upload it again.",
+          "file_set_mismatch": "This archive's files do not match its manifest.",
+          "tier_violation": "This archive's contents do not match its declared kind.",
+          "unknown": "This plugin could not be installed (code {{code}})."
+        }
+      }
     }
   },
   "roles": {

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1504,7 +1504,8 @@
       "subtitle_providers": "Subtitle providers",
       "subtitles": "Subtitles",
       "schedulers": "Scheduled tasks",
-      "streaming": "Streaming"
+      "streaming": "Streaming",
+      "plugins": "Plugins"
     },
     "streaming": {
       "title": "Streaming",
@@ -2279,6 +2280,64 @@
       "search_one": "Search for this subtitle",
       "search_one_ok": "{{lang}} subtitle downloaded for \"{{title}}\"",
       "search_one_none": "No {{lang}} subtitle found with a sufficient score"
+    },
+    "plugins": {
+      "title": "Plugins",
+      "subtitle": "Install plugins to add indexers, jobs and interface pages to Fliks.",
+      "upload": "Install plugin…",
+      "load_error": "Unable to load the plugin list.",
+      "empty": "No plugin installed.",
+      "col_plugin": "Plugin",
+      "col_version": "Version",
+      "col_tier": "Tier",
+      "col_trust": "Trust",
+      "col_status": "Status",
+      "tier_data": "Data",
+      "tier_process": "Process",
+      "status_active": "Active",
+      "status_failed": "Failed",
+      "uninstall": "Uninstall",
+      "confirm_uninstall": "Uninstall \"{{name}}\"? Its files are removed immediately.",
+      "uninstalled": "Plugin uninstalled.",
+      "uninstall_error": "Unable to uninstall the plugin.",
+      "inspect_error": "Unable to read this archive.",
+      "installed": "Plugin installed.",
+      "install_failed_but_kept": "\"{{id}}\" was installed but could not start: {{reason}}",
+      "trust": {
+        "official": "Official",
+        "verified": "Verified — {{key}}",
+        "unverified": "Unverified",
+        "manual": "Imported manually"
+      },
+      "consent": {
+        "refused_title": "This plugin cannot be installed",
+        "title": "Install {{name}}?",
+        "identity": "{{id}} · v{{version}}",
+        "data_tier": "This plugin contains no program code. It cannot run anything on your server.",
+        "process_tier_title": "{{name}} runs code on your server.",
+        "process_tier_body": "It runs in its own process with restricted file access — it cannot read your server's secrets. It can reach your network, and it can add files to your media library. A signature confirms who published it. It does not confirm that the code is safe.",
+        "capabilities_title": "This plugin can",
+        "capability": {
+          "ui": "Add a \"{{value}}\" interface element",
+          "config": "Add a \"{{value}}\" settings page",
+          "scope": "Access: {{value}}",
+          "job": "Run a scheduled job: {{value}}",
+          "webhook": "Subscribe to server events"
+        },
+        "unverified_ack": "I understand this plugin's publisher is not verified, and I want to install it anyway.",
+        "confirm": "Install",
+        "refusal": {
+          "malformed": "This archive is not a valid Fliks plugin package.",
+          "too_large": "This archive is too large, or its contents don't match what it declares.",
+          "data_tier_field": "This plugin claims to be data-only, but its manifest declares program code. It was refused.",
+          "bad_signature": "This archive's signature is malformed.",
+          "unsigned_process": "This plugin runs code but is not signed. Signed process plugins are required.",
+          "hash_mismatch": "This archive changed after it was inspected. Upload it again.",
+          "file_set_mismatch": "This archive's files do not match its manifest.",
+          "tier_violation": "This archive's contents do not match its declared kind.",
+          "unknown": "This plugin could not be installed (code {{code}})."
+        }
+      }
     }
   },
   "roles": {

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1494,7 +1494,8 @@
       "subtitle_providers": "Proveedores de subtítulos",
       "subtitles": "Subtítulos",
       "schedulers": "Tareas programadas",
-      "streaming": "Streaming"
+      "streaming": "Streaming",
+      "plugins": "Plugins"
     },
     "streaming": {
       "title": "Streaming",
@@ -2252,6 +2253,64 @@
       "search_one": "Buscar este subtítulo",
       "search_one_ok": "Subtítulo {{lang}} descargado para «{{title}}»",
       "search_one_none": "No se encontró ningún subtítulo {{lang}} con una puntuación suficiente"
+    },
+    "plugins": {
+      "title": "Plugins",
+      "subtitle": "Install plugins to add indexers, jobs and interface pages to Fliks.",
+      "upload": "Install plugin…",
+      "load_error": "Unable to load the plugin list.",
+      "empty": "No plugin installed.",
+      "col_plugin": "Plugin",
+      "col_version": "Version",
+      "col_tier": "Tier",
+      "col_trust": "Trust",
+      "col_status": "Status",
+      "tier_data": "Data",
+      "tier_process": "Process",
+      "status_active": "Active",
+      "status_failed": "Failed",
+      "uninstall": "Uninstall",
+      "confirm_uninstall": "Uninstall \"{{name}}\"? Its files are removed immediately.",
+      "uninstalled": "Plugin uninstalled.",
+      "uninstall_error": "Unable to uninstall the plugin.",
+      "inspect_error": "Unable to read this archive.",
+      "installed": "Plugin installed.",
+      "install_failed_but_kept": "\"{{id}}\" was installed but could not start: {{reason}}",
+      "trust": {
+        "official": "Official",
+        "verified": "Verified — {{key}}",
+        "unverified": "Unverified",
+        "manual": "Imported manually"
+      },
+      "consent": {
+        "refused_title": "This plugin cannot be installed",
+        "title": "Install {{name}}?",
+        "identity": "{{id}} · v{{version}}",
+        "data_tier": "This plugin contains no program code. It cannot run anything on your server.",
+        "process_tier_title": "{{name}} runs code on your server.",
+        "process_tier_body": "It runs in its own process with restricted file access — it cannot read your server's secrets. It can reach your network, and it can add files to your media library. A signature confirms who published it. It does not confirm that the code is safe.",
+        "capabilities_title": "This plugin can",
+        "capability": {
+          "ui": "Add a \"{{value}}\" interface element",
+          "config": "Add a \"{{value}}\" settings page",
+          "scope": "Access: {{value}}",
+          "job": "Run a scheduled job: {{value}}",
+          "webhook": "Subscribe to server events"
+        },
+        "unverified_ack": "I understand this plugin's publisher is not verified, and I want to install it anyway.",
+        "confirm": "Install",
+        "refusal": {
+          "malformed": "This archive is not a valid Fliks plugin package.",
+          "too_large": "This archive is too large, or its contents don't match what it declares.",
+          "data_tier_field": "This plugin claims to be data-only, but its manifest declares program code. It was refused.",
+          "bad_signature": "This archive's signature is malformed.",
+          "unsigned_process": "This plugin runs code but is not signed. Signed process plugins are required.",
+          "hash_mismatch": "This archive changed after it was inspected. Upload it again.",
+          "file_set_mismatch": "This archive's files do not match its manifest.",
+          "tier_violation": "This archive's contents do not match its declared kind.",
+          "unknown": "This plugin could not be installed (code {{code}})."
+        }
+      }
     }
   },
   "roles": {

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1504,7 +1504,8 @@
       "subtitle_providers": "Fournisseurs de sous-titres",
       "subtitles": "Sous-titres",
       "schedulers": "Tâches planifiées",
-      "streaming": "Streaming"
+      "streaming": "Streaming",
+      "plugins": "Plugins"
     },
     "streaming": {
       "title": "Streaming",
@@ -2279,6 +2280,64 @@
       "search_one": "Rechercher ce sous-titre",
       "search_one_ok": "Sous-titre {{lang}} téléchargé pour « {{title}} »",
       "search_one_none": "Aucun sous-titre {{lang}} trouvé avec un score suffisant"
+    },
+    "plugins": {
+      "title": "Plugins",
+      "subtitle": "Installez des plugins pour ajouter des indexeurs, des tâches et des pages à Fliks.",
+      "upload": "Installer un plugin…",
+      "load_error": "Impossible de charger la liste des plugins.",
+      "empty": "Aucun plugin installé.",
+      "col_plugin": "Plugin",
+      "col_version": "Version",
+      "col_tier": "Niveau",
+      "col_trust": "Confiance",
+      "col_status": "Statut",
+      "tier_data": "Données",
+      "tier_process": "Processus",
+      "status_active": "Actif",
+      "status_failed": "Échec",
+      "uninstall": "Désinstaller",
+      "confirm_uninstall": "Désinstaller « {{name}} » ? Ses fichiers sont supprimés immédiatement.",
+      "uninstalled": "Plugin désinstallé.",
+      "uninstall_error": "Impossible de désinstaller le plugin.",
+      "inspect_error": "Impossible de lire cette archive.",
+      "installed": "Plugin installé.",
+      "install_failed_but_kept": "« {{id}} » a été installé mais n'a pas pu démarrer : {{reason}}",
+      "trust": {
+        "official": "Officiel",
+        "verified": "Vérifié — {{key}}",
+        "unverified": "Non vérifié",
+        "manual": "Importé manuellement"
+      },
+      "consent": {
+        "refused_title": "Ce plugin ne peut pas être installé",
+        "title": "Installer {{name}} ?",
+        "identity": "{{id}} · v{{version}}",
+        "data_tier": "Ce plugin ne contient aucun code exécutable. Il ne peut rien exécuter sur votre serveur.",
+        "process_tier_title": "{{name}} exécute du code sur votre serveur.",
+        "process_tier_body": "Il s'exécute dans son propre processus avec un accès restreint aux fichiers — il ne peut pas lire les secrets de votre serveur. Il peut accéder au réseau et ajouter des fichiers à votre bibliothèque de médias. Une signature confirme qui l'a publié. Elle ne confirme pas que le code est sûr.",
+        "capabilities_title": "Ce plugin peut",
+        "capability": {
+          "ui": "Ajouter un élément d'interface « {{value}} »",
+          "config": "Ajouter une page de réglages « {{value}} »",
+          "scope": "Accès : {{value}}",
+          "job": "Exécuter une tâche planifiée : {{value}}",
+          "webhook": "S'abonner aux événements du serveur"
+        },
+        "unverified_ack": "Je comprends que l'éditeur de ce plugin n'est pas vérifié, et je veux quand même l'installer.",
+        "confirm": "Installer",
+        "refusal": {
+          "malformed": "Cette archive n'est pas un package de plugin Fliks valide.",
+          "too_large": "Cette archive est trop volumineuse, ou son contenu ne correspond pas à ce qu'elle déclare.",
+          "data_tier_field": "Ce plugin se déclare comme données uniquement, mais son manifeste déclare du code exécutable. Il a été refusé.",
+          "bad_signature": "La signature de cette archive est mal formée.",
+          "unsigned_process": "Ce plugin exécute du code mais n'est pas signé. Les plugins de type processus doivent être signés.",
+          "hash_mismatch": "Cette archive a changé après son inspection. Envoyez-la à nouveau.",
+          "file_set_mismatch": "Les fichiers de cette archive ne correspondent pas à son manifeste.",
+          "tier_violation": "Le contenu de cette archive ne correspond pas au niveau déclaré.",
+          "unknown": "Ce plugin n'a pas pu être installé (code {{code}})."
+        }
+      }
     }
   },
   "roles": {

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1494,7 +1494,8 @@
       "subtitle_providers": "Fornitori di sottotitoli",
       "subtitles": "Sottotitoli",
       "schedulers": "Attività pianificate",
-      "streaming": "Streaming"
+      "streaming": "Streaming",
+      "plugins": "Plugins"
     },
     "streaming": {
       "title": "Streaming",
@@ -2252,6 +2253,64 @@
       "search_one": "Cerca questo sottotitolo",
       "search_one_ok": "Sottotitolo {{lang}} scaricato per « {{title}} »",
       "search_one_none": "Nessun sottotitolo {{lang}} trovato con un punteggio sufficiente"
+    },
+    "plugins": {
+      "title": "Plugins",
+      "subtitle": "Install plugins to add indexers, jobs and interface pages to Fliks.",
+      "upload": "Install plugin…",
+      "load_error": "Unable to load the plugin list.",
+      "empty": "No plugin installed.",
+      "col_plugin": "Plugin",
+      "col_version": "Version",
+      "col_tier": "Tier",
+      "col_trust": "Trust",
+      "col_status": "Status",
+      "tier_data": "Data",
+      "tier_process": "Process",
+      "status_active": "Active",
+      "status_failed": "Failed",
+      "uninstall": "Uninstall",
+      "confirm_uninstall": "Uninstall \"{{name}}\"? Its files are removed immediately.",
+      "uninstalled": "Plugin uninstalled.",
+      "uninstall_error": "Unable to uninstall the plugin.",
+      "inspect_error": "Unable to read this archive.",
+      "installed": "Plugin installed.",
+      "install_failed_but_kept": "\"{{id}}\" was installed but could not start: {{reason}}",
+      "trust": {
+        "official": "Official",
+        "verified": "Verified — {{key}}",
+        "unverified": "Unverified",
+        "manual": "Imported manually"
+      },
+      "consent": {
+        "refused_title": "This plugin cannot be installed",
+        "title": "Install {{name}}?",
+        "identity": "{{id}} · v{{version}}",
+        "data_tier": "This plugin contains no program code. It cannot run anything on your server.",
+        "process_tier_title": "{{name}} runs code on your server.",
+        "process_tier_body": "It runs in its own process with restricted file access — it cannot read your server's secrets. It can reach your network, and it can add files to your media library. A signature confirms who published it. It does not confirm that the code is safe.",
+        "capabilities_title": "This plugin can",
+        "capability": {
+          "ui": "Add a \"{{value}}\" interface element",
+          "config": "Add a \"{{value}}\" settings page",
+          "scope": "Access: {{value}}",
+          "job": "Run a scheduled job: {{value}}",
+          "webhook": "Subscribe to server events"
+        },
+        "unverified_ack": "I understand this plugin's publisher is not verified, and I want to install it anyway.",
+        "confirm": "Install",
+        "refusal": {
+          "malformed": "This archive is not a valid Fliks plugin package.",
+          "too_large": "This archive is too large, or its contents don't match what it declares.",
+          "data_tier_field": "This plugin claims to be data-only, but its manifest declares program code. It was refused.",
+          "bad_signature": "This archive's signature is malformed.",
+          "unsigned_process": "This plugin runs code but is not signed. Signed process plugins are required.",
+          "hash_mismatch": "This archive changed after it was inspected. Upload it again.",
+          "file_set_mismatch": "This archive's files do not match its manifest.",
+          "tier_violation": "This archive's contents do not match its declared kind.",
+          "unknown": "This plugin could not be installed (code {{code}})."
+        }
+      }
     }
   },
   "roles": {

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1494,7 +1494,8 @@
       "subtitle_providers": "Fornecedores de legendas",
       "subtitles": "Legendas",
       "schedulers": "Tarefas agendadas",
-      "streaming": "Streaming"
+      "streaming": "Streaming",
+      "plugins": "Plugins"
     },
     "streaming": {
       "title": "Streaming",
@@ -2252,6 +2253,64 @@
       "search_one": "Procurar esta legenda",
       "search_one_ok": "Legenda {{lang}} transferida para «{{title}}»",
       "search_one_none": "Nenhuma legenda {{lang}} encontrada com pontuação suficiente"
+    },
+    "plugins": {
+      "title": "Plugins",
+      "subtitle": "Install plugins to add indexers, jobs and interface pages to Fliks.",
+      "upload": "Install plugin…",
+      "load_error": "Unable to load the plugin list.",
+      "empty": "No plugin installed.",
+      "col_plugin": "Plugin",
+      "col_version": "Version",
+      "col_tier": "Tier",
+      "col_trust": "Trust",
+      "col_status": "Status",
+      "tier_data": "Data",
+      "tier_process": "Process",
+      "status_active": "Active",
+      "status_failed": "Failed",
+      "uninstall": "Uninstall",
+      "confirm_uninstall": "Uninstall \"{{name}}\"? Its files are removed immediately.",
+      "uninstalled": "Plugin uninstalled.",
+      "uninstall_error": "Unable to uninstall the plugin.",
+      "inspect_error": "Unable to read this archive.",
+      "installed": "Plugin installed.",
+      "install_failed_but_kept": "\"{{id}}\" was installed but could not start: {{reason}}",
+      "trust": {
+        "official": "Official",
+        "verified": "Verified — {{key}}",
+        "unverified": "Unverified",
+        "manual": "Imported manually"
+      },
+      "consent": {
+        "refused_title": "This plugin cannot be installed",
+        "title": "Install {{name}}?",
+        "identity": "{{id}} · v{{version}}",
+        "data_tier": "This plugin contains no program code. It cannot run anything on your server.",
+        "process_tier_title": "{{name}} runs code on your server.",
+        "process_tier_body": "It runs in its own process with restricted file access — it cannot read your server's secrets. It can reach your network, and it can add files to your media library. A signature confirms who published it. It does not confirm that the code is safe.",
+        "capabilities_title": "This plugin can",
+        "capability": {
+          "ui": "Add a \"{{value}}\" interface element",
+          "config": "Add a \"{{value}}\" settings page",
+          "scope": "Access: {{value}}",
+          "job": "Run a scheduled job: {{value}}",
+          "webhook": "Subscribe to server events"
+        },
+        "unverified_ack": "I understand this plugin's publisher is not verified, and I want to install it anyway.",
+        "confirm": "Install",
+        "refusal": {
+          "malformed": "This archive is not a valid Fliks plugin package.",
+          "too_large": "This archive is too large, or its contents don't match what it declares.",
+          "data_tier_field": "This plugin claims to be data-only, but its manifest declares program code. It was refused.",
+          "bad_signature": "This archive's signature is malformed.",
+          "unsigned_process": "This plugin runs code but is not signed. Signed process plugins are required.",
+          "hash_mismatch": "This archive changed after it was inspected. Upload it again.",
+          "file_set_mismatch": "This archive's files do not match its manifest.",
+          "tier_violation": "This archive's contents do not match its declared kind.",
+          "unknown": "This plugin could not be installed (code {{code}})."
+        }
+      }
     }
   },
   "roles": {

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -412,6 +412,7 @@ export const routes: Routes = [
           { path: 'blocklist', loadComponent: () => import('./features/settings/blocklist/blocklist').then((m) => m.BlocklistSettingsComponent) },
           { path: 'notifications', loadComponent: () => import('./features/settings/notifications/notifications').then((m) => m.NotificationsSettingsComponent) },
           { path: 'media-servers', loadComponent: () => import('./features/settings/media-servers/media-servers').then((m) => m.MediaServersSettingsComponent) },
+          { path: 'plugins', loadComponent: () => import('./features/settings/plugins/plugins').then((m) => m.PluginsSettingsComponent) },
           { path: 'data-imports', loadComponent: () => import('./features/settings/data-imports/data-imports').then((m) => m.DataImportsSettingsComponent) },
           { path: 'libraries', loadComponent: () => import('./features/settings/libraries/libraries').then((m) => m.LibrariesSettingsComponent) },
           {

--- a/client/src/app/core/services/api/plugins-api.service.ts
+++ b/client/src/app/core/services/api/plugins-api.service.ts
@@ -1,0 +1,78 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+
+export type PluginKind = 'data' | 'process';
+/** Mirrors backend `TrustOutcome` (`archive/trust-store.ts`). */
+export type PluginTrust = 'official' | `verified-${string}` | 'unverified' | 'unsigned';
+export type PluginOrigin = 'catalog' | 'manual';
+export type PluginStatus = 'active' | 'failed';
+
+export interface PluginSummary {
+  pluginId: string;
+  name: string;
+  version: string;
+  kind: PluginKind;
+  origin: PluginOrigin;
+  status: PluginStatus;
+  statusReason: string | null;
+  signature: PluginTrust;
+  verifiedByKeyId: string | null;
+}
+
+/** Mirrors backend `PluginInspectReport`. A refusal carries `refusalCode`/`detail` and nothing else. */
+export interface PluginInspectReport {
+  installable: boolean;
+  refusalCode?: string;
+  detail?: string;
+  stagingId?: string;
+  sha256?: string;
+  id?: string;
+  name?: string;
+  version?: string;
+  kind?: PluginKind;
+  signature?: PluginTrust;
+  signedByKeyId?: string;
+  capabilities?: string[];
+  compatible?: boolean;
+}
+
+export interface PluginInstallResult {
+  pluginId: string;
+  version: string;
+  status: PluginStatus;
+  reason?: string;
+  detail?: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class PluginsApiService {
+  private readonly http = inject(HttpClient);
+
+  list() {
+    return firstValueFrom(this.http.get<PluginSummary[]>('/api/plugins'));
+  }
+
+  inspect(file: File) {
+    const form = new FormData();
+    form.append('file', file);
+    return firstValueFrom(
+      this.http.post<PluginInspectReport>('/api/plugins/import/inspect', form),
+    );
+  }
+
+  confirm(stagingId: string, sha256: string) {
+    return firstValueFrom(
+      this.http.post<PluginInstallResult>('/api/plugins/import/confirm', { stagingId, sha256 }),
+    );
+  }
+
+  uninstall(pluginId: string) {
+    return firstValueFrom(this.http.delete<void>(`/api/plugins/${pluginId}`));
+  }
+
+  /** `<img src>` only — never fetched and inlined as trusted markup (the route is `sandbox`-CSP'd SVG/PNG bytes). */
+  logoUrl(pluginId: string): string {
+    return `/api/plugins/${pluginId}/logo`;
+  }
+}

--- a/client/src/app/features/admin/admin-shell.html
+++ b/client/src/app/features/admin/admin-shell.html
@@ -54,5 +54,6 @@
     <li class="menu-title text-xs uppercase tracking-wider mt-4">{{ 'admin.section_advanced' | translate }}</li>
     <li><a routerLink="/admin/settings/schedulers" routerLinkActive="active">{{ 'settings.nav.schedulers' | translate }}</a></li>
     <li><a routerLink="/admin/settings/streaming" routerLinkActive="active">{{ 'settings.nav.streaming' | translate }}</a></li>
+    <li><a routerLink="/admin/settings/plugins" routerLinkActive="active">{{ 'settings.nav.plugins' | translate }}</a></li>
   </ng-container>
 </app-settings-drawer>

--- a/client/src/app/features/settings/plugins/plugin-install-consent/plugin-install-consent.html
+++ b/client/src/app/features/settings/plugins/plugin-install-consent/plugin-install-consent.html
@@ -1,0 +1,71 @@
+<dialog #dialog class="modal">
+  <div class="modal-box max-w-lg">
+    @if (report(); as r) {
+      @if (!r.installable) {
+        <h3 class="text-lg font-bold mb-2">{{ 'settings.plugins.consent.refused_title' | translate }}</h3>
+        <p class="text-sm text-base-content/70">{{ refusalMessage() }}</p>
+        <div class="modal-action">
+          <button type="button" class="btn" (click)="close()">{{ 'common.close' | translate }}</button>
+        </div>
+      } @else {
+        <h3 class="text-lg font-bold">{{ 'settings.plugins.consent.title' | translate: { name: r.name } }}</h3>
+        <p class="text-xs text-base-content/50 mb-3">{{ 'settings.plugins.consent.identity' | translate: { id: r.id, version: r.version } }}</p>
+
+        <span class="badge badge-sm mb-3" [class]="trust().cssClass">
+          {{ trust().labelKey | translate: trust().params }}
+        </span>
+
+        @if (r.kind === 'data') {
+          <p class="text-sm mb-4">{{ 'settings.plugins.consent.data_tier' | translate }}</p>
+        } @else {
+          <p class="text-sm font-semibold mb-1">{{ 'settings.plugins.consent.process_tier_title' | translate: { name: r.name } }}</p>
+          <p class="text-sm text-base-content/70 mb-4">{{ 'settings.plugins.consent.process_tier_body' | translate }}</p>
+        }
+
+        @if (r.capabilities?.length) {
+          <p class="text-xs font-semibold uppercase tracking-wider text-base-content/50 mb-2">
+            {{ 'settings.plugins.consent.capabilities_title' | translate }}
+          </p>
+          <ul class="list-disc list-inside text-sm mb-4 space-y-1">
+            @for (capability of r.capabilities; track capability) {
+              <li>{{ capabilityLabel(capability) }}</li>
+            }
+          </ul>
+        }
+
+        @if (requiresAck()) {
+          <label class="label cursor-pointer justify-start gap-3 mb-2">
+            <input
+              type="checkbox"
+              class="checkbox checkbox-sm"
+              [ngModel]="acknowledged()"
+              (ngModelChange)="acknowledged.set($event)"
+            />
+            <span class="label-text text-sm">{{ 'settings.plugins.consent.unverified_ack' | translate }}</span>
+          </label>
+        }
+
+        @if (error()) {
+          <div role="alert" class="alert alert-error text-sm py-2 mb-2">{{ error() }}</div>
+        }
+
+        <div class="modal-action">
+          <button type="button" class="btn btn-ghost" (click)="close()" [disabled]="confirming()">
+            {{ 'common.cancel' | translate }}
+          </button>
+          <button type="button" class="btn btn-primary" (click)="confirm()" [disabled]="!canConfirm()">
+            @if (confirming()) {
+              <span class="loading loading-spinner loading-sm"></span>
+            }
+            {{ 'settings.plugins.consent.confirm' | translate }}
+          </button>
+        </div>
+      }
+    }
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="button" (click)="close()" [attr.aria-label]="'common.close' | translate">
+      {{ 'common.close' | translate }}
+    </button>
+  </form>
+</dialog>

--- a/client/src/app/features/settings/plugins/plugin-install-consent/plugin-install-consent.ts
+++ b/client/src/app/features/settings/plugins/plugin-install-consent/plugin-install-consent.ts
@@ -1,0 +1,107 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  ElementRef,
+  computed,
+  inject,
+  output,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import {
+  PluginsApiService,
+  PluginInspectReport,
+  PluginInstallResult,
+} from '../../../../core/services/api/plugins-api.service';
+import { trustBadgeFor, requiresAcknowledgement } from '../plugin-trust';
+import { refusalMessageKey } from '../plugin-refusal';
+
+/**
+ * The install consent sheet ("plans/plugin-system.plan.md", "One install UX").
+ * Owns the confirm call itself — the caller only needs to open it with an
+ * inspect report and listen for `installed`.
+ */
+@Component({
+  selector: 'app-plugin-install-consent',
+  imports: [FormsModule, TranslateModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './plugin-install-consent.html',
+})
+export class PluginInstallConsentComponent {
+  private readonly api = inject(PluginsApiService);
+  protected readonly translate = inject(TranslateService);
+
+  private readonly dialogRef = viewChild.required<ElementRef<HTMLDialogElement>>('dialog');
+
+  readonly report = signal<PluginInspectReport | null>(null);
+  readonly acknowledged = signal(false);
+  readonly confirming = signal(false);
+  readonly error = signal('');
+
+  readonly installed = output<PluginInstallResult>();
+
+  readonly trust = computed(() => trustBadgeFor(this.report()?.signature));
+  readonly requiresAck = computed(() => requiresAcknowledgement(this.report()?.signature));
+  readonly canConfirm = computed(() => {
+    const r = this.report();
+    return !!r?.installable && !this.confirming() && (!this.requiresAck() || this.acknowledged());
+  });
+  readonly refusalMessage = computed(() => {
+    const r = this.report();
+    if (!r || r.installable) return '';
+    return this.translate.instant(refusalMessageKey(r.refusalCode), { code: r.refusalCode ?? '' });
+  });
+
+  open(report: PluginInspectReport): void {
+    this.report.set(report);
+    this.acknowledged.set(false);
+    this.confirming.set(false);
+    this.error.set('');
+    this.dialogRef().nativeElement.showModal();
+  }
+
+  close(): void {
+    this.dialogRef().nativeElement.close();
+  }
+
+  /** `ui:<slot>` / `config:<id>` / `scope:<name>` / `job:<name>` / `webhook` — see `deriveCapabilities` on the backend. */
+  capabilityLabel(capability: string): string {
+    const separator = capability.indexOf(':');
+    const prefix = separator === -1 ? capability : capability.slice(0, separator);
+    const value = separator === -1 ? '' : capability.slice(separator + 1);
+    switch (prefix) {
+      case 'ui':
+        return this.translate.instant('settings.plugins.consent.capability.ui', { value });
+      case 'config':
+        return this.translate.instant('settings.plugins.consent.capability.config', { value });
+      case 'scope':
+        return this.translate.instant('settings.plugins.consent.capability.scope', { value });
+      case 'job':
+        return this.translate.instant('settings.plugins.consent.capability.job', { value });
+      case 'webhook':
+        return this.translate.instant('settings.plugins.consent.capability.webhook');
+      default:
+        return capability;
+    }
+  }
+
+  async confirm(): Promise<void> {
+    const report = this.report();
+    if (!report?.stagingId || !report.sha256 || !this.canConfirm()) return;
+
+    this.confirming.set(true);
+    this.error.set('');
+    try {
+      const result = await this.api.confirm(report.stagingId, report.sha256);
+      this.close();
+      this.installed.emit(result);
+    } catch (err: unknown) {
+      const httpErr = err as { error?: { message?: string } };
+      this.error.set(httpErr.error?.message ?? this.translate.instant('common.error'));
+    } finally {
+      this.confirming.set(false);
+    }
+  }
+}

--- a/client/src/app/features/settings/plugins/plugin-refusal.spec.ts
+++ b/client/src/app/features/settings/plugins/plugin-refusal.spec.ts
@@ -1,0 +1,31 @@
+import { refusalMessageKey } from './plugin-refusal';
+
+describe('refusalMessageKey', () => {
+  it('buckets zip/manifest structural codes as malformed', () => {
+    expect(refusalMessageKey('PLUGIN_BAD_MAGIC')).toBe('settings.plugins.consent.refusal.malformed');
+    expect(refusalMessageKey('PLUGIN_SYMLINK')).toBe('settings.plugins.consent.refusal.malformed');
+  });
+
+  it('buckets size/ratio codes together', () => {
+    expect(refusalMessageKey('PLUGIN_TOO_LARGE')).toBe('settings.plugins.consent.refusal.too_large');
+    expect(refusalMessageKey('PLUGIN_RATIO')).toBe('settings.plugins.consent.refusal.too_large');
+  });
+
+  it('buckets every data-tier field violation together', () => {
+    expect(refusalMessageKey('PLUGIN_DATA_HAS_ROUTES')).toBe('settings.plugins.consent.refusal.data_tier_field');
+    expect(refusalMessageKey('PLUGIN_DATA_HAS_CHECKLIST')).toBe('settings.plugins.consent.refusal.data_tier_field');
+  });
+
+  it('gives signature/hash/tier codes their own message', () => {
+    expect(refusalMessageKey('PLUGIN_BAD_SIGNATURE')).toBe('settings.plugins.consent.refusal.bad_signature');
+    expect(refusalMessageKey('PLUGIN_UNSIGNED')).toBe('settings.plugins.consent.refusal.unsigned_process');
+    expect(refusalMessageKey('PLUGIN_HASH_MISMATCH')).toBe('settings.plugins.consent.refusal.hash_mismatch');
+    expect(refusalMessageKey('PLUGIN_FILE_SET_MISMATCH')).toBe('settings.plugins.consent.refusal.file_set_mismatch');
+    expect(refusalMessageKey('PLUGIN_TIER_VIOLATION')).toBe('settings.plugins.consent.refusal.tier_violation');
+  });
+
+  it('falls back to a generic message for an unknown or missing code', () => {
+    expect(refusalMessageKey('PLUGIN_SOME_FUTURE_GUARD')).toBe('settings.plugins.consent.refusal.unknown');
+    expect(refusalMessageKey(undefined)).toBe('settings.plugins.consent.refusal.unknown');
+  });
+});

--- a/client/src/app/features/settings/plugins/plugin-refusal.ts
+++ b/client/src/app/features/settings/plugins/plugin-refusal.ts
@@ -1,0 +1,64 @@
+/** Zip-structure and manifest-shape guards (`archive/zip-inspector.ts` V1-V7) — none of them actionable by an admin beyond "get a different build". */
+const MALFORMED_CODES = new Set([
+  'PLUGIN_BAD_MAGIC',
+  'PLUGIN_TOO_MANY_ENTRIES',
+  'PLUGIN_UNEXPECTED_ENTRY',
+  'PLUGIN_PATH_SEPARATOR',
+  'PLUGIN_ABSOLUTE_PATH',
+  'PLUGIN_CONTROL_CHAR',
+  'PLUGIN_NOT_NFC',
+  'PLUGIN_DUPLICATE_ENTRY',
+  'PLUGIN_DIRECTORY_ENTRY',
+  'PLUGIN_SYMLINK',
+  'PLUGIN_ZIP64',
+  'PLUGIN_DATA_DESCRIPTOR',
+  'PLUGIN_TRAILING_DATA',
+  'PLUGIN_ARCHIVE_COMMENT',
+  'PLUGIN_ENCRYPTED',
+  'PLUGIN_COMPRESSION_METHOD',
+  'PLUGIN_MALFORMED_ARCHIVE',
+  'PLUGIN_BAD_MANIFEST',
+  'PLUGIN_BAD_LOGO',
+]);
+
+const TOO_LARGE_CODES = new Set(['PLUGIN_TOO_LARGE', 'PLUGIN_RATIO', 'PLUGIN_MANIFEST_TOO_LARGE']);
+
+/** `data`-tier manifest carrying a process-only field (`archive/refusal-codes.ts`) — one message covers the family. */
+const DATA_TIER_CODES = new Set([
+  'PLUGIN_DATA_HAS_FILES',
+  'PLUGIN_DATA_HAS_ROUTES',
+  'PLUGIN_DATA_HAS_DATABASE',
+  'PLUGIN_DATA_HAS_JOBS',
+  'PLUGIN_DATA_HAS_INGEST_ROOTS',
+  'PLUGIN_DATA_HAS_MEMORY_MB',
+  'PLUGIN_DATA_HAS_RUNTIME',
+  'PLUGIN_DATA_HAS_PERMISSIONS',
+  'PLUGIN_DATA_HAS_CHECKLIST',
+]);
+
+/**
+ * One i18n key per refusal-code family — never the backend `detail` string, which
+ * is log/debug text only (see `archive/refusal-codes.ts`'s own doc comment). A code
+ * this map doesn't know yet (a future guard) falls back to a generic message that
+ * still carries the raw `code`, since the code itself — unlike `detail` — is the
+ * stable, safe-to-surface contract.
+ */
+export function refusalMessageKey(code: string | undefined): string {
+  if (code && MALFORMED_CODES.has(code)) return 'settings.plugins.consent.refusal.malformed';
+  if (code && TOO_LARGE_CODES.has(code)) return 'settings.plugins.consent.refusal.too_large';
+  if (code && DATA_TIER_CODES.has(code)) return 'settings.plugins.consent.refusal.data_tier_field';
+  switch (code) {
+    case 'PLUGIN_BAD_SIGNATURE':
+      return 'settings.plugins.consent.refusal.bad_signature';
+    case 'PLUGIN_UNSIGNED':
+      return 'settings.plugins.consent.refusal.unsigned_process';
+    case 'PLUGIN_HASH_MISMATCH':
+      return 'settings.plugins.consent.refusal.hash_mismatch';
+    case 'PLUGIN_FILE_SET_MISMATCH':
+      return 'settings.plugins.consent.refusal.file_set_mismatch';
+    case 'PLUGIN_TIER_VIOLATION':
+      return 'settings.plugins.consent.refusal.tier_violation';
+    default:
+      return 'settings.plugins.consent.refusal.unknown';
+  }
+}

--- a/client/src/app/features/settings/plugins/plugin-trust.spec.ts
+++ b/client/src/app/features/settings/plugins/plugin-trust.spec.ts
@@ -1,0 +1,37 @@
+import { trustBadgeFor, requiresAcknowledgement } from './plugin-trust';
+
+describe('trustBadgeFor', () => {
+  it('badges an official signature', () => {
+    expect(trustBadgeFor('official')).toEqual({ labelKey: 'settings.plugins.trust.official', cssClass: 'badge-success' });
+  });
+
+  it('badges an unsigned archive as manually imported', () => {
+    expect(trustBadgeFor('unsigned')).toEqual({ labelKey: 'settings.plugins.trust.manual', cssClass: 'badge-ghost' });
+  });
+
+  it('badges an unverified signature, including a missing value', () => {
+    expect(trustBadgeFor('unverified').labelKey).toBe('settings.plugins.trust.unverified');
+    expect(trustBadgeFor(undefined).labelKey).toBe('settings.plugins.trust.unverified');
+  });
+
+  it('extracts the key id from a verified-<key> outcome', () => {
+    expect(trustBadgeFor('verified-acme-2026')).toEqual({
+      labelKey: 'settings.plugins.trust.verified',
+      params: { key: 'acme-2026' },
+      cssClass: 'badge-success',
+    });
+  });
+});
+
+describe('requiresAcknowledgement', () => {
+  it('requires it for anything without an attributable signature', () => {
+    expect(requiresAcknowledgement('unverified')).toBe(true);
+    expect(requiresAcknowledgement('unsigned')).toBe(true);
+    expect(requiresAcknowledgement(undefined)).toBe(true);
+  });
+
+  it('does not require it once a key attributes the signature', () => {
+    expect(requiresAcknowledgement('official')).toBe(false);
+    expect(requiresAcknowledgement('verified-acme-2026')).toBe(false);
+  });
+});

--- a/client/src/app/features/settings/plugins/plugin-trust.ts
+++ b/client/src/app/features/settings/plugins/plugin-trust.ts
@@ -1,0 +1,24 @@
+import type { PluginTrust } from '../../../core/services/api/plugins-api.service';
+
+export interface TrustBadge {
+  labelKey: string;
+  params?: Record<string, string>;
+  cssClass: string;
+}
+
+/** Maps backend `TrustOutcome` onto the plan's four-badge model (Official / Verified / Unverified / Imported manually). */
+export function trustBadgeFor(trust: PluginTrust | undefined): TrustBadge {
+  if (trust === 'official') return { labelKey: 'settings.plugins.trust.official', cssClass: 'badge-success' };
+  if (trust === 'unsigned') return { labelKey: 'settings.plugins.trust.manual', cssClass: 'badge-ghost' };
+  if (trust === 'unverified' || !trust) return { labelKey: 'settings.plugins.trust.unverified', cssClass: 'badge-warning' };
+  return {
+    labelKey: 'settings.plugins.trust.verified',
+    params: { key: trust.slice('verified-'.length) },
+    cssClass: 'badge-success',
+  };
+}
+
+/** Gate for the consent sheet's acknowledgement checkbox: anything without an attributable signature. */
+export function requiresAcknowledgement(trust: PluginTrust | undefined): boolean {
+  return trust === 'unverified' || trust === 'unsigned' || !trust;
+}

--- a/client/src/app/features/settings/plugins/plugins.html
+++ b/client/src/app/features/settings/plugins/plugins.html
@@ -1,0 +1,85 @@
+<div class="flex flex-col gap-6">
+  <div class="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
+    <div>
+      <h1 class="text-2xl font-bold">{{ 'settings.plugins.title' | translate }}</h1>
+      <p class="text-sm text-base-content/60 mt-1">{{ 'settings.plugins.subtitle' | translate }}</p>
+    </div>
+    <button type="button" class="btn btn-primary self-start sm:self-auto" [disabled]="uploading()" (click)="pickFile()">
+      @if (uploading()) {
+        <span class="loading loading-spinner loading-sm"></span>
+      }
+      {{ 'settings.plugins.upload' | translate }}
+    </button>
+    <input #fileInput type="file" accept=".zip" class="hidden" (change)="onFilePicked($event)" />
+  </div>
+
+  @if (loading()) {
+    <div class="flex justify-center py-16">
+      <span class="loading loading-spinner loading-lg"></span>
+    </div>
+  } @else if (listError()) {
+    <div role="alert" class="alert alert-error">{{ listError() }}</div>
+  } @else if (rows().length === 0) {
+    <p class="text-center py-12 text-base-content/50">{{ 'settings.plugins.empty' | translate }}</p>
+  } @else {
+    <div class="overflow-x-auto rounded-lg border border-base-200">
+      <table class="table table-zebra table-sm">
+        <thead>
+          <tr>
+            <th>{{ 'settings.plugins.col_plugin' | translate }}</th>
+            <th>{{ 'settings.plugins.col_version' | translate }}</th>
+            <th>{{ 'settings.plugins.col_tier' | translate }}</th>
+            <th>{{ 'settings.plugins.col_trust' | translate }}</th>
+            <th>{{ 'settings.plugins.col_status' | translate }}</th>
+            <th class="text-end w-32"></th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (row of rows(); track row.pluginId) {
+            <tr>
+              <td>
+                <div class="flex items-center gap-3">
+                  <span class="w-8 h-8 rounded bg-base-200 shrink-0 flex items-center justify-center overflow-hidden">
+                    <img [src]="logoUrl(row.pluginId)" (error)="hideBrokenLogo($event)" alt="" class="w-full h-full object-contain" />
+                  </span>
+                  <div class="min-w-0">
+                    <p class="font-medium truncate">{{ row.name }}</p>
+                    <p class="text-xs text-base-content/50 truncate">{{ row.pluginId }}</p>
+                  </div>
+                </div>
+              </td>
+              <td class="text-sm">{{ row.version }}</td>
+              <td>
+                <span class="badge badge-ghost badge-sm">
+                  {{ (row.kind === 'data' ? 'settings.plugins.tier_data' : 'settings.plugins.tier_process') | translate }}
+                </span>
+              </td>
+              <td>
+                <span class="badge badge-sm" [class]="trustBadgeFor(row.signature).cssClass">
+                  {{ trustBadgeFor(row.signature).labelKey | translate: trustBadgeFor(row.signature).params }}
+                </span>
+              </td>
+              <td>
+                @if (row.status === 'active') {
+                  <span class="badge badge-success badge-sm">{{ 'settings.plugins.status_active' | translate }}</span>
+                } @else {
+                  <span class="badge badge-error badge-sm">{{ 'settings.plugins.status_failed' | translate }}</span>
+                  @if (row.statusReason) {
+                    <p class="text-xs text-error/80 mt-1 max-w-[16rem]">{{ row.statusReason }}</p>
+                  }
+                }
+              </td>
+              <td class="text-end">
+                <button type="button" class="btn btn-ghost btn-xs text-error" (click)="uninstall(row)">
+                  {{ 'settings.plugins.uninstall' | translate }}
+                </button>
+              </td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    </div>
+  }
+</div>
+
+<app-plugin-install-consent #consentSheet (installed)="onInstalled($event)" />

--- a/client/src/app/features/settings/plugins/plugins.ts
+++ b/client/src/app/features/settings/plugins/plugins.ts
@@ -1,0 +1,122 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  OnInit,
+  inject,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { ConfirmationService } from '../../../core/services/confirmation.service';
+import { ToastService } from '../../../core/services/toast.service';
+import {
+  PluginsApiService,
+  PluginSummary,
+  PluginInspectReport,
+  PluginInstallResult,
+} from '../../../core/services/api/plugins-api.service';
+import { PluginInstallConsentComponent } from './plugin-install-consent/plugin-install-consent';
+import { trustBadgeFor } from './plugin-trust';
+
+@Component({
+  selector: 'app-plugins-settings',
+  imports: [TranslateModule, PluginInstallConsentComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './plugins.html',
+})
+export class PluginsSettingsComponent implements OnInit {
+  private readonly api = inject(PluginsApiService);
+  private readonly translate = inject(TranslateService);
+  private readonly toast = inject(ToastService);
+  private readonly confirmation = inject(ConfirmationService);
+
+  private readonly fileInput = viewChild<ElementRef<HTMLInputElement>>('fileInput');
+  private readonly consentSheet = viewChild<PluginInstallConsentComponent>('consentSheet');
+
+  readonly rows = signal<PluginSummary[]>([]);
+  readonly loading = signal(true);
+  readonly listError = signal('');
+  readonly uploading = signal(false);
+
+  readonly trustBadgeFor = trustBadgeFor;
+
+  ngOnInit(): void {
+    this.reload();
+  }
+
+  async reload(): Promise<void> {
+    this.loading.set(true);
+    this.listError.set('');
+    try {
+      this.rows.set(await this.api.list());
+    } catch {
+      this.listError.set(this.translate.instant('settings.plugins.load_error'));
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  logoUrl(pluginId: string): string {
+    return this.api.logoUrl(pluginId);
+  }
+
+  /** No logo entry, or the plugin isn't registered (a `failed` row) — the route 404s either way; keep the placeholder box empty. */
+  hideBrokenLogo(event: Event): void {
+    (event.target as HTMLImageElement).style.display = 'none';
+  }
+
+  pickFile(): void {
+    this.fileInput()?.nativeElement.click();
+  }
+
+  /** Inspect uploads to staging regardless of outcome; the consent sheet renders either the consent UI or the refusal. */
+  async onFilePicked(event: Event): Promise<void> {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = '';
+    if (!file) return;
+
+    this.uploading.set(true);
+    try {
+      const report: PluginInspectReport = await this.api.inspect(file);
+      this.consentSheet()?.open(report);
+    } catch (err: unknown) {
+      const httpErr = err as { error?: { message?: string } };
+      this.toast.error(httpErr.error?.message ?? this.translate.instant('settings.plugins.inspect_error'));
+    } finally {
+      this.uploading.set(false);
+    }
+  }
+
+  async onInstalled(result: PluginInstallResult): Promise<void> {
+    await this.reload();
+    if (result.status === 'active') {
+      this.toast.success(this.translate.instant('settings.plugins.installed'));
+    } else {
+      this.toast.warning(
+        this.translate.instant('settings.plugins.install_failed_but_kept', {
+          id: result.pluginId,
+          reason: result.detail ?? result.reason ?? '',
+        }),
+      );
+    }
+  }
+
+  async uninstall(row: PluginSummary): Promise<void> {
+    const confirmed = await this.confirmation.confirm({
+      title: this.translate.instant('common.confirm'),
+      message: this.translate.instant('settings.plugins.confirm_uninstall', { name: row.name }),
+      variant: 'danger',
+    });
+    if (!confirmed) return;
+
+    try {
+      await this.api.uninstall(row.pluginId);
+      await this.reload();
+      this.toast.success(this.translate.instant('settings.plugins.uninstalled'));
+    } catch {
+      this.toast.error(this.translate.instant('settings.plugins.uninstall_error'));
+    }
+  }
+}


### PR DESCRIPTION
The plan's 7.3 and 7.4, **merged into one PR**: a consent sheet with no page to open it is a component nothing renders.

**Consent needs something to consent to**, so the UI mirrors the API's two steps — inspect and stage, show what it actually is, then confirm. The sheet exists rather than reusing `ConfirmationService` because that takes a title and a message and cannot render a capability list, a trust badge or a checkbox. It states the tier difference in the plan's own words, including that a signature confirms *who published it*, not that the code is safe.

**An unverified plugin cannot be installed on one click** — the acknowledgement gates the button. The agent extended that to *unsigned* as well, and it was right to: a plugin with no signature has strictly less provenance than one signed by an unrecognised key, so gating only the latter would have made the weaker case the easier one to accept.

**The page reads the table, not the registry**, so a plugin that failed to activate still appears with its reason — which is what the `statusReason` column in #905 was for. The registry only holds what loaded.

## Verified

- backend `tsc` 0, suite **959** (+2, for the new `GET /api/plugins`)
- client `tsc -p tsconfig.app.json` 0 — note plain `tsconfig.json` is a false green here (`files: []` plus project references, so it checks nothing without `-b`)
- production `ng build` succeeds; the page is a **lazy chunk**, initial bundle unchanged at 195 kB transfer
- client unit tests 102 pass
- **i18n parity checked mechanically**: 49 new keys, present in all six locales. A missing key renders as a raw key and no test catches it
- no hardcoded user-facing strings in the new templates, no inline templates — both repo rules, both checked rather than assumed
- the logo image tag authenticates because `JwtStrategy` extracts from the cookie before the Authorization header; a browser cannot send a Bearer header on an `<img>`, so this was worth confirming rather than assuming

## What I could not verify

**I did not see this render.** I built the client and served it, but headless Chromium hung on this machine and I stopped rather than sink more time into the tooling. So the checks above are structural: AOT compilation proves the templates type-check and that every pipe and directive is imported, but nothing here proves the layout looks right, the empty state reads well, or the sheet is usable at a small width.

Someone should open `/admin/settings/plugins` and actually look before this is considered done. The backend behind it is exercised end to end in #905, so what is unproven is presentation, not function.
