### PR TITLE
feat(plugins): let a data plugin's webhook point at the operator's own endpoint

### DIFF
--- a/backend/src/common/plugin-contract/manifest.ts
+++ b/backend/src/common/plugin-contract/manifest.ts
@@ -29,10 +29,15 @@ export type PluginWebhookEventName = (typeof PLUGIN_WEBHOOK_EVENT_NAMES)[number]
  * fields are optional at the type level — a manifest is untrusted JSON, so
  * `PluginRegistryService` validates every entry before believing it.
  */
+/** Makes a webhook target the operator's own: the rest of the value names a field the plugin
+ *  declares on a `form` page, read at delivery. A manifest cannot know an install's endpoint. */
+export const WEBHOOK_SETTING_PREFIX = 'setting:';
+
 export interface PluginWebhookDeclaration {
   event: PluginWebhookEventName;
-  /** An absolute https URL. Validated again at registration and at every
-   *  dispatch: a manifest is untrusted JSON and DNS can move under it. */
+  /** An absolute https URL, or `setting:<key>`. Either way it is validated at registration and
+   *  again at every dispatch: a manifest is untrusted JSON, a setting is operator input, and
+   *  DNS can move under both. */
   webhook: string;
 }
 

--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -149,6 +149,10 @@ export interface ProvidersConfigPage extends ConfigPageBase {
     emptyKey?: string;
     testKey?: string;
     deleteConfirmKey?: string;
+    /** The editor dialog's own titles — "New instance" reads like a placeholder on a page
+     *  about indexers. */
+    createTitleKey?: string;
+    editTitleKey?: string;
   };
 }
 

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -16,6 +16,7 @@ import { arePluginsDisabled, FLIKS_PLUGINS_DISABLED_ENV } from '../../common/con
 import {
   PLUGIN_API_VERSION,
   PLUGIN_WEBHOOK_EVENT_NAMES,
+  WEBHOOK_SETTING_PREFIX,
   type PluginKind,
   type PluginManifest,
   type ProcessPluginManifest,
@@ -24,6 +25,7 @@ import {
   type PluginJob,
   type ReleasePickerPair,
   type ReleasePickerRoutes,
+  type ConfigPage,
 } from '../../common/plugin-contract';
 import { OFFICIAL_KEYS, resolveTrust, readArchiveEntries, type TrustOutcome } from './archive';
 import { isInternalAddress } from './internal-address';
@@ -86,6 +88,7 @@ export type PluginRegistrationFailureReason =
   | 'invalid-webhook-url'
   | 'insecure-webhook-scheme'
   | 'internal-webhook-host'
+  | 'unknown-webhook-setting'
   | 'invalid-route-method'
   | 'invalid-route-path'
   | 'invalid-route-policy'
@@ -135,6 +138,16 @@ export type PluginRegistrationResult = PluginRegistrationSuccess | PluginRegistr
  * tiers (P4a). L1 (`state.json` quarantine) still has no home; L3
  * (re-hashing `plugin.js` from the loaded fd) is `PluginProcessService`'s.
  */
+/** Keys a plugin declares on its `form` pages — the only values an operator can set for it. */
+function formFieldKeys(pages: ConfigPage[]): ReadonlySet<string> {
+  const keys = new Set<string>();
+  for (const page of pages) {
+    if (page.kind && page.kind !== 'form') continue;
+    for (const field of page.fields ?? []) if (typeof field?.key === 'string') keys.add(field.key);
+  }
+  return keys;
+}
+
 @Injectable()
 export class PluginRegistryService implements OnModuleInit {
   private readonly logger = new Logger(PluginRegistryService.name);
@@ -214,7 +227,10 @@ export class PluginRegistryService implements OnModuleInit {
 
     // Structurally legal on `process` too, but only `data` fans out over HTTP —
     // `process` gets domain events pushed over its own socket instead.
-    const webhookCheck = this.validateWebhookDeclarations(manifest.events ?? []);
+    const webhookCheck = this.validateWebhookDeclarations(
+      manifest.events ?? [],
+      formFieldKeys(manifest.ui?.configPages ?? []),
+    );
     if (!webhookCheck.ok) return this.fail(pkg.pluginId, webhookCheck.reason, webhookCheck.detail);
 
     const releasePickerCheck = this.validateReleasePicker(
@@ -397,6 +413,7 @@ export class PluginRegistryService implements OnModuleInit {
    */
   private validateWebhookDeclarations(
     raw: unknown[],
+    settingKeys: ReadonlySet<string>,
   ):
     | { ok: true; declarations: { event: PluginWebhookEventName; webhook: string }[] }
     | { ok: false; reason: PluginRegistrationFailureReason; detail: string } {
@@ -408,6 +425,19 @@ export class PluginRegistryService implements OnModuleInit {
 
       if (!WEBHOOK_EVENT_NAMES.has(event)) {
         return { ok: false, reason: 'invalid-webhook-event', detail: `event "${event}" is not a recognised domain event` };
+      }
+      if (webhook.startsWith(WEBHOOK_SETTING_PREFIX)) {
+        // A key naming nothing would deliver nowhere, in silence, forever.
+        const key = webhook.slice(WEBHOOK_SETTING_PREFIX.length);
+        if (!settingKeys.has(key)) {
+          return {
+            ok: false,
+            reason: 'unknown-webhook-setting',
+            detail: `webhook "${webhook}" names no field declared on a form page`,
+          };
+        }
+        declarations.push({ event: event as PluginWebhookEventName, webhook });
+        continue;
       }
       let url: URL;
       try {

--- a/backend/src/modules/plugins/plugin-registry.service.webhooks.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.webhooks.spec.ts
@@ -82,6 +82,35 @@ describe('PluginRegistryService — webhooks', () => {
     });
   });
 
+  it('accepts `setting:` naming a field the plugin declares on a form page', async () => {
+    const manifest = minimalDataManifest({
+      fliks: COMPATIBLE_RANGE,
+      events: [webhookDeclaration({ webhook: 'setting:endpoint_url' })],
+      ui: { configPages: [{ id: 'general', labelKey: 'x', fields: [{ key: 'endpoint_url', type: 'url', labelKey: 'y' }] }] },
+    });
+    const service = makeService();
+
+    await expect(service.register(makePackage(manifest))).resolves.toEqual({ ok: true, pluginId: manifest.id });
+  });
+
+  it('VERDICT: refuses `setting:` naming a field no page declares — it would deliver nowhere, in silence', async () => {
+    const manifest = minimalDataManifest({
+      fliks: COMPATIBLE_RANGE,
+      events: [webhookDeclaration({ webhook: 'setting:typo_url' })],
+      ui: { configPages: [{ id: 'general', labelKey: 'x', fields: [{ key: 'endpoint_url', type: 'url', labelKey: 'y' }] }] },
+    });
+    const service = makeService();
+
+    const result = await service.register(makePackage(manifest));
+
+    expect(result).toEqual({
+      ok: false,
+      pluginId: manifest.id,
+      reason: 'unknown-webhook-setting',
+      detail: expect.any(String),
+    });
+  });
+
   it('refuses a malformed webhook URL', async () => {
     const manifest = minimalDataManifest({
       fliks: COMPATIBLE_RANGE,

--- a/backend/src/modules/plugins/plugin-webhook-dispatcher.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-webhook-dispatcher.service.spec.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosRequestConfig } from 'axios';
 import * as dns from 'dns';
 import { PluginWebhookDispatcherService } from './plugin-webhook-dispatcher.service';
+import type { SettingsService } from '../settings/settings.service';
 import { EventsService } from '../scheduler/events.service';
 import { PluginRegistryService } from './plugin-registry.service';
 
@@ -8,6 +9,11 @@ jest.mock('dns', () => ({ promises: { lookup: jest.fn() } }));
 
 function registryStub(map: Record<string, { pluginId: string; webhook: string }[]>): PluginRegistryService {
   return { listWebhooksForEvent: jest.fn((eventType: string) => map[eventType] ?? []) } as unknown as PluginRegistryService;
+}
+
+/** Only `get` is reached: a `setting:` webhook resolves through it, a literal URL never touches it. */
+function settingsStub(values: Record<string, string> = {}) {
+  return { get: async (key: string) => values[key] ?? null } as unknown as SettingsService;
 }
 
 const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
@@ -36,7 +42,7 @@ describe('PluginWebhookDispatcherService', () => {
       'media.imported': [{ pluginId: 'fliks.plugin-a', webhook: 'https://hooks.example/a' }],
     });
     const events = new EventsService();
-    new PluginWebhookDispatcherService(events, registry).onModuleInit();
+    new PluginWebhookDispatcherService(events, registry, settingsStub()).onModuleInit();
 
     events.emitDomain({ type: 'media.imported', mediaId: 1, tmdbId: null, mediaType: 'movie', libraryId: null, addedByUserId: null });
     await flush();
@@ -48,7 +54,7 @@ describe('PluginWebhookDispatcherService', () => {
   it('does not deliver to a plugin subscribed to a different event', async () => {
     const registry = registryStub({}); // nothing subscribed to media.removed
     const events = new EventsService();
-    new PluginWebhookDispatcherService(events, registry).onModuleInit();
+    new PluginWebhookDispatcherService(events, registry, settingsStub()).onModuleInit();
 
     events.emitDomain({ type: 'media.removed', mediaId: 1, tmdbId: null, mediaType: 'movie' });
     await flush();
@@ -64,7 +70,7 @@ describe('PluginWebhookDispatcherService', () => {
       ],
     });
     const events = new EventsService();
-    new PluginWebhookDispatcherService(events, registry).onModuleInit();
+    new PluginWebhookDispatcherService(events, registry, settingsStub()).onModuleInit();
 
     events.emitDomain({ type: 'settings.changed', key: 'library_path' });
     await flush();
@@ -78,7 +84,7 @@ describe('PluginWebhookDispatcherService', () => {
       'settings.changed': [{ pluginId: 'fliks.rebinder', webhook: 'https://rebinder.example/hook' }],
     });
     const events = new EventsService();
-    new PluginWebhookDispatcherService(events, registry).onModuleInit();
+    new PluginWebhookDispatcherService(events, registry, settingsStub()).onModuleInit();
 
     events.emitDomain({ type: 'settings.changed', key: 'x' });
     await flush();
@@ -99,7 +105,7 @@ describe('PluginWebhookDispatcherService', () => {
       return Promise.resolve({ data: {}, status: 200, statusText: 'OK', headers: {}, config }) as never;
     };
     const events = new EventsService();
-    new PluginWebhookDispatcherService(events, registry).onModuleInit();
+    new PluginWebhookDispatcherService(events, registry, settingsStub()).onModuleInit();
 
     // emitDomain is synchronous and void — the caller (and the emitter's own contract) is never affected.
     expect(() => events.emitDomain({ type: 'settings.changed', key: 'x' })).not.toThrow();
@@ -114,7 +120,7 @@ describe('PluginWebhookDispatcherService', () => {
       'media.removed': [{ pluginId: 'fliks.plugin-a', webhook: 'https://hooks.example/a' }],
     });
     const events = new EventsService();
-    new PluginWebhookDispatcherService(events, registry).onModuleInit();
+    new PluginWebhookDispatcherService(events, registry, settingsStub()).onModuleInit();
 
     events.emitDomain({ type: 'media.removed', mediaId: 42, tmdbId: 99, mediaType: 'movie' });
     await flush();
@@ -123,5 +129,46 @@ describe('PluginWebhookDispatcherService', () => {
       event: { type: 'media.removed', mediaId: 42, tmdbId: 99, mediaType: 'movie' },
       pluginId: 'fliks.plugin-a',
     });
+  });
+
+    it("VERDICT: resolves `setting:` to the operator's own URL and posts there", async () => {
+      const registry = registryStub({
+        'media.imported': [{ pluginId: 'fliks.acme', webhook: 'setting:endpoint_url' }],
+      });
+      const events = new EventsService();
+      const settings = settingsStub({ 'plugin.fliks.acme.endpoint_url': 'https://hooks.example/mine' });
+      new PluginWebhookDispatcherService(events, registry, settings).onModuleInit();
+
+      events.emitDomain({ type: 'media.imported', mediaId: 1, tmdbId: null, mediaType: 'movie', libraryId: null, addedByUserId: null });
+      await flush();
+
+      expect(requests.map((r) => r.url)).toEqual(['https://hooks.example/mine']);
+    });
+
+    it('posts nothing while the endpoint is unset — an operator who has not filled it in is not a failure', async () => {
+      const registry = registryStub({
+        'media.imported': [{ pluginId: 'fliks.acme', webhook: 'setting:endpoint_url' }],
+      });
+      const events = new EventsService();
+      new PluginWebhookDispatcherService(events, registry, settingsStub()).onModuleInit();
+
+      events.emitDomain({ type: 'media.imported', mediaId: 1, tmdbId: null, mediaType: 'movie', libraryId: null, addedByUserId: null });
+      await flush();
+
+      expect(requests).toHaveLength(0);
+    });
+
+    it('refuses a configured endpoint that is not https', async () => {
+      const registry = registryStub({
+        'media.imported': [{ pluginId: 'fliks.acme', webhook: 'setting:endpoint_url' }],
+      });
+      const events = new EventsService();
+      const settings = settingsStub({ 'plugin.fliks.acme.endpoint_url': 'http://hooks.example/mine' });
+      new PluginWebhookDispatcherService(events, registry, settings).onModuleInit();
+
+      events.emitDomain({ type: 'media.imported', mediaId: 1, tmdbId: null, mediaType: 'movie', libraryId: null, addedByUserId: null });
+      await flush();
+
+      expect(requests).toHaveLength(0);
   });
 });

--- a/backend/src/modules/plugins/plugin-webhook-dispatcher.service.ts
+++ b/backend/src/modules/plugins/plugin-webhook-dispatcher.service.ts
@@ -5,6 +5,8 @@ import * as dns from 'dns';
 import { EventsService, type DomainEvent } from '../scheduler/events.service';
 import { PluginRegistryService } from './plugin-registry.service';
 import { isInternalAddress } from './internal-address';
+import { SettingsService } from '../settings/settings.service';
+import { WEBHOOK_SETTING_PREFIX } from '../../common/plugin-contract';
 
 const WEBHOOK_TIMEOUT_MS = 5_000;
 /** Core never reads the body — cap it so a hostile endpoint can't hold the connection streaming data. */
@@ -23,6 +25,7 @@ export class PluginWebhookDispatcherService implements OnModuleInit, OnModuleDes
   constructor(
     private readonly events: EventsService,
     private readonly registry: PluginRegistryService,
+    private readonly settings: SettingsService,
   ) {}
 
   onModuleInit(): void {
@@ -44,7 +47,22 @@ export class PluginWebhookDispatcherService implements OnModuleInit, OnModuleDes
    * does not eliminate the attack: the HTTP client below re-resolves the same name to
    * actually connect, leaving a window between this check and its connect().
    */
-  private async deliver(pluginId: string, webhook: string, event: DomainEvent): Promise<void> {
+  /** `setting:<key>` reads `plugin.<id>.<key>`; an operator who hasn't filled it in yet has no
+   *  endpoint, which is a normal state and not a failure to report. */
+  private async resolveTarget(pluginId: string, webhook: string): Promise<string | null> {
+    if (!webhook.startsWith(WEBHOOK_SETTING_PREFIX)) return webhook;
+    const key = `plugin.${pluginId}.${webhook.slice(WEBHOOK_SETTING_PREFIX.length)}`;
+    const value = (await this.settings.get(key))?.trim();
+    return value ? value : null;
+  }
+
+  private async deliver(pluginId: string, declared: string, event: DomainEvent): Promise<void> {
+    const webhook = await this.resolveTarget(pluginId, declared);
+    if (!webhook) return;
+    if (!webhook.startsWith('https://')) {
+      this.logger.warn(`plugin "${pluginId}" webhook skipped — configured endpoint is not https`);
+      return;
+    }
     let hostname: string;
     try {
       hostname = new URL(webhook).hostname;

--- a/client/src/app/core/plugin-ui/contribution.types.ts
+++ b/client/src/app/core/plugin-ui/contribution.types.ts
@@ -152,6 +152,10 @@ export interface ProvidersConfigPage extends ConfigPageBase {
     emptyKey?: string;
     testKey?: string;
     deleteConfirmKey?: string;
+    /** The editor dialog's own titles — "New instance" reads like a placeholder on a page
+     *  about indexers. */
+    createTitleKey?: string;
+    editTitleKey?: string;
   };
 }
 

--- a/client/src/app/features/plugin-view/plugin-view.ts
+++ b/client/src/app/features/plugin-view/plugin-view.ts
@@ -261,6 +261,8 @@ export class PluginViewComponent {
       ...(l?.emptyKey ? { emptyKey: l.emptyKey } : {}),
       ...(l?.testKey ? { testConnectionKey: l.testKey } : {}),
       ...(l?.deleteConfirmKey ? { confirmDeleteKey: l.deleteConfirmKey } : {}),
+      ...(l?.createTitleKey ? { createTitleKey: l.createTitleKey } : {}),
+      ...(l?.editTitleKey ? { editTitleKey: l.editTitleKey } : {}),
     };
   }
 

--- a/client/src/app/shared/components/provider-list/provider-list.html
+++ b/client/src/app/shared/components/provider-list/provider-list.html
@@ -106,6 +106,15 @@
       <h2 class="text-lg font-bold leading-tight">
         {{ (editingId() === null ? labels().createTitleKey : labels().editTitleKey) | translate }}
       </h2>
+      <button
+        type="button"
+        class="btn btn-sm btn-circle btn-ghost shrink-0"
+        (click)="closeEditor()"
+        [disabled]="saving()"
+        [attr.aria-label]="labels().cancelKey | translate"
+      >
+        ✕
+      </button>
     </div>
     <div class="px-5 sm:px-6 py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 bg-base-100">
       <app-input-field

--- a/client/src/app/shared/components/provider-list/provider-list.spec.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.spec.ts
@@ -81,6 +81,7 @@ async function createComponent(
     rowActions: ProviderRowAction[];
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     confirmation: { confirm: (...a: any[]) => Promise<boolean>; alert: (...a: any[]) => Promise<void> };
+    labels: ProviderListLabels;
   }> = {},
 ) {
   TestBed.configureTestingModule({
@@ -101,7 +102,7 @@ async function createComponent(
   fixture.componentRef.setInput('titleKey', 'x.title');
   fixture.componentRef.setInput('listUrl', '/api/x');
   fixture.componentRef.setInput('implementations', opts.implementations ?? IMPLS);
-  fixture.componentRef.setInput('labels', LABELS);
+  fixture.componentRef.setInput('labels', opts.labels ?? LABELS);
   if (opts.reorderable) fixture.componentRef.setInput('reorderable', opts.reorderable);
   if (opts.listActions) fixture.componentRef.setInput('listActions', opts.listActions);
   if (opts.rowActions) fixture.componentRef.setInput('rowActions', opts.rowActions);
@@ -314,5 +315,31 @@ describe('resolveRowActionRoute', () => {
 
   it('returns null when the route never had :id to begin with', () => {
     expect(resolveRowActionRoute('/api/plugins/x/indexers/cooldowns', 7)).toBeNull();
+  });
+});
+
+describe('ProviderListComponent — editor dialog chrome', () => {
+  it('names the dialog from the page, and closes on the ✕ without saving', async () => {
+    const get = vi.fn(() => of([{ id: 1, name: 'A', implementation: 'demo', enabled: true, priority: 1, settings: {} }]));
+    const post = vi.fn(() => of({}));
+    const fixture = await createComponent(
+      { get, post },
+      { labels: { ...LABELS, createTitleKey: 'x.new_indexer' } },
+    );
+
+    fixture.componentInstance.openCreate();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('x.new_indexer');
+
+    const close = Array.from(fixture.nativeElement.querySelectorAll('dialog button')).find(
+      (b) => (b as HTMLButtonElement).textContent?.trim() === '✕',
+    ) as HTMLButtonElement | undefined;
+    expect(close).toBeTruthy();
+    close!.click();
+    await fixture.whenStable();
+
+    expect(post).not.toHaveBeenCalled();
+    expect(fixture.componentInstance.editingId()).toBeNull();
   });
 });


### PR DESCRIPTION
## Why

`events[].webhook` was an absolute URL frozen into the manifest, so a `data` plugin could only ever POST where its author chose at publish time. That is why the one published webhook plugin ships `https://example.com/fliks/webhooks`: installed on a real server it notifies nobody, and no config page could have fixed it — there was no path from a setting to a webhook target.

## What

`webhook` accepts `setting:<key>` besides an https URL.

- **Resolved at delivery** from `plugin.<id>.<key>`, so the operator's own endpoint on the plugin's own `form` page is what gets used.
- **Refused at registration** (`unknown-webhook-setting`) when the key names no field the plugin declares on a `form` page — a typo would otherwise deliver nowhere, in silence, for good.
- **Unset is not a failure.** Nothing is posted until someone fills the field in; an operator mid-setup produces no warnings.
- The https check, the internal-address check and the per-delivery DNS re-resolution apply to a configured URL exactly as to a declared one — a setting is operator input, not a trusted constant.

## And the dialog titles

A `providers` page can name its editor dialog (`labels.createTitleKey` / `labels.editTitleKey`). "Nouvelle instance" reads like a placeholder on a page about indexers. The download plugin now says *Nouvel indexeur* / *Nouveau client de téléchargement* and their edit equivalents, and the dialog gets the close ✕ it was missing (disabled while saving, so it can't be used to abandon a write mid-flight).

## Verification

Backend `tsc` exit 0, **125 suites / 1342 tests**. Client `ng build` exit 0, **42 files / 356 tests**. Plugin repo 256 tests.

New specs, each sabotage-checked: `setting:` resolves to the configured URL and posts there; an unset endpoint posts nothing; a configured `http://` endpoint is refused (removing the guard fails it); registration accepts a key that a form page declares and refuses one it does not; the dialog takes its title from the page and the ✕ closes without saving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)