### PR TITLE
docs: give the plugin system one shared page, on this side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,9 @@ volumes/*
 /scripts/
 logos/
 plans/
-/docs/
+# Scratch documentation stays local; the plugin contract is shared, so it is tracked.
+/docs/*
+!/docs/plugins.md
 docker-compose.yml
 docker-compose.prod.yml
 .worktrees/

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ then always reports "up to date" and never contacts GitHub.
 | `windows/`, `macos/` | native server hosts (tray / menu bar) |
 | `appletv/` | native tvOS app (SwiftUI) |
 | `cast-receiver/` | custom Chromecast receiver |
+| `docs/plugins.md` | how the plugin system works, for whoever writes one |
 
 ## License
 

--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -86,6 +86,10 @@ interface ConfigPageBase {
 export interface FormConfigPage extends ConfigPageBase {
   kind?: 'form';
   fields: FieldDef[];
+  /** Buttons core implements on the plugin's behalf. `actionId` names a closed catalogue core
+   *  resolves; an unknown one renders nothing. A `data` plugin executes no code of its own, so
+   *  this is the only way it can offer an action at all. */
+  actions?: { id: string; labelKey: string; actionId: string }[];
 }
 
 /** One search/grab pair the core release picker calls for a given context. */

--- a/backend/src/modules/plugins/plugin-install.service.ts
+++ b/backend/src/modules/plugins/plugin-install.service.ts
@@ -224,6 +224,12 @@ export class PluginInstallService {
     await this.registry.restartProcess(pluginId);
   }
 
+  /** 404s an id nothing is installed under, for a caller that acts on a plugin without needing
+   *  its row. */
+  async assertInstalled(pluginId: string): Promise<void> {
+    await this.findInstalledPlugin(pluginId);
+  }
+
   /** Idempotent: an already-disabled plugin is returned as-is. Stops the supervisor and drops the
    *  live registration via `unregister()` — the package row, its archive and its schema are untouched. */
   async disable(pluginId: string): Promise<PluginSummary> {

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -379,6 +379,11 @@ export class PluginRegistryService implements OnModuleInit {
     return out;
   }
 
+  /** Everything one plugin declared — what a test delivery walks. */
+  listWebhooksForPlugin(pluginId: string): { event: PluginWebhookEventName; webhook: string }[] {
+    return [...(this.webhookDeclarations.get(pluginId) ?? [])];
+  }
+
   /** Drops this plugin's previous webhooks (if any) and installs `declarations` in their place. */
   private replaceWebhookDeclarations(pluginId: string, declarations: { event: PluginWebhookEventName; webhook: string }[]): void {
     if (declarations.length === 0) this.webhookDeclarations.delete(pluginId);

--- a/backend/src/modules/plugins/plugin-route-shadowing.spec.ts
+++ b/backend/src/modules/plugins/plugin-route-shadowing.spec.ts
@@ -10,6 +10,7 @@ import { PluginProxyController } from './proxy/plugin-proxy.controller';
 import { PluginRouteGuard } from './proxy/plugin-route.guard';
 import { PluginRegistryService } from './plugin-registry.service';
 import { PluginInstallService } from './plugin-install.service';
+import { PluginWebhookDispatcherService } from './plugin-webhook-dispatcher.service';
 import { PluginCatalogClientService } from './plugin-catalog-client.service';
 import { PluginProcessService } from './plugin-process.service';
 import { PluginSource } from './entities/plugin-source.entity';
@@ -57,6 +58,7 @@ describe('plugins/* route shadowing', () => {
       providers: [
         { provide: PluginRegistryService, useValue: registry },
         { provide: PluginInstallService, useValue: installService },
+        { provide: PluginWebhookDispatcherService, useValue: { sendTest: jest.fn() } },
         { provide: PluginCatalogClientService, useValue: catalogClient },
         { provide: PluginProcessService, useValue: processService },
         { provide: getRepositoryToken(PluginSource), useValue: sourceRepo },

--- a/backend/src/modules/plugins/plugin-webhook-dispatcher.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-webhook-dispatcher.service.spec.ts
@@ -171,4 +171,31 @@ describe('PluginWebhookDispatcherService', () => {
 
       expect(requests).toHaveLength(0);
   });
+
+    it('posts one synthetic event per declaration, through the same guards', async () => {
+      const registry = {
+        listWebhooksForEvent: () => [],
+        listWebhooksForPlugin: () => [{ event: 'media.imported', webhook: 'setting:endpoint_url' }],
+      } as unknown as PluginRegistryService;
+      const settings = settingsStub({ 'plugin.fliks.acme.endpoint_url': 'https://hooks.example/mine' });
+      const service = new PluginWebhookDispatcherService(new EventsService(), registry, settings);
+
+      const result = await service.sendTest('fliks.acme');
+
+      expect(result).toEqual({ configured: true, delivered: 1, failures: [] });
+      expect(requests.map((r) => r.url)).toEqual(['https://hooks.example/mine']);
+    });
+
+    it('VERDICT: reports "not configured" instead of sending anywhere when the endpoint is empty', async () => {
+      const registry = {
+        listWebhooksForEvent: () => [],
+        listWebhooksForPlugin: () => [{ event: 'media.imported', webhook: 'setting:endpoint_url' }],
+      } as unknown as PluginRegistryService;
+      const service = new PluginWebhookDispatcherService(new EventsService(), registry, settingsStub());
+
+      const result = await service.sendTest('fliks.acme');
+
+      expect(result).toEqual({ configured: false, delivered: 0, failures: [] });
+      expect(requests).toHaveLength(0);
+  });
 });

--- a/backend/src/modules/plugins/plugin-webhook-dispatcher.service.ts
+++ b/backend/src/modules/plugins/plugin-webhook-dispatcher.service.ts
@@ -8,6 +8,14 @@ import { isInternalAddress } from './internal-address';
 import { SettingsService } from '../settings/settings.service';
 import { WEBHOOK_SETTING_PREFIX } from '../../common/plugin-contract';
 
+/** What the admin page shows after a test: whether an endpoint is configured at all, how many
+ *  answered, and what the ones that did not said. */
+export interface WebhookTestResult {
+  configured: boolean;
+  delivered: number;
+  failures: string[];
+}
+
 const WEBHOOK_TIMEOUT_MS = 5_000;
 /** Core never reads the body — cap it so a hostile endpoint can't hold the connection streaming data. */
 const WEBHOOK_MAX_RESPONSE_BYTES = 64 * 1024;
@@ -59,16 +67,23 @@ export class PluginWebhookDispatcherService implements OnModuleInit, OnModuleDes
   private async deliver(pluginId: string, declared: string, event: DomainEvent): Promise<void> {
     const webhook = await this.resolveTarget(pluginId, declared);
     if (!webhook) return;
+    if (!(await this.isDeliverable(pluginId, webhook))) return;
+    await this.postGuarded(pluginId, webhook, { event, pluginId });
+  }
+
+  /** https, parses, and resolves to nothing internal — re-checked on every attempt, because a
+   *  name that passed at configuration time can be repointed afterwards. */
+  private async isDeliverable(pluginId: string, webhook: string): Promise<boolean> {
     if (!webhook.startsWith('https://')) {
       this.logger.warn(`plugin "${pluginId}" webhook skipped — configured endpoint is not https`);
-      return;
+      return false;
     }
     let hostname: string;
     try {
       hostname = new URL(webhook).hostname;
     } catch {
       this.logger.warn(`plugin "${pluginId}" webhook skipped — "${webhook}" no longer parses as a URL`);
-      return;
+      return false;
     }
 
     let addresses: string[];
@@ -76,18 +91,23 @@ export class PluginWebhookDispatcherService implements OnModuleInit, OnModuleDes
       addresses = (await dns.promises.lookup(hostname, { all: true })).map((a) => a.address);
     } catch (err) {
       this.logger.warn(`plugin "${pluginId}" webhook skipped — DNS lookup failed for "${hostname}": ${(err as Error).message}`);
-      return;
+      return false;
     }
     const internal = addresses.find(isInternalAddress);
     if (internal) {
       this.logger.warn(`plugin "${pluginId}" webhook skipped — "${hostname}" resolves to internal address ${internal}`);
-      return;
+      return false;
     }
+    return true;
+  }
 
+  /** Resolves, re-checks and posts. The guards — https, no internal address, DNS re-resolved on
+   *  every attempt — are the point of routing every delivery through here. */
+  private async postGuarded(pluginId: string, webhook: string, body: unknown): Promise<{ ok: boolean; detail?: string }> {
     try {
       await axios.post(
         webhook,
-        { event, pluginId },
+        body,
         {
           timeout: WEBHOOK_TIMEOUT_MS,
           maxRedirects: 0,
@@ -95,8 +115,42 @@ export class PluginWebhookDispatcherService implements OnModuleInit, OnModuleDes
           headers: { 'User-Agent': 'Fliks-Plugin-Webhook/1.0', 'Content-Type': 'application/json' },
         },
       );
+      return { ok: true };
     } catch (err) {
-      this.logger.warn(`plugin "${pluginId}" webhook delivery failed: ${(err as Error).message}`);
+      const detail = (err as Error).message;
+      this.logger.warn(`plugin "${pluginId}" webhook delivery failed: ${detail}`);
+      return { ok: false, detail };
     }
+  }
+
+  /**
+   * Posts one synthetic event to every webhook this plugin declares, so an operator can prove
+   * their endpoint answers before waiting for something real. Same resolution and same guards as
+   * a real delivery; `configured: false` means the target setting is still empty.
+   */
+  async sendTest(pluginId: string): Promise<WebhookTestResult> {
+    const targets = this.registry.listWebhooksForPlugin(pluginId);
+    const failures: string[] = [];
+    let delivered = 0;
+    let configured = false;
+
+    for (const declared of targets) {
+      const webhook = await this.resolveTarget(pluginId, declared.webhook);
+      if (!webhook) continue;
+      configured = true;
+      if (!(await this.isDeliverable(pluginId, webhook))) {
+        failures.push(`${declared.event}: target refused`);
+        continue;
+      }
+      const result = await this.postGuarded(pluginId, webhook, {
+        event: { type: 'test.delivery', declaredFor: declared.event },
+        pluginId,
+        test: true,
+      });
+      if (result.ok) delivered++;
+      else failures.push(`${declared.event}: ${result.detail ?? 'failed'}`);
+    }
+
+    return { configured, delivered, failures };
   }
 }

--- a/backend/src/modules/plugins/plugins.controller.spec.ts
+++ b/backend/src/modules/plugins/plugins.controller.spec.ts
@@ -3,7 +3,7 @@ import { PluginsController } from './plugins.controller';
 describe('PluginsController', () => {
   it('delegates uninstall to the install service', async () => {
     const installService = { uninstall: jest.fn().mockResolvedValue(undefined) };
-    const controller = new PluginsController(installService as never);
+    const controller = new PluginsController(installService as never, { sendTest: jest.fn() } as never);
 
     await expect(controller.uninstall('fliks.test-plugin')).resolves.toBeUndefined();
     expect(installService.uninstall).toHaveBeenCalledWith('fliks.test-plugin');
@@ -12,7 +12,7 @@ describe('PluginsController', () => {
   it('delegates list to the install service', async () => {
     const rows = [{ pluginId: 'fliks.test-plugin', status: 'active' }];
     const installService = { listInstalled: jest.fn().mockResolvedValue(rows) };
-    const controller = new PluginsController(installService as never);
+    const controller = new PluginsController(installService as never, { sendTest: jest.fn() } as never);
 
     await expect(controller.list()).resolves.toBe(rows);
     expect(installService.listInstalled).toHaveBeenCalled();
@@ -21,7 +21,7 @@ describe('PluginsController', () => {
 
   it('delegates restart to the install service', async () => {
     const installService = { restart: jest.fn().mockResolvedValue(undefined) };
-    const controller = new PluginsController(installService as never);
+    const controller = new PluginsController(installService as never, { sendTest: jest.fn() } as never);
 
     await expect(controller.restart('fliks.test-plugin')).resolves.toBeUndefined();
     expect(installService.restart).toHaveBeenCalledWith('fliks.test-plugin');
@@ -30,7 +30,7 @@ describe('PluginsController', () => {
   it('delegates disable to the install service', async () => {
     const summary = { pluginId: 'fliks.test-plugin', enabled: false };
     const installService = { disable: jest.fn().mockResolvedValue(summary) };
-    const controller = new PluginsController(installService as never);
+    const controller = new PluginsController(installService as never, { sendTest: jest.fn() } as never);
 
     await expect(controller.disable('fliks.test-plugin')).resolves.toBe(summary);
     expect(installService.disable).toHaveBeenCalledWith('fliks.test-plugin');
@@ -39,7 +39,7 @@ describe('PluginsController', () => {
   it('delegates enable to the install service', async () => {
     const summary = { pluginId: 'fliks.test-plugin', enabled: true };
     const installService = { enable: jest.fn().mockResolvedValue(summary) };
-    const controller = new PluginsController(installService as never);
+    const controller = new PluginsController(installService as never, { sendTest: jest.fn() } as never);
 
     await expect(controller.enable('fliks.test-plugin')).resolves.toBe(summary);
     expect(installService.enable).toHaveBeenCalledWith('fliks.test-plugin');

--- a/backend/src/modules/plugins/plugins.controller.ts
+++ b/backend/src/modules/plugins/plugins.controller.ts
@@ -3,12 +3,16 @@ import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
 import { PoliciesGuard } from '../auth/casl/policies.guard';
 import { CheckPolicies } from '../auth/casl/check-policies.decorator';
 import { Action } from '../auth/casl/actions.enum';
+import { PluginWebhookDispatcherService, type WebhookTestResult } from './plugin-webhook-dispatcher.service';
 import { PluginInstallService, PluginSummary } from './plugin-install.service';
 
 @Controller('plugins')
 @UseGuards(JwtOrApiKeyGuard, PoliciesGuard)
 export class PluginsController {
-  constructor(private readonly installService: PluginInstallService) {}
+  constructor(
+    private readonly installService: PluginInstallService,
+    private readonly dispatcher: PluginWebhookDispatcherService,
+  ) {}
 
   @Get()
   @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
@@ -31,6 +35,15 @@ export class PluginsController {
   @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
   async disable(@Param('pluginId') pluginId: string): Promise<PluginSummary> {
     return this.installService.disable(pluginId);
+  }
+
+  /** Posts one synthetic event to whatever this plugin declared, so an operator can prove their
+   *  endpoint answers without waiting for a real import. */
+  @Post(':pluginId/events/test')
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
+  async testEventDelivery(@Param('pluginId') pluginId: string): Promise<WebhookTestResult> {
+    await this.installService.assertInstalled(pluginId);
+    return this.dispatcher.sendTest(pluginId);
   }
 
   /** Re-registers through the same path a boot load takes. Idempotent. */

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2337,7 +2337,10 @@
     "unavailable_title": "Diese Seite ist nicht verfügbar",
     "unknown_plugin": "Das Plugin, zu dem diese Seite gehört, ist nicht installiert.",
     "unknown_view": "Dieses Plugin hat keine Seite mit diesem Namen.",
-    "unsupported_kind": "Diese Seite wird von deiner Fliks-Version noch nicht unterstützt."
+    "unsupported_kind": "Diese Seite wird von deiner Fliks-Version noch nicht unterstützt.",
+    "webhook_test_ok": "Testereignis an {{count}} Endpunkt(e) geliefert.",
+    "webhook_test_unconfigured": "Noch kein Endpunkt konfiguriert — es wurde nichts gesendet.",
+    "webhook_test_failed": "Testzustellung fehlgeschlagen: {{detail}}"
   },
   "provider_list": {
     "new": "Neu",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2365,7 +2365,10 @@
     "unknown_plugin": "The plugin this page belongs to isn't installed.",
     "unknown_view": "This plugin doesn't have a page by that name.",
     "unsupported_kind": "This page isn't supported by your version of Fliks yet.",
-    "implementations_load_error": "Couldn't load the provider types — some fields may be missing below."
+    "implementations_load_error": "Couldn't load the provider types — some fields may be missing below.",
+    "webhook_test_ok": "Test event delivered to {{count}} endpoint(s).",
+    "webhook_test_unconfigured": "No endpoint configured yet — nothing was sent.",
+    "webhook_test_failed": "Test delivery failed: {{detail}}"
   },
   "provider_list": {
     "new": "New",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2337,7 +2337,10 @@
     "unavailable_title": "Esta página no está disponible",
     "unknown_plugin": "El plugin al que pertenece esta página no está instalado.",
     "unknown_view": "Este plugin no tiene ninguna página con ese nombre.",
-    "unsupported_kind": "Esta página aún no es compatible con tu versión de Fliks."
+    "unsupported_kind": "Esta página aún no es compatible con tu versión de Fliks.",
+    "webhook_test_ok": "Evento de prueba entregado a {{count}} punto(s) de entrada.",
+    "webhook_test_unconfigured": "Aún no hay punto de entrada configurado: no se envió nada.",
+    "webhook_test_failed": "La entrega de prueba falló: {{detail}}"
   },
   "provider_list": {
     "new": "Nuevo",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2365,7 +2365,10 @@
     "unknown_plugin": "Le plugin auquel appartient cette page n'est pas installé.",
     "unknown_view": "Ce plugin n'a pas de page portant ce nom.",
     "unsupported_kind": "Cette page n'est pas encore prise en charge par votre version de Fliks.",
-    "implementations_load_error": "Impossible de charger les types de fournisseur — certains champs peuvent manquer ci-dessous."
+    "implementations_load_error": "Impossible de charger les types de fournisseur — certains champs peuvent manquer ci-dessous.",
+    "webhook_test_ok": "Événement de test livré à {{count}} point(s) d’entrée.",
+    "webhook_test_unconfigured": "Aucun point d’entrée configuré — rien n’a été envoyé.",
+    "webhook_test_failed": "Échec de la livraison de test : {{detail}}"
   },
   "provider_list": {
     "new": "Nouveau",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2337,7 +2337,10 @@
     "unavailable_title": "Questa pagina non è disponibile",
     "unknown_plugin": "Il plugin a cui appartiene questa pagina non è installato.",
     "unknown_view": "Questo plugin non ha una pagina con questo nome.",
-    "unsupported_kind": "Questa pagina non è ancora supportata dalla tua versione di Fliks."
+    "unsupported_kind": "Questa pagina non è ancora supportata dalla tua versione di Fliks.",
+    "webhook_test_ok": "Evento di test consegnato a {{count}} endpoint.",
+    "webhook_test_unconfigured": "Nessun endpoint configurato: non è stato inviato nulla.",
+    "webhook_test_failed": "Consegna di test non riuscita: {{detail}}"
   },
   "provider_list": {
     "new": "Nuovo",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2337,7 +2337,10 @@
     "unavailable_title": "Esta página não está disponível",
     "unknown_plugin": "O plugin ao qual esta página pertence não está instalado.",
     "unknown_view": "Este plugin não tem nenhuma página com esse nome.",
-    "unsupported_kind": "Esta página ainda não é suportada pela sua versão do Fliks."
+    "unsupported_kind": "Esta página ainda não é suportada pela sua versão do Fliks.",
+    "webhook_test_ok": "Evento de teste entregue a {{count}} ponto(s) de entrada.",
+    "webhook_test_unconfigured": "Nenhum ponto de entrada configurado — nada foi enviado.",
+    "webhook_test_failed": "A entrega de teste falhou: {{detail}}"
   },
   "provider_list": {
     "new": "Novo",

--- a/client/src/app/core/plugin-ui/contribution.types.ts
+++ b/client/src/app/core/plugin-ui/contribution.types.ts
@@ -89,6 +89,10 @@ interface ConfigPageBase {
 export interface FormConfigPage extends ConfigPageBase {
   kind?: 'form';
   fields: FieldDef[];
+  /** Buttons core implements on the plugin's behalf. `actionId` names a closed catalogue core
+   *  resolves; an unknown one renders nothing. A `data` plugin executes no code of its own, so
+   *  this is the only way it can offer an action at all. */
+  actions?: { id: string; labelKey: string; actionId: string }[];
 }
 
 /** One search/grab pair the core release picker calls for a given context. */

--- a/client/src/app/features/plugin-view/plugin-view.html
+++ b/client/src/app/features/plugin-view/plugin-view.html
@@ -57,12 +57,22 @@
         <div class="flex flex-col gap-4">
           <h2 class="text-lg font-bold">{{ page.labelKey | translate }}</h2>
           <app-schema-form [fields]="page.fields" [(value)]="formValue" [disabled]="formSaving()" />
-          <button type="button" class="btn btn-primary self-start" [disabled]="formSaving()" (click)="saveForm()">
-            @if (formSaving()) {
-              <span class="loading loading-spinner loading-sm"></span>
+          <div class="flex flex-wrap items-center gap-2">
+            <button type="button" class="btn btn-primary" [disabled]="formSaving()" (click)="saveForm()">
+              @if (formSaving()) {
+                <span class="loading loading-spinner loading-sm"></span>
+              }
+              {{ 'common.save' | translate }}
+            </button>
+            @for (action of formActions(page); track action.id) {
+              <button type="button" class="btn btn-outline" [disabled]="formActionBusy() === action.id" (click)="runFormAction(action)">
+                @if (formActionBusy() === action.id) {
+                  <span class="loading loading-spinner loading-sm"></span>
+                }
+                {{ action.labelKey | translate }}
+              </button>
             }
-            {{ 'common.save' | translate }}
-          </button>
+          </div>
         </div>
       }
     } @else {

--- a/client/src/app/features/plugin-view/plugin-view.ts
+++ b/client/src/app/features/plugin-view/plugin-view.ts
@@ -7,6 +7,7 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { LucideTriangleAlert } from '@lucide/angular';
 import { PluginUiRegistryService } from '../../core/plugin-ui/plugin-ui-registry.service';
 import { SettingsApiService } from '../../core/services/api/settings-api.service';
+import { ToastService } from '../../core/services/toast.service';
 import { SchemaFormComponent, SchemaFormValue } from '../../shared/components/schema-form/schema-form';
 import { ProviderListComponent } from '../../shared/components/provider-list/provider-list';
 import {
@@ -92,6 +93,7 @@ export class PluginViewComponent {
   private readonly settingsApi = inject(SettingsApiService);
   private readonly translate = inject(TranslateService);
   private readonly router = inject(Router);
+  private readonly toast = inject(ToastService);
 
   // Angular reuses this component across param changes on the same route
   // config (same wildcard path, different pluginId/view) — read reactively.
@@ -127,6 +129,7 @@ export class PluginViewComponent {
   readonly formValue = signal<SchemaFormValue>({});
   readonly formLoading = signal(true);
   readonly formSaving = signal(false);
+  readonly formActionBusy = signal<string | null>(null);
 
   // --- `providers` kind: the driver list is itself a proxied route ---
   readonly resolvedImplementations = signal<ProviderImplementation[] | null>(null);
@@ -155,6 +158,34 @@ export class PluginViewComponent {
       this.formValue.set(value);
     } finally {
       this.formLoading.set(false);
+    }
+  }
+
+  /** The closed catalogue of buttons core implements on a `form` page. An unknown id renders
+   *  nothing: a `data` plugin cannot ship code, so core is the only thing that can act. */
+  formActions(page: FormConfigPage): { id: string; labelKey: string; actionId: string }[] {
+    return (page.actions ?? []).filter((a) => a.actionId === 'events.test-delivery');
+  }
+
+  async runFormAction(action: { id: string; labelKey: string; actionId: string }): Promise<void> {
+    this.formActionBusy.set(action.id);
+    try {
+      const res = await firstValueFrom(
+        this.http.post<{ configured: boolean; delivered: number; failures: string[] }>(
+          `/api/plugins/${this.pluginId()}/events/test`,
+          {},
+        ),
+      );
+      if (!res.configured) this.toast.warning(this.translate.instant('plugin_view.webhook_test_unconfigured'));
+      else if (res.failures.length) {
+        this.toast.error(this.translate.instant('plugin_view.webhook_test_failed', { detail: res.failures.join('; ') }));
+      } else {
+        this.toast.success(this.translate.instant('plugin_view.webhook_test_ok', { count: res.delivered }));
+      }
+    } catch {
+      // surfaced by the global error interceptor
+    } finally {
+      this.formActionBusy.set(null);
     }
   }
 

--- a/client/src/app/features/settings/plugins/plugins.spec.ts
+++ b/client/src/app/features/settings/plugins/plugins.spec.ts
@@ -105,7 +105,6 @@ describe('PluginsSettingsComponent — enable/disable toggle', () => {
     http.expectOne({ url: '/api/plugins/fliks.acme', method: 'DELETE' }).flush({});
     await settle(fixture);
     http.expectOne({ url: '/api/plugins', method: 'GET' }).flush([]);
-    http.expectOne({ url: '/api/plugins/sources', method: 'GET' }).flush([]);
     await settle(fixture);
 
     // Without this the pages stay linked in the admin sidebar until a full page load.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,117 @@
+# Plugins
+
+How the plugin system works, for whoever writes a plugin or changes core's side of it. What a
+particular plugin *does* belongs in that plugin's own README.
+
+## Two tiers
+
+**`data`** ships JSON and executes nothing. It can contribute pages and menu entries, declare
+settings, and subscribe to domain events — core makes every outbound request on its behalf. It
+holds no database, answers no route, and runs no code. Installing one cannot execute anything.
+
+**`process`** ships a `plugin.js` that core spawns as a child process. It answers HTTP routes
+through core's proxy, owns a Postgres schema, and runs jobs on a schedule. It is the tier that can
+do work of its own, and the one whose failure needs supervision.
+
+Pick `data` unless the plugin genuinely needs to act. The tiers are not a spectrum: a `data`
+plugin that needs to answer one route is a `process` plugin.
+
+## The manifest
+
+One `plugin.json` at the archive root, validated before anything is written. Beyond identity
+(`id`, `version`, `pluginApi`, `fliks` range with a mandatory upper bound, `author`, `license`,
+`logo`):
+
+- `kind` — `data` or `process`, read from inside the signed manifest.
+- `provides.routes[]` (`process`) — every route core will proxy, each with the CASL `policy` it
+  requires and an optional `objectGuard`. A route that is not declared does not exist.
+- `database` (`process`) — whether it wants its own schema, and which core tables it needs
+  `REFERENCES` on.
+- `jobs[]` (`process`) — named cron entries core schedules and dispatches.
+- `events[]` — domain events to receive. A `data` plugin gets an HTTPS POST from core; a `process`
+  plugin gets a note over its socket.
+- `permissions[]` — raw names; core builds the CASL subject as `plugin:<id>:<name>`, so a plugin cannot claim another's or a core subject.
+- `ui.*` — see below.
+- `i18n` — every `labelKey` the plugin uses, per locale. Core merges them into the active language.
+
+Unknown top-level keys are rejected, so a typo fails the install rather than being ignored.
+
+## Contributing to the UI
+
+A plugin ships **no** Angular. It declares data; core renders it.
+
+**`ui.contributions[]`** puts an entry in one of six slots (`nav.main`, `nav.acquisition`,
+`settings.page`, `media.actions`, `media.season.actions`, `card.actions`), with a weight, a
+`labelKey`, an optional icon, and `when` predicates from a closed vocabulary — an unknown
+predicate evaluates false, so a client that does not know a rule hides the entry rather than
+guessing. The action is either a route or a **core-declared `actionId`**: core keeps a closed
+catalogue per slot, and an id it does not know renders nothing.
+
+**`ui.configPages[]`** declares a page, discriminated on `kind`:
+
+- `form` — key/value settings stored in `app_settings` under `plugin.<id>.<key>`, rendered by
+  core's schema form. Works with the process stopped. May declare `actions[]` naming a
+  core-implemented button.
+- `providers` — a CRUD list of instances over the plugin's own routes, with a per-implementation
+  field set, an optional connection test, and row/list actions.
+- `table` — a read-only list over one route, with declared columns and row actions.
+
+Declaring a page does **not** link to it: a `settings.page` contribution is what puts it in the
+admin sidebar.
+
+If a page needs something these three cannot express, it is not a plugin page. The escape is a
+core change adding a `kind`, not a plugin shipping code.
+
+## What a `process` plugin can ask of core
+
+A spawned plugin talks to core over two unix sockets with newline-delimited JSON-RPC: one for the
+calls it makes, one for the notes core sends it (`hello`, `health`, `event`, `config`, `http`,
+`job`, `shutdown`). Its host API is a fixed set of methods — media lookup, acquisition targets,
+release scoring, library ingest constrained to declared `ingestRoots`, event publication with a
+forced `<pluginId>.` prefix, settings read/write scoped to its own namespace.
+
+The contract types live in `backend/src/common/plugin-contract/` and are **restated** in each
+plugin repository, because a spawned plugin cannot import from core at runtime. Two guards keep
+the copies honest: a CI job diffs the client mirror against the backend's, and each plugin repo
+runs a drift checker against a sibling checkout. Compare **declarations, not just names** — a
+field that matches by name and differs by type compiles and misbehaves.
+
+## Database
+
+A `process` plugin that asks for a schema gets its own Postgres role and schema
+(`plugin_<id with dots as underscores>`), a password rotated on every spawn, and `REFERENCES`-only
+grants on the core tables it declared. It runs its own migrations. Core never reads those tables.
+
+Uninstalling drops the role and the schema. Disabling does not.
+
+## Events
+
+`events[]` names domain events. For a `data` plugin, `webhook` is either an absolute https URL or
+`setting:<key>` naming a field the plugin declares on a `form` page — the operator's own endpoint,
+read at delivery. Either way core checks https, refuses an internal address, and re-resolves DNS on
+every attempt, because a name that passed at install can be repointed afterwards. Delivery is
+at-most-once with no retry; a plugin that needs retries is `process` and does its own.
+
+## Trust and installation
+
+An archive is a ZIP with a closed set of legal entry names, size caps, and an Ed25519 signature
+over the manifest. Install is two steps: `inspect` verifies and stages, `confirm` promotes what was
+staged, and the consent sheet in between is the only place an unverified plugin is accepted.
+
+Signature outcomes are `official` (a catalogue release key), `verified`, `unverified`, or
+`unsigned`. A `process` plugin must be signed unless its id is in `FLIKS_UNSIGNED_PLUGINS`, which
+exists for local development only.
+
+Catalogue sources are HTTPS documents listing each plugin's installable versions with a `sha256`
+per version; core refuses bytes whose hash does not match. Publishing a plugin means committing its
+built source into the catalogue repository, adding a version entry, and running its packaging
+workflow, which signs with the catalogue key and records the published archive's hash.
+
+## Operator semantics worth knowing before you rely on them
+
+- **Disable** stops the process and drops every live registration — routes, contributions, jobs,
+  webhooks — while the row, the archive, the role and the schema stand.
+- **Uninstall** destroys the schema and its data.
+- **An upgrade over a disabled plugin stays disabled.**
+- A plugin that goes unreachable has its contributions filtered out server-side, so a frozen
+  client never has to know about plugin health.


### PR DESCRIPTION
## Why

Each plugin repository was documenting **how the plugin system works** — the two tiers, the manifest surface, the RPC contract and its mirrors, per-plugin database provisioning, trust and signing. That is this repo's contract, not theirs: three copies, drifting the moment core changes, and none of them where a plugin author looks first.

`docs/` is gitignored for local scratch notes. This one file is un-ignored (`/docs/*` + `!/docs/plugins.md`), because a shared contract nobody can clone is the same problem as citing a plan that is not in the tree — which is what we cleaned out of every comment earlier today.

## What it covers

The two tiers and how to choose; the manifest keys; the UI contribution model (six slots, three page kinds, core-declared action ids, and the fact that declaring a page does not link to it); what a spawned plugin may ask of core and why the contract is restated per repo with two drift gates; database provisioning; event delivery including `setting:` targets and the per-attempt guards; trust, the two-step install and the catalogue; and the operator semantics — disable keeps the data, uninstall destroys it, an upgrade over a disabled plugin stays disabled.

One correction went in while writing it: `permissions[]` entries are raw names and core builds `plugin:<id>:<name>` itself. The notify plugin's notes had guessed at that namespacing before it landed and were still labelled "reconciliation needed".

## The plugin repositories

`fk-plugin-download` and `fk-plugin-notify` keep build, test and publish only, and link here. The download plugin's test section now gives the exact commands CI uses — including the core-table stubs whose absence fails the FK tests — because its database tests skip themselves and the suite still prints green, which is how its CI stayed red for five commits. Both commands were run verbatim against a fresh container before being written down (262 pass, 2 skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)