### PR TITLE
fix(requests): announce an approved acquisition instead of deciding for its owner

### DIFF
--- a/backend/src/modules/requests/request-lifecycle.service.ts
+++ b/backend/src/modules/requests/request-lifecycle.service.ts
@@ -77,10 +77,6 @@ export class RequestLifecycleService
    * Admin-toggleable from the General settings page; defaults to `true`
    * (an unset key reads as enabled) to preserve behaviour on existing installs.
    */
-  private async autoGrabOnApproval(): Promise<boolean> {
-    return (await this.settings.get('requests_auto_grab_on_approval')) !== 'false';
-  }
-
   onModuleInit(): void {
     // Files landing on disk is the canonical "request might be
     // available now" trigger. Subscribing here keeps the recompute
@@ -174,11 +170,9 @@ export class RequestLifecycleService
     }
     if (touched.length) await this.requestRepo.save(touched);
 
-    // If the import actually satisfied at least one request, kick off
-    // an immediate SearchMissing for that media so the user doesn't
-    // wait up to 6 h for the next scheduled tick. Fire-and-forget;
-    // failures (no release source configured, etc.) are logged by whoever searches.
-    if (touched.length && (await this.autoGrabOnApproval())) {
+    // An import satisfying a request is worth announcing: whoever owns acquisition can act
+    // on it immediately instead of waiting for its own next tick.
+    if (touched.length) {
       this.events.emitDomain({
         type: 'media.acquisition.requested',
         mediaIds: [media.id],

--- a/backend/src/modules/requests/requests.service.ts
+++ b/backend/src/modules/requests/requests.service.ts
@@ -74,11 +74,6 @@ export class RequestsService {
 
   private readonly logger = new Logger(RequestsService.name);
 
-  /** Admin-toggleable from the General settings page; an unset key reads as enabled. */
-  private async autoGrabOnApproval(): Promise<boolean> {
-    return (await this.settings.get('requests_auto_grab_on_approval')) !== 'false';
-  }
-
   /** Aligné sur PoliciesGuard / CaslAbilityFactory (manage:all → Manage sur tout). */
   private canManageRequests(user: User): boolean {
     return this.caslAbilityFactory
@@ -811,13 +806,13 @@ export class RequestsService {
         linked.media = media;
         await this.requestRepo.save(linked);
       }
-      if (await this.autoGrabOnApproval()) {
-        this.events.emitDomain({
-          type: 'media.acquisition.requested',
-          mediaIds: [media.id],
-          reason: 'request-approved',
-        });
-      }
+      // States the fact, unconditionally: whether it leads to a grab is the acquisition
+      // owner's decision, and core no longer holds one to make.
+      this.events.emitDomain({
+        type: 'media.acquisition.requested',
+        mediaIds: [media.id],
+        reason: 'request-approved',
+      });
     }
 
     this.events.emitDomain({

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1500,7 +1500,6 @@
       "metadata_region": "Region der Metadaten",
       "metadata_region_hint": "Region für Veröffentlichungsdaten und kommende Veröffentlichungen. Kann pro Bibliothek überschrieben werden.",
       "section_automation": "Automatisierung",
-      "auto_grab_on_approval": "Nach Genehmigung einer Anfrage automatisch herunterladen",
       "auto_detect_markers_on_import": "Intros / Vorspanne beim Import von Serien erkennen",
       "saved": "Einstellungen gespeichert.",
       "save_error": "Speichern nicht möglich.",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1510,7 +1510,6 @@
       "metadata_region": "Metadata region",
       "metadata_region_hint": "Region used for release dates and upcoming releases. Can be overridden per library.",
       "section_automation": "Automation",
-      "auto_grab_on_approval": "Automatically download after a request is approved",
       "auto_detect_markers_on_import": "Detect intros / credits when importing series",
       "saved": "Settings saved.",
       "save_error": "Unable to save.",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1500,7 +1500,6 @@
       "metadata_region": "Región de los metadatos",
       "metadata_region_hint": "Región utilizada para las fechas de estreno y los próximos estrenos. Puede sobrescribirse por biblioteca.",
       "section_automation": "Automatización",
-      "auto_grab_on_approval": "Descargar automáticamente tras la aprobación de una solicitud",
       "auto_detect_markers_on_import": "Detectar las intros / créditos al importar las series",
       "saved": "Ajustes guardados.",
       "save_error": "No se puede guardar.",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1510,7 +1510,6 @@
       "metadata_region": "Région des métadonnées",
       "metadata_region_hint": "Région utilisée pour les dates de sortie et les prochaines sorties. Peut être surchargée par bibliothèque.",
       "section_automation": "Automatisation",
-      "auto_grab_on_approval": "Télécharger automatiquement après l'approbation d'une demande",
       "auto_detect_markers_on_import": "Détecter les intros / génériques à l'import des séries",
       "saved": "Paramètres enregistrés.",
       "save_error": "Impossible d'enregistrer.",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1500,7 +1500,6 @@
       "metadata_region": "Regione dei metadati",
       "metadata_region_hint": "Regione usata per le date di uscita e le prossime uscite. Può essere sovrascritta per libreria.",
       "section_automation": "Automazione",
-      "auto_grab_on_approval": "Scarica automaticamente dopo l'approvazione di una richiesta",
       "auto_detect_markers_on_import": "Rileva le intro / titoli di testa all'import delle serie",
       "saved": "Impostazioni salvate.",
       "save_error": "Impossibile salvare.",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1500,7 +1500,6 @@
       "metadata_region": "Região dos metadados",
       "metadata_region_hint": "Região utilizada para as datas de estreia e as próximas estreias. Pode ser substituída por biblioteca.",
       "section_automation": "Automatização",
-      "auto_grab_on_approval": "Transferir automaticamente após a aprovação de um pedido",
       "auto_detect_markers_on_import": "Detetar as intros / genéricos na importação das séries",
       "saved": "Definições guardadas.",
       "save_error": "Não foi possível guardar.",

--- a/client/src/app/features/settings/general/general.html
+++ b/client/src/app/features/settings/general/general.html
@@ -119,16 +119,6 @@
           <input
             type="checkbox"
             class="toggle toggle-sm"
-            [ngModel]="autoGrabOnApproval() === 'true'"
-            (ngModelChange)="autoGrabOnApproval.set($event ? 'true' : 'false')"
-          />
-          <span class="label-text">{{ 'settings.general.auto_grab_on_approval' | translate }}</span>
-        </label>
-
-        <label class="label cursor-pointer justify-start gap-3 max-w-max">
-          <input
-            type="checkbox"
-            class="toggle toggle-sm"
             [ngModel]="autoDetectMarkersOnImport() === 'true'"
             (ngModelChange)="autoDetectMarkersOnImport.set($event ? 'true' : 'false')"
           />

--- a/client/src/app/features/settings/general/general.ts
+++ b/client/src/app/features/settings/general/general.ts
@@ -42,7 +42,6 @@ export class GeneralSettingsComponent implements OnInit {
   readonly metadataRegionOptions = metadataRegionOptions(this.translate.currentLang);
 
   // Automation
-  readonly autoGrabOnApproval = signal('true');
   readonly autoDetectMarkersOnImport = signal('true');
   readonly companionFileExtensions = signal('');
   readonly savingAutomation = signal(false);
@@ -58,7 +57,6 @@ export class GeneralSettingsComponent implements OnInit {
       this.publicUrl.set(map['public_url'] ?? '');
       this.metadataLanguage.set(map['metadata_language'] ?? 'en');
       this.metadataRegion.set(map['metadata_region'] ?? 'US');
-      this.autoGrabOnApproval.set(map['requests_auto_grab_on_approval'] ?? 'true');
       this.autoDetectMarkersOnImport.set(map['markers_auto_detect_on_import'] ?? 'true');
       this.postImportScript.set(map['post_import_script'] ?? '');
       this.companionFileExtensions.set(
@@ -98,7 +96,6 @@ export class GeneralSettingsComponent implements OnInit {
     this.savingAutomation.set(true);
     try {
       await this.api.setBulk({
-        requests_auto_grab_on_approval: this.autoGrabOnApproval(),
         markers_auto_detect_on_import: this.autoDetectMarkersOnImport(),
         companion_file_extensions: this.companionFileExtensions(),
       });


### PR DESCRIPTION
Half of a two-repo fix: an approved request was not grabbed until the next six-hourly tick.

## What core was doing

Core emits `media.acquisition.requested` on approval, on an import that satisfied a request, and on a season drop — with a comment saying exactly why: *"kick off an immediate SearchMissing for that media so the user doesn't wait up to 6 h for the next scheduled tick."*

It gated all three behind its own `requests_auto_grab_on_approval` key, surfaced as a toggle on the General page. Two problems with that:

- **Acquisition belongs to whichever plugin owns it**, and the download plugin declares `requestsAutoGrabOnApproval` for the same idea. An admin therefore saw two switches for one behaviour, on two pages — and the one on the acquisition page was read by nothing at all.
- Core was deciding whether a subscriber should act on a fact core had observed. Emitting the fact is core's job; acting on it is not.

Core now states it unconditionally. The key, both gates and the General-page toggle are removed, along with the i18n entries. Nothing else in core ever subscribed to the event — verified, not assumed.

## Migration, stated plainly

An instance that had turned this off in core must now turn it off where acquisition lives: the download plugin's General page. Core no longer reads the old key, so a stored `false` becomes inert and the plugin's own default (on) applies. This is the price of putting the switch where the behaviour is, and it is a one-line change for the two or three people it affects.

## The other half

`fk-plugin-download` is where the actual bug was: its `event` note handler logged *"no subscriber registered yet"* and dropped every event, so nothing was ever acted on. Its companion PR implements the handler, reads its own toggle, and searches only the media core named.

## Checks

- backend `tsc` clean, `jest src/modules/requests` → 11 passing
- client `ng build` clean, `ng test` → 442 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)