### PR TITLE
fix(plugins): stop cutting slow routes and leaking their RPC error

### DIFF
--- a/backend/src/common/plugin-contract/protocol.ts
+++ b/backend/src/common/plugin-contract/protocol.ts
@@ -90,6 +90,10 @@ export const PLUGIN_DEADLINES_MS = {
   healthReply: 3_000,
   /** Ceiling on one host call, unless the method appears in {@link HOST_CALL_DEADLINE_OVERRIDES_MS}. */
   hostCall: 8_000,
+  /** Ceiling on one call core makes into the plugin — a proxied `http` route or a `job`.
+   *  A route fanning out to third-party upstreams is allowed to be slow, so the plugin's
+   *  own per-upstream timeouts have to fit under this. */
+  pluginCall: 180_000,
   /** After `shutdown` is answered (or not), before SIGTERM, then before SIGKILL. */
   shutdownRpc: 3_000,
   sigtermGrace: 2_000,

--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -118,6 +118,8 @@ interface ConfigPageBase {
   id: string;
   labelKey: string;
   icon?: string;
+  /** One explanatory line under the page title, like every core settings page carries. */
+  subtitleKey?: string;
 }
 
 /** Rendered by `<app-schema-form>` over `app_settings`; omitting `kind` means this one. */

--- a/backend/src/modules/plugins/plugin-jobs.service.ts
+++ b/backend/src/modules/plugins/plugin-jobs.service.ts
@@ -3,10 +3,10 @@ import { SchedulerRegistry } from '@nestjs/schedule';
 import { CronJob } from 'cron';
 import { randomUUID } from 'crypto';
 import { PluginProcessService } from './plugin-process.service';
-import type { PluginJob } from '../../common/plugin-contract';
+import { PLUGIN_DEADLINES_MS, type PluginJob } from '../../common/plugin-contract';
 
-/** Deadline for one `job` call — mirrors `PluginProxyController`'s `CALL_DEADLINE_MS`. */
-const JOB_CALL_DEADLINE_MS = 30_000;
+/** A scheduled search fans out to the same slow upstreams as its interactive counterpart. */
+const JOB_CALL_DEADLINE_MS = PLUGIN_DEADLINES_MS.pluginCall;
 
 function cronKey(pluginId: string, name: string): string {
   return `plugin:${pluginId}:${name}`;

--- a/backend/src/modules/plugins/proxy/plugin-proxy.controller.spec.ts
+++ b/backend/src/modules/plugins/proxy/plugin-proxy.controller.spec.ts
@@ -1,7 +1,9 @@
 import { HttpStatus } from '@nestjs/common';
+import { PLUGIN_DEADLINES_MS } from '../../../common/plugin-contract';
 import type { Response } from 'express';
 import { PluginProxyController } from './plugin-proxy.controller';
 import { PluginInstallException } from '../plugin-install.exception';
+import { RpcTimeoutError } from '../supervisor/wire';
 import type { PluginRouteRequest } from './plugin-route.guard';
 
 function fakeResponse(): Response & { status: jest.Mock; setHeader: jest.Mock; send: jest.Mock } {
@@ -64,8 +66,22 @@ describe('PluginProxyController — plugin availability', () => {
     expect(err.message).toContain('fliks.testplugin');
   });
 
-  it('503 PLUGIN_UNAVAILABLE when the RPC call itself rejects (e.g. a hung plugin past the deadline)', async () => {
-    const callPlugin = jest.fn().mockRejectedValue(new Error('timeout waiting for "http"'));
+  it('504 PLUGIN_TIMEOUT with a translatable key when the plugin does not answer in time', async () => {
+    const callPlugin = jest.fn().mockRejectedValue(new RpcTimeoutError('http', 180_000));
+    const { controller } = makeController('ready', callPlugin);
+    const req = fakeRequest();
+    const res = fakeResponse();
+
+    const err = await captureThrown(() => controller.proxy('fliks.testplugin', req, res));
+    expect(err).toBeInstanceOf(PluginInstallException);
+    expect(err.code).toBe('PLUGIN_TIMEOUT');
+    expect(err.getStatus()).toBe(HttpStatus.GATEWAY_TIMEOUT);
+    // Never the RPC's own wording: it lands in a modal verbatim.
+    expect(err.message).toBe('errors.plugin_timeout');
+  });
+
+  it('503 PLUGIN_UNAVAILABLE, message-free, when the RPC call rejects for any other reason', async () => {
+    const callPlugin = jest.fn().mockRejectedValue(new Error('connection closed'));
     const { controller } = makeController('ready', callPlugin);
     const req = fakeRequest();
     const res = fakeResponse();
@@ -74,6 +90,7 @@ describe('PluginProxyController — plugin availability', () => {
     expect(err).toBeInstanceOf(PluginInstallException);
     expect(err.code).toBe('PLUGIN_UNAVAILABLE');
     expect(err.getStatus()).toBe(HttpStatus.SERVICE_UNAVAILABLE);
+    expect(err.message).toBe('errors.plugin_unavailable');
   });
 
   it('forwards the request\'s own path (not the declared pattern), method, query, body and delegated principal', async () => {
@@ -100,7 +117,7 @@ describe('PluginProxyController — plugin availability', () => {
         body: { grab: true },
         principal: { kind: 'delegated', userId: 9 },
       },
-      30_000,
+      PLUGIN_DEADLINES_MS.pluginCall,
     );
   });
 });

--- a/backend/src/modules/plugins/proxy/plugin-proxy.controller.ts
+++ b/backend/src/modules/plugins/proxy/plugin-proxy.controller.ts
@@ -1,12 +1,15 @@
-import { All, Controller, HttpStatus, Param, Req, Res, UseGuards } from '@nestjs/common';
+import { All, Controller, HttpStatus, Logger, Param, Req, Res, UseGuards } from '@nestjs/common';
 import type { Response } from 'express';
+import { PLUGIN_DEADLINES_MS } from '../../../common/plugin-contract';
 import { JwtOrApiKeyGuard } from '../../auth/guards/jwt-or-api-key.guard';
+import { RpcTimeoutError } from '../supervisor/wire';
 import { PluginRegistryService } from '../plugin-registry.service';
 import { PluginProcessService } from '../plugin-process.service';
 import { PluginInstallException } from '../plugin-install.exception';
 import { PluginRouteGuard, pluginRequestPath, type PluginRouteRequest } from './plugin-route.guard';
 
-const CALL_DEADLINE_MS = 30_000;
+/** A route fanning out to third-party upstreams (indexer search) is allowed to be slow. */
+const CALL_DEADLINE_MS = PLUGIN_DEADLINES_MS.pluginCall;
 
 /** Everything a data response needs, and nothing that steers the browser's session or
  *  navigation — a plugin must never be able to set `Set-Cookie`, `Location` or `Authorization`. */
@@ -41,6 +44,8 @@ interface PluginHttpResult {
 @Controller()
 @UseGuards(JwtOrApiKeyGuard, PluginRouteGuard)
 export class PluginProxyController {
+  private readonly log = new Logger(PluginProxyController.name);
+
   constructor(
     private readonly registry: PluginRegistryService,
     private readonly processService: PluginProcessService,
@@ -76,7 +81,11 @@ export class PluginProxyController {
         CALL_DEADLINE_MS,
       );
     } catch (err) {
-      throw new PluginInstallException(HttpStatus.SERVICE_UNAVAILABLE, 'PLUGIN_UNAVAILABLE', (err as Error).message);
+      // The reason is internal RPC vocabulary and reaches a modal verbatim: log it, answer a key.
+      this.log.warn(`plugin "${pluginId}" ${req.method} ${pluginRequestPath(req)}: ${(err as Error).message}`);
+      throw err instanceof RpcTimeoutError
+        ? new PluginInstallException(HttpStatus.GATEWAY_TIMEOUT, 'PLUGIN_TIMEOUT', 'errors.plugin_timeout')
+        : new PluginInstallException(HttpStatus.SERVICE_UNAVAILABLE, 'PLUGIN_UNAVAILABLE', 'errors.plugin_unavailable');
     }
 
     res.status(clampStatus(result.status));

--- a/backend/src/modules/plugins/supervisor/rpc-channel.spec.ts
+++ b/backend/src/modules/plugins/supervisor/rpc-channel.spec.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { MAX_FRAME_BYTES } from '../../../common/plugin-contract';
 import { RpcChannel } from './rpc-channel';
+import { RpcTimeoutError } from './wire';
 
 interface Pair {
   srv: Server;
@@ -61,7 +62,7 @@ describe('RpcChannel', () => {
   it('rejects with a timeout when nothing answers', async () => {
     const pair = await makePair();
     cleanup = () => teardown(pair);
-    await expect(pair.client.call('health', {}, 30)).rejects.toThrow(/timeout/);
+    await expect(pair.client.call('health', {}, 30)).rejects.toThrow(RpcTimeoutError);
   });
 
   it('delivers a fire-and-forget note with no reply expected', async () => {

--- a/backend/src/modules/plugins/supervisor/rpc-channel.ts
+++ b/backend/src/modules/plugins/supervisor/rpc-channel.ts
@@ -5,6 +5,7 @@ import {
   FrameTooLargeError,
   parseFrame,
   ProtocolViolationError,
+  RpcTimeoutError,
   type Frame,
 } from './wire';
 import type { Req, Res, Note } from '../../../common/plugin-contract';
@@ -151,7 +152,7 @@ export class RpcChannel {
     return new Promise<T>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(i);
-        reject(new Error(`timeout waiting for "${method}"`));
+        reject(new RpcTimeoutError(method, deadlineMs));
       }, deadlineMs);
       this.pending.set(i, { resolve: resolve as (v: unknown) => void, reject, timer });
       try {

--- a/backend/src/modules/plugins/supervisor/wire.ts
+++ b/backend/src/modules/plugins/supervisor/wire.ts
@@ -10,6 +10,15 @@ export class ProtocolViolationError extends Error {
   }
 }
 
+/** Raised when a call gets no reply before its deadline. Typed so a caller can tell a
+ *  slow plugin from an unreachable one without matching on message text. */
+export class RpcTimeoutError extends Error {
+  constructor(public readonly method: string, deadlineMs: number) {
+    super(`no reply to "${method}" within ${deadlineMs}ms`);
+    this.name = 'RpcTimeoutError';
+  }
+}
+
 /** Raised when a frame we're about to send would breach MAX_FRAME_BYTES — our own fault, not the peer's. */
 export class FrameTooLargeError extends Error {
   constructor(reason: string) {

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -879,6 +879,7 @@
     "analyze_launch_error": "Die Analyse konnte nicht gestartet werden",
     "not_found": "Inhalt nicht gefunden",
     "download_section": "Download",
+    "releases_title": "Verfügbare Releases",
     "download_detail_title": "Download-Details",
     "download_pack": "Pack",
     "quality_profile_label": "Qualitätsprofil",
@@ -2250,6 +2251,8 @@
     "502": "Ungültiges Gateway oder Proxy",
     "503": "Dienst vorübergehend nicht verfügbar",
     "504": "Zeitüberschreitung des Servers",
+    "plugin_timeout": "Das Plugin hat zu lange gebraucht. Seine Suche läuft möglicherweise noch — versuche es in einem Moment erneut.",
+    "plugin_unavailable": "Das Plugin hat nicht geantwortet. Prüfe unter Einstellungen › Plugins, ob es läuft.",
     "unknown": "Fehler {{code}}"
   },
   "media_card": {

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -884,6 +884,7 @@
     "analyze_launch_error": "Unable to start the analysis",
     "not_found": "Content not found",
     "download_section": "Downloading",
+    "releases_title": "Available releases",
     "download_detail_title": "Download details",
     "download_pack": "Pack",
     "quality_profile_label": "Quality profile",
@@ -2277,6 +2278,8 @@
     "502": "Invalid gateway or proxy",
     "503": "Service temporarily unavailable",
     "504": "Server timed out",
+    "plugin_timeout": "The plugin took too long to answer. Its search may still be running — try again in a moment.",
+    "plugin_unavailable": "The plugin did not answer. Check that it is running in Settings › Plugins.",
     "unknown": "Error {{code}}"
   },
   "media_card": {

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -879,6 +879,7 @@
     "analyze_launch_error": "No se puede iniciar el análisis",
     "not_found": "Contenido no encontrado",
     "download_section": "Descarga",
+    "releases_title": "Releases disponibles",
     "download_detail_title": "Detalles de la descarga",
     "download_pack": "Pack",
     "quality_profile_label": "Perfil de calidad",
@@ -2250,6 +2251,8 @@
     "502": "Puerta de enlace o proxy no válido",
     "503": "Servicio temporalmente no disponible",
     "504": "Se agotó el tiempo de espera del servidor",
+    "plugin_timeout": "El plugin tardó demasiado en responder. Su búsqueda puede seguir en curso — inténtalo de nuevo en un momento.",
+    "plugin_unavailable": "El plugin no respondió. Comprueba que está en marcha en Ajustes › Plugins.",
     "unknown": "Error {{code}}"
   },
   "media_card": {

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -884,6 +884,7 @@
     "analyze_launch_error": "Impossible de lancer l'analyse",
     "not_found": "Contenu introuvable",
     "download_section": "Téléchargement",
+    "releases_title": "Releases disponibles",
     "download_detail_title": "Détails du téléchargement",
     "download_pack": "Pack",
     "quality_profile_label": "Profil de qualité",
@@ -2277,6 +2278,8 @@
     "502": "Passerelle ou proxy invalide",
     "503": "Service temporairement indisponible",
     "504": "Délai d'attente du serveur dépassé",
+    "plugin_timeout": "Le plugin a mis trop de temps à répondre. Sa recherche est peut-être encore en cours — réessaie dans un instant.",
+    "plugin_unavailable": "Le plugin n'a pas répondu. Vérifie qu'il est démarré dans Réglages › Plugins.",
     "unknown": "Erreur {{code}}"
   },
   "media_card": {

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -879,6 +879,7 @@
     "analyze_launch_error": "Impossibile avviare l'analisi",
     "not_found": "Contenuto non trovato",
     "download_section": "Download",
+    "releases_title": "Release disponibili",
     "download_detail_title": "Dettagli del download",
     "download_pack": "Pack",
     "quality_profile_label": "Profilo di qualità",
@@ -2250,6 +2251,8 @@
     "502": "Gateway o proxy non valido",
     "503": "Servizio temporaneamente non disponibile",
     "504": "Timeout del server superato",
+    "plugin_timeout": "Il plugin ha tardato troppo a rispondere. La sua ricerca potrebbe essere ancora in corso — riprova tra un momento.",
+    "plugin_unavailable": "Il plugin non ha risposto. Verifica che sia in esecuzione in Impostazioni › Plugin.",
     "unknown": "Errore {{code}}"
   },
   "media_card": {

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -879,6 +879,7 @@
     "analyze_launch_error": "Não foi possível iniciar a análise",
     "not_found": "Conteúdo não encontrado",
     "download_section": "Transferência",
+    "releases_title": "Releases disponíveis",
     "download_detail_title": "Detalhes da transferência",
     "download_pack": "Pack",
     "quality_profile_label": "Perfil de qualidade",
@@ -2250,6 +2251,8 @@
     "502": "Gateway ou proxy inválido",
     "503": "Serviço temporariamente indisponível",
     "504": "Tempo de espera do servidor esgotado",
+    "plugin_timeout": "O plugin demorou demasiado a responder. A pesquisa pode ainda estar a decorrer — tenta novamente dentro de um momento.",
+    "plugin_unavailable": "O plugin não respondeu. Verifica se está em execução em Definições › Plugins.",
     "unknown": "Erro {{code}}"
   },
   "media_card": {

--- a/client/src/app/core/interceptors/error.interceptor.ts
+++ b/client/src/app/core/interceptors/error.interceptor.ts
@@ -3,6 +3,7 @@ import { inject } from '@angular/core';
 import { catchError, throwError } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
 import { ToastService } from '../services/toast.service';
+import { translatedServerMessage } from '../utils/server-message';
 
 export const errorInterceptor: HttpInterceptorFn = (req, next) => {
   const toast = inject(ToastService);
@@ -58,13 +59,8 @@ function extractMessage(
   }
 
   if (body?.message && !isFrameworkNotFound(err.status, body.message)) {
-    if (Array.isArray(body.message)) return body.message.join(', ');
-    // Backends may return an i18n key for user-facing validation errors
-    // (English-only rule keeps the copy out of the API); translate it when
-    // known, otherwise show the message as-is.
-    const msg = body.message as string;
-    const translated = translate.instant(msg);
-    return translated !== msg ? translated : msg;
+    const message = translatedServerMessage(body.message, translate);
+    if (message) return message;
   }
 
   // A plugin route answers `{error:{key,detail}}`; its keys are merged into the catalogue on

--- a/client/src/app/core/utils/server-message.spec.ts
+++ b/client/src/app/core/utils/server-message.spec.ts
@@ -1,0 +1,40 @@
+import type { TranslateService } from '@ngx-translate/core';
+import { serverMessage, translatedServerMessage } from './server-message';
+
+/** Knows two keys; anything else comes back unchanged, like ngx-translate does. */
+const translate = {
+  instant: (key: string) =>
+    key === 'errors.plugin_timeout' ? 'The plugin took too long' : key === 'fallback.key' ? 'Fallback' : key,
+} as TranslateService;
+
+describe('translatedServerMessage', () => {
+  it('translates a key the catalogue knows', () => {
+    expect(translatedServerMessage('errors.plugin_timeout', translate)).toBe('The plugin took too long');
+  });
+
+  it('keeps a plain sentence the backend wrote', () => {
+    expect(translatedServerMessage('Username already taken', translate)).toBe('Username already taken');
+  });
+
+  it('joins a validation array', () => {
+    expect(translatedServerMessage(['too short', 'not a url'], translate)).toBe('too short, not a url');
+  });
+
+  it('reports nothing for an absent or non-string message', () => {
+    expect(translatedServerMessage(undefined, translate)).toBeNull();
+    expect(translatedServerMessage('', translate)).toBeNull();
+    expect(translatedServerMessage({ nested: true }, translate)).toBeNull();
+  });
+});
+
+describe('serverMessage', () => {
+  it('prefers the translated server message', () => {
+    const err = { error: { message: 'errors.plugin_timeout' } };
+    expect(serverMessage(err, translate, 'fallback.key')).toBe('The plugin took too long');
+  });
+
+  it('falls back when the body carries no message', () => {
+    expect(serverMessage({ error: {} }, translate, 'fallback.key')).toBe('Fallback');
+    expect(serverMessage(null, translate, 'fallback.key')).toBe('Fallback');
+  });
+});

--- a/client/src/app/core/utils/server-message.ts
+++ b/client/src/app/core/utils/server-message.ts
@@ -1,0 +1,26 @@
+import type { TranslateService } from '@ngx-translate/core';
+
+/**
+ * What a server-supplied message should read as. A backend may answer a translation key
+ * (the English-only rule keeps user-facing copy out of the API), an English sentence, or
+ * an array of validation messages. An unknown key would otherwise reach the user raw.
+ */
+export function translatedServerMessage(
+  message: unknown,
+  translate: TranslateService,
+): string | null {
+  if (Array.isArray(message)) return message.join(', ');
+  if (typeof message !== 'string' || !message) return null;
+  const translated = translate.instant(message);
+  return translated !== message ? translated : message;
+}
+
+/** The same rule for a component holding an `HttpErrorResponse`, with its own fallback key. */
+export function serverMessage(
+  err: unknown,
+  translate: TranslateService,
+  fallbackKey: string,
+): string {
+  const body = (err as { error?: { message?: unknown } })?.error;
+  return translatedServerMessage(body?.message, translate) ?? translate.instant(fallbackKey);
+}

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -334,7 +334,7 @@
     <div>
       <app-tracking-status-modal #trackingModal />
       <app-releases-modal #movieReleasesModal
-        [title]="'media_detail.download_section' | translate"
+        [title]="'media_detail.releases_title' | translate"
         [releases]="releases()"
         [loading]="releasesLoading()"
         [searched]="releasesSearched()"

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -74,6 +74,7 @@ import {
 } from './media-detail.utils';
 import type { MediaFileRow } from './media-detail.utils';
 import { isUnprofiledReleaseError, releaseGrabBody } from './media-detail-release.utils';
+import { serverMessage } from '../../core/utils/server-message';
 import { ConfirmationService } from '../../core/services/confirmation.service';
 import { ToastService } from '../../core/services/toast.service';
 import { SseService, type SseEvent } from '../../core/services/sse.service';
@@ -1076,11 +1077,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       this.draftLanguageProfileId.set(updated.languageProfile?.id ?? null);
       this.profilesOk.set(this.translate.instant('media_detail.profiles_saved'));
     } catch (err: unknown) {
-      const httpErr = err as { error?: { message?: string } };
-      this.profilesErr.set(
-        httpErr.error?.message ??
-          this.translate.instant('media_detail.profiles_save_error'),
-      );
+      this.profilesErr.set(serverMessage(err, this.translate, 'media_detail.profiles_save_error'));
     } finally {
       this.profilesSaveLoading.set(false);
     }
@@ -1106,11 +1103,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       if (isUnprofiledReleaseError(err)) {
         this.releasesEmptyMessage.set('media_detail.no_quality_profile');
       } else {
-        const httpErr = err as { error?: { message?: string } };
-        this.releasesError.set(
-          httpErr.error?.message ??
-            this.translate.instant('media_detail.releases_error'),
-        );
+        this.releasesError.set(serverMessage(err, this.translate, 'media_detail.releases_error'));
       }
     } finally {
       this.releasesLoading.set(false);
@@ -1200,11 +1193,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
         this.translate.instant('media_detail.refresh_launched'),
       );
     } catch (err: unknown) {
-      const httpErr = err as { error?: { message?: string } };
-      this.toast.error(
-        httpErr.error?.message ??
-          this.translate.instant('media_detail.refresh_error'),
-      );
+      this.toast.error(serverMessage(err, this.translate, 'media_detail.refresh_error'));
     }
   }
 
@@ -1546,10 +1535,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       if (isUnprofiledReleaseError(err)) {
         this.epReleasesEmptyMessage.set('media_detail.no_quality_profile');
       } else {
-        const httpErr = err as { error?: { message?: string } };
-        this.epReleasesError.set(
-          httpErr.error?.message ?? this.translate.instant('media_detail.releases_error'),
-        );
+        this.epReleasesError.set(serverMessage(err, this.translate, 'media_detail.releases_error'));
       }
     } finally {
       this.epReleasesLoading.set(false);
@@ -1598,10 +1584,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       if (isUnprofiledReleaseError(err)) {
         this.seasonReleasesEmptyMessage.set('media_detail.no_quality_profile');
       } else {
-        const httpErr = err as { error?: { message?: string } };
-        this.seasonReleasesError.set(
-          httpErr.error?.message ?? this.translate.instant('media_detail.releases_error'),
-        );
+        this.seasonReleasesError.set(serverMessage(err, this.translate, 'media_detail.releases_error'));
       }
     } finally {
       this.seasonReleasesLoading.set(false);

--- a/client/src/app/features/plugin-view/plugin-view.html
+++ b/client/src/app/features/plugin-view/plugin-view.html
@@ -14,13 +14,21 @@
     </div>
   }
   @default {
+    @if (page(); as header) {
+      <div class="mb-6">
+        <h1 class="text-2xl font-bold">{{ header.labelKey | translate }}</h1>
+        @if (header.subtitleKey) {
+          <p class="text-sm text-base-content/60 mt-1">{{ header.subtitleKey | translate }}</p>
+        }
+      </div>
+    }
     @if (providersView(); as view) {
       @if (resolvedImplementations(); as impls) {
         @if (implementationsLoadError()) {
           <div role="alert" class="alert alert-warning mb-4">{{ 'plugin_view.implementations_load_error' | translate }}</div>
         }
         <app-provider-list
-          [titleKey]="view.labelKey"
+          [titleKey]="''"
           [listUrl]="resourceUrl(view.list)"
           [implementations]="impls"
           [labels]="providerLabels(view)"
@@ -38,7 +46,7 @@
       }
     } @else if (tableView(); as view) {
       <app-data-table
-        [titleKey]="view.labelKey"
+        [titleKey]="''"
         [listUrl]="resourceUrl(view.list)"
         [columns]="view.columns"
         [filters]="view.filters ?? []"
@@ -56,7 +64,6 @@
         </div>
       } @else {
         <div class="flex flex-col gap-4">
-          <h2 class="text-lg font-bold">{{ page.labelKey | translate }}</h2>
           <app-schema-form #schemaForm [fields]="page.fields" [(value)]="formValue" [disabled]="formSaving()" />
           <div class="flex flex-wrap items-center gap-2">
             <button type="button" class="btn btn-primary" [disabled]="formSaving() || schemaForm.invalid()" (click)="saveForm()">

--- a/client/src/app/shared/components/provider-list/provider-list.html
+++ b/client/src/app/shared/components/provider-list/provider-list.html
@@ -1,7 +1,9 @@
 <div class="flex flex-col gap-4">
   <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
-    <h2 class="card-title text-lg">{{ titleKey() | translate }}</h2>
-    <div class="flex gap-2 shrink-0 self-start">
+    @if (titleKey()) {
+      <h2 class="card-title text-lg">{{ titleKey() | translate }}</h2>
+    }
+    <div class="flex gap-2 shrink-0 self-start sm:ml-auto">
       @for (action of listActions(); track action.labelKey) {
         <button
           type="button"

--- a/client/src/app/shared/components/provider-list/provider-list.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.ts
@@ -77,7 +77,8 @@ export class ProviderListComponent implements OnInit {
   private readonly editorDialog = viewChild<ElementRef<HTMLDialogElement>>('editorDialog');
   private readonly resultDialog = viewChild<ElementRef<HTMLDialogElement>>('resultDialog');
 
-  readonly titleKey = input.required<string>();
+  /** Empty renders no heading — a plugin page carries its own page-level title. */
+  readonly titleKey = input('');
   readonly listUrl = input.required<string>();
   readonly implementations = input.required<readonly ProviderImplementation[]>();
   /** The wire field naming the implementation — `type` for subtitle providers, `implementation` elsewhere. */


### PR DESCRIPTION
Searching for a release showed `timeout waiting for "http"` in the modal (and again in a toast). Two separate defects behind one symptom.

## The budget was impossible to satisfy

A release search fans out to every configured indexer. The plugin allows **90 s per indexer** (`fetchText(url, { timeoutMs: 90_000 })`), the fan-out is a `Promise.allSettled` so it lasts as long as the slowest one, and the proxy gave up after **30 s**. One hanging tracker sank the whole search — and took with it the seven indexers that had already answered in under 40 ms.

Per the decision on the report: the per-indexer search is allowed to be slow, so the host budget goes up rather than the plugin's timeouts coming down. `PLUGIN_DEADLINES_MS.pluginCall` (180 s) is the new home — it sits beside `hostCall` and `handshake`, so a plugin author reads it from the contract tarball instead of guessing. `plugin-jobs.service.ts` reads the same constant: its comment already said it mirrored the proxy's value, and a scheduled `SearchMissing` reaches the same trackers with the same 90 s ceiling.

Known remaining gap, deliberately not papered over with a bigger number: an indexer that times out on the typed search **and** on the `t=search` fallback spends ~190 s, which still exceeds 180 s. The fix for that is a fan-out budget in the plugin returning partial results, not a longer host wait. Also worth knowing: a reverse proxy in front of Fliks needs its own read timeout raised (nginx defaults `proxy_read_timeout` to 60 s), otherwise it cuts the request before core does.

## The failure was reported in RPC vocabulary

`timeout waiting for "http"` comes from `RpcChannel.call`; the proxy copied that internal message straight into the 503 body, and both the release modal and the global toast render `error.message` as-is.

- The timeout is now a typed `RpcTimeoutError`, answered as **504 `PLUGIN_TIMEOUT`** with `errors.plugin_timeout` as the message — a key the client already knows how to translate. Any other RPC rejection stays 503 with `errors.plugin_unavailable`. The internal detail goes to the log, with the plugin id, method and path.
- The client had the right rule in `error.interceptor.ts` (translate a key, keep a real sentence, join a validation array) and the wrong one — `error?.message ?? instant(fallback)`, which lets an untranslated server string win — copy-pasted at five sites in `media-detail.ts`. The rule now lives in `core/utils/server-message.ts` and both use it.
- The dialog was titled "Downloading" while showing a release *search*, which is the other half of the confusion. It now names releases.

## Plugin page titles

`app-data-table` and `app-provider-list` render a *section* heading (`card-title text-lg`) — right inside a card, which is how the subtitle-providers page uses them, wrong when a plugin view mounts one as the entire page. Plugin pages came out at `text-lg` where 35 of 40 core pages use `text-2xl font-bold` plus a subtitle line.

`plugin-view` now renders that header and passes an empty `titleKey` to suppress the component's own (`app-data-table` already supported it; `app-provider-list`'s becomes optional). `subtitleKey` is additive on the page contract — a manifest declaring none renders exactly as before.

## Checks

- backend: `tsc` clean, `jest src/modules/plugins` → 791 passing (proxy spec now asserts the 504 + key, and that neither branch carries RPC wording)
- client: `ng build` clean, `ng test` → 437 passing, including a new spec for `server-message`

🤖 Generated with [Claude Code](https://claude.com/claude-code)