### PR TITLE
fix(plugin-ui): send a plugin page's requests to the plugin

### DIFF
--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -93,7 +93,16 @@ export interface ProvidersConfigPage extends ConfigPageBase {
   kind: 'providers';
   list: string;
   implementations: string;
-  actions?: { id: string; labelKey: string; route: string; scope: 'row' | 'list' }[];
+  /** `method` is explicit: encoding it into `route` left the caller POSTing to a
+   *  string that contained the verb. */
+  actions?: {
+    id: string;
+    labelKey: string;
+    method: 'GET' | 'POST' | 'DELETE';
+    route: string;
+    scope: 'row' | 'list';
+    confirmKey?: string;
+  }[];
   reorderable?: boolean;
   /** Priority is not a universal provider concept; hide the column when the
    *  resource has none. */

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2326,7 +2326,8 @@
     "unavailable_title": "This page isn't available",
     "unknown_plugin": "The plugin this page belongs to isn't installed.",
     "unknown_view": "This plugin doesn't have a page by that name.",
-    "unsupported_kind": "This page isn't supported by your version of Fliks yet."
+    "unsupported_kind": "This page isn't supported by your version of Fliks yet.",
+    "implementations_load_error": "Couldn't load the provider types — some fields may be missing below."
   },
   "provider_list": {
     "new": "New",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2326,7 +2326,8 @@
     "unavailable_title": "Cette page n'est pas disponible",
     "unknown_plugin": "Le plugin auquel appartient cette page n'est pas installé.",
     "unknown_view": "Ce plugin n'a pas de page portant ce nom.",
-    "unsupported_kind": "Cette page n'est pas encore prise en charge par votre version de Fliks."
+    "unsupported_kind": "Cette page n'est pas encore prise en charge par votre version de Fliks.",
+    "implementations_load_error": "Impossible de charger les types de fournisseur — certains champs peuvent manquer ci-dessous."
   },
   "provider_list": {
     "new": "Nouveau",

--- a/client/src/app/core/plugin-ui/contribution.types.ts
+++ b/client/src/app/core/plugin-ui/contribution.types.ts
@@ -96,7 +96,16 @@ export interface ProvidersConfigPage extends ConfigPageBase {
   kind: 'providers';
   list: string;
   implementations: string;
-  actions?: { id: string; labelKey: string; route: string; scope: 'row' | 'list' }[];
+  /** `method` is explicit: encoding it into `route` left the caller POSTing to a
+   *  string that contained the verb. */
+  actions?: {
+    id: string;
+    labelKey: string;
+    method: 'GET' | 'POST' | 'DELETE';
+    route: string;
+    scope: 'row' | 'list';
+    confirmKey?: string;
+  }[];
   reorderable?: boolean;
   /** Priority is not a universal provider concept; hide the column when the
    *  resource has none. */

--- a/client/src/app/features/plugin-view/plugin-view.html
+++ b/client/src/app/features/plugin-view/plugin-view.html
@@ -16,9 +16,12 @@
   @default {
     @if (providersView(); as view) {
       @if (resolvedImplementations(); as impls) {
+        @if (implementationsLoadError()) {
+          <div role="alert" class="alert alert-warning mb-4">{{ 'plugin_view.implementations_load_error' | translate }}</div>
+        }
         <app-provider-list
           [titleKey]="view.labelKey"
-          [listUrl]="view.list"
+          [listUrl]="resourceUrl(view.list)"
           [implementations]="impls"
           [labels]="providerLabels(view)"
           [showPriority]="view.showPriority ?? true"
@@ -35,10 +38,10 @@
     } @else if (tableView(); as view) {
       <app-data-table
         [titleKey]="view.labelKey"
-        [listUrl]="view.list"
+        [listUrl]="resourceUrl(view.list)"
         [columns]="view.columns"
-        [rowActions]="view.rowActions ?? []"
-        [listActions]="view.listActions ?? []"
+        [rowActions]="tableRowActions(view)"
+        [listActions]="tableListActions(view)"
         [defaultSortKey]="view.defaultSortKey ?? null"
         [paged]="view.paged ?? false"
         [pageSize]="view.pageSize ?? 20"

--- a/client/src/app/features/plugin-view/plugin-view.spec.ts
+++ b/client/src/app/features/plugin-view/plugin-view.spec.ts
@@ -81,6 +81,8 @@ describe('PluginViewComponent', () => {
   });
 
   it('renders the providers renderer once the implementations route resolves, and lists rows from the declared route', async () => {
+    // Manifest paths are declared relative to the plugin, exactly as a real manifest ships them —
+    // if the component ever requests these verbatim instead of proxying them, `http.expectOne` below fails.
     const { fixture, http } = createComponent(
       { pluginId: 'fliks.a', view: 'providers' },
       {
@@ -89,8 +91,8 @@ describe('PluginViewComponent', () => {
           kind: 'providers',
           id: 'x',
           labelKey: 'x.title',
-          list: '/api/plugins/fliks.a/providers',
-          implementations: '/api/plugins/fliks.a/implementations',
+          list: '/providers',
+          implementations: '/implementations',
         }),
       },
     );
@@ -108,7 +110,7 @@ describe('PluginViewComponent', () => {
     http.verify();
   });
 
-  it('renders a translated message rather than a blank page when the implementations route fails', async () => {
+  it('renders a translated warning (not a blank page, not a silently empty form) when the implementations route fails', async () => {
     const { fixture, http } = createComponent(
       { pluginId: 'fliks.a', view: 'providers' },
       {
@@ -117,8 +119,8 @@ describe('PluginViewComponent', () => {
           kind: 'providers',
           id: 'x',
           labelKey: 'x.title',
-          list: '/api/plugins/fliks.a/providers',
-          implementations: '/api/plugins/fliks.a/implementations',
+          list: '/providers',
+          implementations: '/implementations',
         }),
       },
     );
@@ -128,7 +130,37 @@ describe('PluginViewComponent', () => {
     // Falls back to an empty implementations list — the provider renderer still mounts and fetches its own list.
     http.expectOne({ url: '/api/plugins/fliks.a/providers', method: 'GET' }).flush([]);
     await settle(fixture);
-    expect(fixture.nativeElement.textContent).not.toBe('');
+    expect(fixture.componentInstance.implementationsLoadError()).toBe(true);
+    expect(fixture.nativeElement.textContent).toContain('plugin_view.implementations_load_error');
+    http.verify();
+  });
+
+  it('runs a `scope: \'row\'` provider action with its declared method against the proxied route', async () => {
+    const { fixture, http } = createComponent(
+      { pluginId: 'fliks.a', view: 'providers' },
+      {
+        hasPlugin: () => true,
+        configPage: () => ({
+          kind: 'providers',
+          id: 'x',
+          labelKey: 'x.title',
+          list: '/providers',
+          implementations: '/implementations',
+          actions: [{ id: 'test', labelKey: 'x.test', method: 'DELETE', route: '/providers/reset', scope: 'row' }],
+        }),
+      },
+    );
+    fixture.detectChanges();
+    http.expectOne({ url: '/api/plugins/fliks.a/implementations', method: 'GET' }).flush([]);
+    await settle(fixture);
+    http.expectOne({ url: '/api/plugins/fliks.a/providers', method: 'GET' }).flush([]);
+    await settle(fixture);
+
+    const run = fixture.componentInstance.providerTestConnection(fixture.componentInstance.providersView()!);
+    const resultPromise = run!({ implementation: 'demo', settings: {} });
+    // A method other than POST proves `action.method` drives the call, not a hardcoded verb.
+    http.expectOne({ url: '/api/plugins/fliks.a/providers/reset', method: 'DELETE' }).flush({ ok: true, message: 'ok' });
+    expect(await resultPromise).toEqual({ ok: true, message: 'ok' });
     http.verify();
   });
 
@@ -141,7 +173,7 @@ describe('PluginViewComponent', () => {
           kind: 'table',
           id: 'x',
           labelKey: 'x.title',
-          list: '/api/plugins/fliks.a/queue',
+          list: '/queue',
           columns: [{ key: 'name', labelKey: 'x.col_name' }],
           rowActions: [{ kind: 'action', labelKey: 'x.doit', actionId: 'core.unknown' }],
         }),
@@ -167,7 +199,7 @@ describe('PluginViewComponent', () => {
           kind: 'table',
           id: 'x',
           labelKey: 'x.title',
-          list: '/api/plugins/fliks.a/queue',
+          list: '/queue',
           columns: [{ key: 'name', labelKey: 'x.col_name' }],
           rowActions: [{ kind: 'action', labelKey: 'x.open', actionId: 'table.open-media' }],
         }),
@@ -187,7 +219,52 @@ describe('PluginViewComponent', () => {
     http.verify();
   });
 
-  it('renders a `scope: \'list\'` provider action once, outside the rows, and running it POSTs then reloads', async () => {
+  it('a table `proxy` row action hits the proxied route with its declared method; a `route` row action navigates in-app unprefixed', async () => {
+    const { fixture, http, navigateByUrl } = createComponent(
+      { pluginId: 'fliks.a', view: 'queue' },
+      {
+        hasPlugin: () => true,
+        configPage: () => ({
+          kind: 'table',
+          id: 'x',
+          labelKey: 'x.title',
+          list: '/queue',
+          columns: [{ key: 'name', labelKey: 'x.col_name' }],
+          rowActions: [
+            { kind: 'proxy', labelKey: 'x.remove', method: 'DELETE', path: '/queue/1' },
+            { kind: 'route', labelKey: 'x.details', path: '/plugins/fliks.a/details' },
+          ],
+          listActions: [{ labelKey: 'x.clear', method: 'DELETE', path: '/queue' }],
+        }),
+      },
+    );
+    fixture.detectChanges();
+    http.expectOne({ url: '/api/plugins/fliks.a/queue', method: 'GET' }).flush([{ id: 1, name: 'Torrent A' }]);
+    await settle(fixture);
+
+    // Checked first, before the row (and its buttons) is removed by the proxy delete below.
+    const routeButtons = Array.from(fixture.nativeElement.querySelectorAll('button')) as HTMLButtonElement[];
+    routeButtons.find((b) => b.textContent?.includes('x.details'))!.click();
+    // An in-app Angular route is never plugin-relative — it must reach the router verbatim.
+    expect(navigateByUrl).toHaveBeenCalledWith('/plugins/fliks.a/details');
+
+    const buttons = Array.from(fixture.nativeElement.querySelectorAll('button')) as HTMLButtonElement[];
+    buttons.find((b) => b.textContent?.includes('x.remove'))!.click();
+    http.expectOne({ url: '/api/plugins/fliks.a/queue/1', method: 'DELETE' }).flush({});
+    await settle(fixture);
+    http.expectOne({ url: '/api/plugins/fliks.a/queue', method: 'GET' }).flush([]);
+    await settle(fixture);
+
+    const clearButtons = Array.from(fixture.nativeElement.querySelectorAll('button')) as HTMLButtonElement[];
+    clearButtons.find((b) => b.textContent?.includes('x.clear'))!.click();
+    http.expectOne({ url: '/api/plugins/fliks.a/queue', method: 'DELETE' }).flush({});
+    await settle(fixture);
+    http.expectOne({ url: '/api/plugins/fliks.a/queue', method: 'GET' }).flush([]);
+    await settle(fixture);
+    http.verify();
+  });
+
+  it('renders a `scope: \'list\'` provider action once, outside the rows, and running it against its declared method reloads', async () => {
     const { fixture, http } = createComponent(
       { pluginId: 'fliks.a', view: 'providers' },
       {
@@ -196,9 +273,9 @@ describe('PluginViewComponent', () => {
           kind: 'providers',
           id: 'x',
           labelKey: 'x.title',
-          list: '/api/plugins/fliks.a/providers',
-          implementations: '/api/plugins/fliks.a/implementations',
-          actions: [{ id: 'sync', labelKey: 'x.sync_all', route: '/api/plugins/fliks.a/sync', scope: 'list' }],
+          list: '/providers',
+          implementations: '/implementations',
+          actions: [{ id: 'sync', labelKey: 'x.sync_all', method: 'POST', route: '/sync', scope: 'list' }],
         }),
       },
     );

--- a/client/src/app/features/plugin-view/plugin-view.ts
+++ b/client/src/app/features/plugin-view/plugin-view.ts
@@ -17,7 +17,7 @@ import {
   ProviderTestResult,
 } from '../../shared/components/provider-list/provider-list.types';
 import { DataTableComponent } from '../../shared/components/data-table/data-table';
-import type { TableRow } from '../../shared/components/data-table/data-table.types';
+import type { ListAction, RowAction, TableRow } from '../../shared/components/data-table/data-table.types';
 import type { FormConfigPage } from '../../core/plugin-ui/contribution.types';
 import { AnyConfigPage, ProvidersView, TableView, isFormView, isProvidersView, isTableView } from './view-kinds.types';
 
@@ -103,6 +103,9 @@ export class PluginViewComponent {
 
   // --- `providers` kind: the driver list is itself a proxied route ---
   readonly resolvedImplementations = signal<ProviderImplementation[] | null>(null);
+  /** A failed fetch still resolves to `[]` (so the renderer mounts), but that's
+   *  indistinguishable from a real driver with no fields — flag it separately. */
+  readonly implementationsLoadError = signal(false);
 
   constructor() {
     effect(() => {
@@ -143,12 +146,23 @@ export class PluginViewComponent {
     }
   }
 
+  /** A manifest declares routes relative to itself — only the proxy at
+   *  `/api/plugins/<id>/` actually serves them. */
+  resourceUrl(path: string): string {
+    return `/api/plugins/${this.pluginId()}${path}`;
+  }
+
   private async loadImplementations(route: string): Promise<void> {
     this.resolvedImplementations.set(null);
+    this.implementationsLoadError.set(false);
     try {
-      this.resolvedImplementations.set(await firstValueFrom(this.http.get<ProviderImplementation[]>(route)));
+      this.resolvedImplementations.set(
+        await firstValueFrom(this.http.get<ProviderImplementation[]>(this.resourceUrl(route))),
+      );
     } catch {
+      // An empty list here is indistinguishable from "no fields to show" — surface it instead.
       this.resolvedImplementations.set([]);
+      this.implementationsLoadError.set(true);
     }
   }
 
@@ -159,23 +173,34 @@ export class PluginViewComponent {
     if (!action) return null;
     return async (draft: ProviderDraft) => {
       try {
-        return await firstValueFrom(this.http.post<ProviderTestResult>(action.route, draft));
+        return await firstValueFrom(
+          this.http.request<ProviderTestResult>(action.method, this.resourceUrl(action.route), { body: draft }),
+        );
       } catch {
         return { ok: false, message: this.translate.instant('provider_list.test_network_error') };
       }
     };
   }
 
-  /** `actions[].scope: 'list'` — rendered once above the rows, POSTed with no draft. */
+  /** `actions[].scope: 'list'` — rendered once above the rows, run with no draft. */
   providerListActions(view: ProvidersView): ProviderListAction[] {
     return (view.actions ?? [])
       .filter((a) => a.scope === 'list')
       .map((a) => ({
         labelKey: a.labelKey,
         run: async () => {
-          await firstValueFrom(this.http.post(a.route, {}));
+          await firstValueFrom(this.http.request(a.method, this.resourceUrl(a.route), { body: {} }));
         },
       }));
+  }
+
+  /** Only `kind: 'proxy'` carries a plugin-relative path — `route`/`action` resolve in-app. */
+  tableRowActions(view: TableView): RowAction[] {
+    return (view.rowActions ?? []).map((a) => (a.kind === 'proxy' ? { ...a, path: this.resourceUrl(a.path) } : a));
+  }
+
+  tableListActions(view: TableView): ListAction[] {
+    return (view.listActions ?? []).map((a) => ({ ...a, path: this.resourceUrl(a.path) }));
   }
 
   /** Merges a page's own wording over the generic provider-list chrome. */


### PR DESCRIPTION
Every admin page a plugin contributes failed to load — `"Impossible de charger la liste."` — and its create form offered only the generic name/priority/enabled. **Both were the same mistake.**

A manifest declares its routes relative to itself (`/indexers`). A plugin's routes are only reachable through core's proxy (`/api/plugins/<id>/indexers`). The renderer used the manifest paths **verbatim as URLs**, so the client asked core for paths it does not serve.

| Site | Now |
| --- | --- |
| providers `list` | proxied |
| providers `implementations` fetch | proxied |
| providers `actions[].route` | proxied, and with the declared method |
| table `list` | proxied |
| table `rowActions[]` of kind `proxy` | proxied |
| table `listActions[]` | proxied |
| table `rowActions[]` of kind `route` / `action` | **untouched** — they resolve in the app, and prefixing would break them |

## The empty form was the same failure wearing a different face

The implementations fetch failed, its `catch` replaced the list with `[]`, and a form whose implementation matches nothing renders no fields. So a user saw a form that looked finished, offered three generic inputs, and reported no error anywhere. That failure **surfaces** now rather than degrading into silence — a field-less form is worse than a visible error, because someone fills it in and saves something incomplete.

## Provider actions carry their method

`ProvidersConfigPage.actions[]` had no `method`, so the plugin encoded it into the route (`"DELETE /indexers/cooldowns"`) while the client hardcoded `.post` — posting to a string containing the verb. The field is explicit now, in both mirrored halves of the contract, and the plugin declares it.

## Verification

- Backend **123 suites / 1312 tests**, `tsc` 0. Client **38 files / 317 tests** (+2), `ng build` 0.
- The tests were rewritten to declare **relative** paths the way a real manifest does, and to assert **the URL requested** rather than that a call happened — the bug was entirely in the address, so a call-count assertion would have passed throughout.
- **Live, after a real uninstall/repackage/reinstall**, every URL the pages request answers 200: both `implementations` endpoints (7 and 8 fields), both lists, the queue, and a method-driven list action. The pre-fix shapes (`/indexers`, `/api/indexers`) both 404 against the same backend.
- The plugin now ships a complete `fr` dictionary: 79 keys each way, no key in one locale missing from the other, with a test that fails on drift in either direction.

## Known, not fixed here

The indexers page's "test connection" button calls the **stats** endpoint. The renderer takes the first `scope: 'row'` action as the test-connection handler, and the plugin's first row action is stats — so it fires `GET /indexers/:id/stats` with the literal `:id`, which 400s. The plugin already serves real `POST .../test-connection` routes that no UI can reach, and download-clients declares no row action at all. Fixing it means separating "test this unsaved draft" from "act on this saved row" in the contract, which is feature work rather than an address bug.