### PR TITLE
feat(plugins): let a spawned plugin's host calls reach core

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -26,6 +26,7 @@ import { FilesystemModule } from './modules/filesystem/filesystem.module';
 import { SetupChecklistModule } from './modules/setup-checklist/setup-checklist.module';
 import { CountsModule } from './modules/counts/counts.module';
 import { PluginsModule } from './modules/plugins/plugins.module';
+import { PluginHostModule } from './modules/plugins/host/plugin-host.module';
 import { CommonModule } from './common/common.module';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
@@ -99,6 +100,9 @@ import { join } from 'path';
     SetupChecklistModule,
     CountsModule,
     PluginsModule,
+    // @Global(): registered once here so PluginProcessService (in PluginsModule) can
+    // inject PluginHostBindingService without an import edge back into this module.
+    PluginHostModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/modules/plugins/host/plugin-host.module.ts
+++ b/backend/src/modules/plugins/host/plugin-host.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Media } from '../../media/entities/media.entity';
 import { Season } from '../../media/entities/season.entity';
@@ -20,12 +20,17 @@ import { PLUGIN_HOST_PLUGIN_ID } from './plugin-host.constants';
 
 /**
  * Wires `FliksHostImpl` — core's implementation of the 15 plugin-facing host
- * methods — the in-process client that stands in for the RPC transport until
- * Phase 10.4, and `PluginHostBindingService`, which a real connection's
- * dispatcher will use to get a `PluginHostApi` scoped to its own registration.
+ * methods — the in-process client, and `PluginHostBindingService`, which the
+ * supervisor uses to get a `PluginHostApi` scoped to one plugin's registration.
  * `EventsService`/`SseAudienceService` come for free from the `@Global()`
  * `EventsModule`, so they aren't imported here.
+ *
+ * `@Global()` for the same reason: this module reaches `MediaModule`, which
+ * (via `FliksSchedulerModule`) reaches `PluginsModule` — importing this module
+ * from `PluginsModule` would close that loop into a cycle. Global-scoping
+ * exports the binding service without adding that edge.
  */
+@Global()
 @Module({
   imports: [
     TypeOrmModule.forFeature([

--- a/backend/src/modules/plugins/plugin-process.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-process.service.spec.ts
@@ -9,6 +9,7 @@ import { createHash } from 'crypto';
 import { minimalProcessManifest } from './archive/test-manifests';
 import type { PluginPackage } from './entities/plugin-package.entity';
 import type { PluginSupervisor, PluginSupervisorOptions, SupervisorState } from './supervisor/plugin-supervisor';
+import type { PluginHostBindingService } from './host/plugin-host-binding.service';
 
 /**
  * Waits until the factory has built `count` supervisors, so a fake's state can be flipped
@@ -166,6 +167,30 @@ describe('PluginProcessService.startFor', () => {
       expect.objectContaining({ id: pkg.pluginId, dbUrl: 'postgresql://fake-dsn', memoryMb: 256 }),
     );
     expect(service.stateOf(pkg.pluginId)).toBe('ready');
+  });
+
+  it("binds the supervisor's hostApi to this plugin's own id when a PluginHostBindingService is given", async () => {
+    const pkg = fakePackage();
+    const boundApi = { 'config.get': jest.fn() };
+    const bind = jest.fn().mockReturnValue(boundApi);
+    const hostBinding = { bind } as unknown as PluginHostBindingService;
+    const { factory, instances } = makeFactory();
+    const service = new PluginProcessService(
+      fakePluginDb() as never,
+      fakeLogBuffer() as never,
+      fakeSettings() as never,
+      factory,
+      undefined,
+      hostBinding,
+    );
+
+    const startPromise = service.startFor(pkg);
+    await waitForSupervisors(instances);
+    instances[0].setState('ready');
+    await startPromise;
+
+    expect(bind).toHaveBeenCalledWith(pkg.pluginId);
+    expect(instances[0].options.hostApi).toBe(boundApi);
   });
 
   it('passes a null rotated password through as undefined', async () => {

--- a/backend/src/modules/plugins/plugin-process.service.ts
+++ b/backend/src/modules/plugins/plugin-process.service.ts
@@ -12,6 +12,7 @@ import {
 import { LogBufferService } from '../scheduler/log-buffer.service';
 import { SettingsService } from '../settings/settings.service';
 import type { ProcessPluginManifest } from '../../common/plugin-contract';
+import { PluginHostBindingService } from './host/plugin-host-binding.service';
 
 export type PluginProcessFailureReason = 'tampered' | 'db-provision-failed' | 'spawn-failed';
 export type PluginProcessStartResult = { ok: true } | { ok: false; reason: PluginProcessFailureReason; detail: string };
@@ -32,6 +33,7 @@ export class PluginProcessService implements OnApplicationShutdown {
   private readonly running = new Map<string, RunningPlugin>();
   private readonly supervisorFactory: PluginSupervisorFactory;
   private readonly startupTimeoutMs: number;
+  private readonly hostBinding: PluginHostBindingService | null;
 
   constructor(
     private readonly pluginDb: PluginDatabaseService,
@@ -39,9 +41,13 @@ export class PluginProcessService implements OnApplicationShutdown {
     private readonly settings: SettingsService,
     @Optional() supervisorFactory?: PluginSupervisorFactory,
     @Optional() startupTimeoutMs?: number,
+    // Optional (rather than an import edge to PluginHostModule) so tests that
+    // build this service by hand need not supply it — see plugin-host.module.ts.
+    @Optional() hostBinding?: PluginHostBindingService,
   ) {
     this.supervisorFactory = supervisorFactory ?? DEFAULT_FACTORY;
     this.startupTimeoutMs = startupTimeoutMs ?? DEFAULT_SUPERVISOR_OPTIONS.handshakeDeadlineMs;
+    this.hostBinding = hostBinding ?? null;
   }
 
   /** Materialise -> provision-check -> rotate -> config -> spawn; each stage's failure
@@ -76,6 +82,7 @@ export class PluginProcessService implements OnApplicationShutdown {
       dbUrl,
       config,
       memoryMb: manifest.memoryMb,
+      hostApi: this.hostBinding?.bind(pkg.pluginId) ?? null,
     });
     const unsubscribe = supervisor.onStateChange((state) =>
       this.logBuffer.log(`state: ${state}`, `plugin:${pkg.pluginId}`),

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.spec.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.spec.ts
@@ -1,5 +1,8 @@
 import { existsSync, rmSync } from 'fs';
+import { connect } from 'net';
 import { DEFAULT_SUPERVISOR_OPTIONS, PluginSupervisor, type PluginSupervisorOptions } from './plugin-supervisor';
+import { RpcChannel } from './rpc-channel';
+import type { PluginHostApi } from '../../../common/plugin-contract';
 import {
   delay,
   makeFixtureDir,
@@ -8,6 +11,16 @@ import {
   waitForExitSignal,
   waitForState,
 } from './supervisor-test-helpers';
+
+/** Dials the supervisor's uplink socket exactly as a real `process` plugin's
+ *  own coreSock client would — same `RpcChannel`, opposite end. */
+function connectAsPlugin(sockPath: string): Promise<RpcChannel> {
+  return new Promise((resolve, reject) => {
+    const sock = connect(sockPath);
+    sock.once('connect', () => resolve(new RpcChannel(sock)));
+    sock.once('error', reject);
+  });
+}
 
 /**
  * Real spawns and real sockets throughout, timing figures scaled down via
@@ -62,6 +75,7 @@ describe('DEFAULT_SUPERVISOR_OPTIONS', () => {
       shutdownRpcDeadlineMs: 3_000,
       sigtermGraceMs: 2_000,
       logCapBytesPerMinute: 65_536,
+      hostCallTimeoutMs: 8_000,
     });
   });
 });
@@ -214,6 +228,72 @@ describe('shutdown', () => {
     expect(sup.getLastExitSignal()).toBe('SIGKILL');
     expect(existsSync(coreSockPath)).toBe(false);
     expect(existsSync(pluginSockPath)).toBe(false);
+  }, 10_000);
+});
+
+describe('host call dispatch', () => {
+  it('dispatches a known method to the bound hostApi and refuses an unknown one', async () => {
+    const hostApi = {
+      'config.get': jest.fn().mockResolvedValue({ token: 'abc' }),
+    } as unknown as PluginHostApi;
+    const sup = makeSupervisor('good', { hostApi });
+    await sup.start();
+    await waitForState(sup, 'ready');
+
+    const client = await connectAsPlugin(sup.getSocketPaths().coreSockPath);
+    const res = await client.call('config.get', { keys: ['token'] }, 2_000);
+    expect(res).toEqual({ token: 'abc' });
+    expect(hostApi['config.get']).toHaveBeenCalledWith({ keys: ['token'] });
+
+    await expect(client.call('no.such.method', {}, 2_000)).rejects.toThrow(/unknown host method/);
+    client.destroy();
+  }, 10_000);
+
+  it("never serves a request under another supervisor's hostApi, even when the payload names it", async () => {
+    const alphaApi = { 'config.get': jest.fn().mockResolvedValue({ who: 'alpha' }) } as unknown as PluginHostApi;
+    const betaApi = { 'config.get': jest.fn().mockResolvedValue({ who: 'beta' }) } as unknown as PluginHostApi;
+    const alpha = makeSupervisor('good', { hostApi: alphaApi });
+    const beta = makeSupervisor('good', { hostApi: betaApi });
+    await Promise.all([alpha.start(), beta.start()]);
+    await Promise.all([waitForState(alpha, 'ready'), waitForState(beta, 'ready')]);
+
+    const client = await connectAsPlugin(alpha.getSocketPaths().coreSockPath);
+    // A field no real payload has — the closest thing to "naming another plugin" a
+    // frame can carry, since none of the 15 methods take an id parameter at all.
+    const res = await client.call('config.get', { pluginId: 'the-other-one' }, 2_000);
+
+    expect(res).toEqual({ who: 'alpha' });
+    expect(alphaApi['config.get']).toHaveBeenCalledWith({ pluginId: 'the-other-one' });
+    expect(betaApi['config.get']).not.toHaveBeenCalled();
+    client.destroy();
+  }, 10_000);
+
+  it('answers a throwing host method with an error frame and keeps the supervisor ready', async () => {
+    const hostApi = {
+      'config.get': jest.fn().mockRejectedValue(new Error('boom')),
+    } as unknown as PluginHostApi;
+    const sup = makeSupervisor('good', { hostApi });
+    await sup.start();
+    await waitForState(sup, 'ready');
+
+    const client = await connectAsPlugin(sup.getSocketPaths().coreSockPath);
+    await expect(client.call('config.get', {}, 2_000)).rejects.toThrow(/boom/);
+    expect(sup.getState()).toBe('ready');
+    client.destroy();
+  }, 10_000);
+
+  it('times out a hanging host method rather than leaving the caller waiting forever', async () => {
+    const hostApi = {
+      'config.get': jest.fn(() => new Promise(() => {})),
+    } as unknown as PluginHostApi;
+    const sup = makeSupervisor('good', { hostApi, hostCallTimeoutMs: 50 });
+    await sup.start();
+    await waitForState(sup, 'ready');
+
+    const client = await connectAsPlugin(sup.getSocketPaths().coreSockPath);
+    await expect(client.call('config.get', {}, 2_000)).rejects.toThrow(/timed out/);
+    expect(sup.getState()).toBe('ready');
+    client.destroy();
   }, 10_000);
 });
 

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
@@ -7,7 +7,7 @@ import { getPluginsSocketDir } from '../../../common/constants/paths';
 import type { OnApplicationShutdown } from '@nestjs/common';
 import { LogBufferService } from '../../scheduler/log-buffer.service';
 import { CURRENT_FLIKS_VERSION } from '../plugin-version';
-import { PLUGIN_API_VERSION, type Note } from '../../../common/plugin-contract';
+import { PLUGIN_API_VERSION, type Note, type PluginHostApi } from '../../../common/plugin-contract';
 import { RpcChannel } from './rpc-channel';
 import { NoteRingBuffer } from './note-ring-buffer';
 import {
@@ -44,6 +44,7 @@ export const DEFAULT_SUPERVISOR_OPTIONS = {
   shutdownRpcDeadlineMs: 3_000,
   sigtermGraceMs: 2_000,
   logCapBytesPerMinute: 64 * 1024,
+  hostCallTimeoutMs: 8_000,
 };
 
 export interface PluginSupervisorOptions {
@@ -67,6 +68,29 @@ export interface PluginSupervisorOptions {
   shutdownRpcDeadlineMs?: number;
   sigtermGraceMs?: number;
   logCapBytesPerMinute?: number;
+  /** Ceiling on one inbound host call's own runtime, separate from the caller's 10s socket timeout. */
+  hostCallTimeoutMs?: number;
+  /** Bound to `id` above at construction via `PluginHostBindingService.bind` —
+   *  dispatch never re-derives identity from an inbound frame. `null` leaves core calls unanswered. */
+  hostApi?: PluginHostApi | null;
+}
+
+/** Rejects once `ms` elapses, whichever of `promise` or the timer settles first;
+ *  always clears the timer so a fast call never leaves one dangling. */
+function withDeadline<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`host method "${label}" timed out after ${ms}ms`)), ms);
+    promise.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (err: unknown) => {
+        clearTimeout(timer);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      },
+    );
+  });
 }
 
 /** 0600 keeps a second plugin out; the chown is what lets the dropped child in at all. */
@@ -83,7 +107,7 @@ function listenAndRestrict(server: Server, path: string, dropTo: { uid: number; 
 
 /**
  * Owns one `process`-tier plugin's lifecycle end to end. Core listens on both
- * sockets; the plugin dials out — `coreSock` for its 17 calls (unhandled here), `pluginSock` for the 7 core-initiated ones.
+ * sockets; the plugin dials out — `coreSock` for its 15 host calls, `pluginSock` for the core-initiated ones.
  */
 export class PluginSupervisor implements OnApplicationShutdown {
   private readonly opts: Required<PluginSupervisorOptions>;
@@ -132,6 +156,7 @@ export class PluginSupervisor implements OnApplicationShutdown {
       dbUrl: '',
       config: {},
       runtimeDir: getPluginsSocketDir(),
+      hostApi: null,
       ...options,
     };
     this.coreSockPath = join(this.opts.runtimeDir, `${this.opts.id}.core.sock`);
@@ -306,10 +331,23 @@ export class PluginSupervisor implements OnApplicationShutdown {
   }
 
   private onCoreConnected(socket: Socket): void {
-    // Plugin's uplink for the 17 core-side methods. No handler registered here —
-    // that dispatch is 3.5's proxy. Still framed and violation-checked like any connection.
+    // Plugin's uplink for the 15 host methods.
     const channel = new RpcChannel(socket);
     channel.onViolation((err) => this.onViolation(err));
+    channel.onRequest((method, payload) => this.dispatchHostCall(method, payload));
+  }
+
+  /** `hostApi` is fixed at construction to `this.opts.id` — nothing in `payload` can
+   *  select another plugin's identity. An unknown method or a call past
+   *  `hostCallTimeoutMs` both reject, so `RpcChannel` answers with an error frame
+   *  instead of leaving the plugin's own 10s client to time out. */
+  private dispatchHostCall(method: string, payload: unknown): Promise<unknown> {
+    const api = this.opts.hostApi as Record<string, (p: unknown) => Promise<unknown>> | null;
+    const fn = api?.[method];
+    if (!fn) return Promise.reject(new Error(`unknown host method "${method}"`));
+    // Promise.resolve().then(...) folds a synchronous throw from `fn` into the same
+    // rejection path as an async one, so both answer with an error frame, never crash.
+    return withDeadline(Promise.resolve().then(() => fn(payload)), this.opts.hostCallTimeoutMs, method);
   }
 
   private onPluginConnected(socket: Socket): void {

--- a/client/src/app/shared/components/schema-form/schema-form.html
+++ b/client/src/app/shared/components/schema-form/schema-form.html
@@ -6,8 +6,8 @@
           <app-input-field
             [type]="inputType(field)"
             [label]="field.labelKey | translate"
-            [hint]="field.hint ?? ''"
-            [placeholder]="field.placeholder ?? ''"
+            [hint]="field.hint ? (field.hint | translate) : ''"
+            [placeholder]="field.placeholder ? (field.placeholder | translate) : ''"
             [disabled]="disabled()"
             [value]="fieldValue(field)"
             (valueChange)="setValue(field, $event)"
@@ -20,7 +20,7 @@
       @case ('toggle') {
         <app-toggle-field
           [label]="field.labelKey | translate"
-          [hint]="field.hint ?? ''"
+          [hint]="field.hint ? (field.hint | translate) : ''"
           [disabled]="disabled()"
           [value]="fieldBool(field)"
           (valueChange)="setBool(field, $event)"
@@ -30,7 +30,7 @@
         <div class="flex flex-col gap-1">
           <app-select-field
             [label]="field.labelKey | translate"
-            [hint]="field.hint ?? ''"
+            [hint]="field.hint ? (field.hint | translate) : ''"
             [disabled]="disabled()"
             [value]="fieldValue(field)"
             (valueChange)="setValue(field, $event)"


### PR DESCRIPTION
The download plugin installs, spawns, migrates its own schema and answers every one of its HTTP routes through the proxy. **One thing did not work, and it was the one that mattered:**

```
GET /api/plugins/fliks.download/190/releases
→ 500 "media.acquisitionContext" timed out after 10000ms
```

A host call never got an answer — and with it, everything a plugin needs core for: scoring, candidates, ingest, events.

## Why it was left undone

The supervisor accepted the child's connection and **registered no handler for inbound requests**, so the frames were never answered. The binding primitive to answer them already existed and was tested; the transport was missing because connecting the two closes a module cycle through media — the same shape that has broken this application's boot **twice**, both times while `tsc` passed and every unit test stayed green.

Marking the host module `@Global()` is what avoids it, the same thing `EventsModule` already does. The supervisor injects the binding as an optional dependency with **no import edge pointing back**, so the graph stays acyclic — and a real DI boot says so, not a type-check.

## The three properties that matter

- **A throwing host method** answers with an error frame and leaves the supervisor `ready`.
- **A hanging one** is cut off short of the plugin's own 10s client deadline, because core answering with an error beats never answering.
- **A frame naming another plugin's id** is still served under the identity the supervisor was constructed with. Proven with two supervisors on two real sockets: the impersonating request resolves through the caller's own host and the other one's is never touched.

## Verification

- `tsc` exit 0; **123 suites / 1312 tests** (+5, none dropped).
- Real DI boot: `DI GRAPH OK`.
- **The live route returns `200 {"releases":[]}`** against the plugin actually installed and running on the dev stack — verified independently after restarting the backend.

## Note

The empty release list is not yet proof the indexer was queried: the test indexer's capabilities were never probed (`capsMovieSearch: false`), so the ready-indexer filter most likely excluded it before any network call. The host path is proven by the route answering at all — it timed out before. Whether a search reaches Jackett is the next thing to check, and it is a plugin-side question rather than a transport one.