### PR TITLE
feat(plugins): implement core's side of the 17 plugin-facing methods

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -31,6 +31,7 @@ import { FilesystemModule } from './modules/filesystem/filesystem.module';
 import { SetupChecklistModule } from './modules/setup-checklist/setup-checklist.module';
 import { CountsModule } from './modules/counts/counts.module';
 import { PluginsModule } from './modules/plugins/plugins.module';
+import { PluginHostModule } from './modules/plugins/host/plugin-host.module';
 import { CommonModule } from './common/common.module';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
@@ -112,6 +113,9 @@ import { isDownloadBundleEnabled } from './common/constants/plugin-flags';
     SetupChecklistModule,
     CountsModule,
     PluginsModule,
+    // Independent of the download bundle — the plugin-facing host methods
+    // are core code and must resolve with FLIKS_BUNDLES=.
+    PluginHostModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/modules/plugins/host/fliks-host.service.spec.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.spec.ts
@@ -1,0 +1,1066 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { FliksHostImpl } from './fliks-host.service';
+import { PluginCountsCacheService } from './plugin-counts-cache.service';
+import { MediaType } from '../../../common/enums';
+import type { Media } from '../../media/entities/media.entity';
+import type { Season } from '../../media/entities/season.entity';
+import type { Episode } from '../../media/entities/episode.entity';
+
+/** Round-trips `value` through JSON and asserts nothing was lost or mutated —
+ *  the property that matters once the transport becomes a socket (Phase 10.4).
+ *  Catches what a naive `toEqual` misses: a `Date` (becomes a string), `Infinity`
+ *  / `NaN` (become `null`), and a circular reference (throws outright). */
+function expectJsonSafe(value: unknown): void {
+  const roundTripped: unknown = JSON.parse(JSON.stringify(value));
+  expect(roundTripped).toEqual(value);
+}
+
+function fakeQueryBuilder(rawMany: unknown[] = [], one: unknown = null) {
+  const qb: Record<string, jest.Mock> = {};
+  for (const m of [
+    'select',
+    'addSelect',
+    'where',
+    'andWhere',
+    'groupBy',
+    'orderBy',
+  ]) {
+    qb[m] = jest.fn(() => qb);
+  }
+  qb.getRawMany = jest.fn().mockResolvedValue(rawMany);
+  qb.getOne = jest.fn().mockResolvedValue(one);
+  qb.getCount = jest.fn().mockResolvedValue(0);
+  return qb;
+}
+
+function fakeRepo() {
+  return {
+    find: jest.fn().mockResolvedValue([]),
+    findOne: jest.fn().mockResolvedValue(null),
+    count: jest.fn().mockResolvedValue(0),
+    save: jest.fn(),
+    create: jest.fn((x: unknown) => x),
+    createQueryBuilder: jest.fn(() => fakeQueryBuilder()),
+  };
+}
+
+function makeMedia(overrides: Record<string, unknown> = {}): Media {
+  return {
+    id: 1,
+    type: MediaType.MOVIE,
+    title: 'A Movie',
+    originalTitle: null,
+    alternativeTitles: [],
+    year: 2020,
+    runtime: 100,
+    imdbId: 'tt1',
+    tmdbId: 42,
+    tvdbId: null,
+    libraryId: 7,
+    monitored: true,
+    releaseDate: null,
+    qualityProfile: null,
+    languageProfile: null,
+    library: { id: 7, path: '/lib', stalledCleanupProfile: null },
+    ...overrides,
+  } as unknown as Media;
+}
+
+function makeSeason(overrides: Partial<Season> = {}): Season {
+  return {
+    id: 10,
+    mediaId: 1,
+    seasonNumber: 1,
+    monitored: true,
+    ...overrides,
+  } as unknown as Season;
+}
+
+function makeEpisode(overrides: Partial<Episode> = {}): Episode {
+  return {
+    id: 100,
+    episodeNumber: 1,
+    endEpisodeNumber: null,
+    airDate: '2020-01-01',
+    monitored: true,
+    hasFile: false,
+    title: 'Pilot',
+    ...overrides,
+  } as unknown as Episode;
+}
+
+interface Harness {
+  host: FliksHostImpl;
+  mediaRepo: ReturnType<typeof fakeRepo>;
+  seasonRepo: ReturnType<typeof fakeRepo>;
+  episodeRepo: ReturnType<typeof fakeRepo>;
+  mediaFileRepo: ReturnType<typeof fakeRepo>;
+  blocklistEntryRepo: ReturnType<typeof fakeRepo>;
+  pluginRegistrationRepo: ReturnType<typeof fakeRepo>;
+  cleanupProfileRepo: ReturnType<typeof fakeRepo>;
+  autoGrab: { classifyForSearch: jest.Mock };
+  acquisitionCandidates: {
+    listMovieTargets: jest.Mock;
+    listEpisodeTargets: jest.Mock;
+    groupIntoSeasonPacks: jest.Mock;
+  };
+  profiles: { resolveAllowedForMedia: jest.Mock };
+  qualityDefs: { getSizeLimitsMap: jest.Mock };
+  customFormats: { scoreRelease: jest.Mock };
+  blocklist: { create: jest.Mock; isBlocked: jest.Mock };
+  requestLifecycle: { markInProgress: jest.Mock };
+  libraryIngestService: { ingest: jest.Mock };
+  notifications: { dispatch: jest.Mock };
+  mediaServers: { dispatch: jest.Mock };
+  settings: { get: jest.Mock; getAll: jest.Mock; set: jest.Mock };
+  events: {
+    emit: jest.Mock;
+    emitToUsers: jest.Mock;
+    emitDomain: jest.Mock;
+    emitRaw: jest.Mock;
+  };
+  sseAudience: { recipientsForMedia: jest.Mock };
+  countsCache: PluginCountsCacheService;
+}
+
+function makeHarness(pluginId = 'test.plugin'): Harness {
+  const mediaRepo = fakeRepo();
+  const seasonRepo = fakeRepo();
+  const episodeRepo = fakeRepo();
+  const mediaFileRepo = fakeRepo();
+  const blocklistEntryRepo = fakeRepo();
+  const pluginRegistrationRepo = fakeRepo();
+  const cleanupProfileRepo = fakeRepo();
+  const autoGrab = { classifyForSearch: jest.fn() };
+  const acquisitionCandidates = {
+    listMovieTargets: jest.fn().mockResolvedValue([]),
+    listEpisodeTargets: jest.fn().mockResolvedValue([]),
+    groupIntoSeasonPacks: jest.fn().mockResolvedValue([]),
+  };
+  const profiles = {
+    resolveAllowedForMedia: jest
+      .fn()
+      .mockReturnValue({ allowed: new Set([1]), allowedLangs: new Set([1]) }),
+  };
+  const qualityDefs = {
+    getSizeLimitsMap: jest.fn().mockResolvedValue(new Map()),
+  };
+  const customFormats = { scoreRelease: jest.fn().mockResolvedValue(0) };
+  const blocklist = {
+    create: jest.fn(),
+    isBlocked: jest.fn().mockResolvedValue(false),
+  };
+  const requestLifecycle = {
+    markInProgress: jest.fn().mockResolvedValue(undefined),
+  };
+  const libraryIngestService = { ingest: jest.fn() };
+  const notifications = { dispatch: jest.fn() };
+  const mediaServers = { dispatch: jest.fn() };
+  const settings = {
+    get: jest.fn().mockResolvedValue(null),
+    getAll: jest.fn().mockResolvedValue({}),
+    set: jest.fn(),
+  };
+  const events = {
+    emit: jest.fn(),
+    emitToUsers: jest.fn(),
+    emitDomain: jest.fn(),
+    emitRaw: jest.fn(),
+  };
+  const sseAudience = { recipientsForMedia: jest.fn().mockResolvedValue([9]) };
+  const countsCache = new PluginCountsCacheService();
+
+  // Fakes stand in for 21 constructor params — a plain unit test of the class,
+  // not a DI-resolved instance (the DI graph itself is proven by the boot check).
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  const host = new (FliksHostImpl as any)(
+    pluginId,
+    mediaRepo,
+    seasonRepo,
+    episodeRepo,
+    mediaFileRepo,
+    blocklistEntryRepo,
+    pluginRegistrationRepo,
+    cleanupProfileRepo,
+    autoGrab,
+    acquisitionCandidates,
+    profiles,
+    qualityDefs,
+    customFormats,
+    blocklist,
+    requestLifecycle,
+    libraryIngestService,
+    notifications,
+    mediaServers,
+    settings,
+    events,
+    sseAudience,
+    countsCache,
+  ) as FliksHostImpl;
+
+  return {
+    host,
+    countsCache,
+    mediaRepo,
+    seasonRepo,
+    episodeRepo,
+    mediaFileRepo,
+    blocklistEntryRepo,
+    pluginRegistrationRepo,
+    cleanupProfileRepo,
+    autoGrab,
+    acquisitionCandidates,
+    profiles,
+    qualityDefs,
+    customFormats,
+    blocklist,
+    requestLifecycle,
+    libraryIngestService,
+    notifications,
+    mediaServers,
+    settings,
+    events,
+    sseAudience,
+  };
+}
+
+describe('FliksHostImpl', () => {
+  // ===========================================================================
+  // A1 — media.acquisitionContext
+  // ===========================================================================
+
+  describe('media.acquisitionContext', () => {
+    it('returns a serialisable target for a missing movie, with the Infinity ceiling made JSON-safe', async () => {
+      const h = makeHarness();
+      const media = makeMedia();
+      h.mediaRepo.findOne.mockResolvedValue(media);
+      h.mediaFileRepo.find.mockResolvedValue([]);
+      h.autoGrab.classifyForSearch.mockReturnValue({
+        mode: 'missing',
+        minRankExclusive: 0,
+        maxRankInclusive: Number.POSITIVE_INFINITY,
+      });
+
+      const result = await h.host['media.acquisitionContext']({ mediaId: 1 });
+      expect(result?.want?.decision).toBe('missing');
+      expect(result?.want?.maxRankInclusive).toBe(Number.MAX_SAFE_INTEGER);
+      expect(Number.isFinite(result?.want?.maxRankInclusive)).toBe(true);
+      expectJsonSafe(result);
+    });
+
+    it('returns null for a media with no library, and for an unknown media id', async () => {
+      const h = makeHarness();
+      h.mediaRepo.findOne.mockResolvedValueOnce(makeMedia({ libraryId: null }));
+      expect(
+        await h.host['media.acquisitionContext']({ mediaId: 1 }),
+      ).toBeNull();
+
+      h.mediaRepo.findOne.mockResolvedValueOnce(null);
+      expect(
+        await h.host['media.acquisitionContext']({ mediaId: 999 }),
+      ).toBeNull();
+    });
+
+    it('collapses "skip" and "unprofiled" decisions to want: null', async () => {
+      const h = makeHarness();
+      h.mediaRepo.findOne.mockResolvedValue(makeMedia());
+      h.mediaFileRepo.find.mockResolvedValue([]);
+
+      h.autoGrab.classifyForSearch.mockReturnValue({ mode: 'skip' });
+      expect(
+        (await h.host['media.acquisitionContext']({ mediaId: 1 }))?.want,
+      ).toBeNull();
+
+      h.autoGrab.classifyForSearch.mockReturnValue({ mode: 'unprofiled' });
+      expect(
+        (await h.host['media.acquisitionContext']({ mediaId: 1 }))?.want,
+      ).toBeNull();
+    });
+
+    it('populates season + episode for an episode-scoped lookup', async () => {
+      const h = makeHarness();
+      const media = makeMedia({ type: MediaType.SERIES });
+      const season = makeSeason();
+      const episode = makeEpisode({ season });
+      h.mediaRepo.findOne.mockResolvedValue(media);
+      h.episodeRepo.findOne.mockResolvedValue(episode);
+      h.episodeRepo.count.mockResolvedValue(8);
+      h.episodeRepo.find.mockResolvedValue([]);
+      h.autoGrab.classifyForSearch.mockReturnValue({
+        mode: 'missing',
+        minRankExclusive: 0,
+        maxRankInclusive: 100,
+      });
+
+      const result = await h.host['media.acquisitionContext']({
+        mediaId: 1,
+        episodeId: 100,
+      });
+      expect(result?.season).toEqual({ id: 10, number: 1, episodeCount: 8 });
+      expect(result?.episode).toEqual({
+        id: 100,
+        number: 1,
+        endNumber: null,
+        airDate: '2020-01-01',
+      });
+      expectJsonSafe(result);
+    });
+  });
+
+  // ===========================================================================
+  // A2 — acquisition.candidates
+  // ===========================================================================
+
+  describe('acquisition.candidates', () => {
+    it('pages a mixed movie/episode/pack result set and returns a resumable cursor', async () => {
+      const h = makeHarness();
+      const movie = makeMedia({ id: 1 });
+      const series = makeMedia({ id: 2, type: MediaType.SERIES });
+      const season = makeSeason({ id: 20, mediaId: 2 });
+      const ep1 = makeEpisode({ id: 201, season, episodeNumber: 1 });
+      const ep2 = makeEpisode({ id: 202, season, episodeNumber: 2 });
+
+      h.acquisitionCandidates.listMovieTargets.mockResolvedValue([
+        { media: movie, files: [] },
+      ]);
+      h.acquisitionCandidates.listEpisodeTargets.mockResolvedValue([
+        { media: series, season, episode: ep1, files: [] },
+        { media: series, season, episode: ep2, files: [] },
+      ]);
+      h.acquisitionCandidates.groupIntoSeasonPacks.mockResolvedValue([
+        {
+          media: series,
+          season,
+          episodes: [ep1, ep2],
+          files: [],
+          totalEpisodeCount: 2,
+        },
+      ]);
+      h.autoGrab.classifyForSearch.mockReturnValue({
+        mode: 'missing',
+        minRankExclusive: 0,
+        maxRankInclusive: 10,
+      });
+
+      const page1 = await h.host['acquisition.candidates']({
+        availableOn: '2099-01-01',
+        limit: 1,
+      });
+      expect(page1.items).toHaveLength(1);
+      expect(page1.cursor).toBe('1');
+      expectJsonSafe(page1);
+
+      const page2 = await h.host['acquisition.candidates']({
+        availableOn: '2099-01-01',
+        limit: 1,
+        cursor: page1.cursor!,
+      });
+      expect(page2.items).toHaveLength(1);
+      expect(page2.cursor).toBeNull();
+      expectJsonSafe(page2);
+    });
+
+    it('clamps the limit to the contract bound', async () => {
+      const h = makeHarness();
+      h.acquisitionCandidates.listMovieTargets.mockResolvedValue([]);
+      h.acquisitionCandidates.listEpisodeTargets.mockResolvedValue([]);
+      const result = await h.host['acquisition.candidates']({
+        availableOn: '2099-01-01',
+        limit: 999999,
+      });
+      expect(result.items).toEqual([]);
+      expectJsonSafe(result);
+    });
+
+    it('respects kind: "movie" by skipping the series query entirely', async () => {
+      const h = makeHarness();
+      h.acquisitionCandidates.listMovieTargets.mockResolvedValue([]);
+      await h.host['acquisition.candidates']({
+        kind: 'movie',
+        availableOn: '2099-01-01',
+        limit: 10,
+      });
+      expect(h.acquisitionCandidates.listEpisodeTargets).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // A3 — releases.match
+  // ===========================================================================
+
+  describe('releases.match', () => {
+    it('reports unmatched, then grab, for a title that matches a missing monitored movie', async () => {
+      const h = makeHarness();
+      const media = makeMedia({ title: 'Some Great Movie' });
+      h.mediaRepo.find.mockResolvedValue([media]);
+      h.mediaFileRepo.find.mockResolvedValue([]);
+      h.autoGrab.classifyForSearch.mockReturnValue({
+        mode: 'missing',
+        minRankExclusive: 0,
+        maxRankInclusive: 100,
+      });
+
+      const result = await h.host['releases.match']({
+        titles: [
+          {
+            id: 'a',
+            title: 'Some.Great.Movie.2020.1080p.WEB-DL',
+            publishDate: new Date().toISOString(),
+          },
+          {
+            id: 'b',
+            title: 'Totally.Unrelated.Thing.2019.720p',
+            publishDate: new Date().toISOString(),
+          },
+        ],
+      });
+
+      expect(result.find((r) => r.id === 'a')).toMatchObject({
+        decision: 'grab',
+        mediaId: media.id,
+      });
+      expect(result.find((r) => r.id === 'b')).toMatchObject({
+        decision: 'skip',
+        skipReason: 'unmatched',
+      });
+      expectJsonSafe(result);
+    });
+
+    it('skips a release fresher than minAgeMinutes', async () => {
+      const h = makeHarness();
+      const media = makeMedia({ title: 'Fresh Movie' });
+      h.mediaRepo.find.mockResolvedValue([media]);
+      h.mediaFileRepo.find.mockResolvedValue([]);
+      h.autoGrab.classifyForSearch.mockReturnValue({
+        mode: 'missing',
+        minRankExclusive: 0,
+        maxRankInclusive: 100,
+      });
+
+      const result = await h.host['releases.match']({
+        titles: [
+          {
+            id: 'a',
+            title: 'Fresh.Movie.2020.1080p',
+            publishDate: new Date().toISOString(),
+          },
+        ],
+        minAgeMinutes: 60,
+      });
+      expect(result[0]).toMatchObject({
+        decision: 'skip',
+        skipReason: 'too-fresh',
+      });
+      expectJsonSafe(result);
+    });
+
+    it('skips on-disk and unprofiled decisions with the matching reason', async () => {
+      const h = makeHarness();
+      const media = makeMedia({ title: 'Owned Movie' });
+      h.mediaRepo.find.mockResolvedValue([media]);
+      h.mediaFileRepo.find.mockResolvedValue([]);
+
+      h.autoGrab.classifyForSearch.mockReturnValue({ mode: 'skip' });
+      let result = await h.host['releases.match']({
+        titles: [
+          {
+            id: 'a',
+            title: 'Owned.Movie.2020.1080p',
+            publishDate: new Date().toISOString(),
+          },
+        ],
+      });
+      expect(result[0]).toMatchObject({ skipReason: 'on-disk' });
+
+      h.autoGrab.classifyForSearch.mockReturnValue({ mode: 'unprofiled' });
+      result = await h.host['releases.match']({
+        titles: [
+          {
+            id: 'a',
+            title: 'Owned.Movie.2020.1080p',
+            publishDate: new Date().toISOString(),
+          },
+        ],
+      });
+      expect(result[0]).toMatchObject({ skipReason: 'unprofiled' });
+    });
+
+    it('flags a series episode that does not exist yet as not-available', async () => {
+      const h = makeHarness();
+      const media = makeMedia({ title: 'A Show', type: MediaType.SERIES });
+      h.mediaRepo.find.mockResolvedValue([media]);
+      h.seasonRepo.findOne.mockResolvedValue(makeSeason());
+      h.episodeRepo.findOne.mockResolvedValue(null);
+
+      const result = await h.host['releases.match']({
+        titles: [
+          {
+            id: 'a',
+            title: 'A.Show.S01E09.1080p',
+            publishDate: new Date().toISOString(),
+          },
+        ],
+      });
+      expect(result[0]).toMatchObject({
+        decision: 'skip',
+        skipReason: 'not-available',
+        seasonNumber: 1,
+      });
+      expectJsonSafe(result);
+    });
+  });
+
+  // ===========================================================================
+  // A4 — releases.score
+  // ===========================================================================
+
+  describe('releases.score', () => {
+    it('scores, ranks and carries the caller-supplied release id through', async () => {
+      const h = makeHarness();
+      h.mediaRepo.findOne.mockResolvedValue(makeMedia({ runtime: 120 }));
+      h.profiles.resolveAllowedForMedia.mockReturnValue({
+        allowed: new Set([9]),
+        allowedLangs: new Set(),
+      });
+      h.qualityDefs.getSizeLimitsMap.mockResolvedValue(new Map());
+
+      const result = await h.host['releases.score']({
+        mediaId: 1,
+        releases: [
+          {
+            id: 'r1',
+            title: 'A Movie 2020 1080p WEB-DL',
+            size: 4_000_000_000,
+            seeders: 10,
+            leechers: 2,
+            publishDate: new Date().toISOString(),
+            sourceRef: 'indexer-a',
+          },
+        ],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('r1');
+      expect(typeof result[0].qualityId).toBe('number');
+      expect(Array.isArray(result[0].rejections)).toBe(true);
+      expectJsonSafe(result);
+    });
+
+    it('returns [] for an unknown media id, and renders rejection params as a detail string', async () => {
+      const h = makeHarness();
+      h.mediaRepo.findOne.mockResolvedValueOnce(null);
+      expect(
+        await h.host['releases.score']({ mediaId: 999, releases: [] }),
+      ).toEqual([]);
+
+      h.mediaRepo.findOne.mockResolvedValue(makeMedia({ runtime: 120 }));
+      h.profiles.resolveAllowedForMedia.mockReturnValue({
+        allowed: new Set(),
+        allowedLangs: new Set(),
+      });
+      const result = await h.host['releases.score']({
+        mediaId: 1,
+        releases: [
+          {
+            id: 'r1',
+            title: 'A Movie 2020 1080p WEB-DL',
+            size: 4_000_000_000,
+            seeders: 10,
+            leechers: 2,
+            publishDate: new Date().toISOString(),
+            sourceRef: 'indexer-a',
+            minSeeders: 50,
+          },
+        ],
+      });
+      expect(result[0].rejections.some((r) => r.code === 'MIN_SEEDERS')).toBe(
+        true,
+      );
+      expect(
+        result[0].rejections.find((r) => r.code === 'MIN_SEEDERS')?.detail,
+      ).toMatch(/actual=10/);
+      expectJsonSafe(result);
+    });
+  });
+
+  // ===========================================================================
+  // A5 — media.resolve
+  // ===========================================================================
+
+  describe('media.resolve', () => {
+    it('resolves media/season/episode ids under prefixed keys, with the cleanup profile inlined', async () => {
+      const h = makeHarness();
+      const media = makeMedia({
+        id: 5,
+        library: { id: 7, path: '/lib', stalledCleanupProfile: 'fast' },
+      });
+      const season = makeSeason({ id: 50, media });
+      const episode = makeEpisode({ id: 500, season, episodeNumber: 3 });
+      h.mediaRepo.find.mockResolvedValue([media]);
+      h.seasonRepo.find.mockResolvedValue([season]);
+      h.episodeRepo.find.mockResolvedValue([episode]);
+      h.cleanupProfileRepo.findOne.mockResolvedValue({
+        key: 'fast',
+        samples: 3,
+        intervalMinutes: 5,
+        autoRestart: true,
+      });
+
+      const result = await h.host['media.resolve']({
+        mediaIds: [5],
+        seasonIds: [50],
+        episodeIds: [500],
+      });
+      expect(Object.keys(result).sort()).toEqual([
+        'episode:500',
+        'media:5',
+        'season:50',
+      ]);
+      expect(result['media:5'].stalledCleanupProfile).toEqual({
+        key: 'fast',
+        samples: 3,
+        intervalMinutes: 5,
+        autoRestart: true,
+      });
+      expect(result['episode:500'].episodeNumber).toBe(3);
+      expectJsonSafe(result);
+    });
+
+    it('refuses a batch bigger than the queue page bound', async () => {
+      const h = makeHarness();
+      const mediaIds = Array.from({ length: 101 }, (_, i) => i + 1);
+      await expect(h.host['media.resolve']({ mediaIds })).rejects.toThrow(
+        /limit/,
+      );
+    });
+  });
+
+  // ===========================================================================
+  // A6 — media.exists
+  // ===========================================================================
+
+  describe('media.exists', () => {
+    it('returns only the ids that exist', async () => {
+      const h = makeHarness();
+      h.mediaRepo.find.mockResolvedValue([{ id: 2 }, { id: 3 }]);
+      const result = await h.host['media.exists']({ mediaIds: [1, 2, 3] });
+      expect(result).toEqual([2, 3]);
+      expectJsonSafe(result);
+    });
+
+    it('short-circuits on an empty input without querying', async () => {
+      const h = makeHarness();
+      const result = await h.host['media.exists']({ mediaIds: [] });
+      expect(result).toEqual([]);
+      expect(h.mediaRepo.find).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // B1 — blocklist.add
+  // ===========================================================================
+
+  describe('blocklist.add', () => {
+    it('creates a row and returns its id', async () => {
+      const h = makeHarness();
+      h.blocklist.create.mockResolvedValue({ id: 77 });
+      const result = await h.host['blocklist.add']({
+        idempotencyKey: 'k1',
+        sourceTitle: 'Some.Release',
+        note: 'blocked',
+      });
+      expect(result).toEqual({ id: 77 });
+      expectJsonSafe(result);
+    });
+
+    it('treats a duplicate sourceTitle as an idempotent success, not an error', async () => {
+      const h = makeHarness();
+      h.blocklist.create.mockRejectedValue({ code: '23505' });
+      h.blocklistEntryRepo.createQueryBuilder.mockReturnValue(
+        fakeQueryBuilder([], { id: 5 }),
+      );
+      const result = await h.host['blocklist.add']({
+        idempotencyKey: 'k1',
+        sourceTitle: 'Some.Release',
+        note: 'blocked',
+      });
+      expect(result).toEqual({ id: 5 });
+    });
+  });
+
+  // ===========================================================================
+  // B2 — blocklist.check
+  // ===========================================================================
+
+  describe('blocklist.check', () => {
+    it('reports which titles are blocked', async () => {
+      const h = makeHarness();
+      h.blocklist.isBlocked.mockImplementation((t: string) =>
+        Promise.resolve(t === 'Blocked.Release'),
+      );
+      const result = await h.host['blocklist.check']({
+        titles: ['Blocked.Release', 'Clean.Release'],
+      });
+      expect(result).toEqual({ blocked: ['Blocked.Release'] });
+      expectJsonSafe(result);
+    });
+  });
+
+  // ===========================================================================
+  // B3 — requests.markInProgress
+  // ===========================================================================
+
+  describe('requests.markInProgress', () => {
+    it('delegates to RequestLifecycleService with mediaId + seasonNumber', async () => {
+      const h = makeHarness();
+      await h.host['requests.markInProgress']({
+        idempotencyKey: 'k',
+        mediaId: 5,
+        seasonNumber: 2,
+      });
+      expect(h.requestLifecycle.markInProgress).toHaveBeenCalledWith(5, 2);
+    });
+
+    it('returns void, trivially serialisable', async () => {
+      const h = makeHarness();
+      const result = await h.host['requests.markInProgress']({
+        idempotencyKey: 'k',
+        mediaId: 5,
+      });
+      expect(result).toBeUndefined();
+      expectJsonSafe(result === undefined ? null : result);
+    });
+  });
+
+  // ===========================================================================
+  // C1 — library.ingest
+  // ===========================================================================
+
+  describe('library.ingest', () => {
+    let tmpRoot: string;
+    let sourceFile: string;
+
+    beforeEach(() => {
+      tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fliks-host-ingest-'));
+      sourceFile = path.join(tmpRoot, 'movie.mkv');
+      fs.writeFileSync(sourceFile, 'data');
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    });
+
+    it('resolves paths under the registered ingest root and strips the entity down to plain fields', async () => {
+      const h = makeHarness();
+      h.pluginRegistrationRepo.findOne.mockResolvedValue({
+        ingestRoots: [tmpRoot],
+      });
+      h.mediaRepo.findOne.mockResolvedValue(makeMedia());
+      h.libraryIngestService.ingest.mockResolvedValue({
+        imported: [
+          {
+            file: {
+              id: 55,
+              relativePath: 'Movie (2020)/Movie.mkv',
+              quality: '1080p',
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              media: {},
+            },
+            episodeId: undefined,
+            seasonId: undefined,
+            sourcePath: sourceFile,
+          },
+        ],
+      });
+
+      const result = await h.host['library.ingest']({
+        idempotencyKey: 'k1',
+        mediaId: 1,
+        paths: [sourceFile],
+        transfer: 'copy',
+        sourceLabel: 'Release.Name',
+      });
+
+      expect(result.imported).toEqual([
+        {
+          mediaFileId: 55,
+          relativePath: 'Movie (2020)/Movie.mkv',
+          quality: '1080p',
+        },
+      ]);
+      expect(Object.keys(result.imported[0]).sort()).toEqual([
+        'mediaFileId',
+        'quality',
+        'relativePath',
+      ]);
+      expectJsonSafe(result);
+      expect(h.notifications.dispatch).toHaveBeenCalledWith(
+        'download.complete',
+        expect.any(Object),
+      );
+    });
+
+    it('refuses a path outside every configured ingest root', async () => {
+      const h = makeHarness();
+      const otherRoot = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'fliks-host-other-'),
+      );
+      h.pluginRegistrationRepo.findOne.mockResolvedValue({
+        ingestRoots: [otherRoot],
+      });
+      await expect(
+        h.host['library.ingest']({
+          idempotencyKey: 'k1',
+          mediaId: 1,
+          paths: [sourceFile],
+          transfer: 'copy',
+          sourceLabel: 'Release.Name',
+        }),
+      ).rejects.toThrow(/outside/);
+      fs.rmSync(otherRoot, { recursive: true, force: true });
+    });
+
+    it('refuses when the plugin has no ingestRoots configured at all', async () => {
+      const h = makeHarness();
+      h.pluginRegistrationRepo.findOne.mockResolvedValue(null);
+      await expect(
+        h.host['library.ingest']({
+          idempotencyKey: 'k1',
+          mediaId: 1,
+          paths: [sourceFile],
+          transfer: 'copy',
+          sourceLabel: 'Release.Name',
+        }),
+      ).rejects.toThrow(/ingestRoots/);
+    });
+  });
+
+  // ===========================================================================
+  // D1 — events.publish
+  // ===========================================================================
+
+  describe('events.publish', () => {
+    it('routes acquisition.grabbed to the domain bus and a queue refresh', async () => {
+      const h = makeHarness();
+      await h.host['events.publish']([
+        {
+          type: 'acquisition.grabbed',
+          mediaId: 1,
+          sourceTitle: 'x',
+          quality: '1080p',
+        },
+      ]);
+      expect(h.events.emitDomain).toHaveBeenCalledWith({
+        type: 'acquisition.grabbed',
+        mediaId: 1,
+        seasonNumber: undefined,
+      });
+      expect(h.events.emit).toHaveBeenCalledWith({ type: 'queue.updated' });
+    });
+
+    it('resolves the SSE audience for acquisition.imported / acquisition.failed', async () => {
+      const h = makeHarness();
+      h.mediaRepo.findOne.mockResolvedValue(
+        makeMedia({ title: 'Imported Title' }),
+      );
+      await h.host['events.publish']([
+        { type: 'acquisition.imported', mediaId: 1 },
+      ]);
+      expect(h.sseAudience.recipientsForMedia).toHaveBeenCalledWith(1);
+      expect(h.events.emitToUsers).toHaveBeenCalledWith(
+        [9],
+        expect.objectContaining({
+          type: 'import.complete',
+          title: 'Imported Title',
+        }),
+      );
+
+      await h.host['events.publish']([
+        { type: 'acquisition.failed', mediaId: 1, reason: 'boom' },
+      ]);
+      expect(h.events.emitToUsers).toHaveBeenCalledWith(
+        [9],
+        expect.objectContaining({ type: 'import.failed', error: 'boom' }),
+      );
+    });
+
+    it('handles queue.changed and the batched acquisition.progress variant', async () => {
+      const h = makeHarness();
+      h.mediaRepo.findOne.mockResolvedValue(makeMedia());
+      await h.host['events.publish']([
+        { type: 'acquisition.queue.changed' },
+        {
+          type: 'acquisition.progress',
+          mediaId: 1,
+          ref: 'r1',
+          progress: 0.5,
+          etaSeconds: 30,
+          state: 'active',
+        },
+      ]);
+      expect(h.events.emit).toHaveBeenCalledWith({ type: 'queue.updated' });
+      expect(h.events.emitToUsers).toHaveBeenCalledWith(
+        [9],
+        expect.objectContaining({ type: 'download.progress' }),
+      );
+    });
+  });
+
+  // ===========================================================================
+  // D2 — notifications.dispatch
+  // ===========================================================================
+
+  describe('notifications.dispatch', () => {
+    it('forwards to NotificationsService with the closed event name', async () => {
+      const h = makeHarness();
+      await h.host['notifications.dispatch']({
+        event: 'grab.started',
+        payload: { title: 'x' },
+      });
+      expect(h.notifications.dispatch).toHaveBeenCalledWith('grab.started', {
+        title: 'x',
+      });
+    });
+  });
+
+  // ===========================================================================
+  // D3 — counts.set
+  // ===========================================================================
+
+  describe('counts.set', () => {
+    it('is readable back through the push cache, and reports 0 for an unset key', async () => {
+      const h = makeHarness();
+      expect(h.countsCache.get('queueActive')).toBe(0);
+      const result = await h.host['counts.set']({
+        key: 'queueActive',
+        value: 4,
+      });
+      expect(h.countsCache.get('queueActive')).toBe(4);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  // ===========================================================================
+  // D4 — events.emitOwn
+  // ===========================================================================
+
+  describe('events.emitOwn', () => {
+    it('force-prefixes the type with the bound plugin id for a broadcast', async () => {
+      const h = makeHarness('fliks.download');
+      await h.host['events.emitOwn']({
+        type: 'sync.finished',
+        payload: { n: 3 },
+        audience: 'all',
+      });
+      expect(h.events.emitRaw).toHaveBeenCalledWith(
+        'plugin.fliks.download.sync.finished',
+        { n: 3 },
+        null,
+      );
+    });
+
+    it('resolves a media-scoped audience instead of broadcasting', async () => {
+      const h = makeHarness('fliks.download');
+      await h.host['events.emitOwn']({
+        type: 'x',
+        payload: null,
+        audience: { mediaId: 1 },
+      });
+      expect(h.sseAudience.recipientsForMedia).toHaveBeenCalledWith(1);
+      expect(h.events.emitRaw).toHaveBeenCalledWith(
+        'plugin.fliks.download.x',
+        null,
+        [9],
+      );
+    });
+  });
+
+  // ===========================================================================
+  // D5 — progress.set
+  // ===========================================================================
+
+  describe('progress.set', () => {
+    it('emits the reserved download.progress SSE type to the resolved audience', async () => {
+      const h = makeHarness();
+      h.mediaRepo.findOne.mockResolvedValue(
+        makeMedia({ type: MediaType.SERIES }),
+      );
+      await h.host['progress.set']({
+        mediaId: 1,
+        seasonNumber: 1,
+        episodeNumber: 2,
+        ref: 'torrent-hash',
+        progress: 0.42,
+        bytesPerSecond: 1000,
+        state: 'active',
+      });
+      expect(h.events.emitToUsers).toHaveBeenCalledWith(
+        [9],
+        expect.objectContaining({
+          type: 'download.progress',
+          mediaType: 'series',
+          progress: 0.42,
+          dlspeed: 1000,
+        }),
+      );
+    });
+
+    it('emits nothing when the audience is empty', async () => {
+      const h = makeHarness();
+      h.sseAudience.recipientsForMedia.mockResolvedValue([]);
+      await h.host['progress.set']({
+        mediaId: 1,
+        ref: 'r',
+        progress: 0.1,
+        state: 'active',
+      });
+      expect(h.events.emitToUsers).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // E1 — config.get
+  // ===========================================================================
+
+  describe('config.get', () => {
+    it('reads only under the plugin.<id>. prefix and strips it back off', async () => {
+      const h = makeHarness('fliks.download');
+      h.settings.getAll.mockResolvedValue({
+        'plugin.fliks.download.rssSyncInterval': '15',
+        'plugin.other.plugin.secret': 'nope',
+        naming_movie_format: 'x',
+      });
+      const result = await h.host['config.get']({});
+      expect(result).toEqual({ rssSyncInterval: '15' });
+      expectJsonSafe(result);
+    });
+
+    it('reads individually requested keys', async () => {
+      const h = makeHarness('fliks.download');
+      h.settings.get.mockImplementation((k: string) =>
+        Promise.resolve(k === 'plugin.fliks.download.foo' ? 'bar' : null),
+      );
+      const result = await h.host['config.get']({ keys: ['foo', 'missing'] });
+      expect(result).toEqual({ foo: 'bar' });
+      expectJsonSafe(result);
+    });
+  });
+
+  // ===========================================================================
+  // E2 — config.set
+  // ===========================================================================
+
+  describe('config.set', () => {
+    it('writes under the derived prefix, never a bare key', async () => {
+      const h = makeHarness('fliks.download');
+      await h.host['config.set']({ key: 'foo', value: 'bar' });
+      expect(h.settings.set).toHaveBeenCalledWith(
+        'plugin.fliks.download.foo',
+        'bar',
+      );
+    });
+  });
+});

--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -1,0 +1,1125 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import * as fs from 'fs';
+import * as path from 'path';
+import type {
+  AcquisitionEvent,
+  AcquisitionTarget,
+  MediaKind,
+  PluginHostApi,
+} from '../../../common/plugin-contract';
+import { MediaType } from '../../../common/enums';
+import { Media } from '../../media/entities/media.entity';
+import { Season } from '../../media/entities/season.entity';
+import { Episode } from '../../media/entities/episode.entity';
+import { MediaFile } from '../../media/entities/media-file.entity';
+import {
+  AutoGrabPipelineService,
+  type SearchDecision,
+} from '../../media/auto-grab-pipeline.service';
+import {
+  AcquisitionCandidatesService,
+  type EpisodeTarget,
+  type MovieTarget,
+  type SeasonPackTarget,
+} from '../../media/acquisition-candidates.service';
+import { ProfilesService } from '../../profiles/profiles.service';
+import { QualityDefinitionsService } from '../../profiles/quality-definitions.service';
+import { CustomFormatsService } from '../../profiles/custom-formats.service';
+import { BlocklistService } from '../../blocklist/blocklist.service';
+import { BlocklistEntry } from '../../blocklist/entities/blocklist-entry.entity';
+import { RequestLifecycleService } from '../../requests/request-lifecycle.service';
+import { LibraryIngestService } from '../../../common/library-ingest/library-ingest.service';
+import { NotificationsService } from '../../notifications/notifications.service';
+import { MediaServersService } from '../../media-servers/media-servers.service';
+import { SettingsService } from '../../settings/settings.service';
+import { EventsService } from '../../scheduler/events.service';
+import { SseAudienceService } from '../../scheduler/sse-audience.service';
+import { PluginRegistration } from '../entities/plugin-registration.entity';
+import { CleanupProfile } from '../../cleanup-profiles/entities/cleanup-profile.entity';
+import {
+  maxResolutionFromQualityStrings,
+  rankFromQualityString,
+  resolveSearchTitles,
+  scoreAndSortReleases,
+  titleMatchesExpectation,
+  type ReleaseCandidate,
+} from '../../../common/release-scoring';
+import { parseSeasonEpisode } from '../../../common/release-parsing';
+import { PluginCountsCacheService } from './plugin-counts-cache.service';
+import { PLUGIN_HOST_PLUGIN_ID } from './plugin-host.constants';
+
+/** `media.resolve`'s own bound — restated because `plugins/download/` (where the
+ *  original `QUEUE_PAGE_SIZE_MAX` lives) is outside this file's import boundary. */
+const QUEUE_PAGE_SIZE_MAX = 100;
+
+/** `acquisition.candidates`'s own bound, per the contract's doc comment. */
+const MAX_CANDIDATES_LIMIT = 500;
+
+type ReleaseMatchResult = Awaited<
+  ReturnType<PluginHostApi['releases.match']>
+>[number];
+type SkipReason = NonNullable<ReleaseMatchResult['skipReason']>;
+type ScoredReleaseOut = Awaited<
+  ReturnType<PluginHostApi['releases.score']>
+>[number];
+type MediaResolveEntry = Awaited<
+  ReturnType<PluginHostApi['media.resolve']>
+>[string];
+
+function rejectionDetail(rejection: {
+  params?: Record<string, number | string>;
+}): string | undefined {
+  if (!rejection.params) return undefined;
+  const parts = Object.entries(rejection.params).map(([k, v]) => `${k}=${v}`);
+  return parts.length ? parts.join(', ') : undefined;
+}
+
+function isUniqueViolation(e: unknown): boolean {
+  return (
+    typeof e === 'object' &&
+    e !== null &&
+    (e as { code?: string }).code === '23505'
+  );
+}
+
+/**
+ * Core's implementation of the 17 plugin-facing host methods. Every value it
+ * returns is a plain, JSON-safe object built field-by-field from entities —
+ * never the entity itself — because the same shape crosses a socket once the
+ * transport changes (Phase 10.4).
+ */
+@Injectable()
+export class FliksHostImpl implements PluginHostApi {
+  constructor(
+    @Inject(PLUGIN_HOST_PLUGIN_ID) private readonly pluginId: string,
+    @InjectRepository(Media) private readonly mediaRepo: Repository<Media>,
+    @InjectRepository(Season) private readonly seasonRepo: Repository<Season>,
+    @InjectRepository(Episode)
+    private readonly episodeRepo: Repository<Episode>,
+    @InjectRepository(MediaFile)
+    private readonly mediaFileRepo: Repository<MediaFile>,
+    @InjectRepository(BlocklistEntry)
+    private readonly blocklistEntryRepo: Repository<BlocklistEntry>,
+    @InjectRepository(PluginRegistration)
+    private readonly pluginRegistrationRepo: Repository<PluginRegistration>,
+    @InjectRepository(CleanupProfile)
+    private readonly cleanupProfileRepo: Repository<CleanupProfile>,
+    private readonly autoGrab: AutoGrabPipelineService,
+    private readonly acquisitionCandidates: AcquisitionCandidatesService,
+    private readonly profiles: ProfilesService,
+    private readonly qualityDefs: QualityDefinitionsService,
+    private readonly customFormats: CustomFormatsService,
+    private readonly blocklist: BlocklistService,
+    private readonly requestLifecycle: RequestLifecycleService,
+    private readonly libraryIngestService: LibraryIngestService,
+    private readonly notifications: NotificationsService,
+    private readonly mediaServers: MediaServersService,
+    private readonly settings: SettingsService,
+    private readonly events: EventsService,
+    private readonly sseAudience: SseAudienceService,
+    private readonly countsCache: PluginCountsCacheService,
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // Group A — read
+  // ---------------------------------------------------------------------------
+
+  'media.acquisitionContext': PluginHostApi['media.acquisitionContext'] = (p) =>
+    this.acquisitionContext(p);
+  'acquisition.candidates': PluginHostApi['acquisition.candidates'] = (p) =>
+    this.candidates(p);
+  'releases.match': PluginHostApi['releases.match'] = (p) =>
+    this.releasesMatch(p);
+  'releases.score': PluginHostApi['releases.score'] = (p) =>
+    this.releasesScore(p);
+  'media.resolve': PluginHostApi['media.resolve'] = (p) => this.mediaResolve(p);
+  'media.exists': PluginHostApi['media.exists'] = (p) => this.mediaExists(p);
+
+  // ---------------------------------------------------------------------------
+  // Group B — write acquisition state
+  // ---------------------------------------------------------------------------
+
+  'blocklist.add': PluginHostApi['blocklist.add'] = (p) => this.blocklistAdd(p);
+  'blocklist.check': PluginHostApi['blocklist.check'] = (p) =>
+    this.blocklistCheck(p);
+  'requests.markInProgress': PluginHostApi['requests.markInProgress'] = (p) =>
+    this.requestsMarkInProgress(p);
+
+  // ---------------------------------------------------------------------------
+  // Group C — ingest
+  // ---------------------------------------------------------------------------
+
+  'library.ingest': PluginHostApi['library.ingest'] = (p) =>
+    this.libraryIngest(p);
+
+  // ---------------------------------------------------------------------------
+  // Group D — events and outbound
+  // ---------------------------------------------------------------------------
+
+  'events.publish': PluginHostApi['events.publish'] = (p) =>
+    this.eventsPublish(p);
+  'notifications.dispatch': PluginHostApi['notifications.dispatch'] = (p) =>
+    this.notificationsDispatch(p);
+  'counts.set': PluginHostApi['counts.set'] = (p) => this.countsSet(p);
+  'events.emitOwn': PluginHostApi['events.emitOwn'] = (p) =>
+    this.eventsEmitOwn(p);
+  'progress.set': PluginHostApi['progress.set'] = (p) => this.progressSet(p);
+
+  // ---------------------------------------------------------------------------
+  // Group E — config
+  // ---------------------------------------------------------------------------
+
+  'config.get': PluginHostApi['config.get'] = (p) => this.configGet(p);
+  'config.set': PluginHostApi['config.set'] = (p) => this.configSet(p);
+
+  // ===========================================================================
+  // A1 — media.acquisitionContext
+  // ===========================================================================
+
+  private async acquisitionContext(p: {
+    mediaId: number;
+    seasonId?: number;
+    episodeId?: number;
+  }): Promise<AcquisitionTarget | null> {
+    const media = await this.mediaRepo.findOne({ where: { id: p.mediaId } });
+    if (!media || media.libraryId == null) return null;
+
+    let season: Season | null = null;
+    let episode: Episode | null = null;
+    if (p.episodeId != null) {
+      episode = await this.episodeRepo.findOne({
+        where: { id: p.episodeId },
+        relations: ['season'],
+      });
+      if (!episode?.season || episode.season.mediaId !== media.id) return null;
+      season = episode.season;
+    } else if (p.seasonId != null) {
+      season = await this.seasonRepo.findOne({ where: { id: p.seasonId } });
+      if (!season || season.mediaId !== media.id) return null;
+    }
+
+    const files = await this.filesForClassification(media, season, episode);
+    // A whole-series lookup (series, no season/episode scope) has no single
+    // quality to classify — nothing to grab at that granularity.
+    const isWholeSeriesLookup =
+      media.type !== MediaType.MOVIE && !season && !episode;
+    const decision = isWholeSeriesLookup
+      ? null
+      : this.autoGrab.classifyForSearch(media, files);
+    const target = this.buildAcquisitionTarget(media, decision, files);
+    if (!target) return null;
+
+    if (season) {
+      const episodeCount = episode
+        ? await this.episodeRepo.count({ where: { season: { id: season.id } } })
+        : (await this.episodesOfSeason(season.id)).length;
+      target.season = {
+        id: season.id,
+        number: season.seasonNumber,
+        episodeCount,
+      };
+    }
+    if (episode) {
+      target.episode = {
+        id: episode.id,
+        number: episode.episodeNumber,
+        endNumber: episode.endEpisodeNumber,
+        airDate: episode.airDate ?? null,
+      };
+    }
+    return target;
+  }
+
+  // ===========================================================================
+  // A2 — acquisition.candidates
+  // ===========================================================================
+
+  private async candidates(p: {
+    kind?: MediaKind;
+    mediaIds?: number[];
+    availableOn: string;
+    limit: number;
+    cursor?: string;
+  }): Promise<{ items: AcquisitionTarget[]; cursor: string | null }> {
+    const limit = Math.min(
+      Math.max(Math.trunc(p.limit) || 1, 1),
+      MAX_CANDIDATES_LIMIT,
+    );
+    const wantMovies = p.kind !== 'series';
+    const wantSeries = p.kind !== 'movie';
+    const targets: AcquisitionTarget[] = [];
+
+    if (wantMovies) {
+      const movieTargets = await this.acquisitionCandidates.listMovieTargets(
+        p.mediaIds,
+      );
+      for (const t of movieTargets) {
+        if (t.media.releaseDate && t.media.releaseDate > p.availableOn)
+          continue;
+        const target = this.buildFromMovieTarget(t);
+        if (target) targets.push(target);
+      }
+    }
+
+    if (wantSeries) {
+      const episodeTargets = (
+        await this.acquisitionCandidates.listEpisodeTargets(p.mediaIds)
+      ).filter((t) => !t.episode.airDate || t.episode.airDate <= p.availableOn);
+      const packs =
+        await this.acquisitionCandidates.groupIntoSeasonPacks(episodeTargets);
+      const packedSeasonIds = new Set(packs.map((pk) => pk.season.id));
+      const singles = episodeTargets.filter(
+        (t) => !packedSeasonIds.has(t.season.id),
+      );
+      const episodeCountBySeason = await this.episodeCountsBySeasons([
+        ...new Set(singles.map((t) => t.season.id)),
+      ]);
+
+      for (const pk of packs) {
+        const target = this.buildFromSeasonPackTarget(pk);
+        if (target) targets.push(target);
+      }
+      for (const t of singles) {
+        const target = this.buildFromEpisodeTarget(
+          t,
+          episodeCountBySeason.get(t.season.id) ?? 1,
+        );
+        if (target) targets.push(target);
+      }
+    }
+
+    targets.sort(
+      (a, b) =>
+        a.mediaId - b.mediaId ||
+        (a.season?.id ?? 0) - (b.season?.id ?? 0) ||
+        (a.episode?.id ?? 0) - (b.episode?.id ?? 0),
+    );
+
+    const offset = p.cursor ? Math.max(0, parseInt(p.cursor, 10) || 0) : 0;
+    const items = targets.slice(offset, offset + limit);
+    const cursor =
+      offset + items.length < targets.length
+        ? String(offset + items.length)
+        : null;
+    return { items, cursor };
+  }
+
+  // ===========================================================================
+  // A3 — releases.match
+  // ===========================================================================
+
+  private async releasesMatch(p: {
+    titles: { id: string; title: string; publishDate: string }[];
+    minAgeMinutes?: number;
+  }): Promise<ReleaseMatchResult[]> {
+    const library = await this.mediaRepo.find({ where: { monitored: true } });
+    const out: ReleaseMatchResult[] = [];
+    for (const entry of p.titles) {
+      out.push(await this.matchOneRelease(entry, library, p.minAgeMinutes));
+    }
+    return out;
+  }
+
+  private async matchOneRelease(
+    entry: { id: string; title: string; publishDate: string },
+    library: Media[],
+    minAgeMinutes: number | undefined,
+  ): Promise<ReleaseMatchResult> {
+    const se = parseSeasonEpisode(entry.title);
+    const skip = (
+      skipReason: SkipReason,
+      mediaId: number | null = null,
+      extra?: { seasonNumber?: number; episodeNumber?: number },
+    ): ReleaseMatchResult => ({
+      id: entry.id,
+      mediaId,
+      isFullSeason: se.isFullSeason,
+      decision: 'skip',
+      skipReason,
+      ...extra,
+    });
+
+    const media = library.find((m) =>
+      titleMatchesExpectation(entry.title, [
+        m.title,
+        m.originalTitle ?? '',
+        ...(m.alternativeTitles ?? []),
+      ]),
+    );
+    if (!media) return skip('unmatched');
+    if (!media.monitored) return skip('not-monitored', media.id);
+
+    let files: { quality?: string | null }[] = [];
+    let seasonNumber: number | undefined;
+    let episodeNumber: number | undefined;
+
+    if (media.type === MediaType.SERIES) {
+      if (se.season == null) return skip('not-available', media.id);
+      const season = await this.seasonRepo.findOne({
+        where: { media: { id: media.id }, seasonNumber: se.season },
+      });
+      if (!season) return skip('not-available', media.id);
+      if (!season.monitored)
+        return skip('not-monitored', media.id, {
+          seasonNumber: season.seasonNumber,
+        });
+      seasonNumber = season.seasonNumber;
+
+      if (se.isFullSeason) {
+        const episodes = await this.episodesOfSeason(season.id);
+        if (!episodes.length)
+          return skip('not-available', media.id, { seasonNumber });
+        files = await this.filesForSeasonPack(episodes);
+      } else if (se.episode != null) {
+        const episode = await this.episodeRepo.findOne({
+          where: { season: { id: season.id }, episodeNumber: se.episode },
+        });
+        if (!episode) return skip('not-available', media.id, { seasonNumber });
+        if (!episode.monitored) {
+          return skip('not-monitored', media.id, {
+            seasonNumber,
+            episodeNumber: episode.episodeNumber,
+          });
+        }
+        episodeNumber = episode.episodeNumber;
+        files = await this.filesForEpisode(episode);
+      } else {
+        return skip('not-available', media.id, { seasonNumber });
+      }
+    } else {
+      files = (
+        await this.mediaFileRepo.find({ where: { media: { id: media.id } } })
+      ).map((f) => ({
+        quality: f.quality,
+      }));
+    }
+
+    const decision = this.autoGrab.classifyForSearch(media, files);
+    if (decision.mode === 'unprofiled')
+      return skip('unprofiled', media.id, { seasonNumber, episodeNumber });
+    if (decision.mode === 'skip')
+      return skip('on-disk', media.id, { seasonNumber, episodeNumber });
+
+    if (minAgeMinutes) {
+      const ageMinutes = (Date.now() - Date.parse(entry.publishDate)) / 60000;
+      if (Number.isFinite(ageMinutes) && ageMinutes < minAgeMinutes) {
+        return skip('too-fresh', media.id, { seasonNumber, episodeNumber });
+      }
+    }
+
+    return {
+      id: entry.id,
+      mediaId: media.id,
+      seasonNumber,
+      episodeNumber,
+      isFullSeason: se.isFullSeason,
+      decision: 'grab',
+    };
+  }
+
+  // ===========================================================================
+  // A4 — releases.score
+  // ===========================================================================
+
+  private async releasesScore(p: {
+    mediaId: number;
+    seasonNumber?: number;
+    episodeNumber?: number;
+    releases: {
+      id: string;
+      title: string;
+      size: number;
+      seeders: number;
+      leechers: number;
+      publishDate: string;
+      freeleech?: boolean;
+      downloadVolumeFactor?: number;
+      sourceRef: string;
+      minSeeders?: number;
+      unknownLanguageIsoCode?: string;
+    }[];
+  }): Promise<ScoredReleaseOut[]> {
+    const media = await this.mediaRepo.findOne({ where: { id: p.mediaId } });
+    if (!media) return [];
+
+    const { allowed, allowedLangs } =
+      this.profiles.resolveAllowedForMedia(media);
+    const { expectedTitles } = resolveSearchTitles(media);
+    const sizeByQuality = await this.qualityDefs.getSizeLimitsMap();
+
+    type CandidateWithId = ReleaseCandidate & { id: string };
+    const candidates: CandidateWithId[] = p.releases.map((r, i) => ({
+      id: r.id,
+      title: r.title,
+      downloadUrl: '',
+      indexerId: i,
+      indexerName: r.sourceRef,
+      size: r.size,
+      seeders: r.seeders,
+      leechers: r.leechers,
+      publishDate: r.publishDate,
+      freeleech: r.freeleech ?? false,
+      downloadVolumeFactor: r.downloadVolumeFactor ?? 1,
+    }));
+    const indexerMinSeeders = new Map(
+      p.releases.map((r, i) => [i, r.minSeeders ?? 0]),
+    );
+    const indexerUnknownLang = new Map<number, string | undefined>(
+      p.releases.map((r, i) => [i, r.unknownLanguageIsoCode]),
+    );
+
+    // `scoreAndSortReleases` is declared to return `ScoredRelease[]` (no `id`),
+    // but every row is a spread of its input candidate — `id` rides along.
+    const scored = (await scoreAndSortReleases(
+      candidates,
+      {
+        allowed,
+        allowedLangs,
+        sizeByQuality,
+        indexerMinSeeders,
+        indexerUnknownLang,
+        runtimeMinutes: media.runtime ?? 0,
+        expectedTitle: expectedTitles,
+      },
+      {
+        scoreCustomFormats: (title, meta) =>
+          this.customFormats.scoreRelease(title, meta),
+        isBlocked: (title) => this.blocklist.isBlocked(title),
+      },
+    )) as unknown as (CandidateWithId &
+      Awaited<ReturnType<typeof scoreAndSortReleases>>[number])[];
+
+    return scored.map((row) => ({
+      id: row.id,
+      qualityId: row.qualityId,
+      rank: row.rank,
+      allowed: row.allowed,
+      customFormatScore: row.customFormatScore,
+      blocklisted: row.blocklisted,
+      languageId: row.languageId,
+      languageAllowed: row.languageAllowed,
+      isFullSeason: row.isFullSeason,
+      sizeDeviation: row.sizeDeviation ?? 0,
+      videoCodec: row.videoCodec,
+      rejections: row.rejections.map((r) => ({
+        code: r.code,
+        detail: rejectionDetail(r),
+      })),
+    }));
+  }
+
+  // ===========================================================================
+  // A5 — media.resolve
+  // ===========================================================================
+
+  private async mediaResolve(p: {
+    mediaIds?: number[];
+    seasonIds?: number[];
+    episodeIds?: number[];
+  }): Promise<Record<string, MediaResolveEntry>> {
+    const mediaIds = p.mediaIds ?? [];
+    const seasonIds = p.seasonIds ?? [];
+    const episodeIds = p.episodeIds ?? [];
+    const total = mediaIds.length + seasonIds.length + episodeIds.length;
+    if (total > QUEUE_PAGE_SIZE_MAX) {
+      throw new Error(
+        `media.resolve: ${total} ids exceeds the ${QUEUE_PAGE_SIZE_MAX} limit`,
+      );
+    }
+
+    const out: Record<string, MediaResolveEntry> = {};
+
+    if (mediaIds.length) {
+      const rows = await this.mediaRepo.find({ where: { id: In(mediaIds) } });
+      for (const m of rows) out[`media:${m.id}`] = await this.mediaLabel(m);
+    }
+    if (seasonIds.length) {
+      const rows = await this.seasonRepo.find({
+        where: { id: In(seasonIds) },
+        relations: ['media'],
+      });
+      for (const s of rows) {
+        const label = await this.mediaLabel(s.media);
+        out[`season:${s.id}`] = { ...label, seasonNumber: s.seasonNumber };
+      }
+    }
+    if (episodeIds.length) {
+      const rows = await this.episodeRepo.find({
+        where: { id: In(episodeIds) },
+        relations: ['season', 'season.media'],
+      });
+      for (const e of rows) {
+        const label = await this.mediaLabel(e.season.media);
+        out[`episode:${e.id}`] = {
+          ...label,
+          seasonNumber: e.season.seasonNumber,
+          episodeNumber: e.episodeNumber,
+          episodeTitle: e.title ?? undefined,
+        };
+      }
+    }
+    return out;
+  }
+
+  private async mediaLabel(media: Media): Promise<MediaResolveEntry> {
+    const kind: MediaKind = media.type === MediaType.MOVIE ? 'movie' : 'series';
+    const key = media.library?.stalledCleanupProfile;
+    const profile = key
+      ? await this.cleanupProfileRepo.findOne({ where: { key } })
+      : null;
+    return {
+      title: media.title,
+      kind,
+      libraryId: media.libraryId ?? 0,
+      stalledCleanupProfile: profile
+        ? {
+            key: profile.key,
+            samples: profile.samples,
+            intervalMinutes: profile.intervalMinutes,
+            autoRestart: profile.autoRestart,
+          }
+        : null,
+    };
+  }
+
+  // ===========================================================================
+  // A6 — media.exists
+  // ===========================================================================
+
+  private async mediaExists(p: { mediaIds: number[] }): Promise<number[]> {
+    if (!p.mediaIds.length) return [];
+    const rows = await this.mediaRepo.find({
+      where: { id: In(p.mediaIds) },
+      select: { id: true },
+    });
+    return rows.map((r) => r.id);
+  }
+
+  // ===========================================================================
+  // B1 — blocklist.add
+  // ===========================================================================
+
+  private async blocklistAdd(p: {
+    idempotencyKey: string;
+    sourceTitle: string;
+    quality?: string;
+    mediaId?: number;
+    indexerName?: string;
+    downloadUrl?: string;
+    note: string;
+  }): Promise<{ id: number }> {
+    try {
+      const row = await this.blocklist.create({
+        sourceTitle: p.sourceTitle,
+        quality: p.quality,
+        mediaId: p.mediaId,
+        indexerName: p.indexerName,
+        downloadUrl: p.downloadUrl,
+        note: p.note,
+      });
+      return { id: row.id };
+    } catch (e) {
+      // Retrying the same title on a timeout must not error twice — the
+      // sourceTitle unique index is the de-dupe key `idempotencyKey` echoes.
+      if (!isUniqueViolation(e)) throw e;
+      const existing = await this.blocklistEntryRepo
+        .createQueryBuilder('b')
+        .where('LOWER(b.sourceTitle) = LOWER(:t)', { t: p.sourceTitle })
+        .getOne();
+      if (existing) return { id: existing.id };
+      throw e;
+    }
+  }
+
+  // ===========================================================================
+  // B2 — blocklist.check
+  // ===========================================================================
+
+  private async blocklistCheck(p: {
+    titles: string[];
+  }): Promise<{ blocked: string[] }> {
+    const blocked: string[] = [];
+    for (const title of p.titles) {
+      if (await this.blocklist.isBlocked(title)) blocked.push(title);
+    }
+    return { blocked };
+  }
+
+  // ===========================================================================
+  // B3 — requests.markInProgress
+  // ===========================================================================
+
+  private async requestsMarkInProgress(p: {
+    idempotencyKey: string;
+    mediaId: number;
+    seasonNumber?: number;
+  }): Promise<void> {
+    await this.requestLifecycle.markInProgress(p.mediaId, p.seasonNumber);
+  }
+
+  // ===========================================================================
+  // C1 — library.ingest
+  // ===========================================================================
+
+  private async libraryIngest(p: {
+    idempotencyKey: string;
+    mediaId: number;
+    paths: string[];
+    transfer: 'copy' | 'move';
+    fallbackQuality?: string;
+    sourceLabel: string;
+  }): Promise<{
+    imported: { mediaFileId: number; relativePath: string; quality: string }[];
+    seasonNumber?: number;
+    episodeNumber?: number;
+  }> {
+    const registration = await this.pluginRegistrationRepo.findOne({
+      where: { pluginId: this.pluginId },
+    });
+    const roots = registration?.ingestRoots ?? [];
+    if (!roots.length) {
+      throw new Error(
+        `library.ingest: no ingestRoots configured for plugin "${this.pluginId}"`,
+      );
+    }
+    const files = p.paths.map((raw) => ({
+      path: this.resolveUnderIngestRoot(raw, roots),
+    }));
+
+    // `force`/`uniquifyOnCollision` are left false: a retried call resolves
+    // the same destination and is a safe no-op, which is the idempotency
+    // guarantee `idempotencyKey` asks for — no separate dedupe table needed.
+    const result = await this.libraryIngestService.ingest({
+      mediaId: p.mediaId,
+      files,
+      transfer: p.transfer,
+      fallbackQuality: p.fallbackQuality,
+      releaseName: p.sourceLabel,
+      sourceLabel: p.sourceLabel,
+    });
+
+    const imported = result.imported.map((x) => ({
+      mediaFileId: x.file.id,
+      relativePath: x.file.relativePath,
+      quality: x.file.quality,
+    }));
+
+    let seasonNumber: number | undefined;
+    let episodeNumber: number | undefined;
+    if (result.imported.length === 1 && result.imported[0].episodeId != null) {
+      const episode = await this.episodeRepo.findOne({
+        where: { id: result.imported[0].episodeId },
+        relations: ['season'],
+      });
+      if (episode) {
+        episodeNumber = episode.episodeNumber;
+        seasonNumber = episode.season?.seasonNumber;
+      }
+    }
+
+    if (imported.length) {
+      const media = await this.mediaRepo.findOne({ where: { id: p.mediaId } });
+      if (media) {
+        void this.notifications.dispatch('download.complete', {
+          title: media.title,
+          quality: imported[0].quality,
+          sourceTitle: p.sourceLabel,
+        });
+        void this.mediaServers.dispatch('download.complete', {
+          title: media.title,
+          path: media.path,
+        });
+      }
+    }
+
+    return { imported, seasonNumber, episodeNumber };
+  }
+
+  /** `realpath`s `rawPath` and refuses it unless it resolves inside one of `roots`. */
+  private resolveUnderIngestRoot(rawPath: string, roots: string[]): string {
+    const real = fs.realpathSync(rawPath);
+    for (const root of roots) {
+      let realRoot: string;
+      try {
+        realRoot = fs.realpathSync(root);
+      } catch {
+        continue;
+      }
+      const rel = path.relative(realRoot, real);
+      if (rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel)))
+        return real;
+    }
+    throw new Error(
+      `library.ingest: "${rawPath}" is outside every configured ingest root`,
+    );
+  }
+
+  // ===========================================================================
+  // D1 — events.publish
+  // ===========================================================================
+
+  private async eventsPublish(events: AcquisitionEvent[]): Promise<void> {
+    for (const event of events) await this.publishOne(event);
+  }
+
+  private async publishOne(event: AcquisitionEvent): Promise<void> {
+    switch (event.type) {
+      case 'acquisition.grabbed':
+        this.events.emitDomain({
+          type: 'acquisition.grabbed',
+          mediaId: event.mediaId,
+          seasonNumber: event.seasonNumber,
+        });
+        this.events.emit({ type: 'queue.updated' });
+        return;
+      case 'acquisition.imported': {
+        const media = await this.mediaRepo.findOne({
+          where: { id: event.mediaId },
+        });
+        const recipients = await this.sseAudience.recipientsForMedia(
+          event.mediaId,
+        );
+        this.events.emitToUsers(recipients, {
+          type: 'import.complete',
+          mediaId: event.mediaId,
+          title: media?.title ?? '',
+          seasonNumber: event.seasonNumber,
+          episodeNumber: event.episodeNumber,
+        });
+        this.events.emit({ type: 'queue.updated' });
+        return;
+      }
+      case 'acquisition.failed': {
+        const media = await this.mediaRepo.findOne({
+          where: { id: event.mediaId },
+        });
+        const recipients = await this.sseAudience.recipientsForMedia(
+          event.mediaId,
+        );
+        this.events.emitToUsers(recipients, {
+          type: 'import.failed',
+          mediaId: event.mediaId,
+          title: media?.title ?? '',
+          error: event.reason,
+        });
+        this.events.emit({ type: 'queue.updated' });
+        return;
+      }
+      case 'acquisition.queue.changed':
+        this.events.emit({ type: 'queue.updated' });
+        return;
+      case 'acquisition.progress':
+        await this.pushProgress({
+          mediaId: event.mediaId,
+          ref: event.ref,
+          progress: event.progress,
+          etaSeconds: event.etaSeconds ?? undefined,
+          state: event.state,
+        });
+        return;
+    }
+  }
+
+  // ===========================================================================
+  // D2 — notifications.dispatch
+  // ===========================================================================
+
+  private async notificationsDispatch(p: {
+    event: 'grab.started';
+    payload: Record<string, unknown>;
+  }): Promise<void> {
+    await this.notifications.dispatch(p.event, p.payload);
+  }
+
+  // ===========================================================================
+  // D3 — counts.set
+  // ===========================================================================
+
+  private countsSet(p: { key: string; value: number }): Promise<void> {
+    this.countsCache.set(p.key, p.value);
+    return Promise.resolve();
+  }
+
+  // ===========================================================================
+  // D4 — events.emitOwn
+  // ===========================================================================
+
+  private async eventsEmitOwn(p: {
+    type: string;
+    payload: unknown;
+    audience: 'all' | { mediaId: number };
+  }): Promise<void> {
+    const type = `plugin.${this.pluginId}.${p.type}`;
+    if (p.audience === 'all') {
+      this.events.emitRaw(type, p.payload, null);
+      return;
+    }
+    const recipients = await this.sseAudience.recipientsForMedia(
+      p.audience.mediaId,
+    );
+    this.events.emitRaw(type, p.payload, recipients);
+  }
+
+  // ===========================================================================
+  // D5 — progress.set
+  // ===========================================================================
+
+  private async progressSet(p: {
+    mediaId: number;
+    seasonNumber?: number;
+    episodeNumber?: number;
+    ref: string;
+    progress: number;
+    bytesPerSecond?: number;
+    etaSeconds?: number;
+    state: 'queued' | 'active' | 'stalled' | 'paused' | 'importing';
+  }): Promise<void> {
+    // ponytail: no server-side coalescing yet (plan asks for <=1/media/sec) —
+    // add a per-media debounce once a real caller exercises the frequency.
+    await this.pushProgress(p);
+  }
+
+  private async pushProgress(p: {
+    mediaId: number;
+    seasonNumber?: number;
+    episodeNumber?: number;
+    ref?: string;
+    progress: number;
+    bytesPerSecond?: number;
+    etaSeconds?: number;
+    state: string;
+  }): Promise<void> {
+    const media = await this.mediaRepo.findOne({ where: { id: p.mediaId } });
+    const recipients = await this.sseAudience.recipientsForMedia(p.mediaId);
+    if (!recipients.length) return;
+    this.events.emitToUsers(recipients, {
+      type: 'download.progress',
+      mediaId: p.mediaId,
+      mediaType: media?.type === MediaType.MOVIE ? 'movie' : 'series',
+      seasonNumber: p.seasonNumber,
+      episodeNumber: p.episodeNumber,
+      hash: p.ref,
+      progress: p.progress,
+      dlspeed: p.bytesPerSecond ?? 0,
+      eta: p.etaSeconds ?? 0,
+      state: p.state,
+    });
+  }
+
+  // ===========================================================================
+  // E1 — config.get
+  // ===========================================================================
+
+  private async configGet(p: {
+    keys?: string[];
+  }): Promise<Record<string, string>> {
+    const prefix = `plugin.${this.pluginId}.`;
+    const out: Record<string, string> = {};
+    if (p.keys?.length) {
+      for (const key of p.keys) {
+        const value = await this.settings.get(prefix + key);
+        if (value != null) out[key] = value;
+      }
+      return out;
+    }
+    const all = await this.settings.getAll();
+    for (const [key, value] of Object.entries(all)) {
+      if (value != null && key.startsWith(prefix))
+        out[key.slice(prefix.length)] = value;
+    }
+    return out;
+  }
+
+  // ===========================================================================
+  // E2 — config.set
+  // ===========================================================================
+
+  private async configSet(p: {
+    key: string;
+    value: string | null;
+  }): Promise<void> {
+    await this.settings.set(`plugin.${this.pluginId}.${p.key}`, p.value);
+  }
+
+  // ===========================================================================
+  // Shared helpers
+  // ===========================================================================
+
+  private buildAcquisitionTarget(
+    media: Media,
+    decision: SearchDecision | null,
+    files: { quality?: string | null }[],
+  ): AcquisitionTarget | null {
+    if (media.libraryId == null) return null;
+    const { searchTitle, expectedTitles } = resolveSearchTitles(media);
+    return {
+      mediaId: media.id,
+      kind: media.type === MediaType.MOVIE ? 'movie' : 'series',
+      title: media.title,
+      originalTitle: media.originalTitle ?? null,
+      alternativeTitles: media.alternativeTitles ?? [],
+      year: media.year ?? null,
+      runtimeMinutes: media.runtime ?? null,
+      imdbId: media.imdbId ?? null,
+      tmdbId: media.tmdbId ?? null,
+      tvdbId: media.tvdbId ?? null,
+      libraryId: media.libraryId,
+      want: this.buildWant(media, decision, files),
+      expectedTitles,
+      searchTitle,
+    };
+  }
+
+  private buildWant(
+    media: Media,
+    decision: SearchDecision | null,
+    files: { quality?: string | null }[],
+  ): AcquisitionTarget['want'] {
+    if (!decision) return null;
+    if (decision.mode === 'skip' || decision.mode === 'unprofiled') return null;
+    // Already excluded 'skip'/'unprofiled' above — only the ranked branch remains.
+    const active = decision as Extract<
+      SearchDecision,
+      { mode: 'missing' | 'upgrade' }
+    >;
+    const { allowed, allowedLangs } =
+      this.profiles.resolveAllowedForMedia(media);
+    const resolutionUpgradeOnly =
+      active.mode === 'upgrade' &&
+      !!media.qualityProfile?.resolutionUpgradeOnly;
+    return {
+      decision: active.mode,
+      allowedQualityIds: [...allowed],
+      allowedLanguageIds: [...allowedLangs],
+      minRankExclusive: active.minRankExclusive,
+      // `Infinity` (JSON-unsafe) means "no ceiling" — MAX_SAFE_INTEGER says the
+      // same thing to a plugin without breaking JSON across the wire.
+      maxRankInclusive: Number.isFinite(active.maxRankInclusive)
+        ? active.maxRankInclusive
+        : Number.MAX_SAFE_INTEGER,
+      minResolution: resolutionUpgradeOnly
+        ? maxResolutionFromQualityStrings(files)
+        : 0,
+      resolutionUpgradeOnly,
+    };
+  }
+
+  private buildFromMovieTarget(t: MovieTarget): AcquisitionTarget | null {
+    const decision = this.autoGrab.classifyForSearch(t.media, t.files);
+    return this.buildAcquisitionTarget(t.media, decision, t.files);
+  }
+
+  private buildFromEpisodeTarget(
+    t: EpisodeTarget,
+    episodeCount: number,
+  ): AcquisitionTarget | null {
+    const decision = this.autoGrab.classifyForSearch(t.media, t.files);
+    const target = this.buildAcquisitionTarget(t.media, decision, t.files);
+    if (!target) return null;
+    target.season = {
+      id: t.season.id,
+      number: t.season.seasonNumber,
+      episodeCount,
+    };
+    target.episode = {
+      id: t.episode.id,
+      number: t.episode.episodeNumber,
+      endNumber: t.episode.endEpisodeNumber,
+      airDate: t.episode.airDate ?? null,
+    };
+    return target;
+  }
+
+  private buildFromSeasonPackTarget(
+    t: SeasonPackTarget,
+  ): AcquisitionTarget | null {
+    const decision = this.autoGrab.classifyForSearch(t.media, t.files);
+    const target = this.buildAcquisitionTarget(t.media, decision, t.files);
+    if (!target) return null;
+    target.season = {
+      id: t.season.id,
+      number: t.season.seasonNumber,
+      episodeCount: t.totalEpisodeCount,
+    };
+    return target;
+  }
+
+  private episodesOfSeason(seasonId: number): Promise<Episode[]> {
+    return this.episodeRepo.find({ where: { season: { id: seasonId } } });
+  }
+
+  private async episodeCountsBySeasons(
+    seasonIds: number[],
+  ): Promise<Map<number, number>> {
+    if (!seasonIds.length) return new Map();
+    const rows = await this.episodeRepo
+      .createQueryBuilder('ep')
+      .select('ep.seasonId', 'seasonId')
+      .addSelect('COUNT(*)', 'cnt')
+      .where('ep.seasonId IN (:...ids)', { ids: seasonIds })
+      .groupBy('ep.seasonId')
+      .getRawMany<{ seasonId: number; cnt: string }>();
+    return new Map(rows.map((r) => [Number(r.seasonId), Number(r.cnt)]));
+  }
+
+  private async filesForClassification(
+    media: Media,
+    season: Season | null,
+    episode: Episode | null,
+  ): Promise<{ quality?: string | null }[]> {
+    if (media.type === MediaType.MOVIE) {
+      const files = await this.mediaFileRepo.find({
+        where: { media: { id: media.id } },
+      });
+      return files.map((f) => ({ quality: f.quality }));
+    }
+    if (episode) return this.filesForEpisode(episode);
+    if (season)
+      return this.filesForSeasonPack(await this.episodesOfSeason(season.id));
+    return [];
+  }
+
+  private async filesForEpisode(
+    episode: Episode,
+  ): Promise<{ quality?: string | null }[]> {
+    if (!episode.hasFile) return [];
+    const files = await this.mediaFileRepo.find({
+      where: { episode: { id: episode.id } },
+    });
+    if (!files.length) return [{ quality: null }];
+    let best: string | null = null;
+    let bestRank = -1;
+    for (const f of files) {
+      const r = rankFromQualityString(f.quality);
+      if (r > bestRank) {
+        bestRank = r;
+        best = f.quality;
+      }
+    }
+    return [{ quality: best }];
+  }
+
+  /** Season-pack semantics: `[]` while any covered episode is missing (grab
+   *  everything), else the weakest on-disk quality (cutoff-gates the pack). */
+  private async filesForSeasonPack(
+    episodes: Episode[],
+  ): Promise<{ quality?: string | null }[]> {
+    if (!episodes.length) return [];
+    const perEpisode = await Promise.all(
+      episodes.map((e) => this.filesForEpisode(e)),
+    );
+    if (perEpisode.some((f) => f.length === 0)) return [];
+    let weakest: string | null = null;
+    let weakestRank = Number.POSITIVE_INFINITY;
+    for (const f of perEpisode) {
+      const r = rankFromQualityString(f[0].quality);
+      if (r < weakestRank) {
+        weakestRank = r;
+        weakest = f[0].quality ?? null;
+      }
+    }
+    return [{ quality: weakest }];
+  }
+}

--- a/backend/src/modules/plugins/host/in-process-plugin-host-client.spec.ts
+++ b/backend/src/modules/plugins/host/in-process-plugin-host-client.spec.ts
@@ -1,0 +1,65 @@
+import { InProcessPluginHostClient } from './in-process-plugin-host-client';
+import type { FliksHostImpl } from './fliks-host.service';
+import type { PluginHostApi } from '../../../common/plugin-contract';
+
+/** The 17 dotted method names `host-methods.ts` declares. */
+const PLUGIN_METHOD_NAMES: (keyof PluginHostApi)[] = [
+  'media.acquisitionContext',
+  'acquisition.candidates',
+  'releases.match',
+  'releases.score',
+  'media.resolve',
+  'media.exists',
+  'blocklist.add',
+  'blocklist.check',
+  'requests.markInProgress',
+  'library.ingest',
+  'events.publish',
+  'notifications.dispatch',
+  'counts.set',
+  'events.emitOwn',
+  'progress.set',
+  'config.get',
+  'config.set',
+];
+
+/** Every dotted method the contract declares, stubbed on a fake host. */
+function fakeHost(): FliksHostImpl {
+  const fake: Record<string, jest.Mock> = {};
+  for (const name of PLUGIN_METHOD_NAMES) {
+    fake[name] = jest.fn().mockResolvedValue(`result:${name}`);
+  }
+  return fake as unknown as FliksHostImpl;
+}
+
+describe('InProcessPluginHostClient', () => {
+  it('covers exactly the 17 methods host-methods.ts declares', () => {
+    expect(PLUGIN_METHOD_NAMES).toHaveLength(17);
+  });
+
+  it('forwards every one of the 17 contract methods to the host, unchanged', async () => {
+    const host = fakeHost();
+    const client = new InProcessPluginHostClient(host);
+    const clientCalls = client as unknown as Record<
+      string,
+      (p: unknown) => Promise<unknown>
+    >;
+    const hostMocks = host as unknown as Record<string, jest.Mock>;
+
+    for (const name of PLUGIN_METHOD_NAMES) {
+      const payload = { probe: name };
+      const result = await clientCalls[name](payload);
+      expect(hostMocks[name]).toHaveBeenCalledWith(payload);
+      expect(result).toBe(`result:${name}`);
+    }
+  });
+
+  it('does no transformation of its own — it is a pure pass-through, not a second implementation', async () => {
+    const host = fakeHost();
+    const client = new InProcessPluginHostClient(host);
+    const payload = { mediaId: 1, seasonId: 2 };
+    await client['media.acquisitionContext'](payload);
+    expect(host['media.acquisitionContext']).toHaveBeenCalledTimes(1);
+    expect(host['media.acquisitionContext']).toHaveBeenCalledWith(payload);
+  });
+});

--- a/backend/src/modules/plugins/host/in-process-plugin-host-client.ts
+++ b/backend/src/modules/plugins/host/in-process-plugin-host-client.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@nestjs/common';
+import type { PluginHostApi } from '../../../common/plugin-contract';
+import { FliksHostImpl } from './fliks-host.service';
+
+/**
+ * A caller's view of the 17 host methods, exactly as a `process` plugin's
+ * socket client will see them. Today it forwards straight into
+ * `FliksHostImpl` in-process; Phase 10.4 replaces the body of every method
+ * here with an `RpcChannel.call(...)` and nothing on the caller side changes.
+ */
+@Injectable()
+export class InProcessPluginHostClient implements PluginHostApi {
+  constructor(private readonly host: FliksHostImpl) {}
+
+  'media.acquisitionContext': PluginHostApi['media.acquisitionContext'] = (p) =>
+    this.host['media.acquisitionContext'](p);
+  'acquisition.candidates': PluginHostApi['acquisition.candidates'] = (p) =>
+    this.host['acquisition.candidates'](p);
+  'releases.match': PluginHostApi['releases.match'] = (p) =>
+    this.host['releases.match'](p);
+  'releases.score': PluginHostApi['releases.score'] = (p) =>
+    this.host['releases.score'](p);
+  'media.resolve': PluginHostApi['media.resolve'] = (p) =>
+    this.host['media.resolve'](p);
+  'media.exists': PluginHostApi['media.exists'] = (p) =>
+    this.host['media.exists'](p);
+  'blocklist.add': PluginHostApi['blocklist.add'] = (p) =>
+    this.host['blocklist.add'](p);
+  'blocklist.check': PluginHostApi['blocklist.check'] = (p) =>
+    this.host['blocklist.check'](p);
+  'requests.markInProgress': PluginHostApi['requests.markInProgress'] = (p) =>
+    this.host['requests.markInProgress'](p);
+  'library.ingest': PluginHostApi['library.ingest'] = (p) =>
+    this.host['library.ingest'](p);
+  'events.publish': PluginHostApi['events.publish'] = (p) =>
+    this.host['events.publish'](p);
+  'notifications.dispatch': PluginHostApi['notifications.dispatch'] = (p) =>
+    this.host['notifications.dispatch'](p);
+  'counts.set': PluginHostApi['counts.set'] = (p) => this.host['counts.set'](p);
+  'events.emitOwn': PluginHostApi['events.emitOwn'] = (p) =>
+    this.host['events.emitOwn'](p);
+  'progress.set': PluginHostApi['progress.set'] = (p) =>
+    this.host['progress.set'](p);
+  'config.get': PluginHostApi['config.get'] = (p) => this.host['config.get'](p);
+  'config.set': PluginHostApi['config.set'] = (p) => this.host['config.set'](p);
+}

--- a/backend/src/modules/plugins/host/plugin-counts-cache.service.ts
+++ b/backend/src/modules/plugins/host/plugin-counts-cache.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+
+/**
+ * In-memory push cache backing `counts.set` (contract D3): the plugin pushes,
+ * core serves the cached number. An unset key reads as 0, matching "the
+ * plugin has never connected". Not persisted — a restart is a legitimate
+ * reset, the plugin re-pushes once it reconnects.
+ */
+@Injectable()
+export class PluginCountsCacheService {
+  private readonly counts = new Map<string, number>();
+
+  set(key: string, value: number): void {
+    this.counts.set(key, value);
+  }
+
+  get(key: string): number {
+    return this.counts.get(key) ?? 0;
+  }
+}

--- a/backend/src/modules/plugins/host/plugin-host.constants.ts
+++ b/backend/src/modules/plugins/host/plugin-host.constants.ts
@@ -1,0 +1,11 @@
+/**
+ * DI token for the plugin id `FliksHostImpl` is scoped to — it derives the
+ * `plugin.<id>.` settings prefix and the `library.ingest` root allowlist.
+ * One host instance serves one plugin; a second concurrent `process`
+ * plugin needs its own instance, wired once the RPC dispatcher binds a
+ * socket connection to a specific registration (Phase 10.3).
+ */
+export const PLUGIN_HOST_PLUGIN_ID = 'PLUGIN_HOST_PLUGIN_ID';
+
+/** The one plugin this host serves today. */
+export const DEFAULT_HOST_PLUGIN_ID = 'fliks.download';

--- a/backend/src/modules/plugins/host/plugin-host.module.ts
+++ b/backend/src/modules/plugins/host/plugin-host.module.ts
@@ -1,0 +1,60 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Media } from '../../media/entities/media.entity';
+import { Season } from '../../media/entities/season.entity';
+import { Episode } from '../../media/entities/episode.entity';
+import { MediaFile } from '../../media/entities/media-file.entity';
+import { BlocklistEntry } from '../../blocklist/entities/blocklist-entry.entity';
+import { PluginRegistration } from '../entities/plugin-registration.entity';
+import { CleanupProfile } from '../../cleanup-profiles/entities/cleanup-profile.entity';
+import { MediaModule } from '../../media/media.module';
+import { ProfilesModule } from '../../profiles/profiles.module';
+import { BlocklistModule } from '../../blocklist/blocklist.module';
+import { RequestsModule } from '../../requests/requests.module';
+import { LibraryIngestModule } from '../../../common/library-ingest/library-ingest.module';
+import { NotificationsModule } from '../../notifications/notifications.module';
+import { MediaServersModule } from '../../media-servers/media-servers.module';
+import { SettingsModule } from '../../settings/settings.module';
+import { FliksHostImpl } from './fliks-host.service';
+import { InProcessPluginHostClient } from './in-process-plugin-host-client';
+import { PluginCountsCacheService } from './plugin-counts-cache.service';
+import {
+  DEFAULT_HOST_PLUGIN_ID,
+  PLUGIN_HOST_PLUGIN_ID,
+} from './plugin-host.constants';
+
+/**
+ * Wires `FliksHostImpl` — core's implementation of the 17 plugin-facing host
+ * methods — and the in-process client that stands in for the RPC transport
+ * until Phase 10.4. `EventsService`/`SseAudienceService` come for free from
+ * the `@Global()` `EventsModule`, so they aren't imported here.
+ */
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      Media,
+      Season,
+      Episode,
+      MediaFile,
+      BlocklistEntry,
+      PluginRegistration,
+      CleanupProfile,
+    ]),
+    MediaModule,
+    ProfilesModule,
+    BlocklistModule,
+    RequestsModule,
+    LibraryIngestModule,
+    NotificationsModule,
+    MediaServersModule,
+    SettingsModule,
+  ],
+  providers: [
+    { provide: PLUGIN_HOST_PLUGIN_ID, useValue: DEFAULT_HOST_PLUGIN_ID },
+    FliksHostImpl,
+    InProcessPluginHostClient,
+    PluginCountsCacheService,
+  ],
+  exports: [FliksHostImpl, InProcessPluginHostClient, PluginCountsCacheService],
+})
+export class PluginHostModule {}

--- a/backend/src/modules/scheduler/events.service.ts
+++ b/backend/src/modules/scheduler/events.service.ts
@@ -247,6 +247,13 @@ export class EventsService {
     this.subject.next({ audience: userIds, connectionIds: null, event });
   }
 
+  /** Escape hatch for a type outside the closed `SseEvent` union — namespaced
+   *  plugin events (`plugin.<id>.<type>`). `audience: null` broadcasts. */
+  emitRaw(type: string, payload: unknown, audience: number[] | null): void {
+    const event = { type, payload } as unknown as SseEvent;
+    this.subject.next({ audience, connectionIds: null, event });
+  }
+
   /** Deliver only to one SSE connection (multi-device remote control). */
   emitToConnection(connectionId: string, event: SseEvent): void {
     if (!this.connections.has(connectionId)) return;


### PR DESCRIPTION
First half of PR 10.1. Core now answers the whole plugin-facing interface, with an in-process client exposing the same shape so a caller can hold the interface instead of injecting core services.

**Deliberately additive: `plugins/download/` is untouched, not one line.** The conversion is the next PR. Mixing the two would make any behaviour regression impossible to attribute — and the conversion is the risky half.

## The serialisability check earned its place

Every method's return value is asserted to survive a `JSON.parse(JSON.stringify(…))` round-trip deep-equal. That matters because the transport becomes a unix socket in 10.4: a method returning a TypeORM entity passes a naive unit test today and breaks a phase later, when it is much harder to attribute.

It caught three real cases:

- a rank ceiling that can be `Infinity`, which JSON turns into `null` — now mapped to a safe integer;
- the ingest result, which returned a **media-file entity** carrying `createdAt`/`updatedAt` dates and a `media` relation — now mapped down to the three fields the contract declares;
- several targets that would have been spread from entities instead of built as fresh literals.

The agent also noted JSON round-tripping is *stricter* than `structuredClone` here, which would have silently preserved a `Date`. It used the stricter one.

## The interface carries no principal

My brief asked how a `delegated` principal is scoped. Reading the contract in full establishes there is **no principal on any of the 17 methods** — so nothing here can widen or narrow access by user, and none was invented. Delegated scoping happens at the HTTP proxy (`PluginRouteGuard` + the object guards from #920) *before* a request ever reaches a plugin.

What the host *is* scoped to is one plugin id, bound at construction. A second concurrently-installed process plugin would need its own instance; that is work tied to wiring the supervisor's request channel, which nothing calls yet.

## Ids the plugin cannot invent

Audited per method: quality and language ids only ever flow host→plugin, computed server-side from parsing and lookups. No method accepts one from a plugin and trusts it back into scoring or storage.

## The one place new logic was written

Sixteen methods delegate to core code that already owns the answer — scoring to `common/release-scoring/`, candidates to `AcquisitionCandidatesService`, ingest to `common/library-ingest/`, and so on. **`releases.match` had no pre-existing implementation** and was written fresh from the parsing and scoring primitives, mirroring the classifier's skip-reason semantics. That is the one place to review for behaviour rather than for wiring.

## Verification

- `tsc --noEmit` exit 0. Suite **1342 tests / 127 suites**, up from 1302/125 — the 40 new tests are the per-method happy paths plus the round-trip assertions.
- **DI graph boots in both bundle modes**, verified independently of the agent's own run: `DI GRAPH OK` by default and with `FLIKS_BUNDLES=`. The host is core code and must resolve without the download bundle, which is why the second one is the interesting one.
- The live acquisition probe still passes all nine checks — expected for an additive PR, and confirmed rather than assumed.
- `plugins/download/` shows zero changed files.

## Flagged, not built

`progress.set` has no coalescing; ingest and blocklist idempotency keys are not tracked in a dedupe table, relying instead on an existing destination-collision no-op and on the real unique index (a retried blocklist insert resolves to the existing row rather than erroring); candidate pagination is an in-memory offset cursor, fine at present scale. Each is marked at the point where it would be upgraded.

Refs: #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)