### PR TITLE
fix(ui): heading overflow, and a trending card that ignored the library

### DIFF
--- a/client/src/app/core/interceptors/cache.interceptor.spec.ts
+++ b/client/src/app/core/interceptors/cache.interceptor.spec.ts
@@ -13,6 +13,15 @@ describe('cache.interceptor — what may be cached', () => {
     expect(isCacheable('/api/plugins/ui')).toBe(false);
   });
 
+  it('refuses the metadata lists that carry library state, keeps the pure reads', () => {
+    expect(isCacheable('/api/metadata/trending/movie?window=week')).toBe(false);
+    expect(isCacheable('/api/metadata/popular/tv')).toBe(false);
+    expect(isCacheable('/api/metadata/discover/movie?genres=28')).toBe(false);
+    expect(isCacheable('/api/metadata/search/movie?q=foo')).toBe(false);
+    expect(isCacheable('/api/metadata/tmdb/movie/123')).toBe(true);
+    expect(isCacheable('/api/metadata/genres/movie')).toBe(true);
+  });
+
   it('refuses auth, streams and live subtitle searches', () => {
     expect(isCacheable('/api/auth/me')).toBe(false);
     expect(isCacheable('/api/stream/1')).toBe(false);

--- a/client/src/app/core/interceptors/cache.interceptor.ts
+++ b/client/src/app/core/interceptors/cache.interceptor.ts
@@ -32,6 +32,7 @@ const CACHEABLE_PREFIXES = [
   '/api/profiles/language',
   // Title details barely change; the request-poster fallback (rows without
   // stored local art) re-fetches them on every cold page open otherwise.
+  // Only the pure provider reads — see EXCLUDED_PATTERNS for the rest.
   '/api/metadata',
 ];
 
@@ -49,6 +50,10 @@ const EXCLUDED_PREFIXES = [
 // background, so the caller never sees the real response.
 const EXCLUDED_PATTERNS = [
   /\/api\/media\/\d+\/subtitles\/search/,
+  // These carry existingMediaId — library state, not provider metadata. Caching it
+  // pins a title to "not in the library" long after it was added, so the card keeps
+  // its add badge and routes to the add page instead of the library one.
+  /^\/api\/metadata\/(search|trending|popular|upcoming|discover)\//,
 ];
 
 const DETAIL_PATTERN = /^\/api\/media\/\d+$/;

--- a/client/src/app/shared/components/collapsible-section/collapsible-section.html
+++ b/client/src/app/shared/components/collapsible-section/collapsible-section.html
@@ -1,13 +1,16 @@
 <button
   type="button"
-  class="flex items-center gap-2 cursor-pointer text-lg font-bold"
+  class="flex w-full items-center gap-2 cursor-pointer text-lg font-bold text-left"
   [attr.aria-expanded]="open()"
+  [title]="heading()"
   (click)="toggle()"
 >
-  {{ heading() }}
+  <!-- text-left undoes the button's centred UA default, which only showed once a
+       long heading wrapped; truncate keeps it on one line and the chevron beside it. -->
+  <span class="truncate">{{ heading() }}</span>
   <svg
     lucideChevronDown
-    class="h-4 w-4 opacity-60 transition-transform duration-200"
+    class="h-4 w-4 shrink-0 opacity-60 transition-transform duration-200"
     [class.rotate-180]="open()"
     aria-hidden="true"
   ></svg>


### PR DESCRIPTION
Two unrelated UI defects reported from the Android app.

## `fix(search)` — a trending card routed to the add page for a title already in the library

Opening a discovery card on `/search` with no query landed on `/add/movie/tmdb/<id>` even though the title was in the library (with no file). The card also lacked its "in library" badge, while its neighbours had theirs.

`onExternalCardClick` already handles this — it routes to the library page whenever the row carries `existingMediaId`. The value was simply stale.

Five `/api/metadata` routes — `search`, `trending`, `popular`, `upcoming`, `discover` — run through `enrichWithExisting` on the backend and therefore carry `existingMediaId`: **library state, not provider metadata**. The HTTP cache had the whole `/api/metadata` prefix on its cacheable list, justified by "title details barely change". That is true of the per-title provider reads, and false of these five.

Nothing ever lifted the stale value:

- a media mutation only invalidates `resourcePrefix(url)`, i.e. `/api/media` — never `/api/metadata`
- the stale-while-revalidate path serves the cached body and only revalidates in the background, so the row the user clicks is the old one

Confirmed against a live server, from the device's own session:

| source | `existingMediaId` |
|---|---|
| cached body (7 min old) | `null` |
| endpoint queried live | **948** |

The library row exists: id 948, matching tmdbId, `type: movie`, zero files. So the backend was right the whole time.

Excluded those five route families from the cache. The per-title reads (`/api/metadata/<provider>/movie/<id>`) and the genre lists carry no library state and stay cached, which is what the original justification was actually about.

**Verified on device** (Galaxy S25, against the real server): purged the leftover rows, reloaded `/search` — none of the five endpoints returns to the cache, and the card now navigates to `/movies/948`.

One note for existing installs: rows already written for those endpoints stay in IndexedDB until the 7-day sweep from #1019. They are never read again — `isCacheable` short-circuits before the lookup.

## `fix(ui)` — a long section heading rendered centred over two lines

A `<button>` carries `text-align: center` from the UA stylesheet. It stays invisible until the heading is long enough to wrap, and then the section title renders centred over two lines, unlike every other heading on the page. Collection sections interpolate the collection name, so they wrap first.

`text-left` on the button, the heading in a `truncate` span so it stays on one line with an ellipsis, `shrink-0` on the chevron so it keeps its place beside the clipped text, and a `title` attribute so the full name stays reachable. The button's accessible name is unchanged — the text node is only clipped visually.

Reported and confirmed fixed by the reporter.

## Test plan

- Search fix verified end to end on device, as described above.
- Heading fix confirmed visually by the reporter.
- `isCacheable` gained a case pinning the split: the five list families are refused, the per-title read and the genre lists stay cacheable.
- Client suite green.