### PR TITLE
fix(playback): persist a seek instead of debouncing it away

### DIFF
--- a/backend/src/modules/streaming/playback.controller.spec.ts
+++ b/backend/src/modules/streaming/playback.controller.spec.ts
@@ -1,0 +1,48 @@
+import { PlaybackController } from './playback.controller';
+
+/**
+ * `updateState` only needs the playback service and the live-session
+ * registry, so we exercise it on a bare prototype instance. The contract
+ * under test: DB writes are debounced to one per 30 s, but a seek flushes
+ * immediately — otherwise quitting right after a jump loses the position.
+ */
+function buildController() {
+  const controller = Object.create(
+    PlaybackController.prototype,
+  ) as PlaybackController;
+  const updateState = jest.fn(async () => ({ id: 1 }));
+  const wired = controller as unknown as {
+    playbackService: unknown;
+    liveSessions: unknown;
+    lastDbWriteAt: Map<string, { at: number; pos: number }>;
+  };
+  wired.playbackService = { updateState };
+  wired.liveSessions = { get: () => null, heartbeat: () => null };
+  wired.lastDbWriteAt = new Map();
+  return { controller, updateState };
+}
+
+const req = { user: { id: 7 }, get: () => undefined } as never;
+const tick = (positionSeconds: number) => ({
+  positionSeconds,
+  durationSeconds: 6000,
+  mediaFileId: 9,
+});
+
+describe('PlaybackController.updateState — DB flush gating', () => {
+  it('debounces a plain 10 s playback tick', async () => {
+    const { controller, updateState } = buildController();
+    await controller.updateState(req, 3, tick(1800));
+    const res = await controller.updateState(req, 3, tick(1810));
+    expect(updateState).toHaveBeenCalledTimes(1);
+    expect(res).toBeNull();
+  });
+
+  it('flushes a seek within the debounce window', async () => {
+    const { controller, updateState } = buildController();
+    await controller.updateState(req, 3, tick(1800));
+    const res = await controller.updateState(req, 3, tick(1920));
+    expect(updateState).toHaveBeenCalledTimes(2);
+    expect(res).toMatchObject({ state: { id: 1 } });
+  });
+});

--- a/backend/src/modules/streaming/playback.controller.ts
+++ b/backend/src/modules/streaming/playback.controller.ts
@@ -26,17 +26,18 @@ import {
 
 /** Debounce window for DB writes — heartbeat fires every 10 s but we
  *  flush playback state on a coarser cadence to avoid hammering
- *  `playback_states` on a busy household. State transitions and the
- *  "completed" threshold short-circuit the debounce. */
+ *  `playback_states` on a busy household. State transitions, the
+ *  "completed" threshold and a seek short-circuit the debounce. */
 const STATE_DB_WRITE_INTERVAL_MS = 30_000;
 
 @Controller('playback')
 @UseGuards(JwtOrApiKeyGuard)
 export class PlaybackController {
-  /** When the last DB write happened per `(userId, mediaId, episodeId)`
-   *  tuple. Drives the debounce above. In-memory map — moves to a
-   *  shared store the day Fliks runs across multiple backend instances. */
-  private readonly lastDbWriteAt = new Map<string, number>();
+  /** When the last DB write happened, and at which position, per
+   *  `(userId, mediaId, episodeId)` tuple. Drives the debounce above.
+   *  In-memory map — moves to a shared store the day Fliks runs across
+   *  multiple backend instances. */
+  private readonly lastDbWriteAt = new Map<string, { at: number; pos: number }>();
 
   constructor(
     private readonly playbackService: PlaybackService,
@@ -230,25 +231,30 @@ export class PlaybackController {
 
     const dbKey = `${user.id}:${mediaId}:${body.episodeId ?? 0}`;
     const now = Date.now();
-    const lastWrite = this.lastDbWriteAt.get(dbKey) ?? 0;
+    const last = this.lastDbWriteAt.get(dbKey);
     const dur = body.durationSeconds ?? 0;
     const pos = body.positionSeconds ?? 0;
     const wouldCompleteRow = dur > 0 && (pos >= dur - 30 || pos >= dur * 0.9);
+    // A position the debounce window can't explain by plain playback is a
+    // seek: flush it now, or leaving the player right after loses the jump.
+    const seeked =
+      !last || Math.abs(pos - last.pos) > STATE_DB_WRITE_INTERVAL_MS / 1000;
     const shouldFlushDb =
       stateChanged ||
       wouldCompleteRow ||
-      now - lastWrite >= STATE_DB_WRITE_INTERVAL_MS;
+      seeked ||
+      now - (last?.at ?? 0) >= STATE_DB_WRITE_INTERVAL_MS;
 
     if (!shouldFlushDb) {
       return sessionLost ? { sessionLost: true } : null;
     }
-    this.lastDbWriteAt.set(dbKey, now);
+    this.lastDbWriteAt.set(dbKey, { at: now, pos });
     // Drop debounce entries for playbacks idle past a few write intervals so
     // the map can't grow unbounded over the process lifetime — a pruned entry
     // only gated the next write, which simply re-creates it.
     const staleBefore = now - STATE_DB_WRITE_INTERVAL_MS * 10;
-    for (const [key, ts] of this.lastDbWriteAt) {
-      if (ts < staleBefore) this.lastDbWriteAt.delete(key);
+    for (const [key, entry] of this.lastDbWriteAt) {
+      if (entry.at < staleBefore) this.lastDbWriteAt.delete(key);
     }
     const state = await this.playbackService.updateState(user.id, mediaId, {
       positionSeconds: body.positionSeconds,

--- a/client/angular.json
+++ b/client/angular.json
@@ -2,7 +2,8 @@
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "cli": {
-    "packageManager": "npm"
+    "packageManager": "npm",
+    "analytics": false
   },
   "newProjectRoot": "projects",
   "projects": {


### PR DESCRIPTION
## Problem

Resume a movie at 30:00, seek to 32:00, leave the player → the position is not retained; reopening resumes at 30:00.

The player does send the position (`onSeeked`, `onBack`, `ngOnDestroy` all call `savePosition`), but the backend throws it away. `PUT /api/playback/media/:id/state` debounces DB writes to one per 30 s, short-circuited only by a play/pause transition or the completion threshold — and nothing signals "the player is closing". Every one of those ticks returns an empty `200` (visible in DevTools: no response body) and the `playback_states` row keeps 30:00.

The debounce reasons about elapsed time only, so it cannot distinguish plain playback drift from a seek.

## Fix

`lastDbWriteAt` now stores the position of the last flush alongside its timestamp, and a tick flushes immediately when the reported position moved further than 30 s of playback could explain. Done in the controller so every client benefits (web, TV, Cast, desktop), not just the reported path.

## Residual

Leaving after continuous playback can still lose up to 30 s — resumes slightly early, never late. That is the pre-existing tolerance and is unchanged. Driving it to zero needs a `final: true` flag on the exit tick, client-side; not done here.

## Tests

New `playback.controller.spec.ts`: a plain 10 s tick stays debounced (`null` response, one DB write), a 2-minute seek inside the window flushes (`{ state }`, two DB writes). `npx jest` green, `tsc --noEmit` clean.

Also carries an unrelated one-liner: `analytics: false` in `client/angular.json` (Angular CLI analytics opt-out).