### PR TITLE
feat(plugins): answer each plugin in its own contract revision

### DIFF
--- a/backend/src/common/plugin-contract/protocol.ts
+++ b/backend/src/common/plugin-contract/protocol.ts
@@ -29,17 +29,18 @@ export type Note<P = unknown> = { m: string; p?: P };
 export const MAX_FRAME_BYTES = 4 * 1024 * 1024;
 
 /**
- * What core sends a plugin at `hello`. Within one value the method set is additive-only; any
- * removal or semantic change bumps it.
+ * The newest version core speaks, and the one a new manifest should declare. Core answers each
+ * plugin in the version that plugin's own manifest declares, so a bump here orphans nobody.
+ * Within one value the method set is additive-only; any removal or semantic change bumps it.
  */
-export const PLUGIN_API_VERSION = 0;
+export const PLUGIN_API_VERSION = 1;
 
 /**
  * Every value core still accepts from a manifest, newest last. Retiring one is what orphans the
  * plugins that declare it, so a bump adds an entry and a later release drops the oldest — the
  * window in between is when authors republish.
  */
-export const SUPPORTED_PLUGIN_API_VERSIONS: readonly number[] = [0];
+export const SUPPORTED_PLUGIN_API_VERSIONS: readonly number[] = [0, 1];
 
 /**
  * The version a `fliks` range is matched against: a prerelease resolves as its own release, since

--- a/backend/src/modules/plugins/archive/trust-store.spec.ts
+++ b/backend/src/modules/plugins/archive/trust-store.spec.ts
@@ -26,23 +26,7 @@ describe('resolveTrust()', () => {
     expect(result.signedByKeyId).toBe('release-2026');
   });
 
-  it('resolves to verified-<keyId> for a third-party key that is not official', () => {
-    const { privateKey, rawPublicKey } = generateTestKeypair();
-    const signature = Buffer.from(signManifestBase64(privateKey, data), 'base64');
-    const thirdPartyKeys = new Map([['admin-added-key', rawPublicKey]]);
-    const result = resolveTrust(data, signature, new Map(), thirdPartyKeys);
-    expect(result.trust).toBe('verified-admin-added-key');
-    expect(result.signedByKeyId).toBe('admin-added-key');
-  });
 
-  it('prefers an official match over an incidental third-party match', () => {
-    const { privateKey, rawPublicKey } = generateTestKeypair();
-    const signature = Buffer.from(signManifestBase64(privateKey, data), 'base64');
-    const officialKeys = new Map([['release-2026', rawPublicKey]]);
-    const thirdPartyKeys = new Map([['admin-added-key', rawPublicKey]]);
-    const result = resolveTrust(data, signature, officialKeys, thirdPartyKeys);
-    expect(result.trust).toBe('official');
-  });
 
   it('a tampered signature against a known key falls through to unverified, never official', () => {
     const { privateKey, rawPublicKey } = generateTestKeypair();

--- a/backend/src/modules/plugins/archive/trust-store.ts
+++ b/backend/src/modules/plugins/archive/trust-store.ts
@@ -16,7 +16,7 @@ export const OFFICIAL_KEYS: ReadonlyMap<string, Buffer> = new Map([
   ],
 ]);
 
-export type TrustOutcome = 'official' | `verified-${string}` | 'unverified' | 'unsigned';
+export type TrustOutcome = 'official' | 'unverified' | 'unsigned';
 
 export interface SignatureVerification {
   trust: TrustOutcome;
@@ -45,27 +45,17 @@ function verifyWithRawKey(data: Buffer, signature: Buffer, rawPublicKey: Buffer)
 }
 
 /**
- * Classify a signature by trying every known key — official first, then
- * caller-supplied third-party keys — never the reverse: an official key
- * always wins the `official` badge over an incidental third-party match.
- * No signature at all is `unsigned`. A signature nothing recognises is
- * `unverified` — including the case where both stores are empty, which
- * must never crash and must never read as `official`.
+ * Classify a signature against the trusted key set. No signature at all is `unsigned`; a signature
+ * nothing recognises is `unverified` — including an empty store, which must never read as `official`.
  */
 export function resolveTrust(
   data: Buffer,
   signature: Buffer | null,
   officialKeys: ReadonlyMap<string, Buffer> = OFFICIAL_KEYS,
-  thirdPartyKeys: ReadonlyMap<string, Buffer> = new Map(),
 ): SignatureVerification {
   if (!signature) return { trust: 'unsigned' };
   for (const [keyId, rawKey] of officialKeys) {
     if (verifyWithRawKey(data, signature, rawKey)) return { trust: 'official', signedByKeyId: keyId };
-  }
-  for (const [keyId, rawKey] of thirdPartyKeys) {
-    if (verifyWithRawKey(data, signature, rawKey)) {
-      return { trust: `verified-${keyId}`, signedByKeyId: keyId };
-    }
   }
   return { trust: 'unverified' };
 }

--- a/backend/src/modules/plugins/archive/zip-inspector.ts
+++ b/backend/src/modules/plugins/archive/zip-inspector.ts
@@ -42,8 +42,6 @@ function hasControlChar(name: string): boolean {
 export interface InspectOptions {
   /** Test-only override of the compiled-in official key set. Defaults to {@link OFFICIAL_KEYS}. */
   officialKeys?: ReadonlyMap<string, Buffer>;
-  /** Admin-registered third-party keys (empty until Phase 7's key registry ships). */
-  thirdPartyKeys?: ReadonlyMap<string, Buffer>;
   /** `FLIKS_UNSIGNED_PLUGINS` ids — the only way a `process` plugin may ship unsigned. */
   unsignedProcessAllowlist?: readonly string[];
 }
@@ -218,7 +216,7 @@ export async function inspect(buffer: Buffer, options: InspectOptions = {}): Pro
     return refuse('PLUGIN_BAD_SIGNATURE', `signature is ${sigBytes.length} bytes, expected ${ED25519_SIGNATURE_LENGTH}`);
   }
   const officialKeys = options.officialKeys ?? OFFICIAL_KEYS;
-  const trust = resolveTrust(manifestBytes, sigBytes, officialKeys, options.thirdPartyKeys ?? new Map());
+  const trust = resolveTrust(manifestBytes, sigBytes, officialKeys);
 
   // V7 - only now is the manifest content itself read.
   const manifest = parseManifest(manifestBytes);

--- a/backend/src/modules/plugins/plugin-catalog-client.service.ts
+++ b/backend/src/modules/plugins/plugin-catalog-client.service.ts
@@ -78,7 +78,7 @@ export class PluginCatalogClientService {
 
     const officialKeys = source.publicKey ? new Map([['source', source.publicKey]]) : OFFICIAL_KEYS;
     const signature = this.parseSignature(sigBytes);
-    const trust = resolveTrust(catalogBytes, signature, officialKeys, new Map());
+    const trust = resolveTrust(catalogBytes, signature, officialKeys);
     if (trust.trust === 'unsigned' || trust.trust === 'unverified') {
       return this.fail(source, 'bad-signature', `catalog signature did not verify (${trust.trust})`);
     }

--- a/backend/src/modules/plugins/plugin-process.service.ts
+++ b/backend/src/modules/plugins/plugin-process.service.ts
@@ -99,6 +99,7 @@ export class PluginProcessService implements OnApplicationShutdown {
       logBuffer: this.logBuffer,
       dbUrl,
       config,
+      pluginApi: manifest.pluginApi,
       memoryMb: manifest.memoryMb,
       hostApi: this.hostBinding?.bind(pkg.pluginId) ?? null,
     });

--- a/backend/src/modules/plugins/plugin-registry.service.routes.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.routes.spec.ts
@@ -2,7 +2,7 @@ import { PluginRegistryService } from './plugin-registry.service';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { minimalProcessManifest } from './archive/test-manifests';
 import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry } from './plugin-registry.test-helpers';
-import type { PluginManifest, PluginRoute } from '../../common/plugin-contract';
+import { SUPPORTED_PLUGIN_API_VERSIONS, type PluginManifest, type PluginRoute } from '../../common/plugin-contract';
 import type { PluginProcessStartResult } from './plugin-process.service';
 
 /** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
@@ -180,7 +180,8 @@ describe('PluginRegistryService — route registration validation', () => {
     await service.register(makePackage(good));
     expect(service.resolveRoute(good.id, 'GET', '/queue')).not.toBeNull();
 
-    const incompatible = { ...processManifest(routes), pluginApi: good.pluginApi + 1 };
+    const unsupported = Math.max(...SUPPORTED_PLUGIN_API_VERSIONS) + 1;
+    const incompatible = { ...processManifest(routes), pluginApi: unsupported };
     const result = await service.register(makePackage(incompatible));
 
     expect(result).toMatchObject({ ok: false, reason: 'incompatible-api' });

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -722,7 +722,7 @@ export class PluginRegistryService implements OnModuleInit {
       }
       const signature = Buffer.from(sigText, 'base64');
       // Scope the check to exactly this one key by passing it as the sole candidate.
-      const result = resolveTrust(manifestBytes, signature, new Map([[pkg.verifiedByKeyId, key]]), new Map());
+      const result = resolveTrust(manifestBytes, signature, new Map([[pkg.verifiedByKeyId, key]]));
       if (result.trust !== 'official') {
         return { ok: false, detail: `signature no longer verifies against key "${pkg.verifiedByKeyId}"` };
       }

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.spec.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.spec.ts
@@ -4,7 +4,7 @@ import { basename, dirname, join } from 'path';
 import { DEFAULT_SUPERVISOR_OPTIONS, PluginSupervisor, type PluginSupervisorOptions } from './plugin-supervisor';
 import { RpcChannel } from './rpc-channel';
 import { pidFilePath } from './pid-file';
-import type { PluginHostApi } from '../../../common/plugin-contract';
+import { PLUGIN_API_VERSION, type PluginHostApi } from '../../../common/plugin-contract';
 import {
   delay,
   makeFixtureDir,
@@ -67,6 +67,7 @@ afterEach(async () => {
 describe('DEFAULT_SUPERVISOR_OPTIONS', () => {
   it('has these exact default values', () => {
     expect(DEFAULT_SUPERVISOR_OPTIONS).toEqual({
+      pluginApi: PLUGIN_API_VERSION,
       memoryMb: 256,
       handshakeDeadlineMs: 10_000,
       healthIntervalMs: 15_000,

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
@@ -49,6 +49,7 @@ const SELF_DECLARED_WARN = /^(?:\[[^\]]*\]\s*)*WARN\b/;
 
 /** Every figure here is "The spawn call and the supervisor"'s, verbatim. Override only in tests. */
 export const DEFAULT_SUPERVISOR_OPTIONS = {
+  pluginApi: PLUGIN_API_VERSION,
   memoryMb: 256,
   handshakeDeadlineMs: 10_000,
   healthIntervalMs: 15_000,
@@ -65,6 +66,8 @@ export const DEFAULT_SUPERVISOR_OPTIONS = {
 
 export interface PluginSupervisorOptions {
   id: string;
+  /** The version this plugin's manifest declares — core answers it in that version, not the newest. */
+  pluginApi?: number;
   /** Directory already holding a materialized `plugin.js` (extraction is out of this PR's scope). */
   dir: string;
   /** Where the sockets and pid file live. Defaults to the `fliks-rt` directory,
@@ -424,6 +427,7 @@ export class PluginSupervisor implements OnApplicationShutdown {
       pluginSockPath: this.pluginSockPath,
       token: this.token,
       pluginId: this.opts.id,
+      pluginApi: this.opts.pluginApi,
       dbUrl: this.opts.dbUrl,
       config: this.opts.config,
     });
@@ -498,7 +502,7 @@ export class PluginSupervisor implements OnApplicationShutdown {
     try {
       const res = await channel.call<HelloReply>(
         'hello',
-        { pluginApi: PLUGIN_API_VERSION, coreVersion: CURRENT_FLIKS_VERSION, config: this.opts.config },
+        { pluginApi: this.opts.pluginApi, coreVersion: CURRENT_FLIKS_VERSION, config: this.opts.config },
         this.opts.handshakeDeadlineMs,
       );
       // The token never travels core->plugin; only a process holding the real FLIKS_PLUGIN_TOKEN

--- a/backend/src/modules/plugins/supervisor/spawn-plan.spec.ts
+++ b/backend/src/modules/plugins/supervisor/spawn-plan.spec.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { PLUGIN_API_VERSION } from '../../../common/plugin-contract';
+import { PLUGIN_API_VERSION, SUPPORTED_PLUGIN_API_VERSIONS } from '../../../common/plugin-contract';
 import {
   buildSpawnPlan,
   prepareDirForDroppedChild,
@@ -51,6 +51,7 @@ describe('buildSpawnPlan', () => {
     pluginSockPath: '/tmp/plugin-x.plugin.sock',
     token: 'the-token',
     pluginId: 'demo',
+    pluginApi: PLUGIN_API_VERSION,
   };
 
   it('never spreads process.env — the env is exactly the allowlist plus FLIKS_CFG_* re-keys', () => {
@@ -68,6 +69,13 @@ describe('buildSpawnPlan', () => {
     expect(plan.env.FLIKS_PLUGIN_TOKEN).toBe(baseInput.token);
     expect(plan.env.FLIKS_PLUGIN_ID).toBe(baseInput.pluginId);
     expect(plan.env.FLIKS_API_VERSION).toBe(String(PLUGIN_API_VERSION));
+  });
+
+  it('tells a plugin the revision its own manifest declares, not core\'s newest', () => {
+    const older = SUPPORTED_PLUGIN_API_VERSIONS.find((v) => v !== PLUGIN_API_VERSION);
+    expect(older).toBeDefined();
+    const plan = buildSpawnPlan({ ...baseInput, pluginApi: older as number });
+    expect(plan.env.FLIKS_API_VERSION).toBe(String(older));
     expect(plan.env.HOME).toBe(`${baseInput.dir}/data`);
     expect(plan.env.NODE_ENV).toBe('production');
   });

--- a/backend/src/modules/plugins/supervisor/spawn-plan.ts
+++ b/backend/src/modules/plugins/supervisor/spawn-plan.ts
@@ -1,7 +1,7 @@
 import { spawnSync, type SpawnOptions } from 'child_process';
 import { chmodSync, chownSync, mkdirSync, readdirSync } from 'fs';
 import { join } from 'path';
-import { PLUGIN_API_VERSION, type PluginSpawnEnv } from '../../../common/plugin-contract';
+import { type PluginSpawnEnv } from '../../../common/plugin-contract';
 
 /** The unprivileged identity a plugin child drops to when core runs as root. */
 export const PLUGIN_CHILD_UID = 65534;
@@ -49,6 +49,8 @@ export interface SpawnPlanInput {
   pluginSockPath: string;
   token: string;
   pluginId: string;
+  /** The version this plugin's manifest declares, which is the one core answers it in. */
+  pluginApi: number;
   dbUrl?: string;
   /** `plugin.<id>.*` admin settings, re-keyed to `FLIKS_CFG_*` env vars. */
   config?: Record<string, string>;
@@ -96,7 +98,7 @@ export function buildSpawnPlan(input: SpawnPlanInput): SpawnPlan {
     FLIKS_PLUGIN_SOCK: input.pluginSockPath,
     FLIKS_PLUGIN_TOKEN: input.token,
     FLIKS_PLUGIN_ID: input.pluginId,
-    FLIKS_API_VERSION: String(PLUGIN_API_VERSION),
+    FLIKS_API_VERSION: String(input.pluginApi),
     FLIKS_DB_URL: input.dbUrl ?? '',
     ...reKeyConfig(input.pluginId, input.config ?? {}),
   };

--- a/client/src/app/core/services/api/plugins-api.service.ts
+++ b/client/src/app/core/services/api/plugins-api.service.ts
@@ -4,7 +4,7 @@ import { firstValueFrom } from 'rxjs';
 
 export type PluginKind = 'data' | 'process';
 /** Mirrors backend `TrustOutcome` (`archive/trust-store.ts`). */
-export type PluginTrust = 'official' | `verified-${string}` | 'unverified' | 'unsigned';
+export type PluginTrust = 'official' | 'unverified' | 'unsigned';
 export type PluginOrigin = 'catalog' | 'manual';
 export type PluginStatus = 'active' | 'failed';
 

--- a/client/src/app/features/settings/plugins/plugin-trust.spec.ts
+++ b/client/src/app/features/settings/plugins/plugin-trust.spec.ts
@@ -14,13 +14,6 @@ describe('trustBadgeFor', () => {
     expect(trustBadgeFor(undefined).labelKey).toBe('settings.plugins.trust.unverified');
   });
 
-  it('extracts the key id from a verified-<key> outcome', () => {
-    expect(trustBadgeFor('verified-acme-2026')).toEqual({
-      labelKey: 'settings.plugins.trust.verified',
-      params: { key: 'acme-2026' },
-      cssClass: 'badge-success',
-    });
-  });
 });
 
 describe('requiresAcknowledgement', () => {
@@ -30,8 +23,7 @@ describe('requiresAcknowledgement', () => {
     expect(requiresAcknowledgement(undefined)).toBe(true);
   });
 
-  it('does not require it once a key attributes the signature', () => {
+  it('does not require it for an official signature', () => {
     expect(requiresAcknowledgement('official')).toBe(false);
-    expect(requiresAcknowledgement('verified-acme-2026')).toBe(false);
   });
 });

--- a/client/src/app/features/settings/plugins/plugin-trust.ts
+++ b/client/src/app/features/settings/plugins/plugin-trust.ts
@@ -6,16 +6,11 @@ export interface TrustBadge {
   cssClass: string;
 }
 
-/** Maps backend `TrustOutcome` onto the four-badge model (Official / Verified / Unverified / Imported manually). */
+/** Maps backend `TrustOutcome` onto the three-badge model (Official / Unverified / Imported manually). */
 export function trustBadgeFor(trust: PluginTrust | undefined): TrustBadge {
   if (trust === 'official') return { labelKey: 'settings.plugins.trust.official', cssClass: 'badge-success' };
   if (trust === 'unsigned') return { labelKey: 'settings.plugins.trust.manual', cssClass: 'badge-ghost' };
-  if (trust === 'unverified' || !trust) return { labelKey: 'settings.plugins.trust.unverified', cssClass: 'badge-warning' };
-  return {
-    labelKey: 'settings.plugins.trust.verified',
-    params: { key: trust.slice('verified-'.length) },
-    cssClass: 'badge-success',
-  };
+  return { labelKey: 'settings.plugins.trust.unverified', cssClass: 'badge-warning' };
 }
 
 /** Gate for the consent sheet's acknowledgement checkbox: anything without an attributable signature. */

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -137,7 +137,9 @@ these, set once at spawn (`supervisor/spawn-plan.ts`):
 ### The handshake
 
 The first call core makes on a freshly spawned child is `hello`, with `{ pluginApi, coreVersion,
-config }`. The reply must be `{ manifest, token }`: `manifest` is this archive's own
+config }`. That `pluginApi` — and the `FLIKS_API_VERSION` env var — is the value **your** manifest
+declares, not core's newest: core answers each plugin in the revision that plugin was written
+against, so comparing it for exact equality against the revision you built for is safe. The reply must be `{ manifest, token }`: `manifest` is this archive's own
 `plugin.json`, read fresh rather than baked into the bundle, and `token` is `FLIKS_PLUGIN_TOKEN`
 echoed back exactly. A wrong or missing token is a crash: core logs `plugin crashed: hello token
 mismatch` against that plugin's own log stream and retries up the backoff ladder until the breaker
@@ -166,9 +168,11 @@ An archive is a ZIP with a closed set of legal entry names, size caps, and an Ed
 over the manifest. Install is two steps: `inspect` verifies and stages, `confirm` promotes what was
 staged, and the consent sheet in between is the only place an unverified plugin is accepted.
 
-Signature outcomes are `official` (a catalogue release key), `verified`, `unverified`, or
-`unsigned`. A `process` plugin must be signed unless its id is in `FLIKS_UNSIGNED_PLUGINS`, which
-exists for local development only.
+Signature outcomes are `official` (a catalogue release key), `unverified`, or `unsigned`. Only the
+catalogue key verifies: there is no registry of third-party signing keys, so an archive signed by
+anyone else is `unverified` and reaches an operator behind the consent sheet's acknowledgement. A
+`process` plugin must be signed unless its id is in `FLIKS_UNSIGNED_PLUGINS`, which exists for local
+development only.
 
 Catalogue sources are HTTPS documents listing each plugin's installable versions with a `sha256`
 per version; core refuses bytes whose hash does not match. Publishing a plugin means committing its


### PR DESCRIPTION
## `pluginApi` → 1, without orphaning anyone

The plan called this "a one-entry edit". It is not, and the reason matters.

`SUPPORTED_PLUGIN_API_VERSIONS` governs what core accepts **from a manifest**. But `PLUGIN_API_VERSION`
was also what core *sent*: the `hello` payload and the `FLIKS_API_VERSION` env var both carried the
global constant. The contract tells authors that value is "compared for exact equality, never a
range". So bumping the constant alone would have told all three installed plugins — every one of them
declaring `pluginApi: 0` — that they were talking to a revision 1 core, and any author who followed
the documented advice would have refused to start.

Core now answers each plugin in the revision **its own manifest declares**. The constant means "the
newest revision core speaks", which is what makes the supported-versions window worth having: a
manifest declaring 0 keeps being spoken to in 0 until a later release drops 0 from the list, and that
gap is the republish window.

Verified on the running stack: core at `PLUGIN_API_VERSION = 1`, and both process plugins spawned
with `FLIKS_API_VERSION=0`, matching their manifests.

```
== acme.hello ==      FLIKS_API_VERSION=0
== fliks.download ==  FLIKS_API_VERSION=0
```

## The third-party trust level is removed rather than half-built

`resolveTrust` took a `thirdPartyKeys` map and **no caller ever supplied one** — both production call
sites passed an empty map — so `verified-<keyId>` was unreachable. A third-party author's best
possible outcome was `unverified` plus the consent sheet's acknowledgement checkbox, permanently.

Leaving the shape in place was the actively dangerous option. `reverifyTrust` resolves a package's
recorded `verifiedByKeyId` against `OFFICIAL_KEYS` alone and requires the outcome to be `official`.
The day a key registry appeared, every plugin installed under one of those keys would fail
re-verification at the next boot with *"key … is no longer in the trust store"* — and since
`untrusted` is not in `INSTALLED_BUT_NOT_RUNNING`, its HTTP routes would be withdrawn too, turning a
signing-key change into a silent outage at the next restart.

Removed: the parameter, the `verified-${string}` member of `TrustOutcome`, the client's mirrored type
and the badge branch that rendered it, and the two tests that exercised the unreachable path.
`docs/plugins.md` said outcomes were `official`, `verified`, `unverified` or `unsigned`; it now says
only the catalogue key verifies, which is what the code does.

One thing I checked before removing it, because it would have changed the answer: `plugin_sources`
rows can pin their own `publicKey`, and `plugin-catalog-client.service.ts` passes it in the
*officialKeys* slot. That verifies the **catalogue document** only — `inspect()` is never called with
a source key, so `verifiedByKeyId` on a package row can only ever hold an `OFFICIAL_KEYS` id. No
existing install can be affected.

## Not in this PR

§2.3, republishing both plugins to `>=3.0.0 <4.0.0`, is a release action in the plugin repositories
and rides the same train as the core tag.

## Verification

- `npx tsc --noEmit` — exit 0.
- Full backend suite: 131 suites, 1465 tests, exit 0.
- Backend restarted against the real dev database: all three plugins `active`, both process plugins
  `ready`, trust badges unchanged (`official` / `unsigned` / `unverified`).
- New test proven to fail when its line is reverted: pinning `FLIKS_API_VERSION` back to a fixed core
  constant → `Expected: "0", Received: "1"`.
- Two existing tests updated rather than deleted, each for a real reason: the defaults snapshot gained
  the new option, and the "incompatible-api" route test used `pluginApi + 1`, which is now a
  *supported* value — it derives an unsupported one instead.
