### PR TITLE
fix(auth): let an authenticated user open the event stream again

### DIFF
--- a/backend/src/modules/scheduler/system.controller.spec.ts
+++ b/backend/src/modules/scheduler/system.controller.spec.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import { SystemController } from './system.controller';
+import { CHECK_POLICIES_KEY, type PolicyHandler } from '../auth/casl/check-policies.decorator';
 
 jest.mock('fs', () => ({
   ...jest.requireActual<typeof import('fs')>('fs'),
@@ -330,5 +331,15 @@ describe('SystemController.restart', () => {
     });
     jest.runAllTimers();
     expect(kill).toHaveBeenCalledWith(1, 'SIGTERM');
+  });
+});
+
+describe('SystemController.events policy', () => {
+  it('VERDICT: declares a policy, because PoliciesGuard denies a handler that declares none', () => {
+    const handlers = Reflect.getMetadata(CHECK_POLICIES_KEY, SystemController.prototype.events) as
+      | PolicyHandler[]
+      | undefined;
+
+    expect(handlers?.length).toBeGreaterThan(0);
   });
 });

--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -215,7 +215,10 @@ export class SystemController {
     private readonly updateCheck: UpdateCheckService,
   ) {}
 
+  // Authentication is the whole gate: the stream only ever emits what this user id is
+  // already a recipient of, and `PoliciesGuard` denies a handler that declares nothing.
   @Sse('events')
+  @CheckPolicies(() => true)
   events(@CurrentUser() user: User): Observable<MessageEvent> {
     return this.eventsService.getStream(user.id);
   }


### PR DESCRIPTION
## The bug

Every `GET /api/system/events` returns **403** — for every account, the owner included. The browser retries it forever, so nothing real-time works: download progress, badge counts, notifications, player commands.

`SystemController` carries a class-level `@UseGuards(JwtOrApiKeyGuard, PoliciesGuard)`, and #872 made `PoliciesGuard` fail closed: a handler that declares no `@CheckPolicies` is denied. `@Sse('events')` declares none, so it has been denied since that change.

An audit of every controller under a class-level `PoliciesGuard` finds this is the **only** handler in that state.

## The fix

The stream declares a policy that authentication alone satisfies. That is the correct gate here and not a hole: `EventsService.getStream(userId)` filters every envelope through `shouldDeliver(env, userId, connectionId)` and replays only progress leaves this user was already a recipient of, so a subscriber never sees another user's events.

A spec asserts the handler declares a policy at all — it fails if the decorator is removed again (verified by sabotage).

## Verification

`tsc --noEmit` exit 0, **128 suites / 1342 tests**. Against the running container: the stream answers **200** with `data: {"type":"sse.connected",...}`, and an unauthenticated request still gets **401**.

Found while diagnosing a separate 404 in the same network log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)