### PR TITLE
style(tables): drop the compact table modifier

### DIFF
--- a/client/src/app/features/dashboard/dashboard.html
+++ b/client/src/app/features/dashboard/dashboard.html
@@ -132,7 +132,7 @@
         @if (sub.recent.length) {
           <h3 class="text-sm font-medium text-base-content/60 mb-2">{{ 'dashboard.sub_recent' | translate }}</h3>
           <div class="overflow-x-auto rounded-lg border border-base-200">
-            <table class="table table-sm">
+            <table class="table">
               <thead>
                 <tr>
                   <th>{{ 'dashboard.sub_col_media' | translate }}</th>

--- a/client/src/app/features/import-disk/import-disk.html
+++ b/client/src/app/features/import-disk/import-disk.html
@@ -85,7 +85,7 @@
         </div>
 
         <div class="overflow-x-auto rounded-lg border border-base-200">
-          <table class="table table-sm">
+          <table class="table">
             <thead>
               <tr>
                 <th class="w-8"></th>

--- a/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.html
@@ -21,7 +21,7 @@
     </div>
     @if (subSearchResults().length > 0) {
       <div class="overflow-y-auto flex-1 min-h-0">
-        <table class="table table-sm">
+        <table class="table">
           <thead>
             <tr>
               <th>{{ 'media_detail.col_sub_title' | translate }}</th>

--- a/client/src/app/features/media-detail/components/releases-table/releases-table.component.html
+++ b/client/src/app/features/media-detail/components/releases-table/releases-table.component.html
@@ -1,5 +1,5 @@
 <div>
-  <table class="table table-sm table-fixed w-full">
+  <table class="table table-fixed w-full">
     <thead>
       <tr>
         <th>{{ 'media_detail.col_release' | translate }}</th>

--- a/client/src/app/features/settings/auto-approval/auto-approval.html
+++ b/client/src/app/features/settings/auto-approval/auto-approval.html
@@ -19,7 +19,7 @@
     <p class="text-base-content/50 text-center py-8">{{ 'settings.auto_approval.empty' | translate }}</p>
   } @else {
     <div class="overflow-x-auto rounded-lg border border-base-200">
-      <table class="table table-sm">
+      <table class="table">
         <thead>
           <tr>
             <th>{{ 'settings.auto_approval.col_name' | translate }}</th>

--- a/client/src/app/features/settings/custom-formats/custom-formats.html
+++ b/client/src/app/features/settings/custom-formats/custom-formats.html
@@ -19,7 +19,7 @@
     <p class="text-center py-12 text-base-content/50">{{ 'settings.custom_formats.empty' | translate }}</p>
   } @else {
     <div class="overflow-x-auto rounded-lg border border-base-200">
-      <table class="table table-zebra table-sm">
+      <table class="table table-zebra">
         <thead>
           <tr>
             <th>{{ 'settings.custom_formats.col_name' | translate }}</th>
@@ -71,7 +71,7 @@
   </div>
   @if (testResults().length) {
     <div class="overflow-x-auto mt-3 rounded-lg border border-base-200">
-      <table class="table table-sm">
+      <table class="table">
         <thead><tr><th>Format</th><th>Match</th><th class="text-right">Score</th></tr></thead>
         <tbody>
           @for (r of testResults(); track r.formatId) {

--- a/client/src/app/features/settings/data-imports/data-imports.html
+++ b/client/src/app/features/settings/data-imports/data-imports.html
@@ -34,7 +34,7 @@
           </p>
         } @else {
           <div class="overflow-x-auto rounded-lg border border-base-200">
-            <table class="table table-zebra table-sm">
+            <table class="table table-zebra">
               <thead>
                 <tr>
                   <th>{{ 'settings.media_servers.col_name' | translate }}</th>

--- a/client/src/app/features/settings/delay-profiles/delay-profiles.html
+++ b/client/src/app/features/settings/delay-profiles/delay-profiles.html
@@ -17,7 +17,7 @@
     <p class="text-center py-12 text-base-content/50">{{ 'settings.delay_profiles.empty' | translate }}</p>
   } @else {
     <div class="overflow-x-auto rounded-lg border border-base-200">
-      <table class="table table-zebra table-sm">
+      <table class="table table-zebra">
         <thead>
           <tr>
             <th>{{ 'settings.delay_profiles.col_delay' | translate }}</th>

--- a/client/src/app/features/settings/media-servers/media-servers.html
+++ b/client/src/app/features/settings/media-servers/media-servers.html
@@ -19,7 +19,7 @@
     <p class="text-center py-12 text-base-content/50">{{ 'settings.media_servers.empty' | translate }}</p>
   } @else {
     <div class="overflow-x-auto rounded-lg border border-base-200">
-      <table class="table table-zebra table-sm">
+      <table class="table table-zebra">
         <thead>
           <tr>
             <th>{{ 'settings.media_servers.col_name' | translate }}</th>

--- a/client/src/app/features/settings/notifications/notifications.html
+++ b/client/src/app/features/settings/notifications/notifications.html
@@ -19,7 +19,7 @@
     <p class="text-center py-12 text-base-content/50">{{ 'settings.notifications.empty' | translate }}</p>
   } @else {
     <div class="overflow-x-auto rounded-lg border border-base-200">
-      <table class="table table-zebra table-sm">
+      <table class="table table-zebra">
         <thead>
           <tr>
             <th>{{ 'settings.notifications.col_name' | translate }}</th>

--- a/client/src/app/features/settings/plugins/plugin-sources/plugin-sources.html
+++ b/client/src/app/features/settings/plugins/plugin-sources/plugin-sources.html
@@ -27,7 +27,7 @@
       <p class="text-center py-8 text-base-content/50">{{ 'settings.plugins.sources.empty' | translate }}</p>
     } @else {
       <div class="overflow-x-auto rounded-lg border border-base-200">
-        <table class="table table-zebra table-sm">
+        <table class="table table-zebra">
           <thead>
             <tr>
               <th>{{ 'settings.plugins.sources.col_url' | translate }}</th>

--- a/client/src/app/features/settings/plugins/plugins.html
+++ b/client/src/app/features/settings/plugins/plugins.html
@@ -41,7 +41,7 @@
     <p class="text-center py-12 text-base-content/50">{{ 'settings.plugins.empty' | translate }}</p>
   } @else {
     <div class="overflow-x-auto rounded-lg border border-base-200">
-      <table class="table table-sm">
+      <table class="table">
         <thead>
           <tr>
             <th>{{ 'settings.plugins.col_plugin' | translate }}</th>

--- a/client/src/app/features/settings/roles/roles.html
+++ b/client/src/app/features/settings/roles/roles.html
@@ -17,7 +17,7 @@
     <div role="alert" class="alert alert-error">{{ listError() }}</div>
   } @else {
     <div class="overflow-x-auto rounded-lg border border-base-200">
-      <table class="table table-zebra table-sm">
+      <table class="table table-zebra">
         <thead>
           <tr>
             <th>{{ 'settings.roles.col_name' | translate }}</th>

--- a/client/src/app/features/settings/schedulers/schedulers.html
+++ b/client/src/app/features/settings/schedulers/schedulers.html
@@ -10,7 +10,7 @@
     </div>
 
     <div class="overflow-x-auto rounded-lg border border-base-200">
-      <table class="table table-sm">
+      <table class="table">
         <thead>
           <tr>
             <th>{{ 'settings.schedulers.col_name' | translate }}</th>

--- a/client/src/app/features/settings/subtitle-providers/subtitle-providers.html
+++ b/client/src/app/features/settings/subtitle-providers/subtitle-providers.html
@@ -48,7 +48,7 @@
         <p class="text-sm text-base-content/50 py-4">{{ 'settings.subtitle_providers.translation_empty' | translate }}</p>
       } @else {
         <div class="overflow-x-auto rounded-lg border border-base-200">
-          <table class="table table-sm">
+          <table class="table">
             <thead>
               <tr>
                 <th>{{ 'settings.subtitle_providers.col_name' | translate }}</th>
@@ -139,7 +139,7 @@
       <p class="text-center py-8 text-base-content/50">{{ 'settings.subtitle_providers.stats_empty' | translate }}</p>
     } @else {
       <div class="overflow-x-auto mt-4 rounded-lg border border-base-200">
-        <table class="table table-sm">
+        <table class="table">
           <thead>
             <tr>
               <th>{{ 'settings.subtitle_providers.stats_date' | translate }}</th>

--- a/client/src/app/features/settings/subtitles-activity/subtitles-activity.html
+++ b/client/src/app/features/settings/subtitles-activity/subtitles-activity.html
@@ -26,7 +26,7 @@
   <p class="text-center py-12 text-base-content/50">{{ 'activity.no_subtitle_history' | translate }}</p>
 } @else {
   <div class="overflow-x-auto rounded-lg border border-base-200">
-    <table class="table table-sm table-zebra">
+    <table class="table table-zebra">
       <thead>
         <tr>
           <th>{{ 'activity.col_date' | translate }}</th>

--- a/client/src/app/features/settings/subtitles/subtitles-stats.html
+++ b/client/src/app/features/settings/subtitles/subtitles-stats.html
@@ -52,7 +52,7 @@
         <p class="text-sm text-base-content/50">{{ 'settings.subtitles.no_missing' | translate }}</p>
       } @else {
         <div class="overflow-x-auto rounded-lg border border-base-200">
-          <table class="table table-sm">
+          <table class="table">
             <thead>
               <tr>
                 <th>{{ 'settings.subtitles.col_media' | translate }}</th>

--- a/client/src/app/features/settings/users/user-detail/user-requests.html
+++ b/client/src/app/features/settings/users/user-detail/user-requests.html
@@ -27,7 +27,7 @@
   <p class="text-sm text-base-content/50 py-4">{{ 'settings.user_detail.no_requests' | translate }}</p>
 } @else {
   <div class="overflow-x-auto rounded-lg border border-base-200">
-    <table class="table table-sm">
+    <table class="table">
       <thead>
         <tr>
           <th>{{ 'settings.user_detail.col_title' | translate }}</th>

--- a/client/src/app/features/settings/users/users.html
+++ b/client/src/app/features/settings/users/users.html
@@ -17,7 +17,7 @@
     <div role="alert" class="alert alert-error">{{ listError() }}</div>
   } @else {
     <div class="overflow-x-auto rounded-lg border border-base-200">
-      <table class="table table-zebra table-sm">
+      <table class="table table-zebra">
         <thead>
           <tr>
             <th>{{ 'settings.users.col_username' | translate }}</th>

--- a/client/src/app/features/system/backups/backups.html
+++ b/client/src/app/features/system/backups/backups.html
@@ -11,7 +11,7 @@
   <p class="text-center py-6 text-base-content/50">{{ 'system.no_backups' | translate }}</p>
 } @else {
   <div class="overflow-x-auto rounded-lg border border-base-200">
-    <table class="table table-sm">
+    <table class="table">
       <thead>
         <tr>
           <th>{{ 'system.col_backup_name' | translate }}</th>

--- a/client/src/app/features/system/logs/logs.html
+++ b/client/src/app/features/system/logs/logs.html
@@ -10,7 +10,7 @@
 </div>
 
 <div class="overflow-x-auto max-h-[32rem] overflow-y-auto rounded-lg border border-base-200">
-  <table class="table table-xs font-mono">
+  <table class="table font-mono">
     <thead class="sticky top-0 bg-base-100">
       <tr>
         <th class="w-40">{{ 'system.col_log_time' | translate }}</th>

--- a/client/src/app/features/system/status/status.html
+++ b/client/src/app/features/system/status/status.html
@@ -102,7 +102,7 @@
     <p class="text-center py-8 text-base-content/50">{{ 'system.no_commands' | translate }}</p>
   } @else {
     <div class="overflow-x-auto rounded-lg border border-base-200">
-      <table class="table table-sm">
+      <table class="table">
         <thead>
           <tr>
             <th>{{ 'system.col_command' | translate }}</th>

--- a/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.html
+++ b/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.html
@@ -16,7 +16,7 @@
         </div>
       } @else if (seasons().length) {
         <div class="overflow-x-auto mt-4 rounded-lg border border-base-200">
-          <table class="table table-sm">
+          <table class="table">
             <thead>
               <tr>
                 <th class="w-12">

--- a/client/src/app/shared/components/data-table/data-table.html
+++ b/client/src/app/shared/components/data-table/data-table.html
@@ -63,7 +63,7 @@
     <p class="text-center py-12 text-base-content/50">{{ emptyKey() | translate }}</p>
   } @else {
     <div class="overflow-x-auto rounded-lg border border-base-200" [class.opacity-50]="loading()">
-      <table class="table table-zebra table-sm">
+      <table class="table table-zebra">
         <thead>
           <tr>
             @for (col of columns(); track col.key) {

--- a/client/src/app/shared/components/provider-list/provider-list.html
+++ b/client/src/app/shared/components/provider-list/provider-list.html
@@ -33,7 +33,7 @@
     <p class="text-center py-12 text-base-content/50">{{ labels().emptyKey | translate }}</p>
   } @else {
     <div class="overflow-x-auto rounded-lg border border-base-200">
-      <table class="table table-zebra table-sm">
+      <table class="table table-zebra">
         <thead>
           <tr>
             <th>{{ labels().colNameKey | translate }}</th>

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -65,7 +65,7 @@
         <p class="text-sm text-base-content/50">{{ 'media_detail.no_subtitles' | translate }}</p>
       } @else {
         <div class="rounded-lg border border-base-200 overflow-x-auto">
-          <table class="table table-sm">
+          <table class="table">
             <thead>
               <tr>
                 <th>{{ 'media_detail.col_sub_language' | translate }}</th>


### PR DESCRIPTION
`table-sm` shrinks a cell's padding **and** its font, so it was undoing part of the `text-xs → text-sm` sweep in #1009. Removed from all 27 tables.

The log viewer's `table-xs` goes with them: it is smaller still, and leaving it would have kept those rows tighter than every other table while its own text had already moved to `text-sm`.

No markup beyond the class list changed — `table`, `table-zebra`, `table-fixed` and `font-mono` all stay.

## Checks

- `ng build` clean, `ng test` → 442 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)