### PR TITLE
docs(plugins): note the contract mount a containerised client needs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -157,7 +157,17 @@ core at runtime. Two entry points: `@fliks/plugin-contract` for the whole surfac
 are what a browser bundle wants.
 
 The client consumes the same files through a tsconfig path mapping, so there is one declaration of
-each type in the tree and nothing to keep in sync.
+each type in the tree and nothing to keep in sync. That mapping points one level above `client/`, so
+anything that builds the client in a container has to bring the directory along — the image build
+copies it, and a dev container bind-mounting only `client/` needs the same:
+
+```yaml
+volumes:
+  - ./client:/app
+  - ./backend/src/common/plugin-contract:/backend/src/common/plugin-contract:ro
+```
+
+Without it the build stops at `TS2307: Cannot find module '@fliks/plugin-contract/ui'`.
 
 `examples/plugin-scaffold/` is the starting point: a `process` plugin that starts, answers all 7
 methods, serves a route and reads its own settings, under MIT. Its README carries the dev loop and


### PR DESCRIPTION
## Why

Since #992 the client resolves `@fliks/plugin-contract` through a tsconfig path mapping that points
one level above `client/`. The production image build copies the directory in, but a dev container
that bind-mounts only `client/` does not — and the failure reads as a missing module rather than a
missing mount:

```
✘ [ERROR] TS2307: Cannot find module '@fliks/plugin-contract/ui'
    src/app/shared/components/schema-form/schema-form.ts:4:71
```

Neither tracked compose file runs the client from source, so there was nothing to fix in the repo —
only somewhere to write it down.

## What

The volume line, next to where `docs/plugins.md` already explains the path mapping, plus the exact
error it prevents so a search lands on it.

Refs: #894