### PR TITLE
refactor(plugin-view): name the detail field for what it is, not as a key

### DIFF
--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -204,10 +204,10 @@ export interface TableColumn {
   /** A second line under the cell's own value. A release's quality and tracker belong with
    *  its name; as columns of their own they cost width the title needed. */
   subValues?: TableSubValue[];
-  /** Names another field of the row. When that field has a value, the cell becomes a button
-   *  opening a dialog that shows it — a long diagnostic message reads there instead of
-   *  stretching a column across every row. */
-  detailKey?: string;
+  /** Names another field of the row — not a translation key, hence no `Key` suffix. When that
+   *  field has a value, the cell becomes a button opening a dialog that shows it: a long
+   *  diagnostic message reads there instead of stretching a column across every row. */
+  detailField?: string;
   /** Title of that dialog. Falls back to the column's own `labelKey`. */
   detailTitleKey?: string;
 }

--- a/client/src/app/shared/components/data-table/data-table.spec.ts
+++ b/client/src/app/shared/components/data-table/data-table.spec.ts
@@ -339,7 +339,7 @@ describe('DataTableComponent — declared filters', () => {
           key: 'status',
           labelKey: 'x.status',
           badges: { failed: 'error', completed: 'success' },
-          detailKey: 'statusMessage',
+          detailField: 'statusMessage',
           detailTitleKey: 'x.detail_title',
         },
       ],

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -181,8 +181,8 @@ export class DataTableComponent implements OnInit {
   /** The row's detail text for this column, or '' when there is none to open. A cell only
    *  becomes a button when it has something to show. */
   detailText(col: TableColumn, row: TableRow): string {
-    if (!col.detailKey) return '';
-    return String(row[col.detailKey] ?? '').trim();
+    if (!col.detailField) return '';
+    return String(row[col.detailField] ?? '').trim();
   }
 
   openDetail(col: TableColumn, row: TableRow): void {

--- a/client/src/app/shared/components/data-table/data-table.types.ts
+++ b/client/src/app/shared/components/data-table/data-table.types.ts
@@ -32,7 +32,7 @@ export interface TableColumn {
   /** A second line of values under the cell's own. */
   subValues?: TableSubValue[];
   /** Another field of the row; when it has a value the cell opens a dialog showing it. */
-  detailKey?: string;
+  detailField?: string;
   /** Title of that dialog; falls back to the column's `labelKey`. */
   detailTitleKey?: string;
 }


### PR DESCRIPTION
Follow-up to #1009, before a release ships the wrong name.

In this contract a `*Key` suffix means **a translation key**. `detailKey` named a field of the row, and the plugin repo's own manifest test caught the lie: it walks every `*Key` under `ui.*` and asserts each one resolves in `i18n`, so declaring `detailKey: 'statusMessage'` failed with

```
"statusMessage" is referenced by ui.* but missing from i18n.en — it would render as a raw key
```

Renamed to `detailField`, which also matches `subValues[].key` — a field name that never claimed to be a key. `detailTitleKey` keeps its suffix: that one really is a translation key.

Nothing depends on the old name yet — it has never been in a release — so this costs nothing now and would cost a contract break later.

## Checks

- `ng build` clean, backend `tsc` clean, `ng test` → 442 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)