### PR TITLE
fix(setup): probe https when the entered http base only redirects

### DIFF
--- a/client/src/app/features/setup/setup.spec.ts
+++ b/client/src/app/features/setup/setup.spec.ts
@@ -1,0 +1,73 @@
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { HttpClient } from '@angular/common/http';
+import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
+import { of, throwError } from 'rxjs';
+import { SetupComponent } from './setup';
+import { ServerConfigService } from '../../core/services/server-config.service';
+import { AuthService } from '../../core/services/auth.service';
+
+/** Reachable over https only — mirrors a host whose http port 301s to https. */
+const httpsOnly = {
+  get: (url: string) =>
+    url.startsWith('https://')
+      ? throwError(() => ({ status: 401 }))
+      : throwError(() => ({ status: 0 })),
+} as unknown as HttpClient;
+
+async function createComponent(http: HttpClient) {
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      provideTranslateService({
+        lang: 'en',
+        loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+      }),
+      { provide: HttpClient, useValue: http },
+      {
+        provide: ServerConfigService,
+        useValue: { serverUrl: () => '', knownServers: signal([]) },
+      },
+      {
+        provide: AuthService,
+        useValue: { switchToServer: () => Promise.resolve(), serversWithSession: () => new Set() },
+      },
+    ],
+  });
+  const fixture = TestBed.createComponent(SetupComponent);
+  await fixture.whenStable();
+  return fixture.componentInstance;
+}
+
+describe('SetupComponent — https fallback', () => {
+  it('retries an http entry over https and keeps the working base', async () => {
+    const c = await createComponent(httpsOnly);
+    c.url.set('http://fliks.example.com');
+
+    await c.test();
+
+    expect(c.testResult()).toEqual({ ok: true, message: 'setup.test_success' });
+    expect(c.url()).toBe('https://fliks.example.com');
+  });
+
+  it('keeps an http entry that answers over http', async () => {
+    const reachable = { get: () => throwError(() => ({ status: 401 })) } as unknown as HttpClient;
+    const c = await createComponent(reachable);
+    c.url.set('http://192.168.1.10:3001');
+
+    await c.test();
+
+    expect(c.testResult()?.ok).toBe(true);
+    expect(c.url()).toBe('http://192.168.1.10:3001');
+  });
+
+  it('reports an error when neither scheme answers', async () => {
+    const dead = { get: () => throwError(() => ({ status: 0 })) } as unknown as HttpClient;
+    const c = await createComponent(dead);
+    c.url.set('http://nope.example.com');
+
+    await c.test();
+
+    expect(c.testResult()).toEqual({ ok: false, message: 'setup.test_error' });
+  });
+});

--- a/client/src/app/features/setup/setup.ts
+++ b/client/src/app/features/setup/setup.ts
@@ -11,6 +11,17 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ServerConfigService, KnownServer } from '../../core/services/server-config.service';
 import { AuthService } from '../../core/services/auth.service';
 
+/**
+ * Bases to probe, in order. An http host that 301s to https is unusable from the
+ * native app: the redirect carries no CORS headers, so the XHR dies before it can
+ * be followed. Probing https directly is the only way to reach such a server.
+ */
+export function withHttpsFallback(base: string): string[] {
+  return base.startsWith('http://')
+    ? [base, `https://${base.slice('http://'.length)}`]
+    : [base];
+}
+
 @Component({
   selector: 'app-setup',
   imports: [FormsModule, TranslateModule],
@@ -39,19 +50,26 @@ export class SetupComponent {
     this.testing.set(true);
     this.testResult.set(null);
     try {
-      // /api/auth/me returns 401 if not logged in, but proves the server is reachable
-      await firstValueFrom(this.http.get(`${raw}/api/auth/me`, { responseType: 'json' }));
-      this.testResult.set({ ok: true, message: 'setup.test_success' });
-    } catch (err: unknown) {
-      const status = (err as { status?: number })?.status;
-      // 401 = server reachable but not authenticated — that's fine
-      if (status === 401) {
-        this.testResult.set({ ok: true, message: 'setup.test_success' });
-      } else {
-        this.testResult.set({ ok: false, message: 'setup.test_error' });
+      for (const base of withHttpsFallback(raw)) {
+        if (await this.reachable(base)) {
+          this.url.set(base);
+          this.testResult.set({ ok: true, message: 'setup.test_success' });
+          return;
+        }
       }
+      this.testResult.set({ ok: false, message: 'setup.test_error' });
     } finally {
       this.testing.set(false);
+    }
+  }
+
+  /** 401 counts as reachable: the server answered, we're just not logged in. */
+  private async reachable(base: string): Promise<boolean> {
+    try {
+      await firstValueFrom(this.http.get(`${base}/api/auth/me`, { responseType: 'json' }));
+      return true;
+    } catch (err: unknown) {
+      return (err as { status?: number })?.status === 401;
     }
   }
 


### PR DESCRIPTION
## Problem

On Android, entering the server as `http://…` in the setup screen always fails with *"Impossible de se connecter au serveur."*, even though the same host works over `https://`.

The cause is not cleartext blocking — that was ruled out: the merged manifest has `usesCleartextTraffic="true"` with no `networkSecurityConfig`, the app origin is already `http://localhost` (`androidScheme: 'http'`), `http://localhost` is in the backend CORS allowlist, and the native build authenticates with a Bearer token, not cookies.

The real cause is the redirect. The host answers plain http with a `301` to https:

```
$ curl -i -H "Origin: http://localhost" http://<host>/api/auth/me
HTTP/1.1 301 Moved Permanently
Location: https://<host>/api/auth/me
```

No `Access-Control-Allow-Origin` on that `301`. A cross-origin XHR must pass the CORS check on the *redirect* response before it may follow it, so the WebView aborts with a network error (status 0) and the probe reports the server unreachable. `resolveCanonicalUrl`'s `redirect: 'follow'` cannot help for the same reason.

## Fix

The setup probe now tries the entered base, then the https upgrade of it, and keeps whichever answered — so the canonical URL that gets stored is one the app can actually talk to. An http-only LAN server (`http://192.168.x.x:3001`) is unaffected: the first candidate answers and nothing is rewritten.

## Tests

`client/src/app/features/setup/setup.spec.ts` — https-only host rewrites the entry, http-only host is kept as typed, dead host still reports the error.

## Manual check

Setup → type `http://<your-host>` → *Test*: the field flips to `https://<your-host>` and the test succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)