### PR TITLE
fix(media-detail): clear the resume state when the header switches episode

### DIFF
--- a/client/src/app/shared/components/media-info-header/media-info-header.spec.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.spec.ts
@@ -74,6 +74,9 @@ interface MediaFixture {
    *  default) — profile/library editing and deletion requests don't exist at
    *  per-episode granularity. When true, those two inputs are left unset here too. */
   episodeInstance?: boolean;
+  /** Playback-state rows keyed by episodeId (0 = media-level), served to the
+   *  header's `getPlaybackState` stub. Absent key → no row, like the API. */
+  playbackStates?: Record<number, { positionSeconds: number; durationSeconds: number; completed: boolean; mediaFileId: number } | undefined>;
 }
 
 async function createFixture(
@@ -138,7 +141,13 @@ async function createFixture(
       },
       { provide: TrackManagerService, useValue: { saveAudioSelection: () => {}, saveSubtitleSelection: () => {} } },
       { provide: PlayableMediaService, useValue: { loadWatchedState: () => Promise.resolve(watched) } },
-      { provide: StreamingApiService, useValue: { getPlaybackState: () => Promise.resolve(null) } },
+      {
+        provide: StreamingApiService,
+        useValue: {
+          getPlaybackState: (_mediaId: number, episodeId?: number) =>
+            Promise.resolve(media.playbackStates?.[episodeId ?? 0] ?? null),
+        },
+      },
       {
         provide: PluginUiRegistryService,
         useValue: { contributionsFor: (slot: SlotId) => media.registry?.[slot] ?? [] },
@@ -597,5 +606,34 @@ describe('MediaInfoHeaderComponent — release-picker actions are plugin-contrib
       releasesLoading: true,
     });
     expect(dropdownButtons(busy.nativeElement)[grabIdx].disabled).toBe(true);
+  });
+});
+
+describe('MediaInfoHeaderComponent — resume state across an episode switch', () => {
+  const SERIES_EPISODE: MediaFixture = {
+    mediaType: 'series',
+    episodeId: 3,
+    selectedFileId: null,
+    monitored: true,
+    qualityProfileName: 'HD-1080p',
+    episodeInstance: true,
+    // Only episode 3 was ever played: 33:12 of a 61-minute episode.
+    playbackStates: {
+      3: { positionSeconds: 1992, durationSeconds: 3660, completed: false, mediaFileId: 30 },
+    },
+  };
+
+  it('drops the previous episode progress when the header switches episode', async () => {
+    const fixture = await createFixture(OWNER, SERIES_EPISODE);
+    expect(fixture.componentInstance.resumePositionSeconds()).toBe(1992);
+
+    fixture.componentRef.setInput('episodeId', 4);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // Episode 4 has no playback row — nothing to resume, no progress bar.
+    expect(fixture.componentInstance.resumePositionSeconds()).toBeNull();
+    expect(fixture.componentInstance.durationSeconds()).toBeNull();
   });
 });

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -301,6 +301,11 @@ export class MediaInfoHeaderComponent {
 
   // ── Load playback state + watched when media/episode changes ──
 
+  /** `mediaId:episodeId` of the last playback-state load. Angular reuses this
+   *  component between two episodes of the same show, so the identity has to
+   *  be tracked to drop the previous episode's resume state. */
+  private lastPlaybackKey: string | null = null;
+
   private readonly loadPlaybackEffect = effect(() => {
     const mediaId = this.mediaId();
     // A series page has no episode context of its own, but it does know which
@@ -309,6 +314,15 @@ export class MediaInfoHeaderComponent {
     // episode-specific label.
     const episodeId = this.episodeId() ?? this.resumeEpisodeId();
     if (!mediaId) return;
+
+    const key = `${mediaId}:${episodeId ?? 0}`;
+    const switched = key !== this.lastPlaybackKey;
+    this.lastPlaybackKey = key;
+    if (switched) {
+      this.resumePositionSeconds.set(null);
+      this.durationSeconds.set(null);
+    }
+
 
     // Watched state: for a series without an episode context, derive from the
     // aggregate `seriesFullyWatched` input (see parent). Otherwise, read the
@@ -321,22 +335,19 @@ export class MediaInfoHeaderComponent {
 
     // Load resume position
     this.streamingApi.getPlaybackState(mediaId, episodeId).then(ps => {
-      if (ps) {
-        // Pre-select last-played file
-        if (ps.mediaFileId) {
-          const files = this.files();
-          if (files.some(f => f.id === ps.mediaFileId)) {
-            this.selectedFileIdChange.emit(ps.mediaFileId);
-          }
-        }
-        if (!ps.completed && ps.positionSeconds > 10) {
-          this.resumePositionSeconds.set(ps.positionSeconds);
-          this.durationSeconds.set(ps.durationSeconds);
-        } else {
-          this.resumePositionSeconds.set(null);
-          this.durationSeconds.set(null);
-        }
+      // A faster episode switch already superseded this request.
+      if (this.lastPlaybackKey !== key) return;
+      if (!ps || ps.completed || ps.positionSeconds <= 10) {
+        this.resumePositionSeconds.set(null);
+        this.durationSeconds.set(null);
+        return;
       }
+      // Pre-select last-played file
+      if (ps.mediaFileId && this.files().some(f => f.id === ps.mediaFileId)) {
+        this.selectedFileIdChange.emit(ps.mediaFileId);
+      }
+      this.resumePositionSeconds.set(ps.positionSeconds);
+      this.durationSeconds.set(ps.durationSeconds);
     }).catch(() => {});
   });
 


### PR DESCRIPTION
## Problem

On an episode detail page, clicking another episode of the same season updates the title, still, synopsis and runtime — but keeps the **previous** episode's progress: the resume button ("Resume at 33:12"), the progress bar and the "x min remaining" line all stay put, even for an episode that was never played.

Not cosmetic: the resume button carries the stale offset, so playing the new episode starts it at the old one's position.

Cause is in `media-info-header.ts`: the playback-state fetch only wrote its signals inside `if (ps)`. `GET /api/playback/media/:id/state` returns `null` for an episode with no row, so nothing reset `resumePositionSeconds` / `durationSeconds` and the previous episode's values survived the switch. Angular reuses the header component between two `series/:id/episode/:episodeId` URLs, so nothing else cleared them either.

## Fix

Track the loaded `(mediaId, episodeId)` pair in the header:

- switching pair clears the resume signals up front, so no stale progress is ever shown under a new title;
- a `null` row (or a completed one) clears them as well, instead of leaving the previous values;
- a response whose pair has already been superseded is dropped, so a fast double switch can't land the wrong episode's position.

## Tests

`media-info-header.spec.ts` gains a case: a header showing episode 3's 33:12 resume, switched to episode 4 (no playback row), must end with a null resume position and duration. Verified to fail against the previous body and pass with the fix — 27/27 green, `tsc --noEmit` clean.