### PR TITLE
fix: localize hardcoded French option labels, document the default login

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,16 @@ docker compose up -d
 ### First run
 
 Whichever you picked, open `http://<host>:4848` in a browser — on the
-machine itself that's `http://localhost:4848`. Create the first account,
-add a library pointing at your video folder (`/medias` under Docker), and
-Fliks scans it and goes looking for the covers.
+machine itself that's `http://localhost:4848`. Sign in with the account
+Fliks creates on its first boot:
+
+| Username | Password |
+|---|---|
+| `admin` | `password` |
+
+Change that password right away — user menu → **Account**. Then add a
+library pointing at your video folder (`/medias` under Docker), and Fliks
+scans it and goes looking for the covers.
 
 Then install the app on your phone or TV, point it at the same address,
 and you're done.

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -446,7 +446,8 @@
     "sub_bottom_margin": "Position des unteren Rands",
     "sub_bottom_margin_hint": "Legt die vertikale Position der Untertitel relativ zum unteren Bildschirmrand fest.",
     "sub_top_margin": "Position des oberen Rands",
-    "sub_top_margin_hint": "Legt die maximal erlaubte vertikale Position relativ zum oberen Bildschirmrand fest. Diese Funktion wird verwendet, wenn die Untertitel Positionierungsanweisungen für den oberen Bildschirmrand enthalten."
+    "sub_top_margin_hint": "Legt die maximal erlaubte vertikale Position relativ zum oberen Bildschirmrand fest. Diese Funktion wird verwendet, wenn die Untertitel Positionierungsanweisungen für den oberen Bildschirmrand enthalten.",
+    "lang_any": "Keine Präferenz"
   },
   "import_disk": {
     "title": "Manueller Import vom Datenträger",
@@ -1730,7 +1731,24 @@
       "name": "Name",
       "name_required": "Der Name ist erforderlich.",
       "icon": "Symbol",
+      "icon_default": "Standard (Bibliothek)",
+      "icons": {
+        "book": "Buch",
+        "clapperboard": "Filmklappe",
+        "film": "Film",
+        "folder": "Ordner",
+        "games": "Spiele",
+        "globe": "Globus",
+        "heart": "Herz",
+        "monitor": "Bildschirm",
+        "music": "Musik",
+        "popcorn": "Popcorn",
+        "star": "Stern",
+        "swords": "Schwerter",
+        "users": "Benutzer"
+      },
       "color": "Farbe",
+      "color_default": "Standard (primary)",
       "media_types": "Medientypen",
       "media_type_required": "Wählen Sie mindestens einen Medientyp aus.",
       "path": "Stammpfad",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -451,7 +451,8 @@
     "sub_bottom_margin": "Bottom edge position",
     "sub_bottom_margin_hint": "Sets the vertical position of subtitles relative to the bottom of the screen.",
     "sub_top_margin": "Top edge position",
-    "sub_top_margin_hint": "Sets the maximum vertical position allowed relative to the top of the screen. This is used when subtitles contain positioning instructions at the top of the screen."
+    "sub_top_margin_hint": "Sets the maximum vertical position allowed relative to the top of the screen. This is used when subtitles contain positioning instructions at the top of the screen.",
+    "lang_any": "No preference"
   },
   "import_disk": {
     "title": "Manual import from disk",
@@ -1747,7 +1748,24 @@
       "name": "Name",
       "name_required": "The name is required.",
       "icon": "Icon",
+      "icon_default": "Default (library)",
+      "icons": {
+        "book": "Book",
+        "clapperboard": "Clapperboard",
+        "film": "Film",
+        "folder": "Folder",
+        "games": "Games",
+        "globe": "Globe",
+        "heart": "Heart",
+        "monitor": "Screen",
+        "music": "Music",
+        "popcorn": "Popcorn",
+        "star": "Star",
+        "swords": "Swords",
+        "users": "Users"
+      },
       "color": "Color",
+      "color_default": "Default (primary)",
       "media_types": "Media types",
       "media_type_required": "Select at least one media type.",
       "path": "Root path",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -446,7 +446,8 @@
     "sub_bottom_margin": "Posición del borde inferior",
     "sub_bottom_margin_hint": "Define la posición vertical de los subtítulos respecto a la parte inferior de la pantalla.",
     "sub_top_margin": "Posición del borde superior",
-    "sub_top_margin_hint": "Define la posición vertical máxima permitida respecto a la parte superior de la pantalla. Esta función se usa cuando los subtítulos contienen instrucciones de posicionamiento en la parte superior de la pantalla."
+    "sub_top_margin_hint": "Define la posición vertical máxima permitida respecto a la parte superior de la pantalla. Esta función se usa cuando los subtítulos contienen instrucciones de posicionamiento en la parte superior de la pantalla.",
+    "lang_any": "Sin preferencia"
   },
   "import_disk": {
     "title": "Importación manual desde el disco",
@@ -1730,7 +1731,24 @@
       "name": "Nombre",
       "name_required": "El nombre es obligatorio.",
       "icon": "Icono",
+      "icon_default": "Por defecto (biblioteca)",
+      "icons": {
+        "book": "Libro",
+        "clapperboard": "Claqueta",
+        "film": "Película",
+        "folder": "Carpeta",
+        "games": "Juegos",
+        "globe": "Globo",
+        "heart": "Corazón",
+        "monitor": "Pantalla",
+        "music": "Música",
+        "popcorn": "Palomitas",
+        "star": "Estrella",
+        "swords": "Espadas",
+        "users": "Usuarios"
+      },
       "color": "Color",
+      "color_default": "Por defecto (primary)",
       "media_types": "Tipos de medios",
       "media_type_required": "Seleccione al menos un tipo de medio.",
       "path": "Ruta raíz",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -451,7 +451,8 @@
     "sub_bottom_margin": "Position du bord inférieur",
     "sub_bottom_margin_hint": "Définit la position verticale des sous-titres par rapport au bas de l'écran.",
     "sub_top_margin": "Position du bord supérieur",
-    "sub_top_margin_hint": "Définit la position verticale maximale autorisée par rapport au haut de l'écran. Cette fonction est utilisée lorsque les sous-titres contiennent des instructions de positionnement en haut de l'écran."
+    "sub_top_margin_hint": "Définit la position verticale maximale autorisée par rapport au haut de l'écran. Cette fonction est utilisée lorsque les sous-titres contiennent des instructions de positionnement en haut de l'écran.",
+    "lang_any": "Aucune préférence"
   },
   "import_disk": {
     "title": "Import manuel depuis le disque",
@@ -1747,7 +1748,24 @@
       "name": "Nom",
       "name_required": "Le nom est obligatoire.",
       "icon": "Icône",
+      "icon_default": "Par défaut (bibliothèque)",
+      "icons": {
+        "book": "Livre",
+        "clapperboard": "Clap",
+        "film": "Film",
+        "folder": "Dossier",
+        "games": "Jeux",
+        "globe": "Globe",
+        "heart": "Cœur",
+        "monitor": "Écran",
+        "music": "Musique",
+        "popcorn": "Popcorn",
+        "star": "Étoile",
+        "swords": "Épées",
+        "users": "Utilisateurs"
+      },
       "color": "Couleur",
+      "color_default": "Par défaut (primary)",
       "media_types": "Types de médias",
       "media_type_required": "Sélectionnez au moins un type de média.",
       "path": "Chemin racine",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -446,7 +446,8 @@
     "sub_bottom_margin": "Posizione del bordo inferiore",
     "sub_bottom_margin_hint": "Definisce la posizione verticale dei sottotitoli rispetto al basso dello schermo.",
     "sub_top_margin": "Posizione del bordo superiore",
-    "sub_top_margin_hint": "Definisce la posizione verticale massima consentita rispetto all'alto dello schermo. Questa funzione viene usata quando i sottotitoli contengono istruzioni di posizionamento in alto sullo schermo."
+    "sub_top_margin_hint": "Definisce la posizione verticale massima consentita rispetto all'alto dello schermo. Questa funzione viene usata quando i sottotitoli contengono istruzioni di posizionamento in alto sullo schermo.",
+    "lang_any": "Nessuna preferenza"
   },
   "import_disk": {
     "title": "Import manuale dal disco",
@@ -1730,7 +1731,24 @@
       "name": "Nome",
       "name_required": "Il nome è obbligatorio.",
       "icon": "Icona",
+      "icon_default": "Predefinito (libreria)",
+      "icons": {
+        "book": "Libro",
+        "clapperboard": "Ciak",
+        "film": "Film",
+        "folder": "Cartella",
+        "games": "Giochi",
+        "globe": "Globo",
+        "heart": "Cuore",
+        "monitor": "Schermo",
+        "music": "Musica",
+        "popcorn": "Popcorn",
+        "star": "Stella",
+        "swords": "Spade",
+        "users": "Utenti"
+      },
       "color": "Colore",
+      "color_default": "Predefinito (primary)",
       "media_types": "Tipi di file multimediali",
       "media_type_required": "Seleziona almeno un tipo di file multimediale.",
       "path": "Percorso radice",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -446,7 +446,8 @@
     "sub_bottom_margin": "Posição da margem inferior",
     "sub_bottom_margin_hint": "Define a posição vertical das legendas em relação à parte inferior do ecrã.",
     "sub_top_margin": "Posição da margem superior",
-    "sub_top_margin_hint": "Define a posição vertical máxima permitida em relação ao topo do ecrã. Esta função é usada quando as legendas contêm instruções de posicionamento no topo do ecrã."
+    "sub_top_margin_hint": "Define a posição vertical máxima permitida em relação ao topo do ecrã. Esta função é usada quando as legendas contêm instruções de posicionamento no topo do ecrã.",
+    "lang_any": "Sem preferência"
   },
   "import_disk": {
     "title": "Importação manual a partir do disco",
@@ -1730,7 +1731,24 @@
       "name": "Nome",
       "name_required": "O nome é obrigatório.",
       "icon": "Ícone",
+      "icon_default": "Predefinido (biblioteca)",
+      "icons": {
+        "book": "Livro",
+        "clapperboard": "Claquete",
+        "film": "Filme",
+        "folder": "Pasta",
+        "games": "Jogos",
+        "globe": "Globo",
+        "heart": "Coração",
+        "monitor": "Ecrã",
+        "music": "Música",
+        "popcorn": "Pipocas",
+        "star": "Estrela",
+        "swords": "Espadas",
+        "users": "Utilizadores"
+      },
       "color": "Cor",
+      "color_default": "Predefinido (primary)",
       "media_types": "Tipos de media",
       "media_type_required": "Selecione pelo menos um tipo de media.",
       "path": "Caminho raiz",

--- a/client/src/app/core/constants/library-appearance.ts
+++ b/client/src/app/core/constants/library-appearance.ts
@@ -1,0 +1,35 @@
+export interface LibraryAppearanceOption {
+  value: string | null;
+  label?: string;
+  labelKey?: string;
+}
+
+export const LIBRARY_ICON_OPTIONS: readonly LibraryAppearanceOption[] = [
+  { value: null, labelKey: 'settings.libraries.icon_default' },
+  { value: 'film', labelKey: 'settings.libraries.icons.film' },
+  { value: 'tv', label: 'TV' },
+  { value: 'popcorn', labelKey: 'settings.libraries.icons.popcorn' },
+  { value: 'clapperboard', labelKey: 'settings.libraries.icons.clapperboard' },
+  { value: 'book', labelKey: 'settings.libraries.icons.book' },
+  { value: 'gamepad-2', labelKey: 'settings.libraries.icons.games' },
+  { value: 'music', labelKey: 'settings.libraries.icons.music' },
+  { value: 'heart', labelKey: 'settings.libraries.icons.heart' },
+  { value: 'star', labelKey: 'settings.libraries.icons.star' },
+  { value: 'globe', labelKey: 'settings.libraries.icons.globe' },
+  { value: 'monitor', labelKey: 'settings.libraries.icons.monitor' },
+  { value: 'users', labelKey: 'settings.libraries.icons.users' },
+  { value: 'folder', labelKey: 'settings.libraries.icons.folder' },
+  { value: 'swords', labelKey: 'settings.libraries.icons.swords' },
+] as const;
+
+/** daisyUI role names — proper nouns of the theme, not translated. */
+export const LIBRARY_COLOR_OPTIONS: readonly LibraryAppearanceOption[] = [
+  { value: null, labelKey: 'settings.libraries.color_default' },
+  { value: 'primary', label: 'Primary' },
+  { value: 'secondary', label: 'Secondary' },
+  { value: 'accent', label: 'Accent' },
+  { value: 'info', label: 'Info' },
+  { value: 'success', label: 'Success' },
+  { value: 'warning', label: 'Warning' },
+  { value: 'error', label: 'Error' },
+] as const;

--- a/client/src/app/core/constants/metadata-locale.spec.ts
+++ b/client/src/app/core/constants/metadata-locale.spec.ts
@@ -1,0 +1,16 @@
+import { metadataRegionOptions } from './metadata-locale';
+
+describe('metadataRegionOptions', () => {
+  it('localizes region names to the given UI language', () => {
+    const en = metadataRegionOptions('en');
+    const fr = metadataRegionOptions('fr');
+    expect(en.find((o) => o.code === 'US')?.label).toBe('United States');
+    expect(fr.find((o) => o.code === 'US')?.label).toBe('États-Unis');
+    expect(en.length).toBe(fr.length);
+  });
+
+  it('falls back to the raw code on an unusable locale tag', () => {
+    const opts = metadataRegionOptions('not-a-locale');
+    expect(opts.find((o) => o.code === 'JP')?.label).toBeTruthy();
+  });
+});

--- a/client/src/app/core/constants/metadata-locale.ts
+++ b/client/src/app/core/constants/metadata-locale.ts
@@ -20,23 +20,38 @@ export const METADATA_LANGUAGE_OPTIONS: readonly MetadataLocaleOption[] = [
 ];
 
 /** Regions driving release dates / upcoming (ISO 3166-1). */
-export const METADATA_REGION_OPTIONS: readonly MetadataLocaleOption[] = [
-  { code: 'US', label: 'États-Unis' },
-  { code: 'GB', label: 'Royaume-Uni' },
-  { code: 'FR', label: 'France' },
-  { code: 'DE', label: 'Allemagne' },
-  { code: 'ES', label: 'Espagne' },
-  { code: 'IT', label: 'Italie' },
-  { code: 'PT', label: 'Portugal' },
-  { code: 'BR', label: 'Brésil' },
-  { code: 'NL', label: 'Pays-Bas' },
-  { code: 'PL', label: 'Pologne' },
-  { code: 'RU', label: 'Russie' },
-  { code: 'JP', label: 'Japon' },
-  { code: 'KR', label: 'Corée du Sud' },
-  { code: 'CN', label: 'Chine' },
-  { code: 'CA', label: 'Canada' },
-  { code: 'AU', label: 'Australie' },
-  { code: 'MX', label: 'Mexique' },
-  { code: 'IN', label: 'Inde' },
-];
+const METADATA_REGION_CODES = [
+  'US',
+  'GB',
+  'FR',
+  'DE',
+  'ES',
+  'IT',
+  'PT',
+  'BR',
+  'NL',
+  'PL',
+  'RU',
+  'JP',
+  'KR',
+  'CN',
+  'CA',
+  'AU',
+  'MX',
+  'IN',
+] as const;
+
+/** Region names come from the platform (`Intl.DisplayNames`) so they follow the
+ *  UI language instead of shipping 18 names × 6 locales. */
+export function metadataRegionOptions(lang: string): MetadataLocaleOption[] {
+  let display: Intl.DisplayNames | null = null;
+  try {
+    display = new Intl.DisplayNames([lang || 'en'], { type: 'region' });
+  } catch {
+    /* unsupported locale data — fall back to the raw code */
+  }
+  return METADATA_REGION_CODES.map((code) => ({
+    code,
+    label: display?.of(code) ?? code,
+  }));
+}

--- a/client/src/app/features/playback-settings/playback-options.ts
+++ b/client/src/app/features/playback-settings/playback-options.ts
@@ -1,7 +1,13 @@
 /** Shared option lists for playback settings pages. */
 
-export const LANGUAGE_OPTIONS = [
-  { value: '', label: 'Aucune préférence' },
+export interface PlaybackOption {
+  value: string;
+  label?: string;
+  labelKey?: string;
+}
+
+export const LANGUAGE_OPTIONS: readonly PlaybackOption[] = [
+  { value: '', labelKey: 'playback_settings.lang_any' },
   { value: 'fra', label: 'Français' },
   { value: 'eng', label: 'English' },
   { value: 'jpn', label: '日本語 (Japanese)' },
@@ -60,7 +66,7 @@ export const QUALITY_OPTIONS = [
 ];
 
 export const AUDIO_CHANNEL_OPTIONS = [
-  { value: 2, label: 'Stéréo (2.0)' },
+  { value: 2, label: 'Stereo (2.0)' },
   { value: 6, label: 'Surround 5.1' },
   { value: 8, label: 'Surround 7.1' },
 ];

--- a/client/src/app/features/playback-settings/player-settings/player-settings.html
+++ b/client/src/app/features/playback-settings/player-settings/player-settings.html
@@ -8,7 +8,7 @@
       [hint]="'playback_settings.player_preferred_lang_hint' | translate"
     >
       @for (l of languageOptions; track l.value) {
-        <option [value]="l.value">{{ l.label }}</option>
+        <option [value]="l.value">{{ l.labelKey ? (l.labelKey | translate) : l.label }}</option>
       }
     </app-select-field>
 

--- a/client/src/app/features/playback-settings/subtitle-settings/subtitle-settings.html
+++ b/client/src/app/features/playback-settings/subtitle-settings/subtitle-settings.html
@@ -4,7 +4,7 @@
     <label class="form-control w-full max-w-xs">
       <div class="label"><span class="label-text font-medium">{{ 'playback_settings.sub_preferred_lang' | translate }}</span></div>
       <select class="select select-bordered w-full" [ngModel]="preferredSubtitleLanguage()" (ngModelChange)="preferredSubtitleLanguage.set($event)">
-        @for (l of languageOptions; track l.value) { <option [value]="l.value">{{ l.label }}</option> }
+        @for (l of languageOptions; track l.value) { <option [value]="l.value">{{ l.labelKey ? (l.labelKey | translate) : l.label }}</option> }
       </select>
     </label>
 

--- a/client/src/app/features/settings/general/general.ts
+++ b/client/src/app/features/settings/general/general.ts
@@ -12,7 +12,7 @@ import { ToastService } from '../../../core/services/toast.service';
 import { SetupChecklistComponent } from '../../../shared/components/setup-checklist/setup-checklist';
 import {
   METADATA_LANGUAGE_OPTIONS,
-  METADATA_REGION_OPTIONS,
+  metadataRegionOptions,
 } from '../../../core/constants/metadata-locale';
 
 @Component({
@@ -39,7 +39,7 @@ export class GeneralSettingsComponent implements OnInit {
   readonly metadataRegion = signal('US');
   readonly savingMetadataLanguage = signal(false);
   readonly metadataLanguageOptions = METADATA_LANGUAGE_OPTIONS;
-  readonly metadataRegionOptions = METADATA_REGION_OPTIONS;
+  readonly metadataRegionOptions = metadataRegionOptions(this.translate.currentLang);
 
   // Automation
   readonly autoGrabOnApproval = signal('true');

--- a/client/src/app/features/settings/libraries/libraries.html
+++ b/client/src/app/features/settings/libraries/libraries.html
@@ -86,7 +86,7 @@
           <select class="select select-bordered select-sm w-full"
             [ngModel]="formIcon()" (ngModelChange)="formIcon.set($event || null)">
             @for (opt of iconOptions; track opt.value) {
-              <option [ngValue]="opt.value">{{ opt.label }}</option>
+              <option [ngValue]="opt.value">{{ opt.labelKey ? (opt.labelKey | translate) : opt.label }}</option>
             }
           </select>
         </label>
@@ -95,7 +95,7 @@
           <select class="select select-bordered select-sm w-full"
             [ngModel]="formColor()" (ngModelChange)="formColor.set($event || null)">
             @for (opt of colorOptions; track opt.value) {
-              <option [ngValue]="opt.value">{{ opt.label }}</option>
+              <option [ngValue]="opt.value">{{ opt.labelKey ? (opt.labelKey | translate) : opt.label }}</option>
             }
           </select>
         </label>

--- a/client/src/app/features/settings/libraries/libraries.ts
+++ b/client/src/app/features/settings/libraries/libraries.ts
@@ -24,6 +24,10 @@ import {
 } from '../../../core/services/api/profiles.service';
 import { ToastService } from '../../../core/services/toast.service';
 import { FolderPickerService } from '../../../core/services/folder-picker.service';
+import {
+  LIBRARY_COLOR_OPTIONS,
+  LIBRARY_ICON_OPTIONS,
+} from '../../../core/constants/library-appearance';
 import { METADATA_PROVIDER_OPTIONS_LIBRARY } from '../../../core/constants/metadata-providers';
 
 @Component({
@@ -67,34 +71,8 @@ export class LibrariesSettingsComponent implements OnInit {
   readonly formUserIds = signal<Set<number>>(new Set());
   readonly saveError = signal('');
 
-  readonly iconOptions = [
-    { value: null, label: 'Par défaut (bibliothèque)' },
-    { value: 'film', label: 'Film' },
-    { value: 'tv', label: 'TV' },
-    { value: 'popcorn', label: 'Popcorn' },
-    { value: 'clapperboard', label: 'Clap' },
-    { value: 'book', label: 'Livre' },
-    { value: 'gamepad-2', label: 'Jeux' },
-    { value: 'music', label: 'Musique' },
-    { value: 'heart', label: 'Cœur' },
-    { value: 'star', label: 'Étoile' },
-    { value: 'globe', label: 'Globe' },
-    { value: 'monitor', label: 'Écran' },
-    { value: 'users', label: 'Utilisateurs' },
-    { value: 'folder', label: 'Dossier' },
-    { value: 'swords', label: 'Épées' },
-  ];
-
-  readonly colorOptions = [
-    { value: null, label: 'Par défaut (primary)' },
-    { value: 'primary', label: 'Primary' },
-    { value: 'secondary', label: 'Secondary' },
-    { value: 'accent', label: 'Accent' },
-    { value: 'info', label: 'Info' },
-    { value: 'success', label: 'Success' },
-    { value: 'warning', label: 'Warning' },
-    { value: 'error', label: 'Error' },
-  ];
+  readonly iconOptions = LIBRARY_ICON_OPTIONS;
+  readonly colorOptions = LIBRARY_COLOR_OPTIONS;
 
   readonly providerOptions = METADATA_PROVIDER_OPTIONS_LIBRARY;
 

--- a/client/src/app/features/settings/libraries/library-detail/library-general.html
+++ b/client/src/app/features/settings/libraries/library-detail/library-general.html
@@ -19,7 +19,7 @@
           <select class="select select-bordered w-full"
             [ngModel]="state.formIcon()" (ngModelChange)="state.formIcon.set($event || null)">
             @for (opt of iconOptions; track opt.value) {
-              <option [ngValue]="opt.value">{{ opt.label }}</option>
+              <option [ngValue]="opt.value">{{ opt.labelKey ? (opt.labelKey | translate) : opt.label }}</option>
             }
           </select>
         </label>
@@ -30,7 +30,7 @@
           <select class="select select-bordered w-full"
             [ngModel]="state.formColor()" (ngModelChange)="state.formColor.set($event || null)">
             @for (opt of colorOptions; track opt.value) {
-              <option [ngValue]="opt.value">{{ opt.label }}</option>
+              <option [ngValue]="opt.value">{{ opt.labelKey ? (opt.labelKey | translate) : opt.label }}</option>
             }
           </select>
         </label>

--- a/client/src/app/features/settings/libraries/library-detail/library-general.ts
+++ b/client/src/app/features/settings/libraries/library-detail/library-general.ts
@@ -1,10 +1,14 @@
 import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import {
+  LIBRARY_COLOR_OPTIONS,
+  LIBRARY_ICON_OPTIONS,
+} from '../../../../core/constants/library-appearance';
 import { METADATA_PROVIDER_OPTIONS_LIBRARY } from '../../../../core/constants/metadata-providers';
 import {
   METADATA_LANGUAGE_OPTIONS,
-  METADATA_REGION_OPTIONS,
+  metadataRegionOptions,
 } from '../../../../core/constants/metadata-locale';
 import { LibraryDetailState } from './library-detail.state';
 
@@ -16,39 +20,14 @@ import { LibraryDetailState } from './library-detail.state';
 })
 export class LibraryGeneralComponent {
   readonly state = inject(LibraryDetailState);
+  private readonly translate = inject(TranslateService);
 
-  readonly iconOptions = [
-    { value: null, label: 'Par défaut (bibliothèque)' },
-    { value: 'film', label: 'Film' },
-    { value: 'tv', label: 'TV' },
-    { value: 'popcorn', label: 'Popcorn' },
-    { value: 'clapperboard', label: 'Clap' },
-    { value: 'book', label: 'Livre' },
-    { value: 'gamepad-2', label: 'Jeux' },
-    { value: 'music', label: 'Musique' },
-    { value: 'heart', label: 'Cœur' },
-    { value: 'star', label: 'Étoile' },
-    { value: 'globe', label: 'Globe' },
-    { value: 'monitor', label: 'Écran' },
-    { value: 'users', label: 'Utilisateurs' },
-    { value: 'folder', label: 'Dossier' },
-    { value: 'swords', label: 'Épées' },
-  ];
-
-  readonly colorOptions = [
-    { value: null, label: 'Par défaut (primary)' },
-    { value: 'primary', label: 'Primary' },
-    { value: 'secondary', label: 'Secondary' },
-    { value: 'accent', label: 'Accent' },
-    { value: 'info', label: 'Info' },
-    { value: 'success', label: 'Success' },
-    { value: 'warning', label: 'Warning' },
-    { value: 'error', label: 'Error' },
-  ];
+  readonly iconOptions = LIBRARY_ICON_OPTIONS;
+  readonly colorOptions = LIBRARY_COLOR_OPTIONS;
 
   readonly providerOptions = METADATA_PROVIDER_OPTIONS_LIBRARY;
   readonly metadataLanguageOptions = METADATA_LANGUAGE_OPTIONS;
-  readonly metadataRegionOptions = METADATA_REGION_OPTIONS;
+  readonly metadataRegionOptions = metadataRegionOptions(this.translate.currentLang);
 
   save() {
     void this.state.save();


### PR DESCRIPTION
Three reported defects, verified in the code before fixing.

## Untranslated "Par défaut" on the library icon and colour pickers

The option lists were literal French strings in the TypeScript (`{ value: null, label: 'Par défaut (bibliothèque)' }`), so every non-French UI showed them as-is — including the 13 icon names (`Livre`, `Jeux`, `Cœur`, `Épées`…). The same two lists were duplicated between `libraries.ts` and `library-general.ts`, so fixing one left the other wrong.

They now live in `core/constants/library-appearance.ts` with `labelKey`s, following the existing `METADATA_PROVIDER_OPTIONS_LIBRARY` pattern, and the keys ship in all six locales.

## Same defect on the neighbouring pickers

Found while grepping for siblings of the reported symptom:

- the 18 metadata **region** names were French for everyone (`États-Unis`, `Royaume-Uni`, `Brésil`…). They now come from `Intl.DisplayNames` driven by the active UI language, which keeps 18 names × 6 locales out of the translation files.
- `Aucune préférence` in the audio/subtitle language pickers → translation key.
- `Stéréo (2.0)` → `Stereo (2.0)` in the cast channel picker.

## The default admin password was undocumented

`UsersService.onModuleInit` seeds `admin` / `password` when the user table is empty, and there is no registration screen — yet the README's *First run* told the user to "create the first account". The credentials appear nowhere in the documentation. The README now states them and tells the user to change the password immediately.

## Checks

- `ng build` clean
- `ng test`: 431 passing, including a new spec covering `metadataRegionOptions` (localization + the unusable-locale fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)