### PR TITLE
feat(download): make the download bundle optional and prove the boundary

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -34,6 +34,7 @@ import { PluginsModule } from './modules/plugins/plugins.module';
 import { CommonModule } from './common/common.module';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
+import { isDownloadBundleEnabled } from './common/constants/plugin-flags';
 
 @Module({
   imports: [
@@ -88,7 +89,9 @@ import { join } from 'path';
     MetadataProvidersModule,
     IndexersModule,
     DownloadClientsModule,
-    GrabModule,
+    // The one in-repo bundle today; FLIKS_BUNDLES=<empty> drops its controller
+    // and grab routes entirely rather than exposing them disabled.
+    ...(isDownloadBundleEnabled() ? [GrabModule] : []),
     RequestsModule,
     FliksSchedulerModule,
     CleanupProfilesModule,

--- a/backend/src/common/constants/plugin-flags.spec.ts
+++ b/backend/src/common/constants/plugin-flags.spec.ts
@@ -1,0 +1,41 @@
+import {
+  FLIKS_BUNDLES_ENV,
+  isBundleEnabled,
+  isDownloadBundleEnabled,
+} from './plugin-flags';
+
+describe('isBundleEnabled / isDownloadBundleEnabled', () => {
+  const original = process.env[FLIKS_BUNDLES_ENV];
+
+  afterEach(() => {
+    if (original === undefined) delete process.env[FLIKS_BUNDLES_ENV];
+    else process.env[FLIKS_BUNDLES_ENV] = original;
+  });
+
+  it('loads every bundle when unset — preserves today\'s default', () => {
+    delete process.env[FLIKS_BUNDLES_ENV];
+    expect(isDownloadBundleEnabled()).toBe(true);
+  });
+
+  it('loads no bundle for an empty string', () => {
+    process.env[FLIKS_BUNDLES_ENV] = '';
+    expect(isDownloadBundleEnabled()).toBe(false);
+  });
+
+  it('loads the download bundle when it is named', () => {
+    process.env[FLIKS_BUNDLES_ENV] = 'download';
+    expect(isDownloadBundleEnabled()).toBe(true);
+  });
+
+  it('drops a bundle absent from a non-empty list', () => {
+    process.env[FLIKS_BUNDLES_ENV] = 'some-other-bundle';
+    expect(isDownloadBundleEnabled()).toBe(false);
+  });
+
+  it('trims ids and drops empties, same as FLIKS_UNSIGNED_PLUGINS', () => {
+    process.env[FLIKS_BUNDLES_ENV] = ' download , , other ';
+    expect(isBundleEnabled('download')).toBe(true);
+    expect(isBundleEnabled('other')).toBe(true);
+    expect(isBundleEnabled('')).toBe(false);
+  });
+});

--- a/backend/src/common/constants/plugin-flags.ts
+++ b/backend/src/common/constants/plugin-flags.ts
@@ -20,3 +20,28 @@ export function unsignedProcessAllowlist(): string[] {
     .map((id) => id.trim())
     .filter((id) => id.length > 0);
 }
+
+/** Which in-repo bundles (`src/plugins/<id>/`) load into the module graph. */
+export const FLIKS_BUNDLES_ENV = 'FLIKS_BUNDLES';
+
+/** The bundle backing acquisition (indexers, download clients, grab, the acquisition jobs). */
+const DOWNLOAD_BUNDLE_ID = 'download';
+
+/**
+ * True when `bundleId` is in the comma-separated `FLIKS_BUNDLES` allowlist. Unset loads every
+ * bundle (today's behaviour); an empty string loads none; an id absent from a non-empty list
+ * is off. Unrecognised ids are ignored, same as `FLIKS_UNSIGNED_PLUGINS`.
+ */
+export function isBundleEnabled(bundleId: string): boolean {
+  const raw = process.env[FLIKS_BUNDLES_ENV];
+  if (raw === undefined) return true;
+  return raw
+    .split(',')
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0)
+    .includes(bundleId);
+}
+
+export function isDownloadBundleEnabled(): boolean {
+  return isBundleEnabled(DOWNLOAD_BUNDLE_ID);
+}

--- a/backend/src/modules/scheduler/scheduler.module.ts
+++ b/backend/src/modules/scheduler/scheduler.module.ts
@@ -46,6 +46,12 @@ import { MarkersModule } from '../markers/markers.module';
 import { Library } from '../libraries/entities/library.entity';
 import { LibraryIngestModule } from '../../common/library-ingest/library-ingest.module';
 import { PluginsModule } from '../plugins/plugins.module';
+import { isDownloadBundleEnabled } from '../../common/constants/plugin-flags';
+
+// SchedulerService keeps these behind @Optional() — see FLIKS_BUNDLES.
+const downloadBundleProviders = isDownloadBundleEnabled()
+  ? [CompletionService, TorrentAutoMatcher, AutoGrabExecutorService, AcquisitionSchedulerService]
+  : [];
 
 @Module({
   imports: [
@@ -93,19 +99,15 @@ import { PluginsModule } from '../plugins/plugins.module';
   controllers: [CommandsController, SystemController, LivenessController],
   providers: [
     SchedulerService,
-    CompletionService,
     AcquisitionEventsService,
     NamingService,
     BackupService,
     UpdateCheckService,
     SubtitleSchedulerService,
-    TorrentAutoMatcher,
-    AutoGrabExecutorService,
-    AcquisitionSchedulerService,
+    ...downloadBundleProviders,
   ],
   exports: [
     SchedulerService,
-    CompletionService,
     AcquisitionEventsService,
     NamingService,
     LogBufferModule,

--- a/backend/src/modules/scheduler/scheduler.service.spec.ts
+++ b/backend/src/modules/scheduler/scheduler.service.spec.ts
@@ -1,0 +1,48 @@
+import { isJobAvailable } from './scheduler.service';
+import { FLIKS_BUNDLES_ENV } from '../../common/constants/plugin-flags';
+
+describe('isJobAvailable', () => {
+  const DOWNLOAD_BUNDLE_JOBS = [
+    'SearchMissing',
+    'RssSync',
+    'ImportCompleted',
+    'CleanStalled',
+    'CleanSeeded',
+  ];
+  const CORE_JOBS = ['RefreshMetadata', 'SubtitleSearch', 'SubtitleUpgrade'];
+
+  it('offers every download-bundle job when the bundle is enabled', () => {
+    for (const name of DOWNLOAD_BUNDLE_JOBS) {
+      expect(isJobAvailable(name, true)).toBe(true);
+    }
+  });
+
+  it('drops every download-bundle job when the bundle is disabled', () => {
+    for (const name of DOWNLOAD_BUNDLE_JOBS) {
+      expect(isJobAvailable(name, false)).toBe(false);
+    }
+  });
+
+  it('never drops a job the download bundle does not own', () => {
+    for (const name of CORE_JOBS) {
+      expect(isJobAvailable(name, true)).toBe(true);
+      expect(isJobAvailable(name, false)).toBe(true);
+    }
+  });
+
+  describe('default parameter — reads FLIKS_BUNDLES at call time', () => {
+    const original = process.env[FLIKS_BUNDLES_ENV];
+
+    afterEach(() => {
+      if (original === undefined) delete process.env[FLIKS_BUNDLES_ENV];
+      else process.env[FLIKS_BUNDLES_ENV] = original;
+    });
+
+    it('follows the env var when no explicit flag is passed', () => {
+      process.env[FLIKS_BUNDLES_ENV] = '';
+      expect(isJobAvailable('SearchMissing')).toBe(false);
+      delete process.env[FLIKS_BUNDLES_ENV];
+      expect(isJobAvailable('SearchMissing')).toBe(true);
+    });
+  });
+});

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -1,8 +1,10 @@
 import {
+  BadRequestException,
   Inject,
   Injectable,
   Logger,
   OnModuleInit,
+  Optional,
   forwardRef,
 } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
@@ -30,9 +32,29 @@ import { MarkersService } from '../markers/markers.service';
 import { CORE_SCHEDULER_JOB_NAMES } from '../../common/constants/core-scheduler-jobs';
 import { PluginJobsService } from '../plugins/plugin-jobs.service';
 import { AcquisitionSchedulerService } from '../../plugins/download/acquisition-scheduler.service';
+import { isDownloadBundleEnabled } from '../../common/constants/plugin-flags';
 
 /** Yield the event loop so HTTP requests aren't starved by bulk tasks. */
 const yieldLoop = () => new Promise<void>((r) => setTimeout(r, 50));
+
+/** Core jobs that need the download bundle (`plugins/download/`) to run — see FLIKS_BUNDLES. */
+const DOWNLOAD_BUNDLE_JOB_NAMES: ReadonlySet<string> = new Set([
+  'SearchMissing',
+  'RssSync',
+  'ImportCompleted',
+  'CleanStalled',
+  'CleanSeeded',
+]);
+
+/** False for a download-bundle job once the bundle is off, so it drops out of the
+ *  scheduler listing and can no longer be triggered. `bundleEnabled` defaults to a
+ *  fresh env read, and is otherwise a plain parameter for `it.each`-style testing. */
+export function isJobAvailable(
+  name: string,
+  bundleEnabled = isDownloadBundleEnabled(),
+): boolean {
+  return bundleEnabled || !DOWNLOAD_BUNDLE_JOB_NAMES.has(name);
+}
 
 @Injectable()
 export class SchedulerService implements OnModuleInit {
@@ -48,15 +70,17 @@ export class SchedulerService implements OnModuleInit {
     private readonly tmdb: TmdbProvider,
     private readonly mediaService: MediaService,
     private readonly config: ConfigService,
+    @Optional()
     @Inject(forwardRef(() => CompletionService))
-    private readonly completion: CompletionService,
+    private readonly completion: CompletionService | undefined,
     private readonly eventsService: EventsService,
     private readonly subtitleScheduler: SubtitleSchedulerService,
     @InjectRepository(MediaFile)
     private readonly mediaFileRepo: Repository<MediaFile>,
     private readonly thumbnailService: ThumbnailService,
     private readonly markers: MarkersService,
-    private readonly acquisitionScheduler: AcquisitionSchedulerService,
+    @Optional()
+    private readonly acquisitionScheduler: AcquisitionSchedulerService | undefined,
     private readonly pluginJobs: PluginJobsService,
   ) {}
 
@@ -131,8 +155,10 @@ export class SchedulerService implements OnModuleInit {
 
   @Cron(CronExpression.EVERY_6_HOURS)
   async searchMissing(): Promise<void> {
+    const scheduler = this.acquisitionScheduler;
+    if (!scheduler) return;
     return this.runCommand('SearchMissing', 'scheduled', () =>
-      this.acquisitionScheduler.searchMissing(),
+      scheduler.searchMissing(),
     );
   }
 
@@ -147,9 +173,9 @@ export class SchedulerService implements OnModuleInit {
   /** RSS sync every 15 minutes */
   @Cron('*/15 * * * *')
   async rssSync(): Promise<void> {
-    return this.runCommand('RssSync', 'scheduled', () =>
-      this.acquisitionScheduler.rssSync(),
-    );
+    const scheduler = this.acquisitionScheduler;
+    if (!scheduler) return;
+    return this.runCommand('RssSync', 'scheduled', () => scheduler.rssSync());
   }
 
   // ---------------------------------------------------------------------------
@@ -168,7 +194,10 @@ export class SchedulerService implements OnModuleInit {
       pluginId: string | null;
     }[]
   > {
-    const names = SchedulerService.SCHEDULERS.map((s) => s.name);
+    const available = SchedulerService.SCHEDULERS.filter((s) =>
+      isJobAvailable(s.name),
+    );
+    const names = available.map((s) => s.name);
 
     // Get last command per scheduler name in one query
     const lastCommands = await this.commandRepo
@@ -181,7 +210,7 @@ export class SchedulerService implements OnModuleInit {
 
     const lastByName = new Map(lastCommands.map((c) => [c.name, c]));
 
-    const core = SchedulerService.SCHEDULERS.map((s) => {
+    const core = available.map((s) => {
       const last = lastByName.get(s.name);
       const interval = CronExpressionParser.parse(s.cron);
       return {
@@ -211,9 +240,9 @@ export class SchedulerService implements OnModuleInit {
 
   async triggerCommand(name: string): Promise<Command> {
     const known = [
-      ...SchedulerService.SCHEDULERS.filter((s) => s.triggerable).map(
-        (s) => s.name,
-      ),
+      ...SchedulerService.SCHEDULERS.filter(
+        (s) => s.triggerable && isJobAvailable(s.name),
+      ).map((s) => s.name),
       'RescanAll',
       'RefreshMissingMetadata',
       'RescanMissingFiles',
@@ -223,7 +252,11 @@ export class SchedulerService implements OnModuleInit {
       'DetectMissingMarkers',
     ];
     if (!known.includes(name)) {
-      throw new Error(`Unknown command: ${name}. Valid: ${known.join(', ')}`);
+      // A caller-input error (unknown name, or a job the download bundle just
+      // dropped) — not a server fault, so 400 rather than an unhandled throw.
+      throw new BadRequestException(
+        `Unknown command: ${name}. Valid: ${known.join(', ')}`,
+      );
     }
 
     const cmd = await this.commandRepo.save(
@@ -315,15 +348,15 @@ export class SchedulerService implements OnModuleInit {
         const mediaIds = Array.isArray(body['mediaIds'])
           ? (body['mediaIds'] as number[])
           : undefined;
-        await this.acquisitionScheduler.searchMissing(mediaIds);
+        await this.acquisitionScheduler?.searchMissing(mediaIds);
       } else if (name === 'RefreshMetadata') await this.doRefreshMetadata();
-      else if (name === 'RssSync') await this.acquisitionScheduler.rssSync();
+      else if (name === 'RssSync') await this.acquisitionScheduler?.rssSync();
       else if (name === 'ImportCompleted')
-        await this.completion.processCompleted();
+        await this.completion?.processCompleted();
       else if (name === 'CleanStalled')
-        await this.completion.cleanStalledTorrents();
+        await this.completion?.cleanStalledTorrents();
       else if (name === 'CleanSeeded')
-        await this.completion.cleanSeededTorrents();
+        await this.completion?.cleanSeededTorrents();
       else if (name === 'SubtitleSearch')
         await this.subtitleScheduler.searchMissingSubtitles();
       else if (name === 'SubtitleUpgrade')


### PR DESCRIPTION
PR 4.6, the last of phase 4. Phases 4.1–4.5 moved the acquisition code into `plugins/download/`; this proves the boundary is real rather than merely tidy, by switching the bundle off and seeing what breaks.

## `FLIKS_BUNDLES`

Comma-separated bundle ids. **Unset loads every bundle**, so today's behaviour is untouched. Empty loads none. Only one id exists today, `download`.

With the bundle off:

- the app boots and serves;
- the eight grab routes are not registered;
- the five acquisition jobs are absent from `GET /api/commands/schedulers` and refuse a manual trigger, rather than being offered and then failing;
- core keeps metadata refresh and both subtitle jobs;
- nothing renders as disabled. The plan's rule for the never-installed state is *shows nothing* — a Fliks without acquisition owes no explanation for a feature it does not have.

## The proof, because booting is not enough

A module that silently does nothing also boots cleanly. So a real application context was instantiated in each mode and **what actually got registered** was enumerated and diffed — independently of the implementing agent's own run:

| | default | bundle off |
|---|---|---|
| registered routes | **387** | **379** |
| jobs listed | 8 | 3 |

The eight that disappear are exactly the grab routes; the only `/upgrade` path left is the subtitle one, which is core's. Jobs drop to `RefreshMetadata`, `SubtitleSearch`, `SubtitleUpgrade`. Both modes report `DI GRAPH OK`.

On the live stack in default mode, the acquisition probe still passes all nine checks — a real indexer search returning 120 releases with the same 23-key scored shape.

## What the exercise surfaced, and this PR does not fix

**The indexer and download-client modules stay loaded unconditionally.** Six core files hard-inject their entities or services: the blocklist module and service, the CASL ability factory, the setup checklist module and service, and the system diagnostics controller — which injects the download client's service directly with no `@Optional()`, a debt already recorded in 4.2.

So indexer and download-client CRUD routes remain reachable with the bundle off, with no acquisition behind them. **That is the one place the never-installed rule is not honoured**, and it is the honest residual: the boundary holds for the grab pipeline, the jobs and the completion path, and does not yet hold for that CRUD surface. Untangling those six files is materially larger than this change and belongs with the RPC boundary in phase 10.

Reported rather than stubbed, because a stub that pretends to work would turn a boundary proof into decoration.

## Also

Turning a job off made an unknown-command path reachable through ordinary use — manually triggering a job the UI no longer offers — and it answered with a bare 500. It answers 400 now. Found while checking the "no request 500s" property rather than by reading.

The `counts` badge needed no change: it only ever injected entity classes, never a plugin service, so it never depended on the bundle. Confirmed live — `GET /api/counts` answers 200 with `queueActive: 0` in off mode.

Cron ticks for the two acquisition jobs still fire on schedule (they live on the always-instantiated core scheduler) but return before creating a command row, so there are no phantom "completed" audit entries for a job that does not exist.

## Verification

`tsc` exit 0. Suite **1302 tests / 125 suites**, up from 1293/123 — the nine new tests cover the flag's parsing and the job filter. The fence needed no allowlist change and was re-proven to fire.

Refs: #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)