### PR TITLE
fix(docker): publish the runtime stage, not whatever ends the Dockerfile

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -83,6 +83,9 @@ jobs:
         with:
           context: .
           file: Dockerfile
+          # Named, not implied: without it the build takes whatever stage ends the
+          # file, and a stage appended after `runtime` ships as the release image.
+          target: runtime
           platforms: ${{ matrix.target.platform }}
           # push-by-digest: each matrix job pushes its single-arch image
           # under a content-addressable digest only (no human tag). The

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,14 @@ COPY --from=vobsub-ocr-build /opt/subtile-ocr/bin/subtile-ocr /usr/local/bin/sub
 RUN mkdir -p /etc/OpenCL/vendors \
   && echo 'libnvidia-opencl.so.1' > /etc/OpenCL/vendors/nvidia.icd
 
+# Dev stage for docker-compose: deps in the image at /src, sources bind-mounted
+# at /src/backend. Rebuild the image when package.json changes.
+FROM runtime-base AS dev
+WORKDIR /src
+COPY backend/package.json backend/package-lock.json ./
+RUN npm ci
+WORKDIR /src/backend
+
 FROM runtime-base AS runtime
 
 WORKDIR /app
@@ -147,11 +155,3 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
   CMD node -e "require('http').get('http://localhost:'+(process.env.PORT||4848)+'/api/system/liveness',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
 
 CMD ["node", "dist/main"]
-
-# Dev stage for docker-compose: deps in the image at /src, sources bind-mounted
-# at /src/backend. Rebuild the image when package.json changes.
-FROM runtime-base AS dev
-WORKDIR /src
-COPY backend/package.json backend/package-lock.json ./
-RUN npm ci
-WORKDIR /src/backend


### PR DESCRIPTION
Fixes the `main` image #1028 broke. Regression from that PR, mine.

## What happened

#1028 appended the `dev` stage after `runtime`. `docker build` with no `--target` builds the **last**
stage in the file, and `docker-publish.yml` names none — so the `main` tag it pushed was the dev
image:

```
$ docker buildx imagetools inspect ghcr.io/fliks-app/fliks:main --format '{{json .Image}}'
linux/amd64 | Cmd: [/bin/bash] | WorkingDir: /src/backend | Entrypoint: None
linux/arm64 | Cmd: [/bin/bash] | WorkingDir: /src/backend | Entrypoint: None
```

No application in it at all. A container from that image starts bash, exits immediately, and writes
nothing — the server is just down, with an empty log, which is exactly how it was reported.

Release tags are unaffected: `latest` and the semver tags were built from `v*` before #1028 landed,
so pinning `3.0.0` is a valid stopgap until this republishes `main`.

## Why my verification missed it

I built `--target runtime` explicitly to check the image, which is precisely the argument CI does not
pass. The build also *succeeded* both times — a dev-stage build is a perfectly valid build — so
nothing failed loudly.

## The fix

Two independent halves, because either alone leaves the trap:

- `runtime` ends the Dockerfile again, so a bare `docker build .` yields the release image as it
  always did before #1028
- the workflow names `target: runtime`, so appending a stage after it can never silently ship that
  stage again

## Verification

Built with **no** `--target`, the way CI does:

```
Cmd=[node dist/main] WorkingDir=/app
app artefacts present
```

And `--target dev` still produces `WorkingDir=/src/backend` for the compose stack.