### PR TITLE
fix(plugins): refuse an oversize frame at the sender, and land an import atomically

### DIFF
--- a/backend/src/common/services/file-transfer.service.spec.ts
+++ b/backend/src/common/services/file-transfer.service.spec.ts
@@ -1,0 +1,118 @@
+import * as fs from 'fs';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { FileTransferService } from './file-transfer.service';
+
+describe('FileTransferService atomic transfer', () => {
+  let service: FileTransferService;
+  let tmpRoot: string;
+  let srcDir: string;
+  let destDir: string;
+
+  beforeEach(async () => {
+    service = new FileTransferService({} as never);
+    tmpRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'fts-spec-'));
+    srcDir = path.join(tmpRoot, 'src');
+    destDir = path.join(tmpRoot, 'dest');
+    await fsp.mkdir(srcDir, { recursive: true });
+    await fsp.mkdir(destDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await fsp.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('copy: lands the complete content and leaves no temp file behind', async () => {
+    const src = path.join(srcDir, 'movie.mp4');
+    const dest = path.join(destDir, 'movie.mp4');
+    await fsp.writeFile(src, 'complete-content');
+
+    await service.transferFile(src, dest, 'copy');
+
+    expect(await fsp.readFile(dest, 'utf8')).toBe('complete-content');
+    expect(fs.readdirSync(destDir)).toEqual(['movie.mp4']);
+  });
+
+  it('copy: a destination basename at the filesystem limit still transfers', async () => {
+    const longBase = `${'x'.repeat(251)}.mp4`;
+    const src = path.join(srcDir, 'movie.mp4');
+    const dest = path.join(destDir, longBase);
+    await fsp.writeFile(src, 'complete-content');
+
+    await service.transferFile(src, dest, 'copy');
+
+    expect(await fsp.readFile(dest, 'utf8')).toBe('complete-content');
+  });
+
+  it('copy: an overwrite keeps the destination mode', async () => {
+    const src = path.join(srcDir, 'movie.mp4');
+    const dest = path.join(destDir, 'movie.mp4');
+    await fsp.writeFile(src, 'new-content');
+    await fsp.writeFile(dest, 'old-content');
+    await fsp.chmod(dest, 0o640);
+
+    await service.transferFile(src, dest, 'copy');
+
+    expect(await fsp.readFile(dest, 'utf8')).toBe('new-content');
+    expect((await fsp.stat(dest)).mode & 0o777).toBe(0o640);
+  });
+
+  it('copy: an interrupted copy leaves no file at the destination', async () => {
+    const src = path.join(srcDir, 'movie.mp4');
+    const dest = path.join(destDir, 'movie.mp4');
+    await fsp.writeFile(src, 'complete-content');
+    // Simulate a copy that dies mid-write: writes partial bytes to
+    // whichever path it was given, then throws.
+    jest
+      .spyOn(fs.promises, 'copyFile')
+      .mockImplementationOnce(async (_s, d) => {
+        await fsp.writeFile(d as string, 'PARTIAL');
+        throw new Error('disk full');
+      });
+
+    await expect(service.transferFile(src, dest, 'copy')).rejects.toThrow(
+      'disk full',
+    );
+
+    expect(fs.existsSync(dest)).toBe(false);
+    expect(fs.readdirSync(destDir)).toEqual([]);
+  });
+
+  it('move (cross-device fallback): lands complete content, no temp file, source removed', async () => {
+    const src = path.join(srcDir, 'movie.mp4');
+    const dest = path.join(destDir, 'movie.mp4');
+    await fsp.writeFile(src, 'complete-content');
+    const exdev = Object.assign(new Error('cross-device'), { code: 'EXDEV' });
+    jest.spyOn(fs.promises, 'rename').mockRejectedValueOnce(exdev);
+
+    await service.transferFile(src, dest, 'move');
+
+    expect(await fsp.readFile(dest, 'utf8')).toBe('complete-content');
+    expect(fs.readdirSync(destDir)).toEqual(['movie.mp4']);
+    expect(fs.existsSync(src)).toBe(false);
+  });
+
+  it('move (cross-device fallback): an interrupted copy leaves no file at the destination', async () => {
+    const src = path.join(srcDir, 'movie.mp4');
+    const dest = path.join(destDir, 'movie.mp4');
+    await fsp.writeFile(src, 'complete-content');
+    const exdev = Object.assign(new Error('cross-device'), { code: 'EXDEV' });
+    jest.spyOn(fs.promises, 'rename').mockRejectedValueOnce(exdev);
+    jest
+      .spyOn(fs.promises, 'copyFile')
+      .mockImplementationOnce(async (_s, d) => {
+        await fsp.writeFile(d as string, 'PARTIAL');
+        throw new Error('disk full');
+      });
+
+    await expect(service.transferFile(src, dest, 'move')).rejects.toThrow(
+      'disk full',
+    );
+
+    expect(fs.existsSync(dest)).toBe(false);
+    expect(fs.readdirSync(destDir)).toEqual([]);
+    expect(fs.existsSync(src)).toBe(true);
+  });
+});

--- a/backend/src/common/services/file-transfer.service.ts
+++ b/backend/src/common/services/file-transfer.service.ts
@@ -3,11 +3,15 @@ import { DataSource } from 'typeorm';
 import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
+import { randomUUID } from 'crypto';
 
 export type TransferMethod = 'copy' | 'move';
 
 const DEFAULT_COMPANION_EXTS =
   '.srt,.ass,.ssa,.vtt,.idx,.sub,.nfo,.jpg,.jpeg,.png,.webp';
+
+const TEMP_PREFIX = '.fliks-tmp-';
+const STALE_TEMP_AGE_MS = 24 * 60 * 60 * 1000;
 
 /**
  * Filesystem helper shared by the disk-import flow and the torrent-completion
@@ -36,7 +40,7 @@ export class FileTransferService {
   ): Promise<void> {
     await fsp.mkdir(path.dirname(dest), { recursive: true });
     if (method === 'copy') {
-      await fsp.copyFile(src, dest);
+      await this.atomicCopy(src, dest);
       return;
     }
     try {
@@ -48,7 +52,7 @@ export class FileTransferService {
       // the unlink fails we still consider the operation successful — the
       // dest is materialised and the orphan source is observable by the
       // admin (and a follow-up move would no-op).
-      await fsp.copyFile(src, dest);
+      await this.atomicCopy(src, dest);
       try {
         await fsp.unlink(src);
       } catch (unlinkErr) {
@@ -56,6 +60,48 @@ export class FileTransferService {
           `Source unlink failed after cross-device move: ${src} — ${(unlinkErr as Error).message}`,
         );
       }
+    }
+  }
+
+  /** The temp name must sit in `dest`'s own directory, or the promoting rename is not atomic.
+   *  Fixed length, so a long destination basename cannot push it past NAME_MAX. */
+  private async atomicCopy(src: string, dest: string): Promise<void> {
+    const destDir = path.dirname(dest);
+    const tmp = path.join(destDir, `${TEMP_PREFIX}${randomUUID()}`);
+    try {
+      await fsp.copyFile(src, tmp);
+      // An overwrite would otherwise silently reset the destination's mode to the temp file's.
+      const existingMode = await fsp
+        .stat(dest)
+        .then((s) => s.mode)
+        .catch(() => null);
+      if (existingMode !== null) await fsp.chmod(tmp, existingMode);
+      const fh = await fsp.open(tmp, 'r+');
+      try {
+        await fh.sync();
+      } finally {
+        await fh.close();
+      }
+      await fsp.rename(tmp, dest);
+    } catch (err) {
+      await fsp.unlink(tmp).catch(() => {});
+      throw err;
+    }
+    void this.reapStaleTemps(destDir);
+  }
+
+  /** A copy killed mid-flight leaves its temp behind; only ones too old to be in flight are removed. */
+  private async reapStaleTemps(destDir: string): Promise<void> {
+    try {
+      const cutoff = Date.now() - STALE_TEMP_AGE_MS;
+      for (const name of await fsp.readdir(destDir)) {
+        if (!name.startsWith(TEMP_PREFIX)) continue;
+        const full = path.join(destDir, name);
+        const stat = await fsp.stat(full).catch(() => null);
+        if (stat && stat.mtimeMs < cutoff) await fsp.unlink(full).catch(() => {});
+      }
+    } catch {
+      // reaping is opportunistic; a transfer must never fail because of it
     }
   }
 

--- a/backend/src/modules/plugins/archive/manifest-parser.spec.ts
+++ b/backend/src/modules/plugins/archive/manifest-parser.spec.ts
@@ -120,3 +120,33 @@ describe('parseManifest — i18n namespace ownership', () => {
     expect(parseManifest(bytesOf(manifest))).not.toBeNull();
   });
 });
+
+describe('parseManifest — ingestRoots floor', () => {
+  function processManifest(ingestRoots: unknown) {
+    return {
+      ...minimalProcessManifest({ 'plugin.js': 'x', 'logo.png': 'x' }),
+      ingestRoots,
+    };
+  }
+
+  it('refuses the whole-filesystem root', () => {
+    expect(parseManifest(bytesOf(processManifest(['/'])))).toBeNull();
+  });
+
+  it('refuses a relative root', () => {
+    expect(parseManifest(bytesOf(processManifest(['media'])))).toBeNull();
+  });
+
+  it('refuses a root with a parent-directory segment', () => {
+    expect(parseManifest(bytesOf(processManifest(['/media/../etc'])))).toBeNull();
+  });
+
+  it('refuses an empty string', () => {
+    expect(parseManifest(bytesOf(processManifest(['']))))
+      .toBeNull();
+  });
+
+  it('accepts a normal absolute root', () => {
+    expect(parseManifest(bytesOf(processManifest(['/media/downloads'])))).not.toBeNull();
+  });
+});

--- a/backend/src/modules/plugins/archive/manifest-parser.ts
+++ b/backend/src/modules/plugins/archive/manifest-parser.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import type {
   DataPluginManifest,
   PluginManifest,
@@ -108,6 +109,13 @@ export function i18nRoot(manifest: PluginManifest): string | null {
   return null;
 }
 
+/** Absolute, normalised, never a volume root. The flavour comes from the value, never from the host:
+ *  a manifest is signed once and must resolve identically wherever core runs. */
+function isValidIngestRoot(root: string): boolean {
+  const flavour = /^[a-zA-Z]:[\\/]/.test(root) ? path.win32 : path.posix;
+  return flavour.isAbsolute(root) && root === flavour.normalize(root) && flavour.dirname(root) !== root;
+}
+
 function isRouteArray(v: unknown): v is PluginRoute[] {
   return (
     Array.isArray(v) &&
@@ -136,7 +144,7 @@ function hasRequiredProcessFields(json: Record<string, unknown>): boolean {
     json.scopes.length > 0 &&
     json.scopes.every((s) => typeof s === 'string' && PLUGIN_SCOPES.has(s)) &&
     Array.isArray(json.ingestRoots) &&
-    json.ingestRoots.every((r) => typeof r === 'string')
+    json.ingestRoots.every((r) => typeof r === 'string' && isValidIngestRoot(r))
   );
 }
 

--- a/backend/src/modules/plugins/archive/zip-inspector.spec.ts
+++ b/backend/src/modules/plugins/archive/zip-inspector.spec.ts
@@ -67,6 +67,7 @@ describe('inspect() — happy path', () => {
     const files = { 'plugin.js': sha256Hex(pluginJs), 'logo.png': sha256Hex(logo) };
     const manifest = minimalProcessManifest(files, {
       jobs: [{ name: 'sync', cron: '0 * * * *', triggerable: true, labelKey: 'jobs.sync' }],
+      ingestRoots: ['/media/downloads'],
     });
     const { entries } = signedManifestEntries(manifest);
     const buffer = buildZip([
@@ -81,6 +82,7 @@ describe('inspect() — happy path', () => {
     expect(result.kind).toBe('process');
     expect(result.capabilities).toContain('scope:media:read');
     expect(result.capabilities).toContain('job:sync');
+    expect(result.capabilities).toContain('ingestroot:/media/downloads');
   });
 });
 

--- a/backend/src/modules/plugins/archive/zip-inspector.ts
+++ b/backend/src/modules/plugins/archive/zip-inspector.ts
@@ -318,6 +318,7 @@ function deriveCapabilities(manifest: PluginManifest): string[] {
   if (manifest.events?.length) caps.push('webhook');
   if (manifest.kind === 'process') {
     for (const s of manifest.scopes) caps.push(`scope:${s}`);
+    for (const r of manifest.ingestRoots) caps.push(`ingestroot:${r}`);
     for (const j of manifest.jobs ?? []) caps.push(`job:${j.name}`);
   }
   return caps;

--- a/backend/src/modules/plugins/entities/plugin-registration.entity.ts
+++ b/backend/src/modules/plugins/entities/plugin-registration.entity.ts
@@ -8,7 +8,7 @@ export class PluginRegistration extends BaseEntity {
   @Column({ unique: true })
   pluginId: string;
 
-  /** Allowlist `library.ingest` paths are checked against; admin-editable after install. */
+  /** Allowlist `library.ingest` paths are checked against; manifest-derived, re-read at every activation. */
   @Column({ type: 'text', array: true, default: () => "'{}'" })
   ingestRoots: string[];
 

--- a/backend/src/modules/plugins/plugin-registry.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.spec.ts
@@ -301,17 +301,18 @@ describe('PluginRegistryService.register()', () => {
       );
     });
 
-    it('refreshes the cached manifest on a second registration without resetting admin-edited fields', async () => {
-      const pkg = processPackage({ id: 'fliks.processreload' });
+    it('refreshes the cached manifest on a second registration, and resyncs ingestRoots so a narrower upgrade takes effect', async () => {
+      const pkg = processPackage({ id: 'fliks.processreload', ingestRoots: ['/media'] });
       const { service, registrationRepo } = makeService();
       await service.register(pkg);
-      registrationRepo.rows.get(pkg.pluginId)!.ingestRoots = ['/media/custom'];
+      // Simulates the wider grant a previous, un-narrowed version left on the row.
+      registrationRepo.rows.get(pkg.pluginId)!.ingestRoots = ['/media', '/downloads'];
 
       const second = await service.register(pkg);
 
       expect(second).toEqual({ ok: true, pluginId: pkg.pluginId });
       const row = registrationRepo.rows.get(pkg.pluginId);
-      expect(row?.ingestRoots).toEqual(['/media/custom']);
+      expect(row?.ingestRoots).toEqual(['/media']);
       expect(row?.manifest).toEqual(pkg.manifest);
     });
 

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -373,7 +373,9 @@ export class PluginRegistryService implements OnModuleInit {
         manifest,
       });
     } else {
+      // Manifest-derived, and re-read at every activation: no admin edit path writes this column.
       registration.manifest = manifest;
+      registration.ingestRoots = manifest.ingestRoots;
     }
     await this.registrationRepo.save(registration);
 

--- a/backend/src/modules/plugins/supervisor/note-ring-buffer.ts
+++ b/backend/src/modules/plugins/supervisor/note-ring-buffer.ts
@@ -22,6 +22,11 @@ export class NoteRingBuffer {
     return this.items.shift();
   }
 
+  /** A note refused at encode time never reaches the queue, but it is still a drop. */
+  countDrop(): void {
+    this.droppedCount++;
+  }
+
   get size(): number {
     return this.items.length;
   }

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
@@ -392,6 +392,10 @@ export class PluginSupervisor implements OnApplicationShutdown {
     this.pluginSocketRef = socket;
     const channel = new RpcChannel(socket);
     channel.onViolation((err) => this.onViolation(err));
+    channel.onNoteDropped((note, err) => {
+      this.ring.countDrop();
+      this.opts.logBuffer.warn(`dropped note "${note.m}": ${err.message}`, `plugin:${this.opts.id}`);
+    });
     this.pluginChannel = channel;
     void this.attemptHandshake(channel);
   }

--- a/backend/src/modules/plugins/supervisor/rpc-channel.spec.ts
+++ b/backend/src/modules/plugins/supervisor/rpc-channel.spec.ts
@@ -2,6 +2,7 @@ import { createServer, connect, type Server, type Socket } from 'net';
 import { mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { MAX_FRAME_BYTES } from '../../../common/plugin-contract';
 import { RpcChannel } from './rpc-channel';
 
 interface Pair {
@@ -87,6 +88,52 @@ describe('RpcChannel', () => {
     const pending = pair.client.call('health', {}, 5_000);
     pair.server.destroy();
     await expect(pending).rejects.toThrow(/closed/);
+  });
+
+  it('rejects a locally oversize request without writing it to the wire', async () => {
+    const pair = await makePair();
+    cleanup = () => teardown(pair);
+    let received = false;
+    pair.server.onRequest(async () => {
+      received = true;
+      return {};
+    });
+    const huge = 'a'.repeat(MAX_FRAME_BYTES);
+    await expect(pair.client.call('big', huge, 1_000)).rejects.toThrow(/exceeds the \d+ byte limit/);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(received).toBe(false);
+  });
+
+  it('answers an oversize result with an error frame, and the channel stays open', async () => {
+    const pair = await makePair();
+    cleanup = () => teardown(pair);
+    const huge = 'a'.repeat(MAX_FRAME_BYTES);
+    pair.server.onRequest(async () => ({ blob: huge }));
+    await expect(pair.client.call('big', {}, 1_000)).rejects.toThrow(/^ERR_RESULT_TOO_LARGE: /);
+
+    pair.server.onRequest(async () => ({ ok: true }));
+    await expect(pair.client.call('small', {}, 1_000)).resolves.toEqual({ ok: true });
+  });
+
+  it('reports an oversize note to the drop handler instead of throwing', async () => {
+    const pair = await makePair();
+    cleanup = () => teardown(pair);
+    const dropped: string[] = [];
+    pair.client.onNoteDropped((note) => dropped.push(note.m));
+    let noteReceived = false;
+    pair.server.onNote(() => {
+      noteReceived = true;
+    });
+
+    const huge = 'a'.repeat(MAX_FRAME_BYTES);
+    expect(() => pair.client.sendNote({ m: 'huge', p: huge })).not.toThrow();
+    await new Promise((r) => setTimeout(r, 50));
+    expect(noteReceived).toBe(false);
+    expect(dropped).toEqual(['huge']);
+
+    const received = new Promise((resolve) => pair.server.onNote(resolve));
+    pair.client.sendNote({ m: 'small', p: {} });
+    await expect(received).resolves.toEqual({ m: 'small', p: {} });
   });
 
   describe('error frame codes', () => {

--- a/backend/src/modules/plugins/supervisor/rpc-channel.ts
+++ b/backend/src/modules/plugins/supervisor/rpc-channel.ts
@@ -1,5 +1,12 @@
 import type { Socket } from 'net';
-import { encodeFrame, FrameReader, parseFrame, ProtocolViolationError, type Frame } from './wire';
+import {
+  encodeFrame,
+  FrameReader,
+  FrameTooLargeError,
+  parseFrame,
+  ProtocolViolationError,
+  type Frame,
+} from './wire';
 import type { Req, Res, Note } from '../../../common/plugin-contract';
 
 interface PendingCall {
@@ -52,6 +59,7 @@ export class RpcChannel {
   private requestHandler: RequestHandler | null = null;
   private noteHandler: ((note: Note) => void) | null = null;
   private violationHandler: ((err: Error) => void) | null = null;
+  private dropHandler: ((note: Note, err: FrameTooLargeError) => void) | null = null;
   private closed = false;
 
   constructor(private readonly socket: Socket) {
@@ -112,7 +120,9 @@ export class RpcChannel {
       this.write({ i: req.i, r });
     } catch (err) {
       const e = err as Error;
-      this.write({ i: req.i, e: { c: classifyHostError(e), m: e.message } });
+      const code = e instanceof FrameTooLargeError ? 'ERR_RESULT_TOO_LARGE' : classifyHostError(e);
+      // Bounded: the reason for refusing an oversize frame must not itself be one.
+      this.write({ i: req.i, e: { c: code, m: e.message.slice(0, 4096) } });
     }
   }
 
@@ -144,13 +154,31 @@ export class RpcChannel {
         reject(new Error(`timeout waiting for "${method}"`));
       }, deadlineMs);
       this.pending.set(i, { resolve: resolve as (v: unknown) => void, reject, timer });
-      this.write({ i, m: method, p: payload });
+      try {
+        this.write({ i, m: method, p: payload });
+      } catch (err) {
+        this.pending.delete(i);
+        clearTimeout(timer);
+        throw err;
+      }
     });
   }
 
-  /** Fire-and-forget. Returns false when the socket is applying backpressure (caller must queue, not retry). */
+  /** Fire-and-forget. Returns false when the socket is applying backpressure (caller must queue, not retry).
+   *  A dropped note reports true: nothing was queued, so there is no drain to wait for. */
   sendNote(note: Note): boolean {
-    return this.write(note);
+    try {
+      return this.write(note);
+    } catch (err) {
+      if (!(err instanceof FrameTooLargeError)) throw err;
+      this.dropHandler?.(note, err);
+      return true;
+    }
+  }
+
+  /** Notified when a note is refused at encode time, so the drop is counted where drops are counted. */
+  onNoteDropped(cb: (note: Note, err: FrameTooLargeError) => void): void {
+    this.dropHandler = cb;
   }
 
   destroy(): void {

--- a/backend/src/modules/plugins/supervisor/wire.spec.ts
+++ b/backend/src/modules/plugins/supervisor/wire.spec.ts
@@ -1,11 +1,32 @@
 import { MAX_FRAME_BYTES } from '../../../common/plugin-contract';
-import { encodeFrame, FrameReader, parseFrame, ProtocolViolationError } from './wire';
+import { encodeFrame, FrameReader, FrameTooLargeError, parseFrame, ProtocolViolationError } from './wire';
+
+/** Pads `p` so the encoded frame lands at exactly `totalBytes`. */
+function noteOfSize(totalBytes: number): { m: string; p: string } {
+  const base = { m: 'x', p: '' };
+  const baseLen = Buffer.byteLength(JSON.stringify(base), 'utf8');
+  return { m: 'x', p: 'a'.repeat(totalBytes - baseLen) };
+}
 
 describe('encodeFrame / parseFrame', () => {
   it('round-trips a Req through one line', () => {
     const line = encodeFrame({ i: 1, m: 'health', p: {} }).toString('utf8');
     expect(line.endsWith('\n')).toBe(true);
     expect(parseFrame(line.slice(0, -1))).toEqual({ i: 1, m: 'health', p: {} });
+  });
+
+  it('accepts a frame sitting right at MAX_FRAME_BYTES', () => {
+    const frame = noteOfSize(MAX_FRAME_BYTES);
+    const buf = encodeFrame(frame);
+    expect(buf.length).toBe(MAX_FRAME_BYTES + 1); // + trailing newline
+  });
+
+  it('refuses a frame one byte over MAX_FRAME_BYTES, naming the size and the limit', () => {
+    const frame = noteOfSize(MAX_FRAME_BYTES + 1);
+    expect(() => encodeFrame(frame)).toThrow(FrameTooLargeError);
+    expect(() => encodeFrame(frame)).toThrow(
+      new RegExp(`frame of ${MAX_FRAME_BYTES + 1} bytes exceeds the ${MAX_FRAME_BYTES} byte limit`),
+    );
   });
 
   it('rejects a malformed line', () => {

--- a/backend/src/modules/plugins/supervisor/wire.ts
+++ b/backend/src/modules/plugins/supervisor/wire.ts
@@ -10,9 +10,22 @@ export class ProtocolViolationError extends Error {
   }
 }
 
-/** One JSON object per line. */
+/** Raised when a frame we're about to send would breach MAX_FRAME_BYTES — our own fault, not the peer's. */
+export class FrameTooLargeError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = 'FrameTooLargeError';
+  }
+}
+
+/** One JSON object per line. Refuses past MAX_FRAME_BYTES rather than breaching the peer's reader. */
 export function encodeFrame(frame: Frame): Buffer {
-  return Buffer.from(JSON.stringify(frame) + '\n', 'utf8');
+  const json = JSON.stringify(frame);
+  const size = Buffer.byteLength(json, 'utf8');
+  if (size > MAX_FRAME_BYTES) {
+    throw new FrameTooLargeError(`frame of ${size} bytes exceeds the ${MAX_FRAME_BYTES} byte limit`);
+  }
+  return Buffer.from(json + '\n', 'utf8');
 }
 
 /**

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2117,6 +2117,7 @@
           "ui": "Add a \"{{value}}\" interface element",
           "config": "Add a \"{{value}}\" settings page",
           "scope": "Access: {{value}}",
+          "ingestroot": "Add files under: {{value}}",
           "job": "Run a scheduled job: {{value}}",
           "webhook": "Subscribe to server events"
         },

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2144,6 +2144,7 @@
           "ui": "Add a \"{{value}}\" interface element",
           "config": "Add a \"{{value}}\" settings page",
           "scope": "Access: {{value}}",
+          "ingestroot": "Add files under: {{value}}",
           "job": "Run a scheduled job: {{value}}",
           "webhook": "Subscribe to server events"
         },

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2117,6 +2117,7 @@
           "ui": "Add a \"{{value}}\" interface element",
           "config": "Add a \"{{value}}\" settings page",
           "scope": "Access: {{value}}",
+          "ingestroot": "Add files under: {{value}}",
           "job": "Run a scheduled job: {{value}}",
           "webhook": "Subscribe to server events"
         },

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2144,6 +2144,7 @@
           "ui": "Ajouter un élément d'interface « {{value}} »",
           "config": "Ajouter une page de réglages « {{value}} »",
           "scope": "Accès : {{value}}",
+          "ingestroot": "Ajouter des fichiers dans : {{value}}",
           "job": "Exécuter une tâche planifiée : {{value}}",
           "webhook": "S'abonner aux événements du serveur"
         },

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2117,6 +2117,7 @@
           "ui": "Add a \"{{value}}\" interface element",
           "config": "Add a \"{{value}}\" settings page",
           "scope": "Access: {{value}}",
+          "ingestroot": "Add files under: {{value}}",
           "job": "Run a scheduled job: {{value}}",
           "webhook": "Subscribe to server events"
         },

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2117,6 +2117,7 @@
           "ui": "Add a \"{{value}}\" interface element",
           "config": "Add a \"{{value}}\" settings page",
           "scope": "Access: {{value}}",
+          "ingestroot": "Add files under: {{value}}",
           "job": "Run a scheduled job: {{value}}",
           "webhook": "Subscribe to server events"
         },

--- a/client/src/app/features/settings/plugins/plugin-install-consent/plugin-install-consent.ts
+++ b/client/src/app/features/settings/plugins/plugin-install-consent/plugin-install-consent.ts
@@ -65,7 +65,8 @@ export class PluginInstallConsentComponent {
     this.dialogRef().nativeElement.close();
   }
 
-  /** `ui:<slot>` / `config:<id>` / `scope:<name>` / `job:<name>` / `webhook` — see `deriveCapabilities` on the backend. */
+  /** `ui:<slot>` / `config:<id>` / `scope:<name>` / `ingestroot:<path>` / `job:<name>` / `webhook`
+   *  — see `deriveCapabilities` on the backend. */
   capabilityLabel(capability: string): string {
     const separator = capability.indexOf(':');
     const prefix = separator === -1 ? capability : capability.slice(0, separator);
@@ -77,6 +78,8 @@ export class PluginInstallConsentComponent {
         return this.translate.instant('settings.plugins.consent.capability.config', { value });
       case 'scope':
         return this.translate.instant('settings.plugins.consent.capability.scope', { value });
+      case 'ingestroot':
+        return this.translate.instant('settings.plugins.consent.capability.ingestroot', { value });
       case 'job':
         return this.translate.instant('settings.plugins.consent.capability.job', { value });
       case 'webhook':


### PR DESCRIPTION
## 1. An oversize frame crashed the receiver for the sender's fault

`MAX_FRAME_BYTES` was checked only by `FrameReader`; `encodeFrame` wrote anything. An oversize frame
was therefore a `ProtocolViolationError` **at the peer**, which is fatal to the connection — and six
crashes inside ten minutes trip the breaker to `failed`.

Encoding now refuses, and each direction degrades sensibly instead of breaching the wire:

| direction | before | now |
|---|---|---|
| host-call result | peer crashes | caller gets `ERR_RESULT_TOO_LARGE`, channel stays open |
| request | peer crashes | rejects locally, nothing written, pending entry and timer cleaned up |
| note | peer crashes | dropped, counted in the supervisor's existing drop counter, logged per plugin |

**Honest scope:** at the documented call limits this is not reachable today. I measured
`acquisition.candidates` at ~1.4 KB/item over the socket, so its documented cap of 500 peaks near
709 KB against a 4 MiB ceiling. This is a fail-safe, not a live incident.

The size is measured with `Buffer.byteLength`, so a multibyte payload cannot slip past a UTF-16
length check, and the error message written into the refusal frame is itself bounded — the reason for
refusing an oversize frame must not be one.

## 2. An interrupted import left a truncated file that was then reported as complete

`transferFile` did `copyFile(src, dest)` straight to the final path. Kill the process mid-copy and
the destination holds a partial file; `LibraryIngestService.collides()` then sees the path taken,
reports it in `alreadyPresent`, and the caller records a completed import. **A partial video stays in
the library.** Every caller routes through this one function, so this hit core imports too, not just
plugin ingests.

The copy now lands on a temporary name in the destination's own directory (so the promoting rename
is same-filesystem and atomic). Three things the first attempt got wrong, caught in review and fixed:

- the temp name embedded the destination basename, adding 42 bytes and dropping the usable basename
  ceiling from 255 to 213 — long titles that used to import started failing `ENAMETOOLONG`. The name
  is now fixed-length. Covered by a test that reproduces the failure exactly.
- an overwrite silently reset the destination's permission bits, since the rename replaces the inode.
  The mode is carried across.
- `fsync` was called on a read-only handle, which is not portable and this project ships a Windows
  backend. Opened `r+`.

A temp file left by a kill is reaped on a later transfer into the same directory, but only once it is
far too old to still be in flight.

## 3. `ingestRoots` had no floor, was frozen at first activation, and was invisible at install

- **No floor.** The only check was "array of strings". A manifest could declare `/` — a real
  whole-filesystem grant, since `path.relative('/', '/etc/passwd')` has no `..` and passes
  enforcement — or a relative path resolved against the server's working directory.
- **Frozen.** `activateProcess` seeded the column on create only, and enforcement reads the row, so a
  plugin that *narrowed* its declared roots kept the wider grant for ever.
- **Invisible.** The consent sheet showed `scope:ingest:write` — that the plugin writes files — but
  never *where*.

Roots are now validated at parse, re-read at every activation, and rendered on the consent sheet
(key added to all six locales). The floor picks the path flavour **from the value, not the host**: the
first attempt used bare `path.normalize`, which on a Windows host rewrites `/downloads` to
`\downloads` and would have refused every POSIX manifest — the same signed archive must resolve
identically wherever core runs. It also refuses a volume root structurally, so `C:\` is closed too,
not just `/`.

The entity docblock said this column was "admin-editable after install". No admin edit path exists
anywhere in the repo; it now says what is true.

## Verification

- `npx tsc --noEmit` — exit 0.
- **Full** backend suite (not just plugins): `npx jest --runInBand` — 131 suites, 1466 tests, exit 0.
- Backend restarted against the real dev database: all three plugins `active`, both process plugins
  `ready`.
- **Real install path, not a `docker cp`.** The published `fliks.download` archive pulled out of
  `plugin_packages` and POSTed to `/api/plugins/import/inspect`: still `installable: true`, and the
  consent report now carries `ingestroot:/downloads`. Repacked with `["/"]`, with a relative root and
  with a traversal root: all three refused `PLUGIN_BAD_MANIFEST`.
- Every new test proven to fail when the line it covers is reverted, including:
  - temp name back to the basename form → `ENAMETOOLONG: name too long, copyfile …`
  - mode preservation removed → `Expected: 416, Received: 436`
  - promoting rename removed → 4 of 6 transfer tests fail (so the happy-path tests do cover the new
    path, not only the interrupted ones)
  - drop handler call removed → `Expected [huge], Received []`
  - encode guard removed / `>` flipped to `>=` → the wire and channel tests fail
  - ingest floor reverted to the plain type check → 4 parser tests fail
