### PR TITLE
feat(plugins): run each plugin under its own uid

### DIFF
--- a/backend/src/migrations/1783800000000-add-plugin-registration-child-uid.ts
+++ b/backend/src/migrations/1783800000000-add-plugin-registration-child-uid.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+// Plugin children all dropped to one shared uid, so at kernel level each could read the others'
+// /proc environ — token, socket paths and database credentials — and open their sockets. A uid per
+// plugin separates them; it has to be stable, because the plugin's data directory is owned by it.
+export class AddPluginRegistrationChildUid1783800000000
+  implements MigrationInterface
+{
+  name = 'AddPluginRegistrationChildUid1783800000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "plugin_registrations" ADD COLUMN IF NOT EXISTS "childUid" integer`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "plugin_registrations"
+         ADD CONSTRAINT "UQ_plugin_registrations_child_uid" UNIQUE ("childUid")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "plugin_registrations" DROP CONSTRAINT IF EXISTS "UQ_plugin_registrations_child_uid"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "plugin_registrations" DROP COLUMN IF EXISTS "childUid"`,
+    );
+  }
+}

--- a/backend/src/modules/plugins/entities/plugin-registration.entity.ts
+++ b/backend/src/modules/plugins/entities/plugin-registration.entity.ts
@@ -12,6 +12,10 @@ export class PluginRegistration extends BaseEntity {
   @Column({ type: 'text', array: true, default: () => "'{}'" })
   ingestRoots: string[];
 
+  /** The unprivileged uid this plugin's child runs as. Stable: its data directory is owned by it. */
+  @Column({ type: 'int', nullable: true, unique: true })
+  childUid: number | null;
+
   /** Scopes consented to at install, a subset of the manifest's declared `scopes`. */
   @Column({ type: 'text', array: true, default: () => "'{}'" })
   scopes: PluginScope[];

--- a/backend/src/modules/plugins/plugin-install.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-install.service.spec.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosRequestConfig } from 'axios';
+import { PLUGIN_UID_MIN } from './supervisor/spawn-plan';
 import { createHash } from 'crypto';
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
@@ -790,7 +791,7 @@ describe('PluginInstallService', () => {
 
       await expect(service.restart(manifest.id)).resolves.toBeUndefined();
 
-      expect(processService.startFor).toHaveBeenCalledWith(expect.objectContaining({ pluginId: manifest.id }));
+      expect(processService.startFor).toHaveBeenCalledWith(expect.objectContaining({ pluginId: manifest.id }), PLUGIN_UID_MIN);
       expect(repo.rows.get(manifest.id)).toEqual(expect.objectContaining({ status: 'active', statusReason: null }));
     });
 

--- a/backend/src/modules/plugins/plugin-process.service.ts
+++ b/backend/src/modules/plugins/plugin-process.service.ts
@@ -80,7 +80,7 @@ export class PluginProcessService implements OnApplicationShutdown {
 
   /** Stop -> materialise -> provision-check -> rotate -> config -> spawn; each stage's failure
    *  carries its own reason. A slow handshake is reported but left running to retry on its own. */
-  async startFor(pkg: PluginPackage): Promise<PluginProcessStartResult> {
+  async startFor(pkg: PluginPackage, childUid?: number): Promise<PluginProcessStartResult> {
     const manifest = pkg.manifest;
     if (manifest.kind !== 'process') {
       throw new Error(`startFor() called for non-process plugin "${pkg.pluginId}"`);
@@ -114,6 +114,7 @@ export class PluginProcessService implements OnApplicationShutdown {
       dbUrl,
       config,
       pluginApi: manifest.pluginApi,
+      ...(childUid === undefined ? {} : { childUid }),
       memoryMb: manifest.memoryMb,
       hostApi: this.hostBinding?.bind(pkg.pluginId) ?? null,
     });

--- a/backend/src/modules/plugins/plugin-registry.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.spec.ts
@@ -1,6 +1,7 @@
 jest.mock('./supervisor/pid-file', () => ({ sweepOrphans: jest.fn() }));
 
 import { PluginRegistryService } from './plugin-registry.service';
+import { PLUGIN_UID_MIN } from './supervisor/spawn-plan';
 import { PluginPackage } from './entities/plugin-package.entity';
 import { buildZip, ZipEntrySpec } from './archive/zip-builder';
 import { generateTestKeypair, signManifestBase64 } from './archive/ed25519-test-keys';
@@ -294,7 +295,7 @@ describe('PluginRegistryService.register()', () => {
       const result = await service.register(pkg);
 
       expect(result).toEqual({ ok: true, pluginId: pkg.pluginId });
-      expect(processService.startFor).toHaveBeenCalledWith(pkg);
+      expect(processService.startFor).toHaveBeenCalledWith(pkg, PLUGIN_UID_MIN);
       expect(service.get(pkg.pluginId)).toBeDefined();
       const row = registrationRepo.rows.get(pkg.pluginId);
       expect(row).toEqual(

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -15,6 +15,7 @@ import type { SupervisorState } from './supervisor/plugin-supervisor';
 import { sweepOrphans } from './supervisor/pid-file';
 import { getPluginsSocketDir } from '../../common/constants/paths';
 import { PluginCountsCacheService } from './host/plugin-counts-cache.service';
+import { allocateChildUid } from './supervisor/spawn-plan';
 import { arePluginsDisabled, FLIKS_PLUGINS_DISABLED_ENV } from '../../common/constants/plugin-flags';
 import {
   SUPPORTED_PLUGIN_API_VERSIONS,
@@ -380,9 +381,19 @@ export class PluginRegistryService implements OnModuleInit {
       registration.manifest = manifest;
       registration.ingestRoots = manifest.ingestRoots;
     }
+    if (registration.childUid === null || registration.childUid === undefined) {
+      const taken = (await this.registrationRepo.find())
+        .map((r) => r.childUid)
+        .filter((uid): uid is number => uid !== null && uid !== undefined);
+      const allocated = allocateChildUid(taken);
+      if (allocated === null) {
+        return this.fail(pkg.pluginId, 'db-provision-failed', 'no unprivileged uid is free for this plugin');
+      }
+      registration.childUid = allocated;
+    }
     await this.registrationRepo.save(registration);
 
-    const result = await this.processService.startFor(pkg);
+    const result = await this.processService.startFor(pkg, registration.childUid);
     if (!result.ok) return this.fail(pkg.pluginId, result.reason, result.detail);
     return { ok: true };
   }

--- a/backend/src/modules/plugins/plugin-registry.test-helpers.ts
+++ b/backend/src/modules/plugins/plugin-registry.test-helpers.ts
@@ -5,6 +5,7 @@ import type { PluginProcessStartResult } from './plugin-process.service';
 
 export function fakeRegistrationRepo(): {
   rows: Map<string, PluginRegistration>;
+  find: jest.Mock;
   findOne: jest.Mock;
   create: jest.Mock;
   save: jest.Mock;
@@ -14,6 +15,7 @@ export function fakeRegistrationRepo(): {
   let nextId = 1;
   return {
     rows,
+    find: jest.fn(async () => [...rows.values()]),
     findOne: jest.fn(async ({ where: { pluginId } }: { where: { pluginId: string } }) => rows.get(pluginId) ?? null),
     create: jest.fn(
       (partial: Partial<PluginRegistration>) =>

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.spec.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.spec.ts
@@ -6,6 +6,7 @@ import { RpcChannel } from './rpc-channel';
 import { pidFilePath } from './pid-file';
 import { pluginDataDir } from '../plugin-paths';
 import { PLUGIN_API_VERSION, type PluginHostApi } from '../../../common/plugin-contract';
+import { PLUGIN_CHILD_UID } from './spawn-plan';
 import {
   delay,
   makeFixtureDir,
@@ -69,6 +70,7 @@ describe('DEFAULT_SUPERVISOR_OPTIONS', () => {
   it('has these exact default values', () => {
     expect(DEFAULT_SUPERVISOR_OPTIONS).toEqual({
       pluginApi: PLUGIN_API_VERSION,
+      childUid: PLUGIN_CHILD_UID,
       memoryMb: 256,
       handshakeDeadlineMs: 10_000,
       healthIntervalMs: 15_000,

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
@@ -56,6 +56,7 @@ const SELF_DECLARED_WARN = /^(?:\[[^\]]*\]\s*)*WARN\b/;
 /** Every figure here is "The spawn call and the supervisor"'s, verbatim. Override only in tests. */
 export const DEFAULT_SUPERVISOR_OPTIONS = {
   pluginApi: PLUGIN_API_VERSION,
+  childUid: PLUGIN_CHILD_UID,
   memoryMb: PLUGIN_DEFAULT_MEMORY_MB,
   handshakeDeadlineMs: PLUGIN_DEADLINES_MS.handshake,
   healthIntervalMs: PLUGIN_DEADLINES_MS.healthInterval,
@@ -74,6 +75,8 @@ export interface PluginSupervisorOptions {
   id: string;
   /** The version this plugin's manifest declares — core answers it in that version, not the newest. */
   pluginApi?: number;
+  /** The uid this plugin's child runs as. Distinct per plugin, so siblings stay separated. */
+  childUid?: number;
   /** Directory already holding a materialized `plugin.js` (extraction is out of this PR's scope). */
   dir: string;
   /** Where the sockets and pid file live. Defaults to the `fliks-rt` directory,
@@ -246,7 +249,7 @@ export class PluginSupervisor implements OnApplicationShutdown {
   /** Non-null only when the child will run as another uid, which is the only case needing a chown. */
   private dropTarget(): { uid: number; gid: number } | null {
     return shouldDropPrivileges(process.platform, process.getuid?.bind(process))
-      ? { uid: PLUGIN_CHILD_UID, gid: PLUGIN_CHILD_GID }
+      ? { uid: this.opts.childUid, gid: PLUGIN_CHILD_GID }
       : null;
   }
 
@@ -442,6 +445,7 @@ export class PluginSupervisor implements OnApplicationShutdown {
       token: this.token,
       pluginId: this.opts.id,
       pluginApi: this.opts.pluginApi,
+      childUid: this.opts.childUid,
       dbUrl: this.opts.dbUrl,
       config: this.opts.config,
     });

--- a/backend/src/modules/plugins/supervisor/spawn-plan.spec.ts
+++ b/backend/src/modules/plugins/supervisor/spawn-plan.spec.ts
@@ -3,6 +3,8 @@ import { tmpdir } from 'os';
 import { dirname, join } from 'path';
 import { PLUGIN_API_VERSION, SUPPORTED_PLUGIN_API_VERSIONS } from '../../../common/plugin-contract';
 import {
+  PLUGIN_UID_MIN,
+  allocateChildUid,
   buildSpawnPlan,
   prepareDirForDroppedChild,
   resolvePermissionFlag,
@@ -53,7 +55,30 @@ describe('buildSpawnPlan', () => {
     token: 'the-token',
     pluginId: 'demo',
     pluginApi: PLUGIN_API_VERSION,
+    childUid: PLUGIN_UID_MIN,
   };
+
+  it('gives each plugin its own uid, and reuses one freed by an uninstall', () => {
+    expect(allocateChildUid([])).toBe(PLUGIN_UID_MIN);
+    expect(allocateChildUid([PLUGIN_UID_MIN])).toBe(PLUGIN_UID_MIN + 1);
+    // A gap left by an uninstalled plugin is filled before the range grows.
+    expect(allocateChildUid([PLUGIN_UID_MIN, PLUGIN_UID_MIN + 2])).toBe(PLUGIN_UID_MIN + 1);
+  });
+
+  it('refuses rather than colliding once the range is exhausted', () => {
+    const everyUid = Array.from({ length: 64999 - PLUGIN_UID_MIN + 1 }, (_, i) => PLUGIN_UID_MIN + i);
+    expect(allocateChildUid(everyUid)).toBeNull();
+  });
+
+  it('spawns the child under the uid it was given, not one shared with every other plugin', () => {
+    const plan = buildSpawnPlan({ ...baseInput, childUid: PLUGIN_UID_MIN + 7 });
+    // Only meaningful where core can actually drop privileges; the field is absent otherwise.
+    if (shouldDropPrivileges(process.platform, process.getuid?.bind(process))) {
+      expect(plan.options.uid).toBe(PLUGIN_UID_MIN + 7);
+    } else {
+      expect(plan.options.uid).toBeUndefined();
+    }
+  });
 
   it('never spreads process.env — the env is exactly the allowlist plus FLIKS_CFG_* re-keys', () => {
     process.env.PLUGIN_SUPERVISOR_TEST_LEAK = 'should-not-appear';

--- a/backend/src/modules/plugins/supervisor/spawn-plan.ts
+++ b/backend/src/modules/plugins/supervisor/spawn-plan.ts
@@ -3,9 +3,26 @@ import { chmodSync, chownSync, mkdirSync, readdirSync } from 'fs';
 import { dirname, join } from 'path';
 import { type PluginSpawnEnv } from '../../../common/plugin-contract';
 
-/** The unprivileged identity a plugin child drops to when core runs as root. */
+/** The unprivileged identity a plugin child drops to when core runs as root, used when no uid was
+ *  allocated for it. Sharing it is what lets one child read another's `/proc` entry. */
 export const PLUGIN_CHILD_UID = 65534;
+
+/** Shared by every child: the runtime directory is group-traversable so each can reach its own
+ *  socket, while the 0600 socket and 0700 data directory are owned by the plugin's own uid. */
 export const PLUGIN_CHILD_GID = 65534;
+
+/** Allocation range for per-plugin uids. Below `nobody`, above anything a base image assigns. */
+export const PLUGIN_UID_MIN = 60000;
+export const PLUGIN_UID_MAX = 64999;
+
+/** Lowest free uid in the range, or null when every one of them is taken. */
+export function allocateChildUid(taken: readonly number[]): number | null {
+  const used = new Set(taken);
+  for (let uid = PLUGIN_UID_MIN; uid <= PLUGIN_UID_MAX; uid++) {
+    if (!used.has(uid)) return uid;
+  }
+  return null;
+}
 
 let cachedPermissionFlag: string | null = null;
 
@@ -53,6 +70,8 @@ export function prepareDirForDroppedChild(
 
 export interface SpawnPlanInput {
   dir: string;
+  /** This plugin's own uid, so a sibling cannot read its `/proc` entry or open its socket. */
+  childUid: number;
   /** `pluginDataDir(pluginId)` — outside `dir`, so it outlives this spawn's code tree. */
   dataDir: string;
   memoryMb: number;
@@ -123,7 +142,7 @@ export function buildSpawnPlan(input: SpawnPlanInput): SpawnPlan {
     detached: false,
     windowsHide: true,
     env,
-    ...(root ? { uid: PLUGIN_CHILD_UID, gid: PLUGIN_CHILD_GID } : {}),
+    ...(root ? { uid: input.childUid, gid: PLUGIN_CHILD_GID } : {}),
   };
 
   const expectedCmdline = [process.execPath, ...nodeArgv];


### PR DESCRIPTION
The kernel-level hole underneath #979. That PR made a plugin's socket path unguessable, which closed
the route reachable *inside* the Node sandbox — but I flagged at the time that the boundary still
rested on one experimental flag. This removes that dependency.

## What was reachable

Every plugin child dropped to the same uid (65534). Same uid means, at kernel level:

| Attack | Before |
|---|---|
| read the neighbour's `/proc/<pid>/environ` | its `FLIKS_PLUGIN_TOKEN`, both socket paths and `FLIKS_DB_URL` (**its database credentials**) |
| read/write the neighbour's data directory | 0700, but owned by the same uid |
| connect to the neighbour's core socket | 0600, but owned by the same uid — and connecting is not gated by the fs permission model at all |

Under `--permission` those reads are denied, which is why #979's random socket name held. But the
whole separation was one flag deep: a plugin that escaped the sandbox got all of it.

## What it is now

A uid per plugin, allocated from a reserved range on first activation and stored on the registration
row. It has to be stable, because the plugin's data directory is owned by it.

The **group stays shared** deliberately: the runtime directory is `0710` group-traversable so each
child can reach its own socket, while the socket (`0600`) and the data directory (`0700`) are owned
by the plugin's own uid. Splitting the gid too would have cost the traversal and bought nothing.

Allocation fills a gap freed by an uninstall before growing the range, and returns null rather than
colliding when the range is exhausted. The column is `UNIQUE`, so two plugins sharing an identity is
a constraint violation, not a silent overlap — verified by running the migration's own statements in
a rolled-back transaction and watching the third insert fail.

## Measured on the running stack

Two plugins installed, `fliks.download` at uid 60000 and `acme.hello` at 60001, each with its socket
and data directory owned accordingly. Running as 60001 against 60000:

```
attacker=60001 victim pid=1152
proc environ       -> ERR_ACCESS_DENIED (denied)
victim data dir    -> ERR_ACCESS_DENIED (denied)
victim core socket -> EACCES (denied)
```

and with the sandbox flag removed entirely — a plugin that has fully escaped the permission model:

```
=== attacker uid 60001, NO --permission (kernel only) ===
proc environ       -> EACCES (denied)
victim data dir    -> EACCES (denied)
victim core socket -> EACCES (denied)
```

The socket denial is now `EACCES` rather than a missing path: knowing the name no longer helps.

## Verification

- `npx tsc --noEmit` — exit 0.
- Full backend suite: 134 suites, **1492 tests**, exit 0.
- Live: all three plugins `active`, both process plugins `ready`, distinct uids in
  `plugin_registrations` and on the real child processes.
- Migration applied statement-by-statement against a table copy in a rolled-back transaction; the
  duplicate-uid insert failed on the unique constraint as intended.
- New tests: allocation reuses a freed uid, refuses an exhausted range, and the spawn plan carries
  the given uid rather than the shared default.

## Note

Existing installs get a uid on their next activation, and `prepareDirForDroppedChild` re-chowns the
data directory on every spawn, so a directory owned by the old shared uid is adopted automatically.
