### PR TITLE
fix(plugins): stop reporting a healthy plugin's warnings as errors

### DIFF
--- a/backend/src/modules/plugins/plugin-process.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-process.service.spec.ts
@@ -361,11 +361,20 @@ describe('PluginProcessService — lifecycle', () => {
     expect(service.statusMessageOf('fliks.never-started')).toBe('');
   });
 
-  it('statusMessageOf falls back to the stderr tail when there is no breaker message', async () => {
+  it('statusMessageOf falls back to the stderr tail of a plugin that is down', async () => {
     const { service, pkg, instances } = await startedService();
     instances[0].stderrTail = 'last gasp';
+    instances[0].setState('crashed');
 
     expect(service.statusMessageOf(pkg.pluginId)).toBe('last gasp');
+  });
+
+  it('statusMessageOf reports nothing for a healthy plugin that logged warnings', async () => {
+    const { service, pkg, instances } = await startedService();
+    instances[0].stderrTail = 'WARN no download client configured yet\n';
+
+    expect(service.stateOf(pkg.pluginId)).toBe('ready');
+    expect(service.statusMessageOf(pkg.pluginId)).toBe('');
   });
 
   it('restart stops the old supervisor and spawns a fresh one, rotating the password again', async () => {

--- a/backend/src/modules/plugins/plugin-process.service.ts
+++ b/backend/src/modules/plugins/plugin-process.service.ts
@@ -26,6 +26,9 @@ interface RunningPlugin {
 
 const DEFAULT_FACTORY: PluginSupervisorFactory = (options) => new PluginSupervisor(options);
 
+/** States where the stderr tail is the diagnosis rather than routine output. */
+const DOWN_STATES: ReadonlySet<SupervisorState> = new Set(['crashed', 'backoff', 'failed', 'degraded']);
+
 /** Owns every live `process` plugin's supervisor, one per plugin id. `startFor`/`stopFor`
  *  are the map's only entry and exit, so it always reflects who is actually spawned. */
 @Injectable()
@@ -113,7 +116,10 @@ export class PluginProcessService implements OnApplicationShutdown {
   statusMessageOf(pluginId: string): string {
     const supervisor = this.running.get(pluginId)?.supervisor;
     if (!supervisor) return '';
-    return supervisor.getStatusMessage() || supervisor.getStderrTail();
+    const breakerMessage = supervisor.getStatusMessage();
+    if (breakerMessage) return breakerMessage;
+    // The stderr tail explains a failure; a healthy plugin's own warnings are not its status.
+    return DOWN_STATES.has(supervisor.getState()) ? supervisor.getStderrTail() : '';
   }
 
   /** Passthrough so the HTTP proxy never touches a supervisor directly. */

--- a/backend/src/modules/plugins/supervisor/__fixtures__/fixture-plugin.js
+++ b/backend/src/modules/plugins/supervisor/__fixtures__/fixture-plugin.js
@@ -107,6 +107,11 @@ if (mode === 'never-connect') {
     process.on('SIGTERM', () => {}); // forces the supervisor down the SIGKILL branch
   }
 
+  if (mode === 'log-levels') {
+    process.stderr.write('[2026-01-01T00:00:00.000Z] WARN nothing configured yet\n');
+    process.stderr.write('[2026-01-01T00:00:00.000Z] ERROR the driver refused\n');
+  }
+
   if (mode === 'flood-stdout') {
     setInterval(() => {
       for (let i = 0; i < 500; i++) process.stdout.write('x'.repeat(200) + '\n');

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.spec.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.spec.ts
@@ -187,6 +187,24 @@ describe('circuit breaker', () => {
   }, 10_000);
 });
 
+describe('child stdio', () => {
+  it("keeps a stderr line's own WARN level instead of logging it as an error", async () => {
+    const logBuffer = newLogBuffer();
+    const sup = makeSupervisor('log-levels', { logBuffer });
+    await sup.start();
+    await waitForState(sup, 'ready');
+    await delay(100);
+
+    const warns = logBuffer.getEntries({ level: 'warn' }).map((e) => e.message);
+    const errors = logBuffer.getEntries({ level: 'error' }).map((e) => e.message);
+    expect(warns.some((m) => m.includes('nothing configured yet'))).toBe(true);
+    expect(errors.some((m) => m.includes('nothing configured yet'))).toBe(false);
+    expect(errors.some((m) => m.includes('the driver refused'))).toBe(true);
+    // Both stay in the tail: it is the crash diagnosis, not a level filter.
+    expect(sup.getStderrTail()).toContain('nothing configured yet');
+  }, 10_000);
+});
+
 describe('ring buffer backpressure', () => {
   it('drops the oldest event and counts drops when the child never reads', async () => {
     const sup = makeSupervisor('no-read');

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
@@ -31,6 +31,9 @@ export type SupervisorState =
 
 const STDERR_TAIL_BYTES = 4 * 1024;
 
+/** `WARN` as the line's own level — after any bracketed prefixes, never inside the message. */
+const SELF_DECLARED_WARN = /^(?:\[[^\]]*\]\s*)*WARN\b/;
+
 /** Every figure here is "The spawn call and the supervisor"'s, verbatim. Override only in tests. */
 export const DEFAULT_SUPERVISOR_OPTIONS = {
   memoryMb: 256,
@@ -420,7 +423,10 @@ export class PluginSupervisor implements OnApplicationShutdown {
         if (line.length === 0) continue;
         if (level === 'log') this.opts.logBuffer.log(line, tag);
         else {
-          this.opts.logBuffer.error(line, undefined, tag);
+          // A plugin that names its own level keeps it: everything it writes to stderr,
+          // warnings included, would otherwise paint the core log as errors.
+          if (SELF_DECLARED_WARN.test(line)) this.opts.logBuffer.warn(line, tag);
+          else this.opts.logBuffer.error(line, undefined, tag);
           this.stderrTail = (this.stderrTail + line + '\n').slice(-STDERR_TAIL_BYTES);
         }
       }


### PR DESCRIPTION
## Why

Verifying the download plugin end to end, `docker compose logs backend` was full of red lines from a plugin that is working fine:

```
ERROR [plugin:fliks.download] [2026-08-12T09:00:00.030Z] WARN Import: no enabled download client found
ERROR [plugin:fliks.download] [2026-08-12T09:00:00.031Z] WARN RssSync: no enabled download client configured
```

Two separate causes, both in core:

1. `PluginSupervisor.wireChildIo` logs **every** stderr line at `error`. A plugin has no way to emit a warning — stderr is the conventional stream for diagnostics, and the plugin does prefix each line with its own level.
2. `PluginProcessService.statusMessageOf` fell back to the stderr tail unconditionally, so `GET /api/plugins` returned 4 KiB of routine warnings as the `statusMessage` of an `active`/`ready` plugin. The plan only ever wanted that tail as the *crash* diagnosis (circuit breaker → `statusMessage` = last 4 KiB of stderr). Nothing renders the field yet, so this was invisible until the first thing does.

## What

- A stderr line whose own leading level is `WARN` is logged at `warn`; anything else stays `error`. The tail keeps both — it is the diagnosis, not a level filter.
- `statusMessageOf` returns the breaker message, then the stderr tail **only** for a plugin in a down state (`crashed`/`backoff`/`failed`/`degraded`), and `''` for a healthy one.

## Verification

- `tsc --noEmit` → exit 0; full backend suite → 1314 passed / 123 suites.
- New fixture mode `log-levels` writes one WARN and one ERROR line to stderr; the new supervisor spec asserts the WARN lands at `warn`, is absent from `error`, and is still in the tail. Sabotaging the level regex fails that test (checked), so it is not vacuous.
- New process-service spec asserts a `ready` plugin with warnings in its tail reports `statusMessage: ''`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)