### PR TITLE
fix(backend): pin the build output layout so dist/main is where the image runs it

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "build": "nest build",
+    "build": "nest build && npm run verify:entrypoint",
+    "verify:entrypoint": "node -e \"require('fs').accessSync('dist/main.js')\"",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch --no-shell",

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,4 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }


### PR DESCRIPTION
## Production outage

```
Error: Cannot find module '/app/dist/main'
```

The image runs `CMD ["node", "dist/main"]` (Dockerfile:147). The compiler was emitting
`dist/src/main.js`.

## Cause

`backend/tsconfig.build.json` declared neither `rootDir` nor `include`:

```json
{ "extends": "./tsconfig.json", "exclude": ["node_modules", "test", "dist", "**/*spec.ts"] }
```

With no `rootDir`, tsc infers the output root from the common directory of every input it collects.
That was `backend/src` for as long as nothing else existed. **`backend/scripts/package-plugin.ts`,
added in #986, sits outside `src/`** — the inferred root moved up to `backend/`, and every emitted
path gained a `src/` segment.

The reason this reached production: **nothing failed.** `tsc` exited 0 and produced a complete,
correct `dist` — one directory deeper than the entrypoint. A PR-time build would not have caught it
either, because the build succeeded. `docker-publish` also only runs on `push: main` and `v*` tags,
never on `pull_request`.

I saw this exact symptom earlier while working on #992 — a `--outDir` build producing `scripts/` and
`src/` at the top level — and dismissed it as an artefact of overriding `outDir` on the command line.
It was the regression.

## Fix

```json
"compilerOptions": { "rootDir": "src" },
"include": ["src/**/*"]
```

`rootDir` pins the layout and turns a future file outside `src/` into a loud compile error rather
than a silently relocated `dist`. `include` keeps the dev CLI out of the server build; it is still
typechecked under the root `tsconfig.json` and still runs from source via ts-node, which is how the
scaffold invokes it. `src/` imports nothing from `scripts/`, so nothing else moves.

## Guard

A wrong-but-successful build is the failure mode here, so `build` now ends by asserting the
entrypoint exists:

```json
"build": "nest build && npm run verify:entrypoint",
"verify:entrypoint": "node -e \"require('fs').accessSync('dist/main.js')\""
```

This covers every build path — local, CI and the image — in one line.

## Verification

- Reproduced first: `tsc -p tsconfig.build.json` put `main.js` at `dist/src/main.js`, exit 0.
- After the fix: `main.js` at the root of the output, `common/plugin-contract/*` still emitted,
  `scripts/` absent from `dist`.
- `docker build --target backend-build` exit 0, and **inside the built image** `/app/dist/main.js`
  exists — checked in the image, not in the build log.
- **The guard is load-bearing.** With `tsconfig.build.json` reverted to the broken version, the image
  build fails:
  ```
  > backend@2.0.1 verify:entrypoint
  Error: ENOENT: no such file or directory, access 'dist/main.js'
  ERROR: process "/bin/sh -c npm run build" did not complete successfully: exit code: 1
  ```
- `tsc --noEmit -p tsconfig.json` exit 0 (this one does cover `scripts/`), backend plugins suite
  790 tests exit 0.
