### PR TITLE
fix(plugins): re-read contributions after an install or an uninstall

### DIFF
--- a/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue-page.ts
+++ b/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue-page.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, OnInit, computed, inject, signal, v
 import { RouterLink } from '@angular/router';
 import { LucideChevronLeft } from '@lucide/angular';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { PluginUiRegistryService } from '../../../../core/plugin-ui/plugin-ui-registry.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import {
   PluginsApiService,
@@ -21,6 +22,7 @@ import { PluginCatalogueComponent } from './plugin-catalogue';
 })
 export class PluginCataloguePageComponent implements OnInit {
   private readonly api = inject(PluginsApiService);
+  private readonly registry = inject(PluginUiRegistryService);
   private readonly translate = inject(TranslateService);
   private readonly toast = inject(ToastService);
 
@@ -48,6 +50,9 @@ export class PluginCataloguePageComponent implements OnInit {
 
   async onInstalled(result: PluginInstallResult): Promise<void> {
     await this.reload();
+    // The sidebar and the nav read the registry: without this a freshly installed plugin's
+    // pages exist and nothing links to them until the next full page load.
+    await this.registry.load();
     if (result.status === 'active') {
       this.toast.success(this.translate.instant('settings.plugins.installed'));
     } else {

--- a/client/src/app/features/settings/plugins/plugins.spec.ts
+++ b/client/src/app/features/settings/plugins/plugins.spec.ts
@@ -97,6 +97,22 @@ describe('PluginsSettingsComponent — enable/disable toggle', () => {
     expect(fixture.componentInstance.rows()[0]).toEqual(expect.objectContaining({ enabled: false, statusReason: 'server-said-so' }));
   });
 
+  it('VERDICT: uninstalling re-reads the contributions, so the sidebar loses the plugin at once', async () => {
+    const { fixture, http } = await createComponent();
+
+    void fixture.componentInstance.uninstall(ROW);
+    await settle(fixture);
+    http.expectOne({ url: '/api/plugins/fliks.acme', method: 'DELETE' }).flush({});
+    await settle(fixture);
+    http.expectOne({ url: '/api/plugins', method: 'GET' }).flush([]);
+    http.expectOne({ url: '/api/plugins/sources', method: 'GET' }).flush([]);
+    await settle(fixture);
+
+    // Without this the pages stay linked in the admin sidebar until a full page load.
+    http.expectOne({ url: '/api/plugins/ui', method: 'GET' }).flush([]);
+    await settle(fixture);
+  });
+
   it('VERDICT: a disabled plugin does not read as active in the status column', async () => {
     const { fixture } = await createComponent([{ ...ROW, enabled: false }]);
 

--- a/client/src/app/features/settings/plugins/plugins.ts
+++ b/client/src/app/features/settings/plugins/plugins.ts
@@ -112,6 +112,7 @@ export class PluginsSettingsComponent implements OnInit {
 
   async onInstalled(result: PluginInstallResult): Promise<void> {
     await this.reload();
+    await this.registry.load();
     if (result.status === 'active') {
       this.toast.success(this.translate.instant('settings.plugins.installed'));
     } else {
@@ -175,6 +176,7 @@ export class PluginsSettingsComponent implements OnInit {
     try {
       await this.api.uninstall(row.pluginId);
       await this.reload();
+      await this.registry.load();
       this.toast.success(this.translate.instant('settings.plugins.uninstalled'));
     } catch {
       this.toast.error(this.translate.instant('settings.plugins.uninstall_error'));


### PR DESCRIPTION
## The bug

Installing a plugin from the catalogue left the admin sidebar without its pages. The maintainer hit it on the webhook plugin: `GET /api/plugins/ui` served the contribution, `SettingsSectionsService` resolves it correctly, and the page still wasn't linked — because nothing re-read the registry.

Both completion paths called `this.reload()`, which refreshes the page's own row list only. The nav, the settings sidebar and every action slot read `PluginUiRegistryService`, which loads once at app init. So a freshly installed plugin's pages existed with nothing pointing at them, and an uninstalled plugin's entries lingered, until a full page load.

Same shape as the enable/disable toggle in #962, which already re-reads it.

## The fix

`registry.load()` after a successful install (catalogue page and manual upload) and after an uninstall.

## Verification

`ng build` exit 0, **42 files / 356 tests**. Confirmed on the running instance by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)