### PR TITLE
feat(plugins): give a form page captions, sections and a status line

### DIFF
--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -48,11 +48,15 @@ export interface UiContribution {
   action: { kind: 'route'; path: string } | { kind: 'action'; actionId: string };
 }
 
-/** The seven field kinds `<app-schema-form>` renders, over four form components. */
+/** The seven field kinds `<app-schema-form>` renders, over three form components. */
 export type FieldType = 'text' | 'email' | 'password' | 'url' | 'number' | 'toggle' | 'select';
 
-/** One input of a plugin's settings form. */
+/**
+ * One input of a plugin's settings form. `kind` is optional and defaults to `'field'` —
+ * a manifest declaring plain fields today needs no change to keep installing and rendering.
+ */
 export interface FieldDef {
+  kind?: 'field';
   key: string;
   type: FieldType;
   labelKey: string;
@@ -66,7 +70,41 @@ export interface FieldDef {
   /** Written to a column on the row itself rather than into its `settings` bag.
    *  Without this a declared field silently stops persisting an entity column. */
   topLevel?: boolean;
+  /**
+   * All optional, all authoring affordances checked by the renderer before it will save — not a
+   * trust boundary, since the settings endpoint behind this page is already admin-gated.
+   */
+  min?: number;
+  max?: number;
+  minLength?: number;
+  maxLength?: number;
 }
+
+/** Static explanatory text between fields — carries no value, renders no input. */
+export interface FormCaption {
+  kind: 'caption';
+  textKey: string;
+}
+
+/** A labelled section of input fields. One level only: `fields` is `FieldDef[]`, not
+ *  `FormItem[]`, so a group inside a group is impossible in the type, not just undocumented. */
+export interface FormGroup {
+  kind: 'group';
+  labelKey: string;
+  fields: FieldDef[];
+}
+
+/** A read-only line showing the current value of `plugin.<id>.<settingKey>` — whatever the
+ *  plugin last wrote there via `config.set`. Needs no route, so it still works stopped. */
+export interface FormStatus {
+  kind: 'status';
+  labelKey: string;
+  settingKey: string;
+}
+
+/** One item of a `form` page, in declared order. A bare field (no `kind`, or `kind: 'field'`)
+ *  is the input the page has always rendered. */
+export type FormItem = FieldDef | FormCaption | FormGroup | FormStatus;
 
 /** One `ui.configPages[]` entry — a form-backed settings page under `plugin.<id>.`. */
 /**
@@ -99,7 +137,7 @@ export type TableRowActionId = (typeof TABLE_ROW_ACTION_IDS)[number];
 
 export interface FormConfigPage extends ConfigPageBase {
   kind?: 'form';
-  fields: FieldDef[];
+  fields: FormItem[];
   /** Buttons core implements on the plugin's behalf. A `data` plugin executes no code of its
    *  own, so this is the only way it can offer an action at all. */
   actions?: { id: string; labelKey: string; actionId: FormActionId }[];

--- a/backend/src/modules/plugins/manifest-shape.validator.spec.ts
+++ b/backend/src/modules/plugins/manifest-shape.validator.spec.ts
@@ -77,6 +77,62 @@ describe('validateManifestShape()', () => {
     expectRefusal({ ...minimalDataManifest(), ui: { configPages: [{ id: 'general' }] } }, 'PLUGIN_BAD_UI_CONFIG_PAGES');
   });
 
+  it('accepts a form page mixing a field, a caption, a group and a status item', () => {
+    const manifest = minimalDataManifest({
+      ui: {
+        configPages: [
+          {
+            id: 'general',
+            labelKey: 'x.general',
+            fields: [
+              { key: 'endpoint_url', type: 'url', labelKey: 'x.endpoint' },
+              { kind: 'caption', textKey: 'x.blurb' },
+              { kind: 'group', labelKey: 'x.advanced', fields: [{ key: 'timeout', type: 'number', labelKey: 'x.timeout' }] },
+              { kind: 'status', labelKey: 'x.last_sync', settingKey: 'last_sync' },
+            ],
+          },
+        ],
+      },
+    });
+    expect(validateManifestShape(manifest).ok).toBe(true);
+  });
+
+  it('refuses a group nested inside a group', () => {
+    expectRefusal(
+      {
+        ...minimalDataManifest(),
+        ui: {
+          configPages: [
+            {
+              id: 'general',
+              labelKey: 'x.general',
+              fields: [
+                {
+                  kind: 'group',
+                  labelKey: 'x.outer',
+                  // Carries key/type too, so nothing but the `kind` guard can refuse it.
+                  fields: [
+                    { kind: 'group', key: 'inner', type: 'text', labelKey: 'x.inner', fields: [] },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+      'PLUGIN_BAD_UI_CONFIG_PAGES',
+    );
+  });
+
+  it('refuses a status item missing settingKey', () => {
+    expectRefusal(
+      { ...minimalDataManifest(), ui: { configPages: [{ id: 'general', labelKey: 'x', fields: [{ kind: 'status', labelKey: 'x.s' }] }] } },
+      'PLUGIN_BAD_UI_CONFIG_PAGES',
+    );
+  });
+
+
+
   it('refuses a ui.releasePicker missing a context', () => {
     const pair = { search: '/search', grab: '/grab' };
     expectRefusal({ ...minimalDataManifest(), ui: { releasePicker: { movie: pair, season: pair } } }, 'PLUGIN_BAD_UI_RELEASE_PICKER');

--- a/backend/src/modules/plugins/manifest-shape.validator.ts
+++ b/backend/src/modules/plugins/manifest-shape.validator.ts
@@ -25,8 +25,38 @@ function isWellShapedContribution(v: unknown): boolean {
   );
 }
 
+/** A bare field carries no `kind` (or explicitly `'field'`) — anything else is a different
+ *  form item, and must not slip through as a field just because it also has key/type/labelKey. */
 function isWellShapedField(v: unknown): boolean {
-  return isRecord(v) && typeof v.key === 'string' && typeof v.type === 'string' && typeof v.labelKey === 'string';
+  return (
+    isRecord(v) &&
+    (v.kind === undefined || v.kind === 'field') &&
+    typeof v.key === 'string' &&
+    typeof v.type === 'string' &&
+    typeof v.labelKey === 'string'
+  );
+}
+
+function isWellShapedCaption(v: unknown): boolean {
+  return isRecord(v) && typeof v.textKey === 'string';
+}
+
+function isWellShapedStatus(v: unknown): boolean {
+  return isRecord(v) && typeof v.settingKey === 'string' && typeof v.labelKey === 'string';
+}
+
+/** One level only: a group's own fields must be plain input fields — `isWellShapedField`
+ *  rejects anything carrying a `kind` of its own, so a nested group is refused here. */
+function isWellShapedGroup(v: unknown): boolean {
+  return isRecord(v) && typeof v.labelKey === 'string' && Array.isArray(v.fields) && v.fields.every(isWellShapedField);
+}
+
+function isWellShapedFormItem(v: unknown): boolean {
+  if (!isRecord(v)) return false;
+  if (v.kind === 'caption') return isWellShapedCaption(v);
+  if (v.kind === 'group') return isWellShapedGroup(v);
+  if (v.kind === 'status') return isWellShapedStatus(v);
+  return isWellShapedField(v);
 }
 
 /** Each `kind` carries its own required key: the client binds them without a guard. */
@@ -34,7 +64,7 @@ function isWellShapedConfigPage(v: unknown): boolean {
   if (!isRecord(v) || typeof v.id !== 'string' || typeof v.labelKey !== 'string') return false;
   if (v.kind === 'table') return typeof v.list === 'string' && Array.isArray(v.columns);
   if (v.kind === 'providers') return typeof v.list === 'string' && typeof v.implementations === 'string';
-  return Array.isArray(v.fields) && v.fields.every(isWellShapedField);
+  return Array.isArray(v.fields) && v.fields.every(isWellShapedFormItem);
 }
 
 function isWellShapedEvent(v: unknown): boolean {

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -148,12 +148,20 @@ export type PluginRegistrationResult = PluginRegistrationSuccess | PluginRegistr
  * tiers (P4a). L1 (`state.json` quarantine) still has no home; L3
  * (re-hashing `plugin.js` from the loaded fd) is `PluginProcessService`'s.
  */
-/** Keys a plugin declares on its `form` pages — the only values an operator can set for it. */
+/** Keys a plugin declares on its `form` pages — the only values an operator can set for it.
+ *  A `group`'s nested fields count too; `caption` and `status` carry no operator-settable key. */
 function formFieldKeys(pages: ConfigPage[]): ReadonlySet<string> {
   const keys = new Set<string>();
   for (const page of pages) {
     if (page.kind && page.kind !== 'form') continue;
-    for (const field of page.fields ?? []) if (typeof field?.key === 'string') keys.add(field.key);
+    for (const item of page.fields ?? []) {
+      if (!item) continue;
+      if (item.kind === 'group') {
+        for (const field of item.fields ?? []) if (typeof field?.key === 'string') keys.add(field.key);
+      } else if (item.kind !== 'caption' && item.kind !== 'status' && typeof item.key === 'string') {
+        keys.add(item.key);
+      }
+    }
   }
   return keys;
 }

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2353,6 +2353,13 @@
     "webhook_test_unconfigured": "Noch kein Endpunkt konfiguriert — es wurde nichts gesendet.",
     "webhook_test_failed": "Testzustellung fehlgeschlagen: {{detail}}"
   },
+  "schema_form": {
+    "min_value": "Muss mindestens {{min}} sein.",
+    "max_value": "Darf höchstens {{max}} sein.",
+    "min_length": "Muss mindestens {{min}} Zeichen lang sein.",
+    "max_length": "Darf höchstens {{max}} Zeichen lang sein.",
+    "status_unset": "Noch nicht festgelegt"
+  },
   "provider_list": {
     "new": "Neu",
     "col_name": "Name",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2381,6 +2381,13 @@
     "webhook_test_unconfigured": "No endpoint configured yet — nothing was sent.",
     "webhook_test_failed": "Test delivery failed: {{detail}}"
   },
+  "schema_form": {
+    "min_value": "Must be at least {{min}}.",
+    "max_value": "Must be at most {{max}}.",
+    "min_length": "Must be at least {{min}} characters.",
+    "max_length": "Must be at most {{max}} characters.",
+    "status_unset": "Not set yet"
+  },
   "provider_list": {
     "new": "New",
     "col_name": "Name",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2353,6 +2353,13 @@
     "webhook_test_unconfigured": "Aún no hay punto de entrada configurado: no se envió nada.",
     "webhook_test_failed": "La entrega de prueba falló: {{detail}}"
   },
+  "schema_form": {
+    "min_value": "Debe ser al menos {{min}}.",
+    "max_value": "Debe ser como máximo {{max}}.",
+    "min_length": "Debe tener al menos {{min}} caracteres.",
+    "max_length": "Debe tener como máximo {{max}} caracteres.",
+    "status_unset": "Aún no establecido"
+  },
   "provider_list": {
     "new": "Nuevo",
     "col_name": "Nombre",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2381,6 +2381,13 @@
     "webhook_test_unconfigured": "Aucun point d’entrée configuré — rien n’a été envoyé.",
     "webhook_test_failed": "Échec de la livraison de test : {{detail}}"
   },
+  "schema_form": {
+    "min_value": "Doit être au moins {{min}}.",
+    "max_value": "Doit être au plus {{max}}.",
+    "min_length": "Doit contenir au moins {{min}} caractères.",
+    "max_length": "Doit contenir au plus {{max}} caractères.",
+    "status_unset": "Non défini"
+  },
   "provider_list": {
     "new": "Nouveau",
     "col_name": "Nom",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2353,6 +2353,13 @@
     "webhook_test_unconfigured": "Nessun endpoint configurato: non è stato inviato nulla.",
     "webhook_test_failed": "Consegna di test non riuscita: {{detail}}"
   },
+  "schema_form": {
+    "min_value": "Deve essere almeno {{min}}.",
+    "max_value": "Deve essere al massimo {{max}}.",
+    "min_length": "Deve contenere almeno {{min}} caratteri.",
+    "max_length": "Deve contenere al massimo {{max}} caratteri.",
+    "status_unset": "Non ancora impostato"
+  },
   "provider_list": {
     "new": "Nuovo",
     "col_name": "Nome",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2353,6 +2353,13 @@
     "webhook_test_unconfigured": "Nenhum ponto de entrada configurado — nada foi enviado.",
     "webhook_test_failed": "A entrega de teste falhou: {{detail}}"
   },
+  "schema_form": {
+    "min_value": "Deve ser pelo menos {{min}}.",
+    "max_value": "Deve ser no máximo {{max}}.",
+    "min_length": "Deve ter pelo menos {{min}} caracteres.",
+    "max_length": "Deve ter no máximo {{max}} caracteres.",
+    "status_unset": "Ainda não definido"
+  },
   "provider_list": {
     "new": "Novo",
     "col_name": "Nome",

--- a/client/src/app/core/plugin-ui/contribution.types.ts
+++ b/client/src/app/core/plugin-ui/contribution.types.ts
@@ -51,11 +51,15 @@ export interface UiContribution {
   action: { kind: 'route'; path: string } | { kind: 'action'; actionId: string };
 }
 
-/** The seven field kinds `<app-schema-form>` renders, over four form components. */
+/** The seven field kinds `<app-schema-form>` renders, over three form components. */
 export type FieldType = 'text' | 'email' | 'password' | 'url' | 'number' | 'toggle' | 'select';
 
-/** One input of a plugin's settings form. */
+/**
+ * One input of a plugin's settings form. `kind` is optional and defaults to `'field'` —
+ * a manifest declaring plain fields today needs no change to keep installing and rendering.
+ */
 export interface FieldDef {
+  kind?: 'field';
   key: string;
   type: FieldType;
   labelKey: string;
@@ -69,7 +73,41 @@ export interface FieldDef {
   /** Written to a column on the row itself rather than into its `settings` bag.
    *  Without this a declared field silently stops persisting an entity column. */
   topLevel?: boolean;
+  /**
+   * All optional, all authoring affordances checked by the renderer before it will save — not a
+   * trust boundary, since the settings endpoint behind this page is already admin-gated.
+   */
+  min?: number;
+  max?: number;
+  minLength?: number;
+  maxLength?: number;
 }
+
+/** Static explanatory text between fields — carries no value, renders no input. */
+export interface FormCaption {
+  kind: 'caption';
+  textKey: string;
+}
+
+/** A labelled section of input fields. One level only: `fields` is `FieldDef[]`, not
+ *  `FormItem[]`, so a group inside a group is impossible in the type, not just undocumented. */
+export interface FormGroup {
+  kind: 'group';
+  labelKey: string;
+  fields: FieldDef[];
+}
+
+/** A read-only line showing the current value of `plugin.<id>.<settingKey>` — whatever the
+ *  plugin last wrote there via `config.set`. Needs no route, so it still works stopped. */
+export interface FormStatus {
+  kind: 'status';
+  labelKey: string;
+  settingKey: string;
+}
+
+/** One item of a `form` page, in declared order. A bare field (no `kind`, or `kind: 'field'`)
+ *  is the input the page has always rendered. */
+export type FormItem = FieldDef | FormCaption | FormGroup | FormStatus;
 
 /** One `ui.configPages[]` entry — a form-backed settings page under `plugin.<id>.`. */
 /**
@@ -102,7 +140,7 @@ export type TableRowActionId = (typeof TABLE_ROW_ACTION_IDS)[number];
 
 export interface FormConfigPage extends ConfigPageBase {
   kind?: 'form';
-  fields: FieldDef[];
+  fields: FormItem[];
   /** Buttons core implements on the plugin's behalf. A `data` plugin executes no code of its
    *  own, so this is the only way it can offer an action at all. */
   actions?: { id: string; labelKey: string; actionId: FormActionId }[];

--- a/client/src/app/features/plugin-view/plugin-view.html
+++ b/client/src/app/features/plugin-view/plugin-view.html
@@ -57,9 +57,9 @@
       } @else {
         <div class="flex flex-col gap-4">
           <h2 class="text-lg font-bold">{{ page.labelKey | translate }}</h2>
-          <app-schema-form [fields]="page.fields" [(value)]="formValue" [disabled]="formSaving()" />
+          <app-schema-form #schemaForm [fields]="page.fields" [(value)]="formValue" [disabled]="formSaving()" />
           <div class="flex flex-wrap items-center gap-2">
-            <button type="button" class="btn btn-primary" [disabled]="formSaving()" (click)="saveForm()">
+            <button type="button" class="btn btn-primary" [disabled]="formSaving() || schemaForm.invalid()" (click)="saveForm()">
               @if (formSaving()) {
                 <span class="loading loading-spinner loading-sm"></span>
               }

--- a/client/src/app/features/plugin-view/plugin-view.spec.ts
+++ b/client/src/app/features/plugin-view/plugin-view.spec.ts
@@ -82,6 +82,69 @@ describe('PluginViewComponent', () => {
     http.verify();
   });
 
+  it('loads a `status` item from settings but never writes it back on save', async () => {
+    const { fixture, http } = createComponent(
+      { pluginId: 'fliks.a', view: 'settings' },
+      {
+        hasPlugin: () => true,
+        configPage: () => ({
+          id: 'settings',
+          labelKey: 'x',
+          fields: [
+            { key: 'apiKey', type: 'text', labelKey: 'y' },
+            { kind: 'status', labelKey: 'x.last_sync', settingKey: 'last_sync' },
+          ],
+        }),
+      },
+    );
+    fixture.detectChanges();
+    http.expectOne({ url: '/api/settings', method: 'GET' }).flush({
+      'plugin.fliks.a.apiKey': 'stored',
+      'plugin.fliks.a.last_sync': '2026-08-14',
+    });
+    await settle(fixture);
+
+    expect(fixture.componentInstance.formValue()['last_sync']).toBe('2026-08-14');
+    expect(fixture.nativeElement.textContent).toContain('x.last_sync');
+    expect(fixture.nativeElement.textContent).toContain('2026-08-14');
+
+    void fixture.componentInstance.saveForm();
+    const req = http.expectOne({ url: '/api/settings', method: 'PUT' });
+    // `last_sync` came from the same value() bag as `apiKey` but is never a declared field — a
+    // save that forwarded it anyway would race whatever the plugin itself writes there.
+    expect(req.request.body).toEqual({ data: { 'plugin.fliks.a.apiKey': 'stored' } });
+    req.flush({ ok: true });
+    await settle(fixture);
+    http.verify();
+  });
+
+  it('disables Save while a declared constraint is violated, and re-enables once it is met', async () => {
+    const { fixture, http } = createComponent(
+      { pluginId: 'fliks.a', view: 'settings' },
+      {
+        hasPlugin: () => true,
+        configPage: () => ({
+          id: 'settings',
+          labelKey: 'x',
+          fields: [{ key: 'code', type: 'text', labelKey: 'x.code', maxLength: 3 }],
+        }),
+      },
+    );
+    fixture.detectChanges();
+    http.expectOne({ url: '/api/settings', method: 'GET' }).flush({ 'plugin.fliks.a.code': 'nope' });
+    await settle(fixture);
+
+    const saveButton = Array.from(fixture.nativeElement.querySelectorAll('button')).find((b) =>
+      (b as HTMLButtonElement).textContent?.includes('common.save'),
+    ) as HTMLButtonElement;
+    expect(saveButton.disabled).toBe(true);
+
+    fixture.componentInstance.formValue.set({ code: 'ABC' });
+    fixture.detectChanges();
+    expect(saveButton.disabled).toBe(false);
+    http.verify();
+  });
+
   it('VERDICT: types a stored setting by its declared field kind — "false" is off, not a truthy string', async () => {
     const { fixture, http } = createComponent(
       { pluginId: 'fliks.a', view: 'settings' },

--- a/client/src/app/features/plugin-view/plugin-view.ts
+++ b/client/src/app/features/plugin-view/plugin-view.ts
@@ -26,6 +26,7 @@ import {
   type FieldDef,
   type FormActionId,
   type FormConfigPage,
+  type FormItem,
   type TableRowActionId,
 } from '../../core/plugin-ui/contribution.types';
 
@@ -50,6 +51,21 @@ interface PluginTestConnectionResponse {
  * string "false" renders checked, and a `number` handed "60" is a string in a numeric field.
  * An unset number stays empty rather than becoming 0 — that is what "no cleanup" means.
  */
+/** A `status` item has no `fields`/`kind: 'group'` of its own to recurse into — only a bare
+ *  field or a group's own fields are operator-editable settings. */
+function flattenFields(items: readonly FormItem[]): FieldDef[] {
+  const out: FieldDef[] = [];
+  for (const item of items) {
+    if (item.kind === 'group') out.push(...item.fields);
+    else if (item.kind === undefined || item.kind === 'field') out.push(item);
+  }
+  return out;
+}
+
+function statusSettingKeys(items: readonly FormItem[]): string[] {
+  return items.filter((item) => item.kind === 'status').map((item) => item.settingKey);
+}
+
 function typedSetting(field: FieldDef, raw: string | null | undefined): string | number | boolean {
   if (field.type === 'toggle') {
     return raw === undefined || raw === null || raw === '' ? Boolean(field.default) : raw === 'true';
@@ -160,13 +176,15 @@ export class PluginViewComponent {
     });
   }
 
-  private async loadFormValue(fields: readonly FieldDef[]): Promise<void> {
+  private async loadFormValue(items: readonly FormItem[]): Promise<void> {
     this.formLoading.set(true);
     try {
       const all = await this.settingsApi.getAll();
       const prefix = `plugin.${this.pluginId()}.`;
       const value: SchemaFormValue = {};
-      for (const field of fields) value[field.key] = typedSetting(field, all[prefix + field.key]);
+      for (const field of flattenFields(items)) value[field.key] = typedSetting(field, all[prefix + field.key]);
+      // Read-only: whatever the plugin last wrote via `config.set`, keyed by its own settingKey.
+      for (const key of statusSettingKeys(items)) value[key] = all[prefix + key] ?? '';
       this.formValue.set(value);
     } finally {
       this.formLoading.set(false);
@@ -204,9 +222,14 @@ export class PluginViewComponent {
   async saveForm(): Promise<void> {
     this.formSaving.set(true);
     try {
+      const editableKeys = new Set(flattenFields(this.formPage()?.fields ?? []).map((f) => f.key));
       const prefix = `plugin.${this.pluginId()}.`;
       const patch: Record<string, string> = {};
-      for (const [k, v] of Object.entries(this.formValue())) patch[prefix + k] = String(v);
+      // A `status` key is loaded into the same value bag for display, but the plugin owns
+      // it — writing it back here would race whatever it writes via `config.set`.
+      for (const [k, v] of Object.entries(this.formValue())) {
+        if (editableKeys.has(k)) patch[prefix + k] = String(v);
+      }
       await this.settingsApi.setBulk(patch);
     } finally {
       this.formSaving.set(false);

--- a/client/src/app/shared/components/schema-form/schema-form.html
+++ b/client/src/app/shared/components/schema-form/schema-form.html
@@ -1,48 +1,73 @@
-<div class="flex flex-col gap-4">
-  @for (field of fields(); track field.key) {
-    @switch (fieldKind(field)) {
-      @case ('input') {
-        <div class="flex flex-col gap-1">
-          <app-input-field
-            [type]="inputType(field)"
-            [label]="field.labelKey | translate"
-            [hint]="field.hint ? (field.hint | translate) : ''"
-            [placeholder]="field.placeholder ? (field.placeholder | translate) : ''"
-            [disabled]="disabled()"
-            [value]="fieldValue(field)"
-            (valueChange)="setValue(field, $event)"
-          />
-          @if (isInvalid(field)) {
-            <p class="text-error text-xs">{{ 'common.field_required' | translate }}</p>
-          }
-        </div>
-      }
-      @case ('toggle') {
-        <app-toggle-field
+<ng-template #fieldTpl let-field>
+  @switch (fieldKind(field)) {
+    @case ('input') {
+      <div class="flex flex-col gap-1">
+        <app-input-field
+          [type]="inputType(field)"
+          [label]="field.labelKey | translate"
+          [hint]="field.hint ? (field.hint | translate) : ''"
+          [placeholder]="field.placeholder ? (field.placeholder | translate) : ''"
+          [disabled]="disabled()"
+          [value]="fieldValue(field)"
+          (valueChange)="setValue(field, $event)"
+        />
+        @for (err of fieldErrors(field); track err.key) {
+          <p class="text-error text-xs">{{ err.key | translate: err.params }}</p>
+        }
+      </div>
+    }
+    @case ('toggle') {
+      <app-toggle-field
+        [label]="field.labelKey | translate"
+        [hint]="field.hint ? (field.hint | translate) : ''"
+        [disabled]="disabled()"
+        [value]="fieldBool(field)"
+        (valueChange)="setBool(field, $event)"
+      />
+    }
+    @case ('select') {
+      <div class="flex flex-col gap-1">
+        <app-select-field
           [label]="field.labelKey | translate"
           [hint]="field.hint ? (field.hint | translate) : ''"
           [disabled]="disabled()"
-          [value]="fieldBool(field)"
-          (valueChange)="setBool(field, $event)"
-        />
-      }
-      @case ('select') {
-        <div class="flex flex-col gap-1">
-          <app-select-field
-            [label]="field.labelKey | translate"
-            [hint]="field.hint ? (field.hint | translate) : ''"
-            [disabled]="disabled()"
-            [value]="fieldValue(field)"
-            (valueChange)="setValue(field, $event)"
-          >
-            @for (opt of field.options ?? []; track opt.value) {
-              <option [value]="opt.value">{{ opt.labelKey | translate }}</option>
-            }
-          </app-select-field>
-          @if (isInvalid(field)) {
-            <p class="text-error text-xs">{{ 'common.field_required' | translate }}</p>
+          [value]="fieldValue(field)"
+          (valueChange)="setValue(field, $event)"
+        >
+          @for (opt of field.options ?? []; track opt.value) {
+            <option [value]="opt.value">{{ opt.labelKey | translate }}</option>
           }
+        </app-select-field>
+        @for (err of fieldErrors(field); track err.key) {
+          <p class="text-error text-xs">{{ err.key | translate: err.params }}</p>
+        }
+      </div>
+    }
+  }
+</ng-template>
+
+<div class="flex flex-col gap-4">
+  @for (item of fields(); track $index) {
+    @switch (itemKind(item)) {
+      @case ('caption') {
+        <p class="text-sm text-base-content/70">{{ asCaption(item).textKey | translate }}</p>
+      }
+      @case ('group') {
+        <fieldset class="flex flex-col gap-3 rounded-box border border-base-300 p-3">
+          <legend class="text-sm font-semibold px-1">{{ asGroup(item).labelKey | translate }}</legend>
+          @for (field of asGroup(item).fields; track field.key) {
+            <ng-container [ngTemplateOutlet]="fieldTpl" [ngTemplateOutletContext]="{ $implicit: field }" />
+          }
+        </fieldset>
+      }
+      @case ('status') {
+        <div class="flex items-center justify-between gap-2 text-sm">
+          <span class="text-base-content/70">{{ asStatus(item).labelKey | translate }}</span>
+          <span class="font-mono">{{ statusValue(asStatus(item)) || ('schema_form.status_unset' | translate) }}</span>
         </div>
+      }
+      @default {
+        <ng-container [ngTemplateOutlet]="fieldTpl" [ngTemplateOutletContext]="{ $implicit: item }" />
       }
     }
   }

--- a/client/src/app/shared/components/schema-form/schema-form.spec.ts
+++ b/client/src/app/shared/components/schema-form/schema-form.spec.ts
@@ -3,9 +3,9 @@ import { TestBed } from '@angular/core/testing';
 import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
 import { SchemaFormComponent } from './schema-form';
-import type { FieldDef } from '../../../core/plugin-ui/contribution.types';
+import type { FieldDef, FormItem } from '../../../core/plugin-ui/contribution.types';
 
-function createComponent(fields: FieldDef[], value: Record<string, unknown>) {
+function createComponent(fields: readonly FormItem[], value: Record<string, unknown>) {
   TestBed.configureTestingModule({
     providers: [
       provideZonelessChangeDetection(),
@@ -157,11 +157,102 @@ describe('SchemaFormComponent — required validation', () => {
     expect(fixture.nativeElement.querySelector('.text-error')).toBeNull();
   });
 
+  it('shows a blank required field as a hint without blocking save, so it can be unset', () => {
+    // A single required field is the whole page for an installed plugin; blocking here would
+    // make clearing it — the way you un-configure that plugin — impossible.
+    const field: FieldDef = { key: 'endpoint_url', type: 'url', labelKey: 'x.url', required: true };
+    const fixture = createComponent([field], {});
+    const component = fixture.componentInstance as unknown as { invalid: () => boolean };
+
+    expect(fixture.nativeElement.querySelector('.text-error')).not.toBeNull();
+    expect(component.invalid()).toBe(false);
+  });
+
+  it('blocks save on a declared constraint, unlike a blank required field', () => {
+    const field: FieldDef = { key: 'name', type: 'text', labelKey: 'x.name', maxLength: 3 };
+    const fixture = createComponent([field], { name: 'far too long' });
+    const component = fixture.componentInstance as unknown as { invalid: () => boolean };
+
+    expect(component.invalid()).toBe(true);
+  });
+
   it('does not flag a non-required field', () => {
     const field: FieldDef = { key: 'name', type: 'text', labelKey: 'x.name' };
     const fixture = createComponent([field], {});
     expect(fixture.nativeElement.querySelector('.text-error')).toBeNull();
   });
+});
+
+describe('SchemaFormComponent — caption, group and status items', () => {
+  it('renders a caption as text, with no input and no effect on value()', () => {
+    const items: FormItem[] = [{ kind: 'caption', textKey: 'x.blurb' }];
+    const fixture = createComponent(items, {});
+    expect(fixture.nativeElement.textContent).toContain('x.blurb');
+    expect(fixture.nativeElement.querySelectorAll('input, select').length).toBe(0);
+  });
+
+  it('renders a group label and its own input fields, wired to the same value()', async () => {
+    const items: FormItem[] = [
+      { kind: 'group', labelKey: 'x.advanced', fields: [{ key: 'timeout', type: 'number', labelKey: 'x.timeout' }] },
+    ];
+    const fixture = createComponent(items, { timeout: 30 });
+    expect(fixture.nativeElement.textContent).toContain('x.advanced');
+    const input = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
+    await fixture.whenStable();
+    expect(input.value).toBe('30');
+
+    setInputAndDispatch(input, '45');
+    expect(fixture.componentInstance.value()['timeout']).toBe(45);
+  });
+
+  it('renders a status item as a read-only label/value pair sourced from value(), never an input', () => {
+    const items: FormItem[] = [{ kind: 'status', labelKey: 'x.last_sync', settingKey: 'last_sync' }];
+    const fixture = createComponent(items, { last_sync: '2026-08-14T00:00:00Z' });
+    expect(fixture.nativeElement.textContent).toContain('x.last_sync');
+    expect(fixture.nativeElement.textContent).toContain('2026-08-14T00:00:00Z');
+    expect(fixture.nativeElement.querySelectorAll('input, select').length).toBe(0);
+  });
+});
+
+describe('SchemaFormComponent — declared validation constraints', () => {
+
+
+  it('enforces min/max on a number field', () => {
+    const field: FieldDef = { key: 'n', type: 'number', labelKey: 'x.n', min: 1, max: 10 };
+    const fixture = createComponent([field], { n: 0 });
+    expect(fixture.componentInstance.invalid()).toBe(true);
+
+    fixture.componentRef.setInput('value', { n: 20 });
+    fixture.detectChanges();
+    expect(fixture.componentInstance.invalid()).toBe(true);
+
+    fixture.componentRef.setInput('value', { n: 5 });
+    fixture.detectChanges();
+    expect(fixture.componentInstance.invalid()).toBe(false);
+  });
+
+  it('enforces minLength/maxLength on a text field', () => {
+    const field: FieldDef = { key: 's', type: 'text', labelKey: 'x.s', minLength: 3, maxLength: 5 };
+    const fixture = createComponent([field], { s: 'ab' });
+    expect(fixture.componentInstance.invalid()).toBe(true);
+
+    fixture.componentRef.setInput('value', { s: 'abcdef' });
+    fixture.detectChanges();
+    expect(fixture.componentInstance.invalid()).toBe(true);
+
+    fixture.componentRef.setInput('value', { s: 'abcd' });
+    fixture.detectChanges();
+    expect(fixture.componentInstance.invalid()).toBe(false);
+  });
+
+  it('flags a field nested in a group, on the same invalid() a plain field would set', () => {
+    const items: FormItem[] = [
+      { kind: 'group', labelKey: 'x.advanced', fields: [{ key: 'n', type: 'number', labelKey: 'x.n', min: 1 }] },
+    ];
+    const fixture = createComponent(items, { n: 0 });
+    expect(fixture.componentInstance.invalid()).toBe(true);
+  });
+
 });
 
 it('VERDICT: reads a stringified boolean, so a stored "false" renders off', async () => {

--- a/client/src/app/shared/components/schema-form/schema-form.ts
+++ b/client/src/app/shared/components/schema-form/schema-form.ts
@@ -1,17 +1,26 @@
-import { ChangeDetectionStrategy, Component, input, model } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, model } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
-import { FieldDef } from '../../../core/plugin-ui/contribution.types';
+import { FieldDef, FormCaption, FormGroup, FormItem, FormStatus } from '../../../core/plugin-ui/contribution.types';
 import { InputFieldComponent, InputFieldType } from '../forms/input-field/input-field';
 import { SelectFieldComponent } from '../forms/select-field/select-field';
 import { ToggleFieldComponent } from '../forms/toggle-field/toggle-field';
 
-/** Keyed by `FieldDef.key`; a select/text/number value is always a string here, coerced on read. */
+/** Keyed by `FieldDef.key`; a select/text/number value is always a string here, coerced on read.
+ *  A `status` item's current value is keyed by its own `settingKey` in this same bag. */
 export type SchemaFormValue = Record<string, string | number | boolean>;
 
 type FieldKind = 'input' | 'toggle' | 'select';
+type ItemKind = 'field' | 'caption' | 'group' | 'status';
+
+interface FieldError {
+  key: string;
+  params?: Record<string, unknown>;
+}
+
 
 /**
- * Renders a `FieldDef[]` as DaisyUI controls, delegating to the four shared
+ * Renders a `FormItem[]` as DaisyUI controls, delegating to the three shared
  * `forms/` components. An unmatched `field.type` renders nothing — it must
  * never blank out or break the rest of the form.
  *
@@ -24,14 +33,53 @@ type FieldKind = 'input' | 'toggle' | 'select';
  */
 @Component({
   selector: 'app-schema-form',
-  imports: [InputFieldComponent, SelectFieldComponent, ToggleFieldComponent, TranslateModule],
+  imports: [InputFieldComponent, SelectFieldComponent, ToggleFieldComponent, NgTemplateOutlet, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './schema-form.html',
 })
 export class SchemaFormComponent {
-  readonly fields = input.required<readonly FieldDef[]>();
+  readonly fields = input.required<readonly FormItem[]>();
   readonly value = model.required<SchemaFormValue>();
   readonly disabled = input(false);
+
+  /** True while a value breaks a declared constraint. A `required` field left empty is shown as a
+   *  hint but does not hold here: clearing one is how an operator unsets it. */
+  readonly invalid = computed(() =>
+    this.flatFields().some((f) => this.fieldErrors(f).some((e) => e.key !== 'common.field_required')),
+  );
+
+  private flatFields(): FieldDef[] {
+    const out: FieldDef[] = [];
+    for (const item of this.fields()) {
+      if (item.kind === 'group') out.push(...item.fields);
+      else if (item.kind === undefined || item.kind === 'field') out.push(item);
+    }
+    return out;
+  }
+
+  protected itemKind(item: FormItem): ItemKind {
+    if (item.kind === 'caption') return 'caption';
+    if (item.kind === 'group') return 'group';
+    if (item.kind === 'status') return 'status';
+    return 'field';
+  }
+
+  protected asCaption(item: FormItem): FormCaption {
+    return item as FormCaption;
+  }
+
+  protected asGroup(item: FormItem): FormGroup {
+    return item as FormGroup;
+  }
+
+  protected asStatus(item: FormItem): FormStatus {
+    return item as FormStatus;
+  }
+
+  protected statusValue(item: FormStatus): string {
+    const v = this.value()[item.settingKey];
+    return v === undefined || v === null ? '' : String(v);
+  }
 
   protected fieldKind(field: FieldDef): FieldKind | null {
     switch (field.type) {
@@ -79,9 +127,32 @@ export class SchemaFormComponent {
     this.value.set({ ...this.value(), [field.key]: v });
   }
 
+  /** An empty optional field is not invalid: a constraint describes a value, and there isn't one. */
+  protected fieldErrors(field: FieldDef): FieldError[] {
+    if (field.secret) return [];
+    const errors: FieldError[] = [];
+    const raw = this.value()[field.key];
+    const isEmpty = raw === undefined || raw === null || String(raw).trim() === '';
+    if (field.required && isEmpty) errors.push({ key: 'common.field_required' });
+    if (isEmpty) return errors;
+
+    const str = String(raw);
+    if (field.type === 'number') {
+      const n = Number(raw);
+      if (field.min !== undefined && n < field.min) errors.push({ key: 'schema_form.min_value', params: { min: field.min } });
+      if (field.max !== undefined && n > field.max) errors.push({ key: 'schema_form.max_value', params: { max: field.max } });
+    } else {
+      if (field.minLength !== undefined && str.length < field.minLength) {
+        errors.push({ key: 'schema_form.min_length', params: { min: field.minLength } });
+      }
+      if (field.maxLength !== undefined && str.length > field.maxLength) {
+        errors.push({ key: 'schema_form.max_length', params: { max: field.maxLength } });
+      }
+    }
+    return errors;
+  }
+
   protected isInvalid(field: FieldDef): boolean {
-    if (!field.required || field.secret) return false;
-    const v = this.value()[field.key];
-    return v === undefined || v === null || String(v).trim() === '';
+    return this.fieldErrors(field).length > 0;
   }
 }

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -89,6 +89,28 @@ catalogue per slot, and an id it does not know renders nothing.
   field set, an optional connection test, and row/list actions.
 - `table` — a read-only list over one route, with declared columns and row actions.
 
+A `form` page's `fields[]` is an ordered list of items, discriminated on `kind`:
+
+- a bare field (no `kind`, or `kind: 'field'`) — the input it has always rendered;
+- `caption` — static text between fields, carrying a `textKey`; no input, no value;
+- `group` — a labelled section of input fields. **One level only**: a group's own `fields` are
+  plain input fields, never another group — nesting one is refused at install, not merely ignored;
+- `status` — a read-only line naming a `settingKey`. It shows whatever value the plugin last wrote
+  to `plugin.<id>.<settingKey>` via `config.set`. There is no route behind it, so — like the rest
+  of `form` — it still renders with the process stopped; it is not a live status check.
+
+A field may also declare validation constraints, all optional: `min`/`max` for a `number` field,
+`minLength`/`maxLength` otherwise. The renderer enforces them before it will save. They are an
+authoring affordance, not a trust boundary — the settings endpoint behind every `form` page is
+already admin-gated. A blank `required` field is shown as a hint but does not block saving, because
+clearing a value is how an operator unsets it.
+
+There is deliberately no author-supplied regular expression. A pattern arriving from a manifest is
+untrusted, a `providers` page's fields arrive over HTTP at render time and never pass the manifest
+validator at all, and no syntactic check separates a safe expression from one that hangs the tab —
+a measured `^(a|a)+$` takes over a second on 26 characters, while an ordinary IPv4 or hostname
+pattern trips every heuristic that catches it.
+
 Declaring a page does **not** link to it: a `settings.page` contribution is what puts it in the
 admin sidebar.
 


### PR DESCRIPTION
§8.5, the last contract-affecting item before the major freezes.

## What shaped the scope

`ui-contribution.ts` states that `form` is **the only page kind that works with the process stopped**
(`providers` and `table` read the plugin's own routes). Two things the item asked for would have
broken that, and the item itself says "declared widgets, **not** plugin code":

- an **author-owned validation hook** is plugin code running per save → declared bounds instead;
- a **status widget calling a plugin route** needs the process up → a status that reads a setting the
  plugin already wrote via `config.set` renders last-known state with the process down, and needs no
  new transport.

A **button widget** was not added either: `actions[]` with its closed `actionId` catalogue already is
the button mechanism, and a second one would be duplicate surface frozen by the major.

## Added

`caption`, `group` (one level — a group cannot hold a group, enforced in the *type*), `status`, and
optional bounds (`min`/`max` for numbers, `minLength`/`maxLength` otherwise).

## Dropped after review: the `pattern` constraint

The first cut included an author-supplied regular expression, defended by a syntactic blacklist plus
a length cap. Review demonstrated it was the worst of both worlds, and I reproduced every number:

```
^(a|a)+$              ACCEPTED by the blacklist   26 chars → 1138 ms (exponential)
^(\d{1,3}\.){3}\d{1,3}$   REFUSED  (an ordinary IPv4 field)
^([a-z0-9-]+\.)+[a-z]{2,}$ REFUSED  (an ordinary hostname field)
```

So it refused the two patterns an author would actually write and accepted a real ReDoS — and
`fieldErrors()` runs on every change detection, making that a main-thread freeze per keystroke. The
length cap did not help: the blow-up is at ~25 characters, not 500.

The install-time "backstop" was also structurally incomplete: `provider-list.html` shares this
component and its fields arrive **over HTTP at render time**, never passing the manifest validator at
all.

A blacklist of regex shapes is unwinnable, so `pattern` is gone. The remaining bounds are safe by
construction and carry most of the value. `docs/plugins.md` says why, so nobody adds it back.

## A regression review caught

Gating Save on `invalid()` included *required-but-empty*. `fliks.webhooks` — installed right now —
declares exactly one field, `endpoint_url`, `required: true`. Save would have been permanently
disabled while it was blank, so **there would have been no way to un-configure webhooks**. Required
is now a hint; only declared bounds block. Covered by a test that fails with the old behaviour:

```
--- required-empty blocks save again (the webhooks regression) ---
AssertionError: expected true to be false
```

## A test that passed for the wrong reason

"refuses a group nested inside a group" was refused because the inner group had no `key`/`type`, not
because of the `kind` guard it was credited with. The inner group now also looks like a field, so
only that guard can refuse it — and removing the guard now fails the test.

## Verification

- Backend: `tsc --noEmit` exit 0; full suite **137 suites, 1516 tests**, exit 0.
- Client: **48 files, 408 tests, exit 0** — exit code read, not inferred.
- Both contract copies structurally identical, so the drift gate stays green.
- Live: backend restarted, all three plugins `active`; `GET /api/plugins/ui` still serves the
  webhooks config page with its `endpoint_url` field, so no installed manifest regressed.
