### PR TITLE
fix(plugin-ui): read a plugin setting as its declared type, not as text

### DIFF
--- a/client/src/app/features/plugin-view/plugin-view.spec.ts
+++ b/client/src/app/features/plugin-view/plugin-view.spec.ts
@@ -82,6 +82,45 @@ describe('PluginViewComponent', () => {
     http.verify();
   });
 
+  it('VERDICT: types a stored setting by its declared field kind — "false" is off, not a truthy string', async () => {
+    const { fixture, http } = createComponent(
+      { pluginId: 'fliks.a', view: 'settings' },
+      {
+        hasPlugin: () => true,
+        configPage: () => ({
+          id: 'settings',
+          labelKey: 'x',
+          fields: [
+            { key: 'autoGrab', type: 'toggle', labelKey: 'y', default: true },
+            { key: 'unsetToggle', type: 'toggle', labelKey: 'y', default: true },
+            { key: 'interval', type: 'number', labelKey: 'y', default: 60 },
+            { key: 'samples', type: 'number', labelKey: 'y' },
+          ],
+        }),
+      },
+    );
+    fixture.detectChanges();
+    http.expectOne({ url: '/api/settings', method: 'GET' }).flush({
+      'plugin.fliks.a.autoGrab': 'false',
+      'plugin.fliks.a.interval': '30',
+      'plugin.fliks.a.samples': '',
+    });
+    await settle(fixture);
+
+    const value = fixture.componentInstance.formValue();
+    expect(value['autoGrab']).toBe(false);
+    // Unset falls back to the declared default, not to the empty string.
+    expect(value['unsetToggle']).toBe(true);
+    expect(value['interval']).toBe(30);
+    // An empty number stays empty: 0 samples would mean something else entirely.
+    expect(value['samples']).toBe('');
+
+    // Every toggle rendered off would look identical to a load that never ran — check the DOM too.
+    const boxes = Array.from(fixture.nativeElement.querySelectorAll('input[type="checkbox"]')) as HTMLInputElement[];
+    expect(boxes.map((b) => b.checked)).toEqual([false, true]);
+    http.verify();
+  });
+
   it('renders the providers renderer once the implementations route resolves, and lists rows from the declared route', async () => {
     // Manifest paths are declared relative to the plugin, exactly as a real manifest ships them —
     // if the component ever requests these verbatim instead of proxying them, `http.expectOne` below fails.

--- a/client/src/app/features/plugin-view/plugin-view.ts
+++ b/client/src/app/features/plugin-view/plugin-view.ts
@@ -19,7 +19,7 @@ import {
 } from '../../shared/components/provider-list/provider-list.types';
 import { DataTableComponent } from '../../shared/components/data-table/data-table';
 import type { ListAction, RowAction, TableRow } from '../../shared/components/data-table/data-table.types';
-import type { FormConfigPage } from '../../core/plugin-ui/contribution.types';
+import type { FieldDef, FormConfigPage } from '../../core/plugin-ui/contribution.types';
 import { AnyConfigPage, ProvidersView, TableView, isFormView, isProvidersView, isTableView } from './view-kinds.types';
 
 type UnavailableReason = 'unknown_plugin' | 'unknown_view';
@@ -30,6 +30,24 @@ interface PluginTestConnectionResponse {
   ok: boolean;
   messageKey: string;
   detail?: string;
+}
+
+/**
+ * `app_settings` stores every value as text, and the form model is typed: a `toggle` handed the
+ * string "false" renders checked, and a `number` handed "60" is a string in a numeric field.
+ * An unset number stays empty rather than becoming 0 — that is what "no cleanup" means.
+ */
+function typedSetting(field: FieldDef, raw: string | null | undefined): string | number | boolean {
+  if (field.type === 'toggle') {
+    return raw === undefined || raw === null || raw === '' ? Boolean(field.default) : raw === 'true';
+  }
+  if (field.type === 'number') {
+    const source = raw !== undefined && raw !== null && raw !== '' ? raw : field.default;
+    if (source === undefined || source === null || source === '') return '';
+    const n = Number(source);
+    return Number.isFinite(n) ? n : '';
+  }
+  return raw ?? (field.default != null ? String(field.default) : '');
 }
 
 /** Generic chrome for a real plugin's `providers` page — the plugin owns only field/implementation labelKeys. */
@@ -119,7 +137,7 @@ export class PluginViewComponent {
   constructor() {
     effect(() => {
       const p = this.page();
-      if (p && isFormView(p)) void this.loadFormValue(p.fields.map((f) => [f.key, f.default] as const));
+      if (p && isFormView(p)) void this.loadFormValue(p.fields);
     });
     effect(() => {
       const p = this.page();
@@ -127,16 +145,13 @@ export class PluginViewComponent {
     });
   }
 
-  private async loadFormValue(defaults: readonly (readonly [string, unknown])[]): Promise<void> {
+  private async loadFormValue(fields: readonly FieldDef[]): Promise<void> {
     this.formLoading.set(true);
     try {
       const all = await this.settingsApi.getAll();
       const prefix = `plugin.${this.pluginId()}.`;
       const value: SchemaFormValue = {};
-      for (const [key, def] of defaults) {
-        const raw = all[prefix + key];
-        value[key] = (raw ?? def ?? '') as string | number | boolean;
-      }
+      for (const field of fields) value[field.key] = typedSetting(field, all[prefix + field.key]);
       this.formValue.set(value);
     } finally {
       this.formLoading.set(false);

--- a/client/src/app/shared/components/schema-form/schema-form.spec.ts
+++ b/client/src/app/shared/components/schema-form/schema-form.spec.ts
@@ -163,3 +163,16 @@ describe('SchemaFormComponent — required validation', () => {
     expect(fixture.nativeElement.querySelector('.text-error')).toBeNull();
   });
 });
+
+it('VERDICT: reads a stringified boolean, so a stored "false" renders off', async () => {
+  const fields: FieldDef[] = [
+    { key: 'a', type: 'toggle', labelKey: 'x.a' },
+    { key: 'b', type: 'toggle', labelKey: 'x.b' },
+  ];
+  const fixture = createComponent(fields, { a: 'false', b: 'true' });
+  // `ngModel` writes to the DOM asynchronously; a single detectChanges leaves both unchecked.
+  await fixture.whenStable();
+
+  const boxes = Array.from(fixture.nativeElement.querySelectorAll('input[type="checkbox"]')) as HTMLInputElement[];
+  expect(boxes.map((b) => b.checked)).toEqual([false, true]);
+});

--- a/client/src/app/shared/components/schema-form/schema-form.ts
+++ b/client/src/app/shared/components/schema-form/schema-form.ts
@@ -60,7 +60,9 @@ export class SchemaFormComponent {
   }
 
   protected fieldBool(field: FieldDef): boolean {
-    return Boolean(this.value()[field.key]);
+    const v = this.value()[field.key];
+    // `Boolean('false')` is true, and a settings store hands back text.
+    return typeof v === 'string' ? v === 'true' : Boolean(v);
   }
 
   protected setValue(field: FieldDef, raw: string): void {


### PR DESCRIPTION
## The bug

On `/admin/settings/plugins/fliks.download/general`, every switch showed as **on** no matter what was saved.

Saving was never broken — `app_settings` holds exactly what the user chose:

```
plugin.fliks.download.requestsAutoGrabOnApproval | false
plugin.fliks.download.stall_auto_restart         | false
plugin.fliks.download.stall_include_manual_grabs | false
plugin.fliks.download.stall_interval_minutes     | 60
plugin.fliks.download.stall_samples              | 1
```

`app_settings` stores every value as **text**, and the loader assigned it into the typed form model unchanged. `SchemaFormComponent.fieldBool` then did `Boolean(this.value()[key])` — and `Boolean('false')` is `true`. Same cause for numbers: a numeric field received the string `'60'`.

## The fix

- `plugin-view.ts` types each value by the field's declared kind on load: `toggle` → `raw === 'true'` (falling back to the declared default when unset), `number` → `Number(raw)`, anything else → the string. An unset number stays **empty** rather than becoming `0`: for `stall_samples` that is the difference between "no cleanup" and "clean up after zero checks".
- `fieldBool` no longer calls `Boolean` on a string, so a value arriving as text from any other caller cannot reproduce this.

The save path already wrote `'true'`/`'false'`/`'60'`, which is what the reader now expects — and what the plugin itself parses (`values[KEY] === 'true'`, `parseInt`), so the plugin's own behaviour was always correct. Only the UI lied.

## Verification

Client `ng build` exit 0, **41 files / 351 tests** (349 + 2).

Both new specs were sabotage-checked:
- `plugin-view.spec.ts` — a stored `'false'` yields `false`, an unset toggle falls back to its default, `'30'` becomes `30`, an empty number stays `''`, and the rendered checkboxes read `[false, true]`. Restoring the old `Boolean(raw)` fails it.
- `schema-form.spec.ts` — `{ a: 'false', b: 'true' }` renders `[false, true]`. Restoring `Boolean(value)` fails it. (It has to await stability: `toggle-field` binds through `ngModel`, which writes to the DOM asynchronously, so a single `detectChanges` leaves both boxes unchecked — worth knowing for the next DOM assertion in this suite.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)