### PR TITLE
feat(plugins): trust the official catalog signing key

### DIFF
--- a/backend/src/modules/plugins/archive/trust-store.ts
+++ b/backend/src/modules/plugins/archive/trust-store.ts
@@ -6,7 +6,15 @@ import { createPublicKey, verify as verifyDetached } from 'crypto';
  * key: populate with `OFFICIAL_KEYS.set('<keyId>', Buffer.from('<base64>', 'base64'))`.
  * An empty store must never resolve a signature to `official` — see {@link resolveTrust}.
  */
-export const OFFICIAL_KEYS: ReadonlyMap<string, Buffer> = new Map();
+export const OFFICIAL_KEYS: ReadonlyMap<string, Buffer> = new Map([
+  // fliks-app/fliks-plugin-catalog signs its catalog and every first-party
+  // plugin with this key. Never remove a published key: old signatures must
+  // stay verifiable, which is what makes rotation safe.
+  [
+    'release-2026',
+    Buffer.from('Cj0i8YENJdTuC0I0pPPZbNuzo4tgIcpMnCjlb8rtaKs=', 'base64'),
+  ],
+]);
 
 export type TrustOutcome = 'official' | `verified-${string}` | 'unverified' | 'unsigned';
 


### PR DESCRIPTION
`OFFICIAL_KEYS` has been empty since #897 wrote the trust store, with a comment pointing at this moment. Empty meant no signature could ever resolve to `official`, so even a first-party plugin would have installed as *Unverified*. The catalog repository now signs with `release-2026`, and core recognises it.

## Verified before landing, not asserted

The key was proven to be the real pair, not just pasted in:

- `fliks-app/fliks-plugin-catalog`'s publish workflow signed the catalog with the private half held in its `CATALOG_SIGNING_KEY` secret, then **independently verified that signature against the committed public key** and refused to deploy otherwise. That step passed.
- Independently of CI, I fetched `https://fliks-app.github.io/fliks-plugin-catalog/catalog.json` and its `.sig` over HTTPS — the exact path a Fliks install uses, since `plugin_sources.url` names the catalog and the client reads `<url>.sig` — and verified the signature against this public key. It verifies.

So a mismatched pair fails in CI before publishing, and would have failed here too.

## Why this key is permanent

A published key is never removed. Old signatures have to stay verifiable, which is what makes rotation safe rather than a flag day: rotate by *adding* a key, not replacing one. That property was exercised with test keys in the catalog repo's `docs/key-rotation.md` before any real key existed.

Losing the private half means minting a new key, adding it here, and shipping a Fliks release that carries it — older installs would not trust the new catalog until they update.

`tsc` 0, suite 959 unchanged.
