### PR TITLE
fix(client): stop replaying a stale SSE event and coalesce redundant refetches

### DIFF
--- a/client/src/app/features/media-detail/media-detail.sse-replay.spec.ts
+++ b/client/src/app/features/media-detail/media-detail.sse-replay.spec.ts
@@ -1,0 +1,132 @@
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { provideTranslateService, TranslateLoader } from '@ngx-translate/core';
+import { EMPTY, of } from 'rxjs';
+import { vi, afterEach, describe, it, expect } from 'vitest';
+import { MediaDetailComponent } from './media-detail';
+import { MediaService, Media } from '../../core/services/api/media.service';
+import { MediaDetailReleasePickerService } from './media-detail-release-picker.service';
+import { AuthService } from '../../core/services/auth.service';
+import { ProfilesService } from '../../core/services/api/profiles.service';
+import { LibrariesApiService } from '../../core/services/api/libraries-api.service';
+import { NavbarService } from '../../core/services/navbar.service';
+import { BackgroundService } from '../../core/services/background.service';
+import { StreamingApiService } from '../../core/services/api/streaming-api.service';
+import { MarkersApiService } from '../../core/services/api/markers-api.service';
+import { RequestsService } from '../../core/services/api/requests.service';
+import { ConfirmationService } from '../../core/services/confirmation.service';
+import { ToastService } from '../../core/services/toast.service';
+import { SseService, SseEvent } from '../../core/services/sse.service';
+import { DownloadManagerService } from '../../core/services/download-manager.service';
+import { DownloadProgressService } from '../../core/services/download-progress.service';
+import { TvService } from '../../core/services/tv.service';
+import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
+import { AddToPlaylistService } from '../../core/services/add-to-playlist.service';
+import { RecommendService } from '../../core/services/recommend.service';
+import { LikesApiService } from '../../core/services/api/likes-api.service';
+
+const MEDIA_ID = 42;
+
+const MOVIE: Media = {
+  id: MEDIA_ID,
+  title: 'Test Movie',
+  originalTitle: 'Test Movie',
+  year: 2024,
+  type: 'movie',
+  tmdbId: 1,
+  overview: '',
+  status: 'released',
+  monitored: true,
+  posterUrl: null,
+  fanartUrl: null,
+  logoUrl: null,
+  additionalFanartUrls: [],
+  rating: 0,
+  runtime: 100,
+  files: [],
+};
+
+/**
+ * Reproduces series -> episode navigation, which destroys and recreates
+ * MediaDetailComponent while the root-provided SseService keeps its last
+ * event: a fresh instance must treat that stale event as already handled.
+ */
+function createHarness(seedEvent: SseEvent | null) {
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      provideTranslateService({
+        lang: 'en',
+        loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+      }),
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          paramMap: EMPTY,
+          snapshot: { data: { kind: 'movie' }, paramMap: { get: () => null } },
+        },
+      },
+      { provide: Router, useValue: { navigate: vi.fn(), getCurrentNavigation: () => null } },
+      { provide: MediaService, useValue: { getOne: vi.fn(async () => MOVIE) } },
+      { provide: MediaDetailReleasePickerService, useValue: {} },
+      { provide: AuthService, useValue: { hasPermission: () => false } },
+      { provide: ProfilesService, useValue: {} },
+      { provide: LibrariesApiService, useValue: {} },
+      { provide: NavbarService, useValue: { enterHeroPage: vi.fn(), leaveHeroPage: vi.fn() } },
+      { provide: BackgroundService, useValue: { clear: vi.fn(), setBackgrounds: vi.fn() } },
+      { provide: ConfirmationService, useValue: {} },
+      { provide: ToastService, useValue: { success: vi.fn(), error: vi.fn() } },
+      { provide: SseService, useValue: { lastEvent: signal(seedEvent) } },
+      { provide: StreamingApiService, useValue: {} },
+      { provide: MarkersApiService, useValue: {} },
+      { provide: RequestsService, useValue: {} },
+      { provide: DownloadManagerService, useValue: {} },
+      { provide: DownloadProgressService, useValue: { progress: signal(new Map()) } },
+      { provide: TvService, useValue: { isTv: () => false } },
+      { provide: ScrollMemoryService, useValue: { activate: vi.fn(), deactivate: vi.fn(), restoreSticky: vi.fn() } },
+      { provide: AddToPlaylistService, useValue: {} },
+      { provide: RecommendService, useValue: {} },
+      { provide: LikesApiService, useValue: { state: vi.fn(async () => ({ media: false, seasonIds: [], episodeIds: [] })) } },
+    ],
+  });
+
+  // Template/child components are irrelevant to the SSE-guard logic under test.
+  TestBed.overrideComponent(MediaDetailComponent, { set: { template: '', imports: [] } });
+
+  const fixture = TestBed.createComponent(MediaDetailComponent);
+  const toast = TestBed.inject(ToastService) as unknown as { success: ReturnType<typeof vi.fn> };
+  const mediaService = TestBed.inject(MediaService) as unknown as { getOne: ReturnType<typeof vi.fn> };
+
+  fixture.detectChanges(); // runs ngOnInit + the initial effect pass
+
+  return { fixture, toast, mediaService };
+}
+
+describe('MediaDetailComponent — SSE replay across route-driven recreation', () => {
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('does not replay a metadata.refreshed event the service already retained before construction', () => {
+    const staleEvent: SseEvent = { type: 'metadata.refreshed', mediaId: MEDIA_ID };
+    const { fixture, toast, mediaService } = createHarness(staleEvent);
+
+    fixture.componentInstance.media.set(MOVIE);
+    fixture.detectChanges(); // flush sseEffect now that `media` matches the stale event
+
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(mediaService.getOne).not.toHaveBeenCalled(); // reloadAfterRescan never fires
+  });
+
+  it('sanity check: a genuinely new event for the same media still fires the toast', () => {
+    const { fixture, toast } = createHarness(null);
+
+    fixture.componentInstance.media.set(MOVIE);
+    fixture.detectChanges();
+
+    const freshEvent: SseEvent = { type: 'metadata.refreshed', mediaId: MEDIA_ID };
+    TestBed.inject(SseService).lastEvent.set(freshEvent);
+    fixture.detectChanges();
+
+    expect(toast.success).toHaveBeenCalled();
+  });
+});

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -181,8 +181,9 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   private readonly downloadModal = viewChild<DownloadQualityModalComponent>('downloadModal');
   private readonly downloadDetailModal =
     viewChild<DownloadDetailModalComponent>('downloadDetailModal');
-  /** Same SSE payload must run handlers once; `media` updates (e.g. after rescan) re-run this effect. */
-  private lastHandledSseEvent: SseEvent | null = null;
+  /** Same SSE payload must run handlers once; `media` updates (e.g. after rescan) re-run this effect.
+   *  Seeded from the service so a re-created instance doesn't replay an event from before it existed. */
+  private lastHandledSseEvent: SseEvent | null = this.sse.lastEvent();
 
   /**
    * Signal mirror of the route's paramMap. Angular reuses this component when

--- a/client/src/app/shared/components/data-table/data-table.spec.ts
+++ b/client/src/app/shared/components/data-table/data-table.spec.ts
@@ -297,6 +297,31 @@ describe('DataTableComponent — declared filters', () => {
     expect(fixture.componentInstance.cellLabel(fixture.componentInstance.columns()[0], 'other')).toBe('other');
   });
 
+  it('VERDICT: a select change inside the search debounce window does not double-fire the request', async () => {
+    const get = vi.fn(() => of({ data: [{ id: 1, name: 'A' }], total: 40, page: 1, pageSize: 20 }));
+    const fixture = await createComponent({ http: { get }, paged: true, filters: [SEARCH, STATUS] });
+    get.mockClear();
+
+    vi.useFakeTimers();
+    try {
+      const input = fixture.nativeElement.querySelector('input[type="search"]') as HTMLInputElement;
+      input.value = 'abc';
+      input.dispatchEvent(new Event('input'));
+
+      const select = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+      select.value = 'failed';
+      select.dispatchEvent(new Event('change'));
+      await vi.advanceTimersByTimeAsync(0);
+
+      // The select's own reload already ran; the still-armed search timer must not fire a second one.
+      await vi.advanceTimersByTimeAsync(350);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+
   it('renders no control for an unrecognised filter kind (fail closed)', async () => {
     const fixture = await createComponent({
       http: { get: () => of([{ id: 1, name: 'A' }]) },

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -122,6 +122,8 @@ export class DataTableComponent implements OnInit {
   }
 
   private async applyFilterChange(): Promise<void> {
+    // Disarms a still-pending debounce so an immediate caller (e.g. a select) can't double-fire it.
+    if (this.searchDebounce) clearTimeout(this.searchDebounce);
     this.page.set(1);
     await this.loadRows();
   }

--- a/client/src/app/shared/layout/layout.spec.ts
+++ b/client/src/app/shared/layout/layout.spec.ts
@@ -1,10 +1,11 @@
 import { CORE_NAV_CONTRIBUTIONS } from '../../core/plugin-ui/core-contributions';
-import { provideZonelessChangeDetection, NO_ERRORS_SCHEMA } from '@angular/core';
+import { provideZonelessChangeDetection, signal, NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Title } from '@angular/platform-browser';
 import { RouterLink, RouterLinkActive, RouterOutlet, provideRouter } from '@angular/router';
 import { TranslateLoader, TranslateModule, provideTranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
+import { vi } from 'vitest';
 import {
   LucideMenu,
   LucideChevronLeft,
@@ -24,7 +25,7 @@ import { LibraryPrefsService } from '../../core/services/library-prefs.service';
 import { LibrariesApiService, type LibrarySummary } from '../../core/services/api/libraries-api.service';
 import { CountsApiService } from '../../core/services/api/counts-api.service';
 import { ServerConfigService } from '../../core/services/server-config.service';
-import { SseService } from '../../core/services/sse.service';
+import { SseService, type SseEvent } from '../../core/services/sse.service';
 import { CastService } from '../../core/services/cast.service';
 import { NavbarService } from '../../core/services/navbar.service';
 import { TvService } from '../../core/services/tv.service';
@@ -61,6 +62,11 @@ interface Fixture {
   libraries: LibrarySummary[];
   pendingRequests: number;
   registry?: Partial<Record<SlotId, UiContribution[]>>;
+  /** Overrides the SSE `lastEvent` signal — a real writable signal, needed so
+   *  the component's `sseEffect` reacts to `.set()` calls made mid-test. */
+  sseLastEvent?: ReturnType<typeof signal<SseEvent | null>>;
+  /** Overrides `CountsApiService.get` — a spy, so tests can assert call counts. */
+  countsGet?: () => Promise<{ mediaByLibrary: Record<number, number>; badgeCounts: Record<string, number>; pendingRequests: number }>;
 }
 
 const lib = (id: number, name: string, opts: Partial<LibrarySummary> = {}): LibrarySummary => ({
@@ -96,16 +102,18 @@ async function createFixture(f: Fixture): Promise<ComponentFixture<LayoutCompone
       {
         provide: CountsApiService,
         useValue: {
-          get: () =>
-            Promise.resolve({
-              mediaByLibrary: {},
-              badgeCounts: {},
-              pendingRequests: f.pendingRequests,
-            }),
+          get:
+            f.countsGet ??
+            (() =>
+              Promise.resolve({
+                mediaByLibrary: {},
+                badgeCounts: {},
+                pendingRequests: f.pendingRequests,
+              })),
         },
       },
       { provide: ServerConfigService, useValue: {} },
-      { provide: SseService, useValue: { lastEvent: () => null, connect: () => {} } },
+      { provide: SseService, useValue: { lastEvent: f.sseLastEvent ?? (() => null), connect: () => {} } },
       { provide: DownloadManagerService, useValue: {} },
       { provide: NavigationHistoryService, useValue: { resetNavHistory: () => {} } },
       { provide: AddToPlaylistService, useValue: { request: () => null, clear: () => {} } },
@@ -443,5 +451,47 @@ describe('LayoutComponent nav — characterisation (data, not pixels)', () => {
 
     expect(downloads?.labelKey).toBe('downloads.title');
     expect(downloads?.shortLabelKey).toBe('nav.downloads');
+  });
+});
+
+describe('LayoutComponent sidebar counts — SSE debounce', () => {
+  afterEach(() => {
+    nativeState.value = false;
+  });
+
+  it('collapses a burst of count-bearing SSE events into a single trailing refresh', async () => {
+    const lastEvent = signal<SseEvent | null>(null);
+    const get = vi.fn(() =>
+      Promise.resolve({ mediaByLibrary: {}, badgeCounts: {}, pendingRequests: 0 }),
+    );
+    const fixture = await createFixture({
+      ...NON_ADMIN_NO_LIBRARIES,
+      sseLastEvent: lastEvent,
+      countsGet: get,
+    });
+    get.mockClear();
+
+    vi.useFakeTimers();
+    try {
+      lastEvent.set({ type: 'queue.updated' });
+      fixture.detectChanges();
+      await vi.advanceTimersByTimeAsync(100);
+
+      lastEvent.set({ type: 'queue.updated' });
+      fixture.detectChanges();
+      await vi.advanceTimersByTimeAsync(100);
+
+      lastEvent.set({ type: 'stalled.removed' });
+      fixture.detectChanges();
+      await vi.advanceTimersByTimeAsync(100);
+
+      // Still inside the debounce window re-armed by the last event: no request yet.
+      expect(get).toHaveBeenCalledTimes(0);
+
+      await vi.advanceTimersByTimeAsync(400);
+      expect(get).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/client/src/app/shared/layout/layout.ts
+++ b/client/src/app/shared/layout/layout.ts
@@ -58,6 +58,9 @@ import {
 } from '@lucide/angular';
 
 
+/** Coalesces a burst of count-bearing SSE events (e.g. a season-pack import) into one request. */
+const SIDEBAR_COUNTS_DEBOUNCE_MS = 400;
+
 @Component({
   selector: 'app-layout',
   imports: [
@@ -232,6 +235,8 @@ export class LayoutComponent implements OnInit, OnDestroy {
     return (item.badgeKey && this.badgeCounts()[item.badgeKey]) || 0;
   }
 
+  private sidebarCountsDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
   /** Refresh counts when relevant SSE events arrive */
   private readonly sseEffect = effect(() => {
     const event = this.sse.lastEvent();
@@ -244,7 +249,7 @@ export class LayoutComponent implements OnInit, OnDestroy {
       case 'stalled.removed':
       case 'request.approved':
       case 'request.declined':
-        this.refreshSidebarCounts();
+        this.debouncedRefreshSidebarCounts();
         break;
     }
   });
@@ -303,6 +308,7 @@ export class LayoutComponent implements OnInit, OnDestroy {
     if (this.isNative) {
       Keyboard.removeAllListeners();
     }
+    if (this.sidebarCountsDebounceTimer) clearTimeout(this.sidebarCountsDebounceTimer);
   }
 
   async refreshCounts() {
@@ -327,6 +333,16 @@ export class LayoutComponent implements OnInit, OnDestroy {
       this.libraryCounts.set(counts.mediaByLibrary);
       this.badgeCounts.set({ ...counts.badgeCounts, pendingRequests: counts.pendingRequests });
     } catch { /* ignore */ }
+  }
+
+  /** Trailing debounce so a burst of SSE events (a season pack importing many
+   *  episodes) collapses into a single request, keeping only the final state. */
+  private debouncedRefreshSidebarCounts(): void {
+    if (this.sidebarCountsDebounceTimer) clearTimeout(this.sidebarCountsDebounceTimer);
+    this.sidebarCountsDebounceTimer = setTimeout(() => {
+      this.sidebarCountsDebounceTimer = null;
+      void this.refreshSidebarCounts();
+    }, SIDEBAR_COUNTS_DEBOUNCE_MS);
   }
 
   libraryUrl(lib: LibrarySummary): string {


### PR DESCRIPTION
## Context

Audit of reactive feedback loops across home, the plugin-contributed queue page and media detail.

**There is no infinite loop.** Every self-writing effect on those paths converges or is guarded —
`autoSelectFileEffect` settles on its second run, `routeMediaEffect` / `likeStateEffect` /
media-detail's `sseEffect` are guarded by sentinel fields, and `plugin-view`'s two effects depend
only on route params. What the audit did find is three redundant fetches, one of which lies to the
user.

## 1. Duplicate "metadata refreshed" toast — `media-detail.ts:185`

`SseService.lastEvent` is a root signal that is never cleared; media detail dedupes against a
per-instance field. `movies/:id`, `series/:id` and `series/:id/episode/:episodeId` are three
separate route configs with no `reuse` flag, so the series → episode hop **re-creates** the
component and re-handles the retained event.

Reproduction: refresh metadata on a series, wait for the toast, click an episode — the success
toast fires again for a refresh that already completed, plus a duplicate `GET /api/media/:id`.

Fix: seed the guard from the service, so an event older than the instance counts as handled.

## 2. Sidebar counts had no debounce — `layout.ts:249`

One `GET /counts` per count-bearing SSE event, per open tab, with no debounce, no in-flight guard
and no deduplication in `CountsApiService`. `counts.service.ts` costs ~4 queries per call including
an unindexed `GROUP BY` over `media`.

Measured on the running stack: 45s of idle SSE with the download plugin `ready` produced only
`sse.connected`, so these events are transition-driven, not periodic. The real cost is bursts — a
season pack importing 20 episodes — which a 400 ms trailing debounce collapses into one request
while still keeping the final state. `ngOnInit` and the `online` listener go through
`refreshCounts()` and are deliberately left immediate.

## 3. Two identical queries from the plugin queue table — `data-table.ts:125`

`onSearchInput` arms a 300 ms debounce that `onSelectChange` never disarmed, so changing a select
just after typing sent two identical requests to the plugin's own uncached database. `loadSeq`
suppressed the stale *write* but not the second request.

Fixed at the choke point (`applyFilterChange`) rather than in the one caller that showed the
symptom — clearing an already-fired timer id is a no-op, so the debounced path is unaffected.

## Verification

- Each fix reverted individually, its test re-run, and the failure confirmed:
  - `expected "vi.fn()" to not be called at all, but actually been called 1 times` (toast)
  - `expected "vi.fn()" to be called +0 times, but got 3 times` (counts)
  - `expected "vi.fn()" to be called 1 times, but got 2 times` (data table)
- `tsc --noEmit` exit 0 on `tsconfig.app.json` and `tsconfig.spec.json`.
- Client suite: 51 files, 416 tests, exit 0 — three consecutive runs, no flakiness.

## Not changed

`route-reuse.strategy.ts` never evicts and `clear()` drops handles without destroying them. It does
not affect these three pages (home is `reuse: true` but param-less, so one instance; the queue and
detail pages are not cached), but `libraries/:libraryName` keeps one live component tree per
library name visited. Left for its own change.