### PR TITLE
fix(subtitles): retire the tracks a remux dropped, without trusting a failed probe

### DIFF
--- a/backend/src/modules/subtitles/embedded-subtitle.announce.spec.ts
+++ b/backend/src/modules/subtitles/embedded-subtitle.announce.spec.ts
@@ -4,14 +4,18 @@ import { EmbeddedSubtitleService } from './embedded-subtitle.service';
  *  service on its own, so the announcement is the only thing standing between a stored image
  *  track and a list that stays stale until its TTL lapses. */
 describe('EmbeddedSubtitleService — announcing what an import stored', () => {
-  const build = (streams: unknown[]) => {
+  const build = (
+    probe: { ok: boolean; streams: unknown[] },
+    opts: { alreadyStored?: number } = {},
+  ) => {
     const emit = jest.fn();
-    const saved = streams.map((_, i) => ({ id: i + 1 }));
+    const del = jest.fn().mockResolvedValue({ affected: opts.alreadyStored ?? 0 });
+    const saved = probe.streams.map((_, i) => ({ id: i + 1 }));
     const service = new EmbeddedSubtitleService(
-      { detectEmbeddedSubtitles: jest.fn().mockResolvedValue(streams) } as never,
+      { detectEmbeddedSubtitles: jest.fn().mockResolvedValue(probe) } as never,
       {
         find: jest.fn().mockResolvedValue([]),
-        delete: jest.fn().mockResolvedValue(undefined),
+        delete: del,
         save: jest.fn().mockResolvedValue(saved),
       } as never,
       { findOne: jest.fn().mockResolvedValue({ id: 7, path: '/library/a' }) } as never,
@@ -19,7 +23,7 @@ describe('EmbeddedSubtitleService — announcing what an import stored', () => {
       { get: jest.fn().mockResolvedValue('false') } as never,
       { emit } as never,
     );
-    return { service, emit };
+    return { service, emit, del };
   };
 
   const imageStream = {
@@ -32,13 +36,31 @@ describe('EmbeddedSubtitleService — announcing what an import stored', () => {
   };
 
   it('announces the media whose list just changed', async () => {
-    const { service, emit } = build([imageStream]);
+    const { service, emit } = build({ ok: true, streams: [imageStream] });
     await service.detectAndStore(7, 42);
     expect(emit).toHaveBeenCalledWith({ type: 'subtitle.list_changed', mediaId: 7 });
   });
 
-  it('stays quiet when the probe found nothing to store', async () => {
-    const { service, emit } = build([]);
+  it('retires the rows of a file whose tracks are gone, and says so', async () => {
+    // A remux that drops every subtitle track: callers rely on the wipe to retire them.
+    const { service, emit, del } = build({ ok: true, streams: [] }, { alreadyStored: 3 });
+    await service.detectAndStore(7, 42);
+    expect(del).toHaveBeenCalled();
+    expect(emit).toHaveBeenCalledWith({ type: 'subtitle.list_changed', mediaId: 7 });
+  });
+
+  it('keeps the stored rows when the probe itself failed', async () => {
+    // ffprobe answers the same empty list on a timeout as on a file with no track. Deleting
+    // here would lose a whole file's subtitles to one unreadable mount.
+    const { service, emit, del } = build({ ok: false, streams: [] }, { alreadyStored: 3 });
+    await service.detectAndStore(7, 42);
+    expect(del).not.toHaveBeenCalled();
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet when a rescan changed nothing', async () => {
+    // Every rescan sweeps every file; a no-op must not wake every client.
+    const { service, emit } = build({ ok: true, streams: [] }, { alreadyStored: 0 });
     await service.detectAndStore(7, 42);
     expect(emit).not.toHaveBeenCalled();
   });

--- a/backend/src/modules/subtitles/embedded-subtitle.service.ts
+++ b/backend/src/modules/subtitles/embedded-subtitle.service.ts
@@ -36,13 +36,16 @@ export class EmbeddedSubtitleService {
     const videoPath = await this.resolveVideoPath(mediaId, mediaFileId);
     if (!videoPath) return [];
 
-    const streams = await this.ffprobe.detectEmbeddedSubtitles(videoPath);
-    if (!streams.length) {
-      this.logger.debug(
-        `No embedded subtitles in "${path.basename(videoPath)}"`,
+    const probe = await this.ffprobe.detectEmbeddedSubtitles(videoPath);
+    // An unreadable file answers the same empty list as one with no subtitle track. Wiping the
+    // stored rows on that would lose a whole file's tracks to one ffprobe timeout.
+    if (!probe.ok) {
+      this.logger.warn(
+        `Keeping stored embedded subtitles for mediaFile #${mediaFileId}: ffprobe could not read "${path.basename(videoPath)}"`,
       );
       return [];
     }
+    const streams = probe.streams;
 
     this.logger.log(
       `Found ${streams.length} embedded subtitle(s) in "${path.basename(videoPath)}"`,
@@ -66,8 +69,10 @@ export class EmbeddedSubtitleService {
       );
     }
 
-    // Remove all existing embedded subs for this file, then recreate
-    await this.subtitleFileRepo.delete({
+    // Remove all existing embedded subs for this file, then recreate. Callers rely on this
+    // to retire tracks a remux dropped, which is why an empty (but successful) probe must
+    // reach it rather than return early.
+    const removed = await this.subtitleFileRepo.delete({
       mediaFile: { id: mediaFileId },
       providerType: SubtitleProviderType.EMBEDDED,
     });
@@ -101,7 +106,11 @@ export class EmbeddedSubtitleService {
     );
     // An import runs this on its own; nothing the client did invalidated the subtitle list it
     // already holds, so without this the image tracks stay invisible until the TTL lapses.
-    this.events.emit({ type: 'subtitle.list_changed', mediaId });
+    // Silent when the refresh was a no-op — a rescan sweeps every file and must not wake
+    // every client once per file.
+    if (created.length || removed.affected) {
+      this.events.emit({ type: 'subtitle.list_changed', mediaId });
+    }
 
     return created;
   }

--- a/backend/src/modules/subtitles/ffprobe.service.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.ts
@@ -17,6 +17,16 @@ export interface EmbeddedSubtitleStream {
   isImageBased: boolean;
 }
 
+/**
+ * Separates "this file carries no subtitle stream" from "ffprobe could not tell us": both
+ * arrive as an empty list, and the caller deletes the file's stored rows on the first while
+ * a timeout or an unreadable mount must leave them alone.
+ */
+export interface EmbeddedSubtitleProbe {
+  ok: boolean;
+  streams: EmbeddedSubtitleStream[];
+}
+
 export interface MediaStream {
   streamIndex: number;
   type: 'audio' | 'subtitle';
@@ -262,7 +272,7 @@ export class FfprobeService {
 
   async detectEmbeddedSubtitles(
     videoPath: string,
-  ): Promise<EmbeddedSubtitleStream[]> {
+  ): Promise<EmbeddedSubtitleProbe> {
     try {
       const { stdout } = await execFileAsync(
         'ffprobe',
@@ -282,19 +292,22 @@ export class FfprobeService {
       const parsed = JSON.parse(stdout) as { streams?: FfprobeStream[] };
       const streams = parsed.streams ?? [];
 
-      return streams.map((s) => ({
-        streamIndex: s.index,
-        codec: s.codec_name ?? 'unknown',
-        language: resolveStreamLanguage(s),
-        forced: s.disposition?.forced === 1,
-        hearingImpaired: s.disposition?.hearing_impaired === 1,
-        isImageBased: isImageBasedSubtitleCodec(s.codec_name),
-      }));
+      return {
+        ok: true,
+        streams: streams.map((s) => ({
+          streamIndex: s.index,
+          codec: s.codec_name ?? 'unknown',
+          language: resolveStreamLanguage(s),
+          forced: s.disposition?.forced === 1,
+          hearingImpaired: s.disposition?.hearing_impaired === 1,
+          isImageBased: isImageBasedSubtitleCodec(s.codec_name),
+        })),
+      };
     } catch (err) {
       this.logger.warn(
         `ffprobe failed for "${videoPath}": ${(err as Error).message}`,
       );
-      return [];
+      return { ok: false, streams: [] };
     }
   }
 


### PR DESCRIPTION
The loose end flagged in #1024, checked before being acted on. It is real, and the obvious fix would have been worse than the bug.

## The defect

`detectAndStore` returned before the delete whenever ffprobe answered no stream, so a file that lost **every** embedded track kept all of its stored rows — listing tracks that no longer exist.

The caller states the opposite contract in its own comment (`media-rescan.service.ts`):

> Always re-detect embedded subtitle streams on rescan: `detectAndStore` **wipes the file's existing embedded rows** and recreates them from ffprobe, so **deleted tracks disappear** and new ones get added even when the file size hasn't changed (e.g. a remux that preserves size).

That is exactly the case the early return breaks.

## Why the obvious fix is wrong

`detectEmbeddedSubtitles` catches its own failures and returns an empty list for them too:

```ts
} catch (err) {
  this.logger.warn(`ffprobe failed for "${videoPath}": …`);
  return [];
}
```

So a thirty-second timeout, an unreadable file, or a network mount that blinked — the ordinary weather of a media server — is indistinguishable from a file with no subtitle track. Deleting on any empty answer would trade a narrow staleness bug for losing a whole file's subtitles to one bad probe. The early return was protective, not an oversight; it was just too blunt.

## The fix

The probe reports which of the two happened:

```ts
export interface EmbeddedSubtitleProbe {
  ok: boolean;
  streams: EmbeddedSubtitleStream[];
}
```

A successful empty answer now reaches the delete; a failed one leaves the rows alone and logs why. It is the same shape the download plugin already uses to separate "holds no torrents" from "could not be reached". `detectEmbeddedSubtitles` has exactly one caller, so the signature change is contained to the two files that matter.

Also gated the `subtitle.list_changed` announcement on something having actually moved — `created.length || removed.affected`. A rescan sweeps every file of a media, and a no-op refresh must not wake every connected client once per file.

## Test plan

Four cases, one per branch of the decision:

- tracks found → rows stored, media announced
- **successful empty probe** → rows retired, announced
- **failed probe** → nothing deleted, nothing announced
- successful empty probe with nothing stored → silent (the rescan no-op)

Backend green: 1,615 tests, 145 files. Type-check clean.