### PR TITLE
feat(plugin-ui): a speed format, a clipped column, and a table that refreshes

### DIFF
--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -183,7 +183,7 @@ export type BadgeTone =
  *  in the type rather than merely undocumented. */
 export interface TableSubValue {
   key: string;
-  format?: 'date' | 'bytes' | 'percent';
+  format?: 'date' | 'bytes' | 'percent' | 'speed';
   labelKeys?: Record<string, string>;
   badges?: Record<string, BadgeTone>;
 }
@@ -192,7 +192,7 @@ export interface TableSubValue {
 export interface TableColumn {
   key: string;
   labelKey: string;
-  format?: 'date' | 'bytes' | 'percent';
+  format?: 'date' | 'bytes' | 'percent' | 'speed';
   /** Maps a cell value to a translate key — a status column renders its raw enum otherwise. */
   labelKeys?: Record<string, string>;
   /** Renders the cell as a badge, the value picking its tone. `*` covers every other value,
@@ -201,6 +201,9 @@ export interface TableColumn {
   badges?: Record<string, BadgeTone>;
   /** Keeps the cell on one line. Implied for `format`ted and badged cells. */
   nowrap?: boolean;
+  /** Clips the value to one line with an ellipsis, full text on hover. For the one column
+   *  carrying free text (a release name), which otherwise wraps a row over several lines. */
+  truncate?: boolean;
   /** A second line under the cell's own value. A release's quality and tracker belong with
    *  its name; as columns of their own they cost width the title needed. */
   subValues?: TableSubValue[];
@@ -273,6 +276,10 @@ export interface PlayerDeclaration {
   preRollRoute: string;
 }
 
+/** Floor for both `refreshMs` and the coalescing of `refreshOn`: a list refetch is a round
+ *  trip per viewer, and no queue reads usefully faster than this. */
+export const TABLE_REFRESH_MIN_MS = 2000;
+
 /** One `table` filter — its current value is sent to `list` as a query param named by
  *  `key`; an empty value is omitted. Filtering itself is the plugin's job, core only forwards it. */
 export type TableFilter =
@@ -295,6 +302,13 @@ export interface TableConfigPage extends ConfigPageBase {
    *  paged resource renders empty against an array-only reader. */
   paged?: boolean;
   pageSize?: number;
+  /** Re-fetch this often while the page is on screen, for a list whose values move on
+   *  their own. Clamped to {@link TABLE_REFRESH_MIN_MS}; polling stops while the tab is
+   *  hidden. Prefer `refreshOn` — this is for values no event announces. */
+  refreshMs?: number;
+  /** Core SSE event types that re-fetch the list as they arrive, coalesced to at most one
+   *  fetch per {@link TABLE_REFRESH_MIN_MS}. */
+  refreshOn?: string[];
   /** List-scope actions (clear-all and the like), distinct from `rowActions`. */
   listActions?: {
     labelKey: string;

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2417,6 +2417,7 @@
   },
   "data_table": {
     "load_error": "Liste konnte nicht geladen werden.",
-    "empty": "Nichts anzuzeigen."
+    "empty": "Nichts anzuzeigen.",
+    "refresh": "Aktualisieren"
   }
 }

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2445,6 +2445,7 @@
   },
   "data_table": {
     "load_error": "Unable to load the list.",
-    "empty": "Nothing to show."
+    "empty": "Nothing to show.",
+    "refresh": "Refresh"
   }
 }

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2417,6 +2417,7 @@
   },
   "data_table": {
     "load_error": "No se pudo cargar la lista.",
-    "empty": "Nada que mostrar."
+    "empty": "Nada que mostrar.",
+    "refresh": "Actualizar"
   }
 }

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2445,6 +2445,7 @@
   },
   "data_table": {
     "load_error": "Impossible de charger la liste.",
-    "empty": "Rien à afficher."
+    "empty": "Rien à afficher.",
+    "refresh": "Actualiser"
   }
 }

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2417,6 +2417,7 @@
   },
   "data_table": {
     "load_error": "Impossibile caricare l'elenco.",
-    "empty": "Niente da visualizzare."
+    "empty": "Niente da visualizzare.",
+    "refresh": "Aggiorna"
   }
 }

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2417,6 +2417,7 @@
   },
   "data_table": {
     "load_error": "Não foi possível carregar a lista.",
-    "empty": "Nada para exibir."
+    "empty": "Nada para exibir.",
+    "refresh": "Atualizar"
   }
 }

--- a/client/src/app/features/plugin-view/plugin-view.html
+++ b/client/src/app/features/plugin-view/plugin-view.html
@@ -55,6 +55,8 @@
         [defaultSortKey]="view.defaultSortKey ?? null"
         [paged]="view.paged ?? false"
         [pageSize]="view.pageSize ?? 20"
+        [refreshMs]="view.refreshMs ?? 0"
+        [refreshOn]="view.refreshOn ?? []"
         [resolveAction]="tableResolveAction"
       />
     } @else if (formPage(); as page) {

--- a/client/src/app/shared/components/data-table/data-table.html
+++ b/client/src/app/shared/components/data-table/data-table.html
@@ -3,8 +3,20 @@
     @if (titleKey()) {
       <h2 class="card-title text-lg">{{ titleKey() | translate }}</h2>
     }
-    @if (listActions().length) {
-      <div class="flex gap-2 shrink-0">
+    <div class="flex gap-2 shrink-0">
+      <button
+        type="button"
+        class="btn btn-outline btn-sm"
+        (click)="refreshNow()"
+        [disabled]="loading()"
+        [attr.aria-label]="'data_table.refresh' | translate"
+      >
+        @if (loading()) {
+          <span class="loading loading-spinner loading-xs"></span>
+        }
+        {{ 'data_table.refresh' | translate }}
+      </button>
+      @if (listActions().length) {
         @for (action of listActions(); track action.path) {
           <button
             type="button"
@@ -18,8 +30,8 @@
             {{ action.labelKey | translate }}
           </button>
         }
-      </div>
-    }
+      }
+    </div>
   </div>
 
   @if (filters().length) {
@@ -83,8 +95,16 @@
                     @case ('date') { {{ cellDate(row[col.key]) | localeDate }} }
                     @case ('bytes') { {{ cellBytes(row[col.key]) }} }
                     @case ('percent') { {{ cellPercent(row[col.key]) }} }
+                    @case ('speed') { {{ cellSpeed(row[col.key]) }} }
                     @default {
-                      @if (detailText(col, row); as detail) {
+                      @if (col.truncate) {
+                        <!-- The width cap is what makes the ellipsis appear: a table cell sizes
+                             to its content otherwise, however narrow the viewport. -->
+                        <span
+                          class="block truncate max-w-[12rem] sm:max-w-xs lg:max-w-md"
+                          [title]="cellLabel(col, row[col.key])"
+                        >{{ cellLabel(col, row[col.key]) }}</span>
+                      } @else if (detailText(col, row); as detail) {
                         <button type="button" class="link link-hover" (click)="openDetail(col, row)"
                           [attr.aria-label]="(col.detailTitleKey ?? col.labelKey) | translate">
                           @if (badgeClass(col, row[col.key]); as badge) {

--- a/client/src/app/shared/components/data-table/data-table.spec.ts
+++ b/client/src/app/shared/components/data-table/data-table.spec.ts
@@ -1,4 +1,4 @@
-import { provideZonelessChangeDetection } from '@angular/core';
+import { WritableSignal, provideZonelessChangeDetection, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
@@ -7,6 +7,7 @@ import { Subject, of } from 'rxjs';
 import { vi } from 'vitest';
 import { DataTableComponent } from './data-table';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
+import { SseService } from '../../../core/services/sse.service';
 import { ListAction, RowAction, TableColumn, TableFilter, TableRow } from './data-table.types';
 
 const COLUMNS: TableColumn[] = [{ key: 'name', labelKey: 'x.name' }];
@@ -27,6 +28,9 @@ async function createComponent(opts: {
   defaultSortKey?: string;
   paged?: boolean;
   pageSize?: number;
+  refreshMs?: number;
+  refreshOn?: string[];
+  sseEvent?: WritableSignal<{ type: string } | null>;
 }) {
   TestBed.configureTestingModule({
     providers: [
@@ -38,6 +42,10 @@ async function createComponent(opts: {
       { provide: HttpClient, useValue: opts.http as unknown as HttpClient },
       { provide: Router, useValue: { navigateByUrl: vi.fn() } },
       { provide: ConfirmationService, useValue: { confirm: () => Promise.resolve(true) } },
+      {
+        provide: SseService,
+        useValue: { lastEvent: opts.sseEvent ?? signal(null) } as unknown as SseService,
+      },
     ],
   });
   const fixture = TestBed.createComponent(DataTableComponent);
@@ -51,6 +59,8 @@ async function createComponent(opts: {
   if (opts.defaultSortKey) fixture.componentRef.setInput('defaultSortKey', opts.defaultSortKey);
   if (opts.paged) fixture.componentRef.setInput('paged', opts.paged);
   if (opts.pageSize) fixture.componentRef.setInput('pageSize', opts.pageSize);
+  if (opts.refreshMs) fixture.componentRef.setInput('refreshMs', opts.refreshMs);
+  if (opts.refreshOn) fixture.componentRef.setInput('refreshOn', opts.refreshOn);
   fixture.detectChanges();
   await fixture.whenStable();
   await new Promise((r) => setTimeout(r, 0));
@@ -435,5 +445,104 @@ describe('DataTableComponent — declared filters', () => {
       filters: [{ kind: 'bogus' } as unknown as TableFilter],
     });
     expect(fixture.nativeElement.querySelectorAll('input[type="search"], select')).toHaveLength(0);
+  });
+});
+
+describe('DataTableComponent — formatting the moving values', () => {
+  it('states the unit on a speed, so a number is not read as a size', async () => {
+    const fixture = await createComponent({
+      http: { get: () => of([{ id: 1, bytesPerSecond: 1536 }]) },
+      columns: [{ key: 'bytesPerSecond', labelKey: 'x.speed', format: 'speed' }],
+    });
+    expect(fixture.nativeElement.textContent).toContain('1.5 KB/s');
+  });
+
+  it('leaves a non-numeric speed alone rather than printing NaN/s', async () => {
+    const fixture = await createComponent({
+      http: { get: () => of([{ id: 1, bytesPerSecond: null }]) },
+      columns: [{ key: 'bytesPerSecond', labelKey: 'x.speed', format: 'speed' }],
+    });
+    expect(fixture.nativeElement.textContent).not.toContain('/s');
+  });
+
+  it('clips a truncated cell to one line and keeps the full text reachable', async () => {
+    const long = 'A release name long enough to wrap a phone over several lines';
+    const fixture = await createComponent({
+      http: { get: () => of([{ id: 1, title: long }]) },
+      columns: [{ key: 'title', labelKey: 'x.title', truncate: true }],
+    });
+    const span = fixture.nativeElement.querySelector('td span.truncate') as HTMLElement;
+    expect(span).toBeTruthy();
+    expect(span.getAttribute('title')).toBe(long);
+    // A truncated cell must not also be nowrap: that would size the column to the
+    // content and there would be nothing left to clip.
+    expect(fixture.componentInstance.cellNowrap({ key: 'title', labelKey: 'x', truncate: true })).toBe(false);
+  });
+});
+
+describe('DataTableComponent — refreshing', () => {
+  it('reloads on demand', async () => {
+    const get = vi.fn(() => of([{ id: 1 }]));
+    const fixture = await createComponent({ http: { get } });
+    const before = get.mock.calls.length;
+    await fixture.componentInstance.refreshNow();
+    expect(get.mock.calls.length).toBe(before + 1);
+  });
+
+  it('coalesces a burst of events into one fetch, then catches up with the last', async () => {
+    const get = vi.fn(() => of([{ id: 1 }]));
+    const event = signal<{ type: string } | null>(null);
+    // The component has to exist before the clock is frozen: creating it awaits a real timer.
+    const fixture = await createComponent({
+      http: { get },
+      refreshOn: ['queue.updated'],
+      sseEvent: event,
+    });
+    vi.useFakeTimers();
+    try {
+      const before = get.mock.calls.length;
+
+      event.set({ type: 'queue.updated' });
+      fixture.detectChanges();
+      expect(get.mock.calls.length).toBe(before + 1);
+
+      // Same window: the second and third must not each cost a round trip...
+      event.set({ type: 'queue.updated', ...{ n: 2 } });
+      fixture.detectChanges();
+      event.set({ type: 'queue.updated', ...{ n: 3 } });
+      fixture.detectChanges();
+      expect(get.mock.calls.length).toBe(before + 1);
+
+      // ...but the last one must still land, or the table keeps a state the server left.
+      await vi.advanceTimersByTimeAsync(2100);
+      expect(get.mock.calls.length).toBe(before + 2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('ignores an event type the page did not declare', async () => {
+    const get = vi.fn(() => of([{ id: 1 }]));
+    const event = signal<{ type: string } | null>(null);
+    const fixture = await createComponent({ http: { get }, refreshOn: ['queue.updated'], sseEvent: event });
+    const before = get.mock.calls.length;
+    event.set({ type: 'something.else' });
+    fixture.detectChanges();
+    expect(get.mock.calls.length).toBe(before);
+  });
+
+  it('refreshes nothing while nobody is looking at the page', async () => {
+    const get = vi.fn(() => of([{ id: 1 }]));
+    const event = signal<{ type: string } | null>(null);
+    const fixture = await createComponent({ http: { get }, refreshOn: ['queue.updated'], sseEvent: event });
+    const spy = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+    try {
+      const before = get.mock.calls.length;
+      event.set({ type: 'queue.updated' });
+      fixture.detectChanges();
+      expect(get.mock.calls.length).toBe(before);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -1,16 +1,21 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, computed, inject, input, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, computed, effect, inject, input, signal, untracked } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
-import { formatBytes } from '../../utils/download-format';
+import { formatBytes, formatSpeed } from '../../utils/download-format';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
+import { SseService } from '../../../core/services/sse.service';
 import { PaginationComponent } from '../pagination/pagination';
 import { BadgeTone, CellValue, ListAction, PagedResult, RowAction, TableColumn, TableFilter, TableRow, TableSubValue } from './data-table.types';
 
 /** Keystroke-to-request debounce for a `search` filter — see `onSearchInput`. */
 const SEARCH_DEBOUNCE_MS = 300;
+
+/** Mirrors the contract's `TABLE_REFRESH_MIN_MS`: one refetch per viewer per this window,
+ *  whatever the declared interval or the rate of the events driving it. */
+const REFRESH_MIN_MS = 2000;
 
 /** The only classes a declared badge can resolve to. A `badges` entry is JSON from a
  *  manifest, so it is looked up here and never interpolated into the rendered `class`. */
@@ -63,6 +68,10 @@ export class DataTableComponent implements OnInit {
   readonly pageSize = input(20);
   /** Declared `search`/`select` filters, rendered above the table. */
   readonly filters = input<readonly TableFilter[]>([]);
+  /** Poll the list this often while the page is on screen; 0 disables it. */
+  readonly refreshMs = input(0);
+  /** SSE event types that reload the list as they arrive. */
+  readonly refreshOn = input<readonly string[]>([]);
 
   readonly rows = signal<TableRow[]>([]);
   readonly loading = signal(true);
@@ -81,21 +90,66 @@ export class DataTableComponent implements OnInit {
   readonly filterValues = signal<Record<string, string>>({});
   private searchDebounce: ReturnType<typeof setTimeout> | null = null;
   private loadSeq = 0;
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  private trailingRefresh: ReturnType<typeof setTimeout> | null = null;
+  private lastRefreshAt = 0;
 
   constructor() {
+    const sse = inject(SseService);
+    effect(() => {
+      const event = sse.lastEvent();
+      if (!event || !this.refreshOn().includes(event.type)) return;
+      untracked(() => this.requestRefresh());
+    });
     inject(DestroyRef).onDestroy(() => {
       if (this.searchDebounce) clearTimeout(this.searchDebounce);
+      if (this.refreshTimer) clearInterval(this.refreshTimer);
+      if (this.trailingRefresh) clearTimeout(this.trailingRefresh);
     });
   }
 
   ngOnInit(): void {
     void this.loadRows();
+    const declared = this.refreshMs();
+    if (declared > 0) {
+      this.refreshTimer = setInterval(() => this.requestRefresh(), Math.max(declared, REFRESH_MIN_MS));
+    }
   }
 
-  async loadRows(): Promise<void> {
+  /** The button: the user asked, so the reload shows itself. */
+  async refreshNow(): Promise<void> {
+    this.lastRefreshAt = Date.now();
+    await this.loadRows();
+  }
+
+  /**
+   * Every automatic trigger — a poll tick, an event the page declared — funnels here, so a
+   * burst of events costs one fetch. The trailing timer keeps the last trigger rather than
+   * dropping it, which is what would leave the table showing a state the server has left.
+   * Nothing fires while the tab is hidden: a backgrounded queue is not being read.
+   */
+  private requestRefresh(): void {
+    if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return;
+    const waitMs = REFRESH_MIN_MS - (Date.now() - this.lastRefreshAt);
+    if (waitMs > 0) {
+      if (!this.trailingRefresh) {
+        this.trailingRefresh = setTimeout(() => {
+          this.trailingRefresh = null;
+          this.requestRefresh();
+        }, waitMs);
+      }
+      return;
+    }
+    this.lastRefreshAt = Date.now();
+    void this.loadRows({ silent: true });
+  }
+
+  /** `silent` keeps the spinner and the dimming off — an automatic reload must not make the
+   *  table flicker under someone reading it. */
+  async loadRows(opts?: { silent?: boolean }): Promise<void> {
     // Only the newest reload may write: a filtered scan can resolve after a later, narrower one.
     const seq = ++this.loadSeq;
-    this.loading.set(true);
+    if (!opts?.silent) this.loading.set(true);
     this.listError.set('');
     try {
       let params = new HttpParams();
@@ -116,7 +170,7 @@ export class DataTableComponent implements OnInit {
     } catch {
       if (seq === this.loadSeq) this.listError.set(this.translate.instant(this.loadErrorKey()));
     } finally {
-      if (seq === this.loadSeq) this.loading.set(false);
+      if (seq === this.loadSeq && !opts?.silent) this.loading.set(false);
     }
   }
 
@@ -166,6 +220,10 @@ export class DataTableComponent implements OnInit {
     return typeof value === 'number' ? `${Math.round(value)}%` : String(value ?? '');
   }
 
+  cellSpeed(value: CellValue): string {
+    return typeof value === 'number' ? formatSpeed(value) : String(value ?? '');
+  }
+
   /**
    * The badge class for a cell, or null to render it as text. `*` catches every value the
    * column didn't name; an unknown tone falls back to `ghost` rather than reaching the DOM.
@@ -204,13 +262,17 @@ export class DataTableComponent implements OnInit {
         return this.cellBytes(value);
       case 'percent':
         return this.cellPercent(value);
+      case 'speed':
+        return this.cellSpeed(value);
       default:
         return this.cellLabel(sub, value);
     }
   }
 
-  /** A formatted value, a badge and a declared `nowrap` are all atomic — none should wrap. */
+  /** A formatted value, a badge and a declared `nowrap` are all atomic — none should wrap.
+   *  A truncated cell clips instead, so it must not claim the row's whole width. */
   cellNowrap(col: TableColumn): boolean {
+    if (col.truncate) return false;
     return col.nowrap === true || col.format !== undefined || col.badges !== undefined;
   }
 

--- a/client/src/app/shared/components/data-table/data-table.types.ts
+++ b/client/src/app/shared/components/data-table/data-table.types.ts
@@ -14,7 +14,7 @@ export type BadgeTone =
 /** One value rendered under a cell's own. One level only: it carries no `subValues`. */
 export interface TableSubValue {
   key: string;
-  format?: 'date' | 'bytes' | 'percent';
+  format?: 'date' | 'bytes' | 'percent' | 'speed';
   labelKeys?: Record<string, string>;
   badges?: Record<string, BadgeTone>;
 }
@@ -22,13 +22,15 @@ export interface TableSubValue {
 export interface TableColumn {
   key: string;
   labelKey: string;
-  format?: 'date' | 'bytes' | 'percent';
+  format?: 'date' | 'bytes' | 'percent' | 'speed';
   /** Maps a cell value to a translate key — a status column renders its raw enum otherwise. */
   labelKeys?: Record<string, string>;
   /** Renders the cell as a badge, the value picking its tone; `*` covers every other value. */
   badges?: Record<string, BadgeTone>;
   /** Keeps the cell on one line. Implied for `format`ted and badged cells. */
   nowrap?: boolean;
+  /** One line, clipped with an ellipsis, full text on hover — for the free-text column. */
+  truncate?: boolean;
   /** A second line of values under the cell's own. */
   subValues?: TableSubValue[];
   /** Another field of the row; when it has a value the cell opens a dialog showing it. */


### PR DESCRIPTION
Three additions to the `table` view kind, each one a defect a user reported on the download plugin's queue page that core had no way to express. The plugin side is a separate change in its own repo; this is the half that makes it possible.

## `format: 'speed'`

A rate declared as `bytes` printed `1.5 KB` — it reads as a size and leaves the interval to be guessed. The new format reuses `formatSpeed`, which core already uses for the activity queue, and renders `1.5 KB/s`.

## `truncate`

Clips one column to a single line with an ellipsis, full value in the cell's `title`. A free-text column — a release name — otherwise wraps a row over four or five lines on a phone and pushes every other column off the screen.

It **suppresses** `nowrap` rather than adding to it: a cell that sizes to its content has nothing left to clip, so the two are mutually exclusive by construction.

## `refreshMs` and `refreshOn`

Core already emits the SSE event `queue.updated` when a plugin publishes `acquisition.queue.changed`, so rows entering and leaving a list are an event, not a poll. What no event announces is the values *between* two such events — a percentage, a speed — and that is all the interval is for. A page declares either, or both.

Every trigger funnels through one coalescer:

- at most one fetch per 2 s, whatever the rate of the events driving it
- a trailing timer, so the last trigger still lands rather than being dropped — otherwise the table keeps showing a state the server has left
- nothing at all while the tab is hidden: a backgrounded queue is not being read
- `silent` reload, so an automatic refresh does not flicker the table under someone reading it

The refresh button is unconditional. No manifest asks for it and every list can use it.

## Compatibility

All three degrade silently in the other direction too: an older core renders an unknown `format` as the raw value and ignores an unknown flag, so a plugin can adopt these without moving its `fliks` range.

## Test plan

- 7 new cases: the speed unit, a non-numeric speed not becoming `NaN/s`, the clipped cell's class/title/nowrap suppression, on-demand reload, burst coalescing plus the trailing catch-up, an undeclared event type ignored, and nothing refreshing while the page is hidden.
- Client suite green: 451 tests, 55 files. Backend type-check clean.
- Two of those tests initially failed on my own mistake, not the code: installing fake timers before creating the component left its `setTimeout(0)` unresolved forever. The component is created first now.