### PR TITLE
feat(plugins): let a plugin declare its own permissions and jobs

### DIFF
--- a/backend/src/common/constants/core-scheduler-jobs.ts
+++ b/backend/src/common/constants/core-scheduler-jobs.ts
@@ -1,0 +1,20 @@
+/**
+ * Every core cron job's bare name, mirrored from `SchedulerService.SCHEDULERS`. Restated here
+ * (rather than imported) so `PluginRegistryService` can refuse a plugin job name that collides
+ * with one without `modules/plugins` importing the scheduler module back.
+ *
+ * `scheduler.service.ts` types `SCHEDULERS[number].name` against this same array, so adding a
+ * core job there without adding its name here fails to typecheck.
+ */
+export const CORE_SCHEDULER_JOB_NAMES = [
+  'SearchMissing',
+  'RefreshMetadata',
+  'RssSync',
+  'ImportCompleted',
+  'CleanStalled',
+  'CleanSeeded',
+  'SubtitleSearch',
+  'SubtitleUpgrade',
+] as const;
+
+export type CoreSchedulerJobName = (typeof CORE_SCHEDULER_JOB_NAMES)[number];

--- a/backend/src/common/constants/plugin-permissions.ts
+++ b/backend/src/common/constants/plugin-permissions.ts
@@ -1,0 +1,24 @@
+/**
+ * Vocabulary for plugin-declared CASL subjects. Self-contained — no imports from `modules/auth`
+ * or `modules/plugins` — so both can depend on it without creating an import cycle between them.
+ */
+
+/** Every plugin-declared subject lives under this prefix; a core subject never does. */
+export const PLUGIN_SUBJECT_PREFIX = 'plugin:';
+
+/** A raw permission name as written in a manifest's `permissions[]`, before namespacing.
+ *  Lowercase only and no `.`/`:` — either would let a name masquerade as a different plugin's
+ *  subject or a multi-segment path once it is namespaced. */
+export const PLUGIN_PERMISSION_NAME_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
+
+/** The CASL subject / grantable permission string a declared name resolves to. Core builds
+ *  this itself from the plugin's own immutable id — a plugin never writes the prefix itself. */
+export function pluginPermissionSubject(pluginId: string, name: string): string {
+  return `${PLUGIN_SUBJECT_PREFIX}${pluginId}:${name}`;
+}
+
+/** Shape only — whether this exact subject is currently declared by that plugin is the
+ *  plugin registry's job, not this function's. */
+export function isPluginPermissionSubject(value: string): boolean {
+  return value.startsWith(PLUGIN_SUBJECT_PREFIX) && value.length > PLUGIN_SUBJECT_PREFIX.length;
+}

--- a/backend/src/modules/auth/casl/casl-ability.factory.spec.ts
+++ b/backend/src/modules/auth/casl/casl-ability.factory.spec.ts
@@ -1,0 +1,39 @@
+import { CaslAbilityFactory } from './casl-ability.factory';
+import { Action } from './actions.enum';
+import type { User } from '../../users/entities/user.entity';
+
+function fakeUser(permissions: string[], isAdmin = false): User {
+  // `User.permissions` is a getter that overrides to `['manage:all']` when `isAdmin` — mirror
+  // that here rather than setting a plain `permissions` property the real class never has.
+  return { id: 1, isAdmin, permissions: isAdmin ? ['manage:all'] : permissions } as unknown as User;
+}
+
+describe('CaslAbilityFactory — plugin-declared subjects', () => {
+  const factory = new CaslAbilityFactory();
+
+  it('grants a plugin subject to a user holding the exact namespaced permission', () => {
+    const ability = factory.createForUser(fakeUser(['plugin:fliks.myplugin:download']));
+    expect(ability.can(Action.Read, 'plugin:fliks.myplugin:download')).toBe(true);
+    expect(ability.can(Action.Manage, 'plugin:fliks.myplugin:download')).toBe(true);
+  });
+
+  it('denies the subject to a user who does not hold that permission', () => {
+    const ability = factory.createForUser(fakeUser([]));
+    expect(ability.can(Action.Read, 'plugin:fliks.myplugin:download')).toBe(false);
+  });
+
+  it('never leaks a granted subject to a different plugin id', () => {
+    const ability = factory.createForUser(fakeUser(['plugin:fliks.myplugin:download']));
+    expect(ability.can(Action.Read, 'plugin:fliks.otherplugin:download')).toBe(false);
+  });
+
+  it('manage:all passes regardless of which plugin subject is asked for', () => {
+    const ability = factory.createForUser(fakeUser([], true));
+    expect(ability.can(Action.Read, 'plugin:fliks.myplugin:download')).toBe(true);
+  });
+
+  it('ignores a permission string that is not shaped like a plugin subject', () => {
+    const ability = factory.createForUser(fakeUser(['media.read']));
+    expect(ability.can(Action.Read, 'plugin:fliks.myplugin:download')).toBe(false);
+  });
+});

--- a/backend/src/modules/auth/casl/casl-ability.factory.ts
+++ b/backend/src/modules/auth/casl/casl-ability.factory.ts
@@ -18,6 +18,7 @@ import { TranslationProvider } from '../../subtitles/entities/translation-provid
 import { Library } from '../../libraries/entities/library.entity';
 import { Playlist } from '../../playlists/entities/playlist.entity';
 import { Action } from './actions.enum';
+import { isPluginPermissionSubject } from '../../../common/constants/plugin-permissions';
 
 type Subjects =
   | InferSubjects<
@@ -35,7 +36,9 @@ type Subjects =
       | typeof Playlist
     >
   | 'Settings'
-  | 'all';
+  | 'all'
+  /** A namespaced plugin subject (`plugin:<id>:<name>`) — see `common/constants/plugin-permissions`. */
+  | `plugin:${string}`;
 
 export type AppAbility = MongoAbility<[Action, Subjects]>;
 
@@ -51,6 +54,12 @@ export class CaslAbilityFactory {
     }
 
     const perms = new Set(user.permissions);
+
+    // Self-contained: `PluginRouteGuard` re-checks the subject against that same plugin's
+    // declared set, so granting it here needs no live plugin registry at all.
+    for (const perm of perms) {
+      if (isPluginPermissionSubject(perm)) can(Action.Manage, perm as `plugin:${string}`);
+    }
 
     // Every authenticated user can read/update themselves
     can(Action.Read, User, { id: user.id } as any);

--- a/backend/src/modules/plugins/plugin-install.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-install.service.spec.ts
@@ -7,7 +7,7 @@ import { PluginInstallException } from './plugin-install.exception';
 import { PluginStagingService } from './plugin-staging.service';
 import { PluginRegistryService } from './plugin-registry.service';
 import { PluginDatabaseService } from './plugin-database.service';
-import { fakeRegistrationRepo, fakeProcessService } from './plugin-registry.test-helpers';
+import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService } from './plugin-registry.test-helpers';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { PluginSource } from './entities/plugin-source.entity';
 import { buildZip, ZipEntrySpec } from './archive/zip-builder';
@@ -133,6 +133,7 @@ async function expectInstallError(promise: Promise<unknown>, status: number, cod
 
 describe('PluginInstallService', () => {
   let repo: ReturnType<typeof fakePackageRepo>;
+  let registrationRepo: ReturnType<typeof fakeRegistrationRepo>;
   let registry: PluginRegistryService;
   let staging: PluginStagingService;
   let pluginDb: ReturnType<typeof fakePluginDb>;
@@ -147,10 +148,24 @@ describe('PluginInstallService', () => {
     rmSync(stagingRoot(), { recursive: true, force: true });
     rmSync(join(getPluginsRuntimeDir(), 'installed'), { recursive: true, force: true });
     repo = fakePackageRepo();
-    registry = new PluginRegistryService(repo as never, fakeRegistrationRepo() as never, fakeProcessService() as never);
+    // One instance shared by both: the registry writes the registration row and uninstall
+    // deletes it, so two separate fakes would make either assertion vacuous.
+    registrationRepo = fakeRegistrationRepo();
+    registry = new PluginRegistryService(
+      repo as never,
+      registrationRepo as never,
+      fakeProcessService() as never,
+      fakePluginJobsService() as never,
+    );
     staging = new PluginStagingService();
     pluginDb = fakePluginDb();
-    service = new PluginInstallService(repo as never, registry, staging, pluginDb as unknown as PluginDatabaseService);
+    service = new PluginInstallService(
+      repo as never,
+      registrationRepo as never,
+      registry,
+      staging,
+      pluginDb as unknown as PluginDatabaseService,
+    );
   });
 
   afterEach(() => {
@@ -404,6 +419,23 @@ describe('PluginInstallService', () => {
       expect(existsSync(installedPluginDir(manifest.id, manifest.version))).toBe(false);
 
       await expect(service.uninstall(manifest.id)).resolves.toBeUndefined();
+    });
+
+    it('deletes the registration row, so a reinstall cannot inherit consented scopes and ingestRoots', async () => {
+      const files = { 'plugin.js': 'a'.repeat(64), 'logo.png': 'b'.repeat(64) };
+      const manifest = minimalProcessManifest(files, { id: 'fliks.grantleak', fliks: COMPATIBLE_RANGE });
+      registrationRepo.rows.set(manifest.id, {
+        pluginId: manifest.id,
+        ingestRoots: ['/downloads'],
+        scopes: ['media:read'],
+        enabled: true,
+        manifest,
+      } as never);
+
+      await service.uninstall(manifest.id);
+
+      expect(registrationRepo.delete).toHaveBeenCalledWith({ pluginId: manifest.id });
+      expect(registrationRepo.rows.has(manifest.id)).toBe(false);
     });
 
     it('deprovisions a process-tier package before removing its row; skips it for a data-tier one', async () => {

--- a/backend/src/modules/plugins/plugin-install.service.ts
+++ b/backend/src/modules/plugins/plugin-install.service.ts
@@ -7,6 +7,7 @@ import { closeSync, existsSync, fsyncSync, openSync, rmSync } from 'fs';
 import * as semver from 'semver';
 import { PluginPackage, PluginPackageOrigin, PluginPackageStatus } from './entities/plugin-package.entity';
 import { PluginSource } from './entities/plugin-source.entity';
+import { PluginRegistration } from './entities/plugin-registration.entity';
 import { PluginRegistryService, CURRENT_FLIKS_VERSION } from './plugin-registry.service';
 import { PluginStagingService } from './plugin-staging.service';
 import { PluginDatabaseService } from './plugin-database.service';
@@ -112,6 +113,8 @@ export class PluginInstallService {
   constructor(
     @InjectRepository(PluginPackage)
     private readonly packageRepo: Repository<PluginPackage>,
+    @InjectRepository(PluginRegistration)
+    private readonly registrationRepo: Repository<PluginRegistration>,
     private readonly registry: PluginRegistryService,
     private readonly staging: PluginStagingService,
     private readonly pluginDb: PluginDatabaseService,
@@ -201,6 +204,9 @@ export class PluginInstallService {
   /** Safe to call for a plugin whose row, registry entry or directory is already gone. */
   async uninstall(pluginId: string): Promise<void> {
     await this.registry.forget(pluginId);
+    // The registration row carries the consented `scopes` and `ingestRoots`: leaving it behind
+    // would let a reinstall silently inherit grants instead of asking for them again.
+    await this.registrationRepo.delete({ pluginId });
     const pkg = await this.packageRepo.findOne({ where: { pluginId } });
     if (!pkg) return;
     if (pkg.manifest.kind === 'process') {

--- a/backend/src/modules/plugins/plugin-jobs.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-jobs.service.spec.ts
@@ -1,0 +1,129 @@
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { PluginJobsService } from './plugin-jobs.service';
+import type { PluginJob } from '../../common/plugin-contract';
+
+/** Never fires during a test run — the point of every test here is the registry entry itself. */
+const FAR_FUTURE_CRON = '0 0 1 1 *';
+
+function job(overrides: Partial<PluginJob> = {}): PluginJob {
+  return { name: 'sync', cron: FAR_FUTURE_CRON, triggerable: true, labelKey: 'plugin.job.sync', ...overrides };
+}
+
+function fakeProcessService(state: 'ready' | 'crashed' | null = 'ready') {
+  return {
+    stateOf: jest.fn().mockReturnValue(state),
+    callPlugin: jest.fn().mockResolvedValue({ ok: true }),
+  };
+}
+
+// A real `CronJob` schedules a real (if far-future) `setTimeout`. Track every registry created
+// by a test and clear its jobs afterwards so no test leaves a live timer behind for Jest to trip on.
+const liveRegistries: SchedulerRegistry[] = [];
+function trackedRegistry(): SchedulerRegistry {
+  const registry = new SchedulerRegistry();
+  liveRegistries.push(registry);
+  return registry;
+}
+afterEach(() => {
+  for (const registry of liveRegistries.splice(0)) {
+    for (const name of registry.getCronJobs().keys()) registry.deleteCronJob(name);
+  }
+});
+
+describe('PluginJobsService', () => {
+  it('registers a real cron per declared job', () => {
+    const registry = trackedRegistry();
+    const service = new PluginJobsService(registry, fakeProcessService() as never);
+
+    service.replaceFor('fliks.p', [job()]);
+
+    expect(registry.doesExist('cron', 'plugin:fliks.p:sync')).toBe(true);
+  });
+
+  it('deregisters the cron when the plugin stops — proves no leaked cron outlives it', () => {
+    const registry = trackedRegistry();
+    const service = new PluginJobsService(registry, fakeProcessService() as never);
+    service.replaceFor('fliks.p', [job()]);
+    expect(registry.doesExist('cron', 'plugin:fliks.p:sync')).toBe(true);
+
+    service.dropFor('fliks.p');
+
+    expect(registry.doesExist('cron', 'plugin:fliks.p:sync')).toBe(false);
+  });
+
+  it('dropFor is a safe no-op for a plugin with nothing registered', () => {
+    const registry = trackedRegistry();
+    const service = new PluginJobsService(registry, fakeProcessService() as never);
+    expect(() => service.dropFor('fliks.never-registered')).not.toThrow();
+  });
+
+  it('re-registering replaces the previous crons rather than throwing on a duplicate name', () => {
+    const registry = trackedRegistry();
+    const service = new PluginJobsService(registry, fakeProcessService() as never);
+    service.replaceFor('fliks.p', [job({ name: 'sync' })]);
+
+    expect(() => service.replaceFor('fliks.p', [job({ name: 'sync', cron: '0 0 2 1 *' })])).not.toThrow();
+    expect(registry.doesExist('cron', 'plugin:fliks.p:sync')).toBe(true);
+  });
+
+  it('listDeclared reports every plugin currently registered', () => {
+    const registry = trackedRegistry();
+    const service = new PluginJobsService(registry, fakeProcessService() as never);
+    service.replaceFor('fliks.a', [job({ name: 'sync' })]);
+    service.replaceFor('fliks.b', [job({ name: 'sweep' })]);
+
+    expect(service.listDeclared()).toEqual(
+      expect.arrayContaining([
+        { pluginId: 'fliks.a', job: job({ name: 'sync' }) },
+        { pluginId: 'fliks.b', job: job({ name: 'sweep' }) },
+      ]),
+    );
+  });
+
+  describe('trigger', () => {
+    it('refuses an unknown job name', () => {
+      const registry = trackedRegistry();
+      const processService = fakeProcessService();
+      const service = new PluginJobsService(registry, processService as never);
+      service.replaceFor('fliks.p', [job()]);
+
+      expect(service.trigger('fliks.p', 'no-such-job')).toEqual({ ok: false, reason: 'unknown-job' });
+      expect(processService.callPlugin).not.toHaveBeenCalled();
+    });
+
+    it('refuses a non-triggerable job', () => {
+      const registry = trackedRegistry();
+      const processService = fakeProcessService();
+      const service = new PluginJobsService(registry, processService as never);
+      service.replaceFor('fliks.p', [job({ triggerable: false })]);
+
+      expect(service.trigger('fliks.p', 'sync')).toEqual({ ok: false, reason: 'not-triggerable' });
+      expect(processService.callPlugin).not.toHaveBeenCalled();
+    });
+
+    it('calls the plugin over callPlugin with a deadline when ready and triggerable', () => {
+      const registry = trackedRegistry();
+      const processService = fakeProcessService('ready');
+      const service = new PluginJobsService(registry, processService as never);
+      service.replaceFor('fliks.p', [job()]);
+
+      expect(service.trigger('fliks.p', 'sync')).toEqual({ ok: true });
+      expect(processService.callPlugin).toHaveBeenCalledWith(
+        'fliks.p',
+        'job',
+        { name: 'sync', jobId: expect.any(String) },
+        expect.any(Number),
+      );
+    });
+
+    it('skips a plugin that is not ready without ever calling it', () => {
+      const registry = trackedRegistry();
+      const processService = fakeProcessService(null);
+      const service = new PluginJobsService(registry, processService as never);
+      service.replaceFor('fliks.p', [job()]);
+
+      expect(service.trigger('fliks.p', 'sync')).toEqual({ ok: true });
+      expect(processService.callPlugin).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/modules/plugins/plugin-jobs.service.ts
+++ b/backend/src/modules/plugins/plugin-jobs.service.ts
@@ -1,0 +1,96 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { CronJob } from 'cron';
+import { randomUUID } from 'crypto';
+import { PluginProcessService } from './plugin-process.service';
+import type { PluginJob } from '../../common/plugin-contract';
+
+/** Deadline for one `job` call — mirrors `PluginProxyController`'s `CALL_DEADLINE_MS`. */
+const JOB_CALL_DEADLINE_MS = 30_000;
+
+function cronKey(pluginId: string, name: string): string {
+  return `plugin:${pluginId}:${name}`;
+}
+
+export type PluginJobTriggerResult = { ok: true } | { ok: false; reason: 'unknown-job' | 'not-triggerable' };
+
+/**
+ * Core owns every plugin's cron schedule via `SchedulerRegistry` — the plugin only ever
+ * receives the resulting `job` call. `replaceFor`/`dropFor` are this map's only entry and
+ * exit, mirroring `PluginRegistryService`'s other per-plugin registries.
+ */
+@Injectable()
+export class PluginJobsService {
+  private readonly logger = new Logger(PluginJobsService.name);
+  private readonly declared = new Map<string, readonly PluginJob[]>();
+
+  constructor(
+    private readonly schedulerRegistry: SchedulerRegistry,
+    private readonly processService: PluginProcessService,
+  ) {}
+
+  /** Tears down this plugin's previous crons, if any, then starts one per job in `jobs`. */
+  replaceFor(pluginId: string, jobs: readonly PluginJob[]): void {
+    this.dropFor(pluginId);
+    if (jobs.length === 0) return;
+    for (const job of jobs) {
+      const cronJob = CronJob.from({
+        cronTime: job.cron,
+        onTick: () => {
+          void this.run(pluginId, job.name);
+        },
+        start: true,
+      });
+      this.schedulerRegistry.addCronJob(cronKey(pluginId, job.name), cronJob);
+    }
+    this.declared.set(pluginId, jobs);
+  }
+
+  /** Idempotent — a no-op for a plugin with no crons currently registered. */
+  dropFor(pluginId: string): void {
+    const jobs = this.declared.get(pluginId);
+    if (!jobs) return;
+    for (const job of jobs) {
+      const key = cronKey(pluginId, job.name);
+      if (this.schedulerRegistry.doesExist('cron', key)) this.schedulerRegistry.deleteCronJob(key);
+    }
+    this.declared.delete(pluginId);
+  }
+
+  /** Every plugin's declared jobs, for the merged admin scheduler listing. */
+  listDeclared(): { pluginId: string; job: PluginJob }[] {
+    const out: { pluginId: string; job: PluginJob }[] = [];
+    for (const [pluginId, jobs] of this.declared) {
+      for (const job of jobs) out.push({ pluginId, job });
+    }
+    return out;
+  }
+
+  declaredJob(pluginId: string, name: string): PluginJob | undefined {
+    return this.declared.get(pluginId)?.find((j) => j.name === name);
+  }
+
+  /** Manual run. Fire-and-forget like `SchedulerService.triggerCommand` — the caller gets an
+   *  immediate verdict, never a promise that waits on the plugin. */
+  trigger(pluginId: string, name: string): PluginJobTriggerResult {
+    const job = this.declaredJob(pluginId, name);
+    if (!job) return { ok: false, reason: 'unknown-job' };
+    if (!job.triggerable) return { ok: false, reason: 'not-triggerable' };
+    void this.run(pluginId, name);
+    return { ok: true };
+  }
+
+  /** Skips, rather than awaits, a plugin that isn't ready — a leaked hang here would back up
+   *  every future tick of this same cron. */
+  private async run(pluginId: string, name: string): Promise<void> {
+    if (this.processService.stateOf(pluginId) !== 'ready') {
+      this.logger.warn(`skipping job "${name}" for plugin "${pluginId}" — process is not ready`);
+      return;
+    }
+    try {
+      await this.processService.callPlugin(pluginId, 'job', { name, jobId: randomUUID() }, JOB_CALL_DEADLINE_MS);
+    } catch (err) {
+      this.logger.warn(`job "${name}" for plugin "${pluginId}" failed: ${(err as Error).message}`);
+    }
+  }
+}

--- a/backend/src/modules/plugins/plugin-registry.service.indexer-descriptors.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.indexer-descriptors.spec.ts
@@ -1,7 +1,7 @@
 import { PluginRegistryService } from './plugin-registry.service';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { minimalDataManifest } from './archive/test-manifests';
-import { fakeRegistrationRepo, fakeProcessService } from './plugin-registry.test-helpers';
+import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService } from './plugin-registry.test-helpers';
 import { buildIndexerImplementationId, type IndexerDescriptor, type PluginManifest } from '../../common/plugin-contract';
 
 /** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
@@ -30,7 +30,12 @@ function repoMock(): { find: jest.Mock } {
 }
 
 function makeService(): PluginRegistryService {
-  return new PluginRegistryService(repoMock() as never, fakeRegistrationRepo() as never, fakeProcessService() as never);
+  return new PluginRegistryService(
+    repoMock() as never,
+    fakeRegistrationRepo() as never,
+    fakeProcessService() as never,
+    fakePluginJobsService() as never,
+  );
 }
 
 function indexerDescriptor(overrides: Partial<IndexerDescriptor> = {}): IndexerDescriptor {

--- a/backend/src/modules/plugins/plugin-registry.service.jobs.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.jobs.spec.ts
@@ -1,0 +1,173 @@
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { PluginRegistryService } from './plugin-registry.service';
+import { PluginJobsService } from './plugin-jobs.service';
+import { PluginPackage } from './entities/plugin-package.entity';
+import { minimalProcessManifest } from './archive/test-manifests';
+import { fakeRegistrationRepo, fakeProcessService } from './plugin-registry.test-helpers';
+import { CORE_SCHEDULER_JOB_NAMES } from '../../common/constants/core-scheduler-jobs';
+import type { PluginJob, PluginManifest } from '../../common/plugin-contract';
+import type { PluginProcessStartResult } from './plugin-process.service';
+
+/** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
+const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
+/** Never fires during a test run — the point of every test here is the registry entry itself. */
+const FAR_FUTURE_CRON = '0 0 1 1 *';
+
+function makePackage(manifest: PluginManifest, overrides: Partial<PluginPackage> = {}): PluginPackage {
+  return {
+    id: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    pluginId: manifest.id,
+    version: manifest.version,
+    archive: Buffer.alloc(0),
+    origin: 'manual',
+    signature: 'unsigned',
+    verifiedByKeyId: null,
+    manifest,
+    status: 'active',
+    ...overrides,
+  } as PluginPackage;
+}
+
+function job(overrides: Partial<PluginJob> = {}): PluginJob {
+  return { name: 'sync', cron: FAR_FUTURE_CRON, triggerable: true, labelKey: 'plugin.job.sync', ...overrides };
+}
+
+function processManifest(pluginId: string, jobs: unknown[]): PluginManifest {
+  return {
+    ...minimalProcessManifest({ 'plugin.js': 'a'.repeat(64), 'logo.png': 'b'.repeat(64) }, {
+      id: pluginId,
+      fliks: COMPATIBLE_RANGE,
+    }),
+    jobs,
+  } as unknown as PluginManifest;
+}
+
+// A real `CronJob` schedules a real (if far-future) `setTimeout`. Track every registry created
+// by a test and clear its jobs afterwards so no test leaves a live timer behind for Jest to trip on.
+const liveRegistries: SchedulerRegistry[] = [];
+afterEach(() => {
+  for (const registry of liveRegistries.splice(0)) {
+    for (const name of registry.getCronJobs().keys()) registry.deleteCronJob(name);
+  }
+});
+
+/** Real `SchedulerRegistry` + real `PluginJobsService` — only `PluginProcessService` is faked —
+ *  so "a cron is deregistered" is proven against the actual registry, not a mock of it. */
+function makeService(startResult?: PluginProcessStartResult) {
+  const registry = new SchedulerRegistry();
+  liveRegistries.push(registry);
+  const processService = fakeProcessService(startResult);
+  const pluginJobs = new PluginJobsService(registry, processService as never);
+  const service = new PluginRegistryService(
+    { find: jest.fn().mockResolvedValue([]) } as never,
+    fakeRegistrationRepo() as never,
+    processService as never,
+    pluginJobs,
+  );
+  return { service, registry, pluginJobs };
+}
+
+describe('PluginRegistryService — jobs registration', () => {
+  it('refuses an empty job name', async () => {
+    const manifest = processManifest('fliks.jobtest', [job({ name: '' })]);
+    const { service } = makeService();
+    const result = await service.register(makePackage(manifest));
+    expect(result).toEqual({ ok: false, pluginId: 'fliks.jobtest', reason: 'invalid-job-name', detail: expect.any(String) });
+  });
+
+  it('refuses a duplicate job name within the same plugin', async () => {
+    const manifest = processManifest('fliks.jobtest', [job({ name: 'sync' }), job({ name: 'sync' })]);
+    const { service } = makeService();
+    const result = await service.register(makePackage(manifest));
+    expect(result).toEqual({
+      ok: false,
+      pluginId: 'fliks.jobtest',
+      reason: 'invalid-job-name',
+      detail: expect.stringContaining('duplicate'),
+    });
+  });
+
+  it.each(CORE_SCHEDULER_JOB_NAMES)('refuses a job name that shadows the core job "%s"', async (coreName) => {
+    const manifest = processManifest('fliks.jobtest', [job({ name: coreName })]);
+    const { service } = makeService();
+    const result = await service.register(makePackage(manifest));
+    expect(result).toEqual({
+      ok: false,
+      pluginId: 'fliks.jobtest',
+      reason: 'job-name-conflict',
+      detail: expect.stringContaining(coreName),
+    });
+  });
+
+  it('refuses a cron expression the scheduler cannot parse', async () => {
+    const manifest = processManifest('fliks.jobtest', [job({ cron: 'not-a-cron' })]);
+    const { service } = makeService();
+    const result = await service.register(makePackage(manifest));
+    expect(result).toEqual({ ok: false, pluginId: 'fliks.jobtest', reason: 'invalid-job-cron', detail: expect.any(String) });
+  });
+
+  it('refuses a non-boolean triggerable', async () => {
+    const manifest = processManifest('fliks.jobtest', [{ ...job(), triggerable: 'yes' }]);
+    const { service } = makeService();
+    const result = await service.register(makePackage(manifest));
+    expect(result).toEqual({ ok: false, pluginId: 'fliks.jobtest', reason: 'invalid-job-triggerable', detail: expect.any(String) });
+  });
+
+  it('refuses an empty labelKey', async () => {
+    const manifest = processManifest('fliks.jobtest', [job({ labelKey: '' })]);
+    const { service } = makeService();
+    const result = await service.register(makePackage(manifest));
+    expect(result).toEqual({ ok: false, pluginId: 'fliks.jobtest', reason: 'invalid-job-label', detail: expect.any(String) });
+  });
+
+  it('registers a real cron once the plugin activates', async () => {
+    const manifest = processManifest('fliks.jobtest', [job()]);
+    const { service, registry } = makeService();
+
+    const result = await service.register(makePackage(manifest));
+
+    expect(result).toEqual({ ok: true, pluginId: 'fliks.jobtest' });
+    expect(registry.doesExist('cron', 'plugin:fliks.jobtest:sync')).toBe(true);
+  });
+
+  it('never registers a cron when activation fails — no leaked cron for a plugin that never ran', async () => {
+    const manifest = processManifest('fliks.jobtest', [job()]);
+    const { service, registry } = makeService({ ok: false, reason: 'spawn-failed', detail: 'boom' });
+
+    const result = await service.register(makePackage(manifest));
+
+    expect(result).toMatchObject({ ok: false, reason: 'spawn-failed' });
+    expect(registry.doesExist('cron', 'plugin:fliks.jobtest:sync')).toBe(false);
+  });
+
+  it('deregisters the cron on unregister — proves no leaked cron outlives the plugin', async () => {
+    const manifest = processManifest('fliks.jobtest', [job()]);
+    const { service, registry } = makeService();
+    await service.register(makePackage(manifest));
+    expect(registry.doesExist('cron', 'plugin:fliks.jobtest:sync')).toBe(true);
+
+    await service.unregister('fliks.jobtest');
+
+    expect(registry.doesExist('cron', 'plugin:fliks.jobtest:sync')).toBe(false);
+  });
+
+  it('deregisters the cron on forget (uninstall)', async () => {
+    const manifest = processManifest('fliks.jobtest', [job()]);
+    const { service, registry } = makeService();
+    await service.register(makePackage(manifest));
+
+    await service.forget('fliks.jobtest');
+
+    expect(registry.doesExist('cron', 'plugin:fliks.jobtest:sync')).toBe(false);
+  });
+
+  it('exposes the declared job on the shared listing surface', async () => {
+    const manifest = processManifest('fliks.jobtest', [job()]);
+    const { service, pluginJobs } = makeService();
+    await service.register(makePackage(manifest));
+
+    expect(pluginJobs.listDeclared()).toEqual([{ pluginId: 'fliks.jobtest', job: job() }]);
+  });
+});

--- a/backend/src/modules/plugins/plugin-registry.service.permissions.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.permissions.spec.ts
@@ -1,0 +1,150 @@
+import { PluginRegistryService } from './plugin-registry.service';
+import { PluginPackage } from './entities/plugin-package.entity';
+import { minimalProcessManifest } from './archive/test-manifests';
+import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService } from './plugin-registry.test-helpers';
+import type { PluginManifest, PluginRoute } from '../../common/plugin-contract';
+
+/** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
+const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
+
+function makePackage(manifest: PluginManifest, overrides: Partial<PluginPackage> = {}): PluginPackage {
+  return {
+    id: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    pluginId: manifest.id,
+    version: manifest.version,
+    // Permission/route validation runs before any archive materialisation — bytes never matter here.
+    archive: Buffer.alloc(0),
+    origin: 'manual',
+    signature: 'unsigned',
+    verifiedByKeyId: null,
+    manifest,
+    status: 'active',
+    ...overrides,
+  } as PluginPackage;
+}
+
+function repoMock(): { find: jest.Mock } {
+  return { find: jest.fn().mockResolvedValue([]) };
+}
+
+function makeService(): PluginRegistryService {
+  return new PluginRegistryService(
+    repoMock() as never,
+    fakeRegistrationRepo() as never,
+    fakeProcessService() as never,
+    fakePluginJobsService() as never,
+  );
+}
+
+function processManifest(
+  pluginId: string,
+  permissions: unknown[],
+  routes: PluginRoute[] = [],
+): PluginManifest {
+  return {
+    ...minimalProcessManifest({ 'plugin.js': 'a'.repeat(64), 'logo.png': 'b'.repeat(64) }, {
+      id: pluginId,
+      fliks: COMPATIBLE_RANGE,
+      routes,
+    }),
+    permissions,
+  } as unknown as PluginManifest;
+}
+
+describe('PluginRegistryService — permission namespacing (adversarial table)', () => {
+  it.each([
+    ['core wildcard action:subject', 'manage:all'],
+    ['a core subject name', 'Settings'],
+    ['a core dotted permission', 'media.read'],
+    ['a bare glob', '*'],
+    ['path-traversal-shaped', '..'],
+    ['empty string', ''],
+    ['contains a colon', 'down:load'],
+    ['contains a space', 'down load'],
+    ['contains uppercase', 'Download'],
+    ['already carries another plugin id, dotted', 'otherplugin.download'],
+    ['already carries another plugin id, namespaced', 'plugin:fliks.other:download'],
+    ['very long', 'a'.repeat(200)],
+  ])('refuses %s ("%s")', async (_label, name) => {
+    const manifest = processManifest('fliks.permtest', [name]);
+    const result = await makeService().register(makePackage(manifest));
+    expect(result).toEqual({ ok: false, pluginId: 'fliks.permtest', reason: 'invalid-permission', detail: expect.any(String) });
+  });
+
+  it('refuses a duplicate permission name within the same plugin', async () => {
+    const manifest = processManifest('fliks.permtest', ['download', 'download']);
+    const result = await makeService().register(makePackage(manifest));
+    expect(result).toEqual({
+      ok: false,
+      pluginId: 'fliks.permtest',
+      reason: 'invalid-permission',
+      detail: expect.stringContaining('duplicate'),
+    });
+  });
+
+  it('accepts "all" as a raw name — once namespaced it can never equal the CASL wildcard subject', async () => {
+    const manifest = processManifest('fliks.permtest', ['all']);
+    const result = await makeService().register(makePackage(manifest));
+    expect(result).toEqual({ ok: true, pluginId: 'fliks.permtest' });
+  });
+
+  it('accepts a well-formed permission name and namespaces it under the plugin id', async () => {
+    const manifest = processManifest('fliks.permtest', ['download']);
+    const service = makeService();
+
+    const result = await service.register(makePackage(manifest));
+
+    expect(result).toEqual({ ok: true, pluginId: 'fliks.permtest' });
+    expect(service.declaredPermissionsFor('fliks.permtest')).toEqual(new Set(['plugin:fliks.permtest:download']));
+  });
+});
+
+describe('PluginRegistryService — a route may only authorize against its own plugin\'s subject', () => {
+  it('accepts a route policy naming a subject this same plugin declared', async () => {
+    const manifest = processManifest('fliks.a', ['download'], [
+      { method: 'GET', path: '/queue', policy: 'read:plugin:fliks.a:download' },
+    ]);
+    const result = await makeService().register(makePackage(manifest));
+    expect(result).toEqual({ ok: true, pluginId: 'fliks.a' });
+  });
+
+  it('refuses a route policy naming another plugin\'s namespaced subject, even with the same permission name declared', async () => {
+    // fliks.a declares "download" itself, but its route reaches for fliks.b's namespace —
+    // never the same subject even though the bare name matches.
+    const manifest = processManifest('fliks.a', ['download'], [
+      { method: 'GET', path: '/queue', policy: 'read:plugin:fliks.b:download' },
+    ]);
+    const result = await makeService().register(makePackage(manifest));
+    expect(result).toEqual({
+      ok: false,
+      pluginId: 'fliks.a',
+      reason: 'invalid-route-policy',
+      detail: expect.any(String),
+    });
+  });
+
+  it('refuses a route policy naming a permission this plugin never declared at all', async () => {
+    const manifest = processManifest('fliks.a', ['upload'], [
+      { method: 'GET', path: '/queue', policy: 'read:plugin:fliks.a:download' },
+    ]);
+    const result = await makeService().register(makePackage(manifest));
+    expect(result).toMatchObject({ ok: false, reason: 'invalid-route-policy' });
+  });
+
+  it('drops the declared permission set on forget, keeps it on unregister', async () => {
+    const manifest = processManifest('fliks.a', ['download'], [
+      { method: 'GET', path: '/queue', policy: 'read:plugin:fliks.a:download' },
+    ]);
+    const service = makeService();
+    await service.register(makePackage(manifest));
+    expect(service.declaredPermissionsFor('fliks.a').size).toBe(1);
+
+    await service.unregister('fliks.a');
+    expect(service.declaredPermissionsFor('fliks.a').size).toBe(1);
+
+    await service.forget('fliks.a');
+    expect(service.declaredPermissionsFor('fliks.a').size).toBe(0);
+  });
+});

--- a/backend/src/modules/plugins/plugin-registry.service.routes.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.routes.spec.ts
@@ -1,7 +1,7 @@
 import { PluginRegistryService } from './plugin-registry.service';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { minimalProcessManifest } from './archive/test-manifests';
-import { fakeRegistrationRepo, fakeProcessService } from './plugin-registry.test-helpers';
+import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService } from './plugin-registry.test-helpers';
 import type { PluginManifest, PluginRoute } from '../../common/plugin-contract';
 import type { PluginProcessStartResult } from './plugin-process.service';
 
@@ -35,6 +35,7 @@ function makeService(startResult?: PluginProcessStartResult): PluginRegistryServ
     repoMock() as never,
     fakeRegistrationRepo() as never,
     fakeProcessService(startResult) as never,
+    fakePluginJobsService() as never,
   );
 }
 

--- a/backend/src/modules/plugins/plugin-registry.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.spec.ts
@@ -5,7 +5,7 @@ import { generateTestKeypair, signManifestBase64 } from './archive/ed25519-test-
 import { minimalDataManifest, minimalProcessManifest } from './archive/test-manifests';
 import { svgLogo, pngLogo } from './archive/test-fixtures';
 import { OFFICIAL_KEYS } from './archive/trust-store';
-import { fakeRegistrationRepo, fakeProcessService } from './plugin-registry.test-helpers';
+import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService } from './plugin-registry.test-helpers';
 import { FLIKS_PLUGINS_DISABLED_ENV } from '../../common/constants/plugin-flags';
 import type { PluginManifest, ProcessPluginManifest } from '../../common/plugin-contract';
 import type { PluginProcessStartResult } from './plugin-process.service';
@@ -50,8 +50,9 @@ function makeService(rows: PluginPackage[] = [], processResult: PluginProcessSta
   const repo = repoMock(rows);
   const registrationRepo = fakeRegistrationRepo();
   const processService = fakeProcessService(processResult);
-  const service = new PluginRegistryService(repo as never, registrationRepo as never, processService as never);
-  return { service, repo, registrationRepo, processService };
+  const pluginJobs = fakePluginJobsService();
+  const service = new PluginRegistryService(repo as never, registrationRepo as never, processService as never, pluginJobs as never);
+  return { service, repo, registrationRepo, processService, pluginJobs };
 }
 
 describe('PluginRegistryService — boot load', () => {

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -4,9 +4,11 @@ import { Repository } from 'typeorm';
 import * as net from 'net';
 import * as semver from 'semver';
 import { pathToRegexp, type Keys } from 'path-to-regexp';
+import { CronExpressionParser } from 'cron-parser';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { PluginRegistration } from './entities/plugin-registration.entity';
 import { PluginProcessService } from './plugin-process.service';
+import { PluginJobsService } from './plugin-jobs.service';
 import { CURRENT_FLIKS_VERSION } from './plugin-version';
 import type { SupervisorState } from './supervisor/plugin-supervisor';
 import { arePluginsDisabled, FLIKS_PLUGINS_DISABLED_ENV } from '../../common/constants/plugin-flags';
@@ -21,6 +23,7 @@ import {
   type IndexerDescriptor,
   type PluginWebhookEventName,
   type PluginRoute,
+  type PluginJob,
 } from '../../common/plugin-contract';
 import { OFFICIAL_KEYS, resolveTrust, readArchiveEntries, type TrustOutcome } from './archive';
 import { isInternalAddress } from './internal-address';
@@ -28,6 +31,8 @@ import type { DomainEvent } from '../scheduler/events.service';
 import { PluginRouteTable, type ResolvedPluginRoute } from './proxy/plugin-route-table';
 import { parseDeclaredPolicy } from './proxy/policy-vocabulary';
 import { parseObjectGuard } from './proxy/plugin-object-guards.service';
+import { PLUGIN_PERMISSION_NAME_PATTERN, pluginPermissionSubject } from '../../common/constants/plugin-permissions';
+import { CORE_SCHEDULER_JOB_NAMES } from '../../common/constants/core-scheduler-jobs';
 
 const WEBHOOK_EVENT_NAMES: ReadonlySet<string> = new Set(PLUGIN_WEBHOOK_EVENT_NAMES);
 
@@ -51,6 +56,11 @@ const SUPPORTED_INDEXER_DRIVER_APIS: ReadonlySet<string> = new Set(['torznab']);
 
 /** A manifest route's `method` must be one of these, compared case-insensitively. */
 const KNOWN_HTTP_METHODS: ReadonlySet<string> = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']);
+
+/** Shared so a plugin with nothing declared doesn't cost an allocation per lookup. */
+const EMPTY_SUBJECT_SET: ReadonlySet<string> = new Set();
+
+const CORE_JOB_NAME_SET: ReadonlySet<string> = new Set(CORE_SCHEDULER_JOB_NAMES);
 
 function isAbsoluteHttpUrl(value: string): boolean {
   try {
@@ -89,6 +99,12 @@ export type PluginRegistrationFailureReason =
   | 'invalid-route-policy'
   | 'invalid-route-object-guard'
   | 'duplicate-route'
+  | 'invalid-permission'
+  | 'invalid-job-name'
+  | 'invalid-job-cron'
+  | 'invalid-job-triggerable'
+  | 'invalid-job-label'
+  | 'job-name-conflict'
   | 'disabled'
   | 'tampered'
   | 'db-provision-failed'
@@ -136,6 +152,9 @@ export class PluginRegistryService implements OnModuleInit {
   private readonly webhookDeclarations = new Map<string, { event: PluginWebhookEventName; webhook: string }[]>();
   /** Keyed by plugin id; compiled once per `register()` from already-validated routes. */
   private readonly routeTables = new Map<string, PluginRouteTable>();
+  /** Keyed by plugin id; namespaced (`plugin:<id>:<name>`) CASL subjects this plugin declared.
+   *  Lifecycle mirrors `routeTables`, not `indexerDescriptors`: kept across `unregister()`, dropped on `forget()`. */
+  private readonly declaredPermissions = new Map<string, ReadonlySet<string>>();
 
   constructor(
     @InjectRepository(PluginPackage)
@@ -143,6 +162,7 @@ export class PluginRegistryService implements OnModuleInit {
     @InjectRepository(PluginRegistration)
     private readonly registrationRepo: Repository<PluginRegistration>,
     private readonly processService: PluginProcessService,
+    private readonly pluginJobs: PluginJobsService,
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -200,16 +220,33 @@ export class PluginRegistryService implements OnModuleInit {
     const webhookCheck = this.validateWebhookDeclarations(manifest.events ?? []);
     if (!webhookCheck.ok) return this.fail(pkg.pluginId, webhookCheck.reason, webhookCheck.detail);
 
+    let declaredSubjects: ReadonlySet<string> = EMPTY_SUBJECT_SET;
     if (manifest.kind === 'process') {
-      const routesCheck = this.validateRoutes(manifest.routes);
+      const permissionsCheck = this.validatePermissions(pkg.pluginId, manifest.permissions ?? []);
+      if (!permissionsCheck.ok) return this.fail(pkg.pluginId, permissionsCheck.reason, permissionsCheck.detail);
+      declaredSubjects = permissionsCheck.subjects;
+
+      const jobsCheck = this.validateJobs(manifest.jobs ?? []);
+      if (!jobsCheck.ok) return this.fail(pkg.pluginId, jobsCheck.reason, jobsCheck.detail);
+
+      const routesCheck = this.validateRoutes(manifest.routes, declaredSubjects);
       if (!routesCheck.ok) return this.fail(pkg.pluginId, routesCheck.reason, routesCheck.detail);
 
       // Installed before running: what a plugin declares stays true while its process is
       // down, so a request to one of its routes can answer 503 instead of a bare Forbidden.
       this.replaceRouteTable(pkg.pluginId, manifest.routes);
+      this.replaceDeclaredPermissions(pkg.pluginId, declaredSubjects);
 
       const activation = await this.activateProcess(pkg, manifest);
       if (!activation.ok) return activation;
+
+      // Only now that the process is actually up — a cron for a plugin that failed to
+      // spawn would fire into a "not running" no-op forever.
+      this.pluginJobs.replaceFor(pkg.pluginId, jobsCheck.jobs);
+    } else {
+      // A tier switch on upgrade (process -> data, same plugin id) must not leave the
+      // previous registration's crons or permission set behind.
+      this.pluginJobs.dropFor(pkg.pluginId);
     }
 
     this.registry.set(pkg.pluginId, {
@@ -224,6 +261,7 @@ export class PluginRegistryService implements OnModuleInit {
     this.replaceIndexerDescriptors(pkg.pluginId, descriptorCheck.descriptors);
     this.replaceWebhookDeclarations(pkg.pluginId, manifest.kind === 'data' ? webhookCheck.declarations : []);
     this.replaceRouteTable(pkg.pluginId, manifest.kind === 'process' ? manifest.routes : []);
+    this.replaceDeclaredPermissions(pkg.pluginId, manifest.kind === 'process' ? declaredSubjects : EMPTY_SUBJECT_SET);
     return { ok: true, pluginId: pkg.pluginId };
   }
 
@@ -231,12 +269,14 @@ export class PluginRegistryService implements OnModuleInit {
   async forget(pluginId: string): Promise<void> {
     await this.unregister(pluginId);
     this.replaceRouteTable(pluginId, []);
+    this.replaceDeclaredPermissions(pluginId, EMPTY_SUBJECT_SET);
   }
 
-  /** Withdraws what the plugin offers and stops its process, but keeps its declared routes:
-   *  a stopped plugin is unavailable, not forbidden. */
+  /** Withdraws what the plugin offers and stops its process, but keeps its declared routes and
+   *  permission set: a stopped plugin is unavailable, not forbidden. Its cron still stops here, though. */
   async unregister(pluginId: string): Promise<void> {
     await this.processService.stopFor(pluginId);
+    this.pluginJobs.dropFor(pluginId);
     this.registry.delete(pluginId);
     this.replaceIndexerDescriptors(pluginId, []);
     this.replaceWebhookDeclarations(pluginId, []);
@@ -326,6 +366,12 @@ export class PluginRegistryService implements OnModuleInit {
     return this.routeTables.get(pluginId)?.resolve(method, path) ?? null;
   }
 
+  /** The namespaced CASL subjects this plugin declared — empty if unregistered, `data`, or none declared.
+   *  `PluginRouteGuard` scopes every check to exactly this, so a route never authorizes against another plugin's subject. */
+  declaredPermissionsFor(pluginId: string): ReadonlySet<string> {
+    return this.declaredPermissions.get(pluginId) ?? EMPTY_SUBJECT_SET;
+  }
+
   /** Every registered webhook subscribed to `eventType` — the dispatcher's fan-out list. */
   listWebhooksForEvent(eventType: string): { pluginId: string; webhook: string }[] {
     const out: { pluginId: string; webhook: string }[] = [];
@@ -351,6 +397,12 @@ export class PluginRegistryService implements OnModuleInit {
     for (const descriptor of descriptors) {
       this.indexerDescriptors.set(buildIndexerImplementationId(pluginId, descriptor.key), { pluginId, descriptor });
     }
+  }
+
+  /** Drops this plugin's previous declared-permission set (if any) and installs `subjects` in its place. */
+  private replaceDeclaredPermissions(pluginId: string, subjects: ReadonlySet<string>): void {
+    if (subjects.size === 0) this.declaredPermissions.delete(pluginId);
+    else this.declaredPermissions.set(pluginId, subjects);
   }
 
   /** Drops this plugin's previous route table (if any) and compiles `routes` into a fresh one. */
@@ -450,9 +502,85 @@ export class PluginRegistryService implements OnModuleInit {
     return { ok: true, declarations };
   }
 
+  /**
+   * `manifest.permissions` is untrusted JSON like `provides.indexers`, so each entry is read
+   * defensively. `PLUGIN_PERMISSION_NAME_PATTERN`'s charset alone rejects every reserved-looking
+   * or foreign-plugin-shaped name — no `: . * space` or uppercase survives it. The namespace
+   * prefix itself always comes from `pkg.pluginId`, never from the manifest, so a name can
+   * never widen into another plugin's subject or a core one.
+   */
+  private validatePermissions(
+    pluginId: string,
+    raw: unknown[],
+  ): { ok: true; subjects: ReadonlySet<string> } | { ok: false; reason: PluginRegistrationFailureReason; detail: string } {
+    const subjects = new Set<string>();
+    const seen = new Set<string>();
+    for (const entry of raw) {
+      const name = typeof entry === 'string' ? entry : '';
+      if (!PLUGIN_PERMISSION_NAME_PATTERN.test(name)) {
+        return { ok: false, reason: 'invalid-permission', detail: `permission ${JSON.stringify(name)} is not a legal permission name` };
+      }
+      if (seen.has(name)) {
+        return { ok: false, reason: 'invalid-permission', detail: `duplicate permission "${name}"` };
+      }
+      seen.add(name);
+      subjects.add(pluginPermissionSubject(pluginId, name));
+    }
+    return { ok: true, subjects };
+  }
+
+  /**
+   * `manifest.jobs` is untrusted JSON like `provides.indexers`. Each violation class gets its own
+   * reason. `CORE_JOB_NAME_SET` mirrors `SchedulerService.SCHEDULERS`'s names — a plugin job can
+   * never shadow one, since the merged admin listing and manual trigger would become ambiguous.
+   */
+  private validateJobs(
+    raw: unknown[],
+  ): { ok: true; jobs: PluginJob[] } | { ok: false; reason: PluginRegistrationFailureReason; detail: string } {
+    const jobs: PluginJob[] = [];
+    const seen = new Set<string>();
+    for (const entry of raw) {
+      const j = (entry ?? {}) as Partial<PluginJob>;
+      const name = typeof j.name === 'string' ? j.name : '';
+      const cron = typeof j.cron === 'string' ? j.cron : '';
+      const triggerable = j.triggerable;
+      const labelKey = typeof j.labelKey === 'string' ? j.labelKey : '';
+
+      if (!name || seen.has(name)) {
+        return {
+          ok: false,
+          reason: 'invalid-job-name',
+          detail: !name ? 'job name must not be empty' : `duplicate job name "${name}"`,
+        };
+      }
+      seen.add(name);
+      if (CORE_JOB_NAME_SET.has(name)) {
+        return { ok: false, reason: 'job-name-conflict', detail: `job "${name}" collides with a core scheduler job` };
+      }
+      try {
+        CronExpressionParser.parse(cron);
+      } catch (err) {
+        return {
+          ok: false,
+          reason: 'invalid-job-cron',
+          detail: `job "${name}" has an invalid cron expression "${cron}": ${(err as Error).message}`,
+        };
+      }
+      if (typeof triggerable !== 'boolean') {
+        return { ok: false, reason: 'invalid-job-triggerable', detail: `job "${name}" has a non-boolean "triggerable"` };
+      }
+      if (!labelKey) {
+        return { ok: false, reason: 'invalid-job-label', detail: `job "${name}" has an empty "labelKey"` };
+      }
+      jobs.push({ name, cron, triggerable, labelKey });
+    }
+    return { ok: true, jobs };
+  }
+
   /** The deep, semantic route check `manifest-parser.ts` defers (its field-type check already ran). */
   private validateRoutes(
     routes: PluginRoute[],
+    declaredSubjects: ReadonlySet<string>,
   ): { ok: true } | { ok: false; reason: PluginRegistrationFailureReason; detail: string } {
     const seen = new Set<string>();
     for (const route of routes) {
@@ -469,7 +597,7 @@ export class PluginRegistryService implements OnModuleInit {
       } catch (err) {
         return { ok: false, reason: 'invalid-route-path', detail: `route path "${route.path}" is invalid: ${(err as Error).message}` };
       }
-      if (!parseDeclaredPolicy(route.policy)) {
+      if (!parseDeclaredPolicy(route.policy, declaredSubjects)) {
         return { ok: false, reason: 'invalid-route-policy', detail: `route policy "${route.policy}" is not a recognised action:subject pair` };
       }
       if (route.objectGuard !== undefined) {
@@ -496,7 +624,12 @@ export class PluginRegistryService implements OnModuleInit {
     this.registry.delete(pluginId);
     this.replaceIndexerDescriptors(pluginId, []);
     this.replaceWebhookDeclarations(pluginId, []);
-    if (!INSTALLED_BUT_NOT_RUNNING.has(reason)) this.replaceRouteTable(pluginId, []);
+    // No failure reason leaves a process running, so its cron never should either.
+    this.pluginJobs.dropFor(pluginId);
+    if (!INSTALLED_BUT_NOT_RUNNING.has(reason)) {
+      this.replaceRouteTable(pluginId, []);
+      this.replaceDeclaredPermissions(pluginId, EMPTY_SUBJECT_SET);
+    }
     return { ok: false, pluginId, reason, detail };
   }
 

--- a/backend/src/modules/plugins/plugin-registry.service.webhooks.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.webhooks.spec.ts
@@ -1,7 +1,7 @@
 import { PluginRegistryService } from './plugin-registry.service';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { minimalDataManifest, minimalProcessManifest } from './archive/test-manifests';
-import { fakeRegistrationRepo, fakeProcessService } from './plugin-registry.test-helpers';
+import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService } from './plugin-registry.test-helpers';
 import type { PluginManifest, PluginWebhookDeclaration } from '../../common/plugin-contract';
 
 /** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
@@ -30,7 +30,12 @@ function repoMock(): { find: jest.Mock } {
 }
 
 function makeService(): PluginRegistryService {
-  return new PluginRegistryService(repoMock() as never, fakeRegistrationRepo() as never, fakeProcessService() as never);
+  return new PluginRegistryService(
+    repoMock() as never,
+    fakeRegistrationRepo() as never,
+    fakeProcessService() as never,
+    fakePluginJobsService() as never,
+  );
 }
 
 function webhookDeclaration(overrides: Partial<PluginWebhookDeclaration> = {}): PluginWebhookDeclaration {

--- a/backend/src/modules/plugins/plugin-registry.test-helpers.ts
+++ b/backend/src/modules/plugins/plugin-registry.test-helpers.ts
@@ -8,6 +8,7 @@ export function fakeRegistrationRepo(): {
   findOne: jest.Mock;
   create: jest.Mock;
   save: jest.Mock;
+  delete: jest.Mock;
 } {
   const rows = new Map<string, PluginRegistration>();
   let nextId = 1;
@@ -21,6 +22,10 @@ export function fakeRegistrationRepo(): {
     save: jest.fn(async (row: PluginRegistration) => {
       rows.set(row.pluginId, row);
       return row;
+    }),
+    delete: jest.fn(async ({ pluginId }: { pluginId: string }) => {
+      const existed = rows.delete(pluginId);
+      return { affected: existed ? 1 : 0 };
     }),
   };
 }
@@ -42,5 +47,23 @@ export function fakeProcessService(startForResult: PluginProcessStartResult = { 
     restart: jest.fn(async () => undefined),
     stopAll: jest.fn(async () => undefined),
     emitToAll: jest.fn(),
+  };
+}
+
+/** A no-op stand-in for `PluginJobsService` — tests that care about cron lifecycle construct
+ *  a real one (see `plugin-registry.service.jobs.spec.ts`) instead of using this. */
+export function fakePluginJobsService(): {
+  replaceFor: jest.Mock;
+  dropFor: jest.Mock;
+  listDeclared: jest.Mock;
+  declaredJob: jest.Mock;
+  trigger: jest.Mock;
+} {
+  return {
+    replaceFor: jest.fn(),
+    dropFor: jest.fn(),
+    listDeclared: jest.fn(() => []),
+    declaredJob: jest.fn(() => undefined),
+    trigger: jest.fn(() => ({ ok: true })),
   };
 }

--- a/backend/src/modules/plugins/plugin-ui.controller.spec.ts
+++ b/backend/src/modules/plugins/plugin-ui.controller.spec.ts
@@ -1,0 +1,108 @@
+import { PluginUiController } from './plugin-ui.controller';
+import type { RegisteredPlugin } from './plugin-registry.service';
+import type { DataPluginManifest, ProcessPluginManifest } from '../../common/plugin-contract';
+
+function dataPlugin(pluginId: string): RegisteredPlugin {
+  return {
+    pluginId,
+    version: '1.0.0',
+    kind: 'data',
+    manifest: {
+      id: pluginId,
+      pluginApi: 0,
+      name: pluginId,
+      version: '1.0.0',
+      fliks: '>=1.0.0',
+      author: 'x',
+      description: 'x',
+      license: 'MIT',
+      logo: 'logo.svg',
+      kind: 'data',
+      ui: { contributions: [], configPages: [] },
+    } as DataPluginManifest,
+    signature: 'unsigned',
+    verifiedByKeyId: null,
+    archive: Buffer.alloc(0),
+  };
+}
+
+function processPlugin(pluginId: string): RegisteredPlugin {
+  return {
+    pluginId,
+    version: '1.0.0',
+    kind: 'process',
+    manifest: {
+      id: pluginId,
+      pluginApi: 0,
+      name: pluginId,
+      version: '1.0.0',
+      fliks: '>=1.0.0',
+      author: 'x',
+      description: 'x',
+      license: 'MIT',
+      logo: 'logo.png',
+      kind: 'process',
+      runtime: 'node',
+      memoryMb: 256,
+      files: {},
+      database: { schema: false, coreRefs: [] },
+      routes: [],
+      scopes: [],
+      ingestRoots: [],
+      ui: {
+        contributions: [{ id: 'nav', slot: 'nav.main', weight: 0, labelKey: 'x', action: { kind: 'route', path: '/x' } }],
+        configPages: [],
+      },
+    } as ProcessPluginManifest,
+    signature: 'unsigned',
+    verifiedByKeyId: null,
+    archive: Buffer.alloc(0),
+  };
+}
+
+function makeController(plugins: RegisteredPlugin[], stateByPluginId: Record<string, string | null> = {}) {
+  const registry = {
+    list: jest.fn().mockReturnValue(plugins),
+    processStateOf: jest.fn((pluginId: string) => stateByPluginId[pluginId] ?? null),
+  };
+  return { controller: new PluginUiController(registry as never), registry };
+}
+
+describe('PluginUiController', () => {
+  it('never calls a plugin — only reads the registry\'s cached manifest', () => {
+    const { controller, registry } = makeController([dataPlugin('fliks.a')]);
+
+    controller.list();
+
+    expect(Object.keys(registry)).toEqual(['list', 'processStateOf']);
+    expect(registry.list).toHaveBeenCalledTimes(1);
+  });
+
+  it('includes a data plugin unconditionally — it has no process to be unhealthy', () => {
+    const { controller } = makeController([dataPlugin('fliks.a')]);
+    const result = controller.list();
+    expect(result).toEqual([{ pluginId: 'fliks.a', contributions: [], configPages: [] }]);
+  });
+
+  it('includes a process plugin whose process is ready, with its contributions', () => {
+    const { controller } = makeController([processPlugin('fliks.b')], { 'fliks.b': 'ready' });
+    const result = controller.list();
+    expect(result).toHaveLength(1);
+    expect(result[0].pluginId).toBe('fliks.b');
+    expect(result[0].contributions).toHaveLength(1);
+  });
+
+  it.each(['crashed', 'degraded', null])('filters out a process plugin whose state is "%s"', (state) => {
+    const { controller } = makeController([processPlugin('fliks.b')], { 'fliks.b': state });
+    expect(controller.list()).toEqual([]);
+  });
+
+  it('mixes a healthy process plugin and a data plugin, filtering only the unhealthy one', () => {
+    const { controller } = makeController(
+      [dataPlugin('fliks.a'), processPlugin('fliks.b'), processPlugin('fliks.c')],
+      { 'fliks.b': 'ready', 'fliks.c': 'crashed' },
+    );
+    const result = controller.list();
+    expect(result.map((r) => r.pluginId)).toEqual(['fliks.a', 'fliks.b']);
+  });
+});

--- a/backend/src/modules/plugins/plugin-ui.controller.ts
+++ b/backend/src/modules/plugins/plugin-ui.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
+import { PluginRegistryService } from './plugin-registry.service';
+import type { ConfigPage, UiContribution } from '../../common/plugin-contract';
+
+export interface PluginUiEntry {
+  pluginId: string;
+  contributions: UiContribution[];
+  configPages: ConfigPage[];
+}
+
+/**
+ * Feeds the app-initializer chain that gates the splash screen, so every logged-in user needs
+ * it — auth-only, no permission gate, mirroring `CountsController`. Reads the in-memory manifest
+ * cache `PluginRegistryService` already keeps (never a live call to a plugin): a dead plugin's
+ * socket timeout must never hold up app boot.
+ */
+@Controller('plugins')
+@UseGuards(JwtOrApiKeyGuard)
+export class PluginUiController {
+  constructor(private readonly registry: PluginRegistryService) {}
+
+  @Get('ui')
+  list(): PluginUiEntry[] {
+    return this.registry
+      .list()
+      .filter((plugin) => plugin.kind === 'data' || this.registry.processStateOf(plugin.pluginId) === 'ready')
+      .map((plugin) => ({
+        pluginId: plugin.pluginId,
+        contributions: plugin.manifest.ui?.contributions ?? [],
+        configPages: plugin.manifest.ui?.configPages ?? [],
+      }));
+  }
+}

--- a/backend/src/modules/plugins/plugins.module.ts
+++ b/backend/src/modules/plugins/plugins.module.ts
@@ -6,6 +6,7 @@ import { PluginRegistration } from './entities/plugin-registration.entity';
 import { PluginRegistryService } from './plugin-registry.service';
 import { PluginWebhookDispatcherService } from './plugin-webhook-dispatcher.service';
 import { PluginProcessService } from './plugin-process.service';
+import { PluginJobsService } from './plugin-jobs.service';
 import { PluginProcessEventDispatcherService } from './plugin-process-event-dispatcher.service';
 import { PluginCatalogClientService } from './plugin-catalog-client.service';
 import { PluginStagingService } from './plugin-staging.service';
@@ -16,6 +17,7 @@ import { PluginIndexerDescriptorsController } from './plugin-indexer-descriptors
 import { PluginSourcesController } from './plugin-sources.controller';
 import { PluginImportController } from './plugin-import.controller';
 import { PluginsController } from './plugins.controller';
+import { PluginUiController } from './plugin-ui.controller';
 import { PluginObjectGuardsService } from './proxy/plugin-object-guards.service';
 import { PluginRouteGuard } from './proxy/plugin-route.guard';
 import { PluginProxyController } from './proxy/plugin-proxy.controller';
@@ -40,6 +42,7 @@ import { LibrariesModule } from '../libraries/libraries.module';
     PluginSourcesController,
     PluginImportController,
     PluginsController,
+    PluginUiController,
     // Last: its `*splat` wildcard must never shadow the concrete routes above.
     PluginProxyController,
   ],
@@ -47,6 +50,7 @@ import { LibrariesModule } from '../libraries/libraries.module';
     PluginRegistryService,
     PluginWebhookDispatcherService,
     PluginProcessService,
+    PluginJobsService,
     PluginProcessEventDispatcherService,
     PluginCatalogClientService,
     PluginStagingService,
@@ -55,6 +59,6 @@ import { LibrariesModule } from '../libraries/libraries.module';
     PluginObjectGuardsService,
     PluginRouteGuard,
   ],
-  exports: [TypeOrmModule, PluginRegistryService, PluginDatabaseService],
+  exports: [TypeOrmModule, PluginRegistryService, PluginDatabaseService, PluginJobsService],
 })
 export class PluginsModule {}

--- a/backend/src/modules/plugins/proxy/plugin-route.guard.spec.ts
+++ b/backend/src/modules/plugins/proxy/plugin-route.guard.spec.ts
@@ -33,7 +33,10 @@ function fakeContext(req: PluginRouteRequest): ExecutionContext {
 
 describe('PluginRouteGuard', () => {
   function makeGuard(resolvedRoute: unknown, canReturns = true) {
-    const registry = { resolveRoute: jest.fn().mockReturnValue(resolvedRoute) };
+    const registry = {
+      resolveRoute: jest.fn().mockReturnValue(resolvedRoute),
+      declaredPermissionsFor: jest.fn().mockReturnValue(new Set<string>()),
+    };
     const objectGuards = { check: jest.fn().mockResolvedValue(true) };
     const caslAbilityFactory = { createForUser: jest.fn().mockReturnValue({ can: jest.fn().mockReturnValue(canReturns) }) };
     const guard = new PluginRouteGuard(registry as never, objectGuards as never, caslAbilityFactory as never);

--- a/backend/src/modules/plugins/proxy/plugin-route.guard.ts
+++ b/backend/src/modules/plugins/proxy/plugin-route.guard.ts
@@ -46,7 +46,8 @@ export class PluginRouteGuard implements CanActivate {
     if (!req.user) return false;
 
     const ability = this.caslAbilityFactory.createForUser(req.user);
-    if (!checkDeclaredPolicy(resolved.route.policy, ability)) return false;
+    const declaredSubjects = this.registry.declaredPermissionsFor(pluginId);
+    if (!checkDeclaredPolicy(resolved.route.policy, ability, declaredSubjects)) return false;
 
     if (resolved.route.objectGuard) {
       const parsedGuard = parseObjectGuard(resolved.route.objectGuard);

--- a/backend/src/modules/plugins/proxy/policy-vocabulary.spec.ts
+++ b/backend/src/modules/plugins/proxy/policy-vocabulary.spec.ts
@@ -23,11 +23,38 @@ describe('parseDeclaredPolicy', () => {
     ['empty string', ''],
     ['"manage" with no colon', 'manage'],
     ['three-part string', 'a:b:c'],
-    // A plugin-declared subject (e.g. "read:download") needs `PermissionRegistry` (3.5c) —
-    // out of scope here, and must be refused, not silently accepted.
-    ['plugin-declared subject', 'read:download'],
+    // A plugin-declared subject is refused unless the caller supplies the declaring
+    // plugin's own set (see the `declaredSubjects` describe block below).
+    ['plugin-declared subject, no declaredSubjects given', 'read:plugin:fliks.myplugin:download'],
   ])('%s ("%s") -> null', (_label, policy) => {
     expect(parseDeclaredPolicy(policy)).toBeNull();
+  });
+});
+
+describe('parseDeclaredPolicy — declaredSubjects (plugin-aware)', () => {
+  it('accepts a namespaced subject declared in the given set', () => {
+    const declared = new Set(['plugin:fliks.myplugin:download']);
+    expect(parseDeclaredPolicy('read:plugin:fliks.myplugin:download', declared)).toEqual({
+      action: Action.Read,
+      subject: 'plugin:fliks.myplugin:download',
+    });
+  });
+
+  it('refuses a subject namespaced under a different plugin id, even if that plugin declared the same name', () => {
+    const declared = new Set(['plugin:fliks.myplugin:download']);
+    expect(parseDeclaredPolicy('read:plugin:fliks.otherplugin:download', declared)).toBeNull();
+  });
+
+  it('refuses a subject the plugin never declared', () => {
+    const declared = new Set(['plugin:fliks.myplugin:upload']);
+    expect(parseDeclaredPolicy('read:plugin:fliks.myplugin:download', declared)).toBeNull();
+  });
+
+  it('still resolves a core subject even when a declaredSubjects set is passed', () => {
+    expect(parseDeclaredPolicy('grab:Media', new Set(['plugin:fliks.myplugin:download']))).toEqual({
+      action: Action.Grab,
+      subject: Media,
+    });
   });
 });
 
@@ -45,5 +72,17 @@ describe('checkDeclaredPolicy', () => {
   it('fails closed on an unparseable policy regardless of how permissive the ability is', () => {
     const allowAll = ability((can) => can(Action.Manage, 'all'));
     expect(checkDeclaredPolicy('not-a-policy', allowAll)).toBe(false);
+  });
+
+  it('permits a namespaced subject declared by the plugin when the ability grants it', () => {
+    const allowed = ability((can) => can(Action.Manage, 'plugin:fliks.myplugin:download'));
+    const declared = new Set(['plugin:fliks.myplugin:download']);
+    expect(checkDeclaredPolicy('read:plugin:fliks.myplugin:download', allowed, declared)).toBe(true);
+  });
+
+  it('denies a namespaced subject the ability grants but this plugin never declared', () => {
+    const allowed = ability((can) => can(Action.Manage, 'plugin:fliks.myplugin:download'));
+    const declared = new Set<string>();
+    expect(checkDeclaredPolicy('read:plugin:fliks.myplugin:download', allowed, declared)).toBe(false);
   });
 });

--- a/backend/src/modules/plugins/proxy/policy-vocabulary.ts
+++ b/backend/src/modules/plugins/proxy/policy-vocabulary.ts
@@ -17,8 +17,8 @@ type PolicySubject = Parameters<AppAbility['can']>[1];
 
 const ACTIONS: ReadonlySet<string> = new Set(Object.values(Action));
 
-/** Closed, case-sensitive subject vocabulary. A plugin-declared subject (`PermissionRegistry`,
- *  3.5c) is deliberately absent — it must fail `parseDeclaredPolicy`, not fall through here. */
+/** Closed, case-sensitive core subject vocabulary. A namespaced plugin subject
+ *  (`plugin:<id>:<name>`) is never in here — it is only ever accepted via `declaredSubjects`. */
 const DECLARED_POLICY_SUBJECTS = new Map<string, PolicySubject>([
   ['User', User],
   ['Media', Media],
@@ -40,21 +40,31 @@ export interface DeclaredPolicy {
   subject: PolicySubject;
 }
 
-/** `"<action>:<Subject>"`, both halves from the closed vocabularies above — a manifest is
- *  untrusted text, so a plugin-declared or wrong-case subject returns `null`, not a guess. */
-export function parseDeclaredPolicy(policy: string): DeclaredPolicy | null {
-  const parts = policy.split(':');
-  if (parts.length !== 2) return null;
-  const [action, subjectName] = parts;
+/**
+ * `"<action>:<Subject>"` — only the first colon separates them, since a namespaced plugin
+ * subject (`plugin:<id>:<name>`) carries two more of its own. `declaredSubjects` is always
+ * built by the caller for the one plugin whose route this is, so a subject namespaced under
+ * a *different* plugin id is never a member and fails closed here, same as an unknown one.
+ */
+export function parseDeclaredPolicy(policy: string, declaredSubjects?: ReadonlySet<string>): DeclaredPolicy | null {
+  const sep = policy.indexOf(':');
+  if (sep === -1) return null;
+  const action = policy.slice(0, sep);
+  const subjectName = policy.slice(sep + 1);
   if (!ACTIONS.has(action)) return null;
-  const subject = DECLARED_POLICY_SUBJECTS.get(subjectName);
-  if (subject === undefined) return null;
-  return { action: action as Action, subject };
+
+  const coreSubject = DECLARED_POLICY_SUBJECTS.get(subjectName);
+  if (coreSubject !== undefined) return { action: action as Action, subject: coreSubject };
+
+  if (declaredSubjects?.has(subjectName)) {
+    return { action: action as Action, subject: subjectName as PolicySubject };
+  }
+  return null;
 }
 
 /** Fail closed: an unparseable policy is denied, never treated as "no policy declared". */
-export function checkDeclaredPolicy(policy: string, ability: AppAbility): boolean {
-  const parsed = parseDeclaredPolicy(policy);
+export function checkDeclaredPolicy(policy: string, ability: AppAbility, declaredSubjects?: ReadonlySet<string>): boolean {
+  const parsed = parseDeclaredPolicy(policy, declaredSubjects);
   if (!parsed) return false;
   return ability.can(parsed.action, parsed.subject);
 }

--- a/backend/src/modules/scheduler/scheduler.module.ts
+++ b/backend/src/modules/scheduler/scheduler.module.ts
@@ -42,6 +42,7 @@ import { ProfilesModule } from '../profiles/profiles.module';
 import { MarkersModule } from '../markers/markers.module';
 import { Library } from '../libraries/entities/library.entity';
 import { LibraryIngestModule } from '../../common/library-ingest/library-ingest.module';
+import { PluginsModule } from '../plugins/plugins.module';
 
 @Module({
   imports: [
@@ -81,6 +82,10 @@ import { LibraryIngestModule } from '../../common/library-ingest/library-ingest.
     MarkersModule,
     forwardRef(() => LibraryIngestModule),
     LogBufferModule,
+    // Already reachable transitively via IndexersModule -> PluginsModule (see
+    // LogBufferModule's own doc comment); imported directly here so SchedulerService can
+    // inject PluginJobsService for the merged job listing.
+    PluginsModule,
   ],
   controllers: [CommandsController, SystemController, LivenessController],
   providers: [

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -50,6 +50,8 @@ import {
   resolveSearchTitles,
 } from '../../common/release-scoring';
 import { parseSeasonEpisode, matchesSeasonPack } from '../../common/release-parsing';
+import { CORE_SCHEDULER_JOB_NAMES } from '../../common/constants/core-scheduler-jobs';
+import { PluginJobsService } from '../plugins/plugin-jobs.service';
 
 // Note: scoring/profile/blocklist/quality-definition wiring lives in
 // AutoGrabPipelineService. This file only orchestrates the high-level
@@ -94,14 +96,17 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
     private readonly markers: MarkersService,
     private readonly autoGrab: AutoGrabPipelineService,
     private readonly candidates: AcquisitionCandidatesService,
+    private readonly pluginJobs: PluginJobsService,
   ) {}
 
   // ---------------------------------------------------------------------------
   // Scheduler definitions
   // ---------------------------------------------------------------------------
 
+  // `name` is typed against `CORE_SCHEDULER_JOB_NAMES` so adding a job here without mirroring
+  // its name there (needed so a plugin job can be refused for colliding with it) fails to typecheck.
   private static readonly SCHEDULERS: {
-    name: string;
+    name: (typeof CORE_SCHEDULER_JOB_NAMES)[number];
     cron: string;
     triggerable: boolean;
   }[] = [
@@ -209,6 +214,8 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
       lastRun: Date | null;
       lastStatus: string | null;
       nextRun: Date;
+      /** `null` for a core job; the owning plugin's id for one it declared. */
+      pluginId: string | null;
     }[]
   > {
     const names = SchedulerService.SCHEDULERS.map((s) => s.name);
@@ -224,7 +231,7 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
 
     const lastByName = new Map(lastCommands.map((c) => [c.name, c]));
 
-    return SchedulerService.SCHEDULERS.map((s) => {
+    const core = SchedulerService.SCHEDULERS.map((s) => {
       const last = lastByName.get(s.name);
       const interval = CronExpressionParser.parse(s.cron);
       return {
@@ -234,8 +241,22 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
         lastRun: last?.startedOn ?? null,
         lastStatus: last?.status ?? null,
         nextRun: interval.next().toDate(),
+        pluginId: null,
       };
     });
+
+    // Plugin jobs have no `Command` history — core owns that audit trail, a plugin's run does not.
+    const plugins = this.pluginJobs.listDeclared().map(({ pluginId, job }) => ({
+      name: job.name,
+      cron: job.cron,
+      triggerable: job.triggerable,
+      lastRun: null,
+      lastStatus: null,
+      nextRun: CronExpressionParser.parse(job.cron).next().toDate(),
+      pluginId,
+    }));
+
+    return [...core, ...plugins];
   }
 
   /**


### PR DESCRIPTION
PR 3.5c, the last of the 3.5 split: the plugin permission registry with plugin-declared CASL subjects, the jobs registry, and `GET /api/plugins/ui`. **Phase 3 is complete with this.**

## Permissions and plugin-declared subjects

A `process` manifest declares **bare** permission names (`permissions: ["download"]`). Core alone builds the CASL subject `plugin:<pluginId>:<name>` — the plugin never writes its own prefix, so it cannot mint a subject outside its namespace, collide with another plugin, or name a core permission. Raw names are `[a-z][a-z0-9_-]{0,63}`.

Adversarial table (all refused with `invalid-permission` unless noted): `manage:all` (colon), `Settings` (uppercase), `media.read` (dot), `*`, `..`, empty, containing a space, carrying another plugin's prefix, a duplicate, 200 chars. `all` **is** accepted as a bare name, deliberately: namespaced to `plugin:<id>:all` it can never equal CASL's literal wildcard subject.

**Policy parsing became plugin-aware.** A route's declared subject must have been declared by the *same* plugin that owns the route, so plugin A cannot authorize its route against plugin B's subject — the guard resolves the permitted set from the same plugin id it resolved the route with. The policy is split on the **first** colon only, since a namespaced subject carries two of its own.

No CASL↔plugins import cycle: the ability factory grants `can(Manage, perm)` for any `perm` on the user shaped like `plugin:…`, via a pure predicate in a dependency-free constants file. The real gate — "was this subject declared by this plugin" — lives in the route guard, not in ability building.

## Jobs

Core owns the cron and calls the plugin's `job` method. A declared job is validated at registration, registered against `SchedulerRegistry` on activation, and deregistered on stop, unregister and uninstall — **a cron must never outlive the plugin that declared it.** Core job names are restated as a typed tuple, so a plugin job that would shadow a core one is refused at registration and a new core job that is not mirrored fails to typecheck. The unit tests use a **real** `SchedulerRegistry` and real `CronJob`, faking only the process service.

## `GET /api/plugins/ui`

Serves the cached manifests' contributions and config pages, **auth-only** (mirroring `CountsController`) because it feeds the app-initializer chain that gates the splash screen. It reads the in-memory registry rather than `plugin_registrations`, which only ever holds `process` rows — reading the table directly would miss every `data` plugin. A plugin whose process is not `ready` is filtered out server-side; a `data` plugin has no process and is never filtered on that basis.

## A leak this PR closes

**Uninstall never deleted the `plugin_registrations` row.** It carries the consented `scopes` and `ingestRoots`, so a reinstall silently inherited grants instead of asking for them again. Introduced in 3.5a, fixed here — and the install spec was building *two separate fakes* for that repository, so either assertion about it would have been vacuous; it now shares one instance and a test pins the deletion.

## Verification

`tsc --noEmit` exit 0. Full suite **1292 tests / 122 suites green**.

Live on the docker stack, using the **real phase-9 plugin** (which declares namespaced permissions and policies) plus a throwaway job fixture:

- install → `active`, supervisor `ready`; owner (`manage:all`) reaches the plugin route, a member without the permission gets 403 on both routes;
- granting `plugin:fliks.notify:delivery-log` opens **that** route and leaves the sibling permission's route still 403 — the two subjects do not collapse even though CASL `Manage` covers every action;
- granting **another** plugin's namespaced permission (`plugin:fliks.other:delivery-log`) does **not** open this plugin's route — the cross-plugin boundary holds at request time, not just at registration;
- `GET /plugins/ui` readable by a non-admin, returns the cached entry;
- a plugin declaring `cron: "* * * * *"` appears in `GET /commands/schedulers` as the 9th entry with its `pluginId` and a computed `nextRun`, and **the cron really fired**: the child logged `job` with its name and a UUID `jobId` at exactly the announced minute;
- after uninstall: listing back to 8 entries, no plugin job, **zero job invocations across a 70 s window spanning a minute boundary**, registration row deleted, no Postgres role, no child process, and the route 403s again.

## Note on a correction to my own method

While testing the grant path I mutated `roles.permissions` with a `jsonb` operator — the column is **text**. That corrupted role 2's permissions and produced 500s I initially read as a policy failure. I restored the row, confirmed the app parses it again, and redid the check with a correct statement wrapped so the restore runs even on failure. No lasting damage; recorded because the failure looked like a code defect and was not.

## Not in scope

- Contributed checklist items: `ChecklistItemDef.check` is a JS closure a plugin cannot supply, and the mechanism exists only to move core's `indexer`/`download-client` rows out in phase 10. Deferred with the phase that will have a declarer.
- No HTTP route for manually triggering a plugin job (`triggerable` is enforced in the service and unit-tested; no endpoint wired).
- Cross-plugin job-name collisions are allowed — identity for cron keying is `(pluginId, name)`, so it is cosmetic in a merged listing, not a dispatch ambiguity.

Refs: #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)