### PR TITLE
perf(client,plugins): destroy cached routes and stop re-joining the library per match

### DIFF
--- a/backend/src/modules/plugins/host/fliks-host.service.spec.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.spec.ts
@@ -33,6 +33,8 @@ function fakeQueryBuilder(rawMany: unknown[] = [], one: unknown = null) {
     'andWhere',
     'groupBy',
     'orderBy',
+    'leftJoin',
+    'innerJoin',
   ]) {
     qb[m] = jest.fn(() => qb);
   }
@@ -51,6 +53,27 @@ function fakeRepo() {
     create: jest.fn((x: unknown) => x),
     createQueryBuilder: jest.fn(() => fakeQueryBuilder()),
   };
+}
+
+/** `releases.match` reads its library via a raw query builder projection, not
+ *  `find()` — this shapes fixture `Media` objects into that raw row format. */
+function mockMonitoredLibrary(
+  mediaRepo: ReturnType<typeof fakeRepo>,
+  media: Media[],
+): void {
+  const rawMany = media.map((m) => ({
+    id: m.id,
+    monitored: m.monitored,
+    type: m.type,
+    title: m.title,
+    originalTitle: m.originalTitle,
+    alternativeTitles: m.alternativeTitles,
+    qualityProfileId: m.qualityProfile?.id ?? null,
+    qualityProfileCutoff: m.qualityProfile?.cutoff ?? null,
+    qualityProfileUpgradeAllowed: m.qualityProfile?.upgradeAllowed ?? null,
+    languageProfileId: m.languageProfile?.id ?? null,
+  }));
+  mediaRepo.createQueryBuilder.mockReturnValue(fakeQueryBuilder(rawMany));
 }
 
 function makeMedia(overrides: Record<string, unknown> = {}): Media {
@@ -581,7 +604,7 @@ describe('FliksHostImpl', () => {
       try {
         const h = makeHarness();
         const library = Array.from({ length: 30 }, (_, i) => makeMedia({ id: i + 1, title: `Library Title ${i}` }));
-        h.mediaRepo.find.mockResolvedValue(library);
+        mockMonitoredLibrary(h.mediaRepo, library);
 
         await h.host['releases.match']({
           titles: Array.from({ length: 8 }, (_, i) => ({
@@ -601,7 +624,7 @@ describe('FliksHostImpl', () => {
 
     it('hands the event loop back between titles so a whole feed does not block core', async () => {
       const h = makeHarness();
-      h.mediaRepo.find.mockResolvedValue([makeMedia({ title: 'Some Great Movie' })]);
+      mockMonitoredLibrary(h.mediaRepo, [makeMedia({ title: 'Some Great Movie' })]);
       const immediate = jest.spyOn(global, 'setImmediate');
       try {
         await h.host['releases.match']({
@@ -620,7 +643,7 @@ describe('FliksHostImpl', () => {
     it('reports unmatched, then grab, for a title that matches a missing monitored movie', async () => {
       const h = makeHarness();
       const media = makeMedia({ title: 'Some Great Movie' });
-      h.mediaRepo.find.mockResolvedValue([media]);
+      mockMonitoredLibrary(h.mediaRepo, [media]);
       h.mediaFileRepo.find.mockResolvedValue([]);
       h.autoGrab.classifyForSearch.mockReturnValue({
         mode: 'missing',
@@ -658,7 +681,7 @@ describe('FliksHostImpl', () => {
       const h = makeHarness();
       // Wholly non-Latin: it tokenizes to nothing, so it can be told apart from no release at all.
       const media = makeMedia({ title: '\u6211\u4e0d\u8fc7\u662f\u4e2a\u5927\u7f57\u91d1\u4ed9' });
-      h.mediaRepo.find.mockResolvedValue([media]);
+      mockMonitoredLibrary(h.mediaRepo, [media]);
       h.mediaFileRepo.find.mockResolvedValue([]);
       h.autoGrab.classifyForSearch.mockReturnValue({ mode: 'missing', minRankExclusive: 0, maxRankInclusive: 100 });
 
@@ -672,7 +695,7 @@ describe('FliksHostImpl', () => {
     it('skips a release fresher than minAgeMinutes', async () => {
       const h = makeHarness();
       const media = makeMedia({ title: 'Fresh Movie' });
-      h.mediaRepo.find.mockResolvedValue([media]);
+      mockMonitoredLibrary(h.mediaRepo, [media]);
       h.mediaFileRepo.find.mockResolvedValue([]);
       h.autoGrab.classifyForSearch.mockReturnValue({
         mode: 'missing',
@@ -700,7 +723,7 @@ describe('FliksHostImpl', () => {
     it('skips on-disk and unprofiled decisions with the matching reason', async () => {
       const h = makeHarness();
       const media = makeMedia({ title: 'Owned Movie' });
-      h.mediaRepo.find.mockResolvedValue([media]);
+      mockMonitoredLibrary(h.mediaRepo, [media]);
       h.mediaFileRepo.find.mockResolvedValue([]);
 
       h.autoGrab.classifyForSearch.mockReturnValue({ mode: 'skip' });
@@ -731,7 +754,7 @@ describe('FliksHostImpl', () => {
     it('flags a series episode that does not exist yet as not-available', async () => {
       const h = makeHarness();
       const media = makeMedia({ title: 'A Show', type: MediaType.SERIES });
-      h.mediaRepo.find.mockResolvedValue([media]);
+      mockMonitoredLibrary(h.mediaRepo, [media]);
       h.seasonRepo.findOne.mockResolvedValue(makeSeason());
       h.episodeRepo.findOne.mockResolvedValue(null);
 

--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -311,7 +311,55 @@ export class FliksHostImpl implements PluginHostApi {
     titles: { id: string; title: string; publishDate: string }[];
     minAgeMinutes?: number;
   }): Promise<ReleaseMatchResult[]> {
-    const library = await this.mediaRepo.find({ where: { monitored: true } });
+    // createQueryBuilder, not find(): find() still joins all 4 `eager: true`
+    // Media relations even under `select`, which dominates this call's cost.
+    const rows = await this.mediaRepo
+      .createQueryBuilder('media')
+      .leftJoin('media.qualityProfile', 'qualityProfile')
+      .leftJoin('media.languageProfile', 'languageProfile')
+      .select('media.id', 'id')
+      .addSelect('media.monitored', 'monitored')
+      .addSelect('media.type', 'type')
+      .addSelect('media.title', 'title')
+      .addSelect('media.originalTitle', 'originalTitle')
+      .addSelect('media.alternativeTitles', 'alternativeTitles')
+      .addSelect('media.qualityProfileId', 'qualityProfileId')
+      .addSelect('qualityProfile.cutoff', 'qualityProfileCutoff')
+      .addSelect('qualityProfile.upgradeAllowed', 'qualityProfileUpgradeAllowed')
+      .addSelect('media.languageProfileId', 'languageProfileId')
+      .where('media.monitored = :monitored', { monitored: true })
+      .getRawMany<{
+        id: number;
+        monitored: boolean;
+        type: MediaType;
+        title: string;
+        originalTitle: string | null;
+        alternativeTitles: string[] | null;
+        qualityProfileId: number | null;
+        qualityProfileCutoff: number | null;
+        qualityProfileUpgradeAllowed: boolean | null;
+        languageProfileId: number | null;
+      }>();
+    const library: Media[] = rows.map(
+      (r) =>
+        ({
+          id: r.id,
+          monitored: r.monitored,
+          type: r.type,
+          title: r.title,
+          originalTitle: r.originalTitle,
+          alternativeTitles: r.alternativeTitles ?? [],
+          qualityProfile:
+            r.qualityProfileId == null
+              ? null
+              : {
+                  cutoff: r.qualityProfileCutoff,
+                  upgradeAllowed: r.qualityProfileUpgradeAllowed,
+                },
+          languageProfile:
+            r.languageProfileId == null ? null : { id: r.languageProfileId },
+        }) as unknown as Media,
+    );
     // Tokenised once for the whole batch: doing it per release title is what made a full feed
     // tens of seconds of blocking CPU.
     const indexed = library.map((media) => ({

--- a/backend/src/modules/plugins/host/plugin-host-binding.service.spec.ts
+++ b/backend/src/modules/plugins/host/plugin-host-binding.service.spec.ts
@@ -17,12 +17,18 @@ function sleep(ms: number): Promise<void> {
 }
 
 function fakeRepo() {
+  const qb: Record<string, jest.Mock> = {};
+  for (const m of ['select', 'addSelect', 'where', 'leftJoin']) {
+    qb[m] = jest.fn(() => qb);
+  }
+  qb.getRawMany = jest.fn().mockResolvedValue([]);
   return {
     find: jest.fn().mockResolvedValue([]),
     findOne: jest.fn().mockResolvedValue(null),
     count: jest.fn().mockResolvedValue(0),
     save: jest.fn(),
     create: jest.fn((x: unknown) => x),
+    createQueryBuilder: jest.fn(() => qb),
   };
 }
 

--- a/client/src/app/core/plugin-ui/plugin-i18n.service.spec.ts
+++ b/client/src/app/core/plugin-ui/plugin-i18n.service.spec.ts
@@ -79,6 +79,37 @@ describe('PluginI18nService', () => {
     expect(translate.instant('nav.plugin_item')).toBe('Item');
   });
 
+  // The merge writes through TranslateStore, which fires `onTranslationChange`. Subscribing to that
+  // here — rather than to `onLangChange` only — is what would make a language switch re-enter forever.
+  it('VERDICT: a language switch never re-enters the merge', async () => {
+    loaderData['en'] = { nav: { home: 'Home' } };
+    loaderData['fr'] = { nav: { home: 'Accueil' } };
+    const { translate, i18n } = setup({ en: { 'p.a': 'A' }, fr: { 'p.a': 'Aa' } });
+
+    let calls = 0;
+    let depth = 0;
+    let maxDepth = 0;
+    const merge = i18n.mergeIntoLang.bind(i18n);
+    i18n.mergeIntoLang = (lang: string) => {
+      calls++;
+      depth++;
+      maxDepth = Math.max(maxDepth, depth);
+      if (calls > 50) throw new Error(`runaway merge: ${calls} calls`);
+      try {
+        merge(lang);
+      } finally {
+        depth--;
+      }
+    };
+
+    i18n.init();
+    await firstValueFrom(translate.use('fr'));
+
+    expect(maxDepth).toBe(1);
+    expect(calls).toBeLessThan(10);
+    expect(translate.instant('p.a')).toBe('Aa');
+  });
+
   it('init() merges whatever is already loaded without awaiting the network', () => {
     loaderData['en'] = { nav: { home: 'Home' } };
     const { translate, i18n } = setup({ en: { 'nav.plugin_item': 'Item' } });

--- a/client/src/app/core/services/route-reuse.strategy.spec.ts
+++ b/client/src/app/core/services/route-reuse.strategy.spec.ts
@@ -1,0 +1,72 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, DetachedRouteHandle, Route } from '@angular/router';
+import { vi } from 'vitest';
+import { CachingReuseStrategy } from './route-reuse.strategy';
+
+const MAX_CACHE_SIZE = 10;
+
+function snapshotFor(route: Route, params: Record<string, string> = {}): ActivatedRouteSnapshot {
+  return { routeConfig: route, params } as unknown as ActivatedRouteSnapshot;
+}
+
+interface FakeHandle {
+  destroy: ReturnType<typeof vi.fn>;
+}
+
+function handleWithDestroy(): DetachedRouteHandle & FakeHandle {
+  const destroy = vi.fn();
+  return { componentRef: { destroy }, destroy } as unknown as DetachedRouteHandle & FakeHandle;
+}
+
+describe('CachingReuseStrategy', () => {
+  function setup() {
+    TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
+    return TestBed.inject(CachingReuseStrategy);
+  }
+
+  it('VERDICT: clear() destroys every cached handle, not just the map entries', () => {
+    const strategy = setup();
+    const route: Route = { path: 'libraries/:libraryName' };
+    const handleA = handleWithDestroy();
+    const handleB = handleWithDestroy();
+    strategy.store(snapshotFor(route, { libraryName: 'Movies' }), handleA);
+    strategy.store(snapshotFor(route, { libraryName: 'Series' }), handleB);
+
+    strategy.clear();
+
+    expect(handleA.destroy).toHaveBeenCalledTimes(1);
+    expect(handleB.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('VERDICT: exceeding the cap destroys and evicts the least-recently-used entry', () => {
+    const strategy = setup();
+    const route: Route = { path: 'libraries/:libraryName' };
+    const handles = Array.from({ length: MAX_CACHE_SIZE }, () => handleWithDestroy());
+    handles.forEach((h, i) => strategy.store(snapshotFor(route, { libraryName: `lib${i}` }), h));
+
+    // retrieve() on the oldest entry marks it recently-used, so it must NOT be evicted next.
+    strategy.retrieve(snapshotFor(route, { libraryName: 'lib0' }));
+
+    const overflow = handleWithDestroy();
+    strategy.store(snapshotFor(route, { libraryName: 'overflow' }), overflow);
+
+    expect(handles[0].destroy).not.toHaveBeenCalled();
+    expect(handles[1].destroy).toHaveBeenCalledTimes(1);
+    expect(strategy.shouldAttach(snapshotFor(route, { libraryName: 'lib0' }))).toBe(true);
+    expect(strategy.shouldAttach(snapshotFor(route, { libraryName: 'lib1' }))).toBe(false);
+  });
+
+  it('VERDICT: re-storing the same handle under an existing key does not destroy it', () => {
+    const strategy = setup();
+    const route: Route = { path: 'libraries/:libraryName' };
+    const handle = handleWithDestroy();
+    const snapshot = snapshotFor(route, { libraryName: 'Movies' });
+
+    strategy.store(snapshot, handle);
+    strategy.store(snapshot, handle);
+
+    expect(handle.destroy).not.toHaveBeenCalled();
+    expect(strategy.shouldAttach(snapshot)).toBe(true);
+  });
+});

--- a/client/src/app/core/services/route-reuse.strategy.ts
+++ b/client/src/app/core/services/route-reuse.strategy.ts
@@ -2,6 +2,9 @@ import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, DetachedRouteHandle, Route, RouteReuseStrategy } from '@angular/router';
 import { Observable, Subject } from 'rxjs';
 
+/** Cap on live detached trees; a handful of libraries visited in one tab, bounding the pathological per-param leak. */
+const MAX_CACHE_SIZE = 10;
+
 /**
  * Detaches and caches the DOM of routes flagged with `data: { reuse: true }`.
  *
@@ -54,6 +57,15 @@ export class CachingReuseStrategy implements RouteReuseStrategy {
     return `${this.idFor(cfg)}::${params}`;
   }
 
+  /** DetachedRouteHandle is opaque with no public API; componentRef is the only way to run ngOnDestroy. */
+  private destroyHandle(handle: DetachedRouteHandle): void {
+    try {
+      (handle as { componentRef?: { destroy(): void } }).componentRef?.destroy();
+    } catch {
+      // Shape mismatch must not break navigation.
+    }
+  }
+
   private idFor(route: Route): string {
     let id = this.routeIds.get(route);
     if (!id) {
@@ -71,7 +83,16 @@ export class CachingReuseStrategy implements RouteReuseStrategy {
     const key = this.keyFor(route);
     if (!key) return;
     if (handle) {
+      const existing = this.cache.get(key);
+      if (existing && existing !== handle) this.destroyHandle(existing);
+      this.cache.delete(key);
       this.cache.set(key, handle);
+      while (this.cache.size > MAX_CACHE_SIZE) {
+        const oldestKey = this.cache.keys().next().value as string;
+        const oldest = this.cache.get(oldestKey);
+        this.cache.delete(oldestKey);
+        if (oldest && oldest !== handle) this.destroyHandle(oldest);
+      }
       this.detachedSubject.next(key);
     } else {
       this.cache.delete(key);
@@ -88,6 +109,9 @@ export class CachingReuseStrategy implements RouteReuseStrategy {
     if (!key) return null;
     const handle = this.cache.get(key) ?? null;
     if (handle) {
+      // Re-insert to mark most-recently-used for the LRU eviction in store().
+      this.cache.delete(key);
+      this.cache.set(key, handle);
       // Microtask so the outlet has finished attaching before subscribers run
       // their refresh / focus-restore work.
       queueMicrotask(() => this.attachedSubject.next(key));
@@ -110,6 +134,7 @@ export class CachingReuseStrategy implements RouteReuseStrategy {
 
   /** Drop every cached page (call on logout / user switch). */
   clear(): void {
+    for (const handle of this.cache.values()) this.destroyHandle(handle);
     this.cache.clear();
   }
 }


### PR DESCRIPTION
The last items from the reactivity audit and the plugin-v3 pass.

## 1. Cached routes were never destroyed, and never evicted

`route-reuse.strategy.ts` detached components for `data: { reuse: true }` routes and dropped the
handles. A `DetachedRouteHandle` wraps a `ComponentRef`, so dropping the reference skips
`ngOnDestroy`, `DestroyRef` callbacks, effects and subscriptions — and those subscriptions reach
root-lived services (SSE, settings, translate), which keeps the whole detached tree reachable from
the root. Not uncollected garbage: a leak.

`keyFor()` includes the snapshot's params, so a `reuse: true` route **with** params got one entry per
distinct value and nothing ever evicted it. `libraries/:libraryName` is exactly that: one live
component tree per library name visited, for the life of the tab.

- `clear()` (logout / user switch) now destroys every handle.
- The map is capped at 10, LRU — `retrieve()` re-inserts to mark use, `store()` evicts and destroys
  the oldest over the cap.
- `store()` never destroys a handle it is keeping: guarded on `existing !== handle` in both the
  overwrite and the eviction path.

**The `store(key, null)` path deliberately does not destroy**, which looks like an omission and is
the crux. Angular calls it *immediately after* `retrieve()` —
`_router-chunk.mjs:2201-2202` — to evict an entry for a handle it is about to attach as a live
component. Destroying there would kill the component being reattached. It also means the cache only
ever holds genuinely detached trees, which is what makes destroying on `clear()` and on eviction safe.

## 2. `releases.match` re-joined the whole library on every call

It opened with `mediaRepo.find({ where: { monitored: true } })`. `Media` has **four `eager: true`
relations** and 38 columns, so that joins all four for every monitored row on every call — and a
plugin scanning a feed calls it repeatedly. The per-pair tokenisation was already fixed; this was the
remaining fixed cost.

Replaced with a `createQueryBuilder` projection (`find()` still eager-joins even under `select`;
the query builder does not). Measured against the dev database, 809 monitored rows, 15 runs each:

| | median |
|---|---|
| `find()` | **178.4 ms** |
| projection | **8.9 ms** |

**The projection has to carry `qualityProfile.cutoff` / `upgradeAllowed` and `languageProfile`
presence.** My own brief for this change said only `id`, `monitored` and `type` were needed — that
was wrong. `matchOneRelease` calls `autoGrab.classifyForSearch` (fliks-host.service.ts:449), which
returns `unprofiled` unless both relations are present, so a projection without them would have
silently skipped every match rather than merely running faster.

Verified against real data — the join resolves correctly and null-profile rows stay null-profile:

```
monitored_rows | with_quality_id | with_cutoff | with_language_id
           809 |              17 |          17 |               15
```

No cache and no TTL were added: a narrower query has no staleness semantics to get wrong.

## 3. Plugin i18n re-entrancy, from an untracked probe into the real spec

An untracked `zz-loop-probe.spec.ts` (console.logs and all) was pinning a real property: the merge
writes through `TranslateStore`, so subscribing to `onTranslationChange` instead of `onLangChange`
alone would make a language switch re-enter forever. That assertion now lives in
`plugin-i18n.service.spec.ts` and the probe is gone.

## Verification

Every mutation check re-run independently of the agents that wrote the fixes:

- `clear()` reverted to a bare `cache.clear()` → `expected "vi.fn()" to be called 1 times, but got 0`
- LRU eviction loop removed → `expected "vi.fn()" to be called 1 times, but got 0`
- `existing !== handle` guard removed → `expected "vi.fn()" to not be called at all, but actually been called 1 times`
- `PluginI18nService` made to subscribe to `onTranslationChange` → `runaway merge: 51 calls`,
  `expected 51 to be 1`

Then: backend `tsc --noEmit` exit 0, 140 suites / 1572 tests exit 0. Client `tsconfig.app.json` and
`tsconfig.spec.json` exit 0, 51 files / 419 tests exit 0. Backend restarted on the live stack with
all three installed plugins back to `active` — `fliks.webhooks`, `fliks.download ready`,
`acme.hello ready` — and no plugin-side error in the log.

`plugin-host-binding.service.spec.ts` carries a second, independent repository mock that exercises
`releases.match`; it needed a `createQueryBuilder` stub to match the new call shape.
