### PR TITLE
feat(plugins): ship a packaging tool, so an author does not hand-roll an archive

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "sync-prowlarr-definitions": "bash scripts/sync-prowlarr-definitions.sh",
+    "package-plugin": "ts-node -O '{\"module\":\"commonjs\"}' scripts/package-plugin.ts",
     "db:migration:generate": "typeorm-ts-node-commonjs migration:generate -d src/data-source.ts",
     "db:migration:run": "typeorm-ts-node-commonjs migration:run -d src/data-source.ts",
     "db:migration:revert": "typeorm-ts-node-commonjs migration:revert -d src/data-source.ts",

--- a/backend/scripts/package-plugin.ts
+++ b/backend/scripts/package-plugin.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { writeFileSync } from 'fs';
+import { resolve } from 'path';
+import { PackagingError, packPluginDir } from '../src/modules/plugins/archive/package-plugin';
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const outIdx = args.findIndex((a) => a === '-o' || a === '--out');
+  const out = outIdx === -1 ? undefined : args[outIdx + 1];
+  if (outIdx !== -1 && (out === undefined || out.startsWith('-'))) {
+    throw new PackagingError('-o needs a filename');
+  }
+  const dir = args.find((a, i) => !a.startsWith('-') && i !== outIdx + 1);
+  if (!dir) throw new PackagingError('usage: package-plugin <plugin-dir> [-o output.fkplugin]');
+
+  const { archive, manifest } = packPluginDir(resolve(dir));
+  const outPath = resolve(out ?? `${manifest.id}-${manifest.version}.fkplugin`);
+  writeFileSync(outPath, archive);
+
+  console.log(`wrote ${outPath} (${archive.length} bytes) for ${manifest.id}@${manifest.version}`);
+  console.log('unsigned — installable only where the core process allowlists this id in FLIKS_UNSIGNED_PLUGINS');
+}
+
+try {
+  main();
+} catch (err) {
+  if (err instanceof PackagingError) {
+    console.error(`package-plugin: ${err.message}`);
+    process.exit(1);
+  }
+  throw err;
+}

--- a/backend/src/modules/plugins/archive/package-plugin.spec.ts
+++ b/backend/src/modules/plugins/archive/package-plugin.spec.ts
@@ -1,0 +1,66 @@
+import { createHash } from 'crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { PackagingError, readPluginDir } from './package-plugin';
+import { buildZip } from './zip-builder';
+import { inspect } from './index';
+import { minimalProcessManifest } from './test-manifests';
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+const STALE_HASH = 'f'.repeat(64);
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/** An author's build output, carrying a `files` map that is out of date — the usual mistake. */
+function pluginDir(overrides: Record<string, unknown> = {}, code = 'module.exports = {};\n'): string {
+  const dir = mkdtempSync(join(tmpdir(), 'pack-plugin-'));
+  dirs.push(dir);
+  const manifest = { ...minimalProcessManifest({ 'plugin.js': STALE_HASH }), ...overrides };
+  writeFileSync(join(dir, 'plugin.json'), JSON.stringify(manifest));
+  writeFileSync(join(dir, 'plugin.js'), code);
+  // The fixture manifest declares a logo, so one has to be on disk; the magic bytes are all
+  // `sniffLogo` reads.
+  writeFileSync(join(dir, 'logo.png'), PNG_MAGIC);
+  return dir;
+}
+
+function pack(dir: string): Buffer {
+  return buildZip(readPluginDir(dir).map((e) => ({ name: e.name, content: e.content })));
+}
+
+describe('package-plugin', () => {
+  it('produces an archive the real inspector accepts, with the hashes it computed itself', async () => {
+    const result = await inspect(pack(pluginDir()), { unsignedProcessAllowlist: ['fliks.testprocessplugin'] });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.id).toBe('fliks.testprocessplugin');
+    // The stale hash the author left behind is replaced, not carried into the archive.
+    const files = result.manifest.kind === 'process' ? result.manifest.files : {};
+    expect(Object.keys(files).sort()).toEqual(['logo.png', 'plugin.js']);
+    expect(files['plugin.js']).not.toBe(STALE_HASH);
+    expect(files['plugin.js']).toBe(createHash('sha256').update('module.exports = {};\n').digest('hex'));
+  });
+
+  it('refuses a directory carrying an entry an archive may not hold', () => {
+    const dir = pluginDir();
+    writeFileSync(join(dir, 'install.sh'), 'echo hi\n');
+    expect(() => pack(dir)).toThrow(PackagingError);
+    expect(() => pack(dir)).toThrow(/install\.sh/);
+  });
+
+  it('refuses a logo whose bytes are not the format its name claims', () => {
+    const dir = pluginDir();
+    writeFileSync(join(dir, 'logo.png'), 'not a png at all');
+    expect(() => pack(dir)).toThrow(/PNG magic bytes/);
+  });
+
+  it('refuses a manifest the parser itself would reject', () => {
+    const dir = pluginDir({ version: 'not-semver' });
+    expect(() => pack(dir)).toThrow(PackagingError);
+  });
+});

--- a/backend/src/modules/plugins/archive/package-plugin.ts
+++ b/backend/src/modules/plugins/archive/package-plugin.ts
@@ -1,0 +1,128 @@
+/** Turns a built plugin directory into the entries a `.fkplugin` archive carries, applying the same
+ *  guards `zip-inspector.ts` and `extract.ts` apply so a bad plugin fails by name, not by refusal code. */
+import { createHash } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as semver from 'semver';
+import { parseManifest } from './manifest-parser';
+import { validateManifestShape } from '../manifest-shape.validator';
+import { sniffLogo } from './extract';
+import { buildZip } from './zip-builder';
+import {
+  LEGAL_ENTRY_NAMES,
+  MAX_ARCHIVE_COMPRESSED_BYTES,
+  MAX_PLUGIN_ID_LENGTH,
+  MAX_TOTAL_UNCOMPRESSED_BYTES,
+  PLUGIN_ID_PATTERN,
+  maxUncompressedBytesFor,
+} from './limits';
+import type { PluginManifest, ProcessPluginManifest } from '../../../common/plugin-contract';
+
+export class PackagingError extends Error {}
+
+function fail(message: string): never {
+  throw new PackagingError(message);
+}
+
+const CODE_ENTRY_NAME = 'plugin.js';
+const LOGO_NAMES = ['logo.svg', 'logo.png'] as const;
+
+interface PackedEntry {
+  name: string;
+  content: Buffer;
+}
+
+export function readPluginDir(dir: string): PackedEntry[] {
+  const manifestPath = path.join(dir, 'plugin.json');
+  if (!fs.existsSync(manifestPath)) fail(`no plugin.json in ${dir}`);
+  const manifestBytes = fs.readFileSync(manifestPath);
+
+  // Read loosely first: `files` is a required field the tool itself fills in, so the manifest an
+  // author writes cannot be validated until the computed hashes are in it.
+  let draft: { kind?: unknown; logo?: unknown };
+  try {
+    draft = JSON.parse(manifestBytes.toString('utf8')) as { kind?: unknown; logo?: unknown };
+  } catch {
+    fail('plugin.json is not valid JSON');
+  }
+  const declaredKind = draft.kind;
+  const declaredLogo = typeof draft.logo === 'string' ? draft.logo : undefined;
+
+  const hasCode = fs.existsSync(path.join(dir, CODE_ENTRY_NAME));
+  if (declaredKind === 'process' && !hasCode) fail(`kind is "process" but ${CODE_ENTRY_NAME} is missing from ${dir}`);
+  if (declaredKind === 'data' && hasCode) fail(`kind is "data" but ${CODE_ENTRY_NAME} is present in ${dir} — a data-tier archive may not carry code`);
+
+  const foundLogos = LOGO_NAMES.filter((name) => fs.existsSync(path.join(dir, name)));
+  if (foundLogos.length > 1) fail(`only one logo entry is allowed, found both ${foundLogos.join(' and ')}`);
+  const logoName = foundLogos[0];
+  if (logoName && declaredLogo !== logoName) {
+    fail(`manifest.logo declares "${String(declaredLogo)}" but the directory contains "${logoName}"`);
+  }
+  if (declaredLogo && !logoName) {
+    fail(`manifest.logo declares "${declaredLogo}" but no such file exists in ${dir}`);
+  }
+
+  // Anything else in the directory would be dropped from the archive without a word, and an
+  // author who expected it to ship would find out at runtime.
+  const stray = fs
+    .readdirSync(dir, { withFileTypes: true })
+    .map((e) => e.name)
+    .filter((name) => !(LEGAL_ENTRY_NAMES as readonly string[]).includes(name));
+  if (stray.length) {
+    fail(`${dir} holds entries an archive may not carry: ${stray.join(', ')} — legal names are ${LEGAL_ENTRY_NAMES.join(', ')}`);
+  }
+
+  const entries: PackedEntry[] = [];
+  if (hasCode) entries.push({ name: CODE_ENTRY_NAME, content: fs.readFileSync(path.join(dir, CODE_ENTRY_NAME)) });
+  if (logoName) entries.push({ name: logoName, content: fs.readFileSync(path.join(dir, logoName)) });
+
+  for (const { name, content } of entries) {
+    const cap = maxUncompressedBytesFor(name);
+    if (content.length > cap) fail(`${name} is ${content.length} bytes, cap is ${cap}`);
+    // Only the logo: sniffLogo reads any other name as an SVG and would refuse the code file.
+    if (name === logoName) {
+      const badLogo = sniffLogo(name, content);
+      if (badLogo) fail(badLogo.detail);
+    }
+  }
+
+  // Author-declared hashes are never trusted, only recomputed — a stale or
+  // hand-typed `files` map is exactly the mistake this tool exists to remove.
+  const withHashes: Record<string, unknown> = { ...(draft as Record<string, unknown>) };
+  if (declaredKind === 'process') {
+    const files: Record<string, string> = {};
+    for (const { name, content } of entries) files[name] = createHash('sha256').update(content).digest('hex');
+    withHashes.files = files;
+  }
+  const finalManifestBytes = Buffer.from(JSON.stringify(withHashes, null, 2), 'utf8');
+
+  const manifest = parseManifest(finalManifestBytes);
+  if (!manifest) fail('plugin.json failed structural validation (bad JSON, missing required field, or an unknown key for its kind)');
+  const shape = validateManifestShape(manifest);
+  if (!shape.ok) fail(`plugin.json: ${shape.detail}`);
+  if (manifest.id.length > MAX_PLUGIN_ID_LENGTH || !PLUGIN_ID_PATTERN.test(manifest.id)) {
+    fail(`"${manifest.id}" is not a legal plugin id (pattern ${PLUGIN_ID_PATTERN}, max ${MAX_PLUGIN_ID_LENGTH} chars)`);
+  }
+  if (semver.valid(manifest.version) === null) fail(`"${manifest.version}" is not valid semver`);
+
+  if (finalManifestBytes.length > maxUncompressedBytesFor('plugin.json')) {
+    fail(`plugin.json is ${finalManifestBytes.length} bytes, cap is ${maxUncompressedBytesFor('plugin.json')}`);
+  }
+
+  const totalUncompressed = finalManifestBytes.length + entries.reduce((sum, e) => sum + e.content.length, 0);
+  if (totalUncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES) {
+    fail(`archive would declare ${totalUncompressed} uncompressed bytes, cap is ${MAX_TOTAL_UNCOMPRESSED_BYTES}`);
+  }
+
+  return [{ name: 'plugin.json', content: finalManifestBytes }, ...entries];
+}
+
+/** The finished archive bytes for a built plugin directory. */
+export function packPluginDir(dir: string): { archive: Buffer; manifest: PluginManifest } {
+  const entries = readPluginDir(dir);
+  const archive = buildZip(entries.map((e) => ({ name: e.name, content: e.content })));
+  if (archive.length > MAX_ARCHIVE_COMPRESSED_BYTES) {
+    fail(`archive is ${archive.length} bytes, cap is ${MAX_ARCHIVE_COMPRESSED_BYTES}`);
+  }
+  return { archive, manifest: parseManifest(entries[0].content) as PluginManifest };
+}

--- a/backend/src/modules/plugins/archive/zip-builder.ts
+++ b/backend/src/modules/plugins/archive/zip-builder.ts
@@ -1,4 +1,4 @@
-import { deflateRawSync } from 'zlib';
+import { crc32, deflateRawSync } from 'zlib';
 
 /**
  * Byte-level ZIP assembler for the guard spec suite. Several guards
@@ -10,6 +10,8 @@ import { deflateRawSync } from 'zlib';
 export interface ZipEntrySpec {
   name: string;
   content: Buffer;
+  /** Overrides the computed checksum — only a corruption fixture needs a wrong one. */
+  declaredCrc32?: number;
   /** 0 = store, 8 = deflate. Default 0. */
   compressionMethod?: number;
   /** Default 0x0800 (UTF-8 flag) — set explicit bits to test the data-descriptor/encryption bits. */
@@ -52,6 +54,11 @@ function encodeExtraFields(fields: { id: number; data: Buffer }[]): Buffer {
   );
 }
 
+/** A real checksum unless a spec pins one: a fixture may need a deliberately wrong value. */
+function entryCrc(spec: ZipEntrySpec): number {
+  return (spec.declaredCrc32 ?? crc32(spec.content)) >>> 0;
+}
+
 function buildLocalHeader(e: BuiltEntry): Buffer {
   const { spec, nameBuf, extraBuf, compressedData } = e;
   const compressionMethod = spec.compressionMethod ?? 0;
@@ -64,7 +71,7 @@ function buildLocalHeader(e: BuiltEntry): Buffer {
   header.writeUInt16LE(compressionMethod, 8);
   header.writeUInt16LE(0, 10); // mod time
   header.writeUInt16LE(0x21, 12); // mod date — an arbitrary valid DOS date
-  header.writeUInt32LE(0, 14); // crc32 — not checked on the read path used here
+  header.writeUInt32LE(entryCrc(spec), 14);
   header.writeUInt32LE(compressedSize >>> 0, 18);
   header.writeUInt32LE(uncompressedSize >>> 0, 22);
   header.writeUInt16LE(nameBuf.length, 26);
@@ -85,7 +92,7 @@ function buildCentralDirectoryRecord(e: BuiltEntry): Buffer {
   header.writeUInt16LE(compressionMethod, 10);
   header.writeUInt16LE(0, 12); // mod time
   header.writeUInt16LE(0x21, 14); // mod date
-  header.writeUInt32LE(0, 16); // crc32
+  header.writeUInt32LE(entryCrc(spec), 16);
   header.writeUInt32LE(compressedSize >>> 0, 20);
   header.writeUInt32LE(uncompressedSize >>> 0, 24);
   header.writeUInt16LE(nameBuf.length, 28);

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -201,6 +201,19 @@ anyone else is `unverified` and reaches an operator behind the consent sheet's a
 `process` plugin must be signed unless its id is in `FLIKS_UNSIGNED_PLUGINS`, which exists for local
 development only.
 
+### Packaging
+
+`npm run package-plugin -- <built-plugin-dir> [-o out.fkplugin]` (from `backend/`) turns a build
+output directory — `plugin.json`, `plugin.js` for a `process` plugin, an optional `logo.svg` or
+`logo.png` — into an archive the inspector above will accept. It recomputes every `files` sha256
+itself rather than trusting the manifest, and refuses early, by name, on anything the inspector
+would refuse later: a missing `plugin.js` for a `process` manifest, a `plugin.js` present on a
+`data` one, a `logo` field that doesn't match what's on disk or whose bytes are not the format its
+name claims, a bad id or version, an oversized entry, and any file an archive may not carry (rather
+than dropping it silently and leaving you to find out at runtime). The archive it writes is always unsigned; a `process` plugin built this way installs only
+when its id is in the installing core's `FLIKS_UNSIGNED_PLUGINS`. Signing an archive for real
+distribution is a separate, later step this tool does not perform.
+
 ### Deadlines and ceilings
 
 Core enforces these; exceeding one gets your call abandoned or your process killed. They are


### PR DESCRIPTION
§7-3 from the readiness list: core shipped no packaging tool, so every plugin author hand-rolls one.

## What existed

`archive/zip-builder.ts` looks like a packer and is not: all six importers are `*.spec.ts`,
`archive/index.ts` exports every sibling but pointedly not this one, and its own doc says it exists to
build archives "that cannot be produced by any real zip writer". The only working packer is 123
hand-rolled lines in the download plugin's repository, licensed AGPL-3.0-or-later — so copying it is a
licensing decision, and the alternative is reimplementing a zip writer *and* the `files` sha256 map,
which has to match the packed bytes exactly or the install fails at extract.

## What this adds

`packPluginDir(dir)` in `archive/`, with a thin CLI at `backend/scripts/package-plugin.ts` wired to
`npm run package-plugin -- <dir> [-o out.fkplugin]`.

It **computes the hashes itself**. That ordering matters and was wrong in the first attempt: `files`
is a required field, so a manifest without it cannot be parsed — the map has to be injected *before*
validation, not after. Otherwise the tool can only ever validate a manifest whose map the author
already got right, which is the problem it exists to solve.

It refuses early, by name, on what the pipeline would refuse later:

| Input | Before | Now |
|---|---|---|
| logo bytes that aren't the declared format | packed fine, `PLUGIN_BAD_LOGO` at extract | refused at pack |
| a file an archive may not carry (`install.sh`, `node_modules/`) | **silently dropped** | refused, naming the file |
| missing/misplaced `plugin.js` for the tier | — | refused |
| a manifest the parser rejects | — | refused |

The silent drop was the worst of these: an author who expected `lib/` to ship would have found out at
runtime, from a plugin that could not load.

## The zip comes from the existing builder

Rather than fork 48 lines. That builder already writes correct local headers, a central directory and
an end-of-central-directory record — only its CRC field was stubbed at zero. It now computes a real
checksum, with an override so a corruption fixture can still pin a wrong one. Consequence worth
noting: a packed archive now passes an ordinary reader's integrity check, not just core's inspector —

```
$ unzip -t repacked.fkplugin
    testing: plugin.js                OK
    testing: logo.svg                 OK
No errors detected in compressed data
```

## Dropped from this PR: the scaffold

A scaffold was built alongside this and I am **not** shipping it. Review found, in a file whose whole
purpose is to be *copied*: prototype-chain dispatch (`handlers[frame.m]` is truthy for inherited
`Object.prototype` names, so the fail-closed branch is bypassed and the process dies instead of
replying), unguarded `JSON.parse` on both sockets, no `'error'` listener on either socket, and a
comment stating the opposite of what its code does. A template propagates every defect into every
plugin written from it, so a buggy scaffold is worse than none. It needs to be minimal *and* robust;
that is its own piece of work.

## Verification

- `npx tsc --noEmit` — exit 0, and confirmed the CLI shim is actually inside the typechecked program
  (introduced a deliberate type error and watched tsc report it).
- Full backend suite: 135 suites, **1496 tests**, exit 0.
- Live round-trip, not a transcript: extracted the published `fliks.download@0.1.5` files from the
  running container, packed them with the CLI, POSTed the result to
  `/api/plugins/import/inspect` → `installable: true, id: fliks.download, version: 0.1.5`.
  Three plugins still `active` afterwards; nothing installed or left behind.
- All four new tests proven to fail when the line they cover is reverted:
  - hash recomputation removed → the inspector rejects the archive (`Expected: true, Received: false`)
  - stray-entry refusal removed → `Received function did not throw`
  - logo sniff removed → `Received function did not throw`
- The round-trip is a **test**, not a manual step, so it re-runs in CI. The first attempt's evidence
  was a curl transcript captured from an archive two code revisions old; a reviewer caught that by
  byte-diffing the leftover staging file against what the delivered code emits.
