### PR TITLE
refactor(playback): move the unique-index DDL out of boot into a migration

### DIFF
--- a/backend/src/migrations/1783400000000-index-playback-state-unique-per-target.ts
+++ b/backend/src/migrations/1783400000000-index-playback-state-unique-per-target.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+// The two partial unique indexes `PlaybackState` declares, for databases whose baseline
+// predates them. `IF NOT EXISTS` because every running install already had them created
+// at boot, which is what this migration replaces.
+export class IndexPlaybackStateUniquePerTarget1783400000000
+  implements MigrationInterface
+{
+  name = 'IndexPlaybackStateUniquePerTarget1783400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX IF NOT EXISTS "idx_playback_user_movie" ON "playback_states" ("userId", "mediaId") WHERE "episodeId" IS NULL`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX IF NOT EXISTS "idx_playback_user_episode" ON "playback_states" ("userId", "episodeId") WHERE "episodeId" IS NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_playback_user_episode"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_playback_user_movie"`);
+  }
+}

--- a/backend/src/modules/streaming/entities/playback-state.entity.ts
+++ b/backend/src/modules/streaming/entities/playback-state.entity.ts
@@ -18,6 +18,11 @@ import { Episode } from '../../media/entities/episode.entity';
 @Index(['user', 'media', 'completed'])
 @Index(['user', 'completed', 'lastPlayedAt'])
 @Index(['user', 'episode', 'completed'])
+// One row per user+movie and per user+episode. Two partial indexes rather than one
+// composite: `episodeId IS NULL` is what separates a movie row from an episode row,
+// and NULLs never collide in a plain unique index.
+@Index('idx_playback_user_movie', ['user', 'media'], { unique: true, where: '"episodeId" IS NULL' })
+@Index('idx_playback_user_episode', ['user', 'episode'], { unique: true, where: '"episodeId" IS NOT NULL' })
 export class PlaybackState extends BaseEntity {
   @ManyToOne(() => User, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'userId' })

--- a/backend/src/modules/streaming/playback.service.ts
+++ b/backend/src/modules/streaming/playback.service.ts
@@ -2,7 +2,6 @@ import {
   BadRequestException,
   Injectable,
   Logger,
-  OnModuleInit,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, IsNull, Repository } from 'typeorm';
@@ -79,7 +78,7 @@ const HISTORY_MIN_WATCH_SECONDS = 5;
 const PG_FK_VIOLATION = '23503';
 
 @Injectable()
-export class PlaybackService implements OnModuleInit {
+export class PlaybackService {
   private readonly log = new Logger(PlaybackService.name);
 
   constructor(
@@ -117,51 +116,7 @@ export class PlaybackService implements OnModuleInit {
     }
   }
 
-  async onModuleInit() {
-    await this.ensureIndexes();
-  }
-
-  /**
-   * Creates the partial unique indexes that keep one row per user+movie and per
-   * user+episode. Idempotent, and the constraint the writes rely on.
-   */
-  private async ensureIndexes() {
-    try {
-      // Drop the old unique constraint if it still exists
-      await this.repo
-        .query(
-          `
-        ALTER TABLE playback_states
-        DROP CONSTRAINT IF EXISTS "UQ_playback_states_userId_mediaFileId"
-      `,
-        )
-        .catch(() => {});
-      // TypeORM may name it differently
-      await this.repo
-        .query(
-          `
-        DROP INDEX IF EXISTS "UQ_playback_states_userId_mediaFileId"
-      `,
-        )
-        .catch(() => {});
-
-      // Create partial unique indexes
-      await this.repo.query(`
-        CREATE UNIQUE INDEX IF NOT EXISTS idx_playback_user_movie
-        ON playback_states ("userId", "mediaId")
-        WHERE "episodeId" IS NULL
-      `);
-      await this.repo.query(`
-        CREATE UNIQUE INDEX IF NOT EXISTS idx_playback_user_episode
-        ON playback_states ("userId", "episodeId")
-        WHERE "episodeId" IS NOT NULL
-      `);
-    } catch (err) {
-      this.log.warn(`Failed to create playback unique indexes: ${err}`);
-    }
-  }
-
-  /** Find state by media/episode (the new primary lookup). */
+  /** Find state by media/episode. */
   private findState(
     userId: number,
     mediaId: number,


### PR DESCRIPTION
## Why

`PlaybackService.onModuleInit` ran `CREATE UNIQUE INDEX IF NOT EXISTS` (plus two speculative `DROP` statements) on every boot, wrapped in a `try` that logged a warning and continued. Schema work at runtime, and silent when it failed.

## What

- `PlaybackState` declares both partial unique indexes itself, so a dev database gets them from `synchronize` and nothing depends on a service hook.
- `1783400000000-index-playback-state-unique-per-target` applies them for databases whose baseline predates them. `IF NOT EXISTS` is deliberate: every running install already has them from the boot routine this replaces.
- The `UQ_playback_states_userId_mediaFileId` drops are gone — no database and no migration in this repo has that constraint.

## Verification

On a throwaway `postgres:17` (the dev DB was built with `synchronize: true`, so replaying the chain against it would hit `42P07`):

- full chain applies clean, both indexes present with the expected `WHERE` clauses;
- `migration:revert` drops them (0 left), re-running restores them (2);
- `migration:generate` afterwards emits **nothing** about `playback_states` — entity metadata and migrated schema agree. Its only output is a pre-existing, unrelated `media.alternativeTitles` default drift.

Backend `tsc --noEmit` exit 0, **125 suites / 1327 tests**. Dev stack restarted clean (`Found 0 errors`, `Nest application successfully started`) with both indexes still in place, confirming `synchronize` is content with the declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)