### PR TITLE
fix(plugin-ui): stop treating a row action as a connection test

### DIFF
--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -93,8 +93,12 @@ export interface ProvidersConfigPage extends ConfigPageBase {
   kind: 'providers';
   list: string;
   implementations: string;
+  /** Tests the unsaved draft — POSTs `{implementation, settings}` before any row is
+   *  saved. Distinct from `actions[]`: there is no row yet, so no `:id` to substitute. */
+  testConnection?: { route: string };
   /** `method` is explicit: encoding it into `route` left the caller POSTing to a
-   *  string that contained the verb. */
+   *  string that contained the verb. Every `scope: 'row'` entry renders its own button —
+   *  its route's `:id` is substituted with the row's id before the request ever fires. */
   actions?: {
     id: string;
     labelKey: string;

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2320,6 +2320,7 @@
     "unknown_implementation": "Unbekannter Anbietertyp — seine Einstellungen können hier nicht bearbeitet werden.",
     "test_connection": "Verbindung testen",
     "test_network_error": "Der Server konnte für den Test nicht erreicht werden.",
+    "test_unknown_result": "Der Test ist abgeschlossen, aber das Ergebnis konnte nicht übersetzt werden.",
     "move_up": "Nach oben",
     "move_down": "Nach unten"
   },

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2348,6 +2348,7 @@
     "unknown_implementation": "Unknown provider type — its settings can't be edited here.",
     "test_connection": "Test connection",
     "test_network_error": "Unable to reach the server for the test.",
+    "test_unknown_result": "Test finished, but the result could not be translated.",
     "move_up": "Move up",
     "move_down": "Move down"
   },

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2320,6 +2320,7 @@
     "unknown_implementation": "Tipo de proveedor desconocido: no se puede editar su configuración aquí.",
     "test_connection": "Probar conexión",
     "test_network_error": "No se pudo contactar con el servidor para la prueba.",
+    "test_unknown_result": "La prueba terminó, pero no se pudo traducir el resultado.",
     "move_up": "Subir",
     "move_down": "Bajar"
   },

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2348,6 +2348,7 @@
     "unknown_implementation": "Type de fournisseur inconnu — impossible d'en modifier les paramètres ici.",
     "test_connection": "Tester la connexion",
     "test_network_error": "Impossible de contacter le serveur pour le test.",
+    "test_unknown_result": "Le test est terminé, mais le résultat n'a pas pu être traduit.",
     "move_up": "Monter",
     "move_down": "Descendre"
   },

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2320,6 +2320,7 @@
     "unknown_implementation": "Tipo di provider sconosciuto: le sue impostazioni non possono essere modificate qui.",
     "test_connection": "Verifica connessione",
     "test_network_error": "Impossibile contattare il server per il test.",
+    "test_unknown_result": "Il test è terminato, ma non è stato possibile tradurre il risultato.",
     "move_up": "Sposta su",
     "move_down": "Sposta giù"
   },

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2320,6 +2320,7 @@
     "unknown_implementation": "Tipo de provedor desconhecido — não é possível editar as configurações aqui.",
     "test_connection": "Testar conexão",
     "test_network_error": "Não foi possível contatar o servidor para o teste.",
+    "test_unknown_result": "O teste terminou, mas o resultado não pôde ser traduzido.",
     "move_up": "Subir",
     "move_down": "Descer"
   },

--- a/client/src/app/core/plugin-ui/contribution.types.ts
+++ b/client/src/app/core/plugin-ui/contribution.types.ts
@@ -96,8 +96,12 @@ export interface ProvidersConfigPage extends ConfigPageBase {
   kind: 'providers';
   list: string;
   implementations: string;
+  /** Tests the unsaved draft — POSTs `{implementation, settings}` before any row is
+   *  saved. Distinct from `actions[]`: there is no row yet, so no `:id` to substitute. */
+  testConnection?: { route: string };
   /** `method` is explicit: encoding it into `route` left the caller POSTing to a
-   *  string that contained the verb. */
+   *  string that contained the verb. Every `scope: 'row'` entry renders its own button —
+   *  its route's `:id` is substituted with the row's id before the request ever fires. */
   actions?: {
     id: string;
     labelKey: string;

--- a/client/src/app/features/plugin-view/plugin-view.html
+++ b/client/src/app/features/plugin-view/plugin-view.html
@@ -28,6 +28,7 @@
           [defaultPriority]="view.defaultPriority ?? 0"
           [reorderable]="view.reorderable ?? false"
           [listActions]="providerListActions(view)"
+          [rowActions]="providerRowActions(view)"
           [testConnection]="providerTestConnection(view)"
         />
       } @else {

--- a/client/src/app/features/plugin-view/plugin-view.spec.ts
+++ b/client/src/app/features/plugin-view/plugin-view.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
+import { TranslateLoader, TranslateService, provideTranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
 import { vi } from 'vitest';
 import { PluginViewComponent } from './plugin-view';
@@ -28,7 +28,9 @@ function createComponent(
       provideHttpClientTesting(),
       provideTranslateService({
         lang: 'en',
-        loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+        // 'ok' stands in for a plugin's own merged messageKey — `PluginI18nService` puts a
+        // plugin's dict in this same store, so a real key resolves exactly like this fake one.
+        loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({ ok: 'All good' }) } },
       }),
       { provide: ActivatedRoute, useValue: { paramMap: of(convertToParamMap(params)) } },
       { provide: Router, useValue: { navigateByUrl } },
@@ -135,7 +137,7 @@ describe('PluginViewComponent', () => {
     http.verify();
   });
 
-  it('runs a `scope: \'row\'` provider action with its declared method against the proxied route', async () => {
+  it('tests the unsaved draft against `testConnection.route`, never an `actions[]` entry', async () => {
     const { fixture, http } = createComponent(
       { pluginId: 'fliks.a', view: 'providers' },
       {
@@ -146,7 +148,10 @@ describe('PluginViewComponent', () => {
           labelKey: 'x.title',
           list: '/providers',
           implementations: '/implementations',
-          actions: [{ id: 'test', labelKey: 'x.test', method: 'DELETE', route: '/providers/reset', scope: 'row' }],
+          testConnection: { route: '/test-connection' },
+          // A row action happens to share the id 'test' here — proves the test handler
+          // never falls back to reading actions[], the shape of the original bug.
+          actions: [{ id: 'test', labelKey: 'x.stats', method: 'GET', route: '/providers/:id/stats', scope: 'row' }],
         }),
       },
     );
@@ -158,9 +163,92 @@ describe('PluginViewComponent', () => {
 
     const run = fixture.componentInstance.providerTestConnection(fixture.componentInstance.providersView()!);
     const resultPromise = run!({ implementation: 'demo', settings: {} });
-    // A method other than POST proves `action.method` drives the call, not a hardcoded verb.
-    http.expectOne({ url: '/api/plugins/fliks.a/providers/reset', method: 'DELETE' }).flush({ ok: true, message: 'ok' });
-    expect(await resultPromise).toEqual({ ok: true, message: 'ok' });
+    const req = http.expectOne({ url: '/api/plugins/fliks.a/test-connection', method: 'POST' });
+    expect(req.request.body).toEqual({ implementation: 'demo', settings: {} });
+    req.flush({ ok: true, messageKey: 'ok' });
+    expect(await resultPromise).toEqual({ ok: true, message: 'All good' });
+    http.verify();
+  });
+
+  it('is absent (null) when a providers page declares no `testConnection`', () => {
+    const { fixture } = createComponent(
+      { pluginId: 'fliks.a', view: 'providers' },
+      {
+        hasPlugin: () => true,
+        configPage: () => ({
+          kind: 'providers',
+          id: 'x',
+          labelKey: 'x.title',
+          list: '/providers',
+          implementations: '/implementations',
+        }),
+      },
+    );
+    fixture.detectChanges();
+    expect(fixture.componentInstance.providerTestConnection(fixture.componentInstance.providersView()!)).toBeNull();
+  });
+
+  it('falls back to a generic message, never the raw key, when `messageKey` resolves to nothing', async () => {
+    const { fixture, http } = createComponent(
+      { pluginId: 'fliks.a', view: 'providers' },
+      {
+        hasPlugin: () => true,
+        configPage: () => ({
+          kind: 'providers',
+          id: 'x',
+          labelKey: 'x.title',
+          list: '/providers',
+          implementations: '/implementations',
+          testConnection: { route: '/test-connection' },
+        }),
+      },
+    );
+    fixture.detectChanges();
+    http.expectOne({ url: '/api/plugins/fliks.a/implementations', method: 'GET' }).flush([]);
+    await settle(fixture);
+    http.expectOne({ url: '/api/plugins/fliks.a/providers', method: 'GET' }).flush([]);
+    await settle(fixture);
+
+    const run = fixture.componentInstance.providerTestConnection(fixture.componentInstance.providersView()!);
+    const resultPromise = run!({ implementation: 'demo', settings: {} });
+    http
+      .expectOne({ url: '/api/plugins/fliks.a/test-connection', method: 'POST' })
+      .flush({ ok: false, messageKey: 'download.indexers.test.a_key_this_plugin_never_shipped', detail: 'boom' });
+    const result = await resultPromise;
+    expect(result.ok).toBe(false);
+    expect(result.message).not.toContain('download.indexers.test.a_key_this_plugin_never_shipped');
+    expect(result.message).toContain('boom');
+    http.verify();
+  });
+
+  it('renders one button per `scope: \'row\'` entry — plural, unlike `actions[].find` first-wins', async () => {
+    const { fixture, http } = createComponent(
+      { pluginId: 'fliks.a', view: 'providers' },
+      {
+        hasPlugin: () => true,
+        configPage: () => ({
+          kind: 'providers',
+          id: 'x',
+          labelKey: 'x.title',
+          list: '/providers',
+          implementations: '/implementations',
+          actions: [
+            { id: 'stats', labelKey: 'x.stats', method: 'GET', route: '/providers/:id/stats', scope: 'row' },
+            { id: 'clear-cooldown', labelKey: 'x.clear', method: 'DELETE', route: '/providers/:id/cooldown', scope: 'row' },
+            { id: 'clear-all', labelKey: 'x.clear_all', method: 'DELETE', route: '/providers/cooldowns', scope: 'list' },
+          ],
+        }),
+      },
+    );
+    fixture.detectChanges();
+    http.expectOne({ url: '/api/plugins/fliks.a/implementations', method: 'GET' }).flush([]);
+    await settle(fixture);
+    http.expectOne({ url: '/api/plugins/fliks.a/providers', method: 'GET' }).flush([]);
+    await settle(fixture);
+
+    const rowActions = fixture.componentInstance.providerRowActions(fixture.componentInstance.providersView()!);
+    expect(rowActions.map((a) => a.labelKey)).toEqual(['x.stats', 'x.clear']);
+    expect(rowActions[0]!.route).toBe('/api/plugins/fliks.a/providers/:id/stats');
     http.verify();
   });
 

--- a/client/src/app/features/plugin-view/plugin-view.ts
+++ b/client/src/app/features/plugin-view/plugin-view.ts
@@ -14,6 +14,7 @@ import {
   ProviderImplementation,
   ProviderListAction,
   ProviderListLabels,
+  ProviderRowAction,
   ProviderTestResult,
 } from '../../shared/components/provider-list/provider-list.types';
 import { DataTableComponent } from '../../shared/components/data-table/data-table';
@@ -22,6 +23,14 @@ import type { FormConfigPage } from '../../core/plugin-ui/contribution.types';
 import { AnyConfigPage, ProvidersView, TableView, isFormView, isProvidersView, isTableView } from './view-kinds.types';
 
 type UnavailableReason = 'unknown_plugin' | 'unknown_view';
+
+/** A plugin's own `testConnection` wire shape — `messageKey` names an entry in its manifest
+ *  `i18n` dict, `detail` the dynamic half (an HTTP status, its own error text). */
+interface PluginTestConnectionResponse {
+  ok: boolean;
+  messageKey: string;
+  detail?: string;
+}
 
 /** Generic chrome for a real plugin's `providers` page — the plugin owns only field/implementation labelKeys. */
 const PLUGIN_PROVIDER_LABELS: ProviderListLabels = {
@@ -166,20 +175,39 @@ export class PluginViewComponent {
     }
   }
 
-  /** The plan's motivating row action — a proxied route, run against the unsaved draft.
-   *  Only the first `scope: 'row'` entry is wired; additional ones are dropped. */
+  /** Tests the unsaved draft — the plan's `ProvidersConfigPage.testConnection`, distinct from
+   *  `actions[]`: there is no row yet, so no `:id` to substitute. */
   providerTestConnection(view: ProvidersView): ((draft: ProviderDraft) => Promise<ProviderTestResult>) | null {
-    const action = view.actions?.find((a) => a.scope === 'row');
-    if (!action) return null;
+    const test = view.testConnection;
+    if (!test) return null;
     return async (draft: ProviderDraft) => {
       try {
-        return await firstValueFrom(
-          this.http.request<ProviderTestResult>(action.method, this.resourceUrl(action.route), { body: draft }),
+        const res = await firstValueFrom(
+          this.http.post<PluginTestConnectionResponse>(this.resourceUrl(test.route), draft),
         );
+        return { ok: res.ok, message: this.resolvePluginMessage(res.messageKey, res.detail) };
       } catch {
         return { ok: false, message: this.translate.instant('provider_list.test_network_error') };
       }
     };
+  }
+
+  /** `messageKey` names an entry in the plugin's own manifest `i18n` dict — merged into the
+   *  active language by `PluginI18nService` at boot, so it resolves the same way a `labelKey`
+   *  does. A miss (a manifest/plugin-code mismatch) falls back rather than printing the raw key. */
+  private resolvePluginMessage(messageKey: string, detail?: string): string {
+    const resolved = this.translate.instant(messageKey);
+    const base = resolved === messageKey ? this.translate.instant('provider_list.test_unknown_result') : resolved;
+    return detail ? `${base} — ${detail}` : base;
+  }
+
+  /** `actions[].scope: 'row'` — every entry renders its own button. `route` is only
+   *  host-prefixed here; substituting the row's `:id` is `ProviderListComponent`'s job,
+   *  since only it holds the row. */
+  providerRowActions(view: ProvidersView): ProviderRowAction[] {
+    return (view.actions ?? [])
+      .filter((a) => a.scope === 'row')
+      .map((a) => ({ labelKey: a.labelKey, method: a.method, route: this.resourceUrl(a.route), confirmKey: a.confirmKey }));
   }
 
   /** `actions[].scope: 'list'` — rendered once above the rows, run with no draft. */

--- a/client/src/app/shared/components/provider-list/provider-list.html
+++ b/client/src/app/shared/components/provider-list/provider-list.html
@@ -72,6 +72,19 @@
                 @if (rowExtraActions(); as tpl) {
                   <ng-container *ngTemplateOutlet="tpl; context: { $implicit: row }" />
                 }
+                @for (action of rowActions(); track action.labelKey) {
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-xs"
+                    (click)="runRowAction(row, action)"
+                    [disabled]="rowActionBusy() === rowActionKey(row, action)"
+                  >
+                    @if (rowActionBusy() === rowActionKey(row, action)) {
+                      <span class="loading loading-spinner loading-xs"></span>
+                    }
+                    {{ action.labelKey | translate }}
+                  </button>
+                }
                 <button type="button" class="btn btn-ghost btn-xs" (click)="openEdit(row)">
                   {{ labels().editKey | translate }}
                 </button>

--- a/client/src/app/shared/components/provider-list/provider-list.spec.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.spec.ts
@@ -4,9 +4,9 @@ import { HttpClient } from '@angular/common/http';
 import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
 import { vi } from 'vitest';
-import { ProviderListComponent } from './provider-list';
+import { ProviderListComponent, resolveRowActionRoute } from './provider-list';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
-import { ProviderImplementation, ProviderListAction, ProviderListLabels } from './provider-list.types';
+import { ProviderImplementation, ProviderListAction, ProviderListLabels, ProviderRowAction } from './provider-list.types';
 
 beforeAll(() => {
   if (!HTMLDialogElement.prototype.showModal) {
@@ -62,6 +62,7 @@ interface FakeHttp {
   post?: (...a: any[]) => unknown;
   put?: (...a: any[]) => unknown;
   delete?: (...a: any[]) => unknown;
+  request?: (...a: any[]) => unknown;
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
@@ -71,6 +72,9 @@ async function createComponent(
     implementations: ProviderImplementation[];
     reorderable: boolean;
     listActions: ProviderListAction[];
+    rowActions: ProviderRowAction[];
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    confirmation: { confirm: (...a: any[]) => Promise<boolean>; alert: (...a: any[]) => Promise<void> };
   }> = {},
 ) {
   TestBed.configureTestingModule({
@@ -81,7 +85,10 @@ async function createComponent(
         loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
       }),
       { provide: HttpClient, useValue: http as unknown as HttpClient },
-      { provide: ConfirmationService, useValue: { confirm: () => Promise.resolve(true), alert: () => Promise.resolve() } },
+      {
+        provide: ConfirmationService,
+        useValue: opts.confirmation ?? { confirm: () => Promise.resolve(true), alert: () => Promise.resolve() },
+      },
     ],
   });
   const fixture = TestBed.createComponent(ProviderListComponent);
@@ -91,6 +98,7 @@ async function createComponent(
   fixture.componentRef.setInput('labels', LABELS);
   if (opts.reorderable) fixture.componentRef.setInput('reorderable', opts.reorderable);
   if (opts.listActions) fixture.componentRef.setInput('listActions', opts.listActions);
+  if (opts.rowActions) fixture.componentRef.setInput('rowActions', opts.rowActions);
   fixture.detectChanges();
   await fixture.whenStable();
   await new Promise((r) => setTimeout(r, 0));
@@ -201,5 +209,89 @@ describe('ProviderListComponent — characterisation', () => {
     await fixture.componentInstance.runListAction({ labelKey: 'x.sync', run });
     expect(run).toHaveBeenCalledTimes(1);
     expect(get).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders one button per `scope: "row"` action — stats and clear-cooldown both reachable, not just the first', async () => {
+    const get = vi.fn(() => of([{ id: 7, name: 'A', implementation: 'demo', enabled: true, priority: 1, settings: {} }]));
+    const rowActions: ProviderRowAction[] = [
+      { labelKey: 'x.stats', method: 'GET', route: '/api/x/:id/stats' },
+      { labelKey: 'x.clear_cooldown', method: 'DELETE', route: '/api/x/:id/cooldown' },
+    ];
+    const fixture = await createComponent({ get }, { rowActions });
+    const buttons = Array.from(fixture.nativeElement.querySelectorAll('button')) as HTMLButtonElement[];
+    expect(buttons.some((b) => b.textContent?.includes('x.stats'))).toBe(true);
+    expect(buttons.some((b) => b.textContent?.includes('x.clear_cooldown'))).toBe(true);
+  });
+
+  it('substitutes the row id into a row action route before requesting it, and shows a GET result via alert', async () => {
+    const get = vi.fn(() => of([{ id: 7, name: 'A', implementation: 'demo', enabled: true, priority: 1, settings: {} }]));
+    const request = vi.fn(() => of({ some: 'stats' }));
+    const alert = vi.fn(() => Promise.resolve());
+    const fixture = await createComponent(
+      { get, request },
+      { confirmation: { confirm: () => Promise.resolve(true), alert } },
+    );
+    await fixture.componentInstance.runRowAction(fixture.componentInstance.rows()[0], {
+      labelKey: 'x.stats',
+      method: 'GET',
+      route: '/api/x/:id/stats',
+    });
+    expect(request).toHaveBeenCalledWith('GET', '/api/x/7/stats');
+    expect(alert).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads (rather than alerting) after a mutating row action succeeds', async () => {
+    const get = vi.fn(() => of([{ id: 7, name: 'A', implementation: 'demo', enabled: true, priority: 1, settings: {} }]));
+    const request = vi.fn(() => of({}));
+    const fixture = await createComponent({ get, request });
+    await fixture.componentInstance.runRowAction(fixture.componentInstance.rows()[0], {
+      labelKey: 'x.clear_cooldown',
+      method: 'DELETE',
+      route: '/api/x/:id/cooldown',
+    });
+    expect(request).toHaveBeenCalledWith('DELETE', '/api/x/7/cooldown');
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips the request entirely when the confirm prompt is declined', async () => {
+    const get = vi.fn(() => of([{ id: 7, name: 'A', implementation: 'demo', enabled: true, priority: 1, settings: {} }]));
+    const request = vi.fn(() => of({}));
+    const fixture = await createComponent(
+      { get, request },
+      { confirmation: { confirm: () => Promise.resolve(false), alert: () => Promise.resolve() } },
+    );
+    await fixture.componentInstance.runRowAction(fixture.componentInstance.rows()[0], {
+      labelKey: 'x.clear_cooldown',
+      method: 'DELETE',
+      route: '/api/x/:id/cooldown',
+      confirmKey: 'x.confirm_clear',
+    });
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('VERDICT: never requests a row action route whose placeholder survives id substitution', async () => {
+    const get = vi.fn(() => of([{ id: 7, name: 'A', implementation: 'demo', enabled: true, priority: 1, settings: {} }]));
+    const request = vi.fn(() => of({}));
+    const fixture = await createComponent({ get, request });
+    await fixture.componentInstance.runRowAction(fixture.componentInstance.rows()[0], {
+      labelKey: 'x.bad',
+      method: 'GET',
+      route: '/api/x/:id/:extra',
+    });
+    expect(request).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveRowActionRoute', () => {
+  it('substitutes the row id for :id', () => {
+    expect(resolveRowActionRoute('/api/plugins/x/indexers/:id/stats', 7)).toBe('/api/plugins/x/indexers/7/stats');
+  });
+
+  it('returns null — never a request — when a placeholder survives substitution', () => {
+    expect(resolveRowActionRoute('/api/plugins/x/indexers/:id/:extra', 7)).toBeNull();
+  });
+
+  it('returns null when the route never had :id to begin with', () => {
+    expect(resolveRowActionRoute('/api/plugins/x/indexers/cooldowns', 7)).toBeNull();
   });
 });

--- a/client/src/app/shared/components/provider-list/provider-list.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.ts
@@ -27,8 +27,18 @@ import {
   ProviderInstance,
   ProviderListAction,
   ProviderListLabels,
+  ProviderRowAction,
   ProviderTestResult,
 } from './provider-list.types';
+
+/** Substitutes a row action route's `:id` with the row's own id — null (never a request) when
+ *  there was no `:id` to substitute, or any `:token` placeholder survives that, so a mistyped
+ *  or list-scope route can never fire with a literal placeholder still in its path. */
+export function resolveRowActionRoute(route: string, id: number | string): string | null {
+  if (!route.includes(':id')) return null;
+  const resolved = route.replace(':id', String(id));
+  return /:[A-Za-z_]/.test(resolved) ? null : resolved;
+}
 
 /**
  * The `providers` view kind from the plugin plan: a CRUD list of instances,
@@ -72,6 +82,8 @@ export class ProviderListComponent implements OnInit {
   readonly reorderable = input(false);
   /** Rendered once above the rows (the plan's `actions[].scope: 'list'`), distinct from per-row actions. */
   readonly listActions = input<readonly ProviderListAction[]>([]);
+  /** Rendered per row (the plan's `actions[].scope: 'row'`) — every entry gets its own button. */
+  readonly rowActions = input<readonly ProviderRowAction[]>([]);
   /** Matches subtitle-providers' current UX: renaming the draft to the driver's label while creating. */
   readonly autoFillNameFromImplementation = input(false);
   /** Runs against the unsaved draft (before create/update) — the plan's motivating row action. */
@@ -100,6 +112,7 @@ export class ProviderListComponent implements OnInit {
   readonly testResult = signal<ProviderTestResult | null>(null);
 
   readonly listActionBusy = signal<string | null>(null);
+  readonly rowActionBusy = signal<string | null>(null);
 
   /** Display order: priority ascending when `reorderable`, otherwise the server's own order. */
   readonly orderedRows = computed(() =>
@@ -293,6 +306,38 @@ export class ProviderListComponent implements OnInit {
       await this.reload();
     } finally {
       this.listActionBusy.set(null);
+    }
+  }
+
+  rowActionKey(row: ProviderInstance, action: ProviderRowAction): string {
+    return `${row.id}:${action.labelKey}`;
+  }
+
+  /** A `GET` shows its response (this generic renderer has no domain-specific view for it);
+   *  a mutation just reloads the rows. Never fires when the row's `:id` can't be substituted. */
+  async runRowAction(row: ProviderInstance, action: ProviderRowAction): Promise<void> {
+    const url = resolveRowActionRoute(action.route, row.id);
+    if (!url) return;
+    if (action.confirmKey) {
+      const ok = await this.confirmation.confirm({
+        title: this.translate.instant('common.confirm'),
+        message: this.translate.instant(action.confirmKey),
+        variant: 'danger',
+      });
+      if (!ok) return;
+    }
+    this.rowActionBusy.set(this.rowActionKey(row, action));
+    try {
+      const result = await firstValueFrom(this.http.request(action.method, url));
+      if (action.method === 'GET') {
+        await this.confirmation.alert({ title: this.translate.instant(action.labelKey), message: JSON.stringify(result) });
+      } else {
+        await this.reload();
+      }
+    } catch {
+      // handled by the global error interceptor
+    } finally {
+      this.rowActionBusy.set(null);
     }
   }
 }

--- a/client/src/app/shared/components/provider-list/provider-list.types.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.types.ts
@@ -39,6 +39,16 @@ export interface ProviderListAction {
   run: () => Promise<void>;
 }
 
+/** A row-scope action (`ProvidersConfigPage.actions[].scope: 'row'`), host-prefixed but with
+ *  `:id` still in `route` — substituting it against the row, and never firing if a placeholder
+ *  survives that, is this component's job because only it holds the row. */
+export interface ProviderRowAction {
+  labelKey: string;
+  method: 'GET' | 'POST' | 'DELETE';
+  route: string;
+  confirmKey?: string;
+}
+
 export interface ProviderListLabels {
   newLabelKey: string;
   colNameKey: string;


### PR DESCRIPTION
A provider page's **"Test connection" button called the statistics endpoint.** The renderer took whichever `scope: 'row'` action came first in the manifest and wired it as the test handler; on the indexers page that is `GET /indexers/:id/stats`, so the button fired a path with the literal `:id` still in it and got a rejection.

And it was worse than a mis-wire: **row actions were never rendered as buttons at all.** They were only harvested into the test slot, so statistics and clearing a cooldown had no way to be invoked in the first place — the report that they "remain reachable" was wrong, they never were.

## Two things were conflated

| | has a row? | needs `:id`? |
| --- | --- | --- |
| testing a draft | no — nothing is saved yet | no |
| acting on a row | yes | yes |

The contract distinguishes them now: a providers page declares `testConnection` on its own, and `actions[]` are just row and list actions — **all** the row ones, one button per row, instead of only the first. Both mirrored halves changed identically, so the drift gate holds.

## The placeholder cannot leak

A route whose `:token` survives substitution is **never requested**, and a row-scoped route that never carried an `:id` is refused too — a row action that ignores its row is the same mistake in different clothes. That makes today's bug unreachable rather than corrected in one call site.

## The message is a key, not a sentence

The plugin answers `{ ok, messageKey, detail? }` — a key into **its own** dictionary. The renderer resolves it through the translations that plugin already ships, appends the dynamic half, and falls back to a generic string when a key is unknown, because printing a key at a user is worse than saying little.

## Live proof, after a real uninstall and reinstall

| draft | result |
| --- | --- |
| indexer, bogus host | `{"ok":false,"messageKey":"…network_error","detail":"fetch failed"}` |
| indexer, empty base URL | `{"ok":false,"messageKey":"…base_url_missing"}` |
| indexer, real Jackett endpoint + key | `{"ok":true,"messageKey":"…test.ok"}` |
| download client, bad port | `{"ok":false,"messageKey":"…network_error","detail":"could not reach the download client: bad port"}` |
| download client, real host, wrong credentials | `{"ok":false,"messageKey":"…auth_failed"}` |

Real structured failures, never a rejection from a malformed path. **The plausible indexer draft reaching Jackett successfully is also the first confirmation that a Torznab call leaves the plugin and gets an answer** — that had been an open question.

## Verification

- Backend **123 suites / 1312 tests**, `tsc` 0. Client **38 files / 328 tests** (+11), `ng build` 0. Plugin 258 tests, `tsc` 0, drift check clean across all nine shapes.
- New tests cover id substitution, the surviving-placeholder refusal, one button per row action, the draft test never touching `actions[]`, and the unknown-key fallback.

## Note

A `GET` row action's result — statistics — renders as raw JSON in a dialog. A generic contract renderer has no knowledge of that payload's shape, and building a statistics view is its own feature rather than part of this fix.