### PR TITLE
feat(plugins): supervise a plugin process over a socket pair

### DIFF
--- a/backend/src/common/constants/paths.ts
+++ b/backend/src/common/constants/paths.ts
@@ -50,3 +50,12 @@ export function getPluginsRuntimeDir(): string {
   );
   return cachedPluginsRuntimeDir;
 }
+
+/**
+ * Sockets and pid files, kept out of the directory that holds plugin content so
+ * a sweep of installed files can never touch a live channel. `fliks-rt` is the
+ * name the plugin plan gives it.
+ */
+export function getPluginsSocketDir(): string {
+  return path.join(getPluginsRuntimeDir(), 'fliks-rt');
+}

--- a/backend/src/modules/plugins/supervisor/__fixtures__/fixture-plugin.js
+++ b/backend/src/modules/plugins/supervisor/__fixtures__/fixture-plugin.js
@@ -1,0 +1,115 @@
+'use strict';
+/**
+ * Real test double for a `process` plugin (never shipped): speaks the real
+ * protocol over both sockets, with misbehaviour selected via FIXTURE_MODE.
+ * ponytail: line-framer duplicated, not imported — this must run as plain node, no build step.
+ */
+const net = require('net');
+const fs = require('fs');
+const path = require('path');
+
+// Mode travels as a file next to plugin.js: the env allowlist has no room for test-only vars.
+let mode = process.env.FIXTURE_MODE || 'good';
+try {
+  mode = fs.readFileSync(path.join(__dirname, 'FIXTURE_MODE'), 'utf8').trim() || mode;
+} catch {
+  // no mode file: env var (unsandboxed manual runs) or default 'good'
+}
+const token = process.env.FLIKS_PLUGIN_TOKEN || '';
+const coreSock = process.env.FLIKS_CORE_SOCK;
+const pluginSock = process.env.FLIKS_PLUGIN_SOCK;
+const FRAME_LIMIT = 4 * 1024 * 1024; // must match MAX_FRAME_BYTES in common/plugin-contract/protocol.ts
+
+function connectLineSocket(path, onLine) {
+  const sock = net.connect(path);
+  let buf = '';
+  sock.on('data', (chunk) => {
+    buf += chunk.toString('utf8');
+    let idx;
+    while ((idx = buf.indexOf('\n')) !== -1) {
+      const line = buf.slice(0, idx);
+      buf = buf.slice(idx + 1);
+      if (line.length > 0) onLine(sock, line);
+    }
+  });
+  sock.on('error', () => {});
+  return sock;
+}
+
+function send(sock, obj) {
+  sock.write(JSON.stringify(obj) + '\n');
+}
+
+if (mode === 'exit-immediately') {
+  process.exit(1);
+}
+
+if (mode === 'never-connect') {
+  // Alive but deliberately never touches either socket — proves the
+  // top-level handshake deadline fires even with no connection at all.
+  setInterval(() => {}, 60_000);
+} else if (mode === 'raw-oversize') {
+  const sock = net.connect(pluginSock);
+  sock.on('connect', () => sock.write('x'.repeat(FRAME_LIMIT + 1) + '\n'));
+  sock.on('error', () => {});
+} else if (mode === 'raw-malformed') {
+  const sock = net.connect(pluginSock);
+  sock.on('connect', () => sock.write('not json\n'));
+  sock.on('error', () => {});
+} else {
+  let healthCount = 0;
+
+  connectLineSocket(coreSock, () => {}); // uplink — nothing calls the 17 core methods in this PR
+
+  connectLineSocket(pluginSock, (sock, line) => {
+    let req;
+    try {
+      req = JSON.parse(line);
+    } catch {
+      return;
+    }
+
+    if (req.m === 'hello') {
+      if (mode === 'never-hello') return;
+      const replyToken = mode === 'wrong-token' ? 'not-the-token' : token;
+      send(sock, { i: req.i, r: { manifest: { id: process.env.FLIKS_PLUGIN_ID }, token: replyToken } });
+      if (mode.startsWith('crash-after-ms:')) {
+        const ms = Number(mode.split(':')[1]);
+        setTimeout(() => process.exit(1), ms);
+      }
+      if (mode === 'no-read') sock.pause();
+      return;
+    }
+
+    if (req.m === 'health') {
+      healthCount++;
+      if (mode.startsWith('health-fail-after:')) {
+        const n = Number(mode.split(':')[1]);
+        if (healthCount > n) return; // stop answering from here on
+      }
+      send(sock, { i: req.i, r: { ok: true } });
+      return;
+    }
+
+    if (req.m === 'shutdown') {
+      if (mode === 'ignore-shutdown') return; // never reply; SIGTERM is also ignored, see below
+      send(sock, { i: req.i, r: { ok: true } });
+      setTimeout(() => process.exit(0), 5);
+      return;
+    }
+
+    if (req.m === 'job' || req.m === 'http') {
+      send(sock, { i: req.i, r: { ok: true } });
+    }
+  });
+
+  if (mode === 'ignore-shutdown') {
+    process.on('SIGTERM', () => {}); // forces the supervisor down the SIGKILL branch
+  }
+
+  if (mode === 'flood-stdout') {
+    setInterval(() => {
+      for (let i = 0; i < 500; i++) process.stdout.write('x'.repeat(200) + '\n');
+    }, 5);
+  }
+}

--- a/backend/src/modules/plugins/supervisor/note-ring-buffer.spec.ts
+++ b/backend/src/modules/plugins/supervisor/note-ring-buffer.spec.ts
@@ -1,0 +1,23 @@
+import { NoteRingBuffer } from './note-ring-buffer';
+
+describe('NoteRingBuffer', () => {
+  it('shifts in FIFO order and drains to empty', () => {
+    const ring = new NoteRingBuffer();
+    ring.push({ m: 'event', p: 1 });
+    ring.push({ m: 'event', p: 2 });
+    expect(ring.size).toBe(2);
+    expect(ring.shift()).toEqual({ m: 'event', p: 1 });
+    expect(ring.shift()).toEqual({ m: 'event', p: 2 });
+    expect(ring.shift()).toBeUndefined();
+    expect(ring.size).toBe(0);
+  });
+
+  it('caps at 64 entries, dropping the oldest and counting drops', () => {
+    const ring = new NoteRingBuffer();
+    for (let i = 0; i < 70; i++) ring.push({ m: 'event', p: i });
+    expect(ring.size).toBe(64);
+    expect(ring.dropped).toBe(6);
+    // the oldest 6 (p: 0..5) were dropped; the next one in line is p: 6
+    expect(ring.shift()).toEqual({ m: 'event', p: 6 });
+  });
+});

--- a/backend/src/modules/plugins/supervisor/note-ring-buffer.ts
+++ b/backend/src/modules/plugins/supervisor/note-ring-buffer.ts
@@ -1,0 +1,32 @@
+import type { Note } from '../../../common/plugin-contract';
+
+const CAPACITY = 64;
+
+/**
+ * Bounded outbound queue for Notes to one plugin: a stalled reader must
+ * never stall core's fan-out. Overflow drops the oldest and counts it — at-most-once by construction.
+ */
+export class NoteRingBuffer {
+  private items: Note[] = [];
+  private droppedCount = 0;
+
+  push(note: Note): void {
+    if (this.items.length >= CAPACITY) {
+      this.items.shift();
+      this.droppedCount++;
+    }
+    this.items.push(note);
+  }
+
+  shift(): Note | undefined {
+    return this.items.shift();
+  }
+
+  get size(): number {
+    return this.items.length;
+  }
+
+  get dropped(): number {
+    return this.droppedCount;
+  }
+}

--- a/backend/src/modules/plugins/supervisor/pid-file.spec.ts
+++ b/backend/src/modules/plugins/supervisor/pid-file.spec.ts
@@ -1,0 +1,79 @@
+import { spawn, type ChildProcess } from 'child_process';
+import { existsSync, rmSync } from 'fs';
+import { pidFilePath, removePidFile, sweepOrphans, writePidFile } from './pid-file';
+import { makeRuntimeDir } from './supervisor-test-helpers';
+
+function spawnDecoy(): ChildProcess {
+  return spawn(process.execPath, ['-e', 'setTimeout(() => {}, 30000)'], { stdio: 'ignore' });
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('pid-file / sweepOrphans', () => {
+  const runtimeDirs: string[] = [];
+  const children: ChildProcess[] = [];
+
+  afterEach(() => {
+    for (const c of children) {
+      if (!c.killed) c.kill('SIGKILL');
+    }
+    children.length = 0;
+    for (const d of runtimeDirs) rmSync(d, { recursive: true, force: true });
+    runtimeDirs.length = 0;
+  });
+
+  it('writes and removes a pid file', () => {
+    const runtimeDir = makeRuntimeDir();
+    runtimeDirs.push(runtimeDir);
+    writePidFile(runtimeDir, 'demo', 12345, [process.execPath, '-e', '0']);
+    expect(existsSync(pidFilePath(runtimeDir, 'demo'))).toBe(true);
+    removePidFile(runtimeDir, 'demo');
+    expect(existsSync(pidFilePath(runtimeDir, 'demo'))).toBe(false);
+  });
+
+  it('kills a live process whose recorded cmdline matches, real spawn and real kill', async () => {
+    const runtimeDir = makeRuntimeDir();
+    runtimeDirs.push(runtimeDir);
+    const argv = [process.execPath, '-e', 'setTimeout(() => {}, 30000)'];
+    const decoy = spawnDecoy();
+    children.push(decoy);
+    await new Promise((r) => setTimeout(r, 50));
+
+    writePidFile(runtimeDir, 'orphan', decoy.pid!, argv);
+    sweepOrphans(runtimeDir);
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(isAlive(decoy.pid!)).toBe(false);
+    expect(existsSync(pidFilePath(runtimeDir, 'orphan'))).toBe(false);
+  }, 10_000);
+
+  it('leaves a live process alone when the recorded cmdline does not match', async () => {
+    const runtimeDir = makeRuntimeDir();
+    runtimeDirs.push(runtimeDir);
+    const innocent = spawnDecoy();
+    children.push(innocent);
+    await new Promise((r) => setTimeout(r, 50));
+
+    writePidFile(runtimeDir, 'not-orphan', innocent.pid!, [process.execPath, '-e', 'totally different argv']);
+    sweepOrphans(runtimeDir);
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(isAlive(innocent.pid!)).toBe(true);
+  }, 10_000);
+
+  it('cleans up a pid file whose process is already dead', () => {
+    const runtimeDir = makeRuntimeDir();
+    runtimeDirs.push(runtimeDir);
+    // A pid essentially guaranteed not to be alive right now.
+    writePidFile(runtimeDir, 'dead', 999_999, [process.execPath]);
+    sweepOrphans(runtimeDir);
+    expect(existsSync(pidFilePath(runtimeDir, 'dead'))).toBe(false);
+  });
+});

--- a/backend/src/modules/plugins/supervisor/pid-file.ts
+++ b/backend/src/modules/plugins/supervisor/pid-file.ts
@@ -1,0 +1,89 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+interface PidFileContents {
+  pid: number;
+  cmdline: string[];
+}
+
+export function pidFilePath(runtimeDir: string, pluginId: string): string {
+  return join(runtimeDir, `${pluginId}.pid`);
+}
+
+export function writePidFile(runtimeDir: string, pluginId: string, pid: number, cmdline: string[]): void {
+  mkdirSync(runtimeDir, { recursive: true });
+  const entry: PidFileContents = { pid, cmdline };
+  writeFileSync(pidFilePath(runtimeDir, pluginId), JSON.stringify(entry));
+}
+
+export function removePidFile(runtimeDir: string, pluginId: string): void {
+  try {
+    unlinkSync(pidFilePath(runtimeDir, pluginId));
+  } catch {
+    // already gone
+  }
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Linux only: argv as the kernel recorded it, NUL-separated. Null if unreadable (e.g. not Linux, or gone). */
+function readCmdline(pid: number): string[] | null {
+  try {
+    return readFileSync(`/proc/${pid}/cmdline`, 'utf8')
+      .split('\0')
+      .filter((s) => s.length > 0);
+  } catch {
+    return null;
+  }
+}
+
+function cmdlineMatches(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((v, i) => v === b[i]);
+}
+
+/**
+ * Kills any live process whose pid file matches its expected cmdline. A
+ * true no-op in Docker (SIGKILLing PID 1 already tears down the namespace) —
+ * it exists for Windows/macOS, which leak a plugin child across a crash. Runs unconditionally so it isn't mistaken for dead code.
+ */
+export function sweepOrphans(runtimeDir: string): void {
+  if (!existsSync(runtimeDir)) return;
+  for (const file of readdirSync(runtimeDir)) {
+    if (!file.endsWith('.pid')) continue;
+    const full = join(runtimeDir, file);
+    let entry: PidFileContents;
+    try {
+      entry = JSON.parse(readFileSync(full, 'utf8')) as PidFileContents;
+    } catch {
+      continue;
+    }
+    if (!isAlive(entry.pid)) {
+      try {
+        unlinkSync(full);
+      } catch {
+        // race with the owning supervisor's own cleanup
+      }
+      continue;
+    }
+    const cmdline = readCmdline(entry.pid);
+    if (cmdline && cmdlineMatches(cmdline, entry.cmdline)) {
+      try {
+        process.kill(entry.pid, 'SIGKILL');
+      } catch {
+        // already gone
+      }
+      try {
+        unlinkSync(full);
+      } catch {
+        // already gone
+      }
+    }
+  }
+}

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.spec.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.spec.ts
@@ -1,0 +1,234 @@
+import { existsSync, rmSync } from 'fs';
+import { DEFAULT_SUPERVISOR_OPTIONS, PluginSupervisor, type PluginSupervisorOptions } from './plugin-supervisor';
+import {
+  delay,
+  makeFixtureDir,
+  makeRuntimeDir,
+  newLogBuffer,
+  waitForExitSignal,
+  waitForState,
+} from './supervisor-test-helpers';
+
+/**
+ * Real spawns and real sockets throughout, timing figures scaled down via
+ * the constructor for speed; DEFAULT_SUPERVISOR_OPTIONS checks the real numbers separately.
+ */
+
+const dirsToClean: string[] = [];
+const supervisorsToStop: PluginSupervisor[] = [];
+
+function makeSupervisor(mode: string, overrides: Partial<PluginSupervisorOptions> = {}): PluginSupervisor {
+  const dir = makeFixtureDir(mode);
+  const runtimeDir = makeRuntimeDir();
+  dirsToClean.push(dir, runtimeDir);
+  const sup = new PluginSupervisor({
+    id: `t${supervisorsToStop.length}`,
+    dir,
+    runtimeDir,
+    logBuffer: newLogBuffer(),
+    handshakeDeadlineMs: 250,
+    healthIntervalMs: 60,
+    healthDeadlineMs: 30,
+    backoffLadderMs: [15, 30, 60, 120, 240, 400],
+    readyResetMs: 300,
+    breakerWindowMs: 600,
+    breakerMaxCrashes: 6,
+    shutdownRpcDeadlineMs: 100,
+    sigtermGraceMs: 80,
+    ...overrides,
+  });
+  supervisorsToStop.push(sup);
+  return sup;
+}
+
+afterEach(async () => {
+  await Promise.all(supervisorsToStop.map((s) => s.stop().catch(() => undefined)));
+  supervisorsToStop.length = 0;
+  for (const d of dirsToClean) rmSync(d, { recursive: true, force: true });
+  dirsToClean.length = 0;
+}, 15_000);
+
+describe('DEFAULT_SUPERVISOR_OPTIONS', () => {
+  it('matches the plan exactly', () => {
+    expect(DEFAULT_SUPERVISOR_OPTIONS).toEqual({
+      memoryMb: 256,
+      handshakeDeadlineMs: 10_000,
+      healthIntervalMs: 15_000,
+      healthDeadlineMs: 3_000,
+      backoffLadderMs: [1_000, 2_000, 4_000, 8_000, 16_000, 30_000],
+      readyResetMs: 120_000,
+      breakerWindowMs: 600_000,
+      breakerMaxCrashes: 6,
+      shutdownRpcDeadlineMs: 3_000,
+      sigtermGraceMs: 2_000,
+      logCapBytesPerMinute: 65_536,
+    });
+  });
+});
+
+describe('handshake', () => {
+  it('a well-behaved plugin reaches ready and answers health', async () => {
+    const sup = makeSupervisor('good');
+    await sup.start();
+    await waitForState(sup, 'ready');
+    const before = sup.getHealthCheckCount();
+    await delay(200); // a few real health ticks at healthIntervalMs=60
+    expect(sup.getHealthCheckCount()).toBeGreaterThan(before);
+    expect(sup.getState()).toBe('ready');
+  }, 10_000);
+
+  it('a wrong token is SIGKILLed and never reaches ready', async () => {
+    // a slow backoff first step so the exit-signal check below can't be preempted by a restart
+    const sup = makeSupervisor('wrong-token', { backoffLadderMs: [1_000, 1_000] });
+    await sup.start();
+    await waitForState(sup, 'crashed');
+    expect(sup.getState()).not.toBe('ready');
+    expect(await waitForExitSignal(sup)).toBe('SIGKILL');
+  }, 10_000);
+
+  it('no handshake within the deadline is SIGKILLed and lands crashed', async () => {
+    const sup = makeSupervisor('never-hello', { backoffLadderMs: [1_000, 1_000] });
+    await sup.start();
+    await waitForState(sup, 'crashed');
+    expect(await waitForExitSignal(sup)).toBe('SIGKILL');
+  }, 10_000);
+
+  it('SIGKILLs even when the plugin never connects at all', async () => {
+    const sup = makeSupervisor('never-connect');
+    await sup.start();
+    await waitForState(sup, 'crashed');
+  }, 10_000);
+});
+
+describe('liveness', () => {
+  it('two health misses degrade it; four force a restart', async () => {
+    const sup = makeSupervisor('health-fail-after:1');
+    const seen: string[] = [];
+    sup.onStateChange((s) => seen.push(s));
+    await sup.start();
+    await waitForState(sup, 'ready');
+    await waitForState(sup, 'degraded');
+    await waitForState(sup, 'backoff');
+    expect(seen).toEqual(expect.arrayContaining(['ready', 'degraded', 'crashed', 'backoff']));
+    expect(seen.indexOf('degraded')).toBeLessThan(seen.lastIndexOf('crashed'));
+  }, 10_000);
+});
+
+describe('backoff', () => {
+  it('grows on each crash and does not reset for a plugin crashing well under the ready-reset window', async () => {
+    // crashes 40ms after every successful hello; readyResetMs (300) never elapses first
+    const sup = makeSupervisor('crash-after-ms:40', { readyResetMs: 300 });
+    const backoffIndices: number[] = [];
+    sup.onStateChange((s) => {
+      if (s === 'backoff') backoffIndices.push(sup.getBackoffIndex());
+    });
+    await sup.start();
+    await delay(600);
+    expect(backoffIndices.length).toBeGreaterThanOrEqual(3);
+    for (let i = 1; i < backoffIndices.length; i++) {
+      expect(backoffIndices[i]).toBeGreaterThan(backoffIndices[i - 1]);
+    }
+  }, 10_000);
+
+  it('resets once the plugin stays continuously ready past the reset window', async () => {
+    // crashes 250ms after hello; readyResetMs (80) elapses first every cycle
+    const sup = makeSupervisor('crash-after-ms:250', { readyResetMs: 80, backoffLadderMs: [15, 30, 60, 120] });
+    const backoffIndices: number[] = [];
+    sup.onStateChange((s) => {
+      if (s === 'backoff') backoffIndices.push(sup.getBackoffIndex());
+    });
+    await sup.start();
+    await delay(750);
+    expect(backoffIndices.length).toBeGreaterThanOrEqual(2);
+    expect(Math.max(...backoffIndices)).toBeLessThanOrEqual(1);
+  }, 10_000);
+});
+
+describe('circuit breaker', () => {
+  it('trips to failed after 6 crashes in the window, captures stderr, and never restarts again', async () => {
+    const sup = makeSupervisor('exit-immediately', {
+      backoffLadderMs: [5, 5, 5, 5, 5, 5],
+      breakerWindowMs: 2_000,
+      breakerMaxCrashes: 6,
+    });
+    await sup.start();
+    await waitForState(sup, 'failed', 5_000);
+    expect(sup.getRestartCount()).toBe(6);
+    const restartsAtFailure = sup.getRestartCount();
+    await delay(200);
+    expect(sup.getRestartCount()).toBe(restartsAtFailure); // no further restart attempts
+    expect(sup.getState()).toBe('failed');
+  }, 10_000);
+
+  it('reEnable clears the breaker and allows starting again', async () => {
+    const sup = makeSupervisor('exit-immediately', {
+      backoffLadderMs: [5, 5, 5, 5, 5, 5],
+      breakerWindowMs: 2_000,
+      breakerMaxCrashes: 6,
+    });
+    await sup.start();
+    await waitForState(sup, 'failed', 5_000);
+    sup.reEnable();
+    expect(sup.getState()).toBe('stopped');
+  }, 10_000);
+});
+
+describe('ring buffer backpressure', () => {
+  it('drops the oldest event and counts drops when the child never reads', async () => {
+    const sup = makeSupervisor('no-read');
+    await sup.start();
+    await waitForState(sup, 'ready');
+    const filler = 'x'.repeat(1024);
+    for (let i = 0; i < 3_000; i++) sup.emitEvent('test.event', { i, filler });
+    expect(sup.getRingSize()).toBeLessThanOrEqual(64);
+    expect(sup.getEventDropCount()).toBeGreaterThan(0);
+  }, 10_000);
+});
+
+describe('shutdown', () => {
+  it('takes the RPC path when the child cooperates and unlinks both sockets', async () => {
+    const sup = makeSupervisor('good');
+    await sup.start();
+    await waitForState(sup, 'ready');
+    const { coreSockPath, pluginSockPath } = sup.getSocketPaths();
+    const t0 = Date.now();
+    await sup.stop();
+    const elapsed = Date.now() - t0;
+    // cooperative exit must not fall through to the SIGTERM/SIGKILL ladder
+    expect(elapsed).toBeLessThan(80 + 100);
+    expect(sup.getState()).toBe('stopped');
+    expect(existsSync(coreSockPath)).toBe(false);
+    expect(existsSync(pluginSockPath)).toBe(false);
+  }, 10_000);
+
+  it('takes the SIGTERM/SIGKILL path when the child ignores shutdown, and still unlinks both sockets', async () => {
+    const sup = makeSupervisor('ignore-shutdown');
+    await sup.start();
+    await waitForState(sup, 'ready');
+    const { coreSockPath, pluginSockPath } = sup.getSocketPaths();
+    const t0 = Date.now();
+    await sup.stop();
+    const elapsed = Date.now() - t0;
+    // must have waited out the RPC deadline (100) + the SIGTERM grace (80) before SIGKILL
+    expect(elapsed).toBeGreaterThanOrEqual(100 + 80 - 20);
+    expect(sup.getLastExitSignal()).toBe('SIGKILL');
+    expect(existsSync(coreSockPath)).toBe(false);
+    expect(existsSync(pluginSockPath)).toBe(false);
+  }, 10_000);
+});
+
+describe('protocol violations', () => {
+  it('an oversize frame is refused and kills the plugin without taking core down', async () => {
+    const sup = makeSupervisor('raw-oversize');
+    await sup.start();
+    await waitForState(sup, 'crashed');
+    expect(sup.getState()).not.toBe('ready');
+  }, 10_000);
+
+  it('a malformed line is refused and kills the plugin without taking core down', async () => {
+    const sup = makeSupervisor('raw-malformed');
+    await sup.start();
+    await waitForState(sup, 'crashed');
+    expect(sup.getState()).not.toBe('ready');
+  }, 10_000);
+});

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
@@ -1,0 +1,528 @@
+import { spawn, type ChildProcess } from 'child_process';
+import { createServer, type Server, type Socket } from 'net';
+import { randomBytes } from 'crypto';
+import { chmodSync, mkdirSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { getPluginsSocketDir } from '../../../common/constants/paths';
+import type { OnApplicationShutdown } from '@nestjs/common';
+import { LogBufferService } from '../../scheduler/log-buffer.service';
+import { CURRENT_FLIKS_VERSION } from '../plugin-registry.service';
+import { PLUGIN_API_VERSION, type Note } from '../../../common/plugin-contract';
+import { RpcChannel } from './rpc-channel';
+import { NoteRingBuffer } from './note-ring-buffer';
+import { buildSpawnPlan } from './spawn-plan';
+import { writePidFile, removePidFile } from './pid-file';
+
+export type SupervisorState =
+  | 'stopped'
+  | 'starting'
+  | 'handshaking'
+  | 'ready'
+  | 'degraded'
+  | 'crashed'
+  | 'backoff'
+  | 'failed';
+
+const STDERR_TAIL_BYTES = 4 * 1024;
+
+/** Every figure here is "The spawn call and the supervisor"'s, verbatim. Override only in tests. */
+export const DEFAULT_SUPERVISOR_OPTIONS = {
+  memoryMb: 256,
+  handshakeDeadlineMs: 10_000,
+  healthIntervalMs: 15_000,
+  healthDeadlineMs: 3_000,
+  backoffLadderMs: [1_000, 2_000, 4_000, 8_000, 16_000, 30_000],
+  readyResetMs: 120_000,
+  breakerWindowMs: 10 * 60_000,
+  breakerMaxCrashes: 6,
+  shutdownRpcDeadlineMs: 3_000,
+  sigtermGraceMs: 2_000,
+  logCapBytesPerMinute: 64 * 1024,
+};
+
+export interface PluginSupervisorOptions {
+  id: string;
+  /** Directory already holding a materialized `plugin.js` (extraction is out of this PR's scope). */
+  dir: string;
+  /** Where the sockets and pid file live. Defaults to the `fliks-rt` directory,
+   *  outside the tree holding plugin content. */
+  runtimeDir?: string;
+  logBuffer: LogBufferService;
+  dbUrl?: string;
+  config?: Record<string, string>;
+  memoryMb?: number;
+  handshakeDeadlineMs?: number;
+  healthIntervalMs?: number;
+  healthDeadlineMs?: number;
+  backoffLadderMs?: number[];
+  readyResetMs?: number;
+  breakerWindowMs?: number;
+  breakerMaxCrashes?: number;
+  shutdownRpcDeadlineMs?: number;
+  sigtermGraceMs?: number;
+  logCapBytesPerMinute?: number;
+}
+
+function listenAndChmod(server: Server, path: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(path, () => {
+      chmodSync(path, 0o600);
+      resolve();
+    });
+  });
+}
+
+/**
+ * Owns one `process`-tier plugin's lifecycle end to end. Core listens on both
+ * sockets; the plugin dials out — `coreSock` for its 17 calls (unhandled here), `pluginSock` for the 7 core-initiated ones.
+ */
+export class PluginSupervisor implements OnApplicationShutdown {
+  private readonly opts: Required<PluginSupervisorOptions>;
+  private readonly coreSockPath: string;
+  private readonly pluginSockPath: string;
+
+  private state: SupervisorState = 'stopped';
+  private stateListeners: ((s: SupervisorState) => void)[] = [];
+
+  private coreServer: Server | null = null;
+  private pluginServer: Server | null = null;
+  private pluginChannel: RpcChannel | null = null;
+  private pluginSocketRef: Socket | null = null;
+
+  private child: ChildProcess | null = null;
+  private token = '';
+  private stopRequested = false;
+  private crashHandledForThisChild = false;
+
+  private handshakeTimer: NodeJS.Timeout | null = null;
+  private healthTimer: NodeJS.Timeout | null = null;
+  private backoffTimer: NodeJS.Timeout | null = null;
+  private readyResetTimer: NodeJS.Timeout | null = null;
+
+  private consecutiveHealthMisses = 0;
+  private healthCheckCount = 0;
+  private backoffIndex = 0;
+  private crashTimestamps: number[] = [];
+  private totalCrashes = 0;
+  private stderrTail = '';
+  private statusMessage = '';
+  private lastExitSignal: NodeJS.Signals | null = null;
+
+  private readonly ring = new NoteRingBuffer();
+  private ringBackpressured = false;
+
+  private logWindowStart = Date.now();
+  private logBytesThisMinute = 0;
+  private logSuppressedThisWindow = false;
+
+  constructor(options: PluginSupervisorOptions) {
+    // Sockets and pid files default out of the directory holding plugin content,
+    // so sweeping installed files can never unlink a live channel.
+    this.opts = {
+      ...DEFAULT_SUPERVISOR_OPTIONS,
+      dbUrl: '',
+      config: {},
+      runtimeDir: getPluginsSocketDir(),
+      ...options,
+    };
+    this.coreSockPath = join(this.opts.runtimeDir, `${this.opts.id}.core.sock`);
+    this.pluginSockPath = join(this.opts.runtimeDir, `${this.opts.id}.plugin.sock`);
+  }
+
+  getState(): SupervisorState {
+    return this.state;
+  }
+  getEventDropCount(): number {
+    return this.ring.dropped;
+  }
+  getRingSize(): number {
+    return this.ring.size;
+  }
+  getRestartCount(): number {
+    return this.totalCrashes;
+  }
+  getBackoffIndex(): number {
+    return this.backoffIndex;
+  }
+  getHealthCheckCount(): number {
+    return this.healthCheckCount;
+  }
+  getStderrTail(): string {
+    return this.stderrTail;
+  }
+  getStatusMessage(): string {
+    return this.statusMessage;
+  }
+  /** For tests: proves which branch of a kill ladder actually fired. */
+  getLastExitSignal(): NodeJS.Signals | null {
+    return this.lastExitSignal;
+  }
+  getSocketPaths(): { coreSockPath: string; pluginSockPath: string } {
+    return { coreSockPath: this.coreSockPath, pluginSockPath: this.pluginSockPath };
+  }
+
+  onStateChange(cb: (s: SupervisorState) => void): () => void {
+    this.stateListeners.push(cb);
+    return () => {
+      this.stateListeners = this.stateListeners.filter((l) => l !== cb);
+    };
+  }
+
+  private setState(s: SupervisorState): void {
+    this.state = s;
+    for (const cb of this.stateListeners) cb(s);
+  }
+
+  /** Fire-and-forget, at-most-once. Queues through the 64-entry ring on backpressure. */
+  emitEvent(name: string, payload: unknown): void {
+    this.ring.push({ m: 'event', p: { name, payload } });
+    this.flushRing();
+  }
+
+  async start(): Promise<void> {
+    if (this.state !== 'stopped') return;
+    this.stopRequested = false;
+    await this.setupSockets();
+    await this.spawnChild();
+  }
+
+  /** Clears the circuit breaker after a manual re-enable. Required before `start()` works again from `failed`. */
+  reEnable(): void {
+    if (this.state !== 'failed') return;
+    this.crashTimestamps = [];
+    this.backoffIndex = 0;
+    this.setState('stopped');
+  }
+
+  async onApplicationShutdown(): Promise<void> {
+    await this.stop();
+  }
+
+  /** `shutdown` RPC -> 3s -> SIGTERM -> 2s -> SIGKILL -> unlink both sockets. */
+  async stop(): Promise<void> {
+    this.stopRequested = true;
+    this.clearAllTimers();
+
+    if (this.child && !this.child.killed) {
+      if (this.pluginChannel) {
+        try {
+          await this.pluginChannel.call('shutdown', {}, this.opts.shutdownRpcDeadlineMs);
+          const exited = await this.waitForExit(this.opts.sigtermGraceMs);
+          if (!exited) await this.killLadder();
+        } catch {
+          await this.killLadder();
+        }
+      } else {
+        await this.killLadder();
+      }
+    }
+
+    this.setState('stopped');
+    this.cleanupSockets();
+  }
+
+  private async killLadder(): Promise<void> {
+    if (!this.child || this.child.killed) return;
+    this.child.kill('SIGTERM');
+    const exited = await this.waitForExit(this.opts.sigtermGraceMs);
+    if (!exited) {
+      this.child.kill('SIGKILL');
+      await this.waitForExit(2_000);
+    }
+  }
+
+  private waitForExit(timeoutMs: number): Promise<boolean> {
+    if (!this.child) return Promise.resolve(true);
+    if (this.child.exitCode !== null || this.child.signalCode !== null) return Promise.resolve(true);
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => resolve(false), timeoutMs);
+      this.child!.once('exit', () => {
+        clearTimeout(timer);
+        resolve(true);
+      });
+    });
+  }
+
+  private cleanupSockets(): void {
+    this.coreServer?.close();
+    this.pluginServer?.close();
+    for (const p of [this.coreSockPath, this.pluginSockPath]) {
+      try {
+        unlinkSync(p);
+      } catch {
+        // never listened, or already gone
+      }
+    }
+    removePidFile(this.opts.runtimeDir, this.opts.id);
+  }
+
+  private async setupSockets(): Promise<void> {
+    mkdirSync(this.opts.runtimeDir, { recursive: true });
+    for (const p of [this.coreSockPath, this.pluginSockPath]) {
+      try {
+        unlinkSync(p);
+      } catch {
+        // nothing stale to remove
+      }
+    }
+    this.coreServer = createServer((s) => this.onCoreConnected(s));
+    this.pluginServer = createServer((s) => {
+      if (this.pluginChannel) {
+        s.destroy();
+        return;
+      }
+      this.onPluginConnected(s);
+    });
+    await Promise.all([
+      listenAndChmod(this.coreServer, this.coreSockPath),
+      listenAndChmod(this.pluginServer, this.pluginSockPath),
+    ]);
+  }
+
+  private onCoreConnected(socket: Socket): void {
+    // Plugin's uplink for the 17 core-side methods. No handler registered here —
+    // that dispatch is 3.5's proxy. Still framed and violation-checked like any connection.
+    const channel = new RpcChannel(socket);
+    channel.onViolation((err) => this.onViolation(err));
+  }
+
+  private onPluginConnected(socket: Socket): void {
+    this.pluginSocketRef = socket;
+    const channel = new RpcChannel(socket);
+    channel.onViolation((err) => this.onViolation(err));
+    this.pluginChannel = channel;
+    void this.attemptHandshake(channel);
+  }
+
+  private onViolation(err: Error): void {
+    this.opts.logBuffer.warn(`protocol violation: ${err.message}`, `plugin:${this.opts.id}`);
+    this.handleCrash(`protocol violation: ${err.message}`);
+  }
+
+  private async spawnChild(): Promise<void> {
+    this.pluginChannel = null;
+    this.pluginSocketRef = null;
+    this.crashHandledForThisChild = false;
+    this.lastExitSignal = null;
+
+    this.setState('starting');
+    mkdirSync(join(this.opts.dir, 'data'), { recursive: true });
+    this.token = randomBytes(32).toString('hex');
+
+    const plan = buildSpawnPlan({
+      dir: this.opts.dir,
+      memoryMb: this.opts.memoryMb,
+      coreSockPath: this.coreSockPath,
+      pluginSockPath: this.pluginSockPath,
+      token: this.token,
+      pluginId: this.opts.id,
+      dbUrl: this.opts.dbUrl,
+      config: this.opts.config,
+    });
+
+    this.child = spawn(plan.command, plan.args, plan.options);
+    writePidFile(this.opts.runtimeDir, this.opts.id, this.child.pid!, plan.expectedCmdline);
+    this.wireChildIo(this.child);
+    this.child.on('exit', (code, signal) => this.onChildExit(code, signal));
+
+    this.setState('handshaking');
+    this.handshakeTimer = setTimeout(() => this.handleCrash('handshake timeout'), this.opts.handshakeDeadlineMs);
+  }
+
+  private wireChildIo(child: ChildProcess): void {
+    const tag = `plugin:${this.opts.id}`;
+    const onChunk = (level: 'log' | 'error', chunk: Buffer) => {
+      const now = Date.now();
+      if (now - this.logWindowStart >= 60_000) {
+        this.logWindowStart = now;
+        this.logBytesThisMinute = 0;
+        this.logSuppressedThisWindow = false;
+      }
+      const text = chunk.toString('utf8');
+      this.logBytesThisMinute += Buffer.byteLength(text);
+      if (this.logBytesThisMinute > this.opts.logCapBytesPerMinute) {
+        if (!this.logSuppressedThisWindow) {
+          this.logSuppressedThisWindow = true;
+          this.opts.logBuffer.warn(
+            `output suppressed — exceeded ${this.opts.logCapBytesPerMinute} B/min`,
+            tag,
+          );
+        }
+        return;
+      }
+      for (const line of text.split('\n')) {
+        if (line.length === 0) continue;
+        if (level === 'log') this.opts.logBuffer.log(line, tag);
+        else {
+          this.opts.logBuffer.error(line, undefined, tag);
+          this.stderrTail = (this.stderrTail + line + '\n').slice(-STDERR_TAIL_BYTES);
+        }
+      }
+    };
+    child.stdout?.on('data', (b: Buffer) => onChunk('log', b));
+    child.stderr?.on('data', (b: Buffer) => onChunk('error', b));
+  }
+
+  private onChildExit(code: number | null, signal: NodeJS.Signals | null): void {
+    this.lastExitSignal = signal;
+    if (this.pluginChannel) {
+      this.pluginChannel.destroy();
+      this.pluginChannel = null;
+    }
+    if (this.stopRequested) return; // stop() owns the transition out of a deliberate shutdown
+    this.handleCrash(`exited unexpectedly (code=${code}, signal=${signal})`);
+  }
+
+  private async attemptHandshake(channel: RpcChannel): Promise<void> {
+    try {
+      const res = await channel.call<{ manifest: unknown; token?: string }>(
+        'hello',
+        { pluginApi: PLUGIN_API_VERSION, coreVersion: CURRENT_FLIKS_VERSION, config: this.opts.config },
+        this.opts.handshakeDeadlineMs,
+      );
+      // The token never travels core->plugin; only a process holding the real
+      // FLIKS_PLUGIN_TOKEN (via its own env) can echo the right value back.
+      if (res.token !== this.token) {
+        this.handleCrash('hello token mismatch');
+        return;
+      }
+      if (this.handshakeTimer) {
+        clearTimeout(this.handshakeTimer);
+        this.handshakeTimer = null;
+      }
+      this.enterReady();
+      this.startHealthLoop();
+      this.flushRing();
+    } catch (err) {
+      this.handleCrash(`handshake failed: ${(err as Error).message}`);
+    }
+  }
+
+  private enterReady(): void {
+    this.setState('ready');
+    this.clearReadyResetTimer();
+    // Resets the backoff ladder only after this much continuous ready time —
+    // a plugin crashing just before the window elapses must not restart at 1s forever.
+    this.readyResetTimer = setTimeout(() => {
+      this.backoffIndex = 0;
+    }, this.opts.readyResetMs);
+  }
+
+  private clearReadyResetTimer(): void {
+    if (this.readyResetTimer) {
+      clearTimeout(this.readyResetTimer);
+      this.readyResetTimer = null;
+    }
+  }
+
+  private startHealthLoop(): void {
+    this.consecutiveHealthMisses = 0;
+    this.healthTimer = setInterval(() => void this.performHealthCheck(), this.opts.healthIntervalMs);
+  }
+
+  private async performHealthCheck(): Promise<void> {
+    if (!this.pluginChannel) return;
+    this.healthCheckCount++;
+    try {
+      await this.pluginChannel.call('health', {}, this.opts.healthDeadlineMs);
+      this.consecutiveHealthMisses = 0;
+      if (this.state === 'degraded') this.enterReady();
+    } catch {
+      this.consecutiveHealthMisses++;
+      if (this.consecutiveHealthMisses === 2 && this.state === 'ready') {
+        this.setState('degraded');
+        this.clearReadyResetTimer();
+      }
+      if (this.consecutiveHealthMisses >= 4) {
+        if (this.healthTimer) {
+          clearInterval(this.healthTimer);
+          this.healthTimer = null;
+        }
+        await this.forceKillForHealthFailure();
+      }
+    }
+  }
+
+  private async forceKillForHealthFailure(): Promise<void> {
+    if (this.child && !this.child.killed) {
+      this.child.kill('SIGTERM');
+      const exited = await this.waitForExit(this.opts.sigtermGraceMs);
+      if (!exited) {
+        this.child.kill('SIGKILL');
+        await this.waitForExit(2_000);
+      }
+    }
+    this.handleCrash('health check missed 4 times');
+  }
+
+  /** Every crash path funnels here — idempotent per spawned child so a kill plus its own exit event can't double-count. */
+  private handleCrash(reason: string): void {
+    if (this.crashHandledForThisChild) return;
+    this.crashHandledForThisChild = true;
+    this.clearAllTimers();
+    if (this.child && !this.child.killed) {
+      try {
+        this.child.kill('SIGKILL');
+      } catch {
+        // already gone
+      }
+    }
+    this.pluginChannel?.destroy();
+    this.pluginChannel = null;
+
+    this.setState('crashed');
+    this.totalCrashes++;
+    const now = Date.now();
+    this.crashTimestamps.push(now);
+    this.crashTimestamps = this.crashTimestamps.filter((t) => now - t < this.opts.breakerWindowMs);
+
+    if (this.crashTimestamps.length >= this.opts.breakerMaxCrashes) {
+      this.statusMessage = this.stderrTail;
+      this.opts.logBuffer.error(
+        `circuit breaker tripped after ${this.crashTimestamps.length} crashes in the last ` +
+          `${this.opts.breakerWindowMs}ms (${reason}); manual re-enable required`,
+        undefined,
+        `plugin:${this.opts.id}`,
+      );
+      this.setState('failed');
+      return;
+    }
+
+    const delay = this.opts.backoffLadderMs[Math.min(this.backoffIndex, this.opts.backoffLadderMs.length - 1)];
+    this.backoffIndex++;
+    this.setState('backoff');
+    this.backoffTimer = setTimeout(() => void this.spawnChild(), delay);
+  }
+
+  private clearAllTimers(): void {
+    if (this.handshakeTimer) {
+      clearTimeout(this.handshakeTimer);
+      this.handshakeTimer = null;
+    }
+    if (this.healthTimer) {
+      clearInterval(this.healthTimer);
+      this.healthTimer = null;
+    }
+    if (this.backoffTimer) {
+      clearTimeout(this.backoffTimer);
+      this.backoffTimer = null;
+    }
+    this.clearReadyResetTimer();
+  }
+
+  private flushRing(): void {
+    if (!this.pluginChannel) return;
+    while (!this.ringBackpressured && this.ring.size > 0) {
+      const note = this.ring.shift() as Note;
+      const ok = this.pluginChannel.sendNote(note);
+      if (!ok) {
+        this.ringBackpressured = true;
+        this.pluginSocketRef?.once('drain', () => {
+          this.ringBackpressured = false;
+          this.flushRing();
+        });
+      }
+    }
+  }
+}

--- a/backend/src/modules/plugins/supervisor/rpc-channel.spec.ts
+++ b/backend/src/modules/plugins/supervisor/rpc-channel.spec.ts
@@ -1,0 +1,91 @@
+import { createServer, connect, type Server, type Socket } from 'net';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { RpcChannel } from './rpc-channel';
+
+interface Pair {
+  srv: Server;
+  server: RpcChannel;
+  client: RpcChannel;
+  clientSocket: Socket;
+  dir: string;
+}
+
+/** Real unix sockets both ends — RpcChannel is the transport under test, never mocked. */
+function makePair(): Promise<Pair> {
+  const dir = mkdtempSync(join(tmpdir(), 'rpc-channel-'));
+  const sockPath = join(dir, 'a.sock');
+  return new Promise((resolve, reject) => {
+    const srv: Server = createServer((socket: Socket) => {
+      resolve({ srv, server: new RpcChannel(socket), client, clientSocket, dir });
+    });
+    let client: RpcChannel;
+    let clientSocket: Socket;
+    srv.once('error', reject);
+    srv.listen(sockPath, () => {
+      clientSocket = connect(sockPath);
+      client = new RpcChannel(clientSocket);
+    });
+  });
+}
+
+/** Closes both channels and the listening server so no socket or handle survives the test. */
+function teardown(pair: Pair): void {
+  pair.server.destroy();
+  pair.client.destroy();
+  pair.srv.close();
+  rmSync(pair.dir, { recursive: true, force: true });
+}
+
+describe('RpcChannel', () => {
+  let cleanup: (() => void) | null = null;
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = null;
+  });
+
+  it('round-trips a call and its response', async () => {
+    const pair = await makePair();
+    cleanup = () => teardown(pair);
+    pair.server.onRequest(async (method, payload) => {
+      expect(method).toBe('health');
+      return { ok: true, echoed: payload };
+    });
+    const res = await pair.client.call<{ ok: boolean; echoed: unknown }>('health', { x: 1 }, 1_000);
+    expect(res).toEqual({ ok: true, echoed: { x: 1 } });
+  });
+
+  it('rejects with a timeout when nothing answers', async () => {
+    const pair = await makePair();
+    cleanup = () => teardown(pair);
+    await expect(pair.client.call('health', {}, 30)).rejects.toThrow(/timeout/);
+  });
+
+  it('delivers a fire-and-forget note with no reply expected', async () => {
+    const pair = await makePair();
+    cleanup = () => teardown(pair);
+    const received = new Promise((resolve) => pair.server.onNote(resolve));
+    pair.client.sendNote({ m: 'event', p: { hello: 'world' } });
+    await expect(received).resolves.toEqual({ m: 'event', p: { hello: 'world' } });
+  });
+
+  it('reports a protocol violation for a malformed line without throwing out of the process', async () => {
+    const pair = await makePair();
+    cleanup = () => teardown(pair);
+    const violation = new Promise<Error>((resolve) => pair.server.onViolation(resolve));
+    // bypass the channel's own encoder to write a raw malformed line
+    pair.clientSocket.write('not json at all\n');
+    const err = await violation;
+    expect(err.message).toMatch(/malformed/);
+  });
+
+  it('rejects pending calls when the connection closes', async () => {
+    const pair = await makePair();
+    cleanup = () => teardown(pair);
+    const pending = pair.client.call('health', {}, 5_000);
+    pair.server.destroy();
+    await expect(pending).rejects.toThrow(/closed/);
+  });
+});

--- a/backend/src/modules/plugins/supervisor/rpc-channel.ts
+++ b/backend/src/modules/plugins/supervisor/rpc-channel.ts
@@ -1,0 +1,143 @@
+import type { Socket } from 'net';
+import { encodeFrame, FrameReader, parseFrame, ProtocolViolationError, type Frame } from './wire';
+import type { Req, Res, Note } from '../../../common/plugin-contract';
+
+interface PendingCall {
+  resolve: (v: unknown) => void;
+  reject: (e: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+export type RequestHandler = (method: string, payload: unknown) => Promise<unknown>;
+
+function isReq(f: Frame): f is Req {
+  return typeof (f as Req).i === 'number' && typeof (f as Req).m === 'string';
+}
+function isRes(f: Frame): f is Res {
+  return typeof (f as Res).i === 'number' && !('m' in f);
+}
+function isNote(f: Frame): f is Note {
+  return typeof (f as Note).m === 'string' && !('i' in f);
+}
+
+/**
+ * One newline-delimited JSON-RPC connection. Symmetric: either side may
+ * `call()` the other; a frame fitting none of Req/Res/Note is a protocol violation, same as an unparsable line.
+ */
+export class RpcChannel {
+  private reader = new FrameReader();
+  private nextId = 1;
+  private pending = new Map<number, PendingCall>();
+  private requestHandler: RequestHandler | null = null;
+  private noteHandler: ((note: Note) => void) | null = null;
+  private violationHandler: ((err: Error) => void) | null = null;
+  private closed = false;
+
+  constructor(private readonly socket: Socket) {
+    socket.on('data', (chunk: Buffer) => this.onData(chunk));
+    socket.on('close', () => this.onClose());
+    socket.on('error', () => this.onClose());
+  }
+
+  onRequest(handler: RequestHandler): void {
+    this.requestHandler = handler;
+  }
+
+  onNote(handler: (note: Note) => void): void {
+    this.noteHandler = handler;
+  }
+
+  /** Oversize frame or malformed line — the caller decides what to do (the supervisor SIGKILLs). */
+  onViolation(handler: (err: Error) => void): void {
+    this.violationHandler = handler;
+  }
+
+  private onData(chunk: Buffer): void {
+    let lines: string[];
+    try {
+      lines = this.reader.push(chunk);
+    } catch (err) {
+      this.violationHandler?.(err as Error);
+      return;
+    }
+    for (const line of lines) {
+      let frame: Frame;
+      try {
+        frame = parseFrame(line);
+      } catch (err) {
+        this.violationHandler?.(err as Error);
+        return;
+      }
+      this.route(frame);
+    }
+  }
+
+  private route(frame: Frame): void {
+    if (isReq(frame)) {
+      void this.handleRequest(frame);
+    } else if (isRes(frame)) {
+      this.handleResponse(frame);
+    } else if (isNote(frame)) {
+      this.noteHandler?.(frame);
+    } else {
+      this.violationHandler?.(new ProtocolViolationError('frame matches neither Req, Res nor Note'));
+    }
+  }
+
+  private async handleRequest(req: Req): Promise<void> {
+    if (!this.requestHandler) return;
+    try {
+      const r = await this.requestHandler(req.m, req.p);
+      this.write({ i: req.i, r });
+    } catch (err) {
+      this.write({ i: req.i, e: { c: 'ERR', m: (err as Error).message } });
+    }
+  }
+
+  private handleResponse(res: Res): void {
+    const call = this.pending.get(res.i);
+    if (!call) return;
+    this.pending.delete(res.i);
+    clearTimeout(call.timer);
+    if (res.e) call.reject(new Error(`${res.e.c}: ${res.e.m}`));
+    else call.resolve(res.r);
+  }
+
+  private onClose(): void {
+    if (this.closed) return;
+    this.closed = true;
+    for (const call of this.pending.values()) {
+      clearTimeout(call.timer);
+      call.reject(new Error('connection closed'));
+    }
+    this.pending.clear();
+  }
+
+  /** Send a request and wait up to `deadlineMs` for a reply. Rejects on timeout or close. */
+  call<T = unknown>(method: string, payload: unknown, deadlineMs: number): Promise<T> {
+    const i = this.nextId++;
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(i);
+        reject(new Error(`timeout waiting for "${method}"`));
+      }, deadlineMs);
+      this.pending.set(i, { resolve: resolve as (v: unknown) => void, reject, timer });
+      this.write({ i, m: method, p: payload });
+    });
+  }
+
+  /** Fire-and-forget. Returns false when the socket is applying backpressure (caller must queue, not retry). */
+  sendNote(note: Note): boolean {
+    return this.write(note);
+  }
+
+  destroy(): void {
+    this.onClose();
+    this.socket.destroy();
+  }
+
+  private write(frame: Frame): boolean {
+    if (this.closed) return false;
+    return this.socket.write(encodeFrame(frame));
+  }
+}

--- a/backend/src/modules/plugins/supervisor/spawn-plan.spec.ts
+++ b/backend/src/modules/plugins/supervisor/spawn-plan.spec.ts
@@ -1,0 +1,113 @@
+import { PLUGIN_API_VERSION } from '../../../common/plugin-contract';
+import { buildSpawnPlan, resolvePermissionFlag, shouldDropPrivileges } from './spawn-plan';
+
+const EXPECTED_ENV_KEYS = [
+  'PATH',
+  'NODE_ENV',
+  'TZ',
+  'HOME',
+  'FLIKS_CORE_SOCK',
+  'FLIKS_PLUGIN_SOCK',
+  'FLIKS_PLUGIN_TOKEN',
+  'FLIKS_PLUGIN_ID',
+  'FLIKS_API_VERSION',
+  'FLIKS_DB_URL',
+].sort();
+
+describe('resolvePermissionFlag', () => {
+  it('resolves to a flag this node build actually accepts', () => {
+    expect(['--permission', '--experimental-permission']).toContain(resolvePermissionFlag());
+  });
+});
+
+describe('shouldDropPrivileges', () => {
+  it('is false on win32 regardless of uid', () => {
+    expect(shouldDropPrivileges('win32', () => 0)).toBe(false);
+  });
+  it('is false when not root', () => {
+    expect(shouldDropPrivileges('linux', () => 1000)).toBe(false);
+  });
+  it('is true only for uid 0 on a non-Windows platform', () => {
+    expect(shouldDropPrivileges('linux', () => 0)).toBe(true);
+  });
+  it('is false when getuid is unavailable (Windows has none)', () => {
+    expect(shouldDropPrivileges('linux', undefined)).toBe(false);
+  });
+});
+
+describe('buildSpawnPlan', () => {
+  const baseInput = {
+    dir: '/tmp/plugin-x',
+    memoryMb: 256,
+    coreSockPath: '/tmp/plugin-x.core.sock',
+    pluginSockPath: '/tmp/plugin-x.plugin.sock',
+    token: 'the-token',
+    pluginId: 'demo',
+  };
+
+  it('never spreads process.env — the env is exactly the allowlist plus FLIKS_CFG_* re-keys', () => {
+    process.env.PLUGIN_SUPERVISOR_TEST_LEAK = 'should-not-appear';
+    const plan = buildSpawnPlan(baseInput);
+    expect(Object.keys(plan.env).sort()).toEqual(EXPECTED_ENV_KEYS);
+    expect(plan.env.PLUGIN_SUPERVISOR_TEST_LEAK).toBeUndefined();
+    delete process.env.PLUGIN_SUPERVISOR_TEST_LEAK;
+  });
+
+  it('carries the exact spawn values', () => {
+    const plan = buildSpawnPlan(baseInput);
+    expect(plan.env.FLIKS_CORE_SOCK).toBe(baseInput.coreSockPath);
+    expect(plan.env.FLIKS_PLUGIN_SOCK).toBe(baseInput.pluginSockPath);
+    expect(plan.env.FLIKS_PLUGIN_TOKEN).toBe(baseInput.token);
+    expect(plan.env.FLIKS_PLUGIN_ID).toBe(baseInput.pluginId);
+    expect(plan.env.FLIKS_API_VERSION).toBe(String(PLUGIN_API_VERSION));
+    expect(plan.env.HOME).toBe(`${baseInput.dir}/data`);
+    expect(plan.env.NODE_ENV).toBe('production');
+  });
+
+  it('re-keys plugin.<id>.* config into FLIKS_CFG_*', () => {
+    const plan = buildSpawnPlan({
+      ...baseInput,
+      config: { 'plugin.demo.minSeeders': '5', 'plugin.demo.some-key': 'v', unrelated: 'kept-as-is' },
+    });
+    expect(plan.env.FLIKS_CFG_MINSEEDERS).toBe('5');
+    expect(plan.env.FLIKS_CFG_SOME_KEY).toBe('v');
+    expect(plan.env.FLIKS_CFG_UNRELATED).toBe('kept-as-is');
+  });
+
+  it('builds the node argv verbatim from the plan', () => {
+    const plan = buildSpawnPlan(baseInput);
+    expect(plan.expectedCmdline).toEqual([
+      process.execPath,
+      resolvePermissionFlag(),
+      `--allow-fs-read=${baseInput.dir}`,
+      `--allow-fs-write=${baseInput.dir}/data`,
+      `--max-old-space-size=${baseInput.memoryMb}`,
+      '--disable-proto=delete',
+      `${baseInput.dir}/plugin.js`,
+    ]);
+  });
+
+  it('wraps with setpriv on Linux, execs the node argv unwrapped elsewhere', () => {
+    const plan = buildSpawnPlan(baseInput);
+    if (process.platform === 'linux') {
+      expect(plan.command).toBe('setpriv');
+      expect(plan.args.slice(0, 2)).toEqual(['--no-new-privs', '--']);
+      expect(plan.args.slice(2)).toEqual(plan.expectedCmdline);
+    } else {
+      expect(plan.command).toBe(process.execPath);
+      expect(plan.args).toEqual(plan.expectedCmdline.slice(1));
+    }
+  });
+
+  it('does not set uid/gid when not root', () => {
+    const plan = buildSpawnPlan(baseInput);
+    expect(plan.options.uid).toBeUndefined();
+    expect(plan.options.gid).toBeUndefined();
+  });
+
+  it('cwd is the plugin data dir, stdio never carries the RPC channel', () => {
+    const plan = buildSpawnPlan(baseInput);
+    expect(plan.options.cwd).toBe(`${baseInput.dir}/data`);
+    expect(plan.options.stdio).toEqual(['ignore', 'pipe', 'pipe']);
+  });
+});

--- a/backend/src/modules/plugins/supervisor/spawn-plan.ts
+++ b/backend/src/modules/plugins/supervisor/spawn-plan.ts
@@ -1,0 +1,103 @@
+import { spawnSync, type SpawnOptions } from 'child_process';
+import { PLUGIN_API_VERSION } from '../../../common/plugin-contract';
+
+let cachedPermissionFlag: string | null = null;
+
+/**
+ * `--permission` is the plan's flag (stable on the NodeSource 24 this server
+ * runs); older Nodes need `--experimental-permission`. Probed once and cached.
+ */
+export function resolvePermissionFlag(): string {
+  if (cachedPermissionFlag) return cachedPermissionFlag;
+  const probe = spawnSync(process.execPath, ['--permission', '-e', '0']);
+  cachedPermissionFlag = probe.status === 0 ? '--permission' : '--experimental-permission';
+  return cachedPermissionFlag;
+}
+
+/** Root is an opportunistic bonus (Decision 25) — the drop only happens when it's true. */
+export function shouldDropPrivileges(platform: NodeJS.Platform, getuid?: () => number): boolean {
+  return platform !== 'win32' && typeof getuid === 'function' && getuid() === 0;
+}
+
+export interface SpawnPlanInput {
+  dir: string;
+  memoryMb: number;
+  coreSockPath: string;
+  pluginSockPath: string;
+  token: string;
+  pluginId: string;
+  dbUrl?: string;
+  /** `plugin.<id>.*` admin settings, re-keyed to `FLIKS_CFG_*` env vars. */
+  config?: Record<string, string>;
+}
+
+export interface SpawnPlan {
+  /** What is actually exec'd — `setpriv` on Linux, wrapping the node invocation below. */
+  command: string;
+  args: string[];
+  /** The node-level identity the kernel reports via cmdline once setpriv (if any) has exec'd into it. */
+  expectedCmdline: string[];
+  env: NodeJS.ProcessEnv;
+  options: SpawnOptions;
+}
+
+function reKeyConfig(pluginId: string, config: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  const prefix = `plugin.${pluginId}.`;
+  for (const [key, value] of Object.entries(config)) {
+    const suffix = key.startsWith(prefix) ? key.slice(prefix.length) : key;
+    out[`FLIKS_CFG_${suffix.toUpperCase().replace(/[^A-Z0-9_]/g, '_')}`] = value;
+  }
+  return out;
+}
+
+/** Builds the exact argv/env from "The spawn call and the supervisor" — never `...process.env`. */
+export function buildSpawnPlan(input: SpawnPlanInput): SpawnPlan {
+  const homeDir = `${input.dir}/data`;
+  const nodeArgv = [
+    resolvePermissionFlag(),
+    `--allow-fs-read=${input.dir}`,
+    `--allow-fs-write=${homeDir}`,
+    `--max-old-space-size=${input.memoryMb}`,
+    '--disable-proto=delete',
+    `${input.dir}/plugin.js`,
+  ];
+
+  const env: NodeJS.ProcessEnv = {
+    PATH: '/usr/local/bin:/usr/bin:/bin',
+    NODE_ENV: 'production',
+    TZ: process.env.TZ ?? 'UTC',
+    HOME: homeDir,
+    FLIKS_CORE_SOCK: input.coreSockPath,
+    FLIKS_PLUGIN_SOCK: input.pluginSockPath,
+    FLIKS_PLUGIN_TOKEN: input.token,
+    FLIKS_PLUGIN_ID: input.pluginId,
+    FLIKS_API_VERSION: String(PLUGIN_API_VERSION),
+    FLIKS_DB_URL: input.dbUrl ?? '',
+    ...reKeyConfig(input.pluginId, input.config ?? {}),
+  };
+
+  const root = shouldDropPrivileges(process.platform, process.getuid?.bind(process));
+  const options: SpawnOptions = {
+    cwd: homeDir,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: false,
+    windowsHide: true,
+    env,
+    ...(root ? { uid: 65534, gid: 65534 } : {}),
+  };
+
+  const expectedCmdline = [process.execPath, ...nodeArgv];
+  // setpriv execs into the target in place (same pid, cmdline becomes the node
+  // invocation) — free on Linux, closes setuid escalation, works unprivileged.
+  if (process.platform === 'linux') {
+    return {
+      command: 'setpriv',
+      args: ['--no-new-privs', '--', process.execPath, ...nodeArgv],
+      expectedCmdline,
+      env,
+      options,
+    };
+  }
+  return { command: process.execPath, args: nodeArgv, expectedCmdline, env, options };
+}

--- a/backend/src/modules/plugins/supervisor/supervisor-test-helpers.ts
+++ b/backend/src/modules/plugins/supervisor/supervisor-test-helpers.ts
@@ -1,0 +1,63 @@
+import { mkdtempSync, copyFileSync, mkdirSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { LogBufferService } from '../../scheduler/log-buffer.service';
+import type { PluginSupervisor, SupervisorState } from './plugin-supervisor';
+
+/** Not a `.spec.ts` — shared helpers for the supervisor test suite, never run as a suite itself. */
+
+const FIXTURE_SOURCE = join(__dirname, '__fixtures__/fixture-plugin.js');
+
+/** A fresh `dir` with the real fixture plugin at `plugin.js` and its mode file next to it. */
+export function makeFixtureDir(mode: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'plugin-sup-dir-'));
+  mkdirSync(join(dir, 'data'), { recursive: true });
+  copyFileSync(FIXTURE_SOURCE, join(dir, 'plugin.js'));
+  writeFileSync(join(dir, 'FIXTURE_MODE'), mode);
+  return dir;
+}
+
+export function makeRuntimeDir(): string {
+  return mkdtempSync(join(tmpdir(), 'plugin-sup-rt-'));
+}
+
+export function newLogBuffer(): LogBufferService {
+  return new LogBufferService();
+}
+
+/** Resolves the next time `sup` reaches `target`; rejects (real timer) if it never does. */
+export function waitForState(sup: PluginSupervisor, target: SupervisorState, timeoutMs = 3_000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (sup.getState() === target) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      off();
+      reject(new Error(`timed out waiting for state "${target}" (currently "${sup.getState()}")`));
+    }, timeoutMs);
+    const off = sup.onStateChange((s) => {
+      if (s === target) {
+        clearTimeout(timer);
+        off();
+        resolve();
+      }
+    });
+  });
+}
+
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** `crashed` fires on the kill decision, not the OS's exit confirmation — polls rather than a fixed delay. */
+export async function waitForExitSignal(
+  sup: { getLastExitSignal(): NodeJS.Signals | null },
+  timeoutMs = 2_000,
+): Promise<NodeJS.Signals | null> {
+  const start = Date.now();
+  while (sup.getLastExitSignal() === null && Date.now() - start < timeoutMs) {
+    await delay(5);
+  }
+  return sup.getLastExitSignal();
+}

--- a/backend/src/modules/plugins/supervisor/wire.spec.ts
+++ b/backend/src/modules/plugins/supervisor/wire.spec.ts
@@ -1,0 +1,51 @@
+import { MAX_FRAME_BYTES } from '../../../common/plugin-contract';
+import { encodeFrame, FrameReader, parseFrame, ProtocolViolationError } from './wire';
+
+describe('encodeFrame / parseFrame', () => {
+  it('round-trips a Req through one line', () => {
+    const line = encodeFrame({ i: 1, m: 'health', p: {} }).toString('utf8');
+    expect(line.endsWith('\n')).toBe(true);
+    expect(parseFrame(line.slice(0, -1))).toEqual({ i: 1, m: 'health', p: {} });
+  });
+
+  it('rejects a malformed line', () => {
+    expect(() => parseFrame('not json')).toThrow(ProtocolViolationError);
+  });
+
+  it('rejects a line that parses to a non-object', () => {
+    expect(() => parseFrame('42')).toThrow(ProtocolViolationError);
+    expect(() => parseFrame('null')).toThrow(ProtocolViolationError);
+  });
+});
+
+describe('FrameReader', () => {
+  it('buffers a partial line across two chunks', () => {
+    const reader = new FrameReader();
+    expect(reader.push(Buffer.from('{"i":1,"m":"a"'))).toEqual([]);
+    expect(reader.push(Buffer.from('}\n'))).toEqual(['{"i":1,"m":"a"}']);
+  });
+
+  it('emits multiple complete lines from one chunk', () => {
+    const reader = new FrameReader();
+    const lines = reader.push(Buffer.from('{"a":1}\n{"a":2}\n'));
+    expect(lines).toEqual(['{"a":1}', '{"a":2}']);
+  });
+
+  it('throws when a single already-terminated line exceeds the frame limit', () => {
+    const reader = new FrameReader();
+    const huge = Buffer.concat([Buffer.alloc(MAX_FRAME_BYTES + 1, 0x78), Buffer.from('\n')]);
+    expect(() => reader.push(huge)).toThrow(ProtocolViolationError);
+  });
+
+  it('throws once the unterminated remainder exceeds the frame limit, without waiting for a newline', () => {
+    const reader = new FrameReader();
+    const chunk = Buffer.alloc(MAX_FRAME_BYTES + 1, 0x78);
+    expect(() => reader.push(chunk)).toThrow(ProtocolViolationError);
+  });
+
+  it('does not throw for a line sitting right at the limit', () => {
+    const reader = new FrameReader();
+    const atLimit = Buffer.concat([Buffer.alloc(MAX_FRAME_BYTES, 0x78), Buffer.from('\n')]);
+    expect(() => reader.push(atLimit)).not.toThrow();
+  });
+});

--- a/backend/src/modules/plugins/supervisor/wire.ts
+++ b/backend/src/modules/plugins/supervisor/wire.ts
@@ -1,0 +1,58 @@
+import { MAX_FRAME_BYTES, type Req, type Res, type Note } from '../../../common/plugin-contract';
+
+export type Frame = Req | Res | Note;
+
+/** Raised on any wire-level breach: oversize frame or unparsable line. Fatal to the connection. */
+export class ProtocolViolationError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = 'ProtocolViolationError';
+  }
+}
+
+/** One JSON object per line. */
+export function encodeFrame(frame: Frame): Buffer {
+  return Buffer.from(JSON.stringify(frame) + '\n', 'utf8');
+}
+
+/**
+ * Buffers raw bytes into newline-delimited lines; a partial line waits for
+ * more data. Any line, complete or still growing, past MAX_FRAME_BYTES throws — bounded even before a newline arrives.
+ */
+export class FrameReader {
+  private pending: Buffer = Buffer.alloc(0);
+
+  push(chunk: Buffer): string[] {
+    const combined = this.pending.length > 0 ? Buffer.concat([this.pending, chunk]) : chunk;
+    const lines: string[] = [];
+    let start = 0;
+    while (true) {
+      const nl = combined.indexOf(0x0a, start);
+      if (nl === -1) break;
+      if (nl - start > MAX_FRAME_BYTES) {
+        throw new ProtocolViolationError(`frame exceeds ${MAX_FRAME_BYTES} bytes`);
+      }
+      lines.push(combined.subarray(start, nl).toString('utf8'));
+      start = nl + 1;
+    }
+    const rest = combined.subarray(start);
+    if (rest.length > MAX_FRAME_BYTES) {
+      throw new ProtocolViolationError(`frame exceeds ${MAX_FRAME_BYTES} bytes`);
+    }
+    this.pending = rest;
+    return lines;
+  }
+}
+
+export function parseFrame(line: string): Frame {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    throw new ProtocolViolationError('malformed JSON line');
+  }
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new ProtocolViolationError('frame is not a JSON object');
+  }
+  return parsed as Frame;
+}


### PR DESCRIPTION
Closes #913. The plan calls this the riskiest new infrastructure in the project, so the interesting part is not the code but what the tests actually exercise.

## Tested against a real child, not a mock

A fixture plugin speaks the real protocol over a real unix socket, switchable into eleven behaviours: correct handshake, wrong token, never answers, never connects, exits immediately, stops answering health after N, crashes after N ms, ignores `SIGTERM`, never drains its socket, writes an oversize frame, writes malformed JSON.

**No test fakes the process or the socket**, and none uses `jest.useFakeTimers()` — mixing fake timers with real child-process I/O is a known flake. The long durations are instead scaled by constructor-injected options (the 120 s ready-reset runs at 300 ms, the 10-minute breaker window at 2 s), and the plan's literal figures are asserted separately as data in one place, so a drift fails a test rather than quietly changing a restart interval.

That approach caught a real leak during development: a spec's `net.createServer` was never closed and hung jest for the whole directory. `--detectOpenHandles` pointed at it.

## What it does

Newline-delimited JSON over two unix sockets core owns at mode `0600`, 4 MiB per frame. An oversize or malformed line is a **protocol violation that kills the child**, never an exception that reaches core — two tests prove the supervisor lands in `crashed` while the test process stays alive.

The state machine and every figure come from `### The spawn call and the supervisor`: 10 s handshake, health every 15 s with a 3 s deadline, two misses → `degraded`, four → restart, backoff 1/2/4/8/16/30 s, and the counter resetting **only** after 120 s continuously ready — otherwise a plugin dying at 118 s restarts forever at 1 s. Six crashes in 10 minutes → `failed` with the last 4 KiB of stderr, manual re-enable only.

The child's environment is a fixed allowlist built from an empty object. A spec poisons `process.env` and asserts nothing leaks through. The single read of the server's own environment is `TZ`, which is what the plan specifies. Privileges drop to `nobody` only when the platform is not Windows *and* we are actually uid 0, and on Linux the exec goes through `setpriv --no-new-privs`.

Events queue through a 64-entry ring that drops the oldest and counts it, driven in test by 3000 real events at a peer that never reads — real socket backpressure, no timer involved.

Shutdown walks `shutdown` RPC → SIGTERM → SIGKILL. The cooperative test asserts the elapsed time stays under the RPC deadline; the uncooperative one asserts it exceeds deadline plus grace and that the exit signal was `SIGKILL`, which is only reachable because the fixture swallows `SIGTERM`. Both assert the socket files are gone afterwards.

## Reviewed by hand, since this spawns processes

I checked the environment allowlist, the privilege-drop condition and both `--allow-fs-*` flags against the plan line by line, and confirmed the suite leaves **nothing** behind: no child matching `plugin.js`, no `.sock` under `/tmp`, no temp directories, measured before and after.

**One change from the delivered branch:** sockets and pid files sat in the directory that also holds `installed/` and `import-staging/`. They now default to a `fliks-rt` subdirectory — the name the plan gives it — so a sweep of installed files can never unlink a live channel. The option stays overridable for tests.

## Deliberately unwired

Nothing spawns. The registry still refuses the `process` tier until 3.4 provisions the database and 3.5 lands the proxy, and the plan sequences it that way on purpose: phase 9 gives the supervisor a first tenant whose failure costs nothing, rather than making its first tenant the thing that downloads.

`tsc` 0, suite **108 suites / 1034 tests** (+46 here).

Known gaps, stated rather than buried: the orphan sweep matches cmdlines through `/proc`, so on macOS and Windows — where the plan says it matters most, since Docker's PID namespace already handles it — it safely does nothing instead of killing blind. And `--permission` is probed once with a fallback to `--experimental-permission`, because the flag is stable on the production Node 24 but not on this machine's Node 20.
