### PR TITLE
fix(db): store every creation and update timestamp as timestamptz

### DIFF
--- a/backend/src/common/entities/base.entity.ts
+++ b/backend/src/common/entities/base.entity.ts
@@ -8,9 +8,9 @@ export abstract class BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @CreateDateColumn()
+  @CreateDateColumn({ type: 'timestamptz' })
   createdAt: Date;
 
-  @UpdateDateColumn()
+  @UpdateDateColumn({ type: 'timestamptz' })
   updatedAt: Date;
 }

--- a/backend/src/migrations/1783000000000-align-timestamp-columns-to-timestamptz.ts
+++ b/backend/src/migrations/1783000000000-align-timestamp-columns-to-timestamptz.ts
@@ -1,0 +1,79 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * `createdAt`/`updatedAt` were synchronised as `timestamp` (no zone) because
+ * `BaseEntity` never set an explicit column type; 9 hand-written tables
+ * already used `timestamptz`. This aligns the rest.
+ *
+ * `AT TIME ZONE 'UTC'` is safe because both the backend and Postgres run in
+ * UTC (no `TZ` override on either service), so every stored naive value
+ * already represents a UTC instant — the cast attaches the zone, it never
+ * shifts the clock.
+ */
+export class AlignTimestampColumnsToTimestamptz1783000000000
+  implements MigrationInterface
+{
+  name = 'AlignTimestampColumnsToTimestamptz1783000000000';
+
+  // timestamp -> timestamptz (BaseEntity tables that predate the explicit type)
+  private readonly tables = [
+    'app_settings',
+    'auto_approval_rules',
+    'blocklist',
+    'commands',
+    'custom_formats',
+    'delay_profiles',
+    'download_clients',
+    'download_history',
+    'episode_markers',
+    'episodes',
+    'indexers',
+    'language_profiles',
+    'libraries',
+    'library_user_access',
+    'media',
+    'media_cast',
+    'media_crew',
+    'media_files',
+    'media_metadata',
+    'media_servers',
+    'notification_connections',
+    'pairing_requests',
+    'persons',
+    'playback_states',
+    'plugin_packages',
+    'plugin_registrations',
+    'plugin_sources',
+    'quality_definitions',
+    'quality_profiles',
+    'recommendation_dismissals',
+    'request_comments',
+    'requests',
+    'roles',
+    'seasons',
+    'subtitle_blacklist',
+    'subtitle_files',
+    'subtitle_providers',
+    'users',
+  ];
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    for (const table of this.tables) {
+      await queryRunner.query(`
+        ALTER TABLE "${table}"
+        ALTER COLUMN "createdAt" TYPE timestamptz USING "createdAt" AT TIME ZONE 'UTC',
+        ALTER COLUMN "updatedAt" TYPE timestamptz USING "updatedAt" AT TIME ZONE 'UTC'
+      `);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    for (const table of this.tables) {
+      await queryRunner.query(`
+        ALTER TABLE "${table}"
+        ALTER COLUMN "createdAt" TYPE timestamp USING "createdAt" AT TIME ZONE 'UTC',
+        ALTER COLUMN "updatedAt" TYPE timestamp USING "updatedAt" AT TIME ZONE 'UTC'
+      `);
+    }
+  }
+}


### PR DESCRIPTION
Closes #898.

`BaseEntity` declared its two date columns with no type, so TypeORM synchronised them as `timestamp without time zone` — a wall-clock reading with no zone attached, which is ambiguous by construction for a column whose whole job is to record when something happened. Meanwhile **fourteen columns elsewhere already declare `timestamptz` explicitly**. The convention existed; it had never reached the base class that forty-seven tables inherit from.

That is what produced the drift: nine tables whose migrations were hand-written used `timestamptz`, the rest synchronised to `timestamp`, and `migration:generate` wanted to `DROP`/`ADD` eighteen columns to reconcile them. Committing its output would have destroyed the very timestamps it was offering to fix.

## Why the stronger type, not the smaller fix

Aligning the nine outliers down to `timestamp` would have been a third of the work and left the codebase declaring the weaker type forever, with every new table inheriting it.

Nothing is wrong **today**, because the server and database both run UTC. The agent measured what happens otherwise, rather than arguing it: reading the same stored value from a `timestamp` column under `Europe/Paris` returns an instant **an hour away from the truth**, while `timestamptz` returns it correctly. Fliks is self-hosted and runs where its users are, so that is a question of when, not if.

## Verification

The conversion reads existing values as UTC — correct because a UTC process wrote them, and stated in the migration as the assumption everything rests on.

- **Data safety, measured not asserted.** Seeded rows with a known instant, then checked the epoch through `migration:run` → `revert` → `run` again: `1710491400` at every step, no shift. A conversion that silently moves data by the UTC offset is the failure mode that matters here, so it is the one that got tested.
- **`down()` reverses only the 38 tables `up()` changed.** The nine that were already `timestamptz` are left alone — confirmed by querying `information_schema` after a revert, not by reading the code.
- **The check that started all this:** after the migration, `migration:generate` emits **nothing** for `createdAt`/`updatedAt` on any of the 47 tables. What remains in its output is pre-existing and unrelated — FK and index name mismatches from those same hand-written migrations, a few nullable-FK `NOT NULL` toggles, and one jsonb default literal. Worth its own cleanup eventually; it is no longer hiding a data-destroying diff.
- **Raw SQL checked** for anything that compares or formats these columns: every call site binds a JS `Date` as a parameter, none use `to_char`/`date_trunc`/`::date`, so parameter binding is type-agnostic here.
- **API shape unchanged**, verified with the `pg` driver rather than assumed: under the container's UTC both types yield identical `Date` objects and identical `JSON.stringify` output.

`tsc` 0, suite 959, final state 94 columns uniformly `timestamptz`.

One convention note: this migration keeps a `down()`, which the migrations README says is not the default here. It exists because revertability is what made the data-safety check possible.
