### PR TITLE
feat(plugins): report what each process plugin costs the host

### DIFF
--- a/backend/src/modules/plugins/plugin-backup.controller.spec.ts
+++ b/backend/src/modules/plugins/plugin-backup.controller.spec.ts
@@ -10,8 +10,8 @@ function denyAll(): AppAbility {
   return { can: () => false } as unknown as AppAbility;
 }
 
-function allowOnly(action: Action): AppAbility {
-  return { can: (a: Action) => a === action } as unknown as AppAbility;
+function allowOnly(action: Action, subject: string): AppAbility {
+  return { can: (a: Action, s: string) => a === action && s === subject } as unknown as AppAbility;
 }
 
 function policiesFor(method: 'export' | 'import'): PolicyHandler[] {
@@ -36,7 +36,7 @@ describe('PluginBackupController — authorization', () => {
 
     const asCallback = handlers[0] as (ability: AppAbility) => boolean;
     expect(asCallback(denyAll())).toBe(false);
-    expect(asCallback(allowOnly(needed))).toBe(true);
+    expect(asCallback(allowOnly(needed, 'Settings'))).toBe(true);
   });
 });
 

--- a/backend/src/modules/plugins/plugin-process.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-process.service.spec.ts
@@ -8,7 +8,12 @@ import { getPluginsRuntimeDir } from '../../common/constants/paths';
 import { createHash } from 'crypto';
 import { minimalProcessManifest } from './archive/test-manifests';
 import type { PluginPackage } from './entities/plugin-package.entity';
-import type { PluginSupervisor, PluginSupervisorOptions, SupervisorState } from './supervisor/plugin-supervisor';
+import type {
+  PluginSupervisor,
+  PluginSupervisorOptions,
+  ProcessPluginMetrics,
+  SupervisorState,
+} from './supervisor/plugin-supervisor';
 import type { PluginHostBindingService } from './host/plugin-host-binding.service';
 import type { UnsafeCoreRefFk } from './plugin-database.service';
 
@@ -33,6 +38,14 @@ class FakeSupervisor {
   stopCalls = 0;
   emitEvent = jest.fn();
   emitConfigChanged = jest.fn();
+  metrics: ProcessPluginMetrics = {
+    hostCallCount: 0,
+    hostCallFailureCount: 0,
+    hostCallP95Ms: null,
+    restartCount: 0,
+    eventDropCount: 0,
+    residentSetSizeBytes: null,
+  };
   private listeners: ((s: SupervisorState) => void)[] = [];
 
   constructor(public readonly options: PluginSupervisorOptions) {}
@@ -45,6 +58,9 @@ class FakeSupervisor {
   }
   getStatusMessage(): string {
     return this.statusMessage;
+  }
+  getMetrics(): ProcessPluginMetrics {
+    return this.metrics;
   }
 
   onStateChange(cb: (s: SupervisorState) => void): () => void {
@@ -414,11 +430,19 @@ describe('PluginProcessService — lifecycle', () => {
     expect(service.stateOf(pkg.pluginId)).toBeNull();
   });
 
-  it('stateOf/statusMessageOf report unknown for a plugin never started', () => {
+  it('stateOf/statusMessageOf/metricsOf report unknown for a plugin never started', () => {
     const service = new PluginProcessService(fakePluginDb() as never, fakeLogBuffer() as never, fakeSettings() as never, makeFactory().factory);
 
     expect(service.stateOf('fliks.never-started')).toBeNull();
     expect(service.statusMessageOf('fliks.never-started')).toBe('');
+    expect(service.metricsOf('fliks.never-started')).toBeNull();
+  });
+
+  it('metricsOf reports the running supervisor’s counters', async () => {
+    const { service, pkg, instances } = await startedService();
+    instances[0].metrics = { ...instances[0].metrics, hostCallCount: 7 };
+
+    expect(service.metricsOf(pkg.pluginId)?.hostCallCount).toBe(7);
   });
 
   it('statusMessageOf falls back to the stderr tail of a plugin that is down', async () => {

--- a/backend/src/modules/plugins/plugin-process.service.ts
+++ b/backend/src/modules/plugins/plugin-process.service.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_SUPERVISOR_OPTIONS,
   PluginSupervisor,
   type PluginSupervisorOptions,
+  type ProcessPluginMetrics,
   type SupervisorState,
 } from './supervisor/plugin-supervisor';
 import { LogBufferService } from '../scheduler/log-buffer.service';
@@ -166,6 +167,11 @@ export class PluginProcessService implements OnApplicationShutdown {
 
   stateOf(pluginId: string): SupervisorState | null {
     return this.running.get(pluginId)?.supervisor.getState() ?? null;
+  }
+
+  /** Null for a plugin with no running supervisor — not started, or `data`, which has none. */
+  metricsOf(pluginId: string): ProcessPluginMetrics | null {
+    return this.running.get(pluginId)?.supervisor.getMetrics() ?? null;
   }
 
   statusMessageOf(pluginId: string): string {

--- a/backend/src/modules/plugins/plugins.controller.spec.ts
+++ b/backend/src/modules/plugins/plugins.controller.spec.ts
@@ -1,9 +1,29 @@
 import { PluginsController } from './plugins.controller';
+import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
+import { PoliciesGuard } from '../auth/casl/policies.guard';
+import { CHECK_POLICIES_KEY, type PolicyHandler } from '../auth/casl/check-policies.decorator';
+import { Action } from '../auth/casl/actions.enum';
+import type { AppAbility } from '../auth/casl/casl-ability.factory';
+
+const noProcessService = { metricsOf: jest.fn() };
+
+/** An ability that answers false to everything: a route's declared policy must refuse it. */
+function denyAll(): AppAbility {
+  return { can: () => false } as unknown as AppAbility;
+}
+
+function allowOnly(action: Action, subject: string): AppAbility {
+  return { can: (a: Action, s: string) => a === action && s === subject } as unknown as AppAbility;
+}
+
+function policiesFor(method: 'list' | 'metrics'): PolicyHandler[] {
+  return (Reflect.getMetadata(CHECK_POLICIES_KEY, PluginsController.prototype[method]) ?? []) as PolicyHandler[];
+}
 
 describe('PluginsController', () => {
   it('delegates uninstall to the install service', async () => {
     const installService = { uninstall: jest.fn().mockResolvedValue(undefined) };
-    const controller = new PluginsController(installService as never, { sendTest: jest.fn() } as never);
+    const controller = new PluginsController(installService as never, { sendTest: jest.fn() } as never, noProcessService as never);
 
     await expect(controller.uninstall('fliks.test-plugin')).resolves.toBeUndefined();
     expect(installService.uninstall).toHaveBeenCalledWith('fliks.test-plugin');
@@ -12,7 +32,7 @@ describe('PluginsController', () => {
   it('delegates list to the install service', async () => {
     const rows = [{ pluginId: 'fliks.test-plugin', status: 'active' }];
     const installService = { listInstalled: jest.fn().mockResolvedValue(rows) };
-    const controller = new PluginsController(installService as never, { sendTest: jest.fn() } as never);
+    const controller = new PluginsController(installService as never, { sendTest: jest.fn() } as never, noProcessService as never);
 
     await expect(controller.list()).resolves.toBe(rows);
     expect(installService.listInstalled).toHaveBeenCalled();
@@ -21,7 +41,7 @@ describe('PluginsController', () => {
 
   it('delegates restart to the install service', async () => {
     const installService = { restart: jest.fn().mockResolvedValue(undefined) };
-    const controller = new PluginsController(installService as never, { sendTest: jest.fn() } as never);
+    const controller = new PluginsController(installService as never, { sendTest: jest.fn() } as never, noProcessService as never);
 
     await expect(controller.restart('fliks.test-plugin')).resolves.toBeUndefined();
     expect(installService.restart).toHaveBeenCalledWith('fliks.test-plugin');
@@ -30,7 +50,7 @@ describe('PluginsController', () => {
   it('delegates disable to the install service', async () => {
     const summary = { pluginId: 'fliks.test-plugin', enabled: false };
     const installService = { disable: jest.fn().mockResolvedValue(summary) };
-    const controller = new PluginsController(installService as never, { sendTest: jest.fn() } as never);
+    const controller = new PluginsController(installService as never, { sendTest: jest.fn() } as never, noProcessService as never);
 
     await expect(controller.disable('fliks.test-plugin')).resolves.toBe(summary);
     expect(installService.disable).toHaveBeenCalledWith('fliks.test-plugin');
@@ -39,9 +59,51 @@ describe('PluginsController', () => {
   it('delegates enable to the install service', async () => {
     const summary = { pluginId: 'fliks.test-plugin', enabled: true };
     const installService = { enable: jest.fn().mockResolvedValue(summary) };
-    const controller = new PluginsController(installService as never, { sendTest: jest.fn() } as never);
+    const controller = new PluginsController(installService as never, { sendTest: jest.fn() } as never, noProcessService as never);
 
     await expect(controller.enable('fliks.test-plugin')).resolves.toBe(summary);
     expect(installService.enable).toHaveBeenCalledWith('fliks.test-plugin');
+  });
+
+  describe('metrics', () => {
+    it('pairs each installed plugin with its process metrics, and null for a data plugin', async () => {
+      const rows = [
+        { pluginId: 'fliks.download', kind: 'process' },
+        { pluginId: 'fliks.notify', kind: 'data' },
+      ];
+      const installService = { listInstalled: jest.fn().mockResolvedValue(rows) };
+      const processMetrics = { hostCallCount: 3, hostCallFailureCount: 0, hostCallP95Ms: 12, restartCount: 0, eventDropCount: 0, residentSetSizeBytes: 123 };
+      const processService = { metricsOf: jest.fn().mockReturnValue(processMetrics) };
+      const controller = new PluginsController(installService as never, { sendTest: jest.fn() } as never, processService as never);
+
+      const result = await controller.metrics();
+
+      expect(result).toEqual([
+        { pluginId: 'fliks.download', kind: 'process', metrics: processMetrics },
+        { pluginId: 'fliks.notify', kind: 'data', metrics: null },
+      ]);
+      expect(processService.metricsOf).toHaveBeenCalledWith('fliks.download');
+      expect(processService.metricsOf).not.toHaveBeenCalledWith('fliks.notify');
+    });
+  });
+
+  describe('authorization', () => {
+    it('puts the controller behind the authenticated policies guard', () => {
+      const guards = (Reflect.getMetadata('__guards__', PluginsController) ?? []) as unknown[];
+      expect(guards).toContain(JwtOrApiKeyGuard);
+      expect(guards).toContain(PoliciesGuard);
+    });
+
+    it.each([['list' as const], ['metrics' as const]])(
+      'declares a Settings-read policy on %s that refuses an ability without it',
+      (method) => {
+        const handlers = policiesFor(method);
+        expect(handlers.length).toBeGreaterThan(0);
+
+        const asCallback = handlers[0] as (ability: AppAbility) => boolean;
+        expect(asCallback(denyAll())).toBe(false);
+        expect(asCallback(allowOnly(Action.Read, 'Settings'))).toBe(true);
+      },
+    );
   });
 });

--- a/backend/src/modules/plugins/plugins.controller.ts
+++ b/backend/src/modules/plugins/plugins.controller.ts
@@ -5,6 +5,16 @@ import { CheckPolicies } from '../auth/casl/check-policies.decorator';
 import { Action } from '../auth/casl/actions.enum';
 import { PluginWebhookDispatcherService, type WebhookTestResult } from './plugin-webhook-dispatcher.service';
 import { PluginInstallService, PluginSummary } from './plugin-install.service';
+import { PluginProcessService } from './plugin-process.service';
+import type { ProcessPluginMetrics } from './supervisor/plugin-supervisor';
+import type { PluginKind } from '../../common/plugin-contract';
+
+export interface PluginMetricsEntry {
+  pluginId: string;
+  kind: PluginKind;
+  /** Null for a `data` plugin (no supervisor) or a `process` plugin that isn't running. */
+  metrics: ProcessPluginMetrics | null;
+}
 
 @Controller('plugins')
 @UseGuards(JwtOrApiKeyGuard, PoliciesGuard)
@@ -12,12 +22,26 @@ export class PluginsController {
   constructor(
     private readonly installService: PluginInstallService,
     private readonly dispatcher: PluginWebhookDispatcherService,
+    private readonly processService: PluginProcessService,
   ) {}
 
   @Get()
   @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
   async list(): Promise<PluginSummary[]> {
     return this.installService.listInstalled();
+  }
+
+  /** Own route rather than a wider `PluginSummary`: that shape is polled by the admin list and
+   *  parsed by several clients, and must stay stable. */
+  @Get('metrics')
+  @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
+  async metrics(): Promise<PluginMetricsEntry[]> {
+    const installed = await this.installService.listInstalled();
+    return installed.map((row) => ({
+      pluginId: row.pluginId,
+      kind: row.kind,
+      metrics: row.kind === 'process' ? this.processService.metricsOf(row.pluginId) : null,
+    }));
   }
 
   /** `process` only — flips `plugin_registrations.enabled` and starts or stops the process to match. */

--- a/backend/src/modules/plugins/supervisor/latency-window.spec.ts
+++ b/backend/src/modules/plugins/supervisor/latency-window.spec.ts
@@ -1,0 +1,35 @@
+import { LatencyWindow } from './latency-window';
+
+describe('LatencyWindow', () => {
+  it('p95 over a known set of samples is the nearest-rank value', () => {
+    const w = new LatencyWindow();
+    // 1..100ms: rank = ceil(0.95*100)-1 = 94 (0-indexed) -> value 95.
+    for (let ms = 1; ms <= 100; ms++) w.push(ms);
+    expect(w.p95()).toBe(95);
+  });
+
+  it('is null with no samples yet', () => {
+    expect(new LatencyWindow().p95()).toBeNull();
+  });
+
+  it('does not grow past its fixed capacity', () => {
+    const w = new LatencyWindow();
+    for (let i = 0; i < 10_000; i++) w.push(i);
+    expect(w.size).toBe(256);
+  });
+
+  it('overwrites the oldest sample once at capacity, so p95 tracks only the recent window', () => {
+    const w = new LatencyWindow();
+    for (let i = 0; i < 256; i++) w.push(1); // fill with a low value
+    expect(w.p95()).toBe(1);
+    for (let i = 0; i < 256; i++) w.push(1000); // fully overwrite with a high one
+    expect(w.p95()).toBe(1000);
+    expect(w.size).toBe(256);
+  });
+
+  it('rounds to a tenth of a millisecond, so a sub-microsecond clock does not reach the UI', () => {
+    const w = new LatencyWindow();
+    w.push(295.8883610000048);
+    expect(w.p95()).toBe(295.9);
+  });
+});

--- a/backend/src/modules/plugins/supervisor/latency-window.ts
+++ b/backend/src/modules/plugins/supervisor/latency-window.ts
@@ -1,0 +1,32 @@
+const CAPACITY = 256;
+
+/**
+ * Fixed-size ring of recent durations. `p95()` is over the last CAPACITY samples, not a time
+ * window — a plugin runs for weeks, so an unbounded array is never an option.
+ */
+export class LatencyWindow {
+  private samples: number[] = [];
+  private next = 0;
+
+  push(ms: number): void {
+    if (this.samples.length < CAPACITY) {
+      this.samples.push(ms);
+    } else {
+      this.samples[this.next] = ms;
+      this.next = (this.next + 1) % CAPACITY;
+    }
+  }
+
+  get size(): number {
+    return this.samples.length;
+  }
+
+  /** Null with no samples yet. Nearest-rank over the current window, rounded to 0.1 ms because
+   *  `performance.now()` resolves finer than any consumer of this number cares about. */
+  p95(): number | null {
+    if (this.samples.length === 0) return null;
+    const sorted = [...this.samples].sort((a, b) => a - b);
+    const rank = Math.min(Math.ceil(0.95 * sorted.length) - 1, sorted.length - 1);
+    return Math.round(sorted[Math.max(0, rank)] * 10) / 10;
+  }
+}

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.spec.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.spec.ts
@@ -598,6 +598,80 @@ describe('host call dispatch', () => {
     expect(sup.getState()).toBe('ready');
     client.destroy();
   }, 10_000);
+
+  it('counts a successful call and times it', async () => {
+    const hostApi = {
+      'config.get': jest.fn(() => new Promise((resolve) => setTimeout(() => resolve({ ok: true }), 20))),
+    } as unknown as PluginHostApi;
+    const sup = makeSupervisor('good', { hostApi });
+    await sup.start();
+    await waitForState(sup, 'ready');
+
+    const client = await connectAsPlugin(sup.getSocketPaths().coreSockPath);
+    await client.call('config.get', {}, 2_000);
+    client.destroy();
+
+    const metrics = sup.getMetrics();
+    expect(metrics.hostCallCount).toBe(1);
+    expect(metrics.hostCallFailureCount).toBe(0);
+    expect(metrics.hostCallP95Ms).not.toBeNull();
+    expect(metrics.hostCallP95Ms as number).toBeGreaterThanOrEqual(15);
+  }, 10_000);
+
+  it('counts a failing call as a failure and still times it', async () => {
+    const hostApi = {
+      'config.get': jest.fn().mockRejectedValue(new Error('boom')),
+    } as unknown as PluginHostApi;
+    const sup = makeSupervisor('good', { hostApi });
+    await sup.start();
+    await waitForState(sup, 'ready');
+
+    const client = await connectAsPlugin(sup.getSocketPaths().coreSockPath);
+    await expect(client.call('config.get', {}, 2_000)).rejects.toThrow(/boom/);
+    client.destroy();
+
+    const metrics = sup.getMetrics();
+    expect(metrics.hostCallCount).toBe(1);
+    expect(metrics.hostCallFailureCount).toBe(1);
+    expect(metrics.hostCallP95Ms).not.toBeNull();
+  }, 10_000);
+});
+
+describe('getMetrics — resident set size', () => {
+  it('reads a live child\'s resident size on Linux, never as a silent zero', async () => {
+    if (process.platform !== 'linux') return;
+    const sup = makeSupervisor('good');
+    await sup.start();
+    await waitForState(sup, 'ready');
+
+    const bytes = sup.getMetrics().residentSetSizeBytes;
+    expect(bytes).not.toBeNull();
+
+    // Against the kernel's own figure: `> 0` alone would pass just as happily on VmSize, which is
+    // virtual address space and runs to gigabytes for the same child.
+    const pid = (sup as unknown as { child: { pid: number } }).child.pid;
+    const status = readFileSync(`/proc/${pid}/status`, 'utf8');
+    const expectedKb = Number(/^VmRSS:\s+(\d+) kB$/m.exec(status)![1]);
+    const virtualKb = Number(/^VmSize:\s+(\d+) kB$/m.exec(status)![1]);
+    expect(virtualKb).toBeGreaterThan(expectedKb * 4); // the two are never confusable on this child
+
+    // Resident size moves under its own feet, so allow drift but not a different quantity.
+    expect(Math.abs((bytes as number) / 1024 - expectedKb)).toBeLessThan(expectedKb * 0.5);
+  }, 10_000);
+
+  it('reports unavailable rather than zero off Linux', async () => {
+    const sup = makeSupervisor('good');
+    await sup.start();
+    await waitForState(sup, 'ready');
+
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    try {
+      expect(sup.getMetrics().residentSetSizeBytes).toBeNull();
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    }
+  }, 10_000);
 });
 
 describe('protocol violations', () => {

--- a/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
+++ b/backend/src/modules/plugins/supervisor/plugin-supervisor.ts
@@ -1,7 +1,7 @@
 import { spawn, type ChildProcess } from 'child_process';
 import { createServer, type Server, type Socket } from 'net';
 import { randomBytes } from 'crypto';
-import { chmodSync, chownSync, mkdirSync, readdirSync, unlinkSync } from 'fs';
+import { chmodSync, chownSync, mkdirSync, readdirSync, readFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { getPluginsSocketDir } from '../../../common/constants/paths';
 import type { OnApplicationShutdown } from '@nestjs/common';
@@ -23,6 +23,7 @@ import {
 } from '../../../common/plugin-contract';
 import { RpcChannel } from './rpc-channel';
 import { NoteRingBuffer } from './note-ring-buffer';
+import { LatencyWindow } from './latency-window';
 import {
   buildSpawnPlan,
   prepareDirForDroppedChild,
@@ -43,6 +44,17 @@ export type SupervisorState =
   | 'failed';
 
 const STDERR_TAIL_BYTES = 4 * 1024;
+
+export interface ProcessPluginMetrics {
+  hostCallCount: number;
+  hostCallFailureCount: number;
+  /** p95 over the most recent host calls (see `LatencyWindow`); null with no calls yet. */
+  hostCallP95Ms: number | null;
+  restartCount: number;
+  eventDropCount: number;
+  /** Null when unreadable: off Linux, or the child isn't up. Never a silent zero. */
+  residentSetSizeBytes: number | null;
+}
 
 /**
  * Host methods whose own work is not a lookup. `library.ingest` copies the release into the
@@ -177,6 +189,10 @@ export class PluginSupervisor implements OnApplicationShutdown {
   private readonly ring = new NoteRingBuffer();
   private ringBackpressured = false;
 
+  private hostCallCount = 0;
+  private hostCallFailureCount = 0;
+  private readonly hostCallLatencies = new LatencyWindow();
+
   private logWindowStart = Date.now();
   private logBytesThisMinute = 0;
   private logSuppressedThisWindow = false;
@@ -228,6 +244,32 @@ export class PluginSupervisor implements OnApplicationShutdown {
   }
   getSocketPaths(): { coreSockPath: string; pluginSockPath: string } {
     return { coreSockPath: this.coreSockPath, pluginSockPath: this.pluginSockPath };
+  }
+
+  /** One snapshot of this plugin's own counters, computed on request rather than polled. */
+  getMetrics(): ProcessPluginMetrics {
+    return {
+      hostCallCount: this.hostCallCount,
+      hostCallFailureCount: this.hostCallFailureCount,
+      hostCallP95Ms: this.hostCallLatencies.p95(),
+      restartCount: this.totalCrashes,
+      eventDropCount: this.ring.dropped,
+      residentSetSizeBytes: this.getResidentSetSizeBytes(),
+    };
+  }
+
+  /** `VmRSS` from `/proc/<pid>/status`: world-readable unlike `environ`, so no CAP_SYS_PTRACE, and
+   *  it states its own unit — `statm` would need this host's page size, which is not always 4 KiB. */
+  private getResidentSetSizeBytes(): number | null {
+    if (process.platform !== 'linux') return null;
+    const pid = this.child?.pid;
+    if (!pid) return null;
+    try {
+      const match = /^VmRSS:\s+(\d+) kB$/m.exec(readFileSync(`/proc/${pid}/status`, 'utf8'));
+      return match ? Number(match[1]) * 1024 : null;
+    } catch {
+      return null;
+    }
   }
 
   /** Thin public wrapper around the private RPC channel, for the HTTP proxy. Rejects
@@ -397,13 +439,31 @@ export class PluginSupervisor implements OnApplicationShutdown {
    *  `hostCallTimeoutMs` both reject, so `RpcChannel` answers with an error frame
    *  instead of leaving the plugin's own 10s client to time out. */
   private dispatchHostCall(method: string, payload: unknown): Promise<unknown> {
+    const startedAt = performance.now();
     const api = this.opts.hostApi as Record<string, (p: unknown) => Promise<unknown>> | null;
     const fn = api?.[method];
-    if (!fn) return Promise.reject(new Error(`unknown host method "${method}"`));
     // Promise.resolve().then(...) folds a synchronous throw from `fn` into the same
     // rejection path as an async one, so both answer with an error frame, never crash.
     const deadlineMs = HOST_CALL_DEADLINE_OVERRIDES_MS[method] ?? this.opts.hostCallTimeoutMs;
-    return withDeadline(Promise.resolve().then(() => fn(payload)), deadlineMs, method);
+    const call = fn
+      ? withDeadline(Promise.resolve().then(() => fn(payload)), deadlineMs, method)
+      : Promise.reject(new Error(`unknown host method "${method}"`));
+    return call.then(
+      (result) => {
+        this.recordHostCall(performance.now() - startedAt, false);
+        return result;
+      },
+      (err: unknown) => {
+        this.recordHostCall(performance.now() - startedAt, true);
+        return Promise.reject(err);
+      },
+    );
+  }
+
+  private recordHostCall(durationMs: number, failed: boolean): void {
+    this.hostCallCount++;
+    if (failed) this.hostCallFailureCount++;
+    this.hostCallLatencies.push(durationMs);
   }
 
   private onPluginConnected(socket: Socket): void {

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2100,6 +2100,17 @@
       "disabled_toast": "Plugin disabled.",
       "enable_failed_but_kept": "\"{{id}}\" is enabled but could not start: {{reason}}",
       "toggle_error": "Unable to update the plugin state.",
+      "metrics": {
+        "toggle": "Metrics",
+        "host_calls": "Host calls",
+        "failed": "failed",
+        "p95": "p95 latency",
+        "restarts": "Restarts",
+        "event_drops": "Event drops",
+        "memory": "Memory (RSS)",
+        "unavailable": "Unavailable",
+        "not_applicable": "Not applicable — this plugin has no running process."
+      },
       "trust": {
         "official": "Official",
         "verified": "Verified — {{key}}",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2127,6 +2127,17 @@
       "disabled_toast": "Plugin disabled.",
       "enable_failed_but_kept": "\"{{id}}\" is enabled but could not start: {{reason}}",
       "toggle_error": "Unable to update the plugin state.",
+      "metrics": {
+        "toggle": "Metrics",
+        "host_calls": "Host calls",
+        "failed": "failed",
+        "p95": "p95 latency",
+        "restarts": "Restarts",
+        "event_drops": "Event drops",
+        "memory": "Memory (RSS)",
+        "unavailable": "Unavailable",
+        "not_applicable": "Not applicable — this plugin has no running process."
+      },
       "trust": {
         "official": "Official",
         "verified": "Verified — {{key}}",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2100,6 +2100,17 @@
       "disabled_toast": "Plugin disabled.",
       "enable_failed_but_kept": "\"{{id}}\" is enabled but could not start: {{reason}}",
       "toggle_error": "Unable to update the plugin state.",
+      "metrics": {
+        "toggle": "Metrics",
+        "host_calls": "Host calls",
+        "failed": "failed",
+        "p95": "p95 latency",
+        "restarts": "Restarts",
+        "event_drops": "Event drops",
+        "memory": "Memory (RSS)",
+        "unavailable": "Unavailable",
+        "not_applicable": "Not applicable — this plugin has no running process."
+      },
       "trust": {
         "official": "Official",
         "verified": "Verified — {{key}}",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2127,6 +2127,17 @@
       "disabled_toast": "Plugin désactivé.",
       "enable_failed_but_kept": "« {{id}} » est activé mais n'a pas pu démarrer : {{reason}}",
       "toggle_error": "Impossible de mettre à jour l'état du plugin.",
+      "metrics": {
+        "toggle": "Métriques",
+        "host_calls": "Appels hôte",
+        "failed": "en échec",
+        "p95": "Latence p95",
+        "restarts": "Redémarrages",
+        "event_drops": "Événements perdus",
+        "memory": "Mémoire (RSS)",
+        "unavailable": "Indisponible",
+        "not_applicable": "Non applicable — ce plugin n'a pas de processus en cours d'exécution."
+      },
       "trust": {
         "official": "Officiel",
         "verified": "Vérifié — {{key}}",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2100,6 +2100,17 @@
       "disabled_toast": "Plugin disabled.",
       "enable_failed_but_kept": "\"{{id}}\" is enabled but could not start: {{reason}}",
       "toggle_error": "Unable to update the plugin state.",
+      "metrics": {
+        "toggle": "Metrics",
+        "host_calls": "Host calls",
+        "failed": "failed",
+        "p95": "p95 latency",
+        "restarts": "Restarts",
+        "event_drops": "Event drops",
+        "memory": "Memory (RSS)",
+        "unavailable": "Unavailable",
+        "not_applicable": "Not applicable — this plugin has no running process."
+      },
       "trust": {
         "official": "Official",
         "verified": "Verified — {{key}}",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2100,6 +2100,17 @@
       "disabled_toast": "Plugin disabled.",
       "enable_failed_but_kept": "\"{{id}}\" is enabled but could not start: {{reason}}",
       "toggle_error": "Unable to update the plugin state.",
+      "metrics": {
+        "toggle": "Metrics",
+        "host_calls": "Host calls",
+        "failed": "failed",
+        "p95": "p95 latency",
+        "restarts": "Restarts",
+        "event_drops": "Event drops",
+        "memory": "Memory (RSS)",
+        "unavailable": "Unavailable",
+        "not_applicable": "Not applicable — this plugin has no running process."
+      },
       "trust": {
         "official": "Official",
         "verified": "Verified — {{key}}",

--- a/client/src/app/core/services/api/plugins-api.service.ts
+++ b/client/src/app/core/services/api/plugins-api.service.ts
@@ -24,6 +24,24 @@ export interface PluginSummary {
   statusMessage?: string;
 }
 
+/** Mirrors backend `ProcessPluginMetrics` (`supervisor/plugin-supervisor.ts`). */
+export interface ProcessPluginMetrics {
+  hostCallCount: number;
+  hostCallFailureCount: number;
+  hostCallP95Ms: number | null;
+  restartCount: number;
+  eventDropCount: number;
+  residentSetSizeBytes: number | null;
+}
+
+/** Mirrors backend `PluginMetricsEntry` (`plugins.controller.ts`). `metrics` is null for a `data`
+ *  plugin, or a `process` plugin that isn't running. */
+export interface PluginMetricsEntry {
+  pluginId: string;
+  kind: PluginKind;
+  metrics: ProcessPluginMetrics | null;
+}
+
 /** Mirrors backend `PluginInspectReport`. A refusal carries `refusalCode`/`detail` and nothing else. */
 export interface PluginInspectReport {
   installable: boolean;
@@ -99,6 +117,10 @@ export class PluginsApiService {
 
   list() {
     return firstValueFrom(this.http.get<PluginSummary[]>('/api/plugins'));
+  }
+
+  metrics() {
+    return firstValueFrom(this.http.get<PluginMetricsEntry[]>('/api/plugins/metrics'));
   }
 
   inspect(file: File) {

--- a/client/src/app/features/settings/plugins/plugin-metrics-panel/plugin-metrics-panel.html
+++ b/client/src/app/features/settings/plugins/plugin-metrics-panel/plugin-metrics-panel.html
@@ -1,0 +1,20 @@
+@if (entry().metrics; as m) {
+  <dl class="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+    <dt class="text-base-content/60">{{ 'settings.plugins.metrics.host_calls' | translate }}</dt>
+    <dd>{{ m.hostCallCount }} ({{ m.hostCallFailureCount }} {{ 'settings.plugins.metrics.failed' | translate }})</dd>
+
+    <dt class="text-base-content/60">{{ 'settings.plugins.metrics.p95' | translate }}</dt>
+    <dd>{{ m.hostCallP95Ms !== null ? (m.hostCallP95Ms + ' ms') : ('settings.plugins.metrics.unavailable' | translate) }}</dd>
+
+    <dt class="text-base-content/60">{{ 'settings.plugins.metrics.restarts' | translate }}</dt>
+    <dd>{{ m.restartCount }}</dd>
+
+    <dt class="text-base-content/60">{{ 'settings.plugins.metrics.event_drops' | translate }}</dt>
+    <dd>{{ m.eventDropCount }}</dd>
+
+    <dt class="text-base-content/60">{{ 'settings.plugins.metrics.memory' | translate }}</dt>
+    <dd>{{ m.residentSetSizeBytes !== null ? formatBytes(m.residentSetSizeBytes) : ('settings.plugins.metrics.unavailable' | translate) }}</dd>
+  </dl>
+} @else {
+  <p class="text-xs text-base-content/50">{{ 'settings.plugins.metrics.not_applicable' | translate }}</p>
+}

--- a/client/src/app/features/settings/plugins/plugin-metrics-panel/plugin-metrics-panel.spec.ts
+++ b/client/src/app/features/settings/plugins/plugin-metrics-panel/plugin-metrics-panel.spec.ts
@@ -1,0 +1,62 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { PluginMetricsPanelComponent } from './plugin-metrics-panel';
+import type { PluginMetricsEntry } from '../../../../core/services/api/plugins-api.service';
+
+function createComponent(entry: PluginMetricsEntry): ComponentFixture<PluginMetricsPanelComponent> {
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      provideTranslateService({
+        lang: 'en',
+        loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+      }),
+    ],
+  });
+  const fixture = TestBed.createComponent(PluginMetricsPanelComponent);
+  fixture.componentRef.setInput('entry', entry);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('PluginMetricsPanelComponent', () => {
+  it("renders a process plugin's host-call count, p95, restarts, event drops and RSS", () => {
+    const fixture = createComponent({
+      pluginId: 'fliks.download',
+      kind: 'process',
+      metrics: {
+        hostCallCount: 42,
+        hostCallFailureCount: 3,
+        hostCallP95Ms: 128,
+        restartCount: 2,
+        eventDropCount: 5,
+        residentSetSizeBytes: 89_915_392, // ~85.8 MB
+      },
+    });
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).toContain('42');
+    expect(text).toContain('3');
+    expect(text).toContain('128 ms');
+    expect(text).toContain('2');
+    expect(text).toContain('5');
+    expect(text).toContain('85.8 MB');
+    expect((fixture.nativeElement as HTMLElement).querySelector('dl')).not.toBeNull();
+  });
+
+  it('renders a data plugin (no supervisor) as not applicable, never as zeros', () => {
+    const fixture = createComponent({ pluginId: 'fliks.notify', kind: 'data', metrics: null });
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('dl')).toBeNull();
+    expect(el.textContent).toContain('settings.plugins.metrics.not_applicable');
+  });
+
+  it('renders a stopped process plugin (metrics null) as not applicable too', () => {
+    const fixture = createComponent({ pluginId: 'fliks.download', kind: 'process', metrics: null });
+
+    expect((fixture.nativeElement as HTMLElement).querySelector('dl')).toBeNull();
+  });
+});

--- a/client/src/app/features/settings/plugins/plugin-metrics-panel/plugin-metrics-panel.ts
+++ b/client/src/app/features/settings/plugins/plugin-metrics-panel/plugin-metrics-panel.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import type { PluginMetricsEntry } from '../../../../core/services/api/plugins-api.service';
+
+/** One plugin's row from `GET /plugins/metrics`. `entry().metrics` is null for a `data`
+ *  plugin or a `process` plugin that isn't running — rendered as "not applicable", never as zeros. */
+@Component({
+  selector: 'app-plugin-metrics-panel',
+  imports: [TranslateModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './plugin-metrics-panel.html',
+})
+export class PluginMetricsPanelComponent {
+  readonly entry = input.required<PluginMetricsEntry>();
+
+  /** Matches the MB formatting already used in `libraries.ts` / `streaming.ts`. */
+  formatBytes(bytes: number): string {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+}

--- a/client/src/app/features/settings/plugins/plugins.html
+++ b/client/src/app/features/settings/plugins/plugins.html
@@ -41,7 +41,7 @@
     <p class="text-center py-12 text-base-content/50">{{ 'settings.plugins.empty' | translate }}</p>
   } @else {
     <div class="overflow-x-auto rounded-lg border border-base-200">
-      <table class="table table-zebra table-sm">
+      <table class="table table-sm">
         <thead>
           <tr>
             <th>{{ 'settings.plugins.col_plugin' | translate }}</th>
@@ -86,7 +86,7 @@
                   <p class="text-xs text-error/80 mt-1 max-w-[16rem]">{{ row.statusReason }}</p>
                 }
                 @if (row.statusMessage) {
-                  <details class="mt-1">
+                  <details class="mt-1 status-message-details">
                     <summary class="text-xs text-warning/80 cursor-pointer select-none">
                       {{ 'settings.plugins.status_message_toggle' | translate }}
                     </summary>
@@ -109,6 +109,20 @@
                 </button>
               </td>
             </tr>
+            @if (row.kind === 'process') {
+            <tr>
+              <td colspan="7" class="pt-0">
+                <details class="metrics-details">
+                  <summary class="text-xs text-base-content/60 cursor-pointer select-none">
+                    {{ 'settings.plugins.metrics.toggle' | translate }}
+                  </summary>
+                  <div class="mt-1">
+                    <app-plugin-metrics-panel [entry]="metricsEntryFor(row)" />
+                  </div>
+                </details>
+              </td>
+            </tr>
+            }
           }
         </tbody>
       </table>

--- a/client/src/app/features/settings/plugins/plugins.spec.ts
+++ b/client/src/app/features/settings/plugins/plugins.spec.ts
@@ -50,6 +50,8 @@ async function createComponent(rows: PluginSummary[] = [ROW]) {
   http.expectOne({ url: '/api/plugins', method: 'GET' }).flush(rows);
   http.expectOne({ url: '/api/plugins/sources', method: 'GET' }).flush([]);
   await settle(fixture);
+  http.expectOne({ url: '/api/plugins/metrics', method: 'GET' }).flush(rows.map((r) => ({ pluginId: r.pluginId, kind: r.kind, metrics: null })));
+  await settle(fixture);
   return { fixture, http };
 }
 
@@ -106,6 +108,8 @@ describe('PluginsSettingsComponent — enable/disable toggle', () => {
     await settle(fixture);
     http.expectOne({ url: '/api/plugins', method: 'GET' }).flush([]);
     await settle(fixture);
+    http.expectOne({ url: '/api/plugins/metrics', method: 'GET' }).flush([]);
+    await settle(fixture);
 
     // Without this the pages stay linked in the admin sidebar until a full page load.
     http.expectOne({ url: '/api/plugins/ui', method: 'GET' }).flush([]);
@@ -141,9 +145,9 @@ describe('PluginsSettingsComponent — enable/disable toggle', () => {
     expect(pre?.textContent).toContain('bad hello token');
   });
 
-  it('a row with no statusMessage renders no details toggle', async () => {
+  it('a row with no statusMessage renders no status-message details toggle', async () => {
     const { fixture } = await createComponent([{ ...ROW, statusMessage: '' }]);
 
-    expect((fixture.nativeElement as HTMLElement).querySelector('tbody details')).toBeNull();
+    expect((fixture.nativeElement as HTMLElement).querySelector('tbody details.status-message-details')).toBeNull();
   });
 });

--- a/client/src/app/features/settings/plugins/plugins.ts
+++ b/client/src/app/features/settings/plugins/plugins.ts
@@ -20,9 +20,11 @@ import {
   PluginSummary,
   PluginInspectReport,
   PluginInstallResult,
+  PluginMetricsEntry,
 } from '../../../core/services/api/plugins-api.service';
 import { PluginInstallConsentComponent } from './plugin-install-consent/plugin-install-consent';
 import { PluginSourcesComponent } from './plugin-sources/plugin-sources';
+import { PluginMetricsPanelComponent } from './plugin-metrics-panel/plugin-metrics-panel';
 import { trustBadgeFor } from './plugin-trust';
 
 @Component({
@@ -35,6 +37,7 @@ import { trustBadgeFor } from './plugin-trust';
     ToggleFieldComponent,
     PluginInstallConsentComponent,
     PluginSourcesComponent,
+    PluginMetricsPanelComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './plugins.html',
@@ -51,6 +54,7 @@ export class PluginsSettingsComponent implements OnInit {
   private readonly sourcesDialog = viewChild<PluginSourcesComponent>('sourcesDialog');
 
   readonly rows = signal<PluginSummary[]>([]);
+  readonly metricsByPluginId = signal<Map<string, PluginMetricsEntry>>(new Map());
   readonly loading = signal(true);
   readonly listError = signal('');
   readonly uploading = signal(false);
@@ -72,6 +76,17 @@ export class PluginsSettingsComponent implements OnInit {
     } finally {
       this.loading.set(false);
     }
+    // Best-effort: a metrics fetch failure never blocks the row list above it depends on.
+    try {
+      const entries = await this.api.metrics();
+      this.metricsByPluginId.set(new Map(entries.map((e) => [e.pluginId, e])));
+    } catch {
+      this.metricsByPluginId.set(new Map());
+    }
+  }
+
+  metricsEntryFor(row: PluginSummary): PluginMetricsEntry {
+    return this.metricsByPluginId().get(row.pluginId) ?? { pluginId: row.pluginId, kind: row.kind, metrics: null };
   }
 
   logoUrl(pluginId: string): string {

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -274,6 +274,23 @@ read at delivery. Either way core checks https, refuses an internal address, and
 every attempt, because a name that passed at install can be repointed afterwards. Delivery is
 at-most-once with no retry; a plugin that needs retries is `process` and does its own.
 
+## Metrics
+
+`GET /plugins/metrics` (admin-gated the same way as the rest of `/plugins`) answers one entry per
+installed plugin: `{ pluginId, kind, metrics }`. `metrics` is `null` for a `data` plugin — it has no
+supervisor — and for a `process` plugin that isn't currently running: never a row of zeros that
+reads like a healthy process. For a running `process` plugin it carries:
+
+- `hostCallCount` / `hostCallFailureCount` — every inbound call across the plugin's 15 host
+  methods, counted once in `dispatchHostCall`, the single funnel all of them share.
+- `hostCallP95Ms` — p95 duration over the most recent 256 host calls, not a time window, so a
+  plugin that has been up for weeks still reports a bounded, recent figure. `null` before the first call.
+- `restartCount` — crash-triggered respawns since this plugin's supervisor last started.
+- `eventDropCount` — notes core could not deliver because the outbound ring to this plugin was full.
+- `residentSetSizeBytes` — the child's resident memory, read from `/proc/<pid>/statm` when the
+  endpoint is called, not polled in the background. `null`, never `0`, off Linux or if the child
+  isn't up — a gauge that always silently reads zero is worse than one that admits it can't answer.
+
 ## Trust and installation
 
 An archive is a ZIP with a closed set of legal entry names, size caps, and an Ed25519 signature


### PR DESCRIPTION
## Why

An operator running several process plugins has no way to tell which one is spending the host's
time or memory. A plugin that hammers a host method, or leaks, shows up only as a slow Fliks.

The supervisor already holds everything needed to answer this — it brokers every host call and owns
the child pid — but kept none of it.

## What

- Per-supervisor counters: host calls, host-call failures, restarts, dropped events.
- A 256-sample ring buffer for host-call latency, nearest-rank p95. Fixed size because these
  processes run for weeks; an unbounded array is not an option.
- Child resident size from `VmRSS:` in `/proc/<pid>/status`.
- `GET /plugins/metrics`, behind the same `Settings`-read policy as the plugin list.
- A per-plugin metrics disclosure in the settings table, translated into all six locales.

## Choices worth naming

**`VmRSS` from `status`, not `statm`.** `statm` reports pages, so reading it means hardcoding a page
size — 4 KiB is wrong on 16K/64K-page arm64 kernels, and the resulting number would be wrong by 4x
or 16x with no symptom. `status` states its own unit and is world-readable without
`CAP_SYS_PTRACE`, which matters now that each plugin runs under its own uid.

**`performance.now()` for latency samples.** A wall clock can step (NTP, suspend) under a call that
is in flight; one such sample poisons the p95 for the next 256 calls.

**Zebra striping dropped from the plugin table.** A plugin now occupies two rows, so alternating
backgrounds were splitting the pair rather than separating plugins.

## Verification

- `tsc --noEmit` exit 0, backend and client.
- Backend `src/modules/plugins`: 52 suites, 789 tests, exit 0. Client: 49 files, 411 tests, exit 0.
- Every new assertion mutation-checked — break the line, confirm the failure, restore:
  - RSS read against `VmSize` instead of `VmRSS` → fails (687612 vs `< 19784`).
  - RSS `kB`→bytes conversion dropped → fails.
  - `metricsOf`'s `?? null` removed → fails on `undefined`.
  - A route's policy subject changed `Settings`→`Media` → fails (the fakes are now subject-aware,
    so a route re-pointed at the wrong subject can no longer pass).
  - p95 rounding removed → fails on the raw float.
- Live on the running stack, not a `docker cp`: after a backend restart all three installed plugins
  report `active`/`ready`, and the endpoint's RSS matches the kernel to the byte —
  `57114624` reported vs `VmRSS: 55776 kB` (= 57114624), `46526464` vs `45436 kB` (= 46526464).
  The `data` plugin reports `metrics: null`. Host-call counting confirmed live: `fliks.download`
  reported `calls=3 fail=0 p95=295.9`.

Refs: #894