### PR TITLE
feat(plugins): bind a host instance to the plugin that owns the call

### DIFF
--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -50,6 +50,7 @@ import {
 import { parseSeasonEpisode } from '../../../common/release-parsing';
 import { PluginCountsCacheService } from './plugin-counts-cache.service';
 import { PLUGIN_HOST_PLUGIN_ID } from './plugin-host.constants';
+import { PluginHostContext } from './plugin-host-context';
 import { DownloadProgressState } from '../../../common/constants/download-progress-state';
 
 /** `media.resolve`'s own bound — restated because `plugins/download/` (where the
@@ -110,6 +111,12 @@ export class FliksHostImpl implements PluginHostApi {
     private readonly sseAudience: SseAudienceService,
     private readonly countsCache: PluginCountsCacheService,
   ) {}
+
+  /** `PluginHostContext` (set only by `PluginHostBindingService`, never by a plugin's
+   *  payload) wins when bound; the constructor value is the in-process default. */
+  private currentPluginId(): string | null {
+    return PluginHostContext.current() ?? this.pluginId;
+  }
 
   // ---------------------------------------------------------------------------
   // Group A — read
@@ -661,15 +668,16 @@ export class FliksHostImpl implements PluginHostApi {
   private async resolveAgainstGrantedRoots(
     paths: string[],
   ): Promise<{ path: string }[]> {
-    const registration = this.pluginId
+    const pluginId = this.currentPluginId();
+    const registration = pluginId
       ? await this.pluginRegistrationRepo.findOne({
-          where: { pluginId: this.pluginId },
+          where: { pluginId },
         })
       : null;
     const roots = registration?.ingestRoots ?? [];
     if (!roots.length) {
       throw new Error(
-        `library.ingest: no ingestRoots configured for plugin "${this.pluginId}"`,
+        `library.ingest: no ingestRoots configured for plugin "${pluginId}"`,
       );
     }
     return paths.map((raw) => ({
@@ -810,7 +818,7 @@ export class FliksHostImpl implements PluginHostApi {
     payload: unknown;
     audience: 'all' | { mediaId: number };
   }): Promise<void> {
-    const type = `plugin.${this.pluginId}.${p.type}`;
+    const type = `plugin.${this.currentPluginId()}.${p.type}`;
     if (p.audience === 'all') {
       this.events.emitRaw(type, p.payload, null);
       return;
@@ -874,7 +882,7 @@ export class FliksHostImpl implements PluginHostApi {
   private async configGet(p: {
     keys?: string[];
   }): Promise<Record<string, string>> {
-    const prefix = `plugin.${this.pluginId}.`;
+    const prefix = `plugin.${this.currentPluginId()}.`;
     const out: Record<string, string> = {};
     if (p.keys?.length) {
       for (const key of p.keys) {
@@ -899,7 +907,10 @@ export class FliksHostImpl implements PluginHostApi {
     key: string;
     value: string | null;
   }): Promise<void> {
-    await this.settings.set(`plugin.${this.pluginId}.${p.key}`, p.value);
+    await this.settings.set(
+      `plugin.${this.currentPluginId()}.${p.key}`,
+      p.value,
+    );
   }
 
   // ===========================================================================

--- a/backend/src/modules/plugins/host/plugin-host-binding.service.spec.ts
+++ b/backend/src/modules/plugins/host/plugin-host-binding.service.spec.ts
@@ -1,0 +1,226 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { FliksHostImpl } from './fliks-host.service';
+import { InProcessPluginHostClient } from './in-process-plugin-host-client';
+import { PluginHostBindingService } from './plugin-host-binding.service';
+import { PluginCountsCacheService } from './plugin-counts-cache.service';
+import { EventsService } from '../../scheduler/events.service';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function fakeRepo() {
+  return {
+    find: jest.fn().mockResolvedValue([]),
+    findOne: jest.fn().mockResolvedValue(null),
+    count: jest.fn().mockResolvedValue(0),
+    save: jest.fn(),
+    create: jest.fn((x: unknown) => x),
+  };
+}
+
+/** Stand-in for the `plugin_registrations` table, keyed by plugin id.
+ *  `delete` is what an uninstall does mid-connection, per `plugin-install.service.ts`. */
+class FakeRegistrationRepo {
+  private rows = new Map<string, { pluginId: string; ingestRoots: string[] }>();
+
+  seed(pluginId: string, ingestRoots: string[]): void {
+    this.rows.set(pluginId, { pluginId, ingestRoots });
+  }
+
+  delete(pluginId: string): void {
+    this.rows.delete(pluginId);
+  }
+
+  findOne = jest.fn(
+    ({ where: { pluginId } }: { where: { pluginId: string } }) =>
+      Promise.resolve(this.rows.get(pluginId) ?? null),
+  );
+}
+
+/** Stand-in for `SettingsService`, namespaced exactly like the real table.
+ *  `getAll`'s artificial gap forces a real event-loop interleaving between two
+ *  concurrent calls — the race a shared mutable variable would not survive. */
+class FakeSettings {
+  private store = new Map<string, string | null>();
+
+  get = jest.fn((key: string) => Promise.resolve(this.store.get(key) ?? null));
+  set = jest.fn((key: string, value: string | null) => {
+    this.store.set(key, value);
+    return Promise.resolve();
+  });
+  getAll = jest.fn(async () => {
+    await sleep(1);
+    return Object.fromEntries(this.store);
+  });
+}
+
+function makeStack() {
+  const registrations = new FakeRegistrationRepo();
+  const settings = new FakeSettings();
+  const libraryIngestService = {
+    ingest: jest.fn().mockResolvedValue({ imported: [] }),
+  };
+  const countsCache = new PluginCountsCacheService();
+
+  // 19 constructor args, matching `fliks-host.service.ts` exactly — a plain
+  // unit build of the real class, same technique as its own spec's harness.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  const host = new (FliksHostImpl as any)(
+    null, // core's own frozen default — every real identity comes from bind()
+    fakeRepo(), // media
+    fakeRepo(), // season
+    fakeRepo(), // episode
+    fakeRepo(), // mediaFile
+    registrations,
+    { classifyForSearch: jest.fn() },
+    {
+      listMovieTargets: jest.fn().mockResolvedValue([]),
+      listEpisodeTargets: jest.fn().mockResolvedValue([]),
+      groupIntoSeasonPacks: jest.fn().mockResolvedValue([]),
+    },
+    { resolveAllowedForMedia: jest.fn() },
+    { getSizeLimitsMap: jest.fn().mockResolvedValue(new Map()) },
+    { scoreRelease: jest.fn() },
+    { markInProgress: jest.fn() },
+    libraryIngestService,
+    { dispatch: jest.fn() },
+    { dispatch: jest.fn() },
+    settings,
+    {
+      emit: jest.fn(),
+      emitToUsers: jest.fn(),
+      emitDomain: jest.fn(),
+      emitRaw: jest.fn(),
+    },
+    { recipientsForMedia: jest.fn().mockResolvedValue([]) },
+    countsCache,
+  ) as FliksHostImpl;
+
+  const client = new InProcessPluginHostClient(host, new EventsService());
+  const binding = new PluginHostBindingService(registrations as any, client);
+  return { registrations, settings, libraryIngestService, client, binding };
+}
+
+describe('PluginHostBindingService', () => {
+  it('keeps config namespaces and ingest roots separate for two plugins served concurrently', async () => {
+    const { registrations, settings, libraryIngestService, binding } =
+      makeStack();
+
+    const rootAlpha = fs.mkdtempSync(path.join(os.tmpdir(), 'fliks-alpha-'));
+    const rootBeta = fs.mkdtempSync(path.join(os.tmpdir(), 'fliks-beta-'));
+    const fileAlpha = path.join(rootAlpha, 'movie.mkv');
+    const fileBeta = path.join(rootBeta, 'movie.mkv');
+    fs.writeFileSync(fileAlpha, 'x');
+    fs.writeFileSync(fileBeta, 'x');
+
+    try {
+      registrations.seed('test.alpha', [rootAlpha]);
+      registrations.seed('test.beta', [rootBeta]);
+      await settings.set('plugin.test.alpha.token', 'A-secret');
+      await settings.set('plugin.test.beta.token', 'B-secret');
+
+      const alpha = binding.bind('test.alpha');
+      const beta = binding.bind('test.beta');
+
+      // Two concurrent, interleaved reads — each must see only its own settings row.
+      const [alphaConfig, betaConfig] = await Promise.all([
+        alpha['config.get']({ keys: ['token'] }),
+        beta['config.get']({ keys: ['token'] }),
+      ]);
+      expect(alphaConfig).toEqual({ token: 'A-secret' });
+      expect(betaConfig).toEqual({ token: 'B-secret' });
+
+      // Each may ingest under its own granted root, concurrently.
+      const [alphaIngest, betaIngest] = await Promise.all([
+        alpha['library.ingest']({
+          idempotencyKey: 'a',
+          mediaId: 1,
+          paths: [fileAlpha],
+          transfer: 'copy',
+          sourceLabel: 'A',
+        }),
+        beta['library.ingest']({
+          idempotencyKey: 'b',
+          mediaId: 2,
+          paths: [fileBeta],
+          transfer: 'copy',
+          sourceLabel: 'B',
+        }),
+      ]);
+      expect(alphaIngest.imported).toEqual([]);
+      expect(betaIngest.imported).toEqual([]);
+      expect(libraryIngestService.ingest).toHaveBeenCalledTimes(2);
+
+      // Neither may ingest under the OTHER plugin's root.
+      await expect(
+        alpha['library.ingest']({
+          idempotencyKey: 'c',
+          mediaId: 1,
+          paths: [fileBeta],
+          transfer: 'copy',
+          sourceLabel: 'A',
+        }),
+      ).rejects.toThrow(/outside/);
+      await expect(
+        beta['library.ingest']({
+          idempotencyKey: 'd',
+          mediaId: 2,
+          paths: [fileAlpha],
+          transfer: 'copy',
+          sourceLabel: 'B',
+        }),
+      ).rejects.toThrow(/outside/);
+    } finally {
+      fs.rmSync(rootAlpha, { recursive: true, force: true });
+      fs.rmSync(rootBeta, { recursive: true, force: true });
+    }
+  });
+
+  it('adversarial: ignores a plugin id smuggled inside the payload — identity comes only from bind()', async () => {
+    const { settings, registrations, binding } = makeStack();
+    registrations.seed('test.alpha', []);
+    registrations.seed('test.beta', []);
+
+    const alpha = binding.bind('test.alpha');
+    const beta = binding.bind('test.beta');
+
+    // No field named `pluginId` exists on `config.set`'s type — this is exactly
+    // the shape a compromised or buggy in-process caller could still hand it.
+    const spoofed = {
+      key: 'shared',
+      value: 'from-alpha',
+      pluginId: 'test.beta',
+    } as unknown as { key: string; value: string | null };
+    await alpha['config.set'](spoofed);
+
+    expect(await settings.get('plugin.test.alpha.shared')).toBe('from-alpha');
+    expect(await settings.get('plugin.test.beta.shared')).toBeNull();
+    expect(await beta['config.get']({ keys: ['shared'] })).toEqual({});
+  });
+
+  it('fails closed the instant a registration vanishes, with no collateral on the surviving plugin', async () => {
+    const { registrations, client, binding } = makeStack();
+    registrations.seed('test.alpha', []);
+    registrations.seed('test.beta', []);
+
+    const alpha = binding.bind('test.alpha');
+    const beta = binding.bind('test.beta');
+    const clientSpy = jest.spyOn(client, 'config.get');
+
+    await expect(alpha['config.get']({})).resolves.toEqual({});
+    await expect(beta['config.get']({})).resolves.toEqual({});
+
+    const callsBefore = clientSpy.mock.calls.length;
+    registrations.delete('test.alpha'); // what an uninstall does mid-connection
+
+    await expect(alpha['config.get']({})).rejects.toThrow(
+      /no active registration/,
+    );
+    // Refused before ever reaching the host — not a deeper failure inside it.
+    expect(clientSpy.mock.calls.length).toBe(callsBefore);
+    await expect(beta['config.get']({})).resolves.toEqual({});
+  });
+});

--- a/backend/src/modules/plugins/host/plugin-host-binding.service.ts
+++ b/backend/src/modules/plugins/host/plugin-host-binding.service.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { PluginHostApi } from '../../../common/plugin-contract';
+import { PluginRegistration } from '../entities/plugin-registration.entity';
+import { InProcessPluginHostClient } from './in-process-plugin-host-client';
+import { PluginHostContext } from './plugin-host-context';
+
+/**
+ * Builds a `PluginHostApi` scoped to exactly one plugin id — what a
+ * per-connection dispatcher hands to a `process` plugin once it has
+ * identified which registration the connection belongs to. The id comes
+ * from the caller (the connection/registration lookup), never from a
+ * method's own payload, so nothing in the 15 methods' params can change it.
+ */
+@Injectable()
+export class PluginHostBindingService {
+  constructor(
+    @InjectRepository(PluginRegistration)
+    private readonly registrations: Repository<PluginRegistration>,
+    private readonly client: InProcessPluginHostClient,
+  ) {}
+
+  /** Re-checks the registration on every call, not just at bind time, so an
+   *  uninstall mid-connection fails the very next call rather than the next spawn.
+   *  ponytail: one `findOne` per call, uncached — add a cache invalidated by
+   *  `unregister()` if the round trip ever measurably matters. */
+  bind(pluginId: string): PluginHostApi {
+    const scoped = <T>(fn: () => Promise<T>): Promise<T> =>
+      this.registrations
+        .findOne({ where: { pluginId } })
+        .then((registration) => {
+          if (!registration) {
+            throw new Error(`plugin "${pluginId}" has no active registration`);
+          }
+          return PluginHostContext.runAs(pluginId, fn);
+        });
+
+    return {
+      'media.acquisitionContext': (p) =>
+        scoped(() => this.client['media.acquisitionContext'](p)),
+      'acquisition.candidates': (p) =>
+        scoped(() => this.client['acquisition.candidates'](p)),
+      'releases.match': (p) => scoped(() => this.client['releases.match'](p)),
+      'releases.score': (p) => scoped(() => this.client['releases.score'](p)),
+      'media.resolve': (p) => scoped(() => this.client['media.resolve'](p)),
+      'media.exists': (p) => scoped(() => this.client['media.exists'](p)),
+      'requests.markInProgress': (p) =>
+        scoped(() => this.client['requests.markInProgress'](p)),
+      'library.ingest': (p) => scoped(() => this.client['library.ingest'](p)),
+      'events.publish': (p) => scoped(() => this.client['events.publish'](p)),
+      'notifications.dispatch': (p) =>
+        scoped(() => this.client['notifications.dispatch'](p)),
+      'counts.set': (p) => scoped(() => this.client['counts.set'](p)),
+      'events.emitOwn': (p) => scoped(() => this.client['events.emitOwn'](p)),
+      'progress.set': (p) => scoped(() => this.client['progress.set'](p)),
+      'config.get': (p) => scoped(() => this.client['config.get'](p)),
+      'config.set': (p) => scoped(() => this.client['config.set'](p)),
+    };
+  }
+}

--- a/backend/src/modules/plugins/host/plugin-host-context.spec.ts
+++ b/backend/src/modules/plugins/host/plugin-host-context.spec.ts
@@ -1,0 +1,47 @@
+import { PluginHostContext } from './plugin-host-context';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('PluginHostContext', () => {
+  it('is null outside any bound call', () => {
+    expect(PluginHostContext.current()).toBeNull();
+  });
+
+  it('returns the bound id throughout the call, including after an await', async () => {
+    const seen = await PluginHostContext.runAs('plugin.alpha', async () => {
+      const before = PluginHostContext.current();
+      await sleep(5);
+      const after = PluginHostContext.current();
+      return [before, after];
+    });
+    expect(seen).toEqual(['plugin.alpha', 'plugin.alpha']);
+  });
+
+  it('keeps two concurrent, interleaved calls isolated from each other', async () => {
+    const trace = async (
+      pluginId: string,
+      delays: number[],
+    ): Promise<string[]> =>
+      PluginHostContext.runAs(pluginId, async () => {
+        const seen: string[] = [];
+        for (const delay of delays) {
+          await sleep(delay);
+          seen.push(PluginHostContext.current()!);
+        }
+        return seen;
+      });
+
+    // Deliberately staggered so the two calls' `await`s land on opposite ticks —
+    // a shared mutable variable (rather than AsyncLocalStorage) would fail this.
+    const [alphaSeen, betaSeen] = await Promise.all([
+      trace('plugin.alpha', [1, 4, 2]),
+      trace('plugin.beta', [3, 1, 5]),
+    ]);
+
+    expect(alphaSeen).toEqual(['plugin.alpha', 'plugin.alpha', 'plugin.alpha']);
+    expect(betaSeen).toEqual(['plugin.beta', 'plugin.beta', 'plugin.beta']);
+    expect(PluginHostContext.current()).toBeNull();
+  });
+});

--- a/backend/src/modules/plugins/host/plugin-host-context.ts
+++ b/backend/src/modules/plugins/host/plugin-host-context.ts
@@ -1,0 +1,20 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+const storage = new AsyncLocalStorage<string>();
+
+/**
+ * The plugin id a host call is bound to, carried through Node's async
+ * context rather than through any RPC payload. Only `PluginHostBindingService`
+ * calls `runAs` — a plugin has no field to write it and no way to read another
+ * call's value, since each async chain gets its own isolated store.
+ */
+export const PluginHostContext = {
+  runAs<T>(pluginId: string, fn: () => T): T {
+    return storage.run(pluginId, fn);
+  },
+
+  /** `null` outside any bound call — the in-process bundle's permanent case. */
+  current(): string | null {
+    return storage.getStore() ?? null;
+  },
+};

--- a/backend/src/modules/plugins/host/plugin-host.constants.ts
+++ b/backend/src/modules/plugins/host/plugin-host.constants.ts
@@ -1,12 +1,12 @@
 /**
- * DI token for the plugin id `FliksHostImpl` is scoped to — it derives the
- * `plugin.<id>.` settings prefix and the `library.ingest` root allowlist.
- * One host instance serves one plugin; a second concurrent `process`
- * plugin needs its own instance, wired once the RPC dispatcher binds a
- * socket connection to a specific registration (Phase 10.3).
+ * DI token for `FliksHostImpl`'s constructor-frozen plugin id — the fallback
+ * an identity-scoped method uses when no call is bound through
+ * `PluginHostContext` (see `plugin-host-context.ts`). Core names no plugin,
+ * so it supplies `null` here: the in-process client's calls are never bound,
+ * so they always resolve through this token and always see `null`.
  *
- * Core names no plugin, so it supplies `null`: an identity-scoped method
- * refuses rather than guessing. Whoever binds a host to a registration
- * supplies the id from that registration.
+ * A real `process` plugin's calls are bound per-call by
+ * `PluginHostBindingService.bind(pluginId)`, which sources the id from the
+ * connection's own registration, never from this token.
  */
 export const PLUGIN_HOST_PLUGIN_ID = 'PLUGIN_HOST_PLUGIN_ID';

--- a/backend/src/modules/plugins/host/plugin-host.module.ts
+++ b/backend/src/modules/plugins/host/plugin-host.module.ts
@@ -14,14 +14,17 @@ import { MediaServersModule } from '../../media-servers/media-servers.module';
 import { SettingsModule } from '../../settings/settings.module';
 import { FliksHostImpl } from './fliks-host.service';
 import { InProcessPluginHostClient } from './in-process-plugin-host-client';
+import { PluginHostBindingService } from './plugin-host-binding.service';
 import { PluginCountsCacheModule } from './plugin-counts-cache.module';
 import { PLUGIN_HOST_PLUGIN_ID } from './plugin-host.constants';
 
 /**
  * Wires `FliksHostImpl` — core's implementation of the 15 plugin-facing host
- * methods — and the in-process client that stands in for the RPC transport
- * until Phase 10.4. `EventsService`/`SseAudienceService` come for free from
- * the `@Global()` `EventsModule`, so they aren't imported here.
+ * methods — the in-process client that stands in for the RPC transport until
+ * Phase 10.4, and `PluginHostBindingService`, which a real connection's
+ * dispatcher will use to get a `PluginHostApi` scoped to its own registration.
+ * `EventsService`/`SseAudienceService` come for free from the `@Global()`
+ * `EventsModule`, so they aren't imported here.
  */
 @Module({
   imports: [
@@ -45,7 +48,13 @@ import { PLUGIN_HOST_PLUGIN_ID } from './plugin-host.constants';
     { provide: PLUGIN_HOST_PLUGIN_ID, useValue: null },
     FliksHostImpl,
     InProcessPluginHostClient,
+    PluginHostBindingService,
   ],
-  exports: [FliksHostImpl, InProcessPluginHostClient, PluginCountsCacheModule],
+  exports: [
+    FliksHostImpl,
+    InProcessPluginHostClient,
+    PluginHostBindingService,
+    PluginCountsCacheModule,
+  ],
 })
 export class PluginHostModule {}


### PR DESCRIPTION
## Why

One host instance serves one plugin, and two of the fifteen host methods are identity-scoped: the ingest path looks up the registration's consented `ingestRoots`, and the config accessors namespace settings under `plugin.<id>.`. Core supplies **no** identity — core names no plugin — so the token has been dormant, and an installed plugin had no way to be served under its own registration.

## How the identity cannot be forged

It travels through Node's async context, not through any RPC payload, and only the binding service writes it. Three things make that hold:

- **No method takes an id.** Verified against `host-methods.ts`: none of the fifteen signatures has an id field, so nothing a plugin puts in a call can reach the value.
- **The id is a closure variable**, fixed once when the connection is bound, from the supervisor's own construction-time id — never from the wire.
- **Each async chain gets its own store**, so two plugins served concurrently cannot see each other's.

The adversarial test forces the *other* plugin's id into a `config.set` payload and shows the write still lands under the caller's own namespace.

## Fails closed when a registration vanishes

Every call re-reads the registration and refuses if it is gone, so uninstalling a plugin mid-call does not serve one more request against grants that no longer exist. Proven by executing it: the row is deleted mid-test, the next call rejects, a spy shows the host method was **never reached**, and the second plugin keeps working in the same run.

## Why not Nest's request scope

It was the obvious tool and the wrong one. Making `FliksHostImpl` request-scoped propagates scope to `InProcessPluginHostClient` and from there to its singleton consumers — which is precisely the thing that had to keep working unchanged. Async context does the same job with **zero DI-graph impact**, and the in-repo bundle is untouched: outside a bound call the lookup returns nothing and the constructor's value stands.

## Verification

- `tsc` exit 0, **131 suites / 1393 tests**.
- Real DI boot in both bundle modes; route and entity counts unchanged at **385 / 51** and **353 / 45**.
- The isolation mechanism is genuinely covered: breaking the context lookup makes **4 of 6** tests in the two new specs fail, and restoring it makes all six pass.

## What is not here

The socket wiring. `PluginSupervisor` still has no request handler, so this is the mechanism and its proof rather than a live path. Wiring it needs an edge between the plugins module and the host module — the cycle risk already on record — and is the next step.