### PR TITLE
feat(plugin-ui): render media-card actions from the contribution registry

### DIFF
--- a/client/src/app/core/plugin-ui/card-action-registry.ts
+++ b/client/src/app/core/plugin-ui/card-action-registry.ts
@@ -1,0 +1,40 @@
+/**
+ * Closed catalogue of `card.actions` actionIds core implements. A separate
+ * namespace from `media-action-registry.ts`'s `media.actions` ids — the two
+ * slots share no id and a card's handlers (open/play/dismiss, closed over a
+ * single card's inputs) have nothing in common with a media-detail header's
+ * (grab/delete/…), so one dispatcher for both would just blur two closed
+ * catalogues that must never resolve each other's ids.
+ */
+export type CoreCardActionId =
+  | 'card.play'
+  | 'card.open'
+  | 'card.add-to-playlist'
+  | 'card.recommend'
+  | 'card.toggle-watched'
+  | 'card.remove';
+
+const CORE_CARD_ACTION_IDS: ReadonlySet<string> = new Set<CoreCardActionId>([
+  'card.play',
+  'card.open',
+  'card.add-to-playlist',
+  'card.recommend',
+  'card.toggle-watched',
+  'card.remove',
+]);
+
+/** One concrete handler per core actionId, supplied by the card that owns the click. */
+export type CardActionHandlers = Record<CoreCardActionId, () => void>;
+
+/**
+ * Resolves a contribution's `actionId` to the handler that implements it.
+ * Anything outside the closed catalogue — a typo, a future id, a plugin
+ * guessing — returns `null`. Fail closed: the caller must render no row at
+ * all, never a button whose click silently does nothing.
+ */
+export function resolveCardAction(
+  actionId: string,
+  handlers: CardActionHandlers,
+): (() => void) | null {
+  return CORE_CARD_ACTION_IDS.has(actionId) ? handlers[actionId as CoreCardActionId] : null;
+}

--- a/client/src/app/core/services/card-actions.service.ts
+++ b/client/src/app/core/services/card-actions.service.ts
@@ -11,17 +11,11 @@ export interface CardAction {
   /** Pre-translated label (used when no `labelKey` is provided). */
   label?: string;
   /**
-   * Lucide icon name for the leading glyph. Resolved by the panel component
-   * against a curated whitelist. Unknown names render no icon.
+   * Lucide icon name for the leading glyph — a `card.actions` contribution
+   * can carry any name. Resolved by the panel component against a curated
+   * whitelist; unrecognised names fall back to a generic glyph, never blank.
    */
-  icon?:
-    | 'play'
-    | 'external-link'
-    | 'eye'
-    | 'eye-off'
-    | 'trash-2'
-    | 'list-plus'
-    | 'user-plus';
+  icon?: string;
   /** Optional tone applied to label + icon. */
   tone?: 'default' | 'danger';
   /** Action invoked when the user activates this row. */

--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
@@ -37,6 +37,7 @@
         @case ('trash-2') { <svg lucideTrash2 class="h-4 w-4 shrink-0 opacity-70"></svg> }
         @case ('list-plus') { <svg lucideListPlus class="h-4 w-4 shrink-0 opacity-70"></svg> }
         @case ('user-plus') { <svg lucideUserPlus class="h-4 w-4 shrink-0 opacity-70"></svg> }
+        @default { <svg lucideCircle class="h-4 w-4 shrink-0 opacity-70"></svg> }
       }
       <span class="flex-1 truncate text-left">{{ a.labelKey ? (a.labelKey | translate) : a.label }}</span>
     </button>

--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.ts
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.ts
@@ -13,6 +13,7 @@ import {
   LucideTrash2,
   LucideListPlus,
   LucideUserPlus,
+  LucideCircle,
 } from '@lucide/angular';
 import { CardAction, CardActionsService } from '../../../core/services/card-actions.service';
 import { PopoverMenuComponent } from '../popover-menu';
@@ -38,6 +39,7 @@ import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
     LucideTrash2,
     LucideListPlus,
     LucideUserPlus,
+    LucideCircle,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './card-actions-panel.html',

--- a/client/src/app/shared/components/media-card/core-card-actions.ts
+++ b/client/src/app/shared/components/media-card/core-card-actions.ts
@@ -1,0 +1,67 @@
+import type { UiContribution } from '../../../core/plugin-ui/contribution.types';
+
+/**
+ * Core's own `card.actions` items, expressed as contributions so they merge
+ * with plugin contributions through the same weight/id sort instead of a
+ * fixed sequence of `.push()` calls. Gating this domain needs almost none of
+ * the closed `when` vocabulary — "has a link", "is playable", "is
+ * dismissable" aren't predicates in it — so the real gate for every id here
+ * lives in `media-card.ts`'s `extraGuards`, documented there. Weights leave
+ * 600-800 open: that is exactly where `extraActions` (the one input this
+ * slot replaces) still splices in, between the watched toggle and Remove.
+ *
+ * `core.toggle_watched` swaps its own label/icon by live state (watched vs
+ * not) — cosmetic, so the swap lives in `media-card.ts`, not here.
+ */
+export const CORE_CARD_ACTIONS: readonly UiContribution[] = [
+  {
+    id: 'core.play',
+    slot: 'card.actions',
+    weight: 100,
+    labelKey: 'media_card.action_play',
+    icon: 'play',
+    action: { kind: 'action', actionId: 'card.play' },
+  },
+  {
+    id: 'core.open',
+    slot: 'card.actions',
+    weight: 200,
+    labelKey: 'media_card.action_open',
+    icon: 'external-link',
+    action: { kind: 'action', actionId: 'card.open' },
+  },
+  {
+    id: 'core.add_to_playlist',
+    slot: 'card.actions',
+    weight: 300,
+    labelKey: 'playlists.add_to_playlist',
+    icon: 'list-plus',
+    action: { kind: 'action', actionId: 'card.add-to-playlist' },
+  },
+  {
+    id: 'core.recommend',
+    slot: 'card.actions',
+    weight: 400,
+    labelKey: 'recommend.menu_item',
+    icon: 'user-plus',
+    when: ['!isTv'],
+    action: { kind: 'action', actionId: 'card.recommend' },
+  },
+  {
+    id: 'core.toggle_watched',
+    slot: 'card.actions',
+    weight: 500,
+    labelKey: 'media_card.mark_watched',
+    icon: 'eye',
+    action: { kind: 'action', actionId: 'card.toggle-watched' },
+  },
+  {
+    id: 'core.remove',
+    slot: 'card.actions',
+    weight: 900,
+    labelKey: 'media_card.remove_from_list',
+    icon: 'trash-2',
+    tone: 'danger',
+    action: { kind: 'action', actionId: 'card.remove' },
+  },
+];

--- a/client/src/app/shared/components/media-card/media-card.spec.ts
+++ b/client/src/app/shared/components/media-card/media-card.spec.ts
@@ -1,0 +1,498 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { vi } from 'vitest';
+import { MediaCardComponent } from './media-card';
+import { Media } from '../../../core/services/api/media.service';
+import { AddToPlaylistService } from '../../../core/services/add-to-playlist.service';
+import { RecommendService } from '../../../core/services/recommend.service';
+import { TvService } from '../../../core/services/tv.service';
+import { AuthService } from '../../../core/services/auth.service';
+import { DeviceService } from '../../../core/services/device.service';
+import { PlayableMediaService } from '../../../core/services/playable-media.service';
+import { NavbarService } from '../../../core/services/navbar.service';
+import { PluginUiRegistryService } from '../../../core/plugin-ui/plugin-ui-registry.service';
+import type { SlotId, UiContribution } from '../../../core/plugin-ui/contribution.types';
+
+/**
+ * Characterisation test for the card's contextual actions menu, written
+ * before the `card.actions` contribution-registry refactor (plan PR 5.5) and
+ * run unchanged before and after. Captures the action list as data
+ * ({labelKey, icon, tone}) plus each handler's real side effect, across every
+ * distinct input combination a real caller uses today (grepped from
+ * home/library/search/media-detail/media-detail-seasons) — a silent change
+ * in what a viewer sees, or in what a row's click actually does, fails here.
+ *
+ * `PluginUiRegistryService` is provided (empty by default) even though the
+ * pre-refactor component never reads it — so this exact file also runs
+ * unchanged post-refactor, once the component starts consuming it.
+ */
+
+interface Role {
+  isTv?: boolean;
+  sharingDisabled?: boolean;
+}
+const FULL_MEMBER: Role = {};
+const TV_VIEWER: Role = { isTv: true };
+const SHARING_DISABLED: Role = { sharingDisabled: true };
+
+interface Harness {
+  fixture: ComponentFixture<MediaCardComponent>;
+  router: Router;
+  addToPlaylist: { open: ReturnType<typeof vi.fn> };
+  recommend: { open: ReturnType<typeof vi.fn> };
+  playableMedia: { play: ReturnType<typeof vi.fn> };
+}
+
+async function createFixture(
+  role: Role,
+  inputs: Record<string, unknown>,
+  registry: Partial<Record<SlotId, UiContribution[]>> = {},
+): Promise<Harness> {
+  const addToPlaylist = { open: vi.fn() };
+  const recommend = { open: vi.fn() };
+  const playableMedia = { play: vi.fn().mockResolvedValue(undefined) };
+  const navbar = { markAsBackNavigation: vi.fn() };
+
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      provideRouter([]),
+      provideTranslateService({
+        lang: 'en',
+        loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+      }),
+      { provide: TvService, useValue: { isTv: () => !!role.isTv } },
+      {
+        provide: AuthService,
+        useValue: {
+          hasPermission: () => false,
+          sharingDisabled: () => !!role.sharingDisabled,
+        },
+      },
+      { provide: DeviceService, useValue: { input: () => 'mouse', isTouch: () => false } },
+      { provide: AddToPlaylistService, useValue: addToPlaylist },
+      { provide: RecommendService, useValue: recommend },
+      { provide: PlayableMediaService, useValue: playableMedia },
+      { provide: NavbarService, useValue: navbar },
+      {
+        provide: PluginUiRegistryService,
+        useValue: { contributionsFor: (slot: SlotId) => registry[slot] ?? [] },
+      },
+    ],
+  });
+
+  const fixture = TestBed.createComponent(MediaCardComponent);
+  for (const [key, value] of Object.entries(inputs)) {
+    fixture.componentRef.setInput(key, value);
+  }
+  const router = TestBed.inject(Router);
+
+  fixture.detectChanges();
+  await fixture.whenStable();
+  fixture.detectChanges();
+
+  return { fixture, router, addToPlaylist, recommend, playableMedia };
+}
+
+function makeMedia(overrides: Partial<Media> = {}): Media {
+  return {
+    id: 5,
+    title: 'Title',
+    originalTitle: 'Title',
+    year: 2020,
+    type: 'movie',
+    tmdbId: 1,
+    overview: '',
+    status: 'released',
+    monitored: true,
+    posterUrl: null,
+    fanartUrl: null,
+    logoUrl: null,
+    additionalFanartUrls: [],
+    rating: 0,
+    runtime: 90,
+    files: [],
+    ...overrides,
+  } as Media;
+}
+
+interface Shape {
+  labelKey: string | undefined;
+  icon: string | undefined;
+  tone: string;
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function actions(h: Harness): any[] {
+  return (h.fixture.componentInstance as any).cardActions();
+}
+function shapes(h: Harness): Shape[] {
+  return actions(h).map((a) => ({ labelKey: a.labelKey, icon: a.icon, tone: a.tone ?? 'default' }));
+}
+function labels(h: Harness): (string | undefined)[] {
+  return shapes(h).map((s) => s.labelKey);
+}
+function findAction(h: Harness, labelKey: string): any {
+  return actions(h).find((a) => a.labelKey === labelKey);
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+describe('MediaCardComponent — card.actions characterisation', () => {
+  it('continue-watching row (home.html): play-intent + playlist target + dismissable + interactiveWatched', async () => {
+    const h = await createFixture(FULL_MEMBER, {
+      link: ['/movies', '7'],
+      playlistMediaId: 7,
+      playlistEpisodeId: 3,
+      playable: true,
+      dismissable: true,
+      interactiveWatched: true,
+      clickIntent: 'play',
+    });
+    expect(shapes(h)).toEqual([
+      { labelKey: 'media_card.action_play', icon: 'play', tone: 'default' },
+      { labelKey: 'media_card.action_open', icon: 'external-link', tone: 'default' },
+      { labelKey: 'playlists.add_to_playlist', icon: 'list-plus', tone: 'default' },
+      { labelKey: 'recommend.menu_item', icon: 'user-plus', tone: 'default' },
+      { labelKey: 'media_card.mark_watched', icon: 'eye', tone: 'default' },
+      { labelKey: 'media_card.remove_from_list', icon: 'trash-2', tone: 'danger' },
+    ]);
+  });
+
+  it('recommendation row (home.html), available: extraActions + dismissable, no interactiveWatched', async () => {
+    const h = await createFixture(FULL_MEMBER, {
+      link: ['/movies', '9'],
+      playlistMediaId: 9,
+      status: null,
+      playable: true,
+      dismissable: true,
+      extraActions: [{ labelKey: 'media_card.mark_watched', icon: 'eye', run: () => {} }],
+    });
+    expect(labels(h)).toEqual([
+      'media_card.action_play',
+      'media_card.action_open',
+      'playlists.add_to_playlist',
+      'recommend.menu_item',
+      'media_card.mark_watched',
+      'media_card.remove_from_list',
+    ]);
+  });
+
+  it('recommendation row, unavailable: Play drops out, the rest holds', async () => {
+    const h = await createFixture(FULL_MEMBER, {
+      link: ['/movies', '9'],
+      playlistMediaId: 9,
+      status: 'missing',
+      playable: false,
+      dismissable: true,
+      extraActions: [{ labelKey: 'media_card.mark_watched', icon: 'eye', run: () => {} }],
+    });
+    expect(labels(h)).toEqual([
+      'media_card.action_open',
+      'playlists.add_to_playlist',
+      'recommend.menu_item',
+      'media_card.mark_watched',
+      'media_card.remove_from_list',
+    ]);
+  });
+
+  it('library/search grid card with files: [media]-driven, interactiveWatched on, never dismissable', async () => {
+    const h = await createFixture(FULL_MEMBER, {
+      media: makeMedia({ id: 5, files: [{ id: 1, quality: '1080p', relativePath: 'x', size: 1 }] }),
+      status: null,
+      interactiveWatched: true,
+    });
+    expect(labels(h)).toEqual([
+      'media_card.action_play',
+      'media_card.action_open',
+      'playlists.add_to_playlist',
+      'recommend.menu_item',
+      'media_card.mark_watched',
+    ]);
+  });
+
+  it('library/search grid card, missing files, read-only (interactiveWatched off)', async () => {
+    const h = await createFixture(FULL_MEMBER, {
+      media: makeMedia({ id: 5, files: [] }),
+      status: null,
+      interactiveWatched: false,
+    });
+    expect(labels(h)).toEqual(['media_card.action_open', 'playlists.add_to_playlist', 'recommend.menu_item']);
+  });
+
+  it('episode row (media-detail-seasons) with a file: play-intent via clickIntent, playlist target from ids', async () => {
+    const h = await createFixture(FULL_MEMBER, {
+      link: ['/series', '1', 'episode', '2'],
+      playlistMediaId: 1,
+      playlistEpisodeId: 2,
+      playable: true,
+      interactiveWatched: true,
+      clickIntent: 'play',
+    });
+    expect(labels(h)).toEqual([
+      'media_card.action_play',
+      'media_card.action_open',
+      'playlists.add_to_playlist',
+      'recommend.menu_item',
+      'media_card.mark_watched',
+    ]);
+  });
+
+  it('episode row, no file: Play and the watched toggle drop out; the playlist target survives on ids alone', async () => {
+    const h = await createFixture(FULL_MEMBER, {
+      link: ['/series', '1', 'episode', '2'],
+      playlistMediaId: 1,
+      playlistEpisodeId: 2,
+      playable: false,
+      interactiveWatched: false,
+      clickIntent: 'open',
+    });
+    expect(labels(h)).toEqual(['media_card.action_open', 'playlists.add_to_playlist', 'recommend.menu_item']);
+  });
+
+  it('season card (media-detail): interactiveWatched only, no playlist target — Add/Recommend absent without an id', async () => {
+    const h = await createFixture(FULL_MEMBER, {
+      link: ['/series', '1', 'season', '2'],
+      interactiveWatched: true,
+      status: null,
+    });
+    expect(shapes(h)).toEqual([
+      { labelKey: 'media_card.action_open', icon: 'external-link', tone: 'default' },
+      { labelKey: 'media_card.mark_watched', icon: 'eye', tone: 'default' },
+    ]);
+  });
+
+  it('season card already watched: the toggle swaps to unwatched/eye-off', async () => {
+    const h = await createFixture(FULL_MEMBER, {
+      link: ['/series', '1', 'season', '2'],
+      interactiveWatched: true,
+      status: 'watched',
+    });
+    expect(shapes(h)).toContainEqual({ labelKey: 'media_card.mark_unwatched', icon: 'eye-off', tone: 'default' });
+  });
+
+  it('minimal card (person/profile/search-external): link only — Open is the sole action', async () => {
+    const h = await createFixture(FULL_MEMBER, { link: ['/movies', '3'] });
+    expect(labels(h)).toEqual(['media_card.action_open']);
+  });
+
+  it('a card with no link and nothing else offers no actions at all', async () => {
+    const h = await createFixture(FULL_MEMBER, {});
+    expect(labels(h)).toEqual([]);
+  });
+});
+
+describe('MediaCardComponent — card.actions role variance (Recommend only)', () => {
+  const base = { link: ['/movies', '7'], playlistMediaId: 7, playable: true };
+
+  it('full member sees Recommend', async () => {
+    const h = await createFixture(FULL_MEMBER, base);
+    expect(labels(h)).toContain('recommend.menu_item');
+  });
+  it('TV viewer never sees Recommend', async () => {
+    const h = await createFixture(TV_VIEWER, base);
+    expect(labels(h)).not.toContain('recommend.menu_item');
+  });
+  it('a sharing-disabled viewer never sees Recommend', async () => {
+    const h = await createFixture(SHARING_DISABLED, base);
+    expect(labels(h)).not.toContain('recommend.menu_item');
+  });
+});
+
+describe('MediaCardComponent — card action handlers do what their row promises', () => {
+  it('Play (play-intent) triggers the card click path — parent owns navigation via `clicked`, not a route push', async () => {
+    const h = await createFixture(FULL_MEMBER, { link: ['/movies', '7'], playable: true, clickIntent: 'play' });
+    const navigateSpy = vi.spyOn(h.router, 'navigate').mockResolvedValue(true);
+    let clicked = false;
+    h.fixture.componentInstance.clicked.subscribe(() => (clicked = true));
+    findAction(h, 'media_card.action_play').run();
+    expect(clicked).toBe(true);
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it('Play (non-play-intent) delegates to PlayableMediaService via a media file', async () => {
+    const h = await createFixture(FULL_MEMBER, {
+      media: makeMedia({ files: [{ id: 42, quality: '1080p', relativePath: 'x', size: 1 }] }),
+    });
+    findAction(h, 'media_card.action_play').run();
+    expect(h.playableMedia.play).toHaveBeenCalled();
+  });
+
+  it('Open navigates to the detail link', async () => {
+    const h = await createFixture(FULL_MEMBER, { link: ['/movies', '7'] });
+    const navigateSpy = vi.spyOn(h.router, 'navigate').mockResolvedValue(true);
+    findAction(h, 'media_card.action_open').run();
+    expect(navigateSpy).toHaveBeenCalledWith(['/movies', '7'], expect.anything());
+  });
+
+  it('Add to playlist opens the modal with the resolved target', async () => {
+    const h = await createFixture(FULL_MEMBER, { link: ['/movies', '7'], playlistMediaId: 7 });
+    findAction(h, 'playlists.add_to_playlist').run();
+    expect(h.addToPlaylist.open).toHaveBeenCalledWith({ mediaId: 7 });
+  });
+
+  it('Recommend opens the modal with the resolved target', async () => {
+    const h = await createFixture(FULL_MEMBER, { link: ['/movies', '7'], playlistMediaId: 7 });
+    findAction(h, 'recommend.menu_item').run();
+    expect(h.recommend.open).toHaveBeenCalledWith({ mediaId: 7, episodeId: undefined });
+  });
+
+  it('the watched toggle emits the target state', async () => {
+    const h = await createFixture(FULL_MEMBER, { link: ['/movies', '7'], interactiveWatched: true, status: null });
+    let emitted: boolean | undefined;
+    h.fixture.componentInstance.watchedToggled.subscribe((v: boolean) => (emitted = v));
+    findAction(h, 'media_card.mark_watched').run();
+    expect(emitted).toBe(true);
+  });
+
+  it('Remove emits dismissed', async () => {
+    const h = await createFixture(FULL_MEMBER, { link: ['/movies', '7'], dismissable: true });
+    let dismissed = false;
+    h.fixture.componentInstance.dismissed.subscribe(() => (dismissed = true));
+    findAction(h, 'media_card.remove_from_list').run();
+    expect(dismissed).toBe(true);
+  });
+
+  it('an extraActions row runs the caller-supplied callback verbatim, untouched by the registry', async () => {
+    const run = vi.fn();
+    const h = await createFixture(FULL_MEMBER, {
+      link: ['/movies', '9'],
+      dismissable: true,
+      extraActions: [{ labelKey: 'x.custom', icon: 'eye', run }],
+    });
+    findAction(h, 'x.custom').run();
+    expect(run).toHaveBeenCalled();
+  });
+});
+
+// ── New in this PR: merging with plugin contributions. Meaningless before the
+// registry existed, so these are additions, not part of the characterisation set above.
+
+describe('MediaCardComponent — card.actions merges with plugin contributions', () => {
+  it('sorts a plugin item into position by weight, between two core items', async () => {
+    const h = await createFixture(
+      FULL_MEMBER,
+      { link: ['/movies', '7'], playlistMediaId: 7, playable: true },
+      {
+        'card.actions': [
+          {
+            id: 'fliks.acme.between',
+            slot: 'card.actions',
+            weight: 250,
+            labelKey: 'x.between',
+            action: { kind: 'route', path: '/plugins/acme/between' },
+          },
+        ],
+      },
+    );
+    const shown = labels(h);
+    expect(shown.indexOf('media_card.action_open')).toBe(1);
+    expect(shown.indexOf('x.between')).toBe(2);
+    expect(shown.indexOf('playlists.add_to_playlist')).toBeGreaterThan(2);
+  });
+
+  it('a route-kind plugin action navigates on click', async () => {
+    const h = await createFixture(
+      FULL_MEMBER,
+      {},
+      {
+        'card.actions': [
+          { id: 'fliks.acme.route', slot: 'card.actions', weight: 50, labelKey: 'x.route', action: { kind: 'route', path: '/plugins/acme' } },
+        ],
+      },
+    );
+    const navigateSpy = vi.spyOn(h.router, 'navigate').mockResolvedValue(true);
+    findAction(h, 'x.route').run();
+    expect(navigateSpy).toHaveBeenCalledWith(['/plugins/acme']);
+  });
+
+  it('an unrecognised icon passes through as data — the generic-glyph fallback is the panel template\'s job', async () => {
+    const h = await createFixture(
+      FULL_MEMBER,
+      {},
+      {
+        'card.actions': [
+          { id: 'fliks.acme.weird-icon', slot: 'card.actions', weight: 50, labelKey: 'x.weird', icon: 'not-a-real-lucide-name', action: { kind: 'route', path: '/x' } },
+        ],
+      },
+    );
+    expect(findAction(h, 'x.weird').icon).toBe('not-a-real-lucide-name');
+  });
+
+  it('VERDICT: an unknown actionId renders no row — fail closed, not a dead click', async () => {
+    const h = await createFixture(
+      FULL_MEMBER,
+      {},
+      {
+        'card.actions': [
+          { id: 'fliks.acme.bogus-action', slot: 'card.actions', weight: 50, labelKey: 'x.bogus', action: { kind: 'action', actionId: 'card.something-invented' } },
+        ],
+      },
+    );
+    expect(labels(h)).not.toContain('x.bogus');
+  });
+
+  it('VERDICT: an unrecognised action.kind renders no row', async () => {
+    const h = await createFixture(
+      FULL_MEMBER,
+      {},
+      {
+        'card.actions': [
+          { id: 'fliks.acme.broken', slot: 'card.actions', weight: 50, labelKey: 'x.broken', action: { kind: 'bogus' } as never },
+        ],
+      },
+    );
+    expect(labels(h)).not.toContain('x.broken');
+  });
+
+  it('a plugin can reuse a core actionId (its handler), but must bring its own `when` — core\'s `when` is per-contribution, not per-actionId', async () => {
+    const gatedRegistry = {
+      'card.actions': [
+        {
+          id: 'fliks.acme.remove-alias',
+          slot: 'card.actions' as const,
+          weight: 850,
+          labelKey: 'x.remove_alias',
+          when: ['isTv' as const],
+          action: { kind: 'action' as const, actionId: 'card.remove' },
+        },
+      ],
+    };
+    const notDismissable = await createFixture(FULL_MEMBER, { link: ['/movies', '7'], dismissable: false }, gatedRegistry);
+    expect(labels(notDismissable)).not.toContain('x.remove_alias');
+
+    const dismissableButNotTv = await createFixture(FULL_MEMBER, { link: ['/movies', '7'], dismissable: true }, gatedRegistry);
+    expect(labels(dismissableButNotTv)).not.toContain('x.remove_alias');
+
+    const dismissableAndTv = await createFixture(TV_VIEWER, { link: ['/movies', '7'], dismissable: true }, gatedRegistry);
+    expect(labels(dismissableAndTv)).toContain('x.remove_alias');
+  });
+
+  it('a plugin cannot widen a core action: an alias with no `when` stays hidden from a role core hides it from (read-only), and shows for one core shows it to (can-delete)', async () => {
+    const wideOpen = {
+      'card.actions': [
+        {
+          id: 'fliks.acme.remove-wide',
+          slot: 'card.actions' as const,
+          weight: 850,
+          labelKey: 'x.remove_wide',
+          action: { kind: 'action' as const, actionId: 'card.remove' },
+        },
+      ],
+    };
+    const readOnly = await createFixture(FULL_MEMBER, { link: ['/movies', '7'], dismissable: false }, wideOpen);
+    expect(labels(readOnly)).not.toContain('x.remove_wide');
+
+    const canDelete = await createFixture(FULL_MEMBER, { link: ['/movies', '7'], dismissable: true }, wideOpen);
+    expect(labels(canDelete)).toContain('x.remove_wide');
+
+    // The alias's own handler is core's Remove handler — clicking it still emits `dismissed`.
+    let dismissed = false;
+    canDelete.fixture.componentInstance.dismissed.subscribe(() => (dismissed = true));
+    findAction(canDelete, 'x.remove_wide').run();
+    expect(dismissed).toBe(true);
+  });
+});

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -16,6 +16,11 @@ import { AuthService } from '../../../core/services/auth.service';
 import { DeviceService } from '../../../core/services/device.service';
 import { PlayableMediaService } from '../../../core/services/playable-media.service';
 import { NavbarService } from '../../../core/services/navbar.service';
+import { PluginUiRegistryService } from '../../../core/plugin-ui/plugin-ui-registry.service';
+import { evaluateWhen, type WhenContext } from '../../../core/plugin-ui/when-evaluator';
+import type { UiContribution } from '../../../core/plugin-ui/contribution.types';
+import { resolveCardAction, type CardActionHandlers } from '../../../core/plugin-ui/card-action-registry';
+import { CORE_CARD_ACTIONS } from './core-card-actions';
 
 export type MediaCardAspect = 'portrait' | 'landscape';
 
@@ -48,6 +53,7 @@ export class MediaCardComponent {
   private readonly auth = inject(AuthService);
   private readonly playableMedia = inject(PlayableMediaService);
   private readonly navbar = inject(NavbarService);
+  private readonly pluginUi = inject(PluginUiRegistryService);
   protected readonly device = inject(DeviceService);
   protected readonly isNative = Capacitor.isNativePlatform();
   /** Hover overlay (play button) only makes sense on a real pointer device. */
@@ -127,9 +133,14 @@ export class MediaCardComponent {
    * change, otherwise the click does nothing.
    */
   readonly interactiveWatched = input(false);
-  /** Extra context-menu actions injected by the parent (e.g. "mark watched"
-   *  on recommendation cards). Appended after the built-in actions, before the
-   *  danger "remove" entry. Pure menu actions — no inline indicator. */
+  /**
+   * Escape hatch for a caller-owned action the `card.actions` registry can't
+   * express (e.g. home's recommendation-row "mark watched", which drops the
+   * item from a page-local list — not a card concern). Spliced between the
+   * watched toggle and Remove, matching where core reserves weights 600-800.
+   * Every other pre-registry caller migrated to a contribution; this one
+   * lives in `features/home/home.html`, outside this refactor's ownership.
+   */
   readonly extraActions = input<CardAction[]>([]);
   /** Library media id used for the "add to playlist" action when the card is
    *  fed by individual inputs rather than `[media]` (continue-watching,
@@ -353,88 +364,117 @@ export class MediaCardComponent {
     }, false);
   }
 
+  // ── card.actions: the contextual panel, rendered from the contribution registry ──
+
+  private readonly cardActionsContext = computed<WhenContext>(() => ({
+    isAdmin: this.auth.hasPermission('settings.access'),
+    hasPermission: (p: string) => this.auth.hasPermission(p),
+    mediaType: this.media()?.type,
+    hasFiles: this._playable(),
+    isMonitored: this.media()?.monitored,
+    hasQualityProfile: !!this.media()?.qualityProfile,
+    isEpisode: this.playlistEpisodeId() != null,
+    isTv: this.tv.isTv(),
+    isTouch: this.device.isTouch(),
+  }));
+
+  /**
+   * Visibility rules the closed `when` vocabulary can't express — this domain has
+   * almost none of it (no "has a link", "is playable" or "is dismissable"
+   * predicate), so nearly every core id is gated here rather than in `when`.
+   */
+  private readonly extraGuards: Record<string, () => boolean> = {
+    'core.play': () => {
+      const hasLink = !!this._link();
+      return (this.clickIntent() === 'play' && hasLink) || (this.clickIntent() !== 'play' && this._playable());
+    },
+    'core.open': () => !!this._link(),
+    'core.add_to_playlist': () => this.media()?.id != null || this.playlistMediaId() != null || this.playlistEpisodeId() != null,
+    'core.recommend': () => {
+      const mediaId = this.media()?.id ?? this.playlistMediaId();
+      return mediaId != null && !this.auth.sharingDisabled();
+    },
+    'core.toggle_watched': () => this.interactiveWatched(),
+    'core.remove': () => this.dismissable(),
+  };
+
+  private readonly actionHandlers: CardActionHandlers = {
+    'card.play': () => (this.clickIntent() === 'play' ? this.onCardClick() : this.onPlayClick(new Event('synthetic'))),
+    'card.open': () => this.openDetail(),
+    'card.add-to-playlist': () => {
+      const episodeId = this.playlistEpisodeId();
+      const mediaId = this.media()?.id ?? this.playlistMediaId();
+      this.addToPlaylist.open(episodeId != null ? { episodeId } : { mediaId: mediaId! });
+    },
+    'card.recommend': () => {
+      const mediaId = this.media()?.id ?? this.playlistMediaId();
+      this.recommend.open({ mediaId: mediaId!, episodeId: this.playlistEpisodeId() ?? undefined });
+    },
+    'card.toggle-watched': () => this.watchedToggled.emit(this.status() !== 'watched'),
+    'card.remove': () => this.dismissed.emit(),
+  };
+
   /**
    * Actions exposed via the contextual panel (TV menu button / mobile long-press).
-   * The set is derived from the same flags that drive the inline buttons so a
-   * card always advertises only what it can actually do.
+   * Core's list merged with the registry's plugin contributions, sorted by weight
+   * then id, `when`/guard-filtered, with the action resolved to a handler. An
+   * unknown actionId or action.kind drops the row rather than rendering a broken
+   * one. `extraActions` — the one caller-owned escape hatch left — splices in at
+   * the point core reserves for it: after the watched toggle, before Remove.
    */
   protected readonly cardActions = computed((): CardAction[] => {
-    const actions: CardAction[] = [];
-    const isPlayIntent = this.clickIntent() === 'play';
-    const hasLink = !!this._link();
+    const ctx = this.cardActionsContext();
+    const watched = this.status() === 'watched';
+    const merged = [...CORE_CARD_ACTIONS, ...this.pluginUi.contributionsFor('card.actions')]
+      .sort((a, b) => a.weight - b.weight || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
 
-    // Order is uniform across every row: Play first when available, then
-    // Open detail. Continue Watching's tap-plays behaviour collapses Play
-    // onto onCardClick; other rows route Play through onPlayClick.
-    if (isPlayIntent && hasLink) {
-      actions.push({
-        labelKey: 'media_card.action_play',
-        icon: 'play',
-        run: () => this.onCardClick(),
-      });
-    } else if (!isPlayIntent && this._playable()) {
-      actions.push({
-        labelKey: 'media_card.action_play',
-        icon: 'play',
-        run: () => this.onPlayClick(new Event('synthetic')),
-      });
-    }
+    const resolved: { weight: number; action: CardAction }[] = [];
+    for (const c of merged) {
+      if (!evaluateWhen(c.when, ctx)) continue;
+      // Reusing a core actionId reuses core's gating too: a plugin may narrow one of
+      // core's own actions, never widen it to someone core would hide it from.
+      if (!this.passesCoreGateFor(c, ctx)) continue;
+      if (!(this.extraGuards[c.id]?.() ?? true)) continue;
 
-    if (hasLink) {
-      actions.push({
-        labelKey: 'media_card.action_open',
-        icon: 'external-link',
-        run: () => this.openDetail(),
-      });
-    }
-    // Library media can be added to a playlist from any card, listed above
-    // "mark watched". Gated on a real media id so TMDB/discover previews (no
-    // library id) don't offer it.
-    const mediaId = this.media()?.id ?? this.playlistMediaId();
-    const episodeId = this.playlistEpisodeId();
-    if (episodeId != null || mediaId != null) {
-      actions.push({
-        labelKey: 'playlists.add_to_playlist',
-        icon: 'list-plus',
-        run: () =>
-          this.addToPlaylist.open(
-            episodeId != null ? { episodeId } : { mediaId: mediaId! },
-          ),
-      });
-      // Recommend to a member sits next to "add to playlist". Needs the parent
-      // mediaId (the API keys recommendations to the title), and is hidden on TV
-      // like the rest of the social surface.
-      if (mediaId != null && !this.tv.isTv() && !this.auth.sharingDisabled()) {
-        actions.push({
-          labelKey: 'recommend.menu_item',
-          icon: 'user-plus',
-          run: () =>
-            this.recommend.open({
-              mediaId,
-              episodeId: episodeId ?? undefined,
-            }),
-        });
+      let run: (() => void) | null = null;
+      if (c.action.kind === 'route') {
+        const path = c.action.path;
+        run = () => void this.router.navigate([path]);
+      } else if (c.action.kind === 'action') {
+        run = resolveCardAction(c.action.actionId, this.actionHandlers);
       }
-    }
-    if (this.interactiveWatched()) {
-      const watched = this.status() === 'watched';
-      actions.push({
-        labelKey: watched ? 'media_card.mark_unwatched' : 'media_card.mark_watched',
-        icon: watched ? 'eye-off' : 'eye',
-        run: () => this.watchedToggled.emit(!watched),
+      if (!run) continue; // unknown actionId, or an unrecognised action.kind
+
+      const isToggle = c.action.kind === 'action' && c.action.actionId === 'card.toggle-watched';
+      resolved.push({
+        weight: c.weight,
+        action: {
+          labelKey: isToggle ? (watched ? 'media_card.mark_unwatched' : 'media_card.mark_watched') : c.labelKey,
+          icon: isToggle ? (watched ? 'eye-off' : 'eye') : c.icon,
+          tone: c.tone ?? 'default',
+          run,
+        },
       });
     }
-    actions.push(...this.extraActions());
-    if (this.dismissable()) {
-      actions.push({
-        labelKey: 'media_card.remove_from_list',
-        icon: 'trash-2',
-        tone: 'danger',
-        run: () => this.dismissed.emit(),
-      });
+
+    const extra = this.extraActions();
+    const actions = resolved.map((r) => r.action);
+    if (extra.length) {
+      const insertAt = resolved.findIndex((r) => r.weight >= 900);
+      if (insertAt === -1) actions.push(...extra);
+      else actions.splice(insertAt, 0, ...extra);
     }
     return actions;
   });
+
+  /** A contribution pointing at a core actionId must also clear that core item's own
+   *  `when` and extra guard, whoever declared it. */
+  private passesCoreGateFor(c: UiContribution, ctx: WhenContext): boolean {
+    if (c.action.kind !== 'action') return true;
+    const core = CORE_CARD_ACTIONS.find((a) => a.action.kind === 'action' && a.action.actionId === (c.action as { actionId: string }).actionId);
+    if (!core || core.id === c.id) return true;
+    return evaluateWhen(core.when, ctx) && (this.extraGuards[core.id]?.() ?? true);
+  }
 
   /**
    * Resolved top-right status. Falls back to an auto-detected `'missing'`


### PR DESCRIPTION
PR 5.5, the last of phase 5's UI slots. Core's six card actions become `card.actions` contributions merged with plugin contributions, sorted by weight then id.

## The alias invariant carries over

A contribution pointing at a core `actionId` must also clear that core item's own gating, so a plugin may **narrow** one of core's card actions but never **widen** it to a card that hides it. Same rule as #927, same shape — an alias of `card.remove` carrying no `when` stays hidden where the core item is hidden, and a plugin can still add its own `when` on top. Both tested.

## A sibling registry, not a shared one

Card actions get their own closed dispatcher. The two id sets never overlap (`card.play` vs `media.recommend`) and the handler shapes have nothing in common — one is a card's open/play/dismiss, the other a detail header's grab/delete/edit. Sharing would force a single record to carry both catalogues and lose exactly what a closed catalogue is for.

An unknown `actionId` renders no item; an unknown icon falls back to a generic glyph rather than a gap.

## Where the gating actually lives

Almost every gate sits beside `when` rather than in it, because the closed vocabulary has no predicate for "has a link", "is playable" or "is dismissable" — which is what a card really varies on. Those are pure functions of the card's own inputs, so each caller's behaviour is unchanged. Same shape as the media-detail menu, and the same limitation: **a plugin has no equivalent escape hatch**, so a plugin contribution can only use the closed predicates.

Worth noting this slot has **no CASL permission at all** in core's set — unlike `media.actions`. Its two real gates are `isTv` and `sharingDisabled`, with per-page ACL expressed through the `dismissable()` input the component already reads.

## `extraActions` stays, deliberately

The plan says `card.actions` replaces it. It does not, for one caller: the home page's recommendation action needs a handler the parent owns and which mutates the parent's own state. A contribution *names* a core-declared action; it never supplies a handler. Replacing that would mean rebuilding the same escape hatch under a different name, so the input stays, documented, spliced at the same relative position as before.

## Real item count

**Six, not the plan's nine.** The 100-900 weight grid has three unused slots at 600-800 — which is the grid doing its job, leaving room for a plugin to slot between existing items.

## Verification

Client suite **298 tests / 37 files green**, `ng build` exit 0, both exit codes read directly.

The action list was captured as data across every context a card appears in — continue-watching, recommendation rows (available and unavailable), library and search grids with and without files, episode rows, season cards, link-only and empty cards — run green against the untouched component, then re-run unchanged after the refactor.

**Not visually verified** — headless Chromium hangs here (#907), and this PR makes no visual claim.

## Not done

A plugin's `confirmKey` on a `card.actions` contribution is currently ignored: none of the six core items has one, so no confirmation UI exists in this panel to hook into. Noted rather than invented.

Refs: #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)