### PR TITLE
feat(plugins): ship a scaffold that starts, and say what an archive can hold

### DIFF
--- a/backend/src/common/plugin-contract/README.md
+++ b/backend/src/common/plugin-contract/README.md
@@ -8,19 +8,31 @@ not put anything of core inside your plugin.
 npm install --save-dev @fliks/plugin-contract
 ```
 
-## Two entry points
+## Entry points
 
 ```ts
-import type { ProcessPluginManifest, HostMethod } from '@fliks/plugin-contract';
-import { PLUGIN_API_VERSION, PLUGIN_DEADLINES_MS } from '@fliks/plugin-contract';
+// Types — erased at build time, so the barrel costs nothing.
+import type { ProcessPluginManifest, PluginApi } from '@fliks/plugin-contract';
 
-// UI contributions alone — no dependencies, safe in a browser bundle.
+// Runtime values — import the leaf.
+import { MAX_FRAME_BYTES, PLUGIN_DEADLINES_MS } from '@fliks/plugin-contract/protocol';
+
+// UI contributions alone. No dependencies, safe in a browser bundle.
 import type { ConfigPage, UiContribution } from '@fliks/plugin-contract/ui';
 ```
 
-The root export covers the manifest, both method tables, the principal, the wire protocol and the
-UI contributions. `semver` is an optional peer dependency, needed only if you call the version
-helpers in `protocol`.
+| Specifier | |
+|---|---|
+| `@fliks/plugin-contract` | Everything: manifest, both method tables, principal, protocol, UI. |
+| `@fliks/plugin-contract/protocol` | Wire constants and frame types. Zero dependencies. |
+| `@fliks/plugin-contract/ui` | UI contributions. Zero dependencies. |
+
+The barrel also re-exports `fliksRangeVersion`, the one helper that needs `semver` — an optional
+peer dependency. Take a runtime value from the barrel and your bundler cannot drop it, which is why
+values come from a leaf.
+
+A `process` plugin ships as a single bundled `plugin.js`: an archive carries no `node_modules`, so
+an unbundled `require` of this package fails at spawn. See `examples/plugin-scaffold`.
 
 ## Versioning
 

--- a/backend/src/common/plugin-contract/fliks-range.ts
+++ b/backend/src/common/plugin-contract/fliks-range.ts
@@ -1,0 +1,11 @@
+import * as semver from 'semver';
+
+/**
+ * The version a `fliks` range is matched against: a prerelease resolves as its own release, since
+ * `3.0.0-rc.1` sorts *below* `3.0.0` and would otherwise satisfy no range that admits 3.0.0 —
+ * leaving a release candidate unable to run any plugin, and the upgrade impossible to rehearse.
+ */
+export function fliksRangeVersion(version: string): string {
+  const parsed = semver.parse(version);
+  return parsed ? `${parsed.major}.${parsed.minor}.${parsed.patch}` : version;
+}

--- a/backend/src/common/plugin-contract/index.ts
+++ b/backend/src/common/plugin-contract/index.ts
@@ -1,6 +1,7 @@
 /** Public surface of the plugin contract. Types and constants only — no runtime wiring. */
 
 export * from './protocol';
+export * from './fliks-range';
 export * from './principal';
 export * from './host-methods';
 export * from './plugin-methods';

--- a/backend/src/common/plugin-contract/package.json
+++ b/backend/src/common/plugin-contract/package.json
@@ -11,7 +11,8 @@
   "types": "./index.ts",
   "exports": {
     ".": "./index.ts",
-    "./ui": "./ui-contribution.ts"
+    "./ui": "./ui-contribution.ts",
+    "./protocol": "./protocol.ts"
   },
   "peerDependencies": {
     "semver": ">=7"

--- a/backend/src/common/plugin-contract/protocol.ts
+++ b/backend/src/common/plugin-contract/protocol.ts
@@ -1,4 +1,3 @@
-import * as semver from 'semver';
 /**
  * Wire protocol for the two unix sockets between core and a `process`
  * plugin: newline-delimited JSON, one object per line.
@@ -43,16 +42,6 @@ export const PLUGIN_API_VERSION = 1;
 export const SUPPORTED_PLUGIN_API_VERSIONS: readonly number[] = [0, 1];
 
 /**
- * The version a `fliks` range is matched against: a prerelease resolves as its own release, since
- * `3.0.0-rc.1` sorts *below* `3.0.0` and would otherwise satisfy no range that admits 3.0.0 —
- * leaving a release candidate unable to run any plugin, and the upgrade impossible to rehearse.
- */
-export function fliksRangeVersion(version: string): string {
-  const parsed = semver.parse(version);
-  return parsed ? `${parsed.major}.${parsed.minor}.${parsed.patch}` : version;
-}
-
-/**
  * Environment core sets on every spawn (see `supervisor/spawn-plan.ts`) — the only way in
  * for a `process` plugin, since core never passes `...process.env`. Every value here is a
  * plain string; only `FLIKS_API_VERSION` has a typed counterpart ({@link PLUGIN_API_VERSION}).
@@ -63,8 +52,9 @@ export interface PluginSpawnEnv {
   FLIKS_PLUGIN_TOKEN: string;
   /** Unix socket this plugin dials to make its `PluginHostApi` calls. */
   FLIKS_CORE_SOCK: string;
-  /** Unix socket this plugin listens on for core's `PluginApi` calls
-   *  (`hello`, `health`, `http`, `job`, `event`, `config`, `shutdown`). */
+  /** Unix socket this plugin dials to *receive* core's `PluginApi` calls
+   *  (`hello`, `health`, `http`, `job`, `event`, `config`, `shutdown`). Core listens on both
+   *  sockets; the plugin connects to both and never binds one of its own. */
   FLIKS_PLUGIN_SOCK: string;
   /** This plugin's own Postgres connection string; `''` when its manifest declared no schema. */
   FLIKS_DB_URL: string;

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -159,8 +159,12 @@ are what a browser bundle wants.
 The client consumes the same files through a tsconfig path mapping, so there is one declaration of
 each type in the tree and nothing to keep in sync.
 
-`fk-plugin-download` is the reference `process` plugin — a working implementation of everything
-in this section, with `src/plugin.ts` answering all 7 core-initiated methods.
+`examples/plugin-scaffold/` is the starting point: a `process` plugin that starts, answers all 7
+methods, serves a route and reads its own settings, under MIT. Its README carries the dev loop and
+the mistakes core refuses by name. `fk-plugin-download` is the full reference implementation.
+
+A `process` plugin ships as **one bundled `plugin.js`** — an archive carries no `node_modules`, so
+an unbundled `require` of any package, this one included, fails at spawn with `MODULE_NOT_FOUND`.
 
 ### Environment
 

--- a/examples/plugin-scaffold/.gitignore
+++ b/examples/plugin-scaffold/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.fkplugin

--- a/examples/plugin-scaffold/LICENSE
+++ b/examples/plugin-scaffold/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Fliks contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/plugin-scaffold/README.md
+++ b/examples/plugin-scaffold/README.md
@@ -1,0 +1,73 @@
+# Fliks plugin scaffold
+
+A `process` plugin that starts, answers all 7 methods core calls, serves one route and reads its
+own settings. MIT — copy it out and change the id.
+
+## The one thing that decides your build
+
+**An archive may contain only `plugin.json`, `plugin.js`, `logo.svg`/`logo.png` and
+`plugin.json.sig`.** There is no `node_modules` in a plugin, so `plugin.js` has to be a bundle.
+This scaffold uses esbuild; any bundler works. A plugin that `require`s a package at runtime dies
+at spawn with `MODULE_NOT_FOUND` and shows up as `spawn-failed`.
+
+The same rule decides how to import the contract:
+
+```ts
+import type { PluginApi, PluginManifest } from '@fliks/plugin-contract';        // types: free
+import { MAX_FRAME_BYTES } from '@fliks/plugin-contract/protocol';              // values: leaf only
+```
+
+Types are erased, so the barrel is fine for them. For *values*, import the leaf — the barrel also
+re-exports the one helper that needs `semver`, and pulling it in takes the bundle from 4 KB to
+72 KB for constants you could have inlined.
+
+## Dev loop
+
+```bash
+npm install
+npm run typecheck        # tsc --noEmit
+npm run package          # bundle → dist/, then core's packaging tool → scaffold.fkplugin
+```
+
+Then install `scaffold.fkplugin` through **Settings → Plugins → Import**. Unsigned archives are
+refused unless the core process allowlists the id:
+
+```
+FLIKS_UNSIGNED_PLUGINS=example.scaffold
+```
+
+On Docker that is an `env_file` value, which is read when the container is *created* — a
+`docker compose restart` will not pick it up, `docker compose up -d --force-recreate backend` will.
+
+Reinstalling the same id replaces the running plugin; there is no need to uninstall first.
+
+## What is in here
+
+| File | |
+|---|---|
+| `plugin.json` | The manifest. `files` is left empty — the packaging tool computes every hash, and a hand-written one is refused. |
+| `src/plugin.ts` | Line framing, the uplink, and the 7 methods. About 100 lines. |
+
+Both sockets are **dialled**, not listened on: core listens on both and the plugin connects to each.
+
+`hello` must echo `FLIKS_PLUGIN_TOKEN` back. A wrong token is treated as an impostor on the socket
+and the process is killed immediately.
+
+`event` and `config` are notes — they carry no `i` and core accepts no reply for them. Every other
+method must answer within the deadline core publishes in `PLUGIN_DEADLINES_MS`.
+
+## Things the manifest will reject
+
+Core answers with a `reason` and a `detail` naming the field, visible on the plugin row:
+
+- `scopes` must come from the closed set (`media:read`, `acquisition:candidates`, `releases:score`,
+  `requests:progress`, `ingest:write`, `events:emit`, `config:rw`) and may not be empty.
+- A route `policy` is `action:subject`, in that order — `read:Settings`, not `Settings:read`.
+- `i18n` keys must share a single root, and no key may be a prefix of another.
+- `fliks` needs an upper bound: `">=2.0.0 <3.0.0"`, never `">=2.0.0"`.
+
+## Logging and failure
+
+Write to stderr. Core tags each line with your plugin id, buffers it, and shows the tail on the
+plugin row when the process is down — so a stack trace at startup is visible in the admin UI
+without touching container logs. The cap is 64 KB/min; past that, lines are dropped.

--- a/examples/plugin-scaffold/logo.svg
+++ b/examples/plugin-scaffold/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2"/></svg>

--- a/examples/plugin-scaffold/package-lock.json
+++ b/examples/plugin-scaffold/package-lock.json
@@ -1,0 +1,553 @@
+{
+  "name": "fliks-plugin-scaffold",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fliks-plugin-scaffold",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@fliks/plugin-contract": "file:../../backend/src/common/plugin-contract"
+      },
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "esbuild": "^0.25.0",
+        "typescript": "^5.6.0"
+      }
+    },
+    "../../backend/src/common/plugin-contract": {
+      "name": "@fliks/plugin-contract",
+      "version": "1.0.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "semver": ">=7"
+      },
+      "peerDependenciesMeta": {
+        "semver": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fliks/plugin-contract": {
+      "resolved": "../../backend/src/common/plugin-contract",
+      "link": true
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/examples/plugin-scaffold/package.json
+++ b/examples/plugin-scaffold/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "fliks-plugin-scaffold",
+  "version": "0.1.0",
+  "private": true,
+  "license": "MIT",
+  "scripts": {
+    "build": "esbuild src/plugin.ts --bundle --platform=node --target=node24 --outfile=dist/plugin.js",
+    "package": "npm run build && cp plugin.json logo.svg dist/ && node ../../backend/node_modules/.bin/ts-node ../../backend/scripts/package-plugin.ts dist -o scaffold.fkplugin",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@fliks/plugin-contract": "file:../../backend/src/common/plugin-contract"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "^5.6.0",
+    "esbuild": "^0.25.0"
+  }
+}

--- a/examples/plugin-scaffold/plugin.json
+++ b/examples/plugin-scaffold/plugin.json
@@ -1,0 +1,25 @@
+{
+  "id": "example.scaffold",
+  "pluginApi": 1,
+  "name": "Scaffold",
+  "version": "0.1.0",
+  "fliks": ">=2.0.0 <3.0.0",
+  "author": "you",
+  "description": "Starting point for a Fliks process plugin",
+  "license": "MIT",
+  "logo": "logo.svg",
+  "kind": "process",
+  "runtime": "node",
+  "memoryMb": 128,
+  "files": {},
+  "database": { "schema": false, "coreRefs": [] },
+  "routes": [{ "method": "GET", "path": "/ping", "policy": "read:Settings" }],
+  "scopes": ["config:rw"],
+  "ingestRoots": [],
+  "ui": {
+    "configPages": [
+      { "kind": "form", "id": "main", "labelKey": "scaffold.settings", "fields": [] }
+    ]
+  },
+  "i18n": { "en": { "scaffold.settings": "Scaffold" } }
+}

--- a/examples/plugin-scaffold/src/plugin.ts
+++ b/examples/plugin-scaffold/src/plugin.ts
@@ -1,0 +1,110 @@
+import { connect, type Socket } from 'net';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import type { PluginApi, PluginManifest } from '@fliks/plugin-contract';
+// Runtime values come from the leaf, not the barrel: the barrel re-exports the one helper that
+// needs semver, and a bundler cannot drop a CJS dependency it has already been asked to evaluate.
+import { MAX_FRAME_BYTES, type Req, type Res } from '@fliks/plugin-contract/protocol';
+
+const env = process.env;
+const manifest = JSON.parse(readFileSync(join(__dirname, 'plugin.json'), 'utf8')) as PluginManifest;
+
+/** Newline-delimited JSON, one object per line. Core listens on both sockets; this dials them. */
+function dial(path: string, onFrame: (sock: Socket, frame: Req) => void): Socket {
+  const sock = connect(path);
+  let buffered = '';
+  sock.on('data', (chunk) => {
+    buffered += chunk.toString('utf8');
+    let cut: number;
+    while ((cut = buffered.indexOf('\n')) !== -1) {
+      const line = buffered.slice(0, cut);
+      buffered = buffered.slice(cut + 1);
+      if (line.length === 0) continue;
+      try {
+        onFrame(sock, JSON.parse(line) as Req);
+      } catch {
+        // A frame core sent that this plugin cannot parse: skip it, stay up for the next one.
+      }
+    }
+  });
+  sock.on('error', (err) => process.stderr.write(`socket ${path}: ${err.message}\n`));
+  return sock;
+}
+
+function reply(sock: Socket, res: Res): void {
+  const line = `${JSON.stringify(res)}\n`;
+  // Core SIGKILLs on an oversize frame, so refuse to be the one that sends it.
+  if (Buffer.byteLength(line) > MAX_FRAME_BYTES) {
+    reply(sock, { i: res.i, e: { c: 'RESPONSE_TOO_LARGE', m: 'reply exceeded the frame limit' } });
+    return;
+  }
+  sock.write(line);
+}
+
+/** The uplink. Requests core's host methods; ids must be unique per connection. */
+const core = dial(env.FLIKS_CORE_SOCK!, (_sock, frame) => {
+  const settle = pending.get((frame as unknown as Res).i);
+  if (!settle) return;
+  pending.delete((frame as unknown as Res).i);
+  settle(frame as unknown as Res);
+});
+
+const pending = new Map<number, (res: Res) => void>();
+let nextId = 1;
+
+export function callHost<T>(method: string, params?: unknown): Promise<T> {
+  const i = nextId++;
+  return new Promise<T>((resolve, reject) => {
+    pending.set(i, (res) => (res.e ? reject(new Error(`${res.e.c}: ${res.e.m}`)) : resolve(res.r as T)));
+    core.write(`${JSON.stringify({ i, m: method, p: params } satisfies Req)}\n`);
+  });
+}
+
+/**
+ * The 7 methods core calls. `event` and `config` are notes — replying to one is a protocol
+ * violation. Everything else must answer, and within the deadline core publishes for it.
+ */
+const api: PluginApi = {
+  hello: async () => ({ manifest, token: env.FLIKS_PLUGIN_TOKEN ?? '' }),
+
+  health: async () => ({ ok: true }),
+
+  job: async ({ name }) => {
+    // stderr is this plugin's log: core tags each line with the plugin id and buffers it.
+    const config = await callHost<Record<string, string>>('config.get', {});
+    process.stderr.write(`job ${name} ran with ${Object.keys(config).length} setting(s)\n`);
+    return { ok: true };
+  },
+
+  http: async ({ method, path }) => ({
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    body: { hello: `${method} ${path}` },
+  }),
+
+  event: () => {},
+
+  config: () => {},
+
+  shutdown: async () => {
+    setTimeout(() => process.exit(0), 10);
+    return { ok: true };
+  },
+};
+
+dial(env.FLIKS_PLUGIN_SOCK!, (sock, req) => {
+  const handler = api[req.m as keyof PluginApi] as ((p: unknown) => unknown) | undefined;
+  if (!handler) {
+    reply(sock, { i: req.i, e: { c: 'UNKNOWN_METHOD', m: req.m } });
+    return;
+  }
+  // A note carries no `i`; core sends no reply for it and accepts none.
+  if (req.i === undefined) {
+    handler(req.p);
+    return;
+  }
+  Promise.resolve(handler(req.p)).then(
+    (r) => reply(sock, { i: req.i, r }),
+    (err: Error) => reply(sock, { i: req.i, e: { c: 'PLUGIN_ERROR', m: err.message } }),
+  );
+});

--- a/examples/plugin-scaffold/tsconfig.json
+++ b/examples/plugin-scaffold/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node10",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Why

The documented starting point for a new plugin was a 4.5 kLOC reference implementation with
protocol and domain interleaved — you had to read all of it to find the ~100 lines that are the
protocol.

## What

`examples/plugin-scaffold/`, MIT, about 100 lines: line framing, the uplink, all 7 methods core
calls, one declared route, one host call. Copy it out, change the id.

Its README carries the dev loop and the refusals core issues by name — legal `scopes`, the
`action:subject` order in a route policy, the `i18n` single-root rule, the mandatory upper bound on
`fliks`.

## What building it surfaced

**An archive may hold only `plugin.json`, `plugin.js`, a logo and a signature.** There is no
`node_modules` in a plugin, so `plugin.js` must be a bundle, and any runtime `require` dies at spawn
with `MODULE_NOT_FOUND`. Nothing said so. The first version of this scaffold hit it — installed
through the real endpoints, it came back `spawn-failed` with that stack trace. Both READMEs and
`docs/plugins.md` now lead with the rule; the scaffold bundles with esbuild.

**Runtime values must come from a leaf, not the barrel.** The barrel re-exports `fliksRangeVersion`,
the one helper needing `semver`, and a bundler cannot drop a CJS dependency it was asked to
evaluate — importing `MAX_FRAME_BYTES` from the barrel took the bundle from 4 KB to 72 KB. That
helper moves to `fliks-range.ts`, `protocol.ts` becomes dependency-free and is exported as
`@fliks/plugin-contract/protocol`. Core imports through the barrel and is unaffected.

**The contract described the wrong socket direction.** `FLIKS_PLUGIN_SOCK` was documented as the
socket the plugin *listens on*. Core listens on both and the plugin dials both — an author
following that comment binds a socket nothing ever connects to.

## Verification

Installed on the running stack through `POST /api/plugins/import/inspect` then `/confirm`, not a
`docker cp`:

- `{"pluginId":"example.scaffold","version":"0.1.0","status":"active"}`, `processState: ready`.
- Its declared route answers through core's proxy:
  `GET /api/plugins/example.scaffold/ping` → `{"hello":"GET /ping"}`.
- `GET /plugins/metrics` reports it with a real RSS.
- Bundle after the leaf import: 3869 bytes, zero occurrences of `semver`.

The two failures along the way were the system correctly refusing bad input, and both are now
documented: `invalid-route-policy` for `Settings:read` instead of `read:Settings`, and the
`MODULE_NOT_FOUND` above.

Backend: 52 suites, 790 tests, exit 0. `tsc --noEmit` exit 0 on backend and client. The stack was
returned to its previous state — the scaffold uninstalled, `FLIKS_UNSIGNED_PLUGINS` restored, and
all three pre-existing plugins confirmed `active` afterwards.

Refs: #894