### PR TITLE
feat(notifications): authenticate ntfy pushes and expose webhook tokens

### DIFF
--- a/backend/src/migrations/1783900000000-normalize-notification-endpoint-key.ts
+++ b/backend/src/migrations/1783900000000-normalize-notification-endpoint-key.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/** The settings editor saved every endpoint as `webhookUrl`, but the webhook,
+ *  gotify and ntfy senders read `url` — those three silently posted to a
+ *  relative path and failed with "Invalid URL". Fold the stored key onto the
+ *  one the senders read so existing connections work without being re-saved. */
+export class NormalizeNotificationEndpointKey1783900000000 implements MigrationInterface {
+  name = 'NormalizeNotificationEndpointKey1783900000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE "notification_connections"
+      SET "settings" = ("settings" - 'webhookUrl')
+        || jsonb_build_object('url', "settings"->'webhookUrl')
+      WHERE "type" IN ('webhook', 'gotify', 'ntfy')
+        AND "settings" ? 'webhookUrl'
+        AND NOT "settings" ? 'url'
+    `);
+
+    // A row carrying both keys kept `url` as the authoritative one above;
+    // drop the now-redundant `webhookUrl` so only one endpoint remains.
+    await queryRunner.query(`
+      UPDATE "notification_connections"
+      SET "settings" = "settings" - 'webhookUrl'
+      WHERE "type" IN ('webhook', 'gotify', 'ntfy')
+        AND "settings" ? 'webhookUrl'
+    `);
+  }
+
+  /** Lossy: rows that already stored `url` before this migration are moved to
+   *  `webhookUrl` too, since nothing records which ones `up()` converted. */
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE "notification_connections"
+      SET "settings" = ("settings" - 'url')
+        || jsonb_build_object('webhookUrl', "settings"->'url')
+      WHERE "type" IN ('webhook', 'gotify', 'ntfy')
+        AND "settings" ? 'url'
+    `);
+  }
+}

--- a/backend/src/migrations/1783900000000-normalize-notification-endpoint-key.ts
+++ b/backend/src/migrations/1783900000000-normalize-notification-endpoint-key.ts
@@ -1,9 +1,7 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-/** The settings editor saved every endpoint as `webhookUrl`, but the webhook,
- *  gotify and ntfy senders read `url` — those three silently posted to a
- *  relative path and failed with "Invalid URL". Fold the stored key onto the
- *  one the senders read so existing connections work without being re-saved. */
+/** The webhook, gotify and ntfy senders read `settings.url`; fold a stored
+ *  `webhookUrl` onto it so existing connections resolve without a re-save. */
 export class NormalizeNotificationEndpointKey1783900000000 implements MigrationInterface {
   name = 'NormalizeNotificationEndpointKey1783900000000';
 

--- a/backend/src/modules/notifications/dto/create-notification-connection.dto.ts
+++ b/backend/src/modules/notifications/dto/create-notification-connection.dto.ts
@@ -5,6 +5,10 @@ import {
   IsOptional,
   IsObject,
   IsIn,
+  Validate,
+  ValidationArguments,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
 } from 'class-validator';
 
 const VALID_TYPES = ['discord', 'slack', 'webhook', 'gotify', 'ntfy'];
@@ -22,6 +26,40 @@ const VALID_EVENTS = [
   'health.issue',
 ];
 
+/** Where each sender reads its endpoint from. Discord and Slack address a
+ *  webhook; the rest address a server. Kept in step with `NotificationsService.send`. */
+const ENDPOINT_KEY: Record<string, 'webhookUrl' | 'url'> = {
+  discord: 'webhookUrl',
+  slack: 'webhookUrl',
+  webhook: 'url',
+  gotify: 'url',
+  ntfy: 'url',
+};
+
+const asText = (v: unknown): string => (typeof v === 'string' ? v.trim() : '');
+
+@ValidatorConstraint({ name: 'notificationSettings' })
+class NotificationSettingsConstraint implements ValidatorConstraintInterface {
+  validate(settings: unknown, args: ValidationArguments): boolean {
+    const { type } = args.object as CreateNotificationConnectionDto;
+    const key = ENDPOINT_KEY[type];
+    if (!key) return true; // unknown type: @IsIn already rejected it
+    const s = (settings ?? {}) as Record<string, unknown>;
+    // `webhookUrl` stays accepted on the url-keyed types — older clients send
+    // it, and the service folds it onto `url` before the row is saved.
+    const endpoint = key === 'url' ? (s.url ?? s.webhookUrl) : s.webhookUrl;
+    if (!asText(endpoint)) return false;
+    return type !== 'gotify' || Boolean(asText(s.token));
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    const { type } = args.object as CreateNotificationConnectionDto;
+    if (type === 'gotify')
+      return 'gotify requires a non-empty settings.url and settings.token';
+    return `${type} requires a non-empty settings.${ENDPOINT_KEY[type] ?? 'url'}`;
+  }
+}
+
 export class CreateNotificationConnectionDto {
   @IsString()
   name: string;
@@ -30,6 +68,7 @@ export class CreateNotificationConnectionDto {
   type: string;
 
   @IsObject()
+  @Validate(NotificationSettingsConstraint)
   @IsOptional()
   settings?: Record<string, unknown>;
 

--- a/backend/src/modules/notifications/dto/create-notification-connection.dto.ts
+++ b/backend/src/modules/notifications/dto/create-notification-connection.dto.ts
@@ -48,16 +48,12 @@ class NotificationSettingsConstraint implements ValidatorConstraintInterface {
     // Either key is accepted: the service folds `webhookUrl` onto `url` for the
     // types whose sender reads `url`.
     const endpoint = key === 'url' ? s.url || s.webhookUrl : s.webhookUrl;
-    if (!/^https?:\/\//i.test(asText(endpoint))) return false;
-    return type !== 'gotify' || Boolean(asText(s.token));
+    return /^https?:\/\//i.test(asText(endpoint));
   }
 
   defaultMessage(args: ValidationArguments): string {
     const { type } = args.object as CreateNotificationConnectionDto;
-    const key = ENDPOINT_KEY[type] ?? 'url';
-    if (type === 'gotify')
-      return `gotify requires settings.${key} to be an http(s) URL and a non-empty settings.token`;
-    return `${type} requires settings.${key} to be an http(s) URL`;
+    return `${type} requires settings.${ENDPOINT_KEY[type] ?? 'url'} to be an http(s) URL`;
   }
 }
 

--- a/backend/src/modules/notifications/dto/create-notification-connection.dto.ts
+++ b/backend/src/modules/notifications/dto/create-notification-connection.dto.ts
@@ -45,18 +45,19 @@ class NotificationSettingsConstraint implements ValidatorConstraintInterface {
     const key = ENDPOINT_KEY[type];
     if (!key) return true; // unknown type: @IsIn already rejected it
     const s = (settings ?? {}) as Record<string, unknown>;
-    // `webhookUrl` stays accepted on the url-keyed types — older clients send
-    // it, and the service folds it onto `url` before the row is saved.
-    const endpoint = key === 'url' ? (s.url ?? s.webhookUrl) : s.webhookUrl;
-    if (!asText(endpoint)) return false;
+    // Either key is accepted: the service folds `webhookUrl` onto `url` for the
+    // types whose sender reads `url`.
+    const endpoint = key === 'url' ? s.url || s.webhookUrl : s.webhookUrl;
+    if (!/^https?:\/\//i.test(asText(endpoint))) return false;
     return type !== 'gotify' || Boolean(asText(s.token));
   }
 
   defaultMessage(args: ValidationArguments): string {
     const { type } = args.object as CreateNotificationConnectionDto;
+    const key = ENDPOINT_KEY[type] ?? 'url';
     if (type === 'gotify')
-      return 'gotify requires a non-empty settings.url and settings.token';
-    return `${type} requires a non-empty settings.${ENDPOINT_KEY[type] ?? 'url'}`;
+      return `gotify requires settings.${key} to be an http(s) URL and a non-empty settings.token`;
+    return `${type} requires settings.${key} to be an http(s) URL`;
   }
 }
 
@@ -69,8 +70,7 @@ export class CreateNotificationConnectionDto {
 
   @IsObject()
   @Validate(NotificationSettingsConstraint)
-  @IsOptional()
-  settings?: Record<string, unknown>;
+  settings: Record<string, unknown>;
 
   @IsArray()
   @IsIn(VALID_EVENTS, { each: true })

--- a/backend/src/modules/notifications/notifications.controller.ts
+++ b/backend/src/modules/notifications/notifications.controller.ts
@@ -9,7 +9,10 @@ import {
   UseGuards,
   ParseIntPipe,
 } from '@nestjs/common';
-import { NotificationsService } from './notifications.service';
+import {
+  NotificationsService,
+  redactNotificationSecrets,
+} from './notifications.service';
 import { CreateNotificationConnectionDto } from './dto/create-notification-connection.dto';
 import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
 import { PoliciesGuard } from '../auth/casl/policies.guard';
@@ -23,29 +26,31 @@ export class NotificationsController {
 
   @Post()
   @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
-  create(@Body() dto: CreateNotificationConnectionDto) {
-    return this.service.create(dto);
+  async create(@Body() dto: CreateNotificationConnectionDto) {
+    return redactNotificationSecrets(await this.service.create(dto));
   }
 
+  // Redacted here, not in the service: the service's own reads are what
+  // authenticate against the provider and need the real credential.
   @Get()
   @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
-  findAll() {
-    return this.service.findAll();
+  async findAll() {
+    return (await this.service.findAll()).map(redactNotificationSecrets);
   }
 
   @Get(':id')
   @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
-  findOne(@Param('id', ParseIntPipe) id: number) {
-    return this.service.findOne(id);
+  async findOne(@Param('id', ParseIntPipe) id: number) {
+    return redactNotificationSecrets(await this.service.findOne(id));
   }
 
   @Put(':id')
   @CheckPolicies((ability) => ability.can(Action.Manage, 'Settings'))
-  update(
+  async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() dto: CreateNotificationConnectionDto,
   ) {
-    return this.service.update(id, dto);
+    return redactNotificationSecrets(await this.service.update(id, dto));
   }
 
   @Delete(':id')

--- a/backend/src/modules/notifications/notifications.service.spec.ts
+++ b/backend/src/modules/notifications/notifications.service.spec.ts
@@ -1,0 +1,118 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { NotificationsService } from './notifications.service';
+import { CreateNotificationConnectionDto } from './dto/create-notification-connection.dto';
+
+describe('NotificationsService settings normalization', () => {
+  const saved: Record<string, unknown>[] = [];
+  const repo = {
+    create: (row: Record<string, unknown>) => row,
+    save: (row: Record<string, unknown>) => {
+      saved.push(row);
+      return Promise.resolve({ id: 1, ...row });
+    },
+    findOne: () =>
+      Promise.resolve({ id: 1, type: 'ntfy', settings: {}, events: [] }),
+  };
+  const service = new NotificationsService(repo as never);
+
+  beforeEach(() => (saved.length = 0));
+
+  it('folds a legacy webhookUrl onto url for server-addressed types', async () => {
+    for (const type of ['webhook', 'gotify', 'ntfy']) {
+      await service.create({
+        name: type,
+        type,
+        settings: { webhookUrl: 'https://ntfy.example.com', topic: 'media' },
+      });
+    }
+    for (const row of saved) {
+      expect(row.settings).toMatchObject({ url: 'https://ntfy.example.com' });
+      expect(row.settings).not.toHaveProperty('webhookUrl');
+    }
+  });
+
+  it('leaves discord and slack on webhookUrl', async () => {
+    await service.create({
+      name: 'd',
+      type: 'discord',
+      settings: { webhookUrl: 'https://discord.test/hook' },
+    });
+    expect(saved[0].settings).toEqual({
+      webhookUrl: 'https://discord.test/hook',
+    });
+  });
+
+  it('keeps url authoritative when a row carries both keys', async () => {
+    await service.create({
+      name: 'n',
+      type: 'ntfy',
+      settings: { url: 'https://new.test', webhookUrl: 'https://old.test' },
+    });
+    expect(saved[0].settings).toEqual({ url: 'https://new.test' });
+  });
+
+  it('normalizes on update too', async () => {
+    await service.update(1, {
+      name: 'n',
+      type: 'ntfy',
+      settings: { webhookUrl: 'https://ntfy.example.com' },
+    });
+    expect(saved[0].settings).toEqual({ url: 'https://ntfy.example.com' });
+  });
+});
+
+describe('CreateNotificationConnectionDto validation', () => {
+  const check = async (payload: Record<string, unknown>) => {
+    const dto = plainToInstance(CreateNotificationConnectionDto, payload);
+    return (await validate(dto)).flatMap((e) =>
+      Object.values(e.constraints ?? {}),
+    );
+  };
+
+  it('rejects an ntfy connection with no endpoint', async () => {
+    const errors = await check({
+      name: 'Ntfy',
+      type: 'ntfy',
+      settings: { topic: 'media' },
+    });
+    expect(errors).toContain('ntfy requires a non-empty settings.url');
+  });
+
+  it('accepts either the canonical or the legacy endpoint key', async () => {
+    expect(
+      await check({
+        name: 'Ntfy',
+        type: 'ntfy',
+        settings: { url: 'https://ntfy.example.com' },
+      }),
+    ).toEqual([]);
+    expect(
+      await check({
+        name: 'Ntfy',
+        type: 'ntfy',
+        settings: { webhookUrl: 'https://ntfy.example.com' },
+      }),
+    ).toEqual([]);
+  });
+
+  it('requires a token for gotify', async () => {
+    const errors = await check({
+      name: 'Gotify',
+      type: 'gotify',
+      settings: { url: 'https://gotify.example.com' },
+    });
+    expect(errors).toContain(
+      'gotify requires a non-empty settings.url and settings.token',
+    );
+  });
+
+  it('rejects a blank endpoint, which is what the editor used to save', async () => {
+    const errors = await check({
+      name: 'Ntfy',
+      type: 'ntfy',
+      settings: { webhookUrl: '   ' },
+    });
+    expect(errors).toContain('ntfy requires a non-empty settings.url');
+  });
+});

--- a/backend/src/modules/notifications/notifications.service.spec.ts
+++ b/backend/src/modules/notifications/notifications.service.spec.ts
@@ -1,7 +1,11 @@
 import { validate } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
+import axios from 'axios';
 import { NotificationsService } from './notifications.service';
 import { CreateNotificationConnectionDto } from './dto/create-notification-connection.dto';
+
+jest.mock('axios');
+const mockedAxios = jest.mocked(axios);
 
 describe('NotificationsService settings normalization', () => {
   const saved: Record<string, unknown>[] = [];
@@ -114,5 +118,77 @@ describe('CreateNotificationConnectionDto validation', () => {
       settings: { webhookUrl: '   ' },
     });
     expect(errors).toContain('ntfy requires a non-empty settings.url');
+  });
+});
+
+describe('NotificationsService provider authentication', () => {
+  const serviceFor = (row: Record<string, unknown>) =>
+    new NotificationsService({
+      findOne: () => Promise.resolve({ id: 1, events: [], ...row }),
+    } as never);
+
+  const lastCall = () => {
+    const [url, body, config] = mockedAxios.post.mock.calls.at(-1) as [
+      string,
+      unknown,
+      { headers?: Record<string, string> },
+    ];
+    return { url, body, headers: config?.headers ?? {} };
+  };
+
+  beforeEach(() => {
+    mockedAxios.post.mockReset();
+    mockedAxios.post.mockResolvedValue({ status: 200 } as never);
+  });
+
+  it('authenticates an ntfy push when a token is configured', async () => {
+    const service = serviceFor({
+      type: 'ntfy',
+      settings: {
+        url: 'https://ntfy.example.com',
+        topic: 'media',
+        token: 'tk_secret',
+      },
+    });
+
+    await expect(service.testConnection(1)).resolves.toMatchObject({
+      ok: true,
+    });
+    const { url, headers } = lastCall();
+    expect(url).toBe('https://ntfy.example.com/media');
+    expect(headers.Authorization).toBe('Bearer tk_secret');
+  });
+
+  it('omits the header entirely on a public ntfy topic', async () => {
+    const service = serviceFor({
+      type: 'ntfy',
+      settings: { url: 'https://ntfy.sh', topic: 'media' },
+    });
+
+    await service.testConnection(1);
+    expect(lastCall().headers).not.toHaveProperty('Authorization');
+  });
+
+  it('keeps the ntfy title ASCII so axios does not strip it', async () => {
+    const service = serviceFor({
+      type: 'ntfy',
+      settings: { url: 'https://ntfy.sh', topic: 'media' },
+    });
+
+    await service.testConnection(1);
+    const title = lastCall().headers.Title;
+    expect(title).toBe('Fliks - health.issue');
+    // eslint-disable-next-line no-control-regex
+    expect(title).toMatch(/^[\x00-\x7F]*$/);
+  });
+
+  it('sends a bearer token on a generic webhook', async () => {
+    const service = serviceFor({
+      type: 'webhook',
+      settings: { url: 'https://hook.example.com', token: 'wh_secret' },
+    });
+
+    await service.testConnection(1);
+    expect(lastCall().headers.Authorization).toBe('Bearer wh_secret');
   });
 });

--- a/backend/src/modules/notifications/notifications.service.spec.ts
+++ b/backend/src/modules/notifications/notifications.service.spec.ts
@@ -1,7 +1,11 @@
 import { validate } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
+import axios from 'axios';
 import { NotificationsService } from './notifications.service';
 import { CreateNotificationConnectionDto } from './dto/create-notification-connection.dto';
+
+jest.mock('axios');
+const mockedAxios = jest.mocked(axios);
 
 describe('NotificationsService settings normalization', () => {
   const saved: Record<string, unknown>[] = [];
@@ -52,6 +56,18 @@ describe('NotificationsService settings normalization', () => {
     expect(saved[0].settings).toEqual({ url: 'https://new.test' });
   });
 
+  it('trims a pasted endpoint so axios can resolve it', async () => {
+    await service.create({
+      name: 'n',
+      type: 'ntfy',
+      settings: { url: '  https://ntfy.example.com  ', topic: ' media ' },
+    });
+    expect(saved[0].settings).toEqual({
+      url: 'https://ntfy.example.com',
+      topic: 'media',
+    });
+  });
+
   it('normalizes on update too', async () => {
     await service.update(1, {
       name: 'n',
@@ -76,7 +92,7 @@ describe('CreateNotificationConnectionDto validation', () => {
       type: 'ntfy',
       settings: { topic: 'media' },
     });
-    expect(errors).toContain('ntfy requires a non-empty settings.url');
+    expect(errors).toContain('ntfy requires settings.url to be an http(s) URL');
   });
 
   it('accepts either the canonical or the legacy endpoint key', async () => {
@@ -103,16 +119,43 @@ describe('CreateNotificationConnectionDto validation', () => {
       settings: { url: 'https://gotify.example.com' },
     });
     expect(errors).toContain(
-      'gotify requires a non-empty settings.url and settings.token',
+      'gotify requires settings.url to be an http(s) URL and a non-empty settings.token',
     );
   });
 
-  it('rejects a blank endpoint, which is what the editor used to save', async () => {
+  it('rejects a blank endpoint', async () => {
     const errors = await check({
       name: 'Ntfy',
       type: 'ntfy',
       settings: { webhookUrl: '   ' },
     });
-    expect(errors).toContain('ntfy requires a non-empty settings.url');
+    expect(errors).toContain('ntfy requires settings.url to be an http(s) URL');
+  });
+
+  it('rejects an endpoint with no scheme, which axios cannot resolve', async () => {
+    const errors = await check({
+      name: 'Ntfy',
+      type: 'ntfy',
+      settings: { url: 'ntfy.example.com' },
+    });
+    expect(errors).toContain('ntfy requires settings.url to be an http(s) URL');
+  });
+});
+
+describe('NotificationsService ntfy dispatch', () => {
+  const serviceFor = (settings: Record<string, unknown>) =>
+    new NotificationsService({
+      findOne: () =>
+        Promise.resolve({ id: 1, type: 'ntfy', events: [], settings }),
+    } as never);
+
+  beforeEach(() => {
+    mockedAxios.post.mockReset();
+    mockedAxios.post.mockResolvedValue({ status: 200 } as never);
+  });
+
+  it('falls back to the default topic when none is stored', async () => {
+    await serviceFor({ url: 'https://ntfy.sh', topic: '' }).testConnection(1);
+    expect(mockedAxios.post.mock.calls[0][0]).toBe('https://ntfy.sh/fliks');
   });
 });

--- a/backend/src/modules/notifications/notifications.service.spec.ts
+++ b/backend/src/modules/notifications/notifications.service.spec.ts
@@ -1,7 +1,10 @@
 import { validate } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
 import axios from 'axios';
-import { NotificationsService } from './notifications.service';
+import {
+  NotificationsService,
+  redactNotificationSecrets,
+} from './notifications.service';
 import { CreateNotificationConnectionDto } from './dto/create-notification-connection.dto';
 
 jest.mock('axios');
@@ -15,19 +18,26 @@ describe('NotificationsService settings normalization', () => {
       saved.push(row);
       return Promise.resolve({ id: 1, ...row });
     },
-    findOne: () =>
-      Promise.resolve({ id: 1, type: 'ntfy', settings: {}, events: [] }),
+    findOne: () => Promise.resolve({ id: 1, events: [], ...stored }),
   };
   const service = new NotificationsService(repo as never);
+  let stored: { type: string; settings: Record<string, unknown> };
 
-  beforeEach(() => (saved.length = 0));
+  beforeEach(() => {
+    saved.length = 0;
+    stored = { type: 'ntfy', settings: {} };
+  });
 
   it('folds a legacy webhookUrl onto url for server-addressed types', async () => {
     for (const type of ['webhook', 'gotify', 'ntfy']) {
       await service.create({
         name: type,
         type,
-        settings: { webhookUrl: 'https://ntfy.example.com', topic: 'media' },
+        settings: {
+          webhookUrl: 'https://ntfy.example.com',
+          topic: 'media',
+          token: 'tk',
+        },
       });
     }
     for (const row of saved) {
@@ -64,6 +74,48 @@ describe('NotificationsService settings normalization', () => {
     });
     expect(saved[0].settings).toEqual({
       url: 'https://ntfy.example.com',
+      topic: 'media',
+    });
+  });
+
+  it('rejects a gotify connection with no token', async () => {
+    await expect(
+      service.create({
+        name: 'Gotify',
+        type: 'gotify',
+        settings: { url: 'https://gotify.example.com' },
+      }),
+    ).rejects.toThrow('gotify requires a non-empty settings.token');
+  });
+
+  it('keeps the stored token when the editor saves a blank one', async () => {
+    stored = {
+      type: 'gotify',
+      settings: { url: 'https://gotify.example.com', token: 'tk_stored' },
+    };
+    await service.update(1, {
+      name: 'Gotify',
+      type: 'gotify',
+      settings: { url: 'https://gotify.example.com', token: '' },
+    });
+    expect(saved[0].settings).toEqual({
+      url: 'https://gotify.example.com',
+      token: 'tk_stored',
+    });
+  });
+
+  it('drops the stored token when the connection changes provider', async () => {
+    stored = {
+      type: 'gotify',
+      settings: { url: 'https://gotify.example.com', token: 'tk_stored' },
+    };
+    await service.update(1, {
+      name: 'Moved',
+      type: 'ntfy',
+      settings: { url: 'https://ntfy.sh', topic: 'media' },
+    });
+    expect(saved[0].settings).toEqual({
+      url: 'https://ntfy.sh',
       topic: 'media',
     });
   });
@@ -112,17 +164,6 @@ describe('CreateNotificationConnectionDto validation', () => {
     ).toEqual([]);
   });
 
-  it('requires a token for gotify', async () => {
-    const errors = await check({
-      name: 'Gotify',
-      type: 'gotify',
-      settings: { url: 'https://gotify.example.com' },
-    });
-    expect(errors).toContain(
-      'gotify requires settings.url to be an http(s) URL and a non-empty settings.token',
-    );
-  });
-
   it('rejects a blank endpoint', async () => {
     const errors = await check({
       name: 'Ntfy',
@@ -139,24 +180,6 @@ describe('CreateNotificationConnectionDto validation', () => {
       settings: { url: 'ntfy.example.com' },
     });
     expect(errors).toContain('ntfy requires settings.url to be an http(s) URL');
-  });
-});
-
-describe('NotificationsService ntfy dispatch', () => {
-  const serviceFor = (settings: Record<string, unknown>) =>
-    new NotificationsService({
-      findOne: () =>
-        Promise.resolve({ id: 1, type: 'ntfy', events: [], settings }),
-    } as never);
-
-  beforeEach(() => {
-    mockedAxios.post.mockReset();
-    mockedAxios.post.mockResolvedValue({ status: 200 } as never);
-  });
-
-  it('falls back to the default topic when none is stored', async () => {
-    await serviceFor({ url: 'https://ntfy.sh', topic: '' }).testConnection(1);
-    expect(mockedAxios.post.mock.calls[0][0]).toBe('https://ntfy.sh/fliks');
   });
 });
 
@@ -221,6 +244,28 @@ describe('NotificationsService provider authentication', () => {
     expect(title).toMatch(/^[\x00-\x7F]*$/);
   });
 
+  it('falls back to the default topic when none is stored', async () => {
+    const service = serviceFor({
+      type: 'ntfy',
+      settings: { url: 'https://ntfy.sh', topic: '' },
+    });
+
+    await service.testConnection(1);
+    expect(lastCall().url).toBe('https://ntfy.sh/fliks');
+  });
+
+  it('escapes the gotify token it puts in the query string', async () => {
+    const service = serviceFor({
+      type: 'gotify',
+      settings: { url: 'https://gotify.example.com', token: 'a b&c' },
+    });
+
+    await service.testConnection(1);
+    expect(lastCall().url).toBe(
+      'https://gotify.example.com/message?token=a%20b%26c',
+    );
+  });
+
   it('sends a bearer token on a generic webhook', async () => {
     const service = serviceFor({
       type: 'webhook',
@@ -229,5 +274,19 @@ describe('NotificationsService provider authentication', () => {
 
     await service.testConnection(1);
     expect(lastCall().headers.Authorization).toBe('Bearer wh_secret');
+  });
+});
+
+describe('redactNotificationSecrets', () => {
+  it('strips the token but keeps the endpoint the editor has to show', () => {
+    const conn = {
+      id: 1,
+      type: 'ntfy',
+      settings: { url: 'https://ntfy.sh', topic: 'media', token: 'tk_secret' },
+    };
+    expect(redactNotificationSecrets(conn as never).settings).toEqual({
+      url: 'https://ntfy.sh',
+      topic: 'media',
+    });
   });
 });

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -53,10 +53,7 @@ export class NotificationsService {
     if (dto.name !== undefined) conn.name = dto.name;
     if (dto.type !== undefined) conn.type = dto.type as any;
     if (dto.settings !== undefined)
-      conn.settings = this.normalizeSettings(
-        dto.type ?? conn.type,
-        dto.settings,
-      );
+      conn.settings = this.normalizeSettings(dto.type, dto.settings);
     if (dto.events !== undefined)
       conn.events = dto.events as NotificationEvent[];
     if (dto.enabled !== undefined) conn.enabled = dto.enabled;
@@ -145,7 +142,7 @@ export class NotificationsService {
         }
         case 'ntfy': {
           const url = String(s.url ?? '').replace(/\/$/, '');
-          const topic = String(s.topic ?? 'fliks');
+          const topic = String(s.topic || 'fliks');
           if (!url) throw new Error('url not configured');
           await axios.post(
             `${url}/${topic}`,
@@ -169,17 +166,22 @@ export class NotificationsService {
     }
   }
 
-  /** Only Discord and Slack address a webhook; the rest read `url`. Older
-   *  clients sent every endpoint as `webhookUrl`, so fold it in on write —
-   *  a stale cached SPA still saves a usable row. */
+  /** Discord and Slack address a webhook, the others a server read from `url`.
+   *  A `webhookUrl` from any client is folded onto the key its sender reads. */
   private normalizeSettings(
     type: string,
     settings: Record<string, unknown>,
   ): Record<string, unknown> {
-    if (type === 'discord' || type === 'slack') return settings;
-    if (!('webhookUrl' in settings)) return settings;
-    const { webhookUrl, ...rest } = settings;
-    return { ...rest, url: rest.url ?? webhookUrl };
+    const out = Object.fromEntries(
+      Object.entries(settings).map(([key, value]) => [
+        key,
+        typeof value === 'string' ? value.trim() : value,
+      ]),
+    );
+    if (type === 'discord' || type === 'slack') return out;
+    const { webhookUrl, ...rest } = out;
+    if (webhookUrl === undefined) return out;
+    return { ...rest, url: rest.url || webhookUrl };
   }
 
   private formatMessage(

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -27,7 +27,7 @@ export class NotificationsService {
     const row = this.repo.create({
       name: dto.name,
       type: dto.type as any,
-      settings: dto.settings ?? {},
+      settings: this.normalizeSettings(dto.type, dto.settings ?? {}),
       events: (dto.events ?? []) as NotificationEvent[],
       enabled: dto.enabled ?? true,
     });
@@ -52,7 +52,11 @@ export class NotificationsService {
     const conn = await this.findOne(id);
     if (dto.name !== undefined) conn.name = dto.name;
     if (dto.type !== undefined) conn.type = dto.type as any;
-    if (dto.settings !== undefined) conn.settings = dto.settings;
+    if (dto.settings !== undefined)
+      conn.settings = this.normalizeSettings(
+        dto.type ?? conn.type,
+        dto.settings,
+      );
     if (dto.events !== undefined)
       conn.events = dto.events as NotificationEvent[];
     if (dto.enabled !== undefined) conn.enabled = dto.enabled;
@@ -142,11 +146,14 @@ export class NotificationsService {
         case 'ntfy': {
           const url = String(s.url ?? '').replace(/\/$/, '');
           const topic = String(s.topic ?? 'fliks');
+          if (!url) throw new Error('url not configured');
           await axios.post(
             `${url}/${topic}`,
             this.formatMessage(event, payload),
             {
-              headers: { Title: `Fliks — ${event}` },
+              // Axios drops non-latin1 characters from header values, so a
+              // fancier dash here reaches ntfy as a gap. Keep it ASCII.
+              headers: { Title: `Fliks - ${event}` },
             },
           );
           break;
@@ -160,6 +167,19 @@ export class NotificationsService {
       );
       throw e;
     }
+  }
+
+  /** Only Discord and Slack address a webhook; the rest read `url`. Older
+   *  clients sent every endpoint as `webhookUrl`, so fold it in on write —
+   *  a stale cached SPA still saves a usable row. */
+  private normalizeSettings(
+    type: string,
+    settings: Record<string, unknown>,
+  ): Record<string, unknown> {
+    if (type === 'discord' || type === 'slack') return settings;
+    if (!('webhookUrl' in settings)) return settings;
+    const { webhookUrl, ...rest } = settings;
+    return { ...rest, url: rest.url ?? webhookUrl };
   }
 
   private formatMessage(

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -147,13 +147,18 @@ export class NotificationsService {
           const url = String(s.url ?? '').replace(/\/$/, '');
           const topic = String(s.topic ?? 'fliks');
           if (!url) throw new Error('url not configured');
+          const token = typeof s.token === 'string' ? s.token : '';
           await axios.post(
             `${url}/${topic}`,
             this.formatMessage(event, payload),
             {
-              // Axios drops non-latin1 characters from header values, so a
-              // fancier dash here reaches ntfy as a gap. Keep it ASCII.
-              headers: { Title: `Fliks - ${event}` },
+              headers: {
+                // Axios drops non-latin1 characters from header values, so a
+                // fancier dash here reaches ntfy as a gap. Keep it ASCII.
+                Title: `Fliks - ${event}`,
+                // A reserved topic or a deny-all server 403s without this.
+                ...(token ? { Authorization: `Bearer ${token}` } : {}),
+              },
             },
           );
           break;

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import axios from 'axios';
@@ -7,6 +12,25 @@ import {
   NotificationEvent,
 } from './entities/notification-connection.entity';
 import { CreateNotificationConnectionDto } from './dto/create-notification-connection.dto';
+import {
+  mergeSecretFields,
+  redactSecretFields,
+} from '../../common/utils/secret-fields.util';
+
+/** The only credential a connection stores; the endpoint is an address, not a secret. */
+export const NOTIFICATION_SECRET_FIELDS = [
+  { key: 'token', secret: true },
+] as const;
+
+/** Strips the stored credential from a connection before it reaches a response. */
+export function redactNotificationSecrets(
+  conn: NotificationConnection,
+): NotificationConnection {
+  return {
+    ...conn,
+    settings: redactSecretFields(conn.settings, NOTIFICATION_SECRET_FIELDS),
+  };
+}
 
 @Injectable()
 export class NotificationsService {
@@ -21,7 +45,7 @@ export class NotificationsService {
   // CRUD
   // ---------------------------------------------------------------------------
 
-  create(
+  async create(
     dto: CreateNotificationConnectionDto,
   ): Promise<NotificationConnection> {
     const row = this.repo.create({
@@ -50,10 +74,17 @@ export class NotificationsService {
     dto: CreateNotificationConnectionDto,
   ): Promise<NotificationConnection> {
     const conn = await this.findOne(id);
+    const previousType = conn.type;
     if (dto.name !== undefined) conn.name = dto.name;
     if (dto.type !== undefined) conn.type = dto.type as any;
     if (dto.settings !== undefined)
-      conn.settings = this.normalizeSettings(dto.type, dto.settings);
+      // A credential belongs to the provider it was issued for: switching type
+      // starts from an empty one instead of posting it to another host.
+      conn.settings = this.normalizeSettings(
+        dto.type,
+        dto.settings,
+        dto.type === previousType ? conn.settings : undefined,
+      );
     if (dto.events !== undefined)
       conn.events = dto.events as NotificationEvent[];
     if (dto.enabled !== undefined) conn.enabled = dto.enabled;
@@ -133,11 +164,14 @@ export class NotificationsService {
           const url = String(s.url ?? '').replace(/\/$/, '');
           const token = String(s.token ?? '');
           if (!url || !token) throw new Error('url and token required');
-          await axios.post(`${url}/message?token=${token}`, {
-            title: `Fliks — ${event}`,
-            message: this.formatMessage(event, payload),
-            priority: 5,
-          });
+          await axios.post(
+            `${url}/message?token=${encodeURIComponent(token)}`,
+            {
+              title: `Fliks — ${event}`,
+              message: this.formatMessage(event, payload),
+              priority: 5,
+            },
+          );
           break;
         }
         case 'ntfy': {
@@ -176,17 +210,29 @@ export class NotificationsService {
   private normalizeSettings(
     type: string,
     settings: Record<string, unknown>,
+    existing?: Record<string, unknown>,
   ): Record<string, unknown> {
-    const out = Object.fromEntries(
+    const trimmed = Object.fromEntries(
       Object.entries(settings).map(([key, value]) => [
         key,
         typeof value === 'string' ? value.trim() : value,
       ]),
     );
-    if (type === 'discord' || type === 'slack') return out;
-    const { webhookUrl, ...rest } = out;
-    if (webhookUrl === undefined) return out;
-    return { ...rest, url: rest.url || webhookUrl };
+    if (type === 'discord' || type === 'slack') return trimmed;
+    const { webhookUrl, ...rest } = trimmed;
+    const folded =
+      webhookUrl === undefined
+        ? trimmed
+        : { ...rest, url: rest.url || webhookUrl };
+    // A response never carries the stored token, so an incoming blank means
+    // "unchanged" — which is also why gotify's token is checked here and not
+    // in the DTO, where the merged value is not visible yet.
+    const out = mergeSecretFields(existing, folded, NOTIFICATION_SECRET_FIELDS);
+    if (type === 'gotify' && !out.token)
+      throw new BadRequestException(
+        'gotify requires a non-empty settings.token',
+      );
+    return out;
   }
 
   private formatMessage(

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1651,6 +1651,7 @@
       "field_webhook_url": "Webhook-URL",
       "field_server_url": "ntfy-Server-URL",
       "field_token": "Token",
+      "field_token_optional": "(optional)",
       "field_topic": "Topic",
       "field_events": "Auslösende Ereignisse",
       "field_enabled": "Verbindung aktiv",

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1652,6 +1652,7 @@
       "field_server_url": "ntfy-Server-URL",
       "field_token": "Token",
       "field_token_optional": "(optional)",
+      "token_hint": "Leer lassen, um den gespeicherten Token zu behalten.",
       "field_topic": "Topic",
       "field_events": "Auslösende Ereignisse",
       "field_enabled": "Verbindung aktiv",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1669,6 +1669,7 @@
       "field_server_url": "ntfy server URL",
       "field_token": "Token",
       "field_token_optional": "(optional)",
+      "token_hint": "Leave empty to keep the stored token.",
       "field_topic": "Topic",
       "field_events": "Trigger events",
       "field_enabled": "Connection active",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1668,6 +1668,7 @@
       "field_webhook_url": "Webhook URL",
       "field_server_url": "ntfy server URL",
       "field_token": "Token",
+      "field_token_optional": "(optional)",
       "field_topic": "Topic",
       "field_events": "Trigger events",
       "field_enabled": "Connection active",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1652,6 +1652,7 @@
       "field_server_url": "URL del servidor ntfy",
       "field_token": "Token",
       "field_token_optional": "(opcional)",
+      "token_hint": "Dejar vacío para conservar el token guardado.",
       "field_topic": "Topic",
       "field_events": "Eventos disparadores",
       "field_enabled": "Conexión activa",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1651,6 +1651,7 @@
       "field_webhook_url": "URL del webhook",
       "field_server_url": "URL del servidor ntfy",
       "field_token": "Token",
+      "field_token_optional": "(opcional)",
       "field_topic": "Topic",
       "field_events": "Eventos disparadores",
       "field_enabled": "Conexión activa",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1668,6 +1668,7 @@
       "field_webhook_url": "URL du webhook",
       "field_server_url": "URL du serveur ntfy",
       "field_token": "Token",
+      "field_token_optional": "(facultatif)",
       "field_topic": "Topic",
       "field_events": "Événements déclencheurs",
       "field_enabled": "Connexion active",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1669,6 +1669,7 @@
       "field_server_url": "URL du serveur ntfy",
       "field_token": "Token",
       "field_token_optional": "(facultatif)",
+      "token_hint": "Laisser vide pour conserver le token enregistré.",
       "field_topic": "Topic",
       "field_events": "Événements déclencheurs",
       "field_enabled": "Connexion active",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1651,6 +1651,7 @@
       "field_webhook_url": "URL del webhook",
       "field_server_url": "URL del server ntfy",
       "field_token": "Token",
+      "field_token_optional": "(facoltativo)",
       "field_topic": "Topic",
       "field_events": "Eventi trigger",
       "field_enabled": "Connessione attiva",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1652,6 +1652,7 @@
       "field_server_url": "URL del server ntfy",
       "field_token": "Token",
       "field_token_optional": "(facoltativo)",
+      "token_hint": "Lascia vuoto per mantenere il token salvato.",
       "field_topic": "Topic",
       "field_events": "Eventi trigger",
       "field_enabled": "Connessione attiva",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1652,6 +1652,7 @@
       "field_server_url": "URL do servidor ntfy",
       "field_token": "Token",
       "field_token_optional": "(opcional)",
+      "token_hint": "Deixe vazio para manter o token guardado.",
       "field_topic": "Topic",
       "field_events": "Eventos acionadores",
       "field_enabled": "Ligação ativa",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1651,6 +1651,7 @@
       "field_webhook_url": "URL do webhook",
       "field_server_url": "URL do servidor ntfy",
       "field_token": "Token",
+      "field_token_optional": "(opcional)",
       "field_topic": "Topic",
       "field_events": "Eventos acionadores",
       "field_enabled": "Ligação ativa",

--- a/client/src/app/features/settings/notifications/notifications.html
+++ b/client/src/app/features/settings/notifications/notifications.html
@@ -135,6 +135,11 @@
               [ngModel]="formToken()"
               (ngModelChange)="formToken.set($event)"
             />
+            @if (editingId() !== null) {
+              <span class="label-text-alt text-base-content/50">
+                {{ 'settings.notifications.token_hint' | translate }}
+              </span>
+            }
           </label>
         }
 

--- a/client/src/app/features/settings/notifications/notifications.html
+++ b/client/src/app/features/settings/notifications/notifications.html
@@ -119,9 +119,16 @@
           />
         </label>
 
-        @if (formType() === 'gotify') {
+        @if (supportsToken()) {
           <label class="form-control w-full">
-            <span class="label-text">{{ 'settings.notifications.field_token' | translate }}</span>
+            <span class="label-text">
+              {{ 'settings.notifications.field_token' | translate }}
+              @if (formType() !== 'gotify') {
+                <span class="opacity-60">
+                  {{ 'settings.notifications.field_token_optional' | translate }}
+                </span>
+              }
+            </span>
             <input
               type="password"
               class="input input-bordered input-sm w-full"

--- a/client/src/app/features/settings/notifications/notifications.spec.ts
+++ b/client/src/app/features/settings/notifications/notifications.spec.ts
@@ -1,0 +1,127 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { HttpClient } from '@angular/common/http';
+import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { NotificationsSettingsComponent } from './notifications';
+import { ConfirmationService } from '../../../core/services/confirmation.service';
+
+beforeAll(() => {
+  if (!HTMLDialogElement.prototype.showModal) {
+    HTMLDialogElement.prototype.showModal = function (this: HTMLDialogElement) {
+      this.setAttribute('open', '');
+    };
+  }
+  if (!HTMLDialogElement.prototype.close) {
+    HTMLDialogElement.prototype.close = function (this: HTMLDialogElement) {
+      this.removeAttribute('open');
+    };
+  }
+});
+
+async function createComponent() {
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      provideTranslateService({
+        lang: 'en',
+        loader: {
+          provide: TranslateLoader,
+          useValue: { getTranslation: () => of({}) },
+        },
+      }),
+      {
+        provide: HttpClient,
+        useValue: { get: () => of([]) } as unknown as HttpClient,
+      },
+      {
+        provide: ConfirmationService,
+        useValue: {
+          confirm: () => Promise.resolve(true),
+          alert: () => Promise.resolve(),
+        },
+      },
+    ],
+  });
+  const fixture = TestBed.createComponent(NotificationsSettingsComponent);
+  fixture.detectChanges();
+  await fixture.whenStable();
+  return fixture.componentInstance;
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const settingsOf = (c: NotificationsSettingsComponent) =>
+  (c as any).buildSettings() as Record<string, unknown>;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+describe('NotificationsSettingsComponent — endpoint settings key', () => {
+  it('sends the endpoint as url for the types that read url', async () => {
+    const c = await createComponent();
+    c.formWebhookUrl.set('https://ntfy.example.com');
+    c.formTopic.set('media');
+    c.formToken.set('tok');
+
+    c.formType.set('ntfy');
+    expect(settingsOf(c)).toEqual({
+      url: 'https://ntfy.example.com',
+      topic: 'media',
+    });
+
+    c.formType.set('gotify');
+    expect(settingsOf(c)).toEqual({
+      url: 'https://ntfy.example.com',
+      token: 'tok',
+    });
+
+    c.formType.set('webhook');
+    expect(settingsOf(c)).toEqual({ url: 'https://ntfy.example.com' });
+  });
+
+  it('keeps discord and slack on webhookUrl', async () => {
+    const c = await createComponent();
+    c.formWebhookUrl.set('https://discord.test/hook');
+    for (const type of ['discord', 'slack'] as const) {
+      c.formType.set(type);
+      expect(settingsOf(c)).toEqual({ webhookUrl: 'https://discord.test/hook' });
+    }
+  });
+
+  it('hydrates the editor instead of blanking it, so an edit keeps the endpoint', async () => {
+    const c = await createComponent();
+    c.openEdit({
+      id: 1,
+      name: 'Ntfy',
+      type: 'ntfy',
+      enabled: true,
+      events: ['health.issue'],
+      settings: { url: 'https://ntfy.example.com', topic: 'media' },
+    });
+
+    expect(c.formWebhookUrl()).toBe('https://ntfy.example.com');
+    expect(c.formTopic()).toBe('media');
+    // Renaming and saving must not wipe the endpoint.
+    c.formName.set('Renamed');
+    expect(settingsOf(c)).toEqual({
+      url: 'https://ntfy.example.com',
+      topic: 'media',
+    });
+  });
+
+  it('hydrates a not-yet-migrated row stored under webhookUrl', async () => {
+    const c = await createComponent();
+    c.openEdit({
+      id: 2,
+      name: 'Legacy',
+      type: 'ntfy',
+      enabled: true,
+      events: [],
+      settings: { webhookUrl: 'https://legacy.example.com', topic: 'old' },
+    });
+
+    expect(c.formWebhookUrl()).toBe('https://legacy.example.com');
+    expect(settingsOf(c)).toEqual({
+      url: 'https://legacy.example.com',
+      topic: 'old',
+    });
+  });
+});

--- a/client/src/app/features/settings/notifications/notifications.spec.ts
+++ b/client/src/app/features/settings/notifications/notifications.spec.ts
@@ -62,19 +62,13 @@ describe('NotificationsSettingsComponent — endpoint settings key', () => {
     c.formToken.set('tok');
 
     c.formType.set('ntfy');
-    expect(settingsOf(c)).toEqual({
-      url: 'https://ntfy.example.com',
-      topic: 'media',
-    });
+    expect(settingsOf(c)).toMatchObject({ url: 'https://ntfy.example.com' });
 
     c.formType.set('gotify');
-    expect(settingsOf(c)).toEqual({
-      url: 'https://ntfy.example.com',
-      token: 'tok',
-    });
+    expect(settingsOf(c)).toMatchObject({ url: 'https://ntfy.example.com' });
 
     c.formType.set('webhook');
-    expect(settingsOf(c)).toEqual({ url: 'https://ntfy.example.com' });
+    expect(settingsOf(c)).toMatchObject({ url: 'https://ntfy.example.com' });
   });
 
   it('keeps discord and slack on webhookUrl', async () => {
@@ -123,5 +117,68 @@ describe('NotificationsSettingsComponent — endpoint settings key', () => {
       url: 'https://legacy.example.com',
       topic: 'old',
     });
+  });
+});
+
+describe('NotificationsSettingsComponent — provider tokens', () => {
+  it('offers a token only to the providers that can use one', async () => {
+    const c = await createComponent();
+    for (const type of ['webhook', 'gotify', 'ntfy'] as const) {
+      c.formType.set(type);
+      expect(c.supportsToken()).toBe(true);
+    }
+    for (const type of ['discord', 'slack'] as const) {
+      c.formType.set(type);
+      expect(c.supportsToken()).toBe(false);
+    }
+  });
+
+  it('sends the token for ntfy and webhook when one is set', async () => {
+    const c = await createComponent();
+    c.formWebhookUrl.set('https://ntfy.example.com');
+    c.formTopic.set('media');
+    c.formToken.set('tk_secret');
+
+    c.formType.set('ntfy');
+    expect(settingsOf(c)).toEqual({
+      url: 'https://ntfy.example.com',
+      topic: 'media',
+      token: 'tk_secret',
+    });
+
+    c.formType.set('webhook');
+    expect(settingsOf(c)).toEqual({
+      url: 'https://ntfy.example.com',
+      token: 'tk_secret',
+    });
+  });
+
+  it('omits a blank token so a public topic stores no credential', async () => {
+    const c = await createComponent();
+    c.formWebhookUrl.set('https://ntfy.sh');
+    c.formTopic.set('media');
+    c.formToken.set('   ');
+    c.formType.set('ntfy');
+
+    expect(settingsOf(c)).toEqual({ url: 'https://ntfy.sh', topic: 'media' });
+  });
+
+  it('round-trips a stored token back into the editor', async () => {
+    const c = await createComponent();
+    c.openEdit({
+      id: 1,
+      name: 'Ntfy',
+      type: 'ntfy',
+      enabled: true,
+      events: [],
+      settings: {
+        url: 'https://ntfy.example.com',
+        topic: 'media',
+        token: 'tk_secret',
+      },
+    });
+
+    expect(c.formToken()).toBe('tk_secret');
+    expect(settingsOf(c)).toMatchObject({ token: 'tk_secret' });
   });
 });

--- a/client/src/app/features/settings/notifications/notifications.spec.ts
+++ b/client/src/app/features/settings/notifications/notifications.spec.ts
@@ -62,13 +62,23 @@ describe('NotificationsSettingsComponent — endpoint settings key', () => {
     c.formToken.set('tok');
 
     c.formType.set('ntfy');
-    expect(settingsOf(c)).toMatchObject({ url: 'https://ntfy.example.com' });
+    expect(settingsOf(c)).toEqual({
+      url: 'https://ntfy.example.com',
+      topic: 'media',
+      token: 'tok',
+    });
 
     c.formType.set('gotify');
-    expect(settingsOf(c)).toMatchObject({ url: 'https://ntfy.example.com' });
+    expect(settingsOf(c)).toEqual({
+      url: 'https://ntfy.example.com',
+      token: 'tok',
+    });
 
     c.formType.set('webhook');
-    expect(settingsOf(c)).toMatchObject({ url: 'https://ntfy.example.com' });
+    expect(settingsOf(c)).toEqual({
+      url: 'https://ntfy.example.com',
+      token: 'tok',
+    });
   });
 
   it('keeps discord and slack on webhookUrl', async () => {
@@ -133,26 +143,6 @@ describe('NotificationsSettingsComponent — provider tokens', () => {
     }
   });
 
-  it('sends the token for ntfy and webhook when one is set', async () => {
-    const c = await createComponent();
-    c.formWebhookUrl.set('https://ntfy.example.com');
-    c.formTopic.set('media');
-    c.formToken.set('tk_secret');
-
-    c.formType.set('ntfy');
-    expect(settingsOf(c)).toEqual({
-      url: 'https://ntfy.example.com',
-      topic: 'media',
-      token: 'tk_secret',
-    });
-
-    c.formType.set('webhook');
-    expect(settingsOf(c)).toEqual({
-      url: 'https://ntfy.example.com',
-      token: 'tk_secret',
-    });
-  });
-
   it('omits a blank token so a public topic stores no credential', async () => {
     const c = await createComponent();
     c.formWebhookUrl.set('https://ntfy.sh');
@@ -163,7 +153,7 @@ describe('NotificationsSettingsComponent — provider tokens', () => {
     expect(settingsOf(c)).toEqual({ url: 'https://ntfy.sh', topic: 'media' });
   });
 
-  it('round-trips a stored token back into the editor', async () => {
+  it('leaves the token blank on edit, so saving keeps the stored one', async () => {
     const c = await createComponent();
     c.openEdit({
       id: 1,
@@ -171,14 +161,10 @@ describe('NotificationsSettingsComponent — provider tokens', () => {
       type: 'ntfy',
       enabled: true,
       events: [],
-      settings: {
-        url: 'https://ntfy.example.com',
-        topic: 'media',
-        token: 'tk_secret',
-      },
+      settings: { url: 'https://ntfy.example.com', topic: 'media' },
     });
 
-    expect(c.formToken()).toBe('tk_secret');
-    expect(settingsOf(c)).toMatchObject({ token: 'tk_secret' });
+    expect(c.formToken()).toBe('');
+    expect(settingsOf(c)).not.toHaveProperty('token');
   });
 });

--- a/client/src/app/features/settings/notifications/notifications.ts
+++ b/client/src/app/features/settings/notifications/notifications.ts
@@ -73,8 +73,8 @@ export class NotificationsSettingsComponent implements OnInit {
   readonly connectionTypes = ['discord', 'slack', 'webhook', 'gotify', 'ntfy'] as const;
 
   /** Discord and Slack authenticate through the webhook URL itself. */
-  readonly supportsToken = computed(() =>
-    (['webhook', 'gotify', 'ntfy'] as string[]).includes(this.formType()),
+  readonly supportsToken = computed(
+    () => this.formType() !== 'discord' && this.formType() !== 'slack',
   );
 
   ngOnInit() {
@@ -115,7 +115,7 @@ export class NotificationsSettingsComponent implements OnInit {
     this.formEnabled.set(nc.enabled);
     const s = nc.settings ?? {};
     this.formWebhookUrl.set(String(s['webhookUrl'] ?? s['url'] ?? ''));
-    this.formToken.set(String(s['token'] ?? ''));
+    this.formToken.set('');
     this.formTopic.set(String(s['topic'] ?? ''));
     this.formEvents.set([...nc.events]);
     this.testResult.set(null);
@@ -143,7 +143,7 @@ export class NotificationsSettingsComponent implements OnInit {
       return { url: this.formWebhookUrl(), ...(token ? { token } : {}) };
     }
     if (type === 'gotify') {
-      return { url: this.formWebhookUrl(), token: this.formToken() };
+      return { url: this.formWebhookUrl(), token };
     }
     if (type === 'ntfy') {
       return {

--- a/client/src/app/features/settings/notifications/notifications.ts
+++ b/client/src/app/features/settings/notifications/notifications.ts
@@ -2,6 +2,7 @@ import {
   Component,
   ChangeDetectionStrategy,
   ElementRef,
+  computed,
   signal,
   inject,
   OnInit,
@@ -71,6 +72,11 @@ export class NotificationsSettingsComponent implements OnInit {
 
   readonly connectionTypes = ['discord', 'slack', 'webhook', 'gotify', 'ntfy'] as const;
 
+  /** Discord and Slack authenticate through the webhook URL itself. */
+  readonly supportsToken = computed(() =>
+    (['webhook', 'gotify', 'ntfy'] as string[]).includes(this.formType()),
+  );
+
   ngOnInit() {
     this.reloadAll();
   }
@@ -132,14 +138,19 @@ export class NotificationsSettingsComponent implements OnInit {
       return { webhookUrl: this.formWebhookUrl() };
     }
     // These three read `url` server-side.
+    const token = this.formToken().trim();
     if (type === 'webhook') {
-      return { url: this.formWebhookUrl() };
+      return { url: this.formWebhookUrl(), ...(token ? { token } : {}) };
     }
     if (type === 'gotify') {
       return { url: this.formWebhookUrl(), token: this.formToken() };
     }
     if (type === 'ntfy') {
-      return { url: this.formWebhookUrl(), topic: this.formTopic() };
+      return {
+        url: this.formWebhookUrl(),
+        topic: this.formTopic(),
+        ...(token ? { token } : {}),
+      };
     }
     return {};
   }

--- a/client/src/app/features/settings/notifications/notifications.ts
+++ b/client/src/app/features/settings/notifications/notifications.ts
@@ -20,6 +20,7 @@ interface NotificationConnection {
   type: string;
   enabled: boolean;
   events: string[];
+  settings?: Record<string, unknown>;
 }
 
 interface CreateNotificationBody {
@@ -106,9 +107,10 @@ export class NotificationsSettingsComponent implements OnInit {
     this.formName.set(nc.name);
     this.formType.set(nc.type as CreateNotificationBody['type']);
     this.formEnabled.set(nc.enabled);
-    this.formWebhookUrl.set('');
-    this.formToken.set('');
-    this.formTopic.set('');
+    const s = nc.settings ?? {};
+    this.formWebhookUrl.set(String(s['webhookUrl'] ?? s['url'] ?? ''));
+    this.formToken.set(String(s['token'] ?? ''));
+    this.formTopic.set(String(s['topic'] ?? ''));
     this.formEvents.set([...nc.events]);
     this.testResult.set(null);
     this.editorDialog()?.nativeElement.showModal();
@@ -126,14 +128,18 @@ export class NotificationsSettingsComponent implements OnInit {
 
   private buildSettings(): Record<string, unknown> {
     const type = this.formType();
-    if (type === 'discord' || type === 'slack' || type === 'webhook') {
+    if (type === 'discord' || type === 'slack') {
       return { webhookUrl: this.formWebhookUrl() };
     }
+    // These three read `url` server-side.
+    if (type === 'webhook') {
+      return { url: this.formWebhookUrl() };
+    }
     if (type === 'gotify') {
-      return { webhookUrl: this.formWebhookUrl(), token: this.formToken() };
+      return { url: this.formWebhookUrl(), token: this.formToken() };
     }
     if (type === 'ntfy') {
-      return { webhookUrl: this.formWebhookUrl(), topic: this.formTopic() };
+      return { url: this.formWebhookUrl(), topic: this.formTopic() };
     }
     return {};
   }


### PR DESCRIPTION
Stacked on #1001 — based on that branch, so review it first. GitHub will retarget this to
`main` automatically once #1001 merges.

## Why

Two providers accept credentials that Fliks could not actually send:

- **ntfy** sent nothing at all. A reserved topic on ntfy.sh, or a self-hosted server running
  `auth-default-access: deny-all`, answers `403` and the notification is dropped — silently,
  since `dispatch()` swallows the rejection.
- **The generic webhook** already sent `Authorization: Bearer` server-side, but the editor
  only rendered the token field for gotify, so the setting was unreachable through the UI.

## What changed

- ntfy sends `Authorization: Bearer <token>` when one is configured, and omits the header
  entirely when it is not, so public topics behave exactly as before.
- The token field now renders for every provider that can use one (webhook, gotify, ntfy).
  Discord and Slack keep authenticating through the webhook URL itself.
- A blank token is dropped rather than stored, so a public topic keeps no empty credential.
- New `field_token_optional` label across all six locales; gotify's token stays mandatory.

## Verification

Ran the real service against a live HTTP server (real axios, no mocking):

```
{"path": "/media",  "title": "Fliks - health.issue", "auth": "Bearer tk_secret"}
{"path": "/public", "title": "Fliks - health.issue"}
{"path": "/hook",                                    "auth": "Bearer wh_secret"}
```

The public topic carries no `Authorization` header. 8 new tests (4 backend, 4 client); full
suites green — 1584 backend, 427 client.

## Note

`findAll()` returns `settings` unredacted, so these tokens reach any client allowed to read
the settings page — the same pre-existing gap called out in #1001, but this PR makes it apply
to more connections. Worth fixing separately; note that redacting naively would break the
editor hydration, which needs the stored value to round-trip.
