### PR TITLE
feat(plugins): add sources management and catalogue browsing

### DIFF
--- a/backend/src/migrations/1783100000000-seed-official-plugin-source.ts
+++ b/backend/src/migrations/1783100000000-seed-official-plugin-source.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const OFFICIAL_CATALOG_URL = 'https://fliks-app.github.io/fliks-plugin-catalog/catalog.json';
+
+/**
+ * The official catalog source, seeded once so a fresh install has something to
+ * browse without typing a URL — "N per install, the official one is just the
+ * seeded first" (`plans/plugin-system.plan.md`). No pinned key: refreshes fall
+ * back to the compiled-in `OFFICIAL_KEYS` (`release-2026`).
+ */
+export class SeedOfficialPluginSource1783100000000 implements MigrationInterface {
+  name = 'SeedOfficialPluginSource1783100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `INSERT INTO "plugin_sources" ("url", "enabled")
+       SELECT $1::varchar, true
+       WHERE NOT EXISTS (SELECT 1 FROM "plugin_sources" WHERE "url" = $1::varchar)`,
+      [OFFICIAL_CATALOG_URL],
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DELETE FROM "plugin_sources" WHERE "url" = $1`, [OFFICIAL_CATALOG_URL]);
+  }
+}

--- a/backend/src/modules/plugins/catalog/catalog.spec.ts
+++ b/backend/src/modules/plugins/catalog/catalog.spec.ts
@@ -49,6 +49,14 @@ describe('parseCatalogDocument()', () => {
     const doc = document({ versions: [version({ fliks: 'not-a-range' })] });
     expect(parseCatalogDocument(Buffer.from(JSON.stringify(doc), 'utf8'))).toBeNull();
   });
+
+  it('accepts a plugin entry with a string logo and rejects a non-string one', () => {
+    const withLogo = document({ logo: 'https://example.com/logo.png' });
+    expect(parseCatalogDocument(Buffer.from(JSON.stringify(withLogo), 'utf8'))).toEqual(withLogo);
+
+    const badLogo = document({ logo: 42 as unknown as string });
+    expect(parseCatalogDocument(Buffer.from(JSON.stringify(badLogo), 'utf8'))).toBeNull();
+  });
 });
 
 describe('filterCatalog()', () => {
@@ -108,5 +116,13 @@ describe('filterCatalog()', () => {
     const result = filterCatalog(doc, PLUGIN_API_VERSION, '2.0.1');
     expect(result.plugins[0].installable).toEqual([ok]);
     expect(result.plugins[0].hidden).toEqual({ count: 1, minFliksVersion: '5.0.0' });
+  });
+
+  it('carries an optional logo URL through unchanged, and omits it when absent', () => {
+    const withLogo = filterCatalog(document({ logo: 'https://example.com/logo.png' }), PLUGIN_API_VERSION, '2.0.1');
+    expect(withLogo.plugins[0].logo).toBe('https://example.com/logo.png');
+
+    const withoutLogo = filterCatalog(document(), PLUGIN_API_VERSION, '2.0.1');
+    expect(withoutLogo.plugins[0].logo).toBeUndefined();
   });
 });

--- a/backend/src/modules/plugins/catalog/catalog.ts
+++ b/backend/src/modules/plugins/catalog/catalog.ts
@@ -21,6 +21,8 @@ export interface CatalogPluginEntry {
   description: string;
   author: string;
   kind: PluginKind;
+  /** Absolute URL to a logo image — opaque, display-only, never fetched server-side. */
+  logo?: string;
   versions: CatalogVersionEntry[];
 }
 
@@ -52,6 +54,7 @@ function isPluginEntry(v: unknown): v is CatalogPluginEntry {
     typeof v.description === 'string' &&
     typeof v.author === 'string' &&
     (v.kind === 'data' || v.kind === 'process') &&
+    (v.logo === undefined || typeof v.logo === 'string') &&
     Array.isArray(v.versions) &&
     v.versions.length > 0 &&
     v.versions.every(isVersionEntry)
@@ -93,6 +96,7 @@ export interface FilteredCatalogEntry {
   description: string;
   author: string;
   kind: PluginKind;
+  logo?: string;
   /** Only versions installable on this core build. A caller iterating this list can
    *  never accidentally offer an incompatible version — there is no boolean to miss. */
   installable: CatalogVersionEntry[];
@@ -143,6 +147,7 @@ export function filterCatalog(document: CatalogDocument, pluginApiVersion: numbe
         description: entry.description,
         author: entry.author,
         kind: entry.kind,
+        logo: entry.logo,
         installable,
         hidden: summarizeHidden(hidden, fliksVersion),
       };

--- a/backend/src/modules/plugins/dto/create-plugin-source.dto.ts
+++ b/backend/src/modules/plugins/dto/create-plugin-source.dto.ts
@@ -1,0 +1,16 @@
+import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class CreatePluginSourceDto {
+  @IsString()
+  @IsNotEmpty()
+  url: string;
+
+  /** Base64, raw 32-byte Ed25519 — same format `keys/*.pub` uses. Omit to defer to `OFFICIAL_KEYS`. */
+  @IsOptional()
+  @IsString()
+  publicKey?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+}

--- a/backend/src/modules/plugins/dto/inspect-from-catalog.dto.ts
+++ b/backend/src/modules/plugins/dto/inspect-from-catalog.dto.ts
@@ -1,6 +1,6 @@
 import { IsNotEmpty, IsString } from 'class-validator';
 
-export class InstallFromCatalogDto {
+export class InspectFromCatalogDto {
   @IsString()
   @IsNotEmpty()
   pluginId: string;

--- a/backend/src/modules/plugins/dto/update-plugin-source.dto.ts
+++ b/backend/src/modules/plugins/dto/update-plugin-source.dto.ts
@@ -1,0 +1,17 @@
+import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class UpdatePluginSourceDto {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  url?: string;
+
+  /** `null` clears a pinned key back to `OFFICIAL_KEYS`; omit to leave it unchanged. */
+  @IsOptional()
+  @IsString()
+  publicKey?: string | null;
+
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+}

--- a/backend/src/modules/plugins/plugin-install.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-install.service.spec.ts
@@ -247,7 +247,7 @@ describe('PluginInstallService', () => {
     });
   });
 
-  describe('installFromCatalog', () => {
+  describe('inspectFromCatalog', () => {
     it('refuses before any guard runs when the fetched archive disagrees with the signed catalog checksum', async () => {
       const { buffer } = signedDataArchive({ id: 'fliks.catalog-mismatch' });
       axios.defaults.adapter = adapterFor({ 'plugin.zip': buffer });
@@ -269,13 +269,13 @@ describe('PluginInstallService', () => {
       });
 
       await expectInstallError(
-        service.installFromCatalog(source, 'fliks.catalog-mismatch', '1.0.0'),
+        service.inspectFromCatalog(source, 'fliks.catalog-mismatch', '1.0.0'),
         422,
         'PLUGIN_CHECKSUM_MISMATCH',
       );
     });
 
-    it('installs a version whose checksum matches the signed catalog entry', async () => {
+    it('stages, but does not promote, a version whose checksum matches the signed catalog entry', async () => {
       const { buffer, manifest } = signedDataArchive({ id: 'fliks.catalog-happy', version: '2.0.0' });
       const sha256 = createHash('sha256').update(buffer).digest('hex');
       axios.defaults.adapter = adapterFor({ 'plugin.zip': buffer });
@@ -290,20 +290,49 @@ describe('PluginInstallService', () => {
         ],
       });
 
-      const result = await service.installFromCatalog(source, manifest.id, manifest.version);
+      const report = await service.inspectFromCatalog(source, manifest.id, manifest.version);
 
-      expect(result).toEqual({ pluginId: manifest.id, version: manifest.version, status: 'active' });
-      expect(registry.get(manifest.id)).toBeDefined();
+      expect(report).toEqual(
+        expect.objectContaining({ installable: true, id: manifest.id, version: manifest.version, stagingId: expect.any(String), sha256 }),
+      );
+      expect(existsSync(stagedArchivePath(report.stagingId!))).toBe(true);
+      expect(registry.get(manifest.id)).toBeUndefined();
     });
 
     it('refuses an id/version that is not on the source catalog', async () => {
       const source = fakeSource({ plugins: [] });
 
       await expectInstallError(
-        service.installFromCatalog(source, 'fliks.unknown', '1.0.0'),
+        service.inspectFromCatalog(source, 'fliks.unknown', '1.0.0'),
         404,
         'PLUGIN_CATALOG_VERSION_NOT_FOUND',
       );
+    });
+
+    it('the two-step flow (inspect then confirm) promotes exactly once, recording the catalog origin', async () => {
+      const { buffer, manifest } = signedDataArchive({ id: 'fliks.catalog-two-step' });
+      const sha256 = createHash('sha256').update(buffer).digest('hex');
+      axios.defaults.adapter = adapterFor({ 'plugin.zip': buffer });
+      const source = fakeSource({
+        plugins: [
+          {
+            id: manifest.id,
+            installable: [
+              { version: manifest.version, pluginApi: PLUGIN_API_VERSION, fliks: COMPATIBLE_RANGE, zipUrl: 'https://cdn.example.com/plugin.zip', sha256 },
+            ],
+          },
+        ],
+      });
+
+      const report = await service.inspectFromCatalog(source, manifest.id, manifest.version);
+      expect(registry.get(manifest.id)).toBeUndefined();
+
+      const result = await service.confirmImport({ stagingId: report.stagingId!, sha256: report.sha256! });
+
+      expect(result).toEqual({ pluginId: manifest.id, version: manifest.version, status: 'active' });
+      expect(repo.rows.get(manifest.id)).toEqual(expect.objectContaining({ origin: 'catalog', status: 'active' }));
+      expect(registry.get(manifest.id)).toBeDefined();
+      expect(existsSync(join(stagingRoot(), report.stagingId!))).toBe(false);
     });
   });
 

--- a/backend/src/modules/plugins/plugin-install.service.ts
+++ b/backend/src/modules/plugins/plugin-install.service.ts
@@ -157,15 +157,23 @@ export class PluginInstallService {
       throw new PluginInstallException(HttpStatus.UNPROCESSABLE_ENTITY, result.code, result.detail);
     }
 
+    // Origin is recorded at stage time, not trusted from the request: a manual upload and a
+    // catalog inspect both land here, and only the staging directory itself says which one it was.
+    const origin = this.staging.originFor(dto.stagingId);
     try {
-      return await this.promote(buffer, result, 'manual');
+      return await this.promote(buffer, result, origin);
     } finally {
       this.staging.discard(dto.stagingId);
     }
   }
 
-  /** A1 (fetch) + A2 (checksum vs the signed catalog document, before any guard runs), then the same pipeline. */
-  async installFromCatalog(source: PluginSource, pluginId: string, version: string): Promise<PluginInstallResult> {
+  /**
+   * A1 (fetch) + A2 (checksum vs the signed catalog document, before any guard runs), then the
+   * same V1-V7 guards as a manual upload, then staging — never promotion. The consent sheet is
+   * the only place an *Unverified* plugin gets acknowledged, so a catalog source goes through it
+   * too: `POST /plugins/import/confirm` finishes the install, exactly like a manual upload does.
+   */
+  async inspectFromCatalog(source: PluginSource, pluginId: string, version: string): Promise<PluginInspectReport> {
     const entry = findInstallableVersion(source.cachedCatalog, pluginId, version);
     const info = entry && catalogArchiveInfo(entry);
     if (!info) {
@@ -188,11 +196,10 @@ export class PluginInstallService {
     }
 
     const result = await inspect(buffer);
-    if (!result.ok) {
-      throw new PluginInstallException(HttpStatus.UNPROCESSABLE_ENTITY, result.code, result.detail);
-    }
+    if (!result.ok) return { installable: false, refusalCode: result.code, detail: result.detail };
 
-    return this.promote(buffer, result, 'catalog');
+    const { stagingId } = this.staging.stage(buffer, 'catalog');
+    return this.buildReport(result, stagingId);
   }
 
   /** Every installed row, active or failed — the admin list reads the table directly for this reason. */

--- a/backend/src/modules/plugins/plugin-sources.controller.spec.ts
+++ b/backend/src/modules/plugins/plugin-sources.controller.spec.ts
@@ -1,6 +1,7 @@
 import { NotFoundException } from '@nestjs/common';
 import { PluginSourcesController } from './plugin-sources.controller';
 import { PluginSource } from './entities/plugin-source.entity';
+import { PluginInstallException } from './plugin-install.exception';
 
 function fakeSource(overrides: Partial<PluginSource> = {}): PluginSource {
   return {
@@ -17,7 +18,142 @@ function fakeSource(overrides: Partial<PluginSource> = {}): PluginSource {
   } as PluginSource;
 }
 
+function fakeRepo(rows: PluginSource[] = []) {
+  return {
+    find: jest.fn().mockResolvedValue(rows),
+    findOne: jest.fn(async ({ where }: { where: Partial<PluginSource> }) =>
+      rows.find((r) => Object.entries(where).every(([k, v]) => (r as never)[k] === v)) ?? null,
+    ),
+    create: jest.fn((partial: Partial<PluginSource>) => ({ id: 99, createdAt: new Date(), updatedAt: new Date(), ...partial }) as PluginSource),
+    save: jest.fn(async (row: PluginSource) => row),
+    remove: jest.fn(async (row: PluginSource) => row),
+  };
+}
+
+async function expectSourceError(promise: Promise<unknown>, status: number, code: string): Promise<void> {
+  const err = await promise.then(
+    () => {
+      throw new Error('expected the promise to reject');
+    },
+    (e: unknown) => e,
+  );
+  expect(err).toBeInstanceOf(PluginInstallException);
+  expect((err as PluginInstallException).getStatus()).toBe(status);
+  expect((err as PluginInstallException).code).toBe(code);
+}
+
 describe('PluginSourcesController', () => {
+  describe('list', () => {
+    it('reports the plugin count and the pinned-key boolean for every source', async () => {
+      const withKey = fakeSource({
+        id: 1,
+        publicKey: Buffer.alloc(32, 7),
+        cachedCatalog: { plugins: [{ id: 'a' }, { id: 'b' }] },
+      });
+      const withoutKey = fakeSource({ id: 2, publicKey: null, cachedCatalog: null });
+      const repo = fakeRepo([withKey, withoutKey]);
+      const controller = new PluginSourcesController(repo as never, {} as never, {} as never);
+
+      const list = await controller.list();
+
+      expect(list).toEqual([
+        expect.objectContaining({ id: 1, hasPinnedKey: true, pluginCount: 2 }),
+        expect.objectContaining({ id: 2, hasPinnedKey: false, pluginCount: 0 }),
+      ]);
+      expect(list[0]).not.toHaveProperty('publicKey');
+    });
+  });
+
+  describe('create', () => {
+    it('refuses a non-https url without touching the repository', async () => {
+      const repo = fakeRepo();
+      const controller = new PluginSourcesController(repo as never, {} as never, {} as never);
+
+      await expectSourceError(
+        controller.create({ url: 'http://insecure.example.com/catalog.json' }),
+        400,
+        'PLUGIN_SOURCE_INSECURE_URL',
+      );
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+
+    it('refuses a duplicate url', async () => {
+      const existing = fakeSource({ url: 'https://catalog.example.com/catalog.json' });
+      const repo = fakeRepo([existing]);
+      const controller = new PluginSourcesController(repo as never, {} as never, {} as never);
+
+      await expectSourceError(
+        controller.create({ url: 'https://catalog.example.com/catalog.json' }),
+        409,
+        'PLUGIN_SOURCE_DUPLICATE_URL',
+      );
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+
+    it('refuses a public key that does not decode to 32 bytes', async () => {
+      const repo = fakeRepo();
+      const controller = new PluginSourcesController(repo as never, {} as never, {} as never);
+
+      await expectSourceError(
+        controller.create({ url: 'https://catalog.example.com/catalog.json', publicKey: Buffer.from('too short').toString('base64') }),
+        400,
+        'PLUGIN_SOURCE_BAD_KEY',
+      );
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+
+    it('creates a source with a valid 32-byte key', async () => {
+      const repo = fakeRepo();
+      const controller = new PluginSourcesController(repo as never, {} as never, {} as never);
+      const key = Buffer.alloc(32, 1);
+
+      const result = await controller.create({ url: 'https://catalog.example.com/catalog.json', publicKey: key.toString('base64') });
+
+      expect(result).toEqual(expect.objectContaining({ hasPinnedKey: true, enabled: true }));
+      expect(repo.save).toHaveBeenCalledWith(expect.objectContaining({ publicKey: key }));
+    });
+  });
+
+  describe('update', () => {
+    it('toggles enabled without requiring the other fields', async () => {
+      const source = fakeSource({ enabled: true });
+      const repo = fakeRepo([source]);
+      const controller = new PluginSourcesController(repo as never, {} as never, {} as never);
+
+      const result = await controller.update(1, { enabled: false });
+
+      expect(result.enabled).toBe(false);
+      expect(repo.save).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
+    });
+
+    it('404s updating an unknown source', async () => {
+      const repo = fakeRepo([]);
+      const controller = new PluginSourcesController(repo as never, {} as never, {} as never);
+
+      await expect(controller.update(99, { enabled: false })).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('remove', () => {
+    it('deletes a source that has a cached catalog', async () => {
+      const source = fakeSource({ cachedCatalog: { plugins: [{ id: 'a' }] } });
+      const repo = fakeRepo([source]);
+      const controller = new PluginSourcesController(repo as never, {} as never, {} as never);
+
+      await controller.remove(1);
+
+      expect(repo.remove).toHaveBeenCalledWith(source);
+    });
+
+    it('404s deleting an unknown source', async () => {
+      const repo = fakeRepo([]);
+      const controller = new PluginSourcesController(repo as never, {} as never, {} as never);
+
+      await expect(controller.remove(99)).rejects.toThrow(NotFoundException);
+      expect(repo.remove).not.toHaveBeenCalled();
+    });
+  });
+
   it('returns the cached catalog fields for a known source', async () => {
     const source = fakeSource({ cachedCatalog: { plugins: [] }, lastRefreshError: 'boom' });
     const repo = { findOne: jest.fn().mockResolvedValue(source) };
@@ -57,26 +193,26 @@ describe('PluginSourcesController', () => {
     expect(catalogClient.refreshSource).not.toHaveBeenCalled();
   });
 
-  it('delegates a catalog install to the install service for a known source', async () => {
+  it('delegates a catalog inspect to the install service for a known source', async () => {
     const source = fakeSource();
     const repo = { findOne: jest.fn().mockResolvedValue(source) };
-    const installService = { installFromCatalog: jest.fn().mockResolvedValue({ pluginId: 'fliks.test', version: '1.0.0', status: 'active' }) };
+    const installService = { inspectFromCatalog: jest.fn().mockResolvedValue({ installable: true, stagingId: 'abc', sha256: 'def' }) };
     const controller = new PluginSourcesController(repo as never, {} as never, installService as never);
 
-    await expect(controller.install(1, { pluginId: 'fliks.test', version: '1.0.0' })).resolves.toEqual({
-      pluginId: 'fliks.test',
-      version: '1.0.0',
-      status: 'active',
+    await expect(controller.inspect(1, { pluginId: 'fliks.test', version: '1.0.0' })).resolves.toEqual({
+      installable: true,
+      stagingId: 'abc',
+      sha256: 'def',
     });
-    expect(installService.installFromCatalog).toHaveBeenCalledWith(source, 'fliks.test', '1.0.0');
+    expect(installService.inspectFromCatalog).toHaveBeenCalledWith(source, 'fliks.test', '1.0.0');
   });
 
-  it('404s a catalog install of an unknown source without touching the install service', async () => {
+  it('404s a catalog inspect of an unknown source without touching the install service', async () => {
     const repo = { findOne: jest.fn().mockResolvedValue(null) };
-    const installService = { installFromCatalog: jest.fn() };
+    const installService = { inspectFromCatalog: jest.fn() };
     const controller = new PluginSourcesController(repo as never, {} as never, installService as never);
 
-    await expect(controller.install(99, { pluginId: 'fliks.test', version: '1.0.0' })).rejects.toThrow(NotFoundException);
-    expect(installService.installFromCatalog).not.toHaveBeenCalled();
+    await expect(controller.inspect(99, { pluginId: 'fliks.test', version: '1.0.0' })).rejects.toThrow(NotFoundException);
+    expect(installService.inspectFromCatalog).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/plugins/plugin-sources.controller.ts
+++ b/backend/src/modules/plugins/plugin-sources.controller.ts
@@ -1,16 +1,57 @@
-import { Body, Controller, Get, Post, Param, ParseIntPipe, NotFoundException, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { PluginSource } from './entities/plugin-source.entity';
 import { PluginCatalogClientService, type CatalogRefreshResult } from './plugin-catalog-client.service';
-import { PluginInstallService, type PluginInstallResult } from './plugin-install.service';
-import { InstallFromCatalogDto } from './dto/install-from-catalog.dto';
+import { PluginInstallService, type PluginInspectReport } from './plugin-install.service';
+import { PluginInstallException } from './plugin-install.exception';
+import { InspectFromCatalogDto } from './dto/inspect-from-catalog.dto';
+import { CreatePluginSourceDto } from './dto/create-plugin-source.dto';
+import { UpdatePluginSourceDto } from './dto/update-plugin-source.dto';
+import type { FilteredCatalog } from './catalog/catalog';
 import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
 import { PoliciesGuard } from '../auth/casl/policies.guard';
 import { CheckPolicies } from '../auth/casl/check-policies.decorator';
 import { Action } from '../auth/casl/actions.enum';
 
-/** Manual refresh, cached-catalog read and install-from-catalog for one `plugin_sources` row. Admin-only. */
+/** One `plugin_sources` row shaped for the admin list — never the raw `publicKey` bytes. */
+export interface PluginSourceSummary {
+  id: number;
+  url: string;
+  enabled: boolean;
+  hasPinnedKey: boolean;
+  lastRefreshedAt: Date | null;
+  lastRefreshError: string | null;
+  pluginCount: number;
+}
+
+function toSummary(source: PluginSource): PluginSourceSummary {
+  const catalog = source.cachedCatalog as unknown as FilteredCatalog | null;
+  return {
+    id: source.id,
+    url: source.url,
+    enabled: source.enabled,
+    hasPinnedKey: source.publicKey !== null,
+    lastRefreshedAt: source.lastRefreshedAt,
+    lastRefreshError: source.lastRefreshError,
+    pluginCount: catalog?.plugins.length ?? 0,
+  };
+}
+
+/** CRUD for `plugin_sources`, plus manual refresh, cached-catalog read and inspect-from-catalog. Admin-only. */
 @Controller('plugins/sources')
 @UseGuards(JwtOrApiKeyGuard, PoliciesGuard)
 export class PluginSourcesController {
@@ -20,6 +61,49 @@ export class PluginSourcesController {
     private readonly catalogClient: PluginCatalogClientService,
     private readonly installService: PluginInstallService,
   ) {}
+
+  @Get()
+  @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
+  async list(): Promise<PluginSourceSummary[]> {
+    const sources = await this.sourceRepo.find({ order: { id: 'ASC' } });
+    return sources.map(toSummary);
+  }
+
+  @Post()
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
+  async create(@Body() dto: CreatePluginSourceDto): Promise<PluginSourceSummary> {
+    this.assertHttpsUrl(dto.url);
+    await this.assertUniqueUrl(dto.url);
+    const publicKey = this.parsePublicKey(dto.publicKey);
+
+    const source = this.sourceRepo.create({ url: dto.url, enabled: dto.enabled ?? true, publicKey });
+    return toSummary(await this.sourceRepo.save(source));
+  }
+
+  @Put(':id')
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
+  async update(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdatePluginSourceDto): Promise<PluginSourceSummary> {
+    const source = await this.findOrThrow(id);
+
+    if (dto.url !== undefined && dto.url !== source.url) {
+      this.assertHttpsUrl(dto.url);
+      await this.assertUniqueUrl(dto.url, id);
+      source.url = dto.url;
+    }
+    if (dto.publicKey !== undefined) source.publicKey = this.parsePublicKey(dto.publicKey);
+    if (dto.enabled !== undefined) source.enabled = dto.enabled;
+
+    return toSummary(await this.sourceRepo.save(source));
+  }
+
+  /** No FK references `plugin_sources` — a cached catalog is just a jsonb column that disappears with the row. */
+  @Delete(':id')
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
+    const source = await this.findOrThrow(id);
+    await this.sourceRepo.remove(source);
+  }
 
   @Get(':id/catalog')
   @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
@@ -43,16 +127,49 @@ export class PluginSourcesController {
     return this.catalogClient.refreshSource(source);
   }
 
-  @Post(':id/install')
+  /** Fetches + verifies + stages, same as a manual upload's `inspect`; `POST /plugins/import/confirm` promotes it. */
+  @Post(':id/inspect')
   @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
-  async install(@Param('id', ParseIntPipe) id: number, @Body() dto: InstallFromCatalogDto): Promise<PluginInstallResult> {
+  async inspect(@Param('id', ParseIntPipe) id: number, @Body() dto: InspectFromCatalogDto): Promise<PluginInspectReport> {
     const source = await this.findOrThrow(id);
-    return this.installService.installFromCatalog(source, dto.pluginId, dto.version);
+    return this.installService.inspectFromCatalog(source, dto.pluginId, dto.version);
   }
 
   private async findOrThrow(id: number): Promise<PluginSource> {
     const source = await this.sourceRepo.findOne({ where: { id } });
     if (!source) throw new NotFoundException(`Plugin source #${id} not found`);
     return source;
+  }
+
+  private assertHttpsUrl(url: string): void {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      throw new PluginInstallException(HttpStatus.BAD_REQUEST, 'PLUGIN_SOURCE_INSECURE_URL', `"${url}" is not a valid URL`);
+    }
+    if (parsed.protocol !== 'https:') {
+      throw new PluginInstallException(HttpStatus.BAD_REQUEST, 'PLUGIN_SOURCE_INSECURE_URL', `source url "${url}" must be https`);
+    }
+  }
+
+  private async assertUniqueUrl(url: string, excludeId?: number): Promise<void> {
+    const existing = await this.sourceRepo.findOne({ where: { url } });
+    if (existing && existing.id !== excludeId) {
+      throw new PluginInstallException(HttpStatus.CONFLICT, 'PLUGIN_SOURCE_DUPLICATE_URL', `a source for "${url}" already exists`);
+    }
+  }
+
+  private parsePublicKey(base64: string | null | undefined): Buffer | null {
+    if (base64 === null || base64 === undefined) return null;
+    const key = Buffer.from(base64, 'base64');
+    if (key.length !== 32) {
+      throw new PluginInstallException(
+        HttpStatus.BAD_REQUEST,
+        'PLUGIN_SOURCE_BAD_KEY',
+        `publicKey must be base64-encoded and decode to exactly 32 bytes, got ${key.length}`,
+      );
+    }
+    return key;
   }
 }

--- a/backend/src/modules/plugins/plugin-staging.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-staging.service.spec.ts
@@ -61,6 +61,18 @@ describe('PluginStagingService', () => {
     }
   });
 
+  it('defaults to a manual origin and records a catalog origin when given one', () => {
+    const manual = service.stage(Buffer.from('manual archive'));
+    const catalog = service.stage(Buffer.from('catalog archive'), 'catalog');
+
+    expect(service.originFor(manual.stagingId)).toBe('manual');
+    expect(service.originFor(catalog.stagingId)).toBe('catalog');
+  });
+
+  it('reports manual for a staging id whose directory has no recorded origin', () => {
+    expect(service.originFor('0'.repeat(32))).toBe('manual');
+  });
+
   it('discard removes a staged directory', () => {
     const { stagingId } = service.stage(Buffer.from('to be discarded'));
     service.discard(stagingId);

--- a/backend/src/modules/plugins/plugin-staging.service.ts
+++ b/backend/src/modules/plugins/plugin-staging.service.ts
@@ -5,11 +5,13 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, wri
 import { join } from 'path';
 import { getPluginsRuntimeDir } from '../../common/constants/paths';
 import { PluginInstallException } from './plugin-install.exception';
+import type { PluginPackageOrigin } from './entities/plugin-package.entity';
 
 /** `plans/plugin-system.plan.md`, "Staging disk-fill" guard. */
 export const MAX_CONCURRENT_STAGED_IMPORTS = 5;
 const STAGING_MAX_AGE_MS = 60 * 60 * 1000;
 const ARCHIVE_FILENAME = 'archive.zip';
+const ORIGIN_FILENAME = 'origin.txt';
 
 /**
  * Holds a manually-uploaded archive on disk between `inspect` and `confirm`,
@@ -29,7 +31,7 @@ export class PluginStagingService {
   }
 
   /** Idempotent on content: identical bytes reuse the existing directory and never count twice against the cap. */
-  stage(buffer: Buffer): { stagingId: string; sha256: string } {
+  stage(buffer: Buffer, origin: PluginPackageOrigin = 'manual'): { stagingId: string; sha256: string } {
     const sha256 = createHash('sha256').update(buffer).digest('hex');
     const stagingId = sha256.slice(0, 32);
     const archivePath = join(this.dirFor(stagingId), ARCHIVE_FILENAME);
@@ -45,6 +47,7 @@ export class PluginStagingService {
 
     mkdirSync(this.dirFor(stagingId), { recursive: true, mode: 0o700 });
     writeFileSync(archivePath, buffer, { mode: 0o600 });
+    writeFileSync(join(this.dirFor(stagingId), ORIGIN_FILENAME), origin, { mode: 0o600 });
     return { stagingId, sha256 };
   }
 
@@ -55,6 +58,16 @@ export class PluginStagingService {
       throw new PluginInstallException(HttpStatus.NOT_FOUND, 'PLUGIN_STAGING_NOT_FOUND', `no staged upload "${stagingId}"`);
     }
     return readFileSync(archivePath);
+  }
+
+  /** How the staged bytes arrived — recorded by `stage()`, never client-supplied. Defaults to `manual` for a directory staged before this file existed. */
+  originFor(stagingId: string): PluginPackageOrigin {
+    try {
+      const raw = readFileSync(join(this.dirFor(stagingId), ORIGIN_FILENAME), 'utf8').trim();
+      return raw === 'catalog' ? 'catalog' : 'manual';
+    } catch {
+      return 'manual';
+    }
   }
 
   discard(stagingId: string): void {

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2314,6 +2314,58 @@
           "tier_violation": "This archive's contents do not match its declared kind.",
           "unknown": "This plugin could not be installed (code {{code}})."
         }
+      },
+      "sources": {
+        "title": "Quellen",
+        "subtitle": "Fügen Sie eine Katalog-URL hinzu, um Plugins daraus zu durchsuchen und zu installieren.",
+        "manage_button": "Quellen verwalten",
+        "load_error": "Die Quellenliste konnte nicht geladen werden.",
+        "empty": "Noch keine Quellen konfiguriert.",
+        "col_url": "URL",
+        "col_key": "Schlüssel",
+        "col_plugins": "Plugins",
+        "col_last_refresh": "Letzte Aktualisierung",
+        "col_enabled": "Aktiviert",
+        "pinned_key": "Angehefteter Schlüssel",
+        "official_key": "Offizieller Schlüssel",
+        "never_refreshed": "Nie aktualisiert",
+        "refresh": "Aktualisieren",
+        "refresh_ok": "Katalog aktualisiert.",
+        "refresh_error": "Aktualisierung fehlgeschlagen: {{detail}}",
+        "delete": "Löschen",
+        "confirm_delete": "Quelle „{{url}}“ entfernen? Der zwischengespeicherte Katalog wird ebenfalls gelöscht.",
+        "deleted": "Quelle entfernt.",
+        "delete_error": "Diese Quelle konnte nicht entfernt werden.",
+        "added": "Quelle hinzugefügt.",
+        "update_error": "Diese Quelle konnte nicht aktualisiert werden.",
+        "form": {
+          "url_placeholder": "https://beispiel.com/catalog.json",
+          "key_placeholder": "Angehefteter öffentlicher Schlüssel (optional, base64)",
+          "enabled_label": "Aktiviert",
+          "add": "Quelle hinzufügen"
+        },
+        "errors": {
+          "url_https": "Die Quell-URL muss mit https:// beginnen.",
+          "url_duplicate": "Eine Quelle mit dieser URL existiert bereits.",
+          "key_invalid": "Der öffentliche Schlüssel muss base64-kodiert sein und genau 32 Bytes ergeben.",
+          "generic": "Diese Quelle konnte nicht hinzugefügt werden."
+        }
+      },
+      "catalogue": {
+        "title": "Katalog",
+        "subtitle": "Plugins, die von Ihren konfigurierten Quellen angeboten werden.",
+        "browse_button": "Plugin suchen",
+        "back": "Zurück zu den Plugins",
+        "load_error": "Der Katalog konnte nicht geladen werden.",
+        "empty_no_sources": "Keine Quellen konfiguriert — fügen Sie oben eine hinzu, um Plugins zu durchsuchen.",
+        "empty_no_catalog": "Noch kein zwischengespeicherter Katalog — aktualisieren Sie oben eine Quelle.",
+        "by": "Von {{author}}",
+        "installed": "Installiert",
+        "install": "v{{version}} installieren",
+        "no_installable": "Keine installierbare Version",
+        "hidden_versions": "{{count}} Version(en) ausgeblendet — erfordert Fliks {{version}}+",
+        "hidden_versions_no_upgrade": "{{count}} Version(en) ausgeblendet",
+        "inspect_error": "Dieses Plugin konnte nicht abgerufen werden."
       }
     }
   },

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2341,6 +2341,58 @@
           "tier_violation": "This archive's contents do not match its declared kind.",
           "unknown": "This plugin could not be installed (code {{code}})."
         }
+      },
+      "sources": {
+        "title": "Sources",
+        "subtitle": "Add a catalog URL to browse and install plugins from it.",
+        "manage_button": "Manage sources",
+        "load_error": "Unable to load the source list.",
+        "empty": "No sources configured yet.",
+        "col_url": "URL",
+        "col_key": "Key",
+        "col_plugins": "Plugins",
+        "col_last_refresh": "Last refresh",
+        "col_enabled": "Enabled",
+        "pinned_key": "Pinned key",
+        "official_key": "Official key",
+        "never_refreshed": "Never refreshed",
+        "refresh": "Refresh",
+        "refresh_ok": "Catalog refreshed.",
+        "refresh_error": "Refresh failed: {{detail}}",
+        "delete": "Delete",
+        "confirm_delete": "Remove source \"{{url}}\"? Its cached catalog is discarded too.",
+        "deleted": "Source removed.",
+        "delete_error": "Unable to remove this source.",
+        "added": "Source added.",
+        "update_error": "Unable to update this source.",
+        "form": {
+          "url_placeholder": "https://example.com/catalog.json",
+          "key_placeholder": "Pinned public key (optional, base64)",
+          "enabled_label": "Enabled",
+          "add": "Add source"
+        },
+        "errors": {
+          "url_https": "The source URL must start with https://.",
+          "url_duplicate": "A source with this URL already exists.",
+          "key_invalid": "The public key must be base64-encoded and decode to exactly 32 bytes.",
+          "generic": "Unable to add this source."
+        }
+      },
+      "catalogue": {
+        "title": "Catalogue",
+        "subtitle": "Plugins offered by your configured sources.",
+        "browse_button": "Search for a plugin",
+        "back": "Back to plugins",
+        "load_error": "Unable to load the catalogue.",
+        "empty_no_sources": "No sources configured — add one above to browse plugins.",
+        "empty_no_catalog": "No cached catalog yet — refresh a source above.",
+        "by": "By {{author}}",
+        "installed": "Installed",
+        "install": "Install v{{version}}",
+        "no_installable": "No installable version",
+        "hidden_versions": "{{count}} version(s) hidden — requires Fliks {{version}}+",
+        "hidden_versions_no_upgrade": "{{count}} version(s) hidden",
+        "inspect_error": "Unable to fetch this plugin."
       }
     }
   },

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2314,6 +2314,58 @@
           "tier_violation": "This archive's contents do not match its declared kind.",
           "unknown": "This plugin could not be installed (code {{code}})."
         }
+      },
+      "sources": {
+        "title": "Fuentes",
+        "subtitle": "Añada la URL de un catálogo para explorar e instalar plugins desde él.",
+        "manage_button": "Gestionar fuentes",
+        "load_error": "No se pudo cargar la lista de fuentes.",
+        "empty": "Aún no hay fuentes configuradas.",
+        "col_url": "URL",
+        "col_key": "Clave",
+        "col_plugins": "Plugins",
+        "col_last_refresh": "Última actualización",
+        "col_enabled": "Activada",
+        "pinned_key": "Clave fijada",
+        "official_key": "Clave oficial",
+        "never_refreshed": "Nunca actualizada",
+        "refresh": "Actualizar",
+        "refresh_ok": "Catálogo actualizado.",
+        "refresh_error": "Error al actualizar: {{detail}}",
+        "delete": "Eliminar",
+        "confirm_delete": "¿Eliminar la fuente «{{url}}»? Su catálogo en caché también se descarta.",
+        "deleted": "Fuente eliminada.",
+        "delete_error": "No se pudo eliminar esta fuente.",
+        "added": "Fuente añadida.",
+        "update_error": "No se pudo actualizar esta fuente.",
+        "form": {
+          "url_placeholder": "https://ejemplo.com/catalog.json",
+          "key_placeholder": "Clave pública fijada (opcional, base64)",
+          "enabled_label": "Activada",
+          "add": "Añadir fuente"
+        },
+        "errors": {
+          "url_https": "La URL de la fuente debe empezar por https://.",
+          "url_duplicate": "Ya existe una fuente con esta URL.",
+          "key_invalid": "La clave pública debe estar codificada en base64 y decodificarse en exactamente 32 bytes.",
+          "generic": "No se pudo añadir esta fuente."
+        }
+      },
+      "catalogue": {
+        "title": "Catálogo",
+        "subtitle": "Plugins ofrecidos por sus fuentes configuradas.",
+        "browse_button": "Buscar un plugin",
+        "back": "Volver a los plugins",
+        "load_error": "No se pudo cargar el catálogo.",
+        "empty_no_sources": "No hay fuentes configuradas — añada una arriba para explorar plugins.",
+        "empty_no_catalog": "Aún no hay catálogo en caché — actualice una fuente arriba.",
+        "by": "Por {{author}}",
+        "installed": "Instalado",
+        "install": "Instalar v{{version}}",
+        "no_installable": "Sin versión instalable",
+        "hidden_versions": "{{count}} versión(es) oculta(s) — requiere Fliks {{version}}+",
+        "hidden_versions_no_upgrade": "{{count}} versión(es) oculta(s)",
+        "inspect_error": "No se pudo obtener este plugin."
       }
     }
   },

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2341,6 +2341,58 @@
           "tier_violation": "Le contenu de cette archive ne correspond pas au niveau déclaré.",
           "unknown": "Ce plugin n'a pas pu être installé (code {{code}})."
         }
+      },
+      "sources": {
+        "title": "Sources",
+        "subtitle": "Ajoutez l'URL d'un catalogue pour parcourir et installer des plugins depuis celui-ci.",
+        "manage_button": "Gérer les sources",
+        "load_error": "Impossible de charger la liste des sources.",
+        "empty": "Aucune source configurée pour le moment.",
+        "col_url": "URL",
+        "col_key": "Clé",
+        "col_plugins": "Plugins",
+        "col_last_refresh": "Dernière actualisation",
+        "col_enabled": "Activée",
+        "pinned_key": "Clé épinglée",
+        "official_key": "Clé officielle",
+        "never_refreshed": "Jamais actualisée",
+        "refresh": "Actualiser",
+        "refresh_ok": "Catalogue actualisé.",
+        "refresh_error": "Échec de l'actualisation : {{detail}}",
+        "delete": "Supprimer",
+        "confirm_delete": "Supprimer la source « {{url}} » ? Son catalogue en cache est également supprimé.",
+        "deleted": "Source supprimée.",
+        "delete_error": "Impossible de supprimer cette source.",
+        "added": "Source ajoutée.",
+        "update_error": "Impossible de mettre à jour cette source.",
+        "form": {
+          "url_placeholder": "https://exemple.com/catalog.json",
+          "key_placeholder": "Clé publique épinglée (facultatif, base64)",
+          "enabled_label": "Activée",
+          "add": "Ajouter la source"
+        },
+        "errors": {
+          "url_https": "L'URL de la source doit commencer par https://.",
+          "url_duplicate": "Une source avec cette URL existe déjà.",
+          "key_invalid": "La clé publique doit être encodée en base64 et faire exactement 32 octets une fois décodée.",
+          "generic": "Impossible d'ajouter cette source."
+        }
+      },
+      "catalogue": {
+        "title": "Catalogue",
+        "subtitle": "Plugins proposés par vos sources configurées.",
+        "browse_button": "Rechercher un plugin",
+        "back": "Retour aux plugins",
+        "load_error": "Impossible de charger le catalogue.",
+        "empty_no_sources": "Aucune source configurée — ajoutez-en une ci-dessus pour parcourir les plugins.",
+        "empty_no_catalog": "Aucun catalogue en cache pour le moment — actualisez une source ci-dessus.",
+        "by": "Par {{author}}",
+        "installed": "Installé",
+        "install": "Installer v{{version}}",
+        "no_installable": "Aucune version installable",
+        "hidden_versions": "{{count}} version(s) masquée(s) — nécessite Fliks {{version}}+",
+        "hidden_versions_no_upgrade": "{{count}} version(s) masquée(s)",
+        "inspect_error": "Impossible de récupérer ce plugin."
       }
     }
   },

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2314,6 +2314,58 @@
           "tier_violation": "This archive's contents do not match its declared kind.",
           "unknown": "This plugin could not be installed (code {{code}})."
         }
+      },
+      "sources": {
+        "title": "Fonti",
+        "subtitle": "Aggiungi l'URL di un catalogo per sfogliare e installare plugin da esso.",
+        "manage_button": "Gestisci fonti",
+        "load_error": "Impossibile caricare l’elenco delle fonti.",
+        "empty": "Nessuna fonte configurata.",
+        "col_url": "URL",
+        "col_key": "Chiave",
+        "col_plugins": "Plugin",
+        "col_last_refresh": "Ultimo aggiornamento",
+        "col_enabled": "Attiva",
+        "pinned_key": "Chiave fissata",
+        "official_key": "Chiave ufficiale",
+        "never_refreshed": "Mai aggiornata",
+        "refresh": "Aggiorna",
+        "refresh_ok": "Catalogo aggiornato.",
+        "refresh_error": "Aggiornamento non riuscito: {{detail}}",
+        "delete": "Elimina",
+        "confirm_delete": "Rimuovere la fonte «{{url}}»? Anche il catalogo in cache viene eliminato.",
+        "deleted": "Fonte rimossa.",
+        "delete_error": "Impossibile rimuovere questa fonte.",
+        "added": "Fonte aggiunta.",
+        "update_error": "Impossibile aggiornare questa fonte.",
+        "form": {
+          "url_placeholder": "https://esempio.com/catalog.json",
+          "key_placeholder": "Chiave pubblica fissata (opzionale, base64)",
+          "enabled_label": "Attiva",
+          "add": "Aggiungi fonte"
+        },
+        "errors": {
+          "url_https": "L'URL della fonte deve iniziare con https://.",
+          "url_duplicate": "Esiste già una fonte con questo URL.",
+          "key_invalid": "La chiave pubblica deve essere codificata in base64 e decodificarsi in esattamente 32 byte.",
+          "generic": "Impossibile aggiungere questa fonte."
+        }
+      },
+      "catalogue": {
+        "title": "Catalogo",
+        "subtitle": "Plugin offerti dalle tue fonti configurate.",
+        "browse_button": "Cerca un plugin",
+        "back": "Torna ai plugin",
+        "load_error": "Impossibile caricare il catalogo.",
+        "empty_no_sources": "Nessuna fonte configurata — aggiungine una sopra per sfogliare i plugin.",
+        "empty_no_catalog": "Nessun catalogo in cache — aggiorna una fonte sopra.",
+        "by": "Di {{author}}",
+        "installed": "Installato",
+        "install": "Installa v{{version}}",
+        "no_installable": "Nessuna versione installabile",
+        "hidden_versions": "{{count}} versione/i nascosta/e — richiede Fliks {{version}}+",
+        "hidden_versions_no_upgrade": "{{count}} versione/i nascosta/e",
+        "inspect_error": "Impossibile recuperare questo plugin."
       }
     }
   },

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2314,6 +2314,58 @@
           "tier_violation": "This archive's contents do not match its declared kind.",
           "unknown": "This plugin could not be installed (code {{code}})."
         }
+      },
+      "sources": {
+        "title": "Fontes",
+        "subtitle": "Adicione o URL de um catálogo para explorar e instalar plugins a partir dele.",
+        "manage_button": "Gerir fontes",
+        "load_error": "Não foi possível carregar a lista de fontes.",
+        "empty": "Ainda não há fontes configuradas.",
+        "col_url": "URL",
+        "col_key": "Chave",
+        "col_plugins": "Plugins",
+        "col_last_refresh": "Última atualização",
+        "col_enabled": "Ativada",
+        "pinned_key": "Chave fixada",
+        "official_key": "Chave oficial",
+        "never_refreshed": "Nunca atualizada",
+        "refresh": "Atualizar",
+        "refresh_ok": "Catálogo atualizado.",
+        "refresh_error": "Falha na atualização: {{detail}}",
+        "delete": "Eliminar",
+        "confirm_delete": "Remover a fonte «{{url}}»? O catálogo em cache também é descartado.",
+        "deleted": "Fonte removida.",
+        "delete_error": "Não foi possível remover esta fonte.",
+        "added": "Fonte adicionada.",
+        "update_error": "Não foi possível atualizar esta fonte.",
+        "form": {
+          "url_placeholder": "https://exemplo.com/catalog.json",
+          "key_placeholder": "Chave pública fixada (opcional, base64)",
+          "enabled_label": "Ativada",
+          "add": "Adicionar fonte"
+        },
+        "errors": {
+          "url_https": "O URL da fonte deve começar com https://.",
+          "url_duplicate": "Já existe uma fonte com este URL.",
+          "key_invalid": "A chave pública deve estar codificada em base64 e resultar em exatamente 32 bytes.",
+          "generic": "Não foi possível adicionar esta fonte."
+        }
+      },
+      "catalogue": {
+        "title": "Catálogo",
+        "subtitle": "Plugins oferecidos pelas suas fontes configuradas.",
+        "browse_button": "Procurar um plugin",
+        "back": "Voltar aos plugins",
+        "load_error": "Não foi possível carregar o catálogo.",
+        "empty_no_sources": "Nenhuma fonte configurada — adicione uma acima para explorar plugins.",
+        "empty_no_catalog": "Ainda não há catálogo em cache — atualize uma fonte acima.",
+        "by": "Por {{author}}",
+        "installed": "Instalado",
+        "install": "Instalar v{{version}}",
+        "no_installable": "Sem versão instalável",
+        "hidden_versions": "{{count}} versão(ões) oculta(s) — requer Fliks {{version}}+",
+        "hidden_versions_no_upgrade": "{{count}} versão(ões) oculta(s)",
+        "inspect_error": "Não foi possível obter este plugin."
       }
     }
   },

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -413,6 +413,7 @@ export const routes: Routes = [
           { path: 'notifications', loadComponent: () => import('./features/settings/notifications/notifications').then((m) => m.NotificationsSettingsComponent) },
           { path: 'media-servers', loadComponent: () => import('./features/settings/media-servers/media-servers').then((m) => m.MediaServersSettingsComponent) },
           { path: 'plugins', loadComponent: () => import('./features/settings/plugins/plugins').then((m) => m.PluginsSettingsComponent) },
+          { path: 'plugin-catalogue', loadComponent: () => import('./features/settings/plugins/plugin-catalogue/plugin-catalogue-page').then((m) => m.PluginCataloguePageComponent) },
           { path: 'data-imports', loadComponent: () => import('./features/settings/data-imports/data-imports').then((m) => m.DataImportsSettingsComponent) },
           { path: 'libraries', loadComponent: () => import('./features/settings/libraries/libraries').then((m) => m.LibrariesSettingsComponent) },
           {

--- a/client/src/app/core/services/api/plugins-api.service.ts
+++ b/client/src/app/core/services/api/plugins-api.service.ts
@@ -46,6 +46,50 @@ export interface PluginInstallResult {
   detail?: string;
 }
 
+/** Mirrors backend `PluginSourceSummary` (`plugin-sources.controller.ts`) — never the raw `publicKey` bytes. */
+export interface PluginSourceRow {
+  id: number;
+  url: string;
+  enabled: boolean;
+  hasPinnedKey: boolean;
+  lastRefreshedAt: string | null;
+  lastRefreshError: string | null;
+  pluginCount: number;
+}
+
+export type CatalogRefreshResult = { ok: true } | { ok: false; reason: string; detail: string };
+
+/** Mirrors backend `CatalogVersionEntry` (`catalog/catalog.ts`) — `zipUrl`/`sha256` pass through unread. */
+export interface CatalogVersionEntry {
+  version: string;
+  pluginApi: number;
+  fliks: string;
+  [key: string]: unknown;
+}
+
+export interface CatalogHiddenSummary {
+  count: number;
+  minFliksVersion: string | null;
+}
+
+/** Mirrors backend `FilteredCatalogEntry`. */
+export interface CatalogPluginEntry {
+  id: string;
+  name: string;
+  description: string;
+  author: string;
+  kind: PluginKind;
+  logo?: string;
+  installable: CatalogVersionEntry[];
+  hidden: CatalogHiddenSummary | null;
+}
+
+export interface PluginSourceCatalog {
+  cachedCatalog: { plugins: CatalogPluginEntry[] } | null;
+  lastRefreshedAt: string | null;
+  lastRefreshError: string | null;
+}
+
 /** One tracker a `data` plugin declares, exposed under its namespaced implementation id. */
 export interface IndexerDescriptorRow {
   implementationId: string;
@@ -87,6 +131,36 @@ export class PluginsApiService {
   getIndexerDescriptors() {
     return firstValueFrom(
       this.http.get<IndexerDescriptorRow[]>('/api/plugins/indexer-descriptors'),
+    );
+  }
+
+  listSources() {
+    return firstValueFrom(this.http.get<PluginSourceRow[]>('/api/plugins/sources'));
+  }
+
+  createSource(dto: { url: string; publicKey?: string; enabled?: boolean }) {
+    return firstValueFrom(this.http.post<PluginSourceRow>('/api/plugins/sources', dto));
+  }
+
+  updateSource(id: number, dto: { url?: string; publicKey?: string | null; enabled?: boolean }) {
+    return firstValueFrom(this.http.put<PluginSourceRow>(`/api/plugins/sources/${id}`, dto));
+  }
+
+  deleteSource(id: number) {
+    return firstValueFrom(this.http.delete<void>(`/api/plugins/sources/${id}`));
+  }
+
+  refreshSource(id: number) {
+    return firstValueFrom(this.http.post<CatalogRefreshResult>(`/api/plugins/sources/${id}/refresh`, {}));
+  }
+
+  getSourceCatalog(id: number) {
+    return firstValueFrom(this.http.get<PluginSourceCatalog>(`/api/plugins/sources/${id}/catalog`));
+  }
+
+  inspectFromCatalog(sourceId: number, pluginId: string, version: string) {
+    return firstValueFrom(
+      this.http.post<PluginInspectReport>(`/api/plugins/sources/${sourceId}/inspect`, { pluginId, version }),
     );
   }
 

--- a/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue-page.html
+++ b/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue-page.html
@@ -1,0 +1,10 @@
+<div class="flex flex-col gap-6">
+  <a routerLink="/admin/settings/plugins" class="btn btn-ghost btn-sm gap-1 w-fit">
+    <svg lucideChevronLeft class="h-4 w-4"></svg>
+    {{ 'settings.plugins.catalogue.back' | translate }}
+  </a>
+
+  <app-plugin-catalogue [installedIds]="installedIds()" (install)="onInspected($event)" />
+</div>
+
+<app-plugin-install-consent #consentSheet (installed)="onInstalled($event)" />

--- a/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue-page.ts
+++ b/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue-page.ts
@@ -1,0 +1,62 @@
+import { ChangeDetectionStrategy, Component, OnInit, computed, inject, signal, viewChild } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { LucideChevronLeft } from '@lucide/angular';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { ToastService } from '../../../../core/services/toast.service';
+import {
+  PluginsApiService,
+  PluginSummary,
+  PluginInspectReport,
+  PluginInstallResult,
+} from '../../../../core/services/api/plugins-api.service';
+import { PluginInstallConsentComponent } from '../plugin-install-consent/plugin-install-consent';
+import { PluginCatalogueComponent } from './plugin-catalogue';
+
+/** Routed wrapper around the catalogue grid — owns installed-state + the consent sheet, same as the plugins page did before this moved to its own route. */
+@Component({
+  selector: 'app-plugin-catalogue-page',
+  imports: [RouterLink, LucideChevronLeft, TranslateModule, PluginInstallConsentComponent, PluginCatalogueComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './plugin-catalogue-page.html',
+})
+export class PluginCataloguePageComponent implements OnInit {
+  private readonly api = inject(PluginsApiService);
+  private readonly translate = inject(TranslateService);
+  private readonly toast = inject(ToastService);
+
+  private readonly consentSheet = viewChild<PluginInstallConsentComponent>('consentSheet');
+
+  private readonly rows = signal<PluginSummary[]>([]);
+  readonly installedIds = computed(() => new Set(this.rows().map((r) => r.pluginId)));
+
+  ngOnInit(): void {
+    this.reload();
+  }
+
+  async reload(): Promise<void> {
+    try {
+      this.rows.set(await this.api.list());
+    } catch {
+      // best-effort — only feeds the "already installed" badge here
+    }
+  }
+
+  /** From the catalogue's "Install" button — the report it staged opens the same consent sheet as a manual upload. */
+  onInspected(report: PluginInspectReport): void {
+    this.consentSheet()?.open(report);
+  }
+
+  async onInstalled(result: PluginInstallResult): Promise<void> {
+    await this.reload();
+    if (result.status === 'active') {
+      this.toast.success(this.translate.instant('settings.plugins.installed'));
+    } else {
+      this.toast.warning(
+        this.translate.instant('settings.plugins.install_failed_but_kept', {
+          id: result.pluginId,
+          reason: result.detail ?? result.reason ?? '',
+        }),
+      );
+    }
+  }
+}

--- a/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.html
+++ b/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.html
@@ -1,0 +1,64 @@
+<div class="flex flex-col gap-4">
+  <div>
+    <h2 class="text-lg font-bold">{{ 'settings.plugins.catalogue.title' | translate }}</h2>
+    <p class="text-sm text-base-content/60 mt-1">{{ 'settings.plugins.catalogue.subtitle' | translate }}</p>
+  </div>
+
+  @if (loading()) {
+    <div class="flex justify-center py-10">
+      <span class="loading loading-spinner loading-lg"></span>
+    </div>
+  } @else if (loadError()) {
+    <div role="alert" class="alert alert-error">{{ loadError() }}</div>
+  } @else if (!hasAnySource()) {
+    <p class="text-center py-8 text-base-content/50">{{ 'settings.plugins.catalogue.empty_no_sources' | translate }}</p>
+  } @else if (rows().length === 0) {
+    <p class="text-center py-8 text-base-content/50">{{ 'settings.plugins.catalogue.empty_no_catalog' | translate }}</p>
+  } @else {
+    <div class="grid gap-3 sm:grid-cols-2">
+      @for (row of rows(); track row.sourceId + ':' + row.plugin.id) {
+        <div class="border border-base-200 rounded-lg p-4 flex flex-col gap-2">
+          <div class="flex items-start gap-3">
+            @if (row.plugin.logo) {
+              <img [src]="row.plugin.logo" (error)="hideBrokenLogo($event)" alt="" class="w-10 h-10 rounded object-contain bg-base-200 shrink-0" />
+            }
+            <div class="min-w-0 flex-1">
+              <p class="font-medium truncate">{{ row.plugin.name }}</p>
+              <p class="text-xs text-base-content/50 truncate">{{ 'settings.plugins.catalogue.by' | translate: { author: row.plugin.author } }}</p>
+            </div>
+            @if (isInstalled(row.plugin.id)) {
+              <span class="badge badge-success badge-sm shrink-0">{{ 'settings.plugins.catalogue.installed' | translate }}</span>
+            }
+          </div>
+
+          <p class="text-sm text-base-content/70 line-clamp-2">{{ row.plugin.description }}</p>
+
+          <div class="flex flex-wrap items-center gap-1 text-xs text-base-content/50">
+            @for (version of row.plugin.installable; track version.version) {
+              <span class="badge badge-ghost badge-xs">v{{ version.version }}</span>
+            }
+            @if (row.plugin.hidden) {
+              <span>{{ hiddenLabel(row) }}</span>
+            }
+          </div>
+
+          <div class="mt-auto pt-2 flex items-center justify-between">
+            <span class="text-xs text-base-content/40 truncate">{{ row.sourceUrl }}</span>
+            @if (!isInstalled(row.plugin.id)) {
+              @if (row.latestVersion) {
+                <button type="button" class="btn btn-primary btn-xs shrink-0" [disabled]="isInspecting(row)" (click)="installLatest(row)">
+                  @if (isInspecting(row)) {
+                    <span class="loading loading-spinner loading-xs"></span>
+                  }
+                  {{ 'settings.plugins.catalogue.install' | translate: { version: row.latestVersion } }}
+                </button>
+              } @else {
+                <span class="text-xs text-base-content/40 shrink-0">{{ 'settings.plugins.catalogue.no_installable' | translate }}</span>
+              }
+            }
+          </div>
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.ts
+++ b/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.ts
@@ -1,0 +1,103 @@
+import { ChangeDetectionStrategy, Component, OnInit, inject, input, output, signal } from '@angular/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { ToastService } from '../../../../core/services/toast.service';
+import { CatalogPluginEntry, PluginInspectReport, PluginsApiService } from '../../../../core/services/api/plugins-api.service';
+
+interface CatalogueRow {
+  sourceId: number;
+  sourceUrl: string;
+  plugin: CatalogPluginEntry;
+  /** ponytail: last entry of `installable`, not a semver max — catalogs are expected to list
+   *  versions oldest-to-newest; revisit with a real semver sort if a catalog ever violates that. */
+  latestVersion: string | null;
+}
+
+/** What every cached catalog offers, merged across sources (`plans/plugin-system.plan.md`, "Catalogue browsing"). */
+@Component({
+  selector: 'app-plugin-catalogue',
+  imports: [TranslateModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './plugin-catalogue.html',
+})
+export class PluginCatalogueComponent implements OnInit {
+  private readonly api = inject(PluginsApiService);
+  private readonly translate = inject(TranslateService);
+  private readonly toast = inject(ToastService);
+
+  readonly installedIds = input<ReadonlySet<string>>(new Set());
+
+  /** A version was inspected and staged; the parent owns the consent sheet and opens it with this report. */
+  readonly install = output<PluginInspectReport>();
+
+  readonly rows = signal<CatalogueRow[]>([]);
+  readonly hasAnySource = signal(true);
+  readonly loading = signal(true);
+  readonly loadError = signal('');
+  readonly inspectingKey = signal<string | null>(null);
+
+  ngOnInit(): void {
+    this.reload();
+  }
+
+  async reload(): Promise<void> {
+    this.loading.set(true);
+    this.loadError.set('');
+    try {
+      const sources = await this.api.listSources();
+      this.hasAnySource.set(sources.length > 0);
+
+      const catalogs = await Promise.all(sources.map((s) => this.api.getSourceCatalog(s.id).catch(() => null)));
+      const rows: CatalogueRow[] = [];
+      sources.forEach((source, i) => {
+        for (const plugin of catalogs[i]?.cachedCatalog?.plugins ?? []) {
+          rows.push({
+            sourceId: source.id,
+            sourceUrl: source.url,
+            plugin,
+            latestVersion: plugin.installable.at(-1)?.version ?? null,
+          });
+        }
+      });
+      this.rows.set(rows);
+    } catch {
+      this.loadError.set(this.translate.instant('settings.plugins.catalogue.load_error'));
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  isInstalled(pluginId: string): boolean {
+    return this.installedIds().has(pluginId);
+  }
+
+  hideBrokenLogo(event: Event): void {
+    (event.target as HTMLImageElement).style.display = 'none';
+  }
+
+  hiddenLabel(row: CatalogueRow): string {
+    const hidden = row.plugin.hidden;
+    if (!hidden) return '';
+    return hidden.minFliksVersion
+      ? this.translate.instant('settings.plugins.catalogue.hidden_versions', { count: hidden.count, version: hidden.minFliksVersion })
+      : this.translate.instant('settings.plugins.catalogue.hidden_versions_no_upgrade', { count: hidden.count });
+  }
+
+  async installLatest(row: CatalogueRow): Promise<void> {
+    if (!row.latestVersion) return;
+    const key = `${row.sourceId}:${row.plugin.id}:${row.latestVersion}`;
+    this.inspectingKey.set(key);
+    try {
+      const report = await this.api.inspectFromCatalog(row.sourceId, row.plugin.id, row.latestVersion);
+      this.install.emit(report);
+    } catch (err: unknown) {
+      const httpErr = err as { error?: { message?: string } };
+      this.toast.error(httpErr.error?.message ?? this.translate.instant('settings.plugins.catalogue.inspect_error'));
+    } finally {
+      this.inspectingKey.set(null);
+    }
+  }
+
+  isInspecting(row: CatalogueRow): boolean {
+    return this.inspectingKey() === `${row.sourceId}:${row.plugin.id}:${row.latestVersion}`;
+  }
+}

--- a/client/src/app/features/settings/plugins/plugin-sources/plugin-sources.html
+++ b/client/src/app/features/settings/plugins/plugin-sources/plugin-sources.html
@@ -1,0 +1,141 @@
+<dialog #dialog class="modal">
+  <div class="modal-box max-w-3xl max-h-[92vh] flex flex-col p-0 gap-0 overflow-hidden">
+    <div class="px-5 sm:px-6 pt-4 pb-3 border-b border-base-200 flex justify-between items-center shrink-0 bg-base-100">
+      <div>
+        <h2 class="text-lg font-bold">{{ 'settings.plugins.sources.title' | translate }}</h2>
+        <p class="text-sm text-base-content/60 mt-1">{{ 'settings.plugins.sources.subtitle' | translate }}</p>
+      </div>
+      <button
+        type="button"
+        class="btn btn-sm btn-ghost btn-circle"
+        (click)="close()"
+        [attr.aria-label]="'common.close' | translate"
+      >
+        <svg lucideX class="h-5 w-5"></svg>
+      </button>
+    </div>
+
+    <div class="px-5 sm:px-6 py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 bg-base-100">
+  @if (loading()) {
+    <div class="flex justify-center py-10">
+      <span class="loading loading-spinner loading-lg"></span>
+    </div>
+  } @else if (listError()) {
+    <div role="alert" class="alert alert-error">{{ listError() }}</div>
+  } @else {
+    @if (sources().length === 0) {
+      <p class="text-center py-8 text-base-content/50">{{ 'settings.plugins.sources.empty' | translate }}</p>
+    } @else {
+      <div class="overflow-x-auto rounded-lg border border-base-200">
+        <table class="table table-zebra table-sm">
+          <thead>
+            <tr>
+              <th>{{ 'settings.plugins.sources.col_url' | translate }}</th>
+              <th>{{ 'settings.plugins.sources.col_key' | translate }}</th>
+              <th>{{ 'settings.plugins.sources.col_plugins' | translate }}</th>
+              <th>{{ 'settings.plugins.sources.col_last_refresh' | translate }}</th>
+              <th>{{ 'settings.plugins.sources.col_enabled' | translate }}</th>
+              <th class="text-end w-40"></th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (source of sources(); track source.id) {
+              <tr>
+                <td class="max-w-[20rem] truncate text-sm" [title]="source.url">{{ source.url }}</td>
+                <td>
+                  @if (source.hasPinnedKey) {
+                    <span class="badge badge-ghost badge-sm">{{ 'settings.plugins.sources.pinned_key' | translate }}</span>
+                  } @else {
+                    <span class="badge badge-ghost badge-sm">{{ 'settings.plugins.sources.official_key' | translate }}</span>
+                  }
+                </td>
+                <td class="text-sm">{{ source.pluginCount }}</td>
+                <td class="text-sm">
+                  @if (source.lastRefreshedAt) {
+                    {{ source.lastRefreshedAt | date: 'short' }}
+                  } @else {
+                    <span class="text-base-content/50">{{ 'settings.plugins.sources.never_refreshed' | translate }}</span>
+                  }
+                  @if (source.lastRefreshError) {
+                    <p class="text-xs text-error/80 mt-1 max-w-[14rem]">{{ source.lastRefreshError }}</p>
+                  }
+                </td>
+                <td>
+                  <input
+                    type="checkbox"
+                    class="toggle toggle-sm"
+                    [ngModel]="source.enabled"
+                    [disabled]="savingId() === source.id"
+                    (ngModelChange)="toggleEnabled(source)"
+                  />
+                </td>
+                <td class="text-end whitespace-nowrap">
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-xs"
+                    [disabled]="refreshingId() === source.id"
+                    (click)="refresh(source)"
+                  >
+                    @if (refreshingId() === source.id) {
+                      <span class="loading loading-spinner loading-xs"></span>
+                    }
+                    {{ 'settings.plugins.sources.refresh' | translate }}
+                  </button>
+                  <button type="button" class="btn btn-ghost btn-xs text-error" (click)="remove(source)">
+                    {{ 'settings.plugins.sources.delete' | translate }}
+                  </button>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  }
+
+  <form class="flex flex-col sm:flex-row gap-2 sm:items-start pt-2" (ngSubmit)="submitCreate()">
+    <input
+      type="url"
+      required
+      class="input input-sm input-bordered flex-1"
+      [placeholder]="'settings.plugins.sources.form.url_placeholder' | translate"
+      [ngModel]="formUrl()"
+      (ngModelChange)="formUrl.set($event)"
+      name="sourceUrl"
+    />
+    <input
+      type="text"
+      class="input input-sm input-bordered flex-1"
+      [placeholder]="'settings.plugins.sources.form.key_placeholder' | translate"
+      [ngModel]="formPublicKey()"
+      (ngModelChange)="formPublicKey.set($event)"
+      name="sourceKey"
+    />
+    <label class="label cursor-pointer gap-2 shrink-0">
+      <input
+        type="checkbox"
+        class="toggle toggle-sm"
+        [ngModel]="formEnabled()"
+        (ngModelChange)="formEnabled.set($event)"
+        name="sourceEnabled"
+      />
+      <span class="label-text text-sm">{{ 'settings.plugins.sources.form.enabled_label' | translate }}</span>
+    </label>
+    <button type="submit" class="btn btn-sm btn-primary shrink-0" [disabled]="creating() || !formUrl().trim()">
+      @if (creating()) {
+        <span class="loading loading-spinner loading-xs"></span>
+      }
+      {{ 'settings.plugins.sources.form.add' | translate }}
+    </button>
+  </form>
+  @if (createError()) {
+    <div role="alert" class="alert alert-error text-sm py-2">{{ createError() }}</div>
+  }
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="button" (click)="close()" [attr.aria-label]="'common.close' | translate">
+      {{ 'common.close' | translate }}
+    </button>
+  </form>
+</dialog>

--- a/client/src/app/features/settings/plugins/plugin-sources/plugin-sources.ts
+++ b/client/src/app/features/settings/plugins/plugin-sources/plugin-sources.ts
@@ -1,0 +1,157 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  OnInit,
+  inject,
+  output,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { LucideX } from '@lucide/angular';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { ConfirmationService } from '../../../../core/services/confirmation.service';
+import { ToastService } from '../../../../core/services/toast.service';
+import { PluginsApiService, PluginSourceRow } from '../../../../core/services/api/plugins-api.service';
+
+/** One `code` per backend refusal (`plugin-sources.controller.ts`) — never the raw `detail`, which is not translated. */
+function createErrorKey(code: string | undefined): string {
+  switch (code) {
+    case 'PLUGIN_SOURCE_INSECURE_URL':
+      return 'settings.plugins.sources.errors.url_https';
+    case 'PLUGIN_SOURCE_DUPLICATE_URL':
+      return 'settings.plugins.sources.errors.url_duplicate';
+    case 'PLUGIN_SOURCE_BAD_KEY':
+      return 'settings.plugins.sources.errors.key_invalid';
+    default:
+      return 'settings.plugins.sources.errors.generic';
+  }
+}
+
+/** Sources list + add form (`plans/plugin-system.plan.md`, "N per install, the official one is just the seeded first"). */
+@Component({
+  selector: 'app-plugin-sources',
+  imports: [FormsModule, DatePipe, LucideX, TranslateModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './plugin-sources.html',
+})
+export class PluginSourcesComponent implements OnInit {
+  private readonly api = inject(PluginsApiService);
+  private readonly translate = inject(TranslateService);
+  private readonly toast = inject(ToastService);
+  private readonly confirmation = inject(ConfirmationService);
+
+  private readonly dialogRef = viewChild.required<ElementRef<HTMLDialogElement>>('dialog');
+
+  readonly sources = signal<PluginSourceRow[]>([]);
+  readonly loading = signal(true);
+  readonly listError = signal('');
+  readonly refreshingId = signal<number | null>(null);
+  readonly savingId = signal<number | null>(null);
+
+  readonly formUrl = signal('');
+  readonly formPublicKey = signal('');
+  readonly formEnabled = signal(true);
+  readonly creating = signal(false);
+  readonly createError = signal('');
+
+  /** A source was added, removed or refreshed — the catalogue view needs to reload too. */
+  readonly changed = output<void>();
+
+  ngOnInit(): void {
+    this.reload();
+  }
+
+  open(): void {
+    this.dialogRef().nativeElement.showModal();
+  }
+
+  close(): void {
+    this.dialogRef().nativeElement.close();
+  }
+
+  async reload(): Promise<void> {
+    this.loading.set(true);
+    this.listError.set('');
+    try {
+      this.sources.set(await this.api.listSources());
+    } catch {
+      this.listError.set(this.translate.instant('settings.plugins.sources.load_error'));
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async submitCreate(): Promise<void> {
+    const url = this.formUrl().trim();
+    if (!url || this.creating()) return;
+
+    this.creating.set(true);
+    this.createError.set('');
+    try {
+      const publicKey = this.formPublicKey().trim() || undefined;
+      await this.api.createSource({ url, publicKey, enabled: this.formEnabled() });
+      this.formUrl.set('');
+      this.formPublicKey.set('');
+      this.formEnabled.set(true);
+      await this.reload();
+      this.toast.success(this.translate.instant('settings.plugins.sources.added'));
+      this.changed.emit();
+    } catch (err: unknown) {
+      const httpErr = err as { error?: { code?: string } };
+      this.createError.set(this.translate.instant(createErrorKey(httpErr.error?.code)));
+    } finally {
+      this.creating.set(false);
+    }
+  }
+
+  async toggleEnabled(row: PluginSourceRow): Promise<void> {
+    this.savingId.set(row.id);
+    try {
+      await this.api.updateSource(row.id, { enabled: !row.enabled });
+      await this.reload();
+    } catch {
+      this.toast.error(this.translate.instant('settings.plugins.sources.update_error'));
+    } finally {
+      this.savingId.set(null);
+    }
+  }
+
+  async refresh(row: PluginSourceRow): Promise<void> {
+    this.refreshingId.set(row.id);
+    try {
+      const result = await this.api.refreshSource(row.id);
+      if (result.ok) {
+        this.toast.success(this.translate.instant('settings.plugins.sources.refresh_ok'));
+      } else {
+        this.toast.error(this.translate.instant('settings.plugins.sources.refresh_error', { detail: result.detail }));
+      }
+      await this.reload();
+      this.changed.emit();
+    } catch {
+      this.toast.error(this.translate.instant('settings.plugins.sources.refresh_error', { detail: '' }));
+    } finally {
+      this.refreshingId.set(null);
+    }
+  }
+
+  async remove(row: PluginSourceRow): Promise<void> {
+    const confirmed = await this.confirmation.confirm({
+      title: this.translate.instant('common.confirm'),
+      message: this.translate.instant('settings.plugins.sources.confirm_delete', { url: row.url }),
+      variant: 'danger',
+    });
+    if (!confirmed) return;
+
+    try {
+      await this.api.deleteSource(row.id);
+      await this.reload();
+      this.toast.success(this.translate.instant('settings.plugins.sources.deleted'));
+      this.changed.emit();
+    } catch {
+      this.toast.error(this.translate.instant('settings.plugins.sources.delete_error'));
+    }
+  }
+}

--- a/client/src/app/features/settings/plugins/plugins.html
+++ b/client/src/app/features/settings/plugins/plugins.html
@@ -4,13 +4,31 @@
       <h1 class="text-2xl font-bold">{{ 'settings.plugins.title' | translate }}</h1>
       <p class="text-sm text-base-content/60 mt-1">{{ 'settings.plugins.subtitle' | translate }}</p>
     </div>
-    <button type="button" class="btn btn-primary self-start sm:self-auto" [disabled]="uploading()" (click)="pickFile()">
-      @if (uploading()) {
-        <span class="loading loading-spinner loading-sm"></span>
-      }
-      {{ 'settings.plugins.upload' | translate }}
-    </button>
-    <input #fileInput type="file" accept=".zip" class="hidden" (change)="onFilePicked($event)" />
+    <div class="flex items-center gap-2 self-start sm:self-auto">
+      <a routerLink="/admin/settings/plugin-catalogue" class="btn btn-primary">
+        {{ 'settings.plugins.catalogue.browse_button' | translate }}
+      </a>
+      <app-dropdown-menu placement="bottom-end">
+        <button
+          trigger
+          type="button"
+          class="btn btn-ghost btn-circle"
+          [attr.aria-label]="'common.more' | translate"
+        >
+          <svg lucideEllipsisVertical class="h-5 w-5"></svg>
+        </button>
+        <button type="button" class="dropdown-item text-white" (click)="openSources()">
+          {{ 'settings.plugins.sources.manage_button' | translate }}
+        </button>
+        <button type="button" class="dropdown-item text-white" [disabled]="uploading()" (click)="pickFile()">
+          @if (uploading()) {
+            <span class="loading loading-spinner loading-xs"></span>
+          }
+          {{ 'settings.plugins.upload' | translate }}
+        </button>
+      </app-dropdown-menu>
+    </div>
+    <input #fileInput type="file" accept=".fkplugin,.zip" class="hidden" (change)="onFilePicked($event)" />
   </div>
 
   @if (loading()) {
@@ -80,6 +98,8 @@
       </table>
     </div>
   }
+
+  <app-plugin-sources #sourcesDialog />
 </div>
 
 <app-plugin-install-consent #consentSheet (installed)="onInstalled($event)" />

--- a/client/src/app/features/settings/plugins/plugins.ts
+++ b/client/src/app/features/settings/plugins/plugins.ts
@@ -7,9 +7,12 @@ import {
   signal,
   viewChild,
 } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { LucideEllipsisVertical } from '@lucide/angular';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { ToastService } from '../../../core/services/toast.service';
+import { DropdownMenuComponent } from '../../../shared/components/dropdown-menu';
 import {
   PluginsApiService,
   PluginSummary,
@@ -17,11 +20,12 @@ import {
   PluginInstallResult,
 } from '../../../core/services/api/plugins-api.service';
 import { PluginInstallConsentComponent } from './plugin-install-consent/plugin-install-consent';
+import { PluginSourcesComponent } from './plugin-sources/plugin-sources';
 import { trustBadgeFor } from './plugin-trust';
 
 @Component({
   selector: 'app-plugins-settings',
-  imports: [TranslateModule, PluginInstallConsentComponent],
+  imports: [RouterLink, LucideEllipsisVertical, TranslateModule, DropdownMenuComponent, PluginInstallConsentComponent, PluginSourcesComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './plugins.html',
 })
@@ -33,6 +37,7 @@ export class PluginsSettingsComponent implements OnInit {
 
   private readonly fileInput = viewChild<ElementRef<HTMLInputElement>>('fileInput');
   private readonly consentSheet = viewChild<PluginInstallConsentComponent>('consentSheet');
+  private readonly sourcesDialog = viewChild<PluginSourcesComponent>('sourcesDialog');
 
   readonly rows = signal<PluginSummary[]>([]);
   readonly loading = signal(true);
@@ -87,6 +92,10 @@ export class PluginsSettingsComponent implements OnInit {
     } finally {
       this.uploading.set(false);
     }
+  }
+
+  openSources(): void {
+    this.sourcesDialog()?.open();
   }
 
   async onInstalled(result: PluginInstallResult): Promise<void> {


### PR DESCRIPTION
The plugins page could upload a `.fkplugin` by hand and nothing else. The backend has been able to fetch, verify and cache a signed catalogue since #904 and install from one since #905, and none of it was reachable — a user opening the page found an upload button and no plugin anywhere. That is what happened when the maintainer opened it.

**Sources** get full CRUD, refusing a non-https URL, a duplicate, and a public key that does not decode to 32 bytes, each with its own error rather than a generic failure. The list reports whether a key is pinned as a boolean rather than handing back the raw bytes. **A migration seeds the official source**, because the plan describes sources as "N per install, the official one is just the seeded first" and a fresh install currently discovers nothing without someone typing a URL.

**Catalogue browsing** is its own page, reached from a *Rechercher un plugin* button, showing what every cached catalogue offers with the *"N versions hidden"* line the backend already computes — including the case where no upgrade would help, where it deliberately offers no version number. Already-installed plugins are marked rather than offered again.

## The one-shot install is gone, on purpose

`POST /plugins/sources/:id/install` fetched, verified and promoted in a single call **with no consent step**. The plan is explicit that both delivery routes share the artifact, the pipeline *and* the consent sheet — and the sheet is where an *Unverified* plugin gets acknowledged, which matters most for a third-party source. Anyone with Manage Settings could have skipped it.

It is replaced by an inspect-from-catalogue call that stages, after checking the archive's sha256 against the value inside the **signed** catalogue before any guard runs. The **existing** confirm endpoint finishes it, so there is exactly one promotion path. The staged origin is read from disk rather than from the client, so a catalogue install keeps `origin: catalog` through the shared endpoint instead of drifting to `manual`.

## Layout, after review

The first pass put sources and catalogue as inline sections. The maintainer looked at it and asked for something else, so: *Rechercher un plugin* is the primary button, and **Gérer les sources** and **Installer depuis un ZIP** sit in a dropdown — matched to the shared `app-dropdown-menu` the rest of the admin area uses, not hand-rolled DaisyUI markup. Sources became a modal. The catalogue page is a lazy chunk, so the initial bundle is unchanged at 195 kB.

**One real bug found by using it:** the file input was `accept=".zip"` while plugin archives are named `.fkplugin`, so the file picker hid the very file a user just downloaded. It predates this PR. Now `accept=".fkplugin,.zip"`.

## Verified

backend `tsc` 0 and **988 tests**; client `tsc` 0, production build clean, 102 tests; 52 i18n keys across all six locales, hand-translated rather than mirrored.

Migration run up → down → up on a throwaway database, idempotency re-checked by dropping its row and re-running, and `migration:generate` emits nothing for `plugin_sources` — the check that has caught two real bugs in this project.

**Note for local stacks:** dev runs `synchronize: true` and never replays the migration chain, so the seeded source does not appear there. Insert it by hand or install from the catalogue after adding it through the new UI.
