### PR TITLE
feat(schedulers): list the plugin-source refresh, and stop core naming plugin jobs

### DIFF
--- a/backend/src/common/constants/core-scheduler-jobs.ts
+++ b/backend/src/common/constants/core-scheduler-jobs.ts
@@ -8,8 +8,13 @@
  * `scheduler.service.ts` types `SCHEDULERS[number].name` against this same array, so adding a
  * core job there without adding its name here fails to typecheck.
  */
+/** Once a day, an hour before the metadata refresh, so a source that publishes a new
+ *  version is already cached when anything looks at the catalog. */
+export const PLUGIN_SOURCE_REFRESH_CRON = '0 3 * * *';
+
 export const CORE_SCHEDULER_JOB_NAMES = [
   'RefreshMetadata',
+  'RefreshPluginSources',
   'SubtitleSearch',
   'SubtitleUpgrade',
 ] as const;

--- a/backend/src/modules/plugins/plugin-catalog-client.service.ts
+++ b/backend/src/modules/plugins/plugin-catalog-client.service.ts
@@ -40,7 +40,8 @@ export class PluginCatalogClientService {
     private readonly registry: PluginRegistryService,
   ) {}
 
-  @Cron(CronExpression.EVERY_DAY_AT_4AM)
+  /** Driven by `SchedulerService`'s `RefreshPluginSources` job, so the run is listed,
+   *  triggerable and recorded — a bare `@Cron` here was none of those. */
   async refreshAll(): Promise<void> {
     const sources = await this.sourceRepo.find({ where: { enabled: true } });
     for (const source of sources) {

--- a/backend/src/modules/plugins/plugins.module.ts
+++ b/backend/src/modules/plugins/plugins.module.ts
@@ -67,6 +67,13 @@ import { ScheduledJobRegistryModule } from '../scheduler/scheduled-job-registry.
     PluginRouteGuard,
     PluginPreRollService,
   ],
-  exports: [TypeOrmModule, PluginRegistryService, PluginDatabaseService, PluginJobsService, PluginPreRollService],
+  exports: [
+    TypeOrmModule,
+    PluginRegistryService,
+    PluginDatabaseService,
+    PluginJobsService,
+    PluginPreRollService,
+    PluginCatalogClientService,
+  ],
 })
 export class PluginsModule {}

--- a/backend/src/modules/scheduler/scheduler.service.spec.ts
+++ b/backend/src/modules/scheduler/scheduler.service.spec.ts
@@ -29,6 +29,7 @@ function makeService(pluginJobs: ReturnType<typeof fakePluginJobs>, jobRegistry:
     unused,
     pluginJobs as unknown as PluginJobsService,
     jobRegistry as unknown as ScheduledJobRegistry,
+    unused,
   );
 }
 

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -26,9 +26,10 @@ import {
   buildSpriteLabel,
 } from '../streaming/thumbnail.service';
 import { MarkersService } from '../markers/markers.service';
-import { CORE_TRIGGER_ONLY_JOB_NAMES, CoreSchedulerJobName } from '../../common/constants/core-scheduler-jobs';
+import { CORE_TRIGGER_ONLY_JOB_NAMES, CoreSchedulerJobName, PLUGIN_SOURCE_REFRESH_CRON } from '../../common/constants/core-scheduler-jobs';
 import { PluginJobsService } from '../plugins/plugin-jobs.service';
 import { ScheduledJobRegistry } from './scheduled-job-registry.service';
+import { PluginCatalogClientService } from '../plugins/plugin-catalog-client.service';
 import { runAuditedCommand } from './command-audit.util';
 
 /** Yield the event loop so HTTP requests aren't starved by bulk tasks. */
@@ -56,6 +57,7 @@ export class SchedulerService implements OnModuleInit {
     private readonly markers: MarkersService,
     private readonly pluginJobs: PluginJobsService,
     private readonly jobRegistry: ScheduledJobRegistry,
+    private readonly catalogClient: PluginCatalogClientService,
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -77,6 +79,12 @@ export class SchedulerService implements OnModuleInit {
       cron: CronExpression.EVERY_DAY_AT_4AM,
       triggerable: true,
       labelKey: 'system.cmd_refresh_metadata',
+    },
+    {
+      name: 'RefreshPluginSources',
+      cron: PLUGIN_SOURCE_REFRESH_CRON,
+      triggerable: true,
+      labelKey: 'system.cmd_refresh_plugin_sources',
     },
     {
       name: 'SubtitleSearch',
@@ -113,6 +121,16 @@ export class SchedulerService implements OnModuleInit {
   async refreshMetadata(): Promise<void> {
     return this.runCommand('RefreshMetadata', 'scheduled', () =>
       this.doRefreshMetadata(),
+    );
+  }
+
+  /** Re-fetch every enabled plugin source's catalog once a day. Driven from here rather than
+   *  from a bare `@Cron` on the catalog client so the run is listed, triggerable and recorded
+   *  like every other scheduled job. */
+  @Cron(PLUGIN_SOURCE_REFRESH_CRON)
+  async refreshPluginSources(): Promise<void> {
+    return this.runCommand('RefreshPluginSources', 'scheduled', () =>
+      this.catalogClient.refreshAll(),
     );
   }
 

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1205,6 +1205,7 @@
     "device_client_version": "v{{version}}",
     "commands_title": "Eine Aufgabe auslösen",
     "cmd_refresh_metadata": "Metadaten aktualisieren",
+    "cmd_refresh_plugin_sources": "Plugin-Quellen aktualisieren",
     "cmd_refresh_missing_metadata": "Fehlende Metadaten neu laden",
     "cmd_rescan_all": "Alle Dateien erneut scannen",
     "cmd_rescan_missing_files": "Fehlende Dateien erneut scannen",
@@ -2034,15 +2035,6 @@
       "trigger": "Manuell auslösen",
       "triggered": "Aufgabe {{ name }} ausgelöst.",
       "never": "Nie",
-      "names": {
-        "SearchMissing": "Suche nach fehlenden Medien",
-        "RefreshMetadata": "Aktualisierung der Metadaten",
-        "RssSync": "RSS-Synchronisierung",
-        "ImportCompleted": "Import der Downloads",
-        "CleanStalled": "Bereinigung blockierter Torrents",
-        "SubtitleSearch": "Untertitelsuche",
-        "SubtitleUpgrade": "Verbesserung der Untertitel"
-      },
       "status": {
         "completed": "Abgeschlossen",
         "running": "Läuft",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1213,6 +1213,7 @@
     "device_client_version": "v{{version}}",
     "commands_title": "Trigger a task",
     "cmd_refresh_metadata": "Refresh metadata",
+    "cmd_refresh_plugin_sources": "Refresh plugin sources",
     "cmd_refresh_missing_metadata": "Reload missing metadata",
     "cmd_rescan_all": "Rescan all files",
     "cmd_rescan_missing_files": "Rescan missing files",
@@ -2061,15 +2062,6 @@
       "trigger": "Trigger manually",
       "triggered": "Task {{ name }} triggered.",
       "never": "Never",
-      "names": {
-        "SearchMissing": "Search for missing media",
-        "RefreshMetadata": "Refresh metadata",
-        "RssSync": "RSS sync",
-        "ImportCompleted": "Import downloads",
-        "CleanStalled": "Cleanup stalled torrents",
-        "SubtitleSearch": "Subtitle search",
-        "SubtitleUpgrade": "Subtitle upgrade"
-      },
       "status": {
         "completed": "Completed",
         "running": "Running",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1205,6 +1205,7 @@
     "device_client_version": "v{{version}}",
     "commands_title": "Iniciar una tarea",
     "cmd_refresh_metadata": "Actualizar los metadatos",
+    "cmd_refresh_plugin_sources": "Actualizar las fuentes de plugins",
     "cmd_refresh_missing_metadata": "Recargar los metadatos faltantes",
     "cmd_rescan_all": "Reescanear todos los archivos",
     "cmd_rescan_missing_files": "Reescanear los archivos faltantes",
@@ -2034,15 +2035,6 @@
       "trigger": "Activar manualmente",
       "triggered": "Tarea {{ name }} activada.",
       "never": "Nunca",
-      "names": {
-        "SearchMissing": "Búsqueda de los medios faltantes",
-        "RefreshMetadata": "Actualización de los metadatos",
-        "RssSync": "Sincronización RSS",
-        "ImportCompleted": "Importación de las descargas",
-        "CleanStalled": "Limpieza de los torrents bloqueados",
-        "SubtitleSearch": "Búsqueda de subtítulos",
-        "SubtitleUpgrade": "Mejora de los subtítulos"
-      },
       "status": {
         "completed": "Terminado",
         "running": "En curso",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1213,6 +1213,7 @@
     "device_client_version": "v{{version}}",
     "commands_title": "Déclencher une tâche",
     "cmd_refresh_metadata": "Rafraîchir les métadonnées",
+    "cmd_refresh_plugin_sources": "Rafraîchir les sources de plugins",
     "cmd_refresh_missing_metadata": "Recharger les métadonnées manquantes",
     "cmd_rescan_all": "Rescanner tous les fichiers",
     "cmd_rescan_missing_files": "Rescanner les fichiers manquants",
@@ -2061,15 +2062,6 @@
       "trigger": "Déclencher manuellement",
       "triggered": "Tâche {{ name }} déclenchée.",
       "never": "Jamais",
-      "names": {
-        "SearchMissing": "Recherche des médias manquants",
-        "RefreshMetadata": "Rafraîchissement des métadonnées",
-        "RssSync": "Synchronisation RSS",
-        "ImportCompleted": "Import des téléchargements",
-        "CleanStalled": "Nettoyage des torrents bloqués",
-        "SubtitleSearch": "Recherche de sous-titres",
-        "SubtitleUpgrade": "Amélioration des sous-titres"
-      },
       "status": {
         "completed": "Terminé",
         "running": "En cours",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1205,6 +1205,7 @@
     "device_client_version": "v{{version}}",
     "commands_title": "Avvia un'attività",
     "cmd_refresh_metadata": "Aggiorna i metadati",
+    "cmd_refresh_plugin_sources": "Aggiorna le sorgenti dei plugin",
     "cmd_refresh_missing_metadata": "Ricarica i metadati mancanti",
     "cmd_rescan_all": "Riscansiona tutti i file",
     "cmd_rescan_missing_files": "Riscansiona i file mancanti",
@@ -2034,15 +2035,6 @@
       "trigger": "Avvia manualmente",
       "triggered": "Attività {{ name }} avviata.",
       "never": "Mai",
-      "names": {
-        "SearchMissing": "Ricerca dei file multimediali mancanti",
-        "RefreshMetadata": "Aggiornamento dei metadati",
-        "RssSync": "Sincronizzazione RSS",
-        "ImportCompleted": "Import dei download",
-        "CleanStalled": "Pulizia dei torrent bloccati",
-        "SubtitleSearch": "Ricerca di sottotitoli",
-        "SubtitleUpgrade": "Miglioramento dei sottotitoli"
-      },
       "status": {
         "completed": "Completato",
         "running": "In corso",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1205,6 +1205,7 @@
     "device_client_version": "v{{version}}",
     "commands_title": "Acionar uma tarefa",
     "cmd_refresh_metadata": "Atualizar os metadados",
+    "cmd_refresh_plugin_sources": "Atualizar as fontes de plugins",
     "cmd_refresh_missing_metadata": "Recarregar os metadados em falta",
     "cmd_rescan_all": "Reanalisar todos os ficheiros",
     "cmd_rescan_missing_files": "Reanalisar os ficheiros em falta",
@@ -2034,15 +2035,6 @@
       "trigger": "Acionar manualmente",
       "triggered": "Tarefa {{ name }} acionada.",
       "never": "Nunca",
-      "names": {
-        "SearchMissing": "Pesquisa dos medias em falta",
-        "RefreshMetadata": "Atualização dos metadados",
-        "RssSync": "Sincronização RSS",
-        "ImportCompleted": "Importação das transferências",
-        "CleanStalled": "Limpeza dos torrents bloqueados",
-        "SubtitleSearch": "Pesquisa de legendas",
-        "SubtitleUpgrade": "Melhoria das legendas"
-      },
       "status": {
         "completed": "Concluído",
         "running": "Em curso",

--- a/client/src/app/features/settings/schedulers/schedulers.html
+++ b/client/src/app/features/settings/schedulers/schedulers.html
@@ -24,7 +24,7 @@
         <tbody>
           @for (s of schedulers(); track s.name) {
             <tr>
-              <td class="font-medium text-sm">{{ 'settings.schedulers.names.' + s.name | translate }}</td>
+              <td class="font-medium text-sm">{{ s.labelKey | translate }}</td>
               <td class="text-sm text-base-content/60 font-mono">{{ s.cron }}</td>
               <td class="text-sm text-base-content/60">
                 @if (s.lastRun) {

--- a/client/src/app/features/settings/schedulers/schedulers.ts
+++ b/client/src/app/features/settings/schedulers/schedulers.ts
@@ -17,6 +17,9 @@ import { SseService } from '../../../core/services/sse.service';
 
 interface SchedulerInfo {
   name: string;
+  /** Supplied by the API: core's own key for a core job, the declaring plugin's for one it
+   *  owns. The page never names a job itself — it would have to know every publisher. */
+  labelKey: string;
   cron: string;
   triggerable: boolean;
   lastRun: string | null;


### PR DESCRIPTION
## The residue

The scheduled-tasks page built every label as `settings.schedulers.names.<name>`, and that map named **four jobs this repo does not own** — `SearchMissing`, `RssSync`, `ImportCompleted` and `CleanStalled` all belong to the download plugin. Its fifth job, `CleanSeeded`, was added after the map was written, so it rendered as its raw key:

> settings.schedulers.names.CleanSeeded

That is the visible half of the problem. The invisible half is that the map could only ever be wrong: core cannot name the jobs of a publisher it knows nothing about, and every new plugin job would arrive as a raw key.

`GET /commands/schedulers` has always answered a `labelKey` per row — core's own `system.cmd_*` for a core job, the declaring plugin's key for one it owns, resolved from the i18n merged in at install. The page reads that field now and the map is deleted, in all six locales.

## The plugin-source refresh is a real job now

`PluginCatalogClientService.refreshAll()` already ran daily, on a bare `@Cron`. It appeared in no listing, could not be triggered by hand, and recorded no run — so as far as the UI was concerned it did not exist.

It is a core scheduler job now (`RefreshPluginSources`), driven from `SchedulerService` like `RefreshMetadata`: listed, triggerable, and wrapped in the same `Command` lifecycle so "Last run" and "Status" mean something. `PLUGIN_SOURCE_REFRESH_CRON` is declared once and used by both the `@Cron` and the listing, so the "Next run" column cannot drift from what actually fires — 03:00, an hour before the metadata refresh, so a newly published version is already cached when anything reads the catalog.

The bare `@Cron` is removed with it: leaving both would have fired the refresh twice a day.

## Checks

- backend `tsc` clean, `jest src/modules/plugins src/modules/scheduler` → 920 passing
- client `ng build` clean, `ng test` → 442 passing

Still open from the same request: the **Settings** entry in the plugins page dropdown and its auto-update toggle. That one needs the update pipeline to exist before the toggle can mean anything, so it is its own change rather than a switch that lies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
