### PR TITLE
feat(plugins): proxy a process plugin's declared routes behind a policy guard

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -30,6 +30,7 @@
         "passport": "^0.7.0",
         "passport-http-header-strategy": "^1.1.0",
         "passport-jwt": "^4.0.1",
+        "path-to-regexp": "^8.4.2",
         "pg": "^8.20.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -46,6 +46,7 @@
     "passport": "^0.7.0",
     "passport-http-header-strategy": "^1.1.0",
     "passport-jwt": "^4.0.1",
+    "path-to-regexp": "^8.4.2",
     "pg": "^8.20.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/backend/src/modules/plugins/plugin-install.service.ts
+++ b/backend/src/modules/plugins/plugin-install.service.ts
@@ -200,7 +200,7 @@ export class PluginInstallService {
 
   /** Safe to call for a plugin whose row, registry entry or directory is already gone. */
   async uninstall(pluginId: string): Promise<void> {
-    await this.registry.unregister(pluginId);
+    await this.registry.forget(pluginId);
     const pkg = await this.packageRepo.findOne({ where: { pluginId } });
     if (!pkg) return;
     if (pkg.manifest.kind === 'process') {

--- a/backend/src/modules/plugins/plugin-process.service.ts
+++ b/backend/src/modules/plugins/plugin-process.service.ts
@@ -109,6 +109,13 @@ export class PluginProcessService implements OnApplicationShutdown {
     return supervisor.getStatusMessage() || supervisor.getStderrTail();
   }
 
+  /** Passthrough so the HTTP proxy never touches a supervisor directly. */
+  callPlugin<T = unknown>(pluginId: string, method: string, params: unknown, timeoutMs: number): Promise<T> {
+    const supervisor = this.running.get(pluginId)?.supervisor;
+    if (!supervisor) return Promise.reject(new Error(`plugin "${pluginId}" is not running`));
+    return supervisor.callPlugin<T>(method, params, timeoutMs);
+  }
+
   /** Swaps in a fresh supervisor rather than reusing the tripped one, so the rotated password stays "once per spawn". */
   async restart(pluginId: string): Promise<void> {
     const entry = this.running.get(pluginId);

--- a/backend/src/modules/plugins/plugin-registry.service.routes.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.routes.spec.ts
@@ -1,0 +1,170 @@
+import { PluginRegistryService } from './plugin-registry.service';
+import { PluginPackage } from './entities/plugin-package.entity';
+import { minimalProcessManifest } from './archive/test-manifests';
+import { fakeRegistrationRepo, fakeProcessService } from './plugin-registry.test-helpers';
+import type { PluginManifest, PluginRoute } from '../../common/plugin-contract';
+import type { PluginProcessStartResult } from './plugin-process.service';
+
+/** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
+const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
+
+function makePackage(manifest: PluginManifest, overrides: Partial<PluginPackage> = {}): PluginPackage {
+  return {
+    id: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    pluginId: manifest.id,
+    version: manifest.version,
+    // Route validation runs before any archive materialisation — bytes never matter here.
+    archive: Buffer.alloc(0),
+    origin: 'manual',
+    signature: 'unsigned',
+    verifiedByKeyId: null,
+    manifest,
+    status: 'active',
+    ...overrides,
+  } as PluginPackage;
+}
+
+function repoMock(): { find: jest.Mock } {
+  return { find: jest.fn().mockResolvedValue([]) };
+}
+
+function makeService(startResult?: PluginProcessStartResult): PluginRegistryService {
+  return new PluginRegistryService(
+    repoMock() as never,
+    fakeRegistrationRepo() as never,
+    fakeProcessService(startResult) as never,
+  );
+}
+
+function processManifest(routes: PluginRoute[]) {
+  return minimalProcessManifest({ 'plugin.js': 'a'.repeat(64), 'logo.png': 'b'.repeat(64) }, { fliks: COMPATIBLE_RANGE, routes });
+}
+
+describe('PluginRegistryService — route registration validation', () => {
+  it('refuses a route with an unknown HTTP method', async () => {
+    const manifest = processManifest([{ method: 'FETCH', path: '/queue', policy: 'read:Media' }]);
+    const result = await makeService().register(makePackage(manifest));
+    expect(result).toEqual({ ok: false, pluginId: manifest.id, reason: 'invalid-route-method', detail: expect.any(String) });
+  });
+
+  it('refuses a route whose path does not start with "/"', async () => {
+    const manifest = processManifest([{ method: 'GET', path: 'queue', policy: 'read:Media' }]);
+    const result = await makeService().register(makePackage(manifest));
+    expect(result).toEqual({ ok: false, pluginId: manifest.id, reason: 'invalid-route-path', detail: expect.any(String) });
+  });
+
+  it('refuses a route whose path path-to-regexp cannot compile', async () => {
+    const manifest = processManifest([{ method: 'GET', path: '/queue/:', policy: 'read:Media' }]);
+    const result = await makeService().register(makePackage(manifest));
+    expect(result).toEqual({ ok: false, pluginId: manifest.id, reason: 'invalid-route-path', detail: expect.any(String) });
+  });
+
+  it('refuses a route whose policy the closed vocabulary does not accept', async () => {
+    const manifest = processManifest([{ method: 'GET', path: '/queue', policy: 'read:download' }]);
+    const result = await makeService().register(makePackage(manifest));
+    expect(result).toEqual({ ok: false, pluginId: manifest.id, reason: 'invalid-route-policy', detail: expect.any(String) });
+  });
+
+  it('refuses an objectGuard naming a param the path does not declare', async () => {
+    const manifest = processManifest([
+      { method: 'GET', path: '/queue', policy: 'read:Media', objectGuard: 'mediaAccessible:id' },
+    ]);
+    const result = await makeService().register(makePackage(manifest));
+    expect(result).toEqual({ ok: false, pluginId: manifest.id, reason: 'invalid-route-object-guard', detail: expect.any(String) });
+  });
+
+  it('refuses an objectGuard that does not resolve to one of the two known guards', async () => {
+    const manifest = processManifest([
+      { method: 'GET', path: '/releases/:id', policy: 'read:Media', objectGuard: 'deleteEverything:id' },
+    ]);
+    const result = await makeService().register(makePackage(manifest));
+    expect(result).toEqual({ ok: false, pluginId: manifest.id, reason: 'invalid-route-object-guard', detail: expect.any(String) });
+  });
+
+  it('refuses two routes sharing the same method and path', async () => {
+    const manifest = processManifest([
+      { method: 'GET', path: '/queue', policy: 'read:Media' },
+      { method: 'get', path: '/queue', policy: 'manage:Settings' },
+    ]);
+    const result = await makeService().register(makePackage(manifest));
+    expect(result).toEqual({ ok: false, pluginId: manifest.id, reason: 'duplicate-route', detail: expect.any(String) });
+  });
+
+  it('accepts a manifest whose routes all validate, and resolves them afterwards', async () => {
+    const manifest = processManifest([
+      { method: 'GET', path: '/queue', policy: 'read:Media' },
+      { method: 'GET', path: '/releases/:id', policy: 'grab:Media', objectGuard: 'mediaAccessible:id' },
+    ]);
+    const service = makeService();
+
+    const result = await service.register(makePackage(manifest));
+
+    expect(result).toEqual({ ok: true, pluginId: manifest.id });
+    expect(service.resolveRoute(manifest.id, 'GET', '/queue')).toEqual({
+      route: manifest.routes[0],
+      params: {},
+    });
+    expect(service.resolveRoute(manifest.id, 'POST', '/queue')).toBeNull();
+  });
+
+  it('keeps the route table on unregister, so a stopped plugin is unavailable rather than forbidden', async () => {
+    const manifest = processManifest([{ method: 'GET', path: '/queue', policy: 'read:Media' }]);
+    const service = makeService();
+    await service.register(makePackage(manifest));
+
+    await service.unregister(manifest.id);
+
+    expect(service.resolveRoute(manifest.id, 'GET', '/queue')).not.toBeNull();
+    expect(service.get(manifest.id)).toBeUndefined();
+  });
+
+  it('drops the route table on forget, which is what uninstall calls', async () => {
+    const manifest = processManifest([{ method: 'GET', path: '/queue', policy: 'read:Media' }]);
+    const service = makeService();
+    await service.register(makePackage(manifest));
+
+    await service.forget(manifest.id);
+
+    expect(service.resolveRoute(manifest.id, 'GET', '/queue')).toBeNull();
+  });
+
+  it('keeps the routes resolvable when activation fails, but drops them when the manifest is unusable', async () => {
+    const service = makeService({ ok: false, reason: 'spawn-failed', detail: 'boom' });
+    const spawnable = processManifest([{ method: 'GET', path: '/queue', policy: 'read:Media' }]);
+
+    const failed = await service.register(makePackage(spawnable));
+
+    expect(failed).toMatchObject({ ok: false, reason: 'spawn-failed' });
+    expect(service.resolveRoute(spawnable.id, 'GET', '/queue')).not.toBeNull();
+
+    const unusable = processManifest([{ method: 'GET', path: '/queue', policy: 'read:NoSuchSubject' }]);
+    const refused = await makeService().register(makePackage(unusable));
+
+    expect(refused).toMatchObject({ ok: false, reason: 'invalid-route-policy' });
+  });
+
+  it('rebuilds the route table on re-registration rather than merging with the old one', async () => {
+    const service = makeService();
+    const first = processManifest([{ method: 'GET', path: '/queue', policy: 'read:Media' }]);
+    await service.register(makePackage(first));
+
+    const second = processManifest([{ method: 'GET', path: '/releases/:id', policy: 'grab:Media' }]);
+    await service.register(makePackage({ ...second, id: first.id } as never));
+
+    expect(service.resolveRoute(first.id, 'GET', '/queue')).toBeNull();
+    expect(service.resolveRoute(first.id, 'GET', '/releases/42')).not.toBeNull();
+  });
+
+  it('leaves no route table behind for a plugin that fails an unrelated, earlier registration check', async () => {
+    const manifest = processManifest([{ method: 'GET', path: '/queue', policy: 'read:Media' }]);
+    manifest.fliks = '>=99.0.0'; // incompatible on purpose — fails before route validation even runs
+    const service = makeService();
+
+    const result = await service.register(makePackage(manifest));
+
+    expect(result.ok).toBe(false);
+    expect(service.resolveRoute(manifest.id, 'GET', '/queue')).toBeNull();
+  });
+});

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import * as net from 'net';
 import * as semver from 'semver';
+import { pathToRegexp, type Keys } from 'path-to-regexp';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { PluginRegistration } from './entities/plugin-registration.entity';
 import { PluginProcessService } from './plugin-process.service';
@@ -19,10 +20,14 @@ import {
   type ProcessPluginManifest,
   type IndexerDescriptor,
   type PluginWebhookEventName,
+  type PluginRoute,
 } from '../../common/plugin-contract';
 import { OFFICIAL_KEYS, resolveTrust, readArchiveEntries, type TrustOutcome } from './archive';
 import { isInternalAddress } from './internal-address';
 import type { DomainEvent } from '../scheduler/events.service';
+import { PluginRouteTable, type ResolvedPluginRoute } from './proxy/plugin-route-table';
+import { parseDeclaredPolicy } from './proxy/policy-vocabulary';
+import { parseObjectGuard } from './proxy/plugin-object-guards.service';
 
 const WEBHOOK_EVENT_NAMES: ReadonlySet<string> = new Set(PLUGIN_WEBHOOK_EVENT_NAMES);
 
@@ -43,6 +48,9 @@ export { CURRENT_FLIKS_VERSION };
 
 /** The only `driverApi` core knows how to run a search through today. */
 const SUPPORTED_INDEXER_DRIVER_APIS: ReadonlySet<string> = new Set(['torznab']);
+
+/** A manifest route's `method` must be one of these, compared case-insensitively. */
+const KNOWN_HTTP_METHODS: ReadonlySet<string> = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']);
 
 function isAbsoluteHttpUrl(value: string): boolean {
   try {
@@ -76,10 +84,27 @@ export type PluginRegistrationFailureReason =
   | 'invalid-webhook-url'
   | 'insecure-webhook-scheme'
   | 'internal-webhook-host'
+  | 'invalid-route-method'
+  | 'invalid-route-path'
+  | 'invalid-route-policy'
+  | 'invalid-route-object-guard'
+  | 'duplicate-route'
   | 'disabled'
   | 'tampered'
   | 'db-provision-failed'
   | 'spawn-failed';
+
+/**
+ * Failures where the plugin is installed and its manifest is sound — only its process
+ * isn't up. Its declared routes stay resolvable so they answer 503 rather than 403,
+ * which is the difference between "unavailable" and "you may not".
+ */
+const INSTALLED_BUT_NOT_RUNNING: ReadonlySet<PluginRegistrationFailureReason> = new Set([
+  'disabled',
+  'tampered',
+  'db-provision-failed',
+  'spawn-failed',
+]);
 
 export interface PluginRegistrationSuccess {
   ok: true;
@@ -109,6 +134,8 @@ export class PluginRegistryService implements OnModuleInit {
   /** Keyed by plugin id; entries are already validated (URL, scheme, event name) — the
    *  dispatcher trusts this without re-checking any of that. */
   private readonly webhookDeclarations = new Map<string, { event: PluginWebhookEventName; webhook: string }[]>();
+  /** Keyed by plugin id; compiled once per `register()` from already-validated routes. */
+  private readonly routeTables = new Map<string, PluginRouteTable>();
 
   constructor(
     @InjectRepository(PluginPackage)
@@ -174,6 +201,13 @@ export class PluginRegistryService implements OnModuleInit {
     if (!webhookCheck.ok) return this.fail(pkg.pluginId, webhookCheck.reason, webhookCheck.detail);
 
     if (manifest.kind === 'process') {
+      const routesCheck = this.validateRoutes(manifest.routes);
+      if (!routesCheck.ok) return this.fail(pkg.pluginId, routesCheck.reason, routesCheck.detail);
+
+      // Installed before running: what a plugin declares stays true while its process is
+      // down, so a request to one of its routes can answer 503 instead of a bare Forbidden.
+      this.replaceRouteTable(pkg.pluginId, manifest.routes);
+
       const activation = await this.activateProcess(pkg, manifest);
       if (!activation.ok) return activation;
     }
@@ -189,9 +223,18 @@ export class PluginRegistryService implements OnModuleInit {
     });
     this.replaceIndexerDescriptors(pkg.pluginId, descriptorCheck.descriptors);
     this.replaceWebhookDeclarations(pkg.pluginId, manifest.kind === 'data' ? webhookCheck.declarations : []);
+    this.replaceRouteTable(pkg.pluginId, manifest.kind === 'process' ? manifest.routes : []);
     return { ok: true, pluginId: pkg.pluginId };
   }
 
+  /** Uninstall: nothing the plugin declared is true any more, its routes included. */
+  async forget(pluginId: string): Promise<void> {
+    await this.unregister(pluginId);
+    this.replaceRouteTable(pluginId, []);
+  }
+
+  /** Withdraws what the plugin offers and stops its process, but keeps its declared routes:
+   *  a stopped plugin is unavailable, not forbidden. */
   async unregister(pluginId: string): Promise<void> {
     await this.processService.stopFor(pluginId);
     this.registry.delete(pluginId);
@@ -277,6 +320,12 @@ export class PluginRegistryService implements OnModuleInit {
     }));
   }
 
+  /** The declared route matching this method+path for a registered `process` plugin, or
+   *  `null` — no table (unregistered / `data` kind) and no match both refuse identically. */
+  resolveRoute(pluginId: string, method: string, path: string): ResolvedPluginRoute | null {
+    return this.routeTables.get(pluginId)?.resolve(method, path) ?? null;
+  }
+
   /** Every registered webhook subscribed to `eventType` — the dispatcher's fan-out list. */
   listWebhooksForEvent(eventType: string): { pluginId: string; webhook: string }[] {
     const out: { pluginId: string; webhook: string }[] = [];
@@ -302,6 +351,12 @@ export class PluginRegistryService implements OnModuleInit {
     for (const descriptor of descriptors) {
       this.indexerDescriptors.set(buildIndexerImplementationId(pluginId, descriptor.key), { pluginId, descriptor });
     }
+  }
+
+  /** Drops this plugin's previous route table (if any) and compiles `routes` into a fresh one. */
+  private replaceRouteTable(pluginId: string, routes: PluginRoute[]): void {
+    if (routes.length === 0) this.routeTables.delete(pluginId);
+    else this.routeTables.set(pluginId, new PluginRouteTable(routes));
   }
 
   /**
@@ -395,11 +450,53 @@ export class PluginRegistryService implements OnModuleInit {
     return { ok: true, declarations };
   }
 
+  /** The deep, semantic route check `manifest-parser.ts` defers (its field-type check already ran). */
+  private validateRoutes(
+    routes: PluginRoute[],
+  ): { ok: true } | { ok: false; reason: PluginRegistrationFailureReason; detail: string } {
+    const seen = new Set<string>();
+    for (const route of routes) {
+      const method = route.method.toUpperCase();
+      if (!KNOWN_HTTP_METHODS.has(method)) {
+        return { ok: false, reason: 'invalid-route-method', detail: `route method "${route.method}" is not a known HTTP verb` };
+      }
+      if (!route.path.startsWith('/')) {
+        return { ok: false, reason: 'invalid-route-path', detail: `route path "${route.path}" must start with "/"` };
+      }
+      let keys: Keys;
+      try {
+        keys = pathToRegexp(route.path).keys;
+      } catch (err) {
+        return { ok: false, reason: 'invalid-route-path', detail: `route path "${route.path}" is invalid: ${(err as Error).message}` };
+      }
+      if (!parseDeclaredPolicy(route.policy)) {
+        return { ok: false, reason: 'invalid-route-policy', detail: `route policy "${route.policy}" is not a recognised action:subject pair` };
+      }
+      if (route.objectGuard !== undefined) {
+        const parsedGuard = parseObjectGuard(route.objectGuard);
+        if (!parsedGuard || !keys.some((k) => k.name === parsedGuard.paramName)) {
+          return {
+            ok: false,
+            reason: 'invalid-route-object-guard',
+            detail: `route objectGuard "${route.objectGuard}" on path "${route.path}" does not resolve to a known guard and param`,
+          };
+        }
+      }
+      const dedupeKey = `${method} ${route.path}`;
+      if (seen.has(dedupeKey)) {
+        return { ok: false, reason: 'duplicate-route', detail: `duplicate route "${dedupeKey}"` };
+      }
+      seen.add(dedupeKey);
+    }
+    return { ok: true };
+  }
+
   /** Every failure path funnels here, so a failing re-registration can never leave a stale entry active. */
   private fail(pluginId: string, reason: PluginRegistrationFailureReason, detail: string): PluginRegistrationFailure {
     this.registry.delete(pluginId);
     this.replaceIndexerDescriptors(pluginId, []);
     this.replaceWebhookDeclarations(pluginId, []);
+    if (!INSTALLED_BUT_NOT_RUNNING.has(reason)) this.replaceRouteTable(pluginId, []);
     return { ok: false, pluginId, reason, detail };
   }
 

--- a/backend/src/modules/plugins/plugin-route-shadowing.spec.ts
+++ b/backend/src/modules/plugins/plugin-route-shadowing.spec.ts
@@ -1,0 +1,133 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import request from 'supertest';
+import { PluginsController } from './plugins.controller';
+import { PluginLogoController } from './plugin-logo.controller';
+import { PluginIndexerDescriptorsController } from './plugin-indexer-descriptors.controller';
+import { PluginSourcesController } from './plugin-sources.controller';
+import { PluginImportController } from './plugin-import.controller';
+import { PluginProxyController } from './proxy/plugin-proxy.controller';
+import { PluginRouteGuard } from './proxy/plugin-route.guard';
+import { PluginRegistryService } from './plugin-registry.service';
+import { PluginInstallService } from './plugin-install.service';
+import { PluginCatalogClientService } from './plugin-catalog-client.service';
+import { PluginProcessService } from './plugin-process.service';
+import { PluginSource } from './entities/plugin-source.entity';
+import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
+import { PoliciesGuard } from '../auth/casl/policies.guard';
+
+/** Every guard is stubbed to permit, so a request's outcome depends only on which controller's
+ *  handler Express actually dispatches to — this proves registration order, not policy logic. */
+describe('plugins/* route shadowing', () => {
+  let app: INestApplication;
+  let installService: Record<string, jest.Mock>;
+  let registry: Record<string, jest.Mock>;
+  let catalogClient: Record<string, jest.Mock>;
+  let processService: Record<string, jest.Mock>;
+  let sourceRepo: Record<string, jest.Mock>;
+
+  beforeAll(async () => {
+    installService = {
+      listInstalled: jest.fn().mockResolvedValue([]),
+      setEnabled: jest.fn().mockResolvedValue({}),
+      restart: jest.fn().mockResolvedValue(undefined),
+      uninstall: jest.fn().mockResolvedValue(undefined),
+      confirmImport: jest.fn().mockResolvedValue({}),
+    };
+    registry = {
+      get: jest.fn().mockReturnValue(undefined),
+      listIndexerDescriptors: jest.fn().mockReturnValue([]),
+      processStateOf: jest.fn().mockReturnValue(null),
+      processStatusMessageOf: jest.fn().mockReturnValue(''),
+    };
+    catalogClient = {};
+    processService = { callPlugin: jest.fn() };
+    sourceRepo = { find: jest.fn().mockResolvedValue([]) };
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [
+        PluginLogoController,
+        PluginIndexerDescriptorsController,
+        PluginSourcesController,
+        PluginImportController,
+        PluginsController,
+        // Last on purpose — mirrors plugins.module.ts's controllers[] order.
+        PluginProxyController,
+      ],
+      providers: [
+        { provide: PluginRegistryService, useValue: registry },
+        { provide: PluginInstallService, useValue: installService },
+        { provide: PluginCatalogClientService, useValue: catalogClient },
+        { provide: PluginProcessService, useValue: processService },
+        { provide: getRepositoryToken(PluginSource), useValue: sourceRepo },
+      ],
+    })
+      .overrideGuard(JwtOrApiKeyGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(PoliciesGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(PluginRouteGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('GET /plugins reaches PluginsController.list, not the proxy', async () => {
+    await request(app.getHttpServer()).get('/plugins').expect(200);
+    expect(installService.listInstalled).toHaveBeenCalledTimes(1);
+    expect(processService.callPlugin).not.toHaveBeenCalled();
+  });
+
+  it('DELETE /plugins/:pluginId reaches PluginsController.uninstall, not the proxy', async () => {
+    await request(app.getHttpServer()).delete('/plugins/fliks.testplugin').expect(204);
+    expect(installService.uninstall).toHaveBeenCalledWith('fliks.testplugin');
+    expect(processService.callPlugin).not.toHaveBeenCalled();
+  });
+
+  it('PATCH /plugins/:pluginId reaches PluginsController.setEnabled, not the proxy', async () => {
+    await request(app.getHttpServer()).patch('/plugins/fliks.testplugin').send({ enabled: false }).expect(200);
+    expect(installService.setEnabled).toHaveBeenCalledWith('fliks.testplugin', false);
+    expect(processService.callPlugin).not.toHaveBeenCalled();
+  });
+
+  it('POST /plugins/:pluginId/restart reaches PluginsController.restart, not the proxy', async () => {
+    await request(app.getHttpServer()).post('/plugins/fliks.testplugin/restart').expect(204);
+    expect(installService.restart).toHaveBeenCalledWith('fliks.testplugin');
+    expect(processService.callPlugin).not.toHaveBeenCalled();
+  });
+
+  it('GET /plugins/:pluginId/logo reaches PluginLogoController.logo, not the proxy', async () => {
+    await request(app.getHttpServer()).get('/plugins/fliks.testplugin/logo').expect(404);
+    expect(registry.get).toHaveBeenCalledWith('fliks.testplugin');
+    expect(processService.callPlugin).not.toHaveBeenCalled();
+  });
+
+  it('POST /plugins/import/confirm reaches PluginImportController.confirm, not the proxy', async () => {
+    await request(app.getHttpServer()).post('/plugins/import/confirm').send({ pluginId: 'x', version: '1.0.0' }).expect(201);
+    expect(installService.confirmImport).toHaveBeenCalledTimes(1);
+    expect(processService.callPlugin).not.toHaveBeenCalled();
+    expect(registry.processStateOf).not.toHaveBeenCalled();
+  });
+
+  it('GET /plugins/sources reaches PluginSourcesController.list, not the proxy', async () => {
+    await request(app.getHttpServer()).get('/plugins/sources').expect(200);
+    expect(sourceRepo.find).toHaveBeenCalledTimes(1);
+    expect(processService.callPlugin).not.toHaveBeenCalled();
+  });
+
+  it('a genuinely undeclared plugins/* path still reaches the proxy controller', async () => {
+    await request(app.getHttpServer()).get('/plugins/fliks.testplugin/some/route').expect(503);
+    expect(registry.processStateOf).toHaveBeenCalledWith('fliks.testplugin');
+  });
+});

--- a/backend/src/modules/plugins/plugins.module.ts
+++ b/backend/src/modules/plugins/plugins.module.ts
@@ -16,10 +16,14 @@ import { PluginIndexerDescriptorsController } from './plugin-indexer-descriptors
 import { PluginSourcesController } from './plugin-sources.controller';
 import { PluginImportController } from './plugin-import.controller';
 import { PluginsController } from './plugins.controller';
+import { PluginObjectGuardsService } from './proxy/plugin-object-guards.service';
+import { PluginRouteGuard } from './proxy/plugin-route.guard';
+import { PluginProxyController } from './proxy/plugin-proxy.controller';
 import { AuthModule } from '../auth/auth.module';
 import { EventsModule } from '../scheduler/events.module';
 import { LogBufferModule } from '../scheduler/log-buffer.module';
 import { SettingsModule } from '../settings/settings.module';
+import { LibrariesModule } from '../libraries/libraries.module';
 
 @Module({
   imports: [
@@ -28,6 +32,7 @@ import { SettingsModule } from '../settings/settings.module';
     EventsModule,
     LogBufferModule,
     SettingsModule,
+    LibrariesModule,
   ],
   controllers: [
     PluginLogoController,
@@ -35,6 +40,8 @@ import { SettingsModule } from '../settings/settings.module';
     PluginSourcesController,
     PluginImportController,
     PluginsController,
+    // Last: its `*splat` wildcard must never shadow the concrete routes above.
+    PluginProxyController,
   ],
   providers: [
     PluginRegistryService,
@@ -45,6 +52,8 @@ import { SettingsModule } from '../settings/settings.module';
     PluginStagingService,
     PluginInstallService,
     PluginDatabaseService,
+    PluginObjectGuardsService,
+    PluginRouteGuard,
   ],
   exports: [TypeOrmModule, PluginRegistryService, PluginDatabaseService],
 })

--- a/backend/src/modules/plugins/proxy/plugin-object-guards.service.spec.ts
+++ b/backend/src/modules/plugins/proxy/plugin-object-guards.service.spec.ts
@@ -1,0 +1,94 @@
+import { parseObjectGuard, parsePositiveInt, PluginObjectGuardsService } from './plugin-object-guards.service';
+import type { User } from '../../users/entities/user.entity';
+
+describe('parseObjectGuard', () => {
+  it('parses the two known guards', () => {
+    expect(parseObjectGuard('mediaAccessible:id')).toEqual({ guard: 'mediaAccessible', paramName: 'id' });
+    expect(parseObjectGuard('libraryAccessible:libraryId')).toEqual({ guard: 'libraryAccessible', paramName: 'libraryId' });
+  });
+
+  it.each([
+    ['unknown guard name', 'deleteEverything:id'],
+    ['no colon', 'mediaAccessible'],
+    ['empty param name', 'mediaAccessible:'],
+    ['too many parts', 'mediaAccessible:id:extra'],
+    ['empty string', ''],
+  ])('%s ("%s") -> null', (_label, spec) => {
+    expect(parseObjectGuard(spec)).toBeNull();
+  });
+});
+
+describe('parsePositiveInt', () => {
+  it.each([
+    ['1', 1],
+    ['42', 42],
+  ])('accepts %s -> %d', (raw, expected) => {
+    expect(parsePositiveInt(raw)).toBe(expected);
+  });
+
+  it.each([
+    ['0'],
+    ['-1'],
+    ['1.5'],
+    ['1e3'],
+    ['01'],
+    ['0x1'],
+    [' 1 '],
+    [''],
+    ['..'],
+    ['1abc'],
+    ['a/b'],
+    ['1'.repeat(40)],
+    ['NaN'],
+    ['Infinity'],
+  ])('rejects %j', (raw) => {
+    expect(parsePositiveInt(raw)).toBeNull();
+  });
+});
+
+function fakeUser(): User {
+  return { id: 7 } as User;
+}
+
+describe('PluginObjectGuardsService.check', () => {
+  function makeService(accessibleLibraryIds: number[]) {
+    const libraries = { getAccessibleLibraryIds: jest.fn().mockResolvedValue(accessibleLibraryIds) };
+    const mediaService = { assertAccessible: jest.fn().mockResolvedValue(undefined) };
+    const moduleRef = { get: jest.fn().mockReturnValue(mediaService) };
+    const service = new PluginObjectGuardsService(libraries as never, moduleRef as never);
+    return { service, libraries, mediaService };
+  }
+
+  it('libraryAccessible: true when the id is in the accessible set', async () => {
+    const { service, libraries } = makeService([1, 2, 3]);
+    await expect(service.check('libraryAccessible', '2', fakeUser())).resolves.toBe(true);
+    expect(libraries.getAccessibleLibraryIds).toHaveBeenCalledTimes(1);
+  });
+
+  it('libraryAccessible: false when the id is not in the accessible set', async () => {
+    const { service } = makeService([1, 2, 3]);
+    await expect(service.check('libraryAccessible', '99', fakeUser())).resolves.toBe(false);
+  });
+
+  it('mediaAccessible: true when MediaService.assertAccessible does not throw', async () => {
+    const { service, mediaService } = makeService([1]);
+    await expect(service.check('mediaAccessible', '55', fakeUser())).resolves.toBe(true);
+    expect(mediaService.assertAccessible).toHaveBeenCalledWith(55, [1]);
+  });
+
+  it('mediaAccessible: false when MediaService.assertAccessible throws', async () => {
+    const { service, mediaService } = makeService([1]);
+    mediaService.assertAccessible.mockRejectedValue(new Error('not found'));
+    await expect(service.check('mediaAccessible', '55', fakeUser())).resolves.toBe(false);
+  });
+
+  it.each(['0', '-1', '1.5', '01', '..', 'a/b', '1abc', ''])(
+    'never calls LibrariesService or MediaService for a rejected raw value %j',
+    async (raw) => {
+      const { service, libraries, mediaService } = makeService([1]);
+      await expect(service.check('mediaAccessible', raw, fakeUser())).resolves.toBe(false);
+      expect(libraries.getAccessibleLibraryIds).not.toHaveBeenCalled();
+      expect(mediaService.assertAccessible).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/backend/src/modules/plugins/proxy/plugin-object-guards.service.ts
+++ b/backend/src/modules/plugins/proxy/plugin-object-guards.service.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+import { LibrariesService } from '../../libraries/libraries.service';
+import { MediaService } from '../../media/media.service';
+import type { User } from '../../users/entities/user.entity';
+
+/** The only two object guards a manifest may declare — never a free-form expression. */
+export type ObjectGuardName = 'mediaAccessible' | 'libraryAccessible';
+
+const OBJECT_GUARD_NAMES: ReadonlySet<string> = new Set<ObjectGuardName>(['mediaAccessible', 'libraryAccessible']);
+
+export interface ParsedObjectGuard {
+  guard: ObjectGuardName;
+  paramName: string;
+}
+
+/** `"<guardName>:<paramName>"`, the guard name from the closed set above. Anything else is `null`. */
+export function parseObjectGuard(spec: string): ParsedObjectGuard | null {
+  const parts = spec.split(':');
+  if (parts.length !== 2) return null;
+  const [guard, paramName] = parts;
+  if (!OBJECT_GUARD_NAMES.has(guard) || paramName === '') return null;
+  return { guard: guard as ObjectGuardName, paramName };
+}
+
+/** Strict positive base-10 integer only — no `parseInt`/`Number()` coercion of signs, decimals,
+ *  leading zeros or whitespace, and nothing past `Number.MAX_SAFE_INTEGER`. */
+export function parsePositiveInt(raw: string): number | null {
+  if (!/^[1-9][0-9]*$/.test(raw)) return null;
+  const n = Number(raw);
+  return Number.isSafeInteger(n) ? n : null;
+}
+
+@Injectable()
+export class PluginObjectGuardsService {
+  constructor(
+    private readonly libraries: LibrariesService,
+    private readonly moduleRef: ModuleRef,
+  ) {}
+
+  /** Resolved lazily, at call time: a static import/DI edge here would close a
+   *  `Plugins -> Media -> Indexers -> Plugins` module cycle. */
+  private mediaService(): MediaService {
+    return this.moduleRef.get(MediaService, { strict: false });
+  }
+
+  /** The captured route param is attacker-controlled text; a value that isn't a
+   *  strict positive integer never reaches `LibrariesService`/`MediaService`. */
+  async check(guard: ObjectGuardName, rawValue: string, user: User): Promise<boolean> {
+    const id = parsePositiveInt(rawValue);
+    if (id === null) return false;
+
+    const accessibleLibraryIds = await this.libraries.getAccessibleLibraryIds(user);
+    if (guard === 'libraryAccessible') return accessibleLibraryIds.includes(id);
+
+    try {
+      await this.mediaService().assertAccessible(id, accessibleLibraryIds);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/backend/src/modules/plugins/proxy/plugin-proxy.controller.spec.ts
+++ b/backend/src/modules/plugins/proxy/plugin-proxy.controller.spec.ts
@@ -1,0 +1,207 @@
+import { HttpStatus } from '@nestjs/common';
+import type { Response } from 'express';
+import { PluginProxyController } from './plugin-proxy.controller';
+import { PluginInstallException } from '../plugin-install.exception';
+import type { PluginRouteRequest } from './plugin-route.guard';
+
+function fakeResponse(): Response & { status: jest.Mock; setHeader: jest.Mock; send: jest.Mock } {
+  const res = {
+    status: jest.fn(),
+    setHeader: jest.fn(),
+    send: jest.fn(),
+  };
+  res.status.mockReturnValue(res);
+  return res as unknown as Response & typeof res;
+}
+
+function fakeRequest(overrides: Partial<PluginRouteRequest> = {}): PluginRouteRequest {
+  return {
+    method: 'GET',
+    originalUrl: '/api/plugins/fliks.testplugin/releases/42',
+    params: { pluginId: 'fliks.testplugin' },
+    query: {},
+    body: undefined,
+    user: { id: 9 },
+    ...overrides,
+  } as unknown as PluginRouteRequest;
+}
+
+async function captureThrown(fn: () => Promise<unknown>): Promise<PluginInstallException> {
+  try {
+    await fn();
+  } catch (err) {
+    return err as PluginInstallException;
+  }
+  throw new Error('expected proxy() to throw');
+}
+
+function makeController(state: string | null, callPlugin: jest.Mock) {
+  const registry = {
+    processStateOf: jest.fn().mockReturnValue(state),
+    processStatusMessageOf: jest.fn().mockReturnValue('crashed hard'),
+  };
+  const processService = { callPlugin };
+  const controller = new PluginProxyController(registry as never, processService as never);
+  return { controller, registry, processService };
+}
+
+describe('PluginProxyController — plugin availability', () => {
+  it.each([
+    ['unregistered', null],
+    ['crashed', 'crashed'],
+    ['backoff', 'backoff'],
+  ])('503 PLUGIN_UNAVAILABLE when the supervisor state is %s', async (_label, state) => {
+    const callPlugin = jest.fn();
+    const { controller } = makeController(state, callPlugin);
+    const req = fakeRequest();
+    const res = fakeResponse();
+
+    const err = await captureThrown(() => controller.proxy('fliks.testplugin', req, res));
+    expect(callPlugin).not.toHaveBeenCalled();
+    expect(err).toBeInstanceOf(PluginInstallException);
+    expect(err.getStatus()).toBe(HttpStatus.SERVICE_UNAVAILABLE);
+    expect(err.code).toBe('PLUGIN_UNAVAILABLE');
+    expect(err.message).toContain('fliks.testplugin');
+  });
+
+  it('503 PLUGIN_UNAVAILABLE when the RPC call itself rejects (e.g. a hung plugin past the deadline)', async () => {
+    const callPlugin = jest.fn().mockRejectedValue(new Error('timeout waiting for "http"'));
+    const { controller } = makeController('ready', callPlugin);
+    const req = fakeRequest();
+    const res = fakeResponse();
+
+    const err = await captureThrown(() => controller.proxy('fliks.testplugin', req, res));
+    expect(err).toBeInstanceOf(PluginInstallException);
+    expect(err.code).toBe('PLUGIN_UNAVAILABLE');
+    expect(err.getStatus()).toBe(HttpStatus.SERVICE_UNAVAILABLE);
+  });
+
+  it('forwards the request\'s own path (not the declared pattern), method, query, body and delegated principal', async () => {
+    const callPlugin = jest.fn().mockResolvedValue({ status: 200, headers: {}, body: { ok: true } });
+    const { controller, processService } = makeController('ready', callPlugin);
+    const req = fakeRequest({
+      method: 'POST',
+      originalUrl: '/api/plugins/fliks.testplugin/releases/42?x=1',
+      query: { x: '1' },
+      body: { grab: true },
+      user: { id: 9 } as never,
+    });
+    const res = fakeResponse();
+
+    await controller.proxy('fliks.testplugin', req, res);
+
+    expect(processService.callPlugin).toHaveBeenCalledWith(
+      'fliks.testplugin',
+      'http',
+      {
+        method: 'POST',
+        path: '/releases/42',
+        query: { x: '1' },
+        body: { grab: true },
+        principal: { kind: 'delegated', userId: 9 },
+      },
+      30_000,
+    );
+  });
+});
+
+describe('PluginProxyController — status clamping', () => {
+  it.each([
+    [200, 200],
+    [404, 404],
+    [100, 100],
+    [599, 599],
+    [0, HttpStatus.BAD_GATEWAY],
+    [99, HttpStatus.BAD_GATEWAY],
+    [600, HttpStatus.BAD_GATEWAY],
+    [1000, HttpStatus.BAD_GATEWAY],
+    [-1, HttpStatus.BAD_GATEWAY],
+    [200.5, HttpStatus.BAD_GATEWAY],
+    [NaN, HttpStatus.BAD_GATEWAY],
+    [undefined, HttpStatus.BAD_GATEWAY],
+    ['200', HttpStatus.BAD_GATEWAY],
+  ])('plugin status %j -> %d', async (pluginStatus, expected) => {
+    const callPlugin = jest.fn().mockResolvedValue({ status: pluginStatus, headers: {}, body: {} });
+    const { controller } = makeController('ready', callPlugin);
+    const res = fakeResponse();
+
+    await controller.proxy('fliks.testplugin', fakeRequest(), res);
+
+    expect(res.status).toHaveBeenCalledWith(expected);
+  });
+});
+
+describe('PluginProxyController — response header allowlist', () => {
+  it('keeps only the allowed headers and drops everything else, including session/navigation-steering ones', async () => {
+    const callPlugin = jest.fn().mockResolvedValue({
+      status: 200,
+      headers: {
+        'Set-Cookie': 'session=hijacked',
+        Location: 'https://evil.example.com',
+        Authorization: 'Bearer stolen',
+        'x-frame-options': 'DENY',
+        'Content-Type': 'application/json',
+      },
+      body: {},
+    });
+    const { controller } = makeController('ready', callPlugin);
+    const res = fakeResponse();
+
+    await controller.proxy('fliks.testplugin', fakeRequest(), res);
+
+    const setHeaderNames = res.setHeader.mock.calls.map(([name]: [string]) => name);
+    expect(setHeaderNames).toEqual(['Content-Type']);
+  });
+
+  it('drops a header name containing CRLF even if its lowercase form would otherwise be allowed', async () => {
+    const callPlugin = jest.fn().mockResolvedValue({
+      status: 200,
+      headers: { 'content-type\r\nX-Injected': 'evil' },
+      body: {},
+    });
+    const { controller } = makeController('ready', callPlugin);
+    const res = fakeResponse();
+
+    await controller.proxy('fliks.testplugin', fakeRequest(), res);
+
+    expect(res.setHeader).not.toHaveBeenCalled();
+  });
+
+  it('drops an allowlisted header whose value carries CRLF, which Node would throw on', async () => {
+    const callPlugin = jest.fn().mockResolvedValue({
+      status: 200,
+      headers: {
+        'content-disposition': 'attachment\r\nX-Smuggled: yes',
+        'content-type': 'text/plain',
+      },
+      body: {},
+    });
+    const { controller } = makeController('ready', callPlugin);
+    const res = fakeResponse();
+
+    await controller.proxy('fliks.testplugin', fakeRequest(), res);
+
+    const names = res.setHeader.mock.calls.map(([name]: [string]) => name.toLowerCase());
+    expect(names).toEqual(['content-type']);
+  });
+
+  it('keeps every header on the allowlist', async () => {
+    const callPlugin = jest.fn().mockResolvedValue({
+      status: 200,
+      headers: {
+        'content-type': 'text/plain',
+        'content-disposition': 'attachment; filename="x.txt"',
+        'cache-control': 'no-store',
+        etag: '"abc"',
+        'last-modified': 'Mon, 01 Jan 2024 00:00:00 GMT',
+      },
+      body: 'x',
+    });
+    const { controller } = makeController('ready', callPlugin);
+    const res = fakeResponse();
+
+    await controller.proxy('fliks.testplugin', fakeRequest(), res);
+
+    expect(res.setHeader).toHaveBeenCalledTimes(5);
+  });
+});

--- a/backend/src/modules/plugins/proxy/plugin-proxy.controller.ts
+++ b/backend/src/modules/plugins/proxy/plugin-proxy.controller.ts
@@ -1,0 +1,96 @@
+import { All, Controller, HttpStatus, Param, Req, Res, UseGuards } from '@nestjs/common';
+import type { Response } from 'express';
+import { JwtOrApiKeyGuard } from '../../auth/guards/jwt-or-api-key.guard';
+import { PluginRegistryService } from '../plugin-registry.service';
+import { PluginProcessService } from '../plugin-process.service';
+import { PluginInstallException } from '../plugin-install.exception';
+import { PluginRouteGuard, pluginRequestPath, type PluginRouteRequest } from './plugin-route.guard';
+
+const CALL_DEADLINE_MS = 30_000;
+
+/** Everything a data response needs, and nothing that steers the browser's session or
+ *  navigation — a plugin must never be able to set `Set-Cookie`, `Location` or `Authorization`. */
+const ALLOWED_RESPONSE_HEADERS: ReadonlySet<string> = new Set([
+  'content-type',
+  'content-disposition',
+  'cache-control',
+  'etag',
+  'last-modified',
+]);
+
+/** RFC 7230 token chars — rejects a header name a plugin could use to smuggle `\r\n` or a `:`. */
+const HEADER_NAME_RE = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+/** Node throws on these rather than emitting them, so an unchecked value is a plugin-triggerable 500. */
+const HEADER_VALUE_FORBIDDEN_RE = /[\r\n\0]/;
+
+function clampStatus(status: unknown): number {
+  return typeof status === 'number' && Number.isInteger(status) && status >= 100 && status <= 599
+    ? status
+    : HttpStatus.BAD_GATEWAY;
+}
+
+interface PluginHttpResult {
+  status: number;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+/** The inbound half of a `process` plugin's routes. Mounted last in `plugins.module.ts`'s
+ *  `controllers[]` so its `*splat` wildcard never shadows the concrete `plugins/*` routes above it. */
+@Controller()
+@UseGuards(JwtOrApiKeyGuard, PluginRouteGuard)
+export class PluginProxyController {
+  constructor(
+    private readonly registry: PluginRegistryService,
+    private readonly processService: PluginProcessService,
+  ) {}
+
+  @All('plugins/:pluginId/*splat')
+  async proxy(@Param('pluginId') pluginId: string, @Req() req: PluginRouteRequest, @Res() res: Response): Promise<void> {
+    const state = this.registry.processStateOf(pluginId);
+    if (state !== 'ready') {
+      throw new PluginInstallException(
+        HttpStatus.SERVICE_UNAVAILABLE,
+        'PLUGIN_UNAVAILABLE',
+        `plugin "${pluginId}" is unavailable (${this.registry.processStatusMessageOf(pluginId) || state || 'not running'})`,
+      );
+    }
+
+    // PluginRouteGuard already resolved the route and checked the policy/objectGuard;
+    // this handler forwards the request's own path, never the declared pattern.
+    const userId = req.user!.id;
+
+    let result: PluginHttpResult;
+    try {
+      result = await this.processService.callPlugin<PluginHttpResult>(
+        pluginId,
+        'http',
+        {
+          method: req.method,
+          path: pluginRequestPath(req),
+          query: req.query as Record<string, string>,
+          body: req.body,
+          principal: { kind: 'delegated', userId },
+        },
+        CALL_DEADLINE_MS,
+      );
+    } catch (err) {
+      throw new PluginInstallException(HttpStatus.SERVICE_UNAVAILABLE, 'PLUGIN_UNAVAILABLE', (err as Error).message);
+    }
+
+    res.status(clampStatus(result.status));
+    for (const [name, value] of Object.entries(result.headers ?? {})) {
+      if (
+        typeof value !== 'string' ||
+        HEADER_VALUE_FORBIDDEN_RE.test(value) ||
+        !HEADER_NAME_RE.test(name) ||
+        !ALLOWED_RESPONSE_HEADERS.has(name.toLowerCase())
+      ) {
+        continue;
+      }
+      res.setHeader(name, value);
+    }
+    res.send(result.body);
+  }
+}

--- a/backend/src/modules/plugins/proxy/plugin-route-table.spec.ts
+++ b/backend/src/modules/plugins/proxy/plugin-route-table.spec.ts
@@ -1,0 +1,67 @@
+import { PluginRouteTable } from './plugin-route-table';
+import type { PluginRoute } from '../../../common/plugin-contract';
+
+function route(overrides: Partial<PluginRoute> = {}): PluginRoute {
+  return { method: 'GET', path: '/queue', policy: 'read:Media', ...overrides };
+}
+
+describe('PluginRouteTable.resolve', () => {
+  const queueRoute = route();
+  const releaseRoute = route({ path: '/releases/:id', policy: 'grab:Media' });
+  const table = new PluginRouteTable([queueRoute, releaseRoute]);
+
+  it('exact hit', () => {
+    expect(table.resolve('GET', '/queue')).toEqual({ route: queueRoute, params: {} });
+  });
+
+  it('wrong method -> null', () => {
+    expect(table.resolve('POST', '/queue')).toBeNull();
+  });
+
+  it('unknown path -> null', () => {
+    expect(table.resolve('GET', '/unknown')).toBeNull();
+  });
+
+  it('trailing slash still matches (`/queue/` hits `/queue`)', () => {
+    expect(table.resolve('GET', '/queue/')).toEqual({ route: queueRoute, params: {} });
+  });
+
+  it('`/queue/../admin` does not match `/queue` — `..` is a literal segment, never resolved', () => {
+    expect(table.resolve('GET', '/queue/../admin')).toBeNull();
+  });
+
+  it('`//queue` (double leading slash) does not match `/queue`', () => {
+    expect(table.resolve('GET', '//queue')).toBeNull();
+  });
+
+  it('`/QUEUE` matches `/queue` — case-insensitive by default, left as-is (Express behaves the same app-wide)', () => {
+    expect(table.resolve('GET', '/QUEUE')).toEqual({ route: queueRoute, params: {} });
+  });
+
+  it('a `%2F` inside a param decodes to a literal `/` in the captured value', () => {
+    expect(table.resolve('GET', '/releases/40%2Fadmin')).toEqual({
+      route: releaseRoute,
+      params: { id: '40/admin' },
+    });
+  });
+
+  it('`..` as a param value is captured happily, not rejected by the route table itself', () => {
+    expect(table.resolve('GET', '/releases/..')).toEqual({ route: releaseRoute, params: { id: '..' } });
+  });
+
+  it('empty path -> null', () => {
+    expect(table.resolve('GET', '')).toBeNull();
+  });
+
+  it('a path longer than any declared route -> null', () => {
+    expect(table.resolve('GET', '/releases/1/2/3/way/too/long')).toBeNull();
+  });
+
+  it('`/releases/:id` is not hit by `/releases/` — an empty param does not match', () => {
+    expect(table.resolve('GET', '/releases/')).toBeNull();
+  });
+
+  it('method comparison is case-insensitive on the verb only', () => {
+    expect(table.resolve('get', '/queue')).toEqual({ route: queueRoute, params: {} });
+  });
+});

--- a/backend/src/modules/plugins/proxy/plugin-route-table.ts
+++ b/backend/src/modules/plugins/proxy/plugin-route-table.ts
@@ -1,0 +1,40 @@
+import { match, type MatchFunction } from 'path-to-regexp';
+import type { PluginRoute } from '../../../common/plugin-contract';
+
+export interface ResolvedPluginRoute {
+  route: PluginRoute;
+  params: Record<string, string>;
+}
+
+interface CompiledRoute {
+  method: string;
+  route: PluginRoute;
+  matcher: MatchFunction<Record<string, string>>;
+}
+
+/** One `process` manifest's `routes[]`, compiled once at `register()` — never per request.
+ *  `match()` is case-insensitive on the path by default; left as-is, Express matches app-wide the same way. */
+export class PluginRouteTable {
+  private readonly compiled: CompiledRoute[];
+
+  constructor(routes: readonly PluginRoute[]) {
+    this.compiled = routes.map((route) => ({
+      method: route.method.toUpperCase(),
+      route,
+      matcher: match<Record<string, string>>(route.path),
+    }));
+  }
+
+  /** No match — wrong method, unknown path, or a param that fails the pattern (e.g. an empty
+   *  capture) — is `null`, a refusal rather than "no route declared". */
+  resolve(method: string, path: string): ResolvedPluginRoute | null {
+    const wanted = method.toUpperCase();
+    for (const entry of this.compiled) {
+      if (entry.method !== wanted) continue;
+      const result = entry.matcher(path);
+      if (result === false) continue;
+      return { route: entry.route, params: result.params };
+    }
+    return null;
+  }
+}

--- a/backend/src/modules/plugins/proxy/plugin-route.guard.spec.ts
+++ b/backend/src/modules/plugins/proxy/plugin-route.guard.spec.ts
@@ -1,0 +1,105 @@
+import type { ExecutionContext } from '@nestjs/common';
+import { PluginRouteGuard, pluginRequestPath, RESOLVED_PLUGIN_ROUTE_KEY, type PluginRouteRequest } from './plugin-route.guard';
+import type { User } from '../../users/entities/user.entity';
+
+describe('pluginRequestPath', () => {
+  it.each([
+    ['/api/plugins/fliks.testplugin/queue', '/queue'],
+    ['/api/plugins/fliks.testplugin/releases/40%2Fadmin', '/releases/40%2Fadmin'],
+    ['/api/plugins/fliks.testplugin', ''],
+    // pluginId literally "plugins" — the *first* "/plugins/" in the raw URL is still ours.
+    ['/api/plugins/plugins/queue', '/queue'],
+  ])('extracts the raw remainder from %s', (originalUrl, expected) => {
+    expect(pluginRequestPath({ originalUrl } as never)).toBe(expected);
+  });
+
+  it('strips the query string before extracting the remainder', () => {
+    expect(pluginRequestPath({ originalUrl: '/api/plugins/x/queue?a=1' } as never)).toBe('/queue');
+  });
+});
+
+function fakeRequest(overrides: Partial<PluginRouteRequest> = {}): PluginRouteRequest {
+  return {
+    method: 'GET',
+    originalUrl: '/api/plugins/fliks.testplugin/queue',
+    params: { pluginId: 'fliks.testplugin' },
+    ...overrides,
+  } as unknown as PluginRouteRequest;
+}
+
+function fakeContext(req: PluginRouteRequest): ExecutionContext {
+  return { switchToHttp: () => ({ getRequest: () => req }) } as unknown as ExecutionContext;
+}
+
+describe('PluginRouteGuard', () => {
+  function makeGuard(resolvedRoute: unknown, canReturns = true) {
+    const registry = { resolveRoute: jest.fn().mockReturnValue(resolvedRoute) };
+    const objectGuards = { check: jest.fn().mockResolvedValue(true) };
+    const caslAbilityFactory = { createForUser: jest.fn().mockReturnValue({ can: jest.fn().mockReturnValue(canReturns) }) };
+    const guard = new PluginRouteGuard(registry as never, objectGuards as never, caslAbilityFactory as never);
+    return { guard, registry, objectGuards, caslAbilityFactory };
+  }
+
+  it('step 1: refuses when the route does not resolve', async () => {
+    const { guard, caslAbilityFactory } = makeGuard(null);
+    const req = fakeRequest({ user: { id: 1 } as User });
+    await expect(guard.canActivate(fakeContext(req))).resolves.toBe(false);
+    // Never even builds an ability for a route that isn't declared.
+    expect(caslAbilityFactory.createForUser).not.toHaveBeenCalled();
+  });
+
+  it('step 2: refuses when there is no req.user, even though the route resolved', async () => {
+    const { guard } = makeGuard({ route: { policy: 'read:Media' }, params: {} });
+    const req = fakeRequest({ user: undefined });
+    await expect(guard.canActivate(fakeContext(req))).resolves.toBe(false);
+  });
+
+  it('step 3: refuses when the declared policy is denied by the ability', async () => {
+    const { guard } = makeGuard({ route: { policy: 'read:Media' }, params: {} }, false);
+    const req = fakeRequest({ user: { id: 1 } as User });
+    await expect(guard.canActivate(fakeContext(req))).resolves.toBe(false);
+  });
+
+  it('step 4: refuses when the route\'s objectGuard denies the captured param', async () => {
+    const { guard, objectGuards } = makeGuard({
+      route: { policy: 'read:Media', objectGuard: 'mediaAccessible:id' },
+      params: { id: '42' },
+    });
+    objectGuards.check.mockResolvedValue(false);
+    const req = fakeRequest({ user: { id: 1 } as User });
+    await expect(guard.canActivate(fakeContext(req))).resolves.toBe(false);
+    expect(objectGuards.check).toHaveBeenCalledWith('mediaAccessible', '42', req.user);
+  });
+
+  it('step 4: refuses when the captured param is missing from the matched route', async () => {
+    const { guard, objectGuards } = makeGuard({
+      route: { policy: 'read:Media', objectGuard: 'mediaAccessible:id' },
+      params: {},
+    });
+    const req = fakeRequest({ user: { id: 1 } as User });
+    await expect(guard.canActivate(fakeContext(req))).resolves.toBe(false);
+    expect(objectGuards.check).not.toHaveBeenCalled();
+  });
+
+  it('refuses a route whose objectGuard fails to parse (registration should already have refused this manifest)', async () => {
+    const { guard } = makeGuard({ route: { policy: 'read:Media', objectGuard: 'not-a-guard' }, params: {} });
+    const req = fakeRequest({ user: { id: 1 } as User });
+    await expect(guard.canActivate(fakeContext(req))).resolves.toBe(false);
+  });
+
+  it('permits and stashes the resolved route on the request when every step passes', async () => {
+    const resolved = { route: { policy: 'read:Media' }, params: {} };
+    const { guard } = makeGuard(resolved);
+    const req = fakeRequest({ user: { id: 1 } as User });
+    await expect(guard.canActivate(fakeContext(req))).resolves.toBe(true);
+    expect(req[RESOLVED_PLUGIN_ROUTE_KEY]).toBe(resolved);
+  });
+
+  it('permits a route with a satisfied objectGuard', async () => {
+    const resolved = { route: { policy: 'read:Media', objectGuard: 'mediaAccessible:id' }, params: { id: '7' } };
+    const { guard, objectGuards } = makeGuard(resolved);
+    const req = fakeRequest({ user: { id: 1 } as User });
+    await expect(guard.canActivate(fakeContext(req))).resolves.toBe(true);
+    expect(objectGuards.check).toHaveBeenCalledWith('mediaAccessible', '7', req.user);
+  });
+});

--- a/backend/src/modules/plugins/proxy/plugin-route.guard.ts
+++ b/backend/src/modules/plugins/proxy/plugin-route.guard.ts
@@ -1,0 +1,62 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import type { Request } from 'express';
+import { PluginRegistryService } from '../plugin-registry.service';
+import type { ResolvedPluginRoute } from './plugin-route-table';
+import { CaslAbilityFactory } from '../../auth/casl/casl-ability.factory';
+import { PluginObjectGuardsService, parseObjectGuard } from './plugin-object-guards.service';
+import { checkDeclaredPolicy } from './policy-vocabulary';
+import type { User } from '../../users/entities/user.entity';
+
+export const RESOLVED_PLUGIN_ROUTE_KEY = 'pluginRoute' as const;
+
+export type PluginRouteRequest = Request & {
+  user?: User;
+  [RESOLVED_PLUGIN_ROUTE_KEY]?: ResolvedPluginRoute;
+};
+
+/** The raw (still percent-encoded) sub-path after `/plugins/<pluginId>` — rebuilding it from
+ *  `req.params.splat` would lose a `%2F` folded inside one segment's already-decoded value. */
+export function pluginRequestPath(req: Request): string {
+  const rawPath = req.originalUrl.split('?')[0];
+  const marker = rawPath.indexOf('/plugins/');
+  if (marker === -1) return '';
+  const afterPluginId = rawPath.slice(marker + '/plugins/'.length);
+  const nextSlash = afterPluginId.indexOf('/');
+  return nextSlash === -1 ? '' : afterPluginId.slice(nextSlash);
+}
+
+/** Stands in for `PoliciesGuard`, which reads `@CheckPolicies` from the handler — every request
+ *  here hits the same handler, so the policy has to come from the resolved route instead. */
+@Injectable()
+export class PluginRouteGuard implements CanActivate {
+  constructor(
+    private readonly registry: PluginRegistryService,
+    private readonly objectGuards: PluginObjectGuardsService,
+    private readonly caslAbilityFactory: CaslAbilityFactory,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest<PluginRouteRequest>();
+    const pluginId = req.params.pluginId;
+    if (typeof pluginId !== 'string') return false;
+
+    const resolved = this.registry.resolveRoute(pluginId, req.method, pluginRequestPath(req));
+    if (!resolved) return false;
+
+    if (!req.user) return false;
+
+    const ability = this.caslAbilityFactory.createForUser(req.user);
+    if (!checkDeclaredPolicy(resolved.route.policy, ability)) return false;
+
+    if (resolved.route.objectGuard) {
+      const parsedGuard = parseObjectGuard(resolved.route.objectGuard);
+      if (!parsedGuard) return false;
+      const value = resolved.params[parsedGuard.paramName];
+      if (typeof value !== 'string') return false;
+      if (!(await this.objectGuards.check(parsedGuard.guard, value, req.user))) return false;
+    }
+
+    req[RESOLVED_PLUGIN_ROUTE_KEY] = resolved;
+    return true;
+  }
+}

--- a/backend/src/modules/plugins/proxy/policy-vocabulary.spec.ts
+++ b/backend/src/modules/plugins/proxy/policy-vocabulary.spec.ts
@@ -1,0 +1,49 @@
+import { AbilityBuilder, createMongoAbility } from '@casl/ability';
+import type { AppAbility } from '../../auth/casl/casl-ability.factory';
+import { Action } from '../../auth/casl/actions.enum';
+import { Media } from '../../media/entities/media.entity';
+import { checkDeclaredPolicy, parseDeclaredPolicy } from './policy-vocabulary';
+
+function ability(setup: (can: AbilityBuilder<AppAbility>['can']) => void): AppAbility {
+  const { can, build } = new AbilityBuilder<AppAbility>(createMongoAbility);
+  setup(can);
+  return build();
+}
+
+describe('parseDeclaredPolicy', () => {
+  it('parses a valid action:Subject pair', () => {
+    expect(parseDeclaredPolicy('grab:Media')).toEqual({ action: Action.Grab, subject: Media });
+  });
+
+  it.each([
+    ['unparseable text', 'not-a-policy'],
+    ['unknown action', 'fly:Media'],
+    ['unknown subject', 'grab:Spaceship'],
+    ['wrong-case subject', 'grab:media'],
+    ['empty string', ''],
+    ['"manage" with no colon', 'manage'],
+    ['three-part string', 'a:b:c'],
+    // A plugin-declared subject (e.g. "read:download") needs `PermissionRegistry` (3.5c) —
+    // out of scope here, and must be refused, not silently accepted.
+    ['plugin-declared subject', 'read:download'],
+  ])('%s ("%s") -> null', (_label, policy) => {
+    expect(parseDeclaredPolicy(policy)).toBeNull();
+  });
+});
+
+describe('checkDeclaredPolicy', () => {
+  it('permits when the ability allows the parsed action:subject', () => {
+    const allowed = ability((can) => can(Action.Grab, Media));
+    expect(checkDeclaredPolicy('grab:Media', allowed)).toBe(true);
+  });
+
+  it('denies when the ability does not allow the parsed action:subject', () => {
+    const denied = ability(() => {});
+    expect(checkDeclaredPolicy('grab:Media', denied)).toBe(false);
+  });
+
+  it('fails closed on an unparseable policy regardless of how permissive the ability is', () => {
+    const allowAll = ability((can) => can(Action.Manage, 'all'));
+    expect(checkDeclaredPolicy('not-a-policy', allowAll)).toBe(false);
+  });
+});

--- a/backend/src/modules/plugins/proxy/policy-vocabulary.ts
+++ b/backend/src/modules/plugins/proxy/policy-vocabulary.ts
@@ -1,0 +1,60 @@
+import { Action } from '../../auth/casl/actions.enum';
+import type { AppAbility } from '../../auth/casl/casl-ability.factory';
+import { User } from '../../users/entities/user.entity';
+import { Media } from '../../media/entities/media.entity';
+import { FliksRequest } from '../../requests/entities/request.entity';
+import { Indexer } from '../../indexers/entities/indexer.entity';
+import { DownloadClient } from '../../download-clients/entities/download-client.entity';
+import { QualityProfile } from '../../profiles/entities/quality-profile.entity';
+import { LanguageProfile } from '../../profiles/entities/language-profile.entity';
+import { SubtitleProvider } from '../../subtitles/entities/subtitle-provider.entity';
+import { SubtitleFile } from '../../subtitles/entities/subtitle-file.entity';
+import { TranslationProvider } from '../../subtitles/entities/translation-provider.entity';
+import { Library } from '../../libraries/entities/library.entity';
+import { Playlist } from '../../playlists/entities/playlist.entity';
+
+type PolicySubject = Parameters<AppAbility['can']>[1];
+
+const ACTIONS: ReadonlySet<string> = new Set(Object.values(Action));
+
+/** Closed, case-sensitive subject vocabulary. A plugin-declared subject (`PermissionRegistry`,
+ *  3.5c) is deliberately absent — it must fail `parseDeclaredPolicy`, not fall through here. */
+const DECLARED_POLICY_SUBJECTS = new Map<string, PolicySubject>([
+  ['User', User],
+  ['Media', Media],
+  ['FliksRequest', FliksRequest],
+  ['Indexer', Indexer],
+  ['DownloadClient', DownloadClient],
+  ['QualityProfile', QualityProfile],
+  ['LanguageProfile', LanguageProfile],
+  ['SubtitleProvider', SubtitleProvider],
+  ['SubtitleFile', SubtitleFile],
+  ['TranslationProvider', TranslationProvider],
+  ['Library', Library],
+  ['Playlist', Playlist],
+  ['Settings', 'Settings'],
+]);
+
+export interface DeclaredPolicy {
+  action: Action;
+  subject: PolicySubject;
+}
+
+/** `"<action>:<Subject>"`, both halves from the closed vocabularies above — a manifest is
+ *  untrusted text, so a plugin-declared or wrong-case subject returns `null`, not a guess. */
+export function parseDeclaredPolicy(policy: string): DeclaredPolicy | null {
+  const parts = policy.split(':');
+  if (parts.length !== 2) return null;
+  const [action, subjectName] = parts;
+  if (!ACTIONS.has(action)) return null;
+  const subject = DECLARED_POLICY_SUBJECTS.get(subjectName);
+  if (subject === undefined) return null;
+  return { action: action as Action, subject };
+}
+
+/** Fail closed: an unparseable policy is denied, never treated as "no policy declared". */
+export function checkDeclaredPolicy(policy: string, ability: AppAbility): boolean {
+  const parsed = parseDeclaredPolicy(policy);
+  if (!parsed) return false;
+  return ability.can(parsed.action, parsed.subject);
+}

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
@@ -170,6 +170,15 @@ export class PluginSupervisor implements OnApplicationShutdown {
     return { coreSockPath: this.coreSockPath, pluginSockPath: this.pluginSockPath };
   }
 
+  /** Thin public wrapper around the private RPC channel, for the HTTP proxy. Rejects
+   *  immediately rather than queuing when the plugin isn't `ready` to answer a call. */
+  callPlugin<T = unknown>(method: string, params: unknown, timeoutMs: number): Promise<T> {
+    if (this.state !== 'ready' || !this.pluginChannel) {
+      return Promise.reject(new Error(`plugin "${this.opts.id}" is not ready (state: ${this.state})`));
+    }
+    return this.pluginChannel.call<T>(method, params, timeoutMs);
+  }
+
   onStateChange(cb: (s: SupervisorState) => void): () => void {
     this.stateListeners.push(cb);
     return () => {


### PR DESCRIPTION
PR 3.5b: the inbound HTTP proxy, the declared-policy vocabulary and the closed `objectGuard` registry. 3.5c is what remains of 3.5 — `PermissionRegistry`, the jobs registry, contributed checklist items and `GET /api/plugins/ui`.

## What lands

`ALL /api/plugins/:pluginId/*splat` resolves the request against the plugin's declared `routes[]`, checks it, and forwards it over the `http` RPC with `principal: { kind: 'delegated', userId }`.

- **Route matching is `path-to-regexp`**, already in the tree as an Express 5 dependency and now declared directly. A hand-rolled matcher on a security boundary is not worth the lines it saves. Express 5 is verified to reject `'/api/plugins/:id/*'` at registration; `*splat` is the form that registers.
- **`PluginRouteGuard` replaces `PoliciesGuard`**, which cannot serve this route: it reads `@CheckPolicies` from the handler and returns `true` when it finds none, so one wildcard handler could not vary its check per plugin route and would default to authorized-by-nobody. The guard refuses in order: route unresolved → no user → declared policy denied → objectGuard denied.
- **`policy` is a closed vocabulary**: the `Action` enum crossed with a closed subject map, matched case-sensitively — a manifest is untrusted text and `"media"` must not silently become `Media`. Validated at registration, so a bad manifest never reaches a request.
- **`objectGuard` is a two-entry registry** (`mediaAccessible`, `libraryAccessible`), never a free-form expression, and its param name must exist in the route's own path.
- Plugin-declared subjects (the plan's `"read:download"`) are refused with `invalid-route-policy` until 3.5c ships `PermissionRegistry`.

## The security decisions worth reviewing

**Captured params are attacker-controlled.** Probed against the real `path-to-regexp@8.4.2`: `:id` matches `..` happily, and `%2F` decodes to a real `/` **inside** one segment's value. So the danger is never the matching, it is what consumes the capture. Each object guard parses its param as a strict positive integer (`^[1-9][0-9]*$` plus a safe-integer check) and refuses anything else **before any service is consulted** — the specs assert the service mocks were never called.

**Response headers are an allowlist, name and value both screened.** A plugin may set a content type; it must never be able to set `Set-Cookie`, `Location` or `Authorization` — that is session fixation and an open redirect handed to a third-party author. Names must be RFC 7230 tokens. Values are screened for CR/LF/NUL too: Node *throws* on those rather than emitting them, so an unchecked value is not response splitting but a plugin-triggerable 500. A status outside 100–599 becomes 502.

**A stopped plugin answers 503, not 403.** What a plugin declares stays true while its process is down, so the route table now outlives activation and is dropped only by uninstall (`forget`, distinct from `unregister`). 403 there would tell the user they lack permission when the truth is the plugin is off — and 503 is the status the plan's down-state UI is built on. Failures that mean "installed but not running" (`disabled`, `spawn-failed`, `db-provision-failed`, `tampered`) keep the routes resolvable; failures that mean the manifest is unusable drop them.

## Verification

`tsc --noEmit` exit 0. Full suite **1227 tests / 117 suites green**.

Live on the docker stack with a plugin whose `plugin.js` really answers `http` and deliberately tries to smuggle headers back — **75 assertions, all passing**:

- the owner reaches every declared route and the plugin sees `{ kind: 'delegated', userId: 1 }`; query and body arrive intact;
- a member (role: `media.read`, `requests.create`) gets 200 on `read:Media`, **403** on `manage:Settings` and **403** on `grab:Media`, with the plugin seeing `userId: 2`; unauthenticated gets 401 — so a 403 in this suite genuinely means "policy denied" and not "auth broken";
- undeclared path, wrong method on a declared path, and a path deeper than any route are all refused;
- **five raw-socket traversal variants** (`..`, doubled `..`, `%2e%2e`, `//`, trailing `/.`) all refused without reaching `/admin`;
- 13 adversarial `objectGuard` params refused (`..`, `-1`, `1.5`, `1e3`, `01`, `0x1`, `0`, `NaN`, `Infinity`, `1abc`, `a%2Fb`, a 40-digit number), an inaccessible library id refused, an accessible one served;
- `Set-Cookie`, `Location`, `Authorization`, `x-frame-options`, a CRLF-bearing name and a CRLF-bearing value on an allowlisted name are all stripped, while `content-type` and `cache-control` survive; statuses `999` and `-1` become 502;
- the wildcard does not shadow `GET /plugins`, `GET /plugins/:id/logo`, `POST /plugins/:id/restart`, `PATCH /plugins/:id` or `DELETE /plugins/:id`;
- a disabled plugin's route returns `503 PLUGIN_UNAVAILABLE`;
- all eight deliberately-broken manifests are refused, each with its own reason (`invalid-route-policy`, `invalid-route-object-guard`, `duplicate-route`, `invalid-route-method`, `invalid-route-path`).

**One correction to my own method, recorded because it nearly produced a false finding:** the first run reported a traversal reaching `/admin`. That was `fetch`/undici collapsing `..` client-side per the WHATWG URL rules — the server never saw a traversal segment, and it correctly enforced `/admin`'s own policy on the normalised path. The assertion was measuring the HTTP client, not the proxy. The raw-socket block is the honest test, and it passes.

## Not in scope

- `legacyPaths` — no plugin declares any yet.
- `PermissionRegistry`, jobs registry, contributed checklist items, `GET /api/plugins/ui` — 3.5c.
- Guard refusals are a uniform 403 rather than per-step codes, deliberately: distinguishing "no such route" from "policy denied" would hand a prober an existence oracle.

Refs: #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)