### PR TITLE
fix(plugins): stop any layer from caching a plugin response

### DIFF
--- a/backend/src/modules/plugins/proxy/plugin-proxy.controller.spec.ts
+++ b/backend/src/modules/plugins/proxy/plugin-proxy.controller.spec.ts
@@ -150,7 +150,7 @@ describe('PluginProxyController — response header allowlist', () => {
     await controller.proxy('fliks.testplugin', fakeRequest(), res);
 
     const setHeaderNames = res.setHeader.mock.calls.map(([name]: [string]) => name);
-    expect(setHeaderNames).toEqual(['Content-Type']);
+    expect(setHeaderNames).toEqual(['Cache-Control', 'Content-Type']);
   });
 
   it('drops a header name containing CRLF even if its lowercase form would otherwise be allowed', async () => {
@@ -164,7 +164,7 @@ describe('PluginProxyController — response header allowlist', () => {
 
     await controller.proxy('fliks.testplugin', fakeRequest(), res);
 
-    expect(res.setHeader).not.toHaveBeenCalled();
+    expect(res.setHeader.mock.calls).toEqual([['Cache-Control', 'no-store']]);
   });
 
   it('drops an allowlisted header whose value carries CRLF, which Node would throw on', async () => {
@@ -182,7 +182,7 @@ describe('PluginProxyController — response header allowlist', () => {
     await controller.proxy('fliks.testplugin', fakeRequest(), res);
 
     const names = res.setHeader.mock.calls.map(([name]: [string]) => name.toLowerCase());
-    expect(names).toEqual(['content-type']);
+    expect(names).toEqual(['cache-control', 'content-type']);
   });
 
   it('keeps every header on the allowlist', async () => {
@@ -202,6 +202,31 @@ describe('PluginProxyController — response header allowlist', () => {
 
     await controller.proxy('fliks.testplugin', fakeRequest(), res);
 
-    expect(res.setHeader).toHaveBeenCalledTimes(5);
+    expect(res.setHeader).toHaveBeenCalledTimes(6);
+  });
+
+  it('sends no-store on a plugin response that declares no cache directive of its own', async () => {
+    const callPlugin = jest.fn().mockResolvedValue({ status: 200, headers: {}, body: [] });
+    const { controller } = makeController('ready', callPlugin);
+    const res = fakeResponse();
+
+    await controller.proxy('fliks.testplugin', fakeRequest(), res);
+
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+  });
+
+  it('lets a plugin serving an asset override no-store', async () => {
+    const callPlugin = jest.fn().mockResolvedValue({
+      status: 200,
+      headers: { 'cache-control': 'public, max-age=86400' },
+      body: 'logo',
+    });
+    const { controller } = makeController('ready', callPlugin);
+    const res = fakeResponse();
+
+    await controller.proxy('fliks.testplugin', fakeRequest(), res);
+
+    const last = res.setHeader.mock.calls.filter(([n]: [string]) => n.toLowerCase() === 'cache-control').at(-1);
+    expect(last).toEqual(['cache-control', 'public, max-age=86400']);
   });
 });

--- a/backend/src/modules/plugins/proxy/plugin-proxy.controller.ts
+++ b/backend/src/modules/plugins/proxy/plugin-proxy.controller.ts
@@ -80,6 +80,9 @@ export class PluginProxyController {
     }
 
     res.status(clampStatus(result.status));
+    // A plugin route reaches whatever the plugin talks to; a stored copy answers a later, different
+    // question. Set before forwarding so a plugin serving an asset can still opt into caching.
+    res.setHeader('Cache-Control', 'no-store');
     for (const [name, value] of Object.entries(result.headers ?? {})) {
       if (
         typeof value !== 'string' ||

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.spec.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.spec.ts
@@ -152,7 +152,9 @@ describe('backoff', () => {
       if (s === 'backoff') backoffIndices.push(sup.getBackoffIndex());
     });
     await sup.start();
-    await delay(750);
+    // Each cycle spawns a real process, so a fixed wait counts fewer cycles under a loaded suite.
+    const deadline = Date.now() + 8_000;
+    while (backoffIndices.length < 2 && Date.now() < deadline) await delay(25);
     expect(backoffIndices.length).toBeGreaterThanOrEqual(2);
     expect(Math.max(...backoffIndices)).toBeLessThanOrEqual(1);
   }, 10_000);

--- a/client/src/app/core/interceptors/cache.interceptor.spec.ts
+++ b/client/src/app/core/interceptors/cache.interceptor.spec.ts
@@ -1,0 +1,21 @@
+import { isCacheable } from './cache.interceptor';
+
+describe('cache.interceptor — what may be cached', () => {
+  it('caches the core reads it was built for', () => {
+    expect(isCacheable('/api/media/12')).toBe(true);
+    expect(isCacheable('/api/libraries/mine')).toBe(true);
+    expect(isCacheable('/api/profiles/quality')).toBe(true);
+  });
+
+  it('never caches a plugin route, whatever the cacheable list grows to', () => {
+    expect(isCacheable('/api/plugins/fliks.acme/42/releases')).toBe(false);
+    expect(isCacheable('/api/plugins/fliks.acme/queue')).toBe(false);
+    expect(isCacheable('/api/plugins/ui')).toBe(false);
+  });
+
+  it('refuses auth, streams and live subtitle searches', () => {
+    expect(isCacheable('/api/auth/me')).toBe(false);
+    expect(isCacheable('/api/stream/1')).toBe(false);
+    expect(isCacheable('/api/media/42/subtitles/search')).toBe(false);
+  });
+});

--- a/client/src/app/core/interceptors/cache.interceptor.ts
+++ b/client/src/app/core/interceptors/cache.interceptor.ts
@@ -39,6 +39,9 @@ const EXCLUDED_PREFIXES = [
   '/api/auth',
   '/api/stream',
   '/api/playback/media/',
+  // A plugin route reaches whatever the plugin talks to — a tracker, a download client. This cache
+  // ignores HTTP headers, so the proxy's `no-store` alone would not stop it.
+  '/api/plugins',
 ];
 
 // Live query endpoints (external providers) — never cache. A stale hit here
@@ -164,7 +167,7 @@ export async function invalidatePrefix(prefix: string): Promise<void> {
 
 // ── Interceptor ──
 
-function isCacheable(url: string): boolean {
+export function isCacheable(url: string): boolean {
   if (EXCLUDED_PREFIXES.some((p) => url.startsWith(p))) return false;
   if (EXCLUDED_PATTERNS.some((r) => r.test(url))) return false;
   return CACHEABLE_PREFIXES.some((p) => url.startsWith(p));


### PR DESCRIPTION
## Problem

A plugin route reaches whatever the plugin talks to — a tracker, a download client. The proxy sent those responses with an `ETag` and **no cache directive at all**, leaving the browser, a service worker or any intermediary free to keep a copy and answer a later, different search from it. The release picker is where it showed: the same rows came back for a new query.

## Fix

`PluginProxyController` sets `Cache-Control: no-store` before forwarding the plugin's own headers, so a plugin serving an asset can still opt into caching deliberately (`cache-control` stays on the response allowlist). One point of passage covers every plugin route, every client and every intermediary.

The client's IndexedDB stale-while-revalidate cache reads no HTTP headers, so `no-store` alone would not stop it — `/api/plugins` joins `EXCLUDED_PREFIXES` there.

## What was *not* the cause

- **ngsw**: its only `dataGroup` is `media-images` (`/images/**`). Nothing matches `/api/**`, so it passes plugin requests through — DevTools attributes a pass-through to the service worker, which reads like a cache hit but is not one.
- **The interceptor, today**: `/api/plugins/…` matches no cacheable prefix, so it was already excluded. Its exclusion is a standing rule, not the fix. I also reverted two release-URL patterns I had added there — `/api/media/:id/releases` and friends no longer exist as core routes.
- **The plugin**: no search-result cache, and `q` is read.

## Verification

- `Cache-Control: no-store` confirmed live against the running container on the exact route from the report: `GET /api/plugins/fliks.download/2/releases`, plus `/queue` and `/indexers`. `/api/counts` (core) unaffected.
- backend `tsc` clean (exit code read), 125 suites / 1347 tests pass; client 44 files / 362 tests pass.
- The header behaviour is pinned by two new proxy specs (default `no-store`, plugin override wins) and the three existing header-allowlist specs updated.

## Drive-by

`plugin-supervisor.spec.ts` "resets once the plugin stays continuously ready" waited a fixed 750ms for cycles that each spawn a real process; it counted too few under a loaded suite and failed once in a full run. It now waits for the condition with a deadline.
