### PR TITLE
feat(plugin-view): badges and nowrap on a declared table column

### DIFF
--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -165,6 +165,19 @@ export interface ReleasePickerRoutes {
   episode: ReleasePickerPair;
 }
 
+/** daisyUI badge tones. Closed: core maps a name to a class and falls back to `ghost`,
+ *  so a manifest can never put a string of its own into the rendered `class`. */
+export type BadgeTone =
+  | 'neutral'
+  | 'primary'
+  | 'secondary'
+  | 'accent'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'error'
+  | 'ghost';
+
 /** One column of a declared table — a `table` page's rows, or a row action's result. */
 export interface TableColumn {
   key: string;
@@ -172,6 +185,12 @@ export interface TableColumn {
   format?: 'date' | 'bytes' | 'percent';
   /** Maps a cell value to a translate key — a status column renders its raw enum otherwise. */
   labelKeys?: Record<string, string>;
+  /** Renders the cell as a badge, the value picking its tone. `*` covers every other value,
+   *  which is how an open-ended column (a quality name) gets one uniform tone. A `format`ted
+   *  cell is never badged. */
+  badges?: Record<string, BadgeTone>;
+  /** Keeps the cell on one line. Implied for `format`ted and badged cells. */
+  nowrap?: boolean;
 }
 
 /** One proxied route lists instances, another lists the implementations and their fields. */

--- a/client/src/app/shared/components/data-table/data-table.html
+++ b/client/src/app/shared/components/data-table/data-table.html
@@ -78,12 +78,18 @@
           @for (row of rows(); track $index) {
             <tr>
               @for (col of columns(); track col.key) {
-                <td>
+                <td [class.whitespace-nowrap]="cellNowrap(col)">
                   @switch (col.format) {
                     @case ('date') { {{ cellDate(row[col.key]) | localeDate }} }
                     @case ('bytes') { {{ cellBytes(row[col.key]) }} }
                     @case ('percent') { {{ cellPercent(row[col.key]) }} }
-                    @default { {{ cellLabel(col, row[col.key]) }} }
+                    @default {
+                      @if (badgeClass(col, row[col.key]); as badge) {
+                        <span class="badge badge-sm" [class]="badge">{{ cellLabel(col, row[col.key]) }}</span>
+                      } @else {
+                        {{ cellLabel(col, row[col.key]) }}
+                      }
+                    }
                   }
                 </td>
               }

--- a/client/src/app/shared/components/data-table/data-table.spec.ts
+++ b/client/src/app/shared/components/data-table/data-table.spec.ts
@@ -297,6 +297,52 @@ describe('DataTableComponent — declared filters', () => {
     expect(fixture.componentInstance.cellLabel(fixture.componentInstance.columns()[0], 'other')).toBe('other');
   });
 
+  it('VERDICT: a declared badge renders as a badge span, and an undeclared tone cannot reach the class', async () => {
+    const fixture = await createComponent({
+      http: { get: () => of([{ id: 1, status: 'failed', quality: 'WEBDL-1080p', title: 'A' }]) },
+      columns: [
+        { key: 'status', labelKey: 'x.status', badges: { failed: 'error', completed: 'success' } },
+        { key: 'quality', labelKey: 'x.quality', badges: { '*': 'ghost' } },
+        { key: 'title', labelKey: 'x.title' },
+      ],
+    });
+    const c = fixture.componentInstance;
+    const [status, quality, title] = c.columns();
+
+    expect(c.badgeClass(status, 'failed')).toBe('badge-error');
+    expect(c.badgeClass(status, 'completed')).toBe('badge-success');
+    // Not named and no `*`: text, not a badge with an empty tone.
+    expect(c.badgeClass(status, 'importing')).toBeNull();
+    // `*` gives an open-ended column one uniform tone.
+    expect(c.badgeClass(quality, 'WEBDL-1080p')).toBe('badge-ghost');
+    expect(c.badgeClass(title, 'A')).toBeNull();
+    // A manifest is untrusted JSON: an unknown tone resolves to a known class, never itself.
+    const hostile = { key: 'status', labelKey: 'x.status', badges: { failed: 'error" onmouseover="x' } } as unknown as TableColumn;
+    expect(c.badgeClass(hostile, 'failed')).toBe('badge-ghost');
+
+    const badges = fixture.nativeElement.querySelectorAll('td span.badge');
+    expect(badges.length).toBe(2);
+    expect(badges[0].className).toContain('badge-error');
+  });
+
+  it('keeps formatted, badged and declared-nowrap cells on one line', async () => {
+    const fixture = await createComponent({
+      http: { get: () => of([{ id: 1, size: 1024, status: 'failed', source: 'x', title: 'A' }]) },
+      columns: [
+        { key: 'size', labelKey: 'x.size', format: 'bytes' },
+        { key: 'status', labelKey: 'x.status', badges: { failed: 'error' } },
+        { key: 'source', labelKey: 'x.source', nowrap: true },
+        { key: 'title', labelKey: 'x.title' },
+      ],
+    });
+    const c = fixture.componentInstance;
+    expect(c.columns().map((col) => c.cellNowrap(col))).toEqual([true, true, true, false]);
+
+    const cells = fixture.nativeElement.querySelectorAll('tbody tr td');
+    expect(cells[3].className).not.toContain('whitespace-nowrap');
+    expect(cells[0].className).toContain('whitespace-nowrap');
+  });
+
   it('VERDICT: a select change inside the search debounce window does not double-fire the request', async () => {
     const get = vi.fn(() => of({ data: [{ id: 1, name: 'A' }], total: 40, page: 1, pageSize: 20 }));
     const fixture = await createComponent({ http: { get }, paged: true, filters: [SEARCH, STATUS] });

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -7,10 +7,24 @@ import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
 import { formatBytes } from '../../utils/download-format';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { PaginationComponent } from '../pagination/pagination';
-import { CellValue, ListAction, PagedResult, RowAction, TableColumn, TableFilter, TableRow } from './data-table.types';
+import { BadgeTone, CellValue, ListAction, PagedResult, RowAction, TableColumn, TableFilter, TableRow } from './data-table.types';
 
 /** Keystroke-to-request debounce for a `search` filter — see `onSearchInput`. */
 const SEARCH_DEBOUNCE_MS = 300;
+
+/** The only classes a declared badge can resolve to. A `badges` entry is JSON from a
+ *  manifest, so it is looked up here and never interpolated into the rendered `class`. */
+const BADGE_CLASSES: Readonly<Record<BadgeTone, string>> = {
+  neutral: 'badge-neutral',
+  primary: 'badge-primary',
+  secondary: 'badge-secondary',
+  accent: 'badge-accent',
+  info: 'badge-info',
+  success: 'badge-success',
+  warning: 'badge-warning',
+  error: 'badge-error',
+  ghost: 'badge-ghost',
+};
 
 /**
  * The `table` view kind: declared columns, declared row actions, no
@@ -145,6 +159,23 @@ export class DataTableComponent implements OnInit {
 
   cellPercent(value: CellValue): string {
     return typeof value === 'number' ? `${Math.round(value)}%` : String(value ?? '');
+  }
+
+  /**
+   * The badge class for a cell, or null to render it as text. `*` catches every value the
+   * column didn't name; an unknown tone falls back to `ghost` rather than reaching the DOM.
+   */
+  badgeClass(col: TableColumn, value: CellValue): string | null {
+    const tones = col.badges;
+    if (!tones) return null;
+    const tone = tones[String(value ?? '')] ?? tones['*'];
+    if (!tone) return null;
+    return BADGE_CLASSES[tone] ?? BADGE_CLASSES.ghost;
+  }
+
+  /** A formatted value, a badge and a declared `nowrap` are all atomic — none should wrap. */
+  cellNowrap(col: TableColumn): boolean {
+    return col.nowrap === true || col.format !== undefined || col.badges !== undefined;
   }
 
   /** An undeclared value renders as itself rather than as a missing translate key. */

--- a/client/src/app/shared/components/data-table/data-table.types.ts
+++ b/client/src/app/shared/components/data-table/data-table.types.ts
@@ -1,9 +1,26 @@
+/** Mirrors the contract's `BadgeTone`: the renderer maps a name to a class and falls back to
+ *  `ghost`, so a declared string never reaches the rendered `class`. */
+export type BadgeTone =
+  | 'neutral'
+  | 'primary'
+  | 'secondary'
+  | 'accent'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'error'
+  | 'ghost';
+
 export interface TableColumn {
   key: string;
   labelKey: string;
   format?: 'date' | 'bytes' | 'percent';
   /** Maps a cell value to a translate key — a status column renders its raw enum otherwise. */
   labelKeys?: Record<string, string>;
+  /** Renders the cell as a badge, the value picking its tone; `*` covers every other value. */
+  badges?: Record<string, BadgeTone>;
+  /** Keeps the cell on one line. Implied for `format`ted and badged cells. */
+  nowrap?: boolean;
 }
 
 /** `TableConfigPage.filters[]` — value sent to `list` as a query param named by `key`. */


### PR DESCRIPTION
Second half of the plugin-table work. Two optional `TableColumn` fields, both additive: an existing manifest renders exactly as it does today.

## `badges`

A status column printed its raw enum as plain text, where every core table renders the same thing as a coloured badge (`releases-table`, `subtitles-activity`, `plugins`).

```ts
{ key: 'status', labelKey: '…', badges: { failed: 'error', completed: 'success' } }
{ key: 'quality', labelKey: '…', badges: { '*': 'ghost' } }
```

- The value picks the tone; `*` covers every value the column didn't name, which is how an open-ended column (a quality name) gets one uniform tone.
- A value with no entry and no `*` renders as text — a partially mapped status column still reads.
- `labelKeys` keeps working: it supplies the badge's text.
- A `format`ted cell is never badged; its own formatting wins.

**A manifest is untrusted JSON**, so `BadgeTone` is a closed union, resolved through a class table in the component, falling back to `badge-ghost`. No declared string can reach the rendered `class` attribute — there is a test asserting exactly that with a quote-breaking tone.

## `nowrap`

Implied for `format`ted and badged cells, since both are atomic. `nowrap: true` opts a plain text column in — that is what a `quality` or `source` column wants. Matches the core convention of `whitespace-nowrap` on short atomic cells.

## Checks

- `ng test` → 439 passing, with two new specs: the badge resolution (including the hostile tone and the rendered spans) and the per-column nowrap decision
- `ng build` clean, backend `tsc` clean, `jest src/modules/plugins` → 791 passing

Once this ships in a core release, `fk-plugin-download` declares `badges` on `status` and `quality` and `nowrap` on `source` / `grabSource`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)