### PR TITLE
feat(plugin-ui): render a GET row action's answer as its declared table

### DIFF
--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -88,6 +88,13 @@ export interface FormConfigPage extends ConfigPageBase {
   fields: FieldDef[];
 }
 
+/** One column of a declared table — a `table` page's rows, or a row action's result. */
+export interface TableColumn {
+  key: string;
+  labelKey: string;
+  format?: 'date' | 'bytes' | 'percent';
+}
+
 /** One proxied route lists instances, another lists the implementations and their fields. */
 export interface ProvidersConfigPage extends ConfigPageBase {
   kind: 'providers';
@@ -106,6 +113,9 @@ export interface ProvidersConfigPage extends ConfigPageBase {
     route: string;
     scope: 'row' | 'list';
     confirmKey?: string;
+    /** How core renders what a `GET` answers — an array of rows, in declared columns.
+     *  A `GET` without it renders no button: core has no domain view to fall back on. */
+    result?: { kind: 'table'; columns: TableColumn[]; emptyKey: string };
   }[];
   reorderable?: boolean;
   /** Priority is not a universal provider concept; hide the column when the
@@ -126,7 +136,7 @@ export interface ProvidersConfigPage extends ConfigPageBase {
 export interface TableConfigPage extends ConfigPageBase {
   kind: 'table';
   list: string;
-  columns: { key: string; labelKey: string; format?: 'date' | 'bytes' | 'percent' }[];
+  columns: TableColumn[];
   rowActions?: (
     | { kind: 'route'; labelKey: string; path: string }
     | { kind: 'action'; labelKey: string; actionId: string }

--- a/client/src/app/core/plugin-ui/contribution.types.ts
+++ b/client/src/app/core/plugin-ui/contribution.types.ts
@@ -91,6 +91,13 @@ export interface FormConfigPage extends ConfigPageBase {
   fields: FieldDef[];
 }
 
+/** One column of a declared table — a `table` page's rows, or a row action's result. */
+export interface TableColumn {
+  key: string;
+  labelKey: string;
+  format?: 'date' | 'bytes' | 'percent';
+}
+
 /** One proxied route lists instances, another lists the implementations and their fields. */
 export interface ProvidersConfigPage extends ConfigPageBase {
   kind: 'providers';
@@ -109,6 +116,9 @@ export interface ProvidersConfigPage extends ConfigPageBase {
     route: string;
     scope: 'row' | 'list';
     confirmKey?: string;
+    /** How core renders what a `GET` answers — an array of rows, in declared columns.
+     *  A `GET` without it renders no button: core has no domain view to fall back on. */
+    result?: { kind: 'table'; columns: TableColumn[]; emptyKey: string };
   }[];
   reorderable?: boolean;
   /** Priority is not a universal provider concept; hide the column when the
@@ -129,7 +139,7 @@ export interface ProvidersConfigPage extends ConfigPageBase {
 export interface TableConfigPage extends ConfigPageBase {
   kind: 'table';
   list: string;
-  columns: { key: string; labelKey: string; format?: 'date' | 'bytes' | 'percent' }[];
+  columns: TableColumn[];
   rowActions?: (
     | { kind: 'route'; labelKey: string; path: string }
     | { kind: 'action'; labelKey: string; actionId: string }

--- a/client/src/app/features/plugin-view/plugin-view.spec.ts
+++ b/client/src/app/features/plugin-view/plugin-view.spec.ts
@@ -233,7 +233,14 @@ describe('PluginViewComponent', () => {
           list: '/providers',
           implementations: '/implementations',
           actions: [
-            { id: 'stats', labelKey: 'x.stats', method: 'GET', route: '/providers/:id/stats', scope: 'row' },
+            {
+              id: 'stats',
+              labelKey: 'x.stats',
+              method: 'GET',
+              route: '/providers/:id/stats',
+              scope: 'row',
+              result: { kind: 'table', columns: [{ key: 'date', labelKey: 'x.date' }], emptyKey: 'x.empty' },
+            },
             { id: 'clear-cooldown', labelKey: 'x.clear', method: 'DELETE', route: '/providers/:id/cooldown', scope: 'row' },
             { id: 'clear-all', labelKey: 'x.clear_all', method: 'DELETE', route: '/providers/cooldowns', scope: 'list' },
           ],
@@ -249,6 +256,8 @@ describe('PluginViewComponent', () => {
     const rowActions = fixture.componentInstance.providerRowActions(fixture.componentInstance.providersView()!);
     expect(rowActions.map((a) => a.labelKey)).toEqual(['x.stats', 'x.clear']);
     expect(rowActions[0]!.route).toBe('/api/plugins/fliks.a/providers/:id/stats');
+    // Dropping `result` here would make the renderer hide the button entirely.
+    expect(rowActions[0]!.result?.columns.map((c) => c.key)).toEqual(['date']);
     http.verify();
   });
 

--- a/client/src/app/features/plugin-view/plugin-view.ts
+++ b/client/src/app/features/plugin-view/plugin-view.ts
@@ -207,7 +207,13 @@ export class PluginViewComponent {
   providerRowActions(view: ProvidersView): ProviderRowAction[] {
     return (view.actions ?? [])
       .filter((a) => a.scope === 'row')
-      .map((a) => ({ labelKey: a.labelKey, method: a.method, route: this.resourceUrl(a.route), confirmKey: a.confirmKey }));
+      .map((a) => ({
+        labelKey: a.labelKey,
+        method: a.method,
+        route: this.resourceUrl(a.route),
+        confirmKey: a.confirmKey,
+        result: a.result,
+      }));
   }
 
   /** `actions[].scope: 'list'` — rendered once above the rows, run with no draft. */

--- a/client/src/app/shared/components/data-table/data-table.html
+++ b/client/src/app/shared/components/data-table/data-table.html
@@ -1,6 +1,8 @@
 <div class="flex flex-col gap-4">
   <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
-    <h2 class="card-title text-lg">{{ titleKey() | translate }}</h2>
+    @if (titleKey()) {
+      <h2 class="card-title text-lg">{{ titleKey() | translate }}</h2>
+    }
     @if (listActions().length) {
       <div class="flex gap-2 shrink-0">
         @for (action of listActions(); track action.path) {
@@ -42,7 +44,7 @@
           </tr>
         </thead>
         <tbody>
-          @for (row of rows(); track row.id) {
+          @for (row of rows(); track $index) {
             <tr>
               @for (col of columns(); track col.key) {
                 <td>

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -26,7 +26,8 @@ export class DataTableComponent implements OnInit {
   private readonly translate = inject(TranslateService);
   private readonly confirmation = inject(ConfirmationService);
 
-  readonly titleKey = input.required<string>();
+  /** Empty renders no heading — an embedded table (a row action's result) carries its own. */
+  readonly titleKey = input('');
   readonly listUrl = input.required<string>();
   readonly columns = input.required<readonly TableColumn[]>();
   readonly rowActions = input<readonly RowAction[]>([]);

--- a/client/src/app/shared/components/provider-list/provider-list.html
+++ b/client/src/app/shared/components/provider-list/provider-list.html
@@ -72,7 +72,7 @@
                 @if (rowExtraActions(); as tpl) {
                   <ng-container *ngTemplateOutlet="tpl; context: { $implicit: row }" />
                 }
-                @for (action of rowActions(); track action.labelKey) {
+                @for (action of visibleRowActions(); track action.labelKey) {
                   <button
                     type="button"
                     class="btn btn-ghost btn-xs"
@@ -175,5 +175,24 @@
   </div>
   <form method="dialog" class="modal-backdrop">
     <button type="button" (click)="closeEditor()" [attr.aria-label]="'common.close' | translate">close</button>
+  </form>
+</dialog>
+
+<dialog #resultDialog class="modal">
+  <div class="modal-box max-w-2xl">
+    @if (resultView(); as view) {
+      <h3 class="font-bold text-lg mb-4">{{ view.title }}</h3>
+      <app-data-table
+        [listUrl]="view.url"
+        [columns]="view.result.columns"
+        [emptyKey]="view.result.emptyKey"
+      />
+    }
+    <div class="modal-action">
+      <button type="button" class="btn btn-ghost" (click)="closeResult()">{{ 'common.close' | translate }}</button>
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="button" (click)="closeResult()" [attr.aria-label]="'common.close' | translate">close</button>
   </form>
 </dialog>

--- a/client/src/app/shared/components/provider-list/provider-list.spec.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.spec.ts
@@ -21,6 +21,12 @@ beforeAll(() => {
   }
 });
 
+const STATS_RESULT: NonNullable<ProviderRowAction['result']> = {
+  kind: 'table',
+  emptyKey: 'x.stats_empty',
+  columns: [{ key: 'date', labelKey: 'x.stats_date' }],
+};
+
 const LABELS: ProviderListLabels = {
   newLabelKey: 'x.new',
   colNameKey: 'x.col_name',
@@ -214,7 +220,7 @@ describe('ProviderListComponent — characterisation', () => {
   it('renders one button per `scope: "row"` action — stats and clear-cooldown both reachable, not just the first', async () => {
     const get = vi.fn(() => of([{ id: 7, name: 'A', implementation: 'demo', enabled: true, priority: 1, settings: {} }]));
     const rowActions: ProviderRowAction[] = [
-      { labelKey: 'x.stats', method: 'GET', route: '/api/x/:id/stats' },
+      { labelKey: 'x.stats', method: 'GET', route: '/api/x/:id/stats', result: STATS_RESULT },
       { labelKey: 'x.clear_cooldown', method: 'DELETE', route: '/api/x/:id/cooldown' },
     ];
     const fixture = await createComponent({ get }, { rowActions });
@@ -223,21 +229,36 @@ describe('ProviderListComponent — characterisation', () => {
     expect(buttons.some((b) => b.textContent?.includes('x.clear_cooldown'))).toBe(true);
   });
 
-  it('substitutes the row id into a row action route before requesting it, and shows a GET result via alert', async () => {
+  it("substitutes the row id into a GET row action's route and hands it to its declared table", async () => {
     const get = vi.fn(() => of([{ id: 7, name: 'A', implementation: 'demo', enabled: true, priority: 1, settings: {} }]));
     const request = vi.fn(() => of({ some: 'stats' }));
-    const alert = vi.fn(() => Promise.resolve());
-    const fixture = await createComponent(
-      { get, request },
-      { confirmation: { confirm: () => Promise.resolve(true), alert } },
-    );
+    const fixture = await createComponent({ get, request });
+
     await fixture.componentInstance.runRowAction(fixture.componentInstance.rows()[0], {
       labelKey: 'x.stats',
       method: 'GET',
       route: '/api/x/:id/stats',
+      result: STATS_RESULT,
     });
-    expect(request).toHaveBeenCalledWith('GET', '/api/x/7/stats');
-    expect(alert).toHaveBeenCalledTimes(1);
+
+    expect(fixture.componentInstance.resultView()?.url).toBe('/api/x/7/stats');
+    expect(fixture.componentInstance.resultView()?.title).toContain('A');
+    // The embedded table owns the fetch; the component must not request it a second time.
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('VERDICT: renders no button for a GET row action that declares no result, and opens nothing', async () => {
+    const get = vi.fn(() => of([{ id: 7, name: 'A', implementation: 'demo', enabled: true, priority: 1, settings: {} }]));
+    const request = vi.fn(() => of({ some: 'stats' }));
+    const rowActions: ProviderRowAction[] = [{ labelKey: 'x.stats', method: 'GET', route: '/api/x/:id/stats' }];
+    const fixture = await createComponent({ get, request }, { rowActions });
+
+    const buttons = Array.from(fixture.nativeElement.querySelectorAll('button')) as HTMLButtonElement[];
+    expect(buttons.some((b) => b.textContent?.includes('x.stats'))).toBe(false);
+
+    await fixture.componentInstance.runRowAction(fixture.componentInstance.rows()[0], rowActions[0]);
+    expect(fixture.componentInstance.resultView()).toBeNull();
+    expect(request).not.toHaveBeenCalled();
   });
 
   it('reloads (rather than alerting) after a mutating row action succeeds', async () => {

--- a/client/src/app/shared/components/provider-list/provider-list.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.ts
@@ -30,6 +30,13 @@ import {
   ProviderRowAction,
   ProviderTestResult,
 } from './provider-list.types';
+import { DataTableComponent } from '../data-table/data-table';
+
+interface RowActionResultView {
+  url: string;
+  title: string;
+  result: NonNullable<ProviderRowAction['result']>;
+}
 
 /** Substitutes a row action route's `:id` with the row's own id — null (never a request) when
  *  there was no `:id` to substitute, or any `:token` placeholder survives that, so a mistyped
@@ -56,6 +63,7 @@ export function resolveRowActionRoute(route: string, id: number | string): strin
     ToggleFieldComponent,
     SelectFieldComponent,
     SchemaFormComponent,
+    DataTableComponent,
     LucideArrowUp,
     LucideArrowDown,
   ],
@@ -67,6 +75,7 @@ export class ProviderListComponent implements OnInit {
   private readonly translate = inject(TranslateService);
   private readonly confirmation = inject(ConfirmationService);
   private readonly editorDialog = viewChild<ElementRef<HTMLDialogElement>>('editorDialog');
+  private readonly resultDialog = viewChild<ElementRef<HTMLDialogElement>>('resultDialog');
 
   readonly titleKey = input.required<string>();
   readonly listUrl = input.required<string>();
@@ -113,6 +122,14 @@ export class ProviderListComponent implements OnInit {
 
   readonly listActionBusy = signal<string | null>(null);
   readonly rowActionBusy = signal<string | null>(null);
+
+  /** The open `GET` row action's declared table. Null keeps `<app-data-table>` out of the
+   *  DOM, so it only fetches when a row asked for it. */
+  readonly resultView = signal<RowActionResultView | null>(null);
+
+  /** A `GET` with no declared `result` has nothing to show, so it gets no button — the same
+   *  fail-closed rule the `table` kind applies to an unknown `actionId`. */
+  readonly visibleRowActions = computed(() => this.rowActions().filter((a) => a.method !== 'GET' || !!a.result));
 
   /** Display order: priority ascending when `reorderable`, otherwise the server's own order. */
   readonly orderedRows = computed(() =>
@@ -313,8 +330,8 @@ export class ProviderListComponent implements OnInit {
     return `${row.id}:${action.labelKey}`;
   }
 
-  /** A `GET` shows its response (this generic renderer has no domain-specific view for it);
-   *  a mutation just reloads the rows. Never fires when the row's `:id` can't be substituted. */
+  /** A `GET` opens its declared table, which fetches the route itself; a mutation just
+   *  reloads the rows. Never fires when the row's `:id` can't be substituted. */
   async runRowAction(row: ProviderInstance, action: ProviderRowAction): Promise<void> {
     const url = resolveRowActionRoute(action.route, row.id);
     if (!url) return;
@@ -326,18 +343,25 @@ export class ProviderListComponent implements OnInit {
       });
       if (!ok) return;
     }
+    if (action.method === 'GET') {
+      if (!action.result) return;
+      this.resultView.set({ url, title: `${row.name} — ${this.translate.instant(action.labelKey)}`, result: action.result });
+      this.resultDialog()?.nativeElement.showModal();
+      return;
+    }
     this.rowActionBusy.set(this.rowActionKey(row, action));
     try {
-      const result = await firstValueFrom(this.http.request(action.method, url));
-      if (action.method === 'GET') {
-        await this.confirmation.alert({ title: this.translate.instant(action.labelKey), message: JSON.stringify(result) });
-      } else {
-        await this.reload();
-      }
+      await firstValueFrom(this.http.request(action.method, url));
+      await this.reload();
     } catch {
       // handled by the global error interceptor
     } finally {
       this.rowActionBusy.set(null);
     }
+  }
+
+  closeResult(): void {
+    this.resultDialog()?.nativeElement.close();
+    this.resultView.set(null);
   }
 }

--- a/client/src/app/shared/components/provider-list/provider-list.types.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.types.ts
@@ -1,4 +1,4 @@
-import type { FieldDef } from '../../../core/plugin-ui/contribution.types';
+import type { FieldDef, TableColumn } from '../../../core/plugin-ui/contribution.types';
 
 /**
  * The generic shape a provider-list consumer's wire format already fits.
@@ -47,6 +47,8 @@ export interface ProviderRowAction {
   method: 'GET' | 'POST' | 'DELETE';
   route: string;
   confirmKey?: string;
+  /** How a `GET`'s answer renders (`ProvidersConfigPage.actions[].result`). */
+  result?: { kind: 'table'; columns: TableColumn[]; emptyKey: string };
 }
 
 export interface ProviderListLabels {


### PR DESCRIPTION
## Why

Clicking **Stats** on an indexer opened a dialog containing `[]`. The generic `providers` renderer had no declared view for a `GET` row action's body, so it fell back to `JSON.stringify`. The core page this replaced showed a five-column table with an empty-state sentence, so this was a visible regression from the plugin extraction.

## What

- `ProvidersConfigPage.actions[].result?: { kind: 'table'; columns; emptyKey }` — a `GET` declares how its answer renders. Mirrored in `client/src/app/core/plugin-ui/contribution.types.ts` (the drift gate compares emitted declarations, checked identical).
- `ProviderListComponent` opens a dialog holding `<app-data-table>` pointed at the resolved route. The table already owns fetching, formatting (`date`/`bytes`/`percent`), the load error and the empty message, so the component no longer requests the route itself.
- **Fail closed:** a `GET` with no `result` renders no button — the same rule the `table` kind already applies to an unknown `actionId`. The guard is in the component, so it covers every consumer, not just plugin pages.
- `TableColumn` extracted from `TableConfigPage.columns` so both places describe a column identically.
- `data-table` tracks rows by `$index` instead of `row.id`, and its `titleKey` is now optional. An aggregate route (`GROUP BY`, which is what stats is) has no id to give; with the old tracking a two-row result would have thrown on duplicate keys.

## Verification

- Full client suite 329 passed / 38 files; `ng build` exit 0 (templates); backend `tsc --noEmit` exit 0.
- New spec: a GET with a declared result puts the substituted URL in `resultView()` and never requests it itself. New VERDICT spec: a GET without `result` renders no button and opens nothing.
- Live, with the plugin reinstalled: `/api/plugins/fliks.download/indexers/2/stats` → `200 []`, and the served manifest carries the five columns plus the `en`/`fr` empty-state key, so the dialog now shows the empty sentence instead of `[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)