### PR TITLE
ci(plugins): attach the contract to each release instead of publishing it

### DIFF
--- a/.github/workflows/plugin-contract-asset.yml
+++ b/.github/workflows/plugin-contract-asset.yml
@@ -1,0 +1,87 @@
+# Attaches the plugin contract to each GitHub release as an npm-installable
+# tarball, so a plugin author can depend on the types without this project
+# publishing to any registry:
+#
+#   npm i -D https://github.com/fliks-app/fliks/releases/download/v3.0.0/fliks-plugin-contract-3.0.0.tgz
+#
+# The tarball carries the CORE release version, not PLUGIN_API_VERSION: it is
+# the number an author already reasons about (their manifest's `fliks` range is
+# a core range), and it makes each asset traceable to the tree that produced it.
+# The rewrite happens here only — the committed package.json is left alone.
+#
+# Triggered by the release `published` event, which release-please raises with a
+# PAT so it can reach other workflows. `workflow_dispatch` exists to re-attach
+# an asset to an existing release without cutting a new one.
+name: Plugin contract asset
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to attach the tarball to (e.g. v3.0.0)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  attach:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Resolve the release tag and version
+        id: v
+        run: |
+          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          if [ -z "$TAG" ]; then echo "::error::no release tag resolved"; exit 1; fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Pack the contract at the release version
+        id: pack
+        working-directory: backend/src/common/plugin-contract
+        run: |
+          npm version --no-git-tag-version --allow-same-version "${{ steps.v.outputs.version }}"
+          npm pack --pack-destination /tmp
+          echo "tarball=/tmp/fliks-plugin-contract-${{ steps.v.outputs.version }}.tgz" >> "$GITHUB_OUTPUT"
+
+      # An asset nobody can install is worse than no asset: install it into a
+      # throwaway project outside the repo and typecheck all three entry points.
+      - name: Verify an outside project can consume it
+        run: |
+          mkdir -p /tmp/probe/src && cd /tmp/probe
+          echo '{ "name": "probe", "private": true }' > package.json
+          cat > tsconfig.json <<'EOF'
+          {
+            "compilerOptions": {
+              "strict": true, "noEmit": true, "target": "ES2022",
+              "module": "nodenext", "moduleResolution": "nodenext",
+              "allowImportingTsExtensions": true, "skipLibCheck": true
+            },
+            "include": ["src"]
+          }
+          EOF
+          cat > src/probe.ts <<'EOF'
+          import type { ProcessPluginManifest, PluginApi } from '@fliks/plugin-contract';
+          import { MAX_FRAME_BYTES, PLUGIN_API_VERSION } from '@fliks/plugin-contract/protocol';
+          import type { ConfigPage } from '@fliks/plugin-contract/ui';
+
+          export const manifest: Partial<ProcessPluginManifest> = { kind: 'process', pluginApi: PLUGIN_API_VERSION };
+          export const frameLimit: number = MAX_FRAME_BYTES;
+          export const page: ConfigPage = { kind: 'form', id: 'p', labelKey: 'p.t', fields: [] };
+          export type Api = PluginApi;
+          EOF
+          npm install --no-audit --no-fund "${{ steps.pack.outputs.tarball }}" semver @types/semver typescript
+          npx tsc --noEmit -p tsconfig.json
+
+      - name: Attach it to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ steps.v.outputs.tag }}" "${{ steps.pack.outputs.tarball }}" --clobber --repo "$GITHUB_REPOSITORY"

--- a/backend/src/common/plugin-contract/README.md
+++ b/backend/src/common/plugin-contract/README.md
@@ -1,11 +1,26 @@
 # @fliks/plugin-contract
 
 Type definitions and protocol constants for Fliks plugins. Types and constants only — no runtime
-wiring, no core code. Everything here is erased at build time, so depending on this package does
-not put anything of core inside your plugin.
+wiring, no core code. Everything here is erased at build time, so depending on it puts nothing of
+core inside your plugin.
+
+Not published to any registry, and it does not need to be: you need these at compile time only and
+never ship them. Two ways to get them.
+
+**The tarball attached to each release.** Pinned to the core version that produced it, so the number
+means something:
 
 ```bash
-npm install --save-dev @fliks/plugin-contract
+npm i -D https://github.com/fliks-app/fliks/releases/download/v3.0.0/fliks-plugin-contract-3.0.0.tgz
+```
+
+**A path mapping onto a checkout**, if you already keep the core repo beside your plugin:
+
+```json
+{ "compilerOptions": { "paths": {
+  "@fliks/plugin-contract": ["../fliks/backend/src/common/plugin-contract/index.ts"],
+  "@fliks/plugin-contract/*": ["../fliks/backend/src/common/plugin-contract/*.ts"]
+} } }
 ```
 
 ## Entry points
@@ -36,10 +51,13 @@ an unbundled `require` of this package fails at spawn. See `examples/plugin-scaf
 
 ## Versioning
 
-The package version tracks `PLUGIN_API_VERSION`, the contract revision core answers a plugin in.
-A plugin declares the revision it speaks as `pluginApi` in its manifest; core refuses a manifest
-whose revision it does not support. A new major here means a breaking change to a frozen item —
-see `docs/plugins.md` in the core repository for what is frozen and what may still move.
+Each release's tarball carries that **core** release's version — the number your manifest's `fliks`
+range already talks about. The committed `version` here is a placeholder; CI stamps the real one
+when it packs (`.github/workflows/plugin-contract-asset.yml`).
+
+What decides compatibility is `PLUGIN_API_VERSION`, the contract revision core answers a plugin in.
+A plugin declares the revision it speaks as `pluginApi`; core refuses a manifest whose revision it
+does not support, and `SUPPORTED_PLUGIN_API_VERSIONS` is the window in which you republish.
 
 ## Source
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -152,9 +152,14 @@ forced `<pluginId>.` prefix, settings read/write scoped to its own namespace.
 The contract types are the `@fliks/plugin-contract` package, whose source is
 `backend/src/common/plugin-contract/`. Depend on it rather than restating it — the types are
 erased at build time, so a spawned plugin still ships no core code and still cannot import from
-core at runtime. Two entry points: `@fliks/plugin-contract` for the whole surface, and
-`@fliks/plugin-contract/ui` for the UI-contribution types alone, which pull in no dependencies and
-are what a browser bundle wants.
+core at runtime. Three entry points: the barrel for the whole surface, `/protocol` for wire
+constants and `/ui` for the UI-contribution types, the last two dependency-free.
+
+It is deliberately **not** on any registry: compile-time-only types need no publishing step, and
+none of this repository depends on one. Each GitHub release carries the package as an installable
+tarball stamped with that release's version (`.github/workflows/plugin-contract-asset.yml`), and an
+author who already keeps a core checkout beside their plugin can point `paths` at it instead. The
+package README states both.
 
 The client consumes the same files through a tsconfig path mapping, so there is one declaration of
 each type in the tree and nothing to keep in sync. That mapping points one level above `client/`, so


### PR DESCRIPTION
## Why

The plugin contract was set up as `@fliks/plugin-contract` with a "publish to npm" step left as
outstanding work. That step was never load-bearing and should not exist:

- the **client** resolves the contract through a tsconfig path mapping;
- the **scaffold** uses `"@fliks/plugin-contract": "file:../../backend/src/common/plugin-contract"`;
- the only registry reference in the repository was one line of README telling authors to
  `npm install` a package that is not there.

And it does not need to be there. These are **compile-time-only types** — erased at build time,
never shipped inside a plugin — so an author needs a copy when they build and nothing more. A
registry dependency buys nothing and costs a publishing credential, a release chore and a second
place for the version to be wrong.

## What

`.github/workflows/plugin-contract-asset.yml`, on `release: published` (release-please raises it
with a PAT, so it reaches other workflows) plus `workflow_dispatch` for re-attaching to an existing
release:

1. stamp the contract's version to the core release version;
2. `npm pack`;
3. **install the tarball into a throwaway project outside the repo and typecheck all three entry
   points**;
4. `gh release upload --clobber`.

An author then does either of:

```bash
npm i -D https://github.com/fliks-app/fliks/releases/download/v3.0.0/fliks-plugin-contract-3.0.0.tgz
```

```json
{ "compilerOptions": { "paths": {
  "@fliks/plugin-contract": ["../fliks/backend/src/common/plugin-contract/index.ts"],
  "@fliks/plugin-contract/*": ["../fliks/backend/src/common/plugin-contract/*.ts"]
} } }
```

The tarball carries the **core** release version rather than `PLUGIN_API_VERSION`: it is the number
a manifest's `fliks` range already talks about, and it makes each asset traceable to the tree that
produced it. Compatibility is still decided by `PLUGIN_API_VERSION` /
`SUPPORTED_PLUGIN_API_VERSIONS`, which the README now says explicitly. The committed `version` stays
a placeholder; CI stamps the real one.

## Rejected: a git dependency

npm cannot install a subdirectory of a git repository without a third-party proxy service, so this
would need a mirror repository — reintroducing exactly the drift the contract package was created to
remove.

## Verification

Every CI step run locally against the real tree, not reasoned about:

- `npm version --no-git-tag-version --allow-same-version 3.0.0` → exit 0; `npm pack` → exit 0,
  produced `fliks-plugin-contract-3.0.0.tgz`.
- The verification step verbatim in `/tmp/probe`, outside the repo: install exit 0, `tsc --noEmit`
  exit 0, installed version reported `3.0.0`, all three entry points resolving.
- **The guard was proved load-bearing**: with `./protocol` deleted from the `exports` map, `npm pack`
  still succeeded (exit 0) and `npm install` still succeeded (exit 0) — only the typecheck failed,
  `TS2307: Cannot find module '@fliks/plugin-contract/protocol'`. Without step 3 a broken asset
  would ship.
- The committed `package.json` was confirmed restored afterwards: version `1.0.0`, exports
  `['.', './ui', './protocol']`.

Docs-and-CI only; no application code touched.
