### PR TITLE
fix(perf): cache scans, leaked listeners and dead SSE streams

### DIFF
--- a/backend/src/modules/scheduler/events.service.ts
+++ b/backend/src/modules/scheduler/events.service.ts
@@ -110,11 +110,6 @@ export type SseEvent =
       connectionId: string;
     }
   | {
-      // Keepalive. Nest disables the socket idle timeout, so without a periodic
-      // write a half-open mobile connection is never detected or unregistered.
-      type: 'sse.ping';
-    }
-  | {
       type: 'player.command';
       sessionId: string;
       mediaFileId: number;
@@ -326,10 +321,10 @@ export class EventsService {
         subscriber.next({ data: JSON.stringify(env.event) } as MessageEvent);
       });
 
+      // Named and data-less: no client dispatches it (the spec drops an event with
+      // an empty data buffer), but the write still surfaces a dead socket.
       const ping = setInterval(() => {
-        subscriber.next({
-          data: JSON.stringify({ type: 'sse.ping' } satisfies SseEvent),
-        } as MessageEvent);
+        subscriber.next({ type: 'ping', data: '' } as MessageEvent);
       }, PING_INTERVAL_MS);
 
       return () => {

--- a/backend/src/modules/scheduler/events.service.ts
+++ b/backend/src/modules/scheduler/events.service.ts
@@ -110,6 +110,11 @@ export type SseEvent =
       connectionId: string;
     }
   | {
+      // Keepalive. Nest disables the socket idle timeout, so without a periodic
+      // write a half-open mobile connection is never detected or unregistered.
+      type: 'sse.ping';
+    }
+  | {
       type: 'player.command';
       sessionId: string;
       mediaFileId: number;
@@ -227,6 +232,9 @@ interface SseEnvelope {
   event: SseEvent;
 }
 
+/** Short enough to beat the ~60s idle cut of mobile carriers and proxies. */
+const PING_INTERVAL_MS = 30_000;
+
 @Injectable()
 export class EventsService {
   private readonly log = new Logger(EventsService.name);
@@ -318,7 +326,14 @@ export class EventsService {
         subscriber.next({ data: JSON.stringify(env.event) } as MessageEvent);
       });
 
+      const ping = setInterval(() => {
+        subscriber.next({
+          data: JSON.stringify({ type: 'sse.ping' } satisfies SseEvent),
+        } as MessageEvent);
+      }, PING_INTERVAL_MS);
+
       return () => {
+        clearInterval(ping);
         sub.unsubscribe();
         this.connections.delete(connectionId);
       };

--- a/client/src/app/core/interceptors/cache.interceptor.ts
+++ b/client/src/app/core/interceptors/cache.interceptor.ts
@@ -69,6 +69,11 @@ let dbPromise: Promise<IDBDatabase> | null = null;
  *  flight for the previous account must not land in the new one's cache. */
 let cacheGeneration = 0;
 
+/** Past this, an entry is dead weight: too old to be a useful offline fallback,
+ *  still scanned by every invalidation. Swept once per app start. */
+const MAX_AGE = 7 * 24 * 60 * 60_000;
+let pruned = false;
+
 function openDb(): Promise<IDBDatabase> {
   if (dbPromise) return dbPromise;
   dbPromise = new Promise((resolve, reject) => {
@@ -78,10 +83,28 @@ function openDb(): Promise<IDBDatabase> {
         req.result.createObjectStore(STORE_NAME, { keyPath: 'url' });
       }
     };
-    req.onsuccess = () => resolve(req.result);
+    req.onsuccess = () => { resolve(req.result); prune(req.result); };
     req.onerror = () => reject(req.error);
   });
   return dbPromise;
+}
+
+/** Entries expire on read but are never deleted there, so a long-lived install
+ *  keeps every URL it ever fetched and every invalidation pays for them. */
+function prune(db: IDBDatabase): void {
+  if (pruned) return;
+  pruned = true;
+  try {
+    const store = db.transaction(STORE_NAME, 'readwrite').objectStore(STORE_NAME);
+    const cutoff = Date.now() - MAX_AGE;
+    const req = store.openCursor();
+    req.onsuccess = () => {
+      const cursor = req.result;
+      if (!cursor) return;
+      if ((cursor.value as CacheEntry).timestamp < cutoff) cursor.delete();
+      cursor.continue();
+    };
+  } catch { /* ignore */ }
 }
 
 /**
@@ -103,6 +126,7 @@ export function clearRequestCache(): Promise<void> {
         })
     : Promise.resolve();
   dbPromise = null;
+  pruned = false;
   return closeExisting.then(() => {
     return new Promise<void>((resolve) => {
       let settled = false;
@@ -155,11 +179,13 @@ export async function invalidatePrefix(prefix: string): Promise<void> {
     const db = await openDb();
     const tx = db.transaction(STORE_NAME, 'readwrite');
     const store = tx.objectStore(STORE_NAME);
-    const req = store.openCursor();
+    // Key cursor, not openCursor: only the key is read here, and deserializing
+    // every cached body to drop it cost 5x more on a mid-size store.
+    const req = store.openKeyCursor();
     req.onsuccess = () => {
       const cursor = req.result;
       if (!cursor) return;
-      if ((cursor.key as string).startsWith(prefix)) cursor.delete();
+      if ((cursor.key as string).startsWith(prefix)) store.delete(cursor.key);
       cursor.continue();
     };
   } catch { /* ignore */ }

--- a/client/src/app/core/services/sse.service.ts
+++ b/client/src/app/core/services/sse.service.ts
@@ -88,6 +88,7 @@ export class SseService implements OnDestroy {
     this.eventSource.onmessage = (event) => {
       try {
         const data = JSON.parse(event.data) as SseEvent;
+        if (data.type === 'sse.ping') return;
         if (data.type === 'sse.connected') {
           const id = data['connectionId'];
           if (typeof id === 'string' && id) {
@@ -118,8 +119,16 @@ export class SseService implements OnDestroy {
         window.addEventListener('online', this.onOnline, { once: true });
         return;
       }
-      // Exponential backoff: 5s → 10s → 20s → 30s max
-      this.retryHandle = setTimeout(() => this.connect(), this.retryDelay);
+      // Exponential backoff: 5s → 10s → 20s → 30s max. On native the token is
+      // baked into the URL, so rotate it first or a long background leaves every
+      // retry replaying the same expired one.
+      this.retryHandle = setTimeout(() => {
+        if (this.serverConfig.isNative && this.auth.refreshToken) {
+          void this.auth.refreshAccessToken().finally(() => this.connect());
+        } else {
+          this.connect();
+        }
+      }, this.retryDelay);
       this.retryDelay = Math.min(this.retryDelay * 2, 30_000);
     };
   }

--- a/client/src/app/core/services/sse.service.ts
+++ b/client/src/app/core/services/sse.service.ts
@@ -88,7 +88,6 @@ export class SseService implements OnDestroy {
     this.eventSource.onmessage = (event) => {
       try {
         const data = JSON.parse(event.data) as SseEvent;
-        if (data.type === 'sse.ping') return;
         if (data.type === 'sse.connected') {
           const id = data['connectionId'];
           if (typeof id === 'string' && id) {

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -328,14 +328,11 @@ export class HomeComponent implements OnInit, OnDestroy {
       this.detached = true;
       this.scrollMemory.deactivateIf(HomeComponent.SCROLL_KEY);
     });
-    // Native app-resume: when the app returns to the foreground after a spell
-    // in the background and home is the page on screen, refresh it. Same
-    // two-pass SWR as the reuse-attach path — cached signals stay visible for
-    // an instant repaint, then a forced round-trip pulls fresh data.
+    // Native app-resume: refresh home when it is the page on screen. Forced only
+    // — its signals are still rendered, so a cache-first pass would repaint nothing.
     this.resumeSub = this.appResume.resume$.subscribe(() => {
       if (this.detached) return;
-      void this.loadAllSections();
-      queueMicrotask(() => void this.loadAllSections({ force: true }));
+      void this.loadAllSections({ force: true });
     });
   }
 

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1525,6 +1525,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       this.state.loading.set(false);
     }
 
+    // Everything above awaits, so a back-out mid-launch runs ngOnDestroy first and
+    // its removals would miss the listeners registered below.
+    if (this.destroyed) return;
+
     // Keyboard shortcuts
     document.addEventListener('keydown', this.onKeyDown);
 

--- a/client/src/app/shared/components/horizontal-scroller.ts
+++ b/client/src/app/shared/components/horizontal-scroller.ts
@@ -77,7 +77,9 @@ export class HorizontalScrollerComponent implements AfterViewInit, OnDestroy {
 
   updateArrows() {
     const el = this.scrollerEl()?.nativeElement;
-    if (!el) return;
+    // attached$ is not route-scoped, so rails of pages still held by the reuse
+    // cache get here too — reading their extents is a forced layout for nothing.
+    if (!el || !el.isConnected) return;
     this.atStart.set(el.scrollLeft <= 0);
     this.atEnd.set(el.scrollLeft + el.clientWidth >= el.scrollWidth - 1);
   }

--- a/client/src/app/shared/utils/infinite-scroll-list.ts
+++ b/client/src/app/shared/utils/infinite-scroll-list.ts
@@ -26,6 +26,7 @@ export class InfiniteScrollList<T extends { id: number }> {
   private idPrefix = '';
   private letterBoundaries: { letter: string; itemId: number; index: number }[] = [];
   private scrollHandler: (() => void) | null = null;
+  private unlockOnScroll: (() => void) | null = null;
   private scrollLock = false;
   private scrollLockTimeout: ReturnType<typeof setTimeout> | null = null;
   private readonly idIndex = new Map<number, number>();
@@ -257,19 +258,22 @@ export class InfiniteScrollList<T extends { id: number }> {
   /** Release the scroll lock once the smooth scroll settles (shared by the
    *  windowed and non-windowed scrollToLetter paths). */
   private armScrollUnlock() {
-    const unlockOnScroll = () => {
-      if (this.scrollLockTimeout) clearTimeout(this.scrollLockTimeout);
-      this.scrollLockTimeout = setTimeout(() => {
-        this.scrollLock = false;
-        window.removeEventListener('scroll', unlockOnScroll);
-      }, 150);
-    };
-    window.addEventListener('scroll', unlockOnScroll, { passive: true });
-    // Fallback if already at position (no scroll event fires).
-    this.scrollLockTimeout = setTimeout(() => {
+    // Re-arming clears the pending timer, so the previous closure has to be
+    // dropped here or it stays bound to window with nothing left to remove it.
+    if (this.unlockOnScroll) window.removeEventListener('scroll', this.unlockOnScroll);
+    const release = () => {
       this.scrollLock = false;
       window.removeEventListener('scroll', unlockOnScroll);
-    }, 150);
+      if (this.unlockOnScroll === unlockOnScroll) this.unlockOnScroll = null;
+    };
+    const unlockOnScroll = () => {
+      if (this.scrollLockTimeout) clearTimeout(this.scrollLockTimeout);
+      this.scrollLockTimeout = setTimeout(release, 150);
+    };
+    this.unlockOnScroll = unlockOnScroll;
+    window.addEventListener('scroll', unlockOnScroll, { passive: true });
+    // Fallback if already at position (no scroll event fires).
+    this.scrollLockTimeout = setTimeout(release, 150);
   }
 
   /** Bind to a sentinel element via @ViewChild setter. */
@@ -289,6 +293,7 @@ export class InfiniteScrollList<T extends { id: number }> {
   /** Start tracking scroll position to update activeLetter. Call once after init. */
   trackScroll(idPrefix: string) {
     this.idPrefix = idPrefix;
+    if (this.scrollHandler) window.removeEventListener('scroll', this.scrollHandler);
     this.scrollHandler = () => {
       this.onWindowScroll();
       this.onScroll();
@@ -301,6 +306,10 @@ export class InfiniteScrollList<T extends { id: number }> {
     this.observer?.disconnect();
     if (this.scrollHandler) {
       window.removeEventListener('scroll', this.scrollHandler);
+    }
+    if (this.unlockOnScroll) {
+      window.removeEventListener('scroll', this.unlockOnScroll);
+      this.unlockOnScroll = null;
     }
     if (this.windowRaf !== null) {
       cancelAnimationFrame(this.windowRaf);


### PR DESCRIPTION
Follow-up to #1018. Those were the defects the 4-second view-transition stall was hiding — each one confirmed by reading the code and, where noted, measured on device. None of them individually explains the reported lag; together they are what the app pays on every navigation, every mutation and every resume.

## `perf(cache)` — invalidation deserialized the whole store

`invalidatePrefix` walked the response store with `openCursor()` while reading nothing but `cursor.key`, so IndexedDB structured-clone-deserialized the full body of every cached row on the main thread. Measured on a Galaxy S25 across 310 rows:

| walk | cost |
|---|---|
| `openCursor()` | **116 ms** |
| `openKeyCursor()` | **22 ms** |

It fires on every non-GET `/api` call — including the playback heartbeat every 10 s for the whole duration of a stream, paused or not — and holds a `readwrite` transaction that the next navigation's reads queue behind, since no cacheable GET is dispatched until `getCached` resolves.

Nothing ever deleted an entry either: the TTL is only consulted on read, and the key is the full `urlWithParams`, so an install accumulates one row per filter/sort/page combination it has ever requested. Added a sweep of week-old entries, once per app start.

## `fix(ui)` — listeners outliving their page

Routes flagged `reuse: true` are detached, not destroyed, so `ngOnDestroy` never runs while up to ten pages sit in the reuse cache. Three registrations leaked beyond even that:

- `trackScroll` rebound a window `scroll` listener without removing the previous one, and `library.ts` calls it inside the route-params subscription — a second emission on the same instance leaked one permanently.
- `armScrollUnlock` relied on its own timer to remove the listener it had just added, but re-arming clears that timer first. Two A-Z taps within 150 ms orphaned the earlier closure with no reference left to remove it.
- The rails subscribe to `attached$`, which is **not** route-scoped, so every reattach made every rail of every retained page read `scrollLeft`/`clientWidth`/`scrollWidth` — forced layouts on DOM no longer in the document.

The player registers its global listeners at the end of an `ngAfterViewInit` that awaits ~30 times. Backing out of a loading player runs `ngOnDestroy` first, so its removals miss what the continuation then adds: four permanent listeners per aborted launch, `app:playerBack` among them — dispatched on every hardware-back on `/watch`.

## `fix(sse)` — a stale token retried forever, and streams that never die

On native the access token is baked into the `EventSource` URL at connect time and nothing in the error path refreshes it. After a background spell long enough to expire it, the stream 401s and every retry replays the same dead token: one failed open every 30 s, indefinitely, with `connectionId` left `null` so admin remote-control cannot bind the device either.

Server side, Nest's `SseStream` calls `req.socket.setTimeout(0)` and the only cleanup is the response close handler. A half-open mobile socket — Doze, a Wi-Fi to cellular switch, anything dropping the connection without a FIN — is never detected: the entry stays in `connections`, still subscribed, and every emit pays a `shouldDeliver` plus a `JSON.stringify` for it. A 30 s keepalive gives the write a chance to fail, which is what triggers the teardown.

## `perf(home)` — the resume burst was doubled

Resume fired `loadAllSections` twice, cache-first then forced. The page is on screen with its signals already rendered, so the first pass repaints nothing — and it is not free: `TTL_LIST` is 5 minutes while `markResumed` only emits after 30 s in the background, so its entries are usually stale and the SWR branch fires the network request anyway. Home fans out to 16-40 calls including one per enabled library row, each writing back through a `readwrite` transaction.

## Test plan

Validated on device (Galaxy S25, Android 16) against the real backend, through the shipped build:

- **Navigation** — 42-122 ms across four route changes, zero view transitions started. No regression from #1018.
- **Prune** — seeded two 8-day-old rows and two fresh ones, cold-restarted the app: only the two stale rows were swept, both fresh ones survived.
- **Prefix invalidation** — seeded probes under three prefixes, then triggered a real `POST /api/likes` from the UI. Both `/api/likes?probe=*` rows were deleted, all four rows under other prefixes survived, and no error fired — `store.delete(cursor.key)` on a key cursor is valid on this engine.
- **Scroll listeners** — counted via `DOMDebugger.getEventListeners` on `window` across 8 home ↔ library round trips: flat at 3 (layout plus the two library pages held in the reuse cache), no growth.
- Client suite green: 443 tests, 55 files. Backend scheduler suite green: 128 tests. Both projects type-check clean.

**Not validated:** the SSE keepalive and the token rotation. Both need a backend running this branch and, for the rotation, an access token expired by a real background spell. The keepalive is a named data-less frame, which no EventSource dispatches, so it cannot reach client code on any version.