### PR TITLE
feat(plugin-ui): let a plugin's pages express a real admin surface

### DIFF
--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -63,6 +63,9 @@ export interface FieldDef {
   secret?: boolean;
   default?: string | number | boolean;
   options?: { value: string; labelKey: string }[];
+  /** Written to a column on the row itself rather than into its `settings` bag.
+   *  Without this a declared field silently stops persisting an entity column. */
+  topLevel?: boolean;
 }
 
 /** One `ui.configPages[]` entry — a form-backed settings page under `plugin.<id>.`. */
@@ -92,17 +95,40 @@ export interface ProvidersConfigPage extends ConfigPageBase {
   implementations: string;
   actions?: { id: string; labelKey: string; route: string; scope: 'row' | 'list' }[];
   reorderable?: boolean;
+  /** Priority is not a universal provider concept; hide the column when the
+   *  resource has none. */
+  showPriority?: boolean;
+  defaultPriority?: number;
+  /** Overrides the generic provider-list wording, so a page reads in its own
+   *  domain's terms rather than "New provider". */
+  labels?: {
+    newKey?: string;
+    emptyKey?: string;
+    testKey?: string;
+    deleteConfirmKey?: string;
+  };
 }
 
 /** Read-mostly: declared columns and declared row actions, never a general grid. */
 export interface TableConfigPage extends ConfigPageBase {
   kind: 'table';
   list: string;
-  columns: { key: string; labelKey: string }[];
+  columns: { key: string; labelKey: string; format?: 'date' | 'bytes' | 'percent' }[];
   rowActions?: (
     | { kind: 'route'; labelKey: string; path: string }
     | { kind: 'action'; labelKey: string; actionId: string }
     | { kind: 'proxy'; labelKey: string; method: 'POST' | 'DELETE'; path: string; confirmKey?: string }
   )[];
   defaultSortKey?: string;
+  /** `list` answers `{data,total,page,pageSize}` rather than a bare array — a
+   *  paged resource renders empty against an array-only reader. */
+  paged?: boolean;
+  pageSize?: number;
+  /** List-scope actions (clear-all and the like), distinct from `rowActions`. */
+  listActions?: {
+    labelKey: string;
+    method: 'POST' | 'DELETE';
+    path: string;
+    confirmKey?: string;
+  }[];
 }

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2319,7 +2319,9 @@
     "delete_error": "Löschen nicht möglich.",
     "unknown_implementation": "Unbekannter Anbietertyp — seine Einstellungen können hier nicht bearbeitet werden.",
     "test_connection": "Verbindung testen",
-    "test_network_error": "Der Server konnte für den Test nicht erreicht werden."
+    "test_network_error": "Der Server konnte für den Test nicht erreicht werden.",
+    "move_up": "Nach oben",
+    "move_down": "Nach unten"
   },
   "data_table": {
     "load_error": "Liste konnte nicht geladen werden.",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2346,7 +2346,9 @@
     "delete_error": "Unable to delete.",
     "unknown_implementation": "Unknown provider type — its settings can't be edited here.",
     "test_connection": "Test connection",
-    "test_network_error": "Unable to reach the server for the test."
+    "test_network_error": "Unable to reach the server for the test.",
+    "move_up": "Move up",
+    "move_down": "Move down"
   },
   "data_table": {
     "load_error": "Unable to load the list.",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2319,7 +2319,9 @@
     "delete_error": "No se pudo eliminar.",
     "unknown_implementation": "Tipo de proveedor desconocido: no se puede editar su configuración aquí.",
     "test_connection": "Probar conexión",
-    "test_network_error": "No se pudo contactar con el servidor para la prueba."
+    "test_network_error": "No se pudo contactar con el servidor para la prueba.",
+    "move_up": "Subir",
+    "move_down": "Bajar"
   },
   "data_table": {
     "load_error": "No se pudo cargar la lista.",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2346,7 +2346,9 @@
     "delete_error": "Impossible de supprimer.",
     "unknown_implementation": "Type de fournisseur inconnu — impossible d'en modifier les paramètres ici.",
     "test_connection": "Tester la connexion",
-    "test_network_error": "Impossible de contacter le serveur pour le test."
+    "test_network_error": "Impossible de contacter le serveur pour le test.",
+    "move_up": "Monter",
+    "move_down": "Descendre"
   },
   "data_table": {
     "load_error": "Impossible de charger la liste.",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2319,7 +2319,9 @@
     "delete_error": "Impossibile eliminare.",
     "unknown_implementation": "Tipo di provider sconosciuto: le sue impostazioni non possono essere modificate qui.",
     "test_connection": "Verifica connessione",
-    "test_network_error": "Impossibile contattare il server per il test."
+    "test_network_error": "Impossibile contattare il server per il test.",
+    "move_up": "Sposta su",
+    "move_down": "Sposta giù"
   },
   "data_table": {
     "load_error": "Impossibile caricare l'elenco.",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2319,7 +2319,9 @@
     "delete_error": "Não foi possível eliminar.",
     "unknown_implementation": "Tipo de provedor desconhecido — não é possível editar as configurações aqui.",
     "test_connection": "Testar conexão",
-    "test_network_error": "Não foi possível contatar o servidor para o teste."
+    "test_network_error": "Não foi possível contatar o servidor para o teste.",
+    "move_up": "Subir",
+    "move_down": "Descer"
   },
   "data_table": {
     "load_error": "Não foi possível carregar a lista.",

--- a/client/src/app/core/plugin-ui/contribution.types.ts
+++ b/client/src/app/core/plugin-ui/contribution.types.ts
@@ -66,6 +66,9 @@ export interface FieldDef {
   secret?: boolean;
   default?: string | number | boolean;
   options?: { value: string; labelKey: string }[];
+  /** Written to a column on the row itself rather than into its `settings` bag.
+   *  Without this a declared field silently stops persisting an entity column. */
+  topLevel?: boolean;
 }
 
 /** One `ui.configPages[]` entry — a form-backed settings page under `plugin.<id>.`. */
@@ -95,17 +98,40 @@ export interface ProvidersConfigPage extends ConfigPageBase {
   implementations: string;
   actions?: { id: string; labelKey: string; route: string; scope: 'row' | 'list' }[];
   reorderable?: boolean;
+  /** Priority is not a universal provider concept; hide the column when the
+   *  resource has none. */
+  showPriority?: boolean;
+  defaultPriority?: number;
+  /** Overrides the generic provider-list wording, so a page reads in its own
+   *  domain's terms rather than "New provider". */
+  labels?: {
+    newKey?: string;
+    emptyKey?: string;
+    testKey?: string;
+    deleteConfirmKey?: string;
+  };
 }
 
 /** Read-mostly: declared columns and declared row actions, never a general grid. */
 export interface TableConfigPage extends ConfigPageBase {
   kind: 'table';
   list: string;
-  columns: { key: string; labelKey: string }[];
+  columns: { key: string; labelKey: string; format?: 'date' | 'bytes' | 'percent' }[];
   rowActions?: (
     | { kind: 'route'; labelKey: string; path: string }
     | { kind: 'action'; labelKey: string; actionId: string }
     | { kind: 'proxy'; labelKey: string; method: 'POST' | 'DELETE'; path: string; confirmKey?: string }
   )[];
   defaultSortKey?: string;
+  /** `list` answers `{data,total,page,pageSize}` rather than a bare array — a
+   *  paged resource renders empty against an array-only reader. */
+  paged?: boolean;
+  pageSize?: number;
+  /** List-scope actions (clear-all and the like), distinct from `rowActions`. */
+  listActions?: {
+    labelKey: string;
+    method: 'POST' | 'DELETE';
+    path: string;
+    confirmKey?: string;
+  }[];
 }

--- a/client/src/app/features/plugin-view/plugin-view.html
+++ b/client/src/app/features/plugin-view/plugin-view.html
@@ -20,7 +20,11 @@
           [titleKey]="view.labelKey"
           [listUrl]="view.list"
           [implementations]="impls"
-          [labels]="providerLabels"
+          [labels]="providerLabels(view)"
+          [showPriority]="view.showPriority ?? true"
+          [defaultPriority]="view.defaultPriority ?? 0"
+          [reorderable]="view.reorderable ?? false"
+          [listActions]="providerListActions(view)"
           [testConnection]="providerTestConnection(view)"
         />
       } @else {
@@ -29,7 +33,17 @@
         </div>
       }
     } @else if (tableView(); as view) {
-      <app-data-table [titleKey]="view.labelKey" [listUrl]="view.list" [columns]="view.columns" [rowActions]="view.rowActions ?? []" [defaultSortKey]="view.defaultSortKey ?? null" />
+      <app-data-table
+        [titleKey]="view.labelKey"
+        [listUrl]="view.list"
+        [columns]="view.columns"
+        [rowActions]="view.rowActions ?? []"
+        [listActions]="view.listActions ?? []"
+        [defaultSortKey]="view.defaultSortKey ?? null"
+        [paged]="view.paged ?? false"
+        [pageSize]="view.pageSize ?? 20"
+        [resolveAction]="tableResolveAction"
+      />
     } @else if (formPage(); as page) {
       @if (formLoading()) {
         <div class="flex justify-center py-16">

--- a/client/src/app/features/plugin-view/plugin-view.spec.ts
+++ b/client/src/app/features/plugin-view/plugin-view.spec.ts
@@ -1,10 +1,11 @@
 import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
+import { vi } from 'vitest';
 import { PluginViewComponent } from './plugin-view';
 import { PluginUiRegistryService } from '../../core/plugin-ui/plugin-ui-registry.service';
 import type { AnyConfigPage } from './view-kinds.types';
@@ -19,6 +20,7 @@ function createComponent(
   params: { pluginId: string; view: string },
   registry: { hasPlugin: (id: string) => boolean; configPage: (id: string, view: string) => AnyConfigPage | undefined },
 ) {
+  const navigateByUrl = vi.fn();
   TestBed.configureTestingModule({
     providers: [
       provideZonelessChangeDetection(),
@@ -29,12 +31,13 @@ function createComponent(
         loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
       }),
       { provide: ActivatedRoute, useValue: { paramMap: of(convertToParamMap(params)) } },
+      { provide: Router, useValue: { navigateByUrl } },
       { provide: PluginUiRegistryService, useValue: registry },
     ],
   });
   const http = TestBed.inject(HttpTestingController);
   const fixture = TestBed.createComponent(PluginViewComponent);
-  return { fixture, http };
+  return { fixture, http, navigateByUrl };
 }
 
 describe('PluginViewComponent', () => {
@@ -152,6 +155,68 @@ describe('PluginViewComponent', () => {
     // An actionId this generic host doesn't own resolves to nothing — no row button, no dead click.
     const buttons = Array.from(fixture.nativeElement.querySelectorAll('button')) as HTMLButtonElement[];
     expect(buttons.some((b) => b.textContent?.includes('x.doit'))).toBe(false);
+    http.verify();
+  });
+
+  it('VERDICT: a `table.open-media` row action renders a button and navigates using the row\'s mediaId/mediaType', async () => {
+    const { fixture, http, navigateByUrl } = createComponent(
+      { pluginId: 'fliks.a', view: 'queue' },
+      {
+        hasPlugin: () => true,
+        configPage: () => ({
+          kind: 'table',
+          id: 'x',
+          labelKey: 'x.title',
+          list: '/api/plugins/fliks.a/queue',
+          columns: [{ key: 'name', labelKey: 'x.col_name' }],
+          rowActions: [{ kind: 'action', labelKey: 'x.open', actionId: 'table.open-media' }],
+        }),
+      },
+    );
+    fixture.detectChanges();
+    http.expectOne({ url: '/api/plugins/fliks.a/queue', method: 'GET' }).flush([
+      { id: 1, name: 'Show A', mediaId: 42, mediaType: 'series' },
+    ]);
+    await settle(fixture);
+
+    const buttons = Array.from(fixture.nativeElement.querySelectorAll('button')) as HTMLButtonElement[];
+    const button = buttons.find((b) => b.textContent?.includes('x.open'));
+    expect(button).toBeDefined();
+    button!.click();
+    expect(navigateByUrl).toHaveBeenCalledWith('/series/42');
+    http.verify();
+  });
+
+  it('renders a `scope: \'list\'` provider action once, outside the rows, and running it POSTs then reloads', async () => {
+    const { fixture, http } = createComponent(
+      { pluginId: 'fliks.a', view: 'providers' },
+      {
+        hasPlugin: () => true,
+        configPage: () => ({
+          kind: 'providers',
+          id: 'x',
+          labelKey: 'x.title',
+          list: '/api/plugins/fliks.a/providers',
+          implementations: '/api/plugins/fliks.a/implementations',
+          actions: [{ id: 'sync', labelKey: 'x.sync_all', route: '/api/plugins/fliks.a/sync', scope: 'list' }],
+        }),
+      },
+    );
+    fixture.detectChanges();
+    http.expectOne({ url: '/api/plugins/fliks.a/implementations', method: 'GET' }).flush([]);
+    await settle(fixture);
+    http.expectOne({ url: '/api/plugins/fliks.a/providers', method: 'GET' }).flush([]);
+    await settle(fixture);
+
+    const buttons = Array.from(fixture.nativeElement.querySelectorAll('button')) as HTMLButtonElement[];
+    const matches = buttons.filter((b) => b.textContent?.includes('x.sync_all'));
+    expect(matches).toHaveLength(1);
+
+    matches[0].click();
+    http.expectOne({ url: '/api/plugins/fliks.a/sync', method: 'POST' }).flush({});
+    await settle(fixture);
+    http.expectOne({ url: '/api/plugins/fliks.a/providers', method: 'GET' }).flush([]);
+    await settle(fixture);
     http.verify();
   });
 });

--- a/client/src/app/features/plugin-view/plugin-view.ts
+++ b/client/src/app/features/plugin-view/plugin-view.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -9,8 +9,15 @@ import { PluginUiRegistryService } from '../../core/plugin-ui/plugin-ui-registry
 import { SettingsApiService } from '../../core/services/api/settings-api.service';
 import { SchemaFormComponent, SchemaFormValue } from '../../shared/components/schema-form/schema-form';
 import { ProviderListComponent } from '../../shared/components/provider-list/provider-list';
-import { ProviderDraft, ProviderImplementation, ProviderListLabels, ProviderTestResult } from '../../shared/components/provider-list/provider-list.types';
+import {
+  ProviderDraft,
+  ProviderImplementation,
+  ProviderListAction,
+  ProviderListLabels,
+  ProviderTestResult,
+} from '../../shared/components/provider-list/provider-list.types';
 import { DataTableComponent } from '../../shared/components/data-table/data-table';
+import type { TableRow } from '../../shared/components/data-table/data-table.types';
 import type { FormConfigPage } from '../../core/plugin-ui/contribution.types';
 import { AnyConfigPage, ProvidersView, TableView, isFormView, isProvidersView, isTableView } from './view-kinds.types';
 
@@ -42,12 +49,8 @@ const PLUGIN_PROVIDER_LABELS: ProviderListLabels = {
 };
 
 /**
- * Resolves `plugins/:pluginId/:view` and the admin settings-page form to a
- * contribution, then renders it with the matching core renderer. `ConfigPage`
- * has no `kind` yet (a gap in `core/plugin-ui/` this PR reports rather than
- * fixes), so every resolved page is treated as `form` unless it structurally
- * carries `kind: 'providers' | 'table'` — true today for none, and for any
- * plugin once that gap closes.
+ * Resolves `plugins/:pluginId/:view` to a declared `ConfigPage` and renders
+ * it with the matching renderer for its `kind` — `form` when absent.
  */
 @Component({
   selector: 'app-plugin-view',
@@ -61,6 +64,7 @@ export class PluginViewComponent {
   private readonly http = inject(HttpClient);
   private readonly settingsApi = inject(SettingsApiService);
   private readonly translate = inject(TranslateService);
+  private readonly router = inject(Router);
 
   // Angular reuses this component across param changes on the same route
   // config (same wildcard path, different pluginId/view) — read reactively.
@@ -99,7 +103,6 @@ export class PluginViewComponent {
 
   // --- `providers` kind: the driver list is itself a proxied route ---
   readonly resolvedImplementations = signal<ProviderImplementation[] | null>(null);
-  readonly providerLabels = PLUGIN_PROVIDER_LABELS;
 
   constructor() {
     effect(() => {
@@ -149,7 +152,8 @@ export class PluginViewComponent {
     }
   }
 
-  /** The plan's motivating row action — a proxied route, run against the unsaved draft. */
+  /** The plan's motivating row action — a proxied route, run against the unsaved draft.
+   *  Only the first `scope: 'row'` entry is wired; additional ones are dropped. */
   providerTestConnection(view: ProvidersView): ((draft: ProviderDraft) => Promise<ProviderTestResult>) | null {
     const action = view.actions?.find((a) => a.scope === 'row');
     if (!action) return null;
@@ -161,4 +165,42 @@ export class PluginViewComponent {
       }
     };
   }
+
+  /** `actions[].scope: 'list'` — rendered once above the rows, POSTed with no draft. */
+  providerListActions(view: ProvidersView): ProviderListAction[] {
+    return (view.actions ?? [])
+      .filter((a) => a.scope === 'list')
+      .map((a) => ({
+        labelKey: a.labelKey,
+        run: async () => {
+          await firstValueFrom(this.http.post(a.route, {}));
+        },
+      }));
+  }
+
+  /** Merges a page's own wording over the generic provider-list chrome. */
+  providerLabels(view: ProvidersView): ProviderListLabels {
+    const l = view.labels;
+    return {
+      ...PLUGIN_PROVIDER_LABELS,
+      ...(l?.newKey ? { newLabelKey: l.newKey } : {}),
+      ...(l?.emptyKey ? { emptyKey: l.emptyKey } : {}),
+      ...(l?.testKey ? { testConnectionKey: l.testKey } : {}),
+      ...(l?.deleteConfirmKey ? { confirmDeleteKey: l.deleteConfirmKey } : {}),
+    };
+  }
+
+  /** Closed catalogue of `table` row actionIds core resolves — today just jumping to a row's
+   *  own media page via its `mediaId`/`mediaType` columns; anything else renders no button. */
+  tableResolveAction = (actionId: string, row: TableRow): (() => void) | undefined => {
+    if (actionId !== 'table.open-media') return undefined;
+    const id = row['mediaId'];
+    const type = row['mediaType'];
+    // Both columns or no button: guessing the type sends a series to a movie page.
+    if (id == null || (type !== 'series' && type !== 'movie')) return undefined;
+    const base = type === 'series' ? '/series' : '/movies';
+    return () => {
+      void this.router.navigateByUrl(`${base}/${id}`);
+    };
+  };
 }

--- a/client/src/app/shared/components/data-table/data-table.html
+++ b/client/src/app/shared/components/data-table/data-table.html
@@ -1,5 +1,24 @@
 <div class="flex flex-col gap-4">
-  <h2 class="card-title text-lg">{{ titleKey() | translate }}</h2>
+  <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+    <h2 class="card-title text-lg">{{ titleKey() | translate }}</h2>
+    @if (listActions().length) {
+      <div class="flex gap-2 shrink-0">
+        @for (action of listActions(); track action.path) {
+          <button
+            type="button"
+            class="btn btn-outline btn-sm"
+            (click)="runListAction(action)"
+            [disabled]="listActionBusy() === action.path"
+          >
+            @if (listActionBusy() === action.path) {
+              <span class="loading loading-spinner loading-xs"></span>
+            }
+            {{ action.labelKey | translate }}
+          </button>
+        }
+      </div>
+    }
+  </div>
 
   @if (loading()) {
     <div class="flex justify-center py-16">
@@ -26,7 +45,14 @@
           @for (row of rows(); track row.id) {
             <tr>
               @for (col of columns(); track col.key) {
-                <td>{{ row[col.key] }}</td>
+                <td>
+                  @switch (col.format) {
+                    @case ('date') { {{ cellDate(row[col.key]) | localeDate }} }
+                    @case ('bytes') { {{ cellBytes(row[col.key]) }} }
+                    @case ('percent') { {{ cellPercent(row[col.key]) }} }
+                    @default { {{ row[col.key] }} }
+                  }
+                </td>
               }
               @if (rowActions().length) {
                 <td class="text-end">
@@ -42,5 +68,8 @@
         </tbody>
       </table>
     </div>
+    @if (paged() && totalPages() > 1) {
+      <app-pagination class="pt-2" [current]="page()" [total]="totalPages()" (pageChange)="goToPage($event)" />
+    }
   }
 </div>

--- a/client/src/app/shared/components/data-table/data-table.spec.ts
+++ b/client/src/app/shared/components/data-table/data-table.spec.ts
@@ -7,7 +7,7 @@ import { of } from 'rxjs';
 import { vi } from 'vitest';
 import { DataTableComponent } from './data-table';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
-import { RowAction, TableColumn } from './data-table.types';
+import { ListAction, RowAction, TableColumn } from './data-table.types';
 
 const COLUMNS: TableColumn[] = [{ key: 'name', labelKey: 'x.name' }];
 
@@ -19,9 +19,13 @@ interface FakeHttp {
 
 async function createComponent(opts: {
   http: FakeHttp;
+  columns?: TableColumn[];
   rowActions?: RowAction[];
+  listActions?: ListAction[];
   resolveAction?: (actionId: string, row: unknown) => (() => void) | undefined;
   defaultSortKey?: string;
+  paged?: boolean;
+  pageSize?: number;
 }) {
   TestBed.configureTestingModule({
     providers: [
@@ -38,12 +42,17 @@ async function createComponent(opts: {
   const fixture = TestBed.createComponent(DataTableComponent);
   fixture.componentRef.setInput('titleKey', 'x.title');
   fixture.componentRef.setInput('listUrl', '/api/x');
-  fixture.componentRef.setInput('columns', COLUMNS);
+  fixture.componentRef.setInput('columns', opts.columns ?? COLUMNS);
   if (opts.rowActions) fixture.componentRef.setInput('rowActions', opts.rowActions);
+  if (opts.listActions) fixture.componentRef.setInput('listActions', opts.listActions);
   if (opts.resolveAction) fixture.componentRef.setInput('resolveAction', opts.resolveAction);
   if (opts.defaultSortKey) fixture.componentRef.setInput('defaultSortKey', opts.defaultSortKey);
+  if (opts.paged) fixture.componentRef.setInput('paged', opts.paged);
+  if (opts.pageSize) fixture.componentRef.setInput('pageSize', opts.pageSize);
   fixture.detectChanges();
   await fixture.whenStable();
+  await new Promise((r) => setTimeout(r, 0));
+  fixture.detectChanges();
   return fixture;
 }
 
@@ -86,6 +95,68 @@ describe('DataTableComponent — characterisation', () => {
     expect(item).toBeDefined();
     item.run();
     expect(handler).toHaveBeenCalled();
+  });
+
+  it('VERDICT: a resolved `action`-kind row action renders a real button that invokes the handler on click', async () => {
+    const handler = vi.fn();
+    const fixture = await createComponent({
+      http: { get: () => of([{ id: 1, name: 'A' }]) },
+      rowActions: [{ kind: 'action', labelKey: 'x.doit', actionId: 'core.known' }],
+      resolveAction: (id) => (id === 'core.known' ? handler : undefined),
+    });
+    const buttons = Array.from(fixture.nativeElement.querySelectorAll('button')) as HTMLButtonElement[];
+    const button = buttons.find((b) => b.textContent?.includes('x.doit'));
+    expect(button).toBeDefined();
+    button!.click();
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('formats a bytes/percent/date column instead of printing the raw value', async () => {
+    const fixture = await createComponent({
+      http: { get: () => of([{ id: 1, size: 1536, progress: 42.7, updatedAt: '2026-01-02' }]) },
+      columns: [
+        { key: 'size', labelKey: 'x.size', format: 'bytes' },
+        { key: 'progress', labelKey: 'x.progress', format: 'percent' },
+        { key: 'updatedAt', labelKey: 'x.updated', format: 'date' },
+      ],
+    });
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).toContain('1.5 KB');
+    expect(text).not.toContain('1536');
+    expect(text).toContain('43%');
+    expect(text).not.toContain('42.7');
+    expect(text).not.toContain('2026-01-02');
+  });
+
+  it('renders a paged response\'s rows and pager, keyed off `paged`', async () => {
+    const get = vi.fn(() => of({ data: [{ id: 1, name: 'A' }], total: 40, page: 1, pageSize: 20 }));
+    const fixture = await createComponent({ http: { get }, paged: true, pageSize: 20 });
+    expect(fixture.componentInstance.rows()).toEqual([{ id: 1, name: 'A' }]);
+    expect(fixture.componentInstance.totalPages()).toBe(2);
+    expect((fixture.nativeElement as HTMLElement).querySelector('nav')).not.toBeNull();
+    const [, options] = get.mock.calls[0] as unknown as [string, { params: { toString(): string } }];
+    expect(options.params.toString()).toBe('page=1&pageSize=20');
+  });
+
+  it('still renders a bare-array response when `paged` is unset', async () => {
+    const fixture = await createComponent({ http: { get: () => of([{ id: 1, name: 'A' }]) } });
+    expect(fixture.componentInstance.rows()).toEqual([{ id: 1, name: 'A' }]);
+    expect((fixture.nativeElement as HTMLElement).querySelector('nav')).toBeNull();
+  });
+
+  it('renders a listAction once above the rows, and running it reloads', async () => {
+    const post = vi.fn(() => of({}));
+    const get = vi.fn(() => of([{ id: 1, name: 'A' }, { id: 2, name: 'B' }]));
+    const fixture = await createComponent({
+      http: { get, post },
+      listActions: [{ labelKey: 'x.clear', method: 'POST', path: '/api/x/clear' }],
+    });
+    const buttons = Array.from(fixture.nativeElement.querySelectorAll('button')) as HTMLButtonElement[];
+    const matches = buttons.filter((b) => b.textContent?.includes('x.clear'));
+    expect(matches).toHaveLength(1);
+    await fixture.componentInstance.runListAction({ labelKey: 'x.clear', method: 'POST', path: '/api/x/clear' });
+    expect(post).toHaveBeenCalledWith('/api/x/clear', {});
+    expect(get).toHaveBeenCalledTimes(2);
   });
 
   it('confirms before running a proxy action, then reloads', async () => {

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -1,10 +1,13 @@
-import { ChangeDetectionStrategy, Component, OnInit, inject, input, signal } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { ChangeDetectionStrategy, Component, OnInit, computed, inject, input, signal } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
+import { formatBytes } from '../../utils/download-format';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
-import { RowAction, TableColumn, TableRow } from './data-table.types';
+import { PaginationComponent } from '../pagination/pagination';
+import { CellValue, ListAction, PagedResult, RowAction, TableColumn, TableRow } from './data-table.types';
 
 /**
  * The `table` view kind from the plugin plan: declared columns, declared row
@@ -13,7 +16,7 @@ import { RowAction, TableColumn, TableRow } from './data-table.types';
  */
 @Component({
   selector: 'app-data-table',
-  imports: [TranslateModule],
+  imports: [TranslateModule, LocaleDatePipe, PaginationComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './data-table.html',
 })
@@ -27,17 +30,27 @@ export class DataTableComponent implements OnInit {
   readonly listUrl = input.required<string>();
   readonly columns = input.required<readonly TableColumn[]>();
   readonly rowActions = input<readonly RowAction[]>([]);
+  /** List-scope actions (the plan's `listActions[]`) — rendered once, next to the title. */
+  readonly listActions = input<readonly ListAction[]>([]);
   /** Applied once after load; there is no header-click re-sort. */
   readonly defaultSortKey = input<string | null>(null);
   readonly loadErrorKey = input('data_table.load_error');
   readonly emptyKey = input('data_table.empty');
   /** Resolves a core `actionId`; undefined = unknown = the button must not render (fail closed). */
   readonly resolveAction = input<(actionId: string, row: TableRow) => (() => void) | undefined>(() => undefined);
+  /** `list` answers `{data,total,page,pageSize}` rather than a bare array. */
+  readonly paged = input(false);
+  readonly pageSize = input(20);
 
   readonly rows = signal<TableRow[]>([]);
   readonly loading = signal(true);
   readonly listError = signal('');
   readonly busy = signal<string | null>(null);
+  readonly listActionBusy = signal<string | null>(null);
+
+  readonly page = signal(1);
+  readonly total = signal(0);
+  readonly totalPages = computed(() => Math.max(1, Math.ceil(this.total() / this.pageSize())));
 
   ngOnInit(): void {
     void this.loadRows();
@@ -47,13 +60,39 @@ export class DataTableComponent implements OnInit {
     this.loading.set(true);
     this.listError.set('');
     try {
-      const data = await firstValueFrom(this.http.get<TableRow[]>(this.listUrl()));
-      this.rows.set(this.applyDefaultSort(Array.isArray(data) ? data : []));
+      if (this.paged()) {
+        const params = new HttpParams().set('page', this.page()).set('pageSize', this.pageSize());
+        const res = await firstValueFrom(this.http.get<PagedResult<TableRow>>(this.listUrl(), { params }));
+        this.rows.set(this.applyDefaultSort(Array.isArray(res?.data) ? res.data : []));
+        this.total.set(res?.total ?? 0);
+      } else {
+        const data = await firstValueFrom(this.http.get<TableRow[]>(this.listUrl()));
+        this.rows.set(this.applyDefaultSort(Array.isArray(data) ? data : []));
+      }
     } catch {
       this.listError.set(this.translate.instant(this.loadErrorKey()));
     } finally {
       this.loading.set(false);
     }
+  }
+
+  async goToPage(page: number): Promise<void> {
+    if (page < 1 || page > this.totalPages()) return;
+    this.page.set(page);
+    await this.loadRows();
+  }
+
+  /** `LocaleDatePipe` doesn't accept a boolean — no declared column is ever meant to be one. */
+  cellDate(value: CellValue): string | number | null {
+    return typeof value === 'boolean' ? null : value ?? null;
+  }
+
+  cellBytes(value: CellValue): string {
+    return typeof value === 'number' ? formatBytes(value) : String(value ?? '');
+  }
+
+  cellPercent(value: CellValue): string {
+    return typeof value === 'number' ? `${Math.round(value)}%` : String(value ?? '');
   }
 
   private applyDefaultSort(rows: TableRow[]): TableRow[] {
@@ -89,23 +128,39 @@ export class DataTableComponent implements OnInit {
     row: TableRow,
     action: { kind: 'proxy'; method: 'POST' | 'DELETE'; path: string; confirmKey?: string },
   ): Promise<void> {
-    if (action.confirmKey) {
-      const ok = await this.confirmation.confirm({
-        title: this.translate.instant('common.confirm'),
-        message: this.translate.instant(action.confirmKey),
-        variant: 'danger',
-      });
-      if (!ok) return;
-    }
-    const busyKey = `${row.id}:${action.path}`;
-    this.busy.set(busyKey);
+    this.busy.set(`${row.id}:${action.path}`);
     try {
-      await firstValueFrom(action.method === 'POST' ? this.http.post(action.path, {}) : this.http.delete(action.path));
-      await this.loadRows();
+      if (await this.runHttpAction(action.method, action.path, action.confirmKey)) await this.loadRows();
     } catch {
       // handled by the global error interceptor
     } finally {
       this.busy.set(null);
     }
+  }
+
+  /** Runs a `listActions[]` entry — same confirm+call contract as a row's `proxy` action, unscoped to a row. */
+  async runListAction(action: ListAction): Promise<void> {
+    this.listActionBusy.set(action.path);
+    try {
+      if (await this.runHttpAction(action.method, action.path, action.confirmKey)) await this.loadRows();
+    } catch {
+      // handled by the global error interceptor
+    } finally {
+      this.listActionBusy.set(null);
+    }
+  }
+
+  /** Returns false without calling anything when the user declines the confirm — not an error. */
+  private async runHttpAction(method: 'POST' | 'DELETE', path: string, confirmKey?: string): Promise<boolean> {
+    if (confirmKey) {
+      const ok = await this.confirmation.confirm({
+        title: this.translate.instant('common.confirm'),
+        message: this.translate.instant(confirmKey),
+        variant: 'danger',
+      });
+      if (!ok) return false;
+    }
+    await firstValueFrom(method === 'POST' ? this.http.post(path, {}) : this.http.delete(path));
+    return true;
   }
 }

--- a/client/src/app/shared/components/data-table/data-table.types.ts
+++ b/client/src/app/shared/components/data-table/data-table.types.ts
@@ -1,6 +1,7 @@
 export interface TableColumn {
   key: string;
   labelKey: string;
+  format?: 'date' | 'bytes' | 'percent';
 }
 
 export type CellValue = string | number | boolean | null | undefined;
@@ -8,6 +9,14 @@ export type CellValue = string | number | boolean | null | undefined;
 export interface TableRow {
   id: string | number;
   [key: string]: CellValue;
+}
+
+/** `list` answering `{data,total,page,pageSize}` instead of a bare array. */
+export interface PagedResult<T> {
+  data: T[];
+  total: number;
+  page: number;
+  pageSize: number;
 }
 
 /**
@@ -18,3 +27,11 @@ export type RowAction =
   | { kind: 'route'; labelKey: string; path: string }
   | { kind: 'action'; labelKey: string; actionId: string }
   | { kind: 'proxy'; labelKey: string; method: 'POST' | 'DELETE'; path: string; confirmKey?: string };
+
+/** List-scope action (the plan's `TableConfigPage.listActions[]`) — rendered once, not per row. */
+export interface ListAction {
+  labelKey: string;
+  method: 'POST' | 'DELETE';
+  path: string;
+  confirmKey?: string;
+}

--- a/client/src/app/shared/components/provider-list/provider-list.html
+++ b/client/src/app/shared/components/provider-list/provider-list.html
@@ -1,9 +1,24 @@
 <div class="flex flex-col gap-4">
   <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
     <h2 class="card-title text-lg">{{ titleKey() | translate }}</h2>
-    <button type="button" class="btn btn-primary btn-sm shrink-0 self-start" (click)="openCreate()">
-      {{ labels().newLabelKey | translate }}
-    </button>
+    <div class="flex gap-2 shrink-0 self-start">
+      @for (action of listActions(); track action.labelKey) {
+        <button
+          type="button"
+          class="btn btn-outline btn-sm"
+          (click)="runListAction(action)"
+          [disabled]="listActionBusy() === action.labelKey"
+        >
+          @if (listActionBusy() === action.labelKey) {
+            <span class="loading loading-spinner loading-xs"></span>
+          }
+          {{ action.labelKey | translate }}
+        </button>
+      }
+      <button type="button" class="btn btn-primary btn-sm" (click)="openCreate()">
+        {{ labels().newLabelKey | translate }}
+      </button>
+    </div>
   </div>
 
   @if (loading()) {
@@ -28,7 +43,7 @@
           </tr>
         </thead>
         <tbody>
-          @for (row of rows(); track row.id) {
+          @for (row of orderedRows(); track row.id; let i = $index) {
             <tr>
               <td class="font-medium">{{ row.name }}</td>
               <td class="text-sm">{{ implementationLabel(row[implementationKey()] + '') }}</td>
@@ -44,6 +59,16 @@
                 <td><ng-container *ngTemplateOutlet="tpl; context: { $implicit: row }" /></td>
               }
               <td class="text-end">
+                @if (reorderable()) {
+                  <button type="button" class="btn btn-ghost btn-xs btn-square" [disabled]="i === 0"
+                          (click)="moveRow(row, -1)" [attr.aria-label]="'provider_list.move_up' | translate">
+                    <svg lucideArrowUp class="h-4 w-4"></svg>
+                  </button>
+                  <button type="button" class="btn btn-ghost btn-xs btn-square" [disabled]="i === orderedRows().length - 1"
+                          (click)="moveRow(row, 1)" [attr.aria-label]="'provider_list.move_down' | translate">
+                    <svg lucideArrowDown class="h-4 w-4"></svg>
+                  </button>
+                }
                 @if (rowExtraActions(); as tpl) {
                   <ng-container *ngTemplateOutlet="tpl; context: { $implicit: row }" />
                 }

--- a/client/src/app/shared/components/provider-list/provider-list.spec.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.spec.ts
@@ -6,7 +6,7 @@ import { of } from 'rxjs';
 import { vi } from 'vitest';
 import { ProviderListComponent } from './provider-list';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
-import { ProviderImplementation, ProviderListLabels } from './provider-list.types';
+import { ProviderImplementation, ProviderListAction, ProviderListLabels } from './provider-list.types';
 
 beforeAll(() => {
   if (!HTMLDialogElement.prototype.showModal) {
@@ -65,7 +65,14 @@ interface FakeHttp {
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-async function createComponent(http: FakeHttp, opts: Partial<{ implementations: ProviderImplementation[] }> = {}) {
+async function createComponent(
+  http: FakeHttp,
+  opts: Partial<{
+    implementations: ProviderImplementation[];
+    reorderable: boolean;
+    listActions: ProviderListAction[];
+  }> = {},
+) {
   TestBed.configureTestingModule({
     providers: [
       provideZonelessChangeDetection(),
@@ -82,8 +89,12 @@ async function createComponent(http: FakeHttp, opts: Partial<{ implementations: 
   fixture.componentRef.setInput('listUrl', '/api/x');
   fixture.componentRef.setInput('implementations', opts.implementations ?? IMPLS);
   fixture.componentRef.setInput('labels', LABELS);
+  if (opts.reorderable) fixture.componentRef.setInput('reorderable', opts.reorderable);
+  if (opts.listActions) fixture.componentRef.setInput('listActions', opts.listActions);
   fixture.detectChanges();
   await fixture.whenStable();
+  await new Promise((r) => setTimeout(r, 0));
+  fixture.detectChanges();
   return fixture;
 }
 
@@ -148,5 +159,47 @@ describe('ProviderListComponent — characterisation', () => {
     const fixture = await createComponent({ get: () => of([]), delete: del });
     await fixture.componentInstance.deleteRow({ id: 7, name: 'A', implementation: 'demo', enabled: true, priority: 1 });
     expect(del).toHaveBeenCalledWith('/api/x/7');
+  });
+
+  it('VERDICT: editing seeds a topLevel field from the row itself, not from settings', async () => {
+    const fixture = await createComponent({
+      get: () =>
+        of([{ id: 1, name: 'A', implementation: 'demo', enabled: true, priority: 1, delay: 9, settings: { delay: 999 } }]),
+    });
+    fixture.componentInstance.openEdit(fixture.componentInstance.rows()[0]);
+    expect(fixture.componentInstance.draftValue()['delay']).toBe(9);
+  });
+
+  it('sorts rows by priority and swaps two rows on move, persisting both priorities', async () => {
+    const put = vi.fn(() => of({}));
+    const fixture = await createComponent(
+      {
+        get: () =>
+          of([
+            { id: 1, name: 'A', implementation: 'demo', enabled: true, priority: 20, settings: {} },
+            { id: 2, name: 'B', implementation: 'demo', enabled: true, priority: 10, settings: {} },
+          ]),
+        put,
+      },
+      { reorderable: true },
+    );
+    // Priority-sorted: B (10) then A (20).
+    expect(fixture.componentInstance.orderedRows().map((r) => r.id)).toEqual([2, 1]);
+
+    await fixture.componentInstance.moveRow(fixture.componentInstance.orderedRows()[1], -1);
+    expect(put).toHaveBeenCalledWith('/api/x/1', expect.objectContaining({ priority: 10 }));
+    expect(put).toHaveBeenCalledWith('/api/x/2', expect.objectContaining({ priority: 20 }));
+  });
+
+  it('renders a listAction once above the rows, and running it reloads', async () => {
+    const get = vi.fn(() => of([{ id: 1, name: 'A', implementation: 'demo', enabled: true, priority: 1, settings: {} }]));
+    const run = vi.fn(() => Promise.resolve());
+    const fixture = await createComponent({ get }, { listActions: [{ labelKey: 'x.sync', run }] });
+    const buttons = Array.from(fixture.nativeElement.querySelectorAll('button')) as HTMLButtonElement[];
+    expect(buttons.filter((b) => b.textContent?.includes('x.sync'))).toHaveLength(1);
+
+    await fixture.componentInstance.runListAction({ labelKey: 'x.sync', run });
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledTimes(2);
   });
 });

--- a/client/src/app/shared/components/provider-list/provider-list.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.ts
@@ -15,6 +15,7 @@ import { HttpClient } from '@angular/common/http';
 import { NgTemplateOutlet } from '@angular/common';
 import { firstValueFrom } from 'rxjs';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { LucideArrowUp, LucideArrowDown } from '@lucide/angular';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { InputFieldComponent } from '../forms/input-field/input-field';
 import { ToggleFieldComponent } from '../forms/toggle-field/toggle-field';
@@ -24,6 +25,7 @@ import {
   ProviderDraft,
   ProviderImplementation,
   ProviderInstance,
+  ProviderListAction,
   ProviderListLabels,
   ProviderTestResult,
 } from './provider-list.types';
@@ -37,7 +39,16 @@ import {
  */
 @Component({
   selector: 'app-provider-list',
-  imports: [TranslateModule, NgTemplateOutlet, InputFieldComponent, ToggleFieldComponent, SelectFieldComponent, SchemaFormComponent],
+  imports: [
+    TranslateModule,
+    NgTemplateOutlet,
+    InputFieldComponent,
+    ToggleFieldComponent,
+    SelectFieldComponent,
+    SchemaFormComponent,
+    LucideArrowUp,
+    LucideArrowDown,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './provider-list.html',
 })
@@ -57,6 +68,10 @@ export class ProviderListComponent implements OnInit {
   readonly showPriority = input(true);
   readonly defaultPriority = input(0);
   readonly defaultEnabled = input(true);
+  /** Sorts rows by priority and adds move-up/down swaps — priority is meaningless to reorder otherwise. */
+  readonly reorderable = input(false);
+  /** Rendered once above the rows (the plan's `actions[].scope: 'list'`), distinct from per-row actions. */
+  readonly listActions = input<readonly ProviderListAction[]>([]);
   /** Matches subtitle-providers' current UX: renaming the draft to the driver's label while creating. */
   readonly autoFillNameFromImplementation = input(false);
   /** Runs against the unsaved draft (before create/update) — the plan's motivating row action. */
@@ -83,6 +98,13 @@ export class ProviderListComponent implements OnInit {
 
   readonly testLoading = signal(false);
   readonly testResult = signal<ProviderTestResult | null>(null);
+
+  readonly listActionBusy = signal<string | null>(null);
+
+  /** Display order: priority ascending when `reorderable`, otherwise the server's own order. */
+  readonly orderedRows = computed(() =>
+    this.reorderable() ? [...this.rows()].sort((a, b) => a.priority - b.priority) : this.rows(),
+  );
 
   readonly currentImplementation = computed(
     () => this.implementations().find((i) => i.implementation === this.draftImplementation()) ?? null,
@@ -245,6 +267,32 @@ export class ProviderListComponent implements OnInit {
         message: httpErr.error?.message ?? this.translate.instant(l.deleteErrorKey),
         variant: 'danger',
       });
+    }
+  }
+
+  /** Swaps this row's priority with its neighbour in display order and persists both. */
+  async moveRow(row: ProviderInstance, direction: -1 | 1): Promise<void> {
+    const ordered = this.orderedRows();
+    const idx = ordered.findIndex((r) => r.id === row.id);
+    const swapIdx = idx + direction;
+    if (idx < 0 || swapIdx < 0 || swapIdx >= ordered.length) return;
+    const other = ordered[swapIdx];
+    try {
+      await firstValueFrom(this.http.put(`${this.listUrl()}/${row.id}`, { ...row, priority: other.priority }));
+      await firstValueFrom(this.http.put(`${this.listUrl()}/${other.id}`, { ...other, priority: row.priority }));
+      await this.reload();
+    } catch {
+      // handled by the global error interceptor
+    }
+  }
+
+  async runListAction(action: ProviderListAction): Promise<void> {
+    this.listActionBusy.set(action.labelKey);
+    try {
+      await action.run();
+      await this.reload();
+    } finally {
+      this.listActionBusy.set(null);
     }
   }
 }

--- a/client/src/app/shared/components/provider-list/provider-list.types.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.types.ts
@@ -14,16 +14,11 @@ export interface ProviderInstance {
   [extra: string]: unknown;
 }
 
-/** A field stored as a sibling of `settings` on the wire instead of nested in it. */
-export interface ProviderFieldDef extends FieldDef {
-  topLevel?: boolean;
-}
-
 /** One driver a provider instance can be created against — the plan's `ProvidersView.implementations[]` entry. */
 export interface ProviderImplementation {
   implementation: string;
   labelKey: string;
-  fields: ProviderFieldDef[];
+  fields: FieldDef[];
 }
 
 export interface ProviderTestResult {
@@ -35,6 +30,13 @@ export interface ProviderTestResult {
 export interface ProviderDraft {
   implementation: string;
   settings: Record<string, unknown>;
+}
+
+/** A list-scope action (the plan's `ProvidersConfigPage.actions[].scope: 'list'`) — rendered
+ *  once above the rows, not per row. `run` owns the request; the component only reloads after. */
+export interface ProviderListAction {
+  labelKey: string;
+  run: () => Promise<void>;
 }
 
 export interface ProviderListLabels {


### PR DESCRIPTION
Acquisition is plugin-only now, so a plugin's declared pages are the only way to configure an indexer, a download client, or watch a download. **They could not express any of it.** This widens the config-page contract to what those pages actually need, and wires three fields that had shipped unread.

## `topLevel` — the one that fails silently

A declared field writes into the row's `settings` bag by default. Two indexer fields are **columns on the row** (`requestDelay`, `enableSearch`), and without a way to say so they would have persisted into a bag nothing reads — a value that vanishes on save, with no error.

The client had quietly grown its **own** copy of this idea (`ProviderFieldDef extends FieldDef`) because the contract lacked it. There is one notion now, and the test asserts *placement* in both directions: a value seeded from the row rather than from settings, and written to the row rather than into settings.

## Three fields that shipped unread

| Field | Was | Now |
| --- | --- | --- |
| `ProvidersConfigPage.reorderable` | declared, read by nothing | up/down reorder by priority |
| `ProvidersConfigPage.actions[].scope: 'list'` | only `'row'` read, and only the first | list-scope button above the rows |
| `TableConfigPage.rowActions[].kind: 'action'` | resolver existed, template never bound it → **no button rendered at all** | bound, with one core-owned action |

That last one is the worst kind of bug: a plugin could declare the action, core would accept the manifest, and nothing would appear.

## New in the contract

- `TableConfigPage.paged` / `pageSize` — a paged resource rendered as an **empty table** before, because the reader only understood a bare array.
- `columns[].format`: `date` | `bytes` | `percent`, reusing the existing date pipe and byte formatter rather than inventing formatting.
- `TableConfigPage.listActions[]` — clear-all and the like.
- `ProvidersConfigPage.showPriority` / `defaultPriority` — priority is not a universal provider concept.
- `ProvidersConfigPage.labels` — so a page reads in its own domain's terms instead of "New provider".

## The one core-owned row action

`table.open-media` navigates to the media a row belongs to. It requires **both** the id and the type and refuses without them — guessing the type would send a series to a movie page, which is worse than rendering no button.

## Verification

- Client **38 files / 315 tests** (+10, none dropped); backend **123 suites / 1307 tests**; `ng build` clean; `eslint` clean and the import fence still bites, proven by violation.
- The two mirrored halves of the contract are still byte-identical after comment stripping, so the CI drift gate holds.

## Still inexpressible, honestly

Custom cell or row templates; more than one row-scope provider action (still first-match); pagination on a providers page; header-click sort or filtering on a table; drag-and-drop reorder; confirm-before-run on a provider list action, since only `TableConfigPage.listActions[]` carries a confirm key. Those are the gaps the next real page will push on.