### PR TITLE
fix(scan): keep serving requests while a scan walks the disk

### DIFF
--- a/backend/src/modules/imports/disk-import.matching.spec.ts
+++ b/backend/src/modules/imports/disk-import.matching.spec.ts
@@ -1,0 +1,47 @@
+import { matchMedia, normalizeTitle } from './disk-import.service';
+
+const media = (title: string, originalTitle = '') => ({
+  title,
+  normTitle: normalizeTitle(title),
+  normOriginal: normalizeTitle(originalTitle),
+});
+
+describe('disk scan — matching a filename to a library title', () => {
+  // Callers hand over the output of extractTitle, which has already turned
+  // dots and underscores into spaces.
+  it('ignores case, punctuation and repeated spaces', () => {
+    const rows = [media('The Long Voyage')];
+    expect(matchMedia('the long voyage', rows)?.title).toBe('The Long Voyage');
+    expect(matchMedia('The  Long   Voyage!', rows)?.title).toBe('The Long Voyage');
+  });
+
+  it('matches the original title too', () => {
+    const rows = [media('The Long Voyage', 'Le Long Voyage')];
+    expect(matchMedia('le long voyage', rows)?.title).toBe('The Long Voyage');
+  });
+
+  it('accepts a filename carrying trailing noise', () => {
+    const rows = [media('The Long Voyage')];
+    expect(matchMedia('the long voyage 2011', rows)?.title).toBe('The Long Voyage');
+  });
+
+  it('accepts a truncated filename against a longer library title', () => {
+    expect(matchMedia('voy', [media('Voyager')])?.title).toBe('Voyager');
+  });
+
+  it('refuses to let a two-letter library title absorb a shorter fragment', () => {
+    // The length guard sits on the library title, not on the filename.
+    expect(matchMedia('v', [media('Vo')])).toBeNull();
+    expect(matchMedia('v', [media('Voy')])?.title).toBe('Voy');
+  });
+
+  it('prefers an exact hit over a prefix one, whatever the order', () => {
+    const rows = [media('Voyager'), media('Voy')];
+    expect(matchMedia('voy', rows)?.title).toBe('Voy');
+  });
+
+  it('returns null on an empty target or no candidate', () => {
+    expect(matchMedia('', [media('Voyager')])).toBeNull();
+    expect(matchMedia('something else', [media('Voyager')])).toBeNull();
+  });
+});

--- a/backend/src/modules/imports/disk-import.service.ts
+++ b/backend/src/modules/imports/disk-import.service.ts
@@ -28,6 +28,7 @@ import {
   RelinkResult,
 } from './dto/orphan-scan.dto';
 import { NfoMetadataService } from './nfo-metadata.service';
+import { mapWithConcurrency } from '../../common/utils/concurrency';
 import { MediaService } from '../media/media.service';
 import { MediaMetadataService } from '../media/media-service/media-metadata.service';
 import { NamingService } from '../scheduler/naming.service';
@@ -53,6 +54,56 @@ export interface ScanCandidate {
   episodeId: number | null;
   episodeTitle: string | null;
   existingQuality: string | null;
+}
+
+/** The scan shares a 30-connection pool with everything else the server is
+ *  serving; unbounded fan-out starved it and the UI stalled until the scan ended. */
+const SCAN_CONCURRENCY = 8;
+
+export interface NormalizedTitles {
+  normTitle: string;
+  normOriginal: string;
+}
+
+type ScanMedia = Pick<
+  Media,
+  'id' | 'title' | 'originalTitle' | 'year' | 'type'
+> &
+  NormalizedTitles;
+
+export function normalizeTitle(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** Pure so the scan can hoist normalization out of its per-file loop. */
+export function matchMedia<T extends NormalizedTitles>(
+  extractedTitle: string,
+  allMedia: readonly T[],
+): T | null {
+  const target = normalizeTitle(extractedTitle);
+  if (!target) return null;
+
+  // Exact match
+  let match = allMedia.find(
+    (m) => m.normTitle === target || m.normOriginal === target,
+  );
+  if (match) return match;
+
+  // Target starts with media title (e.g. "inception 2010" -> "inception")
+  match = allMedia.find(
+    (m) => m.normTitle.length >= 2 && target.startsWith(m.normTitle),
+  );
+  if (match) return match;
+
+  // Media title starts with target
+  match = allMedia.find(
+    (m) => m.normTitle.length >= 3 && m.normTitle.startsWith(target),
+  );
+  return match ?? null;
 }
 
 @Injectable()
@@ -92,7 +143,7 @@ export class DiskImportService {
     const root = path.resolve(library.path!);
     this.logger.log(`Orphan scan started — library #${libraryId} root="${root}"`);
 
-    const allFiles = this.collectVideoFiles(root, 0);
+    const allFiles = await this.collectVideoFiles(root, 0);
 
     // Build the set of absolute paths already linked in this library.
     const linkedRows = await this.fileRepo.find({
@@ -126,7 +177,7 @@ export class DiskImportService {
       const { quality } = parseReleaseQuality(filename);
       let size = 0;
       try {
-        size = fs.statSync(abs).size;
+        size = (await fsp.stat(abs)).size;
       } catch {
         /* ignore */
       }
@@ -383,7 +434,7 @@ export class DiskImportService {
     this.logger.log(`Disk library scan started — folder="${resolved}"`);
     let stat: fs.Stats;
     try {
-      stat = fs.statSync(resolved);
+      stat = await fsp.stat(resolved);
     } catch {
       throw new BadRequestException(
         `Path "${resolved}" does not exist or is not accessible`,
@@ -393,20 +444,29 @@ export class DiskImportService {
       throw new BadRequestException(`Path "${resolved}" is not a directory`);
     }
 
-    const videoFiles = this.collectVideoFiles(resolved, 0);
+    const videoFiles = await this.collectVideoFiles(resolved, 0);
     if (!videoFiles.length) return [];
 
-    const allMedia = await this.mediaRepo.find({
+    const rows = await this.mediaRepo.find({
       select: ['id', 'title', 'originalTitle', 'year', 'type'],
     });
+    // Normalize once: matchMedia scans the whole list per file, and re-running
+    // the regexes there made the scan O(files x media) in regex work alone.
+    const allMedia: ScanMedia[] = rows.map((m) => ({
+      ...m,
+      normTitle: normalizeTitle(m.title),
+      normOriginal: normalizeTitle(m.originalTitle ?? ''),
+    }));
 
     // `buildCandidate` may invent a fresh season / episode slot for any file
     // that references one we haven't pulled metadata for yet. Collect the
     // owning media so we can backfill those rows (titles, overviews, stills)
     // via the shared series refresh, instead of leaving them bare in the UI.
     const dirty = new Set<number>();
-    const candidates = await Promise.all(
-      videoFiles.map((f) => this.buildCandidate(f, allMedia, dirty)),
+    const candidates = await mapWithConcurrency(
+      videoFiles,
+      SCAN_CONCURRENCY,
+      (f) => this.buildCandidate(f, allMedia, dirty),
     );
     for (const mediaId of dirty) {
       try {
@@ -536,19 +596,22 @@ export class DiskImportService {
 
   // ---------------------------------------------------------------------------
 
-  private collectVideoFiles(dir: string, depth: number): string[] {
+  private async collectVideoFiles(
+    dir: string,
+    depth: number,
+  ): Promise<string[]> {
     if (depth > 3) return [];
     const files: string[] = [];
     let entries: fs.Dirent[];
     try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
+      entries = await fsp.readdir(dir, { withFileTypes: true });
     } catch {
       return [];
     }
     for (const entry of entries) {
       const fullPath = path.join(dir, entry.name);
       if (entry.isDirectory()) {
-        files.push(...this.collectVideoFiles(fullPath, depth + 1));
+        files.push(...(await this.collectVideoFiles(fullPath, depth + 1)));
       } else if (VIDEO_EXTS.has(path.extname(entry.name).toLowerCase())) {
         files.push(fullPath);
       }
@@ -558,13 +621,13 @@ export class DiskImportService {
 
   private async buildCandidate(
     filePath: string,
-    allMedia: Pick<Media, 'id' | 'title' | 'originalTitle' | 'year' | 'type'>[],
+    allMedia: ScanMedia[],
     dirtyMediaIds?: Set<number>,
   ): Promise<ScanCandidate> {
     const filename = path.basename(filePath);
     let size = 0;
     try {
-      size = fs.statSync(filePath).size;
+      size = (await fsp.stat(filePath)).size;
     } catch {
       /* ignore */
     }
@@ -572,7 +635,7 @@ export class DiskImportService {
     const { quality } = parseReleaseQuality(filename);
     const epNums = this.naming.parseEpisodeNumbers(filename);
     const extractedTitle = this.extractTitle(filename);
-    const matched = this.matchMedia(extractedTitle, allMedia);
+    const matched = matchMedia(extractedTitle, allMedia);
 
     let episodeId: number | null = null;
     let episodeTitle: string | null = null;
@@ -649,38 +712,4 @@ export class DiskImportService {
     return name.trim().toLowerCase();
   }
 
-  private matchMedia(
-    extractedTitle: string,
-    allMedia: Pick<Media, 'id' | 'title' | 'originalTitle' | 'year' | 'type'>[],
-  ): Pick<Media, 'id' | 'title' | 'originalTitle' | 'year' | 'type'> | null {
-    const norm = (s: string) =>
-      s
-        .toLowerCase()
-        .replace(/[^a-z0-9\s]/g, '')
-        .replace(/\s+/g, ' ')
-        .trim();
-
-    const target = norm(extractedTitle);
-    if (!target) return null;
-
-    // Exact match
-    let match = allMedia.find(
-      (m) => norm(m.title) === target || norm(m.originalTitle ?? '') === target,
-    );
-    if (match) return match;
-
-    // Target starts with media title (e.g. "inception 2010" -> "inception")
-    match = allMedia.find((m) => {
-      const mt = norm(m.title);
-      return mt.length >= 2 && target.startsWith(mt);
-    });
-    if (match) return match;
-
-    // Media title starts with target
-    match = allMedia.find((m) => {
-      const mt = norm(m.title);
-      return mt.length >= 3 && mt.startsWith(target);
-    });
-    return match ?? null;
-  }
 }

--- a/backend/src/modules/imports/disk-import.service.ts
+++ b/backend/src/modules/imports/disk-import.service.ts
@@ -309,7 +309,7 @@ export class DiskImportService {
       }
     }
     if (!media) {
-      throw new BadRequestException('Média introuvable après import');
+      throw new BadRequestException('Media not found after import');
     }
     if (media.library && media.library.id !== dto.libraryId) {
       throw new BadRequestException(
@@ -340,7 +340,7 @@ export class DiskImportService {
                 }
               : this.naming.parseEpisodeNumbers(filename);
           if (!epNums) {
-            errors.push(`${filename}: aucun motif SxxEyy détecté`);
+            errors.push(`${filename}: no SxxEyy pattern found`);
             continue;
           }
           const ep = await this.mediaService.ensureSeriesEpisode(media, epNums);
@@ -521,7 +521,7 @@ export class DiskImportService {
           fs.statSync(entry.filePath);
         } catch {
           errors.push(
-            `${path.basename(entry.filePath)}: fichier source introuvable`,
+            `${path.basename(entry.filePath)}: source file not found`,
           );
           continue;
         }

--- a/backend/src/modules/media/media-service/media-rescan.service.ts
+++ b/backend/src/modules/media/media-service/media-rescan.service.ts
@@ -7,6 +7,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import * as fs from 'fs';
+import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { Media } from '../entities/media.entity';
 import { MediaFile } from '../entities/media-file.entity';
@@ -35,6 +36,17 @@ import { relativePathUnderMediaRoot } from '../../../common/utils/media-path.uti
 import { VIDEO_EXTS } from '../../../common/constants/video-extensions';
 
 type ProbeResult = Awaited<ReturnType<FfprobeService['detectMediaFileInfo']>>;
+
+/** Sync fs on the event loop stalled every other request for the length of a
+ *  scan — worse on the network mounts these libraries usually live on. */
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fsp.access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 @Injectable()
 export class MediaRescanService {
@@ -78,14 +90,14 @@ export class MediaRescanService {
     const normPath = dbFile.relativePath?.replace(/\\/g, '/');
     if (!normPath) return;
     const absPath = path.join(mediaDir, normPath);
-    if (!fs.existsSync(absPath)) {
+    if (!(await pathExists(absPath))) {
       this.log.warn(`enrichMediaFileFromDisk: file not on disk — "${absPath}"`);
       return;
     }
 
     let diskSize: number;
     try {
-      diskSize = fs.statSync(absPath).size;
+      diskSize = (await fsp.stat(absPath)).size;
     } catch (err) {
       this.log.warn(
         `enrichMediaFileFromDisk: cannot stat "${absPath}"`,
@@ -189,7 +201,7 @@ export class MediaRescanService {
 
     let size = 0;
     try {
-      size = fs.statSync(absPath).size;
+      size = (await fsp.stat(absPath)).size;
     } catch {
       /* keep 0 — enrich re-stats anyway */
     }
@@ -346,7 +358,7 @@ export class MediaRescanService {
         mediaDir,
         file.relativePath.replace(/\\/g, '/'),
       );
-      if (!fs.existsSync(absPath)) {
+      if (!(await pathExists(absPath))) {
         this.log.warn(
           `analyzeMedia[#${mediaId}]: file off-disk, skipping "${absPath}"`,
         );
@@ -415,7 +427,7 @@ export class MediaRescanService {
     }
 
     const mediaDir = path.resolve(media.path);
-    if (!fs.existsSync(mediaDir)) {
+    if (!(await pathExists(mediaDir))) {
       try {
         fs.mkdirSync(mediaDir, { recursive: true });
         this.log.warn(
@@ -434,7 +446,11 @@ export class MediaRescanService {
     );
 
     // 1. Collect all video files on disk
-    const rawDiskFiles = this.collectVideoFilesRecursive(mediaDir, 0, mediaId);
+    const rawDiskFiles = await this.collectVideoFilesRecursive(
+      mediaDir,
+      0,
+      mediaId,
+    );
     const diskFiles: string[] = [];
     const diskRelPaths = new Set<string>();
     for (const f of rawDiskFiles) {
@@ -514,7 +530,7 @@ export class MediaRescanService {
 
       let diskSize: number;
       try {
-        diskSize = fs.statSync(absPath).size;
+        diskSize = (await fsp.stat(absPath)).size;
       } catch (err) {
         this.log.warn(
           `Rescan[media #${mediaId}]: cannot stat file for refresh (skipped) — path="${absPath}" relativePath="${normPath}"`,
@@ -637,7 +653,7 @@ export class MediaRescanService {
 
       let size = 0;
       try {
-        size = fs.statSync(absPath).size;
+        size = (await fsp.stat(absPath)).size;
       } catch (err) {
         this.log.error(
           `Rescan[media #${mediaId}]: cannot stat new file — path="${absPath}"`,
@@ -916,11 +932,11 @@ export class MediaRescanService {
     return { streamInfo, quality };
   }
 
-  private collectVideoFilesRecursive(
+  private async collectVideoFilesRecursive(
     dir: string,
     depth: number,
     mediaId: number,
-  ): string[] {
+  ): Promise<string[]> {
     if (depth > 3) {
       this.log.warn(
         `Rescan[media #${mediaId}]: skipping subfolder (max depth 3) — "${dir}"`,
@@ -930,7 +946,7 @@ export class MediaRescanService {
     const files: string[] = [];
     let entries: fs.Dirent[];
     try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
+      entries = await fsp.readdir(dir, { withFileTypes: true });
     } catch (err) {
       this.log.error(
         `Rescan[media #${mediaId}]: cannot read directory (permissions, missing path, or I/O) — "${dir}"`,
@@ -942,7 +958,11 @@ export class MediaRescanService {
       const fullPath = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         files.push(
-          ...this.collectVideoFilesRecursive(fullPath, depth + 1, mediaId),
+          ...(await this.collectVideoFilesRecursive(
+            fullPath,
+            depth + 1,
+            mediaId,
+          )),
         );
       } else if (VIDEO_EXTS.has(path.extname(entry.name).toLowerCase())) {
         files.push(fullPath);

--- a/backend/src/modules/media/media-service/media-rescan.service.ts
+++ b/backend/src/modules/media/media-service/media-rescan.service.ts
@@ -168,7 +168,7 @@ export class MediaRescanService {
     const { media, absPath } = p;
     const relativePath = relativePathUnderMediaRoot(media.path, absPath);
     if (!relativePath) {
-      return { error: 'fichier en dehors du dossier du média' };
+      return { error: 'file outside the media folder' };
     }
 
     const existing = await this.mediaFileRepo.findOne({
@@ -188,7 +188,7 @@ export class MediaRescanService {
     if (media.type === MediaType.SERIES) {
       const epNums = p.epNums ?? this.naming.parseEpisodeNumbers(filename);
       if (!epNums) {
-        return { error: 'aucun motif SxxEyy détecté' };
+        return { error: 'no SxxEyy pattern found' };
       }
       const { ep, created: c } = await this.ensureSeasonAndEpisode(
         media,


### PR DESCRIPTION
Reported by a user: *"when scanning files, i can't do anything on the UI."*

It is a backend problem, not a frontend one. Three things in the scan path compete for the single thread that also answers every API call, so nothing else gets served until the scan ends.

## 1. The disk I/O was synchronous

The directory walks and the per-file stats used `readdirSync` / `statSync`. Measured over a 36,614-file tree on a warm local SSD, with a 10 ms timer standing in for incoming requests:

| walk | duration | requests served during it | worst wait |
|---|---|---|---|
| sync | 153 ms | **0 / 15 expected** | 153 ms |
| async | 562 ms | 56 / 56 | 3 ms |

Zero. The event loop does not turn once for the length of a synchronous walk. Media libraries almost always live on a network mount, where per-file latency turns that dead window into seconds or minutes.

## 2. `scanFolder` fanned every file out at once

`Promise.all` over every video file, where each candidate can issue season lookups and inserts. The pool holds 30 connections and is shared with everything else the server is doing, so a few thousand files starved it — unrelated requests waited for a connection until the scan drained. Bounded to 8 via `mapWithConcurrency`, the helper and the limit the metadata paths already use.

## 3. `matchMedia` re-normalized the whole library per file

Two regexes over every library title, for every file, up to three times per file across its fallback passes. A few thousand files against a few thousand titles is tens of millions of regex passes on that same thread. Normalization now happens once per scan.

## The matcher, and what its test caught

`matchMedia` moved to module scope unchanged, so its behaviour is pinned by a test that needs no service wiring. Two of the six cases I first wrote were wrong, and the test corrected me rather than the reverse:

- callers hand it the output of `extractTitle`, which has already turned dots and underscores into spaces — a dot-separated filename never reaches it
- the three-character guard sits on the **library title**, not on the filename, so a two-letter fragment can still match a longer title

Both are now written down as the contract they are.

## Trade-off

The async walk is ~3.7x slower in wall-clock on warm local storage. That is deliberate: the scan gives the thread back between files instead of holding it to the end. In absolute terms it is a fraction of a second, against a scan that also runs ffprobe.


## Also in here: the scan error messages go back to English

Five user-facing strings on the import and rescan paths were written in French, while the backend is English-only and the client owns translation. Four sit on the orphan-relink and disk-scan error lists, one is a `BadRequestException` raised after an import. The `fichier` field in the SubSynchro provider stays — it is a key in that provider'''s own API response, not a message.

## Test plan

- Backend suite green: 1,611 tests, 144 files. Type-check clean.
- New spec pins the matcher's semantics (case/punctuation, original title, trailing noise, truncation, the length guard, the exact-over-prefix precedence).
- **The original symptom was not reproduced.** It happens on the reporter's server, with their library on their mount; I have neither, and did not restart a backend. The diagnosis comes from reading the path, and the measurement above validates the mechanism on a synthetic tree only.
- The frontend was checked and ruled out: `task.progress` is emitted once per media with a 50 ms yield between them, so at most ~20 events/s — nowhere near a freeze.