### PR TITLE
fix(plugins): stop an ingest that is still copying from being called a failure

### DIFF
--- a/backend/src/common/library-ingest/library-ingest.service.ts
+++ b/backend/src/common/library-ingest/library-ingest.service.ts
@@ -46,6 +46,9 @@ export interface IngestResult {
     seasonId?: number;
     sourcePath: string;
   }[];
+  /** Files whose destination was already taken. A retried import is a no-op, and a caller that
+   *  cannot tell that from "nothing could be placed" reports a success as a failure. */
+  alreadyPresent: string[];
 }
 
 /**
@@ -91,7 +94,7 @@ export class LibraryIngestService {
         `Media #${req.mediaId} is not anchored to a library folder`,
       );
     }
-    if (!req.files.length) return { imported: [] };
+    if (!req.files.length) return { imported: [], alreadyPresent: [] };
 
     // A series release carrying several video files is a season pack: every file
     // is its own episode. Anything else keeps only the largest file (samples,
@@ -113,6 +116,7 @@ export class LibraryIngestService {
       ? this.naming.extractReleaseGroup(req.releaseName)
       : undefined;
 
+    const alreadyPresent: string[] = [];
     const imported: (IngestResult['imported'][number] & {
       destPath: string;
       seasonNumber?: number;
@@ -246,7 +250,8 @@ export class LibraryIngestService {
 
       if ((await collides(relativePath, destPath)) && !req.force) {
         if (!req.uniquifyOnCollision) {
-          // Re-running the same import is a safe no-op.
+          // Re-running the same import is a safe no-op — reported, not silent.
+          alreadyPresent.push(file.path);
           continue;
         }
         // A different file maps to a name already taken by this media (e.g.
@@ -376,6 +381,7 @@ export class LibraryIngestService {
         seasonId,
         sourcePath,
       })),
+      alreadyPresent,
     };
   }
 }

--- a/backend/src/common/plugin-contract/host-methods.ts
+++ b/backend/src/common/plugin-contract/host-methods.ts
@@ -219,6 +219,10 @@ export interface PluginHostApi {
     sourceLabel: string;
   }) => Promise<{
     imported: { mediaFileId: number; relativePath: string; quality: string }[];
+    /** Source paths whose destination was already taken, so nothing was written for them. A
+     *  retried ingest lands here, and reading it as "nothing could be placed" reports a
+     *  completed import as a failure. */
+    alreadyPresent: string[];
     seasonNumber?: number;
     episodeNumber?: number;
   }>;

--- a/backend/src/modules/plugins/host/fliks-host.service.spec.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.spec.ts
@@ -949,6 +949,25 @@ describe('FliksHostImpl', () => {
         expect.any(Object),
       );
     });
+    it('VERDICT: passes through the paths that were already in place, so a retry is not a failure', async () => {
+      const h = makeHarness();
+      h.pluginRegistrationRepo.findOne.mockResolvedValue({ ingestRoots: [tmpRoot] });
+      h.mediaRepo.findOne.mockResolvedValue(makeMedia());
+      h.libraryIngestService.ingest.mockResolvedValue({ imported: [], alreadyPresent: [sourceFile] });
+
+      const result = await h.host['library.ingest']({
+        idempotencyKey: 'k1',
+        mediaId: 1,
+        paths: [sourceFile],
+        transfer: 'copy',
+        sourceLabel: 'Release.Name',
+      });
+
+      // Without this a caller cannot tell "nothing could be placed" from "it is already there",
+      // and reports a completed import as failed on every retry.
+      expect(result).toEqual(expect.objectContaining({ imported: [], alreadyPresent: [sourceFile] }));
+    });
+
 
     it('refuses a path outside every configured ingest root', async () => {
       const h = makeHarness();

--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -596,6 +596,7 @@ export class FliksHostImpl implements PluginHostApi {
     sourceLabel: string;
   }): Promise<{
     imported: { mediaFileId: number; relativePath: string; quality: string }[];
+    alreadyPresent: string[];
     seasonNumber?: number;
     episodeNumber?: number;
   }> {
@@ -647,7 +648,7 @@ export class FliksHostImpl implements PluginHostApi {
       }
     }
 
-    return { imported, seasonNumber, episodeNumber };
+    return { imported, alreadyPresent: result.alreadyPresent, seasonNumber, episodeNumber };
   }
 
   /** `realpath`s `rawPath` and refuses it unless it resolves inside one of `roots`. */

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
@@ -31,6 +31,16 @@ export type SupervisorState =
 
 const STDERR_TAIL_BYTES = 4 * 1024;
 
+/**
+ * Host methods whose own work is not a lookup. `library.ingest` copies the release into the
+ * library and probes it: one 2160p file blew straight past the 8 s default in production, and the
+ * deadline only abandons the wait — core finished the copy, so the plugin recorded a failure for
+ * an import that had landed.
+ */
+const HOST_CALL_DEADLINE_OVERRIDES_MS: Readonly<Record<string, number>> = {
+  'library.ingest': 30 * 60_000,
+};
+
 /** `WARN` as the line's own level — after any bracketed prefixes, never inside the message. */
 const SELF_DECLARED_WARN = /^(?:\[[^\]]*\]\s*)*WARN\b/;
 
@@ -350,7 +360,8 @@ export class PluginSupervisor implements OnApplicationShutdown {
     if (!fn) return Promise.reject(new Error(`unknown host method "${method}"`));
     // Promise.resolve().then(...) folds a synchronous throw from `fn` into the same
     // rejection path as an async one, so both answer with an error frame, never crash.
-    return withDeadline(Promise.resolve().then(() => fn(payload)), this.opts.hostCallTimeoutMs, method);
+    const deadlineMs = HOST_CALL_DEADLINE_OVERRIDES_MS[method] ?? this.opts.hostCallTimeoutMs;
+    return withDeadline(Promise.resolve().then(() => fn(payload)), deadlineMs, method);
   }
 
   private onPluginConnected(socket: Socket): void {


### PR DESCRIPTION
## What happened in production

```
17:06:09  ERROR Import: FAILED for "…(2026) [2160p] [WEBRip] [x265]…":
          ERR: host method "library.ingest" timed out after 8000ms
17:07:00  ERROR Import[…]: no file could be placed under the library root for "…"
17:08:00  ERROR Import[…]: no file could be placed under the library root for "…"   (every minute)
```

The file had landed. The row was marked `failed` and `acquisition.failed` published, once a minute.

## Two causes

**The deadline was wrong for the method.** `PluginSupervisor` wraps every host call in one 8 s bound. `library.ingest` copies the release into the library (`transfer: 'copy'`) and runs `ffprobe` on it — a 2160p x265 file is not an 8 s operation. And the deadline only abandons the *wait*: core kept copying and finished, so the plugin's "failure" described nothing real.

`library.ingest` now has its own bound of thirty minutes; every other method keeps the 8 s that suits a lookup. The plugin's own client timeout was 10 s, which would have fired next, so it passes a longer one for this call — deliberately longer than core's, so core's error frame is what a caller sees instead of a local give-up.

**The retry could not tell success from failure.** Core skips a file whose destination is already taken — the comment there calls that "the idempotency guarantee `idempotencyKey` asks for" — but the response carried only `imported: []`, which reads exactly like *nothing could be placed*. `IngestResult` and the host method now report `alreadyPresent[]`, and the plugin completes the row when that is what came back.

## Verification

Backend `tsc` exit 0, **125 suites / 1345 tests**. Client build exit 0. Plugin repo 264 tests, shipped as 0.1.3.

New specs, each sabotage-checked: the host method passes `alreadyPresent` through; the plugin completes a row on an already-present retry (removing that branch fails it); and the ingest call is given more than a lookup's timeout (removing the argument fails it).

Not fixed here, and worth its own change: a *timeout* is still treated as a definitive failure by the plugin. With these two fixes the retry now resolves correctly, but the honest state after a timeout is "unknown", not "failed".