### PR TITLE
fix(i18n): name the manual install action for what it does

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2261,7 +2261,7 @@
     "plugins": {
       "title": "Plugins",
       "subtitle": "Installiere Plugins, um den Funktionsumfang von Fliks zu erweitern.",
-      "upload": "Install plugin…",
+      "upload": "Aus einer Zip-Datei installieren…",
       "load_error": "Unable to load the plugin list.",
       "empty": "No plugin installed.",
       "col_plugin": "Plugin",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2288,7 +2288,7 @@
     "plugins": {
       "title": "Plugins",
       "subtitle": "Install plugins to extend what Fliks can do.",
-      "upload": "Install plugin…",
+      "upload": "Install from a zip…",
       "load_error": "Unable to load the plugin list.",
       "empty": "No plugin installed.",
       "col_plugin": "Plugin",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2261,7 +2261,7 @@
     "plugins": {
       "title": "Plugins",
       "subtitle": "Instala plugins para ampliar lo que Fliks puede hacer.",
-      "upload": "Install plugin…",
+      "upload": "Instalar desde un zip…",
       "load_error": "Unable to load the plugin list.",
       "empty": "No plugin installed.",
       "col_plugin": "Plugin",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2288,7 +2288,7 @@
     "plugins": {
       "title": "Plugins",
       "subtitle": "Installez des plugins pour étendre les possibilités de Fliks.",
-      "upload": "Installer un plugin…",
+      "upload": "Installer depuis un zip…",
       "load_error": "Impossible de charger la liste des plugins.",
       "empty": "Aucun plugin installé.",
       "col_plugin": "Plugin",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2261,7 +2261,7 @@
     "plugins": {
       "title": "Plugins",
       "subtitle": "Installa plugin per ampliare ciò che Fliks può fare.",
-      "upload": "Install plugin…",
+      "upload": "Installa da uno zip…",
       "load_error": "Unable to load the plugin list.",
       "empty": "No plugin installed.",
       "col_plugin": "Plugin",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2261,7 +2261,7 @@
     "plugins": {
       "title": "Plugins",
       "subtitle": "Instale plugins para ampliar o que o Fliks pode fazer.",
-      "upload": "Install plugin…",
+      "upload": "Instalar a partir de um zip…",
       "load_error": "Unable to load the plugin list.",
       "empty": "No plugin installed.",
       "col_plugin": "Plugin",


### PR DESCRIPTION
The dropdown item read *"Installer un plugin…"* directly beside a primary button reading *"Rechercher un plugin"* — two vague verbs, and nothing telling a user which one takes the file they already downloaded. It now reads *"Installer depuis un zip…"*.

Four locales were still carrying the English string for this key, so they are translated properly rather than left mirrored.

One line changed per file, no collateral reformatting, key sets unchanged. Client `tsc` 0.