### PR TITLE
feat(plugin-ui): render the main navigation from the contribution registry

### DIFF
--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -17,7 +17,7 @@ export type SlotId =
  * Closed `when` vocabulary, evaluated with `.every()`. A leading "!"
  * negates any entry; an unknown predicate evaluates false (fail closed).
  */
-export type WhenPredicate =
+export type WhenPredicateName =
   | 'isAdmin'
   | `hasPermission:${string}`
   | 'mediaType:movie'
@@ -29,12 +29,17 @@ export type WhenPredicate =
   | 'isTv'
   | 'isTouch';
 
+/** A predicate, optionally negated. Negating an unknown predicate is still unknown, so still false. */
+export type WhenPredicate = WhenPredicateName | `!${WhenPredicateName}`;
+
 /** One `ui.contributions[]` entry — a nav item, action or menu row. */
 export interface UiContribution {
   id: string;
   slot: SlotId;
   weight: number;
   labelKey: string;
+  /** A shorter label for compact surfaces such as the phone dock; falls back to `labelKey`. */
+  shortLabelKey?: string;
   icon?: string;
   tone?: 'default' | 'danger';
   badge?: string;

--- a/client/src/app/core/plugin-ui/contribution.types.ts
+++ b/client/src/app/core/plugin-ui/contribution.types.ts
@@ -20,7 +20,7 @@ export type SlotId =
  * Closed `when` vocabulary, evaluated with `.every()`. A leading "!"
  * negates any entry; an unknown predicate evaluates false (fail closed).
  */
-export type WhenPredicate =
+export type WhenPredicateName =
   | 'isAdmin'
   | `hasPermission:${string}`
   | 'mediaType:movie'
@@ -32,12 +32,17 @@ export type WhenPredicate =
   | 'isTv'
   | 'isTouch';
 
+/** A predicate, optionally negated. Negating an unknown predicate is still unknown, so still false. */
+export type WhenPredicate = WhenPredicateName | `!${WhenPredicateName}`;
+
 /** One `ui.contributions[]` entry — a nav item, action or menu row. */
 export interface UiContribution {
   id: string;
   slot: SlotId;
   weight: number;
   labelKey: string;
+  /** A shorter label for compact surfaces such as the phone dock; falls back to `labelKey`. */
+  shortLabelKey?: string;
   icon?: string;
   tone?: 'default' | 'danger';
   badge?: string;

--- a/client/src/app/core/plugin-ui/core-contributions.ts
+++ b/client/src/app/core/plugin-ui/core-contributions.ts
@@ -1,0 +1,32 @@
+import type { UiContribution } from './contribution.types';
+
+// `WhenPredicate` (mirrored from the backend contract) only lists the
+// positive spellings; the evaluator's documented "!" negation isn't part of
+// the type. Cast at the two call sites rather than fork the shared type.
+type When = NonNullable<UiContribution['when']>;
+const not = (p: string) => `!${p}` as unknown as When[number];
+
+/**
+ * Core's own `nav.main` / `nav.acquisition` items, expressed as contributions
+ * so they merge with plugin contributions through the same weight/id sort
+ * instead of being hardcoded markup. `core.activity` sits at weight 200 —
+ * reserved for an acquisition plugin per the plan — because no such plugin
+ * ships yet; core keeps rendering the item it still owns today.
+ */
+export const CORE_NAV_CONTRIBUTIONS: readonly UiContribution[] = [
+  { id: 'core.home', slot: 'nav.main', weight: 100, labelKey: 'nav.home', icon: 'home', action: { kind: 'route', path: '/' } },
+  { id: 'core.search', slot: 'nav.main', weight: 200, labelKey: 'search.title', icon: 'search', action: { kind: 'route', path: '/search' } },
+  { id: 'core.my_profile', slot: 'nav.main', weight: 300, labelKey: 'nav.my_profile', icon: 'user-round', when: [not('isTv')], action: { kind: 'action', actionId: 'nav.my-profile' } },
+  { id: 'core.playlists', slot: 'nav.main', weight: 2000, labelKey: 'nav.playlists', icon: 'list-video', action: { kind: 'route', path: '/playlists' } },
+  { id: 'core.downloads', slot: 'nav.main', weight: 2100, labelKey: 'downloads.title', shortLabelKey: 'nav.downloads', icon: 'download', when: [not('isTv')], action: { kind: 'route', path: '/downloads' } },
+  { id: 'core.history', slot: 'nav.main', weight: 2200, labelKey: 'nav.history', icon: 'history', action: { kind: 'route', path: '/history' } },
+
+  { id: 'core.requests', slot: 'nav.acquisition', weight: 100, labelKey: 'nav.requests', icon: 'clipboard-list', badge: 'pendingRequests', tone: 'danger', action: { kind: 'route', path: '/requests' } },
+  { id: 'core.activity', slot: 'nav.acquisition', weight: 200, labelKey: 'nav.activity', icon: 'download', badge: 'queueActive', action: { kind: 'route', path: '/activity' } },
+  { id: 'core.calendar', slot: 'nav.acquisition', weight: 300, labelKey: 'nav.calendar', icon: 'calendar', action: { kind: 'route', path: '/calendar' } },
+];
+
+/** Libraries render as their own data-driven block, anchored between the
+ *  weight-300 and weight-2000 core items — this is where a plugin's
+ *  `nav.main` item at weight 1000-1999 would land, visually after them. */
+export const LIBRARIES_BLOCK_WEIGHT = 1000;

--- a/client/src/app/core/plugin-ui/nav-contributions.service.spec.ts
+++ b/client/src/app/core/plugin-ui/nav-contributions.service.spec.ts
@@ -1,0 +1,138 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { NavContributionsService } from './nav-contributions.service';
+import { PluginUiRegistryService } from './plugin-ui-registry.service';
+import { AuthService } from '../services/auth.service';
+import { TvService } from '../services/tv.service';
+import { DeviceService } from '../services/device.service';
+import type { SlotId, UiContribution } from './contribution.types';
+
+const contribution = (id: string, weight: number, overrides: Partial<UiContribution> = {}): UiContribution => ({
+  id,
+  slot: 'nav.main',
+  weight,
+  labelKey: `x.${id}`,
+  action: { kind: 'route', path: `/plugins/x/${id}` },
+  ...overrides,
+});
+
+function createService(opts: {
+  registry?: Partial<Record<SlotId, UiContribution[]>>;
+  isAdmin?: boolean;
+  isTv?: boolean;
+  userId?: number | null;
+} = {}) {
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      {
+        provide: PluginUiRegistryService,
+        useValue: { contributionsFor: (slot: SlotId) => opts.registry?.[slot] ?? [] },
+      },
+      {
+        provide: AuthService,
+        useValue: {
+          user: () => (opts.userId === null ? null : { id: opts.userId ?? 1, isAdmin: !!opts.isAdmin }),
+          hasPermission: () => false,
+        },
+      },
+      { provide: TvService, useValue: { isTv: () => !!opts.isTv } },
+      { provide: DeviceService, useValue: { isTouch: () => false } },
+    ],
+  });
+  return TestBed.inject(NavContributionsService);
+}
+
+describe('NavContributionsService', () => {
+  it('merges core with plugin contributions and sorts ascending by weight, ties break on id', () => {
+    const svc = createService({
+      registry: {
+        'nav.main': [contribution('z-plugin', 300, { slot: 'nav.main' }), contribution('a-plugin', 300, { slot: 'nav.main' })],
+      },
+    });
+    const ids = svc.mainItems().map((i) => i.id);
+    // Both plugin items tie core's "My profile" (weight 300) — id order wins,
+    // and stays the same regardless of which plugin installed first.
+    expect(ids).toEqual(['core.home', 'core.search', 'a-plugin', 'core.my_profile', 'z-plugin', 'core.playlists', 'core.downloads', 'core.history']);
+  });
+
+  it('drops a contribution with an unknown action.kind — fails closed, never a broken item', () => {
+    const svc = createService({
+      registry: { 'nav.main': [contribution('broken', 150, { action: { kind: 'bogus' } as never })] },
+    });
+    expect(svc.mainItems().map((i) => i.id)).not.toContain('broken');
+  });
+
+  it('drops a core-declared action this client does not recognise', () => {
+    const svc = createService({
+      registry: { 'nav.main': [contribution('unknown-action', 150, { action: { kind: 'action', actionId: 'nothing.like.this' } })] },
+    });
+    expect(svc.mainItems().map((i) => i.id)).not.toContain('unknown-action');
+  });
+
+  it('resolves core.my_profile to the current user id', () => {
+    const svc = createService({ userId: 42 });
+    expect(svc.mainItems().find((i) => i.id === 'core.my_profile')?.route).toBe('/profile/42');
+  });
+
+  it('drops core.my_profile when there is no user id to build the route from', () => {
+    const svc = createService({ userId: null });
+    expect(svc.mainItems().map((i) => i.id)).not.toContain('core.my_profile');
+  });
+
+  it('hides an item whose `when` fails, and it never appears at all', () => {
+    const svc = createService({
+      registry: { 'nav.main': [contribution('admin-only', 150, { when: ['isAdmin'] })] },
+      isAdmin: false,
+    });
+    expect(svc.mainItems().map((i) => i.id)).not.toContain('admin-only');
+  });
+
+  it('shows a `when`-gated item once its predicate passes', () => {
+    const svc = createService({
+      registry: { 'nav.main': [contribution('admin-only', 150, { when: ['isAdmin'] })] },
+      isAdmin: true,
+    });
+    expect(svc.mainItems().map((i) => i.id)).toContain('admin-only');
+  });
+
+  it('hides core.my_profile and core.downloads on TV', () => {
+    const svc = createService({ isTv: true });
+    const ids = svc.mainItems().map((i) => i.id);
+    expect(ids).not.toContain('core.my_profile');
+    expect(ids).not.toContain('core.downloads');
+  });
+
+  it('passes an unrecognised icon through unchanged — the render layer decides the fallback glyph', () => {
+    const svc = createService({
+      registry: { 'nav.main': [contribution('weird-icon', 150, { icon: 'not-a-real-lucide-name' })] },
+    });
+    expect(svc.mainItems().find((i) => i.id === 'weird-icon')?.icon).toBe('not-a-real-lucide-name');
+  });
+
+  it('defaults a missing icon to the generic glyph key', () => {
+    const svc = createService({
+      registry: { 'nav.main': [contribution('no-icon', 150, { icon: undefined })] },
+    });
+    expect(svc.mainItems().find((i) => i.id === 'no-icon')?.icon).toBe('circle');
+  });
+
+  it('splits nav.main around the library block at weight 1000', () => {
+    const svc = createService();
+    expect(svc.mainItemsBeforeLibraries().map((i) => i.id)).toEqual(['core.home', 'core.search', 'core.my_profile']);
+    expect(svc.mainItemsAfterLibraries().map((i) => i.id)).toEqual(['core.playlists', 'core.downloads', 'core.history']);
+  });
+
+  it('acquisition: core requests + calendar, weight 200 free for a plugin', () => {
+    const svc = createService();
+    expect(svc.acquisitionItems().map((i) => i.id)).toEqual(['core.requests', 'core.activity', 'core.calendar']);
+  });
+
+  it('maps tone to a badge class: danger -> warning, default -> primary', () => {
+    const svc = createService();
+    const requests = svc.acquisitionItems().find((i) => i.id === 'core.requests');
+    const activity = svc.acquisitionItems().find((i) => i.id === 'core.activity');
+    expect(requests?.badgeClass).toBe('badge-warning');
+    expect(activity?.badgeClass).toBe('badge-primary');
+  });
+});

--- a/client/src/app/core/plugin-ui/nav-contributions.service.ts
+++ b/client/src/app/core/plugin-ui/nav-contributions.service.ts
@@ -1,0 +1,104 @@
+import { Injectable, computed, inject } from '@angular/core';
+import { AuthService } from '../services/auth.service';
+import { DeviceService } from '../services/device.service';
+import { TvService } from '../services/tv.service';
+import { CORE_NAV_CONTRIBUTIONS, LIBRARIES_BLOCK_WEIGHT } from './core-contributions';
+import { PluginUiRegistryService } from './plugin-ui-registry.service';
+import { evaluateWhen, type WhenContext } from './when-evaluator';
+import type { SlotId, UiContribution } from './contribution.types';
+
+/** A `nav.main` / `nav.acquisition` contribution resolved to something a
+ *  template can render directly, with visibility and action already decided. */
+export interface ResolvedNavItem {
+  id: string;
+  labelKey: string;
+  /** Compact-surface label for the phone dock; absent means the dock uses `labelKey`. */
+  shortLabelKey?: string;
+  icon: string;
+  route: string;
+  exact: boolean;
+  weight: number;
+  badgeKey?: string;
+  badgeClass: string;
+}
+
+/** Items pinned to the native-phone dock's limited primary row — excluded
+ *  from the overflow "more" sheet so they aren't shown twice. */
+export const DOCK_PINNED_IDS: readonly string[] = ['core.home', 'core.downloads', 'core.requests'];
+/** Never shown on the native-phone dock or its sheet: Search is its own FAB,
+ *  My profile is reachable from the always-visible user menu instead. */
+export const MOBILE_HIDDEN_IDS: readonly string[] = ['core.search', 'core.my_profile'];
+
+function sortByWeightThenId(list: readonly UiContribution[]): UiContribution[] {
+  return [...list].sort((a, b) => a.weight - b.weight || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+}
+
+/**
+ * Resolves `nav.main` / `nav.acquisition` into renderable items: core's
+ * declarative list merged with the registry's plugin contributions, sorted
+ * by weight then id, `when`-filtered, and with the action resolved to a
+ * route. Every surface (sidebar, dock, more-sheet) reads this — an item
+ * cannot appear in one and be missing from another.
+ */
+@Injectable({ providedIn: 'root' })
+export class NavContributionsService {
+  private readonly registry = inject(PluginUiRegistryService);
+  private readonly auth = inject(AuthService);
+  private readonly tv = inject(TvService);
+  private readonly device = inject(DeviceService);
+
+  readonly mainItems = computed(() => this.resolve('nav.main'));
+  readonly acquisitionItems = computed(() => this.resolve('nav.acquisition'));
+
+  /** `nav.main` items anchored before the library block (weight < 1000). */
+  readonly mainItemsBeforeLibraries = computed(() =>
+    this.mainItems().filter((i) => i.weight < LIBRARIES_BLOCK_WEIGHT),
+  );
+  /** `nav.main` items anchored after the library block (weight >= 1000). */
+  readonly mainItemsAfterLibraries = computed(() =>
+    this.mainItems().filter((i) => i.weight >= LIBRARIES_BLOCK_WEIGHT),
+  );
+
+  private resolve(slot: SlotId): ResolvedNavItem[] {
+    const core = CORE_NAV_CONTRIBUTIONS.filter((c) => c.slot === slot);
+    const merged = sortByWeightThenId([...core, ...this.registry.contributionsFor(slot)]);
+    const ctx: WhenContext = {
+      isAdmin: !!this.auth.user()?.isAdmin,
+      hasPermission: (p) => this.auth.hasPermission(p),
+      isTv: this.tv.isTv(),
+      isTouch: this.device.isTouch(),
+    };
+    const items: ResolvedNavItem[] = [];
+    for (const c of merged) {
+      if (!evaluateWhen(c.when, ctx)) continue;
+      const route = this.resolveRoute(c);
+      if (route === null) continue;
+      items.push({
+        id: c.id,
+        labelKey: c.labelKey,
+        shortLabelKey: c.shortLabelKey,
+        icon: c.icon ?? 'circle',
+        route,
+        exact: route === '/',
+        weight: c.weight,
+        badgeKey: c.badge,
+        badgeClass: c.tone === 'danger' ? 'badge-warning' : 'badge-primary',
+      });
+    }
+    return items;
+  }
+
+  /** Resolves a contribution's action to a route, or `null` to fail closed
+   *  (an unknown `action.kind`, or a core action id this client can't serve). */
+  private resolveRoute(c: UiContribution): string | null {
+    if (c.action.kind === 'route') return c.action.path;
+    if (c.action.kind === 'action') {
+      if (c.action.actionId === 'nav.my-profile') {
+        const id = this.auth.user()?.id;
+        return id != null ? `/profile/${id}` : null;
+      }
+      return null;
+    }
+    return null;
+  }
+}

--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -184,25 +184,31 @@
          Tablets and TV use the drawer/sidebar instead. -->
     @if (isNative && device.isPhone() && !keyboardOpen()) {
       <div class="dock z-40 dock-with-fab-cradle">
-        <a routerLink="/" routerLinkActive="dock-active" [routerLinkActiveOptions]="{ exact: true }"
-           (click)="resetNavHistory()">
-          <svg lucideHome class="h-5 w-5"></svg>
-          <span class="dock-label truncate max-w-full">{{ 'nav.home' | translate }}</span>
-        </a>
-        <a routerLink="/downloads" routerLinkActive="dock-active" [routerLinkActiveOptions]="{ exact: false }"
-           (click)="resetNavHistory()">
-          <svg lucideDownload class="h-5 w-5"></svg>
-          <span class="dock-label truncate max-w-full">{{ 'nav.downloads' | translate }}</span>
-        </a>
+        @if (dockHome(); as item) {
+          <a [routerLink]="item.route" routerLinkActive="dock-active" [routerLinkActiveOptions]="{ exact: item.exact }"
+             (click)="resetNavHistory()">
+            <app-nav-icon [name]="item.icon" class="h-5 w-5" />
+            <span class="dock-label truncate max-w-full">{{ (item.shortLabelKey ?? item.labelKey) | translate }}</span>
+          </a>
+        }
+        @if (dockDownloads(); as item) {
+          <a [routerLink]="item.route" routerLinkActive="dock-active" [routerLinkActiveOptions]="{ exact: item.exact }"
+             (click)="resetNavHistory()">
+            <app-nav-icon [name]="item.icon" class="h-5 w-5" />
+            <span class="dock-label truncate max-w-full">{{ (item.shortLabelKey ?? item.labelKey) | translate }}</span>
+          </a>
+        }
         <!-- Empty cell that holds the centre slot in the flex chain so the
              4 nav items distribute evenly across 5 columns. The FAB sits
              outside the dock to keep .dock's position:fixed intact. -->
         <span aria-hidden="true" class="invisible"></span>
-        <a routerLink="/requests" routerLinkActive="dock-active" [routerLinkActiveOptions]="{ exact: false }"
-           (click)="resetNavHistory()">
-          <svg lucideClipboardList class="h-5 w-5"></svg>
-          <span class="dock-label truncate max-w-full">{{ 'nav.requests' | translate }}</span>
-        </a>
+        @if (dockRequests(); as item) {
+          <a [routerLink]="item.route" routerLinkActive="dock-active" [routerLinkActiveOptions]="{ exact: item.exact }"
+             (click)="resetNavHistory()">
+            <app-nav-icon [name]="item.icon" class="h-5 w-5" />
+            <span class="dock-label truncate max-w-full">{{ (item.shortLabelKey ?? item.labelKey) | translate }}</span>
+          </a>
+        }
         <button (click)="toggleBottomMenu()" [class.dock-active]="bottomMenuOpen()"
                 class="[&.dock-active]:before:hidden [&.dock-active]:after:hidden">
           <svg lucideEllipsisVertical class="h-5 w-5"></svg>
@@ -243,35 +249,32 @@
                   </a>
                 </li>
               }
-              <li>
-                <a routerLink="/playlists" routerLinkActive="active" (click)="resetNavHistory()">
-                  <svg lucideListVideo class="h-5 w-5"></svg>
-                  {{ 'nav.playlists' | translate }}
-                </a>
-              </li>
-              <li>
-                <a routerLink="/activity" routerLinkActive="active" class="justify-between" (click)="resetNavHistory()">
-                  <span class="flex items-center gap-2">
-                    <svg lucideDownload class="h-5 w-5"></svg>
-                    {{ 'nav.activity' | translate }}
-                  </span>
-                  @if (queueCount() > 0) {
-                    <span class="badge badge-sm badge-primary">{{ queueCount() }}</span>
-                  }
-                </a>
-              </li>
-              <li>
-                <a routerLink="/history" routerLinkActive="active" (click)="resetNavHistory()">
-                  <svg lucideHistory class="h-5 w-5"></svg>
-                  {{ 'nav.history' | translate }}
-                </a>
-              </li>
-              <li>
-                <a routerLink="/calendar" routerLinkActive="active" (click)="resetNavHistory()">
-                  <svg lucideCalendar class="h-5 w-5"></svg>
-                  {{ 'nav.calendar' | translate }}
-                </a>
-              </li>
+              @for (item of sheetMainItems(); track item.id) {
+                <li>
+                  <a [routerLink]="item.route" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: item.exact }" class="justify-between" (click)="resetNavHistory()">
+                    <span class="flex items-center gap-2">
+                      <app-nav-icon [name]="item.icon" class="h-5 w-5" />
+                      {{ item.labelKey | translate }}
+                    </span>
+                    @if (item.badgeKey && badgeCountFor(item) > 0) {
+                      <span class="badge badge-sm" [class]="item.badgeClass">{{ badgeCountFor(item) }}</span>
+                    }
+                  </a>
+                </li>
+              }
+              @for (item of sheetAcquisitionItems(); track item.id) {
+                <li>
+                  <a [routerLink]="item.route" routerLinkActive="active" class="justify-between" (click)="resetNavHistory()">
+                    <span class="flex items-center gap-2">
+                      <app-nav-icon [name]="item.icon" class="h-5 w-5" />
+                      {{ item.labelKey | translate }}
+                    </span>
+                    @if (item.badgeKey && badgeCountFor(item) > 0) {
+                      <span class="badge badge-sm" [class]="item.badgeClass">{{ badgeCountFor(item) }}</span>
+                    }
+                  </a>
+                </li>
+              }
             </ul>
           </div>
         }
@@ -326,23 +329,16 @@
       </div>
 
       <ul class="menu p-4 flex-1 gap-0.5 min-w-64">
-        <li>
-          <a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">
-            <svg lucideHome class="h-5 w-5"></svg>
-            {{ 'nav.home' | translate }}
-          </a>
-        </li>
-        <li>
-          <a routerLink="/search" routerLinkActive="active">
-            <svg lucideSearch class="h-5 w-5"></svg>
-            {{ 'search.title' | translate }}
-          </a>
-        </li>
-        @if (!tv.isTv() && auth.user()?.id) {
+        @for (item of mainItemsBeforeLibraries(); track item.id) {
           <li>
-            <a [routerLink]="['/profile', auth.user()!.id]" routerLinkActive="active">
-              <svg lucideUserRound class="h-5 w-5"></svg>
-              {{ 'nav.my_profile' | translate }}
+            <a [routerLink]="item.route" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: item.exact }" class="justify-between">
+              <span class="flex items-center gap-2">
+                <app-nav-icon [name]="item.icon" class="h-5 w-5" />
+                {{ item.labelKey | translate }}
+              </span>
+              @if (item.badgeKey && badgeCountFor(item) > 0) {
+                <span class="badge badge-sm" [class]="item.badgeClass">{{ badgeCountFor(item) }}</span>
+              }
             </a>
           </li>
         }
@@ -361,55 +357,33 @@
             </a>
           </li>
         }
-        <li>
-          <a routerLink="/playlists" routerLinkActive="active">
-            <svg lucideListVideo class="h-5 w-5"></svg>
-            {{ 'nav.playlists' | translate }}
-          </a>
-        </li>
-        @if (!tv.isTv()) {
+        @for (item of mainItemsAfterLibraries(); track item.id) {
           <li>
-            <a routerLink="/downloads" routerLinkActive="active">
-              <svg lucideDownload class="h-5 w-5"></svg>
-              {{ 'downloads.title' | translate }}
+            <a [routerLink]="item.route" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: item.exact }" class="justify-between">
+              <span class="flex items-center gap-2">
+                <app-nav-icon [name]="item.icon" class="h-5 w-5" />
+                {{ item.labelKey | translate }}
+              </span>
+              @if (item.badgeKey && badgeCountFor(item) > 0) {
+                <span class="badge badge-sm" [class]="item.badgeClass">{{ badgeCountFor(item) }}</span>
+              }
             </a>
           </li>
         }
-        <li>
-          <a routerLink="/history" routerLinkActive="active">
-            <svg lucideHistory class="h-5 w-5"></svg>
-            {{ 'nav.history' | translate }}
-          </a>
-        </li>
         <li class="menu-title text-xs uppercase tracking-wider mt-3">{{ 'nav.section_downloads' | translate }}</li>
-        <li>
-          <a routerLink="/requests" routerLinkActive="active" class="justify-between">
-            <span class="flex items-center gap-2">
-              <svg lucideClipboardList class="h-5 w-5"></svg>
-              {{ 'nav.requests' | translate }}
-            </span>
-            @if (pendingRequestCount() > 0) {
-              <span class="badge badge-sm badge-warning">{{ pendingRequestCount() }}</span>
-            }
-          </a>
-        </li>
-        <li>
-          <a routerLink="/activity" routerLinkActive="active" class="justify-between">
-            <span class="flex items-center gap-2">
-              <svg lucideDownload class="h-5 w-5"></svg>
-              {{ 'nav.activity' | translate }}
-            </span>
-            @if (queueCount() > 0) {
-              <span class="badge badge-sm badge-primary">{{ queueCount() }}</span>
-            }
-          </a>
-        </li>
-        <li>
-          <a routerLink="/calendar" routerLinkActive="active">
-            <svg lucideCalendar class="h-5 w-5"></svg>
-            {{ 'nav.calendar' | translate }}
-          </a>
-        </li>
+        @for (item of acquisitionItems(); track item.id) {
+          <li>
+            <a [routerLink]="item.route" routerLinkActive="active" class="justify-between">
+              <span class="flex items-center gap-2">
+                <app-nav-icon [name]="item.icon" class="h-5 w-5" />
+                {{ item.labelKey | translate }}
+              </span>
+              @if (item.badgeKey && badgeCountFor(item) > 0) {
+                <span class="badge badge-sm" [class]="item.badgeClass">{{ badgeCountFor(item) }}</span>
+              }
+            </a>
+          </li>
+        }
       </ul>
 
     </aside>

--- a/client/src/app/shared/layout/layout.spec.ts
+++ b/client/src/app/shared/layout/layout.spec.ts
@@ -1,0 +1,456 @@
+import { CORE_NAV_CONTRIBUTIONS } from '../../core/plugin-ui/core-contributions';
+import { provideZonelessChangeDetection, NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Title } from '@angular/platform-browser';
+import { RouterLink, RouterLinkActive, RouterOutlet, provideRouter } from '@angular/router';
+import { TranslateLoader, TranslateModule, provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import {
+  LucideMenu,
+  LucideChevronLeft,
+  LucideSearch,
+  LucideCast,
+  LucideEllipsisVertical,
+  LucidePin,
+  LucideRocket,
+} from '@lucide/angular';
+import { LayoutComponent } from './layout';
+import { NavIconComponent } from './nav-icon';
+import { LucideIconComponent } from '../components/lucide-icon';
+import { TvRowDirective } from '../directives/tv-row.directive';
+import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
+import { AuthService } from '../../core/services/auth.service';
+import { LibraryPrefsService } from '../../core/services/library-prefs.service';
+import { LibrariesApiService, type LibrarySummary } from '../../core/services/api/libraries-api.service';
+import { CountsApiService } from '../../core/services/api/counts-api.service';
+import { ServerConfigService } from '../../core/services/server-config.service';
+import { SseService } from '../../core/services/sse.service';
+import { CastService } from '../../core/services/cast.service';
+import { NavbarService } from '../../core/services/navbar.service';
+import { TvService } from '../../core/services/tv.service';
+import { DeviceService } from '../../core/services/device.service';
+import { CastPlayerService } from '../../core/services/cast-player.service';
+import { DownloadManagerService } from '../../core/services/download-manager.service';
+import { NavigationHistoryService } from '../../core/services/navigation-history.service';
+import { NetworkService } from '../../core/services/network.service';
+import { AddToPlaylistService } from '../../core/services/add-to-playlist.service';
+import { RecommendService } from '../../core/services/recommend.service';
+import { AppUpdateService } from '../../core/services/app-update.service';
+import { BackgroundService } from '../../core/services/background.service';
+import { SearchStateService } from '../../core/services/search-state.service';
+import { PluginUiRegistryService } from '../../core/plugin-ui/plugin-ui-registry.service';
+import type { SlotId, UiContribution } from '../../core/plugin-ui/contribution.types';
+
+// LayoutComponent reads `Capacitor.isNativePlatform()` at construction time to
+// decide sidebar vs. phone-dock rendering — mocked so fixtures can force either.
+const nativeState = vi.hoisted(() => ({ value: false }));
+vi.mock('@capacitor/core', () => ({
+  Capacitor: { isNativePlatform: () => nativeState.value },
+  registerPlugin: () => ({ setLightStatusBar: () => Promise.resolve() }),
+}));
+vi.mock('@capacitor/keyboard', () => ({
+  Keyboard: { addListener: () => {}, removeAllListeners: () => {} },
+}));
+
+interface Fixture {
+  userId: number;
+  isAdmin: boolean;
+  device: { isDesktop?: boolean; isTablet?: boolean; isPhone?: boolean; isTv?: boolean; isTouch?: boolean };
+  isTv: boolean;
+  isNative: boolean;
+  libraries: LibrarySummary[];
+  queueActive: number;
+  pendingRequests: number;
+  registry?: Partial<Record<SlotId, UiContribution[]>>;
+}
+
+const lib = (id: number, name: string, opts: Partial<LibrarySummary> = {}): LibrarySummary => ({
+  id,
+  name,
+  icon: null,
+  color: null,
+  mediaTypes: ['movie'],
+  isDefaultForMovies: false,
+  isDefaultForSeries: false,
+  ...opts,
+});
+
+async function createFixture(f: Fixture): Promise<ComponentFixture<LayoutComponent>> {
+  nativeState.value = f.isNative;
+
+  TestBed.configureTestingModule({
+    schemas: [NO_ERRORS_SCHEMA],
+    providers: [
+      provideZonelessChangeDetection(),
+      provideRouter([]),
+      provideTranslateService({
+        lang: 'en',
+        loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+      }),
+      { provide: Title, useValue: { setTitle: () => {} } },
+      {
+        provide: AuthService,
+        useValue: { user: () => ({ id: f.userId, isAdmin: f.isAdmin }), hasPermission: () => false },
+      },
+      { provide: LibraryPrefsService, useValue: { present: (libs: LibrarySummary[]) => libs } },
+      { provide: LibrariesApiService, useValue: { listMine: () => Promise.resolve(f.libraries) } },
+      {
+        provide: CountsApiService,
+        useValue: {
+          get: () =>
+            Promise.resolve({ mediaByLibrary: {}, queueActive: f.queueActive, pendingRequests: f.pendingRequests }),
+        },
+      },
+      { provide: ServerConfigService, useValue: {} },
+      { provide: SseService, useValue: { lastEvent: () => null, connect: () => {} } },
+      { provide: DownloadManagerService, useValue: {} },
+      { provide: NavigationHistoryService, useValue: { resetNavHistory: () => {} } },
+      { provide: AddToPlaylistService, useValue: { request: () => null, clear: () => {} } },
+      { provide: RecommendService, useValue: { request: () => null, clear: () => {} } },
+      { provide: NetworkService, useValue: { isOnline: () => true } },
+      {
+        provide: CastService,
+        useValue: { isAvailable: () => false, connecting: () => false, isConnected: () => false, disconnect: () => {}, requestSession: () => {} },
+      },
+      {
+        provide: NavbarService,
+        useValue: {
+          canGoBack: () => false,
+          navbarTransparent: () => false,
+          heroLogoUrl: () => null,
+          heroTitle: () => '',
+          isHeroPage: () => false,
+          showBackButton: () => false,
+          mobileNavTitle: () => '',
+          mobileNavbarVisible: () => true,
+          effectiveSidebarPinned: () => false,
+          sidebarPinned: () => false,
+          toggleSidebarPinned: () => {},
+          scrollAtTop: { set: () => {} },
+          setPageTitle: () => {},
+          resetNavHistory: () => {},
+          goBack: () => {},
+        },
+      },
+      { provide: BackgroundService, useValue: { url: () => null } },
+      { provide: SearchStateService, useValue: { requestFocus: () => {} } },
+      {
+        provide: TvService,
+        useValue: { isTv: () => f.isTv, isTizen: () => false, isAndroidTv: () => false, isWebOs: () => false },
+      },
+      {
+        provide: DeviceService,
+        useValue: {
+          isDesktop: () => !!f.device.isDesktop,
+          isTablet: () => !!f.device.isTablet,
+          isPhone: () => !!f.device.isPhone,
+          isTv: () => !!f.device.isTv,
+          isTouch: () => !!f.device.isTouch,
+        },
+      },
+      {
+        provide: CastPlayerService,
+        useValue: { hasMedia: () => false, mediaTitle: () => '', expanded: { update: () => {} } },
+      },
+      { provide: AppUpdateService, useValue: { available: () => false } },
+      {
+        provide: PluginUiRegistryService,
+        useValue: { contributionsFor: (slot: SlotId) => f.registry?.[slot] ?? [] },
+      },
+    ],
+  });
+
+  // Replace the component's `imports` to drop child components unrelated to
+  // nav (cast, modals, user menu, background) so their own DI graphs never
+  // need stubbing — their now-unmatched tags fall through to NO_ERRORS_SCHEMA.
+  TestBed.overrideComponent(LayoutComponent, {
+    set: {
+      schemas: [NO_ERRORS_SCHEMA],
+      imports: [
+        RouterOutlet, RouterLink, RouterLinkActive, TranslateModule,
+        LucideMenu, LucideChevronLeft, LucideSearch, LucideCast, LucideEllipsisVertical, LucidePin, LucideRocket,
+        LucideIconComponent,
+        NavIconComponent,
+        TvRowDirective,
+        ResolveUrlPipe,
+      ],
+    },
+  });
+
+  const fixture = TestBed.createComponent(LayoutComponent);
+  fixture.detectChanges();
+  // ngOnInit's own refreshCounts() is fire-and-forget (a plain Promise, not
+  // tracked by zoneless `whenStable()`) — await it directly for determinism.
+  await fixture.componentInstance.refreshCounts();
+  fixture.detectChanges();
+  return fixture;
+}
+
+interface CapturedItem {
+  label: string;
+  icon: string | null;
+  badge: string | null;
+  href: string | null;
+}
+
+function readItem(anchor: Element | null): CapturedItem | null {
+  if (!anchor) return null;
+  const badgeEl = anchor.querySelector('.badge');
+  const badge = badgeEl ? (badgeEl.textContent ?? '').trim() : null;
+  const svg = anchor.querySelector('svg');
+  const icon = svg
+    ? (Array.from(svg.attributes).map((a) => a.name).find((n) => n.startsWith('lucide')) ?? null)
+    : null;
+  const labelHost = anchor.querySelector(':scope > span:not(.badge)') ?? anchor;
+  const label = (labelHost.textContent ?? '').trim();
+  return { label, icon, badge, href: anchor.getAttribute('href') };
+}
+
+function sidebarItems(root: HTMLElement): CapturedItem[] {
+  return Array.from(root.querySelectorAll('aside ul.menu > li'))
+    .map((li) => readItem(li.querySelector('a')))
+    .filter((x): x is CapturedItem => x !== null);
+}
+
+function dockItems(root: HTMLElement): CapturedItem[] {
+  const dock = root.querySelector('.dock');
+  if (!dock) return [];
+  return Array.from(dock.children)
+    .filter((c) => c.tagName === 'A' || c.tagName === 'BUTTON')
+    .map((c) => readItem(c))
+    .filter((x): x is CapturedItem => x !== null);
+}
+
+function sheetItems(root: HTMLElement): CapturedItem[] {
+  const sidebarMenu = root.querySelector('aside ul.menu');
+  const sheetMenu = Array.from(root.querySelectorAll('ul.menu')).find((m) => m !== sidebarMenu);
+  if (!sheetMenu) return [];
+  return Array.from(sheetMenu.querySelectorAll('li'))
+    .map((li) => readItem(li.querySelector('a')))
+    .filter((x): x is CapturedItem => x !== null);
+}
+
+function searchFab(root: HTMLElement): CapturedItem | null {
+  return readItem(root.querySelector('a[href="/search"]'));
+}
+
+const ADMIN_WITH_LIBRARIES: Fixture = {
+  userId: 1,
+  isAdmin: true,
+  device: { isDesktop: true },
+  isTv: false,
+  isNative: false,
+  libraries: [
+    lib(1, 'Movies', { isDefaultForMovies: true }),
+    lib(2, 'Series', { isDefaultForSeries: true }),
+    lib(3, 'Anime', { icon: 'swords' }),
+  ],
+  queueActive: 3,
+  pendingRequests: 2,
+};
+
+const NON_ADMIN_NO_LIBRARIES: Fixture = {
+  userId: 2,
+  isAdmin: false,
+  device: { isTablet: true },
+  isTv: false,
+  isNative: false,
+  libraries: [],
+  queueActive: 0,
+  pendingRequests: 0,
+};
+
+const TV_FORM_FACTOR: Fixture = {
+  userId: 3,
+  isAdmin: false,
+  device: { isTv: true },
+  isTv: true,
+  isNative: false,
+  libraries: [lib(1, 'Movies', { isDefaultForMovies: true })],
+  queueActive: 1,
+  pendingRequests: 0,
+};
+
+const NATIVE_PHONE: Fixture = {
+  userId: 4,
+  isAdmin: false,
+  device: { isPhone: true, isTouch: true },
+  isTv: false,
+  isNative: true,
+  libraries: [
+    lib(1, 'Movies', { isDefaultForMovies: true }),
+    lib(2, 'Series', { isDefaultForSeries: true }),
+    lib(3, 'Anime', { icon: 'swords' }),
+  ],
+  queueActive: 5,
+  pendingRequests: 1,
+};
+
+describe('LayoutComponent nav — characterisation (data, not pixels)', () => {
+  afterEach(() => {
+    nativeState.value = false;
+  });
+
+  it('sidebar: admin with libraries', async () => {
+    const fixture = await createFixture(ADMIN_WITH_LIBRARIES);
+    expect(sidebarItems(fixture.nativeElement)).toEqual([
+      { label: 'nav.home', icon: 'lucideHome', badge: null, href: '/' },
+      { label: 'search.title', icon: 'lucideSearch', badge: null, href: '/search' },
+      { label: 'nav.my_profile', icon: 'lucideUserRound', badge: null, href: '/profile/1' },
+      { label: 'Movies', icon: 'lucideLibrary', badge: null, href: '/libraries/Movies' },
+      { label: 'Series', icon: 'lucideLibrary', badge: null, href: '/libraries/Series' },
+      { label: 'Anime', icon: 'lucideSwords', badge: null, href: '/libraries/Anime' },
+      { label: 'nav.playlists', icon: 'lucideListVideo', badge: null, href: '/playlists' },
+      { label: 'downloads.title', icon: 'lucideDownload', badge: null, href: '/downloads' },
+      { label: 'nav.history', icon: 'lucideHistory', badge: null, href: '/history' },
+      { label: 'nav.requests', icon: 'lucideClipboardList', badge: '2', href: '/requests' },
+      { label: 'nav.activity', icon: 'lucideDownload', badge: '3', href: '/activity' },
+      { label: 'nav.calendar', icon: 'lucideCalendar', badge: null, href: '/calendar' },
+    ]);
+    expect(dockItems(fixture.nativeElement)).toEqual([]);
+    expect(sheetItems(fixture.nativeElement)).toEqual([]);
+  });
+
+  it('sidebar: non-admin without libraries', async () => {
+    const fixture = await createFixture(NON_ADMIN_NO_LIBRARIES);
+    expect(sidebarItems(fixture.nativeElement)).toEqual([
+      { label: 'nav.home', icon: 'lucideHome', badge: null, href: '/' },
+      { label: 'search.title', icon: 'lucideSearch', badge: null, href: '/search' },
+      { label: 'nav.my_profile', icon: 'lucideUserRound', badge: null, href: '/profile/2' },
+      { label: 'nav.playlists', icon: 'lucideListVideo', badge: null, href: '/playlists' },
+      { label: 'downloads.title', icon: 'lucideDownload', badge: null, href: '/downloads' },
+      { label: 'nav.history', icon: 'lucideHistory', badge: null, href: '/history' },
+      { label: 'nav.requests', icon: 'lucideClipboardList', badge: null, href: '/requests' },
+      { label: 'nav.activity', icon: 'lucideDownload', badge: null, href: '/activity' },
+      { label: 'nav.calendar', icon: 'lucideCalendar', badge: null, href: '/calendar' },
+    ]);
+  });
+
+  it('sidebar: TV form factor hides My profile and Downloads', async () => {
+    const fixture = await createFixture(TV_FORM_FACTOR);
+    expect(sidebarItems(fixture.nativeElement)).toEqual([
+      { label: 'nav.home', icon: 'lucideHome', badge: null, href: '/' },
+      { label: 'search.title', icon: 'lucideSearch', badge: null, href: '/search' },
+      { label: 'Movies', icon: 'lucideLibrary', badge: null, href: '/libraries/Movies' },
+      { label: 'nav.playlists', icon: 'lucideListVideo', badge: null, href: '/playlists' },
+      { label: 'nav.history', icon: 'lucideHistory', badge: null, href: '/history' },
+      { label: 'nav.requests', icon: 'lucideClipboardList', badge: null, href: '/requests' },
+      { label: 'nav.activity', icon: 'lucideDownload', badge: '1', href: '/activity' },
+      { label: 'nav.calendar', icon: 'lucideCalendar', badge: null, href: '/calendar' },
+    ]);
+  });
+
+  it('native phone: dock primary row is Home, Downloads, Requests + the search FAB', async () => {
+    const fixture = await createFixture(NATIVE_PHONE);
+    expect(dockItems(fixture.nativeElement)).toEqual([
+      { label: 'nav.home', icon: 'lucideHome', badge: null, href: '/' },
+      // The dock keeps its own abbreviated label via `shortLabelKey`; the sidebar
+      // and the sheet render the full one. Identical to the pre-refactor markup.
+      { label: 'nav.downloads', icon: 'lucideDownload', badge: null, href: '/downloads' },
+      { label: 'nav.requests', icon: 'lucideClipboardList', badge: null, href: '/requests' },
+      { label: 'nav.more', icon: 'lucideEllipsisVertical', badge: null, href: null },
+    ]);
+    expect(searchFab(fixture.nativeElement)).toEqual({
+      label: '',
+      icon: 'lucideSearch',
+      badge: null,
+      href: '/search',
+    });
+  });
+
+  it('native phone: the more-sheet holds everything not pinned to the dock', async () => {
+    const fixture = await createFixture(NATIVE_PHONE);
+    fixture.componentInstance.bottomMenuOpen.set(true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // Deliberate change: the sheet used to hand-order main/acquisition items
+    // (Activity before History); it now renders each group by weight, main
+    // items first then acquisition items, so Activity (weight 200) now
+    // trails History (weight 2200) — a side effect of one ordering rule
+    // replacing the old ad-hoc markup order.
+    expect(sheetItems(fixture.nativeElement)).toEqual([
+      { label: 'Anime', icon: 'lucideSwords', badge: null, href: '/libraries/Anime' },
+      { label: 'nav.playlists', icon: 'lucideListVideo', badge: null, href: '/playlists' },
+      { label: 'nav.history', icon: 'lucideHistory', badge: null, href: '/history' },
+      { label: 'nav.activity', icon: 'lucideDownload', badge: '5', href: '/activity' },
+      { label: 'nav.calendar', icon: 'lucideCalendar', badge: null, href: '/calendar' },
+    ]);
+  });
+
+  it('a plugin contribution with an unknown icon renders a generic glyph, never a blank space', async () => {
+    const fixture = await createFixture({
+      ...NATIVE_PHONE,
+      registry: {
+        'nav.acquisition': [
+          {
+            id: 'fliks.acme.weird-icon',
+            slot: 'nav.acquisition',
+            weight: 150,
+            labelKey: 'x.weird',
+            icon: 'not-a-real-lucide-name',
+            action: { kind: 'route', path: '/plugins/acme/weird' },
+          },
+        ],
+      },
+    });
+    fixture.componentInstance.bottomMenuOpen.set(true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const inSidebar = sidebarItems(fixture.nativeElement).find((i) => i.label === 'x.weird');
+    const inSheet = sheetItems(fixture.nativeElement).find((i) => i.label === 'x.weird');
+    expect(inSidebar?.icon).toBe('lucideCircle');
+    expect(inSheet?.icon).toBe('lucideCircle');
+  });
+
+  it('a plugin contribution with an unknown action.kind never renders — fails closed, not blank', async () => {
+    const fixture = await createFixture({
+      ...ADMIN_WITH_LIBRARIES,
+      registry: {
+        'nav.main': [
+          { id: 'fliks.acme.broken', slot: 'nav.main', weight: 150, labelKey: 'x.broken', action: { kind: 'bogus' } as never },
+        ],
+      },
+    });
+    expect(sidebarItems(fixture.nativeElement).some((i) => i.label === 'x.broken')).toBe(false);
+  });
+
+  it('a `when`-hidden plugin contribution is absent from the sidebar, the dock and the sheet alike', async () => {
+    const fixture = await createFixture({
+      ...NATIVE_PHONE,
+      registry: {
+        'nav.main': [
+          {
+            id: 'fliks.acme.admin-only',
+            slot: 'nav.main',
+            weight: 150,
+            labelKey: 'x.admin_only',
+            when: ['isAdmin'],
+            action: { kind: 'route', path: '/plugins/acme/admin' },
+          },
+        ],
+      },
+    });
+    fixture.componentInstance.bottomMenuOpen.set(true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // NATIVE_PHONE is a non-admin fixture, so the gated item must show up nowhere.
+    expect(sidebarItems(fixture.nativeElement).some((i) => i.label === 'x.admin_only')).toBe(false);
+    expect(dockItems(fixture.nativeElement).some((i) => i.label === 'x.admin_only')).toBe(false);
+    expect(sheetItems(fixture.nativeElement).some((i) => i.label === 'x.admin_only')).toBe(false);
+  });
+
+  it('renders the full label everywhere except the compact dock, which prefers shortLabelKey', async () => {
+    // `/downloads` is the on-device offline page, unrelated to the acquisition plugin — its
+    // per-surface labels predate this work and must survive it.
+    const downloads = CORE_NAV_CONTRIBUTIONS.find((c) => c.id === 'core.downloads');
+
+    expect(downloads?.labelKey).toBe('downloads.title');
+    expect(downloads?.shortLabelKey).toBe('nav.downloads');
+  });
+});

--- a/client/src/app/shared/layout/layout.ts
+++ b/client/src/app/shared/layout/layout.ts
@@ -45,21 +45,16 @@ import { BackgroundComponent } from '../components/background/background';
 import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
 import { BackgroundService } from '../../core/services/background.service';
 import { SearchStateService } from '../../core/services/search-state.service';
+import { NavContributionsService, DOCK_PINNED_IDS, MOBILE_HIDDEN_IDS, type ResolvedNavItem } from '../../core/plugin-ui/nav-contributions.service';
+import { NavIconComponent } from './nav-icon';
 import {
   LucideMenu,
   LucideChevronLeft,
-  LucideHome,
   LucideSearch,
-  LucideClipboardList,
-  LucideDownload,
-  LucideCalendar,
   LucideCast,
-  LucideHistory,
   LucideEllipsisVertical,
   LucidePin,
   LucideRocket,
-  LucideListVideo,
-  LucideUserRound,
 } from '@lucide/angular';
 
 
@@ -67,9 +62,7 @@ import {
   selector: 'app-layout',
   imports: [
     RouterOutlet, RouterLink, RouterLinkActive, TranslateModule,
-    LucideMenu, LucideChevronLeft, LucideHome, LucideSearch,
-    LucideClipboardList, LucideDownload, LucideCalendar, LucideCast,
-    LucideHistory, LucideEllipsisVertical, LucidePin, LucideRocket, LucideListVideo, LucideUserRound,
+    LucideMenu, LucideChevronLeft, LucideSearch, LucideCast, LucideEllipsisVertical, LucidePin, LucideRocket,
     CastOverlayComponent,
     CardActionsPanelComponent,
     AddToPlaylistModalComponent,
@@ -77,6 +70,7 @@ import {
     UserMenuComponent,
     AppUpdateModalComponent,
     LucideIconComponent,
+    NavIconComponent,
     TvRowDirective,
     BackgroundComponent,
     ResolveUrlPipe,
@@ -211,6 +205,34 @@ export class LayoutComponent implements OnInit, OnDestroy {
   readonly queueCount = signal(0);
   readonly pendingRequestCount = signal(0);
 
+  private readonly navContrib = inject(NavContributionsService);
+  /** `nav.main` items before/after the library block, and `nav.acquisition` —
+   *  the sidebar, the phone dock and the more-sheet all read these same lists. */
+  readonly mainItemsBeforeLibraries = this.navContrib.mainItemsBeforeLibraries;
+  readonly mainItemsAfterLibraries = this.navContrib.mainItemsAfterLibraries;
+  readonly acquisitionItems = this.navContrib.acquisitionItems;
+  readonly dockHome = computed(() => this.mainItemsBeforeLibraries().find((i) => i.id === 'core.home'));
+  readonly dockDownloads = computed(() => this.mainItemsAfterLibraries().find((i) => i.id === 'core.downloads'));
+  readonly dockRequests = computed(() => this.acquisitionItems().find((i) => i.id === 'core.requests'));
+  /** Everything not pinned to the dock's primary row — the more-sheet's content,
+   *  so a plugin item always reaches at least one native-phone surface. */
+  readonly sheetMainItems = computed(() =>
+    [...this.mainItemsBeforeLibraries(), ...this.mainItemsAfterLibraries()].filter(
+      (i) => !DOCK_PINNED_IDS.includes(i.id) && !MOBILE_HIDDEN_IDS.includes(i.id),
+    ),
+  );
+  readonly sheetAcquisitionItems = computed(() =>
+    this.acquisitionItems().filter((i) => !DOCK_PINNED_IDS.includes(i.id)),
+  );
+
+  /** Looks up a contribution's badge count by its declared key — the only
+   *  keys core's own items use today; a plugin badge stays at 0 until the
+   *  counts endpoint grows a matching field. */
+  badgeCountFor(item: ResolvedNavItem): number {
+    if (item.badgeKey === 'queueActive') return this.queueCount();
+    if (item.badgeKey === 'pendingRequests') return this.pendingRequestCount();
+    return 0;
+  }
 
   /** Refresh counts when relevant SSE events arrive */
   private readonly sseEffect = effect(() => {

--- a/client/src/app/shared/layout/nav-icon.html
+++ b/client/src/app/shared/layout/nav-icon.html
@@ -1,0 +1,11 @@
+@switch (name()) {
+  @case ('home') { <svg lucideHome></svg> }
+  @case ('search') { <svg lucideSearch></svg> }
+  @case ('user-round') { <svg lucideUserRound></svg> }
+  @case ('list-video') { <svg lucideListVideo></svg> }
+  @case ('download') { <svg lucideDownload></svg> }
+  @case ('history') { <svg lucideHistory></svg> }
+  @case ('clipboard-list') { <svg lucideClipboardList></svg> }
+  @case ('calendar') { <svg lucideCalendar></svg> }
+  @default { <svg lucideCircle></svg> }
+}

--- a/client/src/app/shared/layout/nav-icon.ts
+++ b/client/src/app/shared/layout/nav-icon.ts
@@ -1,0 +1,31 @@
+import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+import {
+  LucideHome,
+  LucideSearch,
+  LucideUserRound,
+  LucideListVideo,
+  LucideDownload,
+  LucideHistory,
+  LucideClipboardList,
+  LucideCalendar,
+  LucideCircle,
+} from '@lucide/angular';
+
+/**
+ * Renders a nav contribution's icon by name. A plugin can name any string —
+ * unrecognised names fall back to a generic circle, never a blank space.
+ */
+@Component({
+  selector: 'app-nav-icon',
+  standalone: true,
+  imports: [
+    LucideHome, LucideSearch, LucideUserRound, LucideListVideo,
+    LucideDownload, LucideHistory, LucideClipboardList, LucideCalendar, LucideCircle,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './nav-icon.html',
+  styles: [`:host { display: inline-flex; } svg { width: 100%; height: 100%; }`],
+})
+export class NavIconComponent {
+  readonly name = input.required<string>();
+}


### PR DESCRIPTION
PR 5.2: the sidebar, the phone dock and its overflow sheet all render from one merged contribution list instead of hardcoded markup — core's own items expressed as contributions, plus whatever plugins contribute, sorted by weight then id.

Core takes the weights the plan assigns (`nav.main`: Home 100, Search 200, My profile 300, libraries at 1000+id, Playlists 2000, Downloads 2100, History 2200; `nav.acquisition`: Requests 100, Activity 200, Calendar 300), leaving room for a plugin to slot between existing entries.

## Fail-closed rendering

- An **unknown icon** falls back to a generic glyph, never a blank space.
- An **unrecognised action kind** renders nothing rather than a broken row.
- A contribution hidden by its `when` is absent from **all three** surfaces — it can never appear in one and be missing from another.

All three asserted.

## How "pixel-identical" was approached without a browser

There is no way to verify a page visually on this machine — headless Chromium hangs (#907). So the strongest available standard was used instead, the same discipline that proved the `HomeSettingsService` refactor in #923:

1. A characterisation test captured each surface as **data** — the ordered list of `{label, icon, badge, href}` from the real rendered DOM — across four fixtures: admin with libraries on desktop, non-admin without libraries on tablet, TV, and native-phone with libraries (which exercises the dock and the sheet).
2. It was run green against the **untouched** template.
3. The refactor was applied.
4. The same tests were re-run and still pass.

**Pixel rendering remains unverified and this PR does not claim otherwise.**

## One deliberate behaviour change

The overflow sheet used to hand-order its items with **Activity before History** — an arrangement not derivable from either slot's weights, since it interleaved them. It now follows the same rule as the sidebar, so Activity trails History. Say the word and it can be restored with an explicit sheet order, but that means a third hardcoded id list next to the dock-pinning ones, which is indirection that does not buy much.

## One regression caught and reverted

The first pass collapsed every surface onto one `labelKey`, which changed the **phone dock's** Downloads label from the deliberately abbreviated `nav.downloads` ("Downl.") to `downloads.title` ("Downloads"), relying on CSS truncation on the narrowest surface in the app — the one that cannot be checked here.

Confirmed against the pre-refactor template that the sidebar (`downloads.title`) and the dock (`nav.downloads`) genuinely used different labels, so per-surface labels were a **pre-existing need**, not something this work should have flattened. `shortLabelKey` joins the contribution shape — in the backend contract and its client mirror together, so the drift gate stays green — and the dock prefers it while the sidebar and sheet use the full label. A test pins both.

Worth noting that `/downloads` is the **on-device offline downloads** page and has nothing to do with the acquisition plugin, so it had no business changing in a plugin refactor at all.

`WhenPredicate` also now expresses the documented `!` negation (`WhenPredicateName | \`!${WhenPredicateName}\``) instead of leaving new code to cast around a type that did not admit what the evaluator accepts.

## Verification

- Client suite **198 tests / 28 files green**; `ng build` exit 0; `tsc -p tsconfig.app.json` and `-p tsconfig.spec.json` exit 0.
- Backend `tsc` exit 0 and suite **1293 / 123 green** — the contract gained one optional field.
- Note for reviewers: `tsc -p tsconfig.spec.json` passing does **not** typecheck templates. The `shortLabelKey` passthrough was missing on the resolved item type and only the Angular compiler caught it, during `ng test`. Two different checks.

The nav had no user-order override to preserve, so `mergeOrdered` does not apply here — it reconciles a *saved* order against availability, and the nav has none.

## Out of scope

The admin settings sidebar and the `settings.page` slot, schema-driven forms (#924), the media-detail action menu, card actions, the `providers`/`table` renderers.

Refs: #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)