### PR TITLE
feat(settings): move subtitle activity into the admin settings sidebar

### DIFF
--- a/backend/src/common/plugin-contract/host-methods.ts
+++ b/backend/src/common/plugin-contract/host-methods.ts
@@ -224,8 +224,6 @@ export interface PluginHostApi {
   }>;
 
   // Group D — events and outbound (5)
-  // (Section header in the plan says "(4)"; the 15-method total only
-  // reconciles with the 5 methods listed below, D1-D5.)
 
   /** Batched. Core resolves the SSE audience via SseAudienceService.recipientsForMedia. */
   'events.publish': (p: AcquisitionEvent[]) => Promise<void>;

--- a/backend/src/migrations/1782800000000-create-plugin-tables.ts
+++ b/backend/src/migrations/1782800000000-create-plugin-tables.ts
@@ -1,6 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-/** The three plugin tables (`plans/plugin-system.plan.md`, "Where plugin storage lives").
+/** The three tables plugin state lives in.
  *  All three are new and empty on upgrade. */
 export class CreatePluginTables1782800000000 implements MigrationInterface {
   name = 'CreatePluginTables1782800000000';

--- a/backend/src/migrations/1782900000000-add-plugin-package-status-reason.ts
+++ b/backend/src/migrations/1782900000000-add-plugin-package-status-reason.ts
@@ -1,6 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-/** Carries why `register()` refused a package, so a `failed` row is attributable (PR 7.2). */
+/** Carries why `register()` refused a package, so a `failed` row is attributable. */
 export class AddPluginPackageStatusReason1782900000000 implements MigrationInterface {
   name = 'AddPluginPackageStatusReason1782900000000';
 

--- a/backend/src/migrations/1783100000000-seed-official-plugin-source.ts
+++ b/backend/src/migrations/1783100000000-seed-official-plugin-source.ts
@@ -4,8 +4,8 @@ const OFFICIAL_CATALOG_URL = 'https://fliks-app.github.io/fliks-plugin-catalog/c
 
 /**
  * The official catalog source, seeded once so a fresh install has something to
- * browse without typing a URL — "N per install, the official one is just the
- * seeded first" (`plans/plugin-system.plan.md`). No pinned key: refreshes fall
+ * browse without typing a URL. It's just the first row in `plugin_sources` —
+ * nothing caps how many more an admin adds. No pinned key: refreshes fall
  * back to the compiled-in `OFFICIAL_KEYS` (`release-2026`).
  */
 export class SeedOfficialPluginSource1783100000000 implements MigrationInterface {

--- a/backend/src/modules/plugins/archive/index.ts
+++ b/backend/src/modules/plugins/archive/index.ts
@@ -1,4 +1,4 @@
-/** Archive validator: guards, signature verification and staging extraction. No DI, no controller — see plans/plugin-system.plan.md PR 3.3. */
+/** Archive validator: guards, signature verification and staging extraction. No DI, no controller. */
 export * from './refusal-codes';
 export * from './limits';
 export * from './trust-store';

--- a/backend/src/modules/plugins/archive/limits.ts
+++ b/backend/src/modules/plugins/archive/limits.ts
@@ -1,7 +1,7 @@
 /**
- * The closed entry-name set (`plans/plugin-system.plan.md`, "The ZIP — a
- * closed literal file list"). Matched by `===` only — never normalised,
- * never case-folded — so path traversal has no class of name to exploit.
+ * The closed entry-name set a plugin archive may contain. Matched by `===`
+ * only — never normalised, never case-folded — so path traversal has no
+ * class of name to exploit.
  */
 export const LEGAL_ENTRY_NAMES = [
   'plugin.json',

--- a/backend/src/modules/plugins/archive/refusal-codes.ts
+++ b/backend/src/modules/plugins/archive/refusal-codes.ts
@@ -1,7 +1,7 @@
 /**
- * One code per archive guard (see `plans/plugin-system.plan.md`, "Guards,
- * ordered"). The code is the contract: a caller branches on it, never on
- * `detail`, which is log/debug text only.
+ * One code per archive guard, in the order the guards run. The code is the
+ * contract: a caller branches on it, never on `detail`, which is log/debug
+ * text only.
  */
 export type PluginRefusalCode =
   | 'PLUGIN_BAD_MAGIC'

--- a/backend/src/modules/plugins/archive/zip-inspector.ts
+++ b/backend/src/modules/plugins/archive/zip-inspector.ts
@@ -69,10 +69,9 @@ interface WalkedEntry {
 }
 
 /**
- * V1-V7 of the install pipeline (`plans/plugin-system.plan.md`, "Guards,
- * ordered"). Nothing touches disk. The signature is verified before the
- * manifest's business rules are even read - refusal order in this
- * function mirrors the plan's table, not convenience.
+ * V1-V7 of the install pipeline. Nothing touches disk. The signature is
+ * verified before the manifest's business rules are even read — this
+ * function's refusal order is deliberate, not convenience.
  */
 export async function inspect(buffer: Buffer, options: InspectOptions = {}): Promise<InspectResult> {
   // V1/V2 - bytes already in RAM; magic + whole-archive size cap, nothing parsed yet.

--- a/backend/src/modules/plugins/catalog/catalog.ts
+++ b/backend/src/modules/plugins/catalog/catalog.ts
@@ -3,9 +3,8 @@ import type { PluginKind } from '../../../common/plugin-contract';
 
 /**
  * One published version's compatibility declaration — the same two axes as a plugin
- * manifest (`pluginApi` exact, `fliks` a lower-bounded range), see
- * `plans/plugin-system.plan.md`, "The four skew cases". Everything else about a
- * version (download location, hashes) is install-pipeline (PR 7.2) concern and
+ * manifest (`pluginApi` exact, `fliks` a lower-bounded range). Everything else about a
+ * version (download location, hashes) is install-pipeline concern and
  * opaque here, so it passes through the index signature untouched.
  */
 export interface CatalogVersionEntry {

--- a/backend/src/modules/plugins/plugin-database.service.ts
+++ b/backend/src/modules/plugins/plugin-database.service.ts
@@ -49,10 +49,9 @@ function asProvisionFailure(err: unknown): PluginInstallException {
 }
 
 /**
- * Owns the per-plugin Postgres role + schema (`plans/plugin-system.plan.md`,
- * "Database ownership"). Every identifier interpolated into SQL here passed
- * {@link pluginDbIdentifier} or {@link validateCoreRefNames} first; every
- * value is a bound parameter.
+ * Owns the per-plugin Postgres role + schema. Every identifier interpolated
+ * into SQL here passed {@link pluginDbIdentifier} or {@link validateCoreRefNames}
+ * first; every value is a bound parameter.
  */
 @Injectable()
 export class PluginDatabaseService {

--- a/backend/src/modules/plugins/plugin-import.controller.ts
+++ b/backend/src/modules/plugins/plugin-import.controller.ts
@@ -8,7 +8,7 @@ import { PluginInstallService, PluginInspectReport, PluginInstallResult } from '
 import { ConfirmImportDto } from './dto/confirm-import.dto';
 import { MAX_ARCHIVE_COMPRESSED_BYTES } from './archive';
 
-/** Manual-upload half of the install pipeline (`plans/plugin-system.plan.md`, "Manual upload"). */
+/** Manual-upload half of the install pipeline. */
 @Controller('plugins/import')
 @UseGuards(JwtOrApiKeyGuard, PoliciesGuard)
 export class PluginImportController {

--- a/backend/src/modules/plugins/plugin-install.service.ts
+++ b/backend/src/modules/plugins/plugin-install.service.ts
@@ -100,8 +100,7 @@ function findInstallableVersion(
 }
 
 /**
- * Orchestrates the install/update/uninstall pipeline for both tiers
- * (`plans/plugin-system.plan.md`, "Install pipeline, end to end"). `process`
+ * Orchestrates the install/update/uninstall pipeline for both tiers. `process`
  * archives flow through the same guards and the same promotion — only
  * `PluginRegistryService.register()` tells them apart, provisioning a schema
  * and spawning a supervisor. A spawn failure does not roll back the install.

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -130,9 +130,9 @@ export type PluginRegistrationResult = PluginRegistrationSuccess | PluginRegistr
 
 /**
  * In-memory installed-plugin set — the only thing the rest of core asks about
- * plugins. Populated at boot (L0-L4 of `plans/plugin-system.plan.md`'s load
- * table) and by `register()`, the hot-reload entry point the installer calls
- * for both tiers (P4a). L1 (`state.json` quarantine) still has no home; L3
+ * plugins. Populated at boot (L0-L4, the load checks below) and by
+ * `register()`, the hot-reload entry point the installer calls for both
+ * tiers (P4a). L1 (`state.json` quarantine) still has no home; L3
  * (re-hashing `plugin.js` from the loaded fd) is `PluginProcessService`'s.
  */
 @Injectable()

--- a/backend/src/modules/plugins/plugin-staging.service.ts
+++ b/backend/src/modules/plugins/plugin-staging.service.ts
@@ -7,7 +7,7 @@ import { getPluginsRuntimeDir } from '../../common/constants/paths';
 import { PluginInstallException } from './plugin-install.exception';
 import type { PluginPackageOrigin } from './entities/plugin-package.entity';
 
-/** `plans/plugin-system.plan.md`, "Staging disk-fill" guard. */
+/** Caps concurrent staged imports so an upload flood can't fill disk. */
 export const MAX_CONCURRENT_STAGED_IMPORTS = 5;
 const STAGING_MAX_AGE_MS = 60 * 60 * 1000;
 const ARCHIVE_FILENAME = 'archive.zip';

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.spec.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.spec.ts
@@ -62,7 +62,7 @@ afterEach(async () => {
 }, 15_000);
 
 describe('DEFAULT_SUPERVISOR_OPTIONS', () => {
-  it('matches the plan exactly', () => {
+  it('has these exact default values', () => {
     expect(DEFAULT_SUPERVISOR_OPTIONS).toEqual({
       memoryMb: 256,
       handshakeDeadlineMs: 10_000,

--- a/backend/src/modules/plugins/supervisor/spawn-plan.spec.ts
+++ b/backend/src/modules/plugins/supervisor/spawn-plan.spec.ts
@@ -82,7 +82,7 @@ describe('buildSpawnPlan', () => {
     expect(plan.env.FLIKS_CFG_UNRELATED).toBe('kept-as-is');
   });
 
-  it('builds the node argv verbatim from the plan', () => {
+  it('builds the exact node argv: permission flag, fs allowlist, heap cap, entry file', () => {
     const plan = buildSpawnPlan(baseInput);
     expect(plan.expectedCmdline).toEqual([
       process.execPath,

--- a/backend/src/modules/plugins/supervisor/spawn-plan.ts
+++ b/backend/src/modules/plugins/supervisor/spawn-plan.ts
@@ -10,8 +10,8 @@ export const PLUGIN_CHILD_GID = 65534;
 let cachedPermissionFlag: string | null = null;
 
 /**
- * `--permission` is the plan's flag (stable on the NodeSource 24 this server
- * runs); older Nodes need `--experimental-permission`. Probed once and cached.
+ * `--permission` is the flag name to use (stable on the NodeSource 24 this
+ * server runs); older Nodes need `--experimental-permission`. Probed once and cached.
  */
 export function resolvePermissionFlag(): string {
   if (cachedPermissionFlag) return cachedPermissionFlag;

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1123,7 +1123,11 @@
     "tstatus_paused": "Pausiert",
     "tstatus_queued": "In Warteschlange",
     "tstatus_unknown": "Unbekannt",
-    "fstatus_importing": "Import läuft"
+    "fstatus_importing": "Import läuft",
+    "status_downloaded": "Heruntergeladen",
+    "status_upgraded": "Aktualisiert",
+    "status_synced": "Synchronisiert",
+    "status_failed": "Fehlgeschlagen"
   },
   "tracking": {
     "menu_item": "Tracking-Status ansehen",
@@ -1431,7 +1435,8 @@
       "subtitles": "Untertitel",
       "schedulers": "Geplante Aufgaben",
       "streaming": "Streaming",
-      "plugins": "Plugins"
+      "plugins": "Plugins",
+      "subtitles_activity": "Untertitel-Aktivität"
     },
     "streaming": {
       "title": "Streaming",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1131,7 +1131,11 @@
     "tstatus_paused": "Paused",
     "tstatus_queued": "Queued",
     "tstatus_unknown": "Unknown",
-    "fstatus_importing": "Importing"
+    "fstatus_importing": "Importing",
+    "status_downloaded": "Downloaded",
+    "status_upgraded": "Upgraded",
+    "status_synced": "Synced",
+    "status_failed": "Failed"
   },
   "tracking": {
     "menu_item": "View tracking status",
@@ -1441,7 +1445,8 @@
       "subtitles": "Subtitles",
       "schedulers": "Scheduled tasks",
       "streaming": "Streaming",
-      "plugins": "Plugins"
+      "plugins": "Plugins",
+      "subtitles_activity": "Subtitle activity"
     },
     "streaming": {
       "title": "Streaming",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1123,7 +1123,11 @@
     "tstatus_paused": "En pausa",
     "tstatus_queued": "En cola",
     "tstatus_unknown": "Desconocido",
-    "fstatus_importing": "Importando"
+    "fstatus_importing": "Importando",
+    "status_downloaded": "Descargado",
+    "status_upgraded": "Mejorado",
+    "status_synced": "Sincronizado",
+    "status_failed": "Fallido"
   },
   "tracking": {
     "menu_item": "Ver el estado del seguimiento",
@@ -1431,7 +1435,8 @@
       "subtitles": "Subtítulos",
       "schedulers": "Tareas programadas",
       "streaming": "Streaming",
-      "plugins": "Plugins"
+      "plugins": "Plugins",
+      "subtitles_activity": "Actividad de subtítulos"
     },
     "streaming": {
       "title": "Streaming",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1131,7 +1131,11 @@
     "tstatus_paused": "En pause",
     "tstatus_queued": "En file d'attente",
     "tstatus_unknown": "Inconnu",
-    "fstatus_importing": "Import en cours"
+    "fstatus_importing": "Import en cours",
+    "status_downloaded": "Téléchargé",
+    "status_upgraded": "Mis à niveau",
+    "status_synced": "Synchronisé",
+    "status_failed": "Échec"
   },
   "tracking": {
     "menu_item": "Voir l'état du suivi",
@@ -1441,7 +1445,8 @@
       "subtitles": "Sous-titres",
       "schedulers": "Tâches planifiées",
       "streaming": "Streaming",
-      "plugins": "Plugins"
+      "plugins": "Plugins",
+      "subtitles_activity": "Activité des sous-titres"
     },
     "streaming": {
       "title": "Streaming",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1123,7 +1123,11 @@
     "tstatus_paused": "In pausa",
     "tstatus_queued": "In coda",
     "tstatus_unknown": "Sconosciuto",
-    "fstatus_importing": "Import in corso"
+    "fstatus_importing": "Import in corso",
+    "status_downloaded": "Scaricato",
+    "status_upgraded": "Aggiornato",
+    "status_synced": "Sincronizzato",
+    "status_failed": "Fallito"
   },
   "tracking": {
     "menu_item": "Vedi lo stato del monitoraggio",
@@ -1431,7 +1435,8 @@
       "subtitles": "Sottotitoli",
       "schedulers": "Attività pianificate",
       "streaming": "Streaming",
-      "plugins": "Plugins"
+      "plugins": "Plugins",
+      "subtitles_activity": "Attività sottotitoli"
     },
     "streaming": {
       "title": "Streaming",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1123,7 +1123,11 @@
     "tstatus_paused": "Em pausa",
     "tstatus_queued": "Na fila de espera",
     "tstatus_unknown": "Desconhecido",
-    "fstatus_importing": "Importação em curso"
+    "fstatus_importing": "Importação em curso",
+    "status_downloaded": "Baixado",
+    "status_upgraded": "Atualizado",
+    "status_synced": "Sincronizado",
+    "status_failed": "Falhou"
   },
   "tracking": {
     "menu_item": "Ver o estado do seguimento",
@@ -1431,7 +1435,8 @@
       "subtitles": "Legendas",
       "schedulers": "Tarefas agendadas",
       "streaming": "Streaming",
-      "plugins": "Plugins"
+      "plugins": "Plugins",
+      "subtitles_activity": "Atividade de legendas"
     },
     "streaming": {
       "title": "Streaming",

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -234,14 +234,6 @@ export const routes: Routes = [
         data: { titleKey: 'requests.title' },
       },
       {
-        path: 'activity',
-        loadComponent: () =>
-          import('./features/activity/subtitles/subtitles').then(
-            (m) => m.ActivitySubtitlesComponent,
-          ),
-        data: { titleKey: 'activity.tab_subtitles' },
-      },
-      {
         path: 'calendar',
         loadComponent: () =>
           import('./features/calendar/calendar').then((m) => m.CalendarComponent),
@@ -424,6 +416,7 @@ export const routes: Routes = [
           { path: 'users', loadComponent: () => import('./features/settings/users/users').then((m) => m.UsersSettingsComponent) },
           { path: 'roles', loadComponent: () => import('./features/settings/roles/roles').then((m) => m.RolesSettingsComponent) },
           { path: 'subtitle-providers', loadComponent: () => import('./features/settings/subtitle-providers/subtitle-providers').then((m) => m.SubtitleProvidersSettingsComponent) },
+          { path: 'subtitles-activity', loadComponent: () => import('./features/settings/subtitles-activity/subtitles-activity').then((m) => m.SubtitlesActivityComponent) },
           {
             path: 'subtitles',
             loadComponent: () => import('./features/settings/subtitles/subtitles-shell').then((m) => m.SubtitlesShellComponent),

--- a/client/src/app/core/plugin-ui/core-contributions.ts
+++ b/client/src/app/core/plugin-ui/core-contributions.ts
@@ -19,7 +19,6 @@ export const CORE_NAV_CONTRIBUTIONS: readonly UiContribution[] = [
   { id: 'core.playlists', slot: 'nav.main', weight: 2000, labelKey: 'nav.playlists', icon: 'list-video', action: { kind: 'route', path: '/playlists' } },
   { id: 'core.downloads', slot: 'nav.main', weight: 2100, labelKey: 'downloads.title', shortLabelKey: 'nav.downloads', icon: 'download', when: [not('isTv')], action: { kind: 'route', path: '/downloads' } },
   { id: 'core.history', slot: 'nav.main', weight: 2200, labelKey: 'nav.history', icon: 'history', action: { kind: 'route', path: '/history' } },
-  { id: 'core.subtitle_activity', slot: 'nav.main', weight: 2300, labelKey: 'activity.tab_subtitles', icon: 'history', action: { kind: 'route', path: '/activity' } },
 
   { id: 'core.requests', slot: 'nav.acquisition', weight: 100, labelKey: 'nav.requests', icon: 'clipboard-list', badge: 'pendingRequests', tone: 'danger', action: { kind: 'route', path: '/requests' } },
   { id: 'core.calendar', slot: 'nav.acquisition', weight: 300, labelKey: 'nav.calendar', icon: 'calendar', action: { kind: 'route', path: '/calendar' } },
@@ -76,6 +75,7 @@ export const CORE_SETTINGS_SECTIONS: readonly CoreSettingsSection[] = [
     items: [
       { id: 'core.subtitles', slot: 'settings.page', weight: 100, labelKey: 'settings.nav.subtitles', action: { kind: 'route', path: '/admin/settings/subtitles' } },
       { id: 'core.subtitle_providers', slot: 'settings.page', weight: 200, labelKey: 'settings.nav.subtitle_providers', action: { kind: 'route', path: '/admin/settings/subtitle-providers' } },
+      { id: 'core.subtitles_activity', slot: 'settings.page', weight: 300, labelKey: 'settings.nav.subtitles_activity', action: { kind: 'route', path: '/admin/settings/subtitles-activity' } },
     ],
   },
   {

--- a/client/src/app/core/plugin-ui/media-action-registry.ts
+++ b/client/src/app/core/plugin-ui/media-action-registry.ts
@@ -1,7 +1,7 @@
 /**
  * Closed catalogue of `media.actions` actionIds core implements. A plugin's
  * contribution to this slot may only reference one of these — it never ships
- * its own handler (per the plan's "no plugin ships Angular" rule).
+ * its own handler — plugins never ship their own Angular code.
  */
 export type CoreMediaActionId =
   | 'media.recommend'

--- a/client/src/app/core/plugin-ui/nav-contributions.service.spec.ts
+++ b/client/src/app/core/plugin-ui/nav-contributions.service.spec.ts
@@ -53,7 +53,7 @@ describe('NavContributionsService', () => {
     const ids = svc.mainItems().map((i) => i.id);
     // Both plugin items tie core's "My profile" (weight 300) — id order wins,
     // and stays the same regardless of which plugin installed first.
-    expect(ids).toEqual(['core.home', 'core.search', 'a-plugin', 'core.my_profile', 'z-plugin', 'core.playlists', 'core.downloads', 'core.history', 'core.subtitle_activity']);
+    expect(ids).toEqual(['core.home', 'core.search', 'a-plugin', 'core.my_profile', 'z-plugin', 'core.playlists', 'core.downloads', 'core.history']);
   });
 
   it('drops a contribution with an unknown action.kind — fails closed, never a broken item', () => {
@@ -120,7 +120,7 @@ describe('NavContributionsService', () => {
   it('splits nav.main around the library block at weight 1000', () => {
     const svc = createService();
     expect(svc.mainItemsBeforeLibraries().map((i) => i.id)).toEqual(['core.home', 'core.search', 'core.my_profile']);
-    expect(svc.mainItemsAfterLibraries().map((i) => i.id)).toEqual(['core.playlists', 'core.downloads', 'core.history', 'core.subtitle_activity']);
+    expect(svc.mainItemsAfterLibraries().map((i) => i.id)).toEqual(['core.playlists', 'core.downloads', 'core.history']);
   });
 
   it('acquisition: core requests + calendar, weight 200 free for a plugin', () => {

--- a/client/src/app/core/plugin-ui/season-action-registry.ts
+++ b/client/src/app/core/plugin-ui/season-action-registry.ts
@@ -1,7 +1,7 @@
 /**
  * Closed catalogue of `media.season.actions` actionIds core implements. A plugin's
  * contribution to this slot may only reference one of these — it never ships
- * its own handler (per the plan's "no plugin ships Angular" rule).
+ * its own handler — plugins never ship their own Angular code.
  */
 export type CoreSeasonActionId = 'season.search-releases' | 'season.grab-best';
 

--- a/client/src/app/features/admin/admin-shell.spec.ts
+++ b/client/src/app/features/admin/admin-shell.spec.ts
@@ -37,6 +37,7 @@ const BASELINE_SIDEBAR = [
   { label: 'admin.section_subtitles', links: [
     { label: 'settings.nav.subtitles', href: '/admin/settings/subtitles' },
     { label: 'settings.nav.subtitle_providers', href: '/admin/settings/subtitle-providers' },
+    { label: 'settings.nav.subtitles_activity', href: '/admin/settings/subtitles-activity' },
   ] },
   { label: 'admin.section_integrations', links: [
     { label: 'settings.nav.media_servers', href: '/admin/settings/media-servers' },
@@ -121,10 +122,10 @@ function createFixture(opts: { isAdmin?: boolean; entries?: PluginUiEntry[] } = 
 
 describe('AdminShellComponent — sidebar characterisation', () => {
   // Same fixture run under both an admin and a non-admin auth context: the
-  // sidebar has never gated any of its 22 links on isAdmin (only the /admin
+  // sidebar has never gated any of its 23 links on isAdmin (only the /admin
   // route guard does), and the refactor must not start doing so implicitly.
   it.each([['admin', true], ['non-admin', false]] as const)(
-    'renders the unchanged 7-section, 22-link sidebar for a %s context',
+    'renders the unchanged 7-section, 23-link sidebar for a %s context',
     (_label, isAdmin) => {
       const fixture = createFixture({ isAdmin });
       expect(readSidebar(fixture)).toEqual(BASELINE_SIDEBAR);

--- a/client/src/app/features/admin/settings-sections.service.spec.ts
+++ b/client/src/app/features/admin/settings-sections.service.spec.ts
@@ -42,11 +42,11 @@ function createService(opts: { isAdmin?: boolean; entries?: PluginUiEntry[] } = 
 }
 
 describe('SettingsSectionsService', () => {
-  it('resolves the 7 core sections with 22 items total, and nothing else, with an empty registry', () => {
+  it('resolves the 7 core sections with 23 items total, and nothing else, with an empty registry', () => {
     const svc = createService();
     const sections = svc.sections();
     expect(sections).toHaveLength(7);
-    expect(sections.reduce((n, s) => n + s.items.length, 0)).toBe(22);
+    expect(sections.reduce((n, s) => n + s.items.length, 0)).toBe(23);
   });
 
   it('sorts a plugin section\'s own items by weight then id, independent of core', () => {

--- a/client/src/app/features/plugin-view/plugin-view.ts
+++ b/client/src/app/features/plugin-view/plugin-view.ts
@@ -175,7 +175,7 @@ export class PluginViewComponent {
     }
   }
 
-  /** Tests the unsaved draft — the plan's `ProvidersConfigPage.testConnection`, distinct from
+  /** Tests the unsaved draft — `ProvidersConfigPage.testConnection`, distinct from
    *  `actions[]`: there is no row yet, so no `:id` to substitute. */
   providerTestConnection(view: ProvidersView): ((draft: ProviderDraft) => Promise<ProviderTestResult>) | null {
     const test = view.testConnection;

--- a/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.ts
+++ b/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.ts
@@ -12,7 +12,7 @@ interface CatalogueRow {
   latestVersion: string | null;
 }
 
-/** What every cached catalog offers, merged across sources (`plans/plugin-system.plan.md`, "Catalogue browsing"). */
+/** What every cached catalog offers, merged across sources. */
 @Component({
   selector: 'app-plugin-catalogue',
   imports: [TranslateModule],

--- a/client/src/app/features/settings/plugins/plugin-install-consent/plugin-install-consent.ts
+++ b/client/src/app/features/settings/plugins/plugin-install-consent/plugin-install-consent.ts
@@ -19,9 +19,8 @@ import { trustBadgeFor, requiresAcknowledgement } from '../plugin-trust';
 import { refusalMessageKey } from '../plugin-refusal';
 
 /**
- * The install consent sheet ("plans/plugin-system.plan.md", "One install UX").
- * Owns the confirm call itself — the caller only needs to open it with an
- * inspect report and listen for `installed`.
+ * The install consent sheet. Owns the confirm call itself — the caller only
+ * needs to open it with an inspect report and listen for `installed`.
  */
 @Component({
   selector: 'app-plugin-install-consent',

--- a/client/src/app/features/settings/plugins/plugin-sources/plugin-sources.ts
+++ b/client/src/app/features/settings/plugins/plugin-sources/plugin-sources.ts
@@ -30,7 +30,7 @@ function createErrorKey(code: string | undefined): string {
   }
 }
 
-/** Sources list + add form (`plans/plugin-system.plan.md`, "N per install, the official one is just the seeded first"). */
+/** Sources list + add form — any number of sources, the official catalog is just the seeded first row. */
 @Component({
   selector: 'app-plugin-sources',
   imports: [FormsModule, DatePipe, LucideX, TranslateModule],

--- a/client/src/app/features/settings/plugins/plugin-trust.ts
+++ b/client/src/app/features/settings/plugins/plugin-trust.ts
@@ -6,7 +6,7 @@ export interface TrustBadge {
   cssClass: string;
 }
 
-/** Maps backend `TrustOutcome` onto the plan's four-badge model (Official / Verified / Unverified / Imported manually). */
+/** Maps backend `TrustOutcome` onto the four-badge model (Official / Verified / Unverified / Imported manually). */
 export function trustBadgeFor(trust: PluginTrust | undefined): TrustBadge {
   if (trust === 'official') return { labelKey: 'settings.plugins.trust.official', cssClass: 'badge-success' };
   if (trust === 'unsigned') return { labelKey: 'settings.plugins.trust.manual', cssClass: 'badge-ghost' };

--- a/client/src/app/features/settings/subtitles-activity/subtitles-activity.html
+++ b/client/src/app/features/settings/subtitles-activity/subtitles-activity.html
@@ -3,25 +3,16 @@
 <div class="flex gap-2 mb-4">
   <select class="select select-bordered select-sm" [ngModel]="subFilterStatus()" (ngModelChange)="subFilterStatus.set($event); applySubFilters()">
     <option value="">{{ 'activity.all_statuses' | translate }}</option>
-    <option value="downloaded">Downloaded</option>
-    <option value="upgraded">Upgraded</option>
-    <option value="synced">Synced</option>
-    <option value="failed">Failed</option>
+    <option value="downloaded">{{ 'activity.status_downloaded' | translate }}</option>
+    <option value="upgraded">{{ 'activity.status_upgraded' | translate }}</option>
+    <option value="synced">{{ 'activity.status_synced' | translate }}</option>
+    <option value="failed">{{ 'activity.status_failed' | translate }}</option>
   </select>
   <select class="select select-bordered select-sm" [ngModel]="subFilterLang()" (ngModelChange)="subFilterLang.set($event); applySubFilters()">
     <option value="">{{ 'activity.all_languages' | translate }}</option>
-    <option value="en">English</option>
-    <option value="fr">French</option>
-    <option value="de">German</option>
-    <option value="es">Spanish</option>
-    <option value="it">Italian</option>
-    <option value="pt">Portuguese</option>
-    <option value="ja">Japanese</option>
-    <option value="ko">Korean</option>
-    <option value="zh">Chinese</option>
-    <option value="ru">Russian</option>
-    <option value="ar">Arabic</option>
-    <option value="nl">Dutch</option>
+    @for (code of languageCodes; track code) {
+      <option [value]="code">{{ code | localizeLanguage }}</option>
+    }
   </select>
 </div>
 

--- a/client/src/app/features/settings/subtitles-activity/subtitles-activity.ts
+++ b/client/src/app/features/settings/subtitles-activity/subtitles-activity.ts
@@ -15,15 +15,20 @@ import {
 } from '../../../core/services/api/subtitles-api.service';
 import { PaginationComponent } from '../../../shared/components/pagination/pagination';
 import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
+import { LocalizeLanguagePipe } from '../../../core/pipes/localize-language.pipe';
+import { SUBTITLE_LANGUAGE_CODES } from '../../../core/constants/subtitle-languages';
 import { episodeLabel } from '../../../shared/utils/episode-label';
 
 @Component({
-  selector: 'app-activity-subtitles',
-  imports: [TranslateModule, LocaleDatePipe, NgClass, RouterLink, FormsModule, PaginationComponent],
+  selector: 'app-subtitles-activity',
+  imports: [TranslateModule, LocaleDatePipe, LocalizeLanguagePipe, NgClass, RouterLink, FormsModule, PaginationComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  templateUrl: './subtitles.html',
+  templateUrl: './subtitles-activity.html',
 })
-export class ActivitySubtitlesComponent implements OnInit {
+export class SubtitlesActivityComponent implements OnInit {
+  /** The same codes the translation targets offer, rendered through `localizeLanguage`. */
+  readonly languageCodes = SUBTITLE_LANGUAGE_CODES;
+
   private readonly subtitlesApi = inject(SubtitlesApiService);
   private readonly translate = inject(TranslateService);
 

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -10,9 +10,9 @@ import { PaginationComponent } from '../pagination/pagination';
 import { CellValue, ListAction, PagedResult, RowAction, TableColumn, TableRow } from './data-table.types';
 
 /**
- * The `table` view kind from the plugin plan: declared columns, declared row
- * actions, no client-side sorting beyond one declared default, no pluggable
- * cell renderers. Deliberately not a general grid.
+ * The `table` view kind: declared columns, declared row actions, no
+ * client-side sorting beyond one declared default, no pluggable cell
+ * renderers. Deliberately not a general grid.
  */
 @Component({
   selector: 'app-data-table',
@@ -31,7 +31,7 @@ export class DataTableComponent implements OnInit {
   readonly listUrl = input.required<string>();
   readonly columns = input.required<readonly TableColumn[]>();
   readonly rowActions = input<readonly RowAction[]>([]);
-  /** List-scope actions (the plan's `listActions[]`) — rendered once, next to the title. */
+  /** List-scope actions (`ListAction[]`) — rendered once, next to the title. */
   readonly listActions = input<readonly ListAction[]>([]);
   /** Applied once after load; there is no header-click re-sort. */
   readonly defaultSortKey = input<string | null>(null);

--- a/client/src/app/shared/components/data-table/data-table.types.ts
+++ b/client/src/app/shared/components/data-table/data-table.types.ts
@@ -20,15 +20,15 @@ export interface PagedResult<T> {
 }
 
 /**
- * The plan's `RowAction` union: `route`/`proxy` the renderer executes itself,
- * `action` an id core resolves — a plugin row invoking a flow it doesn't own.
+ * `route`/`proxy` the renderer executes itself, `action` an id core resolves
+ * — a plugin row invoking a flow it doesn't own.
  */
 export type RowAction =
   | { kind: 'route'; labelKey: string; path: string }
   | { kind: 'action'; labelKey: string; actionId: string }
   | { kind: 'proxy'; labelKey: string; method: 'POST' | 'DELETE'; path: string; confirmKey?: string };
 
-/** List-scope action (the plan's `TableConfigPage.listActions[]`) — rendered once, not per row. */
+/** List-scope action (`TableConfigPage.listActions[]`) — rendered once, not per row. */
 export interface ListAction {
   labelKey: string;
   method: 'POST' | 'DELETE';

--- a/client/src/app/shared/components/media-card/media-card.spec.ts
+++ b/client/src/app/shared/components/media-card/media-card.spec.ts
@@ -17,17 +17,15 @@ import { PluginUiRegistryService } from '../../../core/plugin-ui/plugin-ui-regis
 import type { SlotId, UiContribution } from '../../../core/plugin-ui/contribution.types';
 
 /**
- * Characterisation test for the card's contextual actions menu, written
- * before the `card.actions` contribution-registry refactor (plan PR 5.5) and
- * run unchanged before and after. Captures the action list as data
- * ({labelKey, icon, tone}) plus each handler's real side effect, across every
- * distinct input combination a real caller uses today (grepped from
- * home/library/search/media-detail/media-detail-seasons) — a silent change
- * in what a viewer sees, or in what a row's click actually does, fails here.
+ * Characterisation test for the card's contextual actions menu. Captures the
+ * action list as data ({labelKey, icon, tone}) plus each handler's real side
+ * effect, across every distinct input combination a real caller uses today
+ * (grepped from home/library/search/media-detail/media-detail-seasons) — a
+ * silent change in what a viewer sees, or in what a row's click actually
+ * does, fails here.
  *
- * `PluginUiRegistryService` is provided (empty by default) even though the
- * pre-refactor component never reads it — so this exact file also runs
- * unchanged post-refactor, once the component starts consuming it.
+ * `PluginUiRegistryService` is provided (empty by default) so this file
+ * keeps passing whether or not the component consumes it.
  */
 
 interface Role {

--- a/client/src/app/shared/components/media-info-header/media-info-header.spec.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.spec.ts
@@ -17,12 +17,10 @@ import type { SlotId, UiContribution } from '../../../core/plugin-ui/contributio
 
 /**
  * Permission-matrix + characterisation test for the `media.actions` kebab
- * menu. Written once, run unchanged before AND after the registry refactor
- * (PR 5.4) — see the plan's PR 5.4 acceptance criteria. `when` is
- * presentation only: every action behind these items stays CASL-guarded
- * server-side, so a bypassed predicate here is a cosmetic bug, never an
- * authorization one — but a WRONG one still offers a destructive action to
- * the wrong viewer's eyes, which is what this file exists to catch.
+ * menu. `when` is presentation only: every action behind these items stays
+ * CASL-guarded server-side, so a bypassed predicate here is a cosmetic bug,
+ * never an authorization one — but a WRONG one still offers a destructive
+ * action to the wrong viewer's eyes, which is what this file exists to catch.
  */
 
 // ── Role model: mirrors backend/src/common/constants/permissions.ts ──

--- a/client/src/app/shared/components/provider-list/provider-list.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.ts
@@ -89,13 +89,13 @@ export class ProviderListComponent implements OnInit {
   readonly defaultEnabled = input(true);
   /** Sorts rows by priority and adds move-up/down swaps — priority is meaningless to reorder otherwise. */
   readonly reorderable = input(false);
-  /** Rendered once above the rows (the plan's `actions[].scope: 'list'`), distinct from per-row actions. */
+  /** Rendered once above the rows (`ProvidersConfigPage.actions[].scope: 'list'`), distinct from per-row actions. */
   readonly listActions = input<readonly ProviderListAction[]>([]);
-  /** Rendered per row (the plan's `actions[].scope: 'row'`) — every entry gets its own button. */
+  /** Rendered per row (`ProvidersConfigPage.actions[].scope: 'row'`) — every entry gets its own button. */
   readonly rowActions = input<readonly ProviderRowAction[]>([]);
   /** Matches subtitle-providers' current UX: renaming the draft to the driver's label while creating. */
   readonly autoFillNameFromImplementation = input(false);
-  /** Runs against the unsaved draft (before create/update) — the plan's motivating row action. */
+  /** Runs against the unsaved draft (before create/update), catching a bad connection before it's saved. */
   readonly testConnection = input<((draft: ProviderDraft) => Promise<ProviderTestResult>) | null>(null);
   /** Last chance to normalise the save body (e.g. trim a URL) without resurrecting a dropped secret. */
   readonly beforeSave = input<((body: Record<string, unknown>) => Record<string, unknown>) | null>(null);

--- a/client/src/app/shared/components/provider-list/provider-list.types.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.types.ts
@@ -14,7 +14,7 @@ export interface ProviderInstance {
   [extra: string]: unknown;
 }
 
-/** One driver a provider instance can be created against — the plan's `ProvidersView.implementations[]` entry. */
+/** One driver a provider instance can be created against — a `ProvidersConfigPage.implementations[]` entry. */
 export interface ProviderImplementation {
   implementation: string;
   labelKey: string;
@@ -32,7 +32,7 @@ export interface ProviderDraft {
   settings: Record<string, unknown>;
 }
 
-/** A list-scope action (the plan's `ProvidersConfigPage.actions[].scope: 'list'`) — rendered
+/** A list-scope action (`ProvidersConfigPage.actions[].scope: 'list'`) — rendered
  *  once above the rows, not per row. `run` owns the request; the component only reloads after. */
 export interface ProviderListAction {
   labelKey: string;

--- a/client/src/app/shared/layout/layout.spec.ts
+++ b/client/src/app/shared/layout/layout.spec.ts
@@ -302,7 +302,6 @@ describe('LayoutComponent nav — characterisation (data, not pixels)', () => {
       { label: 'nav.playlists', icon: 'lucideListVideo', badge: null, href: '/playlists' },
       { label: 'downloads.title', icon: 'lucideDownload', badge: null, href: '/downloads' },
       { label: 'nav.history', icon: 'lucideHistory', badge: null, href: '/history' },
-        { label: 'activity.tab_subtitles', icon: 'lucideHistory', badge: null, href: '/activity' },
       { label: 'nav.requests', icon: 'lucideClipboardList', badge: '2', href: '/requests' },
       { label: 'nav.calendar', icon: 'lucideCalendar', badge: null, href: '/calendar' },
     ]);
@@ -319,7 +318,6 @@ describe('LayoutComponent nav — characterisation (data, not pixels)', () => {
       { label: 'nav.playlists', icon: 'lucideListVideo', badge: null, href: '/playlists' },
       { label: 'downloads.title', icon: 'lucideDownload', badge: null, href: '/downloads' },
       { label: 'nav.history', icon: 'lucideHistory', badge: null, href: '/history' },
-        { label: 'activity.tab_subtitles', icon: 'lucideHistory', badge: null, href: '/activity' },
       { label: 'nav.requests', icon: 'lucideClipboardList', badge: null, href: '/requests' },
       { label: 'nav.calendar', icon: 'lucideCalendar', badge: null, href: '/calendar' },
     ]);
@@ -333,7 +331,6 @@ describe('LayoutComponent nav — characterisation (data, not pixels)', () => {
       { label: 'Movies', icon: 'lucideLibrary', badge: null, href: '/libraries/Movies' },
       { label: 'nav.playlists', icon: 'lucideListVideo', badge: null, href: '/playlists' },
       { label: 'nav.history', icon: 'lucideHistory', badge: null, href: '/history' },
-        { label: 'activity.tab_subtitles', icon: 'lucideHistory', badge: null, href: '/activity' },
       { label: 'nav.requests', icon: 'lucideClipboardList', badge: null, href: '/requests' },
       { label: 'nav.calendar', icon: 'lucideCalendar', badge: null, href: '/calendar' },
     ]);
@@ -369,7 +366,6 @@ describe('LayoutComponent nav — characterisation (data, not pixels)', () => {
       { label: 'Anime', icon: 'lucideSwords', badge: null, href: '/libraries/Anime' },
       { label: 'nav.playlists', icon: 'lucideListVideo', badge: null, href: '/playlists' },
       { label: 'nav.history', icon: 'lucideHistory', badge: null, href: '/history' },
-        { label: 'activity.tab_subtitles', icon: 'lucideHistory', badge: null, href: '/activity' },
       { label: 'nav.calendar', icon: 'lucideCalendar', badge: null, href: '/calendar' },
     ]);
   });


### PR DESCRIPTION
## Two things, both asked for

### 1. Subtitle activity is an admin settings page

It was at `/activity` in the main navigation — where it ended up only because #947 removed the acquisition nav entry that used to lead to it. It reads subtitle download history, which is an operator view, so it now sits at **`/admin/settings/subtitles-activity`**, in the *Subtitles* section next to the subtitle settings and providers, and the main-nav entry is gone.

The component moved from `features/activity/subtitles/` to `features/settings/subtitles-activity/` (the `features/activity/` folder is now empty and removed) and is renamed to match its route.

Two defects in the page itself, fixed while moving it — the project rule is that no user-facing string is hardcoded:
- the status filter read `Downloaded` / `Upgraded` / `Synced` / `Failed` in English whatever the UI language; those are keys now, in all six languages;
- the language filter hardcoded 13 English language names, a subset of what the app supports. It reads `SUBTITLE_LANGUAGE_CODES` through `localizeLanguage` now, so it cannot drift from the codes the rest of the app offers and it renders in the user's language.

### 2. No code refers to `plans/*.plan.md` any more

`plans/` is **gitignored** (`git check-ignore` confirms). 15 comments cited `plans/plugin-system.plan.md`, 14 more said "the plan's X", and 5 cited plan PR numbers — every one of them told a reader to consult a file they do not have, instead of stating the rule. Each comment now carries the rule itself:

- `(see plans/…, "Guards, ordered")` → "in the order the guards run"
- `it('matches the plan exactly')` → `it('has these exact default values')`
- `it('builds the node argv verbatim from the plan')` → `it('builds the exact node argv: permission flag, fs allowlist, heap cap, entry file')`
- `Populated at boot (L0-L4 of plans/…'s load table)` → `Populated at boot (L0-L4, the load checks below)`
- `media-card.spec.ts` lost its "written before the refactor (plan PR 5.5)" framing and keeps what it actually guards.

Three "plan" mentions stay: `hls-variant-ladder.ts`, `per-stream-audio-args.spec.ts` and `system.controller.ts:160` mean a **transcode/audio plan** — domain vocabulary, not a document.

## Verification

Backend `tsc --noEmit` exit 0, **125 suites / 1327 tests**. Client `ng build` exit 0, **41 files / 349 tests**.

Four characterisation specs asserted the old sidebar and had to move with the change, which is the point of having them: the admin sidebar baseline is now 7 sections / **23** links, `SettingsSectionsService` resolves 23 items, and `nav.main` no longer ends with `core.subtitle_activity` (`nav-contributions.service.spec.ts`, `layout.spec.ts`).

`grep -rn "plans/\|the plan's\|PR [0-9]\.[0-9]" backend/src client/src` → empty. `grep -rn "'/activity'\|features/activity"` → empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)