### PR TITLE
feat(plugins): update plugins by default, and reuse the shared toggle

### DIFF
--- a/backend/src/modules/plugins/plugin-auto-update.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-auto-update.service.spec.ts
@@ -40,16 +40,24 @@ const PKG = [{ pluginId: 'a.plugin', version: '1.0.0' }] as Partial<PluginPackag
 const SRC = [{ id: 1, cachedCatalog: catalogWith('a.plugin', ['1.0.0', '2.0.0']) }] as unknown as Partial<PluginSource>[];
 
 describe('PluginAutoUpdateService', () => {
-  it('does nothing at all while the setting is off', async () => {
-    const { service, inspect } = makeService({ setting: null, packages: PKG, sources: SRC });
+  it('VERDICT: does nothing at all once an admin turned it off', async () => {
+    const { service, inspect } = makeService({ setting: 'false', packages: PKG, sources: SRC });
     expect(await service.run()).toEqual({ updated: [], skipped: [] });
     expect(inspect).not.toHaveBeenCalled();
   });
 
-  it('reads the opt-in from its own key', async () => {
-    const { service } = makeService({ setting: 'true' });
-    expect(await service.enabled()).toBe(true);
+  it("VERDICT: an unset key reads as on — only the dialog's explicit 'false' disables it", async () => {
     expect(PLUGIN_AUTO_UPDATE_SETTING).toBe('plugins.auto_update');
+    expect(await makeService({ setting: null }).service.enabled()).toBe(true);
+    expect(await makeService({ setting: 'true' }).service.enabled()).toBe(true);
+    expect(await makeService({ setting: 'false' }).service.enabled()).toBe(false);
+
+    // Unset, so the pass runs and installs without anyone having opened the dialog.
+    const { service, confirm } = makeService({ setting: null, packages: PKG, sources: SRC });
+    expect((await service.run()).updated).toEqual([
+      { pluginId: 'a.plugin', from: '1.0.0', to: '2.0.0' },
+    ]);
+    expect(confirm).toHaveBeenCalled();
   });
 
   it('installs the newest offered version when it is newer than the installed one', async () => {

--- a/backend/src/modules/plugins/plugin-auto-update.service.ts
+++ b/backend/src/modules/plugins/plugin-auto-update.service.ts
@@ -8,7 +8,8 @@ import { PluginPackage } from './entities/plugin-package.entity';
 import { PluginSource } from './entities/plugin-source.entity';
 import type { FilteredCatalog, FilteredCatalogEntry } from './catalog/catalog';
 
-/** Off unless an admin turned it on: an unattended install is opt-in, never a default. */
+/** On unless an admin turned it off — an unset key reads as enabled, so an instance that
+ *  never opened the dialog still gets signed updates. */
 export const PLUGIN_AUTO_UPDATE_SETTING = 'plugins.auto_update';
 
 export interface AutoUpdateOutcome {
@@ -34,8 +35,9 @@ export class PluginAutoUpdateService {
     private readonly installService: PluginInstallService,
   ) {}
 
+  /** Only the explicit `'false'` the dialog writes disables it; unset means on. */
   async enabled(): Promise<boolean> {
-    return (await this.settings.get(PLUGIN_AUTO_UPDATE_SETTING)) === 'true';
+    return (await this.settings.get(PLUGIN_AUTO_UPDATE_SETTING)) !== 'false';
   }
 
   async run(): Promise<AutoUpdateOutcome> {

--- a/backend/src/modules/settings/entities/app-setting.entity.ts
+++ b/backend/src/modules/settings/entities/app-setting.entity.ts
@@ -24,6 +24,8 @@ import { BaseEntity } from '../../../common/entities/base.entity';
  *     OpenAI-compatible endpoint (Groq, OpenRouter, Ollama…)
  *   subtitle_translation_libretranslate_url / _libretranslate_api_key —
  *     self-hosted LibreTranslate server
+ *   plugins.auto_update  — "false" disables the daily plugin update pass; absent or
+ *     anything else means on. Not a `plugin.<id>.*` key, so an uninstall never clears it.
  */
 @Entity('app_settings')
 export class AppSetting extends BaseEntity {

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2225,7 +2225,7 @@
         "title": "Einstellungen",
         "subtitle": "Wie Fliks installierte Plugins verwaltet.",
         "auto_update": "Plugins automatisch aktualisieren",
-        "auto_update_hint": "Installiert einmal täglich, nach dem Aktualisieren der Quellen, die neueste angebotene Version eines installierten Plugins. Unbeaufsichtigt wird nur ein Archiv installiert, das der Quellkatalog signiert hat; alles andere braucht weiterhin deine Bestätigung.",
+        "auto_update_hint": "Standardmäßig aktiviert. Installiert einmal täglich, nach dem Aktualisieren der Quellen, die neueste angebotene Version eines installierten Plugins. Unbeaufsichtigt wird nur ein Archiv installiert, das der Quellkatalog signiert hat; alles andere braucht weiterhin deine Bestätigung.",
         "saved": "Plugin-Einstellungen gespeichert"
       }
     }

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2252,7 +2252,7 @@
         "title": "Settings",
         "subtitle": "How Fliks manages installed plugins.",
         "auto_update": "Update plugins automatically",
-        "auto_update_hint": "Once a day, after the sources are refreshed, installs the newest version each source offers for an installed plugin. Only an archive signed by the source catalogue is installed unattended: anything else still needs your acknowledgement.",
+        "auto_update_hint": "On by default. Once a day, after the sources are refreshed, installs the newest version each source offers for an installed plugin. Only an archive signed by the source catalogue is installed unattended: anything else still needs your acknowledgement.",
         "saved": "Plugin settings saved"
       }
     }

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2225,7 +2225,7 @@
         "title": "Ajustes",
         "subtitle": "Gestión de los plugins instalados por Fliks.",
         "auto_update": "Actualizar los plugins automáticamente",
-        "auto_update_hint": "Una vez al día, tras actualizar las fuentes, instala la versión más reciente ofrecida para un plugin instalado. Solo se instala sin intervención un archivo firmado por el catálogo de la fuente: el resto requiere tu confirmación.",
+        "auto_update_hint": "Activado por defecto. Una vez al día, tras actualizar las fuentes, instala la versión más reciente ofrecida para un plugin instalado. Solo se instala sin intervención un archivo firmado por el catálogo de la fuente: el resto requiere tu confirmación.",
         "saved": "Ajustes de plugins guardados"
       }
     }

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2252,7 +2252,7 @@
         "title": "Paramètres",
         "subtitle": "Gestion des plugins installés par Fliks.",
         "auto_update": "Mettre à jour automatiquement les plugins",
-        "auto_update_hint": "Une fois par jour, après le rafraîchissement des sources, installe la version la plus récente proposée pour un plugin installé. Seule une archive signée par le catalogue de la source est installée sans intervention : le reste demande toujours une validation.",
+        "auto_update_hint": "Activé par défaut. Une fois par jour, après le rafraîchissement des sources, installe la version la plus récente proposée pour un plugin installé. Seule une archive signée par le catalogue de la source est installée sans intervention : le reste demande toujours une validation.",
         "saved": "Paramètres des plugins enregistrés"
       }
     }

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2225,7 +2225,7 @@
         "title": "Impostazioni",
         "subtitle": "Come Fliks gestisce i plugin installati.",
         "auto_update": "Aggiorna automaticamente i plugin",
-        "auto_update_hint": "Una volta al giorno, dopo l’aggiornamento delle sorgenti, installa la versione più recente offerta per un plugin installato. Senza intervento viene installato solo un archivio firmato dal catalogo della sorgente: il resto richiede la tua conferma.",
+        "auto_update_hint": "Attivo per impostazione predefinita. Una volta al giorno, dopo l’aggiornamento delle sorgenti, installa la versione più recente offerta per un plugin installato. Senza intervento viene installato solo un archivio firmato dal catalogo della sorgente: il resto richiede la tua conferma.",
         "saved": "Impostazioni dei plugin salvate"
       }
     }

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2225,7 +2225,7 @@
         "title": "Definições",
         "subtitle": "Como o Fliks gere os plugins instalados.",
         "auto_update": "Atualizar os plugins automaticamente",
-        "auto_update_hint": "Uma vez por dia, após atualizar as fontes, instala a versão mais recente oferecida para um plugin instalado. Sem intervenção só é instalado um arquivo assinado pelo catálogo da fonte: o resto continua a exigir a tua confirmação.",
+        "auto_update_hint": "Ativado por predefinição. Uma vez por dia, após atualizar as fontes, instala a versão mais recente oferecida para um plugin instalado. Sem intervenção só é instalado um arquivo assinado pelo catálogo da fonte: o resto continua a exigir a tua confirmação.",
         "saved": "Definições dos plugins guardadas"
       }
     }

--- a/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.html
+++ b/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.html
@@ -16,21 +16,15 @@
         <span class="loading loading-spinner loading-lg"></span>
       </div>
     } @else {
-      <label class="label cursor-pointer justify-start gap-3 mt-6 items-start">
-        <input
-          type="checkbox"
-          class="toggle mt-0.5"
+      <div class="mt-6">
+        <app-toggle-field
+          [value]="autoUpdate()"
+          (valueChange)="toggleAutoUpdate($event)"
           [disabled]="saving()"
-          [ngModel]="autoUpdate()"
-          (ngModelChange)="toggleAutoUpdate($event)"
+          [label]="'settings.plugins.settings.auto_update' | translate"
+          [hint]="'settings.plugins.settings.auto_update_hint' | translate"
         />
-        <span>
-          <span class="label-text text-base">{{ 'settings.plugins.settings.auto_update' | translate }}</span>
-          <span class="block text-sm text-base-content/60 mt-1">
-            {{ 'settings.plugins.settings.auto_update_hint' | translate }}
-          </span>
-        </span>
-      </label>
+      </div>
     }
 
     <div class="modal-action">

--- a/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.ts
+++ b/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.ts
@@ -6,9 +6,9 @@ import {
   signal,
   viewChild,
 } from '@angular/core';
-import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { LucideX } from '@lucide/angular';
+import { ToggleFieldComponent } from '../../../../shared/components/forms/toggle-field/toggle-field';
 import { SettingsApiService } from '../../../../core/services/api/settings-api.service';
 import { ToastService } from '../../../../core/services/toast.service';
 
@@ -17,7 +17,7 @@ const AUTO_UPDATE_KEY = 'plugins.auto_update';
 
 @Component({
   selector: 'app-plugin-settings',
-  imports: [FormsModule, TranslateModule, LucideX],
+  imports: [TranslateModule, LucideX, ToggleFieldComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './plugin-settings.html',
 })
@@ -28,7 +28,8 @@ export class PluginSettingsComponent {
 
   private readonly dialogRef = viewChild.required<ElementRef<HTMLDialogElement>>('dialog');
 
-  readonly autoUpdate = signal(false);
+  /** On unless the stored value is the explicit 'false' — mirrors the backend's own reading. */
+  readonly autoUpdate = signal(true);
   readonly loading = signal(true);
   readonly saving = signal(false);
 
@@ -38,9 +39,9 @@ export class PluginSettingsComponent {
     this.loading.set(true);
     try {
       const row = await this.settings.get(AUTO_UPDATE_KEY);
-      this.autoUpdate.set(row?.value === 'true');
+      this.autoUpdate.set(row?.value !== 'false');
     } catch {
-      this.autoUpdate.set(false);
+      this.autoUpdate.set(true);
     } finally {
       this.loading.set(false);
     }

--- a/client/src/app/features/settings/streaming/streaming.html
+++ b/client/src/app/features/settings/streaming/streaming.html
@@ -33,13 +33,11 @@
 
     <!-- Auto-crop black bars. Off = keep the bars and Direct Play / remux
          instead of forcing a re-encode just to crop (low-power servers). -->
-    <div class="form-control">
-      <label class="label cursor-pointer justify-start gap-3">
-        <input type="checkbox" class="toggle" [ngModel]="autoCropEnabled()" (ngModelChange)="autoCropEnabled.set($event)" />
-        <span class="label-text font-medium">{{ 'settings.streaming.auto_crop' | translate }}</span>
-      </label>
-      <label class="label"><span class="label-text-alt text-base-content/50">{{ 'settings.streaming.auto_crop_help' | translate }}</span></label>
-    </div>
+    <app-toggle-field
+      [(value)]="autoCropEnabled"
+      [label]="'settings.streaming.auto_crop' | translate"
+      [hint]="'settings.streaming.auto_crop_help' | translate"
+    />
 
     <!-- QSV / libx264 encoder preset -->
     <div class="form-control">
@@ -87,13 +85,11 @@
     <!-- QSV advanced options (Intel Quick Sync only) -->
     <div class="divider">{{ 'settings.streaming.qsv_advanced' | translate }}</div>
 
-    <div class="form-control">
-      <label class="label cursor-pointer justify-start gap-3">
-        <input type="checkbox" class="toggle" [ngModel]="qsvLowPower()" (ngModelChange)="qsvLowPower.set($event)" />
-        <span class="label-text font-medium">{{ 'settings.streaming.qsv_low_power' | translate }}</span>
-      </label>
-      <label class="label"><span class="label-text-alt text-base-content/50">{{ 'settings.streaming.qsv_low_power_help' | translate }}</span></label>
-    </div>
+    <app-toggle-field
+      [(value)]="qsvLowPower"
+      [label]="'settings.streaming.qsv_low_power' | translate"
+      [hint]="'settings.streaming.qsv_low_power_help' | translate"
+    />
 
     <button class="btn btn-primary" [disabled]="saving()" (click)="save()">
       @if (saving()) { <span class="loading loading-spinner loading-xs"></span> }

--- a/client/src/app/features/settings/streaming/streaming.ts
+++ b/client/src/app/features/settings/streaming/streaming.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject, signal, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { ToggleFieldComponent } from '../../../shared/components/forms/toggle-field/toggle-field';
 import { SettingsApiService } from '../../../core/services/api/settings-api.service';
 import { StreamingApiService } from '../../../core/services/api/streaming-api.service';
 import { StreamsApiService } from '../../../core/services/api/streams-api.service';
@@ -9,7 +10,7 @@ import { ToastService } from '../../../core/services/toast.service';
 
 @Component({
   selector: 'app-streaming-settings',
-  imports: [FormsModule, TranslateModule],
+  imports: [FormsModule, TranslateModule, ToggleFieldComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './streaming.html',
 })


### PR DESCRIPTION
## Auto-update is on by default

#1013 shipped the toggle as opt-in. It now reads as **on** when its key is absent, so an instance whose admin never opened the dialog still applies signed updates.

Consequence, stated plainly: after this ships, every existing instance starts installing plugin updates unattended. What bounds it is unchanged — only an archive the source catalogue's key signed is ever promoted; anything `unverified` or `unsigned` is still logged and skipped, because the consent sheet is the only place that gets acknowledged.

**How the default works without a migration:** `app_settings` is a key/value table and holds no row for `plugins.auto_update` until someone toggles it. Both sides read *absent = on*, and only the explicit `"false"` the dialog writes disables it. Four cases are pinned by test: unset, `"true"`, `"false"`, and a full pass running on an unset key.

The key is now listed in `AppSetting`'s known-keys block, including the detail that it is **not** a `plugin.<id>.*` key — `clearPluginSettings` purges that prefix on uninstall, and `plugins.` does not match it (the seventh character is `s`, not a dot), so uninstalling a plugin cannot silently re-enable or wipe the preference.

## `app-toggle-field` instead of three hand-rolled toggles

`ToggleFieldComponent` exists for a daisyUI switch with a label and a hint underneath, and was already imported by the plugins page. Three call sites were rebuilding it by hand:

- the plugin settings dialog (`[value]` + `(valueChange)`, one-way in so the immediate write can revert the switch if the request fails)
- `admin/settings/streaming` — `auto_crop` and `qsv_low_power`, both of which also carried their hint as a second `<label class="label">`

Roughly 17 other files still have a raw `class="toggle"`. Not swept here: it is mechanical but it is not what was asked, and each one needs its label/hint pairing checked rather than pattern-replaced.

## Checks

- backend `tsc` clean, `jest src/modules/plugins src/modules/scheduler src/modules/settings` → 929 passing
- client `ng build` clean, `ng test` → 442 passing
- the toggle's hint states the new default, in all six locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)