### PR TITLE
feat(plugins): revoke a published plugin, and carry its state across a reinstall

### DIFF
--- a/backend/src/modules/plugins/catalog/catalog.spec.ts
+++ b/backend/src/modules/plugins/catalog/catalog.spec.ts
@@ -1,4 +1,12 @@
-import { parseCatalogDocument, filterCatalog, type CatalogDocument, type CatalogVersionEntry } from './catalog';
+import {
+  parseCatalogDocument,
+  filterCatalog,
+  findDenial,
+  extractCachedDenyList,
+  type CatalogDocument,
+  type CatalogVersionEntry,
+  type CatalogDenyEntry,
+} from './catalog';
 import { PLUGIN_API_VERSION, SUPPORTED_PLUGIN_API_VERSIONS } from '../../../common/plugin-contract';
 
 /** A `fliks` range every test can rely on matching this repo's own `package.json` version
@@ -56,6 +64,74 @@ describe('parseCatalogDocument()', () => {
 
     const badLogo = document({ logo: 42 as unknown as string });
     expect(parseCatalogDocument(Buffer.from(JSON.stringify(badLogo), 'utf8'))).toBeNull();
+  });
+
+  it('keeps a valid deny-list entry and silently drops a malformed sibling, never failing the document', () => {
+    const valid: CatalogDenyEntry = { pluginId: 'fliks.bad-actor', reason: 'known credential leak' };
+    const malformed = { pluginId: 'fliks.other' }; // missing required `reason`
+    const doc = { ...document(), denyList: [valid, malformed] };
+
+    const parsed = parseCatalogDocument(Buffer.from(JSON.stringify(doc), 'utf8'));
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.denyList).toEqual([valid]);
+  });
+
+  it('omits denyList entirely when the document never declared one', () => {
+    const parsed = parseCatalogDocument(Buffer.from(JSON.stringify(document()), 'utf8'));
+    expect(parsed?.denyList).toBeUndefined();
+  });
+});
+
+describe('findDenial()', () => {
+  const entry: CatalogDenyEntry = { pluginId: 'fliks.bad-actor', version: '1.0.0', reason: 'known credential leak' };
+  const pkg = { pluginId: 'fliks.bad-actor', version: '1.0.0', sha256: 'deadbeef', verifiedByKeyId: 'release-2026' };
+
+  it('denies a package whose verifiedByKeyId matches the key that signed the deny-list’s own catalogue', () => {
+    const result = findDenial(pkg, [{ denyList: [entry], signedByKeyId: 'release-2026' }]);
+    expect(result).toEqual({ reason: 'known credential leak' });
+  });
+
+  it('revokes nothing when the deny-list was signed by a different key than the one that signed the package', () => {
+    const result = findDenial(pkg, [{ denyList: [entry], signedByKeyId: 'some-other-source' }]);
+    expect(result).toBeNull();
+  });
+
+  it('narrows an entry carrying a sha256 to that exact build, not every archive of the version', () => {
+    const pinned: CatalogDenyEntry = { ...entry, sha256: 'deadbeef' };
+    expect(findDenial(pkg, [{ denyList: [pinned], signedByKeyId: 'release-2026' }])).toEqual({
+      reason: 'known credential leak',
+    });
+    // Same id and version, a different build: a hash-scoped entry must leave it alone.
+    const rebuilt = { ...pkg, sha256: 'cafebabe' };
+    expect(findDenial(rebuilt, [{ denyList: [pinned], signedByKeyId: 'release-2026' }])).toBeNull();
+  });
+
+  it('never revokes an unsigned/unverified package — nobody vouched for it, so nobody can pull it back', () => {
+    const unsigned = { ...pkg, verifiedByKeyId: null };
+    // The source itself lacks a resolvable key too (an unrefreshed/malformed cache reads this
+    // way) — without the explicit null guard, `null === null` would coincidentally match.
+    const result = findDenial(unsigned, [{ denyList: [entry], signedByKeyId: null }]);
+    expect(result).toBeNull();
+  });
+
+  it('leaves an unlisted version alone when the entry names a specific version', () => {
+    const otherVersion = { ...pkg, version: '2.0.0' };
+    const result = findDenial(otherVersion, [{ denyList: [entry], signedByKeyId: 'release-2026' }]);
+    expect(result).toBeNull();
+  });
+});
+
+describe('extractCachedDenyList()', () => {
+  it('defaults to an empty deny-list and no key for a null or shape-less cache', () => {
+    expect(extractCachedDenyList(null)).toEqual({ denyList: [], signedByKeyId: null });
+    expect(extractCachedDenyList({ plugins: [] })).toEqual({ denyList: [], signedByKeyId: null });
+  });
+
+  it('filters a malformed entry out of an otherwise-valid cached deny-list', () => {
+    const valid: CatalogDenyEntry = { pluginId: 'fliks.bad-actor', reason: 'known credential leak' };
+    const result = extractCachedDenyList({ denyList: [valid, { reason: 'no pluginId' }], signedByKeyId: 'release-2026' });
+    expect(result).toEqual({ denyList: [valid], signedByKeyId: 'release-2026' });
   });
 });
 

--- a/backend/src/modules/plugins/catalog/catalog.ts
+++ b/backend/src/modules/plugins/catalog/catalog.ts
@@ -26,12 +26,36 @@ export interface CatalogPluginEntry {
   versions: CatalogVersionEntry[];
 }
 
+/**
+ * A publisher-issued revocation. Absent `version` denies every version of `pluginId`; absent
+ * `sha256` denies by version alone. See docs/plugins.md for the authority rule this enforces.
+ */
+export interface CatalogDenyEntry {
+  pluginId: string;
+  version?: string;
+  sha256?: string;
+  reason: string;
+}
+
 export interface CatalogDocument {
   plugins: CatalogPluginEntry[];
+  denyList?: CatalogDenyEntry[];
 }
 
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function isDenyEntry(v: unknown): v is CatalogDenyEntry {
+  return (
+    isRecord(v) &&
+    typeof v.pluginId === 'string' &&
+    v.pluginId.length > 0 &&
+    (v.version === undefined || typeof v.version === 'string') &&
+    (v.sha256 === undefined || typeof v.sha256 === 'string') &&
+    typeof v.reason === 'string' &&
+    v.reason.length > 0
+  );
 }
 
 function isVersionEntry(v: unknown): v is CatalogVersionEntry {
@@ -76,7 +100,13 @@ export function parseCatalogDocument(bytes: Buffer): CatalogDocument | null {
   if (!isRecord(json) || !Array.isArray(json.plugins) || !json.plugins.every(isPluginEntry)) {
     return null;
   }
-  return json as unknown as CatalogDocument;
+  const document: CatalogDocument = { plugins: json.plugins as CatalogPluginEntry[] };
+  // A denyList entry is untrusted the same as everything else here; a garbled one is dropped,
+  // never allowed to fail the whole (already signature-verified) document.
+  if (Array.isArray(json.denyList)) {
+    document.denyList = json.denyList.filter(isDenyEntry);
+  }
+  return document;
 }
 
 export interface HiddenVersionsSummary {
@@ -107,6 +137,9 @@ export interface FilteredCatalogEntry {
 
 export interface FilteredCatalog {
   plugins: FilteredCatalogEntry[];
+  /** Carried through unfiltered by compatibility — a denied version is denied regardless of
+   *  whether this core could otherwise install it. Always an array, never absent. */
+  denyList: CatalogDenyEntry[];
 }
 
 function isInstallable(v: CatalogVersionEntry, supportedApiVersions: readonly number[], fliksVersion: string): boolean {
@@ -138,6 +171,7 @@ export function filterCatalog(
   fliksVersion: string,
 ): FilteredCatalog {
   return {
+    denyList: document.denyList ?? [],
     plugins: document.plugins.map((entry) => {
       const installable: CatalogVersionEntry[] = [];
       const hidden: CatalogVersionEntry[] = [];
@@ -158,4 +192,48 @@ export function filterCatalog(
       };
     }),
   };
+}
+
+/** One source's cached deny-list plus the key that verified the catalogue carrying it —
+ *  the pair {@link findDenial} needs to enforce the authority rule below. */
+export interface DenyListSource {
+  denyList: CatalogDenyEntry[];
+  signedByKeyId: string | null;
+}
+
+/**
+ * Pulls `denyList`/`signedByKeyId` back out of a `PluginSource.cachedCatalog` blob — opaque
+ * jsonb, so re-validated defensively rather than trusted as already-shaped `FilteredCatalog`.
+ */
+export function extractCachedDenyList(cachedCatalog: Record<string, unknown> | null): DenyListSource {
+  if (!cachedCatalog) return { denyList: [], signedByKeyId: null };
+  const denyList = Array.isArray(cachedCatalog.denyList) ? cachedCatalog.denyList.filter(isDenyEntry) : [];
+  const signedByKeyId = typeof cachedCatalog.signedByKeyId === 'string' ? cachedCatalog.signedByKeyId : null;
+  return { denyList, signedByKeyId };
+}
+
+export interface DeniedPackage {
+  pluginId: string;
+  version: string;
+  sha256: string;
+  verifiedByKeyId: string | null;
+}
+
+/**
+ * Revocation authority is signing authority: an entry only denies a package whose
+ * `verifiedByKeyId` is the same key that verified the catalogue carrying the entry. A package
+ * nobody vouched for (`verifiedByKeyId: null`) matches no source and so is never denied.
+ */
+export function findDenial(pkg: DeniedPackage, sources: readonly DenyListSource[]): { reason: string } | null {
+  if (!pkg.verifiedByKeyId) return null;
+  for (const source of sources) {
+    if (source.signedByKeyId !== pkg.verifiedByKeyId) continue;
+    for (const entry of source.denyList) {
+      if (entry.pluginId !== pkg.pluginId) continue;
+      if (entry.version !== undefined && entry.version !== pkg.version) continue;
+      if (entry.sha256 !== undefined && entry.sha256 !== pkg.sha256) continue;
+      return { reason: entry.reason };
+    }
+  }
+  return null;
 }

--- a/backend/src/modules/plugins/plugin-backup.controller.spec.ts
+++ b/backend/src/modules/plugins/plugin-backup.controller.spec.ts
@@ -1,0 +1,62 @@
+import { PluginBackupController } from './plugin-backup.controller';
+import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
+import { PoliciesGuard } from '../auth/casl/policies.guard';
+import { CHECK_POLICIES_KEY, type PolicyHandler } from '../auth/casl/check-policies.decorator';
+import { Action } from '../auth/casl/actions.enum';
+import type { AppAbility } from '../auth/casl/casl-ability.factory';
+
+/** An ability that answers false to everything: a route's declared policy must refuse it. */
+function denyAll(): AppAbility {
+  return { can: () => false } as unknown as AppAbility;
+}
+
+function allowOnly(action: Action): AppAbility {
+  return { can: (a: Action) => a === action } as unknown as AppAbility;
+}
+
+function policiesFor(method: 'export' | 'import'): PolicyHandler[] {
+  return (Reflect.getMetadata(CHECK_POLICIES_KEY, PluginBackupController.prototype[method]) ??
+    []) as PolicyHandler[];
+}
+
+describe('PluginBackupController — authorization', () => {
+  it('puts both routes behind the authenticated policies guard', () => {
+    // An export is a credential dump; losing this guard is the one defect worth a test here.
+    const guards = (Reflect.getMetadata('__guards__', PluginBackupController) ?? []) as unknown[];
+    expect(guards).toContain(JwtOrApiKeyGuard);
+    expect(guards).toContain(PoliciesGuard);
+  });
+
+  it.each([
+    ['export' as const, Action.Read],
+    ['import' as const, Action.Manage],
+  ])('declares a %s policy that refuses an ability without it', (method, needed) => {
+    const handlers = policiesFor(method);
+    expect(handlers.length).toBeGreaterThan(0);
+
+    const asCallback = handlers[0] as (ability: AppAbility) => boolean;
+    expect(asCallback(denyAll())).toBe(false);
+    expect(asCallback(allowOnly(needed))).toBe(true);
+  });
+});
+
+describe('PluginBackupController', () => {
+  it('delegates export to the backup service', async () => {
+    const doc = { pluginId: 'acme.tool' };
+    const backup = { exportPlugin: jest.fn(async () => doc) };
+    const controller = new PluginBackupController(backup as never);
+
+    await expect(controller.export('acme.tool')).resolves.toBe(doc);
+    expect(backup.exportPlugin).toHaveBeenCalledWith('acme.tool');
+  });
+
+  it('delegates import to the backup service, forwarding the raw body', async () => {
+    const result = { pluginId: 'acme.tool', tablesRestored: {}, settingsRestored: 0 };
+    const backup = { importPlugin: jest.fn(async () => result) };
+    const controller = new PluginBackupController(backup as never);
+    const body = { formatVersion: 1 };
+
+    await expect(controller.import('acme.tool', body)).resolves.toBe(result);
+    expect(backup.importPlugin).toHaveBeenCalledWith('acme.tool', body);
+  });
+});

--- a/backend/src/modules/plugins/plugin-backup.controller.ts
+++ b/backend/src/modules/plugins/plugin-backup.controller.ts
@@ -1,0 +1,26 @@
+import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
+import { PoliciesGuard } from '../auth/casl/policies.guard';
+import { CheckPolicies } from '../auth/casl/check-policies.decorator';
+import { Action } from '../auth/casl/actions.enum';
+import { PluginBackupService, PluginExportDocument, PluginImportResult } from './plugin-backup.service';
+
+/** An export is a credential-bearing document — whatever the plugin stored, `secret` fields
+ *  included — so both routes sit behind the same admin policy as the rest of `/plugins`. */
+@Controller('plugins')
+@UseGuards(JwtOrApiKeyGuard, PoliciesGuard)
+export class PluginBackupController {
+  constructor(private readonly backup: PluginBackupService) {}
+
+  @Get(':pluginId/export')
+  @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
+  async export(@Param('pluginId') pluginId: string): Promise<PluginExportDocument> {
+    return this.backup.exportPlugin(pluginId);
+  }
+
+  @Post(':pluginId/import')
+  @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
+  async import(@Param('pluginId') pluginId: string, @Body() document: unknown): Promise<PluginImportResult> {
+    return this.backup.importPlugin(pluginId, document);
+  }
+}

--- a/backend/src/modules/plugins/plugin-backup.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-backup.service.spec.ts
@@ -1,0 +1,176 @@
+import { PluginBackupService } from './plugin-backup.service';
+import { PluginInstallException } from './plugin-install.exception';
+import { minimalDataManifest, minimalProcessManifest } from './archive/test-manifests';
+
+function fakePackageRepo(packages: Record<string, unknown>[]) {
+  return {
+    findOne: jest.fn(async ({ where: { pluginId } }: { where: { pluginId: string } }) => packages.find((p) => p.pluginId === pluginId) ?? null),
+    find: jest.fn(async () => packages),
+  };
+}
+
+function fakePluginDb(overrides: Record<string, jest.Mock> = {}) {
+  return {
+    exportSchemaRows: jest.fn(async () => ({})),
+    schemaHasRows: jest.fn(async () => false),
+    restoreSchemaRows: jest.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+function fakeSettings(all: Record<string, string | null> = {}) {
+  return {
+    getAll: jest.fn(async () => all),
+    set: jest.fn(async () => undefined),
+  };
+}
+
+function service(packageRepo: unknown, pluginDb: unknown, settings: unknown) {
+  return new PluginBackupService(packageRepo as never, pluginDb as never, settings as never);
+}
+
+const PROCESS_PKG = {
+  pluginId: 'acme.tool',
+  version: '1.2.0',
+  status: 'active',
+  manifest: minimalProcessManifest({}, { id: 'acme.tool', version: '1.2.0', database: { schema: true, coreRefs: [] } }),
+};
+
+const DATA_PKG = {
+  pluginId: 'acme.notify',
+  version: '1.0.0',
+  status: 'active',
+  manifest: minimalDataManifest({ id: 'acme.notify', version: '1.0.0' }),
+};
+
+describe('PluginBackupService.exportPlugin', () => {
+  it('404s a plugin id nothing is installed under', async () => {
+    const svc = service(fakePackageRepo([]), fakePluginDb(), fakeSettings());
+    await expect(svc.exportPlugin('acme.tool')).rejects.toThrow(PluginInstallException);
+  });
+
+  it('carries the plugin id, its installed version, its own settings and its schema rows', async () => {
+    const pluginDb = fakePluginDb({ exportSchemaRows: jest.fn(async () => ({ notes: [{ id: 1 }] })) });
+    const settings = fakeSettings({ 'plugin.acme.tool.apiKey': 'secret', 'other.setting': 'x' });
+    const svc = service(fakePackageRepo([PROCESS_PKG]), pluginDb, settings);
+
+    const doc = await svc.exportPlugin('acme.tool');
+
+    expect(doc.pluginId).toBe('acme.tool');
+    expect(doc.pluginVersion).toBe('1.2.0');
+    expect(doc.settings).toEqual({ 'plugin.acme.tool.apiKey': 'secret' });
+    expect(doc.tables).toEqual({ notes: [{ id: 1 }] });
+    expect(pluginDb.exportSchemaRows).toHaveBeenCalledWith('acme.tool');
+  });
+
+  it('excludes a more specific installed id\'s settings from a shorter id\'s export', async () => {
+    const settings = fakeSettings({ 'plugin.acme.toolbox.z': 'z', 'plugin.acme.toolbox.sub.z': 'stolen' });
+    const shortPkg = { ...PROCESS_PKG, pluginId: 'acme.toolbox', version: '1.0.0', manifest: minimalDataManifest({ id: 'acme.toolbox' }) };
+    const longPkg = { pluginId: 'acme.toolbox.sub', version: '1.0.0', status: 'active', manifest: minimalDataManifest({ id: 'acme.toolbox.sub' }) };
+    const svc = service(fakePackageRepo([shortPkg, longPkg]), fakePluginDb(), settings);
+
+    const doc = await svc.exportPlugin('acme.toolbox');
+
+    expect(doc.settings).toEqual({ 'plugin.acme.toolbox.z': 'z' });
+  });
+
+  it('never touches the schema for a `data` plugin', async () => {
+    const pluginDb = fakePluginDb();
+    const svc = service(fakePackageRepo([DATA_PKG]), pluginDb, fakeSettings());
+
+    const doc = await svc.exportPlugin('acme.notify');
+
+    expect(doc.tables).toEqual({});
+    expect(pluginDb.exportSchemaRows).not.toHaveBeenCalled();
+  });
+});
+
+describe('PluginBackupService.importPlugin', () => {
+  function exportOf(pkg: typeof PROCESS_PKG, overrides: Record<string, unknown> = {}) {
+    return {
+      formatVersion: 1,
+      pluginId: pkg.pluginId,
+      pluginVersion: pkg.version,
+      exportedAt: new Date().toISOString(),
+      settings: {},
+      tables: {},
+      ...overrides,
+    };
+  }
+
+  it('rejects a malformed document before touching the database', async () => {
+    const pluginDb = fakePluginDb();
+    const svc = service(fakePackageRepo([PROCESS_PKG]), pluginDb, fakeSettings());
+
+    await expect(svc.importPlugin('acme.tool', { not: 'an export' })).rejects.toThrow(PluginInstallException);
+    expect(pluginDb.restoreSchemaRows).not.toHaveBeenCalled();
+  });
+
+  it('rejects a document exported for a different plugin id', async () => {
+    const svc = service(fakePackageRepo([PROCESS_PKG]), fakePluginDb(), fakeSettings());
+    const doc = exportOf(PROCESS_PKG, { pluginId: 'someone.else' });
+
+    await expect(svc.importPlugin('acme.tool', doc)).rejects.toThrow(PluginInstallException);
+  });
+
+  it('refuses a version mismatch instead of restoring a possibly-incompatible schema', async () => {
+    const pluginDb = fakePluginDb();
+    const svc = service(fakePackageRepo([PROCESS_PKG]), pluginDb, fakeSettings());
+    const doc = exportOf(PROCESS_PKG, { pluginVersion: '1.1.0' });
+
+    await expect(svc.importPlugin('acme.tool', doc)).rejects.toMatchObject({ code: 'PLUGIN_EXPORT_VERSION_MISMATCH' });
+    expect(pluginDb.restoreSchemaRows).not.toHaveBeenCalled();
+  });
+
+  it('refuses a plugin whose activation never completed, even at a matching version', async () => {
+    const notReady = { ...PROCESS_PKG, status: 'failed' };
+    const pluginDb = fakePluginDb();
+    const svc = service(fakePackageRepo([notReady]), pluginDb, fakeSettings());
+
+    await expect(svc.importPlugin('acme.tool', exportOf(PROCESS_PKG))).rejects.toMatchObject({ code: 'PLUGIN_NOT_READY' });
+    expect(pluginDb.restoreSchemaRows).not.toHaveBeenCalled();
+  });
+
+  it('refuses to import into a schema that already has rows', async () => {
+    const pluginDb = fakePluginDb({ schemaHasRows: jest.fn(async () => true) });
+    const svc = service(fakePackageRepo([PROCESS_PKG]), pluginDb, fakeSettings());
+
+    await expect(svc.importPlugin('acme.tool', exportOf(PROCESS_PKG))).rejects.toMatchObject({ code: 'PLUGIN_SCHEMA_NOT_EMPTY' });
+    expect(pluginDb.restoreSchemaRows).not.toHaveBeenCalled();
+  });
+
+  it('restores rows and settings on a clean, matching-version target', async () => {
+    const pluginDb = fakePluginDb();
+    const settings = fakeSettings();
+    const svc = service(fakePackageRepo([PROCESS_PKG]), pluginDb, settings);
+    const doc = exportOf(PROCESS_PKG, {
+      settings: { 'plugin.acme.tool.apiKey': 'secret' },
+      tables: { notes: [{ id: 1 }] },
+    });
+
+    const result = await svc.importPlugin('acme.tool', doc);
+
+    expect(pluginDb.restoreSchemaRows).toHaveBeenCalledWith('acme.tool', { notes: [{ id: 1 }] });
+    expect(settings.set).toHaveBeenCalledWith('plugin.acme.tool.apiKey', 'secret', 'plugin-import:acme.tool');
+    expect(result).toEqual({ pluginId: 'acme.tool', tablesRestored: { notes: 1 }, settingsRestored: 1 });
+  });
+
+  it('rejects a setting key outside the target plugin\'s own namespace', async () => {
+    const settings = fakeSettings();
+    const svc = service(fakePackageRepo([PROCESS_PKG]), fakePluginDb(), settings);
+    const doc = exportOf(PROCESS_PKG, { settings: { 'plugin.someone.else.apiKey': 'x' } });
+
+    await expect(svc.importPlugin('acme.tool', doc)).rejects.toMatchObject({ code: 'PLUGIN_EXPORT_SETTING_OUT_OF_SCOPE' });
+    expect(settings.set).not.toHaveBeenCalled();
+  });
+
+  it('never calls restoreSchemaRows for a `data` plugin, which has no schema', async () => {
+    const pluginDb = fakePluginDb();
+    const svc = service(fakePackageRepo([DATA_PKG]), pluginDb, fakeSettings());
+
+    await svc.importPlugin('acme.notify', exportOf(DATA_PKG as never));
+
+    expect(pluginDb.restoreSchemaRows).not.toHaveBeenCalled();
+    expect(pluginDb.schemaHasRows).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/plugins/plugin-backup.service.ts
+++ b/backend/src/modules/plugins/plugin-backup.service.ts
@@ -1,0 +1,172 @@
+import { HttpStatus, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PluginPackage } from './entities/plugin-package.entity';
+import { PluginDatabaseService } from './plugin-database.service';
+import { PluginInstallException } from './plugin-install.exception';
+import { SettingsService } from '../settings/settings.service';
+
+const EXPORT_FORMAT_VERSION = 1;
+
+export interface PluginExportDocument {
+  formatVersion: 1;
+  pluginId: string;
+  pluginVersion: string;
+  exportedAt: string;
+  /** Every `plugin.<id>.*` setting this plugin owns, secrets included — a credential-bearing document. */
+  settings: Record<string, string | null>;
+  tables: Record<string, Record<string, unknown>[]>;
+}
+
+export interface PluginImportResult {
+  pluginId: string;
+  tablesRestored: Record<string, number>;
+  settingsRestored: number;
+}
+
+/** Structural check only — a malformed document throws 400 rather than reaching SQL or the
+ *  settings store with the wrong shape. */
+function assertExportDocumentShape(document: unknown): PluginExportDocument {
+  const bad = (): never => {
+    throw new PluginInstallException(HttpStatus.BAD_REQUEST, 'PLUGIN_EXPORT_MALFORMED', 'not a recognisable plugin export document');
+  };
+  if (typeof document !== 'object' || document === null) bad();
+  const doc = document as Record<string, unknown>;
+  if (doc.formatVersion !== EXPORT_FORMAT_VERSION) bad();
+  if (typeof doc.pluginId !== 'string' || typeof doc.pluginVersion !== 'string') bad();
+  if (typeof doc.settings !== 'object' || doc.settings === null) bad();
+  if (typeof doc.tables !== 'object' || doc.tables === null) bad();
+  for (const value of Object.values(doc.settings as Record<string, unknown>)) {
+    if (value !== null && typeof value !== 'string') bad();
+  }
+  for (const rows of Object.values(doc.tables as Record<string, unknown>)) {
+    if (!Array.isArray(rows)) bad();
+  }
+  return doc as unknown as PluginExportDocument;
+}
+
+/**
+ * Exports and restores one plugin's state: its `plugin.<id>.*` settings and every row of its
+ * own schema. Data only — a plugin's schema DDL comes from its own migrations, never from this
+ * document.
+ */
+@Injectable()
+export class PluginBackupService {
+  constructor(
+    @InjectRepository(PluginPackage) private readonly packageRepo: Repository<PluginPackage>,
+    private readonly pluginDb: PluginDatabaseService,
+    private readonly settings: SettingsService,
+  ) {}
+
+  async exportPlugin(pluginId: string): Promise<PluginExportDocument> {
+    const pkg = await this.findInstalled(pluginId);
+    const tables = pkg.manifest.kind === 'process' && pkg.manifest.database.schema ? await this.pluginDb.exportSchemaRows(pluginId) : {};
+
+    return {
+      formatVersion: EXPORT_FORMAT_VERSION,
+      pluginId,
+      pluginVersion: pkg.version,
+      exportedAt: new Date().toISOString(),
+      settings: await this.collectSettings(pluginId),
+      tables,
+    };
+  }
+
+  /**
+   * Refuses rather than merges. A version mismatch means the schema this document describes may
+   * not be the schema installed today — there is no migration-diff engine here to reconcile the
+   * two — so the operator installs the matching version first. Rows already present in the
+   * schema are refused for the same reason: a partial merge on top of existing data would look
+   * like a complete restore without being one.
+   */
+  async importPlugin(pluginId: string, document: unknown): Promise<PluginImportResult> {
+    const doc = assertExportDocumentShape(document);
+    if (doc.pluginId !== pluginId) {
+      throw new PluginInstallException(HttpStatus.BAD_REQUEST, 'PLUGIN_EXPORT_ID_MISMATCH', `export is for "${doc.pluginId}", not "${pluginId}"`);
+    }
+
+    const pkg = await this.findInstalled(pluginId);
+    if (pkg.status !== 'active') {
+      throw new PluginInstallException(
+        HttpStatus.CONFLICT,
+        'PLUGIN_NOT_READY',
+        `plugin "${pluginId}" has not completed activation — its schema may not be migrated yet`,
+      );
+    }
+    if (doc.pluginVersion !== pkg.version) {
+      throw new PluginInstallException(
+        HttpStatus.CONFLICT,
+        'PLUGIN_EXPORT_VERSION_MISMATCH',
+        `export is from version ${doc.pluginVersion}, installed version is ${pkg.version} — install ${doc.pluginVersion} before importing`,
+      );
+    }
+
+    const hasSchema = pkg.manifest.kind === 'process' && pkg.manifest.database.schema;
+    if (hasSchema && (await this.pluginDb.schemaHasRows(pluginId))) {
+      throw new PluginInstallException(
+        HttpStatus.CONFLICT,
+        'PLUGIN_SCHEMA_NOT_EMPTY',
+        `plugin "${pluginId}" already has rows in its schema — uninstall and reinstall it before importing`,
+      );
+    }
+
+    if (hasSchema) {
+      await this.pluginDb.restoreSchemaRows(pluginId, doc.tables);
+    } else if (Object.keys(doc.tables).length) {
+      throw new PluginInstallException(
+        HttpStatus.CONFLICT,
+        'PLUGIN_EXPORT_HAS_NO_SCHEMA',
+        `export carries table rows but plugin "${pluginId}" declares no schema to restore them into`,
+      );
+    }
+    const settingsRestored = await this.restoreSettings(pluginId, doc.settings);
+
+    return {
+      pluginId,
+      tablesRestored: hasSchema
+        ? Object.fromEntries(Object.entries(doc.tables).map(([table, rows]) => [table, rows.length]))
+        : {},
+      settingsRestored,
+    };
+  }
+
+  private async findInstalled(pluginId: string): Promise<PluginPackage> {
+    const pkg = await this.packageRepo.findOne({ where: { pluginId } });
+    if (!pkg) throw new PluginInstallException(HttpStatus.NOT_FOUND, 'PLUGIN_NOT_FOUND', `plugin "${pluginId}" is not installed`);
+    return pkg;
+  }
+
+  /** Same dotted-prefix collision guard as uninstall's settings wipe: a more specific installed
+   *  id's keys are never swept into a shorter id's export. */
+  private async collectSettings(pluginId: string): Promise<Record<string, string | null>> {
+    const prefix = `plugin.${pluginId}.`;
+    const others = (await this.packageRepo.find()).map((p) => `plugin.${p.pluginId}.`).filter((p) => p !== prefix && p.startsWith(prefix));
+    const all = await this.settings.getAll();
+    const out: Record<string, string | null> = {};
+    for (const [key, value] of Object.entries(all)) {
+      if (!key.startsWith(prefix)) continue;
+      if (others.some((p) => key.startsWith(p))) continue;
+      out[key] = value;
+    }
+    return out;
+  }
+
+  /** Every key must sit under this plugin's own namespace — a document doctored to carry another
+   *  plugin's (or core's) setting key is refused rather than written. */
+  private async restoreSettings(pluginId: string, settings: Record<string, string | null>): Promise<number> {
+    const prefix = `plugin.${pluginId}.`;
+    // Every key is checked before any is written: a refusal half-way would leave the plugin
+    // configured from two different exports.
+    for (const key of Object.keys(settings)) {
+      if (!key.startsWith(prefix)) {
+        throw new PluginInstallException(HttpStatus.BAD_REQUEST, 'PLUGIN_EXPORT_SETTING_OUT_OF_SCOPE', `setting ${JSON.stringify(key)} is outside plugin "${pluginId}"'s namespace`);
+      }
+    }
+    let count = 0;
+    for (const [key, value] of Object.entries(settings)) {
+      await this.settings.set(key, value, `plugin-import:${pluginId}`);
+      count++;
+    }
+    return count;
+  }
+}

--- a/backend/src/modules/plugins/plugin-catalog-client.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-catalog-client.service.spec.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosRequestConfig } from 'axios';
 import { PluginCatalogClientService } from './plugin-catalog-client.service';
 import { PluginSource } from './entities/plugin-source.entity';
+import { PluginPackage } from './entities/plugin-package.entity';
 import { generateTestKeypair, signManifestBase64 } from './archive/ed25519-test-keys';
 import { OFFICIAL_KEYS } from './archive/trust-store';
 import type { CatalogDocument } from './catalog/catalog';
@@ -43,6 +44,15 @@ function repoStub() {
   return { save } as unknown as { save: jest.Mock };
 }
 
+/** No installed packages by default — nothing for `enforceDenyList` to act on. */
+function fakePackageRepo(rows: PluginPackage[] = []) {
+  return { find: jest.fn(async () => rows), save: jest.fn(async (row: PluginPackage) => row) };
+}
+
+function fakeRegistry() {
+  return { revoke: jest.fn(async () => undefined) };
+}
+
 /** Routes a GET by URL suffix — `catalog.json` and `catalog.json.sig` never collide since
  *  `endsWith` is exact. A value that is an `Error` rejects instead of resolving. */
 function adapterFor(responses: Record<string, Buffer | Error>) {
@@ -71,7 +81,7 @@ describe('PluginCatalogClientService', () => {
     axios.defaults.adapter = adapterFor({ 'catalog.json.sig': sig, 'catalog.json': bytes });
 
     const repo = repoStub();
-    const service = new PluginCatalogClientService(repo as never);
+    const service = new PluginCatalogClientService(repo as never, fakePackageRepo() as never, fakeRegistry() as never);
     const source = fakeSource({ publicKey: rawPublicKey });
 
     const result = await service.refreshSource(source);
@@ -80,6 +90,8 @@ describe('PluginCatalogClientService', () => {
     expect(source.lastRefreshError).toBeNull();
     expect(source.lastRefreshedAt).toBeInstanceOf(Date);
     expect(source.cachedCatalog).toEqual({
+      denyList: [],
+      signedByKeyId: 'source',
       plugins: [
         expect.objectContaining({
           id: 'fliks.test-plugin',
@@ -99,7 +111,7 @@ describe('PluginCatalogClientService', () => {
     axios.defaults.adapter = adapterFor({ 'catalog.json.sig': tamperedSig, 'catalog.json': bytes });
 
     const repo = repoStub();
-    const service = new PluginCatalogClientService(repo as never);
+    const service = new PluginCatalogClientService(repo as never, fakePackageRepo() as never, fakeRegistry() as never);
     const previousCatalog = { plugins: [{ id: 'old' }] };
     const source = fakeSource({
       publicKey: rawPublicKey,
@@ -123,7 +135,7 @@ describe('PluginCatalogClientService', () => {
     axios.defaults.adapter = adapterFor({ 'catalog.json.sig': sig, 'catalog.json': bytes });
 
     const repo = repoStub();
-    const service = new PluginCatalogClientService(repo as never);
+    const service = new PluginCatalogClientService(repo as never, fakePackageRepo() as never, fakeRegistry() as never);
     const source = fakeSource({ publicKey: sourceKeypair.rawPublicKey });
 
     const result = await service.refreshSource(source);
@@ -142,7 +154,7 @@ describe('PluginCatalogClientService', () => {
     mutableOfficialKeys.set('test-official', rawPublicKey);
     try {
       const repo = repoStub();
-      const service = new PluginCatalogClientService(repo as never);
+      const service = new PluginCatalogClientService(repo as never, fakePackageRepo() as never, fakeRegistry() as never);
       const source = fakeSource({ publicKey: null });
 
       const result = await service.refreshSource(source);
@@ -161,7 +173,7 @@ describe('PluginCatalogClientService', () => {
     axios.defaults.adapter = adapterFor({ 'catalog.json.sig': sig, 'catalog.json': bytes });
 
     const repo = repoStub();
-    const service = new PluginCatalogClientService(repo as never);
+    const service = new PluginCatalogClientService(repo as never, fakePackageRepo() as never, fakeRegistry() as never);
     const source = fakeSource({ publicKey: rawPublicKey });
 
     await service.refreshSource(source);
@@ -171,6 +183,65 @@ describe('PluginCatalogClientService', () => {
     expect(catalog.plugins[0].hidden).toEqual({ count: 1, minFliksVersion: '5.0.0' });
   });
 
+  it('stops and marks failed an installed package a landed revocation denies, immediately — not on next reboot', async () => {
+    const { privateKey, rawPublicKey } = generateTestKeypair();
+    const doc = { ...catalogWith(), denyList: [{ pluginId: 'fliks.test-plugin', reason: 'known credential leak' }] };
+    const bytes = Buffer.from(JSON.stringify(doc), 'utf8');
+    const sig = Buffer.from(signManifestBase64(privateKey, bytes), 'utf8');
+    axios.defaults.adapter = adapterFor({ 'catalog.json.sig': sig, 'catalog.json': bytes });
+
+    // `publicKey` pins this source's verification key to id 'source' — the same id the
+    // installed package's `verifiedByKeyId` must carry for the revocation to reach it.
+    const pkg = {
+      pluginId: 'fliks.test-plugin',
+      version: '1.0.0',
+      archive: Buffer.from('fake archive bytes'),
+      verifiedByKeyId: 'source',
+      status: 'active',
+      statusReason: null,
+    } as PluginPackage;
+    const packageRepo = fakePackageRepo([pkg]);
+    const registry = fakeRegistry();
+    const repo = repoStub();
+    const service = new PluginCatalogClientService(repo as never, packageRepo as never, registry as never);
+    const source = fakeSource({ publicKey: rawPublicKey });
+
+    const result = await service.refreshSource(source);
+
+    expect(result).toEqual({ ok: true });
+    expect(registry.revoke).toHaveBeenCalledWith('fliks.test-plugin', 'known credential leak');
+    expect(pkg.status).toBe('failed');
+    expect(pkg.statusReason).toBe('revoked: known credential leak');
+  });
+
+  it('leaves an installed package alone when the deny-list was signed by a different key', async () => {
+    const { privateKey, rawPublicKey } = generateTestKeypair();
+    const doc = { ...catalogWith(), denyList: [{ pluginId: 'fliks.test-plugin', reason: 'known credential leak' }] };
+    const bytes = Buffer.from(JSON.stringify(doc), 'utf8');
+    const sig = Buffer.from(signManifestBase64(privateKey, bytes), 'utf8');
+    axios.defaults.adapter = adapterFor({ 'catalog.json.sig': sig, 'catalog.json': bytes });
+
+    // This package was verified by the compiled-in official key, not this source's pinned key.
+    const pkg = {
+      pluginId: 'fliks.test-plugin',
+      version: '1.0.0',
+      archive: Buffer.from('fake archive bytes'),
+      verifiedByKeyId: 'release-2026',
+      status: 'active',
+      statusReason: null,
+    } as PluginPackage;
+    const packageRepo = fakePackageRepo([pkg]);
+    const registry = fakeRegistry();
+    const repo = repoStub();
+    const service = new PluginCatalogClientService(repo as never, packageRepo as never, registry as never);
+    const source = fakeSource({ publicKey: rawPublicKey });
+
+    await service.refreshSource(source);
+
+    expect(registry.revoke).not.toHaveBeenCalled();
+    expect(pkg.status).toBe('active');
+  });
+
   it('keeps the previous cachedCatalog and records the error on a network failure', async () => {
     axios.defaults.adapter = adapterFor({
       'catalog.json.sig': new Error('ECONNRESET'),
@@ -178,7 +249,7 @@ describe('PluginCatalogClientService', () => {
     });
 
     const repo = repoStub();
-    const service = new PluginCatalogClientService(repo as never);
+    const service = new PluginCatalogClientService(repo as never, fakePackageRepo() as never, fakeRegistry() as never);
     const previousCatalog = { plugins: [{ id: 'old' }] };
     const previousRefreshedAt = new Date('2026-01-01T00:00:00Z');
     const source = fakeSource({
@@ -202,7 +273,7 @@ describe('PluginCatalogClientService', () => {
     axios.defaults.adapter = adapterFor({ 'catalog.json.sig': sig, 'catalog.json': bytes });
 
     const repo = repoStub();
-    const service = new PluginCatalogClientService(repo as never);
+    const service = new PluginCatalogClientService(repo as never, fakePackageRepo() as never, fakeRegistry() as never);
     const source = fakeSource({ publicKey: rawPublicKey });
 
     await expect(service.refreshSource(source)).resolves.toEqual({
@@ -220,7 +291,7 @@ describe('PluginCatalogClientService', () => {
     };
 
     const repo = repoStub();
-    const service = new PluginCatalogClientService(repo as never);
+    const service = new PluginCatalogClientService(repo as never, fakePackageRepo() as never, fakeRegistry() as never);
     const source = fakeSource({ url: 'http://insecure.example.com/catalog.json' });
 
     const result = await service.refreshSource(source);
@@ -233,7 +304,7 @@ describe('PluginCatalogClientService', () => {
     it('refreshes every enabled source and never queries a disabled one', async () => {
       const enabledSource = fakeSource({ id: 1, enabled: true });
       const find = jest.fn().mockResolvedValue([enabledSource]);
-      const service = new PluginCatalogClientService({ find } as never);
+      const service = new PluginCatalogClientService({ find } as never, fakePackageRepo() as never, fakeRegistry() as never);
       jest.spyOn(service, 'refreshSource').mockResolvedValue({ ok: true });
 
       await service.refreshAll();

--- a/backend/src/modules/plugins/plugin-catalog-client.service.ts
+++ b/backend/src/modules/plugins/plugin-catalog-client.service.ts
@@ -3,11 +3,13 @@ import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import axios from 'axios';
+import { createHash } from 'crypto';
 import { PluginSource } from './entities/plugin-source.entity';
+import { PluginPackage } from './entities/plugin-package.entity';
 import { OFFICIAL_KEYS, resolveTrust, MAX_SIGNATURE_BYTES } from './archive';
 import { SUPPORTED_PLUGIN_API_VERSIONS } from '../../common/plugin-contract';
-import { CURRENT_FLIKS_VERSION } from './plugin-registry.service';
-import { parseCatalogDocument, filterCatalog, type FilteredCatalog } from './catalog/catalog';
+import { CURRENT_FLIKS_VERSION, PluginRegistryService } from './plugin-registry.service';
+import { parseCatalogDocument, filterCatalog, findDenial, type FilteredCatalog } from './catalog/catalog';
 
 const CATALOG_REQUEST_TIMEOUT_MS = 10_000;
 /** A catalog is a small JSON index of plugin metadata, nowhere near the 8 MiB
@@ -33,6 +35,9 @@ export class PluginCatalogClientService {
   constructor(
     @InjectRepository(PluginSource)
     private readonly sourceRepo: Repository<PluginSource>,
+    @InjectRepository(PluginPackage)
+    private readonly packageRepo: Repository<PluginPackage>,
+    private readonly registry: PluginRegistryService,
   ) {}
 
   @Cron(CronExpression.EVERY_DAY_AT_4AM)
@@ -89,11 +94,44 @@ export class PluginCatalogClientService {
     }
 
     const filtered: FilteredCatalog = filterCatalog(document, SUPPORTED_PLUGIN_API_VERSIONS, CURRENT_FLIKS_VERSION);
-    source.cachedCatalog = filtered as unknown as Record<string, unknown>;
+    const signedByKeyId = trust.signedByKeyId ?? null;
+    source.cachedCatalog = { ...filtered, signedByKeyId } as unknown as Record<string, unknown>;
     source.lastRefreshedAt = new Date();
     source.lastRefreshError = null;
     await this.sourceRepo.save(source);
+    if (source.enabled) await this.enforceDenyList(filtered.denyList, signedByKeyId);
     return { ok: true };
+  }
+
+  /**
+   * A revocation that just landed must not wait for a reboot: every installed package this
+   * catalogue's key vouched for is re-checked immediately, and a match is stopped and marked
+   * `failed` right away rather than merely blocked at the next install.
+   */
+  private async enforceDenyList(
+    denyList: FilteredCatalog['denyList'],
+    signedByKeyId: string | null,
+  ): Promise<void> {
+    if (denyList.length === 0 || !signedByKeyId) return;
+    const source = [{ denyList, signedByKeyId }];
+    for (const pkg of await this.packageRepo.find()) {
+      const sha256 = createHash('sha256').update(pkg.archive).digest('hex');
+      const denial = findDenial(
+        { pluginId: pkg.pluginId, version: pkg.version, sha256, verifiedByKeyId: pkg.verifiedByKeyId },
+        source,
+      );
+      if (!denial) continue;
+      this.logger.warn(`plugin "${pkg.pluginId}" revoked by catalog: ${denial.reason}`);
+      try {
+        await this.registry.revoke(pkg.pluginId, denial.reason);
+        pkg.status = 'failed';
+        pkg.statusReason = `revoked: ${denial.reason}`;
+        await this.packageRepo.save(pkg);
+      } catch (err) {
+        // One package must not abort the refresh, nor the rest of the nightly loop.
+        this.logger.warn(`could not revoke "${pkg.pluginId}": ${(err as Error).message}`);
+      }
+    }
   }
 
   private async fail(

--- a/backend/src/modules/plugins/plugin-database.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-database.service.spec.ts
@@ -409,3 +409,206 @@ describe('PluginDatabaseService.findUnsafeCoreRefFks', () => {
     await expect(service(fakeDataSource(makeRecorder())).findUnsafeCoreRefFks('acme.tool')).resolves.toEqual([]);
   });
 });
+
+/** Export/import's own fixtures: table listing, per-table rows, per-table column lists — kept
+ *  separate from `respondFor` above since these methods query shapes provision/rotate never do. */
+function extractSchemaAndTable(sql: string): { schema: string; table: string } {
+  const match = normalizeSql(sql).match(/"([^"]+)"\."([^"]+)"/);
+  return { schema: match?.[1] ?? '', table: match?.[2] ?? '' };
+}
+
+interface ExportFixtures {
+  schemaTables?: string[];
+  tableRows?: Record<string, Record<string, unknown>[]>;
+  tableHasRows?: Record<string, boolean>;
+  tableColumns?: Record<string, string[]>;
+  failInsert?: boolean;
+}
+
+function fakeExportDataSource(fixtures: ExportFixtures = {}) {
+  const queries: { sql: string; parameters: unknown[] }[] = [];
+  const events: string[] = [];
+
+  function topLevelRespond(sql: string, parameters: unknown[]): unknown[] {
+    const norm = normalizeSql(sql);
+    if (norm.includes('FROM information_schema.tables')) {
+      return (fixtures.schemaTables ?? []).map((t) => ({ table_name: t }));
+    }
+    if (norm.startsWith('SELECT 1 FROM')) {
+      const { table } = extractSchemaAndTable(sql);
+      return fixtures.tableHasRows?.[table] ? [{ x: 1 }] : [];
+    }
+    if (norm.startsWith('SELECT * FROM')) {
+      const { table } = extractSchemaAndTable(sql);
+      return fixtures.tableRows?.[table] ?? [];
+    }
+    return [];
+  }
+
+  const runner = {
+    isTransactionActive: false,
+    connect: jest.fn(async () => {
+      events.push('connect');
+    }),
+    startTransaction: jest.fn(async () => {
+      events.push('startTransaction');
+      runner.isTransactionActive = true;
+    }),
+    commitTransaction: jest.fn(async () => {
+      events.push('commitTransaction');
+      runner.isTransactionActive = false;
+    }),
+    rollbackTransaction: jest.fn(async () => {
+      events.push('rollbackTransaction');
+      runner.isTransactionActive = false;
+    }),
+    release: jest.fn(async () => {
+      events.push('release');
+    }),
+    query: jest.fn(async (sql: string, parameters: unknown[] = []) => {
+      events.push('query');
+      queries.push({ sql, parameters });
+      const norm = normalizeSql(sql);
+      if (norm.includes('FROM information_schema.columns')) {
+        const table = parameters[1] as string;
+        return (fixtures.tableColumns?.[table] ?? []).map((c) => ({ column_name: c }));
+      }
+      if (norm.startsWith('INSERT INTO')) {
+        if (fixtures.failInsert) throw new Error('insert failed at the server');
+        return [];
+      }
+      return [];
+    }),
+  };
+
+  const dataSource = {
+    createQueryRunner: jest.fn(() => runner),
+    query: jest.fn(async (sql: string, parameters: unknown[] = []) => {
+      events.push('query');
+      queries.push({ sql, parameters });
+      return topLevelRespond(sql, parameters);
+    }),
+  };
+
+  return { dataSource, queries, events, runner };
+}
+
+describe('PluginDatabaseService.listSchemaTables / schemaHasRows / exportSchemaRows', () => {
+  it('scopes the table listing to this plugin schema alone, bound as a parameter — never a literal `public`', async () => {
+    const { dataSource, queries } = fakeExportDataSource({ schemaTables: ['notes'] });
+
+    await expect(service(dataSource as never).listSchemaTables('acme.tool')).resolves.toEqual(['notes']);
+
+    expect(queries).toHaveLength(1);
+    expect(normalizeSql(queries[0].sql)).toContain("table_schema = $1 AND table_type = 'BASE TABLE'");
+    expect(queries[0].parameters).toEqual(['plugin_acme_tool']);
+  });
+
+  it('a plugin id crafted to read `public` still resolves to a `plugin_`-prefixed schema, never `public` itself', async () => {
+    const { dataSource, queries } = fakeExportDataSource({ schemaTables: [] });
+
+    await service(dataSource as never).listSchemaTables('public');
+
+    expect(queries[0].parameters).toEqual(['plugin_public']);
+    expect(queries[0].parameters).not.toContain('public');
+  });
+
+  it('rejects an id provision could never have accepted before any query is issued', async () => {
+    const { dataSource, queries } = fakeExportDataSource();
+
+    await expect(service(dataSource as never).listSchemaTables('acme"; DROP SCHEMA public CASCADE; --')).rejects.toThrow();
+    await expect(service(dataSource as never).exportSchemaRows('acme"; DROP SCHEMA public CASCADE; --')).rejects.toThrow();
+    expect(queries).toHaveLength(0);
+  });
+
+  it('exports every row of every table, addressed as "schema"."table" for this plugin only', async () => {
+    const { dataSource, queries } = fakeExportDataSource({
+      schemaTables: ['notes', 'tags'],
+      tableRows: { notes: [{ id: 1, text: 'hi' }], tags: [] },
+    });
+
+    await expect(service(dataSource as never).exportSchemaRows('acme.tool')).resolves.toEqual({
+      notes: [{ id: 1, text: 'hi' }],
+      tags: [],
+    });
+
+    const selects = queries.filter((q) => normalizeSql(q.sql).startsWith('SELECT * FROM'));
+    expect(selects).toHaveLength(2);
+    for (const q of selects) {
+      expect(normalizeSql(q.sql)).toContain('"plugin_acme_tool".');
+      expect(normalizeSql(q.sql)).not.toMatch(/"public"/);
+    }
+  });
+
+  it('schemaHasRows is true once any table has a row, false when every table is empty', async () => {
+    const empty = fakeExportDataSource({ schemaTables: ['notes'], tableHasRows: {} });
+    await expect(service(empty.dataSource as never).schemaHasRows('acme.tool')).resolves.toBe(false);
+
+    const populated = fakeExportDataSource({ schemaTables: ['notes'], tableHasRows: { notes: true } });
+    await expect(service(populated.dataSource as never).schemaHasRows('acme.tool')).resolves.toBe(true);
+  });
+});
+
+describe('PluginDatabaseService.restoreSchemaRows', () => {
+  it('round-trips exported rows back through parameterised INSERTs, inside a committed transaction', async () => {
+    const { dataSource, queries, events } = fakeExportDataSource({
+      schemaTables: ['notes'],
+      tableColumns: { notes: ['id', 'text'] },
+    });
+
+    await service(dataSource as never).restoreSchemaRows('acme.tool', { notes: [{ id: 1, text: 'hi' }] });
+
+    const insert = queries.find((q) => normalizeSql(q.sql).startsWith('INSERT INTO'));
+    expect(insert).toBeDefined();
+    expect(normalizeSql(insert!.sql)).toBe('INSERT INTO "plugin_acme_tool"."notes" ("id", "text") VALUES ($1, $2)');
+    expect(insert!.parameters).toEqual([1, 'hi']);
+    expect(events).toContain('commitTransaction');
+    expect(events).not.toContain('rollbackTransaction');
+  });
+
+  it('rejects and rolls back a table name that is not in this plugin schema\'s own catalogue', async () => {
+    // `tableColumns` deliberately matches the row, so only the table-membership check (not the
+    // column check) can be what rejects this — proving that check independently.
+    const { dataSource, events, queries } = fakeExportDataSource({
+      schemaTables: ['notes'],
+      tableColumns: { other_plugins_table: ['id'] },
+    });
+
+    await expect(
+      service(dataSource as never).restoreSchemaRows('acme.tool', { other_plugins_table: [{ id: 1 }] }),
+    ).rejects.toThrow(PluginInstallException);
+
+    expect(events).toContain('rollbackTransaction');
+    expect(events).not.toContain('commitTransaction');
+    expect(queries.some((q) => normalizeSql(q.sql).startsWith('INSERT INTO'))).toBe(false);
+  });
+
+  it('rejects and rolls back a row carrying a column this table does not have', async () => {
+    const { dataSource, events } = fakeExportDataSource({
+      schemaTables: ['notes'],
+      tableColumns: { notes: ['id'] },
+    });
+
+    await expect(
+      service(dataSource as never).restoreSchemaRows('acme.tool', { notes: [{ id: 1, injected: 'x' }] }),
+    ).rejects.toThrow(PluginInstallException);
+
+    expect(events).toContain('rollbackTransaction');
+    expect(events).not.toContain('commitTransaction');
+  });
+
+  it('rolls back the whole transaction when a later row fails to insert, rather than leaving a partial restore', async () => {
+    const { dataSource, events } = fakeExportDataSource({
+      schemaTables: ['notes'],
+      tableColumns: { notes: ['id'] },
+      failInsert: true,
+    });
+
+    await expect(service(dataSource as never).restoreSchemaRows('acme.tool', { notes: [{ id: 1 }] })).rejects.toThrow(
+      PluginInstallException,
+    );
+
+    expect(events).toContain('rollbackTransaction');
+    expect(events).not.toContain('commitTransaction');
+  });
+});

--- a/backend/src/modules/plugins/plugin-database.service.ts
+++ b/backend/src/modules/plugins/plugin-database.service.ts
@@ -34,6 +34,10 @@ function validateCoreRefNames(coreRefs: readonly string[]): string[] {
   return [...coreRefs];
 }
 
+function quoteIdent(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
 function randomHexPassword(): string {
   const password = randomBytes(24).toString('hex');
   if (!HEX_PASSWORD_PATTERN.test(password)) {
@@ -204,6 +208,121 @@ export class PluginDatabaseService {
       await queryRunner.query(`DROP SCHEMA IF EXISTS "${identifier}" CASCADE`);
       await queryRunner.query(`DROP ROLE IF EXISTS "${identifier}"`);
     } catch (err) {
+      throw asProvisionFailure(err);
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  /** A leading underscore marks a table as the plugin's own bookkeeping — its migration ledger
+   *  above all, which records the schema version and must never be exported or written back. */
+  private static isBookkeeping(table: string): boolean {
+    return table.startsWith('_');
+  }
+
+  /** Base tables in this plugin's own schema, read from the catalogue — the only source export/import may take a table name from. */
+  async listSchemaTables(pluginId: string): Promise<string[]> {
+    const identifier = pluginDbIdentifier(pluginId);
+    const rows = await this.dataSource.query(
+      `SELECT table_name FROM information_schema.tables WHERE table_schema = $1 AND table_type = 'BASE TABLE' ORDER BY table_name`,
+      [identifier],
+    );
+    return (rows as { table_name: string }[])
+      .map((row) => row.table_name)
+      .filter((table) => !PluginDatabaseService.isBookkeeping(table));
+  }
+
+  /** True once any base table in this plugin's schema holds at least one row. */
+  async schemaHasRows(pluginId: string): Promise<boolean> {
+    const identifier = pluginDbIdentifier(pluginId);
+    for (const table of await this.listSchemaTables(pluginId)) {
+      const rows = await this.dataSource.query(`SELECT 1 FROM ${quoteIdent(identifier)}.${quoteIdent(table)} LIMIT 1`);
+      if (rows.length > 0) return true;
+    }
+    return false;
+  }
+
+  /** Every row of every base table in this plugin's own schema, keyed by table name. */
+  async exportSchemaRows(pluginId: string): Promise<Record<string, Record<string, unknown>[]>> {
+    const identifier = pluginDbIdentifier(pluginId);
+    const out: Record<string, Record<string, unknown>[]> = {};
+    for (const table of await this.listSchemaTables(pluginId)) {
+      out[table] = await this.dataSource.query(`SELECT * FROM ${quoteIdent(identifier)}.${quoteIdent(table)}`);
+    }
+    return out;
+  }
+
+  /**
+   * Restores previously exported rows into this plugin's own schema, one transaction for every
+   * table. Table and column names are re-checked against the live catalogue on every call, never
+   * trusted from `tables` — an unknown table or column throws instead of reaching SQL.
+   *
+   * ponytail: inserts each table in the document's own key order; a schema whose tables reference
+   * each other needs that order to already be dependency-safe. Upgrade to a topological sort over
+   * the schema's own FKs if a plugin ever needs one.
+   */
+  async restoreSchemaRows(pluginId: string, tables: Record<string, Record<string, unknown>[]>): Promise<void> {
+    const identifier = pluginDbIdentifier(pluginId);
+    const knownTables = new Set(await this.listSchemaTables(pluginId));
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+    try {
+      for (const [table, rows] of Object.entries(tables)) {
+        if (!knownTables.has(table)) {
+          throw new Error(`table ${JSON.stringify(table)} does not belong to plugin "${pluginId}"'s schema`);
+        }
+        if (!Array.isArray(rows) || rows.length === 0) continue;
+
+        const columnRows = await queryRunner.query(
+          `SELECT column_name FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2`,
+          [identifier, table],
+        );
+        const knownColumns = new Set((columnRows as { column_name: string }[]).map((row) => row.column_name));
+
+        for (const row of rows) {
+          if (typeof row !== 'object' || row === null) {
+            throw new Error(`a row in table ${JSON.stringify(table)} is not an object`);
+          }
+          const columns = Object.keys(row);
+          for (const column of columns) {
+            if (!knownColumns.has(column)) {
+              throw new Error(`column ${JSON.stringify(column)} does not belong to table ${JSON.stringify(table)}`);
+            }
+          }
+          if (columns.length === 0) continue;
+          const columnList = columns.map(quoteIdent).join(', ');
+          const placeholders = columns.map((_, i) => `$${i + 1}`).join(', ');
+          await queryRunner.query(
+            `INSERT INTO ${quoteIdent(identifier)}.${quoteIdent(table)} (${columnList}) VALUES (${placeholders})`,
+            columns.map((column) => (row as Record<string, unknown>)[column]),
+          );
+        }
+      }
+      // Restored rows carry their original ids, so every serial is left behind them and the
+      // plugin's first insert would collide.
+      for (const table of Object.keys(tables)) {
+        if (!knownTables.has(table)) continue;
+        const serials = await queryRunner.query(
+          `SELECT column_name FROM information_schema.columns
+             WHERE table_schema = $1 AND table_name = $2
+               AND pg_get_serial_sequence($1 || '.' || $2, column_name) IS NOT NULL`,
+          [identifier, table],
+        );
+        for (const { column_name } of serials as { column_name: string }[]) {
+          await queryRunner.query(
+            `SELECT setval(
+               pg_get_serial_sequence($1 || '.' || $2, $3),
+               (SELECT COALESCE(MAX(${quoteIdent(column_name)}), 0) + 1 FROM ${quoteIdent(identifier)}.${quoteIdent(table)}),
+               false)`,
+            [identifier, table, column_name],
+          );
+        }
+      }
+      await queryRunner.commitTransaction();
+    } catch (err) {
+      if (queryRunner.isTransactionActive) await queryRunner.rollbackTransaction();
       throw asProvisionFailure(err);
     } finally {
       await queryRunner.release();

--- a/backend/src/modules/plugins/plugin-install.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-install.service.spec.ts
@@ -14,6 +14,7 @@ import { PluginPackage } from './entities/plugin-package.entity';
 import { PluginSource } from './entities/plugin-source.entity';
 import { buildZip, ZipEntrySpec } from './archive/zip-builder';
 import { generateTestKeypair, signManifestBase64 } from './archive/ed25519-test-keys';
+import { OFFICIAL_KEYS } from './archive/trust-store';
 import { minimalDataManifest, minimalProcessManifest } from './archive/test-manifests';
 import { pngLogo, sha256Hex, svgLogo } from './archive/test-fixtures';
 import { getPluginsRuntimeDir } from '../../common/constants/paths';
@@ -27,6 +28,23 @@ function signedDataArchive(overrides: Partial<DataPluginManifest> = {}): { buffe
   const manifest = minimalDataManifest({ fliks: COMPATIBLE_RANGE, ...overrides });
   const manifestBytes = Buffer.from(JSON.stringify(manifest), 'utf8');
   const { privateKey } = generateTestKeypair();
+  const sig = signManifestBase64(privateKey, manifestBytes);
+  const buffer = buildZip([
+    { name: 'plugin.json', content: manifestBytes },
+    { name: 'plugin.json.sig', content: Buffer.from(sig, 'utf8') },
+    { name: 'logo.svg', content: svgLogo() },
+  ]);
+  return { buffer, manifest };
+}
+
+/** Same shape as `signedDataArchive`, but signed with a caller-supplied key so the test can
+ *  register it as an official one and get a `signedByKeyId` the deny-list can match. */
+function signedDataArchiveWithKey(
+  privateKey: ReturnType<typeof generateTestKeypair>['privateKey'],
+  overrides: Partial<DataPluginManifest> = {},
+): { buffer: Buffer; manifest: DataPluginManifest } {
+  const manifest = minimalDataManifest({ fliks: COMPATIBLE_RANGE, ...overrides });
+  const manifestBytes = Buffer.from(JSON.stringify(manifest), 'utf8');
   const sig = signManifestBase64(privateKey, manifestBytes);
   const buffer = buildZip([
     { name: 'plugin.json', content: manifestBytes },
@@ -125,6 +143,11 @@ function fakeSource(cachedCatalog: Record<string, unknown> | null): PluginSource
   } as PluginSource;
 }
 
+/** Empty unless a test seeds `rows` with a source whose cached catalog carries a deny-list. */
+function fakeSourceRepo(rows: PluginSource[] = []) {
+  return { find: jest.fn(async () => rows.filter((s) => s.enabled)) };
+}
+
 /** Routes a GET by URL suffix, mirroring `plugin-catalog-client.service.spec.ts`'s adapter. */
 function adapterFor(responses: Record<string, Buffer | Error>) {
   return (config: AxiosRequestConfig) => {
@@ -157,6 +180,7 @@ describe('PluginInstallService', () => {
   let staging: PluginStagingService;
   let pluginDb: ReturnType<typeof fakePluginDb>;
   let settings: ReturnType<typeof fakeSettingsService>;
+  let sourceRepo: ReturnType<typeof fakeSourceRepo>;
   let service: PluginInstallService;
   const originalAdapter = axios.defaults.adapter;
 
@@ -172,8 +196,10 @@ describe('PluginInstallService', () => {
     // deletes it, so two separate fakes would make either assertion vacuous.
     registrationRepo = fakeRegistrationRepo();
     processService = fakeProcessService();
+    sourceRepo = fakeSourceRepo();
     registry = new PluginRegistryService(
       repo as never,
+      sourceRepo as never,
       registrationRepo as never,
       processService as never,
       fakePluginJobsService() as never,
@@ -186,6 +212,7 @@ describe('PluginInstallService', () => {
     service = new PluginInstallService(
       repo as never,
       registrationRepo as never,
+      sourceRepo as never,
       registry,
       staging,
       pluginDb as unknown as PluginDatabaseService,
@@ -286,6 +313,31 @@ describe('PluginInstallService', () => {
         422,
         'PLUGIN_CONTROL_CHAR',
       );
+    });
+
+    it('refuses to install a version an enabled source’s deny-list revokes, and the publisher’s reason reaches the caller', async () => {
+      const { privateKey, rawPublicKey } = generateTestKeypair();
+      (OFFICIAL_KEYS as Map<string, Buffer>).set('release-2026', rawPublicKey);
+      try {
+        const { buffer, manifest } = signedDataArchiveWithKey(privateKey, { id: 'fliks.denied' });
+        sourceRepo.find.mockResolvedValue([
+          fakeSource({ denyList: [{ pluginId: manifest.id, reason: 'known credential leak' }], signedByKeyId: 'release-2026' }),
+        ]);
+        const { stagingId, sha256 } = await service.inspectUpload(buffer);
+
+        const err = await service.confirmImport({ stagingId: stagingId!, sha256: sha256! }).catch((e: unknown) => e);
+
+        expect(err).toBeInstanceOf(PluginInstallException);
+        expect((err as PluginInstallException).getStatus()).toBe(403);
+        expect((err as PluginInstallException).code).toBe('PLUGIN_DENIED');
+        expect((err as PluginInstallException).getResponse()).toEqual({
+          code: 'PLUGIN_DENIED',
+          message: 'known credential leak',
+        });
+        expect(repo.rows.get(manifest.id)).toBeUndefined();
+      } finally {
+        (OFFICIAL_KEYS as Map<string, Buffer>).clear();
+      }
     });
 
     it('promotes on success: a plugin_packages row exists and the registry has the plugin', async () => {

--- a/backend/src/modules/plugins/plugin-install.service.ts
+++ b/backend/src/modules/plugins/plugin-install.service.ts
@@ -28,7 +28,7 @@ import {
 } from './archive';
 import { validateManifestShape } from './manifest-shape.validator';
 import type { TrustOutcome } from './archive/trust-store';
-import type { CatalogVersionEntry, FilteredCatalog, FilteredCatalogEntry } from './catalog/catalog';
+import { extractCachedDenyList, findDenial, type CatalogVersionEntry, type FilteredCatalog, type FilteredCatalogEntry } from './catalog/catalog';
 import { SUPPORTED_PLUGIN_API_VERSIONS, fliksRangeVersion, type PluginKind, type PluginManifest } from '../../common/plugin-contract';
 import type { ConfirmImportDto } from './dto/confirm-import.dto';
 import type { SupervisorState } from './supervisor/plugin-supervisor';
@@ -130,6 +130,8 @@ export class PluginInstallService {
     private readonly packageRepo: Repository<PluginPackage>,
     @InjectRepository(PluginRegistration)
     private readonly registrationRepo: Repository<PluginRegistration>,
+    @InjectRepository(PluginSource)
+    private readonly sourceRepo: Repository<PluginSource>,
     private readonly registry: PluginRegistryService,
     private readonly staging: PluginStagingService,
     private readonly pluginDb: PluginDatabaseService,
@@ -362,6 +364,11 @@ export class PluginInstallService {
   private async promote(buffer: Buffer, result: InspectSuccess, origin: PluginPackageOrigin): Promise<PluginInstallResult> {
     const { manifest } = result;
 
+    const denial = await this.checkDenial(manifest.id, manifest.version, result.sha256, result.signedByKeyId ?? null);
+    if (denial) {
+      throw new PluginInstallException(HttpStatus.FORBIDDEN, 'PLUGIN_DENIED', denial.reason);
+    }
+
     const existing = await this.packageRepo.findOne({ where: { pluginId: manifest.id } });
     // Going back is a legitimate operator choice and the only rollback there is, so it is recorded
     // rather than refused — the catalogue list is ordered, so it cannot be reached by accident.
@@ -465,6 +472,21 @@ export class PluginInstallService {
       if (entry === keepName || !entry.startsWith(prefix)) continue;
       rmSync(join(root, entry), { recursive: true, force: true });
     }
+  }
+
+  /** Every enabled catalog source's cached deny-list, checked against the package this install
+   *  would produce — before anything is written to disk or to `plugin_packages`. */
+  private async checkDenial(
+    pluginId: string,
+    version: string,
+    sha256: string,
+    verifiedByKeyId: string | null,
+  ): Promise<{ reason: string } | null> {
+    const sources = await this.sourceRepo.find({ where: { enabled: true } });
+    return findDenial(
+      { pluginId, version, sha256, verifiedByKeyId },
+      sources.map((s) => extractCachedDenyList(s.cachedCatalog)),
+    );
   }
 
   private async fetchArchive(zipUrl: string): Promise<Buffer> {

--- a/backend/src/modules/plugins/plugin-registry.service.jobs.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.jobs.spec.ts
@@ -63,6 +63,7 @@ function makeService(startResult?: PluginProcessStartResult, publishedJobNames: 
   const scheduledJobs = fakeScheduledJobRegistry(publishedJobNames);
   const service = new PluginRegistryService(
     { find: jest.fn().mockResolvedValue([]) } as never,
+    { find: jest.fn().mockResolvedValue([]) } as never,
     fakeRegistrationRepo() as never,
     processService as never,
     pluginJobs,

--- a/backend/src/modules/plugins/plugin-registry.service.permissions.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.permissions.spec.ts
@@ -32,6 +32,7 @@ function repoMock(): { find: jest.Mock } {
 function makeService(): PluginRegistryService {
   return new PluginRegistryService(
     repoMock() as never,
+    { find: jest.fn().mockResolvedValue([]) } as never,
     fakeRegistrationRepo() as never,
     fakeProcessService() as never,
     fakePluginJobsService() as never,

--- a/backend/src/modules/plugins/plugin-registry.service.player.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.player.spec.ts
@@ -32,6 +32,7 @@ function repoMock(): { find: jest.Mock } {
 function makeService(): PluginRegistryService {
   return new PluginRegistryService(
     repoMock() as never,
+    { find: jest.fn().mockResolvedValue([]) } as never,
     fakeRegistrationRepo() as never,
     fakeProcessService() as never,
     fakePluginJobsService() as never,

--- a/backend/src/modules/plugins/plugin-registry.service.release-picker.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.release-picker.spec.ts
@@ -45,6 +45,7 @@ function repoMock(): { find: jest.Mock } {
 function makeService(): PluginRegistryService {
   return new PluginRegistryService(
     repoMock() as never,
+    { find: jest.fn().mockResolvedValue([]) } as never,
     fakeRegistrationRepo() as never,
     fakeProcessService() as never,
     fakePluginJobsService() as never,

--- a/backend/src/modules/plugins/plugin-registry.service.routes.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.routes.spec.ts
@@ -33,6 +33,7 @@ function repoMock(): { find: jest.Mock } {
 function makeService(startResult?: PluginProcessStartResult): PluginRegistryService {
   return new PluginRegistryService(
     repoMock() as never,
+    { find: jest.fn().mockResolvedValue([]) } as never,
     fakeRegistrationRepo() as never,
     fakeProcessService(startResult) as never,
     fakePluginJobsService() as never,

--- a/backend/src/modules/plugins/plugin-registry.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.spec.ts
@@ -8,7 +8,8 @@ import { generateTestKeypair, signManifestBase64 } from './archive/ed25519-test-
 import { minimalDataManifest, minimalProcessManifest } from './archive/test-manifests';
 import { svgLogo, pngLogo } from './archive/test-fixtures';
 import { OFFICIAL_KEYS } from './archive/trust-store';
-import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry, fakeCountsCache } from './plugin-registry.test-helpers';
+import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry,
+  fakeSourceRepo, fakeCountsCache } from './plugin-registry.test-helpers';
 import { FLIKS_PLUGINS_DISABLED_ENV } from '../../common/constants/plugin-flags';
 import { sweepOrphans } from './supervisor/pid-file';
 import { getPluginsSocketDir } from '../../common/constants/paths';
@@ -55,20 +56,27 @@ function repoMock(rows: PluginPackage[] = []) {
 }
 
 /** Every registry test but boot-load exercises `register()` directly, so the process side is always faked here. */
-function makeService(rows: PluginPackage[] = [], processResult: PluginProcessStartResult = { ok: true }) {
+function makeService(
+  rows: PluginPackage[] = [],
+  processResult: PluginProcessStartResult = { ok: true },
+  sources: Array<{ enabled: boolean; cachedCatalog: Record<string, unknown> | null }> = [],
+) {
   const repo = repoMock(rows);
+  // The shared helper honours `where`, so the enabled-only filter is the code's job, not the mock's.
+  const sourceRepo = fakeSourceRepo(sources as never);
   const registrationRepo = fakeRegistrationRepo();
   const processService = fakeProcessService(processResult);
   const pluginJobs = fakePluginJobsService();
   const service = new PluginRegistryService(
     repo as never,
+    sourceRepo as never,
     registrationRepo as never,
     processService as never,
     pluginJobs as never,
     fakeScheduledJobRegistry() as never,
     fakeCountsCache() as never,
   );
-  return { service, repo, registrationRepo, processService, pluginJobs };
+  return { service, repo, sourceRepo, registrationRepo, processService, pluginJobs };
 }
 
 describe('PluginRegistryService — boot load', () => {
@@ -247,6 +255,72 @@ describe('PluginRegistryService.register()', () => {
     expect(result).toEqual({ ok: true, pluginId: manifest.id });
   });
 
+  it('refuses to register a package an enabled source’s deny-list revokes, and the reason reaches the caller', async () => {
+    const { privateKey, rawPublicKey } = generateTestKeypair();
+    (OFFICIAL_KEYS as Map<string, Buffer>).set('release-2026', rawPublicKey);
+    const manifest = minimalDataManifest({ fliks: COMPATIBLE_RANGE });
+    const manifestBytes = Buffer.from(JSON.stringify(manifest), 'utf8');
+    const sig = signManifestBase64(privateKey, manifestBytes);
+    const archive = archiveFor(manifest, [{ name: 'plugin.json.sig', content: Buffer.from(sig, 'utf8') }]);
+    const pkg = makePackage(manifest, { archive, signature: 'official', verifiedByKeyId: 'release-2026' });
+    const source = {
+      enabled: true,
+      cachedCatalog: {
+        denyList: [{ pluginId: manifest.id, reason: 'known credential leak' }],
+        signedByKeyId: 'release-2026',
+      },
+    };
+    const { service } = makeService([], { ok: true }, [source]);
+
+    const result = await service.register(pkg);
+
+    expect(result).toEqual({ ok: false, pluginId: manifest.id, reason: 'revoked', detail: 'known credential leak' });
+    expect(service.get(manifest.id)).toBeUndefined();
+  });
+
+  it('ignores the deny-list of a source the operator disabled', async () => {
+    const { privateKey, rawPublicKey } = generateTestKeypair();
+    (OFFICIAL_KEYS as Map<string, Buffer>).set('release-2026', rawPublicKey);
+    const manifest = minimalDataManifest({ fliks: COMPATIBLE_RANGE });
+    const manifestBytes = Buffer.from(JSON.stringify(manifest), 'utf8');
+    const sig = signManifestBase64(privateKey, manifestBytes);
+    const archive = archiveFor(manifest, [{ name: 'plugin.json.sig', content: Buffer.from(sig, 'utf8') }]);
+    const pkg = makePackage(manifest, { archive, signature: 'official', verifiedByKeyId: 'release-2026' });
+    // Everything else matches, so only the disabled flag can keep this plugin installed.
+    const source = {
+      enabled: false,
+      cachedCatalog: {
+        denyList: [{ pluginId: manifest.id, reason: 'known credential leak' }],
+        signedByKeyId: 'release-2026',
+      },
+    };
+    const { service } = makeService([], { ok: true }, [source]);
+
+    await expect(service.register(pkg)).resolves.toEqual({ ok: true, pluginId: manifest.id });
+  });
+
+  it('does not revoke a package when the deny-list was signed by a different key than the one that verified the package', async () => {
+    const { privateKey, rawPublicKey } = generateTestKeypair();
+    (OFFICIAL_KEYS as Map<string, Buffer>).set('release-2026', rawPublicKey);
+    const manifest = minimalDataManifest({ fliks: COMPATIBLE_RANGE });
+    const manifestBytes = Buffer.from(JSON.stringify(manifest), 'utf8');
+    const sig = signManifestBase64(privateKey, manifestBytes);
+    const archive = archiveFor(manifest, [{ name: 'plugin.json.sig', content: Buffer.from(sig, 'utf8') }]);
+    const pkg = makePackage(manifest, { archive, signature: 'official', verifiedByKeyId: 'release-2026' });
+    const source = {
+      enabled: true,
+      cachedCatalog: {
+        denyList: [{ pluginId: manifest.id, reason: 'known credential leak' }],
+        signedByKeyId: 'some-other-source',
+      },
+    };
+    const { service } = makeService([], { ok: true }, [source]);
+
+    const result = await service.register(pkg);
+
+    expect(result).toEqual({ ok: true, pluginId: manifest.id });
+  });
+
   it('L4: does not register when pluginApi differs from PLUGIN_API_VERSION, with its own reason', async () => {
     const manifest = minimalDataManifest({ fliks: COMPATIBLE_RANGE, pluginApi: 99 });
     const pkg = makePackage(manifest);
@@ -318,6 +392,20 @@ describe('PluginRegistryService.register()', () => {
       expect(row?.manifest).toEqual(pkg.manifest);
     });
 
+
+    it('revoke() stops a running plugin’s process and tears its routes down like an untrusted plugin, not a merely-stopped one', async () => {
+      const pkg = processPackage({ id: 'fliks.processrevoked', routes: [{ method: 'GET', path: '/health', policy: 'read:Media' }] });
+      const { service, processService } = makeService();
+      await service.register(pkg);
+      expect(service.resolveRoute(pkg.pluginId, 'GET', '/health')).not.toBeNull();
+
+      await service.revoke(pkg.pluginId, 'known credential leak');
+
+      expect(processService.stopFor).toHaveBeenCalledWith(pkg.pluginId);
+      expect(service.get(pkg.pluginId)).toBeUndefined();
+      // 403, not 503: a revocation withdraws authority, it doesn't just take the process down.
+      expect(service.resolveRoute(pkg.pluginId, 'GET', '/health')).toBeNull();
+    });
 
     it('propagates a spawn failure reason and registers nothing', async () => {
       const pkg = processPackage({ id: 'fliks.processspawnfail' });

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -3,9 +3,11 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import * as net from 'net';
 import * as semver from 'semver';
+import { createHash } from 'crypto';
 import { pathToRegexp, type Keys } from 'path-to-regexp';
 import { CronExpressionParser } from 'cron-parser';
 import { PluginPackage, type PluginPackageStatus } from './entities/plugin-package.entity';
+import { PluginSource } from './entities/plugin-source.entity';
 import { PluginRegistration } from './entities/plugin-registration.entity';
 import { PluginProcessService, type PluginProcessStartResult } from './plugin-process.service';
 import { PluginJobsService } from './plugin-jobs.service';
@@ -34,6 +36,7 @@ import {
   type ConfigPage,
 } from '../../common/plugin-contract';
 import { OFFICIAL_KEYS, resolveTrust, readArchiveEntries, type TrustOutcome } from './archive';
+import { extractCachedDenyList, findDenial } from './catalog/catalog';
 import { i18nRoot } from './archive/manifest-parser';
 import { isInternalAddress } from './internal-address';
 import type { DomainEvent } from '../scheduler/events.service';
@@ -89,6 +92,7 @@ export interface RegisteredPlugin {
 
 export type PluginRegistrationFailureReason =
   | 'untrusted'
+  | 'revoked'
   | 'incompatible-api'
   | 'incompatible-fliks'
   | 'invalid-webhook-event'
@@ -188,6 +192,8 @@ export class PluginRegistryService implements OnModuleInit {
   constructor(
     @InjectRepository(PluginPackage)
     private readonly packageRepo: Repository<PluginPackage>,
+    @InjectRepository(PluginSource)
+    private readonly sourceRepo: Repository<PluginSource>,
     @InjectRepository(PluginRegistration)
     private readonly registrationRepo: Repository<PluginRegistration>,
     private readonly processService: PluginProcessService,
@@ -248,6 +254,9 @@ export class PluginRegistryService implements OnModuleInit {
     // L2
     const trust = await this.reverifyTrust(pkg);
     if (!trust.ok) return this.fail(pkg.pluginId, 'untrusted', trust.detail);
+
+    const denial = await this.checkDenial(pkg);
+    if (denial) return this.fail(pkg.pluginId, 'revoked', denial.reason);
 
     // L3 (re-hash plugin.js from the loaded fd) happens inside `PluginProcessService.startFor`, below.
     // L4
@@ -780,6 +789,23 @@ export class PluginRegistryService implements OnModuleInit {
       this.replacePlayer(pluginId, undefined);
     }
     return { ok: false, pluginId, reason, detail };
+  }
+
+  /** Called when a catalog refresh lands a denial for a package already registered: stops its
+   *  process and tears its live state down the same way a failed `register()` would. */
+  async revoke(pluginId: string, reason: string): Promise<void> {
+    await this.unregister(pluginId);
+    this.fail(pluginId, 'revoked', reason);
+  }
+
+  /** `enabled` catalog sources only — a disabled source's cached signature is stale trust, not authority. */
+  private async checkDenial(pkg: PluginPackage): Promise<{ reason: string } | null> {
+    const sources = await this.sourceRepo.find({ where: { enabled: true } });
+    const sha256 = createHash('sha256').update(pkg.archive).digest('hex');
+    return findDenial(
+      { pluginId: pkg.pluginId, version: pkg.version, sha256, verifiedByKeyId: pkg.verifiedByKeyId },
+      sources.map((s) => extractCachedDenyList(s.cachedCatalog)),
+    );
   }
 
   /**

--- a/backend/src/modules/plugins/plugin-registry.service.webhooks.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.webhooks.spec.ts
@@ -32,6 +32,7 @@ function repoMock(): { find: jest.Mock } {
 function makeService(): PluginRegistryService {
   return new PluginRegistryService(
     repoMock() as never,
+    { find: jest.fn().mockResolvedValue([]) } as never,
     fakeRegistrationRepo() as never,
     fakeProcessService() as never,
     fakePluginJobsService() as never,

--- a/backend/src/modules/plugins/plugin-registry.test-helpers.ts
+++ b/backend/src/modules/plugins/plugin-registry.test-helpers.ts
@@ -81,3 +81,11 @@ export function fakeScheduledJobRegistry(names: readonly string[] = []): { list:
 export function fakeCountsCache(): { forget: jest.Mock } {
   return { forget: jest.fn() };
 }
+
+/** Stands in for the `PluginSource` repo — empty by default, so a test only wires it up when the
+ *  deny-list it is asserting on actually needs one. */
+export function fakeSourceRepo(rows: Array<{ enabled: boolean; cachedCatalog: Record<string, unknown> | null }> = []): {
+  find: jest.Mock;
+} {
+  return { find: jest.fn(async ({ where }: { where?: { enabled?: boolean } } = {}) => (where?.enabled === undefined ? rows : rows.filter((r) => r.enabled === where.enabled))) };
+}

--- a/backend/src/modules/plugins/plugins.module.ts
+++ b/backend/src/modules/plugins/plugins.module.ts
@@ -16,6 +16,8 @@ import { PluginDatabaseService } from './plugin-database.service';
 import { PluginLogoController } from './plugin-logo.controller';
 import { PluginSourcesController } from './plugin-sources.controller';
 import { PluginImportController } from './plugin-import.controller';
+import { PluginBackupController } from './plugin-backup.controller';
+import { PluginBackupService } from './plugin-backup.service';
 import { PluginsController } from './plugins.controller';
 import { PluginUiController } from './plugin-ui.controller';
 import { PluginObjectGuardsService } from './proxy/plugin-object-guards.service';
@@ -44,6 +46,7 @@ import { ScheduledJobRegistryModule } from '../scheduler/scheduled-job-registry.
     PluginLogoController,
     PluginSourcesController,
     PluginImportController,
+    PluginBackupController,
     PluginsController,
     PluginUiController,
     // Last: its `*splat` wildcard must never shadow the concrete routes above.
@@ -59,6 +62,7 @@ import { ScheduledJobRegistryModule } from '../scheduler/scheduled-job-registry.
     PluginStagingService,
     PluginInstallService,
     PluginDatabaseService,
+    PluginBackupService,
     PluginObjectGuardsService,
     PluginRouteGuard,
     PluginPreRollService,

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -227,6 +227,45 @@ grants on the core tables it declared. It runs its own migrations. Core never re
 
 Uninstalling drops the role and the schema. Disabling does not.
 
+### Export and import
+
+`GET /api/plugins/:id/export` returns one JSON document: the plugin id, its installed version,
+every `plugin.<id>.*` setting, and every row of every table in the plugin's own schema (`data`
+plugins have no schema, so `tables` is empty). Column and table names are read from the database
+catalogue on every call, never trusted from anywhere else, and the schema queried is always
+`plugin_<id>` — never `public` and never another plugin's schema.
+
+**A table whose name begins with an underscore is yours, and core leaves it alone.** It is never
+exported, never written back, and never counted when deciding whether a schema is empty. That is
+what a migration ledger like `_migrations` is: it records which migrations have run, so restoring an
+older copy of it over a freshly-migrated schema would misstate the schema's own version.
+
+**This document is a credential-bearing artifact.** It contains whatever the plugin stored,
+including anything an operator typed into a `secret` field on a config page. Nothing is stripped
+or masked — a partial export that looks complete is worse than one that's honest about carrying
+secrets. Handle it like any other credential dump.
+
+`POST /api/plugins/:id/import` restores that document, and refuses rather than merges:
+
+- **Version mismatch** (`PLUGIN_EXPORT_VERSION_MISMATCH`, 409): the export's `pluginVersion` must
+  equal the installed version. There is no migration-diff engine here — a plugin's schema and its
+  setting keys are shaped by its own migrations, so replaying an old export onto a newer (or
+  older) version risks writing rows or keys that no longer match. Install the matching version
+  first.
+- **Schema already has rows** (`PLUGIN_SCHEMA_NOT_EMPTY`, 409): import refuses if any table in the
+  plugin's schema already holds a row, bookkeeping tables aside — a plugin that has merely migrated
+  counts as empty, which is the state a restore is meant for. A silent merge into a half-populated schema would look like
+  a complete restore without being one; uninstall and reinstall the plugin (which wipes its
+  schema) before importing.
+- **Not yet activated** (`PLUGIN_NOT_READY`, 409): the installed plugin's last activation must have
+  succeeded, since that's what proves its own migrations have run.
+
+A restore writes rows carrying their original ids, so every serial column's sequence is moved past
+the highest restored value in the same transaction. Without that the plugin's first insert after an
+apparently successful import fails on a duplicate key.
+
+Both routes are admin-only, gated the same way as the rest of `/plugins`.
+
 ## Events
 
 `events[]` names domain events. For a `data` plugin, `webhook` is either an absolute https URL or
@@ -281,6 +320,34 @@ Catalogue sources are HTTPS documents listing each plugin's installable versions
 per version; core refuses bytes whose hash does not match. Publishing a plugin means committing its
 built source into the catalogue repository, adding a version entry, and running its packaging
 workflow, which signs with the catalogue key and records the published archive's hash.
+
+## Revocation
+
+A catalogue document may also carry a `denyList`: entries of `{ pluginId, version?, sha256?, reason }`.
+Omitting `version` denies every version of `pluginId`; adding `sha256` narrows an entry to one exact
+build rather than every archive ever published under that version string. A malformed entry is
+dropped rather than failing the whole (already signature-verified) refresh.
+
+**Revocation authority is signing authority.** An entry only revokes a package whose
+`verifiedByKeyId` equals the key id that verified the deny-list's own catalogue document. A
+catalogue signed by the compiled-in release key revokes anything that key signed; a source with its
+own pinned key revokes only what *that* key signed — nothing, today, since no plugin ships signed by
+a source key yet; and an unsigned or manually-imported package (`verifiedByKeyId: null`) is
+revocable by nobody, because nobody vouched for it in the first place. This falls out of the
+existing trust model with no migration and no new authority to reason about: a catalogue's key is
+already the thing an operator chose to trust when they added the source.
+
+A denied version cannot be installed — refused with `PLUGIN_DENIED` (403), carrying the publisher's
+`reason` — and cannot register, at boot or on hot-reload, with its own `revoked` failure reason.
+Like `untrusted`, `revoked` is **not** treated as "installed but not running": its routes are torn
+down rather than left answering 503, because a revocation withdraws the authority to run at all —
+it is not reporting an outage.
+
+Latency: a revocation reaches an already-running plugin the moment the catalogue that names it
+refreshes — the daily 4am cron, or immediately on a manual refresh — never waiting for a reboot. The
+refresh that lands a new deny-list entry stops any matching installed package's process and marks
+its row `failed` with the publisher's reason right there, rather than merely blocking the next
+install.
 
 ## Operator semantics worth knowing before you rely on them
 


### PR DESCRIPTION
§8.4 and §8.3 together: a way to withdraw a published plugin, and a way to carry a plugin's state
across a reinstall.

## Revocation authority is signing authority

Today the only way to withdraw a plugin is to remove a signing key, which fails **every** plugin that
key ever signed. A catalogue document can now carry a deny-list, which works because
`resolveTrust` must succeed *before* `parseCatalogDocument` runs — the entries are as trustworthy as
the catalogue itself.

The original plan said "scope a deny-list to its own source". That is unimplementable as written:
`plugin_packages` records `origin` (`catalog`/`manual`) but **not which source** a package came from,
so it cannot be evaluated for an installed package without a new column. The rule shipped instead
needs none and is stricter:

> An entry may only withdraw a package whose `verifiedByKeyId` equals the key that verified the
> deny-list's own document.

Checked against what is actually installed:

| plugin | `verifiedByKeyId` | revocable by |
|---|---|---|
| `acme.hello` | *(null)* | nobody |
| `fliks.download` | *(null)* | nobody |
| `fliks.webhooks` | `release-2026` | a deny-list signed by `release-2026` |

Two of three are structurally unrevocable, which is right — an operator side-loaded them and no
catalogue ever vouched for either. A source pinning its own key verifies as `signedByKeyId: 'source'`
and no package carries that id, so a hostile source withdraws nothing.

Enforced at install, at registration, and — since waiting for a reboot would make it useless —
against what is already running the moment a refresh lands it.

### Review findings fixed

- **A disabled source could still revoke.** The manual-refresh route resolves a source without
  checking `enabled`, while the registration check reads enabled sources only — so a disabled source
  could kill a plugin and pressing *Restart* brought it straight back. The state flapped instead of
  settling. Now enforcement respects `enabled`, matching the other two paths.
- **A failure escaped the refresh contract.** `enforceDenyList` ran outside any try/catch after the
  source row was saved, so one bad package turned a `CatalogRefreshResult` into a 500 and aborted the
  rest of the nightly loop. Now it logs and continues, the same posture the boot loop takes.
- Two guards had no coverage at all — the `sha256` narrowing, and the enabled-only filter, whose test
  mock was doing the filtering the code was credited with. Both now fail when reverted.

## Export and import

Data only. A plugin owns its schema through its own migrations, so the restorable unit is rows plus
`plugin.<id>.*` settings. That also sidesteps a real deployment problem: the image ships `pg_dump`
**16.14** against a **17.9** server, which pg_dump refuses outright — a dump-based export would have
been broken on this stack the day it shipped.

Verified live: exporting `fliks.download` returns its five settings and every row of its six data
tables (180 `indexer_stats`, 7 `download_history`, …).

### Three defects review caught, each reproduced on real Postgres

- **Import was unreachable.** The emptiness guard counted `_migrations`, which always has rows once a
  plugin has migrated, so every real plugin looked occupied and import always answered
  `PLUGIN_SCHEMA_NOT_EMPTY`. A table whose name begins with an underscore is now the plugin's own
  bookkeeping: never exported, never written back, never counted. Confirmed against a simulated
  freshly-migrated schema.
- **A "successful" restore broke the plugin's next write.** Restored rows keep their ids, leaving
  every serial behind them:
  ```
  INSERT INTO items (label) VALUES ('next');
  ERROR: duplicate key value violates unique constraint "items_pkey"
  ```
  Sequences are now moved past the highest restored id in the same transaction; the same insert then
  lands at 8.
- **A rejected import had already written settings.** The namespace check ran per key inside the write
  loop, so keys before the bad one were committed and the 400 left half-applied state. Every key is
  validated before any is written.

Also: the export route's spec asserted nothing about authorization and passed with `@UseGuards` and
both `@CheckPolicies` deleted — on a route that returns a credential-bearing document. It now
asserts the reflected guards and that each declared policy refuses an ability lacking it.

## Verification

- `npx tsc --noEmit` — exit 0.
- Full backend suite: **139 suites, 1558 tests**, exit 0.
- Live: backend restarted, all three plugins `active`; a real export round-tripped through the API.
- Every fix proven to fail when reverted, including the two previously-uncovered deny-list guards and
  the authorization assertions.
