### PR TITLE
chore(backend): drop the entrypoint assertion the rootDir already covers

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,8 +6,7 @@
   "private": true,
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "build": "nest build && npm run verify:entrypoint",
-    "verify:entrypoint": "node -e \"require('fs').accessSync('dist/main.js')\"",
+    "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch --no-shell",


### PR DESCRIPTION
Removes the `verify:entrypoint` step added in #999.

`rootDir: "src"` in `backend/tsconfig.build.json` is what actually pins the output layout, and it
fails better than the assertion did. Widening the build back to `scripts/` — the mistake that caused
the outage — now fails with exit 2 and names the cause:

```
error TS6059: File '.../backend/scripts/package-plugin.ts' is not under 'rootDir' '.../backend/src'.
  The file is in the program because:
    Matched by include pattern 'scripts/**/*' in 'tsconfig.build.json'
```

The assertion could only ever report the symptom (`dist/main.js` is absent), for a failure mode
already covered upstream. One mechanism per failure mode.

Verified: `docker build --target backend-build` exit 0, and inside the built image `/app/dist/main.js`
is present with no `dist/scripts`.
