### PR TITLE
fix(plugin-ui): align the refresh button right when the table has no title

### DIFF
--- a/client/src/app/shared/components/data-table/data-table.html
+++ b/client/src/app/shared/components/data-table/data-table.html
@@ -3,7 +3,9 @@
     @if (titleKey()) {
       <h2 class="card-title text-lg">{{ titleKey() | translate }}</h2>
     }
-    <div class="flex gap-2 shrink-0">
+    <!-- ms-auto, not justify-between: a page passing no title leaves this block as the row's
+         only child, which lands it on the left. -->
+    <div class="flex gap-2 shrink-0 justify-end ms-auto">
       <button
         type="button"
         class="btn btn-outline btn-sm"


### PR DESCRIPTION
Follow-up to #1022, reported from the download plugin's queue page. Replaces #1023, which I branched from a pre-squash local commit and which therefore re-applied all of #1022 on top of main.

The table header pushes its actions right with `justify-between`, which only works while a title occupies the other end of the row. A plugin page passes an empty `titleKey` — its heading is rendered by the page above the table, not inside it — so the actions block was the row's only child and sat on the left.

`ms-auto` puts it at the end whether or not a title is there.

## Test plan

Measured on the device at a 360px viewport, against the app's compiled stylesheet:

| case | left gap | right gap | result |
|---|---|---|---|
| before, no title | 0px | 279px | left |
| after, no title | 279px | 0px | **right** |
| after, with title | 279px | 0px | **right** |

Table suite green (31 tests).