### PR TITLE
feat(plugins): a settings dialog, and an opt-in daily plugin update

### DIFF
--- a/backend/src/modules/plugins/plugin-auto-update.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-auto-update.service.spec.ts
@@ -1,0 +1,152 @@
+import { PluginAutoUpdateService, PLUGIN_AUTO_UPDATE_SETTING } from './plugin-auto-update.service';
+import type { PluginPackage } from './entities/plugin-package.entity';
+import type { PluginSource } from './entities/plugin-source.entity';
+
+type Report = Record<string, unknown>;
+
+function catalogWith(pluginId: string, versions: string[]) {
+  return {
+    plugins: [{ id: pluginId, installable: versions.map((version) => ({ version })) }],
+    denyList: [],
+  };
+}
+
+function makeService(opts: {
+  setting?: string | null;
+  packages?: Partial<PluginPackage>[];
+  sources?: Partial<PluginSource>[];
+  report?: Report;
+  confirmStatus?: 'active' | 'failed';
+}) {
+  const inspect = jest.fn().mockResolvedValue(
+    opts.report ?? { installable: true, stagingId: 's1', sha256: 'abc', signature: 'official' },
+  );
+  const confirm = jest.fn().mockResolvedValue({
+    pluginId: 'x',
+    version: '2.0.0',
+    status: opts.confirmStatus ?? 'active',
+    reason: opts.confirmStatus === 'failed' ? 'spawn refused' : undefined,
+  });
+  const service = new PluginAutoUpdateService(
+    { find: jest.fn().mockResolvedValue(opts.packages ?? []) } as never,
+    { find: jest.fn().mockResolvedValue(opts.sources ?? []) } as never,
+    { get: jest.fn().mockResolvedValue(opts.setting ?? null) } as never,
+    { inspectFromCatalog: inspect, confirmImport: confirm } as never,
+  );
+  return { service, inspect, confirm };
+}
+
+const PKG = [{ pluginId: 'a.plugin', version: '1.0.0' }] as Partial<PluginPackage>[];
+const SRC = [{ id: 1, cachedCatalog: catalogWith('a.plugin', ['1.0.0', '2.0.0']) }] as unknown as Partial<PluginSource>[];
+
+describe('PluginAutoUpdateService', () => {
+  it('does nothing at all while the setting is off', async () => {
+    const { service, inspect } = makeService({ setting: null, packages: PKG, sources: SRC });
+    expect(await service.run()).toEqual({ updated: [], skipped: [] });
+    expect(inspect).not.toHaveBeenCalled();
+  });
+
+  it('reads the opt-in from its own key', async () => {
+    const { service } = makeService({ setting: 'true' });
+    expect(await service.enabled()).toBe(true);
+    expect(PLUGIN_AUTO_UPDATE_SETTING).toBe('plugins.auto_update');
+  });
+
+  it('installs the newest offered version when it is newer than the installed one', async () => {
+    const { service, inspect, confirm } = makeService({ setting: 'true', packages: PKG, sources: SRC });
+    const outcome = await service.run();
+    expect(inspect).toHaveBeenCalledWith(SRC[0], 'a.plugin', '2.0.0');
+    expect(confirm).toHaveBeenCalledWith({ stagingId: 's1', sha256: 'abc' });
+    expect(outcome.updated).toEqual([{ pluginId: 'a.plugin', from: '1.0.0', to: '2.0.0' }]);
+  });
+
+  it('leaves an already-current plugin alone', async () => {
+    const { service, inspect } = makeService({
+      setting: 'true',
+      packages: [{ pluginId: 'a.plugin', version: '2.0.0' }] as Partial<PluginPackage>[],
+      sources: SRC,
+    });
+    expect((await service.run()).updated).toEqual([]);
+    expect(inspect).not.toHaveBeenCalled();
+  });
+
+  it('VERDICT: never promotes an archive the catalogue key did not sign', async () => {
+    for (const signature of ['unverified', 'unsigned', undefined]) {
+      const { service, confirm } = makeService({
+        setting: 'true',
+        packages: PKG,
+        sources: SRC,
+        report: { installable: true, stagingId: 's1', sha256: 'abc', signature },
+      });
+      const outcome = await service.run();
+      expect(confirm).not.toHaveBeenCalled();
+      expect(outcome.updated).toEqual([]);
+      expect(outcome.skipped[0]?.reason).toContain('acknowledgement');
+    }
+  });
+
+  it('records a refusal instead of installing when the archive is not installable', async () => {
+    const { service, confirm } = makeService({
+      setting: 'true',
+      packages: PKG,
+      sources: SRC,
+      report: { installable: false, refusalCode: 'PLUGIN_CHECKSUM_MISMATCH' },
+    });
+    const outcome = await service.run();
+    expect(confirm).not.toHaveBeenCalled();
+    expect(outcome.skipped[0]?.reason).toBe('PLUGIN_CHECKSUM_MISMATCH');
+  });
+
+  it('reports an install that did not activate as skipped, not as updated', async () => {
+    const { service } = makeService({ setting: 'true', packages: PKG, sources: SRC, confirmStatus: 'failed' });
+    const outcome = await service.run();
+    expect(outcome.updated).toEqual([]);
+    expect(outcome.skipped[0]?.reason).toBe('spawn refused');
+  });
+
+  it('VERDICT: one plugin throwing does not stop the others', async () => {
+    const { service } = makeService({
+      setting: 'true',
+      packages: [
+        { pluginId: 'a.plugin', version: '1.0.0' },
+        { pluginId: 'b.plugin', version: '1.0.0' },
+      ] as Partial<PluginPackage>[],
+      sources: [
+        {
+          id: 1,
+          cachedCatalog: {
+            plugins: [
+              { id: 'a.plugin', installable: [{ version: '2.0.0' }] },
+              { id: 'b.plugin', installable: [{ version: '2.0.0' }] },
+            ],
+            denyList: [],
+          },
+        },
+      ] as unknown as Partial<PluginSource>[],
+    });
+    const inspect = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValue({ installable: true, stagingId: 's2', sha256: 'def', signature: 'official' });
+    (service as unknown as { installService: { inspectFromCatalog: jest.Mock } }).installService.inspectFromCatalog =
+      inspect;
+
+    const outcome = await service.run();
+    expect(outcome.skipped[0]?.reason).toBe('network down');
+    expect(outcome.updated.map((u) => u.pluginId)).toEqual(['b.plugin']);
+  });
+
+  it('picks the highest version across sources, not the first source that offers one', async () => {
+    const { service, inspect } = makeService({
+      setting: 'true',
+      packages: PKG,
+      sources: [
+        { id: 1, cachedCatalog: catalogWith('a.plugin', ['1.5.0']) },
+        { id: 2, cachedCatalog: catalogWith('a.plugin', ['3.0.0']) },
+      ] as unknown as Partial<PluginSource>[],
+    });
+    await service.run();
+    expect(inspect.mock.calls[0][2]).toBe('3.0.0');
+    expect((inspect.mock.calls[0][0] as { id: number }).id).toBe(2);
+  });
+});

--- a/backend/src/modules/plugins/plugin-auto-update.service.ts
+++ b/backend/src/modules/plugins/plugin-auto-update.service.ts
@@ -1,0 +1,124 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as semver from 'semver';
+import { SettingsService } from '../settings/settings.service';
+import { PluginInstallService } from './plugin-install.service';
+import { PluginPackage } from './entities/plugin-package.entity';
+import { PluginSource } from './entities/plugin-source.entity';
+import type { FilteredCatalog, FilteredCatalogEntry } from './catalog/catalog';
+
+/** Off unless an admin turned it on: an unattended install is opt-in, never a default. */
+export const PLUGIN_AUTO_UPDATE_SETTING = 'plugins.auto_update';
+
+export interface AutoUpdateOutcome {
+  updated: { pluginId: string; from: string; to: string }[];
+  skipped: { pluginId: string; version: string; reason: string }[];
+}
+
+/**
+ * Installs a newer catalog version of an already-installed plugin, once a day, after the
+ * sources have been refreshed. The cached catalog is stored pre-filtered by core
+ * compatibility, so its newest `installable` entry is by construction one this core can run.
+ */
+@Injectable()
+export class PluginAutoUpdateService {
+  private readonly log = new Logger(PluginAutoUpdateService.name);
+
+  constructor(
+    @InjectRepository(PluginPackage)
+    private readonly packageRepo: Repository<PluginPackage>,
+    @InjectRepository(PluginSource)
+    private readonly sourceRepo: Repository<PluginSource>,
+    private readonly settings: SettingsService,
+    private readonly installService: PluginInstallService,
+  ) {}
+
+  async enabled(): Promise<boolean> {
+    return (await this.settings.get(PLUGIN_AUTO_UPDATE_SETTING)) === 'true';
+  }
+
+  async run(): Promise<AutoUpdateOutcome> {
+    const outcome: AutoUpdateOutcome = { updated: [], skipped: [] };
+    if (!(await this.enabled())) return outcome;
+
+    const [installed, sources] = await Promise.all([
+      this.packageRepo.find(),
+      this.sourceRepo.find({ where: { enabled: true } }),
+    ]);
+
+    for (const pkg of installed) {
+      const candidate = this.newestFor(pkg.pluginId, sources);
+      if (!candidate) continue;
+      if (!semver.valid(pkg.version) || !semver.gt(candidate.version, pkg.version)) continue;
+      await this.update(pkg, candidate, outcome);
+    }
+
+    if (outcome.updated.length || outcome.skipped.length) {
+      this.log.log(
+        `auto-update: ${outcome.updated.length} updated, ${outcome.skipped.length} skipped`,
+      );
+    }
+    return outcome;
+  }
+
+  /** The highest version any enabled source offers, with the source that offers it. */
+  private newestFor(
+    pluginId: string,
+    sources: PluginSource[],
+  ): { source: PluginSource; version: string } | null {
+    let best: { source: PluginSource; version: string } | null = null;
+    for (const source of sources) {
+      const catalog = source.cachedCatalog as unknown as FilteredCatalog | null;
+      const entry = catalog?.plugins?.find((p: FilteredCatalogEntry) => p.id === pluginId);
+      // `filterCatalog` sorts `installable` ascending and drops what this core cannot run.
+      const newest = entry?.installable?.at(-1)?.version;
+      if (!newest || !semver.valid(newest)) continue;
+      if (!best || semver.gt(newest, best.version)) best = { source, version: newest };
+    }
+    return best;
+  }
+
+  private async update(
+    pkg: PluginPackage,
+    candidate: { source: PluginSource; version: string },
+    outcome: AutoUpdateOutcome,
+  ): Promise<void> {
+    const { pluginId } = pkg;
+    const skip = (reason: string) => {
+      outcome.skipped.push({ pluginId, version: candidate.version, reason });
+      this.log.warn(`auto-update: ${pluginId}@${candidate.version} skipped — ${reason}`);
+    };
+    try {
+      const report = await this.installService.inspectFromCatalog(
+        candidate.source,
+        pluginId,
+        candidate.version,
+      );
+      if (!report.installable || !report.stagingId || !report.sha256) {
+        skip(report.refusalCode ?? 'not installable');
+        return;
+      }
+      // The consent sheet is the only place an unverified archive is acknowledged. An
+      // unattended run must never stand in for that acknowledgement, so it installs
+      // nothing the catalogue key did not sign. Staging is swept hourly on its own.
+      if (report.signature !== 'official') {
+        skip(`signature is "${report.signature ?? 'unknown'}", which needs an admin's acknowledgement`);
+        return;
+      }
+      const result = await this.installService.confirmImport({
+        stagingId: report.stagingId,
+        sha256: report.sha256,
+      });
+      if (result.status !== 'active') {
+        skip(result.reason ?? 'install did not activate');
+        return;
+      }
+      outcome.updated.push({ pluginId, from: pkg.version, to: candidate.version });
+      this.log.log(`auto-update: ${pluginId} ${pkg.version} → ${candidate.version}`);
+    } catch (err) {
+      // One plugin's failure must not stop the others: this runs unattended.
+      skip((err as Error).message);
+    }
+  }
+}

--- a/backend/src/modules/plugins/plugins.module.ts
+++ b/backend/src/modules/plugins/plugins.module.ts
@@ -10,6 +10,7 @@ import { PluginProcessService } from './plugin-process.service';
 import { PluginJobsService } from './plugin-jobs.service';
 import { PluginProcessEventDispatcherService } from './plugin-process-event-dispatcher.service';
 import { PluginCatalogClientService } from './plugin-catalog-client.service';
+import { PluginAutoUpdateService } from './plugin-auto-update.service';
 import { PluginStagingService } from './plugin-staging.service';
 import { PluginInstallService } from './plugin-install.service';
 import { PluginDatabaseService } from './plugin-database.service';
@@ -59,6 +60,7 @@ import { ScheduledJobRegistryModule } from '../scheduler/scheduled-job-registry.
     PluginJobsService,
     PluginProcessEventDispatcherService,
     PluginCatalogClientService,
+    PluginAutoUpdateService,
     PluginStagingService,
     PluginInstallService,
     PluginDatabaseService,
@@ -74,6 +76,7 @@ import { ScheduledJobRegistryModule } from '../scheduler/scheduled-job-registry.
     PluginJobsService,
     PluginPreRollService,
     PluginCatalogClientService,
+    PluginAutoUpdateService,
   ],
 })
 export class PluginsModule {}

--- a/backend/src/modules/scheduler/scheduler.service.spec.ts
+++ b/backend/src/modules/scheduler/scheduler.service.spec.ts
@@ -30,6 +30,7 @@ function makeService(pluginJobs: ReturnType<typeof fakePluginJobs>, jobRegistry:
     pluginJobs as unknown as PluginJobsService,
     jobRegistry as unknown as ScheduledJobRegistry,
     unused,
+    unused,
   );
 }
 

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -30,6 +30,7 @@ import { CORE_TRIGGER_ONLY_JOB_NAMES, CoreSchedulerJobName, PLUGIN_SOURCE_REFRES
 import { PluginJobsService } from '../plugins/plugin-jobs.service';
 import { ScheduledJobRegistry } from './scheduled-job-registry.service';
 import { PluginCatalogClientService } from '../plugins/plugin-catalog-client.service';
+import { PluginAutoUpdateService } from '../plugins/plugin-auto-update.service';
 import { runAuditedCommand } from './command-audit.util';
 
 /** Yield the event loop so HTTP requests aren't starved by bulk tasks. */
@@ -58,6 +59,7 @@ export class SchedulerService implements OnModuleInit {
     private readonly pluginJobs: PluginJobsService,
     private readonly jobRegistry: ScheduledJobRegistry,
     private readonly catalogClient: PluginCatalogClientService,
+    private readonly pluginAutoUpdate: PluginAutoUpdateService,
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -129,9 +131,11 @@ export class SchedulerService implements OnModuleInit {
    *  like every other scheduled job. */
   @Cron(PLUGIN_SOURCE_REFRESH_CRON)
   async refreshPluginSources(): Promise<void> {
-    return this.runCommand('RefreshPluginSources', 'scheduled', () =>
-      this.catalogClient.refreshAll(),
-    );
+    return this.runCommand('RefreshPluginSources', 'scheduled', async () => {
+      await this.catalogClient.refreshAll();
+      // Reads the freshly cached catalogs; a no-op unless an admin opted in.
+      await this.pluginAutoUpdate.run();
+    });
   }
 
   // ---------------------------------------------------------------------------

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2220,7 +2220,14 @@
       },
       "status_disabled": "Deaktiviert",
       "status_unavailable": "Nicht verfügbar",
-      "status_message_toggle": "Details ansehen"
+      "status_message_toggle": "Details ansehen",
+      "settings": {
+        "title": "Einstellungen",
+        "subtitle": "Wie Fliks installierte Plugins verwaltet.",
+        "auto_update": "Plugins automatisch aktualisieren",
+        "auto_update_hint": "Installiert einmal täglich, nach dem Aktualisieren der Quellen, die neueste angebotene Version eines installierten Plugins. Unbeaufsichtigt wird nur ein Archiv installiert, das der Quellkatalog signiert hat; alles andere braucht weiterhin deine Bestätigung.",
+        "saved": "Plugin-Einstellungen gespeichert"
+      }
     }
   },
   "roles": {

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2247,7 +2247,14 @@
       },
       "status_disabled": "Disabled",
       "status_unavailable": "Unavailable",
-      "status_message_toggle": "View details"
+      "status_message_toggle": "View details",
+      "settings": {
+        "title": "Settings",
+        "subtitle": "How Fliks manages installed plugins.",
+        "auto_update": "Update plugins automatically",
+        "auto_update_hint": "Once a day, after the sources are refreshed, installs the newest version each source offers for an installed plugin. Only an archive signed by the source catalogue is installed unattended: anything else still needs your acknowledgement.",
+        "saved": "Plugin settings saved"
+      }
     }
   },
   "roles": {

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2220,7 +2220,14 @@
       },
       "status_disabled": "Desactivado",
       "status_unavailable": "No disponible",
-      "status_message_toggle": "Ver los detalles"
+      "status_message_toggle": "Ver los detalles",
+      "settings": {
+        "title": "Ajustes",
+        "subtitle": "Gestión de los plugins instalados por Fliks.",
+        "auto_update": "Actualizar los plugins automáticamente",
+        "auto_update_hint": "Una vez al día, tras actualizar las fuentes, instala la versión más reciente ofrecida para un plugin instalado. Solo se instala sin intervención un archivo firmado por el catálogo de la fuente: el resto requiere tu confirmación.",
+        "saved": "Ajustes de plugins guardados"
+      }
     }
   },
   "roles": {

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2247,7 +2247,14 @@
       },
       "status_disabled": "Désactivé",
       "status_unavailable": "Indisponible",
-      "status_message_toggle": "Voir les détails"
+      "status_message_toggle": "Voir les détails",
+      "settings": {
+        "title": "Paramètres",
+        "subtitle": "Gestion des plugins installés par Fliks.",
+        "auto_update": "Mettre à jour automatiquement les plugins",
+        "auto_update_hint": "Une fois par jour, après le rafraîchissement des sources, installe la version la plus récente proposée pour un plugin installé. Seule une archive signée par le catalogue de la source est installée sans intervention : le reste demande toujours une validation.",
+        "saved": "Paramètres des plugins enregistrés"
+      }
     }
   },
   "roles": {

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2220,7 +2220,14 @@
       },
       "status_disabled": "Disattivato",
       "status_unavailable": "Non disponibile",
-      "status_message_toggle": "Vedi i dettagli"
+      "status_message_toggle": "Vedi i dettagli",
+      "settings": {
+        "title": "Impostazioni",
+        "subtitle": "Come Fliks gestisce i plugin installati.",
+        "auto_update": "Aggiorna automaticamente i plugin",
+        "auto_update_hint": "Una volta al giorno, dopo l’aggiornamento delle sorgenti, installa la versione più recente offerta per un plugin installato. Senza intervento viene installato solo un archivio firmato dal catalogo della sorgente: il resto richiede la tua conferma.",
+        "saved": "Impostazioni dei plugin salvate"
+      }
     }
   },
   "roles": {

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2220,7 +2220,14 @@
       },
       "status_disabled": "Desativado",
       "status_unavailable": "Indisponível",
-      "status_message_toggle": "Ver os detalhes"
+      "status_message_toggle": "Ver os detalhes",
+      "settings": {
+        "title": "Definições",
+        "subtitle": "Como o Fliks gere os plugins instalados.",
+        "auto_update": "Atualizar os plugins automaticamente",
+        "auto_update_hint": "Uma vez por dia, após atualizar as fontes, instala a versão mais recente oferecida para um plugin instalado. Sem intervenção só é instalado um arquivo assinado pelo catálogo da fonte: o resto continua a exigir a tua confirmação.",
+        "saved": "Definições dos plugins guardadas"
+      }
     }
   },
   "roles": {

--- a/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.html
+++ b/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.html
@@ -1,0 +1,43 @@
+<dialog #dialog class="modal">
+  <div class="modal-box max-w-xl">
+    <div class="flex justify-between items-start gap-4">
+      <div>
+        <h2 class="text-lg font-bold">{{ 'settings.plugins.settings.title' | translate }}</h2>
+        <p class="text-sm text-base-content/60 mt-1">{{ 'settings.plugins.settings.subtitle' | translate }}</p>
+      </div>
+      <button type="button" class="btn btn-sm btn-ghost btn-circle" (click)="close()"
+        [attr.aria-label]="'common.close' | translate">
+        <svg lucideX class="h-4 w-4"></svg>
+      </button>
+    </div>
+
+    @if (loading()) {
+      <div class="flex justify-center py-10">
+        <span class="loading loading-spinner loading-lg"></span>
+      </div>
+    } @else {
+      <label class="label cursor-pointer justify-start gap-3 mt-6 items-start">
+        <input
+          type="checkbox"
+          class="toggle mt-0.5"
+          [disabled]="saving()"
+          [ngModel]="autoUpdate()"
+          (ngModelChange)="toggleAutoUpdate($event)"
+        />
+        <span>
+          <span class="label-text text-base">{{ 'settings.plugins.settings.auto_update' | translate }}</span>
+          <span class="block text-sm text-base-content/60 mt-1">
+            {{ 'settings.plugins.settings.auto_update_hint' | translate }}
+          </span>
+        </span>
+      </label>
+    }
+
+    <div class="modal-action">
+      <button type="button" class="btn btn-ghost" (click)="close()">{{ 'common.close' | translate }}</button>
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="button" (click)="close()" [attr.aria-label]="'common.close' | translate">close</button>
+  </form>
+</dialog>

--- a/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.ts
+++ b/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.ts
@@ -1,0 +1,66 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  inject,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { LucideX } from '@lucide/angular';
+import { SettingsApiService } from '../../../../core/services/api/settings-api.service';
+import { ToastService } from '../../../../core/services/toast.service';
+
+/** Mirrors the backend's `PLUGIN_AUTO_UPDATE_SETTING`. */
+const AUTO_UPDATE_KEY = 'plugins.auto_update';
+
+@Component({
+  selector: 'app-plugin-settings',
+  imports: [FormsModule, TranslateModule, LucideX],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './plugin-settings.html',
+})
+export class PluginSettingsComponent {
+  private readonly settings = inject(SettingsApiService);
+  private readonly translate = inject(TranslateService);
+  private readonly toast = inject(ToastService);
+
+  private readonly dialogRef = viewChild.required<ElementRef<HTMLDialogElement>>('dialog');
+
+  readonly autoUpdate = signal(false);
+  readonly loading = signal(true);
+  readonly saving = signal(false);
+
+  /** Read on open, not at construction: the value can change while the page stays mounted. */
+  async open(): Promise<void> {
+    this.dialogRef().nativeElement.showModal();
+    this.loading.set(true);
+    try {
+      const row = await this.settings.get(AUTO_UPDATE_KEY);
+      this.autoUpdate.set(row?.value === 'true');
+    } catch {
+      this.autoUpdate.set(false);
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  close(): void {
+    this.dialogRef().nativeElement.close();
+  }
+
+  async toggleAutoUpdate(next: boolean): Promise<void> {
+    const previous = this.autoUpdate();
+    this.autoUpdate.set(next);
+    this.saving.set(true);
+    try {
+      await this.settings.set(AUTO_UPDATE_KEY, String(next));
+      this.toast.success(this.translate.instant('settings.plugins.settings.saved'));
+    } catch {
+      this.autoUpdate.set(previous);
+    } finally {
+      this.saving.set(false);
+    }
+  }
+}

--- a/client/src/app/features/settings/plugins/plugins.html
+++ b/client/src/app/features/settings/plugins/plugins.html
@@ -20,6 +20,9 @@
         <button type="button" class="dropdown-item text-white" (click)="openSources()">
           {{ 'settings.plugins.sources.manage_button' | translate }}
         </button>
+        <button type="button" class="dropdown-item text-white" (click)="openSettings()">
+          {{ 'settings.plugins.settings.title' | translate }}
+        </button>
         <button type="button" class="dropdown-item text-white" [disabled]="uploading()" (click)="pickFile()">
           @if (uploading()) {
             <span class="loading loading-spinner loading-xs"></span>
@@ -130,6 +133,7 @@
   }
 
   <app-plugin-sources #sourcesDialog />
+  <app-plugin-settings #settingsDialog />
 </div>
 
 <app-plugin-install-consent #consentSheet (installed)="onInstalled($event)" />

--- a/client/src/app/features/settings/plugins/plugins.ts
+++ b/client/src/app/features/settings/plugins/plugins.ts
@@ -24,6 +24,7 @@ import {
 } from '../../../core/services/api/plugins-api.service';
 import { PluginInstallConsentComponent } from './plugin-install-consent/plugin-install-consent';
 import { PluginSourcesComponent } from './plugin-sources/plugin-sources';
+import { PluginSettingsComponent } from './plugin-settings/plugin-settings';
 import { PluginMetricsPanelComponent } from './plugin-metrics-panel/plugin-metrics-panel';
 import { trustBadgeFor } from './plugin-trust';
 
@@ -36,6 +37,7 @@ import { trustBadgeFor } from './plugin-trust';
     DropdownMenuComponent,
     ToggleFieldComponent,
     PluginInstallConsentComponent,
+    PluginSettingsComponent,
     PluginSourcesComponent,
     PluginMetricsPanelComponent,
   ],
@@ -52,6 +54,7 @@ export class PluginsSettingsComponent implements OnInit {
   private readonly fileInput = viewChild<ElementRef<HTMLInputElement>>('fileInput');
   private readonly consentSheet = viewChild<PluginInstallConsentComponent>('consentSheet');
   private readonly sourcesDialog = viewChild<PluginSourcesComponent>('sourcesDialog');
+  private readonly settingsDialog = viewChild<PluginSettingsComponent>('settingsDialog');
 
   readonly rows = signal<PluginSummary[]>([]);
   readonly metricsByPluginId = signal<Map<string, PluginMetricsEntry>>(new Map());
@@ -123,6 +126,10 @@ export class PluginsSettingsComponent implements OnInit {
 
   openSources(): void {
     this.sourcesDialog()?.open();
+  }
+
+  openSettings(): void {
+    void this.settingsDialog()?.open();
   }
 
   async onInstalled(result: PluginInstallResult): Promise<void> {


### PR DESCRIPTION
The plugins page dropdown gains a **Settings** entry, opening a dialog with one toggle: *Update plugins automatically*. Off by default.

A toggle has to do something, so the behaviour ships with it.

## What the toggle turns on

With it on, the daily `RefreshPluginSources` job (#1012) continues into an update pass: for every installed plugin, the newest version any enabled source offers.

- The cached catalog is stored **already filtered** by `filterCatalog`, so its newest `installable` entry is by construction a version this core's `pluginApi` and `fliks` range admit. No compatibility logic is re-derived here.
- `semver.gt` against the installed version decides whether there is anything to do; a plugin already current is not even inspected.
- Across several sources, the highest version wins — not the first source that happens to offer one.

## What it refuses to do

**It installs nothing the source catalogue's key did not sign.** `inspectFromCatalog`'s own comment is explicit that the consent sheet is the only place an *Unverified* archive gets acknowledged; a scheduled run must never stand in for a human's acknowledgement. An `unverified` or `unsigned` candidate is logged with the reason and skipped. There is a test asserting this for all three non-official outcomes, because it is the one thing in here that must not regress.

It also fails soft per plugin: a network error, a checksum mismatch, a refused spawn — each is recorded as skipped and the remaining plugins still run. An unattended job that aborts halfway is worse than one that reports what it could not do.

Everything goes through the existing pipeline (`inspectFromCatalog` → `confirmImport`), so every V1-V7 guard, the deny list and the re-read-from-staging check all apply exactly as they do to a manual install. Staged bytes for a skipped candidate are swept by the existing hourly GC.

## Checks

- backend `jest src/modules/plugins src/modules/scheduler` → 929 passing, including 9 new: the off-by-default no-op, the version comparison, the multi-source pick, the signature refusal, a non-installable report, an install that did not activate, and one plugin throwing without stopping the next
- client `ng build` clean, `ng test` → 442 passing
- copy in all six locales; the hint states the signature rule, so the toggle does not promise more than it does

🤖 Generated with [Claude Code](https://claude.com/claude-code)
