### PR TITLE
feat(plugins): let a table view declare server-side filters

### DIFF
--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -117,6 +117,8 @@ export interface TableColumn {
   key: string;
   labelKey: string;
   format?: 'date' | 'bytes' | 'percent';
+  /** Maps a cell value to a translate key — a status column renders its raw enum otherwise. */
+  labelKeys?: Record<string, string>;
 }
 
 /** One proxied route lists instances, another lists the implementations and their fields. */
@@ -160,11 +162,18 @@ export interface ProvidersConfigPage extends ConfigPageBase {
   };
 }
 
+/** One `table` filter — its current value is sent to `list` as a query param named by
+ *  `key`; an empty value is omitted. Filtering itself is the plugin's job, core only forwards it. */
+export type TableFilter =
+  | { kind: 'search'; key: string; placeholderKey: string }
+  | { kind: 'select'; key: string; labelKey: string; options: { value: string; labelKey: string }[] };
+
 /** Read-mostly: declared columns and declared row actions, never a general grid. */
 export interface TableConfigPage extends ConfigPageBase {
   kind: 'table';
   list: string;
   columns: TableColumn[];
+  filters?: TableFilter[];
   rowActions?: (
     | { kind: 'route'; labelKey: string; path: string }
     | { kind: 'action'; labelKey: string; actionId: string }

--- a/client/src/app/core/plugin-ui/contribution.types.ts
+++ b/client/src/app/core/plugin-ui/contribution.types.ts
@@ -120,6 +120,8 @@ export interface TableColumn {
   key: string;
   labelKey: string;
   format?: 'date' | 'bytes' | 'percent';
+  /** Maps a cell value to a translate key — a status column renders its raw enum otherwise. */
+  labelKeys?: Record<string, string>;
 }
 
 /** One proxied route lists instances, another lists the implementations and their fields. */
@@ -163,11 +165,18 @@ export interface ProvidersConfigPage extends ConfigPageBase {
   };
 }
 
+/** One `table` filter — its current value is sent to `list` as a query param named by
+ *  `key`; an empty value is omitted. Filtering itself is the plugin's job, core only forwards it. */
+export type TableFilter =
+  | { kind: 'search'; key: string; placeholderKey: string }
+  | { kind: 'select'; key: string; labelKey: string; options: { value: string; labelKey: string }[] };
+
 /** Read-mostly: declared columns and declared row actions, never a general grid. */
 export interface TableConfigPage extends ConfigPageBase {
   kind: 'table';
   list: string;
   columns: TableColumn[];
+  filters?: TableFilter[];
   rowActions?: (
     | { kind: 'route'; labelKey: string; path: string }
     | { kind: 'action'; labelKey: string; actionId: string }

--- a/client/src/app/features/plugin-view/plugin-view.html
+++ b/client/src/app/features/plugin-view/plugin-view.html
@@ -41,6 +41,7 @@
         [titleKey]="view.labelKey"
         [listUrl]="resourceUrl(view.list)"
         [columns]="view.columns"
+        [filters]="view.filters ?? []"
         [rowActions]="tableRowActions(view)"
         [listActions]="tableListActions(view)"
         [defaultSortKey]="view.defaultSortKey ?? null"

--- a/client/src/app/shared/components/data-table/data-table.html
+++ b/client/src/app/shared/components/data-table/data-table.html
@@ -22,7 +22,38 @@
     }
   </div>
 
-  @if (loading()) {
+  @if (filters().length) {
+    <div class="flex flex-wrap items-center gap-2">
+      @for (filter of filters(); track filter.key) {
+        @switch (filter.kind) {
+          @case ('search') {
+            <input
+              type="search"
+              class="input input-bordered input-sm w-full max-w-xs"
+              [placeholder]="filter.placeholderKey | translate"
+              [value]="filterValue(filter.key)"
+              (input)="onSearchInput(filter.key, $event)"
+            />
+          }
+          @case ('select') {
+            <select
+              class="select select-bordered select-sm"
+              [attr.aria-label]="filter.labelKey | translate"
+              (change)="onSelectChange(filter.key, $event)"
+            >
+              @for (option of filter.options; track option.value) {
+                <option [value]="option.value" [selected]="filterValue(filter.key) === option.value">
+                  {{ option.labelKey | translate }}
+                </option>
+              }
+            </select>
+          }
+        }
+      }
+    </div>
+  }
+
+  @if (loading() && !rows().length) {
     <div class="flex justify-center py-16">
       <span class="loading loading-spinner loading-lg"></span>
     </div>
@@ -31,7 +62,7 @@
   } @else if (rows().length === 0) {
     <p class="text-center py-12 text-base-content/50">{{ emptyKey() | translate }}</p>
   } @else {
-    <div class="overflow-x-auto rounded-lg border border-base-200">
+    <div class="overflow-x-auto rounded-lg border border-base-200" [class.opacity-50]="loading()">
       <table class="table table-zebra table-sm">
         <thead>
           <tr>
@@ -52,7 +83,7 @@
                     @case ('date') { {{ cellDate(row[col.key]) | localeDate }} }
                     @case ('bytes') { {{ cellBytes(row[col.key]) }} }
                     @case ('percent') { {{ cellPercent(row[col.key]) }} }
-                    @default { {{ row[col.key] }} }
+                    @default { {{ cellLabel(col, row[col.key]) }} }
                   }
                 </td>
               }

--- a/client/src/app/shared/components/data-table/data-table.spec.ts
+++ b/client/src/app/shared/components/data-table/data-table.spec.ts
@@ -3,11 +3,11 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
-import { of } from 'rxjs';
+import { Subject, of } from 'rxjs';
 import { vi } from 'vitest';
 import { DataTableComponent } from './data-table';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
-import { ListAction, RowAction, TableColumn } from './data-table.types';
+import { ListAction, RowAction, TableColumn, TableFilter, TableRow } from './data-table.types';
 
 const COLUMNS: TableColumn[] = [{ key: 'name', labelKey: 'x.name' }];
 
@@ -22,6 +22,7 @@ async function createComponent(opts: {
   columns?: TableColumn[];
   rowActions?: RowAction[];
   listActions?: ListAction[];
+  filters?: TableFilter[];
   resolveAction?: (actionId: string, row: unknown) => (() => void) | undefined;
   defaultSortKey?: string;
   paged?: boolean;
@@ -45,6 +46,7 @@ async function createComponent(opts: {
   fixture.componentRef.setInput('columns', opts.columns ?? COLUMNS);
   if (opts.rowActions) fixture.componentRef.setInput('rowActions', opts.rowActions);
   if (opts.listActions) fixture.componentRef.setInput('listActions', opts.listActions);
+  if (opts.filters) fixture.componentRef.setInput('filters', opts.filters);
   if (opts.resolveAction) fixture.componentRef.setInput('resolveAction', opts.resolveAction);
   if (opts.defaultSortKey) fixture.componentRef.setInput('defaultSortKey', opts.defaultSortKey);
   if (opts.paged) fixture.componentRef.setInput('paged', opts.paged);
@@ -170,5 +172,136 @@ describe('DataTableComponent — characterisation', () => {
     await item.run();
     expect(post).toHaveBeenCalledWith('/api/x/1/grab', {});
     expect(get).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('DataTableComponent — declared filters', () => {
+  const SEARCH: TableFilter = { kind: 'search', key: 'q', placeholderKey: 'x.search' };
+  const STATUS: TableFilter = {
+    kind: 'select',
+    key: 'status',
+    labelKey: 'x.status',
+    options: [{ value: '', labelKey: 'x.all' }, { value: 'failed', labelKey: 'x.failed' }],
+  };
+
+  it('VERDICT: typing in a search filter sends it as a query param, debounced, and resets the page', async () => {
+    const get = vi.fn(() => of({ data: [{ id: 1, name: 'A' }], total: 40, page: 1, pageSize: 20 }));
+    const fixture = await createComponent({ http: { get }, paged: true, filters: [SEARCH] });
+    await fixture.componentInstance.goToPage(2);
+    get.mockClear();
+
+    const input = fixture.nativeElement.querySelector('input[type="search"]') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    input.value = 'abc';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    // Debounced: the keystroke alone must not have fired a request yet.
+    expect(get).not.toHaveBeenCalled();
+    await new Promise((r) => setTimeout(r, 350));
+    fixture.detectChanges();
+
+    expect(get).toHaveBeenCalledTimes(1);
+    const [, options] = get.mock.calls[0] as unknown as [string, { params: { toString(): string } }];
+    expect(options.params.toString()).toBe('q=abc&page=1&pageSize=20');
+  });
+
+  it('VERDICT: a select filter reloads immediately and resets the page', async () => {
+    const get = vi.fn(() => of({ data: [{ id: 1, name: 'A' }], total: 40, page: 1, pageSize: 20 }));
+    const fixture = await createComponent({ http: { get }, paged: true, filters: [STATUS] });
+    await fixture.componentInstance.goToPage(2);
+    get.mockClear();
+
+    const select = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+    expect(select).toBeTruthy();
+    select.value = 'failed';
+    select.dispatchEvent(new Event('change'));
+    await new Promise((r) => setTimeout(r, 0));
+    fixture.detectChanges();
+
+    expect(get).toHaveBeenCalledTimes(1);
+    const [, options] = get.mock.calls[0] as unknown as [string, { params: { toString(): string } }];
+    expect(options.params.toString()).toBe('status=failed&page=1&pageSize=20');
+  });
+
+  it('sends a declared filter on an unpaged (bare-array) list too', async () => {
+    const get = vi.fn(() => of([{ id: 1, name: 'A' }]));
+    const fixture = await createComponent({ http: { get }, filters: [STATUS] });
+    const select = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+    select.value = 'failed';
+    select.dispatchEvent(new Event('change'));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const last = get.mock.calls.at(-1) as unknown as [string, { params: { toString(): string } }];
+    expect(last[1].params.toString()).toBe('status=failed');
+  });
+
+  it('VERDICT: clearing a filter drops the param instead of sending it blank', async () => {
+    const get = vi.fn(() => of([{ id: 1, name: 'A' }]));
+    const fixture = await createComponent({ http: { get }, filters: [STATUS] });
+    const select = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+
+    select.value = 'failed';
+    select.dispatchEvent(new Event('change'));
+    await new Promise((r) => setTimeout(r, 0));
+    select.value = '';
+    select.dispatchEvent(new Event('change'));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const last = get.mock.calls.at(-1) as unknown as [string, { params: { toString(): string } }];
+    expect(last[1].params.toString()).toBe('');
+  });
+
+  it('VERDICT: the rendered selection comes from state, not from a prior DOM write', async () => {
+    const fixture = await createComponent({ http: { get: () => of([{ id: 1, name: 'A' }]) }, filters: [STATUS] });
+
+    fixture.componentInstance.filterValues.set({ status: 'failed' });
+    fixture.detectChanges();
+
+    const select = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+    expect(select.value).toBe('failed');
+  });
+
+  it('VERDICT: a superseded reload never overwrites the rows of the newest one', async () => {
+    const pending: Subject<TableRow[]>[] = [];
+    const get = vi.fn(() => {
+      const subject = new Subject<TableRow[]>();
+      pending.push(subject);
+      return subject.asObservable();
+    });
+    const fixture = await createComponent({ http: { get }, filters: [STATUS] });
+    const select = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+
+    select.value = 'failed';
+    select.dispatchEvent(new Event('change'));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(pending).toHaveLength(2);
+
+    // The newest request answers first; the slow initial one must not win the race.
+    pending[1].next([{ id: 2, name: 'newest' }]);
+    pending[1].complete();
+    await new Promise((r) => setTimeout(r, 0));
+    pending[0].next([{ id: 1, name: 'stale' }]);
+    pending[0].complete();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fixture.componentInstance.rows().map((r) => r['name'])).toEqual(['newest']);
+  });
+
+  it('renders a declared value label for a cell instead of its raw value', async () => {
+    const fixture = await createComponent({
+      http: { get: () => of([{ id: 1, status: 'failed' }]) },
+      columns: [{ key: 'status', labelKey: 'x.status', labelKeys: { failed: 'x.failed_label' } }],
+    });
+    expect(fixture.componentInstance.cellLabel(fixture.componentInstance.columns()[0], 'failed')).toBe('x.failed_label');
+    expect(fixture.componentInstance.cellLabel(fixture.componentInstance.columns()[0], 'other')).toBe('other');
+  });
+
+  it('renders no control for an unrecognised filter kind (fail closed)', async () => {
+    const fixture = await createComponent({
+      http: { get: () => of([{ id: 1, name: 'A' }]) },
+      filters: [{ kind: 'bogus' } as unknown as TableFilter],
+    });
+    expect(fixture.nativeElement.querySelectorAll('input[type="search"], select')).toHaveLength(0);
   });
 });

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit, computed, inject, input, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, computed, inject, input, signal } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
@@ -7,7 +7,10 @@ import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
 import { formatBytes } from '../../utils/download-format';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { PaginationComponent } from '../pagination/pagination';
-import { CellValue, ListAction, PagedResult, RowAction, TableColumn, TableRow } from './data-table.types';
+import { CellValue, ListAction, PagedResult, RowAction, TableColumn, TableFilter, TableRow } from './data-table.types';
+
+/** Keystroke-to-request debounce for a `search` filter — see `onSearchInput`. */
+const SEARCH_DEBOUNCE_MS = 300;
 
 /**
  * The `table` view kind: declared columns, declared row actions, no
@@ -42,6 +45,8 @@ export class DataTableComponent implements OnInit {
   /** `list` answers `{data,total,page,pageSize}` rather than a bare array. */
   readonly paged = input(false);
   readonly pageSize = input(20);
+  /** Declared `search`/`select` filters, rendered above the table. */
+  readonly filters = input<readonly TableFilter[]>([]);
 
   readonly rows = signal<TableRow[]>([]);
   readonly loading = signal(true);
@@ -53,28 +58,72 @@ export class DataTableComponent implements OnInit {
   readonly total = signal(0);
   readonly totalPages = computed(() => Math.max(1, Math.ceil(this.total() / this.pageSize())));
 
+  /** Current value per filter `key`; an empty entry is omitted from the request. */
+  readonly filterValues = signal<Record<string, string>>({});
+  private searchDebounce: ReturnType<typeof setTimeout> | null = null;
+  private loadSeq = 0;
+
+  constructor() {
+    inject(DestroyRef).onDestroy(() => {
+      if (this.searchDebounce) clearTimeout(this.searchDebounce);
+    });
+  }
+
   ngOnInit(): void {
     void this.loadRows();
   }
 
   async loadRows(): Promise<void> {
+    // Only the newest reload may write: a filtered scan can resolve after a later, narrower one.
+    const seq = ++this.loadSeq;
     this.loading.set(true);
     this.listError.set('');
     try {
+      let params = new HttpParams();
+      for (const [key, value] of Object.entries(this.filterValues())) {
+        if (value) params = params.set(key, value);
+      }
       if (this.paged()) {
-        const params = new HttpParams().set('page', this.page()).set('pageSize', this.pageSize());
+        params = params.set('page', this.page()).set('pageSize', this.pageSize());
         const res = await firstValueFrom(this.http.get<PagedResult<TableRow>>(this.listUrl(), { params }));
+        if (seq !== this.loadSeq) return;
         this.rows.set(this.applyDefaultSort(Array.isArray(res?.data) ? res.data : []));
         this.total.set(res?.total ?? 0);
       } else {
-        const data = await firstValueFrom(this.http.get<TableRow[]>(this.listUrl()));
+        const data = await firstValueFrom(this.http.get<TableRow[]>(this.listUrl(), { params }));
+        if (seq !== this.loadSeq) return;
         this.rows.set(this.applyDefaultSort(Array.isArray(data) ? data : []));
       }
     } catch {
-      this.listError.set(this.translate.instant(this.loadErrorKey()));
+      if (seq === this.loadSeq) this.listError.set(this.translate.instant(this.loadErrorKey()));
     } finally {
-      this.loading.set(false);
+      if (seq === this.loadSeq) this.loading.set(false);
     }
+  }
+
+  /** A `select` filter reloads immediately; a `search` box debounces so a fast typist
+   *  doesn't fire one query per keystroke against the plugin's own (uncached) database. */
+  onSearchInput(key: string, event: Event): void {
+    const value = (event.target as HTMLInputElement).value;
+    this.filterValues.update((v) => ({ ...v, [key]: value }));
+    if (this.searchDebounce) clearTimeout(this.searchDebounce);
+    this.searchDebounce = setTimeout(() => void this.applyFilterChange(), SEARCH_DEBOUNCE_MS);
+  }
+
+  onSelectChange(key: string, event: Event): void {
+    const value = (event.target as HTMLSelectElement).value;
+    this.filterValues.update((v) => ({ ...v, [key]: value }));
+    void this.applyFilterChange();
+  }
+
+  /** A key with no entry yet — no keystroke, no default selection — reads as ''. */
+  filterValue(key: string): string {
+    return (this.filterValues() as Record<string, string | undefined>)[key] ?? '';
+  }
+
+  private async applyFilterChange(): Promise<void> {
+    this.page.set(1);
+    await this.loadRows();
   }
 
   async goToPage(page: number): Promise<void> {
@@ -94,6 +143,13 @@ export class DataTableComponent implements OnInit {
 
   cellPercent(value: CellValue): string {
     return typeof value === 'number' ? `${Math.round(value)}%` : String(value ?? '');
+  }
+
+  /** An undeclared value renders as itself rather than as a missing translate key. */
+  cellLabel(col: TableColumn, value: CellValue): string {
+    const raw = String(value ?? '');
+    const key = col.labelKeys?.[raw];
+    return key ? this.translate.instant(key) : raw;
   }
 
   private applyDefaultSort(rows: TableRow[]): TableRow[] {

--- a/client/src/app/shared/components/data-table/data-table.types.ts
+++ b/client/src/app/shared/components/data-table/data-table.types.ts
@@ -2,7 +2,14 @@ export interface TableColumn {
   key: string;
   labelKey: string;
   format?: 'date' | 'bytes' | 'percent';
+  /** Maps a cell value to a translate key — a status column renders its raw enum otherwise. */
+  labelKeys?: Record<string, string>;
 }
+
+/** `TableConfigPage.filters[]` — value sent to `list` as a query param named by `key`. */
+export type TableFilter =
+  | { kind: 'search'; key: string; placeholderKey: string }
+  | { kind: 'select'; key: string; labelKey: string; options: { value: string; labelKey: string }[] };
 
 export type CellValue = string | number | boolean | null | undefined;
 


### PR DESCRIPTION
## Why

The download-history page could only render a page of rows. With no way to narrow them, a history of any real age was unusable — the concrete gap left open when the page was restored.

## The contract

`TableConfigPage` gains a declared filter surface, so this is a feature of the `table` view kind rather than a special case for one page:

```ts
export type TableFilter =
  | { kind: 'search'; key: string; placeholderKey: string }
  | { kind: 'select'; key: string; labelKey: string; options: { value: string; labelKey: string }[] };
```

Each filter's current value reaches `list` as a query param named by its `key`; an empty value is omitted. Core forwards the params and nothing more — the filtering is the plugin's job. An unrecognised `kind` renders no control, the same fail-closed rule as an unknown `actionId`.

`TableColumn.labelKeys` maps a cell value to a translate key. Without it a status column renders the plugin's own enum (`grabbed`, `failed`) untranslated next to a filter dropdown that is translated.

Both additions are mirrored into the client's copy of the contract, which is kept identical below its header, and the plugin repo's drift gate passes against this checkout rather than skipping.

## Renderer correctness

Three defects found by review before this shipped, each now covered by a test I verified fails when the guard is reverted:

- **Out-of-order responses.** `loadRows()` had no sequencing. `download_history` has no index on the searched column and the query is a substring scan, so typing `a` then `ab` can have the first request resolve last and repaint rows for a filter the box no longer shows. Only the newest reload may write.
- **Selection rendered from a DOM write.** `[value]` on the `<select>` races the `@for` that creates its options: applied first it is a no-op and the browser auto-selects option 0, so the control shows one filter while the request sends another. The selection now comes from state via `[selected]` per option. (My first test for this passed either way, because it set `select.value` by hand — it now asserts state→DOM.)
- **Debounce outliving the component.** A pending search timer fired a request after navigation; cleared on destroy.

Rows also stay on screen and dim during a reload instead of collapsing to a full-height spinner on every keystroke.

## Verification

- backend `tsc` clean (exit code read), 125 suites / 1347 tests pass; client 44 files / 370 tests pass; production build succeeds.
- Live against the running container: `GET /api/plugins/fliks.download/history?page=1&q=…&status=…` answers 200 with `Cache-Control: no-store`. The installed plugin build predates the filters and ignores the params rather than rejecting them, so the contract addition is backwards compatible.

## Not included

The plugin side — reading `q`/`status`, filtering both the page and the count query, and declaring the two filters — ships in the plugin repo and needs a release before the page is filterable end to end. The `grabSource` column still renders `auto`/`manual` raw; it predates this change and is not part of the filter surface.
