### PR TITLE
fix(i18n): describe plugins by what they do, not by today's features

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2256,7 +2256,7 @@
     },
     "plugins": {
       "title": "Plugins",
-      "subtitle": "Install plugins to add indexers, jobs and interface pages to Fliks.",
+      "subtitle": "Installiere Plugins, um den Funktionsumfang von Fliks zu erweitern.",
       "upload": "Install plugin…",
       "load_error": "Unable to load the plugin list.",
       "empty": "No plugin installed.",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2283,7 +2283,7 @@
     },
     "plugins": {
       "title": "Plugins",
-      "subtitle": "Install plugins to add indexers, jobs and interface pages to Fliks.",
+      "subtitle": "Install plugins to extend what Fliks can do.",
       "upload": "Install plugin…",
       "load_error": "Unable to load the plugin list.",
       "empty": "No plugin installed.",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2256,7 +2256,7 @@
     },
     "plugins": {
       "title": "Plugins",
-      "subtitle": "Install plugins to add indexers, jobs and interface pages to Fliks.",
+      "subtitle": "Instala plugins para ampliar lo que Fliks puede hacer.",
       "upload": "Install plugin…",
       "load_error": "Unable to load the plugin list.",
       "empty": "No plugin installed.",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2283,7 +2283,7 @@
     },
     "plugins": {
       "title": "Plugins",
-      "subtitle": "Installez des plugins pour ajouter des indexeurs, des tâches et des pages à Fliks.",
+      "subtitle": "Installez des plugins pour étendre les possibilités de Fliks.",
       "upload": "Installer un plugin…",
       "load_error": "Impossible de charger la liste des plugins.",
       "empty": "Aucun plugin installé.",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2256,7 +2256,7 @@
     },
     "plugins": {
       "title": "Plugins",
-      "subtitle": "Install plugins to add indexers, jobs and interface pages to Fliks.",
+      "subtitle": "Installa plugin per ampliare ciò che Fliks può fare.",
       "upload": "Install plugin…",
       "load_error": "Unable to load the plugin list.",
       "empty": "No plugin installed.",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2256,7 +2256,7 @@
     },
     "plugins": {
       "title": "Plugins",
-      "subtitle": "Install plugins to add indexers, jobs and interface pages to Fliks.",
+      "subtitle": "Instale plugins para ampliar o que o Fliks pode fazer.",
       "upload": "Install plugin…",
       "load_error": "Unable to load the plugin list.",
       "empty": "No plugin installed.",


### PR DESCRIPTION
The plugins page said *"Install plugins to add indexers, jobs and interface pages to Fliks."* — a list of three current capabilities, which dates itself as soon as a plugin does something outside the list, and reads as an enumeration rather than an extension mechanism.

Now: *"Install plugins to extend what Fliks can do."*

One line per locale, no collateral reformatting, key sets identical across all six. The four locales that were mirroring the English string are translated properly while here rather than left as English.