### PR TITLE
fix(navigation): disable view transitions on capacitor

### DIFF
--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -68,12 +68,9 @@ export const appConfig: ApplicationConfig = {
     provideRouter(
       routes,
       withInMemoryScrolling({ scrollPositionRestoration: 'top' }),
-      // Enables document.startViewTransition() around every navigation. Browsers
-      // without VT support (Safari < 18, iOS WebKit) get a no-op fallback —
-      // Angular feature-detects internally. Combined with view-transition-name
-      // on the card poster + the matching detail-page hero, this morphs the
-      // poster between list and detail rather than cross-fading the page.
-      withViewTransitions(),
+      // Poster→hero morph. Off on Capacitor: its WebView never completes a snapshot
+      // capture for a launch-created document, so every navigation waits Chrome's 4s timeout.
+      ...(Capacitor.isNativePlatform() ? [] : [withViewTransitions()]),
     ),
     { provide: RouteReuseStrategy, useExisting: CachingReuseStrategy },
     provideHttpClient(

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -265,12 +265,9 @@ export class MediaCardComponent {
   }
 
   protected flagPosterForTransition() {
-    // Skip on engines without View Transitions API (Chromium <111,
-    // Tizen 5.5 WebKit, webOS 5 Chromium 79). Angular's
-    // `withViewTransitions()` already feature-detects, but the
-    // imperative DOM stamping below would mutate styles for nothing on
-    // those targets and adds a querySelectorAll per click.
-    if (!('startViewTransition' in document)) return;
+    // Pointless where the router runs no transition (Capacitor) or the engine has
+    // none (Chromium <111, Tizen 5.5 WebKit, webOS 5) — and it costs a querySelectorAll per click.
+    if (this.isNative || !('startViewTransition' in document)) return;
     const id = this.resolveMediaId();
     const img = this.imgRef()?.nativeElement;
     if (id == null || !img) return;


### PR DESCRIPTION
## Problem

On the Capacitor WebView every route change took a fixed **4 seconds**. Measured on a Galaxy S25 (Android 16, WebView Chrome 150.0.7871.181) over the real app via remote debugging:

```
startViewTransition() called      →    7 ms
update callback invoked           → 4017 ms
ready                             → rejected: "Transition was aborted
                                     because of timeout in DOM update"
URL flipped                       → 4100 ms
first IndexedDB transaction       → 4055 ms
first API request                 → 4073 ms
long tasks during that window     →    0
```

`withViewTransitions()` makes the router await the transition's update callback before activating the route, so the URL, the IndexedDB reads and every API call queue behind it. The main thread is idle throughout and rAF keeps ticking at 120 Hz — the WebView simply never completes the snapshot capture, and Chrome waits out its 4 s DOM-update timeout before giving up and invoking the callback.

## What was ruled out

| Hypothesis | Measurement |
|---|---|
| Page content | emptied `<body>` + every stylesheet disabled → **4004 ms** |
| WebView not rendering | rAF at 120 Hz, `visibilityState: visible`, `hasFocus: true` |
| The `::view-transition` CSS rules | identical with no stylesheet at all |
| Native splash screen | `show()` + `hide()` on a healthy document → stays at 33-42 ms |
| `Immersive.applyEdgeToEdge()` | 46 ms before, 28-53 ms after |
| background → resume cycle | 33-49 ms before, 34-44 ms after |
| IndexedDB request-cache size | 208-352 ms per navigation, an order of magnitude below |

The breakage is a property of **the document created during app launch**: it reproduces on every cold start (4012, 4029, 4030, 4034, 4036, 4038, 4031, 4032 ms sampled over 60 s) and lasts for the life of that document, while a plain page reload restores 30-45 ms transitions without touching anything native.

## Fix

Gate the router feature off on Capacitor. Verified on the deployed debug build, cold start:

```
viewTransitionsStarted : 0
/downloads → /                  57 ms
/ → /libraries/Films            47 ms
/libraries/Films → /movies/1   106 ms
/movies/1 → /movies/890         45 ms
```

Only the poster-to-hero morph is lost on native — the full-page cross-fade is already neutralised by `animation: none` on `::view-transition-old/new(root)` in `styles.css`. The card's poster stamping is skipped there too: it ran a document-wide unindexable `querySelectorAll('img[style*="view-transition-name"]')` on every tap for a transition that no longer happens.

## Scope caveat

The capture bug is WebView-version specific, not universal:

| Device | WebView | Bare view transition |
|---|---|---|
| Galaxy S25 (Android 16) | Chrome **150**.0.7871.181 | broken — 4030 ms, timeout |
| Galaxy Tab S5e (Android 15) | Chrome **148**.0.7778.120 | healthy — 19-32 ms, `ready: ok` |

This disables the morph on every native device while only some are affected. That is the deliberate trade: the failure mode is catastrophic and silent, and the effect is purely cosmetic. Gating on a Chrome version parsed from the UA would be fragile and would rot.

## Test plan

- Debug build deployed and measured on both devices above; navigations 45-115 ms on the S25, 80-395 ms on the Tab S5e, zero transitions started on either.
- Web and desktop keep `withViewTransitions()` and the poster morph unchanged.