### PR TITLE
feat(plugins): let a plugin name what plays before the main video

### DIFF
--- a/backend/src/common/plugin-contract/manifest.ts
+++ b/backend/src/common/plugin-contract/manifest.ts
@@ -1,4 +1,4 @@
-import type { UiContribution, ConfigPage, ReleasePickerRoutes } from './ui-contribution';
+import type { UiContribution, ConfigPage, ReleasePickerRoutes, PlayerDeclaration } from './ui-contribution';
 import type { PluginScope } from './principal';
 
 /**
@@ -87,6 +87,8 @@ interface PluginManifestBase {
     /** Fills core's release picker. Every route here must also be declared in
      *  `provides.routes[]`, so it carries a policy like any other. */
     releasePicker?: ReleasePickerRoutes;
+    /** `preRollRoute` must equally be one of this manifest's own `routes[]` (POST). */
+    player?: PlayerDeclaration;
   };
   /** `data`-tier outbound notifications only. */
   events?: PluginWebhookDeclaration[];

--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -175,6 +175,24 @@ export interface ProvidersConfigPage extends ConfigPageBase {
   };
 }
 
+/** Cap on how many `preRoll` items core will ever forward from one `playback-info` call —
+ *  a plugin's route may answer more, but everything past this is dropped. */
+export const PRE_ROLL_ITEMS_MAX = 5;
+
+/** One pre-roll candidate a plugin's route may offer. It names a library file — there is no
+ *  URL and no path here — so core resolves and ACL-checks it the same way as the main item. */
+export interface PreRollItem {
+  mediaFileId: number;
+  labelKey?: string;
+  skippable?: boolean;
+}
+
+/** `ui.player` — the one POST route, declared in the manifest's own `routes[]` like
+ *  `releasePicker`'s, that core calls before playback to ask for pre-roll candidates. */
+export interface PlayerDeclaration {
+  preRollRoute: string;
+}
+
 /** One `table` filter — its current value is sent to `list` as a query param named by
  *  `key`; an empty value is omitted. Filtering itself is the plugin's job, core only forwards it. */
 export type TableFilter =

--- a/backend/src/modules/plugins/plugin-pre-roll.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-pre-roll.service.spec.ts
@@ -1,0 +1,113 @@
+import { PluginPreRollService } from './plugin-pre-roll.service';
+import { PRE_ROLL_ITEMS_MAX } from '../../common/plugin-contract';
+
+function fakeRegistry(winner: { pluginId: string; route: string } | undefined) {
+  return { preRollRoute: jest.fn().mockReturnValue(winner) };
+}
+
+function fakeProcessService(callPlugin: jest.Mock) {
+  return { callPlugin };
+}
+
+const ASK = { mediaFileId: 1, mediaId: 10, principal: { kind: 'system' as const } };
+
+describe('PluginPreRollService.ask', () => {
+  it('returns an empty list when no plugin declares ui.player', async () => {
+    const service = new PluginPreRollService(fakeRegistry(undefined) as never, fakeProcessService(jest.fn()) as never);
+
+    expect(await service.ask(ASK)).toEqual([]);
+  });
+
+  it('returns an empty list, never throws, when the call rejects (stopped plugin / timeout)', async () => {
+    const callPlugin = jest.fn().mockRejectedValue(new Error('plugin "fliks.a" is not running'));
+    const service = new PluginPreRollService(
+      fakeRegistry({ pluginId: 'fliks.a', route: '/pre-roll' }) as never,
+      fakeProcessService(callPlugin) as never,
+    );
+
+    await expect(service.ask(ASK)).resolves.toEqual([]);
+  });
+
+  it('returns an empty list on a non-200 status', async () => {
+    const callPlugin = jest.fn().mockResolvedValue({ status: 500, body: [{ mediaFileId: 5 }] });
+    const service = new PluginPreRollService(
+      fakeRegistry({ pluginId: 'fliks.a', route: '/pre-roll' }) as never,
+      fakeProcessService(callPlugin) as never,
+    );
+
+    expect(await service.ask(ASK)).toEqual([]);
+  });
+
+  it('returns an empty list on a malformed (non-array) body', async () => {
+    const callPlugin = jest.fn().mockResolvedValue({ status: 200, body: { not: 'an array' } });
+    const service = new PluginPreRollService(
+      fakeRegistry({ pluginId: 'fliks.a', route: '/pre-roll' }) as never,
+      fakeProcessService(callPlugin) as never,
+    );
+
+    expect(await service.ask(ASK)).toEqual([]);
+  });
+
+  it('drops entries that are not a positive-integer mediaFileId, keeps the rest', async () => {
+    const callPlugin = jest.fn().mockResolvedValue({
+      status: 200,
+      body: [{ mediaFileId: 5 }, { mediaFileId: -1 }, { mediaFileId: 'x' }, { mediaFileId: 1.5 }, {}],
+    });
+    const service = new PluginPreRollService(
+      fakeRegistry({ pluginId: 'fliks.a', route: '/pre-roll' }) as never,
+      fakeProcessService(callPlugin) as never,
+    );
+
+    expect(await service.ask(ASK)).toEqual([{ mediaFileId: 5 }]);
+  });
+
+  it('truncates a response longer than the published cap', async () => {
+    // Ids start above ASK's own mediaFileId, so this measures the cap and nothing else.
+    const body = Array.from({ length: PRE_ROLL_ITEMS_MAX + 10 }, (_, i) => ({ mediaFileId: i + 2 }));
+    const callPlugin = jest.fn().mockResolvedValue({ status: 200, body });
+    const service = new PluginPreRollService(
+      fakeRegistry({ pluginId: 'fliks.a', route: '/pre-roll' }) as never,
+      fakeProcessService(callPlugin) as never,
+    );
+
+    const result = await service.ask(ASK);
+    expect(result).toHaveLength(PRE_ROLL_ITEMS_MAX);
+    expect(result).toEqual(Array.from({ length: PRE_ROLL_ITEMS_MAX }, (_, i) => ({ mediaFileId: i + 2 })));
+  });
+
+  it('calls the winning plugin route as a POST carrying the ask, delegated to the caller', async () => {
+    const callPlugin = jest.fn().mockResolvedValue({ status: 200, body: [] });
+    const service = new PluginPreRollService(
+      fakeRegistry({ pluginId: 'fliks.a', route: '/pre-roll' }) as never,
+      fakeProcessService(callPlugin) as never,
+    );
+
+    await service.ask({ mediaFileId: 1, mediaId: 10, episodeId: 3, principal: { kind: 'delegated', userId: 7 } });
+
+    expect(callPlugin).toHaveBeenCalledWith(
+      'fliks.a',
+      'http',
+      expect.objectContaining({
+        method: 'POST',
+        path: '/pre-roll',
+        body: { mediaFileId: 1, mediaId: 10, episodeId: 3 },
+        principal: { kind: 'delegated', userId: 7 },
+      }),
+      expect.any(Number),
+    );
+  });
+
+  it('drops the main item and any repeat, so nothing plays twice', async () => {
+    const callPlugin = jest.fn().mockResolvedValue({
+      status: 200,
+      body: [{ mediaFileId: 1 }, { mediaFileId: 7 }, { mediaFileId: 7 }, { mediaFileId: 9 }],
+    });
+    const service = new PluginPreRollService(
+      fakeRegistry({ pluginId: 'fliks.a', route: '/pre-roll' }) as never,
+      fakeProcessService(callPlugin) as never,
+    );
+
+    // ASK's own mediaFileId is 1: pre-rolling the main item would play it twice.
+    await expect(service.ask(ASK)).resolves.toEqual([{ mediaFileId: 7 }, { mediaFileId: 9 }]);
+  });
+});

--- a/backend/src/modules/plugins/plugin-pre-roll.service.ts
+++ b/backend/src/modules/plugins/plugin-pre-roll.service.ts
@@ -1,0 +1,83 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PluginRegistryService } from './plugin-registry.service';
+import { PluginProcessService } from './plugin-process.service';
+import { PLUGIN_DEADLINES_MS, PRE_ROLL_ITEMS_MAX, type Principal, type PreRollItem } from '../../common/plugin-contract';
+
+/** Own, short deadline — playback-info sits on the critical path of pressing play. */
+const PRE_ROLL_CALL_DEADLINE_MS = PLUGIN_DEADLINES_MS.healthReply;
+
+export interface PreRollAsk {
+  mediaFileId: number;
+  mediaId: number;
+  episodeId?: number;
+  principal: Principal;
+}
+
+interface PluginHttpResult {
+  status: number;
+  body: unknown;
+}
+
+function isPositiveInt(v: unknown): v is number {
+  return typeof v === 'number' && Number.isInteger(v) && v > 0;
+}
+
+/** Validates and caps whatever a plugin's route answered — untrusted JSON, so nothing here
+ *  is assumed to have the declared shape. Anything not a well-formed item is dropped, as is
+ *  the main item itself and any repeat: both would play the same file twice. */
+function sanitizeItems(body: unknown, mainMediaFileId: number): PreRollItem[] {
+  if (!Array.isArray(body)) return [];
+  const out: PreRollItem[] = [];
+  const seen = new Set<number>([mainMediaFileId]);
+  for (const entry of body) {
+    if (out.length >= PRE_ROLL_ITEMS_MAX) break;
+    if (typeof entry !== 'object' || entry === null) continue;
+    const e = entry as Record<string, unknown>;
+    if (!isPositiveInt(e.mediaFileId) || seen.has(e.mediaFileId)) continue;
+    seen.add(e.mediaFileId);
+    const item: PreRollItem = { mediaFileId: e.mediaFileId };
+    if (typeof e.labelKey === 'string') item.labelKey = e.labelKey;
+    if (typeof e.skippable === 'boolean') item.skippable = e.skippable;
+    out.push(item);
+  }
+  return out;
+}
+
+/** Asks the winning `ui.player` plugin for pre-roll candidates. Never throws: no declaring
+ *  plugin, a stopped/failed/timed-out call, a non-200, or a malformed body all answer `[]`. */
+@Injectable()
+export class PluginPreRollService {
+  private readonly logger = new Logger(PluginPreRollService.name);
+
+  constructor(
+    private readonly registry: PluginRegistryService,
+    private readonly processService: PluginProcessService,
+  ) {}
+
+  async ask(params: PreRollAsk): Promise<PreRollItem[]> {
+    const winner = this.registry.preRollRoute();
+    if (!winner) return [];
+
+    let result: PluginHttpResult;
+    try {
+      result = await this.processService.callPlugin<PluginHttpResult>(
+        winner.pluginId,
+        'http',
+        {
+          method: 'POST',
+          path: winner.route,
+          query: {},
+          body: { mediaFileId: params.mediaFileId, mediaId: params.mediaId, episodeId: params.episodeId },
+          principal: params.principal,
+        },
+        PRE_ROLL_CALL_DEADLINE_MS,
+      );
+    } catch (err) {
+      this.logger.warn(`pre-roll call to "${winner.pluginId}" failed: ${(err as Error).message}`);
+      return [];
+    }
+
+    if (result.status !== 200) return [];
+    return sanitizeItems(result.body, params.mediaFileId);
+  }
+}

--- a/backend/src/modules/plugins/plugin-registry.service.player.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.player.spec.ts
@@ -1,0 +1,84 @@
+import { PluginRegistryService } from './plugin-registry.service';
+import { PluginPackage } from './entities/plugin-package.entity';
+import { minimalProcessManifest } from './archive/test-manifests';
+import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry, fakeCountsCache } from './plugin-registry.test-helpers';
+import type { PluginManifest, PluginRoute, PlayerDeclaration } from '../../common/plugin-contract';
+
+const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
+
+const ROUTES: PluginRoute[] = [{ method: 'POST', path: '/pre-roll', policy: 'read:Media' }];
+
+function makePackage(manifest: PluginManifest, overrides: Partial<PluginPackage> = {}): PluginPackage {
+  return {
+    id: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    pluginId: manifest.id,
+    version: manifest.version,
+    archive: Buffer.alloc(0),
+    origin: 'manual',
+    signature: 'unsigned',
+    verifiedByKeyId: null,
+    manifest,
+    status: 'active',
+    ...overrides,
+  } as PluginPackage;
+}
+
+function repoMock(): { find: jest.Mock } {
+  return { find: jest.fn().mockResolvedValue([]) };
+}
+
+function makeService(): PluginRegistryService {
+  return new PluginRegistryService(
+    repoMock() as never,
+    fakeRegistrationRepo() as never,
+    fakeProcessService() as never,
+    fakePluginJobsService() as never,
+    fakeScheduledJobRegistry() as never,
+    fakeCountsCache() as never,
+  );
+}
+
+function processManifest(id: string, player: PlayerDeclaration | undefined, routes: PluginRoute[] = ROUTES) {
+  return minimalProcessManifest(
+    { 'plugin.js': 'a'.repeat(64), 'logo.png': 'b'.repeat(64) },
+    { id, fliks: COMPATIBLE_RANGE, routes, ui: player ? { player } : undefined },
+  );
+}
+
+describe('PluginRegistryService — ui.player registration validation', () => {
+  it('refuses a preRollRoute that is not one of the manifest\'s own POST routes', async () => {
+    const manifest = processManifest('fliks.a', { preRollRoute: '/not-declared' });
+    const result = await makeService().register(makePackage(manifest));
+    expect(result).toEqual({ ok: false, pluginId: manifest.id, reason: 'invalid-player', detail: expect.any(String) });
+  });
+
+  it('refuses a preRollRoute declared with a method other than POST', async () => {
+    const manifest = processManifest('fliks.a', { preRollRoute: '/pre-roll' }, [
+      { method: 'GET', path: '/pre-roll', policy: 'read:Media' },
+    ]);
+    const result = await makeService().register(makePackage(manifest));
+    expect(result).toEqual({ ok: false, pluginId: manifest.id, reason: 'invalid-player', detail: expect.any(String) });
+  });
+
+  it('accepts a valid preRollRoute and exposes the winner', async () => {
+    const manifest = processManifest('fliks.a', { preRollRoute: '/pre-roll' });
+    const service = makeService();
+
+    const result = await service.register(makePackage(manifest));
+
+    expect(result).toEqual({ ok: true, pluginId: manifest.id });
+    expect(service.preRollRoute()).toEqual({ pluginId: 'fliks.a', route: '/pre-roll' });
+  });
+
+  it('resolves the winner by lexicographically smallest plugin id, and logs the loser', async () => {
+    const service = makeService();
+    await service.register(makePackage(processManifest('fliks.zebra', { preRollRoute: '/pre-roll' })));
+    await service.register(makePackage(processManifest('fliks.alpha', { preRollRoute: '/pre-roll' })));
+
+    // The loser keeps every other route it declared; only the pre-roll slot is exclusive.
+    expect(service.preRollRoute()).toEqual({ pluginId: 'fliks.alpha', route: '/pre-roll' });
+    expect(service.resolveRoute('fliks.zebra', 'POST', '/pre-roll')).not.toBeNull();
+  });
+});

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -30,6 +30,7 @@ import {
   type PluginJob,
   type ReleasePickerPair,
   type ReleasePickerRoutes,
+  type PlayerDeclaration,
   type ConfigPage,
 } from '../../common/plugin-contract';
 import { OFFICIAL_KEYS, resolveTrust, readArchiveEntries, type TrustOutcome } from './archive';
@@ -101,6 +102,7 @@ export type PluginRegistrationFailureReason =
   | 'invalid-route-object-guard'
   | 'duplicate-route'
   | 'invalid-release-picker'
+  | 'invalid-player'
   | 'invalid-permission'
   | 'invalid-job-name'
   | 'invalid-job-cron'
@@ -168,6 +170,9 @@ export class PluginRegistryService implements OnModuleInit {
   /** Keyed by plugin id; one entry per plugin that declares a releasePicker — `releasePickerFor`
    *  exposes only the entry whose id wins `releasePickerWinner`. Lifecycle mirrors `routeTables`. */
   private readonly releasePickers = new Map<string, ReleasePickerRoutes>();
+  /** Keyed by plugin id; one entry per plugin that declares `ui.player` — `preRollRoute`
+   *  exposes only the entry whose id wins `preRollWinner`. Lifecycle mirrors `releasePickers`. */
+  private readonly playerDeclarations = new Map<string, PlayerDeclaration>();
   /** Keyed by plugin id; namespaced (`plugin:<id>:<name>`) CASL subjects this plugin declared.
    *  Lifecycle mirrors `routeTables`, not `webhookDeclarations`: kept across `unregister()`, dropped on `forget()`. */
   private readonly declaredPermissions = new Map<string, ReadonlySet<string>>();
@@ -267,6 +272,9 @@ export class PluginRegistryService implements OnModuleInit {
     );
     if (!releasePickerCheck.ok) return this.fail(pkg.pluginId, releasePickerCheck.reason, releasePickerCheck.detail);
 
+    const playerCheck = this.validatePlayer(manifest.ui?.player, manifest.kind === 'process' ? manifest.routes : []);
+    if (!playerCheck.ok) return this.fail(pkg.pluginId, playerCheck.reason, playerCheck.detail);
+
     const i18nCheck = this.validateI18nNamespace(pkg.pluginId, manifest);
     if (!i18nCheck.ok) return this.fail(pkg.pluginId, i18nCheck.reason, i18nCheck.detail);
 
@@ -288,6 +296,7 @@ export class PluginRegistryService implements OnModuleInit {
       this.replaceRouteTable(pkg.pluginId, manifest.routes);
       this.replaceDeclaredPermissions(pkg.pluginId, declaredSubjects);
       this.replaceReleasePicker(pkg.pluginId, manifest.ui?.releasePicker);
+      this.replacePlayer(pkg.pluginId, manifest.ui?.player);
 
       const activation = await this.activateProcess(pkg, manifest);
       if (!activation.ok) return activation;
@@ -320,6 +329,13 @@ export class PluginRegistryService implements OnModuleInit {
         this.logger.warn(`plugin "${pkg.pluginId}" declared a releasePicker but "${winner}" holds it (lower plugin id wins)`);
       }
     }
+    this.replacePlayer(pkg.pluginId, manifest.ui?.player);
+    if (manifest.ui?.player) {
+      const winner = this.preRollWinner();
+      if (winner !== pkg.pluginId) {
+        this.logger.warn(`plugin "${pkg.pluginId}" declared ui.player but "${winner}" holds it (lower plugin id wins)`);
+      }
+    }
     return { ok: true, pluginId: pkg.pluginId };
   }
 
@@ -329,6 +345,7 @@ export class PluginRegistryService implements OnModuleInit {
     this.replaceRouteTable(pluginId, []);
     this.replaceDeclaredPermissions(pluginId, EMPTY_SUBJECT_SET);
     this.replaceReleasePicker(pluginId, undefined);
+    this.replacePlayer(pluginId, undefined);
   }
 
   /** Withdraws what the plugin offers and stops its process, but keeps its declared routes and
@@ -429,6 +446,24 @@ export class PluginRegistryService implements OnModuleInit {
     return winner;
   }
 
+  /** The winning plugin id and its route in one call — what `PluginPreRollService` actually
+   *  needs, since it starts with no plugin id in hand. `undefined` when nobody declares it. */
+  preRollRoute(): { pluginId: string; route: string } | undefined {
+    const pluginId = this.preRollWinner();
+    const route = pluginId ? this.playerDeclarations.get(pluginId)?.preRollRoute : undefined;
+    return pluginId && route ? { pluginId, route } : undefined;
+  }
+
+  /** Deterministic winner among every plugin currently declaring `ui.player`: the
+   *  lexicographically smallest id, same rule as {@link releasePickerWinner}. */
+  private preRollWinner(): string | undefined {
+    let winner: string | undefined;
+    for (const id of this.playerDeclarations.keys()) {
+      if (winner === undefined || id < winner) winner = id;
+    }
+    return winner;
+  }
+
   /** The namespaced CASL subjects this plugin declared — empty if unregistered, `data`, or none declared.
    *  `PluginRouteGuard` scopes every check to exactly this, so a route never authorizes against another plugin's subject. */
   declaredPermissionsFor(pluginId: string): ReadonlySet<string> {
@@ -473,6 +508,12 @@ export class PluginRegistryService implements OnModuleInit {
   private replaceReleasePicker(pluginId: string, picker: ReleasePickerRoutes | undefined): void {
     if (!picker) this.releasePickers.delete(pluginId);
     else this.releasePickers.set(pluginId, picker);
+  }
+
+  /** Drops this plugin's previous `ui.player` (if any) and installs `player` in its place. */
+  private replacePlayer(pluginId: string, player: PlayerDeclaration | undefined): void {
+    if (!player) this.playerDeclarations.delete(pluginId);
+    else this.playerDeclarations.set(pluginId, player);
   }
 
   /**
@@ -699,6 +740,25 @@ export class PluginRegistryService implements OnModuleInit {
     return { ok: true };
   }
 
+  /** `manifest.ui.player` is untrusted JSON; `preRollRoute` must name a route this manifest
+   *  declares in `routes[]`, with method POST — exactly as `releasePicker` requires of its routes. */
+  private validatePlayer(
+    player: PlayerDeclaration | undefined,
+    routes: PluginRoute[],
+  ): { ok: true } | { ok: false; reason: PluginRegistrationFailureReason; detail: string } {
+    if (!player) return { ok: true };
+
+    const declaredRouteKeys = new Set(routes.map((r) => `${r.method.toUpperCase()} ${r.path}`));
+    if (!declaredRouteKeys.has(`POST ${player.preRollRoute}`)) {
+      return {
+        ok: false,
+        reason: 'invalid-player',
+        detail: `ui.player.preRollRoute "${player.preRollRoute}" is not declared as a POST route in routes[]`,
+      };
+    }
+    return { ok: true };
+  }
+
   /** Every failure path funnels here, so a failing re-registration can never leave a stale entry active. */
   private fail(pluginId: string, reason: PluginRegistrationFailureReason, detail: string): PluginRegistrationFailure {
     this.registry.delete(pluginId);
@@ -709,6 +769,7 @@ export class PluginRegistryService implements OnModuleInit {
       this.replaceRouteTable(pluginId, []);
       this.replaceDeclaredPermissions(pluginId, EMPTY_SUBJECT_SET);
       this.replaceReleasePicker(pluginId, undefined);
+      this.replacePlayer(pluginId, undefined);
     }
     return { ok: false, pluginId, reason, detail };
   }

--- a/backend/src/modules/plugins/plugins.module.ts
+++ b/backend/src/modules/plugins/plugins.module.ts
@@ -4,6 +4,7 @@ import { PluginPackage } from './entities/plugin-package.entity';
 import { PluginSource } from './entities/plugin-source.entity';
 import { PluginRegistration } from './entities/plugin-registration.entity';
 import { PluginRegistryService } from './plugin-registry.service';
+import { PluginPreRollService } from './plugin-pre-roll.service';
 import { PluginWebhookDispatcherService } from './plugin-webhook-dispatcher.service';
 import { PluginProcessService } from './plugin-process.service';
 import { PluginJobsService } from './plugin-jobs.service';
@@ -60,7 +61,8 @@ import { ScheduledJobRegistryModule } from '../scheduler/scheduled-job-registry.
     PluginDatabaseService,
     PluginObjectGuardsService,
     PluginRouteGuard,
+    PluginPreRollService,
   ],
-  exports: [TypeOrmModule, PluginRegistryService, PluginDatabaseService, PluginJobsService],
+  exports: [TypeOrmModule, PluginRegistryService, PluginDatabaseService, PluginJobsService, PluginPreRollService],
 })
 export class PluginsModule {}

--- a/backend/src/modules/streaming/dto/playback-info.dto.ts
+++ b/backend/src/modules/streaming/dto/playback-info.dto.ts
@@ -1,3 +1,5 @@
+import type { PreRollItem } from '../../../common/plugin-contract';
+
 /**
  * Playback info response — the backend's decision on how to play a media file.
  */
@@ -182,4 +184,7 @@ export interface PlaybackInfoResponse {
      *  overlay can flag the active crop without re-running detect. */
     crop?: { width: number; height: number; x: number; y: number };
   };
+
+  /** ACL-filtered pre-roll candidates (ids/labels only, no URL). Omitted, not `[]`, when unused. */
+  preRoll?: PreRollItem[];
 }

--- a/backend/src/modules/streaming/streaming.controller.spec.ts
+++ b/backend/src/modules/streaming/streaming.controller.spec.ts
@@ -3,8 +3,10 @@ import {
   withTimestampMap,
   buildVodPlaylist,
   buildVariableVodPlaylist,
+  resolvePreRoll,
 } from './streaming.controller';
 import type { LiveSession } from './live-session.service';
+import type { PreRollItem } from '../../common/plugin-contract';
 
 describe('buildVodPlaylist', () => {
   const url = (i: string): string => `seg-${i}.m4s`;
@@ -105,6 +107,7 @@ describe('StreamingController.stopLiveSession', () => {
       {} as never, // segmentPackaging
       {} as never, // sessionRouter
       {} as never, // sessionContextBuilder
+      {} as never, // pluginPreRoll
     );
 
     return { controller, liveSessions, activeStreamTracker, transcodingService };
@@ -217,5 +220,56 @@ describe('StreamingController.stopLiveSession', () => {
     controller.stopLiveSession('sid-1');
 
     expect(activeStreamTracker.unregister).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolvePreRoll', () => {
+  const item = (mediaFileId: number): PreRollItem => ({ mediaFileId });
+  const USER = { id: 42, name: 'viewer' };
+
+  it('drops a candidate the user has no library access to (the security property)', async () => {
+    // Mirrors resolveFile: rejects for anything outside this user's ACL.
+    const resolveFile = jest.fn((id: number) =>
+      id === 2 ? Promise.reject(new Error('MediaFile #2 not found')) : Promise.resolve({ id }),
+    );
+
+    const result = await resolvePreRoll({
+      ask: () => Promise.resolve([item(1), item(2), item(3)]),
+      resolveFile,
+      user: USER,
+    });
+
+    expect(result).toEqual([item(1), item(3)]);
+  });
+
+  it('checks every candidate against the REQUESTING user, not some other identity', async () => {
+    const resolveFile = jest.fn(() => Promise.resolve({}));
+
+    await resolvePreRoll({ ask: () => Promise.resolve([item(1), item(2)]), resolveFile, user: USER });
+
+    // The user threaded into the check is the one the request was made by.
+    expect(resolveFile).toHaveBeenCalledWith(1, USER);
+    expect(resolveFile).toHaveBeenCalledWith(2, USER);
+  });
+
+  it('is undefined, not an empty array, when the plugin offers nothing', async () => {
+    const resolveFile = jest.fn(() => Promise.resolve({}));
+    await expect(resolvePreRoll({ ask: () => Promise.resolve([]), resolveFile, user: USER })).resolves.toBeUndefined();
+    expect(resolveFile).not.toHaveBeenCalled();
+  });
+
+  it('is undefined when nothing survives the ACL filter, so the field stays absent', async () => {
+    const result = await resolvePreRoll({
+      ask: () => Promise.resolve([item(1)]),
+      resolveFile: () => Promise.reject(new Error('not found')),
+      user: USER,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('never throws when the ask itself fails', async () => {
+    await expect(
+      resolvePreRoll({ ask: () => Promise.resolve([]), resolveFile: () => Promise.resolve({}), user: USER }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -66,6 +66,8 @@ import { PlaybackService } from './playback.service';
 import { MarkersService } from '../markers/markers.service';
 import { DeviceProfileDto } from './dto/device-profile.dto';
 import { StreamingSettingsCache } from './streaming-settings-cache.service';
+import { PluginPreRollService } from '../plugins/plugin-pre-roll.service';
+import type { PreRollItem } from '../../common/plugin-contract';
 
 // Derived from the ladders themselves (SDR + HDR, full + eco) so a new rung
 // can never be forgotten here — the missing eco entry is exactly what 400'd
@@ -95,6 +97,23 @@ export function withTimestampMap(
   const mpegts = Math.round(Math.max(0, startSeconds) * 90000);
   const map = `X-TIMESTAMP-MAP=MPEGTS:${mpegts},LOCAL:00:00:00.000`;
   return text.replace(/^(WEBVTT[^\n]*)\n/, `$1\n${map}\n`);
+}
+
+/**
+ * Asks the plugin, then ACL-gates every candidate through the same `resolveFile` the main item
+ * uses, for the same user: a plugin only names an id, it never grants access to one. Answers
+ * `undefined` rather than `[]` so a plugin-free install serializes with `preRoll` absent.
+ */
+export async function resolvePreRoll<TUser>(deps: {
+  ask: () => Promise<PreRollItem[]>;
+  resolveFile: (mediaFileId: number, user: TUser) => Promise<unknown>;
+  user: TUser;
+}): Promise<PreRollItem[] | undefined> {
+  const candidates = await deps.ask();
+  if (!candidates.length) return undefined;
+  const checks = await Promise.allSettled(candidates.map((c) => deps.resolveFile(c.mediaFileId, deps.user)));
+  const allowed = candidates.filter((_, i) => checks[i].status === 'fulfilled');
+  return allowed.length ? allowed : undefined;
 }
 
 /** Accepted HLS segment / init filenames (fMP4 init, fMP4 or TS segment). */
@@ -297,6 +316,7 @@ export class StreamingController {
     private readonly segmentPackaging: SegmentPackagingService,
     private readonly sessionRouter: SessionRouter,
     private readonly sessionContextBuilder: SessionContextBuilder,
+    private readonly pluginPreRoll: PluginPreRollService,
   ) {}
 
   private getStreamingSettings() {
@@ -754,6 +774,18 @@ export class StreamingController {
       ? resolved.mediaFile.streamInfo.chapters
       : undefined;
 
+    const preRoll = await resolvePreRoll({
+      ask: () =>
+        this.pluginPreRoll.ask({
+          mediaFileId,
+          mediaId: resolved.mediaFile.mediaId,
+          episodeId: episodeId ?? undefined,
+          principal: { kind: 'delegated', userId },
+        }),
+      resolveFile: (id, forUser) => this.streamingService.resolveFile(id, forUser),
+      user,
+    });
+
     // Surface the tonemap mechanism the session actually runs, not the admin
     // pick. QSV/VAAPI encoders run the HW tonemap (vaapi/opencl/qsv after
     // `auto` resolution + boot probe); NVENC runs `tonemap_opencl` on the GPU
@@ -933,6 +965,7 @@ export class StreamingController {
       durationSeconds: duration,
       markers,
       chapters,
+      preRoll,
       sessionId: liveSession.sessionId,
       profileHash,
     };

--- a/backend/src/modules/streaming/streaming.module.ts
+++ b/backend/src/modules/streaming/streaming.module.ts
@@ -30,6 +30,7 @@ import { SettingsModule } from '../settings/settings.module';
 import { LibrariesModule } from '../libraries/libraries.module';
 import { MarkersModule } from '../markers/markers.module';
 import { PlaylistsModule } from '../playlists/playlists.module';
+import { PluginsModule } from '../plugins/plugins.module';
 
 @Module({
   imports: [
@@ -48,6 +49,7 @@ import { PlaylistsModule } from '../playlists/playlists.module';
     LibrariesModule,
     MarkersModule,
     PlaylistsModule,
+    PluginsModule,
   ],
   controllers: [StreamingController, PlaybackController],
   providers: [

--- a/client/src/app/core/plugin-ui/contribution.types.ts
+++ b/client/src/app/core/plugin-ui/contribution.types.ts
@@ -178,6 +178,24 @@ export interface ProvidersConfigPage extends ConfigPageBase {
   };
 }
 
+/** Cap on how many `preRoll` items core will ever forward from one `playback-info` call —
+ *  a plugin's route may answer more, but everything past this is dropped. */
+export const PRE_ROLL_ITEMS_MAX = 5;
+
+/** One pre-roll candidate a plugin's route may offer. It names a library file — there is no
+ *  URL and no path here — so core resolves and ACL-checks it the same way as the main item. */
+export interface PreRollItem {
+  mediaFileId: number;
+  labelKey?: string;
+  skippable?: boolean;
+}
+
+/** `ui.player` — the one POST route, declared in the manifest's own `routes[]` like
+ *  `releasePicker`'s, that core calls before playback to ask for pre-roll candidates. */
+export interface PlayerDeclaration {
+  preRollRoute: string;
+}
+
 /** One `table` filter — its current value is sent to `list` as a query param named by
  *  `key`; an empty value is omitted. Filtering itself is the plugin's job, core only forwards it. */
 export type TableFilter =

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -95,6 +95,30 @@ admin sidebar.
 If a page needs something these three cannot express, it is not a plugin page. The escape is a
 core change adding a `kind`, not a plugin shipping code.
 
+## Player pre-roll
+
+**`ui.player`** declares one route, `{ preRollRoute: string }`, that must name a `POST` entry in
+this manifest's own `routes[]` — the same rule `releasePicker` applies to its own routes. Only one
+plugin's declaration is ever live: if more than one declares it, the lexicographically smallest
+plugin id wins and the others are logged and ignored, exactly like `releasePicker`.
+
+Before a `playback-info` response goes out, core POSTs `{ mediaFileId, mediaId, episodeId }` to the
+winning plugin's route on behalf of the requesting user and expects back a JSON array of items
+shaped `{ mediaFileId: number, labelKey?: string, skippable?: boolean }` — **`mediaFileId` only**;
+there is no URL and no path in this contract. An item names a library file; it is not a pointer to
+one, and core is the only party that ever turns it into something playable. The array is capped at
+`PRE_ROLL_ITEMS_MAX` items; anything past the cap, not a positive integer `mediaFileId`, repeated,
+or naming the item about to play anyway, is dropped — the last two would play one file twice.
+
+Every id core gets back is still resolved and ACL-checked through the exact same path the main
+item uses — a file in a library the requesting user cannot see, or one that no longer resolves, is
+dropped silently. A plugin can only *name* a candidate; it can never grant access to one. If no
+plugin declares `ui.player`, the plugin is not running, the call fails or times out, or it answers
+anything other than 200 with that exact shape, `playback-info` simply omits `preRoll` from its
+response — the feature is invisible on failure, never a broken playback-info call.
+
+The Apple TV and Cast players do not model this field and will play the main video only.
+
 ## What a `process` plugin can ask of core
 
 A spawned plugin talks to core over two unix sockets with newline-delimited JSON-RPC: one for the


### PR DESCRIPTION
Phase 1 of §8.2: the contract and the backend. A plugin can now name what plays before the main
video. The player half is separate.

## Why the contract carries an id and not a URL

Every streaming route core has is `:mediaFileId`-scoped, and `streaming.service.ts` `resolveFile`
requires a `media_files` row, a library, a root-folder containment check and a symlink-escape check
before it will serve anything. A pre-roll contract carrying a path or a URL would have had to bypass
exactly the control that makes streaming safe, so it carries **`mediaFileId` only**.

Consequence worth stating plainly: pre-roll items are library files. An operator who wants trailers
before a film keeps them in a library. The trailers already stored in `media_metadata.videos` are
YouTube keys rendered in an `<iframe>` — core never fetches or streams one, and a plugin injecting a
third-party embed into the player is not something this contract should make possible.

## The security property

A plugin names a candidate. It never grants access to one.

Every id comes back through the **same** `resolveFile` call the main item uses, with the **same
user**, and `Promise.allSettled` drops anything that rejects — a file in a library that user cannot
see, or one that no longer resolves, disappears silently.

The first version of this tested that with a fake resolver, which proved the filter drops rejections
but mocked away the thing that actually matters: that the *requesting* user is the identity being
checked. Swapping in any other identity would have passed. The pre-roll step is now one unit taking
`{ ask, resolveFile, user }`, and there is a test that fails if the user threaded into the check is
not the request's own:

```
--- wrong identity passed to the check ---
Expected: 1, {"id": 42, "name": "viewer"}
Tests: 1 failed
```

## A misbehaving plugin cannot break pressing play

`playback-info` is on the critical path of the play button, so every failure answers with nothing:
no declaration, a stopped or failed process, a call that outruns its own short deadline (it reuses a
published deadline constant rather than inventing one), a non-200, a body that is not an array, items
that are not positive integers.

The list is capped at a published `PRE_ROLL_ITEMS_MAX`. An id repeated, or equal to the item about to
play, is dropped as well — either would play one file twice. That was missing from the first version.

## The field is absent, not empty

Verified live against the running stack, with none of the three installed plugins declaring
`ui.player`:

```
playMethod: DirectStream | mediaFileId: 1 | sessionId set: True
preRoll key present? False
```

That matters beyond tidiness: the Apple TV client decodes this response into a hand-maintained struct
and silently drops keys it does not model, and Cast forwards a single prepared URL. Keeping the
serialized shape identical for a plugin-free install is what keeps both of them unaffected. Both are
documented as playing the main video only.

## Registration and the winner

`preRollRoute` must name a POST route the same manifest declares, mirroring what `releasePicker`
already requires, with its own refusal reason. If two plugins declare `ui.player`, the
lexicographically smallest id wins and the loser is logged — the same rule and the same wording as
the release picker, and the loser keeps every other route it declared.

I also removed a `preRollRouteFor(pluginId)` accessor the first version added: no production caller,
only its own test asserted it. That is the dead-surface pattern #984 exists to stop, and a major
would have frozen it.

## Verification

- `npx tsc --noEmit` — exit 0.
- Full backend suite: **137 suites, 1513 tests**, exit 0.
- Backend restarted against the real dev database: all three plugins `active`, both process plugins
  `ready`; `playback-info` for a real file returns `DirectStream` with a session, and no `preRoll` key.
- The two contract copies (backend + Angular mirror) are byte-identical, so the drift gate stays green.
- Security and shape assertions each proven to fail when the line they cover is reverted:
  - ACL filter neutralised → all three candidates come back
  - a different identity passed to the check → the identity assertion fails
  - `[]` returned instead of `undefined` → the absent-field assertion fails
  - self/duplicate exclusion removed → the main item comes back as its own pre-roll
