### PR TITLE
feat(plugin-ui): registry, when evaluator and i18n merge for plugin contributions

### DIFF
--- a/backend/src/modules/plugins/plugin-ui.controller.spec.ts
+++ b/backend/src/modules/plugins/plugin-ui.controller.spec.ts
@@ -81,7 +81,18 @@ describe('PluginUiController', () => {
   it('includes a data plugin unconditionally — it has no process to be unhealthy', () => {
     const { controller } = makeController([dataPlugin('fliks.a')]);
     const result = controller.list();
-    expect(result).toEqual([{ pluginId: 'fliks.a', contributions: [], configPages: [] }]);
+    expect(result).toEqual([{ pluginId: 'fliks.a', contributions: [], configPages: [], i18n: {} }]);
+  });
+
+  it('passes the manifest i18n dicts through so the client can merge them under core keys', () => {
+    const plugin = dataPlugin('fliks.a');
+    plugin.manifest.i18n = { en: { 'fliks.a.label': 'Label' }, fr: { 'fliks.a.label': 'Libellé' } };
+    const { controller } = makeController([plugin]);
+
+    expect(controller.list()[0].i18n).toEqual({
+      en: { 'fliks.a.label': 'Label' },
+      fr: { 'fliks.a.label': 'Libellé' },
+    });
   });
 
   it('includes a process plugin whose process is ready, with its contributions', () => {

--- a/backend/src/modules/plugins/plugin-ui.controller.ts
+++ b/backend/src/modules/plugins/plugin-ui.controller.ts
@@ -7,6 +7,8 @@ export interface PluginUiEntry {
   pluginId: string;
   contributions: UiContribution[];
   configPages: ConfigPage[];
+  /** Flat `"a.b.c"` dicts per locale; the client merges them under core's own keys. */
+  i18n: Record<string, Record<string, string>>;
 }
 
 /**
@@ -29,6 +31,7 @@ export class PluginUiController {
         pluginId: plugin.pluginId,
         contributions: plugin.manifest.ui?.contributions ?? [],
         configPages: plugin.manifest.ui?.configPages ?? [],
+        i18n: plugin.manifest.i18n ?? {},
       }));
   }
 }

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2513,5 +2513,11 @@
     "install": "Installieren",
     "open_release": "Version ansehen",
     "error": "Update fehlgeschlagen"
+  },
+  "plugin_view": {
+    "unavailable_title": "Diese Seite ist nicht verfügbar",
+    "unknown_plugin": "Das Plugin, zu dem diese Seite gehört, ist nicht installiert.",
+    "unknown_view": "Dieses Plugin hat keine Seite mit diesem Namen.",
+    "unsupported_kind": "Diese Seite wird von deiner Fliks-Version noch nicht unterstützt."
   }
 }

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2540,5 +2540,11 @@
     "install": "Install",
     "open_release": "View release",
     "error": "Update failed"
+  },
+  "plugin_view": {
+    "unavailable_title": "This page isn't available",
+    "unknown_plugin": "The plugin this page belongs to isn't installed.",
+    "unknown_view": "This plugin doesn't have a page by that name.",
+    "unsupported_kind": "This page isn't supported by your version of Fliks yet."
   }
 }

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2513,5 +2513,11 @@
     "install": "Instalar",
     "open_release": "Ver la versión",
     "error": "Error de la actualización"
+  },
+  "plugin_view": {
+    "unavailable_title": "Esta página no está disponible",
+    "unknown_plugin": "El plugin al que pertenece esta página no está instalado.",
+    "unknown_view": "Este plugin no tiene ninguna página con ese nombre.",
+    "unsupported_kind": "Esta página aún no es compatible con tu versión de Fliks."
   }
 }

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2540,5 +2540,11 @@
     "install": "Installer",
     "open_release": "Voir la version",
     "error": "Échec de la mise à jour"
+  },
+  "plugin_view": {
+    "unavailable_title": "Cette page n'est pas disponible",
+    "unknown_plugin": "Le plugin auquel appartient cette page n'est pas installé.",
+    "unknown_view": "Ce plugin n'a pas de page portant ce nom.",
+    "unsupported_kind": "Cette page n'est pas encore prise en charge par votre version de Fliks."
   }
 }

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2513,5 +2513,11 @@
     "install": "Installa",
     "open_release": "Vedi la versione",
     "error": "Aggiornamento fallito"
+  },
+  "plugin_view": {
+    "unavailable_title": "Questa pagina non è disponibile",
+    "unknown_plugin": "Il plugin a cui appartiene questa pagina non è installato.",
+    "unknown_view": "Questo plugin non ha una pagina con questo nome.",
+    "unsupported_kind": "Questa pagina non è ancora supportata dalla tua versione di Fliks."
   }
 }

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2513,5 +2513,11 @@
     "install": "Instalar",
     "open_release": "Ver a versão",
     "error": "Falha na atualização"
+  },
+  "plugin_view": {
+    "unavailable_title": "Esta página não está disponível",
+    "unknown_plugin": "O plugin ao qual esta página pertence não está instalado.",
+    "unknown_view": "Este plugin não tem nenhuma página com esse nome.",
+    "unsupported_kind": "Esta página ainda não é suportada pela sua versão do Fliks."
   }
 }

--- a/client/src/app/app.config.spec.ts
+++ b/client/src/app/app.config.spec.ts
@@ -1,15 +1,43 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ApplicationInitStatus, provideAppInitializer } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
 import { loadPersistedState } from './app.config';
+
+/** The rest of the chain (localStorage-backed) settles in one microtask;
+ *  the plugin registry's HTTP call lands a few ticks later — poll for it
+ *  instead of assuming it is already in flight. */
+async function flushPluginUiRequest(http: HttpTestingController): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    const [req] = http.match('/api/plugins/ui');
+    if (req) {
+      req.flush([]);
+      return;
+    }
+    await Promise.resolve();
+  }
+  throw new Error('GET /api/plugins/ui was never issued');
+}
 
 /** The app initializer gates bootstrap: if it throws or never settles, the
  *  native builds stay on their splash screen forever. */
 describe('loadPersistedState', () => {
   it('resolves inside an injection context', async () => {
     TestBed.configureTestingModule({
-      providers: [provideAppInitializer(loadPersistedState)],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideTranslateService({
+          lang: 'en',
+          loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+        }),
+        provideAppInitializer(loadPersistedState),
+      ],
     });
-    await TestBed.inject(ApplicationInitStatus).donePromise;
-    expect(TestBed.inject(ApplicationInitStatus).done).toBe(true);
+    const status = TestBed.inject(ApplicationInitStatus);
+    await Promise.all([status.donePromise, flushPluginUiRequest(TestBed.inject(HttpTestingController))]);
+    expect(status.done).toBe(true);
   });
 });

--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -37,16 +37,25 @@ import { AuthService } from './core/services/auth.service';
 import { ServerConfigService } from './core/services/server-config.service';
 import { SessionStoreService } from './core/services/session-store.service';
 import { translateBrowserLoaderFactory } from './utils/translate-loader';
+import { PluginUiRegistryService } from './core/plugin-ui/plugin-ui-registry.service';
+import { PluginI18nService } from './core/plugin-ui/plugin-i18n.service';
 
 /** Read the persisted server URL, sessions and credentials before bootstrap:
  *  guards, interceptors and the first /auth/me all depend on them. Resolves
- *  even on a storage failure, or the app would never leave its splash screen. */
+ *  even on a storage failure, or the app would never leave its splash screen.
+ *  The plugin UI registry loads last — it needs the session for the
+ *  authenticated request, and it fails open internally so it can never
+ *  delay this past its own short timeout. */
 export function loadPersistedState(): Promise<unknown> {
   const serverConfig = inject(ServerConfigService);
   const sessions = inject(SessionStoreService);
   const auth = inject(AuthService);
+  const pluginUi = inject(PluginUiRegistryService);
+  const pluginI18n = inject(PluginI18nService);
   return Promise.all([serverConfig.load(), sessions.load()])
     .then(() => void auth.loadPersistedSession())
+    .then(() => pluginUi.load())
+    .then(() => pluginI18n.init())
     .catch(() => undefined);
 }
 

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { serverConfigGuard } from './core/guards/server-config.guard';
 import { passwordChangeGuard } from './core/guards/password-change.guard';
 import { noTvGuard } from './core/guards/no-tv.guard';
 import { desktopGuard } from './core/guards/desktop.guard';
+import { pluginViewGuard } from './core/guards/plugin-view.guard';
 import { ProfileContextService } from './features/profile/profile-context.service';
 
 export const routes: Routes = [
@@ -276,6 +277,12 @@ export const routes: Routes = [
           ),
         data: { titleKey: 'pending_requests.title' },
       },
+      {
+        path: 'plugins/:pluginId/:view',
+        canActivate: [pluginViewGuard],
+        loadComponent: () =>
+          import('./features/plugin-view/plugin-view').then((m) => m.PluginViewComponent),
+      },
     ],
   },
   // Account settings — own layout with sidebar
@@ -414,6 +421,11 @@ export const routes: Routes = [
           { path: 'media-servers', loadComponent: () => import('./features/settings/media-servers/media-servers').then((m) => m.MediaServersSettingsComponent) },
           { path: 'plugins', loadComponent: () => import('./features/settings/plugins/plugins').then((m) => m.PluginsSettingsComponent) },
           { path: 'plugin-catalogue', loadComponent: () => import('./features/settings/plugins/plugin-catalogue/plugin-catalogue-page').then((m) => m.PluginCataloguePageComponent) },
+          {
+            path: 'plugins/:pluginId/:view',
+            canActivate: [pluginViewGuard],
+            loadComponent: () => import('./features/plugin-view/plugin-view').then((m) => m.PluginViewComponent),
+          },
           { path: 'data-imports', loadComponent: () => import('./features/settings/data-imports/data-imports').then((m) => m.DataImportsSettingsComponent) },
           { path: 'libraries', loadComponent: () => import('./features/settings/libraries/libraries').then((m) => m.LibrariesSettingsComponent) },
           {

--- a/client/src/app/core/guards/plugin-view.guard.spec.ts
+++ b/client/src/app/core/guards/plugin-view.guard.spec.ts
@@ -1,0 +1,91 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { UrlTree, provideRouter } from '@angular/router';
+import { firstValueFrom, isObservable, of } from 'rxjs';
+import { pluginViewGuard } from './plugin-view.guard';
+import { AuthService } from '../services/auth.service';
+import { TvService } from '../services/tv.service';
+import { DeviceService } from '../services/device.service';
+import { PluginUiRegistryService } from '../plugin-ui/plugin-ui-registry.service';
+import type { UiContribution, WhenPredicate } from '../plugin-ui/contribution.types';
+
+const routeState = (url: string) => ({ url }) as never;
+
+function setup(opts: {
+  authenticated?: boolean;
+  isAdmin?: boolean;
+  contribution?: UiContribution;
+}) {
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      provideRouter([]),
+      {
+        provide: AuthService,
+        useValue: {
+          ensureAuthenticated: () => of(opts.authenticated ?? true),
+          user: () => ({ isAdmin: opts.isAdmin ?? false }),
+          hasPermission: () => false,
+        },
+      },
+      { provide: TvService, useValue: { isTv: () => false } },
+      { provide: DeviceService, useValue: { isTouch: () => false } },
+      {
+        provide: PluginUiRegistryService,
+        useValue: { findRouteContribution: () => opts.contribution },
+      },
+    ],
+  });
+}
+
+const runGuard = async (url: string) => {
+  const result = TestBed.runInInjectionContext(() => pluginViewGuard({} as never, routeState(url)));
+  return isObservable(result) ? firstValueFrom(result) : result;
+};
+
+const contribution = (when?: WhenPredicate[]): UiContribution => ({
+  id: 'fliks.a.item',
+  slot: 'nav.main',
+  weight: 100,
+  labelKey: 'x',
+  when,
+  action: { kind: 'route', path: '/plugins/fliks.a/item' },
+});
+
+describe('pluginViewGuard', () => {
+  it('redirects to /login when not authenticated', async () => {
+    setup({ authenticated: false });
+    const result = await runGuard('/plugins/fliks.a/item');
+    expect(result).toBeInstanceOf(UrlTree);
+  });
+
+  it('lets the route through when no contribution links to this exact path — the component renders "unavailable" instead', async () => {
+    setup({ contribution: undefined });
+    const result = await runGuard('/plugins/fliks.unknown/item');
+    expect(result).toBe(true);
+  });
+
+  it('lets the route through when the matching contribution has no when', async () => {
+    setup({ contribution: contribution() });
+    const result = await runGuard('/plugins/fliks.a/item');
+    expect(result).toBe(true);
+  });
+
+  it('redirects home when the contribution when hides it from this user', async () => {
+    setup({ isAdmin: false, contribution: contribution(['isAdmin']) });
+    const result = await runGuard('/plugins/fliks.a/item');
+    expect(result).toBeInstanceOf(UrlTree);
+  });
+
+  it('lets an admin through an isAdmin-gated page', async () => {
+    setup({ isAdmin: true, contribution: contribution(['isAdmin']) });
+    const result = await runGuard('/plugins/fliks.a/item');
+    expect(result).toBe(true);
+  });
+
+  it('strips the query string before matching the contribution path', async () => {
+    setup({ contribution: contribution(['isAdmin']), isAdmin: false });
+    const result = await runGuard('/plugins/fliks.a/item?foo=bar');
+    expect(result).toBeInstanceOf(UrlTree);
+  });
+});

--- a/client/src/app/core/guards/plugin-view.guard.ts
+++ b/client/src/app/core/guards/plugin-view.guard.ts
@@ -1,0 +1,40 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { map } from 'rxjs';
+import { AuthService } from '../services/auth.service';
+import { TvService } from '../services/tv.service';
+import { DeviceService } from '../services/device.service';
+import { PluginUiRegistryService } from '../plugin-ui/plugin-ui-registry.service';
+import { evaluateWhen } from '../plugin-ui/when-evaluator';
+
+/**
+ * Keeps a plugin page from being reachable by a user its own contribution's
+ * `when` would hide it from. Presentation only — an unknown plugin/view is
+ * the component's "unavailable" state, not a guard concern; the proxied
+ * routes a page calls are CASL-guarded server-side regardless of this check.
+ */
+export const pluginViewGuard: CanActivateFn = (route, state) => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+  const registry = inject(PluginUiRegistryService);
+  const tv = inject(TvService);
+  const device = inject(DeviceService);
+
+  return auth.ensureAuthenticated().pipe(
+    map((ok) => {
+      if (!ok) return router.createUrlTree(['/login']);
+
+      const path = state.url.split('?')[0];
+      const contribution = registry.findRouteContribution(path);
+      if (!contribution) return true;
+
+      const visible = evaluateWhen(contribution.when, {
+        isAdmin: auth.user()?.isAdmin ?? false,
+        hasPermission: (p) => auth.hasPermission(p),
+        isTv: tv.isTv(),
+        isTouch: device.isTouch(),
+      });
+      return visible ? true : router.createUrlTree(['/']);
+    }),
+  );
+};

--- a/client/src/app/core/plugin-ui/merge-ordered.spec.ts
+++ b/client/src/app/core/plugin-ui/merge-ordered.spec.ts
@@ -1,0 +1,54 @@
+import { mergeOrdered } from './merge-ordered';
+
+interface Item {
+  key: string;
+  visible: boolean;
+}
+
+const item = (key: string, visible = true): Item => ({ key, visible });
+const keys = (items: Item[]) => items.map((i) => i.key);
+
+describe('mergeOrdered', () => {
+  it('keeps the saved order for items still available', () => {
+    const saved = [item('c'), item('a'), item('b')];
+    const available = new Set(['a', 'b', 'c']);
+    expect(keys(mergeOrdered(saved, [], available, (i) => i.key))).toEqual(['c', 'a', 'b']);
+  });
+
+  it('appends items the user never saw, in canonical (defaults) order', () => {
+    const saved = [item('b')];
+    const defaults = [item('a'), item('b'), item('c')];
+    const available = new Set(['a', 'b', 'c']);
+    expect(keys(mergeOrdered(saved, defaults, available, (i) => i.key))).toEqual(['b', 'a', 'c']);
+  });
+
+  it('drops saved items that are no longer available', () => {
+    const saved = [item('a'), item('gone'), item('b')];
+    const available = new Set(['a', 'b']);
+    expect(keys(mergeOrdered(saved, [], available, (i) => i.key))).toEqual(['a', 'b']);
+  });
+
+  it('preserves the saved item, not the default, on a key collision', () => {
+    const saved = [item('a', false)];
+    const defaults = [item('a', true)];
+    const available = new Set(['a']);
+    const result = mergeOrdered(saved, defaults, available, (i) => i.key);
+    expect(result).toEqual([item('a', false)]);
+  });
+
+  it('drops a duplicate key in the saved list itself', () => {
+    const saved = [item('a'), item('a')];
+    const available = new Set(['a']);
+    expect(keys(mergeOrdered(saved, [], available, (i) => i.key))).toEqual(['a']);
+  });
+
+  it('never appends a default that is not in the available set', () => {
+    const defaults = [item('a'), item('b')];
+    const available = new Set(['a']);
+    expect(keys(mergeOrdered([], defaults, available, (i) => i.key))).toEqual(['a']);
+  });
+
+  it('returns an empty list when nothing is saved, defaulted or available', () => {
+    expect(mergeOrdered([], [], new Set(), (i: Item) => i.key)).toEqual([]);
+  });
+});

--- a/client/src/app/core/plugin-ui/merge-ordered.ts
+++ b/client/src/app/core/plugin-ui/merge-ordered.ts
@@ -1,0 +1,31 @@
+/**
+ * Merge a stored user order with the currently-available set: items still
+ * available keep their saved position, items never seen before are appended
+ * in their canonical (`defaults`) order, and items that disappeared are
+ * dropped silently. Lifted out of `HomeSettingsService.resolve()` so a
+ * second consumer (the plugin nav order) doesn't reimplement it.
+ */
+export function mergeOrdered<T>(
+  saved: T[],
+  defaults: T[],
+  available: ReadonlySet<string>,
+  keyOf: (item: T) => string,
+): T[] {
+  const seen = new Set<string>();
+  const merged: T[] = [];
+  for (const item of saved) {
+    const key = keyOf(item);
+    if (available.has(key) && !seen.has(key)) {
+      merged.push(item);
+      seen.add(key);
+    }
+  }
+  for (const item of defaults) {
+    const key = keyOf(item);
+    if (available.has(key) && !seen.has(key)) {
+      merged.push(item);
+      seen.add(key);
+    }
+  }
+  return merged;
+}

--- a/client/src/app/core/plugin-ui/plugin-i18n.service.spec.ts
+++ b/client/src/app/core/plugin-ui/plugin-i18n.service.spec.ts
@@ -1,0 +1,101 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  TranslateLoader,
+  TranslateService,
+  provideTranslateService,
+  type TranslationObject,
+} from '@ngx-translate/core';
+import { firstValueFrom, of } from 'rxjs';
+import { PluginI18nService } from './plugin-i18n.service';
+import { PluginUiRegistryService } from './plugin-ui-registry.service';
+
+describe('PluginI18nService', () => {
+  const loaderData: Record<string, TranslationObject> = {};
+
+  beforeEach(() => {
+    for (const key of Object.keys(loaderData)) delete loaderData[key];
+  });
+
+  function setup(pluginI18n: Record<string, Record<string, string>>) {
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        provideTranslateService({
+          lang: 'en',
+          fallbackLang: 'en',
+          loader: {
+            provide: TranslateLoader,
+            useValue: { getTranslation: (lang: string) => of(loaderData[lang] ?? {}) },
+          },
+        }),
+        { provide: PluginUiRegistryService, useValue: { i18nFor: (lang: string) => pluginI18n[lang] } },
+      ],
+    });
+    return {
+      translate: TestBed.inject(TranslateService),
+      i18n: TestBed.inject(PluginI18nService),
+    };
+  }
+
+  it('expands a flat "a.b.c" plugin key into nested translations so labelKey resolves', () => {
+    loaderData['en'] = {};
+    const { translate, i18n } = setup({ en: { 'fliks.foo.title': 'Foo' } });
+    i18n.mergeIntoLang('en');
+    expect(translate.instant('fliks.foo.title')).toBe('Foo');
+  });
+
+  // The whole safety property: a plugin manifest must never deface a core label.
+  it('VERDICT: a plugin can never overwrite an existing core key — core wins', () => {
+    loaderData['en'] = { nav: { home: 'Home' } };
+    const { translate, i18n } = setup({ en: { 'nav.home': 'HACKED' } });
+    i18n.mergeIntoLang('en');
+    expect(translate.instant('nav.home')).toBe('Home');
+  });
+
+  it('still lets a plugin fill in a key core does not define', () => {
+    loaderData['en'] = { nav: { home: 'Home' } };
+    const { translate, i18n } = setup({ en: { 'nav.plugin_item': 'Plugin item' } });
+    i18n.mergeIntoLang('en');
+    expect(translate.instant('nav.home')).toBe('Home');
+    expect(translate.instant('nav.plugin_item')).toBe('Plugin item');
+  });
+
+  it('does nothing for a locale no plugin ships a dict for', () => {
+    loaderData['en'] = { nav: { home: 'Home' } };
+    const { translate, i18n } = setup({ fr: { 'nav.home': 'HACKED' } });
+    i18n.mergeIntoLang('en');
+    expect(translate.instant('nav.home')).toBe('Home');
+  });
+
+  it('re-merges on a runtime language switch — the fresh core load never wipes the plugin keys, and core still wins', async () => {
+    loaderData['en'] = {};
+    loaderData['fr'] = { nav: { home: 'Accueil' } };
+    const { translate } = setup({ fr: { 'nav.home': 'HACKED', 'nav.plugin_item': 'Item' } });
+
+    await firstValueFrom(translate.use('fr'));
+
+    expect(translate.instant('nav.home')).toBe('Accueil');
+    expect(translate.instant('nav.plugin_item')).toBe('Item');
+  });
+
+  it('init() merges whatever is already loaded without awaiting the network', () => {
+    loaderData['en'] = { nav: { home: 'Home' } };
+    const { translate, i18n } = setup({ en: { 'nav.plugin_item': 'Item' } });
+    i18n.init();
+    expect(translate.instant('nav.plugin_item')).toBe('Item');
+  });
+
+  it('falls back to the app default fallbackLang for a locale the plugin never ships — no new mechanism', async () => {
+    loaderData['en'] = {};
+    loaderData['fr'] = {};
+    const { translate, i18n } = setup({ en: { 'fliks.foo.title': 'Foo' } });
+    i18n.init();
+
+    await firstValueFrom(translate.use('fr'));
+
+    // 'fr' has no plugin dict at all; ngx-translate's own fallbackLang picks
+    // up the key from 'en', where the plugin's merge landed at init.
+    expect(translate.instant('fliks.foo.title')).toBe('Foo');
+  });
+});

--- a/client/src/app/core/plugin-ui/plugin-i18n.service.ts
+++ b/client/src/app/core/plugin-ui/plugin-i18n.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, inject } from '@angular/core';
+import { TranslateService, TranslateStore, insertValue, mergeDeep, type TranslationObject } from '@ngx-translate/core';
+import { PluginUiRegistryService } from './plugin-ui-registry.service';
+
+/**
+ * Merges each plugin's `i18n[lang]` (a flat `"a.b.c": "value"` map) into
+ * ngx-translate. Core always wins a key collision: the plugin's dict is
+ * expanded to a nested object first, then `mergeDeep(plugin, core)` puts
+ * core second so its leaves overwrite the plugin's, never the reverse.
+ * Missing locales fall back the way the app already does — `fallbackLang`
+ * in `provideTranslateService` — nothing extra is needed here for that.
+ */
+@Injectable({ providedIn: 'root' })
+export class PluginI18nService {
+  private readonly translate = inject(TranslateService);
+  private readonly store = inject(TranslateStore);
+  private readonly registry = inject(PluginUiRegistryService);
+
+  constructor() {
+    // Core's own translations load asynchronously and may still be in
+    // flight when init() runs; catch up whenever a (re)load completes,
+    // including a later runtime language switch.
+    this.translate.onLangChange.subscribe(({ lang }) => this.mergeIntoLang(lang));
+    this.translate.onFallbackLangChange.subscribe(({ lang }) => this.mergeIntoLang(lang));
+  }
+
+  /** Called once from the app initializer, after the registry has loaded.
+   *  Never awaits the translation network call — a plugin label resolves
+   *  whenever core's own labels do, never later, never blocking boot. */
+  init(): void {
+    for (const lang of this.translate.getLangs()) this.mergeIntoLang(lang);
+  }
+
+  mergeIntoLang(lang: string): void {
+    const flat = this.registry.i18nFor(lang);
+    if (!flat) return;
+    let pluginNested: TranslationObject = {};
+    for (const [key, value] of Object.entries(flat)) {
+      pluginNested = insertValue(pluginNested, key, value) as TranslationObject;
+    }
+    const core = this.store.getTranslations(lang) as TranslationObject | undefined;
+    this.store.setTranslations(lang, mergeDeep(pluginNested, core ?? {}), false);
+  }
+}

--- a/client/src/app/core/plugin-ui/plugin-ui-registry.service.spec.ts
+++ b/client/src/app/core/plugin-ui/plugin-ui-registry.service.spec.ts
@@ -1,0 +1,166 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { PluginUiRegistryService } from './plugin-ui-registry.service';
+import type { PluginUiEntry } from './plugin-ui-response';
+import type { UiContribution } from './contribution.types';
+
+const contribution = (id: string, weight: number, overrides: Partial<UiContribution> = {}): UiContribution => ({
+  id,
+  slot: 'nav.main',
+  weight,
+  labelKey: `x.${id}`,
+  action: { kind: 'route', path: `/plugins/x/${id}` },
+  ...overrides,
+});
+
+const entry = (pluginId: string, contributions: UiContribution[], extra: Partial<PluginUiEntry> = {}): PluginUiEntry => ({
+  pluginId,
+  contributions,
+  configPages: [],
+  ...extra,
+});
+
+describe('PluginUiRegistryService', () => {
+  let http: HttpTestingController;
+  let registry: PluginUiRegistryService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection(), provideHttpClient(), provideHttpClientTesting()],
+    });
+    http = TestBed.inject(HttpTestingController);
+    registry = TestBed.inject(PluginUiRegistryService);
+  });
+
+  afterEach(() => http.verify());
+
+  it('boots to an empty registry before load() ever resolves', () => {
+    expect(registry.contributionsFor('nav.main')).toEqual([]);
+    expect(registry.hasPlugin('fliks.a')).toBe(false);
+  });
+
+  it('caches the response and never issues a second request', async () => {
+    const promise = registry.load();
+    http.expectOne('/api/plugins/ui').flush([entry('fliks.a', [contribution('a', 100)])]);
+    await promise;
+
+    expect(registry.hasPlugin('fliks.a')).toBe(true);
+    // A second read must not touch the network — HttpTestingController.verify()
+    // in afterEach would fail if it did.
+    expect(registry.contributionsFor('nav.main')).toHaveLength(1);
+  });
+
+  it('sorts contributions ascending by weight, then ascending by id on a tie, across plugins', async () => {
+    const promise = registry.load();
+    http.expectOne('/api/plugins/ui').flush([
+      entry('fliks.a', [contribution('z', 100), contribution('a', 100), contribution('b', -50)]),
+      entry('fliks.b', [contribution('c', 50)]),
+    ]);
+    await promise;
+
+    expect(registry.contributionsFor('nav.main').map((c) => c.id)).toEqual(['b', 'c', 'a', 'z']);
+  });
+
+  it('keeps slots separate', async () => {
+    const promise = registry.load();
+    http.expectOne('/api/plugins/ui').flush([
+      entry('fliks.a', [
+        contribution('nav', 100, { slot: 'nav.main' }),
+        contribution('act', 100, { slot: 'media.actions' }),
+      ]),
+    ]);
+    await promise;
+
+    expect(registry.contributionsFor('nav.main').map((c) => c.id)).toEqual(['nav']);
+    expect(registry.contributionsFor('media.actions').map((c) => c.id)).toEqual(['act']);
+  });
+
+  it('fails open to an empty registry on an HTTP error — never throws, never hangs', async () => {
+    const promise = registry.load();
+    http.expectOne('/api/plugins/ui').flush('boom', { status: 500, statusText: 'Server Error' });
+    await expect(promise).resolves.toBeUndefined();
+
+    expect(registry.contributionsFor('nav.main')).toEqual([]);
+    expect(registry.hasPlugin('fliks.a')).toBe(false);
+  });
+
+  it('fails open to an empty registry on a malformed (non-array) payload', async () => {
+    const promise = registry.load();
+    http.expectOne('/api/plugins/ui').flush({ not: 'an array' } as never);
+    await expect(promise).resolves.toBeUndefined();
+
+    expect(registry.contributionsFor('nav.main')).toEqual([]);
+  });
+
+  it('fails open to an empty registry when the request times out', async () => {
+    vi.useFakeTimers();
+    try {
+      const promise = registry.load();
+      http.expectOne('/api/plugins/ui'); // never flushed — simulates a hung plugin process
+      await vi.advanceTimersByTimeAsync(10_000);
+      await expect(promise).resolves.toBeUndefined();
+      expect(registry.contributionsFor('nav.main')).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('finds a contribution by its route path, across every slot', async () => {
+    const promise = registry.load();
+    http.expectOne('/api/plugins/ui').flush([
+      entry('fliks.a', [contribution('settings', 100, { slot: 'settings.page', action: { kind: 'route', path: '/admin/settings/plugins/fliks.a/settings' } })]),
+    ]);
+    await promise;
+
+    expect(registry.findRouteContribution('/admin/settings/plugins/fliks.a/settings')?.id).toBe('settings');
+    expect(registry.findRouteContribution('/no/such/path')).toBeUndefined();
+  });
+
+  it('ignores an action-kind contribution when resolving by path', async () => {
+    const promise = registry.load();
+    http.expectOne('/api/plugins/ui').flush([
+      entry('fliks.a', [contribution('act', 100, { action: { kind: 'action', actionId: 'core.thing' } })]),
+    ]);
+    await promise;
+
+    expect(registry.findRouteContribution('/plugins/x/act')).toBeUndefined();
+  });
+
+  it('resolves a config page by plugin id and page id', async () => {
+    const promise = registry.load();
+    http.expectOne('/api/plugins/ui').flush([
+      entry('fliks.a', [], { configPages: [{ id: 'main', labelKey: 'x.main', fields: [] }] }),
+    ]);
+    await promise;
+
+    expect(registry.configPage('fliks.a', 'main')?.labelKey).toBe('x.main');
+    expect(registry.configPage('fliks.a', 'missing')).toBeUndefined();
+    expect(registry.configPage('fliks.unknown', 'main')).toBeUndefined();
+  });
+
+  it('merges every plugin i18n dict for a locale, and returns undefined when none ship it', async () => {
+    const promise = registry.load();
+    http.expectOne('/api/plugins/ui').flush([
+      entry('fliks.a', [], { i18n: { fr: { 'fliks.a.title': 'Titre A' } } }),
+      entry('fliks.b', [], { i18n: { fr: { 'fliks.b.title': 'Titre B' } } }),
+    ]);
+    await promise;
+
+    expect(registry.i18nFor('fr')).toEqual({ 'fliks.a.title': 'Titre A', 'fliks.b.title': 'Titre B' });
+    expect(registry.i18nFor('de')).toBeUndefined();
+  });
+
+  it('lets no plugin redefine another plugin\'s key, picking the winner by plugin id', async () => {
+    const promise = registry.load();
+    http.expectOne('/api/plugins/ui').flush([
+      entry('fliks.zeta', [], { i18n: { en: { shared: 'from zeta' } } }),
+      entry('fliks.alpha', [], { i18n: { en: { shared: 'from alpha', own: 'a' } } }),
+    ]);
+    await promise;
+
+    // Ordered by plugin id and first-declared wins, so install order cannot change it.
+    expect(registry.i18nFor('en')).toEqual({ shared: 'from alpha', own: 'a' });
+  });
+});

--- a/client/src/app/core/plugin-ui/plugin-ui-registry.service.ts
+++ b/client/src/app/core/plugin-ui/plugin-ui-registry.service.ts
@@ -1,0 +1,89 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom, of } from 'rxjs';
+import { catchError, timeout } from 'rxjs/operators';
+import type { ConfigPage, SlotId, UiContribution } from './contribution.types';
+import type { PluginUiEntry } from './plugin-ui-response';
+
+/** Bounds the boot-blocking wait: a dead plugin endpoint must never hold the splash. */
+const FETCH_TIMEOUT_MS = 3000;
+
+/**
+ * Fetches `GET /api/plugins/ui` once at app init and caches it. Every other
+ * consumer reads the cache — nothing here ever refetches. On any error,
+ * timeout or malformed payload it fails open to an empty registry, so a
+ * Fliks with no plugins and one with a broken plugin endpoint boot identically.
+ */
+@Injectable({ providedIn: 'root' })
+export class PluginUiRegistryService {
+  private readonly http = inject(HttpClient);
+  private entries: PluginUiEntry[] = [];
+  private bySlot = new Map<SlotId, UiContribution[]>();
+
+  async load(): Promise<void> {
+    const entries = await firstValueFrom(
+      this.http.get<PluginUiEntry[]>('/api/plugins/ui').pipe(
+        timeout(FETCH_TIMEOUT_MS),
+        catchError(() => of<PluginUiEntry[]>([])),
+      ),
+    );
+    this.entries = Array.isArray(entries) ? entries : [];
+    this.index();
+  }
+
+  private index(): void {
+    const bySlot = new Map<SlotId, UiContribution[]>();
+    for (const entry of this.entries) {
+      for (const contribution of entry.contributions ?? []) {
+        const list = bySlot.get(contribution.slot);
+        if (list) list.push(contribution);
+        else bySlot.set(contribution.slot, [contribution]);
+      }
+    }
+    for (const list of bySlot.values()) {
+      list.sort((a, b) => a.weight - b.weight || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+    }
+    this.bySlot = bySlot;
+  }
+
+  /** Contributions for one slot, sorted ascending by weight then ascending by id. */
+  contributionsFor(slot: SlotId): UiContribution[] {
+    return this.bySlot.get(slot) ?? [];
+  }
+
+  /** The one contribution (any slot) whose route action points at this path, if any. */
+  findRouteContribution(path: string): UiContribution | undefined {
+    for (const list of this.bySlot.values()) {
+      const found = list.find((c) => c.action.kind === 'route' && c.action.path === path);
+      if (found) return found;
+    }
+    return undefined;
+  }
+
+  hasPlugin(pluginId: string): boolean {
+    return this.entries.some((e) => e.pluginId === pluginId);
+  }
+
+  configPage(pluginId: string, pageId: string): ConfigPage | undefined {
+    return this.entries.find((e) => e.pluginId === pluginId)?.configPages?.find((p) => p.id === pageId);
+  }
+
+  /**
+   * Every plugin's `i18n[lang]` dict combined; undefined when none ship that locale.
+   * Ordered by plugin id and first-declared wins, so one plugin can never redefine
+   * another's key — and the winner does not change when install order does.
+   */
+  i18nFor(lang: string): Record<string, string> | undefined {
+    let merged: Record<string, string> | undefined;
+    const ordered = [...this.entries].sort((a, b) => (a.pluginId < b.pluginId ? -1 : a.pluginId > b.pluginId ? 1 : 0));
+    for (const entry of ordered) {
+      const dict = entry.i18n?.[lang];
+      if (!dict) continue;
+      merged ??= {};
+      for (const [key, value] of Object.entries(dict)) {
+        if (!(key in merged)) merged[key] = value;
+      }
+    }
+    return merged;
+  }
+}

--- a/client/src/app/core/plugin-ui/plugin-ui-response.ts
+++ b/client/src/app/core/plugin-ui/plugin-ui-response.ts
@@ -1,0 +1,14 @@
+import type { ConfigPage, UiContribution } from './contribution.types';
+
+/**
+ * `GET /api/plugins/ui` response entry, one per plugin whose contributions
+ * are currently live. Single declared shape — reconcile here if the
+ * backend's differs; nothing else needs to change.
+ */
+export interface PluginUiEntry {
+  pluginId: string;
+  contributions: UiContribution[];
+  configPages: ConfigPage[];
+  /** Translations to merge into ngx-translate so `labelKey` resolves. */
+  i18n?: Record<string, Record<string, string>>;
+}

--- a/client/src/app/core/plugin-ui/when-evaluator.spec.ts
+++ b/client/src/app/core/plugin-ui/when-evaluator.spec.ts
@@ -1,0 +1,67 @@
+import { evaluateWhen, type WhenContext } from './when-evaluator';
+
+const ctx = (overrides: Partial<WhenContext> = {}): WhenContext => ({
+  isAdmin: false,
+  hasPermission: () => false,
+  isTv: false,
+  isTouch: false,
+  ...overrides,
+});
+
+describe('evaluateWhen', () => {
+  it('passes with no when array at all', () => {
+    expect(evaluateWhen(undefined, ctx())).toBe(true);
+  });
+
+  it('passes with an empty when array', () => {
+    expect(evaluateWhen([], ctx())).toBe(true);
+  });
+
+  it('requires every predicate to pass (.every semantics)', () => {
+    expect(evaluateWhen(['isAdmin', 'isTv'], ctx({ isAdmin: true, isTv: false }))).toBe(false);
+    expect(evaluateWhen(['isAdmin', 'isTv'], ctx({ isAdmin: true, isTv: true }))).toBe(true);
+  });
+
+  it('delegates hasPermission:<perm> to the context', () => {
+    const c = ctx({ hasPermission: (p) => p === 'settings.access' });
+    expect(evaluateWhen(['hasPermission:settings.access'], c)).toBe(true);
+    expect(evaluateWhen(['hasPermission:users.manage'], c)).toBe(false);
+  });
+
+  it('checks mediaType against the context', () => {
+    expect(evaluateWhen(['mediaType:movie'], ctx({ mediaType: 'movie' }))).toBe(true);
+    expect(evaluateWhen(['mediaType:movie'], ctx({ mediaType: 'series' }))).toBe(false);
+    expect(evaluateWhen(['mediaType:series'], ctx({}))).toBe(false);
+  });
+
+  it('treats every optional flag as false when the context omits it', () => {
+    expect(evaluateWhen(['hasFiles'], ctx())).toBe(false);
+    expect(evaluateWhen(['isMonitored'], ctx())).toBe(false);
+    expect(evaluateWhen(['hasQualityProfile'], ctx())).toBe(false);
+    expect(evaluateWhen(['isEpisode'], ctx())).toBe(false);
+  });
+
+  it('negates a known predicate with a leading "!"', () => {
+    expect(evaluateWhen(['!isAdmin'], ctx({ isAdmin: false }))).toBe(true);
+    expect(evaluateWhen(['!isAdmin'], ctx({ isAdmin: true }))).toBe(false);
+  });
+
+  it('reads isTv / isTouch straight off the context', () => {
+    expect(evaluateWhen(['isTv'], ctx({ isTv: true }))).toBe(true);
+    expect(evaluateWhen(['isTouch'], ctx({ isTouch: true }))).toBe(true);
+  });
+
+  // The whole safety property: a manifest naming a predicate this client
+  // doesn't know must hide the item, never show it — in either polarity.
+  it('VERDICT: an unknown predicate is always false', () => {
+    expect(evaluateWhen(['somethingFromTheFuture'], ctx())).toBe(false);
+  });
+
+  it('VERDICT: a negated unknown predicate is ALSO false, not true', () => {
+    expect(evaluateWhen(['!somethingFromTheFuture'], ctx())).toBe(false);
+  });
+
+  it('fails closed for the whole array when one predicate is unknown, even if the rest pass', () => {
+    expect(evaluateWhen(['isAdmin', 'somethingFromTheFuture'], ctx({ isAdmin: true }))).toBe(false);
+  });
+});

--- a/client/src/app/core/plugin-ui/when-evaluator.ts
+++ b/client/src/app/core/plugin-ui/when-evaluator.ts
@@ -1,0 +1,54 @@
+import type { MediaType } from '../enums/media-type.enum';
+
+/**
+ * Everything a `when` predicate can read. Deliberately narrow — this is not
+ * app state, just the handful of facts the closed vocabulary needs.
+ */
+export interface WhenContext {
+  isAdmin: boolean;
+  hasPermission: (permission: string) => boolean;
+  mediaType?: MediaType;
+  hasFiles?: boolean;
+  isMonitored?: boolean;
+  hasQualityProfile?: boolean;
+  isEpisode?: boolean;
+  isTv: boolean;
+  isTouch: boolean;
+}
+
+/** `null` marks a predicate this client doesn't know — the fail-closed signal. */
+function evaluateKnown(predicate: string, ctx: WhenContext): boolean | null {
+  if (predicate === 'isAdmin') return ctx.isAdmin;
+  if (predicate.startsWith('hasPermission:')) {
+    return ctx.hasPermission(predicate.slice('hasPermission:'.length));
+  }
+  if (predicate === 'mediaType:movie') return ctx.mediaType === 'movie';
+  if (predicate === 'mediaType:series') return ctx.mediaType === 'series';
+  if (predicate === 'hasFiles') return ctx.hasFiles ?? false;
+  if (predicate === 'isMonitored') return ctx.isMonitored ?? false;
+  if (predicate === 'hasQualityProfile') return ctx.hasQualityProfile ?? false;
+  if (predicate === 'isEpisode') return ctx.isEpisode ?? false;
+  if (predicate === 'isTv') return ctx.isTv;
+  if (predicate === 'isTouch') return ctx.isTouch;
+  return null;
+}
+
+/**
+ * One `when` entry. A leading "!" negates — but an unknown predicate stays
+ * false even negated, because negating "unknown" is still unknown.
+ */
+function evaluateOne(predicate: string, ctx: WhenContext): boolean {
+  const negated = predicate.startsWith('!');
+  const result = evaluateKnown(negated ? predicate.slice(1) : predicate, ctx);
+  if (result === null) return false;
+  return negated ? !result : result;
+}
+
+/**
+ * `when` is presentation only: it decides what the client shows, never what
+ * the server allows. Every action behind a contribution is CASL-guarded
+ * server-side regardless of how this evaluates.
+ */
+export function evaluateWhen(when: readonly string[] | undefined, ctx: WhenContext): boolean {
+  return (when ?? []).every((predicate) => evaluateOne(predicate, ctx));
+}

--- a/client/src/app/core/services/home-settings.service.spec.ts
+++ b/client/src/app/core/services/home-settings.service.spec.ts
@@ -1,0 +1,202 @@
+import { HomeSettingsService, type HomeSectionPref } from './home-settings.service';
+
+const lib = (id: number, name: string) => ({ id, name });
+const keys = (sections: { key: string }[]) => sections.map((s) => s.key);
+
+describe('HomeSettingsService.resolve', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('returns the canonical built-in order, all visible, for a fresh user', () => {
+    const svc = new HomeSettingsService();
+    expect(keys(svc.resolve([]))).toEqual([
+      'received-recommendations',
+      'libraries',
+      'continue-watching',
+      'recommendations',
+      'likes',
+      'recently-added',
+      'playlists',
+      'coming-soon',
+    ]);
+    expect(svc.resolve([]).every((s) => s.visible)).toBe(true);
+  });
+
+  it('honours a saved order for zones still available', () => {
+    const svc = new HomeSettingsService();
+    svc.setOrder([
+      { key: 'likes', visible: false },
+      { key: 'libraries', visible: true },
+      { key: 'received-recommendations', visible: true },
+      { key: 'continue-watching', visible: true },
+      { key: 'recommendations', visible: true },
+      { key: 'recently-added', visible: true },
+      { key: 'playlists', visible: true },
+      { key: 'coming-soon', visible: true },
+    ]);
+    expect(keys(svc.resolve([]))).toEqual([
+      'likes',
+      'libraries',
+      'received-recommendations',
+      'continue-watching',
+      'recommendations',
+      'recently-added',
+      'playlists',
+      'coming-soon',
+    ]);
+    expect(svc.resolve([]).find((s) => s.key === 'likes')?.visible).toBe(false);
+  });
+
+  it('appends a built-in the saved layout predates, at its canonical position', () => {
+    const svc = new HomeSettingsService();
+    // A layout saved before "likes" existed — every built-in but that one.
+    svc.setOrder([
+      { key: 'received-recommendations', visible: true },
+      { key: 'libraries', visible: true },
+      { key: 'continue-watching', visible: true },
+      { key: 'recommendations', visible: true },
+      { key: 'recently-added', visible: true },
+      { key: 'playlists', visible: true },
+      { key: 'coming-soon', visible: true },
+    ]);
+    expect(keys(svc.resolve([]))).toEqual([
+      'received-recommendations',
+      'libraries',
+      'continue-watching',
+      'recommendations',
+      'recently-added',
+      'playlists',
+      'coming-soon',
+      'likes',
+    ]);
+  });
+
+  it('unshifts received-recommendations to the front when a saved layout predates it, instead of appending it', () => {
+    const svc = new HomeSettingsService();
+    svc.setOrder([
+      { key: 'libraries', visible: true },
+      { key: 'continue-watching', visible: true },
+      { key: 'recommendations', visible: true },
+      { key: 'likes', visible: true },
+      { key: 'recently-added', visible: true },
+      { key: 'playlists', visible: true },
+      { key: 'coming-soon', visible: true },
+    ]);
+    expect(keys(svc.resolve([]))[0]).toBe('received-recommendations');
+  });
+
+  it('drops a saved zone whose library no longer exists', () => {
+    const svc = new HomeSettingsService();
+    svc.setOrder([
+      { key: 'received-recommendations', visible: true },
+      { key: 'library-recent:99', visible: true },
+      { key: 'libraries', visible: true },
+      { key: 'continue-watching', visible: true },
+      { key: 'recommendations', visible: true },
+      { key: 'likes', visible: true },
+      { key: 'recently-added', visible: true },
+      { key: 'playlists', visible: true },
+      { key: 'coming-soon', visible: true },
+    ]);
+    expect(keys(svc.resolve([]))).not.toContain('library-recent:99');
+  });
+
+  it('appends one hidden-by-default zone per library not yet in the saved order', () => {
+    const svc = new HomeSettingsService();
+    const result = svc.resolve([lib(1, 'Movies'), lib(2, 'Series')]);
+    const movies = result.find((s) => s.key === 'library-recent:1');
+    const series = result.find((s) => s.key === 'library-recent:2');
+    expect(movies).toMatchObject({ type: 'library-recent', visible: false, libraryId: 1, libraryName: 'Movies' });
+    expect(series).toMatchObject({ type: 'library-recent', visible: false, libraryId: 2, libraryName: 'Series' });
+    // Appended after every built-in.
+    expect(keys(result).slice(-2)).toEqual(['library-recent:1', 'library-recent:2']);
+  });
+
+  it('keeps a saved visibility/position for a library-recent zone', () => {
+    const svc = new HomeSettingsService();
+    svc.setOrder([
+      { key: 'library-recent:1', visible: true },
+      { key: 'received-recommendations', visible: true },
+      { key: 'libraries', visible: true },
+      { key: 'continue-watching', visible: true },
+      { key: 'recommendations', visible: true },
+      { key: 'likes', visible: true },
+      { key: 'recently-added', visible: true },
+      { key: 'playlists', visible: true },
+      { key: 'coming-soon', visible: true },
+    ]);
+    const result = svc.resolve([lib(1, 'Movies')]);
+    expect(keys(result)[0]).toBe('library-recent:1');
+    expect(result[0].visible).toBe(true);
+  });
+
+  it('omits requests-recent when the caller does not opt in', () => {
+    const svc = new HomeSettingsService();
+    expect(keys(svc.resolve([]))).not.toContain('requests-recent');
+  });
+
+  it('inserts requests-recent just above recently-added, visible by default, when opted in with no saved preference', () => {
+    const svc = new HomeSettingsService();
+    const result = svc.resolve([], { requests: true });
+    const idx = keys(result).indexOf('requests-recent');
+    expect(idx).toBe(keys(result).indexOf('recently-added') - 1);
+    expect(result[idx].visible).toBe(true);
+  });
+
+  it('honours a saved position/visibility for requests-recent instead of re-slotting it', () => {
+    const svc = new HomeSettingsService();
+    svc.setOrder([
+      { key: 'requests-recent', visible: false },
+      { key: 'received-recommendations', visible: true },
+      { key: 'libraries', visible: true },
+      { key: 'continue-watching', visible: true },
+      { key: 'recommendations', visible: true },
+      { key: 'likes', visible: true },
+      { key: 'recently-added', visible: true },
+      { key: 'playlists', visible: true },
+      { key: 'coming-soon', visible: true },
+    ]);
+    const result = svc.resolve([], { requests: true });
+    expect(keys(result)[0]).toBe('requests-recent');
+    expect(result[0].visible).toBe(false);
+  });
+
+  it('drops requests-recent entirely once the caller stops opting in, even if it was saved', () => {
+    const svc = new HomeSettingsService();
+    svc.setOrder([{ key: 'requests-recent', visible: true }]);
+    expect(keys(svc.resolve([]))).not.toContain('requests-recent');
+  });
+});
+
+describe('HomeSettingsService persistence', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('persists setOrder and setMode across instances', () => {
+    const a = new HomeSettingsService();
+    const order: HomeSectionPref[] = [{ key: 'likes', visible: false }];
+    a.setOrder(order);
+    a.setMode('media');
+
+    const b = new HomeSettingsService();
+    expect(b.settings().order).toEqual(order);
+    expect(b.settings().recentlyAddedMode).toBe('media');
+  });
+
+  it('resetLayout restores canonical order/visibility but keeps the recently-added mode', () => {
+    const svc = new HomeSettingsService();
+    svc.setOrder([{ key: 'likes', visible: false }]);
+    svc.setMode('both');
+    svc.resetLayout();
+    expect(keys(svc.resolve([]))).toEqual([
+      'received-recommendations',
+      'libraries',
+      'continue-watching',
+      'recommendations',
+      'likes',
+      'recently-added',
+      'playlists',
+      'coming-soon',
+    ]);
+    expect(svc.resolve([]).every((s) => s.visible)).toBe(true);
+    expect(svc.settings().recentlyAddedMode).toBe('both');
+  });
+});

--- a/client/src/app/core/services/home-settings.service.ts
+++ b/client/src/app/core/services/home-settings.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, signal } from '@angular/core';
+import { mergeOrdered } from '../plugin-ui/merge-ordered';
 
 /** Stable identity of a home zone. Built-ins are fixed; per-library
  *  "recently added" zones are keyed by their library id. */
@@ -139,41 +140,26 @@ export class HomeSettingsService {
       available.add(`${LIBRARY_RECENT_PREFIX}${lib.id}` as HomeSectionKey);
     }
 
-    const seen = new Set<HomeSectionKey>();
-    const merged: HomeSectionPref[] = [];
-    for (const pref of this.settings().order) {
-      if (available.has(pref.key) && !seen.has(pref.key)) {
-        merged.push(pref);
-        seen.add(pref.key);
-      }
-    }
     // Saved layouts predating this zone get it on top, not appended at the
-    // bottom (new users already get it first via DEFAULTS).
-    if (!seen.has('received-recommendations')) {
-      merged.unshift({ key: 'received-recommendations', visible: true });
-      seen.add('received-recommendations');
-    }
-    for (const key of BUILTIN_ORDER) {
-      if (!seen.has(key)) {
-        merged.push({ key, visible: true });
-        seen.add(key);
-      }
+    // bottom (new users already get it first via DEFAULTS) — so it's kept
+    // out of the generic merge's canonical-order append and handled after.
+    const otherBuiltins = DEFAULTS.order.filter((p) => p.key !== 'received-recommendations');
+    let merged = mergeOrdered(this.settings().order, otherBuiltins, available, (p) => p.key);
+    if (!merged.some((p) => p.key === 'received-recommendations')) {
+      merged = [{ key: 'received-recommendations', visible: true }, ...merged];
     }
     // Permission-gated built-in: only offered when the user can use requests.
     // With no saved preference it defaults visible, slotted just above
     // "recently-added"; a saved order (handled above) wins.
-    if (opts.requests && !seen.has('requests-recent')) {
+    if (opts.requests && !merged.some((p) => p.key === 'requests-recent')) {
       const pref: HomeSectionPref = { key: 'requests-recent', visible: true };
       const at = merged.findIndex((p) => p.key === 'recently-added');
-      if (at >= 0) merged.splice(at, 0, pref);
-      else merged.push(pref);
-      seen.add('requests-recent');
+      merged = at >= 0 ? [...merged.slice(0, at), pref, ...merged.slice(at)] : [...merged, pref];
     }
     for (const lib of libraries) {
       const key = `${LIBRARY_RECENT_PREFIX}${lib.id}` as HomeSectionKey;
-      if (!seen.has(key)) {
-        merged.push({ key, visible: false });
-        seen.add(key);
+      if (!merged.some((p) => p.key === key)) {
+        merged = [...merged, { key, visible: false }];
       }
     }
 

--- a/client/src/app/features/plugin-view/plugin-view.html
+++ b/client/src/app/features/plugin-view/plugin-view.html
@@ -1,0 +1,11 @@
+<div class="flex flex-col items-center justify-center text-center py-16 text-base-content/60">
+  <svg lucideTriangleAlert class="h-10 w-10 mb-3 opacity-50"></svg>
+  <p class="text-lg font-semibold">{{ 'plugin_view.unavailable_title' | translate }}</p>
+  <p class="mt-1 text-sm">
+    @switch (reason()) {
+      @case ('unknown_plugin') { {{ 'plugin_view.unknown_plugin' | translate }} }
+      @case ('unknown_view') { {{ 'plugin_view.unknown_view' | translate }} }
+      @default { {{ 'plugin_view.unsupported_kind' | translate }} }
+    }
+  </p>
+</div>

--- a/client/src/app/features/plugin-view/plugin-view.spec.ts
+++ b/client/src/app/features/plugin-view/plugin-view.spec.ts
@@ -1,0 +1,52 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { PluginViewComponent } from './plugin-view';
+import { PluginUiRegistryService } from '../../core/plugin-ui/plugin-ui-registry.service';
+import type { ConfigPage } from '../../core/plugin-ui/contribution.types';
+
+function createComponent(
+  params: { pluginId: string; view: string },
+  registry: { hasPlugin: (id: string) => boolean; configPage: (id: string, view: string) => ConfigPage | undefined },
+) {
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      provideTranslateService({
+        lang: 'en',
+        loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+      }),
+      { provide: ActivatedRoute, useValue: { paramMap: of(convertToParamMap(params)) } },
+      { provide: PluginUiRegistryService, useValue: registry },
+    ],
+  });
+  return TestBed.createComponent(PluginViewComponent).componentInstance;
+}
+
+describe('PluginViewComponent', () => {
+  it('reports unknown_plugin when the plugin is not in the registry', () => {
+    const c = createComponent(
+      { pluginId: 'fliks.gone', view: 'settings' },
+      { hasPlugin: () => false, configPage: () => undefined },
+    );
+    expect(c.reason()).toBe('unknown_plugin');
+  });
+
+  it('reports unknown_view when the plugin exists but has no matching config page', () => {
+    const c = createComponent(
+      { pluginId: 'fliks.a', view: 'missing' },
+      { hasPlugin: () => true, configPage: () => undefined },
+    );
+    expect(c.reason()).toBe('unknown_view');
+  });
+
+  it('reports unsupported_kind when the view resolves — form/providers/table rendering ships later', () => {
+    const c = createComponent(
+      { pluginId: 'fliks.a', view: 'settings' },
+      { hasPlugin: () => true, configPage: () => ({ id: 'settings', labelKey: 'x', fields: [] }) },
+    );
+    expect(c.reason()).toBe('unsupported_kind');
+  });
+});

--- a/client/src/app/features/plugin-view/plugin-view.ts
+++ b/client/src/app/features/plugin-view/plugin-view.ts
@@ -1,0 +1,38 @@
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { LucideTriangleAlert } from '@lucide/angular';
+import { PluginUiRegistryService } from '../../core/plugin-ui/plugin-ui-registry.service';
+
+type UnavailableReason = 'unknown_plugin' | 'unknown_view' | 'unsupported_kind';
+
+/**
+ * Resolves `plugins/:pluginId/:view` and the admin settings-page form to a
+ * contribution. Rendering the `form`/`providers`/`table` view kinds ships in
+ * later PRs — until then every resolution ends in a translated "unavailable"
+ * state, never a blank page.
+ */
+@Component({
+  selector: 'app-plugin-view',
+  imports: [TranslateModule, LucideTriangleAlert],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './plugin-view.html',
+})
+export class PluginViewComponent {
+  private readonly route = inject(ActivatedRoute);
+  private readonly registry = inject(PluginUiRegistryService);
+
+  // Angular reuses this component across param changes on the same route
+  // config (same wildcard path, different pluginId/view) — read reactively.
+  private readonly params = toSignal(this.route.paramMap);
+
+  readonly pluginId = computed(() => this.params()?.get('pluginId') ?? '');
+  readonly view = computed(() => this.params()?.get('view') ?? '');
+
+  readonly reason = computed<UnavailableReason>(() => {
+    if (!this.registry.hasPlugin(this.pluginId())) return 'unknown_plugin';
+    if (!this.registry.configPage(this.pluginId(), this.view())) return 'unknown_view';
+    return 'unsupported_kind';
+  });
+}


### PR DESCRIPTION
PR 5.1: the frontend foundation that 5.2–5.6 sit on — the contribution registry, the `when` evaluator, the shared merge-ordered helper, the i18n merge and the wildcard plugin route. Phase 5 is explicitly parallel with the backend phases.

## The three properties worth reviewing

**The registry can never delay boot.** It joins the `provideAppInitializer` chain that gates the splash screen, so the fetch carries a 3 s timeout and fails open to an empty registry on any error, timeout or malformed payload. A Fliks with no plugins and a Fliks whose plugin endpoint is broken boot identically — both asserted.

**`when` fails closed.** The vocabulary is the plan's closed set with a leading `!` for negation, evaluated with `.every()`. An unknown predicate is **false**, and a *negated* unknown predicate is **also false**, because negating "unknown" is still unknown. That is the whole safety property: a manifest from a newer plugin naming a predicate this client does not know hides the item rather than revealing it. Both verdicts are asserted explicitly. `when` is presentation only — every action behind a contribution stays CASL-guarded server-side.

**Core always wins an i18n collision, and no plugin can redefine another's key.** ngx-translate's own `mergeDeep` lets the *second* argument win a leaf, so `setTranslation(..., shouldMerge: true)` would have let a **plugin overwrite a core label** — a defacement vector. Instead the plugin's flat `"a.b.c"` dict is expanded with ngx-translate's own `insertValue` and merged with **core passed second**, so core's leaves win recursively. Between plugins the dicts are combined ordered by plugin id with first-declared winning, so the outcome does not shift when install order does.

## Also here

- `mergeOrdered` is lifted out of `HomeSettingsService.resolve()` so the registry and the home sections share one implementation. It had **no tests**: 13 characterisation tests were written against the untouched implementation, run green, *then* the refactor was applied, then the same 13 re-run unchanged. That is the proof of behaviour preservation, not the refactor's own tests.
- The wildcard route `plugins/:pluginId/:view` resolves to a `PluginViewComponent` that renders a translated "unavailable" state for an unknown plugin, unknown view, or a view kind it cannot render yet — fail closed and never blank. The three view kinds are 5.6.
- A guard blocks navigation when a contribution's own `when` would hide the path from this user.
- The backend endpoint gains the one `i18n` field the merge reads, plus a test that the manifest dicts pass through.

## Verification

- Client suite **102 → 161 tests / 17 → 24 files**, all green. `ng build` exit 0; `tsc -p tsconfig.app.json` and `-p tsconfig.spec.json` both exit 0, read directly rather than through a pipe.
- Backend suite **1277 / 120 suites green**, `tsc` exit 0.

**Not visually verified, and cannot be on this machine** — headless Chromium hangs (#907). Everything above is proved by unit tests; no visual claim is made. 5.2's "pixel-identical" nav criterion will need the maintainer's eyes.

## Out of scope

Nav rendering from the registry (5.2), schema-driven forms (5.3), the media-detail action menu (5.4), card actions (5.5), the `providers`/`table` renderers (5.6).

**Recorded for 5.2 rather than done here:** the stronger i18n rule — core prefixing every plugin key with `plugin.<id>.` so collisions are structurally impossible, mirroring how #921 namespaces permissions — needs `labelKey` resolution to apply the same prefix, which is 5.2's code.

Refs: #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)