### PR TITLE
feat(plugins): switch an installed plugin off without destroying it

### DIFF
--- a/backend/src/migrations/1783500000000-add-plugin-package-enabled.ts
+++ b/backend/src/migrations/1783500000000-add-plugin-package-enabled.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/** Operator on/off switch, independent of `status` — an activation outcome, not a choice. */
+export class AddPluginPackageEnabled1783500000000 implements MigrationInterface {
+  name = 'AddPluginPackageEnabled1783500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "plugin_packages" ADD COLUMN "enabled" boolean NOT NULL DEFAULT true`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "plugin_packages" DROP COLUMN "enabled"`);
+  }
+}

--- a/backend/src/migrations/1783600000000-drop-plugin-registration-enabled.ts
+++ b/backend/src/migrations/1783600000000-drop-plugin-registration-enabled.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+// An operator's decision to switch a plugin off belongs to the installed artifact, which exists
+// for both tiers; `plugin_packages.enabled` is that flag. Two of them could only disagree.
+export class DropPluginRegistrationEnabled1783600000000
+  implements MigrationInterface
+{
+  name = 'DropPluginRegistrationEnabled1783600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "plugin_packages" p SET "enabled" = false
+         FROM "plugin_registrations" r
+        WHERE r."pluginId" = p."pluginId" AND r."enabled" = false`,
+    );
+    await queryRunner.query(`ALTER TABLE "plugin_registrations" DROP COLUMN IF EXISTS "enabled"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "plugin_registrations" ADD COLUMN IF NOT EXISTS "enabled" boolean NOT NULL DEFAULT true`,
+    );
+  }
+}

--- a/backend/src/modules/plugins/dto/set-plugin-enabled.dto.ts
+++ b/backend/src/modules/plugins/dto/set-plugin-enabled.dto.ts
@@ -1,6 +1,0 @@
-import { IsBoolean } from 'class-validator';
-
-export class SetPluginEnabledDto {
-  @IsBoolean()
-  enabled: boolean;
-}

--- a/backend/src/modules/plugins/entities/plugin-package.entity.ts
+++ b/backend/src/modules/plugins/entities/plugin-package.entity.ts
@@ -35,6 +35,10 @@ export class PluginPackage extends BaseEntity {
   @Column({ type: 'jsonb' })
   manifest: PluginManifest;
 
+  /** Operator on/off switch — independent of `status`, which is an activation outcome, not a choice. */
+  @Column({ default: true })
+  enabled: boolean;
+
   /** `failed` on a P4 activation failure; the row (and archive) stand regardless. */
   @Column({ type: 'enum', enum: PLUGIN_PACKAGE_STATUSES, default: 'active' })
   status: PluginPackageStatus;

--- a/backend/src/modules/plugins/entities/plugin-registration.entity.ts
+++ b/backend/src/modules/plugins/entities/plugin-registration.entity.ts
@@ -16,9 +16,6 @@ export class PluginRegistration extends BaseEntity {
   @Column({ type: 'text', array: true, default: () => "'{}'" })
   scopes: PluginScope[];
 
-  @Column({ default: true })
-  enabled: boolean;
-
   /** Cached for `GET /api/plugins/ui`; refreshed at hello, manual refresh, and the plugin's own notify. */
   @Column({ type: 'jsonb' })
   manifest: PluginManifest;

--- a/backend/src/modules/plugins/plugin-install.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-install.service.spec.ts
@@ -6,6 +6,7 @@ import { PluginInstallService, installedPluginDir } from './plugin-install.servi
 import { PluginInstallException } from './plugin-install.exception';
 import { PluginStagingService } from './plugin-staging.service';
 import { PluginRegistryService } from './plugin-registry.service';
+import { PluginUiController } from './plugin-ui.controller';
 import { PluginDatabaseService } from './plugin-database.service';
 import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry } from './plugin-registry.test-helpers';
 import { PluginPackage } from './entities/plugin-package.entity';
@@ -135,6 +136,7 @@ describe('PluginInstallService', () => {
   let repo: ReturnType<typeof fakePackageRepo>;
   let registrationRepo: ReturnType<typeof fakeRegistrationRepo>;
   let registry: PluginRegistryService;
+  let processService: ReturnType<typeof fakeProcessService>;
   let staging: PluginStagingService;
   let pluginDb: ReturnType<typeof fakePluginDb>;
   let service: PluginInstallService;
@@ -151,10 +153,11 @@ describe('PluginInstallService', () => {
     // One instance shared by both: the registry writes the registration row and uninstall
     // deletes it, so two separate fakes would make either assertion vacuous.
     registrationRepo = fakeRegistrationRepo();
+    processService = fakeProcessService();
     registry = new PluginRegistryService(
       repo as never,
       registrationRepo as never,
-      fakeProcessService() as never,
+      processService as never,
       fakePluginJobsService() as never,
       fakeScheduledJobRegistry() as never,
     );
@@ -489,6 +492,112 @@ describe('PluginInstallService', () => {
           }),
         ]),
       );
+    });
+  });
+
+  describe('disable / enable', () => {
+    async function installProcess(overrides: Partial<ProcessPluginManifest> = {}): Promise<ProcessPluginManifest> {
+      const { buffer, manifest } = signedProcessArchive(overrides);
+      const { stagingId, sha256 } = await service.inspectUpload(buffer);
+      await service.confirmImport({ stagingId: stagingId!, sha256: sha256! });
+      return manifest;
+    }
+
+    async function installData(overrides: Partial<DataPluginManifest> = {}): Promise<DataPluginManifest> {
+      const { buffer, manifest } = signedDataArchive(overrides);
+      const { stagingId, sha256 } = await service.inspectUpload(buffer);
+      await service.confirmImport({ stagingId: stagingId!, sha256: sha256! });
+      return manifest;
+    }
+
+    it('stops the supervisor and drops the live registration, leaving the row, archive and schema alone', async () => {
+      const manifest = await installProcess({ id: 'fliks.disablehappy' });
+      expect(registry.get(manifest.id)).toBeDefined();
+
+      const summary = await service.disable(manifest.id);
+
+      expect(summary).toEqual(expect.objectContaining({ pluginId: manifest.id, enabled: false, status: 'active' }));
+      expect(processService.stopFor).toHaveBeenCalledWith(manifest.id);
+      expect(registry.get(manifest.id)).toBeUndefined();
+      expect(repo.rows.get(manifest.id)).toEqual(expect.objectContaining({ enabled: false, status: 'active' }));
+      expect(repo.remove).not.toHaveBeenCalled();
+      expect(pluginDb.deprovision).not.toHaveBeenCalled();
+      expect(existsSync(installedPluginDir(manifest.id, manifest.version))).toBe(true);
+    });
+
+    it('VERDICT: an upgrade over a disabled plugin stores the archive and stays off', async () => {
+      const manifest = await installProcess({ id: 'fliks.upgradedisabled', version: '1.0.0' });
+      await service.disable(manifest.id);
+      processService.startFor.mockClear();
+
+      await installProcess({ id: 'fliks.upgradedisabled', version: '1.1.0' });
+
+      const row = repo.rows.get(manifest.id);
+      expect(row).toEqual(expect.objectContaining({ version: '1.1.0', enabled: false }));
+      // Reactivating behind a version bump would undo the operator's decision in silence.
+      expect(registry.get(manifest.id)).toBeUndefined();
+      expect(processService.startFor).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent: disabling an already-disabled plugin does not stop the supervisor again', async () => {
+      const manifest = await installProcess({ id: 'fliks.disabletwice' });
+      await service.disable(manifest.id);
+      processService.stopFor.mockClear();
+
+      const summary = await service.disable(manifest.id);
+
+      expect(summary.enabled).toBe(false);
+      expect(processService.stopFor).not.toHaveBeenCalled();
+    });
+
+    it('restores the plugin through the same activation path a boot load takes', async () => {
+      const manifest = await installProcess({ id: 'fliks.enablehappy' });
+      await service.disable(manifest.id);
+      processService.startFor.mockClear();
+
+      const summary = await service.enable(manifest.id);
+
+      expect(summary).toEqual(expect.objectContaining({ pluginId: manifest.id, enabled: true, status: 'active' }));
+      expect(processService.startFor).toHaveBeenCalledTimes(1);
+      expect(registry.get(manifest.id)).toBeDefined();
+    });
+
+    it('is idempotent: enabling an already-enabled plugin does not re-register', async () => {
+      const manifest = await installProcess({ id: 'fliks.enabletwice' });
+      processService.startFor.mockClear();
+
+      const summary = await service.enable(manifest.id);
+
+      expect(summary.enabled).toBe(true);
+      expect(processService.startFor).not.toHaveBeenCalled();
+    });
+
+    it('a failed re-activation reports the way it would at boot: enabled, but status failed with the reason', async () => {
+      const manifest = await installProcess({ id: 'fliks.enablefails' });
+      await service.disable(manifest.id);
+      processService.startFor.mockResolvedValueOnce({ ok: false, reason: 'spawn-failed', detail: 'never reached ready' });
+
+      const summary = await service.enable(manifest.id);
+
+      expect(summary).toEqual(
+        expect.objectContaining({ enabled: true, status: 'failed', statusReason: expect.stringContaining('spawn-failed') }),
+      );
+      expect(registry.get(manifest.id)).toBeUndefined();
+    });
+
+    it('404s on an unknown plugin id for both routes', async () => {
+      await expectInstallError(service.disable('fliks.neverinstalled'), 404, 'PLUGIN_NOT_FOUND');
+      await expectInstallError(service.enable('fliks.neverinstalled'), 404, 'PLUGIN_NOT_FOUND');
+    });
+
+    it('excludes a disabled plugin from GET /plugins/ui — the controller reads the same registry membership', async () => {
+      const manifest = await installData({ id: 'fliks.disableui' });
+      const ui = new PluginUiController(registry);
+      expect(ui.list().map((r) => r.pluginId)).toContain(manifest.id);
+
+      await service.disable(manifest.id);
+
+      expect(ui.list().map((r) => r.pluginId)).not.toContain(manifest.id);
     });
   });
 });

--- a/backend/src/modules/plugins/plugin-install.service.ts
+++ b/backend/src/modules/plugins/plugin-install.service.ts
@@ -60,6 +60,7 @@ export interface PluginSummary {
   statusReason: string | null;
   signature: TrustOutcome;
   verifiedByKeyId: string | null;
+  enabled: boolean;
   /** `process` only — `null`/`''` for `data`, which has no supervisor. */
   processState: SupervisorState | null;
   statusMessage: string;
@@ -216,14 +217,6 @@ export class PluginInstallService {
   }
 
   /** Persists the enabled flag on `plugin_registrations` and starts or stops the process to match. */
-  async setEnabled(pluginId: string, enabled: boolean): Promise<PluginSummary> {
-    const pkg = await this.findInstalledProcessPlugin(pluginId);
-    const result = await this.registry.setEnabled(pkg, enabled);
-    pkg.status = result.ok ? 'active' : 'failed';
-    pkg.statusReason = result.ok ? null : `${result.reason}: ${result.detail}`;
-    await this.packageRepo.save(pkg);
-    return this.toSummary(pkg);
-  }
 
   /** Clears a tripped circuit breaker and respawns. */
   async restart(pluginId: string): Promise<void> {
@@ -231,9 +224,40 @@ export class PluginInstallService {
     await this.registry.restartProcess(pluginId);
   }
 
-  private async findInstalledProcessPlugin(pluginId: string): Promise<PluginPackage> {
+  /** Idempotent: an already-disabled plugin is returned as-is. Stops the supervisor and drops the
+   *  live registration via `unregister()` — the package row, its archive and its schema are untouched. */
+  async disable(pluginId: string): Promise<PluginSummary> {
+    const pkg = await this.findInstalledPlugin(pluginId);
+    if (!pkg.enabled) return this.toSummary(pkg);
+
+    pkg.enabled = false;
+    await this.packageRepo.save(pkg);
+    await this.registry.unregister(pluginId);
+    return this.toSummary(pkg);
+  }
+
+  /** Idempotent: an already-enabled plugin is returned as-is. Otherwise re-registers through the
+   *  same path a boot load takes, so a failure to come back reports the way it would at boot. */
+  async enable(pluginId: string): Promise<PluginSummary> {
+    const pkg = await this.findInstalledPlugin(pluginId);
+    if (pkg.enabled) return this.toSummary(pkg);
+
+    pkg.enabled = true;
+    const result = await this.registry.register(pkg);
+    pkg.status = result.ok ? 'active' : 'failed';
+    pkg.statusReason = result.ok ? null : `${result.reason}: ${result.detail}`;
+    await this.packageRepo.save(pkg);
+    return this.toSummary(pkg);
+  }
+
+  private async findInstalledPlugin(pluginId: string): Promise<PluginPackage> {
     const pkg = await this.packageRepo.findOne({ where: { pluginId } });
     if (!pkg) throw new PluginInstallException(HttpStatus.NOT_FOUND, 'PLUGIN_NOT_FOUND', `plugin "${pluginId}" is not installed`);
+    return pkg;
+  }
+
+  private async findInstalledProcessPlugin(pluginId: string): Promise<PluginPackage> {
+    const pkg = await this.findInstalledPlugin(pluginId);
     if (pkg.manifest.kind !== 'process') {
       throw new PluginInstallException(HttpStatus.BAD_REQUEST, 'PLUGIN_NOT_PROCESS_TIER', `plugin "${pluginId}" is not a process-tier plugin`);
     }
@@ -252,6 +276,7 @@ export class PluginInstallService {
       statusReason: pkg.statusReason,
       signature: pkg.signature,
       verifiedByKeyId: pkg.verifiedByKeyId,
+      enabled: pkg.enabled,
       processState: isProcess ? this.registry.processStateOf(pkg.pluginId) : null,
       statusMessage: isProcess ? this.registry.processStatusMessageOf(pkg.pluginId) : '',
     };
@@ -307,7 +332,8 @@ export class PluginInstallService {
 
     let saved: PluginPackage;
     try {
-      const row = existing ?? this.packageRepo.create({ pluginId: manifest.id });
+      // A fresh install always starts enabled; an upgrade keeps whatever the admin last chose.
+      const row = existing ?? this.packageRepo.create({ pluginId: manifest.id, enabled: true });
       row.version = manifest.version;
       row.archive = buffer;
       row.origin = origin;
@@ -323,6 +349,13 @@ export class PluginInstallService {
     }
 
     if (previousDir && existsSync(previousDir)) rmSync(previousDir, { recursive: true, force: true });
+
+    // An upgrade over a disabled plugin stores the new archive and stays off: reactivating it
+    // silently would undo the operator's decision behind a version bump.
+    if (!saved.enabled) {
+      this.logger.log(`plugin "${saved.pluginId}" upgraded while disabled — not activated`);
+      return { pluginId: saved.pluginId, version: saved.version, status: 'active' };
+    }
 
     const registration = await this.registry.register(saved);
     if (!registration.ok) {

--- a/backend/src/modules/plugins/plugin-registry.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.spec.ts
@@ -37,6 +37,7 @@ function makePackage(manifest: PluginManifest, overrides: Partial<PluginPackage>
     verifiedByKeyId: null,
     manifest,
     status: 'active',
+    enabled: true,
     ...overrides,
   } as PluginPackage;
 }
@@ -108,6 +109,31 @@ describe('PluginRegistryService — boot load', () => {
     expect(service.get(failing.id)).toBeUndefined();
     expect(service.get(good.id)).toBeDefined();
     expect(service.list()).toHaveLength(1);
+  });
+
+  it('a disabled package is neither started nor registered, and a later enabled one still loads', async () => {
+    const disabled = minimalDataManifest({ id: 'fliks.boot-disabled', fliks: COMPATIBLE_RANGE });
+    const good = minimalDataManifest({ id: 'fliks.good-plugin', fliks: COMPATIBLE_RANGE });
+    const { service } = makeService([makePackage(disabled, { enabled: false }), makePackage(good)]);
+
+    await service.onModuleInit();
+
+    expect(service.get(disabled.id)).toBeUndefined();
+    expect(service.get(good.id)).toBeDefined();
+    expect(service.list()).toHaveLength(1);
+  });
+
+  it('a disabled process-tier package never spawns its supervisor', async () => {
+    const manifest = minimalProcessManifest(
+      { 'plugin.js': 'a'.repeat(64), 'logo.png': 'b'.repeat(64) },
+      { id: 'fliks.boot-disabled-process', fliks: COMPATIBLE_RANGE },
+    );
+    const { service, processService } = makeService([makePackage(manifest, { enabled: false })]);
+
+    await service.onModuleInit();
+
+    expect(processService.startFor).not.toHaveBeenCalled();
+    expect(service.get(manifest.id)).toBeUndefined();
   });
 });
 
@@ -217,7 +243,7 @@ describe('PluginRegistryService.register()', () => {
       expect(service.get(pkg.pluginId)).toBeDefined();
       const row = registrationRepo.rows.get(pkg.pluginId);
       expect(row).toEqual(
-        expect.objectContaining({ pluginId: pkg.pluginId, enabled: true, ingestRoots: [], scopes: ['media:read'] }),
+        expect.objectContaining({ pluginId: pkg.pluginId, ingestRoots: [], scopes: ['media:read'] }),
       );
     });
 
@@ -225,30 +251,16 @@ describe('PluginRegistryService.register()', () => {
       const pkg = processPackage({ id: 'fliks.processreload' });
       const { service, registrationRepo } = makeService();
       await service.register(pkg);
-      registrationRepo.rows.get(pkg.pluginId)!.enabled = false;
       registrationRepo.rows.get(pkg.pluginId)!.ingestRoots = ['/media/custom'];
 
       const second = await service.register(pkg);
 
-      expect(second).toEqual({ ok: false, pluginId: pkg.pluginId, reason: 'disabled', detail: expect.any(String) });
+      expect(second).toEqual({ ok: true, pluginId: pkg.pluginId });
       const row = registrationRepo.rows.get(pkg.pluginId);
       expect(row?.ingestRoots).toEqual(['/media/custom']);
       expect(row?.manifest).toEqual(pkg.manifest);
     });
 
-    it('a disabled registration refuses with "disabled" and never calls startFor', async () => {
-      const pkg = processPackage({ id: 'fliks.processdisabled' });
-      const { service, registrationRepo, processService } = makeService();
-      await service.register(pkg);
-      registrationRepo.rows.get(pkg.pluginId)!.enabled = false;
-      processService.startFor.mockClear();
-
-      const result = await service.register(pkg);
-
-      expect(result).toEqual({ ok: false, pluginId: pkg.pluginId, reason: 'disabled', detail: expect.any(String) });
-      expect(processService.startFor).not.toHaveBeenCalled();
-      expect(service.get(pkg.pluginId)).toBeUndefined();
-    });
 
     it('propagates a spawn failure reason and registers nothing', async () => {
       const pkg = processPackage({ id: 'fliks.processspawnfail' });

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -170,6 +170,10 @@ export class PluginRegistryService implements OnModuleInit {
 
     const packages = await this.packageRepo.find();
     for (const pkg of packages) {
+      if (!pkg.enabled) {
+        this.logger.log(`plugin "${pkg.pluginId}" is disabled — not loaded`);
+        continue;
+      }
       try {
         const result = await this.register(pkg);
         if (!result.ok) {
@@ -284,18 +288,6 @@ export class PluginRegistryService implements OnModuleInit {
   }
 
   /** Persists the admin's enabled/disabled choice and starts or stops the process to match it. */
-  async setEnabled(pkg: PluginPackage, enabled: boolean): Promise<PluginRegistrationResult> {
-    const registration = await this.registrationRepo.findOne({ where: { pluginId: pkg.pluginId } });
-    if (!registration) throw new NotFoundException(`plugin "${pkg.pluginId}" has no registration row`);
-    registration.enabled = enabled;
-    await this.registrationRepo.save(registration);
-
-    if (!enabled) {
-      await this.unregister(pkg.pluginId);
-      return this.fail(pkg.pluginId, 'disabled', `plugin "${pkg.pluginId}" is disabled`);
-    }
-    return this.register(pkg);
-  }
 
   /** Clears a tripped circuit breaker by swapping in a freshly-provisioned supervisor. */
   async restartProcess(pluginId: string): Promise<void> {
@@ -311,7 +303,7 @@ export class PluginRegistryService implements OnModuleInit {
   }
 
   /** Loads or creates the `plugin_registrations` row (seeding it only on create),
-   *  refreshes its cached manifest, then spawns unless the admin disabled it. */
+   *  refreshes its cached manifest, then spawns. */
   private async activateProcess(
     pkg: PluginPackage,
     manifest: ProcessPluginManifest,
@@ -322,17 +314,12 @@ export class PluginRegistryService implements OnModuleInit {
         pluginId: pkg.pluginId,
         ingestRoots: manifest.ingestRoots,
         scopes: manifest.scopes,
-        enabled: true,
         manifest,
       });
     } else {
       registration.manifest = manifest;
     }
     await this.registrationRepo.save(registration);
-
-    if (!registration.enabled) {
-      return this.fail(pkg.pluginId, 'disabled', `plugin "${pkg.pluginId}" is disabled`);
-    }
 
     const result = await this.processService.startFor(pkg);
     if (!result.ok) return this.fail(pkg.pluginId, result.reason, result.detail);

--- a/backend/src/modules/plugins/plugin-route-shadowing.spec.ts
+++ b/backend/src/modules/plugins/plugin-route-shadowing.spec.ts
@@ -29,7 +29,7 @@ describe('plugins/* route shadowing', () => {
   beforeAll(async () => {
     installService = {
       listInstalled: jest.fn().mockResolvedValue([]),
-      setEnabled: jest.fn().mockResolvedValue({}),
+      disable: jest.fn().mockResolvedValue({}),
       restart: jest.fn().mockResolvedValue(undefined),
       uninstall: jest.fn().mockResolvedValue(undefined),
       confirmImport: jest.fn().mockResolvedValue({}),
@@ -94,9 +94,9 @@ describe('plugins/* route shadowing', () => {
     expect(processService.callPlugin).not.toHaveBeenCalled();
   });
 
-  it('PATCH /plugins/:pluginId reaches PluginsController.setEnabled, not the proxy', async () => {
-    await request(app.getHttpServer()).patch('/plugins/fliks.testplugin').send({ enabled: false }).expect(200);
-    expect(installService.setEnabled).toHaveBeenCalledWith('fliks.testplugin', false);
+  it('POST /plugins/:pluginId/disable reaches PluginsController.disable, not the proxy', async () => {
+    await request(app.getHttpServer()).post('/plugins/fliks.testplugin/disable').expect(201);
+    expect(installService.disable).toHaveBeenCalledWith('fliks.testplugin');
     expect(processService.callPlugin).not.toHaveBeenCalled();
   });
 

--- a/backend/src/modules/plugins/plugins.controller.spec.ts
+++ b/backend/src/modules/plugins/plugins.controller.spec.ts
@@ -18,14 +18,6 @@ describe('PluginsController', () => {
     expect(installService.listInstalled).toHaveBeenCalled();
   });
 
-  it('delegates setEnabled to the install service with the parsed body', async () => {
-    const summary = { pluginId: 'fliks.test-plugin', status: 'active' };
-    const installService = { setEnabled: jest.fn().mockResolvedValue(summary) };
-    const controller = new PluginsController(installService as never);
-
-    await expect(controller.setEnabled('fliks.test-plugin', { enabled: false })).resolves.toBe(summary);
-    expect(installService.setEnabled).toHaveBeenCalledWith('fliks.test-plugin', false);
-  });
 
   it('delegates restart to the install service', async () => {
     const installService = { restart: jest.fn().mockResolvedValue(undefined) };
@@ -33,5 +25,23 @@ describe('PluginsController', () => {
 
     await expect(controller.restart('fliks.test-plugin')).resolves.toBeUndefined();
     expect(installService.restart).toHaveBeenCalledWith('fliks.test-plugin');
+  });
+
+  it('delegates disable to the install service', async () => {
+    const summary = { pluginId: 'fliks.test-plugin', enabled: false };
+    const installService = { disable: jest.fn().mockResolvedValue(summary) };
+    const controller = new PluginsController(installService as never);
+
+    await expect(controller.disable('fliks.test-plugin')).resolves.toBe(summary);
+    expect(installService.disable).toHaveBeenCalledWith('fliks.test-plugin');
+  });
+
+  it('delegates enable to the install service', async () => {
+    const summary = { pluginId: 'fliks.test-plugin', enabled: true };
+    const installService = { enable: jest.fn().mockResolvedValue(summary) };
+    const controller = new PluginsController(installService as never);
+
+    await expect(controller.enable('fliks.test-plugin')).resolves.toBe(summary);
+    expect(installService.enable).toHaveBeenCalledWith('fliks.test-plugin');
   });
 });

--- a/backend/src/modules/plugins/plugins.controller.ts
+++ b/backend/src/modules/plugins/plugins.controller.ts
@@ -4,7 +4,6 @@ import { PoliciesGuard } from '../auth/casl/policies.guard';
 import { CheckPolicies } from '../auth/casl/check-policies.decorator';
 import { Action } from '../auth/casl/actions.enum';
 import { PluginInstallService, PluginSummary } from './plugin-install.service';
-import { SetPluginEnabledDto } from './dto/set-plugin-enabled.dto';
 
 @Controller('plugins')
 @UseGuards(JwtOrApiKeyGuard, PoliciesGuard)
@@ -18,11 +17,6 @@ export class PluginsController {
   }
 
   /** `process` only — flips `plugin_registrations.enabled` and starts or stops the process to match. */
-  @Patch(':pluginId')
-  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
-  async setEnabled(@Param('pluginId') pluginId: string, @Body() dto: SetPluginEnabledDto): Promise<PluginSummary> {
-    return this.installService.setEnabled(pluginId, dto.enabled);
-  }
 
   /** Clears a tripped circuit breaker and respawns. */
   @Post(':pluginId/restart')
@@ -30,6 +24,20 @@ export class PluginsController {
   @HttpCode(HttpStatus.NO_CONTENT)
   async restart(@Param('pluginId') pluginId: string): Promise<void> {
     await this.installService.restart(pluginId);
+  }
+
+  /** Drops the live registration, leaving the package row, archive and schema untouched. Idempotent. */
+  @Post(':pluginId/disable')
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
+  async disable(@Param('pluginId') pluginId: string): Promise<PluginSummary> {
+    return this.installService.disable(pluginId);
+  }
+
+  /** Re-registers through the same path a boot load takes. Idempotent. */
+  @Post(':pluginId/enable')
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
+  async enable(@Param('pluginId') pluginId: string): Promise<PluginSummary> {
+    return this.installService.enable(pluginId);
   }
 
   /** Row + registry entry + extracted directory. Safe on a plugin whose files or row are already gone. */

--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -131,6 +131,8 @@ export interface HealthReport {
   /** Core reports only how many plugins are installed. A capability's own
    *  reachability belongs on that capability's page, which its plugin owns. */
   installedPlugins: number;
+  /** Enabled, not necessarily reachable — same scope limit as `installedPlugins`. */
+  runningPlugins: number;
   restartSupervisor: string | null;
 }
 
@@ -231,6 +233,7 @@ export class SystemController {
       uptimeSeconds: Math.floor(process.uptime()),
       database: await this.checkDatabase(),
       installedPlugins: await this.pluginPackageRepo.count(),
+      runningPlugins: await this.pluginPackageRepo.count({ where: { enabled: true } }),
       restartSupervisor: detectRestartSupervisor(),
     };
   }

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1243,6 +1243,7 @@
     "health_app": "App",
     "health_db": "Datenbank",
     "health_plugins": "Installierte Plugins",
+    "health_plugins_running": "{{count}} aktiv",
     "uptime": "Uptime",
     "logs_title": "Logs",
     "logs_all_levels": "Alle Stufen",
@@ -2080,6 +2081,7 @@
       "col_tier": "Tier",
       "col_trust": "Trust",
       "col_status": "Status",
+      "col_enabled": "Enabled",
       "tier_data": "Data",
       "tier_process": "Process",
       "status_active": "Active",
@@ -2091,6 +2093,10 @@
       "inspect_error": "Unable to read this archive.",
       "installed": "Plugin installed.",
       "install_failed_but_kept": "\"{{id}}\" was installed but could not start: {{reason}}",
+      "enabled_toast": "Plugin enabled.",
+      "disabled_toast": "Plugin disabled.",
+      "enable_failed_but_kept": "\"{{id}}\" is enabled but could not start: {{reason}}",
+      "toggle_error": "Unable to update the plugin state.",
       "trust": {
         "official": "Official",
         "verified": "Verified — {{key}}",
@@ -2177,7 +2183,9 @@
         "hidden_versions": "{{count}} Version(en) ausgeblendet — erfordert Fliks {{version}}+",
         "hidden_versions_no_upgrade": "{{count}} Version(en) ausgeblendet",
         "inspect_error": "Dieses Plugin konnte nicht abgerufen werden."
-      }
+      },
+      "status_disabled": "Deaktiviert",
+      "status_unavailable": "Nicht verfügbar"
     }
   },
   "roles": {

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1251,6 +1251,7 @@
     "health_app": "App",
     "health_db": "Database",
     "health_plugins": "Installed plugins",
+    "health_plugins_running": "{{count}} running",
     "uptime": "Uptime",
     "logs_title": "Logs",
     "logs_all_levels": "All levels",
@@ -2107,6 +2108,7 @@
       "col_tier": "Tier",
       "col_trust": "Trust",
       "col_status": "Status",
+      "col_enabled": "Enabled",
       "tier_data": "Data",
       "tier_process": "Process",
       "status_active": "Active",
@@ -2118,6 +2120,10 @@
       "inspect_error": "Unable to read this archive.",
       "installed": "Plugin installed.",
       "install_failed_but_kept": "\"{{id}}\" was installed but could not start: {{reason}}",
+      "enabled_toast": "Plugin enabled.",
+      "disabled_toast": "Plugin disabled.",
+      "enable_failed_but_kept": "\"{{id}}\" is enabled but could not start: {{reason}}",
+      "toggle_error": "Unable to update the plugin state.",
       "trust": {
         "official": "Official",
         "verified": "Verified — {{key}}",
@@ -2204,7 +2210,9 @@
         "hidden_versions": "{{count}} version(s) hidden — requires Fliks {{version}}+",
         "hidden_versions_no_upgrade": "{{count}} version(s) hidden",
         "inspect_error": "Unable to fetch this plugin."
-      }
+      },
+      "status_disabled": "Disabled",
+      "status_unavailable": "Unavailable"
     }
   },
   "roles": {

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1243,6 +1243,7 @@
     "health_app": "Aplicación",
     "health_db": "Base de datos",
     "health_plugins": "Plugins instalados",
+    "health_plugins_running": "{{count}} en ejecución",
     "uptime": "Uptime",
     "logs_title": "Registros",
     "logs_all_levels": "Todos los niveles",
@@ -2080,6 +2081,7 @@
       "col_tier": "Tier",
       "col_trust": "Trust",
       "col_status": "Status",
+      "col_enabled": "Enabled",
       "tier_data": "Data",
       "tier_process": "Process",
       "status_active": "Active",
@@ -2091,6 +2093,10 @@
       "inspect_error": "Unable to read this archive.",
       "installed": "Plugin installed.",
       "install_failed_but_kept": "\"{{id}}\" was installed but could not start: {{reason}}",
+      "enabled_toast": "Plugin enabled.",
+      "disabled_toast": "Plugin disabled.",
+      "enable_failed_but_kept": "\"{{id}}\" is enabled but could not start: {{reason}}",
+      "toggle_error": "Unable to update the plugin state.",
       "trust": {
         "official": "Official",
         "verified": "Verified — {{key}}",
@@ -2177,7 +2183,9 @@
         "hidden_versions": "{{count}} versión(es) oculta(s) — requiere Fliks {{version}}+",
         "hidden_versions_no_upgrade": "{{count}} versión(es) oculta(s)",
         "inspect_error": "No se pudo obtener este plugin."
-      }
+      },
+      "status_disabled": "Desactivado",
+      "status_unavailable": "No disponible"
     }
   },
   "roles": {

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1251,6 +1251,7 @@
     "health_app": "Application",
     "health_db": "Base de données",
     "health_plugins": "Plugins installés",
+    "health_plugins_running": "{{count}} en cours",
     "uptime": "Uptime",
     "logs_title": "Logs",
     "logs_all_levels": "Tous les niveaux",
@@ -2107,6 +2108,7 @@
       "col_tier": "Niveau",
       "col_trust": "Confiance",
       "col_status": "Statut",
+      "col_enabled": "Activé",
       "tier_data": "Données",
       "tier_process": "Processus",
       "status_active": "Actif",
@@ -2118,6 +2120,10 @@
       "inspect_error": "Impossible de lire cette archive.",
       "installed": "Plugin installé.",
       "install_failed_but_kept": "« {{id}} » a été installé mais n'a pas pu démarrer : {{reason}}",
+      "enabled_toast": "Plugin activé.",
+      "disabled_toast": "Plugin désactivé.",
+      "enable_failed_but_kept": "« {{id}} » est activé mais n'a pas pu démarrer : {{reason}}",
+      "toggle_error": "Impossible de mettre à jour l'état du plugin.",
       "trust": {
         "official": "Officiel",
         "verified": "Vérifié — {{key}}",
@@ -2204,7 +2210,9 @@
         "hidden_versions": "{{count}} version(s) masquée(s) — nécessite Fliks {{version}}+",
         "hidden_versions_no_upgrade": "{{count}} version(s) masquée(s)",
         "inspect_error": "Impossible de récupérer ce plugin."
-      }
+      },
+      "status_disabled": "Désactivé",
+      "status_unavailable": "Indisponible"
     }
   },
   "roles": {

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1243,6 +1243,7 @@
     "health_app": "Applicazione",
     "health_db": "Database",
     "health_plugins": "Plugin installati",
+    "health_plugins_running": "{{count}} in esecuzione",
     "uptime": "Uptime",
     "logs_title": "Log",
     "logs_all_levels": "Tutti i livelli",
@@ -2080,6 +2081,7 @@
       "col_tier": "Tier",
       "col_trust": "Trust",
       "col_status": "Status",
+      "col_enabled": "Enabled",
       "tier_data": "Data",
       "tier_process": "Process",
       "status_active": "Active",
@@ -2091,6 +2093,10 @@
       "inspect_error": "Unable to read this archive.",
       "installed": "Plugin installed.",
       "install_failed_but_kept": "\"{{id}}\" was installed but could not start: {{reason}}",
+      "enabled_toast": "Plugin enabled.",
+      "disabled_toast": "Plugin disabled.",
+      "enable_failed_but_kept": "\"{{id}}\" is enabled but could not start: {{reason}}",
+      "toggle_error": "Unable to update the plugin state.",
       "trust": {
         "official": "Official",
         "verified": "Verified — {{key}}",
@@ -2177,7 +2183,9 @@
         "hidden_versions": "{{count}} versione/i nascosta/e — richiede Fliks {{version}}+",
         "hidden_versions_no_upgrade": "{{count}} versione/i nascosta/e",
         "inspect_error": "Impossibile recuperare questo plugin."
-      }
+      },
+      "status_disabled": "Disattivato",
+      "status_unavailable": "Non disponibile"
     }
   },
   "roles": {

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1243,6 +1243,7 @@
     "health_app": "Aplicação",
     "health_db": "Base de dados",
     "health_plugins": "Plugins instalados",
+    "health_plugins_running": "{{count}} em execução",
     "uptime": "Uptime",
     "logs_title": "Registos",
     "logs_all_levels": "Todos os níveis",
@@ -2080,6 +2081,7 @@
       "col_tier": "Tier",
       "col_trust": "Trust",
       "col_status": "Status",
+      "col_enabled": "Enabled",
       "tier_data": "Data",
       "tier_process": "Process",
       "status_active": "Active",
@@ -2091,6 +2093,10 @@
       "inspect_error": "Unable to read this archive.",
       "installed": "Plugin installed.",
       "install_failed_but_kept": "\"{{id}}\" was installed but could not start: {{reason}}",
+      "enabled_toast": "Plugin enabled.",
+      "disabled_toast": "Plugin disabled.",
+      "enable_failed_but_kept": "\"{{id}}\" is enabled but could not start: {{reason}}",
+      "toggle_error": "Unable to update the plugin state.",
       "trust": {
         "official": "Official",
         "verified": "Verified — {{key}}",
@@ -2177,7 +2183,9 @@
         "hidden_versions": "{{count}} versão(ões) oculta(s) — requer Fliks {{version}}+",
         "hidden_versions_no_upgrade": "{{count}} versão(ões) oculta(s)",
         "inspect_error": "Não foi possível obter este plugin."
-      }
+      },
+      "status_disabled": "Desativado",
+      "status_unavailable": "Indisponível"
     }
   },
   "roles": {

--- a/client/src/app/core/plugin-ui/plugin-ui-registry.service.ts
+++ b/client/src/app/core/plugin-ui/plugin-ui-registry.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, inject } from '@angular/core';
+import { Injectable, computed, inject, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom, of } from 'rxjs';
 import { catchError, timeout } from 'rxjs/operators';
@@ -17,8 +17,9 @@ const FETCH_TIMEOUT_MS = 3000;
 @Injectable({ providedIn: 'root' })
 export class PluginUiRegistryService {
   private readonly http = inject(HttpClient);
-  private entries: PluginUiEntry[] = [];
-  private bySlot = new Map<SlotId, UiContribution[]>();
+  /** A signal, so a reload after an install or a toggle re-runs every consumer's `computed`
+   *  instead of waiting for the next full page load. */
+  private readonly entriesSignal = signal<PluginUiEntry[]>([]);
 
   async load(): Promise<void> {
     const entries = await firstValueFrom(
@@ -27,13 +28,16 @@ export class PluginUiRegistryService {
         catchError(() => of<PluginUiEntry[]>([])),
       ),
     );
-    this.entries = Array.isArray(entries) ? entries : [];
-    this.index();
+    this.entriesSignal.set(Array.isArray(entries) ? entries : []);
   }
 
-  private index(): void {
+  private get entries(): PluginUiEntry[] {
+    return this.entriesSignal();
+  }
+
+  private readonly bySlotSignal = computed(() => {
     const bySlot = new Map<SlotId, UiContribution[]>();
-    for (const entry of this.entries) {
+    for (const entry of this.entriesSignal()) {
       for (const contribution of entry.contributions ?? []) {
         const list = bySlot.get(contribution.slot);
         if (list) list.push(contribution);
@@ -43,17 +47,17 @@ export class PluginUiRegistryService {
     for (const list of bySlot.values()) {
       list.sort((a, b) => a.weight - b.weight || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
     }
-    this.bySlot = bySlot;
-  }
+    return bySlot;
+  });
 
   /** Contributions for one slot, sorted ascending by weight then ascending by id. */
   contributionsFor(slot: SlotId): UiContribution[] {
-    return this.bySlot.get(slot) ?? [];
+    return this.bySlotSignal().get(slot) ?? [];
   }
 
   /** The one contribution (any slot) whose route action points at this path, if any. */
   findRouteContribution(path: string): UiContribution | undefined {
-    for (const list of this.bySlot.values()) {
+    for (const list of this.bySlotSignal().values()) {
       const found = list.find((c) => c.action.kind === 'route' && c.action.path === path);
       if (found) return found;
     }

--- a/client/src/app/core/services/api/plugins-api.service.ts
+++ b/client/src/app/core/services/api/plugins-api.service.ts
@@ -18,6 +18,10 @@ export interface PluginSummary {
   statusReason: string | null;
   signature: PluginTrust;
   verifiedByKeyId: string | null;
+  enabled: boolean;
+  /** `process` only — null for `data`, which has no supervisor. */
+  processState?: string | null;
+  statusMessage?: string;
 }
 
 /** Mirrors backend `PluginInspectReport`. A refusal carries `refusalCode`/`detail` and nothing else. */
@@ -113,6 +117,14 @@ export class PluginsApiService {
 
   uninstall(pluginId: string) {
     return firstValueFrom(this.http.delete<void>(`/api/plugins/${pluginId}`));
+  }
+
+  disable(pluginId: string) {
+    return firstValueFrom(this.http.post<PluginSummary>(`/api/plugins/${pluginId}/disable`, {}));
+  }
+
+  enable(pluginId: string) {
+    return firstValueFrom(this.http.post<PluginSummary>(`/api/plugins/${pluginId}/enable`, {}));
   }
 
   listSources() {

--- a/client/src/app/features/settings/plugins/plugins.html
+++ b/client/src/app/features/settings/plugins/plugins.html
@@ -49,6 +49,7 @@
             <th>{{ 'settings.plugins.col_tier' | translate }}</th>
             <th>{{ 'settings.plugins.col_trust' | translate }}</th>
             <th>{{ 'settings.plugins.col_status' | translate }}</th>
+            <th>{{ 'settings.plugins.col_enabled' | translate }}</th>
             <th class="text-end w-32"></th>
           </tr>
         </thead>
@@ -78,14 +79,21 @@
                 </span>
               </td>
               <td>
-                @if (row.status === 'active') {
-                  <span class="badge badge-success badge-sm">{{ 'settings.plugins.status_active' | translate }}</span>
-                } @else {
-                  <span class="badge badge-error badge-sm">{{ 'settings.plugins.status_failed' | translate }}</span>
-                  @if (row.statusReason) {
-                    <p class="text-xs text-error/80 mt-1 max-w-[16rem]">{{ row.statusReason }}</p>
-                  }
+                <span class="badge badge-sm" [class]="statusBadgeFor(row).cssClass">
+                  {{ statusBadgeFor(row).labelKey | translate }}
+                </span>
+                @if (row.status === 'failed' && row.statusReason) {
+                  <p class="text-xs text-error/80 mt-1 max-w-[16rem]">{{ row.statusReason }}</p>
                 }
+              </td>
+              <td>
+                <app-toggle-field
+                  [label]="''"
+                  [value]="row.enabled"
+                  (valueChange)="toggleEnabled(row, $event)"
+                  [disabled]="togglingId() === row.pluginId"
+                  toggleClass="toggle-primary toggle-sm"
+                />
               </td>
               <td class="text-end">
                 <button type="button" class="btn btn-ghost btn-xs text-error" (click)="uninstall(row)">

--- a/client/src/app/features/settings/plugins/plugins.spec.ts
+++ b/client/src/app/features/settings/plugins/plugins.spec.ts
@@ -1,0 +1,119 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { PluginsSettingsComponent } from './plugins';
+import { ConfirmationService } from '../../../core/services/confirmation.service';
+import type { PluginSummary } from '../../../core/services/api/plugins-api.service';
+
+/** Drives the enable/disable toggle through its rendered DOM and the real HTTP wire. */
+
+async function settle(fixture: ComponentFixture<unknown>) {
+  await fixture.whenStable();
+  await new Promise((r) => setTimeout(r, 0));
+  fixture.detectChanges();
+}
+
+const ROW: PluginSummary = {
+  pluginId: 'fliks.acme',
+  name: 'Acme',
+  version: '1.0.0',
+  kind: 'data',
+  origin: 'manual',
+  status: 'active',
+  statusReason: null,
+  signature: 'unsigned',
+  verifiedByKeyId: null,
+  enabled: true,
+};
+
+async function createComponent(rows: PluginSummary[] = [ROW]) {
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      provideRouter([]),
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      provideTranslateService({
+        lang: 'en',
+        loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+      }),
+      { provide: ConfirmationService, useValue: { confirm: () => Promise.resolve(true) } },
+    ],
+  });
+  const http = TestBed.inject(HttpTestingController);
+  const fixture = TestBed.createComponent(PluginsSettingsComponent);
+  fixture.detectChanges();
+  http.expectOne({ url: '/api/plugins', method: 'GET' }).flush(rows);
+  http.expectOne({ url: '/api/plugins/sources', method: 'GET' }).flush([]);
+  await settle(fixture);
+  return { fixture, http };
+}
+
+function toggleInput(fixture: ComponentFixture<unknown>): HTMLInputElement {
+  const input = (fixture.nativeElement as HTMLElement).querySelector('tbody input.toggle');
+  if (!input) throw new Error('No row toggle found');
+  return input as HTMLInputElement;
+}
+
+describe('PluginsSettingsComponent — enable/disable toggle', () => {
+  afterEach(() => TestBed.inject(HttpTestingController).verify());
+
+  it('disabling calls POST .../disable and the row signal reflects the response', async () => {
+    const { fixture, http } = await createComponent();
+    expect(toggleInput(fixture).checked).toBe(true);
+
+    toggleInput(fixture).click();
+    await settle(fixture);
+
+    const req = http.expectOne({ url: '/api/plugins/fliks.acme/disable', method: 'POST' });
+    // The server disagrees with what the native click alone already shows, so only a
+    // real read of this response — not the click's own DOM side effect — can pass.
+    req.flush({ ...ROW, enabled: true, statusReason: 'server-said-so' });
+    await settle(fixture);
+    // Contributions are re-read so the nav and the settings sidebar follow the switch.
+    http.expectOne({ url: '/api/plugins/ui', method: 'GET' }).flush([]);
+    await settle(fixture);
+
+    expect(fixture.componentInstance.rows()[0]).toEqual(expect.objectContaining({ enabled: true, statusReason: 'server-said-so' }));
+  });
+
+  it('enabling calls POST .../enable and the row signal reflects the response', async () => {
+    const { fixture, http } = await createComponent([{ ...ROW, enabled: false }]);
+    expect(toggleInput(fixture).checked).toBe(false);
+
+    toggleInput(fixture).click();
+    await settle(fixture);
+
+    const req = http.expectOne({ url: '/api/plugins/fliks.acme/enable', method: 'POST' });
+    req.flush({ ...ROW, enabled: false, statusReason: 'server-said-so' });
+    await settle(fixture);
+    http.expectOne({ url: '/api/plugins/ui', method: 'GET' }).flush([]);
+    await settle(fixture);
+
+    expect(fixture.componentInstance.rows()[0]).toEqual(expect.objectContaining({ enabled: false, statusReason: 'server-said-so' }));
+  });
+
+  it('VERDICT: a disabled plugin does not read as active in the status column', async () => {
+    const { fixture } = await createComponent([{ ...ROW, enabled: false }]);
+
+    const badges = Array.from((fixture.nativeElement as HTMLElement).querySelectorAll('tbody .badge')).map(
+      (b) => b.textContent?.trim(),
+    );
+    expect(badges).toContain('settings.plugins.status_disabled');
+    expect(badges).not.toContain('settings.plugins.status_active');
+  });
+
+  it('a plugin that is on but not answering reads as unavailable, not active', async () => {
+    const { fixture } = await createComponent([{ ...ROW, kind: 'process', processState: 'backoff' }]);
+
+    const badges = Array.from((fixture.nativeElement as HTMLElement).querySelectorAll('tbody .badge')).map(
+      (b) => b.textContent?.trim(),
+    );
+    expect(badges).toContain('settings.plugins.status_unavailable');
+    expect(badges).not.toContain('settings.plugins.status_active');
+  });
+});

--- a/client/src/app/features/settings/plugins/plugins.ts
+++ b/client/src/app/features/settings/plugins/plugins.ts
@@ -12,7 +12,9 @@ import { LucideEllipsisVertical } from '@lucide/angular';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { ToastService } from '../../../core/services/toast.service';
+import { PluginUiRegistryService } from '../../../core/plugin-ui/plugin-ui-registry.service';
 import { DropdownMenuComponent } from '../../../shared/components/dropdown-menu';
+import { ToggleFieldComponent } from '../../../shared/components/forms/toggle-field/toggle-field';
 import {
   PluginsApiService,
   PluginSummary,
@@ -25,7 +27,15 @@ import { trustBadgeFor } from './plugin-trust';
 
 @Component({
   selector: 'app-plugins-settings',
-  imports: [RouterLink, LucideEllipsisVertical, TranslateModule, DropdownMenuComponent, PluginInstallConsentComponent, PluginSourcesComponent],
+  imports: [
+    RouterLink,
+    LucideEllipsisVertical,
+    TranslateModule,
+    DropdownMenuComponent,
+    ToggleFieldComponent,
+    PluginInstallConsentComponent,
+    PluginSourcesComponent,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './plugins.html',
 })
@@ -33,6 +43,7 @@ export class PluginsSettingsComponent implements OnInit {
   private readonly api = inject(PluginsApiService);
   private readonly translate = inject(TranslateService);
   private readonly toast = inject(ToastService);
+  private readonly registry = inject(PluginUiRegistryService);
   private readonly confirmation = inject(ConfirmationService);
 
   private readonly fileInput = viewChild<ElementRef<HTMLInputElement>>('fileInput');
@@ -43,6 +54,7 @@ export class PluginsSettingsComponent implements OnInit {
   readonly loading = signal(true);
   readonly listError = signal('');
   readonly uploading = signal(false);
+  readonly togglingId = signal<string | null>(null);
 
   readonly trustBadgeFor = trustBadgeFor;
 
@@ -109,6 +121,46 @@ export class PluginsSettingsComponent implements OnInit {
           reason: result.detail ?? result.reason ?? '',
         }),
       );
+    }
+  }
+
+  /** Idempotent on the backend, so a stray double-click never 409s — only the in-flight guard here matters for the UI. */
+  /** What the row is actually doing, in the order that matters to an operator: their own off
+   *  switch, then a failed activation, then a process that is up but not answering. */
+  statusBadgeFor(row: PluginSummary): { labelKey: string; cssClass: string } {
+    if (!row.enabled) return { labelKey: 'settings.plugins.status_disabled', cssClass: 'badge-ghost' };
+    if (row.status === 'failed') return { labelKey: 'settings.plugins.status_failed', cssClass: 'badge-error' };
+    if (row.processState && row.processState !== 'ready') {
+      return { labelKey: 'settings.plugins.status_unavailable', cssClass: 'badge-warning' };
+    }
+    return { labelKey: 'settings.plugins.status_active', cssClass: 'badge-success' };
+  }
+
+  async toggleEnabled(row: PluginSummary, enabled: boolean): Promise<void> {
+    if (this.togglingId()) return;
+    this.togglingId.set(row.pluginId);
+    try {
+      const updated = enabled ? await this.api.enable(row.pluginId) : await this.api.disable(row.pluginId);
+      this.rows.update((rows) => rows.map((r) => (r.pluginId === updated.pluginId ? updated : r)));
+      // The nav, the settings sidebar and every action slot read the registry — without this
+      // a toggled plugin's entries only appear or vanish on the next full page load.
+      await this.registry.load();
+      if (updated.status === 'failed') {
+        this.toast.warning(
+          this.translate.instant('settings.plugins.enable_failed_but_kept', {
+            id: updated.pluginId,
+            reason: updated.statusReason ?? '',
+          }),
+        );
+      } else {
+        this.toast.success(
+          this.translate.instant(enabled ? 'settings.plugins.enabled_toast' : 'settings.plugins.disabled_toast'),
+        );
+      }
+    } catch {
+      this.toast.error(this.translate.instant('settings.plugins.toggle_error'));
+    } finally {
+      this.togglingId.set(null);
     }
   }
 

--- a/client/src/app/features/system/status/status.html
+++ b/client/src/app/features/system/status/status.html
@@ -33,6 +33,7 @@
       <div class="card-body py-4 px-5 gap-2">
         <p class="text-sm text-base-content/50 uppercase tracking-wide">{{ 'system.health_plugins' | translate }}</p>
         <p class="text-lg font-semibold">{{ h.installedPlugins | number }}</p>
+        <p class="text-sm text-base-content/60">{{ 'system.health_plugins_running' | translate: { count: h.runningPlugins } }}</p>
       </div>
     </div>
   </div>

--- a/client/src/app/features/system/status/status.ts
+++ b/client/src/app/features/system/status/status.ts
@@ -14,7 +14,7 @@ import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
 
 interface CommandEntry { id: number; name: string; status: string; trigger: string; startedOn: string; endedOn?: string; body?: Record<string, unknown>; }
 interface ServiceStatus { name: string; ok: boolean; message?: string; }
-interface HealthReport { version: string; uptimeSeconds: number; database: ServiceStatus; installedPlugins: number; restartSupervisor: string | null; }
+interface HealthReport { version: string; uptimeSeconds: number; database: ServiceStatus; installedPlugins: number; runningPlugins: number; restartSupervisor: string | null; }
 /** Trimmed to what the manual-trigger button list needs. */
 interface SchedulerJob { name: string; triggerable: boolean; labelKey: string; }
 


### PR DESCRIPTION
## Why

A plugin was either installed and running, or uninstalled — and uninstall runs `DROP OWNED BY` + `DROP SCHEMA CASCADE`. The only way to stop a misbehaving plugin was to lose its data.

## What

- `plugin_packages.enabled` (migration `1783500000000`), `POST /plugins/:pluginId/disable` and `/enable`, both idempotent and 404 on an unknown id.
- Disabling stops the supervisor and calls `registry.unregister()` — routes, contributions, jobs and webhooks stop resolving — while the package row, the archive, the Postgres role and the schema stay untouched.
- Boot skips a disabled package before touching it, and **an upgrade over a disabled plugin stores the new archive and stays off**: `promote()` used to call `register()` unconditionally, so a version bump silently reactivated it.
- The admin page gets a per-row toggle, and the health card reports running against installed.

### One flag, not two

The repo already had a second mechanism: `PATCH /plugins/:pluginId` writing `plugin_registrations.enabled`, process-only, called by nothing in the client. Keeping both would have left two flags free to disagree about the same question — with `register()` consulting one and boot the other. The registration column, its route, its DTO and `registry.setEnabled` are removed; migration `1783600000000` carries any disabled state over to the package row before dropping the column.

## Two defects the maintainer hit while using it

- **The status column read "Actif" on a disabled plugin.** It rendered `status`, which is the *activation outcome* (`active`/`failed`) — a different question from what the plugin is doing. It now derives: switched off → *Disabled*; failed activation → *Failed* with its reason; up but not `ready` → *Unavailable*; otherwise *Active*.
- **The sidebar did not follow a toggle.** `PluginUiRegistryService` held its entries in plain fields while every consumer reads them through `computed()`, so a reload changed nothing until a full page load. The entries are a signal now — nav, settings sidebar, media/card/season action slots and the release picker all follow — and the toggle re-reads `/api/plugins/ui`.

## Verification

Backend `tsc` exit 0, **125 suites / 1337 tests**. Client `ng build` exit 0, **42 files / 355 tests**.

Migrations on a throwaway `postgres:17`: the whole chain applies, `plugin_packages.enabled` exists and `plugin_registrations.enabled` is gone; `revert` restores the column; re-running drops it again and a package row seeded `enabled = false` survives the round trip.

Live against the dev stack with a real `process` plugin:

| step | result |
|---|---|
| before | `enabled: true`, `processState: ready`, 1 `plugin.js` process, `GET /queue` → 200 |
| `POST /disable` | `enabled: false`, `processState: null`, **0** processes, `GET /queue` → **503**, `/plugins/ui` → `[]` |
| data | schema `plugin_fliks_download` and its 7 tables still present |
| `POST /enable` | `enabled: true`, `processState: ready`, 1 process, `GET /queue` → 200 |
| idempotence / unknown id | repeated disable → 201; `fliks.acme` → 404 |
| health | `installedPlugins: 1`, `runningPlugins: 1` (0 while disabled) |

Both new guards were sabotage-checked: removing the boot skip fails the boot tests, removing the upgrade guard fails the new upgrade-while-disabled spec, and removing the disabled branch of the status badge fails the column spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)