### PR TITLE
feat(plugin-ui): render the media-detail action menu from the registry

### DIFF
--- a/client/src/app/core/plugin-ui/media-action-registry.spec.ts
+++ b/client/src/app/core/plugin-ui/media-action-registry.spec.ts
@@ -1,0 +1,40 @@
+import { resolveMediaAction, type CoreMediaActionId, type MediaActionHandlers } from './media-action-registry';
+
+const ALL_IDS: CoreMediaActionId[] = [
+  'media.recommend',
+  'media.toggle-series-watched',
+  'media.open-tracking',
+  'media.request',
+  'media.grab-best',
+  'media.search-releases',
+  'media.edit-profiles',
+  'media.edit-library',
+  'media.edit-subtitles',
+  'media.refresh-metadata',
+  'media.analyze',
+  'media.toggle-monitored',
+  'media.delete',
+  'media.request-deletion',
+];
+
+function fakeHandlers(): MediaActionHandlers {
+  const handlers = {} as MediaActionHandlers;
+  for (const id of ALL_IDS) handlers[id] = () => {};
+  return handlers;
+}
+
+describe('resolveMediaAction', () => {
+  it('resolves every declared core actionId to its own handler', () => {
+    const handlers = fakeHandlers();
+    for (const id of ALL_IDS) {
+      expect(resolveMediaAction(id, handlers)).toBe(handlers[id]);
+    }
+  });
+
+  it('VERDICT: an unknown actionId resolves to null — fail closed, no row rather than a dead click', () => {
+    const handlers = fakeHandlers();
+    expect(resolveMediaAction('media.something-a-plugin-made-up', handlers)).toBeNull();
+    expect(resolveMediaAction('', handlers)).toBeNull();
+    expect(resolveMediaAction('media.delete-typo', handlers)).toBeNull();
+  });
+});

--- a/client/src/app/core/plugin-ui/media-action-registry.ts
+++ b/client/src/app/core/plugin-ui/media-action-registry.ts
@@ -1,0 +1,53 @@
+/**
+ * Closed catalogue of `media.actions` actionIds core implements. A plugin's
+ * contribution to this slot may only reference one of these — it never ships
+ * its own handler (per the plan's "no plugin ships Angular" rule).
+ */
+export type CoreMediaActionId =
+  | 'media.recommend'
+  | 'media.toggle-series-watched'
+  | 'media.open-tracking'
+  | 'media.request'
+  | 'media.grab-best'
+  | 'media.search-releases'
+  | 'media.edit-profiles'
+  | 'media.edit-library'
+  | 'media.edit-subtitles'
+  | 'media.refresh-metadata'
+  | 'media.analyze'
+  | 'media.toggle-monitored'
+  | 'media.delete'
+  | 'media.request-deletion';
+
+const CORE_MEDIA_ACTION_IDS: ReadonlySet<string> = new Set<CoreMediaActionId>([
+  'media.recommend',
+  'media.toggle-series-watched',
+  'media.open-tracking',
+  'media.request',
+  'media.grab-best',
+  'media.search-releases',
+  'media.edit-profiles',
+  'media.edit-library',
+  'media.edit-subtitles',
+  'media.refresh-metadata',
+  'media.analyze',
+  'media.toggle-monitored',
+  'media.delete',
+  'media.request-deletion',
+]);
+
+/** One concrete handler per core actionId, supplied by whatever component owns the click. */
+export type MediaActionHandlers = Record<CoreMediaActionId, () => void>;
+
+/**
+ * Resolves a contribution's `actionId` to the handler that implements it.
+ * Anything outside the closed catalogue — a typo, a future id, a plugin
+ * guessing — returns `null`. Fail closed: the caller must render no row at
+ * all, never a button whose click silently does nothing.
+ */
+export function resolveMediaAction(
+  actionId: string,
+  handlers: MediaActionHandlers,
+): (() => void) | null {
+  return CORE_MEDIA_ACTION_IDS.has(actionId) ? handlers[actionId as CoreMediaActionId] : null;
+}

--- a/client/src/app/shared/components/media-info-header/core-media-actions.ts
+++ b/client/src/app/shared/components/media-info-header/core-media-actions.ts
@@ -1,0 +1,153 @@
+import type { UiContribution } from '../../../core/plugin-ui/contribution.types';
+
+/**
+ * Core's own `media.actions` items, expressed as contributions so they merge
+ * with plugin contributions through the same weight/id sort instead of being
+ * a fixed sequence of `@if` blocks. `when` encodes every part of the
+ * pre-refactor gate that the closed vocabulary can express; the handful that
+ * can't (an OR, or a fact that isn't a permission) stay as an extra guard in
+ * `media-info-header.ts`, documented there.
+ *
+ * Two rows (`core.mark_series_watched`, `core.toggle_monitored`) toggle their
+ * own label/icon by live state — cosmetic, so the swap lives in the
+ * component's `displayLabelKey`/`displayIcon`, not here.
+ */
+export const CORE_MEDIA_ACTIONS: readonly UiContribution[] = [
+  {
+    id: 'core.recommend',
+    slot: 'media.actions',
+    weight: 100,
+    labelKey: 'recommend.menu_item',
+    icon: 'user-plus',
+    when: ['!isTv'],
+    action: { kind: 'action', actionId: 'media.recommend' },
+  },
+  {
+    id: 'core.mark_series_watched',
+    slot: 'media.actions',
+    weight: 200,
+    labelKey: 'media_detail.mark_series_watched',
+    icon: 'check',
+    when: ['mediaType:series', '!isEpisode'],
+    action: { kind: 'action', actionId: 'media.toggle-series-watched' },
+  },
+  {
+    id: 'core.tracking',
+    slot: 'media.actions',
+    weight: 300,
+    labelKey: 'tracking.menu_item',
+    icon: 'list-checks',
+    when: ['isMonitored'],
+    action: { kind: 'action', actionId: 'media.open-tracking' },
+  },
+  {
+    id: 'core.request_media',
+    slot: 'media.actions',
+    weight: 400,
+    labelKey: 'media_detail.request_media',
+    icon: 'clipboard-list',
+    when: ['hasPermission:requests.create', '!hasPermission:media.create'],
+    action: { kind: 'action', actionId: 'media.request' },
+  },
+  {
+    id: 'core.grab_best',
+    slot: 'media.actions',
+    weight: 500,
+    labelKey: 'media_detail.grab_best',
+    icon: 'download',
+    when: ['hasPermission:media.grab', '!mediaType:series', 'hasQualityProfile'],
+    action: { kind: 'action', actionId: 'media.grab-best' },
+  },
+  {
+    id: 'core.search_releases',
+    slot: 'media.actions',
+    weight: 600,
+    labelKey: 'media_detail.search_releases',
+    icon: 'search',
+    when: ['hasPermission:media.grab', '!mediaType:series', 'hasQualityProfile'],
+    action: { kind: 'action', actionId: 'media.search-releases' },
+  },
+  {
+    // `!isEpisode`: profile/library assignment is title-level, not
+    // per-episode — the pre-refactor episode header never bound
+    // `canEditProfiles` at all (always false), for the same reason.
+    id: 'core.edit_profiles',
+    slot: 'media.actions',
+    weight: 700,
+    labelKey: 'media_detail.edit_profiles',
+    icon: 'settings',
+    when: ['hasPermission:media.edit', '!isEpisode'],
+    action: { kind: 'action', actionId: 'media.edit-profiles' },
+  },
+  {
+    id: 'core.edit_library',
+    slot: 'media.actions',
+    weight: 800,
+    labelKey: 'media_detail.edit_library',
+    icon: 'folder',
+    when: ['hasPermission:media.edit', '!isEpisode'],
+    action: { kind: 'action', actionId: 'media.edit-library' },
+  },
+  {
+    id: 'core.edit_subtitles',
+    slot: 'media.actions',
+    weight: 900,
+    labelKey: 'media_detail.edit_subtitles',
+    icon: 'captions',
+    // Original gate is `mediaType:movie OR isEpisode` — an OR, so it can't
+    // live in `when` (a flat AND-list). Full guard in media-info-header.ts.
+    action: { kind: 'action', actionId: 'media.edit-subtitles' },
+  },
+  {
+    id: 'core.refresh_metadata',
+    slot: 'media.actions',
+    weight: 1000,
+    labelKey: 'media_detail.refresh_metadata',
+    icon: 'rotate-ccw',
+    when: ['isAdmin'],
+    action: { kind: 'action', actionId: 'media.refresh-metadata' },
+  },
+  {
+    id: 'core.analyze',
+    slot: 'media.actions',
+    weight: 1100,
+    labelKey: 'media_detail.analyze',
+    icon: 'scan-line',
+    when: ['isAdmin'],
+    action: { kind: 'action', actionId: 'media.analyze' },
+  },
+  {
+    id: 'core.toggle_monitored',
+    slot: 'media.actions',
+    weight: 1200,
+    labelKey: 'media_detail.monitor',
+    icon: 'eye',
+    when: ['isAdmin'],
+    action: { kind: 'action', actionId: 'media.toggle-monitored' },
+  },
+  {
+    id: 'core.delete',
+    slot: 'media.actions',
+    weight: 1300,
+    labelKey: 'media_detail.delete_from_library',
+    icon: 'trash-2',
+    tone: 'danger',
+    confirmKey: 'media_detail.confirm_delete',
+    when: ['hasPermission:media.delete'],
+    action: { kind: 'action', actionId: 'media.delete' },
+  },
+  {
+    id: 'core.request_deletion',
+    slot: 'media.actions',
+    weight: 1400,
+    labelKey: 'media_detail.request_deletion',
+    icon: 'trash-2',
+    tone: 'danger',
+    confirmKey: 'media_detail.request_deletion_confirm',
+    // The pre-refactor gate is the single `canRequestDeletion` input, already
+    // `requests.create && !media.delete && !<a deletion request is already
+    // pending>` — pending is per-title async state, not a permission, so it
+    // can't be a `when` predicate. Full guard in media-info-header.ts.
+    action: { kind: 'action', actionId: 'media.request-deletion' },
+  },
+];

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -500,101 +500,59 @@
   }
 </ng-template>
 
-<!-- Items projected into both mobile + desktop dropdown-menus. -->
+<!-- Items projected into both mobile + desktop dropdown-menus. Rendered from
+     the `media.actions` contribution registry: core's own list merged with
+     any plugin contributions, sorted by weight then id, `when`-filtered. -->
 <ng-template #moreMenuItems>
-  @if (!tv.isTv() && !auth.sharingDisabled()) {
-    <button type="button" class="dropdown-item text-white" (click)="recommend.emit()">
-      <svg lucideUserPlus class="h-5 w-5 shrink-0 opacity-80"></svg>
-      <span class="flex-1">{{ 'recommend.menu_item' | translate }}</span>
-    </button>
-  }
-  @if (mediaType() === 'series' && !episodeId()) {
-    <button type="button" class="dropdown-item text-white" (click)="onToggleWatched()">
-      <svg lucideCheck class="h-5 w-5 shrink-0 opacity-80" [class.text-success]="watched()"></svg>
-      <span class="flex-1">{{ (watched() ? 'media_detail.mark_series_unwatched' : 'media_detail.mark_series_watched') | translate }}</span>
-    </button>
-  }
-  @if (monitored()) {
-    <button type="button" class="dropdown-item text-white" (click)="openTracking.emit()">
-      <svg lucideListChecks class="h-5 w-5 shrink-0 opacity-80"></svg>
-      <span class="flex-1">{{ 'tracking.menu_item' | translate }}</span>
-    </button>
-  }
-  <!-- Grab + Search releases are per-unit (movie or single episode). Hide
-       on the series-level header — the user picks a specific episode
-       from the seasons grid first, which renders its own header with
-       `mediaType` defaulting to 'movie'. Also gated on `qualityProfileName`
-       because the back-end refuses both actions without a quality profile;
-       surfacing greyed-out buttons that only ever throw an error toast is
-       worse than hiding them entirely until a profile is assigned. -->
-  <!-- Regular requester: surface a Demander entry when the unit isn't
-       downloaded yet AND the viewer doesn't already have an active
-       request that would cover it. Skipped for admins (canGrab takes
-       over below). The series-root case targets the whole series;
-       per-season requests live in media-detail-seasons. -->
-  @if (canRequest() && !userHasOpenWholeRequest()) {
-    @let needsFile = mediaType() === 'movie' || episodeId();
-    @if (!needsFile || !selectedFileId()) {
-      <button type="button" class="dropdown-item text-white" (click)="requestMedia.emit()">
-        <svg lucideClipboardList class="h-5 w-5 shrink-0 opacity-80"></svg>
-        <span class="flex-1">{{ 'media_detail.request_media' | translate }}</span>
+  @for (item of menuItems(); track item.id) {
+    @if (item.route) {
+      <a
+        [routerLink]="item.route"
+        class="dropdown-item"
+        [class.text-error]="item.tone === 'danger'"
+        [class.text-white]="item.tone !== 'danger'"
+      >
+        <ng-container *ngTemplateOutlet="menuItemIcon; context: { item }"></ng-container>
+        <span class="flex-1">{{ displayLabelKey(item) | translate }}</span>
+      </a>
+    } @else {
+      <button
+        type="button"
+        [disabled]="isItemDisabled(item)"
+        class="dropdown-item"
+        [class.text-error]="item.tone === 'danger'"
+        [class.text-white]="item.tone !== 'danger'"
+        (click)="item.handler!()"
+      >
+        @if (isItemBusy(item)) {
+          <span class="loading loading-spinner loading-sm"></span>
+        } @else {
+          <ng-container *ngTemplateOutlet="menuItemIcon; context: { item }"></ng-container>
+        }
+        <span class="flex-1">{{ displayLabelKey(item) | translate }}</span>
       </button>
     }
   }
-  @if (canGrab() && mediaType() !== 'series' && qualityProfileName()) {
-    <button type="button" [disabled]="grabBusy() !== null" class="dropdown-item text-white" (click)="grabBest.emit()">
-      @if (grabBusy() === 'best') { <span class="loading loading-spinner loading-sm"></span> }
-      @else { <svg lucideDownload class="h-5 w-5 shrink-0 opacity-80"></svg> }
-      <span class="flex-1">{{ 'media_detail.grab_best' | translate }}</span>
-    </button>
-    <button type="button" class="dropdown-item text-white" (click)="loadReleases.emit()">
-      @if (releasesLoading()) { <span class="loading loading-spinner loading-sm"></span> }
-      @else { <svg lucideSearch class="h-5 w-5 shrink-0 opacity-80"></svg> }
-      <span class="flex-1">{{ 'media_detail.search_releases' | translate }}</span>
-    </button>
-  }
-  @if (canEditProfiles()) {
-    <button type="button" class="dropdown-item text-white" (click)="openProfiles.emit()">
-      <svg lucideSettings class="h-5 w-5 shrink-0 opacity-80"></svg>
-      <span class="flex-1">{{ 'media_detail.edit_profiles' | translate }}</span>
-    </button>
-    <button type="button" class="dropdown-item text-white" (click)="openLibrary.emit()">
-      <svg lucideFolder class="h-5 w-5 shrink-0 opacity-80"></svg>
-      <span class="flex-1">{{ 'media_detail.edit_library' | translate }}</span>
-    </button>
-  }
-  @if (mediaType() === 'movie' || episodeId()) {
-    <button type="button" class="dropdown-item text-white" (click)="editSubtitles.emit()">
-      <svg lucideCaptions class="h-5 w-5 shrink-0 opacity-80"></svg>
-      <span class="flex-1">{{ 'media_detail.edit_subtitles' | translate }}</span>
-    </button>
-  }
-  @if (isAdmin()) {
-    <button type="button" class="dropdown-item text-white" (click)="refreshMetadata.emit()">
-      <svg lucideRotateCcw class="h-5 w-5 shrink-0 opacity-80"></svg>
-      <span class="flex-1">{{ 'media_detail.refresh_metadata' | translate }}</span>
-    </button>
-    <button type="button" class="dropdown-item text-white" (click)="openAnalyze.emit()">
-      <svg lucideScanLine class="h-5 w-5 shrink-0 opacity-80"></svg>
-      <span class="flex-1">{{ 'media_detail.analyze' | translate }}</span>
-    </button>
-    <button type="button" [disabled]="monitoredLoading()" class="dropdown-item text-white" (click)="toggleMonitored.emit()">
-      @if (monitored()) { <svg lucideEyeOff class="h-5 w-5 shrink-0 opacity-80"></svg> }
-      @else { <svg lucideEye class="h-5 w-5 shrink-0 opacity-80"></svg> }
-      <span class="flex-1">{{ (monitored() ? 'media_detail.unmonitor' : 'media_detail.monitor') | translate }}</span>
-    </button>
-  }
-  @if (canDelete()) {
-    <button type="button" [disabled]="deleteLoading()" class="dropdown-item text-error" (click)="deleteMedia.emit()">
-      @if (deleteLoading()) { <span class="loading loading-spinner loading-sm"></span> }
-      @else { <svg lucideTrash2 class="h-5 w-5 shrink-0"></svg> }
-      <span class="flex-1">{{ 'media_detail.delete_from_library' | translate }}</span>
-    </button>
-  }
-  @if (canRequestDeletion()) {
-    <button type="button" class="dropdown-item text-error" (click)="requestDeletion.emit()">
-      <svg lucideTrash2 class="h-5 w-5 shrink-0"></svg>
-      <span class="flex-1">{{ 'media_detail.request_deletion' | translate }}</span>
-    </button>
+</ng-template>
+
+<!-- Icon by name, with a danger-tone accent kept as-is from the pre-refactor
+     markup. Unrecognised name → generic glyph, never blank. -->
+<ng-template #menuItemIcon let-item="item">
+  @switch (displayIcon(item)) {
+    @case ('user-plus') { <svg lucideUserPlus class="h-5 w-5 shrink-0 opacity-80"></svg> }
+    @case ('check') { <svg lucideCheck class="h-5 w-5 shrink-0 opacity-80" [class.text-success]="item.actionId === 'media.toggle-series-watched' && watched()"></svg> }
+    @case ('list-checks') { <svg lucideListChecks class="h-5 w-5 shrink-0 opacity-80"></svg> }
+    @case ('clipboard-list') { <svg lucideClipboardList class="h-5 w-5 shrink-0 opacity-80"></svg> }
+    @case ('download') { <svg lucideDownload class="h-5 w-5 shrink-0 opacity-80"></svg> }
+    @case ('search') { <svg lucideSearch class="h-5 w-5 shrink-0 opacity-80"></svg> }
+    @case ('settings') { <svg lucideSettings class="h-5 w-5 shrink-0 opacity-80"></svg> }
+    @case ('folder') { <svg lucideFolder class="h-5 w-5 shrink-0 opacity-80"></svg> }
+    @case ('captions') { <svg lucideCaptions class="h-5 w-5 shrink-0 opacity-80"></svg> }
+    @case ('rotate-ccw') { <svg lucideRotateCcw class="h-5 w-5 shrink-0 opacity-80"></svg> }
+    @case ('scan-line') { <svg lucideScanLine class="h-5 w-5 shrink-0 opacity-80"></svg> }
+    @case ('eye') { <svg lucideEye class="h-5 w-5 shrink-0 opacity-80"></svg> }
+    @case ('eye-off') { <svg lucideEyeOff class="h-5 w-5 shrink-0 opacity-80"></svg> }
+    @case ('trash-2') { <svg lucideTrash2 class="h-5 w-5 shrink-0"></svg> }
+    @default { <svg lucideCircle class="h-5 w-5 shrink-0 opacity-80"></svg> }
   }
 </ng-template>

--- a/client/src/app/shared/components/media-info-header/media-info-header.spec.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.spec.ts
@@ -1,0 +1,547 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { MediaInfoHeaderComponent } from './media-info-header';
+import { AuthService } from '../../../core/services/auth.service';
+import { TvService } from '../../../core/services/tv.service';
+import { DeviceService } from '../../../core/services/device.service';
+import { NavbarService } from '../../../core/services/navbar.service';
+import { PlayerSettingsService } from '../../../core/services/player-settings.service';
+import { TrackManagerService } from '../../../core/services/track-manager.service';
+import { PlayableMediaService } from '../../../core/services/playable-media.service';
+import { StreamingApiService } from '../../../core/services/api/streaming-api.service';
+import { PluginUiRegistryService } from '../../../core/plugin-ui/plugin-ui-registry.service';
+import type { SlotId, UiContribution } from '../../../core/plugin-ui/contribution.types';
+
+/**
+ * Permission-matrix + characterisation test for the `media.actions` kebab
+ * menu. Written once, run unchanged before AND after the registry refactor
+ * (PR 5.4) — see the plan's PR 5.4 acceptance criteria. `when` is
+ * presentation only: every action behind these items stays CASL-guarded
+ * server-side, so a bypassed predicate here is a cosmetic bug, never an
+ * authorization one — but a WRONG one still offers a destructive action to
+ * the wrong viewer's eyes, which is what this file exists to catch.
+ */
+
+// ── Role model: mirrors backend/src/common/constants/permissions.ts ──
+
+interface Role {
+  isAdmin: boolean;
+  permissions: string[];
+}
+
+function hasPerm(role: Role, perm: string): boolean {
+  return role.isAdmin || role.permissions.includes(perm);
+}
+
+const OWNER: Role = { isAdmin: true, permissions: [] };
+const READER: Role = { isAdmin: false, permissions: ['media.read'] };
+const REQUESTER: Role = { isAdmin: false, permissions: ['media.read', 'requests.create'] };
+const GRABBER: Role = { isAdmin: false, permissions: ['media.grab'] };
+const DELETER: Role = { isAdmin: false, permissions: ['media.delete'] };
+
+/** Reproduces media-detail.ts's own derivations (media-detail.ts:648-668) so the
+ *  fixture feeds the header exactly what the real smart component would. */
+function deriveInputs(role: Role, opts: { deleteRequestPending?: boolean } = {}) {
+  const pending = opts.deleteRequestPending ?? false;
+  return {
+    canGrab: hasPerm(role, 'media.grab'),
+    canEditProfiles: hasPerm(role, 'media.edit'),
+    canDelete: hasPerm(role, 'media.delete'),
+    isAdmin: hasPerm(role, 'settings.access'),
+    canRequest: hasPerm(role, 'requests.create') && !hasPerm(role, 'media.create'),
+    canRequestDeletion: hasPerm(role, 'requests.create') && !hasPerm(role, 'media.delete') && !pending,
+  };
+}
+
+// ── Fixture / rendering plumbing ──
+
+interface MediaFixture {
+  mediaType: 'movie' | 'series';
+  episodeId?: number;
+  selectedFileId: number | null;
+  monitored: boolean;
+  qualityProfileName: string | null;
+  userHasOpenWholeRequest?: boolean;
+  sharingDisabled?: boolean;
+  isTv?: boolean;
+  watched?: boolean;
+  grabBusy?: string | null;
+  releasesLoading?: boolean;
+  monitoredLoading?: boolean;
+  deleteLoading?: boolean;
+  registry?: Partial<Record<SlotId, UiContribution[]>>;
+  /** Mirrors the episode-level header instance in media-detail.html, which never
+   *  binds `canEditProfiles`/`canRequestDeletion` at all (left at their `false`
+   *  default) — profile/library editing and deletion requests don't exist at
+   *  per-episode granularity. When true, those two inputs are left unset here too. */
+  episodeInstance?: boolean;
+}
+
+async function createFixture(
+  role: Role,
+  media: MediaFixture,
+  opts: { deleteRequestPending?: boolean } = {},
+): Promise<ComponentFixture<MediaInfoHeaderComponent>> {
+  const derived = deriveInputs(role, opts);
+  const watched = media.watched ?? false;
+
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      provideRouter([]),
+      provideTranslateService({
+        lang: 'en',
+        loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+      }),
+      {
+        provide: AuthService,
+        useValue: {
+          hasPermission: (p: string) => hasPerm(role, p),
+          sharingDisabled: () => !!media.sharingDisabled,
+        },
+      },
+      { provide: TvService, useValue: { isTv: () => !!media.isTv } },
+      {
+        provide: DeviceService,
+        useValue: {
+          isDesktop: () => true,
+          isTablet: () => false,
+          isPhone: () => false,
+          isTv: () => !!media.isTv,
+          isTouch: () => false,
+        },
+      },
+      {
+        provide: NavbarService,
+        useValue: {
+          canGoBack: () => false,
+          navbarTransparent: () => false,
+          heroLogoUrl: () => null,
+          heroTitle: () => '',
+          isHeroPage: () => false,
+          showBackButton: () => false,
+          mobileNavTitle: () => '',
+          mobileNavbarVisible: () => true,
+          effectiveSidebarPinned: () => false,
+          sidebarPinned: () => false,
+          toggleSidebarPinned: () => {},
+          scrollAtTop: { set: () => {} },
+          setPageTitle: () => {},
+          resetNavHistory: () => {},
+          goBack: () => {},
+          lastWasBack: () => false,
+        },
+      },
+      {
+        provide: PlayerSettingsService,
+        useValue: { resolveAudioStreamIndex: () => null, getRememberedSubtitleTrack: () => null },
+      },
+      { provide: TrackManagerService, useValue: { saveAudioSelection: () => {}, saveSubtitleSelection: () => {} } },
+      { provide: PlayableMediaService, useValue: { loadWatchedState: () => Promise.resolve(watched) } },
+      { provide: StreamingApiService, useValue: { getPlaybackState: () => Promise.resolve(null) } },
+      {
+        provide: PluginUiRegistryService,
+        useValue: { contributionsFor: (slot: SlotId) => media.registry?.[slot] ?? [] },
+      },
+    ],
+  });
+
+  const fixture = TestBed.createComponent(MediaInfoHeaderComponent);
+  fixture.componentRef.setInput('title', 'Test title');
+  fixture.componentRef.setInput('mediaId', 1);
+  fixture.componentRef.setInput('mediaType', media.mediaType);
+  fixture.componentRef.setInput('episodeId', media.episodeId);
+  fixture.componentRef.setInput('selectedFileId', media.selectedFileId);
+  fixture.componentRef.setInput('monitored', media.monitored);
+  fixture.componentRef.setInput('qualityProfileName', media.qualityProfileName);
+  // Series-root watched state comes from `seriesFullyWatched`, not the playback-state
+  // fetch — the component reads it directly when there's no episode context.
+  fixture.componentRef.setInput('seriesFullyWatched', watched);
+  fixture.componentRef.setInput('canGrab', derived.canGrab);
+  fixture.componentRef.setInput('canDelete', derived.canDelete);
+  fixture.componentRef.setInput('isAdmin', derived.isAdmin);
+  fixture.componentRef.setInput('canRequest', derived.canRequest);
+  if (!media.episodeInstance) {
+    fixture.componentRef.setInput('canEditProfiles', derived.canEditProfiles);
+    fixture.componentRef.setInput('canRequestDeletion', derived.canRequestDeletion);
+  }
+  fixture.componentRef.setInput('userHasOpenWholeRequest', !!media.userHasOpenWholeRequest);
+  fixture.componentRef.setInput('grabBusy', media.grabBusy ?? null);
+  fixture.componentRef.setInput('releasesLoading', !!media.releasesLoading);
+  fixture.componentRef.setInput('monitoredLoading', !!media.monitoredLoading);
+  fixture.componentRef.setInput('deleteLoading', !!media.deleteLoading);
+
+  fixture.detectChanges();
+  await fixture.whenStable();
+  fixture.detectChanges();
+  return fixture;
+}
+
+interface CapturedItem {
+  label: string;
+  icon: string | null;
+  danger: boolean;
+  disabled: boolean;
+}
+
+function readItem(el: Element): CapturedItem {
+  const svg = el.querySelector('svg');
+  const icon = svg
+    ? (Array.from(svg.attributes).map((a) => a.name).find((n) => n.startsWith('lucide')) ?? null)
+    : null;
+  const labelHost = el.querySelector(':scope > span:not(.badge)') ?? el;
+  return {
+    label: (labelHost.textContent ?? '').trim(),
+    icon,
+    danger: el.classList.contains('text-error'),
+    disabled: (el as HTMLButtonElement).disabled === true,
+  };
+}
+
+/** Scoped to the desktop layout's dropdown — mobile renders an identical
+ *  second copy of the same `moreMenuItems` template via its own outlet. */
+function menuItems(root: HTMLElement): CapturedItem[] {
+  const desktopMenu = root.querySelectorAll('app-dropdown-menu')[1];
+  if (!desktopMenu) return [];
+  return Array.from(desktopMenu.querySelectorAll('.dropdown-item')).map(readItem);
+}
+
+function labels(root: HTMLElement): string[] {
+  return menuItems(root).map((i) => i.label);
+}
+
+// ── The permission matrix ──
+//
+// Every row lists the FULL expected item set for that role — not just
+// whether the destructive ones are absent. Baseline computed by hand from
+// the pre-refactor `media-info-header.html` (lines 504-599), independently
+// of whatever the registry refactor produces, so it doubles as the
+// pre-refactor-vs-post-refactor regression check the brief asks for.
+
+const MOVIE: Omit<MediaFixture, 'mediaType'> = {
+  selectedFileId: null,
+  monitored: true,
+  qualityProfileName: 'HD-1080p',
+};
+const SERIES: Omit<MediaFixture, 'mediaType'> = {
+  selectedFileId: null,
+  monitored: true,
+  qualityProfileName: 'HD-1080p',
+};
+
+describe('MediaInfoHeaderComponent — media.actions permission matrix', () => {
+  it('owner (isAdmin): movie root', async () => {
+    const fixture = await createFixture(OWNER, { mediaType: 'movie', ...MOVIE });
+    expect(labels(fixture.nativeElement)).toEqual([
+      'recommend.menu_item',
+      'tracking.menu_item',
+      'media_detail.grab_best',
+      'media_detail.search_releases',
+      'media_detail.edit_profiles',
+      'media_detail.edit_library',
+      'media_detail.edit_subtitles',
+      'media_detail.refresh_metadata',
+      'media_detail.analyze',
+      'media_detail.unmonitor',
+      'media_detail.delete_from_library',
+    ]);
+  });
+
+  it('owner (isAdmin): series root', async () => {
+    const fixture = await createFixture(OWNER, { mediaType: 'series', ...SERIES });
+    expect(labels(fixture.nativeElement)).toEqual([
+      'recommend.menu_item',
+      'media_detail.mark_series_watched',
+      'tracking.menu_item',
+      'media_detail.edit_profiles',
+      'media_detail.edit_library',
+      'media_detail.refresh_metadata',
+      'media_detail.analyze',
+      'media_detail.unmonitor',
+      'media_detail.delete_from_library',
+    ]);
+  });
+
+  it('media.read only: movie root', async () => {
+    const fixture = await createFixture(READER, { mediaType: 'movie', ...MOVIE });
+    expect(labels(fixture.nativeElement)).toEqual([
+      'recommend.menu_item',
+      'tracking.menu_item',
+      'media_detail.edit_subtitles',
+    ]);
+  });
+
+  it('media.read only: series root', async () => {
+    const fixture = await createFixture(READER, { mediaType: 'series', ...SERIES });
+    expect(labels(fixture.nativeElement)).toEqual([
+      'recommend.menu_item',
+      'media_detail.mark_series_watched',
+      'tracking.menu_item',
+    ]);
+  });
+
+  it('media.read + requests.create: movie root', async () => {
+    const fixture = await createFixture(REQUESTER, { mediaType: 'movie', ...MOVIE });
+    expect(labels(fixture.nativeElement)).toEqual([
+      'recommend.menu_item',
+      'tracking.menu_item',
+      'media_detail.request_media',
+      'media_detail.edit_subtitles',
+      'media_detail.request_deletion',
+    ]);
+  });
+
+  it('media.read + requests.create: series root', async () => {
+    const fixture = await createFixture(REQUESTER, { mediaType: 'series', ...SERIES });
+    expect(labels(fixture.nativeElement)).toEqual([
+      'recommend.menu_item',
+      'media_detail.mark_series_watched',
+      'tracking.menu_item',
+      'media_detail.request_media',
+      'media_detail.request_deletion',
+    ]);
+  });
+
+  it('media.grab: movie root', async () => {
+    const fixture = await createFixture(GRABBER, { mediaType: 'movie', ...MOVIE });
+    expect(labels(fixture.nativeElement)).toEqual([
+      'recommend.menu_item',
+      'tracking.menu_item',
+      'media_detail.grab_best',
+      'media_detail.search_releases',
+      'media_detail.edit_subtitles',
+    ]);
+  });
+
+  it('media.grab: series root — grab/search are per-unit, hidden at series level despite the permission', async () => {
+    const fixture = await createFixture(GRABBER, { mediaType: 'series', ...SERIES });
+    expect(labels(fixture.nativeElement)).toEqual([
+      'recommend.menu_item',
+      'media_detail.mark_series_watched',
+      'tracking.menu_item',
+    ]);
+  });
+
+  it('media.delete: movie root', async () => {
+    const fixture = await createFixture(DELETER, { mediaType: 'movie', ...MOVIE });
+    expect(labels(fixture.nativeElement)).toEqual([
+      'recommend.menu_item',
+      'tracking.menu_item',
+      'media_detail.edit_subtitles',
+      'media_detail.delete_from_library',
+    ]);
+  });
+
+  it('media.delete: series root', async () => {
+    const fixture = await createFixture(DELETER, { mediaType: 'series', ...SERIES });
+    expect(labels(fixture.nativeElement)).toEqual([
+      'recommend.menu_item',
+      'media_detail.mark_series_watched',
+      'tracking.menu_item',
+      'media_detail.delete_from_library',
+    ]);
+  });
+});
+
+// ── Destructive items keep their styling, and stay gone once request state changes ──
+
+describe('MediaInfoHeaderComponent — destructive-item styling and ephemeral guards', () => {
+  it('Delete and Request deletion render with danger styling; nothing else does', async () => {
+    const fixture = await createFixture(OWNER, { mediaType: 'movie', ...MOVIE });
+    const items = menuItems(fixture.nativeElement);
+    const dangerLabels = items.filter((i) => i.danger).map((i) => i.label);
+    expect(dangerLabels).toEqual(['media_detail.delete_from_library']);
+
+    const requester = await createFixture(REQUESTER, { mediaType: 'movie', ...MOVIE });
+    const requesterDanger = menuItems(requester.nativeElement).filter((i) => i.danger).map((i) => i.label);
+    expect(requesterDanger).toEqual(['media_detail.request_deletion']);
+  });
+
+  it('a pending deletion request hides Request deletion even though the permission still holds', async () => {
+    const fixture = await createFixture(
+      REQUESTER,
+      { mediaType: 'movie', ...MOVIE },
+      { deleteRequestPending: true },
+    );
+    expect(labels(fixture.nativeElement)).not.toContain('media_detail.request_deletion');
+  });
+
+  it('an existing whole-title request hides Request media even though the permission still holds', async () => {
+    const fixture = await createFixture(REQUESTER, {
+      mediaType: 'movie',
+      ...MOVIE,
+      userHasOpenWholeRequest: true,
+    });
+    expect(labels(fixture.nativeElement)).not.toContain('media_detail.request_media');
+  });
+
+  it('a movie that already has a file hides Request media (nothing left to request)', async () => {
+    const fixture = await createFixture(REQUESTER, { mediaType: 'movie', ...MOVIE, selectedFileId: 42 });
+    expect(labels(fixture.nativeElement)).not.toContain('media_detail.request_media');
+  });
+
+  it('a series root still offers Request media even with files present — partial availability is requestable', async () => {
+    const fixture = await createFixture(REQUESTER, { mediaType: 'series', ...SERIES, selectedFileId: 42 });
+    expect(labels(fixture.nativeElement)).toContain('media_detail.request_media');
+  });
+
+  it('sharing-disabled hides Recommend for every role, including the owner', async () => {
+    const fixture = await createFixture(OWNER, { mediaType: 'movie', ...MOVIE, sharingDisabled: true });
+    expect(labels(fixture.nativeElement)).not.toContain('recommend.menu_item');
+  });
+
+  it('TV form factor hides Recommend for every role, including the owner', async () => {
+    const fixture = await createFixture(OWNER, { mediaType: 'movie', ...MOVIE, isTv: true });
+    expect(labels(fixture.nativeElement)).not.toContain('recommend.menu_item');
+  });
+
+  it('an episode-level header hides Edit profiles/library and Request deletion for an owner — the parent never binds those inputs there, regardless of permission', async () => {
+    const fixture = await createFixture(OWNER, {
+      mediaType: 'movie',
+      ...MOVIE,
+      episodeId: 999,
+      episodeInstance: true,
+    });
+    const shown = labels(fixture.nativeElement);
+    expect(shown).not.toContain('media_detail.edit_profiles');
+    expect(shown).not.toContain('media_detail.edit_library');
+    expect(shown).not.toContain('media_detail.request_deletion');
+    // isAdmin-gated items ARE bound per-episode and must still show.
+    expect(shown).toContain('media_detail.refresh_metadata');
+    expect(shown).toContain('media_detail.analyze');
+    expect(shown).toContain('media_detail.delete_from_library');
+  });
+
+  it('the series-watched toggle swaps its label with the live watched state', async () => {
+    const unwatched = await createFixture(OWNER, { mediaType: 'series', ...SERIES, watched: false });
+    expect(labels(unwatched.nativeElement)).toContain('media_detail.mark_series_watched');
+
+    const watched = await createFixture(OWNER, { mediaType: 'series', ...SERIES, watched: true });
+    expect(labels(watched.nativeElement)).toContain('media_detail.mark_series_unwatched');
+  });
+});
+
+// ── New in this PR: merging with plugin contributions. Meaningless before the
+// registry existed, so these are additions, not part of the characterisation set above.
+
+describe('MediaInfoHeaderComponent — media.actions merges with plugin contributions', () => {
+  it('sorts a plugin item into position by weight, between two core items', async () => {
+    const fixture = await createFixture(OWNER, {
+      mediaType: 'movie',
+      ...MOVIE,
+      registry: {
+        'media.actions': [
+          {
+            id: 'fliks.acme.between',
+            slot: 'media.actions',
+            weight: 150,
+            labelKey: 'x.between',
+            action: { kind: 'route', path: '/plugins/acme/between' },
+          },
+        ],
+      },
+    });
+    const shown = labels(fixture.nativeElement);
+    expect(shown.indexOf('recommend.menu_item')).toBe(0);
+    expect(shown.indexOf('x.between')).toBe(1);
+    expect(shown.indexOf('tracking.menu_item')).toBeGreaterThan(1);
+  });
+
+  it('an unrecognised icon renders the generic glyph, never blank', async () => {
+    const fixture = await createFixture(OWNER, {
+      mediaType: 'movie',
+      ...MOVIE,
+      registry: {
+        'media.actions': [
+          {
+            id: 'fliks.acme.weird-icon',
+            slot: 'media.actions',
+            weight: 150,
+            labelKey: 'x.weird',
+            icon: 'not-a-real-lucide-name',
+            action: { kind: 'route', path: '/plugins/acme/weird' },
+          },
+        ],
+      },
+    });
+    const item = menuItems(fixture.nativeElement).find((i) => i.label === 'x.weird');
+    expect(item?.icon).toBe('lucideCircle');
+  });
+
+  it('VERDICT: an unknown actionId renders no row — fail closed, not a dead click', async () => {
+    const fixture = await createFixture(OWNER, {
+      mediaType: 'movie',
+      ...MOVIE,
+      registry: {
+        'media.actions': [
+          {
+            id: 'fliks.acme.bogus-action',
+            slot: 'media.actions',
+            weight: 150,
+            labelKey: 'x.bogus',
+            action: { kind: 'action', actionId: 'media.something-invented' },
+          },
+        ],
+      },
+    });
+    expect(labels(fixture.nativeElement)).not.toContain('x.bogus');
+  });
+
+  it('VERDICT: an unrecognised action.kind renders no row', async () => {
+    const fixture = await createFixture(OWNER, {
+      mediaType: 'movie',
+      ...MOVIE,
+      registry: {
+        'media.actions': [
+          { id: 'fliks.acme.broken', slot: 'media.actions', weight: 150, labelKey: 'x.broken', action: { kind: 'bogus' } as never },
+        ],
+      },
+    });
+    expect(labels(fixture.nativeElement)).not.toContain('x.broken');
+  });
+
+  it('a plugin can reuse a core actionId (its handler), but must bring its own `when` — core\'s `when` is per-contribution, not per-actionId', async () => {
+    const gatedRegistry = {
+      'media.actions': [
+        {
+          id: 'fliks.acme.delete-alias',
+          slot: 'media.actions' as const,
+          weight: 150,
+          labelKey: 'x.delete_alias',
+          when: ['hasPermission:media.delete' as const],
+          action: { kind: 'action' as const, actionId: 'media.delete' },
+        },
+      ],
+    };
+    const reader = await createFixture(READER, { mediaType: 'movie', ...MOVIE, registry: gatedRegistry });
+    expect(labels(reader.nativeElement)).not.toContain('x.delete_alias');
+
+    const deleter = await createFixture(DELETER, { mediaType: 'movie', ...MOVIE, registry: gatedRegistry });
+    expect(labels(deleter.nativeElement)).toContain('x.delete_alias');
+  });
+
+  it('a plugin cannot widen a core action: an alias with no `when` stays hidden from a role core hides it from', async () => {
+    // The alias reuses core's Delete handler, so it must clear core's own gate too —
+    // otherwise a plugin could surface core's destructive action to anyone.
+    const wideOpen = {
+      'media.actions': [
+        {
+          id: 'fliks.acme.delete-wide',
+          slot: 'media.actions' as const,
+          weight: 150,
+          labelKey: 'x.delete_wide',
+          action: { kind: 'action' as const, actionId: 'media.delete' },
+        },
+      ],
+    };
+    const reader = await createFixture(READER, { mediaType: 'movie', ...MOVIE, registry: wideOpen });
+    expect(labels(reader.nativeElement)).not.toContain('x.delete_wide');
+
+    const deleter = await createFixture(DELETER, { mediaType: 'movie', ...MOVIE, registry: wideOpen });
+    expect(labels(deleter.nativeElement)).toContain('x.delete_wide');
+  });
+});

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -15,6 +15,7 @@ import { FormsModule } from '@angular/forms';
 import {
   LucideCaptions,
   LucideCheck,
+  LucideCircle,
   LucideClipboardList,
   LucideDownload,
   LucideEllipsisVertical,
@@ -39,6 +40,7 @@ import { PlayerSettingsService } from '../../../core/services/player-settings.se
 import { TrackManagerService } from '../../../core/services/track-manager.service';
 import { NavbarService } from '../../../core/services/navbar.service';
 import { TvService } from '../../../core/services/tv.service';
+import { DeviceService } from '../../../core/services/device.service';
 import { AuthService } from '../../../core/services/auth.service';
 import { MobileFanartHeroComponent } from '../mobile-fanart-hero';
 import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
@@ -56,6 +58,25 @@ import { ClampToggleDirective } from '../../directives/clamp-toggle.directive';
 import { TvRowDirective } from '../../directives/tv-row.directive';
 import { TvSelectDirective } from '../../directives/tv-select.directive';
 import { NgTemplateOutlet } from '@angular/common';
+import { PluginUiRegistryService } from '../../../core/plugin-ui/plugin-ui-registry.service';
+import { evaluateWhen, type WhenContext } from '../../../core/plugin-ui/when-evaluator';
+import type { MediaType } from '../../../core/enums/media-type.enum';
+import { resolveMediaAction, type MediaActionHandlers } from '../../../core/plugin-ui/media-action-registry';
+import { CORE_MEDIA_ACTIONS } from './core-media-actions';
+import type { UiContribution } from '../../../core/plugin-ui/contribution.types';
+
+/** One `media.actions` contribution resolved to something the template can
+ *  render directly — visibility, handler and icon fallback already decided. */
+export interface ResolvedMediaAction {
+  id: string;
+  labelKey: string;
+  icon: string;
+  tone: 'default' | 'danger';
+  confirmKey?: string;
+  actionId?: string;
+  route?: string;
+  handler: (() => void) | null;
+}
 
 export interface MediaInfoHeaderFile {
   id: number;
@@ -108,7 +129,7 @@ interface AudioTrack {
     TvSelectDirective,
     NgTemplateOutlet,
     DecimalPipe, FormsModule, RouterLink, TranslateModule,
-    LucideCaptions, LucideCheck, LucideClipboardList, LucideDownload,
+    LucideCaptions, LucideCheck, LucideCircle, LucideClipboardList, LucideDownload,
     LucideEllipsisVertical, LucideEye, LucideEyeOff,
     LucideFilm, LucideFolder, LucideHeart, LucideListChecks, LucideListPlus, LucidePlay, LucideRotateCcw, LucideScanLine,
     LucideSearch, LucideSettings, LucideTrash2, LucideUserPlus,
@@ -123,9 +144,11 @@ export class MediaInfoHeaderComponent {
   private readonly trackManager = inject(TrackManagerService);
   readonly navbar = inject(NavbarService);
   readonly tv = inject(TvService);
+  private readonly device = inject(DeviceService);
   readonly auth = inject(AuthService);
   private readonly playable = inject(PlayableMediaService);
   private readonly streamingApi = inject(StreamingApiService);
+  private readonly pluginUi = inject(PluginUiRegistryService);
 
   // ── Inputs: content ──
   readonly title = input.required<string>();
@@ -535,12 +558,140 @@ export class MediaInfoHeaderComponent {
     return `${(bytes / 1_073_741_824).toFixed(2)} GB`;
   }
 
-
-
   navigateToGenre(genre: string) {
     const library = this.libraryName();
     if (!library) return;
     void this.router.navigate(['/libraries', library], { queryParams: { genre } });
   }
 
+  // ── media.actions: the kebab menu, rendered from the contribution registry ──
+
+  private readonly mediaActionsContext = computed<WhenContext>(() => ({
+    isAdmin: this.isAdmin(),
+    hasPermission: (p: string) => this.auth.hasPermission(p),
+    mediaType: this.mediaType() as MediaType,
+    hasFiles: !!this.selectedFileId(),
+    isMonitored: this.monitored(),
+    hasQualityProfile: !!this.qualityProfileName(),
+    isEpisode: !!this.episodeId(),
+    isTv: this.tv.isTv(),
+    isTouch: this.device.isTouch(),
+  }));
+
+  /**
+   * Visibility rules the closed `when` vocabulary can't express — an OR, or a
+   * fact that isn't a permission (a sharing preference, in-flight request
+   * state). `when` already gated everything it can; this only narrows
+   * further, and only for the three ids that need it.
+   */
+  private readonly extraGuards: Record<string, () => boolean> = {
+    'core.recommend': () => !this.auth.sharingDisabled(),
+    'core.request_media': () => {
+      const needsFile = this.mediaType() === 'movie' || !!this.episodeId();
+      return !this.userHasOpenWholeRequest() && (!needsFile || !this.selectedFileId());
+    },
+    'core.edit_subtitles': () => this.mediaType() === 'movie' || !!this.episodeId(),
+    // Already `requests.create && !media.delete && !<pending>` — pending is
+    // per-title async state fetched by the parent, not a permission.
+    'core.request_deletion': () => this.canRequestDeletion(),
+  };
+
+  private readonly actionHandlers: MediaActionHandlers = {
+    'media.recommend': () => this.recommend.emit(),
+    'media.toggle-series-watched': () => this.onToggleWatched(),
+    'media.open-tracking': () => this.openTracking.emit(),
+    'media.request': () => this.requestMedia.emit(),
+    'media.grab-best': () => this.grabBest.emit(),
+    'media.search-releases': () => this.loadReleases.emit(),
+    'media.edit-profiles': () => this.openProfiles.emit(),
+    'media.edit-library': () => this.openLibrary.emit(),
+    'media.edit-subtitles': () => this.editSubtitles.emit(),
+    'media.refresh-metadata': () => this.refreshMetadata.emit(),
+    'media.analyze': () => this.openAnalyze.emit(),
+    'media.toggle-monitored': () => this.toggleMonitored.emit(),
+    'media.delete': () => this.deleteMedia.emit(),
+    'media.request-deletion': () => this.requestDeletion.emit(),
+  };
+
+  /** Core's list merged with the registry's plugin contributions, sorted by
+   *  weight then id, `when`-filtered, with the action resolved to a handler.
+   *  An unknown actionId or action.kind drops the row rather than rendering
+   *  a broken one. */
+  readonly menuItems = computed<ResolvedMediaAction[]>(() => {
+    const merged = [...CORE_MEDIA_ACTIONS, ...this.pluginUi.contributionsFor('media.actions')]
+      .sort((a, b) => a.weight - b.weight || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+    const ctx = this.mediaActionsContext();
+    const items: ResolvedMediaAction[] = [];
+    for (const c of merged) {
+      if (!evaluateWhen(c.when, ctx)) continue;
+      // Reusing a core actionId reuses core's gating too: a plugin may narrow one of
+      // core's own actions, never widen it to someone core would hide it from.
+      if (!this.passesCoreGateFor(c, ctx)) continue;
+      if (!(this.extraGuards[c.id]?.() ?? true)) continue;
+      const base = {
+        id: c.id,
+        labelKey: c.labelKey,
+        icon: c.icon ?? 'circle',
+        tone: c.tone ?? ('default' as const),
+        confirmKey: c.confirmKey,
+      };
+      if (c.action.kind === 'route') {
+        items.push({ ...base, route: c.action.path, handler: null });
+      } else if (c.action.kind === 'action') {
+        const handler = resolveMediaAction(c.action.actionId, this.actionHandlers);
+        if (!handler) continue;
+        items.push({ ...base, actionId: c.action.actionId, handler });
+      }
+      // else: unrecognised action kind — nothing rather than a broken row.
+    }
+    return items;
+  });
+
+  /** A contribution pointing at a core actionId must also clear that core item's own
+   *  `when` and extra guard, whoever declared it. */
+  private passesCoreGateFor(c: UiContribution, ctx: WhenContext): boolean {
+    if (c.action.kind !== 'action') return true;
+    const core = CORE_MEDIA_ACTIONS.find((a) => a.action.kind === 'action' && a.action.actionId === (c.action as { actionId: string }).actionId);
+    if (!core || core.id === c.id) return true;
+    return evaluateWhen(core.when, ctx) && (this.extraGuards[core.id]?.() ?? true);
+  }
+
+  /** A couple of rows swap their label by live state (watched, monitored) —
+   *  cosmetic, so the swap lives here rather than in the static contribution. */
+  displayLabelKey(item: ResolvedMediaAction): string {
+    if (item.actionId === 'media.toggle-series-watched') {
+      return this.watched() ? 'media_detail.mark_series_unwatched' : 'media_detail.mark_series_watched';
+    }
+    if (item.actionId === 'media.toggle-monitored') {
+      return this.monitored() ? 'media_detail.unmonitor' : 'media_detail.monitor';
+    }
+    return item.labelKey;
+  }
+
+  /** Same idea as {@link displayLabelKey}, for the one row whose icon shape
+   *  (not just tint) follows live state. */
+  displayIcon(item: ResolvedMediaAction): string {
+    if (item.actionId === 'media.toggle-monitored') {
+      return this.monitored() ? 'eye-off' : 'eye';
+    }
+    return item.icon;
+  }
+
+  /** Mid-request spinner, per actionId — matches the pre-refactor markup 1:1
+   *  (search-releases and request-deletion never had one; grab-best did). */
+  isItemBusy(item: ResolvedMediaAction): boolean {
+    if (item.actionId === 'media.grab-best') return this.grabBusy() === 'best';
+    if (item.actionId === 'media.search-releases') return this.releasesLoading();
+    if (item.actionId === 'media.delete') return this.deleteLoading();
+    return false;
+  }
+
+  /** Disabled state, per actionId — matches the pre-refactor markup 1:1
+   *  (search-releases and request-deletion were never disabled). */
+  isItemDisabled(item: ResolvedMediaAction): boolean {
+    if (item.actionId === 'media.grab-best') return this.grabBusy() !== null;
+    if (item.actionId === 'media.toggle-monitored') return this.monitoredLoading();
+    if (item.actionId === 'media.delete') return this.deleteLoading();
+    return false;
+  }
 }


### PR DESCRIPTION
PR 5.4 — the plan calls this the highest-risk frontend PR of the phase, because the menu contains destructive actions including Delete. So the deliverable here is the **permission matrix**, not the rendering.

## The matrix

Core's 14 items become `media.actions` contributions merged with plugin contributions, sorted by weight then id, gated by `when`. Visibility was computed by hand from the **pre-refactor** template for five roles across a movie and a series fixture, asserted, run green against the untouched component, then re-run **byte-for-byte unchanged** after the refactor:

| Role | Movie root | Series root |
|---|---|---|
| Owner | Recommend, Tracking, Grab, Search, Edit profiles, Edit library, Edit subtitles, Refresh, Analyze, Unmonitor, **Delete** | Recommend, Mark watched, Tracking, Edit profiles, Edit library, Refresh, Analyze, Unmonitor, **Delete** |
| `media.read` | Recommend, Tracking, Edit subtitles | Recommend, Mark watched, Tracking |
| `media.read` + `requests.create` | + Request media, **Request deletion** | + Request media, **Request deletion** |
| `media.grab` | + Grab, Search | *(grab/search are per-unit on series)* |
| `media.delete` | + **Delete** | + **Delete** |

Both directions are asserted: nothing a role could see before has disappeared, and nothing new has leaked in. A separate test pins the episode-level header, which never binds `canEditProfiles`/`canRequestDeletion` and therefore hides those rows even for an admin — a pre-refactor accident that is now an explicit invariant.

## A plugin may narrow a core action, never widen it

A contribution pointing at a core `actionId` reuses core's **gating** as well as its handler. Without that, a plugin could declare an alias for `media.delete` with no `when` at all and surface core's Delete row to any reader. The server would still refuse the call, so it was never an authorization hole — but the row should never have been offered, and a 403 on click is a worse answer than an absent item.

Added on review, with the test that matters: an alias carrying **no** `when` stays hidden from a reader and visible to a deleter. This is the same posture as core-wins on i18n keys (#923) and same-plugin-only policy subjects (#921) — a plugin can only ever constrain, never widen.

An unknown `actionId` drops the row entirely rather than rendering a button that silently does nothing.

## A limitation worth knowing

Four core items keep a small extra guard beside `when`, because the closed vocabulary is **AND-only** and cannot express what they need: an OR over media type (`mediaType:movie || isEpisode`), and one ephemeral fact that is not a permission. They only ever narrow further.

**A plugin has no equivalent escape hatch**, so a plugin needing an OR cannot express it today. Not fixed here: adding disjunction to a deliberately closed predicate language is the kind of generality worth deferring until something actually needs it.

## Verification

- Client suite **238 tests / 32 files green**; `ng build` exit 0 both before and after the refactor.
- No new i18n keys — all 14 items reuse existing ones.
- `media-detail.ts`/`.html` needed **zero** changes: every fact the header needs was already an input or an injected service.

**Not visually verified** — headless Chromium hangs here (#907), and this PR makes no visual claim. `when` is presentation only; every action behind these rows stays CASL-guarded server-side, so a wrong predicate is a cosmetic bug and never an authorization one.

## Note

`confirmKey` is declared as metadata; the actual confirmation still lives downstream in `media-detail.ts`, unchanged. Adding a generic confirm inside the presentational header would have duplicated or doubled the existing one.

Refs: #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)