### PR TITLE
fix(subtitles): announce a list an import or an OCR run changed

### DIFF
--- a/backend/src/modules/scheduler/events.service.ts
+++ b/backend/src/modules/scheduler/events.service.ts
@@ -45,6 +45,13 @@ export type SseEvent =
       automatic?: boolean;
     }
   | {
+      // A media's subtitle list gained or lost a row without any client having asked for it:
+      // an import storing embedded tracks, an OCR run creating its PROCESSING placeholder.
+      // Carries no title and raises no toast — it exists so the list stops being stale.
+      type: 'subtitle.list_changed';
+      mediaId: number;
+    }
+  | {
       // Machine-translation progress for a PROCESSING subtitle row. `progress`
       // is 0–100; `subtitleId` is the placeholder row the client shows.
       type: 'subtitle.translation_progress';

--- a/backend/src/modules/subtitles/embedded-subtitle.announce.spec.ts
+++ b/backend/src/modules/subtitles/embedded-subtitle.announce.spec.ts
@@ -1,0 +1,45 @@
+import { EmbeddedSubtitleService } from './embedded-subtitle.service';
+
+/** The client caches a media's subtitle list and only drops it on an event. An import runs this
+ *  service on its own, so the announcement is the only thing standing between a stored image
+ *  track and a list that stays stale until its TTL lapses. */
+describe('EmbeddedSubtitleService — announcing what an import stored', () => {
+  const build = (streams: unknown[]) => {
+    const emit = jest.fn();
+    const saved = streams.map((_, i) => ({ id: i + 1 }));
+    const service = new EmbeddedSubtitleService(
+      { detectEmbeddedSubtitles: jest.fn().mockResolvedValue(streams) } as never,
+      {
+        find: jest.fn().mockResolvedValue([]),
+        delete: jest.fn().mockResolvedValue(undefined),
+        save: jest.fn().mockResolvedValue(saved),
+      } as never,
+      { findOne: jest.fn().mockResolvedValue({ id: 7, path: '/library/a' }) } as never,
+      { findOne: jest.fn().mockResolvedValue({ id: 42, relativePath: 'a.mkv' }) } as never,
+      { get: jest.fn().mockResolvedValue('false') } as never,
+      { emit } as never,
+    );
+    return { service, emit };
+  };
+
+  const imageStream = {
+    streamIndex: 5,
+    language: 'fr',
+    forced: false,
+    hearingImpaired: false,
+    codec: 'hdmv_pgs_subtitle',
+    isImageBased: true,
+  };
+
+  it('announces the media whose list just changed', async () => {
+    const { service, emit } = build([imageStream]);
+    await service.detectAndStore(7, 42);
+    expect(emit).toHaveBeenCalledWith({ type: 'subtitle.list_changed', mediaId: 7 });
+  });
+
+  it('stays quiet when the probe found nothing to store', async () => {
+    const { service, emit } = build([]);
+    await service.detectAndStore(7, 42);
+    expect(emit).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/subtitles/embedded-subtitle.service.ts
+++ b/backend/src/modules/subtitles/embedded-subtitle.service.ts
@@ -8,6 +8,7 @@ import { MediaFile } from '../media/entities/media-file.entity';
 import { FfprobeService } from './ffprobe.service';
 import { SettingsService } from '../settings/settings.service';
 import { SubtitleProviderType, SubtitleStatus } from '../../common/enums';
+import { EventsService } from '../scheduler/events.service';
 
 import { normalizeLanguageCode } from '../../common/constants/app-languages';
 
@@ -24,6 +25,7 @@ export class EmbeddedSubtitleService {
     @InjectRepository(MediaFile)
     private readonly mediaFileRepo: Repository<MediaFile>,
     private readonly settings: SettingsService,
+    private readonly events: EventsService,
   ) {}
 
   async detectAndStore(
@@ -97,6 +99,9 @@ export class EmbeddedSubtitleService {
     this.logger.log(
       `Refreshed embedded subtitles for mediaFile #${mediaFileId}: ${created.length} stored`,
     );
+    // An import runs this on its own; nothing the client did invalidated the subtitle list it
+    // already holds, so without this the image tracks stay invisible until the TTL lapses.
+    this.events.emit({ type: 'subtitle.list_changed', mediaId });
 
     return created;
   }

--- a/backend/src/modules/subtitles/subtitle-ocr.service.ts
+++ b/backend/src/modules/subtitles/subtitle-ocr.service.ts
@@ -148,6 +148,10 @@ export class SubtitleOcrService {
       sourceStreamIndex: source.streamIndex,
     } as any);
 
+    // The row exists as PROCESSING from here; without this the UI only learns of the run
+    // when it ends, so a long OCR looks like nothing is happening.
+    this.events.emit({ type: 'subtitle.list_changed', mediaId: source.mediaId });
+
     void this.runOcr(placeholder.id, source, options.automatic).catch((err) => {
       this.log.error(`OCR run crashed for sub #${subtitleId}: ${err}`);
     });

--- a/client/src/app/core/services/sse.service.ts
+++ b/client/src/app/core/services/sse.service.ts
@@ -150,9 +150,10 @@ export class SseService implements OnDestroy {
       case 'subtitle.synced':
       case 'subtitle.downloaded':
       case 'subtitle.failed':
-        // These land asynchronously (e.g. an OCR or sync finishing minutes after
-        // the request returned), so no client mutation invalidated the cached
-        // subtitle list — drop the media cache here so the next fetch is fresh.
+      case 'subtitle.list_changed':
+        // These land asynchronously (an import storing embedded tracks, an OCR run starting
+        // or ending minutes after the request returned), so no client mutation invalidated
+        // the cached subtitle list — drop the media cache here so the next fetch is fresh.
         void invalidatePrefix('/api/media');
         // Toasts are handled by the media-detail component (only on the right page).
         break;

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -608,7 +608,10 @@ export class SubtitlesModalComponent {
     this.lastSseEvent = event;
 
     const automatic = event['automatic'] === true;
-    if (event.type === 'subtitle.synced') {
+    if (event.type === 'subtitle.list_changed') {
+      // Carries no outcome to announce — it says the list moved, nothing more.
+      void this.loadSubtitles(mediaId);
+    } else if (event.type === 'subtitle.synced') {
       if (!automatic) this.toast.success(this.translate.instant('sse.subtitle_synced'));
       void this.loadSubtitles(mediaId);
     } else if (event.type === 'subtitle.downloaded') {


### PR DESCRIPTION
Reported after an auto-import: the subtitle list showed nothing but the placeholder rows the language profile generates, and an OCR run in flight was nowhere to be seen.

## What was actually there

Queried live on the reporter's server for the media in question — one file, five subtitles:

| id | language | status | type | codec |
|---|---|---|---|---|
| …207 | fr | `downloaded` | ocr | subrip |
| …208 | en | **`processing`** | ocr | subrip |
| …212 | es | `embedded` | embedded | hdmv_pgs |
| …213 | es | `embedded` | embedded | hdmv_pgs |
| …214 | fr | `embedded` | embedded | hdmv_pgs |

So the server was right and the client was holding an empty list.

## Why

`/api/media/:id/subtitles` falls under the cacheable `/api/media` prefix: five-minute TTL, served stale-while-revalidate. `sse.service.ts` already drops that cache on `subtitle.synced|downloaded|failed`, and the comment there shows the problem was anticipated:

> These land asynchronously (e.g. an OCR or sync finishing minutes after the request returned), so no client mutation invalidated the cached subtitle list.

Two paths change the list and emit none of them:

1. **`EmbeddedSubtitleService`** stores a file's embedded tracks during an import and only logs it. That is where the image tracks come from, so they stayed invisible until the TTL lapsed.
2. **An OCR run** creates its `PROCESSING` placeholder silently; only the end emits `subtitle.downloaded` / `subtitle.failed`. A run was therefore invisible until it finished — the moment it stops being interesting. The modal already knows how to render one (`ocrProcessing`); it never had the data.

## Fix

Both emit `subtitle.list_changed`, carrying a media id and nothing else — no title, no outcome, no toast. It joins the invalidation the other three already trigger, and the modal reloads on it silently.

Emitting an event rather than dropping `/api/media/:id/subtitles` from the cache is what makes the in-flight OCR appear *live*; un-caching would only have fixed the first symptom and still needed a manual refresh for the second.

## Left alone

`detectAndStore` returns before touching the repository when a probe finds no stream, so a file that lost every embedded track keeps its old rows. That predates this and deserves its own change.

## Test plan

- New spec pins both halves of the contract: storing tracks announces the media, an empty probe stays quiet.
- Backend green: 1,613 tests, 145 files. Client green: 451 tests. Both type-check clean.