### PR TITLE
feat(plugins): give the plugin API a deprecation window, and let a prerelease rehearse it

### DIFF
--- a/backend/src/common/plugin-contract/protocol.ts
+++ b/backend/src/common/plugin-contract/protocol.ts
@@ -1,3 +1,4 @@
+import * as semver from 'semver';
 /**
  * Wire protocol for the two unix sockets between core and a `process`
  * plugin: newline-delimited JSON, one object per line.
@@ -28,11 +29,27 @@ export type Note<P = unknown> = { m: string; p?: P };
 export const MAX_FRAME_BYTES = 4 * 1024 * 1024;
 
 /**
- * Checked for exact equality at catalog, install and `hello` — never a
- * range. Within one value the method set is additive-only; any removal
- * or semantic change bumps it.
+ * What core sends a plugin at `hello`. Within one value the method set is additive-only; any
+ * removal or semantic change bumps it.
  */
 export const PLUGIN_API_VERSION = 0;
+
+/**
+ * Every value core still accepts from a manifest, newest last. Retiring one is what orphans the
+ * plugins that declare it, so a bump adds an entry and a later release drops the oldest — the
+ * window in between is when authors republish.
+ */
+export const SUPPORTED_PLUGIN_API_VERSIONS: readonly number[] = [0];
+
+/**
+ * The version a `fliks` range is matched against: a prerelease resolves as its own release, since
+ * `3.0.0-rc.1` sorts *below* `3.0.0` and would otherwise satisfy no range that admits 3.0.0 —
+ * leaving a release candidate unable to run any plugin, and the upgrade impossible to rehearse.
+ */
+export function fliksRangeVersion(version: string): string {
+  const parsed = semver.parse(version);
+  return parsed ? `${parsed.major}.${parsed.minor}.${parsed.patch}` : version;
+}
 
 /**
  * Environment core sets on every spawn (see `supervisor/spawn-plan.ts`) — the only way in

--- a/backend/src/modules/plugins/api-compatibility.spec.ts
+++ b/backend/src/modules/plugins/api-compatibility.spec.ts
@@ -1,0 +1,45 @@
+import * as semver from 'semver';
+import { fliksRangeVersion, SUPPORTED_PLUGIN_API_VERSIONS, PLUGIN_API_VERSION } from '../../common/plugin-contract';
+import { filterCatalog } from './catalog/catalog';
+import type { CatalogDocument } from './catalog/catalog';
+
+function catalogWith(pluginApi: number, fliks: string): CatalogDocument {
+  return {
+    plugins: [
+      {
+        id: 'acme.one',
+        name: 'One',
+        description: 'd',
+        author: 'a',
+        kind: 'data',
+        versions: [{ version: '1.0.0', pluginApi, fliks, zipUrl: 'https://example.invalid/a.fkplugin', sha256: 'a'.repeat(64) }],
+      },
+    ],
+  };
+}
+
+describe('plugin API compatibility', () => {
+  it('accepts every version in the supported set, not just the newest', () => {
+    expect(SUPPORTED_PLUGIN_API_VERSIONS).toContain(PLUGIN_API_VERSION);
+    for (const api of SUPPORTED_PLUGIN_API_VERSIONS) {
+      expect(filterCatalog(catalogWith(api, '>=2.0.0 <3.0.0'), SUPPORTED_PLUGIN_API_VERSIONS, '2.0.1').plugins[0]!.installable).toHaveLength(1);
+    }
+  });
+
+  it('hides a version whose pluginApi the set does not carry', () => {
+    const unsupported = Math.max(...SUPPORTED_PLUGIN_API_VERSIONS) + 1;
+    const result = filterCatalog(catalogWith(unsupported, '>=2.0.0 <3.0.0'), SUPPORTED_PLUGIN_API_VERSIONS, '2.0.1');
+    expect(result.plugins[0]!.installable).toHaveLength(0);
+  });
+
+  it('VERDICT: a release candidate resolves as its own release would, so the upgrade can be rehearsed', () => {
+    expect(semver.satisfies(fliksRangeVersion('3.0.0-rc.1'), '>=3.0.0 <4.0.0')).toBe(true);
+    const result = filterCatalog(catalogWith(PLUGIN_API_VERSION, '>=3.0.0 <4.0.0'), SUPPORTED_PLUGIN_API_VERSIONS, '3.0.0-rc.1');
+    expect(result.plugins[0]!.installable).toHaveLength(1);
+  });
+
+  it('still refuses a range that genuinely excludes the running version', () => {
+    const result = filterCatalog(catalogWith(PLUGIN_API_VERSION, '>=4.0.0 <5.0.0'), SUPPORTED_PLUGIN_API_VERSIONS, '3.0.0-rc.1');
+    expect(result.plugins[0]!.installable).toHaveLength(0);
+  });
+});

--- a/backend/src/modules/plugins/catalog/catalog.spec.ts
+++ b/backend/src/modules/plugins/catalog/catalog.spec.ts
@@ -1,5 +1,5 @@
 import { parseCatalogDocument, filterCatalog, type CatalogDocument, type CatalogVersionEntry } from './catalog';
-import { PLUGIN_API_VERSION } from '../../../common/plugin-contract';
+import { PLUGIN_API_VERSION, SUPPORTED_PLUGIN_API_VERSIONS } from '../../../common/plugin-contract';
 
 /** A `fliks` range every test can rely on matching this repo's own `package.json` version
  *  (same convention as `plugin-registry.service.spec.ts`'s `COMPATIBLE_RANGE`). */
@@ -62,7 +62,7 @@ describe('parseCatalogDocument()', () => {
 describe('filterCatalog()', () => {
   it('lists a version whose pluginApi matches and whose fliks range is satisfied', () => {
     const doc = document({ versions: [version()] });
-    const result = filterCatalog(doc, PLUGIN_API_VERSION, '2.0.1');
+    const result = filterCatalog(doc, SUPPORTED_PLUGIN_API_VERSIONS, '2.0.1');
     expect(result.plugins[0].installable).toEqual([version()]);
     expect(result.plugins[0].hidden).toBeNull();
   });
@@ -70,7 +70,7 @@ describe('filterCatalog()', () => {
   it('hides a version whose pluginApi does not match exactly, and counts it', () => {
     const mismatched = version({ pluginApi: PLUGIN_API_VERSION + 1, fliks: COMPATIBLE_RANGE });
     const doc = document({ versions: [mismatched] });
-    const result = filterCatalog(doc, PLUGIN_API_VERSION, '2.0.1');
+    const result = filterCatalog(doc, SUPPORTED_PLUGIN_API_VERSIONS, '2.0.1');
     expect(result.plugins[0].installable).toEqual([]);
     // No version number reveals it: the mismatch is the plugin API, not the range.
     expect(result.plugins[0].hidden).toEqual({ count: 1, minFliksVersion: null });
@@ -79,7 +79,7 @@ describe('filterCatalog()', () => {
   it('hides a version whose fliks range excludes the running core version, and counts it', () => {
     const tooNew = version({ fliks: '>=5.0.0 <6.0.0' });
     const doc = document({ versions: [tooNew] });
-    const result = filterCatalog(doc, PLUGIN_API_VERSION, '2.0.1');
+    const result = filterCatalog(doc, SUPPORTED_PLUGIN_API_VERSIONS, '2.0.1');
     expect(result.plugins[0].installable).toEqual([]);
     expect(result.plugins[0].hidden).toEqual({ count: 1, minFliksVersion: '5.0.0' });
   });
@@ -88,7 +88,7 @@ describe('filterCatalog()', () => {
     const needsFive = version({ version: '2.0.0', fliks: '>=5.0.0 <6.0.0' });
     const needsFour = version({ version: '3.0.0', fliks: '>=4.0.0 <5.0.0' });
     const doc = document({ versions: [needsFive, needsFour] });
-    const result = filterCatalog(doc, PLUGIN_API_VERSION, '2.0.1');
+    const result = filterCatalog(doc, SUPPORTED_PLUGIN_API_VERSIONS, '2.0.1');
     expect(result.plugins[0].hidden).toEqual({ count: 2, minFliksVersion: '4.0.0' });
   });
 
@@ -96,13 +96,13 @@ describe('filterCatalog()', () => {
     // The range's upper bound is already behind us: upgrading moves further away.
     const tooOld = version({ fliks: '>=1.0.0 <2.0.0' });
     const doc = document({ versions: [tooOld] });
-    const result = filterCatalog(doc, PLUGIN_API_VERSION, '2.0.1');
+    const result = filterCatalog(doc, SUPPORTED_PLUGIN_API_VERSIONS, '2.0.1');
     expect(result.plugins[0].hidden).toEqual({ count: 1, minFliksVersion: null });
   });
 
   it('keeps a plugin in the result with an empty installable list when every version is hidden', () => {
     const doc = document({ versions: [version({ fliks: '>=5.0.0 <6.0.0' })] });
-    const result = filterCatalog(doc, PLUGIN_API_VERSION, '2.0.1');
+    const result = filterCatalog(doc, SUPPORTED_PLUGIN_API_VERSIONS, '2.0.1');
     expect(result.plugins).toHaveLength(1);
     expect(result.plugins[0].id).toBe('fliks.test-plugin');
     expect(result.plugins[0].installable).toEqual([]);
@@ -113,16 +113,16 @@ describe('filterCatalog()', () => {
     const ok = version({ version: '1.0.0' });
     const tooNew = version({ version: '2.0.0', fliks: '>=5.0.0 <6.0.0' });
     const doc = document({ versions: [ok, tooNew] });
-    const result = filterCatalog(doc, PLUGIN_API_VERSION, '2.0.1');
+    const result = filterCatalog(doc, SUPPORTED_PLUGIN_API_VERSIONS, '2.0.1');
     expect(result.plugins[0].installable).toEqual([ok]);
     expect(result.plugins[0].hidden).toEqual({ count: 1, minFliksVersion: '5.0.0' });
   });
 
   it('carries an optional logo URL through unchanged, and omits it when absent', () => {
-    const withLogo = filterCatalog(document({ logo: 'https://example.com/logo.png' }), PLUGIN_API_VERSION, '2.0.1');
+    const withLogo = filterCatalog(document({ logo: 'https://example.com/logo.png' }), SUPPORTED_PLUGIN_API_VERSIONS, '2.0.1');
     expect(withLogo.plugins[0].logo).toBe('https://example.com/logo.png');
 
-    const withoutLogo = filterCatalog(document(), PLUGIN_API_VERSION, '2.0.1');
+    const withoutLogo = filterCatalog(document(), SUPPORTED_PLUGIN_API_VERSIONS, '2.0.1');
     expect(withoutLogo.plugins[0].logo).toBeUndefined();
   });
 });

--- a/backend/src/modules/plugins/catalog/catalog.ts
+++ b/backend/src/modules/plugins/catalog/catalog.ts
@@ -1,4 +1,5 @@
 import * as semver from 'semver';
+import { fliksRangeVersion } from '../../../common/plugin-contract';
 import type { PluginKind } from '../../../common/plugin-contract';
 
 /**
@@ -108,8 +109,8 @@ export interface FilteredCatalog {
   plugins: FilteredCatalogEntry[];
 }
 
-function isInstallable(v: CatalogVersionEntry, pluginApiVersion: number, fliksVersion: string): boolean {
-  return v.pluginApi === pluginApiVersion && semver.satisfies(fliksVersion, v.fliks);
+function isInstallable(v: CatalogVersionEntry, supportedApiVersions: readonly number[], fliksVersion: string): boolean {
+  return supportedApiVersions.includes(v.pluginApi) && semver.satisfies(fliksRangeVersion(fliksVersion), v.fliks);
 }
 
 function summarizeHidden(
@@ -118,7 +119,7 @@ function summarizeHidden(
 ): HiddenVersionsSummary | null {
   if (hidden.length === 0) return null;
   const reachable = hidden
-    .filter((v) => !semver.satisfies(fliksVersion, v.fliks))
+    .filter((v) => !semver.satisfies(fliksRangeVersion(fliksVersion), v.fliks))
     .map((v) => semver.minVersion(v.fliks))
     .filter((v): v is semver.SemVer => v !== null && semver.gt(v, fliksVersion));
   const lowest = reachable.length
@@ -128,17 +129,20 @@ function summarizeHidden(
 }
 
 /**
- * `pluginApi` exact equality and `semver.satisfies` against the running core version
- * — the same two checks `PluginRegistryService.register` runs at load, applied here
- * one layer earlier so the admin never sees a version they cannot install.
+ * The same two checks `PluginRegistryService.register` runs at load, applied one layer earlier
+ * so an admin never sees a version they cannot install.
  */
-export function filterCatalog(document: CatalogDocument, pluginApiVersion: number, fliksVersion: string): FilteredCatalog {
+export function filterCatalog(
+  document: CatalogDocument,
+  supportedApiVersions: readonly number[],
+  fliksVersion: string,
+): FilteredCatalog {
   return {
     plugins: document.plugins.map((entry) => {
       const installable: CatalogVersionEntry[] = [];
       const hidden: CatalogVersionEntry[] = [];
       for (const version of entry.versions) {
-        (isInstallable(version, pluginApiVersion, fliksVersion) ? installable : hidden).push(version);
+        (isInstallable(version, supportedApiVersions, fliksVersion) ? installable : hidden).push(version);
       }
       return {
         id: entry.id,

--- a/backend/src/modules/plugins/plugin-catalog-client.service.ts
+++ b/backend/src/modules/plugins/plugin-catalog-client.service.ts
@@ -5,7 +5,7 @@ import { Repository } from 'typeorm';
 import axios from 'axios';
 import { PluginSource } from './entities/plugin-source.entity';
 import { OFFICIAL_KEYS, resolveTrust, MAX_SIGNATURE_BYTES } from './archive';
-import { PLUGIN_API_VERSION } from '../../common/plugin-contract';
+import { SUPPORTED_PLUGIN_API_VERSIONS } from '../../common/plugin-contract';
 import { CURRENT_FLIKS_VERSION } from './plugin-registry.service';
 import { parseCatalogDocument, filterCatalog, type FilteredCatalog } from './catalog/catalog';
 
@@ -88,7 +88,7 @@ export class PluginCatalogClientService {
       return this.fail(source, 'malformed-catalog', 'catalog signature verified but the document did not parse');
     }
 
-    const filtered: FilteredCatalog = filterCatalog(document, PLUGIN_API_VERSION, CURRENT_FLIKS_VERSION);
+    const filtered: FilteredCatalog = filterCatalog(document, SUPPORTED_PLUGIN_API_VERSIONS, CURRENT_FLIKS_VERSION);
     source.cachedCatalog = filtered as unknown as Record<string, unknown>;
     source.lastRefreshedAt = new Date();
     source.lastRefreshError = null;

--- a/backend/src/modules/plugins/plugin-install.service.ts
+++ b/backend/src/modules/plugins/plugin-install.service.ts
@@ -28,7 +28,7 @@ import {
 import { validateManifestShape } from './manifest-shape.validator';
 import type { TrustOutcome } from './archive/trust-store';
 import type { CatalogVersionEntry, FilteredCatalog, FilteredCatalogEntry } from './catalog/catalog';
-import { PLUGIN_API_VERSION, type PluginKind, type PluginManifest } from '../../common/plugin-contract';
+import { SUPPORTED_PLUGIN_API_VERSIONS, fliksRangeVersion, type PluginKind, type PluginManifest } from '../../common/plugin-contract';
 import type { ConfirmImportDto } from './dto/confirm-import.dto';
 import type { SupervisorState } from './supervisor/plugin-supervisor';
 
@@ -90,7 +90,10 @@ function fsyncPath(path: string): void {
 
 /** Same two checks `PluginRegistryService.register()` runs at L4 — reported here as information only, never a staging gate. */
 function isCompatible(manifest: PluginManifest): boolean {
-  return manifest.pluginApi === PLUGIN_API_VERSION && semver.satisfies(CURRENT_FLIKS_VERSION, manifest.fliks);
+  return (
+    SUPPORTED_PLUGIN_API_VERSIONS.includes(manifest.pluginApi) &&
+    semver.satisfies(fliksRangeVersion(CURRENT_FLIKS_VERSION), manifest.fliks)
+  );
 }
 
 /** `zipUrl`/`sha256` are install-pipeline-owned fields on a catalog version entry — see `catalog/catalog.ts`'s doc comment. */

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -16,7 +16,8 @@ import { sweepOrphans } from './supervisor/pid-file';
 import { getPluginsSocketDir } from '../../common/constants/paths';
 import { arePluginsDisabled, FLIKS_PLUGINS_DISABLED_ENV } from '../../common/constants/plugin-flags';
 import {
-  PLUGIN_API_VERSION,
+  SUPPORTED_PLUGIN_API_VERSIONS,
+  fliksRangeVersion,
   PLUGIN_WEBHOOK_EVENT_NAMES,
   WEBHOOK_SETTING_PREFIX,
   type PluginKind,
@@ -234,14 +235,14 @@ export class PluginRegistryService implements OnModuleInit {
 
     // L3 (re-hash plugin.js from the loaded fd) happens inside `PluginProcessService.startFor`, below.
     // L4
-    if (manifest.pluginApi !== PLUGIN_API_VERSION) {
+    if (!SUPPORTED_PLUGIN_API_VERSIONS.includes(manifest.pluginApi)) {
       return this.fail(
         pkg.pluginId,
         'incompatible-api',
-        `manifest declares pluginApi ${manifest.pluginApi}, running ${PLUGIN_API_VERSION}`,
+        `manifest declares pluginApi ${manifest.pluginApi}, this core accepts ${SUPPORTED_PLUGIN_API_VERSIONS.join(', ')}`,
       );
     }
-    if (!semver.satisfies(CURRENT_FLIKS_VERSION, manifest.fliks)) {
+    if (!semver.satisfies(fliksRangeVersion(CURRENT_FLIKS_VERSION), manifest.fliks)) {
       return this.fail(
         pkg.pluginId,
         'incompatible-fliks',

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -29,6 +29,12 @@ A `process` manifest additionally requires these seven keys — reference `fk-pl
 
 - `runtime` — the only legal value is the literal `"node"`.
 - `memoryMb` — passed through as the child's own `--max-old-space-size`. Core does not clamp it.
+- `pluginApi` — the contract revision this plugin is written against. Core accepts every value in
+  its own `SUPPORTED_PLUGIN_API_VERSIONS`, so a bump does not orphan your plugin the day it lands:
+  the older value keeps working until a later release drops it, and that window is when to republish.
+- `fliks` — the core versions this plugin runs on, as a semver range with a mandatory upper bound
+  (`>=3.0.0 <4.0.0`). A prerelease core matches as its own release would, so a `3.0.0-rc` runs the
+  plugins that declare `>=3.0.0` — which is how a major upgrade gets rehearsed before it ships.
 - `files` — sha256 of every archive entry but the manifest and its own signature.
 - `database` — `{ schema: boolean, coreRefs: string[] }`: whether it wants its own schema, and
   which core tables it needs `REFERENCES` on.


### PR DESCRIPTION
Fourth batch out of the audit: the release train.

## `pluginApi` was a cliff

Exact equality at three gates — the catalogue filter, the install report and `register()` — meant the day core bumped `pluginApi`, every published plugin would stop installing simultaneously **and** disappear from the catalogue, with no deprecation window and no additive path.

Core accepts every value in `SUPPORTED_PLUGIN_API_VERSIONS` now. A bump adds an entry; a later release drops the oldest; the window between is when authors republish. The set holds one value today, so nothing changes for a plugin in the field.

**The number itself is still `0`, deliberately — that is your call to make at release time**, and it is now a one-entry edit rather than a breaking change. Worth deciding, though: `0` reads as "this contract is not stable" on the day it is frozen for third parties.

## A release candidate could not run any plugin

I got this wrong on the first attempt and the test caught me: I reached for `includePrerelease: true`, which decides whether prereleases are *considered*, not how they *order*. `3.0.0-rc.1` sorts **below** `3.0.0`, so it satisfies no range admitting 3.0.0 no matter what options you pass — measured, not assumed.

A `fliks` range is now matched against the running version with its prerelease stripped, so a `3.0.0-rc` resolves as `3.0.0` would. Without this, the obvious way to rehearse the v3 migration — cut a release candidate and watch the plugins load — reports a false failure for correctly republished plugins.

## Verification

- `tsc` clean, **1443 tests** pass.
- Four new specs pin the window and the rehearsal, including that a genuinely-excluding range (`>=4.0.0` against a 3.0.0-rc) still refuses. Both halves reverted in turn to confirm they fail.

## Still to do for v3 day, not in this PR

- Republish both plugins as `>=3.0.0 <4.0.0` with the `COMPATIBILITY.md` row — that is release-day work, and the plugin repo's own version gate now fails closed instead of passing on a hardcoded `2.0.1`, so a tag cannot publish a v3-incompatible archive by accident.
- Decide the `pluginApi` number.