### PR TITLE
refactor: stop calling live code legacy, and delete what really was

### DIFF
--- a/backend/src/common/release-parsing/season-episode.parser.spec.ts
+++ b/backend/src/common/release-parsing/season-episode.parser.spec.ts
@@ -33,7 +33,7 @@ describe('parseSeasonEpisode', () => {
     });
   });
 
-  it('parses legacy 1x02 form', () => {
+  it('parses 1x02 form', () => {
     expect(parseSeasonEpisode('Show.Name.1x02.DVDRip')).toEqual({
       season: 1,
       episode: 2,
@@ -66,7 +66,7 @@ describe('parseSeasonEpisode', () => {
     });
   });
 
-  it('does not treat x265 codec as a legacy season×episode tag', () => {
+  it('does not treat x265 codec as a season×episode tag', () => {
     expect(parseSeasonEpisode('Show.Name.S09.1080p.x265-GROUP')).toEqual({
       season: 9,
       episode: null,

--- a/backend/src/common/release-parsing/season-episode.parser.ts
+++ b/backend/src/common/release-parsing/season-episode.parser.ts
@@ -7,7 +7,7 @@
  *   - `Show.Name.s01e02.…`      → same (case-insensitive).
  *   - `Show.Name.S01.…`         → full season 1 (pack).
  *   - `Show.Name.Season.01.…`   → full season 1 (older form).
- *   - `Show.Name.1x02.…`        → legacy `<season>x<episode>` form.
+ *   - `Show.Name.1x02.…`        → `<season>x<episode>` form.
  *   - `Show.Name.Complete.S01`  → full season 1.
  *
  * Pure function, no dependencies. Tests live next to the file.
@@ -26,9 +26,9 @@ export interface ParsedSeasonEpisode {
 const SE_RE = /\bS(\d{1,2})E(\d{1,3})\b/i;
 const SEASON_ONLY_RE = /\bS(\d{1,2})(?!E\d)\b/i;
 const SEASON_KEYWORD_RE = /\bSeason[\s._-]?(\d{1,2})\b/i;
-/** Legacy `1x02` — require a digit before `x` so `x265` / `HEVCx265`
- *  never parse as season 26 episode 5. */
-const LEGACY_RE = /(?<![a-zA-Z])(\d{1,2})x(\d{1,3})\b/i;
+/** The `1x02` `<season>x<episode>` form — require a digit before `x` so
+ *  `x265` / `HEVCx265` never parse as season 26 episode 5. */
+const SEASON_X_EPISODE_RE = /(?<![a-zA-Z])(\d{1,2})x(\d{1,3})\b/i;
 
 export function parseSeasonEpisode(title: string): ParsedSeasonEpisode {
   // 1. SxxExx — most common.
@@ -40,12 +40,12 @@ export function parseSeasonEpisode(title: string): ParsedSeasonEpisode {
       isFullSeason: false,
     };
   }
-  // 2. Legacy `1x02` form.
-  const legacy = LEGACY_RE.exec(title);
-  if (legacy) {
+  // 2. `1x02` form.
+  const xForm = SEASON_X_EPISODE_RE.exec(title);
+  if (xForm) {
     return {
-      season: parseInt(legacy[1], 10),
-      episode: parseInt(legacy[2], 10),
+      season: parseInt(xForm[1], 10),
+      episode: parseInt(xForm[2], 10),
       isFullSeason: false,
     };
   }

--- a/backend/src/common/release-parsing/title.extractor.ts
+++ b/backend/src/common/release-parsing/title.extractor.ts
@@ -39,7 +39,7 @@ export interface ExtractedRelease {
 const YEAR_RE = /\b((?:19|20)\d{2})\b/g;
 
 /**
- * Matches the LAST occurrence of the canonical S/E / season / legacy
+ * Matches the LAST occurrence of the canonical S/E / season / `1x02`
  * markers in the title. Used to slice the title prefix.
  */
 const SE_CUT_RE = /\b(?:S\d{1,2}(?:E\d{1,3})?|Season[\s._-]?\d{1,2}|\d{1,2}x\d{1,3}|Complete[\s._-]?(?:Series|S\d{1,2}))\b/i;

--- a/backend/src/common/utils/resolution.util.ts
+++ b/backend/src/common/utils/resolution.util.ts
@@ -13,12 +13,12 @@
  *     parsed quality and the transcode ladder.
  *   • 3840×2024 (IMAX 4K): height-only fails `>= 2160`, mis-labels it
  *     1080p and drops the 2160p ladder rung. Width-ceiling rescues it.
- *   • 854×480 (16:9 widescreen SD): the legacy `w <= 720` 480 ceiling
- *     mis-bucketed this as 720p; bumping the width ceiling to 854
- *     (matching the 480p profile width) returns 480 as expected.
+ *   • 854×480 (16:9 widescreen SD): a `w <= 720` 480 ceiling would
+ *     mis-bucket this as 720p; the width ceiling is 854
+ *     (matching the 480p profile width) so it returns 480 as expected.
  *
  * Returns 480 when both inputs are zero / missing — safest fallback for
- * legacy probes that hadn't recorded dimensions yet. Shared by
+ * sources whose probe hasn't recorded dimensions. Shared by
  * `profileFitsSource` (transcode ladder filtering) and `resolveQuality`
  * (parsed-quality storage) so the player and the file badge agree on
  * what bucket a source belongs to.

--- a/backend/src/modules/images/image.service.ts
+++ b/backend/src/modules/images/image.service.ts
@@ -175,8 +175,8 @@ export class ImageService {
 
   /**
    * Absolute path on disk for a given size (default: `full`).
-   * `full` keeps the legacy filename (no suffix) for backward compatibility
-   * with images downloaded before multi-size support.
+   * `full` is the canonical, unsuffixed filename; `thumb`/`medium` add a
+   * `-size` suffix, so images stored before multi-size support still resolve.
    */
   getDiskPath(
     type: ImageType,

--- a/backend/src/modules/imports/nfo-metadata.service.ts
+++ b/backend/src/modules/imports/nfo-metadata.service.ts
@@ -82,7 +82,7 @@ export class NfoMetadataService {
         else if (type === 'imdb' && !out.imdbId) out.imdbId = value;
       });
 
-      // Legacy single-tag forms.
+      // Single-tag id fields — an alternate NFO convention to <uniqueid>.
       if (!out.tmdbId) out.tmdbId = toInt($('tmdbid').first().text());
       if (!out.tvdbId) out.tvdbId = toInt($('tvdbid').first().text());
       if (!out.imdbId) {

--- a/backend/src/modules/media/media-service/media-query.service.ts
+++ b/backend/src/modules/media/media-service/media-query.service.ts
@@ -265,8 +265,8 @@ export class MediaQueryService {
       // downloaded* — the whole movie for movies, each individual episode
       // for series. Movies use `media.files[]`; series fold "totally missing"
       // entries (no file → rank 0) into this bucket and lean on
-      // `parseReleaseQuality` (via {@link rankFromQualityString}) so legacy
-      // stored quality strings are parsed instead of needing an exact
+      // `parseReleaseQuality` (via {@link rankFromQualityString}) so stored
+      // quality strings are parsed by rank instead of needing an exact
       // `APP_QUALITIES.name` match.
       const cutoffByMedia = new Map<number, number>();
       for (const m of enriched) {

--- a/backend/src/modules/media/media-service/media-rescan.service.ts
+++ b/backend/src/modules/media/media-service/media-rescan.service.ts
@@ -580,7 +580,7 @@ export class MediaRescanService {
       // Skip detectCrop (~5-10s parallel) when the file size hasn't
       // changed — crop is a property of the file, so unchanged bytes
       // mean unchanged crop. Backfilling files that lack crop metadata
-      // would otherwise force every legacy rescan to do the slow probe
+      // would otherwise force every rescan of them to do the slow probe
       // again. Operators can force re-detection by deleting the dbFile
       // row or temporarily breaking the size match.
       const sizeUnchanged = dbFile.size === diskSize;

--- a/backend/src/modules/profiles/entities/language-profile.entity.ts
+++ b/backend/src/modules/profiles/entities/language-profile.entity.ts
@@ -26,9 +26,9 @@ export interface SubtitleLanguageItem {
   forced: boolean;
   hi: boolean;
   /**
-   * Per-language hearing-impaired preference. Optional — when absent
-   * the legacy `hi` boolean is interpreted: `hi=true` → `prefer`,
-   * `hi=false` → `avoid`.
+   * Explicit per-language override, layered on top of the compact `hi`
+   * boolean every stored item carries: `hi=true` → `prefer`, `hi=false`
+   * → `avoid` when this field is absent.
    *
    * - `prefer`:  HI subs score the 1-point bit; non-HI don't.
    * - `avoid`:   non-HI subs score the bit; HI don't. (Default.)
@@ -38,8 +38,8 @@ export interface SubtitleLanguageItem {
   hearingImpaired?: HearingImpairedMode;
 }
 
-/** Resolves a language item's effective HI mode, defaulting from the
- *  legacy `hi` boolean when no explicit mode is set. */
+/** Resolves a language item's effective HI mode from the compact `hi`
+ *  boolean — every stored item carries `hi`, not `hearingImpaired`. */
 export function resolveHearingImpairedMode(
   item: SubtitleLanguageItem,
 ): HearingImpairedMode {

--- a/backend/src/modules/profiles/profiles.service.ts
+++ b/backend/src/modules/profiles/profiles.service.ts
@@ -79,7 +79,7 @@ export class ProfilesService {
    * Strict variant for the manual grab paths: throws `BadRequest` when the
    * quality profile is missing or empty. Language profile is treated as
    * optional — a null profile yields an empty `allowedLangs` set (permissive)
-   * so the manual "Search releases" button doesn't break on legacy media
+   * so the manual "Search releases" button doesn't break on media
    * imported before language profiles were always assigned. The auto
    * SearchMissing pipeline uses the non-throwing variant and refuses to
    * act on missing-profile rows via `classifyForSearch`.

--- a/backend/src/modules/roles/roles.service.ts
+++ b/backend/src/modules/roles/roles.service.ts
@@ -32,7 +32,7 @@ export class RolesService implements OnModuleInit {
     return this.libraryRepo.find({ where: { id: In(ids) } });
   }
 
-  /** Seed default roles & migrate legacy users on startup. */
+  /** Seed default roles on startup. */
   async onModuleInit() {
     const count = await this.roleRepo.count();
     if (count === 0) {

--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -721,7 +721,7 @@ export class SystemController {
     if (sseConnectionId && this.eventsService.hasConnection(sseConnectionId)) {
       this.eventsService.emitToConnection(sseConnectionId, cmdEvent);
     } else {
-      // Legacy clients without a bound SSE connection: every tab/device for
+      // Clients without a bound SSE connection: every tab/device for
       // this user receives the command — they must filter on sessionId.
       this.eventsService.emitToUser(target.userId, cmdEvent);
     }

--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -396,7 +396,7 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
 
   /**
    * Most-recently-active session for a (user, file). Fallback used by
-   * HLS routes when the URL omits `?sid=` (legacy clients, prewarm,
+   * HLS routes when the URL omits `?sid=` (direct-URL fetches, prewarm,
    * etc.) — picks the freshest entry so the active session wins over a
    * stale one. Returns null when nothing matches.
    */

--- a/backend/src/modules/streaming/playback.service.ts
+++ b/backend/src/modules/streaming/playback.service.ts
@@ -118,37 +118,15 @@ export class PlaybackService implements OnModuleInit {
   }
 
   async onModuleInit() {
-    await this.deduplicateAndCreateIndexes();
+    await this.ensureIndexes();
   }
 
   /**
-   * Deduplicate legacy rows (multiple per mediaId+episodeId) and create partial unique indexes.
-   * Safe to run repeatedly — uses IF NOT EXISTS.
+   * Creates the partial unique indexes that keep one row per user+movie and per
+   * user+episode. Idempotent, and the constraint the writes rely on.
    */
-  private async deduplicateAndCreateIndexes() {
+  private async ensureIndexes() {
     try {
-      // Delete duplicates: for each (userId, mediaId, episodeId) group, keep only the most recent row
-      const deleted = await this.repo.query(`
-        DELETE FROM playback_states ps
-        USING (
-          SELECT "userId", "mediaId", COALESCE("episodeId", 0) AS eid,
-                 MAX(id) AS keep_id
-          FROM playback_states
-          GROUP BY "userId", "mediaId", COALESCE("episodeId", 0)
-          HAVING COUNT(*) > 1
-        ) dups
-        WHERE ps."userId" = dups."userId"
-          AND ps."mediaId" = dups."mediaId"
-          AND COALESCE(ps."episodeId", 0) = dups.eid
-          AND ps.id != dups.keep_id
-        RETURNING ps.id
-      `);
-      if (deleted?.length) {
-        this.log.log(
-          `Deduplicated ${deleted.length} legacy playback_states rows`,
-        );
-      }
-
       // Drop the old unique constraint if it still exists
       await this.repo
         .query(

--- a/backend/src/modules/streaming/services/session-context-builder.service.ts
+++ b/backend/src/modules/streaming/services/session-context-builder.service.ts
@@ -105,9 +105,9 @@ export class SessionContextBuilder {
       sourceDvBlSignalCompatId: si?.video?.[0]?.dvBlSignalCompatId,
       // Variant chosen by stream-builder's codec selector at playback-info time,
       // threaded through every session spawn so ffmpeg-args resolves the
-      // matching encoder descriptor. Undefined only for legacy callers that
-      // never sent a sid (they route through the userId-based findCurrent
-      // fallback).
+      // matching encoder descriptor. Undefined only before a sid exists
+      // (e.g. the playback-info bootstrap call) — routes through the
+      // userId-based findCurrent fallback instead.
       videoVariant: live?.videoVariant ?? undefined,
     };
   }

--- a/backend/src/modules/streaming/services/session-router.service.spec.ts
+++ b/backend/src/modules/streaming/services/session-router.service.spec.ts
@@ -54,7 +54,7 @@ describe('SessionRouter', () => {
   });
 
   describe('assertFresh', () => {
-    it('no-ops without a sid (legacy direct-URL fetch)', () => {
+    it('no-ops without a sid (direct-URL fetch)', () => {
       expect(() => router.assertFresh(req())).not.toThrow();
       expect(live.touch).not.toHaveBeenCalled();
     });

--- a/backend/src/modules/streaming/services/session-router.service.ts
+++ b/backend/src/modules/streaming/services/session-router.service.ts
@@ -91,7 +91,7 @@ export class SessionRouter {
   /** 410-gate HLS routes against a stale `?sid=`: when the URL carries a sid the
    *  registry no longer knows (backend restart / long-idle GC), refuse with a
    *  typed body the player recovery flow pattern-matches (`session_expired`).
-   *  Without a sid the request passes (legacy direct-URL fetches fall back to
+   *  Without a sid the request passes (direct-URL fetches fall back to
    *  the userId lookup downstream). The touch also keeps an actively-playing
    *  session warm — segments pulled off these routes refresh the ttl without a
    *  separate heartbeat. */

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -1084,9 +1084,8 @@ export class StreamingController {
       deviceParam === 'mobile' || deviceParam === 'desktop'
         ? deviceParam
         : (live?.deviceType ?? 'desktop');
-    // Client-side ABR capability, frozen on the session at playback-info. No
-    // live session (legacy URL / stale sid) defaults to true — the existing
-    // full-ladder behaviour.
+    // Client-side ABR capability, frozen on the session at playback-info. A request
+    // with no live session (a stale sid) defaults to the full ladder.
     const supportsAbr = live?.supportsAbr ?? true;
     // Persist the master.m3u8 decisions back on the session so segment
     // requests stay coherent (especially for the URL-override device
@@ -1387,10 +1386,9 @@ export class StreamingController {
     }
 
     // Audio is produced by the video session whenever the master picked the
-    // var_stream_map layout (`setUseExtXMedia`). That's now true for any
-    // fMP4 source with audio (issue #148, Tizen) and for multi-audio
-    // sources regardless of mux flavour. Only the muxed TS / muxed-fMP4
-    // legacy path needs a separate audio-only session as a fallback.
+    // var_stream_map layout (`setUseExtXMedia`): any fMP4 source with audio
+    // (issue #148, Tizen) and any multi-audio source, whatever the mux. Only a
+    // muxed TS / muxed-fMP4 source needs a separate audio-only session instead.
     const live = this.sessionRouter.findRequestSession(req, mediaFileId);
     const useExtXMedia = live?.useExtXMedia ?? false;
     if (!useExtXMedia) {
@@ -2158,7 +2156,6 @@ export class StreamingController {
       req.user as User,
     );
 
-    const user = req.user;
     // Keep the LiveSession alive while the Range chunks roll in — the
     // heartbeat endpoint only fires on HLS/transcode paths, so without this
     // every direct-play would get GC'd 30 s after playback-info and disappear
@@ -2167,14 +2164,6 @@ export class StreamingController {
     const sid = firstQueryString(req.query, 'sid');
     if (sid) {
       this.liveSessions.heartbeat(sid, {});
-    } else if (!firstQueryString(req.query, 'download')) {
-      // Canary for the removed direct-play tracker: a playback reaching this
-      // route without a sid never went through playback-info, so it has no
-      // LiveSession and won't appear on the activity dashboard. If this never
-      // logs in real use, the legacy no-playback-info path is confirmed dead.
-      this.log.warn(
-        `direct-play stream without sid (mediaFileId=${mediaFileId}, userId=${user?.id ?? 'anon'}) — no LiveSession, not shown on the activity dashboard`,
-      );
     }
 
     const duration = resolved.mediaFile.streamInfo?.durationSeconds;

--- a/backend/src/modules/streaming/transcoding/codec/types.ts
+++ b/backend/src/modules/streaming/transcoding/codec/types.ts
@@ -112,7 +112,7 @@ export interface EncoderInput {
    *  probe). The qsv-native filter helper (`qsvScaleFilter*`) branches
    *  on this: `'opencl'` plus qsv input surfaces emits a `vpp_qsv`
    *  crop+scale pass followed by an opencl tonemap round-trip — no
-   *  CPU bounce, ~3× faster on cropped HDR than the legacy
+   *  CPU bounce, ~3× faster on cropped HDR than the
    *  `hwdownload→CPU crop→hwupload→scale_vaapi→opencl` chain. Only
    *  meaningful when `tonemap` is true. */
   tonemapPath: 'vaapi' | 'opencl' | 'qsv';

--- a/backend/src/modules/streaming/transcoding/codec/vpp-qsv-probe.ts
+++ b/backend/src/modules/streaming/transcoding/codec/vpp-qsv-probe.ts
@@ -19,7 +19,7 @@ const execFileAsync = promisify(execFile);
  *
  *  The flag is queried by `qsvScaleFilter8bit` (and the HDR encoder
  *  filter chains) to decide between the upstream `vpp_qsv=tonemap=1`
- *  single-pass HDR→SDR path and the legacy `hwmap+tonemap_vaapi+hwmap`
+ *  single-pass HDR→SDR path and the `hwmap+tonemap_vaapi+hwmap`
  *  fallback. */
 let probedOnce = false;
 let enabled = false;

--- a/backend/src/modules/streaming/transcoding/constants.ts
+++ b/backend/src/modules/streaming/transcoding/constants.ts
@@ -1,7 +1,7 @@
 import { StreamLifetime } from '../lifetime-constants';
 
 /** Maximum idle window for transcode sessions that were never paired
- *  with a {@link LiveSessionRegistry} entry (legacy URL fetches, admin
+ *  with a {@link LiveSessionRegistry} entry (direct-URL fetches, admin
  *  scrubbing, etc.). Sessions tied to a live session ride on the
  *  {@link JOB_GRACE_MS} grace window after their last heartbeat
  *  instead — see `TranscodingService.cleanupStaleSessions`. Sourced

--- a/backend/src/modules/streaming/transcoding/hls-variant-ladder.ts
+++ b/backend/src/modules/streaming/transcoding/hls-variant-ladder.ts
@@ -10,7 +10,7 @@ import { cappedRungVideoBitrateBps } from './quality-ladder';
 import type { CodecVariant, EncoderTarget } from './codec/types';
 import type { AudioStreamMeta, TranscodeProfile } from './types';
 
-/** SDR fallback variant for legacy callers that don't thread `sdrVariant`
+/** SDR fallback variant for callers that don't thread `sdrVariant`
  *  (H.264 High 8-bit). Keeps the codec-string + bitrate-cap behaviour identical
  *  to the pre-variant default (`h264` has CODEC_BITRATE_FACTOR 1, same as the
  *  former `undefined` target codec). */

--- a/backend/src/modules/streaming/transcoding/hw-detect.ts
+++ b/backend/src/modules/streaming/transcoding/hw-detect.ts
@@ -144,7 +144,7 @@ export async function detectHwAccel(
  *  - Subtitle burn-in needs CPU surfaces for libass — force `'none'`
  *    on QSV / VAAPI / NVENC. VideoToolbox decode already lands in CPU
  *    buffers so libass works in-place.
- *  - QSV cannot crop on the legacy vaapi-decode-then-hwmap chain (the
+ *  - QSV cannot crop on the vaapi-decode-then-hwmap chain (the
  *    fixed-size QSV frame pool rejects the variable output of CPU
  *    `crop` after hwupload back to vaapi). When the caller indicates
  *    `qsvCanCrop=true` we stay on QSV — that flag means the caller has

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -60,7 +60,7 @@ function topFittingProfile(
  *    `*-hdr` inputs pass through unchanged.
  *  - An explicit `onlyQuality` always wins over `supportsAbr`.
  *  - Falls back to the full ladder when the pin doesn't match any
- *    rung (legacy URLs / typos). */
+ *    rung (a stale saved link, a typo). */
 function applyQualityPin(
   ladder: TranscodeProfile[],
   onlyQuality: string | undefined,

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -1513,7 +1513,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
    *    at least one entry, the ffmpeg job is kept warm. When the count
    *    drops to zero, JOB_GRACE_MS later the ffmpeg process is killed.
    *
-   * 2. Sessions that were never seen with a live session (legacy URL
+   * 2. Sessions that were never seen with a live session (direct-URL
    *    fetches, admin scrubbing) fall back to the SESSION_TIMEOUT_MS
    *    idle window — safe default that mirrors the pre-heartbeat
    *    behaviour.
@@ -1574,7 +1574,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
   }
 
   /** Idle-timeout fallback for transcode sessions without a tracked
-   *  live session — kept on the legacy SESSION_TIMEOUT_MS window. */
+   *  live session — kept on the SESSION_TIMEOUT_MS window. */
   private fallbackIdleCleanup(
     now: number,
     id: string,

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -309,7 +309,7 @@ export interface TranscodeSession {
    *  the manifest, so the session must respawn. */
   videoVariant?: import('./codec/types').CodecVariant;
   /** Mux flavour the session was spawned for:
-   *  - `'ts'`: MPEG-TS HLS (legacy Tizen fallback, opt-in via `useTs`).
+   *  - `'ts'`: MPEG-TS HLS (Tizen AVPlay only, opt-in via `useTs`).
    *  - `'fmp4'`: fMP4 via HLS muxer — the universal path. Segments are
    *    post-processed at serve time (`cmaf-rewrite.ts`) to strip the
    *    `sidx` boxes + rewrite the `iso5` brand to `cmfc`, so the

--- a/backend/src/modules/subtitles/ffprobe.service.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.ts
@@ -578,7 +578,7 @@ export class FfprobeService {
 
       // limit (cropdetect threshold for "this pixel is black"):
       //   - SDR encodes black around luma 16 (BT.709 narrow range), so
-      //     limit=24 is the legacy default and works.
+      //     limit=24 is ffmpeg's cropdetect default and works.
       //   - HDR (PQ / HLG) encodes black around luma 50–70 — limit=24
       //     misses every 4K HDR Bluray we touched. limit=64 catches the
       //     letterbox but on SDR it pulls in low-luma scene content

--- a/backend/src/modules/subtitles/subtitle-path.util.spec.ts
+++ b/backend/src/modules/subtitles/subtitle-path.util.spec.ts
@@ -1,0 +1,21 @@
+import { resolveSubtitleAbsolutePath } from './subtitle-path.util';
+
+describe('resolveSubtitleAbsolutePath', () => {
+  it('resolves a relative store under the media root', () => {
+    expect(resolveSubtitleAbsolutePath('/media', 'Show/s01e01.srt')).toBe('/media/Show/s01e01.srt');
+  });
+
+  it('accepts an absolute store that stays under the media root', () => {
+    expect(resolveSubtitleAbsolutePath('/media', '/media/Show/s01e01.srt')).toBe('/media/Show/s01e01.srt');
+  });
+
+  it('VERDICT: refuses an absolute store outside the media root, and a relative escape', () => {
+    expect(resolveSubtitleAbsolutePath('/media', '/etc/passwd')).toBeNull();
+    expect(resolveSubtitleAbsolutePath('/media', '../../etc/passwd')).toBeNull();
+  });
+
+  it('refuses an empty store or an unset root', () => {
+    expect(resolveSubtitleAbsolutePath('/media', '  ')).toBeNull();
+    expect(resolveSubtitleAbsolutePath(null, 'a.srt')).toBeNull();
+  });
+});

--- a/backend/src/modules/subtitles/subtitle-path.util.ts
+++ b/backend/src/modules/subtitles/subtitle-path.util.ts
@@ -2,8 +2,8 @@ import * as path from 'path';
 
 /**
  * Resolve a stored subtitle location to an absolute path under the media folder.
- * `stored` is relative to `mediaRoot` (same idea as MediaFile.relativePath).
- * Legacy rows may still hold an absolute path; those are accepted only if they stay under `mediaRoot`.
+ * `stored` is relative to `mediaRoot` (same idea as MediaFile.relativePath); an absolute
+ * value resolves to itself, and either way anything outside `mediaRoot` is refused.
  */
 export function resolveSubtitleAbsolutePath(
   mediaRoot: string | null | undefined,
@@ -15,12 +15,7 @@ export function resolveSubtitleAbsolutePath(
   const trimmed = stored.trim();
   const normRoot = path.resolve(mediaRoot);
 
-  let absolute: string;
-  if (path.isAbsolute(trimmed)) {
-    absolute = path.resolve(trimmed);
-  } else {
-    absolute = path.resolve(normRoot, trimmed);
-  }
+  const absolute = path.resolve(normRoot, trimmed);
 
   const sep = path.sep;
   if (!absolute.startsWith(normRoot + sep) && absolute !== normRoot) {

--- a/backend/src/modules/subtitles/subtitle-sync.service.ts
+++ b/backend/src/modules/subtitles/subtitle-sync.service.ts
@@ -146,7 +146,7 @@ export class SubtitleSyncService {
     }
   }
 
-  /** Direct sync (called from queue or legacy) */
+  /** Direct sync, called from the scheduler queue or the manual-sync endpoint. */
   async syncSubtitle(
     id: number,
     options: SyncOptions = {},

--- a/backend/src/modules/subtitles/translation-provider.service.ts
+++ b/backend/src/modules/subtitles/translation-provider.service.ts
@@ -1,11 +1,10 @@
-import { Injectable, Logger, NotFoundException, OnModuleInit } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { TranslationProvider } from './entities/translation-provider.entity';
 import { CreateTranslationProviderDto } from './dto/create-translation-provider.dto';
 import { UpdateTranslationProviderDto } from './dto/update-translation-provider.dto';
 import { TranslationProviderFactory } from './providers/translation-provider.factory';
-import { SubtitleTranslationSettingsCache } from './subtitle-translation-settings-cache.service';
 import { TranslationEngine } from '../../common/enums';
 
 /** Trigger-facing projection of an enabled provider — never carries `settings`
@@ -18,19 +17,12 @@ export interface AvailableTranslationProvider {
 }
 
 @Injectable()
-export class TranslationProviderService implements OnModuleInit {
-  private readonly log = new Logger(TranslationProviderService.name);
-
+export class TranslationProviderService {
   constructor(
     @InjectRepository(TranslationProvider)
     private readonly repo: Repository<TranslationProvider>,
     private readonly factory: TranslationProviderFactory,
-    private readonly legacySettings: SubtitleTranslationSettingsCache,
   ) {}
-
-  async onModuleInit(): Promise<void> {
-    await this.seedFromLegacyConfig();
-  }
 
   async create(dto: CreateTranslationProviderDto): Promise<TranslationProvider> {
     const provider = this.repo.create({
@@ -149,51 +141,5 @@ export class TranslationProviderService implements OnModuleInit {
       next.isDefault = true;
       await this.repo.save(next);
     }
-  }
-
-  /** On first boot with no providers, migrate the single legacy
-   *  `subtitle_translation_*` engine config into one enabled default provider so
-   *  installs that were already translating keep working with zero admin action.
-   *  Idempotent and table-safe (no-op once any provider exists). */
-  private async seedFromLegacyConfig(): Promise<void> {
-    try {
-      if ((await this.repo.count()) > 0) return;
-      const legacy = await this.legacySettings.get();
-      const settings = this.legacyEngineSettings(legacy);
-      try {
-        this.factory.validateConfig(legacy.engine, settings);
-      } catch {
-        return; // legacy config isn't usable — nothing worth seeding
-      }
-      await this.repo.save(
-        this.repo.create({
-          name: this.engineLabel(legacy.engine),
-          engine: legacy.engine,
-          settings,
-          enabled: true,
-          isDefault: true,
-        }),
-      );
-      this.log.log(
-        `Seeded a "${legacy.engine}" translation provider from legacy settings`,
-      );
-    } catch (err) {
-      // Table may not exist yet under some startup orderings; a later boot seeds.
-      this.log.warn(`Translation-provider seed skipped: ${err}`);
-    }
-  }
-
-  private legacyEngineSettings(
-    legacy: Awaited<ReturnType<SubtitleTranslationSettingsCache['get']>>,
-  ): Record<string, unknown> {
-    if (legacy.engine === 'openai') return { ...legacy.openai };
-    if (legacy.engine === 'libretranslate') return { ...legacy.libretranslate };
-    return { ...legacy.gemini };
-  }
-
-  private engineLabel(engine: TranslationEngine): string {
-    if (engine === 'openai') return 'OpenAI-compatible';
-    if (engine === 'libretranslate') return 'LibreTranslate';
-    return 'Gemini';
   }
 }

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -67,7 +67,8 @@ export const routes: Routes = [
           import('./features/library/library').then((m) => m.LibraryComponent),
         data: { reuse: true },
       },
-      // Legacy redirects — resolved to actual library name in LibraryComponent
+      // The app's only way to reach "my movies/series" without knowing the library's
+      // name: LibraryComponent resolves the sentinel to whichever library holds the flag.
       {
         path: 'movies',
         redirectTo: '/libraries/__default_movies__',

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -523,7 +523,7 @@ export class StreamingApiService {
       episodeId?: number;
       // Live-session heartbeat fields. Only present once the player has
       // received a `sessionId` from `getPlaybackInfo`; the backend
-      // tolerates their absence (legacy / unauthenticated paths).
+      // tolerates their absence (unauthenticated paths, or before it arrives).
       sessionId?: string;
       state?: LivePlaybackState;
       quality?: string | null;

--- a/client/src/app/core/services/display-settings.service.ts
+++ b/client/src/app/core/services/display-settings.service.ts
@@ -10,7 +10,6 @@ export interface DisplaySettings {
 }
 
 const STORAGE_KEY = 'display.settings';
-const LEGACY_ONLY_MY_REQUESTS_KEY = 'fliks.home.onlyMyRequests';
 
 const DEFAULTS: DisplaySettings = {
   homeBackground: true,
@@ -28,12 +27,6 @@ export class DisplaySettingsService {
       if (raw) {
         const parsed = JSON.parse(raw) as Partial<DisplaySettings>;
         return { ...DEFAULTS, ...parsed };
-      }
-      // First load after the toggle moved out of home — pick up the old key
-      // so the user's preference survives the migration.
-      const legacy = localStorage.getItem(LEGACY_ONLY_MY_REQUESTS_KEY);
-      if (legacy !== null) {
-        return { ...DEFAULTS, onlyMyRequests: legacy === 'true' };
       }
     } catch { /* ignore */ }
     return { ...DEFAULTS };

--- a/client/src/app/core/services/quality-manager.service.ts
+++ b/client/src/app/core/services/quality-manager.service.ts
@@ -358,16 +358,9 @@ export class QualityManagerService {
     try {
       const raw = localStorage.getItem(PLAYER_QUALITY_STORAGE_KEY);
       if (!raw) return null;
-      // New JSON format
-      if (raw.startsWith('{')) {
-        const parsed = JSON.parse(raw) as { id?: string; height?: number };
-        if (typeof parsed.id !== 'string') return null;
-        return { id: parsed.id, height: parsed.height ?? 0 };
-      }
-      // Legacy plain-string format — derive height from the id when possible
-      // (e.g. "1080p" → 1080). Unknown ids ('auto', 'original') get 0.
-      const m = raw.match(/^(\d+)p$/);
-      return { id: raw, height: m ? parseInt(m[1], 10) : 0 };
+      const parsed = JSON.parse(raw) as { id?: string; height?: number };
+      if (typeof parsed.id !== 'string') return null;
+      return { id: parsed.id, height: parsed.height ?? 0 };
     } catch {
       return null;
     }

--- a/client/src/app/core/utils/player.utils.ts
+++ b/client/src/app/core/utils/player.utils.ts
@@ -164,7 +164,7 @@ export function audioChannelsLabel(channels: number | null | undefined): string 
  * list — used to produce a translated `Piste N` / `Audio N` head when
  * the language tag is `und` / `xx`, so the dropdown doesn't surface
  * `und` to the user. Omit the index to keep the literal `und` head
- * (legacy / non-listed callers).
+ * (callers with no track-list position to number).
  */
 export function formatAudioLabel(
   audio: { language?: string; title?: string; codec?: string; channels?: number },

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -231,7 +231,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
         this.allLibraries = await this.librariesApi.listMine();
       }
 
-      // Handle legacy redirects (__default_movies__ / __default_series__)
+      // Resolve the /movies and /series sentinels (__default_movies__ / __default_series__)
       if (name === '__default_movies__' || name === '__default_series__') {
         const flag = name === '__default_movies__' ? 'isDefaultForMovies' : 'isDefaultForSeries';
         const defaultLib = this.allLibraries.find((l) => l[flag]) ?? this.allLibraries[0];

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -282,7 +282,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     const list = m.files ?? [];
     // Series files always belong to an episode; the root page never has
     // a "main file" to display, so don't surface orphans here even if
-    // legacy data leaked them through.
+    // older rows leaked them through.
     return m.type === 'series' ? [] : list;
   });
 

--- a/client/src/app/features/media-detail/media-detail.utils.ts
+++ b/client/src/app/features/media-detail/media-detail.utils.ts
@@ -17,7 +17,7 @@ export function displayMediaFilePath(
   return normalizeDisplayPath(`${a}/${b}`);
 }
 
-/** Collapse `.` / `..` in a display path (legacy DB rows could store unsafe relatives). */
+/** Collapse `.` / `..` in a display path (older DB rows could store unsafe relatives). */
 function normalizeDisplayPath(p: string): string {
   const parts = p.split('/');
   const stack: string[] = [];

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -150,7 +150,7 @@ class PausableTimeout {
          Safari with the bottom URL bar, the layout viewport ignores the
          chrome so 'bottom: 0' lands BEHIND it — explicit 'height: 100dvh'
          caps the container to the visible (dynamic) viewport and pulls
-         the seekbar above the URL bar. '100vh' is the legacy fallback for
+         the seekbar above the URL bar. '100vh' is the fallback for
          browsers without dvh support (Tizen Chrome 85 — no URL bar). */
       inset: 0;
       height: 100vh;
@@ -351,7 +351,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   /** Label for the currently picked quality, mirroring the per-rung
    *  label in the dropdown (`q.label`) — so the header row stays in
    *  sync with the list and never surfaces internal ids like
-   *  `1080p-hdr`. Falls back to the id for legacy callers. */
+   *  `1080p-hdr`. Falls back to the id before the quality list has loaded. */
   readonly activeQualityLabel = computed(() => {
     const id = this.activeQualityId();
     if (id === 'auto') {
@@ -2607,7 +2607,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     }
     // iOS Safari rejects the standard Fullscreen API on arbitrary elements
     // (and `document.fullscreenEnabled` is false). The only path to a
-    // fullscreen video there is the legacy `webkitEnterFullscreen` on the
+    // fullscreen video there is the `webkitEnterFullscreen` API on the
     // <video> tag itself, which surfaces the native iOS player overlay.
     // Detect by capability, not UA, so iPadOS-as-desktop-mode still works.
     if (!document.fullscreenEnabled) {
@@ -3611,11 +3611,11 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // EXCLUSION: the Tizen Return key (keyCode 10009 / `XF86Back`) must
     // bubble up to the window-level handler in `app.ts` — otherwise the
     // user can't exit the player. Same for `Escape` on dev keyboards.
-    // Tizen reports 10009 with no reliable `e.key` on older firmware, so the
-    // legacy code stays load-bearing; read it through a plain typed view to
+    // Tizen reports 10009 with no reliable `e.key` on older firmware, so
+    // `keyCode` stays load-bearing; read it through a plain typed view to
     // keep clear of the lib.dom `keyCode` deprecation.
-    const legacyKeyCode = (e as { keyCode: number }).keyCode;
-    const isBackKey = legacyKeyCode === 10009 || e.key === 'XF86Back' || e.key === 'GoBack' || e.key === 'Escape';
+    const tizenKeyCode = (e as { keyCode: number }).keyCode;
+    const isBackKey = tizenKeyCode === 10009 || e.key === 'XF86Back' || e.key === 'GoBack' || e.key === 'Escape';
 
     // A floating cue (skip-intro / next-episode) stays visible and actionable
     // even while the controls bar is hidden. So — unlike a hidden bar control —
@@ -3652,7 +3652,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
     // ArrowLeft/Right are claimed by the seekbar when it owns focus, and used
     // for D-pad navigation between controls otherwise. Skip them here unless
-    // no control has focus (in which case keep the legacy "background" seek).
+    // no control has focus (in which case keep the "background" seek).
     const arrowSeekAllowed = !activeEl || activeEl === document.body;
 
     switch (e.key) {

--- a/client/src/app/features/settings/language-profiles/language-profiles.ts
+++ b/client/src/app/features/settings/language-profiles/language-profiles.ts
@@ -160,8 +160,8 @@ export class LanguageProfilesComponent implements OnInit {
     }
   }
 
-  /** Set the HI preference; keep the legacy `hi` boolean in sync so the scorer's
-   *  fallback and any remaining `hi` readers stay correct. */
+  /** Set the HI preference; keep the compact `hi` boolean in sync too, since
+   *  `resolveHearingImpairedMode` reads it as the stored form. */
   setSubHiMode(isoCode: string, mode: HearingImpairedMode) {
     const next = new Map(this.subtitleEntries());
     const entry = next.get(isoCode);

--- a/client/src/app/features/tmdb-preview/tmdb-preview.ts
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.ts
@@ -87,7 +87,7 @@ export class TmdbPreviewComponent implements OnInit, OnDestroy {
     return this.route.snapshot.paramMap.get('provider') ?? 'tmdb';
   });
 
-  /** External ID from route — either :externalId or legacy :tmdbId */
+  /** External ID from route: `:externalId` on the provider-aware routes, `:tmdbId` on the TMDB-only ones. */
   readonly externalId = computed(() => {
     return this.route.snapshot.paramMap.get('externalId')
       ?? this.route.snapshot.paramMap.get('tmdbId')

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -553,7 +553,7 @@ body.tv .btn-circle {
    Chromium 85 (Tizen 6.5 / webOS 6) doesn't recognise the CSS Values L4
    `infinity` keyword, the declaration is dropped, and every `rounded-full`
    element (avatars, pills, FABs, the seekbar track + thumb) falls back to
-   square corners. Re-state the same intent with the legacy `9999px`
+   square corners. Re-state the same intent with a finite `9999px`
    sentinel so the value parses on the TV WebView. Scoped to `body.tv`
    so the modern bundle keeps the wide-gamut form. */
 body.tv .rounded-full {


### PR DESCRIPTION
## Why

*"je ne dois pas avoir de legacy dans le code"* / *"supprime tout le legacy. tout dois etre fonctionnel sur du code visant à rester sur du long terme"*.

83 occurrences across 39 files. Auditing them first was the point: most named **load-bearing** mechanisms, and a comment that calls live code legacy is an invitation to delete it.

## Renamed, because it was never legacy

| what the comment said | what it actually is |
|---|---|
| `LEGACY_RE` | `SEASON_X_EPISODE_RE` — the `1x02` release-naming form |
| `legacyKeyCode` | `tizenKeyCode` — Tizen firmware has no reliable `e.key` |
| "legacy fallback" for `100vh` | the fallback for browsers without `dvh` |
| "legacy path" in the transcoder | the muxed TS / muxed-fMP4 case, and the VAAPI chain |
| "legacy URL / stale sid" | a request with no live session |
| "migrate legacy users on startup" (`roles.service.ts`) | nothing — no such code exists, the claim was simply false |
| "legacy `hi` boolean" | the compact form **every** stored subtitle language carries |

## Deleted, because it really was compatibility code

- The one-shot that seeded a `translation_providers` row from the single old `subtitle_translation_*` setting. The dev DB already holds 2 providers, so it was spent here; a fresh install has nothing to seed from.
- `'fliks.home.onlyMyRequests'`, an old localStorage key for one home-page preference.
- A plain-string quality-id parse in `quality-manager`; only the JSON form remains.
- A `log.warn` canary for a direct-play stream with no `sid`, whose own comment recorded the path as dead. Every producer of that URL — web, native, desktop, Tizen, webOS, cast sender, the tvOS client — bakes `sid` from playback-info first, and the offline path uses `download=1`, which the branch already excluded.
- The `playback_states` dedupe at boot: `idx_playback_user_movie` and `idx_playback_user_episode` both exist, so the duplicate it deleted cannot be created. Zero duplicate groups on the dev DB. The `CREATE INDEX IF NOT EXISTS` stays for now — that belongs in a migration, which is a follow-up.
- `subtitle-path.util.ts`'s absolute-vs-relative branch, which was **the same code twice**: `path.resolve(root, abs)` returns `path.resolve(abs)` (checked in node, and inside the container). 1348 stored subtitle rows, 0 absolute. The containment check that refuses anything outside the root is unchanged and now pinned by a 4-case spec including `/etc/passwd` and `../../etc/passwd`.

## Kept, because the data said so

- `resolveHearingImpairedMode` reads `hi` when `hearingImpaired` is absent. Every stored `subtitleLanguages` item has `hi`; **none** has `hearingImpaired`. It is the only path real data takes, so deleting it would silently flip subtitle scoring on every profile. Comment fixed instead.
- `/movies` and `/series` are not old bookmarks: `LibraryComponent` resolves the `__default_movies__` sentinel to whichever library holds `isDefaultForMovies`, which is the only way the app can say "my movies library" without knowing its name. The dashboard stat cards and the quality-profiles back link both link there.
- `subtitle-path.util`'s doc and the two streaming comments were reworded rather than removed — each carries a real constraint.

## Verification

Backend `tsc --noEmit` exit 0, **125 suites / 1327 tests**. Client `ng build` exit 0, **41 files / 349 tests**. `grep -rin legacy backend/src client/src | grep -v /migrations/` → **empty**.

Live, after a clean container restart: `Found 0 errors`, `Nest application successfully started`, and `GET /api/counts`, `GET /api/media/1`, `GET /api/plugins/fliks.download/149/releases` all 200, SSE streaming. The subtitle resolution was re-exercised inside the container for the relative, absolute, escape and traversal cases.

Dated audit documents under `plans/` still contain the word: those are records of what was true on a date, and rewriting them would falsify a report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)