### PR TITLE
feat(plugins): freeze the contract items a major locks in

### DIFF
--- a/backend/src/common/plugin-contract/host-methods.ts
+++ b/backend/src/common/plugin-contract/host-methods.ts
@@ -240,7 +240,8 @@ export interface PluginHostApi {
     payload: Record<string, unknown>;
   }) => Promise<void>;
 
-  /** The sidebar badge, pushed not polled. */
+  /** The sidebar badge, pushed not polled. Stored per plugin: two plugins pushing one key add up
+   *  rather than overwrite, and a stopped plugin stops counting. Core serves `queueActive`. */
   'counts.set': (p: { key: string; value: number }) => Promise<void>;
 
   /** Plugin-namespaced SSE. Core force-prefixes the type to `plugin.<id>.<type>`. */
@@ -252,7 +253,8 @@ export interface PluginHostApi {
 
   /**
    * Live acquisition progress. Plugin pushes; core emits the reserved
-   * `download.progress` SSE type. Coalesced server-side to <= 1/media/second.
+   * `download.progress` SSE type, coalesced to one emission per media per second: pushing faster
+   * is allowed, and the last value of a window is the one that goes out.
    */
   'progress.set': (p: {
     mediaId: number;

--- a/backend/src/common/plugin-contract/manifest.ts
+++ b/backend/src/common/plugin-contract/manifest.ts
@@ -115,7 +115,7 @@ export interface ProcessPluginManifest extends PluginManifestBase {
   jobs?: PluginJob[];
   /** Legal on `process`, refused on `data`; item shape is the pre-existing baseline's. */
   permissions?: string[];
-  /** Legal on `process`, refused on `data`; item shape is the pre-existing baseline's. */
+  /** Accepted and ignored: core reads no checklist from a manifest. Dropped in the next major. */
   checklist?: string[];
 }
 

--- a/backend/src/common/plugin-contract/protocol.ts
+++ b/backend/src/common/plugin-contract/protocol.ts
@@ -85,3 +85,33 @@ export interface PluginSpawnEnv {
  * `[A-Z0-9_]` with `_`, and prepend `FLIKS_CFG_` (see `reKeyConfig` in `supervisor/spawn-plan.ts`).
  * Not a fixed set — read whichever `FLIKS_CFG_*` names your own manifest's settings resolve to.
  */
+
+/**
+ * The deadlines and ceilings a plugin must design against. Core enforces these; a plugin that
+ * exceeds one is killed or has its call abandoned, so they belong on the published surface rather
+ * than in core's private configuration. `supervisor-deadlines.spec.ts` fails if they drift from
+ * what the supervisor actually applies.
+ */
+export const PLUGIN_DEADLINES_MS = {
+  /** From spawn to a `hello` reply. Exceeded: the child is killed and restarted. */
+  handshake: 10_000,
+  /** Interval between `health` calls, and how long each has to answer. */
+  healthInterval: 15_000,
+  healthReply: 3_000,
+  /** Ceiling on one host call, unless the method appears in {@link HOST_CALL_DEADLINE_OVERRIDES_MS}. */
+  hostCall: 8_000,
+  /** After `shutdown` is answered (or not), before SIGTERM, then before SIGKILL. */
+  shutdownRpc: 3_000,
+  sigtermGrace: 2_000,
+} as const;
+
+/** Host methods whose own work is not a lookup, so they are allowed longer than {@link PLUGIN_DEADLINES_MS.hostCall}. */
+export const HOST_CALL_DEADLINE_OVERRIDES_MS: Readonly<Record<string, number>> = {
+  'library.ingest': 30 * 60_000,
+};
+
+/** Output above this, per minute, is dropped with one warning — a plugin must rate-limit its own logs. */
+export const PLUGIN_LOG_CAP_BYTES_PER_MINUTE = 64 * 1024;
+
+/** `memoryMb`'s default when a manifest declares none. It caps the V8 old space, not the process RSS. */
+export const PLUGIN_DEFAULT_MEMORY_MB = 256;

--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -83,13 +83,26 @@ interface ConfigPageBase {
 }
 
 /** Rendered by `<app-schema-form>` over `app_settings`; omitting `kind` means this one. */
+/**
+ * Every `actionId` a `form` page's button may name. Core implements each one; an unknown value
+ * renders nothing, so this list is the whole vocabulary available to a manifest.
+ */
+export const FORM_ACTION_IDS = ['events.test-delivery'] as const;
+export type FormActionId = (typeof FORM_ACTION_IDS)[number];
+
+/**
+ * Every `actionId` a `table` row action may name, resolved by core against the row it sits on.
+ * Same rule: an unknown value renders nothing.
+ */
+export const TABLE_ROW_ACTION_IDS = ['table.open-media'] as const;
+export type TableRowActionId = (typeof TABLE_ROW_ACTION_IDS)[number];
+
 export interface FormConfigPage extends ConfigPageBase {
   kind?: 'form';
   fields: FieldDef[];
-  /** Buttons core implements on the plugin's behalf. `actionId` names a closed catalogue core
-   *  resolves; an unknown one renders nothing. A `data` plugin executes no code of its own, so
-   *  this is the only way it can offer an action at all. */
-  actions?: { id: string; labelKey: string; actionId: string }[];
+  /** Buttons core implements on the plugin's behalf. A `data` plugin executes no code of its
+   *  own, so this is the only way it can offer an action at all. */
+  actions?: { id: string; labelKey: string; actionId: FormActionId }[];
 }
 
 /** One search/grab pair the core release picker calls for a given context. */
@@ -176,7 +189,7 @@ export interface TableConfigPage extends ConfigPageBase {
   filters?: TableFilter[];
   rowActions?: (
     | { kind: 'route'; labelKey: string; path: string }
-    | { kind: 'action'; labelKey: string; actionId: string }
+    | { kind: 'action'; labelKey: string; actionId: TableRowActionId }
     | { kind: 'proxy'; labelKey: string; method: 'POST' | 'DELETE'; path: string; confirmKey?: string }
   )[];
   defaultSortKey?: string;

--- a/backend/src/modules/counts/counts.service.spec.ts
+++ b/backend/src/modules/counts/counts.service.spec.ts
@@ -46,7 +46,7 @@ describe('CountsService.getCounts', () => {
 
   it('reflects a value pushed to the shared cache, with no cache mock in the way', async () => {
     const { service, pluginCounts } = make({ canManageRequests: false });
-    pluginCounts.set('queueActive', 4);
+    pluginCounts.set('some.plugin', 'queueActive', 4);
     const counts = await service.getCounts(user);
     expect(counts.badgeCounts.queueActive).toBe(4);
   });
@@ -56,7 +56,7 @@ describe('CountsService.getCounts', () => {
       canManageRequests: false,
       canReadMedia: false,
     });
-    pluginCounts.set('queueActive', 4);
+    pluginCounts.set('some.plugin', 'queueActive', 4);
     const counts = await service.getCounts(user);
     expect(counts.badgeCounts).not.toHaveProperty('queueActive');
   });

--- a/backend/src/modules/plugins/archive/manifest-parser.ts
+++ b/backend/src/modules/plugins/archive/manifest-parser.ts
@@ -36,6 +36,7 @@ const PROCESS_KEYS = new Set([
   'ingestRoots',
   'jobs',
   'permissions',
+  // Accepted so an installed plugin declaring it keeps loading; nothing reads it.
   'checklist',
 ]);
 

--- a/backend/src/modules/plugins/host/fliks-host.service.spec.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.spec.ts
@@ -1288,6 +1288,43 @@ describe('FliksHostImpl', () => {
       );
     });
 
+    it('coalesces to one emission per media per second, and the trailing one carries the latest', async () => {
+      jest.useFakeTimers();
+      try {
+        const h = makeHarness();
+        h.mediaRepo.findOne.mockResolvedValue(makeMedia({ type: MediaType.SERIES }));
+        const push = (progress: number) =>
+          h.host['progress.set']({ mediaId: 7, ref: 'r', progress, state: 'active' });
+
+        await push(0.1);
+        await push(0.2);
+        await push(0.3);
+        expect(h.events.emitToUsers).toHaveBeenCalledTimes(1);
+
+        await jest.advanceTimersByTimeAsync(1_000);
+        expect(h.events.emitToUsers).toHaveBeenCalledTimes(2);
+        expect(h.events.emitToUsers).toHaveBeenLastCalledWith(
+          [9],
+          expect.objectContaining({ progress: 0.3 }),
+        );
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('does not hold one media behind another', async () => {
+      jest.useFakeTimers();
+      try {
+        const h = makeHarness();
+        h.mediaRepo.findOne.mockResolvedValue(makeMedia({ type: MediaType.SERIES }));
+        await h.host['progress.set']({ mediaId: 1, ref: 'r', progress: 0.1, state: 'active' });
+        await h.host['progress.set']({ mediaId: 2, ref: 'r', progress: 0.1, state: 'active' });
+        expect(h.events.emitToUsers).toHaveBeenCalledTimes(2);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     it('emits nothing when the audience is empty', async () => {
       const h = makeHarness();
       h.sseAudience.recipientsForMedia.mockResolvedValue([]);

--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -56,6 +56,15 @@ import { PLUGIN_HOST_PLUGIN_ID } from './plugin-host.constants';
 import { PluginHostContext } from './plugin-host-context';
 import { DownloadProgressState } from '../../../common/constants/download-progress-state';
 
+/** The rate `progress.set` promises: at most one SSE emission per media per second. */
+const PROGRESS_MIN_INTERVAL_MS = 1_000;
+
+interface ProgressGate {
+  lastEmitMs: number;
+  pending: Parameters<PluginHostApi['progress.set']>[0] | null;
+  timer: NodeJS.Timeout | null;
+}
+
 /** `media.resolve`'s own bound, per the contract's doc comment. */
 const QUEUE_PAGE_SIZE_MAX = 100;
 
@@ -105,6 +114,8 @@ export class FliksHostImpl implements PluginHostApi {
     private readonly sseAudience: SseAudienceService,
     private readonly countsCache: PluginCountsCacheService,
   ) {}
+
+  private readonly progressGates = new Map<number, ProgressGate>();
 
   /** `PluginHostContext` (set only by `PluginHostBindingService`, never by a plugin's
    *  payload) wins when bound; the constructor value is the in-process default. */
@@ -802,7 +813,8 @@ export class FliksHostImpl implements PluginHostApi {
   // ===========================================================================
 
   private countsSet(p: { key: string; value: number }): Promise<void> {
-    this.countsCache.set(p.key, p.value);
+    const pluginId = this.currentPluginId();
+    if (pluginId) this.countsCache.set(pluginId, p.key, p.value);
     return Promise.resolve();
   }
 
@@ -840,9 +852,37 @@ export class FliksHostImpl implements PluginHostApi {
     etaSeconds?: number;
     state: DownloadProgressState;
   }): Promise<void> {
-    // ponytail: no server-side coalescing yet (plan asks for <=1/media/sec) —
-    // add a per-media debounce once a real caller exercises the frequency.
+    const gate = this.progressGates.get(p.mediaId);
+    const now = Date.now();
+    if (gate && now - gate.lastEmitMs < PROGRESS_MIN_INTERVAL_MS) {
+      // Newest wins: the trailing emit carries the latest state, so nothing is merely dropped.
+      gate.pending = p;
+      if (!gate.timer) {
+        gate.timer = setTimeout(
+          () => this.flushProgress(p.mediaId),
+          PROGRESS_MIN_INTERVAL_MS - (now - gate.lastEmitMs),
+        );
+        gate.timer.unref();
+      }
+      return;
+    }
+    this.progressGates.set(p.mediaId, { lastEmitMs: now, pending: null, timer: null });
     await this.pushProgress(p);
+  }
+
+  private flushProgress(mediaId: number): void {
+    const gate = this.progressGates.get(mediaId);
+    if (!gate) return;
+    gate.timer = null;
+    const pending = gate.pending;
+    gate.pending = null;
+    if (!pending) {
+      // Idle for a whole window: drop the gate so the map cannot grow with every media ever seen.
+      this.progressGates.delete(mediaId);
+      return;
+    }
+    gate.lastEmitMs = Date.now();
+    void this.pushProgress(pending);
   }
 
   private async pushProgress(p: {

--- a/backend/src/modules/plugins/host/plugin-counts-cache.service.spec.ts
+++ b/backend/src/modules/plugins/host/plugin-counts-cache.service.spec.ts
@@ -1,0 +1,37 @@
+import { PluginCountsCacheService } from './plugin-counts-cache.service';
+
+describe('PluginCountsCacheService', () => {
+  it('adds up a key two plugins push instead of letting the second overwrite the first', () => {
+    const cache = new PluginCountsCacheService();
+    cache.set('fliks.a', 'queueActive', 3);
+    cache.set('fliks.b', 'queueActive', 4);
+    expect(cache.get('queueActive')).toBe(7);
+  });
+
+  it('keeps each plugin to its own slot, so one cannot read or clear another key', () => {
+    const cache = new PluginCountsCacheService();
+    cache.set('fliks.a', 'queueActive', 3);
+    cache.set('fliks.b', 'other', 9);
+    expect(cache.get('queueActive')).toBe(3);
+    expect(cache.get('other')).toBe(9);
+  });
+
+  it('stops counting a plugin that is no longer running', () => {
+    const cache = new PluginCountsCacheService();
+    cache.set('fliks.a', 'queueActive', 3);
+    cache.set('fliks.b', 'queueActive', 4);
+    cache.forget('fliks.a');
+    expect(cache.get('queueActive')).toBe(4);
+    expect(cache.has('queueActive')).toBe(true);
+    cache.forget('fliks.b');
+    expect(cache.has('queueActive')).toBe(false);
+  });
+
+  it('tells an explicit zero apart from never having been pushed', () => {
+    const cache = new PluginCountsCacheService();
+    expect(cache.has('queueActive')).toBe(false);
+    cache.set('fliks.a', 'queueActive', 0);
+    expect(cache.has('queueActive')).toBe(true);
+    expect(cache.get('queueActive')).toBe(0);
+  });
+});

--- a/backend/src/modules/plugins/host/plugin-counts-cache.service.ts
+++ b/backend/src/modules/plugins/host/plugin-counts-cache.service.ts
@@ -5,22 +5,36 @@ import { Injectable } from '@nestjs/common';
  * core serves the cached number. An unset key reads as 0, matching "the
  * plugin has never connected". Not persisted — a restart is a legitimate
  * reset, the plugin re-pushes once it reconnects.
+ *
+ * Keyed by plugin then by key, so two plugins pushing the same key contribute
+ * to it instead of overwriting each other, and neither can reach the other's slot.
  */
 @Injectable()
 export class PluginCountsCacheService {
-  private readonly counts = new Map<string, number>();
+  private readonly byPlugin = new Map<string, Map<string, number>>();
 
-  set(key: string, value: number): void {
-    this.counts.set(key, value);
+  set(pluginId: string, key: string, value: number): void {
+    const owned = this.byPlugin.get(pluginId) ?? new Map<string, number>();
+    owned.set(key, value);
+    this.byPlugin.set(pluginId, owned);
   }
 
+  /** Summed across the plugins that pushed it: with one publisher this is that publisher's number. */
   get(key: string): number {
-    return this.counts.get(key) ?? 0;
+    let total = 0;
+    for (const owned of this.byPlugin.values()) total += owned.get(key) ?? 0;
+    return total;
   }
 
   /** Tells "never pushed" apart from an explicit 0 — callers that must not
    *  show a badge for a publisher that never connected read this first. */
   has(key: string): boolean {
-    return this.counts.has(key);
+    for (const owned of this.byPlugin.values()) if (owned.has(key)) return true;
+    return false;
+  }
+
+  /** A plugin that is no longer running must stop contributing to any badge it pushed. */
+  forget(pluginId: string): void {
+    this.byPlugin.delete(pluginId);
   }
 }

--- a/backend/src/modules/plugins/plugin-install.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-install.service.spec.ts
@@ -8,7 +8,7 @@ import { PluginStagingService } from './plugin-staging.service';
 import { PluginRegistryService } from './plugin-registry.service';
 import { PluginUiController } from './plugin-ui.controller';
 import { PluginDatabaseService } from './plugin-database.service';
-import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry } from './plugin-registry.test-helpers';
+import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry, fakeCountsCache } from './plugin-registry.test-helpers';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { PluginSource } from './entities/plugin-source.entity';
 import { buildZip, ZipEntrySpec } from './archive/zip-builder';
@@ -177,6 +177,7 @@ describe('PluginInstallService', () => {
       processService as never,
       fakePluginJobsService() as never,
       fakeScheduledJobRegistry() as never,
+      fakeCountsCache() as never,
     );
     staging = new PluginStagingService();
     pluginDb = fakePluginDb();

--- a/backend/src/modules/plugins/plugin-registry.service.jobs.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.jobs.spec.ts
@@ -3,7 +3,7 @@ import { PluginRegistryService } from './plugin-registry.service';
 import { PluginJobsService } from './plugin-jobs.service';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { minimalProcessManifest } from './archive/test-manifests';
-import { fakeRegistrationRepo, fakeProcessService, fakeScheduledJobRegistry } from './plugin-registry.test-helpers';
+import { fakeRegistrationRepo, fakeProcessService, fakeScheduledJobRegistry, fakeCountsCache } from './plugin-registry.test-helpers';
 import { CORE_SCHEDULER_JOB_NAMES } from '../../common/constants/core-scheduler-jobs';
 import type { PluginJob, PluginManifest } from '../../common/plugin-contract';
 import type { PluginProcessStartResult } from './plugin-process.service';
@@ -67,6 +67,7 @@ function makeService(startResult?: PluginProcessStartResult, publishedJobNames: 
     processService as never,
     pluginJobs,
     scheduledJobs as never,
+    fakeCountsCache() as never,
   );
   return { service, registry, pluginJobs };
 }

--- a/backend/src/modules/plugins/plugin-registry.service.permissions.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.permissions.spec.ts
@@ -1,7 +1,7 @@
 import { PluginRegistryService } from './plugin-registry.service';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { minimalProcessManifest } from './archive/test-manifests';
-import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry } from './plugin-registry.test-helpers';
+import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry, fakeCountsCache } from './plugin-registry.test-helpers';
 import type { PluginManifest, PluginRoute } from '../../common/plugin-contract';
 
 /** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
@@ -36,6 +36,7 @@ function makeService(): PluginRegistryService {
     fakeProcessService() as never,
     fakePluginJobsService() as never,
     fakeScheduledJobRegistry() as never,
+    fakeCountsCache() as never,
   );
 }
 

--- a/backend/src/modules/plugins/plugin-registry.service.release-picker.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.release-picker.spec.ts
@@ -1,7 +1,7 @@
 import { PluginRegistryService } from './plugin-registry.service';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { minimalProcessManifest } from './archive/test-manifests';
-import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry } from './plugin-registry.test-helpers';
+import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry, fakeCountsCache } from './plugin-registry.test-helpers';
 import type { PluginManifest, PluginRoute, ReleasePickerRoutes } from '../../common/plugin-contract';
 
 const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
@@ -49,6 +49,7 @@ function makeService(): PluginRegistryService {
     fakeProcessService() as never,
     fakePluginJobsService() as never,
     fakeScheduledJobRegistry() as never,
+    fakeCountsCache() as never,
   );
 }
 

--- a/backend/src/modules/plugins/plugin-registry.service.routes.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.routes.spec.ts
@@ -1,7 +1,7 @@
 import { PluginRegistryService } from './plugin-registry.service';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { minimalProcessManifest } from './archive/test-manifests';
-import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry } from './plugin-registry.test-helpers';
+import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry, fakeCountsCache } from './plugin-registry.test-helpers';
 import { SUPPORTED_PLUGIN_API_VERSIONS, type PluginManifest, type PluginRoute } from '../../common/plugin-contract';
 import type { PluginProcessStartResult } from './plugin-process.service';
 
@@ -37,6 +37,7 @@ function makeService(startResult?: PluginProcessStartResult): PluginRegistryServ
     fakeProcessService(startResult) as never,
     fakePluginJobsService() as never,
     fakeScheduledJobRegistry() as never,
+    fakeCountsCache() as never,
   );
 }
 

--- a/backend/src/modules/plugins/plugin-registry.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.spec.ts
@@ -7,7 +7,7 @@ import { generateTestKeypair, signManifestBase64 } from './archive/ed25519-test-
 import { minimalDataManifest, minimalProcessManifest } from './archive/test-manifests';
 import { svgLogo, pngLogo } from './archive/test-fixtures';
 import { OFFICIAL_KEYS } from './archive/trust-store';
-import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry } from './plugin-registry.test-helpers';
+import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry, fakeCountsCache } from './plugin-registry.test-helpers';
 import { FLIKS_PLUGINS_DISABLED_ENV } from '../../common/constants/plugin-flags';
 import { sweepOrphans } from './supervisor/pid-file';
 import { getPluginsSocketDir } from '../../common/constants/paths';
@@ -65,6 +65,7 @@ function makeService(rows: PluginPackage[] = [], processResult: PluginProcessSta
     processService as never,
     pluginJobs as never,
     fakeScheduledJobRegistry() as never,
+    fakeCountsCache() as never,
   );
   return { service, repo, registrationRepo, processService, pluginJobs };
 }

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -14,6 +14,7 @@ import { CURRENT_FLIKS_VERSION } from './plugin-version';
 import type { SupervisorState } from './supervisor/plugin-supervisor';
 import { sweepOrphans } from './supervisor/pid-file';
 import { getPluginsSocketDir } from '../../common/constants/paths';
+import { PluginCountsCacheService } from './host/plugin-counts-cache.service';
 import { arePluginsDisabled, FLIKS_PLUGINS_DISABLED_ENV } from '../../common/constants/plugin-flags';
 import {
   SUPPORTED_PLUGIN_API_VERSIONS,
@@ -178,6 +179,7 @@ export class PluginRegistryService implements OnModuleInit {
     private readonly processService: PluginProcessService,
     private readonly pluginJobs: PluginJobsService,
     private readonly scheduledJobs: ScheduledJobRegistry,
+    private readonly countsCache: PluginCountsCacheService,
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -333,6 +335,7 @@ export class PluginRegistryService implements OnModuleInit {
   async unregister(pluginId: string): Promise<void> {
     await this.processService.stopFor(pluginId);
     this.pluginJobs.dropFor(pluginId);
+    this.countsCache.forget(pluginId);
     this.registry.delete(pluginId);
     this.replaceWebhookDeclarations(pluginId, []);
   }

--- a/backend/src/modules/plugins/plugin-registry.service.webhooks.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.webhooks.spec.ts
@@ -1,7 +1,7 @@
 import { PluginRegistryService } from './plugin-registry.service';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { minimalDataManifest, minimalProcessManifest } from './archive/test-manifests';
-import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry } from './plugin-registry.test-helpers';
+import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry, fakeCountsCache } from './plugin-registry.test-helpers';
 import type { PluginManifest, PluginWebhookDeclaration } from '../../common/plugin-contract';
 
 /** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
@@ -36,6 +36,7 @@ function makeService(): PluginRegistryService {
     fakeProcessService() as never,
     fakePluginJobsService() as never,
     fakeScheduledJobRegistry() as never,
+    fakeCountsCache() as never,
   );
 }
 

--- a/backend/src/modules/plugins/plugin-registry.test-helpers.ts
+++ b/backend/src/modules/plugins/plugin-registry.test-helpers.ts
@@ -75,3 +75,7 @@ export function fakeScheduledJobRegistry(names: readonly string[] = []): { list:
     list: jest.fn(() => names.map((name) => ({ name, cron: '* * * * *', triggerable: true, run: jest.fn() }))),
   };
 }
+
+export function fakeCountsCache(): { forget: jest.Mock } {
+  return { forget: jest.fn() };
+}

--- a/backend/src/modules/plugins/plugins.module.ts
+++ b/backend/src/modules/plugins/plugins.module.ts
@@ -18,6 +18,7 @@ import { PluginImportController } from './plugin-import.controller';
 import { PluginsController } from './plugins.controller';
 import { PluginUiController } from './plugin-ui.controller';
 import { PluginObjectGuardsService } from './proxy/plugin-object-guards.service';
+import { PluginCountsCacheModule } from './host/plugin-counts-cache.module';
 import { PluginRouteGuard } from './proxy/plugin-route.guard';
 import { PluginProxyController } from './proxy/plugin-proxy.controller';
 import { AuthModule } from '../auth/auth.module';
@@ -36,6 +37,7 @@ import { ScheduledJobRegistryModule } from '../scheduler/scheduled-job-registry.
     SettingsModule,
     LibrariesModule,
     ScheduledJobRegistryModule,
+    PluginCountsCacheModule,
   ],
   controllers: [
     PluginLogoController,

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
@@ -12,7 +12,15 @@ import type { PluginApi } from '../../../common/plugin-contract';
 
 type HelloReply = Awaited<ReturnType<PluginApi['hello']>>;
 type HealthReply = Awaited<ReturnType<PluginApi['health']>>;
-import { PLUGIN_API_VERSION, type Note, type PluginHostApi } from '../../../common/plugin-contract';
+import {
+  HOST_CALL_DEADLINE_OVERRIDES_MS,
+  PLUGIN_API_VERSION,
+  PLUGIN_DEADLINES_MS,
+  PLUGIN_DEFAULT_MEMORY_MB,
+  PLUGIN_LOG_CAP_BYTES_PER_MINUTE,
+  type Note,
+  type PluginHostApi,
+} from '../../../common/plugin-contract';
 import { RpcChannel } from './rpc-channel';
 import { NoteRingBuffer } from './note-ring-buffer';
 import {
@@ -42,28 +50,24 @@ const STDERR_TAIL_BYTES = 4 * 1024;
  * deadline only abandons the wait — core finished the copy, so the plugin recorded a failure for
  * an import that had landed.
  */
-const HOST_CALL_DEADLINE_OVERRIDES_MS: Readonly<Record<string, number>> = {
-  'library.ingest': 30 * 60_000,
-};
-
 /** `WARN` as the line's own level — after any bracketed prefixes, never inside the message. */
 const SELF_DECLARED_WARN = /^(?:\[[^\]]*\]\s*)*WARN\b/;
 
 /** Every figure here is "The spawn call and the supervisor"'s, verbatim. Override only in tests. */
 export const DEFAULT_SUPERVISOR_OPTIONS = {
   pluginApi: PLUGIN_API_VERSION,
-  memoryMb: 256,
-  handshakeDeadlineMs: 10_000,
-  healthIntervalMs: 15_000,
-  healthDeadlineMs: 3_000,
+  memoryMb: PLUGIN_DEFAULT_MEMORY_MB,
+  handshakeDeadlineMs: PLUGIN_DEADLINES_MS.handshake,
+  healthIntervalMs: PLUGIN_DEADLINES_MS.healthInterval,
+  healthDeadlineMs: PLUGIN_DEADLINES_MS.healthReply,
   backoffLadderMs: [1_000, 2_000, 4_000, 8_000, 16_000, 30_000],
   readyResetMs: 120_000,
   breakerWindowMs: 10 * 60_000,
   breakerMaxCrashes: 6,
-  shutdownRpcDeadlineMs: 3_000,
-  sigtermGraceMs: 2_000,
-  logCapBytesPerMinute: 64 * 1024,
-  hostCallTimeoutMs: 8_000,
+  shutdownRpcDeadlineMs: PLUGIN_DEADLINES_MS.shutdownRpc,
+  sigtermGraceMs: PLUGIN_DEADLINES_MS.sigtermGrace,
+  logCapBytesPerMinute: PLUGIN_LOG_CAP_BYTES_PER_MINUTE,
+  hostCallTimeoutMs: PLUGIN_DEADLINES_MS.hostCall,
 };
 
 export interface PluginSupervisorOptions {

--- a/backend/src/modules/plugins/supervisor/published-deadlines.spec.ts
+++ b/backend/src/modules/plugins/supervisor/published-deadlines.spec.ts
@@ -1,0 +1,26 @@
+import { DEFAULT_SUPERVISOR_OPTIONS } from './plugin-supervisor';
+import {
+  HOST_CALL_DEADLINE_OVERRIDES_MS,
+  PLUGIN_DEADLINES_MS,
+  PLUGIN_DEFAULT_MEMORY_MB,
+  PLUGIN_LOG_CAP_BYTES_PER_MINUTE,
+} from '../../../common/plugin-contract';
+
+/** Lives outside the contract directory's own emit: it imports the supervisor, which the
+ *  island itself never may. Its job is to fail if a published figure stops being the real one. */
+describe('published plugin deadlines', () => {
+  it('are the figures the supervisor actually applies', () => {
+    expect(DEFAULT_SUPERVISOR_OPTIONS.handshakeDeadlineMs).toBe(PLUGIN_DEADLINES_MS.handshake);
+    expect(DEFAULT_SUPERVISOR_OPTIONS.healthIntervalMs).toBe(PLUGIN_DEADLINES_MS.healthInterval);
+    expect(DEFAULT_SUPERVISOR_OPTIONS.healthDeadlineMs).toBe(PLUGIN_DEADLINES_MS.healthReply);
+    expect(DEFAULT_SUPERVISOR_OPTIONS.hostCallTimeoutMs).toBe(PLUGIN_DEADLINES_MS.hostCall);
+    expect(DEFAULT_SUPERVISOR_OPTIONS.shutdownRpcDeadlineMs).toBe(PLUGIN_DEADLINES_MS.shutdownRpc);
+    expect(DEFAULT_SUPERVISOR_OPTIONS.sigtermGraceMs).toBe(PLUGIN_DEADLINES_MS.sigtermGrace);
+    expect(DEFAULT_SUPERVISOR_OPTIONS.logCapBytesPerMinute).toBe(PLUGIN_LOG_CAP_BYTES_PER_MINUTE);
+    expect(DEFAULT_SUPERVISOR_OPTIONS.memoryMb).toBe(PLUGIN_DEFAULT_MEMORY_MB);
+  });
+
+  it('carry the one host method allowed longer than the common ceiling', () => {
+    expect(HOST_CALL_DEADLINE_OVERRIDES_MS['library.ingest']).toBeGreaterThan(PLUGIN_DEADLINES_MS.hostCall);
+  });
+});

--- a/client/src/app/core/plugin-ui/contribution.types.ts
+++ b/client/src/app/core/plugin-ui/contribution.types.ts
@@ -86,13 +86,26 @@ interface ConfigPageBase {
 }
 
 /** Rendered by `<app-schema-form>` over `app_settings`; omitting `kind` means this one. */
+/**
+ * Every `actionId` a `form` page's button may name. Core implements each one; an unknown value
+ * renders nothing, so this list is the whole vocabulary available to a manifest.
+ */
+export const FORM_ACTION_IDS = ['events.test-delivery'] as const;
+export type FormActionId = (typeof FORM_ACTION_IDS)[number];
+
+/**
+ * Every `actionId` a `table` row action may name, resolved by core against the row it sits on.
+ * Same rule: an unknown value renders nothing.
+ */
+export const TABLE_ROW_ACTION_IDS = ['table.open-media'] as const;
+export type TableRowActionId = (typeof TABLE_ROW_ACTION_IDS)[number];
+
 export interface FormConfigPage extends ConfigPageBase {
   kind?: 'form';
   fields: FieldDef[];
-  /** Buttons core implements on the plugin's behalf. `actionId` names a closed catalogue core
-   *  resolves; an unknown one renders nothing. A `data` plugin executes no code of its own, so
-   *  this is the only way it can offer an action at all. */
-  actions?: { id: string; labelKey: string; actionId: string }[];
+  /** Buttons core implements on the plugin's behalf. A `data` plugin executes no code of its
+   *  own, so this is the only way it can offer an action at all. */
+  actions?: { id: string; labelKey: string; actionId: FormActionId }[];
 }
 
 /** One search/grab pair the core release picker calls for a given context. */
@@ -179,7 +192,7 @@ export interface TableConfigPage extends ConfigPageBase {
   filters?: TableFilter[];
   rowActions?: (
     | { kind: 'route'; labelKey: string; path: string }
-    | { kind: 'action'; labelKey: string; actionId: string }
+    | { kind: 'action'; labelKey: string; actionId: TableRowActionId }
     | { kind: 'proxy'; labelKey: string; method: 'POST' | 'DELETE'; path: string; confirmKey?: string }
   )[];
   defaultSortKey?: string;

--- a/client/src/app/features/plugin-view/plugin-view.spec.ts
+++ b/client/src/app/features/plugin-view/plugin-view.spec.ts
@@ -311,7 +311,9 @@ describe('PluginViewComponent', () => {
           labelKey: 'x.title',
           list: '/queue',
           columns: [{ key: 'name', labelKey: 'x.col_name' }],
-          rowActions: [{ kind: 'action', labelKey: 'x.doit', actionId: 'core.unknown' }],
+          // Cast on purpose: a manifest is untrusted JSON, so an id outside the union is
+          // exactly what this asserts core refuses to render.
+          rowActions: [{ kind: 'action', labelKey: 'x.doit', actionId: 'core.unknown' as never }],
         }),
       },
     );

--- a/client/src/app/features/plugin-view/plugin-view.ts
+++ b/client/src/app/features/plugin-view/plugin-view.ts
@@ -20,7 +20,19 @@ import {
 } from '../../shared/components/provider-list/provider-list.types';
 import { DataTableComponent } from '../../shared/components/data-table/data-table';
 import type { ListAction, RowAction, TableRow } from '../../shared/components/data-table/data-table.types';
-import type { FieldDef, FormConfigPage } from '../../core/plugin-ui/contribution.types';
+import {
+  FORM_ACTION_IDS,
+  TABLE_ROW_ACTION_IDS,
+  type FieldDef,
+  type FormActionId,
+  type FormConfigPage,
+  type TableRowActionId,
+} from '../../core/plugin-ui/contribution.types';
+
+/** A manifest is untrusted JSON, so the declared union has to be re-checked at runtime. */
+function isTableRowActionId(value: string): value is TableRowActionId {
+  return (TABLE_ROW_ACTION_IDS as readonly string[]).includes(value);
+}
 import { AnyConfigPage, ProvidersView, TableView, isFormView, isProvidersView, isTableView } from './view-kinds.types';
 
 type UnavailableReason = 'unknown_plugin' | 'unknown_view';
@@ -161,13 +173,13 @@ export class PluginViewComponent {
     }
   }
 
-  /** The closed catalogue of buttons core implements on a `form` page. An unknown id renders
-   *  nothing: a `data` plugin cannot ship code, so core is the only thing that can act. */
-  formActions(page: FormConfigPage): { id: string; labelKey: string; actionId: string }[] {
-    return (page.actions ?? []).filter((a) => a.actionId === 'events.test-delivery');
+  /** An unknown id renders nothing: a `data` plugin cannot ship code, so core is the only
+   *  thing that can act. `FormActionId` is the whole catalogue. */
+  formActions(page: FormConfigPage): { id: string; labelKey: string; actionId: FormActionId }[] {
+    return (page.actions ?? []).filter((a) => (FORM_ACTION_IDS as readonly string[]).includes(a.actionId));
   }
 
-  async runFormAction(action: { id: string; labelKey: string; actionId: string }): Promise<void> {
+  async runFormAction(action: { id: string; labelKey: string; actionId: FormActionId }): Promise<void> {
     this.formActionBusy.set(action.id);
     try {
       const res = await firstValueFrom(
@@ -297,10 +309,10 @@ export class PluginViewComponent {
     };
   }
 
-  /** Closed catalogue of `table` row actionIds core resolves — today just jumping to a row's
-   *  own media page via its `mediaId`/`mediaType` columns; anything else renders no button. */
+  /** Resolves a `TableRowActionId` against its row — today only jumping to that row's own media
+   *  page via its `mediaId`/`mediaType` columns; anything else renders no button. */
   tableResolveAction = (actionId: string, row: TableRow): (() => void) | undefined => {
-    if (actionId !== 'table.open-media') return undefined;
+    if (!isTableRowActionId(actionId)) return undefined;
     const id = row['mediaId'];
     const type = row['mediaType'];
     // Both columns or no button: guessing the type sends a series to a movie page.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -201,6 +201,23 @@ anyone else is `unverified` and reaches an operator behind the consent sheet's a
 `process` plugin must be signed unless its id is in `FLIKS_UNSIGNED_PLUGINS`, which exists for local
 development only.
 
+### Deadlines and ceilings
+
+Core enforces these; exceeding one gets your call abandoned or your process killed. They are
+exported from the contract as `PLUGIN_DEADLINES_MS`, `HOST_CALL_DEADLINE_OVERRIDES_MS`,
+`PLUGIN_LOG_CAP_BYTES_PER_MINUTE`, `PLUGIN_DEFAULT_MEMORY_MB` and `MAX_FRAME_BYTES`, and a test
+fails if they ever stop matching what the supervisor applies.
+
+| What | Value | On breach |
+|---|---|---|
+| `hello` reply | 10 s | killed, restarted with backoff |
+| `health` reply | 3 s, asked every 15 s | 2 misses degrade, 4 recycle |
+| host call | 8 s | the call rejects; `library.ingest` is allowed 30 min |
+| `shutdown` reply | 3 s, then 2 s before SIGKILL | killed |
+| stdout+stderr | 64 KB/min | output dropped for the rest of the minute, once with a warning |
+| heap (`memoryMb`) | 256 MB default | V8 old space only — nothing caps process RSS |
+| one frame | 4 MiB | refused at the sender rather than breaking the connection |
+
 Catalogue sources are HTTPS documents listing each plugin's installable versions with a `sha256`
 per version; core refuses bytes whose hash does not match. Publishing a plugin means committing its
 built source into the catalogue repository, adding a version entry, and running its packaging


### PR DESCRIPTION
The §6 items a major locks in. Each one is either made true or made honest — nothing is left
declared-but-unimplemented on a surface third parties are about to build against.

## `counts.set` had no namespace

The only plugin-writable keyspace without one: `config.*` is force-prefixed `plugin.<id>.`,
`events.emitOwn` is force-prefixed `plugin.<id>.<type>`, and `counts.set` put the plugin's key
straight into a flat process-wide map. A second plugin pushing `queueActive` silently overwrote the
first, and nothing evicted a plugin that stopped.

Entries are now per plugin, and the served key is **summed** across publishers — identical to today
with one publisher, correct with two — with `forget(pluginId)` on unregister so a stopped plugin
stops counting.

Two notes on why this shape:
- an earlier attempt namespaced writes but resolved reads by first-insertion suffix match with no
  eviction, which serves a dead plugin's number for ever and makes the live plugin's pushes
  unreachable — strictly worse than the clobbering it replaced;
- a string-separated key lets a plugin's own free-form key double-count into the same badge, so the
  store is a nested map with no parsing at all.

Free to change **today**: no installed manifest declares a badge and the reference plugin never
calls `counts.set`. After the freeze it would break every published `badge:` declaration.

## `progress.set` promised coalescing it did not do

The contract said "Coalesced server-side to <= 1/media/second". Nothing throttled — and the false
promise is already mirrored into the plugin-side copy of the contract, so an author reading either
side was told the same untrue thing.

Implemented rather than retracted, because retracting would have required a coordinated plugin
release to correct the mirrored comment. A burst now emits once immediately and once on a trailing
timer carrying the **latest** value, so nothing is merely dropped, and the gate is per media so one
download never delays another. The timer is `unref`'d and the gate is deleted after an idle window,
so the map cannot grow with every media ever seen.

## The deadlines were unreachable from a plugin repo

`DEFAULT_SUPERVISOR_OPTIONS` lives in `modules/plugins`, and the host-call override and stderr cap
were module-private. `docs/plugins.md` documented none of the numbers, while a plugin is killed for
breaching them.

They are exported from the contract, **the supervisor now reads them** instead of restating them —
so drift is impossible by construction — and a spec asserts the published figures are the applied
ones. That spec lives in `modules/plugins/supervisor/`, not in the contract directory: the island
must import nothing from `backend/src`, and a spec inside it that imports the supervisor would drag
the whole backend closure into a directory-wide declaration emit.

No figure was invented. An earlier attempt published a 1024 MB cap that exists nowhere in the code.

## The `actionId` catalogues were undiscoverable

Both catalogues — `events.test-delivery` on a form page, `table.open-media` on a table row — were
single hardcoded string comparisons in an Angular feature component no drift gate reads, while the
contract promised only "a closed catalogue core resolves" without enumerating it.

Both are now exported unions with a runtime list beside them, mirrored in the client contract copy,
and the comparisons read that list. Closed-to-one is a defensible policy; closed and undocumented is
not. Neither was widened: adding a member without a core implementation to resolve it would just move
the problem.

The type is enforced at compile time *and* re-checked at runtime, because a manifest is untrusted
JSON. The existing test that feeds an unknown id to prove core refuses it now casts deliberately,
with a comment saying why.

## `checklist` is deprecated, not removed

It is genuinely dead — declared, accepted by the parser, read by nothing. But dropping it from the
accepted key set does not *ignore* it, it **refuses the whole manifest**, so any process plugin in
the field carrying it would stop installing and stop loading with no version bump. That is exactly
what the deprecation window shipped in #978 exists to avoid. It stays accepted, and both the type
and the parser say it is ignored and goes in the next major.

## Verification

- `npx tsc --noEmit` — exit 0.
- Full backend suite: **134 suites, 1489 tests**, exit 0.
- Client suite: 47 files, 389 tests, exit 0.
- Live: backend restarted against the real dev database — all three plugins `active`, both process
  plugins `ready`; the published archive re-inspected through `/api/plugins/import/inspect` still
  reports `installable: true`.
- New tests proven to fail when the line they cover is reverted:
  - coalescing removed → `Expected 1 call, received 3`
  - trailing emit dropped → `Expected 2 calls, received 1`
  - counts eviction, per-plugin isolation and explicit-zero all covered by direct assertions
  - the deadline spec fails on any published figure that stops matching the supervisor
