### PR TITLE
fix(plugins): stop the alias catch-all from swallowing core routes

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -26,6 +26,7 @@ import { FilesystemModule } from './modules/filesystem/filesystem.module';
 import { SetupChecklistModule } from './modules/setup-checklist/setup-checklist.module';
 import { CountsModule } from './modules/counts/counts.module';
 import { PluginsModule } from './modules/plugins/plugins.module';
+import { PluginLegacyAliasModule } from './modules/plugins/proxy/plugin-legacy-alias.module';
 import { PluginHostModule } from './modules/plugins/host/plugin-host.module';
 import { CommonModule } from './common/common.module';
 import { ServeStaticModule } from '@nestjs/serve-static';
@@ -103,6 +104,9 @@ import { join } from 'path';
     // @Global(): registered once here so PluginProcessService (in PluginsModule) can
     // inject PluginHostBindingService without an import edge back into this module.
     PluginHostModule,
+    // Dead last, and it must stay there: it owns an app-wide `*splat` catch-all, which
+    // Express matches ahead of every route registered after it.
+    PluginLegacyAliasModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/modules/plugins/plugins.module.ts
+++ b/backend/src/modules/plugins/plugins.module.ts
@@ -20,8 +20,6 @@ import { PluginUiController } from './plugin-ui.controller';
 import { PluginObjectGuardsService } from './proxy/plugin-object-guards.service';
 import { PluginRouteGuard } from './proxy/plugin-route.guard';
 import { PluginProxyController } from './proxy/plugin-proxy.controller';
-import { PluginLegacyAliasMatchGuard, PluginLegacyAliasPolicyGuard } from './proxy/plugin-legacy-alias.guard';
-import { PluginLegacyAliasController } from './proxy/plugin-legacy-alias.controller';
 import { AuthModule } from '../auth/auth.module';
 import { EventsModule } from '../scheduler/events.module';
 import { LogBufferModule } from '../scheduler/log-buffer.module';
@@ -47,8 +45,6 @@ import { ScheduledJobRegistryModule } from '../scheduler/scheduled-job-registry.
     PluginUiController,
     // Last: its `*splat` wildcard must never shadow the concrete routes above.
     PluginProxyController,
-    // Last of all: a legacy alias must never shadow a route any other controller — core's own included — already serves.
-    PluginLegacyAliasController,
   ],
   providers: [
     PluginRegistryService,
@@ -62,9 +58,7 @@ import { ScheduledJobRegistryModule } from '../scheduler/scheduled-job-registry.
     PluginDatabaseService,
     PluginObjectGuardsService,
     PluginRouteGuard,
-    PluginLegacyAliasMatchGuard,
-    PluginLegacyAliasPolicyGuard,
   ],
-  exports: [TypeOrmModule, PluginRegistryService, PluginDatabaseService, PluginJobsService],
+  exports: [TypeOrmModule, PluginRegistryService, PluginDatabaseService, PluginJobsService, PluginProcessService],
 })
 export class PluginsModule {}

--- a/backend/src/modules/plugins/proxy/plugin-legacy-alias-registration-order.spec.ts
+++ b/backend/src/modules/plugins/proxy/plugin-legacy-alias-registration-order.spec.ts
@@ -1,0 +1,38 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+import { AppModule } from '../../../app.module';
+import { PluginLegacyAliasModule } from './plugin-legacy-alias.module';
+
+const SRC_ROOT = join(__dirname, '..', '..', '..');
+
+function moduleFiles(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) moduleFiles(full, found);
+    else if (entry.endsWith('.module.ts')) found.push(full);
+  }
+  return found;
+}
+
+/**
+ * `PluginLegacyAliasController` answers an app-wide `*splat`, and Express matches routes in
+ * registration order — so anything registered after it is unreachable. Nest's registration
+ * order is the module *scan* order, not `AppModule`'s import array: a module another module
+ * imports is inserted where that importer is reached. Both facts below are what keeps the
+ * catch-all last; each has already cost one production 404 on a real core route.
+ */
+describe('legacy-alias catch-all registration order', () => {
+  it('is the last module AppModule imports', () => {
+    const imports = (Reflect.getMetadata('imports', AppModule) as unknown[]) ?? [];
+    expect(imports.length).toBeGreaterThan(1);
+    expect(imports[imports.length - 1]).toBe(PluginLegacyAliasModule);
+  });
+
+  it('VERDICT: no other module imports it — one importer scanned earlier moves the catch-all ahead of core routes', () => {
+    const offenders = moduleFiles(SRC_ROOT)
+      .filter((f) => !f.endsWith('plugin-legacy-alias.module.ts') && !f.endsWith('app.module.ts'))
+      .filter((f) => readFileSync(f, 'utf8').includes('PluginLegacyAliasModule'));
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/backend/src/modules/plugins/proxy/plugin-legacy-alias.module.ts
+++ b/backend/src/modules/plugins/proxy/plugin-legacy-alias.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { PluginsModule } from '../plugins.module';
+import { AuthModule } from '../../auth/auth.module';
+import { LibrariesModule } from '../../libraries/libraries.module';
+import { PluginObjectGuardsService } from './plugin-object-guards.service';
+import { PluginLegacyAliasMatchGuard, PluginLegacyAliasPolicyGuard } from './plugin-legacy-alias.guard';
+import { PluginLegacyAliasController } from './plugin-legacy-alias.controller';
+
+/**
+ * Holds the app-wide `*splat` catch-all on its own, so that it can be the very last
+ * module `AppModule` imports and its route the very last one Express registers.
+ *
+ * It cannot live in `PluginsModule`: `FliksSchedulerModule` imports that module for the
+ * merged job listing, which inserts it early in the scan and would register the catch-all
+ * ahead of every controller scanned later — silently 404ing real core routes.
+ * Nothing else may import this module. `plugin-legacy-alias-registration-order.spec.ts`
+ * fails if anything does.
+ */
+@Module({
+  imports: [PluginsModule, AuthModule, LibrariesModule],
+  controllers: [PluginLegacyAliasController],
+  providers: [PluginObjectGuardsService, PluginLegacyAliasMatchGuard, PluginLegacyAliasPolicyGuard],
+})
+export class PluginLegacyAliasModule {}


### PR DESCRIPTION
## The bug

`GET /api/counts` and `GET /api/likes/state/:id` returned **404 in the browser** after #954. Both are real core routes.

Nest registers routes in module **scan** order, not in the order `AppModule` lists its imports. `FliksSchedulerModule` imports `PluginsModule` directly (`scheduler.module.ts:56`, for the merged job listing), so `PluginsModule` — and the app-wide `@All('*splat')` alias catch-all it held — was inserted early in the scan, ahead of every controller scanned later. Express matched the catch-all first, its match guard threw a plain `NotFoundException`, and the request never reached `CountsController`.

Diagnosis: tagging that guard's exception showed `{"message":"ALIAS-GUARD-PROBE"}` coming back from `/api/counts`.

The shadowing spec added in #954 passed straight through this: its stand-in controller sat in the *same* module as the catch-all, where the `controllers[]` array order is authoritative. Cross-module order is not.

## The fix

The catch-all moves into `PluginLegacyAliasModule`, which `AppModule` imports **last** and nothing else imports at all — the only arrangement that keeps its route last. `PluginsModule` now exports `PluginProcessService` so the new module can inject it.

Two specs hold the invariant, both of which fail on the old arrangement:
- the last entry of `AppModule`'s `imports` metadata is `PluginLegacyAliasModule`;
- no other `*.module.ts` in `backend/src` mentions it (one importer scanned earlier is all it takes).

## Verification

`tsc --noEmit` exit 0. Full backend suite **128 suites / 1341 tests**.

A green suite is what let this ship the first time — nothing built the real `AppModule` — so this was verified against the running container:
- `GET /api/counts` → **200** `{"badgeCounts":{},"pendingRequests":1,...}`
- `GET /api/likes/state/149` → **200**
- `GET /api/media/1/releases` (the alias) → **200**, still working
- the app boots clean; the first attempt did not (`PluginProcessService` was not exported), which the suite also failed to catch.

The alias mechanism itself is being removed in the next change — the maintainer wants no compatibility layer in the codebase — but main should not stay broken while that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)