### PR TITLE
feat(plugins): let core boot with no acquisition code at all

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, type Type } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from './modules/auth/auth.module';
@@ -6,10 +6,6 @@ import { UsersModule } from './modules/users/users.module';
 import { MediaModule } from './modules/media/media.module';
 import { ProfilesModule } from './modules/profiles/profiles.module';
 import { MetadataProvidersModule } from './modules/metadata-providers/metadata-providers.module';
-import { IndexersModule } from './plugins/download/indexers/indexers.module';
-import { DownloadClientsModule } from './plugins/download/download-clients/download-clients.module';
-import { GrabModule } from './plugins/download/grab.module';
-import { DownloadBundleModule } from './plugins/download/download-bundle.module';
 import { RequestsModule } from './modules/requests/requests.module';
 import { FliksSchedulerModule } from './modules/scheduler/scheduler.module';
 import { EventsModule } from './modules/scheduler/events.module';
@@ -34,6 +30,27 @@ import { CommonModule } from './common/common.module';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
 import { isDownloadBundleEnabled } from './common/constants/plugin-flags';
+
+/**
+ * The one in-repo bundle today. Loaded through `require` on purpose: a static
+ * import runs the module's `TypeOrmModule.forFeature(...)` at import time, which
+ * registers its entities with `autoLoadEntities` whether or not the module is
+ * ever mounted — so `FLIKS_BUNDLES=` would still leave core carrying its tables.
+ * These four lines go away with the directory when the bundle ships as an
+ * archive the registry mounts at runtime.
+ */
+function downloadBundleModules(): Type<unknown>[] {
+  if (!isDownloadBundleEnabled()) return [];
+  /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-require-imports */
+  return [
+    require('./plugins/download/indexers/indexers.module').IndexersModule,
+    require('./plugins/download/download-clients/download-clients.module')
+      .DownloadClientsModule,
+    require('./plugins/download/grab.module').GrabModule,
+    require('./plugins/download/download-bundle.module').DownloadBundleModule,
+  ];
+  /* eslint-enable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-require-imports */
+}
 
 @Module({
   imports: [
@@ -86,11 +103,7 @@ import { isDownloadBundleEnabled } from './common/constants/plugin-flags';
     PersonsModule,
     ProfilesModule,
     MetadataProvidersModule,
-    IndexersModule,
-    DownloadClientsModule,
-    // The one in-repo bundle today; FLIKS_BUNDLES=<empty> drops its controller,
-    // grab routes and scheduled jobs entirely rather than exposing them disabled.
-    ...(isDownloadBundleEnabled() ? [GrabModule, DownloadBundleModule] : []),
+    ...downloadBundleModules(),
     RequestsModule,
     FliksSchedulerModule,
     LibrariesModule,

--- a/backend/src/plugins/download/blocklist/blocklist.module.ts
+++ b/backend/src/plugins/download/blocklist/blocklist.module.ts
@@ -2,18 +2,13 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { BlocklistEntry } from './entities/blocklist-entry.entity';
 import { BlocklistService } from './blocklist.service';
+import { BlocklistController } from './blocklist.controller';
 import { AuthModule } from '../../../modules/auth/auth.module';
 import { Indexer } from '../indexers/entities/indexer.entity';
 
-/**
- * No `BlocklistController` here: this module is imported unconditionally
- * (`DownloadClientsModule`'s own `blockTorrent` needs the service), but the
- * HTTP route must disappear with `FLIKS_BUNDLES=` — so the controller is
- * mounted from `GrabModule` instead, which is gated and already has
- * `AuthModule` for the same guard pair.
- */
 @Module({
   imports: [TypeOrmModule.forFeature([BlocklistEntry, Indexer]), AuthModule],
+  controllers: [BlocklistController],
   providers: [BlocklistService],
   exports: [BlocklistService],
 })

--- a/backend/src/plugins/download/grab.module.ts
+++ b/backend/src/plugins/download/grab.module.ts
@@ -13,7 +13,6 @@ import { LibrariesModule } from '../../modules/libraries/libraries.module';
 import { MediaModule } from '../../modules/media/media.module';
 import { PluginHostModule } from '../../modules/plugins/host/plugin-host.module';
 import { GrabController } from './grab.controller';
-import { BlocklistController } from './blocklist/blocklist.controller';
 import { MovieDownloadService } from './movie-download.service';
 import { EpisodeDownloadService } from './episode-download.service';
 
@@ -29,7 +28,7 @@ import { EpisodeDownloadService } from './episode-download.service';
     MediaModule,
     PluginHostModule,
   ],
-  controllers: [GrabController, BlocklistController],
+  controllers: [GrabController],
   providers: [MovieDownloadService, EpisodeDownloadService],
 })
 export class GrabModule {}


### PR DESCRIPTION
## The milestone

Every core file that reached into `plugins/download/` has now been converted — health probes, counts, the checklist, CASL, the policy vocabulary, the scoring context, the blocklist, stall detection. So the two modules that were still mounted unconditionally can go behind the same flag as the rest.

| | routes | entities | acquisition tables |
| --- | --- | --- | --- |
| bundle **on** | 385 | 51 | all six |
| bundle **off** | 353 | 45 | **none** |

The 32-route difference is exactly the acquisition surface: 9 indexer, 11 download-client, 4 blocklist, 8 grab. Nothing is exposed only when the bundle is off.

## Gating the mount was not enough

A conditional `imports` array still left core carrying all six acquisition tables, and this is the non-obvious reason: **a static import runs the module's `TypeOrmModule.forFeature(...)` at import time**, which registers its entities with `autoLoadEntities` whether or not the module is ever mounted. The import statement, not the mount, is what registers an entity.

With `synchronize` on in dev, that meant a core-only boot would happily **recreate every acquisition table** it had just been told to forget. Loading the bundle's modules only when the flag is on drops the entity count from 51 to 45 and takes the tables with it.

That also removes the trap that was blocking the table drop: the recorded sequencing constraint said the drop had to wait until the bundle physically left `src/`, because `synchronize` would undo it. It no longer would.

## Also

The blocklist controller returns to `BlocklistModule` — the split existed only because `DownloadClientsModule` was mounted unconditionally and needed the service, and that is no longer true.

## Verification

- `tsc` exit 0, `eslint` clean on the touched file, **128 suites / 1377 tests**.
- Both modes booted for real, with the route table and the TypeORM entity metadata enumerated per mode — the numbers above are from that boot, not from reading the module graph.
- The mechanism was established by experiment: with static imports, six acquisition entities are registered with the bundle off; with deferred loading, none are.

## Note

The four `require` calls are the one place a bundle name legitimately appears in core, and they go away with the directory when the bundle ships as an archive the registry mounts at runtime. `app.module.ts` is already the only core file allowlisted in the import fence for exactly that reason.