### PR TITLE
fix(i18n): call the manual path importing a plugin, not a zip

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2261,7 +2261,7 @@
     "plugins": {
       "title": "Plugins",
       "subtitle": "Installiere Plugins, um den Funktionsumfang von Fliks zu erweitern.",
-      "upload": "Aus einer Zip-Datei installieren",
+      "upload": "Plugin importieren",
       "load_error": "Unable to load the plugin list.",
       "empty": "No plugin installed.",
       "col_plugin": "Plugin",

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2261,7 +2261,7 @@
     "plugins": {
       "title": "Plugins",
       "subtitle": "Installiere Plugins, um den Funktionsumfang von Fliks zu erweitern.",
-      "upload": "Aus einer Zip-Datei installieren…",
+      "upload": "Aus einer Zip-Datei installieren",
       "load_error": "Unable to load the plugin list.",
       "empty": "No plugin installed.",
       "col_plugin": "Plugin",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2288,7 +2288,7 @@
     "plugins": {
       "title": "Plugins",
       "subtitle": "Install plugins to extend what Fliks can do.",
-      "upload": "Install from a zip…",
+      "upload": "Install from a zip",
       "load_error": "Unable to load the plugin list.",
       "empty": "No plugin installed.",
       "col_plugin": "Plugin",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2288,7 +2288,7 @@
     "plugins": {
       "title": "Plugins",
       "subtitle": "Install plugins to extend what Fliks can do.",
-      "upload": "Install from a zip",
+      "upload": "Import a plugin",
       "load_error": "Unable to load the plugin list.",
       "empty": "No plugin installed.",
       "col_plugin": "Plugin",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2261,7 +2261,7 @@
     "plugins": {
       "title": "Plugins",
       "subtitle": "Instala plugins para ampliar lo que Fliks puede hacer.",
-      "upload": "Instalar desde un zip…",
+      "upload": "Instalar desde un zip",
       "load_error": "Unable to load the plugin list.",
       "empty": "No plugin installed.",
       "col_plugin": "Plugin",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2261,7 +2261,7 @@
     "plugins": {
       "title": "Plugins",
       "subtitle": "Instala plugins para ampliar lo que Fliks puede hacer.",
-      "upload": "Instalar desde un zip",
+      "upload": "Importar un plugin",
       "load_error": "Unable to load the plugin list.",
       "empty": "No plugin installed.",
       "col_plugin": "Plugin",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2288,7 +2288,7 @@
     "plugins": {
       "title": "Plugins",
       "subtitle": "Installez des plugins pour étendre les possibilités de Fliks.",
-      "upload": "Installer depuis un zip",
+      "upload": "Importer un plugin",
       "load_error": "Impossible de charger la liste des plugins.",
       "empty": "Aucun plugin installé.",
       "col_plugin": "Plugin",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2288,7 +2288,7 @@
     "plugins": {
       "title": "Plugins",
       "subtitle": "Installez des plugins pour étendre les possibilités de Fliks.",
-      "upload": "Installer depuis un zip…",
+      "upload": "Installer depuis un zip",
       "load_error": "Impossible de charger la liste des plugins.",
       "empty": "Aucun plugin installé.",
       "col_plugin": "Plugin",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2261,7 +2261,7 @@
     "plugins": {
       "title": "Plugins",
       "subtitle": "Installa plugin per ampliare ciò che Fliks può fare.",
-      "upload": "Installa da uno zip",
+      "upload": "Importa un plugin",
       "load_error": "Unable to load the plugin list.",
       "empty": "No plugin installed.",
       "col_plugin": "Plugin",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2261,7 +2261,7 @@
     "plugins": {
       "title": "Plugins",
       "subtitle": "Installa plugin per ampliare ciò che Fliks può fare.",
-      "upload": "Installa da uno zip…",
+      "upload": "Installa da uno zip",
       "load_error": "Unable to load the plugin list.",
       "empty": "No plugin installed.",
       "col_plugin": "Plugin",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2261,7 +2261,7 @@
     "plugins": {
       "title": "Plugins",
       "subtitle": "Instale plugins para ampliar o que o Fliks pode fazer.",
-      "upload": "Instalar a partir de um zip…",
+      "upload": "Instalar a partir de um zip",
       "load_error": "Unable to load the plugin list.",
       "empty": "No plugin installed.",
       "col_plugin": "Plugin",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2261,7 +2261,7 @@
     "plugins": {
       "title": "Plugins",
       "subtitle": "Instale plugins para ampliar o que o Fliks pode fazer.",
-      "upload": "Instalar a partir de um zip",
+      "upload": "Importar um plugin",
       "load_error": "Unable to load the plugin list.",
       "empty": "No plugin installed.",
       "col_plugin": "Plugin",

--- a/client/src/app/features/settings/plugins/plugin-sources/plugin-sources.html
+++ b/client/src/app/features/settings/plugins/plugin-sources/plugin-sources.html
@@ -44,9 +44,9 @@
                 <td class="max-w-[20rem] truncate text-sm" [title]="source.url">{{ source.url }}</td>
                 <td>
                   @if (source.hasPinnedKey) {
-                    <span class="badge badge-ghost badge-sm">{{ 'settings.plugins.sources.pinned_key' | translate }}</span>
+                    <span class="badge badge-ghost badge-sm whitespace-nowrap">{{ 'settings.plugins.sources.pinned_key' | translate }}</span>
                   } @else {
-                    <span class="badge badge-ghost badge-sm">{{ 'settings.plugins.sources.official_key' | translate }}</span>
+                    <span class="badge badge-ghost badge-sm whitespace-nowrap">{{ 'settings.plugins.sources.official_key' | translate }}</span>
                   }
                 </td>
                 <td class="text-sm">{{ source.pluginCount }}</td>

--- a/client/src/app/features/settings/plugins/plugin-sources/plugin-sources.html
+++ b/client/src/app/features/settings/plugins/plugin-sources/plugin-sources.html
@@ -1,5 +1,5 @@
 <dialog #dialog class="modal">
-  <div class="modal-box max-w-3xl max-h-[92vh] flex flex-col p-0 gap-0 overflow-hidden">
+  <div class="modal-box max-w-5xl max-h-[92vh] flex flex-col p-0 gap-0 overflow-hidden">
     <div class="px-5 sm:px-6 pt-4 pb-3 border-b border-base-200 flex justify-between items-center shrink-0 bg-base-100">
       <div>
         <h2 class="text-lg font-bold">{{ 'settings.plugins.sources.title' | translate }}</h2>


### PR DESCRIPTION
Removes the trailing ellipsis from the manual-install dropdown item in all six locales. It was the only label in the plugins section carrying one.