### PR TITLE
fix(plugins): isolate the plugin sockets, and report an unsafe core foreign key

### DIFF
--- a/backend/src/modules/plugins/plugin-database.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-database.service.spec.ts
@@ -14,6 +14,8 @@ interface Fixtures {
   schemaOwner?: string;
   /** Names the fake probe resolves to a `public` `BASE TABLE` carrying an `id` column. */
   baseTables?: readonly string[];
+  /** Rows the fake catalog returns for `findUnsafeCoreRefFks`, in Postgres's own column shape. */
+  unsafeFkRows?: { constraint_name: string; table_name: string; referenced_table: string }[];
 }
 
 function makeRecorder(): Recorder {
@@ -73,7 +75,15 @@ function fakeQueryRunner(
 
 function fakeDataSource(recorder: Recorder, fixtures: Fixtures = {}, failCommit = false) {
   const respond = respondFor(fixtures);
-  return { createQueryRunner: jest.fn(() => fakeQueryRunner(recorder, respond, failCommit)) };
+  return {
+    createQueryRunner: jest.fn(() => fakeQueryRunner(recorder, respond, failCommit)),
+    // findUnsafeCoreRefFks queries the DataSource directly, not through a queryRunner.
+    query: jest.fn(async (sql: string, parameters: unknown[] = []) => {
+      recorder.events.push('query');
+      recorder.queries.push({ sql, parameters });
+      return fixtures.unsafeFkRows ?? [];
+    }),
+  };
 }
 
 function fakeConfig(overrides: Record<string, unknown> = {}) {
@@ -364,5 +374,38 @@ describe('PluginDatabaseService.deprovision', () => {
       'DROP SCHEMA IF EXISTS "plugin_acme_tool" CASCADE',
       'DROP ROLE IF EXISTS "plugin_acme_tool"',
     ]);
+  });
+});
+
+describe('PluginDatabaseService.findUnsafeCoreRefFks', () => {
+  it('scopes the catalog query to this plugin schema, binds it as a parameter, and excludes only CASCADE/SET NULL', async () => {
+    const recorder = makeRecorder();
+    await service(fakeDataSource(recorder)).findUnsafeCoreRefFks('acme.tool');
+
+    expect(recorder.queries).toHaveLength(1);
+    const sql = normalizeSql(recorder.queries[0].sql);
+    expect(sql).toContain('ns.nspname = $1');
+    expect(sql).toContain("con.confdeltype NOT IN ('c', 'n')");
+    expect(recorder.queries[0].parameters).toEqual(['plugin_acme_tool']);
+  });
+
+  it('maps every row the catalog returns onto the caller-facing shape', async () => {
+    const dataSource = fakeDataSource(makeRecorder(), {
+      unsafeFkRows: [
+        { constraint_name: 'zz_probe_media_id_fkey', table_name: 'zz_probe', referenced_table: 'media' },
+        { constraint_name: 'zz_setdefault_media_id_fkey', table_name: 'zz_setdefault', referenced_table: 'media' },
+      ],
+    });
+
+    const result = await service(dataSource).findUnsafeCoreRefFks('acme.tool');
+
+    expect(result).toEqual([
+      { constraint: 'zz_probe_media_id_fkey', table: 'zz_probe', referencedTable: 'media' },
+      { constraint: 'zz_setdefault_media_id_fkey', table: 'zz_setdefault', referencedTable: 'media' },
+    ]);
+  });
+
+  it('returns empty when the catalog has nothing to report', async () => {
+    await expect(service(fakeDataSource(makeRecorder())).findUnsafeCoreRefFks('acme.tool')).resolves.toEqual([]);
   });
 });

--- a/backend/src/modules/plugins/plugin-database.service.ts
+++ b/backend/src/modules/plugins/plugin-database.service.ts
@@ -42,6 +42,13 @@ function randomHexPassword(): string {
   return password;
 }
 
+/** A foreign key from this plugin's own schema into `public` that would block core deletes. */
+export interface UnsafeCoreRefFk {
+  constraint: string;
+  table: string;
+  referencedTable: string;
+}
+
 function asProvisionFailure(err: unknown): PluginInstallException {
   if (err instanceof PluginInstallException) return err;
   const detail = err instanceof Error ? err.message : String(err);
@@ -127,6 +134,28 @@ export class PluginDatabaseService {
     } finally {
       await queryRunner.release();
     }
+  }
+
+  /** Only `CASCADE`/`SET NULL` (`confdeltype` 'c'/'n') let a core `DELETE` proceed unattended. */
+  async findUnsafeCoreRefFks(pluginId: string): Promise<UnsafeCoreRefFk[]> {
+    const identifier = pluginDbIdentifier(pluginId);
+    const rows = await this.dataSource.query(
+      `SELECT con.conname AS constraint_name, cl.relname AS table_name, fcl.relname AS referenced_table
+         FROM pg_constraint con
+         JOIN pg_class cl ON cl.oid = con.conrelid
+         JOIN pg_namespace ns ON ns.oid = cl.relnamespace
+         JOIN pg_class fcl ON fcl.oid = con.confrelid
+         JOIN pg_namespace fns ON fns.oid = fcl.relnamespace
+        WHERE con.contype = 'f' AND ns.nspname = $1 AND fns.nspname = 'public'
+          AND con.confdeltype NOT IN ('c', 'n')
+        ORDER BY con.conname`,
+      [identifier],
+    );
+    return (rows as { constraint_name: string; table_name: string; referenced_table: string }[]).map((row) => ({
+      constraint: row.constraint_name,
+      table: row.table_name,
+      referencedTable: row.referenced_table,
+    }));
   }
 
   /** P4b — a fresh password per spawn, never persisted. Returns the DSN, or null when this plugin has no provisioned role. */

--- a/backend/src/modules/plugins/plugin-process.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-process.service.spec.ts
@@ -10,6 +10,7 @@ import { minimalProcessManifest } from './archive/test-manifests';
 import type { PluginPackage } from './entities/plugin-package.entity';
 import type { PluginSupervisor, PluginSupervisorOptions, SupervisorState } from './supervisor/plugin-supervisor';
 import type { PluginHostBindingService } from './host/plugin-host-binding.service';
+import type { UnsafeCoreRefFk } from './plugin-database.service';
 
 /**
  * Waits until the factory has built `count` supervisors, so a fake's state can be flipped
@@ -82,6 +83,7 @@ function fakePluginDb(order: string[] = []) {
     provision: jest.fn(async () => {
       order.push('provision');
     }),
+    findUnsafeCoreRefFks: jest.fn(async (): Promise<UnsafeCoreRefFk[]> => []),
     rotatePassword: jest.fn(async () => {
       order.push('rotate');
       return 'postgresql://fake-dsn' as string | null;
@@ -253,6 +255,32 @@ describe('PluginProcessService.startFor', () => {
 
     expect(result).toEqual({ ok: false, reason: 'db-provision-failed', detail: 'db unreachable' });
     expect(instances).toHaveLength(0);
+  });
+
+  it('an unsafe core-ref foreign key warns for every offending constraint but still starts the plugin', async () => {
+    const pkg = fakePackage();
+
+    const pluginDb = fakePluginDb();
+    pluginDb.findUnsafeCoreRefFks.mockResolvedValue([
+      { constraint: 'zz_probe_mediaId_fkey', table: 'zz_probe', referencedTable: 'media' },
+      { constraint: 'zz_second_fkey', table: 'zz_second', referencedTable: 'episodes' },
+    ]);
+    const logBuffer = fakeLogBuffer();
+    const { factory, instances } = makeFactory();
+    const service = new PluginProcessService(pluginDb as never, logBuffer as never, fakeSettings() as never, factory);
+
+    const startPromise = service.startFor(pkg);
+    await waitForSupervisors(instances);
+    instances[0].setState('ready');
+    const result = await startPromise;
+
+    expect(result).toEqual({ ok: true });
+    expect(instances).toHaveLength(1);
+    expect(pluginDb.rotatePassword).toHaveBeenCalled();
+    expect(logBuffer.warn).toHaveBeenCalledWith(expect.stringContaining('zz_probe_mediaId_fkey'), `plugin:${pkg.pluginId}`);
+    expect(logBuffer.warn).toHaveBeenCalledWith(expect.stringContaining('zz_second_fkey'), `plugin:${pkg.pluginId}`);
+    expect(service.statusMessageOf(pkg.pluginId)).toContain('zz_probe_mediaId_fkey');
+    expect(service.statusMessageOf(pkg.pluginId)).toContain('zz_second_fkey');
   });
 
   it('a rotatePassword failure also returns "db-provision-failed" and spawns nothing', async () => {

--- a/backend/src/modules/plugins/plugin-process.service.ts
+++ b/backend/src/modules/plugins/plugin-process.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Optional, type OnApplicationShutdown } from '@nestjs/common
 import type { PluginPackage } from './entities/plugin-package.entity';
 import { installedPluginDir, promoteDir } from './plugin-paths';
 import { extractToStaging } from './archive';
-import { PluginDatabaseService } from './plugin-database.service';
+import { PluginDatabaseService, type UnsafeCoreRefFk } from './plugin-database.service';
 import {
   DEFAULT_SUPERVISOR_OPTIONS,
   PluginSupervisor,
@@ -22,9 +22,20 @@ interface RunningPlugin {
   supervisor: PluginSupervisor;
   pkg: PluginPackage;
   unsubscribe: () => void;
+  /** Non-fatal: this plugin's schema holds a core FK that blocks deleting the referenced rows. */
+  unsafeFkWarning: string;
 }
 
 const DEFAULT_FACTORY: PluginSupervisorFactory = (options) => new PluginSupervisor(options);
+
+/** One sentence: constraint, both tables and the remedy — the operator needs all four to act. */
+function unsafeCoreRefWarning(fk: UnsafeCoreRefFk): string {
+  return (
+    `constraint "${fk.constraint}" on "${fk.table}" references public."${fk.referencedTable}" ` +
+    `without ON DELETE CASCADE or SET NULL, which will block core deletion of that table's rows. ` +
+    `Declare ON DELETE CASCADE or SET NULL on it, or uninstall this plugin to drop its schema.`
+  );
+}
 
 /** States where the stderr tail is the diagnosis rather than routine output. */
 const DOWN_STATES: ReadonlySet<SupervisorState> = new Set(['crashed', 'backoff', 'failed', 'degraded']);
@@ -96,12 +107,36 @@ export class PluginProcessService implements OnApplicationShutdown {
     );
     // Registered before the handshake settles: a plugin stuck retrying its own backoff
     // ladder must stay observable and restartable, not vanish because it isn't ready yet.
-    this.running.set(pkg.pluginId, { supervisor, pkg, unsubscribe });
+    this.running.set(pkg.pluginId, { supervisor, pkg, unsubscribe, unsafeFkWarning: '' });
 
     await supervisor.start();
     const outcome = await this.waitForReadyOrGiveUp(supervisor);
+
+    // Probed only now: the plugin's own migrations run once it is up, so an earlier look
+    // cannot see a constraint this run just created.
+    const entry = this.running.get(pkg.pluginId);
+    if (entry) entry.unsafeFkWarning = await this.probeUnsafeCoreRefFks(pkg.pluginId);
+
     if (!outcome.ok) return { ok: false, reason: 'spawn-failed', detail: outcome.detail };
     return { ok: true };
+  }
+
+  /** Advisory only: a plugin -> public FK that blocks core deletes never gates the spawn. */
+  private async probeUnsafeCoreRefFks(pluginId: string): Promise<string> {
+    let unsafeFks: UnsafeCoreRefFk[];
+    try {
+      unsafeFks = await this.pluginDb.findUnsafeCoreRefFks(pluginId);
+    } catch (err) {
+      this.logBuffer.warn(`could not check core foreign keys: ${(err as Error).message}`, `plugin:${pluginId}`);
+      return '';
+    }
+    for (const fk of unsafeFks) this.logBuffer.warn(unsafeCoreRefWarning(fk), `plugin:${pluginId}`);
+    if (unsafeFks.length === 0) return '';
+    const names = unsafeFks.map((fk) => `"${fk.constraint}"`).join(', ');
+    return (
+      `${unsafeFks.length} foreign key(s) block core deletion (${names}) — ` +
+      `declare ON DELETE CASCADE or SET NULL on them.`
+    );
   }
 
   /** Idempotent — a no-op for a plugin that was never started, or already stopped. */
@@ -118,12 +153,13 @@ export class PluginProcessService implements OnApplicationShutdown {
   }
 
   statusMessageOf(pluginId: string): string {
-    const supervisor = this.running.get(pluginId)?.supervisor;
-    if (!supervisor) return '';
-    const breakerMessage = supervisor.getStatusMessage();
+    const entry = this.running.get(pluginId);
+    if (!entry) return '';
+    const breakerMessage = entry.supervisor.getStatusMessage();
     if (breakerMessage) return breakerMessage;
-    // The stderr tail explains a failure; a healthy plugin's own warnings are not its status.
-    return DOWN_STATES.has(supervisor.getState()) ? supervisor.getStderrTail() : '';
+    // A crash reason is more actionable than the standing FK warning — show it first when down.
+    if (DOWN_STATES.has(entry.supervisor.getState())) return entry.supervisor.getStderrTail();
+    return entry.unsafeFkWarning;
   }
 
   /** Passthrough so the HTTP proxy never touches a supervisor directly. */

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.spec.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.spec.ts
@@ -1,6 +1,6 @@
 import { existsSync, rmSync, writeFileSync } from 'fs';
 import { connect } from 'net';
-import { join } from 'path';
+import { basename, dirname, join } from 'path';
 import { DEFAULT_SUPERVISOR_OPTIONS, PluginSupervisor, type PluginSupervisorOptions } from './plugin-supervisor';
 import { RpcChannel } from './rpc-channel';
 import { pidFilePath } from './pid-file';
@@ -375,6 +375,64 @@ describe('shutdown', () => {
     expect(sup.getLastExitSignal()).toBe('SIGKILL');
     expect(existsSync(coreSockPath)).toBe(false);
     expect(existsSync(pluginSockPath)).toBe(false);
+  }, 10_000);
+});
+
+describe('socket path isolation', () => {
+  it('two supervisors built with the same id in the same runtime dir get different socket paths', () => {
+    const runtimeDir = makeRuntimeDir();
+    const dir = makeFixtureDir('good');
+    dirsToClean.push(dir, runtimeDir);
+    const opts: PluginSupervisorOptions = { id: 'dup-id', dir, runtimeDir, logBuffer: newLogBuffer() };
+    const a = new PluginSupervisor(opts);
+    const b = new PluginSupervisor(opts);
+    supervisorsToStop.push(a, b);
+
+    const pa = a.getSocketPaths();
+    const pb = b.getSocketPaths();
+    expect(pa.coreSockPath).not.toBe(pb.coreSockPath);
+    expect(pa.pluginSockPath).not.toBe(pb.pluginSockPath);
+  });
+
+  it('clears its own sockets from an earlier run, and leaves another plugin id alone', async () => {
+    const sup = makeSupervisor('good');
+    const { coreSockPath } = sup.getSocketPaths();
+    const runtimeDir = dirname(coreSockPath);
+    const id = basename(coreSockPath).split('.')[0];
+    const mine = join(runtimeDir, `${id}.0123456789abcdef.core.sock`);
+    const other = join(runtimeDir, `other-plugin.0123456789abcdef.core.sock`);
+    writeFileSync(mine, '');
+    writeFileSync(other, '');
+
+    await sup.start();
+    await waitForState(sup, 'ready');
+
+    expect(existsSync(mine)).toBe(false);
+    expect(existsSync(other)).toBe(true);
+  }, 10_000);
+});
+
+describe('runtime dir hardening', () => {
+  it('a chmod failure on the runtime dir warns and still reaches ready, never fails the plugin', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment
+    const fs: typeof import('fs') = require('fs');
+    const spy = jest.spyOn(fs, 'chmodSync').mockImplementationOnce(() => {
+      throw new Error('EPERM: operation not permitted');
+    });
+    const logBuffer = newLogBuffer();
+    const warn = jest.spyOn(logBuffer, 'warn');
+    try {
+      const sup = makeSupervisor('good', { logBuffer });
+      await sup.start();
+      await waitForState(sup, 'ready');
+      expect(sup.getState()).toBe('ready');
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('could not harden runtime dir permissions'),
+        expect.stringContaining('plugin:'),
+      );
+    } finally {
+      spy.mockRestore();
+    }
   }, 10_000);
 });
 

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
@@ -1,7 +1,7 @@
 import { spawn, type ChildProcess } from 'child_process';
 import { createServer, type Server, type Socket } from 'net';
 import { randomBytes } from 'crypto';
-import { chmodSync, chownSync, mkdirSync, unlinkSync } from 'fs';
+import { chmodSync, chownSync, mkdirSync, readdirSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { getPluginsSocketDir } from '../../../common/constants/paths';
 import type { OnApplicationShutdown } from '@nestjs/common';
@@ -109,6 +109,11 @@ function withDeadline<T>(promise: Promise<T>, ms: number, label: string): Promis
   });
 }
 
+/** A plugin id is dotted, and a dot is a regex metacharacter. */
+function escapeForRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /** 0600 keeps a second plugin out; the chown is what lets the dropped child in at all. */
 function listenAndRestrict(server: Server, path: string, dropTo: { uid: number; gid: number } | null): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -175,8 +180,10 @@ export class PluginSupervisor implements OnApplicationShutdown {
       hostApi: null,
       ...options,
     };
-    this.coreSockPath = join(this.opts.runtimeDir, `${this.opts.id}.core.sock`);
-    this.pluginSockPath = join(this.opts.runtimeDir, `${this.opts.id}.plugin.sock`);
+    // Random suffix: another plugin (same uid, same runtime dir) can't derive this path from the id alone.
+    const rand = randomBytes(8).toString('hex');
+    this.coreSockPath = join(this.opts.runtimeDir, `${this.opts.id}.${rand}.core.sock`);
+    this.pluginSockPath = join(this.opts.runtimeDir, `${this.opts.id}.${rand}.plugin.sock`);
   }
 
   getState(): SupervisorState {
@@ -324,9 +331,24 @@ export class PluginSupervisor implements OnApplicationShutdown {
 
   private async setupSockets(): Promise<void> {
     mkdirSync(this.opts.runtimeDir, { recursive: true });
-    for (const p of [this.coreSockPath, this.pluginSockPath]) {
+    const dropTo = this.dropTarget();
+    try {
+      // 0710: owner lists it, a dropped child's group traverses to a known socket path but cannot readdir.
+      chmodSync(this.opts.runtimeDir, 0o710);
+      if (dropTo) chownSync(this.opts.runtimeDir, -1, dropTo.gid);
+    } catch (err) {
+      this.opts.logBuffer.warn(
+        `could not harden runtime dir permissions: ${(err as Error).message}`,
+        `plugin:${this.opts.id}`,
+      );
+    }
+    // A random name is never reused, so this plugin's own sockets from earlier runs would
+    // accumulate for ever; only its own are touched, and it is about to own them anyway.
+    const stale = new RegExp(`^${escapeForRegExp(this.opts.id)}\\.[0-9a-f]{16}\\.(?:core|plugin)\\.sock$`);
+    for (const name of readdirSync(this.opts.runtimeDir)) {
+      if (!stale.test(name)) continue;
       try {
-        unlinkSync(p);
+        unlinkSync(join(this.opts.runtimeDir, name));
       } catch {
         // nothing stale to remove
       }
@@ -339,7 +361,6 @@ export class PluginSupervisor implements OnApplicationShutdown {
       }
       this.onPluginConnected(s);
     });
-    const dropTo = this.dropTarget();
     await Promise.all([
       listenAndRestrict(this.coreServer, this.coreSockPath, dropTo),
       listenAndRestrict(this.pluginServer, this.pluginSockPath, dropTo),


### PR DESCRIPTION
## Why

Two independent holes in the plugin boundary, both found while re-verifying the v3 readiness list,
both proven on the running stack rather than reasoned about.

### 1. A plugin could call the host API as another plugin

Socket paths were `<runtime dir>/<plugin id>.core.sock`. Every plugin child runs as the same
unprivileged uid, and Node's filesystem permission model does **not** gate a unix-socket `connect`,
so a plugin only had to derive a sibling's path from its id.

Reproduced against the dev stack, as the same uid a plugin child runs under and with the same
sandbox flags: a process dialled the download plugin's core socket and got real answers to
`acquisition.candidates` (scopes `media:read` + `acquisition:candidates`) and `config.get` — i.e.
the caller inherited the victim's whole scope set and read its private settings. The other installed
plugin holds only `config:rw`.

After this change the same probe reports `readdir DENIED: ERR_ACCESS_DENIED` and the derived path
`ENOENT`.

The fix needs no wire change and no plugin release: the child receives both socket paths through its
spawn environment, so only core has to know the name.

**Known residual, not addressed here.** All children still share one uid, so at kernel level a
plugin that escaped the Node permission model could read a sibling's `/proc/<pid>/environ` and
recover the token, the socket paths and its database credentials. Under `--permission` that read is
denied (verified), so the sandbox still holds — but the boundary rests on that one flag. A distinct
uid per plugin is the real answer and is tracked separately.

### 2. A plugin foreign key can block core deletion

A plugin may point a foreign key at a core table it declared as a `coreRef`. Postgres defaults to
`NO ACTION` when the author omits `ON DELETE`, and the delete then fails install-wide:

```
ERROR: update or delete on table "media" violates foreign key constraint
       "zz_probe_mediaId_fkey" on table "zz_probe"
```

Nothing in that error names the plugin. Confirmed empirically in a rolled-back transaction.

Not currently triggered: the installed plugin's four foreign keys into `public` are all `CASCADE` or
`SET NULL`. This is a guard against the next plugin, not an incident.

## What it does *not* do

It does **not** refuse to activate the plugin. That was the first design and it is wrong:

- the constraint stays in the database either way, so core deletion is broken with or without it;
- refusing removes the only thing that can repair it — the plugin's own corrective migration, which
  only runs when the plugin starts;
- and a hardening that refuses an already-published plugin is a blocker, not progress. Any author
  who wrote a plain `REFERENCES` would have been refused.

So it reports: every offending constraint, with its table, the referenced table and the remedy, in
the log and in the plugin's `statusMessage`. The probe runs after the handshake, because the
plugin's own migrations only run once it is up — an earlier look cannot see a constraint this run
just created. A failure of the probe itself warns and is ignored; a diagnostic must never gate a
spawn.

`ON DELETE SET DEFAULT` counts as unsafe alongside `NO ACTION` and `RESTRICT`: it blocks the delete
whenever the column default is not itself a live parent row.

## Verification

- `npx tsc --noEmit` — exit 0.
- `npx jest src/modules/plugins --runInBand` — 44 suites, 682 tests, exit 0.
- Backend restarted against the real dev database: `fliks.webhooks`, `fliks.download` and
  `acme.hello` all `active`, the two process plugins `ready`, exactly one socket pair each.
- Every new test was proven to fail when the line it covers is reverted:
  - random suffix removed → `Expected: not "/tmp/…/dup-id.core.sock"`
  - the warn inside the chmod guard removed → `Number of calls: 0`
  - the foreign-key probe wiring stubbed out → `Number of calls: 0`
  - the SQL predicate widened back to `NOT IN ('c','n','d')` → substring assertion fails
  - the socket cleanup neutralised → `Expected: false, Received: true`; widened to sweep every
    `.sock` → the other plugin's socket is gone, `Expected: true, Received: false`
