### PR TITLE
feat(plugin-ui): render the admin settings sidebar from the registry

### DIFF
--- a/backend/src/modules/plugins/plugin-ui.controller.spec.ts
+++ b/backend/src/modules/plugins/plugin-ui.controller.spec.ts
@@ -81,7 +81,7 @@ describe('PluginUiController', () => {
   it('includes a data plugin unconditionally — it has no process to be unhealthy', () => {
     const { controller } = makeController([dataPlugin('fliks.a')]);
     const result = controller.list();
-    expect(result).toEqual([{ pluginId: 'fliks.a', contributions: [], configPages: [], i18n: {} }]);
+    expect(result).toEqual([{ pluginId: 'fliks.a', name: expect.any(String), contributions: [], configPages: [], i18n: {} }]);
   });
 
   it('passes the manifest i18n dicts through so the client can merge them under core keys', () => {

--- a/backend/src/modules/plugins/plugin-ui.controller.ts
+++ b/backend/src/modules/plugins/plugin-ui.controller.ts
@@ -5,6 +5,8 @@ import type { ConfigPage, UiContribution } from '../../common/plugin-contract';
 
 export interface PluginUiEntry {
   pluginId: string;
+  /** The manifest's human-readable name — labels the plugin's own settings section. */
+  name: string;
   contributions: UiContribution[];
   configPages: ConfigPage[];
   /** Flat `"a.b.c"` dicts per locale; the client merges them under core's own keys. */
@@ -29,6 +31,7 @@ export class PluginUiController {
       .filter((plugin) => plugin.kind === 'data' || this.registry.processStateOf(plugin.pluginId) === 'ready')
       .map((plugin) => ({
         pluginId: plugin.pluginId,
+        name: plugin.manifest.name,
         contributions: plugin.manifest.ui?.contributions ?? [],
         configPages: plugin.manifest.ui?.configPages ?? [],
         i18n: plugin.manifest.i18n ?? {},

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -380,7 +380,7 @@ export const routes: Routes = [
     path: 'admin',
     loadComponent: () =>
       import('./features/admin/admin-shell').then((m) => m.AdminShellComponent),
-    canActivate: [serverConfigGuard, authGuard, passwordChangeGuard, adminGuard],
+    canActivate: [serverConfigGuard, authGuard, passwordChangeGuard, adminGuard, noTvGuard],
     children: [
       { path: '', pathMatch: 'full', redirectTo: 'statistics' },
       { path: 'statistics', loadComponent: () => import('./features/dashboard/dashboard').then((m) => m.DashboardComponent) },

--- a/client/src/app/core/plugin-ui/core-contributions.ts
+++ b/client/src/app/core/plugin-ui/core-contributions.ts
@@ -30,3 +30,86 @@ export const CORE_NAV_CONTRIBUTIONS: readonly UiContribution[] = [
  *  weight-300 and weight-2000 core items — this is where a plugin's
  *  `nav.main` item at weight 1000-1999 would land, visually after them. */
 export const LIBRARIES_BLOCK_WEIGHT = 1000;
+
+/** One `menu-title` group in the admin settings sidebar. */
+export interface CoreSettingsSection {
+  labelKey: string;
+  items: readonly UiContribution[];
+}
+
+/**
+ * Core's own admin settings links as `settings.page` contributions, grouped
+ * into the 8 sections the sidebar has always had. A plugin never joins one
+ * of these — it gets a section of its own instead (see the admin feature's
+ * `SettingsSectionsService`) — so weight only orders core items against
+ * each other; the 100-spacing is kept anyway for a future core item to slot
+ * into, on the same convention as `CORE_NAV_CONTRIBUTIONS`.
+ */
+export const CORE_SETTINGS_SECTIONS: readonly CoreSettingsSection[] = [
+  {
+    labelKey: 'admin.section_system',
+    items: [
+      { id: 'core.statistics', slot: 'settings.page', weight: 100, labelKey: 'nav.statistics', icon: 'bar-chart-3', action: { kind: 'route', path: '/admin/statistics' } },
+      { id: 'core.system', slot: 'settings.page', weight: 200, labelKey: 'nav.system', icon: 'layout-grid', action: { kind: 'route', path: '/admin/system' } },
+      { id: 'core.streams', slot: 'settings.page', weight: 300, labelKey: 'system.tab_streams', icon: 'play', action: { kind: 'route', path: '/admin/streams' } },
+    ],
+  },
+  {
+    labelKey: 'admin.section_settings',
+    items: [
+      { id: 'core.general', slot: 'settings.page', weight: 100, labelKey: 'settings.nav.general', action: { kind: 'route', path: '/admin/settings/general' } },
+      { id: 'core.libraries', slot: 'settings.page', weight: 200, labelKey: 'settings.nav.libraries', action: { kind: 'route', path: '/admin/settings/libraries' } },
+      { id: 'core.naming', slot: 'settings.page', weight: 300, labelKey: 'settings.nav.naming', action: { kind: 'route', path: '/admin/settings/naming' } },
+    ],
+  },
+  {
+    labelKey: 'admin.section_media',
+    items: [
+      { id: 'core.quality_profiles', slot: 'settings.page', weight: 100, labelKey: 'settings.nav.quality_profiles', action: { kind: 'route', path: '/admin/settings/quality-profiles' } },
+      { id: 'core.language_profiles', slot: 'settings.page', weight: 200, labelKey: 'settings.nav.language_profiles', action: { kind: 'route', path: '/admin/settings/language-profiles' } },
+      { id: 'core.quality_definitions', slot: 'settings.page', weight: 300, labelKey: 'settings.nav.quality_definitions', action: { kind: 'route', path: '/admin/settings/quality-definitions' } },
+      { id: 'core.custom_formats', slot: 'settings.page', weight: 400, labelKey: 'settings.nav.custom_formats', action: { kind: 'route', path: '/admin/settings/custom-formats' } },
+      { id: 'core.delay_profiles', slot: 'settings.page', weight: 500, labelKey: 'settings.nav.delay_profiles', action: { kind: 'route', path: '/admin/settings/delay-profiles' } },
+      { id: 'core.cleanup_profiles', slot: 'settings.page', weight: 600, labelKey: 'settings.nav.cleanup_profiles', action: { kind: 'route', path: '/admin/settings/cleanup-profiles' } },
+    ],
+  },
+  {
+    labelKey: 'admin.section_indexers',
+    items: [
+      { id: 'core.indexers', slot: 'settings.page', weight: 100, labelKey: 'settings.nav.indexers', action: { kind: 'route', path: '/admin/settings/indexers' } },
+      { id: 'core.download_clients', slot: 'settings.page', weight: 200, labelKey: 'settings.nav.download_clients', action: { kind: 'route', path: '/admin/settings/download-clients' } },
+      { id: 'core.blocklist', slot: 'settings.page', weight: 300, labelKey: 'settings.nav.blocklist', action: { kind: 'route', path: '/admin/settings/blocklist' } },
+    ],
+  },
+  {
+    labelKey: 'admin.section_subtitles',
+    items: [
+      { id: 'core.subtitles', slot: 'settings.page', weight: 100, labelKey: 'settings.nav.subtitles', action: { kind: 'route', path: '/admin/settings/subtitles' } },
+      { id: 'core.subtitle_providers', slot: 'settings.page', weight: 200, labelKey: 'settings.nav.subtitle_providers', action: { kind: 'route', path: '/admin/settings/subtitle-providers' } },
+    ],
+  },
+  {
+    labelKey: 'admin.section_integrations',
+    items: [
+      { id: 'core.media_servers', slot: 'settings.page', weight: 100, labelKey: 'settings.nav.media_servers', action: { kind: 'route', path: '/admin/settings/media-servers' } },
+      { id: 'core.data_imports', slot: 'settings.page', weight: 200, labelKey: 'settings.nav.data_imports', action: { kind: 'route', path: '/admin/settings/data-imports' } },
+      { id: 'core.notifications', slot: 'settings.page', weight: 300, labelKey: 'settings.nav.notifications', action: { kind: 'route', path: '/admin/settings/notifications' } },
+    ],
+  },
+  {
+    labelKey: 'admin.section_users',
+    items: [
+      { id: 'core.users', slot: 'settings.page', weight: 100, labelKey: 'settings.nav.users', action: { kind: 'route', path: '/admin/settings/users' } },
+      { id: 'core.roles', slot: 'settings.page', weight: 200, labelKey: 'settings.nav.roles', action: { kind: 'route', path: '/admin/settings/roles' } },
+      { id: 'core.auto_approval', slot: 'settings.page', weight: 300, labelKey: 'settings.nav.auto_approval', action: { kind: 'route', path: '/admin/settings/auto-approval' } },
+    ],
+  },
+  {
+    labelKey: 'admin.section_advanced',
+    items: [
+      { id: 'core.schedulers', slot: 'settings.page', weight: 100, labelKey: 'settings.nav.schedulers', action: { kind: 'route', path: '/admin/settings/schedulers' } },
+      { id: 'core.streaming', slot: 'settings.page', weight: 200, labelKey: 'settings.nav.streaming', action: { kind: 'route', path: '/admin/settings/streaming' } },
+      { id: 'core.plugins', slot: 'settings.page', weight: 300, labelKey: 'settings.nav.plugins', action: { kind: 'route', path: '/admin/settings/plugins' } },
+    ],
+  },
+];

--- a/client/src/app/core/plugin-ui/plugin-ui-registry.service.ts
+++ b/client/src/app/core/plugin-ui/plugin-ui-registry.service.ts
@@ -64,6 +64,12 @@ export class PluginUiRegistryService {
     return this.entries.some((e) => e.pluginId === pluginId);
   }
 
+  /** Raw per-plugin entries — needed where a slot's contributions must stay
+   *  grouped by the plugin that declared them (settings.page's per-plugin sections). */
+  pluginEntries(): readonly PluginUiEntry[] {
+    return this.entries;
+  }
+
   configPage(pluginId: string, pageId: string): ConfigPage | undefined {
     return this.entries.find((e) => e.pluginId === pluginId)?.configPages?.find((p) => p.id === pageId);
   }

--- a/client/src/app/core/plugin-ui/plugin-ui-response.ts
+++ b/client/src/app/core/plugin-ui/plugin-ui-response.ts
@@ -7,6 +7,8 @@ import type { ConfigPage, UiContribution } from './contribution.types';
  */
 export interface PluginUiEntry {
   pluginId: string;
+  /** The plugin's manifest display name; absent on a backend that hasn't shipped it yet. */
+  name?: string;
   contributions: UiContribution[];
   configPages: ConfigPage[];
   /** Translations to merge into ngx-translate so `labelKey` resolves. */

--- a/client/src/app/features/admin/admin-shell.html
+++ b/client/src/app/features/admin/admin-shell.html
@@ -6,54 +6,18 @@
   <svg drawerIcon lucideShield class="h-5 w-5"></svg>
 
   <ng-container drawerMenu>
-    <!-- System -->
-    <li class="menu-title text-xs uppercase tracking-wider mt-2">{{ 'admin.section_system' | translate }}</li>
-    <li><a routerLink="/admin/statistics" routerLinkActive="active"><svg lucideBarChart3 class="h-4 w-4"></svg>{{ 'nav.statistics' | translate }}</a></li>
-    <li><a routerLink="/admin/system" routerLinkActive="active"><svg lucideLayoutGrid class="h-4 w-4"></svg>{{ 'nav.system' | translate }}</a></li>
-    <li><a routerLink="/admin/streams" routerLinkActive="active"><svg lucidePlay class="h-4 w-4"></svg>{{ 'system.tab_streams' | translate }}</a></li>
-
-    <!-- General -->
-    <li class="menu-title text-xs uppercase tracking-wider mt-4">{{ 'admin.section_settings' | translate }}</li>
-    <li><a routerLink="/admin/settings/general" routerLinkActive="active">{{ 'settings.nav.general' | translate }}</a></li>
-    <li><a routerLink="/admin/settings/libraries" routerLinkActive="active">{{ 'settings.nav.libraries' | translate }}</a></li>
-    <li><a routerLink="/admin/settings/naming" routerLinkActive="active">{{ 'settings.nav.naming' | translate }}</a></li>
-
-    <!-- Médias / profils -->
-    <li class="menu-title text-xs uppercase tracking-wider mt-4">{{ 'admin.section_media' | translate }}</li>
-    <li><a routerLink="/admin/settings/quality-profiles" routerLinkActive="active">{{ 'settings.nav.quality_profiles' | translate }}</a></li>
-    <li><a routerLink="/admin/settings/language-profiles" routerLinkActive="active">{{ 'settings.nav.language_profiles' | translate }}</a></li>
-    <li><a routerLink="/admin/settings/quality-definitions" routerLinkActive="active">{{ 'settings.nav.quality_definitions' | translate }}</a></li>
-    <li><a routerLink="/admin/settings/custom-formats" routerLinkActive="active">{{ 'settings.nav.custom_formats' | translate }}</a></li>
-    <li><a routerLink="/admin/settings/delay-profiles" routerLinkActive="active">{{ 'settings.nav.delay_profiles' | translate }}</a></li>
-    <li><a routerLink="/admin/settings/cleanup-profiles" routerLinkActive="active">{{ 'settings.nav.cleanup_profiles' | translate }}</a></li>
-
-    <!-- Indexation & téléchargement -->
-    <li class="menu-title text-xs uppercase tracking-wider mt-4">{{ 'admin.section_indexers' | translate }}</li>
-    <li><a routerLink="/admin/settings/indexers" routerLinkActive="active">{{ 'settings.nav.indexers' | translate }}</a></li>
-    <li><a routerLink="/admin/settings/download-clients" routerLinkActive="active">{{ 'settings.nav.download_clients' | translate }}</a></li>
-    <li><a routerLink="/admin/settings/blocklist" routerLinkActive="active">{{ 'settings.nav.blocklist' | translate }}</a></li>
-
-    <!-- Sous-titres -->
-    <li class="menu-title text-xs uppercase tracking-wider mt-4">{{ 'admin.section_subtitles' | translate }}</li>
-    <li><a routerLink="/admin/settings/subtitles" routerLinkActive="active">{{ 'settings.nav.subtitles' | translate }}</a></li>
-    <li><a routerLink="/admin/settings/subtitle-providers" routerLinkActive="active">{{ 'settings.nav.subtitle_providers' | translate }}</a></li>
-
-    <!-- Intégrations -->
-    <li class="menu-title text-xs uppercase tracking-wider mt-4">{{ 'admin.section_integrations' | translate }}</li>
-    <li><a routerLink="/admin/settings/media-servers" routerLinkActive="active">{{ 'settings.nav.media_servers' | translate }}</a></li>
-    <li><a routerLink="/admin/settings/data-imports" routerLinkActive="active">{{ 'settings.nav.data_imports' | translate }}</a></li>
-    <li><a routerLink="/admin/settings/notifications" routerLinkActive="active">{{ 'settings.nav.notifications' | translate }}</a></li>
-
-    <!-- Utilisateurs -->
-    <li class="menu-title text-xs uppercase tracking-wider mt-4">{{ 'admin.section_users' | translate }}</li>
-    <li><a routerLink="/admin/settings/users" routerLinkActive="active">{{ 'settings.nav.users' | translate }}</a></li>
-    <li><a routerLink="/admin/settings/roles" routerLinkActive="active">{{ 'settings.nav.roles' | translate }}</a></li>
-    <li><a routerLink="/admin/settings/auto-approval" routerLinkActive="active">{{ 'settings.nav.auto_approval' | translate }}</a></li>
-
-    <!-- Avancé -->
-    <li class="menu-title text-xs uppercase tracking-wider mt-4">{{ 'admin.section_advanced' | translate }}</li>
-    <li><a routerLink="/admin/settings/schedulers" routerLinkActive="active">{{ 'settings.nav.schedulers' | translate }}</a></li>
-    <li><a routerLink="/admin/settings/streaming" routerLinkActive="active">{{ 'settings.nav.streaming' | translate }}</a></li>
-    <li><a routerLink="/admin/settings/plugins" routerLinkActive="active">{{ 'settings.nav.plugins' | translate }}</a></li>
+    @for (section of sections(); track section.id; let i = $index) {
+      <li class="menu-title text-xs uppercase tracking-wider" [class.mt-2]="i === 0" [class.mt-4]="i !== 0">{{ section.label | translate }}</li>
+      @for (item of section.items; track item.id) {
+        <li>
+          <a [routerLink]="item.route" routerLinkActive="active">
+            @if (item.icon) {
+              <app-settings-icon [name]="item.icon" class="h-4 w-4" />
+            }
+            {{ item.labelKey | translate }}
+          </a>
+        </li>
+      }
+    }
   </ng-container>
 </app-settings-drawer>

--- a/client/src/app/features/admin/admin-shell.spec.ts
+++ b/client/src/app/features/admin/admin-shell.spec.ts
@@ -1,0 +1,183 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Title } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
+import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { AdminShellComponent } from './admin-shell';
+import { AuthService } from '../../core/services/auth.service';
+import { DeviceService } from '../../core/services/device.service';
+import { TvService } from '../../core/services/tv.service';
+import { PluginUiRegistryService } from '../../core/plugin-ui/plugin-ui-registry.service';
+import type { PluginUiEntry } from '../../core/plugin-ui/plugin-ui-response';
+import type { UiContribution } from '../../core/plugin-ui/contribution.types';
+
+// Characterisation contract: this is the exact section/link shape the
+// hand-written template rendered before the registry-driven refactor.
+// Captured green against the untouched template, then re-run unchanged
+// against the refactor — see the task report for both runs.
+const BASELINE_SIDEBAR = [
+  { label: 'admin.section_system', links: [
+    { label: 'nav.statistics', href: '/admin/statistics' },
+    { label: 'nav.system', href: '/admin/system' },
+    { label: 'system.tab_streams', href: '/admin/streams' },
+  ] },
+  { label: 'admin.section_settings', links: [
+    { label: 'settings.nav.general', href: '/admin/settings/general' },
+    { label: 'settings.nav.libraries', href: '/admin/settings/libraries' },
+    { label: 'settings.nav.naming', href: '/admin/settings/naming' },
+  ] },
+  { label: 'admin.section_media', links: [
+    { label: 'settings.nav.quality_profiles', href: '/admin/settings/quality-profiles' },
+    { label: 'settings.nav.language_profiles', href: '/admin/settings/language-profiles' },
+    { label: 'settings.nav.quality_definitions', href: '/admin/settings/quality-definitions' },
+    { label: 'settings.nav.custom_formats', href: '/admin/settings/custom-formats' },
+    { label: 'settings.nav.delay_profiles', href: '/admin/settings/delay-profiles' },
+    { label: 'settings.nav.cleanup_profiles', href: '/admin/settings/cleanup-profiles' },
+  ] },
+  { label: 'admin.section_indexers', links: [
+    { label: 'settings.nav.indexers', href: '/admin/settings/indexers' },
+    { label: 'settings.nav.download_clients', href: '/admin/settings/download-clients' },
+    { label: 'settings.nav.blocklist', href: '/admin/settings/blocklist' },
+  ] },
+  { label: 'admin.section_subtitles', links: [
+    { label: 'settings.nav.subtitles', href: '/admin/settings/subtitles' },
+    { label: 'settings.nav.subtitle_providers', href: '/admin/settings/subtitle-providers' },
+  ] },
+  { label: 'admin.section_integrations', links: [
+    { label: 'settings.nav.media_servers', href: '/admin/settings/media-servers' },
+    { label: 'settings.nav.data_imports', href: '/admin/settings/data-imports' },
+    { label: 'settings.nav.notifications', href: '/admin/settings/notifications' },
+  ] },
+  { label: 'admin.section_users', links: [
+    { label: 'settings.nav.users', href: '/admin/settings/users' },
+    { label: 'settings.nav.roles', href: '/admin/settings/roles' },
+    { label: 'settings.nav.auto_approval', href: '/admin/settings/auto-approval' },
+  ] },
+  { label: 'admin.section_advanced', links: [
+    { label: 'settings.nav.schedulers', href: '/admin/settings/schedulers' },
+    { label: 'settings.nav.streaming', href: '/admin/settings/streaming' },
+    { label: 'settings.nav.plugins', href: '/admin/settings/plugins' },
+  ] },
+];
+
+const contribution = (id: string, weight: number, overrides: Partial<UiContribution> = {}): UiContribution => ({
+  id,
+  slot: 'settings.page',
+  weight,
+  labelKey: `x.${id}`,
+  action: { kind: 'route', path: `/admin/settings/plugins/x/${id}` },
+  ...overrides,
+});
+
+const entry = (pluginId: string, contributions: UiContribution[], extra: Partial<PluginUiEntry> = {}): PluginUiEntry => ({
+  pluginId,
+  contributions,
+  configPages: [],
+  ...extra,
+});
+
+function readSidebar(fixture: ComponentFixture<AdminShellComponent>) {
+  const menu: Element = fixture.nativeElement.querySelector('ul.menu');
+  const sections: { label: string; links: { label: string; href: string }[] }[] = [];
+  let current: { label: string; links: { label: string; href: string }[] } | null = null;
+  for (const li of Array.from(menu.children)) {
+    if (li.classList.contains('menu-title')) {
+      current = { label: (li.textContent ?? '').replace(/\s+/g, ' ').trim(), links: [] };
+      sections.push(current);
+    } else if (current) {
+      const a = li.querySelector('a');
+      if (a) {
+        current.links.push({
+          label: (a.textContent ?? '').replace(/\s+/g, ' ').trim(),
+          href: a.getAttribute('href') ?? '',
+        });
+      }
+    }
+  }
+  return sections;
+}
+
+function createFixture(opts: { isAdmin?: boolean; entries?: PluginUiEntry[] } = {}) {
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      provideRouter([]),
+      provideTranslateService({
+        lang: 'en',
+        loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+      }),
+      { provide: Title, useValue: { setTitle: () => {} } },
+      {
+        provide: AuthService,
+        useValue: { user: () => ({ id: 1, isAdmin: !!opts.isAdmin }), hasPermission: () => false },
+      },
+      { provide: TvService, useValue: { isTv: () => false, isAndroidTv: () => false } },
+      { provide: DeviceService, useValue: { isTouch: () => false } },
+      {
+        provide: PluginUiRegistryService,
+        useValue: { pluginEntries: () => opts.entries ?? [] },
+      },
+    ],
+  });
+  const fixture = TestBed.createComponent(AdminShellComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('AdminShellComponent — sidebar characterisation', () => {
+  // Same fixture run under both an admin and a non-admin auth context: the
+  // sidebar has never gated any of its 26 links on isAdmin (only the /admin
+  // route guard does), and the refactor must not start doing so implicitly.
+  it.each([['admin', true], ['non-admin', false]] as const)(
+    'renders the unchanged 8-section, 26-link sidebar for a %s context',
+    (_label, isAdmin) => {
+      const fixture = createFixture({ isAdmin });
+      expect(readSidebar(fixture)).toEqual(BASELINE_SIDEBAR);
+    },
+  );
+
+  it('appends a plugin section after every core section, labelled by manifest name', () => {
+    const fixture = createFixture({
+      entries: [
+        entry('fliks.b', [contribution('page', 100, { labelKey: 'b.page' })], { name: 'B Plugin' }),
+      ],
+    });
+    const sections = readSidebar(fixture);
+    expect(sections).toHaveLength(9);
+    expect(sections[8]).toEqual({ label: 'B Plugin', links: [{ label: 'b.page', href: '/admin/settings/plugins/x/page' }] });
+  });
+
+  it('orders plugin sections by plugin id, not install/array order', () => {
+    const fixture = createFixture({
+      entries: [
+        entry('fliks.zeta', [contribution('z', 100)], { name: 'Zeta' }),
+        entry('fliks.alpha', [contribution('a', 100)], { name: 'Alpha' }),
+      ],
+    });
+    const sections = readSidebar(fixture);
+    expect(sections.slice(8).map((s) => s.label)).toEqual(['Alpha', 'Zeta']);
+  });
+
+  it('produces no section for a plugin with zero settings.page contributions', () => {
+    const fixture = createFixture({
+      entries: [entry('fliks.empty', [contribution('nav-item', 100, { slot: 'nav.main' })], { name: 'Empty' })],
+    });
+    expect(readSidebar(fixture)).toHaveLength(8);
+  });
+
+  it('produces no section for a plugin whose only contribution is hidden by `when`', () => {
+    const fixture = createFixture({
+      entries: [entry('fliks.hidden', [contribution('gone', 100, { when: ['isAdmin'] })], { name: 'Hidden' })],
+    });
+    // isAdmin is false in this fixture's default context, so the predicate fails.
+    expect(readSidebar(fixture)).toHaveLength(8);
+  });
+
+  it('falls back to the plugin id when the manifest name is not yet in the response', () => {
+    const fixture = createFixture({
+      entries: [entry('fliks.noname', [contribution('page', 100)])],
+    });
+    expect(readSidebar(fixture)[8].label).toBe('fliks.noname');
+  });
+});

--- a/client/src/app/features/admin/admin-shell.ts
+++ b/client/src/app/features/admin/admin-shell.ts
@@ -1,23 +1,21 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
+import { LucideShield } from '@lucide/angular';
 import { SettingsDrawerComponent } from '../../shared/components/settings-drawer/settings-drawer';
-import {
-  LucideLayoutGrid,
-  LucideBarChart3,
-  LucidePlay,
-  LucideShield,
-} from '@lucide/angular';
+import { SettingsIconComponent } from './settings-icon';
+import { SettingsSectionsService } from './settings-sections.service';
 
 @Component({
   selector: 'app-admin-shell',
   imports: [
     RouterLink, RouterLinkActive, TranslateModule,
-    SettingsDrawerComponent,
-    LucideLayoutGrid, LucidePlay,
-    LucideBarChart3, LucideShield,
+    SettingsDrawerComponent, SettingsIconComponent,
+    LucideShield,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './admin-shell.html',
 })
-export class AdminShellComponent {}
+export class AdminShellComponent {
+  readonly sections = inject(SettingsSectionsService).sections;
+}

--- a/client/src/app/features/admin/settings-icon.html
+++ b/client/src/app/features/admin/settings-icon.html
@@ -1,0 +1,6 @@
+@switch (name()) {
+  @case ('bar-chart-3') { <svg lucideBarChart3></svg> }
+  @case ('layout-grid') { <svg lucideLayoutGrid></svg> }
+  @case ('play') { <svg lucidePlay></svg> }
+  @default { <svg lucideCircle></svg> }
+}

--- a/client/src/app/features/admin/settings-icon.ts
+++ b/client/src/app/features/admin/settings-icon.ts
@@ -1,0 +1,18 @@
+import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+import { LucideBarChart3, LucideLayoutGrid, LucidePlay, LucideCircle } from '@lucide/angular';
+
+/**
+ * Renders a `settings.page` contribution's icon by name — a plugin can name
+ * any string; unrecognised names fall back to a generic circle, never blank.
+ */
+@Component({
+  selector: 'app-settings-icon',
+  standalone: true,
+  imports: [LucideBarChart3, LucideLayoutGrid, LucidePlay, LucideCircle],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './settings-icon.html',
+  styles: [`:host { display: inline-flex; } svg { width: 100%; height: 100%; }`],
+})
+export class SettingsIconComponent {
+  readonly name = input.required<string>();
+}

--- a/client/src/app/features/admin/settings-sections.service.spec.ts
+++ b/client/src/app/features/admin/settings-sections.service.spec.ts
@@ -1,0 +1,91 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { SettingsSectionsService } from './settings-sections.service';
+import { AuthService } from '../../core/services/auth.service';
+import { DeviceService } from '../../core/services/device.service';
+import { TvService } from '../../core/services/tv.service';
+import { PluginUiRegistryService } from '../../core/plugin-ui/plugin-ui-registry.service';
+import type { PluginUiEntry } from '../../core/plugin-ui/plugin-ui-response';
+import type { UiContribution } from '../../core/plugin-ui/contribution.types';
+
+const contribution = (id: string, weight: number, overrides: Partial<UiContribution> = {}): UiContribution => ({
+  id,
+  slot: 'settings.page',
+  weight,
+  labelKey: `x.${id}`,
+  action: { kind: 'route', path: `/admin/settings/plugins/x/${id}` },
+  ...overrides,
+});
+
+const entry = (pluginId: string, contributions: UiContribution[], extra: Partial<PluginUiEntry> = {}): PluginUiEntry => ({
+  pluginId,
+  contributions,
+  configPages: [],
+  ...extra,
+});
+
+function createService(opts: { isAdmin?: boolean; entries?: PluginUiEntry[] } = {}) {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      {
+        provide: AuthService,
+        useValue: { user: () => ({ id: 1, isAdmin: !!opts.isAdmin }), hasPermission: () => false },
+      },
+      { provide: TvService, useValue: { isTv: () => false } },
+      { provide: DeviceService, useValue: { isTouch: () => false } },
+      { provide: PluginUiRegistryService, useValue: { pluginEntries: () => opts.entries ?? [] } },
+    ],
+  });
+  return TestBed.inject(SettingsSectionsService);
+}
+
+describe('SettingsSectionsService', () => {
+  it('resolves the 8 core sections with 26 items total, and nothing else, with an empty registry', () => {
+    const svc = createService();
+    const sections = svc.sections();
+    expect(sections).toHaveLength(8);
+    expect(sections.reduce((n, s) => n + s.items.length, 0)).toBe(26);
+  });
+
+  it('sorts a plugin section\'s own items by weight then id, independent of core', () => {
+    const svc = createService({
+      entries: [entry('fliks.a', [contribution('z', 100), contribution('a', 100), contribution('b', 50)], { name: 'A' })],
+    });
+    const plugin = svc.sections().at(-1)!;
+    expect(plugin.items.map((i) => i.id)).toEqual(['b', 'a', 'z']);
+  });
+
+  it('never lets a plugin contribution join a core section, however its id or weight looks', () => {
+    const svc = createService({
+      // Deliberately mimics a core id/weight to prove grouping is by plugin
+      // entry, never by string-matching an item into an existing section.
+      entries: [entry('fliks.a', [contribution('core.system', 50)], { name: 'A' })],
+    });
+    const sections = svc.sections();
+    const system = sections.find((s) => s.id === 'core:admin.section_system')!;
+    expect(system.items).toHaveLength(3); // its 3 real core items only, not 4
+    expect(sections.at(-1)!.items.map((i) => i.id)).toEqual(['core.system']);
+  });
+
+  it('ignores a plugin contribution outside settings.page when building its section', () => {
+    const svc = createService({
+      entries: [entry('fliks.a', [contribution('nav', 100, { slot: 'nav.main' })], { name: 'A' })],
+    });
+    expect(svc.sections()).toHaveLength(8);
+  });
+
+  it('drops a plugin settings.page contribution with an unrecognised action kind', () => {
+    const svc = createService({
+      entries: [entry('fliks.a', [contribution('broken', 100, { action: { kind: 'bogus' } as never })], { name: 'A' })],
+    });
+    expect(svc.sections()).toHaveLength(8);
+  });
+
+  it('produces the identical section list for an admin and a non-admin context', () => {
+    const withAdmin = createService({ isAdmin: true }).sections();
+    const withoutAdmin = createService({ isAdmin: false }).sections();
+    expect(withoutAdmin).toEqual(withAdmin);
+  });
+});

--- a/client/src/app/features/admin/settings-sections.service.ts
+++ b/client/src/app/features/admin/settings-sections.service.ts
@@ -1,0 +1,85 @@
+import { Injectable, computed, inject } from '@angular/core';
+import { AuthService } from '../../core/services/auth.service';
+import { DeviceService } from '../../core/services/device.service';
+import { TvService } from '../../core/services/tv.service';
+import { CORE_SETTINGS_SECTIONS } from '../../core/plugin-ui/core-contributions';
+import { PluginUiRegistryService } from '../../core/plugin-ui/plugin-ui-registry.service';
+import { evaluateWhen, type WhenContext } from '../../core/plugin-ui/when-evaluator';
+import type { UiContribution } from '../../core/plugin-ui/contribution.types';
+
+export interface ResolvedSettingsItem {
+  id: string;
+  labelKey: string;
+  icon?: string;
+  route: string;
+}
+
+export interface ResolvedSettingsSection {
+  id: string;
+  /** An i18n key for a core section; a plugin section's manifest name (or
+   *  its id as a last resort) — always piped through `translate`, which
+   *  falls back to the literal string when no such key exists. */
+  label: string;
+  items: ResolvedSettingsItem[];
+}
+
+function sortByWeightThenId(list: readonly UiContribution[]): UiContribution[] {
+  return [...list].sort((a, b) => a.weight - b.weight || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+}
+
+/**
+ * Resolves `settings.page` into the admin sidebar's section list. Unlike
+ * `nav.main`/`nav.acquisition`, a plugin never joins a core section: every
+ * plugin's pages form one section of their own, labelled by the plugin's
+ * manifest name and ordered after every core section, by plugin id — never
+ * by install order. A section with no visible item cannot appear at all,
+ * core or plugin, so an install/uninstall or a `when` change can never leave
+ * an orphaned header.
+ */
+@Injectable({ providedIn: 'root' })
+export class SettingsSectionsService {
+  private readonly registry = inject(PluginUiRegistryService);
+  private readonly auth = inject(AuthService);
+  private readonly tv = inject(TvService);
+  private readonly device = inject(DeviceService);
+
+  readonly sections = computed<ResolvedSettingsSection[]>(() => {
+    const ctx: WhenContext = {
+      isAdmin: !!this.auth.user()?.isAdmin,
+      hasPermission: (p) => this.auth.hasPermission(p),
+      isTv: this.tv.isTv(),
+      isTouch: this.device.isTouch(),
+    };
+
+    const core = CORE_SETTINGS_SECTIONS.map((s) => ({
+      id: `core:${s.labelKey}`,
+      label: s.labelKey,
+      items: this.resolveItems(s.items, ctx),
+    }));
+
+    const plugins = [...this.registry.pluginEntries()]
+      .sort((a, b) => (a.pluginId < b.pluginId ? -1 : a.pluginId > b.pluginId ? 1 : 0))
+      .map((e) => ({
+        id: `plugin:${e.pluginId}`,
+        label: e.name ?? e.pluginId,
+        items: this.resolveItems(
+          sortByWeightThenId((e.contributions ?? []).filter((c) => c.slot === 'settings.page')),
+          ctx,
+        ),
+      }));
+
+    return [...core, ...plugins].filter((s) => s.items.length > 0);
+  });
+
+  /** `when`-filters and resolves the action to a route; drops a contribution
+   *  this client can't render rather than showing a broken row. */
+  private resolveItems(items: readonly UiContribution[], ctx: WhenContext): ResolvedSettingsItem[] {
+    const out: ResolvedSettingsItem[] = [];
+    for (const c of items) {
+      if (!evaluateWhen(c.when, ctx)) continue;
+      if (c.action.kind !== 'route') continue;
+      out.push({ id: c.id, labelKey: c.labelKey, icon: c.icon, route: c.action.path });
+    }
+    return out;
+  }
+}


### PR DESCRIPTION
The `settings.page` slot. Core's own settings links become contributions grouped into the eight sections that already exist, and **each plugin gets a section of its own**.

## The per-plugin section

This overrides the plan, which grouped plugin pages into core's sections. A plugin's pages now land under a section labelled by its manifest `name`, ordered after every core section by plugin id so the order does not shift with install order.

- **No `section` key in the manifest.** An author picks nothing — less work than choosing from core's taxonomy, and the point of the decision.
- **A section with zero visible items is dropped**, and that filter runs identically for core and plugin sections. An orphaned header is therefore impossible by construction, not by a special case. Proved twice: a plugin contributing only to `nav.main`, and a plugin whose only `settings.page` contribution is hidden by its `when` — both yield exactly eight sections, no ninth.

This is what resolved the problem the maintainer spotted from a screenshot: with *Indexeurs* and *Clients de téléchargement* leaving for the plugin and *Liste de blocage* staying, core's "Indexation & téléchargement" header would have survived with one unrelated child. Under the new model a plugin's pages never sit in a core section at all.

`GET /api/plugins/ui` gains the manifest `name` the section label reads — the client degrades to labelling by `pluginId` without it, which is how the agent found the gap.

## No TV

Per the maintainer's ruling, admin surfaces get **no** TV support — hidden, not adapted. `/admin` had no `noTvGuard` while sibling personal-surface routes (`downloads`, `profile/:userId`) already carried one; it now does, so the whole admin subtree redirects on any TV form factor. No TV layout, compact variant or spatial-navigation handling was added, and none is wanted.

## Numbers the plan got wrong

The plan's `settings.page` row says "all 34 admin links". The real markup has **8 sections and 26 links**. Flagged rather than silently reconciled — cross-checked against the `admin.section_*` i18n keys, which are 8 in every locale.

## Verification

- Client suite **213 tests / 31 files green**, `ng build` exit 0. Backend suite **1293 / 123 green**, `tsc` exit 0.
- The sidebar was captured as data — eight sections with their labels, and within each the ordered links with labels and hrefs — across an admin and a non-admin fixture; run green against the **untouched** template, then re-run unchanged after the refactor. That also established that today's sidebar gates nothing on `isAdmin` beyond the route guard.

**Not visually verified** — headless Chromium hangs here (#907), and this PR makes no visual claim.

Two differences called out rather than absorbed: the three icon-bearing items now render through a wrapping component instead of a bare inline `<svg>` (the same trade-off already accepted for the main nav), and `/admin` is deliberately unreachable on TV.

## Note

`plugin-ui-response.ts` and `plugin-ui-registry.service.ts` gained an optional field and one accessor. `contributionsFor()` flattens across plugins and loses which plugin declared what, so grouping per plugin structurally needs per-entry access. Both changes are additive.

Refs: #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)