### PR TITLE
feat(player): play the pre-roll items a plugin named before the main video

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -39,6 +39,7 @@
     "play_from_start": "Von Anfang an",
     "resume_at": "Fortsetzen bei {{time}}",
     "skip_intro": "Intro überspringen",
+    "skip_pre_roll": "Überspringen",
     "pause": "Pause",
     "next_episode": "Nächste Folge",
     "play_next": "Weiter abspielen",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -39,6 +39,7 @@
     "play_from_start": "From the beginning",
     "resume_at": "Resume at {{time}}",
     "skip_intro": "Skip intro",
+    "skip_pre_roll": "Skip",
     "pause": "Pause",
     "next_episode": "Next episode",
     "play_next": "Play next",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -39,6 +39,7 @@
     "play_from_start": "Desde el principio",
     "resume_at": "Reanudar en {{time}}",
     "skip_intro": "Saltar intro",
+    "skip_pre_roll": "Saltar",
     "pause": "Pausa",
     "next_episode": "Episodio siguiente",
     "play_next": "Reproducir siguiente",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -39,6 +39,7 @@
     "play_from_start": "Depuis le début",
     "resume_at": "Reprendre à {{time}}",
     "skip_intro": "Passer l'intro",
+    "skip_pre_roll": "Passer",
     "pause": "Pause",
     "next_episode": "Épisode suivant",
     "play_next": "Lire la suite",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -39,6 +39,7 @@
     "play_from_start": "Dall'inizio",
     "resume_at": "Riprendi da {{time}}",
     "skip_intro": "Salta l'intro",
+    "skip_pre_roll": "Salta",
     "pause": "Pausa",
     "next_episode": "Episodio successivo",
     "play_next": "Riproduci il seguito",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -39,6 +39,7 @@
     "play_from_start": "Desde o início",
     "resume_at": "Retomar em {{time}}",
     "skip_intro": "Saltar a introdução",
+    "skip_pre_roll": "Saltar",
     "pause": "Pausa",
     "next_episode": "Episódio seguinte",
     "play_next": "Reproduzir a seguir",

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -10,6 +10,7 @@ import {
   DeviceProfile,
 } from '../browser-device-profile.service';
 import { SseService } from '../sse.service';
+import type { PreRollItem } from '../../plugin-ui/contribution.types';
 
 const SSE_CONNECTION_HEADER = 'X-Fliks-Sse-Connection';
 
@@ -104,6 +105,8 @@ export interface PlaybackInfoResponse {
   };
   /** Embedded chapters from the container (MKV/MP4). */
   chapters?: { startSeconds: number; endSeconds: number; title?: string }[];
+  /** Plugin-named items to play before the main video. Read at launch only. */
+  preRoll?: PreRollItem[];
   /** Server-issued live-session identifier. The client embeds it in every
    *  subsequent `PUT /api/playback/media/:id/state` (heartbeat) and on
    *  the `DELETE /api/stream/:mediaFileId/sessions` unload signal so the

--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -278,7 +278,7 @@
     #skipIntroBtn
     type="button"
     class="btn btn-primary absolute right-6 z-50 shadow-lg overflow-hidden rounded-lg player-floating-cue"
-    style="right: max(1.5rem, env(safe-area-inset-right)); bottom: max(var(--cue-bottom, 8rem), calc(var(--cue-bottom, 8rem) + env(safe-area-inset-bottom)));"
+    style="right: 1.5rem; bottom: 8rem; right: max(1.5rem, env(safe-area-inset-right)); bottom: max(var(--cue-bottom, 8rem), calc(var(--cue-bottom, 8rem) + env(safe-area-inset-bottom)));"
     (click)="skipIntro.emit()"
     (focus)="cueFocused.set(true)"
     (blur)="cueFocused.set(false)"
@@ -295,13 +295,28 @@
   </button>
 }
 
+<!-- ===== Pre-roll skip button — up for the whole item, no sweep/countdown ===== -->
+@if (showPreRollSkip()) {
+  <button
+    type="button"
+    class="btn btn-primary absolute right-6 z-50 shadow-lg overflow-hidden rounded-lg player-floating-cue"
+    style="right: 1.5rem; bottom: 8rem; right: max(1.5rem, env(safe-area-inset-right)); bottom: max(var(--cue-bottom, 8rem), calc(var(--cue-bottom, 8rem) + env(safe-area-inset-bottom)));"
+    (click)="skipPreRoll.emit()"
+  >
+    <span class="relative flex items-center gap-2">
+      <svg lucideSkipForward class="h-4 w-4"></svg>
+      {{ 'player.skip_pre_roll' | translate }}
+    </span>
+  </button>
+}
+
 <!-- ===== Next item floating button (during outro) ===== -->
 @if (showNextCue()) {
   <button
     #nextEpisodeBtn
     type="button"
     class="btn btn-primary absolute right-6 z-50 shadow-lg overflow-hidden rounded-lg player-floating-cue"
-    style="right: max(1.5rem, env(safe-area-inset-right)); bottom: max(var(--cue-bottom, 8rem), calc(var(--cue-bottom, 8rem) + env(safe-area-inset-bottom)));"
+    style="right: 1.5rem; bottom: 8rem; right: max(1.5rem, env(safe-area-inset-right)); bottom: max(var(--cue-bottom, 8rem), calc(var(--cue-bottom, 8rem) + env(safe-area-inset-bottom)));"
     (click)="next.emit()"
     (focus)="cueFocused.set(true)"
     (blur)="cueFocused.set(false)"

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -303,6 +303,8 @@ export class PlayerControlsComponent {
   readonly statsVisible = input(false);
   readonly showSkipIntro = input(false);
   readonly showNextCue = input(false);
+  /** Shown for the whole pre-roll item, not a timed cue — no sweep, no countdown. */
+  readonly showPreRollSkip = input(false);
   /** How long a floating cue stays up, in ms — drives the in-button progress
    *  sweep so it finishes exactly as the parent retracts the cue. */
   readonly cueDurationMs = input(6000);
@@ -315,6 +317,7 @@ export class PlayerControlsComponent {
   readonly cueFocused = signal(false);
   readonly togglePlay = output<void>();
   readonly skipIntro = output<void>();
+  readonly skipPreRoll = output<void>();
   readonly tapOverlay = output<void>();
   readonly seek = output<number>();
   readonly volumeChange = output<number>();

--- a/client/src/app/features/player/player.html
+++ b/client/src/app/features/player/player.html
@@ -123,10 +123,10 @@
     [playbackRate]="playbackRate()"
     [mediaTitle]="mediaTitle()"
     [logoUrl]="mediaLogoUrl()"
-    [episodeTitle]="episodeTitle()"
+    [episodeTitle]="displayEpisodeTitle()"
     [hasNext]="upNext() !== null"
     [nextLabelKey]="nextLabelKey()"
-    [queueItems]="queueItems()"
+    [queueItems]="preRollActive() ? [] : queueItems()"
     [queueIndex]="queueIndex()"
     (selectQueueItem)="playQueueItem($event)"
     [activeQualityLabel]="activeQualityLabel()"
@@ -172,6 +172,8 @@
     [cueDurationMs]="cueRevealMs"
     (skipIntro)="skipIntro()"
     (next)="advance()"
+    [showPreRollSkip]="preRollSkippable()"
+    (skipPreRoll)="skipPreRoll()"
     (panelOpenChange)="onControlsPanelOpenChange($event)"
   />
   }

--- a/client/src/app/features/player/player.spec.ts
+++ b/client/src/app/features/player/player.spec.ts
@@ -1,0 +1,407 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { provideTranslateService, TranslateLoader } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { vi, afterEach, describe, it, expect } from 'vitest';
+import { PlayerComponent } from './player';
+import { PlayerStateService } from '../../core/services/player-state.service';
+import { StreamingApiService, PlaybackInfoResponse } from '../../core/services/api/streaming-api.service';
+import { MediaService, Media } from '../../core/services/api/media.service';
+import { BrowserDeviceProfileService, DeviceProfile } from '../../core/services/browser-device-profile.service';
+import { SseService } from '../../core/services/sse.service';
+import { AuthService } from '../../core/services/auth.service';
+import { CastService } from '../../core/services/cast.service';
+import { CastPlayerService } from '../../core/services/cast-player.service';
+import { CastSettingsService } from '../../core/services/cast-settings.service';
+import { OfflineStorageService } from '../../core/services/offline-storage.service';
+import { OfflinePlaybackSyncService } from '../../core/services/offline-playback-sync.service';
+import { AutoDownloadService } from '../../core/services/auto-download.service';
+import { NetworkService } from '../../core/services/network.service';
+import { DownloadCacheService } from '../../core/services/download-cache.service';
+import { ServerConfigService } from '../../core/services/server-config.service';
+import { NavigationHistoryService } from '../../core/services/navigation-history.service';
+import { ToastService } from '../../core/services/toast.service';
+import { NavbarService } from '../../core/services/navbar.service';
+import { PlaybackQueueService } from '../../core/services/playback-queue.service';
+import { TrackManagerService } from '../../core/services/track-manager.service';
+import { DeviceService } from '../../core/services/device.service';
+
+/*
+ * Angular's vitest builder refuses `vi.mock` on relative specifiers, so the
+ * real ShakaEngine (and its `shaka-player` dependency) can't be swapped out
+ * that way. These are white-box tests instead: the component is constructed
+ * via TestBed (so every injected service, computed and `effect()` is real —
+ * only I/O boundaries are faked below), then the pre-roll orchestration
+ * methods are driven directly, with `engine` seeded to a plain fake object.
+ * `TestBed.tick()` flushes the component's own `effect()`s (registered at
+ * construction) without ever calling `ngAfterViewInit` or touching a real
+ * playback engine.
+ */
+
+async function flush(times = 40) {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+const MAIN_FILE_ID = 1;
+const TRAILER_FILE_ID = 99;
+const MEDIA_ID = 10;
+const DEVICE_PROFILE = { deviceType: 'desktop', supportsAbr: true } as DeviceProfile;
+
+function buildPi(mediaFileId: number, overrides: Partial<PlaybackInfoResponse> = {}): PlaybackInfoResponse {
+  return {
+    mediaFileId,
+    playMethod: 'DirectPlay',
+    playUrl: '',
+    contentType: 'video/mp4',
+    transcodeReasons: [],
+    videoCopyStream: true,
+    audioCopyStream: true,
+    outputVideoCodec: 'h264',
+    outputAudioCodec: 'aac',
+    outputContainer: 'mp4',
+    hwAccel: 'none',
+    tonemapping: false,
+    source: { container: 'mp4', videoCodec: 'h264', audioCodec: 'aac', durationSeconds: mediaFileId === TRAILER_FILE_ID ? 30 : 100 },
+    sessionId: `sid-${mediaFileId}`,
+    ...overrides,
+  };
+}
+
+function fakeEngine() {
+  const loadCalls: { url: string; startTime?: number; mimeType?: string }[] = [];
+  return {
+    loadCalls,
+    currentTime: 0,
+    duration: 100,
+    resetRecoveryGuard: vi.fn(),
+    load: vi.fn(async (url: string, startTime?: number, mimeType?: string) => {
+      loadCalls.push({ url, startTime, mimeType });
+    }),
+    play: vi.fn(async () => {}),
+    pause: vi.fn(async () => {}),
+    destroy: vi.fn(async () => {}),
+  };
+}
+
+const MOVIE: Media = {
+  id: MEDIA_ID,
+  title: 'Test Movie',
+  originalTitle: 'Test Movie',
+  year: 2024,
+  type: 'movie',
+  tmdbId: 1,
+  overview: '',
+  status: 'released',
+  monitored: true,
+  posterUrl: null,
+  fanartUrl: null,
+  logoUrl: null,
+  additionalFanartUrls: [],
+  rating: 0,
+  runtime: 100,
+  files: [{ id: MAIN_FILE_ID, quality: '1080p', relativePath: 'x', size: 0, streamInfo: { durationSeconds: 100 } as any }],
+};
+
+function createHarness(opts: {
+  preRoll?: { mediaFileId: number; labelKey?: string; skippable?: boolean }[];
+  trailerPlaybackInfo?: PlaybackInfoResponse | 'reject';
+} = {}) {
+  const router = {
+    getCurrentNavigation: () => null,
+    navigate: vi.fn().mockResolvedValue(true),
+    navigateByUrl: vi.fn().mockResolvedValue(true),
+    url: '/watch/1',
+  };
+  const getPlaybackInfo = vi.fn(async (mediaFileId: number) => {
+    if (mediaFileId === MAIN_FILE_ID) return buildPi(MAIN_FILE_ID, { preRoll: opts.preRoll });
+    if (mediaFileId === TRAILER_FILE_ID) {
+      if (opts.trailerPlaybackInfo === 'reject') throw new Error('negotiation failed');
+      return opts.trailerPlaybackInfo ?? buildPi(TRAILER_FILE_ID);
+    }
+    return buildPi(mediaFileId);
+  });
+  const getPlaybackState = vi.fn(async () => null);
+  const stopSessions = vi.fn(async () => ({}));
+  const updatePlaybackState = vi.fn(async () => ({}));
+  const getStreamUrl = vi.fn((id: number, sid?: string) => `stream://${id}?sid=${sid}`);
+  const getHlsUrl = vi.fn((id: number) => `hls://${id}`);
+
+  const streamingApi = {
+    getPlaybackInfo,
+    getPlaybackState,
+    stopSessions,
+    updatePlaybackState,
+    getStreamUrl,
+    getHlsUrl,
+    getStopSessionsUrl: vi.fn(() => 'stop://x'),
+    getThumbnailMetadataUrl: vi.fn(() => ''),
+    getThumbnailSpriteUrl: vi.fn(() => ''),
+    getSubtitleUrl: vi.fn(() => ''),
+    getEmbeddedSubtitleUrl: vi.fn(() => ''),
+  };
+
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      provideTranslateService({
+        lang: 'en',
+        loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+      }),
+      {
+        provide: ActivatedRoute,
+        useValue: { snapshot: { params: { mediaFileId: String(MAIN_FILE_ID) }, queryParams: {} } },
+      },
+      {
+        provide: Router,
+        useValue: router,
+      },
+      { provide: StreamingApiService, useValue: streamingApi },
+      { provide: MediaService, useValue: { getOne: vi.fn(async () => MOVIE) } },
+      { provide: BrowserDeviceProfileService, useValue: { getProfile: () => DEVICE_PROFILE } },
+      { provide: SseService, useValue: { connectionId: () => null, lastEvent: () => null } },
+      {
+        provide: AuthService,
+        useValue: {
+          ensureStreamToken: vi.fn(async () => {}),
+          streamToken: () => 'tok',
+          accessToken: 'tok',
+          user: () => ({ id: 1 }),
+        },
+      },
+      {
+        provide: CastService,
+        useValue: {
+          isConnected: () => false,
+          isAvailable: () => false,
+          connecting: () => false,
+          currentTime: () => 0,
+          duration: () => 0,
+          disconnect: vi.fn(),
+          requestSession: vi.fn(),
+          pause: vi.fn(),
+          play: vi.fn(),
+        },
+      },
+      {
+        provide: CastPlayerService,
+        useValue: {
+          liveSessionId: () => undefined,
+          expanded: { set: vi.fn() },
+          getCastDeviceProfile: () => DEVICE_PROFILE,
+          reloadCastStream: vi.fn(),
+          startCast: vi.fn(),
+          clear: vi.fn(),
+        },
+      },
+      { provide: CastSettingsService, useValue: { get: () => ({ maxQuality: 'auto' }) } },
+      { provide: ServerConfigService, useValue: { isNative: false, resolveUrl: (u: string) => u } },
+      { provide: NavigationHistoryService, useValue: { previousUrl: null } },
+      { provide: ToastService, useValue: { error: vi.fn(), success: vi.fn() } },
+      { provide: NavbarService, useValue: { markAsBackNavigation: vi.fn() } },
+      {
+        provide: PlaybackQueueService,
+        useValue: {
+          source: () => 'none',
+          sourceId: () => undefined,
+          active: () => false,
+          peekNext: () => null,
+          items: () => [],
+          index: () => 0,
+          advance: () => null,
+          setIndex: vi.fn(),
+          syncTo: vi.fn(),
+          clear: vi.fn(),
+          start: vi.fn(),
+          autoplay: () => false,
+        },
+      },
+      {
+        provide: TrackManagerService,
+        useValue: {
+          loadSubtitles: vi.fn(async () => []),
+          autoSelectSubtitle: vi.fn(async () => {}),
+          autoSelectAudioTrack: vi.fn(),
+        },
+      },
+      {
+        provide: DeviceService,
+        useValue: {
+          isTv: () => false,
+          isTouch: () => false,
+          isDpad: () => false,
+          isDesktop: () => true,
+          formFactor: () => 'desktop',
+          tvPlatform: () => null,
+          desktopPlatform: () => null,
+        },
+      },
+      { provide: OfflineStorageService, useValue: { getLocalUrl: vi.fn(), getSmallFileNativeUri: vi.fn() } },
+      { provide: OfflinePlaybackSyncService, useValue: { queue: vi.fn() } },
+      { provide: AutoDownloadService, useValue: { onItemCompleted: vi.fn(async () => {}) } },
+      { provide: NetworkService, useValue: { isOnline: () => true } },
+      { provide: DownloadCacheService, useValue: { load: vi.fn(() => []) } },
+    ],
+  });
+
+  const fixture = TestBed.createComponent(PlayerComponent);
+  const component = fixture.componentInstance as any;
+  const state = TestBed.inject(PlayerStateService);
+
+  // Seed the state ngAfterViewInit would have produced for a main-item launch.
+  component.mediaFileId = MAIN_FILE_ID;
+  component.mediaId = MEDIA_ID;
+  component.episodeId = undefined;
+  component.media = MOVIE;
+  component.playbackInfo = buildPi(MAIN_FILE_ID, { preRoll: opts.preRoll });
+  component.initCompleted = true;
+  const engine = fakeEngine();
+  component.engine = engine;
+
+  return {
+    fixture,
+    component,
+    state,
+    streamingApi,
+    engine,
+    router,
+    get navigated(): boolean {
+      return router.navigate.mock.calls.length > 0;
+    },
+  };
+}
+
+describe('PlayerComponent pre-roll', () => {
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('plays the pre-roll item before the main item, then the main item after it ends', async () => {
+    const h = createHarness({ preRoll: [{ mediaFileId: TRAILER_FILE_ID, labelKey: 'x' }] });
+
+    await h.component.maybeStartPreRoll(undefined, DEVICE_PROFILE);
+
+    expect(h.component.preRollActive()).toBe(true);
+    expect(h.component.mediaFileId).toBe(TRAILER_FILE_ID);
+    expect(h.streamingApi.stopSessions).toHaveBeenCalledWith(MAIN_FILE_ID, `sid-${MAIN_FILE_ID}`);
+
+    // preRollAdvanceEffect is what calls advancePreRoll() once state.ended()
+    // latches — exercised directly here because Angular's only TestBed hook
+    // to flush a live effect (tick()/flushEffects()) also forces a full
+    // component render, which would construct a real ShakaEngine (unmockable
+    // for a relative import under this project's vitest builder) and crash
+    // on unrelated template directives this suite never sets up.
+    h.state.ended.set(true);
+    await h.component.advancePreRoll();
+    await flush();
+
+    expect(h.component.preRollActive()).toBe(false);
+    expect(h.component.mediaFileId).toBe(MAIN_FILE_ID);
+    expect(h.engine.loadCalls.at(-1)?.url).toBe(`stream://${MAIN_FILE_ID}?sid=sid-${MAIN_FILE_ID}`);
+  });
+
+  it('skips pre-roll entirely on a resume launch (startTime > 0)', async () => {
+    const h = createHarness({ preRoll: [{ mediaFileId: TRAILER_FILE_ID }] });
+
+    await h.component.maybeStartPreRoll(120, DEVICE_PROFILE);
+
+    expect(h.component.preRollActive()).toBe(false);
+    expect(h.component.mediaFileId).toBe(MAIN_FILE_ID);
+    // On the recorded ids: `expect.anything()` never matches the `undefined` args this call passes.
+    expect(h.streamingApi.getPlaybackInfo.mock.calls.map((c: unknown[]) => c[0])).not.toContain(TRAILER_FILE_ID);
+  });
+
+  it('a failing pre-roll negotiation does not stop the main video from playing', async () => {
+    const h = createHarness({ preRoll: [{ mediaFileId: TRAILER_FILE_ID }], trailerPlaybackInfo: 'reject' });
+
+    await h.component.maybeStartPreRoll(undefined, DEVICE_PROFILE);
+
+    expect(h.component.preRollActive()).toBe(false);
+    expect(h.component.mediaFileId).toBe(MAIN_FILE_ID);
+    expect(h.streamingApi.stopSessions).not.toHaveBeenCalled();
+  });
+
+  it('records no progress while a pre-roll item is playing', async () => {
+    const h = createHarness({ preRoll: [{ mediaFileId: TRAILER_FILE_ID }] });
+    await h.component.maybeStartPreRoll(undefined, DEVICE_PROFILE);
+    expect(h.component.preRollActive()).toBe(true);
+
+    await h.component.savePosition();
+
+    expect(h.streamingApi.updatePlaybackState).not.toHaveBeenCalled();
+  });
+
+  it('skip advances past the current pre-roll item onto the main video', async () => {
+    const h = createHarness({ preRoll: [{ mediaFileId: TRAILER_FILE_ID, skippable: true }] });
+    await h.component.maybeStartPreRoll(undefined, DEVICE_PROFILE);
+    expect(h.component.preRollActive()).toBe(true);
+    expect(h.component.preRollSkippable()).toBe(true);
+
+    h.component.skipPreRoll();
+    await flush();
+
+    expect(h.component.preRollActive()).toBe(false);
+    expect(h.engine.loadCalls.at(-1)?.url).toBe(`stream://${MAIN_FILE_ID}?sid=sid-${MAIN_FILE_ID}`);
+  });
+
+  it('an in-place episode advance does not replay pre-roll, and still resumes that episode', async () => {
+    const NEXT_FILE_ID = 2;
+    // Already on the main item, as for every non-launch reload (advance(), the queue, a retry).
+    const h = createHarness();
+    // The backend answers `preRoll` on every playback-info call, including a plain in-place
+    // reload — the client must ignore it there.
+    h.streamingApi.getPlaybackInfo.mockResolvedValueOnce(
+      buildPi(NEXT_FILE_ID, { preRoll: [{ mediaFileId: TRAILER_FILE_ID }] }),
+    );
+
+    await h.component.reloadForEpisode(NEXT_FILE_ID, MEDIA_ID, undefined);
+    await flush();
+
+    expect(h.component.preRollActive()).toBe(false);
+    expect(h.streamingApi.getPlaybackInfo.mock.calls.map((c: unknown[]) => c[0])).not.toContain(TRAILER_FILE_ID);
+    // A normal reload still looks up where to resume; only a pre-roll transition skips it.
+    expect(h.streamingApi.getPlaybackState).toHaveBeenCalled();
+    expect(h.engine.loadCalls.at(-1)?.url).toBe(`stream://${NEXT_FILE_ID}?sid=sid-${NEXT_FILE_ID}`);
+  });
+
+  it('a pre-roll transition does not resume it from the main film\'s stored position', async () => {
+    const h = createHarness({ preRoll: [{ mediaFileId: TRAILER_FILE_ID }] });
+    await h.component.maybeStartPreRoll(undefined, DEVICE_PROFILE);
+    h.streamingApi.getPlaybackState.mockClear();
+
+    h.component.skipPreRoll();
+    await flush();
+
+    // `noResumeLookup`: the stored position belongs to the film, not to what plays before it.
+    expect(h.streamingApi.getPlaybackState).not.toHaveBeenCalled();
+  });
+
+  it('keeps progress gated while remounting away from a dead pre-roll', async () => {
+    const h = createHarness({ preRoll: [{ mediaFileId: TRAILER_FILE_ID }] });
+    await h.component.maybeStartPreRoll(undefined, DEVICE_PROFILE);
+    expect(h.component.preRollActive()).toBe(true);
+
+    h.component.remountWithoutPreRoll();
+    await flush();
+
+    // Teardown calls savePosition on the way out; ungated, the trailer's playhead
+    // and duration would be written against the film's row.
+    await h.component.savePosition();
+    expect(h.streamingApi.updatePlaybackState).not.toHaveBeenCalled();
+  });
+
+  it('reaches the main video even when a transition is refused', async () => {
+    const h = createHarness({ preRoll: [{ mediaFileId: TRAILER_FILE_ID }] });
+    await h.component.maybeStartPreRoll(undefined, DEVICE_PROFILE);
+    expect(h.component.preRollActive()).toBe(true);
+    // reloadForEpisode refuses silently without an engine, as it does mid-reload.
+    h.component.engine = null;
+
+    h.component.skipPreRoll();
+    await flush();
+
+    // A refusal must not strand the run on a finished trailer with no way forward.
+    expect(h.navigated).toBe(true);
+  });
+
+});

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -18,7 +18,8 @@ import { Title } from '@angular/platform-browser';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { StreamingApiService, PlaybackInfoResponse } from '../../core/services/api/streaming-api.service';
 import { MediaService, Media } from '../../core/services/api/media.service';
-import { BrowserDeviceProfileService } from '../../core/services/browser-device-profile.service';
+import { BrowserDeviceProfileService, DeviceProfile } from '../../core/services/browser-device-profile.service';
+import type { PreRollItem } from '../../core/plugin-ui/contribution.types';
 import { SseService } from '../../core/services/sse.service';
 import { AuthService } from '../../core/services/auth.service';
 import { CastService } from '../../core/services/cast.service';
@@ -431,6 +432,31 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   private readonly togglePlayCoalesceMs = 250;
   /** Tracks last episodeId we auto-skipped for to ensure we only auto-skip once per session. */
   private autoSkipFiredForEpisode: number | null = null;
+
+  // ── Pre-roll state ──
+  /** Item on screen; the single source of truth for every pre-roll gate. */
+  private readonly preRollCurrent = signal<PreRollItem | null>(null);
+  readonly preRollActive = computed(() => this.preRollCurrent() !== null);
+  /** Skippable unless the plugin explicitly opts out. */
+  readonly preRollSkippable = computed(() => {
+    const item = this.preRollCurrent();
+    return !!item && item.skippable !== false;
+  });
+  /** Title shown by the controls while a pre-roll item plays. */
+  readonly displayEpisodeTitle = computed(() => {
+    const key = this.preRollCurrent()?.labelKey;
+    return key ? this.translate.instant(key) : this.episodeTitle();
+  });
+  /** How long a pre-roll transition waits out an in-flight reload before giving up and remounting. */
+  private static readonly PRE_ROLL_RELOAD_WAIT_MS = 3_000;
+
+  /** Remaining items, consumed FIFO by {@link advancePreRoll}. */
+  private preRollRest: PreRollItem[] = [];
+  /** File to land on once the list is exhausted. */
+  private preRollMainFileId = 0;
+  /** Re-entry guard: the 'ended' latch and an error can both fire in the same tick. */
+  private preRollAdvancing = false;
+
   readonly spriteUrl = signal<string | null>(null);
   readonly spriteMetadata = signal<SpriteMetadata | null>(null);
   readonly activeSubtitleId = signal<string | null>(null);
@@ -1146,7 +1172,8 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
         // Await playback-info (kicked off in parallel with media load above)
         this.playbackInfo = await playbackInfoPromise!;
-        const pi = this.playbackInfo;
+        await this.maybeStartPreRoll(startTime, deviceProfile);
+        const pi = this.playbackInfo!;
         this.introMarker.set(pi.markers?.intro ?? null);
         this.outroMarker.set(pi.markers?.outro ?? null);
         this.chapters.set(pi.chapters ?? []);
@@ -1440,6 +1467,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
           this.statsRefreshTick.update((n) => n + 1);
         }
       }, 1000);
+
     } catch (e: any) {
       console.error('[Player] Init error:', e?.code, e?.category, e?.data, e);
       const msg = e?.message ?? String(e);
@@ -1463,31 +1491,35 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         data: e?.data,
         message: msg,
       });
-      // TV / Tizen engine path: the AVPlay <object> + the hidden <video>
-      // both stay parked on top of the error overlay if the engine dies
-      // during load(). Force the player UI back into a visible-DOM state
-      // so the user can read what blew up instead of staring at the
-      // pre-paint bg-base-200 plane.
-      if ((this.isTizenEngine() || this.isDesktopNative || this.isNativeEngine()) && this.engine) {
-        document.documentElement.classList.remove('native-player-active');
-        const video = this.videoEl()?.nativeElement;
-        if (video) video.style.display = '';
-        try {
-          await this.engine.destroy();
-        } catch {
-          /* engine state may already be torn down — fine */
+      // preRollAdvanceEffect handles a pre-roll failure; this teardown would
+      // null the engine it needs, and the toast has no film-error to show.
+      if (!this.preRollActive()) {
+        // TV / Tizen engine path: the AVPlay <object> + the hidden <video>
+        // both stay parked on top of the error overlay if the engine dies
+        // during load(). Force the player UI back into a visible-DOM state
+        // so the user can read what blew up instead of staring at the
+        // pre-paint bg-base-200 plane.
+        if ((this.isTizenEngine() || this.isDesktopNative || this.isNativeEngine()) && this.engine) {
+          document.documentElement.classList.remove('native-player-active');
+          const video = this.videoEl()?.nativeElement;
+          if (video) video.style.display = '';
+          try {
+            await this.engine.destroy();
+          } catch {
+            /* engine state may already be torn down — fine */
+          }
+          this.engine = null;
+          this.isTizenEngine.set(false);
+          this.isNativeEngine.set(false);
         }
-        this.engine = null;
-        this.isTizenEngine.set(false);
-        this.isNativeEngine.set(false);
-      }
-      // Surface a toast on top of everything — fixed z-[9999], rendered
-      // by the always-mounted <app-toast-container>, so it survives even
-      // when the player-container itself isn't laying out correctly.
-      try {
-        this.toast.error(userMessage);
-      } catch {
-        /* toast service may not be ready during early init — ignore */
+        // Surface a toast on top of everything — fixed z-[9999], rendered
+        // by the always-mounted <app-toast-container>, so it survives even
+        // when the player-container itself isn't laying out correctly.
+        try {
+          this.toast.error(userMessage);
+        } catch {
+          /* toast service may not be ready during early init — ignore */
+        }
       }
     } finally {
       this.state.loading.set(false);
@@ -1558,6 +1590,103 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       window.removeEventListener('pipModeChanged', this.onPipModeChanged as EventListener);
       window.removeEventListener('pipAction', this.onPipAction as EventListener);
     }
+  }
+
+  // ── Pre-roll ──
+
+  /** Take over the launch with the plugin's pre-roll list when the response
+   *  carries one. No-op on resume, offline, Cast, or when nothing negotiates. */
+  private async maybeStartPreRoll(
+    startTime: number | undefined,
+    deviceProfile: DeviceProfile,
+  ): Promise<void> {
+    const items = this.playbackInfo?.preRoll ?? [];
+    if (!items.length) return;
+    if (startTime || this.isOfflinePlayback || this.castService.isConnected()) return;
+    if (this.route.snapshot.queryParams['noPreRoll'] === '1') return;
+
+    const mainFileId = this.mediaFileId;
+    const mainSid = this.playbackInfo!.sessionId;
+    const rest = [...items];
+    while (rest.length) {
+      const item = rest.shift()!;
+      const info = await this.streamingApi
+        .getPlaybackInfo(item.mediaFileId, deviceProfile, undefined, undefined, this.resolveStartQuality())
+        .catch(() => null);
+      if (!info) continue; // this candidate failed to negotiate — try the next
+      // Only stop the main session once a pre-roll item is committed: if every
+      // candidate fails, the launch is byte-identical to a plugin-free one.
+      await this.streamingApi.stopSessions(mainFileId, mainSid).catch(() => {});
+      this.preRollMainFileId = mainFileId;
+      this.preRollRest = rest;
+      this.preRollCurrent.set(item);
+      this.mediaFileId = item.mediaFileId;
+      this.playbackInfo = info;
+      this.state.duration.set(info.source?.durationSeconds ?? 0);
+      return;
+    }
+  }
+
+  /** Move past the item on screen: the next pre-roll item, else the main video.
+   *  Reuses {@link reloadForEpisode} for every transition, main item included. */
+  private async advancePreRoll(): Promise<void> {
+    if (!this.preRollActive() || this.preRollAdvancing) return;
+    this.preRollAdvancing = true;
+    try {
+      // `reloadForEpisode` refuses while another reload is in flight. Consuming the item first
+      // would strand the run on a finished one, with nothing left to re-trigger this.
+      const deadline = Date.now() + PlayerComponent.PRE_ROLL_RELOAD_WAIT_MS;
+      while (this.reloadingStream && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      const next = this.preRollRest.shift();
+      if (next) this.preRollCurrent.set(next);
+      const fileId = next ? next.mediaFileId : this.preRollMainFileId;
+      this.state.ended.set(false);
+      this.state.error.set(null);
+      await this.reloadForEpisode(fileId, this.mediaId, this.episodeId, { noResumeLookup: true });
+      // Any refusal above is silent, so the loaded file is the only proof it happened.
+      if (this.mediaFileId !== fileId) this.remountWithoutPreRoll();
+    } finally {
+      // Guards lift only once the main item is the loaded file — a chained
+      // failure re-enters this before landing there.
+      if (this.mediaFileId === this.preRollMainFileId) this.preRollCurrent.set(null);
+      this.preRollAdvancing = false;
+    }
+  }
+
+  /** Skip-button handler — drops the item on screen; any remaining items still play. */
+  skipPreRoll(): void {
+    void this.advancePreRoll();
+  }
+
+  /** Pre-roll chains unconditionally on end or error — autoplay settings don't
+   *  apply, and a failure must never be able to stop the main video. */
+  private readonly preRollAdvanceEffect = effect(() => {
+    if (!this.preRollActive()) return;
+    if (!this.state.ended() && !this.state.error()) return;
+    // Without an engine there is nothing to load into, so the run cannot continue in place.
+    if (!this.engine) {
+      this.remountWithoutPreRoll();
+      return;
+    }
+    void this.advancePreRoll();
+  });
+
+  /** Remount on the main item with `noPreRoll=1` so the fresh mount doesn't
+   *  retry a pre-roll that died before it could be advanced in place. */
+  private remountWithoutPreRoll(): void {
+    // The gate stays on until this component dies: teardown calls savePosition, and with it
+    // cleared the trailer's playhead would land on the main film's row.
+    const qp = { ...this.route.snapshot.queryParams, noPreRoll: '1' };
+    void this.router
+      .navigateByUrl('/', { skipLocationChange: true })
+      .then(() =>
+        this.router.navigate(['/watch', this.preRollMainFileId], {
+          queryParams: qp,
+          replaceUrl: true,
+        }),
+      );
   }
 
   // ── Engine factories ──
@@ -1992,6 +2121,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
   /** True when the cursor is inside the detected intro window. */
   readonly inIntroRange = computed(() => {
+    if (this.preRollActive()) return false;
     const m = this.introMarker();
     if (!m) return false;
     const t = this.currentTime();
@@ -2125,7 +2255,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
    *  next episode of the series queue). Null when nothing follows or there's no
    *  queue (a standalone film). Drives the skip control and auto-advance alike. */
   readonly upNext = computed<QueueItem | null>(() =>
-    this.queue.active() ? this.queue.peekNext() : null,
+    this.preRollActive() ? null : this.queue.active() ? this.queue.peekNext() : null,
   );
 
   /** Whether the current context advances automatically when a stream ends: the
@@ -2276,6 +2406,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     mediaFileId: number,
     mediaId: number,
     episodeId: number | undefined,
+    opts: { noResumeLookup?: boolean } = {},
   ): Promise<void> {
     if (!this.engine || this.reloadingStream || mediaFileId === this.mediaFileId) return;
     this.reloadingStream = true;
@@ -2318,13 +2449,16 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       const knownDuration = (file?.streamInfo as any)?.durationSeconds;
       if (knownDuration && knownDuration > 0) this.state.duration.set(knownDuration);
 
-      // Resume point of the incoming episode (usually the start).
+      // Resume point of the incoming episode. Skipped for a pre-roll transition:
+      // mediaId/episodeId stay on the main film, so this would seek a trailer to it.
       let startTime: number | undefined;
-      const playbackState = await this.streamingApi
-        .getPlaybackState(this.mediaId, this.episodeId)
-        .catch(() => null);
-      if (playbackState && !playbackState.completed && playbackState.positionSeconds > 10) {
-        startTime = playbackState.positionSeconds;
+      if (!opts.noResumeLookup) {
+        const playbackState = await this.streamingApi
+          .getPlaybackState(this.mediaId, this.episodeId)
+          .catch(() => null);
+        if (playbackState && !playbackState.completed && playbackState.positionSeconds > 10) {
+          startTime = playbackState.positionSeconds;
+        }
       }
 
       // Audio preference for the new file (UI/state; the backend picks the
@@ -2421,7 +2555,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
    *  past it (auto or manual) counts as watched.
    *  Backend threshold: position >= duration - 30s OR position >= duration * 0.9. */
   private async markCurrentComplete(): Promise<void> {
-    if (!this.mediaId) return;
+    if (!this.mediaId || this.preRollActive()) return;
     const dur =
       (this.castService.isConnected()
         ? this.castService.duration()
@@ -2509,7 +2643,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
    *  Unlike {@link advance} it does NOT mark the current item watched — a jump
    *  isn't finishing — and it does not skip: the user chose this item. */
   async playQueueItem(index: number): Promise<void> {
-    if (this.advancing || this.reloadingStream) return;
+    if (this.advancing || this.reloadingStream || this.preRollActive()) return;
     if (index === this.queue.index()) return; // already playing it
     const item = this.queue.items()[index];
     if (!item) return;
@@ -2657,6 +2791,13 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     if (this.castService.isConnected()) {
       this.castService.disconnect();
       return;
+    }
+
+    // startCastFromPlayer builds from this.mediaFileId — drop straight to the
+    // main item first so a Cast connect can never cast the trailer.
+    if (this.preRollActive()) {
+      this.preRollRest = [];
+      await this.advancePreRoll();
     }
 
     const wasPlaying = this.engine && !this.engine.paused;
@@ -3207,6 +3348,8 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
    *  backend (within 30s of the end, or past 90%). Drives the "back" target:
    *  a finished episode returns to the next one. */
   private episodeFinished(): boolean {
+    // A pre-roll item reading past 90% must not send "back" to the next episode.
+    if (this.preRollActive()) return false;
     const dur = this.duration();
     const pos = this.currentTime();
     return dur > 0 && (pos >= dur - 30 || pos >= dur * 0.9);
@@ -3994,7 +4137,9 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   private lastSaveAt = 0;
 
   private async savePosition() {
-    if (!this.mediaId) return;
+    // mediaFileId is the pre-roll's while mediaId still names the film — an
+    // escaped write here would stamp the film's row with the trailer's position.
+    if (!this.mediaId || this.preRollActive()) return;
 
     let pos: number;
     let dur: number;


### PR DESCRIPTION
Phase 2 of §8.2, and the half that makes #987 mean something: core has been answering `playback-info`
with a plugin's pre-roll list, and nothing read it.

**One implementation, six surfaces.** Web, Tizen, webOS, desktop (Electron+libmpv), Android and iOS
all run `PlayerComponent`; divergence is confined to `PlaybackEngine.load(url, …)` and the
`ENGINE_TRAITS` table. Apple TV and Cast are separate implementations that do not model the field and
play the main video only, as documented.

## Shape

A pre-roll item **takes over the launch** instead of opening a second load path. The decision sits
between the response arriving and the engine being created, so the item's own negotiated stream flows
through the init tail that already exists — URL building, quality options, engine choice, subtitles,
sprites, autoplay, the stall watchdog — and no frame of the film can paint first. Every later
transition reuses `reloadForEpisode`, the in-place item switch that already releases the outgoing
session, renegotiates, reloads and rebinds.

The main session is released **only after** a candidate has negotiated, so a list where nothing
negotiates leaves the launch byte-identical to today.

## Two bugs review caught, both of which I confirmed by reading before fixing

**A refused transition stranded the run, and the film never played.** `advancePreRoll` consumed the
item and cleared the `ended`/`error` latches *before* calling `reloadForEpisode` — which returns
silently when another reload is in flight, when there is no engine, or on the same id. When it did,
nothing was loaded and nothing could re-trigger the effect: stuck on a finished trailer, permanently.
Now the run waits out an in-flight reload, and since a refusal is silent, **the loaded file is the
only proof it happened** — if it isn't the one requested, the player remounts on the film.

**A trailer's playhead was written onto the film's row.** `remountWithoutPreRoll` cleared the pre-roll
flag *before* navigating, and teardown calls `savePosition()` on the way out — with the gate down and
`mediaId` still the film's. The gate now stays up until the component dies. The test for it fails
loudly with the bug reintroduced:

```
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
```

## Two tests that could not fail

- `not.toHaveBeenCalledWith(TRAILER_FILE_ID, expect.anything(), …)` — `expect.anything()` does not
  match `undefined`, and the call passes `undefined` for those arguments, so the assertion was
  unfailable. It now asserts on the recorded ids.
- "an in-place episode advance does not replay pre-roll" asserted pre-existing behaviour and passed
  with every new line reverted. It now also proves a normal reload still resumes, which is what the
  new `noResumeLookup` option is for — with a sibling test proving a pre-roll transition does *not*
  resume from the film's stored position.

## Also

- The `!initCompleted` gate became `!this.engine`: the engine is what a transition actually needs, so
  a failure in that window keeps the remaining items instead of discarding them and paying a visible
  route hop. `initCompleted` was then dead and is gone.
- The skip button used CSS `max()`, which Chromium 76 drops, and the class carried no `bottom` — on a
  Samsung TV it would have landed wherever the default put it. Plain fallbacks now precede the
  `max()` declarations so the cascade covers both.
- `player.skip_pre_roll` added to all six locales.

## Verification

- Client suite: **48 files, 398 tests, exit 0** — and the exit code was read, not inferred: an earlier
  iteration passed every test while exiting 1, because fake timers let Angular render the template for
  the first time and an unstubbed directive threw. That test was reworked to exercise the same guard
  without timers.
- `npx tsc --noEmit` on the backend — exit 0.
- Both fixes proven to fail when reverted (captures above); no TV-unsafe CSS in the diff
  (`translate:`/`scale:`/`rotate:`/`min(`/`clamp(`); the i18n key is in all six locale files.
