### PR TITLE
feat(plugins): publish the handshake, enforce the scopes, name the errors

### DIFF
--- a/backend/src/common/plugin-contract/plugin-methods.ts
+++ b/backend/src/common/plugin-contract/plugin-methods.ts
@@ -15,7 +15,11 @@ export interface PluginApi {
     pluginApi: number;
     coreVersion: string;
     config: Record<string, string>;
-  }) => Promise<{ manifest: PluginManifest }>;
+  }) => Promise<{
+    manifest: PluginManifest;
+    /** `FLIKS_PLUGIN_TOKEN` echoed back — proof the responder is the process core spawned; never travels core→plugin. */
+    token: string;
+  }>;
 
   health: () => Promise<{ ok: boolean; detail?: string }>;
 

--- a/backend/src/common/plugin-contract/principal.ts
+++ b/backend/src/common/plugin-contract/principal.ts
@@ -1,3 +1,5 @@
+import type { PluginHostApi } from './host-methods';
+
 /**
  * Auth model for the plugin socket. There is no JWT and no `User` row on
  * this side of the boundary — only these two principals.
@@ -23,3 +25,27 @@ export type PluginScope =
   | 'ingest:write'
   | 'events:emit'
   | 'config:rw';
+
+/**
+ * The scopes each `PluginHostApi` method requires — every one of them — derived from what
+ * `FliksHostImpl` reads or writes rather than from the method's own name.
+ */
+export const HOST_METHOD_SCOPES: Readonly<Record<keyof PluginHostApi, readonly PluginScope[]>> = {
+  'media.acquisitionContext': ['media:read'],
+  // Both enumerate the monitored library and answer with media identity, which is `media:read`'s
+  // to grant: an acquisition scope alone would be a title oracle for the whole library.
+  'acquisition.candidates': ['acquisition:candidates', 'media:read'],
+  'releases.match': ['acquisition:candidates', 'media:read'],
+  'releases.score': ['releases:score'],
+  'media.resolve': ['media:read'],
+  'media.exists': ['media:read'],
+  'requests.markInProgress': ['requests:progress'],
+  'library.ingest': ['ingest:write'],
+  'events.publish': ['events:emit'],
+  'notifications.dispatch': ['events:emit'],
+  'counts.set': ['events:emit'],
+  'events.emitOwn': ['events:emit'],
+  'progress.set': ['events:emit'],
+  'config.get': ['config:rw'],
+  'config.set': ['config:rw'],
+};

--- a/backend/src/common/plugin-contract/protocol.ts
+++ b/backend/src/common/plugin-contract/protocol.ts
@@ -33,3 +33,37 @@ export const MAX_FRAME_BYTES = 4 * 1024 * 1024;
  * or semantic change bumps it.
  */
 export const PLUGIN_API_VERSION = 0;
+
+/**
+ * Environment core sets on every spawn (see `supervisor/spawn-plan.ts`) — the only way in
+ * for a `process` plugin, since core never passes `...process.env`. Every value here is a
+ * plain string; only `FLIKS_API_VERSION` has a typed counterpart ({@link PLUGIN_API_VERSION}).
+ */
+export interface PluginSpawnEnv {
+  /** Random per spawn, known only to core and this child. Echo it back as `hello`'s `token` —
+   *  proof the responder is the process core spawned, not an impostor on the socket. */
+  FLIKS_PLUGIN_TOKEN: string;
+  /** Unix socket this plugin dials to make its `PluginHostApi` calls. */
+  FLIKS_CORE_SOCK: string;
+  /** Unix socket this plugin listens on for core's `PluginApi` calls
+   *  (`hello`, `health`, `http`, `job`, `event`, `config`, `shutdown`). */
+  FLIKS_PLUGIN_SOCK: string;
+  /** This plugin's own Postgres connection string; `''` when its manifest declared no schema. */
+  FLIKS_DB_URL: string;
+  /** This manifest's `id`, verbatim. */
+  FLIKS_PLUGIN_ID: string;
+  /** {@link PLUGIN_API_VERSION}, stringified — compared for exact equality, never a range. */
+  FLIKS_API_VERSION: string;
+  /** `${dir}/data` — the child's cwd, and the one path its sandbox may write to. */
+  HOME: string;
+  PATH: string;
+  NODE_ENV: string;
+  TZ: string;
+}
+
+/**
+ * Every `plugin.<id>.<key>` admin setting also arrives re-keyed as an env var: strip the
+ * `plugin.<id>.` prefix, upper-case what remains, replace every character outside
+ * `[A-Z0-9_]` with `_`, and prepend `FLIKS_CFG_` (see `reKeyConfig` in `supervisor/spawn-plan.ts`).
+ * Not a fixed set — read whichever `FLIKS_CFG_*` names your own manifest's settings resolve to.
+ */

--- a/backend/src/modules/plugins/host/plugin-host-binding.service.spec.ts
+++ b/backend/src/modules/plugins/host/plugin-host-binding.service.spec.ts
@@ -6,6 +6,11 @@ import { InProcessPluginHostClient } from './in-process-plugin-host-client';
 import { PluginHostBindingService } from './plugin-host-binding.service';
 import { PluginCountsCacheService } from './plugin-counts-cache.service';
 import { EventsService } from '../../scheduler/events.service';
+import {
+  HOST_METHOD_SCOPES,
+  type PluginHostApi,
+  type PluginScope,
+} from '../../../common/plugin-contract';
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -24,10 +29,13 @@ function fakeRepo() {
 /** Stand-in for the `plugin_registrations` table, keyed by plugin id.
  *  `delete` is what an uninstall does mid-connection, per `plugin-install.service.ts`. */
 class FakeRegistrationRepo {
-  private rows = new Map<string, { pluginId: string; ingestRoots: string[] }>();
+  private rows = new Map<
+    string,
+    { pluginId: string; ingestRoots: string[]; scopes: PluginScope[] }
+  >();
 
-  seed(pluginId: string, ingestRoots: string[]): void {
-    this.rows.set(pluginId, { pluginId, ingestRoots });
+  seed(pluginId: string, ingestRoots: string[], scopes: PluginScope[] = []): void {
+    this.rows.set(pluginId, { pluginId, ingestRoots, scopes });
   }
 
   delete(pluginId: string): void {
@@ -117,8 +125,8 @@ describe('PluginHostBindingService', () => {
     fs.writeFileSync(fileBeta, 'x');
 
     try {
-      registrations.seed('test.alpha', [rootAlpha]);
-      registrations.seed('test.beta', [rootBeta]);
+      registrations.seed('test.alpha', [rootAlpha], ['config:rw', 'ingest:write']);
+      registrations.seed('test.beta', [rootBeta], ['config:rw', 'ingest:write']);
       await settings.set('plugin.test.alpha.token', 'A-secret');
       await settings.set('plugin.test.beta.token', 'B-secret');
 
@@ -181,8 +189,8 @@ describe('PluginHostBindingService', () => {
 
   it('adversarial: ignores a plugin id smuggled inside the payload — identity comes only from bind()', async () => {
     const { settings, registrations, binding } = makeStack();
-    registrations.seed('test.alpha', []);
-    registrations.seed('test.beta', []);
+    registrations.seed('test.alpha', [], ['config:rw']);
+    registrations.seed('test.beta', [], ['config:rw']);
 
     const alpha = binding.bind('test.alpha');
     const beta = binding.bind('test.beta');
@@ -203,8 +211,8 @@ describe('PluginHostBindingService', () => {
 
   it('fails closed the instant a registration vanishes, with no collateral on the surviving plugin', async () => {
     const { registrations, client, binding } = makeStack();
-    registrations.seed('test.alpha', []);
-    registrations.seed('test.beta', []);
+    registrations.seed('test.alpha', [], ['config:rw']);
+    registrations.seed('test.beta', [], ['config:rw']);
 
     const alpha = binding.bind('test.alpha');
     const beta = binding.bind('test.beta');
@@ -222,5 +230,76 @@ describe('PluginHostBindingService', () => {
     // Refused before ever reaching the host — not a deeper failure inside it.
     expect(clientSpy.mock.calls.length).toBe(callsBefore);
     await expect(beta['config.get']({})).resolves.toEqual({});
+  });
+
+  describe('scope enforcement', () => {
+    /** One valid payload per method — just enough for `FliksHostImpl` to run its
+     *  fake-backed path without throwing for a reason other than the scope check. */
+    const PAYLOADS: { [K in keyof PluginHostApi]: Parameters<PluginHostApi[K]>[0] } = {
+      'media.acquisitionContext': { mediaId: 1 },
+      'acquisition.candidates': { availableOn: '2024-01-01', limit: 10 },
+      'releases.match': { titles: [] },
+      'releases.score': { mediaId: 1, releases: [] },
+      'media.resolve': {},
+      'media.exists': { mediaIds: [] },
+      'requests.markInProgress': { idempotencyKey: 'x', mediaId: 1 },
+      'library.ingest': {
+        idempotencyKey: 'x',
+        mediaId: 1,
+        paths: [],
+        transfer: 'copy',
+        sourceLabel: 's',
+      },
+      'events.publish': [],
+      'notifications.dispatch': { event: 'grab.started', payload: {} },
+      'counts.set': { key: 'k', value: 1 },
+      'events.emitOwn': { type: 't', payload: {}, audience: 'all' },
+      'progress.set': { mediaId: 1, ref: 'r', progress: 0, state: 'active' },
+      'config.get': {},
+      'config.set': { key: 'k', value: 'v' },
+    };
+
+    const cases = (Object.keys(HOST_METHOD_SCOPES) as (keyof PluginHostApi)[]).map((method) => ({
+      method,
+      scopes: HOST_METHOD_SCOPES[method],
+      /** The one reported when nothing is granted — the first the filter finds. */
+      firstScope: HOST_METHOD_SCOPES[method][0]!,
+    }));
+
+    function call(api: PluginHostApi, method: keyof PluginHostApi): Promise<unknown> {
+      return (api[method] as (p: unknown) => Promise<unknown>)(PAYLOADS[method]);
+    }
+
+    it.each(cases)(
+      '$method rejects without $firstScope and passes once every scope it needs is granted',
+      async ({ method, scopes, firstScope }) => {
+        const { registrations, binding } = makeStack();
+
+        registrations.seed('test.scoped', ['/tmp'], []);
+        await expect(call(binding.bind('test.scoped'), method)).rejects.toThrow(
+          `missing scope "${firstScope}" required for "${method}"`,
+        );
+
+        // Granting all but the last must still refuse: a method needing two is not half-granted.
+        if (scopes.length > 1) {
+          registrations.seed('test.scoped', ['/tmp'], scopes.slice(0, -1));
+          await expect(call(binding.bind('test.scoped'), method)).rejects.toThrow('missing scope');
+        }
+
+        registrations.seed('test.scoped', ['/tmp'], [...scopes]);
+        await call(binding.bind('test.scoped'), method); // must not reject once granted
+      },
+    );
+
+    it('a plugin holding only one scope cannot reach a method requiring another', async () => {
+      const { registrations, binding } = makeStack();
+      registrations.seed('test.narrow', [], ['config:rw']);
+      const bound = binding.bind('test.narrow');
+
+      await expect(bound['media.exists']({ mediaIds: [] })).rejects.toThrow(
+        'missing scope "media:read" required for "media.exists"',
+      );
+      await expect(bound['config.get']({})).resolves.toEqual({});
+    });
   });
 });

--- a/backend/src/modules/plugins/host/plugin-host-binding.service.ts
+++ b/backend/src/modules/plugins/host/plugin-host-binding.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import type { PluginHostApi } from '../../../common/plugin-contract';
+import { HOST_METHOD_SCOPES, type PluginHostApi } from '../../../common/plugin-contract';
 import { PluginRegistration } from '../entities/plugin-registration.entity';
 import { InProcessPluginHostClient } from './in-process-plugin-host-client';
 import { PluginHostContext } from './plugin-host-context';
@@ -26,36 +26,50 @@ export class PluginHostBindingService {
    *  ponytail: one `findOne` per call, uncached — add a cache invalidated by
    *  `unregister()` if the round trip ever measurably matters. */
   bind(pluginId: string): PluginHostApi {
-    const scoped = <T>(fn: () => Promise<T>): Promise<T> =>
+    /** Distinct from the "no active registration" message so a plugin (and a test)
+     *  can tell an unknown identity apart from a known one refused for this method. */
+    const scoped = <T>(method: keyof PluginHostApi, fn: () => Promise<T>): Promise<T> =>
       this.registrations
         .findOne({ where: { pluginId } })
         .then((registration) => {
           if (!registration) {
             throw new Error(`plugin "${pluginId}" has no active registration`);
           }
+          const missing = HOST_METHOD_SCOPES[method].filter((s) => !registration.scopes.includes(s));
+          if (missing.length) {
+            throw new Error(
+              `plugin "${pluginId}" is missing scope "${missing[0]}" required for "${method}"`,
+            );
+          }
           return PluginHostContext.runAs(pluginId, fn);
         });
 
     return {
       'media.acquisitionContext': (p) =>
-        scoped(() => this.client['media.acquisitionContext'](p)),
+        scoped('media.acquisitionContext', () => this.client['media.acquisitionContext'](p)),
       'acquisition.candidates': (p) =>
-        scoped(() => this.client['acquisition.candidates'](p)),
-      'releases.match': (p) => scoped(() => this.client['releases.match'](p)),
-      'releases.score': (p) => scoped(() => this.client['releases.score'](p)),
-      'media.resolve': (p) => scoped(() => this.client['media.resolve'](p)),
-      'media.exists': (p) => scoped(() => this.client['media.exists'](p)),
+        scoped('acquisition.candidates', () => this.client['acquisition.candidates'](p)),
+      'releases.match': (p) =>
+        scoped('releases.match', () => this.client['releases.match'](p)),
+      'releases.score': (p) =>
+        scoped('releases.score', () => this.client['releases.score'](p)),
+      'media.resolve': (p) =>
+        scoped('media.resolve', () => this.client['media.resolve'](p)),
+      'media.exists': (p) => scoped('media.exists', () => this.client['media.exists'](p)),
       'requests.markInProgress': (p) =>
-        scoped(() => this.client['requests.markInProgress'](p)),
-      'library.ingest': (p) => scoped(() => this.client['library.ingest'](p)),
-      'events.publish': (p) => scoped(() => this.client['events.publish'](p)),
+        scoped('requests.markInProgress', () => this.client['requests.markInProgress'](p)),
+      'library.ingest': (p) =>
+        scoped('library.ingest', () => this.client['library.ingest'](p)),
+      'events.publish': (p) =>
+        scoped('events.publish', () => this.client['events.publish'](p)),
       'notifications.dispatch': (p) =>
-        scoped(() => this.client['notifications.dispatch'](p)),
-      'counts.set': (p) => scoped(() => this.client['counts.set'](p)),
-      'events.emitOwn': (p) => scoped(() => this.client['events.emitOwn'](p)),
-      'progress.set': (p) => scoped(() => this.client['progress.set'](p)),
-      'config.get': (p) => scoped(() => this.client['config.get'](p)),
-      'config.set': (p) => scoped(() => this.client['config.set'](p)),
+        scoped('notifications.dispatch', () => this.client['notifications.dispatch'](p)),
+      'counts.set': (p) => scoped('counts.set', () => this.client['counts.set'](p)),
+      'events.emitOwn': (p) =>
+        scoped('events.emitOwn', () => this.client['events.emitOwn'](p)),
+      'progress.set': (p) => scoped('progress.set', () => this.client['progress.set'](p)),
+      'config.get': (p) => scoped('config.get', () => this.client['config.get'](p)),
+      'config.set': (p) => scoped('config.set', () => this.client['config.set'](p)),
     };
   }
 }

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
@@ -7,6 +7,9 @@ import { getPluginsSocketDir } from '../../../common/constants/paths';
 import type { OnApplicationShutdown } from '@nestjs/common';
 import { LogBufferService } from '../../scheduler/log-buffer.service';
 import { CURRENT_FLIKS_VERSION } from '../plugin-version';
+import type { PluginApi } from '../../../common/plugin-contract';
+
+type HelloReply = Awaited<ReturnType<PluginApi['hello']>>;
 import { PLUGIN_API_VERSION, type Note, type PluginHostApi } from '../../../common/plugin-contract';
 import { RpcChannel } from './rpc-channel';
 import { NoteRingBuffer } from './note-ring-buffer';
@@ -468,14 +471,15 @@ export class PluginSupervisor implements OnApplicationShutdown {
 
   private async attemptHandshake(channel: RpcChannel): Promise<void> {
     try {
-      const res = await channel.call<{ manifest: unknown; token?: string }>(
+      const res = await channel.call<HelloReply>(
         'hello',
         { pluginApi: PLUGIN_API_VERSION, coreVersion: CURRENT_FLIKS_VERSION, config: this.opts.config },
         this.opts.handshakeDeadlineMs,
       );
-      // The token never travels core->plugin; only a process holding the real
-      // FLIKS_PLUGIN_TOKEN (via its own env) can echo the right value back.
-      if (res.token !== this.token) {
+      // The token never travels core->plugin; only a process holding the real FLIKS_PLUGIN_TOKEN
+      // can echo it back. Annotated, so loosening the contract's `token` stops compiling here.
+      const echoed: string = res.token;
+      if (echoed !== this.token) {
         this.handleCrash('hello token mismatch');
         return;
       }

--- a/backend/src/modules/plugins/supervisor/rpc-channel.spec.ts
+++ b/backend/src/modules/plugins/supervisor/rpc-channel.spec.ts
@@ -88,4 +88,49 @@ describe('RpcChannel', () => {
     pair.server.destroy();
     await expect(pending).rejects.toThrow(/closed/);
   });
+
+  describe('error frame codes', () => {
+    // Each message mirrors an exact throw site in fliks-host.service.ts,
+    // plugin-host-binding.service.ts or plugin-supervisor.ts, pinned by those files' own specs.
+    const cases: [string, () => Error, string][] = [
+      ['unknown host method', () => new Error('unknown host method "media.resolve"'), 'ERR_NO_METHOD'],
+      ['host-side deadline', () => new Error('host method "library.ingest" timed out after 30000ms'), 'ERR_TIMEOUT'],
+      ['registration gone', () => new Error('plugin "some-plugin" has no active registration'), 'ERR_NOT_FOUND'],
+      [
+        'ingest path missing on disk',
+        () => Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' }),
+        'ERR_NOT_FOUND',
+      ],
+      [
+        'no ingest roots configured',
+        () => new Error('library.ingest: no ingestRoots configured for plugin "some-plugin"'),
+        'ERR_DENIED',
+      ],
+      [
+        'path outside every ingest root',
+        () => new Error('library.ingest: "/tmp/x" is outside every configured ingest root'),
+        'ERR_DENIED',
+      ],
+      [
+        'plugin missing a required scope',
+        () => new Error('plugin "some-plugin" is missing scope "ingest:write" required for "library.ingest"'),
+        'ERR_DENIED',
+      ],
+      ['payload over its documented limit', () => new Error('media.resolve: 150 ids exceeds the 100 limit'), 'ERR_VALIDATION'],
+      ['anything else', () => new Error('some completely unrelated failure'), 'ERR'],
+    ];
+
+    for (const [label, buildError, expectedCode] of cases) {
+      it(`classifies ${label} as ${expectedCode}`, async () => {
+        const pair = await makePair();
+        cleanup = () => teardown(pair);
+        pair.server.onRequest(async () => {
+          throw buildError();
+        });
+        await expect(pair.client.call('some.method', {}, 1_000)).rejects.toThrow(
+          new RegExp(`^${expectedCode}: `),
+        );
+      });
+    }
+  });
 });

--- a/backend/src/modules/plugins/supervisor/rpc-channel.ts
+++ b/backend/src/modules/plugins/supervisor/rpc-channel.ts
@@ -20,6 +20,27 @@ function isNote(f: Frame): f is Note {
   return typeof (f as Note).m === 'string' && !('i' in f);
 }
 
+/** ENOENT is a structural signal (`fs.realpathSync` on a missing ingest path); everything
+ *  else here matches message text from fliks-host.service.ts / plugin-host-binding.service.ts /
+ *  plugin-supervisor.ts, which this file never edits — a wording change there falls back to 'ERR'. */
+const HOST_ERROR_PATTERNS: readonly [RegExp, string][] = [
+  [/^unknown host method /, 'ERR_NO_METHOD'],
+  [/ timed out after \d+ms$/, 'ERR_TIMEOUT'],
+  [/ has no active registration$/, 'ERR_NOT_FOUND'],
+  [/^library\.ingest: no ingestRoots configured/, 'ERR_DENIED'],
+  [/ is outside every configured ingest root$/, 'ERR_DENIED'],
+  [/ is missing scope ".*" required for /, 'ERR_DENIED'],
+  [/ exceeds the \d+ limit$/, 'ERR_VALIDATION'],
+];
+
+function classifyHostError(err: Error): string {
+  if ((err as NodeJS.ErrnoException).code === 'ENOENT') return 'ERR_NOT_FOUND';
+  for (const [pattern, code] of HOST_ERROR_PATTERNS) {
+    if (pattern.test(err.message)) return code;
+  }
+  return 'ERR';
+}
+
 /**
  * One newline-delimited JSON-RPC connection. Symmetric: either side may
  * `call()` the other; a frame fitting none of Req/Res/Note is a protocol violation, same as an unparsable line.
@@ -90,7 +111,8 @@ export class RpcChannel {
       const r = await this.requestHandler(req.m, req.p);
       this.write({ i: req.i, r });
     } catch (err) {
-      this.write({ i: req.i, e: { c: 'ERR', m: (err as Error).message } });
+      const e = err as Error;
+      this.write({ i: req.i, e: { c: classifyHostError(e), m: e.message } });
     }
   }
 

--- a/backend/src/modules/plugins/supervisor/spawn-plan.ts
+++ b/backend/src/modules/plugins/supervisor/spawn-plan.ts
@@ -1,7 +1,7 @@
 import { spawnSync, type SpawnOptions } from 'child_process';
 import { chmodSync, chownSync, mkdirSync, readdirSync } from 'fs';
 import { join } from 'path';
-import { PLUGIN_API_VERSION } from '../../../common/plugin-contract';
+import { PLUGIN_API_VERSION, type PluginSpawnEnv } from '../../../common/plugin-contract';
 
 /** The unprivileged identity a plugin child drops to when core runs as root. */
 export const PLUGIN_CHILD_UID = 65534;
@@ -86,7 +86,8 @@ export function buildSpawnPlan(input: SpawnPlanInput): SpawnPlan {
     `${input.dir}/plugin.js`,
   ];
 
-  const env: NodeJS.ProcessEnv = {
+  // Typed off the contract, so a variable renamed or dropped here stops compiling.
+  const env: PluginSpawnEnv & NodeJS.ProcessEnv = {
     PATH: '/usr/local/bin:/usr/bin:/bin',
     NODE_ENV: 'production',
     TZ: process.env.TZ ?? 'UTC',

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -18,15 +18,42 @@ plugin that needs to answer one route is a `process` plugin.
 
 ## The manifest
 
-One `plugin.json` at the archive root, validated before anything is written. Beyond identity
-(`id`, `version`, `pluginApi`, `fliks` range with a mandatory upper bound, `author`, `license`,
-`logo`):
+One `plugin.json` at the archive root, validated before anything is written. Every manifest,
+`data` or `process`, must carry all of: `id`, `pluginApi`, `name`, `version`, `fliks` (a semver
+range with a mandatory upper bound, e.g. `">=2.1.0 <3.0.0"`), `author`, `description`, `license`,
+`logo`, and `kind` (`data` or `process`) — the install fails if any one is missing. `homepage` is
+the only identity field that's optional.
 
-- `kind` — `data` or `process`, read from inside the signed manifest.
-- `provides.routes[]` (`process`) — every route core will proxy, each with the CASL `policy` it
-  requires and an optional `objectGuard`. A route that is not declared does not exist.
-- `database` (`process`) — whether it wants its own schema, and which core tables it needs
-  `REFERENCES` on.
+A `process` manifest additionally requires these seven keys — reference `fk-plugin-download`'s
+`plugin.json` for a manifest that satisfies all of them:
+
+- `runtime` — the only legal value is the literal `"node"`.
+- `memoryMb` — passed through as the child's own `--max-old-space-size`. Core does not clamp it.
+- `files` — sha256 of every archive entry but the manifest and its own signature.
+- `database` — `{ schema: boolean, coreRefs: string[] }`: whether it wants its own schema, and
+  which core tables it needs `REFERENCES` on.
+- `routes[]` — every route core will proxy, each with the CASL `policy` it requires and an
+  optional `objectGuard`. A route that is not declared does not exist. (Not `provides.routes[]` —
+  there is no `provides` key; `routes` sits at the manifest's top level.)
+- `scopes[]` — the grants this plugin needs, consented once at install and enforced on every host
+  call. Declare every scope the methods you call require, from this table:
+
+  | Scope | Host methods it unlocks |
+  |---|---|
+  | `media:read` | `media.acquisitionContext`, `media.resolve`, `media.exists`, and — because both answer with media identity for the whole library — `acquisition.candidates` and `releases.match` |
+  | `acquisition:candidates` | `acquisition.candidates`, `releases.match` |
+  | `releases:score` | `releases.score` |
+  | `requests:progress` | `requests.markInProgress` |
+  | `ingest:write` | `library.ingest` |
+  | `events:emit` | `events.publish`, `notifications.dispatch`, `events.emitOwn`, `counts.set`, `progress.set` |
+  | `config:rw` | `config.get`, `config.set` |
+
+  A method whose scopes you have not all declared rejects with `missing scope "<scope>" required
+  for "<method>"`. `HOST_METHOD_SCOPES` in the contract is the source this table restates.
+- `ingestRoots[]` — the allowlist `library.ingest` paths must fall under; may be empty.
+
+Optional beyond that:
+
 - `jobs[]` (`process`) — named cron entries core schedules and dispatches.
 - `events[]` — domain events to receive. A `data` plugin gets an HTTPS POST from core; a `process`
   plugin gets a note over its socket.
@@ -75,6 +102,41 @@ plugin repository, because a spawned plugin cannot import from core at runtime. 
 the copies honest: a CI job diffs the client mirror against the backend's, and each plugin repo
 runs a drift checker against a sibling checkout. Compare **declarations, not just names** — a
 field that matches by name and differs by type compiles and misbehaves.
+
+`fk-plugin-download` is the reference `process` plugin — a working implementation of everything
+in this section. Its `src/plugin.ts` answers all 7 core-initiated methods, `src/host-methods.ts`
+and `src/protocol.ts` are its own hand-kept mirrors of the contract, and
+`scripts/check-contract-drift.ts` is how it checks itself against a sibling core checkout.
+
+### Environment
+
+Core never passes `...process.env` to the child — everything a `process` plugin gets is one of
+these, set once at spawn (`supervisor/spawn-plan.ts`):
+
+- `FLIKS_PLUGIN_TOKEN` — random per spawn. Echo it back, unmodified, as `hello`'s `token`: it is
+  the only proof the responder is the process core just spawned, not something else connected to
+  the same socket. Get this wrong and the plugin is SIGKILLed with no message naming why.
+- `FLIKS_CORE_SOCK` — the unix socket to dial for this plugin's own host-API calls.
+- `FLIKS_PLUGIN_SOCK` — the unix socket to listen on for core's calls.
+- `FLIKS_DB_URL` — this plugin's own Postgres connection string; empty when its manifest declared
+  no schema.
+- `FLIKS_PLUGIN_ID` — this manifest's `id`, verbatim.
+- `FLIKS_API_VERSION` — the plugin API version, stringified. Checked for exact equality, never a
+  range.
+- `FLIKS_CFG_*` — every `plugin.<id>.<key>` admin setting, re-keyed: drop the `plugin.<id>.`
+  prefix, upper-case what's left, replace every character outside `[A-Z0-9_]` with `_`, and
+  prepend `FLIKS_CFG_`. Not a fixed set — read whichever names your own manifest's settings
+  resolve to.
+
+### The handshake
+
+The first call core makes on a freshly spawned child is `hello`, with `{ pluginApi, coreVersion,
+config }`. The reply must be `{ manifest, token }`: `manifest` is this archive's own
+`plugin.json`, read fresh rather than baked into the bundle, and `token` is `FLIKS_PLUGIN_TOKEN`
+echoed back exactly. A wrong or missing token is a crash: core logs `plugin crashed: hello token
+mismatch` against that plugin's own log stream and retries up the backoff ladder until the breaker
+trips. See `fk-plugin-download`'s `hello` handler in `src/plugin.ts` for a minimal implementation
+that gets both right.
 
 ## Database
 


### PR DESCRIPTION
Second batch out of the audit: the items a major release freezes. An adversarial pass reviewed each one and found seven defects in the first attempt — including a contract shape that would have been permanent. Those are the interesting part, so they are described here.

## A plugin written to the published contract could not start

`hello`'s published return type was `{ manifest }`. The supervisor requires `res.token === this.token` and treats a mismatch as a crash, and `grep token` across `plugin-contract/` returned **zero hits** — as did the six environment variables a child is spawned with. A third party implementing the contract exactly walks the backoff ladder until the breaker fails it. Nothing in the ecosystem caught this because the reference plugin happens to echo the token.

`token` is now a required field, and `PluginSpawnEnv` declares the environment — including `HOME`, which is the child's cwd and the only path its sandbox may write to, the most load-bearing fact for an author and previously written down nowhere.

**The review caught that my first pin was a tautology.** I typed the supervisor's call against the contract, which does not fail when the contract loosens: comparing `string | undefined` to `string` compiles fine. The echoed token is now assigned to a `string`, so making `token` optional stops compiling — verified by doing it. `buildSpawnPlan` builds its environment as `PluginSpawnEnv`, which I verified the same way by renaming a variable.

## Scopes were a decoration

`plugin_registrations.scopes` was validated at parse, written once, rendered to the operator on the consent sheet as a boundary — and read by nothing. `bind()` returned all fifteen host methods unconditionally, so a manifest declaring `['media:read']` reached `library.ingest`, `config.set` and `notifications.dispatch`. Enforcing this after v3 breaks every third-party plugin that under-declared, with no way to warn them.

**The review corrected the table itself, and this is the finding that mattered most.** I had typed it `Record<keyof PluginHostApi, PluginScope>` — one scope per method. But `releases.match` loads the entire monitored library and answers with `mediaId` per caller-supplied title, and `acquisition.candidates` returns media titles: both are identity oracles over the whole library, which is `media:read`'s to grant. A single-value shape cannot express "needs both", and a major would have frozen that. The table is a list per method, and those two carry `media:read` as well.

Verified live, both directions, on the running stack: with all seven scopes the reference plugin's release search answers 200 with 81 342 bytes of releases; with only `events:emit` persisted, the host call is refused with `ERR_DENIED: plugin "fliks.download" is missing scope "media:read" required for "media.acquisitionContext"`. Scopes restored afterwards, verified byte for byte.

## Errors had one code for everything

`Res.e` has always carried a code channel and core always wrote `'ERR'`, so a plugin could not distinguish an unknown method, a denial, a validation throw and a host-side deadline — `HostCallError.outcome` collapsed them all to `rejected`. Each class has a stable code now, preserved to `HostCallError.code`, with `outcome` keeping its own unknown-versus-rejected meaning.

## The guard that guarded one file

The drift gate diffed `host-methods.ts` only, and its matcher recognises quoted keys, so it could not have seen `PluginApi`'s members even if asked. It now compares the normalised bodies of `PluginApi` and `PluginSpawnEnv` as well — and **caught a real drift on its first run**, the four environment variables I had added to core and not to the mirror. Sabotaged by dropping `token` from the mirror, it exits 1 and names the drift.

I also removed a type-level pin the first attempt added, then had to re-derive a working one: the file it lived in was the only consumer of the type it asserted against, which made it a tautology, but my replacement was weaker than what I deleted. It took a third attempt to get a pin that actually fires.

## Docs

`docs/plugins.md` told an author to declare a manifest key that fails the install, listed none of the mandatory keys, promised that core clamps `memoryMb` at 1024 (nothing in the code does — the value is passed to `--max-old-space-size` verbatim, so the sentence is deleted rather than the clamp invented), claimed a token mismatch yields "no retry and no diagnostic" when core retries up the ladder and logs `plugin crashed: hello token mismatch`, and never named the reference plugin. All fixed, and the scope table is published — enforcement without a published mapping would just move the trap.

## Verification

- core `tsc` clean, **1396 tests** pass; plugin **290 tests** (288 pass, 2 pre-existing skips); drift gate exits 0 and covers four shapes across three files.
- Every new guard reverted in turn to confirm its test or its typecheck fails: the scope enforcement (16 specs fail without it), the token annotation, the spawn-env binding, and the drift gate.
- A stray default `jest.config.js` an agent scaffolded at the repo root is deleted; the real config lives in `backend/package.json`.

## Note

A scope denial reaches the browser as the plugin's generic internal-error key with the cause in `detail`. That is the plugin's own mapping, not core's, and it is worth tightening on the plugin side — not in this PR.
