### PR TITLE
feat(plugins): provision a postgres role and schema per process plugin

### DIFF
--- a/backend/src/common/constants/plugin-flags.ts
+++ b/backend/src/common/constants/plugin-flags.ts
@@ -9,3 +9,14 @@ export const FLIKS_PLUGINS_DISABLED_ENV = 'FLIKS_PLUGINS_DISABLED';
 export function arePluginsDisabled(): boolean {
   return process.env[FLIKS_PLUGINS_DISABLED_ENV] === '1';
 }
+
+/** The only way a `process` plugin may ship unsigned — for local development against the production signing key. */
+export const FLIKS_UNSIGNED_PLUGINS_ENV = 'FLIKS_UNSIGNED_PLUGINS';
+
+/** Comma-separated `FLIKS_UNSIGNED_PLUGINS` ids, trimmed, empties dropped. */
+export function unsignedProcessAllowlist(): string[] {
+  return (process.env[FLIKS_UNSIGNED_PLUGINS_ENV] ?? '')
+    .split(',')
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0);
+}

--- a/backend/src/modules/plugins/archive/limits.ts
+++ b/backend/src/modules/plugins/archive/limits.ts
@@ -24,6 +24,12 @@ export const MAX_SIGNATURE_BYTES = 256;
 export const MAX_PLUGIN_JS_BYTES = 8 * 1024 * 1024;
 export const MAX_LOGO_BYTES = 64 * 1024;
 
+/** Mirrors the published catalog's `schema/plugin.schema.v0.json` — core must not be laxer than the catalog. */
+export const PLUGIN_ID_PATTERN = /^[a-z][a-z0-9]*(\.[a-z0-9]+)*$/;
+
+/** 63 (Postgres NAMEDATALEN) minus `plugin_`, past which two ids collide onto one schema. */
+export const MAX_PLUGIN_ID_LENGTH = 56;
+
 /** Raw byte length of an Ed25519 signature — fixed regardless of message size. */
 export const ED25519_SIGNATURE_LENGTH = 64;
 

--- a/backend/src/modules/plugins/archive/refusal-codes.ts
+++ b/backend/src/modules/plugins/archive/refusal-codes.ts
@@ -29,6 +29,10 @@ export type PluginRefusalCode =
   | 'PLUGIN_FILE_SET_MISMATCH'
   | 'PLUGIN_TIER_VIOLATION'
   | 'PLUGIN_BAD_MANIFEST'
+  /** `id`/`version` are SQL identifiers and filesystem path segments downstream —
+   *  validated once here so every later consumer can trust them unchecked. */
+  | 'PLUGIN_BAD_ID'
+  | 'PLUGIN_BAD_VERSION'
   | 'PLUGIN_BAD_LOGO'
   /** `data`-tier manifest field bans (see `PluginManifestBase` deltas) — each
    *  names the process-only field it caught, so a refusal is attributable. */

--- a/backend/src/modules/plugins/archive/test-manifests.ts
+++ b/backend/src/modules/plugins/archive/test-manifests.ts
@@ -3,7 +3,7 @@ import type { DataPluginManifest, ProcessPluginManifest } from '../../../common/
 /** Minimal, structurally-valid `data` manifest — spread `overrides` to break one field at a time. */
 export function minimalDataManifest(overrides: Partial<DataPluginManifest> = {}): DataPluginManifest {
   return {
-    id: 'fliks.test-plugin',
+    id: 'fliks.testplugin',
     pluginApi: 0,
     name: 'Test plugin',
     version: '1.0.0',
@@ -23,7 +23,7 @@ export function minimalProcessManifest(
   overrides: Partial<ProcessPluginManifest> = {},
 ): ProcessPluginManifest {
   return {
-    id: 'fliks.test-process-plugin',
+    id: 'fliks.testprocessplugin',
     pluginApi: 0,
     name: 'Test process plugin',
     version: '1.0.0',

--- a/backend/src/modules/plugins/archive/zip-inspector.spec.ts
+++ b/backend/src/modules/plugins/archive/zip-inspector.spec.ts
@@ -307,6 +307,24 @@ describe('inspect() — guards', () => {
     await expectRefusal(buffer, 'PLUGIN_BAD_SIGNATURE');
   });
 
+  it('PLUGIN_BAD_ID: an id the published catalog schema would also refuse', async () => {
+    const manifest = minimalDataManifest({ id: 'fliks.Test-Plugin' });
+    const buffer = buildZip([{ name: 'plugin.json', content: Buffer.from(JSON.stringify(manifest)) }]);
+    await expectRefusal(buffer, 'PLUGIN_BAD_ID');
+  });
+
+  it('PLUGIN_BAD_ID: an id past the 56-char cap', async () => {
+    const manifest = minimalDataManifest({ id: `fliks.${'a'.repeat(56)}` });
+    const buffer = buildZip([{ name: 'plugin.json', content: Buffer.from(JSON.stringify(manifest)) }]);
+    await expectRefusal(buffer, 'PLUGIN_BAD_ID');
+  });
+
+  it('PLUGIN_BAD_VERSION: a version that is not valid semver', async () => {
+    const manifest = minimalDataManifest({ version: 'not-a-version' });
+    const buffer = buildZip([{ name: 'plugin.json', content: Buffer.from(JSON.stringify(manifest)) }]);
+    await expectRefusal(buffer, 'PLUGIN_BAD_VERSION');
+  });
+
   it('PLUGIN_UNSIGNED: a process-tier archive with no plugin.json.sig entry', async () => {
     const pluginJs = Buffer.from('module.exports = {};');
     const logo = pngLogo();
@@ -317,6 +335,41 @@ describe('inspect() — guards', () => {
       { name: 'logo.png', content: logo },
     ]);
     await expectRefusal(buffer, 'PLUGIN_UNSIGNED');
+  });
+
+  it('unsignedProcessAllowlist: an unsigned process archive is accepted when its id is on the list', async () => {
+    const pluginJs = Buffer.from('module.exports = {};');
+    const logo = pngLogo();
+    const manifest = minimalProcessManifest(
+      { 'plugin.js': sha256Hex(pluginJs), 'logo.png': sha256Hex(logo) },
+      { id: 'fliks.allowedunsigned' },
+    );
+    const buffer = buildZip([
+      { name: 'plugin.json', content: Buffer.from(JSON.stringify(manifest)) },
+      { name: 'plugin.js', content: pluginJs },
+      { name: 'logo.png', content: logo },
+    ]);
+
+    const result = await inspect(buffer, { unsignedProcessAllowlist: ['fliks.allowedunsigned'] });
+    expect(result.ok).toBe(true);
+  });
+
+  it('unsignedProcessAllowlist: an unsigned process archive is still refused when its id is not on the list', async () => {
+    const pluginJs = Buffer.from('module.exports = {};');
+    const logo = pngLogo();
+    const manifest = minimalProcessManifest(
+      { 'plugin.js': sha256Hex(pluginJs), 'logo.png': sha256Hex(logo) },
+      { id: 'fliks.notallowed' },
+    );
+    const buffer = buildZip([
+      { name: 'plugin.json', content: Buffer.from(JSON.stringify(manifest)) },
+      { name: 'plugin.js', content: pluginJs },
+      { name: 'logo.png', content: logo },
+    ]);
+
+    const result = await inspect(buffer, { unsignedProcessAllowlist: ['fliks.allowedunsigned'] });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('PLUGIN_UNSIGNED');
   });
 
   it('PLUGIN_TIER_VIOLATION: a data-tier archive carrying plugin.js', async () => {

--- a/backend/src/modules/plugins/archive/zip-inspector.ts
+++ b/backend/src/modules/plugins/archive/zip-inspector.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'crypto';
+import * as semver from 'semver';
 import * as yauzl from 'yauzl';
 import type { PluginKind, PluginManifest } from '../../../common/plugin-contract';
 import { parseManifest } from './manifest-parser';
@@ -10,7 +11,9 @@ import {
   MAX_ARCHIVE_COMPRESSED_BYTES,
   MAX_ARCHIVE_ENTRIES,
   MAX_ENTRY_RATIO,
+  MAX_PLUGIN_ID_LENGTH,
   MAX_TOTAL_UNCOMPRESSED_BYTES,
+  PLUGIN_ID_PATTERN,
   PROCESS_ONLY_ENTRY_NAMES,
   maxUncompressedBytesFor,
 } from './limits';
@@ -221,6 +224,12 @@ export async function inspect(buffer: Buffer, options: InspectOptions = {}): Pro
   const manifest = parseManifest(manifestBytes);
   if (!manifest) {
     return refuse('PLUGIN_BAD_MANIFEST', 'plugin.json failed structural validation');
+  }
+  if (manifest.id.length > MAX_PLUGIN_ID_LENGTH || !PLUGIN_ID_PATTERN.test(manifest.id)) {
+    return refuse('PLUGIN_BAD_ID', `id ${JSON.stringify(manifest.id)} is not a legal plugin id`);
+  }
+  if (semver.valid(manifest.version) === null) {
+    return refuse('PLUGIN_BAD_VERSION', `version ${JSON.stringify(manifest.version)} is not valid semver`);
   }
   const hasPluginJs = entryBuffers.has('plugin.js');
   if (manifest.kind === 'data' && hasPluginJs) {

--- a/backend/src/modules/plugins/plugin-database.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-database.service.spec.ts
@@ -1,0 +1,368 @@
+import type { ConfigService } from '@nestjs/config';
+import type { DataSource } from 'typeorm';
+import { PluginDatabaseService, pluginDbIdentifier } from './plugin-database.service';
+import { PluginInstallException } from './plugin-install.exception';
+import { minimalProcessManifest } from './archive/test-manifests';
+
+interface Recorder {
+  events: string[];
+  queries: { sql: string; parameters: unknown[] }[];
+}
+
+interface Fixtures {
+  roleExists?: boolean;
+  schemaOwner?: string;
+  /** Names the fake probe resolves to a `public` `BASE TABLE` carrying an `id` column. */
+  baseTables?: readonly string[];
+}
+
+function makeRecorder(): Recorder {
+  return { events: [], queries: [] };
+}
+
+/** Routes each query by a substring of its SQL — enough to answer the three probes `provision`/`rotatePassword`/`deprovision` run. */
+function respondFor(fixtures: Fixtures) {
+  return (sql: string, parameters: unknown[]): unknown[] => {
+    if (sql.includes('FROM pg_roles')) return fixtures.roleExists ? [{ x: 1 }] : [];
+    if (sql.includes('FROM pg_namespace')) return fixtures.schemaOwner ? [{ owner: fixtures.schemaOwner }] : [];
+    if (sql.includes('information_schema')) {
+      const table = parameters[0] as string;
+      return fixtures.baseTables?.includes(table) ? [{ table_type: 'BASE TABLE' }] : [];
+    }
+    return [];
+  };
+}
+
+function fakeQueryRunner(
+  recorder: Recorder,
+  respond: (sql: string, parameters: unknown[]) => unknown[],
+  failCommit = false,
+) {
+  // `isTransactionActive` is tracked the way the real runner tracks it: rolling
+  // back once it is false throws, which is what the service guards against.
+  const runner = {
+    isTransactionActive: false,
+    connect: jest.fn(async () => {
+      recorder.events.push('connect');
+    }),
+    startTransaction: jest.fn(async () => {
+      recorder.events.push('startTransaction');
+      runner.isTransactionActive = true;
+    }),
+    commitTransaction: jest.fn(async () => {
+      recorder.events.push('commitTransaction');
+      runner.isTransactionActive = false;
+      if (failCommit) throw new Error('COMMIT failed at the server');
+    }),
+    rollbackTransaction: jest.fn(async () => {
+      recorder.events.push('rollbackTransaction');
+      if (!runner.isTransactionActive) throw new Error('TransactionNotStartedError');
+      runner.isTransactionActive = false;
+    }),
+    release: jest.fn(async () => {
+      recorder.events.push('release');
+    }),
+    query: jest.fn(async (sql: string, parameters: unknown[] = []) => {
+      recorder.events.push('query');
+      recorder.queries.push({ sql, parameters });
+      return respond(sql, parameters);
+    }),
+  };
+  return runner;
+}
+
+function fakeDataSource(recorder: Recorder, fixtures: Fixtures = {}, failCommit = false) {
+  const respond = respondFor(fixtures);
+  return { createQueryRunner: jest.fn(() => fakeQueryRunner(recorder, respond, failCommit)) };
+}
+
+function fakeConfig(overrides: Record<string, unknown> = {}) {
+  return { get: jest.fn((key: string, fallback?: unknown) => (key in overrides ? overrides[key] : fallback)) };
+}
+
+function service(dataSource: ReturnType<typeof fakeDataSource>, config: ReturnType<typeof fakeConfig> = fakeConfig()) {
+  return new PluginDatabaseService(dataSource as unknown as DataSource, config as unknown as ConfigService);
+}
+
+/** Collapses incidental whitespace so a multi-line template literal compares like the single statement it is. */
+function normalizeSql(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim();
+}
+
+function hasBareSemicolon(sql: string): boolean {
+  return sql.replace(/'[^']*'/g, "''").includes(';');
+}
+
+describe('pluginDbIdentifier', () => {
+  it('maps a dotted id to the role/schema name', () => {
+    expect(pluginDbIdentifier('fliks.download')).toBe('plugin_fliks_download');
+    expect(pluginDbIdentifier('fliks')).toBe('plugin_fliks');
+  });
+
+  it('accepts the longest id that still fits an untruncated identifier', () => {
+    // Postgres truncates past 63 bytes, so 56 is the last length two ids cannot collide at.
+    expect(pluginDbIdentifier('a'.repeat(56))).toHaveLength(63);
+  });
+
+  const badIds = [
+    'fliks.download; DROP TABLE media',
+    'fliks."; DROP',
+    '"fliks"',
+    '../../etc/passwd',
+    'fliks..download',
+    '.fliks',
+    'fliks.',
+    'Fliks.Download',
+    'fliks_download',
+    'fliks-download',
+    '1fliks',
+    '',
+    'a'.repeat(57),
+    'fliks.download\nDROP',
+    'fliks.dow nload',
+    'flіks.download', // Cyrillic 'і' (U+0456), a homoglyph for latin 'i'
+  ];
+
+  it.each(badIds)('rejects %j — and provision() never touches the database for it', async (id) => {
+    expect(() => pluginDbIdentifier(id)).toThrow();
+
+    const recorder = makeRecorder();
+    const dataSource = fakeDataSource(recorder);
+    const manifest = minimalProcessManifest({}, { id, database: { schema: true, coreRefs: [] } });
+
+    await expect(service(dataSource).provision(manifest)).rejects.toThrow(PluginInstallException);
+    expect(recorder.queries).toHaveLength(0);
+    expect(dataSource.createQueryRunner).not.toHaveBeenCalled();
+  });
+});
+
+describe('PluginDatabaseService.provision', () => {
+  it('no-ops when database.schema is false and coreRefs is empty', async () => {
+    const recorder = makeRecorder();
+    const dataSource = fakeDataSource(recorder);
+    const manifest = minimalProcessManifest({}, { database: { schema: false, coreRefs: [] } });
+
+    await expect(service(dataSource).provision(manifest)).resolves.toBeUndefined();
+    expect(dataSource.createQueryRunner).not.toHaveBeenCalled();
+  });
+
+  it('throws when database.schema is false but coreRefs is declared — nothing to grant them into', async () => {
+    const recorder = makeRecorder();
+    const dataSource = fakeDataSource(recorder);
+    const manifest = minimalProcessManifest({}, { database: { schema: false, coreRefs: ['media'] } });
+
+    await expect(service(dataSource).provision(manifest)).rejects.toThrow(PluginInstallException);
+    expect(dataSource.createQueryRunner).not.toHaveBeenCalled();
+  });
+
+  it('emits the exact statement sequence for two coreRefs: probes, role, schema, owner check, usage, revoke, then the grants', async () => {
+    const recorder = makeRecorder();
+    const dataSource = fakeDataSource(recorder, {
+      roleExists: false,
+      schemaOwner: 'plugin_fliks_download',
+      baseTables: ['media', 'episodes'],
+    });
+    const manifest = minimalProcessManifest({}, {
+      id: 'fliks.download',
+      database: { schema: true, coreRefs: ['media', 'episodes'] },
+    });
+
+    await service(dataSource).provision(manifest);
+
+    expect(recorder.events).toEqual([
+      'connect',
+      'startTransaction',
+      'query',
+      'query',
+      'query',
+      'query',
+      'query',
+      'query',
+      'query',
+      'query',
+      'query',
+      'query',
+      'commitTransaction',
+      'release',
+    ]);
+    expect(recorder.queries).toHaveLength(10);
+    const sql = recorder.queries.map((q) => normalizeSql(q.sql));
+    const probe =
+      "SELECT t.table_type FROM information_schema.columns c JOIN information_schema.tables t ON t.table_schema = c.table_schema AND t.table_name = c.table_name WHERE c.table_schema = 'public' AND c.table_name = $1 AND c.column_name = 'id'";
+    expect(sql[0]).toBe(probe);
+    expect(recorder.queries[0].parameters).toEqual(['media']);
+    expect(sql[1]).toBe(probe);
+    expect(recorder.queries[1].parameters).toEqual(['episodes']);
+    expect(sql[2]).toBe('SELECT 1 FROM pg_roles WHERE rolname = $1');
+    expect(recorder.queries[2].parameters).toEqual(['plugin_fliks_download']);
+    expect(sql[3]).toMatch(/^CREATE ROLE "plugin_fliks_download" LOGIN PASSWORD '[0-9a-f]{48}'$/);
+    expect(sql[4]).toBe('CREATE SCHEMA IF NOT EXISTS "plugin_fliks_download" AUTHORIZATION "plugin_fliks_download"');
+    expect(sql[5]).toBe('SELECT pg_get_userbyid(nspowner) AS owner FROM pg_namespace WHERE nspname = $1');
+    expect(recorder.queries[5].parameters).toEqual(['plugin_fliks_download']);
+    expect(sql[6]).toBe('GRANT USAGE ON SCHEMA public TO "plugin_fliks_download"');
+    expect(sql[7]).toBe('REVOKE REFERENCES ON ALL TABLES IN SCHEMA public FROM "plugin_fliks_download"');
+    expect(sql[8]).toBe('GRANT REFERENCES (id) ON public."media" TO "plugin_fliks_download"');
+    expect(sql[9]).toBe('GRANT REFERENCES (id) ON public."episodes" TO "plugin_fliks_download"');
+    // Positions 6/7 (usage/revoke) precede 8/9 (grants) in `recorder.queries`, which is push order == execution order.
+  });
+
+  it('skips CREATE ROLE when pg_roles already reports the role', async () => {
+    const recorder = makeRecorder();
+    const dataSource = fakeDataSource(recorder, { roleExists: true, schemaOwner: 'plugin_fliks_download', baseTables: [] });
+    const manifest = minimalProcessManifest({}, { id: 'fliks.download', database: { schema: true, coreRefs: [] } });
+
+    await service(dataSource).provision(manifest);
+
+    const sql = recorder.queries.map((q) => normalizeSql(q.sql));
+    expect(sql.some((s) => s.startsWith('CREATE ROLE'))).toBe(false);
+  });
+
+  it('throws, rolls back and grants nothing when the schema already exists owned by a different role', async () => {
+    const recorder = makeRecorder();
+    const dataSource = fakeDataSource(recorder, { roleExists: true, schemaOwner: 'someone_else', baseTables: [] });
+    const manifest = minimalProcessManifest({}, { id: 'fliks.ownertest', database: { schema: true, coreRefs: [] } });
+
+    await expect(service(dataSource).provision(manifest)).rejects.toThrow(PluginInstallException);
+
+    expect(recorder.events).toContain('rollbackTransaction');
+    expect(recorder.events).not.toContain('commitTransaction');
+    expect(recorder.queries.some((q) => /^GRANT/i.test(q.sql.trim()))).toBe(false);
+  });
+
+  it('reports the commit failure itself, not a second error from rolling back an ended transaction', async () => {
+    const recorder = makeRecorder();
+    const dataSource = fakeDataSource(
+      recorder,
+      { roleExists: true, schemaOwner: 'plugin_fliks_download', baseTables: [] },
+      true,
+    );
+    const manifest = minimalProcessManifest({}, { id: 'fliks.download', database: { schema: true, coreRefs: [] } });
+
+    await expect(service(dataSource).provision(manifest)).rejects.toThrow('COMMIT failed at the server');
+    expect(recorder.events).not.toContain('rollbackTransaction');
+    expect(recorder.events).toContain('release');
+  });
+
+  const BASE_TABLES = ['media'];
+  const coreRefCases: { name: string; coreRefs: string[]; rejectedAfterProbe: boolean }[] = [
+    { name: 'media; DROP TABLE users', coreRefs: ['media; DROP TABLE users'], rejectedAfterProbe: false },
+    { name: 'media"', coreRefs: ['media"'], rejectedAfterProbe: false },
+    { name: '"media"', coreRefs: ['"media"'], rejectedAfterProbe: false },
+    { name: 'public.media', coreRefs: ['public.media'], rejectedAfterProbe: false },
+    { name: 'pg_authid', coreRefs: ['pg_authid'], rejectedAfterProbe: true },
+    { name: 'information_schema.tables', coreRefs: ['information_schema.tables'], rejectedAfterProbe: false },
+    { name: 'MEDIA', coreRefs: ['MEDIA'], rejectedAfterProbe: false },
+    { name: 'does_not_exist', coreRefs: ['does_not_exist'], rejectedAfterProbe: true },
+    { name: '(empty string)', coreRefs: [''], rejectedAfterProbe: false },
+    { name: 'a'.repeat(64) + ' (64 chars)', coreRefs: ['a'.repeat(64)], rejectedAfterProbe: false },
+    { name: 'duplicate of a valid entry', coreRefs: ['media', 'media'], rejectedAfterProbe: false },
+    { name: 'table with no id column', coreRefs: ['profile_no_id'], rejectedAfterProbe: true },
+  ];
+
+  it.each(coreRefCases)('rejects coreRef case: $name', async ({ coreRefs, rejectedAfterProbe }) => {
+    const recorder = makeRecorder();
+    const dataSource = fakeDataSource(recorder, { roleExists: false, schemaOwner: 'plugin_fliks_coretest', baseTables: BASE_TABLES });
+    const manifest = minimalProcessManifest({}, { id: 'fliks.coretest', database: { schema: true, coreRefs } });
+
+    await expect(service(dataSource).provision(manifest)).rejects.toThrow(PluginInstallException);
+
+    if (rejectedAfterProbe) {
+      expect(recorder.queries.length).toBeGreaterThan(0);
+      expect(recorder.queries.some((q) => /^(GRANT|CREATE)/i.test(q.sql.trim()))).toBe(false);
+      expect(recorder.events).toContain('rollbackTransaction');
+      expect(recorder.events).not.toContain('commitTransaction');
+    } else {
+      expect(recorder.queries).toHaveLength(0);
+      expect(dataSource.createQueryRunner).not.toHaveBeenCalled();
+    }
+  });
+
+  it('every passing-case statement has no bare semicolon, and every DDL statement carries the expected quoted identifier', async () => {
+    const provisionRecorder = makeRecorder();
+    await service(
+      fakeDataSource(provisionRecorder, { roleExists: false, schemaOwner: 'plugin_fliks_download', baseTables: ['media', 'episodes'] }),
+    ).provision(minimalProcessManifest({}, { id: 'fliks.download', database: { schema: true, coreRefs: ['media', 'episodes'] } }));
+
+    const rotateRecorder = makeRecorder();
+    await service(fakeDataSource(rotateRecorder, { roleExists: true })).rotatePassword('fliks.download');
+
+    const deprovisionRecorder = makeRecorder();
+    await service(fakeDataSource(deprovisionRecorder, { roleExists: true })).deprovision('fliks.download');
+
+    const allSql = [...provisionRecorder.queries, ...rotateRecorder.queries, ...deprovisionRecorder.queries].map((q) => q.sql);
+    for (const sql of allSql) {
+      expect(hasBareSemicolon(sql)).toBe(false);
+    }
+    const ddl = allSql.filter((sql) => /^(CREATE|GRANT|REVOKE|ALTER|DROP)/i.test(sql.trim()));
+    expect(ddl.length).toBeGreaterThan(0);
+    for (const sql of ddl) {
+      expect(sql).toContain('"plugin_fliks_download"');
+    }
+  });
+});
+
+describe('PluginDatabaseService.rotatePassword', () => {
+  it('returns null when the role has never been provisioned', async () => {
+    const recorder = makeRecorder();
+    const dataSource = fakeDataSource(recorder, { roleExists: false });
+
+    await expect(service(dataSource).rotatePassword('fliks.download')).resolves.toBeNull();
+    expect(recorder.queries).toHaveLength(1);
+    expect(recorder.queries[0].sql).toContain('pg_roles');
+  });
+
+  it('returns a DSN pinning search_path to the plugin schema alone, with a fresh 48-hex password each call', async () => {
+    const dsnPattern =
+      /^postgresql:\/\/plugin_fliks_download:[0-9a-f]{48}@localhost:5432\/fliks\?options=-c%20search_path%3Dplugin_fliks_download$/;
+
+    const first = await service(fakeDataSource(makeRecorder(), { roleExists: true })).rotatePassword('fliks.download');
+    const second = await service(fakeDataSource(makeRecorder(), { roleExists: true })).rotatePassword('fliks.download');
+
+    expect(first).toMatch(dsnPattern);
+    expect(second).toMatch(dsnPattern);
+    expect(first).not.toBe(second);
+  });
+
+  it('reads host/port/database from ConfigService with app.module.ts defaults', async () => {
+    const config = fakeConfig({ DB_HOST: 'db.internal', DB_PORT: 5433, DB_NAME: 'fliks_test' });
+
+    const dsn = await service(fakeDataSource(makeRecorder(), { roleExists: true }), config).rotatePassword('fliks.download');
+
+    expect(dsn).toMatch(/^postgresql:\/\/plugin_fliks_download:[0-9a-f]{48}@db\.internal:5433\/fliks_test\?/);
+  });
+});
+
+describe('PluginDatabaseService.deprovision', () => {
+  it('drops owned objects, the schema and the role, in that order, when the role exists', async () => {
+    const recorder = makeRecorder();
+    await service(fakeDataSource(recorder, { roleExists: true })).deprovision('fliks.download');
+
+    const sql = recorder.queries.map((q) => normalizeSql(q.sql));
+    expect(sql).toEqual([
+      'SELECT 1 FROM pg_roles WHERE rolname = $1',
+      'DROP OWNED BY "plugin_fliks_download"',
+      'DROP SCHEMA IF EXISTS "plugin_fliks_download" CASCADE',
+      'DROP ROLE IF EXISTS "plugin_fliks_download"',
+    ]);
+  });
+
+  it('touches no database for an id provision could never have accepted', async () => {
+    const recorder = makeRecorder();
+    const dataSource = fakeDataSource(recorder, { roleExists: true });
+
+    await expect(service(dataSource).deprovision('../../etc/passwd')).resolves.toBeUndefined();
+    expect(dataSource.createQueryRunner).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op that throws nothing when the role never existed', async () => {
+    const recorder = makeRecorder();
+    await expect(service(fakeDataSource(recorder, { roleExists: false })).deprovision('fliks.download')).resolves.toBeUndefined();
+
+    const sql = recorder.queries.map((q) => normalizeSql(q.sql));
+    expect(sql).toEqual([
+      'SELECT 1 FROM pg_roles WHERE rolname = $1',
+      'DROP SCHEMA IF EXISTS "plugin_fliks_download" CASCADE',
+      'DROP ROLE IF EXISTS "plugin_fliks_download"',
+    ]);
+  });
+});

--- a/backend/src/modules/plugins/plugin-database.service.ts
+++ b/backend/src/modules/plugins/plugin-database.service.ts
@@ -1,0 +1,193 @@
+import { HttpStatus, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { randomBytes } from 'crypto';
+import { DataSource } from 'typeorm';
+import { MAX_PLUGIN_ID_LENGTH, PLUGIN_ID_PATTERN } from './archive';
+import { PluginInstallException } from './plugin-install.exception';
+import type { ProcessPluginManifest } from '../../common/plugin-contract';
+
+const CORE_REF_PATTERN = /^[a-z_][a-z0-9_]*$/;
+const MAX_CORE_REF_LENGTH = 63;
+const HEX_PASSWORD_PATTERN = /^[0-9a-f]{48}$/;
+
+/** `fliks.download` -> `plugin_fliks_download`. Role name and schema name are the same string. */
+export function pluginDbIdentifier(pluginId: string): string {
+  if (!PLUGIN_ID_PATTERN.test(pluginId) || pluginId.length > MAX_PLUGIN_ID_LENGTH) {
+    throw new Error(`"${pluginId}" is not a legal plugin id`);
+  }
+  return `plugin_${pluginId.replace(/\./g, '_')}`;
+}
+
+/** Syntax + duplicate check only — the DB probe that resolves these to real tables runs in `provision()`. */
+function validateCoreRefNames(coreRefs: readonly string[]): string[] {
+  const seen = new Set<string>();
+  for (const name of coreRefs) {
+    if (!CORE_REF_PATTERN.test(name) || name.length > MAX_CORE_REF_LENGTH) {
+      throw new Error(`coreRef ${JSON.stringify(name)} is not a legal table name`);
+    }
+    if (seen.has(name)) {
+      throw new Error(`coreRef ${JSON.stringify(name)} is declared more than once`);
+    }
+    seen.add(name);
+  }
+  return [...coreRefs];
+}
+
+function randomHexPassword(): string {
+  const password = randomBytes(24).toString('hex');
+  if (!HEX_PASSWORD_PATTERN.test(password)) {
+    throw new Error('generated password is not the expected hex shape');
+  }
+  return password;
+}
+
+function asProvisionFailure(err: unknown): PluginInstallException {
+  if (err instanceof PluginInstallException) return err;
+  const detail = err instanceof Error ? err.message : String(err);
+  return new PluginInstallException(HttpStatus.INTERNAL_SERVER_ERROR, 'PLUGIN_DB_PROVISION_FAILED', detail);
+}
+
+/**
+ * Owns the per-plugin Postgres role + schema (`plans/plugin-system.plan.md`,
+ * "Database ownership"). Every identifier interpolated into SQL here passed
+ * {@link pluginDbIdentifier} or {@link validateCoreRefNames} first; every
+ * value is a bound parameter.
+ */
+@Injectable()
+export class PluginDatabaseService {
+  constructor(
+    @InjectDataSource() private readonly dataSource: DataSource,
+    private readonly config: ConfigService,
+  ) {}
+
+  /** P1. No-op when the manifest declares `database.schema === false`. */
+  async provision(manifest: ProcessPluginManifest): Promise<void> {
+    if (manifest.database.schema === false) {
+      if (manifest.database.coreRefs.length > 0) {
+        throw new PluginInstallException(
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          'PLUGIN_DB_PROVISION_FAILED',
+          'coreRefs declared with database.schema false — no schema to grant them into',
+        );
+      }
+      return;
+    }
+
+    let identifier: string;
+    let coreRefs: string[];
+    try {
+      identifier = pluginDbIdentifier(manifest.id);
+      coreRefs = validateCoreRefNames(manifest.database.coreRefs);
+    } catch (err) {
+      throw asProvisionFailure(err);
+    }
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+    try {
+      for (const table of coreRefs) {
+        const rows = await queryRunner.query(
+          `SELECT t.table_type FROM information_schema.columns c
+             JOIN information_schema.tables t ON t.table_schema = c.table_schema AND t.table_name = c.table_name
+            WHERE c.table_schema = 'public' AND c.table_name = $1 AND c.column_name = 'id'`,
+          [table],
+        );
+        if (rows[0]?.table_type !== 'BASE TABLE') {
+          throw new Error(`coreRef ${JSON.stringify(table)} is not a public base table with an id column`);
+        }
+      }
+
+      const roleRows = await queryRunner.query('SELECT 1 FROM pg_roles WHERE rolname = $1', [identifier]);
+      if (roleRows.length === 0) {
+        const password = randomHexPassword();
+        await queryRunner.query(`CREATE ROLE "${identifier}" LOGIN PASSWORD '${password}'`);
+      }
+
+      await queryRunner.query(`CREATE SCHEMA IF NOT EXISTS "${identifier}" AUTHORIZATION "${identifier}"`);
+      const ownerRows = await queryRunner.query(
+        'SELECT pg_get_userbyid(nspowner) AS owner FROM pg_namespace WHERE nspname = $1',
+        [identifier],
+      );
+      if (ownerRows[0]?.owner !== identifier) {
+        throw new Error(`schema "${identifier}" already exists, owned by "${ownerRows[0]?.owner}"`);
+      }
+
+      await queryRunner.query(`GRANT USAGE ON SCHEMA public TO "${identifier}"`);
+      await queryRunner.query(`REVOKE REFERENCES ON ALL TABLES IN SCHEMA public FROM "${identifier}"`);
+      for (const table of coreRefs) {
+        await queryRunner.query(`GRANT REFERENCES (id) ON public."${table}" TO "${identifier}"`);
+      }
+
+      await queryRunner.commitTransaction();
+    } catch (err) {
+      // Rolling back an already-ended transaction throws and would mask a commit failure.
+      if (queryRunner.isTransactionActive) await queryRunner.rollbackTransaction();
+      throw asProvisionFailure(err);
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  /** P4b — a fresh password per spawn, never persisted. Returns the DSN, or null when this plugin has no provisioned role. */
+  async rotatePassword(pluginId: string): Promise<string | null> {
+    let identifier: string;
+    try {
+      identifier = pluginDbIdentifier(pluginId);
+    } catch (err) {
+      throw asProvisionFailure(err);
+    }
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    try {
+      const roleRows = await queryRunner.query('SELECT 1 FROM pg_roles WHERE rolname = $1', [identifier]);
+      if (roleRows.length === 0) return null;
+
+      const password = randomHexPassword();
+      await queryRunner.query(`ALTER ROLE "${identifier}" WITH PASSWORD '${password}'`);
+      return this.buildDsn(identifier, password);
+    } catch (err) {
+      throw asProvisionFailure(err);
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  /** Uninstall. Idempotent: safe when the role, schema or grants were never created. */
+  async deprovision(pluginId: string): Promise<void> {
+    let identifier: string;
+    try {
+      identifier = pluginDbIdentifier(pluginId);
+    } catch {
+      // `provision()` refuses the same ids, so nothing can exist to drop — and
+      // throwing here would make such a row impossible to uninstall at all.
+      return;
+    }
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    try {
+      const roleRows = await queryRunner.query('SELECT 1 FROM pg_roles WHERE rolname = $1', [identifier]);
+      if (roleRows.length > 0) {
+        await queryRunner.query(`DROP OWNED BY "${identifier}"`);
+      }
+      await queryRunner.query(`DROP SCHEMA IF EXISTS "${identifier}" CASCADE`);
+      await queryRunner.query(`DROP ROLE IF EXISTS "${identifier}"`);
+    } catch (err) {
+      throw asProvisionFailure(err);
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  /** Same keys/defaults as `app.module.ts`'s TypeORM factory. `search_path` is the plugin schema only — never `,public`. */
+  private buildDsn(identifier: string, password: string): string {
+    const host = this.config.get('DB_HOST', 'localhost');
+    const port = this.config.get<number>('DB_PORT', 5432);
+    const database = this.config.get('DB_NAME', 'fliks');
+    const searchPath = encodeURIComponent(`-c search_path=${identifier}`);
+    return `postgresql://${identifier}:${encodeURIComponent(password)}@${host}:${port}/${database}?options=${searchPath}`;
+  }
+}

--- a/backend/src/modules/plugins/plugin-install.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-install.service.spec.ts
@@ -6,15 +6,16 @@ import { PluginInstallService, installedPluginDir } from './plugin-install.servi
 import { PluginInstallException } from './plugin-install.exception';
 import { PluginStagingService } from './plugin-staging.service';
 import { PluginRegistryService } from './plugin-registry.service';
+import { PluginDatabaseService } from './plugin-database.service';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { PluginSource } from './entities/plugin-source.entity';
 import { buildZip, ZipEntrySpec } from './archive/zip-builder';
 import { generateTestKeypair, signManifestBase64 } from './archive/ed25519-test-keys';
-import { minimalDataManifest } from './archive/test-manifests';
-import { svgLogo } from './archive/test-fixtures';
+import { minimalDataManifest, minimalProcessManifest } from './archive/test-manifests';
+import { pngLogo, sha256Hex, svgLogo } from './archive/test-fixtures';
 import { getPluginsRuntimeDir } from '../../common/constants/paths';
 import { PLUGIN_API_VERSION } from '../../common/plugin-contract';
-import type { DataPluginManifest } from '../../common/plugin-contract';
+import type { DataPluginManifest, ProcessPluginManifest } from '../../common/plugin-contract';
 
 /** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
 const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
@@ -30,6 +31,31 @@ function signedDataArchive(overrides: Partial<DataPluginManifest> = {}): { buffe
     { name: 'logo.svg', content: svgLogo() },
   ]);
   return { buffer, manifest };
+}
+
+function signedProcessArchive(overrides: Partial<ProcessPluginManifest> = {}): { buffer: Buffer; manifest: ProcessPluginManifest } {
+  const pluginJs = Buffer.from('module.exports = {};', 'utf8');
+  const logo = pngLogo();
+  const files = { 'plugin.js': sha256Hex(pluginJs), 'logo.png': sha256Hex(logo) };
+  const manifest = minimalProcessManifest(files, { fliks: COMPATIBLE_RANGE, ...overrides });
+  const manifestBytes = Buffer.from(JSON.stringify(manifest), 'utf8');
+  const { privateKey } = generateTestKeypair();
+  const sig = signManifestBase64(privateKey, manifestBytes);
+  const buffer = buildZip([
+    { name: 'plugin.json', content: manifestBytes },
+    { name: 'plugin.json.sig', content: Buffer.from(sig, 'utf8') },
+    { name: 'plugin.js', content: pluginJs },
+    { name: 'logo.png', content: logo },
+  ]);
+  return { buffer, manifest };
+}
+
+function fakePluginDb() {
+  return {
+    provision: jest.fn(async () => undefined),
+    rotatePassword: jest.fn(async () => null),
+    deprovision: jest.fn(async () => undefined),
+  };
 }
 
 function tamperedZip(): Buffer {
@@ -108,6 +134,7 @@ describe('PluginInstallService', () => {
   let repo: ReturnType<typeof fakePackageRepo>;
   let registry: PluginRegistryService;
   let staging: PluginStagingService;
+  let pluginDb: ReturnType<typeof fakePluginDb>;
   let service: PluginInstallService;
   const originalAdapter = axios.defaults.adapter;
 
@@ -121,7 +148,8 @@ describe('PluginInstallService', () => {
     repo = fakePackageRepo();
     registry = new PluginRegistryService(repo as never);
     staging = new PluginStagingService();
-    service = new PluginInstallService(repo as never, registry, staging);
+    pluginDb = fakePluginDb();
+    service = new PluginInstallService(repo as never, registry, staging, pluginDb as unknown as PluginDatabaseService);
   });
 
   afterEach(() => {
@@ -130,7 +158,7 @@ describe('PluginInstallService', () => {
 
   describe('inspectUpload', () => {
     it('reports a valid signed data archive as installable, with its id/version/trust, and stages it', async () => {
-      const { buffer, manifest } = signedDataArchive({ id: 'fliks.inspect-happy' });
+      const { buffer, manifest } = signedDataArchive({ id: 'fliks.inspecthappy' });
 
       const report = await service.inspectUpload(buffer);
 
@@ -162,7 +190,7 @@ describe('PluginInstallService', () => {
 
   describe('confirmImport', () => {
     it('refuses with a distinct conflict code when the claimed hash no longer matches the staged bytes', async () => {
-      const { buffer } = signedDataArchive({ id: 'fliks.confirm-stale' });
+      const { buffer } = signedDataArchive({ id: 'fliks.confirmstale' });
       const { stagingId } = await service.inspectUpload(buffer);
 
       await expectInstallError(
@@ -181,7 +209,7 @@ describe('PluginInstallService', () => {
     });
 
     it('re-runs the guards against a fresh read: a directory modified after inspect is caught even when the claimed hash matches the tampered bytes', async () => {
-      const { buffer } = signedDataArchive({ id: 'fliks.confirm-tamper' });
+      const { buffer } = signedDataArchive({ id: 'fliks.confirmtamper' });
       const { stagingId } = await service.inspectUpload(buffer);
 
       const tampered = tamperedZip();
@@ -198,7 +226,7 @@ describe('PluginInstallService', () => {
     });
 
     it('promotes on success: a plugin_packages row exists and the registry has the plugin', async () => {
-      const { buffer, manifest } = signedDataArchive({ id: 'fliks.confirm-promote' });
+      const { buffer, manifest } = signedDataArchive({ id: 'fliks.confirmpromote' });
       const { stagingId, sha256 } = await service.inspectUpload(buffer);
 
       const result = await service.confirmImport({ stagingId: stagingId!, sha256: sha256! });
@@ -210,7 +238,7 @@ describe('PluginInstallService', () => {
     });
 
     it('discards the staging directory after a successful confirm', async () => {
-      const { buffer } = signedDataArchive({ id: 'fliks.confirm-discard' });
+      const { buffer } = signedDataArchive({ id: 'fliks.confirmdiscard' });
       const { stagingId, sha256 } = await service.inspectUpload(buffer);
 
       await service.confirmImport({ stagingId: stagingId!, sha256: sha256! });
@@ -219,7 +247,7 @@ describe('PluginInstallService', () => {
     });
 
     it('leaves a failed activation standing: the row is present with its reason, and nothing is registered', async () => {
-      const { buffer, manifest } = signedDataArchive({ id: 'fliks.confirm-incompatible', fliks: '>=99.0.0' });
+      const { buffer, manifest } = signedDataArchive({ id: 'fliks.confirmincompatible', fliks: '>=99.0.0' });
       const { stagingId, sha256 } = await service.inspectUpload(buffer);
 
       const result = await service.confirmImport({ stagingId: stagingId!, sha256: sha256! });
@@ -249,12 +277,12 @@ describe('PluginInstallService', () => {
 
   describe('inspectFromCatalog', () => {
     it('refuses before any guard runs when the fetched archive disagrees with the signed catalog checksum', async () => {
-      const { buffer } = signedDataArchive({ id: 'fliks.catalog-mismatch' });
+      const { buffer } = signedDataArchive({ id: 'fliks.catalogmismatch' });
       axios.defaults.adapter = adapterFor({ 'plugin.zip': buffer });
       const source = fakeSource({
         plugins: [
           {
-            id: 'fliks.catalog-mismatch',
+            id: 'fliks.catalogmismatch',
             installable: [
               {
                 version: '1.0.0',
@@ -269,14 +297,14 @@ describe('PluginInstallService', () => {
       });
 
       await expectInstallError(
-        service.inspectFromCatalog(source, 'fliks.catalog-mismatch', '1.0.0'),
+        service.inspectFromCatalog(source, 'fliks.catalogmismatch', '1.0.0'),
         422,
         'PLUGIN_CHECKSUM_MISMATCH',
       );
     });
 
     it('stages, but does not promote, a version whose checksum matches the signed catalog entry', async () => {
-      const { buffer, manifest } = signedDataArchive({ id: 'fliks.catalog-happy', version: '2.0.0' });
+      const { buffer, manifest } = signedDataArchive({ id: 'fliks.cataloghappy', version: '2.0.0' });
       const sha256 = createHash('sha256').update(buffer).digest('hex');
       axios.defaults.adapter = adapterFor({ 'plugin.zip': buffer });
       const source = fakeSource({
@@ -310,7 +338,7 @@ describe('PluginInstallService', () => {
     });
 
     it('the two-step flow (inspect then confirm) promotes exactly once, recording the catalog origin', async () => {
-      const { buffer, manifest } = signedDataArchive({ id: 'fliks.catalog-two-step' });
+      const { buffer, manifest } = signedDataArchive({ id: 'fliks.catalogtwostep' });
       const sha256 = createHash('sha256').update(buffer).digest('hex');
       axios.defaults.adapter = adapterFor({ 'plugin.zip': buffer });
       const source = fakeSource({
@@ -336,9 +364,35 @@ describe('PluginInstallService', () => {
     });
   });
 
+  describe('process-tier database provisioning', () => {
+    it('provisions before promoting; registration still fails for lack of a supervisor', async () => {
+      const { buffer, manifest } = signedProcessArchive({ id: 'fliks.provisionhappy' });
+      const { stagingId, sha256 } = await service.inspectUpload(buffer);
+
+      const result = await service.confirmImport({ stagingId: stagingId!, sha256: sha256! });
+
+      expect(pluginDb.provision).toHaveBeenCalledWith(expect.objectContaining({ id: manifest.id }));
+      expect(result).toEqual(
+        expect.objectContaining({ pluginId: manifest.id, version: manifest.version, status: 'failed', reason: 'unsupported-tier' }),
+      );
+      expect(existsSync(installedPluginDir(manifest.id, manifest.version))).toBe(true);
+    });
+
+    it('purges the staged extraction and never promotes when provisioning fails', async () => {
+      const { buffer, manifest } = signedProcessArchive({ id: 'fliks.provisionfails' });
+      const { stagingId, sha256 } = await service.inspectUpload(buffer);
+      pluginDb.provision.mockRejectedValueOnce(new Error('db unreachable'));
+
+      await expect(service.confirmImport({ stagingId: stagingId!, sha256: sha256! })).rejects.toThrow('db unreachable');
+
+      expect(existsSync(installedPluginDir(manifest.id, manifest.version))).toBe(false);
+      expect(repo.rows.has(manifest.id)).toBe(false);
+    });
+  });
+
   describe('uninstall', () => {
     it('removes the row, the registry entry and the directory; calling it twice is not an error', async () => {
-      const { buffer, manifest } = signedDataArchive({ id: 'fliks.uninstall-me' });
+      const { buffer, manifest } = signedDataArchive({ id: 'fliks.uninstallme' });
       const { stagingId, sha256 } = await service.inspectUpload(buffer);
       await service.confirmImport({ stagingId: stagingId!, sha256: sha256! });
       expect(registry.get(manifest.id)).toBeDefined();
@@ -352,19 +406,34 @@ describe('PluginInstallService', () => {
       await expect(service.uninstall(manifest.id)).resolves.toBeUndefined();
     });
 
+    it('deprovisions a process-tier package before removing its row; skips it for a data-tier one', async () => {
+      const { buffer: procBuf, manifest: procManifest } = signedProcessArchive({ id: 'fliks.uninstallprocess' });
+      const procStage = await service.inspectUpload(procBuf);
+      await service.confirmImport({ stagingId: procStage.stagingId!, sha256: procStage.sha256! });
+      const { buffer: dataBuf, manifest: dataManifest } = signedDataArchive({ id: 'fliks.uninstalldata' });
+      const dataStage = await service.inspectUpload(dataBuf);
+      await service.confirmImport({ stagingId: dataStage.stagingId!, sha256: dataStage.sha256! });
+
+      await service.uninstall(procManifest.id);
+      await service.uninstall(dataManifest.id);
+
+      expect(pluginDb.deprovision).toHaveBeenCalledTimes(1);
+      expect(pluginDb.deprovision).toHaveBeenCalledWith(procManifest.id);
+    });
+
     it('is safe for a plugin whose row and files never existed', async () => {
-      await expect(service.uninstall('fliks.never-installed')).resolves.toBeUndefined();
+      await expect(service.uninstall('fliks.neverinstalled')).resolves.toBeUndefined();
     });
   });
 
   describe('listInstalled', () => {
     it('lists every row regardless of status, with the failed one carrying its reason', async () => {
-      const { buffer: activeBuf, manifest: activeManifest } = signedDataArchive({ id: 'fliks.list-active' });
+      const { buffer: activeBuf, manifest: activeManifest } = signedDataArchive({ id: 'fliks.listactive' });
       const activeStage = await service.inspectUpload(activeBuf);
       await service.confirmImport({ stagingId: activeStage.stagingId!, sha256: activeStage.sha256! });
 
       const { buffer: failedBuf, manifest: failedManifest } = signedDataArchive({
-        id: 'fliks.list-failed',
+        id: 'fliks.listfailed',
         fliks: '>=99.0.0',
       });
       const failedStage = await service.inspectUpload(failedBuf);

--- a/backend/src/modules/plugins/plugin-install.service.ts
+++ b/backend/src/modules/plugins/plugin-install.service.ts
@@ -10,8 +10,10 @@ import { PluginPackage, PluginPackageOrigin, PluginPackageStatus } from './entit
 import { PluginSource } from './entities/plugin-source.entity';
 import { PluginRegistryService, CURRENT_FLIKS_VERSION } from './plugin-registry.service';
 import { PluginStagingService } from './plugin-staging.service';
+import { PluginDatabaseService } from './plugin-database.service';
 import { PluginInstallException } from './plugin-install.exception';
 import { getPluginsRuntimeDir } from '../../common/constants/paths';
+import { unsignedProcessAllowlist } from '../../common/constants/plugin-flags';
 import { inspect, InspectSuccess, extractToStaging, MAX_ARCHIVE_COMPRESSED_BYTES, type PluginRefusalCode } from './archive';
 import type { TrustOutcome } from './archive/trust-store';
 import type { CatalogVersionEntry, FilteredCatalog, FilteredCatalogEntry } from './catalog/catalog';
@@ -125,11 +127,12 @@ export class PluginInstallService {
     private readonly packageRepo: Repository<PluginPackage>,
     private readonly registry: PluginRegistryService,
     private readonly staging: PluginStagingService,
+    private readonly pluginDb: PluginDatabaseService,
   ) {}
 
   /** V1-V7 in memory, then stages the raw bytes. Nothing is activated. */
   async inspectUpload(buffer: Buffer): Promise<PluginInspectReport> {
-    const result = await inspect(buffer);
+    const result = await inspect(buffer, { unsignedProcessAllowlist: unsignedProcessAllowlist() });
     if (!result.ok) return { installable: false, refusalCode: result.code, detail: result.detail };
 
     const { stagingId } = this.staging.stage(buffer);
@@ -152,7 +155,7 @@ export class PluginInstallService {
       );
     }
 
-    const result = await inspect(buffer);
+    const result = await inspect(buffer, { unsignedProcessAllowlist: unsignedProcessAllowlist() });
     if (!result.ok) {
       throw new PluginInstallException(HttpStatus.UNPROCESSABLE_ENTITY, result.code, result.detail);
     }
@@ -195,7 +198,7 @@ export class PluginInstallService {
       );
     }
 
-    const result = await inspect(buffer);
+    const result = await inspect(buffer, { unsignedProcessAllowlist: unsignedProcessAllowlist() });
     if (!result.ok) return { installable: false, refusalCode: result.code, detail: result.detail };
 
     const { stagingId } = this.staging.stage(buffer, 'catalog');
@@ -223,6 +226,9 @@ export class PluginInstallService {
     this.registry.unregister(pluginId);
     const pkg = await this.packageRepo.findOne({ where: { pluginId } });
     if (!pkg) return;
+    if (pkg.manifest.kind === 'process') {
+      await this.pluginDb.deprovision(pluginId);
+    }
     await this.packageRepo.remove(pkg);
     rmSync(installedPluginDir(pkg.pluginId, pkg.version), { recursive: true, force: true });
   }
@@ -249,6 +255,16 @@ export class PluginInstallService {
     const extracted = await extractToStaging(buffer, manifest);
     if (!extracted.ok) {
       throw new PluginInstallException(HttpStatus.UNPROCESSABLE_ENTITY, extracted.code, extracted.detail);
+    }
+
+    // P1 before P2: idempotent, so a retry after a later failure just reuses the role.
+    if (manifest.kind === 'process') {
+      try {
+        await this.pluginDb.provision(manifest);
+      } catch (err) {
+        rmSync(extracted.dir, { recursive: true, force: true });
+        throw err;
+      }
     }
 
     const existing = await this.packageRepo.findOne({ where: { pluginId: manifest.id } });

--- a/backend/src/modules/plugins/plugins.module.ts
+++ b/backend/src/modules/plugins/plugins.module.ts
@@ -8,6 +8,7 @@ import { PluginWebhookDispatcherService } from './plugin-webhook-dispatcher.serv
 import { PluginCatalogClientService } from './plugin-catalog-client.service';
 import { PluginStagingService } from './plugin-staging.service';
 import { PluginInstallService } from './plugin-install.service';
+import { PluginDatabaseService } from './plugin-database.service';
 import { PluginLogoController } from './plugin-logo.controller';
 import { PluginIndexerDescriptorsController } from './plugin-indexer-descriptors.controller';
 import { PluginSourcesController } from './plugin-sources.controller';
@@ -31,7 +32,8 @@ import { EventsModule } from '../scheduler/events.module';
     PluginCatalogClientService,
     PluginStagingService,
     PluginInstallService,
+    PluginDatabaseService,
   ],
-  exports: [TypeOrmModule, PluginRegistryService],
+  exports: [TypeOrmModule, PluginRegistryService, PluginDatabaseService],
 })
 export class PluginsModule {}


### PR DESCRIPTION
PR 3.4 of the plugin-system plan: the database provisioning a `process`-tier plugin needs, plus the two prerequisites without which it is neither safe nor testable. The supervisor from #917 stays unwired — the registry still refuses the `process` tier until 3.5.

## What lands

**`PluginDatabaseService`** — step P1 of the install pipeline and the uninstall SQL block.

- `provision()` — one transaction: `CREATE ROLE` (guarded by a `pg_roles` lookup, so it is idempotent), `CREATE SCHEMA … AUTHORIZATION`, `GRANT USAGE ON SCHEMA public`, and one `GRANT REFERENCES (id) ON public."<t>"` per declared `coreRefs` entry. Nothing else.
- `rotatePassword()` — a fresh 48-hex password per spawn, never persisted, returning a DSN that pins `search_path` to the plugin schema **alone**. The plugin therefore never derives its own schema name, and an unqualified name cannot silently resolve to a core table.
- `deprovision()` — `DROP OWNED BY` / `DROP SCHEMA … CASCADE` / `DROP ROLE`, idempotent.

**The identifier guard.** `manifest.id` and `manifest.version` were validated only as non-empty strings, while both are already interpolated into `<runtime>/installed/<id>@<version>` — which `uninstall()` hands to a recursive delete. An id of `x/../../../../tmp/pwned` escapes the runtime directory, and 3.4 additionally turns `id` into a SQL identifier. Both are now checked in the archive guard every install path crosses:

- the id pattern is the one `schema/plugin.schema.v0.json` in the catalog repo already enforces on submissions — core must not be laxer than the catalog;
- the 56-character cap exists because Postgres truncates identifiers at 63 bytes, so two longer ids would land on **one shared schema**. Verified: a 67-character role name was stored as its 63-character prefix.

**`FLIKS_UNSIGNED_PLUGINS`.** `InspectOptions.unsignedProcessAllowlist` existed and was documented as reading this variable; nothing populated it. A `process` archive was consequently uninstallable without the production signing key, which would have made this PR and 3.5 unverifiable locally. Now read from the environment at all three `inspect()` call sites.

## Why these decisions

**One blanket revoke, then re-grant.** `REVOKE REFERENCES ON ALL TABLES IN SCHEMA public` (table-level, no column list) clears the column-level `REFERENCES (id)` grants too — verified. That makes provisioning idempotent *and* shrink-correct: an upgrade that drops a `coreRef` loses the privilege instead of keeping it forever. The column-list form is a trap; it dies on the first table without an `id` column.

**Provisioning is not rolled back by a later failure.** P2/P3 failures leave the role in place, because provisioning is idempotent and a retry reuses it.

**`deprovision()` is silent on an id it could never have provisioned.** `provision()` refuses the same ids, so nothing can exist to drop — and throwing would make such a row impossible to uninstall at all.

**Rollback is guarded on `isTransactionActive`.** TypeORM's `rollbackTransaction()` throws `TransactionNotStartedError` on an ended transaction, so an unguarded rollback in the catch would replace a genuine commit failure with a useless second error.

## Verification

`tsc --noEmit` exit 0 (exit code read, not stdout). Full suite **1085 tests / 109 suites green**.

The unit spec asserts the exact statement sequence and carries a **28-row adversarial table** (16 ids, 12 `coreRefs`), each row asserting both the refusal and that no DDL was emitted. Because a validator tested against its own fixture builder only catches what that builder can express, the same predicates were then run against **real Postgres** through the real DI graph — **90 assertions, all passing**:

- every adversarial `coreRefs` value refused (`media; DROP TABLE media`, `media" TO postgres --`, `public.media`, `pg_authid`, `pg_shadow`, `information_schema.tables`, `MEDIA`, a 64-char name, a duplicate, and `cleanup_profiles` which exists but has no `id` column) with **no role or schema left behind**, and `public.media` intact after all of them;
- as the provisioned role: `SELECT`/`UPDATE`/`DELETE`/`INSERT` on `public.media`, `CREATE TABLE public.evil`, `ALTER`/`DROP TABLE media`, `pg_authid`, `pg_read_file`, `CREATE ROLE`, `COPY TO PROGRAM`, and reads of `users` and `plugin_packages` — all refused. `usesuper` false. Exactly two `REFERENCES` grants, **zero** table-level privileges;
- an FK into `public.media` builds, an insert against a real media id succeeds, a nonexistent id is refused `23503`;
- rotation: the previous password is refused immediately, the new one works, plugin data survives;
- teardown leaves no role, no schema, no grants, and 840 media rows untouched.

And end to end over real HTTP, with archives built by **python's `zipfile`** rather than the repo's own builder: `probe.dbok` inspect → confirm → role + schema + exactly two `REFERENCES (id)` grants and no table-level grants, row `failed`/`unsupported-tier` (the registry's process-tier refusal, which by design does not roll the install back) → `DELETE` 204 → every Postgres object gone, second `DELETE` also 204, staging and installed directories empty. The bad-id fixtures return `PLUGIN_BAD_ID` and the bad-version one `PLUGIN_BAD_VERSION`, ahead of the unsigned check.

## Not in scope

- Wiring `rotatePassword()` into the spawn path — 3.5, with the supervisor.
- Deleting `app_settings` rows at uninstall — no plugin config path exists yet; 3.5.
- Rollback to a previous version, still pending a retain-prior-versions decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)