### PR TITLE
feat(plugin-view): open a cell's detail in a dialog, and read tables at text-sm

### DIFF
--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -178,6 +178,16 @@ export type BadgeTone =
   | 'error'
   | 'ghost';
 
+/** One value rendered under a cell's own, as a badge or as plain text. One level only:
+ *  it carries no `subValues` of its own, so a sub-value under a sub-value is impossible
+ *  in the type rather than merely undocumented. */
+export interface TableSubValue {
+  key: string;
+  format?: 'date' | 'bytes' | 'percent';
+  labelKeys?: Record<string, string>;
+  badges?: Record<string, BadgeTone>;
+}
+
 /** One column of a declared table — a `table` page's rows, or a row action's result. */
 export interface TableColumn {
   key: string;
@@ -191,6 +201,15 @@ export interface TableColumn {
   badges?: Record<string, BadgeTone>;
   /** Keeps the cell on one line. Implied for `format`ted and badged cells. */
   nowrap?: boolean;
+  /** A second line under the cell's own value. A release's quality and tracker belong with
+   *  its name; as columns of their own they cost width the title needed. */
+  subValues?: TableSubValue[];
+  /** Names another field of the row. When that field has a value, the cell becomes a button
+   *  opening a dialog that shows it — a long diagnostic message reads there instead of
+   *  stretching a column across every row. */
+  detailKey?: string;
+  /** Title of that dialog. Falls back to the column's own `labelKey`. */
+  detailTitleKey?: string;
 }
 
 /** One proxied route lists instances, another lists the implementations and their fields. */
@@ -198,8 +217,10 @@ export interface ProvidersConfigPage extends ConfigPageBase {
   kind: 'providers';
   list: string;
   implementations: string;
-  /** Tests the unsaved draft — POSTs `{implementation, settings}` before any row is
-   *  saved. Distinct from `actions[]`: there is no row yet, so no `:id` to substitute. */
+  /** Tests the unsaved draft — POSTs `{implementation, settings, id?}` before it is saved.
+   *  Distinct from `actions[]`: there is no route parameter, and on a new draft no row exists
+   *  at all. A blank secret is omitted from `settings`, and `id` names the row being edited,
+   *  so the resource resolves it against what it stored rather than asking the user again. */
   testConnection?: { route: string };
   /** `method` is explicit: encoding it into `route` left the caller POSTing to a
    *  string that contained the verb. Every `scope: 'row'` entry renders its own button —

--- a/client/src/app/features/dashboard/dashboard.html
+++ b/client/src/app/features/dashboard/dashboard.html
@@ -151,7 +151,7 @@
                         class="link link-hover block truncate"
                       >{{ r.mediaTitle }}</a>
                       @if (episodeLabel(r)) {
-                        <span class="block text-xs font-normal text-base-content/60 truncate" [title]="episodeLabel(r)">
+                        <span class="block text-sm font-normal text-base-content/60 truncate" [title]="episodeLabel(r)">
                           @if (r.episodeId != null) {
                             <a
                               [routerLink]="['/series', r.mediaId, 'episode', r.episodeId]"

--- a/client/src/app/features/import-disk/import-disk.html
+++ b/client/src/app/features/import-disk/import-disk.html
@@ -111,13 +111,13 @@
                     <p class="truncate text-sm font-mono" [title]="row.candidate.filePath">
                       {{ row.candidate.filename }}
                     </p>
-                    <div class="flex flex-wrap items-center gap-2 mt-1 text-xs text-base-content/60">
+                    <div class="flex flex-wrap items-center gap-2 mt-1 text-sm text-base-content/60">
                       <span class="badge badge-ghost badge-sm">{{ row.candidate.qualityName }}</span>
                       <span class="tabular-nums">{{ formatBytes(row.candidate.size) }}</span>
                     </div>
                     @if (row.candidate.existingQuality && !row.force) {
                       <div class="flex items-center gap-2 mt-1">
-                        <span class="text-xs text-warning">
+                        <span class="text-sm text-warning">
                           {{ 'import_disk.existing_quality' | translate:{ quality: row.candidate.existingQuality } }}
                         </span>
                         <button

--- a/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.html
@@ -36,7 +36,7 @@
               <tr>
                 <td class="text-sm">
                   <div class="max-w-[13rem] sm:max-w-[20rem] truncate" [title]="r.title">{{ r.title }}</div>
-                  <div class="sm:hidden mt-1 flex items-center gap-2 text-xs">
+                  <div class="sm:hidden mt-1 flex items-center gap-2 text-sm">
                     <progress
                       class="progress w-14 h-1.5"
                       [class.progress-success]="r.score >= 80"
@@ -47,10 +47,10 @@
                     ></progress>
                     <span class="tabular-nums">{{ r.score }}%</span>
                     @if (r.forced) {
-                      <span class="badge badge-xs badge-outline">F</span>
+                      <span class="badge badge-sm badge-outline">F</span>
                     }
                     @if (r.hearingImpaired) {
-                      <span class="badge badge-xs badge-outline">HI</span>
+                      <span class="badge badge-sm badge-outline">HI</span>
                     }
                   </div>
                 </td>
@@ -64,21 +64,21 @@
                       [value]="r.score"
                       max="100"
                     ></progress>
-                    <span class="tabular-nums text-xs w-9 text-right">{{ r.score }}%</span>
+                    <span class="tabular-nums text-sm w-9 text-right">{{ r.score }}%</span>
                   </div>
                 </td>
-                <td class="text-center text-xs hidden sm:table-cell">
+                <td class="text-center text-sm hidden sm:table-cell">
                   @if (r.forced) {
-                    <span class="badge badge-xs badge-outline mr-1">F</span>
+                    <span class="badge badge-sm badge-outline mr-1">F</span>
                   }
                   @if (r.hearingImpaired) {
-                    <span class="badge badge-xs badge-outline">HI</span>
+                    <span class="badge badge-sm badge-outline">HI</span>
                   }
                 </td>
                 <td class="text-sm">
                   {{ r.providerName }}
                   @if (r.downloadCount) {
-                    <span class="block text-xs text-base-content/50 whitespace-nowrap">{{ 'media_detail.subtitle_downloads' | translate: { count: r.downloadCount } }}</span>
+                    <span class="block text-sm text-base-content/50 whitespace-nowrap">{{ 'media_detail.subtitle_downloads' | translate: { count: r.downloadCount } }}</span>
                   }
                 </td>
                 <td>

--- a/client/src/app/features/media-detail/components/releases-table/releases-table.component.html
+++ b/client/src/app/features/media-detail/components/releases-table/releases-table.component.html
@@ -49,12 +49,12 @@
                     </div>
                   }
                   @if (showCfScore() && r.customFormatScore !== 0) {
-                    <span class="text-xs" [class]="r.customFormatScore > 0 ? 'text-success font-medium' : 'text-error'">
+                    <span class="text-sm" [class]="r.customFormatScore > 0 ? 'text-success font-medium' : 'text-error'">
                       CF {{ r.customFormatScore > 0 ? '+' : '' }}{{ r.customFormatScore }}
                     </span>
                   }
                 </div>
-                <div class="flex gap-3 text-xs tabular-nums text-base-content/70">
+                <div class="flex gap-3 text-sm tabular-nums text-base-content/70">
                   <span>{{ formatBytes(r.size) }}</span>
                   <span>
                     <span class="text-success">▲{{ r.seeders }}</span>

--- a/client/src/app/features/settings/plugins/plugin-sources/plugin-sources.html
+++ b/client/src/app/features/settings/plugins/plugin-sources/plugin-sources.html
@@ -57,7 +57,7 @@
                     <span class="text-base-content/50">{{ 'settings.plugins.sources.never_refreshed' | translate }}</span>
                   }
                   @if (source.lastRefreshError) {
-                    <p class="text-xs text-error/80 mt-1 max-w-[14rem]">{{ source.lastRefreshError }}</p>
+                    <p class="text-sm text-error/80 mt-1 max-w-[14rem]">{{ source.lastRefreshError }}</p>
                   }
                 </td>
                 <td>

--- a/client/src/app/features/settings/plugins/plugins.html
+++ b/client/src/app/features/settings/plugins/plugins.html
@@ -63,7 +63,7 @@
                   </span>
                   <div class="min-w-0">
                     <p class="font-medium truncate">{{ row.name }}</p>
-                    <p class="text-xs text-base-content/50 truncate">{{ row.pluginId }}</p>
+                    <p class="text-sm text-base-content/50 truncate">{{ row.pluginId }}</p>
                   </div>
                 </div>
               </td>
@@ -83,14 +83,14 @@
                   {{ statusBadgeFor(row).labelKey | translate }}
                 </span>
                 @if (row.status === 'failed' && row.statusReason) {
-                  <p class="text-xs text-error/80 mt-1 max-w-[16rem]">{{ row.statusReason }}</p>
+                  <p class="text-sm text-error/80 mt-1 max-w-[16rem]">{{ row.statusReason }}</p>
                 }
                 @if (row.statusMessage) {
                   <details class="mt-1 status-message-details">
-                    <summary class="text-xs text-warning/80 cursor-pointer select-none">
+                    <summary class="text-sm text-warning/80 cursor-pointer select-none">
                       {{ 'settings.plugins.status_message_toggle' | translate }}
                     </summary>
-                    <pre class="text-xs whitespace-pre-wrap break-words max-w-xs max-h-40 overflow-auto bg-base-200 rounded p-2 mt-1">{{ row.statusMessage }}</pre>
+                    <pre class="text-sm whitespace-pre-wrap break-words max-w-xs max-h-40 overflow-auto bg-base-200 rounded p-2 mt-1">{{ row.statusMessage }}</pre>
                   </details>
                 }
               </td>
@@ -113,7 +113,7 @@
             <tr>
               <td colspan="7" class="pt-0">
                 <details class="metrics-details">
-                  <summary class="text-xs text-base-content/60 cursor-pointer select-none">
+                  <summary class="text-sm text-base-content/60 cursor-pointer select-none">
                     {{ 'settings.plugins.metrics.toggle' | translate }}
                   </summary>
                   <div class="mt-1">

--- a/client/src/app/features/settings/roles/roles.html
+++ b/client/src/app/features/settings/roles/roles.html
@@ -33,7 +33,7 @@
               <td>
                 <div class="flex flex-wrap gap-1">
                   @for (perm of role.permissions; track perm) {
-                    <span class="badge badge-xs badge-ghost">{{ permLabel(perm) }}</span>
+                    <span class="badge badge-sm badge-ghost">{{ permLabel(perm) }}</span>
                   }
                 </div>
               </td>

--- a/client/src/app/features/settings/subtitle-providers/subtitle-providers.html
+++ b/client/src/app/features/settings/subtitle-providers/subtitle-providers.html
@@ -63,7 +63,7 @@
                   <td class="font-medium">
                     <div class="whitespace-nowrap">{{ row.name }}</div>
                     @if (row.isDefault) {
-                      <span class="badge badge-primary badge-xs mt-1">{{ 'settings.subtitle_providers.translation_default' | translate }}</span>
+                      <span class="badge badge-primary badge-sm mt-1">{{ 'settings.subtitle_providers.translation_default' | translate }}</span>
                     }
                   </td>
                   <td class="text-sm">{{ translationEngineLabel(row.engine) }}</td>

--- a/client/src/app/features/settings/subtitles-activity/subtitles-activity.html
+++ b/client/src/app/features/settings/subtitles-activity/subtitles-activity.html
@@ -48,7 +48,7 @@
                 class="link link-hover block truncate"
               >{{ entry.mediaTitle }}</a>
               @if (episodeLabel(entry)) {
-                <p class="text-xs font-normal text-base-content/60 truncate" [title]="episodeLabel(entry)">
+                <p class="text-sm font-normal text-base-content/60 truncate" [title]="episodeLabel(entry)">
                   @if (entry.episodeId != null) {
                     <a
                       [routerLink]="['/series', entry.mediaId, 'episode', entry.episodeId]"
@@ -66,10 +66,10 @@
             <td class="text-center">
               <span class="badge badge-sm" [ngClass]="subStatusClass(entry.status)">{{ entry.status }}</span>
             </td>
-            <td class="text-center text-xs">
-              @if (entry.forced) { <span class="badge badge-xs badge-outline mr-1">F</span> }
-              @if (entry.hearingImpaired) { <span class="badge badge-xs badge-outline">HI</span> }
-              @if (entry.synced) { <span class="badge badge-xs badge-info ml-1">Synced</span> }
+            <td class="text-center text-sm">
+              @if (entry.forced) { <span class="badge badge-sm badge-outline mr-1">F</span> }
+              @if (entry.hearingImpaired) { <span class="badge badge-sm badge-outline">HI</span> }
+              @if (entry.synced) { <span class="badge badge-sm badge-info ml-1">Synced</span> }
             </td>
           </tr>
         }

--- a/client/src/app/features/settings/users/user-detail/user-requests.html
+++ b/client/src/app/features/settings/users/user-detail/user-requests.html
@@ -41,7 +41,7 @@
           <tr>
             <td class="font-medium max-w-xs truncate" [title]="req.title">{{ req.title }}</td>
             <td>
-              <span class="badge badge-xs" [class.badge-info]="req.mediaType === 'movie'" [class.badge-accent]="req.mediaType === 'series'">
+              <span class="badge badge-sm" [class.badge-info]="req.mediaType === 'movie'" [class.badge-accent]="req.mediaType === 'series'">
                 {{ req.mediaType }}
               </span>
             </td>
@@ -56,7 +56,7 @@
                 {{ req.status }}
               </span>
               @if (req.declinedReason) {
-                <span class="text-xs text-base-content/50 ml-1" [title]="req.declinedReason">— {{ req.declinedReason }}</span>
+                <span class="text-sm text-base-content/50 ml-1" [title]="req.declinedReason">— {{ req.declinedReason }}</span>
               }
             </td>
             <td class="text-sm text-base-content/60">{{ req.createdAt | localeDate }}</td>

--- a/client/src/app/features/settings/users/users.html
+++ b/client/src/app/features/settings/users/users.html
@@ -32,7 +32,7 @@
               <td class="font-medium">
                 <a [routerLink]="['/admin/users', user.id]" class="link link-hover">{{ user.username }}</a>
                 @if (auth.user()?.id === user.id) {
-                  <span class="badge badge-primary badge-xs ml-2">{{ 'settings.users.you' | translate }}</span>
+                  <span class="badge badge-primary badge-sm ml-2">{{ 'settings.users.you' | translate }}</span>
                 }
               </td>
               <td>

--- a/client/src/app/features/system/logs/logs.html
+++ b/client/src/app/features/system/logs/logs.html
@@ -22,10 +22,10 @@
     <tbody>
       @for (entry of logs(); track entry.timestamp + entry.message) {
         <tr [class.text-warning]="entry.level === 'warn'" [class.text-error]="entry.level === 'error'" [class.text-info]="entry.level === 'debug'">
-          <td class="text-xs tabular-nums whitespace-nowrap">{{ entry.timestamp | date:'HH:mm:ss.SSS' }}</td>
-          <td><span class="badge badge-xs" [ngClass]="{'badge-success': entry.level === 'log', 'badge-warning': entry.level === 'warn', 'badge-error': entry.level === 'error', 'badge-info': entry.level === 'debug'}">{{ entry.level }}</span></td>
-          <td class="text-xs truncate max-w-32">{{ entry.context }}</td>
-          <td class="text-xs whitespace-pre-wrap break-all">{{ entry.message }}</td>
+          <td class="text-sm tabular-nums whitespace-nowrap">{{ entry.timestamp | date:'HH:mm:ss.SSS' }}</td>
+          <td><span class="badge badge-sm" [ngClass]="{'badge-success': entry.level === 'log', 'badge-warning': entry.level === 'warn', 'badge-error': entry.level === 'error', 'badge-info': entry.level === 'debug'}">{{ entry.level }}</span></td>
+          <td class="text-sm truncate max-w-32">{{ entry.context }}</td>
+          <td class="text-sm whitespace-pre-wrap break-all">{{ entry.message }}</td>
         </tr>
       }
     </tbody>

--- a/client/src/app/features/system/status/status.html
+++ b/client/src/app/features/system/status/status.html
@@ -118,7 +118,7 @@
               <td class="font-medium">
                 {{ commandLabelKey(cmd.name) | translate }}
                 @if (cmd.body?.['mediaTitle']) {
-                  <span class="text-xs text-base-content/50 ml-1">— {{ cmd.body?.['mediaTitle'] }}</span>
+                  <span class="text-sm text-base-content/50 ml-1">— {{ cmd.body?.['mediaTitle'] }}</span>
                 }
               </td>
               <td class="text-sm text-base-content/60">{{ cmd.trigger }}</td>

--- a/client/src/app/shared/components/data-table/data-table.html
+++ b/client/src/app/shared/components/data-table/data-table.html
@@ -84,12 +84,34 @@
                     @case ('bytes') { {{ cellBytes(row[col.key]) }} }
                     @case ('percent') { {{ cellPercent(row[col.key]) }} }
                     @default {
-                      @if (badgeClass(col, row[col.key]); as badge) {
+                      @if (detailText(col, row); as detail) {
+                        <button type="button" class="link link-hover" (click)="openDetail(col, row)"
+                          [attr.aria-label]="(col.detailTitleKey ?? col.labelKey) | translate">
+                          @if (badgeClass(col, row[col.key]); as badge) {
+                            <span class="badge badge-sm" [class]="badge">{{ cellLabel(col, row[col.key]) }}</span>
+                          } @else {
+                            {{ cellLabel(col, row[col.key]) }}
+                          }
+                        </button>
+                      } @else if (badgeClass(col, row[col.key]); as badge) {
                         <span class="badge badge-sm" [class]="badge">{{ cellLabel(col, row[col.key]) }}</span>
                       } @else {
                         {{ cellLabel(col, row[col.key]) }}
                       }
                     }
+                  }
+                  @if (col.subValues?.length) {
+                    <div class="flex flex-wrap items-center gap-1 mt-1 whitespace-nowrap">
+                      @for (sub of col.subValues; track sub.key) {
+                        @if (row[sub.key] !== null && row[sub.key] !== undefined && row[sub.key] !== '') {
+                          @if (badgeClass(sub, row[sub.key]); as badge) {
+                            <span class="badge badge-sm" [class]="badge">{{ subValueText(sub, row[sub.key]) }}</span>
+                          } @else {
+                            <span class="text-sm text-base-content/60">{{ subValueText(sub, row[sub.key]) }}</span>
+                          }
+                        }
+                      }
+                    </div>
                   }
                 </td>
               }
@@ -112,3 +134,18 @@
     }
   }
 </div>
+
+@if (detail(); as open) {
+  <dialog class="modal modal-open">
+    <div class="modal-box max-w-2xl">
+      <h3 class="font-bold text-lg mb-4">{{ open.titleKey | translate }}</h3>
+      <pre class="text-sm whitespace-pre-wrap break-words bg-base-200 rounded p-3 max-h-[60vh] overflow-auto">{{ open.text }}</pre>
+      <div class="modal-action">
+        <button type="button" class="btn btn-ghost" (click)="closeDetail()">{{ 'common.close' | translate }}</button>
+      </div>
+    </div>
+    <form method="dialog" class="modal-backdrop">
+      <button type="button" (click)="closeDetail()" [attr.aria-label]="'common.close' | translate">close</button>
+    </form>
+  </dialog>
+}

--- a/client/src/app/shared/components/data-table/data-table.spec.ts
+++ b/client/src/app/shared/components/data-table/data-table.spec.ts
@@ -325,6 +325,67 @@ describe('DataTableComponent — declared filters', () => {
     expect(badges[0].className).toContain('badge-error');
   });
 
+  it('VERDICT: a cell with a detail opens a dialog showing it, and one without is not a button', async () => {
+    const fixture = await createComponent({
+      http: {
+        get: () =>
+          of([
+            { id: 1, status: 'failed', statusMessage: 'tracker refused: 403' },
+            { id: 2, status: 'completed', statusMessage: null },
+          ]),
+      },
+      columns: [
+        {
+          key: 'status',
+          labelKey: 'x.status',
+          badges: { failed: 'error', completed: 'success' },
+          detailKey: 'statusMessage',
+          detailTitleKey: 'x.detail_title',
+        },
+      ],
+    });
+    const c = fixture.componentInstance;
+    const [status] = c.columns();
+    const rows = c.rows();
+
+    expect(c.detailText(status, rows[0])).toBe('tracker refused: 403');
+    // Nothing to show: the badge stays inert rather than opening an empty dialog.
+    expect(c.detailText(status, rows[1])).toBe('');
+    expect(fixture.nativeElement.querySelectorAll('tbody button').length).toBe(1);
+
+    c.openDetail(status, rows[1]);
+    expect(c.detail()).toBeNull();
+
+    c.openDetail(status, rows[0]);
+    expect(c.detail()).toEqual({ titleKey: 'x.detail_title', text: 'tracker refused: 403' });
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('dialog pre').textContent).toContain('403');
+
+    c.closeDetail();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('dialog')).toBeNull();
+  });
+
+  it('renders declared sub-values under the cell, skipping the ones the row has no value for', async () => {
+    const fixture = await createComponent({
+      http: { get: () => of([{ id: 1, title: 'A Release', quality: 'WEBDL-1080p', source: '' }]) },
+      columns: [
+        {
+          key: 'title',
+          labelKey: 'x.title',
+          subValues: [
+            { key: 'quality', badges: { '*': 'ghost' } },
+            { key: 'source', badges: { '*': 'neutral' } },
+          ],
+        },
+      ],
+    });
+    const badges = fixture.nativeElement.querySelectorAll('tbody td span.badge');
+    // `source` is empty on this row: no badge for it, rather than an empty one.
+    expect(badges.length).toBe(1);
+    expect(badges[0].textContent.trim()).toBe('WEBDL-1080p');
+  });
+
   it('keeps formatted, badged and declared-nowrap cells on one line', async () => {
     const fixture = await createComponent({
       http: { get: () => of([{ id: 1, size: 1024, status: 'failed', source: 'x', title: 'A' }]) },

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -7,7 +7,7 @@ import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
 import { formatBytes } from '../../utils/download-format';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { PaginationComponent } from '../pagination/pagination';
-import { BadgeTone, CellValue, ListAction, PagedResult, RowAction, TableColumn, TableFilter, TableRow } from './data-table.types';
+import { BadgeTone, CellValue, ListAction, PagedResult, RowAction, TableColumn, TableFilter, TableRow, TableSubValue } from './data-table.types';
 
 /** Keystroke-to-request debounce for a `search` filter — see `onSearchInput`. */
 const SEARCH_DEBOUNCE_MS = 300;
@@ -34,6 +34,7 @@ const BADGE_CLASSES: Readonly<Record<BadgeTone, string>> = {
 @Component({
   selector: 'app-data-table',
   imports: [TranslateModule, LocaleDatePipe, PaginationComponent],
+  providers: [LocaleDatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './data-table.html',
 })
@@ -42,6 +43,7 @@ export class DataTableComponent implements OnInit {
   private readonly router = inject(Router);
   private readonly translate = inject(TranslateService);
   private readonly confirmation = inject(ConfirmationService);
+  private readonly localeDate = inject(LocaleDatePipe);
 
   /** Empty renders no heading — an embedded table (a row action's result) carries its own. */
   readonly titleKey = input('');
@@ -67,6 +69,9 @@ export class DataTableComponent implements OnInit {
   readonly listError = signal('');
   readonly busy = signal<string | null>(null);
   readonly listActionBusy = signal<string | null>(null);
+
+  /** The open detail dialog's title key and text, or null when it is closed. */
+  readonly detail = signal<{ titleKey: string; text: string } | null>(null);
 
   readonly page = signal(1);
   readonly total = signal(0);
@@ -165,12 +170,43 @@ export class DataTableComponent implements OnInit {
    * The badge class for a cell, or null to render it as text. `*` catches every value the
    * column didn't name; an unknown tone falls back to `ghost` rather than reaching the DOM.
    */
-  badgeClass(col: TableColumn, value: CellValue): string | null {
+  badgeClass(col: Pick<TableColumn, 'badges'>, value: CellValue): string | null {
     const tones = col.badges;
     if (!tones) return null;
     const tone = tones[String(value ?? '')] ?? tones['*'];
     if (!tone) return null;
     return BADGE_CLASSES[tone] ?? BADGE_CLASSES.ghost;
+  }
+
+  /** The row's detail text for this column, or '' when there is none to open. A cell only
+   *  becomes a button when it has something to show. */
+  detailText(col: TableColumn, row: TableRow): string {
+    if (!col.detailKey) return '';
+    return String(row[col.detailKey] ?? '').trim();
+  }
+
+  openDetail(col: TableColumn, row: TableRow): void {
+    const text = this.detailText(col, row);
+    if (!text) return;
+    this.detail.set({ titleKey: col.detailTitleKey ?? col.labelKey, text });
+  }
+
+  closeDetail(): void {
+    this.detail.set(null);
+  }
+
+  /** Sub-values render as their own badge or text, reusing the column rules one level down. */
+  subValueText(sub: TableSubValue, value: CellValue): string {
+    switch (sub.format) {
+      case 'date':
+        return this.localeDate.transform(this.cellDate(value));
+      case 'bytes':
+        return this.cellBytes(value);
+      case 'percent':
+        return this.cellPercent(value);
+      default:
+        return this.cellLabel(sub, value);
+    }
   }
 
   /** A formatted value, a badge and a declared `nowrap` are all atomic — none should wrap. */
@@ -179,7 +215,7 @@ export class DataTableComponent implements OnInit {
   }
 
   /** An undeclared value renders as itself rather than as a missing translate key. */
-  cellLabel(col: TableColumn, value: CellValue): string {
+  cellLabel(col: Pick<TableColumn, 'labelKeys'>, value: CellValue): string {
     const raw = String(value ?? '');
     const key = col.labelKeys?.[raw];
     return key ? this.translate.instant(key) : raw;

--- a/client/src/app/shared/components/data-table/data-table.types.ts
+++ b/client/src/app/shared/components/data-table/data-table.types.ts
@@ -11,6 +11,14 @@ export type BadgeTone =
   | 'error'
   | 'ghost';
 
+/** One value rendered under a cell's own. One level only: it carries no `subValues`. */
+export interface TableSubValue {
+  key: string;
+  format?: 'date' | 'bytes' | 'percent';
+  labelKeys?: Record<string, string>;
+  badges?: Record<string, BadgeTone>;
+}
+
 export interface TableColumn {
   key: string;
   labelKey: string;
@@ -21,6 +29,12 @@ export interface TableColumn {
   badges?: Record<string, BadgeTone>;
   /** Keeps the cell on one line. Implied for `format`ted and badged cells. */
   nowrap?: boolean;
+  /** A second line of values under the cell's own. */
+  subValues?: TableSubValue[];
+  /** Another field of the row; when it has a value the cell opens a dialog showing it. */
+  detailKey?: string;
+  /** Title of that dialog; falls back to the column's `labelKey`. */
+  detailTitleKey?: string;
 }
 
 /** `TableConfigPage.filters[]` — value sent to `list` as a query param named by `key`. */

--- a/client/src/app/shared/components/provider-list/provider-list.spec.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.spec.ts
@@ -165,8 +165,23 @@ describe('ProviderListComponent — characterisation', () => {
 
     await fixture.componentInstance.runTestConnection();
 
-    expect(run).toHaveBeenCalledWith({ implementation: 'demo', settings: { url: 'http://x', apiKey: '' } });
+    // A new draft carries no id, and the blank secret is omitted rather than sent as ''.
+    expect(run).toHaveBeenCalledWith({ implementation: 'demo', settings: { url: 'http://x' } });
     expect(fixture.componentInstance.testResult()).toEqual({ ok: true, message: 'ok' });
+  });
+
+  it('VERDICT: testing an edit sends the row id and no blank secret, so the stored one is reusable', async () => {
+    const run = vi.fn(() => Promise.resolve({ ok: true, message: 'ok' }));
+    const fixture = await createComponent({
+      get: () => of([{ id: 7, name: 'A', implementation: 'demo', enabled: true, priority: 1, settings: { url: 'http://x' } }]),
+    });
+    fixture.componentRef.setInput('testConnection', run);
+    fixture.detectChanges();
+    fixture.componentInstance.openEdit(fixture.componentInstance.rows()[0]);
+
+    await fixture.componentInstance.runTestConnection();
+
+    expect(run).toHaveBeenCalledWith({ implementation: 'demo', settings: { url: 'http://x' }, id: 7 });
   });
 
   it('deletes after confirmation and reloads', async () => {

--- a/client/src/app/shared/components/provider-list/provider-list.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.ts
@@ -234,6 +234,16 @@ export class ProviderListComponent implements OnInit {
     return { settings, topLevel };
   }
 
+  /** Blank means "leave the stored secret alone" — never round-trip it as ''. Applied to the
+   *  test draft as well as the save body, so testing an edit doesn't demand the key again. */
+  private withoutBlankSecrets(settings: Record<string, unknown>): Record<string, unknown> {
+    const out = { ...settings };
+    for (const f of this.currentImplementation()?.fields ?? []) {
+      if (f.secret && out[f.key] === '') delete out[f.key];
+    }
+    return out;
+  }
+
   async runTestConnection(): Promise<void> {
     const run = this.testConnection();
     if (!run) return;
@@ -241,7 +251,14 @@ export class ProviderListComponent implements OnInit {
     this.testLoading.set(true);
     try {
       const { settings } = this.splitDraft();
-      this.testResult.set(await run({ implementation: this.draftImplementation(), settings }));
+      const id = this.editingId();
+      this.testResult.set(
+        await run({
+          implementation: this.draftImplementation(),
+          settings: this.withoutBlankSecrets(settings),
+          ...(id == null ? {} : { id }),
+        }),
+      );
     } catch {
       this.testResult.set({ ok: false, message: this.translate.instant('provider_list.test_network_error') });
     } finally {
@@ -254,17 +271,13 @@ export class ProviderListComponent implements OnInit {
     if (!name || this.requiredFieldMissing()) return;
 
     const { settings, topLevel } = this.splitDraft();
-    // Blank means "leave the stored secret alone" — never round-trip it as ''.
-    for (const f of this.currentImplementation()?.fields ?? []) {
-      if (f.secret && settings[f.key] === '') delete settings[f.key];
-    }
     let body: Record<string, unknown> = {
       name,
       [this.implementationKey()]: this.draftImplementation(),
       priority: this.draftPriority(),
       enabled: this.draftEnabled(),
       ...topLevel,
-      settings,
+      settings: this.withoutBlankSecrets(settings),
     };
     const transform = this.beforeSave();
     if (transform) body = transform(body);

--- a/client/src/app/shared/components/provider-list/provider-list.types.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.types.ts
@@ -30,6 +30,9 @@ export interface ProviderTestResult {
 export interface ProviderDraft {
   implementation: string;
   settings: Record<string, unknown>;
+  /** The row being edited, absent when the draft is new. Lets the resource resolve a blank
+   *  secret against what it already stored instead of making the user retype it. */
+  id?: number;
 }
 
 /** A list-scope action (`ProvidersConfigPage.actions[].scope: 'list'`) — rendered

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -116,7 +116,7 @@
                         {{ sub.score }}
                       }
                     </td>
-                    <td class="text-center text-xs">
+                    <td class="text-center text-sm">
                       @if (sub.status === 'processing') {
                         @if (sub.providerType === 'translated' && translationPercent(sub.id) !== null) {
                           <span class="inline-flex items-center gap-1 align-middle">
@@ -124,16 +124,16 @@
                             <span class="tabular-nums text-[10px]">{{ translationPercent(sub.id) }}%</span>
                           </span>
                         } @else {
-                          <span class="badge badge-xs badge-warning gap-1">
+                          <span class="badge badge-sm badge-warning gap-1">
                             <span class="loading loading-spinner loading-xs"></span>
                             {{ (sub.providerType === 'translated' ? 'media_detail.translate_processing' : 'media_detail.ocr_processing') | translate }}
                           </span>
                         }
                       }
-                      @if (sub.forced) { <span class="badge badge-xs badge-outline mr-1">F</span> }
-                      @if (sub.hearingImpaired) { <span class="badge badge-xs badge-outline">HI</span> }
-                      @if (sub.synced) { <span class="badge badge-xs badge-info ml-1">Synced</span> }
-                      @if (sub.codec) { <span class="badge badge-xs badge-ghost ml-1">{{ sub.codec }}</span> }
+                      @if (sub.forced) { <span class="badge badge-sm badge-outline mr-1">F</span> }
+                      @if (sub.hearingImpaired) { <span class="badge badge-sm badge-outline">HI</span> }
+                      @if (sub.synced) { <span class="badge badge-sm badge-info ml-1">Synced</span> }
+                      @if (sub.codec) { <span class="badge badge-sm badge-ghost ml-1">{{ sub.codec }}</span> }
                     </td>
                     <td class="text-end">
                       @if (canManage() && rowHasActions(sub) && sub.status !== 'processing') {


### PR DESCRIPTION
Core half of four requests. All three contract fields are optional, so an existing manifest renders exactly as before.

## `detailKey` — a clickable cell instead of a column

`detailKey` names another field of the row. When it holds a value the cell becomes a **button** that opens a dialog showing it; when it doesn't, the cell stays inert rather than opening an empty dialog.

It cost nothing to fetch because **the value already travels in the row** — `handleHistory` sends `statusMessage` per row today, which is exactly what the column was printing. No route, no plugin call, no loading or error state, no deadline story. Had the detail needed fetching on click, this would have been a different order of work.

A real `<button>`, not a clickable `<span>`: a span is unreachable by remote, and spatial navigation is a live constraint on this project.

## `subValues` — a second line under a cell

A release's quality and tracker belong with its name; as columns of their own they spent width the title needed. Each sub-value reuses the column rules one level down — `badges`, `labelKeys`, `format` — and one whose field is empty on a given row renders nothing rather than an empty badge. `TableSubValue` carries no `subValues` of its own, so nesting is impossible in the type, not merely undocumented.

## Tables read at `text-sm`

Every `text-xs` and `badge-xs` **inside a `<table>`** is now `text-sm` / `badge-sm` — 23 and 17 sites across 14 files. 12px and 11px are below what a table of real data can be read at.

**One thing I did not change, on purpose:** 35 `btn-xs` on row-action buttons, also inside tables. Their label is the same 12px, so the same complaint applies, but `btn-sm` raises every row's height across ~20 pages — that's a density decision, not a legibility one. Say the word and it is one sweep.

## Testing an indexer no longer demands the API key again

`runTestConnection` now omits a blank secret and carries the row `id` when the draft is an edit — the same convention the save body already applied. The resource can resolve the secret it already stored. The key still never travels back to the client on read; only its id does.

## Checks

- `ng test` → 442 passing, including the dialog (opens with text, stays closed with none, one button for two rows), the sub-value line (skips a row's empty field), and the test payload for both a new draft and an edit
- `ng build` clean, backend `tsc` clean, `jest src/modules/plugins` → 791 passing

Follow-up in `fk-plugin-download`: the history table declares `detailKey` on status and `subValues` on the title, drops the quality, tracker and detail columns, and its test-connection route resolves a blank API key from the stored row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)