### PR TITLE
feat(plugins): fence the plugin off from core and convert what is provably equivalent

### DIFF
--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -68,4 +68,60 @@ export default tseslint.config(
       ],
     },
   },
+  {
+    // plugins/download/** reaches core only through common/plugin-contract (and
+    // the host client wired up under modules/plugins/host/); ignores list is
+    // every current importer of a not-yet-converted core dependency (PR 10.1b).
+    files: ['src/plugins/download/**/*.ts'],
+    ignores: [
+      'src/plugins/download/acquisition-scheduler.service.ts',
+      'src/plugins/download/auto-grab-pipeline.service.ts',
+      'src/plugins/download/completion.service.spec.ts',
+      'src/plugins/download/completion.service.ts',
+      'src/plugins/download/download-clients/download-clients.controller.ts',
+      'src/plugins/download/download-clients/download-clients.module.ts',
+      'src/plugins/download/download-clients/download-clients.service.ts',
+      'src/plugins/download/download-clients/entities/download-client.entity.ts',
+      'src/plugins/download/download-clients/qbittorrent.service.ts',
+      'src/plugins/download/entities/download-history.entity.ts',
+      'src/plugins/download/episode-download.service.ts',
+      'src/plugins/download/grab.controller.ts',
+      'src/plugins/download/grab-history.util.ts',
+      'src/plugins/download/grab.module.ts',
+      'src/plugins/download/indexers/entities/indexer.entity.ts',
+      'src/plugins/download/indexers/indexers.controller.ts',
+      'src/plugins/download/indexers/indexers.module.ts',
+      'src/plugins/download/indexers/torznab.service.ts',
+      'src/plugins/download/movie-download.service.ts',
+      'src/plugins/download/torrent-auto-matcher.service.ts',
+      'src/plugins/download/torrent-history-matcher.service.ts',
+    ],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: [
+                '**/modules/**',
+                '**/common/**',
+                // gitignore semantics: a path can't be un-excluded while its
+                // parent still is, so every intermediate segment needs its own
+                // negation, not just the two leaf directories.
+                '!**/common',
+                '!**/common/plugin-contract',
+                '!**/common/plugin-contract/**',
+                '!**/modules',
+                '!**/modules/plugins',
+                '!**/modules/plugins/host',
+                '!**/modules/plugins/host/**',
+              ],
+              message:
+                'plugins/download/** reaches core only through common/plugin-contract (or the host client under modules/plugins/host/) — inject that instead. Known pre-fence importers are allowlisted in eslint.config.mjs.',
+            },
+          ],
+        },
+      ],
+    },
+  },
 );

--- a/backend/src/plugins/download/episode-download.service.ts
+++ b/backend/src/plugins/download/episode-download.service.ts
@@ -29,7 +29,7 @@ import { CustomFormatsService } from '../../modules/profiles/custom-formats.serv
 import { ProfilesService } from '../../modules/profiles/profiles.service';
 import { QualityDefinitionsService } from '../../modules/profiles/quality-definitions.service';
 import { BlocklistService } from '../../modules/blocklist/blocklist.service';
-import { NotificationsService } from '../../modules/notifications/notifications.service';
+import { InProcessPluginHostClient } from '../../modules/plugins/host/in-process-plugin-host-client';
 import { MediaType } from '../../common/enums';
 import { QualityProfileItem } from '../../modules/profiles/entities/quality-profile.entity';
 
@@ -104,7 +104,7 @@ export class EpisodeDownloadService {
     private readonly qbittorrent: QbittorrentService,
     private readonly customFormats: CustomFormatsService,
     private readonly blocklist: BlocklistService,
-    private readonly notifications: NotificationsService,
+    private readonly host: InProcessPluginHostClient,
     private readonly qualityDefs: QualityDefinitionsService,
     private readonly profiles: ProfilesService,
     private readonly events: EventsService,
@@ -371,10 +371,13 @@ export class EpisodeDownloadService {
       ),
     );
 
-    void this.notifications.dispatch('grab.started', {
-      title: `${media.title} ${epLabel}`,
-      quality: parsed.quality.name,
-      sourceTitle,
+    void this.host['notifications.dispatch']({
+      event: 'grab.started',
+      payload: {
+        title: `${media.title} ${epLabel}`,
+        quality: parsed.quality.name,
+        sourceTitle,
+      },
     });
 
     this.events.emitDomain({
@@ -659,10 +662,13 @@ export class EpisodeDownloadService {
           }),
         ),
       );
-      void this.notifications.dispatch('grab.started', {
-        title: `${media.title} S${String(season.seasonNumber).padStart(2, '0')}`,
-        quality: parsed.quality.name,
-        sourceTitle,
+      void this.host['notifications.dispatch']({
+        event: 'grab.started',
+        payload: {
+          title: `${media.title} S${String(season.seasonNumber).padStart(2, '0')}`,
+          quality: parsed.quality.name,
+          sourceTitle,
+        },
       });
       this.events.emitDomain({
         type: 'acquisition.grabbed',
@@ -761,10 +767,13 @@ export class EpisodeDownloadService {
           }),
         ),
       );
-      void this.notifications.dispatch('grab.started', {
-        title: `${media.title} S${String(season.seasonNumber).padStart(2, '0')}`,
-        quality: bestPack.qualityName,
-        sourceTitle: bestPack.title,
+      void this.host['notifications.dispatch']({
+        event: 'grab.started',
+        payload: {
+          title: `${media.title} S${String(season.seasonNumber).padStart(2, '0')}`,
+          quality: bestPack.qualityName,
+          sourceTitle: bestPack.title,
+        },
       });
       this.events.emitDomain({
         type: 'acquisition.grabbed',

--- a/backend/src/plugins/download/grab.module.ts
+++ b/backend/src/plugins/download/grab.module.ts
@@ -9,9 +9,9 @@ import { DownloadClientsModule } from './download-clients/download-clients.modul
 import { AuthModule } from '../../modules/auth/auth.module';
 import { ProfilesModule } from '../../modules/profiles/profiles.module';
 import { BlocklistModule } from '../../modules/blocklist/blocklist.module';
-import { NotificationsModule } from '../../modules/notifications/notifications.module';
 import { LibrariesModule } from '../../modules/libraries/libraries.module';
 import { MediaModule } from '../../modules/media/media.module';
+import { PluginHostModule } from '../../modules/plugins/host/plugin-host.module';
 import { GrabController } from './grab.controller';
 import { MovieDownloadService } from './movie-download.service';
 import { EpisodeDownloadService } from './episode-download.service';
@@ -24,9 +24,9 @@ import { EpisodeDownloadService } from './episode-download.service';
     AuthModule,
     ProfilesModule,
     BlocklistModule,
-    NotificationsModule,
     LibrariesModule,
     MediaModule,
+    PluginHostModule,
   ],
   controllers: [GrabController],
   providers: [MovieDownloadService, EpisodeDownloadService],

--- a/backend/src/plugins/download/movie-download.service.ts
+++ b/backend/src/plugins/download/movie-download.service.ts
@@ -18,7 +18,7 @@ import { CustomFormatsService } from '../../modules/profiles/custom-formats.serv
 import { ProfilesService } from '../../modules/profiles/profiles.service';
 import { QualityDefinitionsService } from '../../modules/profiles/quality-definitions.service';
 import { BlocklistService } from '../../modules/blocklist/blocklist.service';
-import { NotificationsService } from '../../modules/notifications/notifications.service';
+import { InProcessPluginHostClient } from '../../modules/plugins/host/in-process-plugin-host-client';
 import { MediaType } from '../../common/enums';
 import { GrabMovieDto } from './dto/grab-movie.dto';
 import { QualityProfileItem } from '../../modules/profiles/entities/quality-profile.entity';
@@ -96,7 +96,7 @@ export class MovieDownloadService {
     private readonly qbittorrent: QbittorrentService,
     private readonly customFormats: CustomFormatsService,
     private readonly blocklist: BlocklistService,
-    private readonly notifications: NotificationsService,
+    private readonly host: InProcessPluginHostClient,
     private readonly qualityDefs: QualityDefinitionsService,
     private readonly profiles: ProfilesService,
     private readonly events: EventsService,
@@ -342,10 +342,13 @@ export class MovieDownloadService {
       ),
     );
 
-    void this.notifications.dispatch('grab.started', {
-      title: media.title,
-      quality: parsed.quality.name,
-      sourceTitle,
+    void this.host['notifications.dispatch']({
+      event: 'grab.started',
+      payload: {
+        title: media.title,
+        quality: parsed.quality.name,
+        sourceTitle,
+      },
     });
 
     this.events.emitDomain({ type: 'acquisition.grabbed', mediaId });
@@ -582,10 +585,13 @@ export class MovieDownloadService {
       ),
     );
 
-    void this.notifications.dispatch('grab.started', {
-      title: media.title,
-      quality: parsed.quality.name,
-      sourceTitle,
+    void this.host['notifications.dispatch']({
+      event: 'grab.started',
+      payload: {
+        title: media.title,
+        quality: parsed.quality.name,
+        sourceTitle,
+      },
     });
 
     return saved;


### PR DESCRIPTION
This is the attempted second half of 10.1, and **most of it deliberately does not ship**. The finding is the deliverable.

## What ships

**A reverse fence.** `plugins/download/**` may not import from `modules/**` or `common/**`; the plugin contract and the host client are the only exceptions. Everything not yet convertible is allowlisted **by exact path**, so the residual is recorded rather than hidden and any *new* core import from the plugin fails closed. Proven to fire; the existing core→plugin fence still works.

**One conversion**, the only one provably equivalent: the two grab-notification dispatches now go through the interface instead of injecting core's notification service.

A fence-mechanics note worth keeping: `no-restricted-imports` uses gitignore semantics, so a leaf negation cannot un-exclude a path while a parent stays excluded. Allowing the host client needed every intermediate segment negated — verified against the `ignore` package directly before touching the config.

## Why the rest does not ship

Each of these was attempted or established, not assumed. **A silent semantic change in the acquisition path fills a user's library with wrong files, and the suite would not say so** — so the brief's instruction was to prefer a documented residual over a guessed conversion.

- **Scoring would lose its labels.** The interface returns `qualityId`/`languageId` and no names. The live release response carries `qualityName` and `languageName` among its 23 fields and the client renders them, so converting drops them. Vendoring the registry to keep them is exactly the persisted-id desync the design forbids. *(Verified independently against the contract and against a captured live response.)*
- **Ingest would throw on every import.** `library.ingest` requires a `plugin_registrations` row with non-empty `ingestRoots` for this plugin id, and nothing seeds one for an in-tree bundle — no migration, no install flow. Core's own host spec asserts the refusal.
- **Publishing an imported event would drop two side effects.** Core's event seam also dispatches the download-complete notification and the media-server refresh for that fact; the interface's equivalent does neither.
- **Candidate enumeration would change what gets searched.** The interface filters a movie by release date; the caller implements the full minimum-availability rule (announced / in-cinemas / released, with digital, physical, in-cinemas+90d and status fallbacks). Swapping is a correctness change, not a style one.
- **Nothing in the core scheduler module can hold the client at all.** A direct import re-enters a `MediaModule`/`LibraryIngestModule` cycle that only a `forwardRef` currently breaks, so `PluginHostModule`'s own imports resolve to `undefined` at decoration time. Established by making the change, watching the DI boot fail, and reverting it in full — the typecheck and all 1342 tests passed while it was broken.
- **There is no push channel.** The interface is call-in only, so the plugin's domain-event subscription has no equivalent in either direction.
- **No id→name resolution** exists for quality or language.

## What this means for the plan

10.1 cannot complete against the interface as it stands. The next step is to close those gaps in core's implementation and the contract — not to push the conversion through, which would trade a real regression for an appearance of progress.

The seven items above are the blocking list. The module-cycle one is structural rather than a missing method, and it gates every future conversion in that module, so it is worth solving first.

## Verification

`tsc` exit 0. Suite **1342 tests / 127 suites**, unchanged, **no assertion modified**. DI graph boots in both bundle modes. The live acquisition probe still passes all nine checks.

Refs: #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)