### PR TITLE
feat(plugins): make a plugin's runtime observable, and stop losing its state on every start

### DIFF
--- a/backend/src/common/constants/core-scheduler-jobs.ts
+++ b/backend/src/common/constants/core-scheduler-jobs.ts
@@ -15,3 +15,23 @@ export const CORE_SCHEDULER_JOB_NAMES = [
 ] as const;
 
 export type CoreSchedulerJobName = (typeof CORE_SCHEDULER_JOB_NAMES)[number];
+
+/**
+ * Core commands that have no cron but are triggerable by name from `POST /commands`. A plugin job
+ * sharing one of these names would never be reachable: the command dispatcher answers first.
+ */
+export const CORE_TRIGGER_ONLY_JOB_NAMES = [
+  'RescanAll',
+  'RefreshMissingMetadata',
+  'RescanMissingFiles',
+  'GenerateSprites',
+  'GenerateMissingSprites',
+  'DetectMarkers',
+  'DetectMissingMarkers',
+] as const;
+
+/** Every name a plugin job may not take, whether cron-driven or trigger-only. */
+export const RESERVED_CORE_JOB_NAMES: readonly string[] = [
+  ...CORE_SCHEDULER_JOB_NAMES,
+  ...CORE_TRIGGER_ONLY_JOB_NAMES,
+];

--- a/backend/src/modules/plugins/catalog/catalog.ts
+++ b/backend/src/modules/plugins/catalog/catalog.ts
@@ -97,8 +97,8 @@ export interface FilteredCatalogEntry {
   author: string;
   kind: PluginKind;
   logo?: string;
-  /** Only versions installable on this core build. A caller iterating this list can
-   *  never accidentally offer an incompatible version — there is no boolean to miss. */
+  /** Only versions installable on this core build, oldest to newest, so the last entry is the one
+   *  to offer as an update. A caller iterating this list cannot offer an incompatible version. */
   installable: CatalogVersionEntry[];
   /** Null when nothing is hidden. A plugin with an empty `installable` list still
    *  appears in the result, carrying this instead — never a bare empty page. */
@@ -144,6 +144,8 @@ export function filterCatalog(
       for (const version of entry.versions) {
         (isInstallable(version, supportedApiVersions, fliksVersion) ? installable : hidden).push(version);
       }
+      // A catalogue document lists versions in whatever order it likes; consumers read the last as newest.
+      installable.sort((a, b) => semver.compare(a.version, b.version));
       return {
         id: entry.id,
         name: entry.name,

--- a/backend/src/modules/plugins/host/fliks-host.service.spec.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.spec.ts
@@ -1294,9 +1294,11 @@ describe('FliksHostImpl', () => {
     it('writes under the derived prefix, never a bare key', async () => {
       const h = makeHarness('acme.tool');
       await h.host['config.set']({ key: 'foo', value: 'bar' });
+      // The third argument is the writer: it stops the config note echoing back to this plugin.
       expect(h.settings.set).toHaveBeenCalledWith(
         'plugin.acme.tool.foo',
         'bar',
+        'acme.tool',
       );
     });
   });

--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -898,10 +898,9 @@ export class FliksHostImpl implements PluginHostApi {
     key: string;
     value: string | null;
   }): Promise<void> {
-    await this.settings.set(
-      `plugin.${this.currentPluginId()}.${p.key}`,
-      p.value,
-    );
+    const pluginId = this.currentPluginId();
+    // Tagged with the writer so the config note is not echoed back to the plugin that made it.
+    await this.settings.set(`plugin.${pluginId}.${p.key}`, p.value, pluginId ?? undefined);
   }
 
   // ===========================================================================

--- a/backend/src/modules/plugins/plugin-install.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-install.service.spec.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosRequestConfig } from 'axios';
 import { createHash } from 'crypto';
-import { existsSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { PluginInstallService, installedPluginDir } from './plugin-install.service';
 import { PluginInstallException } from './plugin-install.exception';
@@ -362,6 +362,57 @@ describe('PluginInstallService', () => {
         detail: expect.any(String),
       });
       expect(repo.rows.get(manifest.id)?.status).toBe('failed');
+    });
+
+    it('records a deliberate downgrade and installs it, leaving no older directory behind', async () => {
+      const { buffer: newer, manifest: newerManifest } = signedDataArchive({ id: 'fliks.downgradeguard', version: '1.1.0' });
+      const newerStage = await service.inspectUpload(newer);
+      await service.confirmImport({ stagingId: newerStage.stagingId!, sha256: newerStage.sha256! });
+
+      const warn = jest.spyOn((service as unknown as { logger: { warn: (m: string) => void } }).logger, 'warn');
+      const { buffer: older } = signedDataArchive({ id: 'fliks.downgradeguard', version: '1.0.0' });
+      const olderStage = await service.inspectUpload(older);
+      await service.confirmImport({ stagingId: olderStage.stagingId!, sha256: olderStage.sha256! });
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('over the newer 1.1.0'));
+      expect(repo.rows.get(newerManifest.id)?.version).toBe('1.0.0');
+      expect(existsSync(installedPluginDir(newerManifest.id, '1.0.0'))).toBe(true);
+      expect(existsSync(installedPluginDir(newerManifest.id, '1.1.0'))).toBe(false);
+    });
+
+    it('reinstalling the exact same version still succeeds', async () => {
+      const { buffer, manifest } = signedDataArchive({ id: 'fliks.samereinstall', version: '1.0.0' });
+      const first = await service.inspectUpload(buffer);
+      await service.confirmImport({ stagingId: first.stagingId!, sha256: first.sha256! });
+
+      const second = await service.inspectUpload(buffer);
+      const result = await service.confirmImport({ stagingId: second.stagingId!, sha256: second.sha256! });
+
+      expect(result).toEqual({ pluginId: manifest.id, version: '1.0.0', status: 'active' });
+    });
+
+    it('VERDICT: an upgrade removes every older on-disk version of the same id, leaving other plugins untouched', async () => {
+      const { buffer: otherBuf, manifest: otherManifest } = signedDataArchive({ id: 'fliks.upgradesweepother', version: '1.0.0' });
+      const otherStage = await service.inspectUpload(otherBuf);
+      await service.confirmImport({ stagingId: otherStage.stagingId!, sha256: otherStage.sha256! });
+
+      const { buffer: firstBuf } = signedDataArchive({ id: 'fliks.upgradesweep', version: '1.0.0' });
+      const firstStage = await service.inspectUpload(firstBuf);
+      await service.confirmImport({ stagingId: firstStage.stagingId!, sha256: firstStage.sha256! });
+
+      // A directory no longer named by any row — what an interrupted upgrade leaves behind, and
+      // what removing only the immediately-previous version can never reach.
+      const stranded = installedPluginDir('fliks.upgradesweep', '0.9.0');
+      mkdirSync(stranded, { recursive: true });
+
+      const { buffer: nextBuf } = signedDataArchive({ id: 'fliks.upgradesweep', version: '1.1.0' });
+      const nextStage = await service.inspectUpload(nextBuf);
+      await service.confirmImport({ stagingId: nextStage.stagingId!, sha256: nextStage.sha256! });
+
+      expect(existsSync(stranded)).toBe(false);
+      expect(existsSync(installedPluginDir('fliks.upgradesweep', '1.0.0'))).toBe(false);
+      expect(existsSync(installedPluginDir('fliks.upgradesweep', '1.1.0'))).toBe(true);
+      expect(existsSync(installedPluginDir(otherManifest.id, '1.0.0'))).toBe(true);
     });
   });
 

--- a/backend/src/modules/plugins/plugin-install.service.ts
+++ b/backend/src/modules/plugins/plugin-install.service.ts
@@ -3,7 +3,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import axios from 'axios';
 import { createHash } from 'crypto';
-import { closeSync, existsSync, fsyncSync, openSync, rmSync } from 'fs';
+import { closeSync, fsyncSync, openSync, readdirSync, rmSync } from 'fs';
+import { basename, dirname, join } from 'path';
 import * as semver from 'semver';
 import { PluginPackage, PluginPackageOrigin, PluginPackageStatus } from './entities/plugin-package.entity';
 import { PluginSource } from './entities/plugin-source.entity';
@@ -13,7 +14,7 @@ import { PluginStagingService } from './plugin-staging.service';
 import { PluginDatabaseService } from './plugin-database.service';
 import { SettingsService } from '../settings/settings.service';
 import { PluginInstallException } from './plugin-install.exception';
-import { installedPluginDir, promoteDir } from './plugin-paths';
+import { installedPluginDir, pluginDataDir, promoteDir } from './plugin-paths';
 import { unsignedProcessAllowlist } from '../../common/constants/plugin-flags';
 import {
   inspect,
@@ -243,6 +244,8 @@ export class PluginInstallService {
     }
     await this.packageRepo.remove(pkg);
     rmSync(installedPluginDir(pkg.pluginId, pkg.version), { recursive: true, force: true });
+    // Same reason as the settings wipe above: a reinstall must not inherit what this one wrote.
+    rmSync(pluginDataDir(pkg.pluginId), { recursive: true, force: true });
   }
 
   /** Every `plugin.<id>.*` app setting this plugin owns. Ids contain dots, so one id can be a
@@ -358,6 +361,16 @@ export class PluginInstallService {
   /** P2 (fsync + rename) -> P3 (upsert the row) -> P4a (register). A P4a refusal leaves the row `failed`, install stands. */
   private async promote(buffer: Buffer, result: InspectSuccess, origin: PluginPackageOrigin): Promise<PluginInstallResult> {
     const { manifest } = result;
+
+    const existing = await this.packageRepo.findOne({ where: { pluginId: manifest.id } });
+    // Going back is a legitimate operator choice and the only rollback there is, so it is recorded
+    // rather than refused — the catalogue list is ordered, so it cannot be reached by accident.
+    if (existing && semver.lt(manifest.version, existing.version)) {
+      this.logger.warn(
+        `installing "${manifest.id}" ${manifest.version} over the newer ${existing.version}`,
+      );
+    }
+
     const extracted = await extractToStaging(buffer, manifest);
     if (!extracted.ok) {
       throw new PluginInstallException(HttpStatus.UNPROCESSABLE_ENTITY, extracted.code, extracted.detail);
@@ -373,10 +386,7 @@ export class PluginInstallService {
       }
     }
 
-    const existing = await this.packageRepo.findOne({ where: { pluginId: manifest.id } });
     const targetDir = installedPluginDir(manifest.id, manifest.version);
-    const previousDir =
-      existing && existing.version !== manifest.version ? installedPluginDir(existing.pluginId, existing.version) : null;
 
     try {
       for (const file of extracted.files) fsyncPath(file.path);
@@ -405,7 +415,7 @@ export class PluginInstallService {
       throw new PluginInstallException(HttpStatus.INTERNAL_SERVER_ERROR, 'PLUGIN_INSTALL_FAILED', (err as Error).message);
     }
 
-    if (previousDir && existsSync(previousDir)) rmSync(previousDir, { recursive: true, force: true });
+    this.removeOtherVersionDirs(saved.pluginId, targetDir);
 
     // An upgrade over a disabled plugin stores the new archive and stays off: reactivating it
     // silently would undo the operator's decision behind a version bump.
@@ -436,6 +446,25 @@ export class PluginInstallService {
     }
 
     return { pluginId: saved.pluginId, version: saved.version, status: 'active' };
+  }
+
+  /** Removes every other on-disk version of this plugin id, e.g. leftovers from upgrades before this
+   *  guard existed. `installedPluginDir(id, '')` gives the exact `<id>@` prefix — never hand-built,
+   *  so an id that is a dot-prefix of another one's (`acme` vs `acme.hello`) can't collide. */
+  private removeOtherVersionDirs(pluginId: string, keepDir: string): void {
+    const root = dirname(keepDir);
+    const prefix = basename(installedPluginDir(pluginId, ''));
+    const keepName = basename(keepDir);
+    let entries: string[];
+    try {
+      entries = readdirSync(root);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry === keepName || !entry.startsWith(prefix)) continue;
+      rmSync(join(root, entry), { recursive: true, force: true });
+    }
   }
 
   private async fetchArchive(zipUrl: string): Promise<Buffer> {

--- a/backend/src/modules/plugins/plugin-jobs.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-jobs.service.spec.ts
@@ -126,4 +126,69 @@ describe('PluginJobsService', () => {
       expect(processService.callPlugin).not.toHaveBeenCalled();
     });
   });
+
+  describe('overlap guard', () => {
+    const flush = () => new Promise((r) => setImmediate(r));
+
+    it('logs once on a completed run', async () => {
+      const registry = trackedRegistry();
+      const processService = fakeProcessService('ready');
+      const service = new PluginJobsService(registry, processService as never);
+      const logSpy = jest.spyOn((service as unknown as { logger: { log: (m: string) => void } }).logger, 'log');
+      service.replaceFor('fliks.p', [job()]);
+
+      service.trigger('fliks.p', 'sync');
+      await flush();
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('completed'));
+    });
+
+    it('skips and warns a second tick while the first is still in flight', async () => {
+      const registry = trackedRegistry();
+      let resolveCall!: () => void;
+      const pending = new Promise((r) => {
+        resolveCall = () => r({ ok: true });
+      });
+      const processService = fakeProcessService('ready');
+      processService.callPlugin.mockReturnValue(pending);
+      const service = new PluginJobsService(registry, processService as never);
+      const warnSpy = jest.spyOn((service as unknown as { logger: { warn: (m: string) => void } }).logger, 'warn');
+      service.replaceFor('fliks.p', [job()]);
+
+      service.trigger('fliks.p', 'sync');
+      expect(processService.callPlugin).toHaveBeenCalledTimes(1);
+
+      const second = service.trigger('fliks.p', 'sync');
+      expect(second).toEqual({ ok: false, reason: 'already-running' });
+      expect(processService.callPlugin).toHaveBeenCalledTimes(1);
+
+      // The warn belongs to the cron path: a manual trigger is refused before run() is entered.
+      for (const cron of registry.getCronJobs().values()) await cron.fireOnTick();
+      await flush();
+      expect(processService.callPlugin).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('in flight'));
+
+      resolveCall();
+      await flush();
+    });
+
+    it('releases the guard after a failure so the next tick runs', async () => {
+      const registry = trackedRegistry();
+      const processService = fakeProcessService('ready');
+      processService.callPlugin
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce({ ok: true });
+      const service = new PluginJobsService(registry, processService as never);
+      service.replaceFor('fliks.p', [job()]);
+
+      service.trigger('fliks.p', 'sync');
+      await flush();
+      expect(processService.callPlugin).toHaveBeenCalledTimes(1);
+
+      service.trigger('fliks.p', 'sync');
+      await flush();
+      expect(processService.callPlugin).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/backend/src/modules/plugins/plugin-jobs.service.ts
+++ b/backend/src/modules/plugins/plugin-jobs.service.ts
@@ -12,7 +12,9 @@ function cronKey(pluginId: string, name: string): string {
   return `plugin:${pluginId}:${name}`;
 }
 
-export type PluginJobTriggerResult = { ok: true } | { ok: false; reason: 'unknown-job' | 'not-triggerable' };
+export type PluginJobTriggerResult =
+  | { ok: true }
+  | { ok: false; reason: 'unknown-job' | 'not-triggerable' | 'already-running' };
 
 /**
  * Core owns every plugin's cron schedule via `SchedulerRegistry` — the plugin only ever
@@ -23,6 +25,8 @@ export type PluginJobTriggerResult = { ok: true } | { ok: false; reason: 'unknow
 export class PluginJobsService {
   private readonly logger = new Logger(PluginJobsService.name);
   private readonly declared = new Map<string, readonly PluginJob[]>();
+  /** Keyed by `cronKey` — shared between a cron tick and a manual trigger so they can't overlap. */
+  private readonly inFlight = new Set<string>();
 
   constructor(
     private readonly schedulerRegistry: SchedulerRegistry,
@@ -76,21 +80,31 @@ export class PluginJobsService {
     const job = this.declaredJob(pluginId, name);
     if (!job) return { ok: false, reason: 'unknown-job' };
     if (!job.triggerable) return { ok: false, reason: 'not-triggerable' };
+    if (this.inFlight.has(cronKey(pluginId, name))) return { ok: false, reason: 'already-running' };
     void this.run(pluginId, name);
     return { ok: true };
   }
 
-  /** Skips, rather than awaits, a plugin that isn't ready — a leaked hang here would back up
-   *  every future tick of this same cron. */
+  /** Skips, rather than awaits, a plugin that isn't ready — a leaked hang here would back up every
+   *  future tick of this same cron. One run at a time per job: a tick and a trigger share the guard. */
   private async run(pluginId: string, name: string): Promise<void> {
-    if (this.processService.stateOf(pluginId) !== 'ready') {
-      this.logger.warn(`skipping job "${name}" for plugin "${pluginId}" — process is not ready`);
+    const key = cronKey(pluginId, name);
+    if (this.inFlight.has(key)) {
+      this.logger.warn(`skipping job "${name}" for plugin "${pluginId}" — previous run still in flight`);
       return;
     }
+    this.inFlight.add(key);
     try {
+      if (this.processService.stateOf(pluginId) !== 'ready') {
+        this.logger.warn(`skipping job "${name}" for plugin "${pluginId}" — process is not ready`);
+        return;
+      }
       await this.processService.callPlugin(pluginId, 'job', { name, jobId: randomUUID() }, JOB_CALL_DEADLINE_MS);
+      this.logger.log(`job "${name}" for plugin "${pluginId}" completed`);
     } catch (err) {
       this.logger.warn(`job "${name}" for plugin "${pluginId}" failed: ${(err as Error).message}`);
+    } finally {
+      this.inFlight.delete(key);
     }
   }
 }

--- a/backend/src/modules/plugins/plugin-paths.ts
+++ b/backend/src/modules/plugins/plugin-paths.ts
@@ -12,6 +12,12 @@ export function installedPluginDir(pluginId: string, version: string): string {
   return join(getPluginsRuntimeDir(), 'installed', `${pluginId}@${version}`);
 }
 
+/** `${runtime dir}/data/<id>/` — keyed by id, not version, and outside `installed/`: a re-extraction
+ *  (every ordinary start) or an upgrade's new version directory never touches it. */
+export function pluginDataDir(pluginId: string): string {
+  return join(getPluginsRuntimeDir(), 'data', pluginId);
+}
+
 /** Same-filesystem rename when possible; copy+remove is the only option across devices. */
 export function promoteDir(srcDir: string, destDir: string): void {
   mkdirSync(dirname(destDir), { recursive: true });

--- a/backend/src/modules/plugins/plugin-process.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-process.service.spec.ts
@@ -32,6 +32,7 @@ class FakeSupervisor {
   startCalls = 0;
   stopCalls = 0;
   emitEvent = jest.fn();
+  emitConfigChanged = jest.fn();
   private listeners: ((s: SupervisorState) => void)[] = [];
 
   constructor(public readonly options: PluginSupervisorOptions) {}
@@ -97,11 +98,17 @@ function fakeLogBuffer() {
 }
 
 function fakeSettings(order: string[] = [], all: Record<string, string | null> = {}) {
+  const listeners: Array<(key: string) => void> = [];
   return {
     getAll: jest.fn(async () => {
       order.push('config');
       return all;
     }),
+    addChangeListener: jest.fn((cb: (key: string) => void) => {
+      listeners.push(cb);
+    }),
+    /** Test-only: fires every registered listener, exactly as `SettingsService.set` would. */
+    emitChange: (key: string) => listeners.forEach((cb) => cb(key)),
   };
 }
 
@@ -519,6 +526,36 @@ describe('PluginProcessService — lifecycle', () => {
     expect(instances[1].stopCalls).toBe(1);
     expect(service.stateOf(pkgA.pluginId)).toBeNull();
     expect(service.stateOf(pkgB.pluginId)).toBeNull();
+  });
+
+  it('saving a setting for plugin A pushes a config note naming only the changed key to A, and nothing to B', async () => {
+    const pluginDb = fakePluginDb();
+    const settings = fakeSettings();
+    const { factory, instances } = makeFactory();
+    const service = new PluginProcessService(pluginDb as never, fakeLogBuffer() as never, settings as never, factory);
+    const pkgA = fakePackage({}, { id: 'fliks.processsvc.a' });
+    const pkgB = fakePackage({}, { id: 'fliks.processsvc.b' });
+
+    const p1 = service.startFor(pkgA);
+    await waitForSupervisors(instances, 1);
+    instances[0].setState('ready');
+    await p1;
+    const p2 = service.startFor(pkgB);
+    await waitForSupervisors(instances, 2);
+    instances[1].setState('ready');
+    await p2;
+
+    settings.emitChange(`plugin.${pkgA.pluginId}.apiKey`);
+
+    expect(instances[0].emitConfigChanged).toHaveBeenCalledWith(['apiKey']);
+    expect(instances[1].emitConfigChanged).not.toHaveBeenCalled();
+  });
+
+  it('a settings key for a plugin that is not running is not an error', async () => {
+    const settings = fakeSettings();
+    const service = new PluginProcessService(fakePluginDb() as never, fakeLogBuffer() as never, settings as never, makeFactory().factory);
+
+    expect(() => settings.emitChange('plugin.fliks.never-started.apiKey')).not.toThrow();
   });
 
   it('emitToAll reaches every running supervisor regardless of state — the ring buffer decides queue vs. send', async () => {

--- a/backend/src/modules/plugins/plugin-process.service.ts
+++ b/backend/src/modules/plugins/plugin-process.service.ts
@@ -62,6 +62,20 @@ export class PluginProcessService implements OnApplicationShutdown {
     this.supervisorFactory = supervisorFactory ?? DEFAULT_FACTORY;
     this.startupTimeoutMs = startupTimeoutMs ?? DEFAULT_SUPERVISOR_OPTIONS.handshakeDeadlineMs;
     this.hostBinding = hostBinding ?? null;
+    this.settings.addChangeListener((key, origin) => this.onSettingChanged(key, origin));
+  }
+
+  /** Notes the one running plugin whose `plugin.<id>.` namespace owns `key`, with that key
+   *  unprefixed as `config.get` returns it. Ids are dotted, so the longest matching id wins. */
+  private onSettingChanged(key: string, origin?: string): void {
+    const prefix = 'plugin.';
+    if (!key.startsWith(prefix)) return;
+    let owner = '';
+    for (const id of this.running.keys()) {
+      if (key.startsWith(`${prefix}${id}.`) && id.length > owner.length) owner = id;
+    }
+    if (!owner || owner === origin) return;
+    this.running.get(owner)?.supervisor.emitConfigChanged([key.slice(prefix.length + owner.length + 1)]);
   }
 
   /** Stop -> materialise -> provision-check -> rotate -> config -> spawn; each stage's failure

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -38,7 +38,7 @@ import { PluginRouteTable, type ResolvedPluginRoute } from './proxy/plugin-route
 import { parseDeclaredPolicy } from './proxy/policy-vocabulary';
 import { parseObjectGuard } from './proxy/plugin-object-guards.service';
 import { PLUGIN_PERMISSION_NAME_PATTERN, pluginPermissionSubject } from '../../common/constants/plugin-permissions';
-import { CORE_SCHEDULER_JOB_NAMES } from '../../common/constants/core-scheduler-jobs';
+import { RESERVED_CORE_JOB_NAMES } from '../../common/constants/core-scheduler-jobs';
 
 const WEBHOOK_EVENT_NAMES: ReadonlySet<string> = new Set(PLUGIN_WEBHOOK_EVENT_NAMES);
 
@@ -63,7 +63,7 @@ const KNOWN_HTTP_METHODS: ReadonlySet<string> = new Set(['GET', 'POST', 'PUT', '
 /** Shared so a plugin with nothing declared doesn't cost an allocation per lookup. */
 const EMPTY_SUBJECT_SET: ReadonlySet<string> = new Set();
 
-const CORE_JOB_NAME_SET: ReadonlySet<string> = new Set(CORE_SCHEDULER_JOB_NAMES);
+const CORE_JOB_NAME_SET: ReadonlySet<string> = new Set(RESERVED_CORE_JOB_NAMES);
 
 const RELEASE_PICKER_CONTEXTS: readonly (keyof ReleasePickerRoutes)[] = ['movie', 'season', 'episode'];
 /** The method each `releasePicker` action's declared route must carry. */

--- a/backend/src/modules/plugins/supervisor/__fixtures__/fixture-plugin.js
+++ b/backend/src/modules/plugins/supervisor/__fixtures__/fixture-plugin.js
@@ -87,6 +87,13 @@ if (mode === 'never-connect') {
         const n = Number(mode.split(':')[1]);
         if (healthCount > n) return; // stop answering from here on
       }
+      if (mode.startsWith('health-not-ok-after:')) {
+        const n = Number(mode.split(':')[1]);
+        if (healthCount > n) {
+          send(sock, { i: req.i, r: { ok: false, detail: 'fixture unhealthy' } });
+          return;
+        }
+      }
       send(sock, { i: req.i, r: { ok: true } });
       return;
     }

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.spec.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.spec.ts
@@ -1,9 +1,10 @@
-import { existsSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { connect } from 'net';
 import { basename, dirname, join } from 'path';
 import { DEFAULT_SUPERVISOR_OPTIONS, PluginSupervisor, type PluginSupervisorOptions } from './plugin-supervisor';
 import { RpcChannel } from './rpc-channel';
 import { pidFilePath } from './pid-file';
+import { pluginDataDir } from '../plugin-paths';
 import { PLUGIN_API_VERSION, type PluginHostApi } from '../../../common/plugin-contract';
 import {
   delay,
@@ -181,6 +182,100 @@ describe('liveness', () => {
     await waitForState(sup, 'backoff');
     expect(seen).toEqual(expect.arrayContaining(['ready', 'degraded', 'crashed', 'backoff']));
     expect(seen.indexOf('degraded')).toBeLessThan(seen.lastIndexOf('crashed'));
+  }, 10_000);
+
+  it('an ok:false health reply counts as a miss on the same ladder, and its detail is logged', async () => {
+    const logBuffer = newLogBuffer();
+    const dir = makeFixtureDir('health-not-ok-after:1');
+    const runtimeDir = makeRuntimeDir();
+    dirsToClean.push(dir, runtimeDir);
+    const sup = new PluginSupervisor({
+      id: 'health-not-ok',
+      dir,
+      runtimeDir,
+      logBuffer,
+      handshakeDeadlineMs: 250,
+      healthIntervalMs: 60,
+      healthDeadlineMs: 30,
+      backoffLadderMs: [15, 30, 60, 120, 240, 400],
+      readyResetMs: 300,
+      breakerWindowMs: 600,
+      breakerMaxCrashes: 6,
+      shutdownRpcDeadlineMs: 100,
+      sigtermGraceMs: 80,
+    });
+    supervisorsToStop.push(sup);
+
+    const seen: string[] = [];
+    sup.onStateChange((s) => seen.push(s));
+    await sup.start();
+    await waitForState(sup, 'ready');
+    await waitForState(sup, 'degraded');
+    await waitForState(sup, 'backoff');
+
+    expect(seen.indexOf('degraded')).toBeLessThan(seen.lastIndexOf('crashed'));
+    expect(
+      logBuffer.getEntries({ q: 'fixture unhealthy' }).some((e) => e.level === 'warn'),
+    ).toBe(true);
+  }, 10_000);
+});
+
+describe('data directory', () => {
+  it('is keyed by plugin id outside the code dir, so it survives the code dir being wiped and recreated — as a restart\'s re-extraction does', async () => {
+    const id = 'data-persist';
+    const firstDir = makeFixtureDir('good');
+    const runtimeDir1 = makeRuntimeDir();
+    dirsToClean.push(firstDir, runtimeDir1);
+    const sup1 = new PluginSupervisor({
+      id,
+      dir: firstDir,
+      runtimeDir: runtimeDir1,
+      logBuffer: newLogBuffer(),
+      handshakeDeadlineMs: 250,
+      healthIntervalMs: 60,
+      healthDeadlineMs: 30,
+      backoffLadderMs: [15, 30],
+      readyResetMs: 300,
+      breakerWindowMs: 600,
+      breakerMaxCrashes: 6,
+      shutdownRpcDeadlineMs: 100,
+      sigtermGraceMs: 80,
+    });
+    supervisorsToStop.push(sup1);
+    await sup1.start();
+    await waitForState(sup1, 'ready');
+
+    const dataDir = pluginDataDir(id);
+    dirsToClean.push(dataDir);
+    expect(existsSync(dataDir)).toBe(true);
+    expect(existsSync(join(firstDir, 'data'))).toBe(false);
+    writeFileSync(join(dataDir, 'marker.txt'), 'hello');
+    await sup1.stop();
+
+    rmSync(firstDir, { recursive: true, force: true }); // promoteDir()'s rmSync(destDir), on every ordinary start
+    const secondDir = makeFixtureDir('good'); // a fresh extraction target, as materialise() builds
+    const runtimeDir2 = makeRuntimeDir();
+    dirsToClean.push(secondDir, runtimeDir2);
+    const sup2 = new PluginSupervisor({
+      id,
+      dir: secondDir,
+      runtimeDir: runtimeDir2,
+      logBuffer: newLogBuffer(),
+      handshakeDeadlineMs: 250,
+      healthIntervalMs: 60,
+      healthDeadlineMs: 30,
+      backoffLadderMs: [15, 30],
+      readyResetMs: 300,
+      breakerWindowMs: 600,
+      breakerMaxCrashes: 6,
+      shutdownRpcDeadlineMs: 100,
+      sigtermGraceMs: 80,
+    });
+    supervisorsToStop.push(sup2);
+    await sup2.start();
+    await waitForState(sup2, 'ready');
+
+    expect(readFileSync(join(dataDir, 'marker.txt'), 'utf8')).toBe('hello');
   }, 10_000);
 });
 

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
@@ -7,9 +7,11 @@ import { getPluginsSocketDir } from '../../../common/constants/paths';
 import type { OnApplicationShutdown } from '@nestjs/common';
 import { LogBufferService } from '../../scheduler/log-buffer.service';
 import { CURRENT_FLIKS_VERSION } from '../plugin-version';
+import { pluginDataDir } from '../plugin-paths';
 import type { PluginApi } from '../../../common/plugin-contract';
 
 type HelloReply = Awaited<ReturnType<PluginApi['hello']>>;
+type HealthReply = Awaited<ReturnType<PluginApi['health']>>;
 import { PLUGIN_API_VERSION, type Note, type PluginHostApi } from '../../../common/plugin-contract';
 import { RpcChannel } from './rpc-channel';
 import { NoteRingBuffer } from './note-ring-buffer';
@@ -255,6 +257,12 @@ export class PluginSupervisor implements OnApplicationShutdown {
     this.flushRing();
   }
 
+  /** Same ring buffer as `emitEvent` — `changed` are this plugin's own setting keys, unprefixed. */
+  emitConfigChanged(changed: string[]): void {
+    this.ring.push({ m: 'config', p: { changed } });
+    this.flushRing();
+  }
+
   async start(): Promise<void> {
     if (this.state !== 'stopped') return;
     this.stopRequested = false;
@@ -415,13 +423,15 @@ export class PluginSupervisor implements OnApplicationShutdown {
     this.lastExitSignal = null;
 
     this.setState('starting');
+    const dataDir = pluginDataDir(this.opts.id);
     const dropTo = this.dropTarget();
-    if (dropTo) prepareDirForDroppedChild(this.opts.dir, dropTo.uid, dropTo.gid);
-    else mkdirSync(join(this.opts.dir, 'data'), { recursive: true });
+    if (dropTo) prepareDirForDroppedChild(this.opts.dir, dataDir, dropTo.uid, dropTo.gid);
+    else mkdirSync(dataDir, { recursive: true });
     this.token = randomBytes(32).toString('hex');
 
     const plan = buildSpawnPlan({
       dir: this.opts.dir,
+      dataDir,
       memoryMb: this.opts.memoryMb,
       coreSockPath: this.coreSockPath,
       pluginSockPath: this.pluginSockPath,
@@ -550,7 +560,14 @@ export class PluginSupervisor implements OnApplicationShutdown {
     if (!this.pluginChannel) return;
     this.healthCheckCount++;
     try {
-      await this.pluginChannel.call('health', {}, this.opts.healthDeadlineMs);
+      const reply = await this.pluginChannel.call<HealthReply>('health', {}, this.opts.healthDeadlineMs);
+      if (!reply.ok) {
+        this.opts.logBuffer.warn(
+          `health check reported unhealthy: ${reply.detail || '(no detail)'}`,
+          `plugin:${this.opts.id}`,
+        );
+        throw new Error(reply.detail || 'health check reported unhealthy');
+      }
       this.consecutiveHealthMisses = 0;
       if (this.state === 'degraded') this.enterReady();
     } catch {

--- a/backend/src/modules/plugins/supervisor/spawn-plan.spec.ts
+++ b/backend/src/modules/plugins/supervisor/spawn-plan.spec.ts
@@ -1,6 +1,6 @@
-import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { PLUGIN_API_VERSION, SUPPORTED_PLUGIN_API_VERSIONS } from '../../../common/plugin-contract';
 import {
   buildSpawnPlan,
@@ -46,6 +46,7 @@ describe('shouldDropPrivileges', () => {
 describe('buildSpawnPlan', () => {
   const baseInput = {
     dir: '/tmp/plugin-x',
+    dataDir: '/tmp/plugin-x-data/demo',
     memoryMb: 256,
     coreSockPath: '/tmp/plugin-x.core.sock',
     pluginSockPath: '/tmp/plugin-x.plugin.sock',
@@ -76,7 +77,7 @@ describe('buildSpawnPlan', () => {
     expect(older).toBeDefined();
     const plan = buildSpawnPlan({ ...baseInput, pluginApi: older as number });
     expect(plan.env.FLIKS_API_VERSION).toBe(String(older));
-    expect(plan.env.HOME).toBe(`${baseInput.dir}/data`);
+    expect(plan.env.HOME).toBe(baseInput.dataDir);
     expect(plan.env.NODE_ENV).toBe('production');
   });
 
@@ -96,7 +97,8 @@ describe('buildSpawnPlan', () => {
       process.execPath,
       resolvePermissionFlag(),
       `--allow-fs-read=${baseInput.dir}`,
-      `--allow-fs-write=${baseInput.dir}/data`,
+      `--allow-fs-read=${baseInput.dataDir}`,
+      `--allow-fs-write=${baseInput.dataDir}`,
       `--max-old-space-size=${baseInput.memoryMb}`,
       '--disable-proto=delete',
       `${baseInput.dir}/plugin.js`,
@@ -123,7 +125,7 @@ describe('buildSpawnPlan', () => {
 
   it('cwd is the plugin data dir, stdio never carries the RPC channel', () => {
     const plan = buildSpawnPlan(baseInput);
-    expect(plan.options.cwd).toBe(`${baseInput.dir}/data`);
+    expect(plan.options.cwd).toBe(baseInput.dataDir);
     expect(plan.options.stdio).toEqual(['ignore', 'pipe', 'pipe']);
   });
 });
@@ -134,11 +136,16 @@ describe('prepareDirForDroppedChild', () => {
   const uid = process.getuid!();
   const gid = process.getgid!();
   let dir: string;
+  let dataDir: string;
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'spawn-plan-perm-'));
+    dataDir = join(mkdtempSync(join(tmpdir(), 'spawn-plan-data-')), 'demo');
   });
-  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(dirname(dataDir), { recursive: true, force: true });
+  });
 
   const mode = (p: string) => statSync(p).mode & 0o777;
 
@@ -148,28 +155,40 @@ describe('prepareDirForDroppedChild', () => {
     writeFileSync(join(dir, 'plugin.js'), 'x', { mode: 0o600 });
     writeFileSync(join(dir, 'logo.svg'), '<svg/>', { mode: 0o600 });
 
-    prepareDirForDroppedChild(dir, uid, gid);
+    prepareDirForDroppedChild(dir, dataDir, uid, gid);
 
     expect(mode(dir)).toBe(0o755);
     expect(mode(join(dir, 'plugin.js'))).toBe(0o644);
     expect(mode(join(dir, 'logo.svg'))).toBe(0o644);
   });
 
-  it('hands the scratch dir to the child and nothing else', () => {
-    prepareDirForDroppedChild(dir, uid, gid);
+  it('hands the data dir to the child and nothing else, outside the code dir', () => {
+    prepareDirForDroppedChild(dir, dataDir, uid, gid);
 
-    const data = statSync(join(dir, 'data'));
+    const data = statSync(dataDir);
     expect(data.isDirectory()).toBe(true);
     expect(data.uid).toBe(uid);
-    expect(mode(join(dir, 'data'))).toBe(0o700);
+    expect(mode(dataDir)).toBe(0o700);
+    expect(existsSync(join(dir, 'data'))).toBe(false);
+  });
+
+  it('survives the code dir being wiped and recreated, as a restart\'s re-extraction does', () => {
+    prepareDirForDroppedChild(dir, dataDir, uid, gid);
+    writeFileSync(join(dataDir, 'marker.txt'), 'hello');
+
+    rmSync(dir, { recursive: true, force: true }); // promoteDir()'s rmSync(destDir)
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    prepareDirForDroppedChild(dir, dataDir, uid, gid);
+
+    expect(existsSync(join(dataDir, 'marker.txt'))).toBe(true);
   });
 
   it('is idempotent across restarts', () => {
     writeFileSync(join(dir, 'plugin.js'), 'x', { mode: 0o600 });
-    prepareDirForDroppedChild(dir, uid, gid);
-    prepareDirForDroppedChild(dir, uid, gid);
+    prepareDirForDroppedChild(dir, dataDir, uid, gid);
+    prepareDirForDroppedChild(dir, dataDir, uid, gid);
 
     expect(mode(join(dir, 'plugin.js'))).toBe(0o644);
-    expect(mode(join(dir, 'data'))).toBe(0o700);
+    expect(mode(dataDir)).toBe(0o700);
   });
 });

--- a/backend/src/modules/plugins/supervisor/spawn-plan.ts
+++ b/backend/src/modules/plugins/supervisor/spawn-plan.ts
@@ -1,6 +1,6 @@
 import { spawnSync, type SpawnOptions } from 'child_process';
 import { chmodSync, chownSync, mkdirSync, readdirSync } from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { type PluginSpawnEnv } from '../../../common/plugin-contract';
 
 /** The unprivileged identity a plugin child drops to when core runs as root. */
@@ -26,13 +26,22 @@ export function shouldDropPrivileges(platform: NodeJS.Platform, getuid?: () => n
 }
 
 /**
- * A dropped child must reach its own code and its scratch dir through the kernel,
- * not just through `--allow-fs-*`: extraction writes 0600 root-owned files into a
- * 0700 directory. Code stays root-owned and read-only to the child; only `data/`
- * changes hands.
+ * A dropped child must reach its own code and its data dir through the kernel, not just
+ * `--allow-fs-*`: extraction writes 0600 root-owned files into a 0700 directory. Code stays
+ * root-owned and read-only to the child; `dataDir` (outside the code tree, keyed by plugin id —
+ * see `pluginDataDir`) is what changes hands. Its shared parent is `0710`, group-owned by the
+ * drop gid: a dropped child can reach its own known path but not list a sibling plugin's.
  */
-export function prepareDirForDroppedChild(dir: string, uid = PLUGIN_CHILD_UID, gid = PLUGIN_CHILD_GID): void {
-  const dataDir = join(dir, 'data');
+export function prepareDirForDroppedChild(
+  dir: string,
+  dataDir: string,
+  uid = PLUGIN_CHILD_UID,
+  gid = PLUGIN_CHILD_GID,
+): void {
+  const dataParent = dirname(dataDir);
+  mkdirSync(dataParent, { recursive: true });
+  chmodSync(dataParent, 0o710);
+  chownSync(dataParent, -1, gid);
   mkdirSync(dataDir, { recursive: true });
   chmodSync(dir, 0o755);
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -44,6 +53,8 @@ export function prepareDirForDroppedChild(dir: string, uid = PLUGIN_CHILD_UID, g
 
 export interface SpawnPlanInput {
   dir: string;
+  /** `pluginDataDir(pluginId)` — outside `dir`, so it outlives this spawn's code tree. */
+  dataDir: string;
   memoryMb: number;
   coreSockPath: string;
   pluginSockPath: string;
@@ -78,10 +89,12 @@ function reKeyConfig(pluginId: string, config: Record<string, string>): Record<s
 
 /** Builds the exact argv/env from "The spawn call and the supervisor" — never `...process.env`. */
 export function buildSpawnPlan(input: SpawnPlanInput): SpawnPlan {
-  const homeDir = `${input.dir}/data`;
+  const homeDir = input.dataDir;
   const nodeArgv = [
     resolvePermissionFlag(),
     `--allow-fs-read=${input.dir}`,
+    // The data dir sits outside the code tree, so it needs its own read grant to be readable back.
+    `--allow-fs-read=${homeDir}`,
     `--allow-fs-write=${homeDir}`,
     `--max-old-space-size=${input.memoryMb}`,
     '--disable-proto=delete',

--- a/backend/src/modules/plugins/supervisor/supervisor-test-helpers.ts
+++ b/backend/src/modules/plugins/supervisor/supervisor-test-helpers.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, copyFileSync, mkdirSync, writeFileSync } from 'fs';
+import { mkdtempSync, copyFileSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { EventEmitter } from 'events';
@@ -18,7 +18,6 @@ const FIXTURE_SOURCE = join(__dirname, '__fixtures__/fixture-plugin.js');
 /** A fresh `dir` with the real fixture plugin at `plugin.js` and its mode file next to it. */
 export function makeFixtureDir(mode: string): string {
   const dir = mkdtempSync(join(tmpdir(), 'plugin-sup-dir-'));
-  mkdirSync(join(dir, 'data'), { recursive: true });
   copyFileSync(FIXTURE_SOURCE, join(dir, 'plugin.js'));
   writeFileSync(join(dir, 'FIXTURE_MODE'), mode);
   return dir;

--- a/backend/src/modules/scheduler/scheduler.service.spec.ts
+++ b/backend/src/modules/scheduler/scheduler.service.spec.ts
@@ -1,0 +1,71 @@
+import { BadRequestException } from '@nestjs/common';
+import { SchedulerService } from './scheduler.service';
+import { PluginJobsService } from '../plugins/plugin-jobs.service';
+import { ScheduledJobRegistry } from './scheduled-job-registry.service';
+
+function fakePluginJobs(overrides: Partial<Record<'listDeclared' | 'trigger', jest.Mock>> = {}) {
+  return {
+    listDeclared: jest.fn().mockReturnValue([]),
+    trigger: jest.fn(),
+    ...overrides,
+  };
+}
+
+/** Only `commandRepo`+`pluginJobs`+`jobRegistry` are ever touched by `triggerCommand`'s
+ *  unknown-name and plugin-job branches — every other dependency stays an unused stub. */
+function makeService(pluginJobs: ReturnType<typeof fakePluginJobs>, jobRegistry: { list: jest.Mock } = { list: jest.fn().mockReturnValue([]) }) {
+  const unused = {} as never;
+  return new SchedulerService(
+    unused,
+    unused,
+    unused,
+    unused,
+    unused,
+    unused,
+    unused,
+    unused,
+    unused,
+    unused,
+    unused,
+    pluginJobs as unknown as PluginJobsService,
+    jobRegistry as unknown as ScheduledJobRegistry,
+  );
+}
+
+describe('SchedulerService.triggerCommand', () => {
+  it('routes a declared plugin job name through PluginJobsService.trigger()', async () => {
+    const pluginJobs = fakePluginJobs({
+      listDeclared: jest.fn().mockReturnValue([
+        { pluginId: 'fliks.p', job: { name: 'sync', cron: '0 0 * * *', triggerable: true, labelKey: 'k' } },
+      ]),
+      trigger: jest.fn().mockReturnValue({ ok: true }),
+    });
+    const service = makeService(pluginJobs);
+
+    const result = await service.triggerCommand('sync');
+
+    expect(pluginJobs.trigger).toHaveBeenCalledWith('fliks.p', 'sync');
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('400s a declared-but-not-triggerable plugin job instead of dispatching it', async () => {
+    const pluginJobs = fakePluginJobs({
+      listDeclared: jest.fn().mockReturnValue([
+        { pluginId: 'fliks.p', job: { name: 'sync', cron: '0 0 * * *', triggerable: false, labelKey: 'k' } },
+      ]),
+      trigger: jest.fn().mockReturnValue({ ok: false, reason: 'not-triggerable' }),
+    });
+    const service = makeService(pluginJobs);
+
+    await expect(service.triggerCommand('sync')).rejects.toThrow(/not triggerable/);
+    expect(pluginJobs.trigger).toHaveBeenCalledWith('fliks.p', 'sync');
+  });
+
+  it('still 400s a name that is neither a core command nor a declared plugin job', async () => {
+    const pluginJobs = fakePluginJobs();
+    const service = makeService(pluginJobs);
+
+    await expect(service.triggerCommand('NoSuchJob')).rejects.toThrow(BadRequestException);
+    expect(pluginJobs.trigger).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   Injectable,
   Logger,
   OnModuleInit,
@@ -25,7 +26,7 @@ import {
   buildSpriteLabel,
 } from '../streaming/thumbnail.service';
 import { MarkersService } from '../markers/markers.service';
-import { CoreSchedulerJobName } from '../../common/constants/core-scheduler-jobs';
+import { CORE_TRIGGER_ONLY_JOB_NAMES, CoreSchedulerJobName } from '../../common/constants/core-scheduler-jobs';
 import { PluginJobsService } from '../plugins/plugin-jobs.service';
 import { ScheduledJobRegistry } from './scheduled-job-registry.service';
 import { runAuditedCommand } from './command-audit.util';
@@ -181,7 +182,7 @@ export class SchedulerService implements OnModuleInit {
     return [...core, ...plugins];
   }
 
-  async triggerCommand(name: string): Promise<Command> {
+  async triggerCommand(name: string): Promise<Command | { ok: true }> {
     const known = [
       ...SchedulerService.SCHEDULERS.filter((s) => s.triggerable).map(
         (s) => s.name,
@@ -190,15 +191,21 @@ export class SchedulerService implements OnModuleInit {
         .list()
         .filter((j) => j.triggerable)
         .map((j) => j.name),
-      'RescanAll',
-      'RefreshMissingMetadata',
-      'RescanMissingFiles',
-      'GenerateSprites',
-      'GenerateMissingSprites',
-      'DetectMarkers',
-      'DetectMissingMarkers',
+      ...CORE_TRIGGER_ONLY_JOB_NAMES,
     ];
     if (!known.includes(name)) {
+      // Registration refuses every reserved core name, so a match here is a plugin's own job.
+      const declared = this.pluginJobs
+        .listDeclared()
+        .find((d) => d.job.name === name);
+      if (declared) {
+        const result = this.pluginJobs.trigger(declared.pluginId, name);
+        if (result.ok) return { ok: true };
+        if (result.reason === 'already-running') {
+          throw new ConflictException(`Job "${name}" is already running`);
+        }
+        throw new BadRequestException(`Job "${name}" is ${result.reason.replace('-', ' ')}`);
+      }
       // A caller-input error (unknown name, or a job its owning plugin just
       // dropped) — not a server fault, so 400 rather than an unhandled throw.
       throw new BadRequestException(

--- a/backend/src/modules/settings/settings.service.ts
+++ b/backend/src/modules/settings/settings.service.ts
@@ -12,16 +12,17 @@ export class SettingsService {
     private readonly events: EventsService,
   ) {}
 
-  private readonly changeListeners: Array<(key: string) => void> = [];
+  private readonly changeListeners: Array<(key: string, origin?: string) => void> = [];
 
-  addChangeListener(listener: (key: string) => void): void {
+  /** `origin` names whoever wrote the key, so a listener can skip echoing a change back to it. */
+  addChangeListener(listener: (key: string, origin?: string) => void): void {
     this.changeListeners.push(listener);
   }
 
-  private notifyChange(key: string): void {
+  private notifyChange(key: string, origin?: string): void {
     for (const l of this.changeListeners) {
       try {
-        l(key);
+        l(key, origin);
       } catch {
         /* listener errors must not break writes */
       }
@@ -39,7 +40,7 @@ export class SettingsService {
     return row?.value ?? null;
   }
 
-  async set(key: string, value: string | null): Promise<AppSetting> {
+  async set(key: string, value: string | null, origin?: string): Promise<AppSetting> {
     let row = await this.repo.findOne({ where: { key } });
     if (row) {
       row.value = value;
@@ -47,7 +48,7 @@ export class SettingsService {
       row = this.repo.create({ key, value });
     }
     const saved = await this.repo.save(row);
-    this.notifyChange(key);
+    this.notifyChange(key, origin);
     return saved;
   }
 

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2194,7 +2194,8 @@
         "update_keeps_data": "Deine Einstellungen bleiben erhalten."
       },
       "status_disabled": "Deaktiviert",
-      "status_unavailable": "Nicht verfügbar"
+      "status_unavailable": "Nicht verfügbar",
+      "status_message_toggle": "Details ansehen"
     }
   },
   "roles": {

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2221,7 +2221,8 @@
         "update_keeps_data": "Your settings are kept."
       },
       "status_disabled": "Disabled",
-      "status_unavailable": "Unavailable"
+      "status_unavailable": "Unavailable",
+      "status_message_toggle": "View details"
     }
   },
   "roles": {

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2194,7 +2194,8 @@
         "update_keeps_data": "Se conservan tus ajustes."
       },
       "status_disabled": "Desactivado",
-      "status_unavailable": "No disponible"
+      "status_unavailable": "No disponible",
+      "status_message_toggle": "Ver los detalles"
     }
   },
   "roles": {

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2221,7 +2221,8 @@
         "update_keeps_data": "Vos réglages sont conservés."
       },
       "status_disabled": "Désactivé",
-      "status_unavailable": "Indisponible"
+      "status_unavailable": "Indisponible",
+      "status_message_toggle": "Voir les détails"
     }
   },
   "roles": {

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2194,7 +2194,8 @@
         "update_keeps_data": "Le tue impostazioni sono conservate."
       },
       "status_disabled": "Disattivato",
-      "status_unavailable": "Non disponibile"
+      "status_unavailable": "Non disponibile",
+      "status_message_toggle": "Vedi i dettagli"
     }
   },
   "roles": {

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2194,7 +2194,8 @@
         "update_keeps_data": "As tuas configurações são mantidas."
       },
       "status_disabled": "Desativado",
-      "status_unavailable": "Indisponível"
+      "status_unavailable": "Indisponível",
+      "status_message_toggle": "Ver os detalhes"
     }
   },
   "roles": {

--- a/client/src/app/features/admin/settings-icon.html
+++ b/client/src/app/features/admin/settings-icon.html
@@ -2,5 +2,11 @@
   @case ('bar-chart-3') { <svg lucideBarChart3></svg> }
   @case ('layout-grid') { <svg lucideLayoutGrid></svg> }
   @case ('play') { <svg lucidePlay></svg> }
+  @case ('webhook') { <svg lucideWebhook></svg> }
+  @case ('download') { <svg lucideDownload></svg> }
+  @case ('search') { <svg lucideSearch></svg> }
+  @case ('server') { <svg lucideServer></svg> }
+  @case ('history') { <svg lucideHistory></svg> }
+  @case ('settings') { <svg lucideSettings></svg> }
   @default { <svg lucideCircle></svg> }
 }

--- a/client/src/app/features/admin/settings-icon.spec.ts
+++ b/client/src/app/features/admin/settings-icon.spec.ts
@@ -1,0 +1,35 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { SettingsIconComponent } from './settings-icon';
+
+/** The rendered SVG children, not the attribute: an unimported directive still leaves its
+ *  attribute in the template's markup, so only the drawn paths prove the icon resolved. */
+function renderIcon(name: string): string {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
+  const fixture = TestBed.createComponent(SettingsIconComponent);
+  fixture.componentRef.setInput('name', name);
+  fixture.detectChanges();
+  return (fixture.nativeElement as HTMLElement).querySelector('svg')!.innerHTML;
+}
+
+describe('SettingsIconComponent', () => {
+  const declaredByRealPlugins = ['webhook', 'download', 'search', 'server', 'history', 'settings'];
+
+  for (const name of declaredByRealPlugins) {
+    it(`draws an icon for "${name}", a name real plugins declare`, () => {
+      expect(renderIcon(name).trim().length).toBeGreaterThan(0);
+    });
+  }
+
+  it('draws a different icon per name rather than one shared glyph', () => {
+    const drawn = declaredByRealPlugins.map(renderIcon);
+    expect(new Set(drawn).size).toBe(declaredByRealPlugins.length);
+  });
+
+  it('falls back to a drawn circle for a name it does not know', () => {
+    const fallback = renderIcon('some-plugin-invented-name');
+    expect(fallback.trim().length).toBeGreaterThan(0);
+    expect(fallback).toBe(renderIcon('another-unknown-name'));
+  });
+});

--- a/client/src/app/features/admin/settings-icon.ts
+++ b/client/src/app/features/admin/settings-icon.ts
@@ -1,5 +1,16 @@
 import { Component, ChangeDetectionStrategy, input } from '@angular/core';
-import { LucideBarChart3, LucideLayoutGrid, LucidePlay, LucideCircle } from '@lucide/angular';
+import {
+  LucideBarChart3,
+  LucideLayoutGrid,
+  LucidePlay,
+  LucideCircle,
+  LucideWebhook,
+  LucideDownload,
+  LucideSearch,
+  LucideServer,
+  LucideHistory,
+  LucideSettings,
+} from '@lucide/angular';
 
 /**
  * Renders a `settings.page` contribution's icon by name — a plugin can name
@@ -8,7 +19,18 @@ import { LucideBarChart3, LucideLayoutGrid, LucidePlay, LucideCircle } from '@lu
 @Component({
   selector: 'app-settings-icon',
   standalone: true,
-  imports: [LucideBarChart3, LucideLayoutGrid, LucidePlay, LucideCircle],
+  imports: [
+    LucideBarChart3,
+    LucideLayoutGrid,
+    LucidePlay,
+    LucideCircle,
+    LucideWebhook,
+    LucideDownload,
+    LucideSearch,
+    LucideServer,
+    LucideHistory,
+    LucideSettings,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './settings-icon.html',
   styles: [`:host { display: inline-flex; } svg { width: 100%; height: 100%; }`],

--- a/client/src/app/features/settings/plugins/plugins.html
+++ b/client/src/app/features/settings/plugins/plugins.html
@@ -85,6 +85,14 @@
                 @if (row.status === 'failed' && row.statusReason) {
                   <p class="text-xs text-error/80 mt-1 max-w-[16rem]">{{ row.statusReason }}</p>
                 }
+                @if (row.statusMessage) {
+                  <details class="mt-1">
+                    <summary class="text-xs text-warning/80 cursor-pointer select-none">
+                      {{ 'settings.plugins.status_message_toggle' | translate }}
+                    </summary>
+                    <pre class="text-xs whitespace-pre-wrap break-words max-w-xs max-h-40 overflow-auto bg-base-200 rounded p-2 mt-1">{{ row.statusMessage }}</pre>
+                  </details>
+                }
               </td>
               <td>
                 <app-toggle-field

--- a/client/src/app/features/settings/plugins/plugins.spec.ts
+++ b/client/src/app/features/settings/plugins/plugins.spec.ts
@@ -131,4 +131,19 @@ describe('PluginsSettingsComponent — enable/disable toggle', () => {
     expect(badges).toContain('settings.plugins.status_unavailable');
     expect(badges).not.toContain('settings.plugins.status_active');
   });
+
+  it('a row carrying a statusMessage renders the stderr tail', async () => {
+    const { fixture } = await createComponent([
+      { ...ROW, kind: 'process', processState: 'backoff', statusMessage: 'bad hello token\nexiting' },
+    ]);
+
+    const pre = (fixture.nativeElement as HTMLElement).querySelector('tbody details pre');
+    expect(pre?.textContent).toContain('bad hello token');
+  });
+
+  it('a row with no statusMessage renders no details toggle', async () => {
+    const { fixture } = await createComponent([{ ...ROW, statusMessage: '' }]);
+
+    expect((fixture.nativeElement as HTMLElement).querySelector('tbody details')).toBeNull();
+  });
 });

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -134,6 +134,17 @@ these, set once at spawn (`supervisor/spawn-plan.ts`):
   prepend `FLIKS_CFG_`. Not a fixed set — read whichever names your own manifest's settings
   resolve to.
 
+### Filesystem
+
+`--allow-fs-read` covers this plugin's own code directory; `--allow-fs-write`, `HOME` and the
+child's cwd are all one directory keyed by this plugin's `id` alone, outside that code tree.
+That split matters because the code directory does not survive: core re-extracts and replaces it
+from the signed archive on every ordinary start — boot, enable, an admin restart, install and
+upgrade alike, not just a crash respawn — so nothing written there outlives the next start. The
+data directory is never touched by that sweep, so it is the only place worth writing anything a
+restart, an upgrade, or a disable/re-enable needs to survive. Uninstall removes the code directory
+and (for a schema-owning plugin) the database schema; the data directory is not part of either.
+
 ### The handshake
 
 The first call core makes on a freshly spawned child is `hello`, with `{ pluginApi, coreVersion,
@@ -145,6 +156,22 @@ echoed back exactly. A wrong or missing token is a crash: core logs `plugin cras
 mismatch` against that plugin's own log stream and retries up the backoff ladder until the breaker
 trips. See `fk-plugin-download`'s `hello` handler in `src/plugin.ts` for a minimal implementation
 that gets both right.
+
+### Health
+
+Once ready, core calls `health` on `healthIntervalMs` (15s default) with no payload; reply with
+`{ ok: boolean, detail?: string }`. A reply of `ok: false` counts exactly like a timed-out or
+unanswered call — two consecutive misses mark the plugin `degraded`, four force a SIGTERM-then-
+SIGKILL respawn — so an unhealthy-but-reachable plugin can ask to be recycled without waiting out
+the deadline. `detail` is logged against this plugin's own log stream, so name what's wrong there.
+
+### Config changes
+
+When an admin saves one of this plugin's own `plugin.<id>.*` settings while it is running, core
+pushes a `config` note: `{ changed: string[] }`, one entry, the same unprefixed key shape
+`config.get` returns. It names what changed; it does not carry the new value — call `config.get`
+for that. A plugin that is not running is never a target, and a save for a namespace no running
+plugin owns raises nothing.
 
 ## Database
 


### PR DESCRIPTION
Nine operational gaps from the v3 readiness list. Three of them turned out to be materially worse
than reported, and two of the first attempts at fixing them were defective — details below, because
the reasoning is the reviewable part.

## The plugin's state was destroyed on every ordinary start

Reported as "the writable directory is deleted on every start/restart/upgrade", blaming the
supervisor. The supervisor only `mkdir`s it. The real cause: `materialise()` re-extracts the archive
into `installed/<id>@<version>/` and `promoteDir()` begins with `rmSync(destDir)` — and `data/` lived
inside that. `materialise()` is unconditional in `startFor()`, reached on **boot, enable, admin
restart, install and upgrade**. Only the supervisor's own crash-backoff respawn spared it.

The directory is now keyed by plugin id, outside the code tree. Proven on the running stack:

```
write {"seen":42} as uid 65534 → restart backend → cat state.json → {"seen":42}
read back under the plugin's own sandbox flags → READ: {"seen":42}
```

That second line matters: the first attempt granted `--allow-fs-write` on the new location but not
`--allow-fs-read`, because the old path was covered incidentally by the code-tree read grant. Every
plugin would have been able to write its state and then get `ERR_ACCESS_DENIED` reading it back.
Confirmed in the container before fixing it (`WRITE ok` / `READ FAILED: ERR_ACCESS_DENIED`).

Uninstall removes it, matching the existing settings wipe — a reinstall must not inherit private
state.

## A plugin job could be shadowed by a core command

`triggerCommand` knows ten names: three cron-driven core jobs, plus **seven trigger-only commands**
(`RescanAll`, `GenerateSprites`, `DetectMarkers`, …). Registration only refused collisions with the
three. A plugin declaring a job called `GenerateSprites` installed cleanly, appeared in the listing
with its own id, and its *Run now* button ran **core's** sprite generation across the whole library
while the plugin's job never fired and nothing warned.

Registration now refuses every reserved name. This was found by a reviewer that proved it with a
throwaway spec rather than by reading — worth saying, because the original comment in the code
asserted the collision was impossible.

## The rest

- **Cron traceability**: a completed run logs once. Skip and failure already logged, so nothing was
  added there.
- **Overlap**: an in-flight guard per (plugin, job), released on both paths and shared by ticks and
  manual triggers. A trigger arriving while a run is in flight returns `409`, not a success toast —
  the first attempt answered `{ok:true}` while quietly doing nothing, which is the same class of bug
  the branch exists to remove.
- **`config` note**: declared in the contract, handled by the reference plugin, never sent. It now
  goes to the owning plugin with only its own changed key, unprefixed. A plugin's own `config.set`
  does not echo back to itself — writes carry an origin so the listener can skip the writer.
  Proven live: `INFO config changed: stall_interval_minutes`.
- **`health`**: `ok`/`detail` were declared and discarded, so a plugin could not report itself
  unready. A reply of `ok:false` now counts as a missed check against the existing degrade-at-2 /
  recycle-at-4 ladder. Note the original claim — "answers ok while hanging, never recycled" — is
  false and was already refuted; a timeout has always recycled.
- **`statusMessage`**: shipped on every process-plugin row and rendered nowhere. Now rendered.
- **Icons**: the component knew `bar-chart-3`, `layout-grid`, `play`; the installed plugins declare
  `webhook`, `download`, `search`, `server`, `history`, `settings`. The intersection was **empty** —
  every plugin settings page showed the same fallback circle.
- **Catalogue ordering**: `installable` is sorted before it leaves core, so the client's
  `at(-1)`-as-newest is now true rather than assumed. That was the only way a downgrade could be
  reached by accident.
- **Downgrade**: recorded with a warning, not refused. The first attempt refused it and told the
  operator to "uninstall first" — which drops the schema, the role, every secret and now the data
  directory. Refusing also removes the only rollback there is, and it was English prose rendered
  verbatim in a UI that translates everything else.

## Verification

- `npx tsc --noEmit` — exit 0.
- Full backend suite: **132 suites, 1479 tests**, exit 0.
- Client suite: **47 files, 389 tests**, exit 0.
- Live: backend restarted against the real dev database, all three plugins `active`, both process
  plugins `ready`; per-plugin data directories present, `0700 nobody:nogroup` under a `0710` parent.
- Every new test proven to fail when the line it covers is reverted, including two that were
  **rewritten because they could not fail**:
  - the icon spec asserted `svg.hasAttribute('lucideWebhook')`, which Angular emits whether or not
    the directive is imported — it passed with every icon blank. It now asserts drawn SVG content and
    that each name draws something distinct; removing `LucideWebhook` from the component's imports
    now fails it.
  - the version-sweep test passed against the old single-previous-directory removal. It now strands a
    directory no row names — what an interrupted upgrade leaves — which the old logic could never reach.
