### PR TITLE
perf(plugins): tokenise the library once per release-match call, not once per pair

### DIFF
--- a/backend/src/common/release-scoring/release-rejection.helper.ts
+++ b/backend/src/common/release-scoring/release-rejection.helper.ts
@@ -335,6 +335,46 @@ function significantTokens(tokens: string[]): string[] {
   return filtered.length ? filtered : tokens;
 }
 
+export interface TitleExpectationIndex {
+  /** Significant tokens per readable reading; empty when nothing in the expectation is comparable. */
+  readings: string[][];
+  /** True when the expectation list was empty, which matches anything. */
+  vacuous: boolean;
+}
+
+/** Tokenises one media's expected titles once, so a scan over many release titles does not redo it. */
+export function indexTitleExpectations(expected: string | string[]): TitleExpectationIndex {
+  const candidates = (Array.isArray(expected) ? expected : [expected]).filter(
+    (s): s is string => !!s && s.trim().length > 0,
+  );
+  if (!candidates.length) return { readings: [], vacuous: true };
+  const readings: string[][] = [];
+  for (const cand of candidates) {
+    for (const reading of titleReadings(cand)) {
+      const tokens = significantTokens(reading);
+      if (tokens.length) readings.push(tokens);
+    }
+  }
+  return { readings, vacuous: false };
+}
+
+/** The release side of the same comparison, hoisted so it is computed once per release title. */
+export function releaseTitleTokens(releaseTitle: string): ReadonlySet<string> {
+  return new Set(titleReadings(releaseTitle).flat());
+}
+
+export function matchesIndexedExpectation(
+  releaseTokens: ReadonlySet<string>,
+  index: TitleExpectationIndex,
+  whenUnreadable: 'match' | 'no-match' = 'match',
+): boolean {
+  if (index.vacuous) return true;
+  for (const tokens of index.readings) {
+    if (tokens.every((t) => releaseTokens.has(t))) return true;
+  }
+  return index.readings.length === 0 && whenUnreadable === 'match';
+}
+
 /**
  * Return true when a release title plausibly matches *any* of the expected
  * titles. A candidate matches when, under either apostrophe reading, all of
@@ -354,21 +394,9 @@ export function titleMatchesExpectation(
    *  net must not veto what it cannot read, identification must not claim every release. */
   whenUnreadable: 'match' | 'no-match' = 'match',
 ): boolean {
-  const candidates = (Array.isArray(expected) ? expected : [expected]).filter(
-    (s): s is string => !!s && s.trim().length > 0,
-  );
-  if (!candidates.length) return true; // nothing meaningful to match
-  const releaseTokens = new Set(titleReadings(releaseTitle).flat());
-  let comparable = false;
-  for (const cand of candidates) {
-    for (const reading of titleReadings(cand)) {
-      const tokens = significantTokens(reading);
-      if (!tokens.length) continue; // no comparable tokens (e.g. a non-Latin title)
-      comparable = true;
-      if (tokens.every((t) => releaseTokens.has(t))) return true;
-    }
-  }
-  return !comparable && whenUnreadable === 'match';
+  const index = indexTitleExpectations(expected);
+  if (index.vacuous) return true;
+  return matchesIndexedExpectation(releaseTitleTokens(releaseTitle), index, whenUnreadable);
 }
 
 export function computeRejections(opts: {

--- a/backend/src/modules/plugins/host/fliks-host.service.spec.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.spec.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as releaseScoring from '../../../common/release-scoring/release-rejection.helper';
 import * as os from 'os';
 import * as path from 'path';
 import { FliksHostImpl } from './fliks-host.service';
@@ -574,6 +575,48 @@ describe('FliksHostImpl', () => {
   // ===========================================================================
 
   describe('releases.match', () => {
+    it('tokenises each library title once per call and each release title once, not once per pair', async () => {
+      const indexSpy = jest.spyOn(releaseScoring, 'indexTitleExpectations');
+      const releaseTokenSpy = jest.spyOn(releaseScoring, 'releaseTitleTokens');
+      try {
+        const h = makeHarness();
+        const library = Array.from({ length: 30 }, (_, i) => makeMedia({ id: i + 1, title: `Library Title ${i}` }));
+        h.mediaRepo.find.mockResolvedValue(library);
+
+        await h.host['releases.match']({
+          titles: Array.from({ length: 8 }, (_, i) => ({
+            id: `r${i}`,
+            title: `Zzqxvvm Plghmnd Wbbrtks ${i}`,
+            publishDate: new Date().toISOString(),
+          })),
+        });
+
+        expect(indexSpy).toHaveBeenCalledTimes(library.length);
+        expect(releaseTokenSpy).toHaveBeenCalledTimes(8);
+      } finally {
+        indexSpy.mockRestore();
+        releaseTokenSpy.mockRestore();
+      }
+    });
+
+    it('hands the event loop back between titles so a whole feed does not block core', async () => {
+      const h = makeHarness();
+      h.mediaRepo.find.mockResolvedValue([makeMedia({ title: 'Some Great Movie' })]);
+      const immediate = jest.spyOn(global, 'setImmediate');
+      try {
+        await h.host['releases.match']({
+          titles: Array.from({ length: 4 }, (_, i) => ({
+            id: `y${i}`,
+            title: `Zzqxvvm Plghmnd ${i}`,
+            publishDate: new Date().toISOString(),
+          })),
+        });
+        expect(immediate).toHaveBeenCalledTimes(4);
+      } finally {
+        immediate.mockRestore();
+      }
+    });
+
     it('reports unmatched, then grab, for a title that matches a missing monitored movie', async () => {
       const h = makeHarness();
       const media = makeMedia({ title: 'Some Great Movie' });

--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -44,7 +44,10 @@ import {
   rankFromQualityString,
   resolveSearchTitles,
   scoreAndSortReleases,
-  titleMatchesExpectation,
+  indexTitleExpectations,
+  matchesIndexedExpectation,
+  releaseTitleTokens,
+  type TitleExpectationIndex,
   type ReleaseCandidate,
 } from '../../../common/release-scoring';
 import { parseSeasonEpisode } from '../../../common/release-parsing';
@@ -298,16 +301,24 @@ export class FliksHostImpl implements PluginHostApi {
     minAgeMinutes?: number;
   }): Promise<ReleaseMatchResult[]> {
     const library = await this.mediaRepo.find({ where: { monitored: true } });
+    // Tokenised once for the whole batch: doing it per release title is what made a full feed
+    // tens of seconds of blocking CPU.
+    const indexed = library.map((media) => ({
+      media,
+      titles: indexTitleExpectations([media.title, media.originalTitle ?? '', ...(media.alternativeTitles ?? [])]),
+    }));
     const out: ReleaseMatchResult[] = [];
     for (const entry of p.titles) {
-      out.push(await this.matchOneRelease(entry, library, p.minAgeMinutes));
+      out.push(await this.matchOneRelease(entry, indexed, p.minAgeMinutes));
+      // The unmatched path never awaits, so without this a whole feed holds core's event loop.
+      await new Promise<void>((resolve) => setImmediate(resolve));
     }
     return out;
   }
 
   private async matchOneRelease(
     entry: { id: string; title: string; publishDate: string },
-    library: Media[],
+    library: { media: Media; titles: TitleExpectationIndex }[],
     minAgeMinutes: number | undefined,
   ): Promise<ReleaseMatchResult> {
     const se = parseSeasonEpisode(entry.title);
@@ -326,13 +337,8 @@ export class FliksHostImpl implements PluginHostApi {
 
     // Identification: a title this tokenizer cannot read must claim nothing, or the first such
     // row in the library answers for every release that matches nothing else.
-    const media = library.find((m) =>
-      titleMatchesExpectation(
-        entry.title,
-        [m.title, m.originalTitle ?? '', ...(m.alternativeTitles ?? [])],
-        'no-match',
-      ),
-    );
+    const releaseTokens = releaseTitleTokens(entry.title);
+    const media = library.find((m) => matchesIndexedExpectation(releaseTokens, m.titles, 'no-match'))?.media;
     if (!media) return skip('unmatched');
     if (!media.monitored) return skip('not-monitored', media.id);
 


### PR DESCRIPTION
## The cost

`releases.match` identifies each release title by scanning every monitored medium. Each comparison
called `titleMatchesExpectation`, which re-derived that medium's token sets (title, original title,
every alternative title, under both apostrophe readings) **and** re-tokenised the release title. So
the tokenizer ran `titles × media` times instead of `titles + media`.

Measured over the socket against the real dev library (809 monitored media), with pure-letter
nonsense titles verified 100/100 genuinely unmatched:

| titles | before | after | per title |
|---|---|---|---|
| 1 | 325 ms | 306 ms | — (all fixed cost) |
| 20 | 1133 ms | 337 ms | 56.6 ms → 16.8 ms |
| 100 | **4040 ms** | **272 ms** | **40.4 ms → 2.7 ms** |

The ~300 ms floor is the single `mediaRepo.find` the call already made; it is untouched.

A measurement trap worth recording, because it cost me a wrong number earlier in this work: a
synthetic release title containing digits can false-positive against a numeric `alternativeTitle` and
short-circuit the scan after a few dozen rows, which makes the per-title cost look ~3× smaller than
it is. The figures above use titles with no digits and assert every result came back `unmatched`.

Reachability is scheduled, not hypothetical: the download plugin's RSS sync hands a whole indexer
feed to one `releases.match` call every 15 minutes per indexer. Past ~200 titles the call also
exceeds the 8 s host deadline — the same deadline that already made that sync time out on every tick
once before.

## The change

`release-rejection.helper.ts` exposes the two halves of the comparison — `indexTitleExpectations`
(per medium) and `releaseTitleTokens` (per release title) — and `titleMatchesExpectation` is
rewritten in terms of them. That matters: there is still exactly **one** tokenizer, so there is no
second copy to drift out of parity. The host builds the index once for the batch.

The loop now yields between titles with `setImmediate`. Nothing on the unmatched path awaits, so a
whole feed previously ran as one contiguous block of core's shared event loop, streaming included.

## No cache, deliberately

An earlier attempt cached the index across calls with event-based invalidation plus a 60 s TTL. Two
independent problems killed it, and both are worth stating because they are the reason this PR is
smaller than it might have been:

- the rebuild was a read-modify-write across an `await`, so an invalidation arriving during the
  ~300 ms query was overwritten and stamped fresh — the stale snapshot then served the next call;
- no reliable event covers a title change. A title-only admin edit emits nothing, and metadata
  refresh rewrites titles without a dedicated signal — so a rename could answer `unmatched` for up to
  a minute, on the path whose whole job is to notice new releases.

An index derived from rows read in the same call has no staleness window and nothing to invalidate.
It captures essentially all of the win, since the per-call rebuild is ~20 ms against a saving of
~38 ms *per title*.

## Verification

- `npx tsc --noEmit` — exit 0.
- Full backend suite: 132 suites, **1481 tests**, exit 0.
- Live: backend restarted against the real dev database, benchmark above run over the plugin's own
  core socket.
- Both new tests proven to fail when the line they cover is reverted:
  - tokenisation moved back inside the per-media scan → `Expected 30 calls, received 270`
  - the `setImmediate` yield replaced with `await Promise.resolve()` (a microtask, which does **not**
    let I/O run) → `Expected 4 calls, received 0`

## Not in this PR

The two uncapped `pageSize` routes from the same audit item live in the plugin repository
(`src/seams/http-routes.ts`), not core — core's `media.resolve` bound is already enforced and
constant-backed. That fix rides the plugin-side PR.
