### PR TITLE
feat(plugins): run a process-tier plugin under the supervisor

### DIFF
--- a/backend/src/modules/plugins/dto/set-plugin-enabled.dto.ts
+++ b/backend/src/modules/plugins/dto/set-plugin-enabled.dto.ts
@@ -1,0 +1,6 @@
+import { IsBoolean } from 'class-validator';
+
+export class SetPluginEnabledDto {
+  @IsBoolean()
+  enabled: boolean;
+}

--- a/backend/src/modules/plugins/plugin-install.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-install.service.spec.ts
@@ -7,6 +7,7 @@ import { PluginInstallException } from './plugin-install.exception';
 import { PluginStagingService } from './plugin-staging.service';
 import { PluginRegistryService } from './plugin-registry.service';
 import { PluginDatabaseService } from './plugin-database.service';
+import { fakeRegistrationRepo, fakeProcessService } from './plugin-registry.test-helpers';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { PluginSource } from './entities/plugin-source.entity';
 import { buildZip, ZipEntrySpec } from './archive/zip-builder';
@@ -146,7 +147,7 @@ describe('PluginInstallService', () => {
     rmSync(stagingRoot(), { recursive: true, force: true });
     rmSync(join(getPluginsRuntimeDir(), 'installed'), { recursive: true, force: true });
     repo = fakePackageRepo();
-    registry = new PluginRegistryService(repo as never);
+    registry = new PluginRegistryService(repo as never, fakeRegistrationRepo() as never, fakeProcessService() as never);
     staging = new PluginStagingService();
     pluginDb = fakePluginDb();
     service = new PluginInstallService(repo as never, registry, staging, pluginDb as unknown as PluginDatabaseService);
@@ -365,17 +366,16 @@ describe('PluginInstallService', () => {
   });
 
   describe('process-tier database provisioning', () => {
-    it('provisions before promoting; registration still fails for lack of a supervisor', async () => {
+    it('provisions before promoting, then activates via the (faked) process service', async () => {
       const { buffer, manifest } = signedProcessArchive({ id: 'fliks.provisionhappy' });
       const { stagingId, sha256 } = await service.inspectUpload(buffer);
 
       const result = await service.confirmImport({ stagingId: stagingId!, sha256: sha256! });
 
       expect(pluginDb.provision).toHaveBeenCalledWith(expect.objectContaining({ id: manifest.id }));
-      expect(result).toEqual(
-        expect.objectContaining({ pluginId: manifest.id, version: manifest.version, status: 'failed', reason: 'unsupported-tier' }),
-      );
+      expect(result).toEqual({ pluginId: manifest.id, version: manifest.version, status: 'active' });
       expect(existsSync(installedPluginDir(manifest.id, manifest.version))).toBe(true);
+      expect(registry.get(manifest.id)).toBeDefined();
     });
 
     it('purges the staged extraction and never promotes when provisioning fails', async () => {

--- a/backend/src/modules/plugins/plugin-install.service.ts
+++ b/backend/src/modules/plugins/plugin-install.service.ts
@@ -3,8 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import axios from 'axios';
 import { createHash } from 'crypto';
-import { closeSync, cpSync, existsSync, fsyncSync, mkdirSync, openSync, renameSync, rmSync } from 'fs';
-import { dirname, join } from 'path';
+import { closeSync, existsSync, fsyncSync, openSync, rmSync } from 'fs';
 import * as semver from 'semver';
 import { PluginPackage, PluginPackageOrigin, PluginPackageStatus } from './entities/plugin-package.entity';
 import { PluginSource } from './entities/plugin-source.entity';
@@ -12,13 +11,14 @@ import { PluginRegistryService, CURRENT_FLIKS_VERSION } from './plugin-registry.
 import { PluginStagingService } from './plugin-staging.service';
 import { PluginDatabaseService } from './plugin-database.service';
 import { PluginInstallException } from './plugin-install.exception';
-import { getPluginsRuntimeDir } from '../../common/constants/paths';
+import { installedPluginDir, promoteDir } from './plugin-paths';
 import { unsignedProcessAllowlist } from '../../common/constants/plugin-flags';
 import { inspect, InspectSuccess, extractToStaging, MAX_ARCHIVE_COMPRESSED_BYTES, type PluginRefusalCode } from './archive';
 import type { TrustOutcome } from './archive/trust-store';
 import type { CatalogVersionEntry, FilteredCatalog, FilteredCatalogEntry } from './catalog/catalog';
 import { PLUGIN_API_VERSION, type PluginKind, type PluginManifest } from '../../common/plugin-contract';
 import type { ConfirmImportDto } from './dto/confirm-import.dto';
+import type { SupervisorState } from './supervisor/plugin-supervisor';
 
 const ARCHIVE_FETCH_TIMEOUT_MS = 30_000;
 
@@ -59,12 +59,12 @@ export interface PluginSummary {
   statusReason: string | null;
   signature: TrustOutcome;
   verifiedByKeyId: string | null;
+  /** `process` only — `null`/`''` for `data`, which has no supervisor. */
+  processState: SupervisorState | null;
+  statusMessage: string;
 }
 
-/** `${runtime dir}/installed/<id>@<version>/` — exported for uninstall's own recomputation and for tests. */
-export function installedPluginDir(pluginId: string, version: string): string {
-  return join(getPluginsRuntimeDir(), 'installed', `${pluginId}@${version}`);
-}
+export { installedPluginDir, promoteDir };
 
 function fsyncPath(path: string): void {
   const fd = openSync(path, 'r');
@@ -72,19 +72,6 @@ function fsyncPath(path: string): void {
     fsyncSync(fd);
   } finally {
     closeSync(fd);
-  }
-}
-
-/** Same-filesystem rename when possible; copy+remove is the only option across devices. */
-function promoteDir(srcDir: string, destDir: string): void {
-  mkdirSync(dirname(destDir), { recursive: true });
-  rmSync(destDir, { recursive: true, force: true });
-  try {
-    renameSync(srcDir, destDir);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== 'EXDEV') throw err;
-    cpSync(srcDir, destDir, { recursive: true });
-    rmSync(srcDir, { recursive: true, force: true });
   }
 }
 
@@ -112,11 +99,11 @@ function findInstallableVersion(
 }
 
 /**
- * Orchestrates the install/update/uninstall pipeline for the `data` tier
+ * Orchestrates the install/update/uninstall pipeline for both tiers
  * (`plans/plugin-system.plan.md`, "Install pipeline, end to end"). `process`
  * archives flow through the same guards and the same promotion — only
- * `PluginRegistryService.register()` tells them apart, refusing to activate
- * one for lack of a supervisor. That refusal does not roll back the install.
+ * `PluginRegistryService.register()` tells them apart, provisioning a schema
+ * and spawning a supervisor. A spawn failure does not roll back the install.
  */
 @Injectable()
 export class PluginInstallService {
@@ -208,7 +195,49 @@ export class PluginInstallService {
   /** Every installed row, active or failed — the admin list reads the table directly for this reason. */
   async listInstalled(): Promise<PluginSummary[]> {
     const packages = await this.packageRepo.find();
-    return packages.map((pkg) => ({
+    return packages.map((pkg) => this.toSummary(pkg));
+  }
+
+  /** Safe to call for a plugin whose row, registry entry or directory is already gone. */
+  async uninstall(pluginId: string): Promise<void> {
+    await this.registry.unregister(pluginId);
+    const pkg = await this.packageRepo.findOne({ where: { pluginId } });
+    if (!pkg) return;
+    if (pkg.manifest.kind === 'process') {
+      await this.pluginDb.deprovision(pluginId);
+    }
+    await this.packageRepo.remove(pkg);
+    rmSync(installedPluginDir(pkg.pluginId, pkg.version), { recursive: true, force: true });
+  }
+
+  /** Persists the enabled flag on `plugin_registrations` and starts or stops the process to match. */
+  async setEnabled(pluginId: string, enabled: boolean): Promise<PluginSummary> {
+    const pkg = await this.findInstalledProcessPlugin(pluginId);
+    const result = await this.registry.setEnabled(pkg, enabled);
+    pkg.status = result.ok ? 'active' : 'failed';
+    pkg.statusReason = result.ok ? null : `${result.reason}: ${result.detail}`;
+    await this.packageRepo.save(pkg);
+    return this.toSummary(pkg);
+  }
+
+  /** Clears a tripped circuit breaker and respawns. */
+  async restart(pluginId: string): Promise<void> {
+    await this.findInstalledProcessPlugin(pluginId);
+    await this.registry.restartProcess(pluginId);
+  }
+
+  private async findInstalledProcessPlugin(pluginId: string): Promise<PluginPackage> {
+    const pkg = await this.packageRepo.findOne({ where: { pluginId } });
+    if (!pkg) throw new PluginInstallException(HttpStatus.NOT_FOUND, 'PLUGIN_NOT_FOUND', `plugin "${pluginId}" is not installed`);
+    if (pkg.manifest.kind !== 'process') {
+      throw new PluginInstallException(HttpStatus.BAD_REQUEST, 'PLUGIN_NOT_PROCESS_TIER', `plugin "${pluginId}" is not a process-tier plugin`);
+    }
+    return pkg;
+  }
+
+  private toSummary(pkg: PluginPackage): PluginSummary {
+    const isProcess = pkg.manifest.kind === 'process';
+    return {
       pluginId: pkg.pluginId,
       name: pkg.manifest.name,
       version: pkg.version,
@@ -218,19 +247,9 @@ export class PluginInstallService {
       statusReason: pkg.statusReason,
       signature: pkg.signature,
       verifiedByKeyId: pkg.verifiedByKeyId,
-    }));
-  }
-
-  /** Safe to call for a plugin whose row, registry entry or directory is already gone. */
-  async uninstall(pluginId: string): Promise<void> {
-    this.registry.unregister(pluginId);
-    const pkg = await this.packageRepo.findOne({ where: { pluginId } });
-    if (!pkg) return;
-    if (pkg.manifest.kind === 'process') {
-      await this.pluginDb.deprovision(pluginId);
-    }
-    await this.packageRepo.remove(pkg);
-    rmSync(installedPluginDir(pkg.pluginId, pkg.version), { recursive: true, force: true });
+      processState: isProcess ? this.registry.processStateOf(pkg.pluginId) : null,
+      statusMessage: isProcess ? this.registry.processStatusMessageOf(pkg.pluginId) : '',
+    };
   }
 
   private buildReport(result: InspectSuccess, stagingId: string): PluginInspectReport {

--- a/backend/src/modules/plugins/plugin-paths.ts
+++ b/backend/src/modules/plugins/plugin-paths.ts
@@ -1,0 +1,26 @@
+import { cpSync, mkdirSync, renameSync, rmSync } from 'fs';
+import { dirname, join } from 'path';
+import { getPluginsRuntimeDir } from '../../common/constants/paths';
+
+/**
+ * A leaf module with no dependency on either service that installs or supervises a plugin —
+ * both need these, and importing one from the other is the cycle that bit this project once.
+ */
+
+/** `${runtime dir}/installed/<id>@<version>/` — exported for uninstall's own recomputation and for tests. */
+export function installedPluginDir(pluginId: string, version: string): string {
+  return join(getPluginsRuntimeDir(), 'installed', `${pluginId}@${version}`);
+}
+
+/** Same-filesystem rename when possible; copy+remove is the only option across devices. */
+export function promoteDir(srcDir: string, destDir: string): void {
+  mkdirSync(dirname(destDir), { recursive: true });
+  rmSync(destDir, { recursive: true, force: true });
+  try {
+    renameSync(srcDir, destDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EXDEV') throw err;
+    cpSync(srcDir, destDir, { recursive: true });
+    rmSync(srcDir, { recursive: true, force: true });
+  }
+}

--- a/backend/src/modules/plugins/plugin-process-event-dispatcher.service.ts
+++ b/backend/src/modules/plugins/plugin-process-event-dispatcher.service.ts
@@ -1,0 +1,24 @@
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { Subscription } from 'rxjs';
+import { EventsService, type DomainEvent } from '../scheduler/events.service';
+import { PluginProcessService } from './plugin-process.service';
+
+/** Fans a domain event out to every ready `process` plugin over its socket, mirroring
+ *  `PluginWebhookDispatcherService`'s at-most-once contract — no filtering, no retry. */
+@Injectable()
+export class PluginProcessEventDispatcherService implements OnModuleInit, OnModuleDestroy {
+  private readonly subscription = new Subscription();
+
+  constructor(
+    private readonly events: EventsService,
+    private readonly processes: PluginProcessService,
+  ) {}
+
+  onModuleInit(): void {
+    this.subscription.add(this.events.onDomain((event: DomainEvent) => this.processes.emitToAll(event.type, event)));
+  }
+
+  onModuleDestroy(): void {
+    this.subscription.unsubscribe();
+  }
+}

--- a/backend/src/modules/plugins/plugin-process.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-process.service.spec.ts
@@ -1,0 +1,429 @@
+import { rmSync } from 'fs';
+import { join } from 'path';
+import { PluginProcessService, type PluginSupervisorFactory } from './plugin-process.service';
+import { installedPluginDir } from './plugin-paths';
+import { buildZip } from './archive/zip-builder';
+import { svgLogo } from './archive/test-fixtures';
+import { getPluginsRuntimeDir } from '../../common/constants/paths';
+import { createHash } from 'crypto';
+import { minimalProcessManifest } from './archive/test-manifests';
+import type { PluginPackage } from './entities/plugin-package.entity';
+import type { PluginSupervisor, PluginSupervisorOptions, SupervisorState } from './supervisor/plugin-supervisor';
+
+/**
+ * Waits until the factory has built `count` supervisors, so a fake's state can be flipped
+ * exactly where `startFor` is blocked. Predicate rather than a fixed number of ticks:
+ * `startFor` re-extracts a real archive first, which takes an unknown number of them.
+ */
+async function waitForSupervisors(instances: FakeSupervisor[], count = 1): Promise<void> {
+  for (let i = 0; i < 500 && instances.length < count; i++) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  if (instances.length < count) throw new Error(`only ${instances.length} supervisor(s) built, wanted ${count}`);
+}
+
+class FakeSupervisor {
+  state: SupervisorState = 'stopped';
+  stderrTail = '';
+  statusMessage = '';
+  startCalls = 0;
+  stopCalls = 0;
+  emitEvent = jest.fn();
+  private listeners: ((s: SupervisorState) => void)[] = [];
+
+  constructor(public readonly options: PluginSupervisorOptions) {}
+
+  getState(): SupervisorState {
+    return this.state;
+  }
+  getStderrTail(): string {
+    return this.stderrTail;
+  }
+  getStatusMessage(): string {
+    return this.statusMessage;
+  }
+
+  onStateChange(cb: (s: SupervisorState) => void): () => void {
+    this.listeners.push(cb);
+    return () => {
+      this.listeners = this.listeners.filter((l) => l !== cb);
+    };
+  }
+
+  setState(s: SupervisorState): void {
+    this.state = s;
+    for (const cb of [...this.listeners]) cb(s);
+  }
+
+  async start(): Promise<void> {
+    this.startCalls++;
+  }
+
+  async stop(): Promise<void> {
+    this.stopCalls++;
+    this.setState('stopped');
+  }
+}
+
+function makeFactory(): { factory: PluginSupervisorFactory; instances: FakeSupervisor[] } {
+  const instances: FakeSupervisor[] = [];
+  const factory = (options: PluginSupervisorOptions): PluginSupervisor => {
+    const sup = new FakeSupervisor(options);
+    instances.push(sup);
+    return sup as unknown as PluginSupervisor;
+  };
+  return { factory, instances };
+}
+
+function fakePluginDb(order: string[] = []) {
+  return {
+    provision: jest.fn(async () => {
+      order.push('provision');
+    }),
+    rotatePassword: jest.fn(async () => {
+      order.push('rotate');
+      return 'postgresql://fake-dsn' as string | null;
+    }),
+    deprovision: jest.fn(async () => undefined),
+  };
+}
+
+function fakeLogBuffer() {
+  return { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+}
+
+function fakeSettings(order: string[] = [], all: Record<string, string | null> = {}) {
+  return {
+    getAll: jest.fn(async () => {
+      order.push('config');
+      return all;
+    }),
+  };
+}
+
+const PLUGIN_ID = 'fliks.processsvc';
+const PLUGIN_JS = Buffer.from('module.exports = {};');
+
+const sha = (b: Buffer) => createHash('sha256').update(b).digest('hex');
+
+/** A real archive, because `startFor` re-extracts and re-hashes on every spawn — that is L3. */
+function fakePackage(overrides: Partial<PluginPackage> = {}, manifestOverrides: Record<string, unknown> = {}): PluginPackage {
+  const logo = svgLogo();
+  const manifest = minimalProcessManifest(
+    { 'plugin.js': sha(PLUGIN_JS), 'logo.svg': sha(logo) },
+    { id: PLUGIN_ID, memoryMb: 256, logo: 'logo.svg', ...manifestOverrides },
+  );
+  const archive = buildZip([
+    { name: 'plugin.json', content: Buffer.from(JSON.stringify(manifest), 'utf8') },
+    { name: 'plugin.js', content: PLUGIN_JS },
+    { name: 'logo.svg', content: logo },
+  ]);
+  return {
+    id: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    pluginId: manifest.id,
+    version: manifest.version,
+    archive,
+    origin: 'manual',
+    signature: 'unsigned',
+    verifiedByKeyId: null,
+    manifest,
+    status: 'active',
+    ...overrides,
+  } as PluginPackage;
+}
+
+describe('PluginProcessService.startFor', () => {
+  beforeEach(() => {
+    rmSync(join(getPluginsRuntimeDir(), 'installed'), { recursive: true, force: true });
+  });
+
+  it('runs materialise -> provision -> rotate -> config -> spawn, in that order, and resolves once ready', async () => {
+    const order: string[] = [];
+    const pkg = fakePackage();
+
+    const pluginDb = fakePluginDb(order);
+    const settings = fakeSettings(order);
+    const { factory: rawFactory, instances } = makeFactory();
+    const factory: PluginSupervisorFactory = (options) => {
+      order.push('spawn');
+      return rawFactory(options);
+    };
+    const service = new PluginProcessService(pluginDb as never, fakeLogBuffer() as never, settings as never, factory);
+
+    const startPromise = service.startFor(pkg);
+    await waitForSupervisors(instances);
+    instances[0].setState('handshaking');
+    instances[0].setState('ready');
+    const result = await startPromise;
+
+    expect(result).toEqual({ ok: true });
+    expect(order).toEqual(['provision', 'rotate', 'config', 'spawn']);
+    expect(instances).toHaveLength(1);
+    expect(instances[0].startCalls).toBe(1);
+    expect(instances[0].options).toEqual(
+      expect.objectContaining({ id: pkg.pluginId, dbUrl: 'postgresql://fake-dsn', memoryMb: 256 }),
+    );
+    expect(service.stateOf(pkg.pluginId)).toBe('ready');
+  });
+
+  it('passes a null rotated password through as undefined', async () => {
+    const pkg = fakePackage();
+
+    const pluginDb = fakePluginDb();
+    pluginDb.rotatePassword.mockResolvedValue(null);
+    const { factory, instances } = makeFactory();
+    const service = new PluginProcessService(pluginDb as never, fakeLogBuffer() as never, fakeSettings() as never, factory);
+
+    const startPromise = service.startFor(pkg);
+    await waitForSupervisors(instances);
+    instances[0].setState('ready');
+    await startPromise;
+
+    expect(instances[0].options.dbUrl).toBeUndefined();
+  });
+
+  it('only forwards plugin.<id>.* settings as config, dropping null values and other plugins', async () => {
+    const pkg = fakePackage();
+
+    const settings = fakeSettings([], {
+      [`plugin.${PLUGIN_ID}.apiKey`]: 'secret',
+      [`plugin.${PLUGIN_ID}.cleared`]: null,
+      'plugin.someone-else.apiKey': 'nope',
+    });
+    const { factory, instances } = makeFactory();
+    const service = new PluginProcessService(fakePluginDb() as never, fakeLogBuffer() as never, settings as never, factory);
+
+    const startPromise = service.startFor(pkg);
+    await waitForSupervisors(instances);
+    instances[0].setState('ready');
+    await startPromise;
+
+    expect(instances[0].options.config).toEqual({ [`plugin.${PLUGIN_ID}.apiKey`]: 'secret' });
+  });
+
+  it('a corrupt archive fails materialise with "tampered", spawning nothing', async () => {
+    const pkg = fakePackage({ archive: Buffer.from('not a zip at all') });
+    const { factory, instances } = makeFactory();
+    const service = new PluginProcessService(fakePluginDb() as never, fakeLogBuffer() as never, fakeSettings() as never, factory);
+
+    const result = await service.startFor(pkg);
+
+    expect(result).toEqual({ ok: false, reason: 'tampered', detail: expect.any(String) });
+    expect(instances).toHaveLength(0);
+    expect(service.stateOf(pkg.pluginId)).toBeNull();
+  });
+
+  it('a provision failure returns "db-provision-failed" and spawns nothing', async () => {
+    const pkg = fakePackage();
+
+    const pluginDb = fakePluginDb();
+    pluginDb.provision.mockRejectedValue(new Error('db unreachable'));
+    const { factory, instances } = makeFactory();
+    const service = new PluginProcessService(pluginDb as never, fakeLogBuffer() as never, fakeSettings() as never, factory);
+
+    const result = await service.startFor(pkg);
+
+    expect(result).toEqual({ ok: false, reason: 'db-provision-failed', detail: 'db unreachable' });
+    expect(instances).toHaveLength(0);
+  });
+
+  it('a rotatePassword failure also returns "db-provision-failed" and spawns nothing', async () => {
+    const pkg = fakePackage();
+
+    const pluginDb = fakePluginDb();
+    pluginDb.rotatePassword.mockRejectedValue(new Error('role missing'));
+    const { factory, instances } = makeFactory();
+    const service = new PluginProcessService(pluginDb as never, fakeLogBuffer() as never, fakeSettings() as never, factory);
+
+    const result = await service.startFor(pkg);
+
+    expect(result).toEqual({ ok: false, reason: 'db-provision-failed', detail: 'role missing' });
+    expect(instances).toHaveLength(0);
+  });
+
+  it('a breaker trip ("failed") returns "spawn-failed" with the stderr tail, but the supervisor is left running and observable', async () => {
+    const pkg = fakePackage();
+
+    const { factory, instances } = makeFactory();
+    const service = new PluginProcessService(fakePluginDb() as never, fakeLogBuffer() as never, fakeSettings() as never, factory);
+
+    const startPromise = service.startFor(pkg);
+    await waitForSupervisors(instances);
+    instances[0].stderrTail = 'boom: could not bind';
+    instances[0].setState('crashed');
+    instances[0].setState('failed');
+    const result = await startPromise;
+
+    expect(result).toEqual({ ok: false, reason: 'spawn-failed', detail: 'boom: could not bind' });
+    expect(instances[0].stopCalls).toBe(0);
+    expect(service.stateOf(pkg.pluginId)).toBe('failed');
+  });
+
+  it('a slow handshake reports failure once the timeout elapses, without stopping or dropping the supervisor', async () => {
+    const pkg = fakePackage();
+
+    const { factory, instances } = makeFactory();
+    const service = new PluginProcessService(fakePluginDb() as never, fakeLogBuffer() as never, fakeSettings() as never, factory, 20);
+
+    const startPromise = service.startFor(pkg);
+    await waitForSupervisors(instances);
+    instances[0].setState('handshaking');
+    const result = await startPromise;
+
+    expect(result).toEqual({ ok: false, reason: 'spawn-failed', detail: expect.any(String) });
+    expect(instances[0].stopCalls).toBe(0);
+    expect(service.stateOf(pkg.pluginId)).toBe('handshaking');
+  });
+
+  it('crashing and backing off on the way to ready still yields ok:true, and the supervisor is never stopped', async () => {
+    const pkg = fakePackage();
+
+    const { factory, instances } = makeFactory();
+    const service = new PluginProcessService(fakePluginDb() as never, fakeLogBuffer() as never, fakeSettings() as never, factory);
+
+    const startPromise = service.startFor(pkg);
+    await waitForSupervisors(instances);
+    instances[0].setState('starting');
+    instances[0].setState('handshaking');
+    instances[0].setState('crashed');
+    instances[0].setState('backoff');
+    instances[0].setState('handshaking');
+    instances[0].setState('ready');
+    const result = await startPromise;
+
+    expect(result).toEqual({ ok: true });
+    expect(instances[0].stopCalls).toBe(0);
+    expect(service.stateOf(pkg.pluginId)).toBe('ready');
+  });
+});
+
+describe('PluginProcessService — lifecycle', () => {
+  beforeEach(() => {
+    rmSync(join(getPluginsRuntimeDir(), 'installed'), { recursive: true, force: true });
+  });
+
+  async function startedService() {
+    const pkg = fakePackage();
+
+    const pluginDb = fakePluginDb();
+    const { factory, instances } = makeFactory();
+    const service = new PluginProcessService(pluginDb as never, fakeLogBuffer() as never, fakeSettings() as never, factory);
+
+    const startPromise = service.startFor(pkg);
+    await waitForSupervisors(instances);
+    instances[0].setState('ready');
+    await startPromise;
+
+    return { service, pkg, pluginDb, instances, factory };
+  }
+
+  it('stopFor stops the supervisor and is idempotent', async () => {
+    const { service, pkg, instances } = await startedService();
+
+    await service.stopFor(pkg.pluginId);
+    await service.stopFor(pkg.pluginId);
+
+    expect(instances[0].stopCalls).toBe(1);
+    expect(service.stateOf(pkg.pluginId)).toBeNull();
+  });
+
+  it('stateOf/statusMessageOf report unknown for a plugin never started', () => {
+    const service = new PluginProcessService(fakePluginDb() as never, fakeLogBuffer() as never, fakeSettings() as never, makeFactory().factory);
+
+    expect(service.stateOf('fliks.never-started')).toBeNull();
+    expect(service.statusMessageOf('fliks.never-started')).toBe('');
+  });
+
+  it('statusMessageOf falls back to the stderr tail when there is no breaker message', async () => {
+    const { service, pkg, instances } = await startedService();
+    instances[0].stderrTail = 'last gasp';
+
+    expect(service.statusMessageOf(pkg.pluginId)).toBe('last gasp');
+  });
+
+  it('restart stops the old supervisor and spawns a fresh one, rotating the password again', async () => {
+    const { service, pkg, pluginDb, instances } = await startedService();
+    expect(pluginDb.rotatePassword).toHaveBeenCalledTimes(1);
+
+    const restartPromise = service.restart(pkg.pluginId);
+    await waitForSupervisors(instances, 2);
+    instances[1].setState('ready');
+    await restartPromise;
+
+    expect(instances).toHaveLength(2);
+    expect(instances[0].stopCalls).toBe(1);
+    expect(instances[1].startCalls).toBe(1);
+    expect(pluginDb.rotatePassword).toHaveBeenCalledTimes(2);
+    expect(service.stateOf(pkg.pluginId)).toBe('ready');
+  });
+
+  it('restart on a plugin that never started is a no-op', async () => {
+    const service = new PluginProcessService(fakePluginDb() as never, fakeLogBuffer() as never, fakeSettings() as never, makeFactory().factory);
+
+    await expect(service.restart('fliks.never-started')).resolves.toBeUndefined();
+  });
+
+  it('a plugin whose start failed is still present for stateOf/statusMessageOf, and restart respawns it', async () => {
+    const pkg = fakePackage();
+
+    const pluginDb = fakePluginDb();
+    const { factory, instances } = makeFactory();
+    const service = new PluginProcessService(pluginDb as never, fakeLogBuffer() as never, fakeSettings() as never, factory);
+
+    const startPromise = service.startFor(pkg);
+    await waitForSupervisors(instances);
+    instances[0].stderrTail = 'boom';
+    instances[0].setState('crashed');
+    instances[0].setState('failed');
+    const startResult = await startPromise;
+
+    expect(startResult).toEqual({ ok: false, reason: 'spawn-failed', detail: 'boom' });
+    expect(service.stateOf(pkg.pluginId)).toBe('failed');
+    expect(service.statusMessageOf(pkg.pluginId)).toBe('boom');
+
+    const restartPromise = service.restart(pkg.pluginId);
+    await waitForSupervisors(instances, 2);
+    instances[1].setState('ready');
+    await restartPromise;
+
+    expect(instances[0].stopCalls).toBe(1);
+    expect(service.stateOf(pkg.pluginId)).toBe('ready');
+  });
+
+  it('stopAll stops every running plugin', async () => {
+    const pluginDb = fakePluginDb();
+    const { factory, instances } = makeFactory();
+    const service = new PluginProcessService(pluginDb as never, fakeLogBuffer() as never, fakeSettings() as never, factory);
+    const pkgA = fakePackage({}, { id: 'fliks.processsvc.a' });
+    const pkgB = fakePackage({}, { id: 'fliks.processsvc.b' });
+
+
+
+    const p1 = service.startFor(pkgA);
+    await waitForSupervisors(instances);
+    instances[0].setState('ready');
+    await p1;
+    const p2 = service.startFor(pkgB);
+    await waitForSupervisors(instances, 2);
+    instances[1].setState('ready');
+    await p2;
+
+    await service.stopAll();
+
+    expect(instances[0].stopCalls).toBe(1);
+    expect(instances[1].stopCalls).toBe(1);
+    expect(service.stateOf(pkgA.pluginId)).toBeNull();
+    expect(service.stateOf(pkgB.pluginId)).toBeNull();
+  });
+
+  it('emitToAll reaches every running supervisor regardless of state — the ring buffer decides queue vs. send', async () => {
+    const { service, instances } = await startedService();
+    instances[0].setState('degraded');
+
+    service.emitToAll('media.imported', { mediaId: 1 });
+
+    expect(instances[0].emitEvent).toHaveBeenCalledWith('media.imported', { mediaId: 1 });
+  });
+});

--- a/backend/src/modules/plugins/plugin-process.service.ts
+++ b/backend/src/modules/plugins/plugin-process.service.ts
@@ -1,0 +1,198 @@
+import { Injectable, Optional, type OnApplicationShutdown } from '@nestjs/common';
+import type { PluginPackage } from './entities/plugin-package.entity';
+import { installedPluginDir, promoteDir } from './plugin-paths';
+import { extractToStaging } from './archive';
+import { PluginDatabaseService } from './plugin-database.service';
+import {
+  DEFAULT_SUPERVISOR_OPTIONS,
+  PluginSupervisor,
+  type PluginSupervisorOptions,
+  type SupervisorState,
+} from './supervisor/plugin-supervisor';
+import { LogBufferService } from '../scheduler/log-buffer.service';
+import { SettingsService } from '../settings/settings.service';
+import type { ProcessPluginManifest } from '../../common/plugin-contract';
+
+export type PluginProcessFailureReason = 'tampered' | 'db-provision-failed' | 'spawn-failed';
+export type PluginProcessStartResult = { ok: true } | { ok: false; reason: PluginProcessFailureReason; detail: string };
+export type PluginSupervisorFactory = (options: PluginSupervisorOptions) => PluginSupervisor;
+
+interface RunningPlugin {
+  supervisor: PluginSupervisor;
+  pkg: PluginPackage;
+  unsubscribe: () => void;
+}
+
+const DEFAULT_FACTORY: PluginSupervisorFactory = (options) => new PluginSupervisor(options);
+
+/** Owns every live `process` plugin's supervisor, one per plugin id. `startFor`/`stopFor`
+ *  are the map's only entry and exit, so it always reflects who is actually spawned. */
+@Injectable()
+export class PluginProcessService implements OnApplicationShutdown {
+  private readonly running = new Map<string, RunningPlugin>();
+  private readonly supervisorFactory: PluginSupervisorFactory;
+  private readonly startupTimeoutMs: number;
+
+  constructor(
+    private readonly pluginDb: PluginDatabaseService,
+    private readonly logBuffer: LogBufferService,
+    private readonly settings: SettingsService,
+    @Optional() supervisorFactory?: PluginSupervisorFactory,
+    @Optional() startupTimeoutMs?: number,
+  ) {
+    this.supervisorFactory = supervisorFactory ?? DEFAULT_FACTORY;
+    this.startupTimeoutMs = startupTimeoutMs ?? DEFAULT_SUPERVISOR_OPTIONS.handshakeDeadlineMs;
+  }
+
+  /** Materialise -> provision-check -> rotate -> config -> spawn; each stage's failure
+   *  carries its own reason. A slow handshake is reported but left running to retry on its own. */
+  async startFor(pkg: PluginPackage): Promise<PluginProcessStartResult> {
+    const manifest = pkg.manifest;
+    if (manifest.kind !== 'process') {
+      throw new Error(`startFor() called for non-process plugin "${pkg.pluginId}"`);
+    }
+
+    const materialised = await this.materialise(pkg, manifest);
+    if (!materialised.ok) return { ok: false, reason: 'tampered', detail: materialised.detail };
+
+    try {
+      await this.pluginDb.provision(manifest);
+    } catch (err) {
+      return { ok: false, reason: 'db-provision-failed', detail: (err as Error).message };
+    }
+
+    let dbUrl: string | undefined;
+    try {
+      dbUrl = (await this.pluginDb.rotatePassword(pkg.pluginId)) ?? undefined;
+    } catch (err) {
+      return { ok: false, reason: 'db-provision-failed', detail: (err as Error).message };
+    }
+
+    const config = await this.readConfig(pkg.pluginId);
+    const supervisor = this.supervisorFactory({
+      id: pkg.pluginId,
+      dir: materialised.dir,
+      logBuffer: this.logBuffer,
+      dbUrl,
+      config,
+      memoryMb: manifest.memoryMb,
+    });
+    const unsubscribe = supervisor.onStateChange((state) =>
+      this.logBuffer.log(`state: ${state}`, `plugin:${pkg.pluginId}`),
+    );
+    // Registered before the handshake settles: a plugin stuck retrying its own backoff
+    // ladder must stay observable and restartable, not vanish because it isn't ready yet.
+    this.running.set(pkg.pluginId, { supervisor, pkg, unsubscribe });
+
+    await supervisor.start();
+    const outcome = await this.waitForReadyOrGiveUp(supervisor);
+    if (!outcome.ok) return { ok: false, reason: 'spawn-failed', detail: outcome.detail };
+    return { ok: true };
+  }
+
+  /** Idempotent — a no-op for a plugin that was never started, or already stopped. */
+  async stopFor(pluginId: string): Promise<void> {
+    const entry = this.running.get(pluginId);
+    if (!entry) return;
+    this.running.delete(pluginId);
+    entry.unsubscribe();
+    await entry.supervisor.stop();
+  }
+
+  stateOf(pluginId: string): SupervisorState | null {
+    return this.running.get(pluginId)?.supervisor.getState() ?? null;
+  }
+
+  statusMessageOf(pluginId: string): string {
+    const supervisor = this.running.get(pluginId)?.supervisor;
+    if (!supervisor) return '';
+    return supervisor.getStatusMessage() || supervisor.getStderrTail();
+  }
+
+  /** Swaps in a fresh supervisor rather than reusing the tripped one, so the rotated password stays "once per spawn". */
+  async restart(pluginId: string): Promise<void> {
+    const entry = this.running.get(pluginId);
+    if (!entry) return;
+    await this.stopFor(pluginId);
+    await this.startFor(entry.pkg);
+  }
+
+  async stopAll(): Promise<void> {
+    await Promise.all([...this.running.keys()].map((id) => this.stopFor(id)));
+  }
+
+  async onApplicationShutdown(): Promise<void> {
+    await this.stopAll();
+  }
+
+  /** Unconditional — the supervisor's own ring buffer, not this method, decides queue vs. send. */
+  emitToAll(name: string, payload: unknown): void {
+    for (const { supervisor } of this.running.values()) {
+      supervisor.emitEvent(name, payload);
+    }
+  }
+
+  /**
+   * Always rebuilt from `pkg.archive`, never trusted from disk: extraction re-hashes every
+   * entry against the signed `files{}`, which is L3. Trusting an existing directory would
+   * skip that check on exactly the persistent `FLIKS_RUNTIME_DIR` where tampering is possible.
+   */
+  private async materialise(
+    pkg: PluginPackage,
+    manifest: ProcessPluginManifest,
+  ): Promise<{ ok: true; dir: string } | { ok: false; detail: string }> {
+    const dir = installedPluginDir(pkg.pluginId, pkg.version);
+
+    try {
+      const extracted = await extractToStaging(pkg.archive, manifest);
+      if (!extracted.ok) return { ok: false, detail: extracted.detail };
+      promoteDir(extracted.dir, dir);
+      return { ok: true, dir };
+    } catch (err) {
+      return { ok: false, detail: (err as Error).message };
+    }
+  }
+
+  /** `plugin.<id>.*` app settings, verbatim keys — `buildSpawnPlan` re-keys them to `FLIKS_CFG_*`. */
+  private async readConfig(pluginId: string): Promise<Record<string, string>> {
+    const prefix = `plugin.${pluginId}.`;
+    const all = await this.settings.getAll();
+    const config: Record<string, string> = {};
+    for (const [key, value] of Object.entries(all)) {
+      if (value !== null && key.startsWith(prefix)) config[key] = value;
+    }
+    return config;
+  }
+
+  /** `crashed`/`backoff` are the ladder doing its job, not a verdict — only `ready` (success),
+   *  `failed` (the breaker gave up) or this method's own timeout end the wait. */
+  private waitForReadyOrGiveUp(supervisor: PluginSupervisor): Promise<{ ok: true } | { ok: false; detail: string }> {
+    const failureDetail = () => supervisor.getStatusMessage() || supervisor.getStderrTail();
+
+    return new Promise((resolve) => {
+      const initial = supervisor.getState();
+      if (initial === 'ready') {
+        resolve({ ok: true });
+        return;
+      }
+      if (initial === 'failed') {
+        resolve({ ok: false, detail: failureDetail() });
+        return;
+      }
+
+      const settle = (result: { ok: true } | { ok: false; detail: string }) => {
+        clearTimeout(timer);
+        unsubscribe();
+        resolve(result);
+      };
+      const unsubscribe = supervisor.onStateChange((state) => {
+        if (state === 'ready') settle({ ok: true });
+        else if (state === 'failed') settle({ ok: false, detail: failureDetail() });
+      });
+      const timer = setTimeout(
+        () => settle({ ok: false, detail: failureDetail() || 'handshake deadline exceeded' }),
+        this.startupTimeoutMs,
+      );
+    });
+  }
+}

--- a/backend/src/modules/plugins/plugin-registry.service.indexer-descriptors.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.indexer-descriptors.spec.ts
@@ -1,6 +1,7 @@
 import { PluginRegistryService } from './plugin-registry.service';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { minimalDataManifest } from './archive/test-manifests';
+import { fakeRegistrationRepo, fakeProcessService } from './plugin-registry.test-helpers';
 import { buildIndexerImplementationId, type IndexerDescriptor, type PluginManifest } from '../../common/plugin-contract';
 
 /** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
@@ -28,6 +29,10 @@ function repoMock(): { find: jest.Mock } {
   return { find: jest.fn().mockResolvedValue([]) };
 }
 
+function makeService(): PluginRegistryService {
+  return new PluginRegistryService(repoMock() as never, fakeRegistrationRepo() as never, fakeProcessService() as never);
+}
+
 function indexerDescriptor(overrides: Partial<IndexerDescriptor> = {}): IndexerDescriptor {
   return {
     key: 'mytracker',
@@ -45,7 +50,7 @@ describe('PluginRegistryService — indexer descriptors', () => {
       fliks: COMPATIBLE_RANGE,
       provides: { indexers: [indexerDescriptor({ driverApi: 'newznab' })] },
     });
-    const service = new PluginRegistryService(repoMock() as never);
+    const service = makeService();
 
     const result = await service.register(makePackage(manifest));
 
@@ -63,7 +68,7 @@ describe('PluginRegistryService — indexer descriptors', () => {
       fliks: COMPATIBLE_RANGE,
       provides: { indexers: [indexerDescriptor({ key: 'dup' }), indexerDescriptor({ key: 'dup' })] },
     });
-    const service = new PluginRegistryService(repoMock() as never);
+    const service = makeService();
 
     const result = await service.register(makePackage(manifest));
 
@@ -80,7 +85,7 @@ describe('PluginRegistryService — indexer descriptors', () => {
       fliks: COMPATIBLE_RANGE,
       provides: { indexers: [indexerDescriptor({ key: 'my.tracker' })] },
     });
-    const service = new PluginRegistryService(repoMock() as never);
+    const service = makeService();
 
     const result = await service.register(makePackage(manifest));
 
@@ -97,7 +102,7 @@ describe('PluginRegistryService — indexer descriptors', () => {
       fliks: COMPATIBLE_RANGE,
       provides: { indexers: [indexerDescriptor({ endpoint: 'not-a-url' })] },
     });
-    const service = new PluginRegistryService(repoMock() as never);
+    const service = makeService();
 
     const result = await service.register(makePackage(manifest));
 
@@ -114,7 +119,7 @@ describe('PluginRegistryService — indexer descriptors', () => {
       fliks: COMPATIBLE_RANGE,
       provides: { indexers: [indexerDescriptor()] },
     });
-    const service = new PluginRegistryService(repoMock() as never);
+    const service = makeService();
 
     const result = await service.register(makePackage(manifest));
 
@@ -131,12 +136,12 @@ describe('PluginRegistryService — indexer descriptors', () => {
       fliks: COMPATIBLE_RANGE,
       provides: { indexers: [indexerDescriptor()] },
     });
-    const service = new PluginRegistryService(repoMock() as never);
+    const service = makeService();
     await service.register(makePackage(manifest));
     const implementationId = buildIndexerImplementationId(manifest.id, 'mytracker');
     expect(service.getIndexerDescriptor(implementationId)).toBeDefined();
 
-    service.unregister(manifest.id);
+    await service.unregister(manifest.id);
 
     expect(service.getIndexerDescriptor(implementationId)).toBeUndefined();
     expect(service.listIndexerDescriptors()).toEqual([]);

--- a/backend/src/modules/plugins/plugin-registry.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.spec.ts
@@ -5,8 +5,10 @@ import { generateTestKeypair, signManifestBase64 } from './archive/ed25519-test-
 import { minimalDataManifest, minimalProcessManifest } from './archive/test-manifests';
 import { svgLogo, pngLogo } from './archive/test-fixtures';
 import { OFFICIAL_KEYS } from './archive/trust-store';
+import { fakeRegistrationRepo, fakeProcessService } from './plugin-registry.test-helpers';
 import { FLIKS_PLUGINS_DISABLED_ENV } from '../../common/constants/plugin-flags';
-import type { PluginManifest } from '../../common/plugin-contract';
+import type { PluginManifest, ProcessPluginManifest } from '../../common/plugin-contract';
+import type { PluginProcessStartResult } from './plugin-process.service';
 
 /** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
 const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
@@ -43,6 +45,15 @@ function repoMock(rows: PluginPackage[] = []) {
   return { find: jest.fn().mockResolvedValue(rows) };
 }
 
+/** Every registry test but boot-load exercises `register()` directly, so the process side is always faked here. */
+function makeService(rows: PluginPackage[] = [], processResult: PluginProcessStartResult = { ok: true }) {
+  const repo = repoMock(rows);
+  const registrationRepo = fakeRegistrationRepo();
+  const processService = fakeProcessService(processResult);
+  const service = new PluginRegistryService(repo as never, registrationRepo as never, processService as never);
+  return { service, repo, registrationRepo, processService };
+}
+
 describe('PluginRegistryService — boot load', () => {
   const originalEnv = process.env[FLIKS_PLUGINS_DISABLED_ENV];
 
@@ -53,8 +64,7 @@ describe('PluginRegistryService — boot load', () => {
 
   it('L0: FLIKS_PLUGINS_DISABLED=1 registers nothing and never queries the repository', async () => {
     process.env[FLIKS_PLUGINS_DISABLED_ENV] = '1';
-    const repo = repoMock([makePackage(minimalDataManifest({ fliks: COMPATIBLE_RANGE }))]);
-    const service = new PluginRegistryService(repo as never);
+    const { service, repo } = makeService([makePackage(minimalDataManifest({ fliks: COMPATIBLE_RANGE }))]);
 
     await service.onModuleInit();
 
@@ -65,12 +75,30 @@ describe('PluginRegistryService — boot load', () => {
   it('boot continues past a failing package and still registers a later valid one', async () => {
     const bad = minimalDataManifest({ id: 'fliks.bad-plugin', fliks: '>=99.0.0' });
     const good = minimalDataManifest({ id: 'fliks.good-plugin', fliks: COMPATIBLE_RANGE });
-    const repo = repoMock([makePackage(bad), makePackage(good)]);
-    const service = new PluginRegistryService(repo as never);
+    const { service } = makeService([makePackage(bad), makePackage(good)]);
 
     await service.onModuleInit();
 
     expect(service.get(bad.id)).toBeUndefined();
+    expect(service.get(good.id)).toBeDefined();
+    expect(service.list()).toHaveLength(1);
+  });
+
+  it('a process-tier plugin whose spawn fails does not take boot down, and a later valid plugin still loads', async () => {
+    const failing = minimalProcessManifest(
+      { 'plugin.js': 'a'.repeat(64), 'logo.png': 'b'.repeat(64) },
+      { id: 'fliks.spawnfails', fliks: COMPATIBLE_RANGE },
+    );
+    const good = minimalDataManifest({ id: 'fliks.good-plugin', fliks: COMPATIBLE_RANGE });
+    const { service } = makeService([makePackage(failing), makePackage(good)], {
+      ok: false,
+      reason: 'spawn-failed',
+      detail: 'never reached ready',
+    });
+
+    await service.onModuleInit();
+
+    expect(service.get(failing.id)).toBeUndefined();
     expect(service.get(good.id)).toBeDefined();
     expect(service.list()).toHaveLength(1);
   });
@@ -84,7 +112,7 @@ describe('PluginRegistryService.register()', () => {
   it('registers a valid data-tier package and is idempotent', async () => {
     const manifest = minimalDataManifest({ fliks: COMPATIBLE_RANGE });
     const pkg = makePackage(manifest);
-    const service = new PluginRegistryService(repoMock() as never);
+    const { service } = makeService();
 
     const first = await service.register(pkg);
     const second = await service.register(pkg);
@@ -102,7 +130,7 @@ describe('PluginRegistryService.register()', () => {
     const sig = signManifestBase64(privateKey, manifestBytes);
     const archive = archiveFor(manifest, [{ name: 'plugin.json.sig', content: Buffer.from(sig, 'utf8') }]);
     const pkg = makePackage(manifest, { archive, signature: 'official', verifiedByKeyId: 'revoked-key' });
-    const service = new PluginRegistryService(repoMock() as never);
+    const { service } = makeService();
 
     const result = await service.register(pkg);
 
@@ -123,7 +151,7 @@ describe('PluginRegistryService.register()', () => {
     const sig = signManifestBase64(privateKey, manifestBytes);
     const archive = archiveFor(manifest, [{ name: 'plugin.json.sig', content: Buffer.from(sig, 'utf8') }]);
     const pkg = makePackage(manifest, { archive, signature: 'official', verifiedByKeyId: 'release-2026' });
-    const service = new PluginRegistryService(repoMock() as never);
+    const { service } = makeService();
 
     const result = await service.register(pkg);
 
@@ -133,7 +161,7 @@ describe('PluginRegistryService.register()', () => {
   it('L4: does not register when pluginApi differs from PLUGIN_API_VERSION, with its own reason', async () => {
     const manifest = minimalDataManifest({ fliks: COMPATIBLE_RANGE, pluginApi: 99 });
     const pkg = makePackage(manifest);
-    const service = new PluginRegistryService(repoMock() as never);
+    const { service } = makeService();
 
     const result = await service.register(pkg);
 
@@ -148,7 +176,7 @@ describe('PluginRegistryService.register()', () => {
   it('L4: does not register when the fliks range excludes the running version, with its own reason', async () => {
     const manifest = minimalDataManifest({ fliks: '>=99.0.0' });
     const pkg = makePackage(manifest);
-    const service = new PluginRegistryService(repoMock() as never);
+    const { service } = makeService();
 
     const result = await service.register(pkg);
 
@@ -160,23 +188,74 @@ describe('PluginRegistryService.register()', () => {
     });
   });
 
-  it('refuses a process-tier package as not supported yet', async () => {
-    const pluginJs = Buffer.from('module.exports = {};', 'utf8');
-    const manifest = minimalProcessManifest(
-      { 'plugin.js': 'a'.repeat(64), 'logo.png': 'b'.repeat(64) },
-      { fliks: COMPATIBLE_RANGE },
-    );
-    const archive = archiveFor(manifest, [{ name: 'plugin.js', content: pluginJs }]);
-    const pkg = makePackage(manifest, { archive });
-    const service = new PluginRegistryService(repoMock() as never);
+  describe('process tier', () => {
+    function processPackage(overrides: Partial<ProcessPluginManifest> = {}) {
+      const pluginJs = Buffer.from('module.exports = {};', 'utf8');
+      const manifest = minimalProcessManifest(
+        { 'plugin.js': 'a'.repeat(64), 'logo.png': 'b'.repeat(64) },
+        { fliks: COMPATIBLE_RANGE, ...overrides },
+      );
+      const archive = archiveFor(manifest, [{ name: 'plugin.js', content: pluginJs }]);
+      return makePackage(manifest, { archive });
+    }
 
-    const result = await service.register(pkg);
+    it('registers and spawns a valid process-tier package, seeding its registration row', async () => {
+      const pkg = processPackage({ id: 'fliks.processhappy' });
+      const { service, registrationRepo, processService } = makeService();
 
-    expect(result).toEqual({
-      ok: false,
-      pluginId: manifest.id,
-      reason: 'unsupported-tier',
-      detail: expect.any(String),
+      const result = await service.register(pkg);
+
+      expect(result).toEqual({ ok: true, pluginId: pkg.pluginId });
+      expect(processService.startFor).toHaveBeenCalledWith(pkg);
+      expect(service.get(pkg.pluginId)).toBeDefined();
+      const row = registrationRepo.rows.get(pkg.pluginId);
+      expect(row).toEqual(
+        expect.objectContaining({ pluginId: pkg.pluginId, enabled: true, ingestRoots: [], scopes: ['media:read'] }),
+      );
+    });
+
+    it('refreshes the cached manifest on a second registration without resetting admin-edited fields', async () => {
+      const pkg = processPackage({ id: 'fliks.processreload' });
+      const { service, registrationRepo } = makeService();
+      await service.register(pkg);
+      registrationRepo.rows.get(pkg.pluginId)!.enabled = false;
+      registrationRepo.rows.get(pkg.pluginId)!.ingestRoots = ['/media/custom'];
+
+      const second = await service.register(pkg);
+
+      expect(second).toEqual({ ok: false, pluginId: pkg.pluginId, reason: 'disabled', detail: expect.any(String) });
+      const row = registrationRepo.rows.get(pkg.pluginId);
+      expect(row?.ingestRoots).toEqual(['/media/custom']);
+      expect(row?.manifest).toEqual(pkg.manifest);
+    });
+
+    it('a disabled registration refuses with "disabled" and never calls startFor', async () => {
+      const pkg = processPackage({ id: 'fliks.processdisabled' });
+      const { service, registrationRepo, processService } = makeService();
+      await service.register(pkg);
+      registrationRepo.rows.get(pkg.pluginId)!.enabled = false;
+      processService.startFor.mockClear();
+
+      const result = await service.register(pkg);
+
+      expect(result).toEqual({ ok: false, pluginId: pkg.pluginId, reason: 'disabled', detail: expect.any(String) });
+      expect(processService.startFor).not.toHaveBeenCalled();
+      expect(service.get(pkg.pluginId)).toBeUndefined();
+    });
+
+    it('propagates a spawn failure reason and registers nothing', async () => {
+      const pkg = processPackage({ id: 'fliks.processspawnfail' });
+      const { service } = makeService([], { ok: false, reason: 'spawn-failed', detail: 'stderr tail here' });
+
+      const result = await service.register(pkg);
+
+      expect(result).toEqual({
+        ok: false,
+        pluginId: pkg.pluginId,
+        reason: 'spawn-failed',
+        detail: 'stderr tail here',
+      });
+      expect(service.get(pkg.pluginId)).toBeUndefined();
     });
   });
 });

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -1,11 +1,13 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, OnModuleInit } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import * as fs from 'fs';
-import * as path from 'path';
 import * as net from 'net';
 import * as semver from 'semver';
 import { PluginPackage } from './entities/plugin-package.entity';
+import { PluginRegistration } from './entities/plugin-registration.entity';
+import { PluginProcessService } from './plugin-process.service';
+import { CURRENT_FLIKS_VERSION } from './plugin-version';
+import type { SupervisorState } from './supervisor/plugin-supervisor';
 import { arePluginsDisabled, FLIKS_PLUGINS_DISABLED_ENV } from '../../common/constants/plugin-flags';
 import {
   PLUGIN_API_VERSION,
@@ -14,6 +16,7 @@ import {
   INDEXER_ID_SEPARATOR,
   type PluginKind,
   type PluginManifest,
+  type ProcessPluginManifest,
   type IndexerDescriptor,
   type PluginWebhookEventName,
 } from '../../common/plugin-contract';
@@ -36,16 +39,7 @@ type AssertSameStringUnion<A extends string, B extends string> = [A] extends [B]
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const _webhookCatalogMatchesDomainEvents: AssertSameStringUnion<PluginWebhookEventName, DomainEvent['type']> = true;
 
-/** Same pattern as `UpdateCheckService`/`SystemController` — no shared version util exists yet.
- *  Exported so the catalog client checks compatibility against this exact value, never a second read. */
-export const CURRENT_FLIKS_VERSION: string = (() => {
-  try {
-    const pkg = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8')) as { version?: string };
-    return pkg.version ?? '0.0.0';
-  } catch {
-    return '0.0.0';
-  }
-})();
+export { CURRENT_FLIKS_VERSION };
 
 /** The only `driverApi` core knows how to run a search through today. */
 const SUPPORTED_INDEXER_DRIVER_APIS: ReadonlySet<string> = new Set(['torznab']);
@@ -72,7 +66,6 @@ export interface RegisteredPlugin {
 }
 
 export type PluginRegistrationFailureReason =
-  | 'unsupported-tier'
   | 'untrusted'
   | 'incompatible-api'
   | 'incompatible-fliks'
@@ -82,7 +75,11 @@ export type PluginRegistrationFailureReason =
   | 'invalid-webhook-event'
   | 'invalid-webhook-url'
   | 'insecure-webhook-scheme'
-  | 'internal-webhook-host';
+  | 'internal-webhook-host'
+  | 'disabled'
+  | 'tampered'
+  | 'db-provision-failed'
+  | 'spawn-failed';
 
 export interface PluginRegistrationSuccess {
   ok: true;
@@ -99,10 +96,9 @@ export type PluginRegistrationResult = PluginRegistrationSuccess | PluginRegistr
 /**
  * In-memory installed-plugin set — the only thing the rest of core asks about
  * plugins. Populated at boot (L0-L4 of `plans/plugin-system.plan.md`'s load
- * table) and by `register()`, the hot-reload entry point a future installer
- * calls for a `data` plugin (P4a). L1/L3 — `state.json` and re-hashing
- * `plugin.js` from the fd that will be loaded — belong to the process-tier
- * supervisor, which does not exist yet.
+ * table) and by `register()`, the hot-reload entry point the installer calls
+ * for both tiers (P4a). L1 (`state.json` quarantine) still has no home; L3
+ * (re-hashing `plugin.js` from the loaded fd) is `PluginProcessService`'s.
  */
 @Injectable()
 export class PluginRegistryService implements OnModuleInit {
@@ -117,6 +113,9 @@ export class PluginRegistryService implements OnModuleInit {
   constructor(
     @InjectRepository(PluginPackage)
     private readonly packageRepo: Repository<PluginPackage>,
+    @InjectRepository(PluginRegistration)
+    private readonly registrationRepo: Repository<PluginRegistration>,
+    private readonly processService: PluginProcessService,
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -144,16 +143,12 @@ export class PluginRegistryService implements OnModuleInit {
   async register(pkg: PluginPackage): Promise<PluginRegistrationResult> {
     const manifest = pkg.manifest;
 
-    if (manifest.kind === 'process') {
-      return this.fail(pkg.pluginId, 'unsupported-tier', 'process-tier plugins are not supported yet (no supervisor)');
-    }
-
-    // L1 (state.json quarantine) slots in here, ahead of the signature re-check — supervisor-owned.
+    // L1 (state.json quarantine) slots in here, ahead of the signature re-check — still has no owner.
     // L2
     const trust = await this.reverifyTrust(pkg);
     if (!trust.ok) return this.fail(pkg.pluginId, 'untrusted', trust.detail);
 
-    // L3 (re-hash plugin.js from the loaded fd) slots in here, process-tier only — supervisor-owned.
+    // L3 (re-hash plugin.js from the loaded fd) happens inside `PluginProcessService.startFor`, below.
     // L4
     if (manifest.pluginApi !== PLUGIN_API_VERSION) {
       return this.fail(
@@ -173,12 +168,15 @@ export class PluginRegistryService implements OnModuleInit {
     const descriptorCheck = this.validateIndexerDescriptors(manifest.provides?.indexers ?? []);
     if (!descriptorCheck.ok) return this.fail(pkg.pluginId, descriptorCheck.reason, descriptorCheck.detail);
 
-    // `events` is a `PluginManifestBase` field so it's structurally legal on `process` too, but
-    // the `unsupported-tier` bail above already refuses every process manifest before reaching
-    // here — so in practice this only ever runs for `data`, which is the only tier the webhook
-    // dispatcher fans out to.
+    // Structurally legal on `process` too, but only `data` fans out over HTTP —
+    // `process` gets domain events pushed over its own socket instead.
     const webhookCheck = this.validateWebhookDeclarations(manifest.events ?? []);
     if (!webhookCheck.ok) return this.fail(pkg.pluginId, webhookCheck.reason, webhookCheck.detail);
+
+    if (manifest.kind === 'process') {
+      const activation = await this.activateProcess(pkg, manifest);
+      if (!activation.ok) return activation;
+    }
 
     this.registry.set(pkg.pluginId, {
       pluginId: pkg.pluginId,
@@ -190,14 +188,71 @@ export class PluginRegistryService implements OnModuleInit {
       archive: pkg.archive,
     });
     this.replaceIndexerDescriptors(pkg.pluginId, descriptorCheck.descriptors);
-    this.replaceWebhookDeclarations(pkg.pluginId, webhookCheck.declarations);
+    this.replaceWebhookDeclarations(pkg.pluginId, manifest.kind === 'data' ? webhookCheck.declarations : []);
     return { ok: true, pluginId: pkg.pluginId };
   }
 
-  unregister(pluginId: string): void {
+  async unregister(pluginId: string): Promise<void> {
+    await this.processService.stopFor(pluginId);
     this.registry.delete(pluginId);
     this.replaceIndexerDescriptors(pluginId, []);
     this.replaceWebhookDeclarations(pluginId, []);
+  }
+
+  /** Persists the admin's enabled/disabled choice and starts or stops the process to match it. */
+  async setEnabled(pkg: PluginPackage, enabled: boolean): Promise<PluginRegistrationResult> {
+    const registration = await this.registrationRepo.findOne({ where: { pluginId: pkg.pluginId } });
+    if (!registration) throw new NotFoundException(`plugin "${pkg.pluginId}" has no registration row`);
+    registration.enabled = enabled;
+    await this.registrationRepo.save(registration);
+
+    if (!enabled) {
+      await this.unregister(pkg.pluginId);
+      return this.fail(pkg.pluginId, 'disabled', `plugin "${pkg.pluginId}" is disabled`);
+    }
+    return this.register(pkg);
+  }
+
+  /** Clears a tripped circuit breaker by swapping in a freshly-provisioned supervisor. */
+  async restartProcess(pluginId: string): Promise<void> {
+    await this.processService.restart(pluginId);
+  }
+
+  processStateOf(pluginId: string): SupervisorState | null {
+    return this.processService.stateOf(pluginId);
+  }
+
+  processStatusMessageOf(pluginId: string): string {
+    return this.processService.statusMessageOf(pluginId);
+  }
+
+  /** Loads or creates the `plugin_registrations` row (seeding it only on create),
+   *  refreshes its cached manifest, then spawns unless the admin disabled it. */
+  private async activateProcess(
+    pkg: PluginPackage,
+    manifest: ProcessPluginManifest,
+  ): Promise<{ ok: true } | PluginRegistrationFailure> {
+    let registration = await this.registrationRepo.findOne({ where: { pluginId: pkg.pluginId } });
+    if (!registration) {
+      registration = this.registrationRepo.create({
+        pluginId: pkg.pluginId,
+        ingestRoots: manifest.ingestRoots,
+        scopes: manifest.scopes,
+        enabled: true,
+        manifest,
+      });
+    } else {
+      registration.manifest = manifest;
+    }
+    await this.registrationRepo.save(registration);
+
+    if (!registration.enabled) {
+      return this.fail(pkg.pluginId, 'disabled', `plugin "${pkg.pluginId}" is disabled`);
+    }
+
+    const result = await this.processService.startFor(pkg);
+    if (!result.ok) return this.fail(pkg.pluginId, result.reason, result.detail);
+    return { ok: true };
   }
 
   list(): RegisteredPlugin[] {
@@ -340,7 +395,11 @@ export class PluginRegistryService implements OnModuleInit {
     return { ok: true, declarations };
   }
 
+  /** Every failure path funnels here, so a failing re-registration can never leave a stale entry active. */
   private fail(pluginId: string, reason: PluginRegistrationFailureReason, detail: string): PluginRegistrationFailure {
+    this.registry.delete(pluginId);
+    this.replaceIndexerDescriptors(pluginId, []);
+    this.replaceWebhookDeclarations(pluginId, []);
     return { ok: false, pluginId, reason, detail };
   }
 

--- a/backend/src/modules/plugins/plugin-registry.service.webhooks.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.webhooks.spec.ts
@@ -1,6 +1,7 @@
 import { PluginRegistryService } from './plugin-registry.service';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { minimalDataManifest, minimalProcessManifest } from './archive/test-manifests';
+import { fakeRegistrationRepo, fakeProcessService } from './plugin-registry.test-helpers';
 import type { PluginManifest, PluginWebhookDeclaration } from '../../common/plugin-contract';
 
 /** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
@@ -28,6 +29,10 @@ function repoMock(): { find: jest.Mock } {
   return { find: jest.fn().mockResolvedValue([]) };
 }
 
+function makeService(): PluginRegistryService {
+  return new PluginRegistryService(repoMock() as never, fakeRegistrationRepo() as never, fakeProcessService() as never);
+}
+
 function webhookDeclaration(overrides: Partial<PluginWebhookDeclaration> = {}): PluginWebhookDeclaration {
   return { event: 'media.imported', webhook: 'https://hooks.example.com/fliks', ...overrides };
 }
@@ -38,7 +43,7 @@ describe('PluginRegistryService — webhooks', () => {
       fliks: COMPATIBLE_RANGE,
       events: [webhookDeclaration({ webhook: 'http://hooks.example.com/fliks' })],
     });
-    const service = new PluginRegistryService(repoMock() as never);
+    const service = makeService();
 
     const result = await service.register(makePackage(manifest));
 
@@ -59,7 +64,7 @@ describe('PluginRegistryService — webhooks', () => {
       fliks: COMPATIBLE_RANGE,
       events: [webhookDeclaration({ webhook })],
     });
-    const service = new PluginRegistryService(repoMock() as never);
+    const service = makeService();
 
     const result = await service.register(makePackage(manifest));
 
@@ -76,7 +81,7 @@ describe('PluginRegistryService — webhooks', () => {
       fliks: COMPATIBLE_RANGE,
       events: [webhookDeclaration({ webhook: 'not-a-url' })],
     });
-    const service = new PluginRegistryService(repoMock() as never);
+    const service = makeService();
 
     const result = await service.register(makePackage(manifest));
 
@@ -93,7 +98,7 @@ describe('PluginRegistryService — webhooks', () => {
       fliks: COMPATIBLE_RANGE,
       events: [{ event: 'media.deleted-forever', webhook: 'https://hooks.example.com/fliks' } as unknown as PluginWebhookDeclaration],
     });
-    const service = new PluginRegistryService(repoMock() as never);
+    const service = makeService();
 
     const result = await service.register(makePackage(manifest));
 
@@ -110,7 +115,7 @@ describe('PluginRegistryService — webhooks', () => {
       fliks: COMPATIBLE_RANGE,
       events: [webhookDeclaration()],
     });
-    const service = new PluginRegistryService(repoMock() as never);
+    const service = makeService();
 
     const result = await service.register(makePackage(manifest));
 
@@ -122,30 +127,38 @@ describe('PluginRegistryService — webhooks', () => {
 
   it('drops a plugin webhooks on unregister', async () => {
     const manifest = minimalDataManifest({ fliks: COMPATIBLE_RANGE, events: [webhookDeclaration()] });
-    const service = new PluginRegistryService(repoMock() as never);
+    const service = makeService();
     await service.register(makePackage(manifest));
     expect(service.listWebhooksForEvent('media.imported')).toHaveLength(1);
 
-    service.unregister(manifest.id);
+    await service.unregister(manifest.id);
 
     expect(service.listWebhooksForEvent('media.imported')).toEqual([]);
   });
 
-  it('refuses a process-tier manifest declaring a webhook (process is not a supported tier yet)', async () => {
+  it('still validates a webhook on a process-tier manifest but never fans it out over HTTP', async () => {
+    // `events[].webhook` is a data-tier capability: a process plugin is handed the same
+    // events over its own socket, so registering it here would double every delivery.
     const manifest = minimalProcessManifest(
       { 'plugin.js': 'a'.repeat(64), 'logo.png': 'b'.repeat(64) },
       { fliks: COMPATIBLE_RANGE, events: [webhookDeclaration()] },
     );
-    const service = new PluginRegistryService(repoMock() as never);
+    const service = makeService();
 
     const result = await service.register(makePackage(manifest));
 
-    expect(result).toEqual({
-      ok: false,
-      pluginId: manifest.id,
-      reason: 'unsupported-tier',
-      detail: expect.any(String),
-    });
+    expect(result).toEqual({ ok: true, pluginId: manifest.id });
     expect(service.listWebhooksForEvent('media.imported')).toEqual([]);
+  });
+
+  it('refuses a process-tier manifest whose webhook is malformed rather than ignoring it', async () => {
+    const manifest = minimalProcessManifest(
+      { 'plugin.js': 'a'.repeat(64), 'logo.png': 'b'.repeat(64) },
+      { fliks: COMPATIBLE_RANGE, events: [{ event: 'media.imported', webhook: 'http://insecure.example.com/x' }] },
+    );
+
+    const result = await makeService().register(makePackage(manifest));
+
+    expect(result).toMatchObject({ ok: false, reason: 'insecure-webhook-scheme' });
   });
 });

--- a/backend/src/modules/plugins/plugin-registry.test-helpers.ts
+++ b/backend/src/modules/plugins/plugin-registry.test-helpers.ts
@@ -1,0 +1,46 @@
+import { PluginRegistration } from './entities/plugin-registration.entity';
+import type { PluginProcessStartResult } from './plugin-process.service';
+
+/** Not a `.spec.ts` — shared fakes for `PluginRegistryService`'s two new constructor dependencies. */
+
+export function fakeRegistrationRepo(): {
+  rows: Map<string, PluginRegistration>;
+  findOne: jest.Mock;
+  create: jest.Mock;
+  save: jest.Mock;
+} {
+  const rows = new Map<string, PluginRegistration>();
+  let nextId = 1;
+  return {
+    rows,
+    findOne: jest.fn(async ({ where: { pluginId } }: { where: { pluginId: string } }) => rows.get(pluginId) ?? null),
+    create: jest.fn(
+      (partial: Partial<PluginRegistration>) =>
+        ({ id: nextId++, createdAt: new Date(), updatedAt: new Date(), ...partial }) as PluginRegistration,
+    ),
+    save: jest.fn(async (row: PluginRegistration) => {
+      rows.set(row.pluginId, row);
+      return row;
+    }),
+  };
+}
+
+export function fakeProcessService(startForResult: PluginProcessStartResult = { ok: true }): {
+  startFor: jest.Mock;
+  stopFor: jest.Mock;
+  stateOf: jest.Mock;
+  statusMessageOf: jest.Mock;
+  restart: jest.Mock;
+  stopAll: jest.Mock;
+  emitToAll: jest.Mock;
+} {
+  return {
+    startFor: jest.fn(async () => startForResult),
+    stopFor: jest.fn(async () => undefined),
+    stateOf: jest.fn(() => null),
+    statusMessageOf: jest.fn(() => ''),
+    restart: jest.fn(async () => undefined),
+    stopAll: jest.fn(async () => undefined),
+    emitToAll: jest.fn(),
+  };
+}

--- a/backend/src/modules/plugins/plugin-version.ts
+++ b/backend/src/modules/plugins/plugin-version.ts
@@ -1,0 +1,13 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** A leaf so the registry, the catalog client and the supervisor can all read this
+ *  without cycling through each other. Same pattern as `UpdateCheckService`/`SystemController`. */
+export const CURRENT_FLIKS_VERSION: string = (() => {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8')) as { version?: string };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+})();

--- a/backend/src/modules/plugins/plugins.controller.spec.ts
+++ b/backend/src/modules/plugins/plugins.controller.spec.ts
@@ -17,4 +17,21 @@ describe('PluginsController', () => {
     await expect(controller.list()).resolves.toBe(rows);
     expect(installService.listInstalled).toHaveBeenCalled();
   });
+
+  it('delegates setEnabled to the install service with the parsed body', async () => {
+    const summary = { pluginId: 'fliks.test-plugin', status: 'active' };
+    const installService = { setEnabled: jest.fn().mockResolvedValue(summary) };
+    const controller = new PluginsController(installService as never);
+
+    await expect(controller.setEnabled('fliks.test-plugin', { enabled: false })).resolves.toBe(summary);
+    expect(installService.setEnabled).toHaveBeenCalledWith('fliks.test-plugin', false);
+  });
+
+  it('delegates restart to the install service', async () => {
+    const installService = { restart: jest.fn().mockResolvedValue(undefined) };
+    const controller = new PluginsController(installService as never);
+
+    await expect(controller.restart('fliks.test-plugin')).resolves.toBeUndefined();
+    expect(installService.restart).toHaveBeenCalledWith('fliks.test-plugin');
+  });
 });

--- a/backend/src/modules/plugins/plugins.controller.ts
+++ b/backend/src/modules/plugins/plugins.controller.ts
@@ -1,9 +1,10 @@
-import { Controller, Delete, Get, HttpCode, HttpStatus, Param, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Patch, Post, UseGuards } from '@nestjs/common';
 import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
 import { PoliciesGuard } from '../auth/casl/policies.guard';
 import { CheckPolicies } from '../auth/casl/check-policies.decorator';
 import { Action } from '../auth/casl/actions.enum';
 import { PluginInstallService, PluginSummary } from './plugin-install.service';
+import { SetPluginEnabledDto } from './dto/set-plugin-enabled.dto';
 
 @Controller('plugins')
 @UseGuards(JwtOrApiKeyGuard, PoliciesGuard)
@@ -14,6 +15,21 @@ export class PluginsController {
   @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
   async list(): Promise<PluginSummary[]> {
     return this.installService.listInstalled();
+  }
+
+  /** `process` only — flips `plugin_registrations.enabled` and starts or stops the process to match. */
+  @Patch(':pluginId')
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
+  async setEnabled(@Param('pluginId') pluginId: string, @Body() dto: SetPluginEnabledDto): Promise<PluginSummary> {
+    return this.installService.setEnabled(pluginId, dto.enabled);
+  }
+
+  /** Clears a tripped circuit breaker and respawns. */
+  @Post(':pluginId/restart')
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async restart(@Param('pluginId') pluginId: string): Promise<void> {
+    await this.installService.restart(pluginId);
   }
 
   /** Row + registry entry + extracted directory. Safe on a plugin whose files or row are already gone. */

--- a/backend/src/modules/plugins/plugins.module.ts
+++ b/backend/src/modules/plugins/plugins.module.ts
@@ -5,6 +5,8 @@ import { PluginSource } from './entities/plugin-source.entity';
 import { PluginRegistration } from './entities/plugin-registration.entity';
 import { PluginRegistryService } from './plugin-registry.service';
 import { PluginWebhookDispatcherService } from './plugin-webhook-dispatcher.service';
+import { PluginProcessService } from './plugin-process.service';
+import { PluginProcessEventDispatcherService } from './plugin-process-event-dispatcher.service';
 import { PluginCatalogClientService } from './plugin-catalog-client.service';
 import { PluginStagingService } from './plugin-staging.service';
 import { PluginInstallService } from './plugin-install.service';
@@ -16,9 +18,17 @@ import { PluginImportController } from './plugin-import.controller';
 import { PluginsController } from './plugins.controller';
 import { AuthModule } from '../auth/auth.module';
 import { EventsModule } from '../scheduler/events.module';
+import { LogBufferModule } from '../scheduler/log-buffer.module';
+import { SettingsModule } from '../settings/settings.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([PluginPackage, PluginSource, PluginRegistration]), AuthModule, EventsModule],
+  imports: [
+    TypeOrmModule.forFeature([PluginPackage, PluginSource, PluginRegistration]),
+    AuthModule,
+    EventsModule,
+    LogBufferModule,
+    SettingsModule,
+  ],
   controllers: [
     PluginLogoController,
     PluginIndexerDescriptorsController,
@@ -29,6 +39,8 @@ import { EventsModule } from '../scheduler/events.module';
   providers: [
     PluginRegistryService,
     PluginWebhookDispatcherService,
+    PluginProcessService,
+    PluginProcessEventDispatcherService,
     PluginCatalogClientService,
     PluginStagingService,
     PluginInstallService,

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
@@ -1,7 +1,7 @@
 import { spawn, type ChildProcess } from 'child_process';
 import { createServer, type Server, type Socket } from 'net';
 import { randomBytes } from 'crypto';
-import { chmodSync, mkdirSync, unlinkSync } from 'fs';
+import { chmodSync, chownSync, mkdirSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { getPluginsSocketDir } from '../../../common/constants/paths';
 import type { OnApplicationShutdown } from '@nestjs/common';
@@ -10,7 +10,13 @@ import { CURRENT_FLIKS_VERSION } from '../plugin-registry.service';
 import { PLUGIN_API_VERSION, type Note } from '../../../common/plugin-contract';
 import { RpcChannel } from './rpc-channel';
 import { NoteRingBuffer } from './note-ring-buffer';
-import { buildSpawnPlan } from './spawn-plan';
+import {
+  buildSpawnPlan,
+  prepareDirForDroppedChild,
+  shouldDropPrivileges,
+  PLUGIN_CHILD_UID,
+  PLUGIN_CHILD_GID,
+} from './spawn-plan';
 import { writePidFile, removePidFile } from './pid-file';
 
 export type SupervisorState =
@@ -63,11 +69,13 @@ export interface PluginSupervisorOptions {
   logCapBytesPerMinute?: number;
 }
 
-function listenAndChmod(server: Server, path: string): Promise<void> {
+/** 0600 keeps a second plugin out; the chown is what lets the dropped child in at all. */
+function listenAndRestrict(server: Server, path: string, dropTo: { uid: number; gid: number } | null): Promise<void> {
   return new Promise((resolve, reject) => {
     server.once('error', reject);
     server.listen(path, () => {
       chmodSync(path, 0o600);
+      if (dropTo) chownSync(path, dropTo.uid, dropTo.gid);
       resolve();
     });
   });
@@ -167,6 +175,13 @@ export class PluginSupervisor implements OnApplicationShutdown {
     return () => {
       this.stateListeners = this.stateListeners.filter((l) => l !== cb);
     };
+  }
+
+  /** Non-null only when the child will run as another uid, which is the only case needing a chown. */
+  private dropTarget(): { uid: number; gid: number } | null {
+    return shouldDropPrivileges(process.platform, process.getuid?.bind(process))
+      ? { uid: PLUGIN_CHILD_UID, gid: PLUGIN_CHILD_GID }
+      : null;
   }
 
   private setState(s: SupervisorState): void {
@@ -274,9 +289,10 @@ export class PluginSupervisor implements OnApplicationShutdown {
       }
       this.onPluginConnected(s);
     });
+    const dropTo = this.dropTarget();
     await Promise.all([
-      listenAndChmod(this.coreServer, this.coreSockPath),
-      listenAndChmod(this.pluginServer, this.pluginSockPath),
+      listenAndRestrict(this.coreServer, this.coreSockPath, dropTo),
+      listenAndRestrict(this.pluginServer, this.pluginSockPath, dropTo),
     ]);
   }
 
@@ -307,7 +323,9 @@ export class PluginSupervisor implements OnApplicationShutdown {
     this.lastExitSignal = null;
 
     this.setState('starting');
-    mkdirSync(join(this.opts.dir, 'data'), { recursive: true });
+    const dropTo = this.dropTarget();
+    if (dropTo) prepareDirForDroppedChild(this.opts.dir, dropTo.uid, dropTo.gid);
+    else mkdirSync(join(this.opts.dir, 'data'), { recursive: true });
     this.token = randomBytes(32).toString('hex');
 
     const plan = buildSpawnPlan({

--- a/backend/src/modules/plugins/supervisor/spawn-plan.spec.ts
+++ b/backend/src/modules/plugins/supervisor/spawn-plan.spec.ts
@@ -1,5 +1,13 @@
+import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { PLUGIN_API_VERSION } from '../../../common/plugin-contract';
-import { buildSpawnPlan, resolvePermissionFlag, shouldDropPrivileges } from './spawn-plan';
+import {
+  buildSpawnPlan,
+  prepareDirForDroppedChild,
+  resolvePermissionFlag,
+  shouldDropPrivileges,
+} from './spawn-plan';
 
 const EXPECTED_ENV_KEYS = [
   'PATH',
@@ -109,5 +117,51 @@ describe('buildSpawnPlan', () => {
     const plan = buildSpawnPlan(baseInput);
     expect(plan.options.cwd).toBe(`${baseInput.dir}/data`);
     expect(plan.options.stdio).toEqual(['ignore', 'pipe', 'pipe']);
+  });
+});
+
+describe('prepareDirForDroppedChild', () => {
+  // The real drop target is uid 65534, which needs root to chown to; passing our own
+  // uid keeps the chown legal so the mode contract is testable at any uid.
+  const uid = process.getuid!();
+  const gid = process.getgid!();
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'spawn-plan-perm-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  const mode = (p: string) => statSync(p).mode & 0o777;
+
+  it('opens the code dir and its files to the child while keeping them unwritable', () => {
+    // Exactly what extraction leaves behind: 0700 dir, 0600 files.
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    writeFileSync(join(dir, 'plugin.js'), 'x', { mode: 0o600 });
+    writeFileSync(join(dir, 'logo.svg'), '<svg/>', { mode: 0o600 });
+
+    prepareDirForDroppedChild(dir, uid, gid);
+
+    expect(mode(dir)).toBe(0o755);
+    expect(mode(join(dir, 'plugin.js'))).toBe(0o644);
+    expect(mode(join(dir, 'logo.svg'))).toBe(0o644);
+  });
+
+  it('hands the scratch dir to the child and nothing else', () => {
+    prepareDirForDroppedChild(dir, uid, gid);
+
+    const data = statSync(join(dir, 'data'));
+    expect(data.isDirectory()).toBe(true);
+    expect(data.uid).toBe(uid);
+    expect(mode(join(dir, 'data'))).toBe(0o700);
+  });
+
+  it('is idempotent across restarts', () => {
+    writeFileSync(join(dir, 'plugin.js'), 'x', { mode: 0o600 });
+    prepareDirForDroppedChild(dir, uid, gid);
+    prepareDirForDroppedChild(dir, uid, gid);
+
+    expect(mode(join(dir, 'plugin.js'))).toBe(0o644);
+    expect(mode(join(dir, 'data'))).toBe(0o700);
   });
 });

--- a/backend/src/modules/plugins/supervisor/spawn-plan.ts
+++ b/backend/src/modules/plugins/supervisor/spawn-plan.ts
@@ -1,5 +1,11 @@
 import { spawnSync, type SpawnOptions } from 'child_process';
+import { chmodSync, chownSync, mkdirSync, readdirSync } from 'fs';
+import { join } from 'path';
 import { PLUGIN_API_VERSION } from '../../../common/plugin-contract';
+
+/** The unprivileged identity a plugin child drops to when core runs as root. */
+export const PLUGIN_CHILD_UID = 65534;
+export const PLUGIN_CHILD_GID = 65534;
 
 let cachedPermissionFlag: string | null = null;
 
@@ -17,6 +23,23 @@ export function resolvePermissionFlag(): string {
 /** Root is an opportunistic bonus (Decision 25) — the drop only happens when it's true. */
 export function shouldDropPrivileges(platform: NodeJS.Platform, getuid?: () => number): boolean {
   return platform !== 'win32' && typeof getuid === 'function' && getuid() === 0;
+}
+
+/**
+ * A dropped child must reach its own code and its scratch dir through the kernel,
+ * not just through `--allow-fs-*`: extraction writes 0600 root-owned files into a
+ * 0700 directory. Code stays root-owned and read-only to the child; only `data/`
+ * changes hands.
+ */
+export function prepareDirForDroppedChild(dir: string, uid = PLUGIN_CHILD_UID, gid = PLUGIN_CHILD_GID): void {
+  const dataDir = join(dir, 'data');
+  mkdirSync(dataDir, { recursive: true });
+  chmodSync(dir, 0o755);
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isFile()) chmodSync(join(dir, entry.name), 0o644);
+  }
+  chownSync(dataDir, uid, gid);
+  chmodSync(dataDir, 0o700);
 }
 
 export interface SpawnPlanInput {
@@ -84,7 +107,7 @@ export function buildSpawnPlan(input: SpawnPlanInput): SpawnPlan {
     detached: false,
     windowsHide: true,
     env,
-    ...(root ? { uid: 65534, gid: 65534 } : {}),
+    ...(root ? { uid: PLUGIN_CHILD_UID, gid: PLUGIN_CHILD_GID } : {}),
   };
 
   const expectedCmdline = [process.execPath, ...nodeArgv];

--- a/backend/src/modules/scheduler/log-buffer.module.ts
+++ b/backend/src/modules/scheduler/log-buffer.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { LogBufferService } from './log-buffer.service';
+
+/** Split out of `FliksSchedulerModule` — that module reaches `PluginsModule` (via `IndexersModule`),
+ *  so a plugin service importing it for this alone would cycle back on itself. */
+@Module({
+  providers: [LogBufferService],
+  exports: [LogBufferService],
+})
+export class LogBufferModule {}

--- a/backend/src/modules/scheduler/scheduler.module.ts
+++ b/backend/src/modules/scheduler/scheduler.module.ts
@@ -16,7 +16,7 @@ import { CompletionService } from './completion.service';
 import { AcquisitionEventsService } from './acquisition-events.service';
 import { NamingService } from './naming.service';
 import { BackupService } from './backup.service';
-import { LogBufferService } from './log-buffer.service';
+import { LogBufferModule } from './log-buffer.module';
 import { UpdateCheckService } from './update-check.service';
 import { CommandsController } from './commands.controller';
 import { SystemController } from './system.controller';
@@ -80,6 +80,7 @@ import { LibraryIngestModule } from '../../common/library-ingest/library-ingest.
     ProfilesModule,
     MarkersModule,
     forwardRef(() => LibraryIngestModule),
+    LogBufferModule,
   ],
   controllers: [CommandsController, SystemController, LivenessController],
   providers: [
@@ -88,7 +89,6 @@ import { LibraryIngestModule } from '../../common/library-ingest/library-ingest.
     AcquisitionEventsService,
     NamingService,
     BackupService,
-    LogBufferService,
     UpdateCheckService,
     SubtitleSchedulerService,
   ],
@@ -97,7 +97,7 @@ import { LibraryIngestModule } from '../../common/library-ingest/library-ingest.
     CompletionService,
     AcquisitionEventsService,
     NamingService,
-    LogBufferService,
+    LogBufferModule,
     SubtitleSchedulerService,
   ],
 })


### PR DESCRIPTION
PR 3.5a of the plugin-system plan. 3.5 as the plan scopes it is the HTTP proxy *plus* the supervisor wiring *plus* three registries; it is split so each part can be verified on its own. This is the half that makes the `process` tier actually run, which is what unblocks phase 9 — a notification-target plugin needs spawning and events, not the proxy. 3.5b is the proxy, `PluginRouteGuard` and the declared-policy vocabulary; 3.5c the permission/jobs/checklist registries and `GET /api/plugins/ui`.

## What lands

`PluginProcessService` owns one supervisor per live `process` plugin. `startFor` runs materialise → provision-check → rotate password → read config → spawn, each stage returning its own failure reason (`tampered`, `db-provision-failed`, `spawn-failed`).

- **Materialised from the archive on every spawn**, never trusted from disk — see below.
- `provision()` is idempotent, so calling it on every boot is correct rather than wasteful.
- A fresh DB password per spawn, including on restart.
- `plugin_registrations` starts being used: its `enabled` flag is what `PATCH /api/plugins/:pluginId` writes, and why a disabled plugin stays down across restarts.
- `POST /api/plugins/:pluginId/restart` clears a tripped circuit breaker with a fresh supervisor.
- `GET /api/plugins` gains `processState` and `statusMessage` for process plugins.
- Domain events are forwarded to every running supervisor, unconditionally — the supervisor's ring buffer, not the caller, decides queue versus send.

## The #917 defect this fixes

**A `process` plugin could not have started at all on a real deployment.** Core is uid 0 under Docker, so `shouldDropPrivileges` always fires and the child runs as uid 65534 — but nothing was prepared for that uid:

| What the child needs | What it got | Result |
|---|---|---|
| Connect to both sockets | `root:root 0600`, chmod'd but never chowned | `EACCES`; endless `handshaking → crashed → backoff` |
| Read its own `plugin.js` | `root:root 0600`, from extraction's `writeGuardedFile` | node dies before executing a line |
| Write `data/` (its cwd and `HOME`) | `root:root 0755` | `EPERM` |

All three reproduced directly with `setpriv --reuid=65534`. The plan specified this — "the **0600 chowned** socket", and `data/` "**chowned** to the plugin uid in root mode" — the implementation did the chmod half only. The supervisor's 46 tests could not catch it: jest never runs as root, so the drop never happens under test, and the code worked everywhere except production.

Fixed at the source. The resulting shape is tighter than a blanket chown: the code dir becomes `0755` and its files `0644`, both still root-owned so the child can read but **not** write them; only `data/` changes hands, at `0700`. Verified with `setpriv`: read code OK, write code denied, create-in-code-dir denied, write scratch OK. Three tests pin the mode contract by passing the caller's own uid as the drop target, so they run at any uid.

## Two other corrections worth calling out

**The backoff ladder and circuit breaker were being defeated.** The first draft resolved on the first `crashed` state and then stopped the supervisor — so a plugin that would have recovered on retry was killed permanently and the breaker could never count past one. `crashed`/`backoff` are now treated as the ladder doing its job; only `ready`, `failed` or a handshake-deadline timeout ends the wait, and the supervisor is left running to retry on its own.

**A failed plugin stays observable.** The map previously held only successfully-started plugins, so `stateOf`/`statusMessageOf` returned `null`/`''` for a crash-looping plugin and `restart` was a silent no-op for it — dead paths for exactly the plugins an admin needs. The entry is now registered before the handshake settles and removed only by `stopFor`.

**L3 is not skipped.** A plugin is re-extracted from `plugin_packages.archive` on every spawn instead of being trusted when the directory already holds `plugin.js`, because extraction is what re-hashes every entry against the signed `files{}`. The shortcut would have skipped that check on precisely the persistent `FLIKS_RUNTIME_DIR` the plan recommends for operators keeping plugins off tmpfs.

**`events[].webhook` stays data-tier.** The declaration on a `process` manifest is still validated and still refuses an insecure or internal target, but it is no longer registered with the HTTP dispatcher — the plugin already receives those events over its socket, so fanning out would double every delivery. The previous code contradicted its own comment here.

## Verification

`tsc --noEmit` exit 0 (exit code read, not stdout). Full suite **1112 tests / 110 suites green**.

Two module cycles surfaced and were broken by extraction rather than `forwardRef`: `installedPluginDir`/`promoteDir` → `plugin-paths.ts`, `CURRENT_FLIKS_VERSION` → `plugin-version.ts`. `LogBufferService` became its own leaf module so `PluginsModule` can inject it without importing the scheduler.

Live, on the docker stack, with **three real process plugins** whose `plugin.js` speaks the actual JSON-RPC over both sockets — 37 assertions, all passing:

- install → `active` and the supervisor reaches `ready`; role, schema and exactly two `REFERENCES (id)` grants provisioned; one child process running;
- the child logs a DSN for **its own** role with `search_path` pinned to its own schema, and its `FLIKS_CFG_*` config;
- a `settings.changed` domain event arrives at the child over the socket;
- `PATCH { enabled: false }` stops the process and leaves no child; `enabled: true` brings it back to `ready`;
- the deliberately-crashing plugin runs its ladder and trips the breaker to `failed` with its stderr in `statusMessage`, without disturbing the healthy plugin and without leaving an orphan — the breaker path was measured separately at 6 crashes over 31.4 s;
- a plugin declaring `database.schema: false` gets no role and an empty DSN;
- after uninstall: no child processes, no roles, no schemas, no rows, sockets cleaned up, 840 media rows untouched.

## Not in scope

- The HTTP proxy, `PluginRouteGuard`, `objectGuard` registry — 3.5b.
- `PermissionRegistry`, the jobs registry, contributed checklist items, `GET /api/plugins/ui` — 3.5c.
- L1 (`state.json` quarantine) still has no owner; `FLIKS_PLUGINS_DISABLED` remains the rescue lever.
- One import in `plugin-supervisor.ts` still reaches `CURRENT_FLIKS_VERSION` through `plugin-registry.service` rather than the new `plugin-version.ts`; harmless today, worth repointing when that file is next touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)